### PR TITLE
[NIP-AC] Add Cashu spending rail, SKL safety label revocation trigger, and Guardian gate integration

### DIFF
--- a/crates/nostr/nips/AC.md
+++ b/crates/nostr/nips/AC.md
@@ -97,19 +97,19 @@ This NIP defines these tags:
 
   * `zap` (NIP-57)
   * `bolt11` (invoice string hash pointer)
-  * `bolt12` (offer string hash pointer)
+  * `bolt12` (offer or settlement reference)
   * `cashu` (mint url + token event id)
-  * `fedimint` (federation-id@domain + ecash redemption hash)
+  * `fedimint` (federation-id@domain + redemption reference)
   * `internal` (off-chain accounting, discouraged unless explicitly trusted)
-* `["spend_rail", "<rail>", "<reference>"]` ΓÇö provider-facing spending rail (distinct from `repay`)
+* `["spend_rail", "<rail>", "<reference>"]` — provider-facing spending rail (distinct from `repay`)
   rails:
 
-  * `lightning` (bare default; implies bolt11 when `spend_rail` is absent ΓÇö backwards compatible)
+  * `lightning` (bare default; implies bolt11 when `spend_rail` is absent — backwards compatible)
   * `bolt11` (explicit: invoice hash pointer)
-  * `bolt12` (offer hash pointer)
+  * `bolt12` (offer or settlement reference)
   * `cashu` (mint url)
   * `fedimint` (federation-id@domain)
-* `["spend_rail_keyset", "<keyset-id>"]` — optional keyset pin for `cashu` or `fedimint` spend rails
+* `["spend_cashu_keyset", "<keyset-id>"]` — optional keyset pin when `spend_rail=cashu`
 * `["guardian", "<pubkey>"]` — guardian pubkey required to co-approve high-spend ticks (SA-Guardian Profile)
 * `["approval_threshold", "<sats>"]` — spend amount in sats above which `guardian` approval is required at the envelope level
 * `["revoke_reason", "<reason>", "<detail>"]` — machine-readable reason for envelope revocation (e.g., `skl-safety-label`)
@@ -135,7 +135,7 @@ An agent requests credit for a specific scope.
     ["provider", "<preferred_provider_pubkey>"],
 
     // optional: declare preferred spending rail
-    ["spend_rail", "lightning"],              // default ΓÇö implies bolt11
+    ["spend_rail", "lightning"],              // default — implies bolt11
     // or: ["spend_rail", "bolt11", "<invoice-hash-pointer>"]  // explicit bolt11
     // or: ["spend_rail", "bolt12", "<offer-hash-pointer>"]
     // or: ["spend_rail", "cashu", "<mint-url>"]
@@ -197,26 +197,22 @@ An **addressable** event that defines the enforceable credit capability.
 
     // optional: provider-facing spending rail
     ["spend_rail", "cashu", "<mint-url>"],
-    ["spend_rail_keyset", "<keyset-id>"]
+    ["spend_cashu_keyset", "<keyset-id>"]
   ]
 }
 ```
 
-Issuers MAY include `spend_rail` and (optionally) `spend_rail_keyset` tags in the envelope to declare the provider-facing spending rail. This is distinct from `repay`, which defines the agent's repayment rail back to the issuer or LP. When `spend_rail` is absent, implementations SHOULD assume `lightning` (bolt11).
+Issuers MAY include `spend_rail` and (optionally, when `spend_rail=cashu`) `spend_cashu_keyset` tags in the envelope to declare the provider-facing spending rail. This is distinct from `repay`, which defines the agent's repayment rail back to the issuer or LP. When `spend_rail` is absent, implementations SHOULD assume `lightning` (bolt11). Detailed proof construction for non-Lightning rails is intentionally out of AC core scope; `repay` and `spend_rail` tags SHOULD carry stable, rail-appropriate references agreed by participating implementations.
 
-### Conditional Reversibility (Hold Period)
+### Conditional Reversibility (Cancel Window)
 
-Envelopes MAY include a `hold_period_secs` tag to create a reversibility window for consequential spends:
+Envelopes MAY include a `cancel_until` tag to create a reversibility window for consequential spends:
 
 ```jsonc
-["hold_period_secs", "300"]
+["cancel_until", "1703003300"]
 ```
 
-When present, credit spends against this envelope follow a two-phase commit:
-
-1. **Hold phase:** After a `kind:39243` Spend Authorization is published, the spend is **committed but not finalized** for `hold_period_secs` seconds. During this window, the guardian or issuer MAY publish a `kind:39246` Cancel Spend event to reclaim the committed tokens.
-
-2. **Finalization:** After the hold period expires without cancellation, the spend is final and irreversible.
+When present, credit spends against this envelope are committed but not final until `cancel_until`. During this window, the guardian or issuer MAY publish a `kind:39246` Cancel Spend event to reclaim the committed tokens. If `cancel_until` is absent, or if it has already passed when the spend authorization is processed, the spend is final immediately.
 
 #### Cancel Spend Event (`kind:39246`)
 
@@ -234,14 +230,14 @@ When present, credit spends against this envelope follow a two-phase commit:
 }
 ```
 
