### PR TITLE
fix: Remove SSR, serve SPA only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,11 @@ WORKDIR /app/frontend
 COPY frontend/ ./
 RUN npm install -g pnpm
 RUN pnpm install
+RUN echo "Building frontend..."
 RUN pnpm run build
+RUN echo "Verifying frontend build..."
+RUN ls -la build/client
+RUN test -f build/client/index.html || (echo "index.html not found" && exit 1)
 
 FROM debian:bookworm-slim AS runtime
 WORKDIR /app
@@ -37,7 +41,6 @@ RUN apt-get update -y \
 COPY --from=builder /app/backend/target/release/openagents openagents
 COPY --from=builder /app/backend/assets assets
 COPY --from=frontend-builder /app/frontend/build/client ./client
-COPY --from=frontend-builder /app/frontend/build/server ./server
 COPY backend/configuration configuration
 ENV APP_ENVIRONMENT production
 ENTRYPOINT ["./openagents"]


### PR DESCRIPTION
Closes #720

This PR simplifies our deployment by removing server-side rendering and serving only the static SPA.

Key changes:
- Removed the COPY command for the server build since we're not using SSR anymore
- Kept only the client build files which contain our static SPA
- Added build verification steps in Dockerfile
- No changes needed to spec.yaml since it's already configured to serve from root path

Everything is properly configured for a static SPA setup:
- Frontend builds static files
- Backend serves static files and handles API routes
- Docker setup only includes necessary files
- All routes fall back to index.html for client-side routing

This simplifies our deployment and reduces complexity by:
1. Eliminating the need for Express server
2. Reducing the number of moving parts
3. Simplifying the routing setup
4. Maintaining a clean separation between frontend and backend

The Rust server will handle:
- Serving static files from /client
- API routes under /api
- Fallback to index.html for client-side routing