### PR TITLE
Consolidate test database setup function

### DIFF
--- a/tests/oidc_client.rs
+++ b/tests/oidc_client.rs
@@ -16,20 +16,7 @@ use openagents::server::{
     handlers::{callback, login, logout, AppState},
     services::OIDCConfig,
 };
-
-async fn setup_test_db() -> PgPool {
-    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
-        .await
-        .unwrap();
-
-    // Clean up any existing test data
-    sqlx::query!("DELETE FROM users WHERE scramble_id LIKE 'test_%'")
-        .execute(&pool)
-        .await
-        .unwrap();
-
-    pool
-}
+use crate::common::setup_test_db;
 
 fn create_test_token(sub: &str) -> String {
     // Create a simple JWT token for testing

--- a/tests/oidc_signup.rs
+++ b/tests/oidc_signup.rs
@@ -9,34 +9,7 @@ use tracing::{debug, info, error};
 use uuid::Uuid;
 
 use openagents::server::services::auth::{OIDCService, OIDCConfig};
-
-async fn setup_test_db() -> PgPool {
-    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
-        .await
-        .unwrap();
-
-    // Clean up any existing test data with better error handling
-    info!("Cleaning up test database");
-    match sqlx::query!("DELETE FROM users").execute(&pool).await {
-        Ok(_) => info!("Successfully cleaned up test database"),
-        Err(e) => {
-            error!("Failed to clean up test database: {}", e);
-            panic!("Database cleanup failed: {}", e);
-        }
-    }
-
-    // Verify the cleanup worked
-    let count = sqlx::query!("SELECT COUNT(*) as count FROM users")
-        .fetch_one(&pool)
-        .await
-        .unwrap()
-        .count
-        .unwrap_or(0);
-    
-    assert_eq!(count, 0, "Database should be empty after cleanup");
-
-    pool
-}
+use crate::common::setup_test_db;
 
 // Helper function to create test service with unique client ID
 async fn create_test_service(base_url: String) -> OIDCService {


### PR DESCRIPTION
This PR consolidates the test database setup function by:

1. Removing duplicate implementations of `setup_test_db()` from oidc_signup.rs and oidc_client.rs
2. Using the common implementation from tests/common/mod.rs in both test files

This change:
- Removes the "function is never used" warning
- Ensures consistent database setup across tests
- Follows DRY principles by using a single implementation
- Makes test maintenance easier since database setup logic is in one place

Changes:
- Added `use crate::common::setup_test_db;` to both test files
- Removed local `setup_test_db()` implementations
- Now using the common implementation from tests/common/mod.rs