### PR TITLE
fix: do not update payments when no status received

### DIFF
--- a/app/Console/Commands/UpdatePrismStatuses.php
+++ b/app/Console/Commands/UpdatePrismStatuses.php
@@ -27,7 +27,7 @@ class UpdatePrismStatuses extends Command
             $wat = $prismService->getTransactionDetails($payment->payment_id);
 
             // If status is different than the one we have, update it
-            if ($wat['status'] !== $payment->status) {
+            if (is_array($wat) && isset($wat['status']) && ($wat['status'] !== $payment->status)) {
                 $this->info('Updating payment '.$payment->payment_id.' to status '.$wat['status']);
                 $payment->update(['status' => $wat['status']]);
             }

--- a/tests/Feature/UpdatePrimsStatusesTest.php
+++ b/tests/Feature/UpdatePrimsStatusesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\PrismSinglePayment;
+use Mockery;
+
+it('updates Prism payment statuses', function () {
+    $mockPayment = Mockery::mock('overload:'.PrismSinglePayment::class);
+
+    $payment = new PrismSinglePayment(['payment_id' => 1, 'status' => 'sending']);
+    $payment->payment_id = 1;
+    $payment->status = 'sending';
+
+    // Set up a fake response for the where call
+    $mockPayments = collect([$payment]);
+    $mockPayment->shouldReceive('where')
+        ->once()
+        ->andReturnSelf()
+        ->shouldReceive('get')
+        ->andReturn($mockPayments);
+
+    // Call the command and assert it runs successfully
+    $this->artisan('prism:update')->assertExitCode(0);
+
+    Mockery::close();
+});


### PR DESCRIPTION
Also add a test, mostly mocked for now, but hitting the current error case of no status available.