### PR TITLE
[psionic][metal][gpt-oss] Make Metal execution mode explicit

### DIFF
--- a/crates/psionic/psionic-serve/src/bin/psionic-gpt-oss-server.rs
+++ b/crates/psionic/psionic-serve/src/bin/psionic-gpt-oss-server.rs
@@ -1,7 +1,8 @@
 use std::{env, process::ExitCode};
 
 use psionic_serve::{
-    GptOssOpenAiCompatBackend, GptOssOpenAiCompatConfig, GptOssOpenAiCompatServer,
+    GptOssMetalExecutionMode, GptOssOpenAiCompatBackend, GptOssOpenAiCompatConfig,
+    GptOssOpenAiCompatServer,
 };
 use tokio::net::TcpListener;
 
@@ -25,11 +26,14 @@ async fn run() -> Result<(), String> {
     let server = GptOssOpenAiCompatServer::from_config(&config)
         .map_err(|error| format!("failed to load GPT-OSS GGUF: {error}"))?;
     eprintln!(
-        "psionic gpt-oss server listening on http://{} with model {}",
+        "psionic gpt-oss server listening on http://{} with model {} backend={} execution_mode={} execution_engine={}",
         listener
             .local_addr()
             .map_err(|error| format!("failed to query listener address: {error}"))?,
         config.model_path.display(),
+        server.backend_label(),
+        server.execution_mode_label(),
+        server.execution_engine_label(),
     );
     server
         .serve(listener)
@@ -38,16 +42,25 @@ async fn run() -> Result<(), String> {
 }
 
 fn parse_args() -> Result<GptOssOpenAiCompatConfig, String> {
+    parse_args_from(env::args().skip(1))
+}
+
+fn parse_args_from<I, S>(args: I) -> Result<GptOssOpenAiCompatConfig, String>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
     let mut model_path = None;
     let mut host = String::from("127.0.0.1");
     let mut port = 8080_u16;
     let mut backend = GptOssOpenAiCompatBackend::Auto;
     let mut context_length = None;
     let mut gpu_layers = None;
+    let mut metal_mode = GptOssMetalExecutionMode::Auto;
     let mut reasoning_budget = 0_u8;
     let mut webui_enabled = false;
 
-    let mut args = env::args().skip(1);
+    let mut args = args.into_iter().map(Into::into);
     while let Some(argument) = args.next() {
         match argument.as_str() {
             "-m" | "--model" => {
@@ -65,6 +78,18 @@ fn parse_args() -> Result<GptOssOpenAiCompatConfig, String> {
                     other => {
                         return Err(format!(
                             "invalid --backend value `{other}` (expected auto, cpu, cuda, or metal)"
+                        ));
+                    }
+                };
+            }
+            "--metal-mode" => {
+                metal_mode = match next_value(&mut args, argument.as_str())?.as_str() {
+                    "auto" => GptOssMetalExecutionMode::Auto,
+                    "native" => GptOssMetalExecutionMode::Native,
+                    "proxy" => GptOssMetalExecutionMode::ProxyLlamaCpp,
+                    other => {
+                        return Err(format!(
+                            "invalid --metal-mode value `{other}` (expected auto, native, or proxy)"
                         ));
                     }
                 };
@@ -111,6 +136,16 @@ fn parse_args() -> Result<GptOssOpenAiCompatConfig, String> {
     let Some(model_path) = model_path else {
         return Err(format!("missing required `-m` / `--model`\n\n{}", usage()));
     };
+    if !matches!(
+        backend,
+        GptOssOpenAiCompatBackend::Auto | GptOssOpenAiCompatBackend::Metal
+    ) && !matches!(metal_mode, GptOssMetalExecutionMode::Auto)
+    {
+        return Err(format!(
+            "`--metal-mode` is only valid with `--backend auto` or `--backend metal`\n\n{}",
+            usage()
+        ));
+    }
     Ok(GptOssOpenAiCompatConfig {
         model_path: model_path.into(),
         host,
@@ -118,6 +153,7 @@ fn parse_args() -> Result<GptOssOpenAiCompatConfig, String> {
         backend,
         context_length,
         gpu_layers,
+        metal_mode,
         reasoning_budget,
         webui_enabled,
     })
@@ -130,6 +166,42 @@ fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<Str
 
 fn usage() -> String {
     String::from(
-        "usage: psionic-gpt-oss-server -m <model.gguf> [--backend <auto|cpu|cuda|metal>] [--host <ip>] [--port <port>] [-c <ctx>] [-ngl <n>] [--reasoning-budget <n>] [--no-webui]",
+        "usage: psionic-gpt-oss-server -m <model.gguf> [--backend <auto|cpu|cuda|metal>] [--metal-mode <auto|native|proxy>] [--host <ip>] [--port <port>] [-c <ctx>] [-ngl <n>] [--reasoning-budget <n>] [--no-webui]",
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GptOssMetalExecutionMode, GptOssOpenAiCompatBackend, parse_args_from};
+
+    #[test]
+    fn parse_args_accepts_explicit_proxy_metal_mode() {
+        let config = parse_args_from([
+            "-m",
+            "/tmp/model.gguf",
+            "--backend",
+            "metal",
+            "--metal-mode",
+            "proxy",
+        ])
+        .expect("config");
+
+        assert_eq!(config.backend, GptOssOpenAiCompatBackend::Metal);
+        assert_eq!(config.metal_mode, GptOssMetalExecutionMode::ProxyLlamaCpp);
+    }
+
+    #[test]
+    fn parse_args_rejects_metal_mode_for_cpu_backend() {
+        let error = parse_args_from([
+            "-m",
+            "/tmp/model.gguf",
+            "--backend",
+            "cpu",
+            "--metal-mode",
+            "native",
+        ])
+        .expect_err("cpu backend should reject metal mode");
+
+        assert!(error.contains("--metal-mode"));
+    }
 }

--- a/crates/psionic/psionic-serve/src/openai_http.rs
+++ b/crates/psionic/psionic-serve/src/openai_http.rs
@@ -17,7 +17,7 @@ use std::{
 use axum::{
     Json, Router,
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
     response::{
         IntoResponse, Response,
         sse::{Event, Sse},
@@ -90,6 +90,104 @@ impl GptOssOpenAiCompatBackend {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GptOssMetalExecutionMode {
+    Auto,
+    Native,
+    ProxyLlamaCpp,
+}
+
+impl GptOssMetalExecutionMode {
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Native => "native",
+            Self::ProxyLlamaCpp => "proxy",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct GptOssOpenAiCompatExecutionSummary {
+    backend_label: &'static str,
+    execution_mode_label: &'static str,
+    execution_engine_label: &'static str,
+}
+
+impl GptOssOpenAiCompatExecutionSummary {
+    const fn native(backend_label: &'static str) -> Self {
+        Self {
+            backend_label,
+            execution_mode_label: "native",
+            execution_engine_label: "psionic",
+        }
+    }
+
+    const fn metal_proxy() -> Self {
+        Self {
+            backend_label: "metal",
+            execution_mode_label: "proxy",
+            execution_engine_label: "llama.cpp",
+        }
+    }
+
+    fn uses_proxy(self) -> bool {
+        matches!(self.execution_engine_label, "llama.cpp")
+    }
+}
+
+fn resolve_execution_summary(
+    backend: GptOssOpenAiCompatBackend,
+    metal_mode: GptOssMetalExecutionMode,
+    legacy_proxy_enabled: bool,
+) -> Result<GptOssOpenAiCompatExecutionSummary, OpenAiCompatServerError> {
+    match backend {
+        GptOssOpenAiCompatBackend::Metal => match metal_mode {
+            GptOssMetalExecutionMode::Auto => Ok(if legacy_proxy_enabled {
+                GptOssOpenAiCompatExecutionSummary::metal_proxy()
+            } else {
+                GptOssOpenAiCompatExecutionSummary::native("metal")
+            }),
+            GptOssMetalExecutionMode::Native => {
+                if legacy_proxy_enabled {
+                    Err(OpenAiCompatServerError::Config(String::from(
+                        "requested `--metal-mode native` while legacy PSIONIC_METAL_PROXY_LLAMA_CPP is enabled",
+                    )))
+                } else {
+                    Ok(GptOssOpenAiCompatExecutionSummary::native("metal"))
+                }
+            }
+            GptOssMetalExecutionMode::ProxyLlamaCpp => {
+                Ok(GptOssOpenAiCompatExecutionSummary::metal_proxy())
+            }
+        },
+        GptOssOpenAiCompatBackend::Cpu => {
+            if matches!(metal_mode, GptOssMetalExecutionMode::Auto) {
+                Ok(GptOssOpenAiCompatExecutionSummary::native("cpu"))
+            } else {
+                Err(OpenAiCompatServerError::Config(format!(
+                    "requested `--metal-mode {}` but resolved backend is cpu",
+                    metal_mode.label()
+                )))
+            }
+        }
+        GptOssOpenAiCompatBackend::Cuda => {
+            if matches!(metal_mode, GptOssMetalExecutionMode::Auto) {
+                Ok(GptOssOpenAiCompatExecutionSummary::native("cuda"))
+            } else {
+                Err(OpenAiCompatServerError::Config(format!(
+                    "requested `--metal-mode {}` but resolved backend is cuda",
+                    metal_mode.label()
+                )))
+            }
+        }
+        GptOssOpenAiCompatBackend::Auto => Err(OpenAiCompatServerError::Config(String::from(
+            "auto backend must be resolved before execution mode selection",
+        ))),
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct GptOssOpenAiCompatConfig {
     pub model_path: PathBuf,
@@ -98,6 +196,7 @@ pub struct GptOssOpenAiCompatConfig {
     pub backend: GptOssOpenAiCompatBackend,
     pub context_length: Option<usize>,
     pub gpu_layers: Option<i32>,
+    pub metal_mode: GptOssMetalExecutionMode,
     pub reasoning_budget: u8,
     pub webui_enabled: bool,
 }
@@ -112,6 +211,7 @@ impl GptOssOpenAiCompatConfig {
             backend: GptOssOpenAiCompatBackend::Auto,
             context_length: None,
             gpu_layers: None,
+            metal_mode: GptOssMetalExecutionMode::Auto,
             reasoning_budget: 0,
             webui_enabled: false,
         }
@@ -139,6 +239,8 @@ struct GptOssOpenAiCompatState {
     worker: Option<GptOssWorker>,
     proxy: Option<Arc<LlamaCppProxyState>>,
     backend_label: &'static str,
+    execution_mode_label: &'static str,
+    execution_engine_label: &'static str,
     descriptor: DecoderModelDescriptor,
     tokenizer: GptOssTokenizer,
     prompt_options: PromptRenderOptions,
@@ -242,12 +344,13 @@ impl GptOssOpenAiCompatServer {
             .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
             .unwrap_or(false);
         let backend = config.backend.resolve();
-        let proxy =
-            if backend == GptOssOpenAiCompatBackend::Metal && metal_proxy_llama_cpp_enabled() {
-                Some(Arc::new(LlamaCppProxyState::spawn(config)?))
-            } else {
-                None
-            };
+        let execution_summary =
+            resolve_execution_summary(backend, config.metal_mode, metal_proxy_llama_cpp_enabled())?;
+        let proxy = if execution_summary.uses_proxy() {
+            Some(Arc::new(LlamaCppProxyState::spawn(config)?))
+        } else {
+            None
+        };
         Ok(Self {
             state: Arc::new(GptOssOpenAiCompatState {
                 worker: if proxy.is_some() {
@@ -256,7 +359,9 @@ impl GptOssOpenAiCompatServer {
                     Some(GptOssWorker::spawn(config.model_path.clone(), backend)?)
                 },
                 proxy,
-                backend_label: backend.label(),
+                backend_label: execution_summary.backend_label,
+                execution_mode_label: execution_summary.execution_mode_label,
+                execution_engine_label: execution_summary.execution_engine_label,
                 descriptor,
                 tokenizer,
                 prompt_options,
@@ -269,6 +374,21 @@ impl GptOssOpenAiCompatServer {
                 request_counter: AtomicU64::new(1),
             }),
         })
+    }
+
+    #[must_use]
+    pub fn backend_label(&self) -> &'static str {
+        self.state.backend_label
+    }
+
+    #[must_use]
+    pub fn execution_mode_label(&self) -> &'static str {
+        self.state.execution_mode_label
+    }
+
+    #[must_use]
+    pub fn execution_engine_label(&self) -> &'static str {
+        self.state.execution_engine_label
     }
 
     #[must_use]
@@ -663,6 +783,8 @@ impl IntoResponse for OpenAiCompatHttpError {
 struct HealthResponse {
     status: &'static str,
     backend: &'static str,
+    execution_mode: &'static str,
+    execution_engine: &'static str,
     model: String,
 }
 
@@ -670,6 +792,8 @@ async fn health(State(state): State<Arc<GptOssOpenAiCompatState>>) -> Json<Healt
     Json(HealthResponse {
         status: "ok",
         backend: state.backend_label,
+        execution_mode: state.execution_mode_label,
+        execution_engine: state.execution_engine_label,
         model: state.default_model_name.clone(),
     })
 }
@@ -751,7 +875,7 @@ async fn handle_chat_completions(
     request: ChatCompletionRequest,
 ) -> Result<Response, OpenAiCompatHttpError> {
     if let Some(proxy) = state.proxy.as_ref() {
-        return proxy_chat_completions(proxy, &request).await;
+        return proxy_chat_completions(state.as_ref(), proxy, &request).await;
     }
     validate_requested_model(request.model.as_deref(), &state.accepted_model_names)?;
     let prompt_messages = chat_messages_to_prompt_messages(&request.messages)?;
@@ -839,7 +963,9 @@ async fn handle_chat_completions(
             ),
             Ok::<_, Infallible>(Event::default().data("[DONE]")),
         ];
-        return Ok(Sse::new(iter(events)).into_response());
+        let mut response = Sse::new(iter(events)).into_response();
+        insert_execution_headers(response.headers_mut(), state.as_ref());
+        return Ok(response);
     }
 
     let psionic_harmony = if state.include_psionic_fields {
@@ -848,7 +974,7 @@ async fn handle_chat_completions(
         None
     };
     let full_choice = choice.into_full_choice();
-    Ok(Json(ChatCompletionResponse {
+    let mut response = Json(ChatCompletionResponse {
         id: request_id,
         object: "chat.completion",
         created: unix_timestamp_secs(),
@@ -868,10 +994,13 @@ async fn handle_chat_completions(
             .then(|| response.metrics.gpt_oss_perf.clone())
             .flatten(),
     })
-    .into_response())
+    .into_response();
+    insert_execution_headers(response.headers_mut(), state.as_ref());
+    Ok(response)
 }
 
 async fn proxy_chat_completions(
+    state: &GptOssOpenAiCompatState,
     proxy: &LlamaCppProxyState,
     request: &ChatCompletionRequest,
 ) -> Result<Response, OpenAiCompatHttpError> {
@@ -906,9 +1035,26 @@ async fn proxy_chat_completions(
     if let Some(content_type) = content_type {
         response = response.header(axum::http::header::CONTENT_TYPE, content_type);
     }
-    response
+    let mut response = response
         .body(axum::body::Body::from(body))
-        .map_err(|error| OpenAiCompatHttpError::BadRequest(error.to_string()))
+        .map_err(|error| OpenAiCompatHttpError::BadRequest(error.to_string()))?;
+    insert_execution_headers(response.headers_mut(), state);
+    Ok(response)
+}
+
+fn insert_execution_headers(headers: &mut HeaderMap, state: &GptOssOpenAiCompatState) {
+    headers.insert(
+        HeaderName::from_static("x-psionic-backend"),
+        HeaderValue::from_static(state.backend_label),
+    );
+    headers.insert(
+        HeaderName::from_static("x-psionic-execution-mode"),
+        HeaderValue::from_static(state.execution_mode_label),
+    );
+    headers.insert(
+        HeaderName::from_static("x-psionic-execution-engine"),
+        HeaderValue::from_static(state.execution_engine_label),
+    );
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1228,10 +1374,11 @@ struct OpenAiErrorBody {
 #[cfg(test)]
 mod tests {
     use super::{
-        ChatCompletionMessage, ChatCompletionRequest, HARMONY_CALL_STOP, HARMONY_RETURN_STOP,
-        PromptTokenCache, chat_messages_to_prompt_messages, ensure_harmony_stop_sequences,
+        ChatCompletionMessage, ChatCompletionRequest, GptOssMetalExecutionMode,
+        GptOssOpenAiCompatBackend, HARMONY_CALL_STOP, HARMONY_RETURN_STOP, PromptTokenCache,
+        chat_messages_to_prompt_messages, ensure_harmony_stop_sequences,
         fast_final_assistant_content, final_assistant_content,
-        generation_options_from_chat_request,
+        generation_options_from_chat_request, resolve_execution_summary,
     };
     use psionic_models::{
         GptOssHarmonyParseSource, GptOssHarmonyParsedOutput, PromptMessage, PromptMessageRole,
@@ -1289,6 +1436,44 @@ mod tests {
                 .iter()
                 .any(|value| value == HARMONY_CALL_STOP)
         );
+    }
+
+    #[test]
+    fn auto_metal_mode_resolves_to_native_without_legacy_proxy() {
+        let summary = resolve_execution_summary(
+            GptOssOpenAiCompatBackend::Metal,
+            GptOssMetalExecutionMode::Auto,
+            false,
+        )
+        .expect("metal summary");
+
+        assert_eq!(summary.backend_label, "metal");
+        assert_eq!(summary.execution_mode_label, "native");
+        assert_eq!(summary.execution_engine_label, "psionic");
+    }
+
+    #[test]
+    fn explicit_native_metal_mode_rejects_legacy_proxy_env() {
+        let error = resolve_execution_summary(
+            GptOssOpenAiCompatBackend::Metal,
+            GptOssMetalExecutionMode::Native,
+            true,
+        )
+        .expect_err("native metal should reject legacy proxy env");
+
+        assert!(error.to_string().contains("PSIONIC_METAL_PROXY_LLAMA_CPP"));
+    }
+
+    #[test]
+    fn explicit_metal_mode_is_rejected_when_backend_is_not_metal() {
+        let error = resolve_execution_summary(
+            GptOssOpenAiCompatBackend::Cuda,
+            GptOssMetalExecutionMode::ProxyLlamaCpp,
+            false,
+        )
+        .expect_err("non-metal backend should reject explicit metal mode");
+
+        assert!(error.to_string().contains("resolved backend is cuda"));
     }
 
     #[test]

--- a/crates/psionic/scripts/benchmark-gpt-oss-vs-llama.sh
+++ b/crates/psionic/scripts/benchmark-gpt-oss-vs-llama.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  crates/psionic/scripts/benchmark-gpt-oss-vs-llama.sh [--model PATH] [--psionic-bin PATH] [--psionic-backend BACKEND] [--llama-bin PATH] [--host HOST] [--port PORT] [--ctx N] [--ngl N] [--max-tokens N] [--startup-timeout-seconds N] [--request-timeout-seconds N] [--json-out DIR]
+  crates/psionic/scripts/benchmark-gpt-oss-vs-llama.sh [--model PATH] [--psionic-bin PATH] [--psionic-backend BACKEND] [--psionic-metal-mode MODE] [--llama-bin PATH] [--host HOST] [--port PORT] [--ctx N] [--ngl N] [--max-tokens N] [--startup-timeout-seconds N] [--request-timeout-seconds N] [--json-out DIR]
 
 Defaults:
   macOS model:           /Users/christopherdavid/models/gpt-oss/gpt-oss-20b-mxfp4.gguf
@@ -14,6 +14,7 @@ Defaults:
   Linux llama-bin:       /home/christopherdavid/code/llama.cpp/build/bin/llama-server
   macOS psionic backend: metal
   Linux psionic backend: cuda
+  psionic metal mode:    native
   host:                  127.0.0.1
   port:                  8099
   ctx:                   4096
@@ -24,6 +25,7 @@ Defaults:
 
 Notes:
   - The script prefers ./target/release/psionic-gpt-oss-server, then ./target/debug/psionic-gpt-oss-server.
+  - On macOS Metal, Psionic defaults to the native Rust/Metal path. Use `--psionic-metal-mode proxy` only for explicit `llama.cpp` oracle/debug runs.
   - Each server is measured on three same-host cases:
       1. cold request
       2. warm non-hit request
@@ -57,6 +59,8 @@ STARTUP_TIMEOUT_SECONDS=60
 REQUEST_TIMEOUT_SECONDS=60
 PSI_BIN=
 JSON_OUT=
+PSIONIC_METAL_MODE=
+PSIONIC_METAL_MODE_SET=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -74,6 +78,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     --llama-bin)
       LLAMA_BIN=${2:?missing value for --llama-bin}
+      shift 2
+      ;;
+    --psionic-metal-mode)
+      PSIONIC_METAL_MODE=${2:?missing value for --psionic-metal-mode}
+      PSIONIC_METAL_MODE_SET=1
       shift 2
       ;;
     --host)
@@ -119,6 +128,37 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+is_truthy() {
+  local value=${1:-}
+  [[ "$value" == "1" || "$value" == "true" || "$value" == "TRUE" || "$value" == "yes" || "$value" == "YES" ]]
+}
+
+if [[ "$PSI_BACKEND" == "metal" ]]; then
+  if [[ -z "$PSIONIC_METAL_MODE" ]]; then
+    PSIONIC_METAL_MODE=native
+  fi
+  case "$PSIONIC_METAL_MODE" in
+    native|proxy)
+      ;;
+    *)
+      echo "invalid --psionic-metal-mode value: $PSIONIC_METAL_MODE (expected native or proxy)" >&2
+      exit 1
+      ;;
+  esac
+else
+  if (( PSIONIC_METAL_MODE_SET )); then
+    echo "--psionic-metal-mode is only valid when --psionic-backend metal" >&2
+    exit 1
+  fi
+  PSIONIC_METAL_MODE=not_applicable
+fi
+
+if [[ "$PSI_BACKEND" == "metal" && "$PSIONIC_METAL_MODE" == "native" ]] && is_truthy "${PSIONIC_METAL_PROXY_LLAMA_CPP:-}"; then
+  echo "native Metal benchmark requested, but legacy PSIONIC_METAL_PROXY_LLAMA_CPP is still enabled" >&2
+  echo "unset PSIONIC_METAL_PROXY_LLAMA_CPP or rerun with --psionic-metal-mode proxy" >&2
+  exit 1
+fi
 
 if [[ -z "$PSI_BIN" ]]; then
   if [[ -x "$REPO_ROOT/target/release/psionic-gpt-oss-server" ]]; then
@@ -227,6 +267,25 @@ run_request() {
     -d "$request_json" | tee "$output_file" | jq -r '.choices[0].message.content'
 }
 
+capture_health_json() {
+  local server_name=$1
+  local output_file=$2
+
+  if [[ "$server_name" == "psionic" ]]; then
+    curl --max-time 2 -fsS "http://$HOST:$PORT/health" > "$output_file"
+  else
+    jq -cn \
+      --arg model "$(basename "$MODEL_PATH")" \
+      '{
+        status: "ok",
+        backend: "reference",
+        execution_mode: "direct",
+        execution_engine: "llama.cpp",
+        model: $model
+      }' > "$output_file"
+  fi
+}
+
 write_summary_json() {
   local server_name=$1
   local case_name=$2
@@ -238,6 +297,7 @@ write_summary_json() {
   [[ -n "$JSON_OUT" ]] || return 0
 
   cp "$response_file" "$JSON_OUT/$server_name.$case_name.response.json"
+  cp "$TMP_DIR/$server_name.health.json" "$JSON_OUT/$server_name.health.json"
   jq -n \
     --arg server "$server_name" \
     --arg case_name "$case_name" \
@@ -248,6 +308,7 @@ write_summary_json() {
     --arg completion_tokens "$tokens" \
     --arg tokens_per_second "$tokps" \
     --slurpfile response "$response_file" \
+    --slurpfile health "$TMP_DIR/$server_name.health.json" \
     '{
       server: $server,
       case: $case_name,
@@ -257,6 +318,9 @@ write_summary_json() {
       elapsed_seconds: ($elapsed_seconds | tonumber),
       completion_tokens: ($completion_tokens | tonumber),
       tokens_per_second: ($tokens_per_second | tonumber),
+      execution_mode: ($health[0].execution_mode // "unknown"),
+      execution_engine: ($health[0].execution_engine // "unknown"),
+      server_health: $health[0],
       response: $response[0]
     }' > "$JSON_OUT/$server_name.$case_name.summary.json"
 }
@@ -294,6 +358,8 @@ bench() {
   SERVER_PID=$!
 
   wait_for_server "http://$HOST:$PORT/health"
+  capture_health_json "$server_name" "$TMP_DIR/$server_name.health.json"
+  echo "health=$(tr -d '\n' < "$TMP_DIR/$server_name.health.json")"
   run_case "$server_name" "cold" "$REQUEST_COLD" "$TMP_DIR/$server_name.cold.json"
   run_case "$server_name" "warm_non_hit" "$REQUEST_WARM" "$TMP_DIR/$server_name.warm_non_hit.json"
   run_case "$server_name" "prompt_cache_hit" "$REQUEST_CACHE_HIT" "$TMP_DIR/$server_name.prompt_cache_hit.json"
@@ -313,6 +379,7 @@ echo "platform=$PLATFORM"
 echo "model=$MODEL_PATH"
 echo "psionic_bin=$PSI_BIN"
 echo "psionic_backend=$PSI_BACKEND"
+echo "psionic_metal_mode=$PSIONIC_METAL_MODE"
 echo "llama_bin=$LLAMA_BIN"
 echo "max_tokens=$MAX_TOKENS"
 echo "startup_timeout_seconds=$STARTUP_TIMEOUT_SECONDS"
@@ -331,10 +398,13 @@ PSIONIC_CMD=(
   --no-webui
 )
 
-if [[ "$PLATFORM" == "Darwin" && "$PSI_BACKEND" == "metal" ]]; then
+if [[ "$PSI_BACKEND" == "metal" ]]; then
+  PSIONIC_CMD+=(--metal-mode "$PSIONIC_METAL_MODE")
+fi
+
+if [[ "$PSI_BACKEND" == "metal" && "$PSIONIC_METAL_MODE" == "proxy" ]]; then
   PSIONIC_CMD=(
     env
-    PSIONIC_METAL_PROXY_LLAMA_CPP=1
     PSIONIC_LLAMA_SERVER_BIN="$LLAMA_BIN"
     PSIONIC_LLAMA_BATCH_SIZE=64
     PSIONIC_LLAMA_UBATCH_SIZE=64


### PR DESCRIPTION
## Summary

Closes #3270.

This makes the Metal GPT-OSS execution path explicit instead of silently benchmarking or serving `llama.cpp` through Psionic on macOS.

- adds an explicit `--metal-mode <auto|native|proxy>` CLI flag to `psionic-gpt-oss-server`
- records the resolved backend, execution mode, and execution engine in `/health`, startup logs, and `x-psionic-*` response headers
- makes the benchmark script default to native Rust/Metal, requires `--psionic-metal-mode proxy` for the oracle path, and writes the resolved mode into benchmark summary JSON
- fails fast when native Metal was requested but the legacy `PSIONIC_METAL_PROXY_LLAMA_CPP` env toggle is still enabled

## Verification

- `cargo test -p psionic-serve auto_metal_mode_resolves_to_native_without_legacy_proxy -- --nocapture`
- `cargo test -p psionic-serve explicit_native_metal_mode_rejects_legacy_proxy_env -- --nocapture`
- `cargo test -p psionic-serve explicit_metal_mode_is_rejected_when_backend_is_not_metal -- --nocapture`
- `cargo test -p psionic-serve --bin psionic-gpt-oss-server -- --nocapture`
- `bash -n crates/psionic/scripts/benchmark-gpt-oss-vs-llama.sh`
- `env PSIONIC_METAL_PROXY_LLAMA_CPP=1 crates/psionic/scripts/benchmark-gpt-oss-vs-llama.sh --psionic-backend metal --psionic-metal-mode native --psionic-bin /bin/true --llama-bin /bin/true --model /Users/christopherdavid/models/gpt-oss/gpt-oss-20b-mxfp4.gguf`
