### PR TITLE
fix: resolve runtime conflicts in solver tests

### DIFF
--- a/src/solver/solution.rs
+++ b/src/solver/solution.rs
@@ -112,42 +112,46 @@ mod tests {
     use tempfile::tempdir;
     use mockito::Server;
     use serde_json::json;
+    use tokio::runtime::Runtime;
 
-    #[tokio::test]
-    async fn test_handle_solution() -> Result<()> {
-        let temp_dir = tempdir()?;
-        let test_file = temp_dir.path().join("test.rs");
-        fs::write(&test_file, "// Original content")?;
+    #[test]
+    fn test_handle_solution() -> Result<()> {
+        let rt = Runtime::new()?;
+        rt.block_on(async {
+            let temp_dir = tempdir()?;
+            let test_file = temp_dir.path().join("test.rs");
+            fs::write(&test_file, "// Original content")?;
 
-        let mut server = Server::new();
-        let mock_response = json!({
-            "choices": [{
-                "message": {
-                    "content": "feat: add multiply function"
-                }
-            }]
-        });
+            let mut server = Server::new();
+            let mock_response = json!({
+                "choices": [{
+                    "message": {
+                        "content": "feat: add multiply function"
+                    }
+                }]
+            });
 
-        let mock = server.mock("POST", "/v1/chat/completions")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(mock_response.to_string())
-            .create();
+            let mock = server.mock("POST", "/v1/chat/completions")
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body(mock_response.to_string())
+                .create();
 
-        std::env::set_var("DEEPSEEK_API_URL", &server.url());
+            std::env::set_var("DEEPSEEK_API_URL", &server.url());
 
-        let result = handle_solution(
-            123,
-            "Add multiply function",
-            "Add a function that multiplies two numbers",
-            "Implementation plan",
-            "Repository map",
-            "test_url",
-        )
-        .await;
+            let result = handle_solution(
+                123,
+                "Add multiply function",
+                "Add a function that multiplies two numbers",
+                "Implementation plan",
+                "Repository map",
+                "test_url",
+            )
+            .await;
 
-        mock.assert();
-        assert!(result.is_ok());
-        Ok(())
+            mock.assert();
+            assert!(result.is_ok());
+            Ok(())
+        })
     }
 }


### PR DESCRIPTION
This PR fixes the runtime conflicts in the solver tests by properly handling async code in test functions. The main changes are:

1. In `src/solver/planning.rs`:
- Changed `test_validate_llm_response` to use `Runtime::new()` and `block_on`
- Properly handles async code in a synchronous test context

2. In `src/solver/github.rs`:
- Changed `test_generate_pr_title` to use `Runtime::new()` and `block_on`
- Maintains existing test functionality while fixing runtime issues

3. In `src/solver/solution.rs`:
- Changed `test_handle_solution` to use `Runtime::new()` and `block_on`
- Properly handles async code in test context

The changes ensure that we don't try to start a runtime from within another runtime, which was causing the test failures. Each test now properly creates its own runtime instance when needed.

Fixes #648