### PR TITLE
docs: Update roadmap timeline to June 2025

### DIFF
--- a/apps/openagents.com/content/docs/psionic.md
+++ b/apps/openagents.com/content/docs/psionic.md
@@ -1,7 +1,7 @@
 ---
 title: Psionic Framework
 date: 2024-12-17
-summary: Hypermedia web framework for building OpenAgents applications
+summary: Agent-first application framework
 category: guide
 order: 3
 ---

--- a/apps/openagents.com/content/docs/roadmap.md
+++ b/apps/openagents.com/content/docs/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-date: 2024-12-17
+date: 2025-06-18
 summary: Current state and future plans for OpenAgents
 category: guide
 order: 6
@@ -12,7 +12,7 @@ This document outlines the current state of OpenAgents and our vision for the fu
 
 > **Important**: OpenAgents is heavily in development. APIs and features are subject to change.
 
-## Current State (December 2024)
+## Current State (June 2025)
 
 ### ✅ Implemented
 
@@ -64,7 +64,7 @@ This document outlines the current state of OpenAgents and our vision for the fu
 - **Compute management**: Resource allocation stubs
 - **Distributed agents**: Multi-node deployment concepts
 
-## Short Term (Q1 2025)
+## Short Term (Q3 2025)
 
 ### 1. Complete Core Integration
 - [ ] Wire Nostr package into SDK for real key generation
@@ -90,7 +90,7 @@ This document outlines the current state of OpenAgents and our vision for the fu
 - [ ] Architecture deep dives
 - [ ] Migration guides
 
-## Medium Term (Q2-Q3 2025)
+## Medium Term (Q4 2025 - Q1 2026)
 
 ### 1. Lightning Network Integration
 - [ ] Real Lightning invoice generation


### PR DESCRIPTION
## Summary
Update roadmap document to reflect current date of June 2025

## Changes
- Changed current state from "December 2024" to "June 2025"
- Moved short-term goals to Q3 2025
- Adjusted medium-term timeline to Q4 2025 - Q1 2026
- Kept long-term vision at 2026+

## Test plan
- [x] Documentation renders correctly
- [x] Timeline makes sense with current date

🤖 Generated with [Claude Code](https://claude.ai/code)