### PR TITLE
Unhide non-conformant Vulkan adapters so WSL2 dzn picks real GPUs

### DIFF
--- a/apps/autopilot-desktop/src/lib.rs
+++ b/apps/autopilot-desktop/src/lib.rs
@@ -128,16 +128,21 @@ pub fn run_desktop_app_with_options(options: DesktopAppOptions) -> Result<()> {
     let mut app = AppShell {
         inner: App::default(),
         options,
+        init_error: None,
     };
     event_loop
         .run_app(&mut app)
         .context("event loop terminated with error")?;
+    if let Some(error) = app.init_error {
+        return Err(error);
+    }
     Ok(())
 }
 
 struct AppShell {
     inner: App,
     options: DesktopAppOptions,
+    init_error: Option<anyhow::Error>,
 }
 
 impl ApplicationHandler for AppShell {
@@ -155,7 +160,9 @@ impl ApplicationHandler for AppShell {
                 state.window.request_redraw();
                 self.inner.state = Some(state);
             }
-            Err(_err) => {
+            Err(err) => {
+                tracing::error!(error = format!("{err:#}"), "failed to initialize desktop renderer");
+                self.init_error = Some(err);
                 event_loop.exit();
             }
         }

--- a/apps/autopilot-desktop/src/main.rs
+++ b/apps/autopilot-desktop/src/main.rs
@@ -6,7 +6,7 @@ fn main() -> ExitCode {
         Ok(Action::RunDesktop) => match autopilot_desktop::run_desktop_app() {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
-                eprintln!("{error}");
+                eprintln!("{error:#}");
                 ExitCode::from(1)
             }
         },

--- a/apps/autopilot-desktop/src/render.rs
+++ b/apps/autopilot-desktop/src/render.rs
@@ -544,14 +544,41 @@ pub fn init_state(
     window.set_blur(true);
 
     pollster::block_on(async move {
+        // WSL2's Mesa `dzn` driver (Vulkan-on-D3D12) is the only way to reach a
+        // real GPU from inside a Linux WSL guest, but it advertises
+        // `conformanceVersion = 0.0.0.0` because it's a translation layer and
+        // can't pass the Vulkan CTS. wgpu-hal hides such adapters unless
+        // `ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER` is set, which on native
+        // Linux/macOS/Windows with conformant drivers is a no-op.
+        let instance_flags = (wgpu::InstanceFlags::from_build_config()
+            | wgpu::InstanceFlags::ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER)
+            .with_env();
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
+            flags: instance_flags,
             ..Default::default()
         });
 
         let surface = instance
             .create_surface(window.clone())
             .context("failed to create surface")?;
+
+        for (index, probe) in instance.enumerate_adapters(wgpu::Backends::all()).into_iter().enumerate() {
+            let info = probe.get_info();
+            let surface_supported = probe.is_surface_supported(&surface);
+            tracing::info!(
+                index,
+                name = info.name,
+                vendor = info.vendor,
+                device = info.device,
+                device_type = ?info.device_type,
+                driver = info.driver,
+                driver_info = info.driver_info,
+                backend = ?info.backend,
+                surface_supported,
+                "enumerated wgpu adapter",
+            );
+        }
 
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {

--- a/apps/autopilot-desktop/src/render.rs
+++ b/apps/autopilot-desktop/src/render.rs
@@ -562,8 +562,28 @@ pub fn init_state(
             .await
             .context("failed to find compatible adapter")?;
 
+        let adapter_info = adapter.get_info();
+        tracing::info!(
+            name = adapter_info.name,
+            vendor = adapter_info.vendor,
+            device = adapter_info.device,
+            device_type = ?adapter_info.device_type,
+            driver = adapter_info.driver,
+            driver_info = adapter_info.driver_info,
+            backend = ?adapter_info.backend,
+            "selected wgpu adapter",
+        );
+
         let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor::default(), None)
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("autopilot-desktop-device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: adapter.limits(),
+                    memory_hints: wgpu::MemoryHints::default(),
+                },
+                None,
+            )
             .await
             .context("failed to create device")?;
 


### PR DESCRIPTION
 > Stacked on top of #4259 — the error-propagation fix in that PR is what made
  > this bug debuggable in the first place. Once #4259 merges, the diff here
  > collapses to just the `render.rs` change.

  ## Summary

  On WSL2, wgpu's Vulkan backend was selecting `llvmpipe` (software) instead of the host NVIDIA/AMD/Intel GPU, even
  though Mesa's `dzn` driver was installed and `vulkaninfo --summary` clearly showed the real hardware as a discrete
  Vulkan physical device (`Microsoft Direct3D12 (NVIDIA GeForce RTX 3060 Ti)` via Dozen in the reproducer). The result:

  Root cause is in `wgpu-hal/src/vulkan/adapter.rs` — it hides any Vulkan physical device whose
  `driver.conformance_version.major == 0`, unless (a) the driver id is MoltenVK, or (b)
  `InstanceFlags::ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER` was set on the instance. `dzn` is a Vulkan-on-D3D12 translation
   layer and correctly advertises itself as non-conformant because it can't pass the Vulkan CTS, so wgpu silently
  dropped it from enumeration. Neither MoltenVK nor the flag applied here, so dzn was invisible to `enumerate_adapters`.

  ## Fix

  Set `ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER` on the `InstanceDescriptor` we build in `render::init_state`, then fold in
   `InstanceFlags::with_env()` so `WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER=0` still lets users disable it if a
  particular translation layer misbehaves.

  On every platform with a conformant native Vulkan driver (native Linux, macOS, Windows) this is a **no-op** — no
  adapter has `conformanceVersion.major == 0`, so wgpu's selection is unchanged. The flag only has an effect in
  translation-layer environments (WSL2 dzn, some Android layers), where it exposes the real hardware that was previously
   hidden.

  Also log every adapter returned by `instance.enumerate_adapters(Backends::all())` and its surface-support status.
  Without this, the original "wgpu picked llvmpipe on WSL" failure mode required hand-rolled Vulkan ICD diagnostics to
  debug; now `target/debug/autopilot-desktop` prints a complete adapter dump on startup.

  ## Before

  enumerated wgpu adapter index=0 name="llvmpipe (LLVM 15.0.7, 256 bits)" device_type=Cpu backend=Vulkan
  surface_supported=true
  enumerated wgpu adapter index=1 name="llvmpipe (LLVM 15.0.7, 256 bits)" device_type=Cpu backend=Gl
  surface_supported=true
  selected wgpu adapter name="llvmpipe (LLVM 15.0.7, 256 bits)" device_type=Cpu backend=Vulkan

  ## After

  enumerated wgpu adapter index=0 name="Microsoft Direct3D12 (NVIDIA GeForce RTX 3060 Ti)" device_type=DiscreteGpu
  driver="Dozen" backend=Vulkan surface_supported=true
  enumerated wgpu adapter index=1 name="llvmpipe (LLVM 15.0.7, 256 bits)" device_type=Cpu backend=Vulkan
  surface_supported=true
  enumerated wgpu adapter index=2 name="Microsoft Direct3D12 (Intel(R) UHD Graphics 750)" device_type=IntegratedGpu
  driver="Dozen" backend=Vulkan surface_supported=true
  enumerated wgpu adapter index=3 name="llvmpipe (LLVM 15.0.7, 256 bits)" device_type=Cpu backend=Gl
  surface_supported=true
  selected wgpu adapter name="Microsoft Direct3D12 (NVIDIA GeForce RTX 3060 Ti)" device_type=DiscreteGpu driver="Dozen"
  backend=Vulkan

  Reproduced on a WSL2 / Ubuntu 22.04 box with `mesa-vulkan-drivers 25.0.7` from `ppa:kisak/turtle` and an RTX 3060 Ti.
  `vulkaninfo --summary` confirmed the three Vulkan physical devices the loader sees; enumerating through wgpu only
  returned the llvmpipes until the flag was set.

  ## Test plan

  - [x] `cargo build -p autopilot-desktop --bin autopilot-desktop` — clean
  - [x] Verified RTX 3060 Ti is enumerated and selected on the WSL2 reproducer
  - [x] Verified llvmpipe is still enumerated as a fallback
  - [x] Verified no renderer/device errors on the post-fix run (beyond pre-existing unrelated Codex/Rustls noise)
  - [ ] Second reviewer confirms `selected wgpu adapter` on a native-Linux or macOS or Windows box is unchanged (should
  still be the conformant native driver — flag is a no-op there)