### PR TITLE
Fix function calling message sequence

### DIFF
--- a/src/bin/deepseek-cli.rs
+++ b/src/bin/deepseek-cli.rs
@@ -228,14 +228,13 @@ async fn main() -> Result<()> {
                         // Create a new sequence of messages - include all messages
                         let messages = vec![
                             user_message.clone(),
-                            ChatMessage::from(assistant_message.clone()),
-                            weather_message.clone(),
+                            ChatMessage::from(assistant_message), // Add the assistant message first
                         ];
 
                         let result = service
                             .chat_with_tool_response(
                                 messages,
-                                weather_message, // This will be properly added as the tool response
+                                weather_message, // This is the tool response
                                 vec![get_weather_tool.clone()],
                                 false,
                             )


### PR DESCRIPTION
This PR fixes the function calling implementation to properly handle the message sequence according to the DeepSeek API requirements.

Changes:
1. Properly sequence messages in the chat_with_tool_response call
2. Remove duplicate weather_message from messages vector
3. Pass weather_message separately as tool response

The error "Messages with role 'tool' must be a response to a preceding message with 'tool_calls'" was occurring because we weren't properly maintaining the required message sequence. This fix ensures that:

1. User message is added first
2. Assistant message with tool_calls is added second
3. Tool response is passed separately with matching tool_call_id

This matches the sequence shown in the DeepSeek function calling documentation.