### PR TITLE
refactor: Remove zinc light theme

### DIFF
--- a/apps/openagents.com/src/components/shared-header.ts
+++ b/apps/openagents.com/src/components/shared-header.ts
@@ -15,8 +15,7 @@ export function sharedHeader({ current }: HeaderOptions = {}) {
           <a href="/blog" class="nav-link ${current === "blog" ? "active" : ""}">¶ Blog</a>
           <div class="theme-switcher-container">
             <select id="theme-select" class="theme-select" onchange="switchTheme(this.value)">
-              <option value="zinc">Zinc Dark</option>
-              <option value="zinc-light">Zinc Light</option>
+              <option value="zinc">Zinc</option>
               <option value="catppuccin">Catppuccin</option>
               <option value="gruvbox">Gruvbox</option>
               <option value="nord">Nord</option>
@@ -136,7 +135,7 @@ export function sharedHeader({ current }: HeaderOptions = {}) {
         console.log('Switching to theme:', theme);
         
         // Remove existing theme classes
-        document.body.classList.remove('theme-zinc', 'theme-zinc-light', 'theme-catppuccin', 'theme-gruvbox', 'theme-nord');
+        document.body.classList.remove('theme-zinc', 'theme-catppuccin', 'theme-gruvbox', 'theme-nord');
         
         // Add new theme class
         document.body.classList.add('theme-' + theme);
@@ -155,10 +154,10 @@ export function sharedHeader({ current }: HeaderOptions = {}) {
         const themeSelect = document.getElementById('theme-select');
         
         if (themeSelect) {
-          // Handle old 'light' value for backwards compatibility
-          if (savedTheme === 'light') {
-            themeSelect.value = 'zinc-light';
-            switchTheme('zinc-light');
+          // Handle old 'light' or 'zinc-light' values for backwards compatibility
+          if (savedTheme === 'light' || savedTheme === 'zinc-light') {
+            themeSelect.value = 'zinc';
+            switchTheme('zinc');
           } else {
             themeSelect.value = savedTheme;
             switchTheme(savedTheme);

--- a/apps/openagents.com/src/styles.ts
+++ b/apps/openagents.com/src/styles.ts
@@ -30,30 +30,6 @@ export const webtuiStyles = css`
     --font-family: "Berkeley Mono", ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
   }
   
-  :root:has(.theme-zinc-light) {
-    --background0: #fafafa;
-    --background1: #f4f4f5;
-    --background2: #e4e4e7;
-    --background3: #d4d4d8;
-    --foreground0: #52525b;
-    --foreground1: #3f3f46;
-    --foreground2: #27272a;
-    --accent: #52525b;
-    --success: #71717a;
-    --warning: #52525b;
-    --danger: #3f3f46;
-    --surface0: #f4f4f5;
-    --surface1: #e4e4e7;
-    --surface2: #d4d4d8;
-    --overlay0: #a1a1aa;
-    --overlay1: #71717a;
-    --overlay2: #52525b;
-    --font-size: 16px;
-    --line-height: 1.3;
-    --font-weight-bold: 700;
-    --font-weight-normal: 400;
-    --font-family: "Berkeley Mono", ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
-  }
   
   :root:has(.theme-catppuccin) {
     --background0: #1e1e2e;


### PR DESCRIPTION
## Summary
- Remove zinc light theme option
- Rename "Zinc Dark" to just "Zinc" in the theme switcher
- Add backwards compatibility for users who had zinc-light saved

## Changes
- Removed zinc-light CSS theme definitions from styles.ts
- Updated theme switcher dropdown to show "Zinc" instead of "Zinc Dark"
- Added migration for users with zinc-light preference to use zinc theme
- Cleaned up theme class removal code

## Test plan
- [x] Theme switcher shows only 4 themes: Zinc, Catppuccin, Gruvbox, Nord
- [x] Zinc theme works correctly
- [x] Users with zinc-light saved preference are migrated to zinc theme
- [x] All theme switching works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)