### PR TITLE
Replace Nexus text homepage with public stats board

### DIFF
--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -1411,7 +1411,7 @@ struct TrainingOperatorSummaryResponse {
     checkpoint_max_age_ms: Option<u64>,
     artifact_failures_open: u64,
     payout_eligible_closeouts: u64,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     runs: Vec<TrainingOperatorRunSummary>,
 }
 
@@ -1420,13 +1420,13 @@ struct NexusHomepageResponse {
     generated_at_unix_ms: u64,
     stats: PublicStatsSnapshot,
     training_summary: TrainingOperatorSummaryResponse,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     training_nodes: Vec<AdmittedTrainingNodeView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     default_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     default_network_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     recent_trn_publications: Vec<NexusHomepageRecentTrainingPublication>,
 }
 

--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -1415,6 +1415,39 @@ struct TrainingOperatorSummaryResponse {
     runs: Vec<TrainingOperatorRunSummary>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct NexusHomepageResponse {
+    generated_at_unix_ms: u64,
+    stats: PublicStatsSnapshot,
+    training_summary: TrainingOperatorSummaryResponse,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    training_nodes: Vec<AdmittedTrainingNodeView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    default_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    default_network_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    recent_trn_publications: Vec<NexusHomepageRecentTrainingPublication>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct NexusHomepageRecentTrainingPublication {
+    publication_key: String,
+    subject_kind: String,
+    subject_id: String,
+    event_kind: u32,
+    publication_state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    event_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    published_at_ms: Option<i64>,
+    last_attempt_at_ms: i64,
+    attempt_count: u32,
+    pending_retry: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 struct TrainingOperatorRunSummary {
     training_run_id: String,
@@ -4057,6 +4090,7 @@ fn build_api_router_with_state(state: AppState) -> Router {
     Router::new()
         .route("/stats", get(public_stats))
         .route("/api/stats", get(public_stats))
+        .route("/api/homepage", get(homepage_snapshot))
         .route(
             "/api/provider-presence/heartbeat",
             post(record_provider_presence_heartbeat),
@@ -4460,6 +4494,20 @@ async fn training_operator_summary(
         reason: "session_store_poisoned".to_string(),
     })?;
     Ok(Json(training_operator_summary_snapshot(&store, now)))
+}
+
+async fn homepage_snapshot(
+    State(state): State<AppState>,
+) -> Result<Json<NexusHomepageResponse>, ApiError> {
+    let now = now_unix_ms();
+    let store = state.store.read().map_err(|_| ApiError {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        error: "internal_error",
+        reason: "session_store_poisoned".to_string(),
+    })?;
+    let snapshot = build_homepage_snapshot(&state.config, &store, now);
+    replace_public_stats_cache(&state, snapshot.stats.clone());
+    Ok(Json(snapshot))
 }
 
 async fn record_provider_presence_heartbeat(
@@ -6852,7 +6900,11 @@ fn training_trn_network_sources(
                 .clone(),
         );
         if let Some(backend_family) = training_backend_family_for_environment_ref(
-            source.training_run.environment_binding.environment_ref.as_str(),
+            source
+                .training_run
+                .environment_binding
+                .environment_ref
+                .as_str(),
         ) {
             entry.backend_families.insert(backend_family.to_string());
         }
@@ -13618,6 +13670,98 @@ fn training_operator_metrics(store: &ControlStore, now_unix_ms: u64) -> Training
     }
 }
 
+fn build_homepage_snapshot(
+    config: &ServiceConfig,
+    store: &ControlStore,
+    now_unix_ms: u64,
+) -> NexusHomepageResponse {
+    let stats = build_public_stats_snapshot(config, store, now_unix_ms);
+    let training_summary = training_operator_summary_snapshot(store, now_unix_ms);
+    let training_nodes = store.kernel.list_admitted_training_nodes(
+        &TrainingNodeQuery {
+            network_id: None,
+            role: None,
+            online_only: false,
+            eligible_only: false,
+        },
+        now_unix_ms as i64,
+    );
+
+    let default_run = training_summary
+        .runs
+        .iter()
+        .find(|run| {
+            matches!(
+                run.run_status.as_str(),
+                "queued" | "preparing" | "running" | "finalizing"
+            )
+        })
+        .or_else(|| training_summary.runs.first());
+    let default_run_id = default_run.map(|run| run.training_run_id.clone());
+    let default_network_id = default_run.map(|run| run.network_id.clone()).or_else(|| {
+        training_nodes
+            .iter()
+            .flat_map(|node| node.allowed_networks.iter())
+            .find(|network_id| !network_id.trim().is_empty())
+            .cloned()
+    });
+
+    NexusHomepageResponse {
+        generated_at_unix_ms: now_unix_ms,
+        stats,
+        training_summary,
+        training_nodes,
+        default_run_id,
+        default_network_id,
+        recent_trn_publications: recent_homepage_training_publications(store),
+    }
+}
+
+fn recent_homepage_training_publications(
+    store: &ControlStore,
+) -> Vec<NexusHomepageRecentTrainingPublication> {
+    let mut records = store.kernel.list_training_trn_publication_records();
+    records.sort_by(|lhs, rhs| {
+        rhs.published_at_ms
+            .unwrap_or(rhs.last_attempt_at_ms)
+            .cmp(&lhs.published_at_ms.unwrap_or(lhs.last_attempt_at_ms))
+            .then_with(|| rhs.last_attempt_at_ms.cmp(&lhs.last_attempt_at_ms))
+            .then_with(|| lhs.publication_key.cmp(&rhs.publication_key))
+    });
+    records
+        .into_iter()
+        .take(12)
+        .map(homepage_training_publication_from_record)
+        .collect()
+}
+
+fn homepage_training_publication_from_record(
+    record: TrainingTrnPublicationRecord,
+) -> NexusHomepageRecentTrainingPublication {
+    let publication_state = if record.pending_retry {
+        "queued_retry".to_string()
+    } else if record.published_at_ms.is_some() || record.event_id.is_some() {
+        "published".to_string()
+    } else if record.attempt_count > 0 {
+        "attempted".to_string()
+    } else {
+        "pending".to_string()
+    };
+    NexusHomepageRecentTrainingPublication {
+        publication_key: record.publication_key,
+        subject_kind: record.subject_kind,
+        subject_id: record.subject_id,
+        event_kind: record.event_kind,
+        publication_state,
+        event_id: record.event_id,
+        published_at_ms: record.published_at_ms,
+        last_attempt_at_ms: record.last_attempt_at_ms,
+        attempt_count: record.attempt_count,
+        pending_retry: record.pending_retry,
+        last_error: record.last_error,
+    }
+}
+
 fn replace_public_stats_cache(state: &AppState, snapshot: PublicStatsSnapshot) {
     if let Ok(mut cache) = state.public_stats_cache.write() {
         *cache = snapshot;
@@ -14015,11 +14159,11 @@ mod tests {
         AdmittedTrainingNodeView, AppState, DEFAULT_COMPUTE_POLICY_BUNDLE_ID,
         DEFAULT_COMPUTE_POLICY_VERSION, DEFAULT_PROVIDER_PRESENCE_STALE_AFTER_MS,
         DesktopSessionCreateRequest, DesktopSessionResponse, FinalizeValidatorChallengeRequest,
-        LeaseValidatorChallengeRequest, LeaseValidatorChallengeResponse,
+        LeaseValidatorChallengeRequest, LeaseValidatorChallengeResponse, NexusHomepageResponse,
         PROVIDER_PRESENCE_RETENTION_WINDOW_MS, PYLON_TRAINING_LEASE_DURATION_MS,
         PlanTrainingWindowRequest, ProviderPresenceHeartbeatRequest,
-        ProviderPresenceOfflineRequest, ProviderPresenceState, PublicStatsSnapshot,
-        ReconcileTrainingWindowRequest, RecordTrainingRunLeaseRequest,
+        ProviderPresenceOfflineRequest, ProviderPresenceResponse, ProviderPresenceState,
+        PublicStatsSnapshot, ReconcileTrainingWindowRequest, RecordTrainingRunLeaseRequest,
         RecordTrainingRunLeaseResponse, ScheduleValidatorChallengeRequest,
         ScheduleValidatorChallengeResponse, SealTrainingWindowRequest, ServiceConfig,
         StarterDemandAckRequest, StarterDemandAckResponse, StarterDemandCompleteRequest,
@@ -14214,6 +14358,20 @@ mod tests {
                 Request::builder()
                     .method("GET")
                     .uri("/api/training/summary")
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        response_json(response).await
+    }
+
+    async fn fetch_homepage(app: &axum::Router) -> Result<NexusHomepageResponse> {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/homepage")
                     .body(Body::empty())?,
             )
             .await?;
@@ -24029,6 +24187,79 @@ mod tests {
         );
         assert!(run_summary.latest_checkpoint_age_ms.is_some());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn homepage_snapshot_aggregates_public_stats_training_state_and_recent_trn() -> Result<()>
+    {
+        let state = build_app_state(test_config()?);
+        let app = build_api_router_with_state(state.clone());
+        let created_at_ms = super::now_unix_ms().saturating_sub(30_000);
+        let training_run_id = "run.homepage.alpha";
+        let session = create_session_token(&app).await?;
+
+        let presence_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/provider-presence/heartbeat")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&provider_presence_request(
+                        "provider-alpha",
+                        session.session_id.as_str(),
+                        "Pylon Alpha",
+                        2,
+                        "online",
+                    ))?))?,
+            )
+            .await?;
+        assert_eq!(presence_response.status(), StatusCode::OK);
+        let presence: ProviderPresenceResponse = response_json(presence_response).await?;
+        assert_eq!(presence.status, "online");
+
+        seed_training_scheduler_run(
+            &state,
+            created_at_ms,
+            training_run_id,
+            "window.0001",
+            "node-alpha",
+            "sha256:build-alpha",
+        );
+
+        let (relay_url, mut event_rx, relay_handle) = spawn_training_trn_capture_relay().await?;
+        let report = publish_training_trn(&app, vec![relay_url]).await?;
+        assert!(
+            !report.network_contracts.is_empty()
+                || !report.windows.is_empty()
+                || !report.receipts.is_empty()
+                || !report.reputation_labels.is_empty()
+        );
+        let published_events = collect_training_trn_events(&mut event_rx).await;
+        assert!(!published_events.is_empty());
+
+        let homepage = fetch_homepage(&app).await?;
+        assert_eq!(homepage.stats.pylons_online_now, 1);
+        assert_eq!(homepage.stats.sellable_pylons_online_now, 1);
+        assert_eq!(homepage.stats.recent_pylons.len(), 1);
+        assert_eq!(homepage.training_summary.active_runs, 1);
+        assert_eq!(homepage.training_summary.runs.len(), 1);
+        assert_eq!(homepage.training_nodes.len(), 1);
+        assert_eq!(homepage.default_run_id.as_deref(), Some(training_run_id));
+        assert_eq!(
+            homepage.default_network_id.as_deref(),
+            Some("trainnet.alpha")
+        );
+        assert!(!homepage.recent_trn_publications.is_empty());
+        assert!(
+            homepage
+                .recent_trn_publications
+                .iter()
+                .any(|publication| publication.publication_state == "published")
+        );
+
+        relay_handle.abort();
         Ok(())
     }
 

--- a/apps/nexus-relay/src/durable.rs
+++ b/apps/nexus-relay/src/durable.rs
@@ -33,6 +33,752 @@ const MAX_PROXY_REQUEST_BYTES: usize = 8 * 1024 * 1024;
 const NEXUS_PRODUCT_NAME: &str = "OpenAgents Nexus";
 const NEXUS_PRODUCT_DESCRIPTION: &str = "The OpenAgents relay and authority host for Autopilot.";
 const MANAGED_GROUPS_MODE_DEFERRED: &str = "deferred";
+const HOMEPAGE_TEMPLATE: &str = r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>__NEXUS_NAME__</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #070908;
+        --panel: rgba(14, 18, 15, 0.96);
+        --panel-border: rgba(112, 176, 138, 0.24);
+        --text: #f1f4ee;
+        --muted: #a1aca0;
+        --line: rgba(110, 145, 113, 0.2);
+        --accent: #88d9b1;
+        --accent-2: #f2df72;
+        --warn: #ffd166;
+        --bad: #ff7f96;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        min-height: 100%;
+        background:
+          linear-gradient(180deg, rgba(26, 35, 22, 0.34), rgba(7, 9, 8, 0)),
+          radial-gradient(circle at top, rgba(136, 217, 177, 0.08), transparent 40%),
+          #070908;
+        color: var(--text);
+        font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      }
+
+      body {
+        padding: 24px;
+      }
+
+      .shell {
+        max-width: 1440px;
+        margin: 0 auto;
+      }
+
+      .hero {
+        padding: 24px 0 20px;
+      }
+
+      .eyebrow {
+        margin: 0 0 10px;
+        color: var(--accent);
+        font: 12px/1.3 "JetBrains Mono", ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 48px;
+        line-height: 0.98;
+      }
+
+      .lede {
+        max-width: 68ch;
+        margin: 14px 0 0;
+        color: var(--muted);
+        font-size: 16px;
+        line-height: 1.6;
+      }
+
+      .status-strip {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 18px;
+      }
+
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 36px;
+        padding: 8px 12px;
+        border: 1px solid var(--panel-border);
+        border-radius: 8px;
+        background: rgba(14, 18, 15, 0.9);
+        color: var(--muted);
+        font: 12px/1.3 "JetBrains Mono", ui-monospace, monospace;
+      }
+
+      .status-pill strong {
+        color: var(--text);
+      }
+
+      .status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--warn);
+        box-shadow: 0 0 14px rgba(255, 209, 102, 0.45);
+      }
+
+      .status-pill--ok .status-dot {
+        background: var(--accent-2);
+        box-shadow: 0 0 14px rgba(134, 244, 199, 0.45);
+      }
+
+      .status-pill--bad .status-dot {
+        background: var(--bad);
+        box-shadow: 0 0 14px rgba(255, 127, 150, 0.45);
+      }
+
+      .summary-grid,
+      .board-grid {
+        display: grid;
+        gap: 14px;
+      }
+
+      .summary-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        margin-top: 18px;
+      }
+
+      .board-grid {
+        grid-template-columns: 1.25fr 1fr;
+        margin-top: 14px;
+      }
+
+      .panel,
+      .metric {
+        border: 1px solid var(--panel-border);
+        border-radius: 8px;
+        background:
+          linear-gradient(180deg, rgba(18, 24, 19, 0.98), rgba(11, 15, 12, 0.98));
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+      }
+
+      .metric {
+        min-height: 116px;
+        padding: 14px 16px;
+      }
+
+      .metric__label,
+      .panel__eyebrow {
+        margin: 0;
+        color: var(--accent);
+        font: 11px/1.3 "JetBrains Mono", ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0;
+      }
+
+      .metric__value {
+        margin: 10px 0 0;
+        font-size: 34px;
+        line-height: 1;
+      }
+
+      .metric__detail {
+        margin: 10px 0 0;
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.5;
+      }
+
+      .panel {
+        min-height: 240px;
+        padding: 16px;
+      }
+
+      .panel__header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 14px;
+      }
+
+      .panel__title {
+        margin: 8px 0 0;
+        font-size: 22px;
+        line-height: 1.1;
+      }
+
+      .panel__body {
+        display: grid;
+        gap: 10px;
+      }
+
+      .stack {
+        display: grid;
+        gap: 10px;
+      }
+
+      .row {
+        display: grid;
+        gap: 10px;
+        padding: 12px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: rgba(13, 17, 14, 0.82);
+      }
+
+      .row__header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px;
+        justify-content: space-between;
+      }
+
+      .row__title {
+        margin: 0;
+        font-size: 15px;
+        line-height: 1.35;
+      }
+
+      .row__meta,
+      .row__detail {
+        margin: 0;
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.5;
+      }
+
+      .chip-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+        padding: 4px 8px;
+        border-radius: 8px;
+        border: 1px solid rgba(112, 176, 138, 0.28);
+        background: rgba(20, 28, 22, 0.9);
+        color: #ecf6dd;
+        font: 11px/1.2 "JetBrains Mono", ui-monospace, monospace;
+      }
+
+      .chip--good {
+        border-color: rgba(134, 244, 199, 0.28);
+        color: #b7ffd8;
+      }
+
+      .chip--warn {
+        border-color: rgba(255, 209, 102, 0.28);
+        color: #ffe29b;
+      }
+
+      .chip--bad {
+        border-color: rgba(255, 127, 150, 0.28);
+        color: #ffb2c0;
+      }
+
+      .meter {
+        height: 8px;
+        border-radius: 8px;
+        overflow: hidden;
+        background: rgba(24, 34, 24, 0.9);
+      }
+
+      .meter > span {
+        display: block;
+        height: 100%;
+        border-radius: inherit;
+        background: linear-gradient(90deg, var(--accent), var(--accent-2));
+      }
+
+      .empty {
+        padding: 14px;
+        border: 1px dashed var(--line);
+        border-radius: 8px;
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      a,
+      code {
+        color: #f0f5d4;
+      }
+
+      code {
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 12px;
+      }
+
+      .footnote {
+        margin-top: 18px;
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.5;
+      }
+
+      @media (max-width: 1120px) {
+        .summary-grid,
+        .board-grid {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+
+      @media (max-width: 760px) {
+        body {
+          padding: 16px;
+        }
+
+        h1 {
+          font-size: 34px;
+        }
+
+        .metric__value {
+          font-size: 28px;
+        }
+
+        .summary-grid,
+        .board-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <header class="hero">
+        <p class="eyebrow">OpenAgents Nexus</p>
+        <h1>__NEXUS_NAME__</h1>
+        <p class="lede">__NEXUS_DESCRIPTION__ Autopilot uses this host as its default Nexus for relay transport, hosted starter jobs, and kernel authority APIs.</p>
+        <div class="status-strip" id="status-strip">
+          <div class="status-pill">
+            <span class="status-dot"></span>
+            <span><strong>Booting</strong> Loading homepage snapshot…</span>
+          </div>
+          <div class="status-pill"><strong>Relay</strong> <code>__RELAY_WS__</code></div>
+          <div class="status-pill"><strong>Authority</strong> <code>__RELAY_HTTP__api/homepage</code></div>
+          <div class="status-pill"><strong>Durable Storage</strong> <code>__DATA_DIR__</code></div>
+        </div>
+      </header>
+
+      <section class="summary-grid" id="summary-grid"></section>
+
+      <section class="board-grid">
+        <section class="panel">
+          <div class="panel__header">
+            <div>
+              <p class="panel__eyebrow">Connected Pylons</p>
+              <h2 class="panel__title">Live provider presence and ready models</h2>
+            </div>
+          </div>
+          <div class="panel__body stack" id="recent-pylons"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel__header">
+            <div>
+              <p class="panel__eyebrow">Recent Diagnostics</p>
+              <h2 class="panel__title">Latest public speed and runtime checks</h2>
+            </div>
+          </div>
+          <div class="panel__body stack" id="recent-diagnostics"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel__header">
+            <div>
+              <p class="panel__eyebrow">Training Network</p>
+              <h2 class="panel__title">Admitted nodes, roles, and process state</h2>
+            </div>
+          </div>
+          <div class="panel__body stack" id="training-nodes"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel__header">
+            <div>
+              <p class="panel__eyebrow">Run Board</p>
+              <h2 class="panel__title">Current run status and validation pressure</h2>
+            </div>
+          </div>
+          <div class="panel__body stack" id="training-runs"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel__header">
+            <div>
+              <p class="panel__eyebrow">TRN Publications</p>
+              <h2 class="panel__title">Recent public training state propagation</h2>
+            </div>
+          </div>
+          <div class="panel__body stack" id="recent-trn"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel__header">
+            <div>
+              <p class="panel__eyebrow">Entrypoints</p>
+              <h2 class="panel__title">Relay and authority surface</h2>
+            </div>
+          </div>
+          <div class="panel__body">
+            <div class="row">
+              <div class="row__header">
+                <h3 class="row__title">Relay websocket</h3>
+                <span class="chip chip--good">NIP-11</span>
+              </div>
+              <p class="row__detail"><code>__RELAY_WS__</code></p>
+            </div>
+            <div class="row">
+              <div class="row__header">
+                <h3 class="row__title">Authority APIs</h3>
+                <span class="chip">Public</span>
+              </div>
+              <p class="row__detail"><code>__RELAY_HTTP__api/*</code> and <code>__RELAY_HTTP__v1/*</code></p>
+            </div>
+            <div class="row">
+              <div class="row__header">
+                <h3 class="row__title">Managed groups</h3>
+                <span class="chip chip--warn">Deferred</span>
+              </div>
+              <p class="row__detail">Deferred on the durable relay path until thin repository hooks are added for group reads and writes.</p>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <p class="footnote">This page renders only public Nexus truth. It does not invent run-series charts when only summary data is available.</p>
+    </main>
+
+    <script>
+      const statusStrip = document.getElementById("status-strip");
+      const summaryGrid = document.getElementById("summary-grid");
+      const pylonsHost = document.getElementById("recent-pylons");
+      const diagnosticsHost = document.getElementById("recent-diagnostics");
+      const trainingNodesHost = document.getElementById("training-nodes");
+      const trainingRunsHost = document.getElementById("training-runs");
+      const trnHost = document.getElementById("recent-trn");
+      const relayWs = "__RELAY_WS__";
+      const relayHttp = "__RELAY_HTTP__";
+
+      function escapeHtml(value) {
+        return String(value ?? "")
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll("\"", "&quot;")
+          .replaceAll("'", "&#39;");
+      }
+
+      function number(value) {
+        return new Intl.NumberFormat("en-US").format(Number(value ?? 0));
+      }
+
+      function formatMsAge(value) {
+        if (value === null || value === undefined) {
+          return "unknown";
+        }
+        const ms = Number(value);
+        if (!Number.isFinite(ms) || ms <= 0) {
+          return "fresh";
+        }
+        const seconds = Math.floor(ms / 1000);
+        if (seconds < 60) {
+          return `${seconds}s`;
+        }
+        const minutes = Math.floor(seconds / 60);
+        if (minutes < 60) {
+          return `${minutes}m`;
+        }
+        const hours = Math.floor(minutes / 60);
+        if (hours < 48) {
+          return `${hours}h`;
+        }
+        return `${Math.floor(hours / 24)}d`;
+      }
+
+      function formatUnixMs(value) {
+        if (!value) {
+          return "unknown";
+        }
+        try {
+          return new Date(Number(value)).toLocaleString();
+        } catch (_error) {
+          return "unknown";
+        }
+      }
+
+      function formatRatio(current, total) {
+        const safeTotal = Math.max(Number(total ?? 0), 1);
+        return Math.max(0, Math.min(100, Math.round((Number(current ?? 0) / safeTotal) * 100)));
+      }
+
+      function chip(label, tone = "") {
+        const suffix = tone ? ` chip--${tone}` : "";
+        return `<span class="chip${suffix}">${escapeHtml(label)}</span>`;
+      }
+
+      function emptyState(message) {
+        return `<div class="empty">${escapeHtml(message)}</div>`;
+      }
+
+      function renderStatus(snapshot, degradedMessage = null) {
+        const stats = snapshot?.stats ?? {};
+        const summary = snapshot?.training_summary ?? {};
+        const isLive = Boolean(snapshot);
+        const statusTone = degradedMessage ? "status-pill--bad" : "status-pill--ok";
+        const statusLabel = degradedMessage ? "Degraded" : "Live";
+        const heartbeatBudget = stats.pylon_presence_stale_after_ms ?? 0;
+        statusStrip.innerHTML = `
+          <div class="status-pill ${statusTone}">
+            <span class="status-dot"></span>
+            <span><strong>${statusLabel}</strong> ${escapeHtml(degradedMessage ?? "Public homepage snapshot is current.")}</span>
+          </div>
+          <div class="status-pill"><strong>Generated</strong> ${escapeHtml(formatUnixMs(snapshot?.generated_at_unix_ms))}</div>
+          <div class="status-pill"><strong>Presence Window</strong> ${escapeHtml(formatMsAge(heartbeatBudget))}</div>
+          <div class="status-pill"><strong>Default Run</strong> ${escapeHtml(snapshot?.default_run_id ?? "none")}</div>
+          <div class="status-pill"><strong>Default Network</strong> ${escapeHtml(snapshot?.default_network_id ?? "none")}</div>
+          <div class="status-pill"><strong>Relay</strong> <code>${escapeHtml(relayWs)}</code></div>
+          <div class="status-pill"><strong>Homepage API</strong> <code>${escapeHtml(relayHttp)}api/homepage</code></div>
+          <div class="status-pill"><strong>Validation Queue</strong> ${escapeHtml(number(summary.pending_validation_windows ?? 0))}</div>
+        `;
+      }
+
+      function renderSummary(snapshot) {
+        const stats = snapshot.stats;
+        const summary = snapshot.training_summary;
+        const metricCards = [
+          {
+            label: "Pylons Online",
+            value: number(stats.pylons_online_now),
+            detail: `${number(stats.sellable_pylons_online_now)} sellable now • ${number(stats.pylons_seen_24h)} seen in 24h`,
+          },
+          {
+            label: "Sessions",
+            value: number(stats.pylon_sessions_online_now),
+            detail: `${number(stats.recent_pylons.length)} recent pylon records in sample`,
+          },
+          {
+            label: "Training Nodes",
+            value: number(summary.admitted_nodes_online),
+            detail: `${number(snapshot.training_nodes.length)} admitted nodes tracked`,
+          },
+          {
+            label: "Active Runs",
+            value: number(summary.active_runs),
+            detail: `${number(summary.active_windows)} windows active • ${number(summary.pending_validation_windows)} pending validation`,
+          },
+          {
+            label: "Validator Pressure",
+            value: number(summary.validator_challenges_open),
+            detail: `${number(summary.validator_challenges_queued)} queued validator challenges`,
+          },
+          {
+            label: "Checkpoint Age",
+            value: escapeHtml(formatMsAge(summary.checkpoint_max_age_ms)),
+            detail: `${number(summary.payout_eligible_closeouts)} payout-eligible closeouts`,
+          },
+          {
+            label: "Payouts",
+            value: `${number(stats.nexus_payout_sats_paid_24h ?? 0)} sats`,
+            detail: `${number(stats.nexus_payout_sats_paid_total ?? 0)} sats total sent`,
+          },
+          {
+            label: "TRN Publications",
+            value: number(snapshot.recent_trn_publications.length),
+            detail: `${number(snapshot.recent_trn_publications.filter((item) => item.pending_retry).length)} pending retry`,
+          },
+        ];
+
+        summaryGrid.innerHTML = metricCards.map((metric) => `
+          <article class="metric">
+            <p class="metric__label">${escapeHtml(metric.label)}</p>
+            <p class="metric__value">${metric.value}</p>
+            <p class="metric__detail">${escapeHtml(metric.detail)}</p>
+          </article>
+        `).join("");
+      }
+
+      function renderPylons(snapshot) {
+        const pylons = snapshot.stats.recent_pylons ?? [];
+        if (pylons.length === 0) {
+          pylonsHost.innerHTML = emptyState("No public pylon-presence sample is available yet.");
+          return;
+        }
+
+        pylonsHost.innerHTML = pylons.map((pylon) => {
+          const title = pylon.node_label || pylon.nostr_pubkey_short;
+          const products = Array.isArray(pylon.products) ? pylon.products.slice(0, 3) : [];
+          const meter = formatRatio(pylon.eligible_product_count, Math.max(pylon.eligible_product_count, 4));
+          return `
+            <article class="row">
+              <div class="row__header">
+                <h3 class="row__title">${escapeHtml(title)}</h3>
+                <div class="chip-row">
+                  ${chip(pylon.runtime_state || "unknown", pylon.runtime_state === "online" ? "good" : "warn")}
+                  ${chip(`${number(pylon.eligible_product_count)} eligible`, pylon.eligible_product_count > 0 ? "good" : "warn")}
+                  ${pylon.ready_model ? chip(pylon.ready_model, "good") : chip("model unknown", "warn")}
+                </div>
+              </div>
+              <div class="meter"><span style="width:${meter}%"></span></div>
+              <p class="row__meta">${escapeHtml(pylon.client_version || "client unknown")} • last seen ${escapeHtml(formatUnixMs(pylon.last_seen_at_unix_ms))}</p>
+              <p class="row__detail">${products.length > 0 ? escapeHtml(products.join(" • ")) : "No public product sample"}</p>
+            </article>
+          `;
+        }).join("");
+      }
+
+      function renderDiagnostics(snapshot) {
+        const diagnostics = snapshot.stats.recent_pylon_diagnostics ?? [];
+        if (diagnostics.length === 0) {
+          diagnosticsHost.innerHTML = emptyState("No recent public diagnostics are available.");
+          return;
+        }
+
+        diagnosticsHost.innerHTML = diagnostics.map((diagnostic) => `
+          <article class="row">
+            <div class="row__header">
+              <h3 class="row__title">${escapeHtml(diagnostic.node_label || diagnostic.nostr_pubkey_short)}</h3>
+              <div class="chip-row">
+                ${chip(diagnostic.status, diagnostic.status === "ok" ? "good" : diagnostic.status === "failed" ? "bad" : "warn")}
+                ${chip(diagnostic.runtime_backend)}
+              </div>
+            </div>
+            <p class="row__meta">${escapeHtml(diagnostic.model_id)} • measured ${escapeHtml(formatUnixMs(diagnostic.measured_at_unix_ms))}</p>
+            <p class="row__detail">
+              ${escapeHtml(`load ${diagnostic.load_s ?? "?"}s • ttft ${diagnostic.mean_ttft_s ?? "?"}s • decode ${diagnostic.mean_decode_tok_s ?? "?"}s/tok`)}
+            </p>
+          </article>
+        `).join("");
+      }
+
+      function renderTrainingNodes(snapshot) {
+        const nodes = snapshot.training_nodes ?? [];
+        if (nodes.length === 0) {
+          trainingNodesHost.innerHTML = emptyState("No admitted training nodes are available.");
+          return;
+        }
+
+        trainingNodesHost.innerHTML = nodes.map((node) => {
+          const roles = Array.isArray(node.role_claims) ? node.role_claims : [];
+          const labels = Array.isArray(node.active_reputation_labels) ? node.active_reputation_labels.slice(0, 3) : [];
+          return `
+            <article class="row">
+              <div class="row__header">
+                <h3 class="row__title">${escapeHtml(node.node_label || node.node_pubkey_hex)}</h3>
+                <div class="chip-row">
+                  ${chip(node.online ? "online" : "offline", node.online ? "good" : "bad")}
+                  ${chip(node.eligible ? "eligible" : "gated", node.eligible ? "good" : "warn")}
+                  ${node.last_process_state ? chip(node.last_process_state) : chip("state unknown", "warn")}
+                </div>
+              </div>
+              <p class="row__meta">${escapeHtml(node.build_version || node.build_digest)} • last heartbeat ${escapeHtml(formatUnixMs(node.last_heartbeat_at_ms))}</p>
+              <div class="chip-row">
+                ${roles.map((role) => chip(role)).join("")}
+                ${labels.map((label) => chip(label, "warn")).join("")}
+                ${node.allowed_networks.map((network) => chip(network, "good")).join("")}
+              </div>
+              <p class="row__detail">${escapeHtml(`run ${node.last_training_run_id || "none"} • window ${node.last_window_id || "none"} • memory ${node.available_memory_gb ?? "?"} GB • disk ${node.available_disk_gb ?? "?"} GB`)}</p>
+            </article>
+          `;
+        }).join("");
+      }
+
+      function renderTrainingRuns(snapshot) {
+        const runs = snapshot.training_summary.runs ?? [];
+        if (runs.length === 0) {
+          trainingRunsHost.innerHTML = emptyState("No public training runs are active.");
+          return;
+        }
+
+        trainingRunsHost.innerHTML = runs.map((run) => {
+          const participation = formatRatio(run.admitted_nodes_online, Math.max(run.worker_target_count + run.validator_target_count + run.recovery_source_target_count, run.admitted_nodes_online, 1));
+          return `
+            <article class="row">
+              <div class="row__header">
+                <h3 class="row__title">${escapeHtml(run.training_run_id)}</h3>
+                <div class="chip-row">
+                  ${chip(run.run_status, run.run_status === "running" ? "good" : "warn")}
+                  ${chip(run.scheduler_window_state, run.pending_validation_window_count > 0 ? "warn" : "good")}
+                  ${chip(run.network_id)}
+                </div>
+              </div>
+              <div class="meter"><span style="width:${participation}%"></span></div>
+              <p class="row__meta">${escapeHtml(`workers ${run.worker_nodes_online}/${run.worker_target_count} • validators ${run.validator_nodes_online}/${run.validator_target_count} • recovery ${run.recovery_source_nodes_online}/${run.recovery_source_target_count}`)}</p>
+              <p class="row__detail">${escapeHtml(`window ${run.current_window_id} • checkpoint ${run.latest_checkpoint_ref || "none"} • checkpoint age ${formatMsAge(run.latest_checkpoint_age_ms)} • closeout ${run.latest_closeout_status || "none"}`)}</p>
+            </article>
+          `;
+        }).join("");
+      }
+
+      function renderTrn(snapshot) {
+        const publications = snapshot.recent_trn_publications ?? [];
+        if (publications.length === 0) {
+          trnHost.innerHTML = emptyState("No public TRN publication sample is available.");
+          return;
+        }
+
+        trnHost.innerHTML = publications.map((publication) => `
+          <article class="row">
+            <div class="row__header">
+              <h3 class="row__title">${escapeHtml(publication.subject_kind)} • ${escapeHtml(publication.subject_id)}</h3>
+              <div class="chip-row">
+                ${chip(publication.publication_state, publication.publication_state === "published" ? "good" : publication.pending_retry ? "bad" : "warn")}
+                ${chip(`kind ${publication.event_kind}`)}
+              </div>
+            </div>
+            <p class="row__meta">${escapeHtml(publication.publication_key)} • published ${escapeHtml(formatUnixMs(publication.published_at_ms))}</p>
+            <p class="row__detail">${escapeHtml(`attempts ${publication.attempt_count} • last attempt ${formatUnixMs(publication.last_attempt_at_ms)}${publication.last_error ? ` • ${publication.last_error}` : ""}`)}</p>
+          </article>
+        `).join("");
+      }
+
+      async function loadHomepage() {
+        try {
+          const response = await fetch("/api/homepage", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`homepage request failed: ${response.status}`);
+          }
+          const snapshot = await response.json();
+          renderStatus(snapshot);
+          renderSummary(snapshot);
+          renderPylons(snapshot);
+          renderDiagnostics(snapshot);
+          renderTrainingNodes(snapshot);
+          renderTrainingRuns(snapshot);
+          renderTrn(snapshot);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          renderStatus(null, message);
+          summaryGrid.innerHTML = "";
+          pylonsHost.innerHTML = emptyState("Homepage snapshot is unavailable.");
+          diagnosticsHost.innerHTML = emptyState("Diagnostics unavailable.");
+          trainingNodesHost.innerHTML = emptyState("Training nodes unavailable.");
+          trainingRunsHost.innerHTML = emptyState("Training runs unavailable.");
+          trnHost.innerHTML = emptyState("TRN publication sample unavailable.");
+        }
+      }
+
+      loadHomepage();
+      window.setInterval(loadHomepage, 5000);
+    </script>
+  </body>
+</html>
+"#;
 
 #[derive(Debug, Clone)]
 pub struct DurableRelayConfig {
@@ -400,14 +1146,12 @@ fn render_homepage(config: &DurableRelayConfig) -> String {
     let public_http_url = config
         .public_http_url()
         .unwrap_or_else(|| "http://127.0.0.1/".to_string());
-    format!(
-        "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><title>{name}</title><style>body{{margin:0;background:#050b16;color:#d6dfec;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}}main{{max-width:880px;margin:0 auto;padding:56px 24px 80px}}h1{{margin:0;font-size:40px;line-height:1.05;color:#f8fbff}}p{{line-height:1.65;color:#93a4ba}}code{{background:#0e1828;color:#a9d7ff;padding:2px 6px;border-radius:6px}}.lede{{max-width:60ch;margin-top:12px}}.grid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;margin-top:28px}}.panel{{padding:18px 20px;border-radius:14px;border:1px solid #1c3553;background:#091120;box-shadow:0 10px 30px rgba(0,0,0,.25)}}.label{{display:block;margin-bottom:8px;font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:#6f89a8}}.value{{font-size:14px;line-height:1.55;color:#f1f6fd;word-break:break-word}}ul{{margin:0;padding-left:18px}}li+li{{margin-top:8px}}</style></head><body><main><h1>{name}</h1><p class=\"lede\">{description} Autopilot uses this host as its default Nexus for relay transport, hosted starter jobs, and kernel authority APIs.</p><div class=\"grid\"><section class=\"panel\"><span class=\"label\">Autopilot Default Relay</span><div class=\"value\"><code>{relay_ws}</code></div></section><section class=\"panel\"><span class=\"label\">Hosted Authority</span><div class=\"value\"><code>{relay_http}api/*</code><br><code>{relay_http}v1/*</code></div></section><section class=\"panel\"><span class=\"label\">Nostr Entry Points</span><div class=\"value\"><ul><li><code>{relay_ws}</code> websocket + NIP-11</li><li><code>{relay_http}ws</code> websocket alias</li><li><code>{relay_http}metrics</code> operator metrics</li></ul></div></section><section class=\"panel\"><span class=\"label\">Managed Groups</span><div class=\"value\">Deferred on the durable relay path until we add thin repository hooks for group reads and writes. The legacy in-memory managed-group module is not on the production path.</div></section><section class=\"panel\"><span class=\"label\">Durable Storage</span><div class=\"value\"><code>{data_dir}</code></div></section></div></main></body></html>",
-        name = NEXUS_PRODUCT_NAME,
-        description = NEXUS_PRODUCT_DESCRIPTION,
-        relay_ws = config.public_ws_url,
-        relay_http = public_http_url,
-        data_dir = config.data_dir.display(),
-    )
+    HOMEPAGE_TEMPLATE
+        .replace("__NEXUS_NAME__", NEXUS_PRODUCT_NAME)
+        .replace("__NEXUS_DESCRIPTION__", NEXUS_PRODUCT_DESCRIPTION)
+        .replace("__RELAY_WS__", config.public_ws_url.as_str())
+        .replace("__RELAY_HTTP__", public_http_url.as_str())
+        .replace("__DATA_DIR__", &config.data_dir.display().to_string())
 }
 
 fn copy_proxy_response_headers(target: &mut HeaderMap, source: &HeaderMap) {
@@ -724,10 +1468,11 @@ mod tests {
         assert!(body.contains(super::NEXUS_PRODUCT_DESCRIPTION));
         assert!(body.contains(expected_relay_url.as_str()));
         assert!(body.contains(expected_http_url.as_str()));
-        assert!(body.contains("Autopilot Default Relay"));
-        assert!(body.contains("Hosted Authority"));
-        assert!(body.contains("Managed Groups"));
-        assert!(body.contains("Deferred on the durable relay path"));
+        assert!(body.contains("Connected Pylons"));
+        assert!(body.contains("Training Network"));
+        assert!(body.contains("Run Board"));
+        assert!(body.contains("/api/homepage"));
+        assert!(body.contains("public pylon-presence sample"));
         assert!(body.contains("kernel authority APIs"));
 
         server.abort();
@@ -805,6 +1550,16 @@ mod tests {
             .send()
             .await?;
         assert_eq!(stats.status(), StatusCode::OK);
+
+        let homepage = client
+            .get(format!("http://{addr}/api/homepage"))
+            .send()
+            .await?;
+        assert_eq!(homepage.status(), StatusCode::OK);
+        let homepage: Value = homepage.json().await?;
+        assert!(homepage.get("stats").is_some());
+        assert!(homepage.get("training_summary").is_some());
+        assert!(homepage.get("training_nodes").is_some());
 
         let snapshot = client
             .get(format!("http://{addr}/v1/kernel/snapshots/0"))


### PR DESCRIPTION
## Summary
- add a public `/api/homepage` Nexus aggregate snapshot route for stats, training summary, training nodes, and recent TRN publications
- replace the relay root text shell with a live public board that renders connected pylons, diagnostics, training nodes, run state, and entrypoints from same-origin homepage data
- stabilize homepage JSON arrays so the board and tests get a consistent payload shape even when lists are empty

## Testing
- cargo test -p nexus-control homepage_snapshot_aggregates_public_stats_training_state_and_recent_trn
- cargo test -p nexus-control training_operator_summary_and_stats_surface_live_run_state
- cargo test -p nexus-relay durable_root_renders_nexus_branding
- cargo test -p nexus-relay durable_shell_serves_in_process_authority_routes

Closes #4263
Closes #4264
