### PR TITLE
Add mobile deep linking support for GitHub auth callback

### DIFF
--- a/src/server/handlers/auth/github.rs
+++ b/src/server/handlers/auth/github.rs
@@ -1,6 +1,6 @@
 use axum::{
-    extract::State,
-    http::StatusCode,
+    extract::{Query, State},
+    http::{header, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -16,6 +16,8 @@ use crate::server::{
 #[derive(Debug, Deserialize)]
 pub struct GitHubCallback {
     code: String,
+    #[serde(default)]
+    platform: Option<String>,
 }
 
 pub async fn github_login_page() -> Response {
@@ -23,32 +25,46 @@ pub async fn github_login_page() -> Response {
 }
 
 #[axum::debug_handler]
-pub async fn handle_github_login(State(state): State<AppState>) -> Response {
+pub async fn handle_github_login(
+    State(state): State<AppState>,
+    Query(params): Query<GitHubCallback>,
+) -> Response {
     info!("Handling GitHub login request");
     
-    match state.github_auth.authorization_url() {
-        Ok(url) => Response::builder()
-            .status(StatusCode::TEMPORARY_REDIRECT)
-            .header("Location", url)
-            .body(axum::body::Body::empty())
-            .unwrap(),
+    // Add platform to authorization URL if provided
+    let mut url = match state.github_auth.authorization_url() {
+        Ok(url) => url,
         Err(e) => {
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
+    };
+
+    // Append platform parameter if provided
+    if let Some(platform) = params.platform {
+        url.push_str(&format!("&platform={}", platform));
     }
+
+    Response::builder()
+        .status(StatusCode::TEMPORARY_REDIRECT)
+        .header(header::LOCATION, url)
+        .body(axum::body::Body::empty())
+        .unwrap()
 }
 
 #[axum::debug_handler]
 pub async fn handle_github_callback(
     State(state): State<AppState>,
-    Json(callback): Json<GitHubCallback>,
+    Query(callback): Query<GitHubCallback>,
 ) -> Response {
     info!("Handling GitHub callback");
 
+    // Check if request is from mobile app
+    let is_mobile = callback.platform.as_deref() == Some("mobile");
+
     match state.github_auth.authenticate(callback.code).await {
-        Ok(user) => create_session_and_redirect(user).await,
+        Ok(user) => create_session_and_redirect(user, is_mobile).await,
         Err(GitHubAuthError::UserAlreadyExists(user)) => {
-            create_session_and_redirect(user).await
+            create_session_and_redirect(user, is_mobile).await
         }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }

--- a/src/server/handlers/auth/login.rs
+++ b/src/server/handlers/auth/login.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::State,
+    extract::{Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     Json,
@@ -16,6 +16,8 @@ pub async fn login_page() -> Response {
 #[derive(Debug, Deserialize)]
 pub struct LoginRequest {
     pub email: String,
+    #[serde(default)]
+    pub platform: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -49,16 +51,26 @@ pub async fn handle_login(
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LoginCallbackRequest {
+    pub code: String,
+    #[serde(default)]
+    pub platform: Option<String>,
+}
+
 pub async fn handle_login_callback(
     State(state): State<AppState>,
-    Json(code): Json<String>,
+    Query(request): Query<LoginCallbackRequest>,
 ) -> Response {
-    info!("Processing login callback with code length: {}", code.len());
+    info!("Processing login callback with code length: {}", request.code.len());
 
-    match state.auth_state.service.login(code).await {
+    // Check if request is from mobile app
+    let is_mobile = request.platform.as_deref() == Some("mobile");
+
+    match state.auth_state.service.login(request.code).await {
         Ok(user) => {
             info!("Successfully logged in user: {:?}", user);
-            super::session::create_session_and_redirect(user).await
+            super::session::create_session_and_redirect(user, is_mobile).await
         }
         Err(e) => {
             info!("Login failed: {}", e);

--- a/src/server/handlers/auth/mod.rs
+++ b/src/server/handlers/auth/mod.rs
@@ -33,6 +33,8 @@ pub const SESSION_DURATION_DAYS: i64 = 7;
 pub struct CallbackParams {
     pub code: String,
     pub flow: Option<String>, // Optional flow parameter to distinguish login vs signup
+    #[serde(default)]
+    pub platform: Option<String>, // Optional platform parameter to detect mobile
 }
 
 #[derive(Debug, Serialize)]
@@ -78,6 +80,7 @@ pub async fn callback(
 ) -> Response {
     info!("Received callback with code length: {}", params.code.len());
     info!("Flow parameter: {:?}", params.flow);
+    info!("Platform parameter: {:?}", params.platform);
 
     // Determine if this is a signup flow
     let is_signup = params.flow.as_deref() == Some("signup");
@@ -85,6 +88,9 @@ pub async fn callback(
         "Callback flow: {}",
         if is_signup { "signup" } else { "login" }
     );
+
+    // Check if request is from mobile app
+    let is_mobile = params.platform.as_deref() == Some("mobile");
 
     // Use appropriate service method based on flow
     let result = if is_signup {
@@ -98,12 +104,12 @@ pub async fn callback(
     match result {
         Ok(user) => {
             info!("Successfully processed user: {:?}", user);
-            create_session_and_redirect(user).await
+            create_session_and_redirect(user, is_mobile).await
         }
         Err(e) => match e {
             AuthError::UserAlreadyExists(user) => {
                 info!("User already exists, creating session and redirecting");
-                create_session_and_redirect(user).await
+                create_session_and_redirect(user, is_mobile).await
             }
             other_error => {
                 error!("Authentication error: {}", &other_error);


### PR DESCRIPTION
This PR adds support for mobile deep linking in the GitHub OAuth callback handler. When the auth flow is initiated from the mobile app, the callback will redirect to `onyx://auth/success?token=SESSION_TOKEN` instead of the web redirect.

Changes:
1. Updated `create_session_and_redirect` to support mobile deep linking
2. Added platform detection in GitHub callback handler
3. Modified GitHub login to preserve platform parameter

Testing:
1. Start auth flow from mobile app with `platform=mobile`
2. Complete GitHub OAuth
3. Verify redirect to `onyx://auth/success` with session token
4. Verify web flow still works without changes

Fixes OpenAgentsInc/onyx#76