### PR TITLE
Stop treasury Spark background sync poisoning

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,8 @@ PROTOC = { value = "scripts/dev/protocw", relative = true }
 # Keep native builds aligned with the app's deployment target on macOS so
 # C/C++ object files do not advertise a newer SDK floor than the final link.
 MACOSX_DEPLOYMENT_TARGET = "11.0"
+
+[net]
+# Git CLI fetches are more reliable than libgit2 for the repo's pinned/forked
+# Git dependencies during local and production builds.
+git-fetch-with-cli = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "breez-sdk-common"
 version = "0.1.0"
-source = "git+https://github.com/breez/spark-sdk?tag=0.12.2#40e3cbe28fed70ef0e1e61a4d726e12032753eb3"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
 dependencies = [
  "aes",
  "anyhow",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "breez-sdk-spark"
 version = "0.1.0"
-source = "git+https://github.com/breez/spark-sdk?tag=0.12.2#40e3cbe28fed70ef0e1e61a4d726e12032753eb3"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2874,7 +2874,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 [[package]]
 name = "flashnet"
 version = "0.1.0"
-source = "git+https://github.com/breez/spark-sdk?tag=0.12.2#40e3cbe28fed70ef0e1e61a4d726e12032753eb3"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
 dependencies = [
  "bitcoin 0.32.8",
  "getrandom 0.2.17",
@@ -4756,7 +4756,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "lnurl-models"
 version = "0.1.0"
-source = "git+https://github.com/breez/spark-sdk?tag=0.12.2#40e3cbe28fed70ef0e1e61a4d726e12032753eb3"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
 dependencies = [
  "serde",
 ]
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/breez/spark-sdk?tag=0.12.2#40e3cbe28fed70ef0e1e61a4d726e12032753eb3"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6283,7 +6283,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/breez/spark-sdk?tag=0.12.2#40e3cbe28fed70ef0e1e61a4d726e12032753eb3"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9597,7 +9597,7 @@ dependencies = [
 [[package]]
 name = "spark"
 version = "0.1.0"
-source = "git+https://github.com/breez/spark-sdk?tag=0.12.2#40e3cbe28fed70ef0e1e61a4d726e12032753eb3"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "spark-wallet"
 version = "0.1.0"
-source = "git+https://github.com/breez/spark-sdk?tag=0.12.2#40e3cbe28fed70ef0e1e61a4d726e12032753eb3"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
 dependencies = [
  "bitcoin 0.32.8",
  "frost-secp256k1-tr-unofficial",

--- a/apps/autopilot-desktop/src/bin/spark_wallet_cli.rs
+++ b/apps/autopilot-desktop/src/bin/spark_wallet_cli.rs
@@ -119,6 +119,7 @@ async fn run(cli: Cli) -> Result<()> {
             api_key: cli.api_key.clone(),
             storage_dir: cli.storage_dir.clone(),
             deposit_claim_fee_policy: DepositClaimFeePolicy::Auto,
+            background_processing: true,
         },
     )
     .await

--- a/apps/autopilot-desktop/src/spark_wallet.rs
+++ b/apps/autopilot-desktop/src/spark_wallet.rs
@@ -935,6 +935,7 @@ impl SparkPaneState {
             api_key: Some(configured_api_key(&self.env_overrides)),
             storage_dir,
             deposit_claim_fee_policy: DepositClaimFeePolicy::Auto,
+            background_processing: true,
         };
         let wallet = run_with_timeout(
             runtime,

--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -13,8 +13,8 @@ use bip39::{Language, Mnemonic};
 use futures::stream::{self, StreamExt};
 use openagents_provider_substrate::verify_provider_payout_target_registration_signature;
 use openagents_spark::{
-    DepositClaimFeePolicy, Network as SparkNetwork, NetworkStatus, PaymentSummary, SparkSigner,
-    SparkWallet, WalletConfig,
+    DepositClaimFeePolicy, Network as SparkNetwork, PaymentSummary, SparkSigner, SparkWallet,
+    WalletConfig,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -3482,50 +3482,6 @@ pub async fn dispatch_live_payouts(
     };
 
     let send_timeout_ms = config.dispatch_result_timeout_ms(config.payout_interval_ms());
-    // Force the live wallet through one full sync in this process before we
-    // attempt a payout batch. Cached account-info balance can be non-zero while
-    // the in-memory Spark leaf set is still cold after startup or recovery.
-    match tokio::time::timeout(
-        Duration::from_millis(send_timeout_ms),
-        wallet.network_status(),
-    )
-    .await
-    {
-        Ok(status) if status.status == NetworkStatus::Connected => {}
-        Ok(status) => {
-            let reason = status.detail.unwrap_or_else(|| {
-                "treasury wallet sync completed without reaching a connected state".to_string()
-            });
-            return TreasuryDispatchBatchResult {
-                outcomes: plans
-                    .iter()
-                    .map(|plan| TreasuryDispatchOutcome::Failed {
-                        payout_key: plan.payout_key.clone(),
-                        reason: reason.clone(),
-                    })
-                    .collect(),
-                wallet_snapshot: None,
-                wallet_error: Some(reason),
-            };
-        }
-        Err(_) => {
-            let reason = format!(
-                "timed out syncing treasury wallet before dispatch after {} ms",
-                send_timeout_ms
-            );
-            return TreasuryDispatchBatchResult {
-                outcomes: plans
-                    .iter()
-                    .map(|plan| TreasuryDispatchOutcome::Failed {
-                        payout_key: plan.payout_key.clone(),
-                        reason: reason.clone(),
-                    })
-                    .collect(),
-                wallet_snapshot: None,
-                wallet_error: Some(reason),
-            };
-        }
-    }
 
     // Keep the wallet-operation lock held for a bounded window even when the
     // upstream Spark send path stalls or many Pylons become due together.
@@ -4041,24 +3997,14 @@ async fn inspect_treasury_wallet_storage(
             return inspection;
         }
     };
-    let network = match parse_wallet_network(config.wallet_network.as_str()) {
-        Ok(network) => network,
+    let wallet_config = match treasury_wallet_config(config, storage_dir.to_path_buf()) {
+        Ok(wallet_config) => wallet_config,
         Err(error) => {
             inspection.error = Some(error.to_string());
             return inspection;
         }
     };
-    let wallet = match SparkWallet::new(
-        signer,
-        WalletConfig {
-            network,
-            api_key: resolve_wallet_api_key(config.wallet_api_key_env.as_deref()),
-            storage_dir: storage_dir.to_path_buf(),
-            deposit_claim_fee_policy: DepositClaimFeePolicy::Auto,
-        },
-    )
-    .await
-    {
+    let wallet = match SparkWallet::new(signer, wallet_config).await {
         Ok(wallet) => wallet,
         Err(error) => {
             inspection.error = Some(format!(
@@ -4068,11 +4014,11 @@ async fn inspect_treasury_wallet_storage(
         }
     };
 
-    let network_status = wallet.network_status().await;
-    inspection.runtime_status = Some(wallet_network_status_label(&network_status).to_string());
-    inspection.runtime_detail = network_status.detail;
+    inspection.runtime_status = Some("cached".to_string());
+    inspection.runtime_detail =
+        Some("treasury wallet inspection skipped live sync to preserve local state".to_string());
 
-    match wallet.get_balance().await {
+    match wallet.get_balance_cached().await {
         Ok(balance) => inspection.balance_sats = Some(balance.total_sats()),
         Err(error) => {
             inspection.error = Some(format!("failed to fetch treasury Spark balance: {error}"));
@@ -5144,15 +5090,20 @@ async fn open_wallet_uncached(
         .map_err(|error| anyhow!("failed to derive treasury Spark signer: {error}"))?;
     SparkWallet::new(
         signer,
-        WalletConfig {
-            network: parse_wallet_network(config.wallet_network.as_str())?,
-            api_key: resolve_wallet_api_key(config.wallet_api_key_env.as_deref()),
-            storage_dir: config.wallet_storage_dir.clone(),
-            deposit_claim_fee_policy: DepositClaimFeePolicy::Auto,
-        },
+        treasury_wallet_config(config, config.wallet_storage_dir.clone())?,
     )
     .await
     .context("failed to initialize treasury Spark wallet")
+}
+
+fn treasury_wallet_config(config: &TreasuryConfig, storage_dir: PathBuf) -> Result<WalletConfig> {
+    Ok(WalletConfig {
+        network: parse_wallet_network(config.wallet_network.as_str())?,
+        api_key: resolve_wallet_api_key(config.wallet_api_key_env.as_deref()),
+        storage_dir,
+        deposit_claim_fee_policy: DepositClaimFeePolicy::Auto,
+        background_processing: false,
+    })
 }
 
 fn wallet_refresh_payment_page_budget(tracked_payment_count: usize) -> usize {
@@ -5288,13 +5239,6 @@ async fn wallet_snapshot_from_wallet_with_plan(
     wallet_snapshot_from_wallet_with_plan_result(wallet, plan)
         .await
         .map(|result| result.snapshot)
-}
-
-fn wallet_network_status_label(status: &openagents_spark::NetworkStatusReport) -> &'static str {
-    match status.status {
-        NetworkStatus::Connected => "connected",
-        NetworkStatus::Disconnected => "disconnected",
-    }
 }
 
 fn ensure_wallet_mnemonic(path: &Path, create_if_missing: bool) -> Result<String> {
@@ -5578,6 +5522,15 @@ mod tests {
                 .expect("clock")
                 .as_nanos()
         ))
+    }
+
+    #[test]
+    fn treasury_wallet_config_disables_background_processing() {
+        let config = test_treasury_config();
+        let wallet_config =
+            super::treasury_wallet_config(&config, config.wallet_storage_dir.clone())
+                .expect("wallet config");
+        assert!(!wallet_config.background_processing);
     }
 
     #[test]

--- a/apps/pylon/src/wallet_runtime.rs
+++ b/apps/pylon/src/wallet_runtime.rs
@@ -816,6 +816,7 @@ async fn open_wallet(context: &WalletRuntimeContext) -> Result<SparkWallet> {
             api_key: context.api_key.clone(),
             storage_dir: context.storage_dir.clone(),
             deposit_claim_fee_policy: DepositClaimFeePolicy::Auto,
+            background_processing: true,
         },
     )
     .await

--- a/crates/spark/Cargo.toml
+++ b/crates/spark/Cargo.toml
@@ -19,7 +19,7 @@ bitcoin = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 hex = { workspace = true }
 dirs = "6.0.0"
-breez-sdk-spark = { git = "https://github.com/breez/spark-sdk", tag = "0.12.2" }
+breez-sdk-spark = { git = "https://github.com/AtlantisPleb/spark-sdk", rev = "c82debf42a9bb8869869a905289c029c25434e24" }
 
 [dev-dependencies]
-spark-sdk-internal = { package = "spark", git = "https://github.com/breez/spark-sdk", tag = "0.12.2" }
+spark-sdk-internal = { package = "spark", git = "https://github.com/AtlantisPleb/spark-sdk", rev = "c82debf42a9bb8869869a905289c029c25434e24" }

--- a/crates/spark/src/wallet.rs
+++ b/crates/spark/src/wallet.rs
@@ -35,6 +35,7 @@ pub struct WalletConfig {
     pub api_key: Option<String>,
     pub storage_dir: PathBuf,
     pub deposit_claim_fee_policy: DepositClaimFeePolicy,
+    pub background_processing: bool,
 }
 
 impl Default for WalletConfig {
@@ -49,6 +50,7 @@ impl Default for WalletConfig {
             api_key: None,
             storage_dir,
             deposit_claim_fee_policy: DepositClaimFeePolicy::Auto,
+            background_processing: true,
         }
     }
 }
@@ -206,7 +208,8 @@ impl SparkWallet {
             .to_sdk_max_fee(config.network);
 
         let builder = SdkBuilder::new(sdk_config, seed)
-            .with_default_storage(config.storage_dir.to_string_lossy().to_string());
+            .with_default_storage(config.storage_dir.to_string_lossy().to_string())
+            .with_background_processing(config.background_processing);
         let sdk = builder
             .build()
             .await
@@ -693,6 +696,11 @@ mod tests {
                 .label(Network::Mainnet),
             "recommended:+1sat/vb"
         );
+    }
+
+    #[test]
+    fn wallet_config_defaults_to_background_processing_enabled() {
+        assert!(WalletConfig::default().background_processing);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route the treasury wallet through a Spark SDK fork that exposes the existing background-processing toggle
- disable Spark background processing for treasury wallets and remove the pre-dispatch `network_status()` full-sync gate that was poisoning cached wallet state on restart
- use Git CLI fetches for pinned Git dependencies and keep interactive wallets explicitly opting into background processing

## Testing
- cargo test -p openagents-spark wallet_config_defaults_to_background_processing_enabled
- cargo test -p nexus-control treasury_wallet_config_disables_background_processing
- cargo test -p nexus-control funding_and_dispatch_hooks_cover_happy_path
