### PR TITLE
docs(pm): add Autopilot project management implementation plan and Step 0 dogfood package

### DIFF
--- a/docs/plans/autopilot-project-management-implementation-plan.md
+++ b/docs/plans/autopilot-project-management-implementation-plan.md
@@ -1,0 +1,566 @@
+# Autopilot Project Management — Granular Implementation & Deployment Plan
+
+**Status:** Draft implementation plan  
+**Last updated:** 2026-03-06  
+**Source:** Derived from the Autopilot Project Management Specification  
+**Intent:** Convert the broad product spec into a step-by-step plan the engineering team can execute with low context switching.
+
+---
+
+## 1. Planning assumptions and guardrails
+
+- This plan is sequenced to respect the current OpenAgents MVP: do not let PM tooling derail the core Autopilot money-printing loop.
+- The first deployment step must be useful internally without requiring new protocol, wallet, or relay work.
+- Start with the smallest viable internal operating system, then progressively replace manual pieces with native product surfaces.
+- Keep product-specific PM behavior in `apps/autopilot-desktop` if/when implemented there.
+- Keep `crates/wgpui` limited to reusable UI primitives only; do not move Autopilot PM workflows into shared crates.
+- Keep Nostr-first as the long-term architecture direction, but do not force Nostr-authoritative storage on day one if it slows adoption.
+- Treat Bitcoin bounties, agent queues, and advanced analytics as follow-on layers, not prerequisites for internal adoption.
+
+---
+
+## 2. What success looks like
+
+This effort is successful when:
+
+1. The team can manage real work in one shared system with minimal confusion.
+2. Work items have a consistent schema, clear workflow states, and reliable ownership.
+3. The system becomes useful internally before it becomes ambitious externally.
+4. Later Nostr, agent, and Bitcoin-native features extend the same workflow instead of replacing it.
+
+---
+
+## 3. Recommended delivery sequence at a glance
+
+| Phase | Name | Primary outcome |
+| --- | --- | --- |
+| 0 | Minimal Deliverable / Internal Dogfood | A usable internal PM workflow the team can adopt immediately |
+| 1 | Domain Model and Contracts | Freeze the core entities, workflows, and authority model |
+| 2 | Core PM MVP | Native issue CRUD, list/board views, and filters |
+| 3 | Project Structure and Collaboration | Projects, cycles, comments, activity, and notifications |
+| 4 | Nostr and Agent-Native Layer | Nostr-backed state, agent tasks, and NIP-90 alignment |
+| 5 | Bitcoin Workflows | Bounties, escrow, payouts, and payment-linked completion |
+| 6 | Analytics, Automation, and Hardening | Metrics, automations, governance, and rollout polish |
+
+---
+
+## 4. Deployment Step 0 — Minimal deliverable we can use ASAP
+
+### Objective
+
+Stand up a team-usable Autopilot PM workflow immediately, without waiting for native product implementation.
+
+### Minimal deliverable definition
+
+Use **GitHub Issues + labels + milestones/cycles + a lightweight operating runbook** as the v0 source of truth, while keeping the future Autopilot PM schema aligned with the long-term product spec.
+
+This gives the team something usable now while reducing rework later.
+
+Detailed internal package: `docs/plans/autopilot-project-management-step-0-dogfood-package.md`
+
+### Step-by-step tasks
+
+1. **Freeze the v0 operating model.**
+   - Adopt one canonical workflow: `Backlog -> Todo -> In Progress -> In Review -> Done -> Cancelled`.
+   - Adopt one priority scale: `Urgent / High / Medium / Low / None`.
+   - Adopt one issue type set: `Bug / Feature / Improvement / Task / Epic / Research / Agent Task`.
+   - Decide which fields are required in v0: title, description, status, priority, assignee, labels, parent link, due date.
+
+2. **Create the internal issue taxonomy.**
+   - Define label prefixes such as `type:*`, `prio:*`, `team:*`, `area:*`, `state:*`.
+   - Define parent/child conventions for epics and sub-tasks.
+   - Define blocking conventions using linked issues.
+
+3. **Create templates the team can use on day one.**
+   - Bug template.
+   - Feature template.
+   - Research template.
+   - Agent Task template.
+   - Epic template with child-issue checklist.
+
+4. **Stand up the default team views.**
+   - My work.
+   - Current cycle.
+   - Bugs only.
+   - Blocked work.
+   - Recently updated.
+   - Agent tasks.
+
+5. **Create a simple cycle ritual.**
+   - Weekly backlog grooming.
+   - Weekly cycle commit.
+   - Daily async status updates in issue comments.
+   - End-of-cycle review and carry-over.
+
+6. **Write the operating runbook.**
+   - How to create work.
+   - When to open an epic vs a task.
+   - How to mark blockers.
+   - How to move status.
+   - How to close work.
+   - How to attach PRs and commits.
+
+7. **Pilot with one engineering slice for one cycle.**
+   - Use only the v0 workflow for one sprint/cycle.
+   - Record friction points.
+   - Capture missing fields and redundant steps.
+
+8. **Run a retrospective before building product surfaces.**
+   - Document what the team actually used.
+   - Remove fields nobody touched.
+   - Promote only proven needs into the native PM MVP.
+
+### Deliverables
+
+- A documented workflow the team can begin using immediately.
+- Templates, labels, and default views.
+- One completed pilot cycle with feedback.
+
+### Exit criteria
+
+- At least one team is actively using the workflow.
+- New work is being created consistently through templates.
+- Status changes are understandable without side-channel clarification.
+- The team can identify the top 5 native features worth building next.
+
+---
+
+## 5. Phase 1 — Domain model and contracts
+
+### Objective
+
+Lock the product model before building UI or sync behavior.
+
+### Step-by-step tasks
+
+1. **Define the canonical entity model.**
+   - Work Item.
+   - Comment.
+   - Team.
+   - Project.
+   - Cycle.
+   - Module.
+   - Notification.
+   - Agent Task.
+   - Bounty.
+
+2. **Define required fields and optional fields for each entity.**
+   - Mark fields required for MVP.
+   - Mark fields deferred to later phases.
+   - Remove speculative fields not needed in the first two phases.
+
+3. **Define the lifecycle rules.**
+   - Allowed status transitions.
+   - Parent/sub-issue rules.
+   - Blocking/dependency rules.
+   - Assignment rules.
+   - Comment edit/delete rules.
+
+4. **Define the authority model.**
+   - Decide what is authoritative in v1.
+   - Decide what may be mirrored locally.
+   - Decide what may be mirrored to Nostr later.
+   - Explicitly separate authoritative state from notifications/activity projections.
+
+5. **Define identifiers and reference strategy.**
+   - Human-readable issue IDs.
+   - Stable internal IDs.
+   - Git integration references.
+   - Future Nostr tag/index strategy.
+
+6. **Define the API/contract surface.**
+   - CRUD operations for each MVP entity.
+   - Filter/query contract.
+   - Bulk update contract.
+   - Activity event shape.
+   - Notification event shape.
+
+7. **Write the v1 state diagrams and sequence diagrams.**
+   - Create issue.
+   - Update issue.
+   - Move through workflow.
+   - Link PR to issue.
+   - Convert issue to Agent Task.
+
+8. **Hold one review and freeze the v1 contract.**
+   - Product review.
+   - Engineering review.
+   - Architecture review.
+   - Record explicit non-goals.
+
+### Exit criteria
+
+- The team has one agreed schema and one agreed workflow model.
+- The first implementation team can build without reopening product-shape debates.
+- Deferred features are clearly marked so they do not leak into MVP.
+
+---
+
+## 6. Phase 2 — Core PM MVP
+
+### Objective
+
+Ship the smallest native Autopilot PM surface that replaces the most painful manual v0 steps.
+
+### Scope for this phase
+
+- Work item CRUD.
+- List view.
+- Board view.
+- Basic filters.
+- Search.
+- Keyboard-first create/edit flows.
+
+### Step-by-step tasks
+
+1. **Implement the storage layer.**
+   - Add local schema/tables for MVP entities.
+   - Add migrations.
+   - Add repository/query layer.
+   - Add test fixtures and seed data.
+
+2. **Implement the command and service layer.**
+   - Create work item.
+   - Update fields.
+   - Change status.
+   - Link related items.
+   - Assign/unassign.
+   - Bulk update selected items.
+
+3. **Implement the first create/edit flows.**
+   - Quick-create modal.
+   - Full issue editor.
+   - Keyboard save/close behavior.
+   - Validation and error states.
+
+4. **Implement list view first.**
+   - Sort by updated date, priority, due date.
+   - Inline status/assignee updates.
+   - Empty state and loading state.
+   - Saved default filters.
+
+5. **Implement board view second.**
+   - One lane per workflow state.
+   - Drag/drop status changes.
+   - Card summary fields.
+   - WIP visibility.
+
+6. **Implement search and filter syntax.**
+   - Text search across title and description.
+   - Filter by state, assignee, priority, label, project, cycle.
+   - Save personal views.
+
+7. **Implement activity basics.**
+   - Record create/update/status-change events.
+   - Surface a simple activity timeline per issue.
+
+8. **Dogfood with the same team from Step 0.**
+   - Move one full cycle into the native surface.
+   - Keep fallback to the v0 workflow only where needed.
+
+### Exit criteria
+
+- Team can create, edit, triage, and complete work in the native PM MVP.
+- List and board views cover most daily usage.
+- Search and filters reduce manual issue hunting.
+
+---
+
+## 7. Phase 3 — Project structure and collaboration
+
+### Objective
+
+Add the organizational features needed for multi-team use.
+
+### Scope for this phase
+
+- Projects.
+- Cycles.
+- Teams.
+- Comments.
+- Notifications.
+- Basic pages/runbooks.
+
+### Step-by-step tasks
+
+1. **Implement team and project entities.**
+   - Team creation/edit flows.
+   - Project creation/edit flows.
+   - Team-specific defaults.
+
+2. **Implement cycles.**
+   - Create cycle.
+   - Assign issues to cycle.
+   - Current cycle view.
+   - Carry-over flow for incomplete work.
+
+3. **Implement comments and mentions.**
+   - Markdown comments.
+   - @mention parsing.
+   - Edit/delete permissions.
+   - Comment activity log.
+
+4. **Implement notifications.**
+   - Assignment notifications.
+   - Mention notifications.
+   - State-change notifications.
+   - Due-date reminders.
+
+5. **Implement project-level views.**
+   - Project backlog.
+   - Cycle board.
+   - Team workload list.
+   - Recently blocked items.
+
+6. **Implement lightweight documentation pages.**
+   - Link docs/pages to projects.
+   - Link issues inside docs.
+   - Version basic content changes.
+
+7. **Run a second internal pilot with more than one team.**
+   - Validate cross-team dependencies.
+   - Validate notification usefulness.
+   - Validate cycle rituals.
+
+### Exit criteria
+
+- Multiple teams can use the system without inventing their own process.
+- The collaboration layer is good enough to replace ad hoc status chasing.
+
+---
+
+## 8. Phase 4 — Nostr and agent-native layer
+
+### Objective
+
+Start making the system OpenAgents-native instead of just internally useful.
+
+### Scope for this phase
+
+- Nostr event model.
+- Relay sync strategy.
+- Agent Task flows.
+- NIP-90-compatible assignment/request patterns.
+
+### Step-by-step tasks
+
+1. **Define the Nostr mapping.**
+   - Map each core entity to an event kind.
+   - Define replaceable vs append-only behavior.
+   - Define tags for projects, assignees, labels, and links.
+
+2. **Build read/write adapters.**
+   - Local-to-Nostr publish.
+   - Relay-to-local sync.
+   - Conflict and replay handling.
+   - Retry and duplicate suppression.
+
+3. **Implement visibility and privacy rules.**
+   - Public work items.
+   - Private team/project visibility.
+   - Encrypted payload plan where needed.
+
+4. **Implement Agent Task specialization.**
+   - Mark issue as Agent Task.
+   - Add capability requirements.
+   - Add input/output artifact fields.
+   - Add verification result fields.
+
+5. **Integrate NIP-90 job request semantics where appropriate.**
+   - Request format.
+   - Result linkage.
+   - Agent attribution.
+   - Status handoff between PM workflow and execution workflow.
+
+6. **Ship read-only Nostr mirror before making Nostr authoritative.**
+   - Validate real relay behavior.
+   - Validate replay semantics.
+   - Validate operational visibility.
+
+7. **Only then evaluate Nostr-authoritative domains.**
+   - Keep comments/activity as earlier candidates.
+   - Keep payout-related truth out of Nostr authority.
+
+### Exit criteria
+
+- PM state can be mirrored and shared through Nostr without breaking local usability.
+- Agent tasks are first-class enough to support OpenAgents-native workflows.
+
+---
+
+## 9. Phase 5 — Bitcoin workflows
+
+### Objective
+
+Add Bitcoin-native value flows only after core work management is stable.
+
+### Scope for this phase
+
+- Bounties.
+- Escrow.
+- Payout triggers.
+- Payment history on work items.
+
+### Step-by-step tasks
+
+1. **Define the bounty state machine.**
+   - Unfunded.
+   - Funding pending.
+   - Funded.
+   - Claimed.
+   - Verification pending.
+   - Released.
+   - Refunded/failed.
+
+2. **Define authority boundaries for money state.**
+   - Wallet/payment truth must remain explicit and authoritative.
+   - Activity feeds may mirror payment status but not invent it.
+
+3. **Implement bounty attachment to work items.**
+   - Amount.
+   - Funding method.
+   - Claimant.
+   - Verification requirement.
+
+4. **Implement escrow and release integration.**
+   - Manual approval path first.
+   - Automated release only after verification is trustworthy.
+
+5. **Implement payout visibility.**
+   - Funding status badge.
+   - Payment history.
+   - Failure states.
+   - Audit trail.
+
+6. **Pilot with internal or tightly controlled design-partner use only.**
+   - Validate payout correctness.
+   - Validate failure messaging.
+   - Validate dispute handling.
+
+### Exit criteria
+
+- Users can attach and track bounties without ambiguity.
+- Payment-linked completion is honest, legible, and auditable.
+
+---
+
+## 10. Phase 6 — Analytics, automation, and hardening
+
+### Objective
+
+Improve leverage, reporting, and operational confidence after the core workflow is proven.
+
+### Step-by-step tasks
+
+1. **Implement baseline metrics.**
+   - Throughput.
+   - Lead time.
+   - Cycle time.
+   - Completion rate.
+   - Blocker count.
+
+2. **Implement health views.**
+   - At-risk projects.
+   - Overdue issues.
+   - Workload imbalance.
+   - Stalled agent tasks.
+
+3. **Implement simple automations.**
+   - PR opened -> move to `In Review`.
+   - PR merged -> move to `Done`.
+   - First commit -> suggest `In Progress`.
+   - Due date reached -> notify assignee.
+
+4. **Implement report export and status summaries.**
+   - Cycle summary.
+   - Project summary.
+   - Team summary.
+
+5. **Implement governance and audit surfaces.**
+   - Permission model.
+   - Audit log.
+   - Change history export.
+
+6. **Run performance and UX hardening.**
+   - Keyboard speed checks.
+   - Large-board performance.
+   - Search responsiveness.
+   - Offline/reconnect behavior.
+
+### Exit criteria
+
+- Operators can trust the system for both execution and reporting.
+- Routine status work is meaningfully automated.
+
+---
+
+## 11. Recommended deployment waves
+
+1. **Wave A — Core team internal use**
+   - Use Step 0 only.
+   - Goal: prove workflow usefulness before product build-out.
+
+2. **Wave B — Engineering alpha**
+   - Use Phases 1-2 outputs.
+   - Goal: replace the most painful manual workflows.
+
+3. **Wave C — Multi-team internal beta**
+   - Use Phase 3 outputs.
+   - Goal: validate cross-team coordination and notifications.
+
+4. **Wave D — OpenAgents-native beta**
+   - Use Phase 4 outputs.
+   - Goal: validate Nostr and agent-native workflows.
+
+5. **Wave E — Incentivized/market beta**
+   - Use Phase 5 outputs.
+   - Goal: validate bounty funding, completion, and payout.
+
+6. **Wave F — Public or partner-facing rollout**
+   - Use Phase 6 outputs.
+   - Goal: ship with governance, reporting, and operational confidence.
+
+---
+
+## 12. Features to explicitly defer until after core adoption
+
+- Gantt charts.
+- Spreadsheet view.
+- Predictive analytics.
+- PDF exports.
+- Advanced role matrices.
+- Marketplace-style agent reputation systems.
+- Full Jira/Linear importer breadth.
+- Mobile-first PM surface.
+
+These should not enter active implementation until the team is successfully using the earlier phases.
+
+---
+
+## 13. Team operating guidance to reduce context switching
+
+### Recommended workstreams
+
+- **Product/Process track:** templates, workflow, cycles, UX rules, acceptance criteria.
+- **Core app track:** native issue flows, list/board views, search, notifications.
+- **Protocol/Sync track:** Nostr mapping, relay sync, activity/event transport.
+- **Payments/Trust track:** bounty state machine, escrow, verification, auditability.
+
+### Recommended execution order inside each phase
+
+1. Freeze the entity/contract shape.
+2. Implement storage and commands.
+3. Implement one view at a time.
+4. Dogfood immediately.
+5. Remove unnecessary fields and steps.
+6. Only then add automation or expansion features.
+
+---
+
+## 14. Final recommendation
+
+Do **not** start by building the full Linear/Plane replacement.
+
+Start with the smallest internal operating system in **Deployment Step 0**, run one real cycle on it, and let that pilot determine which native surfaces earn the right to be built next.
+
+That approach gets the team using Autopilot PM quickly, preserves alignment with the repo's MVP discipline, and gives later Nostr/agent/Bitcoin-native features a real workflow to attach to.

