### PR TITLE
docs(a2a): add A2A interop profile and sovereign agent integration plan

### DIFF
--- a/docs/A2A_INTEROP_PROFILE.md
+++ b/docs/A2A_INTEROP_PROFILE.md
@@ -2,17 +2,18 @@
 
 **Status:** Non-normative, ecosystem-specific profile layered on A2A / NIP-SKL / NIP-SA / NIP-AC.
 
-This document describes how an **A2A-compliant agent** can interoperably layer in the OpenAgents sovereign stack:
+This document describes a practical way for an **A2A-compliant agent** to expose the OpenAgents sovereign stack without changing A2A itself.
 
-- **NIP-SKL** — skill registry, identity, attestation, revocation, auth challenge, permission grants
-- **NIP-SA** — sovereign agent identity, guardianship, lifecycle, sessions/trajectories, audit, delegation
-- **NIP-AC** — outcome-scoped credit (OSCE), spend authorization, settlement, hold/cancel behavior
+- **A2A** remains the wire protocol, discovery surface, and task orchestration layer.
+- **NIP-SKL** remains the skill registry, trust, and optional proof-of-possession layer.
+- **NIP-SA** remains the lifecycle, trajectory, guardianship, and delegation layer.
+- **NIP-AC** remains the outcome-scoped credit, settlement, and cancel-window layer.
 
-The profile is **optional** and **non-normative**:
+This profile is **optional**:
 
-- It does **not** modify the A2A protocol.
-- It does **not** change the canonical semantics of NIP-SKL, NIP-SA, or NIP-AC.
-- It describes a common interoperability pattern so A2A agents can expose sovereign identity, trust, lifecycle, and payment rails while preserving existing protocol boundaries.
+- It does **not** modify A2A.
+- It does **not** redefine NIP-SKL, NIP-SA, or NIP-AC.
+- It describes a compatible layering pattern for agents that want both **A2A interoperability** and **Nostr-backed sovereign state**.
 
 ---
 
@@ -20,497 +21,583 @@ The profile is **optional** and **non-normative**:
 
 This profile exists to define a practical mapping between:
 
-- **A2A** as the wire protocol, discovery mechanism, and orchestration surface, and
-- **NIP-SKL / NIP-SA / NIP-AC** as the canonical identity, lifecycle, and credit layers.
+- **A2A** as the discovery, transport, and task protocol, and
+- **NIP-SKL / NIP-SA / NIP-AC** as the canonical skill, lifecycle, and funding layers.
 
-Under this profile:
-
-- A2A remains the **transport and interoperability layer**.
-- NIP-SKL remains the **skill / identity / trust layer**.
-- NIP-SA remains the **lifecycle / guardianship / audit / delegation layer**.
-- NIP-AC remains the **credit / settlement / rollback layer**.
-
-The goal is not to replace A2A or restate the NIP specifications. The goal is to let existing and future A2A agents **bolt on sovereign capabilities incrementally** while keeping canonical state on Nostr.
+The goal is not to replace A2A or restate the NIP drafts. The goal is to let existing and future A2A agents **add sovereign identity, audit, and payment semantics incrementally** while keeping canonical state on Nostr.
 
 ### 1.1 What this profile is for
 
 This profile is intended for:
 
-- protocol and spec readers who need a clean interoperability model,
-- engineering implementers building A2A-facing sovereign agents,
-- future coding agents working from repository docs.
+- protocol readers who need a clean A2A-to-sovereign layering model,
+- implementers building A2A-facing sovereign agents,
+- future coding agents working from repo docs.
 
 ### 1.2 What this profile is not
 
 This profile does **not**:
 
-- redefine A2A operations, data model, or transport rules,
+- add new core A2A fields,
+- redefine A2A transport bindings or RPC names,
 - redefine NIP-SKL, NIP-SA, or NIP-AC wire semantics,
-- merge SKL / SA / AC into one layer,
-- require all A2A agents to adopt the OpenAgents sovereign stack.
+- require every A2A agent to adopt the OpenAgents sovereign stack.
 
 ### Related document
 
-For the implementation-oriented planning and sequencing handoff that complements this profile, see:
+For the implementation-oriented planning handoff that complements this profile, see:
 
 - [`docs/plans/a2a-sovereign-agent-integration-plan.md`](plans/a2a-sovereign-agent-integration-plan.md)
 
 ---
 
-## 2. Conceptual Mapping
+## 2. Current A2A Alignment Notes
 
-### 2.1 AgentCard → SA Agent Profile + SKL manifests + optional org identity
+This profile assumes the current A2A wire shape from `specification/a2a.proto` in `/Users/christopherdavid/code/A2A`.
 
-An A2A **AgentCard** can act as the public discovery surface for a sovereign agent.
+The important constraints are:
 
-- `AgentCard.id`
-  - SHOULD bind to the sovereign Nostr identity.
-  - Recommended format: `nostr:<npub>`.
-- `AgentCard.name` and `AgentCard.description`
-  - SHOULD be derived from the SA Agent Profile (`kind:39200`).
-- `AgentCard.skills[]`
-  - SHOULD be projected from SKL manifests (`kind:33400`).
-  - Each declared skill SHOULD remain traceable back to a SKL manifest reference such as `33400:<pubkey>:<d-tag>`.
-- Optional NIP-05 / organizational identity
-  - MAY be surfaced through metadata or extension metadata when the agent also publishes an optional SKL NIP-05 identity binding.
-- `extensions[]`
-  - MAY declare OpenAgents interoperability URIs indicating SKL / SA / AC participation.
+- `AgentCard` has **no core `id` field**. Sovereign identity therefore has to be projected through profile-defined extension params rather than a new top-level field.
+- Agent-level extensions are declared in `AgentCard.capabilities.extensions[]`, not at the top level of the card.
+- Extension-specific card data belongs in each extension's `params` object.
+- Request/task/artifact correlation data belongs in A2A `metadata` fields and request-time extension negotiation, not in new core fields.
+- `supportedInterfaces[]` entries use `protocolBinding` and `protocolVersion`.
+- The standard binding string for the REST binding is `HTTP+JSON`.
 
-In this model, the AgentCard is a **projection**, not the authoritative identity record.
+Under this profile:
 
-### 2.2 Task → SA session / trajectory
-
-An A2A **Task** maps naturally to an SA session / trajectory.
-
-- `Task.id` SHOULD correlate to an SA `session` identifier.
-- New tasks SHOULD create a new SA trajectory session (`kind:39230`).
-- Multi-turn A2A exchanges MAY continue an existing SA session when the underlying work is part of the same lifecycle.
-- Task status changes SHOULD correspond to SA session state transitions and related audit records.
-
-### 2.3 Message / Part / Artifact → SA ticks + SKL-backed capabilities + Nostr references
-
-- A2A `Message` content maps to SA tick inputs and outputs.
-- A2A `Part` content can carry user input, structured data, or references to externally stored payloads that are processed through SKL-backed capabilities.
-- A2A `Artifact` objects can represent outputs that are also hashed, referenced, or summarized in SA trajectory and audit events.
-- SKL manifests remain the canonical description of capabilities; A2A message exchange is the execution surface.
-
-### 2.4 securitySchemes / authorization behavior → SKL auth challenge + grants + SA guardians
-
-Under this profile, A2A `securitySchemes` and authorization behavior can be backed by:
-
-- SKL **authentication challenge / response** (`kind:33410` / `kind:33411`) to prove control of a Nostr key,
-- SKL **permission grants** (`kind:33420`) to scope allowed tools, actions, data, expiry, and invocation limits,
-- SA **guardian policies** and `security_posture` to require additional approval for higher-risk operations.
-
-In other words:
-
-- A2A declares the auth surface.
-- SKL and SA provide the sovereign authorization substrate.
-
-### 2.5 Funding / metering expectations → NIP-AC OSCE and settlement chain
-
-A2A does not define a sovereign credit or settlement model. Under this profile:
-
-- NIP-AC **OSCE envelopes** fund or constrain work.
-- AC **spend authorizations**, **settlement receipts**, and **cancel behavior** remain canonical.
-- A2A messages or task metadata may carry AC references or payloads, but the authoritative payment record remains the AC event chain.
+- card-level sovereign declarations live in `capabilities.extensions[].params`,
+- request-level sovereign declarations live in `SendMessageRequest.metadata`, `Message.metadata`, `Task.metadata`, `TaskStatusUpdateEvent.metadata`, and `Artifact.metadata`,
+- request-time extension behavior uses normal A2A extension negotiation.
 
 ---
 
-## 3. AgentCard Examples
+## 3. Conceptual Mapping
 
-The following examples are illustrative, non-normative, and intended to help implementers converge on compatible patterns.
+### 3.1 AgentCard -> SA profile + SKL manifests + extension params
 
