### PR TITLE
fix: Correct GFN naming to Group-Forming Network and realistic values

### DIFF
--- a/apps/openagents.com/src/components/navigation.ts
+++ b/apps/openagents.com/src/components/navigation.ts
@@ -2,7 +2,7 @@ import { html } from "@openagentsinc/psionic"
 
 export function navigation({ current }: { current: string }) {
   const rightLinks = [
-    { href: "/gfn", label: "⚡ GFN", key: "gfn" },
+    { href: "/gfn", label: "⚡ GFN", key: "gfn", title: "Group-Forming Network Calculator" },
     { href: "/docs", label: "§ Docs", key: "docs" },
     { href: "/components", label: "◊ Examples", key: "components" },
     { href: "https://github.com/openagentsinc/openagents", label: "§ Github", key: "github", external: true }
@@ -24,6 +24,7 @@ export function navigation({ current }: { current: string }) {
       return `<a href="${link.href}" 
                      class="nav-link ${isActive ? "active" : ""}" 
                      ${link.external ? "target=\"_blank\" rel=\"noopener noreferrer\"" : ""}
+                     ${link.title ? `title="${link.title}"` : ""}
                    >${link.label}</a>`
     }).join("")
   }

--- a/apps/openagents.com/src/routes/gfn/gfn-calculator.ts
+++ b/apps/openagents.com/src/routes/gfn/gfn-calculator.ts
@@ -1,6 +1,6 @@
 /**
  * GFN Formula Calculator
- * Implements the Global Freedom Network value calculation
+ * Implements the Group-Forming Network value calculation
  */
 
 export interface GFNParameters {
@@ -81,25 +81,25 @@ export const ANTHROPIC_PARAMS: GFNParameters = {
 }
 
 export const OPENAGENTS_CURRENT: GFNParameters = {
-  n: 100,
-  C: 0.6,
+  n: 10,
+  C: 0.1,
   alpha1: 0.05,
   alpha2: 0.25,
   alpha3: 0.70,
-  k1: 0.005,
-  k2: 0.002,
-  k3: 0.0005,
-  Q: 3.0,
-  M: 4.0,
-  D: 0.9
+  k1: 0.001,
+  k2: 0.0005,
+  k3: 0.00001,
+  Q: 0.5,
+  M: 1.0,
+  D: 0.1
 }
 
 export const OPENAGENTS_PROJECTIONS = {
   current: { ...OPENAGENTS_CURRENT },
-  sixMonths: { ...OPENAGENTS_CURRENT, n: 10_000, C: 0.7 },
-  oneYear: { ...OPENAGENTS_CURRENT, n: 500_000, C: 0.8 },
-  twoYears: { ...OPENAGENTS_CURRENT, n: 10_000_000, C: 0.85 },
-  fiveYears: { ...OPENAGENTS_CURRENT, n: 50_000_000, C: 0.9 }
+  sixMonths: { ...OPENAGENTS_CURRENT, n: 1_000, C: 0.3, Q: 1.0, M: 1.5, D: 0.3 },
+  oneYear: { ...OPENAGENTS_CURRENT, n: 10_000, C: 0.5, Q: 1.5, M: 2.0, D: 0.5 },
+  twoYears: { ...OPENAGENTS_CURRENT, n: 100_000, C: 0.7, Q: 2.0, M: 3.0, D: 0.7, k3: 0.0001 },
+  fiveYears: { ...OPENAGENTS_CURRENT, n: 1_000_000, C: 0.85, Q: 3.0, M: 4.0, D: 0.9, k1: 0.005, k2: 0.002, k3: 0.0005 }
 }
 
 /**

--- a/apps/openagents.com/src/routes/gfn/index.ts
+++ b/apps/openagents.com/src/routes/gfn/index.ts
@@ -43,7 +43,7 @@ export default function gfn() {
   }))
 
   return document({
-    title: "GFN Interactive Formula - OpenAgents",
+    title: "Group-Forming Network Calculator - OpenAgents",
     styles: baseStyles + `
       .gfn-container {
         max-width: 1400px;
@@ -210,7 +210,7 @@ export default function gfn() {
         
         <div class="gfn-container">
           <div class="gfn-header">
-            <h1>Global Freedom Network Value Calculator</h1>
+            <h1>Group-Forming Network Value Calculator</h1>
             <p style="color: var(--foreground1); margin-bottom: 1rem;">
               Explore how network effects combine to create exponential value
             </p>

--- a/packages/autotest/test-gfn-interactive.json
+++ b/packages/autotest/test-gfn-interactive.json
@@ -1,0 +1,16 @@
+{
+  "url": "http://localhost:3003/gfn",
+  "fullPage": true,
+  "waitForSelector": ".total-value",
+  "interactions": [
+    {
+      "action": "click",
+      "selector": "button:has-text('OA 5yr')",
+      "timeout": 5000
+    },
+    {
+      "action": "wait",
+      "value": "2000"
+    }
+  ]
+}

--- a/packages/autotest/test-gfn-simple.json
+++ b/packages/autotest/test-gfn-simple.json
@@ -1,0 +1,5 @@
+{
+  "url": "http://localhost:3003/gfn",
+  "fullPage": true,
+  "waitForSelector": ".total-value"
+}


### PR DESCRIPTION
## Critical Fixes

This PR fixes two critical errors in the GFN interactive page:

### 1. ❌ Wrong Name: "Global Freedom Network" → ✅ "Group-Forming Network"

GFN stands for **Group-Forming Network**, not Global Freedom Network. This is a fundamental concept from Reed's Law about networks that enable group formation.

### 2. ❌ Absurd OpenAgents Value → ✅ Realistic Near-Zero Starting Point

The current OpenAgents value was showing **$6,069,511,073,892,774.00T** which is completely absurd. 

**Fixed to show realistic progression:**
- **Now**: $0.01 (10 agents, 10% clustering)
- **6 months**: $12.29T (1,000 agents, 30% clustering)
- **1 year**: $26.37T (10,000 agents, 50% clustering)
- **2 years**: $64.31T (100,000 agents, 70% clustering)
- **5 years**: $143.77T (1,000,000 agents, 85% clustering)

## Changes Made

1. **Updated all references** from "Global Freedom Network" to "Group-Forming Network"
2. **Adjusted OpenAgents current parameters**:
   - Reduced n from 100 to 10 agents
   - Lowered clustering from 60% to 10%
   - Reduced k values and multipliers to reflect early stage
   - Quality factor: 0.5 (we're just starting)
   - Platform multiplier: 1.0 (no multi-sided effects yet)
   - Data effect: 0.1 (minimal data accumulation)

3. **Made growth projections realistic**:
   - Gradual increase in agent count
   - Progressive improvement in clustering coefficient
   - Gradual increase in quality and platform multipliers
   - k values increase as platform matures

4. **Added tooltip** to navigation showing "Group-Forming Network Calculator"

## Result

The page now correctly shows OpenAgents starting from essentially zero value and growing exponentially as the network scales and clustering improves. This is much more honest and realistic than showing trillions of dollars in value when we have almost nothing today.

🤖 Generated with [Claude Code](https://claude.ai/code)