### PR TITLE
Fix autopilot build break after provider local_gemma rename

### DIFF
--- a/apps/autopilot-desktop/src/snapshot_domains.rs
+++ b/apps/autopilot-desktop/src/snapshot_domains.rs
@@ -614,11 +614,11 @@ fn append_provider_inventory_signature(builder: &mut SignatureBuilder, state: &R
     let controls = &state.provider_runtime.inventory_controls;
     builder.bool(
         "inventory_gpt_oss_inference_enabled",
-        controls.gpt_oss_inference_enabled,
+        controls.local_gemma_inference_enabled,
     );
     builder.bool(
         "inventory_gpt_oss_embeddings_enabled",
-        controls.gpt_oss_embeddings_enabled,
+        controls.local_gemma_embeddings_enabled,
     );
     builder.bool(
         "inventory_apple_fm_inference_enabled",

--- a/apps/autopilot-desktop/src/state/provider_runtime.rs
+++ b/apps/autopilot-desktop/src/state/provider_runtime.rs
@@ -448,7 +448,7 @@ impl ProviderRuntimeState {
 
     pub fn availability(&self) -> ProviderAvailability {
         ProviderAvailability {
-            gpt_oss: self.gpt_oss.substrate_health(),
+            local_gemma: self.gpt_oss.substrate_health(),
             apple_foundation_models: self.apple_fm.substrate_health(),
             apple_adapter_hosting: self.apple_fm.substrate_adapter_hosting(),
             adapter_training_contributor: self.apple_fm.substrate_training_contributor(),


### PR DESCRIPTION
## Summary
- replace stale gpt_oss inventory control field reads with local_gemma equivalents in snapshot signatures
- update ProviderAvailability construction to write local_gemma instead of removed gpt_oss field

## Why
autopilot-desktop failed to compile on main due to provider substrate field renames.

## Validation
- cargo check -p autopilot-desktop