-### 3.1 Example 1: Basic Sovereign Agent A2A card
+An A2A `AgentCard` can act as the public discovery surface for a sovereign agent.
+
+- `AgentCard.name` and `AgentCard.description`
+  - SHOULD be derived from the current SA agent profile (`kind:39200`).
+- `AgentCard.skills[]`
+  - SHOULD be projected from SKL manifests (`kind:33400`).
+  - Each projected skill SHOULD remain traceable back to a SKL manifest reference such as `33400:<skill_hex_pubkey>:<d-tag>`.
+- `AgentCard.capabilities.extensions[]`
+  - SHOULD declare the OpenAgents profile URIs used to expose SKL / SA / AC participation.
+  - SHOULD carry sovereign hints in each extension's `params` object.
+- Optional organization or NIP-05 identity
+  - MAY be surfaced through `provider`, `documentationUrl`, or extension params.
+
+Important boundary:
+
+- A2A discovery starts from the Agent Card URL.
+- Sovereign identity binding comes from extension params plus optional SKL auth challenge verification.
+
+### 3.2 Task -> SA session / trajectory
+
+An A2A `Task` maps naturally to an SA trajectory run.
+
+- `Task.id` SHOULD correlate to the SA session identifier.
+- A server MAY reuse `Task.id` as the `d` tag of the corresponding `kind:39230` session, or keep a separate session identifier and publish the mapping in task metadata.
+- Task status transitions SHOULD correspond to SA lifecycle transitions and related `kind:39231` trajectory events.
+- `Task.metadata` and task update metadata SHOULD carry the sovereign refs needed for correlation.
+
+### 3.3 Message / Part / Artifact -> SA trajectory events + off-Nostr payload refs
+
+- A2A `Message` and `Part` content maps to SA trajectory inputs and outputs.
+- A2A `Message.metadata` and `Part.metadata` may carry sovereign refs, hashes, or extension-specific funding metadata.
+- A2A `Artifact` objects can represent outputs that are also hashed, referenced, or summarized in SA trajectory events.
+- Large or sensitive payloads SHOULD stay off Nostr, with only hashes or minimal refs published where needed.
+
+### 3.4 Authentication / authorization -> A2A auth surface + SKL auth challenge + SA guardians
+
+Under this profile:
+
+- A2A `securitySchemes` remains the declared authentication surface.
+- The optional SKL auth challenge profile (`kind:33410` / `kind:33411`) can be used to prove current control of the claimed Nostr key.
+- SA guardian policy can be used to gate high-risk operations once the caller is authenticated.
+
+Current boundary:
+
+- This profile does **not** define a portable permission-grant event kind.
+- Fine-grained authorization beyond A2A auth plus guardian policy remains implementation-specific unless a later profile standardizes it.
+
+### 3.5 Funding / metering -> NIP-AC OSCE and settlement chain
+
+A2A does not define a sovereign settlement model. Under this profile:
+
+- NIP-AC outcome-scoped credit envelopes fund or constrain work.
+- A2A requests, message metadata, or parts may carry envelope refs or funding payloads.
+- NIP-AC remains authoritative for spend, settlement, receipt, default, and cancel-window semantics.
+
+---
+
+## 4. AgentCard Examples
+
+The following examples are illustrative and intentionally follow the current A2A card shape:
+
+- sovereign hints live in `capabilities.extensions[].params`,
+- transport entries use `protocolBinding` and `protocolVersion`,
+- the REST binding is `HTTP+JSON`.
+
+### 4.1 Example 1: Public card with sovereign identity hints
 
 ```json
 {
-  "id": "nostr:npub1researchagent7m3zq0example0000000000000000000000000",
   "name": "Research Assistant Agent",
-  "description": "Sovereign research agent that exposes A2A interfaces while publishing canonical identity and skill state on Nostr.",
-  "version": "1.0.0",
-  "documentationUrl": "https://example.com/docs/research-agent",
+  "description": "A2A research agent that publishes canonical sovereign state on Nostr.",
   "supportedInterfaces": [
     {
       "url": "https://agent.example.com/a2a/v1",
-      "protocolBinding": "HTTP_JSON",
-      "version": "1.0"
+      "protocolBinding": "HTTP+JSON",
+      "protocolVersion": "1.0"
     }
   ],
+  "version": "1.0.0",
+  "documentationUrl": "https://example.com/docs/research-agent",
   "capabilities": {
     "streaming": true,
     "pushNotifications": false,
-    "extendedAgentCard": false
+    "extendedAgentCard": false,
+    "extensions": [
+      {
+        "uri": "https://openagents.org/extensions/nip-skl/v1",
+        "description": "Publishes SKL manifests and supports optional SKL auth challenge verification.",
+        "required": false,
+        "params": {
+          "agentNpub": "npub1researchagentexample",
+          "nostrRelays": [
+            "wss://relay.example.com",
+            "wss://relay2.example.com"
+          ],
+          "sklManifestRefs": [
+            "33400:<agent_hex_pubkey>:web-search-v1",
+            "33400:<agent_hex_pubkey>:citation-format-v1"
+          ],
+          "authChallengeSupported": true
+        }
+      },
+      {
+        "uri": "https://openagents.org/extensions/nip-sa/v1",
+        "description": "Projects sovereign profile and trajectory correlation hints into A2A.",
+        "required": false,
+        "params": {
+          "agentProfileRef": "<current-39200-profile-ref>",
+          "trajectoryAuditAvailable": true
+        }
+      },
+      {
+        "uri": "https://openagents.org/extensions/nip-ac/v1",
+        "description": "Exposes optional OSCE funding support for A2A tasks.",
+        "required": false,
+        "params": {
+          "osceSupported": false
+        }
+      }
+    ]
   },
+  "defaultInputModes": [
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "text/plain",
+    "application/json"
+  ],
   "skills": [
     {
-      "id": "33400:npub1researchagent7m3zq0example0000000000000000000000000:web-search-v1",
+      "id": "33400:<agent_hex_pubkey>:web-search-v1",
       "name": "Web Search",
       "description": "Searches public web sources and returns ranked summaries.",
-      "tags": ["research", "search", "web"]
+      "tags": [
+        "research",
+        "search",
+        "web"
+      ],
+      "examples": [
+        "Find primary sources about Lightning Network fee markets."
+      ]
     },
     {
-      "id": "33400:npub1researchagent7m3zq0example0000000000000000000000000:citation-format-v1",
+      "id": "33400:<agent_hex_pubkey>:citation-format-v1",
       "name": "Citation Formatting",
       "description": "Formats references into common academic citation styles.",
-      "tags": ["citation", "formatting", "academic"]
-    }
-  ],
-  "extensions": [
-    {
-      "uri": "https://openagents.org/extensions/nip-skl/v1",
-      "required": false,
-      "metadata": {
-        "skl_manifest_refs": [
-          "33400:npub1researchagent7m3zq0example0000000000000000000000000:web-search-v1",
-          "33400:npub1researchagent7m3zq0example0000000000000000000000000:citation-format-v1"
-        ]
-      }
-    },
-    {
-      "uri": "https://openagents.org/extensions/nip-sa/v1",
-      "required": false,
-      "metadata": {
-        "agent_profile_ref": "39200:npub1researchagent7m3zq0example0000000000000000000000000:default-profile",
-        "audit_trail_available": true
-      }
-    },
-    {
-      "uri": "https://openagents.org/extensions/nip-ac/v1",
-      "required": false,
-      "metadata": {
-        "osce_supported": false
-      }
+      "tags": [
+        "citation",
+        "formatting",
+        "academic"
+      ]
     }
   ]
 }
 ```
 
-### 3.2 Example 2: Extended AgentCard with payments and trust
+### 4.2 Example 2: Extended card with auth, trust, and funding hints
 
 ```json
 {
-  "id": "nostr:npub1researchagent7m3zq0example0000000000000000000000000",
   "name": "Research Assistant Agent",
-  "description": "Sovereign research agent with evaluated skills, guardian controls, and OSCE-funded task execution.",
-  "version": "1.1.0",
-  "documentationUrl": "https://example.com/docs/research-agent",
+  "description": "A2A sovereign agent with evaluated skills, guardian-aware execution, and OSCE-funded task support.",
   "supportedInterfaces": [
     {
       "url": "https://agent.example.com/a2a/v1",
-      "protocolBinding": "HTTP_JSON",
-      "version": "1.0"
+      "protocolBinding": "HTTP+JSON",
+      "protocolVersion": "1.0"
+    },
+    {
+      "url": "https://agent.example.com/a2a/jsonrpc",
+      "protocolBinding": "JSONRPC",
+      "protocolVersion": "1.0"
     }
   ],
+  "version": "1.1.0",
+  "documentationUrl": "https://example.com/docs/research-agent",
   "capabilities": {
     "streaming": true,
     "pushNotifications": true,
-    "extendedAgentCard": true
-  },
-  "skills": [
-    {
-      "id": "33400:npub1researchagent7m3zq0example0000000000000000000000000:web-search-v2",
-      "name": "Web Search",
-      "description": "Searches public web sources and returns ranked summaries.",
-      "tags": ["research", "search", "web"],
-      "metadata": {
-        "assurance_tier": "third-party-evaluated",
-        "evaluator_pubkey": "npub1evaluator000000000000000000000000000000000000000000000",
-        "attestation_event_id": "attestation-event-001"
-      }
-    },
-    {
-      "id": "33400:npub1researchagent7m3zq0example0000000000000000000000000:citation-format-v2",
-      "name": "Citation Formatting",
-      "description": "Formats references into common academic citation styles.",
-      "tags": ["citation", "formatting", "academic"],
-      "metadata": {
-        "assurance_tier": "red-team-tested",
-        "evaluator_pubkey": "npub1redteam00000000000000000000000000000000000000000000000",
-        "attestation_event_id": "attestation-event-002"
-      }
-    },
-    {
-      "id": "33400:npub1researchagent7m3zq0example0000000000000000000000000:summarize-v1",
-      "name": "Summarization",
-      "description": "Produces concise summaries from supplied material.",
-      "tags": ["summary", "analysis"],
-      "metadata": {
-        "assurance_tier": "self-assessed"
-      }
-    }
-  ],
-  "securitySchemes": {
-    "nostrChallenge": {
-      "type": "http",
-      "scheme": "bearer",
-      "bearerFormat": "Nostr-SKL-Challenge",
-      "description": "Bearer credential derived from a successful SKL auth challenge / response flow and bound to the caller's authorized session."
-    }
-  },
-  "security": [
-    {
-      "nostrChallenge": []
-    }
-  ],
-  "extensions": [
-    {
-      "uri": "https://openagents.org/extensions/nip-skl/v1",
-      "required": false,
-      "metadata": {
-        "nostr_relays": [
-          "wss://relay.example.com",
-          "wss://relay2.example.com"
-        ],
-        "skl_manifest_refs": [
-          "33400:npub1researchagent7m3zq0example0000000000000000000000000:web-search-v2",
-          "33400:npub1researchagent7m3zq0example0000000000000000000000000:citation-format-v2",
-          "33400:npub1researchagent7m3zq0example0000000000000000000000000:summarize-v1"
-        ],
-        "auth_challenge_supported": true,
-        "permission_grants_required": true
-      }
-    },
-    {
-      "uri": "https://openagents.org/extensions/nip-sa/v1",
-      "required": false,
-      "metadata": {
-        "agent_profile_ref": "39200:npub1researchagent7m3zq0example0000000000000000000000000:default-profile",
-        "guardian_threshold": 2,
-        "audit_trail_available": true,
-        "delegation_supported": true,
-        "security_posture_summary": {
-          "instruction_data_separation": true,
-          "tool_use_requires_guardian": true,
-          "hijacking_resistance_tier": "third-party-evaluated"
+    "extendedAgentCard": true,
+    "extensions": [
+      {
+        "uri": "https://openagents.org/extensions/nip-skl/v1",
+        "description": "Publishes SKL manifests, assurance hints, and optional SKL auth challenge support.",
+        "required": false,
+        "params": {
+          "agentNpub": "npub1researchagentexample",
+          "nostrRelays": [
+            "wss://relay.example.com",
+            "wss://relay2.example.com"
+          ],
+          "sklManifestRefs": [
+            "33400:<agent_hex_pubkey>:web-search-v2",
+            "33400:<agent_hex_pubkey>:citation-format-v2",
+            "33400:<agent_hex_pubkey>:summarize-v1"
+          ],
+          "authChallengeSupported": true,
+          "assuranceSummary": {
+            "33400:<agent_hex_pubkey>:web-search-v2": "third-party-evaluated",
+            "33400:<agent_hex_pubkey>:citation-format-v2": "red-team-tested",
+            "33400:<agent_hex_pubkey>:summarize-v1": "self-assessed"
+          }
+        }
+      },
+      {
+        "uri": "https://openagents.org/extensions/nip-sa/v1",
+        "description": "Projects sovereign profile, trajectory audit hints, delegation support, and security posture summary.",
+        "required": false,
+        "params": {
+          "agentProfileRef": "<current-39200-profile-ref>",
+          "trajectoryAuditAvailable": true,
+          "delegationSupported": true,
+          "securityPostureSummary": {
+            "instructionDataSeparation": true,
+            "toolUseRequiresGuardian": true,
+            "hijackingResistanceTier": "third-party-evaluated"
+          }
+        }
+      },
+      {
+        "uri": "https://openagents.org/extensions/nip-ac/v1",
+        "description": "Supports OSCE-funded task execution and NIP-AC receipt correlation.",
+        "required": false,
+        "params": {
+          "osceSupported": true,
+          "acceptedCurrencies": [
+            "sat"
+          ],
+          "acceptedUnderwriters": [
+            "<underwriter_hex_pubkey>"
+          ],
+          "acceptedSpendRails": [
+            "lightning"
+          ],
+          "cancelWindowSupported": true,
+          "osceHandoverMode": "by-reference"
         }
       }
-    },
-    {
-      "uri": "https://openagents.org/extensions/nip-ac/v1",
-      "required": false,
-      "metadata": {
-        "osce_supported": true,
-        "accepted_currencies": ["sat"],
-        "accepted_underwriters": [
-          "npub1underwriter0000000000000000000000000000000000000000000"
-        ],
-        "hold_period_secs_default": 3600,
-        "osce_handover_mode": "by-reference"
+    ]
+  },
+  "securitySchemes": {
+    "nostrChallenge": {
+      "httpAuthSecurityScheme": {
+        "scheme": "Bearer",
+        "bearerFormat": "OpenAgents-SKL-Challenge-Session",
+        "description": "Bearer credential bound to a completed SKL auth challenge and the caller's authenticated session."
       }
     }
+  },
+  "defaultInputModes": [
+    "text/plain",
+    "application/json"
   ],
-  "metadata": {
-    "nip05": "research-agent@example.com"
-  }
+  "defaultOutputModes": [
+    "text/plain",
+    "application/json"
+  ],
+  "skills": [
+    {
+      "id": "33400:<agent_hex_pubkey>:web-search-v2",
+      "name": "Web Search",
+      "description": "Searches public web sources and returns ranked summaries.",
+      "tags": [
+        "research",
+        "search",
+        "web"
+      ]
+    },
+    {
+      "id": "33400:<agent_hex_pubkey>:citation-format-v2",
+      "name": "Citation Formatting",
+      "description": "Formats references into common academic citation styles.",
+      "tags": [
+        "citation",
+        "formatting",
+        "academic"
+      ]
+    },
+    {
+      "id": "33400:<agent_hex_pubkey>:summarize-v1",
+      "name": "Summarization",
+      "description": "Produces concise summaries from supplied material.",
+      "tags": [
+        "summary",
+        "analysis"
+      ]
+    }
+  ]
 }
 ```
 
