### PR TITLE
fix: move OPENAI models comment to correct place

### DIFF
--- a/app/AI/Models.php
+++ b/app/AI/Models.php
@@ -24,14 +24,14 @@ class Models
             'access' => 'pro',
             'max_tokens' => 4096,
         ],
+
+        // OPENAI
         'gpt-3.5-turbo-16k' => [
             'name' => 'GPT-3.5 Turbo 16K',
             'gateway' => 'openai',
             'access' => 'user',
             'max_tokens' => 14000,
         ],
-
-        // OPENAI
         'gpt-4-turbo-preview' => [
             'name' => 'GPT-4 Turbo Preview',
             'gateway' => 'openai',


### PR DESCRIPTION
One of the smallest PRs in history, but if we have to have those comments they should be in correct place.