--- a/docs/plans/autopilot-project-management-step-0-dogfood-package.md
+++ b/docs/plans/autopilot-project-management-step-0-dogfood-package.md
@@ -1,0 +1,762 @@
+# Autopilot Project Management — Step 0 Internal Dogfood Package
+
+**Status:** Ready-to-use internal operating package  
+**Scope:** Step 0 only — GitHub-native internal dogfooding layer  
+**Goal:** Let the team start managing work immediately with minimal process overhead and without waiting for native Autopilot PM implementation.
+
+---
+
+## 1. Step 0 operating rules
+
+### What Step 0 is
+
+Step 0 is a lightweight internal operating system built on:
+
+- GitHub Issues
+- Labels
+- Milestones as cycles
+- Issue comments for async status
+- Pull requests linked back to work items
+
+It is intentionally simple. Its job is to make work visible, prioritized, and finishable while preserving alignment with the OpenAgents MVP.
+
+### What Step 0 is not
+
+- Not a full Linear/Jira replacement
+- Not a governance-heavy process
+- Not a long-term storage or protocol decision
+- Not a reason to slow down core MVP delivery
+
+### Required issue metadata for internal use
+
+Every active issue should have:
+
+- exactly **1** `type:*` label
+- exactly **1** `prio:*` label
+- exactly **1** `state:*` label
+- exactly **1** `team:*` label once triaged
+- **0-2** `area:*` labels
+- a clear title
+- a short problem or outcome statement
+- an assignee when work is committed or started
+
+Optional but recommended:
+
+- milestone for the current cycle
+- parent epic link
+- due date if externally constrained
+- linked PR or commit once implementation starts
+
+### Canonical workflow
+
+Use one shared workflow only:
+
+`Backlog -> Todo -> In Progress -> In Review -> Done -> Cancelled`
+
+Definitions:
+
+- **Backlog** — captured, not yet committed
+- **Todo** — accepted into a cycle, not started
+- **In Progress** — actively being worked by one clear owner
+- **In Review** — implementation complete, awaiting review/verification/merge
+- **Done** — accepted and complete
+- **Cancelled** — deliberately dropped or superseded
+
+### MVP-first prioritization scale
+
+- **Urgent** — directly blocks the MVP money-printing loop, correctness, or team execution right now
+- **High** — should land in the current or next cycle
+- **Medium** — valuable, but can wait behind MVP-critical work
+- **Low** — useful cleanup or enhancement
+- **None** — capture only; not currently prioritized
+
+---
+
+## 2. GitHub label taxonomy
+
+### Label usage rules
+
+1. Keep the taxonomy small.
+2. Prefer one meaning per label.
+3. Avoid duplicate labels that encode the same thing.
+4. Do not invent team-specific labels unless the team is active.
+5. If a label stops helping decisions, remove it.
+
+### Label groups overview
+
+| Group | Purpose | When to use it | Example labels |
+| --- | --- | --- | --- |
+| `type:*` | Classifies the kind of work | Always; every issue gets exactly one | `type:bug`, `type:feature`, `type:research` |
+| `prio:*` | Signals urgency and ordering | Always; every issue gets exactly one | `prio:urgent`, `prio:high`, `prio:medium` |
+| `state:*` | Tracks workflow stage | Always; every issue gets exactly one | `state:backlog`, `state:todo`, `state:in-progress` |
+| `team:*` | Marks the owning team | After triage; every committed issue gets one | `team:desktop`, `team:runtime`, `team:protocol` |
+| `area:*` | Gives topical context | Optional; use 0-2 only | `area:wallet`, `area:nostr`, `area:sync` |
+| operational | Flags special handling | Only when it changes behavior | `blocked`, `needs-decision`, `needs-repro` |
+
+### `type:*` labels
+
+**Purpose**
+
+- Say what kind of work this is.
+- Make saved views and triage faster.
+
+**When to use**
+
+- Always.
+- Apply exactly one.
+
+**Starter set**
+
+- `type:bug` — incorrect behavior, regression, broken flow
+- `type:feature` — new user-facing capability
+- `type:improvement` — upgrade to an existing capability
+- `type:task` — implementation work that is not best framed as a feature or bug
+- `type:epic` — larger initiative that owns child issues
+- `type:research` — investigation, framing, analysis, or decision support
+- `type:agent-task` — work intended to be delegated to or executed by an agent
+
+### `prio:*` labels
+
+**Purpose**
+
+- Force explicit ordering decisions.
+- Keep the team aligned on what matters now.
+
+**When to use**
+
+- Always.
+- Apply exactly one.
+
+**Starter set**
+
+- `prio:urgent`
+- `prio:high`
+- `prio:medium`
+- `prio:low`
+- `prio:none`
+
+### `state:*` labels
+
+**Purpose**
+
+- Give the team one shared workflow language.
+- Make status visible without meetings.
+
+**When to use**
+
+- Always.
+- Apply exactly one.
+- When an issue is moved to `Done` or `Cancelled`, update the label and then close the issue.
+
+**Starter set**
+
+- `state:backlog`
+- `state:todo`
+- `state:in-progress`
+- `state:in-review`
+- `state:done`
+- `state:cancelled`
+
+### `team:*` labels
+
+**Purpose**
+
+- Make ownership obvious.
+- Support team-level views and cycle planning.
+
+**When to use**
+
+- Use once triage determines the owning team.
+- Apply exactly one on any issue that has entered `Todo`, `In Progress`, or `In Review`.
+
+**Example labels**
+
+- `team:desktop`
+- `team:runtime`
+- `team:protocol`
+- `team:wallet`
+- `team:design`
+
+Only create labels for teams that actively exist.
+
+### `area:*` labels
+
+**Purpose**
+
+- Add light topical context without turning labels into a taxonomy project.
+- Help find related work across teams.
+
+**When to use**
+
+- Optional.
+- Use 0-2 only.
+- Prefer stable product or system areas, not temporary initiatives.
+
+**Starter set**
+
+- `area:ui`
+- `area:sync`
+- `area:nostr`
+- `area:wallet`
+- `area:provider`
+- `area:auth`
+- `area:build`
+- `area:docs`
+
+### Operational labels
+
+**Purpose**
+
+- Mark issues that need special handling right now.
+
+**When to use**
+
+- Only when the label changes how the team responds.
+- Remove the label as soon as the special condition is gone.
+
+**Starter set**
+
+- `blocked` — cannot progress because of an external dependency or unresolved prerequisite
+- `needs-decision` — requires a product, architecture, or owner decision
+- `needs-repro` — bug exists but reproduction is not yet reliable
+
+**Important note**
+
+- Do **not** create a separate `agent-task` operational label; use `type:agent-task` only.
+
+### Recommended naming conventions for labels
+
+- Use lowercase only.
+- Use singular nouns where possible.
+- Use prefixes consistently: `type:*`, `prio:*`, `state:*`, `team:*`, `area:*`.
+- Avoid spaces except in rare plain operational labels.
+- Prefer stable names over clever names.
+
+---
+
+## 3. Issue templates
+
+These templates are designed for low-friction team use. They are intentionally short. The goal is to create useful issues quickly, not write mini-specs.
+
+### 3.1 Bug template
+
+**Use when**
+
+- Something is broken, incorrect, misleading, or regressed.
+
+**Required fields**
+
+- problem summary
+- expected behavior
+- actual behavior
+- impact
+- labels: `type:bug`, one `prio:*`, one `state:*`, one `team:*` once triaged
+
+**Optional fields**
+
+- reproduction steps
+- logs/screenshots
+- suspected area
+- linked PR or issue
+
+**Template**
+
+```md
+## Summary
+<one sentence: what is broken?>
+
+## Expected behavior
+<what should happen?>
+
+## Actual behavior
+<what happens instead?>
+
+## Impact
+- Who or what is affected?
+- Does this block MVP-critical flow?
+
+## Reproduction
+1. 
+2. 
+3. 
+
+## Notes
+<logs, screenshots, guesses, linked issues/PRs>
+```
+
+### 3.2 Feature template
+
+**Use when**
+
+- A new user-facing or team-facing capability is needed.
+
+**Required fields**
+
+- problem or opportunity
+- desired outcome
+- scope of this issue
+- labels: `type:feature`, one `prio:*`, one `state:*`, one `team:*` once triaged
+
+**Optional fields**
+
+- acceptance notes
+- linked epic
+- dependencies
+- rollout notes
+
+**Template**
+
+```md
+## Problem / opportunity
+<what need are we addressing?>
+
+## Desired outcome
+<what should be true when this is done?>
+
+## Scope
+- In scope:
+- Out of scope:
+
+## Acceptance notes
+- 
+- 
+
+## Dependencies / links
+<epic, related issues, PRs, docs>
+```
+
+### 3.3 Research template
+
+**Use when**
+
+- The team needs investigation, comparison, framing, or a recommendation before implementation.
+
+**Required fields**
+
+- question to answer
+- why it matters now
+- expected output
+- labels: `type:research`, one `prio:*`, one `state:*`, one `team:*` once triaged
+
+**Optional fields**
+
+- decision deadline
+- references
+- linked epic or blocker
+
+**Template**
+
+```md
+## Question
+<what do we need to learn or decide?>
+
+## Why this matters now
+<why is this worth doing in this cycle?>
+
+## Expected output
+- Recommendation
+- Tradeoffs
+- Next-step proposal
+
+## Inputs / references
+- 
+- 
+
+## Done when
+<what artifact or decision closes this?>
+```
+
+### 3.4 Agent Task template
+
+**Use when**
+
+- The work is intended for an AI agent or needs to be structured so an agent can execute it with minimal ambiguity.
+
+**Required fields**
+
+- task objective
+- constraints
+- inputs/context
+- expected output
+- verification method
+- labels: `type:agent-task`, one `prio:*`, one `state:*`, one `team:*` once triaged
+
+**Optional fields**
+
+- repo/path scope
+- budget or timebox
+- linked human owner
+- follow-up tasks
+
+**Template**
+
+```md
+## Objective
+<what should the agent accomplish?>
+
+## Inputs / context
+- Repo/path scope:
+- Related issue/epic:
+- Relevant docs:
+
+## Constraints
+- Do not:
+- Must preserve:
+- Timebox / budget:
+
+## Expected output
+- 
+- 
+
+## Verification
+<how will a human or system verify completion?>
+
+## Human owner
+<who will review or unblock this?>
+```
+
+---
+
+## 4. Epic template
+
+Use an epic only when the work clearly spans multiple deliverables or multiple cycles. If the work can be completed as one issue, do not create an epic.
+
+### Required fields
+
+- problem statement
+- desired outcome
+- scope
+- non-goals
+- milestones/checkpoints
+- child issue checklist
+- risks/dependencies
+- definition of done
+
+### Optional fields
+
+- owner
+- target cycle range
+- linked docs
+- status summary
+
+### Template
+
+```md
+## Problem statement
+<what problem is this initiative solving and why now?>
+
+## Desired outcome
+<what should be true when this epic is complete?>
+
+## Scope
+- In scope:
+- In scope:
+- Out of scope:
+
+## Non-goals
+- 
+- 
+
+## Milestones / checkpoints
+1. 
+2. 
+3. 
+
+## Child issues
+- [ ] Child issue title
+- [ ] Child issue title
+- [ ] Child issue title
+
+## Risks / dependencies
+- Dependency:
+- Risk:
+
+## Definition of done
+- 
+- 
+- 
+```
+
+### Epic usage rules
+
+- Give every child issue a backlink to the epic.
+- Do not put day-to-day implementation notes only in the epic; keep execution details in child issues.
+- Close the epic only when all required child issues are done or intentionally cancelled.
+
+---
+
+## 5. Cycle ritual and lightweight operating runbook
+
+### 5.1 How work gets created
+
+1. Any team member may create a new issue.
+2. New work starts in `state:backlog` unless it is already agreed for the current cycle.
+3. The creator should choose the best `type:*` and a rough `prio:*`.
+4. During triage, the owning team, final priority, and next action are clarified.
+5. If the issue is larger than one deliverable, open an epic and then split child issues.
+
+### 5.2 How work gets prioritized
+
+Use these rules:
+
+- Prioritize work that protects or advances the core OpenAgents MVP loop first.
+- Prefer finishing active work over starting new work.
+- If two items compete, the item with clearer user impact or unblock value wins.
+- If work is interesting but not timely, give it `prio:none` and keep it in backlog.
+
+Practical triage order:
+
+1. Urgent bugs
+2. Active blockers
+3. Current cycle commitments
+4. Near-term MVP work
+5. Research and lower-priority backlog
+
+### 5.3 How issues move across states
+
+#### `state:backlog`
+
+- Default for newly captured work
+- Not yet committed
+- May be incomplete, but must have enough information to understand the request
+
+#### `state:todo`
+
+- The issue is accepted into the current cycle
+- A team owns it
+- It is ready to start without another planning meeting
+
+#### `state:in-progress`
+
+- One owner is actively working it
+- The issue should have a clear next step
+- If no progress occurs for multiple days, add a status comment or move it back
+
+#### `state:in-review`
+
+- Implementation or investigation is complete enough for review
+- PR, validation, or signoff is pending
+- Review comments should stay linked from the issue/PR pair
+
+#### `state:done`
+
+- Acceptance criteria are met
+- PR is merged or the agreed artifact exists
+- The issue is closed after the label is updated
+
+#### `state:cancelled`
+
+- The team explicitly decided not to do it now
+- The issue is closed after a short reason is left in a comment
+
+### 5.4 How blockers are handled
+
+When an issue is blocked:
+
+1. Add the `blocked` label.
+2. Leave a short comment with:
+   - what is blocked
+   - why it is blocked
+   - who or what is needed to unblock it
+   - the next check-in date if known
+3. If the blocker is a decision, also add `needs-decision`.
+4. If the blocker lasts beyond the current cycle, decide whether to:
+   - carry it over,
+   - move it back to backlog,
+   - or cancel it.
+
+**Blocked comment format**
+
+```md
+Blocked on: <dependency or decision>
+Need from: <owner/team>
+Next unblock check: <date or trigger>
+```
+
+### 5.5 Weekly planning and backlog grooming
+
+Run one short weekly session per active team.
+
+**Recommended duration:** 30-45 minutes
+
+**Agenda**
+
+1. Review urgent bugs.
+2. Review blocked issues.
+3. Review in-progress work that may need help.
+4. Pull the next highest-value issues from backlog into `Todo`.
+5. Assign the cycle milestone.
+6. Confirm each committed issue has:
+   - owner/team
+   - priority
+   - state
+   - enough detail to start
+
+### 5.6 Daily async update expectations
+
+Keep this lightweight.
+
+Post a short async update in the issue comment thread when:
+
+- the issue enters `In Progress`
+- the issue is blocked
+- the issue changes materially
+- the issue stays active across multiple days
+
+**Recommended update format**
+
+```md
+Yesterday: <what changed>
+Today: <next step>
+Blockers: <none / blocker>
+```
+
+Do not require a daily comment on dormant backlog items.
+
+### 5.7 End-of-cycle review
+
+At the end of each cycle:
+
+1. Review all `Done` issues.
+2. Review all unfinished `Todo`, `In Progress`, and `In Review` issues.
+3. Ask why unfinished work did not complete:
+   - unclear scope
+   - hidden dependency
+   - too large
+   - wrong priority
+   - resourcing gap
+4. Capture a short list of friction points in one retrospective note.
+5. Identify the smallest process fix for the next cycle.
+
+### 5.8 Carry-over rules
+
+Carry work over only when all of the following are true:
+
+- it is still valuable now
+- there is a clear owner
+- the next step is known
+- the work is small enough to finish in the next cycle, or is explicitly split first
+
+Otherwise:
+
+- move it back to `state:backlog`, or
+- close it as `state:cancelled` with a reason
+
+### 5.9 Definition of good Step 0 hygiene
+
+The workflow is healthy when:
+
+- active issues have owners
+- blocked issues are visibly marked
+- the backlog is not a dumping ground for half-written work
+- most in-progress items have visible next steps
+- cycle carry-over is the exception, not the default
+
+---
+
+## 6. Recommended saved views and naming conventions
+
+### 6.1 Saved views
+
+Use a small set of high-value views first.
+
+| View | What it shows | Why it matters | Suggested filter logic |
+| --- | --- | --- | --- |
+| My Work | Open issues assigned to me | Personal daily queue | `is:open assignee:@me sort:updated-desc` |
+| Current Cycle | Open issues in the active milestone | Team commitment for the week/cycle | `is:open milestone:<current-cycle> sort:updated-desc` |
+| Blocked | Open issues that cannot move | Fastest way to find stuck work | `is:open label:blocked sort:updated-desc` |
+| Bugs | Open bug issues | Keeps broken behavior visible | `is:open label:"type:bug" sort:updated-desc` |
+| Recently Updated | Most recently touched open issues | Good default triage and review view | `is:open sort:updated-desc` |
+| Agent Tasks | Open work intended for agent execution | Separates agent-shaped work from human-owned work | `is:open label:"type:agent-task" sort:updated-desc` |
+
+### 6.2 Optional extra view if needed
+
+- **In Review** — `is:open label:"state:in-review" sort:updated-desc`
+
+Only add more views after the team is consistently using the starter set.
+
+### 6.3 Naming conventions
+
+#### Epics
+
+- Format: `[Epic] <outcome-oriented title>`
+- Example: `[Epic] Make provider online/offline state legible in desktop`
+
+Rule: epic titles should describe the outcome, not the implementation bucket.
+
+#### Issues
+
+- Format: `<verb> <object> <optional constraint or context>`
+- Good examples:
+  - `Show wallet sync health in the wallet pane`
+  - `Fix stale provider heartbeat after reconnect`
+  - `Research Nostr event shape for PM comments`
+
+Avoid vague titles like:
+
+- `Wallet stuff`
+- `PM improvements`
+- `Refactor issue model`
+
+#### Cycles
+
+- Format: `Cycle YYYY-Www`
+- Example: `Cycle 2026-W11`
+
+This is simple, sortable, and works well as a GitHub milestone name.
+
+#### Labels
+
+- Lowercase
+- Prefix-based for grouped labels
+- Stable terms only
+- Examples:
+  - `type:bug`
+  - `prio:high`
+  - `state:in-review`
+  - `team:desktop`
+  - `area:wallet`
+
+#### Team and project identifiers
+
+- Use short lowercase identifiers.
+- Prefer durable names over temporary code names.
+- Team examples:
+  - `desktop`
+  - `runtime`
+  - `protocol`
+  - `wallet`
+- Project examples:
+  - `autopilot`
+  - `provider-runtime`
+  - `spark-wallet`
+
+---
+
+## 7. Immediate setup checklist
+
+Use this as the first adoption pass.
+
+1. Create the starter labels from Section 2.
+2. Create one current-cycle milestone using `Cycle YYYY-Www`.
+3. Create starter issue templates from Sections 3 and 4.
+4. Share this runbook with the pilot team.
+5. Move one real slice of work into the workflow.
+6. Use the workflow for one full cycle before changing the taxonomy.
+7. At cycle end, remove or simplify anything the team did not actually use.
+
+---
+
+## 8. Final recommendation for Step 0
+
+Optimize for clarity and finish rate, not completeness.
+
+If the team can reliably answer these questions from GitHub alone, Step 0 is working:
+
+- What are we doing now?
+- What is blocked?
+- Who owns it?
+- What should happen next?
+- What finished this cycle?
+
+If that is true, the dogfood layer is good enough to support internal adoption and inform the later native implementation.


### PR DESCRIPTION
## Summary

This PR adds documentation and planning material for Autopilot project management.

This is **documentation/planning only**. It does **not** implement native product functionality. The purpose is to give the team a concrete planning artifact for review and a practical Step 0 operating package for possible immediate internal adoption.

## Included files

- `docs/plans/autopilot-project-management-implementation-plan.md`
- `docs/plans/autopilot-project-management-step-0-dogfood-package.md`

## Purpose

The implementation plan converts the broader Autopilot PM outline into a phased, execution-oriented plan.

The Step 0 package is intentionally lightweight and GitHub-native. It is designed for **immediate internal review and possible adoption** as a low-overhead dogfooding layer before any native Autopilot PM implementation work.

## Notes

- This branch is scoped to planning/docs only
- No native PM product implementation is included
- The Step 0 package focuses on immediate usability, minimal process overhead, and MVP-aligned internal workflow discipline

## What reviewers should focus on

- Whether the phased rollout is sensibly scoped and sequenced
- Whether Step 0 is realistic, lightweight, and usable right away
- Whether the label taxonomy, templates, and cycle ritual are practical for internal engineering use
- Whether the docs stay aligned with current OpenAgents MVP discipline and avoid unnecessary future-state complexity

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author