### PR TITLE
fix: Remove SDK import causing module resolution error on agents page

### DIFF
--- a/apps/openagents.com/src/components/agent-chat.ts
+++ b/apps/openagents.com/src/components/agent-chat.ts
@@ -23,7 +23,6 @@ export function agentChat({ agentId: _agentId, channelId: initialChannelId }: Ag
     <script type="module">
       // Initialize Effect runtime when component mounts
       import { Effect, Stream, Ref } from "https://esm.sh/effect@3.10.3"
-      import { Browser } from "@openagentsinc/sdk"
       
       const container = document.getElementById('agent-chat-container')
       const initialChannelId = ${JSON.stringify(initialChannelId || null)}


### PR DESCRIPTION
## Summary
Fixes critical module resolution error on /agents page that was causing complete page failure.

## Bug Details (Fixes #1029)
- Removed unused `@openagentsinc/sdk` import from `agent-chat.ts` line 26
- Browser cannot resolve npm module specifiers without bundling
- This was causing: `Uncaught TypeError: Failed to resolve module specifier "@openagentsinc/sdk"`

## Impact
- The agents page was completely broken
- Users saw blank page with console errors
- Agent chat functionality didn't work

## Solution
Removed the unused SDK import since it wasn't being used in the component.

## Test Plan
- [x] Verified agent-chat.ts no longer imports SDK
- [x] Built openagents.com successfully
- [ ] Manually test /agents page loads without console errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>