### PR TITLE
fix: avoid errors due to null content

### DIFF
--- a/app/AI/GreptileGateway.php
+++ b/app/AI/GreptileGateway.php
@@ -76,7 +76,7 @@ class GreptileGateway implements GatewayInterface
             $json = $response->json();
 
             return [
-                'content' => $json['message'],
+                'content' => $json['message'] ?? '',
                 'output_tokens' => 0,
                 'input_tokens' => 0,
             ];

--- a/app/AI/SimpleInferencer.php
+++ b/app/AI/SimpleInferencer.php
@@ -102,6 +102,7 @@ function get_truncated_messages(Thread $thread, int $maxTokens)
                 $userContent .= ' '.$message->body;
             }
         } else {
+            $userContent = trim($userContent);
             if (! empty($userContent)) {
                 $messageTokens = ceil(str_word_count($userContent) / 3);
 
@@ -111,7 +112,7 @@ function get_truncated_messages(Thread $thread, int $maxTokens)
 
                 $messages[] = [
                     'role' => 'user',
-                    'content' => trim($userContent),
+                    'content' => $userContent,
                 ];
 
                 $tokenCount += $messageTokens;
@@ -121,7 +122,11 @@ function get_truncated_messages(Thread $thread, int $maxTokens)
             if (strtolower(substr($message->body, 0, 11)) === 'data:image/') {
                 $content = '<image>';
             } else {
-                $content = $message->body;
+                $content = trim($message->body);
+                if (empty($content)) {
+                    // Some LLMs return a 400 error if they receive blank content
+                    continue;
+                }
             }
 
             $messageTokens = ceil(str_word_count($content) / 3);

--- a/app/AI/TogetherAIGateway.php
+++ b/app/AI/TogetherAIGateway.php
@@ -40,9 +40,9 @@ class TogetherAIGateway implements GatewayInterface
             $responseData = json_decode($response->getBody()->getContents(), true);
 
             return [
-                'content' => $responseData['choices'][0]['message']['content'],
-                'output_tokens' => $responseData['usage']['completion_tokens'],
-                'input_tokens' => $responseData['usage']['prompt_tokens'],
+                'content' => $responseData['choices'][0]['message']['content'] ?? '',
+                'output_tokens' => $responseData['usage']['completion_tokens'] ?? 0,
+                'input_tokens' => $responseData['usage']['prompt_tokens'] ?? 0,
             ];
         } catch (RequestException $e) {
             dd($e->getMessage());

--- a/app/Livewire/Chat.php
+++ b/app/Livewire/Chat.php
@@ -180,22 +180,19 @@ class Chat extends Component
         $output = SimpleInferencer::inference($this->input, $this->selectedModel, $this->thread, $this->getStreamingCallback());
 
         // Append the response to the chat
-        $this->messages[] = [
+        $message = [
             'body' => $output['content'],
             'model' => $this->selectedModel,
             'user_id' => auth()->id() ?? null,
             'session_id' => $sessionId,
         ];
+        $this->messages[] = $message;
 
         // Save the agent's response to the thread
-        $this->thread->messages()->create([
-            'body' => $output['content'],
-            'session_id' => $sessionId,
-            'model' => $this->selectedModel,
-            'user_id' => auth()->id() ?? null,
+        $this->thread->messages()->create(array_merge($message, [
             'input_tokens' => $output['input_tokens'],
             'output_tokens' => $output['output_tokens'],
-        ]);
+        ]));
 
         // Reset pending status and scroll to the latest message
         $this->pending = false;


### PR DESCRIPTION
For now just avoid warnings and errors if empty content somehow sneaks in (usually due to some failure on LLM side.)