### PR TITLE
Add Citrea crate + CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5225,6 +5225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6813,6 +6822,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openagents-citrea"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "hex",
+ "nostr 0.1.0",
+ "rand 0.9.2",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "openagents-cli"
 version = "0.1.0"
 dependencies = [
@@ -6822,6 +6846,7 @@ dependencies = [
  "clap",
  "hex",
  "nostr 0.1.0",
+ "openagents-citrea",
  "openagents-spark",
  "rand 0.9.2",
  "reqwest",
@@ -9084,6 +9109,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/codex-client",
     "crates/codex-mcp",
     "crates/compute",
+    "crates/citrea",
     "crates/dsrs",
     "crates/dsrs-macros",
     "crates/editor",

--- a/crates/citrea/Cargo.toml
+++ b/crates/citrea/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "openagents-citrea"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Citrea integration primitives for OpenAgents"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+bitcoin.workspace = true
+hex.workspace = true
+nostr.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha3 = "0.10"
+thiserror.workspace = true
+
+[dev-dependencies]
+rand.workspace = true

--- a/crates/citrea/docs/INTEGRATION_STATUS.md
+++ b/crates/citrea/docs/INTEGRATION_STATUS.md
@@ -1,0 +1,98 @@
+# Citrea CLI + crate status (OpenAgents2)
+
+## What shipped
+
+### New crate: `openagents-citrea`
+Location: `crates/citrea/`
+
+Core utilities implemented:
+- BIP340 Schnorr sign/verify helpers (reuses `bitcoin::secp256k1`).
+- NIP-06 compatible key derivation via `nostr::derive_keypair_full`.
+- EOA address derivation (keccak over uncompressed pubkey).
+- CREATE2 address derivation.
+- ERC20 `balanceOf`/`transfer` calldata helpers.
+- JSON-RPC client with Citrea/EVM methods:
+  - `eth_chainId`, `eth_blockNumber`
+  - `eth_getBalance`, `eth_getTransactionCount`
+  - `eth_call`, `eth_sendRawTransaction`
+  - `eth_getTransactionReceipt`
+  - `citrea_sendRawDepositTransaction`
+  - `txpool_content`
+
+Relevant files:
+- `crates/citrea/src/lib.rs`
+- `crates/citrea/src/keys.rs`
+- `crates/citrea/src/address.rs`
+- `crates/citrea/src/rpc.rs`
+- `crates/citrea/src/util.rs`
+
+### CLI: `oa citrea ...`
+Location: `crates/openagents-cli/src/citrea_cli.rs`
+
+New subcommand wired into `openagents-cli` (`oa` / `openagents`).
+
+Key commands (offline):
+- `oa citrea new`
+- `oa citrea derive`
+- `oa citrea seed`
+- `oa citrea pubkey`
+- `oa citrea sign`
+- `oa citrea verify`
+- `oa citrea address eoa`
+- `oa citrea address create2`
+- `oa citrea address pubkey`
+
+RPC commands (no network tests here):
+- `oa citrea chain info`
+- `oa citrea balance --address ... [--token ...]`
+- `oa citrea nonce --address ...`
+- `oa citrea call --to ... --data ...`
+- `oa citrea send --raw ...`
+- `oa citrea receipt --tx-hash ...`
+- `oa citrea deposit submit --raw ...` (Citrea RPC)
+- `oa citrea txpool`
+
+Env fallbacks:
+- `CITREA_RPC` / `CITREA_RPC_URL` for RPC URL
+- `CITREA_MNEMONIC` / `OPENAGENTS_MNEMONIC` for key derivation
+
+## Tests added
+
+### New crate tests
+- `crates/citrea/tests/citrea_tests.rs`
+  - Schnorr sign/verify roundtrip
+  - EOA address derivation (privkey = 1)
+  - ERC20 balanceOf calldata encoding
+
+### CLI tests
+- `crates/openagents-cli/src/citrea_cli.rs` basic clap parse test
+
+## Tests run locally
+
+- `cargo test -p openagents-citrea`
+- `cargo test -p openagents-cli`
+
+## What’s next (recommended)
+
+1) **RPC integration tests (local-only)**
+   - Add a local JSON-RPC stub for `eth_*` and `citrea_*` methods.
+   - Validate request payloads and response parsing for `balance`, `call`, `deposit submit`.
+
+2) **Smart-account address derivation**
+   - Once the OpenAgents Citrea smart-account factory + init code are defined,
+     add a deterministic `oa citrea address smart` command (CREATE2 wrapper with
+     factory + init-code hash).
+
+3) **TreasuryRouter + receipts**
+   - Wire Citrea actions into receipts (REPLAY/ARTIFACTS) once TreasuryRouter
+     is available in OpenAgents2.
+
+4) **Account abstraction flow**
+   - Add commands for:
+     - constructing meta-tx payloads
+     - Schnorr signature for smart-account auth
+     - optional passkey / secp256r1 co-sign
+
+5) **Token helpers**
+   - Add ERC20 `decimals`, `symbol`, `name` helpers in CLI.
+

--- a/crates/citrea/src/address.rs
+++ b/crates/citrea/src/address.rs
@@ -1,0 +1,61 @@
+use sha3::{Digest, Keccak256};
+
+use crate::{CitreaError, Address, Bytes32};
+
+pub fn keccak256(data: &[u8]) -> Bytes32 {
+    let mut hasher = Keccak256::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&result);
+    out
+}
+
+pub fn format_address(address: &Address) -> String {
+    format!("0x{}", hex::encode(address))
+}
+
+pub fn address_from_uncompressed_pubkey(pubkey: &[u8]) -> Result<Address, CitreaError> {
+    let (payload, expected_len) = match pubkey.len() {
+        65 if pubkey[0] == 0x04 => (&pubkey[1..], 64),
+        64 => (pubkey, 64),
+        other => {
+            return Err(CitreaError::InvalidLength {
+                expected: 64,
+                actual: other,
+            })
+        }
+    };
+
+    if payload.len() != expected_len {
+        return Err(CitreaError::InvalidLength {
+            expected: expected_len,
+            actual: payload.len(),
+        });
+    }
+
+    let hash = keccak256(payload);
+    let mut address = [0u8; 20];
+    address.copy_from_slice(&hash[12..]);
+    Ok(address)
+}
+
+pub fn eoa_address_from_secret(secret: &Bytes32) -> Result<Address, CitreaError> {
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let sk = bitcoin::secp256k1::SecretKey::from_slice(secret)?;
+    let pk = bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &sk);
+    let uncompressed = pk.serialize_uncompressed();
+    address_from_uncompressed_pubkey(&uncompressed)
+}
+
+pub fn create2_address(factory: &Address, salt: &Bytes32, init_code_hash: &Bytes32) -> Address {
+    let mut payload = Vec::with_capacity(1 + 20 + 32 + 32);
+    payload.push(0xff);
+    payload.extend_from_slice(factory);
+    payload.extend_from_slice(salt);
+    payload.extend_from_slice(init_code_hash);
+    let hash = keccak256(&payload);
+    let mut address = [0u8; 20];
+    address.copy_from_slice(&hash[12..]);
+    address
+}

