### PR TITLE
Gate idle treasury wallet refreshes

### DIFF
--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -16359,6 +16359,15 @@ async fn run_treasury_wallet_refresh_cycle(state: &AppState, create_if_missing: 
     ) {
         return;
     }
+    if matches!(refresh_state, TreasuryWalletRefreshState::Due)
+        && state
+            .store
+            .read()
+            .map(|store| !store.treasury.due_wallet_refresh_requires_reconciliation())
+            .unwrap_or(false)
+    {
+        return;
+    }
     if !try_begin_treasury_wallet_refresh_cycle() {
         return;
     }
@@ -19535,9 +19544,10 @@ mod tests {
         ProviderPayoutTargetChallengeRequest, ProviderPayoutTargetChallengeResponse,
         ProviderPayoutTargetRegistrationRequest, ProviderPayoutTargetRegistrationResponse,
         RegisteredPayoutTarget, TreasuryFundingMaterial, TreasuryFundingTargetRequest,
-        TreasuryFundingTargetResponse, TreasuryPayoutClass, TreasuryState, TreasuryStatusResponse,
-        TreasuryWalletSnapshot, set_test_wallet_funding_hook, set_test_wallet_send_hook,
-        set_test_wallet_snapshot_hook, treasury_test_hook_lock,
+        TreasuryFundingTargetResponse, TreasuryPayoutClass, TreasuryPayoutClassification,
+        TreasuryPayoutRecord, TreasuryState, TreasuryStatusResponse, TreasuryWalletSnapshot,
+        set_test_wallet_funding_hook, set_test_wallet_send_hook, set_test_wallet_snapshot_hook,
+        treasury_test_hook_lock,
     };
 
     use super::{
@@ -24522,7 +24532,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn public_stats_serves_cached_background_snapshot_when_wallet_refresh_is_due()
+    async fn treasury_wallet_refresh_cycle_skips_idle_due_refreshes() -> Result<()> {
+        let mut config = test_config()?;
+        config.treasury.enabled = true;
+        config.treasury.wallet_status_refresh_seconds = 1;
+        let state = build_app_state(config);
+        let _guard = treasury_test_hook_lock()
+            .lock()
+            .expect("treasury hook guard");
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        let hook_calls_clone = hook_calls.clone();
+
+        set_test_wallet_snapshot_hook(Some(Arc::new(move || {
+            let call_index = hook_calls_clone.fetch_add(1, Ordering::SeqCst);
+            Ok(TreasuryWalletSnapshot {
+                runtime_status: "connected".to_string(),
+                runtime_detail: None,
+                balance_sats: if call_index == 0 { 500 } else { 710 },
+                payments: Vec::new(),
+            })
+        })));
+
+        run_treasury_wallet_refresh_cycle(&state, true).await;
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
+
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+
+        run_treasury_wallet_refresh_cycle(&state, true).await;
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
+
+        let store = state
+            .store
+            .read()
+            .expect("store read after idle refresh skip");
+        assert_eq!(store.treasury.wallet_balance_sats, 500);
+
+        set_test_wallet_snapshot_hook(None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn public_stats_serves_cached_background_snapshot_when_due_refresh_tracks_dispatched_payouts()
     -> Result<()> {
         let mut config = test_config()?;
         config.treasury.enabled = true;
@@ -24562,9 +24612,36 @@ mod tests {
         assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
         assert_eq!(first_stats.nexus_treasury_degraded_reason, None);
 
+        {
+            let mut store = state.store.write().expect("store write for payout backlog");
+            store.treasury.payout_records_by_key.insert(
+                "window-a:pubkey-a".to_string(),
+                TreasuryPayoutRecord {
+                    payout_key: "window-a:pubkey-a".to_string(),
+                    nostr_pubkey_hex: "pubkey-a".to_string(),
+                    payout_target: "spark:alice".to_string(),
+                    amount_sats: 50,
+                    status: "dispatched".to_string(),
+                    reason: None,
+                    payment_id: Some("pay-confirm-me".to_string()),
+                    window_started_at_unix_ms: 1_000,
+                    window_ends_at_unix_ms: 2_000,
+                    created_at_unix_ms: 1_000,
+                    updated_at_unix_ms: 1_000,
+                    sellable_at_window_open: true,
+                    dispatch_receipt_recorded: true,
+                    confirm_receipt_recorded: false,
+                    fail_receipt_recorded: false,
+                    skip_receipt_recorded: false,
+                    counted_in_paid_total: false,
+                    classification: TreasuryPayoutClassification::default(),
+                },
+            );
+        }
+
         tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
 
-        let second_response = app
+        let third_response = app
             .clone()
             .oneshot(
                 Request::builder()
@@ -24573,20 +24650,14 @@ mod tests {
                     .body(Body::empty())?,
             )
             .await?;
-        assert_eq!(second_response.status(), StatusCode::OK);
-        let second_stats: PublicStatsSnapshot = response_json(second_response).await?;
-        assert_eq!(second_stats.nexus_wallet_balance_sats, 500);
+        assert_eq!(third_response.status(), StatusCode::OK);
+        let stale_stats: PublicStatsSnapshot = response_json(third_response).await?;
+        assert_eq!(stale_stats.nexus_wallet_balance_sats, 500);
         assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(second_stats.nexus_treasury_degraded_reason, None);
-        assert!(
-            second_stats
-                .nexus_wallet_sync_lag_ms
-                .is_some_and(|lag_ms| lag_ms >= 1_000)
-        );
 
         run_treasury_wallet_refresh_cycle(&state, true).await;
 
-        let third_response = app
+        let refreshed_response = app
             .oneshot(
                 Request::builder()
                     .method("GET")
@@ -24594,11 +24665,11 @@ mod tests {
                     .body(Body::empty())?,
             )
             .await?;
-        assert_eq!(third_response.status(), StatusCode::OK);
-        let third_stats: PublicStatsSnapshot = response_json(third_response).await?;
-        assert_eq!(third_stats.nexus_wallet_balance_sats, 710);
+        assert_eq!(refreshed_response.status(), StatusCode::OK);
+        let refreshed_stats: PublicStatsSnapshot = response_json(refreshed_response).await?;
+        assert_eq!(refreshed_stats.nexus_wallet_balance_sats, 710);
         assert_eq!(hook_calls.load(Ordering::SeqCst), 2);
-        assert_eq!(third_stats.nexus_treasury_degraded_reason, None);
+        assert_eq!(refreshed_stats.nexus_treasury_degraded_reason, None);
 
         set_test_wallet_snapshot_hook(None);
         Ok(())

--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -1524,6 +1524,14 @@ impl TreasuryState {
         })
     }
 
+    pub fn due_wallet_refresh_requires_reconciliation(&self) -> bool {
+        self.payout_records_by_key.values().any(|record| {
+            record.status == "dispatched"
+                && !record.counted_in_paid_total
+                && record.payment_id.is_some()
+        })
+    }
+
     fn payout_loop_health(&self, config: &TreasuryConfig) -> String {
         if !self.treasury_enabled(config) {
             return "disabled".to_string();


### PR DESCRIPTION
## Summary
- skip background treasury wallet refreshes once the wallet is already synced and there are no unconfirmed dispatched payouts to reconcile
- keep bootstrap refreshes and dispatched-payout reconciliation refreshes active
- add regression coverage for idle due-refresh skips and dispatched-payout reconciliation refreshes

Closes #4321