### PR TITLE
fix: no need to give max-tokens to OpenAI, it handles it well

### DIFF
--- a/app/AI/OpenAIGateway.php
+++ b/app/AI/OpenAIGateway.php
@@ -31,7 +31,6 @@ class OpenAIGateway implements GatewayInterface
     {
         $model = $params['model'];
         $messages = $params['messages'];
-        $max_tokens = $params['max_tokens'];
         $streamFunction = $params['stream_function'];
 
         $message = '';
@@ -39,7 +38,6 @@ class OpenAIGateway implements GatewayInterface
         $stream = $this->client->chat()->createStreamed([
             'model' => $model,
             'messages' => $messages,
-            'max_tokens' => $max_tokens,
         ]);
 
         foreach ($stream as $response) {


### PR DESCRIPTION
Our estimation of token counts can be improved, but will never be exact, and sometimes are off by a lot. We can still truncate messages on our end to optimize network traffic and other costs, but let the api decide.