### PR TITLE
Fix login form submission URL

### DIFF
--- a/docs/repomap.md
+++ b/docs/repomap.md
@@ -159,11 +159,11 @@ src/repo/types.rs:
 src/repomap.rs:
 │#id: test
 │fn generate_repo_map
-│fn 
+│fn
 │fn extract_id
 │fn extract_function_name
-│fn 
-│fn 
+│fn
+│fn
 │fn extract_class_name
 │fn extract_const_name
 │fn init_logging
@@ -175,15 +175,15 @@ src/repomap.rs:
 │fn test_extractors
 │fn test_func
 │class in
-│class 
-│class 
-│class 
-│class 
+│class
+│class
+│class
+│class
 │class TestClass
 │const DEFAULT_BLACKLIST
-│const 
-│const 
-│const 
+│const
+│const
+│const
 │const TEST_CONST
 
 src/routes.rs:
@@ -514,7 +514,7 @@ src/solver/types.rs:
 │fn test_change_error_equality
 
 tailwind.config.cjs:
-│const 
+│const
 
 templates/admin/dashboard.html:
 │#id: bg
@@ -614,7 +614,7 @@ templates/layouts/content.html:
 │#id: content
 
 templates/macros/ui.html:
-│class 
+│class
 
 templates/pages/company.html:
 │class of
@@ -871,4 +871,3 @@ tests/tool_selection.rs:
 tests/user.rs:
 │fn test_user_creation
 │fn create_test_user
-

--- a/docs/repomap.md
+++ b/docs/repomap.md
@@ -159,11 +159,11 @@ src/repo/types.rs:
 src/repomap.rs:
 │#id: test
 │fn generate_repo_map
-│fn
+│fn 
 │fn extract_id
 │fn extract_function_name
-│fn
-│fn
+│fn 
+│fn 
 │fn extract_class_name
 │fn extract_const_name
 │fn init_logging
@@ -175,15 +175,15 @@ src/repomap.rs:
 │fn test_extractors
 │fn test_func
 │class in
-│class
-│class
-│class
-│class
+│class 
+│class 
+│class 
+│class 
 │class TestClass
 │const DEFAULT_BLACKLIST
-│const
-│const
-│const
+│const 
+│const 
+│const 
 │const TEST_CONST
 
 src/routes.rs:
@@ -206,17 +206,32 @@ src/server/config.rs:
 │fn configure_app
 │fn configure_app_with_config
 
-src/server/handlers/auth.rs:
+src/server/handlers/auth/forms.rs:
 │fn deserialize_checkbox
+│fn validate
+
+src/server/handlers/auth/login.rs:
+│fn login_page
+│fn handle_login
+│fn handle_login_callback
+
+src/server/handlers/auth/mod.rs:
 │fn new
-│fn login
-│fn signup
-│fn handle_signup
+│fn handle_auth_error
 │fn callback
-│fn create_session_and_redirect
-│fn logout
 │const SESSION_COOKIE_NAME
 │const SESSION_DURATION_DAYS
+
+src/server/handlers/auth/session.rs:
+│fn create_session_and_redirect
+│fn clear_session_and_redirect
+│fn render_login_template
+│fn render_signup_template
+
+src/server/handlers/auth/signup.rs:
+│fn signup_page
+│fn handle_signup
+│fn handle_signup_callback
 
 src/server/handlers/user.rs:
 │fn create_user
@@ -499,7 +514,7 @@ src/solver/types.rs:
 │fn test_change_error_equality
 
 tailwind.config.cjs:
-│const
+│const 
 
 templates/admin/dashboard.html:
 │#id: bg
@@ -599,7 +614,7 @@ templates/layouts/content.html:
 │#id: content
 
 templates/macros/ui.html:
-│class
+│class 
 
 templates/pages/company.html:
 │class of
@@ -607,14 +622,22 @@ templates/pages/company.html:
 templates/pages/login.html:
 │#id: auth-error
 │#id: auth-error-message
+│#id: loading-spinner
+│#id: login-form
 │#id: email
 │#id: password
 │#id: remember-me
 │const errorDiv
 │const errorMessage
 │const errorDiv
+│const spinner
+│const spinner
 │const errorMessages
 │const message
+│const formData
+│const response
+│const location
+│const data
 
 templates/pages/repomap.html:
 │#id: repo_url
@@ -848,3 +871,4 @@ tests/tool_selection.rs:
 tests/user.rs:
 │fn test_user_creation
 │fn create_test_user
+

--- a/templates/pages/login.html
+++ b/templates/pages/login.html
@@ -135,7 +135,12 @@
           });
       </script>
 
-      <form id="login-form" class="space-y-6" method="POST" action="/auth/login">
+      <form
+        id="login-form"
+        class="space-y-6"
+        method="POST"
+        action="/auth/login"
+      >
         <div>
           <label for="email" class="block text-sm font-medium text-gray-700">
             Email address

--- a/templates/pages/login.html
+++ b/templates/pages/login.html
@@ -135,7 +135,7 @@
           });
       </script>
 
-      <form id="login-form" class="space-y-6" method="POST">
+      <form id="login-form" class="space-y-6" method="POST" action="/auth/login">
         <div>
           <label for="email" class="block text-sm font-medium text-gray-700">
             Email address


### PR DESCRIPTION
This PR fixes an issue where the login form was submitting to `/login` instead of `/auth/login`, causing a 405 Method Not Allowed error.

Changes:
- Added explicit `action="/auth/login"` attribute to the login form
- Form now correctly submits to the endpoint with POST handler
- Maintains existing JavaScript fetch handler which was already using correct URL

This fixes issue #616 where the login form was getting a 405 error due to submitting to the wrong endpoint.