### PR TITLE
Auto-pair on deep link: connect and skip onboarding

### DIFF
--- a/expo/app/_layout.tsx
+++ b/expo/app/_layout.tsx
@@ -356,11 +356,13 @@ function LinkingBootstrap() {
       try {
         const parsed = parseBridgeCode(url)
         if (!parsed) return
-        // Do not set bridgeCode from deep link to avoid TextInput updates during navigation
+        // Apply host/token from deep link and auto-connect, skipping onboarding.
+        // We intentionally do not set the raw bridgeCode field to avoid TextInput churn.
         try { if (parsed.bridgeHost) setBridgeHost(parsed.bridgeHost) } catch {}
         try { if (parsed.token) setBridgeToken(parsed.token || '') } catch {}
-        // Do not auto-connect on deep link; route to onboarding and let user press Connect
-        try { router.push('/onboarding' as any) } catch {}
+        try { connect() } catch {}
+        // While connecting, Drawer gating allows /thread paths; land user in a new thread.
+        try { router.replace('/thread/new' as any) } catch {}
       } catch {}
     }
     try { Linking.getInitialURL().then((u) => { if (u) handleUrl(u) }).catch(() => {}) } catch {}


### PR DESCRIPTION
## Summary
Auto-pair on deep link: when opened via `openagents://connect?j=<code>` (or similar), apply host/token, call `connect()`, and skip the onboarding “Pair with Desktop” screen by navigating to `/thread/new` while connecting.

## Changes
- `expo/app/_layout.tsx`
  - `LinkingBootstrap`: if `parseBridgeCode(url)` returns a valid host, set `bridgeHost` and `bridgeToken`, call `connect()`, and `router.replace('/thread/new')`.
  - Keeps the existing behavior of not writing the raw `bridgeCode` into the input field to avoid TextInput churn.

## Rationale
- Scanning the QR (or tapping the deep link) previously dropped users on onboarding with no action, requiring a second manual pairing step. Deep links now perform the same pairing/connection path automatically.
- Drawer gating allows `/thread` paths while `connecting`, so landing on `/thread/new` is valid and avoids UI dead ends.

## Testing
- Launch app via `openagents://connect?j=<valid-encoded-json>`.
- Expected: host/token set, WS connection initiated, routed to `/thread/new` immediately. Onboarding is skipped.
- Malformed links: no crash; onboarding remains the fallback path (only when `parseBridgeCode` fails).

Closes #1364.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-link handling to automatically establish connections and route users directly to a new thread, eliminating the forced onboarding flow for valid deep links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->