### PR TITLE
Optimize header navigation with hx-preserve and client-side templates

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -15,35 +15,38 @@
     <script src="js/htmx.min.js"></script>
     <script src="js/client-side-templates.js"></script>
     <script src="js/mustache.js"></script>
-    <script src="js/client-side-templates.js"></script>
 </head>
 
-<body class="bg-black text-white font-mono min-h-screen max-w-[60rem] sm:border sm:border-white leading-6 mt-8 mb-8 py-2 px-4 pb-1 mx-auto" hx-boost="true">
+<body class="bg-black text-white font-mono min-h-screen max-w-[60rem] sm:border sm:border-white leading-6 mt-8 mb-8 py-2 px-4 pb-1 mx-auto">
     <div class="container mx-auto" hx-ext="client-side-templates">
-        <div hx-get="/templates/header.json"
+        <div id="header-container"
+             hx-get="/templates/header.json"
              hx-trigger="load"
              mustache-template="header-template">
         </div>
 
         <template id="header-template">
-            <header class="py-2 mb-5">
-                <div class="flex justify-between items-center w-full">
-                    <span class="text-lg font-bold">OpenAgents</span>
-                </div>
-                <div class="mt-4">
-                    <nav>
-                        <ul class="grid grid-cols-3 gap-2 lg:grid-cols-6" id="nav-buttons">
-                            {{#buttons}}
-                            <li class="flex justify-center mb-1">
-                                <a class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6 border border-white" 
-                                   href="{{href}}">{{text}}</a>
-                            </li>
-                            {{/buttons}}
-                        </ul>
-                    </nav>
-                </div>
-            </header>
+            <div hx-get="/templates/header.mustache"
+                 hx-trigger="load"
+                 mustache-template="header-content">
+            </div>
         </template>
+
+        <div id="content">
+            <!-- Page content will be loaded here -->
+        </div>
     </div>
+
+    <script>
+        document.body.addEventListener('htmx:afterSwap', function(evt) {
+            // Preserve header state after content swap
+            if (evt.detail.target === document.body) {
+                const header = document.querySelector('#header-container');
+                if (header) {
+                    evt.detail.shouldSwap = false;
+                }
+            }
+        });
+    </script>
 </body>
 </html>

--- a/static/templates/header.mustache
+++ b/static/templates/header.mustache
@@ -1,0 +1,20 @@
+<header class="py-2 mb-5" hx-preserve="true">
+    <div class="flex justify-between items-center w-full">
+        <span class="text-lg font-bold">OpenAgents</span>
+    </div>
+    <div class="mt-4">
+        <nav>
+            <ul class="grid grid-cols-3 gap-2 lg:grid-cols-6" id="nav-buttons">
+                {{#buttons}}
+                <li class="flex justify-center mb-1">
+                    <a class="btn-nav bg-black hover:bg-zinc-900 text-white text-xs inline-flex items-center justify-center whitespace-nowrap select-none text-center align-middle no-underline outline-none w-full px-6 border border-white" 
+                       href="{{href}}"
+                       hx-boost="true"
+                       hx-target="body"
+                       hx-swap="innerHTML">{{text}}</a>
+                </li>
+                {{/buttons}}
+            </ul>
+        </nav>
+    </div>
+</header>


### PR DESCRIPTION
This PR optimizes the header navigation to prevent re-rendering when navigating between pages. Changes include:

1. Added hx-preserve to the header component
2. Moved header template to a separate file for better organization
3. Added proper HTMX boost and client-side template configuration
4. Added event listener to prevent header re-rendering during page swaps
5. Removed duplicate client-side-templates.js script include

The changes ensure that:
- Header state is preserved during navigation
- Navigation is smooth and efficient
- Templates are properly organized and maintainable
- No unnecessary re-renders occur

Testing:
1. Header should load correctly on initial page load
2. Navigation between pages should be smooth
3. Header should not re-render when clicking navigation links
4. All navigation links should work as expected