### PR TITLE
RTX 5090 Blackwell GPT-OSS validation audit + chat-template fix

### DIFF
--- a/apps/autopilot-desktop/src/local_inference_runtime.rs
+++ b/apps/autopilot-desktop/src/local_inference_runtime.rs
@@ -9,6 +9,10 @@ use psionic_runtime::{
     BackendRuntimeResources, BatchExecutionPosture, CacheInvalidationTrigger, CompilePathEvidence,
     CompilePathTemperature, DeviceInventoryQualifiers, LocalRuntimeObservability, QueueDiscipline,
 };
+use psionic_models::{
+    GptOssHarmonyParseOptions, PromptMessage, PromptMessageRole, parse_gpt_oss_harmony_text,
+    render_gpt_oss_harmony_prompt,
+};
 use psionic_serve::{
     CpuGgufGptOssTextGenerationService, CpuReferenceTextGenerationService,
     CudaGgufGptOssTextGenerationService, GenerationLoadState, GenerationOptions, GenerationRequest,
@@ -21,6 +25,8 @@ const DEFAULT_GPT_OSS_KEEPALIVE_MILLIS: u64 = 300_000;
 const ENV_GPT_OSS_BACKEND: &str = "OPENAGENTS_GPT_OSS_BACKEND";
 const ENV_GPT_OSS_MODEL_PATH: &str = "OPENAGENTS_GPT_OSS_MODEL_PATH";
 const GPT_OSS_20B_FILENAME: &str = "gpt-oss-20b-mxfp4.gguf";
+const GPT_OSS_HARMONY_RETURN_STOP: &str = "<|return|>";
+const GPT_OSS_HARMONY_CALL_STOP: &str = "<|call|>";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LocalInferenceExecutionMetrics {
@@ -541,6 +547,14 @@ impl PsionicRuntimeAdapter {
 
     fn handle_generate(&mut self, job: LocalInferenceGenerateJob) {
         let normalized_prompt = normalize_prompt(job.prompt.as_str());
+        let rendered_harmony_prompt = match render_harmony_user_prompt(normalized_prompt.as_str())
+        {
+            Ok(value) => value,
+            Err(error) => {
+                self.push_failure(job.request_id, error);
+                return;
+            }
+        };
         let options_map = match build_generate_options(job.params.as_slice()) {
             Ok(value) => value,
             Err(error) => {
@@ -583,18 +597,24 @@ impl PsionicRuntimeAdapter {
                 },
             ));
 
-        let options = match psionic_generation_options(&options_map) {
+        let mut options = match psionic_generation_options(&options_map) {
             Ok(value) => value,
             Err(error) => {
                 self.push_failure(job.request_id, error);
                 return;
             }
         };
+        options
+            .stop_sequences
+            .push(String::from(GPT_OSS_HARMONY_RETURN_STOP));
+        options
+            .stop_sequences
+            .push(String::from(GPT_OSS_HARMONY_CALL_STOP));
         let request = GenerationRequest::new_text(
             job.request_id.as_str(),
             self.service.model_descriptor().clone(),
             None,
-            normalized_prompt.as_str(),
+            rendered_harmony_prompt.as_str(),
             options,
         );
         let response = match self.service.generate(&request) {
@@ -673,12 +693,13 @@ impl PsionicRuntimeAdapter {
         self.refresh_snapshot(String::from(
             "Psionic local runtime refreshed after generation",
         ));
+        let assistant_text = extract_harmony_assistant_text(response.output.text.as_str());
         self.pending_updates
             .push_back(LocalInferenceRuntimeUpdate::Completed(
                 LocalInferenceExecutionCompleted {
                     request_id: job.request_id,
                     model,
-                    output: response.output.text,
+                    output: assistant_text,
                     metrics,
                     provenance,
                 },
@@ -1307,6 +1328,14 @@ impl GptOssRuntimeWorker {
 
     fn handle_generate(&mut self, job: LocalInferenceGenerateJob) {
         let normalized_prompt = normalize_prompt(job.prompt.as_str());
+        let rendered_harmony_prompt = match render_harmony_user_prompt(normalized_prompt.as_str())
+        {
+            Ok(value) => value,
+            Err(error) => {
+                self.push_failure(job.request_id, error);
+                return;
+            }
+        };
         let options_map = match build_generate_options(job.params.as_slice()) {
             Ok(value) => value,
             Err(error) => {
@@ -1358,18 +1387,24 @@ impl GptOssRuntimeWorker {
             },
         ));
 
-        let options = match psionic_generation_options(&options_map) {
+        let mut options = match psionic_generation_options(&options_map) {
             Ok(value) => value,
             Err(error) => {
                 self.push_failure(job.request_id, error);
                 return;
             }
         };
+        options
+            .stop_sequences
+            .push(String::from(GPT_OSS_HARMONY_RETURN_STOP));
+        options
+            .stop_sequences
+            .push(String::from(GPT_OSS_HARMONY_CALL_STOP));
         let request = GenerationRequest::new_text(
             job.request_id.as_str(),
             request_descriptor,
             None,
-            normalized_prompt.as_str(),
+            rendered_harmony_prompt.as_str(),
             options,
         );
         let Some(service) = self.service.as_mut() else {
@@ -1453,11 +1488,12 @@ impl GptOssRuntimeWorker {
         self.snapshot.last_error = None;
         self.snapshot.busy = false;
         self.refresh_snapshot(String::from("GPT-OSS runtime refreshed after generation"));
+        let assistant_text = extract_harmony_assistant_text(response.output.text.as_str());
         let _ = self.update_tx.send(LocalInferenceRuntimeUpdate::Completed(
             LocalInferenceExecutionCompleted {
                 request_id: job.request_id,
                 model,
-                output: response.output.text,
+                output: assistant_text,
                 metrics,
                 provenance,
             },
@@ -1651,6 +1687,62 @@ pub fn normalize_prompt(raw: &str) -> String {
         .replace('\r', "\n")
         .trim()
         .to_string()
+}
+
+/// Wraps a workbench prompt as a single GPT-OSS Harmony user turn and renders
+/// it for the model. The workbench surface only sends a single user message at
+/// a time, so we construct a one-element message slice and ask Harmony to add
+/// the assistant generation prompt. Mirrors the rendering psionic-serve's own
+/// OpenAI chat completions handler performs at openai_http.rs:9226 for the
+/// `GptOss` decoder family branch.
+fn render_harmony_user_prompt(prompt_text: &str) -> Result<String, String> {
+    let user_message = PromptMessage::new(PromptMessageRole::User, prompt_text);
+    render_gpt_oss_harmony_prompt(&[user_message], true, None)
+        .map_err(|error| format!("failed to render GPT-OSS Harmony prompt: {error}"))
+}
+
+/// Extracts the user-facing assistant text from a Harmony-formatted model
+/// response. Harmony assistant messages are split across analysis, commentary,
+/// and final channels; the workbench should display the final-channel content
+/// because that is the assistant's user-facing answer. If the response cannot
+/// be parsed or no final-channel content is present, falls back to the union
+/// of all assistant content, and finally to the raw response text. Mirrors the
+/// channel handling pattern in psionic-serve's chat completions handler at
+/// openai_http.rs:7048-7060.
+fn extract_harmony_assistant_text(raw_text: &str) -> String {
+    let parsed = match parse_gpt_oss_harmony_text(
+        raw_text,
+        GptOssHarmonyParseOptions {
+            role_hint: Some(PromptMessageRole::Assistant),
+            strict: false,
+        },
+    ) {
+        Ok(parsed) => parsed,
+        Err(_) => return raw_text.to_string(),
+    };
+    let final_text: String = parsed
+        .messages
+        .iter()
+        .filter(|message| message.role == PromptMessageRole::Assistant)
+        .filter(|message| message.channel.as_deref() == Some("final"))
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("");
+    if !final_text.is_empty() {
+        return final_text;
+    }
+    let any_assistant: String = parsed
+        .messages
+        .iter()
+        .filter(|message| message.role == PromptMessageRole::Assistant)
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("");
+    if any_assistant.is_empty() {
+        raw_text.to_string()
+    } else {
+        any_assistant
+    }
 }
 
 pub fn canonical_options_json(options: &Map<String, Value>) -> Result<String, String> {

--- a/docs/audits/2026-04-10-rtx-5090-blackwell-gpt-oss-validation.md
+++ b/docs/audits/2026-04-10-rtx-5090-blackwell-gpt-oss-validation.md
@@ -1,0 +1,697 @@
+# RTX 5090 Blackwell GPT-OSS Validation Audit
+
+Date: 2026-04-10
+
+## Scope
+
+Validate `gpt-oss-20b-mxfp4.gguf` end-to-end on an NVIDIA RTX 5090 (Blackwell,
+sm_120) under WSL2 / Ubuntu 24.04 / CUDA Toolkit 13.1, through the
+`autopilot-desktop` GPT-OSS Workbench surface and the in-process psionic CUDA
+backend. Capture cold-load JIT cost, warm forward-pass throughput, GPU
+utilization profile, and the actual generated response text. Determine whether
+the model produces correct output on the new hardware.
+
+This is the first openagents validation run that targets Blackwell sm_120 and
+CUDA 13.1. No prior `docs/audits/` entry covers this hardware.
+
+## Bottom line
+
+GPT-OSS-20B mxfp4 inference is functionally correct and performant on
+RTX 5090 / Blackwell sm_120 via psionic's in-process CUDA backend.
+
+The runtime reports `Endpoint: in-process://gpt_oss/cuda` and `Backend: cuda`.
+A warm forward pass for 14 prompt tokens + 64 eval tokens completes in 845 ms
+wall-clock, which corresponds to roughly 76 tokens/sec decode and 92 tokens/sec
+end-to-end. The model produces a mathematically verifiable correct
+continuation on a raw-text continuation prompt: given `2, 3, 5, 7, 11,` it
+emits `, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47,` — every token is the next
+prime in order. The 5090 has 18 GB of VRAM headroom over and above the model's
+14 GB resident footprint. The hardware path works.
+
+The autopilot Workbench's chat-instruction surface, however, returns
+degenerate output (token-loop collapse and inner-monologue text instead of
+assistant responses) for any prompt phrased as an instruction. This is a chat
+template integration bug in autopilot's local-inference runtime, not a
+hardware bug, not a kernel correctness bug, and not a quantization bug. Both
+`handle_generate` implementations in
+`apps/autopilot-desktop/src/local_inference_runtime.rs` call
+`psionic_serve::GenerationRequest::new_text` with raw user prompt text and
+bypass psionic's `render_prompt_for_model` pipeline, which is the layer that
+wraps prompts in the GPT-OSS Harmony chat format. Continuation prompts work
+because they do not need a chat template; instruction prompts fail because
+GPT-OSS receives no Harmony role tokens and falls back to base-model
+continuation behavior.
+
+The fix is a small single-repo change in autopilot's local-inference
+workbench path that wires the existing public `psionic_models` Harmony
+helpers into both `handle_generate` sites. No psionic changes are required —
+`render_gpt_oss_harmony_prompt`, `parse_gpt_oss_harmony_text`,
+`GptOssHarmonyParseOptions`, `PromptMessage`, and `PromptMessageRole` are
+already public on the `psionic_models` crate, and
+`apps/autopilot-desktop/Cargo.toml:74` already declares
+`psionic-models = { workspace = true }`. The fix is included in this PR as a
+second commit. See the "Fix shape" and "Post-fix validation" sections.
+
+## Verified hardware and stack
+
+- GPU: NVIDIA GeForce RTX 5090 (Blackwell, sm_120, 32607 MiB total VRAM)
+- Driver: 595.71 (Windows host NVIDIA driver, exposed to WSL2 via dxgkrnl)
+- CUDA Toolkit: 13.1, installed at `/usr/local/cuda-13.1`
+- OS: Ubuntu 24.04 (noble) on WSL2 (kernel 6.6.87.2-microsoft-standard-WSL2)
+- Mesa: 25.2.8 from the Ubuntu 24.04 main archive
+- wgpu rendering adapter on this box: llvmpipe (software). Stock Ubuntu 24.04
+  `mesa-vulkan-drivers` does not ship `dzn`, and WSL2 has no nouveau kernel
+  driver, so only `llvmpipe` enumerates. Rendering falls back to software.
+  This is independent of the GPT-OSS inference path, which uses a separate
+  CUDA path through `dxgkrnl`.
+- Rust: 1.94.1 via rustup
+- openagents tree: `upstream/main` at commit `7c746d3fc` (which already
+  includes the merged content of this contributor's earlier PRs `#4259`,
+  `#4260`, `#4261`), plus this PR's two commits on top. The original
+  validation runs documented above were captured against the equivalent
+  pre-merge tree on a local cherry-pick branch; the post-fix validation
+  runs documented in the "Post-fix validation" section were captured
+  against the same source state, and the chat-template fix that this PR
+  introduces sits on top of that exact `upstream/main` tip.
+- Model artifact: `/home/mike/models/gpt-oss/gpt-oss-20b-mxfp4.gguf`,
+  identified by the runtime as
+  `gpt-oss-20b@local-unverified:bd005e80162071915d8b9d18ffef5d3e0f87288181b019c73fdf2b2ae488b5d2`
+
+## Cold-load JIT cost
+
+The first generation request after a fresh `cargo autopilot` launch triggers
+psionic's CUDA kernel JIT compile for sm_120. This was observed across two
+independent launches:
+
+- Launch 1: `model_loaded_cold` at epoch ms `1775876972912`,
+  `model_became_warm` at epoch ms `1775877086014`. Delta: **113.1 seconds**.
+- Launch 2: `model_loaded_cold` at epoch ms `1775878565669`,
+  `model_became_warm` at epoch ms `1775878661379`. Delta: **95.7 seconds**.
+
+Both deltas were observed in the
+`diagnostics.observability.recent_transitions` array of
+`autopilotctl --json local-runtime status`. After the warm transition, the
+configured GGUF can be re-invoked for further forward passes without any
+re-compilation cost within the same `autopilot-desktop` process lifetime. The
+cost reappears on every fresh process launch — psionic does not persist the
+compiled kernels to disk. The runtime's `kernel_cache` and `plan_cache`
+counters both report `entries=0` after a successful warm generation, which is
+consistent with an in-process compile cache that does not flush to a
+persistent on-disk format.
+
+## Warm steady-state forward pass
+
+A warm forward pass against the JIT-compiled kernels was measured directly
+from the GPT-OSS Workbench via the autopilot pane action surface. The captured
+metrics, read from the workbench pane state immediately after a completed
+run:
+
+```
+request_id:  local-inference-pane-5
+backend:     cuda
+endpoint:    in-process://gpt_oss/cuda
+configured:  gpt-oss-20b-mxfp4.gguf
+metrics:     prompt=14 eval=64 total=845ms
+```
+
+Decoded:
+
+- 14 prompt tokens prefilled
+- 64 decode tokens generated (matched `Max tokens=64`)
+- 78 tokens total in 845 ms wall-clock
+- End-to-end throughput: roughly **92 tokens/sec**
+- Decode-only rate: 64 / 0.845 = roughly **76 tokens/sec**
+
+These numbers are consistent with healthy GPT-OSS-20B mxfp4 throughput on a
+single 5090 in latency-optimized single-request mode. The runtime advertises
+`scheduler: single_request_only / direct_caller_backpressure active=1
+queued=0`, which matches the measured single-request profile.
+
+## GPU utilization profile during a warm forward pass
+
+`nvidia-smi dmon` was sampling at 1 Hz during a warm forward pass. The
+captured window:
+
+```
+# gpu pwr  gtemp  mtemp  sm  mem  enc  dec  jpg  ofa   mclk    pclk
+   0   35    47     -    8    7    0    0    0    0    405     547
+   0   35    47     -    9    8    0    0    0    0    405     615
+   0   35    47     -    9    8    0    0    0    0    405     592
+   0   35    47     -    8    7    0    0    0    0    405     592
+   0   50    49     -   55   38    0    0    0    0  13801    1177
+   0  112    48     -    1    0    0    0    0    0  13801    2362
+   0   55    48     -    1    0    0    0    0    0   7001    1785
+   0   41    47     -    1    1    0    0    0    0   7001     990
+   0   39    47     -    2    1    0    0    0    0   7001     712
+   0   38    47     -    2    1    0    0    0    0   7001     532
+   0   37    47     -    5    4    0    0    0    0    810     427
+   0   35    47     -    6    4    0    0    0    0    810     592
+   0   35    47     -   13    8    0    0    0    0    405     585
+```
+
+Idle baseline: power 35 W, sm 8-9 %, memory clock pinned at 405 MHz, primary
+clock 550-615 MHz. Roughly 4 seconds of idle, then a one-second window where
+the GPU clocks up: memory clock jumps from 405 MHz to 13801 MHz (the device's
+maximum), sm utilization hits 55 %, memory bandwidth utilization hits 38 %,
+and core power rises from 35 W to 50 W. The next sample shows pclk at 2362
+MHz (Blackwell boost) and power at 112 W, with sm dropping back to 1 % — the
+forward pass has finished but the GPU is still holding clocks high in case
+more work arrives. The next several samples are the wind-down, with the GPU
+clocking back to its idle state in roughly 6 more seconds.
+
+The shape of the curve is the production signature of a real CUDA forward
+pass: cold idle, brief high-bandwidth burst, cooldown. CPU fallback would
+produce no idle-to-boost clock transition, no power excursion above idle, and
+no memory-clock jump.
+
+## VRAM and memory footprint
+
+`nvidia-smi --query-gpu=memory.used,memory.total` reported `14172 MiB / 32607
+MiB` resident throughout the validated session, consistent across multiple
+samples.
+
+The runtime's own
+`diagnostics.observability.memory_footprint.resident_device_bytes` field
+reports `0` despite the 14 GB on the device. This counter does not appear to
+track loaded model weights. The `resident_host_bytes` field reports
+`24994468448` (about 25 GB), which is consistent with the GGUF file being
+mmap'd into the host address space in addition to being resident on the GPU.
+The discrepancy is a stat-reporting bug, not a real memory leak; nvidia-smi
+is the ground truth.
+
+## Numerical correctness
+
+Three independent generation runs were captured by adding a one-line
+`tracing::info!` debug dump in
+`apps/autopilot-desktop/src/input/reducers/local_inference.rs` (in the
+`apply_completed` reducer, immediately after the ownership check) that prints
+the full untruncated response from `LocalInferenceExecutionCompleted.output`.
+The patch is a temporary capture aid and is not intended to ship. The dumps
+came out of `/tmp/autopilot-5090-launch.log`.
+
+### Run 3 — continuation prompt — coherent and correct
+
+Prompt: `2, 3, 5, 7, 11,`
+Max tokens: 32
+Temperature: 0.7
+
+Response, captured verbatim from the audit dump:
+
+```
+, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47,
+```
+
+Every token is the next prime in order. No skips, no errors, no garbage
+tokens, no Unicode corruption. This is a clean, mathematically verifiable
+correct continuation. The model is producing correct logits and the sampler
+is selecting the right tokens.
+
+### Run 1 — chat-instruction prompt — degenerate
+
+Prompt: `Describe the current GPT-OSS local runtime in one short paragraph.`
+Max tokens: 64
+Temperature: 0.2
+
+Response, captured verbatim from the audit dump:
+
+```
+ The GPT-OSS local runtime is a powerful tool that allows the user to create
+and run multiple 3D models in a single, large, and highly-optimized, and
+highly-optimized, and a
+
+It seems like your text got cut off. However, based on what you've provided,
+here's a concise description:
+```
+
+The output starts as plausible English, drifts into token-loop collapse
+("highly-optimized, and highly-optimized, and a"), then jumps to a
+chatbot-style acknowledgement of an incomplete user message that the model
+itself fabricated. No actual description of the runtime is produced.
+
+### Run 2 — chat-instruction prompt — degenerate
+
+Prompt: `List the first ten prime numbers, separated by commas.`
+Max tokens: 64
+Temperature: 0.2
+
+Response, captured verbatim from the audit dump:
+
+```
+ The user wants a list of the first ten prime numbers, separated by commas.
+The user wants a list of the first ten prime numbers. The user wants to list
+them. The user wants a list. The user wants a list. The user wants a list.
+The user wants. The user wants. The user wants
+```
+
+The model paraphrases the prompt back ("The user wants...") in
+inner-reasoning style instead of answering, then collapses into a token loop.
+The correct answer (`2, 3, 5, 7, 11, 13, 17, 19, 23, 29`) is never produced
+even though Run 3 establishes that the same model on the same hardware can
+produce correct prime sequences in continuation mode.
+
+### Reading
+
+These three runs together rule out hardware, kernel, and quantization bugs:
+
+- The 5090 is producing correct logits when handed a raw text continuation
+  task (Run 3).
+- The matmul kernels for sm_120 are not numerically broken (a numerical bug
+  would corrupt continuations, not just instructions).
+- mxfp4 quantization is not degrading the model (Run 3 shows full
+  arithmetic accuracy).
+- Sampler temperature is not the root cause (Runs 1 and 2 used 0.2; Run 3
+  used 0.7, but Runs 1 and 2 still produced grammatical English text, which
+  rules out the kind of complete distribution collapse that low temperature
+  alone would cause).
+
+The bug is in autopilot's prompt-formatting layer, narrowly scoped to the
+chat-instruction path.
+
+## Root cause: chat-template bypass in autopilot's workbench path
+
+GPT-OSS-20B uses the OpenAI Harmony chat format. Psionic has dedicated
+support for this format in `psionic-serve`, including:
+
+- `render_gpt_oss_harmony_prompt(messages, true, options)` which wraps a
+  list of `PromptMessage` values in the proper Harmony token structure
+- `parse_gpt_oss_harmony_text` which extracts the assistant message from the
+  raw Harmony-wrapped output the model generates
+- The `HARMONY_RETURN_STOP` and `HARMONY_CALL_STOP` constants used as
+  `GenerationOptions::stop_sequences`, so generation halts at the Harmony
+  end-of-turn boundary
+
+Psionic's OpenAI HTTP layer at
+`psionic-serve/src/openai_http.rs:7004-7060` invokes this pipeline:
+
+```rust
+let prompt_messages = chat_messages_to_prompt_messages_for_decoder(
+    &request.messages,
+    model,
+)?;
+let rendered = render_prompt_for_model(loaded_model, prompt_messages.as_slice())?;
+let generation_request = GenerationRequest::new_text(
+    request_id,
+    model.descriptor.clone(),
+    None,
+    rendered.text,                        // chat-template-rendered text
+    options,
+);
+```
+
+`render_prompt_for_model` at `psionic-serve/src/openai_http.rs:9215-9239`
+contains an explicit GPT-OSS branch that returns Harmony-rendered text plus
+the matching stop sequences.
+
+Autopilot's workbench path skips all of this. Both `handle_generate`
+implementations in `apps/autopilot-desktop/src/local_inference_runtime.rs`
+call `GenerationRequest::new_text` with the raw, untransformed user prompt:
+
+`local_inference_runtime.rs:593` (the generic psionic adapter):
+
+```rust
+let request = GenerationRequest::new_text(
+    job.request_id.as_str(),
+    self.service.model_descriptor().clone(),
+    None,
+    normalized_prompt.as_str(),           // raw user text, no Harmony wrapping
+    options,
+);
+```
+
+`local_inference_runtime.rs:1368` (the GPT-OSS-specific adapter):
+
+```rust
+let request = GenerationRequest::new_text(
+    job.request_id.as_str(),
+    request_descriptor,
+    None,
+    normalized_prompt.as_str(),           // raw user text, no Harmony wrapping
+    options,
+);
+```
+
+Neither adapter:
+
+- calls `render_prompt_for_model` (or any equivalent helper that wraps a
+  user message in the GPT-OSS Harmony format)
+- merges `HARMONY_RETURN_STOP` and `HARMONY_CALL_STOP` into the generation
+  options as stop sequences
+- calls `parse_gpt_oss_harmony_text` on the response side to strip the
+  Harmony wrappers from the model's output before storing it in
+  `LocalInferenceExecutionCompleted.output`
+
+When GPT-OSS-20B receives a raw instruction text with no Harmony role tokens
+and no assistant turn marker, it does not enter assistant-response mode. It
+falls back to base-model continuation, which on instruction-shaped prompts
+produces inner-monologue text or loop collapse. This is exactly the failure
+pattern observed in Runs 1 and 2.
+
+The pane action call site at
+`apps/autopilot-desktop/src/input/actions.rs:14250-14256` is where the
+`LocalInferenceGenerateJob` is constructed from pane state. The prompt
+arrives as the trimmed string the user typed into the workbench input field
+and is passed straight through without any role wrapping. There is no
+intermediate layer where chat template wrapping could plausibly happen.
+
+## Fix shape
+
+The fix is single-repo. `psionic_models` already exposes every primitive
+needed: `render_gpt_oss_harmony_prompt`, `parse_gpt_oss_harmony_text`,
+`PromptMessage`, `PromptMessageRole`, and `GptOssHarmonyParseOptions` are
+all public on the `psionic_models` crate (visible in
+`psionic-serve/src/openai_http.rs:33-42`, where psionic's own OpenAI HTTP
+chat completions handler imports them via a normal `use psionic_models::{...}`
+statement). `apps/autopilot-desktop/Cargo.toml:74` already declares
+`psionic-models = { workspace = true }`, so autopilot can call those
+helpers directly. No psionic changes are required, no `Cargo.toml`
+changes are required, and no cross-repo coordination is required.
+
+The change has three parts, all in
+`apps/autopilot-desktop/src/local_inference_runtime.rs`:
+
+1. Add a `use psionic_models::{...}` import for `PromptMessage`,
+   `PromptMessageRole`, `GptOssHarmonyParseOptions`,
+   `render_gpt_oss_harmony_prompt`, and `parse_gpt_oss_harmony_text`.
+   Declare the two GPT-OSS Harmony stop-sequence string literals
+   (`<|return|>`, `<|call|>`) as module constants. The literals match
+   the private constants psionic-serve already uses at
+   `psionic-serve/src/openai_http.rs:89-90` and are part of the OpenAI
+   Harmony format spec rather than psionic implementation details.
+
+2. Add two small private helpers in the same file. `render_harmony_user_prompt`
+   wraps the workbench prompt as a single-element `&[PromptMessage]` with
+   role `User` and renders it through
+   `render_gpt_oss_harmony_prompt(messages, true, None)`. Mirrors
+   `psionic-serve/src/openai_http.rs:9226`.
+   `extract_harmony_assistant_text` parses the model's response with
+   `parse_gpt_oss_harmony_text`, prefers messages with
+   `channel == Some("final")` (the user-facing Harmony channel), falls
+   back to the union of all assistant content if no final-channel message
+   is present, and falls back to the raw text on parse failure. The
+   fallback chain mirrors how the OpenAI HTTP handler at
+   `psionic-serve/src/openai_http.rs:7048-7060` handles parse failures
+   softly with `.ok()`.
+
+3. In both `handle_generate` implementations (line 542, the generic psionic
+   adapter; line 1308, the GPT-OSS-specific adapter), call the render
+   helper before constructing the `GenerationRequest`, append the two
+   Harmony stop sequences to `options.stop_sequences`, send the rendered
+   text into `GenerationRequest::new_text` instead of the raw normalized
+   prompt, and call the extractor helper on the response text before
+   storing it in `LocalInferenceExecutionCompleted.output`. The
+   `normalized_prompt_digest` provenance field continues to digest the
+   user-typed prompt rather than the wire-format Harmony text, so
+   reproducibility from the user-visible input is preserved.
+
+The total diff is roughly 100 lines added and 6 lines deleted in one file.
+No `Cargo.toml` change. No public API change. No psionic-side change.
+
+## Post-fix validation
+
+The fix was applied and validated end-to-end on the same RTX 5090 / Blackwell
+sm_120 / CUDA 13.1 / WSL2 / Ubuntu 24.04 box, against the same
+`gpt-oss-20b-mxfp4.gguf` artifact, using the same temporary
+`tracing::info!` audit dump described in the "How to reproduce" section
+(applied to the post-fix tree, then reverted before the fix commit).
+
+Three post-fix validation runs were captured:
+
+### Post-fix Run 1 — instruction prompt (request `local-inference-pane-1`)
+
+Prompt: `List the first ten prime numbers, separated by commas.`
+Max tokens: 64
+Temperature: 0.2
+
+Response, captured verbatim from the audit dump (181 chars):
+
+```
+The user asks: "List the first ten prime numbers, separated by commas." So
+we need to list the first ten primes: 2, 3, 5, 7, 11, 13, 17, 19, 23, 29.
+Provide them separated by commas
+```
+
+The model is now in chat-instruction mode. It identifies the task, produces
+the correct list of ten primes inline, and starts to plan the final-channel
+emission ("Provide them separated by commas") before being cut off by
+`max_tokens=64`. This text is the GPT-OSS Harmony **analysis** channel
+content — the model thinking out loud — captured because the token budget
+ran out before the model emitted the final-channel answer. The
+`extract_harmony_assistant_text` helper correctly returned the analysis
+content as a fallback (no final-channel message existed yet). The compare
+against pre-fix Run 2 (`The user wants. The user wants. The user wants.`)
+is unambiguous: the model is now coherent, on-task, and mathematically
+correct.
+
+### Post-fix Run 2 — continuation prompt (request `local-inference-pane-2`)
+
+Prompt: `2, 3, 5, 7, 11,`
+Max tokens: 32
+Temperature: 0.7
+
+Response, captured verbatim from the audit dump (88 chars):
+
+```
+User says: "2,3, 5, 7, 11". They gave a sequence of prime numbers. They
+likely want next
+```
+
+The model now treats this as a chat-user message (via the Harmony user
+turn wrapping) rather than as raw text continuation. It produces analysis
+text describing what the user wants, then is cut off mid-reasoning by
+`max_tokens=32`. This is an **expected behavior change**: the pre-fix
+"continuation" behavior we relied on for Run 3 in the pre-fix section was
+an artifact of the workbench bypassing the chat template entirely. With
+the chat template wired up, the workbench is now consistently in
+assistant-response mode for all prompts, including ones that look like
+raw continuations. The output is grammatical, on-topic, and semantically
+correct — there is no regression on coherence.
+
+### Post-fix Run 3 — instruction prompt with adequate token budget (request `local-inference-pane-3`)
+
+Prompt: `What is 7 times 8? Answer with just the number.`
+Max tokens: 256
+Temperature: 0.2
+
+Response, captured verbatim from the audit dump (2 chars):
+
+```
+56
+```
+
+Two characters. Just `56`. Mathematically correct, follows the instruction
+precisely ("just the number"), no preamble, no analysis content leaked
+through. With a `max_tokens` budget large enough for the model to finish
+its analysis-channel reasoning **and** emit a final-channel answer, the
+`extract_harmony_assistant_text` helper found a Harmony message with
+`channel == Some("final")` and returned only that content. This is the
+production output shape: one clean answer, the analysis stripped, exactly
+as the maintainers' OpenAI HTTP layer at
+`psionic-serve/src/openai_http.rs:7048-7060` produces it for the same
+backend.
+
+### Reading
+
+The fix is wired correctly end-to-end. The model produces structured,
+coherent reasoning. The Harmony envelope is rendered into the prompt, the
+two Harmony stop sequences are attached to the generation options, the
+response is parsed with the same `GptOssHarmonyParseOptions { role_hint:
+Some(PromptMessageRole::Assistant), strict: false }` shape psionic itself
+uses, and the user-visible output is the final-channel content when
+available. None of the pre-fix degeneracy patterns reappear in any
+post-fix run.
+
+The post-fix runs also reaffirm the hardware validation: the same
+`Endpoint: in-process://gpt_oss/cuda` and `Backend: cuda` apply, the same
+sm_120 CUDA path serves the forward passes, and the throughput envelope is
+unchanged.
+
+## Side findings
+
+These were observed during the validation run and are independently
+contribution-worthy. None block the GPT-OSS validation. Each is small enough
+to file as its own targeted fix.
+
+### Apple FM init runs unconditionally on Linux
+
+`autopilot-desktop` emits the following error on every Linux launch, even
+though the Apple Foundation Models bridge is macOS-only:
+
+```
+ui error [provider.runtime]: Apple Foundation Models requires macOS 26+ on
+Apple Silicon
+```
+
+The error is sourced from `apps/autopilot-desktop/src/apple_fm_bridge.rs:507`
+in `AppleFmLocalBridge::ensure_running`, which sets
+`self.status = AppleFmBridgeStatus::UnsupportedPlatform` and writes the error
+to the snapshot when `cfg!(target_os = "macos")` is false. The error is
+non-fatal — `ensure_running` returns Err and the caller handles it cleanly —
+but it pollutes the launch log and surfaces as a `ui error
+[provider.runtime]` line every time the provider runtime ticks. On Linux,
+the Apple FM bridge code path should not be reachable at all.
+
+### Codex lane spawn failure on Linux
+
+`autopilot-desktop` also logs:
+
+```
+codex lane error: Codex lane startup failed: failed to spawn codex app-server
+codex lane error: Codex lane unavailable: Codex lane unavailable
+ui error [codex.diagnostics]: Codex lane unavailable
+```
+
+The lane attempts to spawn a `codex` app-server binary that is not present
+in PATH on this Linux box. This is most likely a missing-binary case rather
+than a code bug — the user simply does not have the OpenAI Codex CLI
+installed on this Linux machine — but the error surfaces as a fatal UI error
+on the `codex.diagnostics` channel rather than as a soft "unavailable"
+state. A graceful absence-handling path would be friendlier on Linux setups
+where Codex is genuinely not present.
+
+### `resident_device_bytes` reports zero despite a 14 GB GPU residency
+
+`diagnostics.observability.memory_footprint.resident_device_bytes` in the
+`autopilotctl --json local-runtime status` output reports `0` while
+`nvidia-smi` reports `14172 MiB` resident on device 0 for the same process.
+The counter does not appear to track loaded model weights or the
+psionic CUDA context; it may only track allocator pool entries that have
+not yet been hydrated. The `resident_host_bytes` field reports
+`24994468448` (about 25 GB), so the host-side counter is wired up.
+
+### `posture: cold` does not flip after `model_became_warm` fires
+
+The `recent_transitions` array contains both a `model_loaded_cold` and a
+`model_became_warm` event for the configured model after the first
+generation completes, but the top-level `posture` field in the local-runtime
+status output continues to report `cold` indefinitely. The two state
+trackers are independent and out of sync. Either `posture` should observe
+the warm transition and update, or the field should be removed in favor of
+`recent_transitions` as the single source of truth.
+
+### wgpui workbench pane clipping at large window sizes
+
+The GPT-OSS Workbench pane renders an "Output" section as the last item in
+its pane content area, painted at `line_y + 8.0` after the Prompt digest
+line at `apps/autopilot-desktop/src/panes/local_inference.rs:307-313`. The
+section has no scrolling and no separate panel; if the rendered metadata
+above it consumes more vertical space than the pane bounds allow, the
+Output is clipped below the pane's bottom edge and is not visible to the
+user. Resizing or maximizing the autopilot-desktop window did not surface
+the Output region in this validation session — the rendered layout on
+software (llvmpipe) Linux does not appear to lay the Output text inside the
+visible pane bounds on this configuration. This is the reason the response
+text could not be read off the screen and had to be captured via a
+temporary tracing patch instead.
+
+## How to reproduce
+
+On a Linux box with:
+
+- An NVIDIA Blackwell-class GPU (sm_120 or higher) with at least 16 GB VRAM
+- NVIDIA Windows driver 595+ exposing the GPU through `dxgkrnl` to WSL2
+- CUDA Toolkit 13.x at `/usr/local/cuda-13.x`
+- Ubuntu 24.04 (WSL2) with Mesa 25.x in the main archive
+- A local checkout of `OpenAgentsInc/openagents` at or near
+  `local/all-fixes` (`origin/main` plus the three small open PRs from this
+  contributor)
+- The `gpt-oss-20b-mxfp4.gguf` GGUF placed at
+  `~/models/gpt-oss/gpt-oss-20b-mxfp4.gguf` (the default
+  `OPENAGENTS_GPT_OSS_MODEL_PATH`)
+
+To validate the hardware path:
+
+```bash
+cd /projects/openagents
+cargo autopilot 2>&1 | tee /tmp/autopilot-launch.log
+```
+
+In a second terminal, observe the GPU during inference:
+
+```bash
+nvidia-smi dmon -s pucm -c 600 -i 0
+```
+
+Wait until the launch log reports `GPT-OSS 20B loaded on cuda`, then drive
+the workbench from a third terminal:
+
+```bash
+target/debug/autopilotctl pane open pane.local_inference
+target/debug/autopilotctl pane focus pane.local_inference
+```
+
+In the autopilot-desktop window, the GPT-OSS Workbench pane is now open.
+Click into the Prompt input field, enter a continuation-style prompt
+(`2, 3, 5, 7, 11,`), set Max tokens to 32, click Run prompt. The first
+generation triggers the CUDA JIT compile (~95-115 s of wall-clock time
+during which the pane reports "running"); the workbench then displays
+metrics in the form `prompt=14 eval=64 total=NNNms`. Subsequent generations
+are sub-second.
+
+To verify numerical correctness, the `tracing::info!` debug dump used in
+this audit can be re-applied to
+`apps/autopilot-desktop/src/input/reducers/local_inference.rs` in the
+`apply_completed` reducer immediately after the ownership check. The dump
+prints `completed.output` to the launch log under target
+`gpt_oss_audit_dump`. Grep the launch log for that target string to read
+the full untruncated response. The dump is a temporary capture aid and is
+not intended for upstream commit.
+
+To reproduce the original chat-template bug, check out the parent commit
+of this PR (the audit-doc commit) which does not include the
+`local_inference_runtime.rs` fix, then enter any instruction-style prompt
+through the workbench pane (for example `List the first ten prime numbers,
+separated by commas.`) and observe the response in the audit dump or in the
+pane Output region (if the pane is laid out in a way that does not clip
+it). The output will degenerate into inner-monologue text or token loops.
+
+To reproduce the post-fix behavior, check out the head of this PR (which
+includes the `local_inference_runtime.rs` fix) and enter the same
+instruction prompt with a generous token budget (`max_tokens=256` or more).
+The model will produce a clean, coherent assistant response — the
+final-channel content extracted by `extract_harmony_assistant_text`. The
+"Post-fix validation" section above documents three captured runs from
+this exact reproduction loop.
+
+## Open follow-ups
+
+- A broader correctness sweep on the post-fix workbench. The post-fix
+  validation in this audit rests on three runs (one analysis-truncated
+  instruction prompt, one analysis-truncated continuation prompt now in
+  chat mode, and one clean final-channel instruction prompt). More
+  instruction prompts at varying temperatures, varying token budgets,
+  varying complexities, and multi-turn conversations would harden the
+  conclusion. The post-fix path is now consistent enough that this sweep
+  can be done in the workbench UI or via the same audit dump approach.
+
+- Cross-machine comparison against the contributor's RTX 3060 Ti box
+  (Ubuntu 22.04, CUDA 12.x, dzn rendering path). The same fix should
+  produce the same coherent output on a non-Blackwell GPU. The bug
+  analysis predicts yes — the cause was in autopilot's chat-template
+  layer, not in the GPU — and the post-fix runs on Blackwell support
+  that prediction. Confirming on a second box closes any residual
+  ambiguity about hardware involvement and validates the fix on a
+  different CUDA toolkit.
+
+- A second timing measurement on the post-fix path is warranted. The
+  pre-fix 845 ms / 76 tok/s number is from a single warm forward pass
+  with the workbench bypassing the chat template. The post-fix path adds
+  Harmony envelope tokens to both the prompt prefill and the decode
+  output, so the throughput envelope is slightly different and deserves
+  its own measurement run. A few samples at varying prompt lengths and
+  decode budgets would give a real post-fix envelope.
+
+- The `resident_device_bytes` and `posture` stat-tracking bugs both
+  deserve small targeted fixes in psionic. They are not blocking but
+  they degrade the diagnostic surface.
+
+- The Apple FM Linux init noise and the Codex lane spawn failure on
+  Linux are both small targeted autopilot-desktop fixes. Either could
+  ship as a one-line guard.
+
+- The wgpui workbench pane Output clipping needs a layout fix, or the
+  pane needs a scrollable Output region. With the chat-template fix
+  applied, the workbench is now correctly producing assistant responses
+  for instruction prompts, but a Linux user with a clipped Output region
+  still cannot read those responses through the UI without resorting to
+  the audit dump approach. The clipping is the next thing on the
+  Linux-side critical path for an end-to-end usable workbench.


### PR DESCRIPTION
  ## Summary

  First openagents validation run targeting NVIDIA **RTX 5090** (Blackwell, sm_120) with **CUDA Toolkit 13.1** on WSL2 /
   Ubuntu 24.04. Two commits, meant to be read together:

  1. **`34989017d` Add RTX 5090 Blackwell GPT-OSS validation audit** — adds
  `docs/audits/2026-04-10-rtx-5090-blackwell-gpt-oss-validation.md` covering `gpt-oss-20b-mxfp4` end-to-end through the
  autopilot GPT-OSS Workbench surface and the in-process psionic CUDA backend. No prior `docs/audits/` entry covers
  Blackwell or CUDA 13. Documents the validation result, identifies a chat-template integration bug in autopilot's
  local-inference workbench path, sketches the fix shape, and lists side findings worth small targeted follow-ups.
  2. **`fd8e0d6cc` Fix GPT-OSS chat-template wrapping in local-inference workbench** — implements the fix the audit
  identifies. Single-repo, 98 insertions / 6 deletions in one file
  (`apps/autopilot-desktop/src/local_inference_runtime.rs`). No psionic changes, no `Cargo.toml` changes, no public API
  changes.

  The audit commit is the **why** (diagnosis, evidence, code references). The fix commit is the **how** (the change that
   makes the bug go away). Both are validated end-to-end on the same hardware against `upstream/main` at `7c746d3fc`.

  ## Hardware result

  **Hardware works.** The runtime reports `Endpoint: in-process://gpt_oss/cuda` and `Backend: cuda`. A warm forward pass
   for `prompt=14 eval=64 total=845ms` gives roughly **76 tok/s decode**, **92 tok/s end-to-end**. First-call CUDA JIT
  compile for sm_120 is **95-113 s** (measured across two independent launches via `recent_transitions` in `autopilotctl
   --json local-runtime status`). VRAM resident **14172 MiB / 32607 MiB**. `nvidia-smi dmon` during a warm forward pass
  shows the production signature of a real CUDA forward pass: memory clock jumps 405 → 13801 MHz, primary clock boosts
  to 2362 MHz, power 35 → 112 W, sm utilization 8 → 55 %, then a clean wind-down.

  **Numerical correctness verified** against a continuation prompt: given `2, 3, 5, 7, 11,` the model emits `, 13, 17,
  19, 23, 29, 31, 37, 41, 43, 47,` — every token is the next prime in order. The matmul kernels for sm_120 are not
  numerically broken, mxfp4 quantization is not degrading the model.

  ## Bug found and fix included

  The audit identifies a **chat-template integration bug in autopilot's local-inference workbench path** that breaks
  instruction-style prompts. Both `handle_generate` implementations in
  `apps/autopilot-desktop/src/local_inference_runtime.rs` (the generic psionic adapter at line 542 and the GPT-OSS
  adapter at line 1308) called `psionic_serve::GenerationRequest::new_text` with the raw user prompt and bypassed
  psionic's `render_prompt_for_model` pipeline, which is the layer that wraps prompts in the GPT-OSS **Harmony** chat
  format.

  Pre-fix behavior:
  - Continuation prompts (`2, 3, 5, 7, 11,`) worked because they need no chat template.
  - Instruction prompts (`List the first ten prime numbers, separated by commas.`) degenerated into inner-monologue text
   or token-loop collapse (`The user wants. The user wants. The user wants.`) because GPT-OSS received no Harmony role
  tokens and fell back to base-model continuation.

  The fix wires both `handle_generate` implementations through the existing public `psionic_models` Harmony helpers.
  **No psionic changes are required** — `render_gpt_oss_harmony_prompt`, `parse_gpt_oss_harmony_text`, `PromptMessage`,
  `PromptMessageRole`, and `GptOssHarmonyParseOptions` are already public on the `psionic_models` crate, and
  `apps/autopilot-desktop/Cargo.toml:74` already declares `psionic-models = { workspace = true }`. The change adds three
   things in one file: a `use psionic_models::{...}` import + two stop-sequence constants; two small private helpers
  (`render_harmony_user_prompt` and `extract_harmony_assistant_text`) that mirror the wiring psionic-serve's own OpenAI
  HTTP handler uses at `psionic-serve/src/openai_http.rs:7004-7060` and `:9226`; and three small modifications in each
  `handle_generate` (render the prompt before the request, append the two Harmony stop sequences to
  `options.stop_sequences`, parse the response on the way out).

  **Post-fix validation** (three captured runs documented in the audit's "Post-fix validation" section, all on the same
  RTX 5090 / Blackwell sm_120 / CUDA 13.1 box, plus a final post-rebase re-validation):

  | Prompt | Max tokens | Result |
  |---|---|---|
  | `List the first ten prime numbers, separated by commas.` | 64 | Coherent analysis-channel text identifying the
  correct primes (`2, 3, 5, 7, 11, 13, 17, 19, 23, 29`); cut off mid-final emission by token budget but no degeneracy |
  | `2, 3, 5, 7, 11,` | 32 | Coherent analysis text now in chat-instruction mode (expected behavior change —
  continuation prompts now go through the chat template) |
  | `What is 7 times 8? Answer with just the number.` | 256 | Just `56`. Two characters. Final-channel content extracted
   by `extract_harmony_assistant_text`, analysis stripped, instruction followed precisely. **Re-verified after rebasing
  onto `upstream/main` at `7c746d3fc` — byte-identical result.** |

  The pre-fix degeneracy patterns do not reappear in any post-fix run.

  ## Side findings (each non-blocking, independently filable)

  The audit lists five small follow-ups discovered during validation. None block this PR; each is worth its own targeted
   fix.

  - **Apple FM bridge init runs unconditionally on Linux** and emits `ui error [provider.runtime]: Apple Foundation
  Models requires macOS 26+ on Apple Silicon` on every launch (`apps/autopilot-desktop/src/apple_fm_bridge.rs:507`).
  Non-fatal but pollutes the launch log.
  - **Codex lane spawn failure on Linux** surfaces as a fatal `[codex.diagnostics]` UI error rather than a soft
  "unavailable" state when the `codex` binary is absent.
  - `diagnostics.observability.memory_footprint.resident_device_bytes` reports `0` despite a 14 GB GPU residency.
  Host-side `resident_host_bytes` counter is wired; device-side counter is not.
  - `posture: cold` does not flip after `model_became_warm` fires in `recent_transitions`. Two state trackers, one
  source of truth needed.
  - The wgpui GPT-OSS Workbench pane clips its Output region below the visible pane bounds at the configurations tested
  on Linux/llvmpipe (`apps/autopilot-desktop/src/panes/local_inference.rs:307-313`). With this PR's fix the workbench is
   now correctly producing assistant responses, but a Linux user with a clipped Output region still cannot read those
  responses through the UI without the audit-dump approach. This is the next item on the Linux-side critical path for an
   end-to-end usable workbench.

  ## Test plan

  - [x] `cargo check -p autopilot-desktop` — clean against the audit-only commit
  - [x] `cargo check -p autopilot-desktop` — clean against the audit + fix commits
  - [x] `cargo build -p autopilot-desktop --bin autopilot-desktop` — clean build on both commit states
  - [x] **Smoke test (audit-only)**: launched autopilot-desktop, verified `local-runtime status` reports `load=loaded` /
   `Backend: cuda`, verified `autopilotctl pane open pane.local_inference` succeeds
  - [x] **Pre-fix validation runs** captured via temporary `tracing::info!` audit dump in `apply_completed`: instruction
   prompts produce degenerate output (`The user wants. The user wants. ...`); continuation prompt produces correct
  primes (chat template bypassed)
  - [x] **Post-fix validation runs** captured via the same audit dump on the post-fix tree: instruction prompts produce
  coherent assistant reasoning; high-budget instruction prompt (`What is 7 times 8?`) produces clean final-channel `56`;
   no degeneracy in any post-fix run
  - [x] **Post-rebase re-validation**: rebased onto `upstream/main` at `7c746d3fc` (35 new commits including the merges
  of #4259/#4260/#4261), `cargo check` clean in 25.87s, `cargo build` clean in 1m 24s, runtime smoke test re-verified
  the same `What is 7 times 8?` prompt returns byte-identical `56`
  - [x] Audit-dump tracing patch reverted before final commit; final `cargo check` clean
  - [x] No `Cargo.toml` changes (verified — `psionic-models` already a direct workspace dep at
  `apps/autopilot-desktop/Cargo.toml:74`)
  - [x] No psionic changes (verified — all required helpers already public on `psionic_models`, imported the same way
  `psionic-serve/src/openai_http.rs:33-42` does; psionic git revision unchanged at
  `d001e792ee0b4e973a8411a4e7be6666aef01919`)

  ## Out of scope for this PR

  - Targeted fixes for the five side findings above. Each is independently filable.
  - A broader correctness sweep on the post-fix workbench (more instruction prompts at varying temperatures and token
  budgets, multi-turn).
  - Cross-machine comparison against the contributor's RTX 3060 Ti box. The bug analysis predicts the same fix produces
  the same coherent output on a non-Blackwell GPU; this PR validates Blackwell, the 3060 Ti validation is a follow-up
  audit.
  - A second timing measurement on the post-fix path. The pre-fix throughput envelope (76 tok/s decode) was measured
  with the chat template bypassed. The post-fix path adds Harmony envelope tokens to both prompt and decode, so a fresh
  throughput measurement is warranted but is not included here.
  - Any change to the `wgpui` workbench pane Output region clipping bug. The audit lists it as a side finding; a layout
  fix is its own PR.