### PR TITLE
Add GitHub issue tool to all DeepSeek chat messages

### DIFF
--- a/src/server/ws/handlers/chat.rs
+++ b/src/server/ws/handlers/chat.rs
@@ -1,5 +1,6 @@
 use super::MessageHandler;
 use crate::server::services::DeepSeekService;
+use crate::server::services::github_issue::GitHubService;
 use crate::server::ws::{transport::WebSocketState, types::ChatMessage};
 use async_trait::async_trait;
 use serde_json::json;
@@ -10,13 +11,19 @@ use tracing::{error, info};
 pub struct ChatHandler {
     ws_state: Arc<WebSocketState>,
     deepseek_service: Arc<DeepSeekService>,
+    github_service: Arc<GitHubService>,
 }
 
 impl ChatHandler {
-    pub fn new(ws_state: Arc<WebSocketState>, deepseek_service: Arc<DeepSeekService>) -> Self {
+    pub fn new(
+        ws_state: Arc<WebSocketState>,
+        deepseek_service: Arc<DeepSeekService>,
+        github_service: Arc<GitHubService>,
+    ) -> Self {
         Self {
             ws_state,
             deepseek_service,
+            github_service,
         }
     }
 
@@ -27,8 +34,29 @@ impl ChatHandler {
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         info!("Processing message: {}", content);
 
-        // Get streaming response from DeepSeek
-        let mut stream = self.deepseek_service.chat_stream(content, true).await;
+        // Create GitHub issue tool
+        let get_issue_tool = DeepSeekService::create_tool(
+            "get_github_issue".to_string(),
+            Some("Get a GitHub issue by number".to_string()),
+            json!({
+                "type": "object",
+                "properties": {
+                    "owner": {
+                        "type": "string",
+                        "description": "The owner of the repository"
+                    },
+                    "repo": {
+                        "type": "string",
+                        "description": "The name of the repository"
+                    },
+                    "issue_number": {
+                        "type": "integer",
+                        "description": "The issue number"
+                    }
+                },
+                "required": ["owner", "repo", "issue_number"]
+            }),
+        );
 
         // Send "typing" indicator
         let typing_json = json!({
@@ -41,50 +69,121 @@ impl ChatHandler {
             .send_to(conn_id, &typing_json.to_string())
             .await?;
 
-        // Accumulate the full response while sending stream updates
-        let mut full_response = String::new();
-        while let Some(update) = stream.recv().await {
-            match update {
-                crate::server::services::deepseek::StreamUpdate::Content(content) => {
-                    full_response.push_str(&content);
+        // Get initial response with potential tool calls
+        let (initial_content, reasoning, tool_calls) = self
+            .deepseek_service
+            .chat_with_tools(content.clone(), vec![get_issue_tool.clone()], None, true)
+            .await?;
 
-                    // Send partial response
-                    let response_json = json!({
+        // Send reasoning if available
+        if let Some(reasoning) = reasoning {
+            let reasoning_json = json!({
+                "type": "chat",
+                "content": reasoning,
+                "sender": "ai",
+                "status": "thinking"
+            });
+            self.ws_state
+                .send_to(conn_id, &reasoning_json.to_string())
+                .await?;
+        }
+
+        // Send initial content
+        let response_json = json!({
+            "type": "chat",
+            "content": initial_content,
+            "sender": "ai",
+            "status": "streaming"
+        });
+        self.ws_state
+            .send_to(conn_id, &response_json.to_string())
+            .await?;
+
+        // Handle tool calls if present
+        if let Some(tool_calls) = tool_calls {
+            for tool_call in tool_calls {
+                if tool_call.function.name == "get_github_issue" {
+                    // Parse tool call arguments
+                    let args: serde_json::Value = serde_json::from_str(&tool_call.function.arguments)?;
+                    let owner = args["owner"].as_str().unwrap_or("OpenAgentsInc");
+                    let repo = args["repo"].as_str().unwrap_or("openagents");
+                    let issue_number = args["issue_number"].as_i64().unwrap_or(0) as i32;
+
+                    // Send tool call status
+                    let tool_call_json = json!({
                         "type": "chat",
-                        "content": &content,
+                        "content": format!("Fetching GitHub issue #{} from {}/{}", issue_number, owner, repo),
                         "sender": "ai",
-                        "status": "streaming"
+                        "status": "tool_calls"
                     });
                     self.ws_state
-                        .send_to(conn_id, &response_json.to_string())
+                        .send_to(conn_id, &tool_call_json.to_string())
                         .await?;
-                }
-                crate::server::services::deepseek::StreamUpdate::Reasoning(reasoning) => {
-                    // Send reasoning update
-                    let reasoning_json = json!({
-                        "type": "chat",
-                        "content": &reasoning,
-                        "sender": "ai",
-                        "status": "thinking"
-                    });
-                    self.ws_state
-                        .send_to(conn_id, &reasoning_json.to_string())
+
+                    // Fetch the issue
+                    let issue = self.github_service.get_issue(owner, repo, issue_number).await?;
+
+                    // Create messages for tool response
+                    let user_message = crate::server::services::deepseek::ChatMessage {
+                        role: "user".to_string(),
+                        content: content.clone(),
+                        tool_call_id: None,
+                        tool_calls: None,
+                    };
+
+                    let assistant_message = crate::server::services::deepseek::AssistantMessage {
+                        role: "assistant".to_string(),
+                        content: format!("Let me fetch GitHub issue #{} for you.", issue_number),
+                        tool_call_id: None,
+                        tool_calls: Some(vec![tool_call.clone()]),
+                    };
+
+                    let issue_message = crate::server::services::deepseek::ChatMessage {
+                        role: "tool".to_string(),
+                        content: serde_json::to_string(&issue)?,
+                        tool_call_id: Some(tool_call.id),
+                        tool_calls: None,
+                    };
+
+                    // Get final response with tool results
+                    let messages = vec![
+                        user_message,
+                        crate::server::services::deepseek::ChatMessage::from(assistant_message),
+                    ];
+
+                    let (final_content, _, _) = self
+                        .deepseek_service
+                        .chat_with_tool_response(
+                            messages,
+                            issue_message,
+                            vec![get_issue_tool.clone()],
+                            true,
+                        )
                         .await?;
-                }
-                crate::server::services::deepseek::StreamUpdate::Done => {
-                    // Send final complete message
-                    let response_json = json!({
+
+                    // Send final response
+                    let final_json = json!({
                         "type": "chat",
-                        "content": full_response,
+                        "content": final_content,
                         "sender": "ai",
                         "status": "complete"
                     });
                     self.ws_state
-                        .send_to(conn_id, &response_json.to_string())
+                        .send_to(conn_id, &final_json.to_string())
                         .await?;
-                    break;
                 }
             }
+        } else {
+            // If no tool calls, send complete status
+            let complete_json = json!({
+                "type": "chat",
+                "content": initial_content,
+                "sender": "ai",
+                "status": "complete"
+            });
+            self.ws_state
+                .send_to(conn_id, &complete_json.to_string())
+                .await?;
         }
 
         Ok(())

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -5,7 +5,7 @@ pub mod handlers;
 pub mod transport;
 pub mod types;
 
-use crate::server::services::DeepSeekService;
+use crate::server::services::{DeepSeekService, github_issue::GitHubService};
 use transport::WebSocketState;
 
 pub async fn ws_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
@@ -17,8 +17,12 @@ async fn handle_socket(socket: axum::extract::ws::WebSocket) {
     let deepseek_api_key = std::env::var("DEEPSEEK_API_KEY").expect("DEEPSEEK_API_KEY must be set");
     let deepseek_service = Arc::new(DeepSeekService::new(deepseek_api_key));
 
-    // Create WebSocketState with DeepSeek service
-    let ws_state = WebSocketState::new(deepseek_service);
+    // Initialize GitHub service
+    let github_token = std::env::var("GITHUB_TOKEN").ok();
+    let github_service = Arc::new(GitHubService::new(github_token));
+
+    // Create WebSocketState with both services
+    let ws_state = WebSocketState::new(deepseek_service, github_service);
 
     // Create handlers using the state
     let (chat_handler, solver_handler) = WebSocketState::create_handlers(ws_state.clone());

--- a/src/server/ws/transport.rs
+++ b/src/server/ws/transport.rs
@@ -9,18 +9,20 @@ use uuid::Uuid;
 
 use super::handlers::{chat::ChatHandler, solver::SolverHandler, MessageHandler};
 use super::types::ChatMessage;
-use crate::server::services::DeepSeekService;
+use crate::server::services::{DeepSeekService, github_issue::GitHubService};
 
 pub struct WebSocketState {
     connections: Arc<RwLock<HashMap<String, mpsc::UnboundedSender<Message>>>>,
     deepseek_service: Arc<DeepSeekService>,
+    github_service: Arc<GitHubService>,
 }
 
 impl WebSocketState {
-    pub fn new(deepseek_service: Arc<DeepSeekService>) -> Arc<Self> {
+    pub fn new(deepseek_service: Arc<DeepSeekService>, github_service: Arc<GitHubService>) -> Arc<Self> {
         Arc::new(Self {
             connections: Arc::new(RwLock::new(HashMap::new())),
             deepseek_service,
+            github_service,
         })
     }
 
@@ -30,6 +32,7 @@ impl WebSocketState {
         let chat_handler = Arc::new(ChatHandler::new(
             ws_state.clone(),
             ws_state.deepseek_service.clone(),
+            ws_state.github_service.clone(),
         ));
         let solver_handler = Arc::new(SolverHandler::new());
         (chat_handler, solver_handler)


### PR DESCRIPTION
This PR adds the GitHub issue tool to all DeepSeek chat messages by:

1. Modifying the ChatHandler to use chat_with_tools instead of chat_stream
2. Adding GitHub service to WebSocketState and passing it through to ChatHandler
3. Updating the handle_socket function to initialize the GitHub service

This allows DeepSeek to access GitHub issues in any chat conversation, not just through the CLI tool.