### PR TITLE
feat: Add llms.txt support with automated generation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup
       - run: pnpm codegen
       - name: Generate llms.txt
-        run: bun run scripts/generate-llms-txt.ts
+        run: pnpm tsx scripts/generate-llms-txt.ts
       - name: Check source state
         run: git add packages/*/src && git diff-index --cached HEAD --exit-code packages/*/src
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/setup
       - run: pnpm codegen
+      - name: Generate llms.txt
+        run: bun run scripts/generate-llms-txt.ts
       - name: Check source state
         run: git add packages/*/src && git diff-index --cached HEAD --exit-code packages/*/src
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup
       - run: pnpm codegen
       - name: Generate llms.txt
-        run: pnpm tsx scripts/generate-llms-txt.ts
+        run: pnpm exec tsx scripts/generate-llms-txt.ts
       - name: Check source state
         run: git add packages/*/src && git diff-index --cached HEAD --exit-code packages/*/src
 

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -22,16 +22,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          bun-version: latest
+          node-version: '20.14.0'
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: bun install
+        run: pnpm install
 
       - name: Generate llms.txt
-        run: bun run scripts/generate-llms-txt.ts
+        run: pnpm tsx scripts/generate-llms-txt.ts
 
       - name: Validate llms.txt format
         run: |

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm install
 
       - name: Generate llms.txt
-        run: pnpm tsx scripts/generate-llms-txt.ts
+        run: pnpm exec tsx scripts/generate-llms-txt.ts
 
       - name: Validate llms.txt format
         run: |

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -1,0 +1,99 @@
+name: Generate llms.txt
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'apps/openagents.com/content/docs/**'
+      - 'scripts/generate-llms-txt.ts'
+      - '.github/workflows/generate-llms-txt.yml'
+  pull_request:
+    paths:
+      - 'apps/openagents.com/content/docs/**'
+      - 'scripts/generate-llms-txt.ts'
+      - '.github/workflows/generate-llms-txt.yml'
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate llms.txt
+        run: bun run scripts/generate-llms-txt.ts
+
+      - name: Validate llms.txt format
+        run: |
+          # Basic validation - check if file exists and has required structure
+          if [ ! -f "apps/openagents.com/static/llms.txt" ]; then
+            echo "Error: llms.txt was not generated"
+            exit 1
+          fi
+          
+          # Check for required title (starts with #)
+          if ! head -n 1 apps/openagents.com/static/llms.txt | grep -q "^# "; then
+            echo "Error: llms.txt missing required title (should start with '# ')"
+            exit 1
+          fi
+          
+          # Check for summary line (starts with >)
+          if ! head -n 2 apps/openagents.com/static/llms.txt | tail -n 1 | grep -q "^> "; then
+            echo "Error: llms.txt missing summary line (should start with '> ')"
+            exit 1
+          fi
+          
+          echo "✅ llms.txt validation passed"
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet apps/openagents.com/static/llms.txt; then
+            echo "No changes to llms.txt"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "llms.txt has been updated"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit changes
+        if: steps.check_changes.outputs.changed == 'true' && github.event_name == 'push'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/openagents.com/static/llms.txt
+          git commit -m "chore: Update llms.txt from documentation changes"
+          git push
+
+      - name: Upload llms.txt artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: llms-txt
+          path: apps/openagents.com/static/llms.txt
+
+      - name: Comment PR with llms.txt preview
+        if: github.event_name == 'pull_request' && steps.check_changes.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const content = fs.readFileSync('apps/openagents.com/static/llms.txt', 'utf8');
+            const preview = content.split('\n').slice(0, 30).join('\n');
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 📄 llms.txt Preview\n\nThe llms.txt file has been updated based on documentation changes.\n\n<details>\n<summary>View llms.txt preview (first 30 lines)</summary>\n\n\`\`\`markdown\n${preview}\n...\n\`\`\`\n\n</details>\n\nFull file available as artifact.`
+            })

--- a/apps/openagents.com/package.json
+++ b/apps/openagents.com/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "bun run --hot src/index.ts",
-    "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "build": "tsc && bun run generate:llms-txt",
+    "typecheck": "tsc --noEmit",
+    "generate:llms-txt": "bun ../../scripts/generate-llms-txt.ts"
   },
   "dependencies": {
     "@openagentsinc/nostr": "workspace:*",
@@ -16,6 +17,7 @@
     "elysia": "^1.3.5"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.16"
+    "@types/bun": "^1.2.16",
+    "gray-matter": "^4.0.3"
   }
 }

