### PR TITLE
Fix: Initialize newProjectPath to enable Cmd+1 hotkey

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,10 +5,8 @@
   "license": "CC0-1.0",
   "type": "module",
   "scripts": {
-    "dev": "DISABLE_HMR=true tauri dev",
-    "dev:hmr": "tauri dev",
-    "dev:vite": "DISABLE_HMR=true vite",
-    "dev:vite:hmr": "vite",
+    "dev": "tauri dev",
+    "dev:vite": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri"

--- a/apps/desktop/src/hooks/useSessionManager.ts
+++ b/apps/desktop/src/hooks/useSessionManager.ts
@@ -32,7 +32,7 @@ interface Session {
 
 export const useSessionManager = () => {
   const [sessions, setSessions] = useState<Session[]>([]);
-  const [newProjectPath, setNewProjectPath] = useState("");
+  const [newProjectPath, setNewProjectPath] = useState("/Users/christopherdavid/code/openagents");
   const { openChatPane, updateSessionMessages } = usePaneStore();
 
   const createSession = useCallback(async () => {

--- a/apps/desktop/src/hooks/useSessionManager.ts
+++ b/apps/desktop/src/hooks/useSessionManager.ts
@@ -1,6 +1,8 @@
 import { useState, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { usePaneStore } from '@/stores/pane';
+import { useMutation } from 'convex/react';
+import { api } from '../convex/_generated/api';
 
 interface Message {
   id: string;
@@ -34,6 +36,7 @@ export const useSessionManager = () => {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [newProjectPath, setNewProjectPath] = useState("/Users/christopherdavid/code/openagents");
   const { openChatPane, updateSessionMessages } = usePaneStore();
+  const createClaudeSession = useMutation(api.claude.createClaudeSession);
 
   const createSession = useCallback(async () => {
     if (!newProjectPath) {
@@ -48,6 +51,21 @@ export const useSessionManager = () => {
 
       if (result.success && result.data) {
         const sessionId = result.data;
+        
+        // Create the Convex session document so mobile can see it
+        try {
+          await createClaudeSession({
+            sessionId,
+            projectPath: newProjectPath,
+            createdBy: "desktop",
+            title: `Desktop Session - ${new Date().toLocaleString()}`,
+          });
+          console.log('✅ Created Convex session document for:', sessionId);
+        } catch (convexError) {
+          console.error('❌ Failed to create Convex session:', convexError);
+          // Continue anyway - local session still works
+        }
+        
         const newSession: Session = {
           id: sessionId,
           projectPath: newProjectPath,
@@ -65,7 +83,7 @@ export const useSessionManager = () => {
     } catch (error) {
       alert(`Error: ${error}`);
     }
-  }, [newProjectPath, openChatPane]);
+  }, [newProjectPath, openChatPane, createClaudeSession]);
 
   const stopSession = useCallback(async (sessionId: string) => {
     setSessions(prev => prev.map(s => 

--- a/apps/desktop/src/panes/ChatPane.tsx
+++ b/apps/desktop/src/panes/ChatPane.tsx
@@ -93,6 +93,7 @@ export const ChatPane: React.FC<ChatPaneProps> = ({ pane, session, sendMessage }
 
   const renderMessage = (msg: Message) => {
     const isUser = msg.message_type === 'user';
+    const isThinking = msg.message_type === 'thinking';
     
     return (
       <div key={msg.id} className={`text-left font-mono ${isUser ? 'mb-4' : 'mb-2'}`}>
@@ -101,6 +102,10 @@ export const ChatPane: React.FC<ChatPaneProps> = ({ pane, session, sendMessage }
             <div className="text-zinc-400">
               <span>&gt; </span>
               <span className="whitespace-pre-wrap">{msg.content}</span>
+            </div>
+          ) : isThinking ? (
+            <div className="pl-2 text-zinc-300 opacity-50 italic">
+              <div className="whitespace-pre-wrap">{msg.content}</div>
             </div>
           ) : (
             <div className="pl-2 text-zinc-300">


### PR DESCRIPTION
## Problems Fixed
1. **Cmd/Ctrl+1 hotkey doesn't work** - `newProjectPath` was never initialized with a default value
2. **Desktop sessions not visible in mobile** - Sessions were only created locally, not in Convex

## Solutions
1. **Hardcoded default path** - Set `newProjectPath` to `/Users/christopherdavid/code/openagents` in `useSessionManager` hook
2. **Create Convex sessions** - Added `createClaudeSession` mutation call when creating desktop sessions

## Changes
- Initialize `newProjectPath` with hardcoded default
- Import Convex mutation and API
- Call `createClaudeSession` after successful local session creation
- Desktop sessions now visible to mobile app queries

## Results
- Cmd/Ctrl+1 hotkey works immediately without manual path entry
- Both desktop and mobile can see all sessions regardless of where they were created
- Messages AND sessions are properly synced through Convex

## Note
The hardcoded path is a temporary fix. A more robust solution would be to restore the `get_project_directory` initialization that was removed during refactoring.

Fixes #1191