--- a/crates/citrea/src/error.rs
+++ b/crates/citrea/src/error.rs
@@ -1,0 +1,51 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CitreaError {
+    #[error("invalid hex: {0}")]
+    InvalidHex(String),
+    #[error("invalid length: expected {expected} bytes, got {actual} bytes")]
+    InvalidLength { expected: usize, actual: usize },
+    #[error("invalid chain id: {0}")]
+    InvalidChainId(String),
+    #[error("key derivation error: {0}")]
+    KeyDerivation(String),
+    #[error("rpc error {code}: {message}")]
+    Rpc {
+        code: i64,
+        message: String,
+        data: Option<serde_json::Value>,
+    },
+    #[error("rpc response missing result")]
+    MissingResult,
+    #[error("http error: {0}")]
+    Http(String),
+    #[error("serialization error: {0}")]
+    Serde(String),
+    #[error("secp256k1 error: {0}")]
+    Secp(String),
+}
+
+impl From<hex::FromHexError> for CitreaError {
+    fn from(err: hex::FromHexError) -> Self {
+        Self::InvalidHex(err.to_string())
+    }
+}
+
+impl From<reqwest::Error> for CitreaError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Http(err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for CitreaError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Serde(err.to_string())
+    }
+}
+
+impl From<bitcoin::secp256k1::Error> for CitreaError {
+    fn from(err: bitcoin::secp256k1::Error) -> Self {
+        Self::Secp(err.to_string())
+    }
+}

--- a/crates/citrea/src/keys.rs
+++ b/crates/citrea/src/keys.rs
@@ -1,0 +1,57 @@
+use bitcoin::secp256k1::{self, Message, Secp256k1, SecretKey, XOnlyPublicKey, schnorr};
+
+use crate::{CitreaError, Bytes32, Bytes64};
+
+pub type SchnorrKeypair = nostr::Keypair;
+
+pub fn derive_keypair_full(
+    mnemonic: &str,
+    passphrase: &str,
+    account: u32,
+) -> Result<SchnorrKeypair, CitreaError> {
+    nostr::derive_keypair_full(mnemonic, passphrase, account)
+        .map_err(|e| CitreaError::KeyDerivation(e.to_string()))
+}
+
+pub fn derive_agent_keypair(
+    mnemonic: &str,
+    passphrase: &str,
+    agent_id: u32,
+) -> Result<(SchnorrKeypair, u32), CitreaError> {
+    let account = agent_id
+        .checked_add(1)
+        .ok_or_else(|| CitreaError::KeyDerivation("agent index overflow".to_string()))?;
+    let keypair = derive_keypair_full(mnemonic, passphrase, account)?;
+    Ok((keypair, account))
+}
+
+pub fn xonly_pubkey_from_secret(secret: &Bytes32) -> Result<Bytes32, CitreaError> {
+    let secp = Secp256k1::new();
+    let sk = SecretKey::from_slice(secret)?;
+    let (xonly, _) = sk.x_only_public_key(&secp);
+    Ok(xonly.serialize())
+}
+
+pub fn sign_schnorr(secret: &Bytes32, message: &Bytes32) -> Result<Bytes64, CitreaError> {
+    let secp = Secp256k1::new();
+    let sk = SecretKey::from_slice(secret)?;
+    let keypair = secp256k1::Keypair::from_secret_key(&secp, &sk);
+    let msg = Message::from_digest_slice(message)?;
+    let sig = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
+    Ok(sig.serialize())
+}
+
+pub fn verify_schnorr(
+    pubkey: &Bytes32,
+    message: &Bytes32,
+    signature: &Bytes64,
+) -> Result<bool, CitreaError> {
+    let secp = Secp256k1::verification_only();
+    let sig = schnorr::Signature::from_slice(signature)?;
+    let pubkey = XOnlyPublicKey::from_slice(pubkey)?;
+    let msg = Message::from_digest_slice(message)?;
+    match secp.verify_schnorr(&sig, &msg, &pubkey) {
+        Ok(()) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}

--- a/crates/citrea/src/lib.rs
+++ b/crates/citrea/src/lib.rs
@@ -1,0 +1,22 @@
+mod address;
+mod error;
+mod keys;
+mod rpc;
+mod types;
+mod util;
+
+pub use address::{
+    address_from_uncompressed_pubkey, create2_address, eoa_address_from_secret, format_address,
+    keccak256,
+};
+pub use error::CitreaError;
+pub use keys::{
+    derive_agent_keypair, derive_keypair_full, sign_schnorr, verify_schnorr,
+    xonly_pubkey_from_secret, SchnorrKeypair,
+};
+pub use rpc::{erc20_balance_of_data, erc20_transfer_data, RpcClient};
+pub use types::{Address, BlockTag, Bytes32, Bytes64, RpcCallRequest};
+pub use util::{
+    format_hex_prefixed, parse_hex_bytes, parse_hex_u128, parse_hex_u64, parse_hex_vec,
+    parse_u64_hex_or_dec, strip_0x,
+};

--- a/crates/citrea/src/rpc.rs
+++ b/crates/citrea/src/rpc.rs
@@ -1,0 +1,178 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CitreaError, BlockTag, RpcCallRequest,
+    types::{Address, Bytes32},
+    util::{format_hex_prefixed, parse_hex_u64},
+};
+
+static RPC_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest<'a, T> {
+    jsonrpc: &'static str,
+    id: u64,
+    method: &'a str,
+    params: T,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct JsonRpcResponse<T> {
+    jsonrpc: Option<String>,
+    id: Option<u64>,
+    result: Option<T>,
+    error: Option<RpcErrorObject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcErrorObject {
+    code: i64,
+    message: String,
+    data: Option<serde_json::Value>,
+}
+
+#[derive(Clone)]
+pub struct RpcClient {
+    url: String,
+    client: reqwest::Client,
+}
+
+impl RpcClient {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub async fn request<P, R>(&self, method: &str, params: P) -> Result<R, CitreaError>
+    where
+        P: Serialize,
+        R: DeserializeOwned,
+    {
+        let id = RPC_ID.fetch_add(1, Ordering::Relaxed);
+        let payload = JsonRpcRequest {
+            jsonrpc: "2.0",
+            id,
+            method,
+            params,
+        };
+
+        let response = self
+            .client
+            .post(&self.url)
+            .header("Content-Type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(CitreaError::Http(format!(
+                "HTTP {} from {}",
+                status,
+                self.url
+            )));
+        }
+
+        let body: JsonRpcResponse<R> = response.json().await?;
+        if let Some(error) = body.error {
+            return Err(CitreaError::Rpc {
+                code: error.code,
+                message: error.message,
+                data: error.data,
+            });
+        }
+
+        body.result.ok_or(CitreaError::MissingResult)
+    }
+
+    pub async fn chain_id(&self) -> Result<u64, CitreaError> {
+        let result: String = self.request("eth_chainId", Vec::<serde_json::Value>::new()).await?;
+        parse_hex_u64(&result)
+    }
+
+    pub async fn block_number(&self) -> Result<u64, CitreaError> {
+        let result: String = self
+            .request("eth_blockNumber", Vec::<serde_json::Value>::new())
+            .await?;
+        parse_hex_u64(&result)
+    }
+
+    pub async fn get_balance(&self, address: &Address, block: BlockTag) -> Result<String, CitreaError> {
+        let params = vec![
+            serde_json::Value::String(format_hex_prefixed(address)),
+            block.to_param(),
+        ];
+        self.request("eth_getBalance", params).await
+    }
+
+    pub async fn get_transaction_count(
+        &self,
+        address: &Address,
+        block: BlockTag,
+    ) -> Result<u64, CitreaError> {
+        let params = vec![
+            serde_json::Value::String(format_hex_prefixed(address)),
+            block.to_param(),
+        ];
+        let result: String = self.request("eth_getTransactionCount", params).await?;
+        parse_hex_u64(&result)
+    }
+
+    pub async fn call(&self, request: RpcCallRequest, block: BlockTag) -> Result<String, CitreaError> {
+        let params = vec![serde_json::to_value(request)?, block.to_param()];
+        self.request("eth_call", params).await
+    }
+
+    pub async fn send_raw_transaction(&self, raw_tx: &str) -> Result<String, CitreaError> {
+        let params = vec![raw_tx];
+        self.request("eth_sendRawTransaction", params).await
+    }
+
+    pub async fn send_raw_deposit_transaction(
+        &self,
+        raw_deposit: &str,
+    ) -> Result<serde_json::Value, CitreaError> {
+        let params = vec![raw_deposit];
+        self.request("citrea_sendRawDepositTransaction", params).await
+    }
+
+    pub async fn transaction_receipt(
+        &self,
+        tx_hash: &str,
+    ) -> Result<serde_json::Value, CitreaError> {
+        let params = vec![tx_hash];
+        self.request("eth_getTransactionReceipt", params).await
+    }
+
+    pub async fn txpool_content(&self) -> Result<serde_json::Value, CitreaError> {
+        self.request("txpool_content", Vec::<serde_json::Value>::new())
+            .await
+    }
+}
+
+pub fn erc20_balance_of_data(owner: &Address) -> String {
+    let mut data = Vec::with_capacity(4 + 32);
+    data.extend_from_slice(&[0x70, 0xa0, 0x82, 0x31]);
+    data.extend_from_slice(&[0u8; 12]);
+    data.extend_from_slice(owner);
+    format_hex_prefixed(&data)
+}
+
+pub fn erc20_transfer_data(to: &Address, amount: &Bytes32) -> String {
+    let mut data = Vec::with_capacity(4 + 32 + 32);
+    data.extend_from_slice(&[0xa9, 0x05, 0x9c, 0xbb]);
+    data.extend_from_slice(&[0u8; 12]);
+    data.extend_from_slice(to);
+    data.extend_from_slice(amount);
+    format_hex_prefixed(&data)
+}

