### PR TITLE
Refine CHAT startup, defaults, and responsive controls

### DIFF
--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -7122,6 +7122,9 @@ pub struct AutopilotChatState {
     pub header_controls_expanded: bool,
     pub thread_tools_expanded: bool,
     pub show_autopilot_help_hint: bool,
+    pub workspace_rail_collapsed: bool,
+    pub thread_rail_collapsed: bool,
+    pub thread_rail_scroll_row_offset: usize,
     pub thread_rename_counter: u64,
     pub transcript_scroll_offset: f32,
     pub transcript_follow_tail: bool,
@@ -7247,7 +7250,7 @@ impl Default for AutopilotChatState {
             auth_refresh_access_token: std::env::var("OPENAI_ACCESS_TOKEN").unwrap_or_default(),
             auth_refresh_account_id: std::env::var("OPENAI_CHATGPT_ACCOUNT_ID").unwrap_or_default(),
             auth_refresh_plan_type: std::env::var("OPENAI_CHATGPT_PLAN_TYPE").unwrap_or_default(),
-            thread_filter_archived: Some(false),
+            thread_filter_archived: None,
             thread_filter_sort_key: codex_client::ThreadSortKey::UpdatedAt,
             thread_filter_source_kind: None,
             thread_filter_model_provider: None,
@@ -7255,6 +7258,9 @@ impl Default for AutopilotChatState {
             header_controls_expanded: false,
             thread_tools_expanded: false,
             show_autopilot_help_hint: false,
+            workspace_rail_collapsed: false,
+            thread_rail_collapsed: false,
+            thread_rail_scroll_row_offset: 0,
             thread_rename_counter: 1,
             transcript_scroll_offset: 0.0,
             transcript_follow_tail: true,
@@ -8611,18 +8617,10 @@ impl AutopilotChatState {
     }
 
     pub fn chat_workspace_entries(&self) -> Vec<ChatWorkspaceSelection> {
-        let mut entries = vec![ChatWorkspaceSelection::Autopilot];
-        entries.extend(
-            self.managed_chat_projection
-                .snapshot
-                .groups
-                .iter()
-                .map(|group| ChatWorkspaceSelection::ManagedGroup(group.group_id.clone())),
-        );
-        if self.has_direct_message_browseable_content() {
-            entries.push(ChatWorkspaceSelection::DirectMessages);
-        }
-        entries
+        // MVP chat shell is currently single-space (private agent lane) in the UI.
+        // Managed groups / DMs continue syncing in projection state but are hidden
+        // from workspace switching until the multi-space UX is re-enabled.
+        vec![ChatWorkspaceSelection::Autopilot]
     }
 
     pub fn select_chat_workspace_by_index(&mut self, index: usize) -> bool {
@@ -8635,6 +8633,7 @@ impl AutopilotChatState {
                 match self.managed_chat_projection.set_selected_group(&group_id) {
                     Ok(()) => {
                         self.selected_workspace = ChatWorkspaceSelection::ManagedGroup(group_id);
+                        self.thread_rail_scroll_row_offset = 0;
                         self.reset_transcript_scroll();
                         self.last_error = None;
                         true
@@ -8669,6 +8668,7 @@ impl AutopilotChatState {
                     match self.direct_message_projection.set_selected_room(&room_id) {
                         Ok(()) => {
                             self.selected_workspace = ChatWorkspaceSelection::DirectMessages;
+                            self.thread_rail_scroll_row_offset = 0;
                             self.reset_transcript_scroll();
                             self.last_error = None;
                             true
@@ -8680,6 +8680,7 @@ impl AutopilotChatState {
                     }
                 } else {
                     self.selected_workspace = ChatWorkspaceSelection::DirectMessages;
+                    self.thread_rail_scroll_row_offset = 0;
                     self.reset_transcript_scroll();
                     self.last_error = None;
                     true
@@ -8687,11 +8688,41 @@ impl AutopilotChatState {
             }
             ChatWorkspaceSelection::Autopilot => {
                 self.selected_workspace = ChatWorkspaceSelection::Autopilot;
+                self.thread_rail_scroll_row_offset = 0;
                 self.reset_transcript_scroll();
                 self.last_error = None;
                 true
             }
         }
+    }
+
+    pub fn thread_rail_scroll_start_index(&self, total_rows: usize, visible_rows: usize) -> usize {
+        let max_start = total_rows.saturating_sub(visible_rows);
+        self.thread_rail_scroll_row_offset.min(max_start)
+    }
+
+    pub fn scroll_thread_rail_by(
+        &mut self,
+        delta: f32,
+        total_rows: usize,
+        visible_rows: usize,
+    ) -> bool {
+        let max_start = total_rows.saturating_sub(visible_rows);
+        if max_start == 0 {
+            self.thread_rail_scroll_row_offset = 0;
+            return false;
+        }
+        let mut steps = (delta / 24.0).round() as isize;
+        if steps == 0 {
+            steps = if delta.is_sign_positive() { 1 } else { -1 };
+        }
+        let current = self.thread_rail_scroll_start_index(total_rows, visible_rows) as isize;
+        let next = (current + steps).clamp(0, max_start as isize) as usize;
+        if next == self.thread_rail_scroll_row_offset {
+            return false;
+        }
+        self.thread_rail_scroll_row_offset = next;
+        true
     }
 
     pub fn active_managed_chat_group(&self) -> Option<&ManagedChatGroupProjection> {
@@ -9428,6 +9459,7 @@ impl AutopilotChatState {
         } else {
             self.active_thread_id = self.threads.first().cloned();
         }
+        self.thread_rail_scroll_row_offset = 0;
         self.rebuild_project_registry();
     }
 
@@ -9521,6 +9553,7 @@ impl AutopilotChatState {
         let thread_id = self.threads.get(index).cloned()?;
         self.cache_active_thread_transcript();
         self.active_thread_id = Some(thread_id.clone());
+        self.thread_rail_scroll_row_offset = index.saturating_add(1);
         self.reset_transcript_scroll();
         self.last_error = None;
         self.restore_cached_thread_transcript(&thread_id);
@@ -9541,6 +9574,7 @@ impl AutopilotChatState {
         if self.active_thread_id.is_none() {
             self.active_thread_id = Some(thread_id);
         }
+        self.thread_rail_scroll_row_offset = 0;
     }
 
     pub fn remember_thread_inactive(&mut self, thread_id: impl Into<String>) {

--- a/apps/autopilot-desktop/src/input/actions.rs
+++ b/apps/autopilot-desktop/src/input/actions.rs
@@ -13,10 +13,10 @@ use crate::local_runtime_capabilities::{
 use crate::pane_renderer::mission_control_current_alert_signature;
 use crate::pane_system::{
     AppleAdapterTrainingPaneAction, AppleFmWorkbenchPaneAction, AttnResLabPaneAction,
-    BuyModePaymentsPaneAction, CHAT_AUTOPILOT_THREAD_PREVIEW_LIMIT, DataBuyerPaneAction,
-    DataMarketPaneAction, DataSellerPaneAction, LocalInferencePaneAction, LogStreamPaneAction,
-    MissionControlPaneAction, Nip90SentPaymentsPaneAction, ProviderControlPaneAction,
-    RivePreviewPaneAction, SparkReplayPaneAction, TassadarLabPaneAction, VoicePlaygroundPaneAction,
+    BuyModePaymentsPaneAction, DataBuyerPaneAction, DataMarketPaneAction, DataSellerPaneAction,
+    LocalInferencePaneAction, LogStreamPaneAction, MissionControlPaneAction,
+    Nip90SentPaymentsPaneAction, ProviderControlPaneAction, RivePreviewPaneAction,
+    SparkReplayPaneAction, TassadarLabPaneAction, VoicePlaygroundPaneAction,
 };
 use crate::spark_wallet::{
     decode_lightning_invoice_payment_hash, is_settled_wallet_payment_status,
@@ -2801,11 +2801,10 @@ fn parse_shell_like_words(input: &str) -> Result<Vec<String>, String> {
         }
     }
 
+    // Degrade gracefully for unmatched quoting/escaping so plain chat text
+    // is never blocked by command-tokenizer edge cases.
     if escaped {
-        return Err("Command parser found a trailing escape character.".to_string());
-    }
-    if quote.is_some() {
-        return Err("Command parser found an unterminated quoted string.".to_string());
+        current.push('\\');
     }
     if !current.is_empty() {
         words.push(current);
@@ -2816,6 +2815,12 @@ fn parse_shell_like_words(input: &str) -> Result<Vec<String>, String> {
 fn parse_chat_git_intent(prompt: &str) -> Result<Option<ChatGitComposerIntent>, String> {
     let trimmed = prompt.trim();
     if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let Some(first_word) = trimmed.split_whitespace().next() else {
+        return Ok(None);
+    };
+    if first_word != "/git" && first_word != "/pr" {
         return Ok(None);
     }
     let words = parse_shell_like_words(trimmed)?;
@@ -3581,13 +3586,13 @@ fn parse_chat_skills_intent(prompt: &str) -> Result<Option<ChatSkillsComposerInt
     if trimmed.is_empty() {
         return Ok(None);
     }
-    let words = parse_shell_like_words(trimmed)?;
-    let Some(command) = words.first().map(String::as_str) else {
+    let Some(first_word) = trimmed.split_whitespace().next() else {
         return Ok(None);
     };
-    if command != "/skills" && command != "/skill" {
+    if first_word != "/skills" && first_word != "/skill" {
         return Ok(None);
     }
+    let words = parse_shell_like_words(trimmed)?;
     let subcommand = words.get(1).map(String::as_str);
     match subcommand {
         None => Ok(Some(ChatSkillsComposerIntent::Summary)),
@@ -3673,13 +3678,13 @@ fn parse_chat_mcp_intent(prompt: &str) -> Result<Option<ChatMcpComposerIntent>, 
     if trimmed.is_empty() {
         return Ok(None);
     }
-    let words = parse_shell_like_words(trimmed)?;
-    let Some(command) = words.first().map(String::as_str) else {
+    let Some(first_word) = trimmed.split_whitespace().next() else {
         return Ok(None);
     };
-    if command != "/mcp" {
+    if first_word != "/mcp" {
         return Ok(None);
     }
+    let words = parse_shell_like_words(trimmed)?;
     match words.get(1).map(String::as_str) {
         None | Some("status") | Some("list") if words.len() <= 2 => {
             Ok(Some(ChatMcpComposerIntent::Summary))
@@ -3710,13 +3715,13 @@ fn parse_chat_apps_intent(prompt: &str) -> Result<Option<ChatAppsComposerIntent>
     if trimmed.is_empty() {
         return Ok(None);
     }
-    let words = parse_shell_like_words(trimmed)?;
-    let Some(command) = words.first().map(String::as_str) else {
+    let Some(first_word) = trimmed.split_whitespace().next() else {
         return Ok(None);
     };
-    if command != "/apps" && command != "/app" {
+    if first_word != "/apps" && first_word != "/app" {
         return Ok(None);
     }
+    let words = parse_shell_like_words(trimmed)?;
     match words.get(1).map(String::as_str) {
         None | Some("list") if words.len() <= 2 => Ok(Some(ChatAppsComposerIntent::Summary)),
         Some("refresh") if words.len() == 2 => Ok(Some(ChatAppsComposerIntent::Refresh)),
@@ -3742,6 +3747,15 @@ fn parse_chat_apps_intent(prompt: &str) -> Result<Option<ChatAppsComposerIntent>
 fn parse_chat_request_intent(prompt: &str) -> Result<Option<ChatRequestComposerIntent>, String> {
     let trimmed = prompt.trim();
     if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let Some(first_word) = trimmed.split_whitespace().next() else {
+        return Ok(None);
+    };
+    if !matches!(
+        first_word,
+        "/requests" | "/approvals" | "/approval" | "/tool" | "/auth"
+    ) {
         return Ok(None);
     }
     let words = parse_shell_like_words(trimmed)?;
@@ -3814,13 +3828,13 @@ fn parse_chat_remote_intent(prompt: &str) -> Result<Option<ChatRemoteComposerInt
     if trimmed.is_empty() {
         return Ok(None);
     }
-    let words = parse_shell_like_words(trimmed)?;
-    let Some(command) = words.first().map(String::as_str) else {
+    let Some(first_word) = trimmed.split_whitespace().next() else {
         return Ok(None);
     };
-    if command != "/remote" {
+    if first_word != "/remote" {
         return Ok(None);
     }
+    let words = parse_shell_like_words(trimmed)?;
     match words.get(1).map(String::as_str) {
         None | Some("status") | Some("show") if words.len() <= 2 => {
             Ok(Some(ChatRemoteComposerIntent::Summary))
@@ -5726,6 +5740,20 @@ pub(super) fn run_chat_toggle_help_hint_action(state: &mut crate::app_state::Ren
     true
 }
 
+pub(super) fn run_chat_toggle_workspace_rail_action(
+    state: &mut crate::app_state::RenderState,
+) -> bool {
+    state.autopilot_chat.workspace_rail_collapsed = !state.autopilot_chat.workspace_rail_collapsed;
+    true
+}
+
+pub(super) fn run_chat_toggle_thread_rail_action(
+    state: &mut crate::app_state::RenderState,
+) -> bool {
+    state.autopilot_chat.thread_rail_collapsed = !state.autopilot_chat.thread_rail_collapsed;
+    true
+}
+
 pub(super) fn run_chat_toggle_thread_tools_action(
     state: &mut crate::app_state::RenderState,
 ) -> bool {
@@ -6087,10 +6115,6 @@ pub(super) fn run_chat_select_thread_action(
             }
 
             let preview_index = index - 1;
-            if preview_index >= CHAT_AUTOPILOT_THREAD_PREVIEW_LIMIT {
-                return false;
-            }
-
             let Some(target) = state.autopilot_chat.select_thread_by_index(preview_index) else {
                 return false;
             };
@@ -14450,8 +14474,8 @@ mod tests {
         parse_chat_request_intent, parse_chat_skills_intent, parse_chat_spacetime_intent,
         parse_chat_terminal_intent, parse_chat_wallet_intent, parse_direct_message_creation_intent,
         parse_direct_message_room_intent, parse_managed_chat_composer_intent,
-        parse_managed_chat_mention_prefix, resolve_apple_fm_workbench_session_id,
-        resolve_wallet_blink_env_from_secure_values,
+        parse_managed_chat_mention_prefix, parse_shell_like_words,
+        resolve_apple_fm_workbench_session_id, resolve_wallet_blink_env_from_secure_values,
         resolve_wallet_settlement_pointer_for_open_network_job,
         stable_sats_period_convert_totals_from_receipts,
         stable_sats_real_round_phase_from_operation_count, taxonomy_failure_detail,
@@ -15529,6 +15553,33 @@ mod tests {
         assert_eq!(
             parse_chat_remote_intent("/remote rotate-token").unwrap(),
             Some(ChatRemoteComposerIntent::RotateToken)
+        );
+    }
+
+    #[test]
+    fn chat_command_parsers_ignore_non_command_quotes() {
+        let prompt = "it's \"working\" now";
+        assert_eq!(parse_chat_git_intent(prompt).unwrap(), None);
+        assert_eq!(parse_chat_skills_intent(prompt).unwrap(), None);
+        assert_eq!(parse_chat_mcp_intent(prompt).unwrap(), None);
+        assert_eq!(parse_chat_apps_intent(prompt).unwrap(), None);
+        assert!(matches!(parse_chat_request_intent(prompt).unwrap(), None));
+        assert_eq!(parse_chat_remote_intent(prompt).unwrap(), None);
+    }
+
+    #[test]
+    fn shell_word_parser_does_not_error_on_unmatched_quotes_or_escape() {
+        assert_eq!(
+            parse_shell_like_words("it's").unwrap(),
+            vec!["its".to_string()]
+        );
+        assert_eq!(
+            parse_shell_like_words("\"unterminated").unwrap(),
+            vec!["unterminated".to_string()]
+        );
+        assert_eq!(
+            parse_shell_like_words("slash\\").unwrap(),
+            vec!["slash\\".to_string()]
         );
     }
 

--- a/apps/autopilot-desktop/src/input/reducers/codex.rs
+++ b/apps/autopilot-desktop/src/input/reducers/codex.rs
@@ -274,6 +274,13 @@ pub(super) fn apply_lane_snapshot(state: &mut RenderState, snapshot: CodexLaneSn
         state.sync_health.last_applied_event_seq.saturating_add(1);
     state.sync_health.cursor_last_advanced_seconds_ago = 0;
     refresh_codex_readiness_summary(state);
+    if state.codex_lane.lifecycle == CodexLaneLifecycle::Ready
+        && state.autopilot_chat.chat_browse_mode() == crate::app_state::ChatBrowseMode::Autopilot
+        && state.autopilot_chat.threads.is_empty()
+        && state.autopilot_chat.active_thread_id.is_none()
+    {
+        queue_thread_history_refresh(state);
+    }
     if previous_lifecycle != CodexLaneLifecycle::Ready
         && state.codex_lane.lifecycle == CodexLaneLifecycle::Ready
     {
@@ -1232,22 +1239,81 @@ pub(super) fn apply_notification(state: &mut RenderState, notification: CodexLan
             }
             CodexLaneNotification::ThreadListLoaded { entries } => {
                 tracing::info!("codex thread/list loaded {} entries", entries.len());
-                state.autopilot_chat.set_thread_entries(
-                    entries
-                        .into_iter()
-                        .map(|entry| crate::app_state::AutopilotThreadListEntry {
-                            thread_id: entry.thread_id,
-                            thread_name: entry.thread_name,
-                            preview: entry.preview,
-                            status: entry.status,
-                            loaded: entry.loaded,
-                            cwd: entry.cwd,
-                            path: entry.path,
-                            created_at: entry.created_at,
-                            updated_at: entry.updated_at,
-                        })
-                        .collect(),
-                );
+                let had_active_thread = state.autopilot_chat.active_thread_id.is_some();
+                let loaded_entries = entries
+                    .into_iter()
+                    .map(|entry| crate::app_state::AutopilotThreadListEntry {
+                        thread_id: entry.thread_id,
+                        thread_name: entry.thread_name,
+                        preview: entry.preview,
+                        status: entry.status,
+                        loaded: entry.loaded,
+                        cwd: entry.cwd,
+                        path: entry.path,
+                        created_at: entry.created_at,
+                        updated_at: entry.updated_at,
+                    })
+                    .collect::<Vec<_>>();
+                state.autopilot_chat.set_thread_entries(loaded_entries);
+                if !had_active_thread {
+                    if let Some(thread_id) = state.autopilot_chat.active_thread_id.clone() {
+                        state
+                            .autopilot_chat
+                            .restore_session_preferences_from_thread(&thread_id);
+                        super::super::actions::restore_chat_composer_draft(state);
+                        let metadata = state
+                            .autopilot_chat
+                            .thread_metadata
+                            .get(&thread_id)
+                            .cloned();
+                        let resume_path = if state.codex_lane_config.experimental_api {
+                            metadata.as_ref().and_then(|value| value.path.clone())
+                        } else {
+                            None
+                        };
+                        if let Err(error) = state.queue_codex_command(
+                            CodexLaneCommand::ThreadResume(codex_client::ThreadResumeParams {
+                                thread_id: thread_id.clone(),
+                                model: state.autopilot_chat.selected_model_override(),
+                                model_provider: None,
+                                service_tier: super::super::actions::chat_session_service_tier(
+                                    state,
+                                ),
+                                cwd: metadata
+                                    .as_ref()
+                                    .and_then(|value| value.cwd.clone())
+                                    .or_else(|| {
+                                        super::super::actions::current_chat_session_cwd(state)
+                                    }),
+                                approval_policy:
+                                    super::super::actions::chat_session_approval_policy(state),
+                                sandbox: super::super::actions::chat_session_thread_sandbox_mode(
+                                    state,
+                                ),
+                                personality: super::super::actions::chat_session_personality(state),
+                                path: resume_path.map(std::path::PathBuf::from),
+                            }),
+                        ) {
+                            state.autopilot_chat.last_error = Some(error);
+                        }
+                        if let Err(error) = state.queue_codex_command(CodexLaneCommand::ThreadRead(
+                            codex_client::ThreadReadParams {
+                                thread_id,
+                                include_turns: true,
+                            },
+                        )) {
+                            state.autopilot_chat.last_error = Some(error);
+                        }
+                    } else if state.autopilot_chat.chat_browse_mode()
+                        == crate::app_state::ChatBrowseMode::Autopilot
+                        && !state.autopilot_chat.startup_new_thread_bootstrap_pending
+                        && !state.autopilot_chat.startup_new_thread_bootstrap_sent
+                        && queue_new_thread(state, "Failed to start default Autopilot Chat thread")
+                    {
+                        state.autopilot_chat.startup_new_thread_bootstrap_pending = true;
+                        state.autopilot_chat.startup_new_thread_bootstrap_sent = true;
+                    }
+                }
             }
             CodexLaneNotification::ThreadLoadedListLoaded { thread_ids } => {
                 state.autopilot_chat.set_thread_loaded_ids(&thread_ids);

--- a/apps/autopilot-desktop/src/pane_registry.rs
+++ b/apps/autopilot-desktop/src/pane_registry.rs
@@ -104,14 +104,14 @@ const PANE_SPECS: [PaneSpec; 63] = [
     },
     PaneSpec {
         kind: PaneKind::AutopilotChat,
-        title: "Autopilot Chat",
-        default_width: 940.0,
+        title: "CHAT",
+        default_width: 760.0,
         default_height: 540.0,
         singleton: true,
-        startup: false,
+        startup: true,
         command: Some(PaneCommandSpec {
             id: "pane.codex",
-            label: "Autopilot Chat",
+            label: "CHAT",
             description: "Open a simple local Autopilot conversation pane",
             keybinding: None,
         }),

--- a/apps/autopilot-desktop/src/pane_system.rs
+++ b/apps/autopilot-desktop/src/pane_system.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use wgpui::components::hud::{PaneFrame, PaneHeaderAction, ResizablePane, ResizeEdge};
 use wgpui::{Bounds, Button, Component, InputEvent, Modifiers, MouseButton, Point, Size, theme};
@@ -49,6 +49,7 @@ const DATA_SELLER_COMPOSER_HEIGHT: f32 = 30.0;
 const DATA_SELLER_SEND_WIDTH: f32 = 72.0;
 const CHAT_HEADER_BUTTON_HEIGHT: f32 = 24.0;
 const CHAT_HEADER_BUTTON_WIDTH: f32 = 104.0;
+const CHAT_HEADER_BUTTON_MIN_WIDTH: f32 = 76.0;
 const CHAT_HEADER_BUTTON_GAP: f32 = 8.0;
 /// Compact + button next to "Threads" to start a new thread
 const CHAT_NEW_THREAD_BUTTON_SIZE: f32 = 26.0;
@@ -110,6 +111,8 @@ const CREDENTIALS_ROW_GAP: f32 = 6.0;
 const CREDENTIALS_MAX_ROWS: usize = 10;
 const CAD_CONTEXT_MENU_ROW_HEIGHT: f32 = 24.0;
 static PANE_Z_SORT_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static CHAT_WORKSPACE_RAIL_COLLAPSED: AtomicBool = AtomicBool::new(false);
+static CHAT_THREAD_RAIL_COLLAPSED: AtomicBool = AtomicBool::new(false);
 const PANE_BUTTON_HORIZONTAL_PADDING: f32 = 14.0;
 const PANE_BUTTON_VERTICAL_PADDING: f32 = 6.0;
 
@@ -119,6 +122,27 @@ use helpers::*;
 pub struct PaneController;
 
 pub struct PaneInput;
+
+pub fn set_chat_shell_layout_state(workspace_collapsed: bool, thread_collapsed: bool) {
+    CHAT_WORKSPACE_RAIL_COLLAPSED.store(workspace_collapsed, Ordering::Relaxed);
+    CHAT_THREAD_RAIL_COLLAPSED.store(thread_collapsed, Ordering::Relaxed);
+}
+
+fn chat_workspace_rail_width() -> f32 {
+    if CHAT_WORKSPACE_RAIL_COLLAPSED.load(Ordering::Relaxed) {
+        40.0
+    } else {
+        CHAT_WORKSPACE_RAIL_WIDTH
+    }
+}
+
+fn chat_thread_rail_width() -> f32 {
+    if CHAT_THREAD_RAIL_COLLAPSED.load(Ordering::Relaxed) {
+        44.0
+    } else {
+        CHAT_THREAD_RAIL_WIDTH
+    }
+}
 
 pub fn sidebar_reserved_width(state: &RenderState) -> f32 {
     if !RIGHT_SIDEBAR_ENABLED {
@@ -176,6 +200,26 @@ fn focus_chat_composer_for_pane_open(state: &mut RenderState) {
     state.credentials_inputs.variable_value.blur();
     state.job_history_inputs.search_job_id.blur();
     state.chat_inputs.composer.focus();
+}
+
+fn queue_chat_thread_history_refresh_for_pane_open(state: &mut RenderState) {
+    if state.codex_lane.lifecycle != crate::codex_lane::CodexLaneLifecycle::Ready {
+        return;
+    }
+    if state.autopilot_chat.chat_browse_mode() != crate::app_state::ChatBrowseMode::Autopilot {
+        return;
+    }
+    let cwd = std::env::current_dir()
+        .ok()
+        .and_then(|value| value.into_os_string().into_string().ok());
+    let params = state.autopilot_chat.build_thread_list_params(cwd);
+    let _ = state.queue_codex_command(crate::codex_lane::CodexLaneCommand::ThreadList(params));
+    let _ = state.queue_codex_command(crate::codex_lane::CodexLaneCommand::ThreadLoadedList(
+        codex_client::ThreadLoadedListParams {
+            cursor: None,
+            limit: Some(200),
+        },
+    ));
 }
 
 fn focus_local_inference_prompt_for_pane_open(state: &mut RenderState) {
@@ -1031,6 +1075,8 @@ pub enum PaneHitAction {
     ChatCycleSandboxMode,
     ChatToggleHeaderControls,
     ChatToggleHelpHint,
+    ChatToggleWorkspaceRail,
+    ChatToggleThreadRail,
     ChatInterruptTurn,
     ChatImplementPlan,
     ChatReviewThread,
@@ -1190,7 +1236,7 @@ fn pane_minimum_size(kind: PaneKind) -> Size {
     };
 
     match kind {
-        PaneKind::AutopilotChat => pane_size_for_content(900.0, 500.0),
+        PaneKind::AutopilotChat => pane_size_for_content(620.0, 500.0),
         PaneKind::CodexAccount
         | PaneKind::CodexModels
         | PaneKind::CodexConfig
@@ -1314,6 +1360,7 @@ impl PaneController {
         let id = Self::create(state, PaneDescriptor::for_kind(kind));
         if kind == PaneKind::AutopilotChat {
             focus_chat_composer_for_pane_open(state);
+            queue_chat_thread_history_refresh_for_pane_open(state);
         } else if kind == PaneKind::LocalInference {
             focus_local_inference_prompt_for_pane_open(state);
         } else if kind == PaneKind::AttnResLab {
@@ -1870,7 +1917,7 @@ pub fn chat_workspace_rail_bounds(content_bounds: Bounds) -> Bounds {
     Bounds::new(
         content_bounds.origin.x + CHAT_PAD,
         content_bounds.origin.y + CHAT_PAD,
-        CHAT_WORKSPACE_RAIL_WIDTH,
+        chat_workspace_rail_width(),
         (content_bounds.size.height - CHAT_PAD * 2.0).max(120.0),
     )
 }
@@ -1906,7 +1953,7 @@ pub fn chat_thread_rail_bounds(content_bounds: Bounds) -> Bounds {
     Bounds::new(
         workspace.max_x() + CHAT_COLUMN_GAP,
         content_bounds.origin.y + CHAT_PAD,
-        CHAT_THREAD_RAIL_WIDTH,
+        chat_thread_rail_width(),
         (content_bounds.size.height - CHAT_PAD * 2.0).max(120.0),
     )
 }
@@ -1953,91 +2000,105 @@ pub fn chat_thread_search_input_bounds(content_bounds: Bounds) -> Bounds {
     )
 }
 
-pub fn chat_cycle_model_button_bounds(content_bounds: Bounds) -> Bounds {
+fn chat_header_button_bounds(
+    content_bounds: Bounds,
+    start_y: f32,
+    index: usize,
+    total: usize,
+) -> Bounds {
     let transcript = chat_transcript_bounds(content_bounds);
-    let controls_top = transcript.origin.y + 66.0;
+    let controls_top = transcript.origin.y + 66.0 + start_y;
+    let available_width = (transcript.size.width - 20.0).max(CHAT_HEADER_BUTTON_MIN_WIDTH);
+    let cols = (((available_width + CHAT_HEADER_BUTTON_GAP)
+        / (CHAT_HEADER_BUTTON_MIN_WIDTH + CHAT_HEADER_BUTTON_GAP))
+        .floor() as usize)
+        .max(1)
+        .min(total.max(1));
+    let width = ((available_width - CHAT_HEADER_BUTTON_GAP * (cols.saturating_sub(1) as f32))
+        / cols as f32)
+        .clamp(CHAT_HEADER_BUTTON_MIN_WIDTH, CHAT_HEADER_BUTTON_WIDTH);
+    let row = index / cols;
+    let col = index % cols;
     Bounds::new(
-        transcript.origin.x + 10.0,
-        controls_top,
-        CHAT_HEADER_BUTTON_WIDTH,
-        CHAT_HEADER_BUTTON_HEIGHT,
-    )
-}
-
-pub fn chat_cycle_reasoning_effort_button_bounds(content_bounds: Bounds) -> Bounds {
-    let model = chat_cycle_model_button_bounds(content_bounds);
-    Bounds::new(
-        model.max_x() + CHAT_HEADER_BUTTON_GAP,
-        model.origin.y,
-        CHAT_HEADER_BUTTON_WIDTH,
-        CHAT_HEADER_BUTTON_HEIGHT,
-    )
-}
-
-pub fn chat_cycle_service_tier_button_bounds(content_bounds: Bounds) -> Bounds {
-    chat_secondary_header_button_bounds(content_bounds, 0)
-}
-
-fn chat_secondary_header_button_bounds(content_bounds: Bounds, index: usize) -> Bounds {
-    let model = chat_cycle_model_button_bounds(content_bounds);
-    let gap = CHAT_HEADER_BUTTON_GAP;
-    let available_width = (chat_transcript_bounds(content_bounds).size.width - 20.0).max(0.0);
-    let width = ((available_width - gap * 5.0) / 6.0).clamp(72.0, CHAT_HEADER_BUTTON_WIDTH);
-    Bounds::new(
-        model.origin.x + index as f32 * (width + gap),
-        model.max_y() + 6.0,
+        transcript.origin.x + 10.0 + col as f32 * (width + CHAT_HEADER_BUTTON_GAP),
+        controls_top + row as f32 * (CHAT_HEADER_BUTTON_HEIGHT + 6.0),
         width,
         CHAT_HEADER_BUTTON_HEIGHT,
     )
 }
 
-pub fn chat_cycle_personality_button_bounds(content_bounds: Bounds) -> Bounds {
+fn chat_primary_header_button_bounds(content_bounds: Bounds, index: usize) -> Bounds {
+    chat_header_button_bounds(content_bounds, 0.0, index, 3)
+}
+
+fn chat_primary_header_row_count(content_bounds: Bounds) -> usize {
+    let transcript = chat_transcript_bounds(content_bounds);
+    let available_width = (transcript.size.width - 20.0).max(CHAT_HEADER_BUTTON_MIN_WIDTH);
+    let cols = (((available_width + CHAT_HEADER_BUTTON_GAP)
+        / (CHAT_HEADER_BUTTON_MIN_WIDTH + CHAT_HEADER_BUTTON_GAP))
+        .floor() as usize)
+        .max(1)
+        .min(3);
+    3_usize.div_ceil(cols)
+}
+
+pub fn chat_cycle_model_button_bounds(content_bounds: Bounds) -> Bounds {
+    chat_primary_header_button_bounds(content_bounds, 0)
+}
+
+pub fn chat_cycle_service_tier_button_bounds(content_bounds: Bounds) -> Bounds {
     chat_secondary_header_button_bounds(content_bounds, 1)
 }
 
-pub fn chat_cycle_collaboration_mode_button_bounds(content_bounds: Bounds) -> Bounds {
+fn chat_secondary_header_button_bounds(content_bounds: Bounds, index: usize) -> Bounds {
+    let primary_rows = chat_primary_header_row_count(content_bounds);
+    let start_y = primary_rows as f32 * (CHAT_HEADER_BUTTON_HEIGHT + 6.0);
+    chat_header_button_bounds(content_bounds, start_y, index, 7)
+}
+
+pub fn chat_cycle_personality_button_bounds(content_bounds: Bounds) -> Bounds {
     chat_secondary_header_button_bounds(content_bounds, 2)
 }
 
-pub fn chat_cycle_approval_mode_button_bounds(content_bounds: Bounds) -> Bounds {
+pub fn chat_cycle_collaboration_mode_button_bounds(content_bounds: Bounds) -> Bounds {
     chat_secondary_header_button_bounds(content_bounds, 3)
 }
 
-pub fn chat_cycle_sandbox_mode_button_bounds(content_bounds: Bounds) -> Bounds {
+pub fn chat_cycle_approval_mode_button_bounds(content_bounds: Bounds) -> Bounds {
     chat_secondary_header_button_bounds(content_bounds, 4)
 }
 
+pub fn chat_cycle_sandbox_mode_button_bounds(content_bounds: Bounds) -> Bounds {
+    chat_secondary_header_button_bounds(content_bounds, 5)
+}
+
 pub fn chat_interrupt_button_bounds(content_bounds: Bounds) -> Bounds {
-    let effort = chat_cycle_reasoning_effort_button_bounds(content_bounds);
-    Bounds::new(
-        effort.max_x() + CHAT_HEADER_BUTTON_GAP,
-        effort.origin.y,
-        CHAT_HEADER_BUTTON_WIDTH,
-        CHAT_HEADER_BUTTON_HEIGHT,
-    )
+    chat_primary_header_button_bounds(content_bounds, 1)
+}
+
+pub fn chat_cycle_reasoning_effort_button_bounds(content_bounds: Bounds) -> Bounds {
+    chat_secondary_header_button_bounds(content_bounds, 0)
 }
 
 pub fn chat_implement_plan_button_bounds(content_bounds: Bounds) -> Bounds {
-    chat_secondary_header_button_bounds(content_bounds, 5)
+    chat_secondary_header_button_bounds(content_bounds, 6)
 }
 
 pub fn chat_review_button_bounds(content_bounds: Bounds) -> Bounds {
-    chat_secondary_header_button_bounds(content_bounds, 5)
+    chat_secondary_header_button_bounds(content_bounds, 6)
 }
 
 pub fn chat_compact_button_bounds(content_bounds: Bounds) -> Bounds {
-    let interrupt = chat_interrupt_button_bounds(content_bounds);
-    Bounds::new(
-        interrupt.max_x() + CHAT_HEADER_BUTTON_GAP,
-        interrupt.origin.y,
-        CHAT_HEADER_BUTTON_WIDTH,
-        CHAT_HEADER_BUTTON_HEIGHT,
-    )
+    chat_primary_header_button_bounds(content_bounds, 2)
 }
 
-pub fn chat_thread_row_bounds(content_bounds: Bounds, index: usize) -> Bounds {
+pub fn chat_thread_row_bounds(
+    content_bounds: Bounds,
+    index: usize,
+    thread_tools_expanded: bool,
+) -> Bounds {
     let rail = chat_thread_rail_bounds(content_bounds);
-    let y = chat_thread_rail_controls_bottom(content_bounds)
+    let y = chat_thread_rail_controls_bottom(content_bounds, thread_tools_expanded)
         + index as f32 * (CHAT_SHELL_ROW_HEIGHT + CHAT_SHELL_ROW_GAP);
     Bounds::new(
         rail.origin.x + 8.0,
@@ -2047,12 +2108,16 @@ pub fn chat_thread_row_bounds(content_bounds: Bounds, index: usize) -> Bounds {
     )
 }
 
-pub fn chat_visible_thread_row_count(content_bounds: Bounds, total_threads: usize) -> usize {
+pub fn chat_visible_thread_row_count(
+    content_bounds: Bounds,
+    total_threads: usize,
+    thread_tools_expanded: bool,
+) -> usize {
     if total_threads == 0 {
         return 0;
     }
 
-    let first_row = chat_thread_row_bounds(content_bounds, 0);
+    let first_row = chat_thread_row_bounds(content_bounds, 0, thread_tools_expanded);
     let rail = chat_thread_rail_bounds(content_bounds);
     let available_height = (rail.max_y() - first_row.origin.y).max(0.0);
     if available_height < CHAT_SHELL_ROW_HEIGHT {
@@ -2158,6 +2223,16 @@ pub fn chat_help_toggle_button_bounds(content_bounds: Bounds) -> Bounds {
         16.0,
         16.0,
     )
+}
+
+pub fn chat_workspace_rail_toggle_button_bounds(content_bounds: Bounds) -> Bounds {
+    let rail = chat_workspace_rail_bounds(content_bounds);
+    Bounds::new(rail.max_x() - 16.0, rail.max_y() - 16.0, 12.0, 12.0)
+}
+
+pub fn chat_thread_rail_toggle_button_bounds(content_bounds: Bounds) -> Bounds {
+    let rail = chat_thread_rail_bounds(content_bounds);
+    Bounds::new(rail.max_x() - 16.0, rail.max_y() - 16.0, 12.0, 12.0)
 }
 
 pub fn chat_server_request_accept_button_bounds(content_bounds: Bounds) -> Bounds {
@@ -6351,19 +6426,28 @@ fn pane_hit_action_for_pane(
         }
         PaneKind::ProjectOps => None,
         PaneKind::AutopilotChat => {
+            set_chat_shell_layout_state(
+                state.autopilot_chat.workspace_rail_collapsed,
+                state.autopilot_chat.thread_rail_collapsed,
+            );
             let browse_mode = state.autopilot_chat.chat_browse_mode();
+            if chat_workspace_rail_toggle_button_bounds(content_bounds).contains(point) {
+                return Some(PaneHitAction::ChatToggleWorkspaceRail);
+            }
+            if chat_thread_rail_toggle_button_bounds(content_bounds).contains(point) {
+                return Some(PaneHitAction::ChatToggleThreadRail);
+            }
             if browse_mode == crate::app_state::ChatBrowseMode::Autopilot {
-                if chat_new_thread_button_bounds(content_bounds).contains(point) {
-                    return Some(PaneHitAction::ChatNewThread);
-                }
-                if chat_refresh_threads_button_bounds(content_bounds).contains(point) {
-                    return Some(PaneHitAction::ChatRefreshThreads);
+                if !state.autopilot_chat.thread_rail_collapsed {
+                    if chat_new_thread_button_bounds(content_bounds).contains(point) {
+                        return Some(PaneHitAction::ChatNewThread);
+                    }
+                    if chat_refresh_threads_button_bounds(content_bounds).contains(point) {
+                        return Some(PaneHitAction::ChatRefreshThreads);
+                    }
                 }
                 if chat_cycle_model_button_bounds(content_bounds).contains(point) {
                     return Some(PaneHitAction::ChatCycleModel);
-                }
-                if chat_cycle_reasoning_effort_button_bounds(content_bounds).contains(point) {
-                    return Some(PaneHitAction::ChatCycleReasoningEffort);
                 }
                 if chat_help_toggle_button_bounds(content_bounds).contains(point) {
                     return Some(PaneHitAction::ChatToggleHelpHint);
@@ -6375,6 +6459,9 @@ fn pane_hit_action_for_pane(
                     return Some(PaneHitAction::ChatInterruptTurn);
                 }
                 if state.autopilot_chat.header_controls_expanded {
+                    if chat_cycle_reasoning_effort_button_bounds(content_bounds).contains(point) {
+                        return Some(PaneHitAction::ChatCycleReasoningEffort);
+                    }
                     if chat_cycle_service_tier_button_bounds(content_bounds).contains(point) {
                         return Some(PaneHitAction::ChatCycleServiceTier);
                     }
@@ -6397,13 +6484,19 @@ fn pane_hit_action_for_pane(
                         return Some(PaneHitAction::ChatReviewThread);
                     }
                 }
-                if chat_thread_filter_archived_button_bounds(content_bounds).contains(point) {
+                if !state.autopilot_chat.thread_rail_collapsed
+                    && chat_thread_filter_archived_button_bounds(content_bounds).contains(point)
+                {
                     return Some(PaneHitAction::ChatToggleArchivedFilter);
                 }
-                if chat_thread_filter_provider_button_bounds(content_bounds).contains(point) {
+                if !state.autopilot_chat.thread_rail_collapsed
+                    && chat_thread_filter_provider_button_bounds(content_bounds).contains(point)
+                {
                     return Some(PaneHitAction::ChatToggleThreadTools);
                 }
-                if state.autopilot_chat.thread_tools_expanded {
+                if !state.autopilot_chat.thread_rail_collapsed
+                    && state.autopilot_chat.thread_tools_expanded
+                {
                     if chat_thread_filter_source_button_bounds(content_bounds).contains(point) {
                         return Some(PaneHitAction::ChatCycleSortFilter);
                     }
@@ -6438,7 +6531,9 @@ fn pane_hit_action_for_pane(
                     }
                 }
             }
-            if state.autopilot_chat.chat_has_browseable_content() {
+            if state.autopilot_chat.chat_has_browseable_content()
+                && !state.autopilot_chat.workspace_rail_collapsed
+            {
                 let workspace_count = chat_visible_workspace_row_count(
                     content_bounds,
                     state.autopilot_chat.chat_workspace_entries().len(),
@@ -6449,40 +6544,54 @@ fn pane_hit_action_for_pane(
                     }
                 }
             }
-            let managed_channel_rows = (browse_mode == crate::app_state::ChatBrowseMode::Managed)
+            let managed_channel_rows = (!state.autopilot_chat.thread_rail_collapsed
+                && browse_mode == crate::app_state::ChatBrowseMode::Managed)
                 .then(|| state.autopilot_chat.active_managed_chat_channel_rail_rows());
-            let direct_room_count =
-                if browse_mode == crate::app_state::ChatBrowseMode::DirectMessages {
-                    state.autopilot_chat.active_direct_message_rooms().len()
-                } else {
-                    0
-                };
+            let direct_room_count = if !state.autopilot_chat.thread_rail_collapsed
+                && browse_mode == crate::app_state::ChatBrowseMode::DirectMessages
+            {
+                state.autopilot_chat.active_direct_message_rooms().len()
+            } else {
+                0
+            };
             let channel_count = if let Some(rows) = managed_channel_rows.as_ref() {
                 rows.len()
             } else if browse_mode == crate::app_state::ChatBrowseMode::DirectMessages {
                 direct_room_count
+            } else if state.autopilot_chat.thread_rail_collapsed {
+                0
             } else {
-                1 + state
-                    .autopilot_chat
-                    .threads
-                    .len()
-                    .min(CHAT_AUTOPILOT_THREAD_PREVIEW_LIMIT)
+                2 + state.autopilot_chat.threads.len()
             };
-            let visible_rows = chat_visible_thread_row_count(content_bounds, channel_count);
+            let visible_rows = chat_visible_thread_row_count(
+                content_bounds,
+                channel_count,
+                state.autopilot_chat.thread_tools_expanded,
+            );
+            let start_index = state
+                .autopilot_chat
+                .thread_rail_scroll_start_index(channel_count, visible_rows);
             for index in 0..visible_rows {
-                if chat_thread_row_bounds(content_bounds, index).contains(point) {
+                if chat_thread_row_bounds(
+                    content_bounds,
+                    index,
+                    state.autopilot_chat.thread_tools_expanded,
+                )
+                .contains(point)
+                {
+                    let absolute_index = start_index + index;
                     if let Some(rows) = managed_channel_rows.as_ref() {
-                        return match rows.get(index) {
+                        return match rows.get(absolute_index) {
                             Some(crate::app_state::ManagedChatChannelRailRow::Category {
                                 ..
-                            }) => Some(PaneHitAction::ChatToggleCategory(index)),
+                            }) => Some(PaneHitAction::ChatToggleCategory(absolute_index)),
                             Some(crate::app_state::ManagedChatChannelRailRow::Channel {
                                 ..
-                            }) => Some(PaneHitAction::ChatSelectThread(index)),
+                            }) => Some(PaneHitAction::ChatSelectThread(absolute_index)),
                             None => None,
                         };
                     }
-                    return Some(PaneHitAction::ChatSelectThread(index));
+                    return Some(PaneHitAction::ChatSelectThread(absolute_index));
                 }
             }
             let can_send = match browse_mode {

--- a/apps/autopilot-desktop/src/panes/chat.rs
+++ b/apps/autopilot-desktop/src/panes/chat.rs
@@ -13,13 +13,12 @@ use crate::app_state::{
 use crate::labor_orchestrator::CodexLaborBinding;
 use crate::pane_renderer::split_text_for_display;
 use crate::pane_system::{
-    CHAT_AUTOPILOT_THREAD_PREVIEW_LIMIT, chat_compact_button_bounds,
-    chat_composer_height_for_value, chat_composer_input_bounds_with_height,
-    chat_cycle_approval_mode_button_bounds, chat_cycle_collaboration_mode_button_bounds,
-    chat_cycle_model_button_bounds, chat_cycle_personality_button_bounds,
-    chat_cycle_reasoning_effort_button_bounds, chat_cycle_sandbox_mode_button_bounds,
-    chat_cycle_service_tier_button_bounds, chat_help_toggle_button_bounds,
-    chat_interrupt_button_bounds, chat_new_thread_button_bounds,
+    chat_compact_button_bounds, chat_composer_height_for_value,
+    chat_composer_input_bounds_with_height, chat_cycle_approval_mode_button_bounds,
+    chat_cycle_collaboration_mode_button_bounds, chat_cycle_model_button_bounds,
+    chat_cycle_personality_button_bounds, chat_cycle_reasoning_effort_button_bounds,
+    chat_cycle_sandbox_mode_button_bounds, chat_cycle_service_tier_button_bounds,
+    chat_help_toggle_button_bounds, chat_interrupt_button_bounds, chat_new_thread_button_bounds,
     chat_refresh_threads_button_bounds, chat_review_button_bounds, chat_send_button_bounds,
     chat_thread_action_archive_button_bounds, chat_thread_action_copy_button_bounds,
     chat_thread_action_fork_button_bounds, chat_thread_action_open_editor_button_bounds,
@@ -27,9 +26,10 @@ use crate::pane_system::{
     chat_thread_action_rollback_button_bounds, chat_thread_action_unarchive_button_bounds,
     chat_thread_action_unsubscribe_button_bounds, chat_thread_filter_archived_button_bounds,
     chat_thread_filter_provider_button_bounds, chat_thread_filter_source_button_bounds,
-    chat_thread_rail_bounds, chat_thread_row_bounds, chat_thread_search_input_bounds,
-    chat_transcript_body_bounds_with_height, chat_transcript_bounds, chat_visible_thread_row_count,
-    chat_workspace_rail_bounds, pane_content_bounds,
+    chat_thread_rail_bounds, chat_thread_rail_toggle_button_bounds, chat_thread_row_bounds,
+    chat_thread_search_input_bounds, chat_transcript_body_bounds_with_height,
+    chat_transcript_bounds, chat_visible_thread_row_count, chat_workspace_rail_bounds,
+    chat_workspace_rail_toggle_button_bounds, pane_content_bounds, set_chat_shell_layout_state,
 };
 use wgpui::components::sections::TerminalStream;
 
@@ -2353,6 +2353,22 @@ fn thread_filter_sort_label(autopilot_chat: &AutopilotChatState) -> &'static str
     }
 }
 
+fn thread_rows_clip_bounds(
+    content_bounds: Bounds,
+    thread_tools_expanded: bool,
+    channel_bounds: Bounds,
+) -> Bounds {
+    let first_row_y = chat_thread_row_bounds(content_bounds, 0, thread_tools_expanded)
+        .origin
+        .y;
+    Bounds::new(
+        channel_bounds.origin.x + 6.0,
+        first_row_y,
+        (channel_bounds.size.width - 12.0).max(0.0),
+        (channel_bounds.max_y() - first_row_y - 6.0).max(0.0),
+    )
+}
+
 fn autopilot_has_copyable_output(autopilot_chat: &AutopilotChatState) -> bool {
     autopilot_chat
         .messages
@@ -2426,99 +2442,15 @@ fn paint_header_chip(bounds: Bounds, label: &str, accent: wgpui::Hsla, paint: &m
     ));
 }
 
-fn shell_workspaces(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellWorkspace> {
-    if autopilot_chat.chat_has_browseable_content() {
-        let accents = [
-            theme::accent::PRIMARY,
-            theme::status::SUCCESS,
-            theme::status::WARNING,
-            theme::status::INFO,
-        ];
-        return autopilot_chat
-            .chat_workspace_entries()
-            .into_iter()
-            .enumerate()
-            .filter_map(|(index, workspace)| match workspace {
-                crate::app_state::ChatWorkspaceSelection::ManagedGroup(group_id) => {
-                    let group = autopilot_chat
-                        .managed_chat_projection
-                        .snapshot
-                        .groups
-                        .iter()
-                        .find(|group| group.group_id == group_id)?;
-                    let label = managed_group_label(group);
-                    let (badge_count, badge_urgent) =
-                        notification_badge(group.unread_count, group.mention_count)
-                            .unwrap_or((0, false));
-                    Some(ChatShellWorkspace {
-                        initials: shell_initials(&label),
-                        label,
-                        accent: accents[index % accents.len()],
-                        active: autopilot_chat.chat_browse_mode() == ChatBrowseMode::Managed
-                            && autopilot_chat
-                                .active_managed_chat_group()
-                                .is_some_and(|active| active.group_id == group.group_id),
-                        badge_count,
-                        badge_urgent,
-                    })
-                }
-                crate::app_state::ChatWorkspaceSelection::DirectMessages => {
-                    let direct_unread = autopilot_chat
-                        .direct_message_projection
-                        .snapshot
-                        .rooms
-                        .iter()
-                        .map(|room| room.unread_count)
-                        .sum();
-                    let direct_mentions = autopilot_chat
-                        .direct_message_projection
-                        .snapshot
-                        .rooms
-                        .iter()
-                        .map(|room| room.mention_count)
-                        .sum();
-                    let (badge_count, badge_urgent) =
-                        notification_badge(direct_unread, direct_mentions).unwrap_or((0, false));
-                    Some(ChatShellWorkspace {
-                        label: "Direct".to_string(),
-                        initials: "DM".to_string(),
-                        accent: theme::status::SUCCESS,
-                        active: autopilot_chat.chat_browse_mode() == ChatBrowseMode::DirectMessages,
-                        badge_count,
-                        badge_urgent,
-                    })
-                }
-                crate::app_state::ChatWorkspaceSelection::Autopilot => None,
-            })
-            .collect();
-    }
-
-    vec![
-        ChatShellWorkspace {
-            label: "OpenAgents".to_string(),
-            initials: "OA".to_string(),
-            accent: theme::accent::PRIMARY,
-            active: true,
-            badge_count: 0,
-            badge_urgent: false,
-        },
-        ChatShellWorkspace {
-            label: "Direct".to_string(),
-            initials: "DM".to_string(),
-            accent: theme::status::SUCCESS,
-            active: false,
-            badge_count: 0,
-            badge_urgent: false,
-        },
-        ChatShellWorkspace {
-            label: "Ops".to_string(),
-            initials: "OP".to_string(),
-            accent: theme::status::WARNING,
-            active: false,
-            badge_count: 0,
-            badge_urgent: false,
-        },
-    ]
+fn shell_workspaces(_autopilot_chat: &AutopilotChatState) -> Vec<ChatShellWorkspace> {
+    vec![ChatShellWorkspace {
+        label: "Private".to_string(),
+        initials: "AG".to_string(),
+        accent: theme::accent::PRIMARY,
+        active: true,
+        badge_count: 0,
+        badge_urgent: false,
+    }]
 }
 
 fn shell_channel_entries(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellChannelEntry> {
@@ -2617,46 +2549,38 @@ fn shell_channel_entries(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellCh
         badge_urgent: false,
     }];
 
-    entries.extend(
-        autopilot_chat
-            .threads
-            .iter()
-            .take(CHAT_AUTOPILOT_THREAD_PREVIEW_LIMIT)
-            .map(|thread_id| {
-                let metadata = autopilot_chat.thread_metadata.get(thread_id);
-                let title = metadata
-                    .and_then(|value| value.thread_name.as_ref())
-                    .map(|name| compact_shell_label(name))
-                    .unwrap_or_else(|| compact_shell_label(thread_id));
-                let summary = metadata
-                    .and_then(|value| value.preview.as_deref())
-                    .map(str::trim)
-                    .filter(|preview| !preview.is_empty())
-                    .map(|preview| compact_display_token(preview, 28))
-                    .or_else(|| {
-                        metadata
-                            .and_then(|value| value.status.as_ref())
-                            .map(|status| status.trim().to_ascii_lowercase())
-                            .filter(|status| !status.is_empty())
-                    })
-                    .unwrap_or_else(|| "thread".to_string());
-                let subtitle = metadata
-                    .and_then(|value| value.project_name.as_deref())
-                    .map(|project| {
-                        format!("{}  •  {}", compact_display_token(project, 12), summary)
-                    })
-                    .unwrap_or(summary);
-                ChatShellChannelEntry {
-                    title: format!("# {title}"),
-                    subtitle,
-                    active: autopilot_chat.active_thread_id.as_deref() == Some(thread_id.as_str()),
-                    is_category: false,
-                    collapsed: false,
-                    badge_count: 0,
-                    badge_urgent: false,
-                }
-            }),
-    );
+    entries.extend(autopilot_chat.threads.iter().map(|thread_id| {
+        let metadata = autopilot_chat.thread_metadata.get(thread_id);
+        let title = metadata
+            .and_then(|value| value.thread_name.as_ref())
+            .map(|name| compact_shell_label(name))
+            .unwrap_or_else(|| compact_shell_label(thread_id));
+        let summary = metadata
+            .and_then(|value| value.preview.as_deref())
+            .map(str::trim)
+            .filter(|preview| !preview.is_empty())
+            .map(|preview| compact_display_token(preview, 28))
+            .or_else(|| {
+                metadata
+                    .and_then(|value| value.status.as_ref())
+                    .map(|status| status.trim().to_ascii_lowercase())
+                    .filter(|status| !status.is_empty())
+            })
+            .unwrap_or_else(|| "thread".to_string());
+        let subtitle = metadata
+            .and_then(|value| value.project_name.as_deref())
+            .map(|project| format!("{}  •  {}", compact_display_token(project, 12), summary))
+            .unwrap_or(summary);
+        ChatShellChannelEntry {
+            title: format!("# {title}"),
+            subtitle,
+            active: autopilot_chat.active_thread_id.as_deref() == Some(thread_id.as_str()),
+            is_category: false,
+            collapsed: false,
+            badge_count: 0,
+            badge_urgent: false,
+        }
+    }));
 
     entries.push(ChatShellChannelEntry {
         title: "@ approvals".to_string(),
@@ -2684,6 +2608,10 @@ fn paint_chat_shell(
     spacetime_presence: &crate::spacetime_presence::SpacetimePresenceSnapshot,
     paint: &mut PaintContext,
 ) {
+    set_chat_shell_layout_state(
+        autopilot_chat.workspace_rail_collapsed,
+        autopilot_chat.thread_rail_collapsed,
+    );
     let workspace_bounds = chat_workspace_rail_bounds(content_bounds);
     let channel_bounds = chat_thread_rail_bounds(content_bounds);
     let transcript_bounds = chat_transcript_bounds(content_bounds);
@@ -2697,102 +2625,141 @@ fn paint_chat_shell(
     paint
         .scene
         .draw_quad(Quad::new(content_bounds).with_background(chat_mission_background_color()));
-    paint_chat_mission_panel(workspace_bounds, "SPACES", chat_mission_cyan_color(), paint);
-    paint.scene.draw_text(paint.text.layout_mono(
-        "SELECT LANE",
-        Point::new(
-            workspace_bounds.origin.x + 12.0,
-            workspace_bounds.origin.y + 46.0,
-        ),
-        9.0,
-        chat_mission_muted_color(),
-    ));
-    for (index, workspace) in shell_workspaces(autopilot_chat).iter().enumerate() {
-        let avatar_bounds = Bounds::new(
-            workspace_bounds.origin.x
-                + (workspace_bounds.size.width - CHAT_WORKSPACE_AVATAR_SIZE) * 0.5,
-            workspace_bounds.origin.y + 64.0 + index as f32 * 52.0,
-            CHAT_WORKSPACE_AVATAR_SIZE,
-            CHAT_WORKSPACE_AVATAR_SIZE,
-        );
-        let background = if workspace.active {
-            workspace.accent
+    paint_chat_mission_panel(
+        workspace_bounds,
+        if autopilot_chat.workspace_rail_collapsed {
+            ""
         } else {
-            chat_mission_panel_header_color().with_alpha(0.75)
-        };
-        let text_color = if workspace.active {
-            chat_mission_background_color()
-        } else {
-            chat_mission_text_color()
-        };
-        paint.scene.draw_quad(
-            Quad::new(avatar_bounds)
-                .with_background(background)
-                .with_border(
-                    if workspace.active {
-                        workspace.accent
-                    } else {
-                        chat_mission_panel_border_color()
-                    },
-                    1.0,
-                )
-                .with_corner_radius(CHAT_WORKSPACE_AVATAR_SIZE * 0.5),
-        );
+            "SPACES"
+        },
+        chat_mission_cyan_color(),
+        paint,
+    );
+    if !autopilot_chat.workspace_rail_collapsed {
         paint.scene.draw_text(paint.text.layout_mono(
-            &workspace.initials,
-            Point::new(avatar_bounds.origin.x + 8.0, avatar_bounds.origin.y + 11.0),
-            11.0,
-            text_color,
-        ));
-        if workspace.badge_count > 0 {
-            paint_notification_badge(
-                Bounds::new(
-                    avatar_bounds.max_x() - 10.0,
-                    avatar_bounds.origin.y - 4.0,
-                    26.0,
-                    16.0,
-                ),
-                workspace.badge_count,
-                workspace.badge_urgent,
-                paint,
-            );
-        }
-        paint.scene.draw_text(paint.text.layout(
-            &workspace.label,
+            "SELECT LANE",
             Point::new(
                 workspace_bounds.origin.x + 12.0,
-                avatar_bounds.max_y() + 4.0,
+                workspace_bounds.origin.y + 46.0,
             ),
             9.0,
-            if workspace.active {
-                chat_mission_text_color()
-            } else {
-                chat_mission_muted_color()
-            },
+            chat_mission_muted_color(),
         ));
+        for (index, workspace) in shell_workspaces(autopilot_chat).iter().enumerate() {
+            let avatar_bounds = Bounds::new(
+                workspace_bounds.origin.x
+                    + (workspace_bounds.size.width - CHAT_WORKSPACE_AVATAR_SIZE) * 0.5,
+                workspace_bounds.origin.y + 64.0 + index as f32 * 52.0,
+                CHAT_WORKSPACE_AVATAR_SIZE,
+                CHAT_WORKSPACE_AVATAR_SIZE,
+            );
+            let background = if workspace.active {
+                workspace.accent
+            } else {
+                chat_mission_panel_header_color().with_alpha(0.75)
+            };
+            let text_color = if workspace.active {
+                chat_mission_background_color()
+            } else {
+                chat_mission_text_color()
+            };
+            paint.scene.draw_quad(
+                Quad::new(avatar_bounds)
+                    .with_background(background)
+                    .with_border(
+                        if workspace.active {
+                            workspace.accent
+                        } else {
+                            chat_mission_panel_border_color()
+                        },
+                        1.0,
+                    )
+                    .with_corner_radius(CHAT_WORKSPACE_AVATAR_SIZE * 0.5),
+            );
+            paint.scene.draw_text(paint.text.layout_mono(
+                &workspace.initials,
+                Point::new(avatar_bounds.origin.x + 8.0, avatar_bounds.origin.y + 11.0),
+                11.0,
+                text_color,
+            ));
+            if workspace.badge_count > 0 {
+                paint_notification_badge(
+                    Bounds::new(
+                        avatar_bounds.max_x() - 10.0,
+                        avatar_bounds.origin.y - 4.0,
+                        26.0,
+                        16.0,
+                    ),
+                    workspace.badge_count,
+                    workspace.badge_urgent,
+                    paint,
+                );
+            }
+            paint.scene.draw_text(paint.text.layout(
+                &workspace.label,
+                Point::new(
+                    workspace_bounds.origin.x + 12.0,
+                    avatar_bounds.max_y() + 4.0,
+                ),
+                9.0,
+                if workspace.active {
+                    chat_mission_text_color()
+                } else {
+                    chat_mission_muted_color()
+                },
+            ));
+        }
     }
+    let workspace_toggle = chat_workspace_rail_toggle_button_bounds(content_bounds);
+    paint.scene.draw_quad(
+        Quad::new(workspace_toggle)
+            .with_background(chat_mission_panel_header_color().with_alpha(0.75))
+            .with_border(chat_mission_panel_border_color().with_alpha(0.8), 1.0)
+            .with_corner_radius(2.0),
+    );
+    paint.scene.draw_text(paint.text.layout_mono(
+        if autopilot_chat.workspace_rail_collapsed {
+            ">"
+        } else {
+            "<"
+        },
+        Point::new(
+            workspace_toggle.origin.x + 3.0,
+            workspace_toggle.origin.y + 2.0,
+        ),
+        9.0,
+        chat_mission_cyan_color(),
+    ));
 
     let (shell_mode_label, rail_title) = match autopilot_chat.chat_browse_mode() {
         ChatBrowseMode::Managed => ("OPENAGENTS / GROUP CHAT", "Channels"),
         ChatBrowseMode::DirectMessages => ("OPENAGENTS / DIRECT MESSAGES", "Rooms"),
-        ChatBrowseMode::Autopilot => ("OPENAGENTS / AUTOPILOT", "Threads"),
+        ChatBrowseMode::Autopilot => ("OPENAGENTS / AUTOPILOT", "THREADS"),
     };
     paint_chat_mission_panel(
         channel_bounds,
-        rail_title,
+        if autopilot_chat.thread_rail_collapsed {
+            ""
+        } else {
+            rail_title
+        },
         chat_mission_green_color(),
         paint,
     );
-    paint.scene.draw_text(paint.text.layout_mono(
-        shell_mode_label,
-        Point::new(
-            channel_bounds.origin.x + 16.0,
-            channel_bounds.origin.y + 34.0,
-        ),
-        9.0,
-        chat_mission_muted_color(),
-    ));
-    if matches!(autopilot_chat.chat_browse_mode(), ChatBrowseMode::Autopilot) {
+    if !autopilot_chat.thread_rail_collapsed {
+        paint.scene.draw_text(paint.text.layout_mono(
+            shell_mode_label,
+            Point::new(
+                channel_bounds.origin.x + 16.0,
+                channel_bounds.origin.y + 34.0,
+            ),
+            9.0,
+            chat_mission_muted_color(),
+        ));
+    }
+    if matches!(autopilot_chat.chat_browse_mode(), ChatBrowseMode::Autopilot)
+        && !autopilot_chat.thread_rail_collapsed
+    {
         let refresh_bounds = chat_refresh_threads_button_bounds(content_bounds);
         paint.scene.draw_quad(
             Quad::new(refresh_bounds)
@@ -2939,76 +2906,133 @@ fn paint_chat_shell(
             );
         }
     }
-    let channel_entries = shell_channel_entries(autopilot_chat);
-    let visible_rows = chat_visible_thread_row_count(content_bounds, channel_entries.len());
-    let first_row_y = chat_thread_row_bounds(content_bounds, 0).origin.y;
-    let rows_clip = Bounds::new(
-        channel_bounds.origin.x + 6.0,
-        first_row_y,
-        (channel_bounds.size.width - 12.0).max(0.0),
-        (channel_bounds.max_y() - first_row_y - 6.0).max(0.0),
-    );
-    paint.scene.push_clip(rows_clip);
-    for (index, entry) in channel_entries.into_iter().take(visible_rows).enumerate() {
-        let row_bounds = chat_thread_row_bounds(content_bounds, index);
-        let background = if entry.is_category {
-            chat_mission_panel_header_color().with_alpha(0.5)
-        } else if entry.active {
-            chat_mission_green_color().with_alpha(0.18)
-        } else {
-            chat_mission_panel_color().with_alpha(0.9)
-        };
-        let border = if entry.is_category {
-            chat_mission_panel_border_color().with_alpha(0.45)
-        } else if entry.active {
-            chat_mission_green_color().with_alpha(0.6)
-        } else {
-            chat_mission_panel_border_color().with_alpha(0.6)
-        };
-        paint.scene.draw_quad(
-            Quad::new(row_bounds)
-                .with_background(background)
-                .with_border(border, 1.0)
-                .with_corner_radius(3.0),
+    if !autopilot_chat.thread_rail_collapsed {
+        let channel_entries = shell_channel_entries(autopilot_chat);
+        let total_rows = channel_entries.len();
+        let visible_rows = chat_visible_thread_row_count(
+            content_bounds,
+            total_rows,
+            autopilot_chat.thread_tools_expanded,
         );
-        let title_color = if entry.is_category {
-            chat_mission_muted_color()
-        } else if entry.active {
-            chat_mission_text_color()
-        } else {
-            chat_mission_muted_color()
-        };
-        paint.scene.draw_text(paint.text.layout(
-            &entry.title,
-            Point::new(row_bounds.origin.x + 12.0, row_bounds.origin.y + 6.0),
-            11.0,
-            title_color,
-        ));
-        paint.scene.draw_text(paint.text.layout_mono(
-            &truncate_for_width(&entry.subtitle, row_bounds.size.width - 16.0),
-            Point::new(row_bounds.origin.x + 12.0, row_bounds.origin.y + 18.0),
-            9.0,
-            if entry.is_category {
-                chat_mission_muted_color().with_alpha(0.85)
+        let start_index = autopilot_chat.thread_rail_scroll_start_index(total_rows, visible_rows);
+        let max_start = total_rows.saturating_sub(visible_rows);
+        let rows_clip = thread_rows_clip_bounds(
+            content_bounds,
+            autopilot_chat.thread_tools_expanded,
+            channel_bounds,
+        );
+        paint.scene.push_clip(rows_clip);
+        for (index, entry) in channel_entries
+            .into_iter()
+            .skip(start_index)
+            .take(visible_rows)
+            .enumerate()
+        {
+            let row_bounds =
+                chat_thread_row_bounds(content_bounds, index, autopilot_chat.thread_tools_expanded);
+            let background = if entry.is_category {
+                chat_mission_panel_header_color().with_alpha(0.5)
+            } else if entry.active {
+                chat_mission_green_color().with_alpha(0.18)
+            } else {
+                chat_mission_panel_color().with_alpha(0.9)
+            };
+            let border = if entry.is_category {
+                chat_mission_panel_border_color().with_alpha(0.45)
+            } else if entry.active {
+                chat_mission_green_color().with_alpha(0.6)
+            } else {
+                chat_mission_panel_border_color().with_alpha(0.6)
+            };
+            paint.scene.draw_quad(
+                Quad::new(row_bounds)
+                    .with_background(background)
+                    .with_border(border, 1.0)
+                    .with_corner_radius(3.0),
+            );
+            let title_color = if entry.is_category {
+                chat_mission_muted_color()
+            } else if entry.active {
+                chat_mission_text_color()
             } else {
                 chat_mission_muted_color()
-            },
-        ));
-        if entry.badge_count > 0 {
-            paint_notification_badge(
-                Bounds::new(
-                    row_bounds.max_x() - 30.0,
-                    row_bounds.origin.y + 7.0,
-                    26.0,
-                    16.0,
-                ),
-                entry.badge_count,
-                entry.badge_urgent,
-                paint,
+            };
+            paint.scene.draw_text(paint.text.layout(
+                &entry.title,
+                Point::new(row_bounds.origin.x + 12.0, row_bounds.origin.y + 6.0),
+                11.0,
+                title_color,
+            ));
+            paint.scene.draw_text(paint.text.layout_mono(
+                &truncate_for_width(&entry.subtitle, row_bounds.size.width - 16.0),
+                Point::new(row_bounds.origin.x + 12.0, row_bounds.origin.y + 18.0),
+                9.0,
+                if entry.is_category {
+                    chat_mission_muted_color().with_alpha(0.85)
+                } else {
+                    chat_mission_muted_color()
+                },
+            ));
+            if entry.badge_count > 0 {
+                paint_notification_badge(
+                    Bounds::new(
+                        row_bounds.max_x() - 30.0,
+                        row_bounds.origin.y + 7.0,
+                        26.0,
+                        16.0,
+                    ),
+                    entry.badge_count,
+                    entry.badge_urgent,
+                    paint,
+                );
+            }
+        }
+        paint.scene.pop_clip();
+        if max_start > 0 && rows_clip.size.height > 0.0 {
+            let track_bounds = Bounds::new(
+                rows_clip.max_x() - 4.0,
+                rows_clip.origin.y,
+                3.0,
+                rows_clip.size.height,
+            );
+            paint.scene.draw_quad(
+                Quad::new(track_bounds)
+                    .with_background(chat_mission_panel_border_color().with_alpha(0.35)),
+            );
+            let thumb_height = (rows_clip.size.height
+                * (visible_rows as f32 / total_rows.max(1) as f32))
+                .clamp(18.0, rows_clip.size.height);
+            let progress = start_index as f32 / max_start.max(1) as f32;
+            let thumb_y =
+                rows_clip.origin.y + progress * (rows_clip.size.height - thumb_height).max(0.0);
+            paint.scene.draw_quad(
+                Quad::new(Bounds::new(
+                    track_bounds.origin.x,
+                    thumb_y,
+                    track_bounds.size.width,
+                    thumb_height,
+                ))
+                .with_background(chat_mission_panel_border_color().with_alpha(0.8)),
             );
         }
     }
-    paint.scene.pop_clip();
+    let thread_toggle = chat_thread_rail_toggle_button_bounds(content_bounds);
+    paint.scene.draw_quad(
+        Quad::new(thread_toggle)
+            .with_background(chat_mission_panel_header_color().with_alpha(0.75))
+            .with_border(chat_mission_panel_border_color().with_alpha(0.8), 1.0)
+            .with_corner_radius(2.0),
+    );
+    paint.scene.draw_text(paint.text.layout_mono(
+        if autopilot_chat.thread_rail_collapsed {
+            ">"
+        } else {
+            "<"
+        },
+        Point::new(thread_toggle.origin.x + 3.0, thread_toggle.origin.y + 2.0),
+        9.0,
+        chat_mission_green_color(),
+    ));
 
     paint_chat_mission_panel(
         transcript_bounds,
@@ -3058,16 +3082,6 @@ fn paint_chat_shell(
                 paint,
             );
             paint_header_chip(
-                chat_cycle_reasoning_effort_button_bounds(content_bounds),
-                format!(
-                    "Effort {}",
-                    autopilot_chat.reasoning_effort.as_deref().unwrap_or("auto")
-                )
-                .as_str(),
-                theme::status::INFO,
-                paint,
-            );
-            paint_header_chip(
                 chat_interrupt_button_bounds(content_bounds),
                 if autopilot_chat.active_turn_id.is_some() {
                     "Interrupt turn"
@@ -3088,6 +3102,16 @@ fn paint_chat_shell(
                 paint,
             );
             if autopilot_chat.header_controls_expanded {
+                paint_header_chip(
+                    chat_cycle_reasoning_effort_button_bounds(content_bounds),
+                    format!(
+                        "Effort {}",
+                        autopilot_chat.reasoning_effort.as_deref().unwrap_or("auto")
+                    )
+                    .as_str(),
+                    theme::status::INFO,
+                    paint,
+                );
                 paint_header_chip(
                     chat_cycle_service_tier_button_bounds(content_bounds),
                     format!("Tier {}", autopilot_chat.service_tier.label()).as_str(),
@@ -3337,7 +3361,7 @@ pub fn paint(
         spacetime_presence,
         paint,
     );
-    if browse_mode == ChatBrowseMode::Autopilot {
+    if browse_mode == ChatBrowseMode::Autopilot && !autopilot_chat.thread_rail_collapsed {
         let search_bounds = chat_thread_search_input_bounds(content_bounds);
         chat_inputs
             .thread_search
@@ -3907,6 +3931,10 @@ pub fn paint(
 }
 
 pub fn dispatch_input_event(state: &mut RenderState, event: &InputEvent) -> bool {
+    set_chat_shell_layout_state(
+        state.autopilot_chat.workspace_rail_collapsed,
+        state.autopilot_chat.thread_rail_collapsed,
+    );
     let top_chat = state
         .panes
         .iter()
@@ -3927,7 +3955,9 @@ pub fn dispatch_input_event(state: &mut RenderState, event: &InputEvent) -> bool
         .composer
         .event(event, composer_bounds, &mut state.event_context)
         .is_handled();
-    if state.autopilot_chat.chat_browse_mode() == ChatBrowseMode::Autopilot {
+    if state.autopilot_chat.chat_browse_mode() == ChatBrowseMode::Autopilot
+        && !state.autopilot_chat.thread_rail_collapsed
+    {
         handled |= state
             .chat_inputs
             .thread_search
@@ -3969,6 +3999,29 @@ pub fn dispatch_transcript_scroll_event(
     };
 
     let content_bounds = pane_content_bounds(bounds);
+    if !state.autopilot_chat.thread_rail_collapsed {
+        let channel_bounds = chat_thread_rail_bounds(content_bounds);
+        let channel_rows = shell_channel_entries(&state.autopilot_chat);
+        let visible_rows = chat_visible_thread_row_count(
+            content_bounds,
+            channel_rows.len(),
+            state.autopilot_chat.thread_tools_expanded,
+        );
+        let rows_clip = thread_rows_clip_bounds(
+            content_bounds,
+            state.autopilot_chat.thread_tools_expanded,
+            channel_bounds,
+        );
+        if rows_clip.contains(cursor_position)
+            && state.autopilot_chat.scroll_thread_rail_by(
+                scroll_dy,
+                channel_rows.len(),
+                visible_rows,
+            )
+        {
+            return true;
+        }
+    }
     let composer_value = state.chat_inputs.composer.get_value().to_string();
     let composer_height = chat_composer_height_for_value(content_bounds, &composer_value);
     let clip = transcript_scroll_clip_bounds_with_height(content_bounds, composer_height);

--- a/apps/autopilot-desktop/src/render.rs
+++ b/apps/autopilot-desktop/src/render.rs
@@ -129,38 +129,37 @@ impl BackdropBlurRenderer {
             label: Some("Backdrop Blur Shader"),
             source: wgpu::ShaderSource::Wgsl(BACKDROP_BLUR_SHADER.into()),
         });
-        let bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("Backdrop Blur Bind Group Layout"),
-                entries: &[
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            multisampled: false,
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        },
-                        count: None,
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Backdrop Blur Bind Group Layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
                     },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                        count: None,
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
                     },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 2,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Uniform,
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    },
-                ],
-            });
+                    count: None,
+                },
+            ],
+        });
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Backdrop Blur Pipeline Layout"),
             bind_group_layouts: &[&bind_group_layout],
@@ -238,10 +237,20 @@ impl BackdropBlurRenderer {
         }
         self.target_size = (width, height);
         self.target_format = target_format;
-        let (scene_texture, scene_view) =
-            create_blur_target_texture(device, "Backdrop Blur Scene Texture", width, height, target_format);
-        let (blur_texture, blur_view) =
-            create_blur_target_texture(device, "Backdrop Blur Intermediate Texture", width, height, target_format);
+        let (scene_texture, scene_view) = create_blur_target_texture(
+            device,
+            "Backdrop Blur Scene Texture",
+            width,
+            height,
+            target_format,
+        );
+        let (blur_texture, blur_view) = create_blur_target_texture(
+            device,
+            "Backdrop Blur Intermediate Texture",
+            width,
+            height,
+            target_format,
+        );
         self.scene_texture = Some(scene_texture);
         self.scene_view = Some(scene_view);
         self.blur_texture = Some(blur_texture);
@@ -323,7 +332,11 @@ impl BackdropBlurRenderer {
         direction: [f32; 2],
         load_op: wgpu::LoadOp<wgpu::Color>,
     ) {
-        queue.write_buffer(&self.uniform_buffer, 0, &blur_uniform_bytes(texel_size, direction));
+        queue.write_buffer(
+            &self.uniform_buffer,
+            0,
+            &blur_uniform_bytes(texel_size, direction),
+        );
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("Backdrop Blur Bind Group"),
             layout: &self.bind_group_layout,
@@ -1055,6 +1068,55 @@ fn open_startup_pane(state: &mut RenderState, pane_kind: PaneKind) {
 }
 
 fn layout_split_shell_startup_panes(state: &mut RenderState) {
+    let chat_idx = state
+        .panes
+        .iter()
+        .position(|pane| pane.kind == PaneKind::AutopilotChat);
+    let mission_idx = state
+        .panes
+        .iter()
+        .position(|pane| pane.kind == PaneKind::GoOnline);
+    if let (Some(chat_idx), Some(mission_idx)) = (chat_idx, mission_idx) {
+        let logical = logical_size(&state.config, state.scale_factor);
+        let usable_width = (logical.width - sidebar_reserved_width(state)).max(0.0);
+        let usable_height = logical.height.max(0.0);
+        let margin = 12.0;
+        let gap = 10.0;
+        let top = 12.0;
+        let bottom_margin = 12.0;
+        let available_height = (usable_height - top - bottom_margin).max(300.0);
+        let available_width = (usable_width - margin * 2.0 - gap).max(900.0);
+
+        let chat_min_width = 620.0;
+        let mission_min_width = 520.0;
+        let mission_pref_width = state.panes[mission_idx].bounds.size.width;
+        let mission_width = mission_pref_width
+            .clamp(mission_min_width, 760.0)
+            .min((available_width - chat_min_width).max(mission_min_width));
+        let chat_width = (available_width - mission_width).max(chat_min_width);
+
+        let chat_height = state.panes[chat_idx]
+            .bounds
+            .size
+            .height
+            .min(available_height);
+        let mission_height = state.panes[mission_idx]
+            .bounds
+            .size
+            .height
+            .min(available_height);
+
+        state.panes[chat_idx].bounds = Bounds::new(margin, top, chat_width, chat_height);
+        state.panes[mission_idx].bounds = Bounds::new(
+            margin + chat_width + gap,
+            top,
+            mission_width,
+            mission_height,
+        );
+        clamp_all_panes_to_window(state);
+        return;
+    }
+
     let Some(provider_idx) = state
         .panes
         .iter()
@@ -1088,7 +1150,12 @@ fn layout_split_shell_startup_panes(state: &mut RenderState) {
 
 fn open_startup_panes(state: &mut RenderState) {
     let startup_panes = startup_pane_kinds();
-    for pane_kind in [PaneKind::EarningsScoreboard, PaneKind::ProviderControl] {
+    for pane_kind in [
+        PaneKind::AutopilotChat,
+        PaneKind::GoOnline,
+        PaneKind::EarningsScoreboard,
+        PaneKind::ProviderControl,
+    ] {
         if startup_panes.contains(&pane_kind) {
             open_startup_pane(state, pane_kind);
         }
@@ -1096,7 +1163,10 @@ fn open_startup_panes(state: &mut RenderState) {
     for pane_kind in startup_panes {
         if matches!(
             pane_kind,
-            PaneKind::EarningsScoreboard | PaneKind::ProviderControl
+            PaneKind::AutopilotChat
+                | PaneKind::GoOnline
+                | PaneKind::EarningsScoreboard
+                | PaneKind::ProviderControl
         ) {
             continue;
         }
@@ -1104,7 +1174,14 @@ fn open_startup_panes(state: &mut RenderState) {
     }
 
     layout_split_shell_startup_panes(state);
-    if let Some(provider_id) = state
+    if let Some(mission_id) = state
+        .panes
+        .iter()
+        .find(|pane| pane.kind == PaneKind::GoOnline)
+        .map(|pane| pane.id)
+    {
+        PaneController::bring_to_front(state, mission_id);
+    } else if let Some(provider_id) = state
         .panes
         .iter()
         .find(|pane| pane.kind == PaneKind::ProviderControl)
@@ -1681,17 +1758,20 @@ pub fn render_frame(state: &mut RenderState) -> Result<crate::app_state::FrameRe
                 .color(tooltip_text_color);
             label.paint(text_bounds, &mut paint);
         }
-
     }
 
     let overlay_scene = if state.onboarding.is_active() {
         let mut overlay_scene = Scene::new();
         let overlay_buy_mode_enabled = state.mission_control_buy_mode_enabled();
-        let overlay_backend_kernel_authority = state.kernel_projection_worker.uses_remote_authority();
+        let overlay_backend_kernel_authority =
+            state.kernel_projection_worker.uses_remote_authority();
         let overlay_cursor_position = state.cursor_position;
         let overlay_desktop_shell_mode = state.desktop_shell_mode;
-        let mut overlay_paint =
-            PaintContext::new(&mut overlay_scene, &mut state.text_system, state.scale_factor);
+        let mut overlay_paint = PaintContext::new(
+            &mut overlay_scene,
+            &mut state.text_system,
+            state.scale_factor,
+        );
         if matches!(
             onboarding_view.phase,
             crate::onboarding::OnboardingPhase::TourSellCompute
@@ -1786,12 +1866,9 @@ pub fn render_frame(state: &mut RenderState) -> Result<crate::app_state::FrameRe
         );
         if let Some(scene_view) = state.backdrop_blur.scene_view() {
             state.renderer.render(&mut encoder, scene_view);
-            state.backdrop_blur.render_blurred(
-                &state.device,
-                &state.queue,
-                &mut encoder,
-                &view,
-            );
+            state
+                .backdrop_blur
+                .render_blurred(&state.device, &state.queue, &mut encoder, &view);
             if let Some(overlay_scene) = overlay_scene.as_ref() {
                 state.renderer.prepare(
                     &state.device,
@@ -2149,8 +2226,7 @@ mod tests {
     #[test]
     fn startup_pane_set_restores_mission_control() {
         let startup = startup_pane_kinds();
-        assert_eq!(startup, vec![PaneKind::GoOnline]);
-        assert!(!startup.contains(&PaneKind::AutopilotChat));
+        assert_eq!(startup, vec![PaneKind::AutopilotChat, PaneKind::GoOnline]);
         assert!(!startup.contains(&PaneKind::ProjectOps));
         assert!(!startup.contains(&PaneKind::CadDemo));
         assert!(!startup.contains(&PaneKind::SparkWallet));


### PR DESCRIPTION
## Summary
- make CHAT a startup pane and default startup layout to CHAT (left) + MISSION CONTROL (right)
- auto-refresh chat thread history on CHAT pane open and improve startup thread hydration/resume behavior
- fix non-command quote parsing in chat input and keep command parsing slash-command scoped
- rename pane title/label to CHAT
- add thread-rail scrolling with scrollbar, scroll-aware hit testing, and keep controls responsive when pane narrows
- move Effort under More so top row is Model, Interrupt, More
- set thread filter default to Show all
- style thread scrollbar thumb to gray for Mission Control parity

## Validation
- cargo fmt --all
- cargo check -p autopilot-desktop