### PR TITLE
Surface and enforce Pylon liveness gates in Mission Control

### DIFF
--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -27196,6 +27196,31 @@ fn load_earn_job_lifecycle_projection_rows(
     Ok(normalize_earn_job_lifecycle_projection_rows(document.rows))
 }
 
+/// Maximum acceptable age of the persisted Pylon provider-admin snapshot
+/// (`ProviderPersistedSnapshot.captured_at_ms`) before
+/// `EarningsScoreboardState::refresh_from_pylon_status` treats it as a dead
+/// authority and falls into `mark_pylon_authority_unavailable`.
+///
+/// Pylon's serve loop has a nominal `sleep_duration` of 2 seconds in the
+/// main `tokio::select!` (`apps/pylon/src/lib.rs:10359`), but its actual
+/// cadence between snapshot writes is much longer when pylon is in
+/// `desired_mode = online`: each iteration also runs the Nexus presence
+/// heartbeat, the provider auto-run pass, the live announcement sync, and
+/// (periodically) the payout-target sync. Live measurement on a healthy
+/// pylon online against `wss://nexus.openagents.com` showed snapshot deltas
+/// up to **14 seconds** between writes, with bursty gaps of 4-14s being
+/// normal under load. A 15-second threshold (~1x the observed max) was
+/// found to false-positive in the wild; bumping to 60 seconds gives ~4x
+/// margin over the observed max, which absorbs jitter from slow Nexus
+/// roundtrips and bursty heartbeat scheduling without losing the ability
+/// to detect a genuinely dead `pylon serve` within a minute.
+///
+/// Without this gate, a stale provider-admin SQLite from a previous pylon
+/// session lets autopilot trust `desired_mode = online` indefinitely, even
+/// after `pylon serve` has been killed -- which would let the operator
+/// click GO ONLINE while no live job pipeline exists.
+pub const PYLON_SNAPSHOT_STALENESS_THRESHOLD_MS: i64 = 60_000;
+
 pub struct EarningsScoreboardState {
     pub load_state: PaneLoadState,
     pub last_error: Option<String>,
@@ -27398,6 +27423,36 @@ impl EarningsScoreboardState {
             );
             return;
         };
