### PR TITLE
fix: Remove excessive console logging for story loading

### DIFF
--- a/packages/psionic/src/components/discovery.ts
+++ b/packages/psionic/src/components/discovery.ts
@@ -22,15 +22,12 @@ export async function discoverStories(storiesDir: string): Promise<Array<StoryMo
     const dirExists = await fs.access(storiesPath).then(() => true).catch(() => false)
 
     if (!dirExists) {
-      console.log(`📚 Stories directory not found: ${storiesPath}`)
       return []
     }
 
     // Read all files in stories directory
     const files = await fs.readdir(storiesPath)
     const storyFiles = files.filter((file) => file.endsWith(".story.ts"))
-
-    console.log(`📚 Found ${storyFiles.length} story files in ${storiesPath}`)
 
     // Load each story file
     for (const file of storyFiles) {
@@ -65,7 +62,6 @@ export async function discoverStories(storiesDir: string): Promise<Array<StoryMo
         }
 
         storyModules.push(storyModule)
-        console.log(`📖 Loaded story: ${storyModule.title} (${Object.keys(stories).length} variants)`)
       } catch (error) {
         console.error(`❌ Error loading story file ${file}:`, error)
       }


### PR DESCRIPTION
## Summary
Removes the excessive console logging that occurs when loading story files in the component explorer.

## Changes
- Remove `console.log` for story file discovery count
- Remove `console.log` for each individual story loading
- Keep error logging for debugging purposes

## Before
```
📚 Found 17 story files in /Users/christopherdavid/code/openagents/apps/openagents.com/stories
📖 Loaded story: WebTUI Badge (6 variants)
📖 Loaded story: WebTUI Typography (10 variants)
... (repeated for all stories)
```

## After
Silent loading with only errors displayed if they occur.

🤖 Generated with [Claude Code](https://claude.ai/code)