+Notes:
+
+- If the agent requires authenticated access, the corresponding A2A security requirement should reference the declared `nostrChallenge` scheme using the current A2A wire shape.
+- A2A card signatures and SKL auth challenge verification solve different problems. JWS card signatures cover the card document; SKL auth challenge proves current control of the sovereign Nostr key.
+
 ---
 
-## 4. Interoperability Flows
+## 5. Interoperability Flows
 
-### 4.1 Flow A — discovery and identity verification
+### 5.1 Flow A: discovery and sovereign identity verification
 
-1. The client discovers the agent through A2A by fetching `/.well-known/agent-card.json`.
-2. The client reads `AgentCard.id` and sees a sovereign identifier such as `nostr:npub1...`.
-3. The client reads `extensions[]` to determine whether the agent advertises SKL / SA / AC participation and to learn relay or manifest hints.
-4. If the card declares a Nostr- or SKL-backed `securitySchemes` entry, the client treats that as the advertised authentication surface for authenticated interactions.
-5. To verify the server's sovereign identity, the client may issue an SKL auth challenge (`kind:33410`) to the claimed pubkey.
-6. The agent responds with a signed SKL auth response (`kind:33411`) proving control of the corresponding Nostr key.
-7. The client verifies the challenge, response, nonce, expiry, and signer identity.
-8. After verification, the client can treat the A2A endpoint and the Nostr identity as bound for this interoperability profile.
-
-Under this flow:
-
-- **A2A** handles discovery and advertised auth surface.
-- **NIP-SKL** handles sovereign proof-of-possession.
-- **NIP-SA** remains the canonical identity profile layer.
-
-### 4.2 Flow B — task execution mapped to SA session + SKL skills
-
-1. The client sends `SendMessage` or `SendStreamingMessage` to the A2A endpoint.
-2. The server authenticates the caller using the declared A2A auth surface and validates the underlying SKL-backed authorization state.
-3. The server creates or resumes an SA session / trajectory for the task.
-4. The server correlates the A2A `Task.id` with the SA `session` identifier.
-5. The server selects one or more SKL-backed skills that satisfy the request.
-6. The server executes the work as SA ticks / actions.
-7. The server emits SA audit events (`kind:39250`) for key actions, inputs, outputs, approvals, and references.
-8. The server returns A2A task status and artifacts, optionally including metadata that points back to the SA session, SKL skill refs used, and audit refs.
+1. The client fetches `/.well-known/agent-card.json`.
+2. The client reads `supportedInterfaces`, `capabilities.extensions`, and any declared `securitySchemes`.
+3. The client resolves sovereign hints from extension params, especially:
+   - `agentProfileRef`
+   - `agentNpub`
+   - `sklManifestRefs`
+   - `nostrRelays`
+4. The client may fetch the referenced SA profile and SKL manifests from Nostr relays.
+5. If higher confidence is needed, the client issues an SKL auth challenge (`kind:33410`) to the claimed pubkey.
+6. The agent responds with a signed SKL auth response (`kind:33411`).
+7. The client verifies the challenge, nonce, expiry window, and signer identity.
+8. The client can now treat the A2A endpoint and the verified Nostr key as bound for this interoperability profile.
 
 Under this flow:
 
-- **A2A** handles task transport, streaming, and artifact delivery.
-- **NIP-SKL** identifies and constrains which skills can be used.
-- **NIP-SA** owns lifecycle, session, audit, and guardianship state.
+- **A2A** handles discovery and endpoint advertisement.
+- **NIP-SKL** handles optional proof-of-possession verification.
+- **NIP-SA** provides the sovereign profile being projected.
 
-### 4.3 Flow C — funding and settlement via NIP-AC
+### 5.2 Flow B: task execution mapped to SA trajectory
 
-1. The client presents or references an OSCE envelope before or during task initiation.
+1. The client calls `SendMessage` or `SendStreamingMessage`.
+2. The server authenticates the caller using the declared A2A auth surface.
+3. If the request depends on extension behavior, the client and server use standard A2A extension negotiation for the relevant URIs.
+4. The server creates or resumes an SA trajectory session (`kind:39230`).
+5. The server correlates the A2A `Task.id` with the SA session identifier.
+6. The server selects one or more SKL-backed skills that satisfy the request.
+7. The server emits `kind:39231` trajectory events for consequential actions, approvals, and outputs.
+8. The server returns A2A task state and artifacts, optionally including metadata refs back to the session, skill refs used, and relevant trajectory events.
+
+Under this flow:
+
+- **A2A** handles task transport, streaming, task updates, and artifact delivery.
+- **NIP-SKL** identifies the skill manifests backing the work.
+- **NIP-SA** owns lifecycle, trajectory, guardianship, and audit-friendly action history.
+
+### 5.3 Flow C: funding and settlement via NIP-AC
+
+1. The client includes an OSCE envelope ref or funding payload in request metadata, message metadata, or an extension-specific data part.
 2. The server resolves and validates the AC funding record, including:
-   - allowed skill scope,
-   - budget / maximum amount,
-   - underwriter identity,
+   - scope,
+   - cap,
    - expiry,
-   - any guardian approval requirements.
-3. The server verifies that the requested SKL-backed actions fit within the permitted funding scope.
+   - issuer / underwriter trust,
+   - applicable guardian policy.
+3. The server verifies that the requested actions fit within the permitted funding scope.
 4. The server executes the task under those budget and authorization constraints.
-5. If the envelope includes hold / reversibility semantics, the server enforces the configured `hold_period_secs` behavior before final settlement.
+5. If the envelope uses `cancel_until`, the server honors that cancel window before irreversible delivery or final settlement.
 6. Successful completion maps to AC spend authorization and settlement receipt behavior.
-7. Interruption, cancellation, or dispute within the allowed hold window may map to AC cancel behavior.
-8. The A2A task outcome is returned to the client, but the authoritative funding and settlement state remains in NIP-AC events.
+7. Cancellation, interruption, or policy-triggered rollback may map to AC cancel or default behavior.
+8. The A2A task outcome is returned to the client, but the authoritative funding state remains in NIP-AC events.
 
 Under this flow:
 
-- **A2A** carries the task request/response interaction.
-- **NIP-AC** remains authoritative for funding, spend, settlement, and rollback semantics.
-- **NIP-SA** may require guardian approval before certain funded actions proceed.
+- **A2A** carries the request/response interaction.
+- **NIP-AC** remains authoritative for funding, settlement, receipts, defaults, and cancel windows.
+- **NIP-SA** may require guardian approval before sensitive funded actions proceed.
 
 ---
 
-## 5. Recommended Metadata and Identifier Conventions
+## 6. Recommended Params and Metadata Conventions
 
 The following conventions are recommended for interoperability and are safe to ignore by generic A2A clients that do not implement this profile.
 
-### 5.1 Identifier conventions
+### 6.1 Identifier conventions
 
-- Sovereign agent id:
-  - `nostr:<npub>`
-- SKL manifest reference:
-  - `33400:<pubkey>:<d-tag>`
-- SA profile reference:
-  - `39200:<pubkey>:<d-tag>`
-- SA session reference:
-  - implementation-defined session id, optionally exposed directly as `Task.id`
-- AC envelope reference:
-  - event id or addressable ref such as `39240:<pubkey>:<d-tag>`
-- Audit reference:
-  - event id or addressable ref for `kind:39250`
+- Nostr address refs SHOULD use raw hex pubkeys in `kind:pubkey:d` form.
+- Human-friendly `npub` strings MAY be duplicated in extension params for display or UX.
+- SKL manifest ref:
+  - `33400:<skill_hex_pubkey>:<d-tag>`
+- SA profile ref:
+  - implementation-defined stable reference to the current `kind:39200` profile event
+- SA session ref:
+  - `39230:<agent_hex_pubkey>:<session-d-tag>`
+- AC envelope ref:
+  - `39242:<issuer_hex_pubkey>:<d-tag>` or a stable event id reference
+- Trajectory event ref:
+  - event id of a relevant `kind:39231` event
+- AC receipt ref:
+  - event id of a relevant `kind:39244` receipt
 
-### 5.2 Recommended task correlation fields
+### 6.2 Where sovereign data belongs in A2A
 
-Implementations MAY include the following fields in task metadata, artifact metadata, or extension-specific metadata:
+- `AgentCard.capabilities.extensions[].params`
+  - card-level sovereign declarations and capability hints
+- `SendMessageRequest.metadata`
+  - caller-provided sovereign task/funding refs
+- `Message.metadata` and `Part.metadata`
+  - per-message correlation, hashes, and extension-specific funding/auth data
+- `Task.metadata` and `TaskStatusUpdateEvent.metadata`
+  - server-emitted lifecycle and session correlation refs
+- `Artifact.metadata`
+  - server-emitted output correlation refs
+- `Message.extensions` and `Artifact.extensions`
+  - extension URIs that were actually active or contributed data during the interaction
 
