### PR TITLE
feat: Add OpenRouter provider to Effect AI library

### DIFF
--- a/apps/openagents.com/src/index.ts
+++ b/apps/openagents.com/src/index.ts
@@ -6,6 +6,7 @@ import { about } from './routes/about'
 import { blogIndex, blogPost } from './routes/blog'
 import { chat } from './routes/chat'
 import { ollamaApi } from './routes/api/ollama'
+import { openrouterApi } from './routes/api/openrouter'
 import { navigation } from './components/navigation'
 import { baseStyles } from './styles'
 import path from 'path'
@@ -39,6 +40,7 @@ app.route('/chat', chat)
 
 // Mount API routes
 app.elysia.use(ollamaApi)
+app.elysia.use(openrouterApi)
 
 // Start the server
 app.start()

--- a/apps/openagents.com/src/routes/api/openrouter.ts
+++ b/apps/openagents.com/src/routes/api/openrouter.ts
@@ -1,0 +1,128 @@
+import * as HttpClient from "@effect/platform/HttpClient"
+import * as Ai from "@openagentsinc/ai"
+import { Effect, Layer, Stream } from "effect"
+import * as Redacted from "effect/Redacted"
+import { Elysia } from "elysia"
+
+export const openrouterApi = new Elysia({ prefix: "/api/openrouter" })
+  .post("/chat", async ({ body, headers }: { body: any; headers: Record<string, string | undefined> }) => {
+    try {
+      const { messages, model } = body
+      const apiKey = headers["x-api-key"]
+
+      if (!apiKey) {
+        return Response.json({ error: "API key required" }, { status: 401 })
+      }
+
+      // Create a TransformStream for streaming response
+      const stream = new TransformStream()
+      const writer = stream.writable.getWriter()
+      const encoder = new TextEncoder() // Start streaming in background using Effect patterns
+      ;(async () => {
+        try {
+          // Create the chat effect using the OpenRouter provider
+          const chatProgram = Effect.gen(function*() {
+            const languageModel = yield* Ai.OpenRouter.makeOpenRouterLanguageModel({
+              modelId: model
+            })
+
+            // Create the request
+            const request = {
+              messages: messages.map((msg: any) => ({
+                role: msg.role,
+                content: msg.content
+              })),
+              config: {
+                temperature: 0.7,
+                maxTokens: 4096
+              }
+            }
+
+            // Get the stream
+            const responseStream = yield* languageModel.generateStream(request)
+
+            // Process the stream
+            yield* responseStream.pipe(
+              Stream.tap((response) =>
+                Effect.sync(() => {
+                  // Convert AiResponse to OpenAI-compatible format
+                  for (const part of response.parts) {
+                    if (part._tag === "text") {
+                      const chunk = {
+                        id: "chatcmpl-" + Math.random().toString(36).substring(2),
+                        object: "chat.completion.chunk",
+                        created: Math.floor(Date.now() / 1000),
+                        model,
+                        choices: [{
+                          index: 0,
+                          delta: {
+                            content: part.text
+                          },
+                          finish_reason: null
+                        }]
+                      }
+                      writer.write(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`)).catch(() => {})
+                    } else if (part._tag === "finish") {
+                      const chunk = {
+                        id: "chatcmpl-" + Math.random().toString(36).substring(2),
+                        object: "chat.completion.chunk",
+                        created: Math.floor(Date.now() / 1000),
+                        model,
+                        choices: [{
+                          index: 0,
+                          delta: {},
+                          finish_reason: part.reason
+                        }]
+                      }
+                      writer.write(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`)).catch(() => {})
+                    }
+                  }
+                })
+              ),
+              Stream.runDrain
+            )
+          })
+
+          // Create the layers
+          const HttpClientLive = HttpClient.layer
+          const OpenRouterClientLive = Ai.OpenRouter.layerOpenRouterClient({
+            apiKey: Redacted.make(apiKey),
+            referer: "https://openagents.com",
+            title: "OpenAgents"
+          })
+
+          // Run the program with layers
+          await Effect.runPromise(
+            chatProgram.pipe(
+              Effect.provide(Layer.mergeAll(HttpClientLive, OpenRouterClientLive)),
+              Effect.tapError((error) =>
+                Effect.sync(() => {
+                  console.error("OpenRouter chat error:", error)
+                  return error
+                })
+              )
+            )
+          )
+
+          // Send completion signal
+          await writer.write(encoder.encode(`data: [DONE]\n\n`))
+        } catch (error: any) {
+          console.error("OpenRouter streaming error:", error)
+          await writer.write(encoder.encode(`data: ${JSON.stringify({ error: error.message })}\n\n`))
+        } finally {
+          await writer.close()
+        }
+      })()
+
+      return new Response(stream.readable, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          "Connection": "keep-alive"
+        }
+      })
+    } catch (error: any) {
+      console.error("OpenRouter API error:", error)
+      return Response.json({ error: error.message }, { status: 500 })
+    }
+  })

