### PR TITLE
Bound Nexus treasury dispatch hangs

### DIFF
--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -1,8 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(test)]
 use std::sync::Mutex;
@@ -229,9 +230,9 @@ impl TreasuryConfig {
     }
 
     pub fn dispatch_result_timeout_ms(&self, payout_interval_ms: u64) -> u64 {
+        let _ = payout_interval_ms;
         TREASURY_DISPATCH_RESULT_TIMEOUT_MS
             .max(self.wallet_status_refresh_seconds.saturating_mul(2_000))
-            .max(payout_interval_ms.saturating_mul(2))
     }
 
     pub fn max_concurrent_send_operations(&self, plan_count: usize) -> usize {
@@ -3324,26 +3325,24 @@ pub async fn dispatch_live_payouts(
         }
     };
 
-    // Keep the wallet lock held for less than one payout interval even when a
-    // large provider set becomes due in the same cycle.
+    // Keep the wallet-operation lock held for a bounded window even when the
+    // upstream Spark send path stalls or many Pylons become due together.
+    let send_timeout_ms = config.dispatch_result_timeout_ms(config.payout_interval_ms());
     let max_concurrent_sends = config.max_concurrent_send_operations(plans.len());
     let mut indexed_outcomes = stream::iter(plans.iter().cloned().enumerate())
         .map(|(index, plan)| {
             let wallet = wallet.clone();
             async move {
-                let outcome = match wallet
-                    .send_payment_simple(plan.payment_request.as_str(), Some(plan.amount_sats))
-                    .await
-                {
-                    Ok(payment_id) => TreasuryDispatchOutcome::Dispatched {
-                        payout_key: plan.payout_key,
-                        payment_id,
-                    },
-                    Err(error) => TreasuryDispatchOutcome::Failed {
-                        payout_key: plan.payout_key,
-                        reason: error.to_string(),
-                    },
-                };
+                let outcome =
+                    dispatch_outcome_from_send_future(plan.clone(), send_timeout_ms, async move {
+                        wallet
+                            .send_payment_simple(
+                                plan.payment_request.as_str(),
+                                Some(plan.amount_sats),
+                            )
+                            .await
+                    })
+                    .await;
                 (index, outcome)
             }
         })
@@ -3363,6 +3362,31 @@ pub async fn dispatch_live_payouts(
         // intended payout cadence even when many Pylons are online.
         wallet_snapshot: None,
         wallet_error: None,
+    }
+}
+
+async fn dispatch_outcome_from_send_future<F, E>(
+    plan: TreasuryDispatchPlan,
+    send_timeout_ms: u64,
+    send_future: F,
+) -> TreasuryDispatchOutcome
+where
+    F: Future<Output = std::result::Result<String, E>>,
+    E: std::fmt::Display,
+{
+    match tokio::time::timeout(Duration::from_millis(send_timeout_ms), send_future).await {
+        Ok(Ok(payment_id)) => TreasuryDispatchOutcome::Dispatched {
+            payout_key: plan.payout_key,
+            payment_id,
+        },
+        Ok(Err(error)) => TreasuryDispatchOutcome::Failed {
+            payout_key: plan.payout_key,
+            reason: error.to_string(),
+        },
+        Err(_) => TreasuryDispatchOutcome::Failed {
+            payout_key: plan.payout_key,
+            reason: format!("wallet_send_timeout:{send_timeout_ms}"),
+        },
     }
 }
 
@@ -6641,6 +6665,18 @@ mod tests {
         );
     }
 
