### PR TITLE
fix(mobile): Make chat messages start at bottom instead of top

### DIFF
--- a/apps/mobile/components/ClaudeCodeMobile.tsx
+++ b/apps/mobile/components/ClaudeCodeMobile.tsx
@@ -342,6 +342,7 @@ export function ClaudeCodeMobile() {
           renderItem={renderMessageItem}
           style={styles.messagesList}
           showsVerticalScrollIndicator={false}
+          inverted
           ListEmptyComponent={
             <View style={styles.emptyState}>
               <CustomText style={styles.emptyStateText}>No messages yet</CustomText>


### PR DESCRIPTION
Fixes #1222

## Summary
- Added `inverted` prop to FlatList in ClaudeCodeMobile.tsx
- Chat messages now appear with newest at bottom (standard chat UX)
- Users no longer need to scroll down to see recent messages

## Technical Details
- Used React Native's built-in `inverted` prop for FlatList
- Minimal change (1 line addition) following React Native best practices
- No breaking changes to existing functionality

## Test plan
- [ ] Test mobile app with existing chat sessions
- [ ] Verify messages appear from bottom up
- [ ] Confirm new messages appear at bottom of visible area
- [ ] Check that scrolling behavior feels natural

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the message list to display the most recent messages at the bottom, allowing users to scroll upwards through previous messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->