### PR TITLE
feat: Connect chat UI to Cloudflare Workers AI integration

### DIFF
--- a/apps/openagents.com/src/index.ts
+++ b/apps/openagents.com/src/index.ts
@@ -1,3 +1,11 @@
+import { config } from 'dotenv'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+// Load .env from the apps/openagents.com directory
+const __dirname = dirname(fileURLToPath(import.meta.url))
+config({ path: join(__dirname, '../.env') })
+
 import { createPsionicApp } from '@openagentsinc/psionic'
 // import { createRelayPlugin } from '@openagentsinc/relay'
 import { home } from './routes/home'

--- a/apps/openagents.com/src/index.ts
+++ b/apps/openagents.com/src/index.ts
@@ -25,9 +25,7 @@ import { channelsApi } from './routes/api/channels'
 import { navigation } from './components/navigation'
 import { baseStyles } from './styles'
 import path from 'path'
-import { fileURLToPath } from 'url'
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
 
 const app = createPsionicApp({
   name: 'OpenAgents',

--- a/apps/openagents.com/src/routes/api/channels.ts
+++ b/apps/openagents.com/src/routes/api/channels.ts
@@ -14,7 +14,7 @@ export const channelsApi = (app: any) => {
       const bodyText = await Effect.runPromise(
         Effect.gen(function*() {
           return yield* context.request.text
-        })
+        }) as Effect.Effect<string, never, never>
       )
       const body = JSON.parse(bodyText) as { name: string; about?: string; picture?: string }
       const program = Effect.gen(function*() {
@@ -93,7 +93,7 @@ export const channelsApi = (app: any) => {
         const bodyText = await Effect.runPromise(
           Effect.gen(function*() {
             return yield* context.request.text
-          })
+          }) as Effect.Effect<string, never, never>
         )
         const body = JSON.parse(bodyText) as {
           channelId: string

--- a/apps/openagents.com/src/routes/api/channels.ts
+++ b/apps/openagents.com/src/routes/api/channels.ts
@@ -95,7 +95,12 @@ export const channelsApi = (app: any) => {
             return yield* context.request.text
           })
         )
-        const body = JSON.parse(bodyText) as { channelId: string; content: string; replyTo?: string; privateKey?: string }
+        const body = JSON.parse(bodyText) as {
+          channelId: string
+          content: string
+          replyTo?: string
+          privateKey?: string
+        }
         const program = Effect.gen(function*() {
           const crypto = yield* Nostr.CryptoService.CryptoService
           const nip28 = yield* Nostr.Nip28Service.Nip28Service
@@ -197,7 +202,7 @@ export const channelsApi = (app: any) => {
 
         // Get channel from database
         const channels = yield* database.getChannels()
-        const channel = channels.find((c) => c.id === params.id)
+        const channel = channels.find((c) => c.id === id)
 
         if (!channel) {
           return { error: "Channel not found" }
@@ -206,7 +211,7 @@ export const channelsApi = (app: any) => {
         // Get recent messages
         const messages = yield* database.queryEvents([{
           kinds: [42],
-          "#e": [params.id as Nostr.Schema.EventId],
+          "#e": [id as Nostr.Schema.EventId],
           limit: 100
         }])
 

--- a/apps/openagents.com/src/routes/api/channels.ts
+++ b/apps/openagents.com/src/routes/api/channels.ts
@@ -11,7 +11,12 @@ export const channelsApi = (app: any) => {
   // Create a new channel
   app.post(`${prefix}/create`, async (context: any) => {
     try {
-      const body = await context.request.json() as { name: string; about?: string; picture?: string }
+      const bodyText = await Effect.runPromise(
+        Effect.gen(function*() {
+          return yield* context.request.text
+        })
+      )
+      const body = JSON.parse(bodyText) as { name: string; about?: string; picture?: string }
       const program = Effect.gen(function*() {
         const crypto = yield* Nostr.CryptoService.CryptoService
         const nip28 = yield* Nostr.Nip28Service.Nip28Service
@@ -85,7 +90,12 @@ export const channelsApi = (app: any) => {
     `${prefix}/message`,
     async (context: any) => {
       try {
-        const body = await context.request.json() as { channelId: string; content: string; replyTo?: string; privateKey?: string }
+        const bodyText = await Effect.runPromise(
+          Effect.gen(function*() {
+            return yield* context.request.text
+          })
+        )
+        const body = JSON.parse(bodyText) as { channelId: string; content: string; replyTo?: string; privateKey?: string }
         const program = Effect.gen(function*() {
           const crypto = yield* Nostr.CryptoService.CryptoService
           const nip28 = yield* Nostr.Nip28Service.Nip28Service

--- a/apps/openagents.com/src/routes/api/channels.ts
+++ b/apps/openagents.com/src/routes/api/channels.ts
@@ -9,8 +9,9 @@ export const channelsApi = (app: any) => {
   const prefix = "/api/channels"
 
   // Create a new channel
-  app.post(`${prefix}/create`, async ({ body }: { body: { name: string; about?: string; picture?: string } }) => {
+  app.post(`${prefix}/create`, async (context: any) => {
     try {
+      const body = await context.request.json() as { name: string; about?: string; picture?: string }
       const program = Effect.gen(function*() {
         const crypto = yield* Nostr.CryptoService.CryptoService
         const nip28 = yield* Nostr.Nip28Service.Nip28Service
@@ -82,8 +83,9 @@ export const channelsApi = (app: any) => {
   // Send a message to a channel
   app.post(
     `${prefix}/message`,
-    async ({ body }: { body: { channelId: string; content: string; replyTo?: string; privateKey?: string } }) => {
+    async (context: any) => {
       try {
+        const body = await context.request.json() as { channelId: string; content: string; replyTo?: string; privateKey?: string }
         const program = Effect.gen(function*() {
           const crypto = yield* Nostr.CryptoService.CryptoService
           const nip28 = yield* Nostr.Nip28Service.Nip28Service
@@ -177,8 +179,9 @@ export const channelsApi = (app: any) => {
   })
 
   // Get channel details and recent messages
-  app.get(`${prefix}/:id`, async ({ params }: { params: { id: string } }) => {
+  app.get(`${prefix}/:id`, async (context: any) => {
     try {
+      const { id } = context.params
       const program = Effect.gen(function*() {
         const database = yield* RelayDatabase
 

--- a/apps/openagents.com/src/routes/api/channels.ts
+++ b/apps/openagents.com/src/routes/api/channels.ts
@@ -1,14 +1,15 @@
 import * as Nostr from "@openagentsinc/nostr"
 import { RelayDatabase, RelayDatabaseLive } from "@openagentsinc/relay"
 import { Effect, Layer, Runtime } from "effect"
-import { Elysia } from "elysia"
 
 // Create a runtime with database layer
 const runtime = Runtime.defaultRuntime
 
-export const channelsApi = new Elysia({ prefix: "/api/channels" })
+export const channelsApi = (app: any) => {
+  const prefix = "/api/channels"
+
   // Create a new channel
-  .post("/create", async ({ body }: { body: { name: string; about?: string; picture?: string } }) => {
+  app.post(`${prefix}/create`, async ({ body }: { body: { name: string; about?: string; picture?: string } }) => {
     try {
       const program = Effect.gen(function*() {
         const crypto = yield* Nostr.CryptoService.CryptoService
@@ -77,9 +78,10 @@ export const channelsApi = new Elysia({ prefix: "/api/channels" })
       )
     }
   })
+
   // Send a message to a channel
-  .post(
-    "/message",
+  app.post(
+    `${prefix}/message`,
     async ({ body }: { body: { channelId: string; content: string; replyTo?: string; privateKey?: string } }) => {
       try {
         const program = Effect.gen(function*() {
@@ -144,8 +146,9 @@ export const channelsApi = new Elysia({ prefix: "/api/channels" })
       }
     }
   )
+
   // List all channels
-  .get("/list", async () => {
+  app.get(`${prefix}/list`, async () => {
     try {
       const program = Effect.gen(function*() {
         const database = yield* RelayDatabase
@@ -172,8 +175,9 @@ export const channelsApi = new Elysia({ prefix: "/api/channels" })
       })
     }
   })
+
   // Get channel details and recent messages
-  .get("/:id", async ({ params }: { params: { id: string } }) => {
+  app.get(`${prefix}/:id`, async ({ params }: { params: { id: string } }) => {
     try {
       const program = Effect.gen(function*() {
         const database = yield* RelayDatabase
@@ -219,3 +223,4 @@ export const channelsApi = new Elysia({ prefix: "/api/channels" })
       })
     }
   })
+}

--- a/apps/openagents.com/src/routes/api/cloudflare.ts
+++ b/apps/openagents.com/src/routes/api/cloudflare.ts
@@ -59,7 +59,8 @@ export const cloudflareApi = (app: any) => {
         },
         body: JSON.stringify({
           messages,
-          stream: true
+          stream: true,
+          max_tokens: 4096
         })
       })
 
@@ -71,12 +72,8 @@ export const cloudflareApi = (app: any) => {
 
       // Create a transform stream to convert Cloudflare's format to OpenAI's format
       const transformStream = new TransformStream({
-        start() {
-          console.log("Transform stream started")
-        },
         async transform(chunk, controller) {
           const text = new TextDecoder().decode(chunk)
-          console.log("Received chunk:", text)
 
           // Handle Cloudflare's streaming format which can be:
           // 1. SSE format: "data: {...}\n\n"
@@ -100,7 +97,6 @@ export const cloudflareApi = (app: any) => {
 
             try {
               const parsed = JSON.parse(jsonData)
-              console.log("Parsed data:", parsed)
 
               // Handle different possible Cloudflare response formats
               let content = ""
@@ -129,7 +125,6 @@ export const cloudflareApi = (app: any) => {
                     finish_reason: null
                   }]
                 }
-                console.log("Sending chunk:", openAIChunk)
                 controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(openAIChunk)}\n\n`))
               }
             } catch (e) {

--- a/apps/openagents.com/src/routes/api/cloudflare.ts
+++ b/apps/openagents.com/src/routes/api/cloudflare.ts
@@ -75,7 +75,7 @@ export const cloudflareApi = (app: any) => {
       const transformStream = new TransformStream({
         async transform(chunk, controller) {
           const text = new TextDecoder().decode(chunk)
-          console.log("Raw chunk received:", JSON.stringify(text))
+          // console.log("Raw chunk received:", JSON.stringify(text))
 
           // Handle Cloudflare's streaming format which can be:
           // 1. SSE format: "data: {...}\n\n"
@@ -99,7 +99,7 @@ export const cloudflareApi = (app: any) => {
 
             try {
               const parsed = JSON.parse(jsonData)
-              console.log("Parsed chunk:", parsed)
+              // console.log("Parsed chunk:", parsed)
 
               // Handle OpenAI-compatible format from Cloudflare
               if (parsed.choices?.[0]?.delta?.content) {

--- a/apps/openagents.com/src/routes/api/cloudflare.ts
+++ b/apps/openagents.com/src/routes/api/cloudflare.ts
@@ -34,7 +34,7 @@ export const cloudflareApi = (app: any) => {
         Effect.gen(function*() {
           const request = context.request
           return yield* request.text
-        })
+        }) as Effect.Effect<string, never, never>
       )
 
       const body = JSON.parse(bodyText)

--- a/apps/openagents.com/src/routes/api/cloudflare.ts
+++ b/apps/openagents.com/src/routes/api/cloudflare.ts
@@ -77,7 +77,7 @@ export const cloudflareApi = (app: any) => {
         async transform(chunk, controller) {
           const text = new TextDecoder().decode(chunk)
           console.log("Received chunk:", text)
-          
+
           // Handle Cloudflare's streaming format which can be:
           // 1. SSE format: "data: {...}\n\n"
           // 2. Raw JSON lines: "{...}\n"
@@ -85,7 +85,7 @@ export const cloudflareApi = (app: any) => {
 
           for (const line of lines) {
             let jsonData = ""
-            
+
             if (line.startsWith("data: ")) {
               jsonData = line.slice(6)
               if (jsonData === "[DONE]") {
@@ -101,7 +101,7 @@ export const cloudflareApi = (app: any) => {
             try {
               const parsed = JSON.parse(jsonData)
               console.log("Parsed data:", parsed)
-              
+
               // Handle different possible Cloudflare response formats
               let content = ""
               if (parsed.response) {
@@ -124,7 +124,7 @@ export const cloudflareApi = (app: any) => {
                   choices: [{
                     index: 0,
                     delta: {
-                      content: content
+                      content
                     },
                     finish_reason: null
                   }]

--- a/apps/openagents.com/src/routes/api/cloudflare.ts
+++ b/apps/openagents.com/src/routes/api/cloudflare.ts
@@ -1,14 +1,15 @@
 import { BunHttpPlatform } from "@effect/platform-bun"
 import * as Ai from "@openagentsinc/ai"
 import { Config, Effect, Layer, Stream } from "effect"
-import { Elysia } from "elysia"
 
 // Cloudflare configuration from environment
 const CloudflareApiKey = Config.redacted("CLOUDFLARE_API_KEY")
 const CloudflareAccountId = Config.string("CLOUDFLARE_ACCOUNT_ID")
 
-export const cloudflareApi = new Elysia({ prefix: "/api/cloudflare" })
-  .get("/status", async () => {
+export const cloudflareApi = (app: any) => {
+  const prefix = "/api/cloudflare"
+
+  app.get(`${prefix}/status`, async () => {
     try {
       // Check if Cloudflare is configured
       const configResult = await Effect.runPromise(
@@ -29,7 +30,8 @@ export const cloudflareApi = new Elysia({ prefix: "/api/cloudflare" })
       return Response.json({ available: false })
     }
   })
-  .post("/chat", async ({ body }: { body: any }) => {
+
+  app.post(`${prefix}/chat`, async ({ body }: { body: any }) => {
     try {
       const { messages, model } = body
 
@@ -146,3 +148,4 @@ export const cloudflareApi = new Elysia({ prefix: "/api/cloudflare" })
       return Response.json({ error: error.message }, { status: 500 })
     }
   })
+}

--- a/apps/openagents.com/src/routes/api/cloudflare.ts
+++ b/apps/openagents.com/src/routes/api/cloudflare.ts
@@ -1,7 +1,4 @@
-import { BunHttpPlatform } from "@effect/platform-bun"
-import * as HttpClient from "@effect/platform/HttpClient"
-import * as Ai from "@openagentsinc/ai"
-import { Config, Effect, Layer, Stream, Redacted } from "effect"
+import { Effect } from "effect"
 
 export const cloudflareApi = (app: any) => {
   const prefix = "/api/cloudflare"
@@ -11,7 +8,7 @@ export const cloudflareApi = (app: any) => {
       // Check environment variables
       const apiKey = process.env.CLOUDFLARE_API_KEY
       const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
-      
+
       // If we have both, return available
       if (apiKey && accountId) {
         return Response.json({
@@ -19,7 +16,7 @@ export const cloudflareApi = (app: any) => {
           provider: "cloudflare"
         })
       }
-      
+
       return Response.json({
         available: false,
         provider: "cloudflare"
@@ -39,33 +36,33 @@ export const cloudflareApi = (app: any) => {
           return yield* request.text
         })
       )
-      
+
       const body = JSON.parse(bodyText)
       const { messages, model } = body
 
       // Get credentials
       const apiKey = process.env.CLOUDFLARE_API_KEY
       const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
-      
+
       if (!apiKey || !accountId) {
         return Response.json({ error: "Cloudflare not configured" }, { status: 500 })
       }
 
       // For now, use direct API call with streaming response
       const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`
-      
+
       const response = await fetch(url, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Authorization': `Bearer ${apiKey}`,
-          'Content-Type': 'application/json'
+          "Authorization": `Bearer ${apiKey}`,
+          "Content-Type": "application/json"
         },
         body: JSON.stringify({
           messages,
           stream: true
         })
       })
-      
+
       if (!response.ok) {
         const error = await response.text()
         console.error("Cloudflare API error:", error)
@@ -76,13 +73,13 @@ export const cloudflareApi = (app: any) => {
       const transformStream = new TransformStream({
         async transform(chunk, controller) {
           const text = new TextDecoder().decode(chunk)
-          const lines = text.split('\n').filter(line => line.trim())
-          
+          const lines = text.split("\n").filter((line) => line.trim())
+
           for (const line of lines) {
-            if (line.startsWith('data: ')) {
+            if (line.startsWith("data: ")) {
               const data = line.slice(6)
-              if (data === '[DONE]') {
-                controller.enqueue(new TextEncoder().encode('data: [DONE]\n\n'))
+              if (data === "[DONE]") {
+                controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"))
               } else {
                 try {
                   const parsed = JSON.parse(data)

--- a/apps/openagents.com/src/routes/api/ollama.ts
+++ b/apps/openagents.com/src/routes/api/ollama.ts
@@ -1,9 +1,10 @@
 import * as Ai from "@openagentsinc/ai"
 import { Effect } from "effect"
-import { Elysia } from "elysia"
 
-export const ollamaApi = new Elysia({ prefix: "/api/ollama" })
-  .get("/status", async () => {
+export const ollamaApi = (app: any) => {
+  const prefix = "/api/ollama"
+
+  app.get(`${prefix}/status`, async () => {
     try {
       // Use the Ollama provider's checkStatus function
       const status = await Effect.runPromise(Ai.Ollama.checkStatus())
@@ -12,7 +13,8 @@ export const ollamaApi = new Elysia({ prefix: "/api/ollama" })
       return Response.json({ online: false, models: [], modelCount: 0 }, { status: 503 })
     }
   })
-  .post("/chat", async ({ body }: { body: any }) => {
+
+  app.post(`${prefix}/chat`, async ({ body }: { body: any }) => {
     try {
       const { messages, model, options } = body
 
@@ -93,3 +95,4 @@ export const ollamaApi = new Elysia({ prefix: "/api/ollama" })
       return Response.json({ error: error.message }, { status: 500 })
     }
   })
+}

--- a/apps/openagents.com/src/routes/api/ollama.ts
+++ b/apps/openagents.com/src/routes/api/ollama.ts
@@ -14,8 +14,9 @@ export const ollamaApi = (app: any) => {
     }
   })
 
-  app.post(`${prefix}/chat`, async ({ body }: { body: any }) => {
+  app.post(`${prefix}/chat`, async (context: any) => {
     try {
+      const body = await context.request.json()
       const { messages, model, options } = body
 
       // Create a TransformStream for streaming response

--- a/apps/openagents.com/src/routes/api/ollama.ts
+++ b/apps/openagents.com/src/routes/api/ollama.ts
@@ -19,7 +19,7 @@ export const ollamaApi = (app: any) => {
       const bodyText = await Effect.runPromise(
         Effect.gen(function*() {
           return yield* context.request.text
-        })
+        }) as Effect.Effect<string, never, never>
       )
       const body = JSON.parse(bodyText)
       const { messages, model, options } = body

--- a/apps/openagents.com/src/routes/api/ollama.ts
+++ b/apps/openagents.com/src/routes/api/ollama.ts
@@ -16,7 +16,12 @@ export const ollamaApi = (app: any) => {
 
   app.post(`${prefix}/chat`, async (context: any) => {
     try {
-      const body = await context.request.json()
+      const bodyText = await Effect.runPromise(
+        Effect.gen(function*() {
+          return yield* context.request.text
+        })
+      )
+      const body = JSON.parse(bodyText)
       const { messages, model, options } = body
 
       // Create a TransformStream for streaming response

--- a/apps/openagents.com/src/routes/api/openrouter.ts
+++ b/apps/openagents.com/src/routes/api/openrouter.ts
@@ -7,9 +7,21 @@ export const openrouterApi = (app: any) => {
 
   app.post(`${prefix}/chat`, async (context: any) => {
     try {
-      const body = await context.request.json()
+      const bodyText = await Effect.runPromise(
+        Effect.gen(function*() {
+          return yield* context.request.text
+        })
+      )
+      const body = JSON.parse(bodyText)
       const { messages, model } = body
-      const apiKey = context.request.headers.get("x-api-key")
+      
+      // Get header from Effect HttpServerRequest
+      const apiKey = await Effect.runPromise(
+        Effect.gen(function*() {
+          const headers = yield* context.request.headers
+          return headers["x-api-key"]
+        })
+      )
 
       if (!apiKey) {
         return Response.json({ error: "API key required" }, { status: 401 })

--- a/apps/openagents.com/src/routes/api/openrouter.ts
+++ b/apps/openagents.com/src/routes/api/openrouter.ts
@@ -5,10 +5,11 @@ import { Effect, Layer, Redacted, Stream } from "effect"
 export const openrouterApi = (app: any) => {
   const prefix = "/api/openrouter"
 
-  app.post(`${prefix}/chat`, async ({ body, headers }: { body: any; headers: Record<string, string | undefined> }) => {
+  app.post(`${prefix}/chat`, async (context: any) => {
     try {
+      const body = await context.request.json()
       const { messages, model } = body
-      const apiKey = headers["x-api-key"]
+      const apiKey = context.request.headers.get("x-api-key")
 
       if (!apiKey) {
         return Response.json({ error: "API key required" }, { status: 401 })

--- a/apps/openagents.com/src/routes/api/openrouter.ts
+++ b/apps/openagents.com/src/routes/api/openrouter.ts
@@ -1,10 +1,11 @@
 import { BunHttpPlatform } from "@effect/platform-bun"
 import * as Ai from "@openagentsinc/ai"
 import { Effect, Layer, Redacted, Stream } from "effect"
-import { Elysia } from "elysia"
 
-export const openrouterApi = new Elysia({ prefix: "/api/openrouter" })
-  .post("/chat", async ({ body, headers }: { body: any; headers: Record<string, string | undefined> }) => {
+export const openrouterApi = (app: any) => {
+  const prefix = "/api/openrouter"
+
+  app.post(`${prefix}/chat`, async ({ body, headers }: { body: any; headers: Record<string, string | undefined> }) => {
     try {
       const { messages, model } = body
       const apiKey = headers["x-api-key"]
@@ -115,3 +116,4 @@ export const openrouterApi = new Elysia({ prefix: "/api/openrouter" })
       return Response.json({ error: error.message }, { status: 500 })
     }
   })
+}

--- a/apps/openagents.com/src/routes/api/openrouter.ts
+++ b/apps/openagents.com/src/routes/api/openrouter.ts
@@ -10,7 +10,7 @@ export const openrouterApi = (app: any) => {
       const bodyText = await Effect.runPromise(
         Effect.gen(function*() {
           return yield* context.request.text
-        })
+        }) as Effect.Effect<string, never, never>
       )
       const body = JSON.parse(bodyText)
       const { messages, model } = body
@@ -20,7 +20,7 @@ export const openrouterApi = (app: any) => {
         Effect.gen(function*() {
           const headers = yield* context.request.headers
           return headers["x-api-key"]
-        })
+        }) as Effect.Effect<string, never, never>
       )
 
       if (!apiKey) {

--- a/apps/openagents.com/src/routes/api/openrouter.ts
+++ b/apps/openagents.com/src/routes/api/openrouter.ts
@@ -14,7 +14,7 @@ export const openrouterApi = (app: any) => {
       )
       const body = JSON.parse(bodyText)
       const { messages, model } = body
-      
+
       // Get header from Effect HttpServerRequest
       const apiKey = await Effect.runPromise(
         Effect.gen(function*() {

--- a/apps/openagents.com/src/routes/home.ts
+++ b/apps/openagents.com/src/routes/home.ts
@@ -648,28 +648,23 @@ export async function home() {
               if (done) break
               
               const chunk = decoder.decode(value)
-              console.log('Received chunk:', chunk)
               const lines = chunk.split('\\n')
               
               for (const line of lines) {
                 if (line.startsWith('data: ')) {
                   const data = line.slice(6)
-                  console.log('SSE data:', data)
                   if (data === '[DONE]') {
-                    console.log('Stream finished')
                     break
                   }
                   
                   try {
                     const parsed = JSON.parse(data)
-                    console.log('Parsed data:', parsed)
                     if (parsed.error) {
                       throw new Error(parsed.error)
                     }
                     
                     if (parsed.choices?.[0]?.delta?.content) {
                       assistantContent += parsed.choices[0].delta.content
-                      console.log('Adding content:', parsed.choices[0].delta.content)
                       
                       // Use requestAnimationFrame to ensure each update is rendered
                       await new Promise(resolve => {
@@ -680,7 +675,7 @@ export async function home() {
                       })
                     }
                   } catch (e) {
-                    console.error('Error parsing chunk:', e, 'Raw data:', data)
+                    // Silently skip malformed chunks
                   }
                 }
               }

--- a/apps/openagents.com/src/routes/home.ts
+++ b/apps/openagents.com/src/routes/home.ts
@@ -624,27 +624,32 @@ export async function home() {
               if (done) break
               
               const chunk = decoder.decode(value)
+              console.log('Received chunk:', chunk)
               const lines = chunk.split('\\n')
               
               for (const line of lines) {
                 if (line.startsWith('data: ')) {
                   const data = line.slice(6)
+                  console.log('SSE data:', data)
                   if (data === '[DONE]') {
+                    console.log('Stream finished')
                     break
                   }
                   
                   try {
                     const parsed = JSON.parse(data)
+                    console.log('Parsed data:', parsed)
                     if (parsed.error) {
                       throw new Error(parsed.error)
                     }
                     
                     if (parsed.choices?.[0]?.delta?.content) {
                       assistantContent += parsed.choices[0].delta.content
+                      console.log('Adding content:', parsed.choices[0].delta.content)
                       updateStreamingMessage(assistantBodyDiv, assistantContent)
                     }
                   } catch (e) {
-                    console.error('Error parsing chunk:', e)
+                    console.error('Error parsing chunk:', e, 'Raw data:', data)
                   }
                 }
               }

--- a/apps/openagents.com/src/routes/home.ts
+++ b/apps/openagents.com/src/routes/home.ts
@@ -158,9 +158,10 @@ const v1Styles = css`
   }
 
   .chat-input:focus {
-    outline: none;
-    border-color: var(--white);
-    ring: 0;
+    outline: none !important;
+    border-color: var(--white) !important;
+    box-shadow: none !important;
+    ring: 0 !important;
   }
 
   .chat-input::placeholder {
@@ -472,6 +473,7 @@ export async function home() {
                   placeholder="Message OpenAgents..."
                   rows="1"
                   autocomplete="off"
+                  autofocus
                   style="outline: none;"
                   oninput="this.style.height = 'auto'; this.style.height = Math.min(this.scrollHeight, 200) + 'px'; document.getElementById('sendBtn').disabled = !this.value.trim();"
                 ></textarea>
@@ -722,8 +724,8 @@ export async function home() {
             }
           })
           
-          // Focus input on load
-          input.focus()
+          // Focus input on load (fallback for autofocus)
+          setTimeout(() => input.focus(), 100)
         })
       </script>
     `

--- a/apps/openagents.com/src/routes/home.ts
+++ b/apps/openagents.com/src/routes/home.ts
@@ -176,6 +176,7 @@ const v1Styles = css`
     height: 28px;
     background-color: var(--white);
     color: var(--black);
+    border: none;
     border-radius: 4px;
     display: flex;
     align-items: center;
@@ -478,7 +479,7 @@ export async function home() {
                   oninput="this.style.height = 'auto'; this.style.height = Math.min(this.scrollHeight, 200) + 'px'; document.getElementById('sendBtn').disabled = !this.value.trim();"
                 ></textarea>
                 <button id="sendBtn" class="send-button" disabled>
-                  <svg class="w-[24px] h-[24px] m-0.5 flex flex-col justify-center items-center" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <line x1="22" y1="2" x2="11" y2="13"></line>
                     <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
                   </svg>
@@ -701,7 +702,12 @@ export async function home() {
             
             input.disabled = false
             sendBtn.disabled = false
-            input.focus()
+            
+            // Force focus back to input with a small delay
+            setTimeout(() => {
+              input.focus()
+              input.setSelectionRange(input.value.length, input.value.length)
+            }, 50)
           }
         }
 

--- a/apps/openagents.com/src/routes/home.ts
+++ b/apps/openagents.com/src/routes/home.ts
@@ -670,14 +670,7 @@ export async function home() {
                     
                     if (parsed.choices?.[0]?.delta?.content) {
                       assistantContent += parsed.choices[0].delta.content
-                      
-                      // Use requestAnimationFrame to ensure each update is rendered
-                      await new Promise(resolve => {
-                        requestAnimationFrame(() => {
-                          updateStreamingMessage(assistantBodyDiv, assistantContent)
-                          resolve()
-                        })
-                      })
+                      updateStreamingMessage(assistantBodyDiv, assistantContent)
                     }
                   } catch (e) {
                     // Silently skip malformed chunks

--- a/apps/openagents.com/src/routes/home.ts
+++ b/apps/openagents.com/src/routes/home.ts
@@ -170,7 +170,8 @@ const v1Styles = css`
 
   .send-button {
     position: absolute;
-    bottom: 10px;
+    top: 50%;
+    transform: translateY(-50%);
     right: 10px;
     width: 28px;
     height: 28px;
@@ -617,6 +618,11 @@ export async function home() {
           input.disabled = true
           sendBtn.disabled = true
           isStreaming = true
+          
+          // Immediately refocus input after clearing (before streaming starts)
+          setTimeout(() => {
+            input.focus()
+          }, 50)
           
           // Add assistant message placeholder
           const assistantBodyDiv = addMessage('Assistant', '', 'assistant')

--- a/apps/openagents.com/src/routes/home.ts
+++ b/apps/openagents.com/src/routes/home.ts
@@ -170,9 +170,8 @@ const v1Styles = css`
 
   .send-button {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    right: 10px;
+    top: 10px;
+    right: 6px;
     width: 28px;
     height: 28px;
     background-color: var(--white);
@@ -185,7 +184,7 @@ const v1Styles = css`
     cursor: pointer;
     transition: background-color 0.2s;
     padding: 0;
-    margin: 2px;
+    margin: 0;
   }
 
   .send-button:hover:not(:disabled) {
@@ -612,17 +611,14 @@ export async function home() {
           chatMessages.push({ role: 'user', content: message })
           addMessage('You', message, 'user')
           
-          // Clear input and disable
+          // Clear input and keep it focused
           input.value = ''
           input.style.height = 'auto'
-          input.disabled = true
+          input.focus()
+          
+          // Disable send button but keep input enabled so user can type next message
           sendBtn.disabled = true
           isStreaming = true
-          
-          // Immediately refocus input after clearing (before streaming starts)
-          setTimeout(() => {
-            input.focus()
-          }, 50)
           
           // Add assistant message placeholder
           const assistantBodyDiv = addMessage('Assistant', '', 'assistant')
@@ -706,14 +702,11 @@ export async function home() {
               cursor.remove()
             }
             
-            input.disabled = false
             sendBtn.disabled = false
             
-            // Force focus back to input with a small delay
-            setTimeout(() => {
-              input.focus()
-              input.setSelectionRange(input.value.length, input.value.length)
-            }, 50)
+            // Ensure input stays focused
+            input.focus()
+            input.setSelectionRange(input.value.length, input.value.length)
           }
         }
 


### PR DESCRIPTION
## Description
Connects the current chat UI to the existing Cloudflare Workers AI integration from PR #983.

## Changes
- Added client-side JavaScript to handle message sending and streaming responses
- Connected to existing `/api/cloudflare/chat` endpoint from PR #983
- Uses Llama 3.3 70B model as default (`@cf/meta/llama-3.3-70b-instruct-fp8-fast`)
- Handles streaming responses in OpenAI-compatible format
- Added status check to verify Cloudflare is configured before enabling chat
- Shows helpful message when Cloudflare environment variables are not set
- **Fixed API routes to be compatible with Psionic framework** (all API routes now use function format instead of Elysia instances)

## Implementation Details
- The chat UI is in `apps/openagents.com/src/routes/home.ts`
- The API endpoint is in `apps/openagents.com/src/routes/api/cloudflare.ts`
- Client handles Server-Sent Events (SSE) for streaming
- Gracefully handles missing configuration
- Fixed 404 errors on API routes by converting them to Psionic-compatible functions

## Testing
- Build passes all checks
- All tests pass
- Handles both configured and unconfigured states
- API endpoints now work correctly (tested with curl)

## Next Steps
- Thread/sidebar functionality can be added in future PRs
- Model selection dropdown can be added later

Closes #1049

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>