-- `sa_session_id`
-- `sa_session_ref`
-- `skl_skill_refs_used`
-- `permission_grant_refs`
-- `guardian_approval_refs`
-- `osce_envelope_ref`
-- `ac_spend_refs`
-- `audit_refs`
+### 6.3 Recommended extension params
 
-These fields make it easier for interoperable clients to correlate A2A-visible behavior with sovereign state.
-
-### 5.3 Recommended extension metadata
-
-#### SKL extension metadata
-
-Suggested fields:
-
-- `nostr_relays`
-- `skl_manifest_refs`
-- `auth_challenge_supported`
-- `permission_grants_required`
-
-#### SA extension metadata
+#### SKL extension params
 
 Suggested fields:
 
-- `agent_profile_ref`
-- `guardian_threshold`
-- `audit_trail_available`
-- `delegation_supported`
-- `security_posture_summary`
+- `agentNpub`
+- `nostrRelays`
+- `sklManifestRefs`
+- `authChallengeSupported`
+- `assuranceSummary` (optional)
 
-#### AC extension metadata
+#### SA extension params
 
 Suggested fields:
 
-- `osce_supported`
-- `accepted_currencies`
-- `accepted_underwriters`
-- `hold_period_secs_default`
-- `osce_handover_mode`
+- `agentProfileRef`
+- `trajectoryAuditAvailable`
+- `delegationSupported`
+- `securityPostureSummary`
 
-### 5.4 Recommended OSCE handover modes
+#### AC extension params
 
-Recommended values for `osce_handover_mode`:
+Suggested fields:
+
+- `osceSupported`
+- `acceptedCurrencies`
+- `acceptedUnderwriters`
+- `acceptedSpendRails`
+- `cancelWindowSupported`
+- `osceHandoverMode`
+
+### 6.4 Recommended metadata keys
+
+Suggested server-emitted metadata keys:
+
+- `saSessionId`
+- `saSessionRef`
+- `sklSkillRefsUsed`
+- `guardianApprovalRefs`
+- `osceEnvelopeRef`
+- `acReceiptRefs`
+- `trajectoryEventRefs`
+
+These keys are profile-level conventions, not A2A core fields.
+
+### 6.5 Recommended OSCE handover modes
+
+Recommended values for `osceHandoverMode`:
 
 - `by-reference`
-- `data-part`
+- `inline-data-part`
 - `either`
 
 Recommended starting point:
 
-- Prefer **by-reference** first, where the A2A request carries an AC envelope reference and the server resolves canonical state from Nostr.
+- prefer **by-reference** first, where the A2A request carries an AC envelope ref and the server resolves canonical state from Nostr.
 
 ---
 
-## 6. Security Considerations
+## 7. Security Considerations
 
-### 6.1 TLS and A2A transport security
+### 7.1 A2A transport security still applies
 
 - Standard A2A transport security remains required.
-- HTTPS or other TLS-backed transport is still mandatory for production deployments.
+- Production deployments still need TLS-backed transport.
 - This profile does not weaken A2A transport requirements.
 
-### 6.2 Nostr key custody and trust
+### 7.2 Nostr key custody is still the sovereign trust root
 
-- The Nostr key used by the sovereign agent is the root of trust for SKL / SA / AC identity and signed event claims.
+- The sovereign Nostr key is the trust root for SKL / SA / AC identity and signed claims.
 - Implementers should treat key custody as security-critical.
-- Threshold or guardian-backed signing arrangements may be appropriate for higher-risk agents.
+- Threshold or guardian-backed signing may be appropriate for higher-risk agents.
 
-### 6.3 Audit trails complement A2A logging
+### 7.3 Trajectory events complement A2A logs
 
-- A2A logs are useful operationally, but SA audit events are the canonical signed record of sensitive or material actions.
-- Implementers should define minimum audit emission rules so task execution can be reconstructed with integrity.
+- A2A logs are operationally useful, but `kind:39230` / `kind:39231` remain the canonical signed lifecycle record.
+- Implementers should define minimum trajectory emission rules so material execution can be reconstructed with integrity.
 
-### 6.4 Hold/cancel rollback semantics complement A2A cancellation
+### 7.4 Cancel windows complement A2A cancellation
 
-- A2A task cancellation and AC hold/cancel behavior are related but not identical.
+- A2A task cancellation and AC `cancel_until` behavior are related but not identical.
 - Task interruption does not by itself define the canonical settlement result.
 - Implementers should ensure task state and AC state cannot silently diverge.
 
-### 6.5 Least privilege through grants and guardianship
+### 7.5 Least privilege comes from auth, local policy, and guardianship
 
-- SKL permission grants should be used to scope skills, tools, actions, boundaries, duration, and invocation counts.
-- SA guardianship should be used where autonomous execution exceeds local risk thresholds.
-- Delegation should never widen the parent authorization or funding scope.
+- `securitySchemes` should expose the auth surface cleanly.
+- SKL auth challenge should be used when Nostr-key proof-of-possession matters.
+- SA guardianship should gate higher-risk operations.
+- Delegation must never widen the parent authorization or funding scope.
 
-### 6.6 Privacy and public Nostr events
+### 7.6 Privacy and public Nostr events
 
 - Public Nostr events are not appropriate for raw sensitive task payloads.
-- Sensitive content should generally stay off-Nostr.
-- On-Nostr references should prefer hashes, identifiers, and minimal metadata rather than full confidential payloads.
+- Sensitive content should generally stay off Nostr.
+- On-Nostr refs should prefer hashes, identifiers, and minimal metadata.
 
 ---
 
-## 7. Non-Goals
+## 8. Non-Goals
 
-This interoperability profile does **not**:
+This profile does **not**:
 
 - modify the A2A protocol,
+- add new A2A core fields,
 - replace NIP-SKL, NIP-SA, or NIP-AC,
-- collapse SKL / SA / AC into one layer,
+- define a new portable authorization-grant event kind,
 - require every A2A agent to adopt the OpenAgents sovereign stack,
 - require every sovereign agent to expose an A2A interface.
 
 Its purpose is narrower:
 
-- to define a stable and practical pattern for agents that want to combine **A2A interoperability** with **sovereign Nostr-backed identity, lifecycle, audit, and payment semantics**.
+- define a stable pattern for agents that want to combine **A2A interoperability** with **sovereign Nostr-backed identity, lifecycle, audit, and payment semantics**.
 
 ---
 
-## 8. Summary
+## 9. Summary
 
 Under this profile:
 
 - A2A is the **wire layer**.
-- NIP-SKL is the **identity / trust / skills layer**.
-- NIP-SA is the **lifecycle / guardianship / audit / delegation layer**.
-- NIP-AC is the **credit / settlement / rollback layer**.
+- NIP-SKL is the **skill registry / trust / optional auth-challenge layer**.
+- NIP-SA is the **lifecycle / trajectory / guardianship / delegation layer**.
+- NIP-AC is the **credit / settlement / cancel-window layer**.
 
-An agent that follows this profile can remain fully A2A-compliant while also exposing a sovereign identity, verifiable skill inventory, explicit permission model, auditable lifecycle, and outcome-scoped payment rails.
-
-That is the intended interoperability result.
+An agent that follows this profile can remain A2A-compliant while also exposing a sovereign identity binding, verifiable skill inventory, explicit task-to-trajectory correlation, and outcome-scoped payment rails.

--- a/docs/plans/a2a-sovereign-agent-integration-plan.md
+++ b/docs/plans/a2a-sovereign-agent-integration-plan.md
@@ -8,301 +8,325 @@
 
 ## 1. Purpose and Scope
 
-This document consolidates the proposed integration model for letting an **A2A-compliant agent** incrementally adopt the OpenAgents sovereign stack:
+This document describes how an **A2A-compliant agent** can incrementally adopt the OpenAgents sovereign stack without changing A2A itself.
 
-- **NIP-SKL** — skill registry, identity, attestation, revocation, auth challenge, permission grants
-- **NIP-SA** — sovereign agent identity, guardianship, lifecycle, sessions/trajectories, audit, delegation
-- **NIP-AC** — outcome-scoped credit (OSCE), spend authorization, settlement, hold/cancel behavior
+- **NIP-SKL** provides skill registry, trust, and optional auth-challenge semantics.
+- **NIP-SA** provides sovereign lifecycle, trajectory, guardianship, and delegation semantics.
+- **NIP-AC** provides outcome-scoped credit, settlement, and cancel-window semantics.
 
-This is an **implementation-oriented handoff**, not a replacement for either the A2A spec or the NIP specs. Its purpose is to give the team a concrete layering model, implementation phases, interface expectations, and ticketable workstreams.
+This is an **implementation-oriented handoff**, not a replacement for the A2A spec or the NIP drafts. Its purpose is to give the team a concrete layering model, interface expectations, and a ticketable rollout path.
 
 ### Intended readers
 
-- Chris and product/spec reviewers deciding what to schedule
-- Engineers implementing the server, identity, audit, or payments pieces
-- Coding agents that need a practical source of truth for sequencing work
+- product/spec reviewers deciding what to schedule,
+- engineers implementing server, identity, audit, or payments work,
+- coding agents that need a current sequencing source of truth.
 
 ### In scope
 
-- How an A2A agent can expose **sovereign identity, skills, guardrails, and payment rails** without changing A2A itself
-- How to map A2A concepts onto SKL / SA / AC responsibilities
-- Recommended metadata shapes and identifiers to support implementation
-- A phased rollout plan that preserves the current layering model
+- how an A2A agent can expose sovereign identity, skills, audit, and payment rails,
+- how to map A2A concepts onto SKL / SA / AC responsibilities,
+- recommended extension params and metadata shapes,
+- a phased rollout plan that preserves the current layering model.
 
 ### Out of scope
 
-- Rewriting A2A
-- Collapsing SKL / SA / AC into one protocol
-- Replacing Nostr as the canonical event substrate for identity, lifecycle, audit, or credit
-- Immediate product commitment to ship the full interop surface in MVP
-- Deep UI design or specific runtime crate ownership changes
+- rewriting A2A,
+- adding new A2A core fields,
+- collapsing SKL / SA / AC into one protocol,
+- replacing Nostr as the canonical event substrate,
+- committing the retained MVP to ship the full interop surface immediately.
 
 ### Scope guardrail
 
-This repo is currently MVP-oriented and desktop-first. This document is therefore best treated as a **planning and architecture handoff** that can be implemented incrementally and only where it supports the retained product direction.
+This repo is currently MVP-oriented and desktop-first. Treat this document as a **planning and architecture handoff** that should only be implemented where it supports the retained product direction.
 
 ### Related document
 