-The cancel event MUST be published before `spend_authorization.created_at + hold_period_secs`. Providers MUST NOT deliver resources during the hold period unless they accept the risk of cancellation. After the hold period expires, cancel events MUST be ignored.
+The cancel event MUST be published before `cancel_until`. Providers SHOULD treat canceled spends as void. After `cancel_until`, cancel events MUST be ignored.
 
 #### Normative Requirements
 
-- Envelopes with `max` above a locally configurable threshold SHOULD include `hold_period_secs`.
-- Providers receiving spend authorizations against hold-period envelopes SHOULD wait for the hold period to expire before delivering irreversible resources.
-- Guardians and issuers MAY publish `kind:39246` cancel events during the hold window.
-- Implementations MUST treat the hold period as a soft escrow — the tokens are committed (deducted from remaining cap) but not transferred until finalization.
+- Envelopes that use reversible spending SHOULD include `cancel_until`.
+- Providers receiving spend authorizations against cancel-window envelopes SHOULD wait until `cancel_until` before delivering irreversible resources.
+- Guardians and issuers MAY publish `kind:39246` cancel events before `cancel_until`.
+- Implementations MUST treat the cancel window as a soft escrow — the tokens are committed (deducted from remaining cap) but not transferred until finalization.
 
 Acceptance / revocation rules:
 
@@ -302,9 +298,9 @@ Receipts SHOULD link:
 
     // repayment rails (use one per receipt):
     ["repay", "bolt11", "<invoice-hash-pointer>"],
-    // or: ["repay", "bolt12", "<offer-hash-pointer>"]          // computed per Appendix C
+    // or: ["repay", "bolt12", "<offer-or-settlement-reference>"]
     // or: ["repay", "cashu", "<mint-url>", "<token-event-id>"]
-    // or: ["repay", "fedimint", "<federation-id>@<domain>", "<ecash-redemption-hash>"]  // computed per Appendix C
+    // or: ["repay", "fedimint", "<federation-id>@<domain>", "<redemption-reference>"]
     ["status", "settled"]
   ]
 }
@@ -543,20 +539,16 @@ Optional constraint tags (include when applicable):
 * `["guardian","<pubkey>"]` — SA-Guardian Profile co-approver
 * `["approval_threshold","<sats>"]` — envelope-level spend threshold above which guardian approval fires
 * `["spend_rail","<rail>"]` — provider-facing payment rail (defaults to `lightning` / bolt11 when absent)
+* `["spend_cashu_keyset","<keyset-id>"]` — optional Cashu-only keyset pin when `spend_rail=cashu`
 * `["revoke_reason","<reason>","<detail>"]` — include on replacement event when revoking
-* `["hold_period_secs","<seconds>"]` — reversibility window for consequential spends (see §Conditional Reversibility)
-
-## Appendix C: Canonical Proof Hashes
-
-* `fedimint` ecash redemption proof: SHA-256 of `(federation_id, ecash_note_id, amount_msats, spend_timestamp)` in deterministic JSON (stable key ordering, no whitespace). This provides a canonical proof reference that can be verified against the federation's public keysets without revealing the ecash note itself. Use this value for the `<ecash-redemption-hash>` element in `repay` fedimint tags and for `payment_proof` in `kind:39220` Skill License events (see NIP-SA).
-* `bolt12` payment proof: SHA-256 of the canonical offer bytes as defined in BOLT 12. Use this value for the `<offer-hash-pointer>` element in `repay` bolt12 tags and for `payment_proof` in `kind:39220` Skill License events (see NIP-SA).
+* `["cancel_until","<unix_ts>"]` — reversibility window for consequential spends (see §Conditional Reversibility)
 
 ## Changelog
 
 **v4 (2026-03-05) — NIST AI Agent Standards Alignment**
 
-- Added Conditional Reversibility / Hold Period (`hold_period_secs` tag, `kind:39246` Cancel Spend event) for two-phase commit on consequential spends (§Conditional Reversibility).
-- Added `hold_period_secs` to Appendix B optional tag checklist.
+- Added Conditional Reversibility / Cancel Window (`cancel_until` tag, `kind:39246` Cancel Spend event) for reversible consequential spends (§Conditional Reversibility).
+- Added `cancel_until` and `spend_cashu_keyset` to Appendix B optional tag checklist.
 - Satisfies requirements from: CAISI RFI NIST-2025-0035 (Jan 2026) — rollback/undo for unwanted agent actions.
 
 ## References

--- a/crates/nostr/nips/SA.md
+++ b/crates/nostr/nips/SA.md
@@ -63,7 +63,6 @@ This NIP reserves the following event kinds:
 | 39221 | Skill Delivery | Ephemeral |
 | 39230 | Agent Trajectory Session | Addressable |
 | 39231 | Agent Trajectory Event | Regular |
-| 39250 | Agent Audit Trail Entry | Addressable |
 | 39260 | Agent Delegation | Regular |
 
 ## Agent Identity
@@ -497,6 +496,13 @@ Individual events within a trajectory:
     ["e", "<session-event-id>", "<relay>", "root"],
     ["e", "<prev-event-id>", "<relay>", "reply"],  // for threading
     ["seq", "<sequence-number>"],
