### PR TITLE
refactor: add Gateway interface, use it in active gateways

### DIFF
--- a/app/AI/AnthropicAIGateway.php
+++ b/app/AI/AnthropicAIGateway.php
@@ -1,16 +1,22 @@
 <?php
+declare(strict_types=1);
 
 namespace App\AI;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 
-class AnthropicAIGateway
+class AnthropicAIGateway implements GatewayInterface
 {
-    public function createStreamed($params)
-    {
-        $client = new Client();
+    private Client $httpClient;
 
+    public function __construct(Client $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    public function inference(array $params): array
+    {
         // If the role of the first message is 'system', remove that and set it as a separate variable
         $systemMessage = null;
         if ($params['messages'][0]['role'] === 'system') {
@@ -34,7 +40,7 @@ class AnthropicAIGateway
         }
 
         try {
-            $response = $client->post('https://api.anthropic.com/v1/messages', [
+            $response = $this->httpClient->post('https://api.anthropic.com/v1/messages', [
                 'json' => $data,
                 'stream' => true, // Important for handling streaming responses
                 'headers' => [
@@ -67,10 +73,7 @@ class AnthropicAIGateway
                 'output_tokens' => $outputTokens,
             ];
         } catch (RequestException $e) {
-            // Handle exception or error
             dd($e->getMessage());
-
-            return 'Error: '.$e->getMessage();
         }
     }
 

--- a/app/AI/GatewayInterface.php
+++ b/app/AI/GatewayInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace App\AI;
+
+interface GatewayInterface
+{
+    public function inference(array $params);
+}

--- a/app/AI/HuggingfaceAIGateway.php
+++ b/app/AI/HuggingfaceAIGateway.php
@@ -1,10 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace App\AI;
 
 use Illuminate\Support\Facades\Http;
 
-class HuggingfaceAIGateway
+class HuggingfaceAIGateway implements GatewayInterface
 {
     private $apiUrl = 'https://zub38q2qmtrdgl1x.us-east-1.aws.endpoints.huggingface.cloud';
 
@@ -15,7 +16,7 @@ class HuggingfaceAIGateway
         $this->apiKey = config('services.huggingface.api_key');
     }
 
-    public function inference($params)
+    public function inference(array $params): array
     {
         // dont care about params model cuz for now we only have one model, deployed at the api url
         $messages = $params['messages'];

--- a/app/AI/MistralAIGateway.php
+++ b/app/AI/MistralAIGateway.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\AI;
 
@@ -7,8 +8,15 @@ use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
-class MistralAIGateway
+class MistralAIGateway implements GatewayInterface
 {
+    private Client $httpClient;
+
+    public function __construct(Client $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
     public function models()
     {
         $url = 'https://api.mistral.ai/v1/models';
@@ -53,79 +61,7 @@ class MistralAIGateway
         }
     }
 
-    public function chat()
-    {
-        return new MistralAIChat();
-    }
-
-    public function inference($messages)
-    {
-        // Your API endpoint
-        $url = 'https://api.mistral.ai/v1/chat/completions';
-
-        // Prepare the data payload
-        $data = [
-            'model' => 'mistral-large-latest',
-            'messages' => $messages,
-            'max_tokens' => 2000,
-            'temperature' => 0.5,
-            'top_p' => 1,
-        ];
-
-        // Make the HTTP POST request
-        $response = Http::withHeaders([
-            'Content-Type' => 'application/json',
-            'Authorization' => 'Bearer '.env('MISTRAL_API_KEY'),
-        ])->post($url, $data);
-
-        // Check if the request was successful
-        if ($response->successful()) {
-            // Return the response body
-            return $response->json();
-        } else {
-            // Handle the error (you can customize this part based on your needs)
-            return [
-                'error' => 'Failed to make inference',
-                'details' => $response->json(),
-            ];
-        }
-    }
-}
-
-class MistralAIChat
-{
-    public function createFunctionCall($params)
-    {
-        $url = 'https://api.mistral.ai/v1/chat/completions';
-        $apiKey = env('MISTRAL_API_KEY');
-        $model = $params['model'];
-        $messages = $params['messages'];
-        $maxTokens = $params['max_tokens'];
-        $tools = $params['tools'] ?? [];
-        $temperature = $params['temperature'] ?? 0.7;
-        $topP = $params['top_p'] ?? 1;
-
-        $data = [
-            'tools' => FunctionCaller::parsedTools($tools),
-            'tool_choice' => 'any',
-            'model' => $model,
-            'messages' => $messages,
-            'max_tokens' => $maxTokens,
-            'temperature' => $temperature,
-            'top_p' => $topP,
-        ];
-
-        try {
-            $response = Http::withHeaders(['Authorization' => 'Bearer '.$apiKey])->post($url, $data);
-
-            return $response->json();
-        } catch (RequestException $e) {
-            // Handle exception or error
-            return 'Error: '.$e->getMessage();
-        }
-    }
-
-    public function createStreamed($params)
+    public function inference(array $params): array
     {
         $url = 'https://api.mistral.ai/v1/chat/completions';
         $apiKey = env('MISTRAL_API_KEY');
@@ -135,8 +71,6 @@ class MistralAIChat
         $streamFunction = $params['stream_function'];
         $temperature = $params['temperature'] ?? 0.7;
         $topP = $params['top_p'] ?? 1;
-
-        $client = new Client();
 
         $data = [
             'model' => $model,
@@ -148,7 +82,7 @@ class MistralAIChat
         ];
 
         try {
-            $response = $client->post($url, [
+            $response = $this->httpClient->post($url, [
                 'json' => $data,
                 'stream' => true, // Important for streaming
                 'headers' => [
@@ -176,10 +110,7 @@ class MistralAIChat
                 'output_tokens' => $outputTokens,
             ];
         } catch (RequestException $e) {
-            // Handle exception or error
             dd($e->getMessage());
-
-            return 'Error: '.$e->getMessage();
         }
     }
 
@@ -220,28 +151,6 @@ class MistralAIChat
             }
         }
     }
-
-    //    private function readStream($stream)
-    //    {
-    //        while (! $stream->eof()) {
-    //            $line = $this->readLine($stream);
-    //            Log::info($line);
-    //
-    //            if (! str_starts_with($line, 'data:')) {
-    //                continue;
-    //            }
-    //
-    //            $data = trim(substr($line, 5)); // Skip the 'data:' part
-    //            if ($data === '[DONE]') {
-    //                break;
-    //            }
-    //
-    //            $response = json_decode($data, true);
-    //            if ($response) {
-    //                yield $response;
-    //            }
-    //        }
-    //    }
 
     private function readLine($stream)
     {

--- a/app/AI/OpenAIGateway.php
+++ b/app/AI/OpenAIGateway.php
@@ -1,17 +1,18 @@
 <?php
+declare(strict_types=1);
 
 namespace App\AI;
 
 use OpenAI;
 use Yethee\Tiktoken\EncoderProvider;
 
-class OpenAIGateway
+class OpenAIGateway implements GatewayInterface
 {
-    private OpenAI\Client $client;
+    private object $client;
 
-    public function __construct()
+    public function __construct(object $client = null)
     {
-        $this->client = OpenAI::client(env('OPENAI_API_KEY'));
+        $this->client = $client ?? OpenAI::client(env('OPENAI_API_KEY'));
     }
 
     public function models()
@@ -24,7 +25,7 @@ class OpenAIGateway
         dd($ids);
     }
 
-    public function stream($params)
+    public function inference(array $params): array
     {
         $model = $params['model'];
         $messages = $params['messages'];

--- a/app/AI/SimpleInferencer.php
+++ b/app/AI/SimpleInferencer.php
@@ -61,8 +61,8 @@ class SimpleInferencer
                     ]);
                     break;
                 case 'perplexity':
-                    $client = new PerplexityAIGateway();
-                    $inference = $client->createStreamed([
+                    $client = new PerplexityAIGateway($httpClient);
+                    $inference = $client->inference([
                         'model' => $model,
                         'messages' => $messages,
                         'max_tokens' => $completionTokens,

--- a/app/AI/SimpleInferencer.php
+++ b/app/AI/SimpleInferencer.php
@@ -44,7 +44,7 @@ class SimpleInferencer
                     break;
                 case 'mistral':
                     $client = new MistralAIGateway($httpClient);
-                    $inference = $client->chat()->createStreamed([
+                    $inference = $client->inference([
                         'model' => $model,
                         'messages' => $messages,
                         'max_tokens' => $completionTokens,

--- a/app/AI/SimpleInferencer.php
+++ b/app/AI/SimpleInferencer.php
@@ -3,10 +3,11 @@
 namespace App\AI;
 
 use App\Models\Thread;
+use GuzzleHttp\Client;
 
 class SimpleInferencer
 {
-    public static function inference(string $prompt, string $model, Thread $thread, callable $streamFunction): array|string
+    public static function inference(string $prompt, string $model, Thread $thread, callable $streamFunction): array
     {
         $modelDetails = Models::MODELS[$model] ?? null;
 
@@ -30,11 +31,11 @@ class SimpleInferencer
 
             // Adjust the max_tokens value for the completion
             $completionTokens = $maxTokens - $messageTokens;
-
+            $httpClient = new Client();
             switch ($gateway) {
                 case 'anthropic':
-                    $client = new AnthropicAIGateway();
-                    $inference = $client->createStreamed([
+                    $client = new AnthropicAIGateway($httpClient);
+                    $inference = $client->inference([
                         'model' => $model,
                         'messages' => $messages,
                         'max_tokens' => $completionTokens,
@@ -42,7 +43,7 @@ class SimpleInferencer
                     ]);
                     break;
                 case 'mistral':
-                    $client = new MistralAIGateway();
+                    $client = new MistralAIGateway($httpClient);
                     $inference = $client->chat()->createStreamed([
                         'model' => $model,
                         'messages' => $messages,
@@ -86,14 +87,11 @@ class SimpleInferencer
                     ]);
                     break;
                 default:
-                    // Handle unknown gateway
                     dd("Unknown gateway: $gateway");
             }
         } else {
-            // Handle unknown model
             dd("Unknown model: $model");
         }
-
         return $inference;
     }
 }

--- a/app/AI/SimpleInferencer.php
+++ b/app/AI/SimpleInferencer.php
@@ -53,7 +53,7 @@ class SimpleInferencer
                     break;
                 case 'openai':
                     $client = new OpenAIGateway();
-                    $inference = $client->stream([
+                    $inference = $client->inference([
                         'model' => $model,
                         'messages' => $messages,
                         'max_tokens' => $completionTokens,

--- a/app/AI/SimpleInferencer.php
+++ b/app/AI/SimpleInferencer.php
@@ -70,8 +70,8 @@ class SimpleInferencer
                     ]);
                     break;
                 case 'cohere':
-                    $client = new CohereAIGateway();
-                    $inference = $client->chatWithHistory([
+                    $client = new CohereAIGateway($httpClient);
+                    $inference = $client->inference([
                         'chat_history' => $messages,
                         'message' => $prompt,
                         'connectors' => [],

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -5,6 +5,10 @@ uses(
     // Illuminate\Foundation\Testing\DatabaseMigrations::class,
 )->in('Browser');
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -47,7 +51,27 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+function mockGuzzleClient(array $mockResponse): Client
 {
-    // ..
+    $mockResponseStream = fopen('php://memory', 'r+');
+    if (isset($mockResponse['text'])) {
+        fwrite(
+            $mockResponseStream,
+            json_encode($mockResponse) . "\n"
+        );
+    } else {
+        $mockResponse = array_map(function($data) {
+            return 'data: ' . json_encode($data);
+        }, $mockResponse);
+        fwrite(
+            $mockResponseStream,
+            \implode("\n", $mockResponse) . "\n"
+        );
+    }
+    rewind($mockResponseStream);
+    $mock = new MockHandler([
+        new Response(200, [], $mockResponseStream)
+    ]);
+    $handlerStack = HandlerStack::create($mock);
+    return new Client(['handler' => $handlerStack]);
 }

--- a/tests/Unit/AnthropicAIGatewayTest.php
+++ b/tests/Unit/AnthropicAIGatewayTest.php
@@ -1,12 +1,9 @@
 <?php
+declare(strict_types=1);
 
 use App\AI\AnthropicAIGateway;
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 
-test('AnthropicAIGateway createStreamed handles stream correctly', function () {
+test('AnthropicAIGateway handles Claude responses correctly', function () {
     $prompt = 'What is the capital of France?';
     $inputTokens = 6;
     $answer = 'Capital of France is Paris.';
@@ -42,25 +39,9 @@ test('AnthropicAIGateway createStreamed handles stream correctly', function () {
             ]
         ]
     ];
-    $mockResponse = array_map(function($data) {
-        return 'data: ' . json_encode($data);
-    }, $mockResponse);
-    $mockResponseStream = fopen('php://memory', 'r+');
-    fwrite(
-        $mockResponseStream,
-        \implode("\n", $mockResponse) . "\n"
-    );
-    rewind($mockResponseStream);
-    
-    $mock = new MockHandler([
-        new Response(200, [], $mockResponseStream)
-    ]);
-    
-    $handlerStack = HandlerStack::create($mock);
-    $httpClient = new Client(['handler' => $handlerStack]);
-    
+    $httpClient = mockGuzzleClient($mockResponse);
     $gateway = new AnthropicAIGateway($httpClient);
-    
+
     $result = $gateway->inference($parameters);
 
     expect($result)->toBeArray();
@@ -68,4 +49,3 @@ test('AnthropicAIGateway createStreamed handles stream correctly', function () {
     expect($result['input_tokens'])->toEqual($inputTokens);
     expect($result['output_tokens'])->toEqual($outputTokens);
 });
-

--- a/tests/Unit/AnthropicAIGatewayTest.php
+++ b/tests/Unit/AnthropicAIGatewayTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\AI\AnthropicAIGateway;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+test('AnthropicAIGateway createStreamed handles stream correctly', function () {
+    $prompt = 'What is the capital of France?';
+    $inputTokens = 6;
+    $answer = 'Capital of France is Paris.';
+    $outputTokens = 5;
+
+    $parameters = [
+        'model' => 'claude-3-haiku-20240307',
+        'messages' => [
+            ['role' => 'user', 'content' => $prompt]
+        ],
+        'max_tokens' => 4096
+    ];
+
+    $mockResponse = [
+        [
+            'type' => 'content_block_delta',
+            'delta' => [
+                'text' => $answer
+            ]
+        ],
+        [
+            'type' => 'message_start',
+            'message' => [
+                'usage' => [
+                    'input_tokens' => $inputTokens
+                ]
+            ]
+        ],
+        [
+            'type' => 'message_delta',
+            'usage' => [
+                'output_tokens' => $outputTokens
+            ]
+        ]
+    ];
+    $mockResponse = array_map(function($data) {
+        return 'data: ' . json_encode($data);
+    }, $mockResponse);
+    $mockResponseStream = fopen('php://memory', 'r+');
+    fwrite(
+        $mockResponseStream,
+        \implode("\n", $mockResponse) . "\n"
+    );
+    rewind($mockResponseStream);
+    
+    $mock = new MockHandler([
+        new Response(200, [], $mockResponseStream)
+    ]);
+    
+    $handlerStack = HandlerStack::create($mock);
+    $httpClient = new Client(['handler' => $handlerStack]);
+    
+    $gateway = new AnthropicAIGateway($httpClient);
+    
+    $result = $gateway->inference($parameters);
+
+    expect($result)->toBeArray();
+    expect($result['content'])->toEqual($answer);
+    expect($result['input_tokens'])->toEqual($inputTokens);
+    expect($result['output_tokens'])->toEqual($outputTokens);
+});
+

--- a/tests/Unit/CohereAIGatewayTest.php
+++ b/tests/Unit/CohereAIGatewayTest.php
@@ -2,10 +2,6 @@
 declare(strict_types=1);
 
 use App\AI\CohereAIGateway;
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 
 test('CohereAIGateway handles mistral responses correctly', function () {
     $prompt = 'What is the capital of France?';
@@ -26,22 +22,9 @@ test('CohereAIGateway handles mistral responses correctly', function () {
             ]
         ]
     ];
-    $mockResponseStream = fopen('php://memory', 'r+');
-    fwrite(
-        $mockResponseStream,
-        json_encode($mockResponse) . "\n"
-    );
-    rewind($mockResponseStream);
-    
-    $mock = new MockHandler([
-        new Response(200, [], $mockResponseStream)
-    ]);
-    
-    $handlerStack = HandlerStack::create($mock);
-    $httpClient = new Client(['handler' => $handlerStack]);
-    
+    $httpClient = mockGuzzleClient($mockResponse);
     $gateway = new CohereAIGateway($httpClient);
-    
+
     $result = $gateway->inference($parameters);
 
     expect($result)->toBeArray();

--- a/tests/Unit/CohereAIGatewayTest.php
+++ b/tests/Unit/CohereAIGatewayTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+use App\AI\CohereAIGateway;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+test('CohereAIGateway handles mistral responses correctly', function () {
+    $prompt = 'What is the capital of France?';
+    $inputTokens = 6;
+    $answer = 'Capital of France is Paris.';
+    $outputTokens = 5;
+
+    $parameters = [
+        'message' => $prompt
+    ];
+
+    $mockResponse = [
+        'text' => $answer,
+        'meta' => [
+            'tokens' => [
+                'input_tokens' => $inputTokens,
+                'output_tokens' => $outputTokens
+            ]
+        ]
+    ];
+    $mockResponseStream = fopen('php://memory', 'r+');
+    fwrite(
+        $mockResponseStream,
+        json_encode($mockResponse) . "\n"
+    );
+    rewind($mockResponseStream);
+    
+    $mock = new MockHandler([
+        new Response(200, [], $mockResponseStream)
+    ]);
+    
+    $handlerStack = HandlerStack::create($mock);
+    $httpClient = new Client(['handler' => $handlerStack]);
+    
+    $gateway = new CohereAIGateway($httpClient);
+    
+    $result = $gateway->inference($parameters);
+
+    expect($result)->toBeArray();
+    expect($result['content'])->toEqual($answer);
+    expect($result['input_tokens'])->toEqual($inputTokens);
+    expect($result['output_tokens'])->toEqual($outputTokens);
+});

--- a/tests/Unit/HugginfaceAIGatewayTest.php
+++ b/tests/Unit/HugginfaceAIGatewayTest.php
@@ -23,7 +23,6 @@ test('CohereAIGateway handles mistral responses correctly', function () {
                     ->andReturn(new HttpPostMock($mockResponse));
 
     $gateway = new HuggingfaceAIGateway();
-    
     $result = $gateway->inference($parameters);
 
     expect($result)->toBeArray();

--- a/tests/Unit/HugginfaceAIGatewayTest.php
+++ b/tests/Unit/HugginfaceAIGatewayTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+use App\AI\HuggingfaceAIGateway;
+use Illuminate\Support\Facades\Http;
+
+test('CohereAIGateway handles mistral responses correctly', function () {
+    $prompt = 'What is the capital of France?';
+    $answer = 'Capital of France is Paris.';
+
+    $parameters = [
+        'messages' => [
+            ['role' => 'user', 'content' => $prompt]
+        ]
+    ];
+
+    $mockResponse = [[
+        'generated_text' => $answer
+    ]];
+
+    Http::shouldReceive('withHeaders')
+                    ->once()
+                    ->andReturn(new HttpPostMock($mockResponse));
+
+    $gateway = new HuggingfaceAIGateway();
+    
+    $result = $gateway->inference($parameters);
+
+    expect($result)->toBeArray();
+    expect($result['content'])->toEqual($answer);
+    expect($result['input_tokens'])->toEqual(0);
+    expect($result['output_tokens'])->toEqual(0);
+});
+
+class HttpPostMock
+{
+    protected array $response = [];
+
+    public function __construct(array $mockResponse)
+    {
+        $this->response = $mockResponse;
+    }
+
+    public function post()
+    {
+        return new class($this->response) extends ChatClientMock
+        {
+            public function successful(): bool
+            {
+                return true;
+            }
+
+            public function json(): array
+            {
+                return $this->response;
+            }
+        };
+    }
+}
+

--- a/tests/Unit/MistralAIGatewayTest.php
+++ b/tests/Unit/MistralAIGatewayTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\AI\MistralAIGateway;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+test('MistralAIGateway handles mistral responses correctly', function () {
+    $prompt = 'What is the capital of France?';
+    $inputTokens = 6;
+    $answer = 'Capital of France is Paris.';
+    $outputTokens = 5;
+
+    $parameters = [
+        'model' => 'mistral-small-latest',
+        'messages' => [
+            ['role' => 'user', 'content' => $prompt]
+        ],
+        'stream_function' => function ($response) use ($answer) {
+            expect($response)->toEqual($answer);
+        },
+        'max_tokens' => 2000
+    ];
+
+    $mockResponse = [
+        [
+            'choices' => [[
+                'delta' => [
+                    'content' => $answer
+                ]
+            ]],
+            'usage' => [
+                'prompt_tokens' => $inputTokens,
+                'completion_tokens' => $outputTokens
+            ]
+        ]
+    ];
+    $mockResponse = array_map(function($data) {
+        return 'data: ' . json_encode($data);
+    }, $mockResponse);
+    $mockResponseStream = fopen('php://memory', 'r+');
+    fwrite(
+        $mockResponseStream,
+        \implode("\n", $mockResponse) . "\n"
+    );
+    rewind($mockResponseStream);
+    
+    $mock = new MockHandler([
+        new Response(200, [], $mockResponseStream)
+    ]);
+    
+    $handlerStack = HandlerStack::create($mock);
+    $httpClient = new Client(['handler' => $handlerStack]);
+    
+    $gateway = new MistralAIGateway($httpClient);
+    
+    $result = $gateway->inference($parameters);
+
+    expect($result)->toBeArray();
+    expect($result['content'])->toEqual($answer);
+    expect($result['input_tokens'])->toEqual($inputTokens);
+    expect($result['output_tokens'])->toEqual($outputTokens);
+});

--- a/tests/Unit/MistralAIGatewayTest.php
+++ b/tests/Unit/MistralAIGatewayTest.php
@@ -1,10 +1,7 @@
 <?php
+declare(strict_types=1);
 
 use App\AI\MistralAIGateway;
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 
 test('MistralAIGateway handles mistral responses correctly', function () {
     $prompt = 'What is the capital of France?';
@@ -36,25 +33,9 @@ test('MistralAIGateway handles mistral responses correctly', function () {
             ]
         ]
     ];
-    $mockResponse = array_map(function($data) {
-        return 'data: ' . json_encode($data);
-    }, $mockResponse);
-    $mockResponseStream = fopen('php://memory', 'r+');
-    fwrite(
-        $mockResponseStream,
-        \implode("\n", $mockResponse) . "\n"
-    );
-    rewind($mockResponseStream);
-    
-    $mock = new MockHandler([
-        new Response(200, [], $mockResponseStream)
-    ]);
-    
-    $handlerStack = HandlerStack::create($mock);
-    $httpClient = new Client(['handler' => $handlerStack]);
-    
+    $httpClient = mockGuzzleClient($mockResponse);
     $gateway = new MistralAIGateway($httpClient);
-    
+
     $result = $gateway->inference($parameters);
 
     expect($result)->toBeArray();

--- a/tests/Unit/OpenAIGatewayTest.php
+++ b/tests/Unit/OpenAIGatewayTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+use App\AI\OpenAIGateway;
+
+test('OpenAIGateway handles OpenAI responses correctly', function () {
+    $prompt = 'What is the capital of France?';
+    $inputTokens = 8;
+    $answer = 'Capital of France is Paris.';
+    $outputTokens = 6;
+
+    $parameters = [
+        'model' => 'gpt-3.5-turbo-16k',
+        'messages' => [
+            ['role' => 'user', 'content' => $prompt]
+        ],
+        'stream_function' => function ($response) use ($answer) {
+            expect($response['choices'][0]['delta']['content'])->toEqual($answer);
+        },
+        'max_tokens' => 2000
+    ];
+
+    $chatClient = new ChatClientMock([[
+        'choices' => [[
+            'delta' => [
+                'content' => $answer
+            ]
+        ]]
+    ]]);
+    $gateway = new OpenAIGateway($chatClient);
+
+    $result = $gateway->inference($parameters);
+
+    expect($result)->toBeArray();
+    expect($result['content'])->toEqual($answer);
+    expect($result['input_tokens'])->toEqual($inputTokens);
+    expect($result['output_tokens'])->toEqual($outputTokens);
+});
+
+class ChatClientMock
+{
+    protected array $response = [];
+
+    public function __construct(array $mockResponse)
+    {
+        $this->response = $mockResponse;
+    }
+
+    public function chat()
+    {
+        return new class($this->response) extends ChatClientMock
+        {
+            public function createStreamed(): array
+            {
+                return $this->response;
+            }
+        };
+    }
+}

--- a/tests/Unit/PerplexityAIGatewayTest.php
+++ b/tests/Unit/PerplexityAIGatewayTest.php
@@ -2,10 +2,6 @@
 declare(strict_types=1);
 
 use App\AI\PerplexityAIGateway;
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 
 test('PerplexityAIGateway handles mistral responses correctly', function () {
     $prompt = 'What is the capital of France?';
@@ -34,25 +30,9 @@ test('PerplexityAIGateway handles mistral responses correctly', function () {
             ]
         ]
     ];
-    $mockResponse = array_map(function($data) {
-        return 'data: ' . json_encode($data);
-    }, $mockResponse);
-    $mockResponseStream = fopen('php://memory', 'r+');
-    fwrite(
-        $mockResponseStream,
-        \implode("\n", $mockResponse) . "\n"
-    );
-    rewind($mockResponseStream);
-    
-    $mock = new MockHandler([
-        new Response(200, [], $mockResponseStream)
-    ]);
-    
-    $handlerStack = HandlerStack::create($mock);
-    $httpClient = new Client(['handler' => $handlerStack]);
-    
+    $httpClient = mockGuzzleClient($mockResponse);
     $gateway = new PerplexityAIGateway($httpClient);
-    
+
     $result = $gateway->inference($parameters);
 
     expect($result)->toBeArray();

--- a/tests/Unit/PerplexityAIGatewayTest.php
+++ b/tests/Unit/PerplexityAIGatewayTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+use App\AI\PerplexityAIGateway;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+test('PerplexityAIGateway handles mistral responses correctly', function () {
+    $prompt = 'What is the capital of France?';
+    $inputTokens = 6;
+    $answer = 'Capital of France is Paris.';
+    $outputTokens = 5;
+
+    $parameters = [
+        'model' => 'sonar-small-online',
+        'messages' => [
+            ['role' => 'user', 'content' => $prompt]
+        ],
+        'max_tokens' => 2000
+    ];
+
+    $mockResponse = [
+        [
+            'choices' => [[
+                'delta' => [
+                    'content' => $answer
+                ]
+            ]],
+            'usage' => [
+                'prompt_tokens' => $inputTokens,
+                'completion_tokens' => $outputTokens
+            ]
+        ]
+    ];
+    $mockResponse = array_map(function($data) {
+        return 'data: ' . json_encode($data);
+    }, $mockResponse);
+    $mockResponseStream = fopen('php://memory', 'r+');
+    fwrite(
+        $mockResponseStream,
+        \implode("\n", $mockResponse) . "\n"
+    );
+    rewind($mockResponseStream);
+    
+    $mock = new MockHandler([
+        new Response(200, [], $mockResponseStream)
+    ]);
+    
+    $handlerStack = HandlerStack::create($mock);
+    $httpClient = new Client(['handler' => $handlerStack]);
+    
+    $gateway = new PerplexityAIGateway($httpClient);
+    
+    $result = $gateway->inference($parameters);
+
+    expect($result)->toBeArray();
+    expect($result['content'])->toEqual($answer);
+    expect($result['input_tokens'])->toEqual($inputTokens);
+    expect($result['output_tokens'])->toEqual($outputTokens);
+});


### PR DESCRIPTION
- created initial `Gateway` interface with a single `inference` method
- converted all active gateways to implement new interface
- added http client class variable to most gateways to be able to mock api calls
- add unit tests for all converted gateways
- removed some unused code
- made all added/updated use strict mode