### PR TITLE
Provider Control pane cleanup: button layout and overlap fixes

### DIFF
--- a/apps/autopilot-desktop/src/pane_registry.rs
+++ b/apps/autopilot-desktop/src/pane_registry.rs
@@ -256,7 +256,7 @@ const PANE_SPECS: [PaneSpec; 64] = [
         kind: PaneKind::ProviderControl,
         title: "Provider Control",
         default_width: 760.0,
-        default_height: 520.0,
+        default_height: 600.0,
         singleton: true,
         startup: false,
         command: Some(PaneCommandSpec {

--- a/apps/autopilot-desktop/src/pane_system.rs
+++ b/apps/autopilot-desktop/src/pane_system.rs
@@ -1273,7 +1273,7 @@ fn pane_minimum_size(kind: PaneKind) -> Size {
         | PaneKind::CodexLabs
         | PaneKind::CodexDiagnostics => pane_size_for_content(920.0, 420.0),
         PaneKind::GoOnline => pane_size_for_content(560.0, 300.0),
-        PaneKind::ProviderControl => pane_size_for_content(720.0, 480.0),
+        PaneKind::ProviderControl => pane_size_for_content(760.0, 560.0),
         PaneKind::VoicePlayground => pane_size_for_content(1040.0, 620.0),
         PaneKind::LocalInference => pane_size_for_content(940.0, 520.0),
         PaneKind::PsionicViz => pane_size_for_content(960.0, 600.0),
@@ -2396,39 +2396,45 @@ pub fn chat_transcript_body_bounds_with_height(
 }
 
 pub fn provider_control_toggle_button_bounds(content_bounds: Bounds) -> Bounds {
+    let column_gap = 8.0;
+    let width = ((content_bounds.size.width - 24.0 - column_gap) * 0.5).max(0.0);
     Bounds::new(
         content_bounds.origin.x + 12.0,
         content_bounds.origin.y + 12.0,
-        (content_bounds.size.width - 24.0).max(0.0),
-        34.0,
+        width,
+        22.0,
     )
 }
 
 pub fn provider_control_local_model_button_bounds(content_bounds: Bounds) -> Bounds {
+    let toggle = provider_control_toggle_button_bounds(content_bounds);
+    let width = toggle.size.width;
     Bounds::new(
-        content_bounds.origin.x + 12.0,
-        provider_control_toggle_button_bounds(content_bounds).max_y() + 10.0,
-        (content_bounds.size.width - 24.0).max(0.0),
+        toggle.max_x() + 8.0,
+        toggle.origin.y,
+        width,
         22.0,
     )
 }
 
 pub fn provider_control_local_fm_test_button_bounds(content_bounds: Bounds) -> Bounds {
+    let toggle = provider_control_toggle_button_bounds(content_bounds);
     Bounds::new(
-        content_bounds.origin.x + 12.0,
-        provider_control_local_model_button_bounds(content_bounds).max_y() + 8.0,
-        ((content_bounds.size.width - 28.0) * 0.5).max(0.0),
+        toggle.origin.x,
+        toggle.max_y() + 8.0,
+        toggle.size.width,
         22.0,
     )
 }
 
 pub fn provider_control_training_button_bounds(content_bounds: Bounds) -> Bounds {
+    let local_model = provider_control_local_model_button_bounds(content_bounds);
     let local_fm_test = provider_control_local_fm_test_button_bounds(content_bounds);
     Bounds::new(
-        local_fm_test.max_x() + 4.0,
+        local_model.origin.x,
         local_fm_test.origin.y,
-        (content_bounds.max_x() - 12.0 - (local_fm_test.max_x() + 4.0)).max(0.0),
-        local_fm_test.size.height,
+        local_model.size.width,
+        22.0,
     )
 }
 
@@ -2436,12 +2442,15 @@ pub fn provider_control_inventory_toggle_button_bounds(
     content_bounds: Bounds,
     row_index: usize,
 ) -> Bounds {
+    let toggle = provider_control_toggle_button_bounds(content_bounds);
+    let row = row_index / 2;
+    let column = row_index % 2;
+    let row_origin_y = provider_control_local_fm_test_button_bounds(content_bounds).max_y() + 10.0;
+    let row_step = 26.0;
     Bounds::new(
-        content_bounds.origin.x + 12.0,
-        provider_control_local_fm_test_button_bounds(content_bounds).max_y()
-            + 12.0
-            + row_index as f32 * 30.0,
-        (content_bounds.size.width - 24.0).max(0.0),
+        toggle.origin.x + column as f32 * (toggle.size.width + 8.0),
+        row_origin_y + row as f32 * row_step,
+        toggle.size.width,
         22.0,
     )
 }
@@ -2458,7 +2467,7 @@ pub fn provider_control_scroll_viewport_bounds(content_bounds: Bounds) -> Bounds
         content_bounds.origin.x + 8.0,
         origin_y,
         (content_bounds.size.width - 16.0).max(0.0),
-        (content_bounds.max_y() - 12.0 - origin_y).max(0.0),
+        (content_bounds.max_y() - 34.0 - origin_y).max(0.0),
     )
 }
 

--- a/apps/autopilot-desktop/src/panes/provider_control.rs
+++ b/apps/autopilot-desktop/src/panes/provider_control.rs
@@ -1,5 +1,5 @@
 use wgpui::{
-    Bounds, Component, PaintContext, Point, Quad, RiveFitMode, RiveHandle, RiveSurface, theme,
+    Bounds, PaintContext, Point, Quad, RiveFitMode, RiveHandle, RiveSurface, theme,
 };
 
 use crate::app_state::{
@@ -12,7 +12,7 @@ use crate::app_state::{
 use crate::bitcoin_display::format_sats_amount;
 use crate::local_inference_runtime::LocalInferenceExecutionSnapshot;
 use crate::pane_renderer::{
-    mission_control_blocker_detail, paint_action_button, paint_source_badge, split_text_for_display,
+    mission_control_blocker_detail, paint_action_button, split_text_for_display,
 };
 use crate::pane_system::{
     provider_control_inventory_toggle_button_bounds, provider_control_local_fm_test_button_bounds,
@@ -36,8 +36,6 @@ pub fn paint_provider_control_pane(
     inventory_status: &DesktopControlInventoryStatus,
     paint: &mut PaintContext,
 ) {
-    paint_source_badge(content_bounds, "runtime", paint);
-
     let runtime_view = mission_control_local_runtime_view_model(
         desktop_shell_mode,
         provider_runtime,
@@ -205,9 +203,6 @@ pub fn paint_provider_control_pane(
     paint_provider_control_hud_shell(hud_bounds, paint);
     ensure_provider_control_hud_loaded(provider_control_hud_runtime);
     sync_provider_control_hud_runtime(provider_control_hud_runtime);
-    if let Some(surface) = provider_control_hud_runtime.surface.as_mut() {
-        surface.paint(hud_bounds, paint);
-    }
     paint_provider_control_hud_overlay(
         hud_bounds,
         provider_runtime,
@@ -246,15 +241,6 @@ pub fn paint_provider_control_pane(
     }
     paint.scene.pop_clip();
 
-    let footer_y = viewport.max_y() - 18.0;
-    if footer_y > viewport.origin.y {
-        paint.scene.draw_text(paint.text.layout(
-            "Scroll for runtime detail and advertised inventory",
-            Point::new(content_bounds.origin.x + 12.0, footer_y),
-            10.0,
-            theme::text::MUTED,
-        ));
-    }
 }
 
 fn paint_provider_control_hud_shell(bounds: Bounds, paint: &mut PaintContext) {
@@ -363,7 +349,7 @@ fn paint_provider_control_hud_overlay(
     ));
     paint.scene.draw_text(paint.text.layout(
         runtime_view.model_label.as_str(),
-        Point::new(top_panel.origin.x + 126.0, top_panel.origin.y + 26.0),
+        Point::new(top_panel.origin.x + 168.0, top_panel.origin.y + 26.0),
         11.0,
         theme::text::MUTED,
     ));


### PR DESCRIPTION
## Summary
- Remove overlapping source badge in Provider Control pane header
- Reflow action controls into a smaller two-column layout
- Increase Provider Control default/open height for better bottom section visibility
- Remove overlapping bottom helper text line
- Nudge packaged HUD model label right to avoid overlap with `Sell compute`

## Validation
- cargo check -p autopilot-desktop
