### PR TITLE
Surface autopilot desktop renderer init errors

### DIFF
--- a/apps/autopilot-desktop/src/lib.rs
+++ b/apps/autopilot-desktop/src/lib.rs
@@ -128,16 +128,21 @@ pub fn run_desktop_app_with_options(options: DesktopAppOptions) -> Result<()> {
     let mut app = AppShell {
         inner: App::default(),
         options,
+        init_error: None,
     };
     event_loop
         .run_app(&mut app)
         .context("event loop terminated with error")?;
+    if let Some(error) = app.init_error {
+        return Err(error);
+    }
     Ok(())
 }
 
 struct AppShell {
     inner: App,
     options: DesktopAppOptions,
+    init_error: Option<anyhow::Error>,
 }
 
 impl ApplicationHandler for AppShell {
@@ -155,7 +160,9 @@ impl ApplicationHandler for AppShell {
                 state.window.request_redraw();
                 self.inner.state = Some(state);
             }
-            Err(_err) => {
+            Err(err) => {
+                tracing::error!(error = format!("{err:#}"), "failed to initialize desktop renderer");
+                self.init_error = Some(err);
                 event_loop.exit();
             }
         }

--- a/apps/autopilot-desktop/src/main.rs
+++ b/apps/autopilot-desktop/src/main.rs
@@ -6,7 +6,7 @@ fn main() -> ExitCode {
         Ok(Action::RunDesktop) => match autopilot_desktop::run_desktop_app() {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
-                eprintln!("{error}");
+                eprintln!("{error:#}");
                 ExitCode::from(1)
             }
         },

--- a/apps/autopilot-desktop/src/render.rs
+++ b/apps/autopilot-desktop/src/render.rs
@@ -562,8 +562,28 @@ pub fn init_state(
             .await
             .context("failed to find compatible adapter")?;
 
+        let adapter_info = adapter.get_info();
+        tracing::info!(
+            name = adapter_info.name,
+            vendor = adapter_info.vendor,
+            device = adapter_info.device,
+            device_type = ?adapter_info.device_type,
+            driver = adapter_info.driver,
+            driver_info = adapter_info.driver_info,
+            backend = ?adapter_info.backend,
+            "selected wgpu adapter",
+        );
+
         let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor::default(), None)
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("autopilot-desktop-device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: adapter.limits(),
+                    memory_hints: wgpu::MemoryHints::default(),
+                },
+                None,
+            )
             .await
             .context("failed to create device")?;
 


### PR DESCRIPTION
  ## Summary

  - `run_desktop_app` silently swallowed any `render::init_state` error and returned `Ok(())`, so a failure to create
  the wgpu surface, adapter, or device produced `cargo autopilot` runs that exited 0 with no output, no window, and no
  diagnostic. Errors are now propagated out of the event loop, logged with the full anyhow chain via `tracing::error!`,
  and printed from `main` with `{error:#}` so the full cause is visible.
  - `render::init_state` requested `DeviceDescriptor::default()`, which asks for the full default wgpu limit set. On
  adapters that advertise weaker limits (observed on a WSL2 setup where Mesa selected an adapter reporting
  `max_compute_workgroups_per_dimension: 0`), this fails with `Limit 'max_compute_workgroups_per_dimension' value 65535
  is better than allowed 0`. Switched to `required_limits: adapter.limits()` to match the pattern already used in
  `crates/wgpui/src/platform/web.rs`, so the device request always fits what the adapter actually supports.
  - Also log the selected adapter info (name, backend, driver, driver_info) at startup so future GPU issues are
  triagable from the session log.

  ## Context

  Found while debugging a `cargo autopilot` install on WSL2 / Ubuntu 22.04 that exited 0 with zero output. After the
  fixes above, the user-visible error pointed directly at the wgpu limits mismatch, which in turn pointed at a stale
  Mesa on the host. The code fixes stand on their own regardless of the host setup — any future GPU init failure will
  now produce an actionable error instead of a silent exit.

  ## Test plan

  - [x] `cargo check -p autopilot-desktop` — clean
  - [x] `cargo build -p autopilot-desktop --bin autopilot-desktop` — clean
  - [x] Reproduced the original silent exit (pre-fix), verified the fix makes the underlying `Limit ...` error visible
  on both stderr and the session log
  - [x] Verified `cargo autopilot` launches a persistent window on a working adapter (llvmpipe Vulkan under Mesa 25,
  WSL2)
  - [ ] Second reviewer confirms behavior unchanged on a macOS / native-Linux box with a working GPU