### PR TITLE
Fix mockall dependency issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tokio-stream = "0.1.17"
 clap = { version = "4.4", features = ["derive"] }
 termcolor = "1.4"
 async-trait = "0.1"
+mockall = { version = "0.12.0", features = ["async"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full", "macros", "rt-multi-thread"] }
@@ -62,4 +63,3 @@ serde_json = "1.0"
 lazy_static = "1.4"
 wiremock = "0.6.2"
 axum-test = "17.1"
-mockall = { version = "0.12.0", features = ["async"] }


### PR DESCRIPTION
Fixes #584

The mockall dependency was in [dev-dependencies] but is being used in the main code. This PR moves it to the main dependencies section.

Changes:
- Moved mockall dependency from [dev-dependencies] to [dependencies]
- Kept the same version and features (0.12.0 with async feature)

This should resolve the dependency resolution error:
```
error: failed to select a version for `mockall`.
    ... required by package `openagents v0.1.0 (/Users/christopherdavid/code/openagents)`
versions that meet the requirements `^0.12.0` (locked to 0.12.1) are: 0.12.1

the package `openagents` depends on `mockall`, with features: `async` but `mockall` does not have these features.
```