### PR TITLE
Add fast thread deletion with toggle and undo functionality

### DIFF
--- a/apps/coder/src/App.tsx
+++ b/apps/coder/src/App.tsx
@@ -5,6 +5,7 @@ import "./localization/i18n";
 import { updateAppLanguage } from "./helpers/language_helpers";
 import { router } from "./routes/router";
 import { RouterProvider } from "@tanstack/react-router";
+import { Toaster } from "./components/ui/sonner";
 
 // Immediately sync theme before any rendering
 (async () => {
@@ -27,5 +28,10 @@ export default function App() {
     updateAppLanguage(i18n);
   }, [i18n]);
 
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <RouterProvider router={router} />
+      <Toaster />
+    </>
+  );
 }

--- a/apps/coder/src/pages/settings/PreferencesPage.tsx
+++ b/apps/coder/src/pages/settings/PreferencesPage.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from "react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useSettings } from "@openagents/core";
+import { toast } from "sonner";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function PreferencesPage() {
+  const { getPreference, setPreference } = useSettings();
+  const [confirmThreadDeletion, setConfirmThreadDeletion] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadPreferences = async () => {
+      try {
+        setIsLoading(true);
+        const shouldConfirm = await getPreference("confirmThreadDeletion", true);
+        setConfirmThreadDeletion(shouldConfirm);
+      } catch (error) {
+        console.error("Error loading preferences:", error);
+        toast.error("Failed to load preferences");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadPreferences();
+  }, [getPreference]);
+
+  const handleToggleConfirmThreadDeletion = async (checked: boolean) => {
+    try {
+      setConfirmThreadDeletion(checked);
+      await setPreference("confirmThreadDeletion", checked);
+      
+      toast.success(
+        checked ? "Thread deletion confirmation enabled" : "Thread deletion confirmation disabled", 
+        { 
+          description: checked 
+            ? "You will be asked to confirm before deleting threads"
+            : "Threads will be deleted instantly with an undo option"
+        }
+      );
+    } catch (error) {
+      console.error("Error saving preference:", error);
+      toast.error("Failed to save preference");
+      // Revert UI state if save fails
+      setConfirmThreadDeletion(!checked);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium">Preferences</h3>
+        <p className="text-sm text-muted-foreground">
+          Customize your application experience
+        </p>
+      </div>
+      
+      <Card>
+        <CardHeader>
+          <CardTitle>Thread Management</CardTitle>
+          <CardDescription>
+            Configure how threads are managed in the application
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between space-x-2">
+            <Label htmlFor="confirmation-toggle" className="flex flex-col space-y-1">
+              <span>Confirm Thread Deletion</span>
+              <span className="font-normal text-sm text-muted-foreground">
+                {confirmThreadDeletion 
+                  ? "You'll be asked to confirm before deleting threads" 
+                  : "Threads will be deleted instantly with an undo option"}
+              </span>
+            </Label>
+            <Switch
+              id="confirmation-toggle"
+              checked={confirmThreadDeletion}
+              onCheckedChange={handleToggleConfirmThreadDeletion}
+              disabled={isLoading}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/coder/src/pages/settings/SettingsLayout.tsx
+++ b/apps/coder/src/pages/settings/SettingsLayout.tsx
@@ -14,7 +14,9 @@ export default function SettingsLayout() {
 
   // Use the proper Tanstack Router location hook
   const location = useLocation();
-  const isPrompts = location.pathname.includes("prompts");
+  const currentPath = location.pathname;
+  const isPrompts = currentPath.includes("prompts");
+  const isPreferences = currentPath.includes("preferences");
 
   return (
     <ScrollArea className="h-screen w-full">
@@ -64,7 +66,7 @@ export default function SettingsLayout() {
                   <Link
                     to="/settings/models"
                     className={`mx-0.5 rounded-md px-4 py-1.5 text-sm font-medium cursor-pointer
-                      ${!isPrompts ? "bg-background text-foreground shadow" : ""}`}
+                      ${currentPath.includes("models") ? "bg-background text-foreground shadow" : ""}`}
                   >
                     Models
                   </Link>
@@ -74,6 +76,13 @@ export default function SettingsLayout() {
                       ${isPrompts ? "bg-background text-foreground shadow" : ""}`}
                   >
                     Prompts
+                  </Link>
+                  <Link
+                    to="/settings/preferences"
+                    className={`mx-0.5 rounded-md px-4 py-1.5 text-sm font-medium cursor-pointer
+                      ${isPreferences ? "bg-background text-foreground shadow" : ""}`}
+                  >
+                    Preferences
                   </Link>
                 </div>
               </div>

--- a/apps/coder/src/routes/routes.tsx
+++ b/apps/coder/src/routes/routes.tsx
@@ -4,6 +4,7 @@ import HomePage from "../pages/HomePage";
 import SettingsLayout from "../pages/settings/SettingsLayout";
 import ModelsPage from "../pages/settings/ModelsPage";
 import PromptsPage from "../pages/settings/PromptsPage";
+import PreferencesPage from "../pages/settings/PreferencesPage";
 
 // TODO: Steps to add a new route:
 // 1. Create a new page component in the '../pages/' directory (e.g., NewPage.tsx)
@@ -48,12 +49,19 @@ export const PromptsSettingsRoute = createRoute({
   component: PromptsPage,
 });
 
+export const PreferencesSettingsRoute = createRoute({
+  getParentRoute: () => SettingsRoute,
+  path: "/preferences",
+  component: PreferencesPage,
+});
+
 // Add all routes to the route tree
 export const rootTree = RootRoute.addChildren([
   HomeRoute,
   SettingsRoute.addChildren([
     SettingsIndexRoute,
     ModelsSettingsRoute,
-    PromptsSettingsRoute
+    PromptsSettingsRoute,
+    PreferencesSettingsRoute
   ])
 ]);

--- a/docs/fast-delete-threads.md
+++ b/docs/fast-delete-threads.md
@@ -1,0 +1,113 @@
+# Fast Thread Deletion Feature
+
+This document covers the implementation of the fast thread deletion feature in OpenAgents, which allows users to toggle between confirmation dialogs and instant deletion for chat threads.
+
+## Overview
+
+The fast thread deletion feature offers users two options for deleting chat threads:
+
+1. **Confirmation Mode (Default)**: A confirmation dialog appears before deleting a thread
+2. **Fast Mode**: Threads are deleted instantly without confirmation, with an undo option available 
+
+This provides flexibility while maintaining a safety net for accidental deletions.
+
+## User Experience
+
+### With Confirmation (Default)
+1. User clicks the delete icon (X) on a thread
+2. A confirmation dialog appears: "Are you sure you want to delete this chat?"
+3. User confirms or cancels the deletion
+4. If confirmed, thread is deleted with a toast notification
+5. Toast provides a 5-second undo option
+
+### Without Confirmation (Fast Mode)
+1. User clicks the delete icon (X) on a thread
+2. Thread is deleted immediately
+3. A toast notification appears with the thread name
+4. Toast provides a 5-second undo option
+
+## Implementation Details
+
+### Settings Storage
+- Preference is stored as `confirmThreadDeletion` in the settings database
+- Default value is `true` (show confirmation)
+- Setting persists across sessions
+
+### Components and Files
+
+#### 1. ThreadList Component
+The main component handling thread deletion logic. Key changes:
+- Added integration with the settings system
+- Implemented conditional confirmation dialog
+- Added toast notifications with undo functionality
+
+#### 2. Preferences Page
+A new settings page allowing users to toggle the confirmation preference:
+- Located at `/settings/preferences`
+- Provides a simple switch toggle with description
+- Shows immediate feedback when changed
+
+#### 3. Routes
+Updated the application routes to include the new preferences page.
+
+### Code Example
+
+The core deletion logic:
+
+```typescript
+// Function to handle thread deletion
+const handleDeleteWithToast = (threadId: string, threadTitle: string) => {
+  // Optimistic update - add to pending deletes first
+  setPendingDeletes(prev => new Set([...prev, threadId]));
+  
+  // Show toast with undo option
+  toast.info(
+    `Chat deleted`,
+    {
+      description: `"${threadTitle || 'Untitled'}" was deleted.`,
+      action: {
+        label: "Undo",
+        onClick: () => {
+          // Remove from pending deletes
+          setPendingDeletes(prev => {
+            const newSet = new Set([...prev]);
+            newSet.delete(threadId);
+            return newSet;
+          });
+          // Refresh to restore the thread in UI
+          refresh();
+        }
+      },
+      duration: 5000
+    }
+  );
+  
+  // Then call the actual delete function
+  onDeleteThread(threadId);
+};
+
+// Use conditional logic based on user preference
+if (confirmThreadDeletion) {
+  // Show confirmation dialog if preference is set
+  if (window.confirm('Are you sure you want to delete this chat?')) {
+    handleDeleteWithToast(thread.id, thread.title);
+  }
+} else {
+  // Delete immediately with toast if confirmation is disabled
+  handleDeleteWithToast(thread.id, thread.title);
+}
+```
+
+## Benefits
+
+- **Increased efficiency** for power users who frequently delete threads
+- **Maintained safety** through the undo option
+- **User preference** respects different workflows
+- **Consistent UX** with modern design patterns
+
+## Future Enhancements
+
+Potential future improvements:
+- Add keyboard shortcuts for deletion and undo
+- Batch deletion of multiple threads
+- Thread archive functionality instead of permanent deletion


### PR DESCRIPTION
This PR implements the fast thread deletion feature requested in #825.

## Changes
- Added new `confirmThreadDeletion` preference to settings
- Implemented conditional confirmation dialog based on user preference
- Added toast notifications with 5-second undo functionality
- Created new preferences page UI for toggling the confirmation setting
- Added documentation in `docs/fast-delete-threads.md`

## Testing
- Confirm that thread deletion works with confirmation dialog when preference is enabled (default)
- Verify instant deletion works when confirmation is disabled
- Test undo functionality within the 5-second window
- Verify preference persists across page reloads
- Check toast notifications appear correctly with thread title
- Ensure settings UI toggle works as expected

## Documentation
See `docs/fast-delete-threads.md` for detailed implementation notes and future enhancement ideas.

Closes #825