### PR TITLE
Simplify database configuration to match OA approach

### DIFF
--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -8,5 +8,3 @@ database:
   password: "password"
   database_name: "openagents"
   require_ssl: false
-  max_connection_retries: 5
-  retry_interval_secs: 5

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -1,12 +1,4 @@
 application:
-  host: "0.0.0.0"  # Explicitly quoted
+  host: 0.0.0.0
 database:
-  host: "${DATABASE_HOST:localhost}"  # Allow override from env
-  port: 5432
-  username: "${DATABASE_USER:postgres}"
-  password: "${DATABASE_PASSWORD:postgres}"
-  database_name: "${DATABASE_NAME:postgres}"
-  require_ssl: true  # Required for DigitalOcean managed databases
-  ssl_mode: "require"
-  max_connection_retries: 20
-  retry_interval_secs: 15
+  require_ssl: true


### PR DESCRIPTION
This PR simplifies the database configuration to match the approach used in the OA repository, which is known to work well with DigitalOcean deployments.

Changes made:
1. Removed connection retry settings from base.yaml
2. Simplified production.yaml to only override essential settings
3. Removed explicit environment variable interpolation in favor of implicit configuration
4. Removed explicit SSL mode setting, keeping only require_ssl flag

This change aims to resolve deployment issues with DigitalOcean by adopting the simpler, proven configuration approach from OA.