### PR TITLE
Wallet pane: scroll and header cleanup

### DIFF
--- a/apps/autopilot-desktop/src/panes/wallet.rs
+++ b/apps/autopilot-desktop/src/panes/wallet.rs
@@ -28,8 +28,6 @@ pub fn paint_wallet_pane(
     details_scroll_offset: f32,
     paint: &mut PaintContext,
 ) {
-    paint_source_badge(content_bounds, "wallet", paint);
-
     let scroll_content_bounds = spark_pane::scroll_content_bounds(content_bounds);
     let viewport = spark_pane::scroll_viewport_bounds(content_bounds);
     let content_height = spark_wallet_content_height(scroll_content_bounds, spark_wallet);
@@ -91,8 +89,8 @@ pub fn paint_wallet_pane(
         "Refresh state or copy your Spark address.",
         paint,
     );
-    paint_tertiary_button(layout.refresh_button, "Refresh wallet", paint);
-    paint_tertiary_button(layout.copy_spark_address_button, "Copy Spark", paint);
+    paint_secondary_button(layout.refresh_button, "Refresh wallet", paint);
+    paint_secondary_button(layout.copy_spark_address_button, "Copy Spark", paint);
 
     paint_wallet_flow_section(
         layout.receive_section_bounds,
@@ -800,7 +798,7 @@ fn paint_wallet_scrollbar(
     }
     let max_offset = (content_height - viewport.size.height).max(0.0);
     let track_bounds = Bounds::new(
-        viewport.max_x() - 4.0,
+        viewport.max_x() - 2.0,
         viewport.origin.y,
         2.0,
         viewport.size.height,

--- a/apps/autopilot-desktop/src/render.rs
+++ b/apps/autopilot-desktop/src/render.rs
@@ -1552,6 +1552,7 @@ pub fn render_frame(state: &mut RenderState) -> Result<crate::app_state::FrameRe
 
         let mission_control_last_action = state.mission_control.last_action.clone();
         let mission_control_last_error = state.mission_control.last_error.clone();
+        let spark_wallet_scroll_offset = state.spark_wallet_pane.scroll_offset();
         pane_paint_report = PaneRenderer::paint(
             &mut state.panes,
             Bounds::new(0.0, 0.0, width, height),
@@ -1623,7 +1624,7 @@ pub fn render_frame(state: &mut RenderState) -> Result<crate::app_state::FrameRe
             &state.credit_settlement_ledger,
             &state.cad_demo,
             &state.spark_wallet,
-            state.spark_wallet_scroll_offset,
+            spark_wallet_scroll_offset,
             &provider_inventory,
             &mut state.spark_inputs,
             &mut state.pay_invoice_inputs,


### PR DESCRIPTION
Summary
- Fix Wallet pane scrolling by wiring render offset to spark_wallet_pane.scroll_offset
- Remove source wallet badge from Wallet pane header
- Style Wallet Utilities buttons to match receive buttons
- Adjust wallet scrollbar horizontal inset to max_x - 2.0 to avoid border collision

Validation
- cargo check -p autopilot-desktop
