### PR TITLE
feat: Add launch notice and WIP alerts to docs

### DIFF
--- a/apps/openagents.com/src/routes/docs.ts
+++ b/apps/openagents.com/src/routes/docs.ts
@@ -37,47 +37,7 @@ export function docs() {
           <!-- Docs Content -->
           <div class="docs-layout">
             <div class="docs-sidebar">
-              <div class="docs-menu">
-                <div class="docs-menu-section">
-                  <div class="menu-section-title">Getting Started</div>
-                  <a href="/docs/getting-started" class="docs-menu-link active">
-                    Quick Start Guide
-                  </a>
-                </div>
-                
-                <div class="docs-menu-section">
-                  <div class="menu-section-title">Core Concepts</div>
-                  <a href="/docs/agent-lifecycle" class="docs-menu-link">
-                    Agent Lifecycle
-                  </a>
-                  <a href="/docs/economics" class="docs-menu-link">
-                    Economic Model
-                  </a>
-                  <a href="/docs/bitcoin-integration" class="docs-menu-link">
-                    Bitcoin Integration
-                  </a>
-                </div>
-                
-                <div class="docs-menu-section">
-                  <div class="menu-section-title">API Reference</div>
-                  <a href="/docs/api-reference" class="docs-menu-link">
-                    Complete API Docs
-                  </a>
-                  <a href="/docs/sdk-examples" class="docs-menu-link">
-                    SDK Examples
-                  </a>
-                </div>
-                
-                <div class="docs-menu-section">
-                  <div class="menu-section-title">Support</div>
-                  <a href="/docs/troubleshooting" class="docs-menu-link">
-                    Troubleshooting
-                  </a>
-                  <a href="/docs/faq" class="docs-menu-link">
-                    FAQ
-                  </a>
-                </div>
-              </div>
+              ${docsMenu()}
             </div>
 
             <div class="docs-content-area">
@@ -460,6 +420,15 @@ export const docPage: RouteHandler = async (context) => {
 
               <div class="docs-content-area">
                 <div class="docs-content">
+                  <!-- Work in Progress Alert -->
+                  <div class="wip-alert" box-="square">
+                    <div class="wip-icon">⚠</div>
+                    <div class="wip-message">
+                      <strong>Documentation is a work in progress</strong>
+                      <p>This documentation is in very early stages and actively being developed. Content may be incomplete or subject to change.</p>
+                    </div>
+                  </div>
+
                   <div class="doc-container">
                     <div class="doc-content" box-="square">
                       <article class="doc-article">
@@ -578,6 +547,41 @@ export const docPage: RouteHandler = async (context) => {
 
           .docs-content {
             max-width: 800px;
+          }
+
+          /* Work in Progress Alert */
+          .wip-alert {
+            background: var(--background1);
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+            display: flex;
+            gap: 1.5rem;
+            align-items: flex-start;
+          }
+
+          .wip-icon {
+            font-size: 2rem;
+            color: var(--foreground2);
+            line-height: 1;
+            flex-shrink: 0;
+          }
+
+          .wip-message {
+            flex: 1;
+          }
+
+          .wip-message strong {
+            display: block;
+            color: var(--foreground0);
+            font-size: 1rem;
+            margin-bottom: 0.5rem;
+          }
+
+          .wip-message p {
+            margin: 0;
+            color: var(--foreground1);
+            font-size: 0.875rem;
+            line-height: 1.5;
           }
 
           .doc-container {

--- a/apps/openagents.com/src/routes/home.ts
+++ b/apps/openagents.com/src/routes/home.ts
@@ -13,8 +13,20 @@ export function home() {
 
         <!-- Main Content -->
         <main class="homepage-main">
-          <div class="centered-card" box-="square">
-            <div class="card-title">OpenAgents</div>
+          <div class="launch-notice" box-="square">
+            <div class="notice-title">※ Welcome to our new site</div>
+            <div class="notice-content">
+              <p>We're launching a few new products on <strong>Saturday June 21</strong>.</p>
+              <p>In the meantime, explore our resources:</p>
+              <div class="notice-links">
+                <a href="/blog" is-="button" variant-="foreground1" box-="square">
+                  Read our Blog →
+                </a>
+                <a href="/docs" is-="button" variant-="foreground1" box-="square">
+                  View Documentation →
+                </a>
+              </div>
+            </div>
           </div>
         </main>
       </div>
@@ -60,29 +72,60 @@ export function home() {
           overflow: hidden;
         }
 
-        .centered-card {
+        .launch-notice {
           text-align: center;
           padding: 3rem 4rem;
           background: var(--background1);
-          min-width: 300px;
+          min-width: 400px;
+          max-width: 600px;
         }
 
-        .card-title {
-          margin: 0;
-          font-size: 2.5rem;
+        .notice-title {
+          margin: 0 0 2rem 0;
+          font-size: 2rem;
           font-weight: 700;
           color: var(--foreground0);
         }
 
+        .notice-content {
+          color: var(--foreground1);
+        }
+
+        .notice-content p {
+          margin: 1rem 0;
+          line-height: 1.6;
+        }
+
+        .notice-content strong {
+          color: var(--foreground0);
+          font-weight: 600;
+        }
+
+        .notice-links {
+          display: flex;
+          gap: 1.5rem;
+          justify-content: center;
+          margin-top: 2.5rem;
+        }
+
+        .notice-links a {
+          text-decoration: none;
+        }
+
         /* Responsive */
         @media (max-width: 768px) {
-          .centered-card {
+          .launch-notice {
             padding: 2rem;
             min-width: 250px;
           }
 
-          .card-title {
-            font-size: 2rem;
+          .notice-title {
+            font-size: 1.5rem;
+          }
+
+          .notice-links {
+            flex-direction: column;
+            gap: 1rem;
           }
         }
       </style>


### PR DESCRIPTION
## Summary
- Replace homepage OpenAgents card with launch notice for June 21 products
- Add work-in-progress alert on all documentation child pages
- Fix docs navigation to use shared component and remove broken links

## Changes
- Updated homepage with launch notice including links to blog and docs
- Added WIP alert banner with warning icon on documentation pages
- Consolidated docs navigation into shared `docsMenu` component
- Removed references to deleted documentation pages (agent-lifecycle, economics, etc.)

## Test plan
- [x] Homepage displays launch notice with links
- [x] Docs index page uses updated navigation menu
- [x] Documentation child pages show WIP alert
- [x] All navigation links work correctly
- [x] Responsive design works on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)