### PR TITLE
Add Nexus tail-latency regression gate

### DIFF
--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -621,6 +621,12 @@ pub struct ProviderPresenceResponse {
     pub stale_after_ms: u64,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+struct ProviderPresenceHeartbeatQuery {
+    #[serde(default)]
+    dry_run: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HealthResponse {
     pub ok: bool,
@@ -4512,6 +4518,7 @@ async fn homepage_snapshot(
 
 async fn record_provider_presence_heartbeat(
     State(state): State<AppState>,
+    Query(query): Query<ProviderPresenceHeartbeatQuery>,
     Json(request): Json<ProviderPresenceHeartbeatRequest>,
 ) -> Result<Json<ProviderPresenceResponse>, ApiError> {
     let normalized_request = ProviderPresenceHeartbeatRequest {
@@ -4531,6 +4538,17 @@ async fn record_provider_presence_heartbeat(
         hosting_telemetry: request.hosting_telemetry,
     };
     let now = now_unix_ms();
+    if query.dry_run {
+        return Ok(Json(ProviderPresenceResponse {
+            authority: "openagents-hosted-nexus".to_string(),
+            session_id: normalized_request.session_id.clone(),
+            nostr_pubkey_hex: normalized_request.nostr_pubkey_hex.clone(),
+            status: "online".to_string(),
+            recorded_at_unix_ms: now,
+            heartbeat_interval_ms: DEFAULT_PROVIDER_PRESENCE_HEARTBEAT_INTERVAL_MS,
+            stale_after_ms: state.config.provider_presence_stale_after_ms,
+        }));
+    }
     let mut store = state.store.write().map_err(|_| ApiError {
         status: StatusCode::INTERNAL_SERVER_ERROR,
         error: "internal_error",
@@ -17880,6 +17898,51 @@ mod tests {
         assert_eq!(stats.pylons_seen_24h, 2);
         assert_eq!(stats.pylon_sessions_online_now, 2);
         assert_eq!(stats.sellable_pylons_online_now, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn provider_presence_heartbeat_dry_run_leaves_public_stats_unchanged() -> Result<()> {
+        let app = build_router(test_config()?);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/provider-presence/heartbeat?dry_run=true")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&provider_presence_request(
+                        "aabbccdd00112233",
+                        "session-a-1",
+                        "alpha",
+                        1,
+                        "online",
+                    ))?))?,
+            )
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        let heartbeat: ProviderPresenceResponse = response_json(response).await?;
+        assert_eq!(heartbeat.status, "online");
+        assert_eq!(heartbeat.session_id, "session-a-1");
+
+        let stats_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/stats")
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(stats_response.status(), StatusCode::OK);
+        let stats: PublicStatsSnapshot = response_json(stats_response).await?;
+        assert_eq!(stats.pylons_online_now, 0);
+        assert_eq!(stats.pylons_seen_24h, 0);
+        assert_eq!(stats.pylon_sessions_online_now, 0);
+        assert_eq!(stats.sellable_pylons_online_now, 0);
+        assert!(stats.recent_pylons.is_empty());
+        assert!(stats.recent_pylon_diagnostics.is_empty());
         Ok(())
     }
 

--- a/docs/deploy/NEXUS_GCP_RUNBOOK.md
+++ b/docs/deploy/NEXUS_GCP_RUNBOOK.md
@@ -88,6 +88,8 @@ the rollout if:
 - the VM or `nexus-relay` systemd service is not healthy
 - `/healthz`, `/api/stats`, or `/v1/treasury/status` latency regresses past the
   configured thresholds
+- repeated local-origin probes show bad tail latency on `/healthz`,
+  `/api/stats`, or `/api/provider-presence/heartbeat?dry_run=true`
 - treasury policy on the live status surface drifts from
   `/etc/nexus-relay/nexus-relay.env`
 - treasury snapshot freshness or wallet-sync freshness crosses the configured
@@ -101,10 +103,20 @@ Optional local threshold overrides:
 VERIFY_HEALTH_LATENCY_MAX_MS=1000 \
 VERIFY_STATS_LATENCY_MAX_MS=1000 \
 VERIFY_TREASURY_LATENCY_MAX_MS=1000 \
+VERIFY_LATENCY_SAMPLE_COUNT=40 \
+VERIFY_HEALTH_LATENCY_P95_MAX_MS=1000 \
+VERIFY_HEALTH_LATENCY_P99_MAX_MS=2000 \
+VERIFY_STATS_LATENCY_P95_MAX_MS=1000 \
+VERIFY_STATS_LATENCY_P99_MAX_MS=2000 \
+VERIFY_PROVIDER_PRESENCE_LATENCY_P95_MAX_MS=1000 \
+VERIFY_PROVIDER_PRESENCE_LATENCY_P99_MAX_MS=2000 \
 VERIFY_TREASURY_SNAPSHOT_MAX_AGE_MS=15000 \
 VERIFY_TREASURY_WALLET_SYNC_MAX_LAG_MS=15000 \
 scripts/deploy/nexus/04-verify-gates.sh
 ```
+
+The provider-presence probe now uses `dry_run=true` so deploy verification hits
+the real heartbeat handler without polluting live public pylon counts.
 
 ## 4) Runtime model
 

--- a/docs/nexus-treasury.md
+++ b/docs/nexus-treasury.md
@@ -347,9 +347,12 @@ Deployment gating:
 - `scripts/deploy/nexus/04-verify-gates.sh` now measures `/healthz`,
   `/api/stats`, and `/v1/treasury/status` latency directly on the VM and fails
   the rollout if latency exceeds the configured thresholds
+- the verifier now also runs repeated local-origin probes against `/healthz`,
+  `/api/stats`, and `/api/provider-presence/heartbeat?dry_run=true`, then fails
+  the rollout if p95 or p99 tail latency exceeds the configured budget
 - the deploy verifier now fails if live treasury policy diverges from the VM env
   file, if snapshot freshness regresses, or if critical treasury continuity
   alerts are active
 - the deploy receipt now includes explicit gate pass/fail rows, endpoint
-  latency, treasury policy evidence, recent payout activity, snapshot freshness,
-  and active continuity alerts
+  latency, tail-latency samples, treasury policy evidence, recent payout
+  activity, snapshot freshness, and active continuity alerts

--- a/scripts/deploy/nexus/04-verify-gates.sh
+++ b/scripts/deploy/nexus/04-verify-gates.sh
@@ -16,6 +16,13 @@ RECEIPT_PATH="${REPORT_DIR}/${STAMP}-deploy-receipt.json"
 VERIFY_HEALTH_LATENCY_MAX_MS="${VERIFY_HEALTH_LATENCY_MAX_MS:-1000}"
 VERIFY_STATS_LATENCY_MAX_MS="${VERIFY_STATS_LATENCY_MAX_MS:-1000}"
 VERIFY_TREASURY_LATENCY_MAX_MS="${VERIFY_TREASURY_LATENCY_MAX_MS:-1000}"
+VERIFY_LATENCY_SAMPLE_COUNT="${VERIFY_LATENCY_SAMPLE_COUNT:-40}"
+VERIFY_HEALTH_LATENCY_P95_MAX_MS="${VERIFY_HEALTH_LATENCY_P95_MAX_MS:-1000}"
+VERIFY_HEALTH_LATENCY_P99_MAX_MS="${VERIFY_HEALTH_LATENCY_P99_MAX_MS:-2000}"
+VERIFY_STATS_LATENCY_P95_MAX_MS="${VERIFY_STATS_LATENCY_P95_MAX_MS:-1000}"
+VERIFY_STATS_LATENCY_P99_MAX_MS="${VERIFY_STATS_LATENCY_P99_MAX_MS:-2000}"
+VERIFY_PROVIDER_PRESENCE_LATENCY_P95_MAX_MS="${VERIFY_PROVIDER_PRESENCE_LATENCY_P95_MAX_MS:-1000}"
+VERIFY_PROVIDER_PRESENCE_LATENCY_P99_MAX_MS="${VERIFY_PROVIDER_PRESENCE_LATENCY_P99_MAX_MS:-2000}"
 VERIFY_TREASURY_SNAPSHOT_MAX_AGE_MS="${VERIFY_TREASURY_SNAPSHOT_MAX_AGE_MS:-15000}"
 VERIFY_TREASURY_WALLET_SYNC_MAX_LAG_MS="${VERIFY_TREASURY_WALLET_SYNC_MAX_LAG_MS:-15000}"
 
@@ -50,6 +57,72 @@ with urllib.request.urlopen(url, timeout=20) as response:
 print(json.dumps({
     "body": json.loads(body),
     "latency_ms": int((time.time() - started) * 1000),
+}))
+PY
+EOF
+)"
+}
+
+fetch_json_probe_series() {
+  local url="$1"
+  local method="${2:-GET}"
+  local request_body="${3:-}"
+  local sample_count="${4:-$VERIFY_LATENCY_SAMPLE_COUNT}"
+  local url_json method_json body_json
+  url_json="$(printf '%s' "$url" | jq -Rs .)"
+  method_json="$(printf '%s' "$method" | jq -Rs .)"
+  body_json="$(printf '%s' "$request_body" | jq -Rs .)"
+  ssh_vm "$(cat <<EOF
+python3 - <<'PY'
+import json
+import math
+import time
+import urllib.request
+
+url = json.loads(${url_json})
+method = json.loads(${method_json}).upper()
+body = json.loads(${body_json})
+sample_count = int(${sample_count})
+
+headers = {}
+request_data = None
+if method == "POST":
+    headers["content-type"] = "application/json"
+    request_data = body.encode()
+
+latencies = []
+last_body = None
+for _ in range(sample_count):
+    request = urllib.request.Request(
+        url,
+        data=request_data,
+        headers=headers,
+        method=method,
+    )
+    started = time.time()
+    with urllib.request.urlopen(request, timeout=20) as response:
+        last_body = json.loads(response.read().decode())
+    latencies.append(int((time.time() - started) * 1000))
+
+sorted_latencies = sorted(latencies)
+
+def percentile(values, pct):
+    if not values:
+        return 0
+    index = max(0, math.ceil((pct / 100.0) * len(values)) - 1)
+    return values[min(index, len(values) - 1)]
+
+print(json.dumps({
+    "body": last_body,
+    "sample_count": len(latencies),
+    "samples_ms": latencies,
+    "latency_ms": {
+        "min": min(sorted_latencies) if sorted_latencies else 0,
+        "p50": percentile(sorted_latencies, 50),
+        "p95": percentile(sorted_latencies, 95),
+        "p99": percentile(sorted_latencies, 99),
+        "max": max(sorted_latencies) if sorted_latencies else 0,
+    },
 }))
 PY
 EOF
@@ -100,8 +173,67 @@ INSTANCE_STATUS="$(gcloud compute instances describe "$NEXUS_VM" \
   --zone "$GCP_ZONE" \
   --format='value(status)')"
 
+PROVIDER_PRESENCE_DRY_RUN_REQUEST="$(jq -nc --arg relay_url "$NEXUS_PUBLIC_WS_URL" '
+  {
+    nostr_pubkey_hex: "0000000000000000000000000000000000000000000000000000000000004254",
+    session_id: "deploy-verify-heartbeat",
+    node_label: "deploy-verify",
+    client_version: "nexus-deploy-verifier",
+    relay_urls: [$relay_url],
+    products: [],
+    eligible_product_count: 0,
+    ready_model: null,
+    runtime_state: "deploy_probe",
+    diagnostic_summaries: [],
+    hosting_telemetry: {
+      captured_at_unix_ms: 0,
+      runtime: {
+        mode: "offline",
+        last_action: null,
+        last_error: null,
+        degraded_reason_code: null,
+        authoritative_status: null,
+        authoritative_error_class: null,
+        queue_depth: 0,
+        online_uptime_seconds: 0,
+        inventory_session_started_at_ms: null,
+        last_completed_job_at_epoch_ms: null,
+        last_authoritative_event_id: null,
+        execution_backend_label: "no active inference backend",
+        provider_blocker_codes: []
+      },
+      availability: {
+        local_gemma: {
+          reachable: false,
+          ready: false,
+          configured_model: null,
+          ready_model: null,
+          available_models: [],
+          last_error: null,
+          last_action: null,
+          availability_message: null,
+          latency_ms_p50: null
+        },
+        sandbox: {
+          runtimes: [],
+          profiles: [],
+          last_scan_error: null
+        }
+      },
+      inventory_rows: []
+    }
+  }'
+)"
+
 HEALTH_RESULT="$(fetch_json_probe "http://127.0.0.1:8080/healthz")"
 STATS_RESULT="$(fetch_json_probe "http://127.0.0.1:8080/api/stats")"
+HEALTH_SERIES_RESULT="$(fetch_json_probe_series "http://127.0.0.1:8080/healthz")"
+STATS_SERIES_RESULT="$(fetch_json_probe_series "http://127.0.0.1:8080/api/stats")"
+PROVIDER_PRESENCE_SERIES_RESULT="$(fetch_json_probe_series \
+  "http://127.0.0.1:8080/api/provider-presence/heartbeat?dry_run=true" \
+  "POST" \
+  "$PROVIDER_PRESENCE_DRY_RUN_REQUEST"
+)"
 
 if [[ "${NEXUS_CONTROL_TREASURY_ENABLED}" == "true" ]]; then
   TREASURY_RESULT="$(fetch_json_probe "http://127.0.0.1:8080/v1/treasury/status")"
@@ -123,11 +255,21 @@ jq -n \
   --arg data_mount "$DATA_DIR_STATUS_RAW" \
   --argjson health_result "$HEALTH_RESULT" \
   --argjson stats_result "$STATS_RESULT" \
+  --argjson health_series_result "$HEALTH_SERIES_RESULT" \
+  --argjson stats_series_result "$STATS_SERIES_RESULT" \
+  --argjson provider_presence_series_result "$PROVIDER_PRESENCE_SERIES_RESULT" \
   --argjson treasury_result "$TREASURY_RESULT" \
   --argjson treasury_env "$TREASURY_ENV_JSON" \
   --argjson verify_health_latency_max_ms "$VERIFY_HEALTH_LATENCY_MAX_MS" \
   --argjson verify_stats_latency_max_ms "$VERIFY_STATS_LATENCY_MAX_MS" \
   --argjson verify_treasury_latency_max_ms "$VERIFY_TREASURY_LATENCY_MAX_MS" \
+  --argjson verify_latency_sample_count "$VERIFY_LATENCY_SAMPLE_COUNT" \
+  --argjson verify_health_latency_p95_max_ms "$VERIFY_HEALTH_LATENCY_P95_MAX_MS" \
+  --argjson verify_health_latency_p99_max_ms "$VERIFY_HEALTH_LATENCY_P99_MAX_MS" \
+  --argjson verify_stats_latency_p95_max_ms "$VERIFY_STATS_LATENCY_P95_MAX_MS" \
+  --argjson verify_stats_latency_p99_max_ms "$VERIFY_STATS_LATENCY_P99_MAX_MS" \
+  --argjson verify_provider_presence_latency_p95_max_ms "$VERIFY_PROVIDER_PRESENCE_LATENCY_P95_MAX_MS" \
+  --argjson verify_provider_presence_latency_p99_max_ms "$VERIFY_PROVIDER_PRESENCE_LATENCY_P99_MAX_MS" \
   --argjson verify_treasury_snapshot_max_age_ms "$VERIFY_TREASURY_SNAPSHOT_MAX_AGE_MS" \
   --argjson verify_treasury_wallet_sync_max_lag_ms "$VERIFY_TREASURY_WALLET_SYNC_MAX_LAG_MS" \
   '
@@ -216,6 +358,64 @@ jq -n \
         ($stats_result.latency_ms <= $verify_stats_latency_max_ms);
         (if $stats_result.latency_ms > $verify_stats_latency_max_ms then "stats_latency_exceeded" else null end);
         {latency_ms: $stats_result.latency_ms, max_latency_ms: $verify_stats_latency_max_ms}
+      ),
+      gate(
+        "health_endpoint_tail_latency";
+        (
+          (($health_series_result.body.ok // false) == true) and
+          (($health_series_result.latency_ms.p95 // 0) <= $verify_health_latency_p95_max_ms) and
+          (($health_series_result.latency_ms.p99 // 0) <= $verify_health_latency_p99_max_ms)
+        );
+        (
+          if (($health_series_result.body.ok // false) != true) then "healthz_not_ok"
+          elif (($health_series_result.latency_ms.p95 // 0) > $verify_health_latency_p95_max_ms) then "healthz_p95_latency_exceeded"
+          elif (($health_series_result.latency_ms.p99 // 0) > $verify_health_latency_p99_max_ms) then "healthz_p99_latency_exceeded"
+          else null end
+        );
+        {
+          sample_count: $health_series_result.sample_count,
+          latency_ms: $health_series_result.latency_ms,
+          max_p95_latency_ms: $verify_health_latency_p95_max_ms,
+          max_p99_latency_ms: $verify_health_latency_p99_max_ms
+        }
+      ),
+      gate(
+        "stats_endpoint_tail_latency";
+        (
+          (($stats_series_result.latency_ms.p95 // 0) <= $verify_stats_latency_p95_max_ms) and
+          (($stats_series_result.latency_ms.p99 // 0) <= $verify_stats_latency_p99_max_ms)
+        );
+        (
+          if (($stats_series_result.latency_ms.p95 // 0) > $verify_stats_latency_p95_max_ms) then "stats_p95_latency_exceeded"
+          elif (($stats_series_result.latency_ms.p99 // 0) > $verify_stats_latency_p99_max_ms) then "stats_p99_latency_exceeded"
+          else null end
+        );
+        {
+          sample_count: $stats_series_result.sample_count,
+          latency_ms: $stats_series_result.latency_ms,
+          max_p95_latency_ms: $verify_stats_latency_p95_max_ms,
+          max_p99_latency_ms: $verify_stats_latency_p99_max_ms
+        }
+      ),
+      gate(
+        "provider_presence_heartbeat_tail_latency";
+        (
+          (($provider_presence_series_result.body.status // "") == "online") and
+          (($provider_presence_series_result.latency_ms.p95 // 0) <= $verify_provider_presence_latency_p95_max_ms) and
+          (($provider_presence_series_result.latency_ms.p99 // 0) <= $verify_provider_presence_latency_p99_max_ms)
+        );
+        (
+          if (($provider_presence_series_result.body.status // "") != "online") then "provider_presence_heartbeat_failed"
+          elif (($provider_presence_series_result.latency_ms.p95 // 0) > $verify_provider_presence_latency_p95_max_ms) then "provider_presence_p95_latency_exceeded"
+          elif (($provider_presence_series_result.latency_ms.p99 // 0) > $verify_provider_presence_latency_p99_max_ms) then "provider_presence_p99_latency_exceeded"
+          else null end
+        );
+        {
+          sample_count: $provider_presence_series_result.sample_count,
+          latency_ms: $provider_presence_series_result.latency_ms,
+          max_p95_latency_ms: $verify_provider_presence_latency_p95_max_ms,
+          max_p99_latency_ms: $verify_provider_presence_latency_p99_max_ms
+        }
       )
     ]
     +
@@ -285,6 +485,17 @@ jq -n \
       healthz: $health_result.latency_ms,
       stats: $stats_result.latency_ms,
       treasury_status: $treasury_result.latency_ms
+    },
+    tail_latency_ms: {
+      sample_count: $verify_latency_sample_count,
+      healthz: $health_series_result.latency_ms,
+      stats: $stats_series_result.latency_ms,
+      provider_presence_heartbeat: $provider_presence_series_result.latency_ms
+    },
+    tail_latency_samples_ms: {
+      healthz: $health_series_result.samples_ms,
+      stats: $stats_series_result.samples_ms,
+      provider_presence_heartbeat: $provider_presence_series_result.samples_ms
     },
     treasury_policy_env: $treasury_env,
     treasury_policy_status: treasury_policy_status,


### PR DESCRIPTION
## Summary
- add a `dry_run=true` path on the provider-presence heartbeat route so deploy probes can hit the real handler without polluting public pylon presence state
- extend the Nexus deploy verifier with repeated `/healthz`, `/api/stats`, and provider-presence heartbeat probes plus p95/p99 tail-latency gates and receipt output
- document the new verifier thresholds and dry-run heartbeat probe in the Nexus deploy runbooks

## Testing
- `cargo test -p nexus-control provider_presence_`
- `bash -n scripts/deploy/nexus/04-verify-gates.sh`

Closes #4254