-For the protocol-facing, non-normative interoperability reference that complements this implementation handoff, see:
+For the protocol-facing interoperability reference that complements this implementation handoff, see:
 
 - [`docs/A2A_INTEROP_PROFILE.md`](../A2A_INTEROP_PROFILE.md)
 
 ---
 
-## 2. Architectural Summary
+## 2. A2A Guardrails for This Plan
+
+This plan follows the current A2A wire shape from `/Users/christopherdavid/code/A2A/specification/a2a.proto`.
+
+That implies several hard guardrails:
+
+- `AgentCard` has **no core `id` field**.
+- Agent-level extension declarations live in `AgentCard.capabilities.extensions[]`.
+- Extension-specific card data belongs in each extension's `params` object.
+- Sovereign request/task/artifact correlation belongs in A2A `metadata` fields and standard A2A extension negotiation.
+- `supportedInterfaces[]` entries use `protocolBinding` and `protocolVersion`.
+- The REST binding string is `HTTP+JSON`.
+
+Current sovereign protocol assumptions for this plan:
+
+- SKL auth challenge is the optional `kind:33410` / `kind:33411` profile.
+- SA audit-friendly history is expressed through `kind:39230` / `kind:39231`.
+- AC reversibility uses `cancel_until`.
+- AC envelopes are `kind:39242`, not `kind:39240`.
+
+When the human-written A2A markdown examples lag the wire schema, follow `a2a.proto`.
+
+---
+
+## 3. Architectural Summary
 
 ### Core position
 
 - **A2A remains the wire protocol and interoperability layer.**
-- **NIP-SKL remains the canonical skill / identity / trust layer.**
-- **NIP-SA remains the canonical lifecycle / guardianship / audit / delegation layer.**
-- **NIP-AC remains the canonical credit / settlement / rollback layer.**
+- **NIP-SKL remains the canonical skill / trust / optional auth-challenge layer.**
+- **NIP-SA remains the canonical lifecycle / trajectory / guardianship / delegation layer.**
+- **NIP-AC remains the canonical credit / settlement / cancel-window layer.**
 
 The integration goal is **layering**, not replacement:
 
 1. An agent speaks **A2A** to clients and peer agents.
-2. That same agent publishes and verifies canonical state through **Nostr events**.
-3. The A2A server surface projects selected sovereign capabilities into A2A structures such as `AgentCard`, `Task`, and `securitySchemes`.
+2. That same agent publishes and verifies canonical sovereign state through **Nostr events**.
+3. The A2A server surface projects selected sovereign capabilities into A2A structures such as `AgentCard`, `Task`, `Message`, `Artifact`, and request metadata.
 
 ### Canonical sources of truth
 
 | Concern | Canonical layer | A2A role |
 | --- | --- | --- |
-| Agent identity | NIP-SA Agent Profile (`kind:39200`) + NIP-SKL identity semantics | Discovery and transport-facing presentation |
-| Skill catalog | NIP-SKL manifests (`kind:33400`) and related attestations | AgentCard skill projection |
-| Authorization substrate | NIP-SKL auth challenge + permission grants | Declared through A2A `securitySchemes` and enforced at request handling |
-| Lifecycle / task execution | NIP-SA sessions, ticks, trajectories, audit events | Task and message exchange |
-| Delegation / sub-agents | NIP-SA delegation events | Optional orchestration behavior behind A2A tasks |
-| Funding / settlement | NIP-AC OSCE envelopes, spends, receipts, cancel semantics | Optional payment/metering integration carried alongside A2A task execution |
+| Agent identity | NIP-SA agent profile (`kind:39200`) plus profile-defined extension params | Discovery and transport-facing presentation |
+| Skill catalog | NIP-SKL manifests (`kind:33400`) and related labels | AgentCard skill projection |
+| Authentication bridge | A2A `securitySchemes` plus optional SKL auth challenge | Declared at the A2A edge, verified against sovereign key material |
+| Lifecycle / task execution | NIP-SA sessions and trajectory events (`39230` / `39231`) | Task, task updates, and message exchange |
+| Delegation / sub-agents | NIP-SA delegation events (`39260`) | Optional orchestration behind A2A tasks |
+| Funding / settlement | NIP-AC envelopes, spends, receipts, cancel/default events | Optional payment integration carried alongside A2A task execution |
 
 ### Architectural principle
 
-The A2A-facing surface should be understood as a **projection layer** over sovereign state, not as an independent source of truth.
+The A2A-facing surface should be treated as a **projection layer** over sovereign state, not as an independent source of truth.
 
 ---
 
-## 3. Conceptual Mapping
+## 4. Conceptual Mapping
 
-### 3.1 A2A `AgentCard` → SA Agent Profile + SKL manifests + optional org identity
+### 4.1 A2A `AgentCard` -> SA profile + SKL manifests + extension params
 
 Recommended mapping:
 
-- `AgentCard.id`
-  - SHOULD bind to the sovereign agent's Nostr identity.
-  - Preferred form: `nostr:<npub>`.
 - `AgentCard.name` / `description`
-  - SHOULD be derived from the SA Agent Profile (`kind:39200`).
+  - SHOULD be derived from the current SA profile.
 - `AgentCard.skills[]`
-  - SHOULD be projected from SKL manifests (`kind:33400`).
-  - Each skill entry SHOULD remain traceable back to a SKL manifest reference such as `33400:<pubkey>:<d-tag>`.
-- `AgentCard.metadata.nip05` or extension metadata
-  - MAY surface optional NIP-05 organizational identity already supported by SKL.
-- `AgentCard.extensions[]`
-  - SHOULD declare any OpenAgents-specific layering URIs used to signal SKL / SA / AC participation.
+  - SHOULD be projected from SKL manifests.
+  - Each skill SHOULD remain traceable back to a manifest ref such as `33400:<skill_hex_pubkey>:<d-tag>`.
+- `AgentCard.capabilities.extensions[]`
+  - SHOULD declare the OpenAgents profile URIs used for SKL / SA / AC participation.
+  - SHOULD carry sovereign identity hints in `params`.
+- `provider` / `documentationUrl`
+  - MAY surface organization or documentation hints, but they are not the sovereign identity anchor.
 
-### 3.2 A2A `Task` → SA session / trajectory
+### 4.2 A2A `Task` -> SA session / trajectory
 
 Recommended mapping:
 
-- A2A `Task.id` SHOULD correlate to an SA `session` identifier.
-- New tasks SHOULD create a new SA trajectory session (`kind:39230`).
-- Multi-turn tasks SHOULD continue the same session where appropriate.
-- Task status transitions SHOULD map to SA lifecycle state and be mirrored in audit / trajectory events.
+- A2A `Task.id` SHOULD correlate to the SA session identifier.
+- A deployment MAY reuse `Task.id` as the `d` tag of the `kind:39230` session, or publish the mapping in task metadata.
+- Task status transitions SHOULD map to SA lifecycle state and be mirrored by `kind:39231` events where material.
 
-### 3.3 A2A `Message` / `Part` / `Artifact` → SA ticks + SKL-described capabilities
+### 4.3 A2A `Message` / `Part` / `Artifact` -> SA trajectory material
 
-- A2A request messages correspond to SA tick inputs and/or trajectory input material.
-- The skill/tooling actually used SHOULD be selected from SKL-described capabilities.
-- Outputs, files, and structured results MAY be exposed as A2A artifacts while being hashed or referenced in SA audit events.
-- Large or sensitive outputs SHOULD live off-Nostr, with only references / hashes published where needed.
+- A2A request messages correspond to SA trajectory inputs and outputs.
+- Sovereign refs, hashes, and funding hints SHOULD live in `metadata`, not new A2A core fields.
+- Large or sensitive outputs SHOULD stay off Nostr, with only refs or hashes published where needed.
 
-### 3.4 A2A `securitySchemes` / authorization model → SKL auth challenge + grants + SA guardians
+### 4.4 A2A auth surface -> `securitySchemes` + SKL auth challenge + SA guardian checks
 
-- A2A authentication can declare a custom scheme that is backed by SKL auth challenge semantics.
-- A2A authorization decisions SHOULD be enforced using:
-  - SKL auth challenge proof-of-possession
-  - SKL permission grants (`kind:33420`)
-  - SA guardian thresholds and security posture for sensitive operations
+- A2A `securitySchemes` remains the public auth declaration surface.
+- The optional SKL auth challenge profile can bind that A2A surface to a Nostr key.
+- SA guardian policy can gate sensitive operations after caller authentication succeeds.
+- Fine-grained authorization beyond this remains implementation-specific unless a later profile standardizes it.
 
-### 3.5 A2A payment / metering expectations → NIP-AC OSCE and settlement
+### 4.5 A2A funding expectations -> NIP-AC envelopes and receipts
 
-- A2A does not standardize sovereign payment rails; NIP-AC provides the canonical payment substrate.
-- Funding for work SHOULD be represented by OSCE envelopes.
-- Spend authorization, settlement receipt, and cancel behavior remain NIP-AC responsibilities.
-- A2A request/response bodies or metadata may carry OSCE references or funding payloads, but AC events remain authoritative.
+- A2A does not standardize sovereign payment rails; NIP-AC provides the canonical funding substrate.
+- Funding for work SHOULD be represented by OSCE envelope refs or equivalent AC payloads.
+- Spend authorization, settlement receipt, default, and cancel behavior remain NIP-AC responsibilities.
 
 ---
 
-## 4. Implementation Flows
+## 5. Implementation Flows
 
-The flows below are implementation-oriented and explicitly identify which layer handles which step.
-
-### 4.1 Discovery and identity verification flow
+### 5.1 Discovery and identity verification
 
 | Step | Description | Primary layer |
 | --- | --- | --- |
 | 1 | Client fetches `/.well-known/agent-card.json` | A2A |
-| 2 | Client reads `AgentCard.id`, supported interfaces, and extension URIs | A2A |
-| 3 | If `AgentCard.id` is `nostr:<npub>`, client resolves that as the sovereign identity anchor | A2A + SA |
-| 4 | Client reads SKL/SA/AC extension metadata (relays, manifest refs, capability hints) | A2A projection of SKL/SA/AC |
-| 5 | Client optionally verifies server identity via SKL auth challenge / response against the claimed pubkey | NIP-SKL |
-| 6 | Client caches the verified sovereign identity and its discovered interfaces | A2A + NIP-SKL |
+| 2 | Client reads `supportedInterfaces`, `capabilities.extensions`, and any declared auth schemes | A2A |
+| 3 | Client resolves sovereign hints such as `agentProfileRef`, `agentNpub`, `sklManifestRefs`, and `nostrRelays` from extension params | A2A projection of SA/SKL |
+| 4 | Client optionally fetches referenced SA profile and SKL manifests from Nostr relays | NIP-SA + NIP-SKL |
+| 5 | Client optionally verifies key control via SKL auth challenge / response | NIP-SKL |
+| 6 | Client caches the verified A2A endpoint to Nostr identity binding | A2A + NIP-SKL |
 
 Implementation notes:
 
