### PR TITLE
Fix Mission Control and wallet sats input key routing

### DIFF
--- a/apps/autopilot-desktop/src/input.rs
+++ b/apps/autopilot-desktop/src/input.rs
@@ -533,15 +533,17 @@ pub fn handle_window_event(app: &mut App, event_loop: &ActiveEventLoop, event: W
                 return;
             }
 
-            let chat_key_handled = map_winit_key(&event.logical_key).is_some_and(|key| {
-                dispatch_chat_input_event(
-                    state,
-                    &InputEvent::KeyDown {
-                        key,
-                        modifiers: state.input_modifiers,
-                    },
-                )
-            });
+            let route_key_to_chat = !non_chat_text_input_focused(state);
+            let chat_key_handled = route_key_to_chat
+                && map_winit_key(&event.logical_key).is_some_and(|key| {
+                    dispatch_chat_input_event(
+                        state,
+                        &InputEvent::KeyDown {
+                            key,
+                            modifiers: state.input_modifiers,
+                        },
+                    )
+                });
 
             if chat_key_handled
                 || dispatch_keyboard_submit_actions(state, &event.logical_key)
@@ -4054,6 +4056,9 @@ fn handle_chat_keyboard_input(
     state: &mut crate::app_state::RenderState,
     logical_key: &WinitLogicalKey,
 ) -> bool {
+    if non_chat_text_input_focused(state) {
+        return false;
+    }
     if (state.chat_inputs.composer.is_focused() || state.chat_inputs.thread_search.is_focused())
         && is_chat_terminal_shortcut(logical_key, state.input_modifiers)
     {

--- a/apps/autopilot-desktop/src/input/shortcuts.rs
+++ b/apps/autopilot-desktop/src/input/shortcuts.rs
@@ -98,6 +98,21 @@ pub(super) fn any_text_input_focused(state: &crate::app_state::RenderState) -> b
         || state.job_history_inputs.search_job_id.is_focused()
 }
 
+pub(super) fn non_chat_text_input_focused(state: &crate::app_state::RenderState) -> bool {
+    state.calculator_inputs.expression.is_focused()
+        || spark_inputs_focused(state)
+        || mission_control_inputs_focused(state)
+        || pay_invoice_inputs_focused(state)
+        || create_invoice_inputs_focused(state)
+        || network_requests_inputs_focused(state)
+        || local_inference_inputs_focused(state)
+        || apple_fm_workbench_inputs_focused(state)
+        || settings_inputs_focused(state)
+        || credentials_inputs_focused(state)
+        || state.relay_connections_inputs.relay_url.is_focused()
+        || state.job_history_inputs.search_job_id.is_focused()
+}
+
 pub(super) fn blur_non_chat_text_inputs(state: &mut crate::app_state::RenderState) {
     state.calculator_inputs.expression.blur();
     state.spark_inputs.invoice_amount.blur();


### PR DESCRIPTION
## Summary
- route keydown events to chat only when no non-chat text input is currently focused
- prevent chat keyboard submit handling from activating while non-chat inputs are focused
- add explicit non-chat focus detection used by global keyboard routing

## Problem
Clicking sats inputs in Wallet / Mission Control showed a caret, but typing still went into chat because chat key handling executed first when chat remained focused.

## Validation
- cargo check -p autopilot-desktop