### PR TITLE
docs: add brand guidelines boilerplate

### DIFF
--- a/openagents/docs/brand.md
+++ b/openagents/docs/brand.md
@@ -1,0 +1,65 @@
+# Brand Guidelines
+
+> Placeholder document. Add voice, visual identity, and usage rules as you define them.
+
+---
+
+## 1) Overview
+
+- **Product / product line:** _e.g. Autopilot, OpenAgents_
+- **Tagline or one-liner:** _e.g. "Your machine. Your agent. Your sats."_
+- **Mission or promise in one sentence:** _e.g. "Turn your machine into a money printer."_
+
+---
+
+## 2) Voice and tone
+
+- **Voice attributes:** _e.g. Clear, direct, human, technical-but-accessible_
+- **We sound like:** _e.g. A capable teammate, not a corporation_
+- **We avoid:** _e.g. Jargon without explanation, hype, fake urgency_
+- **Example phrases / anti-patterns:** _Add do's and don'ts as you lock them in_
+
+---
+
+## 3) Visual identity
+
+### Logo
+
+- **Primary logo:** _Path or description, usage (light/dark), clear space_
+- **Lockups / wordmark:** _When to use which_
+- **Don’t:** _Stretch, recolor outside palette, add effects_
+
+### Color
+
+- **Primary palette:** _Hex / token names and usage_
+- **Secondary / accent:** _e.g. Bloomberg yellow, status colors_
+- **Backgrounds and surfaces:** _Reference theme tokens if applicable (e.g. `theme().colors`)_
+
+### Typography
+
+- **Primary typeface(s):** _e.g. UI font, marketing font_
+- **Scale:** _Reference design tokens if applicable (e.g. `theme::font_size`)_
+
+### Imagery and iconography
+
+- **Style:** _e.g. Line, filled, 24px grid_
+- **Icon set or source:** _If any_
+
+---
+
+## 4) Product UI (desktop)
+
+- **Design system:** _e.g. wgpui theme + component library; link to THEME.md or design docs_
+- **Key screens or flows:** _Link to MVP, panes, or UX specs as they exist_
+
+---
+
+## 5) Usage and governance
+
+- **Who approves:** _e.g. Design lead, product_
+- **Where assets live:** _e.g. Repo path, Figma, asset bucket_
+- **Changelog:** _Optional: date and short note when this doc was last updated_
+
+---
+
+_Last updated: YYYY-MM-DD (placeholder)._


### PR DESCRIPTION
Adds `docs/brand.md` as a placeholder for voice, visual identity, and usage rules. Expand as the brand is defined.