-- Discovery should work even for clients that ignore the OpenAgents extensions.
-- Verification via SKL challenge should be optional for basic discovery, but recommended for higher-trust use cases.
+- Discovery must still work for clients that ignore the OpenAgents extensions.
+- Verification via SKL challenge is optional for basic discovery, but recommended for higher-trust use cases.
 
-### 4.2 Authentication and authorization flow
+### 5.2 Authentication and authorization bridge
 
 | Step | Description | Primary layer |
 | --- | --- | --- |
-| 1 | Server declares supported `securitySchemes` in AgentCard | A2A |
-| 2 | Client acquires or derives credentials using the declared scheme | A2A + NIP-SKL |
-| 3 | Client submits A2A request with credential/token/header material | A2A |
-| 4 | Server validates that the presented credential maps to a Nostr identity or session authorized by the auth challenge flow | NIP-SKL |
-| 5 | Server checks applicable SKL permission grants for requested skill, tool, action, and data scope | NIP-SKL |
-| 6 | Server evaluates SA guardian policy if the operation is high-risk or exceeds local policy thresholds | NIP-SA |
-| 7 | Server accepts or rejects the request and records the decision in audit logs if required | NIP-SA |
+| 1 | Server declares supported `securitySchemes` in the public Agent Card | A2A |
+| 2 | Client acquires credentials using the declared scheme | A2A |
+| 3 | Client submits A2A request with credential material | A2A |
+| 4 | Server optionally binds the caller session to a verified Nostr key using SKL auth challenge state | NIP-SKL |
+| 5 | Server evaluates local authorization policy for requested skill, tool, or boundary | Implementation-local |
+| 6 | Server evaluates SA guardian policy if the operation is high-risk | NIP-SA |
+| 7 | Server accepts or rejects the request and records material decisions in trajectory or audit-friendly sovereign state as needed | NIP-SA |
 
 Implementation notes:
 
-- Treat A2A `securitySchemes` as the discovery surface, not the authoritative policy layer.
-- SKL grants should be enforced before expensive work begins.
+- Treat A2A `securitySchemes` as the discovery surface, not the authoritative policy engine.
+- The first interoperable version does not require a portable grant event kind.
 
-### 4.3 Task execution and audit logging flow
+### 5.3 Task execution and trajectory correlation
 
 | Step | Description | Primary layer |
 | --- | --- | --- |
 | 1 | Client calls `SendMessage` or `SendStreamingMessage` | A2A |
-| 2 | Server creates or resumes an SA session / trajectory | NIP-SA |
-| 3 | Server binds A2A `Task.id` to the SA session ID | A2A + NIP-SA |
-| 4 | Server selects the SKL-backed skills that satisfy the request | NIP-SKL |
-| 5 | Server performs ticks / actions and emits trajectory or result events as needed | NIP-SA |
-| 6 | Server emits SA audit events (`kind:39250`) for key actions, approvals, and outputs | NIP-SA |
-| 7 | Server returns A2A task status and artifacts, optionally with metadata linking back to session, grant, or audit refs | A2A projection of SA/SKL |
+| 2 | Server creates or resumes an SA trajectory session (`kind:39230`) | NIP-SA |
+| 3 | Server binds A2A `Task.id` to the SA session identifier | A2A + NIP-SA |
+| 4 | Server selects SKL-backed skills that satisfy the request | NIP-SKL |
+| 5 | Server performs work and emits `kind:39231` trajectory events for consequential actions and outputs | NIP-SA |
+| 6 | Server returns A2A task state and artifacts, optionally with metadata linking back to session, skill refs used, and trajectory refs | A2A projection of SA/SKL |
 
 Implementation notes:
 
-- The A2A task must be understandable on its own.
-- The SA session and audit trail must remain sufficient to reconstruct what happened.
+- The A2A task should remain understandable on its own.
+- The sovereign session and trajectory chain should remain sufficient to reconstruct what happened.
 
-### 4.4 Funding and settlement flow
+### 5.4 Funding and settlement
 
 | Step | Description | Primary layer |
 | --- | --- | --- |
-| 1 | Client includes an OSCE envelope or reference before or during task initiation | NIP-AC carried via A2A |
-| 2 | Server resolves and validates the envelope, currency, amount, skill scope, expiry, and underwriter trust | NIP-AC + NIP-SKL |
-| 3 | Server checks whether guardian approval is required before spending | NIP-SA |
-| 4 | Task executes under the allowed budget and permitted skill set | NIP-SA + NIP-AC |
-| 5 | Server issues spend authorization / settlement events as work progresses or completes | NIP-AC |
-| 6 | If `hold_period_secs` is active, server honors hold/cancel window before final settlement | NIP-AC |
-| 7 | A2A task concludes with success, failure, interruption, or cancellation, with funding outcome reflected in AC events | A2A + NIP-AC |
+| 1 | Client includes an OSCE envelope ref or funding payload in request metadata, message metadata, or an extension-specific data part | A2A carrying NIP-AC |
+| 2 | Server resolves and validates the envelope, amount cap, scope, expiry, and issuer / underwriter trust | NIP-AC |
+| 3 | Server checks whether guardian approval is required before spend-sensitive execution | NIP-SA |
+| 4 | Task executes under the allowed budget and permitted scope | NIP-SA + NIP-AC |
+| 5 | If `cancel_until` is present, server honors the cancel window before irreversible delivery or final settlement | NIP-AC |
+| 6 | Server emits spend / receipt / cancel / default events as required by outcome | NIP-AC |
+| 7 | A2A task concludes with success, failure, interruption, or cancellation, with authoritative funding outcome reflected in AC events | A2A + NIP-AC |
 
 Implementation notes:
 
-- Settlement correctness should never depend solely on A2A response payloads.
-- The AC event chain is the payment record.
+- Settlement correctness must never depend solely on A2A response payloads.
+- `kind:39242` envelopes and `kind:39244` receipts are the durable payment anchors.
 
-### 4.5 Optional delegation / sub-agent flow
+### 5.5 Optional delegation / sub-agent flow
 
 | Step | Description | Primary layer |
 | --- | --- | --- |
 | 1 | Primary agent decides to delegate part of the task | NIP-SA |
-| 2 | Server checks delegation is allowed under guardian policy, permission grant, and OSCE scope | NIP-SA + NIP-SKL + NIP-AC |
+| 2 | Server checks delegation is allowed under local auth policy, guardian policy, and funding scope | Implementation-local + NIP-SA + NIP-AC |
 | 3 | Server emits an SA delegation event (`kind:39260`) describing sub-agent, scope, and expiry | NIP-SA |
 | 4 | Delegated work may be handled via internal orchestration or another A2A call | NIP-SA + optional A2A |
-| 5 | Parent audit chain records the delegation relationship and downstream outputs | NIP-SA |
-| 6 | Budget and settlement remain bounded by the parent OSCE and delegation scope | NIP-AC |
+| 5 | Parent trajectory records the delegation relationship and downstream outputs | NIP-SA |
+| 6 | Budget and settlement remain bounded by the parent envelope and delegation scope | NIP-AC |
 
 Implementation notes:
 
-- Delegation should be treated as advanced scope.
-- It is not required for initial A2A interop.
+- Delegation is advanced scope.
+- It is not required for the first interoperable slice.
 
 ---
 
-## 5. Recommended Data Shapes / Interface Contracts
+## 6. Recommended Data Shapes / Interface Contracts
 
 The following are recommended implementation contracts, not normative protocol changes.
 
-### 5.1 Identifier conventions
+### 6.1 Identifier conventions
 
 | Concept | Recommended form | Notes |
 | --- | --- | --- |
-| Sovereign agent ID | `nostr:<npub>` | Used in `AgentCard.id` |
-| SKL manifest ref | `33400:<pubkey>:<d-tag>` | Matches addressable SKL manifest reference |
-| SA session ID | implementation-defined opaque string | Must be stable enough to correlate with `Task.id` |
-| AC envelope ref | `39240:<pubkey>:<d-tag>` or event id reference | Choose one consistent implementation strategy |
-| Audit ref | `39250:<pubkey>:<d-tag>` or event id reference | Used in metadata correlation |
-| Permission grant ref | event id or addressable reference | Needed for traceability in audits |
+| SKL manifest ref | `33400:<skill_hex_pubkey>:<d-tag>` | Canonical SKL manifest reference |
+| SA profile ref | implementation-defined stable ref to current `kind:39200` profile event | Avoid inventing a new A2A core field for identity |
+| SA session ref | `39230:<agent_hex_pubkey>:<session-d-tag>` | Correlates with `Task.id` directly or indirectly |
+| AC envelope ref | `39242:<issuer_hex_pubkey>:<d-tag>` or event id | `39240` is credit intent, not the envelope |
+| Trajectory event ref | event id of `kind:39231` | Use for audit-friendly action refs |
+| AC receipt ref | event id of `kind:39244` | Durable settlement reference |
 
-### 5.2 Recommended AgentCard extension URIs
+Additional convention:
+
+- Use raw hex pubkeys inside Nostr-style refs.
+- Duplicate `npub` strings in extension params only as a human-friendly convenience.
+
+### 6.2 Recommended AgentCard extension URIs
 
 - `https://openagents.org/extensions/nip-skl/v1`
 - `https://openagents.org/extensions/nip-sa/v1`
 - `https://openagents.org/extensions/nip-ac/v1`
 
-These URIs should be treated as capability hints that the agent speaks A2A while backing those semantics with sovereign Nostr events.
+These URIs should be treated as capability hints that the agent speaks A2A while backing selected semantics with sovereign Nostr state.
 
-### 5.3 Recommended AgentCard extension metadata
+### 6.3 Recommended extension params
 
-#### SKL extension metadata
-
-Suggested fields:
-
-- `nostr_relays: string[]`
-- `skl_manifest_refs: string[]`
-- `auth_challenge_supported: boolean`
-- `permission_grants_required: boolean`
-- `assurance_summary: { [skill_ref]: tier }` (optional)
-
-#### SA extension metadata
+#### SKL extension params
 
 Suggested fields:
 
-- `agent_profile_ref: string`
-- `guardian_threshold: number`
-- `audit_trail_available: boolean`
-- `delegation_supported: boolean`
-- `security_posture_summary: object`
+- `agentNpub`
+- `nostrRelays: string[]`
+- `sklManifestRefs: string[]`
+- `authChallengeSupported: boolean`
+- `assuranceSummary: { [skillRef]: tier }` (optional)
 
-#### AC extension metadata
+#### SA extension params
 
 Suggested fields:
 
-- `osce_supported: boolean`
-- `accepted_currencies: string[]`
-- `accepted_underwriters: string[]`
-- `max_envelope_amounts: object` or `max_amount_by_currency`
-- `hold_period_secs_default: number`
-- `osce_handover_mode: "by-reference" | "data-part" | "either"`
+- `agentProfileRef: string`
+- `trajectoryAuditAvailable: boolean`
+- `delegationSupported: boolean`
+- `securityPostureSummary: object`
 
-### 5.4 Recommended A2A task metadata correlation fields
+#### AC extension params
 
