### PR TITLE
Add pages for buttons with shared layout and hx-boost

### DIFF
--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -35,11 +35,39 @@ pub async fn changelog_page() -> impl Responder {
     NamedFile::open(path)
 }
 
+#[get("/mobile-app")]
+pub async fn mobile_app_page() -> impl Responder {
+    let path: PathBuf = "./static/mobile-app.html".into();
+    NamedFile::open(path)
+}
+
+#[get("/business")]
+pub async fn business_page() -> impl Responder {
+    let path: PathBuf = "./static/business.html".into();
+    NamedFile::open(path)
+}
+
+#[get("/company")]
+pub async fn company_page() -> impl Responder {
+    let path: PathBuf = "./static/company.html".into();
+    NamedFile::open(path)
+}
+
+#[get("/contact")]
+pub async fn contact_page() -> impl Responder {
+    let path: PathBuf = "./static/contact.html".into();
+    NamedFile::open(path)
+}
+
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(health_check)
         .service(new_page)
         .service(agents_page)
         .service(video_series_page)
         .service(changelog_page)
+        .service(mobile_app_page)
+        .service(business_page)
+        .service(company_page)
+        .service(contact_page)
         .route("/subscriptions", web::post().to(subscribe));
 }

--- a/static/business.html
+++ b/static/business.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/>
+    <meta name="application-name" content="OpenAgents"/>
+    <meta name="description" content="Business Services"/>
+    <meta name="author" content="OpenAgents, Inc.">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="js/htmx.min.js"></script>
+    <script src="js/mustache.js"></script>
+</head>
+
+<body class="bg-black text-white font-mono min-h-screen max-w-[60rem] sm:border sm:border-white leading-6 mt-8 mb-8 py-2 px-4 pb-1 mx-auto">
+    <div class="container mx-auto">
+        <div hx-get="/templates/header.mustache"
+             hx-trigger="load">
+        </div>
+
+        <template id="button-template">
+            <a class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6 border border-white" href="{{href}}" hx-boost="true">{{text}}</a>
+        </template>
+
+        <div class="content">
+            <h1 class="text-3xl font-bold mb-4">Business Services</h1>
+            <p class="mb-4">Welcome to our Business Services page. Here you can find information about the various services we offer to help your business grow and succeed.</p>
+            <p class="mb-4">Our team of experts is dedicated to providing top-notch services tailored to meet your specific needs. Whether you are looking for consulting, software development, or marketing solutions, we have you covered.</p>
+            <p class="mb-4">Contact us today to learn more about how we can assist you in achieving your business goals.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/static/company.html
+++ b/static/company.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/>
+    <meta name="application-name" content="OpenAgents"/>
+    <meta name="description" content="Company Information"/>
+    <meta name="author" content="OpenAgents, Inc.">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="js/htmx.min.js"></script>
+    <script src="js/mustache.js"></script>
+</head>
+
+<body class="bg-black text-white font-mono min-h-screen max-w-[60rem] sm:border sm:border-white leading-6 mt-8 mb-8 py-2 px-4 pb-1 mx-auto">
+    <div class="container mx-auto">
+        <div hx-get="/templates/header.mustache"
+             hx-trigger="load">
+        </div>
+
+        <template id="button-template">
+            <a class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6 border border-white" href="{{href}}" hx-boost="true">{{text}}</a>
+        </template>
+
+        <div class="content">
+            <h1 class="text-3xl font-bold mb-4">Company</h1>
+            <p class="mb-4">Welcome to the Company page. Here you can find information about our company, our mission, and our team.</p>
+            <p class="mb-4">Our company is dedicated to providing innovative solutions to help businesses and individuals achieve their goals. We believe in the power of technology to transform lives and create new opportunities.</p>
+            <p class="mb-4">Our team is composed of experienced professionals who are passionate about what they do. We are committed to delivering high-quality products and services that meet the needs of our customers.</p>
+            <p class="mb-4">Thank you for visiting our Company page. We look forward to working with you and helping you achieve your goals.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/static/contact.html
+++ b/static/contact.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/>
+    <meta name="application-name" content="OpenAgents"/>
+    <meta name="description" content="Contact OpenAgents"/>
+    <meta name="author" content="OpenAgents, Inc.">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="js/htmx.min.js"></script>
+    <script src="js/mustache.js"></script>
+</head>
+
+<body class="bg-black text-white font-mono min-h-screen max-w-[60rem] sm:border sm:border-white leading-6 mt-8 mb-8 py-2 px-4 pb-1 mx-auto">
+    <div class="container mx-auto">
+        <div hx-get="/templates/header.mustache"
+             hx-trigger="load">
+        </div>
+
+        <template id="button-template">
+            {{> button}}
+        </template>
+
+        <div class="contact-form">
+            <h2 class="text-xl font-bold mb-4">Contact Us</h2>
+            <form id="contact-form">
+                <div class="form-group mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+                    <input type="text" id="name" name="name" required
+                           class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
+                           placeholder="Your Name">
+                </div>
+                <div class="form-group mb-4">
+                    <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+                    <input type="email" id="email" name="email" required
+                           class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
+                           placeholder="you@example.com">
+                </div>
+                <div class="form-group mb-4">
+                    <label for="message" class="block text-sm font-medium text-gray-700">Message</label>
+                    <textarea id="message" name="message" required
+                              class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
+                              placeholder="Your message..."></textarea>
+                </div>
+                <button type="submit" class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6">Send Message</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/static/mobile-app.html
+++ b/static/mobile-app.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/>
+    <meta name="application-name" content="OpenAgents"/>
+    <meta name="description" content="Mobile App for OpenAgents"/>
+    <meta name="author" content="OpenAgents, Inc.">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="js/htmx.min.js"></script>
+    <script src="js/mustache.js"></script>
+</head>
+
+<body class="bg-black text-white font-mono min-h-screen max-w-[60rem] sm:border sm:border-white leading-6 mt-8 mb-8 py-2 px-4 pb-1 mx-auto">
+    <div class="container mx-auto">
+        <div hx-get="/templates/header.mustache"
+             hx-trigger="load">
+        </div>
+
+        <template id="button-template">
+            <a class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6 border border-white" href="{{href}}" hx-boost="true">{{text}}</a>
+        </template>
+
+        <div class="content">
+            <h1 class="text-3xl font-bold mb-4">Mobile App</h1>
+            <p>Welcome to the Mobile App page of OpenAgents. Here you can find information about our mobile application.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/static/templates/button.mustache
+++ b/static/templates/button.mustache
@@ -1,1 +1,1 @@
-<a class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6" href="{{href}}">{{text}}</a>
+<a class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6 border border-white" href="{{href}}" hx-boost="true">{{text}}</a>

