### PR TITLE
Add separate template for home page

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ async fn business(headers: HeaderMap) -> Html<String> {
     let is_htmx = headers.contains_key("hx-request");
     let title = "Services".to_string();
     let content = "Enterprise AI solutions".to_string();
-    let path = "/business".to_string();
+    let path = "/services".to_string();
 
     if is_htmx {
         let template = ContentTemplate { title, content };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,136 @@
-use openagents::run;
+use askama::Template;
+use axum::{
+    response::Html,
+    routing::get,
+    Router,
+    http::header::HeaderMap,
+};
+use tower_http::services::ServeDir;
+use std::path::PathBuf;
 
-fn main() -> std::io::Result<()> {
-    run()
+#[tokio::main]
+async fn main() {
+    let assets_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets");
+    
+    let app = Router::new()
+        .route("/", get(home))
+        .route("/mobile-app", get(mobile_app))
+        .route("/video-series", get(video_series))
+        .route("/services", get(business))
+        .route("/company", get(company))
+        .route("/contact", get(contact))
+        .nest_service("/assets", ServeDir::new(assets_path));
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8000").await.unwrap();
+    println!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}
+
+#[derive(Template)]
+#[template(path = "base.html")]
+struct PageTemplate {
+    title: String,
+    content: String,
+    path: String,
+}
+
+#[derive(Template)]
+#[template(path = "content.html")]
+struct ContentTemplate {
+    title: String,
+    content: String,
+}
+
+#[derive(Template)]
+#[template(path = "pages/home.html")]
+struct HomeTemplate;
+
+async fn home(headers: HeaderMap) -> Html<String> {
+    let is_htmx = headers.contains_key("hx-request");
+    
+    if is_htmx {
+        let template = ContentTemplate { 
+            title: "Home".to_string(),
+            content: "Welcome to OpenAgents".to_string()
+        };
+        Html(template.render().unwrap())
+    } else {
+        let template = HomeTemplate;
+        Html(template.render().unwrap())
+    }
+}
+
+async fn mobile_app(headers: HeaderMap) -> Html<String> {
+    let is_htmx = headers.contains_key("hx-request");
+    let title = "Mobile App".to_string();
+    let content = "Our mobile app is coming soon".to_string();
+    let path = "/mobile-app".to_string();
+
+    if is_htmx {
+        let template = ContentTemplate { title, content };
+        Html(template.render().unwrap())
+    } else {
+        let template = PageTemplate { title, content, path };
+        Html(template.render().unwrap())
+    }
+}
+
+async fn business(headers: HeaderMap) -> Html<String> {
+    let is_htmx = headers.contains_key("hx-request");
+    let title = "Services".to_string();
+    let content = "Enterprise AI solutions".to_string();
+    let path = "/business".to_string();
+
+    if is_htmx {
+        let template = ContentTemplate { title, content };
+        Html(template.render().unwrap())
+    } else {
+        let template = PageTemplate { title, content, path };
+        Html(template.render().unwrap())
+    }
+}
+
+async fn video_series(headers: HeaderMap) -> Html<String> {
+    let is_htmx = headers.contains_key("hx-request");
+    let title = "Video Series".to_string();
+    let content = "Watch our latest content".to_string();
+    let path = "/video-series".to_string();
+
+    if is_htmx {
+        let template = ContentTemplate { title, content };
+        Html(template.render().unwrap())
+    } else {
+        let template = PageTemplate { title, content, path };
+        Html(template.render().unwrap())
+    }
+}
+
+async fn company(headers: HeaderMap) -> Html<String> {
+    let is_htmx = headers.contains_key("hx-request");
+    let title = "Company".to_string();
+    let content = "About our mission and team".to_string();
+    let path = "/company".to_string();
+
+    if is_htmx {
+        let template = ContentTemplate { title, content };
+        Html(template.render().unwrap())
+    } else {
+        let template = PageTemplate { title, content, path };
+        Html(template.render().unwrap())
+    }
+}
+
+async fn contact(headers: HeaderMap) -> Html<String> {
+    let is_htmx = headers.contains_key("hx-request");
+    let title = "Contact".to_string();
+    let content = "Get in touch with us".to_string();
+    let path = "/contact".to_string();
+
+    if is_htmx {
+        let template = ContentTemplate { title, content };
+        Html(template.render().unwrap())
+    } else {
+        let template = PageTemplate { title, content, path };
+        Html(template.render().unwrap())
+    }
 }

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}Home{% endblock %}
+
+{% block content %}
+<div class="space-y-6">
+    <h1 class="text-4xl font-bold">Welcome to OpenAgents</h1>
+    
+    <div class="space-y-4">
+        <p class="text-lg">
+            OpenAgents is an open-source platform for building and deploying AI agents.
+        </p>
+        
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="p-6 border border-white/90 hover:bg-zinc-900 transition-colors">
+                <h2 class="text-xl font-bold mb-2">Mobile App</h2>
+                <p>Access your AI agents on the go with our upcoming mobile app.</p>
+                <a href="/mobile-app" class="text-sm text-white/80 hover:text-white mt-2 inline-block">Learn more →</a>
+            </div>
+            
+            <div class="p-6 border border-white/90 hover:bg-zinc-900 transition-colors">
+                <h2 class="text-xl font-bold mb-2">Enterprise Solutions</h2>
+                <p>Custom AI solutions for your business needs.</p>
+                <a href="/services" class="text-sm text-white/80 hover:text-white mt-2 inline-block">Learn more →</a>
+            </div>
+        </div>
+        
+        <div class="mt-8">
+            <h2 class="text-2xl font-bold mb-4">Latest Content</h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <a href="/video-series" class="p-4 border border-white/90 hover:bg-zinc-900 transition-colors">
+                    <h3 class="font-bold mb-2">Video Series</h3>
+                    <p class="text-sm text-white/80">Watch our latest tutorials and demos</p>
+                </a>
+                
+                <a href="/company" class="p-4 border border-white/90 hover:bg-zinc-900 transition-colors">
+                    <h3 class="font-bold mb-2">About Us</h3>
+                    <p class="text-sm text-white/80">Learn about our mission and team</p>
+                </a>
+                
+                <a href="/contact" class="p-4 border border-white/90 hover:bg-zinc-900 transition-colors">
+                    <h3 class="font-bold mb-2">Get in Touch</h3>
+                    <p class="text-sm text-white/80">Have questions? Contact us</p>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds a separate template for the home page, following the Rust/Axum/Askama tutorial pattern. Changes include:

1. Created new `templates/pages/home.html` with a rich home page layout
2. Updated `main.rs` to use the new template
3. Added `HomeTemplate` struct for the home page

The home page now has:
- Hero section with welcome message
- Feature cards for Mobile App and Enterprise Solutions
- Latest content grid with links to other sections

This is the first step in moving to separate templates per page, making the content more maintainable and specific to each route.