### PR TITLE
feat: ability to edit my last prompt and resubmit it

### DIFF
--- a/resources/views/components/chat/message.blade.php
+++ b/resources/views/components/chat/message.blade.php
@@ -22,7 +22,7 @@
                             <img class="mt-6" src="{{ $message }}" alt="Embedded Image">
                         @else
                             <x-markdown
-                                    class="text-md text-text markdown-content">{!! $message !!}</x-markdown>
+                                    class="text-md text-text markdown-content {{ $promptClass }}">{!! $message !!}</x-markdown>
                         @endif
 
                     </div>

--- a/resources/views/components/chat/textarea.blade.php
+++ b/resources/views/components/chat/textarea.blade.php
@@ -16,6 +16,7 @@
     minRows: @js($minRows),
     maxRows: @js($maxRows),
     viewportMaxHeight: window.innerHeight * 0.95,
+    promptIndex: -1,
     update() {
         this.$refs.textarea.style.height = 'auto';
         let newHeight = this.$refs.textarea.scrollHeight;
@@ -46,6 +47,28 @@
         this.$refs.textarea.style.height = `${minHeight}px`;
         this.$refs.textarea.style.overflowY = 'hidden';
         this.isDisabled = true;
+    },
+    reusePreviousPrompt(event) {
+        const prompts = document.getElementsByClassName('prompt');
+        --this.promptIndex;
+        if (this.promptIndex < 0) {
+            this.promptIndex = prompts.length - 1;
+        }
+        this.setInputFromPrompt(prompts);
+    },
+    reuseNextPrompt(event) {
+        const prompts = document.getElementsByClassName('prompt');
+        ++this.promptIndex;
+        if (this.promptIndex >= prompts.length) {
+            this.promptIndex = 0;
+        }
+        this.setInputFromPrompt(prompts);
+    },
+    setInputFromPrompt(prompts) {
+        if (prompts[this.promptIndex]) {
+            event.target.value = prompts[this.promptIndex].textContent.trim();
+            this.update();
+        }
     }
 }" x-init="$nextTick(() => {
     $refs.textarea.style.height = `${minRows * lineHeight()}px`;
@@ -61,6 +84,8 @@
         x-model="inputVal"
         x-effect="if (inputVal === '') resetHeight()"
         :rows="minRows"
+        @keyup.alt.up.prevent="reusePreviousPrompt"
+        @keyup.alt.down.prevent="reuseNextPrompt"
     {{ $attributes->merge([
         'class' => "resize-none flex w-full rounded-md border-2 bg-transparent px-4 py-[0.65rem] pl-10 pr-10 text-[16px] placeholder:text-[#777A81] focus-visible:outline-none focus-visible:ring-0 focus-visible:border-white focus-visible:ring-white " . ($hasError ? 'border-red' : 'border-[#3D3E42]') . " $className transition-all duration-300 ease-in-out",
     ]) }}

--- a/resources/views/livewire/chat.blade.php
+++ b/resources/views/livewire/chat.blade.php
@@ -35,8 +35,13 @@
                     @foreach($messages as $message)
                         @php
                             $author = !empty($message['model']) ? $models[$message['model']]["name"] : 'You';
+                            $promptClass = $author === 'You' ? 'prompt' : '';
                         @endphp
-                        <x-chat.message :author="$author" :message="$message['body']"></x-chat.message>
+                        <x-chat.message
+                            :author="$author"
+                            :message="$message['body']"
+                            :promptClass="$promptClass"
+                        ></x-chat.message>
                     @endforeach
 
                     @if($pending)


### PR DESCRIPTION
Allow using ALT+up/down arrow keys to scroll through prompt history in the current thread.

TODO: handle code and other special formatting smarter, currently simply copies the text content of the prompt.