### PR TITLE
Refine wallet receive/send UX and copy flows

### DIFF
--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -423,14 +423,17 @@ impl Default for SparkPaneInputs {
             invoice_amount: wallet_text_input(
                 TextInput::new()
                     .value("1000")
-                    .placeholder("Lightning invoice sats"),
-            ),
+                    .placeholder("1000"),
+            )
+            .padding(36.0, 6.0),
             send_request: wallet_text_input(
                 TextInput::new()
-                    .placeholder("Lightning invoice / payment request")
+                    .placeholder("Lightning invoice / payment request (ln...)")
                     .mono(true),
             ),
-            send_amount: wallet_text_input(TextInput::new().placeholder("Send sats (optional)")),
+            send_amount: wallet_text_input(
+                TextInput::new().placeholder("Amount sats (optional)"),
+            ),
             identity_path: wallet_text_input(
                 TextInput::new()
                     .placeholder("Wallet seed path (identity mnemonic)")
@@ -452,9 +455,11 @@ impl Default for PayInvoicePaneInputs {
     fn default() -> Self {
         Self {
             payment_request: wallet_text_input(
-                TextInput::new().placeholder("Lightning invoice / payment request"),
+                TextInput::new().placeholder("Lightning invoice / payment request (ln...)"),
             ),
-            amount_sats: wallet_text_input(TextInput::new().placeholder("Send sats (optional)")),
+            amount_sats: wallet_text_input(
+                TextInput::new().placeholder("Amount sats (optional)"),
+            ),
         }
     }
 }

--- a/apps/autopilot-desktop/src/input/actions.rs
+++ b/apps/autopilot-desktop/src/input/actions.rs
@@ -14764,6 +14764,42 @@ pub(super) fn run_spark_action(
         return true;
     }
 
+    if action == SparkPaneAction::CopyBitcoinAddress {
+        state.spark_wallet.last_error = None;
+        let notice = match state.spark_wallet.bitcoin_address.as_deref() {
+            Some(address) if !address.trim().is_empty() => match copy_to_clipboard(address) {
+                Ok(()) => "Copied Bitcoin address to clipboard".to_string(),
+                Err(error) => format!("Failed to copy Bitcoin address: {error}"),
+            },
+            _ => "No Bitcoin address available yet. Generate one first.".to_string(),
+        };
+
+        if notice.starts_with("Failed") || notice.starts_with("No Bitcoin address available") {
+            state.spark_wallet.last_error = Some(notice);
+        } else {
+            state.spark_wallet.last_action = Some(notice);
+        }
+        return true;
+    }
+
+    if action == SparkPaneAction::CopyInvoice {
+        state.spark_wallet.last_error = None;
+        let notice = match state.spark_wallet.last_invoice.as_deref() {
+            Some(invoice) if !invoice.trim().is_empty() => match copy_to_clipboard(invoice) {
+                Ok(()) => "Copied Lightning invoice to clipboard".to_string(),
+                Err(error) => format!("Failed to copy Lightning invoice: {error}"),
+            },
+            _ => "No Lightning invoice generated yet. Create one first.".to_string(),
+        };
+
+        if notice.starts_with("Failed") || notice.starts_with("No Lightning invoice generated") {
+            state.spark_wallet.last_error = Some(notice);
+        } else {
+            state.spark_wallet.last_action = Some(notice);
+        }
+        return true;
+    }
+
     let command = match build_spark_command_for_action(
         action,
         state.spark_inputs.identity_path.get_value(),
@@ -14873,11 +14909,17 @@ pub(super) fn build_spark_command_for_action(
         SparkPaneAction::CopySparkAddress => {
             Err("Copy Spark address action is handled directly in UI".to_string())
         }
+        SparkPaneAction::CopyBitcoinAddress => {
+            Err("Copy Bitcoin address action is handled directly in UI".to_string())
+        }
         SparkPaneAction::CreateInvoice => Ok(SparkWalletCommand::CreateBolt11Invoice {
             amount_sats: parse_positive_amount_str(invoice_amount, "Invoice amount")?,
             description: Some("OpenAgents Lightning receive".to_string()),
             expiry_seconds: Some(3600),
         }),
+        SparkPaneAction::CopyInvoice => {
+            Err("Copy Lightning invoice action is handled directly in UI".to_string())
+        }
         SparkPaneAction::SendPayment => {
             let request = validate_lightning_payment_request(send_request)?;
             let amount = resolve_lightning_send_amount(send_amount, &request)?;
@@ -14945,6 +14987,12 @@ fn resolve_lightning_send_amount(
             Ok(None)
         }
     } else {
+        if !lightning_invoice_requires_amount(payment_request) {
+            return Err(
+                "Amount is already embedded in this invoice. Clear the amount field and try again."
+                    .to_string(),
+            );
+        }
         Ok(Some(parse_positive_amount_str(amount_sats, "Send amount")?))
     }
 }

--- a/apps/autopilot-desktop/src/input/tool_bridge.rs
+++ b/apps/autopilot-desktop/src/input/tool_bridge.rs
@@ -4899,11 +4899,16 @@ fn pane_action_to_hit_action(
             "generate_spark_address" => {
                 Ok(PaneHitAction::Spark(SparkPaneAction::GenerateSparkAddress))
             }
+            "copy_spark_address" => Ok(PaneHitAction::Spark(SparkPaneAction::CopySparkAddress)),
+            "copy_bitcoin_address" => {
+                Ok(PaneHitAction::Spark(SparkPaneAction::CopyBitcoinAddress))
+            }
             "generate_bitcoin_address" => Ok(PaneHitAction::Spark(
                 SparkPaneAction::GenerateBitcoinAddress,
             )),
             "create_new_wallet" => Ok(PaneHitAction::Spark(SparkPaneAction::CreateNewWallet)),
             "create_invoice" => Ok(PaneHitAction::Spark(SparkPaneAction::CreateInvoice)),
+            "copy_invoice" => Ok(PaneHitAction::Spark(SparkPaneAction::CopyInvoice)),
             "send_payment" => Ok(PaneHitAction::Spark(SparkPaneAction::SendPayment)),
             _ => unsupported(),
         },

--- a/apps/autopilot-desktop/src/panes/wallet.rs
+++ b/apps/autopilot-desktop/src/panes/wallet.rs
@@ -18,6 +18,7 @@ const WALLET_PANEL_RADIUS: f32 = 3.0;
 const WALLET_CARD_RADIUS: f32 = 3.0;
 const WALLET_DATA_LABEL_COLUMN_WIDTH: f32 = 164.0;
 const WALLET_DATA_VALUE_GAP: f32 = 8.0;
+const WALLET_DATA_VALUE_RIGHT_PADDING: f32 = 18.0;
 
 pub fn wallet_details_scroll_bounds(content_bounds: Bounds) -> Bounds {
     spark_pane::scroll_viewport_bounds(content_bounds)
@@ -166,7 +167,7 @@ pub fn paint_wallet_pane(
 
     let mut y = layout.details_origin.y;
     let row_x = details_section_bounds.origin.x + 12.0;
-    let row_width = (details_section_bounds.size.width - 24.0).max(180.0);
+    let row_width = (details_section_bounds.size.width - 32.0).max(180.0);
     let row_chunk_len = wallet_data_value_chunk_len(row_width);
     if state == PaneLoadState::Loading {
         paint.scene.draw_text(paint.text.layout(
@@ -784,7 +785,7 @@ fn wallet_supporting_details_height(
     spark_wallet: &SparkPaneState,
     state: PaneLoadState,
 ) -> f32 {
-    let row_width = (section_width - 24.0).max(180.0);
+    let row_width = (section_width - 32.0).max(180.0);
     let row_chunk_len = wallet_data_value_chunk_len(row_width);
     let mut height = 48.0;
     if state == PaneLoadState::Loading {
@@ -870,7 +871,7 @@ fn wallet_supporting_details_height(
     if !spark_wallet.recent_payments.is_empty() {
         height += 16.0 + spark_wallet.recent_payments.iter().take(6).count() as f32 * 14.0;
     }
-    height + 12.0
+    height + 4.0
 }
 
 fn spark_wallet_content_height(content_bounds: Bounds, spark_wallet: &SparkPaneState) -> f32 {
@@ -891,7 +892,12 @@ fn wallet_data_row_height(value: &str, value_chunk_len: usize) -> f32 {
 }
 
 fn wallet_data_value_chunk_len(row_width: f32) -> usize {
-    (((row_width - (WALLET_DATA_LABEL_COLUMN_WIDTH + WALLET_DATA_VALUE_GAP)).max(120.0)) / 6.2)
+    (((row_width
+        - (WALLET_DATA_LABEL_COLUMN_WIDTH
+            + WALLET_DATA_VALUE_GAP
+            + WALLET_DATA_VALUE_RIGHT_PADDING))
+    .max(120.0))
+        / 6.2)
         .floor() as usize
 }
 

--- a/apps/autopilot-desktop/src/panes/wallet.rs
+++ b/apps/autopilot-desktop/src/panes/wallet.rs
@@ -16,6 +16,8 @@ use crate::ui_style::AppTextRole;
 
 const WALLET_PANEL_RADIUS: f32 = 3.0;
 const WALLET_CARD_RADIUS: f32 = 3.0;
+const WALLET_DATA_LABEL_COLUMN_WIDTH: f32 = 164.0;
+const WALLET_DATA_VALUE_GAP: f32 = 8.0;
 
 pub fn wallet_details_scroll_bounds(content_bounds: Bounds) -> Bounds {
     spark_pane::scroll_viewport_bounds(content_bounds)
@@ -165,7 +167,7 @@ pub fn paint_wallet_pane(
     let mut y = layout.details_origin.y;
     let row_x = details_section_bounds.origin.x + 12.0;
     let row_width = (details_section_bounds.size.width - 24.0).max(180.0);
-    let row_chunk_len = (((row_width - 130.0).max(120.0)) / 6.2).floor() as usize;
+    let row_chunk_len = wallet_data_value_chunk_len(row_width);
     if state == PaneLoadState::Loading {
         paint.scene.draw_text(paint.text.layout(
             "Waiting for first refresh to hydrate balance and payment history.",
@@ -269,7 +271,7 @@ pub fn paint_wallet_pane(
             paint,
             row_x,
             y,
-            "Wallet fingerprint",
+            "Fingerprint",
             fingerprint.as_str(),
             row_chunk_len,
             row_width,
@@ -783,7 +785,7 @@ fn wallet_supporting_details_height(
     state: PaneLoadState,
 ) -> f32 {
     let row_width = (section_width - 24.0).max(180.0);
-    let row_chunk_len = (((row_width - 130.0).max(120.0)) / 6.2).floor() as usize;
+    let row_chunk_len = wallet_data_value_chunk_len(row_width);
     let mut height = 48.0;
     if state == PaneLoadState::Loading {
         height += 16.0;
@@ -888,6 +890,11 @@ fn wallet_data_row_height(value: &str, value_chunk_len: usize) -> f32 {
     split_text_for_display(value, value_chunk_len.max(1)).len() as f32 * 18.0 + 13.0
 }
 
+fn wallet_data_value_chunk_len(row_width: f32) -> usize {
+    (((row_width - (WALLET_DATA_LABEL_COLUMN_WIDTH + WALLET_DATA_VALUE_GAP)).max(120.0)) / 6.2)
+        .floor() as usize
+}
+
 fn paint_wallet_scrollbar(
     viewport: Bounds,
     content_height: f32,
@@ -938,7 +945,7 @@ fn paint_wallet_data_row(
 ) -> f32 {
     let label_style = app_text_style(AppTextRole::FormLabel);
     let value_style = app_text_style(AppTextRole::FormValue);
-    let label_column_width = 122.0;
+    let label_column_width = WALLET_DATA_LABEL_COLUMN_WIDTH;
     let mut line_y = y;
     paint.scene.draw_text(paint.text.layout_mono(
         &format!("{label}:"),
@@ -950,7 +957,7 @@ fn paint_wallet_data_row(
     for chunk in split_text_for_display(value, value_chunk_len.max(1)) {
         paint.scene.draw_text(paint.text.layout_mono(
             &chunk,
-            Point::new(x + label_column_width, line_y),
+            Point::new(x + label_column_width + WALLET_DATA_VALUE_GAP, line_y),
             value_style.font_size,
             value_color,
         ));
@@ -1511,7 +1518,7 @@ fn pay_invoice_content_height(content_bounds: Bounds, spark_wallet: &SparkPaneSt
     let layout = spark_pane::pay_invoice_layout_with_scroll(content_bounds, 0.0);
     let mut height = (layout.details_origin.y - content_bounds.origin.y).max(0.0);
     let row_width = (content_bounds.size.width - 48.0).max(180.0);
-    let row_chunk_len = ((row_width - 122.0) / 6.1).max(18.0) as usize;
+    let row_chunk_len = wallet_data_value_chunk_len(row_width).max(18);
 
     height += 34.0 + 8.0;
     if pay_invoice_view_state(spark_wallet) == PaneLoadState::Loading {

--- a/apps/autopilot-desktop/src/panes/wallet.rs
+++ b/apps/autopilot-desktop/src/panes/wallet.rs
@@ -12,13 +12,14 @@ use crate::pane_renderer::{
 use crate::pane_system::pane_content_bounds;
 use crate::spark_pane;
 use crate::spark_wallet::SparkPaneState;
-use crate::ui_style::AppTextRole;
+use crate::ui_style::{AppButtonRole, AppTextRole};
 
 const WALLET_PANEL_RADIUS: f32 = 3.0;
 const WALLET_CARD_RADIUS: f32 = 3.0;
 const WALLET_DATA_LABEL_COLUMN_WIDTH: f32 = 164.0;
 const WALLET_DATA_VALUE_GAP: f32 = 8.0;
-const WALLET_DATA_VALUE_RIGHT_PADDING: f32 = 18.0;
+const WALLET_DATA_VALUE_RIGHT_PADDING: f32 = 28.0;
+const WALLET_SUPPORTING_DETAILS_BOTTOM_PADDING: f32 = 12.0;
 
 pub fn wallet_details_scroll_bounds(content_bounds: Bounds) -> Bounds {
     spark_pane::scroll_viewport_bounds(content_bounds)
@@ -82,33 +83,60 @@ pub fn paint_wallet_pane(
         paint,
     );
 
-    let label_style = app_text_style(AppTextRole::FormLabel);
     paint_wallet_utility_section(
         layout.utility_section_bounds,
         "Wallet utilities",
-        "Refresh state or copy your Spark address.",
+        "Refresh wallet state before running receive or send actions.",
         paint,
     );
-    paint_secondary_button(layout.refresh_button, "Refresh wallet", paint);
-    paint_secondary_button(layout.copy_spark_address_button, "Copy Spark", paint);
+    paint_secondary_button(layout.refresh_button, "Refresh Wallet", paint);
 
     paint_wallet_flow_section(
         layout.receive_section_bounds,
         "Receive",
-        "Create or refresh addresses, then generate a Lightning invoice.",
+        "Generate receive targets and copy each value directly from its output row.",
         paint,
     );
-    paint_secondary_button(layout.spark_address_button, "Spark receive", paint);
-    paint_secondary_button(layout.bitcoin_address_button, "Bitcoin receive", paint);
-    paint_primary_button(layout.create_invoice_button, "Create Lightning", paint);
+    paint_secondary_button(layout.spark_address_button, "Generate Spark Address", paint);
+    paint_wallet_receive_value_row(
+        layout.spark_address_value,
+        spark_wallet
+            .spark_address
+            .as_deref()
+            .unwrap_or("No Spark address yet. Generate one first."),
+        paint,
+    );
+    paint_wallet_copy_icon_button(layout.copy_spark_address_button, paint);
+
+    paint_secondary_button(layout.bitcoin_address_button, "Generate Bitcoin Address", paint);
+    paint_wallet_receive_value_row(
+        layout.bitcoin_address_value,
+        spark_wallet
+            .bitcoin_address
+            .as_deref()
+            .unwrap_or("No Bitcoin address yet. Generate one first."),
+        paint,
+    );
+    paint_wallet_copy_icon_button(layout.copy_bitcoin_address_button, paint);
+
+    paint_wallet_solid_blue_button(layout.create_invoice_button, "Create Lightning Invoice", paint);
+    paint_wallet_receive_value_row(
+        layout.invoice_value,
+        spark_wallet
+            .last_invoice
+            .as_deref()
+            .unwrap_or("No Lightning invoice yet. Create one first."),
+        paint,
+    );
+    paint_wallet_copy_icon_button(layout.copy_invoice_button, paint);
 
     paint_wallet_flow_section(
         layout.send_section_bounds,
         "Send",
-        "Paste a request or invoice, then optionally set the sats to send.",
+        "Paste a Lightning request (ln...). Amount is required only for zero-amount invoices. On-chain addresses are not supported here.",
         paint,
     );
-    paint_primary_button(layout.send_payment_button, "Send payment", paint);
+    paint_wallet_solid_blue_button(layout.send_payment_button, "Send Payment", paint);
     let details_section_bounds = Bounds::new(
         layout.details_section_bounds.origin.x,
         layout.details_section_bounds.origin.y,
@@ -146,28 +174,19 @@ pub fn paint_wallet_pane(
         .send_amount
         .paint(layout.send_amount_input, paint);
 
-    paint_wallet_input_label(
-        paint,
-        layout.invoice_amount_input,
-        "Lightning invoice sats",
-        label_style,
-    );
-    paint_wallet_input_label(
-        paint,
-        layout.send_request_input,
-        "Send request / invoice",
-        label_style,
-    );
-    paint_wallet_input_label(
-        paint,
-        layout.send_amount_input,
-        "Send sats (optional)",
-        label_style,
-    );
+    paint.scene.draw_text(paint.text.layout_mono(
+        "₿",
+        Point::new(
+            layout.invoice_amount_input.origin.x + 11.0,
+            layout.invoice_amount_input.origin.y + 9.0,
+        ),
+        10.0,
+        app_text_style(AppTextRole::Helper).color.with_alpha(0.76),
+    ));
 
     let mut y = layout.details_origin.y;
     let row_x = details_section_bounds.origin.x + 12.0;
-    let row_width = (details_section_bounds.size.width - 32.0).max(180.0);
+    let row_width = (details_section_bounds.size.width - 40.0).max(180.0);
     let row_chunk_len = wallet_data_value_chunk_len(row_width);
     if state == PaneLoadState::Loading {
         paint.scene.draw_text(paint.text.layout(
@@ -457,6 +476,7 @@ fn paint_wallet_overview(
     connection: &str,
     paint: &mut PaintContext,
 ) {
+    const OVERVIEW_CONTENT_TOP_PADDING: f32 = 6.0;
     paint_wallet_panel_shell(bounds, state_color, 0.18, true, paint);
     paint_wallet_panel_heading(bounds, "WALLET OVERVIEW", state_color, true, paint);
 
@@ -464,7 +484,7 @@ fn paint_wallet_overview(
     let section_style = app_text_style(AppTextRole::SectionHeading);
     let value_style = app_text_style(AppTextRole::FormValue);
     let balance_x = bounds.origin.x + 18.0;
-    let balance_y = bounds.origin.y + 24.0;
+    let balance_y = bounds.origin.y + 24.0 + OVERVIEW_CONTENT_TOP_PADDING;
     let status_chip = Bounds::new(balance_x, balance_y - 2.0, 164.0, 24.0);
     paint.scene.draw_quad(
         Quad::new(status_chip)
@@ -491,13 +511,23 @@ fn paint_wallet_overview(
         section_style.font_size,
         helper_style.color.with_alpha(0.74),
     ));
-    paint.scene.draw_text(paint.text.layout_mono(
+    let balance_value_font_size = (value_style.font_size + 16.0).max(30.0);
+    let balance_value_run = paint.text.layout_mono(
         balance_sats,
-        Point::new(balance_x, balance_y + 70.0),
-        (value_style.font_size + 16.0).max(30.0),
+        Point::new(balance_x, balance_y + 62.0),
+        balance_value_font_size,
         value_style.color,
-    ));
-    let pending_chip = Bounds::new(balance_x + 118.0, balance_y + 60.0, 122.0, 22.0);
+    );
+    let balance_value_width = balance_value_run.bounds().size.width;
+    paint.scene.draw_text(balance_value_run);
+    let card_width = 186.0;
+    let card_height = 34.0;
+    let right_x = bounds.origin.x + bounds.size.width - card_width - 18.0;
+    let pending_width = 122.0;
+    let pending_x_min = balance_x + 118.0;
+    let pending_x_max = right_x - pending_width - 10.0;
+    let pending_x = (balance_x + balance_value_width + 16.0).clamp(pending_x_min, pending_x_max);
+    let pending_chip = Bounds::new(pending_x, balance_y + 58.0, pending_width, 22.0);
     paint.scene.draw_quad(
         Quad::new(pending_chip)
             .with_background(theme::bg::SURFACE.with_alpha(0.18))
@@ -511,9 +541,6 @@ fn paint_wallet_overview(
         helper_style.color.with_alpha(0.76),
     ));
 
-    let card_width = 186.0;
-    let card_height = 34.0;
-    let right_x = bounds.origin.x + bounds.size.width - card_width - 18.0;
     let network_bounds = Bounds::new(right_x, balance_y + 2.0, card_width, card_height);
     let connection_bounds = Bounds::new(right_x, balance_y + 44.0, card_width, card_height);
     paint_wallet_summary_card(
@@ -645,16 +672,22 @@ fn paint_wallet_panel_shell(
     show_left_rail: bool,
     paint: &mut PaintContext,
 ) {
+    let base_border = theme::border::DEFAULT.with_alpha(0.16);
     paint.scene.draw_quad(
         Quad::new(bounds)
             .with_background(theme::bg::SURFACE.with_alpha(background_alpha))
-            .with_border(accent.with_alpha(0.52), 1.0)
+            .with_border(base_border, 1.0)
             .with_corner_radius(WALLET_PANEL_RADIUS),
     );
+    // Keep a slightly brighter top edge while side/bottom borders stay dim.
     paint.scene.draw_quad(
-        Quad::new(bounds)
-            .with_border(accent.with_alpha(0.06), 1.0)
-            .with_corner_radius(WALLET_PANEL_RADIUS),
+        Quad::new(Bounds::new(
+            bounds.origin.x,
+            bounds.origin.y,
+            bounds.size.width.max(0.0),
+            1.0,
+        ))
+        .with_background(accent.with_alpha(0.24)),
     );
     if show_left_rail {
         paint.scene.draw_quad(
@@ -785,7 +818,7 @@ fn wallet_supporting_details_height(
     spark_wallet: &SparkPaneState,
     state: PaneLoadState,
 ) -> f32 {
-    let row_width = (section_width - 32.0).max(180.0);
+    let row_width = (section_width - 40.0).max(180.0);
     let row_chunk_len = wallet_data_value_chunk_len(row_width);
     let mut height = 48.0;
     if state == PaneLoadState::Loading {
@@ -871,7 +904,7 @@ fn wallet_supporting_details_height(
     if !spark_wallet.recent_payments.is_empty() {
         height += 16.0 + spark_wallet.recent_payments.iter().take(6).count() as f32 * 14.0;
     }
-    height + 4.0
+    height + WALLET_SUPPORTING_DETAILS_BOTTOM_PADDING
 }
 
 fn spark_wallet_content_height(content_bounds: Bounds, spark_wallet: &SparkPaneState) -> f32 {
@@ -882,7 +915,8 @@ fn spark_wallet_content_height(content_bounds: Bounds, spark_wallet: &SparkPaneS
         spark_wallet,
         state,
     );
-    let content_top = content_bounds.origin.y + 12.0;
+    let viewport = spark_pane::scroll_viewport_bounds(content_bounds);
+    let content_top = viewport.origin.y;
     let content_bottom = layout.details_section_bounds.origin.y + details_height;
     (content_bottom - content_top).max(0.0)
 }
@@ -892,13 +926,12 @@ fn wallet_data_row_height(value: &str, value_chunk_len: usize) -> f32 {
 }
 
 fn wallet_data_value_chunk_len(row_width: f32) -> usize {
-    (((row_width
-        - (WALLET_DATA_LABEL_COLUMN_WIDTH
-            + WALLET_DATA_VALUE_GAP
-            + WALLET_DATA_VALUE_RIGHT_PADDING))
-    .max(120.0))
-        / 6.2)
-        .floor() as usize
+    let available_width = (row_width
+        - (WALLET_DATA_LABEL_COLUMN_WIDTH + WALLET_DATA_VALUE_GAP + WALLET_DATA_VALUE_RIGHT_PADDING))
+    .max(48.0);
+    let value_font_size = app_text_style(AppTextRole::FormValue).font_size;
+    let estimated_char_width = (value_font_size * 0.66).max(1.0);
+    (available_width / estimated_char_width).floor().max(1.0) as usize
 }
 
 fn paint_wallet_scrollbar(
@@ -975,6 +1008,70 @@ fn paint_wallet_data_row(
             .with_background(theme::border::DEFAULT.with_alpha(0.08)),
     );
     divider_y + 11.0
+}
+
+fn paint_wallet_solid_blue_button(bounds: Bounds, label: &str, paint: &mut PaintContext) {
+    let background = Hsla::from_hex(crate::ui_style::button::PRIMARY_BORDER);
+    let border = Hsla::from_hex(crate::ui_style::button::PRIMARY_BORDER);
+    let text_color = Hsla::from_hex(0xFFFFFF);
+    paint.scene.draw_quad(
+        Quad::new(bounds)
+            .with_background(background)
+            .with_border(border, 1.0)
+            .with_corner_radius(crate::ui_style::button::SECONDARY_CORNER_RADIUS),
+    );
+    let font_size = crate::ui_style::button::label_font_size(AppButtonRole::Secondary);
+    let text = paint
+        .text
+        .layout_mono(label, Point::new(0.0, 0.0), font_size, text_color);
+    let text_bounds = text.bounds();
+    let text_x = bounds.origin.x + (bounds.size.width - text_bounds.size.width).max(0.0) * 0.5;
+    let text_y = bounds.origin.y + (bounds.size.height - text_bounds.size.height).max(0.0) * 0.5;
+    paint.scene.draw_text(
+        paint.text
+            .layout_mono(label, Point::new(text_x, text_y), font_size, text_color),
+    );
+}
+
+fn paint_wallet_receive_value_row(bounds: Bounds, value: &str, paint: &mut PaintContext) {
+    paint.scene.draw_quad(
+        Quad::new(bounds)
+            .with_background(theme::bg::SURFACE.with_alpha(0.30))
+            .with_border(theme::border::DEFAULT.with_alpha(0.18), 1.0)
+            .with_corner_radius(WALLET_CARD_RADIUS),
+    );
+    let max_chars = ((bounds.size.width - 14.0).max(40.0) / 6.0).floor() as usize;
+    let lines = split_text_for_display(value, max_chars.max(16));
+    let mut y = bounds.origin.y + 7.0;
+    let max_lines = if bounds.size.height >= 50.0 { 3 } else { 2 };
+    for line in lines.iter().take(max_lines) {
+        paint.scene.draw_text(paint.text.layout_mono(
+            line,
+            Point::new(bounds.origin.x + 7.0, y),
+            10.0,
+            theme::text::PRIMARY.with_alpha(0.92),
+        ));
+        y += 14.0;
+    }
+}
+
+fn paint_wallet_copy_icon_button(bounds: Bounds, paint: &mut PaintContext) {
+    paint.scene.draw_quad(
+        Quad::new(bounds)
+            .with_background(theme::bg::SURFACE.with_alpha(0.36))
+            .with_border(theme::border::DEFAULT.with_alpha(0.24), 1.0)
+            .with_corner_radius(WALLET_CARD_RADIUS),
+    );
+    let stroke = app_text_style(AppTextRole::FormValue).color.with_alpha(0.86);
+    let back = Bounds::new(
+        bounds.origin.x + 8.0,
+        bounds.origin.y + 9.0,
+        (bounds.size.width - 16.0).max(6.0),
+        (bounds.size.height - 16.0).max(6.0),
+    );
+    let front = Bounds::new(back.origin.x - 3.0, back.origin.y - 3.0, back.size.width, back.size.height);
+    paint.scene.draw_quad(Quad::new(back).with_border(stroke, 1.0).with_corner_radius(2.0));
+    paint.scene.draw_quad(Quad::new(front).with_border(stroke, 1.0).with_corner_radius(2.0));
 }
 
 pub fn paint_create_invoice_pane(
@@ -1183,7 +1280,6 @@ pub fn paint_pay_invoice_pane(
         PaneLoadState::Loading => theme::accent::PRIMARY,
         PaneLoadState::Error => theme::status::ERROR,
     };
-    let label_style = app_text_style(AppTextRole::FormLabel);
     let form_section_top = content_bounds.origin.y + 12.0;
     let form_section_bounds = Bounds::new(
         content_bounds.origin.x + 12.0,
@@ -1200,7 +1296,7 @@ pub fn paint_pay_invoice_pane(
     paint_wallet_flow_section(
         form_section_bounds,
         "Send",
-        "Paste a request, then confirm the sats to pay.",
+        "Paste a Lightning request (ln...). Amount is required only for zero-amount invoices. On-chain addresses are not supported here.",
         paint,
     );
     paint_wallet_supporting_section(
@@ -1225,19 +1321,6 @@ pub fn paint_pay_invoice_pane(
     pay_invoice_inputs
         .amount_sats
         .paint(layout.amount_input, paint);
-
-    paint_wallet_input_label(
-        paint,
-        layout.payment_request_input,
-        "Lightning invoice / payment request",
-        label_style,
-    );
-    paint_wallet_input_label(
-        paint,
-        layout.amount_input,
-        "Send sats (optional)",
-        label_style,
-    );
 
     let mut y = layout.details_origin.y;
     y = paint_wallet_status_summary(

--- a/apps/autopilot-desktop/src/spark_pane.rs
+++ b/apps/autopilot-desktop/src/spark_pane.rs
@@ -36,7 +36,9 @@ pub enum SparkPaneAction {
     GenerateBitcoinAddress,
     CreateNewWallet,
     CopySparkAddress,
+    CopyBitcoinAddress,
     CreateInvoice,
+    CopyInvoice,
     SendPayment,
 }
 
@@ -58,11 +60,16 @@ pub struct SparkPaneLayout {
     pub refresh_button: Bounds,
     pub spark_address_button: Bounds,
     pub bitcoin_address_button: Bounds,
+    pub spark_address_value: Bounds,
+    pub bitcoin_address_value: Bounds,
+    pub invoice_value: Bounds,
     pub copy_spark_address_button: Bounds,
+    pub copy_bitcoin_address_button: Bounds,
     pub receive_section_bounds: Bounds,
     pub send_section_bounds: Bounds,
     pub invoice_amount_input: Bounds,
     pub create_invoice_button: Bounds,
+    pub copy_invoice_button: Bounds,
     pub send_request_input: Bounds,
     pub send_amount_input: Bounds,
     pub send_payment_button: Bounds,
@@ -124,55 +131,80 @@ pub fn layout_with_scroll(content_bounds: Bounds, scroll_offset: f32) -> SparkPa
     let utility_width = (usable_width * 0.24).clamp(138.0, 186.0);
     let controls_y = utility_section_bounds.origin.y + 52.0;
     let refresh_button = Bounds::new(utility_content_x, controls_y, utility_width, CONTROL_HEIGHT);
-    let copy_spark_address_button = Bounds::new(
-        refresh_button.origin.x + refresh_button.size.width + GAP,
-        controls_y,
-        utility_width,
-        CONTROL_HEIGHT,
-    );
-
     let receive_section_y = utility_section_bounds.max_y() + SECTION_TO_SECTION_GAP;
-    let receive_section_height = SECTION_HEADER_HEIGHT
-        + SECTION_HEADER_TO_CONTROLS_GAP
-        + CONTROL_HEIGHT
-        + SECTION_CONTROLS_TO_FORM_GAP
-        + CONTROL_HEIGHT
-        + FLOW_SECTION_BOTTOM_PADDING;
-    let receive_section_bounds =
-        Bounds::new(origin_x, receive_section_y, usable_width, receive_section_height);
-    let receive_content_x = receive_section_bounds.origin.x + FLOW_SECTION_INSET;
-    let receive_content_width =
-        (receive_section_bounds.size.width - FLOW_SECTION_INSET * 2.0).max(180.0);
+    let receive_content_x = origin_x + FLOW_SECTION_INSET;
+    let receive_content_width = (usable_width - FLOW_SECTION_INSET * 2.0).max(180.0);
+    let copy_button_size = CONTROL_HEIGHT;
+    let value_gap = 8.0;
+    let value_width = (receive_content_width - copy_button_size - GAP).max(120.0);
+    let spark_row_gap = 12.0;
+    let value_row_height = 30.0;
+    let invoice_row_height = 50.0;
+
     let receive_y = receive_section_y + SECTION_HEADER_HEIGHT + SECTION_HEADER_TO_CONTROLS_GAP;
-    let receive_width = ((receive_content_width - GAP) / 2.0).max(140.0);
-    let spark_address_button = Bounds::new(
-        receive_content_x,
-        receive_y,
-        receive_width,
-        CONTROL_HEIGHT,
-    );
-    let bitcoin_address_button = Bounds::new(
-        spark_address_button.origin.x + spark_address_button.size.width + GAP,
-        receive_y,
-        receive_width,
-        CONTROL_HEIGHT,
+    let action_button_width = (receive_content_width * 0.40).clamp(180.0, 300.0);
+    let spark_address_button = Bounds::new(receive_content_x, receive_y, action_button_width, CONTROL_HEIGHT);
+    let spark_value_y = spark_address_button.max_y() + value_gap;
+    let spark_address_value =
+        Bounds::new(receive_content_x, spark_value_y, value_width, value_row_height);
+    let copy_spark_address_button = Bounds::new(
+        spark_address_value.max_x() + GAP,
+        spark_value_y + ((value_row_height - copy_button_size).max(0.0) * 0.5),
+        copy_button_size,
+        copy_button_size,
     );
 
-    let invoice_row_y = receive_y + CONTROL_HEIGHT + SECTION_CONTROLS_TO_FORM_GAP;
-    let invoice_input_width = (receive_content_width * 0.28).clamp(110.0, 180.0);
+    let bitcoin_button_y = spark_address_value.max_y() + spark_row_gap;
+    let bitcoin_address_button = Bounds::new(
+        receive_content_x,
+        bitcoin_button_y,
+        action_button_width,
+        CONTROL_HEIGHT,
+    );
+    let bitcoin_value_y = bitcoin_address_button.max_y() + value_gap;
+    let bitcoin_address_value =
+        Bounds::new(receive_content_x, bitcoin_value_y, value_width, value_row_height);
+    let copy_bitcoin_address_button = Bounds::new(
+        bitcoin_address_value.max_x() + GAP,
+        bitcoin_value_y + ((value_row_height - copy_button_size).max(0.0) * 0.5),
+        copy_button_size,
+        copy_button_size,
+    );
+
+    let invoice_row_y = bitcoin_address_value.max_y() + spark_row_gap;
+    let invoice_input_width = (receive_content_width * 0.22).clamp(104.0, 168.0);
     let invoice_amount_input =
         Bounds::new(receive_content_x, invoice_row_y, invoice_input_width, CONTROL_HEIGHT);
+    let create_invoice_width = (receive_content_width - invoice_input_width - GAP).max(140.0);
     let create_invoice_button = Bounds::new(
         invoice_amount_input.origin.x + invoice_amount_input.size.width + GAP,
         invoice_row_y,
-        (receive_content_width - invoice_input_width - GAP).max(120.0),
+        create_invoice_width,
         CONTROL_HEIGHT,
     );
+    let invoice_value_y = create_invoice_button.max_y() + value_gap;
+    let invoice_value = Bounds::new(
+        receive_content_x,
+        invoice_value_y,
+        value_width,
+        invoice_row_height,
+    );
+    let copy_invoice_button = Bounds::new(
+        invoice_value.max_x() + GAP,
+        invoice_value_y + ((invoice_row_height - copy_button_size).max(0.0) * 0.5),
+        copy_button_size,
+        copy_button_size,
+    );
+    let receive_section_height = invoice_value.max_y() - receive_section_y + FLOW_SECTION_BOTTOM_PADDING;
+    let receive_section_bounds =
+        Bounds::new(origin_x, receive_section_y, usable_width, receive_section_height.max(120.0));
 
     let send_section_y = receive_section_bounds.max_y() + SECTION_TO_SECTION_GAP;
-    let send_section_height = SECTION_HEADER_TO_FORM_GAP
+    let send_section_controls_top = send_section_y + SECTION_HEADER_HEIGHT + SECTION_HEADER_TO_CONTROLS_GAP;
+    let send_section_height = SECTION_HEADER_HEIGHT
+        + SECTION_HEADER_TO_CONTROLS_GAP
         + CONTROL_HEIGHT
-        + SECTION_CTA_ROW_GAP
+        + GAP
         + CONTROL_HEIGHT
         + FLOW_SECTION_BOTTOM_PADDING;
     let send_section_bounds =
@@ -180,11 +212,11 @@ pub fn layout_with_scroll(content_bounds: Bounds, scroll_offset: f32) -> SparkPa
     let send_content_x = send_section_bounds.origin.x + FLOW_SECTION_INSET;
     let send_content_width =
         (send_section_bounds.size.width - FLOW_SECTION_INSET * 2.0).max(180.0);
-    let send_request_y = send_section_y + SECTION_HEADER_TO_FORM_GAP;
+    let send_request_y = send_section_controls_top;
     let send_request_input =
         Bounds::new(send_content_x, send_request_y, send_content_width, CONTROL_HEIGHT);
 
-    let send_row_y = send_request_y + CONTROL_HEIGHT + SECTION_CTA_ROW_GAP;
+    let send_row_y = send_request_y + CONTROL_HEIGHT + GAP;
     let send_amount_width = (send_content_width * 0.28).clamp(110.0, 180.0);
     let send_amount_input =
         Bounds::new(send_content_x, send_row_y, send_amount_width, CONTROL_HEIGHT);
@@ -207,11 +239,16 @@ pub fn layout_with_scroll(content_bounds: Bounds, scroll_offset: f32) -> SparkPa
         refresh_button,
         spark_address_button,
         bitcoin_address_button,
+        spark_address_value,
+        bitcoin_address_value,
+        invoice_value,
         copy_spark_address_button,
+        copy_bitcoin_address_button,
         receive_section_bounds,
         send_section_bounds,
         invoice_amount_input,
         create_invoice_button,
+        copy_invoice_button,
         send_request_input,
         send_amount_input,
         send_payment_button,
@@ -233,8 +270,14 @@ pub fn hit_action(layout: SparkPaneLayout, point: Point) -> Option<SparkPaneActi
     if layout.copy_spark_address_button.contains(point) {
         return Some(SparkPaneAction::CopySparkAddress);
     }
+    if layout.copy_bitcoin_address_button.contains(point) {
+        return Some(SparkPaneAction::CopyBitcoinAddress);
+    }
     if layout.create_invoice_button.contains(point) {
         return Some(SparkPaneAction::CreateInvoice);
+    }
+    if layout.copy_invoice_button.contains(point) {
+        return Some(SparkPaneAction::CopyInvoice);
     }
     if layout.send_payment_button.contains(point) {
         return Some(SparkPaneAction::SendPayment);
@@ -349,10 +392,10 @@ pub fn pay_invoice_layout_with_scroll(
     let form_width = (usable_width * 0.82).clamp(300.0, 620.0);
     let origin_x = pane_origin_x + ((usable_width - form_width) * 0.5);
 
-    let request_y = origin_y + SECTION_HEADER_TO_FORM_GAP;
+    let request_y = origin_y + SECTION_HEADER_HEIGHT + SECTION_HEADER_TO_CONTROLS_GAP;
     let payment_request_input = Bounds::new(origin_x, request_y, form_width, CONTROL_HEIGHT);
 
-    let send_row_y = request_y + CONTROL_HEIGHT + SECTION_CTA_ROW_GAP;
+    let send_row_y = request_y + CONTROL_HEIGHT + GAP;
     let amount_width = (form_width * 0.24).clamp(110.0, 148.0);
     let send_width = (form_width * 0.34).clamp(152.0, 208.0);
     let amount_input = Bounds::new(origin_x, send_row_y, amount_width, CONTROL_HEIGHT);
@@ -436,6 +479,24 @@ mod tests {
         assert_eq!(
             hit_action(layout, copy),
             Some(SparkPaneAction::CopySparkAddress)
+        );
+
+        let copy_bitcoin = Point::new(
+            layout.copy_bitcoin_address_button.origin.x + 3.0,
+            layout.copy_bitcoin_address_button.origin.y + 3.0,
+        );
+        assert_eq!(
+            hit_action(layout, copy_bitcoin),
+            Some(SparkPaneAction::CopyBitcoinAddress)
+        );
+
+        let copy_invoice = Point::new(
+            layout.copy_invoice_button.origin.x + 3.0,
+            layout.copy_invoice_button.origin.y + 3.0,
+        );
+        assert_eq!(
+            hit_action(layout, copy_invoice),
+            Some(SparkPaneAction::CopyInvoice)
         );
     }
 


### PR DESCRIPTION
## Summary
This PR rolls up all wallet-pane updates made after the previous wallet PRs and aligns Mission Control wallet UX with the latest feedback.

## What Changed
1. Reworked Receive section layout for clearer action/result flow
- Put each receive action on its own line in the wallet pane:
  - Generate Spark Address -> output row + copy icon
  - Generate Bitcoin Address -> output row + copy icon
  - Create Lightning Invoice -> output row + copy icon
- Added compact value rows and copy icon buttons rendered inline with each output.
- Reduced Spark/Bitcoin output row heights for denser layout.

2. Added missing wallet copy behaviors and action routing
- Added wallet-pane action handling for copying Lightning invoice directly from the wallet pane.
- Added new wallet-pane action for copying Bitcoin address.
- Extended Spark wallet tool/action bridge mappings for:
  - copy_spark_address
  - copy_bitcoin_address
  - copy_invoice

3. Updated wallet labels, capitalization, and wording consistency
- Updated receive button labels to explicit verbs (Generate/Copy).
- Kept Create Lightning Invoice / Send Payment button naming consistent.
- Preserved earlier capitalization cleanup across wallet actions.

4. Clarified Send semantics and removed duplicate label noise
- Removed top-of-field labels above send inputs in wallet Send and Pay panes (placeholder-only guidance).
- Tightened send form spacing after removing labels.
- Kept amount placeholder as: `Amount sats (optional)`.
- Updated send helper copy to explicitly indicate Lightning request (`ln...`) input and that on-chain addresses are not supported in this form.

5. Added explicit validation for conflicting send amount input
- If a user enters an amount for an invoice that already embeds an amount, send now returns a clear error:
  - `Amount is already embedded in this invoice. Clear the amount field and try again.`
- Existing zero-amount invoice behavior remains: amount is required when the invoice omits amount.

6. Wallet amount input polish
- Added fixed `₿` prefix inside the wallet invoice amount field (before default `1000`).
- Removed the old `Lightning invoice sats` label above that field.

## Files Updated
- `apps/autopilot-desktop/src/panes/wallet.rs`
- `apps/autopilot-desktop/src/spark_pane.rs`
- `apps/autopilot-desktop/src/input/actions.rs`
- `apps/autopilot-desktop/src/input/tool_bridge.rs`
- `apps/autopilot-desktop/src/app_state.rs`

## Validation
- `cargo check -p autopilot-desktop`
- `cargo test -p autopilot-desktop spark_pane::tests::hit_action_detects_buttons -- --nocapture`
