### PR TITLE
fix: use unique stream names to avoid conflicts

### DIFF
--- a/app/Livewire/Chat.php
+++ b/app/Livewire/Chat.php
@@ -325,7 +325,7 @@ class Chat extends Component
         return function ($response) {
             $token = $response['choices'][0]['delta']['content'] ?? '';
             $this->stream(
-                to: 'streamtext',
+                to: 'streamtext'.$this->thread->id,
                 content: $token
             );
         };

--- a/resources/views/components/chat/messagestreaming.blade.php
+++ b/resources/views/components/chat/messagestreaming.blade.php
@@ -21,7 +21,7 @@
                 <span class="mb-1 font-semibold select-none text-white">{{ $author }}</span>
                 <div class="flex-col gap-1 md:gap-3">
                     <div class="flex flex-grow flex-col max-w-[936px]">
-                        <x-markdown wire:stream="streamtext" class="text-md whitespace-pre-wrap"></x-markdown>
+                        <x-markdown wire:stream="streamtext{{ $thread }}" class="text-md whitespace-pre-wrap"></x-markdown>
                         <div class="dot-flashing"></div>
                     </div>
                     <div class="flex justify-start gap-3 empty:hidden">

--- a/resources/views/livewire/chat.blade.php
+++ b/resources/views/livewire/chat.blade.php
@@ -87,13 +87,13 @@
                             $image = $selectedAgent ? $selectedAgent['image'] : null;
 
                             $model_image = $selectedModel ? asset('images/icons/' . $models[$selectedModel]['gateway'] . '.png') : null;
-
                         @endphp
 
                         <x-chat.messagestreaming
                                 :author="$author"
                                 :agent-image="$image"
-                                :model-image="$model_image">
+                                :model-image="$model_image"
+                                :thread="$thread->id">
                         </x-chat.messagestreaming>
                     @endif
 


### PR DESCRIPTION
When a stream starts in one thread and a new thread is started, use a different stream name to avoid streams overwriting each other.