### PR TITLE
Mission Control: alert truncation and log stream level filter cleanup

### DIFF
--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -5754,7 +5754,23 @@ pub struct LogStreamPaneState {
     copy_button_clicked_at_epoch_ms: u64,
     /// Dedupe keys for already-rendered runtime log entries.
     rendered_log_content: Vec<String>,
+    rendered_log_lines: Vec<LogStreamRenderedLine>,
+    active_level_filter: Option<LogStreamLevelFilter>,
     last_mirrored_trace_id: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LogStreamLevelFilter {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Clone, Debug)]
+struct LogStreamRenderedLine {
+    line: TerminalLine,
+    level: LogStreamLevelFilter,
 }
 
 impl Default for LogStreamPaneState {
@@ -5766,6 +5782,8 @@ impl Default for LogStreamPaneState {
                 .code_block_style(true),
             copy_button_clicked_at_epoch_ms: 0,
             rendered_log_content: Vec::new(),
+            rendered_log_lines: Vec::new(),
+            active_level_filter: Some(LogStreamLevelFilter::Info),
             last_mirrored_trace_id: 0,
         }
     }
@@ -5773,6 +5791,7 @@ impl Default for LogStreamPaneState {
 
 impl LogStreamPaneState {
     const ICON_CLICK_FEEDBACK_DURATION_MS: u64 = 650;
+    const MAX_STORED_LOG_LINES: usize = 2000;
 
     fn icon_click_feedback_intensity(clicked_at_epoch_ms: u64, now_epoch_ms: u64) -> f32 {
         if clicked_at_epoch_ms == 0 {
@@ -5794,13 +5813,125 @@ impl LogStreamPaneState {
         Self::icon_click_feedback_intensity(self.copy_button_clicked_at_epoch_ms, now_epoch_ms)
     }
 
-    fn push_persisted_log_line(&mut self, line: TerminalLine) {
+    pub fn active_level_filter(&self) -> Option<LogStreamLevelFilter> {
+        self.active_level_filter
+    }
+
+    pub fn set_level_filter(&mut self, filter: Option<LogStreamLevelFilter>) {
+        if self.active_level_filter != filter {
+            self.active_level_filter = filter;
+            self.rebuild_visible_terminal();
+        }
+    }
+
+    pub fn cycle_level_filter(&mut self) -> LogStreamLevelFilter {
+        let next = match self.active_level_filter.unwrap_or(LogStreamLevelFilter::Info) {
+            LogStreamLevelFilter::Debug => LogStreamLevelFilter::Info,
+            LogStreamLevelFilter::Info => LogStreamLevelFilter::Warn,
+            LogStreamLevelFilter::Warn => LogStreamLevelFilter::Error,
+            LogStreamLevelFilter::Error => LogStreamLevelFilter::Debug,
+        };
+        self.set_level_filter(Some(next));
+        next
+    }
+
+    fn level_matches_filter(&self, level: LogStreamLevelFilter) -> bool {
+        match self.active_level_filter {
+            None => true,
+            Some(active) => Self::level_rank(level) >= Self::level_rank(active),
+        }
+    }
+
+    fn level_rank(level: LogStreamLevelFilter) -> u8 {
+        match level {
+            LogStreamLevelFilter::Debug => 0,
+            LogStreamLevelFilter::Info => 1,
+            LogStreamLevelFilter::Warn => 2,
+            LogStreamLevelFilter::Error => 3,
+        }
+    }
+
+    fn rebuild_visible_terminal(&mut self) {
+        self.terminal.clear();
+        for entry in self.rendered_log_lines.iter() {
+            if self.level_matches_filter(entry.level) {
+                self.terminal.push_line(entry.line.clone());
+            }
+        }
+    }
+
+    fn classify_terminal_line_level(stream: &TerminalStream, text: &str) -> LogStreamLevelFilter {
+        let lowered = text.to_ascii_lowercase();
+        if matches!(stream, TerminalStream::Stderr)
+            || lowered.contains("error")
+            || lowered.contains("failed")
+            || lowered.contains("panic")
+            || lowered.contains("fatal")
+            || lowered.contains("rejected")
+            || lowered.contains("status=error")
+        {
+            return LogStreamLevelFilter::Error;
+        }
+        if lowered.contains("warn")
+            || lowered.contains("warning")
+            || lowered.contains("degraded")
+            || lowered.contains("retry")
+            || lowered.contains("payment-required")
+            || lowered.contains("blocked")
+            || lowered.contains("status=payment-required")
+        {
+            return LogStreamLevelFilter::Warn;
+        }
+        if lowered.contains("debug") || lowered.contains("trace") {
+            return LogStreamLevelFilter::Debug;
+        }
+        LogStreamLevelFilter::Info
+    }
+
+    fn tracing_level_to_filter(level: tracing::Level) -> LogStreamLevelFilter {
+        match level {
+            tracing::Level::ERROR => LogStreamLevelFilter::Error,
+            tracing::Level::WARN => LogStreamLevelFilter::Warn,
+            tracing::Level::INFO => LogStreamLevelFilter::Info,
+            tracing::Level::DEBUG | tracing::Level::TRACE => LogStreamLevelFilter::Debug,
+        }
+    }
+
+    fn push_persisted_log_line(&mut self, line: TerminalLine, level: LogStreamLevelFilter) {
         crate::runtime_log::record_mission_control_line(
             line.stream.clone(),
             line.text.clone(),
             line.key.as_deref(),
         );
-        self.terminal.push_line(line);
+        if let Some(key) = line.key.as_deref()
+            && let Some(existing) = self
+                .rendered_log_lines
+                .iter_mut()
+                .find(|existing| existing.line.key.as_deref() == Some(key))
+        {
+            existing.line = line;
+            existing.level = level;
+            self.rebuild_visible_terminal();
+            return;
+        }
+
+        let line_clone = line.clone();
+        self.rendered_log_lines
+            .push(LogStreamRenderedLine { line, level });
+
+        let overflow = self
+            .rendered_log_lines
+            .len()
+            .saturating_sub(Self::MAX_STORED_LOG_LINES);
+        if overflow > 0 {
+            self.rendered_log_lines.drain(0..overflow);
+            self.rebuild_visible_terminal();
+            return;
+        }
+
+        if self.level_matches_filter(level) {
+            self.terminal.push_line(line_clone);
+        }
     }
 
     fn build_runtime_terminal_line(
@@ -5825,7 +5956,9 @@ impl LogStreamPaneState {
     }
 
     pub fn push_runtime_log_line(&mut self, stream: TerminalStream, text: impl Into<String>) {
-        self.push_persisted_log_line(self.build_runtime_terminal_line(stream, text, None));
+        let line = self.build_runtime_terminal_line(stream, text, None);
+        let level = Self::classify_terminal_line_level(&line.stream, line.text.as_str());
+        self.push_persisted_log_line(line, level);
     }
 
     pub fn upsert_runtime_log_line(
@@ -5834,11 +5967,9 @@ impl LogStreamPaneState {
         stream: TerminalStream,
         text: impl Into<String>,
     ) {
-        self.push_persisted_log_line(self.build_runtime_terminal_line(
-            stream,
-            text,
-            Some(key.into()),
-        ));
+        let line = self.build_runtime_terminal_line(stream, text, Some(key.into()));
+        let level = Self::classify_terminal_line_level(&line.stream, line.text.as_str());
+        self.push_persisted_log_line(line, level);
     }
 
     pub fn has_pending_mirrored_trace_logs(&self) -> bool {
@@ -5874,7 +6005,8 @@ impl LogStreamPaneState {
         );
         for (line, entry) in lines.into_iter().zip(content.into_iter()) {
             if !self.rendered_log_content.contains(&entry) {
-                self.push_persisted_log_line(line);
+                let level = Self::classify_terminal_line_level(&line.stream, line.text.as_str());
+                self.push_persisted_log_line(line, level);
                 self.rendered_log_content.push(entry);
             }
         }
@@ -5885,14 +6017,16 @@ impl LogStreamPaneState {
                     TerminalStream::Stdout
                 }
             };
-            self.terminal.push_line(TerminalLine::new(
+            let line = TerminalLine::new(
                 stream,
                 format!(
                     "{}  {}",
                     mission_control_log_timestamp(entry.at_epoch_seconds),
                     entry.line
                 ),
-            ));
+            );
+            let level = Self::tracing_level_to_filter(entry.level);
+            self.push_persisted_log_line(line, level);
             self.last_mirrored_trace_id = entry.id;
         }
     }

--- a/apps/autopilot-desktop/src/input/actions.rs
+++ b/apps/autopilot-desktop/src/input/actions.rs
@@ -10042,6 +10042,17 @@ pub(super) fn run_mission_control_action(
             }
             true
         }
+        MissionControlPaneAction::CycleLogLevelFilter => {
+            let level = state.log_stream.cycle_level_filter();
+            let label = match level {
+                crate::app_state::LogStreamLevelFilter::Debug => "Log stream filter: DEBUG",
+                crate::app_state::LogStreamLevelFilter::Info => "Log stream filter: INFO",
+                crate::app_state::LogStreamLevelFilter::Warn => "Log stream filter: WARN",
+                crate::app_state::LogStreamLevelFilter::Error => "Log stream filter: ERROR",
+            };
+            state.mission_control.record_action(label);
+            true
+        }
         MissionControlPaneAction::SendLightningPayment => {
             let command = match build_pay_invoice_command(
                 PayInvoicePaneAction::SendPayment,

--- a/apps/autopilot-desktop/src/pane_renderer.rs
+++ b/apps/autopilot-desktop/src/pane_renderer.rs
@@ -12,7 +12,7 @@ use crate::app_state::{
     DataBuyerPaneState, DataMarketPaneState, DataSellerPaneState, DesktopPane,
     EarnJobLifecycleProjectionState, EarningsScoreboardState, FrameDebuggerPaneState,
     JobHistoryPaneInputs, JobHistoryState, JobInboxState, JobLifecycleStage,
-    LocalInferencePaneInputs, LocalInferencePaneState, LogStreamPaneState,
+    LocalInferencePaneInputs, LocalInferencePaneState, LogStreamLevelFilter, LogStreamPaneState,
     MissionControlLocalRuntimeLane, MissionControlPaneState, NetworkRequestsPaneInputs,
     NetworkRequestsState, Nip90SentPaymentsPaneState, NostrSecretState, PaneKind, PaneLoadState,
     PanePaintTimingSample, PayInvoicePaneInputs, PresentationPaneState, PresentationRuntimeState,
@@ -55,6 +55,7 @@ use crate::pane_system::{
     mission_control_buy_mode_history_button_bounds_for_panel,
     mission_control_buy_mode_popup_bounds, mission_control_buy_mode_popup_close_button_bounds,
     mission_control_copy_log_stream_button_bounds, mission_control_layout_for_mode,
+    mission_control_log_stream_filter_button_bounds,
     mission_control_load_funds_popup_bounds, mission_control_load_funds_popup_close_button_bounds,
     mission_control_load_funds_popup_layout_with_scroll,
     mission_control_load_funds_popup_scroll_viewport_bounds,
@@ -2716,6 +2717,15 @@ fn paint_go_online_pane(
         log_copy_clicked,
         paint,
     );
+    let filter_bounds = mission_control_log_stream_filter_button_bounds(content_bounds, buy_mode_enabled);
+    let filter_hovered = pointer_in_pane && filter_bounds.contains(cursor_position);
+    let filter_label = match log_stream.active_level_filter().unwrap_or(LogStreamLevelFilter::Info) {
+        LogStreamLevelFilter::Debug => "DBG",
+        LogStreamLevelFilter::Info => "INF",
+        LogStreamLevelFilter::Warn => "WRN",
+        LogStreamLevelFilter::Error => "ERR",
+    };
+    paint_mission_control_log_filter_button(filter_bounds, filter_label, filter_hovered, paint);
     let log_body_bounds = mission_control_section_scroll_viewport_bounds(layout.log_stream);
     paint.scene.draw_quad(
         Quad::new(log_body_bounds)
@@ -3226,6 +3236,12 @@ fn paint_mission_control_alert_band(
         .with_corner_radius(4.0),
     );
     if show_alert {
+        let text_left = bounds.origin.x + 28.0;
+        let legend_max_chars = (((bounds.size.width - 24.0).max(60.0)) / 5.9).floor() as usize;
+        let target_right_x = bounds.origin.x + 16.0 + legend_max_chars as f32 * 5.9;
+        let top_text_width = (target_right_x - text_left).max(24.0);
+        let text_max_chars = ((top_text_width / 6.4).floor() as usize).max(8);
+        let compact_alert_text = mission_control_compact_single_line(alert.text.as_str(), text_max_chars);
         paint.scene.draw_text(paint.text.layout_mono(
             "!",
             Point::new(bounds.origin.x + 12.0, bounds.origin.y + 5.0),
@@ -3233,8 +3249,8 @@ fn paint_mission_control_alert_band(
             accent,
         ));
         paint.scene.draw_text(paint.text.layout_mono(
-            alert.text.as_str(),
-            Point::new(bounds.origin.x + 28.0, bounds.origin.y + 8.0),
+            compact_alert_text.as_str(),
+            Point::new(text_left, bounds.origin.y + 8.0),
             11.0,
             mission_control_text_color(),
         ));
@@ -3278,8 +3294,13 @@ fn paint_mission_control_alert_band(
                 .with_background(accent.with_alpha(0.30)),
         );
     }
-    paint.scene.draw_text(paint.text.layout_mono(
+    let legend_max_chars = (((bounds.size.width - 24.0).max(60.0)) / 5.9).floor() as usize;
+    let compact_legend = mission_control_compact_single_line(
         mission_control_truth_legend(),
+        legend_max_chars.max(10),
+    );
+    paint.scene.draw_text(paint.text.layout_mono(
+        compact_legend.as_str(),
         Point::new(bounds.origin.x + 16.0, bounds.origin.y + 22.0),
         9.0,
         mission_control_muted_color(),
@@ -3288,6 +3309,54 @@ fn paint_mission_control_alert_band(
 
 fn mission_control_truth_legend() -> &'static str {
     "LEGEND // PROV=SELECTED PROVIDER // WORK=MARKET FLOW // PAY=WALLET FLOW // NEXT=EXPECTED EVENT"
+}
+
+fn mission_control_compact_single_line(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let keep = max_chars.saturating_sub(1).max(1);
+    let truncated: String = value.chars().take(keep).collect();
+    format!("{truncated}…")
+}
+
+fn paint_mission_control_log_filter_button(
+    bounds: Bounds,
+    label: &str,
+    hovered: bool,
+    paint: &mut PaintContext,
+) {
+    let accent = mission_control_orange_color();
+    let bg = if hovered {
+        accent.with_alpha(0.16)
+    } else {
+        mission_control_background_color().with_alpha(0.22)
+    };
+    let border = if hovered {
+        accent.with_alpha(0.56)
+    } else {
+        mission_control_muted_color().with_alpha(0.44)
+    };
+    paint.scene.draw_quad(
+        Quad::new(bounds)
+            .with_background(bg)
+            .with_border(border, 1.0)
+            .with_corner_radius(3.0),
+    );
+    let mut label_run = paint.text.layout_mono(
+        label,
+        Point::ZERO,
+        8.0,
+        mission_control_text_color(),
+    );
+    let label_bounds = label_run.bounds();
+    label_run.origin = Point::new(
+        bounds.origin.x + ((bounds.size.width - label_bounds.size.width).max(0.0) * 0.5)
+            - label_bounds.origin.x,
+        bounds.origin.y + ((bounds.size.height - label_bounds.size.height).max(0.0) * 0.5)
+            - label_bounds.origin.y,
+    );
+    paint.scene.draw_text(label_run);
 }
 
 struct MissionControlAlertDescriptor {
@@ -4195,12 +4264,18 @@ fn mission_control_backend_label(
     provider_runtime: &ProviderRuntimeState,
     local_inference_runtime: &LocalInferenceExecutionSnapshot,
 ) -> String {
-    crate::app_state::mission_control_local_runtime_view_model(
+    let backend = crate::app_state::mission_control_local_runtime_view_model(
         desktop_shell_mode,
         provider_runtime,
         local_inference_runtime,
     )
-    .backend_label
+    .backend_label;
+    let normalized = backend.trim().to_ascii_uppercase();
+    if normalized.starts_with("APPLE FM BRIDGE") {
+        "APPLE FM".to_string()
+    } else {
+        backend
+    }
 }
 
 fn mission_control_model_load_status(

--- a/apps/autopilot-desktop/src/pane_system.rs
+++ b/apps/autopilot-desktop/src/pane_system.rs
@@ -468,6 +468,7 @@ pub enum MissionControlPaneAction {
     CreateLightningReceiveTarget,
     CopyLightningReceiveTarget,
     CopyLogStream,
+    CycleLogLevelFilter,
     SendLightningPayment,
     CopySeedPhrase,
     OpenLocalModelWorkbench,
@@ -3462,6 +3463,20 @@ pub fn mission_control_copy_log_stream_button_bounds(
         log_stream.origin.y + 7.0,
         size,
         size,
+    )
+}
+
+pub fn mission_control_log_stream_filter_button_bounds(
+    content_bounds: Bounds,
+    buy_mode_enabled: bool,
+) -> Bounds {
+    let copy_button = mission_control_copy_log_stream_button_bounds(content_bounds, buy_mode_enabled);
+    let button_width = 46.0;
+    Bounds::new(
+        copy_button.origin.x - 8.0 - button_width,
+        copy_button.origin.y - 1.0,
+        button_width,
+        16.0,
     )
 }
 
@@ -7047,6 +7062,13 @@ fn pane_hit_action_for_pane(
             {
                 return Some(PaneHitAction::MissionControl(
                     MissionControlPaneAction::CopyLogStream,
+                ));
+            }
+            if mission_control_log_stream_filter_button_bounds(content_bounds, buy_mode_enabled)
+                .contains(point)
+            {
+                return Some(PaneHitAction::MissionControl(
+                    MissionControlPaneAction::CycleLogLevelFilter,
                 ));
             }
             if mission_control_show_local_model_button(


### PR DESCRIPTION
## Summary
- Normalize Mission Control backend label so Apple FM backend shows as `APPLE FM`
- Fix notification band truncation so top and legend lines truncate cleanly without clipping glyphs
- Replace multi-chip log filter with a single cycling level button in Mission Control Log Stream
- Set default log filter to `INF` and cycle levels as `DBG -> INF -> WRN -> ERR`
- Apply threshold filtering behavior (selected level + higher severities)

## Validation
- cargo check -p autopilot-desktop