--- a/static/templates/header.mustache
+++ b/static/templates/header.mustache
@@ -30,3 +30,7 @@
         navButtons.appendChild(li);
     });
 </script>
+
+<template id="button-template">
+    {{> button}}
+</template>

--- a/static/video-series.html
+++ b/static/video-series.html
@@ -22,7 +22,7 @@
         </div>
 
         <template id="button-template">
-            <a class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6" href="{{href}}">{{text}}</a>
+            {{> button}}
         </template>
 
         <div id="videos" 


### PR DESCRIPTION
Add pages for the six buttons at the top using a shared layout, with a white border and no radius, and use hx-boost to prevent the top from reloading.

* **Shared Layout**: Add `hx-boost` attribute and white border with no radius to the `<a>` tag in `static/templates/button.mustache`.
* **Header Template**: Update `static/templates/header.mustache` to use the shared layout `static/templates/button.mustache`.
* **New Pages**: Create new HTML files for Mobile App (`static/mobile-app.html`), Business Services (`static/business.html`), Company (`static/company.html`), and Contact (`static/contact.html`) using the shared layout.
* **Video Series Page**: Update `static/video-series.html` to use the shared layout.
* **Routes**: Add routes for the new pages in `src/server/routes.rs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OpenAgentsInc/openagents/pull/547?shareId=6e4bdcdd-21d2-4d1d-bcec-35a75a659a4f).