### PR TITLE
Trigger a full Spark sync before payout dispatch

### DIFF
--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -3477,11 +3477,17 @@ pub async fn dispatch_live_payouts(
     // Force the live wallet through one full sync in this process before we
     // attempt a payout batch. Cached account-info balance can be non-zero while
     // the in-memory Spark leaf set is still cold after startup or recovery.
-    match tokio::time::timeout(Duration::from_millis(send_timeout_ms), wallet.get_balance()).await
+    match tokio::time::timeout(
+        Duration::from_millis(send_timeout_ms),
+        wallet.network_status(),
+    )
+    .await
     {
-        Ok(Ok(_)) => {}
-        Ok(Err(error)) => {
-            let reason = format!("failed to sync treasury wallet before dispatch: {error}");
+        Ok(status) if status.status == NetworkStatus::Connected => {}
+        Ok(status) => {
+            let reason = status.detail.unwrap_or_else(|| {
+                "treasury wallet sync completed without reaching a connected state".to_string()
+            });
             return TreasuryDispatchBatchResult {
                 outcomes: plans
                     .iter()


### PR DESCRIPTION
## Summary
- force the treasury wallet through `network_status()` before each live payout batch so the Spark SDK performs a full sync in-process
- fail the batch early with a bounded timeout if the wallet does not reach a connected state instead of dispatching against a cold leaf set
- preserve the existing payout timeout budget and follow up to #4327 / issue #4321

## Testing
- cargo test -p nexus-control wallet_ -- --nocapture
- cargo test -p nexus-control --bin nexus-control -- --nocapture
- cargo test -p nexus-control dispatch_result_timeout_stays_bounded_when_payout_interval_increases -- --nocapture
- cargo test -p nexus-control max_concurrent_send_operations_clamps_to_configured_limit -- --nocapture