### PR TITLE
Add pane search release/experimental cycle filter

### DIFF
--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -15647,6 +15647,7 @@ pub struct RenderState {
     pub onboarding: crate::onboarding::OnboardingState,
     pub command_palette: CommandPalette,
     pub command_palette_actions: Rc<RefCell<Vec<String>>>,
+    pub pane_search_filter: crate::pane_registry::PaneSearchFilter,
 }
 
 impl RenderState {

--- a/apps/autopilot-desktop/src/input.rs
+++ b/apps/autopilot-desktop/src/input.rs
@@ -80,8 +80,9 @@ use crate::pane_system::{
 use crate::panes::{cad as cad_pane, chat as chat_pane};
 use crate::provider_nip90_lane::ProviderNip90LaneCommand;
 use crate::render::{
-    logical_size, pane_fullscreen_active, render_frame, sidebar_go_online_button_bounds,
-    sidebar_handle_bounds, wallet_balance_sats_label_bounds,
+    COMMAND_PALETTE_PANE_FILTER_CYCLE_ACTION, command_registry, logical_size,
+    pane_fullscreen_active, render_frame, sidebar_go_online_button_bounds, sidebar_handle_bounds,
+    wallet_balance_sats_label_bounds,
 };
 use crate::runtime_lanes::{
     AcCreditCommand, RuntimeCommandResponse, RuntimeCommandStatus, RuntimeLane, SaLifecycleCommand,

--- a/apps/autopilot-desktop/src/input/shortcuts.rs
+++ b/apps/autopilot-desktop/src/input/shortcuts.rs
@@ -194,6 +194,12 @@ pub(super) fn toggle_command_palette(state: &mut crate::app_state::RenderState) 
     if state.command_palette.is_open() {
         state.command_palette.close();
     } else {
+        state
+            .command_palette
+            .set_commands(command_registry(state.pane_search_filter));
+        state
+            .command_palette
+            .set_aux_button_label(Some(state.pane_search_filter.button_label()));
         state.command_palette.open();
     }
 }
@@ -292,6 +298,18 @@ pub(super) fn dispatch_command_palette_actions(state: &mut crate::app_state::Ren
 
     let mut changed = false;
     for action in action_ids {
+        if action == COMMAND_PALETTE_PANE_FILTER_CYCLE_ACTION {
+            state.pane_search_filter = state.pane_search_filter.cycle();
+            state
+                .command_palette
+                .set_commands(command_registry(state.pane_search_filter));
+            state
+                .command_palette
+                .set_aux_button_label(Some(state.pane_search_filter.button_label()));
+            changed = true;
+            continue;
+        }
+
         if let Some(cad_action) = crate::pane_system::cad_palette_action_for_command_id(&action) {
             let _ = PaneController::create_for_kind(state, PaneKind::CadDemo);
             changed |= reducers::run_cad_demo_action(state, cad_action);

--- a/apps/autopilot-desktop/src/pane_registry.rs
+++ b/apps/autopilot-desktop/src/pane_registry.rs
@@ -43,6 +43,91 @@ pub struct PaneSpec {
     pub hotbar: Option<PaneHotbarSpec>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PaneSearchTier {
+    Release,
+    Experimental,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PaneSearchFilter {
+    Release,
+    Experimental,
+    All,
+}
+
+impl PaneSearchFilter {
+    pub const fn cycle(self) -> Self {
+        match self {
+            Self::Release => Self::Experimental,
+            Self::Experimental => Self::All,
+            Self::All => Self::Release,
+        }
+    }
+
+    pub const fn button_label(self) -> &'static str {
+        match self {
+            Self::Release => "REL",
+            Self::Experimental => "EXP",
+            Self::All => "ALL",
+        }
+    }
+
+    pub const fn includes(self, tier: PaneSearchTier) -> bool {
+        match self {
+            Self::All => true,
+            Self::Release => matches!(tier, PaneSearchTier::Release),
+            Self::Experimental => matches!(tier, PaneSearchTier::Experimental),
+        }
+    }
+}
+
+pub const fn pane_search_tier(kind: PaneKind) -> PaneSearchTier {
+    match kind {
+        PaneKind::ProjectOps
+        | PaneKind::CodexAccount
+        | PaneKind::CodexModels
+        | PaneKind::CodexConfig
+        | PaneKind::CodexMcp
+        | PaneKind::CodexApps
+        | PaneKind::CodexLabs
+        | PaneKind::CodexDiagnostics
+        | PaneKind::PsionicViz
+        | PaneKind::PsionicRemoteTraining
+        | PaneKind::AttnResLab
+        | PaneKind::TassadarLab
+        | PaneKind::RivePreview
+        | PaneKind::Presentation
+        | PaneKind::FrameDebugger
+        | PaneKind::AppleFmWorkbench
+        | PaneKind::AppleAdapterTraining
+        | PaneKind::NetworkRequests
+        | PaneKind::StarterJobs
+        | PaneKind::ReciprocalLoop
+        | PaneKind::ActivityFeed
+        | PaneKind::AlertsRecovery
+        | PaneKind::Settings
+        | PaneKind::Credentials
+        | PaneKind::AgentProfileState
+        | PaneKind::AgentScheduleTick
+        | PaneKind::TrajectoryAudit
+        | PaneKind::CastControl
+        | PaneKind::SkillRegistry
+        | PaneKind::SkillTrustRevocation
+        | PaneKind::CreditDesk
+        | PaneKind::CreditSettlementLedger
+        | PaneKind::Calculator
+        | PaneKind::CadDemo
+        | PaneKind::BuyerRaceMatrix
+        | PaneKind::SellerEarningsTimeline
+        | PaneKind::SettlementLadder
+        | PaneKind::KeyLedger
+        | PaneKind::SettlementAtlas
+        | PaneKind::RelayChoreography => PaneSearchTier::Experimental,
+        _ => PaneSearchTier::Release,
+    }
+}
+
 pub fn pane_specs() -> &'static [PaneSpec] {
     &PANE_SPECS
 }

--- a/apps/autopilot-desktop/src/render.rs
+++ b/apps/autopilot-desktop/src/render.rs
@@ -27,7 +27,9 @@ use crate::local_inference_runtime::{
     initial_local_inference_runtime_snapshot,
 };
 use crate::nip_sa_wallet_bridge::spark_total_balance_sats;
-use crate::pane_registry::{enabled_pane_specs, startup_pane_kinds};
+use crate::pane_registry::{
+    PaneSearchFilter, enabled_pane_specs, pane_search_tier, startup_pane_kinds,
+};
 use crate::pane_renderer::PaneRenderer;
 use crate::pane_system::{
     PANE_MIN_HEIGHT, PANE_MIN_WIDTH, PaneController, RIGHT_SIDEBAR_ENABLED,
@@ -51,6 +53,7 @@ const SIDEBAR_HANDLE_ICON_TOP_PAD: f32 = 12.0;
 const SIDEBAR_HANDLE_ICON_LEFT_INSET: f32 = 2.0;
 const SIDEBAR_COLLAPSED_RAIL_WIDTH: f32 = 28.0;
 const LOCAL_SIM_RUNTIME_BOOTSTRAP_ENV: &str = "OPENAGENTS_ENABLE_LOCAL_SIMULATION_LANES";
+pub(crate) const COMMAND_PALETTE_PANE_FILTER_CYCLE_ACTION: &str = "pane.search_filter.cycle";
 const BACKDROP_BLUR_SHADER: &str = r#"
 struct BlurUniforms {
     texel_size: vec2<f32>,
@@ -606,13 +609,23 @@ pub fn init_state(
         sync_health.cursor_position = sync_health.last_applied_event_seq;
         sync_health.cursor_target_position = sync_health.last_applied_event_seq;
         let command_palette_actions = Rc::new(RefCell::new(Vec::<String>::new()));
+        let default_pane_search_filter = PaneSearchFilter::Release;
         let mut command_palette = CommandPalette::new()
             .mono(true)
-            .commands(command_registry());
+            .commands(command_registry(default_pane_search_filter))
+            .aux_button_label(default_pane_search_filter.button_label());
         {
             let action_queue = Rc::clone(&command_palette_actions);
             command_palette = command_palette.on_select(move |command| {
                 action_queue.borrow_mut().push(command.id.clone());
+            });
+        }
+        {
+            let action_queue = Rc::clone(&command_palette_actions);
+            command_palette = command_palette.on_aux_button(move || {
+                action_queue
+                    .borrow_mut()
+                    .push(COMMAND_PALETTE_PANE_FILTER_CYCLE_ACTION.to_string());
             });
         }
 
@@ -798,6 +811,7 @@ pub fn init_state(
             onboarding: crate::onboarding::OnboardingState::load_or_default(),
             command_palette,
             command_palette_actions,
+            pane_search_filter: default_pane_search_filter,
         };
         rehydrate_startup_earnings_history(&mut state);
         apply_spacetime_sync_bootstrap(&mut state);
@@ -2067,8 +2081,9 @@ pub fn sidebar_go_online_button_bounds(state: &RenderState) -> Bounds {
     Bounds::new(sidebar_x + 12.0, 72.0, width, 34.0)
 }
 
-fn command_registry() -> Vec<Command> {
+pub(crate) fn command_registry(pane_filter: PaneSearchFilter) -> Vec<Command> {
     let mut commands: Vec<Command> = enabled_pane_specs()
+        .filter(|spec| pane_filter.includes(pane_search_tier(spec.kind)))
         .filter_map(|spec| {
             let command = spec.command?;
             let mut entry = Command::new(command.id, command.label)
@@ -2081,15 +2096,17 @@ fn command_registry() -> Vec<Command> {
         })
         .collect();
 
-    commands.extend(cad_palette_command_specs().iter().map(|spec| {
-        let mut command = Command::new(spec.id, spec.label)
-            .description(spec.description)
-            .category("CAD");
-        if let Some(keys) = spec.keybinding {
-            command = command.keybinding(keys);
-        }
-        command
-    }));
+    if pane_filter.includes(crate::pane_registry::PaneSearchTier::Experimental) {
+        commands.extend(cad_palette_command_specs().iter().map(|spec| {
+            let mut command = Command::new(spec.id, spec.label)
+                .description(spec.description)
+                .category("CAD");
+            if let Some(keys) = spec.keybinding {
+                command = command.keybinding(keys);
+            }
+            command
+        }));
+    }
 
     commands
 }
@@ -2100,18 +2117,22 @@ mod tests {
         command_registry, pane_fullscreen_active_for_panes, wallet_balance_chip_bounds_for_logical,
     };
     use crate::app_state::{DesktopPane, PaneKind, PanePresentation};
-    use crate::pane_registry::{enabled_pane_specs, pane_spec_by_command_id, startup_pane_kinds};
+    use crate::pane_registry::{
+        PaneSearchFilter, enabled_pane_specs, pane_search_tier, pane_spec_by_command_id,
+        startup_pane_kinds,
+    };
     use crate::pane_system::cad_palette_command_specs;
     use std::collections::BTreeSet;
     use wgpui::{Bounds, Size};
 
     #[test]
     fn command_registry_matches_pane_specs() {
-        let commands = command_registry();
+        let commands = command_registry(PaneSearchFilter::All);
         let command_ids: BTreeSet<&str> =
             commands.iter().map(|command| command.id.as_str()).collect();
 
         let pane_command_ids: BTreeSet<&str> = enabled_pane_specs()
+            .filter(|spec| PaneSearchFilter::All.includes(pane_search_tier(spec.kind)))
             .filter_map(|spec| spec.command.map(|command| command.id))
             .collect();
         let cad_command_ids: BTreeSet<&str> = cad_palette_command_specs()
@@ -2138,7 +2159,7 @@ mod tests {
 
     #[test]
     fn command_registry_includes_job_inbox_command() {
-        let commands = command_registry();
+        let commands = command_registry(PaneSearchFilter::All);
         assert!(
             commands
                 .iter()

--- a/crates/wgpui/src/components/hud/command_palette.rs
+++ b/crates/wgpui/src/components/hud/command_palette.rs
@@ -6,6 +6,7 @@ use crate::{Bounds, InputEvent, Point, Quad, theme};
 
 type CommandSelectHandler = Box<dyn FnMut(&Command) + 'static>;
 type CommandCloseHandler = Box<dyn FnMut() + 'static>;
+type CommandAuxButtonHandler = Box<dyn FnMut() + 'static>;
 
 #[derive(Clone, Debug)]
 pub struct Command {
@@ -56,6 +57,8 @@ pub struct CommandPalette {
     mono: bool,
     on_select: Option<CommandSelectHandler>,
     on_close: Option<CommandCloseHandler>,
+    aux_button_label: Option<String>,
+    on_aux_button: Option<CommandAuxButtonHandler>,
 }
 
 impl CommandPalette {
@@ -77,6 +80,8 @@ impl CommandPalette {
             mono: false,
             on_select: None,
             on_close: None,
+            aux_button_label: None,
+            on_aux_button: None,
         }
     }
 
@@ -115,6 +120,23 @@ impl CommandPalette {
         F: FnMut() + 'static,
     {
         self.on_close = Some(Box::new(f));
+        self
+    }
+
+    pub fn aux_button_label(mut self, label: impl Into<String>) -> Self {
+        self.aux_button_label = Some(label.into());
+        self
+    }
+
+    pub fn set_aux_button_label(&mut self, label: Option<&str>) {
+        self.aux_button_label = label.map(ToString::to_string);
+    }
+
+    pub fn on_aux_button<F>(mut self, f: F) -> Self
+    where
+        F: FnMut() + 'static,
+    {
+        self.on_aux_button = Some(Box::new(f));
         self
     }
 
@@ -295,6 +317,19 @@ impl CommandPalette {
         )
     }
 
+    fn aux_button_bounds(&self, palette_bounds: Bounds) -> Option<Bounds> {
+        self.aux_button_label.as_ref()?;
+        let input_height = 48.0;
+        let padding = theme::spacing::XS;
+        let button_size = (input_height - padding * 2.0).max(16.0);
+        Some(Bounds::new(
+            palette_bounds.max_x() - button_size - padding,
+            palette_bounds.origin.y + padding,
+            button_size,
+            button_size,
+        ))
+    }
+
     fn scroll_by_pixels(&mut self, delta_pixels: f32) -> bool {
         if self.filtered_commands.len() <= self.max_visible_items
             || !delta_pixels.is_finite()
@@ -365,13 +400,60 @@ impl Component for CommandPalette {
                 .with_border(theme::border::DEFAULT, 1.0),
         );
 
+        let input_right_inset = self
+            .aux_button_bounds(palette_bounds)
+            .map(|button| (palette_bounds.max_x() - button.origin.x) + padding)
+            .unwrap_or(padding);
         let input_bounds = Bounds::new(
             palette_bounds.origin.x + padding,
             palette_bounds.origin.y + padding,
-            palette_bounds.size.width - padding * 2.0,
+            (palette_bounds.size.width - padding - input_right_inset).max(60.0),
             input_height - padding * 2.0,
         );
         self.search_input.paint(input_bounds, cx);
+
+        if let (Some(button_bounds), Some(label)) = (
+            self.aux_button_bounds(palette_bounds),
+            self.aux_button_label.as_deref(),
+        ) {
+            cx.scene.draw_quad(
+                Quad::new(button_bounds)
+                    .with_background(theme::bg::ELEVATED)
+                    .with_border(theme::border::DEFAULT, 1.0)
+                    .with_corner_radius(4.0),
+            );
+            let label_width = if self.mono {
+                cx.text.measure_styled_mono(
+                    label,
+                    theme::font_size::XS,
+                    FontStyle::default(),
+                )
+            } else {
+                cx.text
+                    .measure_styled(label, theme::font_size::XS, FontStyle::default())
+            };
+            let label_origin = Point::new(
+                button_bounds.origin.x + (button_bounds.size.width - label_width) * 0.5,
+                button_bounds.origin.y + (button_bounds.size.height - theme::font_size::XS) * 0.5,
+            );
+            let label_run = if self.mono {
+                cx.text.layout_styled_mono(
+                    label,
+                    label_origin,
+                    theme::font_size::XS,
+                    theme::text::PRIMARY,
+                    FontStyle::default(),
+                )
+            } else {
+                cx.text.layout_mono(
+                    label,
+                    label_origin,
+                    theme::font_size::XS,
+                    theme::text::PRIMARY,
+                )
+            };
+            cx.scene.draw_text(label_run);
+        }
 
         let visible_end =
             (self.scroll_offset + self.max_visible_items).min(self.filtered_commands.len());
@@ -579,6 +661,15 @@ impl Component for CommandPalette {
                     return EventResult::Handled;
                 }
 
+                if let Some(button_bounds) = self.aux_button_bounds(palette_bounds)
+                    && button_bounds.contains(point)
+                {
+                    if let Some(callback) = &mut self.on_aux_button {
+                        callback();
+                    }
+                    return EventResult::Handled;
+                }
+
                 let visible_end =
                     (self.scroll_offset + self.max_visible_items).min(self.filtered_commands.len());
                 for vis_index in self.scroll_offset..visible_end {
@@ -604,7 +695,13 @@ impl Component for CommandPalette {
         let input_bounds = Bounds::new(
             palette_bounds.origin.x + padding,
             palette_bounds.origin.y + padding,
-            palette_bounds.size.width - padding * 2.0,
+            (palette_bounds.size.width
+                - padding
+                - self
+                    .aux_button_bounds(palette_bounds)
+                    .map(|button| (palette_bounds.max_x() - button.origin.x) + padding)
+                    .unwrap_or(padding))
+            .max(60.0),
             48.0 - padding * 2.0,
         );
 


### PR DESCRIPTION
Summary:
- add a single cycle filter button in pane search: REL -> EXP -> ALL
- default pane search filter to REL on startup
- make release search exclude CAD command entries
- keep CAD pane/actions discoverable in EXP and ALL

Where to set experimental vs release:
- pane tier mapping lives in apps/autopilot-desktop/src/pane_registry.rs
- update pane_search_tier(kind: PaneKind) to classify pane kinds as Experimental or Release
- anything not explicitly listed as Experimental defaults to Release

How pane search filtering works:
- pane commands are filtered in apps/autopilot-desktop/src/render.rs inside command_registry(pane_filter)
- CAD command-palette actions are only included when filter includes Experimental
- command palette filter state is stored on RenderState in apps/autopilot-desktop/src/app_state.rs (pane_search_filter)
- cycling behavior is handled in apps/autopilot-desktop/src/input/shortcuts.rs via pane.search_filter.cycle

UI details:
- added a single square cycle button to command palette in crates/wgpui/src/components/hud/command_palette.rs
- button label reflects current mode (REL/EXP/ALL) and is clickable

Validation:
- cargo check -p autopilot-desktop