+        // Pylon's serve loop persists a fresh snapshot every ~2 seconds with
+        // `captured_at_ms = now_epoch_ms()`. When `pylon serve` dies, the
+        // SQLite row stays put and `captured_at_ms` stops advancing -- so a
+        // file-based reader like autopilot otherwise has no way to tell that
+        // pylon is gone. Treat any snapshot older than
+        // `PYLON_SNAPSHOT_STALENESS_THRESHOLD_MS` as a dead authority and
+        // fall into `mark_pylon_authority_unavailable` so the existing
+        // `PylonAuthorityUnavailable` blocker fires (no new variant needed:
+        // semantically a stale snapshot is the same failure as a missing
+        // store -- "we cannot trust live truth from pylon"). This catches
+        // the third Pylon liveness failure mode that the previous two
+        // commits' gates do not see: pylon serve dead, SQLite still on disk
+        // with `desired_mode = online` from a previous session.
+        let now_epoch_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0i64, |duration| {
+                i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
+            });
+        let staleness_ms = now_epoch_ms.saturating_sub(snapshot.captured_at_ms);
+        if staleness_ms > PYLON_SNAPSHOT_STALENESS_THRESHOLD_MS {
+            self.mark_pylon_authority_unavailable(
+                now,
+                source_tag,
+                format!(
+                    "Pylon provider admin snapshot is stale ({}s old); pylon serve may not be running.",
+                    staleness_ms / 1000,
+                ),
+            );
+            return;
+        }
         let Some(earnings) = snapshot.earnings.as_ref() else {
             self.mark_pylon_authority_unavailable(
                 now,

--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -28254,7 +28254,7 @@ impl RenderState {
         !matches!(
             self.provider_runtime.mode,
             ProviderMode::Offline | ProviderMode::Degraded
-        ) || self.mission_control_local_runtime_ready()
+        ) || (self.mission_control_local_runtime_ready() && self.provider_blockers().is_empty())
     }
 
     pub fn configured_provider_relay_urls(&self) -> Vec<String> {
@@ -28319,6 +28319,23 @@ impl RenderState {
         }
         if self.spark_wallet.last_error.is_some() {
             blockers.push(ProviderBlocker::WalletError);
+        }
+        // Pylon is the authority for live provider earnings (PR #4266: "Source
+        // Autopilot earnings from Pylon authority"). The Pylon provider-admin
+        // store is the canonical sink for both sell-compute earnings and
+        // data-market earnings, so an unavailable Pylon authority blocks
+        // go-online in *every* provider mode -- not just sell-compute. This
+        // check sits above the data_seller / data_buyer / supports_sell_compute
+        // early returns so that a stale Data Seller draft from prior testing
+        // cannot accidentally short-circuit the Pylon gate on a sell-compute
+        // bring-up. The conservative `!= Ready` shape avoids a transient
+        // startup window where load_state is still `Loading` (its default)
+        // before the first earnings refresh tick has fired, during which an
+        // `== Error` check would let the user click Go Online before the gate
+        // kicks in. Mirrors how `GptOssModelUnavailable` is cleared only on an
+        // explicit `is_ready()`, not on the absence of an error.
+        if self.earnings_scoreboard.load_state != PaneLoadState::Ready {
+            blockers.push(ProviderBlocker::PylonAuthorityUnavailable);
         }
         if self.data_seller.derived_nip90_profile().is_some()
             || self.data_buyer.requires_nip90_response_tracking()

--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -25042,8 +25042,8 @@ fn labor_tool_evidence_ref(
 }
 
 pub use crate::state::provider_runtime::{
-    EarnFailureClass, ProviderBlocker, ProviderInventoryProductToggleTarget, ProviderMode,
-    ProviderRuntimeState,
+    EarnFailureClass, ProviderBlocker, ProviderDesiredMode, ProviderInventoryProductToggleTarget,
+    ProviderMode, ProviderRuntimeState,
 };
 #[allow(unused_imports)]
 pub use crate::state::{
@@ -27213,6 +27213,14 @@ pub struct EarningsScoreboardState {
     pub avg_wallet_confirmation_latency_seconds: Option<u64>,
     pub stale_after: Duration,
     pub last_refreshed_at: Option<Instant>,
+    /// Pylon's persisted `desired_mode` from the most recent successful
+    /// `refresh_from_pylon_status` call. `None` until the first refresh has
+    /// run successfully (or after `mark_pylon_authority_unavailable` clears
+    /// it). Drives the `ProviderBlocker::PylonProviderOffline` gate so that
+    /// autopilot will not let the operator click GO ONLINE while the Pylon
+    /// provider lane is configured to drop incoming NIP-90 requests with
+    /// `provider_not_online`.
+    pub pylon_desired_mode: Option<ProviderDesiredMode>,
     scroll_offset_px: f32,
     tracked_online_since: Option<Instant>,
     first_completed_since_online: Option<Instant>,
@@ -27237,6 +27245,7 @@ impl Default for EarningsScoreboardState {
             avg_wallet_confirmation_latency_seconds: None,
             stale_after: Duration::from_secs(12),
             last_refreshed_at: None,
+            pylon_desired_mode: None,
             scroll_offset_px: 0.0,
             tracked_online_since: None,
             first_completed_since_online: None,
@@ -27372,6 +27381,14 @@ impl EarningsScoreboardState {
         self.tracked_online_since = None;
         self.first_completed_since_online = None;
         self.first_job_latency_seconds = None;
+        // Pylon's `desired_mode` lives at the top of `ProviderStatusResponse`,
+        // separate from the persisted snapshot. Capture it on every successful
+        // status load so the `PylonProviderOffline` gate in `provider_blockers()`
+        // can see whether the operator has flipped pylon online via the TUI or
+        // `pylon provider run`. The field is cleared back to `None` by
+        // `mark_pylon_authority_unavailable` so a stale "online" reading from a
+        // previous refresh cannot mask a now-unreachable Pylon authority.
+        self.pylon_desired_mode = Some(status.desired_mode);
 
         let Some(snapshot) = status.snapshot.as_ref() else {
             self.mark_pylon_authority_unavailable(
@@ -27448,6 +27465,7 @@ impl EarningsScoreboardState {
         self.completion_ratio_bps = None;
         self.payout_success_ratio_bps = None;
         self.avg_wallet_confirmation_latency_seconds = None;
+        self.pylon_desired_mode = None;
         self.tracked_online_since = None;
         self.first_completed_since_online = None;
     }
@@ -28336,6 +28354,21 @@ impl RenderState {
         // explicit `is_ready()`, not on the absence of an error.
         if self.earnings_scoreboard.load_state != PaneLoadState::Ready {
             blockers.push(ProviderBlocker::PylonAuthorityUnavailable);
+        } else if self.earnings_scoreboard.pylon_desired_mode != Some(ProviderDesiredMode::Online) {
+            // Even when the Pylon authority is reachable and reporting a clean
+            // snapshot, pylon's NIP-90 runtime drops every incoming job request
+            // with `provider_not_online` whenever its persisted `desired_mode`
+            // is not `Online` (see `apps/pylon/src/nip90_runtime.rs`). Going
+            // online from autopilot in that state produces a contradictory
+            // surface where Mission Control reads "ready to earn" but the
+            // actual job pipeline silently rejects every request. The
+            // operator must flip Pylon online via the `pylon` TUI or
+            // `pylon provider run` before autopilot's go-online is meaningful.
+            // Only fires when the scoreboard is `Ready`, so the
+            // `PylonAuthorityUnavailable` blocker above takes precedence for
+            // the missing-store case (avoids stacking two pylon blockers for
+            // the same root cause).
+            blockers.push(ProviderBlocker::PylonProviderOffline);
         }
         if self.data_seller.derived_nip90_profile().is_some()
             || self.data_buyer.requires_nip90_response_tracking()

--- a/apps/autopilot-desktop/src/input.rs
+++ b/apps/autopilot-desktop/src/input.rs
@@ -2561,11 +2561,22 @@ fn dispatch_mouse_down(
     // Sidebar "Go Online" button (when panel is open).
     if button == MouseButton::Left && state.sidebar.is_open {
         let go_online_bounds = sidebar_go_online_button_bounds(state);
-        if go_online_bounds.size.width > 0.0
-            && go_online_bounds.contains(point)
-            && run_pane_hit_action(state, PaneHitAction::GoOnlineToggle)
-        {
-            return true;
+        if go_online_bounds.size.width > 0.0 && go_online_bounds.contains(point) {
+            // Mirror the Mission Control pane gating: when offline/degraded and
+            // the gate is closed (LLM not ready, or there are provider blockers
+            // such as the Pylon authority being unavailable), consume the click
+            // but reject the toggle. Without this, the sidebar shortcut bypasses
+            // the same go-online gate the in-pane button respects.
+            if matches!(
+                state.provider_runtime.mode,
+                crate::app_state::ProviderMode::Offline | crate::app_state::ProviderMode::Degraded
+            ) && !state.mission_control_go_online_enabled()
+            {
+                return true;
+            }
+            if run_pane_hit_action(state, PaneHitAction::GoOnlineToggle) {
+                return true;
+            }
         }
     }
 

--- a/apps/autopilot-desktop/src/input/actions.rs
+++ b/apps/autopilot-desktop/src/input/actions.rs
@@ -20776,6 +20776,10 @@ mod tests {
             scoreboard.load_state,
             crate::app_state::PaneLoadState::Ready
         );
+        assert_eq!(
+            scoreboard.pylon_desired_mode,
+            Some(openagents_provider_substrate::ProviderDesiredMode::Online)
+        );
         assert_eq!(scoreboard.sats_today, 21);
         assert_eq!(scoreboard.sats_this_month, 21);
         assert_eq!(scoreboard.lifetime_sats, 84);
@@ -20792,6 +20796,105 @@ mod tests {
                 .as_deref()
                 .is_some_and(|action| action.contains("Pylon"))
         );
+    }
+
+    #[test]
+    fn refresh_earnings_scoreboard_captures_pylon_desired_mode_offline() {
+        // Mirrors `refresh_earnings_scoreboard_reads_authoritative_pylon_store`
+        // but persists the store with `desired_mode = Offline` and a healthy
+        // snapshot. Confirms that `EarningsScoreboardState.pylon_desired_mode`
+        // is populated from `ProviderStatusResponse.desired_mode` so the
+        // `ProviderBlocker::PylonProviderOffline` gate in
+        // `RenderState::provider_blockers()` can see the operator-configured
+        // offline state even when the Pylon authority itself is reachable
+        // (`load_state == Ready`).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("provider-admin.sqlite");
+        let listen_addr = "127.0.0.1:0"
+            .parse()
+            .expect("static provider admin listen addr");
+        let config =
+            openagents_provider_substrate::ProviderAdminConfig::new(db_path.clone(), listen_addr);
+        let mut store = openagents_provider_substrate::ProviderPersistenceStore::open(&config)
+            .expect("provider admin store");
+        store
+            .set_listen_addr("127.0.0.1:9468")
+            .expect("persist listen addr");
+        store
+            .set_desired_mode(openagents_provider_substrate::ProviderDesiredMode::Offline)
+            .expect("persist desired mode");
+
+        let reference_epoch_seconds = crate::app_state::current_reference_epoch_seconds();
+        let snapshot = openagents_provider_substrate::assemble_provider_persisted_snapshot(
+            openagents_provider_substrate::ProviderSnapshotParts {
+                captured_at_ms: i64::try_from(reference_epoch_seconds).unwrap_or(i64::MAX) * 1000,
+                runtime: openagents_provider_substrate::ProviderRuntimeStatusSnapshot {
+                    mode: openagents_provider_substrate::ProviderMode::Offline,
+                    authoritative_status: Some("offline".to_string()),
+                    online_uptime_seconds: 0,
+                    ..Default::default()
+                },
+                payouts: Vec::new(),
+                earnings: Some(openagents_provider_substrate::ProviderEarningsSummary::default()),
+                ..Default::default()
+            },
+        );
+        store.persist_snapshot(&snapshot).expect("persist snapshot");
+
+        let mut scoreboard = crate::app_state::EarningsScoreboardState::default();
+        refresh_earnings_scoreboard_from_pylon_store(
+            &mut scoreboard,
+            std::time::Instant::now(),
+            db_path.as_path(),
+        )
+        .expect("refresh from pylon store");
+
+        assert_eq!(
+            scoreboard.load_state,
+            crate::app_state::PaneLoadState::Ready,
+            "store loaded cleanly so the scoreboard should be Ready, not Error"
+        );
+        assert_eq!(
+            scoreboard.pylon_desired_mode,
+            Some(openagents_provider_substrate::ProviderDesiredMode::Offline),
+            "pylon_desired_mode should mirror ProviderStatusResponse.desired_mode"
+        );
+    }
+
+    #[test]
+    fn refresh_earnings_scoreboard_clears_pylon_desired_mode_on_unavailable() {
+        // When the store is missing entirely, refresh falls into
+        // `mark_pylon_authority_unavailable`, which must clear
+        // `pylon_desired_mode` back to `None` so a stale "online" reading from
+        // a previous successful refresh cannot mask a now-unreachable Pylon
+        // authority. Without this, a flaky bring-down of pylon would leave
+        // the offline gate seeing `Some(Online)` and let the operator click
+        // GO ONLINE while the Pylon authority is silently gone.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let missing_db_path = temp.path().join("does-not-exist.sqlite");
+        let mut scoreboard = crate::app_state::EarningsScoreboardState::default();
+        scoreboard.pylon_desired_mode =
+            Some(openagents_provider_substrate::ProviderDesiredMode::Online);
+
+        let result = refresh_earnings_scoreboard_from_pylon_store(
+            &mut scoreboard,
+            std::time::Instant::now(),
+            missing_db_path.as_path(),
+        );
+
+        assert!(result.is_err(), "missing store should propagate as Err");
+        // The action handler responds to that Err by calling
+        // `mark_pylon_authority_unavailable`, which is what tests the clear.
+        scoreboard.mark_pylon_authority_unavailable(
+            std::time::Instant::now(),
+            "pylon.provider-admin",
+            "Pylon provider admin store not found",
+        );
+        assert_eq!(
+            scoreboard.load_state,
+            crate::app_state::PaneLoadState::Error
+        );
+        assert_eq!(scoreboard.pylon_desired_mode, None);
     }
 
     #[test]

--- a/apps/autopilot-desktop/src/input/actions.rs
+++ b/apps/autopilot-desktop/src/input/actions.rs
@@ -20898,6 +20898,85 @@ mod tests {
     }
 
     #[test]
+    fn refresh_earnings_scoreboard_marks_stale_pylon_snapshot_as_unavailable() {
+        // Catches the third Pylon liveness failure mode: pylon serve dead,
+        // SQLite still on disk with `desired_mode = online` from a previous
+        // session. Persist a snapshot with `captured_at_ms` set ~10 minutes
+        // in the past (well past the 15s
+        // `PYLON_SNAPSHOT_STALENESS_THRESHOLD_MS`) and confirm
+        // `refresh_from_pylon_status` falls into
+        // `mark_pylon_authority_unavailable` instead of trusting the stale
+        // row. Without this gate, autopilot would happily read
+        // `desired_mode = Online` from the file and let the operator click
+        // GO ONLINE while no live job pipeline exists.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("provider-admin.sqlite");
+        let listen_addr = "127.0.0.1:0"
+            .parse()
+            .expect("static provider admin listen addr");
+        let config =
+            openagents_provider_substrate::ProviderAdminConfig::new(db_path.clone(), listen_addr);
+        let mut store = openagents_provider_substrate::ProviderPersistenceStore::open(&config)
+            .expect("provider admin store");
+        store
+            .set_listen_addr("127.0.0.1:9468")
+            .expect("persist listen addr");
+        store
+            .set_desired_mode(openagents_provider_substrate::ProviderDesiredMode::Online)
+            .expect("persist desired mode");
+
+        // 10 minutes ago, well past the 15s staleness threshold.
+        let stale_captured_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0i64, |duration| {
+                i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
+            })
+            .saturating_sub(10 * 60 * 1_000);
+        let snapshot = openagents_provider_substrate::assemble_provider_persisted_snapshot(
+            openagents_provider_substrate::ProviderSnapshotParts {
+                captured_at_ms: stale_captured_at_ms,
+                runtime: openagents_provider_substrate::ProviderRuntimeStatusSnapshot {
+                    mode: openagents_provider_substrate::ProviderMode::Online,
+                    authoritative_status: Some("online".to_string()),
+                    online_uptime_seconds: 3600,
+                    ..Default::default()
+                },
+                payouts: Vec::new(),
+                earnings: Some(openagents_provider_substrate::ProviderEarningsSummary::default()),
+                ..Default::default()
+            },
+        );
+        store.persist_snapshot(&snapshot).expect("persist snapshot");
+
+        let mut scoreboard = crate::app_state::EarningsScoreboardState::default();
+        refresh_earnings_scoreboard_from_pylon_store(
+            &mut scoreboard,
+            std::time::Instant::now(),
+            db_path.as_path(),
+        )
+        .expect("refresh from pylon store");
+
+        assert_eq!(
+            scoreboard.load_state,
+            crate::app_state::PaneLoadState::Error,
+            "stale snapshot should fall into mark_pylon_authority_unavailable"
+        );
+        assert!(
+            scoreboard
+                .last_error
+                .as_deref()
+                .is_some_and(|error| error.contains("stale")),
+            "stale snapshot last_error should call out the staleness; got {:?}",
+            scoreboard.last_error
+        );
+        assert_eq!(
+            scoreboard.pylon_desired_mode, None,
+            "stale snapshot must clear pylon_desired_mode so the offline gate \
+             cannot mistake the prior `online` reading for live truth"
+        );
+    }
+
+    #[test]
     fn resolves_open_network_wallet_pointer_by_exact_invoice_identity_before_amount_heuristic() {
         let mut job = fixture_open_network_delivered_job(10);
         job.settlement_bolt11 = Some("lnbc20n1targetinvoice".to_string());

--- a/apps/autopilot-desktop/src/input/actions.rs
+++ b/apps/autopilot-desktop/src/input/actions.rs
@@ -15359,6 +15359,7 @@ pub(super) fn run_mission_control_action(
                 &state.gpt_oss_execution,
                 provider_blockers.as_slice(),
                 &state.spark_wallet,
+                &state.earnings_scoreboard,
             );
             state.mission_control.dismiss_alert(signature);
             true

--- a/apps/autopilot-desktop/src/pane_renderer.rs
+++ b/apps/autopilot-desktop/src/pane_renderer.rs
@@ -18,8 +18,8 @@ use crate::app_state::{
     NetworkRequestsState, Nip90SentPaymentsPaneState, NostrIdentityPaneState, NostrSecretState,
     PaneKind, PaneLoadState, PanePaintTimingSample, PanePresentation, PayInvoicePaneInputs,
     PresentationPaneState, PresentationRuntimeState, ProjectOpsPaneState, ProviderBlocker,
-    ProviderControlHudRuntimeState, ProviderControlPaneState, ProviderRuntimeState,
-    ProviderStatusPaneState, ReciprocalLoopState, RelayConnectionsPaneInputs,
+    ProviderControlHudRuntimeState, ProviderControlPaneState, ProviderDesiredMode,
+    ProviderRuntimeState, ProviderStatusPaneState, ReciprocalLoopState, RelayConnectionsPaneInputs,
     RelayConnectionsState, RivePreviewPaneState, RivePreviewRuntimeState, SettingsPaneInputs,
     SettingsState, SidebarState, SkillRegistryPaneState, SkillTrustRevocationPaneState,
     SparkPaneInputs, SparkReplayPaneState, SparkWalletPaneState, StarterJobStatus,
@@ -5073,19 +5073,35 @@ fn mission_control_earnings_amount_color(
     }
 }
 
-/// Short alert-band summary for the earnings scoreboard, derived from
-/// `source_tag` rather than the long `last_error` text so the Mission Control
-/// alert band can fit it. Returns `None` when the scoreboard is not in the
-/// Error state (the alert band uses other priorities in that case).
+/// Short alert-band summary for the earnings scoreboard. Returns one of two
+/// distinct messages so the alert band can communicate which Pylon failure
+/// mode the operator is in:
+///
+/// 1. **Authority unreachable** (`load_state == Error`) — the Pylon
+///    provider-admin store is missing or load failed. The summary is derived
+///    from `source_tag` rather than the long `last_error` text so the alert
+///    band can fit it.
+/// 2. **Provider configured offline** (`load_state == Ready` but
+///    `pylon_desired_mode != Some(Online)`) — Pylon is reachable and the
+///    snapshot loaded cleanly, but the operator has not flipped pylon online
+///    via the `pylon` TUI or `pylon provider run`. Pylon's NIP-90 runtime
+///    drops every incoming job request with `provider_not_online` in this
+///    state, so going online from autopilot earns nothing.
+///
+/// Returns `None` in all other cases (the alert band uses other priorities).
 fn mission_control_earnings_alert_summary(state: &EarningsScoreboardState) -> Option<String> {
-    if state.load_state != PaneLoadState::Error {
-        return None;
+    if state.load_state == PaneLoadState::Error {
+        if state.source_tag.starts_with("pylon.provider-admin") {
+            return Some("PYLON AUTHORITY UNAVAILABLE".to_string());
+        }
+        return Some("EARNINGS AUTHORITY UNAVAILABLE".to_string());
     }
-    if state.source_tag.starts_with("pylon.provider-admin") {
-        Some("PYLON AUTHORITY UNAVAILABLE".to_string())
-    } else {
-        Some("EARNINGS AUTHORITY UNAVAILABLE".to_string())
+    if state.load_state == PaneLoadState::Ready
+        && state.pylon_desired_mode != Some(ProviderDesiredMode::Online)
+    {
+        return Some("PYLON PROVIDER OFFLINE".to_string());
     }
+    None
 }
 
 fn mission_control_buy_mode_result_label(
@@ -11186,6 +11202,14 @@ pub(crate) fn mission_control_blocker_detail(
             .filter(|entry| !entry.is_empty())
             .map(ToString::to_string)
             .unwrap_or_else(|| blocker.detail().to_string()),
+        // The two Pylon blockers use short alert-band labels here so the
+        // PREFLIGHT line in `mission_control_alert_message` does not truncate
+        // the substrate's longer diagnostic strings (which remain available
+        // via `blocker.detail()` for `autopilotctl --json` and CLI surfaces).
+        // Mirrors how `GptOssUnavailable` and friends already swap in short
+        // forms above for the same display reason.
+        ProviderBlocker::PylonAuthorityUnavailable => "Pylon authority unreachable".to_string(),
+        ProviderBlocker::PylonProviderOffline => "Pylon desired_mode is offline".to_string(),
         _ => blocker.detail().to_string(),
     }
 }

--- a/apps/autopilot-desktop/src/pane_renderer.rs
+++ b/apps/autopilot-desktop/src/pane_renderer.rs
@@ -2196,6 +2196,7 @@ fn paint_go_online_pane(
         local_inference_runtime,
         provider_blockers,
         spark_wallet,
+        earnings_scoreboard,
     );
     let alert_visible = mission_control.should_show_alert(alert_message.signature.as_str());
     let alert_dismiss_bounds = mission_control_alert_dismiss_button_bounds(content_bounds);
@@ -2290,7 +2291,7 @@ fn paint_go_online_pane(
     paint_mission_control_section_panel(
         layout.earnings_panel,
         "WALLET & EARNINGS",
-        mission_control_green_color(),
+        mission_control_earnings_panel_accent(earnings_scoreboard.load_state),
         false,
         paint,
     );
@@ -2327,11 +2328,11 @@ fn paint_go_online_pane(
         crate::app_state::ProviderMode::Offline | crate::app_state::ProviderMode::Degraded
     );
     let go_online_enabled = !wants_online
-        || mission_control_local_runtime_is_ready(
+        || (mission_control_local_runtime_is_ready(
             desktop_shell_mode,
             provider_runtime,
             local_inference_runtime,
-        );
+        ) && provider_blockers.is_empty());
     let toggle_label = if wants_online {
         "GO ONLINE"
     } else {
@@ -2601,7 +2602,10 @@ fn paint_go_online_pane(
         earnings_y,
         "Today",
         &today_display,
-        mission_control_green_color(),
+        mission_control_earnings_amount_color(
+            earnings_scoreboard.load_state,
+            mission_control_green_color(),
+        ),
         MISSION_CONTROL_PANEL_FONT_SIZE,
         layout.earnings_panel.size.width - 24.0,
         true,
@@ -2612,7 +2616,10 @@ fn paint_go_online_pane(
         earnings_y,
         "This Month",
         &month_display,
-        mission_control_text_color(),
+        mission_control_earnings_amount_color(
+            earnings_scoreboard.load_state,
+            mission_control_text_color(),
+        ),
         MISSION_CONTROL_PANEL_FONT_SIZE,
         layout.earnings_panel.size.width - 24.0,
         true,
@@ -2623,7 +2630,10 @@ fn paint_go_online_pane(
         earnings_y,
         "All Time",
         &lifetime_display,
-        mission_control_cyan_color(),
+        mission_control_earnings_amount_color(
+            earnings_scoreboard.load_state,
+            mission_control_cyan_color(),
+        ),
         MISSION_CONTROL_PANEL_FONT_SIZE,
         layout.earnings_panel.size.width - 24.0,
         true,
@@ -3238,6 +3248,7 @@ fn paint_go_online_docked_pane(
         local_inference_runtime,
         provider_blockers,
         spark_wallet,
+        earnings_scoreboard,
     );
     let alert_visible = mission_control.should_show_alert(alert_message.signature.as_str());
     let alert_dismiss_bounds =
@@ -3295,11 +3306,11 @@ fn paint_go_online_docked_pane(
         crate::app_state::ProviderMode::Offline | crate::app_state::ProviderMode::Degraded
     );
     let go_online_enabled = !wants_online
-        || mission_control_local_runtime_is_ready(
+        || (mission_control_local_runtime_is_ready(
             desktop_shell_mode,
             provider_runtime,
             local_inference_runtime,
-        );
+        ) && provider_blockers.is_empty());
     let toggle_label = if wants_online {
         "GO ONLINE"
     } else {
@@ -3401,7 +3412,7 @@ fn paint_go_online_docked_pane(
     paint_mission_control_section_panel(
         layout.earnings_panel,
         "WALLET & EARNINGS",
-        mission_control_green_color(),
+        mission_control_earnings_panel_accent(earnings_scoreboard.load_state),
         false,
         paint,
     );
@@ -3656,7 +3667,10 @@ fn paint_go_online_docked_pane(
         earnings_y,
         "Today",
         &today_display,
-        mission_control_green_color(),
+        mission_control_earnings_amount_color(
+            earnings_scoreboard.load_state,
+            mission_control_green_color(),
+        ),
         MISSION_CONTROL_PANEL_FONT_SIZE,
         layout.earnings_panel.size.width - 24.0,
         true,
@@ -3667,7 +3681,10 @@ fn paint_go_online_docked_pane(
         earnings_y,
         "This Month",
         &month_display,
-        mission_control_text_color(),
+        mission_control_earnings_amount_color(
+            earnings_scoreboard.load_state,
+            mission_control_text_color(),
+        ),
         MISSION_CONTROL_PANEL_FONT_SIZE,
         layout.earnings_panel.size.width - 24.0,
         true,
@@ -3678,7 +3695,10 @@ fn paint_go_online_docked_pane(
         earnings_y,
         "All Time",
         &lifetime_display,
-        mission_control_cyan_color(),
+        mission_control_earnings_amount_color(
+            earnings_scoreboard.load_state,
+            mission_control_cyan_color(),
+        ),
         MISSION_CONTROL_PANEL_FONT_SIZE,
         layout.earnings_panel.size.width - 24.0,
         true,
@@ -4524,6 +4544,7 @@ pub(crate) fn mission_control_current_alert_signature(
     local_inference_runtime: &LocalInferenceExecutionSnapshot,
     provider_blockers: &[ProviderBlocker],
     spark_wallet: &SparkPaneState,
+    earnings_scoreboard: &EarningsScoreboardState,
 ) -> String {
     mission_control_alert_message(
         mission_control,
@@ -4532,6 +4553,7 @@ pub(crate) fn mission_control_current_alert_signature(
         local_inference_runtime,
         provider_blockers,
         spark_wallet,
+        earnings_scoreboard,
     )
     .signature
 }
@@ -4543,6 +4565,7 @@ fn mission_control_alert_message(
     local_inference_runtime: &LocalInferenceExecutionSnapshot,
     provider_blockers: &[ProviderBlocker],
     spark_wallet: &SparkPaneState,
+    earnings_scoreboard: &EarningsScoreboardState,
 ) -> MissionControlAlertDescriptor {
     if let Some(error) = mission_control.last_error.as_deref().map(str::trim)
         && !error.is_empty()
@@ -4561,6 +4584,15 @@ fn mission_control_alert_message(
             mission_control_blocker_detail(blocker, spark_wallet, provider_runtime)
                 .to_ascii_uppercase()
         );
+        return MissionControlAlertDescriptor {
+            signature: text.clone(),
+            text,
+            accent: mission_control_orange_color(),
+        };
+    }
+
+    if let Some(summary) = mission_control_earnings_alert_summary(earnings_scoreboard) {
+        let text = format!("EARNINGS // {summary}");
         return MissionControlAlertDescriptor {
             signature: text.clone(),
             text,
@@ -5007,6 +5039,52 @@ fn mission_control_mode_color(mode: crate::app_state::ProviderMode) -> Hsla {
         crate::app_state::ProviderMode::Connecting => mission_control_cyan_color(),
         crate::app_state::ProviderMode::Online => mission_control_green_color(),
         crate::app_state::ProviderMode::Degraded => mission_control_red_color(),
+    }
+}
+
+/// Mission Control "WALLET & EARNINGS" section panel accent color, derived from
+/// the earnings scoreboard load state. PR #4266 plumbed the new
+/// `pylon.provider-admin` `load_state` into `EarningsScoreboardState` but the
+/// section panel header was left hardcoded to green; this helper completes the
+/// surfacing so the panel accent reflects whether Pylon authority is healthy.
+fn mission_control_earnings_panel_accent(load_state: PaneLoadState) -> Hsla {
+    match load_state {
+        PaneLoadState::Ready => mission_control_green_color(),
+        PaneLoadState::Loading => mission_control_cyan_color(),
+        PaneLoadState::Error => mission_control_amber_color(),
+    }
+}
+
+/// Mission Control "Today / This Month / All Time" amount-line color, derived
+/// from the earnings scoreboard load state. Returns the caller's preferred
+/// `default_color` when the scoreboard is Ready or Loading; replaces it with
+/// the amber degraded-state accent when in Error so the row visibly stands out
+/// from a healthy "no earnings yet" zero. The amount string itself is left to
+/// `earnings_scoreboard_amount_display`, whose Loading-vs-Ready/Error contract
+/// is preserved by PR #4266 and its existing test.
+fn mission_control_earnings_amount_color(
+    load_state: PaneLoadState,
+    default_color: Hsla,
+) -> Hsla {
+    if load_state == PaneLoadState::Error {
+        mission_control_amber_color()
+    } else {
+        default_color
+    }
+}
+
+/// Short alert-band summary for the earnings scoreboard, derived from
+/// `source_tag` rather than the long `last_error` text so the Mission Control
+/// alert band can fit it. Returns `None` when the scoreboard is not in the
+/// Error state (the alert band uses other priorities in that case).
+fn mission_control_earnings_alert_summary(state: &EarningsScoreboardState) -> Option<String> {
+    if state.load_state != PaneLoadState::Error {
+        return None;
+    }
+    if state.source_tag.starts_with("pylon.provider-admin") {
+        Some("PYLON AUTHORITY UNAVAILABLE".to_string())
+    } else {
+        Some("EARNINGS AUTHORITY UNAVAILABLE".to_string())
     }
 }
 

--- a/apps/autopilot-desktop/src/pane_renderer.rs
+++ b/apps/autopilot-desktop/src/pane_renderer.rs
@@ -5092,14 +5092,14 @@ fn mission_control_earnings_amount_color(
 fn mission_control_earnings_alert_summary(state: &EarningsScoreboardState) -> Option<String> {
     if state.load_state == PaneLoadState::Error {
         if state.source_tag.starts_with("pylon.provider-admin") {
-            return Some("PYLON AUTHORITY UNAVAILABLE".to_string());
+            return Some("PYLON SERVICE UNAVAILABLE".to_string());
         }
-        return Some("EARNINGS AUTHORITY UNAVAILABLE".to_string());
+        return Some("EARNINGS SERVICE UNAVAILABLE".to_string());
     }
     if state.load_state == PaneLoadState::Ready
         && state.pylon_desired_mode != Some(ProviderDesiredMode::Online)
     {
-        return Some("PYLON PROVIDER OFFLINE".to_string());
+        return Some("PYLON SERVICE IN OFFLINE MODE".to_string());
     }
     None
 }
@@ -11207,9 +11207,14 @@ pub(crate) fn mission_control_blocker_detail(
         // the substrate's longer diagnostic strings (which remain available
         // via `blocker.detail()` for `autopilotctl --json` and CLI surfaces).
         // Mirrors how `GptOssUnavailable` and friends already swap in short
-        // forms above for the same display reason.
-        ProviderBlocker::PylonAuthorityUnavailable => "Pylon authority unreachable".to_string(),
-        ProviderBlocker::PylonProviderOffline => "Pylon desired_mode is offline".to_string(),
+        // forms above for the same display reason. The user-facing wording
+        // says "Pylon service" rather than the internal #4266 term
+        // "Pylon authority", because operators reading the alert band do not
+        // share the maintainers' substrate vocabulary -- the ProviderBlocker
+        // variant and JSON code keep the original "authority" wording for
+        // CLI/JSON surfaces and substrate consumers.
+        ProviderBlocker::PylonAuthorityUnavailable => "Pylon service unavailable".to_string(),
+        ProviderBlocker::PylonProviderOffline => "Pylon service in offline mode".to_string(),
         _ => blocker.detail().to_string(),
     }
 }

--- a/apps/autopilot-desktop/src/pane_system.rs
+++ b/apps/autopilot-desktop/src/pane_system.rs
@@ -8164,6 +8164,7 @@ fn pane_hit_action_for_pane(
                 &state.gpt_oss_execution,
                 provider_blockers.as_slice(),
                 &state.spark_wallet,
+                &state.earnings_scoreboard,
             );
             let alert_dismiss_bounds = if docked {
                 mission_control_docked_alert_dismiss_button_bounds(

--- a/apps/autopilot-desktop/src/panes/provider_control.rs
+++ b/apps/autopilot-desktop/src/panes/provider_control.rs
@@ -63,11 +63,11 @@ pub fn paint_provider_control_pane(
         ProviderMode::Offline | ProviderMode::Degraded
     );
     let go_online_enabled = !wants_online
-        || mission_control_local_runtime_is_ready(
+        || (mission_control_local_runtime_is_ready(
             desktop_shell_mode,
             provider_runtime,
             local_inference_runtime,
-        );
+        ) && provider_blockers.is_empty());
     let toggle_label = if wants_online {
         "GO ONLINE"
     } else {

--- a/apps/autopilot-desktop/src/render.rs
+++ b/apps/autopilot-desktop/src/render.rs
@@ -1473,6 +1473,7 @@ pub fn render_frame(state: &mut RenderState) -> Result<crate::app_state::FrameRe
     }
 
     let provider_blockers = state.provider_blockers();
+    let sidebar_go_online_enabled = state.mission_control_go_online_enabled();
     let provider_inventory = crate::provider_inventory::inventory_status_for_state(state);
     let training_status = crate::desktop_control::current_training_status(state);
     let remote_training_status = crate::desktop_control::current_remote_training_status(state);
@@ -1537,16 +1538,21 @@ pub fn render_frame(state: &mut RenderState) -> Result<crate::app_state::FrameRe
 
             let go_online_bounds = Bounds::new(left, 72.0, (panel_width - 24.0).max(120.0), 34.0);
             let is_online = state.provider_runtime.mode != ProviderMode::Offline;
+            let go_online_enabled = sidebar_go_online_enabled;
             let action_label = if is_online { "GO OFFLINE" } else { "GO ONLINE" };
             paint.scene.draw_quad(
                 Quad::new(go_online_bounds)
-                    .with_background(if is_online {
+                    .with_background(if !go_online_enabled {
+                        theme::bg::APP.with_alpha(0.40)
+                    } else if is_online {
                         theme::status::ERROR.with_alpha(0.25)
                     } else {
                         theme::status::SUCCESS.with_alpha(0.28)
                     })
                     .with_border(
-                        if is_online {
+                        if !go_online_enabled {
+                            theme::border::DEFAULT.with_alpha(0.50)
+                        } else if is_online {
                             theme::status::ERROR.with_alpha(0.75)
                         } else {
                             theme::status::SUCCESS.with_alpha(0.75)

--- a/apps/autopilot-desktop/src/state/provider_runtime.rs
+++ b/apps/autopilot-desktop/src/state/provider_runtime.rs
@@ -13,9 +13,9 @@ pub use openagents_provider_substrate::{
     ProviderAdapterTrainingSettlementTrigger, ProviderAdvertisedProduct,
     ProviderAppleAdapterHostingAvailability, ProviderAppleAdapterHostingEntry,
     ProviderAvailability, ProviderBackendHealth, ProviderBackendKind, ProviderBlocker,
-    ProviderComputeProduct, ProviderFailureClass, ProviderInventoryControls, ProviderInventoryRow,
-    ProviderMode, ProviderSandboxAvailability, ProviderSandboxDetectionConfig,
-    derive_provider_products, detect_sandbox_supply,
+    ProviderComputeProduct, ProviderDesiredMode, ProviderFailureClass, ProviderInventoryControls,
+    ProviderInventoryRow, ProviderMode, ProviderSandboxAvailability,
+    ProviderSandboxDetectionConfig, derive_provider_products, detect_sandbox_supply,
 };
 use psionic_apple_fm::{
     AppleFmAdapterInventoryEntry, AppleFmSystemLanguageModel, AppleFmSystemLanguageModelGuardrails,

--- a/crates/openagents-provider-substrate/src/lib.rs
+++ b/crates/openagents-provider-substrate/src/lib.rs
@@ -82,6 +82,7 @@ pub enum ProviderBlocker {
     GptOssModelUnavailable,
     AppleFoundationModelsUnavailable,
     AppleFoundationModelsModelUnavailable,
+    PylonAuthorityUnavailable,
 }
 
 impl ProviderBlocker {
@@ -95,6 +96,7 @@ impl ProviderBlocker {
             Self::GptOssModelUnavailable => "LOCAL_GEMMA_MODEL_UNAVAILABLE",
             Self::AppleFoundationModelsUnavailable => "APPLE_FM_UNAVAILABLE",
             Self::AppleFoundationModelsModelUnavailable => "APPLE_FM_MODEL_UNAVAILABLE",
+            Self::PylonAuthorityUnavailable => "PYLON_AUTHORITY_UNAVAILABLE",
         }
     }
 
@@ -111,6 +113,9 @@ impl ProviderBlocker {
             }
             Self::AppleFoundationModelsModelUnavailable => {
                 "Apple Foundation Models is not ready to serve inference"
+            }
+            Self::PylonAuthorityUnavailable => {
+                "Pylon provider authority is unavailable; live earnings cannot be tracked"
             }
         }
     }

--- a/crates/openagents-provider-substrate/src/lib.rs
+++ b/crates/openagents-provider-substrate/src/lib.rs
@@ -83,6 +83,7 @@ pub enum ProviderBlocker {
     AppleFoundationModelsUnavailable,
     AppleFoundationModelsModelUnavailable,
     PylonAuthorityUnavailable,
+    PylonProviderOffline,
 }
 
 impl ProviderBlocker {
@@ -97,6 +98,7 @@ impl ProviderBlocker {
             Self::AppleFoundationModelsUnavailable => "APPLE_FM_UNAVAILABLE",
             Self::AppleFoundationModelsModelUnavailable => "APPLE_FM_MODEL_UNAVAILABLE",
             Self::PylonAuthorityUnavailable => "PYLON_AUTHORITY_UNAVAILABLE",
+            Self::PylonProviderOffline => "PYLON_PROVIDER_OFFLINE",
         }
     }
 
@@ -116,6 +118,9 @@ impl ProviderBlocker {
             }
             Self::PylonAuthorityUnavailable => {
                 "Pylon provider authority is unavailable; live earnings cannot be tracked"
+            }
+            Self::PylonProviderOffline => {
+                "Pylon provider is reachable but desired_mode is offline; incoming jobs will be dropped"
             }
         }
     }


### PR DESCRIPTION
  ## Summary

  - Completes the Mission Control side of #4266 by **surfacing** the new
    `pylon.provider-admin` `load_state` in the WALLET & EARNINGS panel and
    alert band, and **enforcing** the maintainer-intended invariant
    ("Pylon is the authority for live provider earnings") so the GO ONLINE
    button cannot be clicked when the Pylon provider is unable to actually
    accept jobs.
  - Catches **three distinct Pylon liveness failure modes** that all
    produce the same operator-facing failure (clicking GO ONLINE earns
    zero sats because Pylon's NIP-90 runtime drops the work):
    1. Pylon admin store is missing entirely
    2. Pylon serve is reachable but `desired_mode != Online`
    3. Pylon serve is dead but the SQLite store is still on disk with a
       stale `captured_at_ms` from a previous session
  - Adds a new `ProviderBlocker::PylonProviderOffline` variant in
    `openagents-provider-substrate`, plumbs `pylon_desired_mode` into
    `EarningsScoreboardState`, and reuses the existing
    `PylonAuthorityUnavailable` blocker for both the missing-store and
    stale-snapshot cases. All four GO ONLINE render sites and three click
    handler paths respect the gates.

  ## Stack

  This PR contains three commits that should be reviewed and merged
  together. Each commit catches a distinct Pylon liveness failure mode but
  they share infrastructure and a common invariant — splitting them into
  separate PRs would create intermediate states where part of the
  maintainer-intended behavior is enforced and part is not.

  | # | Commit | Failure mode caught |
  |---|---|---|
  | 1 | `7e1a79d57` Surface and enforce Pylon authority gate in Mission Control | Pylon admin store missing |
  | 2 | `e1387fc32` Block Mission Control GO ONLINE when Pylon desired_mode is offline | Pylon reachable but
  operator-set offline |
  | 3 | `250d12354` Block GO ONLINE on stale Pylon snapshot and humanize alert wording | Pylon serve dead, SQLite stale
  |

  ## What's broken on `main` today

  PR #4266 ("Source Autopilot earnings from Pylon authority") plumbed the
  new `pylon.provider-admin` SQLite store into `EarningsScoreboardState`
  and correctly marks it as `PaneLoadState::Error` when the Pylon
  authority is unavailable. But the Mission Control surfaces that consume
  that state were not updated, and there is no equivalent gate for the
  "pylon reachable but offline" or "pylon dead but file persists" cases:

  - The WALLET & EARNINGS section panel header is hardcoded to green
    regardless of `load_state`.
  - The Today / This Month / All Time amount lines render as a healthy
    green / white / cyan even when the scoreboard is in `Error`, so a
    stale "0 sats" reads as a healthy zero.
  - The Mission Control alert band has no priority for the earnings
    scoreboard being unhealthy.
  - The SELL COMPUTE GO ONLINE button stays clickable, and clicking it
    silently transitions the provider to `Online` even though Pylon — the
    canonical authority for live provider earnings — is unreachable, in
    offline mode, or has a stale truth source.
  - Pylon's NIP-90 runtime explicitly drops every incoming job request
    with `provider_not_online` whenever its persisted `desired_mode` is
    not `Online` (`apps/pylon/src/nip90_runtime.rs:608`), so going online
    from autopilot in any of these states earns nothing.

  The visible failure mode on a sell-compute provider host is that the
  operator brings up Autopilot, sees a healthy-looking Mission Control,
  clicks GO ONLINE, sees the provider go online and start publishing
  capability events to relays, and never learns that Pylon is the missing
  piece. This is the exact failure encountered during RTX 5090 sell-compute
  bring-up testing on a Linux Box B (Ubuntu 24.04 / CUDA 13.1).

  ## What this PR changes

  ### Commit 1 — Renderer surfacing and missing-store enforcement (`7e1a79d57`)

  **Renderer surfacing (active and docked Mission Control panes):**

  - WALLET & EARNINGS section panel accent now follows
    `earnings_scoreboard.load_state` instead of being hardcoded green via
    three new helper fns: `mission_control_earnings_panel_accent`,
    `mission_control_earnings_amount_color`,
    `mission_control_earnings_alert_summary`.
  - Today / This Month / All Time amount lines tint amber when the
    scoreboard is in the Error state.
  - Mission Control alert band gains an EARNINGS priority that fires when
    the scoreboard is in Error.
  - Sidebar GO ONLINE button paints a disabled appearance when the gate
    is closed, matching how the in-pane button has always looked.

  **Preflight blocker enforcement:**

  - New `ProviderBlocker::PylonAuthorityUnavailable` variant in
    `crates/openagents-provider-substrate`, with code
    `PYLON_AUTHORITY_UNAVAILABLE`.
  - `RenderState::provider_blockers()` pushes the new variant whenever
    `earnings_scoreboard.load_state != PaneLoadState::Ready`. The check
    sits **above** the existing data_seller / data_buyer /
    supports_sell_compute early returns: Pylon is the canonical sink for
    both sell-compute and data-market earnings, and a stale Data Seller
    draft from prior testing must not short-circuit the gate on a
    sell-compute bring-up. This was hit live during testing — see "Why
    hoist the Pylon check" below.
  - `mission_control_go_online_enabled()` ANDs against
    `provider_blockers().is_empty()` so the canonical "is the button
    clickable" predicate sees the new blocker.
  - All four GO ONLINE render sites and three click handler paths respect
    the gate (sidebar mouse-down, docked Mission Control hit-test, action
    handler `apply_provider_mode_target` via
    `provider_go_online_block_reason`).

  ### Commit 2 — `desired_mode = offline` enforcement (`e1387fc32`)

  Catches the second Pylon failure mode: pylon serve is reachable and the
  admin store is loading cleanly, but the operator has not flipped pylon
  online via the `pylon` TUI or `pylon online` CLI. Pylon's NIP-90 runtime
  drops every job in this state with `provider_not_online`, so going
  online from Mission Control earns nothing.

  **Plumbing:**

  - New `ProviderBlocker::PylonProviderOffline` variant in
    `openagents-provider-substrate`, code `PYLON_PROVIDER_OFFLINE`.
  - New `pylon_desired_mode: Option<ProviderDesiredMode>` field on
    `EarningsScoreboardState`. Captured in `refresh_from_pylon_status`
    from `ProviderStatusResponse.desired_mode` (which lives at the top of
    the response, separate from the persisted snapshot). Cleared back to
    `None` in `mark_pylon_authority_unavailable`.
  - `RenderState::provider_blockers()` adds the new check in an
    `else if` branch immediately after the existing
    `PylonAuthorityUnavailable` push, conditioned on `load_state == Ready`.
    This ordering is deliberate: the existing blocker takes precedence
    when the store is missing, and the new blocker only fires when the
    store is healthy but pylon is operator-offline. The two never stack
    for the same root cause.
  - `mission_control_earnings_alert_summary` is extended with a third
    return path that produces the offline-mode alert when
    `load_state == Ready` but `pylon_desired_mode != Some(Online)`.

  ### Commit 3 — Stale snapshot gate and humanized alert wording (`250d12354`)

  Catches the third Pylon liveness failure mode that the previous two
  commits do not see: `pylon serve` is dead but the SQLite store is still
  on disk with `desired_mode = online` from a previous session. In that
  state, autopilot would happily read `load_state = Ready,
  desired_mode = Online` from the stale row and let the operator click
  GO ONLINE while no live job pipeline exists.

  **Plumbing:**

  - New `PYLON_SNAPSHOT_STALENESS_THRESHOLD_MS` const next to
    `EarningsScoreboardState`, set to **60 seconds**. See "Why 60 seconds"
    below for the cadence measurement that drove the threshold choice.
  - `EarningsScoreboardState::refresh_from_pylon_status` checks
    `now_epoch_ms - snapshot.captured_at_ms` against the threshold
    immediately after extracting the snapshot. When stale, falls into
    `mark_pylon_authority_unavailable` so the existing
    `PylonAuthorityUnavailable` blocker fires automatically — no new
    variant is needed because a stale snapshot is the same failure as a
    missing store from autopilot's perspective ("we cannot trust live
    truth from pylon"). The `last_error` text reports the exact staleness
    age in seconds so operators can correlate against the pylon process
    death timestamp.

  **Alert-band wording fixes (operator-facing):**

  | Before (technical) | After (operator-facing) |
  |---|---|
  | `Pylon authority unreachable` | `Pylon service unavailable` |
  | `Pylon desired_mode is offline` | `Pylon service in offline mode` |
  | `PYLON AUTHORITY UNAVAILABLE` | `PYLON SERVICE UNAVAILABLE` |
  | `EARNINGS AUTHORITY UNAVAILABLE` | `EARNINGS SERVICE UNAVAILABLE` |
  | `PYLON PROVIDER OFFLINE` | `PYLON SERVICE IN OFFLINE MODE` |

  Operators reading the alert band don't share the maintainers' #4266
  substrate vocabulary. The user-facing wording now says "Pylon service"
  rather than the internal "Pylon authority" / "Pylon provider", and
  calls out "in offline mode" rather than the raw `desired_mode` field
  name. The substrate `ProviderBlocker` variant identifiers and JSON
  codes (`PYLON_AUTHORITY_UNAVAILABLE`, `PYLON_PROVIDER_OFFLINE`) keep
  their original wording for `autopilotctl --json` / CLI surfaces and
  substrate consumers.

  ## Why hoist the Pylon check above the data_seller / supports_sell_compute early returns

  `provider_blockers()` historically had two early returns:

  ```rust
  if self.data_seller.derived_nip90_profile().is_some()
      || self.data_buyer.requires_nip90_response_tracking()
  {
      return blockers;
  }
  // ...
  if !runtime_view.supports_sell_compute {
      return blockers;
  }
  ```

  Live diagnostics on a sell-compute provider host showed
  `data_seller.derived_nip90_profile()` returning `Some` whenever the user
  had any Data Seller draft sitting in app state from prior testing. That
  caused the maintainer-intended "if you're in data market mode, skip
  sell-compute checks" early return to fire on a sell-compute bring-up,
  short-circuiting any Pylon check that lived below it. Concretely, with
  diagnostic tracing temporarily added to the click hit-test:

  ```
  mode=Offline enabled=true earnings_load_state=Error
  supports_sell_compute=true lane=Some(GptOss) backend_label="cuda"
  data_seller_active=true data_buyer_active=false blockers=[]
  ```

  (The button is enabled even though the earnings scoreboard is in Error,
  because `data_seller_active=true` triggered the early return and emptied
  the blockers list before any Pylon check ran.)

  The fix places the Pylon check **above** both early returns. This is
  correct on its own merits, not just as a workaround for the diagnostic:
  PR #4266 explicitly framed Pylon as "the authority for live provider
  earnings", and the Pylon provider-admin store is the canonical sink for
  both sell-compute earnings and data-market earnings. An unavailable
  Pylon authority should block GO ONLINE in **every** provider mode, not
  just sell-compute, because no mode can truthfully report earnings
  without it.

  ## Why `!= Ready` and not `== Error`

  The conservative `!= Ready` shape (rather than `== Error`) avoids a
  transient startup window where `load_state` is still its default
  `Loading` value before the first earnings refresh tick has fired. An
  `== Error` check would let the user click GO ONLINE in that window and
  race the first refresh. This mirrors how `GptOssModelUnavailable` is
  cleared only on an explicit `is_ready()`, never on the absence of an
  error.

  ## Why 60 seconds for `PYLON_SNAPSHOT_STALENESS_THRESHOLD_MS`

  Pylon's serve loop has a nominal `sleep_duration` of 2 seconds in the
  main `tokio::select!` (`apps/pylon/src/lib.rs:10359`), but its actual
  cadence between snapshot writes is much longer when pylon is in
  `desired_mode = online`: each iteration also runs the Nexus presence
  heartbeat (5s interval target), the provider auto-run pass (2s interval
  target), the live announcement sync, and (periodically) the
  payout-target sync.

  Live measurement on a healthy `pylon online` against
  `wss://nexus.openagents.com` over a 60-tick / 60-second sample showed:

  ```
  max observed delta between snapshot writes: 14 seconds
  max observed snapshot age before refresh: 15 seconds
  typical bursty cadence: 4-14 seconds
  ```

  A first attempt at 15s (~1x the observed max) false-positived
  immediately in the wild — autopilot would log
  `Pylon provider admin snapshot is stale (15s old); pylon serve may not
  be running` once per second whenever pylon was inside a 14-second gap
  between heartbeats. Bumping to 60s (~4x the observed max) absorbs
  jitter from slow Nexus roundtrips and bursty heartbeat scheduling
  without losing the ability to detect a genuinely dead `pylon serve`
  within a minute.

  ## Test plan

  Validated end-to-end on a Linux RTX 5090 / CUDA GPT-OSS box (Ubuntu
  24.04, CUDA 13.1) in **four** distinct states. Validation matrix:

  | State | Pylon serve | SQLite | Pylon `desired_mode` | Snapshot age | Expected | ✓ |
  |---|---|---|---|---|---|---|
  | Missing store | dead | removed | n/a | n/a | `PylonAuthorityUnavailable` fires, alert reads `PYLON SERVICE
  UNAVAILABLE`, button stays grayed, click rejected | ✓ |
  | Stale snapshot | dead | present | `online` (from prior session) | ~7 minutes | `PylonAuthorityUnavailable` fires via
   the staleness path, alert reads `PYLON SERVICE UNAVAILABLE`, `last_error` reports staleness age in seconds | ✓ |
  | Operator offline | running | present | `offline` | fresh | `PylonProviderOffline` fires, alert reads `PYLON SERVICE
  IN OFFLINE MODE`, button stays grayed, click rejected | ✓ |
  | Healthy | running | present | `online` (after `pylon online`) | fresh | No Pylon blocker, GO ONLINE button goes
  green, click transitions provider to Online and publishes capability events to 3 relays with `accepted_relays=3
  rejected_relays=0` | ✓ |

  The 60-second staleness threshold was specifically chosen after
  observing that 15-second false-positives appeared in the log every
  1-second refresh tick when pylon's online iteration was in a 14-second
  gap between snapshot writes (heartbeat to Nexus). The 60s threshold
  fully eliminates the false positives without losing detection of a
  genuinely dead pylon.

  Cargo / clippy / format:

  - [x] `cargo build -p autopilot-desktop --bin autopilot-desktop` clean
        after each commit.
  - [x] `cargo test -p autopilot-desktop --lib refresh_earnings_scoreboard`
        passes all 4 tests:
    - `refresh_earnings_scoreboard_reads_authoritative_pylon_store`
    - `refresh_earnings_scoreboard_captures_pylon_desired_mode_offline`
    - `refresh_earnings_scoreboard_clears_pylon_desired_mode_on_unavailable`
    - `refresh_earnings_scoreboard_marks_stale_pylon_snapshot_as_unavailable`
  - [ ] `cargo fmt` / `cargo clippy` (please run before merge — local
        validation only covered the build and the targeted tests)
  - [ ] CI

  ## Notes for reviewers

  - The three commits are intentionally stacked rather than bundled
    because each commit catches a distinct failure mode and could in
    principle be reverted independently if a regression appears. They
    belong in the same PR because they share the same maintainer-intended
    invariant from #4266 and would otherwise require coordinating three
    parallel reviews of code that touches the same files.
  - New variant ordering in `ProviderBlocker` is appended to the end so
    it does not perturb existing match arms or serialization order.
  - The `mission_control_alert_message` parameter list grows by one for
    the new `earnings_scoreboard` argument; both call sites
    (`pane_system.rs`, `input/actions.rs`) are updated.
  - The substrate `ProviderBlocker::detail()` strings stay in their
    longer form ("Pylon provider authority is unavailable; live earnings
    cannot be tracked", "Pylon provider is reachable but desired_mode is
    offline; incoming jobs will be dropped") for `autopilotctl --json` /
    CLI surfaces and substrate consumers. The short alert-band forms in
    `mission_control_blocker_detail` are display-only.
  - I have **not** touched `apply_provider_mode_target` itself; the
    existing `provider_go_online_block_reason()` → `provider_blockers()`
    path already gates it transitively now that the new variants are in
    place.
  - Builds on PR #4266 — does not revert or change the maintainer's data
    plumbing, only completes the UI side that PR #4266 left as a
    follow-up and adds the operator-facing liveness gates that #4266 did
    not include.