### PR TITLE
fix: update dependencies to address OpenSSL vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ bitcoin_hashes = "0.12"
 secp256k1 = { version = "0.27", features = ["rand", "bitcoin_hashes", "global-context"] }
 chrono = "0.4"
 lazy_static = "1.4"
-sqlx = { version = "0.8.1", features = ["time", "uuid", "runtime-tokio", "postgres", "json", "tls-native-tls", "bigdecimal"] }
+sqlx = { version = "0.8.3", features = ["time", "uuid", "runtime-tokio", "postgres", "json", "tls-native-tls", "bigdecimal"] }
 config = "0.14"
 secrecy = { version = "0.8", features = ["serde"] }
 tracing = { version = "0.1", features = ["log"] }
@@ -53,7 +53,7 @@ axum-extra = { version = "0.9.2", features = ["cookie"] }
 tower = "0.5.2"
 tower-http = { version = "0.6.2", features = ["fs", "trace", "cors"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-reqwest = { version = "0.11", features = ["json", "stream", "multipart", "blocking"] }
+reqwest = { version = "0.11.27", features = ["json", "stream", "multipart", "blocking"] }
 pulldown-cmark = "0.9"
 askama_escape = "0.1"
 bytes = "1.5"


### PR DESCRIPTION
Fixes RUSTSEC-2025-0004: OpenSSL vulnerability in ssl::select_next_proto

Updates the following dependencies to get the fixed OpenSSL version (>=0.10.70):
- sqlx from 0.8.1 to 0.8.3
- reqwest to 0.11.27 (explicit version)

This addresses the use-after-free vulnerability in OpenSSL's ssl::select_next_proto function that could potentially cause crashes or memory disclosure.