### PR TITLE
Add Agent Earnings screen to Onyx wallet

### DIFF
--- a/apps/onyx/app/navigators/WalletNavigator.tsx
+++ b/apps/onyx/app/navigators/WalletNavigator.tsx
@@ -4,6 +4,7 @@ import { SendScreen } from "@/screens/WalletScreen/SendScreen"
 import { ReceiveScreen } from "@/screens/WalletScreen/ReceiveScreen"
 import { BackupWalletScreen } from "@/screens/WalletScreen/BackupWalletScreen"
 import { RestoreWalletScreen } from "@/screens/WalletScreen/RestoreWalletScreen"
+import { AgentEarningsScreen } from "@/screens/WalletScreen/AgentEarningsScreen"
 
 export type WalletStackParamList = {
   WalletMain: undefined
@@ -11,6 +12,7 @@ export type WalletStackParamList = {
   Receive: undefined
   BackupWallet: undefined
   RestoreWallet: undefined
+  AgentEarnings: undefined
 }
 
 const Stack = createNativeStackNavigator<WalletStackParamList>()
@@ -28,6 +30,7 @@ export const WalletNavigator = () => {
       <Stack.Screen name="Receive" component={ReceiveScreen} />
       <Stack.Screen name="BackupWallet" component={BackupWalletScreen} />
       <Stack.Screen name="RestoreWallet" component={RestoreWalletScreen} />
+      <Stack.Screen name="AgentEarnings" component={AgentEarningsScreen} />
     </Stack.Navigator>
   )
 }

