### PR TITLE
Fix: clean Chat mode, remove startup summarizer, add server logs; default to main app

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper to run the Tauri dev server's frontend (Trunk) robustly
+# from either repo root or src-tauri/.
+
+if [[ -f ./src-tauri/dev.sh ]]; then
+  exec bash ./src-tauri/dev.sh
+fi
+
+# Fallback (shouldn't happen in this repo): run Trunk directly.
+echo "src-tauri/dev.sh not found; running plain 'trunk serve'" >&2
+exec trunk serve
+

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
+default-run = "openagents"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/dev.sh
+++ b/src-tauri/dev.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple guard to ensure Trunk dev server is available on the expected port.
+# - If port 1420 is already used by a Trunk process, reuse it (do nothing).
+# - If port 1420 is used by a non-Trunk process, try to terminate stale Trunk
+#   instances on that port; if it remains occupied by something else, exit
+#   with a clear message so Tauri fails fast instead of flapping.
+
+PORT="${TRUNK_PORT:-1420}"
+
+is_trunk_pid() {
+  local pid="$1"
+  local cmd
+  cmd=$(ps -p "$pid" -o comm= 2>/dev/null || true)
+  if [[ "${cmd:-}" == *trunk* ]]; then
+    return 0
+  fi
+  # Fallback to args if comm didn't include trunk
+  cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
+  [[ "${cmd:-}" == *trunk* ]]
+}
+
+in_use_pids() {
+  # macOS has lsof by default; use it for a reliable PID list
+  lsof -n -P -i TCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true
+}
+
+PIDS=( $(in_use_pids) )
+if [[ ${#PIDS[@]} -gt 0 ]]; then
+  # If it's already Trunk, reuse it silently
+  reuse=true
+  for p in "${PIDS[@]}"; do
+    if ! is_trunk_pid "$p"; then
+      reuse=false
+      break
+    fi
+  done
+
+  if [[ "$reuse" == true ]]; then
+    echo "Reusing existing Trunk on http://localhost:${PORT}" >&2
+    exit 0
+  fi
+
+  echo "Port ${PORT} is in use by PID(s): ${PIDS[*]} (not Trunk)." >&2
+  echo "If this is a stale dev server, attempting to free the port..." >&2
+
+  # Try to terminate any Trunk processes on that port specifically.
+  for p in "${PIDS[@]}"; do
+    if is_trunk_pid "$p"; then
+      kill -TERM "$p" 2>/dev/null || true
+    fi
+  done
+  # Give it a moment to stop
+  sleep 1
+  PIDS=( $(in_use_pids) )
+  if [[ ${#PIDS[@]} -gt 0 ]]; then
+  echo "Port ${PORT} still in use by PID(s): ${PIDS[*]}." >&2
+  echo "Please stop the process using ${PORT} and retry (Tauri expects ${PORT})." >&2
+    exit 1
+  fi
+fi
+
+exec trunk serve --port "$PORT"

--- a/src-tauri/dev.sh
+++ b/src-tauri/dev.sh
@@ -8,6 +8,16 @@ set -euo pipefail
 #   with a clear message so Tauri fails fast instead of flapping.
 
 PORT="${TRUNK_PORT:-1420}"
+# Always run from repo root so Trunk sees Trunk.toml and index.html
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd -P)"
+cd "$ROOT_DIR"
+
+# Preflight compile once to surface real errors early instead of a silent reuse.
+echo "[dev.sh] Preflight UI build (trunk build)" >&2
+if ! trunk build >/dev/null 2>&1; then
+  echo "[dev.sh] Trunk build failed. Showing verbose error:" >&2
+  trunk build -v || exit 1
+fi
 
 is_trunk_pid() {
   local pid="$1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -837,18 +837,8 @@ async fn list_recent_chats(window: tauri::Window, limit: Option<usize>) -> Resul
         out.push(UiChatSummary { id, path: f.display().to_string(), started_at, title, cwd });
         if out.len() >= limit { break; }
     }
-    // Summarize via existing proto (off-record). If summarization fails, keep current titles.
-    if !raw_titles.is_empty() {
-        if let Ok(summaries) = summarize_titles_via_proto(&window, raw_titles.clone()).await {
-            for (i, (idx, path)) in candidates.iter().enumerate() {
-                if let Some(sum) = summaries.get(i) {
-                    if let Some(item) = out.get_mut(*idx) { item.title = sum.clone(); }
-                    // Persist sidecar for future loads
-                    let _ = write_sidecar_title(path, summaries[i].as_str());
-                }
-            }
-        }
-    }
+    // Avoid triggering model traffic on startup: do not auto-summarize titles here.
+    // Users can invoke explicit summarization via the generate_titles_for_all command.
     Ok(out)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1083,9 +1083,9 @@ async fn submit_chat(window: tauri::Window, prompt: String) -> Result<(), String
         if let Ok(guard) = state_arc2.lock() {
             let id = format!("{}", guard.next_request_id());
             drop(guard);
-            let sub = serde_json::json!({ "id": id, "op": { "type": "get_path" } });
+            let sub = serde_json::json!({ "id": id, "op": { "type": "add_to_history", "text": "debug: ping" } });
             let len = serde_json::to_vec(&sub).map(|mut v| { v.push(b'\n'); v.len() }).unwrap_or(0);
-            let _ = win3.emit("codex:stream", &UiStreamEvent::SystemNote { text: format!("Debug: sending get_path ({} bytes)", len) });
+            let _ = win3.emit("codex:stream", &UiStreamEvent::SystemNote { text: format!("Debug: sending add_to_history ({} bytes)", len) });
             if let Ok(guard2) = state_arc2.lock() {
                 let _ = guard2.send_json(&sub);
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1112,7 +1112,7 @@ struct McpState {
 
 impl Default for McpState {
     fn default() -> Self {
-        Self { child: None, stdout: None, next_id: AtomicU64::new(1), conversation_id: None, last_rollout_path: None, tx: None, config_reasoning_effort: "high".to_string(), summarize_wait: HashMap::new(), summarize_buf: HashMap::new(), last_token_usage: None, last_event_at: None, history_persistence: "save_all".to_string() }
+        Self { child: None, stdout: None, next_id: AtomicU64::new(1), conversation_id: None, last_rollout_path: None, tx: None, config_reasoning_effort: "high".to_string(), summarize_wait: HashMap::new(), summarize_buf: HashMap::new(), last_token_usage: None, last_event_at: None, history_persistence: "save-all".to_string() }
     }
 }
 
@@ -1896,7 +1896,7 @@ async fn task_cancel_cmd(window: tauri::Window, id: String) -> Result<Task, Stri
 #[tauri::command]
 async fn configure_session_mode(window: tauri::Window, mode: String) -> Result<(), String> {
     let state = window.state::<Arc<Mutex<McpState>>>();
-    let val = if mode.to_lowercase() == "chat" { "none" } else { "save_all" };
+    let val = if mode.to_lowercase() == "chat" { "none" } else { "save-all" };
     if let Ok(mut guard) = state.lock() { guard.history_persistence = val.to_string(); }
     let _ = window.emit("codex:stream", &UiStreamEvent::SystemNote { text: format!("Session history.persistence={}", val) });
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1535,12 +1535,8 @@ fn handle_proto_event(win: &tauri::Window, event: &serde_json::Value) {
                 let _ = win.emit("codex:stream", &UiStreamEvent::SystemNote { text: "Task started".into() });
             }
             "task_complete" => {
-                // Some versions include a final message here
-                if let Some(text) = msg.get("last_agent_message").and_then(|d| d.as_str()) {
-                    if !text.trim().is_empty() {
-                        let _ = win.emit("codex:stream", &UiStreamEvent::OutputItemDoneMessage { text: text.to_string() });
-                    }
-                }
+                // Do not synthesize a transcript message from last_agent_message here to avoid
+                // showing stale text from previous turns. Just mark the turn complete.
                 let _ = win.emit("codex:stream", &UiStreamEvent::Completed { response_id: None, token_usage: None });
             }
             "error" => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1149,6 +1149,7 @@ impl McpState {
                 .arg("-c").arg(format!("model={}", env_default_model()))
                 .arg("-c").arg(format!("model_reasoning_effort={}", self.config_reasoning_effort))
                 .arg("-c").arg(format!("history.persistence={}", self.history_persistence))
+                .arg("-c").arg(format!("cwd={}", cwd.display()))
                 // Optional: override user_instructions for Chat mode
                 .current_dir(&codex_dir);
             if let Some(ui) = &self.user_instructions_override {
@@ -1161,7 +1162,8 @@ impl McpState {
                 .arg("-c").arg("sandbox_mode=danger-full-access")
                 .arg("-c").arg(format!("model={}", env_default_model()))
                 .arg("-c").arg(format!("model_reasoning_effort={}", self.config_reasoning_effort))
-                .arg("-c").arg(format!("history.persistence={}", self.history_persistence));
+                .arg("-c").arg(format!("history.persistence={}", self.history_persistence))
+                .arg("-c").arg(format!("cwd={}", cwd.display()));
             if let Some(ui) = &self.user_instructions_override {
                 cmd.arg("-c").arg(format!("user_instructions={}", ui));
             }
@@ -1170,7 +1172,7 @@ impl McpState {
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
-        server_log("proto: spawning process");
+        server_log(&format!("proto: spawning process (cwd override={})", cwd.display()));
         let mut child = cmd.spawn()?;
         let mut stdin = child.stdin.take().ok_or_else(|| anyhow::anyhow!("no stdin"))?;
         let stdout = child.stdout.take().ok_or_else(|| anyhow::anyhow!("no stdout"))?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,8 +14,10 @@
     "windows": [
       {
         "title": "OpenAgents",
-        "width": 800,
-        "height": 600
+        "width": 1280,
+        "height": 900,
+        "minWidth": 1024,
+        "minHeight": 720
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "identifier": "com.openagents.desktop",
   "build": {
-    "beforeDevCommand": "trunk serve",
+    "beforeDevCommand": "bash dev.sh",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "trunk build",
     "frontendDist": "../dist"

--- a/src/app.rs
+++ b/src/app.rs
@@ -210,7 +210,7 @@ pub fn App() -> impl IntoView {
     let raw_events: RwSignal<Vec<String>> = RwSignal::new(vec![]);
     // Tracks if we have streamed any reasoning deltas for the current turn
     let reasoning_streamed: RwSignal<bool> = RwSignal::new(false);
-    let raw_open: RwSignal<bool> = RwSignal::new(false);
+    let raw_open: RwSignal<bool> = RwSignal::new(true);
     let status_open: RwSignal<bool> = RwSignal::new(false);
 
     // Recent chats
@@ -221,6 +221,8 @@ pub fn App() -> impl IntoView {
     let bottom_ref: NodeRef<leptos::html::Div> = NodeRef::new();
     let raw_bottom_ref: NodeRef<leptos::html::Div> = NodeRef::new();
     let input_ref: NodeRef<leptos::html::Input> = NodeRef::new();
+    // Session mode: Chat (default) vs Task (routes send() into master task flow)
+    let session_mode: RwSignal<String> = RwSignal::new("Chat".to_string());
     // Master tasks
     let tasks: RwSignal<Vec<TaskMeta>> = RwSignal::new(vec![]);
     let _tasks_open: RwSignal<bool> = RwSignal::new(true);
@@ -532,7 +534,7 @@ pub fn App() -> impl IntoView {
                 <div class="mx-auto w-full max-w-[768px] px-4">
                     <div class="flex items-center justify-between gap-3 mb-4">
                         <div class="text-sm opacity-90 truncate">{move || chat_title.get()}</div>
-                        <div class="flex items-center gap-2">
+                        <div class="flex items-center gap-3">
                             <label class="text-xs opacity-80">"Reasoning"</label>
                             { // selector
                                 let reasoning = reasoning;
@@ -551,6 +553,22 @@ pub fn App() -> impl IntoView {
                                         <option>Low</option>
                                         <option>Medium</option>
                                         <option>High</option>
+                                    </select>
+                                }
+                            }
+                            <label class="text-xs opacity-80">"Mode"</label>
+                            { // mode selector
+                                let session_mode = session_mode;
+                                view! {
+                                    <select class="text-xs text-white bg-black border border-white rounded-none px-2 py-1 cursor-pointer appearance-none focus:outline-none"
+                                            prop:value=move || session_mode.get()
+                                            on:change=move |ev| {
+                                                if let Some(sel) = ev.target().and_then(|t| t.dyn_into::<web_sys::HtmlSelectElement>().ok()) {
+                                                    session_mode.set(sel.value());
+                                                }
+                                            }>
+                                        <option>Chat</option>
+                                        <option>Task</option>
                                     </select>
                                 }
                             }
@@ -683,23 +701,53 @@ pub fn App() -> impl IntoView {
                             let msg_get = msg.read_only();
                             let reasoning_streamed = reasoning_streamed;
                             let input_ref = input_ref.clone();
+                            let session_mode = session_mode.read_only();
+                            let tasks_setter = tasks.write_only();
+                            let sel_setter = selected_task.write_only();
+                            let sel_detail = selected_task_detail.write_only();
                             move || {
                                 let text = msg_get.get();
                                 if text.is_empty() { return; }
-                                items.update(|list| list.push(ChatItem::User { text: text.clone() }));
-                                // New turn: reset reasoning streamed flag
-                                reasoning_streamed.set(false);
-                                let args = serde_wasm_bindgen::to_value(&serde_json::json!({ "prompt": text.clone() })).unwrap_or(JsValue::UNDEFINED);
-                                let items2 = items.clone();
-                                spawn_local(async move {
-                                    match JsFuture::from(tauri_invoke("submit_chat", args)).await {
-                                        Ok(_) => {}
-                                        Err(e) => {
-                                            let err = js_sys::JSON::stringify(&e).ok().and_then(|v| v.as_string()).unwrap_or_else(|| "invoke error".into());
-                                            items2.update(|list| list.push(ChatItem::System { text: format!("submit_chat failed: {}", err) }));
+                                if session_mode.get() == "Task" {
+                                    // Route to Master Task: create + plan + run
+                                    let items2 = items.clone();
+                                    let goal = text.clone();
+                                    spawn_local(async move {
+                                        // Create a quick task
+                                        match task_create(&format!("Quick: {}", goal)).await {
+                                            Some(t) => {
+                                                let id = t.id.clone();
+                                                sel_setter.set(Some(id.clone()));
+                                                sel_detail.set(Some(t));
+                                                // Plan subtasks from goal
+                                                let args = serde_wasm_bindgen::to_value(&serde_json::json!({ "id": id.clone(), "goal": goal })).unwrap_or(JsValue::UNDEFINED);
+                                                let _ = JsFuture::from(tauri_invoke("task_plan_cmd", args)).await;
+                                                // Run first pending
+                                                let args2 = serde_wasm_bindgen::to_value(&serde_json::json!({ "id": id.clone() })).unwrap_or(JsValue::UNDEFINED);
+                                                let _ = JsFuture::from(tauri_invoke("task_run_cmd", args2)).await;
+                                                tasks_setter.set(tasks_list().await);
+                                            }
+                                            None => {
+                                                items2.update(|list| list.push(ChatItem::System { text: "Failed to create task".into() }));
+                                            }
                                         }
-                                    }
-                                });
+                                    });
+                                } else {
+                                    // Standard chat
+                                    items.update(|list| list.push(ChatItem::User { text: text.clone() }));
+                                    reasoning_streamed.set(false);
+                                    let args = serde_wasm_bindgen::to_value(&serde_json::json!({ "prompt": text.clone() })).unwrap_or(JsValue::UNDEFINED);
+                                    let items2 = items.clone();
+                                    spawn_local(async move {
+                                        match JsFuture::from(tauri_invoke("submit_chat", args)).await {
+                                            Ok(_) => {}
+                                            Err(e) => {
+                                                let err = js_sys::JSON::stringify(&e).ok().and_then(|v| v.as_string()).unwrap_or_else(|| "invoke error".into());
+                                                items2.update(|list| list.push(ChatItem::System { text: format!("submit_chat failed: {}", err) }));
+                                            }
+                                        }
+                                    });
+                                }
                                 msg.set(String::new());
                                 if let Some(el) = input_ref.get() { let _ = el.focus(); }
                             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -363,7 +363,11 @@ pub fn App() -> impl IntoView {
                         on:click=move |_| {
                             items.set(Vec::new());
                             chat_title.set("New chat".to_string());
-                            let _ = tauri_invoke("new_chat_session", JsValue::UNDEFINED);
+                            let mode = session_mode.get();
+                            spawn_local(async move {
+                                let _ = JsFuture::from(tauri_invoke("configure_session_mode", serde_wasm_bindgen::to_value(&serde_json::json!({ "mode": mode })).unwrap_or(JsValue::UNDEFINED))).await;
+                                let _ = JsFuture::from(tauri_invoke("new_chat_session", JsValue::UNDEFINED)).await;
+                            });
                             if let Some(el) = input_ref.get() { let _ = el.focus(); }
                         }>
                     "New chat"


### PR DESCRIPTION
Fix: Clean Chat mode, remove startup summarizer, add server logs; default to main app

Summary
- Default desktop binary: ensure `cargo tauri dev` launches the main app (`default-run = "openagents"`).
- Robust dev startup: add root `dev.sh` + `src-tauri/dev.sh` to preflight Trunk, reuse/guard port 1420, and fail with clear errors.
- Window + UX: increase initial size to 1280×900 (min 1024×720); event log shown by default.
- Chat vs Task modes: add a Mode toggle. Chat creates clean sessions; Task routes Send into Master Task (create → plan → run).
- Clean Chat sessions: launch codex with `history.persistence=none` and inject per‑turn `<user_instructions>` so we get a plain answer (no project/task bleed).
- Remove confusing fallback: do not render `task_complete.last_agent_message` (prevents stale lists showing as replies).
- Startup correctness: stop auto‑summarizing chat titles on load (no off‑record prompts at startup).
- Server logging: print proto spawn args (cwd, model, effort, history), stdin writes (`proto >> …`), stdout lines (`proto << …`), stderr, and an 8s watchdog on silence.
- Anchor session cwd: pass `-c cwd=<repo root>` to codex proto to avoid `cwd not set` and keep context stable.
- Event mapping: support `token_count` top‑level fields; map `stream_error`/`error` to System notes.
- Minor: New Task panel reactive; various UI robustness and error surfacing.

Testing
- `cargo check --target wasm32-unknown-unknown` (UI): OK
- `cd src-tauri && cargo check` (Tauri): OK
- `trunk build` preflight runs via dev.sh; successful.
- Manual run: `cargo tauri dev` prints server logs and Chat mode returns a plain assistant reply.

Notes
- This PR intentionally avoids model traffic on startup.
- Chat mode no longer renders `task_complete.last_agent_message` to prevent stale content.
- All changes are scoped to dev/runtime; production packaging unaffected.
