### PR TITLE
Fix signup flow to include email parameter

### DIFF
--- a/src/server/services/auth.rs
+++ b/src/server/services/auth.rs
@@ -102,7 +102,7 @@ impl OIDCService {
         Ok(url)
     }
 
-    pub fn authorization_url_for_signup(&self) -> Result<String, AuthError> {
+    pub fn authorization_url_for_signup(&self, email: &str) -> Result<String, AuthError> {
         let mut url = format!(
             "{}?client_id={}&redirect_uri={}&response_type=code&scope=openid",
             self.config.auth_url,
@@ -110,6 +110,7 @@ impl OIDCService {
             urlencoding::encode(&self.config.redirect_uri)
         );
         url.push_str("&prompt=create");
+        url.push_str(&format!("&email={}", urlencoding::encode(email)));
         Ok(url)
     }
 

--- a/tests/oidc_signup.rs
+++ b/tests/oidc_signup.rs
@@ -47,11 +47,12 @@ async fn test_signup_authorization_url() {
     let mock_server = MockServer::start().await;
     let service = create_test_service(mock_server.uri()).await;
 
-    let url = service.authorization_url_for_signup().unwrap();
+    let url = service.authorization_url_for_signup("test@example.com").unwrap();
 
     assert!(url.contains("response_type=code"));
     assert!(url.contains("prompt=create"));
     assert!(url.contains("scope=openid"));
+    assert!(url.contains("email=test%40example.com"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR fixes the signup flow by adding the required email parameter when redirecting to pseudoidc.

Changes:
1. Updated `authorization_url_for_signup` to require an email parameter
2. Modified the signup handler to accept email in the request body
3. Updated tests to include email parameter in URL generation test

This fixes the "Email required for signup" error we were seeing in pseudoidc.

Related:
- Fixes #655
- Related to pseudoidc#30