+    #[test]
+    fn dispatch_result_timeout_stays_bounded_when_payout_interval_increases() {
+        let mut config = test_treasury_config();
+        config.payout_interval_seconds = 600;
+        config.wallet_status_refresh_seconds = 30;
+
+        assert_eq!(
+            config.dispatch_result_timeout_ms(config.payout_interval_ms()),
+            60_000
+        );
+    }
+
     #[tokio::test]
     async fn funding_and_dispatch_hooks_cover_happy_path() {
         let _lock = treasury_test_hook_lock().lock().expect("guard");
@@ -6723,6 +6759,29 @@ mod tests {
 
         set_test_wallet_send_hook(None);
         set_test_wallet_snapshot_hook(None);
+    }
+
+    #[tokio::test]
+    async fn dispatch_send_timeout_returns_failed_outcome() {
+        let outcome = super::dispatch_outcome_from_send_future(
+            super::TreasuryDispatchPlan {
+                payout_key: "window-a:pubkey-a".to_string(),
+                payment_request: "spark:alice".to_string(),
+                amount_sats: 120,
+            },
+            5,
+            async {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                Ok::<_, anyhow::Error>("payment-send-001".to_string())
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            outcome,
+            TreasuryDispatchOutcome::Failed { ref reason, .. }
+                if reason == "wallet_send_timeout:5"
+        ));
     }
 
     #[test]

--- a/docs/deploy/NEXUS_GCP_RUNBOOK.md
+++ b/docs/deploy/NEXUS_GCP_RUNBOOK.md
@@ -176,7 +176,7 @@ export NEXUS_CONTROL_TREASURY_PAYOUT_INTERVAL_SECONDS=600
 export NEXUS_CONTROL_TREASURY_REQUIRE_SELLABLE=true
 export NEXUS_CONTROL_TREASURY_DAILY_BUDGET_CAP_SATS=1000000
 export NEXUS_CONTROL_TREASURY_WALLET_STATUS_REFRESH_SECONDS=30
-export NEXUS_CONTROL_TREASURY_MAX_CONCURRENT_SENDS=16
+export NEXUS_CONTROL_TREASURY_MAX_CONCURRENT_SENDS=4
 ```
 
 Why the extra two envs matter:
@@ -196,9 +196,9 @@ Why the extra two envs matter:
   reduces Spark transfer pressure to `0.4` sends/second even if the eligible
   set reaches `240` providers, while keeping the daily ceiling under
   `864000 sats` at that scale.
-- `NEXUS_CONTROL_TREASURY_MAX_CONCURRENT_SENDS=16` remains sufficient at that
-  wider cadence because the staggered per-identity phase offsets keep the due
-  set small per dispatch cycle.
+- `NEXUS_CONTROL_TREASURY_MAX_CONCURRENT_SENDS=4` caps the per-cycle Spark
+  fan-out so one stalled upstream batch cannot occupy all live payout slots at
+  once.
 - `scripts/deploy/nexus/10-install-treasury-watchdog.sh` installs a systemd
   timer on the VM that runs every 5 minutes, checks the local treasury status
   plus recent completed-send journal entries, and restarts `nexus-relay` only

--- a/docs/nexus-treasury.md
+++ b/docs/nexus-treasury.md
@@ -152,18 +152,23 @@ sends can be dispatched concurrently inside one payout cycle. The default is
 `16`, clamped to `64`. This matters in production because too-low concurrency
 can hold the wallet-operation lock long enough that a nominal `20s` payout
 interval stretches into `40-60s` effective receive spacing once many Pylons are
-eligible at the same time.
+eligible at the same time. The hosted production Nexus should currently pin
+this lower than the default to avoid wedging entire send batches behind a
+Spark-side stall.
 
 For the hosted production Nexus, the current safe reference treasury policy is:
 
 - `NEXUS_CONTROL_TREASURY_PAYOUT_SATS_PER_WINDOW=25`
 - `NEXUS_CONTROL_TREASURY_PAYOUT_INTERVAL_SECONDS=600`
 - `NEXUS_CONTROL_TREASURY_DAILY_BUDGET_CAP_SATS=1000000`
+- `NEXUS_CONTROL_TREASURY_MAX_CONCURRENT_SENDS=4`
 
 That policy keeps the hosted treasury under `864000 sats/day` even if the
 eligible set reaches `240` providers and holds the steady-state Spark send rate
 to `0.4` transfers/second instead of the unsustainable `5+` transfers/second
 range that a `2 sats / 20s` policy reaches once the provider set crosses `100`.
+The lower concurrent-send cap keeps a single wedged Spark batch from occupying
+all live payout slots at once.
 
 For the production VM, `scripts/deploy/nexus/03-configure-and-start.sh` now
 loads the persisted policy from `${NEXUS_CONTROL_TREASURY_STATE_PATH}` by


### PR DESCRIPTION
## Summary
- bound live Spark send attempts with a per-send timeout so payout batches cannot stay stuck in `dispatching` forever
- stop stale-dispatch retry timing from expanding with larger payout intervals
- lower the hosted Nexus production guidance for concurrent sends to 4 to cap Spark fan-out

## Testing
- cargo test -p nexus-control dispatch_ -- --nocapture
- cargo test -p nexus-control funding_and_dispatch_hooks_cover_happy_path -- --nocapture

Closes #4321