-Suggested server-added fields:
+Suggested fields:
 
-- `sa_session_id`
-- `sa_session_ref`
-- `skl_skill_refs_used`
-- `permission_grant_refs`
-- `guardian_approval_refs`
-- `osce_envelope_ref`
-- `ac_spend_refs`
-- `audit_refs`
+- `osceSupported: boolean`
+- `acceptedCurrencies: string[]`
+- `acceptedUnderwriters: string[]`
+- `acceptedSpendRails: string[]`
+- `cancelWindowSupported: boolean`
+- `osceHandoverMode: "by-reference" | "inline-data-part" | "either"`
 
-These fields should be safe to ignore by generic A2A clients while giving interoperable clients enough information to correlate back to sovereign state.
+### 6.4 Recommended A2A metadata keys
 
-### 5.5 Recommended handover modes for OSCE funding
+Suggested server-emitted keys:
+
+- `saSessionId`
+- `saSessionRef`
+- `sklSkillRefsUsed`
+- `guardianApprovalRefs`
+- `osceEnvelopeRef`
+- `acReceiptRefs`
+- `trajectoryEventRefs`
+
+Suggested client-provided keys:
+
+- `osceEnvelopeRef`
+- `preferredNostrRelays`
+- `requestedProfileUris`
+
+These are profile conventions, not A2A core fields.
+
+### 6.5 Recommended OSCE handover modes
 
 Preferred options:
 
 1. **By reference**
-   - Client passes an AC envelope ref in task metadata or a data part.
-   - Server resolves envelope from Nostr.
+   - Client passes an AC envelope ref in request or message metadata.
+   - Server resolves the envelope from Nostr.
 2. **Inline data part**
-   - Client passes a signed envelope payload in an A2A data part.
-   - Server still resolves or verifies against canonical AC events.
+   - Client passes signed funding payload in a data part or metadata.
+   - Server still verifies against canonical AC state.
 3. **Hybrid**
    - Client passes both ref and payload for lower round-trip latency.
 
@@ -310,35 +334,34 @@ Recommendation: start with **by reference** for simpler trust boundaries.
 
 ---
 
-## 6. Phased Implementation Plan
+## 7. Phased Implementation Plan
 
 This sequence is designed so an existing A2A agent can bolt on sovereign capabilities incrementally.
 
-### Phase 1 — Discovery and identity binding
+### Phase 1: Discovery and identity binding
 
 **Objectives**
 
-- Publish an A2A AgentCard that binds to a sovereign Nostr identity.
-- Establish extension URIs and minimal correlation metadata.
+- Publish an A2A Agent Card that binds to sovereign state through extension params.
+- Establish stable extension URIs and minimal correlation metadata.
 
 **Dependencies**
 
 - Existing A2A server surface
-- SA Agent Profile publication path
+- SA profile publication path
 
 **Deliverables**
 
-- `AgentCard.id = nostr:<npub>`
-- AgentCard generation from SA profile name/description
-- Basic SKL / SA extension declarations
-- Relay and manifest references exposed via metadata
+- `capabilities.extensions[]` declarations for SKL / SA
+- `agentProfileRef`, `agentNpub`, and relay hints exposed via extension params
+- AgentCard generation from SA profile name / description
 
 **Risks / open questions**
 
-- Exact metadata field names should be kept stable once clients depend on them.
-- Need a clear rule for whether `npub` or raw hex pubkey is preferred in different contexts.
+- Exact extension param names should be kept stable once clients depend on them.
+- Need a clear rule for which identity hints are mandatory vs optional.
 
-### Phase 2 — SKL skill projection into AgentCard
+### Phase 2: SKL skill projection into AgentCard
 
 **Objectives**
 
@@ -352,38 +375,39 @@ This sequence is designed so an existing A2A agent can bolt on sovereign capabil
 **Deliverables**
 
 - Skill projection pipeline from `kind:33400` to `AgentCard.skills[]`
-- Optional exposure of assurance tiers and evaluator refs
-- Clear mapping from skill id back to manifest reference
+- Optional exposure of assurance tiers in SKL extension params
+- Clear mapping from `skills[].id` back to manifest refs
 
 **Risks / open questions**
 
-- Need to decide how much SKL detail belongs in public card vs extended card.
-- Revocation semantics must be reflected cleanly in AgentCard refresh/update behavior.
+- Need to decide how much SKL detail belongs in the public card vs extended card.
+- Revocation semantics must be reflected cleanly in AgentCard refresh behavior.
 
-### Phase 3 — Auth challenge and permission grant enforcement
+### Phase 3: Auth bridge and local authorization enforcement
 
 **Objectives**
 
-- Back A2A auth and authorization with SKL primitives.
+- Back A2A authentication with a sovereign key-binding path where needed.
+- Enforce local authorization policy before expensive work begins.
 
 **Dependencies**
 
-- SKL auth challenge implementation
-- Permission grant issuance and validation path
+- A2A auth surface for the deployment
+- Optional SKL auth challenge support
 
 **Deliverables**
 
-- A2A `securitySchemes` entry for Nostr / SKL-backed auth
-- Server-side auth challenge verification
-- Grant enforcement middleware for request handling
+- A2A `securitySchemes` entries for the chosen auth bridge
+- Server-side SKL auth challenge verification where Nostr binding matters
+- Local authorization middleware for skills, tools, and sensitive boundaries
 - Authorization failure mapping into A2A errors
 
 **Risks / open questions**
 
-- Token/session format bridging A2A request auth to Nostr proof may need a local profile decision.
-- Need to define how long challenge-derived credentials live.
+- Token/session format bridging A2A auth to Nostr proof may need a local profile decision.
+- Need to decide whether a future portable grant model is worth standardizing or whether local policy is sufficient.
 
-### Phase 4 — SA session and audit integration
+### Phase 4: SA session and trajectory integration
 
 **Objectives**
 
@@ -393,44 +417,44 @@ This sequence is designed so an existing A2A agent can bolt on sovereign capabil
 
 - Phase 1 discovery
 - Phase 2 skill mapping
-- Phase 3 auth and grants
+- Phase 3 auth bridge
 
 **Deliverables**
 
 - Session creation / resume path for each A2A task
-- `Task.id` ↔ `session` correlation strategy
-- Audit event emission (`kind:39250`) for key actions
-- Task metadata linking to session and audit refs
+- `Task.id` to `kind:39230` correlation strategy
+- `kind:39231` emission for key actions, approvals, and outputs
+- Task and artifact metadata linking to session and trajectory refs
 
 **Risks / open questions**
 
-- Need a stable policy for when to emit audit entries to avoid noisy or incomplete chains.
-- Need to decide whether every streaming chunk is audited or only material transitions.
+- Need a stable policy for when to emit trajectory entries to avoid noisy or incomplete chains.
+- Need to decide whether every streaming chunk is reflected or only material transitions.
 
-### Phase 5 — NIP-AC funding and settlement
+### Phase 5: NIP-AC funding and settlement
 
 **Objectives**
 
-- Allow funded A2A work using OSCE envelopes and settlement semantics.
+- Allow funded A2A work using OSCE envelopes and NIP-AC settlement semantics.
 
 **Dependencies**
 
-- AC event production / verification
+- AC envelope / receipt production and verification
 - Guardian policy integration for spend-sensitive actions
 
 **Deliverables**
 
-- Envelope resolution / validation path
+- `kind:39242` envelope resolution / validation path
 - Budget enforcement during task execution
-- Spend authorization and settlement emission
-- Hold/cancel support mapped to task outcome handling
+- Receipt / cancel / default handling aligned with task outcomes
+- `cancel_until` support for reversible consequential spends
 
 **Risks / open questions**
 
 - Need a clear model for partial completion, partial settlement, and interrupted tasks.
 - Need policy for whether unfunded tasks are rejected, rate-limited, or allowed in limited mode.
 
-### Phase 6 — Extended cards, delegation, and advanced trust metadata
+### Phase 6: Extended cards, delegation, and advanced trust metadata
 
 **Objectives**
 
@@ -438,196 +462,200 @@ This sequence is designed so an existing A2A agent can bolt on sovereign capabil
 
 **Dependencies**
 
-- Phases 1–5 complete or sufficiently stable
+- Phases 1 through 5 complete or sufficiently stable
 
 **Deliverables**
 
-- Extended AgentCard support for authenticated clients
-- Delegation/sub-agent metadata and flows
-- Richer trust metadata (assurance, org identity, evaluation refs)
+- Extended Agent Card support for authenticated clients
+- Delegation / sub-agent metadata and flows
+- Richer trust metadata and security posture hints
 - Better client guidance on capability tiers
 
 **Risks / open questions**
 
 - Extended card content must avoid leaking sensitive infrastructure details.
-- Delegation creates more complex audit and budget inheritance logic.
+- Delegation creates more complex trajectory and budget inheritance logic.
 
 ---
 
-## 7. Engineering Work Breakdown
+## 8. Engineering Work Breakdown
 
 These workstreams should be easy to convert into tickets.
 
-### 7.1 A2A server surface
+### 8.1 A2A server surface
 
-- Implement or refine HTTP/JSON A2A endpoints
-- Add support for required request metadata and extension header handling
-- Add task metadata injection hooks for sovereign correlation fields
+- Implement or refine HTTP+JSON / JSON-RPC A2A endpoints
+- Add support for request metadata and extension activation handling
+- Add task / artifact metadata injection hooks for sovereign correlation fields
 
-### 7.2 AgentCard generation
+### 8.2 AgentCard generation
 
-- Generate card from SA profile + SKL manifests
+- Generate card from SA profile plus SKL manifests
+- Serialize `capabilities.extensions[]` with stable `params` keys
 - Support public card and optional extended card variants
-- Add extension metadata serialization and versioning
 
-### 7.3 Nostr event publishing / retrieval
+### 8.3 Nostr event publishing / retrieval
 
-- Resolve SKL manifests, SA profiles, audit refs, AC envelope refs from relays
-- Publish SA session / audit / delegation events as needed
-- Cache and refresh strategies for relay-backed data
+- Resolve SKL manifests, SA profiles, trajectory refs, and AC envelope refs from relays
+- Publish SA sessions, trajectory events, and delegation events as needed
+- Add cache and refresh strategies for relay-backed data
 
-### 7.4 Auth challenge verification
+### 8.4 Auth challenge verification
 
 - Implement SKL auth challenge request / response flow
-- Bind challenge success to A2A auth/session handling
-- Define and implement credential bridging format
+- Bind challenge success to the A2A auth/session model where needed
+- Define the credential-bridge format used by the deployment
 
-### 7.5 Permission grant enforcement
+### 8.5 Authorization bridge / policy enforcement
 
-- Grant lookup and validation middleware
-- Policy checks for tools, actions, data scope, expiration, and invocation counts
-- Failure mapping into A2A response semantics
+- Add local authorization middleware for tools, boundaries, and sensitive actions
+- Evaluate guardian requirements during request authorization
+- Map local policy failures into A2A response semantics
 
-### 7.6 Session and audit correlation
+### 8.6 Session and trajectory correlation
 
