### PR TITLE
Update blog macro date formatting

### DIFF
--- a/templates/macros/blog.html
+++ b/templates/macros/blog.html
@@ -1,8 +1,8 @@
 {% macro blog_post(date, title, content) %}
 <div class="border-b pb-4 mb-4">
-  <div class="flex items-center justify-between mb-2">
+  <div class="flex items-center gap-4 mb-2">
     <h3 class="text-base font-semibold">{{title}}</h3>
-    <span class="text-white/50 text-sm">{{date}}</span>
+    <p class="text-white/50 text-sm">{{date}}</p>
   </div>
   <p class="text-sm">{{content}}</p>
 </div>


### PR DESCRIPTION
Updated the blog macro to match the video macro's date formatting style:
- Changed date from right-aligned to inline with title
- Updated HTML structure to match video macro
- Replaced span with p tag for consistency
- Added gap-4 spacing between title and date