### PR TITLE
Polish autopilot chat rails and thread hover previews

### DIFF
--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -664,7 +664,7 @@ impl Default for ChatPaneInputs {
                 .border_color_focused(theme::border::FOCUS),
             thread_search: TextInput::new()
                 .placeholder("Filter thread history...")
-                .font_size(wgpui::theme::font_size::SM - 2.0)
+                .font_size(wgpui::theme::font_size::SM - 3.0)
                 .border_color_focused(theme::border::FOCUS),
         }
     }
@@ -7085,6 +7085,8 @@ pub struct AutopilotChatState {
     pub direct_message_projection: DirectMessageProjectionState,
     pub startup_new_thread_bootstrap_pending: bool,
     pub startup_new_thread_bootstrap_sent: bool,
+    pub pending_thread_history_refresh_on_ready: bool,
+    thread_history_refresh_retry_last_attempt_at: Option<Instant>,
     pub messages: Vec<AutopilotMessage>,
     pub next_message_id: u64,
     pub active_turn_id: Option<String>,
@@ -7125,6 +7127,9 @@ pub struct AutopilotChatState {
     pub workspace_rail_collapsed: bool,
     pub thread_rail_collapsed: bool,
     pub thread_rail_scroll_row_offset: usize,
+    pub thread_hover_preview_thread_id: Option<String>,
+    thread_hover_preview_started_at: Option<Instant>,
+    pub thread_hover_preview_visible: bool,
     pub thread_rename_counter: u64,
     pub transcript_scroll_offset: f32,
     pub transcript_follow_tail: bool,
@@ -7221,6 +7226,8 @@ impl Default for AutopilotChatState {
             direct_message_projection: DirectMessageProjectionState::default(),
             startup_new_thread_bootstrap_pending: false,
             startup_new_thread_bootstrap_sent: false,
+            pending_thread_history_refresh_on_ready: true,
+            thread_history_refresh_retry_last_attempt_at: None,
             messages: Vec::new(),
             next_message_id: 1,
             active_turn_id: None,
@@ -7261,6 +7268,9 @@ impl Default for AutopilotChatState {
             workspace_rail_collapsed: false,
             thread_rail_collapsed: false,
             thread_rail_scroll_row_offset: 0,
+            thread_hover_preview_thread_id: None,
+            thread_hover_preview_started_at: None,
+            thread_hover_preview_visible: false,
             thread_rename_counter: 1,
             transcript_scroll_offset: 0.0,
             transcript_follow_tail: true,
@@ -8621,6 +8631,20 @@ impl AutopilotChatState {
         // Managed groups / DMs continue syncing in projection state but are hidden
         // from workspace switching until the multi-space UX is re-enabled.
         vec![ChatWorkspaceSelection::Autopilot]
+    }
+
+    pub fn thread_history_refresh_retry_due(
+        &self,
+        now: Instant,
+        interval: std::time::Duration,
+    ) -> bool {
+        self.thread_history_refresh_retry_last_attempt_at
+            .map(|last| now.duration_since(last) >= interval)
+            .unwrap_or(true)
+    }
+
+    pub fn note_thread_history_refresh_retry_attempt(&mut self, now: Instant) {
+        self.thread_history_refresh_retry_last_attempt_at = Some(now);
     }
 
     pub fn select_chat_workspace_by_index(&mut self, index: usize) -> bool {
@@ -10560,6 +10584,32 @@ impl AutopilotChatState {
         if self.copy_notice_until.is_some_and(|until| until <= now) {
             self.copy_notice = None;
             self.copy_notice_until = None;
+            return true;
+        }
+        false
+    }
+
+    pub fn set_thread_hover_preview_target(
+        &mut self,
+        thread_id: Option<String>,
+        now: Instant,
+    ) -> bool {
+        if self.thread_hover_preview_thread_id == thread_id {
+            return false;
+        }
+        self.thread_hover_preview_thread_id = thread_id;
+        self.thread_hover_preview_started_at = self.thread_hover_preview_thread_id.as_ref().map(|_| now);
+        self.thread_hover_preview_visible = false;
+        true
+    }
+
+    pub fn refresh_thread_hover_preview_visibility(&mut self, now: Instant) -> bool {
+        let should_show = self
+            .thread_hover_preview_started_at
+            .is_some_and(|started| now.saturating_duration_since(started) >= Duration::from_secs(1))
+            && self.thread_hover_preview_thread_id.is_some();
+        if self.thread_hover_preview_visible != should_show {
+            self.thread_hover_preview_visible = should_show;
             return true;
         }
         false

--- a/apps/autopilot-desktop/src/input.rs
+++ b/apps/autopilot-desktop/src/input.rs
@@ -1137,6 +1137,22 @@ fn pump_background_every_loop(
     ) {
         changed = true;
     }
+    if record_runtime_changed_op(
+        state,
+        "every_loop",
+        "autopilot_chat::hover_preview_visibility",
+        |state| state.autopilot_chat.refresh_thread_hover_preview_visibility(now),
+    ) {
+        changed = true;
+    }
+    if record_runtime_changed_op(
+        state,
+        "every_loop",
+        "autopilot_chat::pending_thread_history_refresh",
+        |state| run_chat_pending_thread_history_refresh_tick(state, now),
+    ) {
+        changed = true;
+    }
     if record_runtime_changed_op(state, "every_loop", "cast_control::process_tick", |state| {
         run_cast_control_process_tick(state)
     }) {
@@ -2455,6 +2471,7 @@ fn dispatch_mouse_move(state: &mut crate::app_state::RenderState, point: Point) 
     if state.cad_camera_drag_state.is_none() {
         handled |= update_cad_hover_target(state, point);
     }
+    handled |= chat_pane::update_thread_hover_preview_target(state, point);
     handled |= update_chat_transcript_selection_drag(state, point);
     let event = InputEvent::MouseMove {
         x: point.x,

--- a/apps/autopilot-desktop/src/input/actions.rs
+++ b/apps/autopilot-desktop/src/input/actions.rs
@@ -5629,6 +5629,62 @@ pub(super) fn run_chat_refresh_threads_action(state: &mut crate::app_state::Rend
     true
 }
 
+pub(super) fn run_chat_pending_thread_history_refresh_tick(
+    state: &mut crate::app_state::RenderState,
+    now: std::time::Instant,
+) -> bool {
+    if !state.autopilot_chat.pending_thread_history_refresh_on_ready {
+        return false;
+    }
+    if state.autopilot_chat.chat_browse_mode() != crate::app_state::ChatBrowseMode::Autopilot {
+        return false;
+    }
+    if !state
+        .panes
+        .iter()
+        .any(|pane| pane.kind == crate::app_state::PaneKind::AutopilotChat)
+    {
+        return false;
+    }
+    if !state
+        .autopilot_chat
+        .thread_history_refresh_retry_due(now, std::time::Duration::from_secs(2))
+    {
+        return false;
+    }
+    state
+        .autopilot_chat
+        .note_thread_history_refresh_retry_attempt(now);
+
+    sync_chat_thread_search_term(state);
+    let cwd = current_chat_workspace_root(state).or_else(|| {
+        std::env::current_dir()
+            .ok()
+            .and_then(|value| value.into_os_string().into_string().ok())
+    });
+    let params = state.autopilot_chat.build_thread_list_params(cwd);
+    let list_result = state.queue_codex_command(crate::codex_lane::CodexLaneCommand::ThreadList(
+        params,
+    ));
+    if let Err(error) = list_result {
+        state.autopilot_chat.last_error = Some(error);
+        return false;
+    }
+    let loaded_result = state.queue_codex_command(crate::codex_lane::CodexLaneCommand::ThreadLoadedList(
+        ThreadLoadedListParams {
+            cursor: None,
+            limit: Some(200),
+        },
+    ));
+    if let Err(error) = loaded_result {
+        state.autopilot_chat.last_error = Some(error);
+        return false;
+    }
+    state.autopilot_chat.last_error = None;
+    state.autopilot_chat.pending_thread_history_refresh_on_ready = false;
+    true
+}
+
 pub(super) fn run_chat_new_thread_action(state: &mut crate::app_state::RenderState) -> bool {
     focus_chat_composer(state);
     sync_chat_composer_draft(state);

--- a/apps/autopilot-desktop/src/input/reducers/codex.rs
+++ b/apps/autopilot-desktop/src/input/reducers/codex.rs
@@ -274,16 +274,22 @@ pub(super) fn apply_lane_snapshot(state: &mut RenderState, snapshot: CodexLaneSn
         state.sync_health.last_applied_event_seq.saturating_add(1);
     state.sync_health.cursor_last_advanced_seconds_ago = 0;
     refresh_codex_readiness_summary(state);
+    let lane_just_became_ready = previous_lifecycle != CodexLaneLifecycle::Ready
+        && state.codex_lane.lifecycle == CodexLaneLifecycle::Ready;
     if state.codex_lane.lifecycle == CodexLaneLifecycle::Ready
         && state.autopilot_chat.chat_browse_mode() == crate::app_state::ChatBrowseMode::Autopilot
-        && state.autopilot_chat.threads.is_empty()
-        && state.autopilot_chat.active_thread_id.is_none()
+        && (state.autopilot_chat.pending_thread_history_refresh_on_ready
+            || lane_just_became_ready
+            || (state.autopilot_chat.threads.is_empty()
+                && state.autopilot_chat.active_thread_id.is_none()))
     {
-        queue_thread_history_refresh(state);
+        if queue_thread_history_refresh(state) {
+            state.autopilot_chat.pending_thread_history_refresh_on_ready = false;
+        } else {
+            state.autopilot_chat.pending_thread_history_refresh_on_ready = true;
+        }
     }
-    if previous_lifecycle != CodexLaneLifecycle::Ready
-        && state.codex_lane.lifecycle == CodexLaneLifecycle::Ready
-    {
+    if lane_just_became_ready {
         queue_codex_readiness_refresh(state, true, "lane ready");
     }
 }
@@ -726,7 +732,7 @@ fn queue_new_thread(state: &mut RenderState, error_prefix: &str) -> bool {
     true
 }
 
-fn queue_thread_history_refresh(state: &mut RenderState) {
+fn queue_thread_history_refresh(state: &mut RenderState) -> bool {
     let cwd = super::super::actions::current_chat_session_cwd(state).or_else(|| {
         std::env::current_dir()
             .ok()
@@ -735,7 +741,7 @@ fn queue_thread_history_refresh(state: &mut RenderState) {
     let params = state.autopilot_chat.build_thread_list_params(cwd);
     if let Err(error) = state.queue_codex_command(CodexLaneCommand::ThreadList(params)) {
         state.autopilot_chat.last_error = Some(error);
-        return;
+        return false;
     }
     if let Err(error) = state.queue_codex_command(CodexLaneCommand::ThreadLoadedList(
         codex_client::ThreadLoadedListParams {
@@ -744,7 +750,9 @@ fn queue_thread_history_refresh(state: &mut RenderState) {
         },
     )) {
         state.autopilot_chat.last_error = Some(error);
+        return false;
     }
+    true
 }
 
 pub(super) fn apply_notification(state: &mut RenderState, notification: CodexLaneNotification) {

--- a/apps/autopilot-desktop/src/pane_renderer.rs
+++ b/apps/autopilot-desktop/src/pane_renderer.rs
@@ -748,6 +748,20 @@ impl PaneRenderer {
             });
         }
 
+        if let Some(chat_pane) = panes
+            .iter()
+            .filter(|pane| pane.kind == PaneKind::AutopilotChat)
+            .max_by_key(|pane| pane.z_index)
+        {
+            paint.scene.set_layer(next_layer);
+            next_layer = next_layer.saturating_add(1);
+            chat_pane::paint_thread_hover_preview_overlay(
+                pane_content_bounds_for_pane(chat_pane),
+                autopilot_chat,
+                paint,
+            );
+        }
+
         if dim_inactive_panes {
             let Some(active_bounds) = panes
                 .iter()

--- a/apps/autopilot-desktop/src/pane_system.rs
+++ b/apps/autopilot-desktop/src/pane_system.rs
@@ -47,10 +47,10 @@ const CHAT_COMPOSER_MAX_HEIGHT: f32 = 120.0;
 const CHAT_SEND_WIDTH: f32 = 30.0;
 const DATA_SELLER_COMPOSER_HEIGHT: f32 = 30.0;
 const DATA_SELLER_SEND_WIDTH: f32 = 72.0;
-const CHAT_HEADER_BUTTON_HEIGHT: f32 = 24.0;
-const CHAT_HEADER_BUTTON_WIDTH: f32 = 104.0;
-const CHAT_HEADER_BUTTON_MIN_WIDTH: f32 = 76.0;
-const CHAT_HEADER_BUTTON_GAP: f32 = 8.0;
+const CHAT_HEADER_BUTTON_HEIGHT: f32 = 22.0;
+const CHAT_HEADER_BUTTON_WIDTH: f32 = 96.0;
+const CHAT_HEADER_BUTTON_MIN_WIDTH: f32 = 70.0;
+const CHAT_HEADER_BUTTON_GAP: f32 = 6.0;
 /// Compact + button next to "Threads" to start a new thread
 const CHAT_NEW_THREAD_BUTTON_SIZE: f32 = 26.0;
 const CHAT_THREAD_SEARCH_INPUT_HEIGHT: f32 = 24.0;
@@ -203,9 +203,6 @@ fn focus_chat_composer_for_pane_open(state: &mut RenderState) {
 }
 
 fn queue_chat_thread_history_refresh_for_pane_open(state: &mut RenderState) {
-    if state.codex_lane.lifecycle != crate::codex_lane::CodexLaneLifecycle::Ready {
-        return;
-    }
     if state.autopilot_chat.chat_browse_mode() != crate::app_state::ChatBrowseMode::Autopilot {
         return;
     }
@@ -213,13 +210,27 @@ fn queue_chat_thread_history_refresh_for_pane_open(state: &mut RenderState) {
         .ok()
         .and_then(|value| value.into_os_string().into_string().ok());
     let params = state.autopilot_chat.build_thread_list_params(cwd);
-    let _ = state.queue_codex_command(crate::codex_lane::CodexLaneCommand::ThreadList(params));
-    let _ = state.queue_codex_command(crate::codex_lane::CodexLaneCommand::ThreadLoadedList(
+    let list_result = state.queue_codex_command(crate::codex_lane::CodexLaneCommand::ThreadList(
+        params,
+    ));
+    let loaded_result = state.queue_codex_command(crate::codex_lane::CodexLaneCommand::ThreadLoadedList(
         codex_client::ThreadLoadedListParams {
             cursor: None,
             limit: Some(200),
         },
     ));
+    if let Err(error) = list_result {
+        state.autopilot_chat.last_error = Some(error);
+        state.autopilot_chat.pending_thread_history_refresh_on_ready = true;
+        return;
+    }
+    if let Err(error) = loaded_result {
+        state.autopilot_chat.last_error = Some(error);
+        state.autopilot_chat.pending_thread_history_refresh_on_ready = true;
+        return;
+    }
+    state.autopilot_chat.last_error = None;
+    state.autopilot_chat.pending_thread_history_refresh_on_ready = false;
 }
 
 fn focus_local_inference_prompt_for_pane_open(state: &mut RenderState) {
@@ -2095,10 +2106,10 @@ pub fn chat_compact_button_bounds(content_bounds: Bounds) -> Bounds {
 pub fn chat_thread_row_bounds(
     content_bounds: Bounds,
     index: usize,
-    _thread_tools_expanded: bool,
+    thread_tools_expanded: bool,
 ) -> Bounds {
     let rail = chat_thread_rail_bounds(content_bounds);
-    let y = chat_thread_rail_controls_bottom(content_bounds)
+    let y = chat_thread_rail_controls_bottom(content_bounds, thread_tools_expanded)
         + index as f32 * (CHAT_SHELL_ROW_HEIGHT + CHAT_SHELL_ROW_GAP);
     Bounds::new(
         rail.origin.x + 8.0,

--- a/apps/autopilot-desktop/src/pane_system/helpers.rs
+++ b/apps/autopilot-desktop/src/pane_system/helpers.rs
@@ -15,8 +15,15 @@ pub(super) fn chat_thread_action_grid_bounds(content_bounds: Bounds, index: usiz
     )
 }
 
-pub(super) fn chat_thread_rail_controls_bottom(content_bounds: Bounds) -> f32 {
-    chat_thread_action_unsubscribe_button_bounds(content_bounds).max_y() + 10.0
+pub(super) fn chat_thread_rail_controls_bottom(
+    content_bounds: Bounds,
+    thread_tools_expanded: bool,
+) -> f32 {
+    if thread_tools_expanded {
+        chat_thread_action_unsubscribe_button_bounds(content_bounds).max_y() + 10.0
+    } else {
+        chat_thread_filter_provider_button_bounds(content_bounds).max_y() + 10.0
+    }
 }
 
 pub(super) fn codex_action_button_bounds(

--- a/apps/autopilot-desktop/src/panes/chat.rs
+++ b/apps/autopilot-desktop/src/panes/chat.rs
@@ -199,6 +199,8 @@ struct ChatShellWorkspace {
 struct ChatShellChannelEntry {
     title: String,
     subtitle: String,
+    thread_id: Option<String>,
+    hover_preview: Option<String>,
     active: bool,
     is_category: bool,
     collapsed: bool,
@@ -2426,19 +2428,24 @@ fn paint_thread_rail_button(
     ));
 }
 
-fn paint_header_chip(bounds: Bounds, label: &str, accent: wgpui::Hsla, paint: &mut PaintContext) {
+fn paint_header_chip(
+    bounds: Bounds,
+    label: &str,
+    _accent: wgpui::Hsla,
+    paint: &mut PaintContext,
+) {
     paint.scene.draw_quad(
         Quad::new(bounds)
-            .with_background(chat_mission_panel_header_color().with_alpha(0.58))
-            .with_border(accent.with_alpha(0.6), 1.0)
+            .with_background(chat_mission_panel_header_color().with_alpha(0.5))
+            .with_border(chat_mission_panel_border_color().with_alpha(0.62), 1.0)
             .with_corner_radius(3.0),
     );
-    let clipped_label = truncate_for_width(label, bounds.size.width - 14.0);
+    let clipped_label = truncate_for_width(label, bounds.size.width - 12.0);
     paint.scene.draw_text(paint.text.layout_mono(
         &clipped_label,
-        Point::new(bounds.origin.x + 8.0, bounds.origin.y + 7.0),
+        Point::new(bounds.origin.x + 6.0, bounds.origin.y + 7.0),
         9.0,
-        chat_mission_text_color(),
+        chat_mission_muted_color(),
     ));
 }
 
@@ -2477,6 +2484,8 @@ fn shell_channel_entries(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellCh
                         } else {
                             format!("{channel_count} channel(s)")
                         },
+                        thread_id: None,
+                        hover_preview: None,
                         active: false,
                         is_category: true,
                         collapsed,
@@ -2500,6 +2509,8 @@ fn shell_channel_entries(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellCh
                         Some(ChatShellChannelEntry {
                             title: format!("# {}", managed_channel_label(channel)),
                             subtitle: managed_channel_subtitle(channel),
+                            thread_id: None,
+                            hover_preview: None,
                             active: active_channel_id == Some(channel.channel_id.as_str()),
                             is_category: false,
                             collapsed: false,
@@ -2527,6 +2538,8 @@ fn shell_channel_entries(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellCh
                             autopilot_chat.direct_message_projection.local_pubkey(),
                         ),
                         subtitle: direct_room_subtitle(room),
+                        thread_id: None,
+                        hover_preview: None,
                         active: active_room_id == Some(room.room_id.as_str()),
                         is_category: false,
                         collapsed: false,
@@ -2542,6 +2555,8 @@ fn shell_channel_entries(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellCh
     let mut entries = vec![ChatShellChannelEntry {
         title: "# mission-control".to_string(),
         subtitle: "provider coordination".to_string(),
+        thread_id: None,
+        hover_preview: None,
         active: autopilot_chat.active_thread_id.is_none(),
         is_category: false,
         collapsed: false,
@@ -2574,6 +2589,12 @@ fn shell_channel_entries(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellCh
         ChatShellChannelEntry {
             title: format!("# {title}"),
             subtitle,
+            thread_id: Some(thread_id.clone()),
+            hover_preview: metadata
+                .and_then(|value| value.preview.as_deref())
+                .map(str::trim)
+                .map(str::to_string)
+                .filter(|preview| !preview.is_empty()),
             active: autopilot_chat.active_thread_id.as_deref() == Some(thread_id.as_str()),
             is_category: false,
             collapsed: false,
@@ -2592,6 +2613,8 @@ fn shell_channel_entries(autopilot_chat: &AutopilotChatState) -> Vec<ChatShellCh
                 + autopilot_chat.pending_tool_user_input.len()
                 + autopilot_chat.pending_auth_refresh.len()
         ),
+        thread_id: None,
+        hover_preview: None,
         active: false,
         is_category: false,
         collapsed: false,
@@ -2695,12 +2718,12 @@ fn paint_chat_shell(
                     paint,
                 );
             }
+            let workspace_label_width = paint.text.measure(&workspace.label, 9.0);
+            let workspace_label_x =
+                avatar_bounds.origin.x + (avatar_bounds.size.width - workspace_label_width) * 0.5;
             paint.scene.draw_text(paint.text.layout(
                 &workspace.label,
-                Point::new(
-                    workspace_bounds.origin.x + 12.0,
-                    avatar_bounds.max_y() + 4.0,
-                ),
+                Point::new(workspace_label_x, avatar_bounds.max_y() + 4.0),
                 9.0,
                 if workspace.active {
                     chat_mission_text_color()
@@ -2921,6 +2944,9 @@ fn paint_chat_shell(
             autopilot_chat.thread_tools_expanded,
             channel_bounds,
         );
+        let hovered_thread_id = autopilot_chat.thread_hover_preview_thread_id.as_deref();
+        let hover_preview_visible = autopilot_chat.thread_hover_preview_visible;
+        let suppress_active_highlight = hovered_thread_id.is_some();
         paint.scene.push_clip(rows_clip);
         for (index, entry) in channel_entries
             .into_iter()
@@ -2930,16 +2956,21 @@ fn paint_chat_shell(
         {
             let row_bounds =
                 chat_thread_row_bounds(content_bounds, index, autopilot_chat.thread_tools_expanded);
+            let is_hovered = entry.thread_id.as_deref() == hovered_thread_id;
             let background = if entry.is_category {
                 chat_mission_panel_header_color().with_alpha(0.5)
-            } else if entry.active {
+            } else if is_hovered {
+                chat_mission_cyan_color().with_alpha(0.12)
+            } else if entry.active && !suppress_active_highlight {
                 chat_mission_green_color().with_alpha(0.18)
             } else {
                 chat_mission_panel_color().with_alpha(0.9)
             };
             let border = if entry.is_category {
                 chat_mission_panel_border_color().with_alpha(0.45)
-            } else if entry.active {
+            } else if is_hovered {
+                chat_mission_cyan_color().with_alpha(0.55)
+            } else if entry.active && !suppress_active_highlight {
                 chat_mission_green_color().with_alpha(0.6)
             } else {
                 chat_mission_panel_border_color().with_alpha(0.6)
@@ -2952,7 +2983,7 @@ fn paint_chat_shell(
             );
             let title_color = if entry.is_category {
                 chat_mission_muted_color()
-            } else if entry.active {
+            } else if entry.active && !suppress_active_highlight {
                 chat_mission_text_color()
             } else {
                 chat_mission_muted_color()
@@ -2986,6 +3017,7 @@ fn paint_chat_shell(
                     paint,
                 );
             }
+            let _ = hover_preview_visible;
         }
         paint.scene.pop_clip();
         if max_start > 0 && rows_clip.size.height > 0.0 {
@@ -3209,6 +3241,96 @@ fn paint_chat_shell(
             }
         }
     }
+
+}
+
+pub fn paint_thread_hover_preview_overlay(
+    content_bounds: Bounds,
+    autopilot_chat: &AutopilotChatState,
+    paint: &mut PaintContext,
+) {
+    if !autopilot_chat.thread_hover_preview_visible
+        || autopilot_chat.chat_browse_mode() != ChatBrowseMode::Autopilot
+        || autopilot_chat.thread_rail_collapsed
+    {
+        return;
+    }
+    let Some(hovered_thread_id) = autopilot_chat.thread_hover_preview_thread_id.as_deref() else {
+        return;
+    };
+
+    let channel_entries = shell_channel_entries(autopilot_chat);
+    let total_rows = channel_entries.len();
+    let visible_rows = chat_visible_thread_row_count(
+        content_bounds,
+        total_rows,
+        autopilot_chat.thread_tools_expanded,
+    );
+    let start_index = autopilot_chat.thread_rail_scroll_start_index(total_rows, visible_rows);
+    let Some((anchor, preview)) = channel_entries
+        .iter()
+        .skip(start_index)
+        .take(visible_rows)
+        .enumerate()
+        .find_map(|(visible_index, entry)| {
+            (entry.thread_id.as_deref() == Some(hovered_thread_id)).then(|| {
+                (
+                    chat_thread_row_bounds(
+                        content_bounds,
+                        visible_index,
+                        autopilot_chat.thread_tools_expanded,
+                    ),
+                    entry
+                        .hover_preview
+                        .clone()
+                        .unwrap_or_else(|| "No preview yet for this thread.".to_string()),
+                )
+            })
+        })
+    else {
+        return;
+    };
+
+    let tooltip_width = 268.0;
+    let tooltip_height = 80.0;
+    let mut tooltip_x = anchor.max_x() + 8.0;
+    let max_tooltip_x =
+        (content_bounds.max_x() - tooltip_width - 8.0).max(content_bounds.origin.x + 8.0);
+    if tooltip_x > max_tooltip_x {
+        tooltip_x = (anchor.origin.x - tooltip_width - 8.0).max(content_bounds.origin.x + 8.0);
+    }
+    let tooltip_y = (anchor.origin.y - 8.0).max(content_bounds.origin.y + 8.0);
+    let tooltip_bounds = Bounds::new(tooltip_x, tooltip_y, tooltip_width, tooltip_height);
+    paint.scene.draw_quad(
+        Quad::new(tooltip_bounds)
+            .with_background(wgpui::Hsla::from_hex(0x0A0F16).with_alpha(0.95))
+            .with_border(chat_mission_panel_border_color().with_alpha(0.98), 1.0)
+            .with_corner_radius(3.0),
+    );
+    paint.scene.push_clip(tooltip_bounds);
+    let compact_preview = preview.replace('\n', " ");
+    let line_width = tooltip_bounds.size.width - 16.0;
+    let max_chars_per_line = ((line_width / 6.2).floor() as usize).max(12);
+    let mut preview_lines = split_text_for_display(&compact_preview, max_chars_per_line);
+    let has_overflow = preview_lines.len() > 5;
+    preview_lines.truncate(5);
+    for (line_index, raw_line) in preview_lines.into_iter().enumerate() {
+        let mut line = truncate_for_width(&raw_line, line_width);
+        if line_index == 4 && has_overflow && !line.ends_with('…') {
+            line.push('…');
+            line = truncate_for_width(&line, line_width);
+        }
+        paint.scene.draw_text(paint.text.layout(
+            &line,
+            Point::new(
+                tooltip_bounds.origin.x + 8.0,
+                tooltip_bounds.origin.y + 9.0 + line_index as f32 * 12.0,
+            ),
+            10.0,
+            chat_mission_text_color(),
+        ));
+    }
+    paint.scene.pop_clip();
 }
 
 pub fn transcript_message_byte_offset_at_point(
@@ -3979,6 +4101,61 @@ pub fn dispatch_input_event(state: &mut RenderState, event: &InputEvent) -> bool
     handled
 }
 
+pub fn update_thread_hover_preview_target(state: &mut RenderState, cursor_position: Point) -> bool {
+    set_chat_shell_layout_state(
+        state.autopilot_chat.workspace_rail_collapsed,
+        state.autopilot_chat.thread_rail_collapsed,
+    );
+    let top_chat = state
+        .panes
+        .iter()
+        .filter(|pane| pane.kind == PaneKind::AutopilotChat)
+        .max_by_key(|pane| pane.z_index)
+        .map(|pane| pane.bounds);
+    let now = std::time::Instant::now();
+    let Some(bounds) = top_chat else {
+        return state.autopilot_chat.set_thread_hover_preview_target(None, now);
+    };
+    if state.autopilot_chat.chat_browse_mode() != ChatBrowseMode::Autopilot
+        || state.autopilot_chat.thread_rail_collapsed
+    {
+        return state.autopilot_chat.set_thread_hover_preview_target(None, now);
+    }
+    let content_bounds = pane_content_bounds(bounds);
+    let channel_entries = shell_channel_entries(&state.autopilot_chat);
+    let visible_rows = chat_visible_thread_row_count(
+        content_bounds,
+        channel_entries.len(),
+        state.autopilot_chat.thread_tools_expanded,
+    );
+    let start_index = state
+        .autopilot_chat
+        .thread_rail_scroll_start_index(channel_entries.len(), visible_rows);
+    let rows_clip = thread_rows_clip_bounds(
+        content_bounds,
+        state.autopilot_chat.thread_tools_expanded,
+        chat_thread_rail_bounds(content_bounds),
+    );
+    if !rows_clip.contains(cursor_position) {
+        return state.autopilot_chat.set_thread_hover_preview_target(None, now);
+    }
+    for (index, entry) in channel_entries
+        .iter()
+        .skip(start_index)
+        .take(visible_rows)
+        .enumerate()
+    {
+        let row_bounds =
+            chat_thread_row_bounds(content_bounds, index, state.autopilot_chat.thread_tools_expanded);
+        if row_bounds.contains(cursor_position) {
+            return state
+                .autopilot_chat
+                .set_thread_hover_preview_target(entry.thread_id.clone(), now);
+        }
+    }
+    false
+}
+
 pub fn dispatch_transcript_scroll_event(
     state: &mut RenderState,
     cursor_position: Point,
@@ -4019,6 +4196,10 @@ pub fn dispatch_transcript_scroll_event(
                 visible_rows,
             )
         {
+            let _ = state.autopilot_chat.set_thread_hover_preview_target(
+                None,
+                std::time::Instant::now(),
+            );
             return true;
         }
     }


### PR DESCRIPTION
## Summary
- refine Autopilot Chat rails and controls layout for thread browsing
- improve thread history loading behavior on pane open/readiness transitions
- add and polish thread hover preview overlay (styling, clipping, multi-line cutoff)
- center workspace labels and adjust thread search input typography
- add subtle hovered-row highlighting and reduce hover preview transparency

## Validation
- cargo check -p autopilot-desktop