--- a/crates/citrea/src/types.rs
+++ b/crates/citrea/src/types.rs
@@ -1,0 +1,39 @@
+use serde::Serialize;
+
+pub type Address = [u8; 20];
+pub type Bytes32 = [u8; 32];
+pub type Bytes64 = [u8; 64];
+
+#[derive(Clone, Copy, Debug)]
+pub enum BlockTag {
+    Latest,
+    Pending,
+    Earliest,
+    Number(u64),
+}
+
+impl BlockTag {
+    pub fn to_param(self) -> serde_json::Value {
+        match self {
+            BlockTag::Latest => serde_json::Value::String("latest".to_string()),
+            BlockTag::Pending => serde_json::Value::String("pending".to_string()),
+            BlockTag::Earliest => serde_json::Value::String("earliest".to_string()),
+            BlockTag::Number(value) => serde_json::Value::String(format!("0x{value:x}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RpcCallRequest {
+    pub to: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_price: Option<String>,
+}

--- a/crates/citrea/src/util.rs
+++ b/crates/citrea/src/util.rs
@@ -1,0 +1,66 @@
+use crate::CitreaError;
+
+pub fn strip_0x(input: &str) -> &str {
+    if let Some(stripped) = input.strip_prefix("0x") {
+        stripped
+    } else if let Some(stripped) = input.strip_prefix("0X") {
+        stripped
+    } else {
+        input
+    }
+}
+
+pub fn parse_hex_bytes<const N: usize>(input: &str) -> Result<[u8; N], CitreaError> {
+    let raw = strip_0x(input);
+    let bytes = hex::decode(raw)?;
+    if bytes.len() != N {
+        return Err(CitreaError::InvalidLength {
+            expected: N,
+            actual: bytes.len(),
+        });
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+pub fn parse_hex_vec(input: &str) -> Result<Vec<u8>, CitreaError> {
+    let raw = strip_0x(input);
+    let bytes = hex::decode(raw)?;
+    Ok(bytes)
+}
+
+pub fn format_hex_prefixed(bytes: &[u8]) -> String {
+    format!("0x{}", hex::encode(bytes))
+}
+
+pub fn parse_u64_hex_or_dec(input: &str) -> Result<u64, CitreaError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(CitreaError::InvalidChainId("empty value".to_string()));
+    }
+    if let Some(hex) = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16)
+            .map_err(|e| CitreaError::InvalidChainId(e.to_string()))
+    } else {
+        trimmed
+            .parse::<u64>()
+            .map_err(|e| CitreaError::InvalidChainId(e.to_string()))
+    }
+}
+
+pub fn parse_hex_u64(input: &str) -> Result<u64, CitreaError> {
+    let raw = strip_0x(input);
+    if raw.is_empty() {
+        return Err(CitreaError::InvalidChainId("empty hex value".to_string()));
+    }
+    u64::from_str_radix(raw, 16).map_err(|e| CitreaError::InvalidChainId(e.to_string()))
+}
+
+pub fn parse_hex_u128(input: &str) -> Result<u128, CitreaError> {
+    let raw = strip_0x(input);
+    if raw.is_empty() {
+        return Err(CitreaError::InvalidHex("empty hex value".to_string()));
+    }
+    u128::from_str_radix(raw, 16).map_err(|e| CitreaError::InvalidHex(e.to_string()))
+}

--- a/crates/citrea/tests/citrea_tests.rs
+++ b/crates/citrea/tests/citrea_tests.rs
@@ -1,0 +1,52 @@
+use openagents_citrea::{
+    erc20_balance_of_data, eoa_address_from_secret, format_address, parse_hex_bytes,
+    sign_schnorr, verify_schnorr, xonly_pubkey_from_secret,
+};
+
+#[test]
+fn sign_and_verify_roundtrip() {
+    let secret = parse_hex_bytes::<32>(
+        "0000000000000000000000000000000000000000000000000000000000000001",
+    )
+    .expect("parse secret");
+    let message = parse_hex_bytes::<32>(
+        "0000000000000000000000000000000000000000000000000000000000010203",
+    )
+    .expect("parse message");
+    let pubkey = xonly_pubkey_from_secret(&secret).expect("pubkey");
+    let sig = sign_schnorr(&secret, &message).expect("sign");
+    let valid = verify_schnorr(&pubkey, &message, &sig).expect("verify");
+    assert!(valid);
+
+    let other_message = parse_hex_bytes::<32>(
+        "00000000000000000000000000000000000000000000000000000000deadbeef",
+    )
+    .expect("parse other message");
+    let valid_other = verify_schnorr(&pubkey, &other_message, &sig).expect("verify other");
+    assert!(!valid_other);
+}
+
+#[test]
+fn eoa_address_from_secret_key_one() {
+    let secret = parse_hex_bytes::<32>(
+        "0000000000000000000000000000000000000000000000000000000000000001",
+    )
+    .expect("secret");
+    let address = eoa_address_from_secret(&secret).expect("address");
+    let rendered = format_address(&address);
+    assert_eq!(
+        rendered,
+        "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+    );
+}
+
+#[test]
+fn erc20_balance_of_encoding() {
+    let owner = parse_hex_bytes::<20>("1111111111111111111111111111111111111111")
+        .expect("owner");
+    let data = erc20_balance_of_data(&owner);
+    assert_eq!(
+        data,
+        "0x70a082310000000000000000000000001111111111111111111111111111111111111111"
+    );
+}

--- a/crates/openagents-cli/Cargo.toml
+++ b/crates/openagents-cli/Cargo.toml
@@ -25,6 +25,7 @@ hex = { workspace = true }
 rand = { workspace = true }
 bip39 = "2.1"
 spark = { package = "openagents-spark", path = "../spark" }
+citrea = { package = "openagents-citrea", path = "../citrea" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 reqwest = { workspace = true }
 bitcoin = { workspace = true }

--- a/crates/openagents-cli/src/citrea_cli.rs
+++ b/crates/openagents-cli/src/citrea_cli.rs
@@ -1,0 +1,996 @@
+use anyhow::{Context, Result};
+use bip39::Mnemonic;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use citrea::{
+    address_from_uncompressed_pubkey, create2_address, derive_keypair_full,
+    eoa_address_from_secret, erc20_balance_of_data, format_address, parse_hex_bytes,
+    parse_hex_u128, parse_hex_vec, sign_schnorr, strip_0x, verify_schnorr,
+    xonly_pubkey_from_secret, BlockTag, RpcCallRequest, RpcClient,
+};
+use rand::RngCore;
+use serde::Serialize;
+use std::env;
+use std::fs;
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+pub struct CitreaArgs {
+    #[command(subcommand)]
+    pub command: CitreaCommand,
+}
+
+#[derive(Subcommand)]
+pub enum CitreaCommand {
+    /// Generate a new mnemonic and derive a Schnorr keypair
+    New(NewArgs),
+    /// Derive a Schnorr keypair from an existing mnemonic
+    Derive(DeriveArgs),
+    /// Derive the BIP39 seed from a mnemonic
+    Seed(SeedArgs),
+    /// Derive a Schnorr public key from a secret key or mnemonic
+    Pubkey(PubkeyArgs),
+    /// Sign a 32-byte hash with Schnorr (BIP340)
+    Sign(SignArgs),
+    /// Verify a 32-byte hash signature with Schnorr (BIP340)
+    Verify(VerifyArgs),
+    /// Address helpers (EOA or CREATE2)
+    Address(AddressArgs),
+    /// Chain info (RPC)
+    Chain(ChainArgs),
+    /// Balance lookup (RPC)
+    Balance(BalanceArgs),
+    /// Nonce lookup (RPC)
+    Nonce(NonceArgs),
+    /// eth_call helper (RPC)
+    Call(CallArgs),
+    /// eth_sendRawTransaction helper (RPC)
+    Send(SendArgs),
+    /// Transaction receipt lookup (RPC)
+    Receipt(ReceiptArgs),
+    /// Citrea-specific deposit submission
+    Deposit(DepositArgs),
+    /// txpool content (RPC)
+    Txpool(TxpoolArgs),
+}
+
+#[derive(Args)]
+pub struct NewArgs {
+    /// Number of words in the mnemonic (12 or 24)
+    #[arg(long, default_value = "12")]
+    pub words: u16,
+    /// Optional BIP39 passphrase
+    #[arg(long, default_value = "")]
+    pub passphrase: String,
+    /// Account index for derivation (m/44'/1237'/<account>'/0/0)
+    #[arg(long)]
+    pub account: Option<u32>,
+    /// Agent index (maps to account = agent + 1)
+    #[arg(long)]
+    pub agent: Option<u32>,
+    /// Do not print the mnemonic
+    #[arg(long)]
+    pub no_mnemonic: bool,
+    /// Do not print the private key
+    #[arg(long)]
+    pub no_private: bool,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct DeriveArgs {
+    #[command(flatten)]
+    pub input: KeyDerivationArgs,
+    /// Print the mnemonic in output
+    #[arg(long)]
+    pub show_mnemonic: bool,
+    /// Do not print the private key
+    #[arg(long)]
+    pub no_private: bool,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct SeedArgs {
+    #[command(flatten)]
+    pub input: MnemonicInput,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct PubkeyArgs {
+    #[arg(long, conflicts_with_all = ["mnemonic", "stdin", "mnemonic_file"])]
+    pub secret_hex: Option<String>,
+    #[command(flatten)]
+    pub input: KeyDerivationArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct SignArgs {
+    /// 32-byte hash (hex)
+    #[arg(long, conflicts_with_all = ["hash_file", "hash_stdin"])]
+    pub hash: Option<String>,
+    /// Read hash from a file
+    #[arg(long, conflicts_with_all = ["hash", "hash_stdin"])]
+    pub hash_file: Option<PathBuf>,
+    /// Read hash from stdin
+    #[arg(long = "hash-stdin", conflicts_with_all = ["hash", "hash_file"])]
+    pub hash_stdin: bool,
+    #[arg(long, conflicts_with_all = ["mnemonic", "stdin", "mnemonic_file"])]
+    pub secret_hex: Option<String>,
+    #[command(flatten)]
+    pub input: KeyDerivationArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct VerifyArgs {
+    /// 32-byte hash (hex)
+    #[arg(long, conflicts_with_all = ["hash_file", "hash_stdin"])]
+    pub hash: Option<String>,
+    /// Read hash from a file
+    #[arg(long, conflicts_with_all = ["hash", "hash_stdin"])]
+    pub hash_file: Option<PathBuf>,
+    /// Read hash from stdin
+    #[arg(long = "hash-stdin", conflicts_with_all = ["hash", "hash_file"])]
+    pub hash_stdin: bool,
+    /// X-only public key hex (32 bytes)
+    #[arg(long)]
+    pub pubkey: String,
+    /// Schnorr signature hex (64 bytes)
+    #[arg(long)]
+    pub signature: String,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct AddressArgs {
+    #[command(subcommand)]
+    pub command: AddressCommand,
+}
+
+#[derive(Subcommand)]
+pub enum AddressCommand {
+    /// Compute an EOA address from a secret key or mnemonic
+    Eoa(AddressEoaArgs),
+    /// Compute a CREATE2 address
+    Create2(AddressCreate2Args),
+    /// Compute an address from an uncompressed public key
+    Pubkey(AddressPubkeyArgs),
+}
+
+#[derive(Args)]
+pub struct AddressEoaArgs {
+    #[arg(long, conflicts_with_all = ["mnemonic", "stdin", "mnemonic_file"])]
+    pub secret_hex: Option<String>,
+    #[command(flatten)]
+    pub input: KeyDerivationArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct AddressCreate2Args {
+    /// Factory address (20-byte hex)
+    #[arg(long)]
+    pub factory: String,
+    /// Salt (32-byte hex)
+    #[arg(long)]
+    pub salt: String,
+    /// Init code hash (32-byte hex)
+    #[arg(long)]
+    pub init_code_hash: String,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct AddressPubkeyArgs {
+    /// Uncompressed public key hex (64 or 65 bytes)
+    #[arg(long)]
+    pub public_key: String,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct ChainArgs {
+    #[command(subcommand)]
+    pub command: ChainCommand,
+}
+
+#[derive(Subcommand)]
+pub enum ChainCommand {
+    /// Fetch chain id and latest block
+    Info(ChainInfoArgs),
+}
+
+#[derive(Args)]
+pub struct ChainInfoArgs {
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct BalanceArgs {
+    /// Address to query (20-byte hex)
+    #[arg(long)]
+    pub address: String,
+    /// Optional ERC20 token address to query
+    #[arg(long)]
+    pub token: Option<String>,
+    #[command(flatten)]
+    pub block: BlockArgs,
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct NonceArgs {
+    /// Address to query (20-byte hex)
+    #[arg(long)]
+    pub address: String,
+    #[command(flatten)]
+    pub block: BlockArgs,
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct CallArgs {
+    /// Contract address
+    #[arg(long)]
+    pub to: String,
+    /// Call data hex
+    #[arg(long)]
+    pub data: String,
+    /// Optional sender address
+    #[arg(long)]
+    pub from: Option<String>,
+    /// Optional value (hex)
+    #[arg(long)]
+    pub value: Option<String>,
+    /// Optional gas (hex)
+    #[arg(long)]
+    pub gas: Option<String>,
+    /// Optional gas price (hex)
+    #[arg(long)]
+    pub gas_price: Option<String>,
+    #[command(flatten)]
+    pub block: BlockArgs,
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct SendArgs {
+    /// Raw signed transaction hex
+    #[arg(long)]
+    pub raw: String,
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct ReceiptArgs {
+    /// Transaction hash
+    #[arg(long)]
+    pub tx_hash: String,
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct DepositArgs {
+    #[command(subcommand)]
+    pub command: DepositCommand,
+}
+
+#[derive(Subcommand)]
+pub enum DepositCommand {
+    /// Submit a raw deposit transaction (citrea_sendRawDepositTransaction)
+    Submit(DepositSubmitArgs),
+}
+
+#[derive(Args)]
+pub struct DepositSubmitArgs {
+    /// Raw deposit hex
+    #[arg(long)]
+    pub raw: String,
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Args)]
+pub struct TxpoolArgs {
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+    #[command(flatten)]
+    pub output: OutputArgs,
+}
+
+#[derive(Clone, Args)]
+pub struct OutputArgs {
+    /// Output JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Clone, Args)]
+pub struct RpcArgs {
+    /// RPC URL (or set CITREA_RPC / CITREA_RPC_URL)
+    #[arg(long)]
+    pub rpc: Option<String>,
+}
+
+#[derive(Clone, Args)]
+pub struct BlockArgs {
+    /// Block tag
+    #[arg(long, value_enum, default_value = "latest")]
+    pub tag: BlockTagArg,
+    /// Block number override
+    #[arg(long)]
+    pub number: Option<u64>,
+}
+
+#[derive(ValueEnum, Clone, Copy)]
+#[value(rename_all = "kebab-case")]
+pub enum BlockTagArg {
+    Latest,
+    Pending,
+    Earliest,
+}
+
+#[derive(Clone, Args)]
+pub struct MnemonicInput {
+    /// Mnemonic phrase (12 or 24 words)
+    #[arg(long, conflicts_with_all = ["stdin", "mnemonic_file"])]
+    pub mnemonic: Option<String>,
+    /// Read mnemonic from stdin
+    #[arg(long, conflicts_with_all = ["mnemonic", "mnemonic_file"])]
+    pub stdin: bool,
+    /// Read mnemonic from a file
+    #[arg(long, conflicts_with_all = ["mnemonic", "stdin"])]
+    pub mnemonic_file: Option<PathBuf>,
+    /// Optional BIP39 passphrase
+    #[arg(long, default_value = "")]
+    pub passphrase: String,
+}
+
+#[derive(Clone, Args)]
+pub struct KeyDerivationArgs {
+    #[command(flatten)]
+    pub mnemonic: MnemonicInput,
+    /// Account index for derivation (m/44'/1237'/<account>'/0/0)
+    #[arg(long)]
+    pub account: Option<u32>,
+    /// Agent index (maps to account = agent + 1)
+    #[arg(long)]
+    pub agent: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct KeypairOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mnemonic: Option<String>,
+    account: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent: Option<u32>,
+    public_key_hex: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    private_key_hex: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    eoa_address: Option<String>,
+}
+
+#[derive(Serialize)]
+struct SeedOutput {
+    seed_hex: String,
+}
+
+#[derive(Serialize)]
+struct PubkeyOutput {
+    public_key_hex: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    eoa_address: Option<String>,
+}
+
+#[derive(Serialize)]
+struct SignOutput {
+    signature_hex: String,
+    public_key_hex: String,
+}
+
+#[derive(Serialize)]
+struct VerifyOutput {
+    valid: bool,
+}
+
+#[derive(Serialize)]
+struct AddressOutput {
+    address: String,
+}
+
+#[derive(Serialize)]
+struct ChainInfoOutput {
+    rpc_url: String,
+    chain_id: u64,
+    block_number: u64,
+}
+
+#[derive(Serialize)]
+struct BalanceOutput {
+    address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token: Option<String>,
+    balance_hex: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    balance_u128: Option<u128>,
+}
+
+#[derive(Serialize)]
+struct NonceOutput {
+    address: String,
+    nonce: u64,
+    nonce_hex: String,
+}
+
+#[derive(Serialize)]
+struct CallOutput {
+    data_hex: String,
+}
+
+#[derive(Serialize)]
+struct SendOutput {
+    tx_hash: String,
+}
+
+pub fn run(args: CitreaArgs) -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new().context("Failed to start Tokio runtime")?;
+    runtime.block_on(run_async(args))
+}
+
+async fn run_async(args: CitreaArgs) -> Result<()> {
+    match args.command {
+        CitreaCommand::New(args) => new_keypair(args),
+        CitreaCommand::Derive(args) => derive_keypair(args),
+        CitreaCommand::Seed(args) => derive_seed(args),
+        CitreaCommand::Pubkey(args) => derive_pubkey(args),
+        CitreaCommand::Sign(args) => sign_hash(args),
+        CitreaCommand::Verify(args) => verify_hash(args),
+        CitreaCommand::Address(args) => address_command(args),
+        CitreaCommand::Chain(args) => chain_command(args).await,
+        CitreaCommand::Balance(args) => balance_command(args).await,
+        CitreaCommand::Nonce(args) => nonce_command(args).await,
+        CitreaCommand::Call(args) => call_command(args).await,
+        CitreaCommand::Send(args) => send_command(args).await,
+        CitreaCommand::Receipt(args) => receipt_command(args).await,
+        CitreaCommand::Deposit(args) => deposit_command(args).await,
+        CitreaCommand::Txpool(args) => txpool_command(args).await,
+    }
+}
+
+fn new_keypair(args: NewArgs) -> Result<()> {
+    let mnemonic = generate_mnemonic(args.words)?;
+    let (account, agent) = resolve_account(args.account, args.agent)?;
+    let keypair = derive_keypair_full(&mnemonic, &args.passphrase, account)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    let eoa_address = if args.no_private {
+        None
+    } else {
+        eoa_address_from_secret(&keypair.private_key)
+            .ok()
+            .map(|addr| format_address(&addr))
+    };
+
+    let output = KeypairOutput {
+        mnemonic: if args.no_mnemonic { None } else { Some(mnemonic) },
+        account,
+        agent,
+        public_key_hex: keypair.public_key_hex(),
+        private_key_hex: if args.no_private {
+            None
+        } else {
+            Some(keypair.private_key_hex())
+        },
+        eoa_address,
+    };
+
+    print_output(&output, args.output.json)
+}
+
+fn derive_keypair(args: DeriveArgs) -> Result<()> {
+    let mnemonic = resolve_mnemonic(&args.input.mnemonic)?;
+    let (account, agent) = resolve_account(args.input.account, args.input.agent)?;
+    let keypair = derive_keypair_full(&mnemonic, &args.input.mnemonic.passphrase, account)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+    let eoa_address = if args.no_private {
+        None
+    } else {
+        eoa_address_from_secret(&keypair.private_key)
+            .ok()
+            .map(|addr| format_address(&addr))
+    };
+
+    let output = KeypairOutput {
+        mnemonic: if args.show_mnemonic {
+            Some(mnemonic)
+        } else {
+            None
+        },
+        account,
+        agent,
+        public_key_hex: keypair.public_key_hex(),
+        private_key_hex: if args.no_private {
+            None
+        } else {
+            Some(keypair.private_key_hex())
+        },
+        eoa_address,
+    };
+
+    print_output(&output, args.output.json)
+}
+
+fn derive_seed(args: SeedArgs) -> Result<()> {
+    let mnemonic = resolve_mnemonic(&args.input)?;
+    let mnemonic = Mnemonic::parse(&mnemonic)
+        .map_err(|e| anyhow::anyhow!(format!("Invalid mnemonic: {e}")))?;
+    let seed = mnemonic.to_seed(&args.input.passphrase);
+    let output = SeedOutput {
+        seed_hex: hex::encode(seed),
+    };
+    print_output(&output, args.output.json)
+}
+
+fn derive_pubkey(args: PubkeyArgs) -> Result<()> {
+    let secret = resolve_secret_key(args.secret_hex, &args.input)?;
+    let pubkey = xonly_pubkey_from_secret(&secret)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let eoa_address = eoa_address_from_secret(&secret)
+        .ok()
+        .map(|addr| format_address(&addr));
+    let output = PubkeyOutput {
+        public_key_hex: hex::encode(pubkey),
+        eoa_address,
+    };
+    print_output(&output, args.output.json)
+}
+
+fn sign_hash(args: SignArgs) -> Result<()> {
+    let hash = read_hash_input(args.hash, args.hash_file, args.hash_stdin)?;
+    let secret = resolve_secret_key(args.secret_hex, &args.input)?;
+    let signature = sign_schnorr(&secret, &hash)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let pubkey = xonly_pubkey_from_secret(&secret)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let output = SignOutput {
+        signature_hex: hex::encode(signature),
+        public_key_hex: hex::encode(pubkey),
+    };
+    print_output(&output, args.output.json)
+}
+
+fn verify_hash(args: VerifyArgs) -> Result<()> {
+    let hash = read_hash_input(args.hash, args.hash_file, args.hash_stdin)?;
+    let pubkey = parse_hex_bytes::<32>(&args.pubkey)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let signature = parse_hex_bytes::<64>(&args.signature)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let valid = verify_schnorr(&pubkey, &hash, &signature)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let output = VerifyOutput { valid };
+    print_output(&output, args.output.json)
+}
+
+fn address_command(args: AddressArgs) -> Result<()> {
+    match args.command {
+        AddressCommand::Eoa(args) => address_eoa(args),
+        AddressCommand::Create2(args) => address_create2(args),
+        AddressCommand::Pubkey(args) => address_pubkey(args),
+    }
+}
+
+fn address_eoa(args: AddressEoaArgs) -> Result<()> {
+    let secret = resolve_secret_key(args.secret_hex, &args.input)?;
+    let address = eoa_address_from_secret(&secret)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let output = AddressOutput {
+        address: format_address(&address),
+    };
+    print_output(&output, args.output.json)
+}
+
+fn address_create2(args: AddressCreate2Args) -> Result<()> {
+    let factory = parse_hex_bytes::<20>(&args.factory)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let salt = parse_hex_bytes::<32>(&args.salt)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let init_code_hash = parse_hex_bytes::<32>(&args.init_code_hash)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let address = create2_address(&factory, &salt, &init_code_hash);
+    let output = AddressOutput {
+        address: format_address(&address),
+    };
+    print_output(&output, args.output.json)
+}
+
+fn address_pubkey(args: AddressPubkeyArgs) -> Result<()> {
+    let bytes = parse_hex_vec(&args.public_key).map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let address = address_from_uncompressed_pubkey(&bytes)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let output = AddressOutput {
+        address: format_address(&address),
+    };
+    print_output(&output, args.output.json)
+}
+
+async fn chain_command(args: ChainArgs) -> Result<()> {
+    match args.command {
+        ChainCommand::Info(args) => chain_info(args).await,
+    }
+}
+
+async fn chain_info(args: ChainInfoArgs) -> Result<()> {
+    let rpc = resolve_rpc(&args.rpc)?;
+    let chain_id = rpc.chain_id().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let block_number = rpc
+        .block_number()
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let output = ChainInfoOutput {
+        rpc_url: rpc.url().to_string(),
+        chain_id,
+        block_number,
+    };
+    print_output(&output, args.output.json)
+}
+
+async fn balance_command(args: BalanceArgs) -> Result<()> {
+    let rpc = resolve_rpc(&args.rpc)?;
+    let address = parse_hex_bytes::<20>(&args.address)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let block = resolve_block_tag(&args.block);
+
+    let (balance_hex, token) = if let Some(token) = args.token {
+        let token_address = parse_hex_bytes::<20>(&token)
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let data = erc20_balance_of_data(&address);
+        let request = RpcCallRequest {
+            to: format_address(&token_address),
+            from: None,
+            data: Some(data),
+            value: None,
+            gas: None,
+            gas_price: None,
+        };
+        let result = rpc
+            .call(request, block)
+            .await
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        (result, Some(format_address(&token_address)))
+    } else {
+        (
+            rpc.get_balance(&address, block)
+                .await
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?,
+            None,
+        )
+    };
+
+    let balance_u128 = parse_hex_u128(&balance_hex).ok();
+    let output = BalanceOutput {
+        address: format_address(&address),
+        token,
+        balance_hex,
+        balance_u128,
+    };
+    print_output(&output, args.output.json)
+}
+
+async fn nonce_command(args: NonceArgs) -> Result<()> {
+    let rpc = resolve_rpc(&args.rpc)?;
+    let address = parse_hex_bytes::<20>(&args.address)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let block = resolve_block_tag(&args.block);
+    let nonce = rpc
+        .get_transaction_count(&address, block)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let output = NonceOutput {
+        address: format_address(&address),
+        nonce,
+        nonce_hex: format!("0x{nonce:x}"),
+    };
+    print_output(&output, args.output.json)
+}
+
+async fn call_command(args: CallArgs) -> Result<()> {
+    let rpc = resolve_rpc(&args.rpc)?;
+    let request = RpcCallRequest {
+        to: ensure_hex_prefixed(&args.to),
+        from: args.from.as_ref().map(|value| ensure_hex_prefixed(value)),
+        data: Some(ensure_hex_prefixed(&args.data)),
+        value: args.value.as_ref().map(|value| ensure_hex_prefixed(value)),
+        gas: args.gas.as_ref().map(|value| ensure_hex_prefixed(value)),
+        gas_price: args.gas_price.as_ref().map(|value| ensure_hex_prefixed(value)),
+    };
+    let block = resolve_block_tag(&args.block);
+    let result = rpc
+        .call(request, block)
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let output = CallOutput { data_hex: result };
+    print_output(&output, args.output.json)
+}
+
+async fn send_command(args: SendArgs) -> Result<()> {
+    let rpc = resolve_rpc(&args.rpc)?;
+    let tx_hash = rpc
+        .send_raw_transaction(&ensure_hex_prefixed(&args.raw))
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let output = SendOutput { tx_hash };
+    print_output(&output, args.output.json)
+}
+
+async fn receipt_command(args: ReceiptArgs) -> Result<()> {
+    let rpc = resolve_rpc(&args.rpc)?;
+    let receipt = rpc
+        .transaction_receipt(&ensure_hex_prefixed(&args.tx_hash))
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    print_output(&receipt, args.output.json)
+}
+
+async fn deposit_command(args: DepositArgs) -> Result<()> {
+    match args.command {
+        DepositCommand::Submit(args) => deposit_submit(args).await,
+    }
+}
+
+async fn deposit_submit(args: DepositSubmitArgs) -> Result<()> {
+    let rpc = resolve_rpc(&args.rpc)?;
+    let result = rpc
+        .send_raw_deposit_transaction(&ensure_hex_prefixed(&args.raw))
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    print_output(&result, args.output.json)
+}
+
+async fn txpool_command(args: TxpoolArgs) -> Result<()> {
+    let rpc = resolve_rpc(&args.rpc)?;
+    let result = rpc
+        .txpool_content()
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    print_output(&result, args.output.json)
+}
+
+fn resolve_block_tag(args: &BlockArgs) -> BlockTag {
+    if let Some(number) = args.number {
+        BlockTag::Number(number)
+    } else {
+        match args.tag {
+            BlockTagArg::Latest => BlockTag::Latest,
+            BlockTagArg::Pending => BlockTag::Pending,
+            BlockTagArg::Earliest => BlockTag::Earliest,
+        }
+    }
+}
+
+fn resolve_rpc(args: &RpcArgs) -> Result<RpcClient> {
+    let rpc_url = if let Some(rpc) = &args.rpc {
+        rpc.to_string()
+    } else if let Ok(value) = env::var("CITREA_RPC") {
+        value
+    } else if let Ok(value) = env::var("CITREA_RPC_URL") {
+        value
+    } else {
+        anyhow::bail!("RPC URL required. Use --rpc or set CITREA_RPC/CITREA_RPC_URL");
+    };
+
+    Ok(RpcClient::new(rpc_url))
+}
+
+fn resolve_secret_key(secret_hex: Option<String>, input: &KeyDerivationArgs) -> Result<[u8; 32]> {
+    if let Some(secret_hex) = secret_hex {
+        return parse_hex_bytes::<32>(&secret_hex).map_err(|e| anyhow::anyhow!(e.to_string()));
+    }
+
+    let mnemonic = resolve_mnemonic(&input.mnemonic)?;
+    let (account, _agent) = resolve_account(input.account, input.agent)?;
+    let keypair = derive_keypair_full(&mnemonic, &input.mnemonic.passphrase, account)
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    Ok(keypair.private_key)
+}
+
+fn resolve_mnemonic(input: &MnemonicInput) -> Result<String> {
+    if input.stdin {
+        return read_stdin_trimmed();
+    }
+    if let Some(mnemonic) = &input.mnemonic {
+        return Ok(normalize_mnemonic(mnemonic));
+    }
+    if let Some(path) = &input.mnemonic_file {
+        let contents = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read mnemonic file: {path:?}"))?;
+        let normalized = normalize_mnemonic(&contents);
+        if normalized.is_empty() {
+            anyhow::bail!("Mnemonic file is empty");
+        }
+        return Ok(normalized);
+    }
+    if let Ok(mnemonic) = env::var("CITREA_MNEMONIC") {
+        let normalized = normalize_mnemonic(&mnemonic);
+        if !normalized.is_empty() {
+            return Ok(normalized);
+        }
+    }
+    if let Ok(mnemonic) = env::var("OPENAGENTS_MNEMONIC") {
+        let normalized = normalize_mnemonic(&mnemonic);
+        if !normalized.is_empty() {
+            return Ok(normalized);
+        }
+    }
+
+    anyhow::bail!(
+        "Mnemonic required. Use --mnemonic, --mnemonic-file, --stdin, or set CITREA_MNEMONIC"
+    )
+}
+
+fn resolve_account(account: Option<u32>, agent: Option<u32>) -> Result<(u32, Option<u32>)> {
+    if let Some(agent_id) = agent {
+        let account = agent_id
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("Agent index overflow"))?;
+        return Ok((account, Some(agent_id)));
+    }
+
+    Ok((account.unwrap_or(0), None))
+}
+
+fn read_hash_input(
+    hash: Option<String>,
+    hash_file: Option<PathBuf>,
+    stdin: bool,
+) -> Result<[u8; 32]> {
+    let raw = if stdin {
+        read_stdin_raw()?
+    } else if let Some(path) = hash_file {
+        fs::read_to_string(path).context("Failed to read hash file")?
+    } else {
+        hash.unwrap_or_default()
+    };
+
+    if raw.trim().is_empty() {
+        anyhow::bail!("Hash is required (--hash, --hash-file, or --stdin)");
+    }
+
+    let normalized = normalize_hex_input(raw.trim());
+    let normalized = strip_0x(&normalized);
+    parse_hex_bytes::<32>(normalized).map_err(|e| anyhow::anyhow!(e.to_string()))
+}
+
+fn read_stdin_trimmed() -> Result<String> {
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer)?;
+    Ok(normalize_mnemonic(&buffer))
+}
+
+fn read_stdin_raw() -> Result<String> {
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer)?;
+    Ok(buffer)
+}
+
+fn normalize_mnemonic(input: &str) -> String {
+    input
+        .split_whitespace()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_hex_input(input: &str) -> String {
+    input.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+fn generate_mnemonic(words: u16) -> Result<String> {
+    let mut entropy = match words {
+        12 => [0u8; 16].to_vec(),
+        24 => [0u8; 32].to_vec(),
+        _ => return Err(anyhow::anyhow!("Invalid word count. Use 12 or 24.")),
+    };
+    rand::rng().fill_bytes(&mut entropy);
+    let mnemonic = Mnemonic::from_entropy(&entropy)
+        .map_err(|e| anyhow::anyhow!(format!("Mnemonic error: {e}")))?;
+    Ok(mnemonic.to_string())
+}
+
+fn ensure_hex_prefixed(value: &str) -> String {
+    if value.starts_with("0x") || value.starts_with("0X") {
+        value.to_string()
+    } else {
+        format!("0x{}", value)
+    }
+}
+
+fn print_output<T: Serialize>(value: &T, json: bool) -> Result<()> {
+    if json {
+        let output = serde_json::to_string_pretty(value)?;
+        println!("{output}");
+    } else {
+        print_human(value)?;
+    }
+    Ok(())
+}
+
+fn print_human<T: Serialize>(value: &T) -> Result<()> {
+    let json = serde_json::to_value(value)?;
+    match json {
+        serde_json::Value::Object(map) => {
+            for (key, value) in map {
+                let rendered = match value {
+                    serde_json::Value::String(s) => s,
+                    serde_json::Value::Null => continue,
+                    other => other.to_string(),
+                };
+                println!("{key}: {rendered}");
+            }
+        }
+        other => {
+            println!("{other}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sign_command() {
+        let args = CitreaArgs::try_parse_from([
+            "citrea",
+            "sign",
+            "--hash",
+            "0000000000000000000000000000000000000000000000000000000000000001",
+            "--secret-hex",
+            "0000000000000000000000000000000000000000000000000000000000000002",
+        ])
+        .expect("parse args");
+
+        match args.command {
+            CitreaCommand::Sign(sign) => {
+                assert!(sign.hash.is_some());
+                assert!(sign.secret_hex.is_some());
+            }
+            _ => panic!("expected sign command"),
+        }
+    }
+}

--- a/crates/openagents-cli/src/lib.rs
+++ b/crates/openagents-cli/src/lib.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 mod nostr_cli;
 mod spark_cli;
+mod citrea_cli;
 
 #[derive(Parser)]
 #[command(name = "openagents")]
@@ -17,6 +18,8 @@ pub enum Commands {
     Nostr(nostr_cli::NostrArgs),
     /// Spark wallet utilities (keys, payments, tokens)
     Spark(spark_cli::SparkArgs),
+    /// Citrea utilities (keys, signatures, RPC helpers)
+    Citrea(citrea_cli::CitreaArgs),
 }
 
 pub fn run() -> anyhow::Result<()> {
@@ -24,5 +27,6 @@ pub fn run() -> anyhow::Result<()> {
     match cli.command {
         Commands::Nostr(args) => nostr_cli::run(args),
         Commands::Spark(args) => spark_cli::run(args),
+        Commands::Citrea(args) => citrea_cli::run(args),
     }
 }


### PR DESCRIPTION
## Summary
- Adds a new `openagents-citrea` crate with Schnorr signing, NIP-06 derivation, address helpers, ERC20 calldata helpers, and a JSON-RPC client (eth_* + citrea_sendRawDepositTransaction + txpool_content).
- Wires a full `oa citrea` CLI into `openagents-cli`, mirroring Nostr/Spark conventions (offline key/sign/address + RPC helpers), with `--json` output and env fallbacks.
- Documents the integration status and next testing steps in `crates/citrea/docs/INTEGRATION_STATUS.md`.
- Adds unit tests for the new crate and a Clap parse test for the CLI.

## Testing
- `cargo test -p openagents-citrea`
- `cargo test -p openagents-cli`

## Notes
- RPC commands are implemented but not exercised against a live chain in tests.
- Local RPC stub tests and smart-account address derivation are called out as next steps in the doc.
