### PR TITLE
🐛 Fix React Hooks violation in mobile ClaudeCodeMobile component

### DIFF
--- a/apps/mobile/components/ClaudeCodeMobile.tsx
+++ b/apps/mobile/components/ClaudeCodeMobile.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -48,6 +48,9 @@ export function ClaudeCodeMobile() {
   const [newSessionTitle, setNewSessionTitle] = useState("");
   const [initialMessage, setInitialMessage] = useState("");
   
+  // Message input state (moved from renderSessionDetail to fix hooks violation)
+  const [newMessage, setNewMessage] = useState("");
+  
   // Convex hooks
   const sessions = useQuery(api.claude.getSessions, { limit: 50 }) || [];
   const selectedSessionMessages = useQuery(
@@ -58,6 +61,11 @@ export function ClaudeCodeMobile() {
   const requestDesktopSession = useMutation(api.claude.requestDesktopSession);
   const addMessage = useMutation(api.claude.addClaudeMessage);
   const updateSyncStatus = useMutation(api.claude.updateSyncStatus);
+
+  // Clear message input when switching sessions
+  useEffect(() => {
+    setNewMessage("");
+  }, [selectedSessionId]);
 
   const handleCreateSession = async () => {
     if (!newProjectPath.trim()) {
@@ -197,7 +205,6 @@ export function ClaudeCodeMobile() {
     }
 
     const session = sessions.find((s: ClaudeSession) => s.sessionId === selectedSessionId);
-    const [newMessage, setNewMessage] = useState("");
 
     return (
       <View style={styles.sessionDetail}>


### PR DESCRIPTION
## 🐛 Bug Fix: React Hooks Violation

Fixes critical React Hook error that was completely crashing the mobile app.

### 🚨 **Problem**
- React Hook `useState` was called inside `renderSessionDetail()` render function
- Caused "Rendered more hooks than during the previous render" error
- Mobile app crashed immediately when trying to view sessions
- Violated React Rules of Hooks

### ✅ **Solution**
**1. Moved Hook to Component Top Level:**
```tsx
// ❌ Before (VIOLATION)
const renderSessionDetail = () => {
  const [newMessage, setNewMessage] = useState(""); // Hook inside render function\!
}

// ✅ After (CORRECT)
export function ClaudeCodeMobile() {
  const [newMessage, setNewMessage] = useState(""); // Hook at component top level
  
  const renderSessionDetail = () => {
    // Uses newMessage state from component level
  }
}
```

**2. Added UX Improvement:**
- Added `useEffect` to clear message input when switching sessions
- Prevents old message text from showing when viewing different session

**3. Fixed Imports:**
- Added `useEffect` to React imports

### 🧪 **Testing Results**
- ✅ **No more React Hook errors** in console
- ✅ **Session list loads without crashes**
- ✅ **Message input functionality restored**
- ✅ **TypeScript compilation passes**
- ✅ **Mobile app fully functional**

### 📋 **Files Changed**
- `apps/mobile/components/ClaudeCodeMobile.tsx` - Fixed hooks violation and improved UX

### 🎯 **Impact**
- **Critical Fix**: Restores mobile app functionality
- **Follows React Best Practices**: Proper hook usage patterns
- **Better UX**: Auto-clears input when switching sessions
- **No Breaking Changes**: Maintains all existing functionality

### ✅ **Ready to Merge**
This fix resolves the critical mobile app crash and follows proper React patterns.

Fixes #1180

---
🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the message input was not properly reset when switching sessions.
  * Improved stability by ensuring consistent state management for the message input field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->