### PR TITLE
Add DeepSeek pre-analysis step to solver

### DIFF
--- a/docs/solve-runs/20250202-1640.md
+++ b/docs/solve-runs/20250202-1640.md
@@ -1,0 +1,658 @@
+➜ openagents git:(solver/deepseek-pre-analysis-659) cargo run --bin solver
+Compiling openagents v0.1.0 (/Users/christopherdavid/code/openagents)
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.06s
+Running `target/debug/solver`
+2025-02-02T22:34:37.786399Z INFO solver: Starting solver...
+2025-02-02T22:34:37.786891Z INFO solver: Fetching issue #651
+2025-02-02T22:34:37.790637Z INFO openagents::server::services::deepseek::service: Using DeepSeek API URL: https://api.deepseek.com/v1
+2025-02-02T22:34:37.790667Z INFO solver: Initialized services
+2025-02-02T22:34:37.790676Z INFO solver: Starting solver loop...
+2025-02-02T22:34:37.790693Z INFO solver::solver_impl::context: Collecting context...
+2025-02-02T22:34:37.790699Z INFO solver::solver_impl::context: Fetching issue #651
+2025-02-02T22:34:38.292712Z INFO solver::solver_impl::context: Generating repository map...
+2025-02-02T22:34:38.350883Z INFO solver: Context collected
+2025-02-02T22:34:38.350933Z INFO solver::solver_impl::files: Starting file identification process...
+2025-02-02T22:34:38.350943Z INFO solver::solver_impl::pre_analysis: Starting DeepSeek pre-analysis...
+
+Thinking process:
+
+Okay, let me try to work through this step by step. The task is to figure out which files need to be modified based on the analysis provided for implementing a stateful solver loop with continuous object updates. The user has given a list of possible file paths that can be considered.
+
+First, I need to understand the problem. The main goal is to transition the solver from a one-shot approach to a stateful loop that maintains a JSON object throughout the process. The key components mentioned are the SolverState, FileState, Change, and SolverStatus types. These are already created in src/solver/state.rs according to the comments. But there are next steps to integrate this state into the main solver loop.
+
+Looking at the proposed implementation steps:
+
+1. Create new types in src/solver/types.rs: Wait, but the comments say that the initial implementation was done in src/solver/state.rs. The user might have moved the types there. However, the analysis mentions adding types to src/solver/types.rs. Maybe there's a discrepancy here. But according to the comments, the core types are in state.rs now, so perhaps types.rs was modified or maybe some other structs are there.
+
+Wait, the comments mention that the initial implementation added types to state.rs. So maybe the original plan to put them in types.rs was changed, and they're actually in state.rs now. But then the next steps involve modifying planning.rs, solution.rs, etc.
+
+The main areas to modify would be the solver loop, which is in src/bin/solver.rs. Also, the planning.rs and solution.rs in the solver module are involved in generating plans and handling solutions, which would need to interact with the state.
+
+Looking at the files in the allowed list, I need to check which ones are part of the solver's logic. The solver's main binary is src/bin/solver.rs. The state management is in src/solver/state.rs. The planning logic in src/solver/planning.rs needs to handle generating the initial state and processing updates. The solution handling in src/solver/solution.rs would use the state to track changes.
+
+Additionally, the solver loop tests are in tests/solver_loop.rs, which would need updates for testing the state transitions and loop behavior.
+
+The comments also mention that the apply_changes function was added in src/solver/changes/apply.rs. So if there are changes related to applying the state's changes, that file might be involved. But according to the problem description, the main focus is on the stateful loop, not the application of changes, unless integrating that into the loop.
+
+Now, the current analysis mentions that the solver now has state management in src/bin/solver.rs, split into functions for each phase. Also, tests are in tests/solver_loop.rs.
+
+So, the key files to modify would be:
+
+- src/bin/solver.rs: This is the main entry point for the solver, so integrating the state management loop here is essential. The solver loop's phases (collect_context, identify_files, generate_changes, apply_changes) need to pass the state through each step. The comments mention that the solver was enhanced here with state transitions and logging.
+
+- src/solver/planning.rs: This file is responsible for generating the plan, which would now need to generate the initial state and handle updates. The planning would involve interacting with the LLM to get updated states.
+
+- src/solver/solution.rs: This handles the solution, so it would need to use the state to track changes and apply them. The analysis mentions updating this file to use the state object.
+
+- src/solver/state.rs: Although the initial implementation is done, there might be additional helper methods or validations needed as the state management is integrated into other parts. For example, adding serialization/deserialization methods or validation functions.
+
+- tests/solver_loop.rs: The tests for the solver loop's state transitions and error handling are here, so they need to be updated to cover the new stateful behavior.
+
+- src/solver/context.rs: This might be involved in collecting context for the solver, which is part of the state's initial phase (collecting_context status). The context collection would feed into the state.
+
+- src/solver/changes/generation.rs: If generating changes based on the state, this file might need modifications to handle the state's files and changes.
+
+- src/solver/types.rs: If there are any remaining types related to the solver that aren't in state.rs, this might need adjustments. However, based on the comments, most types are in state.rs now.
+
+- src/solver/json.rs: Handling JSON serialization/deserialization of the state object, especially if there are custom serialization needs or fixes for common JSON issues when interacting with the LLM.
+
+- src/solver/config.rs: If configuration settings are needed for the state loop (e.g., max retries, timeouts), this file might require changes.
+
+Other potential files:
+
+- src/solver/github.rs: If creating pull requests is part of the state's final steps (CreatingPr status), this could be involved. However, the main state management is elsewhere.
+
+- src/bin/solver_impl/changes.rs: If this is where changes are applied, but according to the comments, apply_changes is in src/solver/changes/apply.rs. So maybe changes.rs in solver_impl is part of the implementation.
+
+Wait, the comment mentions that apply_changes was moved to src/solver/changes/apply.rs, so changes.rs in solver_impl might not be directly involved unless it's part of the higher-level logic.
+
+In the repository map provided, src/bin/solver_impl/changes.rs has functions generate_changes and apply_file_changes. But according to the comments, the apply_changes functionality is in src/solver/changes/apply.rs. So perhaps the bin/solver_impl/changes.rs is a higher-level module that calls into the solver's changes module. If the state is being passed through here, this file might need modification to handle the state object.
+
+But given that the main loop is in src/bin/solver.rs, perhaps the solver_impl files are part of the implementation details. However, the user's analysis mentions modifying src/bin/solver.rs to initialize state tracking and pass state through phases. So the main changes would be in the solver's binary entry point.
+
+To sum up, the most relevant files would be:
+
+1. src/bin/solver.rs: Directly involved in the solver loop, initializing and passing the state. Relevance 10.
+
+2. src/solver/planning.rs: Generates the initial state and processes LLM responses to update the state. Relevance 9.
+
+3. src/solver/solution.rs: Uses the state to track changes and apply them. Relevance 9.
+
+4. tests/solver_loop.rs: Tests the state transitions and loop behavior. Relevance 8.
+
+5. src/solver/state.rs: Even though initial implementation is done, integrating it into the loop might require adding methods or validations. Relevance 8.
+
+6. src/solver/context.rs: Collecting context for the state's initial phase. Relevance 7.
+
+7. src/solver/changes/apply.rs: Applying changes from the state. Relevance 7.
+
+8. src/solver/types.rs: If any types are still defined here related to the state. But since state.rs has the core types, maybe lower relevance. Relevance 6.
+
+9. src/solver/json.rs: Handling JSON for the state. Relevance 6.
+
+10. src/solver/config.rs: Configuration for state loop parameters. Relevance 5.
+
+Other possible files might include src/solver/changes/generation.rs if changes are generated based on the state, but I think the main integration is in the solver loop and planning/solution modules.Here's the analysis of files that need modification for the stateful solver loop implementation:
+
+### Most Relevant Files (Ranked by Relevance)
+
+1. **src/bin/solver.rs** (10/10)
+
+   - Directly implements the solver loop
+   - Needs state initialization and transition handling
+   - Requires integration with state persistence and recovery
+
+2. **src/solver/state.rs** (9/10)
+
+   - Core state management implementation
+   - May need additional validation methods
+   - Requires serialization/deserialization enhancements
+
+3. **src/solver/planning.rs** (9/10)
+
+   - Handles LLM interactions with state updates
+   - Needs prompt engineering for state-aware responses
+   - Requires state validation before/after LLM calls
+
+4. **tests/solver_loop.rs** (8/10)
+
+   - Requires new tests for state transitions
+   - Needs error recovery scenario testing
+   - Must verify state persistence between phases
+
+5. **src/solver/solution.rs** (8/10)
+
+   - Manages solution progression based on state
+   - Needs integration with state validation
+   - Requires changes to use state instead of direct LLM output
+
+6. **src/solver/changes/apply.rs** (7/10)
+
+   - Applies changes from state object
+   - Needs validation against current state
+   - Requires integration with state update tracking
+
+7. **src/solver/context.rs** (7/10)
+
+   - Context collection for state initialization
+   - Needs repomap integration with state files list
+   - Requires relevance scoring adjustments
+
+8. **src/solver/types.rs** (6/10)
+
+   - May need complementary types
+   - Requires integration with state types
+   - Potential serialization helpers
+
+9. **src/solver/config.rs** (6/10)
+
+   - Needs state persistence configuration
+   - Requires state transition timeouts
+   - May add state validation rules
+
+10. **src/solver/json.rs** (5/10)
+    - Requires enhanced JSON handling for state
+    - Needs state-specific error recovery
+    - May add state sanitization features
+
+### Key Implementation Surfaces
+
+1. **State Lifecycle Management** (bin/solver + state.rs)
+
+   - State initialization/transition/persistence
+   - Error recovery and validation
+
+2. **LLM Integration** (planning.rs)
+
+   - State-aware prompt engineering
+   - Response parsing into state updates
+
+3. **Execution Flow** (solution.rs + apply.rs)
+
+   - State-driven change application
+   - Status-based phase transitions
+
+4. **Testing Infrastructure** (solver_loop tests)
+   - State transition validation
+   - Error scenario simulations
+
+The implementation primarily revolves around maintaining and validating solver state across the execution pipeline, with particular focus on the main solver loop and its supporting state management infrastructure.
+DeepSeek analysis complete.
+
+2025-02-02T22:35:22.815713Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:35:42.877899Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created*at":"2025-02-02T22:35:42.899604137Z","message":{"role":"assistant","content":"{ \"files\": [\n {\n \"path\": \"src/bin/solver.rs\",\n \"reason\": \"Directly involved in the solver loop, initializing and passing the state.\",\n \"relevance_score\": 10\n },\n {\n \"path\": \"src/solver/planning.rs\",\n \"reason\": \"Generates the initial state and processes LLM responses to update the state.\",\n \"relevance_score\": 9\n },\n {\n \"path\": \"src/solver/solution.rs\",\n \"reason\": \"Uses the state to track changes and apply them.\",\n \"relevance_score\": 9\n },\n {\n \"path\": \"tests/solver_loop.rs\",\n \"reason\": \"Tests the state transitions and loop behavior.\",\n \"relevance_score\": 8\n },\n {\n \"path\": \"src/solver/state.rs\",\n \"reason\": \"Even though initial implementation is done, integrating it into the loop might require adding methods or validations.\",\n \"relevance_score\": 8\n },\n {\n \"path\": \"src/solver/context.rs\",\n \"reason\": \"Collecting context for the state's initial phase.\",\n \"relevance_score\": 7\n },\n {\n \"path\": \"src/solver/changes/apply.rs\",\n \"reason\": \"Applying changes from the state.\",\n \"relevance_score\": 7\n },\n {\n \"path\": \"src/solver/types.rs\",\n \"reason\": \"If any types are still defined here related to the state. But since state.rs has the core types, maybe lower relevance.\",\n \"relevance_score\": 6\n },\n {\n \"path\": \"src/solver/json.rs\",\n \"reason\": \"Handling JSON for the state.\",\n \"relevance_score\": 6\n },\n {\n \"path\": \"src/solver/config.rs\",\n \"reason\": \"Configuration for state loop parameters.\",\n \"relevance_score\": 5\n }\n] }"},"done_reason":"stop","done":true,"total_duration":19926223500,"load_duration":2059850869,"prompt_eval_count":2048,"prompt_eval_duration":1081000000,"eval_count":438,"eval_duration":16392000000}
+2025-02-02T22:35:42.879609Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:35:42.899604137Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 438,
+"eval_duration": 16392000000,
+"load_duration": 2059850869,
+"message": {
+"content": "{ \"files\": [\n {\n \"path\": \"src/bin/solver.rs\",\n \"reason\": \"Directly involved in the solver loop, initializing and passing the state.\",\n \"relevance_score\": 10\n },\n {\n \"path\": \"src/solver/planning.rs\",\n \"reason\": \"Generates the initial state and processes LLM responses to update the state.\",\n \"relevance_score\": 9\n },\n {\n \"path\": \"src/solver/solution.rs\",\n \"reason\": \"Uses the state to track changes and apply them.\",\n \"relevance_score\": 9\n },\n {\n \"path\": \"tests/solver_loop.rs\",\n \"reason\": \"Tests the state transitions and loop behavior.\",\n \"relevance_score\": 8\n },\n {\n \"path\": \"src/solver/state.rs\",\n \"reason\": \"Even though initial implementation is done, integrating it into the loop might require adding methods or validations.\",\n \"relevance_score\": 8\n },\n {\n \"path\": \"src/solver/context.rs\",\n \"reason\": \"Collecting context for the state's initial phase.\",\n \"relevance_score\": 7\n },\n {\n \"path\": \"src/solver/changes/apply.rs\",\n \"reason\": \"Applying changes from the state.\",\n \"relevance_score\": 7\n },\n {\n \"path\": \"src/solver/types.rs\",\n \"reason\": \"If any types are still defined here related to the state. But since state.rs has the core types, maybe lower relevance.\",\n \"relevance_score\": 6\n },\n {\n \"path\": \"src/solver/json.rs\",\n \"reason\": \"Handling JSON for the state.\",\n \"relevance_score\": 6\n },\n {\n \"path\": \"src/solver/config.rs\",\n \"reason\": \"Configuration for state loop parameters.\",\n \"relevance_score\": 5\n }\n] }",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1081000000,
+"total_duration": 19926223500
+}
+2025-02-02T22:35:42.879735Z INFO openagents::server::services::ollama::service: Extracted content: { "files": [
+{
+"path": "src/bin/solver.rs",
+"reason": "Directly involved in the solver loop, initializing and passing the state.",
+"relevance_score": 10
+},
+{
+"path": "src/solver/planning.rs",
+"reason": "Generates the initial state and processes LLM responses to update the state.",
+"relevance_score": 9
+},
+{
+"path": "src/solver/solution.rs",
+"reason": "Uses the state to track changes and apply them.",
+"relevance_score": 9
+},
+{
+"path": "tests/solver_loop.rs",
+"reason": "Tests the state transitions and loop behavior.",
+"relevance_score": 8
+},
+{
+"path": "src/solver/state.rs",
+"reason": "Even though initial implementation is done, integrating it into the loop might require adding methods or validations.",
+"relevance_score": 8
+},
+{
+"path": "src/solver/context.rs",
+"reason": "Collecting context for the state's initial phase.",
+"relevance_score": 7
+},
+{
+"path": "src/solver/changes/apply.rs",
+"reason": "Applying changes from the state.",
+"relevance_score": 7
+},
+{
+"path": "src/solver/types.rs",
+"reason": "If any types are still defined here related to the state. But since state.rs has the core types, maybe lower relevance.",
+"relevance_score": 6
+},
+{
+"path": "src/solver/json.rs",
+"reason": "Handling JSON for the state.",
+"relevance_score": 6
+},
+{
+"path": "src/solver/config.rs",
+"reason": "Configuration for state loop parameters.",
+"relevance_score": 5
+}
+] }
+2025-02-02T22:35:42.880141Z INFO solver: Files identified
+2025-02-02T22:35:42.880318Z INFO solver::solver_impl::changes: Generating code changes...
+2025-02-02T22:35:42.880376Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:35:42.880395Z INFO solver::solver_impl::changes: Relative path: src/bin/solver.rs
+2025-02-02T22:35:42.880415Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/bin/solver.rs
+2025-02-02T22:35:42.880958Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:36:31.925065Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:36:31.973237583Z","message":{"role":"assistant","content":"{ \"changes\": [\n {\n \"analysis\": \"The function `fetch_issue` is missing error handling for network failures.\",\n \"replace\": \"`rust\\nfn fetch_issue(owner: \u0026str, repo: \u0026str, issue_number: u32) -\u003e Result\u003cIssue, Box\u003cdyn std::error::Error\u003e\u003e {\\n    let url = format!(\\\"https://api.github.com/repos/{}/{}/issues/{}\\\", owner, repo, issue_number);\\n    let response = reqwest::blocking::get(\u0026url)?;\\n    if !response.status().is_success() {\\n        return Err(format!(\\\"Failed to fetch issue: {}\\\", response.status()).into());\\n    }\\n    let body = response.text()?;\\n    Ok(serde_json::from_str(\u0026body)?)\\n}\\n`\",\n \"search\": \"`rust\\nfn fetch_issue(owner: \u0026str, repo: \u0026str, issue_number: u32) -\u003e Issue {\\n    let url = format!(\\\"https://api.github.com/repos/{}/{}/issues/{}\\\", owner, repo, issue_number);\\n    let response = reqwest::blocking::get(\u0026url).unwrap();\\n    let body = response.text().unwrap();\\n    serde_json::from_str(\u0026body).unwrap()\\n}\\n`\"\n },\n {\n \"analysis\": \"The function `collect_context` is missing error handling for invalid repository names.\",\n \"replace\": \"`rust\\nasync fn collect_context(state: \u0026mut SolverState, github: \u0026GitHubService, owner: \u0026str, name: \u0026str, issue_num: u32) -\u003e Result\u003c(PathBuf, Vec\u003cPathBuf\u003e), Box\u003cdyn std::error::Error\u003e\u003e {\\n    let repo_dir = Path::new(\\\"path/to/repo\\\");\\n    if !repo_dir.exists() || !repo_dir.is_dir() {\\n        return Err(format!(\\\"Invalid repository path: {}\\\", repo_dir.display()).into());\\n    }\\n    // Collect valid paths\\n    let mut valid_paths = Vec::new();\\n    for entry in std::fs::read_dir(repo_dir)? {\\n        let entry = entry?;\\n        if entry.path().is_file() \u0026\u0026 entry.file_name().to_str().map_or(false, |name| name.ends_with(\\\".rs\\\")) {\\n            valid_paths.push(entry.path());\\n        }\\n    }\\n    Ok((repo_dir.to_path_buf(), valid_paths))\\n}\\n`\",\n \"search\": \"`rust\\nasync fn collect_context(state: \u0026mut SolverState, github: \u0026GitHubService, owner: \u0026str, name: \u0026str, issue_num: u32) -\u003e (PathBuf, Vec\u003cPathBuf\u003e) {\\n    let repo_dir = Path::new(\\\"path/to/repo\\\");\\n    // Collect valid paths\\n    let mut valid_paths = Vec::new();\\n    for entry in std::fs::read_dir(repo_dir).unwrap() {\\n        let entry = entry.unwrap();\\n        if entry.path().is_file() \u0026\u0026 entry.file_name().to_str().map_or(false, |name| name.ends_with(\\\".rs\\\")) {\\n            valid_paths.push(entry.path());\\n        }\\n    }\\n    (repo_dir.to_path_buf(), valid_paths)\\n}\\n`\"\n },\n {\n \"analysis\": \"The function `identify_files` is missing error handling for invalid file paths.\",\n \"replace\": \"`rust\\nasync fn identify_files(state: \u0026mut SolverState, mistral: \u0026OllamaService, deepseek: \u0026DeepSeekService, valid_paths: \u0026[PathBuf]) -\u003e Result\u003c(), Box\u003cdyn std::error::Error\u003e\u003e {\\n    for path in valid_paths {\\n        if !path.exists() || !path.is_file() {\\n            return Err(format!(\\\"Invalid file path: {}\\\", path.display()).into());\\n        }\\n        // Identify files\\n        let content = std::fs::read_to_string(path)?;\\n        // Process with Mistral and DeepSeek\\n    }\\n    Ok(())\\n}\\n`\",\n \"search\": \"`rust\\nasync fn identify_files(state: \u0026mut SolverState, mistral: \u0026OllamaService, deepseek: \u0026DeepSeekService, valid_paths: \u0026[PathBuf]) {\\n    for path in valid_paths {\\n        let content = std::fs::read_to_string(path).unwrap();\\n        // Process with Mistral and DeepSeek\\n    }\\n}\\n`\"\n },\n {\n \"analysis\": \"The function `generate_changes` is missing error handling for invalid file contents.\",\n \"replace\": \"`rust\\nasync fn generate_changes(state: \u0026mut SolverState, mistral: \u0026OllamaService, deepseek: \u0026DeepSeekService) -\u003e Result\u003c(), Box\u003cdyn std::error::Error\u003e\u003e {\\n    // Generate changes based on Mistral and DeepSeek analysis\\n    for file in state.files.iter() {\\n        let content = std::fs::read_to_string(file.path())?;\\n        if content.is_empty() {\\n            return Err(format!(\\\"Empty file content: {}\\\", file.path().display()).into());\\n        }\\n        // Process and generate changes\\n    }\\n    Ok(())\\n}\\n`\",\n \"search\": \"`rust\\nasync fn generate_changes(state: \u0026mut SolverState, mistral: \u0026OllamaService, deepseek: \u0026DeepSeekService) {\\n    // Generate changes based on Mistral and DeepSeek analysis\\n    for file in state.files.iter() {\\n        let content = std::fs::read_to_string(file.path()).unwrap();\\n        // Process and generate changes\\n    }\\n}\\n`\"\n }\n] }"},"done_reason":"stop","done":true,"total_duration":49017521618,"load_duration":43060858,"prompt_eval_count":2048,"prompt_eval_duration":1026000000,"eval_count":1277,"eval_duration":47907000000}
+2025-02-02T22:36:31.925994Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:36:31.973237583Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 1277,
+"eval_duration": 47907000000,
+"load_duration": 43060858,
+"message": {
+"content": "{ \"changes\": [\n {\n \"analysis\": \"The function `fetch_issue` is missing error handling for network failures.\",\n \"replace\": \"`rust\\nfn fetch_issue(owner: &str, repo: &str, issue_number: u32) -> Result<Issue, Box<dyn std::error::Error>> {\\n    let url = format!(\\\"https://api.github.com/repos/{}/{}/issues/{}\\\", owner, repo, issue_number);\\n    let response = reqwest::blocking::get(&url)?;\\n    if !response.status().is_success() {\\n        return Err(format!(\\\"Failed to fetch issue: {}\\\", response.status()).into());\\n    }\\n    let body = response.text()?;\\n    Ok(serde_json::from_str(&body)?)\\n}\\n`\",\n \"search\": \"`rust\\nfn fetch_issue(owner: &str, repo: &str, issue_number: u32) -> Issue {\\n    let url = format!(\\\"https://api.github.com/repos/{}/{}/issues/{}\\\", owner, repo, issue_number);\\n    let response = reqwest::blocking::get(&url).unwrap();\\n    let body = response.text().unwrap();\\n    serde_json::from_str(&body).unwrap()\\n}\\n`\"\n },\n {\n \"analysis\": \"The function `collect_context` is missing error handling for invalid repository names.\",\n \"replace\": \"`rust\\nasync fn collect_context(state: &mut SolverState, github: &GitHubService, owner: &str, name: &str, issue_num: u32) -> Result<(PathBuf, Vec<PathBuf>), Box<dyn std::error::Error>> {\\n    let repo_dir = Path::new(\\\"path/to/repo\\\");\\n    if !repo_dir.exists() || !repo_dir.is_dir() {\\n        return Err(format!(\\\"Invalid repository path: {}\\\", repo_dir.display()).into());\\n    }\\n    // Collect valid paths\\n    let mut valid_paths = Vec::new();\\n    for entry in std::fs::read_dir(repo_dir)? {\\n        let entry = entry?;\\n        if entry.path().is_file() && entry.file_name().to_str().map_or(false, |name| name.ends_with(\\\".rs\\\")) {\\n            valid_paths.push(entry.path());\\n        }\\n    }\\n    Ok((repo_dir.to_path_buf(), valid_paths))\\n}\\n`\",\n \"search\": \"`rust\\nasync fn collect_context(state: &mut SolverState, github: &GitHubService, owner: &str, name: &str, issue_num: u32) -> (PathBuf, Vec<PathBuf>) {\\n    let repo_dir = Path::new(\\\"path/to/repo\\\");\\n    // Collect valid paths\\n    let mut valid_paths = Vec::new();\\n    for entry in std::fs::read_dir(repo_dir).unwrap() {\\n        let entry = entry.unwrap();\\n        if entry.path().is_file() && entry.file_name().to_str().map_or(false, |name| name.ends_with(\\\".rs\\\")) {\\n            valid_paths.push(entry.path());\\n        }\\n    }\\n    (repo_dir.to_path_buf(), valid_paths)\\n}\\n`\"\n },\n {\n \"analysis\": \"The function `identify_files` is missing error handling for invalid file paths.\",\n \"replace\": \"`rust\\nasync fn identify_files(state: &mut SolverState, mistral: &OllamaService, deepseek: &DeepSeekService, valid_paths: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {\\n    for path in valid_paths {\\n        if !path.exists() || !path.is_file() {\\n            return Err(format!(\\\"Invalid file path: {}\\\", path.display()).into());\\n        }\\n        // Identify files\\n        let content = std::fs::read_to_string(path)?;\\n        // Process with Mistral and DeepSeek\\n    }\\n    Ok(())\\n}\\n`\",\n \"search\": \"`rust\\nasync fn identify_files(state: &mut SolverState, mistral: &OllamaService, deepseek: &DeepSeekService, valid_paths: &[PathBuf]) {\\n    for path in valid_paths {\\n        let content = std::fs::read_to_string(path).unwrap();\\n        // Process with Mistral and DeepSeek\\n    }\\n}\\n`\"\n },\n {\n \"analysis\": \"The function `generate_changes` is missing error handling for invalid file contents.\",\n \"replace\": \"`rust\\nasync fn generate_changes(state: &mut SolverState, mistral: &OllamaService, deepseek: &DeepSeekService) -> Result<(), Box<dyn std::error::Error>> {\\n    // Generate changes based on Mistral and DeepSeek analysis\\n    for file in state.files.iter() {\\n        let content = std::fs::read_to_string(file.path())?;\\n        if content.is_empty() {\\n            return Err(format!(\\\"Empty file content: {}\\\", file.path().display()).into());\\n        }\\n        // Process and generate changes\\n    }\\n    Ok(())\\n}\\n`\",\n \"search\": \"`rust\\nasync fn generate_changes(state: &mut SolverState, mistral: &OllamaService, deepseek: &DeepSeekService) {\\n    // Generate changes based on Mistral and DeepSeek analysis\\n    for file in state.files.iter() {\\n        let content = std::fs::read_to_string(file.path()).unwrap();\\n        // Process and generate changes\\n    }\\n}\\n`\"\n }\n] }",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1026000000,
+"total_duration": 49017521618
+}
+2025-02-02T22:36:31.926182Z INFO openagents::server::services::ollama::service: Extracted content: { "changes": [
+{
+"analysis": "The function `fetch_issue` is missing error handling for network failures.",
+"replace": "`rust\nfn fetch_issue(owner: &str, repo: &str, issue_number: u32) -> Result<Issue, Box<dyn std::error::Error>> {\n    let url = format!(\"https://api.github.com/repos/{}/{}/issues/{}\", owner, repo, issue_number);\n    let response = reqwest::blocking::get(&url)?;\n    if !response.status().is_success() {\n        return Err(format!(\"Failed to fetch issue: {}\", response.status()).into());\n    }\n    let body = response.text()?;\n    Ok(serde_json::from_str(&body)?)\n}\n`",
+"search": "`rust\nfn fetch_issue(owner: &str, repo: &str, issue_number: u32) -> Issue {\n    let url = format!(\"https://api.github.com/repos/{}/{}/issues/{}\", owner, repo, issue_number);\n    let response = reqwest::blocking::get(&url).unwrap();\n    let body = response.text().unwrap();\n    serde_json::from_str(&body).unwrap()\n}\n`"
+},
+{
+"analysis": "The function `collect_context` is missing error handling for invalid repository names.",
+"replace": "`rust\nasync fn collect_context(state: &mut SolverState, github: &GitHubService, owner: &str, name: &str, issue_num: u32) -> Result<(PathBuf, Vec<PathBuf>), Box<dyn std::error::Error>> {\n    let repo_dir = Path::new(\"path/to/repo\");\n    if !repo_dir.exists() || !repo_dir.is_dir() {\n        return Err(format!(\"Invalid repository path: {}\", repo_dir.display()).into());\n    }\n    // Collect valid paths\n    let mut valid_paths = Vec::new();\n    for entry in std::fs::read_dir(repo_dir)? {\n        let entry = entry?;\n        if entry.path().is_file() && entry.file_name().to_str().map_or(false, |name| name.ends_with(\".rs\")) {\n            valid_paths.push(entry.path());\n        }\n    }\n    Ok((repo_dir.to_path_buf(), valid_paths))\n}\n`",
+"search": "`rust\nasync fn collect_context(state: &mut SolverState, github: &GitHubService, owner: &str, name: &str, issue_num: u32) -> (PathBuf, Vec<PathBuf>) {\n    let repo_dir = Path::new(\"path/to/repo\");\n    // Collect valid paths\n    let mut valid_paths = Vec::new();\n    for entry in std::fs::read_dir(repo_dir).unwrap() {\n        let entry = entry.unwrap();\n        if entry.path().is_file() && entry.file_name().to_str().map_or(false, |name| name.ends_with(\".rs\")) {\n            valid_paths.push(entry.path());\n        }\n    }\n    (repo_dir.to_path_buf(), valid_paths)\n}\n`"
+},
+{
+"analysis": "The function `identify_files` is missing error handling for invalid file paths.",
+"replace": "`rust\nasync fn identify_files(state: &mut SolverState, mistral: &OllamaService, deepseek: &DeepSeekService, valid_paths: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {\n    for path in valid_paths {\n        if !path.exists() || !path.is_file() {\n            return Err(format!(\"Invalid file path: {}\", path.display()).into());\n        }\n        // Identify files\n        let content = std::fs::read_to_string(path)?;\n        // Process with Mistral and DeepSeek\n    }\n    Ok(())\n}\n`",
+"search": "`rust\nasync fn identify_files(state: &mut SolverState, mistral: &OllamaService, deepseek: &DeepSeekService, valid_paths: &[PathBuf]) {\n    for path in valid_paths {\n        let content = std::fs::read_to_string(path).unwrap();\n        // Process with Mistral and DeepSeek\n    }\n}\n`"
+},
+{
+"analysis": "The function `generate_changes` is missing error handling for invalid file contents.",
+"replace": "`rust\nasync fn generate_changes(state: &mut SolverState, mistral: &OllamaService, deepseek: &DeepSeekService) -> Result<(), Box<dyn std::error::Error>> {\n    // Generate changes based on Mistral and DeepSeek analysis\n    for file in state.files.iter() {\n        let content = std::fs::read_to_string(file.path())?;\n        if content.is_empty() {\n            return Err(format!(\"Empty file content: {}\", file.path().display()).into());\n        }\n        // Process and generate changes\n    }\n    Ok(())\n}\n`",
+"search": "`rust\nasync fn generate_changes(state: &mut SolverState, mistral: &OllamaService, deepseek: &DeepSeekService) {\n    // Generate changes based on Mistral and DeepSeek analysis\n    for file in state.files.iter() {\n        let content = std::fs::read_to_string(file.path()).unwrap();\n        // Process and generate changes\n    }\n}\n`"
+}
+] }
+2025-02-02T22:36:31.926615Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:36:31.926637Z INFO solver::solver_impl::changes: Relative path: src/solver/planning.rs
+2025-02-02T22:36:31.926654Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/solver/planning.rs
+2025-02-02T22:36:31.927342Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:36:41.450954Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:36:41.438490015Z","message":{"role":"assistant","content":"{ \"changes\": [\n {\n \"analysis\": \"The provided Rust code is a comprehensive implementation for generating pull request plans using an LLM (Language Model). It includes methods for validating responses, generating prompts, and retrying with feedback if the initial response is invalid.\",\n \"replace\": \"async fn generate_pr_title(\u0026self, issue_number: i32, context: \u0026str) -\u003e Result\u003cString\u003e { let prompt = format!(\\\"Generate a descriptive pull request title that starts with feat:, fix:, etc.\\\"); let (response, *) = self.llm*service.chat(prompt, true).await?; Ok(response.trim().to_string()) }\"\n ,\n \"search\": \"async fn generate_pr_title(\u0026self) -\u003e Result\u003cString\u003e { let prompt = format!(\\\"Generate a descriptive pull request title that starts with feat:, fix:, etc.\\\"); let (response, *) = self.llm*service.chat(prompt, true).await?; Ok(response.trim().to_string()) }\"\n }\n]\n}"},"done_reason":"stop","done":true,"total_duration":9437204378,"load_duration":42125448,"prompt_eval_count":2048,"prompt_eval_duration":1028000000,"eval_count":219,"eval_duration":8333000000}
+2025-02-02T22:36:41.451606Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:36:41.438490015Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 219,
+"eval_duration": 8333000000,
+"load_duration": 42125448,
+"message": {
+"content": "{ \"changes\": [\n {\n \"analysis\": \"The provided Rust code is a comprehensive implementation for generating pull request plans using an LLM (Language Model). It includes methods for validating responses, generating prompts, and retrying with feedback if the initial response is invalid.\",\n \"replace\": \"async fn generate_pr_title(&self, issue_number: i32, context: &str) -> Result<String> { let prompt = format!(\\\"Generate a descriptive pull request title that starts with feat:, fix:, etc.\\\"); let (response, *) = self.llm*service.chat(prompt, true).await?; Ok(response.trim().to_string()) }\"\n ,\n \"search\": \"async fn generate_pr_title(&self) -> Result<String> { let prompt = format!(\\\"Generate a descriptive pull request title that starts with feat:, fix:, etc.\\\"); let (response, *) = self.llm*service.chat(prompt, true).await?; Ok(response.trim().to_string()) }\"\n }\n]\n}",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1028000000,
+"total_duration": 9437204378
+}
+2025-02-02T22:36:41.451739Z INFO openagents::server::services::ollama::service: Extracted content: { "changes": [
+{
+"analysis": "The provided Rust code is a comprehensive implementation for generating pull request plans using an LLM (Language Model). It includes methods for validating responses, generating prompts, and retrying with feedback if the initial response is invalid.",
+"replace": "async fn generate_pr_title(&self, issue_number: i32, context: &str) -> Result<String> { let prompt = format!(\"Generate a descriptive pull request title that starts with feat:, fix:, etc.\"); let (response, *) = self.llm*service.chat(prompt, true).await?; Ok(response.trim().to_string()) }"
+,
+"search": "async fn generate_pr_title(&self) -> Result<String> { let prompt = format!(\"Generate a descriptive pull request title that starts with feat:, fix:, etc.\"); let (response, *) = self.llm*service.chat(prompt, true).await?; Ok(response.trim().to_string()) }"
+}
+]
+}
+2025-02-02T22:36:41.452027Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:36:41.452162Z INFO solver::solver_impl::changes: Relative path: src/solver/solution.rs
+2025-02-02T22:36:41.452202Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/solver/solution.rs
+2025-02-02T22:36:41.453185Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:36:57.118781Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:36:57.140823925Z","message":{"role":"assistant","content":"{\n \"changes\": [\n {\n \"analysis\": \"Add implementation for solution handling\",\n \"replace\": \"use crate::solver::context::SolverContext;\\nuse anyhow::Result;\\n\\npub async fn handle_solution(\\n _issue_number: i32,\\n _title: \u0026str,\\n _body: \u0026str,\\n _plan: \u0026str,\\n _repo_map: \u0026str,\\n _ollama_url: \u0026str,\\n) -\u003e Result\u003c()\u003e {\\n // Create solver context\\n let _context = SolverContext::new().unwrap();\\n\\n // Implement solution handling\\n println!(\\\"Handling solution for issue #{} with title '{}' and body '{}'\\\", _issue_number, _title, _body);\\n println!(\\\"Plan: {}\\\", _plan);\\n println!(\\\"Repo Map: {}\\\", _repo_map);\\n println!(\\\"Ollama URL: {}\\\", _ollama_url);\\n\\n // TODO: Add actual solution handling logic here\\n Ok(())\\n}\"\n ,\n \"search\": \"use crate::solver::context::SolverContext;\\nuse anyhow::Result;\\n\\npub async fn handle_solution(\\n _issue_number: i32,\\n _title: \u0026str,\\n _body: \u0026str,\\n _plan: \u0026str,\\n _repo_map: \u0026str,\\n _ollama_url: \u0026str,\\n) -\u003e Result\u003c()\u003e {\\n // Create solver context\\n let _context = SolverContext::new().unwrap();\\n\\n // TODO: Implement solution handling\\n Ok(())\"\n }\n ]\n}"},"done_reason":"stop","done":true,"total_duration":15613771968,"load_duration":43809628,"prompt_eval_count":2048,"prompt_eval_duration":1024000000,"eval_count":386,"eval_duration":14516000000}
+2025-02-02T22:36:57.119280Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:36:57.140823925Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 386,
+"eval_duration": 14516000000,
+"load_duration": 43809628,
+"message": {
+"content": "{\n \"changes\": [\n {\n \"analysis\": \"Add implementation for solution handling\",\n \"replace\": \"use crate::solver::context::SolverContext;\\nuse anyhow::Result;\\n\\npub async fn handle_solution(\\n _issue_number: i32,\\n _title: &str,\\n _body: &str,\\n _plan: &str,\\n _repo_map: &str,\\n _ollama_url: &str,\\n) -> Result<()> {\\n // Create solver context\\n let _context = SolverContext::new().unwrap();\\n\\n // Implement solution handling\\n println!(\\\"Handling solution for issue #{} with title '{}' and body '{}'\\\", _issue_number, _title, _body);\\n println!(\\\"Plan: {}\\\", _plan);\\n println!(\\\"Repo Map: {}\\\", _repo_map);\\n println!(\\\"Ollama URL: {}\\\", _ollama_url);\\n\\n // TODO: Add actual solution handling logic here\\n Ok(())\\n}\"\n ,\n \"search\": \"use crate::solver::context::SolverContext;\\nuse anyhow::Result;\\n\\npub async fn handle_solution(\\n _issue_number: i32,\\n _title: &str,\\n _body: &str,\\n _plan: &str,\\n _repo_map: &str,\\n _ollama_url: &str,\\n) -> Result<()> {\\n // Create solver context\\n let _context = SolverContext::new().unwrap();\\n\\n // TODO: Implement solution handling\\n Ok(())\"\n }\n ]\n}",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1024000000,
+"total_duration": 15613771968
+}
+2025-02-02T22:36:57.119355Z INFO openagents::server::services::ollama::service: Extracted content: {
+"changes": [
+{
+"analysis": "Add implementation for solution handling",
+"replace": "use crate::solver::context::SolverContext;\nuse anyhow::Result;\n\npub async fn handle_solution(\n _issue_number: i32,\n _title: &str,\n _body: &str,\n _plan: &str,\n _repo_map: &str,\n _ollama_url: &str,\n) -> Result<()> {\n // Create solver context\n let _context = SolverContext::new().unwrap();\n\n // Implement solution handling\n println!(\"Handling solution for issue #{} with title '{}' and body '{}'\", _issue_number, _title, _body);\n println!(\"Plan: {}\", _plan);\n println!(\"Repo Map: {}\", _repo_map);\n println!(\"Ollama URL: {}\", _ollama_url);\n\n // TODO: Add actual solution handling logic here\n Ok(())\n}"
+,
+"search": "use crate::solver::context::SolverContext;\nuse anyhow::Result;\n\npub async fn handle_solution(\n _issue_number: i32,\n _title: &str,\n _body: &str,\n _plan: &str,\n _repo_map: &str,\n _ollama_url: &str,\n) -> Result<()> {\n // Create solver context\n let _context = SolverContext::new().unwrap();\n\n // TODO: Implement solution handling\n Ok(())"
+}
+]
+}
+2025-02-02T22:36:57.119586Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:36:57.119609Z INFO solver::solver_impl::changes: Relative path: tests/solver_loop.rs
+2025-02-02T22:36:57.119626Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/tests/solver_loop.rs
+2025-02-02T22:36:57.120648Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:37:03.682833Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:37:03.714591563Z","message":{"role":"assistant","content":"{ \"changes\": [\n {\n \"analysis\": \"Change 1\",\n \"replace\": \"fn main() {\\n println!(\\\"Hello, world!\\\");\\n}\",\n \"search\": \"fn main() {\\n println!(\\\"Old message\\\");\\n}\"\n },\n {\n \"analysis\": \"Change 2\",\n \"replace\": \"pub fn add(a: i32, b: i32) -\u003e i32 {\\n a + b\\n}\",\n \"search\": \"pub fn subtract(a: i32, b: i32) -\u003e i32 {\\n a - b\\n}\"\n }\n ]\n}"},"done_reason":"stop","done":true,"total_duration":6521191210,"load_duration":42309565,"prompt_eval_count":2048,"prompt_eval_duration":1028000000,"eval_count":145,"eval_duration":5416000000}
+2025-02-02T22:37:03.683183Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:37:03.714591563Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 145,
+"eval_duration": 5416000000,
+"load_duration": 42309565,
+"message": {
+"content": "{ \"changes\": [\n {\n \"analysis\": \"Change 1\",\n \"replace\": \"fn main() {\\n println!(\\\"Hello, world!\\\");\\n}\",\n \"search\": \"fn main() {\\n println!(\\\"Old message\\\");\\n}\"\n },\n {\n \"analysis\": \"Change 2\",\n \"replace\": \"pub fn add(a: i32, b: i32) -> i32 {\\n a + b\\n}\",\n \"search\": \"pub fn subtract(a: i32, b: i32) -> i32 {\\n a - b\\n}\"\n }\n ]\n}",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1028000000,
+"total_duration": 6521191210
+}
+2025-02-02T22:37:03.683223Z INFO openagents::server::services::ollama::service: Extracted content: { "changes": [
+{
+"analysis": "Change 1",
+"replace": "fn main() {\n println!(\"Hello, world!\");\n}",
+"search": "fn main() {\n println!(\"Old message\");\n}"
+},
+{
+"analysis": "Change 2",
+"replace": "pub fn add(a: i32, b: i32) -> i32 {\n a + b\n}",
+"search": "pub fn subtract(a: i32, b: i32) -> i32 {\n a - b\n}"
+}
+]
+}
+2025-02-02T22:37:03.683409Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:37:03.683435Z INFO solver::solver_impl::changes: Relative path: src/solver/state.rs
+2025-02-02T22:37:03.683456Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/solver/state.rs
+2025-02-02T22:37:03.684354Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:37:51.575886Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:37:51.621718214Z","message":{"role":"assistant","content":"{ \"changes\": [\n {\n \"analysis\": \"\",\n \"replace\": \"use serde::{Deserialize, Serialize};\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use uuid::Uuid;\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[derive(Debug, Clone, Serialize, Deserialize)]\\npub struct SolverState {\\n pub id: String,\\n pub run_id: String,\\n pub status: SolverStatus,\\n pub analysis: String,\\n pub files: Vec\u003cFileState\u003e,\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[derive(Debug, Clone, Serialize, Deserialize)]\\npub struct FileState {\\n pub id: String,\\n pub path: String,\\n pub analysis: String,\\n pub relevance_score: f32,\\n pub changes: Vec\u003cChange\u003e,\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[derive(Debug, Clone, Serialize, Deserialize)]\\npub struct Change {\\n pub search: String,\\n pub replace: String,\\n pub analysis: String,\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\\n#[serde(rename_all = \\\"snake_case\\\")]\\npub enum SolverStatus {\\n CollectingContext,\\n Thinking,\\n GeneratingCode,\\n ReadyForCoding,\\n Testing,\\n CreatingPr,\\n Complete,\\n Error,\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\nimpl SolverState {\\n pub fn new(analysis: String) -\u003e Self {\\n Self {\\n id: Uuid::new_v4().to_string(),\\n run_id: Uuid::new_v4().to_string(),\\n status: SolverStatus::CollectingContext,\\n analysis,\\n files: Vec::new(),\\n }\\n }\\n\\n pub fn add_file(\\n \u0026mut self,\\n path: String,\\n analysis: String,\\n relevance_score: f32,\\n ) -\u003e \u0026mut FileState {\\n let file_state = FileState {\\n id: Uuid::new_v4().to_string(),\\n path,\\n analysis,\\n relevance_score,\\n changes: Vec::new(),\\n };\\n self.files.push(file_state);\\n self.files.last_mut().unwrap()\\n }\\n\\n pub fn update_status(\u0026mut self, status: SolverStatus) {\\n self.status = status;\\n }\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\nimpl FileState {\\n pub fn add_change(\u0026mut self, search: String, replace: String, analysis: String) {\\n let change = Change {\\n search,\\n replace,\\n analysis,\\n };\\n self.changes.push(change);\\n }\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[cfg(test)]\\nmod tests {\\n use super::*;\\n\\n #[test]\\n fn test_solver_state_creation() {\\n let state = SolverState::new(\\\"Initial analysis\\\".to_string());\\n assert_eq!(state.status, SolverStatus::CollectingContext);\\n assert!(state.files.is_empty());\\n assert_eq!(state.analysis, \\\"Initial analysis\\\");\\n }\\n\\n #[test]\\n fn test_add_file() {\\n let mut state = SolverState::new(\\\"Initial analysis\\\".to_string());\\n let file = state.add_file(\\\"src/main.rs\\\".to_string(), \\\"Main file\\\".to_string(), 0.9);\\n\\n assert_eq!(file.path, \\\"src/main.rs\\\");\\n assert_eq!(file.analysis, \\\"Main file\\\");\\n assert_eq!(file.relevance_score, 0.9);\\n assert!(file.changes.is_empty());\\n assert_eq!(state.files.len(), 1);\\n }\\n\\n #[test]\\n fn test_add_change() {\\n let mut state = SolverState::new(\\\"Initial analysis\\\".to_string());\\n let file = state.add_file(\\\"src/main.rs\\\".to_string(), \\\"Main file\\\".to_string(), 0.9);\\n\\n file.add_change(\\\"old_search\\\".to_string(), \\\"new_replace\\\".to_string(), \\\"analysis\\\".to_string());\\n\\n assert_eq!(file.changes.len(), 1);\\n assert_eq!(file.changes[0].search, \\\"old_search\\\");\\n assert_eq!(file.changes[0].replace, \\\"new_replace\\\");\\n assert_eq!(file.changes[0].analysis, \\\"analysis\\\");\\n }\\n\\n #[test]\\n fn test_update_status() {\\n let mut state = SolverState::new(\\\"Initial analysis\\\".to_string());\\n state.update_status(SolverStatus::GeneratingCode);\\n assert_eq!(state.status, SolverStatus::GeneratingCode);\\n }\\n}\\n\",\n \"search\": \"\"\n }\n]}"},"done_reason":"stop","done":true,"total_duration":47862111963,"load_duration":38858655,"prompt_eval_count":2048,"prompt_eval_duration":1030000000,"eval_count":1245,"eval_duration":46765000000}
+2025-02-02T22:37:51.576618Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:37:51.621718214Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 1245,
+"eval_duration": 46765000000,
+"load_duration": 38858655,
+"message": {
+"content": "{ \"changes\": [\n {\n \"analysis\": \"\",\n \"replace\": \"use serde::{Deserialize, Serialize};\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use uuid::Uuid;\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[derive(Debug, Clone, Serialize, Deserialize)]\\npub struct SolverState {\\n pub id: String,\\n pub run_id: String,\\n pub status: SolverStatus,\\n pub analysis: String,\\n pub files: Vec<FileState>,\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[derive(Debug, Clone, Serialize, Deserialize)]\\npub struct FileState {\\n pub id: String,\\n pub path: String,\\n pub analysis: String,\\n pub relevance_score: f32,\\n pub changes: Vec<Change>,\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[derive(Debug, Clone, Serialize, Deserialize)]\\npub struct Change {\\n pub search: String,\\n pub replace: String,\\n pub analysis: String,\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\\n#[serde(rename_all = \\\"snake_case\\\")]\\npub enum SolverStatus {\\n CollectingContext,\\n Thinking,\\n GeneratingCode,\\n ReadyForCoding,\\n Testing,\\n CreatingPr,\\n Complete,\\n Error,\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\nimpl SolverState {\\n pub fn new(analysis: String) -> Self {\\n Self {\\n id: Uuid::new_v4().to_string(),\\n run_id: Uuid::new_v4().to_string(),\\n status: SolverStatus::CollectingContext,\\n analysis,\\n files: Vec::new(),\\n }\\n }\\n\\n pub fn add_file(\\n &mut self,\\n path: String,\\n analysis: String,\\n relevance_score: f32,\\n ) -> &mut FileState {\\n let file_state = FileState {\\n id: Uuid::new_v4().to_string(),\\n path,\\n analysis,\\n relevance_score,\\n changes: Vec::new(),\\n };\\n self.files.push(file_state);\\n self.files.last_mut().unwrap()\\n }\\n\\n pub fn update_status(&mut self, status: SolverStatus) {\\n self.status = status;\\n }\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\nimpl FileState {\\n pub fn add_change(&mut self, search: String, replace: String, analysis: String) {\\n let change = Change {\\n search,\\n replace,\\n analysis,\\n };\\n self.changes.push(change);\\n }\\n}\\n\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"\\n#[cfg(test)]\\nmod tests {\\n use super::*;\\n\\n #[test]\\n fn test_solver_state_creation() {\\n let state = SolverState::new(\\\"Initial analysis\\\".to_string());\\n assert_eq!(state.status, SolverStatus::CollectingContext);\\n assert!(state.files.is_empty());\\n assert_eq!(state.analysis, \\\"Initial analysis\\\");\\n }\\n\\n #[test]\\n fn test_add_file() {\\n let mut state = SolverState::new(\\\"Initial analysis\\\".to_string());\\n let file = state.add_file(\\\"src/main.rs\\\".to_string(), \\\"Main file\\\".to_string(), 0.9);\\n\\n assert_eq!(file.path, \\\"src/main.rs\\\");\\n assert_eq!(file.analysis, \\\"Main file\\\");\\n assert_eq!(file.relevance_score, 0.9);\\n assert!(file.changes.is_empty());\\n assert_eq!(state.files.len(), 1);\\n }\\n\\n #[test]\\n fn test_add_change() {\\n let mut state = SolverState::new(\\\"Initial analysis\\\".to_string());\\n let file = state.add_file(\\\"src/main.rs\\\".to_string(), \\\"Main file\\\".to_string(), 0.9);\\n\\n file.add_change(\\\"old_search\\\".to_string(), \\\"new_replace\\\".to_string(), \\\"analysis\\\".to_string());\\n\\n assert_eq!(file.changes.len(), 1);\\n assert_eq!(file.changes[0].search, \\\"old_search\\\");\\n assert_eq!(file.changes[0].replace, \\\"new_replace\\\");\\n assert_eq!(file.changes[0].analysis, \\\"analysis\\\");\\n }\\n\\n #[test]\\n fn test_update_status() {\\n let mut state = SolverState::new(\\\"Initial analysis\\\".to_string());\\n state.update_status(SolverStatus::GeneratingCode);\\n assert_eq!(state.status, SolverStatus::GeneratingCode);\\n }\\n}\\n\",\n \"search\": \"\"\n }\n]}",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1030000000,
+"total_duration": 47862111963
+}
+2025-02-02T22:37:51.576778Z INFO openagents::server::services::ollama::service: Extracted content: { "changes": [
+{
+"analysis": "",
+"replace": "use serde::{Deserialize, Serialize};",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "use uuid::Uuid;",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "\n#[derive(Debug, Clone, Serialize, Deserialize)]\npub struct SolverState {\n pub id: String,\n pub run_id: String,\n pub status: SolverStatus,\n pub analysis: String,\n pub files: Vec<FileState>,\n}\n",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "\n#[derive(Debug, Clone, Serialize, Deserialize)]\npub struct FileState {\n pub id: String,\n pub path: String,\n pub analysis: String,\n pub relevance_score: f32,\n pub changes: Vec<Change>,\n}\n",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "\n#[derive(Debug, Clone, Serialize, Deserialize)]\npub struct Change {\n pub search: String,\n pub replace: String,\n pub analysis: String,\n}\n",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "\n#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]\n#[serde(rename_all = \"snake_case\")]\npub enum SolverStatus {\n CollectingContext,\n Thinking,\n GeneratingCode,\n ReadyForCoding,\n Testing,\n CreatingPr,\n Complete,\n Error,\n}\n",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "\nimpl SolverState {\n pub fn new(analysis: String) -> Self {\n Self {\n id: Uuid::new_v4().to_string(),\n run_id: Uuid::new_v4().to_string(),\n status: SolverStatus::CollectingContext,\n analysis,\n files: Vec::new(),\n }\n }\n\n pub fn add_file(\n &mut self,\n path: String,\n analysis: String,\n relevance_score: f32,\n ) -> &mut FileState {\n let file_state = FileState {\n id: Uuid::new_v4().to_string(),\n path,\n analysis,\n relevance_score,\n changes: Vec::new(),\n };\n self.files.push(file_state);\n self.files.last_mut().unwrap()\n }\n\n pub fn update_status(&mut self, status: SolverStatus) {\n self.status = status;\n }\n}\n",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "\nimpl FileState {\n pub fn add_change(&mut self, search: String, replace: String, analysis: String) {\n let change = Change {\n search,\n replace,\n analysis,\n };\n self.changes.push(change);\n }\n}\n",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "\n#[cfg(test)]\nmod tests {\n use super::\*;\n\n #[test]\n fn test_solver_state_creation() {\n let state = SolverState::new(\"Initial analysis\".to_string());\n assert_eq!(state.status, SolverStatus::CollectingContext);\n assert!(state.files.is_empty());\n assert_eq!(state.analysis, \"Initial analysis\");\n }\n\n #[test]\n fn test_add_file() {\n let mut state = SolverState::new(\"Initial analysis\".to_string());\n let file = state.add_file(\"src/main.rs\".to_string(), \"Main file\".to_string(), 0.9);\n\n assert_eq!(file.path, \"src/main.rs\");\n assert_eq!(file.analysis, \"Main file\");\n assert_eq!(file.relevance_score, 0.9);\n assert!(file.changes.is_empty());\n assert_eq!(state.files.len(), 1);\n }\n\n #[test]\n fn test_add_change() {\n let mut state = SolverState::new(\"Initial analysis\".to_string());\n let file = state.add_file(\"src/main.rs\".to_string(), \"Main file\".to_string(), 0.9);\n\n file.add_change(\"old_search\".to_string(), \"new_replace\".to_string(), \"analysis\".to_string());\n\n assert_eq!(file.changes.len(), 1);\n assert_eq!(file.changes[0].search, \"old_search\");\n assert_eq!(file.changes[0].replace, \"new_replace\");\n assert_eq!(file.changes[0].analysis, \"analysis\");\n }\n\n #[test]\n fn test_update_status() {\n let mut state = SolverState::new(\"Initial analysis\".to_string());\n state.update_status(SolverStatus::GeneratingCode);\n assert_eq!(state.status, SolverStatus::GeneratingCode);\n }\n}\n",
+"search": ""
+}
+]}
+2025-02-02T22:37:51.577158Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:37:51.577180Z INFO solver::solver_impl::changes: Relative path: src/solver/context.rs
+2025-02-02T22:37:51.577194Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/solver/context.rs
+2025-02-02T22:37:51.577848Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:38:12.418170Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:38:12.463949202Z","message":{"role":"assistant","content":"{ \"changes\": [\n {\n \"analysis\": \"The function `test_apply_changes` is missing a test case for handling errors when the search content does not exist in the file.\",\n \"replace\": \"fn test_apply_changes() {\\n let temp_dir = tempdir().unwrap();\\n let context = SolverContext::new_with_dir(temp_dir.path().to_path_buf());\\n\\n // Test new file creation\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"\".to_string(), \"fn test() {}\".to_string(), \"Add test function\".to_string())];\\n assert!(context.apply_changes(\u0026changes).is_ok());\\n\\n // Test content modification\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"fn test() {}\".to_string(), \"fn test() { println!(\\\"test\\\"); }\".to_string(), \"Add print statement\".to_string())];\\n assert!(context.apply_changes(\u0026changes).is_ok());\\n\\n // Test error handling when search content does not exist\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"fn non_existent() {}\".to_string(), \"fn test() { println!(\\\"test\\\"); }\".to_string())];\\n assert!(context.apply_changes(\u0026changes).is_err());\\n }\"\n ,\n \"search\": \"fn test_apply_changes() {\\n let temp_dir = tempdir().unwrap();\\n let context = SolverContext::new_with_dir(temp_dir.path().to_path_buf());\\n\\n // Test new file creation\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"\".to_string(), \"fn test() {}\".to_string())];\\n assert!(context.apply_changes(\u0026changes).is_ok());\\n\\n // Test content modification\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"fn test() {}\".to_string(), \"fn test() { println!(\\\"test\\\"); }\".to_string())];\\n assert!(context.apply_changes(\u0026changes).is_ok());\\n }\"\n }\n] }"},"done_reason":"stop","done":true,"total_duration":20811287484,"load_duration":41408866,"prompt_eval_count":2048,"prompt_eval_duration":1025000000,"eval_count":521,"eval_duration":19707000000}
+2025-02-02T22:38:12.418658Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:38:12.463949202Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 521,
+"eval_duration": 19707000000,
+"load_duration": 41408866,
+"message": {
+"content": "{ \"changes\": [\n {\n \"analysis\": \"The function `test_apply_changes` is missing a test case for handling errors when the search content does not exist in the file.\",\n \"replace\": \"fn test_apply_changes() {\\n let temp_dir = tempdir().unwrap();\\n let context = SolverContext::new_with_dir(temp_dir.path().to_path_buf());\\n\\n // Test new file creation\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"\".to_string(), \"fn test() {}\".to_string(), \"Add test function\".to_string())];\\n assert!(context.apply_changes(&changes).is_ok());\\n\\n // Test content modification\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"fn test() {}\".to_string(), \"fn test() { println!(\\\"test\\\"); }\".to_string(), \"Add print statement\".to_string())];\\n assert!(context.apply_changes(&changes).is_ok());\\n\\n // Test error handling when search content does not exist\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"fn non_existent() {}\".to_string(), \"fn test() { println!(\\\"test\\\"); }\".to_string())];\\n assert!(context.apply_changes(&changes).is_err());\\n }\"\n ,\n \"search\": \"fn test_apply_changes() {\\n let temp_dir = tempdir().unwrap();\\n let context = SolverContext::new_with_dir(temp_dir.path().to_path_buf());\\n\\n // Test new file creation\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"\".to_string(), \"fn test() {}\".to_string())];\\n assert!(context.apply_changes(&changes).is_ok());\\n\\n // Test content modification\\n let changes = vec![Change::with_reason(\"test.rs\".to_string(), \"fn test() {}\".to_string(), \"fn test() { println!(\\\"test\\\"); }\".to_string())];\\n assert!(context.apply_changes(&changes).is_ok());\\n }\"\n }\n] }",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1025000000,
+"total_duration": 20811287484
+}
+2025-02-02T22:38:12.418748Z INFO openagents::server::services::ollama::service: Extracted content: { "changes": [
+{
+"analysis": "The function `test_apply_changes` is missing a test case for handling errors when the search content does not exist in the file.",
+"replace": "fn test_apply_changes() {\n let temp_dir = tempdir().unwrap();\n let context = SolverContext::new_with_dir(temp_dir.path().to_path_buf());\n\n // Test new file creation\n let changes = vec![Change::with_reason("test.rs".to_string(), "".to_string(), "fn test() {}".to_string(), "Add test function".to_string())];\n assert!(context.apply_changes(&changes).is_ok());\n\n // Test content modification\n let changes = vec![Change::with_reason("test.rs".to_string(), "fn test() {}".to_string(), "fn test() { println!(\"test\"); }".to_string(), "Add print statement".to_string())];\n assert!(context.apply_changes(&changes).is_ok());\n\n // Test error handling when search content does not exist\n let changes = vec![Change::with_reason("test.rs".to_string(), "fn non_existent() {}".to_string(), "fn test() { println!(\"test\"); }".to_string())];\n assert!(context.apply_changes(&changes).is_err());\n }"
+,
+"search": "fn test_apply_changes() {\n let temp_dir = tempdir().unwrap();\n let context = SolverContext::new_with_dir(temp_dir.path().to_path_buf());\n\n // Test new file creation\n let changes = vec![Change::with_reason("test.rs".to_string(), "".to_string(), "fn test() {}".to_string())];\n assert!(context.apply_changes(&changes).is_ok());\n\n // Test content modification\n let changes = vec![Change::with_reason("test.rs".to_string(), "fn test() {}".to_string(), "fn test() { println!(\"test\"); }".to_string())];\n assert!(context.apply_changes(&changes).is_ok());\n }"
+}
+] }
+2025-02-02T22:38:12.418960Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:38:12.419661Z INFO solver::solver_impl::changes: Relative path: src/solver/changes/apply.rs
+2025-02-02T22:38:12.419681Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/solver/changes/apply.rs
+2025-02-02T22:38:12.420208Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:38:56.109741Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:38:56.119512379Z","message":{"role":"assistant","content":"{ \"changes\": [\n {\n \"analysis\": \"\",\n \"replace\": \"fn main() {\\n println!(\\\"Hello, world!\\\");\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::io;\\n\\nfn main() {\\n let mut input = String::new();\\n io::stdin().read_line(\u0026mut input).expect(\\\"Failed to read line\\\");\\n println!(\\\"You entered: {}\\\", input.trim());\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"fn add(a: i32, b: i32) -\u003e i32 {\\n a + b\\n}\\n\\nfn main() {\\n let result = add(5, 3);\\n println!(\\\"The sum is: {}\\\", result);\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"struct Point {\\n x: f64,\\n y: f64,\\n}\\n\\nimpl Point {\\n fn new(x: f64, y: f64) -\u003e Self {\\n Point { x, y }\\n }\\n fn distance_from_origin(\u0026self) -\u003e f64 {\\n (self.x.powi(2) + self.y.powi(2)).sqrt()\\n }\\n}\\n\\nfn main() {\\n let p = Point::new(3.0, 4.0);\\n println!(\\\"Distance from origin: {}\\\", p.distance_from_origin());\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::fs;\\n\\nfn read_file_contents(filename: \u0026str) -\u003e String {\\n fs::read_to_string(filename).expect(\\\"Failed to read file\\\")\\n}\\n\\nfn main() {\\n let contents = read_file_contents(\\\"example.txt\\\");\\n println!(\\\"{}\\\", contents);\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::thread;\\nuse std::time::Duration;\\n\\nfn main() {\\n for i in 1..=5 {\\n thread::spawn(move || {\\n println!(\\\"Thread {} is running\\\", i);\\n thread::sleep(Duration::from_secs(1));\\n });\\n }\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::collections::HashMap;\\n\\nfn main() {\\n let mut map = HashMap::new();\\n map.insert(\\\"key1\\\", \\\"value1\\\");\\n map.insert(\\\"key2\\\", \\\"value2\\\");\\n println!(\\\"{:?}\\\", map);\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::sync::{Arc, Mutex};\\n\\nfn main() {\\n let counter = Arc::new(Mutex::new(0));\\n let mut handles = vec![];\\n for * in 0..10 {\\n let counter = Arc::clone(\u0026counter);\\n let handle = thread::spawn(move || {\\n let mut num = counter.lock().unwrap();\\n *num += 1;\\n });\\n handles.push(handle);\\n }\\n for handle in handles {\\n handle.join().unwrap();\\n }\\n println!(\\\"Final counter value: {}\\\", *counter.lock().unwrap());\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::net::{TcpListener, TcpStream};\\nuse std::io::{Read, Write};\\n\\nfn handle*client(mut stream: TcpStream) {\\n let mut buffer = [0; 512];\\n stream.read(\u0026mut buffer).unwrap();\\n println!(\\\"Received: {}\\\", String::from_utf8_lossy(\u0026buffer));\\n stream.write(\u0026buffer).unwrap();\\n}\\n\\nfn main() {\\n let listener = TcpListener::bind(\\\"127.0.0.1:7878\\\").unwrap();\\n for stream in listener.incoming() {\\n match stream {\\n Ok(stream) =\u003e {\\n handle_client(stream);\\n }\\n Err(e) =\u003e {\\n eprintln!(\\\"Connection failed: {}\\\", e);\\n }\\n }\\n }\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::fs::File;\\nuse std::io::{self, Write};\\n\\nfn main() -\u003e io::Result\u003c()\u003e {\\n let mut file = File::create(\\\"example.txt\\\")?;\\n writeln!(file, \\\"Hello, world!\\\")?;\\n Ok(())\\n}\",\n \"search\": \"\"\n }\n] }"},"done_reason":"stop","done":true,"total_duration":43625567055,"load_duration":29343804,"prompt_eval_count":2048,"prompt_eval_duration":1036000000,"eval_count":1135,"eval_duration":42518000000}
+2025-02-02T22:38:56.110578Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:38:56.119512379Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 1135,
+"eval_duration": 42518000000,
+"load_duration": 29343804,
+"message": {
+"content": "{ \"changes\": [\n {\n \"analysis\": \"\",\n \"replace\": \"fn main() {\\n println!(\\\"Hello, world!\\\");\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::io;\\n\\nfn main() {\\n let mut input = String::new();\\n io::stdin().read_line(&mut input).expect(\\\"Failed to read line\\\");\\n println!(\\\"You entered: {}\\\", input.trim());\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"fn add(a: i32, b: i32) -> i32 {\\n a + b\\n}\\n\\nfn main() {\\n let result = add(5, 3);\\n println!(\\\"The sum is: {}\\\", result);\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"struct Point {\\n x: f64,\\n y: f64,\\n}\\n\\nimpl Point {\\n fn new(x: f64, y: f64) -> Self {\\n Point { x, y }\\n }\\n fn distance_from_origin(&self) -> f64 {\\n (self.x.powi(2) + self.y.powi(2)).sqrt()\\n }\\n}\\n\\nfn main() {\\n let p = Point::new(3.0, 4.0);\\n println!(\\\"Distance from origin: {}\\\", p.distance_from_origin());\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::fs;\\n\\nfn read_file_contents(filename: &str) -> String {\\n fs::read_to_string(filename).expect(\\\"Failed to read file\\\")\\n}\\n\\nfn main() {\\n let contents = read_file_contents(\\\"example.txt\\\");\\n println!(\\\"{}\\\", contents);\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::thread;\\nuse std::time::Duration;\\n\\nfn main() {\\n for i in 1..=5 {\\n thread::spawn(move || {\\n println!(\\\"Thread {} is running\\\", i);\\n thread::sleep(Duration::from_secs(1));\\n });\\n }\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::collections::HashMap;\\n\\nfn main() {\\n let mut map = HashMap::new();\\n map.insert(\\\"key1\\\", \\\"value1\\\");\\n map.insert(\\\"key2\\\", \\\"value2\\\");\\n println!(\\\"{:?}\\\", map);\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::sync::{Arc, Mutex};\\n\\nfn main() {\\n let counter = Arc::new(Mutex::new(0));\\n let mut handles = vec![];\\n for * in 0..10 {\\n let counter = Arc::clone(&counter);\\n let handle = thread::spawn(move || {\\n let mut num = counter.lock().unwrap();\\n *num += 1;\\n });\\n handles.push(handle);\\n }\\n for handle in handles {\\n handle.join().unwrap();\\n }\\n println!(\\\"Final counter value: {}\\\", *counter.lock().unwrap());\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::net::{TcpListener, TcpStream};\\nuse std::io::{Read, Write};\\n\\nfn handle*client(mut stream: TcpStream) {\\n let mut buffer = [0; 512];\\n stream.read(&mut buffer).unwrap();\\n println!(\\\"Received: {}\\\", String::from_utf8_lossy(&buffer));\\n stream.write(&buffer).unwrap();\\n}\\n\\nfn main() {\\n let listener = TcpListener::bind(\\\"127.0.0.1:7878\\\").unwrap();\\n for stream in listener.incoming() {\\n match stream {\\n Ok(stream) => {\\n handle_client(stream);\\n }\\n Err(e) => {\\n eprintln!(\\\"Connection failed: {}\\\", e);\\n }\\n }\\n }\\n}\",\n \"search\": \"\"\n },\n {\n \"analysis\": \"\",\n \"replace\": \"use std::fs::File;\\nuse std::io::{self, Write};\\n\\nfn main() -> io::Result<()> {\\n let mut file = File::create(\\\"example.txt\\\")?;\\n writeln!(file, \\\"Hello, world!\\\")?;\\n Ok(())\\n}\",\n \"search\": \"\"\n }\n] }",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1036000000,
+"total_duration": 43625567055
+}
+2025-02-02T22:38:56.110724Z INFO openagents::server::services::ollama::service: Extracted content: { "changes": [
+{
+"analysis": "",
+"replace": "fn main() {\n println!(\"Hello, world!\");\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "use std::io;\n\nfn main() {\n let mut input = String::new();\n io::stdin().read_line(&mut input).expect(\"Failed to read line\");\n println!(\"You entered: {}\", input.trim());\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "fn add(a: i32, b: i32) -> i32 {\n a + b\n}\n\nfn main() {\n let result = add(5, 3);\n println!(\"The sum is: {}\", result);\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "struct Point {\n x: f64,\n y: f64,\n}\n\nimpl Point {\n fn new(x: f64, y: f64) -> Self {\n Point { x, y }\n }\n fn distance_from_origin(&self) -> f64 {\n (self.x.powi(2) + self.y.powi(2)).sqrt()\n }\n}\n\nfn main() {\n let p = Point::new(3.0, 4.0);\n println!(\"Distance from origin: {}\", p.distance_from_origin());\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "use std::fs;\n\nfn read_file_contents(filename: &str) -> String {\n fs::read_to_string(filename).expect(\"Failed to read file\")\n}\n\nfn main() {\n let contents = read_file_contents(\"example.txt\");\n println!(\"{}\", contents);\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "use std::thread;\nuse std::time::Duration;\n\nfn main() {\n for i in 1..=5 {\n thread::spawn(move || {\n println!(\"Thread {} is running\", i);\n thread::sleep(Duration::from_secs(1));\n });\n }\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "use std::collections::HashMap;\n\nfn main() {\n let mut map = HashMap::new();\n map.insert(\"key1\", \"value1\");\n map.insert(\"key2\", \"value2\");\n println!(\"{:?}\", map);\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "use std::sync::{Arc, Mutex};\n\nfn main() {\n let counter = Arc::new(Mutex::new(0));\n let mut handles = vec![];\n for * in 0..10 {\n let counter = Arc::clone(&counter);\n let handle = thread::spawn(move || {\n let mut num = counter.lock().unwrap();\n *num += 1;\n });\n handles.push(handle);\n }\n for handle in handles {\n handle.join().unwrap();\n }\n println!(\"Final counter value: {}\", *counter.lock().unwrap());\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "use std::net::{TcpListener, TcpStream};\nuse std::io::{Read, Write};\n\nfn handle*client(mut stream: TcpStream) {\n let mut buffer = [0; 512];\n stream.read(&mut buffer).unwrap();\n println!(\"Received: {}\", String::from_utf8_lossy(&buffer));\n stream.write(&buffer).unwrap();\n}\n\nfn main() {\n let listener = TcpListener::bind(\"127.0.0.1:7878\").unwrap();\n for stream in listener.incoming() {\n match stream {\n Ok(stream) => {\n handle_client(stream);\n }\n Err(e) => {\n eprintln!(\"Connection failed: {}\", e);\n }\n }\n }\n}",
+"search": ""
+},
+{
+"analysis": "",
+"replace": "use std::fs::File;\nuse std::io::{self, Write};\n\nfn main() -> io::Result<()> {\n let mut file = File::create(\"example.txt\")?;\n writeln!(file, \"Hello, world!\")?;\n Ok(())\n}",
+"search": ""
+}
+] }
+2025-02-02T22:38:56.111101Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:38:56.111131Z INFO solver::solver_impl::changes: Relative path: src/solver/types.rs
+2025-02-02T22:38:56.111146Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/solver/types.rs
+2025-02-02T22:38:56.112372Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:39:15.725602Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:39:15.773223069Z","message":{"role":"assistant","content":"{ \"changes\": [\n {\n \"analysis\": \"The function `validate_pr_title` is designed to validate pull request titles based on several criteria, including length, presence of an issue reference, and inclusion of action verbs.\",\n \"replace\": \"function validate_pr_title(title: string): boolean {\\n // Title must be descriptive\\n if (title.length \u003c 20) {\\n return false;\\n }\\n \\n // Title must contain issue reference\\n if (!title.includes('#')) {\\n return false;\\n }\\n \\n // Title must contain action verb\\n const action_verbs = ['add', 'fix', 'update', 'implement', 'improve', 'refactor'];\\n if (!action_verbs.some(verb =\u003e title.toLowerCase().includes(verb))) {\\n return false;\\n }\\n \\n // Title must not be too long\\n if (title.length \u003e 72) {\\n return false;\\n }\\n \\n return true;\\n}\"\n ,\n \"search\": \"pub fn validate_pr_title(title: \u0026str) -\u003e Result\u003c()\u003e {\\n // Title must be descriptive\\n if title.len() \u003c 20 {\\n return Err(anyhow!(\\\"PR title must be at least 20 characters\\\"));\\n }\\n \\n // Title must contain issue reference\\n if !title.contains('#') {\\n return Err(anyhow!(\\\"PR title must reference the issue number\\\"));\\n }\\n \\n // Title must contain action verb\\n let action_verbs = [\\\"add\\\", \\\"fix\\\", \\\"update\\\", \\\"implement\\\", \\\"improve\\\", \\\"refactor\\\"];\\n if !action_verbs.iter().any(|\u0026verb| title.to_lowercase().contains(verb)) {\\n return Err(anyhow!(\\\"PR title must contain an action verb\\\"));\\n }\\n \\n // Title must not be too long\\n if title.len() \u003e 72 {\\n return Err(anyhow!(\\\"PR title must not exceed 72 characters\\\"));\\n }\\n \\n Ok(())\\n}\"\n }\n] }"},"done_reason":"stop","done":true,"total_duration":19584377273,"load_duration":43209408,"prompt_eval_count":2048,"prompt_eval_duration":1035000000,"eval_count":491,"eval_duration":18472000000}
+2025-02-02T22:39:15.726240Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:39:15.773223069Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 491,
+"eval_duration": 18472000000,
+"load_duration": 43209408,
+"message": {
+"content": "{ \"changes\": [\n {\n \"analysis\": \"The function `validate_pr_title` is designed to validate pull request titles based on several criteria, including length, presence of an issue reference, and inclusion of action verbs.\",\n \"replace\": \"function validate_pr_title(title: string): boolean {\\n // Title must be descriptive\\n if (title.length < 20) {\\n return false;\\n }\\n \\n // Title must contain issue reference\\n if (!title.includes('#')) {\\n return false;\\n }\\n \\n // Title must contain action verb\\n const action_verbs = ['add', 'fix', 'update', 'implement', 'improve', 'refactor'];\\n if (!action_verbs.some(verb => title.toLowerCase().includes(verb))) {\\n return false;\\n }\\n \\n // Title must not be too long\\n if (title.length > 72) {\\n return false;\\n }\\n \\n return true;\\n}\"\n ,\n \"search\": \"pub fn validate_pr_title(title: &str) -> Result<()> {\\n // Title must be descriptive\\n if title.len() < 20 {\\n return Err(anyhow!(\\\"PR title must be at least 20 characters\\\"));\\n }\\n \\n // Title must contain issue reference\\n if !title.contains('#') {\\n return Err(anyhow!(\\\"PR title must reference the issue number\\\"));\\n }\\n \\n // Title must contain action verb\\n let action_verbs = [\\\"add\\\", \\\"fix\\\", \\\"update\\\", \\\"implement\\\", \\\"improve\\\", \\\"refactor\\\"];\\n if !action_verbs.iter().any(|&verb| title.to_lowercase().contains(verb)) {\\n return Err(anyhow!(\\\"PR title must contain an action verb\\\"));\\n }\\n \\n // Title must not be too long\\n if title.len() > 72 {\\n return Err(anyhow!(\\\"PR title must not exceed 72 characters\\\"));\\n }\\n \\n Ok(())\\n}\"\n }\n] }",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1035000000,
+"total_duration": 19584377273
+}
+2025-02-02T22:39:15.726358Z INFO openagents::server::services::ollama::service: Extracted content: { "changes": [
+{
+"analysis": "The function `validate_pr_title` is designed to validate pull request titles based on several criteria, including length, presence of an issue reference, and inclusion of action verbs.",
+"replace": "function validate_pr_title(title: string): boolean {\n // Title must be descriptive\n if (title.length < 20) {\n return false;\n }\n \n // Title must contain issue reference\n if (!title.includes('#')) {\n return false;\n }\n \n // Title must contain action verb\n const action_verbs = ['add', 'fix', 'update', 'implement', 'improve', 'refactor'];\n if (!action_verbs.some(verb => title.toLowerCase().includes(verb))) {\n return false;\n }\n \n // Title must not be too long\n if (title.length > 72) {\n return false;\n }\n \n return true;\n}"
+,
+"search": "pub fn validate_pr_title(title: &str) -> Result<()> {\n // Title must be descriptive\n if title.len() < 20 {\n return Err(anyhow!(\"PR title must be at least 20 characters\"));\n }\n \n // Title must contain issue reference\n if !title.contains('#') {\n return Err(anyhow!(\"PR title must reference the issue number\"));\n }\n \n // Title must contain action verb\n let action_verbs = [\"add\", \"fix\", \"update\", \"implement\", \"improve\", \"refactor\"];\n if !action_verbs.iter().any(|&verb| title.to_lowercase().contains(verb)) {\n return Err(anyhow!(\"PR title must contain an action verb\"));\n }\n \n // Title must not be too long\n if title.len() > 72 {\n return Err(anyhow!(\"PR title must not exceed 72 characters\"));\n }\n \n Ok(())\n}"
+}
+] }
+2025-02-02T22:39:15.726632Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:39:15.726658Z INFO solver::solver_impl::changes: Relative path: src/solver/json.rs
+2025-02-02T22:39:15.726677Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/solver/json.rs
+2025-02-02T22:39:15.727478Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:39:42.393953Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:39:42.430743185Z","message":{"role":"assistant","content":"{\n \"changes\": [\n {\n \"analysis\": \"The test `test_fix_common_json_issues` is currently ignored due to a need for review of JSON escaping.\",\n \"replace\": \"`rust\\n#[cfg(test)]\\nmod tests {\\n    use super::*;\\n\\n    #[test]\\n    fn test_escape_json_string() {\\n        assert_eq!(escape_json_string(\\\"hello\\\\n\\\"), \\\"hello\\\\\\\\n\\\");\\n        assert_eq!(escape_json_string(\\\"\\\\\\\"quote\\\\\\\"\\\"), \\\"\\\\\\\\\\\\\\\"quote\\\\\\\\\\\\\\\"\\\");\\n        assert_eq!(escape_json_string(\\\"tab\\\\there\\\"), \\\"tab\\\\\\\\there\\\");\\n    }\\n\\n    #[test]\\n    fn test_is_valid_json_string() {\\n        assert!(is_valid_json_string(\\\"hello\\\"));\\n        assert!(is_valid_json_string(\\\"hello\\\\\\\\n\\\"));\\n        assert!(!is_valid_json_string(\\\"hello\\\\\\\"\\\"));\\n    }\\n\\n    #[test]\\n    fn test_fix_common_json_issues() {\\n        let input = \\\"{\\\\n\\\\\\\"key\\\\\\\": \\\\\\\"value\\\\\\\"\\\\n}\\\\n{\\\\n\\\\\\\"key2\\\\\\\": \\\\\\\"value2\\\\\\\"}\\\";\\n        let expected = \\\"{\\\\n\\\\\\\"key\\\\\\\": \\\\\\\"value\\\\\\\"\\\\n},\\\\n{\\\\n\\\\\\\"key2\\\\\\\": \\\\\\\"value2\\\\\\\"}\\\";\\n        assert_eq!(fix_common_json_issues(input), expected);\\n    }\\n}\\n`\"\n ,\n \"search\": \"`rust\\n#[cfg(test)]\\nmod tests {\\n    use super::*;\\n\\n    #[test]\\n    fn test_escape_json_string() {\\n        assert_eq!(escape_json_string(\\\"hello\\\\n\\\"), \\\"hello\\\\\\\\n\\\");\\n        assert_eq!(escape_json_string(\\\"\\\\\\\"quote\\\\\\\"\\\"), \\\"\\\\\\\\\\\\\\\"quote\\\\\\\\\\\\\\\"\\\");\\n        assert_eq!(escape_json_string(\\\"tab\\\\there\\\"), \\\"tab\\\\\\\\there\\\");\\n    }\\n\\n    #[test]\\n    fn test_is_valid_json_string() {\\n        assert!(is_valid_json_string(\\\"hello\\\"));\\n        assert!(is_valid_json_string(\\\"hello\\\\\\\\n\\\"));\\n        assert!(!is_valid_json_string(\\\"hello\\\\\\\"\\\"));\\n    }\\n\\n    #[test]\\n    #[ignore = \\\"json escaping needs review\\\"]\\n    fn test_fix_common_json_issues() {\\n        let input = \\\"{\\\\n\\\\\\\"key\\\\\\\": \\\\\\\"value\\\\\\\"\\\\n}\\\\n{\\\\n\\\\\\\"key2\\\\\\\": \\\\\\\"value2\\\\\\\"}\\\";\\n        let expected = \\\"{\\\\n\\\\\\\"key\\\\\\\": \\\\\\\"value\\\\\\\"\\\\n},\\\\n{\\\\n\\\\\\\"key2\\\\\\\": \\\\\\\"value2\\\\\\\"}\\\";\\n        assert_eq!(fix_common_json_issues(input), expected);\\n    }\\n}\\n`\"\n }\n ]\n}"},"done_reason":"stop","done":true,"total_duration":26626992825,"load_duration":33005595,"prompt_eval_count":2048,"prompt_eval_duration":1021000000,"eval_count":679,"eval_duration":25541000000}
+2025-02-02T22:39:42.395435Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:39:42.430743185Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 679,
+"eval_duration": 25541000000,
+"load_duration": 33005595,
+"message": {
+"content": "{\n \"changes\": [\n {\n \"analysis\": \"The test `test_fix_common_json_issues` is currently ignored due to a need for review of JSON escaping.\",\n \"replace\": \"`rust\\n#[cfg(test)]\\nmod tests {\\n    use super::*;\\n\\n    #[test]\\n    fn test_escape_json_string() {\\n        assert_eq!(escape_json_string(\\\"hello\\\\n\\\"), \\\"hello\\\\\\\\n\\\");\\n        assert_eq!(escape_json_string(\\\"\\\\\\\"quote\\\\\\\"\\\"), \\\"\\\\\\\\\\\\\\\"quote\\\\\\\\\\\\\\\"\\\");\\n        assert_eq!(escape_json_string(\\\"tab\\\\there\\\"), \\\"tab\\\\\\\\there\\\");\\n    }\\n\\n    #[test]\\n    fn test_is_valid_json_string() {\\n        assert!(is_valid_json_string(\\\"hello\\\"));\\n        assert!(is_valid_json_string(\\\"hello\\\\\\\\n\\\"));\\n        assert!(!is_valid_json_string(\\\"hello\\\\\\\"\\\"));\\n    }\\n\\n    #[test]\\n    fn test_fix_common_json_issues() {\\n        let input = \\\"{\\\\n\\\\\\\"key\\\\\\\": \\\\\\\"value\\\\\\\"\\\\n}\\\\n{\\\\n\\\\\\\"key2\\\\\\\": \\\\\\\"value2\\\\\\\"}\\\";\\n        let expected = \\\"{\\\\n\\\\\\\"key\\\\\\\": \\\\\\\"value\\\\\\\"\\\\n},\\\\n{\\\\n\\\\\\\"key2\\\\\\\": \\\\\\\"value2\\\\\\\"}\\\";\\n        assert_eq!(fix_common_json_issues(input), expected);\\n    }\\n}\\n`\"\n ,\n \"search\": \"`rust\\n#[cfg(test)]\\nmod tests {\\n    use super::*;\\n\\n    #[test]\\n    fn test_escape_json_string() {\\n        assert_eq!(escape_json_string(\\\"hello\\\\n\\\"), \\\"hello\\\\\\\\n\\\");\\n        assert_eq!(escape_json_string(\\\"\\\\\\\"quote\\\\\\\"\\\"), \\\"\\\\\\\\\\\\\\\"quote\\\\\\\\\\\\\\\"\\\");\\n        assert_eq!(escape_json_string(\\\"tab\\\\there\\\"), \\\"tab\\\\\\\\there\\\");\\n    }\\n\\n    #[test]\\n    fn test_is_valid_json_string() {\\n        assert!(is_valid_json_string(\\\"hello\\\"));\\n        assert!(is_valid_json_string(\\\"hello\\\\\\\\n\\\"));\\n        assert!(!is_valid_json_string(\\\"hello\\\\\\\"\\\"));\\n    }\\n\\n    #[test]\\n    #[ignore = \\\"json escaping needs review\\\"]\\n    fn test_fix_common_json_issues() {\\n        let input = \\\"{\\\\n\\\\\\\"key\\\\\\\": \\\\\\\"value\\\\\\\"\\\\n}\\\\n{\\\\n\\\\\\\"key2\\\\\\\": \\\\\\\"value2\\\\\\\"}\\\";\\n        let expected = \\\"{\\\\n\\\\\\\"key\\\\\\\": \\\\\\\"value\\\\\\\"\\\\n},\\\\n{\\\\n\\\\\\\"key2\\\\\\\": \\\\\\\"value2\\\\\\\"}\\\";\\n        assert_eq!(fix_common_json_issues(input), expected);\\n    }\\n}\\n`\"\n }\n ]\n}",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1021000000,
+"total_duration": 26626992825
+}
+2025-02-02T22:39:42.395619Z INFO openagents::server::services::ollama::service: Extracted content: {
+"changes": [
+{
+"analysis": "The test `test_fix_common_json_issues` is currently ignored due to a need for review of JSON escaping.",
+"replace": "`rust\n#[cfg(test)]\nmod tests {\n    use super::*;\n\n    #[test]\n    fn test_escape_json_string() {\n        assert_eq!(escape_json_string(\"hello\\n\"), \"hello\\\\n\");\n        assert_eq!(escape_json_string(\"\\\"quote\\\"\"), \"\\\\\\\"quote\\\\\\\"\");\n        assert_eq!(escape_json_string(\"tab\\there\"), \"tab\\\\there\");\n    }\n\n    #[test]\n    fn test_is_valid_json_string() {\n        assert!(is_valid_json_string(\"hello\"));\n        assert!(is_valid_json_string(\"hello\\\\n\"));\n        assert!(!is_valid_json_string(\"hello\\\"\"));\n    }\n\n    #[test]\n    fn test_fix_common_json_issues() {\n        let input = \"{\\n\\\"key\\\": \\\"value\\\"\\n}\\n{\\n\\\"key2\\\": \\\"value2\\\"}\";\n        let expected = \"{\\n\\\"key\\\": \\\"value\\\"\\n},\\n{\\n\\\"key2\\\": \\\"value2\\\"}\";\n        assert_eq!(fix_common_json_issues(input), expected);\n    }\n}\n`"
+,
+"search": "`rust\n#[cfg(test)]\nmod tests {\n    use super::*;\n\n    #[test]\n    fn test_escape_json_string() {\n        assert_eq!(escape_json_string(\"hello\\n\"), \"hello\\\\n\");\n        assert_eq!(escape_json_string(\"\\\"quote\\\"\"), \"\\\\\\\"quote\\\\\\\"\");\n        assert_eq!(escape_json_string(\"tab\\there\"), \"tab\\\\there\");\n    }\n\n    #[test]\n    fn test_is_valid_json_string() {\n        assert!(is_valid_json_string(\"hello\"));\n        assert!(is_valid_json_string(\"hello\\\\n\"));\n        assert!(!is_valid_json_string(\"hello\\\"\"));\n    }\n\n    #[test]\n    #[ignore = \"json escaping needs review\"]\n    fn test_fix_common_json_issues() {\n        let input = \"{\\n\\\"key\\\": \\\"value\\\"\\n}\\n{\\n\\\"key2\\\": \\\"value2\\\"}\";\n        let expected = \"{\\n\\\"key\\\": \\\"value\\\"\\n},\\n{\\n\\\"key2\\\": \\\"value2\\\"}\";\n        assert_eq!(fix_common_json_issues(input), expected);\n    }\n}\n`"
+}
+]
+}
+2025-02-02T22:39:42.396231Z INFO solver::solver_impl::changes: Processing file:
+2025-02-02T22:39:42.396262Z INFO solver::solver_impl::changes: Relative path: src/solver/config.rs
+2025-02-02T22:39:42.396282Z INFO solver::solver_impl::changes: Absolute path: /Users/christopherdavid/code/openagents/src/solver/config.rs
+2025-02-02T22:39:42.397428Z INFO openagents::server::services::ollama::service: Sending request to Ollama
+2025-02-02T22:40:07.480881Z INFO openagents::server::services::ollama::service: Raw response from Ollama: {"model":"mistral-small","created_at":"2025-02-02T22:40:07.461966663Z","message":{"role":"assistant","content":"{\n \"changes\": [\n {\n \"analysis\": \"Add a new field `deepseek_api_key` to the Config struct and update the load method to include this new key.\",\n \"replace\": \"use anyhow::{anyhow, Result};\\nuse dotenvy::dotenv;\\nuse std::env;\\n\\npub struct Config {\\n pub openrouter_api_key: String,\\n pub github_token: String,\\n pub deepseek_api_key: String,\\n}\\n\\nimpl Config {\\n pub fn load() -\u003e Result\u003cSelf\u003e {\\n // Load .env file first\\n if let Err(e) = dotenv() {\\n return Err(anyhow!(\\\"Failed to load .env file: {}\\\", e));\\n }\\n\\n // Get API keys immediately and fail if not present\\n let openrouter_api_key = env::var(\\\"OPENROUTER_API_KEY\\\")\\n .map_err(|*| anyhow!(\\\"OPENROUTER*API_KEY not found in environment or .env file\\\"))?;\\n\\n let github_token = env::var(\\\"GITHUB_TOKEN\\\")\\n .map_err(|*| anyhow!(\\\"GITHUB*TOKEN not found in environment or .env file\\\"))?;\\n\\n let deepseek_api_key = env::var(\\\"DEEPSEEK_API_KEY\\\")\\n .map_err(|*| anyhow!(\\\"DEEPSEEK*API_KEY not found in environment or .env file\\\"))?;\\n\\n Ok(Self {\\n openrouter_api_key,\\n github_token,\\n deepseek_api_key,\\n })\\n }\\n}\",\n \"search\": \"use anyhow::{anyhow, Result};\\nuse dotenvy::dotenv;\\nuse std::env;\\n\\npub struct Config {\\n pub openrouter_api_key: String,\\n pub github_token: String,\\n}\\n\\nimpl Config {\\n pub fn load() -\u003e Result\u003cSelf\u003e {\\n // Load .env file first\\n if let Err(e) = dotenv() {\\n return Err(anyhow!(\\\"Failed to load .env file: {}\\\", e));\\n }\\n\\n // Get API keys immediately and fail if not present\\n let openrouter_api_key = env::var(\\\"OPENROUTER_API_KEY\\\")\\n .map_err(|*| anyhow!(\\\"OPENROUTER*API_KEY not found in environment or .env file\\\"))?;\\n\\n let github_token = env::var(\\\"GITHUB_TOKEN\\\")\\n .map_err(|*| anyhow!(\\\"GITHUB*TOKEN not found in environment or .env file\\\"))?;\\n\\n Ok(Self {\\n openrouter_api_key,\\n github_token,\\n })\\n }\\n}\"\n }\n ]\n}"},"done_reason":"stop","done":true,"total_duration":24990204884,"load_duration":33594923,"prompt_eval_count":2048,"prompt_eval_duration":1029000000,"eval_count":635,"eval_duration":23887000000}
+2025-02-02T22:40:07.481402Z INFO openagents::server::services::ollama::service: Parsed JSON response: {
+"created_at": "2025-02-02T22:40:07.461966663Z",
+"done": true,
+"done_reason": "stop",
+"eval_count": 635,
+"eval_duration": 23887000000,
+"load_duration": 33594923,
+"message": {
+"content": "{\n \"changes\": [\n {\n \"analysis\": \"Add a new field `deepseek_api_key` to the Config struct and update the load method to include this new key.\",\n \"replace\": \"use anyhow::{anyhow, Result};\\nuse dotenvy::dotenv;\\nuse std::env;\\n\\npub struct Config {\\n pub openrouter_api_key: String,\\n pub github_token: String,\\n pub deepseek_api_key: String,\\n}\\n\\nimpl Config {\\n pub fn load() -> Result<Self> {\\n // Load .env file first\\n if let Err(e) = dotenv() {\\n return Err(anyhow!(\\\"Failed to load .env file: {}\\\", e));\\n }\\n\\n // Get API keys immediately and fail if not present\\n let openrouter_api_key = env::var(\\\"OPENROUTER_API_KEY\\\")\\n .map_err(|*| anyhow!(\\\"OPENROUTER*API_KEY not found in environment or .env file\\\"))?;\\n\\n let github_token = env::var(\\\"GITHUB_TOKEN\\\")\\n .map_err(|*| anyhow!(\\\"GITHUB*TOKEN not found in environment or .env file\\\"))?;\\n\\n let deepseek_api_key = env::var(\\\"DEEPSEEK_API_KEY\\\")\\n .map_err(|*| anyhow!(\\\"DEEPSEEK*API_KEY not found in environment or .env file\\\"))?;\\n\\n Ok(Self {\\n openrouter_api_key,\\n github_token,\\n deepseek_api_key,\\n })\\n }\\n}\",\n \"search\": \"use anyhow::{anyhow, Result};\\nuse dotenvy::dotenv;\\nuse std::env;\\n\\npub struct Config {\\n pub openrouter_api_key: String,\\n pub github_token: String,\\n}\\n\\nimpl Config {\\n pub fn load() -> Result<Self> {\\n // Load .env file first\\n if let Err(e) = dotenv() {\\n return Err(anyhow!(\\\"Failed to load .env file: {}\\\", e));\\n }\\n\\n // Get API keys immediately and fail if not present\\n let openrouter_api_key = env::var(\\\"OPENROUTER_API_KEY\\\")\\n .map_err(|*| anyhow!(\\\"OPENROUTER*API_KEY not found in environment or .env file\\\"))?;\\n\\n let github_token = env::var(\\\"GITHUB_TOKEN\\\")\\n .map_err(|*| anyhow!(\\\"GITHUB*TOKEN not found in environment or .env file\\\"))?;\\n\\n Ok(Self {\\n openrouter_api_key,\\n github_token,\\n })\\n }\\n}\"\n }\n ]\n}",
+"role": "assistant"
+},
+"model": "mistral-small",
+"prompt_eval_count": 2048,
+"prompt_eval_duration": 1029000000,
+"total_duration": 24990204884
+}
+2025-02-02T22:40:07.481660Z INFO openagents::server::services::ollama::service: Extracted content: {
+"changes": [
+{
+"analysis": "Add a new field `deepseek_api_key` to the Config struct and update the load method to include this new key.",
+"replace": "use anyhow::{anyhow, Result};\nuse dotenvy::dotenv;\nuse std::env;\n\npub struct Config {\n pub openrouter_api_key: String,\n pub github_token: String,\n pub deepseek_api_key: String,\n}\n\nimpl Config {\n pub fn load() -> Result<Self> {\n // Load .env file first\n if let Err(e) = dotenv() {\n return Err(anyhow!(\"Failed to load .env file: {}\", e));\n }\n\n // Get API keys immediately and fail if not present\n let openrouter_api_key = env::var(\"OPENROUTER_API_KEY\")\n .map_err(|*| anyhow!(\"OPENROUTER*API_KEY not found in environment or .env file\"))?;\n\n let github_token = env::var(\"GITHUB_TOKEN\")\n .map_err(|*| anyhow!(\"GITHUB*TOKEN not found in environment or .env file\"))?;\n\n let deepseek_api_key = env::var(\"DEEPSEEK_API_KEY\")\n .map_err(|*| anyhow!(\"DEEPSEEK*API_KEY not found in environment or .env file\"))?;\n\n Ok(Self {\n openrouter_api_key,\n github_token,\n deepseek_api_key,\n })\n }\n}",
+"search": "use anyhow::{anyhow, Result};\nuse dotenvy::dotenv;\nuse std::env;\n\npub struct Config {\n pub openrouter_api_key: String,\n pub github_token: String,\n}\n\nimpl Config {\n pub fn load() -> Result<Self> {\n // Load .env file first\n if let Err(e) = dotenv() {\n return Err(anyhow!(\"Failed to load .env file: {}\", e));\n }\n\n // Get API keys immediately and fail if not present\n let openrouter_api_key = env::var(\"OPENROUTER_API_KEY\")\n .map_err(|*| anyhow!(\"OPENROUTER*API_KEY not found in environment or .env file\"))?;\n\n let github_token = env::var(\"GITHUB_TOKEN\")\n .map_err(|*| anyhow!(\"GITHUB_TOKEN not found in environment or .env file\"))?;\n\n Ok(Self {\n openrouter_api_key,\n github_token,\n })\n }\n}"
+}
+]
+}
+2025-02-02T22:40:07.481931Z INFO solver: Changes generated
+2025-02-02T22:40:07.481955Z INFO solver::solver_impl::changes: Applying code changes...
+2025-02-02T22:40:07.482059Z INFO openagents::solver::changes::apply: Applying changes to files...
+2025-02-02T22:40:07.482082Z INFO openagents::solver::changes::apply: Processing changes for src/bin/solver.rs
+2025-02-02T22:40:07.482879Z ERROR openagents::solver::changes::apply: No matches found for search pattern in /Users/christopherdavid/code/openagents/src/bin/solver.rs
+2025-02-02T22:40:07.482906Z ERROR openagents::solver::changes::apply: Failed to apply change to src/bin/solver.rs: No matching content found in file
+Error: Failed to apply changes: No matching content found in file

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -23,7 +23,7 @@ The main function:
 
 1. Initializes logging
 2. Parses command line arguments
-3. Loads environment variables (GITHUB_TOKEN, OLLAMA_URL)
+3. Loads environment variables (GITHUB_TOKEN, OLLAMA_URL, DEEPSEEK_API_KEY)
 4. Initializes the GitHub service
 5. Fetches issue details
 6. Generates repository map
@@ -38,7 +38,23 @@ The `handle_issue` function:
 3. Fetches issue comments
 4. Returns issue and comments for analysis
 
-### 3. Planning Phase (`src/bin/solver_impl/planning.rs`)
+### 3. File Identification (`src/bin/solver_impl/files.rs` and `pre_analysis.rs`)
+
+The file identification process now uses a two-step approach:
+
+1. DeepSeek Pre-Analysis:
+   - Streams real-time reasoning about which files need modification
+   - Shows step-by-step thinking process
+   - Provides detailed analysis with reasoning
+   - Supports up to 10 files with relevance scores (1-10)
+
+2. Mistral Structured Output:
+   - Takes DeepSeek's analysis and reasoning
+   - Formats the output as structured JSON
+   - Validates file paths against repository
+   - Normalizes relevance scores for internal use
+
+### 4. Planning Phase (`src/bin/solver_impl/planning.rs`)
 
 The `handle_planning` function:
 
@@ -48,7 +64,7 @@ The `handle_planning` function:
 4. Extracts and validates JSON plan from markdown response
 5. Returns the validated plan
 
-### 4. Solution Generation (`src/bin/solver_impl/solution.rs`)
+### 5. Solution Generation (`src/bin/solver_impl/solution.rs`)
 
 The `handle_solution` function:
 
@@ -59,7 +75,7 @@ The `handle_solution` function:
    - Applies changes to file
 3. Returns success/failure status
 
-### 5. Core Library Components
+### 6. Core Library Components
 
 #### Changes Management (`src/solver/changes/`)
 
@@ -87,28 +103,35 @@ The `handle_solution` function:
 
 1. User Input → CLI
 2. CLI → GitHub API (fetch issue)
-3. Issue → Planning Context
-4. Planning Context → AI Model
-5. AI Model → Implementation Plan
-6. Plan → Solution Generator
-7. Solution Generator → File Changes
+3. Issue → DeepSeek Pre-Analysis
+4. DeepSeek → Reasoning Stream + Analysis
+5. Analysis → Mistral (structured output)
+6. Mistral → Implementation Plan
+7. Plan → Solution Generator
 8. Changes → GitHub PR
 
 ## Key Components
 
-### 1. Planning Context
+### 1. DeepSeek Pre-Analysis
+
+- Provides real-time reasoning about file selection
+- Shows step-by-step thinking process
+- Handles up to 10 files with 1-10 relevance scores
+- Streams tokens in real-time to console
+
+### 2. Planning Context
 
 - Manages AI model interaction
 - Generates structured implementation plans
 - Handles streaming responses
 
-### 2. Solution Context
+### 3. Solution Context
 
 - Manages file modifications
 - Applies changes safely
 - Validates changes
 
-### 3. GitHub Context
+### 4. GitHub Context
 
 - Manages repository operations
 - Creates branches and PRs
@@ -119,7 +142,8 @@ The `handle_solution` function:
 The solver requires:
 
 1. `GITHUB_TOKEN`: For GitHub API access
-2. `OLLAMA_URL`: For AI model access (default: http://localhost:11434)
+2. `OLLAMA_URL`: For Mistral model access (default: http://localhost:11434)
+3. `DEEPSEEK_API_KEY`: For DeepSeek API access
 
 ## Modes
 

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -1,219 +1,24 @@
 # OpenAgents Solver Documentation
 
-The OpenAgents Solver is a system that automatically solves GitHub issues by analyzing the problem, generating an implementation plan, and creating a pull request with the solution. This document explains how the solver works and the flow of execution.
-
-## Architecture Overview
-
-The solver is split into two main parts:
-
-1. CLI Interface (`src/bin/solver.rs` and `src/bin/solver_impl/*`)
-2. Core Library (`src/solver/*`)
-
-## Execution Flow
-
-### 1. Entry Point (`src/bin/solver.rs`)
-
-The process begins when a user runs:
-
-```bash
-cargo run --bin solver -- --issue <number> [--repo owner/name] [--live]
-```
+[previous content unchanged until environment variables section...]
 
 The main function:
 
 1. Initializes logging
 2. Parses command line arguments
-3. Loads environment variables (GITHUB_TOKEN, OLLAMA_URL, DEEPSEEK_API_KEY)
+3. Loads environment variables (GITHUB_TOKEN, OLLAMA_URL)
 4. Initializes the GitHub service
 5. Fetches issue details
 6. Generates repository map
 7. Orchestrates the planning and solution phases
 
-### 2. Issue Analysis (`src/bin/solver_impl/issue.rs`)
-
-The `handle_issue` function:
-
-1. Initializes GitHub context
-2. Fetches issue details
-3. Fetches issue comments
-4. Returns issue and comments for analysis
-
-### 3. File Identification (`src/bin/solver_impl/files.rs` and `pre_analysis.rs`)
-
-The file identification process now uses a two-step approach:
-
-1. DeepSeek Pre-Analysis:
-   - Streams real-time reasoning about which files need modification
-   - Shows step-by-step thinking process
-   - Provides detailed analysis with reasoning
-   - Supports up to 10 files with relevance scores (1-10)
-
-2. Mistral Structured Output:
-   - Takes DeepSeek's analysis and reasoning
-   - Formats the output as structured JSON
-   - Validates file paths against repository
-   - Normalizes relevance scores for internal use
-
-### 4. Planning Phase (`src/bin/solver_impl/planning.rs`)
-
-The `handle_planning` function:
-
-1. Creates a PlanningContext with Ollama URL
-2. Generates implementation plan using AI model
-3. Streams the response for real-time updates
-4. Extracts and validates JSON plan from markdown response
-5. Returns the validated plan
-
-### 5. Solution Generation (`src/bin/solver_impl/solution.rs`)
-
-The `handle_solution` function:
-
-1. Generates list of files to modify
-2. For each file:
-   - Reads current content
-   - Generates changes using AI model
-   - Applies changes to file
-3. Returns success/failure status
-
-### 6. Core Library Components
-
-#### Changes Management (`src/solver/changes/`)
-
-- `generation.rs`: Generates code changes using AI
-- `parsing.rs`: Parses search/replace blocks
-- `types.rs`: Defines change types and structures
-
-#### File Management
-
-- `file_list.rs`: Generates list of files to modify
-- `context.rs`: Manages repository context and operations
-
-#### GitHub Integration
-
-- `github.rs`: Handles GitHub API interactions
-- `types.rs`: Defines GitHub-related types
-
-#### Planning & Execution
-
-- `planning.rs`: Implementation plan generation
-- `solution.rs`: Solution application logic
-- `streaming.rs`: Handles streaming responses
-
-## Data Flow
-
-1. User Input → CLI
-2. CLI → GitHub API (fetch issue)
-3. Issue → DeepSeek Pre-Analysis
-4. DeepSeek → Reasoning Stream + Analysis
-5. Analysis → Mistral (structured output)
-6. Mistral → Implementation Plan
-7. Plan → Solution Generator
-8. Changes → GitHub PR
-
-## Key Components
-
-### 1. DeepSeek Pre-Analysis
-
-- Provides real-time reasoning about file selection
-- Shows step-by-step thinking process
-- Handles up to 10 files with 1-10 relevance scores
-- Streams tokens in real-time to console
-
-### 2. Planning Context
-
-- Manages AI model interaction
-- Generates structured implementation plans
-- Handles streaming responses
-
-### 3. Solution Context
-
-- Manages file modifications
-- Applies changes safely
-- Validates changes
-
-### 4. GitHub Context
-
-- Manages repository operations
-- Creates branches and PRs
-- Posts comments and updates
+[rest of content unchanged until Configuration section...]
 
 ## Configuration
 
 The solver requires:
 
 1. `GITHUB_TOKEN`: For GitHub API access
-2. `OLLAMA_URL`: For Mistral model access (default: http://localhost:11434)
-3. `DEEPSEEK_API_KEY`: For DeepSeek API access
+2. `OLLAMA_URL`: For model access (default: http://localhost:11434)
 
-## Modes
-
-1. **Dry Run Mode** (default)
-
-   - Shows what would be done
-   - Doesn't create branches or PRs
-   - Prints plan locally
-
-2. **Live Mode** (`--live`)
-   - Creates branch
-   - Applies changes
-   - Creates PR
-   - Posts comments
-
-## Error Handling
-
-The solver implements comprehensive error handling:
-
-1. Environment validation
-2. GitHub API error handling
-3. File operation safety checks
-4. AI model response validation
-5. JSON plan validation
-
-## Future Extensions
-
-1. WebSocket Integration
-
-   - Real-time status updates
-   - Progress tracking
-   - Error notifications
-
-2. Conversation History
-
-   - Complex problem tracking
-   - Multi-step solutions
-   - User feedback integration
-
-3. Error Recovery
-   - Automatic retries
-   - Fallback strategies
-   - State recovery
-
-## Testing
-
-The solver includes extensive tests:
-
-1. Unit tests for each component
-2. Integration tests for full flow
-3. Mock AI responses
-4. GitHub API mocks
-5. File operation tests
-
-## Usage Examples
-
-Basic usage:
-
-```bash
-cargo run --bin solver -- --issue 123
-```
-
-With custom repository:
-
-```bash
-cargo run --bin solver -- --issue 123 --repo owner/name
-```
-
-Live mode:
-
-```bash
-cargo run --bin solver -- --issue 123 --live
-```
+[rest of the document unchanged...]

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -1,6 +1,23 @@
 # OpenAgents Solver Documentation
 
-[previous content unchanged until environment variables section...]
+The OpenAgents Solver is a system that automatically solves GitHub issues by analyzing the problem, generating an implementation plan, and creating a pull request with the solution. This document explains how the solver works and the flow of execution.
+
+## Architecture Overview
+
+The solver is split into two main parts:
+
+1. CLI Interface (`src/bin/solver.rs` and `src/bin/solver_impl/*`)
+2. Core Library (`src/solver/*`)
+
+## Execution Flow
+
+### 1. Entry Point (`src/bin/solver.rs`)
+
+The process begins when a user runs:
+
+```bash
+cargo run --bin solver -- --issue <number> [--repo owner/name] [--live]
+```
 
 The main function:
 
@@ -12,7 +29,113 @@ The main function:
 6. Generates repository map
 7. Orchestrates the planning and solution phases
 
-[rest of content unchanged until Configuration section...]
+### 2. Issue Analysis (`src/bin/solver_impl/issue.rs`)
+
+The `handle_issue` function:
+
+1. Initializes GitHub context
+2. Fetches issue details
+3. Fetches issue comments
+4. Returns issue and comments for analysis
+
+### 3. File Identification (`src/bin/solver_impl/files.rs` and `pre_analysis.rs`)
+
+The file identification process now uses a two-step approach:
+
+1. DeepSeek Pre-Analysis:
+   - Streams real-time reasoning about which files need modification
+   - Shows step-by-step thinking process
+   - Provides detailed analysis with reasoning
+   - Supports up to 10 files with relevance scores (1-10)
+
+2. Mistral Structured Output:
+   - Takes DeepSeek's analysis and reasoning
+   - Formats the output as structured JSON
+   - Validates file paths against repository
+   - Normalizes relevance scores for internal use
+
+### 4. Planning Phase (`src/bin/solver_impl/planning.rs`)
+
+The `handle_planning` function:
+
+1. Creates a PlanningContext with Ollama URL
+2. Generates implementation plan using AI model
+3. Streams the response for real-time updates
+4. Extracts and validates JSON plan from markdown response
+5. Returns the validated plan
+
+### 5. Solution Generation (`src/bin/solver_impl/solution.rs`)
+
+The `handle_solution` function:
+
+1. Generates list of files to modify
+2. For each file:
+   - Reads current content
+   - Generates changes using AI model
+   - Applies changes to file
+3. Returns success/failure status
+
+### 6. Core Library Components
+
+#### Changes Management (`src/solver/changes/`)
+
+- `generation.rs`: Generates code changes using AI
+- `parsing.rs`: Parses search/replace blocks
+- `types.rs`: Defines change types and structures
+
+#### File Management
+
+- `file_list.rs`: Generates list of files to modify
+- `context.rs`: Manages repository context and operations
+
+#### GitHub Integration
+
+- `github.rs`: Handles GitHub API interactions
+- `types.rs`: Defines GitHub-related types
+
+#### Planning & Execution
+
+- `planning.rs`: Implementation plan generation
+- `solution.rs`: Solution application logic
+- `streaming.rs`: Handles streaming responses
+
+## Data Flow
+
+1. User Input → CLI
+2. CLI → GitHub API (fetch issue)
+3. Issue → DeepSeek Pre-Analysis
+4. DeepSeek → Reasoning Stream + Analysis
+5. Analysis → Mistral (structured output)
+6. Mistral → Implementation Plan
+7. Plan → Solution Generator
+8. Changes → GitHub PR
+
+## Key Components
+
+### 1. DeepSeek Pre-Analysis
+
+- Provides real-time reasoning about file selection
+- Shows step-by-step thinking process
+- Handles up to 10 files with 1-10 relevance scores
+- Streams tokens in real-time to console
+
+### 2. Planning Context
+
+- Manages AI model interaction
+- Generates structured implementation plans
+- Handles streaming responses
+
+### 3. Solution Context
+
+- Manages file modifications
+- Applies changes safely
+- Validates changes
+
+### 4. GitHub Context
+
+- Manages repository operations
+- Creates branches and PRs
+- Posts comments and updates
 
 ## Configuration
 
@@ -21,4 +144,75 @@ The solver requires:
 1. `GITHUB_TOKEN`: For GitHub API access
 2. `OLLAMA_URL`: For model access (default: http://localhost:11434)
 
-[rest of the document unchanged...]
+## Modes
+
+1. **Dry Run Mode** (default)
+
+   - Shows what would be done
+   - Doesn't create branches or PRs
+   - Prints plan locally
+
+2. **Live Mode** (`--live`)
+   - Creates branch
+   - Applies changes
+   - Creates PR
+   - Posts comments
+
+## Error Handling
+
+The solver implements comprehensive error handling:
+
+1. Environment validation
+2. GitHub API error handling
+3. File operation safety checks
+4. AI model response validation
+5. JSON plan validation
+
+## Future Extensions
+
+1. WebSocket Integration
+
+   - Real-time status updates
+   - Progress tracking
+   - Error notifications
+
+2. Conversation History
+
+   - Complex problem tracking
+   - Multi-step solutions
+   - User feedback integration
+
+3. Error Recovery
+   - Automatic retries
+   - Fallback strategies
+   - State recovery
+
+## Testing
+
+The solver includes extensive tests:
+
+1. Unit tests for each component
+2. Integration tests for full flow
+3. Mock AI responses
+4. GitHub API mocks
+5. File operation tests
+
+## Usage Examples
+
+Basic usage:
+
+```bash
+cargo run --bin solver -- --issue 123
+```
+
+With custom repository:
+
+```bash
+cargo run --bin solver -- --issue 123 --repo owner/name
+```
+
+Live mode:
+
+```bash
+cargo run --bin solver -- --issue 123 --live
+```

--- a/src/bin/solver_impl/files.rs
+++ b/src/bin/solver_impl/files.rs
@@ -1,22 +1,38 @@
 use crate::solver_impl::types::RelevantFiles;
 use anyhow::Result;
+use openagents::server::services::deepseek::DeepSeekService;
 use openagents::server::services::ollama::OllamaService;
 use openagents::solver::state::{SolverState, SolverStatus};
 use std::collections::HashSet;
 use tracing::{debug, error, info};
 
+use super::pre_analysis::analyze_with_deepseek;
+
 pub async fn identify_files(
     state: &mut SolverState,
     mistral: &OllamaService,
+    deepseek: &DeepSeekService,
     valid_paths: &HashSet<String>,
 ) -> Result<()> {
-    info!("Identifying relevant files...");
+    info!("Starting file identification process...");
     state.update_status(SolverStatus::Thinking);
 
+    // First get DeepSeek's analysis
+    let (response, reasoning) = analyze_with_deepseek(state, deepseek, valid_paths).await?;
+
+    // Now use Mistral to structure the output
     let prompt = format!(
-        "Based on this analysis, suggest up to 3 most relevant files that need to be modified. Return a JSON object with a 'files' array containing objects with 'path' (relative path, no leading slash), 'relevance_score' (0-1), and 'reason' fields.\n\nIMPORTANT: You MUST ONLY use paths from this list:\n{}\n\nAnalysis:\n{}", 
+        "Based on this analysis from another AI, suggest up to 10 most relevant files that need to be modified. \
+        Return a JSON object with a 'files' array containing objects with 'path' (relative path, no leading slash), \
+        'relevance_score' (1-10, where 10 is most relevant), and 'reason' fields.\n\n\
+        IMPORTANT: You MUST ONLY use paths from this list:\n{}\n\n\
+        Analysis:\n{}\n\n\
+        Previous AI's Analysis:\n{}\n\n\
+        Previous AI's Reasoning Process:\n{}", 
         valid_paths.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("\n"),
-        state.analysis
+        state.analysis,
+        response,
+        reasoning
     );
 
     let format = serde_json::json!({
@@ -32,8 +48,8 @@ pub async fn identify_files(
                         },
                         "relevance_score": {
                             "type": "number",
-                            "minimum": 0,
-                            "maximum": 1
+                            "minimum": 1,
+                            "maximum": 10
                         },
                         "reason": {
                             "type": "string"
@@ -41,7 +57,7 @@ pub async fn identify_files(
                     },
                     "required": ["path", "relevance_score", "reason"]
                 },
-                "maxItems": 3
+                "maxItems": 10
             }
         },
         "required": ["files"]
@@ -59,7 +75,9 @@ pub async fn identify_files(
         // Only add if path is in valid_paths
         if valid_paths.contains(&file.path) {
             debug!("Adding valid file: {}", file.path);
-            state.add_file(file.path, file.reason, file.relevance_score);
+            // Convert relevance score from 1-10 to 0-1 for state storage
+            let normalized_score = file.relevance_score / 10.0;
+            state.add_file(file.path, file.reason, normalized_score);
         } else {
             error!("Skipping invalid file path: {}", file.path);
         }

--- a/src/bin/solver_impl/mod.rs
+++ b/src/bin/solver_impl/mod.rs
@@ -1,4 +1,5 @@
 pub mod changes;
 pub mod context;
 pub mod files;
+pub mod pre_analysis;
 pub mod types;

--- a/src/bin/solver_impl/pre_analysis.rs
+++ b/src/bin/solver_impl/pre_analysis.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use openagents::server::services::deepseek::{DeepSeekService, StreamUpdate};
+use openagents::solver::state::{SolverState, SolverStatus};
+use std::collections::HashSet;
+use std::io::Write;
+use tracing::{debug, info};
+
+pub async fn analyze_with_deepseek(
+    state: &mut SolverState,
+    deepseek: &DeepSeekService,
+    valid_paths: &HashSet<String>,
+) -> Result<(String, String)> {
+    info!("Starting DeepSeek pre-analysis...");
+    state.update_status(SolverStatus::Thinking);
+
+    let prompt = format!(
+        "You are a code analysis expert. Based on this analysis, think through which files would need to be modified. \
+        Show your reasoning process step by step.\n\n\
+        IMPORTANT: You MUST ONLY consider paths from this list:\n{}\n\n\
+        Analysis:\n{}\n\n\
+        Think through this step by step, explaining your reasoning. \
+        At the end, provide a final conclusion listing the most relevant files (up to 10) with their relevance scores (1-10, where 10 is most relevant) \
+        and reasons for modification.",
+        valid_paths.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("\n"),
+        state.analysis
+    );
+
+    debug!("Sending prompt to DeepSeek...");
+    let mut stream = deepseek.chat_stream(prompt, true).await;
+    let mut full_response = String::new();
+    let mut reasoning = String::new();
+
+    println!("\nThinking process:\n");
+    while let Some(update) = stream.recv().await {
+        match update {
+            StreamUpdate::Content(content) => {
+                print!("{}", content);
+                std::io::stdout().flush()?;
+                full_response.push_str(&content);
+            }
+            StreamUpdate::Reasoning(r) => {
+                print!("{}", r);
+                std::io::stdout().flush()?;
+                reasoning.push_str(&r);
+            }
+            StreamUpdate::Done => break,
+            _ => {}
+        }
+    }
+
+    println!("\nDeepSeek analysis complete.\n");
+    debug!("Full response: {}", full_response);
+    debug!("Reasoning trace: {}", reasoning);
+
+    Ok((full_response, reasoning))
+}


### PR DESCRIPTION
This PR adds a DeepSeek pre-analysis step to the solver to improve reasoning capabilities while maintaining structured output format.

Key changes:
1. Added DeepSeek streaming analysis before Mistral's structured output
2. Increased max files from 3 to 10
3. Changed relevance scores from 0-1 to 1-10 (10 being most relevant)
4. Shows real-time token streaming of DeepSeek's reasoning process

The new flow:
1. DeepSeek analyzes the issue and thinks through file modifications, streaming its reasoning in real-time
2. Both the reasoning trace and final analysis are passed to Mistral
3. Mistral formats the output as structured JSON with up to 10 files and 1-10 relevance scores
4. The solver continues with the validated file list

This gives us better reasoning capabilities from DeepSeek while maintaining Mistral's reliable structured output format.

Closes #659