--- a/apps/openagents.com/package.json
+++ b/apps/openagents.com/package.json
@@ -7,7 +7,7 @@
     "dev": "bun run --hot src/index.ts",
     "build": "tsc && bun run generate:llms-txt",
     "typecheck": "tsc --noEmit",
-    "generate:llms-txt": "bun ../../scripts/generate-llms-txt.ts"
+    "generate:llms-txt": "tsx ../../scripts/generate-llms-txt.ts"
   },
   "dependencies": {
     "@openagentsinc/nostr": "workspace:*",

--- a/apps/openagents.com/src/index.ts
+++ b/apps/openagents.com/src/index.ts
@@ -10,6 +10,8 @@ import { navigation } from './components/navigation'
 import { baseStyles } from './styles'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 
 const app = createPsionicApp({
   name: 'OpenAgents',
@@ -39,6 +41,26 @@ app.route('/chat', chat)
 
 // Mount API routes
 app.elysia.use(ollamaApi)
+
+// Serve llms.txt
+app.elysia.get('/llms.txt', async () => {
+  try {
+    const llmsTxtPath = join(path.dirname(fileURLToPath(import.meta.url)), '../static/llms.txt')
+    const content = await readFile(llmsTxtPath, 'utf-8')
+    return new Response(content, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8'
+      }
+    })
+  } catch (error) {
+    return new Response('llms.txt not found. Please run: bun run generate:llms-txt', {
+      status: 404,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8'
+      }
+    })
+  }
+})
 
 // Start the server
 app.start()

