### PR TITLE
Add periodic Spark wallet refresh tick

### DIFF
--- a/apps/autopilot-desktop/src/app_state.rs
+++ b/apps/autopilot-desktop/src/app_state.rs
@@ -27786,9 +27786,21 @@ pub struct ProviderHeartbeatCadenceState {
 pub struct BackgroundCadenceState {
     pub last_fast_poll_at: Option<Instant>,
     pub last_coarse_poll_at: Option<Instant>,
+    /// Tracks the last time `pump_background_state` enqueued a periodic
+    /// `SparkWalletCommand::Refresh`. Until this was added, the wallet only
+    /// refreshed on startup convergence (which stops once the first balance
+    /// arrives) and on explicit user actions (refresh icon click, sidebar
+    /// open, payment finished). The breez SDK syncs balance internally on
+    /// its own cadence and emits `Synced` events, but autopilot does not
+    /// subscribe to those events, so the displayed balance went arbitrarily
+    /// stale between user clicks. This field gates a 30-second periodic
+    /// refresh that closes that gap without resorting to an SDK event
+    /// listener thread.
+    pub last_spark_wallet_refresh_at: Option<Instant>,
     pub every_loop_runs: u64,
     pub fast_poll_runs: u64,
     pub coarse_poll_runs: u64,
+    pub spark_wallet_periodic_refresh_runs: u64,
 }
 
 pub struct RenderState {

--- a/apps/autopilot-desktop/src/input.rs
+++ b/apps/autopilot-desktop/src/input.rs
@@ -162,6 +162,22 @@ pub(crate) use tool_bridge::{
 
 const BACKGROUND_FAST_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
 const BACKGROUND_COARSE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+/// Cadence at which `pump_background_state` enqueues a periodic
+/// `SparkWalletCommand::Refresh` so the displayed wallet balance does not
+/// drift between explicit user actions. Until this was added, the wallet
+/// only refreshed on startup convergence (which stops once the first
+/// balance arrives) and on user-driven events (refresh icon click, sidebar
+/// open, payment finished). The breez SDK syncs balance internally and
+/// emits `Synced` events on its own ~few-second cadence, but autopilot
+/// does not subscribe to those events, so the displayed balance went
+/// arbitrarily stale between user clicks. 30 seconds is well above the
+/// 3-second `REFRESH_THROTTLE_INTERVAL` in `spark_wallet.rs` (so it never
+/// gets throttled away) and well below any reasonable user expectation of
+/// "current". The worker also coalesces refresh-like command bursts via
+/// `coalesce_refresh_like_command_burst`, so an enqueue that races a
+/// pending refresh collapses safely.
+const SPARK_WALLET_PERIODIC_REFRESH_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(30);
 
 pub(crate) fn bootstrap_startup_cad_mesh(state: &mut crate::app_state::RenderState) {
     let _ = reducers::bootstrap_startup_parallel_jaw_gripper(state);
@@ -998,6 +1014,24 @@ fn pump_background_state(state: &mut crate::app_state::RenderState) -> bool {
             changed = true;
         }
     }
+    if cadence_due(
+        &mut state.background_cadence.last_spark_wallet_refresh_at,
+        now,
+        SPARK_WALLET_PERIODIC_REFRESH_INTERVAL,
+    ) {
+        state.background_cadence.spark_wallet_periodic_refresh_runs = state
+            .background_cadence
+            .spark_wallet_periodic_refresh_runs
+            .saturating_add(1);
+        if record_runtime_changed_op(
+            state,
+            "spark_wallet_periodic_refresh",
+            "spark_wallet::periodic_refresh_tick",
+            |state| run_periodic_spark_wallet_refresh_tick(state),
+        ) {
+            changed = true;
+        }
+    }
     record_runtime_observer_op(
         state,
         "post_loop",
@@ -1406,6 +1440,33 @@ fn run_startup_spark_wallet_convergence_tick(state: &mut crate::app_state::Rende
         state.spark_wallet.cancel_startup_convergence();
     }
     true
+}
+
+/// Periodic Spark wallet refresh, gated by `cadence_due` against the
+/// `SPARK_WALLET_PERIODIC_REFRESH_INTERVAL` const. Skips while the startup
+/// convergence tick is still active (so the two refresh paths do not double
+/// up while the wallet is converging) and skips when the spark worker has
+/// not been initialized yet (no point queuing commands the worker cannot
+/// execute). The enqueue itself is non-blocking and the worker coalesces
+/// refresh-like command bursts via `coalesce_refresh_like_command_burst`,
+/// so a periodic enqueue that races a user-driven refresh collapses safely
+/// to a single fetch. Errors from the enqueue (e.g. worker channel
+/// dropped) are recorded on the wallet pane state for surfacing in the UI.
+fn run_periodic_spark_wallet_refresh_tick(state: &mut crate::app_state::RenderState) -> bool {
+    if state.spark_wallet.startup_convergence_active() {
+        // Startup convergence tick is already driving refreshes; do not
+        // double up while it is converging. The periodic tick takes over
+        // once the first balance has loaded and the convergence tick stops
+        // self-firing.
+        return false;
+    }
+    match state.spark_worker.enqueue(SparkWalletCommand::Refresh) {
+        Ok(()) => true,
+        Err(error) => {
+            state.spark_wallet.last_error = Some(error);
+            true
+        }
+    }
 }
 
 fn run_goal_restart_recovery(state: &mut crate::app_state::RenderState) -> bool {

--- a/apps/autopilot-desktop/src/spark_wallet.rs
+++ b/apps/autopilot-desktop/src/spark_wallet.rs
@@ -346,6 +346,14 @@ impl SparkPaneState {
         self.last_action = Some("Wallet reconciling after startup sync".to_string());
     }
 
+    /// Whether the startup-convergence refresh loop is currently driving
+    /// refreshes. Read by the periodic refresh tick in `input.rs` so that
+    /// the two refresh paths do not double up while the wallet is still
+    /// converging on its first balance read.
+    pub fn startup_convergence_active(&self) -> bool {
+        self.startup_convergence_active
+    }
+
     pub fn startup_convergence_refresh_due(&self, now_epoch_seconds: u64) -> bool {
         self.startup_convergence_active
             && self


### PR DESCRIPTION
  ## Summary

  - Adds a 30-second periodic refresh tick for the Spark wallet so the
    displayed balance updates automatically instead of only on explicit
    user actions.
  - Reuses the existing `cadence_due` infrastructure in
    `pump_background_state` and the existing `SparkWalletCommand::Refresh`
    worker channel — no new threads, no new event listener plumbing.
  - Skips while the existing startup-convergence tick is still
    self-firing, so the two refresh paths do not double up during the
    wallet's initial converge-on-first-balance phase.

  ## What's broken on `main` today

  The autopilot Spark wallet balance is only refreshed on three paths,
  none of which fire on a periodic timer:

  1. **Startup convergence tick**
     (`run_startup_spark_wallet_convergence_tick` in `input.rs`) — runs a
     small burst of refreshes on launch and then stops self-firing as
     soon as the first balance arrives.
  2. **Explicit user actions** — clicking the refresh icon in the
     Mission Control wallet panel, opening the wallet sidebar, sending
     or receiving a payment, etc.
  3. **Headless / control surfaces** — `headless_compute.rs` and tool
     bridge `refresh_wallet`.

  The breez SDK syncs balance internally on its own ~few-second cadence
  and emits `Synced` events from `breez_sdk_spark::sdk::sync`, but
  autopilot does not subscribe to those events — `add_event_listener` is
  not called anywhere in `apps/autopilot-desktop/src/spark_wallet.rs` or
  the `openagents-spark` wrapper crate. The displayed balance therefore
  goes arbitrarily stale between user-driven refreshes.

  The visible failure mode on a sell-compute provider host is "I'm
  earning sats according to Pylon, but the displayed Spark wallet
  balance never moves until I click the refresh icon." Hit live during
  RTX 5090 sell-compute bring-up testing on a Linux Box B (Ubuntu 24.04
  / CUDA 13.1).

  ## What this PR changes

  - New `last_spark_wallet_refresh_at: Option<Instant>` and
    `spark_wallet_periodic_refresh_runs: u64` fields on
    `BackgroundCadenceState` (`app_state.rs`). Gated by the existing
    `cadence_due` helper in `pump_background_state` (`input.rs`) so the
    same cadence-tracking pattern as the existing fast/coarse polls is
    reused.
  - New `SPARK_WALLET_PERIODIC_REFRESH_INTERVAL` const set to **30
    seconds**. Well above the 3-second `REFRESH_THROTTLE_INTERVAL` in
    `spark_wallet.rs` (so it never gets throttled away), well below any
    reasonable user expectation of "current".
  - New `run_periodic_spark_wallet_refresh_tick` function in `input.rs`
    that enqueues `SparkWalletCommand::Refresh` on the existing spark
    worker channel. Skips while `startup_convergence_active()` is true
    so the two refresh paths do not double up while the wallet is
    converging on its first balance read; takes over once convergence
    stops self-firing.
  - New `pub fn startup_convergence_active(&self) -> bool` accessor on
    `SparkPaneState` so the input.rs tick can read the convergence flag
    without exposing the underlying private field.

  The enqueue is non-blocking and the worker coalesces refresh-like
  command bursts via the existing `coalesce_refresh_like_command_burst`,
  so a periodic enqueue that races a user-driven refresh collapses
  safely to a single fetch — no double work, no fetch flood.

  ## Why 30 seconds and not real-time SDK event subscription

  A more sophisticated alternative would be to subscribe to the breez
  SDK's event stream and refresh on `Synced` events, which would give
  near-real-time balance updates instead of a 30-second ceiling. That
  requires async listener plumbing (event handler thread, channel from
  listener to UI, lifecycle management, error propagation) and is a
  meaningful design choice that deserves its own PR.

  The 30-second periodic tick is the smallest viable fix for the
  immediate "balance never moves" complaint and matches how autopilot
  already handles other background refresh cadences (network aggregate
  counters, earnings scoreboard, sync health). 30 seconds also gives ~6
  RPC calls per minute (one `get_balance` + one `list_all_payments` +
  one `list_unclaimed_deposits` per refresh, roughly), which is
  negligible against the SDK's own internal sync load.

  A follow-up PR adding real `Synced` event subscription would deprecate
  this 30s tick (or increase its interval to 5 minutes as a backstop) —
  but that PR is much larger than this one and the user-facing fix is
  the same: balance updates without explicit click.

  ## Test plan

  Validated end-to-end on a Linux RTX 5090 / CUDA box (Box B). Cadence
  measurement after 7 minutes 46 seconds of steady-state autopilot
  runtime against `pylon serve` running with `desired_mode = online`
  and accepting incoming sat payments:

  - [x] **22 `Wallet sync completed` events** in the launch log over the
        466-second window (~21 second average gap).
  - [x] **~5 of those came from the initial startup convergence burst**
        (`STARTUP_CONVERGENCE_REFRESH_ATTEMPTS = 5`).
  - [x] **Remaining ~17 over the steady-state ~7 minutes** is consistent
        with a 30-second periodic tick plus the breez SDK's own
        background sync events.
  - [x] **No flood**: a broken `cadence_due` would have produced
        hundreds of syncs in the same window. The visible cadence
        confirms the gate is working.
  - [x] **Balance visibly auto-updates** in the GUI without any user
        clicks (operator-confirmed).
  - [x] `cargo build -p autopilot-desktop --bin autopilot-desktop` clean
        after the change.

  Cargo / clippy / format:

  - [ ] `cargo fmt` / `cargo clippy` (please run before merge — local
        validation only covered the build and the live cadence test)
  - [ ] CI

  ## Notes for reviewers

  - This is **not** a fix for the unrelated upstream `breez/spark-sdk`
    log noise that surfaces during refreshes. The leaf optimizer logs
    ERROR for `TransferAlreadyClaimed` and "nodes not owned by the
    authenticated identity public key" / `PermissionDenied` failures
    even when the SDK itself notes (in an INFO line right above) that
    those failures are "likely caused by leaves having been spent by a
    concurrent instance". Three distinct upstream sources for the same
    benign concurrent-claim race: `spark::services::leaf_optimizer`
    (ERROR, two variants) and `spark_wallet::wallet` (WARN). The right
    fix lives in `breez/spark-sdk` 0.12.2+ — either downgrading those
    log levels to DEBUG or short-circuiting the optimizer when the
    deposit was already claimed. Out of scope for this repo.
  - This PR is independent of #4293 (Mission Control Pylon liveness
    gates) and branches off `upstream/main` at `85c537b61`. They can be
    reviewed and merged in either order.
  - The new tick adds one entry to the `BackgroundCadenceState` runs
    counter for diagnostics, in case future debugging wants to verify
    the cadence is actually firing without grepping the log.