--- a/apps/openagents.com/src/routes/chat.ts
+++ b/apps/openagents.com/src/routes/chat.ts
@@ -23,6 +23,32 @@ export function chat() {
             </div>
           </div>
 
+          <!-- API Keys Card -->
+          <div class="api-keys-card" box-="square">
+            <h4>API Keys</h4>
+            <div class="api-key-section">
+              <label for="openrouter-api-key">OpenRouter API Key</label>
+              <div class="api-key-input-wrapper">
+                <input 
+                  type="password" 
+                  id="openrouter-api-key" 
+                  is-="input" 
+                  box-="square"
+                  placeholder="sk-or-v1-..."
+                />
+                <button 
+                  id="openrouter-save" 
+                  is-="button" 
+                  box-="square"
+                  variant-="foreground1"
+                >
+                  Save
+                </button>
+              </div>
+              <div id="openrouter-status" class="api-key-status"></div>
+            </div>
+          </div>
+
           <!-- Models List Card -->
           <div id="model-list-card" class="model-list-card" box-="square" style="display: none;">
             <h4>Available Models</h4>
@@ -91,14 +117,54 @@ export function chat() {
           min-width: 0; /* Allow flex item to shrink */
         }
 
-        .status-card, .model-list-card {
+        .status-card, .api-keys-card, .model-list-card {
           padding: 0.75rem;
         }
 
-        .status-card h4, .model-list-card h4 {
+        .status-card h4, .api-keys-card h4, .model-list-card h4 {
           margin: 0 0 0.5rem 0;
           font-size: 0.85em;
           color: var(--foreground1);
+        }
+
+        .api-key-section {
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+
+        .api-key-section label {
+          font-size: 0.8em;
+          color: var(--foreground0);
+        }
+
+        .api-key-input-wrapper {
+          display: flex;
+          gap: 0.5rem;
+        }
+
+        .api-key-input-wrapper input {
+          flex: 1;
+          font-size: 0.85em;
+        }
+
+        .api-key-input-wrapper button {
+          font-size: 0.85em;
+          padding: 0.25rem 0.75rem;
+        }
+
+        .api-key-status {
+          font-size: 0.75em;
+          color: var(--foreground0);
+          min-height: 1.2em;
+        }
+
+        .api-key-status.success {
+          color: #10b981;
+        }
+
+        .api-key-status.error {
+          color: #ef4444;
         }
 
         .status-header {
@@ -292,7 +358,9 @@ export function chat() {
         // Chat state
         let chatMessages = []
         let currentModel = ''
+        let currentProvider = 'ollama' // 'ollama' or 'openrouter'
         let isStreaming = false
+        let openRouterApiKey = localStorage.getItem('openRouterApiKey') || ''
 
         // Format file size
         const formatSize = (bytes) => {
@@ -546,11 +614,211 @@ export function chat() {
           }
         }
 
+        // Handle OpenRouter API key
+        const saveOpenRouterApiKey = () => {
+          const input = document.getElementById('openrouter-api-key')
+          const statusDiv = document.getElementById('openrouter-status')
+          const dropdown = document.getElementById('chat-model-select')
+          
+          if (!input || !statusDiv) return
+          
+          const apiKey = input.value.trim()
+          if (!apiKey) {
+            statusDiv.textContent = 'API key is required'
+            statusDiv.className = 'api-key-status error'
+            return
+          }
+          
+          // Save to localStorage
+          localStorage.setItem('openRouterApiKey', apiKey)
+          openRouterApiKey = apiKey
+          
+          // Update status
+          statusDiv.textContent = 'API key saved!'
+          statusDiv.className = 'api-key-status success'
+          
+          // Add OpenRouter models to dropdown
+          if (dropdown && apiKey) {
+            // Check if OpenRouter option group already exists
+            let openRouterGroup = dropdown.querySelector('optgroup[label="OpenRouter"]')
+            if (!openRouterGroup) {
+              openRouterGroup = document.createElement('optgroup')
+              openRouterGroup.label = 'OpenRouter'
+              dropdown.appendChild(openRouterGroup)
+            } else {
+              openRouterGroup.innerHTML = ''
+            }
+            
+            // Add popular OpenRouter models
+            const openRouterModels = [
+              { value: 'openrouter/auto', name: 'Auto (Best Available)' },
+              { value: 'openai/gpt-4o', name: 'GPT-4o' },
+              { value: 'openai/gpt-4o-mini', name: 'GPT-4o Mini' },
+              { value: 'anthropic/claude-3.5-sonnet', name: 'Claude 3.5 Sonnet' },
+              { value: 'anthropic/claude-3-haiku', name: 'Claude 3 Haiku' },
+              { value: 'google/gemini-pro-1.5', name: 'Gemini Pro 1.5' },
+              { value: 'meta-llama/llama-3.1-70b-instruct', name: 'Llama 3.1 70B' },
+              { value: 'meta-llama/llama-3.1-8b-instruct', name: 'Llama 3.1 8B' },
+              { value: 'mistralai/mistral-large', name: 'Mistral Large' },
+              { value: 'deepseek/deepseek-chat', name: 'DeepSeek Chat' }
+            ]
+            
+            openRouterModels.forEach(model => {
+              const option = document.createElement('option')
+              option.value = model.value
+              option.textContent = model.name
+              openRouterGroup.appendChild(option)
+            })
+          }
+          
+          setTimeout(() => {
+            statusDiv.textContent = ''
+            statusDiv.className = 'api-key-status'
+          }, 3000)
+        }
+
+        // Update send message to handle both providers
+        const sendChatMessage = async () => {
+          const input = document.getElementById('chat-input')
+          const sendButton = document.getElementById('chat-send')
+          const message = input.value.trim()
+          
+          if (!message || !currentModel || isStreaming) return
+          
+          // Determine provider from model name
+          currentProvider = currentModel.includes('/') ? 'openrouter' : 'ollama'
+          
+          chatMessages.push({ role: 'user', content: message })
+          addMessageToUI('user', message)
+          
+          input.value = ''
+          input.disabled = true
+          sendButton.disabled = true
+          isStreaming = true
+          
+          const assistantDiv = addMessageToUI('assistant', '', true)
+          let assistantContent = ''
+          
+          try {
+            const endpoint = currentProvider === 'openrouter' ? '/api/openrouter/chat' : '/api/ollama/chat'
+            const headers = {
+              'Content-Type': 'application/json'
+            }
+            
+            if (currentProvider === 'openrouter' && openRouterApiKey) {
+              headers['X-API-Key'] = openRouterApiKey
+            }
+            
+            const response = await fetch(endpoint, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify({
+                model: currentModel,
+                messages: chatMessages,
+                options: {
+                  temperature: 0.7,
+                  num_ctx: 4096
+                }
+              })
+            })
+            
+            if (!response.ok) {
+              throw new Error(\`HTTP error! status: \${response.status}\`)
+            }
+            
+            const reader = response.body.getReader()
+            const decoder = new TextDecoder()
+            
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) break
+              
+              const chunk = decoder.decode(value)
+              const lines = chunk.split('\\n')
+              
+              for (const line of lines) {
+                if (line.startsWith('data: ')) {
+                  const data = line.slice(6)
+                  if (data === '[DONE]') {
+                    assistantDiv.classList.remove('streaming')
+                    break
+                  }
+                  
+                  try {
+                    const parsed = JSON.parse(data)
+                    if (parsed.error) {
+                      throw new Error(parsed.error)
+                    }
+                    
+                    // Handle both Ollama and OpenRouter response formats
+                    let content = ''
+                    if (currentProvider === 'ollama' && parsed.message?.content) {
+                      content = parsed.message.content
+                    } else if (currentProvider === 'openrouter' && parsed.choices?.[0]?.delta?.content) {
+                      content = parsed.choices[0].delta.content
+                    }
+                    
+                    if (content) {
+                      assistantContent += content
+                      assistantDiv.textContent = assistantContent
+                      
+                      const messagesContainer = document.getElementById('chat-messages')
+                      messagesContainer.scrollTop = messagesContainer.scrollHeight
+                    }
+                    
+                    if (parsed.done || (parsed.choices?.[0]?.finish_reason)) {
+                      assistantDiv.classList.remove('streaming')
+                    }
+                  } catch (e) {
+                    console.error('Error parsing chunk:', e)
+                  }
+                }
+              }
+            }
+            
+            chatMessages.push({ role: 'assistant', content: assistantContent })
+            
+          } catch (error) {
+            console.error('Chat error:', error)
+            assistantDiv.textContent = \`Error: \${error.message}\`
+            assistantDiv.classList.remove('streaming')
+            assistantDiv.style.color = 'var(--danger)'
+          } finally {
+            isStreaming = false
+            input.disabled = false
+            sendButton.disabled = false
+            input.focus()
+          }
+        }
+
         // Initialize
         document.addEventListener('DOMContentLoaded', () => {
           // Check status
           checkOllamaStatus()
           setInterval(checkOllamaStatus, 10000)
+          
+          // Load saved OpenRouter API key
+          const apiKeyInput = document.getElementById('openrouter-api-key')
+          if (apiKeyInput && openRouterApiKey) {
+            apiKeyInput.value = openRouterApiKey
+            // Trigger save to populate models
+            saveOpenRouterApiKey()
+          }
+          
+          // OpenRouter API key handler
+          const saveButton = document.getElementById('openrouter-save')
+          if (saveButton) {
+            saveButton.addEventListener('click', saveOpenRouterApiKey)
+          }
+          
+          if (apiKeyInput) {
+            apiKeyInput.addEventListener('keypress', (e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                saveOpenRouterApiKey()
+              }
+            })
+          }
 
           // Model dropdown handler
           const modelDropdown = document.getElementById('chat-model-select')

--- a/docs/research/cloudflare-workers-ai-provider-research-prompt.md
+++ b/docs/research/cloudflare-workers-ai-provider-research-prompt.md
@@ -1,0 +1,209 @@
+# Cloudflare Workers AI Provider Research Brief
+
+## Context
+OpenAgents needs to integrate Cloudflare Workers AI to provide access to their extensive model catalog including Llama 3, quantized DeepSeek variants, and other optimized models. Cloudflare Workers AI offers edge-deployed inference with excellent performance characteristics for Bitcoin-powered agents.
+
+## Current Architecture Understanding
+
+### Effect AI Provider Structure
+The Effect AI library uses a service-oriented architecture with:
+- **Core abstractions** in `packages/ai/src/core/`:
+  - `AiLanguageModel.ts` - Main service interface
+  - `AiChat.ts` - Chat abstractions
+  - `AiTool.ts` - Tool system
+  - `AiResponse.ts` - Response types
+  - `AiError.ts` - Error handling
+
+### Existing Providers
+1. **OpenAI Provider** - Standard OpenAI API format
+2. **Anthropic Provider** - Claude models
+3. **Ollama Provider** - Local LLM support
+
+## Research Questions
+
+### 1. Cloudflare Workers AI API Structure
+**Primary Question**: What is the API format for Cloudflare Workers AI?
+
+**Research Tasks**:
+- Document the REST API endpoint structure
+- Understand the authentication mechanism (API tokens, account IDs)
+- Check request/response formats for text generation
+- Verify streaming support capabilities
+- Investigate rate limiting and quotas
+
+**Key URLs to investigate**:
+- https://developers.cloudflare.com/workers-ai/
+- Workers AI API reference
+- Model catalog and specifications
+- Pricing and limits documentation
+
+### 2. Model Catalog & Capabilities
+**Primary Question**: What models are available and how are they accessed?
+
+**Research Tasks**:
+- List all available LLM models (Llama 3, DeepSeek, etc.)
+- Document model identifiers and naming conventions
+- Check quantization options (INT8, INT4, etc.)
+- Investigate model-specific parameters
+- Understand context window limits
+- Document performance characteristics
+
+**Specific Models to Research**:
+- Llama 3 variants (8B, 70B)
+- DeepSeek quantized versions
+- Code generation models
+- Embedding models
+- Any Bitcoin/crypto specialized models
+
+### 3. Deployment Models
+**Primary Question**: How can we access Workers AI from OpenAgents?
+
+**Option A - Direct API Access**:
+- Can we call Workers AI API directly from our backend?
+- What are the CORS/security implications?
+- How do we handle API keys securely?
+
+**Option B - Workers Proxy**:
+- Do we need a Cloudflare Worker as proxy?
+- Can we deploy our own Worker for custom logic?
+- How would this affect latency?
+
+**Option C - Hybrid Approach**:
+- Use Workers for edge inference
+- Fallback to direct API for complex requests
+
+**Research Tasks**:
+- Authentication methods for different deployment models
+- Network requirements and restrictions
+- Best practices for production deployment
+
+### 4. Unique Features & Optimizations
+**Primary Question**: What Workers AI features should we leverage?
+
+**Research Tasks**:
+- Edge deployment benefits for global users
+- Quantization options and quality tradeoffs
+- Batch inference capabilities
+- Model caching strategies
+- GPU availability and allocation
+- Regional deployment options
+
+**Special Features to Investigate**:
+- Model switching without cold starts
+- Request batching for efficiency
+- Custom model deployment options
+- Integration with other Workers services
+
+### 5. Streaming & Real-time Response
+**Primary Question**: How does Workers AI handle streaming responses?
+
+**Research Tasks**:
+- Does Workers AI support SSE or WebSocket streaming?
+- What's the format for streaming responses?
+- How do we handle partial token generation?
+- Latency characteristics for streaming
+- Any special headers or protocols required?
+
+### 6. Cost & Performance Optimization
+**Primary Question**: How can we optimize for cost and performance?
+
+**Research Tasks**:
+- Pricing model (per request, per token, per second?)
+- Free tier limitations
+- Cost comparison between models
+- Performance benchmarks
+- Caching strategies to reduce costs
+- Batching opportunities
+
+### 7. Effect Integration Design
+**Primary Question**: How should we structure the Workers AI provider?
+
+**Research Tasks**:
+- Service/Layer pattern for Workers AI
+- Configuration schema design
+- Error types and handling
+- Retry strategies for edge cases
+- Telemetry integration points
+
+## Implementation Recommendations Needed
+
+Based on your research, please provide:
+
+1. **Provider Architecture**:
+   - Recommended structure for Workers AI provider
+   - Key services and layers needed
+   - Integration points with Effect patterns
+
+2. **API Client Design**:
+   - HTTP client configuration
+   - Request/response transformation
+   - Streaming implementation approach
+   - Error handling strategy
+
+3. **Model Management**:
+   - How to enumerate available models
+   - Model selection interface
+   - Parameter validation per model
+   - Fallback strategies
+
+4. **Configuration Schema**:
+   ```typescript
+   // Example structure needed
+   interface WorkersAiConfig {
+     accountId: string
+     apiToken: Redacted
+     // What else?
+   }
+   ```
+
+5. **Code Examples**:
+   - Basic text generation
+   - Streaming response handling
+   - Model switching
+   - Error recovery
+
+6. **Deployment Strategy**:
+   - Direct API vs Worker proxy decision
+   - Security considerations
+   - Performance optimization tips
+
+## Success Criteria
+
+A successful research outcome will:
+1. Provide complete API documentation summary
+2. List all available models with specifications
+3. Include working code examples for common operations
+4. Define clear configuration requirements
+5. Address streaming and real-time response handling
+6. Provide cost optimization strategies
+7. Include Effect.js integration patterns
+
+## Additional Context
+
+- OpenAgents prioritizes privacy and edge deployment
+- Quantized models are important for cost efficiency
+- Must support streaming for real-time agent interactions
+- Should integrate seamlessly with existing Effect patterns
+- Need to handle both chat and completion endpoints
+- Consider future support for embeddings and other AI tasks
+
+## Specific Technical Requirements
+
+1. **Streaming Support**: Critical for responsive agent interactions
+2. **Model Flexibility**: Easy switching between models
+3. **Error Resilience**: Graceful handling of rate limits and failures
+4. **Type Safety**: Full TypeScript types for all operations
+5. **Observability**: Integration with Effect telemetry
+
+## Questions for Deep Investigation
+
+1. Can we use Workers AI without deploying to Cloudflare Workers?
+2. How does the pricing compare to other providers for similar models?
+3. What's the cold start performance for different models?
+4. Are there any geographic restrictions?
+5. How do we handle model deprecation and updates?
+6. Can we fine-tune or customize models?
+7. What's the maximum context length for each model?
+8. How does batching work for multiple requests?
+
+Please conduct thorough research focusing on practical implementation details that will enable rapid integration of Cloudflare Workers AI into the OpenAgents Effect AI library.

--- a/docs/research/cloudflare-workers-ai-provider-research-report.md
+++ b/docs/research/cloudflare-workers-ai-provider-research-report.md
@@ -1,0 +1,148 @@
+# Cloudflare Workers AI integration unleashes edge-native LLM capabilities
+
+Integrating Cloudflare Workers AI with the OpenAgents Effect AI library enables developers to build production-ready AI applications with **zero cold starts**, global edge deployment, and enterprise-grade reliability. The platform offers 80+ models including Llama 4 Scout with 10M token context windows, streaming support via Server-Sent Events, and a neuron-based pricing model starting at $0.011 per 1,000 neurons with a generous 10,000 neuron daily free tier.
+
+## API structure powers flexible AI inference
+
+Cloudflare Workers AI provides multiple API endpoint patterns for different use cases. The primary REST endpoint follows the structure `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/run/{MODEL_NAME}` with Bearer token authentication. For OpenAI compatibility, endpoints like `/v1/chat/completions` and `/v1/embeddings` enable drop-in replacement of existing integrations.
+
+Authentication requires an API token created through the Cloudflare Dashboard with "Workers AI - Read" permissions. The token is passed via the `Authorization: Bearer {API_TOKEN}` header. Account IDs are found in the Cloudflare Dashboard sidebar. Request bodies use standard JSON with model-specific parameters, while responses include success indicators and structured results.
+
+**Rate limiting** operates at 300 requests/minute for most LLMs, with smaller models supporting up to 3,000 requests/minute. The platform handles 10,000+ requests/second globally with intelligent load balancing across GPU infrastructure in 150+ cities.
+
+## Complete model catalog spans text, vision, and speech
+
+The Workers AI catalog includes **80+ models** across multiple categories. **Text generation** leads with the flagship Llama 4 Scout (109B parameters, 10M token context), Llama 3.3 70B with FP8 optimization for 2-4x faster inference, and the Llama 3.1 series supporting 128K contexts with function calling. Google's Gemma 3 offers multilingual support for 140+ languages, while Mistral Small 3.1 provides vision understanding capabilities.
+
+**Code generation** models include DeepSeek Coder (6.7B, AWQ quantized) trained on 2T tokens of code, Qwen2.5-Coder (32B) optimized for programming tasks, and SQLCoder for database query generation. **Embedding models** feature the BGE series with multilingual BGE-M3 supporting 100+ languages, plus specialized reranking models for RAG applications.
+
+**Vision capabilities** come through Llama 4 Scout's native multimodal support and Llama 3.2 11B Vision, while **text-to-image** generation uses FLUX.1 Schnell (12B) and Stable Diffusion variants. **Speech processing** leverages OpenAI Whisper for multilingual ASR and MeloTTS for text-to-speech synthesis.
+
+## Hono deployment creates robust AI proxy architecture
+
+Deploying a Hono app on Cloudflare Workers as an AI proxy follows established patterns for serverless architectures. The basic structure includes middleware for authentication, CORS, rate limiting, and request validation:
+
+```typescript
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { bearerAuth } from 'hono/bearer-auth'
+
+type Bindings = {
+  AI: Ai
+  API_KEY: string
+  CORS_ORIGIN: string
+}
+
+const app = new Hono<{ Bindings: Bindings }>()
+
+app.use('*', cors({
+  origin: c => c.env.CORS_ORIGIN.split(','),
+  allowMethods: ['GET', 'POST', 'OPTIONS'],
+  credentials: true
+}))
+
+app.use('/api/*', bearerAuth({
+  verifyToken: async (token, c) => token === c.env.API_KEY
+}))
+
+app.post('/api/chat/completions', async (c) => {
+  const { model, messages, stream } = await c.req.json()
+
+  const response = await c.env.AI.run(model, {
+    messages,
+    stream
+  })
+
+  if (stream) {
+    return new Response(response as ReadableStream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache'
+      }
+    })
+  }
+
+  return c.json(response)
+})
+```
+
+**Request routing** implements model-specific endpoints, dynamic model selection, and batch processing capabilities. **CORS configuration** uses environment-specific origins with proper preflight handling. **Authentication flow** supports multiple methods including API keys, JWT tokens, and bearer authentication with secure token comparison to prevent timing attacks.
+
+## Streaming unlocks real-time AI interactions
+
+Workers AI implements streaming through **Server-Sent Events (SSE)** with the `text/event-stream` content type. Each chunk contains JSON with a `response` field holding the generated token. Streams terminate with `data: [DONE]` markers following SSE specifications.
+
+Enabling streaming requires setting `stream: true` in the request. The Hono proxy handles streaming responses by returning the ReadableStream directly with appropriate headers. **Latency characteristics** show 200-500ms time to first token versus 2-10 seconds for complete responses, providing 60-80% reduction in perceived wait time.
+
+Client-side consumption uses EventSource API or Fetch with ReadableStream processing. Error handling during streaming requires managing connection timeouts, parse errors, and graceful degradation to non-streaming mode when necessary.
+
+## Effect integration enables type-safe AI clients
+
+The Effect library provides powerful abstractions for building Workers AI clients with comprehensive error handling and retry logic. The HTTP client configuration leverages `@effect/platform` for request/response transformations:
+
+```typescript
+import { HttpClient, HttpClientRequest } from "@effect/platform"
+import { Effect, Layer, Stream } from "effect"
+import { Schema } from "@effect/schema"
+
+const ChatCompletionRequest = Schema.Struct({
+  model: Schema.String,
+  messages: Schema.Array(Schema.Struct({
+    role: Schema.Literal("system", "user", "assistant"),
+    content: Schema.String
+  })),
+  stream: Schema.optional(Schema.Boolean)
+})
+
+const makeRequest = (request: ChatCompletionRequest) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient
+
+    return yield* HttpClientRequest.post("/api/v1/chat/completions")
+      .pipe(
+        HttpClientRequest.schemaBodyJson(ChatCompletionRequest)(request),
+        Effect.flatMap(client.execute),
+        Effect.flatMap(HttpClientResponse.schemaBodyJson(ChatCompletionResponse)),
+        Effect.scoped
+      )
+  })
+```
+
+**Streaming implementation** uses Effect's Stream module for SSE parsing with backpressure control. **Error handling** defines custom error types for rate limiting, authentication failures, and validation errors with precise recovery strategies. **Retry patterns** implement exponential backoff with jitter and circuit breaker patterns for resilience.
+
+The **Service/Layer pattern** enables dependency injection and modular architecture with proper configuration management through Effect's Config system.
+
+## Cost and performance deliver exceptional value
+
+Workers AI's **pricing model** charges $0.011 per 1,000 neurons with a 10,000 neuron daily free tier. Model-specific pricing ranges from $0.012/M tokens for embeddings to $2.25/M output tokens for large models. This represents 70-80% cost savings versus comparable cloud AI services.
+
+**Performance characteristics** include virtually zero cold starts through Cloudflare's isolate technology, achieving sub-5ms initialization compared to container-based systems. The platform handles 300 requests/minute for LLMs with intelligent load balancing across global GPU infrastructure.
+
+**Optimization strategies** leverage AI Gateway for request caching, implement rate limiting to prevent cost overruns, and use model fallback for cost-effective inference. Geographic distribution across 150+ cities ensures consistent low latency globally with automatic failover.
+
+## Production-ready configuration patterns
+
+Complete configuration requires proper environment setup through `wrangler.toml`:
+
+```toml
+name = "ai-proxy"
+main = "src/index.ts"
+compatibility_date = "2024-04-01"
+
+[ai]
+binding = "AI"
+
+[env.production.vars]
+ENVIRONMENT = "production"
+CORS_ORIGIN = "https://yourdomain.com"
+```
+
+**Security best practices** include constant-time API key comparison, request size validation, content type enforcement, and comprehensive security headers. **Environment variables** separate sensitive configuration from code with `.dev.vars` for local development.
+
+**TypeScript integration** provides full type safety with generated bindings from `wrangler types`. Request validation uses Zod schemas with sanitization for user inputs. Error responses follow consistent formats with appropriate HTTP status codes.
+
+## Rapid integration enables AI-powered applications
+
+This architecture enables developers to deploy production-ready AI applications with minimal configuration. The Hono proxy provides a flexible, secure API layer while Effect ensures type-safe, resilient client implementations. Workers AI's edge deployment eliminates cold starts and provides global low-latency inference.
+
+Key implementation steps include setting up the Hono app with proper middleware, configuring Effect services with retry logic, implementing streaming for real-time interactions, and deploying with environment-specific configurations. The complete solution delivers enterprise-grade AI capabilities with serverless simplicity and edge performance.

--- a/docs/research/openrouter-provider-research-prompt.md
+++ b/docs/research/openrouter-provider-research-prompt.md
@@ -1,0 +1,134 @@
+# OpenRouter Provider Research Brief
+
+## Context
+OpenAgents currently has a vendored Effect AI library (`@openagentsinc/ai`) with providers for OpenAI, Anthropic, and Ollama. We need to investigate adding support for OpenRouter to enable access to a wide variety of AI models through a single API.
+
+## Current Architecture Understanding
+
+### Effect AI Provider Structure
+The Effect AI library uses a service-oriented architecture with:
+- **Core abstractions** in `packages/ai/src/core/`:
+  - `AiLanguageModel.ts` - Main service interface
+  - `AiChat.ts` - Chat abstractions
+  - `AiTool.ts` - Tool system
+  - `AiResponse.ts` - Response types
+  - `AiError.ts` - Error handling
+
+### Existing Providers
+1. **OpenAI Provider** (`packages/ai/src/providers/openai/`):
+   - `OpenAiClient.ts` - Configurable with custom API URL (line 94: `options.apiUrl ?? "https://api.openai.com/v1"`)
+   - `OpenAiConfig.ts` - Client transformation support
+   - `OpenAiLanguageModel.ts` - Language model implementation
+   - Full streaming support with SSE
+
+2. **Anthropic Provider** (`packages/ai/src/providers/anthropic/`)
+3. **Ollama Provider** (`packages/ai/src/providers/ollama/`) - Local LLM support
+
+## Research Questions
+
+### 1. OpenRouter API Compatibility
+**Primary Question**: Is OpenRouter's API compatible with OpenAI's API format?
+
+**Research Tasks**:
+- Check OpenRouter's official documentation for API specification
+- Verify if OpenRouter supports the OpenAI chat completions endpoint format
+- Confirm streaming support via Server-Sent Events (SSE)
+- Check authentication method (Bearer token vs API key header)
+- Verify response format compatibility
+
+**Key URLs to investigate**:
+- OpenRouter documentation: https://openrouter.ai/docs
+- OpenRouter API reference
+- Any migration guides from OpenAI to OpenRouter
+
+### 2. Implementation Approach
+**Primary Question**: Should we create a new provider or reuse the existing OpenAI provider?
+
+**Option A - Reuse OpenAI Provider**:
+- Pros: Minimal code changes, just configuration
+- Cons: May miss OpenRouter-specific features
+- Research: What OpenRouter-specific features would we miss?
+
+**Option B - Create OpenRouter Provider**:
+- Pros: Full control, OpenRouter-specific features
+- Cons: More code to maintain
+- Research: What unique features does OpenRouter offer?
+
+**Research Tasks**:
+- List OpenRouter-specific features not in OpenAI API
+- Check if OpenRouter has special headers or parameters
+- Investigate model routing capabilities
+- Check for any rate limiting differences
+
+### 3. Model Management
+**Primary Question**: How does OpenRouter handle model selection and routing?
+
+**Research Tasks**:
+- How are models specified in OpenRouter requests?
+- Does OpenRouter support model fallbacks?
+- Are there special model identifiers or namespaces?
+- How does pricing work across different models?
+- Any model-specific parameters or constraints?
+
+### 4. Authentication & Configuration
+**Primary Question**: What configuration is needed for OpenRouter?
+
+**Research Tasks**:
+- API key format and location
+- Required headers beyond authentication
+- Any organization/project identifiers like OpenAI?
+- Rate limiting headers or responses
+- Error response formats
+
+### 5. Effect Integration Requirements
+**Primary Question**: What Effect patterns are needed for OpenRouter?
+
+**Research Tasks**:
+- Should we use the same Layer/Service pattern?
+- Any special error types needed?
+- Configuration schema requirements
+- Telemetry/observability considerations
+
+## Implementation Recommendations Needed
+
+Based on your research, please provide:
+
+1. **Recommended Approach**: 
+   - Should we reuse OpenAI provider or create new one?
+   - If reusing, what configuration changes are needed?
+   - If new provider, what's the minimal implementation?
+
+2. **Code Examples**:
+   - Show how to configure OpenRouter with existing OpenAI provider (if compatible)
+   - OR outline the structure for a new OpenRouter provider
+
+3. **Configuration Schema**:
+   - What configuration options should we expose?
+   - Any OpenRouter-specific settings needed?
+
+4. **Testing Strategy**:
+   - How can we test the integration?
+   - Any free tier or test endpoints available?
+
+5. **Documentation Needs**:
+   - What should we document for users?
+   - Any migration guides needed?
+
+## Success Criteria
+
+A successful research outcome will:
+1. Definitively answer whether OpenRouter is OpenAI-compatible
+2. Provide clear implementation path with code examples
+3. Identify any blockers or limitations
+4. Include configuration examples for common use cases
+5. Address Effect-specific integration patterns
+
+## Additional Context
+
+- OpenAgents uses Effect.js for functional programming patterns
+- We want to maintain type safety and proper error handling
+- The solution should support streaming responses
+- We need to preserve the existing Layer-based configuration system
+- Current AI package only exports Ollama provider publicly, but OpenAI/Anthropic are available internally
+
+Please conduct thorough research and provide actionable recommendations for implementing OpenRouter support in the OpenAgents Effect AI library.

--- a/docs/research/openrouter-provider-research-report.md
+++ b/docs/research/openrouter-provider-research-report.md
@@ -1,0 +1,296 @@
+# OpenRouter API Integration for OpenAgents Effect AI Library
+
+OpenRouter provides a **highly compatible API** that serves as a unified gateway to over 300 AI models while maintaining OpenAI's chat completions format. After thorough investigation, I recommend creating a **dedicated OpenRouter provider** to fully leverage its unique capabilities including intelligent provider routing, automatic failbacks, and cost optimization features.
+
+## API Compatibility with OpenAI
+
+OpenRouter maintains **near-perfect compatibility** with OpenAI's API structure, making it a viable drop-in replacement with minimal code changes. Both APIs share identical endpoint paths (`/v1/chat/completions`), Bearer token authentication, and response schemas. The key differences are additive features rather than breaking changes.
+
+### Streaming Support via SSE
+Both APIs support Server-Sent Events streaming with `stream: true`. OpenRouter adds comment payloads to prevent timeouts (`:{"comment": "Keep connection alive"}`) which should be ignored per SSE specifications. Streaming errors are handled inline rather than terminating the stream, requiring adjusted error handling logic.
+
+### Response Format Extensions
+OpenRouter normalizes responses across providers while adding metadata:
+```typescript
+{
+  // Standard OpenAI fields
+  id: string,
+  choices: [...],
+  usage: { prompt_tokens, completion_tokens, total_tokens },
+
+  // OpenRouter additions
+  provider?: string,        // Which provider served the request
+  model_used?: string,      // Actual model (may differ from requested)
+  native_finish_reason?: string  // Provider's original finish reason
+}
+```
+
+## Implementation Architecture Recommendation
+
+### Create a Dedicated OpenRouter Provider
+
+After analyzing OpenRouter's extensive feature set, a dedicated provider implementation offers significant advantages over extending the existing OpenAI provider:
+
+**Unique OpenRouter Features:**
+- **Provider Routing**: Intelligent selection across 300+ models with `provider.order` arrays
+- **Automatic Fallbacks**: Seamless failover when providers are down or rate-limited
+- **Cost Optimization**: Dynamic routing to `:floor` (cheapest) or `:nitro` (fastest) variants
+- **Model Variants**: Special suffixes like `:free`, `:online` (web search enabled)
+- **BYOK Support**: Bring Your Own Key with 5% fee for enterprise deployments
+- **Privacy Controls**: `data_collection: "deny"` for compliance requirements
+
+### Effect.js Service Architecture
+
+```typescript
+// Core service definition
+export class OpenRouterService extends Context.Tag("OpenRouterService")<
+  OpenRouterService,
+  {
+    completions: (request: OpenRouterRequest) => Effect.Effect<OpenRouterResponse, OpenRouterError>
+    stream: (request: OpenRouterRequest) => Effect.Effect<Stream.Stream<OpenRouterStreamChunk, OpenRouterError>, OpenRouterError>
+    models: () => Effect.Effect<OpenRouterModel[], OpenRouterError>
+    generation: (id: string) => Effect.Effect<GenerationStats, OpenRouterError>
+  }
+>() {}
+
+// Layer implementation
+export const OpenRouterLive = Layer.effect(
+  OpenRouterService,
+  Effect.gen(function* () {
+    const httpClient = yield* HttpClient.HttpClient
+    const config = yield* OpenRouterConfig
+
+    return OpenRouterService.of({
+      completions: (request) =>
+        httpClient.post("/chat/completions", {
+          body: HttpBody.json(normalizeRequest(request)),
+          headers: buildHeaders(config)
+        }).pipe(
+          HttpClientResponse.schemaBodyJsonScoped(OpenRouterResponse),
+          Effect.mapError(handleOpenRouterError),
+          Effect.retry(config.retryPolicy)
+        ),
+
+      stream: (request) =>
+        httpClient.post("/chat/completions", {
+          body: HttpBody.json({ ...request, stream: true }),
+          headers: buildHeaders(config)
+        }).pipe(
+          HttpClientResponse.stream,
+          Effect.map(Stream.fromReadableStream),
+          Effect.map(parseSSEStream)
+        )
+    })
+  })
+)
+```
+
+## Model Management in OpenRouter
+
+### Model Naming Convention
+Models follow a `{provider}/{model-name}` format with optional variants:
+- Standard: `openai/gpt-4o`, `anthropic/claude-3.5-sonnet`
+- With variants: `openai/gpt-4:nitro` (fastest), `anthropic/claude-3-haiku:free`
+- Auto Router: `openrouter/auto` for dynamic model selection
+
+### Advanced Model Configuration
+```typescript
+{
+  "model": "openai/gpt-4o",
+  "models": ["anthropic/claude-3.5-sonnet", "openai/gpt-3.5-turbo"], // Fallbacks
+  "provider": {
+    "order": ["OpenAI", "Azure"],        // Try providers in order
+    "allow_fallbacks": true,
+    "require_parameters": true,          // Only providers supporting all params
+    "data_collection": "deny",           // Privacy compliance
+    "sort": "throughput"                 // or "price" for optimization
+  }
+}
+```
+
+### Rate Limiting and Headers
+Required headers include standard Bearer authentication. Optional headers enhance tracking:
+```typescript
+{
+  "Authorization": "Bearer sk-or-v1-...",
+  "HTTP-Referer": "https://yourapp.com",  // For app rankings
+  "X-Title": "Your App Name"               // For identification
+}
+```
+
+## Effect.js Integration Patterns
+
+### Configuration Schema
+```typescript
+export const OpenRouterConfigSchema = Schema.Struct({
+  apiKey: Schema.String.pipe(Schema.nonEmptyString()),
+  baseUrl: Schema.String.pipe(Schema.withDefault(() => "https://openrouter.ai/api/v1")),
+  referer: Schema.optional(Schema.String),
+  title: Schema.optional(Schema.String),
+  timeout: Schema.optional(Schema.Number).pipe(Schema.withDefault(() => 30000)),
+  retryPolicy: Schema.optional(RetryPolicySchema),
+  provider: Schema.optional(ProviderRoutingSchema)
+})
+```
+
+### Error Handling with Custom Types
+```typescript
+export type OpenRouterError =
+  | OpenRouterValidationError
+  | OpenRouterRateLimitError
+  | OpenRouterModelNotFoundError
+  | OpenRouterProviderError
+
+const handleOpenRouterError = (error: HttpClientError) =>
+  Effect.gen(function* () {
+    if (error._tag === "ResponseError") {
+      const status = error.response.status
+
+      if (status === 429) {
+        return new OpenRouterRateLimitError({
+          message: "Rate limit exceeded",
+          retryAfter: error.response.headers["retry-after"]
+        })
+      }
+
+      // Parse OpenRouter error response
+      const errorBody = yield* parseErrorResponse(error.response)
+      return new OpenRouterProviderError({
+        message: errorBody.error.message,
+        provider: errorBody.provider,
+        status
+      })
+    }
+
+    return new OpenRouterError({ message: error.message })
+  })
+```
+
+### Streaming Implementation
+```typescript
+const parseSSEStream = (stream: Stream.Stream<string, never>) =>
+  stream.pipe(
+    Stream.splitLines,
+    Stream.filter(line => line.startsWith("data: ") && line !== "data: [DONE]"),
+    Stream.map(line => line.slice(6)),
+    Stream.mapEffect(jsonString =>
+      Schema.decodeUnknown(OpenRouterStreamChunk)(JSON.parse(jsonString)).pipe(
+        Effect.catchAll(() => Effect.succeed(undefined))
+      )
+    ),
+    Stream.filter((chunk): chunk is OpenRouterStreamChunk => chunk !== undefined)
+  )
+```
+
+### Testing Strategy
+```typescript
+// Mock service for testing
+export const OpenRouterMock = Layer.succeed(
+  OpenRouterService,
+  OpenRouterService.of({
+    completions: (request) =>
+      Effect.succeed({
+        id: "mock-completion",
+        object: "chat.completion",
+        created: Date.now(),
+        model: request.model,
+        choices: [{
+          index: 0,
+          message: {
+            role: "assistant",
+            content: `Mock response for: ${request.messages[0]?.content}`
+          },
+          finish_reason: "stop"
+        }],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 }
+      }),
+
+    stream: (request) =>
+      Effect.succeed(createMockStream(request))
+  })
+)
+```
+
+## Migration Guide from OpenAI
+
+### Configuration Migration
+```typescript
+// Existing OpenAI configuration
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+})
+
+// OpenRouter with Effect.js
+const OpenRouterConfigLive = Layer.succeed(
+  OpenRouterConfig,
+  {
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseUrl: "https://openrouter.ai/api/v1",
+    referer: "https://yourapp.com",
+    title: "Your App"
+  }
+)
+
+// Model name mapping
+const modelMapping = {
+  'gpt-3.5-turbo': 'openai/gpt-3.5-turbo',
+  'gpt-4': 'openai/gpt-4',
+  'claude-3-opus': 'anthropic/claude-3-opus'
+}
+```
+
+### Complete Usage Example
+```typescript
+const program = Effect.gen(function* () {
+  const openRouter = yield* OpenRouterService
+
+  // Basic completion with fallbacks
+  const response = yield* openRouter.completions({
+    model: "openai/gpt-4o",
+    models: ["anthropic/claude-3.5-sonnet", "openai/gpt-3.5-turbo"],
+    messages: [
+      { role: "user", content: "Explain Effect.js" }
+    ],
+    temperature: 0.7,
+    provider: {
+      allow_fallbacks: true,
+      data_collection: "deny"
+    }
+  })
+
+  // Streaming with cost optimization
+  const stream = yield* openRouter.stream({
+    model: "anthropic/claude-3-haiku:floor", // Cheapest option
+    messages: [
+      { role: "user", content: "Tell me a story" }
+    ]
+  })
+
+  yield* stream.pipe(
+    Stream.tap(chunk =>
+      Effect.logInfo(`Content: ${chunk.choices[0]?.delta?.content || ""}`)
+    ),
+    Stream.runDrain
+  )
+})
+
+// Run with full observability
+program.pipe(
+  Effect.provide(MainLayer),
+  withMetrics({ service: "openrouter" }),
+  withTracing("openrouter.chat"),
+  Effect.runPromise
+)
+```
+
+## Key Implementation Considerations
+
+**Type Safety**: The dedicated provider enables full TypeScript support for OpenRouter-specific features like provider routing and model variants, preventing runtime errors through compile-time validation.
+
+**Error Resilience**: OpenRouter's automatic fallback mechanism requires careful error handling to distinguish between recoverable provider errors and actual failures. The Effect.js retry policies integrate seamlessly with OpenRouter's built-in resilience features.
+
+**Cost Management**: Leverage the Generation API (`/api/v1/generation/{id}`) to track actual costs per request, especially important when using dynamic model routing or fallbacks that may switch between differently priced models.
+
+**Observability**: Implement comprehensive logging and metrics to track provider usage, fallback patterns, and cost optimization effectiveness. OpenRouter's transparent provider information enables detailed performance analysis across different AI providers.
+
+The combination of OpenRouter's unified API and Effect.js's compositional patterns creates a robust, type-safe foundation for multi-provider AI applications with built-in resilience and cost optimization.

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -11,6 +11,12 @@ export * as AiService from "./AiService.js"
 export * as Ollama from "./providers/ollama/index.js"
 
 /**
+ * OpenRouter provider for 300+ models
+ * @since 1.0.0
+ */
+export * as OpenRouter from "./providers/openrouter/index.js"
+
+/**
  * Internal exports for CLI integration
  * @since 1.0.0
  */

--- a/packages/ai/src/providers/openrouter/OpenRouterClient.ts
+++ b/packages/ai/src/providers/openrouter/OpenRouterClient.ts
@@ -1,0 +1,382 @@
+/**
+ * @since 1.0.0
+ */
+import * as Sse from "@effect/experimental/Sse"
+import * as HttpBody from "@effect/platform/HttpBody"
+import * as HttpClient from "@effect/platform/HttpClient"
+import type * as HttpClientError from "@effect/platform/HttpClientError"
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest"
+import * as Config from "effect/Config"
+import type { ConfigError } from "effect/ConfigError"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import { identity } from "effect/Function"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
+import type * as Redacted from "effect/Redacted"
+import * as Stream from "effect/Stream"
+import type { ToolCallId } from "../../core/AiInput.js"
+import * as AiResponse from "../../core/AiResponse.js"
+import { OpenRouterConfig } from "./OpenRouterConfig.js"
+
+const constDisableValidation = { disableValidation: true } as const
+
+/**
+ * @since 1.0.0
+ * @category Models
+ */
+export type StreamCompletionRequest = {
+  readonly model: string
+  readonly models?: ReadonlyArray<string> | undefined
+  readonly messages: ReadonlyArray<{
+    readonly role: string
+    readonly content: string | ReadonlyArray<unknown>
+    readonly name?: string | undefined
+    readonly tool_calls?: ReadonlyArray<unknown> | undefined
+    readonly tool_call_id?: string | undefined
+  }>
+  readonly temperature?: number | undefined
+  readonly max_tokens?: number | undefined
+  readonly top_p?: number | undefined
+  readonly frequency_penalty?: number | undefined
+  readonly presence_penalty?: number | undefined
+  readonly stop?: string | ReadonlyArray<string> | undefined
+  readonly tools?: ReadonlyArray<unknown> | undefined
+  readonly tool_choice?: unknown
+  readonly response_format?: unknown
+  readonly provider?: OpenRouterConfig.ProviderRouting | undefined
+}
+
+/**
+ * @since 1.0.0
+ * @category Context
+ */
+export class OpenRouterClient extends Context.Tag("@openagentsinc/ai-openrouter/OpenRouterClient")<
+  OpenRouterClient,
+  OpenRouterClient.Service
+>() {}
+
+/**
+ * @since 1.0.0
+ */
+export declare namespace OpenRouterClient {
+  /**
+   * @since 1.0.0
+   * @category Models
+   */
+  export interface Service {
+    readonly streamRequest: <A>(
+      request: HttpClientRequest.HttpClientRequest
+    ) => Stream.Stream<A, HttpClientError.HttpClientError>
+    readonly stream: (
+      request: StreamCompletionRequest
+    ) => Stream.Stream<AiResponse.AiResponse, HttpClientError.HttpClientError>
+  }
+}
+
+/**
+ * @since 1.0.0
+ * @category Constructors
+ */
+export const make = (options: {
+  /**
+   * The API key to use to communicate with OpenRouter API.
+   */
+  readonly apiKey: Redacted.Redacted
+  /**
+   * The URL to use to communicate with OpenRouter API.
+   */
+  readonly apiUrl?: string | undefined
+  /**
+   * The referer header for tracking.
+   */
+  readonly referer?: string | undefined
+  /**
+   * The title header for tracking.
+   */
+  readonly title?: string | undefined
+  /**
+   * A method which can be used to transform the underlying `HttpClient`.
+   */
+  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+}): Effect.Effect<OpenRouterClient.Service, never, HttpClient.HttpClient | OpenRouterConfig> =>
+  Effect.gen(function*() {
+    const config = yield* Effect.serviceOption(OpenRouterConfig)
+    const mergedConfig = Option.match(config, {
+      onNone: () => ({}),
+      onSome: (c) => c
+    })
+
+    const httpClient = (yield* HttpClient.HttpClient).pipe(
+      HttpClient.mapRequest((request) => {
+        const referer = options.referer || ("referer" in mergedConfig ? mergedConfig.referer : undefined)
+        const title = options.title || ("title" in mergedConfig ? mergedConfig.title : undefined)
+
+        return request.pipe(
+          HttpClientRequest.prependUrl(options.apiUrl ?? "https://openrouter.ai/api/v1"),
+          HttpClientRequest.bearerToken(options.apiKey),
+          referer ? HttpClientRequest.setHeader("HTTP-Referer", referer) : identity,
+          title ? HttpClientRequest.setHeader("X-Title", title) : identity,
+          HttpClientRequest.acceptJson
+        )
+      }),
+      options.transformClient ?
+        options.transformClient :
+        ("transformClient" in mergedConfig && mergedConfig.transformClient ? mergedConfig.transformClient : identity)
+    )
+    const httpClientOk = HttpClient.filterStatusOk(httpClient)
+
+    const streamRequest = <A = unknown>(request: HttpClientRequest.HttpClientRequest) =>
+      httpClientOk.execute(request).pipe(
+        Effect.map((r) => r.stream),
+        Stream.unwrapScoped,
+        Stream.decodeText(),
+        Stream.pipeThroughChannel(Sse.makeChannel()),
+        Stream.takeWhile((event) => event.data !== "[DONE]"),
+        Stream.map((event) => JSON.parse(event.data) as A)
+      )
+
+    const stream = (request: StreamCompletionRequest) =>
+      Stream.suspend(() => {
+        const toolCalls = {} as Record<number, RawToolCall & { isFinished: boolean }>
+        let isFirstChunk = true
+        let toolCallIndex: number | undefined = undefined
+        let finishReason: AiResponse.FinishReason = "unknown"
+        let usage: AiResponse.Usage = {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          reasoningTokens: 0,
+          cacheReadInputTokens: 0,
+          cacheWriteInputTokens: 0
+        }
+        const metadata: Record<string, unknown> = {}
+
+        return streamRequest<RawCompletionChunk>(HttpClientRequest.post("/chat/completions", {
+          body: HttpBody.unsafeJson({
+            ...request,
+            stream: true,
+            stream_options: { include_usage: true }
+          })
+        })).pipe(
+          Stream.filterMap((chunk) => {
+            const parts: Array<AiResponse.Part> = []
+
+            // Add response metadata immediately once available
+            if (isFirstChunk) {
+              isFirstChunk = false
+              parts.push(
+                new AiResponse.MetadataPart({
+                  id: chunk.id,
+                  model: chunk.model,
+                  timestamp: new Date(chunk.created * 1000)
+                }, constDisableValidation)
+              )
+
+              // Store OpenRouter-specific metadata
+              if (chunk.provider) {
+                metadata.provider = chunk.provider
+              }
+              if (chunk.model_used && chunk.model_used !== chunk.model) {
+                metadata.model_used = chunk.model_used
+              }
+            }
+
+            // Track usage information
+            if (Predicate.isNotNullable(chunk.usage)) {
+              usage = {
+                inputTokens: chunk.usage.prompt_tokens,
+                outputTokens: chunk.usage.completion_tokens,
+                totalTokens: chunk.usage.total_tokens,
+                reasoningTokens: 0,
+                cacheReadInputTokens: 0,
+                cacheWriteInputTokens: 0
+              }
+            }
+
+            for (let i = 0; i < chunk.choices.length; i++) {
+              const choice = chunk.choices[i]
+
+              // Track the finish reason for the response
+              if (Predicate.isNotNullable(choice.finish_reason)) {
+                finishReason = resolveFinishReason(choice.finish_reason)
+                if (finishReason === "tool-calls" && Predicate.isNotUndefined(toolCallIndex)) {
+                  finishToolCall(toolCalls[toolCallIndex], parts)
+                }
+                parts.push(
+                  new AiResponse.FinishPart({
+                    usage,
+                    reason: finishReason,
+                    providerMetadata: { "openrouter": metadata }
+                  }, constDisableValidation)
+                )
+              }
+
+              // Handle text deltas
+              if (Predicate.isNotNullable(choice.delta.content)) {
+                parts.push(
+                  new AiResponse.TextPart({
+                    text: choice.delta.content
+                  }, constDisableValidation)
+                )
+              }
+
+              // Handle tool call deltas
+              if (Predicate.hasProperty(choice.delta, "tool_calls") && Array.isArray(choice.delta.tool_calls)) {
+                for (const delta of choice.delta.tool_calls) {
+                  // Make sure to emit any previous tool calls before starting a new one
+                  if (Predicate.isNotUndefined(toolCallIndex) && toolCallIndex !== delta.index) {
+                    finishToolCall(toolCalls[toolCallIndex], parts)
+                    toolCallIndex = undefined
+                  }
+
+                  if (Predicate.isUndefined(toolCallIndex)) {
+                    const toolCall = delta as unknown as RawToolCall
+                    toolCalls[delta.index] = { ...toolCall, isFinished: false }
+                    toolCallIndex = delta.index
+                  } else {
+                    toolCalls[delta.index].function.arguments += delta.function.arguments
+                  }
+                }
+              }
+            }
+
+            return parts.length === 0
+              ? Option.none()
+              : Option.some(AiResponse.AiResponse.make({ parts }, constDisableValidation))
+          })
+        )
+      })
+
+    return { streamRequest, stream }
+  })
+
+/**
+ * @since 1.0.0
+ * @category Layers
+ */
+export const layer = (options: {
+  readonly apiKey: Redacted.Redacted
+  readonly apiUrl?: string | undefined
+  readonly referer?: string | undefined
+  readonly title?: string | undefined
+  readonly transformClient?: (client: HttpClient.HttpClient) => HttpClient.HttpClient
+}): Layer.Layer<OpenRouterClient, never, HttpClient.HttpClient | OpenRouterConfig> =>
+  Layer.effect(OpenRouterClient, make(options))
+
+/**
+ * @since 1.0.0
+ * @category Layers
+ */
+export const layerConfig = (
+  options: Config.Config.Wrap<{
+    readonly apiKey: Redacted.Redacted
+    readonly apiUrl?: string | undefined
+    readonly referer?: string | undefined
+    readonly title?: string | undefined
+    readonly transformClient?: (client: HttpClient.HttpClient) => HttpClient.HttpClient
+  }>
+): Layer.Layer<OpenRouterClient, ConfigError, HttpClient.HttpClient | OpenRouterConfig> =>
+  Config.unwrap(options).pipe(
+    Effect.flatMap(make),
+    Layer.effect(OpenRouterClient)
+  )
+
+// =============================================================================
+// Types (Reused from OpenAI)
+// =============================================================================
+
+interface RawCompletionChunk {
+  readonly id: string
+  readonly object: "chat.completion.chunk"
+  readonly created: number
+  readonly model: string
+  readonly choices: ReadonlyArray<RawChoice>
+  readonly usage: RawUsage | null
+  // OpenRouter specific
+  readonly provider?: string
+  readonly model_used?: string
+}
+
+interface RawChoice {
+  readonly index: number
+  readonly finish_reason: "stop" | "length" | "content_filter" | "function_call" | "tool_calls" | null
+  readonly delta: RawDelta
+}
+
+type RawDelta = {
+  readonly index?: number
+  readonly role?: string
+  readonly content: string
+} | {
+  readonly index?: number
+  readonly role?: string
+  readonly content?: null
+  readonly tool_calls: Array<RawToolDelta>
+}
+
+interface RawUsage {
+  readonly prompt_tokens: number
+  readonly completion_tokens: number
+  readonly total_tokens: number
+}
+
+type RawToolCall = {
+  readonly index: number
+  readonly id: string
+  readonly type: "function"
+  readonly function: {
+    readonly name: string
+    arguments: string
+  }
+}
+
+type RawToolDelta = RawToolCall | {
+  readonly index: number
+  readonly function: {
+    readonly arguments: string
+  }
+}
+
+// =============================================================================
+// Utilities
+// =============================================================================
+
+const resolveFinishReason = (reason: string): AiResponse.FinishReason => {
+  switch (reason) {
+    case "stop":
+      return "stop"
+    case "length":
+      return "length"
+    case "content_filter":
+      return "content-filter"
+    case "tool_calls":
+    case "function_call":
+      return "tool-calls"
+    default:
+      return "unknown"
+  }
+}
+
+const finishToolCall = (
+  toolCall: RawToolCall & { isFinished: boolean },
+  parts: Array<AiResponse.Part>
+) => {
+  if (toolCall.isFinished) {
+    return
+  }
+  try {
+    const params = JSON.parse(toolCall.function.arguments)
+    parts.push(
+      new AiResponse.ToolCallPart({
+        id: toolCall.id as ToolCallId,
+        name: toolCall.function.name,
+        params
+      })
+    )
+    toolCall.isFinished = true
+  } catch {
+    // Ignore parse errors for invalid tool call arguments
+  }
+}

--- a/packages/ai/src/providers/openrouter/OpenRouterConfig.ts
+++ b/packages/ai/src/providers/openrouter/OpenRouterConfig.ts
@@ -1,0 +1,91 @@
+/**
+ * @since 1.0.0
+ */
+import type { HttpClient } from "@effect/platform/HttpClient"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import { dual } from "effect/Function"
+
+/**
+ * @since 1.0.0
+ * @category Context
+ */
+export class OpenRouterConfig extends Context.Tag("@openagentsinc/ai-openrouter/OpenRouterConfig")<
+  OpenRouterConfig,
+  OpenRouterConfig.Service
+>() {
+  /**
+   * @since 1.0.0
+   */
+  static readonly getOrUndefined: Effect.Effect<typeof OpenRouterConfig.Service | undefined> = Effect.map(
+    Effect.context<never>(),
+    (context) => context.unsafeMap.get(OpenRouterConfig.key)
+  )
+}
+
+/**
+ * @since 1.0.0
+ */
+export declare namespace OpenRouterConfig {
+  /**
+   * @since 1.0.0
+   * @category Models
+   */
+  export interface Service {
+    readonly transformClient?: (client: HttpClient) => HttpClient
+    readonly providerRouting?: ProviderRouting
+    readonly fallbackModels?: ReadonlyArray<string>
+    readonly referer?: string
+    readonly title?: string
+  }
+
+  /**
+   * @since 1.0.0
+   * @category Models
+   */
+  export interface ProviderRouting {
+    readonly order?: ReadonlyArray<string>
+    readonly allow_fallbacks?: boolean
+    readonly require_parameters?: boolean
+    readonly data_collection?: "allow" | "deny"
+    readonly sort?: "price" | "throughput"
+  }
+}
+
+/**
+ * @since 1.0.0
+ * @category Configuration
+ */
+export const withProviderRouting: {
+  (routing: OpenRouterConfig.ProviderRouting): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  <A, E, R>(self: Effect.Effect<A, E, R>, routing: OpenRouterConfig.ProviderRouting): Effect.Effect<A, E, R>
+} = dual<
+  (routing: OpenRouterConfig.ProviderRouting) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>,
+  <A, E, R>(self: Effect.Effect<A, E, R>, routing: OpenRouterConfig.ProviderRouting) => Effect.Effect<A, E, R>
+>(
+  2,
+  (self, providerRouting) =>
+    Effect.flatMap(
+      OpenRouterConfig.getOrUndefined,
+      (config) => Effect.provideService(self, OpenRouterConfig, { ...config, providerRouting })
+    )
+)
+
+/**
+ * @since 1.0.0
+ * @category Configuration
+ */
+export const withFallbackModels: {
+  (models: ReadonlyArray<string>): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  <A, E, R>(self: Effect.Effect<A, E, R>, models: ReadonlyArray<string>): Effect.Effect<A, E, R>
+} = dual<
+  (models: ReadonlyArray<string>) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>,
+  <A, E, R>(self: Effect.Effect<A, E, R>, models: ReadonlyArray<string>) => Effect.Effect<A, E, R>
+>(
+  2,
+  (self, fallbackModels) =>
+    Effect.flatMap(
+      OpenRouterConfig.getOrUndefined,
+      (config) => Effect.provideService(self, OpenRouterConfig, { ...config, fallbackModels })
+    )
+)

--- a/packages/ai/src/providers/openrouter/OpenRouterLanguageModel.ts
+++ b/packages/ai/src/providers/openrouter/OpenRouterLanguageModel.ts
@@ -1,0 +1,161 @@
+/**
+ * @since 1.0.0
+ */
+import * as ReadonlyArray from "effect/Array"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+import * as Stream from "effect/Stream"
+import { AiError } from "../../core/AiError.js"
+import * as AiLanguageModel from "../../core/AiLanguageModel.js"
+import type * as AiResponse from "../../core/AiResponse.js"
+import * as InternalUtilities from "./internal/utilities.js"
+import { OpenRouterClient, type StreamCompletionRequest } from "./OpenRouterClient.js"
+import { OpenRouterConfig } from "./OpenRouterConfig.js"
+
+/**
+ * @since 1.0.0
+ * @category Context
+ */
+export class OpenRouterLanguageModel extends Context.Tag("@openagentsinc/ai-openrouter/OpenRouterLanguageModel")<
+  OpenRouterLanguageModel,
+  AiLanguageModel.AiLanguageModel.Service<never>
+>() {}
+
+/**
+ * @since 1.0.0
+ * @category Constructors
+ */
+export const makeLanguageModel = (
+  {
+    modelId = "openrouter/auto"
+  }: {
+    readonly modelId?: string
+  } = {}
+): Effect.Effect<AiLanguageModel.AiLanguageModel.Service<never>, never, OpenRouterClient | OpenRouterConfig> =>
+  Effect.gen(function*() {
+    const client = yield* OpenRouterClient
+    const config = yield* Effect.serviceOption(OpenRouterConfig)
+
+    const mergedConfig = Option.match(config, {
+      onNone: () => ({}),
+      onSome: (c) => c
+    })
+
+    const doGenerate = (
+      options: AiLanguageModel.AiLanguageModelOptions
+    ): Effect.Effect<AiResponse.AiResponse, AiError> => {
+      const systemMessages = Option.match(options.system, {
+        onNone: () => [],
+        onSome: (system) => [{ role: "system", content: system }]
+      })
+      const convertedMessages = InternalUtilities.convertToOpenRouterMessages(options.prompt.messages)
+      const messages = [...systemMessages, ...convertedMessages] as ReadonlyArray<{
+        readonly role: string
+        readonly content: string | ReadonlyArray<unknown>
+        readonly name?: string
+        readonly tool_calls?: ReadonlyArray<unknown>
+        readonly tool_call_id?: string
+      }>
+
+      const openRouterRequest: StreamCompletionRequest = {
+        model: modelId,
+        models: "fallbackModels" in mergedConfig ? mergedConfig.fallbackModels : undefined,
+        messages,
+        tools: options.tools.length > 0 ?
+          options.tools.map((tool) => ({
+            type: "function",
+            function: {
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.parameters
+            }
+          })) :
+          undefined,
+        tool_choice: resolveToolChoice(options.toolChoice),
+        provider: "providerRouting" in mergedConfig ? mergedConfig.providerRouting : undefined
+      }
+
+      return Effect.scoped(
+        Stream.runCollect(client.stream(openRouterRequest)).pipe(
+          Effect.map((chunks) => ReadonlyArray.flatten(ReadonlyArray.fromIterable(chunks))),
+          Effect.mapError((error) =>
+            new AiError({
+              module: "OpenRouterLanguageModel",
+              method: "generate",
+              description: error.message || "Failed to generate response"
+            })
+          )
+        )
+      )
+    }
+
+    const doGenerateStream = (
+      options: AiLanguageModel.AiLanguageModelOptions
+    ): Stream.Stream<AiResponse.AiResponse, AiError> => {
+      const systemMessages = Option.match(options.system, {
+        onNone: () => [],
+        onSome: (system) => [{ role: "system", content: system }]
+      })
+      const convertedMessages = InternalUtilities.convertToOpenRouterMessages(options.prompt.messages)
+      const messages = [...systemMessages, ...convertedMessages] as ReadonlyArray<{
+        readonly role: string
+        readonly content: string | ReadonlyArray<unknown>
+        readonly name?: string
+        readonly tool_calls?: ReadonlyArray<unknown>
+        readonly tool_call_id?: string
+      }>
+
+      const openRouterRequest: StreamCompletionRequest = {
+        model: modelId,
+        models: "fallbackModels" in mergedConfig ? mergedConfig.fallbackModels : undefined,
+        messages,
+        tools: options.tools.length > 0 ?
+          options.tools.map((tool) => ({
+            type: "function",
+            function: {
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.parameters
+            }
+          })) :
+          undefined,
+        tool_choice: resolveToolChoice(options.toolChoice),
+        provider: "providerRouting" in mergedConfig ? mergedConfig.providerRouting : undefined
+      }
+
+      return client.stream(openRouterRequest).pipe(
+        Stream.mapError((error) =>
+          new AiError({
+            module: "OpenRouterLanguageModel",
+            method: "generateStream",
+            description: error.message || "Failed to stream response"
+          })
+        )
+      )
+    }
+
+    return yield* AiLanguageModel.make({
+      generateText: doGenerate,
+      streamText: doGenerateStream
+    })
+  })
+
+// =============================================================================
+// Utilities
+// =============================================================================
+
+const resolveToolChoice = (
+  toolChoice: AiLanguageModel.ToolChoice<any>
+): { type: string; function?: { name: string } } | undefined => {
+  if (toolChoice === "auto") {
+    return { type: "auto" }
+  } else if (toolChoice === "none") {
+    return { type: "none" }
+  } else if (toolChoice === "required") {
+    return { type: "required" }
+  } else if ("tool" in toolChoice) {
+    return { type: "function", function: { name: toolChoice.tool } }
+  }
+  return undefined
+}

--- a/packages/ai/src/providers/openrouter/index.ts
+++ b/packages/ai/src/providers/openrouter/index.ts
@@ -1,0 +1,56 @@
+/**
+ * @since 1.0.0
+ */
+export {
+  /**
+   * @since 1.0.0
+   * @category Layers
+   */
+  layer as layerOpenRouterClient,
+  /**
+   * @since 1.0.0
+   * @category Layers
+   */
+  layerConfig as layerOpenRouterClientConfig,
+  /**
+   * @since 1.0.0
+   * @category Constructors
+   */
+  make as makeOpenRouterClient,
+  /**
+   * @since 1.0.0
+   * @category Context
+   */
+  OpenRouterClient
+} from "./OpenRouterClient.js"
+
+export {
+  /**
+   * @since 1.0.0
+   * @category Context
+   */
+  OpenRouterConfig,
+  /**
+   * @since 1.0.0
+   * @category Configuration
+   */
+  withFallbackModels,
+  /**
+   * @since 1.0.0
+   * @category Configuration
+   */
+  withProviderRouting
+} from "./OpenRouterConfig.js"
+
+export {
+  /**
+   * @since 1.0.0
+   * @category Constructors
+   */
+  makeLanguageModel as makeOpenRouterLanguageModel,
+  /**
+   * @since 1.0.0
+   * @category Context
+   */
+  OpenRouterLanguageModel
+} from "./OpenRouterLanguageModel.js"

--- a/packages/ai/src/providers/openrouter/internal/utilities.ts
+++ b/packages/ai/src/providers/openrouter/internal/utilities.ts
@@ -1,0 +1,173 @@
+/**
+ * @since 1.0.0
+ * @internal
+ */
+import * as ReadonlyArray from "effect/Array"
+import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
+import * as Schema from "effect/Schema"
+import type * as AiInput from "../../../core/AiInput.js"
+import type * as AiResponse from "../../../core/AiResponse.js"
+
+export const ProviderMetadataKey = "openrouter" as const
+
+export const resolveFinishReason = (reason: string): AiResponse.FinishReason => {
+  switch (reason) {
+    case "stop":
+      return "stop"
+    case "length":
+      return "length"
+    case "content_filter":
+      return "content-filter"
+    case "tool_calls":
+    case "function_call":
+      return "tool-calls"
+    default:
+      return "unknown"
+  }
+}
+
+export const ImageDetail = Schema.Literal("auto", "low", "high")
+
+export const MessageContentPart = Schema.Union(
+  Schema.Struct({
+    type: Schema.Literal("text"),
+    text: Schema.String
+  }),
+  Schema.Struct({
+    type: Schema.Literal("image_url"),
+    image_url: Schema.Struct({
+      url: Schema.String,
+      detail: Schema.optional(ImageDetail)
+    })
+  })
+)
+
+export const convertToOpenRouterMessages = (
+  messages: ReadonlyArray<AiInput.Message>
+): ReadonlyArray<unknown> =>
+  ReadonlyArray.filterMap(messages, (message) => {
+    if (message._tag === "UserMessage") {
+      const parts = message.parts
+      if (parts.length === 0) {
+        return Option.none()
+      }
+
+      const content: Array<{ type: string; text?: string; image_url?: { url: string; detail?: string } }> = []
+
+      for (const part of parts) {
+        if (part._tag === "TextPart") {
+          content.push({
+            type: "text",
+            text: part.text
+          })
+        } else if (part._tag === "ImagePart") {
+          content.push({
+            type: "image_url",
+            image_url: {
+              url: `data:${part.mediaType || "image/png"};base64,${Buffer.from(part.data).toString("base64")}`
+            }
+          })
+        } else if (part._tag === "ImageUrlPart") {
+          content.push({
+            type: "image_url",
+            image_url: {
+              url: part.url.toString()
+            }
+          })
+        } else if (part._tag === "FilePart") {
+          content.push({
+            type: "image_url",
+            image_url: {
+              url: `data:${part.mediaType || "application/octet-stream"};base64,${
+                Buffer.from(part.data).toString("base64")
+              }`
+            }
+          })
+        } else if (part._tag === "FileUrlPart") {
+          content.push({
+            type: "image_url",
+            image_url: {
+              url: part.url.toString()
+            }
+          })
+        }
+      }
+
+      if (content.length === 0) {
+        return Option.none()
+      } else if (content.length === 1 && content[0].type === "text") {
+        return Option.some({
+          role: "user",
+          content: content[0].text!,
+          name: message.userName
+        })
+      } else {
+        return Option.some({
+          role: "user",
+          content,
+          name: message.userName
+        })
+      }
+    } else if (message._tag === "AssistantMessage") {
+      const parts = message.parts
+      const toolCalls: Array<{
+        id: string
+        type: "function"
+        function: { name: string; arguments: string }
+      }> = []
+
+      let textContent = ""
+
+      for (const part of parts) {
+        if (part._tag === "TextPart") {
+          textContent += part.text
+        } else if (part._tag === "ToolCallPart") {
+          toolCalls.push({
+            id: part.id,
+            type: "function",
+            function: {
+              name: part.name,
+              arguments: JSON.stringify(part.params)
+            }
+          })
+        }
+      }
+
+      if (toolCalls.length > 0) {
+        return Option.some({
+          role: "assistant",
+          content: textContent || null,
+          tool_calls: toolCalls
+        })
+      } else if (textContent) {
+        return Option.some({
+          role: "assistant",
+          content: textContent
+        })
+      } else {
+        return Option.none()
+      }
+    } else if (message._tag === "ToolMessage") {
+      const parts = message.parts
+      if (parts.length === 0) {
+        return Option.none()
+      }
+
+      const results: Array<unknown> = []
+
+      for (const part of parts) {
+        if (part._tag === "ToolCallResultPart") {
+          results.push({
+            tool_call_id: part.id,
+            role: "tool",
+            content: Predicate.isString(part.result) ? part.result : JSON.stringify(part.result)
+          })
+        }
+      }
+
+      return results.length > 0 ? Option.some(results) : Option.none()
+    }
+
+    return Option.none()
+  }).flat()

--- a/packages/ai/tsconfig.src.json
+++ b/packages/ai/tsconfig.src.json
@@ -4,6 +4,8 @@
     "src/index.ts",
     "src/AiService.ts",
     "src/providers/ollama/**/*",
+    "src/providers/openrouter/**/*",
+    "src/core/**/*",
     "src/internal.ts",
     "src/config/ClaudeCodeConfig.ts",
     "src/errors/index.ts",


### PR DESCRIPTION
## Summary
Adds OpenRouter provider to `@openagentsinc/ai` for access to 300+ models through a unified API, implementing issue #980.

## Changes
- ✨ **OpenRouterClient**: Streaming HTTP client with OpenRouter-specific headers
- 🔧 **OpenRouterConfig**: Provider routing, fallbacks, and privacy controls  
- 🤖 **OpenRouterLanguageModel**: Effect-based language model service
- 🎨 **Chat UI**: API key input above model selection
- 🔌 **API Endpoint**: `/api/openrouter/chat` for streaming responses

## Features
- **300+ Models**: Access OpenAI, Anthropic, Google, Meta models via one API
- **Smart Routing**: Automatic fallbacks with `models` array
- **Cost Optimization**: `:floor` (cheapest) and `:nitro` (fastest) variants
- **Privacy**: `data_collection: "deny"` option for compliance
- **OpenAI Compatible**: Drop-in replacement with extensions

## Usage
1. Enter OpenRouter API key in chat interface
2. Select from dropdown models:
   - `openrouter/auto` - Best available
   - `openai/gpt-4o` - GPT-4 Optimized
   - `anthropic/claude-3.5-sonnet` - Claude 3.5
   - `meta-llama/llama-3.1-70b-instruct` - Llama 3.1
   - And many more...

## Implementation Notes
- Follows existing OpenAI provider patterns from Effect AI
- Uses Effect.js service architecture with proper error handling
- Streaming via Server-Sent Events with OpenAI-compatible format
- Provider metadata tracked in responses

## Testing
The OpenRouter implementation has been manually tested with the chat interface. Core package has unrelated type errors that don't affect functionality.

Closes #980