--- a/apps/openagents.com/static/llms.txt
+++ b/apps/openagents.com/static/llms.txt
@@ -1,0 +1,34 @@
+# OpenAgents
+> Bitcoin-powered digital agents built with Effect
+
+OpenAgents is a platform for creating autonomous AI agents that can transact value using Bitcoin Lightning Network. Built on the Effect framework for type-safe, composable TypeScript, it provides a complete SDK for agent development, Lightning payments, and Nostr communication.
+
+## Getting Started
+- [Getting Started](https://openagents.com/docs/getting-started)
+
+## SDK & API Reference
+- [SDK Reference](https://openagents.com/docs/sdk-reference)
+
+## Core Features
+- [OpenAgents Codebase Overview](https://openagents.com/docs/agent-intro)
+
+## Packages
+- [@openagentsinc/sdk](https://openagents.com/docs/packages/sdk): Core SDK for building Bitcoin-powered agents
+- [@openagentsinc/nostr](https://openagents.com/docs/packages/nostr): Effect-based Nostr protocol implementation
+- [@openagentsinc/ai](https://openagents.com/docs/packages/ai): AI provider abstraction layer
+- [@openagentsinc/ui](https://openagents.com/docs/packages/ui): WebTUI component library
+- [@openagentsinc/psionic](https://openagents.com/docs/packages/psionic): Hypermedia web framework
+
+## Additional Resources
+- [Psionic Framework](https://openagents.com/docs/psionic)
+- [Architecture Overview](https://openagents.com/docs/architecture)
+- [Troubleshooting](https://openagents.com/docs/troubleshooting)
+- [Development Guide](https://openagents.com/docs/development)
+- [Roadmap](https://openagents.com/docs/roadmap)
+- [Modern syntax highlighting for TypeScript monorepos with Effect.js and Bun](https://openagents.com/docs/syntax-highlighting)
+
+## Optional
+- [Component Explorer](https://openagents.com/components): Interactive UI component showcase
+- [GitHub Repository](https://github.com/OpenAgentsInc/openagents): Source code and contributions
+- [Discord Community](https://discord.gg/openagents): Support and discussions
+- [Effect Documentation](https://effect.website): Learn more about the Effect framework

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-simple-import-sort": "12.1.1",
     "eslint-plugin-sort-destructure-keys": "2.0.0",
     "glob": "11.0.2",
+    "gray-matter": "4.0.3",
     "tsx": "4.19.4",
     "typescript": "5.8.3",
     "vitest": "3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@types/bun':
         specifier: ^1.2.16
         version: 1.2.16
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
 
   apps/playground:
     dependencies:
@@ -8077,7 +8080,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extendable: 0.1.1
-    dev: false
 
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -8571,7 +8573,6 @@ packages:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
-    dev: false
 
   /happy-dom@8.9.0:
     resolution: {integrity: sha512-JZwJuGdR7ko8L61136YzmrLv7LgTh5b8XaEM3P709mLjyQuXJ3zHTDXvUtBBahRjGlcYW0zGjIiEWizoTUGKfA==}
@@ -8963,7 +8964,6 @@ packages:
   /is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -9375,7 +9375,6 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -11039,7 +11038,6 @@ packages:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
-    dev: false
 
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -11492,7 +11490,6 @@ packages:
   /strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       glob:
         specifier: 11.0.2
         version: 11.0.2
+      gray-matter:
+        specifier: 4.0.3
+        version: 4.0.3
       tsx:
         specifier: 4.19.4
         version: 4.19.4

--- a/scripts/generate-llms-txt.ts
+++ b/scripts/generate-llms-txt.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 
 import matter from "gray-matter"
 import { readdir, readFile, writeFile } from "node:fs/promises"

--- a/scripts/generate-llms-txt.ts
+++ b/scripts/generate-llms-txt.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env bun
+
+import matter from "gray-matter"
+import { readdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+interface DocMeta {
+  title: string
+  description?: string
+  order?: number
+  category?: string
+  path: string
+}
+
+async function getAllDocs(docsDir: string): Promise<Array<DocMeta>> {
+  const docs: Array<DocMeta> = []
+
+  async function scanDir(dir: string, basePath: string = ""): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name)
+      const relativePath = join(basePath, entry.name)
+
+      if (entry.isDirectory()) {
+        await scanDir(fullPath, relativePath)
+      } else if (entry.name.endsWith(".md")) {
+        const content = await readFile(fullPath, "utf-8")
+        const { data } = matter(content)
+
+        // Generate the URL path
+        const urlPath = relativePath
+          .replace(/\.md$/, "")
+          .replace(/\/index$/, "")
+          .replace(/\\/g, "/")
+
+        docs.push({
+          title: data.title || entry.name.replace(/\.md$/, ""),
+          description: data.description || data.excerpt,
+          order: data.order || 999,
+          category: data.category || basePath.split("/")[0] || "docs",
+          path: `/docs/${urlPath}`.replace(/\/+/g, "/")
+        })
+      }
+    }
+  }
+
+  await scanDir(docsDir)
+  return docs.sort((a, b) => (a.order ?? 999) - (b.order ?? 999))
+}
+
+async function generateLlmsTxt(): Promise<string> {
+  const docsDir = join(process.cwd(), "apps/openagents.com/content/docs")
+  const docs = await getAllDocs(docsDir)
+
+  // Group docs by category
+  const categories = new Map<string, Array<DocMeta>>()
+  for (const doc of docs) {
+    const category = doc.category || "Documentation"
+    if (!categories.has(category)) {
+      categories.set(category, [])
+    }
+    categories.get(category)!.push(doc)
+  }
+
+  // Build the llms.txt content
+  let content = `# OpenAgents
+> Bitcoin-powered digital agents built with Effect
+
+OpenAgents is a platform for creating autonomous AI agents that can transact value using Bitcoin Lightning Network. Built on the Effect framework for type-safe, composable TypeScript, it provides a complete SDK for agent development, Lightning payments, and Nostr communication.
+
+`
+
+  // Core documentation section
+  const coreDocs = docs.filter((d) =>
+    ["getting-started", "introduction", "overview", "quickstart"].some((term) => d.path.toLowerCase().includes(term))
+  )
+
+  if (coreDocs.length > 0) {
+    content += "## Getting Started\n"
+    for (const doc of coreDocs) {
+      content += `- [${doc.title}](https://openagents.com${doc.path})`
+      if (doc.description) {
+        content += `: ${doc.description}`
+      }
+      content += "\n"
+    }
+    content += "\n"
+  }
+
+  // SDK and API documentation
+  const sdkDocs = docs.filter((d) => ["sdk", "api", "reference"].some((term) => d.path.toLowerCase().includes(term)))
+
+  if (sdkDocs.length > 0) {
+    content += "## SDK & API Reference\n"
+    for (const doc of sdkDocs) {
+      content += `- [${doc.title}](https://openagents.com${doc.path})`
+      if (doc.description) {
+        content += `: ${doc.description}`
+      }
+      content += "\n"
+    }
+    content += "\n"
+  }
+
+  // Core features
+  const featureDocs = docs.filter((d) =>
+    ["agent", "lightning", "nostr", "bitcoin", "effect"].some((term) => d.path.toLowerCase().includes(term)) &&
+    !sdkDocs.includes(d) && !coreDocs.includes(d)
+  )
+
+  if (featureDocs.length > 0) {
+    content += "## Core Features\n"
+    for (const doc of featureDocs) {
+      content += `- [${doc.title}](https://openagents.com${doc.path})`
+      if (doc.description) {
+        content += `: ${doc.description}`
+      }
+      content += "\n"
+    }
+    content += "\n"
+  }
+
+  // Package references
+  content += `## Packages
+- [@openagentsinc/sdk](https://openagents.com/docs/packages/sdk): Core SDK for building Bitcoin-powered agents
+- [@openagentsinc/nostr](https://openagents.com/docs/packages/nostr): Effect-based Nostr protocol implementation
+- [@openagentsinc/ai](https://openagents.com/docs/packages/ai): AI provider abstraction layer
+- [@openagentsinc/ui](https://openagents.com/docs/packages/ui): WebTUI component library
+- [@openagentsinc/psionic](https://openagents.com/docs/packages/psionic): Hypermedia web framework
+
+`
+
+  // Other resources
+  const otherDocs = docs.filter((d) =>
+    !coreDocs.includes(d) &&
+    !sdkDocs.includes(d) &&
+    !featureDocs.includes(d)
+  ).slice(0, 10) // Limit to prevent overwhelming the file
+
+  if (otherDocs.length > 0) {
+    content += "## Additional Resources\n"
+    for (const doc of otherDocs) {
+      content += `- [${doc.title}](https://openagents.com${doc.path})`
+      if (doc.description) {
+        content += `: ${doc.description}`
+      }
+      content += "\n"
+    }
+    content += "\n"
+  }
+
+  // Static links
+  content += `## Optional
+- [Component Explorer](https://openagents.com/components): Interactive UI component showcase
+- [GitHub Repository](https://github.com/OpenAgentsInc/openagents): Source code and contributions
+- [Discord Community](https://discord.gg/openagents): Support and discussions
+- [Effect Documentation](https://effect.website): Learn more about the Effect framework
+`
+
+  return content
+}
+
+// Main execution
+async function main() {
+  try {
+    console.log("Generating llms.txt from documentation...")
+
+    const content = await generateLlmsTxt()
+    const outputPath = join(process.cwd(), "apps/openagents.com/static/llms.txt")
+
+    await writeFile(outputPath, content, "utf-8")
+
+    console.log(`✅ Generated llms.txt (${content.length} bytes)`)
+    console.log(`📄 Output: ${outputPath}`)
+
+    // Optional: validate the format
+    const lines = content.split("\n")
+    const hasTitle = lines[0].startsWith("# ")
+    const hasSummary = lines[1]?.startsWith("> ")
+
+    if (!hasTitle || !hasSummary) {
+      console.error("❌ Warning: Generated file may not conform to llms.txt spec")
+      process.exit(1)
+    }
+  } catch (error) {
+    console.error("❌ Error generating llms.txt:", error)
+    process.exit(1)
+  }
+}
+
+main()

--- a/server.log
+++ b/server.log
@@ -1,1 +1,10 @@
-error: Module not found "src/index.ts"
+
+> @openagentsinc/openagents.com@0.0.0 dev /Users/christopherdavid/code/openagents/worktrees/llms-txt/apps/openagents.com
+> bun run --hot src/index.ts
+
+📚 Component explorer enabled at /components
+🧠 OpenAgents is running at http://0.0.0.0:3003
+undefined
+/Users/christopherdavid/code/openagents/worktrees/llms-txt/apps/openagents.com:
+ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @openagentsinc/openagents.com@0.0.0 dev: `bun run --hot src/index.ts`
+Command failed with signal "SIGTERM"


### PR DESCRIPTION
## Summary
Implements automated llms.txt generation for improved LLM navigation of OpenAgents documentation.

## Changes
- ✨ Add llms.txt generator script that parses docs to create spec-compliant file
- 🛣️ Configure route to serve llms.txt at `/llms.txt` endpoint
- 🤖 Add GitHub Actions workflow to auto-generate on docs changes
- 🏗️ Include generation in build process to ensure it stays in sync
- 📄 Generate initial llms.txt from current documentation

## Implementation Details
- **Generator Script**: `scripts/generate-llms-txt.ts` parses all markdown docs in `content/docs/`
- **Automatic Updates**: CI/CD pipeline regenerates on any docs changes
- **Build Integration**: Added to `openagents.com` build process
- **Validation**: GitHub Actions validates format compliance

## Testing
- Generated initial llms.txt successfully
- Verified route serves the file at `/llms.txt`
- Linting and tests pass

## Related
- Implements #976
- Spec: https://llmstxt.org/

## Preview
The generated llms.txt includes:
- Project overview and summary
- Categorized documentation links
- Package references
- External resources

This ensures LLMs can efficiently navigate and understand the OpenAgents platform.