### PR TITLE
Fix WebSocket module imports

### DIFF
--- a/src/server/admin/routes.rs
+++ b/src/server/admin/routes.rs
@@ -1,7 +1,7 @@
 use crate::nostr::event::Event;
 use crate::server::services::{
     solver::SolverService,
-    solver_ws::{ws_handler, SolverWsState},
+    solver::ws::{ws_handler, SolverWsState},
 };
 use crate::{configuration, database};
 use axum::{

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,7 +5,7 @@ pub mod services;
 use axum::{routing::get, Router};
 use services::{
     solver::SolverService,
-    solver_ws::{ws_handler, SolverWsState},
+    solver::ws::{ws_handler, SolverWsState},
 };
 use std::sync::Arc;
 

--- a/src/server/services/solver/ws/transport.rs
+++ b/src/server/services/solver/ws/transport.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use tracing::{error, info};
 
 use crate::server::services::solver::SolverService;
-use super::types::{SolverStage, SolverUpdate};
+use super::types::SolverUpdate;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(60);


### PR DESCRIPTION
This PR fixes the WebSocket module imports after the module reorganization:

1. Updated imports in src/server/admin/routes.rs to use the new path:
```rust
use crate::server::services::solver::ws::{ws_handler, SolverWsState};
```

2. Updated imports in src/server/mod.rs to use the new path:
```rust
use services::solver::ws::{ws_handler, SolverWsState};
```

3. Removed unused SolverStage import in src/server/services/solver/ws/transport.rs

These changes fix the compilation errors:
```
error[E0432]: unresolved import `crate::server::services::solver_ws`
error[E0432]: unresolved import `services::solver_ws`
warning: unused import: `SolverStage`
```