### PR TITLE
Disable Breez startup workers for treasury wallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "breez-sdk-common"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
 dependencies = [
  "aes",
  "anyhow",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "breez-sdk-spark"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2445,7 +2445,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2714,7 +2714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2868,7 +2868,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 [[package]]
 name = "flashnet"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
 dependencies = [
  "bitcoin 0.32.8",
  "getrandom 0.2.17",
@@ -3988,7 +3988,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4307,7 +4307,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4750,7 +4750,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "lnurl-models"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
 dependencies = [
  "serde",
 ]
@@ -4825,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5340,7 +5340,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6261,7 +6261,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6655,7 +6655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -6688,7 +6688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7957,7 +7957,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8723,7 +8723,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9569,13 +9569,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "spark"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "spark-wallet"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
 dependencies = [
  "bitcoin 0.32.8",
  "frost-secp256k1-tr-unofficial",
@@ -10102,7 +10102,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "breez-sdk-common"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?branch=cd%2Ftreasury-wallet-runtime-only-sync#c78d9050f754330c32e6753e26a57cf977466659"
 dependencies = [
  "aes",
  "anyhow",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "breez-sdk-spark"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?branch=cd%2Ftreasury-wallet-runtime-only-sync#c78d9050f754330c32e6753e26a57cf977466659"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2868,7 +2868,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 [[package]]
 name = "flashnet"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?branch=cd%2Ftreasury-wallet-runtime-only-sync#c78d9050f754330c32e6753e26a57cf977466659"
 dependencies = [
  "bitcoin 0.32.8",
  "getrandom 0.2.17",
@@ -4327,15 +4327,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4750,7 +4741,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "lnurl-models"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?branch=cd%2Ftreasury-wallet-runtime-only-sync#c78d9050f754330c32e6753e26a57cf977466659"
 dependencies = [
  "serde",
 ]
@@ -4825,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?branch=cd%2Ftreasury-wallet-runtime-only-sync#c78d9050f754330c32e6753e26a57cf977466659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6261,7 +6252,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?branch=cd%2Ftreasury-wallet-runtime-only-sync#c78d9050f754330c32e6753e26a57cf977466659"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6655,7 +6646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6688,7 +6679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9575,7 +9566,7 @@ dependencies = [
 [[package]]
 name = "spark"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?branch=cd%2Ftreasury-wallet-runtime-only-sync#c78d9050f754330c32e6753e26a57cf977466659"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9620,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "spark-wallet"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=258ac2f976088386711ef4aa055f15ce99a2028e#258ac2f976088386711ef4aa055f15ce99a2028e"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?branch=cd%2Ftreasury-wallet-runtime-only-sync#c78d9050f754330c32e6753e26a57cf977466659"
 dependencies = [
  "bitcoin 0.32.8",
  "frost-secp256k1-tr-unofficial",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "breez-sdk-common"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
 dependencies = [
  "aes",
  "anyhow",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "breez-sdk-spark"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2445,7 +2445,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2714,7 +2714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2866,15 +2866,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
 name = "flashnet"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
 dependencies = [
  "bitcoin 0.32.8",
  "getrandom 0.2.17",
@@ -3994,7 +3988,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4313,7 +4307,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4756,7 +4750,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "lnurl-models"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
 dependencies = [
  "serde",
 ]
@@ -4831,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5032,12 +5026,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "naga"
@@ -5352,7 +5340,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6143,17 +6131,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset 0.4.2",
- "indexmap 2.13.0",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "indexmap 2.13.0",
 ]
 
@@ -6283,7 +6261,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-utils"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6659,8 +6637,8 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap 0.8.3",
- "petgraph 0.6.5",
+ "multimap",
+ "petgraph",
  "prettyplease 0.1.25",
  "prost 0.11.9",
  "prost-types 0.11.9",
@@ -6677,11 +6655,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
- "multimap 0.10.1",
+ "multimap",
  "once_cell",
- "petgraph 0.7.1",
+ "petgraph",
  "prettyplease 0.2.37",
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -6710,7 +6688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7979,7 +7957,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8745,7 +8723,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9597,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "spark"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9642,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "spark-wallet"
 version = "0.1.0"
-source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=c82debf42a9bb8869869a905289c029c25434e24#c82debf42a9bb8869869a905289c029c25434e24"
+source = "git+https://github.com/AtlantisPleb/spark-sdk?rev=3142cf25525155301e571ad82b78867e02d1b566#3142cf25525155301e571ad82b78867e02d1b566"
 dependencies = [
  "bitcoin 0.32.8",
  "frost-secp256k1-tr-unofficial",
@@ -10124,7 +10102,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11919,7 +11897,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -16359,15 +16359,6 @@ async fn run_treasury_wallet_refresh_cycle(state: &AppState, create_if_missing: 
     ) {
         return;
     }
-    if matches!(refresh_state, TreasuryWalletRefreshState::Due)
-        && state
-            .store
-            .read()
-            .map(|store| !store.treasury.due_wallet_refresh_requires_reconciliation())
-            .unwrap_or(false)
-    {
-        return;
-    }
     if !try_begin_treasury_wallet_refresh_cycle() {
         return;
     }
@@ -24532,7 +24523,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn treasury_wallet_refresh_cycle_skips_idle_due_refreshes() -> Result<()> {
+    async fn treasury_wallet_refresh_cycle_refreshes_due_snapshots() -> Result<()> {
         let mut config = test_config()?;
         config.treasury.enabled = true;
         config.treasury.wallet_status_refresh_seconds = 1;
@@ -24559,13 +24550,10 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
 
         run_treasury_wallet_refresh_cycle(&state, true).await;
-        assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 2);
 
-        let store = state
-            .store
-            .read()
-            .expect("store read after idle refresh skip");
-        assert_eq!(store.treasury.wallet_balance_sats, 500);
+        let store = state.store.read().expect("store read after due refresh");
+        assert_eq!(store.treasury.wallet_balance_sats, 710);
 
         set_test_wallet_snapshot_hook(None);
         Ok(())

--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -5254,10 +5254,19 @@ async fn wallet_snapshot_from_wallet_with_plan_result(
     wallet: &SparkWallet,
     plan: &TreasuryWalletRefreshPlan,
 ) -> Result<TreasuryWalletRefreshResult> {
-    wallet
-        .sync()
-        .await
-        .context("failed to sync treasury Spark wallet")?;
+    // The hosted treasury wallet now runs in manual mode with background
+    // processing disabled. Full Spark sync currently exercises deposit-claim
+    // and other network-heavy paths that can wedge or zero a recovered
+    // treasury wallet even when the local cached state is valid enough to
+    // continue dispatching. In that manual mode, prefer the cached wallet
+    // snapshot and bounded payment scan instead of forcing a full network sync
+    // on every treasury refresh.
+    if wallet.config().background_processing {
+        wallet
+            .sync()
+            .await
+            .context("failed to sync treasury Spark wallet")?;
+    }
     let balance = wallet
         .get_balance_cached()
         .await

--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -239,6 +239,10 @@ impl TreasuryConfig {
             .max(self.wallet_status_refresh_seconds.saturating_mul(2_000))
     }
 
+    pub fn dispatch_plan_limit(&self) -> usize {
+        self.max_concurrent_send_operations(usize::MAX)
+    }
+
     pub fn max_concurrent_send_operations(&self, plan_count: usize) -> usize {
         plan_count.min(self.max_concurrent_sends).max(1)
     }
@@ -1525,14 +1529,6 @@ impl TreasuryState {
         })
     }
 
-    pub fn due_wallet_refresh_requires_reconciliation(&self) -> bool {
-        self.payout_records_by_key.values().any(|record| {
-            record.status == "dispatched"
-                && !record.counted_in_paid_total
-                && record.payment_id.is_some()
-        })
-    }
-
     fn payout_loop_health(&self, config: &TreasuryConfig) -> String {
         if !self.treasury_enabled(config) {
             return "disabled".to_string();
@@ -2641,6 +2637,7 @@ impl TreasuryState {
         policy: &TreasuryRuntimePolicy,
         now_unix_ms: u64,
         reserved_budget_sats: &mut u64,
+        available_dispatch_slots: usize,
     ) -> Vec<TreasuryDispatchPlan> {
         let mut queued = self
             .payout_records_by_key
@@ -2658,6 +2655,9 @@ impl TreasuryState {
 
         let mut dispatch_plans = Vec::new();
         for (_, _, payout_key) in queued {
+            if dispatch_plans.len() >= available_dispatch_slots {
+                break;
+            }
             let Some(record) = self.payout_records_by_key.get_mut(payout_key.as_str()) else {
                 continue;
             };
@@ -2712,8 +2712,19 @@ impl TreasuryState {
         }
 
         let mut reserved_budget_sats = self.reserved_budget_last_24h(now_unix_ms);
-        let mut dispatch_plans =
-            self.claim_queued_payouts_for_dispatch(&policy, now_unix_ms, &mut reserved_budget_sats);
+        let dispatch_plan_limit = config.dispatch_plan_limit();
+        let inflight_dispatch_count = self
+            .payout_records_by_key
+            .values()
+            .filter(|record| record.status == "dispatching" && record.payment_id.is_none())
+            .count();
+        let available_dispatch_slots = dispatch_plan_limit.saturating_sub(inflight_dispatch_count);
+        let mut dispatch_plans = self.claim_queued_payouts_for_dispatch(
+            &policy,
+            now_unix_ms,
+            &mut reserved_budget_sats,
+            available_dispatch_slots,
+        );
         if online_identities.is_empty() {
             self.refresh_public_snapshot(config, now_unix_ms);
             return TreasuryPayoutPreparation {
@@ -2850,8 +2861,11 @@ impl TreasuryState {
                         continue;
                     }
 
-                    reserved_budget_sats =
-                        reserved_budget_sats.saturating_add(policy.payout_sats_per_window);
+                    let can_dispatch_now = dispatch_plans.len() < available_dispatch_slots;
+                    if can_dispatch_now {
+                        reserved_budget_sats =
+                            reserved_budget_sats.saturating_add(policy.payout_sats_per_window);
+                    }
                     self.payout_records_by_key.insert(
                         payout_key.clone(),
                         TreasuryPayoutRecord {
@@ -2859,7 +2873,11 @@ impl TreasuryState {
                             nostr_pubkey_hex: identity.nostr_pubkey_hex.clone(),
                             payout_target: target.spark_address.clone(),
                             amount_sats: policy.payout_sats_per_window,
-                            status: "dispatching".to_string(),
+                            status: if can_dispatch_now {
+                                "dispatching".to_string()
+                            } else {
+                                "queued".to_string()
+                            },
                             reason: None,
                             payment_id: None,
                             window_started_at_unix_ms,
@@ -2875,11 +2893,13 @@ impl TreasuryState {
                             classification: TreasuryPayoutClassification::default(),
                         },
                     );
-                    dispatch_plans.push(TreasuryDispatchPlan {
-                        payout_key,
-                        payment_request: target.spark_address,
-                        amount_sats: policy.payout_sats_per_window,
-                    });
+                    if can_dispatch_now {
+                        dispatch_plans.push(TreasuryDispatchPlan {
+                            payout_key,
+                            payment_request: target.spark_address,
+                            amount_sats: policy.payout_sats_per_window,
+                        });
+                    }
                 }
 
                 if window_started_at_unix_ms >= current_window_started_at_unix_ms {
@@ -5834,6 +5854,65 @@ mod tests {
         let prepared_again = state.prepare_due_payouts(&config, &online, now_unix_ms);
         assert!(prepared_again.dispatch_plans.is_empty());
         assert!(prepared_again.receipt_events.is_empty());
+    }
+
+    #[test]
+    fn payout_preparation_caps_dispatches_and_queues_overflow() {
+        let mut state = TreasuryState::default();
+        let mut config = test_treasury_config();
+        config.max_concurrent_sends = 1;
+        for (nostr_pubkey_hex, spark_address) in [
+            ("pubkey-a", "spark:alice"),
+            ("pubkey-b", "spark:bob"),
+            ("pubkey-c", "spark:carol"),
+        ] {
+            state.payout_targets_by_identity.insert(
+                nostr_pubkey_hex.to_string(),
+                super::RegisteredPayoutTarget {
+                    nostr_pubkey_hex: nostr_pubkey_hex.to_string(),
+                    source_session_id: format!("session-{nostr_pubkey_hex}"),
+                    spark_address: spark_address.to_string(),
+                    bitcoin_address: None,
+                    registered_at_unix_ms: 10,
+                    last_verified_at_unix_ms: 10,
+                },
+            );
+        }
+
+        let online = vec![
+            OnlinePylonIdentity {
+                nostr_pubkey_hex: "pubkey-a".to_string(),
+                sellable: true,
+            },
+            OnlinePylonIdentity {
+                nostr_pubkey_hex: "pubkey-b".to_string(),
+                sellable: true,
+            },
+            OnlinePylonIdentity {
+                nostr_pubkey_hex: "pubkey-c".to_string(),
+                sellable: true,
+            },
+        ];
+        let now_unix_ms = super::now_unix_ms();
+        let prepared = state.prepare_due_payouts(&config, &online, now_unix_ms);
+
+        assert_eq!(prepared.dispatch_plans.len(), 1);
+        assert_eq!(
+            state
+                .payout_records_by_key
+                .values()
+                .filter(|record| record.status == "dispatching")
+                .count(),
+            1
+        );
+        assert_eq!(
+            state
+                .payout_records_by_key
+                .values()
+                .filter(|record| record.status == "queued")
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -5104,6 +5104,7 @@ async fn open_wallet(config: &TreasuryConfig, create_if_missing: bool) -> Result
         return Ok(entry.wallet.clone());
     }
     let wallet = Arc::new(open_wallet_uncached(config, create_if_missing).await?);
+    prime_manual_live_wallet(config, wallet.as_ref()).await?;
     *cache_guard = Some(LiveWalletCacheEntry {
         key: cache_key,
         wallet: wallet.clone(),
@@ -5142,6 +5143,30 @@ fn treasury_wallet_config(config: &TreasuryConfig, storage_dir: PathBuf) -> Resu
         deposit_claim_fee_policy: DepositClaimFeePolicy::Auto,
         background_processing: false,
     })
+}
+
+async fn prime_manual_live_wallet(config: &TreasuryConfig, wallet: &SparkWallet) -> Result<()> {
+    if wallet.config().background_processing {
+        return Ok(());
+    }
+
+    tracing::info!(
+        storage_dir = %config.wallet_storage_dir.display(),
+        "priming manual treasury Spark wallet with initial sync"
+    );
+    wallet
+        .sync()
+        .await
+        .context("failed to perform initial manual treasury Spark sync")?;
+    let balance = wallet
+        .get_balance_cached()
+        .await
+        .context("failed to read manual treasury Spark balance after initial sync")?;
+    tracing::info!(
+        balance_sats = balance.total_sats(),
+        "manual treasury Spark wallet initial sync completed"
+    );
+    Ok(())
 }
 
 fn wallet_refresh_payment_page_budget(tracked_payment_count: usize) -> usize {
@@ -5258,9 +5283,10 @@ async fn wallet_snapshot_from_wallet_with_plan_result(
     // processing disabled. Full Spark sync currently exercises deposit-claim
     // and other network-heavy paths that can wedge or zero a recovered
     // treasury wallet even when the local cached state is valid enough to
-    // continue dispatching. In that manual mode, prefer the cached wallet
-    // snapshot and bounded payment scan instead of forcing a full network sync
-    // on every treasury refresh.
+    // continue dispatching. The live runtime now primes that manual wallet with
+    // one explicit sync when the cached process-local wallet is created. After
+    // that initial sync, prefer the cached wallet snapshot and bounded payment
+    // scan instead of forcing a full network sync on every treasury refresh.
     if wallet.config().background_processing {
         wallet
             .sync()

--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -351,6 +351,7 @@ pub struct TreasuryWalletRecoveryComparison {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rebuilt_minus_current_balance_sats: Option<i64>,
     pub current_zero_with_receive_history: bool,
+    pub rebuilt_storage_looks_uninitialized: bool,
     pub major_divergence_detected: bool,
     pub validation_passed: bool,
     pub recommended_action: String,
@@ -3947,20 +3948,27 @@ fn build_treasury_wallet_recovery_comparison(
                 .payment_totals
                 .completed_send_total_sats
                 .saturating_add(TREASURY_IMPOSSIBLE_ZERO_BALANCE_THRESHOLD_SATS);
+    let rebuilt_storage_looks_uninitialized = rebuilt_storage.payment_totals.total_payments == 0
+        && rebuilt_storage.balance_sats.unwrap_or(0) == 0
+        && (current_storage.payment_totals.total_payments > 0
+            || current_storage.payment_totals.completed_receive_total_sats > 0
+            || current_storage.payment_totals.completed_send_total_sats > 0);
     let major_divergence_detected =
         match (current_storage.balance_sats, rebuilt_storage.balance_sats) {
             (Some(current), Some(rebuilt)) => {
                 let delta = current.abs_diff(rebuilt);
                 let larger_balance = current.max(rebuilt);
                 current_zero_with_receive_history
+                    || rebuilt_storage_looks_uninitialized
                     || delta >= TREASURY_IMPOSSIBLE_ZERO_BALANCE_THRESHOLD_SATS
                     || (larger_balance > 0 && delta.saturating_mul(100) >= larger_balance * 10)
             }
-            _ => current_zero_with_receive_history,
+            _ => current_zero_with_receive_history || rebuilt_storage_looks_uninitialized,
         };
     let validation_passed = current_storage.error.is_none()
         && rebuilt_storage.error.is_none()
-        && wallet_identity_pubkey_match;
+        && wallet_identity_pubkey_match
+        && !rebuilt_storage_looks_uninitialized;
     let recommended_action = if !validation_passed {
         "inspect_errors".to_string()
     } else if major_divergence_detected {
@@ -3972,6 +3980,7 @@ fn build_treasury_wallet_recovery_comparison(
         wallet_identity_pubkey_match,
         rebuilt_minus_current_balance_sats,
         current_zero_with_receive_history,
+        rebuilt_storage_looks_uninitialized,
         major_divergence_detected,
         validation_passed,
         recommended_action,
@@ -4014,9 +4023,14 @@ async fn inspect_treasury_wallet_storage(
         }
     };
 
-    inspection.runtime_status = Some("cached".to_string());
+    if let Err(error) = wallet.sync().await {
+        inspection.error = Some(format!("failed to sync treasury Spark wallet: {error}"));
+        let _ = wallet.disconnect().await;
+        return inspection;
+    }
+    inspection.runtime_status = Some("connected".to_string());
     inspection.runtime_detail =
-        Some("treasury wallet inspection skipped live sync to preserve local state".to_string());
+        Some("treasury wallet inspection synced copied wallet state".to_string());
 
     match wallet.get_balance_cached().await {
         Ok(balance) => inspection.balance_sats = Some(balance.total_sats()),
@@ -4668,6 +4682,10 @@ fn render_treasury_wallet_recovery_report(report: &TreasuryWalletRecoveryReport)
             report.comparison.major_divergence_detected
         ),
         format!(
+            "rebuilt_storage_looks_uninitialized: {}",
+            report.comparison.rebuilt_storage_looks_uninitialized
+        ),
+        format!(
             "recommended_action: {}",
             report.comparison.recommended_action
         ),
@@ -5216,6 +5234,10 @@ async fn wallet_snapshot_from_wallet_with_plan_result(
     wallet: &SparkWallet,
     plan: &TreasuryWalletRefreshPlan,
 ) -> Result<TreasuryWalletRefreshResult> {
+    wallet
+        .sync()
+        .await
+        .context("failed to sync treasury Spark wallet")?;
     let balance = wallet
         .get_balance_cached()
         .await
@@ -5706,11 +5728,44 @@ mod tests {
         assert!(comparison.wallet_identity_pubkey_match);
         assert!(comparison.current_zero_with_receive_history);
         assert!(comparison.major_divergence_detected);
+        assert!(!comparison.rebuilt_storage_looks_uninitialized);
         assert!(comparison.validation_passed);
         assert_eq!(
             comparison.recommended_action,
             "cutover_rebuilt_storage_after_service_stop"
         );
+    }
+
+    #[test]
+    fn recovery_comparison_rejects_empty_rebuilt_storage_when_current_has_history() {
+        let comparison = build_treasury_wallet_recovery_comparison(
+            &TreasuryWalletInspection {
+                wallet_identity_pubkey: "identity".to_string(),
+                inspected_storage_dir: "/tmp/current".to_string(),
+                balance_sats: Some(0),
+                payment_totals: TreasuryWalletPaymentAggregate {
+                    total_payments: 42,
+                    completed_receive_total_sats: 100_000,
+                    completed_send_total_sats: 20_000,
+                    ..TreasuryWalletPaymentAggregate::default()
+                },
+                ..TreasuryWalletInspection::default()
+            },
+            &TreasuryWalletInspection {
+                wallet_identity_pubkey: "identity".to_string(),
+                inspected_storage_dir: "/tmp/rebuilt".to_string(),
+                balance_sats: Some(0),
+                payment_totals: TreasuryWalletPaymentAggregate::default(),
+                ..TreasuryWalletInspection::default()
+            },
+        );
+
+        assert!(comparison.wallet_identity_pubkey_match);
+        assert!(comparison.current_zero_with_receive_history);
+        assert!(comparison.rebuilt_storage_looks_uninitialized);
+        assert!(comparison.major_divergence_detected);
+        assert!(!comparison.validation_passed);
+        assert_eq!(comparison.recommended_action, "inspect_errors");
     }
 
     #[test]
@@ -6898,6 +6953,7 @@ mod tests {
                 wallet_identity_pubkey_match: true,
                 rebuilt_minus_current_balance_sats: Some(80_000),
                 current_zero_with_receive_history: true,
+                rebuilt_storage_looks_uninitialized: false,
                 major_divergence_detected: true,
                 validation_passed: true,
                 recommended_action: "cutover_rebuilt_storage_after_service_stop".to_string(),

--- a/crates/spark/Cargo.toml
+++ b/crates/spark/Cargo.toml
@@ -19,7 +19,7 @@ bitcoin = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 hex = { workspace = true }
 dirs = "6.0.0"
-breez-sdk-spark = { git = "https://github.com/AtlantisPleb/spark-sdk", rev = "3142cf25525155301e571ad82b78867e02d1b566" }
+breez-sdk-spark = { git = "https://github.com/AtlantisPleb/spark-sdk", rev = "258ac2f976088386711ef4aa055f15ce99a2028e" }
 
 [dev-dependencies]
-spark-sdk-internal = { package = "spark", git = "https://github.com/AtlantisPleb/spark-sdk", rev = "3142cf25525155301e571ad82b78867e02d1b566" }
+spark-sdk-internal = { package = "spark", git = "https://github.com/AtlantisPleb/spark-sdk", rev = "258ac2f976088386711ef4aa055f15ce99a2028e" }

--- a/crates/spark/Cargo.toml
+++ b/crates/spark/Cargo.toml
@@ -19,7 +19,7 @@ bitcoin = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 hex = { workspace = true }
 dirs = "6.0.0"
-breez-sdk-spark = { git = "https://github.com/AtlantisPleb/spark-sdk", rev = "c82debf42a9bb8869869a905289c029c25434e24" }
+breez-sdk-spark = { git = "https://github.com/AtlantisPleb/spark-sdk", rev = "3142cf25525155301e571ad82b78867e02d1b566" }
 
 [dev-dependencies]
-spark-sdk-internal = { package = "spark", git = "https://github.com/AtlantisPleb/spark-sdk", rev = "c82debf42a9bb8869869a905289c029c25434e24" }
+spark-sdk-internal = { package = "spark", git = "https://github.com/AtlantisPleb/spark-sdk", rev = "3142cf25525155301e571ad82b78867e02d1b566" }

--- a/crates/spark/Cargo.toml
+++ b/crates/spark/Cargo.toml
@@ -19,7 +19,7 @@ bitcoin = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 hex = { workspace = true }
 dirs = "6.0.0"
-breez-sdk-spark = { git = "https://github.com/AtlantisPleb/spark-sdk", rev = "258ac2f976088386711ef4aa055f15ce99a2028e" }
+breez-sdk-spark = { git = "https://github.com/AtlantisPleb/spark-sdk", branch = "cd/treasury-wallet-runtime-only-sync" }
 
 [dev-dependencies]
-spark-sdk-internal = { package = "spark", git = "https://github.com/AtlantisPleb/spark-sdk", rev = "258ac2f976088386711ef4aa055f15ce99a2028e" }
+spark-sdk-internal = { package = "spark", git = "https://github.com/AtlantisPleb/spark-sdk", branch = "cd/treasury-wallet-runtime-only-sync" }

--- a/crates/spark/src/wallet.rs
+++ b/crates/spark/src/wallet.rs
@@ -6,7 +6,7 @@ use breez_sdk_spark::{
     BreezSdk, ClaimDepositRequest, DepositClaimError, GetInfoRequest, ListPaymentsRequest,
     ListUnclaimedDepositsRequest, MaxFee, Network as SdkNetwork, Payment, PaymentDetails,
     PaymentStatus, PaymentType, PrepareSendPaymentRequest, ReceivePaymentMethod,
-    ReceivePaymentRequest, SdkBuilder, Seed, SendPaymentRequest, SyncWalletRequest, default_config,
+    ReceivePaymentRequest, SdkBuilder, Seed, SendPaymentRequest, default_config,
 };
 
 use crate::{SparkError, SparkSigner};
@@ -239,7 +239,7 @@ impl SparkWallet {
 
     pub async fn sync(&self) -> Result<(), SparkError> {
         self.sdk
-            .sync_wallet(SyncWalletRequest {})
+            .sync_wallet_runtime_state()
             .await
             .map(|_| ())
             .map_err(|error| SparkError::Wallet(error.to_string()))

--- a/crates/spark/src/wallet.rs
+++ b/crates/spark/src/wallet.rs
@@ -11,6 +11,8 @@ use breez_sdk_spark::{
 
 use crate::{SparkError, SparkSigner};
 
+const MANUAL_SYNC_INTERVAL_SECS: u32 = 24 * 60 * 60;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Network {
     Mainnet,
@@ -197,15 +199,7 @@ impl SparkWallet {
             },
         };
 
-        let mut sdk_config = default_config(config.network.to_sdk_network()?);
-        if let Some(api_key) = &config.api_key {
-            sdk_config.api_key = Some(api_key.clone());
-        } else {
-            sdk_config.real_time_sync_server_url = None;
-        }
-        sdk_config.max_deposit_claim_fee = config
-            .deposit_claim_fee_policy
-            .to_sdk_max_fee(config.network);
+        let sdk_config = sdk_config_for_wallet(&config)?;
 
         let builder = SdkBuilder::new(sdk_config, seed)
             .with_default_storage(config.storage_dir.to_string_lossy().to_string())
@@ -494,6 +488,29 @@ impl SparkWallet {
     }
 }
 
+fn sdk_config_for_wallet(config: &WalletConfig) -> Result<breez_sdk_spark::Config, SparkError> {
+    let mut sdk_config = default_config(config.network.to_sdk_network()?);
+    if let Some(api_key) = &config.api_key {
+        sdk_config.api_key = Some(api_key.clone());
+    } else {
+        sdk_config.real_time_sync_server_url = None;
+    }
+    sdk_config.max_deposit_claim_fee = config
+        .deposit_claim_fee_policy
+        .to_sdk_max_fee(config.network);
+
+    // Treasury and other manual-operation wallets should not keep Breez's
+    // real-time, LNURL, or minute-by-minute sync helpers alive between explicit
+    // operations.
+    if !config.background_processing {
+        sdk_config.real_time_sync_server_url = None;
+        sdk_config.lnurl_domain = None;
+        sdk_config.sync_interval_secs = MANUAL_SYNC_INTERVAL_SECS;
+    }
+
+    Ok(sdk_config)
+}
+
 fn payment_direction_label(payment_type: PaymentType) -> &'static str {
     match payment_type {
         PaymentType::Send => "send",
@@ -647,8 +664,9 @@ fn payment_status_detail(status: PaymentStatus, htlc_status: Option<&str>) -> Op
 #[cfg(test)]
 mod tests {
     use super::{
-        Balance, DepositClaimFeePolicy, Network, PaymentSummary, PaymentType, SdkNetwork,
-        UnclaimedDeposit, WalletConfig, payment_direction_label, payment_summary_from_sdk_payment,
+        Balance, DepositClaimFeePolicy, MANUAL_SYNC_INTERVAL_SECS, Network, PaymentSummary,
+        PaymentType, SdkNetwork, UnclaimedDeposit, WalletConfig, payment_direction_label,
+        payment_summary_from_sdk_payment, sdk_config_for_wallet,
         unclaimed_deposit_from_sdk_deposit,
     };
     use crate::SparkError;
@@ -709,6 +727,33 @@ mod tests {
     #[test]
     fn wallet_config_defaults_to_background_processing_enabled() {
         assert!(WalletConfig::default().background_processing);
+    }
+
+    #[test]
+    fn manual_wallet_config_disables_realtime_and_lnurl_sync() {
+        let sdk_config = sdk_config_for_wallet(&WalletConfig {
+            api_key: Some("test-api-key".to_string()),
+            background_processing: false,
+            ..WalletConfig::default()
+        })
+        .expect("manual wallet sdk config");
+
+        assert!(sdk_config.real_time_sync_server_url.is_none());
+        assert!(sdk_config.lnurl_domain.is_none());
+        assert_eq!(sdk_config.sync_interval_secs, MANUAL_SYNC_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn background_wallet_config_keeps_realtime_sync_defaults() {
+        let sdk_config = sdk_config_for_wallet(&WalletConfig {
+            api_key: Some("test-api-key".to_string()),
+            background_processing: true,
+            ..WalletConfig::default()
+        })
+        .expect("background wallet sdk config");
+
+        assert!(sdk_config.real_time_sync_server_url.is_some());
+        assert!(sdk_config.lnurl_domain.is_some());
     }
 
     #[test]

--- a/crates/spark/src/wallet.rs
+++ b/crates/spark/src/wallet.rs
@@ -231,7 +231,7 @@ impl SparkWallet {
     }
 
     pub async fn network_status(&self) -> NetworkStatusReport {
-        match self.sdk.sync_wallet(SyncWalletRequest {}).await {
+        match self.sync().await {
             Ok(_) => NetworkStatusReport {
                 status: NetworkStatus::Connected,
                 detail: None,
@@ -241,6 +241,14 @@ impl SparkWallet {
                 detail: Some(error.to_string()),
             },
         }
+    }
+
+    pub async fn sync(&self) -> Result<(), SparkError> {
+        self.sdk
+            .sync_wallet(SyncWalletRequest {})
+            .await
+            .map(|_| ())
+            .map_err(|error| SparkError::Wallet(error.to_string()))
     }
 
     pub async fn get_balance(&self) -> Result<Balance, SparkError> {


### PR DESCRIPTION
## Summary
- bump the pinned AtlantisPleb Spark SDK fork to a rev that honors background processing at the Breez SDK layer
- skip Breez startup workers and conversion helper background tasks when treasury wallets disable background processing
- keep the treasury wallet on the explicit no-background path that was added in the first fix

## Testing
- cargo test -p openagents-spark wallet_config_defaults_to_background_processing_enabled
- cargo test -p nexus-control treasury_wallet_config_disables_background_processing
- cargo test -p nexus-control funding_and_dispatch_hooks_cover_happy_path