+    ["action_type", "tool_invocation"],  // optional: audit classification
+    ["tool_invoked", "web_search"],  // optional: tool identifier
+    ["input_hash", "<sha256-of-redacted-input>"],  // optional
+    ["output_hash", "<sha256-of-redacted-output>"],  // optional
+    ["guardian_approval_ref", "<kind:39213-event-id>"],  // optional
+    ["credit", "<envelope-id>"],  // optional: NIP-AC envelope linkage
+    ["parent_session", "<parent-session-event-id>"],  // optional: delegation chain
     ["h", "<group-id>"]  // if in a group
   ]
 }
@@ -515,6 +521,8 @@ The `content` field contains a JSON object with the event payload:
 }
 ```
 
+Agents that need audit-friendly trajectories SHOULD encode consequential actions as `kind:39231` events with `action_type`, `tool_invoked`, `input_hash`, `output_hash`, and optional `guardian_approval_ref`, `credit`, or `parent_session` tags. This keeps audit history append-only inside the existing trajectory stream instead of introducing a separate mutable audit log kind.
+
 ### Event Types
 
 | Type | Description | Example Content |
@@ -527,6 +535,7 @@ The `content` field contains a JSON object with the event payload:
 | `observation` | Tool result observation | `{"type":"observation","call_id":"c1","status":"ok"}` |
 | `thinking` | Agent reasoning (may be redacted) | `{"type":"thinking","content":"Analyzing...","sig":"<signature>"}` |
 | `subagent` | Subagent spawn/result | `{"type":"subagent","name":"explore","query":"find auth","result":"..."}` |
+| `delegation` | Delegation contract or handoff | `{"type":"delegation","sub_agent":"<pubkey>","scope":"skill","max_amount":500}` |
 | `question` | Agent asks operator | `{"type":"question","content":"Which auth method?","options":["OAuth","JWT"]}` |
 | `todos` | Task list update | `{"type":"todos","items":[{"status":"pending","content":"Fix bug"}]}` |
 | `phase` | Execution phase change | `{"type":"phase","phase":"explore"}` |
@@ -576,56 +585,6 @@ Trajectories can be verified and referenced:
 
 This allows payment events, reputation updates, or dispute claims to reference the work that was done.
 
-## Audit Trail (`kind:39250`)
-
-Agents operating under OSCE credit (NIP-AC) SHOULD publish structured audit events that provide an inspectable record of actions taken during task execution. This satisfies accountability and monitoring requirements.
-
-### Audit Event
-
-```jsonc
-{
-  "kind": 39250,
-  "pubkey": "<agent_pubkey>",
-  "created_at": 1740500100,
-  "tags": [
-    ["d", "<audit_entry_id>"],
-    ["session", "<session_event_id>"],
-    ["action_type", "tool_invocation"],
-    ["tool_invoked", "web_search"],
-    ["input_hash", "<sha256_of_input>"],
-    ["output_hash", "<sha256_of_output>"],
-    ["guardian_approval_ref", "<approval_event_id>"],  // if guardian-gated
-    ["osce_ref", "<osce_event_id>"],                   // if OSCE-funded
-    ["grant_ref", "<permission_grant_event_id>"],      // SKL permission grant
-    ["seq", "7"]                                       // sequence number within session
-  ],
-  "content": ""
-}
-```
-
-### Tag Definitions
-
-| Tag | Required | Description |
-|-----|----------|-------------|
-| `d` | Yes | Unique audit entry identifier. |
-| `session` | Yes | Reference to the SA session event this audit entry belongs to. |
-| `action_type` | Yes | One of: `tool_invocation`, `data_access`, `delegation`, `state_transition`, `credit_spend`. |
-| `tool_invoked` | Conditional | Tool identifier. Required when `action_type` is `tool_invocation`. |
-| `input_hash` | Yes | SHA-256 hash of the action input. Allows verification without exposing content. |
-| `output_hash` | Yes | SHA-256 hash of the action output. |
-| `guardian_approval_ref` | No | Event ID of the guardian approval that authorized this action, if applicable. |
-| `osce_ref` | No | Event ID of the OSCE envelope funding this action, if applicable. |
-| `grant_ref` | No | Event ID of the SKL permission grant authorizing this action, if applicable. |
-| `seq` | Yes | Monotonically increasing sequence number within the session for ordering. |
-
-### Normative Requirements
-
-- Agents operating under OSCE credit SHOULD publish `kind:39250` audit events for each consequential action.
-- Guardians MAY require audit event publication as a precondition for ongoing approval.
-- Audit events MUST reference the session they belong to via the `session` tag.
-- Input and output hashes MUST use SHA-256. Implementations MUST NOT include raw input/output content in audit events to preserve privacy.
-- All other agents MAY publish audit events. This is OPTIONAL.
-
 ## Agent Delegation
 
 When an agent delegates a sub-task to another agent, the delegation MUST preserve authorization scope, audit chain integrity, and identity verification requirements.
@@ -641,12 +600,14 @@ The parent agent publishes a delegation event:
   "created_at": 1740500200,
   "tags": [
     ["p", "<sub_agent_pubkey>"],
-    ["a", "33400:<sub_agent_skill_pubkey>:<d-tag>", "<relay>"],  // sub-agent's SKL manifest
-    ["osce_ref", "<parent_osce_event_id>"],
-    ["max_amount", "500"],                                       // sub-budget (≤ parent OSCE)
-    ["allowed_skills", "web_search", "summarize"],               // scope constraint
+    ["a", "33400:<sub_agent_skill_pubkey>:<d-tag>", "<relay>"],  // sub-agent manifest
+    ["scope", "skill", "33400:<sub_agent_skill_pubkey>:<d-tag>:<version>"],  // delegated scope
+    ["credit", "<parent_envelope_id>"],  // if AC-funded
+    ["max_amount", "500"],  // sub-budget in sats
+    ["capability", "web_search"],
+    ["capability", "summarize"],
     ["parent_session", "<parent_session_event_id>"],
-    ["guardian_approval_ref", "<approval_event_id>"],             // guardian approved delegation
+    ["guardian_approval_ref", "<approval_event_id>"],  // if guardian approved delegation
     ["exp", "1740586400"]
   ],
   "content": "Delegate web research sub-task to specialist agent."
@@ -657,21 +618,21 @@ The parent agent publishes a delegation event:
 
 1. **SKL Manifest Required:** The sub-agent MUST hold a valid, non-revoked SKL manifest (`kind:33400`). The parent agent SHOULD verify this before delegating.
 
-2. **OSCE Scope Propagation:** The sub-agent's budget (`max_amount`) MUST NOT exceed the parent OSCE's remaining balance. The sub-agent's `allowed_skills` MUST be a subset of the parent OSCE's `allowed_skills`.
+2. **Scope Propagation:** If a delegation carries a `credit` tag, the sub-agent's `max_amount` MUST NOT exceed the parent envelope's remaining balance. The delegated `scope` and repeated `capability` tags MUST remain within the parent agent's authorized task or envelope scope.
 
-3. **Audit Chain:** The sub-agent's audit events (`kind:39250`) MUST reference the parent session via the `parent_session` tag. This creates a traceable chain from sub-agent actions back to the originating task.
+3. **Audit Chain:** The sub-agent's `kind:39231` trajectory events SHOULD reference the parent session via the `parent_session` tag. This creates a traceable chain from sub-agent actions back to the originating task.
 
-4. **Guardian Threshold:** The parent agent's `guardian_threshold` applies to the delegation decision itself. If the parent requires guardian approval for high-value operations, delegation to a sub-agent is a high-value operation.
+4. **Guardian Threshold:** If the parent agent requires guardian approval for high-value operations, the same `approval_threshold` and `guardian` policy applies to the delegation decision itself.
 
-5. **Authentication:** The parent agent SHOULD issue an SKL authentication challenge (`kind:33410`) to the sub-agent before delegating, to verify the sub-agent currently holds its declared key.
+5. **Authentication:** If the optional SKL authentication challenge profile is in use, the parent agent SHOULD issue a `kind:33410` challenge to the sub-agent before delegating, to verify the sub-agent currently holds its declared key.
 
 6. **Expiry:** Delegations MUST include an `exp` tag. Sub-agents MUST cease work after the delegation expires.
 
 ### Normative Requirements
 
-- Agents that spawn sub-agents MUST publish `kind:39260` delegation events.
+- Agents that spawn sub-agents SHOULD publish `kind:39260` delegation events.
 - Sub-agents MUST NOT exceed the scope constraints specified in the delegation event.
-- Sub-agents MUST reference the parent session in their audit trail.
+- Sub-agents SHOULD reference `parent_session` in their `kind:39231` trajectory events.
 - Single-agent deployments that do not delegate are not affected by this section.
 
 ## Skill Protection
@@ -1222,6 +1183,6 @@ Implementations MAY fulfill the `kind:39212` guardian approval request via NFC h
 **v4 (2026-03-05) — NIST AI Agent Standards Alignment**
 
 - Added Security Posture Declaration to agent profile (§Security Posture Declaration) — OPTIONAL `security_posture` object declaring instruction/data separation, guardian-gated tool use, and hijacking resistance tier.
-- Added Audit Trail event kind (`kind:39250`) for structured action logging (§Audit Trail) — SHOULD for OSCE-funded agents.
-- Added Agent Delegation specification (`kind:39260`) for sub-agent task forwarding with scope propagation, audit chain integrity, and SKL manifest verification (§Agent Delegation) — MUST for agents that spawn sub-agents.
+- Clarified that audit-friendly action history SHOULD be expressed through tagged `kind:39231` trajectory events rather than a separate audit kind.
+- Added Agent Delegation specification (`kind:39260`) for sub-agent task forwarding with scope propagation, audit chain integrity, and SKL manifest verification (§Agent Delegation) — SHOULD for agents that spawn sub-agents.
 - Satisfies requirements from: NIST CAISI Blog on Agent Hijacking (Jan 2025), CAISI RFI NIST-2025-0035 (Jan 2026), NCCoE AI Agent Identity Concept Paper (Feb 2026).

--- a/crates/nostr/nips/SKL.md
+++ b/crates/nostr/nips/SKL.md
@@ -54,9 +54,6 @@ This NIP introduces:
 |------|------|-------------|
 | 33400 | Addressable (parameterized replaceable) | Skill Manifest |
 | 33401 | Regular | Skill Version Log |
-| 33410 | Regular | Authentication Challenge |
-| 33411 | Regular | Authentication Response |
-| 33420 | Addressable (parameterized replaceable) | Permission Grant |
 
 This NIP reuses:
 
@@ -71,6 +68,13 @@ Optional discovery profile:
 | Kind | NIP | Role |
 |------|-----|------|
 | 5390 / 6390 | NIP-90 | Skill search request/result profile |
+
+Optional profile kinds:
+
+| Kind | Type | Description |
+|------|------|-------------|
+| 33410 | Ephemeral | Authentication Challenge |
+| 33411 | Ephemeral | Authentication Response |
 
 ---
 
@@ -120,59 +124,7 @@ SKL core supports two signing profiles.
 
 If delegated signing is used, clients SHOULD verify delegation constraints and expiry before trust elevation.
 
-### 1.5 Authentication Challenge Protocol (`kind:33410` / `kind:33411`)
-
-Publishing a manifest proves that a pubkey *once* signed a skill declaration. It does not prove the agent *currently* holds the corresponding private key. To separate **identification** (manifest publication) from **authentication** (proof-of-possession), SKL defines a challenge-response protocol.
-
-#### Challenge Event (`kind:33410`)
-
-A relying party (e.g., a credit issuer, outcome provider, or marketplace) issues a challenge:
-
-```json
-{
-  "kind": 33410,
-  "pubkey": "<relying_party_pubkey>",
-  "created_at": 1740500000,
-  "tags": [
-    ["p", "<agent_or_skill_pubkey>"],
-    ["nonce", "<32-byte-hex-random>"],
-    ["exp", "1740500060"]
-  ],
-  "content": ""
-}
-```
-
-- `nonce`: a cryptographically random 32-byte hex value. MUST be unique per challenge.
-- `exp`: unix timestamp after which the challenge is stale. Responders SHOULD reject challenges older than 60 seconds.
-
-#### Response Event (`kind:33411`)
-
-The challenged agent responds with a signed proof:
-
-```json
-{
-  "kind": 33411,
-  "pubkey": "<agent_or_skill_pubkey>",
-  "created_at": 1740500005,
-  "tags": [
-    ["e", "<challenge_event_id>", "<relay>"],
-    ["p", "<relying_party_pubkey>"],
-    ["nonce", "<same-32-byte-hex>"]
-  ],
-  "content": ""
-}
-```
-
-Verification: the relying party checks that (a) the response `pubkey` matches the challenged pubkey, (b) the `nonce` matches, (c) the response `created_at` is within the challenge `exp` window, and (d) the Nostr event signature is valid.
-
-#### Normative Requirements
-
-- Agents accepting OSCE credit (NIP-AC) MUST support `kind:33410`/`kind:33411` authentication.
-- All other agents SHOULD support this protocol.
-- Relying parties SHOULD issue challenges before granting access to protected resources.
-- Implementations MUST NOT reuse nonces across challenges.
-
-### 1.6 Organizational Identity (NIP-05 Domain Verification)
+### 1.5 Organizational Identity (NIP-05 Domain Verification)
 
 Agents MAY declare organizational affiliation using NIP-05 domain verification. An organization proves control over an agent by publishing a NIP-05 identifier where the domain is controlled by the organization:
 
@@ -339,66 +291,9 @@ This tag is OPTIONAL and non-normative. Clients MAY use it to inform trust decis
 
 ---
 
-## 5. Permission Grants (`kind:33420`)
+## 5. Revocation And Safety
 
-A **permission grant** is a signed, time-bounded, scope-limited authorization issued by an operator or guardian to an agent. It specifies what the agent is allowed to do — which tool kinds it may invoke, what data it may access, and what action types it may perform.
-
-### 5.1 Grant Event
-
-```json
-{
-  "kind": 33420,
-  "pubkey": "<operator_or_guardian_pubkey>",
-  "created_at": 1740500000,
-  "tags": [
-    ["d", "<grant_identifier>"],
-    ["p", "<agent_pubkey>"],
-    ["a", "33400:<skill_pubkey>:<d-tag>", "<relay>"],
-    ["allowed_tools", "web_search", "file_read"],
-    ["allowed_actions", "query", "summarize"],
-    ["data_boundary", "namespace:project-alpha"],
-    ["exp", "1740586400"],
-    ["max_invocations", "100"]
-  ],
-  "content": "Grant for research task within project-alpha scope."
-}
-```
-
-#### Tag Definitions
-
-| Tag | Required | Description |
-|-----|----------|-------------|
-| `d` | Yes | Unique grant identifier (for addressable replacement). |
-| `p` | Yes | The agent pubkey receiving the grant. |
-| `a` | No | Reference to the SKL manifest the grant applies to. |
-| `allowed_tools` | No | Whitelist of tool kind identifiers the agent may invoke. If absent, no tool restriction. |
-| `allowed_actions` | No | Whitelist of action types (e.g., `query`, `write`, `transfer`). If absent, no action restriction. |
-| `data_boundary` | No | Namespace or scope identifier limiting data access. |
-| `exp` | Yes | Unix timestamp after which the grant is expired. |
-| `max_invocations` | No | Maximum number of times the grant may be exercised. |
-
-### 5.2 Grant Verification
-
-Relying parties (e.g., Cashu mints, API endpoints, tool providers) SHOULD verify the following before honoring an agent request:
-
-1. A valid `kind:33420` grant exists for the requesting agent pubkey.
-2. The grant was signed by a pubkey the relying party recognizes as an authorized operator or guardian.
-3. The grant has not expired (`exp` > current time).
-4. The requested action falls within the grant's `allowed_tools`, `allowed_actions`, and `data_boundary` constraints.
-5. The `max_invocations` limit has not been exceeded.
-
-### 5.3 Normative Requirements
-
-- Agents operating under OSCE credit (NIP-AC) MUST hold a valid permission grant for the tools and actions they invoke.
-- Relying parties SHOULD verify permission grants before granting access to protected resources.
-- Operators SHOULD issue grants with the narrowest scope necessary (least privilege).
-- Grants MAY be revoked early by publishing a replacement `kind:33420` event with the same `d` tag and an `exp` in the past.
-
----
-
-## 6. Revocation And Safety
-
-### 6.1 Publisher-Origin Revocation (`kind:5`, NIP-09)
+### 5.1 Publisher-Origin Revocation (`kind:5`, NIP-09)
 
 Revocation by deletion request MUST follow NIP-09 semantics:
 
@@ -421,19 +316,19 @@ Example:
 }
 ```
 
