### PR TITLE
Fix chat pane compile breaks after merge

### DIFF
--- a/apps/autopilot-desktop/src/input.rs
+++ b/apps/autopilot-desktop/src/input.rs
@@ -3417,6 +3417,8 @@ pub(super) fn run_pane_hit_action(
         PaneHitAction::ChatCycleSandboxMode => run_chat_cycle_sandbox_mode_action(state),
         PaneHitAction::ChatToggleHeaderControls => run_chat_toggle_header_controls_action(state),
         PaneHitAction::ChatToggleHelpHint => run_chat_toggle_help_hint_action(state),
+        PaneHitAction::ChatToggleWorkspaceRail => run_chat_toggle_workspace_rail_action(state),
+        PaneHitAction::ChatToggleThreadRail => run_chat_toggle_thread_rail_action(state),
         PaneHitAction::ChatInterruptTurn => run_chat_interrupt_turn_action(state),
         PaneHitAction::ChatImplementPlan => run_chat_implement_plan_action(state),
         PaneHitAction::ChatReviewThread => run_chat_review_action(state),

--- a/apps/autopilot-desktop/src/pane_system.rs
+++ b/apps/autopilot-desktop/src/pane_system.rs
@@ -2095,10 +2095,10 @@ pub fn chat_compact_button_bounds(content_bounds: Bounds) -> Bounds {
 pub fn chat_thread_row_bounds(
     content_bounds: Bounds,
     index: usize,
-    thread_tools_expanded: bool,
+    _thread_tools_expanded: bool,
 ) -> Bounds {
     let rail = chat_thread_rail_bounds(content_bounds);
-    let y = chat_thread_rail_controls_bottom(content_bounds, thread_tools_expanded)
+    let y = chat_thread_rail_controls_bottom(content_bounds)
         + index as f32 * (CHAT_SHELL_ROW_HEIGHT + CHAT_SHELL_ROW_GAP);
     Bounds::new(
         rail.origin.x + 8.0,


### PR DESCRIPTION
## Summary
- fix stale callsite using old helper signature
- add missing PaneHitAction handlers for workspace/thread rail toggles in run_pane_hit_action
- remove now-unused parameter warning in chat thread row layout

## Validation
- cargo check -p autopilot-desktop
