### PR TITLE
Fix: Prevent mobile sessions from re-triggering on app restart

### DIFF
--- a/apps/desktop/src/hooks/useMobileSessionSync.ts
+++ b/apps/desktop/src/hooks/useMobileSessionSync.ts
@@ -157,17 +157,9 @@ export const useMobileSessionSync = (
         openChatPane(localSessionId, mobileSession.projectPath);
         console.log('✅ [MOBILE-SYNC] Chat pane opened successfully');
         
-        console.log('🔄 [MOBILE-SYNC] Updating mobile session status to active...');
-        try {
-          await updateSessionStatus({
-            sessionId: mobileSession.sessionId,
-            status: "active"
-          });
-          console.log('✅ [MOBILE-SYNC] Successfully updated mobile session to active status');
-        } catch (statusError) {
-          console.error('❌ [MOBILE-SYNC] Failed to update session status:', statusError);
-          throw statusError;
-        }
+        // Note: We don't change the status to "active" here anymore
+        // The session will be marked as "processed" after successful handling
+        console.log('📝 [MOBILE-SYNC] Keeping mobile session in pending state until processing completes');
         
         console.log('💬 [MOBILE-SYNC] Triggering Claude Code to respond to existing message...');
         
@@ -205,7 +197,17 @@ export const useMobileSessionSync = (
           console.error('❌ [MOBILE-SYNC] Failed to get mobile session messages:', messageError);
         }
 
-        // Session is now active, no need to mark as processed
+        // Mark the mobile session as processed to prevent re-triggering on app restart
+        console.log('🏁 [MOBILE-SYNC] Marking mobile session as processed to prevent re-triggering...');
+        try {
+          await updateSessionStatus({
+            sessionId: mobileSession.sessionId,
+            status: "processed"
+          });
+          console.log('✅ [MOBILE-SYNC] Successfully marked mobile session as processed');
+        } catch (statusError) {
+          console.error('❌ [MOBILE-SYNC] Failed to mark session as processed:', statusError);
+        }
 
         setProcessedMobileSessions(prev => new Set(prev).add(mobileSession.sessionId));
         console.log('✅ [MOBILE-SYNC] Successfully created and synced local session from mobile request');

--- a/docs/systems/mobile-desktop-claude-sync.md
+++ b/docs/systems/mobile-desktop-claude-sync.md
@@ -632,6 +632,10 @@ bun run compile
 - **Cause**: Rust `send_message` command always creates a new user message
 - **Solution**: Use `trigger_claude_response` command which triggers Claude without creating a user message
 
+**Issue**: Mobile sessions re-triggering on app restart
+- **Cause**: Sessions remain with "active" status after processing
+- **Solution**: Mark sessions as "processed" after successful handling to prevent re-triggering
+
 **Issue**: Duplicate sessions being created
 - **Cause**: Race condition in session processing or mapping failure
 - **Solution**: Check circuit breaker logic and session deduplication


### PR DESCRIPTION
## Problem
When closing and reopening the desktop app, mobile sessions were being re-processed every time, causing:
- Claude to respond to the same message multiple times
- Duplicate responses accumulating in the session
- Poor user experience with repeated processing

## Root Cause
Mobile sessions were left in "active" status even after successful processing, causing them to be picked up again by `getPendingMobileSessions` query on next app start.

## Solution
1. **Mark sessions as "processed"** after successfully triggering Claude response
2. **Remove intermediate status update** that was setting sessions to "active" 
3. Sessions now flow from "active" → "processed" preventing re-triggering

## Changes
- Updated `useMobileSessionSync` to mark sessions as "processed" after handling
- Removed unnecessary "active" status update during processing
- Added troubleshooting documentation for this issue

## Testing
1. Create a mobile session
2. Open desktop app - session processes once
3. Close and reopen desktop app - session should NOT re-trigger
4. Historical messages should still load correctly

## Related Issues
- Fixes the re-triggering problem mentioned in #1189
- Builds on PR #1187 (duplicate messages fix)

The fix ensures mobile sessions are only processed once, providing a clean user experience across app restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where mobile sessions could re-trigger upon app restart by updating session status only after full processing.

* **Documentation**
  * Added troubleshooting guidance for mobile session re-triggering, including explanation and solution steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->