-- Session id generation / correlation policy
-- Audit emission points for task lifecycle and tool use
-- Correlation between A2A task ids, session ids, and audit refs
+- Define session id generation / correlation policy
+- Emit `kind:39231` for task lifecycle and consequential actions
+- Correlate A2A task ids, session ids, and trajectory refs
 
-### 7.7 OSCE handling and settlement logic
+### 8.7 OSCE handling and settlement logic
 
-- Envelope parsing and validation
-- Budget tracking during execution
-- Spend authorization / settlement / cancel support
-- Reconciliation between task outcomes and AC event chain
+- Parse and validate `kind:39242` envelopes
+- Track budget during execution
+- Emit or verify receipts / cancel / default behavior
+- Reconcile A2A task outcomes with AC state
 
-### 7.8 Guardian and delegation policy
+### 8.8 Guardian and delegation policy
 
-- Guardian approval checks during request authorization and spend flow
-- Delegation scope subset enforcement
-- Parent/child session and budget inheritance checks
+- Perform guardian approval checks during request authorization and spend flow
+- Enforce delegation scope subset rules
+- Validate parent / child session and budget inheritance
 
-### 7.9 Client compatibility / docs
+### 8.9 Client compatibility / docs
 
-- Document extension field meanings
-- Provide client examples for basic and extended AgentCard handling
+- Document extension param meanings
+- Provide client examples for public and extended cards
 - Clarify required vs optional behavior for generic A2A clients
 
 ---
 
-## 8. Open Questions / Decision Points
+## 9. Open Questions / Decision Points
 
 The team should make explicit decisions on the following:
 
 1. **Credential bridge design**
-   - How exactly does a completed SKL auth challenge translate into an A2A request credential?
+   - How does the chosen A2A auth surface bind to a verified Nostr identity when SKL auth challenge is used?
 
-2. **Public vs extended AgentCard split**
-   - Which sovereign details belong in the public card, and which only in authenticated extended cards?
+2. **Identity anchor shape**
+   - Which extension params are required for sovereign identity binding in the first interoperable version?
 
-3. **Identifier representation**
-   - Where should we prefer `npub` vs raw hex pubkey vs full Nostr event references?
+3. **Profile ref format**
+   - What exact stable reference form should we use for the current `kind:39200` profile event?
 
 4. **Task/session correlation policy**
-   - Should `Task.id` equal the SA session ID directly, or should one wrap the other?
+   - Should `Task.id` equal the SA session `d` tag directly, or should one wrap the other?
 
 5. **Artifact storage model**
-   - Which artifacts are persisted off-Nostr, and how are hashes / URLs linked back into SA audit records?
+   - Which artifacts are persisted off Nostr, and how are hashes / URLs linked back into trajectory events?
 
 6. **Funding requirement policy**
    - Are tasks allowed without AC funding, or is OSCE mandatory for certain classes of work?
 
 7. **Partial settlement semantics**
-   - How should progressive work, retries, interruptions, and streaming outputs map to AC spends and receipts?
+   - How should progressive work, retries, interruptions, and streaming outputs map to AC receipts and defaults?
 
 8. **Delegation rollout**
    - Is sub-agent delegation part of the first implementation or explicitly deferred until core interop is stable?
 
 9. **Extension versioning**
-   - How will we evolve `nip-skl/v1`, `nip-sa/v1`, and `nip-ac/v1` metadata without breaking clients?
+   - How will we evolve the OpenAgents extension URIs and `params` keys without breaking clients?
 
-10. **MVP prioritization**
-   - Which parts of this plan help the current retained MVP, and which should remain design-ready but unscheduled for now?
+10. **Future grant model**
+   - Do we eventually want a portable authorization-grant profile, or is local policy plus guardian checks sufficient?
+
+11. **MVP prioritization**
+   - Which parts of this plan help the retained MVP, and which should remain design-ready but unscheduled?
 
 ---
 
-## 9. Security and Operational Considerations
+## 10. Security and Operational Considerations
 
-### 9.1 Transport security
+### 10.1 Transport security
 
-- A2A endpoints must use TLS.
-- Standard A2A transport and authentication best practices still apply.
+- A2A endpoints must use TLS-backed transport.
+- Standard A2A auth and transport best practices still apply.
 - OpenAgents layering does not weaken A2A security requirements.
 
-### 9.2 Nostr key custody and signing
+### 10.2 Nostr key custody and signing
 
 - The sovereign Nostr key is the trust root for identity and signed event claims.
 - Key custody should be treated as security-critical infrastructure.
-- Threshold / guardian-backed signing strategies should be considered for higher-risk agents.
+- Threshold or guardian-backed signing should be considered for higher-risk agents.
 
-### 9.3 Audit trail integrity
+### 10.3 Trajectory integrity
 
-- SA audit events provide the durable, signed record of key actions.
-- The implementation should define minimum audit emission points for reproducibility.
-- A2A logs are useful operationally but are not a substitute for sovereign audit state.
+- `kind:39230` / `kind:39231` provide the durable signed lifecycle record.
+- The implementation should define minimum emission points for reproducibility.
+- A2A logs are operationally useful but not a substitute for sovereign state.
 
-### 9.4 Hold/cancel rollback semantics
+### 10.4 Cancel-window semantics
 
-- AC hold periods and cancel events are safety mechanisms that complement A2A task cancellation.
+- AC `cancel_until` and A2A task cancellation are complementary, not identical.
 - The implementation must keep task state, spend state, and settlement state from drifting apart.
-- Cancellation semantics need explicit recovery behavior when task completion and funding state race.
+- Recovery behavior must be explicit when task completion and funding state race.
 
-### 9.5 Permission scoping and least privilege
+### 10.5 Least privilege
 
-- Permission grants should scope by tool, action, boundary, and duration.
-- Guardian approval should be required when work exceeds configured risk boundaries.
+- A2A auth should expose the caller identity clearly enough for policy enforcement.
+- Local authorization policy should scope tools, actions, boundaries, and duration.
+- Guardian approval should gate work that exceeds configured risk thresholds.
 - Delegation must never widen the parent scope.
 
-### 9.6 Privacy and public event exposure
+### 10.6 Privacy and public event exposure
 
 - Nostr is not a safe place for raw sensitive payloads.
-- Sensitive task content should generally remain off-Nostr.
-- Hashes, references, and minimal metadata should be preferred in public events.
+- Sensitive task content should generally remain off Nostr.
+- Hashes, refs, and minimal metadata should be preferred in public events.
 
-### 9.7 Failure and recovery
+### 10.7 Failure and recovery
 
-- The system should tolerate relay outages, delayed reads, and temporary inability to publish.
+- The system should tolerate relay outages, delayed reads, and temporary publish failures.
 - Recovery logic must define what happens if:
-  - A2A task is accepted but SA session publish fails
-  - Task completes but settlement publish fails
-  - Spend authorization succeeds but A2A response delivery fails
-- Reconciliation jobs may be needed to restore consistency between A2A task state and sovereign state.
+  - A2A task is accepted but sovereign session publish fails
+  - task completes but receipt publish fails
+  - receipt succeeds but A2A response delivery fails
+- Reconciliation jobs may be needed to restore consistency between A2A-visible task state and sovereign state.
 
 ---
 
-## 10. Recommended Next Steps
+## 11. Recommended Next Steps
 
 1. **Confirm scope with product and engineering**
-   - Decide which phases are immediate engineering work vs design-ready backlog.
+   - Decide which phases are immediate work vs design-ready backlog.
 
-2. **Lock the minimal interop profile fields**
-   - Freeze initial AgentCard extension URIs, metadata keys, and identifier conventions.
+2. **Lock the minimal extension params**
+   - Freeze the first set of OpenAgents extension URIs and `params` keys.
 
 3. **Implement Phase 1 first**
-   - Start with `AgentCard.id = nostr:<npub>`, extension declarations, and profile/manifest refs.
+   - Start with extension-based identity hints, profile refs, and manifest refs.
 
 4. **Choose the auth bridge strategy**
-   - Make an explicit decision on how SKL auth challenge results become A2A request credentials.
+   - Make an explicit decision on how A2A auth binds to verified Nostr identity.
 
 5. **Prototype task/session correlation**
-   - Build a thin slice where one A2A task creates one SA session and one audit chain.
+   - Build a thin slice where one A2A task creates one SA session and one trajectory chain.
 
 6. **Decide the first funding mode**
-   - Prefer by-reference OSCE envelope handling before inline payload complexity.
+   - Prefer by-reference OSCE handling before inline payload complexity.
 
 7. **Defer delegation unless needed immediately**
    - Keep sub-agent orchestration as a later phase unless a concrete product use case demands it now.
 
 8. **Translate workstreams into tickets**
-   - Split the work by server surface, AgentCard generation, Nostr integration, auth/grants, audit/session correlation, and AC settlement.
+   - Split the work by server surface, card generation, Nostr integration, auth bridge, trajectory correlation, and AC settlement.
 
 9. **Document client expectations early**
-   - Provide one basic and one extended AgentCard example so client implementers can adopt the profile consistently.
+   - Provide one public and one extended Agent Card example built on the current A2A card shape.
 
 10. **Validate against MVP priorities before scheduling broad work**
    - Preserve the current repo direction by only advancing implementation that clearly supports the retained product path.
@@ -636,11 +664,11 @@ The team should make explicit decisions on the following:
 
 ## Working Summary
 
-The recommended implementation model is simple:
+The recommended implementation model is:
 
-- Speak **A2A** at the edge.
-- Keep **SKL / SA / AC** authoritative underneath.
-- Project only enough sovereign metadata into A2A to enable discovery, trust, authorization, task correlation, and payment settlement.
-- Roll out in phases so an existing A2A agent can bolt on sovereign capabilities without re-architecting the entire system.
+- speak **A2A** at the edge,
+- keep **SKL / SA / AC** authoritative underneath,
+- project sovereign identity, trust, lifecycle, and funding state into A2A through **extension params**, **metadata**, and standard A2A auth surfaces,
+- roll out in phases so an existing A2A agent can bolt on sovereign capabilities without re-architecting the whole system.
 
 That gives the team a path to interoperability without breaking either side of the layering model.


### PR DESCRIPTION
## Summary

This PR adds A2A-focused documentation for internal developer review.

The goal is to document the A2A interoperability profile and the related sovereign agent integration plan as a standalone documentation thread, separate from unrelated planning work.

## Included files

- `docs/A2A_INTEROP_PROFILE.md`
- `docs/plans/a2a-sovereign-agent-integration-plan.md`

## Purpose

These docs are intended to clarify the A2A profile shape, interoperability framing, and the associated planning direction in one reviewable branch.

Keeping this work isolated makes it easier to review the A2A material on its own terms without mixing it with Autopilot PM/process planning.

## What reviewers should focus on

- Whether the A2A profile framing is clear and internally consistent
- Whether the interoperability assumptions are reasonable and well-scoped
- Whether the integration plan is actionable without overreaching
- Any terminology, structure, or protocol details that should be corrected

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author