### PR TITLE
Fix Nexus treasury backlog continuity alerts

### DIFF
--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -1651,36 +1651,35 @@ impl TreasuryState {
         let mut active_alerts = Vec::new();
         let latest_eligible_window_started_at_unix_ms =
             self.latest_eligible_window_started_at_unix_ms;
+        let oldest_dispatch_pending_at_unix_ms =
+            self.oldest_pending_payout_updated_at_unix_ms(&["queued", "dispatching"]);
+        let oldest_confirmation_pending_at_unix_ms =
+            self.oldest_pending_payout_updated_at_unix_ms(&["queued", "dispatching", "dispatched"]);
         let policy = self.active_policy(config);
 
         if policy.treasury_enabled {
-            if latest_eligible_window_started_at_unix_ms.is_some_and(|window_started_at| {
-                self.eligible_online_payout_targets > 0
-                    && window_started_at > self.last_dispatch_at_unix_ms.unwrap_or(0)
-                    && now_unix_ms.saturating_sub(window_started_at)
-                        >= TREASURY_CONTINUITY_ALERT_THRESHOLD_MS
+            if oldest_dispatch_pending_at_unix_ms.is_some_and(|pending_since_unix_ms| {
+                now_unix_ms.saturating_sub(pending_since_unix_ms)
+                    >= TREASURY_CONTINUITY_ALERT_THRESHOLD_MS
             }) {
                 active_alerts.push(TreasuryContinuityAlert {
                     alert_id: "dispatch_stalled".to_string(),
                     severity: "critical".to_string(),
-                    reason: "eligible_windows_not_dispatching".to_string(),
-                    started_at_unix_ms: latest_eligible_window_started_at_unix_ms
-                        .unwrap_or(now_unix_ms),
+                    reason: "pending_payouts_not_dispatching".to_string(),
+                    started_at_unix_ms: oldest_dispatch_pending_at_unix_ms.unwrap_or(now_unix_ms),
                     observed_at_unix_ms: now_unix_ms,
                 });
             }
 
-            if latest_eligible_window_started_at_unix_ms.is_some_and(|window_started_at| {
-                self.eligible_online_payout_targets > 0
-                    && window_started_at > self.last_confirmed_payout_at_unix_ms.unwrap_or(0)
-                    && now_unix_ms.saturating_sub(window_started_at)
-                        >= TREASURY_CONTINUITY_ALERT_THRESHOLD_MS
+            if oldest_confirmation_pending_at_unix_ms.is_some_and(|pending_since_unix_ms| {
+                now_unix_ms.saturating_sub(pending_since_unix_ms)
+                    >= TREASURY_CONTINUITY_ALERT_THRESHOLD_MS
             }) {
                 active_alerts.push(TreasuryContinuityAlert {
                     alert_id: "confirmations_stalled".to_string(),
                     severity: "critical".to_string(),
-                    reason: "eligible_windows_not_confirming".to_string(),
-                    started_at_unix_ms: latest_eligible_window_started_at_unix_ms
+                    reason: "pending_payouts_not_confirming".to_string(),
+                    started_at_unix_ms: oldest_confirmation_pending_at_unix_ms
                         .unwrap_or(now_unix_ms),
                     observed_at_unix_ms: now_unix_ms,
                 });
@@ -1796,6 +1795,14 @@ impl TreasuryState {
         receipts
     }
 
+    fn oldest_pending_payout_updated_at_unix_ms(&self, statuses: &[&str]) -> Option<u64> {
+        self.payout_records_by_key
+            .values()
+            .filter(|record| statuses.contains(&record.status.as_str()))
+            .map(|record| record.updated_at_unix_ms)
+            .min()
+    }
+
     fn impossible_zero_balance_with_receive_history(&self) -> bool {
         self.wallet_balance_sats == 0
             && self.completed_funding_receive_total_sats()
@@ -1842,6 +1849,7 @@ impl TreasuryState {
     fn degraded_reason(&self, config: &TreasuryConfig, now_unix_ms: u64) -> Option<String> {
         let (wallet_runtime_status, wallet_last_error) =
             self.wallet_runtime_view(config, now_unix_ms);
+        let active_continuity_alerts = self.continuity_signal_snapshot(config, now_unix_ms);
         if matches!(self.policy_runtime_status.as_deref(), Some("blocked")) {
             return self
                 .policy_last_error
@@ -1857,8 +1865,8 @@ impl TreasuryState {
                 .clone()
                 .or_else(|| Some("payout_loop_unhealthy".to_string()));
         }
-        if let Some(alert) = self
-            .active_continuity_alerts
+        if let Some(alert) = active_continuity_alerts
+            .active_alerts
             .iter()
             .find(|alert| alert.severity == "critical")
         {
@@ -2043,6 +2051,7 @@ impl TreasuryState {
             .public_snapshot
             .clone()
             .unwrap_or_else(|| self.build_public_snapshot(config, now_unix_ms));
+        let continuity = self.continuity_signal_snapshot(config, now_unix_ms);
         let (wallet_runtime_status, wallet_last_error) =
             self.wallet_runtime_view(config, now_unix_ms);
         let wallet_sync_lag_ms = self
@@ -2104,7 +2113,7 @@ impl TreasuryState {
             payouts_skipped_24h: snapshot.payouts_skipped_24h,
             skip_reason_metrics_24h: snapshot.skip_reason_metrics_24h,
             fail_reason_metrics_24h: snapshot.fail_reason_metrics_24h,
-            active_continuity_alerts: snapshot.active_continuity_alerts,
+            active_continuity_alerts: continuity.active_alerts,
         }
     }
 
@@ -6223,30 +6232,36 @@ mod tests {
     fn continuity_alerts_raise_and_clear_for_stalled_windows() {
         let mut state = TreasuryState::default();
         let config = test_treasury_config();
-        state.payout_targets_by_identity.insert(
-            "pubkey-a".to_string(),
-            super::RegisteredPayoutTarget {
+        let eligible_at_unix_ms = 1_800_000;
+        state.eligible_online_payout_targets = 1;
+        state.sellable_pylons_online_now = 1;
+        state.latest_eligible_window_started_at_unix_ms = Some(eligible_at_unix_ms);
+        state.payout_records_by_key.insert(
+            "pending-a".to_string(),
+            super::TreasuryPayoutRecord {
+                payout_key: "pending-a".to_string(),
                 nostr_pubkey_hex: "pubkey-a".to_string(),
-                source_session_id: "session-a".to_string(),
-                spark_address: "spark:alice".to_string(),
-                bitcoin_address: None,
-                registered_at_unix_ms: 10,
-                last_verified_at_unix_ms: 10,
+                payout_target: "spark:alice".to_string(),
+                amount_sats: 2,
+                status: "dispatching".to_string(),
+                reason: None,
+                payment_id: None,
+                window_started_at_unix_ms: eligible_at_unix_ms,
+                window_ends_at_unix_ms: eligible_at_unix_ms.saturating_add(20_000),
+                created_at_unix_ms: eligible_at_unix_ms,
+                updated_at_unix_ms: eligible_at_unix_ms,
+                sellable_at_window_open: true,
+                dispatch_receipt_recorded: false,
+                confirm_receipt_recorded: false,
+                fail_receipt_recorded: false,
+                skip_receipt_recorded: false,
+                counted_in_paid_total: false,
+                classification: TreasuryPayoutClassification::default(),
             },
         );
 
-        let eligible_at_unix_ms = 1_800_000;
-        state.observe_payout_eligibility(
-            &config,
-            &[OnlinePylonIdentity {
-                nostr_pubkey_hex: "pubkey-a".to_string(),
-                sellable: true,
-            }],
-            eligible_at_unix_ms,
-        );
-
         let alert_at_unix_ms =
-            eligible_at_unix_ms + super::TREASURY_CONTINUITY_ALERT_THRESHOLD_MS + 1;
+            eligible_at_unix_ms + super::TREASURY_CONTINUITY_ALERT_THRESHOLD_MS + 60_000;
         let raised = state.sync_continuity_alerts(&config, alert_at_unix_ms);
         assert_eq!(raised.len(), 2);
         assert!(
@@ -6256,6 +6271,10 @@ mod tests {
         );
         assert_eq!(state.active_continuity_alerts.len(), 2);
 
+        if let Some(record) = state.payout_records_by_key.get_mut("pending-a") {
+            record.status = "confirmed".to_string();
+            record.updated_at_unix_ms = alert_at_unix_ms;
+        }
         state.last_dispatch_at_unix_ms = Some(alert_at_unix_ms);
         state.last_confirmed_payout_at_unix_ms = Some(alert_at_unix_ms);
         let cleared = state.sync_continuity_alerts(&config, alert_at_unix_ms + 1);
@@ -6266,6 +6285,68 @@ mod tests {
                 .all(|event| event.receipt_type == "treasury.alert.cleared")
         );
         assert!(state.active_continuity_alerts.is_empty());
+    }
+
+    #[test]
+    fn continuity_alerts_detect_backlog_even_when_latest_window_is_recent() {
+        let mut state = TreasuryState::default();
+        let config = test_treasury_config();
+        let now_unix_ms = 2_000_000u64;
+
+        state.eligible_online_payout_targets = 120;
+        state.sellable_pylons_online_now = 120;
+        state.latest_eligible_window_started_at_unix_ms = Some(now_unix_ms.saturating_sub(1_000));
+        state.last_dispatch_at_unix_ms = Some(
+            now_unix_ms.saturating_sub(super::TREASURY_CONTINUITY_ALERT_THRESHOLD_MS + 60_000),
+        );
+        state.last_confirmed_payout_at_unix_ms = Some(
+            now_unix_ms.saturating_sub(super::TREASURY_CONTINUITY_ALERT_THRESHOLD_MS + 60_000),
+        );
+        state.payout_records_by_key.insert(
+            "dispatch-backlog".to_string(),
+            super::TreasuryPayoutRecord {
+                payout_key: "dispatch-backlog".to_string(),
+                nostr_pubkey_hex: "pubkey-a".to_string(),
+                payout_target: "spark:alice".to_string(),
+                amount_sats: 2,
+                status: "dispatching".to_string(),
+                reason: None,
+                payment_id: None,
+                window_started_at_unix_ms: now_unix_ms.saturating_sub(60_000),
+                window_ends_at_unix_ms: now_unix_ms.saturating_sub(40_000),
+                created_at_unix_ms: now_unix_ms
+                    .saturating_sub(super::TREASURY_CONTINUITY_ALERT_THRESHOLD_MS + 10_000),
+                updated_at_unix_ms: now_unix_ms
+                    .saturating_sub(super::TREASURY_CONTINUITY_ALERT_THRESHOLD_MS + 10_000),
+                sellable_at_window_open: true,
+                dispatch_receipt_recorded: false,
+                confirm_receipt_recorded: false,
+                fail_receipt_recorded: false,
+                skip_receipt_recorded: false,
+                counted_in_paid_total: false,
+                classification: TreasuryPayoutClassification::default(),
+            },
+        );
+
+        let stats = state.public_stats(&config, now_unix_ms);
+        assert_eq!(
+            stats.degraded_reason.as_deref(),
+            Some("continuity_alert:dispatch_stalled")
+        );
+        assert!(
+            stats.active_continuity_alerts.iter().any(|alert| {
+                alert.alert_id == "dispatch_stalled"
+                    && alert.reason == "pending_payouts_not_dispatching"
+            }),
+            "dispatch backlog should raise a critical continuity alert"
+        );
+        assert!(
+            stats.active_continuity_alerts.iter().any(|alert| {
+                alert.alert_id == "confirmations_stalled"
+                    && alert.reason == "pending_payouts_not_confirming"
+            }),
+            "confirmation backlog should raise a critical continuity alert"
+        );
     }
 
     #[test]

--- a/docs/deploy/NEXUS_GCP_RUNBOOK.md
+++ b/docs/deploy/NEXUS_GCP_RUNBOOK.md
@@ -171,8 +171,8 @@ Treasury deployment note:
 
 ```bash
 export NEXUS_CONTROL_TREASURY_ENABLED=true
-export NEXUS_CONTROL_TREASURY_PAYOUT_SATS_PER_WINDOW=2
-export NEXUS_CONTROL_TREASURY_PAYOUT_INTERVAL_SECONDS=20
+export NEXUS_CONTROL_TREASURY_PAYOUT_SATS_PER_WINDOW=25
+export NEXUS_CONTROL_TREASURY_PAYOUT_INTERVAL_SECONDS=600
 export NEXUS_CONTROL_TREASURY_REQUIRE_SELLABLE=true
 export NEXUS_CONTROL_TREASURY_DAILY_BUDGET_CAP_SATS=1000000
 export NEXUS_CONTROL_TREASURY_WALLET_STATUS_REFRESH_SECONDS=30
@@ -190,10 +190,15 @@ Why the extra two envs matter:
   snapshot during a restart, the runtime now attempts to recover from the
   remaining state and at minimum preserves the persisted payout total rather
   than silently zeroing the public counter
-- `NEXUS_CONTROL_TREASURY_MAX_CONCURRENT_SENDS=16` prevents the live treasury
-  dispatch loop from batching too few sends under one wallet-operation lock,
-  which had stretched per-pylon credits from the configured `20s` interval to
-  roughly `40-60s` once the eligible target set grew into the twenties
+- `NEXUS_CONTROL_TREASURY_PAYOUT_SATS_PER_WINDOW=25` and
+  `NEXUS_CONTROL_TREASURY_PAYOUT_INTERVAL_SECONDS=600` are the current
+  production-safe reference values for the hosted Nexus treasury. That policy
+  reduces Spark transfer pressure to `0.4` sends/second even if the eligible
+  set reaches `240` providers, while keeping the daily ceiling under
+  `864000 sats` at that scale.
+- `NEXUS_CONTROL_TREASURY_MAX_CONCURRENT_SENDS=16` remains sufficient at that
+  wider cadence because the staggered per-identity phase offsets keep the due
+  set small per dispatch cycle.
 - `scripts/deploy/nexus/10-install-treasury-watchdog.sh` installs a systemd
   timer on the VM that runs every 5 minutes, checks the local treasury status
   plus recent completed-send journal entries, and restarts `nexus-relay` only

--- a/docs/nexus-treasury.md
+++ b/docs/nexus-treasury.md
@@ -154,6 +154,17 @@ can hold the wallet-operation lock long enough that a nominal `20s` payout
 interval stretches into `40-60s` effective receive spacing once many Pylons are
 eligible at the same time.
 
+For the hosted production Nexus, the current safe reference treasury policy is:
+
+- `NEXUS_CONTROL_TREASURY_PAYOUT_SATS_PER_WINDOW=25`
+- `NEXUS_CONTROL_TREASURY_PAYOUT_INTERVAL_SECONDS=600`
+- `NEXUS_CONTROL_TREASURY_DAILY_BUDGET_CAP_SATS=1000000`
+
+That policy keeps the hosted treasury under `864000 sats/day` even if the
+eligible set reaches `240` providers and holds the steady-state Spark send rate
+to `0.4` transfers/second instead of the unsustainable `5+` transfers/second
+range that a `2 sats / 20s` policy reaches once the provider set crosses `100`.
+
 For the production VM, `scripts/deploy/nexus/03-configure-and-start.sh` now
 loads the persisted policy from `${NEXUS_CONTROL_TREASURY_STATE_PATH}` by
 default and writes those values back into the container env file. That keeps
@@ -412,6 +423,10 @@ Continuity alerts:
   breakage such as dispatch stalls, confirmation stalls, budget-cap exhaustion,
   policy-runtime blocking, or stale treasury snapshots.
 - `treasury.alert.cleared` receipts fire when that condition recovers.
+- dispatch and confirmation stall detection now keys off the oldest still-
+  pending payout work and is recomputed live from current treasury state, so a
+  hung dispatch cycle still surfaces a critical alert through
+  `/v1/treasury/status` and `/api/stats`.
 - critical alerts are also reflected directly in `payout_loop_health` and
   `degraded_reason`, so operators do not need to infer failures from homepage
   behavior.


### PR DESCRIPTION
Closes #4321

## What changed
- detect dispatch and confirmation stalls from the oldest still-pending payout work instead of the newest eligible window
- derive continuity alerts live in `public_stats` and `degraded_reason` so a hung treasury dispatch cycle still surfaces a critical status
- update the Nexus treasury docs and GCP runbook with the current production-safe reference policy of `25 sats / 600 seconds / 1,000,000 sats daily cap`

## Investigation
- On April 12, 2026, VM-local `http://127.0.0.1:8080/v1/treasury/status` still showed `payout_sats_per_window=2`, `payout_interval_seconds=20`, `wallet_last_error=wallet_refresh_timeout:60000`, `dispatch_lag_ms=1311702`, and `confirm_lag_ms=1313943`, but `active_continuity_alerts` was still empty.
- Over the same investigation window, the VM journal only showed `116` completed sends in the last `30 minutes` and `0` completed sends in the last `10 minutes`.
- The backlog was therefore real, and the status surface was underreporting it.

## Validation
- `cargo test -p nexus-control continuity_alerts_ -- --nocapture`