### PR TITLE
fix: Claude Code chat display improvements

### DIFF
--- a/apps/openagents.com/src/components/chat-view/chat-view.css
+++ b/apps/openagents.com/src/components/chat-view/chat-view.css
@@ -209,6 +209,22 @@ body {
   margin: 0 auto;
 }
 
+/* Conversation Title */
+.conversation-title {
+  margin-bottom: 3rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.conversation-title h1 {
+  font-size: 1.875rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.4;
+  font-family: var(--font-family-mono);
+}
+
 /* OpenCode-style Message Blocks */
 .message {
   display: flex;

--- a/apps/openagents.com/src/components/chat-view/chat-view.css
+++ b/apps/openagents.com/src/components/chat-view/chat-view.css
@@ -266,6 +266,18 @@ body {
 /* Tool message styling */
 .message-block.tool {
   border-left-color: #a855f7; /* Purple for tools */
+  margin-left: 60px;
+}
+
+/* Tool result styling */
+.message-block.tool-result {
+  border-left-color: #a855f7; /* Purple for tool results */
+  margin-left: 60px;
+}
+
+.message-block.tool-result-error {
+  border-left-color: #f7768e; /* Red for error results */
+  margin-left: 60px;
 }
 
 /* Message header styles - removed as headers are no longer displayed */

--- a/apps/openagents.com/src/components/chat-view/chat-view.css
+++ b/apps/openagents.com/src/components/chat-view/chat-view.css
@@ -217,7 +217,7 @@ body {
 }
 
 .conversation-title h1 {
-  font-size: 1.875rem;
+  font-size: 1.25rem;
   font-weight: 600;
   color: var(--text);
   margin: 0;

--- a/apps/openagents.com/src/components/chat-view/chat-view.css
+++ b/apps/openagents.com/src/components/chat-view/chat-view.css
@@ -988,3 +988,68 @@ body {
   border-color: #ef4444;
   color: #ef4444;
 }
+
+/* Debug button styles */
+.message-actions {
+  position: absolute;
+  right: 0;
+  bottom: -30px; /* Position below the message block to avoid overlap */
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.group:hover .message-actions {
+  opacity: 1;
+}
+
+.debug-button {
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  color: var(--gray);
+  cursor: pointer;
+  font-size: 12px;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.debug-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--lightgray);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.debug-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Add extra padding to messages to accommodate debug button */
+.message {
+  padding-bottom: 2rem; /* Extra space for debug button */
+}
+
+/* Debug section styles */
+.message-debug {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--lightgray);
+  overflow-x: auto;
+}
+
+.debug-json {
+  margin: 0;
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  line-height: 1.4;
+}

--- a/apps/openagents.com/src/components/chat-view/chat-view.css
+++ b/apps/openagents.com/src/components/chat-view/chat-view.css
@@ -1006,7 +1006,7 @@ body {
 }
 
 .debug-button {
-  padding: 4px;
+  padding: 8px 4px 4px 4px; /* Added 4px more top padding */
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 4px;

--- a/apps/openagents.com/src/components/chat-view/chat-view.html
+++ b/apps/openagents.com/src/components/chat-view/chat-view.html
@@ -100,6 +100,7 @@
     <!-- Messages Area -->
     <div id="messages-container" class="messages-container">
       <div class="messages-inner">
+        <!-- Conversation Title will be inserted here -->
         <!-- Messages will be dynamically added here -->
       </div>
     </div>

--- a/apps/openagents.com/src/components/chat-view/index.ts
+++ b/apps/openagents.com/src/components/chat-view/index.ts
@@ -91,14 +91,14 @@ export async function createChatView({ conversationId }: ChatViewProps) {
   // Extract summary from messages
   let conversationTitle = null
   let messagesToRender = messages
-  
+
   // Find summary message by checking metadata or id
-  const summaryIndex = messages.findIndex(msg => 
-    (msg.metadata?.entryType === "summary") || 
+  const summaryIndex = messages.findIndex((msg) =>
+    (msg.metadata?.entryType === "summary") ||
     (msg.id === "summary-0") ||
     (msg.role === "system" && msg.content.includes("Summary:"))
   )
-  
+
   if (summaryIndex !== -1) {
     const summaryMessage = messages[summaryIndex]
     // Extract title from metadata first, then fall back to parsing content
@@ -107,7 +107,7 @@ export async function createChatView({ conversationId }: ChatViewProps) {
     } else if (summaryMessage.content.includes("Summary:")) {
       conversationTitle = summaryMessage.content.substring(summaryMessage.content.indexOf("Summary:") + 8).trim()
     }
-    
+
     // Remove the summary message from the list to render
     messagesToRender = messages.filter((_, index) => index !== summaryIndex)
     console.log("Extracted conversation title:", conversationTitle)
@@ -172,10 +172,11 @@ export async function createChatView({ conversationId }: ChatViewProps) {
     ""
 
   // Generate conversation title HTML if we extracted one
-  const conversationTitleHTML = conversationTitle ? 
+  const conversationTitleHTML = conversationTitle ?
     `<div class="conversation-title">
       <h1>${escapeHtml(conversationTitle)}</h1>
-    </div>` : ""
+    </div>` :
+    ""
 
   // Generate messages HTML
   console.log("Generating messages HTML...")

--- a/apps/openagents.com/src/components/chat-view/index.ts
+++ b/apps/openagents.com/src/components/chat-view/index.ts
@@ -291,6 +291,16 @@ export async function createChatView({ conversationId }: ChatViewProps) {
     body: html`
       ${processedHTML}
       
+      <script>
+        // Toggle debug info visibility
+        function toggleDebug(debugId) {
+          const debugElement = document.getElementById(debugId);
+          if (debugElement) {
+            debugElement.style.display = debugElement.style.display === 'none' ? 'block' : 'none';
+          }
+        }
+      </script>
+      
       ${isDev ? "<script type=\"module\" src=\"http://localhost:5173/@vite/client\"></script>" : ""}
       <script type="module">
         // Import client initialization (includes CSS in dev mode)

--- a/apps/openagents.com/src/components/chat-view/index.ts
+++ b/apps/openagents.com/src/components/chat-view/index.ts
@@ -114,8 +114,18 @@ export async function createChatView({ conversationId }: ChatViewProps) {
     console.log("Summary message:", summaryMessage)
   }
 
+  // Filter out system messages with tool_use entry type (they're shown via metadata)
+  const filteredMessages = messagesToRender.filter(msg => {
+    // Skip system messages that are tool uses (they're displayed via metadata)
+    if (msg.role === "system" && msg.metadata?.entryType === "tool_use") {
+      console.log("Filtering out tool_use system message:", msg.id)
+      return false
+    }
+    return true
+  })
+  
   // Show all messages (template literal issue is now fixed)
-  const limitedMessages = messagesToRender
+  const limitedMessages = filteredMessages
   console.log("Showing all messages:", limitedMessages.length)
 
   // Render messages with markdown

--- a/apps/openagents.com/src/components/chat-view/index.ts
+++ b/apps/openagents.com/src/components/chat-view/index.ts
@@ -115,7 +115,7 @@ export async function createChatView({ conversationId }: ChatViewProps) {
   }
 
   // Filter out system messages with tool_use entry type (they're shown via metadata)
-  const filteredMessages = messagesToRender.filter(msg => {
+  const filteredMessages = messagesToRender.filter((msg) => {
     // Skip system messages that are tool uses (they're displayed via metadata)
     if (msg.role === "system" && msg.metadata?.entryType === "tool_use") {
       console.log("Filtering out tool_use system message:", msg.id)
@@ -123,7 +123,7 @@ export async function createChatView({ conversationId }: ChatViewProps) {
     }
     return true
   })
-  
+
   // Show all messages (template literal issue is now fixed)
   const limitedMessages = filteredMessages
   console.log("Showing all messages:", limitedMessages.length)

--- a/apps/openagents.com/src/components/chat-view/index.ts
+++ b/apps/openagents.com/src/components/chat-view/index.ts
@@ -121,6 +121,19 @@ export async function createChatView({ conversationId }: ChatViewProps) {
       console.log("Filtering out tool_use system message:", msg.id)
       return false
     }
+
+    // Skip user messages that are actually tool results (already shown as tool results)
+    if (
+      msg.role === "user" && msg.content && (
+        msg.content.includes("[Request interrupted by user for tool use]") ||
+        msg.content.includes("📤 Tool Result") ||
+        (msg.content.startsWith("[{") && msg.content.includes("\"type\":\"tool_result\""))
+      )
+    ) {
+      console.log("Filtering out duplicate tool result shown as user message:", msg.id)
+      return false
+    }
+
     return true
   })
 

--- a/apps/openagents.com/src/lib/chat-client-convex.ts
+++ b/apps/openagents.com/src/lib/chat-client-convex.ts
@@ -371,11 +371,11 @@ function parseMessageContent(message: any): string {
             const textParts = parsed.filter((part: any) => part.type === "text")
             const toolParts = parsed.filter((part: any) => part.type === "tool_use")
 
-            // If there's no text but there are tools, show tool invocation
+            // If there's no text but there are tools, return empty
+            // (tool info will be shown via metadata)
             if (textParts.length === 0 && toolParts.length > 0) {
               debug(`Assistant message contains only tool_use, no text`)
-              const tool = toolParts[0]
-              return `🔧 Using tool: ${tool.name}`
+              return ""
             }
 
             const parts = parsed.map((part: any) => {

--- a/apps/openagents.com/src/lib/chat-client-convex.ts
+++ b/apps/openagents.com/src/lib/chat-client-convex.ts
@@ -302,21 +302,20 @@ function parseMessageContent(message: any): string {
                 debug(`User message is actually a tool_result that was mis-categorized`)
                 const toolResult = parsed[0]
                 const content = toolResult.content || ""
-                const toolUseId = toolResult.tool_use_id || ""
                 const isError = toolResult.is_error || false
 
                 // Handle empty tool results
                 if (!content || content.trim() === "") {
                   debug(`Tool result has empty content`)
-                  return `📤 Tool Result (${toolUseId}): [No output]${isError ? " - ERROR" : ""}`
+                  return `📤 Tool Result: [No output]${isError ? " - ERROR" : ""}`
                 }
 
                 // Format tool result nicely
                 if (content.includes("→")) {
                   // It's file content with line numbers
-                  return `📤 Tool Result (${toolUseId}):\n\`\`\`\n${content}\n\`\`\`${isError ? "\n[ERROR]" : ""}`
+                  return `📤 Tool Result:\n\`\`\`\n${content}\n\`\`\`${isError ? "\n[ERROR]" : ""}`
                 }
-                return `📤 Tool Result (${toolUseId}): ${content}${isError ? " [ERROR]" : ""}`
+                return `📤 Tool Result: ${content}${isError ? " [ERROR]" : ""}`
               }
               // If it's an array format
               if (Array.isArray(parsed)) {

--- a/apps/openagents.com/src/lib/chat-client-convex.ts
+++ b/apps/openagents.com/src/lib/chat-client-convex.ts
@@ -415,10 +415,8 @@ function parseMessageContent(message: any): string {
 
     case "tool_use": {
       debug(`Formatting tool_use entry: ${message.tool_name}`)
-      const toolInputStr = typeof message.tool_input === "string"
-        ? message.tool_input
-        : JSON.stringify(message.tool_input, null, 2)
-      return `🔧 Tool: ${message.tool_name || "Unknown"}\n\nInput:\n\`\`\`json\n${toolInputStr}\n\`\`\``
+      // Return empty string since tool info is displayed via metadata
+      return ""
     }
 
     case "tool_result": {

--- a/apps/openagents.com/src/lib/chat-utils.ts
+++ b/apps/openagents.com/src/lib/chat-utils.ts
@@ -297,9 +297,16 @@ export function renderChatMessage(message: {
 
   // Determine the role class for the message block
   let roleClass = "user"
+  
+  // Check if this message contains tool result content
+  const messageContainsToolResult = isToolResultProcessed || 
+                                    rawContent.startsWith("📤 Tool Result:") ||
+                                    (rawContent.startsWith("[{") && rawContent.includes('"type":"tool_result"'))
+  
   if (isToolOnlyMessage) {
     roleClass = "tool"
-  } else if (isToolResultProcessed) {
+  } else if (messageContainsToolResult) {
+    // Any message containing tool result content should be styled as tool result
     roleClass = isErrorResult ? "tool-result-error" : "tool-result"
   } else if (message.metadata?.entryType === "tool_result") {
     roleClass = isErrorResult ? "tool-result-error" : "tool-result"

--- a/apps/openagents.com/src/lib/chat-utils.ts
+++ b/apps/openagents.com/src/lib/chat-utils.ts
@@ -95,10 +95,10 @@ export function renderChatMessage(message: {
     rawContent.includes("<p>[&lt;{")
 
   // Check if this is an error tool result
-  const isErrorResult = rawContent.includes("[ERROR]") || 
-                       rawContent.includes("[Request interrupted") ||
-                       rawContent.includes("error:") ||
-                       rawContent.includes("Error:")
+  const isErrorResult = rawContent.includes("[ERROR]") ||
+    rawContent.includes("[Request interrupted") ||
+    rawContent.includes("error:") ||
+    rawContent.includes("Error:")
 
   // Handle plain text tool results
   if (message.role === "user" && isPlainTextToolResult) {
@@ -174,9 +174,9 @@ export function renderChatMessage(message: {
   }
 
   // Check if this is a tool-only message
-  const isToolOnlyMessage = message.metadata?.hasEmbeddedTool && 
-                           message.metadata?.toolName && 
-                           (!content || content.trim() === "")
+  const isToolOnlyMessage = message.metadata?.hasEmbeddedTool &&
+    message.metadata?.toolName &&
+    (!content || content.trim() === "")
 
   // Add tool information if present in metadata
   if (message.metadata?.hasEmbeddedTool && message.metadata?.toolName) {
@@ -208,12 +208,12 @@ export function renderChatMessage(message: {
           "</div>" :
           "") +
         "</div>"
-      
+
       // Prepend tool info to content
       content = toolInfo + content
     }
   }
-  
+
   // Skip rendering if there's no content at all
   if (!content || content.trim() === "") {
     return ""
@@ -226,7 +226,6 @@ export function renderChatMessage(message: {
   const messageDebugId = "debug-" + (message.id || Math.random().toString(36).substr(2, 9))
 
   let debugSection = ""
-  let debugData = ""
   if (includeDebug) {
     // Create a comprehensive debug object showing ALL database fields
     const debugObject = {
@@ -287,8 +286,7 @@ export function renderChatMessage(message: {
     }
 
     const debugJson = escapeHtml(JSON.stringify(debugObject, null, 2))
-    debugData = debugJson
-    
+
     // Create debug section (hidden by default)
     debugSection = "<div id=\"" + messageDebugId + "\" class=\"message-debug\" style=\"display: none;\">" +
       "<pre class=\"debug-json\">" + debugJson + "</pre>" +
@@ -297,12 +295,14 @@ export function renderChatMessage(message: {
 
   // Determine the role class for the message block
   let roleClass = "user"
-  
+
   // Check if this message contains tool result content
-  const messageContainsToolResult = isToolResultProcessed || 
-                                    rawContent.startsWith("📤 Tool Result:") ||
-                                    (rawContent.startsWith("[{") && rawContent.includes('"type":"tool_result"'))
-  
+  const messageContainsToolResult = isToolResultProcessed ||
+    rawContent.startsWith("📤 Tool Result:") ||
+    rawContent.includes("📤 Tool Result") ||
+    (rawContent.startsWith("[{") && rawContent.includes("\"type\":\"tool_result\"")) ||
+    rawContent.includes("Tool Result (")
+
   if (isToolOnlyMessage) {
     roleClass = "tool"
   } else if (messageContainsToolResult) {
@@ -321,7 +321,8 @@ export function renderChatMessage(message: {
     debugSection +
     // Hover buttons container
     "<div class=\"message-actions absolute right-0 mt-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100\">" +
-    "<button class=\"debug-button\" onclick=\"toggleDebug('" + messageDebugId + "')\" aria-label=\"Toggle debug info\">" +
+    "<button class=\"debug-button\" onclick=\"toggleDebug('" + messageDebugId +
+    "')\" aria-label=\"Toggle debug info\">" +
     // Bug icon SVG
     "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">" +
     "<path d=\"m8 2 1.88 1.88M14.12 3.88 16 2\"></path>" +

--- a/apps/openagents.com/src/lib/chat-utils.ts
+++ b/apps/openagents.com/src/lib/chat-utils.ts
@@ -105,11 +105,11 @@ export function renderChatMessage(message: {
     // Extract content after "📤 Tool Result: "
     const toolResultContent = rawContent.substring("📤 Tool Result: ".length).trim()
     const formattedContent = formatToolResult(toolResultContent)
-    content = "<div class=\"tool-result-header\">" +
-      "<span class=\"tool-result-icon\">📤</span>" +
-      "<span class=\"tool-result-label\">Tool Result</span>" +
+    content = "<div class=\"tool-header\">" +
+      "<span class=\"tool-icon\">📤</span>" +
+      "<span class=\"tool-name\">Tool Result</span>" +
       "</div>" +
-      "<div class=\"tool-result-content\">" +
+      "<div class=\"tool-content\">" +
       formattedContent +
       "</div>"
     isToolResultProcessed = true
@@ -129,14 +129,12 @@ export function renderChatMessage(message: {
         // Format tool result nicely - ignore any rendered markdown
         const toolResult = parsed[0]
         const formattedContent = formatToolResult(toolResult.content || "")
-        content = "<div class=\"tool-result-header\">" +
-          "<span class=\"tool-result-icon\">📤</span>" +
-          "<span class=\"tool-result-label\">Tool Result</span>" +
-          "<span class=\"tool-result-id\" style=\"font-size: 11px; opacity: 0.7; margin-left: 0.5rem;\">" +
-          escapeHtml(toolResult.tool_use_id || "") + "</span>" +
+        content = "<div class=\"tool-header\">" +
+          "<span class=\"tool-icon\">📤</span>" +
+          "<span class=\"tool-name\">Tool Result</span>" +
           "</div>" +
-          "<div class=\"tool-result-content\">" +
-          formattedContent + // Don't wrap in pre tag - formatToolResult handles it
+          "<div class=\"tool-content\">" +
+          formattedContent +
           "</div>"
         isToolResultProcessed = true
       }

--- a/apps/openagents.com/src/lib/chat-utils.ts
+++ b/apps/openagents.com/src/lib/chat-utils.ts
@@ -68,7 +68,7 @@ function formatToolResult(content: string): string {
  * Generate HTML for a chat message (using string concatenation instead of template literals)
  */
 export function renderChatMessage(message: {
-  role: "user" | "assistant"
+  role: "user" | "assistant" | "system"
   content: string
   timestamp?: number
   rendered?: string
@@ -194,6 +194,11 @@ export function renderChatMessage(message: {
 
     // Prepend tool info to content
     content = toolInfo + content
+  }
+  
+  // Skip rendering if there's no content at all
+  if (!content || content.trim() === "") {
+    return ""
   }
 
   // Only include debug section if explicitly enabled or in development
@@ -729,6 +734,11 @@ export const chatStyles = `
   /* Tool message styling */
   .message-block.tool {
     border-left-color: #a855f7; /* Purple for tools */
+  }
+  
+  /* System message styling (for tool uses, etc) */
+  .message-block.system {
+    border-left-color: #a855f7; /* Purple for system/tool messages */
   }
   
   .message-body {

--- a/apps/openagents.com/src/lib/chat-utils.ts
+++ b/apps/openagents.com/src/lib/chat-utils.ts
@@ -171,29 +171,51 @@ export function renderChatMessage(message: {
       "</div>"
   }
 
+  // Check if this is a tool-only message
+  const isToolOnlyMessage = message.metadata?.hasEmbeddedTool && 
+                           message.metadata?.toolName && 
+                           (!content || content.trim() === "")
+
   // Add tool information if present in metadata
   if (message.metadata?.hasEmbeddedTool && message.metadata?.toolName) {
     const toolInput = message.metadata.toolInput ?
       escapeHtml(JSON.stringify(message.metadata.toolInput, null, 2)) :
       ""
 
-    const toolInfo = "<div class=\"tool-section\">" +
-      "<div class=\"tool-header\">" +
-      "<span class=\"tool-icon\">🔧</span>" +
-      "<span class=\"tool-name\">" + escapeHtml(message.metadata.toolName) + "</span>" +
-      "</div>" +
-      (toolInput ?
-        "<div class=\"tool-input\">" +
-        "<details>" +
-        "<summary>View input</summary>" +
-        "<pre>" + toolInput + "</pre>" +
-        "</details>" +
-        "</div>" :
-        "") +
-      "</div>"
-
-    // Prepend tool info to content
-    content = toolInfo + content
+    if (isToolOnlyMessage) {
+      // For tool-only messages, show tool info directly without wrapper
+      content = "<div class=\"tool-header\">" +
+        "<span class=\"tool-icon\">🔧</span>" +
+        "<span class=\"tool-name\">" + escapeHtml(message.metadata.toolName) + "</span>" +
+        "</div>" +
+        (toolInput ?
+          "<div class=\"tool-input\">" +
+          "<details>" +
+          "<summary>View input</summary>" +
+          "<pre>" + toolInput + "</pre>" +
+          "</details>" +
+          "</div>" :
+          "")
+    } else {
+      // For messages with both tool and content, show tool in a section
+      const toolInfo = "<div class=\"tool-section\">" +
+        "<div class=\"tool-header\">" +
+        "<span class=\"tool-icon\">🔧</span>" +
+        "<span class=\"tool-name\">" + escapeHtml(message.metadata.toolName) + "</span>" +
+        "</div>" +
+        (toolInput ?
+          "<div class=\"tool-input\">" +
+          "<details>" +
+          "<summary>View input</summary>" +
+          "<pre>" + toolInput + "</pre>" +
+          "</details>" +
+          "</div>" :
+          "") +
+        "</div>"
+      
+      // Prepend tool info to content
+      content = toolInfo + content
+    }
   }
   
   // Skip rendering if there's no content at all
@@ -277,9 +299,12 @@ export function renderChatMessage(message: {
       "</div>"
   }
 
+  // Determine the role class for the message block
+  const roleClass = isToolOnlyMessage ? "tool" : message.role
+
   return (
     "<div class=\"message\">" +
-    "<div class=\"message-block " + message.role + " group relative\">" +
+    "<div class=\"message-block " + roleClass + " group relative\">" +
     "<div class=\"message-body\">" + content + "</div>" +
     debugSection +
     // Hover buttons container

--- a/apps/openagents.com/src/lib/chat-utils.ts
+++ b/apps/openagents.com/src/lib/chat-utils.ts
@@ -190,10 +190,7 @@ export function renderChatMessage(message: {
         "</div>" +
         (toolInput ?
           "<div class=\"tool-input\">" +
-          "<details>" +
-          "<summary>View input</summary>" +
           "<pre>" + toolInput + "</pre>" +
-          "</details>" +
           "</div>" :
           "")
     } else {
@@ -205,10 +202,7 @@ export function renderChatMessage(message: {
         "</div>" +
         (toolInput ?
           "<div class=\"tool-input\">" +
-          "<details>" +
-          "<summary>View input</summary>" +
           "<pre>" + toolInput + "</pre>" +
-          "</details>" +
           "</div>" :
           "") +
         "</div>"
@@ -803,21 +797,6 @@ export const chatStyles = `
   
   .tool-input {
     margin-top: 0.5rem;
-  }
-  
-  .tool-input details {
-    margin: 0;
-  }
-  
-  .tool-input summary {
-    cursor: pointer;
-    font-size: 12px;
-    color: var(--gray);
-    user-select: none;
-  }
-  
-  .tool-input summary:hover {
-    color: var(--white);
   }
   
   .tool-input pre {

--- a/apps/openagents.com/src/lib/chat-utils.ts
+++ b/apps/openagents.com/src/lib/chat-utils.ts
@@ -318,11 +318,11 @@ export function renderChatMessage(message: {
     "<div class=\"message-body\">" + content + "</div>" +
     debugSection +
     // Hover buttons container
-    "<div class=\"message-actions absolute right-0 mt-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100\">" +
+    "<div class=\"message-actions\">" +
     "<button class=\"debug-button\" onclick=\"toggleDebug('" + messageDebugId +
     "')\" aria-label=\"Toggle debug info\">" +
     // Bug icon SVG
-    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">" +
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">" +
     "<path d=\"m8 2 1.88 1.88M14.12 3.88 16 2\"></path>" +
     "<path d=\"M9 7.13v-1a3.003 3.003 0 1 1 6 0v1\"></path>" +
     "<path d=\"M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6z\"></path>" +

--- a/apps/openagents.com/src/lib/chat-utils.ts
+++ b/apps/openagents.com/src/lib/chat-utils.ts
@@ -199,7 +199,11 @@ export function renderChatMessage(message: {
   // Only include debug section if explicitly enabled or in development
   const includeDebug = true // Re-enabled for debugging
 
+  // Generate a unique ID for this message's debug section
+  const messageDebugId = "debug-" + (message.id || Math.random().toString(36).substr(2, 9))
+
   let debugSection = ""
+  let debugData = ""
   if (includeDebug) {
     // Create a comprehensive debug object showing ALL database fields
     const debugObject = {
@@ -260,19 +264,37 @@ export function renderChatMessage(message: {
     }
 
     const debugJson = escapeHtml(JSON.stringify(debugObject, null, 2))
-    debugSection = "<div class=\"message-debug\">" +
-      "<details>" +
-      "<summary>Debug Info</summary>" +
+    debugData = debugJson
+    
+    // Create debug section (hidden by default)
+    debugSection = "<div id=\"" + messageDebugId + "\" class=\"message-debug\" style=\"display: none;\">" +
       "<pre class=\"debug-json\">" + debugJson + "</pre>" +
-      "</details>" +
       "</div>"
   }
 
   return (
     "<div class=\"message\">" +
-    "<div class=\"message-block " + message.role + "\">" +
+    "<div class=\"message-block " + message.role + " group relative\">" +
     "<div class=\"message-body\">" + content + "</div>" +
     debugSection +
+    // Hover buttons container
+    "<div class=\"message-actions absolute right-0 mt-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100\">" +
+    "<button class=\"debug-button\" onclick=\"toggleDebug('" + messageDebugId + "')\" aria-label=\"Toggle debug info\">" +
+    // Bug icon SVG
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">" +
+    "<path d=\"m8 2 1.88 1.88M14.12 3.88 16 2\"></path>" +
+    "<path d=\"M9 7.13v-1a3.003 3.003 0 1 1 6 0v1\"></path>" +
+    "<path d=\"M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6z\"></path>" +
+    "<path d=\"M12 20v-9\"></path>" +
+    "<path d=\"M6.53 9C4.6 8.8 3 7.1 3 5\"></path>" +
+    "<path d=\"M6 13H2\"></path>" +
+    "<path d=\"M3 21c0-2.1 1.7-3.9 3.8-4\"></path>" +
+    "<path d=\"M20.97 5c0 2.1-1.6 3.8-3.5 4\"></path>" +
+    "<path d=\"M22 13h-4\"></path>" +
+    "<path d=\"M17.2 17c2.1.1 3.8 1.9 3.8 4\"></path>" +
+    "</svg>" +
+    "</button>" +
+    "</div>" +
     "</div>" +
     "</div>"
   )
@@ -992,28 +1014,6 @@ export const chatStyles = `
   }
 
   /* Debug section styling - only shown when enabled */
-  .message-debug {
-    margin-top: 8px;
-    padding-top: 8px;
-    border-top: 1px solid var(--offblack);
-  }
-
-  .message-debug details {
-    margin: 0;
-  }
-
-  .message-debug summary {
-    color: var(--gray);
-    font-size: 11px;
-    font-family: var(--font-family-mono);
-    cursor: pointer;
-    user-select: none;
-    padding: 2px 0;
-  }
-
-  .message-debug summary:hover {
-    color: var(--white);
-  }
 
   .debug-json {
     background-color: var(--black);
@@ -1090,5 +1090,59 @@ export const chatStyles = `
   .tool-name {
     color: #a855f7;
     font-weight: 600;
+  }
+
+  /* Group hover functionality */
+  .group {
+    position: relative;
+  }
+
+  /* Message actions (hover buttons) */
+  .message-actions {
+    position: absolute;
+    right: 0;
+    margin-top: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .group:hover .message-actions {
+    opacity: 1;
+  }
+
+  /* Debug button styling */
+  .debug-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    border: none;
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--gray);
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+
+  .debug-button:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--lightgray);
+  }
+
+  .debug-button svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  /* Debug section when visible */
+  .message-debug {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--offblack);
   }
 `


### PR DESCRIPTION
## Summary
- Remove redundant "Using tool: Bash" text that appeared in both blue container and purple section
- Display tool invocations in purple-bordered containers directly (not purple sections inside blue containers)  
- Make bash input JSON always visible without collapsible behavior
- Fix tool results showing with green borders - now display with purple borders to match tool invocations
- Handle error tool results with red borders when they contain "[ERROR]" or similar error indicators

## Changes
1. Modified `parseMessageContent` in `chat-client-convex.ts` to return empty string for assistant messages containing only tool_use
2. Added tool-only message detection in `chat-utils.ts` to use "tool" class for the entire message block
3. Removed collapsible functionality for tool inputs - now always visible
4. Fixed tool result detection to check message content patterns and force appropriate styling class regardless of message role
5. Added comprehensive tool result content detection including various formats

## Test plan
- [x] Verified tool invocations show in purple containers without redundant text
- [x] Confirmed bash inputs are always visible
- [x] Tested tool results display with purple borders
- [x] Verified error tool results show with red borders
- [x] ESLint and tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)