### PR TITLE
Fix wallet input hitboxes after scrolling

### DIFF
--- a/apps/autopilot-desktop/src/pane_system.rs
+++ b/apps/autopilot-desktop/src/pane_system.rs
@@ -9780,12 +9780,9 @@ pub fn dispatch_wallet_scroll_event(
     {
         return false;
     }
-    let next = (state.spark_wallet_scroll_offset - scroll_dy).clamp(0.0, 4000.0);
-    if (next - state.spark_wallet_scroll_offset).abs() <= f32::EPSILON {
-        return false;
-    }
-    state.spark_wallet_scroll_offset = next;
-    true
+    let before = state.spark_wallet_pane.scroll_offset();
+    state.spark_wallet_pane.scroll_by(scroll_dy);
+    (state.spark_wallet_pane.scroll_offset() - before).abs() > f32::EPSILON
 }
 
 pub fn dispatch_log_stream_scroll_event(

--- a/apps/autopilot-desktop/src/panes/wallet.rs
+++ b/apps/autopilot-desktop/src/panes/wallet.rs
@@ -1451,7 +1451,7 @@ pub fn dispatch_spark_input_event(state: &mut RenderState, event: &InputEvent) -
     let content_bounds = pane_content_bounds(bounds);
     let layout = spark_pane::layout_with_scroll(
         spark_pane::scroll_content_bounds(content_bounds),
-        state.spark_wallet_scroll_offset,
+        state.spark_wallet_pane.scroll_offset(),
     );
     let mut handled = false;
 


### PR DESCRIPTION
## Summary
Fixes wallet pane input focus/click hitboxes so they track the same scroll offset used by rendering.

## Problem
After scrolling the wallet pane, the visible input boxes (Create Lightning amount and Send fields) no longer matched their interaction hitboxes. Users could only focus/type reliably near the top or by clicking where the fields would be without scroll.

## Root Cause
Input dispatch for the Spark wallet pane used the legacy `state.spark_wallet_scroll_offset` while rendering and scroll behavior had moved to `state.spark_wallet_pane.scroll_offset()`.

## Changes
1. Wallet input dispatch now uses pane-owned scroll offset
- Updated `dispatch_spark_input_event` to build input layout with `state.spark_wallet_pane.scroll_offset()`.

2. Legacy wallet scroll handler now updates pane-owned scroll state
- Updated `dispatch_wallet_scroll_event` to call `state.spark_wallet_pane.scroll_by(scroll_dy)` and detect change from pane scroll offset, rather than mutating `state.spark_wallet_scroll_offset`.

## Files
- `apps/autopilot-desktop/src/panes/wallet.rs`
- `apps/autopilot-desktop/src/pane_system.rs`

## Validation
- `cargo check -p autopilot-desktop`
