### PR TITLE
feat: Add markdown rendering and syntax highlighting to chat messages

### DIFF
--- a/packages/psionic/src/markdown/service.ts
+++ b/packages/psionic/src/markdown/service.ts
@@ -365,3 +365,6 @@ export const renderMarkdownWithHighlighting = renderMarkdownWithMetadata as (
   content: string,
   theme?: string
 ) => Promise<{ html: string; metadata: BlogPostMetadata }>
+
+// Export the core markdown rendering function for direct usage
+export { renderMarkdown }


### PR DESCRIPTION
## Overview
This PR adds proper markdown rendering and syntax highlighting to chat messages, enhancing readability and user experience.

Fixes #1055

## Changes Made

### 1. Export Markdown Rendering Function
- Exported the renderMarkdown function from Psionic's markdown service
- This allows direct usage of the existing Shiki-based rendering in other parts of the app

### 2. Update Chat Route
- Converted renderMessage function to async to support markdown rendering
- Updated message rendering to use await Promise.all() for concurrent processing
- Integrated markdown rendering into the message display pipeline

### 3. Enhanced CSS Styling
Added comprehensive markdown styling support:
- **Code blocks**: Proper styling for WebTUI pre elements with Shiki highlighting
- **Inline code**: Background styling with proper padding
- **Headings**: Styled h1-h6 with appropriate sizes and spacing
- **Lists**: Proper indentation for ul/ol elements
- **Blockquotes**: Left border and color styling
- **Links**: White color with hover effects
- **Paragraphs**: Proper spacing between elements

### 4. Theme-Aware Syntax Highlighting
- Leverages existing Shiki integration with WebTUI themes:
  - zinc → github-dark
  - catppuccin → catppuccin-mocha
  - gruvbox → gruvbox-dark-medium
  - nord → nord
- Preserves WebTUI styling attributes (is-="pre" box-="square")

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint checks pass
- ✅ All tests pass
- ✅ Build completes successfully

## Screenshots
Before: Raw text without formatting
After: Properly rendered markdown with syntax highlighting

## Next Steps
Once merged, all chat messages will display with proper markdown formatting and syntax-highlighted code blocks that match the current WebTUI theme.