### PR TITLE
fix: Integrate desktop app authentication with Convex queries

### DIFF
--- a/apps/desktop/src/components/providers/ConvexProviderWithAuth.tsx
+++ b/apps/desktop/src/components/providers/ConvexProviderWithAuth.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, ReactNode, useMemo } from 'react';
+import { ConvexProvider, ConvexReactClient } from 'convex/react';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface ConvexProviderWithAuthProps {
+  children: ReactNode;
+}
+
+export const ConvexProviderWithAuth: React.FC<ConvexProviderWithAuthProps> = ({ children }) => {
+  const { token, isAuthenticated } = useAuth();
+
+  // Create Convex client once and reuse it
+  const convex = useMemo(() => {
+    const convexUrl = import.meta.env.VITE_CONVEX_URL;
+    if (!convexUrl) {
+      console.error('❌ [CONVEX] VITE_CONVEX_URL not configured');
+      return null;
+    }
+
+    console.log('🔧 [CONVEX] Creating ConvexReactClient for desktop');
+    return new ConvexReactClient(convexUrl, {
+      unsavedChangesWarning: false,
+    });
+  }, []);
+
+  // Update authentication when token changes
+  useEffect(() => {
+    if (!convex) return;
+
+    if (isAuthenticated && token) {
+      console.log('🔑 [CONVEX] Setting authentication token for desktop');
+      console.log('🔍 [CONVEX] Token preview:', token.substring(0, 50) + '...');
+      
+      // Decode JWT to check its contents (for debugging)
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1]));
+        console.log('🔍 [CONVEX] JWT payload:', {
+          iss: payload.iss,
+          aud: payload.aud,
+          sub: payload.sub,
+          exp: payload.exp,
+          iat: payload.iat
+        });
+        
+        // Check if JWT has required fields
+        if (!payload.iat) {
+          console.warn('⚠️ [CONVEX] JWT missing iat field - this may cause auth issues');
+        }
+      } catch (e) {
+        console.error('❌ [CONVEX] Failed to decode JWT:', e);
+      }
+      
+      // Clear any existing auth first, then set new auth
+      convex.clearAuth();
+      
+      // Add small delay to ensure clearAuth completes
+      setTimeout(() => {
+        console.log('🔑 [CONVEX] Setting new authentication for desktop');
+        convex.setAuth(async () => {
+          console.log('🔑 [CONVEX] Auth function called, returning token');
+          return token;
+        });
+      }, 100);
+    } else {
+      console.log('🔓 [CONVEX] Clearing authentication for desktop');
+      convex.clearAuth();
+    }
+  }, [convex, token, isAuthenticated]);
+
+  // Show loading state while Convex client is being initialized
+  if (!convex) {
+    return null;
+  }
+
+  return (
+    <ConvexProvider client={convex}>
+      {children}
+    </ConvexProvider>
+  );
+};

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,21 +1,13 @@
 import "./index.css"
 import ReactDOM from "react-dom/client"
 import App from "./App"
-import { ConvexReactClient } from "convex/react"
-import { ConvexProvider } from "@/components/providers/React19ConvexProvider"
 import { AuthProvider } from "@/contexts/AuthContext"
-
-
-const convexUrl = import.meta.env.VITE_CONVEX_URL;
-if (!convexUrl) {
-  throw new Error("VITE_CONVEX_URL environment variable is required");
-}
-const convex = new ConvexReactClient(convexUrl);
+import { ConvexProviderWithAuth } from "@/components/providers/ConvexProviderWithAuth"
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <AuthProvider>
-    <ConvexProvider client={convex}>
+    <ConvexProviderWithAuth>
       <App />
-    </ConvexProvider>
+    </ConvexProviderWithAuth>
   </AuthProvider>,
 );


### PR DESCRIPTION
## Problem
Desktop app was experiencing authentication errors when trying to load session messages:
- ❌ `confect/mobile_sync:getSessionMessages` fails with **"Not authenticated"**
- ✅ `confect/mobile_sync:getPendingMobileSessions` works fine  
- 🔥 Blocks mobile-desktop session sync functionality

## Root Cause Analysis
**Desktop App** (❌ Broken):
- ConvexProvider not configured with authentication
- No `setAuth()` call to provide tokens to Convex queries
- Auth context exists but not integrated with Convex

**Mobile App** (✅ Working):  
- Uses `ConvexProviderWithAuth` with proper token handling
- JWT tokens properly passed to Convex queries
- Authentication fully integrated

## Solution
✅ **Created `ConvexProviderWithAuth`** for desktop matching mobile pattern  
✅ **Integrated AuthContext** with Convex client authentication  
✅ **Updated main.tsx** to use auth-integrated ConvexProvider  
✅ **Added JWT debugging** with proper token handling  

## Files Changed
- 🆕 `apps/desktop/src/components/providers/ConvexProviderWithAuth.tsx`  
- ✏️ `apps/desktop/src/main.tsx`

## Key Features
- **Token Management**: Automatically sets/clears Convex auth based on login state
- **JWT Debugging**: Logs token payload for troubleshooting  
- **Error Handling**: Proper auth state cleanup on logout
- **Parity**: Desktop auth now matches mobile app architecture

## Testing Results
- ✅ Desktop build successful
- ✅ TypeScript compilation passes  
- ✅ Convex TypeScript check passes

## Expected Impact
- 🔥 **Fixes "Not authenticated" errors** in desktop app
- 📱 **Enables mobile-desktop sync** for session messages  
- 🔒 **Proper authentication flow** matching mobile app
- 🔧 **Better debugging** with JWT payload logging

Closes #1273

🤖 Generated with [Claude Code](https://claude.ai/code)