### PR TITLE
fix: php cleanup

### DIFF
--- a/app/AI/AnthropicAIGateway.php
+++ b/app/AI/AnthropicAIGateway.php
@@ -7,25 +7,6 @@ use GuzzleHttp\Exception\RequestException;
 
 class AnthropicAIGateway
 {
-    private $client;
-
-    private $apiBaseUrl = 'https://api.anthropic.com';
-
-    public function __construct()
-    {
-        $this->client = new Client([
-            // Base URI is used with relative requests
-            'base_uri' => $this->apiBaseUrl,
-            // You can set any number of default request options.
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'x-api-key' => env('ANTHROPIC_API_KEY'), // Make sure to set your API key in your .env file
-                'anthropic-version' => '2023-06-01',
-                'anthropic-beta' => 'messages-2023-12-15',
-            ],
-        ]);
-    }
-
     public function createStreamed($params)
     {
         $client = new Client();

--- a/app/AI/CohereAIGateway.php
+++ b/app/AI/CohereAIGateway.php
@@ -7,22 +7,6 @@ use GuzzleHttp\Exception\RequestException;
 
 class CohereAIGateway
 {
-    private $client;
-
-    private $apiBaseUrl = 'https://api.cohere.ai';
-
-    public function __construct()
-    {
-        $this->client = new Client([
-            'base_uri' => $this->apiBaseUrl,
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Authorization' => 'Bearer '.env('COHERE_API_KEY'),
-                'accept' => 'application/json',
-            ],
-        ]);
-    }
-
     public function chatWithHistory($params)
     {
         $client = new Client();

--- a/app/AI/OpenAIGateway.php
+++ b/app/AI/OpenAIGateway.php
@@ -7,6 +7,8 @@ use Yethee\Tiktoken\EncoderProvider;
 
 class OpenAIGateway
 {
+    private OpenAI $client;
+
     public function __construct()
     {
         $this->client = OpenAI::client(env('OPENAI_API_KEY'));

--- a/app/AI/PerplexityAIGateway.php
+++ b/app/AI/PerplexityAIGateway.php
@@ -7,21 +7,6 @@ use GuzzleHttp\Exception\RequestException;
 
 class PerplexityAIGateway
 {
-    private $client;
-
-    private $apiBaseUrl = 'https://api.perplexity.ai';
-
-    public function __construct()
-    {
-        $this->client = new Client([
-            'base_uri' => $this->apiBaseUrl,
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'x-api-key' => env('PERPLEXITY_API_KEY'), // Make sure to set your API key in your .env file
-            ],
-        ]);
-    }
-
     public function createStreamed($params)
     {
         $client = new Client();

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -66,25 +66,18 @@ class Register extends ModalComponent
     }
 
     /**
-     * Resent verificaiton email to user.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * Resend verification email to user.
      */
     public function resend()
     {
         if (Auth::check()) {
             auth()->user()->sendEmailVerificationNotification();
             $this->alert('success', 'A fresh verification link has been sent to your email address.');
-        } else {
-
         }
-
     }
 
     public static function closeModalOnClickAway(): bool
     {
-
         return true;
     }
 


### PR DESCRIPTION
Some of the gateways had a private client setup, but are not using it. Another one is using it but it was not declared. This is an initial cleanup, but might be a good idea to make them all consistent for easier maintenance in the future?