### PR TITLE
Fix development mode database configuration

### DIFF
--- a/configuration/local.yaml
+++ b/configuration/local.yaml
@@ -1,4 +1,9 @@
 application:
   host: 127.0.0.1
 database:
+  host: "127.0.0.1"
+  port: 5432
+  username: "postgres"
+  password: "postgres"
+  database_name: "openagents"
   require_ssl: false


### PR DESCRIPTION
This PR fixes development mode database configuration issues:

1. Added proper development database settings to local.yaml
2. Updated DatabaseSettings defaults to use sensible development values
3. Updated default_password to use "postgres" instead of empty string
4. Added check to only set database name if it's not empty
5. Added better error logging for database connection details

The changes ensure that:
- Development mode works out of the box with default Postgres settings
- Empty database settings don't cause connection errors
- Connection details are properly logged for debugging