--- a/apps/onyx/app/screens/WalletScreen/AgentEarningsScreen.tsx
+++ b/apps/onyx/app/screens/WalletScreen/AgentEarningsScreen.tsx
@@ -1,0 +1,240 @@
+import { observer } from "mobx-react-lite"
+import { FC } from "react"
+import { ScrollView, StyleSheet, TextStyle, TouchableOpacity, View, ViewStyle } from "react-native"
+import { Button, Icon, Screen, Text } from "@/components"
+import { useHeader } from "@/hooks/useHeader"
+import { goBack } from "@/navigators/navigationUtilities"
+import { typography } from "@/theme"
+import { colors } from "@/theme/colorsDark"
+import Money from "./Money"
+
+interface EarningsCategory {
+  id: string
+  name: string
+  amount: number
+  percentage: number
+  icon: string
+  description: string
+}
+
+const mockEarnings: EarningsCategory[] = [
+  {
+    id: "mcp",
+    name: "MCP Server Usage",
+    amount: 2000,
+    percentage: 40,
+    icon: "server",
+    description: "Earnings from providing compute resources",
+  },
+  {
+    id: "plugin",
+    name: "Agent Plugin",
+    amount: 1500,
+    percentage: 30,
+    icon: "extension",
+    description: "Earnings from your agent plugins",
+  },
+  {
+    id: "referral",
+    name: "Referral Rewards",
+    amount: 1000,
+    percentage: 20,
+    icon: "people",
+    description: "Earnings from referred users",
+  },
+  {
+    id: "content",
+    name: "Content Creation",
+    amount: 500,
+    percentage: 10,
+    icon: "edit",
+    description: "Earnings from content contributions",
+  },
+]
+
+export const AgentEarningsScreen: FC = observer(function AgentEarningsScreen() {
+  useHeader({
+    title: "Agent Earnings",
+    leftIcon: "back",
+    onLeftPress: goBack,
+  })
+
+  const totalEarnings = mockEarnings.reduce((sum, category) => sum + category.amount, 0)
+
+  return (
+    <Screen style={$root} preset="scroll">
+      <View style={$container}>
+        <View style={$totalSection}>
+          <Text text="Total Earnings" style={$totalLabel} />
+          <Money sats={totalEarnings} symbol={true} />
+          <View style={$periodSelector}>
+            <Button
+              text="Week"
+              style={[$periodButton, $periodButtonActive]}
+              textStyle={$periodButtonText}
+            />
+            <Button text="Month" style={$periodButton} textStyle={$periodButtonText} />
+            <Button text="Year" style={$periodButton} textStyle={$periodButtonText} />
+            <Button text="All" style={$periodButton} textStyle={$periodButtonText} />
+          </View>
+        </View>
+
+        <Text text="Earnings Breakdown" style={$sectionHeader} />
+        <ScrollView style={$categoriesList}>
+          {mockEarnings.map((category) => (
+            <TouchableOpacity key={category.id} style={$categoryItem}>
+              <View style={$categoryHeader}>
+                <View style={$categoryLeft}>
+                  <Icon icon={category.icon as any} color="white" size={24} />
+                  <View style={$categoryInfo}>
+                    <Text text={category.name} style={$categoryName} />
+                    <Text text={category.description} style={$categoryDescription} />
+                  </View>
+                </View>
+                <Text text={`${category.amount} sats`} style={$categoryAmount} />
+              </View>
+              <View style={$progressContainer}>
+                <View style={[$progressBar, { width: `${category.percentage}%` }]} />
+              </View>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+
+        <View style={$actionsContainer}>
+          <Button
+            text="View Details"
+            style={$actionButton}
+            LeftAccessory={() => <Icon icon="analytics" color="white" size={20} />}
+          />
+          <Button
+            text="Withdraw"
+            style={$actionButton}
+            LeftAccessory={() => <Icon icon="download" color="white" size={20} />}
+          />
+        </View>
+      </View>
+    </Screen>
+  )
+})
+
+const $root: ViewStyle = {
+  flex: 1,
+}
+
+const $container: ViewStyle = {
+  flex: 1,
+  padding: 16,
+}
+
+const $totalSection: ViewStyle = {
+  alignItems: "center",
+  marginBottom: 32,
+}
+
+const $totalLabel: TextStyle = {
+  color: colors.palette.accent100,
+  fontSize: 16,
+  marginBottom: 8,
+  fontFamily: typography.primary.medium,
+}
+
+const $periodSelector: ViewStyle = {
+  flexDirection: "row",
+  marginTop: 16,
+  gap: 8,
+}
+
+const $periodButton: ViewStyle = {
+  paddingHorizontal: 16,
+  paddingVertical: 8,
+  backgroundColor: colors.palette.neutral700,
+  borderRadius: 20,
+  minWidth: 70,
+}
+
+const $periodButtonActive: ViewStyle = {
+  backgroundColor: colors.palette.accent200,
+}
+
+const $periodButtonText: TextStyle = {
+  fontSize: 14,
+  fontFamily: typography.primary.medium,
+}
+
+const $sectionHeader: TextStyle = {
+  color: colors.palette.accent100,
+  fontSize: 16,
+  marginBottom: 16,
+  fontFamily: typography.primary.medium,
+}
+
+const $categoriesList: ViewStyle = {
+  flex: 1,
+}
+
+const $categoryItem: ViewStyle = {
+  backgroundColor: colors.palette.neutral800,
+  borderRadius: 12,
+  padding: 16,
+  marginBottom: 12,
+}
+
+const $categoryHeader: ViewStyle = {
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center",
+  marginBottom: 12,
+}
+
+const $categoryLeft: ViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  flex: 1,
+}
+
+const $categoryInfo: ViewStyle = {
+  marginLeft: 12,
+  flex: 1,
+}
+
+const $categoryName: TextStyle = {
+  color: "white",
+  fontSize: 16,
+  fontFamily: typography.primary.medium,
+  marginBottom: 4,
+}
+
+const $categoryDescription: TextStyle = {
+  color: colors.palette.neutral400,
+  fontSize: 12,
+  fontFamily: typography.primary.normal,
+}
+
+const $categoryAmount: TextStyle = {
+  color: "white",
+  fontSize: 16,
+  fontFamily: typography.primary.medium,
+}
+
+const $progressContainer: ViewStyle = {
+  height: 4,
+  backgroundColor: colors.palette.neutral700,
+  borderRadius: 2,
+  overflow: "hidden",
+}
+
+const $progressBar: ViewStyle = {
+  height: "100%",
+  backgroundColor: colors.palette.accent200,
+}
+
+const $actionsContainer: ViewStyle = {
+  flexDirection: "row",
+  justifyContent: "space-between",
+  gap: 16,
+  marginTop: 24,
+}
+
+const $actionButton: ViewStyle = {
+  flex: 1,
+}

--- a/apps/onyx/app/screens/WalletScreen/AgentEarningsScreen.tsx
+++ b/apps/onyx/app/screens/WalletScreen/AgentEarningsScreen.tsx
@@ -7,6 +7,7 @@ import { goBack } from "@/navigators/navigationUtilities"
 import { typography } from "@/theme"
 import { colors } from "@/theme/colorsDark"
 import Money from "./Money"
+import MoneySmall from "./MoneySmall"
 
 interface EarningsCategory {
   id: string
@@ -66,7 +67,7 @@ export const AgentEarningsScreen: FC = observer(function AgentEarningsScreen() {
       <View style={$container}>
         <View style={$totalSection}>
           <Text text="Total Earnings" style={$totalLabel} />
-          <Money sats={totalEarnings} symbol={true} />
+          <Money sats={totalEarnings} symbol={true} size="display" style={$totalMoneyStyle} />
           <View style={$periodSelector}>
             <Button
               text="Week"
@@ -91,7 +92,13 @@ export const AgentEarningsScreen: FC = observer(function AgentEarningsScreen() {
                     <Text text={category.description} style={$categoryDescription} />
                   </View>
                 </View>
-                <Text text={`${category.amount} sats`} style={$categoryAmount} />
+                <View style={$categoryAmountContainer}>
+                  <MoneySmall
+                    sats={category.amount}
+                    symbol={true}
+                    style={$moneyStyle}
+                  />
+                </View>
               </View>
               <View style={$progressContainer}>
                 <View style={[$progressBar, { width: `${category.percentage}%` }]} />
@@ -155,8 +162,8 @@ const $periodButton: ViewStyle = {
 }
 
 const $periodButtonActive: ViewStyle = {
-  backgroundColor: colors.palette.accent200,
-  borderColor: "white",
+  backgroundColor: colors.palette.neutral200,
+  borderColor: colors.palette.neutral400,
 }
 
 const $periodButtonText: TextStyle = {
@@ -215,10 +222,13 @@ const $categoryDescription: TextStyle = {
   fontFamily: typography.primary.normal,
 }
 
-const $categoryAmount: TextStyle = {
-  color: "white",
-  fontSize: 16,
-  fontFamily: typography.primary.medium,
+const $categoryAmountContainer: ViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+}
+
+const $moneyStyle: ViewStyle = {
+  marginTop: 0,
 }
 
 const $progressContainer: ViewStyle = {
@@ -242,4 +252,8 @@ const $actionsContainer: ViewStyle = {
 
 const $actionButton: ViewStyle = {
   flex: 1,
+}
+
+const $totalMoneyStyle: ViewStyle = {
+  marginTop: 0,
 }

--- a/apps/onyx/app/screens/WalletScreen/AgentEarningsScreen.tsx
+++ b/apps/onyx/app/screens/WalletScreen/AgentEarningsScreen.tsx
@@ -23,7 +23,7 @@ const mockEarnings: EarningsCategory[] = [
     name: "MCP Server Usage",
     amount: 2000,
     percentage: 40,
-    icon: "server",
+    icon: "computer",
     description: "Earnings from providing compute resources",
   },
   {
@@ -147,13 +147,16 @@ const $periodSelector: ViewStyle = {
 const $periodButton: ViewStyle = {
   paddingHorizontal: 16,
   paddingVertical: 8,
-  backgroundColor: colors.palette.neutral700,
+  backgroundColor: colors.palette.neutral100,
   borderRadius: 20,
   minWidth: 70,
+  borderWidth: 1,
+  borderColor: colors.palette.neutral300,
 }
 
 const $periodButtonActive: ViewStyle = {
   backgroundColor: colors.palette.accent200,
+  borderColor: "white",
 }
 
 const $periodButtonText: TextStyle = {
@@ -173,10 +176,12 @@ const $categoriesList: ViewStyle = {
 }
 
 const $categoryItem: ViewStyle = {
-  backgroundColor: colors.palette.neutral800,
+  backgroundColor: colors.palette.neutral100,
   borderRadius: 12,
   padding: 16,
   marginBottom: 12,
+  borderWidth: 1,
+  borderColor: "white",
 }
 
 const $categoryHeader: ViewStyle = {
@@ -205,7 +210,7 @@ const $categoryName: TextStyle = {
 }
 
 const $categoryDescription: TextStyle = {
-  color: colors.palette.neutral400,
+  color: colors.palette.neutral600,
   fontSize: 12,
   fontFamily: typography.primary.normal,
 }
@@ -218,7 +223,7 @@ const $categoryAmount: TextStyle = {
 
 const $progressContainer: ViewStyle = {
   height: 4,
-  backgroundColor: colors.palette.neutral700,
+  backgroundColor: colors.palette.neutral200,
   borderRadius: 2,
   overflow: "hidden",
 }

--- a/apps/onyx/app/screens/WalletScreen/WalletScreen.tsx
+++ b/apps/onyx/app/screens/WalletScreen/WalletScreen.tsx
@@ -59,6 +59,23 @@ export const WalletScreen: FC = observer(function WalletScreen() {
             )}
           />
         </View>
+        <View style={$buttonRow}>
+          <Button
+            text="Agent Earnings"
+            onPress={() => {
+              navigation.navigate("AgentEarnings")
+            }}
+            style={$earningsButton}
+            LeftAccessory={(props) => (
+              <Icon
+                icon="analytics"
+                color="white"
+                size={20}
+                containerStyle={[$iconContainer, props.style]}
+              />
+            )}
+          />
+        </View>
       </View>
 
       <TransactionsList />
@@ -84,11 +101,17 @@ const $buttonRow: ViewStyle = {
   justifyContent: "center",
   gap: 20,
   paddingHorizontal: 20,
+  marginBottom: 12,
 }
 
 const $actionButton: ViewStyle = {
   flex: 1,
   minWidth: 130,
+}
+
+const $earningsButton: ViewStyle = {
+  flex: 1,
+  minWidth: 280,
 }
 
 const $iconContainer: ViewStyle = {


### PR DESCRIPTION
This PR adds a new Agent Earnings screen to the Onyx wallet, including:

1. New AgentEarningsScreen component with:
   - Total earnings display
   - Time period selector (Week/Month/Year/All)
   - Earnings breakdown by category
   - Progress bars showing relative earnings
   - Action buttons for details and withdrawals

2. Updated WalletNavigator to include the new screen

3. Added "Agent Earnings" button to main wallet screen

The earnings categories include:
- MCP Server Usage
- Agent Plugin
- Referral Rewards
- Content Creation

The screen follows the existing wallet's dark theme and design patterns.

Screenshots:
[Add screenshots here when available]

Testing:
- Navigate to Agent Earnings from main wallet screen
- View mock earnings data
- Test time period selector buttons
- Verify back navigation
- Check responsive layout