### PR TITLE
docs(nist): add NIST RFI NIST-2025-0035 supporting materials

### DIFF
--- a/docs/nist/README.md
+++ b/docs/nist/README.md
@@ -1,0 +1,18 @@
+# NIST Submission Materials
+
+This directory preserves the OpenAgents submission bundle prepared for NIST RFI `NIST-2025-0035` on March 4, 2026.
+
+These files are archival supporting materials. They are not the normative source of truth for current OpenAgents product behavior, protocol surface, or implementation status.
+
+Current repo authority remains:
+
+- `docs/MVP.md` for MVP product scope
+- `docs/plans/economy-kernel.md` for broader economy-kernel direction
+- `crates/nostr/nips/*.md` plus `docs/PROTOCOL_SURFACE.md` for the active in-repo SA/SKL/AC protocol surface
+
+Included documents:
+
+- `rfi-executive-summary.md`
+- `rfi-full-response.md`
+- `rfi-iam-comparison.md`
+- `technical-appendix.md`

--- a/docs/nist/rfi-executive-summary.md
+++ b/docs/nist/rfi-executive-summary.md
@@ -3,6 +3,8 @@
 **Submitter:** OpenAgents  
 **Date:** March 4, 2026
 
+> Archival note: this document preserves submission materials prepared for NIST RFI `NIST-2025-0035` on March 4, 2026. It is not the normative source of truth for current OpenAgents product or protocol behavior.
+
 ---
 
 ## Core Message
@@ -93,7 +95,7 @@ If NIST guidance assumes centralized identity registries and enterprise IAM as t
 
 **Contact:** OpenAgents is available to provide implementation examples, test vectors, and open-source reference code.
 
-**Supporting materials:**
+**Supporting materials in this directory:**
 - NIP-AC: Agent Credit (Outcome-Scoped Credit Envelopes)
 - NIP-SKL: Agent Skill Identity, Manifest, and Trust Registry
-- Full response with technical appendix (attached)
+- Full response and technical appendix

--- a/docs/nist/rfi-full-response.md
+++ b/docs/nist/rfi-full-response.md
@@ -7,6 +7,8 @@
 **Date:** March 4, 2026  
 **Submitted via:** www.regulations.gov
 
+> Archival note: this document preserves submission materials prepared for NIST RFI `NIST-2025-0035` on March 4, 2026. It is not the normative source of truth for current OpenAgents product or protocol behavior.
+
 ---
 
 ## Executive Summary
@@ -15,7 +17,7 @@ AI agents will increasingly act as long-lived software principals capable of pla
 
 OpenAgents urges NIST to **explicitly recognize open, permissionless identity and authorization protocols as valid compliance paths** alongside enterprise IAM patterns, because agent ecosystems will include open-source agents, small developers, and individuals who cannot operate inside centralized identity registries. The technical proposals below (NIP-SA, NIP-SKL, NIP-AC) demonstrate a practical, auditable, least-privilege approach for agent identity, delegation, capability restriction, and payment authorization using cryptographic keys and signed event logs.
 
-**Supporting materials attached:**
+**Supporting materials in this directory:**
 - NIP-AC: Agent Credit (Outcome-Scoped Credit Envelopes)
 - NIP-SKL: Agent Skill Identity, Manifest, and Trust Registry
 - Technical Appendix with event schemas and examples

--- a/docs/nist/rfi-iam-comparison.md
+++ b/docs/nist/rfi-iam-comparison.md
@@ -4,6 +4,8 @@
 **Submitter:** OpenAgents  
 **Date:** March 4, 2026
 
+> Archival note: this document preserves submission materials prepared for NIST RFI `NIST-2025-0035` on March 4, 2026. It is not the normative source of truth for current OpenAgents product or protocol behavior.
+
 ---
 
 ## Executive Summary

--- a/docs/nist/technical-appendix.md
+++ b/docs/nist/technical-appendix.md
@@ -4,6 +4,8 @@
 **Submitter:** OpenAgents  
 **Date:** March 4, 2026
 
+> Archival note: this document preserves submission materials prepared for NIST RFI `NIST-2025-0035` on March 4, 2026. It is not the normative source of truth for current OpenAgents product or protocol behavior.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

This is a **docs-only PR** containing the NIST RFI NIST-2025-0035 supporting materials so reviewers can evaluate the standards/RFI submission independently from the in-flight NIP-AC / NIP-SA / NIP-SKL implementation changes.

## Included files

- `docs/nist/technical-appendix`
- `docs/nist/rfi-full-response`
- `docs/nist/rfi-executive summary`
- `docs/nist/rfi-iam-comparison`

## Scope

- No protocol/spec implementation changes
- No code changes
- No movement of `docs/TRUE_NAME_INTEGRATION_PROFILE.md` (that remains with the NIP work, not the NIST submission bundle)

## Purpose

These materials provide the standalone NIST submission/supporting documentation, including:
- the full RFI response
- an executive summary
- an enterprise IAM vs. open protocol comparison
- a technical appendix with event schemas, workflow diagrams, and implementation examples

This PR is intentionally separated from the implementation-focused branch so review can stay clean and narrowly scoped.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author