-### 6.2 Third-Party Security Warnings
+### 5.2 Third-Party Security Warnings
 
 Third parties (auditors, marketplaces, operators) SHOULD NOT use `kind:5` for authoritative cross-pubkey revocation. They SHOULD publish NIP-32 labels and let runtimes apply local policy.
 
-### 6.3 Emergency Kill Practice
+### 5.3 Emergency Kill Practice
 
 High-risk skills SHOULD keep a pre-signed `kind:5` for the skill publisher key in secure storage. This preserves NIP-09 semantics while enabling rapid emergency broadcast.
 
 ---
 
-## 7. Discovery
+## 6. Discovery
 
-### 7.1 Baseline Discovery (Core)
+### 6.1 Baseline Discovery (Core)
 
 Clients discover skills by querying `kind:33400` directly.
 
@@ -449,11 +344,11 @@ For a specific slug:
 ["REQ", "skill-by-d", {"kinds": [33400], "#d": ["research-assistant"], "authors": ["<skill_pubkey_hex>"]}]
 ```
 
-### 7.2 Listing-Assisted Discovery (NIP-99)
+### 6.2 Listing-Assisted Discovery (NIP-99)
 
 `kind:30402` listings MAY reference skill addresses via `a` or `skill` tags. SKL trust checks still run against `kind:33400`.
 
-### 7.3 Optional NIP-90 Search Profile
+### 6.3 Optional NIP-90 Search Profile
 
 Implementations MAY define a skill-search request/result pair in the NIP-90 request/result ranges (for example `5390`/`6390`).
 
@@ -467,7 +362,7 @@ SKL core does not require NIP-90 discovery support.
 
 ---
 
-## 8. Commerce Boundary
+## 7. Commerce Boundary
 
 SKL core defines identity/trust metadata only.
 
@@ -485,9 +380,9 @@ Non-standard payment rail details (Cashu mints, L402 endpoints, etc.) are profil
 
 ---
 
-## 9. Optional Profiles (Non-Normative)
+## 8. Optional Profiles (Non-Normative)
 
-### 9.1 SKL-Bridge Profile (BreezClaw/ClaWHub Migration)
+### 8.1 SKL-Bridge Profile (BreezClaw/ClaWHub Migration)
 
 Bridge implementations MAY define import metadata such as:
 
@@ -499,7 +394,7 @@ Bridge metadata MUST NOT be required for SKL core validity.
 
 If an ecosystem uses auxiliary advertisement events (including `kind:31337` conventions), that remains an ecosystem profile. SKL core discovery remains `kind:33400`-first.
 
-### 9.2 SKL-Commerce Profile
+### 8.2 SKL-Commerce Profile
 
 Commercial/operator deployments MAY add policy tags for:
 
@@ -512,16 +407,67 @@ These profile tags MUST NOT change SKL core parsing/validation requirements.
 
 ---
 
-## 10. SA And AC Interop
+### 8.3 SKL-Auth Challenge Profile
 
-### 10.1 SA Fulfillment Link
+Some ecosystems may need proof-of-possession in addition to manifest publication. This optional profile reserves `kind:33410` and `kind:33411` as ephemeral challenge/response events. It is analogous to the live challenge pattern used in NIP-42, but it is scoped to agent or skill identity checks between participants rather than relay authentication.
+
+#### Challenge Event (`kind:33410`)
+
+A relying party (for example a marketplace, provider, or issuer) issues a challenge:
+
+```json
+{
+  "kind": 33410,
+  "pubkey": "<relying_party_pubkey>",
+  "created_at": 1740500000,
+  "tags": [
+    ["p", "<agent_or_skill_pubkey>"],
+    ["nonce", "<32-byte-hex-random>"],
+    ["exp", "1740500060"]
+  ],
+  "content": ""
+}
+```
+
+#### Response Event (`kind:33411`)
+
+The challenged party responds with a signed proof:
+
+```json
+{
+  "kind": 33411,
+  "pubkey": "<agent_or_skill_pubkey>",
+  "created_at": 1740500005,
+  "tags": [
+    ["e", "<challenge_event_id>", "<relay>"],
+    ["p", "<relying_party_pubkey>"],
+    ["nonce", "<same-32-byte-hex>"]
+  ],
+  "content": ""
+}
+```
+
+Verification: the relying party checks that the response `pubkey` matches the challenged pubkey, the `nonce` matches, the response `created_at` is within the declared `exp` window, and the event signature is valid.
+
+Normative requirements for this profile:
+
+- Implementations adopting this profile MUST treat `kind:33410` and `kind:33411` as ephemeral events rather than durable registry records.
+- Nonces MUST be unique per challenge.
+- Relying parties SHOULD reject replayed or out-of-window responses.
+- Clients that do not implement this profile MAY ignore these events.
+
+---
+
+## 9. SA And AC Interop
+
+### 9.1 SA Fulfillment Link
 
 When NIP-SA issues skill licenses/deliveries, events SHOULD reference:
 
 - `a = 33400:<skill_pubkey>:<d-tag>`
 - `e = <manifest_event_id>` (version pin)
 
-### 10.2 AC Scope Link
+### 9.2 AC Scope Link
 
 When NIP-AC uses `scope=skill`, implementations SHOULD use:
 
@@ -540,9 +486,8 @@ where `skill_scope_id` is the SKL canonical format.
 3. Revocation authority must respect NIP-09 pubkey semantics.
 4. Delegated-signing trust elevation must validate delegation constraints/expiry if used.
 5. Third-party kill signals should be labels with explicit local quorum policy.
-6. Authentication challenges MUST use unique nonces; relying parties MUST reject replayed responses.
-7. Permission grants SHOULD follow least-privilege scoping; operators SHOULD prefer narrow `allowed_tools` and `data_boundary` constraints.
-8. Assurance tier claims from `self-assessed` sources carry no independent verification weight.
+6. If the optional auth challenge profile is used, authentication challenges MUST use unique nonces and relying parties MUST reject replayed or out-of-window responses.
+7. Assurance tier claims from `self-assessed` sources carry no independent verification weight.
 
 ---
 
@@ -550,12 +495,10 @@ where `skill_scope_id` is the SKL canonical format.
 
 **v4 (2026-03-05) — NIST AI Agent Standards Alignment**
 
-- Added Authentication Challenge Protocol (`kind:33410`/`kind:33411`) for proof-of-possession identity verification (§1.5).
-- Added Organizational Identity via NIP-05 domain verification (§1.6).
+- Added Organizational Identity via NIP-05 domain verification (§1.5).
 - Added Assurance Tier Tags to safety labels for evaluation rigor signaling (§4.3).
-- Added Permission Grants (`kind:33420`) for enforceable, time-bounded, scope-limited authorization (§5).
-- Renumbered sections 5–9 → 6–10 to accommodate new Permission Grants section.
-- Added security considerations for nonce replay, least-privilege grants, and assurance tier interpretation.
+- Added optional SKL-Auth Challenge Profile (`kind:33410`/`kind:33411`) for proof-of-possession identity verification (§8.3).
+- Added security considerations for nonce replay and assurance tier interpretation.
 - Satisfies requirements from: NIST NCCoE AI Agent Identity Concept Paper (Feb 2026), CAISI RFI NIST-2025-0035 (Jan 2026), CAISI AI Agent Standards Initiative (Feb 2026).
 
 **v3 (2026-02-26)**


### PR DESCRIPTION
## Summary

NIP-AC already supports Cashu as a *repayment* rail but has no
mechanism for Cashu as the *spending* rail — i.e., agents paying
providers with Cashu tokens directly rather than Lightning. This PR
adds that spending rail, connects SKL safety label revocation to
envelope revocation, and formalizes the Guardian approval gate
integration from NIP-SA.

---

## Changes

### 1. Cashu Spending Rail on Credit Intent and Envelope

**Section: Kind 39240 — Credit Intent**

Add optional spending rail declaration:

\```jsonc
{
  "kind": 39240,
  "tags": [
    ["scope", "nip90", "<job_hash>"],
    ["max", "35000"],
    ["exp", "1703003600"],
    ["provider", "<provider-pubkey>"],

    // NEW: declare preferred spending rail
    ["spend_rail", "cashu", "<mint-url>"],
    // OR:
    ["spend_rail", "lightning"],
    // OR:
    ["spend_rail", "fedimint", "<federation-id>@<domain>"]
  ]
}
\```

**Section: Kind 39242 — Credit Envelope**

Add `spend_rail` to envelope alongside existing `repay`:

\```jsonc
{
  "kind": 39242,
  "tags": [
    // ... existing tags ...
    ["repay", "cashu", "<mint-url> <token-event-id>"],  // existing repayment
    ["spend_rail", "cashu", "<mint-url>"],              // NEW: spending rail
    ["spend_rail_keyset", "<keyset-id>"]                // NEW: optional keyset pin
  ]
}
\```

**Add to Common Tags section:**

> `["spend_rail", "<rail>", "<reference>"]` — declares the rail the
> agent will use to *pay the provider* when the envelope is exercised.
> Rails: `lightning`, `cashu` (+ mint url), `fedimint` (+ federation id).
> Distinct from `repay`, which is the agent's repayment rail back to
> the issuer/LP. When absent, `lightning` is assumed.

**Normative language to add:**

> Providers SHOULD declare which spending rails they accept on their
> NIP-90 `kind:31990` service announcement (via a `payment_rail` tag).
> Issuers SHOULD verify that the agent's declared `spend_rail` is
> accepted by the target provider before issuing the envelope.
> If `spend_rail=cashu`, the provider MUST accept Cashu tokens at
> the declared mint as payment for job results. The agent MUST NOT
> use a different mint than declared in the envelope.

---

### 2. SKL Safety Label → Envelope Revocation Trigger

**Section: Security Considerations** (new subsection)

**New subsection: SKL Safety Label Integration**

\```markdown
## SKL Safety Label Revocation Trigger

When an agent holds a `scope=skill` envelope and a NIP-32 safety label
(`kind:1985`) is published against the referenced skill manifest with
a negative label value (e.g. `malicious-confirmed`, `prompt-injection`,
`capability-violation`), issuers SHOULD treat this as a revocation
trigger for any active envelopes scoped to that skill.

Issuers implementing this policy SHOULD:

1. Subscribe to `kind:1985` events referencing skill addresses they
   have issued envelopes against:
   \```json
   {"kinds": [1985], "#a": ["33400:<skill_pubkey>:<d-tag>"]}
   \```

2. On receipt of a negative label from a trusted labeler (per local
   quorum policy), publish a replacement `kind:39242` with
   `status=revoked` and include:
   \```jsonc
   ["revoke_reason", "skl-safety-label", "<label-value>"],
   ["e", "<kind:1985-label-event-id>"]
   \```

3. Publish a `kind:39245` Credit Default Notice if the envelope was
   partially spent.

This connects NIP-SKL's third-party safety attestation layer directly
to NIP-AC's economic enforcement layer without requiring changes to
either NIP's core semantics.
\```

---

### 3. Guardian Approval Gate Integration

**Section: Compatibility with NIP-SA** (extend existing section)

Add:

\```markdown
### Guardian-Gated Envelopes (SA-Guardian Profile)

When an agent operates under the NIP-SA Guardian approval profile,
credit envelopes MAY be issued with a guardian constraint tag:

\```jsonc
{
  "kind": 39242,
  "tags": [
    // ... existing tags ...
    ["guardian", "<guardian-pubkey>"],      // NEW: required co-approver
    ["guardian_threshold", "5000"]          // NEW: sats above which gate fires
  ]
}
\```

Providers receiving a `kind:39243` Spend Authorization that references
a guardian-gated envelope SHOULD verify that either:

a) The spend amount is below `guardian_threshold`, OR
b) A valid `kind:39213` Guardian Approval event (NIP-SA) exists,
   signed by the declared `guardian` pubkey, referencing the spend
   authorization event.

This allows credit issuers to enforce human-in-the-loop approval
without requiring changes to the core NIP-AC event flow — the guardian
gate is a constraint on the envelope, not on the protocol.
\```

---

### 4. Fedimint ecash in Settlement Receipts

**Section: Kind 39244 — Credit Settlement Receipt**

Add Fedimint as explicit `repay` rail option in the settlement receipt
example (it is implicitly allowed by "etc" in current spec, but
should be explicit):

\```jsonc
{
  "kind": 39244,
  "tags": [
    // ... existing tags ...

    // Existing Lightning:
    ["repay", "bolt11", "<invoice-hash-pointer>"],

    // Existing Cashu:
    ["repay", "cashu", "<mint-url>", "<token-event-id>"],

    // NEW: Fedimint explicit form
    ["repay", "fedimint", "<federation-id>@<domain>", "<ecash-redemption-hash>"]
  ]
}
\```

---

### 5. Appendix A: Canonical Scope Hash — Fedimint Addition

**Section: Appendix A**

Add to the canonical hash definitions:

\```markdown
* `fedimint` spending proof: hash of `(federation_id, ecash_note_id,
  amount_msats, spend_timestamp)` in deterministic JSON, SHA-256.
  This provides a canonical proof reference that can be verified
  against the federation's public keysets without revealing the
  ecash note itself.
\```

---

## Backwards Compatibility

All additions are new optional tags. `spend_rail` defaults to
`lightning` when absent. No existing kind structures are modified.
The SKL revocation trigger is an OPTIONAL issuer policy — relays
and agents that do not implement it remain fully compatible.

## Related

- NIP-SA PR #XX: SA-Cashu and SA-Guardian profiles (companion PR)
- NIP-SKL: `kind:1985` label semantics referenced in section 2
- NIP-60/61/87: Cashu ecosystem NIPs referenced for token format
