### PR TITLE
Add database connection resilience

### DIFF
--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -8,3 +8,6 @@ database:
   password: "password"
   database_name: "openagents"
   require_ssl: false
+  connection_timeout_secs: 30
+  max_connection_retries: 5
+  retry_interval_secs: 5

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -8,6 +8,5 @@ database:
   password: "password"
   database_name: "openagents"
   require_ssl: false
-  connection_timeout_secs: 30
   max_connection_retries: 5
   retry_interval_secs: 5

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -2,3 +2,6 @@ application:
   host: 0.0.0.0
 database:
   require_ssl: true
+  connection_timeout_secs: 60
+  max_connection_retries: 10
+  retry_interval_secs: 10

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -2,6 +2,5 @@ application:
   host: 0.0.0.0
 database:
   require_ssl: true
-  connection_timeout_secs: 120
   max_connection_retries: 20
   retry_interval_secs: 15

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -2,6 +2,6 @@ application:
   host: 0.0.0.0
 database:
   require_ssl: true
-  connection_timeout_secs: 60
-  max_connection_retries: 10
-  retry_interval_secs: 10
+  connection_timeout_secs: 120
+  max_connection_retries: 20
+  retry_interval_secs: 15

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -26,16 +26,10 @@ pub struct DatabaseSettings {
     pub host: String,
     pub database_name: String,
     pub require_ssl: bool,
-    #[serde(default = "default_connection_timeout")]
-    pub connection_timeout_secs: u64,
     #[serde(default = "default_max_retries")]
     pub max_connection_retries: u32,
     #[serde(default = "default_retry_interval")]
     pub retry_interval_secs: u64,
-}
-
-fn default_connection_timeout() -> u64 {
-    30 // 30 seconds default timeout
 }
 
 fn default_max_retries() -> u32 {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,7 +3,6 @@ use secrecy::{ExposeSecret, Secret};
 use serde_aux::field_attributes::deserialize_number_from_string;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
 use sqlx::ConnectOptions;
-use std::time::Duration;
 
 #[derive(serde::Deserialize, Clone)]
 pub struct Settings {
@@ -65,5 +64,59 @@ impl DatabaseSettings {
 
         options = options.log_statements(tracing::log::LevelFilter::Trace);
         options
+    }
+}
+
+pub fn get_configuration() -> Result<Settings, ConfigError> {
+    let base_path = std::env::current_dir()
+        .expect("Failed to determine current directory")
+        .join("configuration");
+
+    let environment: AppEnvironment = std::env::var("APP_ENVIRONMENT")
+        .unwrap_or_else(|_| "local".into())
+        .try_into()
+        .expect("Failed to parse APP_ENVIRONMENT");
+
+    let environment_filename = format!("{}.yaml", environment.as_str());
+
+    let settings = Config::builder()
+        .add_source(File::from(base_path.join("base.yaml")))
+        .add_source(File::from(base_path.join(environment_filename)))
+        .add_source(
+            ConfigEnvironment::with_prefix("APP")
+                .prefix_separator("_")
+                .separator("__"),
+        )
+        .build()?;
+
+    settings.try_deserialize::<Settings>()
+}
+
+pub enum AppEnvironment {
+    Local,
+    Production,
+}
+
+impl AppEnvironment {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AppEnvironment::Local => "local",
+            AppEnvironment::Production => "production",
+        }
+    }
+}
+
+impl TryFrom<String> for AppEnvironment {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.to_lowercase().as_str() {
+            "local" => Ok(Self::Local),
+            "production" => Ok(Self::Production),
+            other => Err(format!(
+                "{} is not a supported environment. Use either `local` or `production`.",
+                other
+            )),
+        }
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,6 +3,7 @@ use secrecy::{ExposeSecret, Secret};
 use serde_aux::field_attributes::deserialize_number_from_string;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
 use sqlx::ConnectOptions;
+use std::time::Duration;
 
 #[derive(serde::Deserialize, Clone)]
 pub struct Settings {
@@ -26,6 +27,24 @@ pub struct DatabaseSettings {
     pub host: String,
     pub database_name: String,
     pub require_ssl: bool,
+    #[serde(default = "default_connection_timeout")]
+    pub connection_timeout_secs: u64,
+    #[serde(default = "default_max_retries")]
+    pub max_connection_retries: u32,
+    #[serde(default = "default_retry_interval")]
+    pub retry_interval_secs: u64,
+}
+
+fn default_connection_timeout() -> u64 {
+    30 // 30 seconds default timeout
+}
+
+fn default_max_retries() -> u32 {
+    5 // 5 retries by default
+}
+
+fn default_retry_interval() -> u64 {
+    5 // 5 seconds between retries
 }
 
 impl DatabaseSettings {
@@ -36,15 +55,17 @@ impl DatabaseSettings {
             PgSslMode::Prefer
         };
 
-        let options = PgConnectOptions::new()
+        let mut options = PgConnectOptions::new()
             .host(&self.host)
             .username(&self.username)
             .password(self.password.expose_secret())
             .port(self.port)
             .ssl_mode(ssl_mode)
-            .database(&self.database_name);
-        
-        options.log_statements(tracing::log::LevelFilter::Trace)
+            .database(&self.database_name)
+            .connect_timeout(Duration::from_secs(self.connection_timeout_secs));
+
+        options = options.log_statements(tracing::log::LevelFilter::Trace);
+        options
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,24 +3,52 @@ use sqlx::postgres::{PgPoolOptions, PgConnectOptions};
 use crate::event::Event;
 use std::collections::HashSet;
 use std::error::Error;
+use std::time::Duration;
+use tracing::warn;
 
 pub struct Database {
     pool: Pool<Postgres>
 }
 
 impl Database {
-    pub async fn new_with_options(options: PgConnectOptions) -> Result<Self, Box<dyn Error>> {
-        let pool = PgPoolOptions::new()
-            .max_connections(5)
-            .connect_with(options)
-            .await?;
+    pub async fn new_with_options(
+        options: PgConnectOptions,
+        max_retries: u32,
+        retry_interval: Duration
+    ) -> Result<Self, Box<dyn Error>> {
+        let mut last_error = None;
+        
+        for attempt in 1..=max_retries {
+            match PgPoolOptions::new()
+                .max_connections(5)
+                .connect_with(options.clone())
+                .await
+            {
+                Ok(pool) => {
+                    // Run migrations after successful connection
+                    match sqlx::migrate!("./migrations").run(&pool).await {
+                        Ok(_) => return Ok(Self { pool }),
+                        Err(e) => {
+                            warn!("Migration failed on attempt {}: {}", attempt, e);
+                            last_error = Some(e.into());
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Database connection attempt {} of {} failed: {}",
+                        attempt, max_retries, e
+                    );
+                    last_error = Some(e.into());
+                }
+            }
 
-        // Run migrations
-        sqlx::migrate!("./migrations")
-            .run(&pool)
-            .await?;
+            if attempt < max_retries {
+                tokio::time::sleep(retry_interval).await;
+            }
+        }
 
-        Ok(Self { pool })
+        Err(last_error.unwrap_or_else(|| "Failed to connect to database".into()))
     }
 
     pub async fn save_event(&self, event: &Event) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
This PR adds connection resilience to the database initialization process to handle cases where the database might be temporarily unavailable or still provisioning. Changes include:

1. Added connection timeout and retry settings to database configuration:
   - `connection_timeout_secs`: How long to wait for each connection attempt
   - `max_connection_retries`: Number of times to retry connecting
   - `retry_interval_secs`: Time to wait between retries

2. Enhanced Database initialization with retry logic:
   - Will attempt to connect multiple times before giving up
   - Logs each failed attempt with details
   - Configurable retry parameters through YAML config or environment variables

3. Updated configuration files:
   - Base config: 30s timeout, 5 retries, 5s interval
   - Production config: 60s timeout, 10 retries, 10s interval

These changes make the application more resilient to temporary database unavailability, which is particularly useful during database provisioning or network issues.

Environment variables can override these settings:
```bash
APP_DATABASE__CONNECTION_TIMEOUT_SECS=60
APP_DATABASE__MAX_CONNECTION_RETRIES=10
APP_DATABASE__RETRY_INTERVAL_SECS=10
```