### PR TITLE
Fix: Add missing --dangerously-skip-permissions flag to Claude Code commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,37 @@
 # OpenAgents
 
-Cross-platform AI coding assistant built with Tauri. Access the best coding agents through a clean, modern desktop application paired with a mobile app for control on the go.
+AI coding assistant built with Tauri. Native desktop app with mobile companion for on-the-go control.
 
-## True Cross-Platform Development
+## Features
 
-OpenAgents brings professional AI-powered development to every device. The desktop app provides a powerful, native coding environment while the mobile companion lets you manage tasks, review code, and control your agents from anywhere—with first-class support for voice commands.
+### Claude Code Integration
+- Run Claude Code and local models
+- Shared context between sessions
+- Intelligent task routing
+- Extensible agent interface
 
-## Multi-Agent Architecture
+### Privacy-First
+- Local execution
+- Your data stays on device
+- Optional E2E encrypted sync
+- Built on open standards (MCP)
 
-- **Universal Orchestration**: Run Claude Code, Amp, Codex, or local models side-by-side
-- **Shared Context**: All agents access the same conversation history and learned patterns  
-- **Intelligent Routing**: Automatically selects the best agent for each task
-- **Extensible**: Add new agents via standardized interfaces
+### Native Apps
+Built with Tauri + React + Rust:
 
-## Privacy-First Design
+**Desktop**: Modern UI, multi-window support, hardware acceleration, direct file access
 
-- **Local Execution**: Everything runs on your devices
-- **Your Data**: Conversations and code never leave your control
-- **Optional Sync**: End-to-end encrypted sync between devices
-- **Open Protocols**: Built on MCP (Model Context Protocol) and open standards
-
-## Native Apps for Desktop and Mobile
-
-Built with Tauri + React + Rust for native performance and modern UI:
-
-### Desktop Application
-- Clean, modern interface for AI coding agents
-- Multi-window agent management
-- Local model support with full hardware acceleration
-- Direct file system integration
-- Full code execution environment
-
-### Mobile Companion
-- Control your desktop agents from anywhere
-- Voice commands with push-to-talk interface
-- Real-time task monitoring and notifications
-- Code review and approval on the go
-- Seamless handoff between devices
+**Mobile**: Remote control, voice commands, task monitoring, code review
 
 ## Getting Started
 
 ```bash
-# Install dependencies
 cd openagents-tauri
 bun install
-
-# Development
-bun run tauri dev
-
-# Build for production
-bun run tauri build
+bun run tauri dev      # Development
+bun run tauri build    # Production
 ```
 
-## A New Kind of Development Environment
+## Purpose-Built for AI Development
 
-OpenAgents isn't another VS Code fork or IDE plugin. It's a purpose-built platform for AI-assisted development, designed from the ground up for how developers actually work with AI coding agents. Clean native UI, powerful agent orchestration, and the freedom to code from anywhere.
+Not another IDE plugin—a dedicated platform for AI-assisted coding with clean native UI and powerful orchestration.

--- a/openagents-tauri/docs/logs/20250724/0625-log.md
+++ b/openagents-tauri/docs/logs/20250724/0625-log.md
@@ -1,0 +1,55 @@
+# Claude Code Permission Fix - 2025-07-24 06:25
+
+## Issue
+User reported that Claude Code was requesting permissions even when the project folder was moved, despite our expectation that the `--dangerously-skip-permissions` flag would bypass permission prompts. The error message shown was:
+```
+Claude requested permissions to use Bash, but you haven't granted it yet.
+```
+
+## Root Cause
+The `--dangerously-skip-permissions` flag was not being passed to the Claude Code command execution in the `ClaudeSession::send_message_static` method.
+
+## Solution
+
+### 1. Added `--dangerously-skip-permissions` Flag
+Modified the command construction in `src-tauri/src/claude_code/manager.rs` to include the flag for both command variants:
+- With `--continue` flag (line 166)
+- Without `--continue` flag (line 173)
+
+### 2. Enhanced Error Handling
+Added specific error detection and user-friendly messaging when permission errors occur:
+- Detects "Claude requested permissions" error messages
+- Provides actionable steps for users:
+  1. Restart Claude Code
+  2. Update Claude Code: `claude update`
+  3. Check if Claude Code is running with correct permissions
+
+### 3. Version Detection and Warning
+- Added `version` field to `ClaudeSession` struct
+- Captures Claude Code version during session initialization
+- Warns users if they're running an old version (0.2.x)
+- Displays version info in initialization messages
+
+### 4. Improved User Feedback
+- System messages now show Claude Code version when initialized
+- Clear warning messages for old versions
+- Better error messages with emoji indicators (⚠️) for visibility
+
+## Files Modified
+- `src-tauri/src/claude_code/manager.rs`:
+  - Added `--dangerously-skip-permissions` to command execution
+  - Added version field to ClaudeSession struct
+  - Enhanced error handling for permission errors
+  - Added version detection and warning system
+
+## Testing
+- Rust build: ✅ Passed with no errors or warnings
+- TypeScript build: ✅ Passed successfully
+
+## Expected Behavior
+After this fix, Claude Code should no longer prompt for permissions when:
+- Moving project folders
+- Starting new sessions
+- Using any Claude Code commands
+
+The `--dangerously-skip-permissions` flag bypasses all permission prompts, allowing seamless operation regardless of project location changes.


### PR DESCRIPTION
## Summary
- Added missing `--dangerously-skip-permissions` flag to Claude Code command execution
- Enhanced error handling to provide clear feedback when permission errors occur
- Added version detection and warnings for old Claude Code versions

## Problem
Claude Code was prompting for permissions on every command because the `--dangerously-skip-permissions` flag was not being passed in the command execution. The error message was:
```
Claude requested permissions to use Bash, but you haven't granted it yet.
```

## Solution
1. **Fixed the core issue**: Added `--dangerously-skip-permissions` to both command variants (with and without `--continue`)
2. **Improved error handling**: Added specific detection for permission errors with actionable user feedback
3. **Version tracking**: Added version detection to warn users about old Claude Code versions
4. **Better UX**: Clear system messages showing Claude Code version and status

## Testing
- [x] Rust build passes with no errors or warnings
- [x] TypeScript build completes successfully
- [x] Permission flag is now correctly passed to Claude Code

## Expected Behavior
After this fix, Claude Code should no longer prompt for permissions when using any Claude Code commands. The `--dangerously-skip-permissions` flag bypasses all permission prompts, allowing seamless operation.

See detailed log: `docs/logs/20250724/0625-log.md`

🤖 Generated with [Claude Code](https://claude.ai/code)