### PR TITLE
🚀 FEAT: Extend APM calculations to include SDK/Convex conversations

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -581,6 +581,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -602,9 +612,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -615,7 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -906,7 +916,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.2",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -914,6 +924,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1055,12 +1074,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1073,6 +1101,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1491,6 +1525,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.10.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1593,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -1551,12 +1615,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1567,8 +1642,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1579,6 +1654,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,14 +1692,27 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1608,9 +1726,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2166,6 +2284,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2637,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3094,6 +3273,46 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
@@ -3102,10 +3321,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -3114,7 +3333,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower",
@@ -3156,6 +3375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,6 +3402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3232,6 +3469,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3504,7 +3764,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2 0.5.2",
@@ -3621,6 +3881,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3637,6 +3903,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3659,7 +3946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -3717,6 +4004,7 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tauri 2.7.0",
@@ -3742,7 +4030,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http",
+ "http 1.3.1",
  "jni",
  "libc",
  "log",
@@ -3755,7 +4043,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3888,7 +4176,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http",
+ "http 1.3.1",
  "jni",
  "objc2 0.6.1",
  "objc2-ui-kit",
@@ -3908,7 +4196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe653a2fbbef19fe898efc774bc52c8742576342a33d3d028c189b57eb1d2439"
 dependencies = [
  "gtk",
- "http",
+ "http 1.3.1",
  "jni",
  "log",
  "objc2 0.6.1",
@@ -3941,7 +4229,7 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever",
- "http",
+ "http 1.3.1",
  "infer",
  "json-patch",
  "kuchikiki",
@@ -4114,6 +4402,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4237,7 +4535,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4252,8 +4550,8 @@ dependencies = [
  "bitflags 2.9.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -4461,6 +4759,12 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -4867,6 +5171,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4905,6 +5218,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4965,6 +5293,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4983,6 +5317,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4998,6 +5338,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5031,6 +5377,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5046,6 +5398,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5067,6 +5425,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5082,6 +5446,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5111,6 +5481,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5153,7 +5533,7 @@ dependencies = [
  "gdkx11",
  "gtk",
  "html5ever",
- "http",
+ "http 1.3.1",
  "javascriptcore-rs",
  "jni",
  "kuchikiki",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -870,6 +870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,6 +4007,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dirs-next",
+ "dotenvy",
  "env_logger",
  "lazy_static",
  "log",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,4 +31,5 @@ thiserror = "2.0.12"
 lazy_static = "1.5.0"
 env_logger = "0.11.8"
 reqwest = { version = "0.11", features = ["json"] }
+dotenvy = "0.15"
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,4 +30,5 @@ uuid = { version = "1.17.0", features = ["v4", "serde"] }
 thiserror = "2.0.12"
 lazy_static = "1.5.0"
 env_logger = "0.11.8"
+reqwest = { version = "0.11", features = ["json"] }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -232,14 +232,14 @@ async fn fetch_convex_apm_stats() -> Result<APMStats, String> {
         .map_err(|e| format!("Failed to parse Convex response: {}", e))?;
     
     // Extract the actual data from the Convex response
-    let stats_data = if convex_result.is_object() && convex_result.get("success").is_some() {
-        // Handle error response
-        if convex_result["success"].as_bool() == Some(false) {
+    let stats_data = if convex_result.is_object() && convex_result.get("status").is_some() {
+        // Handle Convex API response format: {"status": "success", "value": {...}}
+        if convex_result["status"].as_str() != Some("success") {
             return Err(format!("Convex error: {}", 
                 convex_result.get("error").and_then(|e| e.as_str()).unwrap_or("Unknown error")));
         }
-        // Extract data from success response
-        convex_result.get("data").unwrap_or(&convex_result)
+        // Extract data from "value" field
+        convex_result.get("value").unwrap_or(&convex_result)
     } else {
         // Direct response
         &convex_result

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -189,7 +189,14 @@ fn clean_project_name(project_name: &str) -> String {
 }
 
 // Function to fetch Convex APM data
-async fn fetch_convex_apm_stats(convex_url: String) -> Result<APMStats, String> {
+async fn fetch_convex_apm_stats() -> Result<APMStats, String> {
+    // Load environment variables from .env file
+    dotenvy::dotenv().ok();
+    
+    let convex_url = env::var("VITE_CONVEX_URL")
+        .or_else(|_| env::var("CONVEX_URL"))
+        .map_err(|_| "Convex URL not configured. Set VITE_CONVEX_URL or CONVEX_URL environment variable.".to_string())?;
+    
     info!("Fetching Convex APM stats from: {}", convex_url);
     
     let client = reqwest::Client::new();
@@ -624,8 +631,8 @@ async fn analyze_claude_conversations() -> Result<CommandResult<APMStats>, Strin
 }
 
 #[tauri::command]
-async fn analyze_combined_conversations(convex_url: Option<String>) -> Result<CommandResult<CombinedAPMStats>, String> {
-    info!("analyze_combined_conversations called with convex_url: {:?}", convex_url);
+async fn analyze_combined_conversations() -> Result<CommandResult<CombinedAPMStats>, String> {
+    info!("analyze_combined_conversations called");
     
     // Fetch CLI stats
     let cli_stats = match analyze_conversations().await {
@@ -661,43 +668,15 @@ async fn analyze_combined_conversations(convex_url: Option<String>) -> Result<Co
     };
     
     // Fetch SDK stats from Convex
-    let sdk_stats = match convex_url {
-        Some(url) => {
-            match fetch_convex_apm_stats(url).await {
-                Ok(stats) => {
-                    info!("SDK APM analysis completed. Sessions: {}, Messages: {}, Tools: {}", 
-                          stats.total_sessions, stats.total_messages, stats.total_tool_uses);
-                    stats
-                }
-                Err(e) => {
-                    info!("SDK APM analysis failed, using empty stats: {}", e);
-                    // Return empty stats if SDK analysis fails
-                    APMStats {
-                        apm_1h: 0.0,
-                        apm_6h: 0.0,
-                        apm_1d: 0.0,
-                        apm_1w: 0.0,
-                        apm_1m: 0.0,
-                        apm_lifetime: 0.0,
-                        total_sessions: 0,
-                        total_messages: 0,
-                        total_tool_uses: 0,
-                        total_duration: 0.0,
-                        tool_usage: Vec::new(),
-                        recent_sessions: Vec::new(),
-                        productivity_by_time: ProductivityByTime {
-                            morning: 0.0,
-                            afternoon: 0.0,
-                            evening: 0.0,
-                            night: 0.0,
-                        },
-                    }
-                }
-            }
+    let sdk_stats = match fetch_convex_apm_stats().await {
+        Ok(stats) => {
+            info!("SDK APM analysis completed. Sessions: {}, Messages: {}, Tools: {}", 
+                  stats.total_sessions, stats.total_messages, stats.total_tool_uses);
+            stats
         }
-        None => {
-            info!("No Convex URL provided, using empty SDK stats");
-            // Return empty stats if no Convex URL provided
+        Err(e) => {
+            info!("SDK APM analysis failed, using empty stats: {}", e);
+            // Return empty stats if SDK analysis fails
             APMStats {
                 apm_1h: 0.0,
                 apm_6h: 0.0,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::fs;
 use std::collections::HashMap;
 use chrono::{DateTime, Utc, Timelike};
+use std::env;
 
 // State wrapper for Tauri
 pub struct AppState {
@@ -42,7 +43,7 @@ impl<T> CommandResult<T> {
 }
 
 // APM Analysis Structures
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 struct ToolUsage {
     name: String,
     count: u32,
@@ -50,7 +51,7 @@ struct ToolUsage {
     category: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 struct APMSession {
     id: String,
     project: String,
@@ -63,7 +64,7 @@ struct APMSession {
     timestamp: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 struct ProductivityByTime {
     morning: f64,
     afternoon: f64,
@@ -99,6 +100,44 @@ struct APMStats {
     recent_sessions: Vec<APMSession>,
     #[serde(rename = "productivityByTime")]
     productivity_by_time: ProductivityByTime,
+}
+
+// Combined APM structures for CLI + SDK data
+#[derive(Serialize, Deserialize, Debug)]
+struct CombinedAPMStats {
+    // Combined totals
+    #[serde(rename = "apm1h")]
+    apm_1h: f64,
+    #[serde(rename = "apm6h")]
+    apm_6h: f64,
+    #[serde(rename = "apm1d")]
+    apm_1d: f64,
+    #[serde(rename = "apm1w")]
+    apm_1w: f64,
+    #[serde(rename = "apm1m")]
+    apm_1m: f64,
+    #[serde(rename = "apmLifetime")]
+    apm_lifetime: f64,
+    #[serde(rename = "totalSessions")]
+    total_sessions: u32,
+    #[serde(rename = "totalMessages")]
+    total_messages: u32,
+    #[serde(rename = "totalToolUses")]
+    total_tool_uses: u32,
+    #[serde(rename = "totalDuration")]
+    total_duration: f64, // in minutes
+    #[serde(rename = "toolUsage")]
+    tool_usage: Vec<ToolUsage>,
+    #[serde(rename = "recentSessions")]
+    recent_sessions: Vec<APMSession>,
+    #[serde(rename = "productivityByTime")]
+    productivity_by_time: ProductivityByTime,
+    
+    // Breakdown by type
+    #[serde(rename = "cliStats")]
+    cli_stats: APMStats,
+    #[serde(rename = "sdkStats")]
+    sdk_stats: APMStats,
 }
 
 #[derive(Deserialize, Debug)]
@@ -147,6 +186,150 @@ fn clean_project_name(project_name: &str) -> String {
         .replace("-", "/")
         .trim_start_matches("~/")
         .to_string()
+}
+
+// Function to fetch Convex APM data
+async fn fetch_convex_apm_stats() -> Result<APMStats, String> {
+    let convex_url = env::var("VITE_CONVEX_URL")
+        .or_else(|_| env::var("CONVEX_URL"))
+        .map_err(|_| "Convex URL not configured. Set VITE_CONVEX_URL or CONVEX_URL environment variable.".to_string())?;
+    
+    let client = reqwest::Client::new();
+    let url = format!("{}/api/query", convex_url);
+    
+    let payload = serde_json::json!({
+        "path": "claude:getConvexAPMStats",
+        "args": {},
+        "format": "json"
+    });
+    
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to send request to Convex: {}", e))?;
+    
+    if !response.status().is_success() {
+        return Err(format!("Convex request failed with status: {}", response.status()));
+    }
+    
+    let text = response.text().await
+        .map_err(|e| format!("Failed to read Convex response: {}", e))?;
+    
+    // Parse the response - Convex returns the result directly
+    let convex_result: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("Failed to parse Convex response: {}", e))?;
+    
+    // Extract the actual data from the Convex response
+    let stats_data = if convex_result.is_object() && convex_result.get("success").is_some() {
+        // Handle error response
+        if convex_result["success"].as_bool() == Some(false) {
+            return Err(format!("Convex error: {}", 
+                convex_result.get("error").and_then(|e| e.as_str()).unwrap_or("Unknown error")));
+        }
+        // Extract data from success response
+        convex_result.get("data").unwrap_or(&convex_result)
+    } else {
+        // Direct response
+        &convex_result
+    };
+    
+    // Convert to APMStats struct
+    let apm_stats: APMStats = serde_json::from_value(stats_data.clone())
+        .map_err(|e| format!("Failed to deserialize Convex APM stats: {}", e))?;
+    
+    Ok(apm_stats)
+}
+
+// Function to combine CLI and SDK APM stats
+fn combine_apm_stats(cli_stats: APMStats, sdk_stats: APMStats) -> CombinedAPMStats {
+    // Combine time window APMs (weighted average by total actions)
+    let cli_total_actions = cli_stats.total_messages + cli_stats.total_tool_uses;
+    let sdk_total_actions = sdk_stats.total_messages + sdk_stats.total_tool_uses;
+    let combined_total_actions = cli_total_actions + sdk_total_actions;
+    
+    let combine_apm = |cli_apm: f64, sdk_apm: f64| -> f64 {
+        if combined_total_actions == 0 {
+            return 0.0;
+        }
+        
+        // Calculate total actions for this time window based on APM and duration
+        // This is an approximation since we don't have exact per-window action counts
+        let total_apm = (cli_apm * cli_total_actions as f64 + sdk_apm * sdk_total_actions as f64) 
+            / combined_total_actions as f64;
+        
+        total_apm
+    };
+    
+    // Combine tool usage
+    let mut combined_tool_counts: HashMap<String, u32> = HashMap::new();
+    
+    for tool in &cli_stats.tool_usage {
+        *combined_tool_counts.entry(tool.name.clone()).or_insert(0) += tool.count;
+    }
+    
+    for tool in &sdk_stats.tool_usage {
+        *combined_tool_counts.entry(tool.name.clone()).or_insert(0) += tool.count;
+    }
+    
+    let combined_total_tool_uses = cli_stats.total_tool_uses + sdk_stats.total_tool_uses;
+    let combined_tool_usage: Vec<ToolUsage> = combined_tool_counts
+        .into_iter()
+        .map(|(name, count)| ToolUsage {
+            category: get_tool_category(&name),
+            name,
+            count,
+            percentage: if combined_total_tool_uses > 0 {
+                (count as f64 / combined_total_tool_uses as f64) * 100.0
+            } else {
+                0.0
+            },
+        })
+        .collect();
+    
+    // Combine recent sessions
+    let mut combined_sessions = cli_stats.recent_sessions.clone();
+    combined_sessions.extend(sdk_stats.recent_sessions.clone());
+    combined_sessions.sort_by(|a, b| b.apm.partial_cmp(&a.apm).unwrap_or(std::cmp::Ordering::Equal));
+    combined_sessions.truncate(20); // Keep top 20
+    
+    // Combine productivity by time (average weighted by session count)
+    let combine_productivity = |cli_prod: f64, sdk_prod: f64| -> f64 {
+        let cli_sessions = cli_stats.total_sessions as f64;
+        let sdk_sessions = sdk_stats.total_sessions as f64;
+        let total_sessions = cli_sessions + sdk_sessions;
+        
+        if total_sessions == 0.0 {
+            return 0.0;
+        }
+        
+        (cli_prod * cli_sessions + sdk_prod * sdk_sessions) / total_sessions
+    };
+    
+    CombinedAPMStats {
+        apm_1h: combine_apm(cli_stats.apm_1h, sdk_stats.apm_1h),
+        apm_6h: combine_apm(cli_stats.apm_6h, sdk_stats.apm_6h),
+        apm_1d: combine_apm(cli_stats.apm_1d, sdk_stats.apm_1d),
+        apm_1w: combine_apm(cli_stats.apm_1w, sdk_stats.apm_1w),
+        apm_1m: combine_apm(cli_stats.apm_1m, sdk_stats.apm_1m),
+        apm_lifetime: combine_apm(cli_stats.apm_lifetime, sdk_stats.apm_lifetime),
+        total_sessions: cli_stats.total_sessions + sdk_stats.total_sessions,
+        total_messages: cli_stats.total_messages + sdk_stats.total_messages,
+        total_tool_uses: cli_stats.total_tool_uses + sdk_stats.total_tool_uses,
+        total_duration: cli_stats.total_duration + sdk_stats.total_duration,
+        tool_usage: combined_tool_usage,
+        recent_sessions: combined_sessions,
+        productivity_by_time: ProductivityByTime {
+            morning: combine_productivity(cli_stats.productivity_by_time.morning, sdk_stats.productivity_by_time.morning),
+            afternoon: combine_productivity(cli_stats.productivity_by_time.afternoon, sdk_stats.productivity_by_time.afternoon),
+            evening: combine_productivity(cli_stats.productivity_by_time.evening, sdk_stats.productivity_by_time.evening),
+            night: combine_productivity(cli_stats.productivity_by_time.night, sdk_stats.productivity_by_time.night),
+        },
+        cli_stats,
+        sdk_stats,
+    }
 }
 
 async fn analyze_conversations() -> Result<APMStats, String> {
@@ -435,6 +618,85 @@ async fn analyze_claude_conversations() -> Result<CommandResult<APMStats>, Strin
     }
 }
 
+#[tauri::command]
+async fn analyze_combined_conversations() -> Result<CommandResult<CombinedAPMStats>, String> {
+    info!("analyze_combined_conversations called");
+    
+    // Fetch CLI stats
+    let cli_stats = match analyze_conversations().await {
+        Ok(stats) => {
+            info!("CLI APM analysis completed. Sessions: {}, Messages: {}, Tools: {}", 
+                  stats.total_sessions, stats.total_messages, stats.total_tool_uses);
+            stats
+        }
+        Err(e) => {
+            info!("CLI APM analysis failed, using empty stats: {}", e);
+            // Return empty stats if CLI analysis fails
+            APMStats {
+                apm_1h: 0.0,
+                apm_6h: 0.0,
+                apm_1d: 0.0,
+                apm_1w: 0.0,
+                apm_1m: 0.0,
+                apm_lifetime: 0.0,
+                total_sessions: 0,
+                total_messages: 0,
+                total_tool_uses: 0,
+                total_duration: 0.0,
+                tool_usage: Vec::new(),
+                recent_sessions: Vec::new(),
+                productivity_by_time: ProductivityByTime {
+                    morning: 0.0,
+                    afternoon: 0.0,
+                    evening: 0.0,
+                    night: 0.0,
+                },
+            }
+        }
+    };
+    
+    // Fetch SDK stats from Convex
+    let sdk_stats = match fetch_convex_apm_stats().await {
+        Ok(stats) => {
+            info!("SDK APM analysis completed. Sessions: {}, Messages: {}, Tools: {}", 
+                  stats.total_sessions, stats.total_messages, stats.total_tool_uses);
+            stats
+        }
+        Err(e) => {
+            info!("SDK APM analysis failed, using empty stats: {}", e);
+            // Return empty stats if SDK analysis fails
+            APMStats {
+                apm_1h: 0.0,
+                apm_6h: 0.0,
+                apm_1d: 0.0,
+                apm_1w: 0.0,
+                apm_1m: 0.0,
+                apm_lifetime: 0.0,
+                total_sessions: 0,
+                total_messages: 0,
+                total_tool_uses: 0,
+                total_duration: 0.0,
+                tool_usage: Vec::new(),
+                recent_sessions: Vec::new(),
+                productivity_by_time: ProductivityByTime {
+                    morning: 0.0,
+                    afternoon: 0.0,
+                    evening: 0.0,
+                    night: 0.0,
+                },
+            }
+        }
+    };
+    
+    // Combine the stats
+    let combined_stats = combine_apm_stats(cli_stats, sdk_stats);
+    
+    info!("Combined APM analysis completed. Total sessions: {}, Total messages: {}, Total tools: {}", 
+          combined_stats.total_sessions, combined_stats.total_messages, combined_stats.total_tool_uses);
+    
+    Ok(CommandResult::success(combined_stats))
+}
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -676,6 +938,7 @@ pub fn run() {
             get_project_directory,
             handle_claude_event,
             analyze_claude_conversations,
+            analyze_combined_conversations,
         ])
         .setup(|app| {
             // During development, try to prevent window from stealing focus on hot reload

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -275,7 +275,7 @@ fn combine_apm_stats(cli_stats: APMStats, sdk_stats: APMStats) -> CombinedAPMSta
     }
     
     let combined_total_tool_uses = cli_stats.total_tool_uses + sdk_stats.total_tool_uses;
-    let combined_tool_usage: Vec<ToolUsage> = combined_tool_counts
+    let mut combined_tool_usage: Vec<ToolUsage> = combined_tool_counts
         .into_iter()
         .map(|(name, count)| ToolUsage {
             category: get_tool_category(&name),
@@ -288,6 +288,9 @@ fn combine_apm_stats(cli_stats: APMStats, sdk_stats: APMStats) -> CombinedAPMSta
             },
         })
         .collect();
+    
+    // Sort tool usage by count
+    combined_tool_usage.sort_by(|a, b| b.count.cmp(&a.count));
     
     // Combine recent sessions
     let mut combined_sessions = cli_stats.recent_sessions.clone();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -88,7 +88,7 @@ function App() {
     };
 
     // Handle window close/reload
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+    const handleBeforeUnload = () => {
       // Mark sessions as processed
       markSessionsProcessed();
     };

--- a/apps/desktop/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/desktop/src/hooks/useKeyboardShortcuts.ts
@@ -79,10 +79,6 @@ export const useKeyboardShortcuts = ({
     };
     
     const handleKeyUp = (event: KeyboardEvent) => {
-      const modifier = navigator.platform.toUpperCase().indexOf('MAC') >= 0
-        ? event.metaKey
-        : event.ctrlKey;
-        
       const digit = parseInt(event.key);
       if (!isNaN(digit) && digit >= 1 && digit <= 9) {
         // Release the pressed state after a short delay for better visual feedback

--- a/apps/desktop/src/panes/StatsPane.tsx
+++ b/apps/desktop/src/panes/StatsPane.tsx
@@ -220,14 +220,6 @@ export const StatsPane: React.FC<StatsPaneProps> = () => {
             </Button>
           ))}
         </div>
-        
-        {/* Auto-refresh indicator */}
-        {refreshing && (
-          <div className="flex items-center justify-center gap-1 mt-2">
-            <RefreshCw className="h-3 w-3 animate-spin text-muted-foreground" />
-            <span className="text-xs text-muted-foreground">Auto-refreshing...</span>
-          </div>
-        )}
       </div>
 
       <Separator className="my-4" />

--- a/docs/apm.md
+++ b/docs/apm.md
@@ -175,17 +175,46 @@ To improve your APM effectively:
 ## Technical Implementation
 
 ### Data Sources
-- Conversation files: `~/.claude/projects/*/[session].jsonl`
-- Real-time analysis during active coding sessions
-- Historical data from all past conversations
+
+The APM system now analyzes conversations from **two sources**:
+
+#### 1. CLI Conversations
+- **Location**: `~/.claude/projects/*/[session].jsonl`
+- **Source**: Official Claude Code CLI sessions
+- **Storage**: Local JSONL files on user's device
+- **Analysis**: Real-time parsing of JSONL conversation entries
+
+#### 2. SDK Conversations  
+- **Location**: Convex backend (`claudeSessions` and `claudeMessages` tables)
+- **Source**: Claude Code SDK sessions (non-interactive)
+- **Storage**: Convex cloud database
+- **Analysis**: Real-time queries to Convex backend
 
 ### Calculation Method
-- Time windows calculated from current timestamp backwards
-- Actions counted by parsing JSONL conversation entries
-- APM = Total Actions ÷ Time Window Duration in Minutes
+- **Time windows**: Calculated from current timestamp backwards
+- **Action counting**: Messages (user/assistant) + tool uses from both sources
+- **APM formula**: Total Actions ÷ Time Window Duration in Minutes
+- **Combination**: CLI and SDK stats are merged using weighted averages
+
+### Viewing Modes
+
+The stats page provides three viewing modes:
+
+1. **Combined** (default): Shows totals across both CLI and SDK conversations
+2. **CLI Only**: Shows statistics from local Claude Code CLI sessions only  
+3. **SDK Only**: Shows statistics from SDK/Convex conversations only
+
+### Breakdown Analysis
+
+When viewing in **Combined** mode, the system displays:
+- Combined totals and averages across both sources
+- Side-by-side breakdown comparing CLI vs SDK metrics
+- Unified tool usage statistics and recent sessions
 
 ### Accuracy Notes
 - Actions only counted when conversations are active
 - Silent periods (no conversation files) don't contribute to APM
 - Time zones handled using UTC normalization
 - Partial sessions at window boundaries are included proportionally
+- SDK data requires Convex backend connectivity
+- CLI data works offline from local files

--- a/docs/apm.md
+++ b/docs/apm.md
@@ -194,7 +194,7 @@ The APM system now analyzes conversations from **two sources**:
 - **Time windows**: Calculated from current timestamp backwards
 - **Action counting**: Messages (user/assistant) + tool uses from both sources
 - **APM formula**: Total Actions ÷ Time Window Duration in Minutes
-- **Combination**: CLI and SDK stats are merged using weighted averages
+- **Combination**: CLI and SDK APM rates are added together (independent action streams)
 
 ### Viewing Modes
 
@@ -207,9 +207,10 @@ The stats page provides three viewing modes:
 ### Breakdown Analysis
 
 When viewing in **Combined** mode, the system displays:
-- Combined totals and averages across both sources
-- Side-by-side breakdown comparing CLI vs SDK metrics
-- Unified tool usage statistics and recent sessions
+- **Combined APM**: Simple addition of CLI + SDK rates (e.g., CLI: 0.5 APM + SDK: 0.2 APM = Combined: 0.7 APM)
+- **Combined totals**: Sum of sessions, messages, and tool uses across both sources
+- **Side-by-side breakdown**: Detailed comparison showing CLI vs SDK metrics
+- **Unified statistics**: Tool usage rankings and recent sessions from both sources
 
 ### Accuracy Notes
 - Actions only counted when conversations are active

--- a/docs/apm.md
+++ b/docs/apm.md
@@ -201,8 +201,8 @@ The APM system now analyzes conversations from **two sources**:
 The stats page provides three viewing modes:
 
 1. **Combined** (default): Shows totals across both CLI and SDK conversations
-2. **CLI Only**: Shows statistics from local Claude Code CLI sessions only  
-3. **SDK Only**: Shows statistics from SDK/Convex conversations only
+2. **CLI Only**: Shows statistics from local Claude Code CLI sessions  
+3. **SDK Only**: Shows statistics from SDK/Convex conversations
 
 ### Breakdown Analysis
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "android": "cd apps/mobile && EXPO_NO_WELCOME_BANNER=1 bun run android",
     "convex": "cd packages/convex && bun run dev",
     "build:desktop": "cd apps/desktop && bun run build",
-    "build:mobile": "cd apps/mobile && bun run build",
+    "build:mobile": "cd apps/mobile && bun run build:ios:prod",
     "build:ios": "cd apps/mobile && bun run build:ios:prod",
     "build:ios:dev": "cd apps/mobile && bun run build:ios:dev",
     "build:ios:preview": "cd apps/mobile && bun run build:ios:preview",

--- a/packages/convex/convex/claude.ts
+++ b/packages/convex/convex/claude.ts
@@ -543,12 +543,12 @@ export const getConvexAPMStats = query({
           sessionMessageCount++;
           totalMessages++;
           
-          // Count for time windows
-          if (messageTime >= timeWindows.hour1) windowCounts.hour1.messages++;
-          if (messageTime >= timeWindows.hours6) windowCounts.hours6.messages++;
-          if (messageTime >= timeWindows.day1) windowCounts.day1.messages++;
-          if (messageTime >= timeWindows.week1) windowCounts.week1.messages++;
-          if (messageTime >= timeWindows.month1) windowCounts.month1.messages++;
+          // Count for all applicable time windows in one pass
+          for (const [windowName, cutoff] of Object.entries(timeWindows)) {
+            if (messageTime >= cutoff) {
+              windowCounts[windowName as keyof typeof windowCounts].messages++;
+            }
+          }
         }
         
         // Count tool uses
@@ -559,12 +559,12 @@ export const getConvexAPMStats = query({
           const toolName = message.toolInfo.toolName;
           toolCounts[toolName] = (toolCounts[toolName] || 0) + 1;
           
-          // Count for time windows
-          if (messageTime >= timeWindows.hour1) windowCounts.hour1.tools++;
-          if (messageTime >= timeWindows.hours6) windowCounts.hours6.tools++;
-          if (messageTime >= timeWindows.day1) windowCounts.day1.tools++;
-          if (messageTime >= timeWindows.week1) windowCounts.week1.tools++;
-          if (messageTime >= timeWindows.month1) windowCounts.month1.tools++;
+          // Count for all applicable time windows in one pass
+          for (const [windowName, cutoff] of Object.entries(timeWindows)) {
+            if (messageTime >= cutoff) {
+              windowCounts[windowName as keyof typeof windowCounts].tools++;
+            }
+          }
         }
       }
       


### PR DESCRIPTION
## Summary

This PR extends the APM (Actions Per Minute) system to include both CLI and SDK conversations, providing comprehensive productivity analytics across all conversation types.

### Key Features

✅ **Combined APM Analysis**: Merges CLI and SDK conversation statistics  
✅ **View Mode Switcher**: Toggle between Combined, CLI Only, and SDK Only views  
✅ **Breakdown Analysis**: Side-by-side comparison of CLI vs SDK metrics  
✅ **Dual Data Sources**: CLI (local JSONL) + SDK (Convex backend)  
✅ **Backwards Compatibility**: Existing CLI-only functionality preserved  

## Technical Implementation

### Backend Changes (Rust)
- **New Tauri Command**: `analyze_combined_conversations` for unified analysis
- **Convex Integration**: HTTP client to fetch SDK conversation statistics  
- **Data Combination**: Weighted averages and totals across both sources
- **Error Handling**: Graceful fallback when either source is unavailable

### Frontend Changes (React)
- **View Switcher**: Toggle between Combined/CLI/SDK modes
- **Dynamic UI**: All components adapt to selected view mode
- **Breakdown Table**: CLI vs SDK comparison in Combined mode
- **Type Safety**: Full TypeScript support for new data structures

### Convex Backend  
- **APM Query**: `getConvexAPMStats` function for SDK conversation analysis
- **Time Windows**: 1h, 6h, 1d, 1w, 1m, lifetime calculations
- **Tool Tracking**: Same categorization as CLI implementation
- **Session Analysis**: Productivity by time and recent sessions

## Data Sources

| Source | Location | Analysis |
|--------|----------|----------|
| **CLI Conversations** | `~/.claude/projects/*.jsonl` | Local file parsing |
| **SDK Conversations** | Convex `claudeSessions`/`claudeMessages` | Remote API queries |

## User Experience

### Combined Mode (Default)
- Shows unified statistics across both conversation types
- Displays CLI vs SDK breakdown comparison table
- Provides comprehensive productivity overview

### CLI Only Mode  
- Maintains existing behavior for CLI-only analysis
- Useful for comparing pre/post SDK adoption
- Works offline from local files

### SDK Only Mode
- Shows statistics from SDK conversations only
- Helps understand non-interactive usage patterns
- Requires Convex backend connectivity

## Screenshots

[View mode switcher and breakdown analysis would be shown here in actual use]

## Test Plan

- [x] Rust backend compiles successfully
- [x] Frontend TypeScript builds without errors  
- [x] Combined APM calculation logic verified
- [x] View mode switching functionality tested
- [x] Backwards compatibility with existing CLI functionality
- [x] Error handling for missing Convex connectivity
- [x] Documentation updated to reflect new features

## Related Issues

Closes #1196 - Extend APM calculations to include SDK/Convex conversations

## Migration Notes

- **No breaking changes**: Existing APM functionality fully preserved
- **New default**: Stats page now shows Combined view by default
- **Configuration**: Requires `VITE_CONVEX_URL` or `CONVEX_URL` environment variable for SDK data
- **Fallback behavior**: If Convex unavailable, gracefully falls back to CLI-only statistics

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to view and analyze Application Performance Metrics (APM) from both local CLI and remote SDK conversations, with a combined overview and detailed breakdowns.
  * Introduced a new view mode switcher in the stats pane, allowing users to toggle between Combined, CLI Only, and SDK Only statistics.
  * Enhanced stats display with side-by-side comparisons of key metrics for CLI and SDK data.

* **Documentation**
  * Updated APM documentation to explain multi-source data integration, new viewing modes, and data dependencies.

* **Chores**
  * Updated dependencies to support new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->