### PR TITLE
🔧 FIX: Implement Claude Code message persistence to Convex

### DIFF
--- a/apps/desktop/src/hooks/useAppInitialization.ts
+++ b/apps/desktop/src/hooks/useAppInitialization.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { useAppStore } from '@/stores/appStore';
 

--- a/apps/desktop/src/hooks/useClaudeStreaming.ts
+++ b/apps/desktop/src/hooks/useClaudeStreaming.ts
@@ -3,6 +3,8 @@ import { Effect, Stream, pipe, Layer } from 'effect';
 import { ClaudeStreamingService, ClaudeStreamingServiceLive, StreamingSession, Message } from '../services/ClaudeStreamingService';
 import { TauriEventService, TauriEventServiceLive } from '../services/TauriEventService';
 import { invoke } from '@tauri-apps/api/core';
+import { useMutation } from 'convex/react';
+import { api } from '../convex/_generated/api';
 
 interface UseClaudeStreamingOptions {
   sessionId: string;
@@ -33,6 +35,7 @@ export function useClaudeStreaming({
   const [error, setError] = useState<Error | null>(null);
   
   const sessionRef = useRef<StreamingSession | null>(null);
+  const addClaudeMessage = useMutation(api.claude.addClaudeMessage);
 
   // Start streaming
   const startStreaming = useCallback(async () => {
@@ -66,6 +69,10 @@ export function useClaudeStreaming({
                   return [...prev, message];
                 }
               });
+              
+              // Persist message to Convex
+              persistMessageToConvex(message);
+              
               onMessage?.(message);
             })
           ),
@@ -98,6 +105,69 @@ export function useClaudeStreaming({
       sessionRef.current = null;
     }
   }, [sessionId, isStreaming, onMessage, onError]);
