### PR TITLE
Fix Log Stream controls and Mission Control popup z-order

### DIFF
--- a/apps/autopilot-desktop/src/input/actions.rs
+++ b/apps/autopilot-desktop/src/input/actions.rs
@@ -10312,6 +10312,17 @@ pub(super) fn run_log_stream_action(
             }
             true
         }
+        LogStreamPaneAction::CycleLevelFilter => {
+            let level = state.log_stream.cycle_level_filter();
+            let label = match level {
+                crate::app_state::LogStreamLevelFilter::Debug => "Log stream filter: DEBUG",
+                crate::app_state::LogStreamLevelFilter::Info => "Log stream filter: INFO",
+                crate::app_state::LogStreamLevelFilter::Warn => "Log stream filter: WARN",
+                crate::app_state::LogStreamLevelFilter::Error => "Log stream filter: ERROR",
+            };
+            state.mission_control.record_action(label);
+            true
+        }
     }
 }
 

--- a/apps/autopilot-desktop/src/input/tool_bridge.rs
+++ b/apps/autopilot-desktop/src/input/tool_bridge.rs
@@ -4296,6 +4296,9 @@ fn pane_action_to_hit_action(
             "copy" | "copy_all" | "copy_logs" => Ok(PaneHitAction::LogStream(
                 crate::pane_system::LogStreamPaneAction::CopyAll,
             )),
+            "filter" | "cycle_filter" | "cycle_log_filter" => Ok(PaneHitAction::LogStream(
+                crate::pane_system::LogStreamPaneAction::CycleLevelFilter,
+            )),
             _ => unsupported(),
         },
         PaneKind::Nip90SentPayments => match action {

--- a/apps/autopilot-desktop/src/pane_renderer.rs
+++ b/apps/autopilot-desktop/src/pane_renderer.rs
@@ -270,7 +270,7 @@ impl PaneRenderer {
         let mut pane_paint_samples = Vec::with_capacity(panes.len());
         for idx in indices {
             paint.scene.set_layer(next_layer);
-            next_layer = next_layer.saturating_add(1);
+            next_layer = next_layer.saturating_add(2);
 
             let pane = &mut panes[idx];
             let pane_is_active = active_id == Some(pane.id);

--- a/apps/autopilot-desktop/src/pane_system.rs
+++ b/apps/autopilot-desktop/src/pane_system.rs
@@ -456,6 +456,7 @@ pub enum EarningsScoreboardPaneAction {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LogStreamPaneAction {
     CopyAll,
+    CycleLevelFilter,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2477,6 +2478,17 @@ pub fn log_stream_copy_button_bounds(content_bounds: Bounds) -> Bounds {
         content_bounds.origin.y + 8.0,
         108.0,
         22.0,
+    )
+}
+
+pub fn log_stream_filter_button_bounds(content_bounds: Bounds) -> Bounds {
+    let copy_button = log_stream_copy_button_bounds(content_bounds);
+    let button_width = 46.0;
+    Bounds::new(
+        copy_button.origin.x - 8.0 - button_width,
+        copy_button.origin.y,
+        button_width,
+        copy_button.size.height,
     )
 }
 
@@ -6911,6 +6923,10 @@ fn pane_hit_action_for_pane(
         PaneKind::LogStream => {
             if log_stream_copy_button_bounds(content_bounds).contains(point) {
                 Some(PaneHitAction::LogStream(LogStreamPaneAction::CopyAll))
+            } else if log_stream_filter_button_bounds(content_bounds).contains(point) {
+                Some(PaneHitAction::LogStream(
+                    LogStreamPaneAction::CycleLevelFilter,
+                ))
             } else {
                 None
             }
@@ -9638,12 +9654,17 @@ mod tests {
     fn log_stream_copy_button_sits_above_terminal() {
         let content_bounds = Bounds::new(0.0, 0.0, 980.0, 560.0);
         let button = super::log_stream_copy_button_bounds(content_bounds);
+        let filter = super::log_stream_filter_button_bounds(content_bounds);
         let terminal = super::log_stream_terminal_bounds(content_bounds);
 
         assert!(button.origin.x >= content_bounds.origin.x);
         assert!(button.origin.y >= content_bounds.origin.y);
         assert!(button.max_x() <= content_bounds.max_x());
         assert!(button.max_y() <= terminal.origin.y);
+        assert!(filter.origin.x >= content_bounds.origin.x);
+        assert!(filter.origin.y >= content_bounds.origin.y);
+        assert!(filter.max_x() <= button.origin.x);
+        assert!(filter.max_y() <= terminal.origin.y);
     }
 
     #[test]

--- a/apps/autopilot-desktop/src/panes/log_stream.rs
+++ b/apps/autopilot-desktop/src/panes/log_stream.rs
@@ -1,18 +1,33 @@
 use wgpui::{Component, PaintContext, Point, theme};
 
-use crate::app_state::LogStreamPaneState;
-use crate::pane_renderer::{paint_action_button, paint_source_badge};
-use crate::pane_system::{log_stream_copy_button_bounds, log_stream_terminal_bounds};
+use crate::app_state::{LogStreamLevelFilter, LogStreamPaneState};
+use crate::pane_renderer::paint_action_button;
+use crate::pane_system::{
+    log_stream_copy_button_bounds, log_stream_filter_button_bounds, log_stream_terminal_bounds,
+};
 
 pub fn paint(
     content_bounds: wgpui::Bounds,
     pane_state: &mut LogStreamPaneState,
     paint: &mut PaintContext,
 ) {
-    paint_source_badge(content_bounds, "log", paint);
     paint_action_button(
         log_stream_copy_button_bounds(content_bounds),
         "Copy all",
+        paint,
+    );
+    let filter_label = match pane_state
+        .active_level_filter()
+        .unwrap_or(LogStreamLevelFilter::Info)
+    {
+        LogStreamLevelFilter::Debug => "DBG",
+        LogStreamLevelFilter::Info => "INF",
+        LogStreamLevelFilter::Warn => "WRN",
+        LogStreamLevelFilter::Error => "ERR",
+    };
+    paint_action_button(
+        log_stream_filter_button_bounds(content_bounds),
+        filter_label,
         paint,
     );
     paint.scene.draw_text(paint.text.layout(


### PR DESCRIPTION
Summary:
- Add standalone Log Stream level filter cycle button (DBG/INF/WRN/ERR)
- Keep Copy all button and remove source badge in Log Stream pane
- Fix Mission Control popup z-order so popup is above Mission Control but below higher-z panes

Validation:
- cargo check -p autopilot-desktop