### PR TITLE
Warm the treasury wallet before dispatch

### DIFF
--- a/apps/nexus-control/src/main.rs
+++ b/apps/nexus-control/src/main.rs
@@ -10,6 +10,7 @@ fn main() -> Result<()> {
 
 async fn async_main(worker_threads: usize) -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
+    ensure_rustls_crypto_provider()?;
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -48,6 +49,16 @@ fn build_runtime(worker_threads: usize) -> Result<tokio::runtime::Runtime> {
         .worker_threads(worker_threads)
         .build()
         .context("failed to build nexus-control tokio runtime")
+}
+
+fn ensure_rustls_crypto_provider() -> Result<()> {
+    if rustls::crypto::CryptoProvider::get_default().is_some() {
+        return Ok(());
+    }
+
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|error| anyhow::anyhow!("failed to install rustls crypto provider: {error:?}"))
 }
 
 fn configured_tokio_worker_threads() -> Result<usize> {

--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -3473,9 +3473,48 @@ pub async fn dispatch_live_payouts(
         }
     };
 
+    let send_timeout_ms = config.dispatch_result_timeout_ms(config.payout_interval_ms());
+    // Force the live wallet through one full sync in this process before we
+    // attempt a payout batch. Cached account-info balance can be non-zero while
+    // the in-memory Spark leaf set is still cold after startup or recovery.
+    match tokio::time::timeout(Duration::from_millis(send_timeout_ms), wallet.get_balance()).await
+    {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => {
+            let reason = format!("failed to sync treasury wallet before dispatch: {error}");
+            return TreasuryDispatchBatchResult {
+                outcomes: plans
+                    .iter()
+                    .map(|plan| TreasuryDispatchOutcome::Failed {
+                        payout_key: plan.payout_key.clone(),
+                        reason: reason.clone(),
+                    })
+                    .collect(),
+                wallet_snapshot: None,
+                wallet_error: Some(reason),
+            };
+        }
+        Err(_) => {
+            let reason = format!(
+                "timed out syncing treasury wallet before dispatch after {} ms",
+                send_timeout_ms
+            );
+            return TreasuryDispatchBatchResult {
+                outcomes: plans
+                    .iter()
+                    .map(|plan| TreasuryDispatchOutcome::Failed {
+                        payout_key: plan.payout_key.clone(),
+                        reason: reason.clone(),
+                    })
+                    .collect(),
+                wallet_snapshot: None,
+                wallet_error: Some(reason),
+            };
+        }
+    }
+
     // Keep the wallet-operation lock held for a bounded window even when the
     // upstream Spark send path stalls or many Pylons become due together.
-    let send_timeout_ms = config.dispatch_result_timeout_ms(config.payout_interval_ms());
     let max_concurrent_sends = config.max_concurrent_send_operations(plans.len());
     let mut indexed_outcomes = stream::iter(plans.iter().cloned().enumerate())
         .map(|(index, plan)| {


### PR DESCRIPTION
## Summary
- install the Rustls crypto provider before treasury CLI commands so recovery commands do not panic
- force the hosted treasury wallet through one bounded full sync before each payout batch dispatch
- fail the whole batch clearly if that pre-dispatch wallet sync errors or times out

## Testing
- cargo test -p nexus-control wallet_ -- --nocapture
- cargo test -p nexus-control --bin nexus-control -- --nocapture
- cargo test -p nexus-control dispatch_result_timeout_stays_bounded_when_payout_interval_increases -- --nocapture
- cargo test -p nexus-control max_concurrent_send_operations_clamps_to_configured_limit -- --nocapture

Closes #4321