+
+  // Persist streaming messages to Convex
+  const persistMessageToConvex = useCallback(async (message: Message) => {
+    try {
+      // Map message type to Convex format
+      const messageType = mapMessageTypeToConvex(message.message_type);
+      
+      if (!messageType) {
+        console.log('🔇 [STREAMING] Skipping message persistence for type:', message.message_type);
+        return;
+      }
+      
+      console.log('💾 [STREAMING] Persisting message to Convex:', {
+        sessionId,
+        messageId: message.id,
+        messageType,
+        contentLength: message.content.length
+      });
+      
+      await addClaudeMessage({
+        sessionId,
+        messageId: message.id,
+        messageType,
+        content: message.content,
+        timestamp: message.timestamp,
+        toolInfo: message.tool_info ? {
+          toolName: message.tool_info.tool_name,
+          toolUseId: message.tool_info.tool_use_id,
+          input: message.tool_info.input,
+          output: message.tool_info.output,
+        } : undefined,
+        metadata: { source: 'claude_streaming' },
+      });
+      
+      console.log('✅ [STREAMING] Message persisted to Convex successfully');
+    } catch (error) {
+      console.error('❌ [STREAMING] Failed to persist message to Convex:', error);
+      // Don't throw - streaming should continue even if persistence fails
+    }
+  }, [sessionId, addClaudeMessage]);
+
+  // Helper function to map streaming message types to Convex types
+  const mapMessageTypeToConvex = (streamingType: string): 'user' | 'assistant' | 'tool_use' | 'tool_result' | null => {
+    switch (streamingType) {
+      case 'assistant':
+        return 'assistant';
+      case 'user':
+        return 'user';
+      case 'tool_use':
+        return 'tool_use';
+      case 'tool_result':
+        return 'tool_result';
+      // Skip system messages, thinking, summaries, errors as they're not user-facing
+      case 'system':
+      case 'thinking':
+      case 'summary':
+      case 'error':
+        return null;
+      default:
+        console.warn('🤔 [STREAMING] Unknown message type:', streamingType);
+        return null;
+    }
+  };
 
   // Send message using the existing Tauri command
   const sendMessage = useCallback(async (message: string) => {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,5 +1,4 @@
 import "./index.css"
-import React from "react"
 import ReactDOM from "react-dom/client"
 import App from "./App"
 import { ConvexProvider, ConvexReactClient } from "convex/react"

--- a/apps/mobile/components/ClaudeCodeMobile.tsx
+++ b/apps/mobile/components/ClaudeCodeMobile.tsx
@@ -61,9 +61,6 @@ export function ClaudeCodeMobile() {
   // Message input state (moved from renderSessionDetail to fix hooks violation)
   const [newMessage, setNewMessage] = useState("");
   
-  // Message input state (moved from renderSessionDetail to fix hooks violation)
-  const [newMessage, setNewMessage] = useState("");
-  
   // Convex hooks
   const sessions = useQuery(api.claude.getSessions, { limit: 50 }) || [];
   const selectedSessionMessages = useQuery(


### PR DESCRIPTION
## Problem Summary

Claude Code messages were streaming successfully to desktop UI but never persisting to Convex database, preventing mobile app from seeing Claude's responses.

## Root Cause

The message flow had a critical gap:
1. Mobile creates session with initial message in Convex ✅
2. Desktop processes mobile session and creates local Claude Code session ✅  
3. Initial message sent to Claude Code ✅
4. Claude responds and messages stream to desktop UI ✅
5. **Missing**: Messages remained in desktop local state only ❌
6. Mobile app couldn't see Claude responses ❌

## Solution Implemented

### Core Fix: Message Persistence in Streaming Pipeline

**Modified `useClaudeStreaming.ts`:**
- Added `persistMessageToConvex()` function that calls `addClaudeMessage` mutation
- Integrated persistence into the streaming message pipeline
- Added proper error handling - streaming continues even if persistence fails

**Message Type Filtering:**
- Added `mapMessageTypeToConvex()` to handle only user-facing message types
- Maps: `assistant`, `user`, `tool_use`, `tool_result` 
- Skips: `system`, `thinking`, `summary`, `error` messages

**Session ID Mapping:**
- Verified proper session ID flow: Mobile session → Desktop UUID session → Convex session
- Streaming messages use correct UUID session ID for persistence

### Additional Bug Fixes

- **Mobile App**: Fixed duplicate `newMessage` state declaration causing build errors
- **TypeScript**: Removed unused imports in `useAppInitialization.ts` and `main.tsx`

## Technical Implementation

### Message Flow (After Fix)
```
Mobile Session (Convex) → Desktop Claude Code → Desktop UI (local state)
                                                      ↓ NEW PERSISTENCE
                                              Convex Database ← Mobile App
```

### Key Features
- **Real-time Persistence**: Each streaming message chunk automatically syncs to Convex
- **Graceful Error Handling**: Persistence failures don't break streaming
- **Proper Metadata**: Messages tagged with `source: 'claude_streaming'`
- **Tool Info Mapping**: Tool usage data properly transformed for Convex format

## Testing

- ✅ Desktop app builds successfully  
- ✅ Mobile app compiles without errors
- ✅ TypeScript compilation passes
- ✅ All existing functionality preserved

## Expected Behavior (After Fix)

1. Mobile creates session with initial message
2. Desktop processes session and starts Claude Code streaming  
3. Claude's responses stream to desktop UI **AND** persist to Convex
4. Mobile app can now see Claude responses in real-time
5. Session continuity maintained across devices

## Files Changed

- `apps/desktop/src/hooks/useClaudeStreaming.ts` - Added message persistence
- `apps/mobile/components/ClaudeCodeMobile.tsx` - Fixed duplicate state declaration  
- `apps/desktop/src/hooks/useAppInitialization.ts` - Removed unused import
- `apps/desktop/src/main.tsx` - Removed unused React import

## Related Issues

- Fixes #1184 
- Follow-up to PR #1183 session management refactoring

@coderabbitai Please review the message persistence implementation and verify the streaming-to-Convex integration approach is sound.

---

Ready for testing with mobile-desktop session synchronization\! 🚀