### PR TITLE
Add health check endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,12 @@ use axum::{
     response::{Html, IntoResponse, Response},
     routing::get,
     Router,
+    Json,
 };
 use std::path::PathBuf;
 use tower_http::services::ServeDir;
 use tracing::info;
+use serde_json::json;
 
 #[tokio::main]
 async fn main() {
@@ -28,6 +30,7 @@ async fn main() {
         .route("/services", get(business))
         .route("/company", get(company))
         .route("/coming-soon", get(coming_soon))
+        .route("/health", get(health_check))
         .nest_service("/assets", ServeDir::new(&assets_path))
         .fallback_service(ServeDir::new(assets_path));
 
@@ -44,6 +47,10 @@ async fn main() {
     info!("✨ Server ready:");
     info!("  🌎 http://{}", listener.local_addr().unwrap());
     axum::serve(listener, app).await.unwrap();
+}
+
+async fn health_check() -> Json<serde_json::Value> {
+    Json(json!({ "status": "healthy" }))
 }
 
 #[derive(Template)]


### PR DESCRIPTION
This PR adds a health check endpoint to fix the Digital Ocean health check failures.

Changes:
- Added `/health` endpoint that returns `{"status": "healthy"}`
- Endpoint matches the test in tests/health_check.rs
- Uses axum's Json response type for proper content-type headers

The health check endpoint will now respond with a 200 status code and the expected JSON response, which should satisfy Digital Ocean's health check requirements.