### PR TITLE
refactor(skills/blink): shared client module and code quality improvements (v0.6.0)

### DIFF
--- a/skills/blink/scripts/_blink_client.js
+++ b/skills/blink/scripts/_blink_client.js
@@ -1,0 +1,520 @@
+/**
+ * Blink Claw Skill — Shared Client Module
+ *
+ * Centralises API key resolution, GraphQL requests, WebSocket helpers,
+ * invoice normalisation, wallet resolution, and common arg-parsing logic
+ * used by every script in blink/scripts/.
+ *
+ * Zero external dependencies — Node.js 18+ built-ins only.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_API_URL = 'https://api.blink.sv/graphql';
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MUTATION_TIMEOUT_MS = 30_000;
+
+// ── Config helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Resolve the Blink API key from the environment or ~/.profile.
+ *
+ * @param {object}  [opts]
+ * @param {boolean} [opts.required=true]  Throw if the key is not found.
+ * @returns {string|null}
+ */
+function getApiKey({ required = true } = {}) {
+  let key = process.env.BLINK_API_KEY;
+  if (!key) {
+    try {
+      const profile = fs.readFileSync(path.join(os.homedir(), '.profile'), 'utf8');
+      const match = profile.match(/BLINK_API_KEY=["']?([a-zA-Z0-9_]+)["']?/);
+      if (match) key = match[1];
+    } catch {
+      // ~/.profile not readable — fall through
+    }
+  }
+  if (!key && required) {
+    throw new Error('BLINK_API_KEY not found. Set it in environment or ~/.profile');
+  }
+  return key || null;
+}
+
+/**
+ * Resolve the Blink GraphQL API URL.
+ * @returns {string}
+ */
+function getApiUrl() {
+  return process.env.BLINK_API_URL || DEFAULT_API_URL;
+}
+
+/**
+ * Resolve the Blink WebSocket URL.
+ * Prefers BLINK_WS_URL env override; otherwise derives from the API URL.
+ * @returns {string}
+ */
+function getWsUrl() {
+  if (process.env.BLINK_WS_URL) return process.env.BLINK_WS_URL;
+  const apiUrl = getApiUrl();
+  const url = new URL(apiUrl);
+  url.protocol = url.protocol === 'http:' ? 'ws:' : 'wss:';
+  if (url.hostname.startsWith('api.')) {
+    url.hostname = url.hostname.replace(/^api\./, 'ws.');
+  }
+  return url.toString();
+}
+
+// ── HTTP / GraphQL ───────────────────────────────────────────────────────────
+
+/**
+ * Execute a GraphQL request against the Blink API.
+ *
+ * @param {object}  opts
+ * @param {string}  opts.query          GraphQL query or mutation string.
+ * @param {object}  [opts.variables={}] GraphQL variables.
+ * @param {string|null} [opts.apiKey]   API key (null ⇒ unauthenticated).
+ * @param {string}  [opts.apiUrl]       API endpoint URL.
+ * @param {number}  [opts.timeoutMs]    Request timeout in ms (default 15 000).
+ * @returns {object} The `data` property of the GraphQL response.
+ */
+async function graphqlRequest({
+  query,
+  variables = {},
+  apiKey = null,
+  apiUrl = DEFAULT_API_URL,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) headers['X-API-KEY'] = apiKey;
+
+    const res = await fetch(apiUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query, variables }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+    }
+
+    const json = await res.json();
+    if (json.errors && json.errors.length > 0) {
+      throw new Error(`GraphQL error: ${json.errors.map((e) => e.message).join(', ')}`);
+    }
+    return json.data;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Invoice helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Trim whitespace and strip a leading `lightning:` URI prefix (case-insensitive).
+ * @param {string} input  Raw invoice / payment-request string.
+ * @returns {string}
+ */
+function normalizeInvoice(input) {
+  const trimmed = input.trim();
+  if (trimmed.toLowerCase().startsWith('lightning:')) {
+    return trimmed.slice('lightning:'.length);
+  }
+  return trimmed;
+}
+
+/**
+ * Emit a warning to stderr if the invoice doesn't look like a valid BOLT-11
+ * payment request. Checks are case-insensitive.
+ * @param {string} invoice  The (already-normalised) invoice string.
+ */
+function warnIfNotBolt11(invoice) {
+  const lower = invoice.toLowerCase();
+  if (!lower.startsWith('lnbc') && !lower.startsWith('lntbs') && !lower.startsWith('lntb')) {
+    console.error('Warning: invoice does not start with lnbc/lntbs/lntb \u2014 may not be a valid BOLT-11 invoice.');
+  }
+}
+
+// ── Wallet helpers ───────────────────────────────────────────────────────────
+
+const WALLET_QUERY = `
+  query Me {
+    me {
+      defaultAccount {
+        wallets {
+          id
+          walletCurrency
+          balance
+          pendingIncomingBalance
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Resolve a wallet by currency.
+ *
+ * @param {object}  opts
+ * @param {string}  opts.apiKey
+ * @param {string}  opts.apiUrl
+ * @param {string}  opts.currency       "BTC" or "USD".
+ * @param {number}  [opts.timeoutMs]
+ * @returns {{ id: string, walletCurrency: string, balance: number, pendingIncomingBalance: number }}
+ */
+async function getWallet({ apiKey, apiUrl, currency, timeoutMs }) {
+  const data = await graphqlRequest({ query: WALLET_QUERY, apiKey, apiUrl, timeoutMs });
+  if (!data.me) throw new Error('Authentication failed. Check your BLINK_API_KEY.');
+  const wallet = data.me.defaultAccount.wallets.find((w) => w.walletCurrency === currency);
+  if (!wallet) throw new Error(`No ${currency} wallet found on this account.`);
+  return wallet;
+}
+
+/**
+ * Resolve all wallets on the account.
+ *
+ * @param {object}  opts
+ * @param {string}  opts.apiKey
+ * @param {string}  opts.apiUrl
+ * @param {number}  [opts.timeoutMs]
+ * @returns {Array}
+ */
+async function getAllWallets({ apiKey, apiUrl, timeoutMs }) {
+  const data = await graphqlRequest({ query: WALLET_QUERY, apiKey, apiUrl, timeoutMs });
+  if (!data.me) throw new Error('Authentication failed. Check your BLINK_API_KEY.');
+  return data.me.defaultAccount.wallets;
+}
+
+// ── Currency conversion ──────────────────────────────────────────────────────
+
+const CONVERSION_QUERY = `
+  query CurrencyConversion($amount: Float!, $currency: DisplayCurrency!) {
+    currencyConversionEstimation(amount: $amount, currency: $currency) {
+      btcSatAmount
+      usdCentAmount
+    }
+  }
+`;
+
+/**
+ * Estimate the USD value of a satoshi amount.
+ * Non-fatal: returns null on failure so callers can treat it as best-effort.
+ *
+ * @param {object}  opts
+ * @param {number}  opts.sats
+ * @param {string}  opts.apiKey
+ * @param {string}  opts.apiUrl
+ * @param {number}  [opts.timeoutMs]
+ * @returns {number|null}  USD value rounded to 2 decimals, or null.
+ */
+async function estimateSatsToUsd({ sats, apiKey, apiUrl, timeoutMs }) {
+  if (sats === 0) return 0;
+  try {
+    const data = await graphqlRequest({
+      query: CONVERSION_QUERY,
+      variables: { amount: 1.0, currency: 'USD' },
+      apiKey,
+      apiUrl,
+      timeoutMs,
+    });
+    const est = data.currencyConversionEstimation;
+    if (!est || !est.btcSatAmount || est.btcSatAmount === 0) return null;
+    const usdPerSat = 1.0 / est.btcSatAmount;
+    return Math.round(sats * usdPerSat * 100) / 100;
+  } catch {
+    return null; // non-fatal — USD estimate is best-effort
+  }
+}
+
+// ── Formatting ───────────────────────────────────────────────────────────────
+
+/**
+ * Human-readable wallet balance string.
+ * @param {{ walletCurrency: string, balance: number }} wallet
+ * @returns {string}
+ */
+function formatBalance(wallet) {
+  if (wallet.walletCurrency === 'USD') {
+    return `$${(wallet.balance / 100).toFixed(2)} (${wallet.balance} cents)`;
+  }
+  return `${wallet.balance} sats`;
+}
+
+/**
+ * Format a cent amount as USD.
+ * @param {number} cents
+ * @returns {string}
+ */
+function formatUsdCents(cents) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+// ── Arg parsing helpers ──────────────────────────────────────────────────────
+
+/**
+ * Parse a --wallet BTC|USD flag from an argv array.
+ * Returns the chosen currency and the remaining args (without --wallet and its value).
+ *
+ * @param {string[]} argv  Typically `process.argv.slice(2)`.
+ * @returns {{ walletCurrency: string, remaining: string[] }}
+ */
+function parseWalletArg(argv) {
+  let walletCurrency = 'BTC';
+  const remaining = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--wallet' && i + 1 < argv.length) {
+      const val = argv[i + 1].toUpperCase();
+      if (val !== 'BTC' && val !== 'USD') {
+        console.error('Error: --wallet must be BTC or USD');
+        process.exit(1);
+      }
+      walletCurrency = val;
+      i++; // skip value
+    } else {
+      remaining.push(argv[i]);
+    }
+  }
+  return { walletCurrency, remaining };
+}
+
+// ── WebSocket helpers ────────────────────────────────────────────────────────
+
+/**
+ * Ensure WebSocket is available (Node 22+ built-in, or --experimental-websocket).
+ * @returns {typeof WebSocket}
+ */
+function requireWebSocket() {
+  if (typeof WebSocket !== 'function') {
+    throw new Error('WebSocket is not available. Run with: node --experimental-websocket <script> ...');
+  }
+  return WebSocket;
+}
+
+/**
+ * Open a WebSocket subscription to watch an invoice's payment status.
+ * Calls `onResult(resultObj, exitCode)` when the subscription resolves.
+ *
+ * @param {object}  opts
+ * @param {string}  opts.paymentRequest   BOLT-11 invoice string.
+ * @param {string}  opts.apiKey           Blink API key.
+ * @param {string}  opts.wsUrl            WebSocket endpoint URL.
+ * @param {number}  opts.timeoutSeconds   Timeout in seconds (0 = no timeout).
+ * @param {(result: object, exitCode: number) => void} opts.onResult  Callback.
+ */
+function subscribeToInvoice({ paymentRequest, apiKey, wsUrl, timeoutSeconds, onResult }) {
+  const WebSocketImpl = requireWebSocket();
+
+  let done = false;
+  let timeoutId = null;
+
+  const ws = new WebSocketImpl(wsUrl, 'graphql-transport-ws');
+
+  function finish(result, exitCode = 0) {
+    if (done) return;
+    done = true;
+    if (timeoutId) clearTimeout(timeoutId);
+    try {
+      if (ws.readyState === ws.OPEN) {
+        ws.send(JSON.stringify({ id: '1', type: 'complete' }));
+      }
+    } catch {
+      // best-effort cleanup
+    }
+    try {
+      ws.close(1000);
+    } catch {
+      // best-effort cleanup
+    }
+    onResult(result, exitCode);
+  }
+
+  if (timeoutSeconds > 0) {
+    timeoutId = setTimeout(() => {
+      console.error('Subscription timed out.');
+      finish(
+        {
+          event: 'subscription_result',
+          paymentRequest,
+          status: 'TIMEOUT',
+          isPaid: false,
+          isExpired: false,
+          isPending: true,
+        },
+        1,
+      );
+    }, timeoutSeconds * 1000);
+  }
+
+  ws.onopen = () => {
+    ws.send(
+      JSON.stringify({
+        type: 'connection_init',
+        payload: { 'X-API-KEY': apiKey },
+      }),
+    );
+  };
+
+  ws.onmessage = (event) => {
+    let message;
+    try {
+      message = JSON.parse(event.data);
+    } catch {
+      console.error('Warning: received non-JSON WebSocket message');
+      return;
+    }
+
+    if (message.type === 'connection_ack') {
+      console.error('Subscribed \u2014 waiting for payment...');
+      ws.send(
+        JSON.stringify({
+          id: '1',
+          type: 'subscribe',
+          payload: {
+            query: `subscription LnInvoicePaymentStatus($input: LnInvoicePaymentStatusInput!) {
+  lnInvoicePaymentStatus(input: $input) {
+    status
+  }
+}`,
+            variables: { input: { paymentRequest } },
+          },
+        }),
+      );
+      return;
+    }
+
+    if (message.type === 'ping') {
+      ws.send(JSON.stringify({ type: 'pong' }));
+      return;
+    }
+
+    if (message.type === 'error') {
+      console.error('Subscription error:', JSON.stringify(message.payload || message));
+      finish(
+        {
+          event: 'subscription_result',
+          paymentRequest,
+          status: 'ERROR',
+          error: message.payload || message,
+        },
+        1,
+      );
+      return;
+    }
+
+    if (message.type === 'next') {
+      const status =
+        message.payload && message.payload.data && message.payload.data.lnInvoicePaymentStatus
+          ? message.payload.data.lnInvoicePaymentStatus.status
+          : null;
+      if (!status) return;
+
+      console.error(`Invoice status: ${status}`);
+      if (status === 'PAID' || status === 'EXPIRED') {
+        finish(
+          {
+            event: 'subscription_result',
+            paymentRequest,
+            status,
+            isPaid: status === 'PAID',
+            isExpired: status === 'EXPIRED',
+            isPending: false,
+          },
+          0,
+        );
+      }
+      return;
+    }
+
+    if (message.type === 'complete') {
+      finish(
+        {
+          event: 'subscription_result',
+          paymentRequest,
+          status: 'COMPLETE',
+          isPaid: false,
+          isExpired: false,
+          isPending: true,
+        },
+        0,
+      );
+    }
+  };
+
+  ws.onerror = () => {
+    console.error('WebSocket error during subscription');
+    finish(
+      {
+        event: 'subscription_result',
+        paymentRequest,
+        status: 'ERROR',
+        error: 'WebSocket error',
+      },
+      1,
+    );
+  };
+
+  ws.onclose = (event) => {
+    if (done) return;
+    console.error(`WebSocket closed: code=${event.code} reason=${event.reason || 'unknown'}`);
+    finish(
+      {
+        event: 'subscription_result',
+        paymentRequest,
+        status: 'CLOSED',
+        isPaid: false,
+        isExpired: false,
+        isPending: true,
+      },
+      1,
+    );
+  };
+}
+
+// ── Exports ──────────────────────────────────────────────────────────────────
+
+module.exports = {
+  // Constants
+  DEFAULT_API_URL,
+  DEFAULT_TIMEOUT_MS,
+  MUTATION_TIMEOUT_MS,
+
+  // Config
+  getApiKey,
+  getApiUrl,
+  getWsUrl,
+
+  // HTTP
+  graphqlRequest,
+
+  // Invoice
+  normalizeInvoice,
+  warnIfNotBolt11,
+
+  // Wallet
+  WALLET_QUERY,
+  getWallet,
+  getAllWallets,
+
+  // Currency
+  CONVERSION_QUERY,
+  estimateSatsToUsd,
+
+  // Formatting
+  formatBalance,
+  formatUsdCents,
+
+  // Arg parsing
+  parseWalletArg,
+
+  // WebSocket
+  requireWebSocket,
+  subscribeToInvoice,
+};

--- a/skills/blink/scripts/balance.js
+++ b/skills/blink/scripts/balance.js
@@ -14,104 +14,16 @@
  * Dependencies: None (uses Node.js built-in fetch)
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const { getApiKey, getApiUrl, getAllWallets, estimateSatsToUsd } = require('./_blink_client');
 
-const DEFAULT_API_URL = 'https://api.blink.sv/graphql';
-
-function getApiKey() {
-  let key = process.env.BLINK_API_KEY;
-  if (!key) {
-    try {
-      const profile = fs.readFileSync(path.join(os.homedir(), '.profile'), 'utf8');
-      const match = profile.match(/BLINK_API_KEY=["']?([a-zA-Z0-9_]+)["']?/);
-      if (match) key = match[1];
-    } catch {}
-  }
-  if (!key) throw new Error('BLINK_API_KEY not found. Set it in environment or ~/.profile');
-  return key;
-}
-
-function getApiUrl() {
-  return process.env.BLINK_API_URL || DEFAULT_API_URL;
-}
-
-async function graphqlRequest(query, variables = {}) {
+async function main() {
   const apiKey = getApiKey();
   const apiUrl = getApiUrl();
 
-  const res = await fetch(apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-KEY': apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
+  const wallets = await getAllWallets({ apiKey, apiUrl });
 
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const json = await res.json();
-  if (json.errors && json.errors.length > 0) {
-    throw new Error(`GraphQL error: ${json.errors.map(e => e.message).join(', ')}`);
-  }
-  return json.data;
-}
-
-const BALANCE_QUERY = `
-  query Me {
-    me {
-      defaultAccount {
-        wallets {
-          id
-          walletCurrency
-          balance
-          pendingIncomingBalance
-        }
-      }
-    }
-  }
-`;
-
-// Public query — converts a fiat amount to sat/cent equivalents (no base/offset math)
-const CONVERSION_QUERY = `
-  query CurrencyConversion($amount: Float!, $currency: DisplayCurrency!) {
-    currencyConversionEstimation(amount: $amount, currency: $currency) {
-      btcSatAmount
-      usdCentAmount
-    }
-  }
-`;
-
-// Estimate USD value of a sat amount using currencyConversionEstimation.
-// Strategy: ask the API "how many sats is $1 USD worth?", then derive the rate.
-async function estimateSatsToUsd(sats) {
-  if (sats === 0) return 0;
-  try {
-    const data = await graphqlRequest(CONVERSION_QUERY, { amount: 1.0, currency: 'USD' });
-    const est = data.currencyConversionEstimation;
-    // est.btcSatAmount = how many sats $1.00 buys
-    if (!est || !est.btcSatAmount || est.btcSatAmount === 0) return null;
-    const usdPerSat = 1.0 / est.btcSatAmount;
-    return Math.round(sats * usdPerSat * 100) / 100;
-  } catch {
-    return null; // non-fatal — USD estimate is best-effort
-  }
-}
-
-async function main() {
-  const data = await graphqlRequest(BALANCE_QUERY);
-
-  if (!data.me) {
-    throw new Error('Authentication failed. Check your BLINK_API_KEY.');
-  }
-
-  const wallets = data.me.defaultAccount.wallets;
   const result = {
-    wallets: wallets.map(w => ({
+    wallets: wallets.map((w) => ({
       id: w.id,
       currency: w.walletCurrency,
       balance: w.balance,
@@ -121,15 +33,15 @@ async function main() {
   };
 
   // Add convenience top-level fields
-  const btc = wallets.find(w => w.walletCurrency === 'BTC');
-  const usd = wallets.find(w => w.walletCurrency === 'USD');
+  const btc = wallets.find((w) => w.walletCurrency === 'BTC');
+  const usd = wallets.find((w) => w.walletCurrency === 'USD');
   if (btc) {
     result.btcWalletId = btc.id;
     result.btcBalance = btc.balance;
     result.btcBalanceSats = btc.balance;
 
     // Pre-compute USD estimate so the agent doesn't have to do its own math
-    const usdEstimate = await estimateSatsToUsd(btc.balance);
+    const usdEstimate = await estimateSatsToUsd({ sats: btc.balance, apiKey, apiUrl });
     if (usdEstimate !== null) {
       result.btcBalanceUsd = usdEstimate;
       result.btcBalanceUsdFormatted = `$${usdEstimate.toFixed(2)}`;
@@ -145,7 +57,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Error:', e.message);
   process.exit(1);
 });

--- a/skills/blink/scripts/create_invoice.js
+++ b/skills/blink/scripts/create_invoice.js
@@ -28,62 +28,15 @@
  * Dependencies: None (uses Node.js built-in fetch and WebSocket)
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
-const DEFAULT_API_URL = 'https://api.blink.sv/graphql';
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-function getApiKey() {
-  let key = process.env.BLINK_API_KEY;
-  if (!key) {
-    try {
-      const profile = fs.readFileSync(path.join(os.homedir(), '.profile'), 'utf8');
-      const match = profile.match(/BLINK_API_KEY=["']?([a-zA-Z0-9_]+)["']?/);
-      if (match) key = match[1];
-    } catch {}
-  }
-  if (!key) throw new Error('BLINK_API_KEY not found. Set it in environment or ~/.profile');
-  return key;
-}
-
-function getApiUrl() {
-  return process.env.BLINK_API_URL || DEFAULT_API_URL;
-}
-
-function getWsUrl() {
-  const apiUrl = getApiUrl();
-  const url = new URL(apiUrl);
-  url.protocol = url.protocol === 'http:' ? 'ws:' : 'wss:';
-  if (url.hostname.startsWith('api.')) url.hostname = url.hostname.replace(/^api\./, 'ws.');
-  return url.toString();
-}
-
-async function graphqlRequest(query, variables = {}) {
-  const apiKey = getApiKey();
-  const apiUrl = getApiUrl();
-
-  const res = await fetch(apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-KEY': apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const json = await res.json();
-  if (json.errors && json.errors.length > 0) {
-    throw new Error(`GraphQL error: ${json.errors.map(e => e.message).join(', ')}`);
-  }
-  return json.data;
-}
+const {
+  getApiKey,
+  getApiUrl,
+  getWsUrl,
+  graphqlRequest,
+  getWallet,
+  subscribeToInvoice,
+  MUTATION_TIMEOUT_MS,
+} = require('./_blink_client');
 
 // ── Arg parsing ──────────────────────────────────────────────────────────────
 
@@ -131,19 +84,6 @@ function parseArgs(argv) {
 
 // ── GraphQL queries ──────────────────────────────────────────────────────────
 
-const WALLET_QUERY = `
-  query Me {
-    me {
-      defaultAccount {
-        wallets {
-          id
-          walletCurrency
-        }
-      }
-    }
-  }
-`;
-
 const CREATE_INVOICE_MUTATION = `
   mutation LnInvoiceCreate($input: LnInvoiceCreateInput!) {
     lnInvoiceCreate(input: $input) {
@@ -164,169 +104,6 @@ const CREATE_INVOICE_MUTATION = `
   }
 `;
 
-// ── Wallet resolution ────────────────────────────────────────────────────────
-
-async function getBtcWalletId() {
-  const data = await graphqlRequest(WALLET_QUERY);
-  if (!data.me) throw new Error('Authentication failed. Check your BLINK_API_KEY.');
-  const btcWallet = data.me.defaultAccount.wallets.find(w => w.walletCurrency === 'BTC');
-  if (!btcWallet) throw new Error('No BTC wallet found on this account.');
-  return btcWallet.id;
-}
-
-// ── WebSocket subscription ───────────────────────────────────────────────────
-
-function subscribeToInvoice(paymentRequest, timeoutSeconds) {
-  if (typeof WebSocket !== 'function') {
-    console.error('Warning: WebSocket not available, skipping auto-subscribe. Run with node --experimental-websocket for auto-subscribe.');
-    return;
-  }
-
-  const apiKey = getApiKey();
-  const wsUrl = getWsUrl();
-
-  let done = false;
-  let timeoutId = null;
-
-  const ws = new WebSocket(wsUrl, 'graphql-transport-ws');
-
-  function finish(result, exitCode = 0) {
-    if (done) return;
-    done = true;
-    if (timeoutId) clearTimeout(timeoutId);
-    try {
-      if (ws.readyState === ws.OPEN) {
-        ws.send(JSON.stringify({ id: '1', type: 'complete' }));
-      }
-    } catch {}
-    try {
-      ws.close(1000);
-    } catch {}
-    if (result) {
-      console.log(JSON.stringify(result, null, 2));
-    }
-    process.exit(exitCode);
-  }
-
-  if (timeoutSeconds > 0) {
-    timeoutId = setTimeout(() => {
-      console.error('Subscription timed out.');
-      finish({
-        event: 'subscription_result',
-        paymentRequest,
-        status: 'TIMEOUT',
-        isPaid: false,
-        isExpired: false,
-        isPending: true,
-      }, 1);
-    }, timeoutSeconds * 1000);
-  }
-
-  ws.onopen = () => {
-    ws.send(JSON.stringify({
-      type: 'connection_init',
-      payload: { 'X-API-KEY': apiKey },
-    }));
-  };
-
-  ws.onmessage = (event) => {
-    let message;
-    try {
-      message = JSON.parse(event.data);
-    } catch (e) {
-      console.error('Warning: received non-JSON WebSocket message');
-      return;
-    }
-
-    if (message.type === 'connection_ack') {
-      console.error('Subscribed — waiting for payment...');
-      ws.send(JSON.stringify({
-        id: '1',
-        type: 'subscribe',
-        payload: {
-          query: `subscription LnInvoicePaymentStatus($input: LnInvoicePaymentStatusInput!) {
-  lnInvoicePaymentStatus(input: $input) {
-    status
-  }
-}`,
-          variables: { input: { paymentRequest } },
-        },
-      }));
-      return;
-    }
-
-    if (message.type === 'ping') {
-      ws.send(JSON.stringify({ type: 'pong' }));
-      return;
-    }
-
-    if (message.type === 'error') {
-      console.error('Subscription error:', JSON.stringify(message.payload || message));
-      finish({
-        event: 'subscription_result',
-        paymentRequest,
-        status: 'ERROR',
-        error: message.payload || message,
-      }, 1);
-      return;
-    }
-
-    if (message.type === 'next') {
-      const status = message.payload && message.payload.data && message.payload.data.lnInvoicePaymentStatus
-        ? message.payload.data.lnInvoicePaymentStatus.status
-        : null;
-      if (!status) return;
-
-      console.error(`Invoice status: ${status}`);
-      if (status === 'PAID' || status === 'EXPIRED') {
-        finish({
-          event: 'subscription_result',
-          paymentRequest,
-          status,
-          isPaid: status === 'PAID',
-          isExpired: status === 'EXPIRED',
-          isPending: false,
-        }, 0);
-      }
-      return;
-    }
-
-    if (message.type === 'complete') {
-      finish({
-        event: 'subscription_result',
-        paymentRequest,
-        status: 'COMPLETE',
-        isPaid: false,
-        isExpired: false,
-        isPending: true,
-      }, 0);
-    }
-  };
-
-  ws.onerror = () => {
-    console.error('WebSocket error during subscription');
-    finish({
-      event: 'subscription_result',
-      paymentRequest,
-      status: 'ERROR',
-      error: 'WebSocket error',
-    }, 1);
-  };
-
-  ws.onclose = (event) => {
-    if (done) return;
-    console.error(`WebSocket closed: code=${event.code} reason=${event.reason || 'unknown'}`);
-    finish({
-      event: 'subscription_result',
-      paymentRequest,
-      status: 'CLOSED',
-      isPaid: false,
-      isExpired: false,
-      isPending: true,
-    }, 1);
-  };
-}
-
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -337,17 +114,27 @@ async function main() {
     process.exit(1);
   }
 
+  const apiKey = getApiKey();
+  const apiUrl = getApiUrl();
+
   // Auto-resolve BTC wallet ID
-  const walletId = await getBtcWalletId();
+  const wallet = await getWallet({ apiKey, apiUrl, currency: 'BTC' });
+  const walletId = wallet.id;
 
   const input = { walletId, amount: args.amountSats };
   if (args.memo) input.memo = args.memo;
 
-  const data = await graphqlRequest(CREATE_INVOICE_MUTATION, { input });
+  const data = await graphqlRequest({
+    query: CREATE_INVOICE_MUTATION,
+    variables: { input },
+    apiKey,
+    apiUrl,
+    timeoutMs: MUTATION_TIMEOUT_MS,
+  });
   const result = data.lnInvoiceCreate;
 
   if (result.errors && result.errors.length > 0) {
-    throw new Error(`Invoice creation failed: ${result.errors.map(e => e.message).join(', ')}`);
+    throw new Error(`Invoice creation failed: ${result.errors.map((e) => e.message).join(', ')}`);
   }
 
   if (!result.invoice) {
@@ -373,11 +160,28 @@ async function main() {
     process.exit(0);
   }
 
+  // Graceful fallback when WebSocket is not available
+  if (typeof WebSocket !== 'function') {
+    console.error(
+      'Warning: WebSocket not available, skipping auto-subscribe. Run with node --experimental-websocket for auto-subscribe.',
+    );
+    return;
+  }
+
   console.error(`Auto-subscribing to invoice payment status (timeout: ${args.timeoutSeconds}s)...`);
-  subscribeToInvoice(result.invoice.paymentRequest, args.timeoutSeconds);
+  subscribeToInvoice({
+    paymentRequest: result.invoice.paymentRequest,
+    apiKey,
+    wsUrl: getWsUrl(),
+    timeoutSeconds: args.timeoutSeconds,
+    onResult(resultObj, exitCode) {
+      console.log(JSON.stringify(resultObj, null, 2));
+      process.exit(exitCode);
+    },
+  });
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Error:', e.message);
   process.exit(1);
 });

--- a/skills/blink/scripts/create_invoice_usd.js
+++ b/skills/blink/scripts/create_invoice_usd.js
@@ -33,62 +33,15 @@
  * Dependencies: None (uses Node.js built-in fetch and WebSocket)
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
-const DEFAULT_API_URL = 'https://api.blink.sv/graphql';
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-function getApiKey() {
-  let key = process.env.BLINK_API_KEY;
-  if (!key) {
-    try {
-      const profile = fs.readFileSync(path.join(os.homedir(), '.profile'), 'utf8');
-      const match = profile.match(/BLINK_API_KEY=["']?([a-zA-Z0-9_]+)["']?/);
-      if (match) key = match[1];
-    } catch {}
-  }
-  if (!key) throw new Error('BLINK_API_KEY not found. Set it in environment or ~/.profile');
-  return key;
-}
-
-function getApiUrl() {
-  return process.env.BLINK_API_URL || DEFAULT_API_URL;
-}
-
-function getWsUrl() {
-  const apiUrl = getApiUrl();
-  const url = new URL(apiUrl);
-  url.protocol = url.protocol === 'http:' ? 'ws:' : 'wss:';
-  if (url.hostname.startsWith('api.')) url.hostname = url.hostname.replace(/^api\./, 'ws.');
-  return url.toString();
-}
-
-async function graphqlRequest(query, variables = {}) {
-  const apiKey = getApiKey();
-  const apiUrl = getApiUrl();
-
-  const res = await fetch(apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-KEY': apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const json = await res.json();
-  if (json.errors && json.errors.length > 0) {
-    throw new Error(`GraphQL error: ${json.errors.map(e => e.message).join(', ')}`);
-  }
-  return json.data;
-}
+const {
+  getApiKey,
+  getApiUrl,
+  getWsUrl,
+  graphqlRequest,
+  getWallet,
+  subscribeToInvoice,
+  MUTATION_TIMEOUT_MS,
+} = require('./_blink_client');
 
 // ── Arg parsing ──────────────────────────────────────────────────────────────
 
@@ -136,19 +89,6 @@ function parseArgs(argv) {
 
 // ── GraphQL queries ──────────────────────────────────────────────────────────
 
-const WALLET_QUERY = `
-  query Me {
-    me {
-      defaultAccount {
-        wallets {
-          id
-          walletCurrency
-        }
-      }
-    }
-  }
-`;
-
 const CREATE_USD_INVOICE_MUTATION = `
   mutation LnUsdInvoiceCreate($input: LnUsdInvoiceCreateInput!) {
     lnUsdInvoiceCreate(input: $input) {
@@ -169,169 +109,6 @@ const CREATE_USD_INVOICE_MUTATION = `
   }
 `;
 
-// ── Wallet resolution ────────────────────────────────────────────────────────
-
-async function getUsdWalletId() {
-  const data = await graphqlRequest(WALLET_QUERY);
-  if (!data.me) throw new Error('Authentication failed. Check your BLINK_API_KEY.');
-  const usdWallet = data.me.defaultAccount.wallets.find(w => w.walletCurrency === 'USD');
-  if (!usdWallet) throw new Error('No USD wallet found on this account.');
-  return usdWallet.id;
-}
-
-// ── WebSocket subscription ───────────────────────────────────────────────────
-
-function subscribeToInvoice(paymentRequest, timeoutSeconds) {
-  if (typeof WebSocket !== 'function') {
-    console.error('Warning: WebSocket not available, skipping auto-subscribe. Run with node --experimental-websocket for auto-subscribe.');
-    return;
-  }
-
-  const apiKey = getApiKey();
-  const wsUrl = getWsUrl();
-
-  let done = false;
-  let timeoutId = null;
-
-  const ws = new WebSocket(wsUrl, 'graphql-transport-ws');
-
-  function finish(result, exitCode = 0) {
-    if (done) return;
-    done = true;
-    if (timeoutId) clearTimeout(timeoutId);
-    try {
-      if (ws.readyState === ws.OPEN) {
-        ws.send(JSON.stringify({ id: '1', type: 'complete' }));
-      }
-    } catch {}
-    try {
-      ws.close(1000);
-    } catch {}
-    if (result) {
-      console.log(JSON.stringify(result, null, 2));
-    }
-    process.exit(exitCode);
-  }
-
-  if (timeoutSeconds > 0) {
-    timeoutId = setTimeout(() => {
-      console.error('Subscription timed out.');
-      finish({
-        event: 'subscription_result',
-        paymentRequest,
-        status: 'TIMEOUT',
-        isPaid: false,
-        isExpired: false,
-        isPending: true,
-      }, 1);
-    }, timeoutSeconds * 1000);
-  }
-
-  ws.onopen = () => {
-    ws.send(JSON.stringify({
-      type: 'connection_init',
-      payload: { 'X-API-KEY': apiKey },
-    }));
-  };
-
-  ws.onmessage = (event) => {
-    let message;
-    try {
-      message = JSON.parse(event.data);
-    } catch (e) {
-      console.error('Warning: received non-JSON WebSocket message');
-      return;
-    }
-
-    if (message.type === 'connection_ack') {
-      console.error('Subscribed — waiting for payment...');
-      ws.send(JSON.stringify({
-        id: '1',
-        type: 'subscribe',
-        payload: {
-          query: `subscription LnInvoicePaymentStatus($input: LnInvoicePaymentStatusInput!) {
-  lnInvoicePaymentStatus(input: $input) {
-    status
-  }
-}`,
-          variables: { input: { paymentRequest } },
-        },
-      }));
-      return;
-    }
-
-    if (message.type === 'ping') {
-      ws.send(JSON.stringify({ type: 'pong' }));
-      return;
-    }
-
-    if (message.type === 'error') {
-      console.error('Subscription error:', JSON.stringify(message.payload || message));
-      finish({
-        event: 'subscription_result',
-        paymentRequest,
-        status: 'ERROR',
-        error: message.payload || message,
-      }, 1);
-      return;
-    }
-
-    if (message.type === 'next') {
-      const status = message.payload && message.payload.data && message.payload.data.lnInvoicePaymentStatus
-        ? message.payload.data.lnInvoicePaymentStatus.status
-        : null;
-      if (!status) return;
-
-      console.error(`Invoice status: ${status}`);
-      if (status === 'PAID' || status === 'EXPIRED') {
-        finish({
-          event: 'subscription_result',
-          paymentRequest,
-          status,
-          isPaid: status === 'PAID',
-          isExpired: status === 'EXPIRED',
-          isPending: false,
-        }, 0);
-      }
-      return;
-    }
-
-    if (message.type === 'complete') {
-      finish({
-        event: 'subscription_result',
-        paymentRequest,
-        status: 'COMPLETE',
-        isPaid: false,
-        isExpired: false,
-        isPending: true,
-      }, 0);
-    }
-  };
-
-  ws.onerror = () => {
-    console.error('WebSocket error during subscription');
-    finish({
-      event: 'subscription_result',
-      paymentRequest,
-      status: 'ERROR',
-      error: 'WebSocket error',
-    }, 1);
-  };
-
-  ws.onclose = (event) => {
-    if (done) return;
-    console.error(`WebSocket closed: code=${event.code} reason=${event.reason || 'unknown'}`);
-    finish({
-      event: 'subscription_result',
-      paymentRequest,
-      status: 'CLOSED',
-      isPaid: false,
-      isExpired: false,
-      isPending: true,
-    }, 1);
-  };
-}
-
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -343,17 +120,27 @@ async function main() {
     process.exit(1);
   }
 
+  const apiKey = getApiKey();
+  const apiUrl = getApiUrl();
+
   // Auto-resolve USD wallet ID
-  const walletId = await getUsdWalletId();
+  const wallet = await getWallet({ apiKey, apiUrl, currency: 'USD' });
+  const walletId = wallet.id;
 
   const input = { walletId, amount: args.amountCents };
   if (args.memo) input.memo = args.memo;
 
-  const data = await graphqlRequest(CREATE_USD_INVOICE_MUTATION, { input });
+  const data = await graphqlRequest({
+    query: CREATE_USD_INVOICE_MUTATION,
+    variables: { input },
+    apiKey,
+    apiUrl,
+    timeoutMs: MUTATION_TIMEOUT_MS,
+  });
   const result = data.lnUsdInvoiceCreate;
 
   if (result.errors && result.errors.length > 0) {
-    throw new Error(`Invoice creation failed: ${result.errors.map(e => e.message).join(', ')}`);
+    throw new Error(`Invoice creation failed: ${result.errors.map((e) => e.message).join(', ')}`);
   }
 
   if (!result.invoice) {
@@ -386,11 +173,28 @@ async function main() {
     process.exit(0);
   }
 
+  // Graceful fallback when WebSocket is not available
+  if (typeof WebSocket !== 'function') {
+    console.error(
+      'Warning: WebSocket not available, skipping auto-subscribe. Run with node --experimental-websocket for auto-subscribe.',
+    );
+    return;
+  }
+
   console.error(`Auto-subscribing to invoice payment status (timeout: ${args.timeoutSeconds}s)...`);
-  subscribeToInvoice(result.invoice.paymentRequest, args.timeoutSeconds);
+  subscribeToInvoice({
+    paymentRequest: result.invoice.paymentRequest,
+    apiKey,
+    wsUrl: getWsUrl(),
+    timeoutSeconds: args.timeoutSeconds,
+    onResult(resultObj, exitCode) {
+      console.log(JSON.stringify(resultObj, null, 2));
+      process.exit(exitCode);
+    },
+  });
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Error:', e.message);
   process.exit(1);
 });

--- a/skills/blink/scripts/fee_probe.js
+++ b/skills/blink/scripts/fee_probe.js
@@ -21,66 +21,16 @@
  * Dependencies: None (uses Node.js built-in fetch)
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
-const DEFAULT_API_URL = 'https://api.blink.sv/graphql';
-
-function getApiKey() {
-  let key = process.env.BLINK_API_KEY;
-  if (!key) {
-    try {
-      const profile = fs.readFileSync(path.join(os.homedir(), '.profile'), 'utf8');
-      const match = profile.match(/BLINK_API_KEY=["']?([a-zA-Z0-9_]+)["']?/);
-      if (match) key = match[1];
-    } catch {}
-  }
-  if (!key) throw new Error('BLINK_API_KEY not found. Set it in environment or ~/.profile');
-  return key;
-}
-
-function getApiUrl() {
-  return process.env.BLINK_API_URL || DEFAULT_API_URL;
-}
-
-async function graphqlRequest(query, variables = {}) {
-  const apiKey = getApiKey();
-  const apiUrl = getApiUrl();
-
-  const res = await fetch(apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-KEY': apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const json = await res.json();
-  if (json.errors && json.errors.length > 0) {
-    throw new Error(`GraphQL error: ${json.errors.map(e => e.message).join(', ')}`);
-  }
-  return json.data;
-}
-
-const WALLET_QUERY = `
-  query Me {
-    me {
-      defaultAccount {
-        wallets {
-          id
-          walletCurrency
-          balance
-        }
-      }
-    }
-  }
-`;
+const {
+  getApiKey,
+  getApiUrl,
+  graphqlRequest,
+  getWallet,
+  parseWalletArg,
+  normalizeInvoice,
+  warnIfNotBolt11,
+  MUTATION_TIMEOUT_MS,
+} = require('./_blink_client');
 
 const FEE_PROBE_BTC_MUTATION = `
   mutation LnInvoiceFeeProbe($input: LnInvoiceFeeProbeInput!) {
@@ -108,53 +58,22 @@ const FEE_PROBE_USD_MUTATION = `
   }
 `;
 
-async function getWallet(currency) {
-  const data = await graphqlRequest(WALLET_QUERY);
-  if (!data.me) throw new Error('Authentication failed. Check your BLINK_API_KEY.');
-  const wallet = data.me.defaultAccount.wallets.find(w => w.walletCurrency === currency);
-  if (!wallet) throw new Error(`No ${currency} wallet found on this account.`);
-  return wallet;
-}
-
-function formatBalance(wallet) {
-  if (wallet.walletCurrency === 'USD') {
-    return `$${(wallet.balance / 100).toFixed(2)} (${wallet.balance} cents)`;
-  }
-  return `${wallet.balance} sats`;
-}
-
-function parseArgs(argv) {
-  const args = { paymentRequest: null, walletCurrency: 'BTC' };
-  const raw = argv.slice(2);
-  for (let i = 0; i < raw.length; i++) {
-    if (raw[i] === '--wallet' && i + 1 < raw.length) {
-      const val = raw[i + 1].toUpperCase();
-      if (val !== 'BTC' && val !== 'USD') {
-        console.error('Error: --wallet must be BTC or USD');
-        process.exit(1);
-      }
-      args.walletCurrency = val;
-      i++;
-    } else if (!args.paymentRequest) {
-      args.paymentRequest = raw[i].trim();
-    }
-  }
-  return args;
-}
-
 async function main() {
-  const args = parseArgs(process.argv);
-  if (!args.paymentRequest) {
+  const { walletCurrency, remaining } = parseWalletArg(process.argv.slice(2));
+  const rawInvoice = remaining[0];
+
+  if (!rawInvoice) {
     console.error('Usage: node fee_probe.js <bolt11_invoice> [--wallet BTC|USD]');
     process.exit(1);
   }
 
-  const paymentRequest = args.paymentRequest;
-  if (!paymentRequest.startsWith('lnbc') && !paymentRequest.startsWith('lntbs') && !paymentRequest.startsWith('lntb')) {
-    console.error('Warning: invoice does not start with lnbc/lntbs/lntb \u2014 may not be a valid BOLT-11 invoice.');
-  }
+  const paymentRequest = normalizeInvoice(rawInvoice);
+  warnIfNotBolt11(paymentRequest);
 
-  const wallet = await getWallet(args.walletCurrency);
+  const apiKey = getApiKey();
+  const apiUrl = getApiUrl();
+
+  const wallet = await getWallet({ apiKey, apiUrl, currency: walletCurrency });
 
   const input = {
     walletId: wallet.id,
@@ -162,25 +81,31 @@ async function main() {
   };
 
   // Use the appropriate fee probe mutation based on wallet currency
-  const mutation = args.walletCurrency === 'USD' ? FEE_PROBE_USD_MUTATION : FEE_PROBE_BTC_MUTATION;
-  const mutationKey = args.walletCurrency === 'USD' ? 'lnUsdInvoiceFeeProbe' : 'lnInvoiceFeeProbe';
+  const mutation = walletCurrency === 'USD' ? FEE_PROBE_USD_MUTATION : FEE_PROBE_BTC_MUTATION;
+  const mutationKey = walletCurrency === 'USD' ? 'lnUsdInvoiceFeeProbe' : 'lnInvoiceFeeProbe';
 
-  const data = await graphqlRequest(mutation, { input });
+  const data = await graphqlRequest({
+    query: mutation,
+    variables: { input },
+    apiKey,
+    apiUrl,
+    timeoutMs: MUTATION_TIMEOUT_MS,
+  });
   const result = data[mutationKey];
 
   if (result.errors && result.errors.length > 0) {
-    const errMsg = result.errors.map(e => `${e.message}${e.code ? ` [${e.code}]` : ''}`).join(', ');
+    const errMsg = result.errors.map((e) => `${e.message}${e.code ? ` [${e.code}]` : ''}`).join(', ');
     throw new Error(`Fee probe failed: ${errMsg}`);
   }
 
   const output = {
     estimatedFeeSats: result.amount,
     walletId: wallet.id,
-    walletCurrency: args.walletCurrency,
+    walletCurrency,
     walletBalance: wallet.balance,
   };
 
-  if (args.walletCurrency === 'USD') {
+  if (walletCurrency === 'USD') {
     output.walletBalanceFormatted = `$${(wallet.balance / 100).toFixed(2)}`;
   }
 
@@ -193,7 +118,7 @@ async function main() {
   console.log(JSON.stringify(output, null, 2));
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Error:', e.message);
   process.exit(1);
 });

--- a/skills/blink/scripts/pay_invoice.js
+++ b/skills/blink/scripts/pay_invoice.js
@@ -20,66 +20,17 @@
  * CAUTION: This sends real bitcoin. The API key must have Write scope.
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
-const DEFAULT_API_URL = 'https://api.blink.sv/graphql';
-
-function getApiKey() {
-  let key = process.env.BLINK_API_KEY;
-  if (!key) {
-    try {
-      const profile = fs.readFileSync(path.join(os.homedir(), '.profile'), 'utf8');
-      const match = profile.match(/BLINK_API_KEY=["']?([a-zA-Z0-9_]+)["']?/);
-      if (match) key = match[1];
-    } catch {}
-  }
-  if (!key) throw new Error('BLINK_API_KEY not found. Set it in environment or ~/.profile');
-  return key;
-}
-
-function getApiUrl() {
-  return process.env.BLINK_API_URL || DEFAULT_API_URL;
-}
-
-async function graphqlRequest(query, variables = {}) {
-  const apiKey = getApiKey();
-  const apiUrl = getApiUrl();
-
-  const res = await fetch(apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-KEY': apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const json = await res.json();
-  if (json.errors && json.errors.length > 0) {
-    throw new Error(`GraphQL error: ${json.errors.map(e => e.message).join(', ')}`);
-  }
-  return json.data;
-}
-
-const WALLET_QUERY = `
-  query Me {
-    me {
-      defaultAccount {
-        wallets {
-          id
-          walletCurrency
-          balance
-        }
-      }
-    }
-  }
-`;
+const {
+  getApiKey,
+  getApiUrl,
+  graphqlRequest,
+  getWallet,
+  formatBalance,
+  parseWalletArg,
+  normalizeInvoice,
+  warnIfNotBolt11,
+  MUTATION_TIMEOUT_MS,
+} = require('./_blink_client');
 
 const PAY_INVOICE_MUTATION = `
   mutation LnInvoicePaymentSend($input: LnInvoicePaymentInput!) {
@@ -94,78 +45,53 @@ const PAY_INVOICE_MUTATION = `
   }
 `;
 
-async function getWallet(currency) {
-  const data = await graphqlRequest(WALLET_QUERY);
-  if (!data.me) throw new Error('Authentication failed. Check your BLINK_API_KEY.');
-  const wallet = data.me.defaultAccount.wallets.find(w => w.walletCurrency === currency);
-  if (!wallet) throw new Error(`No ${currency} wallet found on this account.`);
-  return wallet;
-}
-
-function formatBalance(wallet) {
-  if (wallet.walletCurrency === 'USD') {
-    return `$${(wallet.balance / 100).toFixed(2)} (${wallet.balance} cents)`;
-  }
-  return `${wallet.balance} sats`;
-}
-
-function parseArgs(argv) {
-  const args = { paymentRequest: null, walletCurrency: 'BTC' };
-  const raw = argv.slice(2);
-  for (let i = 0; i < raw.length; i++) {
-    if (raw[i] === '--wallet' && i + 1 < raw.length) {
-      const val = raw[i + 1].toUpperCase();
-      if (val !== 'BTC' && val !== 'USD') {
-        console.error('Error: --wallet must be BTC or USD');
-        process.exit(1);
-      }
-      args.walletCurrency = val;
-      i++;
-    } else if (!args.paymentRequest) {
-      args.paymentRequest = raw[i].trim();
-    }
-  }
-  return args;
-}
-
 async function main() {
-  const args = parseArgs(process.argv);
-  if (!args.paymentRequest) {
+  const { walletCurrency, remaining } = parseWalletArg(process.argv.slice(2));
+  const rawInvoice = remaining[0];
+
+  if (!rawInvoice) {
     console.error('Usage: node pay_invoice.js <bolt11_invoice> [--wallet BTC|USD]');
     process.exit(1);
   }
 
-  const paymentRequest = args.paymentRequest;
-  if (!paymentRequest.startsWith('lnbc') && !paymentRequest.startsWith('lntbs') && !paymentRequest.startsWith('lntb')) {
-    console.error('Warning: invoice does not start with lnbc/lntbs/lntb \u2014 may not be a valid BOLT-11 invoice.');
-  }
+  const paymentRequest = normalizeInvoice(rawInvoice);
+  warnIfNotBolt11(paymentRequest);
+
+  const apiKey = getApiKey();
+  const apiUrl = getApiUrl();
 
   // Resolve wallet (BTC or USD)
-  const wallet = await getWallet(args.walletCurrency);
+  const wallet = await getWallet({ apiKey, apiUrl, currency: walletCurrency });
 
-  console.error(`Using ${args.walletCurrency} wallet ${wallet.id} (balance: ${formatBalance(wallet)})`);
+  console.error(`Using ${walletCurrency} wallet ${wallet.id} (balance: ${formatBalance(wallet)})`);
 
   const input = {
     walletId: wallet.id,
     paymentRequest,
   };
 
-  const data = await graphqlRequest(PAY_INVOICE_MUTATION, { input });
+  const data = await graphqlRequest({
+    query: PAY_INVOICE_MUTATION,
+    variables: { input },
+    apiKey,
+    apiUrl,
+    timeoutMs: MUTATION_TIMEOUT_MS,
+  });
   const result = data.lnInvoicePaymentSend;
 
   if (result.errors && result.errors.length > 0) {
-    const errMsg = result.errors.map(e => `${e.message}${e.code ? ` [${e.code}]` : ''}`).join(', ');
+    const errMsg = result.errors.map((e) => `${e.message}${e.code ? ` [${e.code}]` : ''}`).join(', ');
     throw new Error(`Payment failed: ${errMsg}`);
   }
 
   const output = {
     status: result.status,
     walletId: wallet.id,
-    walletCurrency: args.walletCurrency,
+    walletCurrency,
     balanceBefore: wallet.balance,
   };
 
-  if (args.walletCurrency === 'USD') {
+  if (walletCurrency === 'USD') {
     output.balanceBeforeFormatted = `$${(wallet.balance / 100).toFixed(2)}`;
   }
 
@@ -182,7 +108,7 @@ async function main() {
   console.log(JSON.stringify(output, null, 2));
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Error:', e.message);
   process.exit(1);
 });

--- a/skills/blink/scripts/pay_lnaddress.js
+++ b/skills/blink/scripts/pay_lnaddress.js
@@ -24,66 +24,15 @@
  * CAUTION: This sends real bitcoin. The API key must have Write scope.
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
-const DEFAULT_API_URL = 'https://api.blink.sv/graphql';
-
-function getApiKey() {
-  let key = process.env.BLINK_API_KEY;
-  if (!key) {
-    try {
-      const profile = fs.readFileSync(path.join(os.homedir(), '.profile'), 'utf8');
-      const match = profile.match(/BLINK_API_KEY=["']?([a-zA-Z0-9_]+)["']?/);
-      if (match) key = match[1];
-    } catch {}
-  }
-  if (!key) throw new Error('BLINK_API_KEY not found. Set it in environment or ~/.profile');
-  return key;
-}
-
-function getApiUrl() {
-  return process.env.BLINK_API_URL || DEFAULT_API_URL;
-}
-
-async function graphqlRequest(query, variables = {}) {
-  const apiKey = getApiKey();
-  const apiUrl = getApiUrl();
-
-  const res = await fetch(apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-KEY': apiKey,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const json = await res.json();
-  if (json.errors && json.errors.length > 0) {
-    throw new Error(`GraphQL error: ${json.errors.map(e => e.message).join(', ')}`);
-  }
-  return json.data;
-}
-
-const WALLET_QUERY = `
-  query Me {
-    me {
-      defaultAccount {
-        wallets {
-          id
-          walletCurrency
-          balance
-        }
-      }
-    }
-  }
-`;
+const {
+  getApiKey,
+  getApiUrl,
+  graphqlRequest,
+  getWallet,
+  formatBalance,
+  parseWalletArg,
+  MUTATION_TIMEOUT_MS,
+} = require('./_blink_client');
 
 const PAY_LN_ADDRESS_MUTATION = `
   mutation LnAddressPaymentSend($input: LnAddressPaymentSendInput!) {
@@ -98,52 +47,15 @@ const PAY_LN_ADDRESS_MUTATION = `
   }
 `;
 
-async function getWallet(currency) {
-  const data = await graphqlRequest(WALLET_QUERY);
-  if (!data.me) throw new Error('Authentication failed. Check your BLINK_API_KEY.');
-  const wallet = data.me.defaultAccount.wallets.find(w => w.walletCurrency === currency);
-  if (!wallet) throw new Error(`No ${currency} wallet found on this account.`);
-  return wallet;
-}
-
-function formatBalance(wallet) {
-  if (wallet.walletCurrency === 'USD') {
-    return `$${(wallet.balance / 100).toFixed(2)} (${wallet.balance} cents)`;
-  }
-  return `${wallet.balance} sats`;
-}
-
-function parseArgs(argv) {
-  const args = { lnAddress: null, amountSats: null, walletCurrency: 'BTC' };
-  const raw = argv.slice(2);
-  const positional = [];
-  for (let i = 0; i < raw.length; i++) {
-    if (raw[i] === '--wallet' && i + 1 < raw.length) {
-      const val = raw[i + 1].toUpperCase();
-      if (val !== 'BTC' && val !== 'USD') {
-        console.error('Error: --wallet must be BTC or USD');
-        process.exit(1);
-      }
-      args.walletCurrency = val;
-      i++;
-    } else {
-      positional.push(raw[i]);
-    }
-  }
-  if (positional.length >= 1) args.lnAddress = positional[0].trim();
-  if (positional.length >= 2) args.amountSats = parseInt(positional[1], 10);
-  return args;
-}
-
 async function main() {
-  const args = parseArgs(process.argv);
-  if (!args.lnAddress || args.amountSats === null) {
+  const { walletCurrency, remaining } = parseWalletArg(process.argv.slice(2));
+  const lnAddress = remaining[0] ? remaining[0].trim() : null;
+  const amountSats = remaining[1] ? parseInt(remaining[1], 10) : null;
+
+  if (!lnAddress || amountSats === null) {
     console.error('Usage: node pay_lnaddress.js <lightning_address> <amount_sats> [--wallet BTC|USD]');
     process.exit(1);
   }
-
-  const lnAddress = args.lnAddress;
-  const amountSats = args.amountSats;
 
   // Basic Lightning Address validation (user@domain)
   if (!lnAddress.includes('@') || lnAddress.startsWith('@') || lnAddress.endsWith('@')) {
@@ -156,16 +68,23 @@ async function main() {
     process.exit(1);
   }
 
+  const apiKey = getApiKey();
+  const apiUrl = getApiUrl();
+
   // Resolve wallet (BTC or USD)
-  const wallet = await getWallet(args.walletCurrency);
+  const wallet = await getWallet({ apiKey, apiUrl, currency: walletCurrency });
 
   // Balance warning (BTC balance is in sats, directly comparable; USD balance
   // is in cents, not directly comparable to sats — skip for USD)
-  if (args.walletCurrency === 'BTC' && wallet.balance < amountSats) {
-    console.error(`Warning: wallet balance (${wallet.balance} sats) may be insufficient for ${amountSats} sats + fees.`);
+  if (walletCurrency === 'BTC' && wallet.balance < amountSats) {
+    console.error(
+      `Warning: wallet balance (${wallet.balance} sats) may be insufficient for ${amountSats} sats + fees.`,
+    );
   }
 
-  console.error(`Sending ${amountSats} sats to ${lnAddress} from ${args.walletCurrency} wallet ${wallet.id} (balance: ${formatBalance(wallet)})`);
+  console.error(
+    `Sending ${amountSats} sats to ${lnAddress} from ${walletCurrency} wallet ${wallet.id} (balance: ${formatBalance(wallet)})`,
+  );
 
   const input = {
     walletId: wallet.id,
@@ -173,11 +92,17 @@ async function main() {
     amount: amountSats,
   };
 
-  const data = await graphqlRequest(PAY_LN_ADDRESS_MUTATION, { input });
+  const data = await graphqlRequest({
+    query: PAY_LN_ADDRESS_MUTATION,
+    variables: { input },
+    apiKey,
+    apiUrl,
+    timeoutMs: MUTATION_TIMEOUT_MS,
+  });
   const result = data.lnAddressPaymentSend;
 
   if (result.errors && result.errors.length > 0) {
-    const errMsg = result.errors.map(e => `${e.message}${e.code ? ` [${e.code}]` : ''}`).join(', ');
+    const errMsg = result.errors.map((e) => `${e.message}${e.code ? ` [${e.code}]` : ''}`).join(', ');
     throw new Error(`Payment failed: ${errMsg}`);
   }
 
@@ -186,11 +111,11 @@ async function main() {
     lnAddress,
     amountSats,
     walletId: wallet.id,
-    walletCurrency: args.walletCurrency,
+    walletCurrency,
     balanceBefore: wallet.balance,
   };
 
-  if (args.walletCurrency === 'USD') {
+  if (walletCurrency === 'USD') {
     output.balanceBeforeFormatted = `$${(wallet.balance / 100).toFixed(2)}`;
   }
 
@@ -205,7 +130,7 @@ async function main() {
   console.log(JSON.stringify(output, null, 2));
 }
 
-main().catch(e => {
+main().catch((e) => {
   console.error('Error:', e.message);
   process.exit(1);
 });

--- a/skills/blink/scripts/subscribe_invoice.js
+++ b/skills/blink/scripts/subscribe_invoice.js
@@ -17,42 +17,7 @@
  *   BLINK_API_URL  - Optional. Override API endpoint (default: https://api.blink.sv/graphql)
  */
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
-const DEFAULT_API_URL = 'https://api.blink.sv/graphql';
-
-function getApiKey() {
-  let key = process.env.BLINK_API_KEY;
-  if (!key) {
-    try {
-      const profile = fs.readFileSync(path.join(os.homedir(), '.profile'), 'utf8');
-      const match = profile.match(/BLINK_API_KEY=["']?([a-zA-Z0-9_]+)["']?/);
-      if (match) key = match[1];
-    } catch {}
-  }
-  if (!key) throw new Error('BLINK_API_KEY not found. Set it in environment or ~/.profile');
-  return key;
-}
-
-function getApiUrl() {
-  return process.env.BLINK_API_URL || DEFAULT_API_URL;
-}
-
-function getWsUrl() {
-  const apiUrl = getApiUrl();
-  const url = new URL(apiUrl);
-  url.protocol = url.protocol === 'http:' ? 'ws:' : 'wss:';
-  if (url.hostname.startsWith('api.')) url.hostname = url.hostname.replace(/^api\./, 'ws.');
-  return url.toString();
-}
-
-function normalizeInvoice(input) {
-  const trimmed = input.trim();
-  if (trimmed.toLowerCase().startsWith('lightning:')) return trimmed.slice('lightning:'.length);
-  return trimmed;
-}
+const { getApiKey, getWsUrl, normalizeInvoice, requireWebSocket, subscribeToInvoice } = require('./_blink_client');
 
 function parseArgs(argv) {
   let invoice = null;
@@ -74,13 +39,6 @@ function parseArgs(argv) {
   return { invoice, timeoutSeconds };
 }
 
-function requireWebSocket() {
-  if (typeof WebSocket !== 'function') {
-    throw new Error('WebSocket is not available. Run with: node --experimental-websocket subscribe_invoice.js ...');
-  }
-  return WebSocket;
-}
-
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (!args.invoice) {
@@ -94,138 +52,21 @@ function main() {
     process.exit(1);
   }
 
+  requireWebSocket();
+
   const apiKey = getApiKey();
   const wsUrl = getWsUrl();
-  const WebSocketImpl = requireWebSocket();
 
-  let done = false;
-  let timeoutId = null;
-
-  const ws = new WebSocketImpl(wsUrl, 'graphql-transport-ws');
-
-  function finish(result, exitCode = 0) {
-    if (done) return;
-    done = true;
-    if (timeoutId) clearTimeout(timeoutId);
-    try {
-      if (ws.readyState === ws.OPEN) {
-        ws.send(JSON.stringify({ id: '1', type: 'complete' }));
-      }
-    } catch {}
-    try {
-      ws.close(1000);
-    } catch {}
-    if (result) {
+  subscribeToInvoice({
+    paymentRequest,
+    apiKey,
+    wsUrl,
+    timeoutSeconds: args.timeoutSeconds,
+    onResult(result, exitCode) {
       console.log(JSON.stringify(result, null, 2));
-    }
-    process.exit(exitCode);
-  }
-
-  if (args.timeoutSeconds > 0) {
-    timeoutId = setTimeout(() => {
-      finish({
-        paymentRequest,
-        status: 'TIMEOUT',
-        isPaid: false,
-        isExpired: false,
-        isPending: true,
-      }, 1);
-    }, args.timeoutSeconds * 1000);
-  }
-
-  ws.onopen = () => {
-    ws.send(JSON.stringify({
-      type: 'connection_init',
-      payload: { 'X-API-KEY': apiKey },
-    }));
-  };
-
-  ws.onmessage = (event) => {
-    let message;
-    try {
-      message = JSON.parse(event.data);
-    } catch (e) {
-      console.error('Warning: received non-JSON message');
-      return;
-    }
-
-    if (message.type === 'connection_ack') {
-      ws.send(JSON.stringify({
-        id: '1',
-        type: 'subscribe',
-        payload: {
-          query: `subscription LnInvoicePaymentStatus($input: LnInvoicePaymentStatusInput!) {\n  lnInvoicePaymentStatus(input: $input) {\n    status\n  }\n}`,
-          variables: { input: { paymentRequest } },
-        },
-      }));
-      return;
-    }
-
-    if (message.type === 'ping') {
-      ws.send(JSON.stringify({ type: 'pong' }));
-      return;
-    }
-
-    if (message.type === 'error') {
-      console.error('Error: subscription error', JSON.stringify(message.payload || message));
-      finish({
-        paymentRequest,
-        status: 'ERROR',
-        error: message.payload || message,
-      }, 1);
-      return;
-    }
-
-    if (message.type === 'next') {
-      const status = message.payload && message.payload.data && message.payload.data.lnInvoicePaymentStatus
-        ? message.payload.data.lnInvoicePaymentStatus.status
-        : null;
-      if (!status) return;
-
-      console.error(`Status: ${status}`);
-      if (status === 'PAID' || status === 'EXPIRED') {
-        finish({
-          paymentRequest,
-          status,
-          isPaid: status === 'PAID',
-          isExpired: status === 'EXPIRED',
-          isPending: false,
-        }, 0);
-      }
-      return;
-    }
-
-    if (message.type === 'complete') {
-      finish({
-        paymentRequest,
-        status: 'COMPLETE',
-        isPaid: false,
-        isExpired: false,
-        isPending: true,
-      }, 0);
-    }
-  };
-
-  ws.onerror = (event) => {
-    console.error('Error: WebSocket error');
-    finish({
-      paymentRequest,
-      status: 'ERROR',
-      error: 'WebSocket error',
-    }, 1);
-  };
-
-  ws.onclose = (event) => {
-    if (done) return;
-    console.error(`WebSocket closed: code=${event.code} reason=${event.reason || 'unknown'}`);
-    finish({
-      paymentRequest,
-      status: 'CLOSED',
-      isPaid: false,
-      isExpired: false,
-      isPending: true,
-    }, 1);
-  };
+      process.exit(exitCode);
+    },
+  });
 }
 
 try {


### PR DESCRIPTION
## Summary

Refactors all 14 Blink skill scripts to eliminate duplicated code and improve reliability. Adds 1 new shared module (`_blink_client.js`) and updates all 14 existing scripts.

**Release**: https://github.com/pretyflaco/blink-claw-skill/releases/tag/v0.6.0

## Changes (7 improvements)

1. **Shared client module** (`_blink_client.js`) — Extracts ~520 lines of duplicated logic (GraphQL client, wallet resolution, auth, WebSocket invoice subscription) into a single shared module with 14+ exports. All scripts now `require('./_blink_client')`.

2. **Normalized invoice inputs** — `pay_invoice.js` and `fee_probe.js` now strip `lightning:` prefixes and whitespace, and warn if the input doesn't look like a BOLT-11 invoice.

3. **Actionable `check_invoice.js` errors** — Replaced blanket `catch { continue }` with targeted error handling that surfaces API errors to the user instead of silently swallowing them.

4. **Reduced redundant API calls** — API key/URL resolved once via shared module; `usd_to_sats.js` reduced from 2 API calls to 1; `realtime_price.js` skips the extra sats conversion call when `--raw` is passed.

5. **Request timeouts** — All HTTP requests now use `AbortController` with a 15s default timeout (30s for mutations), preventing scripts from hanging indefinitely on network issues.

6. **WebSocket endpoint override** — New `BLINK_WS_URL` environment variable allows overriding the default `wss://ws.blink.sv/graphql` WebSocket endpoint (useful for testing against staging).

7. **Code formatting** — All files formatted with ESLint + Prettier (dev tooling lives in blink-claw-skill repo only, not included in this PR).

## Notes

- **SKILL.md is unchanged** — all CLI interfaces remain identical (same args, same env vars, same exit codes)
- **No new runtime dependencies** — scripts use only Node.js 18+ built-ins
- **Files**: 1 new (`_blink_client.js`) + 14 updated scripts under `skills/blink/scripts/`