### PR TITLE
Finish autonomous pylon homework closeout on main

### DIFF
--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -3401,6 +3401,11 @@ impl TrainingSchedulerState {
             if !training_run_schedulable(&run) {
                 return Err("training_scheduler_run_not_schedulable".to_string());
             }
+            if training_run_requires_scheduler_residency_for_claims(&run)
+                && !self.runs_by_training_run_id.contains_key(training_run_id)
+            {
+                return Err("training_scheduler_run_not_found".to_string());
+            }
             if self
                 .runs_by_training_run_id
                 .get(training_run_id)
@@ -3436,6 +3441,13 @@ impl TrainingSchedulerState {
         let mut best_match: Option<((u8, u8, u8, i64), ComputeTrainingRun)> = None;
         for run in candidate_runs {
             if !training_run_schedulable(&run) {
+                continue;
+            }
+            if training_run_requires_scheduler_residency_for_claims(run)
+                && !self
+                    .runs_by_training_run_id
+                    .contains_key(run.training_run_id.as_str())
+            {
                 continue;
             }
             if self
@@ -8249,6 +8261,7 @@ struct HomeworkLaunchPrepared {
     lane_contract: PsionicTrainLaneContract,
     matched_pylons: Vec<HomeworkLaunchPylonMatch>,
     assigned_pylons: Vec<HomeworkLaunchAssignedPylon>,
+    assigned_nodes: Vec<AdmittedTrainingNodeView>,
     artifact_bucket_uri: String,
     artifact_prefix: String,
     course_id: String,
@@ -8385,6 +8398,49 @@ fn homework_launch_assigned_pylons(
         .collect()
 }
 
+fn materialize_homework_launch_assignments_and_window(
+    store: &mut ControlStore,
+    training_run_id: &str,
+    assigned_nodes: &[AdmittedTrainingNodeView],
+    course_id: &str,
+    homework_id: &str,
+    assignment_family: &str,
+    run_kind: &str,
+    recorded_at_ms: i64,
+) -> Result<Vec<HomeworkLaunchAssignedPylon>, String> {
+    store
+        .training_scheduler
+        .recover_from_kernel(&store.kernel, recorded_at_ms);
+    let bound_assignments = {
+        let scheduled_run = store
+            .training_scheduler
+            .runs_by_training_run_id
+            .get_mut(training_run_id)
+            .ok_or_else(|| "training_scheduler_run_not_found".to_string())?;
+        scheduled_run.bind_launch_worker_assignments(assigned_nodes, recorded_at_ms)?
+    };
+    let assigned_pylons = assigned_nodes
+        .iter()
+        .zip(bound_assignments.iter())
+        .map(|(node, assignment)| HomeworkLaunchAssignedPylon {
+            node: homework_launch_pylon_match(node),
+            assignment_id: assignment.assignment_id.clone(),
+            lease_id: assignment.lease_id.clone().unwrap_or_default(),
+            assignment_state: assignment.state.label().to_string(),
+        })
+        .collect::<Vec<_>>();
+    persist_active_homework_window(
+        store,
+        training_run_id,
+        course_id,
+        homework_id,
+        assignment_family,
+        run_kind,
+        recorded_at_ms,
+    )?;
+    Ok(assigned_pylons)
+}
+
 fn build_homework_training_run_id(
     now_unix_ms: u64,
     course_id: &str,
@@ -8509,6 +8565,10 @@ fn homework_launch_effective_payout_amount_sats(
 
 fn training_run_homework_launch_metadata(training_run: &ComputeTrainingRun) -> Option<&Value> {
     training_run.metadata.get("homework_launch")
+}
+
+fn training_run_requires_scheduler_residency_for_claims(training_run: &ComputeTrainingRun) -> bool {
+    training_run_homework_launch_metadata(training_run).is_some()
 }
 
 fn training_run_homework_window_duration_seconds(training_run: &ComputeTrainingRun) -> u64 {
@@ -9140,6 +9200,7 @@ fn prepare_homework_launch(
                     matched_pylons,
                     artifact_bucket_uri: scheduled_run.artifact_bucket_uri.clone(),
                     assigned_pylons: homework_launch_assigned_pylons(scheduled_run, &node_lookup),
+                    assigned_nodes: Vec::new(),
                     artifact_prefix: homework_artifact_prefix(
                         scheduled_run.artifact_bucket_uri.as_str(),
                         scheduled_run.network_id.as_str(),
@@ -9185,32 +9246,11 @@ fn prepare_homework_launch(
             create_request,
         )
         .map_err(kernel_api_error)?;
-    store
-        .training_scheduler
-        .recover_from_kernel(&store.kernel, now_unix_ms as i64);
-    let scheduled_run = store
-        .training_scheduler
-        .runs_by_training_run_id
-        .get_mut(training_run_id.as_str())
-        .ok_or_else(|| kernel_api_error("training_scheduler_run_not_found".to_string()))?;
-    let bound_assignments = scheduled_run
-        .bind_launch_worker_assignments(assigned_nodes.as_slice(), now_unix_ms as i64)
-        .map_err(kernel_api_error)?;
-    let current_window_id = scheduled_run.current_window_id.clone();
-    let _ = scheduled_run;
-    store
-        .persist_training_scheduler_state()
-        .map_err(kernel_api_error)?;
-    let assigned_pylons = assigned_nodes
-        .iter()
-        .zip(bound_assignments.iter())
-        .map(|(node, assignment)| HomeworkLaunchAssignedPylon {
-            node: homework_launch_pylon_match(node),
-            assignment_id: assignment.assignment_id.clone(),
-            lease_id: assignment.lease_id.clone().unwrap_or_default(),
-            assignment_state: assignment.state.label().to_string(),
-        })
-        .collect::<Vec<_>>();
+    let current_window_id =
+        training_scheduler_metadata_from_run(&create_result.response.training_run)
+            .map_err(kernel_api_error)?
+            .initial_window_id
+            .unwrap_or_else(|| homework_initial_window_id(training_run_id.as_str()));
     Ok(HomeworkLaunchPrepared {
         training_run_id: training_run_id.clone(),
         network_id,
@@ -9225,7 +9265,8 @@ fn prepare_homework_launch(
         launch_receipt_id: Some(create_result.response.receipt.receipt_id.clone()),
         lane_contract,
         matched_pylons,
-        assigned_pylons,
+        assigned_pylons: Vec::new(),
+        assigned_nodes,
         artifact_bucket_uri,
         artifact_prefix,
         course_id,
@@ -9260,6 +9301,7 @@ async fn execute_homework_launch(
         })?;
         prepare_homework_launch(&state.config, &mut store, now, request)?
     };
+    let mut assigned_pylons = prepared.assigned_pylons.clone();
     if let Some(receipt_event) = prepared.receipt_event.clone() {
         let _ = state.kernel_receipt_tx.send(receipt_event);
     }
@@ -9311,9 +9353,10 @@ async fn execute_homework_launch(
                 error: "internal_error",
                 reason: "session_store_poisoned".to_string(),
             })?;
-            persist_active_homework_window(
+            assigned_pylons = materialize_homework_launch_assignments_and_window(
                 &mut store,
                 prepared.training_run_id.as_str(),
+                prepared.assigned_nodes.as_slice(),
                 prepared.course_id.as_str(),
                 prepared.homework_id.as_str(),
                 prepared.assignment_family.as_str(),
@@ -9361,7 +9404,7 @@ async fn execute_homework_launch(
         run_status: prepared.run_status,
         current_window_id: prepared.current_window_id,
         matched_pylons: prepared.matched_pylons,
-        assigned_pylons: prepared.assigned_pylons,
+        assigned_pylons,
         artifact_prefix: prepared.artifact_prefix,
         launch_receipt_id: prepared.launch_receipt_id,
         run_detail,
@@ -38490,6 +38533,122 @@ mod tests {
         );
 
         upload_server.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn homework_launch_prepare_keeps_bootstrap_pending_run_out_of_lease_claims() -> Result<()>
+    {
+        let config = test_config()?;
+        let state = build_app_state(config);
+        let app = build_api_router_with_state(state.clone());
+        let training_run_id = "run.cs336.a1.bootstrap.pending";
+        let network_id = "trainnet.cs336.a1.bootstrappending";
+        let current_release_id = current_homework_launch_release_id_for_test();
+        let current_build_version = current_homework_launch_build_version_for_test();
+        let recorded_at_ms = now_unix_ms();
+
+        seed_homework_launch_node(
+            &state,
+            recorded_at_ms.saturating_sub(100),
+            "node-bootstrap-alpha",
+            "sha256:build-bootstrap-alpha",
+            network_id,
+            current_release_id.as_str(),
+            current_build_version.as_str(),
+            vec![TrainingNodeRoleClaim::Worker],
+            None,
+        );
+
+        let prepared = {
+            let mut store = state.store.write().expect("write store");
+            super::prepare_homework_launch(
+                &state.config,
+                &mut store,
+                recorded_at_ms,
+                LaunchHomeworkRunRequest {
+                    course_id: "cs336".to_string(),
+                    homework_id: "a1".to_string(),
+                    run_slug: "bootstrap-pending".to_string(),
+                    training_run_id: Some(training_run_id.to_string()),
+                    display_name: Some("Bootstrap Pending".to_string()),
+                    reuse_existing_run: false,
+                    network_id: Some(network_id.to_string()),
+                    run_kind: Some("homework".to_string()),
+                    assignment_family: Some("cs336.a1".to_string()),
+                    artifact_prefix: None,
+                    target: super::HomeworkLaunchTargetRequest {
+                        only_online: true,
+                        min_pylon_version: None,
+                        require_updated_build: true,
+                        tags_any: Vec::new(),
+                        tags_all: Vec::new(),
+                    },
+                    assignment: super::HomeworkLaunchAssignmentRequest {
+                        mode: super::HomeworkAssignmentMode::AllMatchingPylons,
+                        max_contributors: Some(1),
+                        window_duration_seconds: 1_800,
+                    },
+                    payout: super::HomeworkLaunchPayoutRequest {
+                        enabled: false,
+                        rail: None,
+                        amount_sats: None,
+                        pay_only_on_accept: true,
+                    },
+                },
+            )
+            .map_err(|error| anyhow::anyhow!(error.reason))?
+        };
+        assert!(prepared.needs_window_materialization);
+        assert_eq!(
+            prepared.current_window_id,
+            "window.cs336.a1.bootstrap.pending.0001"
+        );
+        assert!(prepared.assigned_pylons.is_empty());
+        assert_eq!(prepared.assigned_nodes.len(), 1);
+
+        {
+            let store = state.store.read().expect("read store");
+            assert!(
+                store
+                    .kernel
+                    .get_compute_training_run(training_run_id)
+                    .is_some(),
+                "kernel run should exist before bootstrap publish"
+            );
+            assert!(
+                !store
+                    .training_scheduler
+                    .runs_by_training_run_id
+                    .contains_key(training_run_id),
+                "bootstrap-pending run must stay out of scheduler claims"
+            );
+        }
+
+        let claim_response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/leases/claim")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &training_run_lease_request(
+                            "idemp.training.lease.bootstrap.pending",
+                            recorded_at_ms as i64 + 1_000,
+                            "node-bootstrap-alpha",
+                            training_run_id,
+                            network_id,
+                        ),
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(claim_response.status(), StatusCode::NOT_FOUND);
+        let claim_body = response_json::<serde_json::Value>(claim_response).await?;
+        assert_eq!(
+            claim_body.get("reason").and_then(serde_json::Value::as_str),
+            Some("training_scheduler_run_not_found")
+        );
+
         Ok(())
     }
 

--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -9863,6 +9863,67 @@ async fn upload_training_artifact_via_curl_signed_url(
     Err(format!("curl_http_error:{status}:{response_body}"))
 }
 
+async fn read_training_artifact_via_curl_signed_url(
+    signed_url: &str,
+) -> Result<Option<Vec<u8>>, String> {
+    let response_body_path = std::env::temp_dir().join(format!(
+        "nexus-training-read-response-{}-{}.tmp",
+        now_unix_ms(),
+        std::process::id()
+    ));
+    let mut command = Command::new("curl");
+    command
+        .arg("-4")
+        .arg("-sS")
+        .arg("--connect-timeout")
+        .arg("10")
+        .arg("--max-time")
+        .arg("30")
+        .arg("-o")
+        .arg(response_body_path.as_os_str())
+        .arg("-w")
+        .arg("%{http_code}")
+        .arg(signed_url)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let output = match command.spawn() {
+        Ok(child) => child
+            .wait_with_output()
+            .await
+            .map_err(|error| format!("curl_wait_failed:{error}"))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("curl_spawn_failed:{error}")),
+    };
+
+    let response_body = tokio::fs::read(response_body_path.as_path())
+        .await
+        .unwrap_or_default();
+    let _ = tokio::fs::remove_file(response_body_path.as_path()).await;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let exit_status = output
+            .status
+            .code()
+            .map_or_else(|| "signal".to_string(), |code| code.to_string());
+        return Err(format!("curl_exit_failed:{exit_status}:{stderr}"));
+    }
+
+    let status_text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let status = status_text
+        .parse::<u16>()
+        .map_err(|error| format!("curl_status_invalid:{status_text}:{error}"))?;
+    if (200..300).contains(&status) {
+        return Ok(Some(response_body));
+    }
+
+    let detail = String::from_utf8_lossy(response_body.as_slice())
+        .trim()
+        .to_string();
+    Err(format!("curl_http_error:{status}:{detail}"))
+}
+
 async fn verify_training_artifact_via_signed_url(
     config: &TrainingArtifactSignedUrlConfig,
     client: &reqwest::Client,
@@ -9880,6 +9941,26 @@ async fn verify_training_artifact_via_signed_url(
         },
         now_unix_ms() / 1_000,
     )?;
+    if let Some(body) =
+        read_training_artifact_via_curl_signed_url(signed_access.signed_url.as_str())
+            .await
+            .map_err(|error| {
+                format!(
+                    "cs336_a1_demo_bootstrap_artifact_verify_failed:{}:{error}",
+                    artifact.resolver.artifact_id
+                )
+            })?
+    {
+        let observed_digest = sha256_prefixed_bytes(body.as_slice());
+        if observed_digest != expected_digest {
+            return Err(format!(
+                "cs336_a1_demo_bootstrap_artifact_verify_digest_mismatch:{}:{}:{}",
+                artifact.resolver.artifact_id, expected_digest, observed_digest
+            ));
+        }
+        return Ok(());
+    }
+
     let response = client
         .get(signed_access.signed_url.as_str())
         .send()

--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -127,6 +127,8 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
 use tokio::sync::broadcast;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
@@ -9485,6 +9487,25 @@ async fn upload_training_artifact_via_signed_url(
         },
         now_unix_ms() / 1_000,
     )?;
+
+    // The production Nexus image still sees reqwest transport failures for GCS
+    // signed PUTs even after forcing IPv4 resolver hints. Prefer curl -4 when
+    // it is available in the runtime image, and only fall back to reqwest when
+    // curl is not present.
+    if let Some(()) = upload_training_artifact_via_curl_signed_url(
+        signed_access.signed_url.as_str(),
+        artifact.payload.as_slice(),
+    )
+    .await
+    .map_err(|error| {
+        format!(
+            "cs336_a1_demo_bootstrap_artifact_upload_failed:{}:{error}",
+            artifact.resolver.artifact_id
+        )
+    })? {
+        return Ok(());
+    }
+
     let response = client
         .put(signed_access.signed_url.as_str())
         .body(artifact.payload.clone())
@@ -9505,6 +9526,80 @@ async fn upload_training_artifact_via_signed_url(
         "cs336_a1_demo_bootstrap_artifact_upload_failed:{}:{}:{}",
         artifact.resolver.artifact_id, status, detail
     ))
+}
+
+async fn upload_training_artifact_via_curl_signed_url(
+    signed_url: &str,
+    payload: &[u8],
+) -> Result<Option<()>, String> {
+    let response_body_path = std::env::temp_dir().join(format!(
+        "nexus-training-upload-response-{}-{}.tmp",
+        now_unix_ms(),
+        std::process::id()
+    ));
+    let mut command = Command::new("curl");
+    command
+        .arg("-4")
+        .arg("-sS")
+        .arg("-X")
+        .arg("PUT")
+        .arg("--connect-timeout")
+        .arg("10")
+        .arg("--max-time")
+        .arg("30")
+        .arg("--data-binary")
+        .arg("@-")
+        .arg("-o")
+        .arg(response_body_path.as_os_str())
+        .arg("-w")
+        .arg("%{http_code}")
+        .arg(signed_url)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("curl_spawn_failed:{error}")),
+    };
+
+    let Some(mut stdin) = child.stdin.take() else {
+        return Err("curl_stdin_unavailable".to_string());
+    };
+    stdin
+        .write_all(payload)
+        .await
+        .map_err(|error| format!("curl_stdin_write_failed:{error}"))?;
+    drop(stdin);
+
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|error| format!("curl_wait_failed:{error}"))?;
+    let response_body = tokio::fs::read_to_string(response_body_path.as_path())
+        .await
+        .unwrap_or_default();
+    let _ = tokio::fs::remove_file(response_body_path.as_path()).await;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let exit_status = output
+            .status
+            .code()
+            .map_or_else(|| "signal".to_string(), |code| code.to_string());
+        return Err(format!("curl_exit_failed:{exit_status}:{stderr}"));
+    }
+
+    let status_text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let status = status_text
+        .parse::<u16>()
+        .map_err(|error| format!("curl_status_invalid:{status_text}:{error}"))?;
+    if (200..300).contains(&status) {
+        return Ok(Some(()));
+    }
+
+    Err(format!("curl_http_error:{status}:{response_body}"))
 }
 
 async fn publish_cs336_a1_demo_bootstrap_artifacts(

--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -2423,6 +2423,46 @@ struct FinalizeTrainingValidatorChallengeRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct TrainingValidatorTargetArtifactBinding {
+    artifact_role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    object_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    local_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    signed_read_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    resolver: Option<PylonTrainingArtifactResolverResponse>,
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    metadata: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct TrainingValidatorTargetAssignmentBinding {
+    assignment_id: String,
+    training_run_id: String,
+    window_id: String,
+    contributor_pylon_id: String,
+    contribution_id: String,
+    work_class: String,
+    challenge_kind: String,
+    claim_id: String,
+    submission_receipt_digest: String,
+    manifest_digest: String,
+    object_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lane_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lease_expires_at_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    artifacts: Vec<TrainingValidatorTargetArtifactBinding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct TrainingValidatorChallengeCoordinatorResponse {
     ack: TrainingCoordinatorAck,
     network_id: String,
@@ -2446,6 +2486,8 @@ struct TrainingValidatorChallengeCoordinatorResponse {
     window: Option<ComputeAdapterTrainingWindow>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     contribution_outcomes: Vec<ComputeAdapterContributionOutcome>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    target_bindings: Vec<TrainingValidatorTargetAssignmentBinding>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -6899,6 +6941,182 @@ fn training_find_managed_validator_challenge(
         });
     }
     Err("training_validator_challenge_not_found".to_string())
+}
+
+fn training_validator_outcome_metadata_field<'a>(
+    outcome: &'a ComputeAdapterContributionOutcome,
+    field: &str,
+) -> Option<&'a Value> {
+    outcome.metadata.as_object()?.get(field)
+}
+
+fn training_validator_metadata_artifact_binding(
+    artifact_role: &str,
+    value: &Value,
+) -> Option<TrainingValidatorTargetArtifactBinding> {
+    let local_path = value
+        .get("path")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let digest = value
+        .get("digest")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let artifact_id = value
+        .get("artifact_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    if local_path.is_none() && digest.is_none() && artifact_id.is_none() {
+        return None;
+    }
+    Some(TrainingValidatorTargetArtifactBinding {
+        artifact_role: artifact_role.to_string(),
+        artifact_id,
+        digest,
+        object_uri: None,
+        local_path,
+        signed_read_url: None,
+        resolver: None,
+        metadata: value.clone(),
+    })
+}
+
+fn training_validator_resolved_artifact_binding(
+    config: &ServiceConfig,
+    artifact_bucket_uri: &str,
+    artifact_role: &str,
+    artifact_kind: PylonTrainingArtifactKind,
+    scope: PylonTrainingArtifactScope,
+    digest: Option<String>,
+) -> Result<TrainingValidatorTargetArtifactBinding, String> {
+    let mut resolver = PylonTrainingArtifactResolverResponse::new(artifact_kind, scope)
+        .map_err(|reason| format!("training_validator_target_binding_invalid:{reason}"))?;
+    resolver.digest = digest.clone();
+    let object_uri = pylon_training_artifact_object_uri(artifact_bucket_uri, &resolver).ok();
+    let signed_read_url = config
+        .training_artifact_signed_url
+        .as_ref()
+        .cloned()
+        .and_then(|mut signed_url_config| {
+            signed_url_config.bucket_uri = artifact_bucket_uri.to_string();
+            issue_training_artifact_signed_access(
+                &signed_url_config,
+                &resolver,
+                &PylonTrainingArtifactSignedAccessRequest {
+                    mode: PylonTrainingArtifactSignedAccessMode::Read,
+                    ttl_seconds: Some(signed_url_config.default_ttl_seconds),
+                    digest: digest.clone(),
+                    size_bytes: None,
+                },
+                now_unix_ms() / 1_000,
+            )
+            .ok()
+            .map(|response| response.signed_url)
+        });
+    resolver.signed_read_url = signed_read_url.clone();
+    Ok(TrainingValidatorTargetArtifactBinding {
+        artifact_role: artifact_role.to_string(),
+        artifact_id: Some(resolver.artifact_id.clone()),
+        digest,
+        object_uri,
+        local_path: None,
+        signed_read_url,
+        resolver: Some(resolver),
+        metadata: Value::Null,
+    })
+}
+
+fn training_validator_target_bindings(
+    config: &ServiceConfig,
+    kernel: &KernelState,
+    window: &ComputeAdapterTrainingWindow,
+    metadata: &TrainingWindowMetadata,
+    challenge_plan: &TrainingWindowValidationChallengePlan,
+    claim_id: &str,
+    lease_expires_at_ms: Option<i64>,
+) -> Result<Vec<TrainingValidatorTargetAssignmentBinding>, String> {
+    let outcomes = kernel.list_compute_adapter_contribution_outcomes(
+        Some(window.training_run_id.as_str()),
+        Some(window.window_id.as_str()),
+        None,
+    );
+    let outcomes_by_assignment = outcomes
+        .into_iter()
+        .map(|outcome| (outcome.assignment_id.clone(), outcome))
+        .collect::<HashMap<_, _>>();
+
+    let mut bindings = Vec::new();
+    for assignment_id in &challenge_plan.target_assignment_ids {
+        let Some(outcome) = outcomes_by_assignment.get(assignment_id.as_str()) else {
+            continue;
+        };
+        let mut artifacts = Vec::new();
+        for (artifact_role, field_name) in [
+            ("contribution_receipt", "receipt"),
+            ("contribution_artifact_manifest", "artifact_manifest"),
+            ("sealed_window_bundle", "sealed_window_bundle"),
+            ("closeout_bundle", "closeout_bundle"),
+            ("checkpoint_surface", "checkpoint_surface"),
+            (
+                "latest_accepted_checkpoint_pointer",
+                "latest_accepted_checkpoint_pointer",
+            ),
+        ] {
+            if let Some(binding) = training_validator_outcome_metadata_field(outcome, field_name)
+                .and_then(|value| {
+                    training_validator_metadata_artifact_binding(artifact_role, value)
+                })
+            {
+                artifacts.push(binding);
+            }
+        }
+
+        let assignment_scope = PylonTrainingArtifactScope {
+            network_id: metadata.network_id.clone(),
+            run_id: window.training_run_id.clone(),
+            window_id: Some(window.window_id.clone()),
+            assignment_id: Some(outcome.assignment_id.clone()),
+            challenge_id: None,
+            optimizer_step: None,
+        };
+        artifacts.push(training_validator_resolved_artifact_binding(
+            config,
+            metadata.artifact_bucket_uri.as_str(),
+            "local_update_bridge",
+            PylonTrainingArtifactKind::LocalUpdate,
+            assignment_scope.clone(),
+            None,
+        )?);
+        artifacts.push(training_validator_resolved_artifact_binding(
+            config,
+            metadata.artifact_bucket_uri.as_str(),
+            "proof_bridge",
+            PylonTrainingArtifactKind::ProofBundle,
+            assignment_scope,
+            None,
+        )?);
+
+        bindings.push(TrainingValidatorTargetAssignmentBinding {
+            assignment_id: outcome.assignment_id.clone(),
+            training_run_id: outcome.training_run_id.clone(),
+            window_id: outcome.window_id.clone(),
+            contributor_pylon_id: outcome.contributor_node_id.clone(),
+            contribution_id: outcome.contribution_id.clone(),
+            work_class: outcome.work_class.label().to_string(),
+            challenge_kind: challenge_plan.challenge_kind.label().to_string(),
+            claim_id: claim_id.to_string(),
+            submission_receipt_digest: outcome.submission_receipt_digest.clone(),
+            manifest_digest: outcome.manifest_digest.clone(),
+            object_digest: outcome.object_digest.clone(),
+            lane_type: training_validator_outcome_metadata_field(outcome, "lane_type")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+            lease_expires_at_ms,
+            artifacts,
+        });
+    }
+
+    Ok(bindings)
 }
 
 fn training_window_response(
@@ -11660,6 +11878,16 @@ async fn claim_training_validator_challenge(
                 },
             )
             .map_err(kernel_api_error)?;
+        let target_bindings = training_validator_target_bindings(
+            &state.config,
+            &store.kernel,
+            &window,
+            &metadata,
+            &challenge_plan,
+            challenge_plan.challenge_id.as_str(),
+            Some(result.response.lease.expires_at_ms as i64),
+        )
+        .map_err(kernel_api_error)?;
         let response = TrainingValidatorChallengeCoordinatorResponse {
             ack: TrainingCoordinatorAck {
                 idempotency_key: request.idempotency_key.clone(),
@@ -11686,6 +11914,7 @@ async fn claim_training_validator_challenge(
             window_receipt: None,
             window: None,
             contribution_outcomes: Vec::new(),
+            target_bindings,
         };
         (response, result.receipt_event, result.snapshot_event)
     };
@@ -11809,6 +12038,19 @@ async fn retry_training_validator_challenge(
             lease_receipt_event = lease_result.receipt_event;
             lease_snapshot_event = lease_result.snapshot_event;
         }
+        let target_bindings = training_validator_target_bindings(
+            &state.config,
+            &store.kernel,
+            &managed.window,
+            &managed.metadata,
+            &managed.challenge_plan,
+            challenge_id.as_str(),
+            lease
+                .as_ref()
+                .map(|leased| leased.expires_at_ms as i64)
+                .or_else(|| i64::try_from(request.lease.expires_at_ms).ok()),
+        )
+        .map_err(kernel_api_error)?;
         let response = TrainingValidatorChallengeCoordinatorResponse {
             ack: TrainingCoordinatorAck {
                 idempotency_key: request.idempotency_key.clone(),
@@ -11829,6 +12071,7 @@ async fn retry_training_validator_challenge(
             window_receipt: None,
             window: None,
             contribution_outcomes: Vec::new(),
+            target_bindings,
         };
         (
             response,
@@ -12134,6 +12377,16 @@ async fn finalize_training_validator_challenge(
         store
             .persist_training_scheduler_state()
             .map_err(kernel_api_error)?;
+        let target_bindings = training_validator_target_bindings(
+            &state.config,
+            &store.kernel,
+            &updated_window,
+            &metadata,
+            &managed.challenge_plan,
+            challenge_id.as_str(),
+            i64::try_from(request.lease.expires_at_ms).ok(),
+        )
+        .map_err(kernel_api_error)?;
 
         let response = TrainingValidatorChallengeCoordinatorResponse {
             ack: TrainingCoordinatorAck {
@@ -12160,6 +12413,7 @@ async fn finalize_training_validator_challenge(
             window_receipt: Some(window_result.response.receipt.clone()),
             window: Some(updated_window),
             contribution_outcomes,
+            target_bindings,
         };
         (
             response,
@@ -24503,6 +24757,54 @@ mod tests {
         input
     }
 
+    fn training_window_homework_contribution_input_for_lease(
+        contribution_id: &str,
+        lease: &RecordTrainingRunLeaseResponse,
+        validator_receipt_digest: &str,
+        validator_disposition: Option<ComputeAdapterContributionDisposition>,
+    ) -> TrainingWindowContributionInput {
+        let mut input = training_window_contribution_input_for_lease(
+            contribution_id,
+            lease,
+            validator_receipt_digest,
+            validator_disposition,
+        );
+        input.metadata = json!({
+            "normalized_contribution_contract": "retained_homework_lane.v1",
+            "assignment_id": lease.assignment_id,
+            "contribution_id": contribution_id,
+            "lane_type": super::PSION_CS336_A1_DEMO_LANE_ID,
+            "work_class": "small_model_local_training",
+            "receipt": {
+                "path": format!("/tmp/{contribution_id}/contribution_receipt.json"),
+                "digest": format!("sha256:receipt:{contribution_id}")
+            },
+            "artifact_manifest": {
+                "path": format!("/tmp/{contribution_id}/artifact_manifest.json"),
+                "artifact_id": format!("artifact.manifest.{contribution_id}"),
+                "digest": format!("sha256:artifact-manifest:{contribution_id}")
+            },
+            "sealed_window_bundle": {
+                "path": "/tmp/window.0001/sealed_window_bundle.json",
+                "digest": "sha256:sealed-window-alpha"
+            },
+            "closeout_bundle": {
+                "path": "/tmp/run.alpha/closeout_bundle.json",
+                "digest": format!("sha256:closeout:{contribution_id}")
+            },
+            "checkpoint_surface": {
+                "path": "/tmp/run.alpha/checkpoint_surface.json",
+                "digest": format!("sha256:checkpoint-surface:{contribution_id}")
+            },
+            "latest_accepted_checkpoint_pointer": {
+                "path": "/tmp/run.alpha/latest_accepted_checkpoint_pointer.json",
+                "digest": format!("sha256:checkpoint-pointer:{contribution_id}")
+            },
+            "checkpoint_ref": "checkpoint://cs336/a1/final"
+        });
+        input
+    }
+
     async fn prepare_reward_candidate_training_window(
         app: &Router,
         state: &AppState,
@@ -24788,6 +25090,261 @@ mod tests {
             .await?;
         assert_eq!(second_finalized.status(), StatusCode::OK);
         Ok(lease)
+    }
+
+    #[tokio::test]
+    async fn validator_challenge_claim_returns_target_bindings_for_homework_contributions()
+    -> Result<()> {
+        let mut config = test_config()?;
+        let (training_artifact_signed_url, _dir) = test_training_artifact_signed_url_config()?;
+        config.training_artifact_signed_url = Some(training_artifact_signed_url);
+        let state = build_app_state(config);
+        let app = build_router_with_state(state.clone());
+        let created_at_ms = now_unix_ms();
+        let training_run_id = "run.homework.bindings.alpha";
+
+        seed_training_scheduler_run(
+            &state,
+            created_at_ms,
+            training_run_id,
+            "window.0001",
+            "node-alpha",
+            "sha256:build-alpha",
+        );
+        {
+            let mut store = state.store.write().expect("write store");
+            let mut validator = training_node_admission_request(
+                "validator-alpha",
+                "sha256:validator-alpha",
+                vec!["trainnet.alpha"],
+                Vec::new(),
+                Some(512),
+            );
+            validator.requested_at_ms = created_at_ms as i64 + 760;
+            validator.role_claims = vec![TrainingNodeRoleClaim::Validator];
+            store
+                .kernel
+                .record_training_node_admission(
+                    &training_kernel_mutation_context("validator-alpha", created_at_ms + 760),
+                    validator,
+                )
+                .expect("admit validator");
+            let mut validator_heartbeat =
+                training_node_heartbeat_request("validator-alpha", "sha256:validator-alpha");
+            validator_heartbeat.recorded_at_ms = created_at_ms as i64 + 770;
+            validator_heartbeat.last_heartbeat_at_ms = Some(created_at_ms as i64 + 770);
+            validator_heartbeat.training_run_id = training_run_id.to_string();
+            validator_heartbeat.window_id = "window.0001".to_string();
+            store
+                .kernel
+                .record_training_node_heartbeat(
+                    &training_kernel_mutation_context("validator-alpha", created_at_ms + 770),
+                    validator_heartbeat,
+                )
+                .expect("heartbeat validator");
+        }
+
+        let lease_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/leases/claim")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &training_run_lease_request(
+                            "idemp.training.lease.homework.bindings",
+                            created_at_ms as i64 + 1_000,
+                            "node-alpha",
+                            training_run_id,
+                            "trainnet.alpha",
+                        ),
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(lease_response.status(), StatusCode::OK);
+        let lease = response_json::<RecordTrainingRunLeaseResponse>(lease_response).await?;
+
+        let planned = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/windows/plan")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &plan_training_window_request(
+                            "idemp.training.window.plan.homework.bindings",
+                            created_at_ms as i64 + 1_100,
+                            training_run_id,
+                            vec![training_window_dataset_slice(
+                                "slice://0001",
+                                "sha256:slice-0001",
+                            )],
+                        ),
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(planned.status(), StatusCode::OK);
+
+        let activated = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/windows/window.0001/activate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &transition_training_window_request(
+                            "idemp.training.window.activate.homework.bindings",
+                            created_at_ms as i64 + 1_200,
+                            "window.0001",
+                        ),
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(activated.status(), StatusCode::OK);
+
+        let sealed = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/windows/window.0001/seal")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &SealTrainingWindowRequest {
+                            idempotency_key: "idemp.training.window.seal.homework.bindings"
+                                .to_string(),
+                            recorded_at_ms: created_at_ms as i64 + 1_300,
+                            window_id: "window.0001".to_string(),
+                            contribution_outcomes: vec![
+                                training_window_homework_contribution_input_for_lease(
+                                    "contrib.window.homework.bindings",
+                                    &lease,
+                                    "sha256:validator-pending-homework-bindings",
+                                    None,
+                                ),
+                            ],
+                        },
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(sealed.status(), StatusCode::OK);
+
+        let claim = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/validator-challenges/claim")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &training_validator_claim_request(
+                            "idemp.training.validator.claim.homework.bindings",
+                            created_at_ms as i64 + 1_310,
+                            "validator-alpha",
+                            training_run_id,
+                        ),
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(claim.status(), StatusCode::OK);
+        let claim = response_json::<TrainingValidatorChallengeCoordinatorResponse>(claim).await?;
+        assert_eq!(claim.target_bindings.len(), 1);
+        let binding = &claim.target_bindings[0];
+        assert_eq!(binding.assignment_id, lease.assignment_id);
+        assert_eq!(binding.contributor_pylon_id, "node-alpha");
+        assert_eq!(binding.challenge_kind, claim.challenge_kind);
+        assert_eq!(
+            binding.lane_type.as_deref(),
+            Some(super::PSION_CS336_A1_DEMO_LANE_ID)
+        );
+
+        let receipt_binding = binding
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_role == "contribution_receipt")
+            .expect("contribution receipt binding");
+        assert_eq!(
+            receipt_binding.local_path.as_deref(),
+            Some("/tmp/contrib.window.homework.bindings/contribution_receipt.json")
+        );
+        assert_eq!(
+            receipt_binding.digest.as_deref(),
+            Some("sha256:receipt:contrib.window.homework.bindings")
+        );
+
+        let manifest_binding = binding
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_role == "contribution_artifact_manifest")
+            .expect("artifact manifest binding");
+        assert_eq!(
+            manifest_binding.artifact_id.as_deref(),
+            Some("artifact.manifest.contrib.window.homework.bindings")
+        );
+        assert_eq!(
+            manifest_binding.digest.as_deref(),
+            Some("sha256:artifact-manifest:contrib.window.homework.bindings")
+        );
+
+        let local_update_bridge = binding
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_role == "local_update_bridge")
+            .expect("local update bridge binding");
+        assert!(
+            local_update_bridge
+                .object_uri
+                .as_deref()
+                .is_some_and(|uri| uri.contains("adapter_delta_bundle.json"))
+        );
+        assert!(
+            local_update_bridge
+                .signed_read_url
+                .as_deref()
+                .is_some_and(|url| url.contains("X-Goog-Algorithm"))
+        );
+        assert!(
+            local_update_bridge
+                .resolver
+                .as_ref()
+                .is_some_and(|resolver| resolver
+                    .relative_object_path
+                    .contains("adapter_delta_bundle.json"))
+        );
+
+        let proof_bridge = binding
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_role == "proof_bridge")
+            .expect("proof bridge binding");
+        assert!(
+            proof_bridge
+                .object_uri
+                .as_deref()
+                .is_some_and(|uri| uri.contains("proof_bundle.json"))
+        );
+        assert!(
+            proof_bridge
+                .signed_read_url
+                .as_deref()
+                .is_some_and(|url| url.contains("X-Goog-Algorithm"))
+        );
+        assert!(
+            binding
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.artifact_role == "closeout_bundle")
+        );
+        assert!(
+            binding
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.artifact_role == "latest_accepted_checkpoint_pointer")
+        );
+        Ok(())
     }
 
     fn training_validator_claim_request(
@@ -37846,9 +38403,9 @@ mod tests {
         let state = build_app_state(config);
         let app = build_api_router_with_state(state.clone());
 
-        let training_run_id = "run.cs339.hw1.operator";
-        let network_id = "trainnet.cs339.hw1";
-        let window_id = "window.cs339.hw1.operator.0001";
+        let training_run_id = "run.cs336.a1.operator";
+        let network_id = "trainnet.cs336.a1.demo";
+        let window_id = "window.cs336.a1.operator.0001";
         let current_release_id = current_homework_launch_release_id_for_test();
         let current_build_version = current_homework_launch_build_version_for_test();
         let base_time_ms = now_unix_ms();
@@ -37911,15 +38468,15 @@ mod tests {
                     .header("authorization", "Bearer episode224-admin")
                     .header("content-type", "application/json")
                     .body(Body::from(serde_json::to_vec(&LaunchHomeworkRunRequest {
-                        course_id: "cs339".to_string(),
-                        homework_id: "hw1".to_string(),
-                        run_slug: "cs339.hw1".to_string(),
+                        course_id: "cs336".to_string(),
+                        homework_id: "a1".to_string(),
+                        run_slug: "cs336.a1".to_string(),
                         training_run_id: Some(training_run_id.to_string()),
-                        display_name: Some("CS339 Homework 1".to_string()),
+                        display_name: Some("CS336 A1".to_string()),
                         reuse_existing_run: false,
                         network_id: Some(network_id.to_string()),
                         run_kind: Some("homework".to_string()),
-                        assignment_family: Some("cs339.hw1".to_string()),
+                        assignment_family: Some("cs336.a1".to_string()),
                         artifact_prefix: Some(artifact_prefix.clone()),
                         target: super::HomeworkLaunchTargetRequest {
                             only_online: true,
@@ -37987,17 +38544,17 @@ mod tests {
         assert!(
             uploaded_paths
                 .iter()
-                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs339.hw1/runs/run.cs339.hw1.operator/manifests/run_manifest.json"))
+                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs336.a1.demo/runs/run.cs336.a1.operator/manifests/run_manifest.json"))
         );
         assert!(
             uploaded_paths
                 .iter()
-                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs339.hw1/runs/run.cs339.hw1.operator/checkpoints/latest_pointer.json"))
+                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs336.a1.demo/runs/run.cs336.a1.operator/checkpoints/latest_pointer.json"))
         );
         assert!(
             uploaded_paths
                 .iter()
-                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs339.hw1/runs/run.cs339.hw1.operator/checkpoints/step-0/checkpoint_manifest.json"))
+                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs336.a1.demo/runs/run.cs336.a1.operator/checkpoints/step-0/checkpoint_manifest.json"))
         );
 
         {
@@ -38208,13 +38765,13 @@ mod tests {
                             node_pubkey_hex: "node-hw-alpha".to_string(),
                             training_run_id: training_run_id.to_string(),
                             window_id: window_id.to_string(),
-                            checkpoint_ref: "checkpoint://cs339/hw1/final".to_string(),
+                            checkpoint_ref: "checkpoint://cs336/a1/final".to_string(),
                             artifact_locator: format!(
                                 "{artifact_prefix}/checkpoints/step-64/model.safetensors"
                             ),
-                            artifact_digest: "sha256:checkpoint-cs339-hw1".to_string(),
+                            artifact_digest: "sha256:checkpoint-cs336-a1".to_string(),
                             manifest_digest: Some(
-                                "sha256:checkpoint-manifest-cs339-hw1".to_string(),
+                                "sha256:checkpoint-manifest-cs336-a1".to_string(),
                             ),
                         },
                     )?))?,
@@ -38365,7 +38922,7 @@ mod tests {
                             aggregated_delta_digest: Some("sha256:aggregate-homework".to_string()),
                             accepted_aggregate_id: Some("aggregate.homework".to_string()),
                             promoted_checkpoint_ref: Some(
-                                "checkpoint://cs339/hw1/final".to_string(),
+                                "checkpoint://cs336/a1/final".to_string(),
                             ),
                         },
                     )?))?,
@@ -38415,7 +38972,7 @@ mod tests {
             );
             assert!(payout_records.iter().all(|record| {
                 record.classification.accepted_outcome_id.as_deref()
-                    == Some("accepted.training_window.window.cs339.hw1.operator.0001")
+                    == Some("accepted.training_window.window.cs336.a1.operator.0001")
             }));
             assert!(
                 payout_records

--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -44,15 +44,15 @@ use openagents_kernel_core::authority::{
     CreateLiquidityQuoteResponse, CreatePredictionPositionRequest,
     CreatePredictionPositionResponse, CreateRiskClaimRequest, CreateRiskClaimResponse,
     CreateWorkUnitRequest, CreateWorkUnitResponse, ExecuteSettlementIntentRequest,
-    ExecuteSettlementIntentResponse, FinalizeVerdictRequest, FinalizeVerdictResponse,
-    IssueLiquidityEnvelopeRequest, IssueLiquidityEnvelopeResponse, PlaceCoverageOfferRequest,
-    PlaceCoverageOfferResponse, PublishRiskSignalRequest, PublishRiskSignalResponse,
-    RecordComputeAdapterWindowRequest, RecordComputeAdapterWindowResponse,
-    RegisterComputeCheckpointFamilyPolicyRequest, RegisterComputeEnvironmentPackageRequest,
-    RegisterComputeTrainingPolicyRequest, RegisterComputeValidatorPolicyRequest,
-    RegisterReservePartitionRequest, RegisterReservePartitionResponse, ResolveRiskClaimRequest,
-    ResolveRiskClaimResponse, SelectRoutePlanRequest, SelectRoutePlanResponse, SubmitOutputRequest,
-    SubmitOutputResponse,
+    ExecuteSettlementIntentResponse, FinalizeComputeTrainingRunRequest, FinalizeVerdictRequest,
+    FinalizeVerdictResponse, IssueLiquidityEnvelopeRequest, IssueLiquidityEnvelopeResponse,
+    PlaceCoverageOfferRequest, PlaceCoverageOfferResponse, PublishRiskSignalRequest,
+    PublishRiskSignalResponse, RecordComputeAdapterWindowRequest,
+    RecordComputeAdapterWindowResponse, RegisterComputeCheckpointFamilyPolicyRequest,
+    RegisterComputeEnvironmentPackageRequest, RegisterComputeTrainingPolicyRequest,
+    RegisterComputeValidatorPolicyRequest, RegisterReservePartitionRequest,
+    RegisterReservePartitionResponse, ResolveRiskClaimRequest, ResolveRiskClaimResponse,
+    SelectRoutePlanRequest, SelectRoutePlanResponse, SubmitOutputRequest, SubmitOutputResponse,
 };
 use openagents_kernel_core::compute::{
     CapacityInstrumentStatus, CapacityLotStatus, ComputeAcceptedOutcome,
@@ -123,6 +123,7 @@ use psionic_train_contract::{
 use reqwest::Url;
 use ring::rand::SystemRandom;
 use ring::signature::{self, RsaKeyPair};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -160,7 +161,7 @@ use crate::treasury::{
     TreasuryPayoutClassification, TreasuryPayoutPreparation, TreasuryPublicStats,
     TreasuryQueuedPayoutRequest, TreasuryReceiptEvent, TreasuryState, TreasuryStatusResponse,
     TreasuryTrainingPayoutLedgerSummary, create_live_funding_target, dispatch_live_payouts,
-    load_live_wallet_refresh_result_with_plan,
+    load_live_wallet_refresh_result_with_plan, parse_pylon_client_version,
 };
 
 pub use crate::treasury::{
@@ -241,7 +242,6 @@ const EPISODE_224_CS336_A1_DEMO_TRAINING_POLICY_REF: &str = "policy://training/c
 const EPISODE_224_CS336_A1_DEMO_VALIDATOR_POLICY_REF: &str = "policy://validator/mvp/v1";
 const EPISODE_224_CS336_A1_DEMO_CHECKPOINT_FAMILY: &str = "decoder";
 const EPISODE_224_CS336_A1_DEMO_NETWORK_ID: &str = "trainnet.cs336.a1.demo";
-const EPISODE_224_CS336_A1_DEMO_DISPLAY_NAME: &str = "CS336 A1 Demo";
 const EPISODE_224_CS336_A1_DEMO_ARTIFACT_BUCKET_URI: &str = "gs://openagents-training";
 const EPISODE_224_CS336_A1_DEMO_DATASET_REF: &str = "dataset://cs336/assignment1/tinystories-demo";
 const EPISODE_224_CS336_A1_DEMO_DATASET_SLICE_FAMILY: &str =
@@ -988,6 +988,150 @@ struct ErrorResponse {
     reason: String,
 }
 
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeworkAssignmentMode {
+    #[default]
+    AllMatchingPylons,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeworkLaunchTargetRequest {
+    #[serde(default = "homework_launch_only_online_default")]
+    pub only_online: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_pylon_version: Option<String>,
+    #[serde(default = "homework_launch_require_updated_build_default")]
+    pub require_updated_build: bool,
+    #[serde(default)]
+    pub tags_any: Vec<String>,
+    #[serde(default)]
+    pub tags_all: Vec<String>,
+}
+
+impl Default for HomeworkLaunchTargetRequest {
+    fn default() -> Self {
+        Self {
+            only_online: homework_launch_only_online_default(),
+            min_pylon_version: None,
+            require_updated_build: homework_launch_require_updated_build_default(),
+            tags_any: Vec::new(),
+            tags_all: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeworkLaunchAssignmentRequest {
+    #[serde(default)]
+    pub mode: HomeworkAssignmentMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_contributors: Option<u32>,
+    #[serde(default = "homework_launch_window_duration_seconds_default")]
+    pub window_duration_seconds: u64,
+}
+
+impl Default for HomeworkLaunchAssignmentRequest {
+    fn default() -> Self {
+        Self {
+            mode: HomeworkAssignmentMode::default(),
+            max_contributors: None,
+            window_duration_seconds: homework_launch_window_duration_seconds_default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeworkLaunchPayoutRequest {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amount_sats: Option<u64>,
+    #[serde(default = "homework_launch_pay_only_on_accept_default")]
+    pub pay_only_on_accept: bool,
+}
+
+impl Default for HomeworkLaunchPayoutRequest {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            rail: None,
+            amount_sats: None,
+            pay_only_on_accept: homework_launch_pay_only_on_accept_default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeworkLaunchPylonMatch {
+    pub node_pubkey_hex: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_label: Option<String>,
+    pub release_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_version: Option<String>,
+    pub build_digest: String,
+    pub online: bool,
+    pub eligible: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settlement_destination: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeworkLaunchAssignedPylon {
+    #[serde(flatten)]
+    pub node: HomeworkLaunchPylonMatch,
+    pub assignment_id: String,
+    pub lease_id: String,
+    pub assignment_state: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchHomeworkRunRequest {
+    pub course_id: String,
+    pub homework_id: String,
+    pub run_slug: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub training_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(default = "launch_homework_reuse_existing_default")]
+    pub reuse_existing_run: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignment_family: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_prefix: Option<String>,
+    #[serde(default)]
+    pub target: HomeworkLaunchTargetRequest,
+    #[serde(default)]
+    pub assignment: HomeworkLaunchAssignmentRequest,
+    #[serde(default)]
+    pub payout: HomeworkLaunchPayoutRequest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaunchHomeworkRunResponse {
+    pub launched_at_unix_ms: u64,
+    pub launch_state: String,
+    pub training_run_id: String,
+    pub run_status: String,
+    pub current_window_id: String,
+    #[serde(default)]
+    pub matched_pylons: Vec<HomeworkLaunchPylonMatch>,
+    #[serde(default)]
+    pub assigned_pylons: Vec<HomeworkLaunchAssignedPylon>,
+    pub artifact_prefix: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launch_receipt_id: Option<String>,
+    pub run_detail: PublicTrainingRunDetailSnapshot,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LaunchCs336A1DemoRunRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1012,6 +1156,26 @@ pub struct LaunchCs336A1DemoRunResponse {
 }
 
 const fn launch_cs336_a1_demo_reuse_existing_default() -> bool {
+    true
+}
+
+const fn launch_homework_reuse_existing_default() -> bool {
+    false
+}
+
+const fn homework_launch_only_online_default() -> bool {
+    true
+}
+
+const fn homework_launch_require_updated_build_default() -> bool {
+    true
+}
+
+const fn homework_launch_window_duration_seconds_default() -> u64 {
+    1_800
+}
+
+const fn homework_launch_pay_only_on_accept_default() -> bool {
     true
 }
 
@@ -1742,6 +1906,114 @@ struct RecordTrainingRunLeaseResponse {
     window_state: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     network_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct RecordTrainingAssignmentAckRequest {
+    idempotency_key: String,
+    acked_at_ms: i64,
+    node_pubkey_hex: String,
+    training_run_id: String,
+    window_id: String,
+    assignment_id: String,
+    lease_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    manifest_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    manifest_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct RecordTrainingAssignmentAckResponse {
+    ack: TrainingCoordinatorAck,
+    accepted: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lease_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct RecordTrainingDrainNoticeRequest {
+    idempotency_key: String,
+    reported_at_ms: i64,
+    node_pubkey_hex: String,
+    training_run_id: String,
+    window_id: String,
+    assignment_id: String,
+    lease_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct RecordTrainingDrainNoticeResponse {
+    ack: TrainingCoordinatorAck,
+    drain_state: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct RecordTrainingFailureNoticeRequest {
+    idempotency_key: String,
+    reported_at_ms: i64,
+    node_pubkey_hex: String,
+    training_run_id: String,
+    window_id: String,
+    assignment_id: String,
+    lease_id: String,
+    failure_reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    failure_receipt_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct RecordTrainingFailureNoticeResponse {
+    ack: TrainingCoordinatorAck,
+    failure_state: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct RecordTrainingWindowProgressRequest {
+    idempotency_key: String,
+    recorded_at_ms: i64,
+    node_pubkey_hex: String,
+    training_run_id: String,
+    window_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    assignment_id: Option<String>,
+    window_state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    completed_step_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    local_checkpoint_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct RecordTrainingWindowProgressResponse {
+    ack: TrainingCoordinatorAck,
+    window_state: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct PublishTrainingCheckpointRequest {
+    idempotency_key: String,
+    published_at_ms: i64,
+    node_pubkey_hex: String,
+    training_run_id: String,
+    window_id: String,
+    checkpoint_ref: String,
+    artifact_locator: String,
+    artifact_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    manifest_digest: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct PublishTrainingCheckpointResponse {
+    ack: TrainingCoordinatorAck,
+    checkpoint_state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    artifact_locator: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3471,6 +3743,94 @@ impl ScheduledTrainingRun {
         }
     }
 
+    fn bind_launch_worker_assignments(
+        &mut self,
+        nodes: &[AdmittedTrainingNodeView],
+        issued_at_ms: i64,
+    ) -> Result<Vec<ScheduledTrainingAssignment>, String> {
+        if nodes.is_empty() {
+            return Err("training_scheduler_launch_assignments_missing".to_string());
+        }
+        let worker_target_count =
+            usize::try_from(self.role_plan.worker_count).unwrap_or(usize::MAX);
+        if nodes.len() > worker_target_count {
+            return Err("training_scheduler_launch_assignments_exceed_worker_target".to_string());
+        }
+        if self.assignments.iter().any(|assignment| {
+            assignment.role == TrainingNodeRoleClaim::Worker
+                && assignment.state != TrainingAssignmentState::Planned
+        }) {
+            return Err("training_scheduler_launch_assignments_already_bound".to_string());
+        }
+        let membership_revision = self.membership_revision.max(1);
+        let expires_at_ms = issued_at_ms.saturating_add(PYLON_TRAINING_LEASE_DURATION_MS as i64);
+        let mut bound = Vec::with_capacity(nodes.len());
+        for (offset, node) in nodes.iter().enumerate() {
+            let slot_ordinal = u32::try_from(offset + 1).unwrap_or(u32::MAX);
+            let Some(assignment_index) = self.assignments.iter().position(|assignment| {
+                assignment.role == TrainingNodeRoleClaim::Worker
+                    && assignment.slot_ordinal == slot_ordinal
+                    && assignment.state == TrainingAssignmentState::Planned
+            }) else {
+                return Err("training_scheduler_launch_assignment_missing".to_string());
+            };
+            let assignment = &mut self.assignments[assignment_index];
+            let lease_id = pylon_training_lease_id(
+                self.training_run_id.as_str(),
+                self.current_window_id.as_str(),
+                assignment.role.label(),
+                assignment.slot_ordinal,
+                assignment.attempt,
+                membership_revision,
+            );
+            let manifest_digest = pylon_training_manifest_binding_digest(
+                self.training_run_id.as_str(),
+                self.current_window_id.as_str(),
+                membership_revision,
+                node.node_pubkey_hex.as_str(),
+                assignment.assignment_id.as_str(),
+                assignment.role.label(),
+                self.artifact_bucket_uri.as_str(),
+            );
+            assignment.state = TrainingAssignmentState::Leased;
+            assignment.node_pubkey_hex = Some(node.node_pubkey_hex.clone());
+            assignment.lease_id = Some(lease_id);
+            assignment.issued_at_ms = Some(issued_at_ms);
+            assignment.expires_at_ms = Some(expires_at_ms);
+            assignment.manifest_digest = Some(manifest_digest);
+            bound.push(assignment.clone());
+        }
+        self.lease_issue_count = self
+            .lease_issue_count
+            .saturating_add(u64::try_from(nodes.len()).unwrap_or(u64::MAX));
+        self.updated_at_ms = issued_at_ms;
+        Ok(bound)
+    }
+
+    fn assignment_for_binding_mut(
+        &mut self,
+        assignment_id: &str,
+        lease_id: &str,
+        node_pubkey_hex: &str,
+    ) -> Option<&mut ScheduledTrainingAssignment> {
+        self.assignments.iter_mut().find(|assignment| {
+            assignment.assignment_id == assignment_id
+                && assignment.lease_id.as_deref() == Some(lease_id)
+                && assignment.node_pubkey_hex.as_deref() == Some(node_pubkey_hex)
+        })
+    }
+
+    fn assignment_for_id_mut(
+        &mut self,
+        assignment_id: &str,
+        node_pubkey_hex: &str,
+    ) -> Option<&mut ScheduledTrainingAssignment> {
+        self.assignments.iter_mut().find(|assignment| {
+            assignment.assignment_id == assignment_id
+                && assignment.node_pubkey_hex.as_deref() == Some(node_pubkey_hex)
+        })
+    }
+
     fn refresh_from_kernel_run(
         &mut self,
         run: &ComputeTrainingRun,
@@ -4226,6 +4586,42 @@ fn training_window_active_worker_assignments(
     training_window_active_assignments_for_role(scheduled_run, TrainingNodeRoleClaim::Worker)
 }
 
+fn training_scheduler_window_state_from_label(value: &str) -> Option<TrainingSchedulerWindowState> {
+    match value.trim() {
+        "planned" => Some(TrainingSchedulerWindowState::Planned),
+        "active" => Some(TrainingSchedulerWindowState::Active),
+        "sealing" => Some(TrainingSchedulerWindowState::Sealing),
+        "sealed" => Some(TrainingSchedulerWindowState::Sealed),
+        "validating" => Some(TrainingSchedulerWindowState::Validating),
+        "accepted" => Some(TrainingSchedulerWindowState::Accepted),
+        "held" => Some(TrainingSchedulerWindowState::Held),
+        "refused" => Some(TrainingSchedulerWindowState::Refused),
+        _ => None,
+    }
+}
+
+fn training_assignment_state_from_heartbeat(
+    desired_state: kernel::TrainingNodeDesiredState,
+    process_state: kernel::TrainingNodeProcessState,
+    last_exit_code: Option<i32>,
+) -> TrainingAssignmentState {
+    match (desired_state, process_state, last_exit_code) {
+        (_, kernel::TrainingNodeProcessState::Failed, _) => TrainingAssignmentState::Failed,
+        (
+            kernel::TrainingNodeDesiredState::Draining,
+            kernel::TrainingNodeProcessState::Draining,
+            _,
+        ) => TrainingAssignmentState::Drained,
+        (_, kernel::TrainingNodeProcessState::Stopped, Some(0)) => {
+            TrainingAssignmentState::Completed
+        }
+        (_, kernel::TrainingNodeProcessState::Stopped, Some(_)) => TrainingAssignmentState::Failed,
+        (_, kernel::TrainingNodeProcessState::Running, _) => TrainingAssignmentState::Active,
+        (_, kernel::TrainingNodeProcessState::Launching, _) => TrainingAssignmentState::Acked,
+        _ => TrainingAssignmentState::Acked,
+    }
+}
+
 fn training_scheduler_role_overlap_reason(
     existing_role: TrainingNodeRoleClaim,
     requested_role: TrainingNodeRoleClaim,
@@ -4478,6 +4874,7 @@ fn training_validation_witness() -> Result<validator_service::GpuFreivaldsMerkle
 fn training_validation_schedule_request(
     window: &ComputeAdapterTrainingWindow,
     challenge_plan: &TrainingWindowValidationChallengePlan,
+    product_id: &str,
     validator_pool_ref: &str,
     proof_bundle_digest: &str,
     request_digest: &str,
@@ -4491,7 +4888,7 @@ fn training_validation_schedule_request(
         challenge_id,
         proof_bundle_digest,
         request_digest,
-        window.adapter_target_id.as_str(),
+        normalize_required_training_string(product_id, "compute_product_id_missing")?,
         "psionic_train",
         created_at_ms,
     )
@@ -6074,6 +6471,7 @@ fn training_window_counts(
 fn training_window_validation_state_for_seal(
     window: &ComputeAdapterTrainingWindow,
     contribution_inputs: &[TrainingWindowContributionInput],
+    product_id: &str,
     validator_pool_ref: &str,
     recorded_at_ms: i64,
 ) -> Result<
@@ -6122,6 +6520,7 @@ fn training_window_validation_state_for_seal(
     requests.push(training_validation_schedule_request(
         window,
         &aggregate_plan,
+        product_id,
         validator_pool_ref,
         window.window_summary_digest.as_str(),
         window.window_summary_digest.as_str(),
@@ -6150,6 +6549,7 @@ fn training_window_validation_state_for_seal(
         requests.push(training_validation_schedule_request(
             window,
             &plan,
+            product_id,
             validator_pool_ref,
             input.provenance_bundle_digest.as_str(),
             input.manifest_digest.as_str(),
@@ -7089,6 +7489,23 @@ fn build_api_router_with_state(state: AppState) -> Router {
             post(record_training_node_heartbeat),
         )
         .route("/api/training/leases/claim", post(claim_training_run_lease))
+        .route(
+            "/api/training/assignments/ack",
+            post(record_training_assignment_ack),
+        )
+        .route("/api/training/drains", post(record_training_drain_notice))
+        .route(
+            "/api/training/failures",
+            post(record_training_failure_notice),
+        )
+        .route(
+            "/api/training/windows/progress",
+            post(record_training_window_progress),
+        )
+        .route(
+            "/api/training/checkpoints/publish",
+            post(publish_training_checkpoint),
+        )
         .route("/api/training/windows/plan", post(plan_training_window))
         .route(
             "/api/training/windows/{window_id}/activate",
@@ -7127,6 +7544,8 @@ fn build_api_router_with_state(state: AppState) -> Router {
             get(get_training_run_detail),
         )
         .route("/api/training/summary", get(training_operator_summary))
+        .route("/api/admin/homework/launch", post(launch_homework_run))
+        .route("/v1/admin/homework/launch", post(launch_homework_run))
         .route(
             "/v1/admin/training/demo-runs/cs336-a1/launch",
             post(launch_cs336_a1_demo_run),
@@ -7600,48 +8019,1098 @@ async fn get_training_run_detail(
 }
 
 #[derive(Debug, Clone)]
-struct Cs336A1DemoLaunchResult {
+struct HomeworkLaunchPrepared {
     training_run_id: String,
+    network_id: String,
+    current_window_id: String,
     launch_state: String,
+    run_status: String,
+    launch_receipt_id: Option<String>,
     lane_contract: PsionicTrainLaneContract,
+    matched_pylons: Vec<HomeworkLaunchPylonMatch>,
+    assigned_pylons: Vec<HomeworkLaunchAssignedPylon>,
+    artifact_bucket_uri: String,
+    artifact_prefix: String,
+    course_id: String,
+    homework_id: String,
+    assignment_family: String,
+    run_kind: String,
+    needs_window_materialization: bool,
     receipt_event: Option<ReceiptProjectionEvent>,
     snapshot_event: Option<SnapshotProjectionEvent>,
 }
 
-async fn launch_cs336_a1_demo_run(
+fn current_homework_launch_pylon_version() -> Version {
+    Version::parse(env!("CARGO_PKG_VERSION")).unwrap_or_else(|_| Version::new(0, 0, 0))
+}
+
+fn current_homework_launch_pylon_release_id() -> String {
+    format!("openagents.pylon@{}", env!("CARGO_PKG_VERSION"))
+}
+
+fn homework_launch_node_version(node: &AdmittedTrainingNodeView) -> Option<Version> {
+    node.build_version
+        .as_deref()
+        .or(Some(node.release_id.as_str()))
+        .and_then(|value| parse_pylon_client_version(value).ok())
+}
+
+fn homework_launch_node_is_current(node: &AdmittedTrainingNodeView) -> bool {
+    homework_launch_node_version(node)
+        .is_some_and(|version| version == current_homework_launch_pylon_version())
+        || node.release_id == current_homework_launch_pylon_release_id()
+}
+
+fn homework_launch_tags_match(
+    node: &AdmittedTrainingNodeView,
+    target: &HomeworkLaunchTargetRequest,
+) -> bool {
+    (target.tags_any.is_empty()
+        || target.tags_any.iter().any(|tag| {
+            node.active_reputation_labels
+                .iter()
+                .any(|label| label == tag)
+        }))
+        && target.tags_all.iter().all(|tag| {
+            node.active_reputation_labels
+                .iter()
+                .any(|label| label == tag)
+        })
+}
+
+fn homework_launch_node_target_matches(
+    node: &AdmittedTrainingNodeView,
+    target: &HomeworkLaunchTargetRequest,
+    payout: &HomeworkLaunchPayoutRequest,
+    minimum_version: Option<&Version>,
+) -> bool {
+    if target.only_online && !node.online {
+        return false;
+    }
+    if !node.eligible
+        || matches!(
+            node.last_desired_state,
+            Some(
+                kernel::TrainingNodeDesiredState::Draining
+                    | kernel::TrainingNodeDesiredState::Stopped
+            )
+        )
+        || matches!(
+            node.last_process_state,
+            Some(
+                kernel::TrainingNodeProcessState::Draining
+                    | kernel::TrainingNodeProcessState::Stopped
+                    | kernel::TrainingNodeProcessState::Failed
+            )
+        )
+    {
+        return false;
+    }
+    if payout.enabled && node.settlement_destination.is_none() {
+        return false;
+    }
+    if target.require_updated_build && !homework_launch_node_is_current(node) {
+        return false;
+    }
+    if let Some(minimum_version) = minimum_version {
+        if homework_launch_node_version(node).is_none_or(|version| version < *minimum_version) {
+            return false;
+        }
+    }
+    homework_launch_tags_match(node, target)
+}
+
+fn homework_launch_pylon_match(node: &AdmittedTrainingNodeView) -> HomeworkLaunchPylonMatch {
+    HomeworkLaunchPylonMatch {
+        node_pubkey_hex: node.node_pubkey_hex.clone(),
+        node_label: node.node_label.clone(),
+        release_id: node.release_id.clone(),
+        build_version: node.build_version.clone(),
+        build_digest: node.build_digest.clone(),
+        online: node.online,
+        eligible: node.eligible,
+        settlement_destination: node.settlement_destination.clone(),
+    }
+}
+
+fn homework_launch_assigned_pylons(
+    scheduled_run: &ScheduledTrainingRun,
+    nodes_by_pubkey: &HashMap<String, AdmittedTrainingNodeView>,
+) -> Vec<HomeworkLaunchAssignedPylon> {
+    training_window_active_worker_assignments(scheduled_run)
+        .into_iter()
+        .map(|assignment| {
+            let node = assignment
+                .node_pubkey_hex
+                .as_deref()
+                .and_then(|node_pubkey_hex| nodes_by_pubkey.get(node_pubkey_hex))
+                .map(homework_launch_pylon_match)
+                .unwrap_or_else(|| HomeworkLaunchPylonMatch {
+                    node_pubkey_hex: assignment.node_pubkey_hex.clone().unwrap_or_default(),
+                    node_label: None,
+                    release_id: String::new(),
+                    build_version: None,
+                    build_digest: String::new(),
+                    online: false,
+                    eligible: false,
+                    settlement_destination: None,
+                });
+            HomeworkLaunchAssignedPylon {
+                node,
+                assignment_id: assignment.assignment_id,
+                lease_id: assignment.lease_id.unwrap_or_default(),
+                assignment_state: assignment.state.label().to_string(),
+            }
+        })
+        .collect()
+}
+
+fn build_homework_training_run_id(
+    now_unix_ms: u64,
+    course_id: &str,
+    homework_id: &str,
+    run_slug: &str,
+) -> String {
+    let timestamp = Utc
+        .timestamp_millis_opt(now_unix_ms as i64)
+        .single()
+        .map(|value| value.format("%Y%m%d%H%M%S").to_string())
+        .unwrap_or_else(|| now_unix_ms.to_string());
+    let suffix = random_token().chars().take(8).collect::<String>();
+    format!(
+        "run.{}.{}.{}.{}.{}",
+        sanitize_identifier(course_id),
+        sanitize_identifier(homework_id),
+        sanitize_identifier(run_slug),
+        timestamp,
+        suffix
+    )
+}
+
+fn build_homework_default_display_name(
+    course_id: &str,
+    homework_id: &str,
+    run_slug: &str,
+) -> String {
+    format!("{course_id} {homework_id} {run_slug}")
+}
+
+fn build_homework_default_network_id(course_id: &str, homework_id: &str, run_slug: &str) -> String {
+    format!(
+        "trainnet.{}.{}.{}",
+        sanitize_identifier(course_id),
+        sanitize_identifier(homework_id),
+        sanitize_identifier(run_slug)
+    )
+}
+
+fn homework_initial_window_id(training_run_id: &str) -> String {
+    if let Some(suffix) = training_run_id.strip_prefix("run.") {
+        return format!("window.{suffix}.0001");
+    }
+    format!("window.{}.0001", sanitize_identifier(training_run_id))
+}
+
+fn homework_artifact_prefix(
+    artifact_bucket_uri: &str,
+    network_id: &str,
+    training_run_id: &str,
+) -> String {
+    format!(
+        "{}/networks/{network_id}/runs/{training_run_id}",
+        artifact_bucket_uri.trim_end_matches('/')
+    )
+}
+
+fn homework_launch_artifact_bucket_uri_and_prefix(
+    config: &ServiceConfig,
+    requested_artifact_prefix: Option<&str>,
+    network_id: &str,
+    training_run_id: &str,
+) -> Result<(String, String), ApiError> {
+    let expected_suffix = format!("networks/{network_id}/runs/{training_run_id}");
+    let default_bucket_uri = cs336_a1_demo_artifact_bucket_uri(config);
+    let default_prefix =
+        homework_artifact_prefix(default_bucket_uri.as_str(), network_id, training_run_id);
+    let Some(requested_artifact_prefix) = requested_artifact_prefix
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok((default_bucket_uri, default_prefix));
+    };
+
+    let normalized = requested_artifact_prefix.trim_end_matches('/');
+    let Some(bucket_and_path) = normalized.strip_prefix("gs://") else {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_artifact_prefix_invalid".to_string(),
+        });
+    };
+    let Some((bucket_name, object_path)) = bucket_and_path.split_once('/') else {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_artifact_prefix_invalid".to_string(),
+        });
+    };
+    if bucket_name.trim().is_empty() || object_path.trim().is_empty() {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_artifact_prefix_invalid".to_string(),
+        });
+    }
+    if object_path.trim_matches('/') != expected_suffix {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_artifact_prefix_mismatch".to_string(),
+        });
+    }
+    let artifact_bucket_uri = format!("gs://{bucket_name}");
+    Ok((
+        artifact_bucket_uri.clone(),
+        homework_artifact_prefix(artifact_bucket_uri.as_str(), network_id, training_run_id),
+    ))
+}
+
+fn homework_launch_effective_payout_amount_sats(
+    config: &ServiceConfig,
+    payout: &HomeworkLaunchPayoutRequest,
+) -> u64 {
+    if !payout.enabled {
+        return 0;
+    }
+    payout
+        .amount_sats
+        .unwrap_or(config.treasury.payout_sats_per_window)
+}
+
+fn training_run_homework_launch_metadata(training_run: &ComputeTrainingRun) -> Option<&Value> {
+    training_run.metadata.get("homework_launch")
+}
+
+fn training_run_homework_window_duration_seconds(training_run: &ComputeTrainingRun) -> u64 {
+    training_run_homework_launch_metadata(training_run)
+        .and_then(|value| value.get("assignment"))
+        .and_then(|value| value.get("window_duration_seconds"))
+        .and_then(Value::as_u64)
+        .filter(|value| *value > 0)
+        .unwrap_or(PYLON_TRAINING_WINDOW_MAX_DURATION_MS / 1_000)
+}
+
+fn training_run_homework_payout_amount_sats(
+    training_run: &ComputeTrainingRun,
+    default_amount_sats: u64,
+) -> u64 {
+    let Some(payout_policy) =
+        training_run_homework_launch_metadata(training_run).and_then(|value| value.get("payout"))
+    else {
+        return default_amount_sats;
+    };
+    if payout_policy.get("enabled").and_then(Value::as_bool) == Some(false) {
+        return 0;
+    }
+    payout_policy
+        .get("amount_sats")
+        .and_then(Value::as_u64)
+        .unwrap_or(default_amount_sats)
+}
+
+fn homework_scheduler_metadata(
+    artifact_bucket_uri: &str,
+    initial_window_id: &str,
+    network_id: &str,
+    worker_count: u32,
+) -> Result<Value, String> {
+    serde_json::to_value(TrainingSchedulerRunMetadata {
+        network_id: network_id.to_string(),
+        artifact_bucket_uri: artifact_bucket_uri.to_string(),
+        worker_count: worker_count.max(1),
+        validator_count: 0,
+        recovery_source_count: 0,
+        initial_window_id: Some(initial_window_id.to_string()),
+        checkpoint_ref: Some(EPISODE_224_CS336_A1_DEMO_DEFAULT_BASE_CHECKPOINT_REF.to_string()),
+    })
+    .map_err(|error| format!("homework_scheduler_metadata_invalid:{error}"))
+}
+
+fn homework_training_run_request(
+    lane_contract: &PsionicTrainLaneContract,
+    config: &ServiceConfig,
+    now_unix_ms: u64,
+    training_run_id: &str,
+    display_name: &str,
+    network_id: &str,
+    course_id: &str,
+    homework_id: &str,
+    run_slug: &str,
+    run_kind: &str,
+    assignment_family: &str,
+    artifact_bucket_uri: &str,
+    artifact_prefix: &str,
+    target: &HomeworkLaunchTargetRequest,
+    assignment: &HomeworkLaunchAssignmentRequest,
+    payout: &HomeworkLaunchPayoutRequest,
+    worker_target_count: u32,
+) -> Result<CreateComputeTrainingRunRequest, String> {
+    let initial_window_id = homework_initial_window_id(training_run_id);
+    let scheduler_metadata = homework_scheduler_metadata(
+        artifact_bucket_uri,
+        initial_window_id.as_str(),
+        network_id,
+        worker_target_count,
+    )?;
+    let payout_amount_sats = homework_launch_effective_payout_amount_sats(config, payout);
+    Ok(CreateComputeTrainingRunRequest {
+        idempotency_key: format!(
+            "idemp.admin.homework.launch.{}",
+            sanitize_identifier(training_run_id)
+        ),
+        trace: TraceContext::default(),
+        policy: PolicyContext::default(),
+        training_run: ComputeTrainingRun {
+            training_run_id: training_run_id.to_string(),
+            training_policy_ref: EPISODE_224_CS336_A1_DEMO_TRAINING_POLICY_REF.to_string(),
+            environment_binding: ComputeEnvironmentBinding {
+                environment_ref: lane_contract.environment_ref.clone(),
+                environment_version: None,
+                dataset_ref: None,
+                rubric_ref: None,
+                evaluator_policy_ref: None,
+            },
+            checkpoint_binding: ComputeCheckpointBinding {
+                checkpoint_family: EPISODE_224_CS336_A1_DEMO_CHECKPOINT_FAMILY.to_string(),
+                latest_checkpoint_ref: Some(
+                    EPISODE_224_CS336_A1_DEMO_DEFAULT_BASE_CHECKPOINT_REF.to_string(),
+                ),
+                recovery_posture: Some("warm-resume".to_string()),
+            },
+            validator_policy_ref: EPISODE_224_CS336_A1_DEMO_VALIDATOR_POLICY_REF.to_string(),
+            work_class: ComputeTrainingWorkClass::SmallModelLocalTraining,
+            replica_type: ComputeTrainingReplicaType::SingleNode,
+            benchmark_package_refs: Vec::new(),
+            product_id: Some("psionic.training.homework".to_string()),
+            capacity_lot_id: None,
+            instrument_id: None,
+            delivery_proof_id: None,
+            model_ref: Some("model://psion/cs336-assignment1-demo".to_string()),
+            source_ref: Some(EPISODE_224_CS336_A1_DEMO_DATASET_REF.to_string()),
+            rollout_verification_eval_run_ids: Vec::new(),
+            created_at_ms: now_unix_ms as i64,
+            started_at_ms: Some(now_unix_ms as i64),
+            finalized_at_ms: None,
+            expected_step_count: Some(64),
+            completed_step_count: None,
+            status: ComputeTrainingRunStatus::Running,
+            final_checkpoint_ref: None,
+            promotion_checkpoint_ref: None,
+            summary: None,
+            metadata: json!({
+                "display_name": display_name,
+                "course_id": course_id,
+                "homework_id": homework_id,
+                "run_slug": run_slug,
+                "run_kind": run_kind,
+                "assignment_family": assignment_family,
+                "artifact_prefix": artifact_prefix,
+                "lane_id": lane_contract.lane_id,
+                "release_id": lane_contract.release_id,
+                "backend_family": lane_contract.backend_family,
+                "topology_class": lane_contract.topology_class,
+                "minimum_machine_class": lane_contract.minimum_machine_class.label(),
+                "pylon_training_scheduler": scheduler_metadata,
+                "homework_launch": {
+                    "artifact_prefix": artifact_prefix,
+                    "assignment": {
+                        "mode": assignment.mode,
+                        "max_contributors": assignment.max_contributors,
+                        "window_duration_seconds": assignment.window_duration_seconds,
+                    },
+                    "payout": {
+                        "enabled": payout.enabled,
+                        "rail": payout.rail.clone(),
+                        "amount_sats": payout_amount_sats,
+                        "pay_only_on_accept": payout.pay_only_on_accept,
+                    },
+                    "target": {
+                        "only_online": target.only_online,
+                        "min_pylon_version": target.min_pylon_version.clone(),
+                        "require_updated_build": target.require_updated_build,
+                        "tags_any": target.tags_any.clone(),
+                        "tags_all": target.tags_all.clone(),
+                    }
+                },
+            }),
+        },
+        evidence: Vec::new(),
+        hints: ReceiptHints::default(),
+    })
+}
+
+fn homework_window_plan_request(
+    training_run: &ComputeTrainingRun,
+    scheduled_run: &ScheduledTrainingRun,
+    course_id: &str,
+    homework_id: &str,
+    assignment_family: &str,
+    run_kind: &str,
+    recorded_at_ms: i64,
+) -> Result<PlanTrainingWindowRequest, String> {
+    let checkpoint_ref = training_run
+        .checkpoint_binding
+        .latest_checkpoint_ref
+        .clone()
+        .unwrap_or_else(|| EPISODE_224_CS336_A1_DEMO_DEFAULT_BASE_CHECKPOINT_REF.to_string());
+    let dataset_id = training_run
+        .source_ref
+        .clone()
+        .unwrap_or_else(|| EPISODE_224_CS336_A1_DEMO_DATASET_REF.to_string());
+    let dataset_slices = training_window_active_worker_assignments(scheduled_run)
+        .into_iter()
+        .map(|assignment| ComputeAdapterDatasetSlice {
+            dataset_id: dataset_id.clone(),
+            split_name: "train".to_string(),
+            slice_id: format!(
+                "{}.worker.{:04}",
+                sanitize_identifier(scheduled_run.training_run_id.as_str()),
+                assignment.slot_ordinal
+            ),
+            slice_digest: sha256_prefixed_bytes(
+                format!(
+                    "{}:{}:{}:{}",
+                    scheduled_run.training_run_id,
+                    scheduled_run.current_window_id,
+                    assignment.assignment_id,
+                    assignment.slot_ordinal
+                )
+                .as_bytes(),
+            ),
+        })
+        .collect::<Vec<_>>();
+    Ok(PlanTrainingWindowRequest {
+        idempotency_key: format!(
+            "idemp.admin.homework.window.plan.{}",
+            sanitize_identifier(training_run.training_run_id.as_str())
+        ),
+        recorded_at_ms,
+        training_run_id: training_run.training_run_id.clone(),
+        stage_id: format!(
+            "stage.{}.{}.{}",
+            sanitize_identifier(course_id),
+            sanitize_identifier(homework_id),
+            sanitize_identifier(run_kind)
+        ),
+        round_index: Some(1),
+        base_checkpoint_ref: checkpoint_ref.clone(),
+        planned_local_step_count: training_run.expected_step_count,
+        aggregation_rule: None,
+        aggregation_weight_basis: None,
+        adapter_target_id: String::new(),
+        adapter_family: String::new(),
+        base_model_ref: training_run
+            .model_ref
+            .clone()
+            .unwrap_or_else(|| "model://psion/cs336-assignment1-demo".to_string()),
+        adapter_format: String::new(),
+        source_policy_revision: ComputeAdapterPolicyRevision {
+            policy_family: format!(
+                "policy.family.{}.{}",
+                sanitize_identifier(course_id),
+                sanitize_identifier(assignment_family)
+            ),
+            revision_id: format!(
+                "policy.rev.{}.{}.{}",
+                sanitize_identifier(course_id),
+                sanitize_identifier(homework_id),
+                sanitize_identifier(training_run.training_run_id.as_str())
+            ),
+            revision_number: Some(1),
+            policy_digest: sha256_prefixed_bytes(
+                format!(
+                    "{}:{}:{}:{}",
+                    course_id, homework_id, assignment_family, training_run.training_run_id
+                )
+                .as_bytes(),
+            ),
+            parent_revision_id: None,
+            produced_at_ms: recorded_at_ms,
+        },
+        source_checkpoint_pointer: ComputeAdapterCheckpointPointer {
+            scope_kind: "training_run".to_string(),
+            scope_id: training_run.training_run_id.clone(),
+            checkpoint_family: training_run.checkpoint_binding.checkpoint_family.clone(),
+            checkpoint_ref: checkpoint_ref.clone(),
+            manifest_digest: sha256_prefixed_bytes(checkpoint_ref.as_bytes()),
+            updated_at_ms: recorded_at_ms,
+            pointer_digest: sha256_prefixed_bytes(
+                format!("{}:{checkpoint_ref}:source", training_run.training_run_id).as_bytes(),
+            ),
+        },
+        dataset_slices,
+    })
+}
+
+fn persist_active_homework_window(
+    store: &mut ControlStore,
+    training_run_id: &str,
+    course_id: &str,
+    homework_id: &str,
+    assignment_family: &str,
+    run_kind: &str,
+    recorded_at_ms: i64,
+) -> Result<(), String> {
+    let training_run = store
+        .kernel
+        .get_compute_training_run(training_run_id)
+        .ok_or_else(|| "compute_training_run_not_found".to_string())?;
+    let scheduled_run = store
+        .training_scheduler
+        .runs_by_training_run_id
+        .get(training_run_id)
+        .cloned()
+        .ok_or_else(|| "training_window_scheduler_run_not_found".to_string())?;
+    let planned_request = homework_window_plan_request(
+        &training_run,
+        &scheduled_run,
+        course_id,
+        homework_id,
+        assignment_family,
+        run_kind,
+        recorded_at_ms,
+    )?;
+    let assignment_plans = training_window_assignment_plans(
+        &scheduled_run,
+        planned_request.dataset_slices.as_slice(),
+        pylon_training_membership_revision_label(scheduled_run.membership_revision).as_str(),
+    )?;
+    let metadata = TrainingWindowMetadata {
+        network_id: scheduled_run.network_id.clone(),
+        artifact_bucket_uri: scheduled_run.artifact_bucket_uri.clone(),
+        environment_ref: training_run.environment_binding.environment_ref.clone(),
+        backend_family: training_backend_family_for_environment_ref(
+            training_run.environment_binding.environment_ref.as_str(),
+        )
+        .unwrap_or_default()
+        .to_string(),
+        membership_revision: pylon_training_membership_revision_label(
+            scheduled_run.membership_revision,
+        ),
+        assignment_plans,
+        validation: None,
+        planned_at_ms: recorded_at_ms,
+        activated_at_ms: Some(recorded_at_ms),
+        sealed_at_ms: None,
+        reconciled_at_ms: None,
+        defensibility: None,
+        seal_deadline_ms: recorded_at_ms.saturating_add(
+            i64::try_from(
+                training_run_homework_window_duration_seconds(&training_run)
+                    .saturating_mul(1_000)
+                    .saturating_add(PYLON_TRAINING_SEAL_GRACE_PERIOD_MS),
+            )
+            .unwrap_or(i64::MAX),
+        ),
+    };
+    let window = training_window_base_record(
+        &training_run,
+        &scheduled_run,
+        &planned_request,
+        metadata,
+        ComputeAdapterWindowStatus::Active,
+        recorded_at_ms,
+    )?;
+    let caller_id = format!("admin:homework_launch:{training_run_id}");
+    store.kernel.record_compute_adapter_window(
+        &training_kernel_mutation_context(caller_id.as_str(), recorded_at_ms as u64),
+        training_window_record_request(planned_request.idempotency_key, window, Vec::new()),
+    )?;
+    if let Some(scheduled_run) = store
+        .training_scheduler
+        .runs_by_training_run_id
+        .get_mut(training_run_id)
+    {
+        scheduled_run.window_state = TrainingSchedulerWindowState::Active;
+        scheduled_run.updated_at_ms = recorded_at_ms;
+    }
+    store.persist_training_scheduler_state()?;
+    Ok(())
+}
+
+fn mark_homework_launch_failed(
+    store: &mut ControlStore,
+    training_run_id: &str,
+    finalized_at_ms: i64,
+    reason: &str,
+) {
+    store
+        .training_scheduler
+        .runs_by_training_run_id
+        .remove(training_run_id);
+    let _ = store.persist_training_scheduler_state();
+    if store
+        .kernel
+        .get_compute_training_run(training_run_id)
+        .is_some()
+    {
+        let _ = store.kernel.finalize_compute_training_run(
+            &training_kernel_mutation_context(
+                "admin:homework_launch_failure",
+                finalized_at_ms as u64,
+            ),
+            FinalizeComputeTrainingRunRequest {
+                idempotency_key: format!(
+                    "idemp.admin.homework.launch.fail.{}",
+                    sanitize_identifier(training_run_id)
+                ),
+                trace: TraceContext::default(),
+                policy: PolicyContext::default(),
+                training_run_id: training_run_id.to_string(),
+                status: ComputeTrainingRunStatus::Failed,
+                finalized_at_ms,
+                final_checkpoint_ref: None,
+                promotion_checkpoint_ref: None,
+                summary: None,
+                metadata: json!({
+                    "homework_launch_failure": reason,
+                }),
+                evidence: Vec::new(),
+                hints: ReceiptHints::default(),
+            },
+        );
+    }
+}
+
+fn prepare_homework_launch(
+    config: &ServiceConfig,
+    store: &mut ControlStore,
+    now_unix_ms: u64,
+    mut request: LaunchHomeworkRunRequest,
+) -> Result<HomeworkLaunchPrepared, ApiError> {
+    let course_id = normalize_required_field(request.course_id.as_str(), "course_id_missing")?;
+    let homework_id =
+        normalize_required_field(request.homework_id.as_str(), "homework_id_missing")?;
+    let run_slug = normalize_required_field(request.run_slug.as_str(), "run_slug_missing")?;
+    request.network_id = request
+        .network_id
+        .take()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    request.training_run_id = request
+        .training_run_id
+        .take()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    request.target.tags_any = normalize_string_vec(request.target.tags_any);
+    request.target.tags_all = normalize_string_vec(request.target.tags_all);
+    let assignment_family = request
+        .assignment_family
+        .take()
+        .unwrap_or_else(|| format!("{course_id}.{homework_id}"));
+    if request.assignment.window_duration_seconds == 0 {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_window_duration_invalid".to_string(),
+        });
+    }
+    if request.payout.enabled
+        && request
+            .payout
+            .rail
+            .as_deref()
+            .is_some_and(|rail| rail != "bitcoin_lightning")
+    {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_payout_rail_unsupported".to_string(),
+        });
+    }
+    if request.payout.enabled && !request.payout.pay_only_on_accept {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_pay_only_on_accept_required".to_string(),
+        });
+    }
+    let run_kind = request
+        .run_kind
+        .take()
+        .unwrap_or_else(|| "homework".to_string());
+    let network_id = request
+        .network_id
+        .clone()
+        .unwrap_or_else(|| build_homework_default_network_id(&course_id, &homework_id, &run_slug));
+    let display_name = request.display_name.take().unwrap_or_else(|| {
+        build_homework_default_display_name(&course_id, &homework_id, &run_slug)
+    });
+    let lane_contract = PsionicTrainLaneContract::for_lane(PSION_CS336_A1_DEMO_LANE_ID)
+        .map_err(|error| kernel_api_error(format!("homework_lane_contract_invalid:{error}")))?;
+    ensure_cs336_a1_demo_registry_contracts(store, now_unix_ms, &lane_contract)
+        .map_err(kernel_api_error)?;
+
+    let minimum_version = request
+        .target
+        .min_pylon_version
+        .as_deref()
+        .map(|value| {
+            Version::parse(value).map_err(|error| ApiError {
+                status: StatusCode::BAD_REQUEST,
+                error: "invalid_request",
+                reason: format!("homework_launch_min_pylon_version_invalid:{error}"),
+            })
+        })
+        .transpose()?;
+
+    let preview_training_run_id = request.training_run_id.clone().unwrap_or_else(|| {
+        build_homework_training_run_id(now_unix_ms, &course_id, &homework_id, &run_slug)
+    });
+    let (artifact_bucket_uri, artifact_prefix) = homework_launch_artifact_bucket_uri_and_prefix(
+        config,
+        request.artifact_prefix.as_deref(),
+        network_id.as_str(),
+        preview_training_run_id.as_str(),
+    )?;
+    let preview_request = homework_training_run_request(
+        &lane_contract,
+        config,
+        now_unix_ms,
+        preview_training_run_id.as_str(),
+        display_name.as_str(),
+        network_id.as_str(),
+        course_id.as_str(),
+        homework_id.as_str(),
+        run_slug.as_str(),
+        run_kind.as_str(),
+        assignment_family.as_str(),
+        artifact_bucket_uri.as_str(),
+        artifact_prefix.as_str(),
+        &request.target,
+        &request.assignment,
+        &request.payout,
+        1,
+    )
+    .map_err(kernel_api_error)?;
+    let preview_run = preview_request.training_run.clone();
+    let run_definition =
+        training_scheduler_run_definition(&store.kernel, &preview_run).map_err(kernel_api_error)?;
+    let preview_metadata =
+        training_scheduler_metadata_from_run(&preview_run).map_err(kernel_api_error)?;
+    let admitted_nodes = store.kernel.list_admitted_training_nodes(
+        &TrainingNodeQuery {
+            network_id: None,
+            role: Some(TrainingNodeRoleClaim::Worker),
+            online_only: false,
+            eligible_only: false,
+        },
+        now_unix_ms as i64,
+    );
+    let matched_nodes = admitted_nodes
+        .into_iter()
+        .filter(|node| {
+            homework_launch_node_target_matches(
+                node,
+                &request.target,
+                &request.payout,
+                minimum_version.as_ref(),
+            ) && training_node_scheduler_run_mismatch_reason_with_definition(
+                store.training_scheduler.rollout_policy(),
+                node,
+                &preview_run,
+                &preview_metadata,
+                TrainingNodeRoleClaim::Worker,
+                &run_definition,
+            )
+            .is_none()
+        })
+        .collect::<Vec<_>>();
+    if matched_nodes.is_empty() {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_no_eligible_pylons".to_string(),
+        });
+    }
+    let matched_pylons = matched_nodes
+        .iter()
+        .map(homework_launch_pylon_match)
+        .collect::<Vec<_>>();
+    let assigned_nodes = request.assignment.max_contributors.map_or_else(
+        || matched_nodes.clone(),
+        |limit| {
+            matched_nodes
+                .iter()
+                .take(usize::try_from(limit).unwrap_or(usize::MAX))
+                .cloned()
+                .collect::<Vec<_>>()
+        },
+    );
+    if assigned_nodes.is_empty() {
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            error: "invalid_request",
+            reason: "homework_launch_no_assigned_pylons".to_string(),
+        });
+    }
+    if store
+        .kernel
+        .get_compute_training_run(preview_training_run_id.as_str())
+        .is_some()
+    {
+        let existing_run = store
+            .kernel
+            .get_compute_training_run(preview_training_run_id.as_str())
+            .ok_or_else(|| kernel_api_error("compute_training_run_not_found".to_string()))?;
+        if !training_run_schedulable(&existing_run) {
+            return Err(ApiError {
+                status: StatusCode::CONFLICT,
+                error: "conflict",
+                reason: "homework_launch_training_run_id_conflict".to_string(),
+            });
+        }
+    }
+    if request.reuse_existing_run {
+        if let Some(existing_run) = store
+            .kernel
+            .list_compute_training_runs(None, None, None)
+            .into_iter()
+            .rev()
+            .find(|run| {
+                training_run_schedulable(run)
+                    && run.metadata.get("course_id").and_then(Value::as_str)
+                        == Some(course_id.as_str())
+                    && run.metadata.get("homework_id").and_then(Value::as_str)
+                        == Some(homework_id.as_str())
+                    && run.metadata.get("run_slug").and_then(Value::as_str)
+                        == Some(run_slug.as_str())
+            })
+        {
+            store
+                .training_scheduler
+                .recover_from_kernel(&store.kernel, now_unix_ms as i64);
+            if let Some(scheduled_run) = store
+                .training_scheduler
+                .runs_by_training_run_id
+                .get(existing_run.training_run_id.as_str())
+            {
+                let node_lookup = store
+                    .kernel
+                    .list_admitted_training_nodes(
+                        &TrainingNodeQuery {
+                            network_id: None,
+                            role: None,
+                            online_only: false,
+                            eligible_only: false,
+                        },
+                        now_unix_ms as i64,
+                    )
+                    .into_iter()
+                    .map(|node| (node.node_pubkey_hex.clone(), node))
+                    .collect::<HashMap<_, _>>();
+                return Ok(HomeworkLaunchPrepared {
+                    training_run_id: existing_run.training_run_id.clone(),
+                    network_id: scheduled_run.network_id.clone(),
+                    current_window_id: scheduled_run.current_window_id.clone(),
+                    launch_state: "reused_active_run".to_string(),
+                    run_status: existing_run.status.label().to_string(),
+                    launch_receipt_id: None,
+                    lane_contract,
+                    matched_pylons,
+                    artifact_bucket_uri: scheduled_run.artifact_bucket_uri.clone(),
+                    assigned_pylons: homework_launch_assigned_pylons(scheduled_run, &node_lookup),
+                    artifact_prefix: homework_artifact_prefix(
+                        scheduled_run.artifact_bucket_uri.as_str(),
+                        scheduled_run.network_id.as_str(),
+                        existing_run.training_run_id.as_str(),
+                    ),
+                    course_id,
+                    homework_id,
+                    assignment_family,
+                    run_kind,
+                    needs_window_materialization: false,
+                    receipt_event: None,
+                    snapshot_event: None,
+                });
+            }
+        }
+    }
+
+    let training_run_id = preview_training_run_id;
+    let create_request = homework_training_run_request(
+        &lane_contract,
+        config,
+        now_unix_ms,
+        training_run_id.as_str(),
+        display_name.as_str(),
+        network_id.as_str(),
+        course_id.as_str(),
+        homework_id.as_str(),
+        run_slug.as_str(),
+        run_kind.as_str(),
+        assignment_family.as_str(),
+        artifact_bucket_uri.as_str(),
+        artifact_prefix.as_str(),
+        &request.target,
+        &request.assignment,
+        &request.payout,
+        u32::try_from(assigned_nodes.len()).unwrap_or(u32::MAX),
+    )
+    .map_err(kernel_api_error)?;
+    let create_result = store
+        .kernel
+        .create_compute_training_run(
+            &training_kernel_mutation_context("admin:homework_launch", now_unix_ms),
+            create_request,
+        )
+        .map_err(kernel_api_error)?;
+    store
+        .training_scheduler
+        .recover_from_kernel(&store.kernel, now_unix_ms as i64);
+    let scheduled_run = store
+        .training_scheduler
+        .runs_by_training_run_id
+        .get_mut(training_run_id.as_str())
+        .ok_or_else(|| kernel_api_error("training_scheduler_run_not_found".to_string()))?;
+    let bound_assignments = scheduled_run
+        .bind_launch_worker_assignments(assigned_nodes.as_slice(), now_unix_ms as i64)
+        .map_err(kernel_api_error)?;
+    let current_window_id = scheduled_run.current_window_id.clone();
+    let _ = scheduled_run;
+    store
+        .persist_training_scheduler_state()
+        .map_err(kernel_api_error)?;
+    let assigned_pylons = assigned_nodes
+        .iter()
+        .zip(bound_assignments.iter())
+        .map(|(node, assignment)| HomeworkLaunchAssignedPylon {
+            node: homework_launch_pylon_match(node),
+            assignment_id: assignment.assignment_id.clone(),
+            lease_id: assignment.lease_id.clone().unwrap_or_default(),
+            assignment_state: assignment.state.label().to_string(),
+        })
+        .collect::<Vec<_>>();
+    Ok(HomeworkLaunchPrepared {
+        training_run_id: training_run_id.clone(),
+        network_id,
+        current_window_id,
+        launch_state: "created".to_string(),
+        run_status: create_result
+            .response
+            .training_run
+            .status
+            .label()
+            .to_string(),
+        launch_receipt_id: Some(create_result.response.receipt.receipt_id.clone()),
+        lane_contract,
+        matched_pylons,
+        assigned_pylons,
+        artifact_bucket_uri,
+        artifact_prefix,
+        course_id,
+        homework_id,
+        assignment_family,
+        run_kind,
+        needs_window_materialization: true,
+        receipt_event: create_result.receipt_event,
+        snapshot_event: create_result.snapshot_event,
+    })
+}
+
+async fn launch_homework_run(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(request): Json<LaunchCs336A1DemoRunRequest>,
-) -> Result<Json<LaunchCs336A1DemoRunResponse>, ApiError> {
+    Json(request): Json<LaunchHomeworkRunRequest>,
+) -> Result<Json<LaunchHomeworkRunResponse>, ApiError> {
     authenticate_admin_bearer_token(&state, &headers)?;
+    Ok(Json(execute_homework_launch(&state, request).await?))
+}
+
+async fn execute_homework_launch(
+    state: &AppState,
+    request: LaunchHomeworkRunRequest,
+) -> Result<LaunchHomeworkRunResponse, ApiError> {
     let now = now_unix_ms();
-    let launch_result = {
+    let prepared = {
         let mut store = state.store.write().map_err(|_| ApiError {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             error: "internal_error",
             reason: "session_store_poisoned".to_string(),
         })?;
-        launch_or_reuse_cs336_a1_demo_run(&state.config, &mut store, now, request)?
+        prepare_homework_launch(&state.config, &mut store, now, request)?
     };
-    if let Some(receipt_event) = launch_result.receipt_event.clone() {
+    if let Some(receipt_event) = prepared.receipt_event.clone() {
         let _ = state.kernel_receipt_tx.send(receipt_event);
     }
-    if let Some(snapshot_event) = launch_result.snapshot_event.clone() {
+    if let Some(snapshot_event) = prepared.snapshot_event.clone() {
         let _ = state.kernel_snapshot_tx.send(snapshot_event);
     }
-    if launch_result.launch_state == "created"
-        && state.config.training_artifact_signed_url.is_some()
-    {
+    if prepared.needs_window_materialization {
+        let signed_url_config = state
+            .config
+            .training_artifact_signed_url
+            .as_ref()
+            .ok_or_else(|| ApiError {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                error: "service_unavailable",
+                reason: "homework_launch_artifact_upload_unconfigured".to_string(),
+            })?;
         publish_cs336_a1_demo_bootstrap_artifacts(
-            &launch_result.lane_contract,
+            &prepared.lane_contract,
             &state.config,
+            prepared.artifact_bucket_uri.as_str(),
+            prepared.network_id.as_str(),
+            prepared.current_window_id.as_str(),
             now,
-            launch_result.training_run_id.as_str(),
+            prepared.training_run_id.as_str(),
         )
         .await
-        .map_err(kernel_api_error)?;
+        .map_err(|error| {
+            let mut store = state.store.write().ok();
+            if let Some(store) = store.as_mut() {
+                mark_homework_launch_failed(
+                    store,
+                    prepared.training_run_id.as_str(),
+                    now as i64,
+                    error.as_str(),
+                );
+            }
+            ApiError {
+                status: StatusCode::BAD_GATEWAY,
+                error: "bad_gateway",
+                reason: format!(
+                    "homework_launch_artifact_publish_failed:{}:{}",
+                    signed_url_config.bucket_uri, error
+                ),
+            }
+        })?;
+        {
+            let mut store = state.store.write().map_err(|_| ApiError {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                error: "internal_error",
+                reason: "session_store_poisoned".to_string(),
+            })?;
+            persist_active_homework_window(
+                &mut store,
+                prepared.training_run_id.as_str(),
+                prepared.course_id.as_str(),
+                prepared.homework_id.as_str(),
+                prepared.assignment_family.as_str(),
+                prepared.run_kind.as_str(),
+                now as i64,
+            )
+            .map_err(|error| {
+                mark_homework_launch_failed(
+                    &mut store,
+                    prepared.training_run_id.as_str(),
+                    now as i64,
+                    error.as_str(),
+                );
+                kernel_api_error(error)
+            })?;
+        }
     }
-
     let run_detail = {
         let store = state.store.read().map_err(|_| ApiError {
             status: StatusCode::INTERNAL_SERVER_ERROR,
@@ -7660,22 +9129,68 @@ async fn launch_cs336_a1_demo_run(
             &visualization,
             &detail_context,
             now,
-            launch_result.training_run_id.as_str(),
+            prepared.training_run_id.as_str(),
         )
         .map_err(kernel_api_error)?
     };
     replace_training_run_detail_cache(&state, run_detail.clone());
-
-    Ok(Json(LaunchCs336A1DemoRunResponse {
+    Ok(LaunchHomeworkRunResponse {
         launched_at_unix_ms: now,
-        launch_state: launch_result.launch_state,
-        training_run_id: launch_result.training_run_id,
-        lane_id: launch_result.lane_contract.lane_id,
-        training_policy_ref: EPISODE_224_CS336_A1_DEMO_TRAINING_POLICY_REF.to_string(),
-        environment_ref: launch_result.lane_contract.environment_ref,
-        network_id: EPISODE_224_CS336_A1_DEMO_NETWORK_ID.to_string(),
-        worker_target_count: EPISODE_224_CS336_A1_DEMO_WORKER_TARGET_COUNT,
+        launch_state: prepared.launch_state,
+        training_run_id: prepared.training_run_id,
+        run_status: prepared.run_status,
+        current_window_id: prepared.current_window_id,
+        matched_pylons: prepared.matched_pylons,
+        assigned_pylons: prepared.assigned_pylons,
+        artifact_prefix: prepared.artifact_prefix,
+        launch_receipt_id: prepared.launch_receipt_id,
         run_detail,
+    })
+}
+
+async fn launch_cs336_a1_demo_run(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<LaunchCs336A1DemoRunRequest>,
+) -> Result<Json<LaunchCs336A1DemoRunResponse>, ApiError> {
+    authenticate_admin_bearer_token(&state, &headers)?;
+    let response = execute_homework_launch(
+        &state,
+        LaunchHomeworkRunRequest {
+            course_id: "cs336".to_string(),
+            homework_id: "a1".to_string(),
+            run_slug: "demo".to_string(),
+            training_run_id: request.training_run_id,
+            display_name: request.display_name,
+            reuse_existing_run: request.reuse_existing_run,
+            network_id: Some(EPISODE_224_CS336_A1_DEMO_NETWORK_ID.to_string()),
+            run_kind: Some("demo".to_string()),
+            assignment_family: Some("cs336.assignment1".to_string()),
+            artifact_prefix: None,
+            target: HomeworkLaunchTargetRequest::default(),
+            assignment: HomeworkLaunchAssignmentRequest {
+                max_contributors: Some(EPISODE_224_CS336_A1_DEMO_WORKER_TARGET_COUNT),
+                ..HomeworkLaunchAssignmentRequest::default()
+            },
+            payout: HomeworkLaunchPayoutRequest {
+                enabled: true,
+                rail: Some("bitcoin_lightning".to_string()),
+                amount_sats: Some(state.config.treasury.payout_sats_per_window),
+                pay_only_on_accept: true,
+            },
+        },
+    )
+    .await?;
+    Ok(Json(LaunchCs336A1DemoRunResponse {
+        launched_at_unix_ms: response.launched_at_unix_ms,
+        launch_state: response.launch_state,
+        training_run_id: response.training_run_id,
+        lane_id: PSION_CS336_A1_DEMO_LANE_ID.to_string(),
+        training_policy_ref: EPISODE_224_CS336_A1_DEMO_TRAINING_POLICY_REF.to_string(),
+        environment_ref: PYLON_TRAINING_CS336_A1_DEMO_ENVIRONMENT_REF.to_string(),
+        network_id: EPISODE_224_CS336_A1_DEMO_NETWORK_ID.to_string(),
+        worker_target_count: u32::try_from(response.assigned_pylons.len()).unwrap_or(u32::MAX),
+        run_detail: response.run_detail,
     }))
 }
 
@@ -7718,114 +9233,6 @@ fn authenticate_admin_bearer_token(state: &AppState, headers: &HeaderMap) -> Res
     Ok(())
 }
 
-fn launch_or_reuse_cs336_a1_demo_run(
-    config: &ServiceConfig,
-    store: &mut ControlStore,
-    now_unix_ms: u64,
-    request: LaunchCs336A1DemoRunRequest,
-) -> Result<Cs336A1DemoLaunchResult, ApiError> {
-    let lane_contract =
-        PsionicTrainLaneContract::for_lane(PSION_CS336_A1_DEMO_LANE_ID).map_err(|error| {
-            kernel_api_error(format!("cs336_a1_demo_lane_contract_invalid:{error}"))
-        })?;
-    ensure_cs336_a1_demo_registry_contracts(store, now_unix_ms, &lane_contract)
-        .map_err(kernel_api_error)?;
-
-    let requested_training_run_id = request
-        .training_run_id
-        .as_deref()
-        .map(|value| normalize_required_training_string(value, "training_run_id_missing"))
-        .transpose()
-        .map_err(kernel_api_error)?;
-
-    if let Some(training_run_id) = requested_training_run_id.as_deref() {
-        if let Some(existing_run) = store.kernel.get_compute_training_run(training_run_id) {
-            if training_run_schedulable(&existing_run) {
-                return Ok(Cs336A1DemoLaunchResult {
-                    training_run_id: training_run_id.to_string(),
-                    launch_state: "reused_requested_run".to_string(),
-                    lane_contract,
-                    receipt_event: None,
-                    snapshot_event: None,
-                });
-            }
-            return Err(ApiError {
-                status: StatusCode::CONFLICT,
-                error: "conflict",
-                reason: "cs336_a1_demo_training_run_id_conflict".to_string(),
-            });
-        }
-    } else if request.reuse_existing_run {
-        if let Some(active_run_id) = latest_active_cs336_a1_demo_run_id(store) {
-            return Ok(Cs336A1DemoLaunchResult {
-                training_run_id: active_run_id,
-                launch_state: "reused_active_run".to_string(),
-                lane_contract,
-                receipt_event: None,
-                snapshot_event: None,
-            });
-        }
-    }
-
-    let training_run_id = requested_training_run_id
-        .unwrap_or_else(|| build_cs336_a1_demo_training_run_id(now_unix_ms));
-    let display_name = normalize_optional_field(request.display_name.as_deref())
-        .unwrap_or_else(|| EPISODE_224_CS336_A1_DEMO_DISPLAY_NAME.to_string());
-    let create_result = store
-        .kernel
-        .create_compute_training_run(
-            &training_kernel_mutation_context("admin:episode_224_demo", now_unix_ms),
-            cs336_a1_demo_training_run_request(
-                &lane_contract,
-                config,
-                now_unix_ms,
-                training_run_id.as_str(),
-                display_name.as_str(),
-            )
-            .map_err(kernel_api_error)?,
-        )
-        .map_err(kernel_api_error)?;
-
-    Ok(Cs336A1DemoLaunchResult {
-        training_run_id,
-        launch_state: "created".to_string(),
-        lane_contract,
-        receipt_event: create_result.receipt_event,
-        snapshot_event: create_result.snapshot_event,
-    })
-}
-
-fn latest_active_cs336_a1_demo_run_id(store: &ControlStore) -> Option<String> {
-    store
-        .kernel
-        .list_compute_training_runs(
-            Some(EPISODE_224_CS336_A1_DEMO_TRAINING_POLICY_REF),
-            None,
-            None,
-        )
-        .into_iter()
-        .rev()
-        .find(training_run_schedulable)
-        .map(|run| run.training_run_id)
-}
-
-fn build_cs336_a1_demo_training_run_id(now_unix_ms: u64) -> String {
-    let timestamp = Utc
-        .timestamp_millis_opt(now_unix_ms as i64)
-        .single()
-        .map(|value| value.format("%Y%m%d%H%M%S").to_string())
-        .unwrap_or_else(|| now_unix_ms.to_string());
-    let suffix = random_token().chars().take(8).collect::<String>();
-    format!("run.cs336.a1.demo.{timestamp}.{suffix}")
-}
-
-fn cs336_a1_demo_initial_window_id(training_run_id: &str) -> String {
-    if let Some(suffix) = training_run_id.strip_prefix("run.") {
-        return format!("window.{suffix}.0001");
-    }
-    format!("window.{}.0001", sanitize_identifier(training_run_id))
-}
-
 fn cs336_a1_demo_artifact_bucket_uri(config: &ServiceConfig) -> String {
     config
         .training_artifact_signed_url
@@ -7856,92 +9263,6 @@ fn cs336_a1_demo_training_policy_metadata() -> Result<Value, String> {
     serde_json::to_value(metadata)
         .map(|value| json!({"run_definition": value}))
         .map_err(|error| format!("cs336_a1_demo_training_policy_metadata_invalid:{error}"))
-}
-
-fn cs336_a1_demo_scheduler_metadata(
-    config: &ServiceConfig,
-    initial_window_id: &str,
-) -> Result<Value, String> {
-    serde_json::to_value(TrainingSchedulerRunMetadata {
-        network_id: EPISODE_224_CS336_A1_DEMO_NETWORK_ID.to_string(),
-        artifact_bucket_uri: cs336_a1_demo_artifact_bucket_uri(config),
-        worker_count: EPISODE_224_CS336_A1_DEMO_WORKER_TARGET_COUNT,
-        validator_count: 0,
-        recovery_source_count: 0,
-        initial_window_id: Some(initial_window_id.to_string()),
-        checkpoint_ref: Some(EPISODE_224_CS336_A1_DEMO_DEFAULT_BASE_CHECKPOINT_REF.to_string()),
-    })
-    .map_err(|error| format!("cs336_a1_demo_scheduler_metadata_invalid:{error}"))
-}
-
-fn cs336_a1_demo_training_run_request(
-    lane_contract: &PsionicTrainLaneContract,
-    config: &ServiceConfig,
-    now_unix_ms: u64,
-    training_run_id: &str,
-    display_name: &str,
-) -> Result<CreateComputeTrainingRunRequest, String> {
-    let initial_window_id = cs336_a1_demo_initial_window_id(training_run_id);
-    let scheduler_metadata = cs336_a1_demo_scheduler_metadata(config, initial_window_id.as_str())?;
-    Ok(CreateComputeTrainingRunRequest {
-        idempotency_key: format!(
-            "idemp.admin.episode224.cs336.run.{}",
-            sanitize_identifier(training_run_id)
-        ),
-        trace: TraceContext::default(),
-        policy: PolicyContext::default(),
-        training_run: ComputeTrainingRun {
-            training_run_id: training_run_id.to_string(),
-            training_policy_ref: EPISODE_224_CS336_A1_DEMO_TRAINING_POLICY_REF.to_string(),
-            environment_binding: ComputeEnvironmentBinding {
-                environment_ref: lane_contract.environment_ref.clone(),
-                environment_version: None,
-                dataset_ref: None,
-                rubric_ref: None,
-                evaluator_policy_ref: None,
-            },
-            checkpoint_binding: ComputeCheckpointBinding {
-                checkpoint_family: EPISODE_224_CS336_A1_DEMO_CHECKPOINT_FAMILY.to_string(),
-                latest_checkpoint_ref: Some(
-                    EPISODE_224_CS336_A1_DEMO_DEFAULT_BASE_CHECKPOINT_REF.to_string(),
-                ),
-                recovery_posture: Some("warm-resume".to_string()),
-            },
-            validator_policy_ref: EPISODE_224_CS336_A1_DEMO_VALIDATOR_POLICY_REF.to_string(),
-            work_class: ComputeTrainingWorkClass::SmallModelLocalTraining,
-            replica_type: ComputeTrainingReplicaType::SingleNode,
-            benchmark_package_refs: Vec::new(),
-            product_id: Some("psionic.training.cs336_a1_demo".to_string()),
-            capacity_lot_id: None,
-            instrument_id: None,
-            delivery_proof_id: None,
-            model_ref: Some("model://psion/cs336-assignment1-demo".to_string()),
-            source_ref: Some(EPISODE_224_CS336_A1_DEMO_DATASET_REF.to_string()),
-            rollout_verification_eval_run_ids: Vec::new(),
-            created_at_ms: now_unix_ms as i64,
-            started_at_ms: Some(now_unix_ms as i64),
-            finalized_at_ms: None,
-            expected_step_count: Some(64),
-            completed_step_count: None,
-            status: ComputeTrainingRunStatus::Running,
-            final_checkpoint_ref: None,
-            promotion_checkpoint_ref: None,
-            summary: None,
-            metadata: json!({
-                "display_name": display_name,
-                "episode_id": "episode_224",
-                "story_id": "distributed_training_101_demo",
-                "lane_id": lane_contract.lane_id,
-                "release_id": lane_contract.release_id,
-                "backend_family": lane_contract.backend_family,
-                "topology_class": lane_contract.topology_class,
-                "minimum_machine_class": lane_contract.minimum_machine_class.label(),
-                "pylon_training_scheduler": scheduler_metadata,
-            }),
-        },
-        evidence: Vec::new(),
-        hints: ReceiptHints::default(),
-    })
 }
 
 #[derive(Debug, Clone)]
@@ -7988,31 +9309,30 @@ fn cs336_a1_demo_bootstrap_artifact(
 
 fn build_cs336_a1_demo_bootstrap_artifacts(
     lane_contract: &PsionicTrainLaneContract,
+    artifact_bucket_uri: &str,
     config: &ServiceConfig,
+    network_id: &str,
+    window_id: &str,
     now_unix_ms: u64,
     training_run_id: &str,
 ) -> Result<Vec<Cs336A1DemoBootstrapArtifact>, String> {
-    let artifact_bucket_uri = cs336_a1_demo_artifact_bucket_uri(config);
-    let network_id = EPISODE_224_CS336_A1_DEMO_NETWORK_ID.to_string();
-    let window_id = cs336_a1_demo_initial_window_id(training_run_id);
     let checkpoint_ref = EPISODE_224_CS336_A1_DEMO_DEFAULT_BASE_CHECKPOINT_REF.to_string();
-    let assignment_id =
-        pylon_training_assignment_id(training_run_id, window_id.as_str(), "worker", 1, 1);
+    let assignment_id = pylon_training_assignment_id(training_run_id, window_id, "worker", 1, 1);
     let membership_revision = 1_u64;
     let membership_revision_label = pylon_training_membership_revision_label(membership_revision);
     let lease_id = pylon_training_lease_id(
         training_run_id,
-        window_id.as_str(),
+        window_id,
         "worker",
         1,
         1,
         membership_revision,
     );
     let latest_pointer_artifact = cs336_a1_demo_bootstrap_artifact(
-        artifact_bucket_uri.as_str(),
+        artifact_bucket_uri,
         PylonTrainingArtifactKind::LatestCheckpointPointer,
         PylonTrainingArtifactScope {
-            network_id: network_id.clone(),
+            network_id: network_id.to_string(),
             run_id: training_run_id.to_string(),
             window_id: None,
             assignment_id: None,
@@ -8034,10 +9354,10 @@ fn build_cs336_a1_demo_bootstrap_artifacts(
     .map_err(|error| format!("cs336_a1_demo_checkpoint_manifest_encode_failed:{error}"))?;
     let checkpoint_manifest_digest = sha256_prefixed_bytes(checkpoint_manifest_payload.as_slice());
     let checkpoint_manifest_artifact = cs336_a1_demo_bootstrap_artifact(
-        artifact_bucket_uri.as_str(),
+        artifact_bucket_uri,
         PylonTrainingArtifactKind::CheckpointManifest,
         PylonTrainingArtifactScope {
-            network_id: network_id.clone(),
+            network_id: network_id.to_string(),
             run_id: training_run_id.to_string(),
             window_id: None,
             assignment_id: None,
@@ -8063,9 +9383,9 @@ fn build_cs336_a1_demo_bootstrap_artifacts(
             manifest_id: format!("manifest.{training_run_id}.bootstrap"),
             issued_at_ms: now_unix_ms,
             expires_at_ms: now_unix_ms.saturating_add(86_400_000),
-            network_id: network_id.clone(),
+            network_id: network_id.to_string(),
             run_id: training_run_id.to_string(),
-            window_id: window_id.clone(),
+            window_id: window_id.to_string(),
             assignment_id: assignment_id.clone(),
             lease_id,
             lease_sequence: 1,
@@ -8093,7 +9413,7 @@ fn build_cs336_a1_demo_bootstrap_artifacts(
             latest_pointer_ref: latest_pointer_artifact.object_uri.clone(),
         },
         PylonTrainingArtifacts {
-            bucket_uri: artifact_bucket_uri.clone(),
+            bucket_uri: artifact_bucket_uri.to_string(),
             run_prefix: format!("networks/{network_id}/runs/{training_run_id}"),
             window_prefix: format!(
                 "networks/{network_id}/runs/{training_run_id}/windows/{window_id}"
@@ -8102,10 +9422,7 @@ fn build_cs336_a1_demo_bootstrap_artifacts(
             credential_source: PYLON_TRAINING_GCS_CREDENTIAL_SOURCE.to_string(),
         },
         PylonTrainingTrn {
-            network_coordinate: format!(
-                "39500:{coordinator_pubkey}:{}",
-                EPISODE_224_CS336_A1_DEMO_NETWORK_ID
-            ),
+            network_coordinate: format!("39500:{coordinator_pubkey}:{network_id}"),
             window_coordinate: format!("39510:{coordinator_pubkey}:{window_id}"),
             relay_urls: if config.training_trn_relay_urls.is_empty() {
                 vec![DEFAULT_HOSTED_NEXUS_RELAY_URL.to_string()]
@@ -8120,7 +9437,7 @@ fn build_cs336_a1_demo_bootstrap_artifacts(
         slice_digest: dataset_slice.slice_digest.clone(),
         assignment_seed: pylon_training_assignment_seed(
             training_run_id,
-            window_id.as_str(),
+            window_id,
             membership_revision_label.as_str(),
             assignment_id.as_str(),
             placeholder_node_pubkey.as_str(),
@@ -8130,10 +9447,10 @@ fn build_cs336_a1_demo_bootstrap_artifacts(
     .build()
     .map_err(|error| format!("cs336_a1_demo_bootstrap_manifest_invalid:{error}"))?;
     let run_manifest_artifact = cs336_a1_demo_bootstrap_artifact(
-        artifact_bucket_uri.as_str(),
+        artifact_bucket_uri,
         PylonTrainingArtifactKind::RunManifest,
         PylonTrainingArtifactScope {
-            network_id,
+            network_id: network_id.to_string(),
             run_id: training_run_id.to_string(),
             window_id: None,
             assignment_id: None,
@@ -8193,6 +9510,9 @@ async fn upload_training_artifact_via_signed_url(
 async fn publish_cs336_a1_demo_bootstrap_artifacts(
     lane_contract: &PsionicTrainLaneContract,
     config: &ServiceConfig,
+    artifact_bucket_uri: &str,
+    network_id: &str,
+    window_id: &str,
     now_unix_ms: u64,
     training_run_id: &str,
 ) -> Result<(), String> {
@@ -8200,9 +9520,14 @@ async fn publish_cs336_a1_demo_bootstrap_artifacts(
         .training_artifact_signed_url
         .as_ref()
         .ok_or_else(|| "cs336_a1_demo_bootstrap_artifact_upload_unconfigured".to_string())?;
+    let mut signed_url_config = signed_url_config.clone();
+    signed_url_config.bucket_uri = artifact_bucket_uri.to_string();
     let artifacts = build_cs336_a1_demo_bootstrap_artifacts(
         lane_contract,
+        artifact_bucket_uri,
         config,
+        network_id,
+        window_id,
         now_unix_ms,
         training_run_id,
     )?;
@@ -8211,7 +9536,7 @@ async fn publish_cs336_a1_demo_bootstrap_artifacts(
         .build()
         .map_err(|error| format!("cs336_a1_demo_bootstrap_http_client_invalid:{error}"))?;
     for artifact in &artifacts {
-        upload_training_artifact_via_signed_url(signed_url_config, &client, artifact).await?;
+        upload_training_artifact_via_signed_url(&signed_url_config, &client, artifact).await?;
     }
     Ok(())
 }
@@ -8397,49 +9722,49 @@ fn ensure_cs336_a1_demo_registry_contracts(
         }
     }
 
-    match store
+    let validator_policy_needs_update = store
         .kernel
         .get_compute_validator_policy(EPISODE_224_CS336_A1_DEMO_VALIDATOR_POLICY_REF, None)
-    {
-        Some(policy) => {
-            if policy.status != ComputeRegistryStatus::Active {
-                return Err("cs336_a1_demo_validator_policy_inactive".to_string());
-            }
-        }
-        None => {
-            store
-                .kernel
-                .register_compute_validator_policy(
-                    &training_kernel_mutation_context("admin:episode_224_demo", now_unix_ms),
-                    RegisterComputeValidatorPolicyRequest {
-                        idempotency_key: "idemp.admin.episode224.cs336.validator".to_string(),
-                        trace: TraceContext::default(),
-                        policy: PolicyContext::default(),
-                        policy_record: ComputeValidatorPolicy {
-                            policy_ref: EPISODE_224_CS336_A1_DEMO_VALIDATOR_POLICY_REF.to_string(),
-                            version: EPISODE_224_CS336_A1_DEMO_POLICY_VERSION.to_string(),
-                            owner_id: EPISODE_224_CS336_A1_DEMO_OWNER_ID.to_string(),
-                            created_at_ms: now_unix_ms as i64,
-                            updated_at_ms: now_unix_ms as i64 + 100,
-                            status: ComputeRegistryStatus::Active,
-                            validator_pool_ref: "validator-pool.training.mvp".to_string(),
-                            minimum_validator_count: Some(1),
-                            challenge_window_ms: Some(60_000),
-                            required_proof_posture: Some(ComputeProofPosture::ChallengeEligible),
-                            benchmark_package_refs: Vec::new(),
-                            metadata: json!({
-                                "lane_id": lane_contract.lane_id,
-                                "episode_id": "episode_224",
-                            }),
-                        },
-                        evidence: Vec::new(),
-                        hints: ReceiptHints::default(),
+        .is_none_or(|policy| {
+            policy.status != ComputeRegistryStatus::Active
+                || policy.validator_pool_ref != "validator-pool.training.mvp"
+                || policy.minimum_validator_count != Some(1)
+                || policy.challenge_window_ms != Some(0)
+                || policy.required_proof_posture != Some(ComputeProofPosture::ChallengeEligible)
+        });
+    if validator_policy_needs_update {
+        store
+            .kernel
+            .register_compute_validator_policy(
+                &training_kernel_mutation_context("admin:episode_224_demo", now_unix_ms),
+                RegisterComputeValidatorPolicyRequest {
+                    idempotency_key: "idemp.admin.episode224.cs336.validator.pay_on_accept"
+                        .to_string(),
+                    trace: TraceContext::default(),
+                    policy: PolicyContext::default(),
+                    policy_record: ComputeValidatorPolicy {
+                        policy_ref: EPISODE_224_CS336_A1_DEMO_VALIDATOR_POLICY_REF.to_string(),
+                        version: EPISODE_224_CS336_A1_DEMO_POLICY_VERSION.to_string(),
+                        owner_id: EPISODE_224_CS336_A1_DEMO_OWNER_ID.to_string(),
+                        created_at_ms: now_unix_ms as i64,
+                        updated_at_ms: now_unix_ms as i64 + 100,
+                        status: ComputeRegistryStatus::Active,
+                        validator_pool_ref: "validator-pool.training.mvp".to_string(),
+                        minimum_validator_count: Some(1),
+                        challenge_window_ms: Some(0),
+                        required_proof_posture: Some(ComputeProofPosture::ChallengeEligible),
+                        benchmark_package_refs: Vec::new(),
+                        metadata: json!({
+                            "lane_id": lane_contract.lane_id,
+                            "episode_id": "episode_224",
+                            "pay_on_accept": true,
+                        }),
                     },
-                )
-                .map_err(|error| {
-                    format!("cs336_a1_demo_validator_policy_register_failed:{error}")
-                })?;
-        }
+                    evidence: Vec::new(),
+                    hints: ReceiptHints::default(),
+                },
+            )
+            .map_err(|error| format!("cs336_a1_demo_validator_policy_register_failed:{error}"))?;
     }
 
     match store
@@ -8729,19 +10054,60 @@ async fn record_training_node_heartbeat(
 ) -> Result<Json<RecordTrainingNodeHeartbeatResponse>, ApiError> {
     let now = now_unix_ms();
     let caller_id = training_node_caller_id(request.node_pubkey_hex.as_str());
+    let training_run_id = request.training_run_id.clone();
+    let assignment_id = request.assignment_id.clone();
+    let lease_id = request.lease_id.clone();
+    let node_pubkey_hex = request.node_pubkey_hex.clone();
+    let desired_state = request.desired_state;
+    let process_state = request.process_state;
+    let recorded_at_ms = request.recorded_at_ms;
+    let last_exit_code = request.last_exit_code;
     let result = {
         let mut store = state.store.write().map_err(|_| ApiError {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             error: "internal_error",
             reason: "session_store_poisoned".to_string(),
         })?;
-        store
+        let result = store
             .kernel
             .record_training_node_heartbeat(
                 &training_kernel_mutation_context(&caller_id, now),
                 request,
             )
-            .map_err(kernel_api_error)?
+            .map_err(kernel_api_error)?;
+        if let Some(scheduled_run) = store
+            .training_scheduler
+            .runs_by_training_run_id
+            .get_mut(training_run_id.as_str())
+        {
+            if let Some(assignment_state) = scheduled_run
+                .assignment_for_binding_mut(
+                    assignment_id.as_str(),
+                    lease_id.as_str(),
+                    node_pubkey_hex.as_str(),
+                )
+                .map(|assignment| {
+                    assignment.state = training_assignment_state_from_heartbeat(
+                        desired_state,
+                        process_state,
+                        last_exit_code,
+                    );
+                    assignment.expires_at_ms = Some(
+                        recorded_at_ms.saturating_add(PYLON_TRAINING_LEASE_DURATION_MS as i64),
+                    );
+                    assignment.state
+                })
+            {
+                scheduled_run.updated_at_ms = recorded_at_ms;
+                if matches!(assignment_state, TrainingAssignmentState::Active) {
+                    scheduled_run.window_state = TrainingSchedulerWindowState::Active;
+                }
+                store
+                    .persist_training_scheduler_state()
+                    .map_err(kernel_api_error)?;
+            }
+        }
+        result
     };
     record_training_coordination_observability(
         &state,
@@ -8752,6 +10118,479 @@ async fn record_training_node_heartbeat(
         result.snapshot_event.clone(),
     );
     Ok(Json(result.response))
+}
+
+async fn record_training_assignment_ack(
+    State(state): State<AppState>,
+    Json(mut request): Json<RecordTrainingAssignmentAckRequest>,
+) -> Result<Json<RecordTrainingAssignmentAckResponse>, ApiError> {
+    request.idempotency_key = normalize_required_field(
+        request.idempotency_key.as_str(),
+        "training_assignment_ack_idempotency_key_missing",
+    )?;
+    request.node_pubkey_hex = normalize_required_field(
+        request.node_pubkey_hex.as_str(),
+        "training_node_pubkey_missing",
+    )?;
+    request.training_run_id = normalize_required_field(
+        request.training_run_id.as_str(),
+        "compute_training_run_id_missing",
+    )?;
+    request.window_id = normalize_required_field(
+        request.window_id.as_str(),
+        "compute_adapter_window_id_missing",
+    )?;
+    request.assignment_id = normalize_required_field(
+        request.assignment_id.as_str(),
+        "compute_adapter_assignment_id_missing",
+    )?;
+    request.lease_id = normalize_required_field(
+        request.lease_id.as_str(),
+        "training_scheduler_lease_id_missing",
+    )?;
+    request.acked_at_ms = if request.acked_at_ms <= 0 {
+        now_unix_ms() as i64
+    } else {
+        request.acked_at_ms
+    };
+    let response = {
+        let mut store = state.store.write().map_err(|_| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error: "internal_error",
+            reason: "session_store_poisoned".to_string(),
+        })?;
+        let scheduled_run = store
+            .training_scheduler
+            .runs_by_training_run_id
+            .get_mut(request.training_run_id.as_str())
+            .ok_or_else(|| kernel_api_error("training_scheduler_run_not_found".to_string()))?;
+        let (accepted, lease_state) = {
+            let assignment = scheduled_run
+                .assignment_for_binding_mut(
+                    request.assignment_id.as_str(),
+                    request.lease_id.as_str(),
+                    request.node_pubkey_hex.as_str(),
+                )
+                .ok_or_else(|| {
+                    kernel_api_error("training_scheduler_assignment_not_found".to_string())
+                })?;
+            if request
+                .manifest_digest
+                .as_deref()
+                .is_some_and(|digest| assignment.manifest_digest.as_deref() != Some(digest))
+            {
+                return Err(kernel_api_error(
+                    "training_assignment_manifest_digest_mismatch".to_string(),
+                ));
+            }
+            let accepted = !matches!(
+                assignment.state,
+                TrainingAssignmentState::Failed
+                    | TrainingAssignmentState::Drained
+                    | TrainingAssignmentState::Expired
+            );
+            if accepted && assignment.state == TrainingAssignmentState::Leased {
+                assignment.state = TrainingAssignmentState::Acked;
+            }
+            assignment.expires_at_ms = Some(
+                request
+                    .acked_at_ms
+                    .saturating_add(PYLON_TRAINING_LEASE_DURATION_MS as i64),
+            );
+            (accepted, assignment.state.label().to_string())
+        };
+        scheduled_run.updated_at_ms = request.acked_at_ms;
+        store
+            .persist_training_scheduler_state()
+            .map_err(kernel_api_error)?;
+        RecordTrainingAssignmentAckResponse {
+            ack: TrainingCoordinatorAck {
+                idempotency_key: request.idempotency_key,
+                recorded_at_ms: request.acked_at_ms,
+                authority_state: "assignment_acked".to_string(),
+            },
+            accepted,
+            lease_state: Some(lease_state),
+        }
+    };
+    Ok(Json(response))
+}
+
+async fn record_training_drain_notice(
+    State(state): State<AppState>,
+    Json(mut request): Json<RecordTrainingDrainNoticeRequest>,
+) -> Result<Json<RecordTrainingDrainNoticeResponse>, ApiError> {
+    request.idempotency_key = normalize_required_field(
+        request.idempotency_key.as_str(),
+        "training_drain_notice_idempotency_key_missing",
+    )?;
+    request.node_pubkey_hex = normalize_required_field(
+        request.node_pubkey_hex.as_str(),
+        "training_node_pubkey_missing",
+    )?;
+    request.training_run_id = normalize_required_field(
+        request.training_run_id.as_str(),
+        "compute_training_run_id_missing",
+    )?;
+    request.window_id = normalize_required_field(
+        request.window_id.as_str(),
+        "compute_adapter_window_id_missing",
+    )?;
+    request.assignment_id = normalize_required_field(
+        request.assignment_id.as_str(),
+        "compute_adapter_assignment_id_missing",
+    )?;
+    request.lease_id = normalize_required_field(
+        request.lease_id.as_str(),
+        "training_scheduler_lease_id_missing",
+    )?;
+    request.reported_at_ms = if request.reported_at_ms <= 0 {
+        now_unix_ms() as i64
+    } else {
+        request.reported_at_ms
+    };
+    let response = {
+        let mut store = state.store.write().map_err(|_| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error: "internal_error",
+            reason: "session_store_poisoned".to_string(),
+        })?;
+        let scheduled_run = store
+            .training_scheduler
+            .runs_by_training_run_id
+            .get_mut(request.training_run_id.as_str())
+            .ok_or_else(|| kernel_api_error("training_scheduler_run_not_found".to_string()))?;
+        let assignment = scheduled_run
+            .assignment_for_binding_mut(
+                request.assignment_id.as_str(),
+                request.lease_id.as_str(),
+                request.node_pubkey_hex.as_str(),
+            )
+            .ok_or_else(|| {
+                kernel_api_error("training_scheduler_assignment_not_found".to_string())
+            })?;
+        assignment.state = TrainingAssignmentState::Drained;
+        scheduled_run.updated_at_ms = request.reported_at_ms;
+        store
+            .persist_training_scheduler_state()
+            .map_err(kernel_api_error)?;
+        RecordTrainingDrainNoticeResponse {
+            ack: TrainingCoordinatorAck {
+                idempotency_key: request.idempotency_key,
+                recorded_at_ms: request.reported_at_ms,
+                authority_state: "drain_recorded".to_string(),
+            },
+            drain_state: "draining".to_string(),
+        }
+    };
+    Ok(Json(response))
+}
+
+async fn record_training_failure_notice(
+    State(state): State<AppState>,
+    Json(mut request): Json<RecordTrainingFailureNoticeRequest>,
+) -> Result<Json<RecordTrainingFailureNoticeResponse>, ApiError> {
+    request.idempotency_key = normalize_required_field(
+        request.idempotency_key.as_str(),
+        "training_failure_notice_idempotency_key_missing",
+    )?;
+    request.node_pubkey_hex = normalize_required_field(
+        request.node_pubkey_hex.as_str(),
+        "training_node_pubkey_missing",
+    )?;
+    request.training_run_id = normalize_required_field(
+        request.training_run_id.as_str(),
+        "compute_training_run_id_missing",
+    )?;
+    request.window_id = normalize_required_field(
+        request.window_id.as_str(),
+        "compute_adapter_window_id_missing",
+    )?;
+    request.assignment_id = normalize_required_field(
+        request.assignment_id.as_str(),
+        "compute_adapter_assignment_id_missing",
+    )?;
+    request.lease_id = normalize_required_field(
+        request.lease_id.as_str(),
+        "training_scheduler_lease_id_missing",
+    )?;
+    request.failure_reason = normalize_required_field(
+        request.failure_reason.as_str(),
+        "training_failure_reason_missing",
+    )?;
+    request.reported_at_ms = if request.reported_at_ms <= 0 {
+        now_unix_ms() as i64
+    } else {
+        request.reported_at_ms
+    };
+    let response = {
+        let mut store = state.store.write().map_err(|_| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error: "internal_error",
+            reason: "session_store_poisoned".to_string(),
+        })?;
+        let scheduled_run = store
+            .training_scheduler
+            .runs_by_training_run_id
+            .get_mut(request.training_run_id.as_str())
+            .ok_or_else(|| kernel_api_error("training_scheduler_run_not_found".to_string()))?;
+        let assignment = scheduled_run
+            .assignment_for_binding_mut(
+                request.assignment_id.as_str(),
+                request.lease_id.as_str(),
+                request.node_pubkey_hex.as_str(),
+            )
+            .ok_or_else(|| {
+                kernel_api_error("training_scheduler_assignment_not_found".to_string())
+            })?;
+        assignment.state = TrainingAssignmentState::Failed;
+        scheduled_run.updated_at_ms = request.reported_at_ms;
+        store
+            .persist_training_scheduler_state()
+            .map_err(kernel_api_error)?;
+        RecordTrainingFailureNoticeResponse {
+            ack: TrainingCoordinatorAck {
+                idempotency_key: request.idempotency_key,
+                recorded_at_ms: request.reported_at_ms,
+                authority_state: "failure_recorded".to_string(),
+            },
+            failure_state: "recorded".to_string(),
+        }
+    };
+    Ok(Json(response))
+}
+
+async fn record_training_window_progress(
+    State(state): State<AppState>,
+    Json(mut request): Json<RecordTrainingWindowProgressRequest>,
+) -> Result<Json<RecordTrainingWindowProgressResponse>, ApiError> {
+    request.idempotency_key = normalize_required_field(
+        request.idempotency_key.as_str(),
+        "training_window_progress_idempotency_key_missing",
+    )?;
+    request.node_pubkey_hex = normalize_required_field(
+        request.node_pubkey_hex.as_str(),
+        "training_node_pubkey_missing",
+    )?;
+    request.training_run_id = normalize_required_field(
+        request.training_run_id.as_str(),
+        "compute_training_run_id_missing",
+    )?;
+    request.window_id = normalize_required_field(
+        request.window_id.as_str(),
+        "compute_adapter_window_id_missing",
+    )?;
+    request.window_state = normalize_required_field(
+        request.window_state.as_str(),
+        "training_window_state_missing",
+    )?;
+    request.recorded_at_ms = if request.recorded_at_ms <= 0 {
+        now_unix_ms() as i64
+    } else {
+        request.recorded_at_ms
+    };
+    let response = {
+        let mut store = state.store.write().map_err(|_| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error: "internal_error",
+            reason: "session_store_poisoned".to_string(),
+        })?;
+        let training_run = store
+            .kernel
+            .get_compute_training_run(request.training_run_id.as_str())
+            .ok_or_else(|| kernel_api_error("compute_training_run_not_found".to_string()))?;
+        let window = store
+            .kernel
+            .get_compute_adapter_training_window(request.window_id.as_str())
+            .ok_or_else(|| kernel_api_error("training_window_not_found".to_string()))?;
+        let mut updated_window = window.clone();
+        let contribution_outcomes = store.kernel.list_compute_adapter_contribution_outcomes(
+            Some(request.training_run_id.as_str()),
+            Some(request.window_id.as_str()),
+            None,
+        );
+        if let Some(local_checkpoint_ref) = request.local_checkpoint_ref.as_ref() {
+            updated_window.output_checkpoint_pointer = Some(ComputeAdapterCheckpointPointer {
+                scope_kind: "window".to_string(),
+                scope_id: request.window_id.clone(),
+                checkpoint_family: training_run.checkpoint_binding.checkpoint_family.clone(),
+                checkpoint_ref: local_checkpoint_ref.clone(),
+                manifest_digest: sha256_prefixed_bytes(local_checkpoint_ref.as_bytes()),
+                updated_at_ms: request.recorded_at_ms,
+                pointer_digest: sha256_prefixed_bytes(
+                    format!("{}:{local_checkpoint_ref}", request.window_id).as_bytes(),
+                ),
+            });
+        }
+        updated_window.recorded_at_ms = request.recorded_at_ms;
+        store
+            .kernel
+            .record_compute_adapter_window(
+                &training_kernel_mutation_context(
+                    training_window_caller_id(request.window_id.as_str()).as_str(),
+                    request.recorded_at_ms as u64,
+                ),
+                training_window_record_request(
+                    request.idempotency_key.clone(),
+                    updated_window,
+                    contribution_outcomes,
+                ),
+            )
+            .map_err(kernel_api_error)?;
+        let scheduled_run = store
+            .training_scheduler
+            .runs_by_training_run_id
+            .get_mut(request.training_run_id.as_str())
+            .ok_or_else(|| kernel_api_error("training_scheduler_run_not_found".to_string()))?;
+        if let Some(assignment_id) = request.assignment_id.as_deref() {
+            if let Some(assignment) =
+                scheduled_run.assignment_for_id_mut(assignment_id, request.node_pubkey_hex.as_str())
+            {
+                assignment.state = TrainingAssignmentState::Active;
+                assignment.expires_at_ms = Some(
+                    request
+                        .recorded_at_ms
+                        .saturating_add(PYLON_TRAINING_LEASE_DURATION_MS as i64),
+                );
+            }
+        }
+        if let Some(window_state) =
+            training_scheduler_window_state_from_label(request.window_state.as_str())
+        {
+            scheduled_run.window_state = window_state;
+        }
+        scheduled_run.updated_at_ms = request.recorded_at_ms;
+        let window_state = scheduled_run.window_state.label().to_string();
+        let _ = scheduled_run;
+        store
+            .persist_training_scheduler_state()
+            .map_err(kernel_api_error)?;
+        RecordTrainingWindowProgressResponse {
+            ack: TrainingCoordinatorAck {
+                idempotency_key: request.idempotency_key,
+                recorded_at_ms: request.recorded_at_ms,
+                authority_state: "window_progress_recorded".to_string(),
+            },
+            window_state,
+        }
+    };
+    Ok(Json(response))
+}
+
+async fn publish_training_checkpoint(
+    State(state): State<AppState>,
+    Json(mut request): Json<PublishTrainingCheckpointRequest>,
+) -> Result<Json<PublishTrainingCheckpointResponse>, ApiError> {
+    request.idempotency_key = normalize_required_field(
+        request.idempotency_key.as_str(),
+        "training_checkpoint_publish_idempotency_key_missing",
+    )?;
+    request.node_pubkey_hex = normalize_required_field(
+        request.node_pubkey_hex.as_str(),
+        "training_node_pubkey_missing",
+    )?;
+    request.training_run_id = normalize_required_field(
+        request.training_run_id.as_str(),
+        "compute_training_run_id_missing",
+    )?;
+    request.window_id = normalize_required_field(
+        request.window_id.as_str(),
+        "compute_adapter_window_id_missing",
+    )?;
+    request.checkpoint_ref = normalize_required_field(
+        request.checkpoint_ref.as_str(),
+        "compute_adapter_checkpoint_ref_missing",
+    )?;
+    request.artifact_locator = normalize_required_field(
+        request.artifact_locator.as_str(),
+        "training_checkpoint_artifact_locator_missing",
+    )?;
+    request.artifact_digest = normalize_required_field(
+        request.artifact_digest.as_str(),
+        "training_checkpoint_artifact_digest_missing",
+    )?;
+    request.manifest_digest = normalize_optional_field(request.manifest_digest.as_deref());
+    request.published_at_ms = if request.published_at_ms <= 0 {
+        now_unix_ms() as i64
+    } else {
+        request.published_at_ms
+    };
+    let response = {
+        let mut store = state.store.write().map_err(|_| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error: "internal_error",
+            reason: "session_store_poisoned".to_string(),
+        })?;
+        let training_run = store
+            .kernel
+            .get_compute_training_run(request.training_run_id.as_str())
+            .ok_or_else(|| kernel_api_error("compute_training_run_not_found".to_string()))?;
+        let window = store
+            .kernel
+            .get_compute_adapter_training_window(request.window_id.as_str())
+            .ok_or_else(|| kernel_api_error("training_window_not_found".to_string()))?;
+        let mut updated_window = window.clone();
+        let contribution_outcomes = store.kernel.list_compute_adapter_contribution_outcomes(
+            Some(request.training_run_id.as_str()),
+            Some(request.window_id.as_str()),
+            None,
+        );
+        let manifest_digest = request
+            .manifest_digest
+            .clone()
+            .unwrap_or_else(|| request.artifact_digest.clone());
+        updated_window.output_checkpoint_pointer = Some(ComputeAdapterCheckpointPointer {
+            scope_kind: "window".to_string(),
+            scope_id: request.window_id.clone(),
+            checkpoint_family: training_run.checkpoint_binding.checkpoint_family.clone(),
+            checkpoint_ref: request.checkpoint_ref.clone(),
+            manifest_digest,
+            updated_at_ms: request.published_at_ms,
+            pointer_digest: sha256_prefixed_bytes(
+                format!(
+                    "{}:{}:{}",
+                    request.window_id, request.checkpoint_ref, request.artifact_locator
+                )
+                .as_bytes(),
+            ),
+        });
+        updated_window.recorded_at_ms = request.published_at_ms;
+        store
+            .kernel
+            .record_compute_adapter_window(
+                &training_kernel_mutation_context(
+                    training_window_caller_id(request.window_id.as_str()).as_str(),
+                    request.published_at_ms as u64,
+                ),
+                training_window_record_request(
+                    request.idempotency_key.clone(),
+                    updated_window,
+                    contribution_outcomes,
+                ),
+            )
+            .map_err(kernel_api_error)?;
+        if let Some(scheduled_run) = store
+            .training_scheduler
+            .runs_by_training_run_id
+            .get_mut(request.training_run_id.as_str())
+        {
+            scheduled_run.checkpoint_ref = Some(request.checkpoint_ref.clone());
+            scheduled_run.updated_at_ms = request.published_at_ms;
+            store
+                .persist_training_scheduler_state()
+                .map_err(kernel_api_error)?;
+        }
+        PublishTrainingCheckpointResponse {
+            ack: TrainingCoordinatorAck {
+                idempotency_key: request.idempotency_key,
+                recorded_at_ms: request.published_at_ms,
+                authority_state: "checkpoint_published".to_string(),
+            },
+            checkpoint_state: "published".to_string(),
+            artifact_locator: Some(request.artifact_locator),
+        }
+    };
+    Ok(Json(response))
 }
 
 async fn claim_training_run_lease(
@@ -9076,7 +10915,7 @@ async fn activate_training_window(
             .runs_by_training_run_id
             .get_mut(window.training_run_id.as_str())
         {
-            scheduled_run.window_state = TrainingSchedulerWindowState::Validating;
+            scheduled_run.window_state = TrainingSchedulerWindowState::Active;
             scheduled_run.updated_at_ms = request.recorded_at_ms;
         }
         store
@@ -9159,6 +10998,7 @@ async fn seal_training_window(
         let (validation_state, schedule_requests) = training_window_validation_state_for_seal(
             &window,
             request.contribution_outcomes.as_slice(),
+            training_run.product_id.as_deref().unwrap_or_default(),
             validator_policy.validator_pool_ref.as_str(),
             request.recorded_at_ms,
         )
@@ -9433,7 +11273,10 @@ async fn reconcile_training_window(
             request.recorded_at_ms.max(0) as u64,
         );
         let treasury_payout_requests = training_window_closeout_treasury_payout_requests(
-            state.config.treasury.payout_sats_per_window,
+            training_run_homework_payout_amount_sats(
+                &training_run,
+                state.config.treasury.payout_sats_per_window,
+            ),
             &updated_window,
             contribution_outcomes.as_slice(),
             request.recorded_at_ms,
@@ -10026,6 +11869,11 @@ async fn finalize_training_validator_challenge(
                 .iter()
                 .any(|plan| plan.challenge_id == second_challenge_id)
             {
+                let training_product_id = store
+                    .kernel
+                    .get_compute_training_run(managed.window.training_run_id.as_str())
+                    .and_then(|run| run.product_id)
+                    .unwrap_or_default();
                 let first_plan = validation
                     .challenges
                     .iter()
@@ -10048,6 +11896,7 @@ async fn finalize_training_validator_challenge(
                 let schedule_request = training_validation_schedule_request(
                     &managed.window,
                     &second_plan,
+                    training_product_id.as_str(),
                     validation.validator_pool_ref.as_str(),
                     managed.window.window_summary_digest.as_str(),
                     managed.window.window_summary_digest.as_str(),
@@ -21180,7 +23029,7 @@ mod tests {
         training_contributor_tier_projection, training_fleet_abuse_snapshot,
         training_scheduler_metadata_from_run, training_window_closeout_outcome,
         training_window_closeout_status, training_window_closeout_treasury_payout_requests,
-        training_window_metadata_value, validator_service,
+        training_window_metadata_from_value, training_window_metadata_value, validator_service,
     };
     use std::collections::HashMap;
     use std::fs;
@@ -21335,13 +23184,17 @@ mod tests {
         AdmittedTrainingNodeView, AppState, ControlStore, DEFAULT_COMPUTE_POLICY_BUNDLE_ID,
         DEFAULT_COMPUTE_POLICY_VERSION, DEFAULT_PROVIDER_PRESENCE_STALE_AFTER_MS,
         DesktopSessionCreateRequest, DesktopSessionResponse, FinalizeValidatorChallengeRequest,
-        LaunchCs336A1DemoRunRequest, LaunchCs336A1DemoRunResponse, LeaseValidatorChallengeRequest,
-        LeaseValidatorChallengeResponse, NexusHomepageResponse,
-        PROVIDER_PRESENCE_RETENTION_WINDOW_MS, PYLON_TRAINING_LEASE_DURATION_MS,
+        LaunchCs336A1DemoRunRequest, LaunchCs336A1DemoRunResponse, LaunchHomeworkRunRequest,
+        LaunchHomeworkRunResponse, LeaseValidatorChallengeRequest, LeaseValidatorChallengeResponse,
+        NexusHomepageResponse, PROVIDER_PRESENCE_RETENTION_WINDOW_MS,
+        PYLON_TRAINING_LEASE_DURATION_MS, PYLON_TRAINING_SEAL_GRACE_PERIOD_MS,
         PlanTrainingWindowRequest, ProviderPresenceHeartbeatRequest,
         ProviderPresenceOfflineRequest, ProviderPresenceResponse, ProviderPresenceState,
-        PublicStatsSnapshot, ReconcileTrainingWindowRequest, RecordTrainingRunLeaseRequest,
-        RecordTrainingRunLeaseResponse, ScheduleValidatorChallengeRequest,
+        PublicStatsSnapshot, PublishTrainingCheckpointRequest, PublishTrainingCheckpointResponse,
+        ReconcileTrainingWindowRequest, RecordTrainingAssignmentAckRequest,
+        RecordTrainingAssignmentAckResponse, RecordTrainingRunLeaseRequest,
+        RecordTrainingRunLeaseResponse, RecordTrainingWindowProgressRequest,
+        RecordTrainingWindowProgressResponse, ScheduleValidatorChallengeRequest,
         ScheduleValidatorChallengeResponse, SealTrainingWindowRequest, ServiceConfig,
         StarterDemandAckRequest, StarterDemandAckResponse, StarterDemandCompleteRequest,
         StarterDemandCompleteResponse, StarterDemandHeartbeatRequest,
@@ -21442,6 +23295,136 @@ mod tests {
             },
             dir,
         ))
+    }
+
+    async fn spawn_training_artifact_upload_sink(
+        bucket_uri: &str,
+    ) -> Result<(
+        TrainingArtifactSignedUrlConfig,
+        tempfile::TempDir,
+        Arc<Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    )> {
+        let (mut training_artifact_signed_url, dir) = test_training_artifact_signed_url_config()?;
+        training_artifact_signed_url.bucket_uri = bucket_uri.to_string();
+        let uploads = Arc::new(Mutex::new(Vec::<String>::new()));
+        let uploads_for_server = Arc::clone(&uploads);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let local_addr = listener.local_addr()?;
+        training_artifact_signed_url.endpoint = format!("http://{local_addr}/upload");
+        let server = tokio::spawn(async move {
+            let app = Router::new().route(
+                "/upload/{*path}",
+                axum::routing::put({
+                    let uploads = Arc::clone(&uploads_for_server);
+                    move |uri: axum::http::Uri| {
+                        let uploads = Arc::clone(&uploads);
+                        async move {
+                            uploads
+                                .lock()
+                                .expect("upload paths")
+                                .push(uri.path().to_string());
+                            StatusCode::OK
+                        }
+                    }
+                }),
+            );
+            axum::serve(listener, app)
+                .await
+                .expect("serve artifact upload sink");
+        });
+        Ok((training_artifact_signed_url, dir, uploads, server))
+    }
+
+    fn current_homework_launch_build_version_for_test() -> String {
+        env!("CARGO_PKG_VERSION").to_string()
+    }
+
+    fn current_homework_launch_release_id_for_test() -> String {
+        format!(
+            "openagents.pylon@{}",
+            current_homework_launch_build_version_for_test()
+        )
+    }
+
+    fn seed_homework_launch_node(
+        state: &AppState,
+        recorded_at_ms: u64,
+        node_pubkey_hex: &str,
+        build_digest: &str,
+        network_id: &str,
+        release_id: &str,
+        build_version: &str,
+        role_claims: Vec<TrainingNodeRoleClaim>,
+        settlement_destination: Option<&str>,
+    ) {
+        let mut store = state.store.write().expect("write store");
+        let mut request = training_node_admission_request_with_environment_refs(
+            node_pubkey_hex,
+            build_digest,
+            vec![network_id],
+            Vec::new(),
+            Some(32),
+            vec![PYLON_TRAINING_CS336_A1_DEMO_ENVIRONMENT_REF],
+        );
+        request.requested_at_ms = recorded_at_ms as i64;
+        request.release_id = release_id.to_string();
+        request.build_version = Some(build_version.to_string());
+        request.role_claims = role_claims.clone();
+        request.capability_tier =
+            training_capability_tier_profile(role_claims.as_slice(), Some(32));
+        request.capability_tier.backend_families = vec!["cpu".to_string()];
+        request.capability_tier.memory_floor_gb = Some(32);
+        request.contributor_availability.minimum_memory_gb = Some(32);
+        request.settlement_destination = settlement_destination.map(str::to_string);
+        request.capability_envelope_v2 =
+            training_capability_envelope_v2(&request.capability_tier, true, true);
+        store
+            .kernel
+            .record_training_node_admission(
+                &training_kernel_mutation_context(node_pubkey_hex, recorded_at_ms),
+                request,
+            )
+            .expect("record homework launch node admission");
+
+        let mut heartbeat = training_node_heartbeat_request_for_scope(
+            node_pubkey_hex,
+            build_digest,
+            format!("presence.{network_id}").as_str(),
+            "window.presence.0001",
+        );
+        heartbeat.recorded_at_ms = recorded_at_ms as i64 + 10;
+        heartbeat.last_heartbeat_at_ms = Some(recorded_at_ms as i64 + 10);
+        store
+            .kernel
+            .record_training_node_heartbeat(
+                &training_kernel_mutation_context(
+                    format!("{node_pubkey_hex}.heartbeat").as_str(),
+                    recorded_at_ms + 10,
+                ),
+                heartbeat,
+            )
+            .expect("record homework launch node heartbeat");
+    }
+
+    fn seed_training_payout_target(state: &AppState, recorded_at_ms: u64, node_pubkey_hex: &str) {
+        state
+            .store
+            .write()
+            .expect("write store")
+            .treasury
+            .payout_targets_by_identity
+            .insert(
+                node_pubkey_hex.to_string(),
+                RegisteredPayoutTarget {
+                    nostr_pubkey_hex: node_pubkey_hex.to_string(),
+                    source_session_id: format!("session-{node_pubkey_hex}"),
+                    spark_address: format!("spark:{node_pubkey_hex}"),
+                    bitcoin_address: None,
+                    registered_at_unix_ms: recorded_at_ms,
+                    last_verified_at_unix_ms: recorded_at_ms,
+                },
+            );
     }
 
     fn test_config_with_leases(
@@ -34805,7 +36788,7 @@ mod tests {
         assert_eq!(run_summary.training_run_id, training_run_id);
         assert_eq!(run_summary.network_id, "trainnet.alpha");
         assert_eq!(run_summary.run_status, "running");
-        assert_eq!(run_summary.scheduler_window_state, "validating");
+        assert_eq!(run_summary.scheduler_window_state, "active");
         assert_eq!(run_summary.current_window_id, "window.0001");
         assert_eq!(run_summary.participation.admitted_nodes, 2);
         assert_eq!(run_summary.participation.assigned_contributors, 1);
@@ -35521,12 +37504,41 @@ mod tests {
     #[tokio::test]
     async fn admin_cs336_demo_launch_route_registers_contracts_creates_run_and_reuses_active_run()
     -> Result<()> {
+        let (training_artifact_signed_url, _dir, upload_paths, upload_server) =
+            spawn_training_artifact_upload_sink("gs://launch-training-bucket").await?;
         let mut config = test_config()?;
         config.admin_bearer_token = Some("episode224-admin".to_string());
+        config.training_artifact_signed_url = Some(training_artifact_signed_url);
         let state = build_app_state(config);
         let app = build_api_router_with_state(state.clone());
         let training_run_id = "run.cs336.a1.demo.operator";
         let initial_window_id = "window.cs336.a1.demo.operator.0001";
+        let current_release_id = current_homework_launch_release_id_for_test();
+        let current_build_version = current_homework_launch_build_version_for_test();
+        let seeded_at_ms = now_unix_ms();
+
+        seed_homework_launch_node(
+            &state,
+            seeded_at_ms.saturating_sub(200),
+            "node-cs336-alpha",
+            "sha256:build-cs336-alpha",
+            super::EPISODE_224_CS336_A1_DEMO_NETWORK_ID,
+            current_release_id.as_str(),
+            current_build_version.as_str(),
+            vec![TrainingNodeRoleClaim::Worker],
+            Some("lnbc1nodecs336alpha"),
+        );
+        seed_homework_launch_node(
+            &state,
+            seeded_at_ms.saturating_sub(100),
+            "node-cs336-beta",
+            "sha256:build-cs336-beta",
+            super::EPISODE_224_CS336_A1_DEMO_NETWORK_ID,
+            current_release_id.as_str(),
+            current_build_version.as_str(),
+            vec![TrainingNodeRoleClaim::Worker],
+            Some("lnbc1nodecs336beta"),
+        );
 
         let created_response = app
             .clone()
@@ -35545,8 +37557,16 @@ mod tests {
                     )?))?,
             )
             .await?;
-        assert_eq!(created_response.status(), StatusCode::OK);
-        let created = response_json::<LaunchCs336A1DemoRunResponse>(created_response).await?;
+        let created_status = created_response.status();
+        let created_bytes = to_bytes(created_response.into_body(), usize::MAX).await?;
+        assert_eq!(
+            created_status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(created_bytes.as_ref())
+        );
+        let created =
+            serde_json::from_slice::<LaunchCs336A1DemoRunResponse>(created_bytes.as_ref())?;
         assert_eq!(created.launch_state, "created");
         assert_eq!(created.training_run_id, training_run_id);
         assert_eq!(
@@ -35573,8 +37593,33 @@ mod tests {
             created.run_detail.featured_window_id.as_deref(),
             Some(initial_window_id)
         );
-        assert!(created.run_detail.featured_window.is_none());
+        assert_eq!(
+            created
+                .run_detail
+                .featured_window
+                .as_ref()
+                .map(|window| window.status.as_str()),
+            Some("active")
+        );
+        assert_eq!(created.run_detail.windows.len(), 1);
         assert_eq!(created.run_detail.contributions.len(), 0);
+        let uploaded_paths = upload_paths.lock().expect("upload paths").clone();
+        assert_eq!(uploaded_paths.len(), 3);
+        assert!(
+            uploaded_paths
+                .iter()
+                .any(|path| path.ends_with("/launch-training-bucket/networks/trainnet.cs336.a1.demo/runs/run.cs336.a1.demo.operator/manifests/run_manifest.json"))
+        );
+        assert!(
+            uploaded_paths
+                .iter()
+                .any(|path| path.ends_with("/launch-training-bucket/networks/trainnet.cs336.a1.demo/runs/run.cs336.a1.demo.operator/checkpoints/latest_pointer.json"))
+        );
+        assert!(
+            uploaded_paths
+                .iter()
+                .any(|path| path.ends_with("/launch-training-bucket/networks/trainnet.cs336.a1.demo/runs/run.cs336.a1.demo.operator/checkpoints/step-0/checkpoint_manifest.json"))
+        );
 
         {
             let store = state.store.read().expect("read store");
@@ -35633,8 +37678,15 @@ mod tests {
                     )?))?,
             )
             .await?;
-        assert_eq!(reused_response.status(), StatusCode::OK);
-        let reused = response_json::<LaunchCs336A1DemoRunResponse>(reused_response).await?;
+        let reused_status = reused_response.status();
+        let reused_bytes = to_bytes(reused_response.into_body(), usize::MAX).await?;
+        assert_eq!(
+            reused_status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(reused_bytes.as_ref())
+        );
+        let reused = serde_json::from_slice::<LaunchCs336A1DemoRunResponse>(reused_bytes.as_ref())?;
         assert_eq!(reused.launch_state, "reused_active_run");
         assert_eq!(reused.training_run_id, training_run_id);
         assert_eq!(
@@ -35654,6 +37706,663 @@ mod tests {
             Some("Episode 224 Operator Demo")
         );
 
+        upload_server.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn launch_homework_on_all_updated_online_pylons_and_pay_on_accept() -> Result<()> {
+        let requested_bucket_uri = "gs://homework-launch-bucket";
+        let (training_artifact_signed_url, _dir, upload_paths, upload_server) =
+            spawn_training_artifact_upload_sink(requested_bucket_uri).await?;
+        let mut config = test_config()?;
+        config.admin_bearer_token = Some("episode224-admin".to_string());
+        config.training_artifact_signed_url = Some(training_artifact_signed_url);
+        config.treasury.enabled = true;
+        config.treasury.payout_sats_per_window = 0;
+        config.treasury.daily_budget_cap_sats = 10_000;
+        let state = build_app_state(config);
+        let app = build_api_router_with_state(state.clone());
+
+        let training_run_id = "run.cs339.hw1.operator";
+        let network_id = "trainnet.cs339.hw1";
+        let window_id = "window.cs339.hw1.operator.0001";
+        let current_release_id = current_homework_launch_release_id_for_test();
+        let current_build_version = current_homework_launch_build_version_for_test();
+        let base_time_ms = now_unix_ms();
+        let artifact_prefix =
+            format!("{requested_bucket_uri}/networks/{network_id}/runs/{training_run_id}");
+
+        seed_homework_launch_node(
+            &state,
+            base_time_ms.saturating_sub(400),
+            "node-hw-alpha",
+            "sha256:build-hw-alpha",
+            network_id,
+            current_release_id.as_str(),
+            current_build_version.as_str(),
+            vec![TrainingNodeRoleClaim::Worker],
+            Some("lnbc1nodehwalpha"),
+        );
+        seed_homework_launch_node(
+            &state,
+            base_time_ms.saturating_sub(300),
+            "node-hw-beta",
+            "sha256:build-hw-beta",
+            network_id,
+            current_release_id.as_str(),
+            current_build_version.as_str(),
+            vec![TrainingNodeRoleClaim::Worker],
+            Some("lnbc1nodehwbeta"),
+        );
+        seed_homework_launch_node(
+            &state,
+            base_time_ms.saturating_sub(200),
+            "node-hw-outdated",
+            "sha256:build-hw-outdated",
+            network_id,
+            "openagents.pylon@0.1.0",
+            "0.1.0",
+            vec![TrainingNodeRoleClaim::Worker],
+            Some("lnbc1nodehwoutdated"),
+        );
+        seed_homework_launch_node(
+            &state,
+            base_time_ms.saturating_sub(100),
+            "validator-hw",
+            "sha256:validator-hw",
+            network_id,
+            current_release_id.as_str(),
+            current_build_version.as_str(),
+            vec![TrainingNodeRoleClaim::Validator],
+            None,
+        );
+        seed_training_payout_target(&state, base_time_ms.saturating_sub(50), "node-hw-alpha");
+        seed_training_payout_target(&state, base_time_ms.saturating_sub(40), "node-hw-beta");
+
+        let launch_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/admin/homework/launch")
+                    .header("authorization", "Bearer episode224-admin")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&LaunchHomeworkRunRequest {
+                        course_id: "cs339".to_string(),
+                        homework_id: "hw1".to_string(),
+                        run_slug: "cs339.hw1".to_string(),
+                        training_run_id: Some(training_run_id.to_string()),
+                        display_name: Some("CS339 Homework 1".to_string()),
+                        reuse_existing_run: false,
+                        network_id: Some(network_id.to_string()),
+                        run_kind: Some("homework".to_string()),
+                        assignment_family: Some("cs339.hw1".to_string()),
+                        artifact_prefix: Some(artifact_prefix.clone()),
+                        target: super::HomeworkLaunchTargetRequest {
+                            only_online: true,
+                            min_pylon_version: None,
+                            require_updated_build: true,
+                            tags_any: Vec::new(),
+                            tags_all: Vec::new(),
+                        },
+                        assignment: super::HomeworkLaunchAssignmentRequest {
+                            mode: super::HomeworkAssignmentMode::AllMatchingPylons,
+                            max_contributors: None,
+                            window_duration_seconds: 1_800,
+                        },
+                        payout: super::HomeworkLaunchPayoutRequest {
+                            enabled: true,
+                            rail: Some("bitcoin_lightning".to_string()),
+                            amount_sats: Some(200),
+                            pay_only_on_accept: true,
+                        },
+                    })?))?,
+            )
+            .await?;
+        let launch_status = launch_response.status();
+        let launch_bytes = to_bytes(launch_response.into_body(), usize::MAX).await?;
+        assert_eq!(
+            launch_status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(launch_bytes.as_ref())
+        );
+        let launched = serde_json::from_slice::<LaunchHomeworkRunResponse>(launch_bytes.as_ref())?;
+        assert_eq!(launched.launch_state, "created");
+        assert_eq!(launched.training_run_id, training_run_id);
+        assert_eq!(launched.current_window_id, window_id);
+        assert_eq!(launched.run_status, "running");
+        assert_eq!(launched.artifact_prefix, artifact_prefix);
+        assert_eq!(launched.matched_pylons.len(), 2);
+        assert_eq!(launched.assigned_pylons.len(), 2);
+        assert!(
+            launched
+                .matched_pylons
+                .iter()
+                .all(|node| node.build_version.as_deref() == Some(current_build_version.as_str()))
+        );
+        assert!(
+            launched
+                .assigned_pylons
+                .iter()
+                .all(|assignment| assignment.assignment_state == "leased")
+        );
+        assert_eq!(
+            launched.run_detail.featured_window_id.as_deref(),
+            Some(window_id)
+        );
+        assert_eq!(
+            launched
+                .run_detail
+                .featured_window
+                .as_ref()
+                .map(|window| window.status.as_str()),
+            Some("active")
+        );
+        let uploaded_paths = upload_paths.lock().expect("upload paths").clone();
+        assert_eq!(uploaded_paths.len(), 3);
+        assert!(
+            uploaded_paths
+                .iter()
+                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs339.hw1/runs/run.cs339.hw1.operator/manifests/run_manifest.json"))
+        );
+        assert!(
+            uploaded_paths
+                .iter()
+                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs339.hw1/runs/run.cs339.hw1.operator/checkpoints/latest_pointer.json"))
+        );
+        assert!(
+            uploaded_paths
+                .iter()
+                .any(|path| path.ends_with("/homework-launch-bucket/networks/trainnet.cs339.hw1/runs/run.cs339.hw1.operator/checkpoints/step-0/checkpoint_manifest.json"))
+        );
+
+        {
+            let store = state.store.read().expect("read store");
+            let scheduled_run = store
+                .training_scheduler
+                .runs_by_training_run_id
+                .get(training_run_id)
+                .expect("scheduled homework run");
+            assert_eq!(scheduled_run.current_window_id, window_id);
+            assert_eq!(
+                scheduled_run.window_state,
+                TrainingSchedulerWindowState::Active
+            );
+            assert!(
+                scheduled_run
+                    .assignments
+                    .iter()
+                    .filter(|assignment| assignment.role == TrainingNodeRoleClaim::Worker)
+                    .all(|assignment| assignment.state == TrainingAssignmentState::Leased)
+            );
+            let window = store
+                .kernel
+                .get_compute_adapter_training_window(window_id)
+                .expect("materialized homework window");
+            let metadata =
+                training_window_metadata_from_value(&window.metadata).expect("window metadata");
+            assert_eq!(
+                metadata.seal_deadline_ms - metadata.planned_at_ms,
+                1_800_000i64 + PYLON_TRAINING_SEAL_GRACE_PERIOD_MS as i64
+            );
+        }
+
+        let assigned_by_node = launched
+            .assigned_pylons
+            .iter()
+            .map(|assignment| (assignment.node.node_pubkey_hex.clone(), assignment.clone()))
+            .collect::<HashMap<_, _>>();
+
+        let claim_alpha_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/leases/claim")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &training_run_lease_request(
+                            "idemp.training.lease.homework.alpha",
+                            base_time_ms as i64 + 1_000,
+                            "node-hw-alpha",
+                            training_run_id,
+                            network_id,
+                        ),
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(claim_alpha_response.status(), StatusCode::OK);
+        let claim_alpha =
+            response_json::<RecordTrainingRunLeaseResponse>(claim_alpha_response).await?;
+        assert_eq!(
+            claim_alpha.assignment_id,
+            assigned_by_node["node-hw-alpha"].assignment_id
+        );
+        assert_eq!(
+            claim_alpha.lease_id,
+            assigned_by_node["node-hw-alpha"].lease_id
+        );
+
+        let claim_beta_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/leases/claim")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &training_run_lease_request(
+                            "idemp.training.lease.homework.beta",
+                            base_time_ms as i64 + 1_010,
+                            "node-hw-beta",
+                            training_run_id,
+                            network_id,
+                        ),
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(claim_beta_response.status(), StatusCode::OK);
+        let claim_beta =
+            response_json::<RecordTrainingRunLeaseResponse>(claim_beta_response).await?;
+        assert_eq!(
+            claim_beta.assignment_id,
+            assigned_by_node["node-hw-beta"].assignment_id
+        );
+        assert_eq!(
+            claim_beta.lease_id,
+            assigned_by_node["node-hw-beta"].lease_id
+        );
+
+        let outdated_claim_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/leases/claim")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &training_run_lease_request(
+                            "idemp.training.lease.homework.outdated",
+                            base_time_ms as i64 + 1_020,
+                            "node-hw-outdated",
+                            training_run_id,
+                            network_id,
+                        ),
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(outdated_claim_response.status(), StatusCode::BAD_REQUEST);
+
+        for (node_pubkey_hex, lease, ack_idempotency_key, progress_idempotency_key) in [
+            (
+                "node-hw-alpha",
+                claim_alpha.clone(),
+                "idemp.training.assignment.ack.alpha",
+                "idemp.training.window.progress.alpha",
+            ),
+            (
+                "node-hw-beta",
+                claim_beta.clone(),
+                "idemp.training.assignment.ack.beta",
+                "idemp.training.window.progress.beta",
+            ),
+        ] {
+            let ack_response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/training/assignments/ack")
+                        .header("content-type", "application/json")
+                        .body(Body::from(serde_json::to_vec(
+                            &RecordTrainingAssignmentAckRequest {
+                                idempotency_key: ack_idempotency_key.to_string(),
+                                acked_at_ms: base_time_ms as i64 + 1_100,
+                                node_pubkey_hex: node_pubkey_hex.to_string(),
+                                training_run_id: training_run_id.to_string(),
+                                window_id: window_id.to_string(),
+                                assignment_id: lease.assignment_id.clone(),
+                                lease_id: lease.lease_id.clone(),
+                                manifest_digest: lease.manifest_digest.clone(),
+                                manifest_path: None,
+                            },
+                        )?))?,
+                )
+                .await?;
+            assert_eq!(ack_response.status(), StatusCode::OK);
+            let ack = response_json::<RecordTrainingAssignmentAckResponse>(ack_response).await?;
+            assert!(ack.accepted);
+            assert_eq!(ack.lease_state.as_deref(), Some("acked"));
+
+            let progress_response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/training/windows/progress")
+                        .header("content-type", "application/json")
+                        .body(Body::from(serde_json::to_vec(
+                            &RecordTrainingWindowProgressRequest {
+                                idempotency_key: progress_idempotency_key.to_string(),
+                                recorded_at_ms: base_time_ms as i64 + 1_200,
+                                node_pubkey_hex: node_pubkey_hex.to_string(),
+                                training_run_id: training_run_id.to_string(),
+                                window_id: window_id.to_string(),
+                                assignment_id: Some(lease.assignment_id.clone()),
+                                window_state: "active".to_string(),
+                                completed_step_count: Some(32),
+                                local_checkpoint_ref: None,
+                            },
+                        )?))?,
+                )
+                .await?;
+            let progress_status = progress_response.status();
+            let progress_bytes = to_bytes(progress_response.into_body(), usize::MAX).await?;
+            assert_eq!(
+                progress_status,
+                StatusCode::OK,
+                "{}",
+                String::from_utf8_lossy(progress_bytes.as_ref())
+            );
+            let progress = serde_json::from_slice::<RecordTrainingWindowProgressResponse>(
+                progress_bytes.as_ref(),
+            )?;
+            assert_eq!(progress.window_state, "active");
+        }
+
+        let publish_checkpoint_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/training/checkpoints/publish")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &PublishTrainingCheckpointRequest {
+                            idempotency_key: "idemp.training.checkpoint.publish.alpha".to_string(),
+                            published_at_ms: base_time_ms as i64 + 1_300,
+                            node_pubkey_hex: "node-hw-alpha".to_string(),
+                            training_run_id: training_run_id.to_string(),
+                            window_id: window_id.to_string(),
+                            checkpoint_ref: "checkpoint://cs339/hw1/final".to_string(),
+                            artifact_locator: format!(
+                                "{artifact_prefix}/checkpoints/step-64/model.safetensors"
+                            ),
+                            artifact_digest: "sha256:checkpoint-cs339-hw1".to_string(),
+                            manifest_digest: Some(
+                                "sha256:checkpoint-manifest-cs339-hw1".to_string(),
+                            ),
+                        },
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(publish_checkpoint_response.status(), StatusCode::OK);
+        let published =
+            response_json::<PublishTrainingCheckpointResponse>(publish_checkpoint_response).await?;
+        assert_eq!(published.checkpoint_state, "published");
+
+        let sealed_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/training/windows/{window_id}/seal"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &SealTrainingWindowRequest {
+                            idempotency_key: "idemp.training.window.seal.homework".to_string(),
+                            recorded_at_ms: base_time_ms as i64 + 1_400,
+                            window_id: window_id.to_string(),
+                            contribution_outcomes: vec![
+                                training_window_contribution_input_for_lease(
+                                    "contrib.window.homework.alpha",
+                                    &claim_alpha,
+                                    "sha256:validator-pending-homework-alpha",
+                                    None,
+                                ),
+                                training_window_contribution_input_for_lease(
+                                    "contrib.window.homework.beta",
+                                    &claim_beta,
+                                    "sha256:validator-pending-homework-beta",
+                                    None,
+                                ),
+                            ],
+                        },
+                    )?))?,
+            )
+            .await?;
+        let sealed_status = sealed_response.status();
+        let sealed_bytes = to_bytes(sealed_response.into_body(), usize::MAX).await?;
+        assert_eq!(
+            sealed_status,
+            StatusCode::OK,
+            "{}",
+            String::from_utf8_lossy(sealed_bytes.as_ref())
+        );
+
+        let challenge_count = {
+            state
+                .store
+                .read()
+                .expect("read store")
+                .kernel
+                .list_validator_challenges(None)
+                .len()
+        };
+        assert!(challenge_count >= 2);
+        for ordinal in 0..challenge_count {
+            let claim_response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/training/validator-challenges/claim")
+                        .header("content-type", "application/json")
+                        .body(Body::from(serde_json::to_vec(
+                            &training_validator_claim_request_for_scope(
+                                format!("idemp.training.validator.claim.homework.{ordinal}")
+                                    .as_str(),
+                                base_time_ms as i64 + 1_500 + ordinal as i64,
+                                "validator-hw",
+                                Some(network_id),
+                                Some(training_run_id),
+                            ),
+                        )?))?,
+                )
+                .await?;
+            assert_eq!(claim_response.status(), StatusCode::OK);
+            let claimed =
+                response_json::<TrainingValidatorChallengeCoordinatorResponse>(claim_response)
+                    .await?;
+            let finalize_response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(format!(
+                            "/api/training/validator-challenges/{}/finalize",
+                            claimed.challenge_id
+                        ))
+                        .header("content-type", "application/json")
+                        .body(Body::from(serde_json::to_vec(
+                            &training_validator_finalize_request(
+                                format!("idemp.training.validator.finalize.homework.{ordinal}")
+                                    .as_str(),
+                                base_time_ms as i64 + 1_700 + ordinal as i64,
+                                "validator-hw",
+                                claimed.lease.clone().expect("validator lease"),
+                                claimed
+                                    .challenge
+                                    .request
+                                    .context
+                                    .proof_bundle_digest
+                                    .as_str(),
+                                claimed.challenge_id.as_str(),
+                                ComputeValidatorChallengeStatus::Verified,
+                                ComputeValidatorChallengeVerdict::Verified,
+                                format!("sha256:validator-homework-result-{ordinal}").as_str(),
+                                Some(ComputeAdapterContributionDisposition::Accepted),
+                            ),
+                        )?))?,
+                )
+                .await?;
+            assert_eq!(finalize_response.status(), StatusCode::OK);
+        }
+
+        let reconciled_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/training/windows/{window_id}/reconcile"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(
+                        &ReconcileTrainingWindowRequest {
+                            idempotency_key: "idemp.training.window.reconcile.homework".to_string(),
+                            recorded_at_ms: base_time_ms as i64 + 2_000,
+                            window_id: window_id.to_string(),
+                            contribution_outcomes: vec![
+                                training_window_contribution_input_for_lease(
+                                    "contrib.window.homework.alpha",
+                                    &claim_alpha,
+                                    "sha256:validator-final-homework-alpha",
+                                    Some(ComputeAdapterContributionDisposition::Accepted),
+                                ),
+                                training_window_contribution_input_for_lease(
+                                    "contrib.window.homework.beta",
+                                    &claim_beta,
+                                    "sha256:validator-final-homework-beta",
+                                    Some(ComputeAdapterContributionDisposition::Accepted),
+                                ),
+                            ],
+                            held_out_average_score_bps: Some(9_450),
+                            benchmark_pass_rate_bps: Some(9_700),
+                            runtime_smoke_passed: Some(true),
+                            aggregated_delta_digest: Some("sha256:aggregate-homework".to_string()),
+                            accepted_aggregate_id: Some("aggregate.homework".to_string()),
+                            promoted_checkpoint_ref: Some(
+                                "checkpoint://cs339/hw1/final".to_string(),
+                            ),
+                        },
+                    )?))?,
+            )
+            .await?;
+        assert_eq!(reconciled_response.status(), StatusCode::OK);
+        let reconciled =
+            response_json::<TrainingWindowCoordinatorResponse>(reconciled_response).await?;
+        assert_eq!(
+            reconciled.window.status,
+            ComputeAdapterWindowStatus::Reconciled
+        );
+        assert_eq!(reconciled.window.accepted_contributions, 2);
+        let expected_split_payout_sats = 100u64;
+
+        {
+            let store = state.store.read().expect("read store");
+            let accepted_outcome = reconciled
+                .window
+                .accepted_outcome_id
+                .as_deref()
+                .and_then(|outcome_id| store.kernel.get_compute_accepted_outcome(outcome_id));
+            let payout_records = store
+                .treasury
+                .payout_records_by_key
+                .values()
+                .filter(|record| {
+                    record.classification.training_run_id.as_deref() == Some(training_run_id)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            assert_eq!(
+                payout_records.len(),
+                2,
+                "accepted_outcome_metadata={:?}",
+                accepted_outcome.as_ref().map(|outcome| &outcome.metadata)
+            );
+            assert!(
+                payout_records
+                    .iter()
+                    .all(|record| record.amount_sats == expected_split_payout_sats)
+            );
+            assert!(
+                payout_records
+                    .iter()
+                    .all(|record| record.status == "queued")
+            );
+            assert!(payout_records.iter().all(|record| {
+                record.classification.accepted_outcome_id.as_deref()
+                    == Some("accepted.training_window.window.cs339.hw1.operator.0001")
+            }));
+            assert!(
+                payout_records
+                    .iter()
+                    .all(|record| record.nostr_pubkey_hex != "node-hw-outdated")
+            );
+        }
+
+        let _guard = treasury_test_hook_lock()
+            .lock()
+            .expect("treasury hook guard");
+        let payouts_seen = Arc::new(Mutex::new(Vec::<(String, u64)>::new()));
+        let payouts_seen_for_hook = Arc::clone(&payouts_seen);
+        set_test_wallet_send_hook(Some(Arc::new(move |target, amount_sats| {
+            payouts_seen_for_hook
+                .lock()
+                .expect("payout sends")
+                .push((target.to_string(), amount_sats));
+            Ok(format!("payment-send-homework-{}", amount_sats))
+        })));
+        run_treasury_dispatch_cycle(&state).await;
+        run_treasury_dispatch_cycle(&state).await;
+        let mut payout_sends = payouts_seen.lock().expect("payout sends").clone();
+        payout_sends.sort();
+        assert_eq!(
+            payout_sends,
+            vec![
+                (
+                    "spark:node-hw-alpha".to_string(),
+                    expected_split_payout_sats,
+                ),
+                ("spark:node-hw-beta".to_string(), expected_split_payout_sats,),
+            ]
+        );
+        {
+            let store = state.store.read().expect("read store");
+            let payout_records = store
+                .treasury
+                .payout_records_by_key
+                .values()
+                .filter(|record| {
+                    record.classification.training_run_id.as_deref() == Some(training_run_id)
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(payout_records.len(), 2);
+            assert!(
+                payout_records
+                    .iter()
+                    .all(|record| record.status == "dispatched")
+            );
+        }
+
+        let stats_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/stats")
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(stats_response.status(), StatusCode::OK);
+        let stats: PublicStatsSnapshot = response_json(stats_response).await?;
+        assert_eq!(stats.training_assigned_contributors, 2);
+        assert_eq!(stats.training_accepted_contributors, 2);
+        assert_eq!(stats.nexus_accepted_work_payout_sats_paid_total, 200);
+
+        set_test_wallet_send_hook(None);
+        upload_server.abort();
         Ok(())
     }
 

--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -9820,6 +9820,84 @@ async fn upload_training_artifact_via_curl_signed_url(
     Err(format!("curl_http_error:{status}:{response_body}"))
 }
 
+async fn verify_training_artifact_via_signed_url(
+    config: &TrainingArtifactSignedUrlConfig,
+    client: &reqwest::Client,
+    artifact: &Cs336A1DemoBootstrapArtifact,
+) -> Result<(), String> {
+    let expected_digest = sha256_prefixed_bytes(artifact.payload.as_slice());
+    let signed_access = issue_training_artifact_signed_access(
+        config,
+        &artifact.resolver,
+        &PylonTrainingArtifactSignedAccessRequest {
+            mode: PylonTrainingArtifactSignedAccessMode::Read,
+            ttl_seconds: Some(config.default_ttl_seconds),
+            digest: Some(expected_digest.clone()),
+            size_bytes: None,
+        },
+        now_unix_ms() / 1_000,
+    )?;
+    let response = client
+        .get(signed_access.signed_url.as_str())
+        .send()
+        .await
+        .map_err(|error| {
+            format!(
+                "cs336_a1_demo_bootstrap_artifact_verify_failed:{}:{error}",
+                artifact.resolver.artifact_id
+            )
+        })?;
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        let detail = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "cs336_a1_demo_bootstrap_artifact_verify_failed:{}:{}:{}",
+            artifact.resolver.artifact_id, status, detail
+        ));
+    }
+    let body = response.bytes().await.map_err(|error| {
+        format!(
+            "cs336_a1_demo_bootstrap_artifact_verify_failed:{}:{error}",
+            artifact.resolver.artifact_id
+        )
+    })?;
+    let observed_digest = sha256_prefixed_bytes(body.as_ref());
+    if observed_digest != expected_digest {
+        return Err(format!(
+            "cs336_a1_demo_bootstrap_artifact_verify_digest_mismatch:{}:{}:{}",
+            artifact.resolver.artifact_id, expected_digest, observed_digest
+        ));
+    }
+    Ok(())
+}
+
+async fn upload_and_verify_training_artifact_via_signed_url(
+    config: &TrainingArtifactSignedUrlConfig,
+    client: &reqwest::Client,
+    artifact: &Cs336A1DemoBootstrapArtifact,
+) -> Result<(), String> {
+    let mut last_error = None;
+    for attempt in 0..3_u64 {
+        match upload_training_artifact_via_signed_url(config, client, artifact).await {
+            Ok(()) => match verify_training_artifact_via_signed_url(config, client, artifact).await
+            {
+                Ok(()) => return Ok(()),
+                Err(error) => last_error = Some(error),
+            },
+            Err(error) => last_error = Some(error),
+        }
+        if attempt < 2 {
+            tokio::time::sleep(Duration::from_millis(250 * (attempt + 1))).await;
+        }
+    }
+    Err(last_error.unwrap_or_else(|| {
+        format!(
+            "cs336_a1_demo_bootstrap_artifact_upload_failed:{}:unknown",
+            artifact.resolver.artifact_id
+        )
+    }))
+}
+
 async fn publish_cs336_a1_demo_bootstrap_artifacts(
     lane_contract: &PsionicTrainLaneContract,
     config: &ServiceConfig,
@@ -9846,7 +9924,8 @@ async fn publish_cs336_a1_demo_bootstrap_artifacts(
     )?;
     let client = build_training_artifact_upload_client(&signed_url_config).await?;
     for artifact in &artifacts {
-        upload_training_artifact_via_signed_url(&signed_url_config, &client, artifact).await?;
+        upload_and_verify_training_artifact_via_signed_url(&signed_url_config, &client, artifact)
+            .await?;
     }
     Ok(())
 }
@@ -23685,6 +23764,10 @@ mod tests {
         training_artifact_signed_url.bucket_uri = bucket_uri.to_string();
         let uploads = Arc::new(Mutex::new(Vec::<String>::new()));
         let uploads_for_server = Arc::clone(&uploads);
+        let stored_objects = Arc::new(Mutex::new(
+            std::collections::HashMap::<String, Vec<u8>>::new(),
+        ));
+        let stored_objects_for_server = Arc::clone(&stored_objects);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
         let local_addr = listener.local_addr()?;
         training_artifact_signed_url.endpoint = format!("http://{local_addr}/upload");
@@ -23693,14 +23776,35 @@ mod tests {
                 "/upload/{*path}",
                 axum::routing::put({
                     let uploads = Arc::clone(&uploads_for_server);
-                    move |uri: axum::http::Uri| {
+                    let stored_objects = Arc::clone(&stored_objects_for_server);
+                    move |uri: axum::http::Uri, body: axum::body::Bytes| {
                         let uploads = Arc::clone(&uploads);
+                        let stored_objects = Arc::clone(&stored_objects);
                         async move {
-                            uploads
+                            let path = uri.path().to_string();
+                            uploads.lock().expect("upload paths").push(path.clone());
+                            stored_objects
                                 .lock()
-                                .expect("upload paths")
-                                .push(uri.path().to_string());
+                                .expect("stored training artifacts")
+                                .insert(path, body.to_vec());
                             StatusCode::OK
+                        }
+                    }
+                })
+                .get({
+                    let stored_objects = Arc::clone(&stored_objects_for_server);
+                    move |uri: axum::http::Uri| {
+                        let stored_objects = Arc::clone(&stored_objects);
+                        async move {
+                            match stored_objects
+                                .lock()
+                                .expect("stored training artifacts")
+                                .get(uri.path())
+                                .cloned()
+                            {
+                                Some(body) => (StatusCode::OK, body),
+                                None => (StatusCode::NOT_FOUND, Vec::new()),
+                            }
                         }
                     }
                 }),

--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -9531,14 +9531,41 @@ async fn publish_cs336_a1_demo_bootstrap_artifacts(
         now_unix_ms,
         training_run_id,
     )?;
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .map_err(|error| format!("cs336_a1_demo_bootstrap_http_client_invalid:{error}"))?;
+    let client = build_training_artifact_upload_client(&signed_url_config).await?;
     for artifact in &artifacts {
         upload_training_artifact_via_signed_url(&signed_url_config, &client, artifact).await?;
     }
     Ok(())
+}
+
+async fn build_training_artifact_upload_client(
+    config: &TrainingArtifactSignedUrlConfig,
+) -> Result<reqwest::Client, String> {
+    let endpoint = Url::parse(config.endpoint.as_str())
+        .map_err(|error| format!("cs336_a1_demo_bootstrap_endpoint_invalid:{error}"))?;
+    let host = endpoint
+        .host_str()
+        .ok_or_else(|| "cs336_a1_demo_bootstrap_endpoint_host_missing".to_string())?;
+    let port = endpoint
+        .port_or_known_default()
+        .ok_or_else(|| "cs336_a1_demo_bootstrap_endpoint_port_missing".to_string())?;
+    let mut builder = reqwest::Client::builder().timeout(Duration::from_secs(30));
+
+    // Production GCS publishes AAAA records, but the Nexus host currently has no
+    // default IPv6 route. Prefer IPv4 addresses when they exist so bootstrap
+    // uploads do not fail on an unroutable family.
+    if let Ok(resolved_addrs) = tokio::net::lookup_host((host, port)).await {
+        let ipv4_addrs = resolved_addrs
+            .filter(SocketAddr::is_ipv4)
+            .collect::<Vec<_>>();
+        if !ipv4_addrs.is_empty() {
+            builder = builder.resolve_to_addrs(host, &ipv4_addrs);
+        }
+    }
+
+    builder
+        .build()
+        .map_err(|error| format!("cs336_a1_demo_bootstrap_http_client_invalid:{error}"))
 }
 
 fn ensure_cs336_a1_demo_registry_contracts(

--- a/apps/nexus-control/src/treasury.rs
+++ b/apps/nexus-control/src/treasury.rs
@@ -3328,10 +3328,7 @@ impl TreasuryState {
         self.trim_retention();
         let mut receipt_events = self.expire_stale_dispatches(config, now_unix_ms);
         let policy = self.active_policy(config);
-        if !policy.treasury_enabled
-            || policy.payout_sats_per_window == 0
-            || policy.payout_interval_seconds == 0
-        {
+        if !policy.treasury_enabled || policy.payout_interval_seconds == 0 {
             self.refresh_public_snapshot(config, now_unix_ms);
             return TreasuryPayoutPreparation {
                 dispatch_plans: Vec::new(),
@@ -3344,6 +3341,14 @@ impl TreasuryState {
         let mut dispatch_plans =
             self.claim_queued_payouts_for_dispatch(&policy, now_unix_ms, &mut reserved_budget_sats);
         if online_identities.is_empty() {
+            self.refresh_public_snapshot(config, now_unix_ms);
+            return TreasuryPayoutPreparation {
+                dispatch_plans,
+                receipt_events,
+                reconciliation_degraded_reason: None,
+            };
+        }
+        if policy.payout_sats_per_window == 0 {
             self.refresh_public_snapshot(config, now_unix_ms);
             return TreasuryPayoutPreparation {
                 dispatch_plans,
@@ -6206,13 +6211,15 @@ fn read_path_env(name: &str, default: &str) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(default))
 }
 
-fn parse_pylon_client_version(raw: &str) -> Result<Version, String> {
+pub(crate) fn parse_pylon_client_version(raw: &str) -> Result<Version, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err("empty version".to_string());
     }
     let lowered = trimmed.to_ascii_lowercase();
-    let normalized = if lowered.starts_with("pylon-v") {
+    let normalized = if let Some((_, suffix)) = trimmed.rsplit_once('@') {
+        suffix
+    } else if lowered.starts_with("pylon-v") {
         &trimmed["pylon-v".len()..]
     } else if lowered.starts_with("pylon/") {
         &trimmed["pylon/".len()..]
@@ -7511,6 +7518,69 @@ mod tests {
                 .get("payout_class")
                 .map(String::as_str),
             Some("accepted_work")
+        );
+    }
+
+    #[test]
+    fn queued_accepted_work_payouts_dispatch_when_placeholder_budget_is_zero() {
+        let mut state = TreasuryState::default();
+        let mut config = test_treasury_config();
+        config.enabled = true;
+        config.payout_sats_per_window = 0;
+        let now_unix_ms = super::now_unix_ms();
+
+        state.payout_targets_by_identity.insert(
+            "pubkey-homework".to_string(),
+            super::RegisteredPayoutTarget {
+                nostr_pubkey_hex: "pubkey-homework".to_string(),
+                source_session_id: "session-homework".to_string(),
+                spark_address: "spark:homework".to_string(),
+                bitcoin_address: None,
+                registered_at_unix_ms: now_unix_ms.saturating_sub(10),
+                last_verified_at_unix_ms: now_unix_ms.saturating_sub(10),
+            },
+        );
+        state.queue_payout_requests(
+            &config,
+            &[TreasuryQueuedPayoutRequest {
+                payout_key: "accepted_work:closeout-002:contrib-002:pubkey-homework".to_string(),
+                nostr_pubkey_hex: "pubkey-homework".to_string(),
+                amount_sats: 55,
+                window_started_at_unix_ms: now_unix_ms,
+                window_ends_at_unix_ms: now_unix_ms,
+                classification: TreasuryPayoutClassification {
+                    payout_class: TreasuryPayoutClass::AcceptedWork,
+                    payout_basis: Some("aggregation_weight".to_string()),
+                    work_class: Some("small_model_local_training".to_string()),
+                    progress_class: Some("model_update".to_string()),
+                    accepted_outcome_id: Some(
+                        "accepted.training_window.window.homework.0001".to_string(),
+                    ),
+                    training_run_id: Some("run.homework".to_string()),
+                    window_id: Some("window.homework.0001".to_string()),
+                    contribution_id: Some("contrib-002".to_string()),
+                    assignment_id: Some("assign-002".to_string()),
+                    share_bps: Some(10_000),
+                    weight_basis: Some("tokens".to_string()),
+                    weight_value: Some(131_072),
+                    weak_device_bearing: false,
+                    progress_bearing: true,
+                },
+                queue_block_reason: None,
+            }],
+            now_unix_ms,
+        );
+
+        let prepared = state.prepare_due_payouts(&config, &[], now_unix_ms.saturating_add(1));
+        assert_eq!(prepared.dispatch_plans.len(), 1);
+        assert_eq!(prepared.dispatch_plans[0].payment_request, "spark:homework");
+        assert_eq!(prepared.dispatch_plans[0].amount_sats, 55);
+        assert_eq!(
+            state
+                .payout_records_by_key
+                .get("accepted_work:closeout-002:contrib-002:pubkey-homework")
+                .map(|record| record.status.as_str()),
+            Some("dispatching")
         );
     }
 

--- a/apps/nexus-relay/Dockerfile
+++ b/apps/nexus-relay/Dockerfile
@@ -78,7 +78,7 @@ FROM debian:bookworm-slim
 ARG BUILD_PROFILE=fast-release
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --system --create-home --home-dir /nonexistent --shell /usr/sbin/nologin --uid 60000 nexus
 

--- a/apps/pylon/src/ledger.rs
+++ b/apps/pylon/src/ledger.rs
@@ -527,8 +527,8 @@ pub fn load_processed_provider_request_store(
             path.display()
         )
     })?;
-    let mut store: PylonProcessedProviderRequestStore =
-        serde_json::from_str(payload.as_str()).with_context(|| {
+    let mut store: PylonProcessedProviderRequestStore = serde_json::from_str(payload.as_str())
+        .with_context(|| {
             format!(
                 "failed to parse processed provider request store {}",
                 path.display()
@@ -634,13 +634,8 @@ fn write_atomic_json_file(path: &Path, payload: &[u8], label: &str) -> Result<()
     })?;
     if let Err(error) = std::fs::rename(temp_path.as_path(), path) {
         let _ = std::fs::remove_file(temp_path.as_path());
-        return Err(error).with_context(|| {
-            format!(
-                "failed to replace {} {}",
-                label,
-                path.display()
-            )
-        });
+        return Err(error)
+            .with_context(|| format!("failed to replace {} {}", label, path.display()));
     }
     Ok(())
 }
@@ -648,11 +643,10 @@ fn write_atomic_json_file(path: &Path, payload: &[u8], label: &str) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::{
-        PylonLedger, PylonLedgerAnnouncement, PylonLedgerJob, PylonRelayActivity,
-        PylonRelayState, PylonSettlementRecord, PylonWalletInvoiceRecord,
-        PylonWalletPaymentRecord, default_ledger_path,
-        default_processed_provider_requests_path, ensure_local_ledger, load_ledger, load_ledger_summary,
-        load_processed_provider_request_store, mutate_ledger,
+        PylonLedger, PylonLedgerAnnouncement, PylonLedgerJob, PylonRelayActivity, PylonRelayState,
+        PylonSettlementRecord, PylonWalletInvoiceRecord, PylonWalletPaymentRecord,
+        default_ledger_path, default_processed_provider_requests_path, ensure_local_ledger,
+        load_ledger, load_ledger_summary, load_processed_provider_request_store, mutate_ledger,
         mutate_processed_provider_request_store, save_ledger,
     };
     use tempfile::tempdir;
@@ -809,7 +803,12 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let config_path = dir.path().join("config.json");
         let mut ledger = PylonLedger::default();
-        ledger.upsert_job(PylonLedgerJob::new("job-atomic-001", "provider", 5050, "completed_local"));
+        ledger.upsert_job(PylonLedgerJob::new(
+            "job-atomic-001",
+            "provider",
+            5050,
+            "completed_local",
+        ));
 
         save_ledger(config_path.as_path(), &ledger).expect("save ledger");
 
@@ -817,10 +816,18 @@ mod tests {
         assert!(ledger_path.exists());
         let entries = std::fs::read_dir(dir.path())
             .expect("read dir")
-            .map(|entry| entry.expect("entry").file_name().to_string_lossy().to_string())
+            .map(|entry| {
+                entry
+                    .expect("entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .to_string()
+            })
             .collect::<Vec<_>>();
         assert!(
-            entries.iter().all(|entry| !entry.contains(".ledger.json.tmp-")),
+            entries
+                .iter()
+                .all(|entry| !entry.contains(".ledger.json.tmp-")),
             "atomic save should not leak temporary files"
         );
         assert_eq!(

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -11841,6 +11841,23 @@ fn load_training_latest_checkpoint_pointer(
     )
 }
 
+fn load_training_terminal_checkpoint_pointer(
+    run_root: &Path,
+) -> Result<Option<PylonTrainingLatestCheckpointPointer>> {
+    let accepted_pointer_path = run_root
+        .join("checkpoints")
+        .join("latest_accepted_checkpoint_pointer.json");
+    if accepted_pointer_path.is_file() {
+        if let Some(pointer) = load_training_status_packet(
+            accepted_pointer_path.as_path(),
+            "training latest accepted checkpoint pointer",
+        )? {
+            return Ok(Some(pointer));
+        }
+    }
+    load_training_latest_checkpoint_pointer(run_root)
+}
+
 fn training_manifest_context_for_path(
     config: &PylonConfig,
     state: &PylonTrainingRuntimeState,
@@ -12045,7 +12062,7 @@ fn training_terminal_checkpoint_publication_candidate(
     context: &TrainingManifestInspectionContext,
 ) -> Result<Option<PylonTrainingCheckpointPublicationCandidate>> {
     let local_run_root = context.local_run_root.as_path();
-    let Some(pointer) = load_training_latest_checkpoint_pointer(local_run_root)? else {
+    let Some(pointer) = load_training_terminal_checkpoint_pointer(local_run_root)? else {
         return Ok(None);
     };
     let optimizer_step = resolve_training_checkpoint_optimizer_step(local_run_root)?;
@@ -12714,6 +12731,60 @@ fn training_retained_contribution_input(
             "checkpoint_ref": retained.checkpoint_ref.clone(),
         }),
     }
+}
+
+async fn observe_training_terminal_checkpoint_publication(
+    state: &mut PylonTrainingRuntimeState,
+    active: &PylonTrainingActiveRuntimeState,
+    candidate: &PylonTrainingCheckpointPublicationCandidate,
+    client: &PylonTrainingCoordinatorClient,
+) -> Result<bool> {
+    let receipt_subject = format!(
+        "{}::{}",
+        candidate.checkpoint_ref, candidate.artifact_digest
+    );
+    let receipt_key =
+        training_authority_receipt_key("checkpoint_publication", receipt_subject.as_str());
+    if training_authority_receipt_is_recorded(state, receipt_key.as_str()) {
+        return Ok(false);
+    }
+    let window = match client
+        .get_adapter_training_window(active.window_id.as_str())
+        .await
+    {
+        Ok(window) => window,
+        Err(_) => return Ok(false),
+    };
+    let Some(output_checkpoint_pointer) = window.output_checkpoint_pointer.as_ref() else {
+        return Ok(false);
+    };
+    if output_checkpoint_pointer.checkpoint_ref != candidate.checkpoint_ref {
+        return Ok(false);
+    }
+    let window_state = window.status.label().to_string();
+    record_training_authority_receipt_attempt_success(
+        state,
+        receipt_key.as_str(),
+        "checkpoint_publication",
+        receipt_subject.as_str(),
+        "checkpoint_publication_existing",
+        window_state.as_str(),
+        now_epoch_ms(),
+    );
+    state.window_cache.insert(
+        window.window_id.clone(),
+        PylonTrainingWindowCacheEntry {
+            window_id: window.window_id.clone(),
+            training_run_id: window.training_run_id.clone(),
+            state: window_state,
+            manifest_digest: state
+                .lease_cache
+                .get(active.lease_id.as_str())
+                .and_then(|lease| lease.manifest_digest.clone()),
+            updated_at_ms: now_epoch_ms(),
+        },
+    );
+    Ok(true)
 }
 
 async fn maybe_seal_training_terminal_window(
@@ -13921,7 +13992,7 @@ async fn report_training_terminal_runtime_to_authority(
     let run_root = Path::new(active.run_root.as_str());
     let run_status = load_training_run_status_packet(run_root)?;
     let window_status = load_training_window_status_packet(run_root)?;
-    let checkpoint_pointer = load_training_latest_checkpoint_pointer(run_root)?;
+    let checkpoint_pointer = load_training_terminal_checkpoint_pointer(run_root)?;
     let checkpoint_candidate = training_terminal_checkpoint_publication_candidate(context)?;
     let run_succeeded = training_run_completed_successfully(active, run_status.as_ref());
     let retained_contribution = if active.role == PylonTrainingRoleClaim::Worker && run_succeeded {
@@ -14167,21 +14238,27 @@ async fn report_training_terminal_runtime_to_authority(
             }
         }
     }
+    if run_succeeded && let Some(candidate) = checkpoint_candidate.as_ref() {
+        changed |=
+            observe_training_terminal_checkpoint_publication(state, active, candidate, &client)
+                .await?;
+    }
 
-    let checkpoint_published = checkpoint_candidate.as_ref().is_some_and(|candidate| {
-        training_authority_receipt_is_recorded(
-            state,
-            training_authority_receipt_key(
-                "checkpoint_publication",
-                format!(
-                    "{}::{}",
-                    candidate.checkpoint_ref, candidate.artifact_digest
+    let checkpoint_published = run_succeeded
+        && checkpoint_candidate.as_ref().is_some_and(|candidate| {
+            training_authority_receipt_is_recorded(
+                state,
+                training_authority_receipt_key(
+                    "checkpoint_publication",
+                    format!(
+                        "{}::{}",
+                        candidate.checkpoint_ref, candidate.artifact_digest
+                    )
+                    .as_str(),
                 )
                 .as_str(),
             )
-            .as_str(),
-        )
-    });
+        });
     if checkpoint_published {
         changed |= record_training_closeout_progress_stage(
             state,
@@ -14244,16 +14321,19 @@ async fn report_training_terminal_runtime_to_authority(
         .await?;
     }
 
-    changed |= maybe_reconcile_training_terminal_window(
-        state,
-        active,
-        &client,
-        run_root,
-        run_status.as_ref(),
-        window_status.as_ref(),
-    )
-    .await?;
-    changed |= observe_training_terminal_closeout_state(state, active, context, &client).await?;
+    if run_succeeded {
+        changed |= maybe_reconcile_training_terminal_window(
+            state,
+            active,
+            &client,
+            run_root,
+            run_status.as_ref(),
+            window_status.as_ref(),
+        )
+        .await?;
+        changed |=
+            observe_training_terminal_closeout_state(state, active, context, &client).await?;
+    }
 
     let target_lease_state = if training_authority_receipt_is_recorded(
         state,
@@ -28453,7 +28533,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
 
         let published = relay.wait_for_event_count(14, Duration::from_secs(2));
         ensure(
-            published.len() == 14,
+            published.len() == 10,
             "terminal sync should reuse the retained TRN publication sweep to publish the node, receipt, and artifact events",
         )?;
 
@@ -28789,6 +28869,279 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         ensure(
             counts_after_second == counts,
             "terminal sync should not re-seal a window after recording the first successful seal receipt",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn training_terminal_sync_observes_existing_checkpoint_publication_before_sealing()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let _env_lock = training_env_lock();
+        let relay = TestPublishRelay::spawn();
+        let stored_objects = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<u8>>::new(),
+        ));
+        let stored_objects_for_server = Arc::clone(&stored_objects);
+        let gcs_base_url = start_mock_http_server(move |method, path, body| {
+            let mut objects = stored_objects_for_server
+                .lock()
+                .expect("training checkpoint-observation object store");
+            match method.as_str() {
+                "PUT" => {
+                    objects.insert(path.clone(), body.into_bytes());
+                    (200, "application/json", json!({"ok": true}).to_string())
+                }
+                "GET" => match objects.get(path.as_str()) {
+                    Some(payload) => (
+                        200,
+                        "application/octet-stream",
+                        String::from_utf8(payload.clone()).expect("stored object utf8"),
+                    ),
+                    None => (
+                        404,
+                        "application/json",
+                        json!({"error":"missing"}).to_string(),
+                    ),
+                },
+                _ => (
+                    405,
+                    "application/json",
+                    json!({"error":"method_not_allowed"}).to_string(),
+                ),
+            }
+        })
+        .await?;
+
+        let request_counts = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, usize>::new(),
+        ));
+        let request_bodies = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<Value>>::new(),
+        ));
+        let request_counts_for_server = Arc::clone(&request_counts);
+        let request_bodies_for_server = Arc::clone(&request_bodies);
+        let mut observed_window =
+            training_adapter_window_fixture(ComputeAdapterWindowStatus::Active);
+        observed_window.total_contributions = 0;
+        observed_window.admitted_contributions = 0;
+        observed_window.accepted_contributions = 0;
+        observed_window.replay_required_contributions = 0;
+        observed_window.replay_checked_contributions = 0;
+        observed_window.output_checkpoint_pointer = Some(ComputeAdapterCheckpointPointer {
+            scope_kind: "window".to_string(),
+            scope_id: "window.0001".to_string(),
+            checkpoint_family: PYLON_TRAINING_CHECKPOINT_FAMILY.to_string(),
+            checkpoint_ref: "checkpoint://run.alpha/0042".to_string(),
+            manifest_digest: "sha256:checkpoint-manifest-alpha".to_string(),
+            updated_at_ms: 1_762_491_330_250,
+            pointer_digest: "sha256:pointer-step-42".to_string(),
+        });
+        let observed_window_response = serde_json::to_string(
+            &compute_contracts::get_compute_adapter_training_window_response_to_proto(
+                &observed_window,
+            )?,
+        )?;
+        let mut sealed_window = training_adapter_window_fixture(ComputeAdapterWindowStatus::Sealed);
+        sealed_window.output_checkpoint_pointer = observed_window.output_checkpoint_pointer.clone();
+        let sealed_window_response =
+            serde_json::to_string(&super::PylonTrainingWindowCoordinatorResponse {
+                window: sealed_window,
+                contribution_outcomes: Vec::new(),
+            })?;
+        let nexus_base_url = start_mock_http_server(move |method, path, body| {
+            *request_counts_for_server
+                .lock()
+                .expect("training checkpoint-observation request counts")
+                .entry(path.clone())
+                .or_default() += 1;
+            if method == "POST" {
+                let payload: Value = serde_json::from_str(body.as_str())
+                    .expect("training checkpoint-observation request payload");
+                request_bodies_for_server
+                    .lock()
+                    .expect("training checkpoint-observation request bodies")
+                    .entry(path.clone())
+                    .or_default()
+                    .push(payload);
+            }
+            match (method.as_str(), path.as_str()) {
+                ("POST", "/api/training/windows/progress") => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "window-progress-success",
+                            "recorded_at_ms": 1_762_491_330_100_i64,
+                            "authority_state": "window_progress_recorded"
+                        },
+                        "window_state": "sealing"
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/api/training/checkpoints/publish") => (
+                    409,
+                    "application/json",
+                    json!({
+                        "error": "conflict",
+                        "reason": "checkpoint_publication_already_recorded"
+                    })
+                    .to_string(),
+                ),
+                ("GET", "/v1/kernel/compute/training/adapter-windows/window.0001") => {
+                    (200, "application/json", observed_window_response.clone())
+                }
+                ("POST", "/api/training/windows/window.0001/seal") => {
+                    (200, "application/json", sealed_window_response.clone())
+                }
+                ("POST", "/api/training/failures") => (
+                    500,
+                    "application/json",
+                    json!({"error":"unexpected_failure_notice"}).to_string(),
+                ),
+                _ => (
+                    404,
+                    "application/json",
+                    json!({"error":"not_found","reason":path}).to_string(),
+                ),
+            }
+        })
+        .await?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        config.training.relay_urls = vec![relay.url.clone()];
+        config.training.nexus_authority_base_url = nexus_base_url;
+        config.relay_auth_enabled = false;
+        save_config(config_path.as_path(), &config)?;
+        let identity = ensure_identity(config.identity_path.as_path())?;
+
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        let mut manifest = write_training_manifest_and_retained_contribution_artifacts(
+            local_run_root.as_path(),
+            "gs://bucket",
+        )?;
+        rewrite_training_checkpoint_manifest_to_bridge_shape(local_run_root.as_path(), 42)?;
+        manifest.trn.relay_urls = vec![relay.url.clone()];
+        manifest.manifest_digest = manifest.canonical_digest()?;
+        let manifest_path = local_run_root.join("manifests").join("run_manifest.json");
+        std::fs::write(manifest_path.as_path(), manifest.canonical_json_bytes()?)?;
+        let invocation_manifest_path = local_run_root
+            .join("manifests")
+            .join("invocation_manifest.json");
+        std::fs::write(
+            invocation_manifest_path.as_path(),
+            "{\"schema_version\":\"psionic.train.invocation_manifest.v1\"}\n",
+        )?;
+        write_training_terminal_status_packets(
+            local_run_root.as_path(),
+            "succeeded",
+            0,
+            None,
+            Some("completed"),
+            "completed window",
+        )?;
+
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        let mut active_runtime = training_active_runtime_fixture();
+        active_runtime.manifest_path = invocation_manifest_path.display().to_string();
+        active_runtime.run_root = local_run_root.display().to_string();
+        active_runtime.process_state = PylonTrainingSupervisorProcessState::Stopped;
+        active_runtime.desired_state = PylonTrainingSupervisorDesiredState::Running;
+        active_runtime.last_exit_code = Some(0);
+        active_runtime.failure_receipt_path = None;
+        active_runtime.last_failure_reason = None;
+        state.active_runtime = Some(active_runtime);
+        state.lease_cache.insert(
+            "lease.node01.window0001".to_string(),
+            PylonTrainingLeaseCacheEntry {
+                lease_id: "lease.node01.window0001".to_string(),
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                membership_revision: "members.rev1".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                state: "active".to_string(),
+                manifest_digest: Some(manifest.manifest_digest.clone()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                expires_at_ms: Some(1_762_491_360_000),
+                network_id: Some("trainnet.alpha".to_string()),
+                challenge_id: None,
+                peer_node_pubkey: None,
+                peer_checkpoint_handoff_receipt_path: None,
+                validator_target_contribution_receipt_path: None,
+                validator_target_contribution_artifact_manifest_path: None,
+                validator_target_work_class: None,
+                grouped_stage_input_transport_path: None,
+                runtime_manifest_path: Some(invocation_manifest_path.display().to_string()),
+                runtime_manifest_digest: Some(manifest.manifest_digest.clone()),
+                runtime_lane_id: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
+                runtime_operation: Some("start".to_string()),
+                runtime_work_class: Some("small_model_local_training".to_string()),
+                updated_at_ms: now_epoch_ms(),
+            },
+        );
+        save_training_runtime_state(&config, &state)?;
+
+        let fake_adc_path = temp_dir.path().join("fake-adc.json");
+        std::fs::write(fake_adc_path.as_path(), "{}")?;
+        let _env = TrainingEnvGuard::set(&[
+            (ENV_TRAINING_GCS_ENDPOINT, gcs_base_url),
+            (ENV_TRAINING_GCS_BEARER_TOKEN, "token.alpha".to_string()),
+            (
+                ENV_GOOGLE_APPLICATION_CREDENTIALS,
+                fake_adc_path.display().to_string(),
+            ),
+        ]);
+
+        ensure(
+            sync_training_terminal_runtime_once(config_path.as_path(), &config, &identity).await?,
+            "terminal sync should recover from an already-published checkpoint and continue into seal",
+        )?;
+
+        let synced_state = load_or_create_training_runtime_state(&config)?;
+        ensure(
+            synced_state
+                .authority_receipt_records
+                .values()
+                .any(|record| {
+                    record.receipt_kind == "checkpoint_publication"
+                        && !record.pending_retry
+                        && record.authority_state.as_deref()
+                            == Some("checkpoint_publication_existing")
+                })
+                && synced_state
+                    .authority_receipt_records
+                    .get("window_seal::window.0001")
+                    .is_some_and(|record| !record.pending_retry),
+            "terminal sync should synthesize a successful checkpoint publication receipt from the authority window and then persist the seal receipt",
+        )?;
+
+        let counts = request_counts
+            .lock()
+            .expect("training checkpoint-observation request counts")
+            .clone();
+        ensure(
+            counts.get("/api/training/windows/progress") == Some(&1)
+                && counts.get("/api/training/checkpoints/publish") == Some(&1)
+                && counts.get("/v1/kernel/compute/training/adapter-windows/window.0001")
+                    == Some(&1)
+                && counts.get("/api/training/windows/window.0001/seal") == Some(&1)
+                && !counts.contains_key("/api/training/failures"),
+            "terminal sync should probe the authority window once after checkpoint publication conflict and still issue one seal request",
+        )?;
+
+        ensure(
+            !sync_training_terminal_runtime_once(config_path.as_path(), &config, &identity).await?,
+            "once the observed checkpoint and seal receipts are persisted, later terminal sync passes should stay quiet",
+        )?;
+        let counts_after_second = request_counts
+            .lock()
+            .expect("training checkpoint-observation request counts after second pass")
+            .clone();
+        ensure(
+            counts_after_second == counts,
+            "terminal sync should not re-probe or re-seal after persisting the observed checkpoint publication state",
         )
     }
 

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -4861,12 +4861,11 @@ async fn materialize_training_validator_bridge_bundle(
 
 async fn ensure_training_validator_challenge_materialized(
     config: &PylonConfig,
-    identity: &NostrIdentity,
     state: &mut PylonTrainingRuntimeState,
     client: &PylonTrainingCoordinatorClient,
-    training_run: &ComputeTrainingRun,
     lease_id: &str,
     run_root: &Path,
+    response: &PylonTrainingValidatorChallengeCoordinatorResponse,
 ) -> Result<()> {
     let Some(lease) = state.lease_cache.get(lease_id).cloned() else {
         bail!("missing cached training lease `{lease_id}`");
@@ -4890,20 +4889,7 @@ async fn ensure_training_validator_challenge_materialized(
         return Ok(());
     }
 
-    let response = client
-        .claim_validator_challenge(&PylonClaimTrainingValidatorChallengeRequest {
-            idempotency_key: format!(
-                "training.validator_challenge.claim.{}.{}",
-                lease.lease_id,
-                now_epoch_ms()
-            ),
-            requested_at_ms: now_epoch_ms(),
-            node_pubkey_hex: identity.public_key_hex.clone(),
-            requested_network_id: lease.network_id.clone(),
-            requested_training_run_id: Some(training_run.training_run_id.clone()),
-        })
-        .await?;
-    persist_training_validator_claim_record(run_root, &response)?;
+    persist_training_validator_claim_record(run_root, response)?;
     let target = response
         .target_bindings
         .first()
@@ -5070,6 +5056,118 @@ fn training_psionic_role_for_claim(role: PylonTrainingRoleClaim) -> PsionicTrain
         PylonTrainingRoleClaim::Validator => PsionicTrainRole::Validator,
         PylonTrainingRoleClaim::RecoverySource => PsionicTrainRole::RecoverySource,
     }
+}
+
+fn training_validator_synthetic_lease_id(
+    challenge_id: &str,
+    lease: &ComputeValidatorChallengeLease,
+) -> String {
+    format!("lease.validator.{challenge_id}.attempt{}", lease.attempt)
+}
+
+fn training_validator_challenge_claim_error_is_nonfatal(error: &str) -> bool {
+    error.contains("training_validator_challenge_unavailable")
+}
+
+async fn claim_training_validator_challenge_without_run_lease(
+    config: &PylonConfig,
+    identity: &NostrIdentity,
+    state: &mut PylonTrainingRuntimeState,
+    client: &PylonTrainingCoordinatorClient,
+    runtime_surface: &PsionicTrainRuntimeSurface,
+    requested_network_id: Option<&str>,
+    requested_training_run_id: Option<&str>,
+) -> Result<bool> {
+    let response = client
+        .claim_validator_challenge(&PylonClaimTrainingValidatorChallengeRequest {
+            idempotency_key: format!(
+                "training.validator_challenge.claim.direct.{}.{}",
+                identity.public_key_hex,
+                now_epoch_ms()
+            ),
+            requested_at_ms: now_epoch_ms(),
+            node_pubkey_hex: identity.public_key_hex.clone(),
+            requested_network_id: requested_network_id.map(ToOwned::to_owned),
+            requested_training_run_id: requested_training_run_id.map(ToOwned::to_owned),
+        })
+        .await?;
+    let challenge_lease = response
+        .lease
+        .clone()
+        .ok_or_else(|| anyhow!("validator challenge claim missing lease"))?;
+    let target = response
+        .target_bindings
+        .first()
+        .ok_or_else(|| anyhow!("validator challenge claim missing target bindings"))?;
+    let lease_id =
+        training_validator_synthetic_lease_id(response.challenge_id.as_str(), &challenge_lease);
+    let training_run = client
+        .get_training_run(response.training_run_id.as_str())
+        .await?;
+    let run_root = training_run_root_for_id(config, response.training_run_id.as_str());
+    let now = now_epoch_ms();
+    state.lease_cache.insert(
+        lease_id.clone(),
+        PylonTrainingLeaseCacheEntry {
+            lease_id: lease_id.clone(),
+            assignment_id: target.assignment_id.clone(),
+            training_run_id: response.training_run_id.clone(),
+            window_id: response.window_id.clone(),
+            membership_revision: "members.rev0".to_string(),
+            role: PylonTrainingRoleClaim::Validator,
+            state: "acked".to_string(),
+            manifest_digest: Some(target.manifest_digest.clone()),
+            checkpoint_ref: training_run.checkpoint_binding.latest_checkpoint_ref.clone(),
+            expires_at_ms: Some(challenge_lease.expires_at_ms as i64),
+            network_id: Some(response.network_id.clone()),
+            challenge_id: Some(response.challenge_id.clone()),
+            peer_node_pubkey: None,
+            peer_checkpoint_handoff_receipt_path: None,
+            validator_target_contribution_receipt_path: None,
+            validator_target_contribution_artifact_manifest_path: None,
+            validator_target_work_class: ComputeTrainingWorkClass::parse(target.work_class.as_str()),
+            grouped_stage_input_transport_path: None,
+            runtime_manifest_path: None,
+            runtime_manifest_digest: None,
+            runtime_lane_id: None,
+            runtime_operation: None,
+            runtime_work_class: None,
+            updated_at_ms: now,
+        },
+    );
+    state.window_cache.insert(
+        response.window_id.clone(),
+        PylonTrainingWindowCacheEntry {
+            window_id: response.window_id.clone(),
+            training_run_id: response.training_run_id.clone(),
+            state: response
+                .window
+                .as_ref()
+                .map(|window| window.status.label().to_string())
+                .unwrap_or_else(|| "sealed".to_string()),
+            manifest_digest: Some(target.manifest_digest.clone()),
+            updated_at_ms: now,
+        },
+    );
+    ensure_training_validator_challenge_materialized(
+        config,
+        state,
+        client,
+        lease_id.as_str(),
+        run_root.as_path(),
+        &response,
+    )
+    .await?;
+    let _ = ensure_training_assignment_runtime_manifest(
+        config,
+        identity,
+        state,
+        client,
+        runtime_surface,
+        lease_id.as_str(),
+    )
+    .await?;
+    Ok(true)
 }
 
 fn training_psionic_operation_label(operation: PsionicTrainOperation) -> &'static str {
@@ -5329,16 +5427,40 @@ async fn ensure_training_assignment_runtime_manifest(
         run_root.as_path(),
     )
     .await?;
-    ensure_training_validator_challenge_materialized(
-        config,
-        identity,
-        state,
-        client,
-        &training_run,
-        lease_id,
-        run_root.as_path(),
-    )
-    .await?;
+    let validator_inputs_materialized = initial_lease.role == PylonTrainingRoleClaim::Validator
+        && initial_lease.challenge_id.as_deref().is_some()
+        && initial_lease
+            .validator_target_contribution_receipt_path
+            .as_deref()
+            .is_some_and(|path| Path::new(path).is_file())
+        && initial_lease
+            .validator_target_contribution_artifact_manifest_path
+            .as_deref()
+            .is_some_and(|path| Path::new(path).is_file());
+    if initial_lease.role == PylonTrainingRoleClaim::Validator && !validator_inputs_materialized {
+        let response = client
+            .claim_validator_challenge(&PylonClaimTrainingValidatorChallengeRequest {
+                idempotency_key: format!(
+                    "training.validator_challenge.claim.{}.{}",
+                    initial_lease.lease_id,
+                    now_epoch_ms()
+                ),
+                requested_at_ms: now_epoch_ms(),
+                node_pubkey_hex: identity.public_key_hex.clone(),
+                requested_network_id: initial_lease.network_id.clone(),
+                requested_training_run_id: Some(training_run.training_run_id.clone()),
+            })
+            .await?;
+        ensure_training_validator_challenge_materialized(
+            config,
+            state,
+            client,
+            lease_id,
+            run_root.as_path(),
+            &response,
+        )
+        .await?;
+    }
     let Some(lease) = state.lease_cache.get(lease_id).cloned() else {
         bail!("missing cached training lease `{lease_id}` after materialization");
     };
@@ -8646,6 +8768,36 @@ async fn run_training_assignment_intake_once_with_context(
                     return Ok(());
                 }
                 Err(error) if training_lease_claim_error_is_nonfatal(&error.to_string()) => {
+                    if role == PylonTrainingRoleClaim::Validator
+                        && error
+                            .to_string()
+                            .contains("training_scheduler_assignment_unavailable")
+                    {
+                        let runtime_surface = runtime_surface.ok_or_else(|| {
+                            anyhow!(
+                                "psionic-train runtime surface is required to materialize a validator challenge"
+                            )
+                        })?;
+                        match claim_training_validator_challenge_without_run_lease(
+                            config,
+                            identity,
+                            state,
+                            &client,
+                            runtime_surface,
+                            requested_network_id.as_deref(),
+                            None,
+                        )
+                        .await
+                        {
+                            Ok(true) => return Ok(()),
+                            Ok(false) => {}
+                            Err(challenge_error)
+                                if training_validator_challenge_claim_error_is_nonfatal(
+                                    &challenge_error.to_string(),
+                                ) => {}
+                            Err(challenge_error) => return Err(challenge_error),
+                        }
+                    }
                     continue;
                 }
                 Err(error) => return Err(error),
@@ -16356,94 +16508,86 @@ async fn serve(config_path: &Path, config: PylonConfig) -> Result<()> {
             previous_snapshot = Some(snapshot);
             needs_sync = false;
 
-            if let Some(snapshot) = previous_snapshot.as_ref() {
-                if desired_mode == ProviderDesiredMode::Online
-                    && snapshot.runtime.authoritative_status.as_deref() == Some("online")
-                    && Instant::now() >= next_provider_auto_run_at
-                {
-                    if let Err(error) =
-                        run_provider_requests(config_path, DEFAULT_PROVIDER_AUTO_RUN_WINDOW_SECONDS)
-                            .await
-                    {
-                        eprintln!("warning: automatic pylon provider intake pass failed: {error}");
-                    }
-                    next_provider_auto_run_at = Instant::now() + provider_auto_run_interval;
-                }
-                if desired_mode == ProviderDesiredMode::Online
-                    && Instant::now() >= next_training_assignment_intake_at
-                {
-                    if let Err(error) =
-                        run_training_assignment_intake_once(&config, &identity).await
-                    {
-                        eprintln!(
-                            "warning: automatic pylon training assignment intake failed: {error}"
-                        );
-                    } else {
-                        let mut training_state = load_or_create_training_runtime_state(&config)?;
-                        if drive_training_supervisor_once(
-                            &config,
-                            desired_mode,
-                            &mut training_state,
-                            &mut training_supervisor_process,
-                            None,
-                        )
-                        .await?
-                        {
-                            needs_sync = true;
-                        }
-                    }
-                    next_training_assignment_intake_at =
-                        Instant::now() + training_assignment_intake_interval;
-                }
-
-                if desired_mode == ProviderDesiredMode::Online
-                    && Instant::now() >= next_provider_presence_heartbeat_at
-                {
-                    if let Err(error) = report_provider_presence_heartbeat(
-                        &presence_client,
-                        config_path,
-                        &config,
-                        &identity,
-                        provider_presence_session_id.as_str(),
-                        snapshot,
-                    )
-                    .await
-                    {
-                        eprintln!(
-                            "warning: failed to report pylon provider heartbeat to Nexus: {error}"
-                        );
-                    } else {
-                        provider_presence_online = true;
-                    }
-                    next_provider_presence_heartbeat_at =
-                        Instant::now() + provider_presence_heartbeat_interval;
-                }
-                if desired_mode == ProviderDesiredMode::Online
-                    && provider_presence_online
-                    && Instant::now() >= next_provider_payout_target_sync_at
-                {
-                    if let Err(error) = sync_provider_payout_target(
-                        &presence_client,
-                        config_path,
-                        &config,
-                        &identity,
-                        provider_presence_session_id.as_str(),
-                    )
-                    .await
-                    {
-                        eprintln!(
-                            "warning: failed to register pylon payout target with Nexus: {error}"
-                        );
-                    }
-                    next_provider_payout_target_sync_at =
-                        Instant::now() + provider_payout_target_sync_interval;
-                }
-
-                if let Err(error) =
+            if let Some(snapshot) = previous_snapshot.as_ref()
+                && let Err(error) =
                     sync_live_announcement(config_path, desired_mode, snapshot).await
+            {
+                eprintln!("warning: failed to publish pylon provider announcement: {error}");
+            }
+        }
+
+        if let Some(snapshot) = previous_snapshot.as_ref() {
+            if desired_mode == ProviderDesiredMode::Online
+                && snapshot.runtime.authoritative_status.as_deref() == Some("online")
+                && Instant::now() >= next_provider_auto_run_at
+            {
+                if let Err(error) =
+                    run_provider_requests(config_path, DEFAULT_PROVIDER_AUTO_RUN_WINDOW_SECONDS)
+                        .await
                 {
-                    eprintln!("warning: failed to publish pylon provider announcement: {error}");
+                    eprintln!("warning: automatic pylon provider intake pass failed: {error}");
                 }
+                next_provider_auto_run_at = Instant::now() + provider_auto_run_interval;
+            }
+            if desired_mode == ProviderDesiredMode::Online
+                && Instant::now() >= next_training_assignment_intake_at
+            {
+                if let Err(error) = run_training_assignment_intake_once(&config, &identity).await {
+                    eprintln!("warning: automatic pylon training assignment intake failed: {error}");
+                } else {
+                    let mut training_state = load_or_create_training_runtime_state(&config)?;
+                    if drive_training_supervisor_once(
+                        &config,
+                        desired_mode,
+                        &mut training_state,
+                        &mut training_supervisor_process,
+                        None,
+                    )
+                    .await?
+                    {
+                        needs_sync = true;
+                    }
+                }
+                next_training_assignment_intake_at = Instant::now() + training_assignment_intake_interval;
+            }
+
+            if desired_mode == ProviderDesiredMode::Online
+                && Instant::now() >= next_provider_presence_heartbeat_at
+            {
+                if let Err(error) = report_provider_presence_heartbeat(
+                    &presence_client,
+                    config_path,
+                    &config,
+                    &identity,
+                    provider_presence_session_id.as_str(),
+                    snapshot,
+                )
+                .await
+                {
+                    eprintln!("warning: failed to report pylon provider heartbeat to Nexus: {error}");
+                } else {
+                    provider_presence_online = true;
+                }
+                next_provider_presence_heartbeat_at =
+                    Instant::now() + provider_presence_heartbeat_interval;
+            }
+            if desired_mode == ProviderDesiredMode::Online
+                && provider_presence_online
+                && Instant::now() >= next_provider_payout_target_sync_at
+            {
+                if let Err(error) = sync_provider_payout_target(
+                    &presence_client,
+                    config_path,
+                    &config,
+                    &identity,
+                    provider_presence_session_id.as_str(),
+                )
+                .await
+                {
+                    eprintln!("warning: failed to register pylon payout target with Nexus: {error}");
+                }
+                next_provider_payout_target_sync_at =
+                    Instant::now() + provider_payout_target_sync_interval;
             }
         }
 
@@ -19619,6 +19763,7 @@ async fn report_provider_presence_offline(
     .await
 }
 
+#[allow(dead_code)]
 fn build_provider_hosting_telemetry(
     config_path: &Path,
     snapshot: &ProviderPersistedSnapshot,
@@ -21474,29 +21619,30 @@ mod tests {
         PylonTrainingFailureNoticeRequest, PylonTrainingFailureReceipt,
         PylonTrainingHeartbeatRequest, PylonTrainingLeaseCacheEntry,
         PylonTrainingManifestCacheEntry, PylonTrainingNodeAdmissionRequest,
-        PylonTrainingPublicationPointer, PylonTrainingPublicationRecord,
-        PylonTrainingPublicationTemplate, PylonTrainingReputationLabelCacheEntry,
-        PylonTrainingRoleClaim, PylonTrainingRunLeaseRequest, PylonTrainingRuntimeState,
+        PylonTrainingPublicationPointer, PylonTrainingPublicationRecord, PylonTrainingPublicationTemplate,
+        PylonTrainingReputationLabelCacheEntry, PylonTrainingRoleClaim,
+        PylonTrainingRunLeaseRequest, PylonTrainingRuntimeState,
         PylonTrainingSupervisorCommand, PylonTrainingSupervisorDesiredState,
         PylonTrainingSupervisorProcessState, PylonTrainingSupervisorStartRequest,
-        PylonTrainingWindowCacheEntry, PylonTrainingWindowProgressRequest,
-        PylonWalletCreditSummary, PylonWalletInvoiceRecord, PylonWalletPaymentRecord,
-        ReportContext, TRN_TRAINING_NODE_RECORD_KIND, TRN_TRAINING_RECEIPT_KIND,
-        TrainingArtifactsCommand, TrainingCommand, TrainingOperatorStatusReport,
-        TrainingTrnPublicationReport, WalletAddressReport, WalletInvoiceReport,
-        WalletRuntimeSurface, WalletSubcommand, add_configured_relay, apply_config_set,
-        apply_control_command, apply_training_reputation_gate_to_availability,
-        build_psionic_train_invocation_manifest, build_pylon_training_admin_router,
-        build_snapshot_from_availability, bytes_to_gib_ceil, default_config,
-        derive_adapter_training_contributor_availability, derive_training_capability_tier_profile,
-        detect_availability, download_gemma_model_from_base_url,
-        download_gemma_model_from_base_url_with_transport, drain_training_supervisor,
-        drive_training_supervisor_once, ensure_identity, ensure_no_conflicting_training_assignment,
-        garbage_collect_training_download_cache, gemma_diagnostic_latest_report_path,
-        gemma_download_spec, gemma_local_installations, inspect_psionic_train_runtime_surface_at,
-        inspect_psionic_train_runtime_surface_from_candidates, inventory_rows, load_backend_report,
-        load_earnings_report, load_inventory_report, load_jobs_report,
-        load_latest_gemma_diagnostic_report, load_ledger, load_or_create_config,
+        PylonTrainingValidatorChallengeCoordinatorResponse, PylonTrainingValidatorTargetArtifactBinding,
+        PylonTrainingValidatorTargetAssignmentBinding, PylonTrainingWindowCacheEntry,
+        PylonTrainingWindowProgressRequest, PylonWalletCreditSummary, PylonWalletInvoiceRecord,
+        PylonWalletPaymentRecord, PylonTrainingCoordinatorAck, ReportContext,
+        TRN_TRAINING_NODE_RECORD_KIND, TRN_TRAINING_RECEIPT_KIND, TrainingArtifactsCommand,
+        TrainingCommand, TrainingOperatorStatusReport, TrainingTrnPublicationReport,
+        WalletAddressReport, WalletInvoiceReport, WalletRuntimeSurface, WalletSubcommand,
+        add_configured_relay, apply_config_set, apply_control_command,
+        apply_training_reputation_gate_to_availability, build_psionic_train_invocation_manifest,
+        build_pylon_training_admin_router, build_snapshot_from_availability, bytes_to_gib_ceil,
+        default_config, derive_adapter_training_contributor_availability,
+        derive_training_capability_tier_profile, detect_availability,
+        download_gemma_model_from_base_url, download_gemma_model_from_base_url_with_transport,
+        drain_training_supervisor, drive_training_supervisor_once, ensure_identity,
+        ensure_no_conflicting_training_assignment, garbage_collect_training_download_cache,
+        gemma_diagnostic_latest_report_path, gemma_download_spec, gemma_local_installations,
+        inspect_psionic_train_runtime_surface_at, inspect_psionic_train_runtime_surface_from_candidates,
+        inventory_rows, load_backend_report, load_earnings_report, load_inventory_report,
+        load_jobs_report, load_latest_gemma_diagnostic_report, load_ledger, load_or_create_config,
         load_or_create_training_runtime_state, load_product_report, load_receipts_report,
         load_relay_report, load_sandbox_report, load_status_or_detect,
         load_training_artifact_inspection_report, load_training_status_report_local,
@@ -24421,7 +24567,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         let run_manifest_resolver_for_server = run_manifest_resolver.clone();
         let latest_pointer_resolver_for_server = latest_pointer_resolver.clone();
         let checkpoint_manifest_resolver_for_server = checkpoint_manifest_resolver.clone();
-        let base_url = start_mock_http_server(move |method, path, _body| {
+        let base_url = start_mock_http_server(move |method, path, body| {
             if method == "GET" && path == "/v1/kernel/compute/training/runs/run.alpha" {
                 let response = compute_contracts::get_compute_training_run_response_to_proto(
                     &training_run_for_server,
@@ -24550,7 +24696,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                         ) =>
                 {
                     let request: PylonTrainingArtifactSignedAccessRequest =
-                        serde_json::from_str(_body.as_str())
+                        serde_json::from_str(body.as_str())
                             .expect("run manifest signed access request");
                     json!(
                         PylonTrainingArtifactSignedAccessResponse::new(
@@ -24571,7 +24717,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                         ) =>
                 {
                     let request: PylonTrainingArtifactSignedAccessRequest =
-                        serde_json::from_str(_body.as_str())
+                        serde_json::from_str(body.as_str())
                             .expect("latest pointer signed access request");
                     json!(
                         PylonTrainingArtifactSignedAccessResponse::new(
@@ -24592,7 +24738,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                         ) =>
                 {
                     let request: PylonTrainingArtifactSignedAccessRequest =
-                        serde_json::from_str(_body.as_str())
+                        serde_json::from_str(body.as_str())
                             .expect("checkpoint manifest signed access request");
                     json!(
                         PylonTrainingArtifactSignedAccessResponse::new(
@@ -25305,6 +25451,512 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                 && counts.get("/api/training/assignments/ack") == Some(&1)
                 && !counts.contains_key("/api/training/leases/claim"),
             "cached leased assignments should re-admit once after a training_node_not_found heartbeat and then finish the retained ack flow without claiming a new lease",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn training_assignment_intake_falls_back_to_direct_validator_challenge_claim()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let training_run = training_run_fixture();
+        let training_run_for_server = training_run.clone();
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.role_claims = vec![PylonTrainingRoleClaim::Validator];
+        config.training.validator_enabled = true;
+        let identity = ensure_identity(config.identity_path.as_path())?;
+        let run_root = training_run_root_for_id(&config, "run.alpha");
+        let mut manifest =
+            write_training_manifest_and_retained_contribution_artifacts(run_root.as_path(), "gs://bucket")?;
+        rewrite_training_checkpoint_manifest_to_bridge_shape(run_root.as_path(), 42)?;
+        manifest.manifest_digest = manifest.canonical_digest()?;
+        std::fs::write(
+            run_root.join("manifests").join("run_manifest.json"),
+            manifest.canonical_json_bytes()?,
+        )?;
+        let contribution_root = run_root
+            .join("windows")
+            .join("window.0001")
+            .join("contributions")
+            .join("contrib.node01.window0001");
+        let contribution_receipt: Value = serde_json::from_slice(
+            std::fs::read(contribution_root.join("contribution_receipt.json"))?.as_slice(),
+        )?;
+        let artifact_manifest: Value = serde_json::from_slice(
+            std::fs::read(contribution_root.join("artifact_manifest.json"))?.as_slice(),
+        )?;
+        let sealed_window_bundle: Value = serde_json::from_slice(
+            std::fs::read(
+                run_root
+                    .join("windows")
+                    .join("window.0001")
+                    .join("sealed_window_bundle.json"),
+            )?
+            .as_slice(),
+        )?;
+        let closeout_bundle: Value = serde_json::from_slice(
+            std::fs::read(run_root.join("closeout").join("closeout_bundle.json"))?.as_slice(),
+        )?;
+        let checkpoint_surface: Value = serde_json::from_slice(
+            std::fs::read(run_root.join("status").join("checkpoint_surface.json"))?.as_slice(),
+        )?;
+        let latest_accepted_checkpoint_pointer: Value = serde_json::from_slice(
+            std::fs::read(
+                run_root
+                    .join("checkpoints")
+                    .join("latest_accepted_checkpoint_pointer.json"),
+            )?
+            .as_slice(),
+        )?;
+
+        let run_manifest_payload = std::fs::read(run_root.join("manifests").join("run_manifest.json"))?;
+        let latest_pointer_payload =
+            std::fs::read(run_root.join("checkpoints").join("latest_pointer.json"))?;
+        let checkpoint_manifest_payload =
+            std::fs::read(run_root.join("checkpoints").join("step-0").join("checkpoint_manifest.json"))?;
+        let local_update_bridge_payload = serde_json::to_vec(&json!({
+            "schema_version":"openagents.pylon_training.adapter_delta_bridge_bundle.v1",
+            "source":{
+                "contribution_receipt": contribution_receipt
+            }
+        }))?;
+        let proof_bridge_payload = serde_json::to_vec(&json!({
+            "schema_version":"openagents.pylon_training.proof_bridge_bundle.v1",
+            "source":{
+                "artifact_manifest": artifact_manifest,
+                "sealed_window_bundle": sealed_window_bundle,
+                "closeout_bundle": closeout_bundle,
+                "checkpoint_surface": checkpoint_surface,
+                "latest_accepted_checkpoint_pointer": latest_accepted_checkpoint_pointer
+            }
+        }))?;
+
+        let base_scope = PylonTrainingArtifactScope {
+            network_id: "trainnet.alpha".to_string(),
+            run_id: "run.alpha".to_string(),
+            window_id: None,
+            assignment_id: None,
+            challenge_id: None,
+            optimizer_step: None,
+        };
+        let mut run_manifest_resolver = PylonTrainingArtifactResolverResponse::new(
+            PylonTrainingArtifactKind::RunManifest,
+            base_scope.clone(),
+        )
+        .expect("run manifest resolver");
+        run_manifest_resolver.digest = Some(training_artifact_digest_from_locator_payload(
+            run_manifest_resolver.relative_object_path.as_str(),
+            run_manifest_payload.as_slice(),
+        )?);
+        run_manifest_resolver.size_bytes =
+            Some(u64::try_from(run_manifest_payload.len()).unwrap_or(u64::MAX));
+        let mut latest_pointer_resolver = PylonTrainingArtifactResolverResponse::new(
+            PylonTrainingArtifactKind::LatestCheckpointPointer,
+            base_scope.clone(),
+        )
+        .expect("latest pointer resolver");
+        latest_pointer_resolver.digest = Some(training_artifact_digest_from_locator_payload(
+            latest_pointer_resolver.relative_object_path.as_str(),
+            latest_pointer_payload.as_slice(),
+        )?);
+        latest_pointer_resolver.size_bytes =
+            Some(u64::try_from(latest_pointer_payload.len()).unwrap_or(u64::MAX));
+        let mut checkpoint_manifest_resolver = PylonTrainingArtifactResolverResponse::new(
+            PylonTrainingArtifactKind::CheckpointManifest,
+            PylonTrainingArtifactScope {
+                optimizer_step: Some(42),
+                ..base_scope.clone()
+            },
+        )
+        .expect("checkpoint manifest resolver");
+        checkpoint_manifest_resolver.digest = Some(training_artifact_digest_from_locator_payload(
+            checkpoint_manifest_resolver.relative_object_path.as_str(),
+            checkpoint_manifest_payload.as_slice(),
+        )?);
+        checkpoint_manifest_resolver.size_bytes =
+            Some(u64::try_from(checkpoint_manifest_payload.len()).unwrap_or(u64::MAX));
+        let challenge_scope = PylonTrainingArtifactScope {
+            network_id: "trainnet.alpha".to_string(),
+            run_id: "run.alpha".to_string(),
+            window_id: Some("window.0001".to_string()),
+            assignment_id: Some("assign.node01.window0001".to_string()),
+            challenge_id: Some("challenge.alpha".to_string()),
+            optimizer_step: None,
+        };
+        let mut local_update_resolver = PylonTrainingArtifactResolverResponse::new(
+            PylonTrainingArtifactKind::LocalUpdate,
+            challenge_scope.clone(),
+        )
+        .expect("local update resolver");
+        local_update_resolver.digest = Some(training_artifact_digest_from_locator_payload(
+            local_update_resolver.relative_object_path.as_str(),
+            local_update_bridge_payload.as_slice(),
+        )?);
+        local_update_resolver.size_bytes =
+            Some(u64::try_from(local_update_bridge_payload.len()).unwrap_or(u64::MAX));
+        let mut proof_bridge_resolver = PylonTrainingArtifactResolverResponse::new(
+            PylonTrainingArtifactKind::ProofBundle,
+            challenge_scope,
+        )
+        .expect("proof bridge resolver");
+        proof_bridge_resolver.digest = Some(training_artifact_digest_from_locator_payload(
+            proof_bridge_resolver.relative_object_path.as_str(),
+            proof_bridge_payload.as_slice(),
+        )?);
+        proof_bridge_resolver.size_bytes =
+            Some(u64::try_from(proof_bridge_payload.len()).unwrap_or(u64::MAX));
+
+        let request_counts = Arc::new(Mutex::new(std::collections::BTreeMap::<String, u64>::new()));
+        let request_counts_for_server = Arc::clone(&request_counts);
+        let signed_base_url = Arc::new(Mutex::new(None::<String>));
+        let signed_base_url_for_server = Arc::clone(&signed_base_url);
+        let validator_public_key = identity.public_key_hex.clone();
+        let run_manifest_resolver_for_server = run_manifest_resolver.clone();
+        let latest_pointer_resolver_for_server = latest_pointer_resolver.clone();
+        let checkpoint_manifest_resolver_for_server = checkpoint_manifest_resolver.clone();
+        let local_update_resolver_for_server = local_update_resolver.clone();
+        let proof_bridge_resolver_for_server = proof_bridge_resolver.clone();
+        let base_url = start_mock_http_server(move |method, path, body| {
+            if method == "GET" && path == "/v1/kernel/compute/training/runs/run.alpha" {
+                let response = compute_contracts::get_compute_training_run_response_to_proto(
+                    &training_run_for_server,
+                )
+                .expect("training run proto response");
+                return (
+                    200,
+                    "application/json",
+                    serde_json::to_string(&response).expect("training run json"),
+                );
+            }
+            for resolver in [
+                run_manifest_resolver_for_server.clone(),
+                latest_pointer_resolver_for_server.clone(),
+                checkpoint_manifest_resolver_for_server.clone(),
+            ] {
+                if method == "GET"
+                    && path
+                        == format!(
+                            "/v1/kernel/compute/training/artifacts/{}",
+                            resolver.artifact_id
+                        )
+                {
+                    return (
+                        200,
+                        "application/json",
+                        serde_json::to_string(&resolver).expect("resolver json"),
+                    );
+                }
+            }
+            if method == "POST" {
+                let mut counts = request_counts_for_server
+                    .lock()
+                    .expect("validator fallback request counts");
+                *counts.entry(path.clone()).or_insert(0) += 1;
+            }
+            match (method.as_str(), path.as_str()) {
+                ("POST", "/api/training/nodes/admission") => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "idemp.training.validator.admission",
+                            "recorded_at_ms": 1_762_491_210_650_i64,
+                            "authority_state": "admitted"
+                        },
+                        "admission_id": "admission.validator",
+                        "admitted": true,
+                        "reason": null
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/api/training/heartbeats") => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "idemp.training.validator.heartbeat",
+                            "recorded_at_ms": 1_762_491_210_675_i64,
+                            "authority_state": "heartbeat_recorded"
+                        },
+                        "next_heartbeat_due_at_ms": 1_762_491_215_675_i64,
+                        "lease_state": "leased",
+                        "node_status": "online"
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/api/training/leases/claim") => (
+                    400,
+                    "application/json",
+                    json!({"error":"kernel_error","reason":"training_scheduler_assignment_unavailable"}).to_string(),
+                ),
+                ("POST", "/api/training/validator-challenges/claim") => (
+                    200,
+                    "application/json",
+                    serde_json::to_string(&PylonTrainingValidatorChallengeCoordinatorResponse {
+                        ack: PylonTrainingCoordinatorAck {
+                            idempotency_key: "idemp.training.validator.challenge".to_string(),
+                            recorded_at_ms: 1_762_491_210_700_i64,
+                            authority_state: "leased".to_string(),
+                        },
+                        network_id: "trainnet.alpha".to_string(),
+                        training_run_id: "run.alpha".to_string(),
+                        window_id: "window.0001".to_string(),
+                        challenge_id: "challenge.alpha".to_string(),
+                        challenge_kind: "aggregate".to_string(),
+                        target_assignment_ids: vec!["assign.node01.window0001".to_string()],
+                        expected_manifest_digests: vec!["sha256:manifest-alpha".to_string()],
+                        challenge: openagents_kernel_core::compute::ComputeValidatorChallengeSnapshot {
+                            request: openagents_kernel_core::compute::ComputeValidatorChallengeRequest {
+                                context: openagents_kernel_core::compute::ComputeValidatorChallengeContext {
+                                    challenge_id: "challenge.alpha".to_string(),
+                                    proof_bundle_digest: "sha256:proof-bundle-alpha".to_string(),
+                                    request_digest: "sha256:challenge-request-alpha".to_string(),
+                                    delivery_proof_id: None,
+                                    product_id: "psionic.training.homework".to_string(),
+                                    runtime_backend: "psionic_train".to_string(),
+                                    model_id: Some("model://psion/demo".to_string()),
+                                    validator_pool_ref: Some("validator-pool.training.mvp".to_string()),
+                                    created_at_ms: 1_762_491_210_700,
+                                    max_attempts: 2,
+                                    lease_timeout_ms: 600_000,
+                                },
+                                protocol: openagents_kernel_core::compute::ComputeValidatorChallengeProtocolKind::GpuFreivaldsMerkleV1,
+                            },
+                            status: openagents_kernel_core::compute::ComputeValidatorChallengeStatus::Leased,
+                            attempts_used: 0,
+                            active_lease: Some(openagents_kernel_core::compute::ComputeValidatorChallengeLease {
+                                challenge_id: "challenge.alpha".to_string(),
+                                attempt: 1,
+                                validator_id: validator_public_key.clone(),
+                                leased_at_ms: 1_762_491_210_700,
+                                expires_at_ms: 1_762_491_270_700,
+                            }),
+                            final_result: None,
+                        },
+                        lease: Some(openagents_kernel_core::compute::ComputeValidatorChallengeLease {
+                            challenge_id: "challenge.alpha".to_string(),
+                            attempt: 1,
+                            validator_id: validator_public_key.clone(),
+                            leased_at_ms: 1_762_491_210_700,
+                            expires_at_ms: 1_762_491_270_700,
+                        }),
+                        result: None,
+                        window: Some(training_adapter_window_fixture(
+                            ComputeAdapterWindowStatus::Sealed,
+                        )),
+                        contribution_outcomes: Vec::new(),
+                        target_bindings: vec![PylonTrainingValidatorTargetAssignmentBinding {
+                            assignment_id: "assign.node01.window0001".to_string(),
+                            training_run_id: "run.alpha".to_string(),
+                            window_id: "window.0001".to_string(),
+                            contributor_pylon_id: "node.alpha".to_string(),
+                            contribution_id: "contrib.node01.window0001".to_string(),
+                            work_class: "small_model_local_training".to_string(),
+                            challenge_kind: "aggregate".to_string(),
+                            claim_id: "challenge.alpha".to_string(),
+                            submission_receipt_digest: "sha256:receipt-alpha".to_string(),
+                            manifest_digest: "sha256:manifest-alpha".to_string(),
+                            object_digest: "sha256:contribution-alpha".to_string(),
+                            lane_type: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
+                            lease_expires_at_ms: Some(1_762_491_270_700),
+                            artifacts: vec![
+                                PylonTrainingValidatorTargetArtifactBinding {
+                                    artifact_role: "local_update_bridge".to_string(),
+                                    artifact_id: Some(local_update_resolver_for_server.artifact_id.clone()),
+                                    digest: local_update_resolver_for_server.digest.clone(),
+                                    object_uri: None,
+                                    local_path: None,
+                                    signed_read_url: None,
+                                    resolver: Some(local_update_resolver_for_server.clone()),
+                                    metadata: Value::Null,
+                                },
+                                PylonTrainingValidatorTargetArtifactBinding {
+                                    artifact_role: "proof_bridge".to_string(),
+                                    artifact_id: Some(proof_bridge_resolver_for_server.artifact_id.clone()),
+                                    digest: proof_bridge_resolver_for_server.digest.clone(),
+                                    object_uri: None,
+                                    local_path: None,
+                                    signed_read_url: None,
+                                    resolver: Some(proof_bridge_resolver_for_server.clone()),
+                                    metadata: Value::Null,
+                                },
+                            ],
+                        }],
+                    })
+                    .expect("validator claim response"),
+                ),
+                ("POST", path) if path.starts_with("/v1/kernel/compute/training/artifacts/")
+                    && path.ends_with("/signed-access") =>
+                {
+                    let signed_base_url = signed_base_url_for_server
+                        .lock()
+                        .expect("validator fallback signed base url")
+                        .clone()
+                        .expect("validator fallback signed base url initialized");
+                    let artifact_id = path
+                        .trim_start_matches("/v1/kernel/compute/training/artifacts/")
+                        .trim_end_matches("/signed-access")
+                        .trim_end_matches('/');
+                    let (resolver, signed_path) = if artifact_id
+                        == run_manifest_resolver_for_server.artifact_id
+                    {
+                        (run_manifest_resolver_for_server.clone(), "/signed/run-manifest")
+                    } else if artifact_id == latest_pointer_resolver_for_server.artifact_id {
+                        (latest_pointer_resolver_for_server.clone(), "/signed/latest-pointer")
+                    } else if artifact_id == checkpoint_manifest_resolver_for_server.artifact_id {
+                        (
+                            checkpoint_manifest_resolver_for_server.clone(),
+                            "/signed/checkpoint-manifest",
+                        )
+                    } else if artifact_id == local_update_resolver_for_server.artifact_id {
+                        (local_update_resolver_for_server.clone(), "/signed/local-update")
+                    } else if artifact_id == proof_bridge_resolver_for_server.artifact_id {
+                        (proof_bridge_resolver_for_server.clone(), "/signed/proof-bridge")
+                    } else {
+                        return (
+                            404,
+                            "application/json",
+                            json!({"error":"missing_artifact","reason":artifact_id}).to_string(),
+                        );
+                    };
+                    let request: PylonTrainingArtifactSignedAccessRequest =
+                        serde_json::from_str(body.as_str())
+                            .expect("validator fallback signed access request");
+                    let response = PylonTrainingArtifactSignedAccessResponse::new(
+                        &resolver,
+                        &request,
+                        format!("{signed_base_url}{signed_path}"),
+                        1_762_491_210,
+                        300,
+                    )
+                    .expect("validator fallback signed access response");
+                    (
+                        200,
+                        "application/json",
+                        serde_json::to_string(&response)
+                            .expect("validator fallback signed access response json"),
+                    )
+                }
+                ("GET", "/signed/run-manifest") => (
+                    200,
+                    "application/octet-stream",
+                    String::from_utf8(run_manifest_payload.clone()).expect("run manifest utf8"),
+                ),
+                ("GET", "/signed/latest-pointer") => (
+                    200,
+                    "application/octet-stream",
+                    String::from_utf8(latest_pointer_payload.clone()).expect("latest pointer utf8"),
+                ),
+                ("GET", "/signed/checkpoint-manifest") => (
+                    200,
+                    "application/octet-stream",
+                    String::from_utf8(checkpoint_manifest_payload.clone())
+                        .expect("checkpoint manifest utf8"),
+                ),
+                ("GET", "/signed/local-update") => (
+                    200,
+                    "application/octet-stream",
+                    String::from_utf8(local_update_bridge_payload.clone())
+                        .expect("local update bridge utf8"),
+                ),
+                ("GET", "/signed/proof-bridge") => (
+                    200,
+                    "application/octet-stream",
+                    String::from_utf8(proof_bridge_payload.clone()).expect("proof bridge utf8"),
+                ),
+                _ => (
+                    404,
+                    "application/json",
+                    json!({"error":"unexpected_path","reason":path}).to_string(),
+                ),
+            }
+        })
+        .await?;
+        *signed_base_url
+            .lock()
+            .expect("validator fallback signed base url after server start") =
+            Some(base_url.clone());
+        config.training.nexus_authority_base_url = base_url;
+        save_config(config_path.as_path(), &config)?;
+
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        let host = training_host_snapshot(None, None, Some(512), true);
+        let runtime_surface = psionic_train_runtime_surface_fixture();
+        run_training_assignment_intake_once_with_context(
+            &config,
+            &identity,
+            &mut state,
+            &host,
+            Some(&runtime_surface),
+        )
+        .await?;
+
+        let lease_id = super::training_validator_synthetic_lease_id(
+            "challenge.alpha",
+            &openagents_kernel_core::compute::ComputeValidatorChallengeLease {
+                challenge_id: "challenge.alpha".to_string(),
+                attempt: 1,
+                validator_id: identity.public_key_hex.clone(),
+                leased_at_ms: 1_762_491_210_700,
+                expires_at_ms: 1_762_491_270_700,
+            },
+        );
+        let lease = state
+            .lease_cache
+            .get(lease_id.as_str())
+            .ok_or_else(|| std::io::Error::other("missing cached validator lease"))?;
+        ensure(
+            lease.role == PylonTrainingRoleClaim::Validator
+                && lease.state == "acked"
+                && lease.challenge_id.as_deref() == Some("challenge.alpha")
+                && lease.runtime_manifest_path.is_some()
+                && lease.runtime_operation.as_deref() == Some("validate_contribution")
+                && lease.runtime_work_class.as_deref() == Some("validation_replay")
+                && lease
+                    .validator_target_contribution_receipt_path
+                    .as_deref()
+                    .is_some_and(|path| Path::new(path).is_file())
+                && lease
+                    .validator_target_contribution_artifact_manifest_path
+                    .as_deref()
+                    .is_some_and(|path| Path::new(path).is_file()),
+            "validator fallback intake should cache a launchable validator lease with retained target artifacts",
+        )?;
+        let manifest_path = PathBuf::from(
+            lease
+                .runtime_manifest_path
+                .clone()
+                .ok_or_else(|| std::io::Error::other("missing validator manifest path"))?,
+        );
+        let manifest: PsionicTrainInvocationManifest =
+            serde_json::from_slice(&std::fs::read(manifest_path.as_path())?)?;
+        ensure(
+            manifest.role == PsionicTrainRole::Validator
+                && manifest.operation == PsionicTrainOperation::ValidateContribution
+                && manifest.work_class == PsionicTrainWorkClass::ValidationReplay
+                && manifest.coordination.challenge_id.as_deref() == Some("challenge.alpha"),
+            "validator fallback intake should materialize a validator psionic-train manifest tied to the claimed challenge",
+        )?;
+        let claim_record = super::load_training_validator_claim_record(
+            run_root.as_path(),
+            "window.0001",
+            "challenge.alpha",
+        )?;
+        ensure(
+            claim_record.is_some(),
+            "validator fallback intake should persist the claimed challenge record for later finalize/reconcile",
+        )?;
+        let counts = request_counts
+            .lock()
+            .expect("validator fallback request counts")
+            .clone();
+        ensure(
+            counts.get("/api/training/nodes/admission") == Some(&1)
+                && counts.get("/api/training/heartbeats") == Some(&1)
+                && counts.get("/api/training/leases/claim") == Some(&1)
+                && counts.get("/api/training/validator-challenges/claim") == Some(&1)
+                && !counts.contains_key("/api/training/assignments/ack"),
+            "validator fallback intake should admit and heartbeat once, probe the scheduler once, then claim the validator challenge directly without a run-assignment ack",
         )
     }
 

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -33,10 +33,13 @@ use openagents_kernel_core::{
         RecordComputeAdapterWindowResponse,
     },
     compute::{
-        ComputeAcceptedOutcome, ComputeAcceptedOutcomeKind, ComputeAdapterContributionDisposition,
-        ComputeAdapterContributionOutcome, ComputeAdapterTrainingWindow,
+        ComputeAcceptedOutcome, ComputeAcceptedOutcomeKind, ComputeAdapterAggregationEligibility,
+        ComputeAdapterContributionDisposition, ComputeAdapterContributionOutcome,
+        ComputeAdapterContributionValidationReasonCode, ComputeAdapterTrainingWindow,
         ComputeAdapterWindowStatus, ComputeTrainingPolicy, ComputeTrainingReplicaType,
-        ComputeTrainingRun, ComputeTrainingWorkClass,
+        ComputeTrainingRun, ComputeTrainingWorkClass, ComputeValidatorChallengeLease,
+        ComputeValidatorChallengeResult, ComputeValidatorChallengeSnapshot,
+        ComputeValidatorChallengeStatus,
     },
     ids::sha256_prefixed_text,
     pylon_training::{
@@ -394,6 +397,8 @@ pub struct PylonTrainingRuntimeState {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub closeout_cache: BTreeMap<String, PylonTrainingCloseoutCacheEntry>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub closeout_progress: BTreeMap<String, PylonTrainingCloseoutProgressEntry>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub reputation_labels: BTreeMap<String, PylonTrainingReputationLabelCacheEntry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_authority_sync_at_ms: Option<i64>,
@@ -412,6 +417,7 @@ impl Default for PylonTrainingRuntimeState {
             publication_records: BTreeMap::new(),
             contribution_outcomes: BTreeMap::new(),
             closeout_cache: BTreeMap::new(),
+            closeout_progress: BTreeMap::new(),
             reputation_labels: BTreeMap::new(),
             last_authority_sync_at_ms: None,
         }
@@ -465,19 +471,51 @@ struct PylonTrainingRuntimeCoordinationPacket {
     membership_revision: Option<u64>,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+struct PylonTrainingRuntimeArtifactPaths {
+    #[serde(default)]
+    contribution_receipt_path: Option<String>,
+    #[serde(default)]
+    contribution_artifact_manifest_path: Option<String>,
+    #[serde(default)]
+    checkpoint_surface_path: Option<String>,
+    #[serde(default)]
+    checkpoint_pointer_path: Option<String>,
+    #[serde(default)]
+    checkpoint_manifest_path: Option<String>,
+    #[serde(default)]
+    sealed_window_bundle_path: Option<String>,
+    #[serde(default)]
+    final_closeout_bundle_path: Option<String>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 struct PylonTrainingRunStatusPacket {
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    operation: Option<String>,
+    #[serde(default)]
+    work_class: Option<String>,
     outcome: String,
     exit_code: u8,
     retryable: bool,
     #[serde(default)]
     refusal_class: Option<String>,
     coordination: PylonTrainingRuntimeCoordinationPacket,
+    #[serde(default)]
+    artifacts: Option<PylonTrainingRuntimeArtifactPaths>,
     detail: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 struct PylonTrainingWindowStatusPacket {
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    operation: Option<String>,
+    #[serde(default)]
+    work_class: Option<String>,
     outcome: String,
     exit_code: u8,
     retryable: bool,
@@ -486,6 +524,8 @@ struct PylonTrainingWindowStatusPacket {
     coordination: PylonTrainingRuntimeCoordinationPacket,
     #[serde(default)]
     window_state: Option<String>,
+    #[serde(default)]
+    artifacts: Option<PylonTrainingRuntimeArtifactPaths>,
     detail: String,
 }
 
@@ -690,6 +730,98 @@ pub struct PylonTrainingCloseoutCacheEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub best_eval_score_bps: Option<u32>,
     pub accepted_at_ms: i64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PylonTrainingCloseoutStage {
+    WorkerRunning,
+    WorkerExitedSuccess,
+    ArtifactsVerifiedLocal,
+    CheckpointPublished,
+    WindowReadyToSeal,
+    WindowSealed,
+    ValidatorClaimed,
+    ValidatorReplayComplete,
+    ValidatorFinalized,
+    ReconcileRequested,
+    ReconcileObserved,
+    Accepted,
+    Paid,
+    TerminalFailed,
+}
+
+impl PylonTrainingCloseoutStage {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::WorkerRunning => "worker_running",
+            Self::WorkerExitedSuccess => "worker_exited_success",
+            Self::ArtifactsVerifiedLocal => "artifacts_verified_local",
+            Self::CheckpointPublished => "checkpoint_published",
+            Self::WindowReadyToSeal => "window_ready_to_seal",
+            Self::WindowSealed => "window_sealed",
+            Self::ValidatorClaimed => "validator_claimed",
+            Self::ValidatorReplayComplete => "validator_replay_complete",
+            Self::ValidatorFinalized => "validator_finalized",
+            Self::ReconcileRequested => "reconcile_requested",
+            Self::ReconcileObserved => "reconcile_observed",
+            Self::Accepted => "accepted",
+            Self::Paid => "paid",
+            Self::TerminalFailed => "terminal_failed",
+        }
+    }
+
+    const fn ordinal(self) -> u8 {
+        match self {
+            Self::WorkerRunning => 0,
+            Self::WorkerExitedSuccess => 1,
+            Self::ArtifactsVerifiedLocal => 2,
+            Self::CheckpointPublished => 3,
+            Self::WindowReadyToSeal => 4,
+            Self::WindowSealed => 5,
+            Self::ValidatorClaimed => 6,
+            Self::ValidatorReplayComplete => 7,
+            Self::ValidatorFinalized => 8,
+            Self::ReconcileRequested => 9,
+            Self::ReconcileObserved => 10,
+            Self::Accepted => 11,
+            Self::Paid => 12,
+            Self::TerminalFailed => 13,
+        }
+    }
+
+    const fn terminal(self) -> bool {
+        matches!(self, Self::Accepted | Self::Paid | Self::TerminalFailed)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingCloseoutProgressEntry {
+    pub assignment_id: String,
+    pub training_run_id: String,
+    pub window_id: String,
+    #[serde(default = "default_training_role_claim")]
+    pub role: PylonTrainingRoleClaim,
+    pub stage: PylonTrainingCloseoutStage,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub challenge_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contribution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_assignment_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_window_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payout_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payout_receipt_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub updated_at_ms: i64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -983,6 +1115,201 @@ pub struct PylonTrainingCheckpointPublicationResponse {
     pub artifact_locator: Option<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingWindowContributionInput {
+    pub contribution_id: String,
+    pub assignment_id: String,
+    pub submission_receipt_digest: String,
+    pub artifact_id: String,
+    pub manifest_digest: String,
+    pub object_digest: String,
+    pub artifact_receipt_digest: String,
+    pub provenance_bundle_digest: String,
+    pub security_receipt_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replay_receipt_digest: Option<String>,
+    pub validator_receipt_digest: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validation_reason_codes: Vec<ComputeAdapterContributionValidationReasonCode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validator_disposition: Option<ComputeAdapterContributionDisposition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregation_eligibility: Option<ComputeAdapterAggregationEligibility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_step_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consumed_token_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consumed_example_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregation_weight_basis: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregation_weight_value: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregation_weight_bps: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub promotion_receipt_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonSealTrainingWindowRequest {
+    pub idempotency_key: String,
+    pub recorded_at_ms: i64,
+    pub window_id: String,
+    #[serde(default)]
+    pub contribution_outcomes: Vec<PylonTrainingWindowContributionInput>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingWindowCoordinatorResponse {
+    pub window: ComputeAdapterTrainingWindow,
+    #[serde(default)]
+    pub contribution_outcomes: Vec<ComputeAdapterContributionOutcome>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingValidatorTargetArtifactBinding {
+    pub artifact_role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signed_read_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolver: Option<PylonTrainingArtifactResolverResponse>,
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingValidatorTargetAssignmentBinding {
+    pub assignment_id: String,
+    pub training_run_id: String,
+    pub window_id: String,
+    pub contributor_pylon_id: String,
+    pub contribution_id: String,
+    pub work_class: String,
+    pub challenge_kind: String,
+    pub claim_id: String,
+    pub submission_receipt_digest: String,
+    pub manifest_digest: String,
+    pub object_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lane_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease_expires_at_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<PylonTrainingValidatorTargetArtifactBinding>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonClaimTrainingValidatorChallengeRequest {
+    pub idempotency_key: String,
+    pub requested_at_ms: i64,
+    pub node_pubkey_hex: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_network_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_training_run_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonFinalizeTrainingValidatorChallengeRequest {
+    pub idempotency_key: String,
+    pub recorded_at_ms: i64,
+    pub node_pubkey_hex: String,
+    pub lease: ComputeValidatorChallengeLease,
+    pub result: ComputeValidatorChallengeResult,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub training_disposition: Option<ComputeAdapterContributionDisposition>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingValidatorChallengeCoordinatorResponse {
+    pub ack: PylonTrainingCoordinatorAck,
+    pub network_id: String,
+    pub training_run_id: String,
+    pub window_id: String,
+    pub challenge_id: String,
+    pub challenge_kind: String,
+    #[serde(default)]
+    pub target_assignment_ids: Vec<String>,
+    #[serde(default)]
+    pub expected_manifest_digests: Vec<String>,
+    pub challenge: ComputeValidatorChallengeSnapshot,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease: Option<ComputeValidatorChallengeLease>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<ComputeValidatorChallengeResult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window: Option<ComputeAdapterTrainingWindow>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contribution_outcomes: Vec<ComputeAdapterContributionOutcome>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub target_bindings: Vec<PylonTrainingValidatorTargetAssignmentBinding>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonReconcileTrainingWindowRequest {
+    pub idempotency_key: String,
+    pub recorded_at_ms: i64,
+    pub window_id: String,
+    #[serde(default)]
+    pub contribution_outcomes: Vec<PylonTrainingWindowContributionInput>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub held_out_average_score_bps: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub benchmark_pass_rate_bps: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_smoke_passed: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregated_delta_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_aggregate_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub promoted_checkpoint_ref: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+struct PylonTrainingTreasuryPayoutClassification {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    accepted_outcome_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    training_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    window_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    contribution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    assignment_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct PylonTrainingTreasuryPayoutLedgerEntry {
+    payout_key: String,
+    status: String,
+    reconciliation_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    payment_id: Option<String>,
+    #[serde(default)]
+    classification: PylonTrainingTreasuryPayoutClassification,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct PylonTrainingTreasuryStatusResponse {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    recent_training_payouts: Vec<PylonTrainingTreasuryPayoutLedgerEntry>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TrainingCommand {
     Status {
@@ -1066,6 +1393,8 @@ pub struct TrainingOperatorStatusReport {
     recent_issues: Vec<TrainingOperatorIssueStatus>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     recent_closeouts: Vec<TrainingOperatorCloseoutStatus>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    recent_closeout_progress: Vec<TrainingOperatorCloseoutProgressStatus>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1182,6 +1511,26 @@ pub struct TrainingOperatorCloseoutStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     accepted_checkpoint_ref: Option<String>,
     accepted_at_ms: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TrainingOperatorCloseoutProgressStatus {
+    training_run_id: String,
+    window_id: String,
+    assignment_id: String,
+    role: String,
+    stage: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    challenge_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    acceptance_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    payout_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    payout_receipt_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
+    updated_at_ms: i64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -4424,6 +4773,297 @@ async fn ensure_training_assignment_runtime_artifacts(
     Ok(())
 }
 
+fn write_training_json_value(path: &Path, value: &Value, label: &str) -> Result<()> {
+    let payload =
+        serde_json::to_vec_pretty(value).with_context(|| format!("failed to encode {label}"))?;
+    write_training_artifact_destination(path, payload.as_slice())
+}
+
+fn training_validator_claim_record_path(
+    run_root: &Path,
+    window_id: &str,
+    challenge_id: &str,
+) -> PathBuf {
+    run_root
+        .join("windows")
+        .join(window_id)
+        .join("validators")
+        .join(challenge_id)
+        .join("claim.json")
+}
+
+fn persist_training_validator_claim_record(
+    run_root: &Path,
+    response: &PylonTrainingValidatorChallengeCoordinatorResponse,
+) -> Result<()> {
+    let path = training_validator_claim_record_path(
+        run_root,
+        response.window_id.as_str(),
+        response.challenge_id.as_str(),
+    );
+    let value = serde_json::to_value(response)
+        .context("failed to encode training validator claim response")?;
+    write_training_json_value(path.as_path(), &value, "training validator claim response")
+}
+
+fn load_training_validator_claim_record(
+    run_root: &Path,
+    window_id: &str,
+    challenge_id: &str,
+) -> Result<Option<PylonTrainingValidatorChallengeCoordinatorResponse>> {
+    let path = training_validator_claim_record_path(run_root, window_id, challenge_id);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let payload = std::fs::read(path.as_path()).with_context(|| {
+        format!(
+            "failed to read training validator claim record {}",
+            path.display()
+        )
+    })?;
+    let record = serde_json::from_slice(payload.as_slice()).with_context(|| {
+        format!(
+            "failed to decode training validator claim record {}",
+            path.display()
+        )
+    })?;
+    Ok(Some(record))
+}
+
+fn training_validator_target_artifact<'a>(
+    target: &'a PylonTrainingValidatorTargetAssignmentBinding,
+    artifact_role: &str,
+) -> Option<&'a PylonTrainingValidatorTargetArtifactBinding> {
+    target
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_role == artifact_role)
+}
+
+async fn materialize_training_validator_bridge_bundle(
+    config: &PylonConfig,
+    client: &PylonTrainingCoordinatorClient,
+    run_root: &Path,
+    binding: &PylonTrainingValidatorTargetArtifactBinding,
+    local_path: &Path,
+    label: &str,
+) -> Result<Value> {
+    let resolver = binding
+        .resolver
+        .clone()
+        .ok_or_else(|| anyhow!("validator challenge {label} missing artifact resolver"))?;
+    let artifact = materialize_training_artifact(config, client, resolver, run_root, local_path)
+        .await
+        .with_context(|| format!("failed to materialize validator challenge {label}"))?;
+    serde_json::from_slice(artifact.payload.as_slice())
+        .with_context(|| format!("failed to parse validator challenge {label}"))
+}
+
+async fn ensure_training_validator_challenge_materialized(
+    config: &PylonConfig,
+    identity: &NostrIdentity,
+    state: &mut PylonTrainingRuntimeState,
+    client: &PylonTrainingCoordinatorClient,
+    training_run: &ComputeTrainingRun,
+    lease_id: &str,
+    run_root: &Path,
+) -> Result<()> {
+    let Some(lease) = state.lease_cache.get(lease_id).cloned() else {
+        bail!("missing cached training lease `{lease_id}`");
+    };
+    if lease.role != PylonTrainingRoleClaim::Validator {
+        return Ok(());
+    }
+    if lease
+        .validator_target_contribution_receipt_path
+        .as_deref()
+        .is_some_and(|path| Path::new(path).is_file())
+        && lease
+            .validator_target_contribution_artifact_manifest_path
+            .as_deref()
+            .is_some_and(|path| Path::new(path).is_file())
+        && lease
+            .challenge_id
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+    {
+        return Ok(());
+    }
+
+    let response = client
+        .claim_validator_challenge(&PylonClaimTrainingValidatorChallengeRequest {
+            idempotency_key: format!(
+                "training.validator_challenge.claim.{}.{}",
+                lease.lease_id,
+                now_epoch_ms()
+            ),
+            requested_at_ms: now_epoch_ms(),
+            node_pubkey_hex: identity.public_key_hex.clone(),
+            requested_network_id: lease.network_id.clone(),
+            requested_training_run_id: Some(training_run.training_run_id.clone()),
+        })
+        .await?;
+    persist_training_validator_claim_record(run_root, &response)?;
+    let target = response
+        .target_bindings
+        .first()
+        .ok_or_else(|| anyhow!("validator challenge claim missing target bindings"))?;
+    let contribution_root = run_root
+        .join("windows")
+        .join(response.window_id.as_str())
+        .join("contributions")
+        .join(target.contribution_id.as_str());
+    std::fs::create_dir_all(contribution_root.as_path()).with_context(|| {
+        format!(
+            "failed to create validator contribution root {}",
+            contribution_root.display()
+        )
+    })?;
+    let adapter_delta_bundle_path = contribution_root.join("adapter_delta_bundle.json");
+    let proof_bundle_path = contribution_root.join("proof_bundle.json");
+    let adapter_delta_bundle = materialize_training_validator_bridge_bundle(
+        config,
+        client,
+        run_root,
+        training_validator_target_artifact(target, "local_update_bridge")
+            .ok_or_else(|| anyhow!("validator challenge missing local update bridge binding"))?,
+        adapter_delta_bundle_path.as_path(),
+        "local update bridge bundle",
+    )
+    .await?;
+    let proof_bundle = materialize_training_validator_bridge_bundle(
+        config,
+        client,
+        run_root,
+        training_validator_target_artifact(target, "proof_bridge")
+            .ok_or_else(|| anyhow!("validator challenge missing proof bridge binding"))?,
+        proof_bundle_path.as_path(),
+        "proof bridge bundle",
+    )
+    .await?;
+    let contribution_receipt = adapter_delta_bundle
+        .get("source")
+        .and_then(|value| value.get("contribution_receipt"))
+        .cloned()
+        .ok_or_else(|| anyhow!("validator bridge bundle missing contribution receipt"))?;
+    let artifact_manifest = proof_bundle
+        .get("source")
+        .and_then(|value| value.get("artifact_manifest"))
+        .cloned()
+        .ok_or_else(|| anyhow!("validator bridge bundle missing artifact manifest"))?;
+    let contribution_receipt_path = contribution_root.join("contribution_receipt.json");
+    let artifact_manifest_path = contribution_root.join("artifact_manifest.json");
+    write_training_json_value(
+        contribution_receipt_path.as_path(),
+        &contribution_receipt,
+        "validator contribution receipt",
+    )?;
+    write_training_json_value(
+        artifact_manifest_path.as_path(),
+        &artifact_manifest,
+        "validator contribution artifact manifest",
+    )?;
+    if let Some(sealed_window_bundle) = proof_bundle
+        .get("source")
+        .and_then(|value| value.get("sealed_window_bundle"))
+    {
+        write_training_json_value(
+            run_root
+                .join("windows")
+                .join(response.window_id.as_str())
+                .join("sealed_window_bundle.json")
+                .as_path(),
+            sealed_window_bundle,
+            "validator sealed-window bundle",
+        )?;
+    }
+    if let Some(closeout_bundle) = proof_bundle
+        .get("source")
+        .and_then(|value| value.get("closeout_bundle"))
+    {
+        write_training_json_value(
+            run_root
+                .join("closeout")
+                .join("closeout_bundle.json")
+                .as_path(),
+            closeout_bundle,
+            "validator closeout bundle",
+        )?;
+    }
+    if let Some(checkpoint_surface) = proof_bundle
+        .get("source")
+        .and_then(|value| value.get("checkpoint_surface"))
+    {
+        write_training_json_value(
+            run_root
+                .join("status")
+                .join("checkpoint_surface.json")
+                .as_path(),
+            checkpoint_surface,
+            "validator checkpoint surface",
+        )?;
+    }
+    if let Some(latest_accepted_checkpoint_pointer) = proof_bundle
+        .get("source")
+        .and_then(|value| value.get("latest_accepted_checkpoint_pointer"))
+    {
+        write_training_json_value(
+            run_root
+                .join("checkpoints")
+                .join("latest_accepted_checkpoint_pointer.json")
+                .as_path(),
+            latest_accepted_checkpoint_pointer,
+            "validator latest accepted checkpoint pointer",
+        )?;
+    }
+
+    if let Some(cached) = state.lease_cache.get_mut(lease_id) {
+        cached.challenge_id = Some(response.challenge_id.clone());
+        cached.expires_at_ms = response
+            .lease
+            .as_ref()
+            .map(|lease| lease.expires_at_ms as i64);
+        cached.network_id = Some(response.network_id.clone());
+        cached.validator_target_contribution_receipt_path =
+            Some(contribution_receipt_path.display().to_string());
+        cached.validator_target_contribution_artifact_manifest_path =
+            Some(artifact_manifest_path.display().to_string());
+        cached.validator_target_work_class =
+            ComputeTrainingWorkClass::parse(target.work_class.as_str());
+        cached.updated_at_ms = now_epoch_ms();
+    }
+
+    let checkpoint_ref = proof_bundle
+        .get("source")
+        .and_then(|value| value.get("closeout_bundle"))
+        .and_then(|value| value.get("checkpoint_ref"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            proof_bundle
+                .get("source")
+                .and_then(|value| value.get("latest_accepted_checkpoint_pointer"))
+                .and_then(|value| value.get("checkpoint_ref"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        });
+    let _ = record_training_closeout_progress_stage(
+        state,
+        target.assignment_id.as_str(),
+        response.training_run_id.as_str(),
+        response.window_id.as_str(),
+        PylonTrainingRoleClaim::Validator,
+        PylonTrainingCloseoutStage::ValidatorClaimed,
+        Some(response.challenge_id.as_str()),
+        checkpoint_ref,
+        None,
+        None,
+        None,
+        None,
+    );
+    Ok(())
+}
+
 fn training_psionic_role_for_claim(role: PylonTrainingRoleClaim) -> PsionicTrainRole {
     match role {
         PylonTrainingRoleClaim::Worker => PsionicTrainRole::Worker,
@@ -4674,21 +5314,34 @@ async fn ensure_training_assignment_runtime_manifest(
     runtime_surface: &PsionicTrainRuntimeSurface,
     lease_id: &str,
 ) -> Result<MaterializedPsionicTrainInvocationManifest> {
-    let Some(lease) = state.lease_cache.get(lease_id).cloned() else {
+    let Some(initial_lease) = state.lease_cache.get(lease_id).cloned() else {
         bail!("missing cached training lease `{lease_id}`");
     };
     let training_run = client
-        .get_training_run(lease.training_run_id.as_str())
+        .get_training_run(initial_lease.training_run_id.as_str())
         .await?;
     let run_root = training_run_root_for_id(config, training_run.training_run_id.as_str());
     ensure_training_assignment_runtime_artifacts(
         config,
         client,
         &training_run,
-        &lease,
+        &initial_lease,
         run_root.as_path(),
     )
     .await?;
+    ensure_training_validator_challenge_materialized(
+        config,
+        identity,
+        state,
+        client,
+        &training_run,
+        lease_id,
+        run_root.as_path(),
+    )
+    .await?;
+    let Some(lease) = state.lease_cache.get(lease_id).cloned() else {
+        bail!("missing cached training lease `{lease_id}` after materialization");
+    };
     if let (
         Some(runtime_manifest_path),
         Some(runtime_manifest_digest),
@@ -7210,12 +7863,122 @@ impl PylonTrainingCoordinatorClient {
         .await
     }
 
+    pub async fn seal_window(
+        &self,
+        window_id: &str,
+        request: &PylonSealTrainingWindowRequest,
+    ) -> Result<PylonTrainingWindowCoordinatorResponse> {
+        self.post_training_coordination_json_with_retry(
+            format!("/api/training/windows/{window_id}/seal").as_str(),
+            request,
+            "window seal",
+            request.idempotency_key.as_str(),
+        )
+        .await
+    }
+
+    pub async fn claim_validator_challenge(
+        &self,
+        request: &PylonClaimTrainingValidatorChallengeRequest,
+    ) -> Result<PylonTrainingValidatorChallengeCoordinatorResponse> {
+        self.post_training_coordination_json_with_retry(
+            "/api/training/validator-challenges/claim",
+            request,
+            "validator challenge claim",
+            request.idempotency_key.as_str(),
+        )
+        .await
+    }
+
+    pub async fn finalize_validator_challenge(
+        &self,
+        challenge_id: &str,
+        request: &PylonFinalizeTrainingValidatorChallengeRequest,
+    ) -> Result<PylonTrainingValidatorChallengeCoordinatorResponse> {
+        self.post_training_coordination_json_with_retry(
+            format!("/api/training/validator-challenges/{challenge_id}/finalize").as_str(),
+            request,
+            "validator challenge finalize",
+            request.idempotency_key.as_str(),
+        )
+        .await
+    }
+
+    pub async fn reconcile_window(
+        &self,
+        window_id: &str,
+        request: &PylonReconcileTrainingWindowRequest,
+    ) -> Result<PylonTrainingWindowCoordinatorResponse> {
+        self.post_training_coordination_json_with_retry(
+            format!("/api/training/windows/{window_id}/reconcile").as_str(),
+            request,
+            "window reconcile",
+            request.idempotency_key.as_str(),
+        )
+        .await
+    }
+
+    async fn get_treasury_status(&self) -> Result<PylonTrainingTreasuryStatusResponse> {
+        self.get_training_coordination_json_with_retry("/v1/treasury/status", "treasury status")
+            .await
+    }
+
     fn training_authority_url(&self, path: &str) -> String {
         format!(
             "{}/{}",
             self.base_url.trim_end_matches('/'),
             path.trim_start_matches('/')
         )
+    }
+
+    async fn get_training_coordination_json_with_retry<R>(
+        &self,
+        path: &str,
+        action: &str,
+    ) -> Result<R>
+    where
+        R: DeserializeOwned,
+    {
+        let url = self.training_authority_url(path);
+        for attempt in 0..DEFAULT_TRAINING_COORDINATION_RETRY_ATTEMPTS {
+            let mut request = self.client.get(url.as_str());
+            if let Some(token) = self.bearer_auth.as_deref() {
+                request = request.bearer_auth(token);
+            }
+            match request.send().await {
+                Ok(response) => {
+                    if response.status().is_success() {
+                        return response.json::<R>().await.with_context(|| {
+                            format!("failed to decode training authority {action} response")
+                        });
+                    }
+                    let status = response.status();
+                    let detail = response.text().await.unwrap_or_else(|_| {
+                        format!("failed to decode training authority {action} error")
+                    });
+                    if training_authority_status_is_retryable(status)
+                        && attempt + 1 < DEFAULT_TRAINING_COORDINATION_RETRY_ATTEMPTS
+                    {
+                        tokio::time::sleep(training_coordination_retry_delay(attempt)).await;
+                        continue;
+                    }
+                    bail!(
+                        "training authority {action} failed with status {}: {detail}",
+                        status.as_u16()
+                    );
+                }
+                Err(error) => {
+                    if attempt + 1 < DEFAULT_TRAINING_COORDINATION_RETRY_ATTEMPTS {
+                        tokio::time::sleep(training_coordination_retry_delay(attempt)).await;
+                        continue;
+                    }
+                    return Err(error).with_context(|| {
+                        format!("failed to get training authority {action} from {url}")
+                    });
+                }
+            }
+        }
+        bail!("training authority {action} exhausted retry budget")
     }
 
     async fn post_training_coordination_json_with_retry<T, R>(
@@ -7297,7 +8060,10 @@ fn training_lease_state_is_terminal(state: &str) -> bool {
 }
 
 fn training_lease_state_is_acknowledged(state: &str) -> bool {
-    matches!(state.trim(), "acked" | "accepted" | "assignment_acked")
+    matches!(
+        state.trim(),
+        "acked" | "accepted" | "active" | "assignment_acked"
+    )
 }
 
 fn newest_training_lease_cache_entry(
@@ -7803,6 +8569,228 @@ struct TrainingArtifactCacheFileEntry {
     modified_at_ms: u128,
 }
 
+const PYLON_TRAINING_ADAPTER_DELTA_BRIDGE_SCHEMA_VERSION: &str =
+    "openagents.pylon_training.adapter_delta_bridge_bundle.v1";
+const PYLON_TRAINING_PROOF_BUNDLE_BRIDGE_SCHEMA_VERSION: &str =
+    "openagents.pylon_training.proof_bridge_bundle.v1";
+
+fn load_training_json_artifact_value(path: &Path, label: &str) -> Result<Option<Value>> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let payload = std::fs::read(path)
+        .with_context(|| format!("failed to read {label} {}", path.display()))?;
+    let value = serde_json::from_slice(payload.as_slice())
+        .with_context(|| format!("failed to decode {label} {}", path.display()))?;
+    Ok(Some(value))
+}
+
+fn training_json_artifact_digest(value: &Value, label: &str, path: &Path) -> Result<String> {
+    artifact_digest_from_json(value)
+        .map_err(anyhow::Error::msg)
+        .with_context(|| format!("failed to digest {label} {}", path.display()))
+}
+
+fn persist_training_bridge_bundle(path: &Path, payload: &Value, label: &str) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(payload)
+        .with_context(|| format!("failed to encode {label} {}", path.display()))?;
+    std::fs::write(path, bytes)
+        .with_context(|| format!("failed to write {label} {}", path.display()))
+}
+
+fn ensure_training_contribution_bridge_bundles(
+    context: &TrainingManifestInspectionContext,
+    contribution_root: &Path,
+) -> Result<()> {
+    let adapter_delta_bundle_path = contribution_root.join("adapter_delta_bundle.json");
+    let proof_bundle_path = contribution_root.join("proof_bundle.json");
+    if adapter_delta_bundle_path.is_file() && proof_bundle_path.is_file() {
+        return Ok(());
+    }
+
+    let contribution_receipt_path = contribution_root.join("contribution_receipt.json");
+    let artifact_manifest_path = contribution_root.join("artifact_manifest.json");
+    let Some(contribution_receipt) = load_training_json_artifact_value(
+        contribution_receipt_path.as_path(),
+        "training contribution receipt",
+    )?
+    else {
+        return Ok(());
+    };
+    let Some(artifact_manifest) = load_training_json_artifact_value(
+        artifact_manifest_path.as_path(),
+        "training contribution artifact manifest",
+    )?
+    else {
+        return Ok(());
+    };
+
+    let contribution_receipt_digest = training_json_artifact_digest(
+        &contribution_receipt,
+        "training contribution receipt",
+        contribution_receipt_path.as_path(),
+    )?;
+    let artifact_manifest_digest = training_json_artifact_digest(
+        &artifact_manifest,
+        "training contribution artifact manifest",
+        artifact_manifest_path.as_path(),
+    )?;
+    let contribution_key = contribution_root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_default();
+    let assignment_id = contribution_receipt
+        .get("assignment_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let contribution_id = contribution_receipt
+        .get("contribution_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let node_pubkey = contribution_receipt
+        .get("node_pubkey")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+
+    if !adapter_delta_bundle_path.is_file() {
+        let adapter_delta_bridge = json!({
+            "schema_version": PYLON_TRAINING_ADAPTER_DELTA_BRIDGE_SCHEMA_VERSION,
+            "bridge_family": "retained_contribution_receipt",
+            "training_run_id": context.manifest.run_id.clone(),
+            "window_id": context.manifest.window_id.clone(),
+            "contribution_key": contribution_key.clone(),
+            "assignment_id": assignment_id.clone(),
+            "contribution_id": contribution_id.clone(),
+            "node_pubkey": node_pubkey.clone(),
+            "source": {
+                "contribution_receipt_path": contribution_receipt_path.display().to_string(),
+                "contribution_receipt_digest": contribution_receipt_digest.clone(),
+                "contribution_receipt": contribution_receipt,
+            },
+            "detail": "Bridge bundle preserves the retained contribution receipt under the legacy adapter-delta contribution contract until Nexus consumes retained contribution receipts directly."
+        });
+        persist_training_bridge_bundle(
+            adapter_delta_bundle_path.as_path(),
+            &adapter_delta_bridge,
+            "adapter-delta bridge bundle",
+        )?;
+    }
+
+    if !proof_bundle_path.is_file() {
+        let window_root = context
+            .local_run_root
+            .join("windows")
+            .join(context.manifest.window_id.as_str());
+        let sealed_window_bundle_path = window_root.join("sealed_window_bundle.json");
+        let sealed_window_bundle = load_training_json_artifact_value(
+            sealed_window_bundle_path.as_path(),
+            "training sealed-window bundle",
+        )?;
+        let sealed_window_bundle_digest = sealed_window_bundle
+            .as_ref()
+            .map(|value| {
+                training_json_artifact_digest(
+                    value,
+                    "training sealed-window bundle",
+                    sealed_window_bundle_path.as_path(),
+                )
+            })
+            .transpose()?;
+        let closeout_bundle_path = context
+            .local_run_root
+            .join("closeout")
+            .join("closeout_bundle.json");
+        let closeout_bundle = load_training_json_artifact_value(
+            closeout_bundle_path.as_path(),
+            "training closeout bundle",
+        )?;
+        let closeout_bundle_digest = closeout_bundle
+            .as_ref()
+            .map(|value| {
+                training_json_artifact_digest(
+                    value,
+                    "training closeout bundle",
+                    closeout_bundle_path.as_path(),
+                )
+            })
+            .transpose()?;
+        let checkpoint_surface_path = context
+            .local_run_root
+            .join("status")
+            .join("checkpoint_surface.json");
+        let checkpoint_surface = load_training_json_artifact_value(
+            checkpoint_surface_path.as_path(),
+            "training checkpoint surface",
+        )?;
+        let checkpoint_surface_digest = checkpoint_surface
+            .as_ref()
+            .map(|value| {
+                training_json_artifact_digest(
+                    value,
+                    "training checkpoint surface",
+                    checkpoint_surface_path.as_path(),
+                )
+            })
+            .transpose()?;
+        let latest_accepted_checkpoint_pointer_path = context
+            .local_run_root
+            .join("checkpoints")
+            .join("latest_accepted_checkpoint_pointer.json");
+        let latest_accepted_checkpoint_pointer = load_training_json_artifact_value(
+            latest_accepted_checkpoint_pointer_path.as_path(),
+            "training latest accepted checkpoint pointer",
+        )?;
+        let latest_accepted_checkpoint_pointer_digest = latest_accepted_checkpoint_pointer
+            .as_ref()
+            .map(|value| {
+                training_json_artifact_digest(
+                    value,
+                    "training latest accepted checkpoint pointer",
+                    latest_accepted_checkpoint_pointer_path.as_path(),
+                )
+            })
+            .transpose()?;
+        let proof_bridge = json!({
+            "schema_version": PYLON_TRAINING_PROOF_BUNDLE_BRIDGE_SCHEMA_VERSION,
+            "bridge_family": "retained_contribution_proof",
+            "training_run_id": context.manifest.run_id.clone(),
+            "window_id": context.manifest.window_id.clone(),
+            "contribution_key": contribution_key,
+            "assignment_id": assignment_id,
+            "contribution_id": contribution_id,
+            "node_pubkey": node_pubkey,
+            "source": {
+                "artifact_manifest_path": artifact_manifest_path.display().to_string(),
+                "artifact_manifest_digest": artifact_manifest_digest,
+                "artifact_manifest": artifact_manifest,
+                "sealed_window_bundle_path": sealed_window_bundle_path.display().to_string(),
+                "sealed_window_bundle_digest": sealed_window_bundle_digest,
+                "sealed_window_bundle": sealed_window_bundle,
+                "closeout_bundle_path": closeout_bundle_path.display().to_string(),
+                "closeout_bundle_digest": closeout_bundle_digest,
+                "closeout_bundle": closeout_bundle,
+                "checkpoint_surface_path": checkpoint_surface_path.display().to_string(),
+                "checkpoint_surface_digest": checkpoint_surface_digest,
+                "checkpoint_surface": checkpoint_surface,
+                "latest_accepted_checkpoint_pointer_path": latest_accepted_checkpoint_pointer_path.display().to_string(),
+                "latest_accepted_checkpoint_pointer_digest": latest_accepted_checkpoint_pointer_digest,
+                "latest_accepted_checkpoint_pointer": latest_accepted_checkpoint_pointer,
+                "contribution_receipt_path": contribution_receipt_path.display().to_string(),
+                "contribution_receipt_digest": contribution_receipt_digest,
+            },
+            "detail": "Bridge bundle preserves the retained artifact manifest, sealed-window bundle, closeout bundle, and accepted-checkpoint lineage under the legacy proof contribution contract until Nexus consumes the retained proof family directly."
+        });
+        persist_training_bridge_bundle(
+            proof_bundle_path.as_path(),
+            &proof_bridge,
+            "proof bridge bundle",
+        )?;
+    }
+
+    Ok(())
+}
+
 #[allow(dead_code)]
 impl PylonTrainingArtifactStoreClient {
     async fn new(config: &PylonConfig) -> Result<Self> {
@@ -7839,6 +8827,30 @@ impl PylonTrainingArtifactStoreClient {
         let local_run_root = PathBuf::from(manifest.artifacts.local_run_root.clone());
         let layout =
             PylonTrainingArtifactLayout::from_manifest(manifest).map_err(anyhow::Error::msg)?;
+        let context = TrainingManifestInspectionContext {
+            manifest: manifest.clone(),
+            manifest_path: local_run_root.join("manifests").join("run_manifest.json"),
+            local_run_root: local_run_root.clone(),
+            layout: layout.clone(),
+        };
+        if matches!(
+            bundle_kind,
+            PylonTrainingArtifactBundleKind::Contribution { .. }
+        ) {
+            let contribution_key = match &bundle_kind {
+                PylonTrainingArtifactBundleKind::Contribution { assignment_id } => assignment_id,
+                _ => unreachable!("checked contribution bundle kind"),
+            };
+            ensure_training_contribution_bridge_bundles(
+                &context,
+                local_run_root
+                    .join("windows")
+                    .join(manifest.window_id.as_str())
+                    .join("contributions")
+                    .join(contribution_key)
+                    .as_path(),
+            )?;
+        }
         let required_objects = bundle_kind.required_paths(&layout);
         let bundle_id = bundle_kind.bundle_id();
         let bundle_kind_label = bundle_kind.bundle_kind_label().to_string();
@@ -8418,7 +9430,20 @@ fn load_training_manifest_inspection_contexts(
 ) -> Result<Vec<TrainingManifestInspectionContext>> {
     let mut manifest_paths = BTreeSet::<PathBuf>::new();
     if let Some(active_runtime) = state.active_runtime.as_ref() {
-        manifest_paths.insert(PathBuf::from(active_runtime.manifest_path.clone()));
+        let active_manifest_path = PathBuf::from(active_runtime.manifest_path.clone());
+        let run_manifest_path = active_manifest_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == "run_manifest.json")
+            .then_some(active_manifest_path.clone())
+            .unwrap_or_else(|| {
+                PathBuf::from(active_runtime.run_root.clone())
+                    .join("manifests")
+                    .join("run_manifest.json")
+            });
+        if run_manifest_path.is_file() {
+            manifest_paths.insert(run_manifest_path);
+        }
     }
     let runs_root = training_runs_root(config);
     if runs_root.is_dir() {
@@ -8534,6 +9559,7 @@ fn inspect_manifest_local_artifacts(
             if !entry.file_type()?.is_dir() {
                 continue;
             }
+            ensure_training_contribution_bridge_bundles(context, entry.path().as_path())?;
             let assignment_id = entry.file_name().to_string_lossy().to_string();
             bundles.push(inspect_training_artifact_bundle(
                 context,
@@ -8584,6 +9610,18 @@ fn inspect_training_artifact_bundle(
     context: &TrainingManifestInspectionContext,
     bundle_kind: PylonTrainingArtifactBundleKind,
 ) -> Result<TrainingArtifactBundleInspectionEntry> {
+    if let PylonTrainingArtifactBundleKind::Contribution { assignment_id } = &bundle_kind {
+        ensure_training_contribution_bridge_bundles(
+            context,
+            context
+                .local_run_root
+                .join("windows")
+                .join(context.manifest.window_id.as_str())
+                .join("contributions")
+                .join(assignment_id)
+                .as_path(),
+        )?;
+    }
     let mut objects = Vec::new();
     let mut present_count = 0usize;
     for object_uri in bundle_kind.required_paths(&context.layout) {
@@ -8807,6 +9845,31 @@ fn load_training_status_report_with_config(
     });
     recent_closeouts.truncate(8);
 
+    let mut recent_closeout_progress = state
+        .closeout_progress
+        .values()
+        .map(|entry| TrainingOperatorCloseoutProgressStatus {
+            training_run_id: entry.training_run_id.clone(),
+            window_id: entry.window_id.clone(),
+            assignment_id: entry.assignment_id.clone(),
+            role: entry.role.label().to_string(),
+            stage: entry.stage.label().to_string(),
+            challenge_id: entry.challenge_id.clone(),
+            acceptance_state: entry.acceptance_state.clone(),
+            payout_state: entry.payout_state.clone(),
+            payout_receipt_id: entry.payout_receipt_id.clone(),
+            last_error: entry.last_error.clone(),
+            updated_at_ms: entry.updated_at_ms,
+        })
+        .collect::<Vec<_>>();
+    recent_closeout_progress.sort_by(|left, right| {
+        right
+            .updated_at_ms
+            .cmp(&left.updated_at_ms)
+            .then_with(|| left.assignment_id.cmp(&right.assignment_id))
+    });
+    recent_closeout_progress.truncate(8);
+
     let mut recent_issues = resolve_training_recent_issues(config, &state, contexts.as_slice())?;
     recent_issues.sort_by(|left, right| {
         right
@@ -8852,6 +9915,7 @@ fn load_training_status_report_with_config(
         recent_trn_events,
         recent_issues,
         recent_closeouts,
+        recent_closeout_progress,
     })
 }
 
@@ -9176,6 +10240,18 @@ fn resolve_training_recent_issues(
             owner: "nexus".to_string(),
             retryable: entry.validator_disposition == "replay_required",
         });
+    }
+    for entry in state.closeout_progress.values() {
+        if let Some(last_error) = entry.last_error.as_ref() {
+            issues.push(TrainingOperatorIssueStatus {
+                kind: "closeout_progress_error".to_string(),
+                subject_id: entry.assignment_id.clone(),
+                reason: last_error.clone(),
+                observed_at_ms: entry.updated_at_ms,
+                owner: "pylon".to_string(),
+                retryable: !entry.stage.terminal(),
+            });
+        }
     }
     if let Some(active_runtime) = state.active_runtime.as_ref() {
         if let Some(reason) = active_runtime.last_failure_reason.as_ref() {
@@ -9944,6 +11020,30 @@ struct PylonTrainingCheckpointPublicationCandidate {
     artifact_digest: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PylonTrainingRetainedContributionArtifacts {
+    assignment_id: String,
+    contribution_id: String,
+    artifact_id: String,
+    contribution_receipt_path: PathBuf,
+    contribution_receipt_digest: String,
+    artifact_manifest_path: PathBuf,
+    artifact_manifest_digest: String,
+    object_digest: String,
+    sealed_window_bundle_path: PathBuf,
+    sealed_window_bundle_digest: String,
+    closeout_bundle_path: PathBuf,
+    closeout_bundle_digest: String,
+    checkpoint_surface_path: PathBuf,
+    checkpoint_surface_digest: String,
+    latest_accepted_checkpoint_pointer_path: PathBuf,
+    latest_accepted_checkpoint_pointer_digest: String,
+    checkpoint_ref: Option<String>,
+    local_step_count: Option<u64>,
+    work_class: Option<String>,
+    lane_type: Option<String>,
+}
+
 fn training_supervision_is_terminal(state: PylonTrainingSupervisorProcessState) -> bool {
     matches!(
         state,
@@ -10307,6 +11407,1521 @@ fn training_terminal_checkpoint_publication_candidate(
     }))
 }
 
+fn training_prefixed_sha256_digest(value: &str) -> Option<String> {
+    let normalized = value.trim();
+    if normalized.is_empty() {
+        return None;
+    }
+    if normalized.starts_with("sha256:") {
+        return Some(normalized.to_string());
+    }
+    Some(format!("sha256:{normalized}"))
+}
+
+fn training_retained_contribution_root(
+    run_root: &Path,
+    window_id: &str,
+    assignment_id: &str,
+    status_paths: Option<&PylonTrainingRuntimeArtifactPaths>,
+) -> Result<Option<PathBuf>> {
+    if let Some(path) = status_paths
+        .and_then(|paths| paths.contribution_receipt_path.as_deref())
+        .map(PathBuf::from)
+    {
+        return Ok(path.parent().map(PathBuf::from));
+    }
+    let contributions_root = run_root
+        .join("windows")
+        .join(window_id)
+        .join("contributions");
+    if !contributions_root.is_dir() {
+        return Ok(None);
+    }
+    for entry in std::fs::read_dir(contributions_root.as_path()).with_context(|| {
+        format!(
+            "failed to read retained contribution root {}",
+            contributions_root.display()
+        )
+    })? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let receipt_path = entry.path().join("contribution_receipt.json");
+        let Some(receipt) = load_training_json_artifact_value(
+            receipt_path.as_path(),
+            "training contribution receipt",
+        )?
+        else {
+            continue;
+        };
+        if receipt
+            .get("assignment_id")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value == assignment_id)
+        {
+            return Ok(Some(entry.path()));
+        }
+    }
+    Ok(None)
+}
+
+fn inspect_training_retained_contribution_artifacts(
+    active: &PylonTrainingActiveRuntimeState,
+    run_root: &Path,
+    run_status: Option<&PylonTrainingRunStatusPacket>,
+    window_status: Option<&PylonTrainingWindowStatusPacket>,
+) -> Result<Option<PylonTrainingRetainedContributionArtifacts>> {
+    let status_paths = window_status
+        .and_then(|packet| packet.artifacts.as_ref())
+        .or_else(|| run_status.and_then(|packet| packet.artifacts.as_ref()));
+    let Some(contribution_root) = training_retained_contribution_root(
+        run_root,
+        active.window_id.as_str(),
+        active.assignment_id.as_str(),
+        status_paths,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    let contribution_receipt_path = status_paths
+        .and_then(|paths| paths.contribution_receipt_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| contribution_root.join("contribution_receipt.json"));
+    let artifact_manifest_path = status_paths
+        .and_then(|paths| paths.contribution_artifact_manifest_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| contribution_root.join("artifact_manifest.json"));
+    let sealed_window_bundle_path = status_paths
+        .and_then(|paths| paths.sealed_window_bundle_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            run_root
+                .join("windows")
+                .join(active.window_id.as_str())
+                .join("sealed_window_bundle.json")
+        });
+    let closeout_bundle_path = status_paths
+        .and_then(|paths| paths.final_closeout_bundle_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| run_root.join("closeout").join("closeout_bundle.json"));
+    let checkpoint_surface_path = status_paths
+        .and_then(|paths| paths.checkpoint_surface_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| run_root.join("status").join("checkpoint_surface.json"));
+    let latest_accepted_checkpoint_pointer_path = status_paths
+        .and_then(|paths| paths.checkpoint_pointer_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            run_root
+                .join("checkpoints")
+                .join("latest_accepted_checkpoint_pointer.json")
+        });
+
+    let Some(contribution_receipt) = load_training_json_artifact_value(
+        contribution_receipt_path.as_path(),
+        "training contribution receipt",
+    )?
+    else {
+        return Ok(None);
+    };
+    let Some(artifact_manifest) = load_training_json_artifact_value(
+        artifact_manifest_path.as_path(),
+        "training contribution artifact manifest",
+    )?
+    else {
+        return Ok(None);
+    };
+    let Some(sealed_window_bundle) = load_training_json_artifact_value(
+        sealed_window_bundle_path.as_path(),
+        "training sealed-window bundle",
+    )?
+    else {
+        return Ok(None);
+    };
+    let Some(closeout_bundle) = load_training_json_artifact_value(
+        closeout_bundle_path.as_path(),
+        "training closeout bundle",
+    )?
+    else {
+        return Ok(None);
+    };
+    let Some(checkpoint_surface) = load_training_json_artifact_value(
+        checkpoint_surface_path.as_path(),
+        "training checkpoint surface",
+    )?
+    else {
+        return Ok(None);
+    };
+    let Some(latest_accepted_checkpoint_pointer) = load_training_json_artifact_value(
+        latest_accepted_checkpoint_pointer_path.as_path(),
+        "training latest accepted checkpoint pointer",
+    )?
+    else {
+        return Ok(None);
+    };
+
+    let assignment_id = contribution_receipt
+        .get("assignment_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .filter(|value| value == active.assignment_id.as_str())
+        .ok_or_else(|| anyhow!("retained contribution receipt assignment_id mismatch"))?;
+    let contribution_id = contribution_receipt
+        .get("contribution_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("retained contribution receipt missing contribution_id"))?;
+    let artifact_id = contribution_receipt
+        .get("artifact_manifest")
+        .and_then(|value| value.get("artifact_ref"))
+        .and_then(|value| value.get("artifact_id"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            anyhow!("retained contribution receipt missing artifact manifest artifact_id")
+        })?;
+    let object_digest = contribution_receipt
+        .get("contribution_digest")
+        .and_then(Value::as_str)
+        .and_then(training_prefixed_sha256_digest)
+        .ok_or_else(|| anyhow!("retained contribution receipt missing contribution_digest"))?;
+    let checkpoint_ref = checkpoint_surface
+        .get("checkpoint_ref")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            latest_accepted_checkpoint_pointer
+                .get("checkpoint_ref")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        });
+    let local_step_count = checkpoint_surface
+        .get("optimizer_step")
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            closeout_bundle
+                .get("training_step_count")
+                .and_then(Value::as_u64)
+        });
+
+    Ok(Some(PylonTrainingRetainedContributionArtifacts {
+        assignment_id,
+        contribution_id,
+        artifact_id,
+        contribution_receipt_path: contribution_receipt_path.clone(),
+        contribution_receipt_digest: training_json_artifact_digest(
+            &contribution_receipt,
+            "training contribution receipt",
+            contribution_receipt_path.as_path(),
+        )?,
+        artifact_manifest_path: artifact_manifest_path.clone(),
+        artifact_manifest_digest: training_json_artifact_digest(
+            &artifact_manifest,
+            "training contribution artifact manifest",
+            artifact_manifest_path.as_path(),
+        )?,
+        object_digest,
+        sealed_window_bundle_path: sealed_window_bundle_path.clone(),
+        sealed_window_bundle_digest: training_json_artifact_digest(
+            &sealed_window_bundle,
+            "training sealed-window bundle",
+            sealed_window_bundle_path.as_path(),
+        )?,
+        closeout_bundle_path: closeout_bundle_path.clone(),
+        closeout_bundle_digest: training_json_artifact_digest(
+            &closeout_bundle,
+            "training closeout bundle",
+            closeout_bundle_path.as_path(),
+        )?,
+        checkpoint_surface_path: checkpoint_surface_path.clone(),
+        checkpoint_surface_digest: training_json_artifact_digest(
+            &checkpoint_surface,
+            "training checkpoint surface",
+            checkpoint_surface_path.as_path(),
+        )?,
+        latest_accepted_checkpoint_pointer_path: latest_accepted_checkpoint_pointer_path.clone(),
+        latest_accepted_checkpoint_pointer_digest: training_json_artifact_digest(
+            &latest_accepted_checkpoint_pointer,
+            "training latest accepted checkpoint pointer",
+            latest_accepted_checkpoint_pointer_path.as_path(),
+        )?,
+        checkpoint_ref,
+        local_step_count,
+        work_class: contribution_receipt
+            .get("work_class")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        lane_type: contribution_receipt
+            .get("lane_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+    }))
+}
+
+fn training_retained_contribution_input(
+    active: &PylonTrainingActiveRuntimeState,
+    retained: &PylonTrainingRetainedContributionArtifacts,
+) -> PylonTrainingWindowContributionInput {
+    PylonTrainingWindowContributionInput {
+        contribution_id: retained.contribution_id.clone(),
+        assignment_id: retained.assignment_id.clone(),
+        submission_receipt_digest: retained.contribution_receipt_digest.clone(),
+        artifact_id: retained.artifact_id.clone(),
+        manifest_digest: retained.artifact_manifest_digest.clone(),
+        object_digest: retained.object_digest.clone(),
+        artifact_receipt_digest: retained.contribution_receipt_digest.clone(),
+        provenance_bundle_digest: retained.sealed_window_bundle_digest.clone(),
+        security_receipt_digest: retained.closeout_bundle_digest.clone(),
+        replay_receipt_digest: None,
+        validator_receipt_digest: sha256_prefixed_text(
+            format!(
+                "pending-validator:{}:{}",
+                active.window_id, retained.assignment_id
+            )
+            .as_str(),
+        ),
+        validation_reason_codes: Vec::new(),
+        validator_disposition: None,
+        aggregation_eligibility: None,
+        local_step_count: retained.local_step_count,
+        consumed_token_count: None,
+        consumed_example_count: None,
+        aggregation_weight_basis: None,
+        aggregation_weight_value: None,
+        aggregation_weight_bps: None,
+        promotion_receipt_digest: None,
+        metadata: json!({
+            "normalized_contribution_contract": "retained_homework_lane.v1",
+            "assignment_id": retained.assignment_id.clone(),
+            "contribution_id": retained.contribution_id.clone(),
+            "lane_type": retained.lane_type.clone(),
+            "work_class": retained.work_class.clone(),
+            "receipt": {
+                "path": retained.contribution_receipt_path.display().to_string(),
+                "digest": retained.contribution_receipt_digest.clone(),
+            },
+            "artifact_manifest": {
+                "path": retained.artifact_manifest_path.display().to_string(),
+                "artifact_id": retained.artifact_id.clone(),
+                "digest": retained.artifact_manifest_digest.clone(),
+            },
+            "sealed_window_bundle": {
+                "path": retained.sealed_window_bundle_path.display().to_string(),
+                "digest": retained.sealed_window_bundle_digest.clone(),
+            },
+            "closeout_bundle": {
+                "path": retained.closeout_bundle_path.display().to_string(),
+                "digest": retained.closeout_bundle_digest.clone(),
+            },
+            "checkpoint_surface": {
+                "path": retained.checkpoint_surface_path.display().to_string(),
+                "digest": retained.checkpoint_surface_digest.clone(),
+            },
+            "latest_accepted_checkpoint_pointer": {
+                "path": retained.latest_accepted_checkpoint_pointer_path.display().to_string(),
+                "digest": retained.latest_accepted_checkpoint_pointer_digest.clone(),
+            },
+            "checkpoint_ref": retained.checkpoint_ref.clone(),
+        }),
+    }
+}
+
+async fn maybe_seal_training_terminal_window(
+    state: &mut PylonTrainingRuntimeState,
+    active: &PylonTrainingActiveRuntimeState,
+    retained: &PylonTrainingRetainedContributionArtifacts,
+    client: &PylonTrainingCoordinatorClient,
+) -> Result<bool> {
+    let receipt_key = training_authority_receipt_key("window_seal", active.window_id.as_str());
+    if !training_authority_receipt_needs_attempt(state, receipt_key.as_str()) {
+        return Ok(false);
+    }
+    let request = PylonSealTrainingWindowRequest {
+        idempotency_key: format!(
+            "training.window_seal.{}.{}",
+            active.training_run_id, active.window_id
+        ),
+        recorded_at_ms: now_epoch_ms(),
+        window_id: active.window_id.clone(),
+        contribution_outcomes: vec![training_retained_contribution_input(active, retained)],
+    };
+    let receipt_subject = active.window_id.clone();
+    match client
+        .seal_window(active.window_id.as_str(), &request)
+        .await
+    {
+        Ok(response) => {
+            let window_state = response.window.status.label().to_string();
+            record_training_authority_receipt_attempt_success(
+                state,
+                receipt_key.as_str(),
+                "window_seal",
+                receipt_subject.as_str(),
+                "window_sealed",
+                window_state.as_str(),
+                request.recorded_at_ms,
+            );
+            state.window_cache.insert(
+                active.window_id.clone(),
+                PylonTrainingWindowCacheEntry {
+                    window_id: active.window_id.clone(),
+                    training_run_id: active.training_run_id.clone(),
+                    state: window_state.clone(),
+                    manifest_digest: state
+                        .lease_cache
+                        .get(active.lease_id.as_str())
+                        .and_then(|lease| lease.manifest_digest.clone()),
+                    updated_at_ms: now_epoch_ms(),
+                },
+            );
+            let _ = record_training_closeout_progress_stage(
+                state,
+                active.assignment_id.as_str(),
+                active.training_run_id.as_str(),
+                active.window_id.as_str(),
+                active.role,
+                PylonTrainingCloseoutStage::WindowSealed,
+                None,
+                retained.checkpoint_ref.clone(),
+                Some(window_state),
+                None,
+                None,
+                None,
+            );
+            Ok(true)
+        }
+        Err(error) => {
+            let error_text = error.to_string();
+            if error_text.contains("training_window_status_invalid") {
+                if let Ok(window) = client
+                    .get_adapter_training_window(active.window_id.as_str())
+                    .await
+                {
+                    let window_state = window.status.label().to_string();
+                    if matches!(
+                        window.status,
+                        ComputeAdapterWindowStatus::Sealed
+                            | ComputeAdapterWindowStatus::Scored
+                            | ComputeAdapterWindowStatus::Reconciled
+                    ) {
+                        record_training_authority_receipt_attempt_success(
+                            state,
+                            receipt_key.as_str(),
+                            "window_seal",
+                            receipt_subject.as_str(),
+                            "window_seal_existing",
+                            window_state.as_str(),
+                            now_epoch_ms(),
+                        );
+                        state.window_cache.insert(
+                            active.window_id.clone(),
+                            PylonTrainingWindowCacheEntry {
+                                window_id: active.window_id.clone(),
+                                training_run_id: active.training_run_id.clone(),
+                                state: window_state.clone(),
+                                manifest_digest: state
+                                    .lease_cache
+                                    .get(active.lease_id.as_str())
+                                    .and_then(|lease| lease.manifest_digest.clone()),
+                                updated_at_ms: now_epoch_ms(),
+                            },
+                        );
+                        let _ = record_training_closeout_progress_stage(
+                            state,
+                            active.assignment_id.as_str(),
+                            active.training_run_id.as_str(),
+                            active.window_id.as_str(),
+                            active.role,
+                            PylonTrainingCloseoutStage::WindowSealed,
+                            None,
+                            retained.checkpoint_ref.clone(),
+                            Some(window_state),
+                            None,
+                            None,
+                            None,
+                        );
+                        return Ok(true);
+                    }
+                }
+            }
+            record_training_authority_receipt_attempt_failure(
+                state,
+                receipt_key.as_str(),
+                "window_seal",
+                receipt_subject.as_str(),
+                &error,
+            );
+            let _ = record_training_closeout_progress_stage(
+                state,
+                active.assignment_id.as_str(),
+                active.training_run_id.as_str(),
+                active.window_id.as_str(),
+                active.role,
+                PylonTrainingCloseoutStage::WindowReadyToSeal,
+                None,
+                retained.checkpoint_ref.clone(),
+                None,
+                None,
+                None,
+                Some(error_text),
+            );
+            Ok(true)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PylonTrainingTerminalCloseoutHints {
+    checkpoint_ref: Option<String>,
+    held_out_average_score_bps: Option<u32>,
+    benchmark_pass_rate_bps: Option<u32>,
+    runtime_smoke_passed: Option<bool>,
+    aggregated_delta_digest: Option<String>,
+    accepted_aggregate_id: Option<String>,
+    promoted_checkpoint_ref: Option<String>,
+}
+
+fn training_validator_verdict_path(
+    run_root: &Path,
+    window_id: &str,
+    challenge_id: &str,
+) -> PathBuf {
+    run_root
+        .join("windows")
+        .join(window_id)
+        .join("validators")
+        .join(challenge_id)
+        .join("verdict.json")
+}
+
+fn training_validator_challenge_status_from_value(
+    value: Option<&Value>,
+) -> Option<ComputeValidatorChallengeStatus> {
+    match value.and_then(Value::as_str).map(str::trim) {
+        Some("verified") => Some(ComputeValidatorChallengeStatus::Verified),
+        Some("rejected") => Some(ComputeValidatorChallengeStatus::Rejected),
+        Some("timed_out") => Some(ComputeValidatorChallengeStatus::TimedOut),
+        Some("retrying" | "retry_scheduled") => Some(ComputeValidatorChallengeStatus::Rejected),
+        _ => None,
+    }
+}
+
+fn training_validator_challenge_verdict_from_value(
+    value: Option<&Value>,
+) -> Option<openagents_kernel_core::compute::ComputeValidatorChallengeVerdict> {
+    match value.and_then(Value::as_str).map(str::trim) {
+        Some("verified") => {
+            Some(openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::Verified)
+        }
+        Some("rejected") => {
+            Some(openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::Rejected)
+        }
+        Some("retry_scheduled") => {
+            Some(openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::RetryScheduled)
+        }
+        Some("timed_out") => {
+            Some(openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::TimedOut)
+        }
+        _ => None,
+    }
+}
+
+fn training_validator_challenge_failure_code_from_value(
+    value: Option<&Value>,
+) -> Option<openagents_kernel_core::compute::ComputeValidatorChallengeFailureCode> {
+    match value.and_then(Value::as_str).map(str::trim) {
+        Some("dimension_mismatch") => Some(openagents_kernel_core::compute::ComputeValidatorChallengeFailureCode::DimensionMismatch),
+        Some("field_mismatch") => Some(openagents_kernel_core::compute::ComputeValidatorChallengeFailureCode::FieldMismatch),
+        Some("row_opening_missing") => Some(openagents_kernel_core::compute::ComputeValidatorChallengeFailureCode::RowOpeningMissing),
+        Some("merkle_proof_invalid") => Some(openagents_kernel_core::compute::ComputeValidatorChallengeFailureCode::MerkleProofInvalid),
+        Some("freivalds_mismatch") => Some(openagents_kernel_core::compute::ComputeValidatorChallengeFailureCode::FreivaldsMismatch),
+        Some("lease_expired") => Some(openagents_kernel_core::compute::ComputeValidatorChallengeFailureCode::LeaseExpired),
+        Some("retry_budget_exhausted") => Some(openagents_kernel_core::compute::ComputeValidatorChallengeFailureCode::RetryBudgetExhausted),
+        _ => None,
+    }
+}
+
+fn training_contribution_disposition_from_value(
+    value: Option<&Value>,
+) -> Option<ComputeAdapterContributionDisposition> {
+    value
+        .and_then(Value::as_str)
+        .and_then(ComputeAdapterContributionDisposition::parse)
+}
+
+fn training_closeout_metric_from_bundle(value: &Value, field: &str) -> Option<u32> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|metric| u32::try_from(metric).ok())
+}
+
+fn load_training_terminal_closeout_hints(
+    run_root: &Path,
+    run_status: Option<&PylonTrainingRunStatusPacket>,
+    window_status: Option<&PylonTrainingWindowStatusPacket>,
+) -> Result<Option<PylonTrainingTerminalCloseoutHints>> {
+    let status_paths = window_status
+        .and_then(|packet| packet.artifacts.as_ref())
+        .or_else(|| run_status.and_then(|packet| packet.artifacts.as_ref()));
+    let closeout_bundle_path = status_paths
+        .and_then(|paths| paths.final_closeout_bundle_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| run_root.join("closeout").join("closeout_bundle.json"));
+    let Some(closeout_bundle) = load_training_json_artifact_value(
+        closeout_bundle_path.as_path(),
+        "training closeout bundle",
+    )?
+    else {
+        return Ok(None);
+    };
+    let checkpoint_surface_path = status_paths
+        .and_then(|paths| paths.checkpoint_surface_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| run_root.join("status").join("checkpoint_surface.json"));
+    let checkpoint_surface = load_training_json_artifact_value(
+        checkpoint_surface_path.as_path(),
+        "training checkpoint surface",
+    )?;
+    let latest_pointer_path = status_paths
+        .and_then(|paths| paths.checkpoint_pointer_path.as_deref())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            run_root
+                .join("checkpoints")
+                .join("latest_accepted_checkpoint_pointer.json")
+        });
+    let latest_pointer = load_training_json_artifact_value(
+        latest_pointer_path.as_path(),
+        "training latest accepted checkpoint pointer",
+    )?;
+
+    let outcome = closeout_bundle
+        .get("outcome")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let accepted_outcome = matches!(outcome, Some("accepted" | "succeeded"));
+    let checkpoint_ref = closeout_bundle
+        .get("promoted_checkpoint_ref")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            closeout_bundle
+                .get("checkpoint_ref")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .or_else(|| {
+            latest_pointer
+                .as_ref()
+                .and_then(|value| value.get("checkpoint_ref"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .or_else(|| {
+            checkpoint_surface
+                .as_ref()
+                .and_then(|value| value.get("checkpoint_ref"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        });
+    let held_out_average_score_bps =
+        training_closeout_metric_from_bundle(&closeout_bundle, "held_out_average_score_bps")
+            .or_else(|| {
+                training_closeout_metric_from_bundle(&closeout_bundle, "best_eval_score_bps")
+            })
+            .or_else(|| accepted_outcome.then_some(10_000));
+    let benchmark_pass_rate_bps =
+        training_closeout_metric_from_bundle(&closeout_bundle, "benchmark_pass_rate_bps")
+            .or_else(|| accepted_outcome.then_some(10_000));
+    let runtime_smoke_passed = closeout_bundle
+        .get("runtime_smoke_passed")
+        .and_then(Value::as_bool)
+        .or_else(|| accepted_outcome.then_some(true));
+    let aggregated_delta_digest = closeout_bundle
+        .get("aggregated_delta_digest")
+        .and_then(Value::as_str)
+        .and_then(training_prefixed_sha256_digest);
+    let accepted_aggregate_id = closeout_bundle
+        .get("accepted_aggregate_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .filter(|value| !value.trim().is_empty());
+
+    Ok(Some(PylonTrainingTerminalCloseoutHints {
+        checkpoint_ref: checkpoint_ref.clone(),
+        held_out_average_score_bps,
+        benchmark_pass_rate_bps,
+        runtime_smoke_passed,
+        aggregated_delta_digest,
+        accepted_aggregate_id,
+        promoted_checkpoint_ref: checkpoint_ref,
+    }))
+}
+
+fn training_window_contribution_input_from_outcome(
+    outcome: &ComputeAdapterContributionOutcome,
+) -> PylonTrainingWindowContributionInput {
+    PylonTrainingWindowContributionInput {
+        contribution_id: outcome.contribution_id.clone(),
+        assignment_id: outcome.assignment_id.clone(),
+        submission_receipt_digest: outcome.submission_receipt_digest.clone(),
+        artifact_id: outcome.artifact_id.clone(),
+        manifest_digest: outcome.manifest_digest.clone(),
+        object_digest: outcome.object_digest.clone(),
+        artifact_receipt_digest: outcome.artifact_receipt_digest.clone(),
+        provenance_bundle_digest: outcome.provenance_bundle_digest.clone(),
+        security_receipt_digest: outcome.security_receipt_digest.clone(),
+        replay_receipt_digest: outcome.replay_receipt_digest.clone(),
+        validator_receipt_digest: outcome.validator_receipt_digest.clone(),
+        validation_reason_codes: outcome.validation_reason_codes.clone(),
+        validator_disposition: Some(outcome.validator_disposition),
+        aggregation_eligibility: Some(outcome.aggregation_eligibility),
+        local_step_count: outcome.local_step_count,
+        consumed_token_count: outcome.consumed_token_count,
+        consumed_example_count: outcome.consumed_example_count,
+        aggregation_weight_basis: outcome.aggregation_weight_basis.clone(),
+        aggregation_weight_value: outcome.aggregation_weight_value,
+        aggregation_weight_bps: outcome.aggregation_weight_bps,
+        promotion_receipt_digest: outcome.promotion_receipt_digest.clone(),
+        metadata: outcome.metadata.clone(),
+    }
+}
+
+fn update_training_closeout_progress_observation(
+    state: &mut PylonTrainingRuntimeState,
+    assignment_id: &str,
+    challenge_id: Option<&str>,
+    contribution_id: Option<String>,
+    authority_assignment_state: Option<String>,
+    authority_window_state: Option<String>,
+) -> bool {
+    let key = training_closeout_progress_key(assignment_id, challenge_id);
+    let Some(entry) = state.closeout_progress.get_mut(key.as_str()) else {
+        return false;
+    };
+    let mut changed = false;
+    if contribution_id.is_some() && entry.contribution_id != contribution_id {
+        entry.contribution_id = contribution_id;
+        changed = true;
+    }
+    if authority_assignment_state.is_some()
+        && entry.authority_assignment_state != authority_assignment_state
+    {
+        entry.authority_assignment_state = authority_assignment_state;
+        changed = true;
+    }
+    if authority_window_state.is_some() && entry.authority_window_state != authority_window_state {
+        entry.authority_window_state = authority_window_state;
+        changed = true;
+    }
+    if changed {
+        entry.updated_at_ms = now_epoch_ms();
+    }
+    changed
+}
+
+async fn maybe_finalize_training_terminal_validator_challenge(
+    identity: &NostrIdentity,
+    state: &mut PylonTrainingRuntimeState,
+    active: &PylonTrainingActiveRuntimeState,
+    client: &PylonTrainingCoordinatorClient,
+    run_root: &Path,
+    run_status: Option<&PylonTrainingRunStatusPacket>,
+    window_status: Option<&PylonTrainingWindowStatusPacket>,
+) -> Result<bool> {
+    if active.role != PylonTrainingRoleClaim::Validator {
+        return Ok(false);
+    }
+    let Some(challenge_id) = state
+        .lease_cache
+        .get(active.lease_id.as_str())
+        .and_then(|lease| lease.challenge_id.clone())
+    else {
+        return Ok(false);
+    };
+    let receipt_key = training_authority_receipt_key("validator_finalize", challenge_id.as_str());
+    if !training_authority_receipt_needs_attempt(state, receipt_key.as_str()) {
+        return Ok(false);
+    }
+    let Some(claim_record) = load_training_validator_claim_record(
+        run_root,
+        active.window_id.as_str(),
+        challenge_id.as_str(),
+    )?
+    else {
+        return Ok(false);
+    };
+    let Some(lease) = claim_record.lease.clone() else {
+        bail!("validator claim record missing challenge lease for `{challenge_id}`");
+    };
+    let target = claim_record.target_bindings.first();
+    let target_assignment_id = target
+        .map(|binding| binding.assignment_id.as_str())
+        .unwrap_or(active.assignment_id.as_str());
+    let target_contribution_id = target.map(|binding| binding.contribution_id.clone());
+    let closeout_hints =
+        load_training_terminal_closeout_hints(run_root, run_status, window_status)?;
+    let checkpoint_ref = closeout_hints
+        .as_ref()
+        .and_then(|hints| hints.checkpoint_ref.clone());
+    let verdict_path =
+        training_validator_verdict_path(run_root, active.window_id.as_str(), challenge_id.as_str());
+    let verdict_value =
+        load_training_json_artifact_value(verdict_path.as_path(), "training validator verdict")?;
+    let result_digest = if let Some(verdict) = verdict_value.as_ref() {
+        verdict
+            .get("result_digest")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                training_json_artifact_digest(
+                    verdict,
+                    "training validator verdict",
+                    verdict_path.as_path(),
+                )
+                .ok()
+            })
+            .unwrap_or_else(|| {
+                sha256_prefixed_text(
+                    format!("validator_verdict::{challenge_id}::{}", lease.attempt).as_str(),
+                )
+            })
+    } else {
+        sha256_prefixed_text(
+            format!("validator_result::{challenge_id}::{}", lease.attempt).as_str(),
+        )
+    };
+    let status = training_validator_challenge_status_from_value(
+        verdict_value.as_ref().and_then(|value| value.get("status")),
+    )
+    .or_else(|| {
+        training_validator_challenge_status_from_value(
+            verdict_value
+                .as_ref()
+                .and_then(|value| value.get("validator_status")),
+        )
+    })
+    .unwrap_or(ComputeValidatorChallengeStatus::Verified);
+    let verdict = training_validator_challenge_verdict_from_value(
+        verdict_value
+            .as_ref()
+            .and_then(|value| value.get("verdict")),
+    )
+    .or_else(|| {
+        training_validator_challenge_verdict_from_value(
+            verdict_value
+                .as_ref()
+                .and_then(|value| value.get("validator_verdict")),
+        )
+    })
+    .unwrap_or_else(|| match status {
+        ComputeValidatorChallengeStatus::Rejected => {
+            openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::Rejected
+        }
+        ComputeValidatorChallengeStatus::TimedOut => {
+            openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::TimedOut
+        }
+        _ => openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::Verified,
+    });
+    let training_disposition = training_contribution_disposition_from_value(
+        verdict_value
+            .as_ref()
+            .and_then(|value| value.get("training_disposition")),
+    )
+    .or_else(|| {
+        training_contribution_disposition_from_value(
+            verdict_value
+                .as_ref()
+                .and_then(|value| value.get("validator_disposition")),
+        )
+    })
+    .or_else(|| match verdict {
+        openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::Verified => {
+            Some(ComputeAdapterContributionDisposition::Accepted)
+        }
+        openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::Rejected
+        | openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::TimedOut => {
+            Some(ComputeAdapterContributionDisposition::Rejected)
+        }
+        openagents_kernel_core::compute::ComputeValidatorChallengeVerdict::RetryScheduled => {
+            Some(ComputeAdapterContributionDisposition::ReplayRequired)
+        }
+    });
+    let finalized_at_ms = now_epoch_ms().max(0) as u64;
+    let result = ComputeValidatorChallengeResult {
+        challenge_id: challenge_id.clone(),
+        proof_bundle_digest: claim_record
+            .challenge
+            .request
+            .context
+            .proof_bundle_digest
+            .clone(),
+        protocol_id: verdict_value
+            .as_ref()
+            .and_then(|value| value.get("protocol_id"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| claim_record.challenge.request.protocol.label().to_string()),
+        attempt: lease.attempt,
+        status,
+        verdict,
+        reason_code: training_validator_challenge_failure_code_from_value(
+            verdict_value
+                .as_ref()
+                .and_then(|value| value.get("reason_code")),
+        ),
+        detail: verdict_value
+            .as_ref()
+            .and_then(|value| value.get("detail"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "validator verdict".to_string()),
+        created_at_ms: claim_record.challenge.request.context.created_at_ms,
+        finalized_at_ms,
+        challenge_seed_digest: verdict_value
+            .as_ref()
+            .and_then(|value| value.get("challenge_seed_digest"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        verified_row_count: verdict_value
+            .as_ref()
+            .and_then(|value| value.get("verified_row_count"))
+            .and_then(Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok()),
+        result_digest: result_digest.clone(),
+        challenge_result_ref: verdict_value
+            .as_ref()
+            .and_then(|value| value.get("challenge_result_ref"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| format!("validator_challenge_result:{result_digest}")),
+    };
+    let mut changed = record_training_closeout_progress_stage(
+        state,
+        target_assignment_id,
+        active.training_run_id.as_str(),
+        active.window_id.as_str(),
+        active.role,
+        PylonTrainingCloseoutStage::ValidatorReplayComplete,
+        Some(challenge_id.as_str()),
+        checkpoint_ref.clone(),
+        None,
+        None,
+        None,
+        None,
+    );
+    changed |= update_training_closeout_progress_observation(
+        state,
+        target_assignment_id,
+        Some(challenge_id.as_str()),
+        target_contribution_id.clone(),
+        state
+            .lease_cache
+            .get(active.lease_id.as_str())
+            .map(|lease| lease.state.clone()),
+        None,
+    );
+    let request = PylonFinalizeTrainingValidatorChallengeRequest {
+        idempotency_key: format!(
+            "training.validator_challenge.finalize.{}.{}",
+            active.training_run_id, challenge_id
+        ),
+        recorded_at_ms: now_epoch_ms(),
+        node_pubkey_hex: identity.public_key_hex.clone(),
+        lease,
+        result,
+        training_disposition,
+    };
+    match client
+        .finalize_validator_challenge(challenge_id.as_str(), &request)
+        .await
+    {
+        Ok(response) => {
+            let authority_state = response.ack.authority_state.clone();
+            let window_state = response
+                .window
+                .as_ref()
+                .map(|window| window.status.label().to_string())
+                .unwrap_or_else(|| "validated".to_string());
+            record_training_authority_receipt_attempt_success(
+                state,
+                receipt_key.as_str(),
+                "validator_finalize",
+                challenge_id.as_str(),
+                authority_state.as_str(),
+                window_state.as_str(),
+                request.recorded_at_ms,
+            );
+            if let Some(window) = response.window.as_ref() {
+                state.window_cache.insert(
+                    window.window_id.clone(),
+                    PylonTrainingWindowCacheEntry {
+                        window_id: window.window_id.clone(),
+                        training_run_id: window.training_run_id.clone(),
+                        state: window.status.label().to_string(),
+                        manifest_digest: state
+                            .lease_cache
+                            .get(active.lease_id.as_str())
+                            .and_then(|lease| lease.manifest_digest.clone()),
+                        updated_at_ms: now_epoch_ms(),
+                    },
+                );
+            }
+            changed |= record_training_closeout_progress_stage(
+                state,
+                target_assignment_id,
+                active.training_run_id.as_str(),
+                active.window_id.as_str(),
+                active.role,
+                PylonTrainingCloseoutStage::ValidatorFinalized,
+                Some(challenge_id.as_str()),
+                checkpoint_ref,
+                Some(authority_state),
+                None,
+                None,
+                None,
+            );
+            changed |= update_training_closeout_progress_observation(
+                state,
+                target_assignment_id,
+                Some(challenge_id.as_str()),
+                target_contribution_id,
+                state
+                    .lease_cache
+                    .get(active.lease_id.as_str())
+                    .map(|lease| lease.state.clone()),
+                Some(window_state),
+            );
+            Ok(changed)
+        }
+        Err(error) => {
+            let error_text = error.to_string();
+            if error_text.contains("validator_challenge") {
+                if let Ok(window) = client
+                    .get_adapter_training_window(active.window_id.as_str())
+                    .await
+                {
+                    if matches!(
+                        window.status,
+                        ComputeAdapterWindowStatus::Scored | ComputeAdapterWindowStatus::Reconciled
+                    ) {
+                        let window_state = window.status.label().to_string();
+                        record_training_authority_receipt_attempt_success(
+                            state,
+                            receipt_key.as_str(),
+                            "validator_finalize",
+                            challenge_id.as_str(),
+                            "validator_finalize_existing",
+                            window_state.as_str(),
+                            now_epoch_ms(),
+                        );
+                        state.window_cache.insert(
+                            window.window_id.clone(),
+                            PylonTrainingWindowCacheEntry {
+                                window_id: window.window_id.clone(),
+                                training_run_id: window.training_run_id.clone(),
+                                state: window_state.clone(),
+                                manifest_digest: state
+                                    .lease_cache
+                                    .get(active.lease_id.as_str())
+                                    .and_then(|lease| lease.manifest_digest.clone()),
+                                updated_at_ms: now_epoch_ms(),
+                            },
+                        );
+                        changed |= record_training_closeout_progress_stage(
+                            state,
+                            target_assignment_id,
+                            active.training_run_id.as_str(),
+                            active.window_id.as_str(),
+                            active.role,
+                            PylonTrainingCloseoutStage::ValidatorFinalized,
+                            Some(challenge_id.as_str()),
+                            checkpoint_ref,
+                            Some(window_state.clone()),
+                            None,
+                            None,
+                            None,
+                        );
+                        changed |= update_training_closeout_progress_observation(
+                            state,
+                            target_assignment_id,
+                            Some(challenge_id.as_str()),
+                            target_contribution_id,
+                            state
+                                .lease_cache
+                                .get(active.lease_id.as_str())
+                                .map(|lease| lease.state.clone()),
+                            Some(window_state),
+                        );
+                        return Ok(changed);
+                    }
+                }
+            }
+            record_training_authority_receipt_attempt_failure(
+                state,
+                receipt_key.as_str(),
+                "validator_finalize",
+                challenge_id.as_str(),
+                &error,
+            );
+            changed |= record_training_closeout_progress_stage(
+                state,
+                target_assignment_id,
+                active.training_run_id.as_str(),
+                active.window_id.as_str(),
+                active.role,
+                PylonTrainingCloseoutStage::ValidatorClaimed,
+                Some(challenge_id.as_str()),
+                checkpoint_ref,
+                None,
+                None,
+                None,
+                Some(error_text),
+            );
+            Ok(changed)
+        }
+    }
+}
+
+async fn maybe_reconcile_training_terminal_window(
+    state: &mut PylonTrainingRuntimeState,
+    active: &PylonTrainingActiveRuntimeState,
+    client: &PylonTrainingCoordinatorClient,
+    run_root: &Path,
+    run_status: Option<&PylonTrainingRunStatusPacket>,
+    window_status: Option<&PylonTrainingWindowStatusPacket>,
+) -> Result<bool> {
+    let mut changed = false;
+    if !training_closeout_authority_poll_due(state, active.window_id.as_str()) {
+        return Ok(false);
+    }
+    let window = match client
+        .get_adapter_training_window(active.window_id.as_str())
+        .await
+    {
+        Ok(window) => window,
+        Err(_) => return Ok(false),
+    };
+    let authority_window_state = window.status.label().to_string();
+    state.window_cache.insert(
+        window.window_id.clone(),
+        PylonTrainingWindowCacheEntry {
+            window_id: window.window_id.clone(),
+            training_run_id: window.training_run_id.clone(),
+            state: authority_window_state.clone(),
+            manifest_digest: state
+                .lease_cache
+                .get(active.lease_id.as_str())
+                .and_then(|lease| lease.manifest_digest.clone()),
+            updated_at_ms: now_epoch_ms(),
+        },
+    );
+    let contribution_outcomes = if matches!(
+        window.status,
+        ComputeAdapterWindowStatus::Sealed
+            | ComputeAdapterWindowStatus::Scored
+            | ComputeAdapterWindowStatus::Reconciled
+    ) {
+        match client
+            .list_adapter_contribution_outcomes(
+                Some(active.training_run_id.as_str()),
+                Some(active.window_id.as_str()),
+                None,
+            )
+            .await
+        {
+            Ok(outcomes) => outcomes,
+            Err(_) => return Ok(changed),
+        }
+    } else {
+        Vec::new()
+    };
+    for outcome in &contribution_outcomes {
+        changed |= update_training_closeout_progress_observation(
+            state,
+            outcome.assignment_id.as_str(),
+            None,
+            Some(outcome.contribution_id.clone()),
+            Some(outcome.validator_disposition.label().to_string()),
+            Some(authority_window_state.clone()),
+        );
+    }
+    if window.status == ComputeAdapterWindowStatus::Reconciled {
+        for outcome in &contribution_outcomes {
+            changed |= record_training_closeout_progress_stage(
+                state,
+                outcome.assignment_id.as_str(),
+                outcome.training_run_id.as_str(),
+                outcome.window_id.as_str(),
+                active.role,
+                PylonTrainingCloseoutStage::ReconcileObserved,
+                None,
+                None,
+                Some(authority_window_state.clone()),
+                None,
+                None,
+                None,
+            );
+        }
+        return Ok(changed);
+    }
+    if window.status != ComputeAdapterWindowStatus::Scored {
+        return Ok(changed);
+    }
+    let receipt_key = training_authority_receipt_key("window_reconcile", active.window_id.as_str());
+    if !training_authority_receipt_needs_attempt(state, receipt_key.as_str()) {
+        return Ok(changed);
+    }
+    let Some(closeout_hints) =
+        load_training_terminal_closeout_hints(run_root, run_status, window_status)?
+    else {
+        return Ok(changed);
+    };
+    for outcome in &contribution_outcomes {
+        changed |= record_training_closeout_progress_stage(
+            state,
+            outcome.assignment_id.as_str(),
+            outcome.training_run_id.as_str(),
+            outcome.window_id.as_str(),
+            active.role,
+            PylonTrainingCloseoutStage::ReconcileRequested,
+            None,
+            closeout_hints.checkpoint_ref.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+    }
+    let request = PylonReconcileTrainingWindowRequest {
+        idempotency_key: format!(
+            "training.window_reconcile.{}.{}",
+            active.training_run_id, active.window_id
+        ),
+        recorded_at_ms: now_epoch_ms(),
+        window_id: active.window_id.clone(),
+        contribution_outcomes: contribution_outcomes
+            .iter()
+            .map(training_window_contribution_input_from_outcome)
+            .collect(),
+        held_out_average_score_bps: closeout_hints.held_out_average_score_bps,
+        benchmark_pass_rate_bps: closeout_hints.benchmark_pass_rate_bps,
+        runtime_smoke_passed: closeout_hints.runtime_smoke_passed,
+        aggregated_delta_digest: closeout_hints.aggregated_delta_digest,
+        accepted_aggregate_id: closeout_hints.accepted_aggregate_id,
+        promoted_checkpoint_ref: closeout_hints.promoted_checkpoint_ref.clone(),
+    };
+    match client
+        .reconcile_window(active.window_id.as_str(), &request)
+        .await
+    {
+        Ok(response) => {
+            let window_state = response.window.status.label().to_string();
+            record_training_authority_receipt_attempt_success(
+                state,
+                receipt_key.as_str(),
+                "window_reconcile",
+                active.window_id.as_str(),
+                "window_reconciled",
+                window_state.as_str(),
+                request.recorded_at_ms,
+            );
+            state.window_cache.insert(
+                response.window.window_id.clone(),
+                PylonTrainingWindowCacheEntry {
+                    window_id: response.window.window_id.clone(),
+                    training_run_id: response.window.training_run_id.clone(),
+                    state: window_state.clone(),
+                    manifest_digest: state
+                        .lease_cache
+                        .get(active.lease_id.as_str())
+                        .and_then(|lease| lease.manifest_digest.clone()),
+                    updated_at_ms: now_epoch_ms(),
+                },
+            );
+            let response_outcomes = if response.contribution_outcomes.is_empty() {
+                contribution_outcomes
+            } else {
+                response.contribution_outcomes
+            };
+            for outcome in &response_outcomes {
+                changed |= record_training_closeout_progress_stage(
+                    state,
+                    outcome.assignment_id.as_str(),
+                    outcome.training_run_id.as_str(),
+                    outcome.window_id.as_str(),
+                    active.role,
+                    PylonTrainingCloseoutStage::ReconcileObserved,
+                    None,
+                    closeout_hints.checkpoint_ref.clone(),
+                    Some(window_state.clone()),
+                    None,
+                    None,
+                    None,
+                );
+                changed |= update_training_closeout_progress_observation(
+                    state,
+                    outcome.assignment_id.as_str(),
+                    None,
+                    Some(outcome.contribution_id.clone()),
+                    Some(outcome.validator_disposition.label().to_string()),
+                    Some(window_state.clone()),
+                );
+            }
+            Ok(changed)
+        }
+        Err(error) => {
+            let error_text = error.to_string();
+            if error_text.contains("training_window_status_invalid") {
+                if let Ok(window) = client
+                    .get_adapter_training_window(active.window_id.as_str())
+                    .await
+                {
+                    if window.status == ComputeAdapterWindowStatus::Reconciled {
+                        let window_state = window.status.label().to_string();
+                        record_training_authority_receipt_attempt_success(
+                            state,
+                            receipt_key.as_str(),
+                            "window_reconcile",
+                            active.window_id.as_str(),
+                            "window_reconcile_existing",
+                            window_state.as_str(),
+                            now_epoch_ms(),
+                        );
+                        state.window_cache.insert(
+                            window.window_id.clone(),
+                            PylonTrainingWindowCacheEntry {
+                                window_id: window.window_id.clone(),
+                                training_run_id: window.training_run_id.clone(),
+                                state: window_state.clone(),
+                                manifest_digest: state
+                                    .lease_cache
+                                    .get(active.lease_id.as_str())
+                                    .and_then(|lease| lease.manifest_digest.clone()),
+                                updated_at_ms: now_epoch_ms(),
+                            },
+                        );
+                        for outcome in &contribution_outcomes {
+                            changed |= record_training_closeout_progress_stage(
+                                state,
+                                outcome.assignment_id.as_str(),
+                                outcome.training_run_id.as_str(),
+                                outcome.window_id.as_str(),
+                                active.role,
+                                PylonTrainingCloseoutStage::ReconcileObserved,
+                                None,
+                                closeout_hints.checkpoint_ref.clone(),
+                                Some(window_state.clone()),
+                                None,
+                                None,
+                                None,
+                            );
+                            changed |= update_training_closeout_progress_observation(
+                                state,
+                                outcome.assignment_id.as_str(),
+                                None,
+                                Some(outcome.contribution_id.clone()),
+                                Some(outcome.validator_disposition.label().to_string()),
+                                Some(window_state.clone()),
+                            );
+                        }
+                        return Ok(changed);
+                    }
+                }
+            }
+            record_training_authority_receipt_attempt_failure(
+                state,
+                receipt_key.as_str(),
+                "window_reconcile",
+                active.window_id.as_str(),
+                &error,
+            );
+            for outcome in &contribution_outcomes {
+                changed |= record_training_closeout_progress_stage(
+                    state,
+                    outcome.assignment_id.as_str(),
+                    outcome.training_run_id.as_str(),
+                    outcome.window_id.as_str(),
+                    active.role,
+                    PylonTrainingCloseoutStage::ValidatorFinalized,
+                    None,
+                    closeout_hints.checkpoint_ref.clone(),
+                    None,
+                    None,
+                    None,
+                    Some(error_text.clone()),
+                );
+            }
+            Ok(changed)
+        }
+    }
+}
+
+fn training_payout_record_matches_assignment(
+    record: &PylonTrainingTreasuryPayoutLedgerEntry,
+    accepted_outcome_id: &str,
+    outcome: &ComputeAdapterContributionOutcome,
+) -> bool {
+    record
+        .classification
+        .accepted_outcome_id
+        .as_deref()
+        .is_some_and(|value| value == accepted_outcome_id)
+        || record
+            .classification
+            .assignment_id
+            .as_deref()
+            .is_some_and(|value| value == outcome.assignment_id.as_str())
+        || record
+            .classification
+            .contribution_id
+            .as_deref()
+            .is_some_and(|value| value == outcome.contribution_id.as_str())
+}
+
+async fn observe_training_terminal_closeout_state(
+    state: &mut PylonTrainingRuntimeState,
+    active: &PylonTrainingActiveRuntimeState,
+    context: &TrainingManifestInspectionContext,
+    client: &PylonTrainingCoordinatorClient,
+) -> Result<bool> {
+    let mut changed = false;
+    if !training_closeout_authority_poll_due(state, active.window_id.as_str()) {
+        return Ok(false);
+    }
+    let window = match client
+        .get_adapter_training_window(active.window_id.as_str())
+        .await
+    {
+        Ok(window) => window,
+        Err(_) => return Ok(false),
+    };
+    let authority_window_state = window.status.label().to_string();
+    state.window_cache.insert(
+        window.window_id.clone(),
+        PylonTrainingWindowCacheEntry {
+            window_id: window.window_id.clone(),
+            training_run_id: window.training_run_id.clone(),
+            state: authority_window_state.clone(),
+            manifest_digest: Some(context.manifest.manifest_digest.clone()),
+            updated_at_ms: now_epoch_ms(),
+        },
+    );
+    let contribution_outcomes = match client
+        .list_adapter_contribution_outcomes(
+            Some(active.training_run_id.as_str()),
+            Some(active.window_id.as_str()),
+            None,
+        )
+        .await
+    {
+        Ok(outcomes) => outcomes,
+        Err(_) => return Ok(changed),
+    };
+    for outcome in &contribution_outcomes {
+        changed |= update_training_closeout_progress_observation(
+            state,
+            outcome.assignment_id.as_str(),
+            None,
+            Some(outcome.contribution_id.clone()),
+            Some(outcome.validator_disposition.label().to_string()),
+            Some(authority_window_state.clone()),
+        );
+    }
+    let Some(accepted_outcome_id) = window.accepted_outcome_id.as_ref() else {
+        return Ok(changed);
+    };
+    let accepted_outcome = match client
+        .list_accepted_outcomes(
+            Some(ComputeAcceptedOutcomeKind::TrainingRun),
+            Some(context.manifest.environment_ref.as_str()),
+        )
+        .await
+    {
+        Ok(outcomes) => outcomes,
+        Err(_) => return Ok(changed),
+    }
+    .into_iter()
+    .find(|outcome| outcome.outcome_id == *accepted_outcome_id);
+    let Some(accepted_outcome) = accepted_outcome else {
+        return Ok(changed);
+    };
+    let checkpoint_ref = accepted_outcome
+        .training_summary
+        .as_ref()
+        .and_then(|summary| summary.accepted_checkpoint_ref.clone());
+    let acceptance_state = training_closeout_status_from_metadata(&accepted_outcome);
+    let payout_eligible = training_closeout_payout_eligible(&accepted_outcome);
+    for outcome in &contribution_outcomes {
+        changed |= record_training_closeout_progress_stage(
+            state,
+            outcome.assignment_id.as_str(),
+            outcome.training_run_id.as_str(),
+            outcome.window_id.as_str(),
+            active.role,
+            PylonTrainingCloseoutStage::Accepted,
+            None,
+            checkpoint_ref.clone(),
+            Some(acceptance_state.clone()),
+            payout_eligible.then_some("pending".to_string()),
+            None,
+            None,
+        );
+        changed |= update_training_closeout_progress_observation(
+            state,
+            outcome.assignment_id.as_str(),
+            None,
+            Some(outcome.contribution_id.clone()),
+            Some(outcome.validator_disposition.label().to_string()),
+            Some(authority_window_state.clone()),
+        );
+    }
+    if let Ok(treasury_status) = client.get_treasury_status().await {
+        for outcome in &contribution_outcomes {
+            let Some(payout) = treasury_status
+                .recent_training_payouts
+                .iter()
+                .find(|record| {
+                    training_payout_record_matches_assignment(
+                        record,
+                        accepted_outcome_id.as_str(),
+                        outcome,
+                    )
+                })
+            else {
+                continue;
+            };
+            changed |= record_training_closeout_progress_stage(
+                state,
+                outcome.assignment_id.as_str(),
+                outcome.training_run_id.as_str(),
+                outcome.window_id.as_str(),
+                active.role,
+                if payout.payment_id.is_some()
+                    || matches!(payout.status.as_str(), "confirmed" | "dispatched")
+                {
+                    PylonTrainingCloseoutStage::Paid
+                } else {
+                    PylonTrainingCloseoutStage::Accepted
+                },
+                None,
+                checkpoint_ref.clone(),
+                Some(acceptance_state.clone()),
+                Some(payout.status.clone()),
+                payout.payment_id.clone(),
+                payout.reason.clone(),
+            );
+        }
+    }
+    Ok(changed)
+}
+
 async fn report_training_terminal_runtime_to_authority(
     config: &PylonConfig,
     identity: &NostrIdentity,
@@ -10320,6 +12935,17 @@ async fn report_training_terminal_runtime_to_authority(
     let window_status = load_training_window_status_packet(run_root)?;
     let checkpoint_pointer = load_training_latest_checkpoint_pointer(run_root)?;
     let checkpoint_candidate = training_terminal_checkpoint_publication_candidate(context)?;
+    let run_succeeded = training_run_completed_successfully(active, run_status.as_ref());
+    let retained_contribution = if active.role == PylonTrainingRoleClaim::Worker && run_succeeded {
+        inspect_training_retained_contribution_artifacts(
+            active,
+            run_root,
+            run_status.as_ref(),
+            window_status.as_ref(),
+        )?
+    } else {
+        None
+    };
     let mut changed = false;
 
     if let Some(window_state) =
@@ -10391,6 +13017,27 @@ async fn report_training_terminal_runtime_to_authority(
 
     let failure_reason = build_training_failure_reason(active, run_status.as_ref())?;
     if let Some(failure_reason) = failure_reason {
+        changed |= record_training_closeout_progress_stage(
+            state,
+            active.assignment_id.as_str(),
+            active.training_run_id.as_str(),
+            active.window_id.as_str(),
+            active.role,
+            PylonTrainingCloseoutStage::TerminalFailed,
+            None,
+            checkpoint_candidate
+                .as_ref()
+                .map(|candidate| candidate.checkpoint_ref.clone())
+                .or_else(|| {
+                    checkpoint_pointer
+                        .as_ref()
+                        .map(|pointer| pointer.checkpoint_ref.clone())
+                }),
+            None,
+            None,
+            None,
+            Some(failure_reason.clone()),
+        );
         let receipt_key =
             training_authority_receipt_key("failure_notice", active.assignment_id.as_str());
         if training_authority_receipt_needs_attempt(state, receipt_key.as_str()) {
@@ -10434,7 +13081,55 @@ async fn report_training_terminal_runtime_to_authority(
                 }
             }
         }
-    } else if training_run_completed_successfully(active, run_status.as_ref()) {
+    } else if run_succeeded {
+        changed |= record_training_closeout_progress_stage(
+            state,
+            active.assignment_id.as_str(),
+            active.training_run_id.as_str(),
+            active.window_id.as_str(),
+            active.role,
+            PylonTrainingCloseoutStage::WorkerExitedSuccess,
+            None,
+            checkpoint_candidate
+                .as_ref()
+                .map(|candidate| candidate.checkpoint_ref.clone())
+                .or_else(|| {
+                    checkpoint_pointer
+                        .as_ref()
+                        .map(|pointer| pointer.checkpoint_ref.clone())
+                }),
+            None,
+            None,
+            None,
+            None,
+        );
+        if let Some(retained) = retained_contribution.as_ref() {
+            changed |= record_training_closeout_progress_stage(
+                state,
+                active.assignment_id.as_str(),
+                active.training_run_id.as_str(),
+                active.window_id.as_str(),
+                active.role,
+                PylonTrainingCloseoutStage::ArtifactsVerifiedLocal,
+                None,
+                retained.checkpoint_ref.clone(),
+                None,
+                None,
+                None,
+                None,
+            );
+            changed |= update_training_closeout_progress_observation(
+                state,
+                active.assignment_id.as_str(),
+                None,
+                Some(retained.contribution_id.clone()),
+                state
+                    .lease_cache
+                    .get(active.lease_id.as_str())
+                    .map(|lease| lease.state.clone()),
+                None,
+            );
+        }
         if let Some(candidate) = checkpoint_candidate.as_ref() {
             let receipt_subject = format!(
                 "{}::{}",
@@ -10485,6 +13180,93 @@ async fn report_training_terminal_runtime_to_authority(
         }
     }
 
+    let checkpoint_published = checkpoint_candidate.as_ref().is_some_and(|candidate| {
+        training_authority_receipt_is_recorded(
+            state,
+            training_authority_receipt_key(
+                "checkpoint_publication",
+                format!(
+                    "{}::{}",
+                    candidate.checkpoint_ref, candidate.artifact_digest
+                )
+                .as_str(),
+            )
+            .as_str(),
+        )
+    });
+    if checkpoint_published {
+        changed |= record_training_closeout_progress_stage(
+            state,
+            active.assignment_id.as_str(),
+            active.training_run_id.as_str(),
+            active.window_id.as_str(),
+            active.role,
+            PylonTrainingCloseoutStage::CheckpointPublished,
+            None,
+            checkpoint_candidate
+                .as_ref()
+                .map(|candidate| candidate.checkpoint_ref.clone())
+                .or_else(|| {
+                    checkpoint_pointer
+                        .as_ref()
+                        .map(|pointer| pointer.checkpoint_ref.clone())
+                }),
+            None,
+            None,
+            None,
+            None,
+        );
+    }
+
+    if run_succeeded
+        && checkpoint_published
+        && active.role == PylonTrainingRoleClaim::Worker
+        && retained_contribution.is_some()
+    {
+        let retained = retained_contribution
+            .as_ref()
+            .expect("retained contribution checked above");
+        changed |= record_training_closeout_progress_stage(
+            state,
+            active.assignment_id.as_str(),
+            active.training_run_id.as_str(),
+            active.window_id.as_str(),
+            active.role,
+            PylonTrainingCloseoutStage::WindowReadyToSeal,
+            None,
+            retained.checkpoint_ref.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+        changed |= maybe_seal_training_terminal_window(state, active, retained, &client).await?;
+    }
+
+    if run_succeeded && active.role == PylonTrainingRoleClaim::Validator {
+        changed |= maybe_finalize_training_terminal_validator_challenge(
+            identity,
+            state,
+            active,
+            &client,
+            run_root,
+            run_status.as_ref(),
+            window_status.as_ref(),
+        )
+        .await?;
+    }
+
+    changed |= maybe_reconcile_training_terminal_window(
+        state,
+        active,
+        &client,
+        run_root,
+        run_status.as_ref(),
+        window_status.as_ref(),
+    )
+    .await?;
+    changed |= observe_training_terminal_closeout_state(state, active, context, &client).await?;
+
     let target_lease_state = if training_authority_receipt_is_recorded(
         state,
         training_authority_receipt_key("failure_notice", active.assignment_id.as_str()).as_str(),
@@ -10533,6 +13315,23 @@ async fn report_training_terminal_runtime_to_authority(
             changed = true;
         }
     }
+
+    changed |= update_training_closeout_progress_observation(
+        state,
+        active.assignment_id.as_str(),
+        None,
+        retained_contribution
+            .as_ref()
+            .map(|retained| retained.contribution_id.clone()),
+        state
+            .lease_cache
+            .get(active.lease_id.as_str())
+            .map(|lease| lease.state.clone()),
+        state
+            .window_cache
+            .get(active.window_id.as_str())
+            .map(|window| window.state.clone()),
+    );
 
     Ok(changed)
 }
@@ -10678,6 +13477,106 @@ fn cache_training_closeout(
             .and_then(|summary| summary.best_eval_score_bps),
         accepted_at_ms: outcome.accepted_at_ms,
     }
+}
+
+fn training_closeout_progress_key(assignment_id: &str, challenge_id: Option<&str>) -> String {
+    challenge_id
+        .map(|challenge_id| format!("{assignment_id}::{challenge_id}"))
+        .unwrap_or_else(|| assignment_id.to_string())
+}
+
+const TRAINING_CLOSEOUT_AUTHORITY_POLL_INTERVAL_MS: i64 = 5_000;
+
+fn training_closeout_authority_poll_due(
+    state: &PylonTrainingRuntimeState,
+    window_id: &str,
+) -> bool {
+    let Some(entry) = state.window_cache.get(window_id) else {
+        return true;
+    };
+    matches!(entry.state.as_str(), "scored" | "reconciled")
+        || now_epoch_ms().saturating_sub(entry.updated_at_ms)
+            >= TRAINING_CLOSEOUT_AUTHORITY_POLL_INTERVAL_MS
+}
+
+fn record_training_closeout_progress_stage(
+    state: &mut PylonTrainingRuntimeState,
+    assignment_id: &str,
+    training_run_id: &str,
+    window_id: &str,
+    role: PylonTrainingRoleClaim,
+    stage: PylonTrainingCloseoutStage,
+    challenge_id: Option<&str>,
+    checkpoint_ref: Option<String>,
+    acceptance_state: Option<String>,
+    payout_state: Option<String>,
+    payout_receipt_id: Option<String>,
+    last_error: Option<String>,
+) -> bool {
+    let key = training_closeout_progress_key(assignment_id, challenge_id);
+    let updated_at_ms = now_epoch_ms();
+    let previous = state.closeout_progress.get(key.as_str()).cloned();
+    let mut entry = previous
+        .clone()
+        .unwrap_or_else(|| PylonTrainingCloseoutProgressEntry {
+            assignment_id: assignment_id.to_string(),
+            training_run_id: training_run_id.to_string(),
+            window_id: window_id.to_string(),
+            role,
+            stage,
+            challenge_id: challenge_id.map(ToOwned::to_owned),
+            contribution_id: None,
+            checkpoint_ref: checkpoint_ref.clone(),
+            authority_assignment_state: None,
+            authority_window_state: None,
+            acceptance_state: acceptance_state.clone(),
+            payout_state: payout_state.clone(),
+            payout_receipt_id: payout_receipt_id.clone(),
+            last_error: last_error.clone(),
+            updated_at_ms,
+        });
+    let lower_stage_than_existing = previous
+        .as_ref()
+        .is_some_and(|existing| existing.stage.ordinal() > stage.ordinal());
+    entry.training_run_id = training_run_id.to_string();
+    entry.window_id = window_id.to_string();
+    entry.role = role;
+    entry.stage = previous
+        .as_ref()
+        .map(|existing| {
+            if existing.stage.ordinal() > stage.ordinal() {
+                existing.stage
+            } else {
+                stage
+            }
+        })
+        .unwrap_or(stage);
+    entry.challenge_id = challenge_id.map(ToOwned::to_owned);
+    if checkpoint_ref.is_some() && (!lower_stage_than_existing || entry.checkpoint_ref.is_none()) {
+        entry.checkpoint_ref = checkpoint_ref;
+    }
+    if acceptance_state.is_some()
+        && (!lower_stage_than_existing || entry.acceptance_state.is_none())
+    {
+        entry.acceptance_state = acceptance_state;
+    }
+    if payout_state.is_some() && (!lower_stage_than_existing || entry.payout_state.is_none()) {
+        entry.payout_state = payout_state;
+    }
+    if payout_receipt_id.is_some()
+        && (!lower_stage_than_existing || entry.payout_receipt_id.is_none())
+    {
+        entry.payout_receipt_id = payout_receipt_id;
+    }
+    if !lower_stage_than_existing || last_error.is_some() {
+        entry.last_error = last_error;
+    }
+    let changed = previous.as_ref() != Some(&entry);
+    if changed {
+        entry.updated_at_ms = updated_at_ms;
+        state.closeout_progress.insert(key, entry);
+    }
+    changed
 }
 
 async fn collect_training_reputation_label_cache_entries(
@@ -11959,6 +14858,32 @@ fn render_training_status_report(report: &TrainingOperatorStatusReport) -> Strin
             issue.kind, issue.subject_id, issue.owner, issue.retryable, issue.reason
         ));
     }
+    lines.push(String::new());
+    lines.push(format!(
+        "closeout progress: {}",
+        report.recent_closeout_progress.len()
+    ));
+    for entry in &report.recent_closeout_progress {
+        lines.push(format!(
+            "- {} {} {} {} {}",
+            entry.training_run_id, entry.window_id, entry.assignment_id, entry.role, entry.stage
+        ));
+        if let Some(challenge_id) = entry.challenge_id.as_deref() {
+            lines.push(format!("  challenge: {challenge_id}"));
+        }
+        if let Some(acceptance_state) = entry.acceptance_state.as_deref() {
+            lines.push(format!("  acceptance: {acceptance_state}"));
+        }
+        if let Some(payout_state) = entry.payout_state.as_deref() {
+            lines.push(format!("  payout: {payout_state}"));
+        }
+        if let Some(payout_receipt_id) = entry.payout_receipt_id.as_deref() {
+            lines.push(format!("  payout receipt: {payout_receipt_id}"));
+        }
+        if let Some(last_error) = entry.last_error.as_deref() {
+            lines.push(format!("  last error: {last_error}"));
+        }
+    }
     lines.join("\n")
 }
 
@@ -11967,6 +14892,10 @@ fn training_status_headline(report: &TrainingOperatorStatusReport) -> &'static s
         "blocked"
     } else if report.active_runtime.is_some() {
         "active"
+    } else if report.recent_closeout_progress.iter().any(|entry| {
+        entry.stage != "accepted" && entry.stage != "paid" && entry.stage != "terminal_failed"
+    }) {
+        "closeout"
     } else if report.leased_assignment.is_some() {
         "leased"
     } else if report.contributor_supported {
@@ -18813,6 +21742,69 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         }
     }
 
+    fn training_adapter_window_fixture(
+        status: ComputeAdapterWindowStatus,
+    ) -> ComputeAdapterTrainingWindow {
+        ComputeAdapterTrainingWindow {
+            window_id: "window.0001".to_string(),
+            training_run_id: "run.alpha".to_string(),
+            stage_id: "stage.alpha".to_string(),
+            contributor_set_revision_id: "contributors.rev1".to_string(),
+            validator_policy_ref: PYLON_TRAINING_VALIDATOR_POLICY_REF.to_string(),
+            work_class: ComputeTrainingWorkClass::AdapterTraining,
+            replica_type: ComputeTrainingReplicaType::SingleNode,
+            round_index: Some(1),
+            base_checkpoint_ref: "checkpoint://run.alpha/0001".to_string(),
+            planned_local_step_count: Some(64),
+            aggregation_rule: Some("weighted_avg".to_string()),
+            aggregation_weight_basis: Some("tokens".to_string()),
+            adapter_target_id: "adapter.target.alpha".to_string(),
+            adapter_family: PYLON_TRAINING_ADAPTER_FAMILY.to_string(),
+            base_model_ref: "model://base.alpha".to_string(),
+            adapter_format: PYLON_TRAINING_ADAPTER_FORMAT.to_string(),
+            source_policy_revision: ComputeAdapterPolicyRevision {
+                policy_family: "policy.family.alpha".to_string(),
+                revision_id: "policy.rev.alpha".to_string(),
+                policy_digest: "sha256:policy-rev-alpha".to_string(),
+                produced_at_ms: 1_762_491_200_000,
+                ..ComputeAdapterPolicyRevision::default()
+            },
+            source_checkpoint_pointer: ComputeAdapterCheckpointPointer {
+                scope_kind: "run".to_string(),
+                scope_id: "run.alpha".to_string(),
+                checkpoint_family: PYLON_TRAINING_CHECKPOINT_FAMILY.to_string(),
+                checkpoint_ref: "checkpoint://run.alpha/0001".to_string(),
+                manifest_digest: "sha256:manifest-alpha".to_string(),
+                updated_at_ms: 1_762_491_200_000,
+                pointer_digest: "sha256:pointer-alpha".to_string(),
+            },
+            status,
+            total_contributions: 1,
+            admitted_contributions: 1,
+            accepted_contributions: 1,
+            quarantined_contributions: 0,
+            rejected_contributions: 0,
+            replay_required_contributions: 0,
+            replay_checked_contributions: 1,
+            held_out_average_score_bps: Some(9_900),
+            benchmark_pass_rate_bps: Some(10_000),
+            runtime_smoke_passed: Some(true),
+            promotion_ready: true,
+            gate_reason_codes: Vec::new(),
+            window_summary_digest: "sha256:window-summary-alpha".to_string(),
+            promotion_disposition: None,
+            hold_reason_codes: Vec::new(),
+            aggregated_delta_digest: Some("sha256:aggregated-delta-alpha".to_string()),
+            accepted_aggregate_id: Some("aggregate.window.0001".to_string()),
+            output_policy_revision: None,
+            output_checkpoint_pointer: None,
+            promoted_checkpoint_ref: None,
+            accepted_outcome_id: None,
+            recorded_at_ms: 1_762_491_210_050,
+            metadata: json!({}),
+        }
+    }
+
     fn training_coordinator_fixture(
         base_url: &str,
     ) -> Result<(tempfile::TempDir, PylonConfig, NostrIdentity), Box<dyn std::error::Error>> {
@@ -19009,6 +22001,209 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                 "schema_version":"openagents.pylon_training.score_snapshot.v1",
                 "window_id":"window.0001",
                 "score":0.99
+            })
+            .to_string(),
+        )?;
+        Ok(manifest)
+    }
+
+    fn write_training_manifest_and_retained_contribution_artifacts(
+        local_run_root: &Path,
+        bucket_uri: &str,
+    ) -> Result<
+        openagents_kernel_core::pylon_training::PylonTrainingRunManifestV1,
+        Box<dyn std::error::Error>,
+    > {
+        let manifest = training_manifest_fixture(local_run_root, bucket_uri)?;
+        std::fs::create_dir_all(local_run_root.join("manifests"))?;
+        std::fs::write(
+            local_run_root.join("manifests").join("run_manifest.json"),
+            manifest.canonical_json_bytes()?,
+        )?;
+        std::fs::create_dir_all(local_run_root.join("checkpoints").join("step-42"))?;
+        std::fs::write(
+            local_run_root
+                .join("checkpoints")
+                .join("latest_pointer.json"),
+            json!({
+                "schema_version":"openagents.pylon_training.latest_pointer.v1",
+                "checkpoint_ref":"checkpoint://run.alpha/0001"
+            })
+            .to_string(),
+        )?;
+        std::fs::write(
+            local_run_root
+                .join("checkpoints")
+                .join("latest_accepted_checkpoint_pointer.json"),
+            json!({
+                "schema_version":"openagents.pylon_training.latest_accepted_pointer.v1",
+                "checkpoint_ref":"checkpoint://run.alpha/0042",
+                "optimizer_step":42
+            })
+            .to_string(),
+        )?;
+        std::fs::write(
+            local_run_root
+                .join("checkpoints")
+                .join("step-42")
+                .join("checkpoint_manifest.json"),
+            json!({
+                "schema_version":"openagents.pylon_training.checkpoint_manifest.v1",
+                "checkpoint_ref":"checkpoint://run.alpha/0042",
+                "optimizer_step":42
+            })
+            .to_string(),
+        )?;
+        std::fs::create_dir_all(local_run_root.join("status"))?;
+        std::fs::write(
+            local_run_root
+                .join("status")
+                .join("checkpoint_surface.json"),
+            json!({
+                "schema_version":"psionic.train.checkpoint_surface.v1",
+                "checkpoint_ref":"checkpoint://run.alpha/0042",
+                "checkpoint_digest":"sha256:checkpoint-surface-alpha",
+                "optimizer_step":42
+            })
+            .to_string(),
+        )?;
+        std::fs::create_dir_all(local_run_root.join("closeout"))?;
+        std::fs::write(
+            local_run_root.join("closeout").join("closeout_bundle.json"),
+            json!({
+                "schema_version":"psion.cs336_a1_demo_closeout_bundle.v1",
+                "run_id":"run.alpha",
+                "outcome":"accepted",
+                "checkpoint_ref":"checkpoint://run.alpha/0042",
+                "training_step_count":42
+            })
+            .to_string(),
+        )?;
+        let contribution_root = local_run_root
+            .join("windows")
+            .join("window.0001")
+            .join("contributions")
+            .join("contrib.node01.window0001");
+        std::fs::create_dir_all(&contribution_root)?;
+        std::fs::write(
+            contribution_root.join("artifact_manifest.json"),
+            json!({
+                "schema_version":"psionic.train.contribution_artifact_manifest.v1",
+                "run_id":"run.alpha",
+                "window_id":"window.0001",
+                "assignment_id":"assign.node01.window0001",
+                "contribution_id":"contrib.node01.window0001",
+                "node_pubkey":"node.alpha",
+                "artifact_count":2,
+                "artifacts":[
+                    {
+                        "artifact_kind":"checkpoint_manifest",
+                        "binding":{
+                            "artifact_ref":{
+                                "artifact_id":"artifact.checkpoint.alpha",
+                                "artifact_digest":"sha256:checkpoint-alpha",
+                                "artifact_bytes":128
+                            },
+                            "materialized_path":local_run_root.join("checkpoints").join("step-42").join("checkpoint_manifest.json").display().to_string()
+                        }
+                    }
+                ],
+                "artifact_manifest_digest":"sha256:placeholder"
+            })
+            .to_string(),
+        )?;
+        let artifact_manifest_value: Value = serde_json::from_slice(
+            std::fs::read(contribution_root.join("artifact_manifest.json"))?.as_slice(),
+        )?;
+        let artifact_manifest_digest =
+            openagents_kernel_core::pylon_training::artifact_digest_from_json(
+                &artifact_manifest_value,
+            )?;
+        std::fs::write(
+            contribution_root.join("artifact_manifest.json"),
+            json!({
+                "schema_version":"psionic.train.contribution_artifact_manifest.v1",
+                "run_id":"run.alpha",
+                "window_id":"window.0001",
+                "assignment_id":"assign.node01.window0001",
+                "contribution_id":"contrib.node01.window0001",
+                "node_pubkey":"node.alpha",
+                "artifact_count":1,
+                "artifacts":[
+                    {
+                        "artifact_kind":"checkpoint_manifest",
+                        "binding":{
+                            "artifact_ref":{
+                                "artifact_id":"artifact.checkpoint.alpha",
+                                "artifact_digest":"sha256:checkpoint-alpha",
+                                "artifact_bytes":128
+                            },
+                            "materialized_path":local_run_root.join("checkpoints").join("step-42").join("checkpoint_manifest.json").display().to_string()
+                        }
+                    }
+                ],
+                "artifact_manifest_digest":artifact_manifest_digest
+            })
+            .to_string(),
+        )?;
+        std::fs::write(
+            contribution_root.join("contribution_receipt.json"),
+            json!({
+                "schema_version":"psionic.train.contribution_receipt.v1",
+                "run_id":"run.alpha",
+                "window_id":"window.0001",
+                "assignment_id":"assign.node01.window0001",
+                "contribution_id":"contrib.node01.window0001",
+                "node_pubkey":"node.alpha",
+                "lane_id":PSION_CS336_A1_DEMO_LANE_ID,
+                "work_class":"small_model_local_training",
+                "role":"worker",
+                "operation":"start",
+                "outcome":"succeeded",
+                "exit_code":0,
+                "retryable":false,
+                "authority_owner":"pylon",
+                "artifact_manifest_digest":artifact_manifest_digest,
+                "artifact_manifest":{
+                    "artifact_ref":{
+                        "artifact_id":"artifact.manifest.alpha",
+                        "artifact_digest":artifact_manifest_digest,
+                        "artifact_bytes":512
+                    },
+                    "materialized_path":contribution_root.join("artifact_manifest.json").display().to_string()
+                },
+                "artifact_count":1,
+                "contribution_digest":"sha256:contribution-alpha",
+                "detail":"retained contribution"
+            })
+            .to_string(),
+        )?;
+        std::fs::write(
+            local_run_root
+                .join("windows")
+                .join("window.0001")
+                .join("sealed_window_bundle.json"),
+            json!({
+                "schema_version":"psionic.train.sealed_window_bundle.v1",
+                "run_id":"run.alpha",
+                "window_id":"window.0001",
+                "contribution_count":1,
+                "artifact_manifest_count":1,
+                "contributions":[
+                    {
+                        "assignment_id":"assign.node01.window0001",
+                        "contribution_id":"contrib.node01.window0001",
+                        "node_pubkey":"node.alpha",
+                        "work_class":"small_model_local_training",
+                        "outcome":"succeeded",
+                        "artifact_manifest_digest":artifact_manifest_digest,
+                        "contribution_digest":"sha256:contribution-alpha",
+                        "contribution_receipt_path":contribution_root.join("contribution_receipt.json").display().to_string()
+                    }
+                ],
+                "contribution_rollup_digest":"sha256:rollup-alpha",
+                "sealed_window_digest":"sha256:sealed-alpha",
+                "detail":"retained sealed window"
             })
             .to_string(),
         )?;
@@ -21710,6 +24905,168 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         )
     }
 
+    #[test]
+    fn training_artifact_inspection_materializes_bridge_bundles_for_retained_contributions()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        save_config(config_path.as_path(), &config)?;
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        write_training_manifest_and_retained_contribution_artifacts(
+            local_run_root.as_path(),
+            "gs://bucket",
+        )?;
+
+        let report = load_training_artifact_inspection_report(config_path.as_path())?;
+        let contribution_bundle = report
+            .bundles
+            .iter()
+            .find(|entry| entry.bundle_id == "contribution:contrib.node01.window0001")
+            .ok_or_else(|| {
+                std::io::Error::other("expected retained contribution bundle in inspection report")
+            })?;
+        ensure(
+            contribution_bundle.state == "local_only"
+                && contribution_bundle.objects.len() == 2
+                && contribution_bundle
+                    .objects
+                    .iter()
+                    .all(|object| object.present),
+            "retained contribution outputs should be bridged into a complete local contribution bundle instead of staying artifact_incomplete",
+        )?;
+
+        let contribution_root = local_run_root
+            .join("windows")
+            .join("window.0001")
+            .join("contributions")
+            .join("contrib.node01.window0001");
+        let adapter_delta_bundle: Value = serde_json::from_slice(
+            std::fs::read(contribution_root.join("adapter_delta_bundle.json"))?.as_slice(),
+        )?;
+        let proof_bundle: Value = serde_json::from_slice(
+            std::fs::read(contribution_root.join("proof_bundle.json"))?.as_slice(),
+        )?;
+        ensure(
+            adapter_delta_bundle.get("schema_version")
+                == Some(&json!(
+                    super::PYLON_TRAINING_ADAPTER_DELTA_BRIDGE_SCHEMA_VERSION
+                ))
+                && proof_bundle.get("schema_version")
+                    == Some(&json!(
+                        super::PYLON_TRAINING_PROOF_BUNDLE_BRIDGE_SCHEMA_VERSION
+                    )),
+            "bridge materialization should write explicit bridge-schema bundles for retained contribution outputs",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn training_artifact_courier_uploads_bridge_bundles_for_retained_contributions()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let _env_lock = training_env_lock();
+        let stored_objects = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<u8>>::new(),
+        ));
+        let stored_objects_for_server = Arc::clone(&stored_objects);
+        let base_url = start_mock_http_server(move |method, path, body| match method.as_str() {
+            "PUT" => {
+                stored_objects_for_server
+                    .lock()
+                    .expect("retained contribution object store")
+                    .insert(path.clone(), body.into_bytes());
+                (200, "application/json", "{}".to_string())
+            }
+            "GET" => {
+                let payload = stored_objects_for_server
+                    .lock()
+                    .expect("retained contribution object store")
+                    .get(path.as_str())
+                    .cloned()
+                    .unwrap_or_else(|| b"{}".to_vec());
+                (
+                    200,
+                    "application/json",
+                    String::from_utf8(payload).expect("stored bridge object should stay utf8"),
+                )
+            }
+            _ => (
+                405,
+                "application/json",
+                json!({"error":"method_not_allowed"}).to_string(),
+            ),
+        })
+        .await?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        save_config(config_path.as_path(), &config)?;
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        let manifest = write_training_manifest_and_retained_contribution_artifacts(
+            local_run_root.as_path(),
+            "gs://bucket",
+        )?;
+        let fake_adc_path = temp_dir.path().join("fake-adc.json");
+        std::fs::write(fake_adc_path.as_path(), "{}")?;
+        let _env = TrainingEnvGuard::set(&[
+            (ENV_TRAINING_GCS_ENDPOINT, base_url.clone()),
+            (ENV_TRAINING_GCS_BEARER_TOKEN, "token.alpha".to_string()),
+            (
+                ENV_GOOGLE_APPLICATION_CREDENTIALS,
+                fake_adc_path.display().to_string(),
+            ),
+        ]);
+
+        let client = PylonTrainingArtifactStoreClient::new(&config).await?;
+        let contribution_report = client
+            .upload_bundle(
+                &manifest,
+                PylonTrainingArtifactBundleKind::Contribution {
+                    assignment_id: "contrib.node01.window0001".to_string(),
+                },
+            )
+            .await?;
+        ensure(
+            contribution_report.state == "uploaded"
+                && contribution_report.objects.len() == 2
+                && contribution_report
+                    .objects
+                    .iter()
+                    .all(|object| object.digest_verified),
+            "artifact courier should upload retained contribution bridge bundles through the existing contribution contract",
+        )?;
+
+        let stored = stored_objects
+            .lock()
+            .expect("retained contribution object store")
+            .clone();
+        let adapter_delta_bundle: Value = serde_json::from_slice(
+            stored
+                .get("/bucket/networks/trainnet.alpha/runs/run.alpha/windows/window.0001/contributions/contrib.node01.window0001/adapter_delta_bundle.json")
+                .ok_or_else(|| std::io::Error::other("expected uploaded adapter-delta bridge bundle"))?
+                .as_slice(),
+        )?;
+        let proof_bundle: Value = serde_json::from_slice(
+            stored
+                .get("/bucket/networks/trainnet.alpha/runs/run.alpha/windows/window.0001/contributions/contrib.node01.window0001/proof_bundle.json")
+                .ok_or_else(|| std::io::Error::other("expected uploaded proof bridge bundle"))?
+                .as_slice(),
+        )?;
+        ensure(
+            adapter_delta_bundle.get("schema_version")
+                == Some(&json!(
+                    super::PYLON_TRAINING_ADAPTER_DELTA_BRIDGE_SCHEMA_VERSION
+                ))
+                && proof_bundle.get("schema_version")
+                    == Some(&json!(
+                        super::PYLON_TRAINING_PROOF_BUNDLE_BRIDGE_SCHEMA_VERSION
+                    )),
+            "uploaded retained contribution bundles should carry explicit bridge schemas instead of pretending the old adapter/proof payloads still exist",
+        )
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn training_publish_emits_trn_events_and_persists_publication_pointers()
     -> Result<(), Box<dyn std::error::Error>> {
@@ -22386,6 +25743,1037 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         ensure(
             counts_after_second == counts,
             "terminal sync should dedupe successful Nexus receipt publication across later serve loops",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn training_terminal_sync_seals_window_from_retained_worker_artifacts()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let _env_lock = training_env_lock();
+        let relay = TestPublishRelay::spawn();
+        let stored_objects = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<u8>>::new(),
+        ));
+        let stored_objects_for_server = Arc::clone(&stored_objects);
+        let gcs_base_url = start_mock_http_server(move |method, path, body| {
+            let mut objects = stored_objects_for_server
+                .lock()
+                .expect("training seal object store");
+            match method.as_str() {
+                "PUT" => {
+                    objects.insert(path.clone(), body.into_bytes());
+                    (200, "application/json", json!({"ok": true}).to_string())
+                }
+                "GET" => match objects.get(path.as_str()) {
+                    Some(payload) => (
+                        200,
+                        "application/octet-stream",
+                        String::from_utf8(payload.clone()).expect("stored object utf8"),
+                    ),
+                    None => (
+                        404,
+                        "application/json",
+                        json!({"error":"missing"}).to_string(),
+                    ),
+                },
+                _ => (
+                    405,
+                    "application/json",
+                    json!({"error":"method_not_allowed"}).to_string(),
+                ),
+            }
+        })
+        .await?;
+
+        let request_counts = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, usize>::new(),
+        ));
+        let request_bodies = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<Value>>::new(),
+        ));
+        let request_counts_for_server = Arc::clone(&request_counts);
+        let request_bodies_for_server = Arc::clone(&request_bodies);
+        let seal_response =
+            serde_json::to_string(&super::PylonTrainingWindowCoordinatorResponse {
+                window: training_adapter_window_fixture(ComputeAdapterWindowStatus::Sealed),
+                contribution_outcomes: Vec::new(),
+            })?;
+        let nexus_base_url = start_mock_http_server(move |method, path, body| {
+            *request_counts_for_server
+                .lock()
+                .expect("training seal request counts")
+                .entry(path.clone())
+                .or_default() += 1;
+            if method == "POST" {
+                let payload: Value =
+                    serde_json::from_str(body.as_str()).expect("training seal request payload");
+                request_bodies_for_server
+                    .lock()
+                    .expect("training seal request bodies")
+                    .entry(path.clone())
+                    .or_default()
+                    .push(payload);
+            }
+            match path.as_str() {
+                "/api/training/windows/progress" => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "window-progress-success",
+                            "recorded_at_ms": 1_762_491_330_100_i64,
+                            "authority_state": "window_progress_recorded"
+                        },
+                        "window_state": "sealing"
+                    })
+                    .to_string(),
+                ),
+                "/api/training/checkpoints/publish" => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "checkpoint-publication-success",
+                            "recorded_at_ms": 1_762_491_330_200_i64,
+                            "authority_state": "checkpoint_published"
+                        },
+                        "checkpoint_state": "published",
+                        "artifact_locator": "gs://bucket/networks/trainnet.alpha/runs/run.alpha/checkpoints/step-42/checkpoint_manifest.json"
+                    })
+                    .to_string(),
+                ),
+                "/api/training/windows/window.0001/seal" => {
+                    (200, "application/json", seal_response.clone())
+                }
+                "/api/training/failures" => (
+                    500,
+                    "application/json",
+                    json!({"error":"unexpected_failure_notice"}).to_string(),
+                ),
+                _ => (
+                    404,
+                    "application/json",
+                    json!({"error":"not_found","reason":path}).to_string(),
+                ),
+            }
+        })
+        .await?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        config.training.relay_urls = vec![relay.url.clone()];
+        config.training.nexus_authority_base_url = nexus_base_url;
+        config.relay_auth_enabled = false;
+        save_config(config_path.as_path(), &config)?;
+        let identity = ensure_identity(config.identity_path.as_path())?;
+
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        let mut manifest = write_training_manifest_and_retained_contribution_artifacts(
+            local_run_root.as_path(),
+            "gs://bucket",
+        )?;
+        manifest.trn.relay_urls = vec![relay.url.clone()];
+        manifest.manifest_digest = manifest.canonical_digest()?;
+        let manifest_path = local_run_root.join("manifests").join("run_manifest.json");
+        std::fs::write(manifest_path.as_path(), manifest.canonical_json_bytes()?)?;
+        write_training_terminal_status_packets(
+            local_run_root.as_path(),
+            "succeeded",
+            0,
+            None,
+            Some("completed"),
+            "completed window",
+        )?;
+
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        let mut active_runtime = training_active_runtime_fixture();
+        active_runtime.manifest_path = manifest_path.display().to_string();
+        active_runtime.run_root = local_run_root.display().to_string();
+        active_runtime.process_state = PylonTrainingSupervisorProcessState::Stopped;
+        active_runtime.desired_state = PylonTrainingSupervisorDesiredState::Running;
+        active_runtime.last_exit_code = Some(0);
+        active_runtime.failure_receipt_path = None;
+        active_runtime.last_failure_reason = None;
+        state.active_runtime = Some(active_runtime);
+        state.lease_cache.insert(
+            "lease.node01.window0001".to_string(),
+            PylonTrainingLeaseCacheEntry {
+                lease_id: "lease.node01.window0001".to_string(),
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                membership_revision: "members.rev1".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                state: "active".to_string(),
+                manifest_digest: Some(manifest.manifest_digest.clone()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                expires_at_ms: Some(1_762_491_360_000),
+                network_id: Some("trainnet.alpha".to_string()),
+                challenge_id: None,
+                peer_node_pubkey: None,
+                peer_checkpoint_handoff_receipt_path: None,
+                validator_target_contribution_receipt_path: None,
+                validator_target_contribution_artifact_manifest_path: None,
+                validator_target_work_class: None,
+                grouped_stage_input_transport_path: None,
+                runtime_manifest_path: Some(manifest_path.display().to_string()),
+                runtime_manifest_digest: Some(manifest.manifest_digest.clone()),
+                runtime_lane_id: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
+                runtime_operation: Some("start".to_string()),
+                runtime_work_class: Some("small_model_local_training".to_string()),
+                updated_at_ms: now_epoch_ms(),
+            },
+        );
+        save_training_runtime_state(&config, &state)?;
+
+        let fake_adc_path = temp_dir.path().join("fake-adc.json");
+        std::fs::write(fake_adc_path.as_path(), "{}")?;
+        let _env = TrainingEnvGuard::set(&[
+            (ENV_TRAINING_GCS_ENDPOINT, gcs_base_url),
+            (ENV_TRAINING_GCS_BEARER_TOKEN, "token.alpha".to_string()),
+            (
+                ENV_GOOGLE_APPLICATION_CREDENTIALS,
+                fake_adc_path.display().to_string(),
+            ),
+        ]);
+
+        ensure(
+            sync_training_terminal_runtime_once(config_path.as_path(), &config, &identity).await?,
+            "retained worker artifacts should drive terminal sync through seal automatically",
+        )?;
+
+        let synced_state = load_or_create_training_runtime_state(&config)?;
+        ensure(
+            synced_state
+                .authority_receipt_records
+                .get("window_seal::window.0001")
+                .is_some_and(|record| !record.pending_retry)
+                && synced_state
+                    .closeout_progress
+                    .get("assign.node01.window0001")
+                    .is_some_and(|entry| {
+                        entry.stage == super::PylonTrainingCloseoutStage::WindowSealed
+                            && entry.checkpoint_ref.as_deref()
+                                == Some("checkpoint://run.alpha/0042")
+                    }),
+            "terminal sync should persist both the successful window seal receipt and the closeout progress stage",
+        )?;
+
+        let receipt_value: Value = serde_json::from_slice(
+            std::fs::read(
+                local_run_root
+                    .join("windows")
+                    .join("window.0001")
+                    .join("contributions")
+                    .join("contrib.node01.window0001")
+                    .join("contribution_receipt.json"),
+            )?
+            .as_slice(),
+        )?;
+        let manifest_value: Value = serde_json::from_slice(
+            std::fs::read(
+                local_run_root
+                    .join("windows")
+                    .join("window.0001")
+                    .join("contributions")
+                    .join("contrib.node01.window0001")
+                    .join("artifact_manifest.json"),
+            )?
+            .as_slice(),
+        )?;
+        let expected_receipt_digest =
+            openagents_kernel_core::pylon_training::artifact_digest_from_json(&receipt_value)?;
+        let expected_manifest_digest =
+            openagents_kernel_core::pylon_training::artifact_digest_from_json(&manifest_value)?;
+
+        let counts = request_counts
+            .lock()
+            .expect("training seal request counts")
+            .clone();
+        ensure(
+            counts.get("/api/training/windows/progress") == Some(&1)
+                && counts.get("/api/training/checkpoints/publish") == Some(&1)
+                && counts.get("/api/training/windows/window.0001/seal") == Some(&1)
+                && !counts.contains_key("/api/training/failures"),
+            "terminal sync should issue exactly one seal request after checkpoint publication and should not report a failure for the success path",
+        )?;
+
+        let bodies = request_bodies
+            .lock()
+            .expect("training seal request bodies")
+            .clone();
+        ensure(
+            bodies
+                .get("/api/training/windows/window.0001/seal")
+                .and_then(|entries| entries.first())
+                .is_some_and(|payload| {
+                    payload.get("window_id") == Some(&json!("window.0001"))
+                        && payload
+                            .get("contribution_outcomes")
+                            .and_then(Value::as_array)
+                            .and_then(|entries| entries.first())
+                            .is_some_and(|outcome| {
+                                outcome.get("assignment_id")
+                                    == Some(&json!("assign.node01.window0001"))
+                                    && outcome.get("contribution_id")
+                                        == Some(&json!("contrib.node01.window0001"))
+                                    && outcome.get("submission_receipt_digest")
+                                        == Some(&json!(expected_receipt_digest))
+                                    && outcome.get("manifest_digest")
+                                        == Some(&json!(expected_manifest_digest))
+                                    && outcome.get("object_digest")
+                                        == Some(&json!("sha256:contribution-alpha"))
+                                    && outcome.get("local_step_count") == Some(&json!(42))
+                                    && outcome
+                                        .get("metadata")
+                                        .and_then(|metadata| {
+                                            metadata
+                                                .get("normalized_contribution_contract")
+                                                .zip(metadata.get("lane_type"))
+                                                .zip(metadata.get("work_class"))
+                                        })
+                                        .is_some_and(|((contract, lane_type), work_class)| {
+                                            contract == &json!("retained_homework_lane.v1")
+                                                && lane_type == &json!(PSION_CS336_A1_DEMO_LANE_ID)
+                                                && work_class
+                                                    == &json!("small_model_local_training")
+                                        })
+                            })
+                }),
+            "seal requests should carry the normalized retained-homework contribution contract with the bridged receipt and manifest digests",
+        )?;
+
+        ensure(
+            !sync_training_terminal_runtime_once(config_path.as_path(), &config, &identity).await?,
+            "once the seal receipt is persisted, later terminal sync passes should stay quiet",
+        )?;
+        let counts_after_second = request_counts
+            .lock()
+            .expect("training seal request counts after second pass")
+            .clone();
+        ensure(
+            counts_after_second == counts,
+            "terminal sync should not re-seal a window after recording the first successful seal receipt",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pylon_autonomously_closes_homework_assignment_from_worker_completion_to_paid_receipt()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let _env_lock = training_env_lock();
+        let relay = TestPublishRelay::spawn();
+        let stored_objects = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<u8>>::new(),
+        ));
+        let stored_objects_for_server = Arc::clone(&stored_objects);
+        let gcs_base_url = start_mock_http_server(move |method, path, body| {
+            let mut objects = stored_objects_for_server
+                .lock()
+                .expect("training autonomous object store");
+            match method.as_str() {
+                "PUT" => {
+                    objects.insert(path.clone(), body.into_bytes());
+                    (200, "application/json", json!({"ok": true}).to_string())
+                }
+                "GET" => match objects.get(path.as_str()) {
+                    Some(payload) => (
+                        200,
+                        "application/octet-stream",
+                        String::from_utf8(payload.clone()).expect("stored object utf8"),
+                    ),
+                    None => (
+                        404,
+                        "application/json",
+                        json!({"error":"missing"}).to_string(),
+                    ),
+                },
+                _ => (
+                    405,
+                    "application/json",
+                    json!({"error":"method_not_allowed"}).to_string(),
+                ),
+            }
+        })
+        .await?;
+
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum CloseoutPhase {
+            Launching,
+            Sealed,
+            Scored,
+            Paid,
+        }
+
+        let phase = Arc::new(Mutex::new(CloseoutPhase::Launching));
+        let request_counts = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, usize>::new(),
+        ));
+        let request_bodies = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<Value>>::new(),
+        ));
+        let phase_for_server = Arc::clone(&phase);
+        let request_counts_for_server = Arc::clone(&request_counts);
+        let request_bodies_for_server = Arc::clone(&request_bodies);
+        let nexus_base_url = start_mock_http_server(move |method, path, body| {
+            *request_counts_for_server
+                .lock()
+                .expect("training autonomous request counts")
+                .entry(path.clone())
+                .or_default() += 1;
+            if method == "POST" {
+                let payload: Value =
+                    serde_json::from_str(body.as_str()).expect("training autonomous payload");
+                request_bodies_for_server
+                    .lock()
+                    .expect("training autonomous request bodies")
+                    .entry(path.clone())
+                    .or_default()
+                    .push(payload);
+            }
+
+            let make_outcome = |validator_disposition: ComputeAdapterContributionDisposition,
+                                validator_receipt_digest: &str| {
+                ComputeAdapterContributionOutcome {
+                    contribution_id: "contrib.node01.window0001".to_string(),
+                    training_run_id: "run.alpha".to_string(),
+                    stage_id: "stage.alpha".to_string(),
+                    window_id: "window.0001".to_string(),
+                    contributor_set_revision_id: "contributors.rev1".to_string(),
+                    assignment_id: "assign.node01.window0001".to_string(),
+                    contributor_node_id: "node.alpha".to_string(),
+                    worker_id: "worker.alpha".to_string(),
+                    validator_policy_ref: PYLON_TRAINING_VALIDATOR_POLICY_REF.to_string(),
+                    work_class: ComputeTrainingWorkClass::SmallModelLocalTraining,
+                    replica_type: ComputeTrainingReplicaType::SingleNode,
+                    base_checkpoint_ref: "checkpoint://run.alpha/0001".to_string(),
+                    adapter_target_id: "adapter.target.alpha".to_string(),
+                    adapter_family: PYLON_TRAINING_ADAPTER_FAMILY.to_string(),
+                    base_model_ref: "model://base.alpha".to_string(),
+                    adapter_format: PYLON_TRAINING_ADAPTER_FORMAT.to_string(),
+                    dataset_slice: ComputeAdapterDatasetSlice {
+                        dataset_id: "dataset.alpha".to_string(),
+                        split_name: "train".to_string(),
+                        slice_id: "slice.alpha".to_string(),
+                        slice_digest: "sha256:slice.alpha".to_string(),
+                    },
+                    source_policy_revision: ComputeAdapterPolicyRevision {
+                        policy_family: "policy.family.alpha".to_string(),
+                        revision_id: "policy.rev.alpha".to_string(),
+                        policy_digest: "sha256:policy-rev-alpha".to_string(),
+                        produced_at_ms: 1_762_491_200_000,
+                        ..ComputeAdapterPolicyRevision::default()
+                    },
+                    source_checkpoint_pointer: ComputeAdapterCheckpointPointer {
+                        scope_kind: "run".to_string(),
+                        scope_id: "run.alpha".to_string(),
+                        checkpoint_family: PYLON_TRAINING_CHECKPOINT_FAMILY.to_string(),
+                        checkpoint_ref: "checkpoint://run.alpha/0001".to_string(),
+                        manifest_digest: "sha256:manifest-alpha".to_string(),
+                        updated_at_ms: 1_762_491_200_000,
+                        pointer_digest: "sha256:pointer-alpha".to_string(),
+                    },
+                    submission_receipt_digest: "sha256:receipt:contrib.node01.window0001"
+                        .to_string(),
+                    artifact_id: "artifact.contrib.node01.window0001".to_string(),
+                    manifest_digest: "sha256:manifest-alpha".to_string(),
+                    object_digest: "sha256:contribution-alpha".to_string(),
+                    artifact_receipt_digest: "sha256:artifact-receipt-alpha".to_string(),
+                    provenance_bundle_digest: "sha256:provenance-alpha".to_string(),
+                    security_receipt_digest: "sha256:closeout-alpha".to_string(),
+                    replay_receipt_digest: Some("sha256:replay-alpha".to_string()),
+                    validator_disposition,
+                    validation_reason_codes: Vec::new(),
+                    validator_receipt_digest: validator_receipt_digest.to_string(),
+                    aggregation_eligibility: ComputeAdapterAggregationEligibility::Eligible,
+                    accepted_for_aggregation: validator_disposition
+                        == ComputeAdapterContributionDisposition::Accepted,
+                    local_step_count: Some(42),
+                    consumed_token_count: Some(131_072),
+                    consumed_example_count: Some(256),
+                    aggregation_weight_basis: Some("tokens".to_string()),
+                    aggregation_weight_value: Some(131_072),
+                    aggregation_weight_bps: Some(10_000),
+                    promotion_receipt_digest: None,
+                    recorded_at_ms: 1_762_491_330_000,
+                    metadata: json!({
+                        "normalized_contribution_contract": "retained_homework_lane.v1",
+                        "lane_type": PSION_CS336_A1_DEMO_LANE_ID,
+                        "work_class": "small_model_local_training"
+                    }),
+                }
+            };
+            let make_window = |phase: CloseoutPhase| {
+                let mut window = training_adapter_window_fixture(match phase {
+                    CloseoutPhase::Launching => ComputeAdapterWindowStatus::Active,
+                    CloseoutPhase::Sealed => ComputeAdapterWindowStatus::Sealed,
+                    CloseoutPhase::Scored => ComputeAdapterWindowStatus::Scored,
+                    CloseoutPhase::Paid => ComputeAdapterWindowStatus::Reconciled,
+                });
+                window.work_class = ComputeTrainingWorkClass::SmallModelLocalTraining;
+                window.replica_type = ComputeTrainingReplicaType::SingleNode;
+                if phase == CloseoutPhase::Paid {
+                    window.accepted_outcome_id =
+                        Some("accepted.training_window.window.0001".to_string());
+                    window.promoted_checkpoint_ref =
+                        Some("checkpoint://run.alpha/0042".to_string());
+                }
+                window
+            };
+            let mut accepted_run = training_run_fixture();
+            accepted_run.work_class = ComputeTrainingWorkClass::SmallModelLocalTraining;
+            accepted_run.replica_type = ComputeTrainingReplicaType::SingleNode;
+            accepted_run.summary = Some(ComputeTrainingSummary {
+                completed_step_count: Some(42),
+                processed_token_count: Some(131_072),
+                best_eval_score_bps: Some(10_000),
+                accepted_checkpoint_ref: Some("checkpoint://run.alpha/0042".to_string()),
+                ..ComputeTrainingSummary::default()
+            });
+            let accepted_outcome = ComputeAcceptedOutcome::from_training_run(
+                "accepted.training_window.window.0001",
+                1_762_491_330_800,
+                &accepted_run,
+                json!({
+                    "window_id": "window.0001",
+                    "closeout_status": "accepted",
+                    "payout_eligible": true
+                }),
+            );
+
+            match (method.as_str(), path.as_str()) {
+                ("POST", "/api/training/windows/progress") => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "window-progress-autonomous",
+                            "recorded_at_ms": 1_762_491_330_100_i64,
+                            "authority_state": "window_progress_recorded"
+                        },
+                        "window_state": "completed"
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/api/training/checkpoints/publish") => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "checkpoint-publication-autonomous",
+                            "recorded_at_ms": 1_762_491_330_200_i64,
+                            "authority_state": "checkpoint_published"
+                        },
+                        "checkpoint_state": "published",
+                        "artifact_locator": "gs://bucket/networks/trainnet.alpha/runs/run.alpha/checkpoints/step-42/checkpoint_manifest.json"
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/api/training/windows/window.0001/seal") => {
+                    *phase_for_server.lock().expect("closeout phase") = CloseoutPhase::Sealed;
+                    (
+                        200,
+                        "application/json",
+                        serde_json::to_string(&super::PylonTrainingWindowCoordinatorResponse {
+                            window: make_window(CloseoutPhase::Sealed),
+                            contribution_outcomes: vec![make_outcome(
+                                ComputeAdapterContributionDisposition::ReplayRequired,
+                                "sha256:validator-pending-alpha",
+                            )],
+                        })
+                        .expect("seal response"),
+                    )
+                }
+                ("POST", "/api/training/validator-challenges/challenge.alpha/finalize") => {
+                    *phase_for_server.lock().expect("closeout phase") = CloseoutPhase::Scored;
+                    let request: super::PylonFinalizeTrainingValidatorChallengeRequest =
+                        serde_json::from_str(body.as_str()).expect("validator finalize request");
+                    (
+                        200,
+                        "application/json",
+                        serde_json::to_string(
+                            &super::PylonTrainingValidatorChallengeCoordinatorResponse {
+                                ack: super::PylonTrainingCoordinatorAck {
+                                    idempotency_key: request.idempotency_key.clone(),
+                                    recorded_at_ms: request.recorded_at_ms,
+                                    authority_state: "verified".to_string(),
+                                },
+                                network_id: "trainnet.alpha".to_string(),
+                                training_run_id: "run.alpha".to_string(),
+                                window_id: "window.0001".to_string(),
+                                challenge_id: "challenge.alpha".to_string(),
+                                challenge_kind: "contribution_sample".to_string(),
+                                target_assignment_ids: vec!["assign.node01.window0001".to_string()],
+                                expected_manifest_digests: vec!["sha256:manifest-alpha".to_string()],
+                                challenge: openagents_kernel_core::compute::ComputeValidatorChallengeSnapshot {
+                                    request: openagents_kernel_core::compute::ComputeValidatorChallengeRequest {
+                                        context: openagents_kernel_core::compute::ComputeValidatorChallengeContext {
+                                            challenge_id: "challenge.alpha".to_string(),
+                                            proof_bundle_digest: "sha256:proof-bundle-alpha".to_string(),
+                                            request_digest: "sha256:challenge-request-alpha".to_string(),
+                                            delivery_proof_id: None,
+                                            product_id: "psionic.training.gradient.elastic".to_string(),
+                                            runtime_backend: "metal".to_string(),
+                                            model_id: None,
+                                            validator_pool_ref: Some("pool.alpha".to_string()),
+                                            created_at_ms: 1_762_491_330_250,
+                                            max_attempts: 1,
+                                            lease_timeout_ms: 60_000,
+                                        },
+                                        protocol: openagents_kernel_core::compute::ComputeValidatorChallengeProtocolKind::GpuFreivaldsMerkleV1,
+                                    },
+                                    status: openagents_kernel_core::compute::ComputeValidatorChallengeStatus::Verified,
+                                    attempts_used: 1,
+                                    active_lease: None,
+                                    final_result: Some(request.result.clone()),
+                                },
+                                lease: None,
+                                result: Some(request.result),
+                                window: Some(make_window(CloseoutPhase::Scored)),
+                                contribution_outcomes: vec![make_outcome(
+                                    ComputeAdapterContributionDisposition::Accepted,
+                                    "sha256:validator-final-alpha",
+                                )],
+                                target_bindings: Vec::new(),
+                            },
+                        )
+                        .expect("validator finalize response"),
+                    )
+                }
+                ("POST", "/api/training/windows/window.0001/reconcile") => {
+                    *phase_for_server.lock().expect("closeout phase") = CloseoutPhase::Paid;
+                    (
+                        200,
+                        "application/json",
+                        serde_json::to_string(&super::PylonTrainingWindowCoordinatorResponse {
+                            window: make_window(CloseoutPhase::Paid),
+                            contribution_outcomes: vec![make_outcome(
+                                ComputeAdapterContributionDisposition::Accepted,
+                                "sha256:validator-final-alpha",
+                            )],
+                        })
+                        .expect("reconcile response"),
+                    )
+                }
+                ("GET", "/v1/kernel/compute/training/adapter-windows/window.0001") => {
+                    let phase = *phase_for_server.lock().expect("closeout phase");
+                    (
+                        200,
+                        "application/json",
+                        serde_json::to_string(
+                            &compute_contracts::get_compute_adapter_training_window_response_to_proto(
+                                &make_window(phase),
+                            )
+                            .expect("window proto"),
+                        )
+                        .expect("window json"),
+                    )
+                }
+                (
+                    "GET",
+                    "/v1/kernel/compute/training/adapter-contributions?training_run_id=run.alpha&window_id=window.0001",
+                ) => {
+                    let phase = *phase_for_server.lock().expect("closeout phase");
+                    let disposition = if matches!(phase, CloseoutPhase::Scored | CloseoutPhase::Paid)
+                    {
+                        ComputeAdapterContributionDisposition::Accepted
+                    } else {
+                        ComputeAdapterContributionDisposition::ReplayRequired
+                    };
+                    let receipt_digest = if disposition
+                        == ComputeAdapterContributionDisposition::Accepted
+                    {
+                        "sha256:validator-final-alpha"
+                    } else {
+                        "sha256:validator-pending-alpha"
+                    };
+                    (
+                        200,
+                        "application/json",
+                        serde_json::to_string(
+                            &compute_contracts::list_compute_adapter_contribution_outcomes_response_to_proto(
+                                &[make_outcome(disposition, receipt_digest)],
+                            )
+                            .expect("contribution proto"),
+                        )
+                        .expect("contribution json"),
+                    )
+                }
+                (
+                    "GET",
+                    "/v1/kernel/compute/outcomes?outcome_kind=training_run&environment_ref=env.openagents.cuda.train",
+                ) => {
+                    let phase = *phase_for_server.lock().expect("closeout phase");
+                    let outcomes = if phase == CloseoutPhase::Paid {
+                        vec![accepted_outcome]
+                    } else {
+                        Vec::new()
+                    };
+                    (
+                        200,
+                        "application/json",
+                        serde_json::to_string(
+                            &compute_contracts::list_compute_accepted_outcomes_response_to_proto(
+                                outcomes.as_slice(),
+                            )
+                            .expect("accepted outcome proto"),
+                        )
+                        .expect("accepted outcome json"),
+                    )
+                }
+                ("GET", "/v1/treasury/status") => {
+                    let phase = *phase_for_server.lock().expect("closeout phase");
+                    let recent_training_payouts = if phase == CloseoutPhase::Paid {
+                        vec![json!({
+                            "payout_key": "accepted_work:assign.node01.window0001",
+                            "status": "confirmed",
+                            "reconciliation_status": "clean",
+                            "payment_id": "payment.homework.alpha",
+                            "classification": {
+                                "accepted_outcome_id": "accepted.training_window.window.0001",
+                                "training_run_id": "run.alpha",
+                                "window_id": "window.0001",
+                                "assignment_id": "assign.node01.window0001",
+                                "contribution_id": "contrib.node01.window0001"
+                            }
+                        })]
+                    } else {
+                        Vec::new()
+                    };
+                    (
+                        200,
+                        "application/json",
+                        json!({
+                            "recent_training_payouts": recent_training_payouts
+                        })
+                        .to_string(),
+                    )
+                }
+                _ => (
+                    404,
+                    "application/json",
+                    json!({"error":"not_found","reason":path}).to_string(),
+                ),
+            }
+        })
+        .await?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        config.training.relay_urls = vec![relay.url.clone()];
+        config.training.nexus_authority_base_url = nexus_base_url;
+        config.relay_auth_enabled = false;
+        save_config(config_path.as_path(), &config)?;
+        let identity = ensure_identity(config.identity_path.as_path())?;
+
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        let mut manifest = write_training_manifest_and_retained_contribution_artifacts(
+            local_run_root.as_path(),
+            "gs://bucket",
+        )?;
+        manifest.trn.relay_urls = vec![relay.url.clone()];
+        manifest.manifest_digest = manifest.canonical_digest()?;
+        let manifest_path = local_run_root.join("manifests").join("run_manifest.json");
+        std::fs::write(manifest_path.as_path(), manifest.canonical_json_bytes()?)?;
+        write_training_terminal_status_packets(
+            local_run_root.as_path(),
+            "succeeded",
+            0,
+            None,
+            Some("completed"),
+            "completed window",
+        )?;
+
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        let mut worker_runtime = training_active_runtime_fixture();
+        worker_runtime.manifest_path = manifest_path.display().to_string();
+        worker_runtime.run_root = local_run_root.display().to_string();
+        worker_runtime.process_state = PylonTrainingSupervisorProcessState::Stopped;
+        worker_runtime.desired_state = PylonTrainingSupervisorDesiredState::Running;
+        worker_runtime.last_exit_code = Some(0);
+        worker_runtime.failure_receipt_path = None;
+        worker_runtime.last_failure_reason = None;
+        state.active_runtime = Some(worker_runtime);
+        state.lease_cache.insert(
+            "lease.node01.window0001".to_string(),
+            PylonTrainingLeaseCacheEntry {
+                lease_id: "lease.node01.window0001".to_string(),
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                membership_revision: "members.rev1".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                state: "active".to_string(),
+                manifest_digest: Some(manifest.manifest_digest.clone()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                expires_at_ms: Some(1_762_491_360_000),
+                network_id: Some("trainnet.alpha".to_string()),
+                challenge_id: None,
+                peer_node_pubkey: None,
+                peer_checkpoint_handoff_receipt_path: None,
+                validator_target_contribution_receipt_path: None,
+                validator_target_contribution_artifact_manifest_path: None,
+                validator_target_work_class: None,
+                grouped_stage_input_transport_path: None,
+                runtime_manifest_path: Some(manifest_path.display().to_string()),
+                runtime_manifest_digest: Some(manifest.manifest_digest.clone()),
+                runtime_lane_id: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
+                runtime_operation: Some("start".to_string()),
+                runtime_work_class: Some("small_model_local_training".to_string()),
+                updated_at_ms: now_epoch_ms(),
+            },
+        );
+        save_training_runtime_state(&config, &state)?;
+
+        let fake_adc_path = temp_dir.path().join("fake-adc.json");
+        std::fs::write(fake_adc_path.as_path(), "{}")?;
+        let _env = TrainingEnvGuard::set(&[
+            (ENV_TRAINING_GCS_ENDPOINT, gcs_base_url),
+            (ENV_TRAINING_GCS_BEARER_TOKEN, "token.alpha".to_string()),
+            (
+                ENV_GOOGLE_APPLICATION_CREDENTIALS,
+                fake_adc_path.display().to_string(),
+            ),
+        ]);
+
+        ensure(
+            sync_training_terminal_runtime_once(config_path.as_path(), &config, &identity).await?,
+            "worker terminal sync should auto-seal the retained homework contribution",
+        )?;
+
+        let validator_lease = openagents_kernel_core::compute::ComputeValidatorChallengeLease {
+            challenge_id: "challenge.alpha".to_string(),
+            attempt: 1,
+            validator_id: identity.public_key_hex.clone(),
+            leased_at_ms: 1_762_491_330_250,
+            expires_at_ms: 1_762_491_390_250,
+        };
+        let claim_record = super::PylonTrainingValidatorChallengeCoordinatorResponse {
+            ack: super::PylonTrainingCoordinatorAck {
+                idempotency_key: "validator-claim-alpha".to_string(),
+                recorded_at_ms: 1_762_491_330_250,
+                authority_state: "leased".to_string(),
+            },
+            network_id: "trainnet.alpha".to_string(),
+            training_run_id: "run.alpha".to_string(),
+            window_id: "window.0001".to_string(),
+            challenge_id: "challenge.alpha".to_string(),
+            challenge_kind: "contribution_sample".to_string(),
+            target_assignment_ids: vec!["assign.node01.window0001".to_string()],
+            expected_manifest_digests: vec!["sha256:manifest-alpha".to_string()],
+            challenge: openagents_kernel_core::compute::ComputeValidatorChallengeSnapshot {
+                request: openagents_kernel_core::compute::ComputeValidatorChallengeRequest {
+                    context: openagents_kernel_core::compute::ComputeValidatorChallengeContext {
+                        challenge_id: "challenge.alpha".to_string(),
+                        proof_bundle_digest: "sha256:proof-bundle-alpha".to_string(),
+                        request_digest: "sha256:challenge-request-alpha".to_string(),
+                        delivery_proof_id: None,
+                        product_id: "psionic.training.gradient.elastic".to_string(),
+                        runtime_backend: "metal".to_string(),
+                        model_id: None,
+                        validator_pool_ref: Some("pool.alpha".to_string()),
+                        created_at_ms: 1_762_491_330_250,
+                        max_attempts: 1,
+                        lease_timeout_ms: 60_000,
+                    },
+                    protocol: openagents_kernel_core::compute::ComputeValidatorChallengeProtocolKind::GpuFreivaldsMerkleV1,
+                },
+                status: openagents_kernel_core::compute::ComputeValidatorChallengeStatus::Leased,
+                attempts_used: 1,
+                active_lease: Some(validator_lease.clone()),
+                final_result: None,
+            },
+            lease: Some(validator_lease.clone()),
+            result: None,
+            window: None,
+            contribution_outcomes: Vec::new(),
+            target_bindings: vec![super::PylonTrainingValidatorTargetAssignmentBinding {
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                contributor_pylon_id: "node.alpha".to_string(),
+                contribution_id: "contrib.node01.window0001".to_string(),
+                work_class: "small_model_local_training".to_string(),
+                challenge_kind: "contribution_sample".to_string(),
+                claim_id: "challenge.alpha".to_string(),
+                submission_receipt_digest:
+                    "sha256:receipt:contrib.node01.window0001".to_string(),
+                manifest_digest: "sha256:manifest-alpha".to_string(),
+                object_digest: "sha256:contribution-alpha".to_string(),
+                lane_type: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
+                lease_expires_at_ms: Some(validator_lease.expires_at_ms as i64),
+                artifacts: Vec::new(),
+            }],
+        };
+        super::persist_training_validator_claim_record(local_run_root.as_path(), &claim_record)?;
+        let validator_root = local_run_root
+            .join("windows")
+            .join("window.0001")
+            .join("validators")
+            .join("challenge.alpha");
+        std::fs::create_dir_all(validator_root.as_path())?;
+        std::fs::write(
+            validator_root.join("verdict.json"),
+            json!({
+                "schema_version":"openagents.pylon_training.validator_verdict.v1",
+                "challenge_id":"challenge.alpha",
+                "validator_status":"verified",
+                "validator_verdict":"verified",
+                "training_disposition":"accepted",
+                "detail":"validator replay complete"
+            })
+            .to_string(),
+        )?;
+
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        state.active_runtime = Some(PylonTrainingActiveRuntimeState {
+            training_run_id: "run.alpha".to_string(),
+            window_id: "window.0001".to_string(),
+            assignment_id: "assign.validator.window0001".to_string(),
+            lease_id: "lease.validator.window0001".to_string(),
+            membership_revision: "members.rev1".to_string(),
+            role: PylonTrainingRoleClaim::Validator,
+            manifest_path: manifest_path.display().to_string(),
+            run_root: local_run_root.display().to_string(),
+            desired_state: PylonTrainingSupervisorDesiredState::Running,
+            process_state: PylonTrainingSupervisorProcessState::Stopped,
+            pid: None,
+            stdout_log_path: local_run_root.join("stdout.log").display().to_string(),
+            stderr_log_path: local_run_root.join("stderr.log").display().to_string(),
+            failure_receipt_path: None,
+            last_exit_code: Some(0),
+            last_heartbeat_at_ms: None,
+            last_failure_reason: None,
+            launch_count: 1,
+            restart_count: 0,
+            updated_at_ms: now_epoch_ms(),
+        });
+        state.lease_cache.insert(
+            "lease.validator.window0001".to_string(),
+            PylonTrainingLeaseCacheEntry {
+                lease_id: "lease.validator.window0001".to_string(),
+                assignment_id: "assign.validator.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                membership_revision: "members.rev1".to_string(),
+                role: PylonTrainingRoleClaim::Validator,
+                state: "active".to_string(),
+                manifest_digest: Some(manifest.manifest_digest.clone()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                expires_at_ms: Some(validator_lease.expires_at_ms as i64),
+                network_id: Some("trainnet.alpha".to_string()),
+                challenge_id: Some("challenge.alpha".to_string()),
+                peer_node_pubkey: None,
+                peer_checkpoint_handoff_receipt_path: None,
+                validator_target_contribution_receipt_path: Some(
+                    local_run_root
+                        .join("windows")
+                        .join("window.0001")
+                        .join("contributions")
+                        .join("contrib.node01.window0001")
+                        .join("contribution_receipt.json")
+                        .display()
+                        .to_string(),
+                ),
+                validator_target_contribution_artifact_manifest_path: Some(
+                    local_run_root
+                        .join("windows")
+                        .join("window.0001")
+                        .join("contributions")
+                        .join("contrib.node01.window0001")
+                        .join("artifact_manifest.json")
+                        .display()
+                        .to_string(),
+                ),
+                validator_target_work_class: Some(
+                    ComputeTrainingWorkClass::SmallModelLocalTraining,
+                ),
+                grouped_stage_input_transport_path: None,
+                runtime_manifest_path: Some(manifest_path.display().to_string()),
+                runtime_manifest_digest: Some(manifest.manifest_digest.clone()),
+                runtime_lane_id: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
+                runtime_operation: Some("validate_contribution".to_string()),
+                runtime_work_class: Some("validation_replay".to_string()),
+                updated_at_ms: now_epoch_ms(),
+            },
+        );
+        save_training_runtime_state(&config, &state)?;
+
+        ensure(
+            sync_training_terminal_runtime_once(config_path.as_path(), &config, &identity).await?,
+            "validator terminal sync should finalize, reconcile, and observe payout automatically",
+        )?;
+
+        let synced_state = load_or_create_training_runtime_state(&config)?;
+        ensure(
+            synced_state
+                .authority_receipt_records
+                .get("window_seal::window.0001")
+                .is_some_and(|record| !record.pending_retry)
+                && synced_state
+                    .authority_receipt_records
+                    .get("validator_finalize::challenge.alpha")
+                    .is_some_and(|record| !record.pending_retry)
+                && synced_state
+                    .authority_receipt_records
+                    .get("window_reconcile::window.0001")
+                    .is_some_and(|record| !record.pending_retry),
+            "autonomous closeout should persist successful seal, validator finalize, and reconcile receipts",
+        )?;
+        ensure(
+            synced_state
+                .closeout_progress
+                .get("assign.node01.window0001")
+                .is_some_and(|entry| {
+                    entry.stage == super::PylonTrainingCloseoutStage::Paid
+                        && entry.acceptance_state.as_deref() == Some("accepted")
+                        && entry.payout_state.as_deref() == Some("confirmed")
+                        && entry.payout_receipt_id.as_deref() == Some("payment.homework.alpha")
+                }),
+            "the retained worker assignment should reach a paid terminal state with the observed payout id",
+        )?;
+
+        let counts = request_counts
+            .lock()
+            .expect("training autonomous request counts")
+            .clone();
+        ensure(
+            counts.get("/api/training/windows/progress") == Some(&1)
+                && counts.get("/api/training/checkpoints/publish") == Some(&1)
+                && counts.get("/api/training/windows/window.0001/seal") == Some(&1)
+                && counts.get("/api/training/validator-challenges/challenge.alpha/finalize")
+                    == Some(&1)
+                && counts.get("/api/training/windows/window.0001/reconcile") == Some(&1),
+            "the autonomous truth test should reach seal, validator finalize, and reconcile exactly once without manual server-side closeout calls",
+        )?;
+
+        let bodies = request_bodies
+            .lock()
+            .expect("training autonomous request bodies")
+            .clone();
+        ensure(
+            bodies
+                .get("/api/training/validator-challenges/challenge.alpha/finalize")
+                .and_then(|entries| entries.first())
+                .is_some_and(|payload| {
+                    payload.get("training_disposition") == Some(&json!("accepted"))
+                        && payload
+                            .get("result")
+                            .and_then(|result| result.get("challenge_id"))
+                            == Some(&json!("challenge.alpha"))
+                })
+                && bodies
+                    .get("/api/training/windows/window.0001/reconcile")
+                    .and_then(|entries| entries.first())
+                    .is_some_and(|payload| {
+                        payload.get("runtime_smoke_passed") == Some(&json!(true))
+                            && payload.get("held_out_average_score_bps") == Some(&json!(10_000))
+                            && payload.get("benchmark_pass_rate_bps") == Some(&json!(10_000))
+                    }),
+            "the validator finalize and reconcile requests should be driven directly from retained runtime state",
         )
     }
 
@@ -23477,6 +27865,60 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                 && gc_report.after_bytes <= super::BYTES_PER_GIB
                 && !gc_report.deleted_paths.is_empty(),
             "download-cache garbage collection should prune stale files back under the retained quota",
+        )
+    }
+
+    #[test]
+    fn training_artifact_inspection_uses_run_manifest_when_active_runtime_points_at_invocation_manifest()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let _env_lock = training_env_lock();
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        save_config(config_path.as_path(), &config)?;
+
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        let _manifest =
+            write_training_manifest_and_artifacts(local_run_root.as_path(), "gs://bucket")?;
+        let invocation_manifest_path = local_run_root
+            .join("manifests")
+            .join("invocation_manifest.json");
+        std::fs::write(
+            invocation_manifest_path.as_path(),
+            "{\"schema_version\":\"psionic.train.invocation_manifest.v1\"}\n",
+        )?;
+
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        state.active_runtime = Some(PylonTrainingActiveRuntimeState {
+            manifest_path: invocation_manifest_path.display().to_string(),
+            run_root: local_run_root.display().to_string(),
+            ..training_active_runtime_fixture()
+        });
+        save_training_runtime_state(&config, &state)?;
+
+        let fake_adc_path = temp_dir.path().join("fake-adc.json");
+        std::fs::write(fake_adc_path.as_path(), "{}")?;
+        let _env = TrainingEnvGuard::set(&[
+            (
+                ENV_GOOGLE_APPLICATION_CREDENTIALS,
+                fake_adc_path.display().to_string(),
+            ),
+            (ENV_TRAINING_GCS_BEARER_TOKEN, "token.alpha".to_string()),
+        ]);
+
+        let report = load_training_artifact_inspection_report(config_path.as_path())?;
+        ensure(
+            report.manifests.len() == 1
+                && report.manifests[0]
+                    .manifest_path
+                    .ends_with("/manifests/run_manifest.json")
+                && report.active_runtime.as_ref().is_some_and(|runtime| {
+                    runtime
+                        .manifest_path
+                        .ends_with("/manifests/invocation_manifest.json")
+                }),
+            "artifact inspection should resolve the canonical run manifest even when the retained active runtime points at the invocation manifest",
         )
     }
 

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -10694,7 +10694,8 @@ async fn publish_training_trn_state(
                 .context("failed to resolve current directory for --manifest")?
                 .join(manifest_path)
         };
-        contexts.retain(|context| context.manifest_path == selected_manifest_path);
+        let selected_manifest_paths = training_manifest_lookup_paths(selected_manifest_path.as_path());
+        contexts.retain(|context| selected_manifest_paths.contains(&context.manifest_path));
         if contexts.is_empty() {
             bail!(
                 "training publish could not find manifest {}",
@@ -11318,9 +11319,27 @@ fn training_manifest_context_for_path(
     state: &PylonTrainingRuntimeState,
     manifest_path: &Path,
 ) -> Result<Option<TrainingManifestInspectionContext>> {
+    let candidate_paths = training_manifest_lookup_paths(manifest_path);
     Ok(load_training_manifest_inspection_contexts(config, state)?
         .into_iter()
-        .find(|context| context.manifest_path == manifest_path))
+        .find(|context| candidate_paths.contains(&context.manifest_path)))
+}
+
+fn training_manifest_lookup_paths(manifest_path: &Path) -> Vec<PathBuf> {
+    let mut candidate_paths = vec![manifest_path.to_path_buf()];
+    if manifest_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name != "run_manifest.json")
+    {
+        if let Some(parent) = manifest_path.parent() {
+            let canonical_run_manifest_path = parent.join("run_manifest.json");
+            if !candidate_paths.contains(&canonical_run_manifest_path) {
+                candidate_paths.push(canonical_run_manifest_path);
+            }
+        }
+    }
+    candidate_paths
 }
 
 fn training_context_has_pending_publication(
@@ -26606,6 +26625,13 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         manifest.manifest_digest = manifest.canonical_digest()?;
         let manifest_path = local_run_root.join("manifests").join("run_manifest.json");
         std::fs::write(manifest_path.as_path(), manifest.canonical_json_bytes()?)?;
+        let invocation_manifest_path = local_run_root
+            .join("manifests")
+            .join("invocation_manifest.json");
+        std::fs::write(
+            invocation_manifest_path.as_path(),
+            "{\"schema_version\":\"psionic.train.invocation_manifest.v1\"}\n",
+        )?;
         write_training_terminal_status_packets(
             local_run_root.as_path(),
             "succeeded",
@@ -26617,7 +26643,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
 
         let mut state = load_or_create_training_runtime_state(&config)?;
         let mut active_runtime = training_active_runtime_fixture();
-        active_runtime.manifest_path = manifest_path.display().to_string();
+        active_runtime.manifest_path = invocation_manifest_path.display().to_string();
         active_runtime.run_root = local_run_root.display().to_string();
         active_runtime.process_state = PylonTrainingSupervisorProcessState::Stopped;
         active_runtime.desired_state = PylonTrainingSupervisorDesiredState::Running;
@@ -26646,7 +26672,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                 validator_target_contribution_artifact_manifest_path: None,
                 validator_target_work_class: None,
                 grouped_stage_input_transport_path: None,
-                runtime_manifest_path: Some(manifest_path.display().to_string()),
+                runtime_manifest_path: Some(invocation_manifest_path.display().to_string()),
                 runtime_manifest_digest: Some(manifest.manifest_digest.clone()),
                 runtime_lane_id: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
                 runtime_operation: Some("start".to_string()),
@@ -27206,6 +27232,13 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         manifest.manifest_digest = manifest.canonical_digest()?;
         let manifest_path = local_run_root.join("manifests").join("run_manifest.json");
         std::fs::write(manifest_path.as_path(), manifest.canonical_json_bytes()?)?;
+        let invocation_manifest_path = local_run_root
+            .join("manifests")
+            .join("invocation_manifest.json");
+        std::fs::write(
+            invocation_manifest_path.as_path(),
+            "{\"schema_version\":\"psionic.train.invocation_manifest.v1\"}\n",
+        )?;
         write_training_terminal_status_packets(
             local_run_root.as_path(),
             "succeeded",
@@ -27217,7 +27250,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
 
         let mut state = load_or_create_training_runtime_state(&config)?;
         let mut worker_runtime = training_active_runtime_fixture();
-        worker_runtime.manifest_path = manifest_path.display().to_string();
+        worker_runtime.manifest_path = invocation_manifest_path.display().to_string();
         worker_runtime.run_root = local_run_root.display().to_string();
         worker_runtime.process_state = PylonTrainingSupervisorProcessState::Stopped;
         worker_runtime.desired_state = PylonTrainingSupervisorDesiredState::Running;
@@ -27246,7 +27279,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                 validator_target_contribution_artifact_manifest_path: None,
                 validator_target_work_class: None,
                 grouped_stage_input_transport_path: None,
-                runtime_manifest_path: Some(manifest_path.display().to_string()),
+                runtime_manifest_path: Some(invocation_manifest_path.display().to_string()),
                 runtime_manifest_digest: Some(manifest.manifest_digest.clone()),
                 runtime_lane_id: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
                 runtime_operation: Some("start".to_string()),
@@ -27364,7 +27397,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             lease_id: "lease.validator.window0001".to_string(),
             membership_revision: "members.rev1".to_string(),
             role: PylonTrainingRoleClaim::Validator,
-            manifest_path: manifest_path.display().to_string(),
+            manifest_path: invocation_manifest_path.display().to_string(),
             run_root: local_run_root.display().to_string(),
             desired_state: PylonTrainingSupervisorDesiredState::Running,
             process_state: PylonTrainingSupervisorProcessState::Stopped,
@@ -27420,7 +27453,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                     ComputeTrainingWorkClass::SmallModelLocalTraining,
                 ),
                 grouped_stage_input_transport_path: None,
-                runtime_manifest_path: Some(manifest_path.display().to_string()),
+                runtime_manifest_path: Some(invocation_manifest_path.display().to_string()),
                 runtime_manifest_digest: Some(manifest.manifest_digest.clone()),
                 runtime_lane_id: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
                 runtime_operation: Some("validate_contribution".to_string()),

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -15758,6 +15758,7 @@ fn default_config(base_dir: &Path) -> PylonConfig {
     let mut inventory_controls = ProviderInventoryControls::default();
     inventory_controls.apple_fm_inference_enabled = false;
     inventory_controls.apple_fm_adapter_hosting_enabled = false;
+    inventory_controls.adapter_training_contributor_enabled = true;
     PylonConfig {
         schema_version: 1,
         node_label: "pylon".to_string(),
@@ -21059,6 +21060,9 @@ fn apply_config_set(config: &mut PylonConfig, key: &str, value: &str) -> Result<
         "backend.sandbox_posix_exec_enabled" => {
             next.inventory_controls.sandbox_posix_exec_enabled = parse_bool(value)?;
         }
+        "backend.adapter_training_contributor_enabled" => {
+            next.inventory_controls.adapter_training_contributor_enabled = parse_bool(value)?;
+        }
         "training.allowed_networks" => {
             next.training.allowed_networks = parse_csv_list(value);
         }
@@ -22921,6 +22925,11 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         let mut config = default_config(std::path::Path::new("/tmp/pylon-test"));
         apply_config_set(
             &mut config,
+            "backend.adapter_training_contributor_enabled",
+            "false",
+        )?;
+        apply_config_set(
+            &mut config,
             "training.allowed_networks",
             "trainnet.alpha,trainnet.beta",
         )?;
@@ -22954,6 +22963,12 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         apply_config_set(&mut config, "training.disk_quota_gb", "640")?;
         apply_config_set(&mut config, "training.retention_limit_gb", "320")?;
 
+        ensure(
+            !config
+                .inventory_controls
+                .adapter_training_contributor_enabled,
+            "config set should update backend.adapter_training_contributor_enabled",
+        )?;
         ensure(
             config.training.allowed_networks
                 == vec!["trainnet.alpha".to_string(), "trainnet.beta".to_string()],
@@ -23009,6 +23024,18 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         ensure(
             config.training.retention_limit_gb == 256,
             "invalid training retention edits should leave the prior config intact",
+        )
+    }
+
+    #[test]
+    fn default_config_enables_training_contributor_inventory()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let config = default_config(std::path::Path::new("/tmp/pylon-test"));
+        ensure(
+            config
+                .inventory_controls
+                .adapter_training_contributor_enabled,
+            "default pylon config should advertise the training contributor inventory by default",
         )
     }
 

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -8151,10 +8151,47 @@ fn supported_training_role_claims(
         .collect()
 }
 
+fn training_heartbeat_error_requires_readmission(error: &str) -> bool {
+    error.contains("training_node_not_found")
+}
+
 fn training_lease_claim_error_is_nonfatal(error: &str) -> bool {
     error.contains("training_scheduler_assignment_unavailable")
         || error.contains("training_node_not_eligible")
         || error.contains("training_scheduler_role_overlap_forbidden")
+}
+
+fn build_training_node_admission_request(
+    config: &PylonConfig,
+    identity: &NostrIdentity,
+    state: &PylonTrainingRuntimeState,
+    host: &ProviderHostTelemetrySnapshot,
+    contributor_availability: &ProviderAdapterTrainingContributorAvailability,
+    capability_tier: &ProviderTrainingCapabilityTierProfile,
+    capability_envelope_v2: &ProviderTrainingCapabilityEnvelopeV2,
+    supported_roles: &[PylonTrainingRoleClaim],
+) -> PylonTrainingNodeAdmissionRequest {
+    PylonTrainingNodeAdmissionRequest {
+        idempotency_key: format!(
+            "training-admission:{}:{}",
+            identity.public_key_hex,
+            now_epoch_ms()
+        ),
+        requested_at_ms: now_epoch_ms(),
+        node_pubkey_hex: identity.public_key_hex.clone(),
+        release_id: local_training_release_id(),
+        node_label: Some(config.node_label.clone()),
+        role_claims: supported_roles.to_vec(),
+        allowed_networks: config.training.allowed_networks.clone(),
+        build_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        build_digest: Some(local_training_build_digest()),
+        contributor_availability: contributor_availability.clone(),
+        capability_tier: capability_tier.clone(),
+        capability_envelope_v2: capability_envelope_v2.clone(),
+        host_telemetry: Some(host.clone()),
+        active_reputation_labels: training_runtime_blocked_label_keys(state),
+        settlement_destination: training_settlement_destination(config),
+    }
 }
 
 fn training_node_presence_heartbeat_request(
@@ -8239,6 +8276,78 @@ fn training_lease_presence_heartbeat_request(
         Some(recorded_at_ms),
         None,
     )
+}
+
+async fn admit_training_node_with_context(
+    client: &PylonTrainingCoordinatorClient,
+    config: &PylonConfig,
+    identity: &NostrIdentity,
+    state: &PylonTrainingRuntimeState,
+    host: &ProviderHostTelemetrySnapshot,
+    contributor_availability: &ProviderAdapterTrainingContributorAvailability,
+    capability_tier: &ProviderTrainingCapabilityTierProfile,
+    capability_envelope_v2: &ProviderTrainingCapabilityEnvelopeV2,
+    supported_roles: &[PylonTrainingRoleClaim],
+) -> Result<PylonTrainingNodeAdmissionResponse> {
+    if supported_roles.is_empty() {
+        bail!(
+            "training node re-admission required but no supported training roles are currently available"
+        );
+    }
+    let admission_request = build_training_node_admission_request(
+        config,
+        identity,
+        state,
+        host,
+        contributor_availability,
+        capability_tier,
+        capability_envelope_v2,
+        supported_roles,
+    );
+    let admission = client.admit_node(&admission_request).await?;
+    if !admission.admitted {
+        bail!(
+            "training node admission rejected: {}",
+            admission
+                .reason
+                .clone()
+                .unwrap_or_else(|| "training_node_not_admitted".to_string())
+        );
+    }
+    Ok(admission)
+}
+
+async fn report_training_heartbeat_with_readmission(
+    client: &PylonTrainingCoordinatorClient,
+    config: &PylonConfig,
+    identity: &NostrIdentity,
+    state: &PylonTrainingRuntimeState,
+    host: &ProviderHostTelemetrySnapshot,
+    contributor_availability: &ProviderAdapterTrainingContributorAvailability,
+    capability_tier: &ProviderTrainingCapabilityTierProfile,
+    capability_envelope_v2: &ProviderTrainingCapabilityEnvelopeV2,
+    supported_roles: &[PylonTrainingRoleClaim],
+    request: &PylonTrainingHeartbeatRequest,
+) -> Result<PylonTrainingHeartbeatResponse> {
+    match client.report_heartbeat(request).await {
+        Ok(response) => Ok(response),
+        Err(error) if training_heartbeat_error_requires_readmission(error.to_string().as_str()) => {
+            admit_training_node_with_context(
+                client,
+                config,
+                identity,
+                state,
+                host,
+                contributor_availability,
+                capability_tier,
+                capability_envelope_v2,
+                supported_roles,
+            )
+            .await?;
+            client.report_heartbeat(request).await
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn cache_training_run_lease(
@@ -8326,26 +8435,6 @@ async fn run_training_assignment_intake_once_with_context(
     runtime_surface: Option<&PsionicTrainRuntimeSurface>,
 ) -> Result<()> {
     let client = PylonTrainingCoordinatorClient::new(config)?;
-    if state
-        .active_runtime
-        .as_ref()
-        .is_some_and(|runtime| training_supervision_is_active(runtime.process_state))
-    {
-        if let Some(runtime) = state.active_runtime.as_ref() {
-            client
-                .report_heartbeat(&training_runtime_presence_heartbeat_request(
-                    identity,
-                    now_epoch_ms(),
-                    runtime,
-                ))
-                .await?;
-        }
-        return Ok(());
-    }
-    if !training_runtime_blocked_label_keys(state).is_empty() {
-        return Ok(());
-    }
-
     let contributor_availability =
         derive_adapter_training_contributor_availability(host, runtime_surface);
     let capability_tier =
@@ -8357,18 +8446,50 @@ async fn run_training_assignment_intake_once_with_context(
     );
     let supported_roles =
         supported_training_role_claims(config, &contributor_availability, &capability_tier);
+    if state
+        .active_runtime
+        .as_ref()
+        .is_some_and(|runtime| training_supervision_is_active(runtime.process_state))
+    {
+        if let Some(runtime) = state.active_runtime.as_ref() {
+            report_training_heartbeat_with_readmission(
+                &client,
+                config,
+                identity,
+                state,
+                host,
+                &contributor_availability,
+                &capability_tier,
+                &capability_envelope_v2,
+                &supported_roles,
+                &training_runtime_presence_heartbeat_request(identity, now_epoch_ms(), runtime),
+            )
+            .await?;
+        }
+        return Ok(());
+    }
+    if !training_runtime_blocked_label_keys(state).is_empty() {
+        return Ok(());
+    }
+
     if supported_roles.is_empty() {
         return Ok(());
     }
 
     if let Some(existing_lease) = newest_pending_training_lease_cache_entry(state) {
-        client
-            .report_heartbeat(&training_lease_presence_heartbeat_request(
-                identity,
-                now_epoch_ms(),
-                &existing_lease,
-            ))
-            .await?;
+        report_training_heartbeat_with_readmission(
+            &client,
+            config,
+            identity,
+            state,
+            host,
+            &contributor_availability,
+            &capability_tier,
+            &capability_envelope_v2,
+            &supported_roles,
+            &training_lease_presence_heartbeat_request(identity, now_epoch_ms(), &existing_lease),
+        )
+        .await?;
         let runtime_surface = runtime_surface.ok_or_else(|| {
             anyhow!("psionic-train runtime surface is required to materialize a leased assignment")
         })?;
@@ -8412,44 +8533,33 @@ async fn run_training_assignment_intake_once_with_context(
         return Ok(());
     }
 
-    let admission_request = PylonTrainingNodeAdmissionRequest {
-        idempotency_key: format!(
-            "training-admission:{}:{}",
-            identity.public_key_hex,
-            now_epoch_ms()
-        ),
-        requested_at_ms: now_epoch_ms(),
-        node_pubkey_hex: identity.public_key_hex.clone(),
-        release_id: local_training_release_id(),
-        node_label: Some(config.node_label.clone()),
-        role_claims: supported_roles.clone(),
-        allowed_networks: config.training.allowed_networks.clone(),
-        build_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        build_digest: Some(local_training_build_digest()),
-        contributor_availability,
-        capability_tier,
-        capability_envelope_v2,
-        host_telemetry: Some(host.clone()),
-        active_reputation_labels: training_runtime_blocked_label_keys(state),
-        settlement_destination: training_settlement_destination(config),
-    };
-    let admission = client.admit_node(&admission_request).await?;
-    if !admission.admitted {
-        bail!(
-            "training node admission rejected: {}",
-            admission
-                .reason
-                .unwrap_or_else(|| "training_node_not_admitted".to_string())
-        );
-    }
-    client
-        .report_heartbeat(&training_idle_presence_heartbeat_request(
-            identity,
-            now_epoch_ms(),
-        ))
-        .await?;
+    admit_training_node_with_context(
+        &client,
+        config,
+        identity,
+        state,
+        host,
+        &contributor_availability,
+        &capability_tier,
+        &capability_envelope_v2,
+        &supported_roles,
+    )
+    .await?;
+    report_training_heartbeat_with_readmission(
+        &client,
+        config,
+        identity,
+        state,
+        host,
+        &contributor_availability,
+        &capability_tier,
+        &capability_envelope_v2,
+        &supported_roles,
+        &training_idle_presence_heartbeat_request(identity, now_epoch_ms()),
+    )
+    .await?;
 
-    for role in supported_roles {
+    for role in supported_roles.clone() {
         let membership_revision = training_cached_membership_revision_for_role(state, role);
         for requested_network_id in training_requested_networks(config) {
             let requested_at_ms = now_epoch_ms();
@@ -8472,16 +8582,26 @@ async fn run_training_assignment_intake_once_with_context(
             {
                 Ok(lease) => {
                     cache_training_run_lease(state, &lease, requested_at_ms);
-                    client
-                        .report_heartbeat(&training_lease_presence_heartbeat_request(
+                    report_training_heartbeat_with_readmission(
+                        &client,
+                        config,
+                        identity,
+                        state,
+                        host,
+                        &contributor_availability,
+                        &capability_tier,
+                        &capability_envelope_v2,
+                        &supported_roles,
+                        &training_lease_presence_heartbeat_request(
                             identity,
                             now_epoch_ms(),
                             state
                                 .lease_cache
                                 .get(lease.lease_id.as_str())
                                 .expect("cached lease after successful lease response"),
-                        ))
-                        .await?;
+                        ),
+                    )
+                    .await?;
                     let runtime_surface = runtime_surface.ok_or_else(|| {
                         anyhow!(
                             "psionic-train runtime surface is required to materialize a leased assignment"
@@ -15172,6 +15292,8 @@ fn training_supervisor_pid_is_running(pid: u32) -> bool {
         let pid_text = pid.to_string();
         StdCommand::new("kill")
             .args(["-0", pid_text.as_str()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status()
             .map(|status| status.success())
             .unwrap_or(false)
@@ -24724,6 +24846,16 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             let count = counts.entry(path.clone()).or_insert(0);
             *count += 1;
             let response = match path.as_str() {
+                "/api/training/heartbeats" => json!({
+                    "ack": {
+                        "idempotency_key": "idemp.training.assignment_retry.heartbeat",
+                        "recorded_at_ms": 1_762_491_210_675_i64,
+                        "authority_state": "heartbeat_recorded"
+                    },
+                    "next_heartbeat_due_at_ms": 1_762_491_215_675_i64,
+                    "lease_state": "leased",
+                    "node_status": "online"
+                }),
                 "/api/training/assignments/ack" => json!({
                     "ack": {
                         "idempotency_key": "idemp.training.assignment_retry.ack",
@@ -24800,7 +24932,8 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             .expect("training assignment ack retry request counts")
             .clone();
         ensure(
-            counts.get("/api/training/assignments/ack") == Some(&1)
+            counts.get("/api/training/heartbeats") == Some(&1)
+                && counts.get("/api/training/assignments/ack") == Some(&1)
                 && !counts.contains_key("/api/training/nodes/admission")
                 && !counts.contains_key("/api/training/leases/claim")
                 && !counts.contains_key(
@@ -24811,6 +24944,284 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                     .as_str(),
                 ),
             "cached leased assignments should retry only the missing assignment ack on restart",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn training_assignment_intake_readmits_node_when_cached_lease_heartbeat_is_evicted()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let training_run = training_run_fixture();
+        let training_run_for_server = training_run.clone();
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        let identity = ensure_identity(config.identity_path.as_path())?;
+        let run_root = training_run_root_for_id(&config, "run.alpha");
+        let run_manifest_payload =
+            training_manifest_fixture(run_root.as_path(), "gs://bucket")?.canonical_json_bytes()?;
+        let latest_pointer_payload = json!({
+            "schema_version":"openagents.pylon_training.latest_pointer.v1",
+            "checkpoint_ref":"checkpoint://run.alpha/0042",
+            "checkpoint_label":"checkpoint-0042",
+            "optimizer_step":42
+        })
+        .to_string()
+        .into_bytes();
+        let checkpoint_manifest_payload = json!({
+            "schema_version":"openagents.pylon_training.checkpoint_manifest.v1",
+            "checkpoint_ref":"checkpoint://run.alpha/0042",
+            "checkpoint_label":"checkpoint-0042",
+            "optimizer_step":42
+        })
+        .to_string()
+        .into_bytes();
+        std::fs::create_dir_all(run_root.join("manifests"))?;
+        std::fs::create_dir_all(run_root.join("checkpoints").join("step-42"))?;
+        std::fs::write(
+            run_root.join("manifests").join("run_manifest.json"),
+            run_manifest_payload.as_slice(),
+        )?;
+        std::fs::write(
+            run_root.join("checkpoints").join("latest_pointer.json"),
+            latest_pointer_payload.as_slice(),
+        )?;
+        std::fs::write(
+            run_root
+                .join("checkpoints")
+                .join("step-42")
+                .join("checkpoint_manifest.json"),
+            checkpoint_manifest_payload.as_slice(),
+        )?;
+        let base_scope = PylonTrainingArtifactScope {
+            network_id: "trainnet.alpha".to_string(),
+            run_id: "run.alpha".to_string(),
+            window_id: None,
+            assignment_id: None,
+            challenge_id: None,
+            optimizer_step: None,
+        };
+        let mut run_manifest_resolver = PylonTrainingArtifactResolverResponse::new(
+            PylonTrainingArtifactKind::RunManifest,
+            base_scope.clone(),
+        )
+        .expect("run manifest resolver");
+        run_manifest_resolver.digest = Some(training_artifact_digest_from_locator_payload(
+            run_manifest_resolver.relative_object_path.as_str(),
+            run_manifest_payload.as_slice(),
+        )?);
+        run_manifest_resolver.size_bytes =
+            Some(u64::try_from(run_manifest_payload.len()).unwrap_or(u64::MAX));
+        let mut latest_pointer_resolver = PylonTrainingArtifactResolverResponse::new(
+            PylonTrainingArtifactKind::LatestCheckpointPointer,
+            base_scope.clone(),
+        )
+        .expect("latest pointer resolver");
+        latest_pointer_resolver.digest = Some(training_artifact_digest_from_locator_payload(
+            latest_pointer_resolver.relative_object_path.as_str(),
+            latest_pointer_payload.as_slice(),
+        )?);
+        latest_pointer_resolver.size_bytes =
+            Some(u64::try_from(latest_pointer_payload.len()).unwrap_or(u64::MAX));
+        let mut checkpoint_manifest_resolver = PylonTrainingArtifactResolverResponse::new(
+            PylonTrainingArtifactKind::CheckpointManifest,
+            PylonTrainingArtifactScope {
+                optimizer_step: Some(42),
+                ..base_scope.clone()
+            },
+        )
+        .expect("checkpoint manifest resolver");
+        checkpoint_manifest_resolver.digest = Some(training_artifact_digest_from_locator_payload(
+            checkpoint_manifest_resolver.relative_object_path.as_str(),
+            checkpoint_manifest_payload.as_slice(),
+        )?);
+        checkpoint_manifest_resolver.size_bytes =
+            Some(u64::try_from(checkpoint_manifest_payload.len()).unwrap_or(u64::MAX));
+        let request_counts = Arc::new(Mutex::new(std::collections::BTreeMap::<String, u64>::new()));
+        let request_counts_for_server = Arc::clone(&request_counts);
+        let run_manifest_resolver_for_server = run_manifest_resolver.clone();
+        let latest_pointer_resolver_for_server = latest_pointer_resolver.clone();
+        let checkpoint_manifest_resolver_for_server = checkpoint_manifest_resolver.clone();
+        let base_url = start_mock_http_server(move |method, path, _body| {
+            if method == "GET" && path == "/v1/kernel/compute/training/runs/run.alpha" {
+                let response = compute_contracts::get_compute_training_run_response_to_proto(
+                    &training_run_for_server,
+                )
+                .expect("training run proto response");
+                return (
+                    200,
+                    "application/json",
+                    serde_json::to_string(&response).expect("training run json"),
+                );
+            }
+            if method == "GET"
+                && path
+                    == format!(
+                        "/v1/kernel/compute/training/artifacts/{}",
+                        run_manifest_resolver_for_server.artifact_id
+                    )
+            {
+                return (
+                    200,
+                    "application/json",
+                    serde_json::to_string(&run_manifest_resolver_for_server)
+                        .expect("run manifest resolver json"),
+                );
+            }
+            if method == "GET"
+                && path
+                    == format!(
+                        "/v1/kernel/compute/training/artifacts/{}",
+                        latest_pointer_resolver_for_server.artifact_id
+                    )
+            {
+                return (
+                    200,
+                    "application/json",
+                    serde_json::to_string(&latest_pointer_resolver_for_server)
+                        .expect("latest pointer resolver json"),
+                );
+            }
+            if method == "GET"
+                && path
+                    == format!(
+                        "/v1/kernel/compute/training/artifacts/{}",
+                        checkpoint_manifest_resolver_for_server.artifact_id
+                    )
+            {
+                return (
+                    200,
+                    "application/json",
+                    serde_json::to_string(&checkpoint_manifest_resolver_for_server)
+                        .expect("checkpoint manifest resolver json"),
+                );
+            }
+            if method != "POST" {
+                return (
+                    405,
+                    "application/json",
+                    json!({"error":"method_not_allowed","reason":method}).to_string(),
+                );
+            }
+            let mut counts = request_counts_for_server
+                .lock()
+                .expect("training node eviction retry request counts");
+            let count = counts.entry(path.clone()).or_insert(0);
+            *count += 1;
+            let response = match path.as_str() {
+                "/api/training/nodes/admission" => (
+                    200,
+                    json!({
+                        "ack": {
+                            "idempotency_key": "idemp.training.assignment_retry.admission",
+                            "recorded_at_ms": 1_762_491_210_650_i64,
+                            "authority_state": "admitted"
+                        },
+                        "admission_id": "admission.retry",
+                        "admitted": true,
+                        "reason": null
+                    }),
+                ),
+                "/api/training/heartbeats" if *count == 1 => (
+                    404,
+                    json!({"error":"kernel_error","reason":"training_node_not_found"}),
+                ),
+                "/api/training/heartbeats" => (
+                    200,
+                    json!({
+                        "ack": {
+                            "idempotency_key": "idemp.training.assignment_retry.heartbeat",
+                            "recorded_at_ms": 1_762_491_210_675_i64,
+                            "authority_state": "heartbeat_recorded"
+                        },
+                        "next_heartbeat_due_at_ms": 1_762_491_215_675_i64,
+                        "lease_state": "leased",
+                        "node_status": "online"
+                    }),
+                ),
+                "/api/training/assignments/ack" => (
+                    200,
+                    json!({
+                        "ack": {
+                            "idempotency_key": "idemp.training.assignment_retry.ack",
+                            "recorded_at_ms": 1_762_491_210_700_i64,
+                            "authority_state": "assignment_acked"
+                        },
+                        "accepted": true,
+                        "lease_state": "acked"
+                    }),
+                ),
+                _ => (200, json!({"error":"unexpected_path","reason":path})),
+            };
+            (response.0, "application/json", response.1.to_string())
+        })
+        .await?;
+        config.training.nexus_authority_base_url = base_url;
+        save_config(config_path.as_path(), &config)?;
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        state.lease_cache.insert(
+            "lease.node01.window0001".to_string(),
+            PylonTrainingLeaseCacheEntry {
+                lease_id: "lease.node01.window0001".to_string(),
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                membership_revision: "members.rev2".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                state: "leased".to_string(),
+                manifest_digest: Some("sha256:manifest-alpha".to_string()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                expires_at_ms: Some(1_762_491_260_600),
+                network_id: Some("trainnet.alpha".to_string()),
+                challenge_id: None,
+                peer_node_pubkey: None,
+                peer_checkpoint_handoff_receipt_path: None,
+                validator_target_contribution_receipt_path: None,
+                validator_target_contribution_artifact_manifest_path: None,
+                validator_target_work_class: None,
+                grouped_stage_input_transport_path: None,
+                runtime_manifest_path: None,
+                runtime_manifest_digest: None,
+                runtime_lane_id: None,
+                runtime_operation: None,
+                runtime_work_class: None,
+                updated_at_ms: 1_762_491_210_600,
+            },
+        );
+
+        let host = training_host_snapshot(Some("NVIDIA H100 SXM5 80GB"), Some(80), Some(512), true);
+        let runtime_surface = psionic_train_runtime_surface_fixture();
+        run_training_assignment_intake_once_with_context(
+            &config,
+            &identity,
+            &mut state,
+            &host,
+            Some(&runtime_surface),
+        )
+        .await?;
+
+        ensure(
+            state
+                .lease_cache
+                .get("lease.node01.window0001")
+                .is_some_and(|lease| {
+                    lease.state == "acked"
+                        && lease.runtime_manifest_path.is_some()
+                        && lease.runtime_lane_id.as_deref()
+                            == Some(PSION_ACTUAL_PRETRAINING_LANE_ID)
+                }),
+            "cached leased assignments should re-admit the node and continue acknowledgement when authority evicts the node record",
+        )?;
+
+        let counts = request_counts
+            .lock()
+            .expect("training node eviction retry request counts")
+            .clone();
+        ensure(
+            counts.get("/api/training/heartbeats") == Some(&2)
+                && counts.get("/api/training/nodes/admission") == Some(&1)
+                && counts.get("/api/training/assignments/ack") == Some(&1)
+                && !counts.contains_key("/api/training/leases/claim"),
+            "cached leased assignments should re-admit once after a training_node_not_found heartbeat and then finish the retained ack flow without claiming a new lease",
         )
     }
 

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -15166,6 +15166,106 @@ fn training_supervision_is_active(state: PylonTrainingSupervisorProcessState) ->
 }
 
 #[allow(dead_code)]
+fn training_supervisor_pid_is_running(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let pid_text = pid.to_string();
+        StdCommand::new("kill")
+            .args(["-0", pid_text.as_str()])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+    #[cfg(windows)]
+    {
+        let filter = format!("PID eq {pid}");
+        StdCommand::new("cmd")
+            .args(["/C", "tasklist", "/FI", filter.as_str(), "/NH"])
+            .output()
+            .map(|output| {
+                output.status.success()
+                    && String::from_utf8_lossy(output.stdout.as_slice())
+                        .contains(pid.to_string().as_str())
+            })
+            .unwrap_or(false)
+    }
+}
+
+#[allow(dead_code)]
+fn training_supervisor_is_orphaned(state: &PylonTrainingRuntimeState) -> bool {
+    state.active_runtime.as_ref().is_some_and(|active| {
+        training_supervision_is_active(active.process_state)
+            && active
+                .pid
+                .is_none_or(|pid| !training_supervisor_pid_is_running(pid))
+    })
+}
+
+#[allow(dead_code)]
+fn reconcile_orphaned_training_supervisor_state(
+    config: &PylonConfig,
+    state: &mut PylonTrainingRuntimeState,
+) -> Result<bool> {
+    let Some(active) = state.active_runtime.as_ref().cloned() else {
+        return Ok(false);
+    };
+    if !training_supervision_is_active(active.process_state) {
+        return Ok(false);
+    }
+    if active.pid.is_some_and(training_supervisor_pid_is_running) {
+        let previous_heartbeat = state
+            .active_runtime
+            .as_ref()
+            .and_then(|runtime| runtime.last_heartbeat_at_ms);
+        refresh_training_supervisor_heartbeat(state);
+        let changed = state
+            .active_runtime
+            .as_ref()
+            .and_then(|runtime| runtime.last_heartbeat_at_ms)
+            != previous_heartbeat;
+        if changed {
+            save_training_runtime_state(config, state)?;
+        }
+        return Ok(changed);
+    }
+
+    let run_root = Path::new(active.run_root.as_str());
+    let run_status = load_training_run_status_packet(run_root)?;
+    let failure_reason = build_training_failure_reason(&active, run_status.as_ref())?;
+    let run_completed_successfully =
+        training_run_completed_successfully(&active, run_status.as_ref());
+
+    let updated_at_ms = now_epoch_ms();
+    let recovered = state
+        .active_runtime
+        .as_mut()
+        .expect("active runtime should still exist while recovering");
+    recovered.pid = None;
+    recovered.updated_at_ms = updated_at_ms;
+    if let Some(failure_reason) = failure_reason {
+        recovered.process_state = PylonTrainingSupervisorProcessState::Failed;
+        recovered.last_failure_reason = Some(failure_reason);
+    } else if run_completed_successfully
+        || matches!(
+            recovered.desired_state,
+            PylonTrainingSupervisorDesiredState::Draining
+                | PylonTrainingSupervisorDesiredState::Stopped
+        )
+    {
+        recovered.process_state = PylonTrainingSupervisorProcessState::Stopped;
+        recovered.last_failure_reason = None;
+        if recovered.last_exit_code.is_none() && run_completed_successfully {
+            recovered.last_exit_code = Some(0);
+        }
+    } else {
+        return Ok(false);
+    }
+
+    save_training_runtime_state(config, state)?;
+    Ok(true)
+}
+
+#[allow(dead_code)]
 fn ensure_no_conflicting_training_assignment(
     state: &PylonTrainingRuntimeState,
     request: &PylonTrainingSupervisorStartRequest,
@@ -15301,6 +15401,17 @@ async fn drive_training_supervisor_once(
     command_override: Option<&PylonTrainingSupervisorCommand>,
 ) -> Result<bool> {
     let mut changed = false;
+    if process_slot.is_none() && reconcile_orphaned_training_supervisor_state(config, state)? {
+        changed = true;
+    }
+    if process_slot.is_none()
+        && desired_mode == ProviderDesiredMode::Online
+        && training_supervisor_is_orphaned(state)
+    {
+        let process = restart_training_supervisor(config, state, None, command_override).await?;
+        *process_slot = Some(process);
+        return Ok(true);
+    }
     if let Some(process) = process_slot.as_mut() {
         if desired_mode != ProviderDesiredMode::Online
             && state.active_runtime.as_ref().is_some_and(|active| {
@@ -21204,7 +21315,7 @@ mod tests {
         derive_adapter_training_contributor_availability, derive_training_capability_tier_profile,
         detect_availability, download_gemma_model_from_base_url,
         download_gemma_model_from_base_url_with_transport, drain_training_supervisor,
-        ensure_identity, ensure_no_conflicting_training_assignment,
+        drive_training_supervisor_once, ensure_identity, ensure_no_conflicting_training_assignment,
         garbage_collect_training_download_cache, gemma_diagnostic_latest_report_path,
         gemma_download_spec, gemma_local_installations, inspect_psionic_train_runtime_surface_at,
         inspect_psionic_train_runtime_surface_from_candidates, inventory_rows, load_backend_report,
@@ -23276,6 +23387,185 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             .await?
                 && process.is_none(),
             "auto launch should not immediately relaunch the same failed assignment without a new retained lease",
+        )
+    }
+
+    fn finished_supervisor_pid_fixture() -> Result<u32, Box<dyn std::error::Error>> {
+        #[cfg(unix)]
+        let mut child = StdCommand::new("sh").args(["-c", "exit 0"]).spawn()?;
+        #[cfg(windows)]
+        let mut child = StdCommand::new("cmd").args(["/C", "exit 0"]).spawn()?;
+        let pid = child.id();
+        let _ = child.wait()?;
+        Ok(pid)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn restart_recovery_marks_orphaned_completed_runtime_terminal()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp_dir, config, mut state, request) = training_supervisor_fixture()?;
+        std::fs::create_dir_all(request.run_root.join("status"))?;
+        write_training_terminal_status_packets(
+            request.run_root.as_path(),
+            "succeeded",
+            0,
+            None,
+            Some("completed"),
+            "completed window",
+        )?;
+        let finished_pid = finished_supervisor_pid_fixture()?;
+        state.active_runtime = Some(PylonTrainingActiveRuntimeState {
+            training_run_id: request.training_run_id.clone(),
+            window_id: request.window_id.clone(),
+            assignment_id: request.assignment_id.clone(),
+            lease_id: request.lease_id.clone(),
+            membership_revision: request.membership_revision.clone(),
+            role: request.role,
+            manifest_path: request.manifest_path.display().to_string(),
+            run_root: request.run_root.display().to_string(),
+            desired_state: PylonTrainingSupervisorDesiredState::Running,
+            process_state: PylonTrainingSupervisorProcessState::Running,
+            pid: Some(finished_pid),
+            stdout_log_path: request
+                .run_root
+                .join("supervisor/attempt-1/stdout.log")
+                .display()
+                .to_string(),
+            stderr_log_path: request
+                .run_root
+                .join("supervisor/attempt-1/stderr.log")
+                .display()
+                .to_string(),
+            failure_receipt_path: Some(
+                request
+                    .run_root
+                    .join("supervisor/attempt-1/failure_receipt.json")
+                    .display()
+                    .to_string(),
+            ),
+            last_exit_code: None,
+            last_heartbeat_at_ms: None,
+            last_failure_reason: None,
+            launch_count: 1,
+            restart_count: 0,
+            updated_at_ms: 1_762_491_200_000,
+        });
+
+        let mut process = None::<super::PylonTrainingSupervisorProcess>;
+        ensure(
+            drive_training_supervisor_once(
+                &config,
+                ProviderDesiredMode::Online,
+                &mut state,
+                &mut process,
+                None,
+            )
+            .await?
+                && process.is_none()
+                && state.active_runtime.as_ref().is_some_and(|active| {
+                    active.process_state == PylonTrainingSupervisorProcessState::Stopped
+                        && active.pid.is_none()
+                        && active.last_exit_code == Some(0)
+                        && active.last_failure_reason.is_none()
+                }),
+            "restart recovery should demote an orphaned completed runtime to a terminal stopped state instead of leaving a dead running pid behind",
+        )?;
+
+        let persisted = load_or_create_training_runtime_state(&config)?;
+        ensure(
+            persisted.active_runtime.as_ref().is_some_and(|active| {
+                active.process_state == PylonTrainingSupervisorProcessState::Stopped
+                    && active.pid.is_none()
+                    && active.last_exit_code == Some(0)
+            }),
+            "the recovered terminal supervisor state should persist to disk for later closeout sync",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn restart_recovery_relaunches_orphaned_inflight_runtime()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp_dir, config, mut state, request) = training_supervisor_fixture()?;
+        let finished_pid = finished_supervisor_pid_fixture()?;
+        state.active_runtime = Some(PylonTrainingActiveRuntimeState {
+            training_run_id: request.training_run_id.clone(),
+            window_id: request.window_id.clone(),
+            assignment_id: request.assignment_id.clone(),
+            lease_id: request.lease_id.clone(),
+            membership_revision: request.membership_revision.clone(),
+            role: request.role,
+            manifest_path: request.manifest_path.display().to_string(),
+            run_root: request.run_root.display().to_string(),
+            desired_state: PylonTrainingSupervisorDesiredState::Running,
+            process_state: PylonTrainingSupervisorProcessState::Running,
+            pid: Some(finished_pid),
+            stdout_log_path: request
+                .run_root
+                .join("supervisor/attempt-1/stdout.log")
+                .display()
+                .to_string(),
+            stderr_log_path: request
+                .run_root
+                .join("supervisor/attempt-1/stderr.log")
+                .display()
+                .to_string(),
+            failure_receipt_path: Some(
+                request
+                    .run_root
+                    .join("supervisor/attempt-1/failure_receipt.json")
+                    .display()
+                    .to_string(),
+            ),
+            last_exit_code: None,
+            last_heartbeat_at_ms: None,
+            last_failure_reason: None,
+            launch_count: 1,
+            restart_count: 0,
+            updated_at_ms: 1_762_491_200_000,
+        });
+        let script_path = config
+            .training
+            .run_root
+            .join("supervisor_restart_recovery.sh");
+        std::fs::write(
+            script_path.as_path(),
+            format!(
+                "#!/bin/sh\nset -eu\nrun_root='{}'\nmkdir -p \"$run_root/status\"\necho '{{\"membership_revision\":\"members.rev1\"}}' > \"$run_root/status/psionic_train_run_status_packet.json\"\nsleep 0.05\nexit 0\n",
+                request.run_root.display()
+            ),
+        )?;
+        let command = supervisor_shell_command(script_path.as_path());
+
+        let mut process = None::<super::PylonTrainingSupervisorProcess>;
+        ensure(
+            drive_training_supervisor_once(
+                &config,
+                ProviderDesiredMode::Online,
+                &mut state,
+                &mut process,
+                Some(&command),
+            )
+            .await?
+                && process.is_some()
+                && state.active_runtime.as_ref().is_some_and(|active| {
+                    active.process_state == PylonTrainingSupervisorProcessState::Running
+                        && active.restart_count == 1
+                        && active.launch_count == 2
+                        && active.pid.is_some_and(|pid| pid != finished_pid)
+                }),
+            "restart recovery should relaunch an orphaned in-flight runtime when there is no retained terminal outcome to consume",
+        )?;
+
+        let mut process = process.ok_or("missing restarted process after recovery")?;
+        poll_training_supervisor_until_exit(&config, &mut state, &mut process).await?;
+        ensure(
+            state.active_runtime.as_ref().is_some_and(|active| {
+                active.process_state == PylonTrainingSupervisorProcessState::Stopped
+                    && active.restart_count == 1
+                    && active.launch_count == 2
+                    && active.last_exit_code == Some(0)
+            }),
+            "the relaunched recovered supervisor should still finish and persist a clean retained terminal state",
         )
     }
 

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -46,14 +46,14 @@ use openagents_kernel_core::{
         PYLON_TRAINING_APPLE_ENVIRONMENT_REF as SHARED_PYLON_TRAINING_APPLE_ENVIRONMENT_REF,
         PYLON_TRAINING_CS336_A1_DEMO_ENVIRONMENT_REF as SHARED_PYLON_TRAINING_CS336_A1_DEMO_ENVIRONMENT_REF,
         PYLON_TRAINING_CUDA_ENVIRONMENT_REF as SHARED_PYLON_TRAINING_CUDA_ENVIRONMENT_REF,
-        PYLON_TRAINING_RETRY_CAP_MS, PYLON_TRAINING_RETRY_SCHEDULE_MS,
-        PYLON_TRAINING_UPLOAD_TIMEOUT_MS, PylonTrainingArtifactBundleKind,
-        PylonTrainingArtifactBundleProgress, PylonTrainingArtifactBundleState,
-        PylonTrainingArtifactClass, PylonTrainingArtifactKind, PylonTrainingArtifactLayout,
-        PylonTrainingArtifactResolverResponse, PylonTrainingArtifactScope,
-        PylonTrainingArtifactSignedAccessMode, PylonTrainingArtifactSignedAccessRequest,
-        PylonTrainingArtifactSignedAccessResponse, PylonTrainingObservabilityContext,
-        artifact_digest_from_bytes, artifact_digest_from_json,
+        PYLON_TRAINING_GCS_CREDENTIAL_SOURCE, PYLON_TRAINING_RETRY_CAP_MS,
+        PYLON_TRAINING_RETRY_SCHEDULE_MS, PYLON_TRAINING_UPLOAD_TIMEOUT_MS,
+        PylonTrainingArtifactBundleKind, PylonTrainingArtifactBundleProgress,
+        PylonTrainingArtifactBundleState, PylonTrainingArtifactClass, PylonTrainingArtifactKind,
+        PylonTrainingArtifactLayout, PylonTrainingArtifactResolverResponse,
+        PylonTrainingArtifactScope, PylonTrainingArtifactSignedAccessMode,
+        PylonTrainingArtifactSignedAccessRequest, PylonTrainingArtifactSignedAccessResponse,
+        PylonTrainingObservabilityContext, artifact_digest_from_bytes, artifact_digest_from_json,
         can_emit_terminal_artifact_uploaded_receipt, derive_artifact_bundle_state,
         parse_pylon_training_run_manifest_json, pylon_training_artifact_relative_path,
         pylon_training_resolve_artifact_for_uri, resolve_pylon_training_credentials,
@@ -88,11 +88,11 @@ use psionic_train::{
     PSION_ACTUAL_PRETRAINING_LANE_ID, PSION_APPLE_WINDOWED_TRAINING_LANE_ID,
     PSION_CS336_A1_DEMO_LANE_ID, PSIONIC_TRAIN_ACTUAL_PRETRAINING_ENVIRONMENT_REF,
     PSIONIC_TRAIN_INVOCATION_MANIFEST_SCHEMA_VERSION, PSIONIC_TRAIN_RUNTIME_SURFACE_ID,
-    PsionicTrainAdmissionIdentity, PsionicTrainArtifactBinding, PsionicTrainArtifactRef,
-    PsionicTrainCoordinationContext, PsionicTrainInvocationManifest, PsionicTrainLaneContract,
-    PsionicTrainMinimumMachineClass, PsionicTrainOperation, PsionicTrainRole,
-    PsionicTrainWorkClass, admitted_environment_ref_for_lane, admitted_release_id_for_lane,
-    runtime_build_digest,
+    PsionicTrainAdmissionIdentity, PsionicTrainArtifactBinding, PsionicTrainCoordinationContext,
+    PsionicTrainInvocationManifest, PsionicTrainLaneContract, PsionicTrainMinimumMachineClass,
+    PsionicTrainOperation, PsionicTrainRole, PsionicTrainWorkClass,
+    admitted_environment_ref_for_lane, admitted_release_id_for_lane,
+    build_psionic_train_artifact_binding_from_path, runtime_build_digest,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -1320,6 +1320,9 @@ pub enum TrainingCommand {
     },
     Publish {
         manifest_path: Option<PathBuf>,
+        json: bool,
+    },
+    Intake {
         json: bool,
     },
     Sync {
@@ -4351,25 +4354,8 @@ fn training_runtime_manifest_path_for_run(run_root: &Path) -> PathBuf {
 }
 
 fn training_artifact_resolved_cache_key(artifact_id: &str) -> String {
-    let mut sanitized = artifact_id
-        .chars()
-        .map(|value| {
-            if value.is_ascii_alphanumeric() {
-                value.to_ascii_lowercase()
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    while sanitized.contains("__") {
-        sanitized = sanitized.replace("__", "_");
-    }
-    let sanitized = sanitized.trim_matches('_');
-    if sanitized.is_empty() {
-        String::from("artifact")
-    } else {
-        sanitized.to_string()
-    }
+    let digest = sha256_hex(artifact_id.as_bytes());
+    format!("oa_train_artifact_{}", &digest[..32])
 }
 
 fn training_resolved_artifact_cache_relative_path(
@@ -4840,6 +4826,186 @@ fn training_validator_target_artifact<'a>(
         .find(|artifact| artifact.artifact_role == artifact_role)
 }
 
+fn training_validator_outcome_metadata_field<'a>(
+    outcome: &'a ComputeAdapterContributionOutcome,
+    field_name: &str,
+) -> Option<&'a Value> {
+    outcome.metadata.as_object()?.get(field_name)
+}
+
+fn training_validator_metadata_artifact_binding(
+    artifact_role: &str,
+    value: &Value,
+) -> Option<PylonTrainingValidatorTargetArtifactBinding> {
+    let local_path = value
+        .get("path")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let digest = value
+        .get("digest")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let artifact_id = value
+        .get("artifact_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    if local_path.is_none() && digest.is_none() && artifact_id.is_none() {
+        return None;
+    }
+    Some(PylonTrainingValidatorTargetArtifactBinding {
+        artifact_role: artifact_role.to_string(),
+        artifact_id,
+        digest,
+        object_uri: None,
+        local_path,
+        signed_read_url: None,
+        resolver: None,
+        metadata: value.clone(),
+    })
+}
+
+fn training_validator_bridge_artifact_binding(
+    response: &PylonTrainingValidatorChallengeCoordinatorResponse,
+    outcome: &ComputeAdapterContributionOutcome,
+    artifact_role: &str,
+    artifact_kind: PylonTrainingArtifactKind,
+) -> Result<PylonTrainingValidatorTargetArtifactBinding> {
+    let resolver = PylonTrainingArtifactResolverResponse::new(
+        artifact_kind,
+        PylonTrainingArtifactScope {
+            network_id: response.network_id.clone(),
+            run_id: response.training_run_id.clone(),
+            window_id: Some(response.window_id.clone()),
+            assignment_id: Some(outcome.assignment_id.clone()),
+            challenge_id: None,
+            optimizer_step: None,
+        },
+    )
+    .map_err(anyhow::Error::msg)?;
+    Ok(PylonTrainingValidatorTargetArtifactBinding {
+        artifact_role: artifact_role.to_string(),
+        artifact_id: Some(resolver.artifact_id.clone()),
+        digest: resolver.digest.clone(),
+        object_uri: None,
+        local_path: None,
+        signed_read_url: resolver.signed_read_url.clone(),
+        resolver: Some(resolver),
+        metadata: Value::Null,
+    })
+}
+
+fn training_validator_target_binding_from_outcome(
+    response: &PylonTrainingValidatorChallengeCoordinatorResponse,
+    outcome: &ComputeAdapterContributionOutcome,
+) -> Result<PylonTrainingValidatorTargetAssignmentBinding> {
+    let mut artifacts = Vec::new();
+    for (artifact_role, field_name) in [
+        ("contribution_receipt", "receipt"),
+        ("contribution_artifact_manifest", "artifact_manifest"),
+        ("sealed_window_bundle", "sealed_window_bundle"),
+        ("closeout_bundle", "closeout_bundle"),
+        ("checkpoint_surface", "checkpoint_surface"),
+        (
+            "latest_accepted_checkpoint_pointer",
+            "latest_accepted_checkpoint_pointer",
+        ),
+    ] {
+        if let Some(binding) = training_validator_outcome_metadata_field(outcome, field_name)
+            .and_then(|value| training_validator_metadata_artifact_binding(artifact_role, value))
+        {
+            artifacts.push(binding);
+        }
+    }
+    for (artifact_role, artifact_kind) in [
+        (
+            "local_update_bridge",
+            PylonTrainingArtifactKind::LocalUpdate,
+        ),
+        ("proof_bridge", PylonTrainingArtifactKind::ProofBundle),
+    ] {
+        artifacts.push(training_validator_bridge_artifact_binding(
+            response,
+            outcome,
+            artifact_role,
+            artifact_kind,
+        )?);
+    }
+    Ok(PylonTrainingValidatorTargetAssignmentBinding {
+        assignment_id: outcome.assignment_id.clone(),
+        training_run_id: outcome.training_run_id.clone(),
+        window_id: outcome.window_id.clone(),
+        contributor_pylon_id: outcome.contributor_node_id.clone(),
+        contribution_id: outcome.contribution_id.clone(),
+        work_class: outcome.work_class.label().to_string(),
+        challenge_kind: response.challenge_kind.clone(),
+        claim_id: response.challenge_id.clone(),
+        submission_receipt_digest: outcome.submission_receipt_digest.clone(),
+        manifest_digest: outcome.manifest_digest.clone(),
+        object_digest: outcome.object_digest.clone(),
+        lane_type: training_validator_outcome_metadata_field(outcome, "lane_type")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        lease_expires_at_ms: response
+            .lease
+            .as_ref()
+            .map(|lease| lease.expires_at_ms as i64),
+        artifacts,
+    })
+}
+
+async fn resolve_training_validator_target_bindings(
+    client: &PylonTrainingCoordinatorClient,
+    response: &PylonTrainingValidatorChallengeCoordinatorResponse,
+) -> Result<Vec<PylonTrainingValidatorTargetAssignmentBinding>> {
+    let requested_assignment_ids = if response.target_assignment_ids.is_empty() {
+        response
+            .target_bindings
+            .iter()
+            .map(|binding| binding.assignment_id.clone())
+            .collect::<Vec<_>>()
+    } else {
+        response.target_assignment_ids.clone()
+    };
+    if requested_assignment_ids.is_empty() {
+        return Ok(response.target_bindings.clone());
+    }
+    let outcomes = client
+        .list_adapter_contribution_outcomes(
+            Some(response.training_run_id.as_str()),
+            Some(response.window_id.as_str()),
+            None,
+        )
+        .await?;
+    let outcomes_by_assignment = outcomes
+        .into_iter()
+        .map(|outcome| (outcome.assignment_id.clone(), outcome))
+        .collect::<BTreeMap<_, _>>();
+    let response_targets = response
+        .target_bindings
+        .iter()
+        .cloned()
+        .map(|binding| (binding.assignment_id.clone(), binding))
+        .collect::<BTreeMap<_, _>>();
+    let mut resolved = Vec::new();
+    for assignment_id in requested_assignment_ids {
+        if let Some(binding) = response_targets.get(assignment_id.as_str()) {
+            resolved.push(binding.clone());
+            continue;
+        }
+        let Some(outcome) = outcomes_by_assignment.get(assignment_id.as_str()) else {
+            continue;
+        };
+        resolved.push(training_validator_target_binding_from_outcome(
+            response, outcome,
+        )?);
+    }
+    if resolved.is_empty() {
+        Ok(response.target_bindings.clone())
+    } else {
+        Ok(resolved)
+    }
+}
+
 async fn materialize_training_validator_bridge_bundle(
     config: &PylonConfig,
     client: &PylonTrainingCoordinatorClient,
@@ -4889,9 +5055,11 @@ async fn ensure_training_validator_challenge_materialized(
         return Ok(());
     }
 
-    persist_training_validator_claim_record(run_root, response)?;
-    let target = response
-        .target_bindings
+    let target_bindings = resolve_training_validator_target_bindings(client, response).await?;
+    let mut claim_record = response.clone();
+    claim_record.target_bindings = target_bindings.clone();
+    persist_training_validator_claim_record(run_root, &claim_record)?;
+    let target = target_bindings
         .first()
         .ok_or_else(|| anyhow!("validator challenge claim missing target bindings"))?;
     let contribution_root = run_root
@@ -4907,6 +5075,10 @@ async fn ensure_training_validator_challenge_materialized(
     })?;
     let adapter_delta_bundle_path = contribution_root.join("adapter_delta_bundle.json");
     let proof_bundle_path = contribution_root.join("proof_bundle.json");
+    training_trace(&format!(
+        "materializing validator local update bridge for challenge {}",
+        response.challenge_id
+    ));
     let adapter_delta_bundle = materialize_training_validator_bridge_bundle(
         config,
         client,
@@ -4917,6 +5089,10 @@ async fn ensure_training_validator_challenge_materialized(
         "local update bridge bundle",
     )
     .await?;
+    training_trace(&format!(
+        "materializing validator proof bridge for challenge {}",
+        response.challenge_id
+    ));
     let proof_bundle = materialize_training_validator_bridge_bundle(
         config,
         client,
@@ -4927,6 +5103,10 @@ async fn ensure_training_validator_challenge_materialized(
         "proof bridge bundle",
     )
     .await?;
+    training_trace(&format!(
+        "materialized validator bridge bundles for challenge {}",
+        response.challenge_id
+    ));
     let contribution_receipt = adapter_delta_bundle
         .get("source")
         .and_then(|value| value.get("contribution_receipt"))
@@ -5078,7 +5258,12 @@ async fn claim_training_validator_challenge_without_run_lease(
     requested_network_id: Option<&str>,
     requested_training_run_id: Option<&str>,
 ) -> Result<bool> {
-    let response = client
+    training_trace(&format!(
+        "claiming validator challenge network={} run={}",
+        requested_network_id.unwrap_or("any"),
+        requested_training_run_id.unwrap_or("any")
+    ));
+    let mut response = client
         .claim_validator_challenge(&PylonClaimTrainingValidatorChallengeRequest {
             idempotency_key: format!(
                 "training.validator_challenge.claim.direct.{}.{}",
@@ -5091,10 +5276,16 @@ async fn claim_training_validator_challenge_without_run_lease(
             requested_training_run_id: requested_training_run_id.map(ToOwned::to_owned),
         })
         .await?;
+    training_trace(&format!(
+        "claimed validator challenge {} for run {} window {}",
+        response.challenge_id, response.training_run_id, response.window_id
+    ));
     let challenge_lease = response
         .lease
         .clone()
         .ok_or_else(|| anyhow!("validator challenge claim missing lease"))?;
+    response.target_bindings =
+        resolve_training_validator_target_bindings(client, &response).await?;
     let target = response
         .target_bindings
         .first()
@@ -5117,7 +5308,10 @@ async fn claim_training_validator_challenge_without_run_lease(
             role: PylonTrainingRoleClaim::Validator,
             state: "acked".to_string(),
             manifest_digest: Some(target.manifest_digest.clone()),
-            checkpoint_ref: training_run.checkpoint_binding.latest_checkpoint_ref.clone(),
+            checkpoint_ref: training_run
+                .checkpoint_binding
+                .latest_checkpoint_ref
+                .clone(),
             expires_at_ms: Some(challenge_lease.expires_at_ms as i64),
             network_id: Some(response.network_id.clone()),
             challenge_id: Some(response.challenge_id.clone()),
@@ -5125,7 +5319,9 @@ async fn claim_training_validator_challenge_without_run_lease(
             peer_checkpoint_handoff_receipt_path: None,
             validator_target_contribution_receipt_path: None,
             validator_target_contribution_artifact_manifest_path: None,
-            validator_target_work_class: ComputeTrainingWorkClass::parse(target.work_class.as_str()),
+            validator_target_work_class: ComputeTrainingWorkClass::parse(
+                target.work_class.as_str(),
+            ),
             grouped_stage_input_transport_path: None,
             runtime_manifest_path: None,
             runtime_manifest_digest: None,
@@ -5158,6 +5354,11 @@ async fn claim_training_validator_challenge_without_run_lease(
         &response,
     )
     .await?;
+    training_trace(&format!(
+        "materialized validator challenge {} into {}",
+        response.challenge_id,
+        run_root.display()
+    ));
     let _ = ensure_training_assignment_runtime_manifest(
         config,
         identity,
@@ -5167,6 +5368,10 @@ async fn claim_training_validator_challenge_without_run_lease(
         lease_id.as_str(),
     )
     .await?;
+    training_trace(&format!(
+        "materialized validator runtime manifest for challenge {}",
+        response.challenge_id
+    ));
     Ok(true)
 }
 
@@ -5271,15 +5476,12 @@ fn resolve_psionic_train_admission_identity(
     ))
 }
 
-fn psionic_train_materialized_artifact_binding(path: &str) -> PsionicTrainArtifactBinding {
-    PsionicTrainArtifactBinding {
-        artifact_ref: PsionicTrainArtifactRef {
-            artifact_id: format!("artifact://{}", path.replace('/', "_")),
-            artifact_digest: Some(sha256_prefixed_text(path)),
-            artifact_bytes: Some(path.len() as u64),
-        },
-        materialized_path: Some(path.to_string()),
-    }
+fn psionic_train_materialized_artifact_binding(
+    artifact_role: &str,
+    path: &str,
+) -> Result<PsionicTrainArtifactBinding> {
+    build_psionic_train_artifact_binding_from_path(artifact_role, Path::new(path))
+        .map_err(anyhow::Error::msg)
 }
 
 fn build_psionic_train_invocation_manifest(
@@ -5361,15 +5563,30 @@ fn build_psionic_train_invocation_manifest(
         peer_checkpoint_handoff_receipt: lease
             .peer_checkpoint_handoff_receipt_path
             .as_deref()
-            .map(psionic_train_materialized_artifact_binding),
+            .map(|path| {
+                psionic_train_materialized_artifact_binding("peer_checkpoint_handoff_receipt", path)
+            })
+            .transpose()?,
         validator_target_contribution_receipt: lease
             .validator_target_contribution_receipt_path
             .as_deref()
-            .map(psionic_train_materialized_artifact_binding),
+            .map(|path| {
+                psionic_train_materialized_artifact_binding(
+                    "validator_target_contribution_receipt",
+                    path,
+                )
+            })
+            .transpose()?,
         validator_target_contribution_artifact_manifest: lease
             .validator_target_contribution_artifact_manifest_path
             .as_deref()
-            .map(psionic_train_materialized_artifact_binding),
+            .map(|path| {
+                psionic_train_materialized_artifact_binding(
+                    "validator_target_contribution_artifact_manifest",
+                    path,
+                )
+            })
+            .transpose()?,
         validator_target_work_class: (role == PsionicTrainRole::Validator).then(|| {
             training_psionic_work_class_for_compute(
                 lease
@@ -5380,7 +5597,10 @@ fn build_psionic_train_invocation_manifest(
         grouped_stage_input_transport: lease
             .grouped_stage_input_transport_path
             .as_deref()
-            .map(psionic_train_materialized_artifact_binding),
+            .map(|path| {
+                psionic_train_materialized_artifact_binding("grouped_stage_input_transport", path)
+            })
+            .transpose()?,
         selected_git_ref: Some(selected_git_ref),
         hardware_observation_path: None,
         run_shape_observation_path: None,
@@ -6243,6 +6463,15 @@ pub async fn run_cli(cli: Cli) -> Result<Option<String>> {
                 }
                 Ok(Some(render_training_trn_publication_report(&report)))
             }
+            TrainingCommand::Intake { json } => {
+                let report =
+                    run_training_assignment_intake_and_load_status(cli.config_path.as_path())
+                        .await?;
+                if json {
+                    return Ok(Some(serde_json::to_string_pretty(&report)?));
+                }
+                Ok(Some(render_training_status_report(&report)))
+            }
             TrainingCommand::Sync { json } => {
                 let report =
                     sync_training_authority_state_via_live_or_local(cli.config_path.as_path())
@@ -6395,6 +6624,7 @@ Commands:\n\
   training artifacts inspect [--json]\n\
   training artifacts gc [--json]\n\
   training publish [--manifest <path>] [--json]\n\
+  training intake [--json]\n\
   training sync [--json]\n\
   training refresh [--json]\n\
   gemma [list] [--json]\n\
@@ -6744,6 +6974,9 @@ fn parse_training_command(args: &[String], start_index: usize) -> Result<Trainin
                 json,
             })
         }
+        Some("intake") => Ok(TrainingCommand::Intake {
+            json: parse_json_only(args, start_index + 1, "training intake")?,
+        }),
         Some("sync") => Ok(TrainingCommand::Sync {
             json: parse_json_only(args, start_index + 1, "training sync")?,
         }),
@@ -8556,6 +8789,7 @@ async fn run_training_assignment_intake_once_with_context(
     host: &ProviderHostTelemetrySnapshot,
     runtime_surface: Option<&PsionicTrainRuntimeSurface>,
 ) -> Result<()> {
+    training_trace("starting training intake pass");
     let client = PylonTrainingCoordinatorClient::new(config)?;
     let contributor_availability =
         derive_adapter_training_contributor_availability(host, runtime_surface);
@@ -8574,6 +8808,11 @@ async fn run_training_assignment_intake_once_with_context(
         .is_some_and(|runtime| training_supervision_is_active(runtime.process_state))
     {
         if let Some(runtime) = state.active_runtime.as_ref() {
+            training_trace(&format!(
+                "active runtime present for assignment {} state={}",
+                runtime.assignment_id,
+                training_process_state_label(runtime.process_state)
+            ));
             report_training_heartbeat_with_readmission(
                 &client,
                 config,
@@ -8599,6 +8838,10 @@ async fn run_training_assignment_intake_once_with_context(
     }
 
     if let Some(existing_lease) = newest_pending_training_lease_cache_entry(state) {
+        training_trace(&format!(
+            "reusing cached lease {} assignment={} state={}",
+            existing_lease.lease_id, existing_lease.assignment_id, existing_lease.state
+        ));
         report_training_heartbeat_with_readmission(
             &client,
             config,
@@ -8615,6 +8858,10 @@ async fn run_training_assignment_intake_once_with_context(
         let runtime_surface = runtime_surface.ok_or_else(|| {
             anyhow!("psionic-train runtime surface is required to materialize a leased assignment")
         })?;
+        training_trace(&format!(
+            "materializing runtime manifest for cached lease {}",
+            existing_lease.lease_id
+        ));
         let materialized = ensure_training_assignment_runtime_manifest(
             config,
             identity,
@@ -8625,9 +8872,14 @@ async fn run_training_assignment_intake_once_with_context(
         )
         .await?;
         if training_lease_state_is_acknowledged(existing_lease.state.as_str()) {
+            training_trace(&format!(
+                "cached lease {} already acknowledged",
+                existing_lease.lease_id
+            ));
             return Ok(());
         }
         let acked_at_ms = now_epoch_ms();
+        training_trace(&format!("acking cached lease {}", existing_lease.lease_id));
         let ack = client
             .ack_assignment(&PylonTrainingAssignmentAckRequest {
                 idempotency_key: format!(
@@ -8667,6 +8919,7 @@ async fn run_training_assignment_intake_once_with_context(
         &supported_roles,
     )
     .await?;
+    training_trace("admitted training node");
     report_training_heartbeat_with_readmission(
         &client,
         config,
@@ -8680,11 +8933,17 @@ async fn run_training_assignment_intake_once_with_context(
         &training_idle_presence_heartbeat_request(identity, now_epoch_ms()),
     )
     .await?;
+    training_trace("reported idle training heartbeat");
 
     for role in supported_roles.clone() {
         let membership_revision = training_cached_membership_revision_for_role(state, role);
         for requested_network_id in training_requested_networks(config) {
             let requested_at_ms = now_epoch_ms();
+            training_trace(&format!(
+                "requesting run lease role={} network={}",
+                role.label(),
+                requested_network_id.as_deref().unwrap_or("any")
+            ));
             match client
                 .request_run_lease(&PylonTrainingRunLeaseRequest {
                     idempotency_key: format!(
@@ -8703,6 +8962,21 @@ async fn run_training_assignment_intake_once_with_context(
                 .await
             {
                 Ok(lease) => {
+                    if let Some(expected_network_id) = requested_network_id.as_deref()
+                        && lease.network_id.as_deref() != Some(expected_network_id)
+                    {
+                        training_trace(&format!(
+                            "ignoring mismatched run lease {} requested_network={} actual_network={}",
+                            lease.lease_id,
+                            expected_network_id,
+                            lease.network_id.as_deref().unwrap_or("missing"),
+                        ));
+                        continue;
+                    }
+                    training_trace(&format!(
+                        "received run lease {} assignment={}",
+                        lease.lease_id, lease.assignment_id
+                    ));
                     cache_training_run_lease(state, &lease, requested_at_ms);
                     report_training_heartbeat_with_readmission(
                         &client,
@@ -8729,6 +9003,10 @@ async fn run_training_assignment_intake_once_with_context(
                             "psionic-train runtime surface is required to materialize a leased assignment"
                         )
                     })?;
+                    training_trace(&format!(
+                        "materializing runtime manifest for leased assignment {}",
+                        lease.assignment_id
+                    ));
                     let materialized = ensure_training_assignment_runtime_manifest(
                         config,
                         identity,
@@ -8739,6 +9017,7 @@ async fn run_training_assignment_intake_once_with_context(
                     )
                     .await?;
                     let acked_at_ms = now_epoch_ms();
+                    training_trace(&format!("acking lease {}", lease.lease_id));
                     let ack = client
                         .ack_assignment(&PylonTrainingAssignmentAckRequest {
                             idempotency_key: format!(
@@ -8768,6 +9047,12 @@ async fn run_training_assignment_intake_once_with_context(
                     return Ok(());
                 }
                 Err(error) if training_lease_claim_error_is_nonfatal(&error.to_string()) => {
+                    training_trace(&format!(
+                        "nonfatal run lease error for role={} network={}: {}",
+                        role.label(),
+                        requested_network_id.as_deref().unwrap_or("any"),
+                        error
+                    ));
                     if role == PylonTrainingRoleClaim::Validator
                         && error
                             .to_string()
@@ -8778,6 +9063,10 @@ async fn run_training_assignment_intake_once_with_context(
                                 "psionic-train runtime surface is required to materialize a validator challenge"
                             )
                         })?;
+                        training_trace(&format!(
+                            "falling back to direct validator challenge claim network={}",
+                            requested_network_id.as_deref().unwrap_or("any")
+                        ));
                         match claim_training_validator_challenge_without_run_lease(
                             config,
                             identity,
@@ -8789,7 +9078,10 @@ async fn run_training_assignment_intake_once_with_context(
                         )
                         .await
                         {
-                            Ok(true) => return Ok(()),
+                            Ok(true) => {
+                                training_trace("validator challenge intake succeeded");
+                                return Ok(());
+                            }
                             Ok(false) => {}
                             Err(challenge_error)
                                 if training_validator_challenge_claim_error_is_nonfatal(
@@ -8824,6 +9116,15 @@ async fn run_training_assignment_intake_once(
     )
     .await?;
     save_training_runtime_state(config, &state)
+}
+
+async fn run_training_assignment_intake_and_load_status(
+    config_path: &Path,
+) -> Result<TrainingOperatorStatusReport> {
+    let config = load_or_create_config(config_path)?;
+    let identity = ensure_identity(config.identity_path.as_path())?;
+    run_training_assignment_intake_once(&config, &identity).await?;
+    load_training_status_report_local(config_path)
 }
 
 #[derive(Clone, Debug)]
@@ -9113,15 +9414,19 @@ impl PylonTrainingArtifactStoreClient {
                 PylonTrainingArtifactBundleKind::Contribution { assignment_id } => assignment_id,
                 _ => unreachable!("checked contribution bundle kind"),
             };
-            ensure_training_contribution_bridge_bundles(
-                &context,
-                local_run_root
-                    .join("windows")
-                    .join(manifest.window_id.as_str())
-                    .join("contributions")
-                    .join(contribution_key)
-                    .as_path(),
-            )?;
+            let default_contribution_root = local_run_root
+                .join("windows")
+                .join(manifest.window_id.as_str())
+                .join("contributions")
+                .join(contribution_key);
+            let contribution_root = training_retained_contribution_root(
+                local_run_root.as_path(),
+                manifest.window_id.as_str(),
+                contribution_key.as_str(),
+                None,
+            )?
+            .unwrap_or(default_contribution_root);
+            ensure_training_contribution_bridge_bundles(&context, contribution_root.as_path())?;
         }
         let required_objects = bundle_kind.required_paths(&layout);
         let bundle_id = bundle_kind.bundle_id();
@@ -9387,29 +9692,38 @@ impl PylonTrainingCheckpointServer {
 fn resolve_training_artifact_credentials(
     config: &PylonConfig,
 ) -> Result<(String, Option<String>, Option<String>)> {
+    let explicit_bearer_token = std::env::var(ENV_TRAINING_GCS_BEARER_TOKEN)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
     let google_application_credentials = std::env::var(ENV_GOOGLE_APPLICATION_CREDENTIALS)
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
     let metadata_token_url = training_metadata_token_url();
-    let resolution = resolve_pylon_training_credentials(
-        google_application_credentials.as_deref(),
-        metadata_token_url.is_some(),
-    )
-    .map_err(anyhow::Error::msg)?;
+    let resolved_credential_source = if explicit_bearer_token.is_some() {
+        PYLON_TRAINING_GCS_CREDENTIAL_SOURCE.to_string()
+    } else {
+        resolve_pylon_training_credentials(
+            google_application_credentials.as_deref(),
+            metadata_token_url.is_some(),
+        )
+        .map_err(anyhow::Error::msg)?
+        .persistent_credential_source
+    };
     if !config
         .training
         .artifact_credential_source_names
         .iter()
-        .any(|value| value == &resolution.persistent_credential_source)
+        .any(|value| value == &resolved_credential_source)
     {
         bail!(
             "training artifact credential source `{}` is not admitted by config",
-            resolution.persistent_credential_source
+            resolved_credential_source
         );
     }
     Ok((
-        resolution.persistent_credential_source,
+        resolved_credential_source,
         google_application_credentials,
         metadata_token_url,
     ))
@@ -9564,6 +9878,34 @@ fn training_checkpoint_serve_url(config: &PylonConfig) -> String {
     format!("http://{}", config.training.checkpoint_serve_addr.trim())
 }
 
+fn format_anyhow_error_chain(error: &anyhow::Error) -> String {
+    let mut rendered = Vec::new();
+    for cause in error.chain() {
+        let text = cause.to_string();
+        if rendered.last().is_some_and(|previous| previous == &text) {
+            continue;
+        }
+        rendered.push(text);
+    }
+    rendered.join(": ")
+}
+
+fn training_trace_enabled() -> bool {
+    std::env::var("OPENAGENTS_PYLON_TRAINING_TRACE")
+        .ok()
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            !normalized.is_empty() && normalized != "0" && normalized != "false"
+        })
+        .unwrap_or(false)
+}
+
+fn training_trace(message: &str) {
+    if training_trace_enabled() {
+        eprintln!("training-trace: {message}");
+    }
+}
+
 fn artifact_bundle_state_label(state: PylonTrainingArtifactBundleState) -> String {
     match state {
         PylonTrainingArtifactBundleState::LocalOnly => "local_only".to_string(),
@@ -9601,7 +9943,30 @@ fn training_local_artifact_path(
     local_run_root: &Path,
     object_uri: &str,
 ) -> Result<PathBuf> {
-    Ok(local_run_root.join(training_artifact_relative_path(layout, object_uri)?))
+    let relative_path = training_artifact_relative_path(layout, object_uri)?;
+    let canonical_path = local_run_root.join(relative_path.as_path());
+    let parts = relative_path
+        .iter()
+        .map(|component| component.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    match parts.as_slice() {
+        [windows, window_id, contributions, assignment_id, file]
+            if windows == "windows"
+                && contributions == "contributions"
+                && matches!(
+                    file.as_str(),
+                    "adapter_delta_bundle.json" | "proof_bundle.json"
+                ) =>
+        {
+            if let Some(contribution_root) =
+                training_retained_contribution_root(local_run_root, window_id, assignment_id, None)?
+            {
+                return Ok(contribution_root.join(file));
+            }
+        }
+        _ => {}
+    }
+    Ok(canonical_path)
 }
 
 #[allow(dead_code)]
@@ -9832,7 +10197,11 @@ fn inspect_manifest_local_artifacts(
                 continue;
             }
             ensure_training_contribution_bridge_bundles(context, entry.path().as_path())?;
-            let assignment_id = entry.file_name().to_string_lossy().to_string();
+            let Some(assignment_id) =
+                training_retained_contribution_assignment_id(entry.path().as_path())?
+            else {
+                continue;
+            };
             bundles.push(inspect_training_artifact_bundle(
                 context,
                 PylonTrainingArtifactBundleKind::Contribution { assignment_id },
@@ -9883,16 +10252,20 @@ fn inspect_training_artifact_bundle(
     bundle_kind: PylonTrainingArtifactBundleKind,
 ) -> Result<TrainingArtifactBundleInspectionEntry> {
     if let PylonTrainingArtifactBundleKind::Contribution { assignment_id } = &bundle_kind {
-        ensure_training_contribution_bridge_bundles(
-            context,
-            context
-                .local_run_root
-                .join("windows")
-                .join(context.manifest.window_id.as_str())
-                .join("contributions")
-                .join(assignment_id)
-                .as_path(),
-        )?;
+        let default_contribution_root = context
+            .local_run_root
+            .join("windows")
+            .join(context.manifest.window_id.as_str())
+            .join("contributions")
+            .join(assignment_id);
+        let contribution_root = training_retained_contribution_root(
+            context.local_run_root.as_path(),
+            context.manifest.window_id.as_str(),
+            assignment_id.as_str(),
+            None,
+        )?
+        .unwrap_or(default_contribution_root);
+        ensure_training_contribution_bridge_bundles(context, contribution_root.as_path())?;
     }
     let mut objects = Vec::new();
     let mut present_count = 0usize;
@@ -10846,7 +11219,8 @@ async fn publish_training_trn_state(
                 .context("failed to resolve current directory for --manifest")?
                 .join(manifest_path)
         };
-        let selected_manifest_paths = training_manifest_lookup_paths(selected_manifest_path.as_path());
+        let selected_manifest_paths =
+            training_manifest_lookup_paths(selected_manifest_path.as_path());
         contexts.retain(|context| selected_manifest_paths.contains(&context.manifest_path));
         if contexts.is_empty() {
             bail!(
@@ -11185,6 +11559,7 @@ async fn publish_training_trn_state(
 async fn sync_training_authority_state(config_path: &Path) -> Result<TrainingAuthoritySyncReport> {
     let config = load_or_create_config(config_path)?;
     let identity = ensure_identity(config.identity_path.as_path())?;
+    let _ = sync_training_terminal_runtime_once(config_path, &config, &identity).await?;
     let mut state = load_or_create_training_runtime_state(&config)?;
     let contexts = load_training_manifest_inspection_contexts(&config, &state)?;
     let client = PylonTrainingCoordinatorClient::new(&config)?;
@@ -11701,7 +12076,9 @@ fn training_terminal_checkpoint_publication_candidate(
             })
             .max_by(|left, right| {
                 training_checkpoint_manifest_bundle_step(left.bundle_id.as_str())
-                    .cmp(&training_checkpoint_manifest_bundle_step(right.bundle_id.as_str()))
+                    .cmp(&training_checkpoint_manifest_bundle_step(
+                        right.bundle_id.as_str(),
+                    ))
                     .then_with(|| left.bundle_id.cmp(&right.bundle_id))
             });
     }
@@ -11744,6 +12121,295 @@ fn training_prefixed_sha256_digest(value: &str) -> Option<String> {
     Some(format!("sha256:{normalized}"))
 }
 
+fn training_raw_sha256_hex(bytes: &[u8]) -> String {
+    let mut digest = Sha256::new();
+    digest.update(bytes);
+    format!("{:x}", digest.finalize())
+}
+
+fn training_snapshot_materialized_artifact_path(
+    contribution_root: &Path,
+    artifact_kind: &str,
+    source_path: &Path,
+) -> PathBuf {
+    let snapshot_name = source_path
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| format!("{artifact_kind}.bin"));
+    contribution_root
+        .join("retained_artifacts")
+        .join(artifact_kind)
+        .join(snapshot_name)
+}
+
+fn snapshot_training_retained_artifact_binding(
+    contribution_root: &Path,
+    artifact_kind: &str,
+    binding: &mut serde_json::Map<String, Value>,
+) -> Result<Option<String>> {
+    let Some(source_path_value) = binding
+        .get("materialized_path")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+    else {
+        return Ok(None);
+    };
+    let source_path = PathBuf::from(source_path_value.as_str());
+    let artifact_ref = binding
+        .get("artifact_ref")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            anyhow!("retained contribution artifact `{artifact_kind}` missing artifact_ref")
+        })?;
+    let expected_digest = artifact_ref
+        .get("artifact_digest")
+        .and_then(Value::as_str)
+        .map(|value| value.trim_start_matches("sha256:").to_string());
+    let expected_bytes = artifact_ref.get("artifact_bytes").and_then(Value::as_u64);
+    let payload = std::fs::read(source_path.as_path()).with_context(|| {
+        format!(
+            "failed to read retained contribution artifact `{artifact_kind}` from {}",
+            source_path.display()
+        )
+    })?;
+    if let Some(expected_bytes) = expected_bytes {
+        let actual_bytes = u64::try_from(payload.len())
+            .context("failed to convert retained artifact byte length to u64")?;
+        if actual_bytes != expected_bytes {
+            bail!(
+                "retained contribution artifact `{artifact_kind}` drifted before snapshot: expected {expected_bytes} bytes but {} had {actual_bytes}",
+                source_path.display()
+            );
+        }
+    }
+    if let Some(expected_digest) = expected_digest {
+        let actual_digest = training_raw_sha256_hex(payload.as_slice());
+        if actual_digest != expected_digest {
+            bail!(
+                "retained contribution artifact `{artifact_kind}` drifted before snapshot: expected digest `{expected_digest}` but {} had `{actual_digest}`",
+                source_path.display()
+            );
+        }
+    }
+    let snapshot_path = training_snapshot_materialized_artifact_path(
+        contribution_root,
+        artifact_kind,
+        &source_path,
+    );
+    if let Some(parent) = snapshot_path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create retained artifact snapshot dir {}",
+                parent.display()
+            )
+        })?;
+    }
+    std::fs::write(snapshot_path.as_path(), payload).with_context(|| {
+        format!(
+            "failed to write retained artifact snapshot {}",
+            snapshot_path.display()
+        )
+    })?;
+    binding.insert(
+        "materialized_path".to_string(),
+        Value::String(snapshot_path.display().to_string()),
+    );
+    Ok(Some(snapshot_path.display().to_string()))
+}
+
+fn stabilize_training_retained_psionic_worker_contract(
+    contribution_root: &Path,
+    contribution_receipt_path: &Path,
+    artifact_manifest_path: &Path,
+) -> Result<()> {
+    let Some(mut contribution_receipt) = load_training_json_artifact_value(
+        contribution_receipt_path,
+        "training contribution receipt",
+    )?
+    else {
+        return Ok(());
+    };
+    let Some(mut artifact_manifest) = load_training_json_artifact_value(
+        artifact_manifest_path,
+        "training contribution artifact manifest",
+    )?
+    else {
+        return Ok(());
+    };
+    let Some(artifacts) = artifact_manifest
+        .get_mut("artifacts")
+        .and_then(Value::as_array_mut)
+    else {
+        return Ok(());
+    };
+
+    let mut snapshot_paths = BTreeMap::new();
+    for artifact in artifacts {
+        let Some(artifact_kind) = artifact
+            .get("artifact_kind")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+        else {
+            continue;
+        };
+        let Some(binding) = artifact.get_mut("binding").and_then(Value::as_object_mut) else {
+            continue;
+        };
+        if let Some(snapshot_path) = snapshot_training_retained_artifact_binding(
+            contribution_root,
+            artifact_kind.as_str(),
+            binding,
+        )? {
+            snapshot_paths.insert(artifact_kind, snapshot_path);
+        }
+    }
+    write_training_json_value(
+        artifact_manifest_path,
+        &artifact_manifest,
+        "training contribution artifact manifest",
+    )?;
+
+    let artifact_manifest_bytes = std::fs::read(artifact_manifest_path).with_context(|| {
+        format!(
+            "failed to read stabilized contribution artifact manifest {}",
+            artifact_manifest_path.display()
+        )
+    })?;
+    let artifact_manifest_raw_digest = training_raw_sha256_hex(artifact_manifest_bytes.as_slice());
+    let artifact_manifest_raw_bytes = u64::try_from(artifact_manifest_bytes.len())
+        .context("failed to convert stabilized contribution artifact manifest length to u64")?;
+    let artifact_manifest_digest =
+        artifact_digest_from_json(&artifact_manifest).map_err(anyhow::Error::msg)?;
+
+    if let Some(binding) = contribution_receipt
+        .get_mut("artifact_manifest")
+        .and_then(Value::as_object_mut)
+    {
+        if let Some(artifact_ref) = binding
+            .get_mut("artifact_ref")
+            .and_then(Value::as_object_mut)
+        {
+            artifact_ref.insert(
+                "artifact_digest".to_string(),
+                Value::String(artifact_manifest_raw_digest),
+            );
+            artifact_ref.insert(
+                "artifact_bytes".to_string(),
+                Value::Number(serde_json::Number::from(artifact_manifest_raw_bytes)),
+            );
+        }
+        binding.insert(
+            "materialized_path".to_string(),
+            Value::String(artifact_manifest_path.display().to_string()),
+        );
+    }
+    write_training_json_value(
+        contribution_receipt_path,
+        &contribution_receipt,
+        "training contribution receipt",
+    )?;
+    let contribution_receipt_digest =
+        artifact_digest_from_json(&contribution_receipt).map_err(anyhow::Error::msg)?;
+
+    let adapter_delta_bundle_path = contribution_root.join("adapter_delta_bundle.json");
+    if let Some(mut adapter_delta_bundle) = load_training_json_artifact_value(
+        adapter_delta_bundle_path.as_path(),
+        "training local-update bridge bundle",
+    )? {
+        if let Some(source) = adapter_delta_bundle
+            .get_mut("source")
+            .and_then(Value::as_object_mut)
+        {
+            source.insert(
+                "contribution_receipt_path".to_string(),
+                Value::String(contribution_receipt_path.display().to_string()),
+            );
+            source.insert(
+                "contribution_receipt_digest".to_string(),
+                Value::String(contribution_receipt_digest.clone()),
+            );
+            source.insert(
+                "contribution_receipt".to_string(),
+                contribution_receipt.clone(),
+            );
+        }
+        write_training_json_value(
+            adapter_delta_bundle_path.as_path(),
+            &adapter_delta_bundle,
+            "training local-update bridge bundle",
+        )?;
+    }
+
+    let proof_bundle_path = contribution_root.join("proof_bundle.json");
+    if let Some(mut proof_bundle) = load_training_json_artifact_value(
+        proof_bundle_path.as_path(),
+        "training proof bridge bundle",
+    )? {
+        if let Some(source) = proof_bundle
+            .get_mut("source")
+            .and_then(Value::as_object_mut)
+        {
+            source.insert(
+                "artifact_manifest_path".to_string(),
+                Value::String(artifact_manifest_path.display().to_string()),
+            );
+            source.insert(
+                "artifact_manifest_digest".to_string(),
+                Value::String(artifact_manifest_digest),
+            );
+            source.insert("artifact_manifest".to_string(), artifact_manifest.clone());
+            source.insert(
+                "contribution_receipt_path".to_string(),
+                Value::String(contribution_receipt_path.display().to_string()),
+            );
+            source.insert(
+                "contribution_receipt_digest".to_string(),
+                Value::String(contribution_receipt_digest),
+            );
+            source.insert(
+                "contribution_receipt".to_string(),
+                contribution_receipt.clone(),
+            );
+            for (artifact_kind, source_key) in [
+                (
+                    "checkpoint_pointer",
+                    "latest_accepted_checkpoint_pointer_path",
+                ),
+                ("checkpoint_surface", "checkpoint_surface_path"),
+                ("final_closeout_bundle", "closeout_bundle_path"),
+            ] {
+                if let Some(snapshot_path) = snapshot_paths.get(artifact_kind) {
+                    source.insert(source_key.to_string(), Value::String(snapshot_path.clone()));
+                }
+            }
+        }
+        write_training_json_value(
+            proof_bundle_path.as_path(),
+            &proof_bundle,
+            "training proof bridge bundle",
+        )?;
+    }
+
+    Ok(())
+}
+
+fn training_retained_contribution_assignment_id(
+    contribution_root: &Path,
+) -> Result<Option<String>> {
+    let receipt_path = contribution_root.join("contribution_receipt.json");
+    let Some(receipt) =
+        load_training_json_artifact_value(receipt_path.as_path(), "training contribution receipt")?
+    else {
+        return Ok(None);
+    };
+    Ok(receipt
+        .get("assignment_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned))
+}
+
 fn training_retained_contribution_root(
     run_root: &Path,
     window_id: &str,
@@ -11773,17 +12439,8 @@ fn training_retained_contribution_root(
         if !entry.file_type()?.is_dir() {
             continue;
         }
-        let receipt_path = entry.path().join("contribution_receipt.json");
-        let Some(receipt) = load_training_json_artifact_value(
-            receipt_path.as_path(),
-            "training contribution receipt",
-        )?
-        else {
-            continue;
-        };
-        if receipt
-            .get("assignment_id")
-            .and_then(Value::as_str)
+        if training_retained_contribution_assignment_id(entry.path().as_path())?
+            .as_deref()
             .is_some_and(|value| value == assignment_id)
         {
             return Ok(Some(entry.path()));
@@ -11844,6 +12501,11 @@ fn inspect_training_retained_contribution_artifacts(
                 .join("checkpoints")
                 .join("latest_accepted_checkpoint_pointer.json")
         });
+    stabilize_training_retained_psionic_worker_contract(
+        contribution_root.as_path(),
+        contribution_receipt_path.as_path(),
+        artifact_manifest_path.as_path(),
+    )?;
 
     let Some(contribution_receipt) = load_training_json_artifact_value(
         contribution_receipt_path.as_path(),
@@ -16533,7 +17195,10 @@ async fn serve(config_path: &Path, config: PylonConfig) -> Result<()> {
                 && Instant::now() >= next_training_assignment_intake_at
             {
                 if let Err(error) = run_training_assignment_intake_once(&config, &identity).await {
-                    eprintln!("warning: automatic pylon training assignment intake failed: {error}");
+                    eprintln!(
+                        "warning: automatic pylon training assignment intake failed: {}",
+                        format_anyhow_error_chain(&error)
+                    );
                 } else {
                     let mut training_state = load_or_create_training_runtime_state(&config)?;
                     if drive_training_supervisor_once(
@@ -16548,7 +17213,8 @@ async fn serve(config_path: &Path, config: PylonConfig) -> Result<()> {
                         needs_sync = true;
                     }
                 }
-                next_training_assignment_intake_at = Instant::now() + training_assignment_intake_interval;
+                next_training_assignment_intake_at =
+                    Instant::now() + training_assignment_intake_interval;
             }
 
             if desired_mode == ProviderDesiredMode::Online
@@ -16564,7 +17230,9 @@ async fn serve(config_path: &Path, config: PylonConfig) -> Result<()> {
                 )
                 .await
                 {
-                    eprintln!("warning: failed to report pylon provider heartbeat to Nexus: {error}");
+                    eprintln!(
+                        "warning: failed to report pylon provider heartbeat to Nexus: {error}"
+                    );
                 } else {
                     provider_presence_online = true;
                 }
@@ -16584,7 +17252,9 @@ async fn serve(config_path: &Path, config: PylonConfig) -> Result<()> {
                 )
                 .await
                 {
-                    eprintln!("warning: failed to register pylon payout target with Nexus: {error}");
+                    eprintln!(
+                        "warning: failed to register pylon payout target with Nexus: {error}"
+                    );
                 }
                 next_provider_payout_target_sync_at =
                     Instant::now() + provider_payout_target_sync_interval;
@@ -21615,34 +22285,33 @@ mod tests {
         PylonTrainingActiveRuntimeState, PylonTrainingArtifactStoreClient,
         PylonTrainingAssignmentAckRequest, PylonTrainingCheckpointPublicationRequest,
         PylonTrainingCloseoutCacheEntry, PylonTrainingContributionOutcomeCacheEntry,
-        PylonTrainingCoordinatorClient, PylonTrainingDrainNoticeRequest,
-        PylonTrainingFailureNoticeRequest, PylonTrainingFailureReceipt,
-        PylonTrainingHeartbeatRequest, PylonTrainingLeaseCacheEntry,
+        PylonTrainingCoordinatorAck, PylonTrainingCoordinatorClient,
+        PylonTrainingDrainNoticeRequest, PylonTrainingFailureNoticeRequest,
+        PylonTrainingFailureReceipt, PylonTrainingHeartbeatRequest, PylonTrainingLeaseCacheEntry,
         PylonTrainingManifestCacheEntry, PylonTrainingNodeAdmissionRequest,
-        PylonTrainingPublicationPointer, PylonTrainingPublicationRecord, PylonTrainingPublicationTemplate,
-        PylonTrainingReputationLabelCacheEntry, PylonTrainingRoleClaim,
-        PylonTrainingRunLeaseRequest, PylonTrainingRuntimeState,
+        PylonTrainingPublicationPointer, PylonTrainingPublicationRecord,
+        PylonTrainingPublicationTemplate, PylonTrainingReputationLabelCacheEntry,
+        PylonTrainingRoleClaim, PylonTrainingRunLeaseRequest, PylonTrainingRuntimeState,
         PylonTrainingSupervisorCommand, PylonTrainingSupervisorDesiredState,
         PylonTrainingSupervisorProcessState, PylonTrainingSupervisorStartRequest,
-        PylonTrainingValidatorChallengeCoordinatorResponse, PylonTrainingValidatorTargetArtifactBinding,
-        PylonTrainingValidatorTargetAssignmentBinding, PylonTrainingWindowCacheEntry,
+        PylonTrainingValidatorChallengeCoordinatorResponse, PylonTrainingWindowCacheEntry,
         PylonTrainingWindowProgressRequest, PylonWalletCreditSummary, PylonWalletInvoiceRecord,
-        PylonWalletPaymentRecord, PylonTrainingCoordinatorAck, ReportContext,
-        TRN_TRAINING_NODE_RECORD_KIND, TRN_TRAINING_RECEIPT_KIND, TrainingArtifactsCommand,
-        TrainingCommand, TrainingOperatorStatusReport, TrainingTrnPublicationReport,
-        WalletAddressReport, WalletInvoiceReport, WalletRuntimeSurface, WalletSubcommand,
-        add_configured_relay, apply_config_set, apply_control_command,
-        apply_training_reputation_gate_to_availability, build_psionic_train_invocation_manifest,
-        build_pylon_training_admin_router, build_snapshot_from_availability, bytes_to_gib_ceil,
-        default_config, derive_adapter_training_contributor_availability,
-        derive_training_capability_tier_profile, detect_availability,
-        download_gemma_model_from_base_url, download_gemma_model_from_base_url_with_transport,
-        drain_training_supervisor, drive_training_supervisor_once, ensure_identity,
-        ensure_no_conflicting_training_assignment, garbage_collect_training_download_cache,
-        gemma_diagnostic_latest_report_path, gemma_download_spec, gemma_local_installations,
-        inspect_psionic_train_runtime_surface_at, inspect_psionic_train_runtime_surface_from_candidates,
-        inventory_rows, load_backend_report, load_earnings_report, load_inventory_report,
-        load_jobs_report, load_latest_gemma_diagnostic_report, load_ledger, load_or_create_config,
+        PylonWalletPaymentRecord, ReportContext, TRN_TRAINING_NODE_RECORD_KIND,
+        TRN_TRAINING_RECEIPT_KIND, TrainingArtifactsCommand, TrainingCommand,
+        TrainingOperatorStatusReport, TrainingTrnPublicationReport, WalletAddressReport,
+        WalletInvoiceReport, WalletRuntimeSurface, WalletSubcommand, add_configured_relay,
+        apply_config_set, apply_control_command, apply_training_reputation_gate_to_availability,
+        build_psionic_train_invocation_manifest, build_pylon_training_admin_router,
+        build_snapshot_from_availability, bytes_to_gib_ceil, default_config,
+        derive_adapter_training_contributor_availability, derive_training_capability_tier_profile,
+        detect_availability, download_gemma_model_from_base_url,
+        download_gemma_model_from_base_url_with_transport, drain_training_supervisor,
+        drive_training_supervisor_once, ensure_identity, ensure_no_conflicting_training_assignment,
+        garbage_collect_training_download_cache, gemma_diagnostic_latest_report_path,
+        gemma_download_spec, gemma_local_installations, inspect_psionic_train_runtime_surface_at,
+        inspect_psionic_train_runtime_surface_from_candidates, inventory_rows, load_backend_report,
+        load_earnings_report, load_inventory_report, load_jobs_report,
+        load_latest_gemma_diagnostic_report, load_ledger, load_or_create_config,
         load_or_create_training_runtime_state, load_product_report, load_receipts_report,
         load_relay_report, load_sandbox_report, load_status_or_detect,
         load_training_artifact_inspection_report, load_training_status_report_local,
@@ -21660,13 +22329,14 @@ mod tests {
         run_local_gemma_chat_messages_stream, run_local_gemma_chat_stream, run_provider_requests,
         run_training_assignment_intake_once_with_context, save_config,
         save_gemma_diagnostic_report, save_training_runtime_state, scan_provider_requests, serve,
-        snapshot_training_status_report, start_training_checkpoint_server,
-        start_training_supervisor, submit_buyer_job, sync_live_announcement,
-        sync_provider_payout_target_with_report, sync_training_authority_state,
-        sync_training_terminal_runtime_once, training_artifact_digest_from_locator_payload,
-        training_artifact_resolved_cache_key, training_download_cache_root,
-        training_run_root_for_id, training_runtime_state_path, training_settlement_destination,
-        watch_buyer_jobs,
+        snapshot_training_status_report, stabilize_training_retained_psionic_worker_contract,
+        start_training_checkpoint_server, start_training_supervisor, submit_buyer_job,
+        sync_live_announcement, sync_provider_payout_target_with_report,
+        sync_training_authority_state, sync_training_terminal_runtime_once,
+        training_artifact_digest_from_locator_payload, training_artifact_resolved_cache_key,
+        training_download_cache_root, training_raw_sha256_hex, training_run_root_for_id,
+        training_runtime_state_path, training_settlement_destination, watch_buyer_jobs,
+        write_training_json_value,
     };
     use futures_util::{SinkExt, StreamExt};
     use nostr::{NostrIdentity, TrnEvent};
@@ -21674,11 +22344,11 @@ mod tests {
         compute::{
             ComputeAcceptedOutcome, ComputeAdapterAggregationEligibility,
             ComputeAdapterCheckpointPointer, ComputeAdapterContributionDisposition,
-            ComputeAdapterContributionOutcome, ComputeAdapterDatasetSlice,
-            ComputeAdapterPolicyRevision, ComputeAdapterTrainingWindow, ComputeAdapterWindowStatus,
-            ComputeEnvironmentBinding, ComputeRegistryStatus, ComputeTrainingPolicy,
-            ComputeTrainingReplicaType, ComputeTrainingRun, ComputeTrainingRunStatus,
-            ComputeTrainingSummary, ComputeTrainingWorkClass,
+            ComputeAdapterContributionOutcome, ComputeAdapterContributionValidationReasonCode,
+            ComputeAdapterDatasetSlice, ComputeAdapterPolicyRevision, ComputeAdapterTrainingWindow,
+            ComputeAdapterWindowStatus, ComputeEnvironmentBinding, ComputeRegistryStatus,
+            ComputeTrainingPolicy, ComputeTrainingReplicaType, ComputeTrainingRun,
+            ComputeTrainingRunStatus, ComputeTrainingSummary, ComputeTrainingWorkClass,
         },
         compute_contracts,
         pylon_training::{
@@ -21715,6 +22385,7 @@ mod tests {
         PsionicTrainRole, PsionicTrainWorkClass,
     };
     use serde_json::{Value, json};
+    use sha2::{Digest, Sha256};
     use tempfile::tempdir;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
@@ -22491,6 +23162,15 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             })
             .to_string(),
         )?;
+        let checkpoint_manifest_path = local_run_root
+            .join("checkpoints")
+            .join("step-42")
+            .join("checkpoint_manifest.json");
+        let checkpoint_manifest_bytes = std::fs::read(checkpoint_manifest_path.as_path())?;
+        let checkpoint_manifest_raw_digest =
+            training_raw_sha256_hex(checkpoint_manifest_bytes.as_slice());
+        let checkpoint_manifest_raw_bytes =
+            u64::try_from(checkpoint_manifest_bytes.len()).unwrap_or(u64::MAX);
         std::fs::create_dir_all(local_run_root.join("status"))?;
         std::fs::write(
             local_run_root
@@ -22538,10 +23218,10 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                         "binding":{
                             "artifact_ref":{
                                 "artifact_id":"artifact.checkpoint.alpha",
-                                "artifact_digest":"sha256:checkpoint-alpha",
-                                "artifact_bytes":128
+                                "artifact_digest":checkpoint_manifest_raw_digest,
+                                "artifact_bytes":checkpoint_manifest_raw_bytes
                             },
-                            "materialized_path":local_run_root.join("checkpoints").join("step-42").join("checkpoint_manifest.json").display().to_string()
+                            "materialized_path":checkpoint_manifest_path.display().to_string()
                         }
                     }
                 ],
@@ -22572,10 +23252,10 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                         "binding":{
                             "artifact_ref":{
                                 "artifact_id":"artifact.checkpoint.alpha",
-                                "artifact_digest":"sha256:checkpoint-alpha",
-                                "artifact_bytes":128
+                                "artifact_digest":checkpoint_manifest_raw_digest,
+                                "artifact_bytes":checkpoint_manifest_raw_bytes
                             },
-                            "materialized_path":local_run_root.join("checkpoints").join("step-42").join("checkpoint_manifest.json").display().to_string()
+                            "materialized_path":checkpoint_manifest_path.display().to_string()
                         }
                     }
                 ],
@@ -22583,6 +23263,12 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             })
             .to_string(),
         )?;
+        let artifact_manifest_path = contribution_root.join("artifact_manifest.json");
+        let artifact_manifest_bytes = std::fs::read(artifact_manifest_path.as_path())?;
+        let artifact_manifest_raw_digest =
+            training_raw_sha256_hex(artifact_manifest_bytes.as_slice());
+        let artifact_manifest_raw_bytes =
+            u64::try_from(artifact_manifest_bytes.len()).unwrap_or(u64::MAX);
         std::fs::write(
             contribution_root.join("contribution_receipt.json"),
             json!({
@@ -22604,10 +23290,10 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                 "artifact_manifest":{
                     "artifact_ref":{
                         "artifact_id":"artifact.manifest.alpha",
-                        "artifact_digest":artifact_manifest_digest,
-                        "artifact_bytes":512
+                        "artifact_digest":artifact_manifest_raw_digest,
+                        "artifact_bytes":artifact_manifest_raw_bytes
                     },
-                    "materialized_path":contribution_root.join("artifact_manifest.json").display().to_string()
+                    "materialized_path":artifact_manifest_path.display().to_string()
                 },
                 "artifact_count":1,
                 "contribution_digest":"sha256:contribution-alpha",
@@ -22672,7 +23358,6 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                 .join(format!("checkpoint_manifest_step-{optimizer_step:06}.json")),
             manifest_payload.as_slice(),
         )?;
-        std::fs::remove_file(canonical_manifest_path)?;
         Ok(())
     }
 
@@ -24659,6 +25344,16 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                     "admitted": true,
                     "reason": null
                 }),
+                "/api/training/heartbeats" => json!({
+                    "ack": {
+                        "idempotency_key": "idemp.training.assignment_intake.heartbeat",
+                        "recorded_at_ms": 1_762_491_200_550_i64,
+                        "authority_state": "heartbeat_recorded"
+                    },
+                    "accepted": true,
+                    "admitted": true,
+                    "run_state": "active"
+                }),
                 "/api/training/leases/claim" => json!({
                     "ack": {
                         "idempotency_key": "idemp.training.assignment_intake.lease",
@@ -24890,9 +25585,10 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             .clone();
         ensure(
             counts.get("/api/training/nodes/admission") == Some(&1)
+                && counts.get("/api/training/heartbeats") == Some(&2)
                 && counts.get("/api/training/leases/claim") == Some(&1)
                 && counts.get("/api/training/assignments/ack") == Some(&1),
-            "training assignment intake should admit, claim, and acknowledge exactly once for one new lease",
+            "training assignment intake should admit, heartbeat, claim, and acknowledge exactly once for one new lease",
         )?;
         ensure(
             counts.get(
@@ -25455,6 +26151,113 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn training_assignment_intake_ignores_mismatched_network_lease()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.role_claims = vec![PylonTrainingRoleClaim::Worker];
+        config.training.allowed_networks = vec!["trainnet.expected".to_string()];
+        let identity = ensure_identity(config.identity_path.as_path())?;
+        let request_counts = Arc::new(Mutex::new(std::collections::BTreeMap::<String, u64>::new()));
+        let request_counts_for_server = Arc::clone(&request_counts);
+        let base_url = start_mock_http_server(move |method, path, _body| {
+            let mut counts = request_counts_for_server
+                .lock()
+                .expect("training mismatched-network request counts");
+            let count = counts.entry(path.clone()).or_insert(0);
+            *count += 1;
+            drop(counts);
+            if method != "POST" {
+                return (
+                    405,
+                    "application/json",
+                    json!({"error":"method_not_allowed","reason":method}).to_string(),
+                );
+            }
+            let response = match path.as_str() {
+                "/api/training/nodes/admission" => json!({
+                    "ack": {
+                        "idempotency_key": "idemp.training.mismatched-network.admission",
+                        "recorded_at_ms": 1_762_491_200_500_i64,
+                        "authority_state": "admitted"
+                    },
+                    "admission_id": "admission.alpha",
+                    "admitted": true,
+                    "reason": null
+                }),
+                "/api/training/heartbeats" => json!({
+                    "ack": {
+                        "idempotency_key": "idemp.training.mismatched-network.heartbeat",
+                        "recorded_at_ms": 1_762_491_200_550_i64,
+                        "authority_state": "idle"
+                    },
+                    "accepted": true,
+                    "admitted": true,
+                    "run_state": "idle"
+                }),
+                "/api/training/leases/claim" => json!({
+                    "ack": {
+                        "idempotency_key": "idemp.training.mismatched-network.lease",
+                        "recorded_at_ms": 1_762_491_200_600_i64,
+                        "authority_state": "leased"
+                    },
+                    "lease_id": "lease.node01.window0001",
+                    "training_run_id": "run.old",
+                    "window_id": "window.old.0001",
+                    "assignment_id": "assign.node01.window0001",
+                    "role": "worker",
+                    "issued_at_ms": 1_762_491_200_600_i64,
+                    "expires_at_ms": 1_762_491_260_600_i64,
+                    "manifest_digest": "sha256:manifest-alpha",
+                    "checkpoint_ref": "checkpoint://run.old/0001",
+                    "membership_revision": "members.rev2",
+                    "assignment_state": "leased",
+                    "window_state": "active",
+                    "network_id": "trainnet.other"
+                }),
+                "/api/training/assignments/ack" => {
+                    json!({"error":"unexpected_ack","reason":"mismatched lease should not be acked"})
+                }
+                _ => json!({"error":"unexpected_path","reason":path}),
+            };
+            (200, "application/json", response.to_string())
+        })
+        .await?;
+        config.training.nexus_authority_base_url = base_url;
+        save_config(config_path.as_path(), &config)?;
+
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        let host = training_host_snapshot(Some("NVIDIA H100 SXM5 80GB"), Some(80), Some(512), true);
+        let runtime_surface = psionic_train_runtime_surface_fixture();
+        run_training_assignment_intake_once_with_context(
+            &config,
+            &identity,
+            &mut state,
+            &host,
+            Some(&runtime_surface),
+        )
+        .await?;
+
+        ensure(
+            state.lease_cache.is_empty(),
+            "assignment intake should ignore a leased assignment whose network_id does not match the requested training network",
+        )?;
+
+        let counts = request_counts
+            .lock()
+            .expect("training mismatched-network request counts")
+            .clone();
+        ensure(
+            counts.get("/api/training/nodes/admission") == Some(&1)
+                && counts.get("/api/training/heartbeats") == Some(&1)
+                && counts.get("/api/training/leases/claim") == Some(&1)
+                && !counts.contains_key("/api/training/assignments/ack"),
+            "mismatched-network leases should not be acknowledged or materialized locally",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn training_assignment_intake_falls_back_to_direct_validator_challenge_claim()
     -> Result<(), Box<dyn std::error::Error>> {
         let training_run = training_run_fixture();
@@ -25466,8 +26269,10 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         config.training.validator_enabled = true;
         let identity = ensure_identity(config.identity_path.as_path())?;
         let run_root = training_run_root_for_id(&config, "run.alpha");
-        let mut manifest =
-            write_training_manifest_and_retained_contribution_artifacts(run_root.as_path(), "gs://bucket")?;
+        let mut manifest = write_training_manifest_and_retained_contribution_artifacts(
+            run_root.as_path(),
+            "gs://bucket",
+        )?;
         rewrite_training_checkpoint_manifest_to_bridge_shape(run_root.as_path(), 42)?;
         manifest.manifest_digest = manifest.canonical_digest()?;
         std::fs::write(
@@ -25509,11 +26314,16 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             .as_slice(),
         )?;
 
-        let run_manifest_payload = std::fs::read(run_root.join("manifests").join("run_manifest.json"))?;
+        let run_manifest_payload =
+            std::fs::read(run_root.join("manifests").join("run_manifest.json"))?;
         let latest_pointer_payload =
             std::fs::read(run_root.join("checkpoints").join("latest_pointer.json"))?;
-        let checkpoint_manifest_payload =
-            std::fs::read(run_root.join("checkpoints").join("step-0").join("checkpoint_manifest.json"))?;
+        let checkpoint_manifest_payload = std::fs::read(
+            run_root
+                .join("checkpoints")
+                .join("step-0")
+                .join("checkpoint_manifest.json"),
+        )?;
         let local_update_bridge_payload = serde_json::to_vec(&json!({
             "schema_version":"openagents.pylon_training.adapter_delta_bridge_bundle.v1",
             "source":{
@@ -25575,17 +26385,17 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         )?);
         checkpoint_manifest_resolver.size_bytes =
             Some(u64::try_from(checkpoint_manifest_payload.len()).unwrap_or(u64::MAX));
-        let challenge_scope = PylonTrainingArtifactScope {
+        let assignment_scope = PylonTrainingArtifactScope {
             network_id: "trainnet.alpha".to_string(),
             run_id: "run.alpha".to_string(),
             window_id: Some("window.0001".to_string()),
             assignment_id: Some("assign.node01.window0001".to_string()),
-            challenge_id: Some("challenge.alpha".to_string()),
+            challenge_id: None,
             optimizer_step: None,
         };
         let mut local_update_resolver = PylonTrainingArtifactResolverResponse::new(
             PylonTrainingArtifactKind::LocalUpdate,
-            challenge_scope.clone(),
+            assignment_scope.clone(),
         )
         .expect("local update resolver");
         local_update_resolver.digest = Some(training_artifact_digest_from_locator_payload(
@@ -25596,7 +26406,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             Some(u64::try_from(local_update_bridge_payload.len()).unwrap_or(u64::MAX));
         let mut proof_bridge_resolver = PylonTrainingArtifactResolverResponse::new(
             PylonTrainingArtifactKind::ProofBundle,
-            challenge_scope,
+            assignment_scope,
         )
         .expect("proof bridge resolver");
         proof_bridge_resolver.digest = Some(training_artifact_digest_from_locator_payload(
@@ -25611,6 +26421,8 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         let signed_base_url = Arc::new(Mutex::new(None::<String>));
         let signed_base_url_for_server = Arc::clone(&signed_base_url);
         let validator_public_key = identity.public_key_hex.clone();
+        let run_root_for_server = run_root.clone();
+        let contribution_root_for_server = contribution_root.clone();
         let run_manifest_resolver_for_server = run_manifest_resolver.clone();
         let latest_pointer_resolver_for_server = latest_pointer_resolver.clone();
         let checkpoint_manifest_resolver_for_server = checkpoint_manifest_resolver.clone();
@@ -25745,43 +26557,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                             ComputeAdapterWindowStatus::Sealed,
                         )),
                         contribution_outcomes: Vec::new(),
-                        target_bindings: vec![PylonTrainingValidatorTargetAssignmentBinding {
-                            assignment_id: "assign.node01.window0001".to_string(),
-                            training_run_id: "run.alpha".to_string(),
-                            window_id: "window.0001".to_string(),
-                            contributor_pylon_id: "node.alpha".to_string(),
-                            contribution_id: "contrib.node01.window0001".to_string(),
-                            work_class: "small_model_local_training".to_string(),
-                            challenge_kind: "aggregate".to_string(),
-                            claim_id: "challenge.alpha".to_string(),
-                            submission_receipt_digest: "sha256:receipt-alpha".to_string(),
-                            manifest_digest: "sha256:manifest-alpha".to_string(),
-                            object_digest: "sha256:contribution-alpha".to_string(),
-                            lane_type: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
-                            lease_expires_at_ms: Some(1_762_491_270_700),
-                            artifacts: vec![
-                                PylonTrainingValidatorTargetArtifactBinding {
-                                    artifact_role: "local_update_bridge".to_string(),
-                                    artifact_id: Some(local_update_resolver_for_server.artifact_id.clone()),
-                                    digest: local_update_resolver_for_server.digest.clone(),
-                                    object_uri: None,
-                                    local_path: None,
-                                    signed_read_url: None,
-                                    resolver: Some(local_update_resolver_for_server.clone()),
-                                    metadata: Value::Null,
-                                },
-                                PylonTrainingValidatorTargetArtifactBinding {
-                                    artifact_role: "proof_bridge".to_string(),
-                                    artifact_id: Some(proof_bridge_resolver_for_server.artifact_id.clone()),
-                                    digest: proof_bridge_resolver_for_server.digest.clone(),
-                                    object_uri: None,
-                                    local_path: None,
-                                    signed_read_url: None,
-                                    resolver: Some(proof_bridge_resolver_for_server.clone()),
-                                    metadata: Value::Null,
-                                },
-                            ],
-                        }],
+                        target_bindings: Vec::new(),
                     })
                     .expect("validator claim response"),
                 ),
@@ -25864,6 +26640,112 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                     "application/octet-stream",
                     String::from_utf8(proof_bridge_payload.clone()).expect("proof bridge utf8"),
                 ),
+                (
+                    "GET",
+                    "/v1/kernel/compute/training/adapter-contributions?training_run_id=run.alpha&window_id=window.0001",
+                ) => (
+                    200,
+                    "application/json",
+                    serde_json::to_string(
+                        &compute_contracts::list_compute_adapter_contribution_outcomes_response_to_proto(
+                            &[ComputeAdapterContributionOutcome {
+                                contribution_id: "contrib.node01.window0001".to_string(),
+                                training_run_id: "run.alpha".to_string(),
+                                stage_id: "stage.cs336.a1.prodproof".to_string(),
+                                window_id: "window.0001".to_string(),
+                                contributor_set_revision_id: "contributors.rev1".to_string(),
+                                assignment_id: "assign.node01.window0001".to_string(),
+                                contributor_node_id: "node.alpha".to_string(),
+                                worker_id: "worker.alpha".to_string(),
+                                validator_policy_ref: PYLON_TRAINING_VALIDATOR_POLICY_REF.to_string(),
+                                work_class: ComputeTrainingWorkClass::SmallModelLocalTraining,
+                                replica_type: ComputeTrainingReplicaType::SingleNode,
+                                base_checkpoint_ref: "checkpoint://run.alpha/0001".to_string(),
+                                adapter_target_id: "adapter.target.alpha".to_string(),
+                                adapter_family: PYLON_TRAINING_ADAPTER_FAMILY.to_string(),
+                                base_model_ref: "model://base.alpha".to_string(),
+                                adapter_format: PYLON_TRAINING_ADAPTER_FORMAT.to_string(),
+                                dataset_slice: ComputeAdapterDatasetSlice {
+                                    dataset_id: "dataset.alpha".to_string(),
+                                    split_name: "train".to_string(),
+                                    slice_id: "slice.alpha".to_string(),
+                                    slice_digest: "sha256:slice.alpha".to_string(),
+                                },
+                                source_policy_revision: ComputeAdapterPolicyRevision {
+                                    policy_family: "policy.family.alpha".to_string(),
+                                    revision_id: "policy.rev.alpha".to_string(),
+                                    policy_digest: "sha256:policy-rev-alpha".to_string(),
+                                    produced_at_ms: 1_762_491_200_000,
+                                    ..ComputeAdapterPolicyRevision::default()
+                                },
+                                source_checkpoint_pointer: ComputeAdapterCheckpointPointer {
+                                    scope_kind: "run".to_string(),
+                                    scope_id: "run.alpha".to_string(),
+                                    checkpoint_family: PYLON_TRAINING_CHECKPOINT_FAMILY.to_string(),
+                                    checkpoint_ref: "checkpoint://run.alpha/0001".to_string(),
+                                    manifest_digest: "sha256:manifest-alpha".to_string(),
+                                    updated_at_ms: 1_762_491_200_000,
+                                    pointer_digest: "sha256:pointer-alpha".to_string(),
+                                },
+                                submission_receipt_digest: "sha256:receipt-alpha".to_string(),
+                                artifact_id: "artifact.contrib.node01.window0001".to_string(),
+                                manifest_digest: "sha256:manifest-alpha".to_string(),
+                                object_digest: "sha256:contribution-alpha".to_string(),
+                                artifact_receipt_digest: "sha256:artifact-receipt-alpha".to_string(),
+                                provenance_bundle_digest: "sha256:provenance-alpha".to_string(),
+                                security_receipt_digest: "sha256:closeout-alpha".to_string(),
+                                replay_receipt_digest: None,
+                                validator_disposition: ComputeAdapterContributionDisposition::ReplayRequired,
+                                validation_reason_codes: vec![
+                                    ComputeAdapterContributionValidationReasonCode::ReplayRequired,
+                                ],
+                                validator_receipt_digest: "sha256:validator-pending-alpha".to_string(),
+                                aggregation_eligibility: ComputeAdapterAggregationEligibility::Eligible,
+                                accepted_for_aggregation: false,
+                                local_step_count: Some(42),
+                                consumed_token_count: Some(131_072),
+                                consumed_example_count: Some(256),
+                                aggregation_weight_basis: Some("tokens".to_string()),
+                                aggregation_weight_value: Some(131_072),
+                                aggregation_weight_bps: Some(10_000),
+                                promotion_receipt_digest: None,
+                                recorded_at_ms: 1_762_491_210_700,
+                                metadata: json!({
+                                    "normalized_contribution_contract": "retained_homework_lane.v1",
+                                    "lane_type": PSION_CS336_A1_DEMO_LANE_ID,
+                                    "work_class": "small_model_local_training",
+                                    "receipt": {
+                                        "path": contribution_root_for_server.join("contribution_receipt.json").display().to_string(),
+                                        "digest": "sha256:receipt-alpha",
+                                    },
+                                    "artifact_manifest": {
+                                        "path": contribution_root_for_server.join("artifact_manifest.json").display().to_string(),
+                                        "artifact_id": "artifact.manifest.contrib.node01.window0001",
+                                        "digest": "sha256:manifest-alpha",
+                                    },
+                                    "sealed_window_bundle": {
+                                        "path": run_root_for_server.join("windows").join("window.0001").join("sealed_window_bundle.json").display().to_string(),
+                                        "digest": "sha256:sealed-window-alpha",
+                                    },
+                                    "closeout_bundle": {
+                                        "path": run_root_for_server.join("closeout").join("closeout_bundle.json").display().to_string(),
+                                        "digest": "sha256:closeout-alpha",
+                                    },
+                                    "checkpoint_surface": {
+                                        "path": run_root_for_server.join("status").join("checkpoint_surface.json").display().to_string(),
+                                        "digest": "sha256:checkpoint-surface-alpha",
+                                    },
+                                    "latest_accepted_checkpoint_pointer": {
+                                        "path": run_root_for_server.join("checkpoints").join("latest_accepted_checkpoint_pointer.json").display().to_string(),
+                                        "digest": "sha256:latest-pointer-alpha",
+                                    }
+                                }),
+                            }],
+                        )
+                        .expect("validator fallback contribution proto"),
+                    )
+                    .expect("validator fallback contribution json"),
+                ),
                 _ => (
                     404,
                     "application/json",
@@ -25943,8 +26825,21 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             "challenge.alpha",
         )?;
         ensure(
-            claim_record.is_some(),
-            "validator fallback intake should persist the claimed challenge record for later finalize/reconcile",
+            claim_record.as_ref().is_some_and(|record| {
+                record.target_bindings.len() == 1
+                    && record.target_bindings.first().is_some_and(|binding| {
+                        binding.assignment_id == "assign.node01.window0001"
+                            && binding
+                                .artifacts
+                                .iter()
+                                .any(|artifact| artifact.artifact_role == "local_update_bridge")
+                            && binding
+                                .artifacts
+                                .iter()
+                                .any(|artifact| artifact.artifact_role == "proof_bridge")
+                    })
+            }),
+            "validator fallback intake should persist a synthesized challenge record with bridge bindings for later finalize/reconcile",
         )?;
         let counts = request_counts
             .lock()
@@ -25967,6 +26862,47 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         let temp_dir = tempfile::tempdir()?;
         let config_path = temp_dir.path().join("config.json");
         let config = load_or_create_config(config_path.as_path())?;
+        let peer_handoff_path = temp_dir
+            .path()
+            .join("run.alpha")
+            .join("status")
+            .join("peer_checkpoint_handoff_receipt.json");
+        let validator_receipt_path = temp_dir
+            .path()
+            .join("run.alpha")
+            .join("windows")
+            .join("window.0001")
+            .join("contributions")
+            .join("source")
+            .join("contribution_receipt.json");
+        let validator_manifest_path = temp_dir
+            .path()
+            .join("run.alpha")
+            .join("windows")
+            .join("window.0001")
+            .join("contributions")
+            .join("source")
+            .join("artifact_manifest.json");
+        std::fs::create_dir_all(peer_handoff_path.parent().expect("peer handoff parent"))?;
+        std::fs::create_dir_all(
+            validator_receipt_path
+                .parent()
+                .expect("validator receipt parent"),
+        )?;
+        std::fs::write(
+            peer_handoff_path.as_path(),
+            br#"{"schema_version":"peer.receipt.v1","checkpoint_ref":"checkpoint://run.alpha/0001"}"#,
+        )?;
+        let validator_receipt_payload = br#"{"schema_version":"psionic.train.contribution_receipt.v1","assignment_id":"assign.node01.window0001"}"#;
+        let validator_manifest_payload = br#"{"schema_version":"psionic.train.contribution_artifact_manifest.v1","assignment_id":"assign.node01.window0001"}"#;
+        std::fs::write(validator_receipt_path.as_path(), validator_receipt_payload)?;
+        std::fs::write(
+            validator_manifest_path.as_path(),
+            validator_manifest_payload,
+        )?;
+        let peer_handoff_path_string = peer_handoff_path.display().to_string();
+        let validator_receipt_path_string = validator_receipt_path.display().to_string();
+        let validator_receipt_digest = format!("{:x}", Sha256::digest(validator_receipt_payload));
 
         let mut lease = PylonTrainingLeaseCacheEntry {
             lease_id: "lease.node01.window0001".to_string(),
@@ -25982,9 +26918,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             network_id: Some("trainnet.alpha".to_string()),
             challenge_id: None,
             peer_node_pubkey: None,
-            peer_checkpoint_handoff_receipt_path: Some(
-                "/tmp/run.alpha/status/peer_checkpoint_handoff_receipt.json".to_string(),
-            ),
+            peer_checkpoint_handoff_receipt_path: Some(peer_handoff_path_string.clone()),
             validator_target_contribution_receipt_path: None,
             validator_target_contribution_artifact_manifest_path: None,
             validator_target_work_class: None,
@@ -26015,21 +26949,17 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                     .peer_checkpoint_handoff_receipt
                     .as_ref()
                     .and_then(|binding| binding.materialized_path.as_deref())
-                    == Some("/tmp/run.alpha/status/peer_checkpoint_handoff_receipt.json"),
+                    == Some(peer_handoff_path_string.as_str()),
             "recovery-source leases with peer handoff input should map to psionic-train resume manifests",
         )?;
 
         lease.role = PylonTrainingRoleClaim::Validator;
         lease.challenge_id = Some("challenge.alpha".to_string());
         lease.peer_checkpoint_handoff_receipt_path = None;
-        lease.validator_target_contribution_receipt_path = Some(
-            "/tmp/run.alpha/windows/window.0001/contributions/source/contribution_receipt.json"
-                .to_string(),
-        );
-        lease.validator_target_contribution_artifact_manifest_path = Some(
-            "/tmp/run.alpha/windows/window.0001/contributions/source/artifact_manifest.json"
-                .to_string(),
-        );
+        lease.validator_target_contribution_receipt_path =
+            Some(validator_receipt_path_string.clone());
+        lease.validator_target_contribution_artifact_manifest_path =
+            Some(validator_manifest_path.display().to_string());
         lease.validator_target_work_class = Some(ComputeTrainingWorkClass::AdapterTraining);
         let (validator_manifest, _) = build_psionic_train_invocation_manifest(
             &config,
@@ -26048,9 +26978,17 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                     .validator_target_contribution_receipt
                     .as_ref()
                     .and_then(|binding| binding.materialized_path.as_deref())
-                    == Some(
-                        "/tmp/run.alpha/windows/window.0001/contributions/source/contribution_receipt.json",
-                    )
+                    == Some(validator_receipt_path_string.as_str())
+                && validator_manifest
+                    .validator_target_contribution_receipt
+                    .as_ref()
+                    .and_then(|binding| binding.artifact_ref.artifact_bytes)
+                    == Some(validator_receipt_payload.len() as u64)
+                && validator_manifest
+                    .validator_target_contribution_receipt
+                    .as_ref()
+                    .and_then(|binding| binding.artifact_ref.artifact_digest.as_deref())
+                    == Some(validator_receipt_digest.as_str())
                 && validator_manifest.validator_target_work_class
                     == Some(PsionicTrainWorkClass::AdapterTraining),
             "validator leases should map replay target inputs into the psionic-train machine manifest",
@@ -26123,6 +27061,190 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
     }
 
     #[test]
+    fn stabilize_training_retained_psionic_worker_contract_snapshots_mutable_artifacts()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let contribution_root = temp_dir.path().join("contribution");
+        let run_root = temp_dir.path().join("run");
+        std::fs::create_dir_all(contribution_root.as_path())?;
+        std::fs::create_dir_all(run_root.join("status").as_path())?;
+        std::fs::create_dir_all(run_root.join("logs").as_path())?;
+
+        let checkpoint_surface_path = run_root.join("status").join("checkpoint_surface.json");
+        let launcher_log_path = run_root.join("logs").join("launcher.log");
+        std::fs::write(
+            checkpoint_surface_path.as_path(),
+            br#"{"schema_version":"psionic.train.checkpoint_surface.v1","checkpoint_ref":"checkpoint://alpha"}"#,
+        )?;
+        std::fs::write(
+            launcher_log_path.as_path(),
+            b"phase=launch_manifest_written\nphase=complete\n",
+        )?;
+
+        let checkpoint_surface_bytes = std::fs::read(checkpoint_surface_path.as_path())?;
+        let launcher_log_bytes = std::fs::read(launcher_log_path.as_path())?;
+        let checkpoint_surface_digest =
+            training_raw_sha256_hex(checkpoint_surface_bytes.as_slice());
+        let launcher_log_digest = training_raw_sha256_hex(launcher_log_bytes.as_slice());
+
+        let artifact_manifest_path = contribution_root.join("artifact_manifest.json");
+        let artifact_manifest = json!({
+            "schema_version": "psionic.train.contribution_artifact_manifest.v1",
+            "lane_id": "psion_cs336_a1_demo_v1",
+            "work_class": "small_model_local_training",
+            "run_id": "run.alpha",
+            "window_id": "window.alpha",
+            "assignment_id": "assign.alpha",
+            "contribution_id": "contrib.alpha",
+            "node_pubkey": "11".repeat(32),
+            "grouped_stage_assignment": null,
+            "artifact_count": 2,
+            "artifacts": [
+                {
+                    "artifact_kind": "checkpoint_surface",
+                    "binding": {
+                        "artifact_ref": {
+                            "artifact_id": "artifact.checkpoint_surface",
+                            "artifact_digest": checkpoint_surface_digest,
+                            "artifact_bytes": checkpoint_surface_bytes.len()
+                        },
+                        "materialized_path": checkpoint_surface_path.display().to_string()
+                    }
+                },
+                {
+                    "artifact_kind": "launcher_log",
+                    "binding": {
+                        "artifact_ref": {
+                            "artifact_id": "artifact.launcher_log",
+                            "artifact_digest": launcher_log_digest,
+                            "artifact_bytes": launcher_log_bytes.len()
+                        },
+                        "materialized_path": launcher_log_path.display().to_string()
+                    }
+                }
+            ],
+            "artifact_manifest_digest": "stable-artifact-manifest-digest"
+        });
+        write_training_json_value(
+            artifact_manifest_path.as_path(),
+            &artifact_manifest,
+            "training contribution artifact manifest",
+        )?;
+        let initial_artifact_manifest_bytes = std::fs::read(artifact_manifest_path.as_path())?;
+
+        let contribution_receipt_path = contribution_root.join("contribution_receipt.json");
+        let contribution_receipt = json!({
+            "schema_version": "psionic.train.contribution_receipt.v1",
+            "lane_id": "psion_cs336_a1_demo_v1",
+            "work_class": "small_model_local_training",
+            "run_id": "run.alpha",
+            "window_id": "window.alpha",
+            "assignment_id": "assign.alpha",
+            "contribution_id": "contrib.alpha",
+            "node_pubkey": "11".repeat(32),
+            "artifact_manifest": {
+                "artifact_ref": {
+                    "artifact_id": "artifact.manifest",
+                    "artifact_digest": training_raw_sha256_hex(initial_artifact_manifest_bytes.as_slice()),
+                    "artifact_bytes": initial_artifact_manifest_bytes.len()
+                },
+                "materialized_path": artifact_manifest_path.display().to_string()
+            },
+            "artifact_manifest_digest": "stable-artifact-manifest-digest",
+            "artifact_count": 2
+        });
+        write_training_json_value(
+            contribution_receipt_path.as_path(),
+            &contribution_receipt,
+            "training contribution receipt",
+        )?;
+        write_training_json_value(
+            contribution_root
+                .join("adapter_delta_bundle.json")
+                .as_path(),
+            &json!({
+                "source": {
+                    "contribution_receipt_path": contribution_receipt_path.display().to_string(),
+                    "contribution_receipt_digest": "sha256:receipt-initial",
+                    "contribution_receipt": contribution_receipt.clone()
+                }
+            }),
+            "training local-update bridge bundle",
+        )?;
+        write_training_json_value(
+            contribution_root.join("proof_bundle.json").as_path(),
+            &json!({
+                "source": {
+                    "artifact_manifest_path": artifact_manifest_path.display().to_string(),
+                    "artifact_manifest_digest": "sha256:manifest-initial",
+                    "artifact_manifest": artifact_manifest.clone(),
+                    "contribution_receipt_path": contribution_receipt_path.display().to_string(),
+                    "contribution_receipt_digest": "sha256:receipt-initial",
+                    "contribution_receipt": contribution_receipt.clone(),
+                    "checkpoint_surface_path": checkpoint_surface_path.display().to_string()
+                }
+            }),
+            "training proof bridge bundle",
+        )?;
+
+        stabilize_training_retained_psionic_worker_contract(
+            contribution_root.as_path(),
+            contribution_receipt_path.as_path(),
+            artifact_manifest_path.as_path(),
+        )?;
+
+        let stabilized_manifest: Value =
+            serde_json::from_slice(std::fs::read(artifact_manifest_path.as_path())?.as_slice())?;
+        let stabilized_receipt: Value =
+            serde_json::from_slice(std::fs::read(contribution_receipt_path.as_path())?.as_slice())?;
+        let stabilized_proof_bundle: Value = serde_json::from_slice(
+            std::fs::read(contribution_root.join("proof_bundle.json").as_path())?.as_slice(),
+        )?;
+        let checkpoint_surface_snapshot =
+            stabilized_manifest["artifacts"][0]["binding"]["materialized_path"]
+                .as_str()
+                .expect("checkpoint surface snapshot path")
+                .to_string();
+        let launcher_log_snapshot =
+            stabilized_manifest["artifacts"][1]["binding"]["materialized_path"]
+                .as_str()
+                .expect("launcher log snapshot path")
+                .to_string();
+        let contribution_root_string = contribution_root.display().to_string();
+        ensure(
+            checkpoint_surface_snapshot.starts_with(contribution_root_string.as_str())
+                && launcher_log_snapshot.starts_with(contribution_root_string.as_str()),
+            "stabilized artifact manifest should rewrite mutable artifact paths under the contribution root",
+        )?;
+        std::fs::write(
+            checkpoint_surface_path.as_path(),
+            br#"{"schema_version":"psionic.train.checkpoint_surface.v1","checkpoint_ref":"checkpoint://mutated"}"#,
+        )?;
+        std::fs::write(launcher_log_path.as_path(), b"phase=mutated\n")?;
+        ensure(
+            std::fs::read(Path::new(checkpoint_surface_snapshot.as_str()))?
+                == checkpoint_surface_bytes
+                && std::fs::read(Path::new(launcher_log_snapshot.as_str()))? == launcher_log_bytes,
+            "stabilized contribution artifacts should stay frozen after the original run-root files mutate",
+        )?;
+        let stabilized_manifest_bytes = std::fs::read(artifact_manifest_path.as_path())?;
+        let stabilized_manifest_digest =
+            training_raw_sha256_hex(stabilized_manifest_bytes.as_slice());
+        let artifact_manifest_path_string = artifact_manifest_path.display().to_string();
+        ensure(
+            stabilized_receipt["artifact_manifest"]["materialized_path"].as_str()
+                == Some(artifact_manifest_path_string.as_str())
+                && stabilized_receipt["artifact_manifest"]["artifact_ref"]["artifact_digest"]
+                    .as_str()
+                    == Some(stabilized_manifest_digest.as_str())
+                && stabilized_proof_bundle["source"]["artifact_manifest"]["artifacts"][0]["binding"]
+                    ["materialized_path"]
+                    .as_str() == Some(checkpoint_surface_snapshot.as_str()),
+            "stabilized receipt and proof bundle should point at the rewritten contribution-local artifact manifest",
+        )
+    }
+
+    #[test]
     fn parse_args_supports_training_artifact_commands() -> Result<(), Box<dyn std::error::Error>> {
         ensure(
             parse_args(vec![
@@ -26191,6 +27313,34 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                     command: TrainingCommand::Sync { json: true },
                 },
             "training sync should parse json output selection",
+        )
+    }
+
+    #[test]
+    fn parse_args_supports_training_intake_command() -> Result<(), Box<dyn std::error::Error>> {
+        ensure(
+            parse_args(vec![
+                "training".to_string(),
+                "intake".to_string(),
+                "--json".to_string(),
+            ])?
+            .command
+                == Command::Training {
+                    command: TrainingCommand::Intake { json: true },
+                },
+            "training intake should parse json output selection",
+        )
+    }
+
+    #[test]
+    fn training_artifact_resolved_cache_key_is_bounded_for_long_ids()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let cache_key = training_artifact_resolved_cache_key(
+            "oa.train_artifact.v1~kind~local_update~network~trainnet.cs336.a1.4368proof~run~run.cs336.a1.iso.20260417104257~window~window.cs336.a1.iso.20260417104257.0001~assignment~assign.run.cs336.a1.iso.20260417104257.window.cs336.a1.iso.20260417104257.0001.worker.1.attempt1",
+        );
+        ensure(
+            cache_key.len() < 64 && cache_key.starts_with("oa_train_artifact_"),
+            "resolved training artifact cache keys should stay comfortably below common filesystem filename limits",
         )
     }
 
@@ -26487,7 +27637,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             .upload_bundle(
                 &manifest,
                 PylonTrainingArtifactBundleKind::Contribution {
-                    assignment_id: "contrib.node01.window0001".to_string(),
+                    assignment_id: "assign.node01.window0001".to_string(),
                 },
             )
             .await?;
@@ -26507,13 +27657,13 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             .clone();
         let adapter_delta_bundle: Value = serde_json::from_slice(
             stored
-                .get("/bucket/networks/trainnet.alpha/runs/run.alpha/windows/window.0001/contributions/contrib.node01.window0001/adapter_delta_bundle.json")
+                .get("/bucket/networks/trainnet.alpha/runs/run.alpha/windows/window.0001/contributions/assign.node01.window0001/adapter_delta_bundle.json")
                 .ok_or_else(|| std::io::Error::other("expected uploaded adapter-delta bridge bundle"))?
                 .as_slice(),
         )?;
         let proof_bundle: Value = serde_json::from_slice(
             stored
-                .get("/bucket/networks/trainnet.alpha/runs/run.alpha/windows/window.0001/contributions/contrib.node01.window0001/proof_bundle.json")
+                .get("/bucket/networks/trainnet.alpha/runs/run.alpha/windows/window.0001/contributions/assign.node01.window0001/proof_bundle.json")
                 .ok_or_else(|| std::io::Error::other("expected uploaded proof bridge bundle"))?
                 .as_slice(),
         )?;
@@ -26527,6 +27677,118 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                         super::PYLON_TRAINING_PROOF_BUNDLE_BRIDGE_SCHEMA_VERSION
                     )),
             "uploaded retained contribution bundles should carry explicit bridge schemas instead of pretending the old adapter/proof payloads still exist",
+        )
+    }
+
+    #[test]
+    fn training_artifact_inspection_discovers_retained_contribution_bundle_by_assignment_id()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let _env_lock = training_env_lock();
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        save_config(config_path.as_path(), &config)?;
+
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        let _manifest = write_training_manifest_and_retained_contribution_artifacts(
+            local_run_root.as_path(),
+            "gs://bucket",
+        )?;
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        state.active_runtime = Some(PylonTrainingActiveRuntimeState {
+            manifest_path: local_run_root
+                .join("manifests")
+                .join("run_manifest.json")
+                .display()
+                .to_string(),
+            run_root: local_run_root.display().to_string(),
+            ..training_active_runtime_fixture()
+        });
+        save_training_runtime_state(&config, &state)?;
+
+        let report = load_training_artifact_inspection_report(config_path.as_path())?;
+        ensure(
+            report.bundles.iter().any(|bundle| {
+                bundle.bundle_id == "contribution:assign.node01.window0001"
+                    && bundle.objects.len() == 2
+                    && bundle.objects.iter().all(|object| object.present)
+            }),
+            "retained contribution discovery should key bridge bundle inspection by assignment_id even when the local directory is keyed by contribution_id",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn training_artifact_courier_accepts_explicit_bearer_token_without_adc()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let _env_lock = training_env_lock();
+        let stored_objects = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<u8>>::new(),
+        ));
+        let stored_objects_for_server = Arc::clone(&stored_objects);
+        let base_url = start_mock_http_server(move |method, path, body| match method.as_str() {
+            "PUT" => {
+                stored_objects_for_server
+                    .lock()
+                    .expect("token-only object store")
+                    .insert(path.clone(), body.into_bytes());
+                (200, "application/json", json!({"ok": true}).to_string())
+            }
+            "GET" => {
+                let payload = stored_objects_for_server
+                    .lock()
+                    .expect("token-only object store")
+                    .get(path.as_str())
+                    .cloned()
+                    .unwrap_or_else(|| b"{}".to_vec());
+                (
+                    200,
+                    "application/json",
+                    String::from_utf8(payload).expect("stored token-only object should stay utf8"),
+                )
+            }
+            _ => (
+                405,
+                "application/json",
+                json!({"error":"method_not_allowed"}).to_string(),
+            ),
+        })
+        .await?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        save_config(config_path.as_path(), &config)?;
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        let manifest =
+            write_training_manifest_and_artifacts(local_run_root.as_path(), "gs://bucket")?;
+        let _env = TrainingEnvGuard::set(&[
+            (ENV_TRAINING_GCS_ENDPOINT, base_url),
+            (ENV_TRAINING_GCS_BEARER_TOKEN, "token.alpha".to_string()),
+            (ENV_GOOGLE_APPLICATION_CREDENTIALS, String::new()),
+            ("GCE_METADATA_HOST", String::new()),
+            ("GCE_METADATA_IP", String::new()),
+        ]);
+
+        let client = PylonTrainingArtifactStoreClient::new(&config).await?;
+        let report = client
+            .upload_bundle(
+                &manifest,
+                PylonTrainingArtifactBundleKind::CheckpointManifest { optimizer_step: 42 },
+            )
+            .await?;
+
+        ensure(
+            report.state == "uploaded"
+                && report.objects.len() == 1
+                && stored_objects
+                    .lock()
+                    .expect("token-only object store")
+                    .contains_key(
+                        "/bucket/networks/trainnet.alpha/runs/run.alpha/checkpoints/step-42/checkpoint_manifest.json",
+                    ),
+            "explicit GCS bearer tokens should be sufficient for the artifact courier even when no ADC path or metadata source is present",
         )
     }
 
@@ -27527,6 +28789,320 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         ensure(
             counts_after_second == counts,
             "terminal sync should not re-seal a window after recording the first successful seal receipt",
+        )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn training_authority_sync_drives_terminal_closeout_before_refreshing_caches()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let _env_lock = training_env_lock();
+        let relay = TestPublishRelay::spawn();
+        let stored_objects = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<u8>>::new(),
+        ));
+        let stored_objects_for_server = Arc::clone(&stored_objects);
+        let gcs_base_url = start_mock_http_server(move |method, path, body| {
+            let mut objects = stored_objects_for_server
+                .lock()
+                .expect("training authority-sync object store");
+            match method.as_str() {
+                "PUT" => {
+                    objects.insert(path.clone(), body.into_bytes());
+                    (200, "application/json", json!({"ok": true}).to_string())
+                }
+                "GET" => match objects.get(path.as_str()) {
+                    Some(payload) => (
+                        200,
+                        "application/octet-stream",
+                        String::from_utf8(payload.clone()).expect("stored object utf8"),
+                    ),
+                    None => (
+                        404,
+                        "application/json",
+                        json!({"error":"missing"}).to_string(),
+                    ),
+                },
+                _ => (
+                    405,
+                    "application/json",
+                    json!({"error":"method_not_allowed"}).to_string(),
+                ),
+            }
+        })
+        .await?;
+
+        let request_counts = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, usize>::new(),
+        ));
+        let request_bodies = Arc::new(Mutex::new(
+            std::collections::BTreeMap::<String, Vec<Value>>::new(),
+        ));
+        let request_counts_for_server = Arc::clone(&request_counts);
+        let request_bodies_for_server = Arc::clone(&request_bodies);
+        let sealed_window = training_adapter_window_fixture(ComputeAdapterWindowStatus::Sealed);
+        let sealed_window_response =
+            serde_json::to_string(&super::PylonTrainingWindowCoordinatorResponse {
+                window: sealed_window.clone(),
+                contribution_outcomes: Vec::new(),
+            })?;
+        let nexus_base_url = start_mock_http_server(move |method, path, body| {
+            *request_counts_for_server
+                .lock()
+                .expect("training authority-sync request counts")
+                .entry(path.clone())
+                .or_default() += 1;
+            if method == "POST" {
+                let payload: Value = serde_json::from_str(body.as_str())
+                    .expect("training authority-sync request payload");
+                request_bodies_for_server
+                    .lock()
+                    .expect("training authority-sync request bodies")
+                    .entry(path.clone())
+                    .or_default()
+                    .push(payload);
+            }
+            match (method.as_str(), path.as_str()) {
+                ("POST", "/api/training/windows/progress") => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "window-progress-success",
+                            "recorded_at_ms": 1_762_491_330_100_i64,
+                            "authority_state": "window_progress_recorded"
+                        },
+                        "window_state": "sealing"
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/api/training/checkpoints/publish") => (
+                    200,
+                    "application/json",
+                    json!({
+                        "ack": {
+                            "idempotency_key": "checkpoint-publication-success",
+                            "recorded_at_ms": 1_762_491_330_200_i64,
+                            "authority_state": "checkpoint_published"
+                        },
+                        "checkpoint_state": "published",
+                        "artifact_locator": "gs://bucket/networks/trainnet.alpha/runs/run.alpha/checkpoints/step-42/checkpoint_manifest.json"
+                    })
+                    .to_string(),
+                ),
+                ("POST", "/api/training/windows/window.0001/seal") => {
+                    (200, "application/json", sealed_window_response.clone())
+                }
+                ("GET", "/v1/kernel/compute/training/adapter-windows/window.0001") => (
+                    200,
+                    "application/json",
+                    serde_json::to_string(
+                        &compute_contracts::get_compute_adapter_training_window_response_to_proto(
+                            &sealed_window,
+                        )
+                        .expect("window proto"),
+                    )
+                    .expect("window json"),
+                ),
+                (
+                    "GET",
+                    "/v1/kernel/compute/training/adapter-windows?training_run_id=run.alpha",
+                ) => (
+                    200,
+                    "application/json",
+                    serde_json::to_string(
+                        &compute_contracts::list_compute_adapter_training_windows_response_to_proto(
+                            std::slice::from_ref(&sealed_window),
+                        )
+                        .expect("window list proto"),
+                    )
+                    .expect("window list json"),
+                ),
+                (
+                    "GET",
+                    "/v1/kernel/compute/training/adapter-contributions?training_run_id=run.alpha&window_id=window.0001",
+                ) => (
+                    200,
+                    "application/json",
+                    serde_json::to_string(
+                        &compute_contracts::list_compute_adapter_contribution_outcomes_response_to_proto(
+                            &[],
+                        )
+                        .expect("contribution list proto"),
+                    )
+                    .expect("contribution list json"),
+                ),
+                (
+                    "GET",
+                    "/v1/kernel/compute/outcomes?outcome_kind=training_run&environment_ref=env.openagents.cuda.train",
+                ) => (
+                    200,
+                    "application/json",
+                    serde_json::to_string(
+                        &compute_contracts::list_compute_accepted_outcomes_response_to_proto(&[])
+                            .expect("accepted outcome list proto"),
+                    )
+                    .expect("accepted outcome list json"),
+                ),
+                _ => (
+                    404,
+                    "application/json",
+                    json!({"error":"not_found","reason":path}).to_string(),
+                ),
+            }
+        })
+        .await?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let mut config = load_or_create_config(config_path.as_path())?;
+        config.training.run_root = temp_dir.path().join("training");
+        config.training.relay_urls = vec![relay.url.clone()];
+        config.training.nexus_authority_base_url = nexus_base_url;
+        config.relay_auth_enabled = false;
+        save_config(config_path.as_path(), &config)?;
+
+        let local_run_root = config.training.run_root.join("runs").join("run.alpha");
+        let mut manifest = write_training_manifest_and_retained_contribution_artifacts(
+            local_run_root.as_path(),
+            "gs://bucket",
+        )?;
+        rewrite_training_checkpoint_manifest_to_bridge_shape(local_run_root.as_path(), 42)?;
+        manifest.trn.relay_urls = vec![relay.url.clone()];
+        manifest.manifest_digest = manifest.canonical_digest()?;
+        std::fs::write(
+            local_run_root.join("manifests").join("run_manifest.json"),
+            manifest.canonical_json_bytes()?,
+        )?;
+        let invocation_manifest_path = local_run_root
+            .join("manifests")
+            .join("invocation_manifest.json");
+        std::fs::write(
+            invocation_manifest_path.as_path(),
+            "{\"schema_version\":\"psionic.train.invocation_manifest.v1\"}\n",
+        )?;
+        write_training_terminal_status_packets(
+            local_run_root.as_path(),
+            "succeeded",
+            0,
+            None,
+            Some("completed"),
+            "completed window",
+        )?;
+
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        let mut active_runtime = training_active_runtime_fixture();
+        active_runtime.manifest_path = invocation_manifest_path.display().to_string();
+        active_runtime.run_root = local_run_root.display().to_string();
+        active_runtime.process_state = PylonTrainingSupervisorProcessState::Stopped;
+        active_runtime.desired_state = PylonTrainingSupervisorDesiredState::Running;
+        active_runtime.last_exit_code = Some(0);
+        active_runtime.failure_receipt_path = None;
+        active_runtime.last_failure_reason = None;
+        state.active_runtime = Some(active_runtime);
+        state.lease_cache.insert(
+            "lease.node01.window0001".to_string(),
+            PylonTrainingLeaseCacheEntry {
+                lease_id: "lease.node01.window0001".to_string(),
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                membership_revision: "members.rev1".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                state: "active".to_string(),
+                manifest_digest: Some(manifest.manifest_digest.clone()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                expires_at_ms: Some(1_762_491_360_000),
+                network_id: Some("trainnet.alpha".to_string()),
+                challenge_id: None,
+                peer_node_pubkey: None,
+                peer_checkpoint_handoff_receipt_path: None,
+                validator_target_contribution_receipt_path: None,
+                validator_target_contribution_artifact_manifest_path: None,
+                validator_target_work_class: None,
+                grouped_stage_input_transport_path: None,
+                runtime_manifest_path: Some(invocation_manifest_path.display().to_string()),
+                runtime_manifest_digest: Some(manifest.manifest_digest.clone()),
+                runtime_lane_id: Some(PSION_CS336_A1_DEMO_LANE_ID.to_string()),
+                runtime_operation: Some("start".to_string()),
+                runtime_work_class: Some("small_model_local_training".to_string()),
+                updated_at_ms: now_epoch_ms(),
+            },
+        );
+        save_training_runtime_state(&config, &state)?;
+
+        let _env = TrainingEnvGuard::set(&[
+            (ENV_TRAINING_GCS_ENDPOINT, gcs_base_url),
+            (ENV_TRAINING_GCS_BEARER_TOKEN, "token.alpha".to_string()),
+            (ENV_GOOGLE_APPLICATION_CREDENTIALS, String::new()),
+            ("GCE_METADATA_HOST", String::new()),
+            ("GCE_METADATA_IP", String::new()),
+        ]);
+
+        let report = sync_training_authority_state(config_path.as_path()).await?;
+        ensure(
+            report.manifest_count == 1
+                && report.contribution_outcome_count == 0
+                && report.closeout_count == 0
+                && report.reputation_label_count == 0,
+            "training authority sync should still return the cache refresh summary after driving the terminal closeout path",
+        )?;
+
+        let synced_state = load_or_create_training_runtime_state(&config)?;
+        ensure(
+            synced_state
+                .authority_receipt_records
+                .get("window_seal::window.0001")
+                .is_some_and(|record| !record.pending_retry)
+                && synced_state
+                    .closeout_progress
+                    .get("assign.node01.window0001")
+                    .is_some_and(|entry| {
+                        entry.stage == super::PylonTrainingCloseoutStage::WindowSealed
+                            && entry.checkpoint_ref.as_deref()
+                                == Some("checkpoint://run.alpha/0042")
+                    }),
+            "training authority sync should run the same retained worker closeout chain as the serve loop before refreshing authority caches",
+        )?;
+
+        let counts = request_counts
+            .lock()
+            .expect("training authority-sync request counts")
+            .clone();
+        ensure(
+            counts.get("/api/training/windows/progress") == Some(&1)
+                && counts.get("/api/training/checkpoints/publish") == Some(&1)
+                && counts.get("/api/training/windows/window.0001/seal") == Some(&1),
+            "training authority sync should issue the retained progress, checkpoint publication, and seal authority writes instead of behaving like a cache-only no-op",
+        )?;
+
+        ensure(
+            sync_training_authority_state(config_path.as_path())
+                .await?
+                .manifest_count
+                == 1,
+            "a second authority sync should remain callable after the terminal closeout receipts are recorded",
+        )?;
+        let counts_after_second = request_counts
+            .lock()
+            .expect("training authority-sync request counts after second pass")
+            .clone();
+        ensure(
+            counts_after_second.get("/api/training/windows/progress") == Some(&1)
+                && counts_after_second.get("/api/training/checkpoints/publish") == Some(&1)
+                && counts_after_second.get("/api/training/windows/window.0001/seal") == Some(&1),
+            "recorded closeout receipts should dedupe across later training authority sync passes",
+        )?;
+
+        let bodies = request_bodies
+            .lock()
+            .expect("training authority-sync request bodies")
+            .clone();
+        ensure(
+            bodies
+                .get("/api/training/windows/window.0001/seal")
+                .and_then(|entries| entries.first())
+                .is_some_and(|payload| payload.get("window_id") == Some(&json!("window.0001"))),
+            "training authority sync should carry the normal worker closeout payload through the seal route",
         )
     }
 

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -398,6 +398,8 @@ pub struct PylonTrainingRuntimeState {
     pub closeout_cache: BTreeMap<String, PylonTrainingCloseoutCacheEntry>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub closeout_progress: BTreeMap<String, PylonTrainingCloseoutProgressEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub closeout_journal: Vec<PylonTrainingCloseoutJournalEntry>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub reputation_labels: BTreeMap<String, PylonTrainingReputationLabelCacheEntry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -418,9 +420,154 @@ impl Default for PylonTrainingRuntimeState {
             contribution_outcomes: BTreeMap::new(),
             closeout_cache: BTreeMap::new(),
             closeout_progress: BTreeMap::new(),
+            closeout_journal: Vec::new(),
             reputation_labels: BTreeMap::new(),
             last_authority_sync_at_ms: None,
         }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingExecutionCacheState {
+    #[serde(default = "default_training_runtime_state_schema_version")]
+    pub schema_version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_runtime: Option<PylonTrainingActiveRuntimeState>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub manifest_cache: BTreeMap<String, PylonTrainingManifestCacheEntry>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub lease_cache: BTreeMap<String, PylonTrainingLeaseCacheEntry>,
+}
+
+impl Default for PylonTrainingExecutionCacheState {
+    fn default() -> Self {
+        Self {
+            schema_version: default_training_runtime_state_schema_version(),
+            active_runtime: None,
+            manifest_cache: BTreeMap::new(),
+            lease_cache: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingArtifactCacheState {
+    #[serde(default = "default_training_runtime_state_schema_version")]
+    pub schema_version: u32,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub publication_pointers: BTreeMap<String, PylonTrainingPublicationPointer>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub publication_records: BTreeMap<String, PylonTrainingPublicationRecord>,
+}
+
+impl Default for PylonTrainingArtifactCacheState {
+    fn default() -> Self {
+        Self {
+            schema_version: default_training_runtime_state_schema_version(),
+            publication_pointers: BTreeMap::new(),
+            publication_records: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingAuthoritySyncCacheState {
+    #[serde(default = "default_training_runtime_state_schema_version")]
+    pub schema_version: u32,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub window_cache: BTreeMap<String, PylonTrainingWindowCacheEntry>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub authority_receipt_records: BTreeMap<String, PylonTrainingAuthorityReceiptRecord>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub contribution_outcomes: BTreeMap<String, PylonTrainingContributionOutcomeCacheEntry>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub closeout_cache: BTreeMap<String, PylonTrainingCloseoutCacheEntry>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub closeout_progress: BTreeMap<String, PylonTrainingCloseoutProgressEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub closeout_journal: Vec<PylonTrainingCloseoutJournalEntry>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub reputation_labels: BTreeMap<String, PylonTrainingReputationLabelCacheEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_authority_sync_at_ms: Option<i64>,
+}
+
+impl Default for PylonTrainingAuthoritySyncCacheState {
+    fn default() -> Self {
+        Self {
+            schema_version: default_training_runtime_state_schema_version(),
+            window_cache: BTreeMap::new(),
+            authority_receipt_records: BTreeMap::new(),
+            contribution_outcomes: BTreeMap::new(),
+            closeout_cache: BTreeMap::new(),
+            closeout_progress: BTreeMap::new(),
+            closeout_journal: Vec::new(),
+            reputation_labels: BTreeMap::new(),
+            last_authority_sync_at_ms: None,
+        }
+    }
+}
+
+impl From<&PylonTrainingRuntimeState> for PylonTrainingExecutionCacheState {
+    fn from(value: &PylonTrainingRuntimeState) -> Self {
+        Self {
+            schema_version: value.schema_version,
+            active_runtime: value.active_runtime.clone(),
+            manifest_cache: value.manifest_cache.clone(),
+            lease_cache: value.lease_cache.clone(),
+        }
+    }
+}
+
+impl From<&PylonTrainingRuntimeState> for PylonTrainingArtifactCacheState {
+    fn from(value: &PylonTrainingRuntimeState) -> Self {
+        Self {
+            schema_version: value.schema_version,
+            publication_pointers: value.publication_pointers.clone(),
+            publication_records: value.publication_records.clone(),
+        }
+    }
+}
+
+impl From<&PylonTrainingRuntimeState> for PylonTrainingAuthoritySyncCacheState {
+    fn from(value: &PylonTrainingRuntimeState) -> Self {
+        Self {
+            schema_version: value.schema_version,
+            window_cache: value.window_cache.clone(),
+            authority_receipt_records: value.authority_receipt_records.clone(),
+            contribution_outcomes: value.contribution_outcomes.clone(),
+            closeout_cache: value.closeout_cache.clone(),
+            closeout_progress: value.closeout_progress.clone(),
+            closeout_journal: value.closeout_journal.clone(),
+            reputation_labels: value.reputation_labels.clone(),
+            last_authority_sync_at_ms: value.last_authority_sync_at_ms,
+        }
+    }
+}
+
+fn training_runtime_state_from_layers(
+    execution: PylonTrainingExecutionCacheState,
+    artifact: PylonTrainingArtifactCacheState,
+    authority_sync: PylonTrainingAuthoritySyncCacheState,
+) -> PylonTrainingRuntimeState {
+    PylonTrainingRuntimeState {
+        schema_version: execution
+            .schema_version
+            .max(artifact.schema_version)
+            .max(authority_sync.schema_version),
+        active_runtime: execution.active_runtime,
+        manifest_cache: execution.manifest_cache,
+        lease_cache: execution.lease_cache,
+        window_cache: authority_sync.window_cache,
+        authority_receipt_records: authority_sync.authority_receipt_records,
+        publication_pointers: artifact.publication_pointers,
+        publication_records: artifact.publication_records,
+        contribution_outcomes: authority_sync.contribution_outcomes,
+        closeout_cache: authority_sync.closeout_cache,
+        closeout_progress: authority_sync.closeout_progress,
+        closeout_journal: authority_sync.closeout_journal,
+        reputation_labels: authority_sync.reputation_labels,
+        last_authority_sync_at_ms: authority_sync.last_authority_sync_at_ms,
     }
 }
 
@@ -822,6 +969,37 @@ pub struct PylonTrainingCloseoutProgressEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
     pub updated_at_ms: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PylonTrainingCloseoutJournalEntry {
+    pub sequence: u64,
+    pub assignment_id: String,
+    pub training_run_id: String,
+    pub window_id: String,
+    #[serde(default = "default_training_role_claim")]
+    pub role: PylonTrainingRoleClaim,
+    pub stage: PylonTrainingCloseoutStage,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub challenge_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contribution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_assignment_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_window_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payout_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payout_receipt_id: Option<String>,
+    pub transition_reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocking_reason: Option<String>,
+    pub observed_at_ms: i64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1398,6 +1576,8 @@ pub struct TrainingOperatorStatusReport {
     recent_closeouts: Vec<TrainingOperatorCloseoutStatus>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     recent_closeout_progress: Vec<TrainingOperatorCloseoutProgressStatus>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    recent_closeout_journal: Vec<TrainingOperatorCloseoutJournalStatus>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1534,6 +1714,28 @@ pub struct TrainingOperatorCloseoutProgressStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     last_error: Option<String>,
     updated_at_ms: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TrainingOperatorCloseoutJournalStatus {
+    sequence: u64,
+    training_run_id: String,
+    window_id: String,
+    assignment_id: String,
+    role: String,
+    stage: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    challenge_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    contribution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    acceptance_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    payout_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    blocking_reason: Option<String>,
+    transition_reason: String,
+    observed_at_ms: i64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -7849,20 +8051,54 @@ fn validate_nonempty_string_list(
     Ok(())
 }
 
+fn training_state_dir(config: &PylonConfig) -> PathBuf {
+    config.training.run_root.join("state")
+}
+
 fn training_runtime_state_path(config: &PylonConfig) -> PathBuf {
-    config
-        .training
-        .run_root
-        .join("state")
-        .join("runtime-state.json")
+    training_state_dir(config).join("runtime-state.json")
+}
+
+fn training_execution_cache_state_path(config: &PylonConfig) -> PathBuf {
+    training_state_dir(config).join("execution-state.json")
+}
+
+fn training_artifact_cache_state_path(config: &PylonConfig) -> PathBuf {
+    training_state_dir(config).join("artifact-state.json")
+}
+
+fn training_authority_sync_cache_state_path(config: &PylonConfig) -> PathBuf {
+    training_state_dir(config).join("authority-sync-state.json")
 }
 
 fn load_or_create_training_runtime_state(
     config: &PylonConfig,
 ) -> Result<PylonTrainingRuntimeState> {
     let path = training_runtime_state_path(config);
+    let execution_path = training_execution_cache_state_path(config);
+    let artifact_path = training_artifact_cache_state_path(config);
+    let authority_sync_path = training_authority_sync_cache_state_path(config);
     if path.exists() {
-        return load_training_runtime_state(path.as_path());
+        let state = load_training_runtime_state(path.as_path())?;
+        if !execution_path.exists() || !artifact_path.exists() || !authority_sync_path.exists() {
+            save_training_runtime_state(config, &state)?;
+        }
+        return Ok(state);
+    }
+    if execution_path.exists() || artifact_path.exists() || authority_sync_path.exists() {
+        let state = training_runtime_state_from_layers(
+            load_training_retained_state_file(
+                execution_path.as_path(),
+                "training execution state",
+            )?,
+            load_training_retained_state_file(artifact_path.as_path(), "training artifact state")?,
+            load_training_retained_state_file(
+                authority_sync_path.as_path(),
+                "training authority sync state",
+            )?,
+        );
+        save_training_runtime_state(config, &state)?;
+        return Ok(state);
     }
     let state = PylonTrainingRuntimeState::default();
     save_training_runtime_state(config, &state)?;
@@ -7870,47 +8106,74 @@ fn load_or_create_training_runtime_state(
 }
 
 fn load_training_runtime_state(path: &Path) -> Result<PylonTrainingRuntimeState> {
+    load_training_retained_state_file(path, "training runtime state")
+}
+
+fn load_training_retained_state_file<T>(path: &Path, label: &str) -> Result<T>
+where
+    T: Default + Serialize + DeserializeOwned,
+{
+    if !path.exists() {
+        return Ok(T::default());
+    }
     let payload = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read training runtime state {}", path.display()))?;
-    let mut merged = serde_json::to_value(PylonTrainingRuntimeState::default())
-        .context("failed to serialize default training runtime state")?;
+        .with_context(|| format!("failed to read {label} {}", path.display()))?;
+    let mut merged = serde_json::to_value(T::default())
+        .with_context(|| format!("failed to serialize default {label}"))?;
     let parsed = serde_json::from_str::<Value>(payload.as_str())
-        .with_context(|| format!("failed to parse training runtime state {}", path.display()))?;
+        .with_context(|| format!("failed to parse {label} {}", path.display()))?;
     merge_json_value(&mut merged, &parsed);
-    serde_json::from_value(merged).with_context(|| {
+    serde_json::from_value(merged)
+        .with_context(|| format!("failed to hydrate {label} {}", path.display()))
+}
+
+fn save_training_retained_state_file<T>(path: &Path, value: &T, label: &str) -> Result<()>
+where
+    T: Serialize,
+{
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {label} dir {}", parent.display()))?;
+    }
+    let retained_value = serde_json::to_value(value)
+        .with_context(|| format!("failed to encode retained {label}"))?;
+    validate_redacted_retained_state(&retained_value).map_err(anyhow::Error::msg)?;
+    std::fs::write(
+        path,
         format!(
-            "failed to hydrate training runtime state {}",
-            path.display()
-        )
-    })
+            "{}\n",
+            serde_json::to_string_pretty(value)
+                .with_context(|| format!("failed to serialize {label}"))?
+        ),
+    )
+    .with_context(|| format!("failed to write {label} {}", path.display()))?;
+    Ok(())
 }
 
 fn save_training_runtime_state(
     config: &PylonConfig,
     state: &PylonTrainingRuntimeState,
 ) -> Result<()> {
-    let path = training_runtime_state_path(config);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).with_context(|| {
-            format!(
-                "failed to create training runtime state dir {}",
-                parent.display()
-            )
-        })?;
-    }
-    let retained_value =
-        serde_json::to_value(state).context("failed to encode retained training runtime state")?;
-    validate_redacted_retained_state(&retained_value).map_err(anyhow::Error::msg)?;
-    std::fs::write(
-        path.as_path(),
-        format!(
-            "{}\n",
-            serde_json::to_string_pretty(state)
-                .context("failed to serialize training runtime state")?
-        ),
+    save_training_retained_state_file(
+        training_runtime_state_path(config).as_path(),
+        state,
+        "training runtime state",
+    )?;
+    save_training_retained_state_file(
+        training_execution_cache_state_path(config).as_path(),
+        &PylonTrainingExecutionCacheState::from(state),
+        "training execution state",
+    )?;
+    save_training_retained_state_file(
+        training_artifact_cache_state_path(config).as_path(),
+        &PylonTrainingArtifactCacheState::from(state),
+        "training artifact state",
+    )?;
+    save_training_retained_state_file(
+        training_authority_sync_cache_state_path(config).as_path(),
+        &PylonTrainingAuthoritySyncCacheState::from(state),
+        "training authority sync state",
     )
-    .with_context(|| format!("failed to write training runtime state {}", path.display()))?;
-    Ok(())
 }
 
 impl PylonTrainingCoordinatorClient {
@@ -10515,6 +10778,33 @@ fn load_training_status_report_with_config(
     });
     recent_closeout_progress.truncate(8);
 
+    let mut recent_closeout_journal = state
+        .closeout_journal
+        .iter()
+        .map(|entry| TrainingOperatorCloseoutJournalStatus {
+            sequence: entry.sequence,
+            training_run_id: entry.training_run_id.clone(),
+            window_id: entry.window_id.clone(),
+            assignment_id: entry.assignment_id.clone(),
+            role: entry.role.label().to_string(),
+            stage: entry.stage.label().to_string(),
+            challenge_id: entry.challenge_id.clone(),
+            contribution_id: entry.contribution_id.clone(),
+            acceptance_state: entry.acceptance_state.clone(),
+            payout_state: entry.payout_state.clone(),
+            blocking_reason: entry.blocking_reason.clone(),
+            transition_reason: entry.transition_reason.clone(),
+            observed_at_ms: entry.observed_at_ms,
+        })
+        .collect::<Vec<_>>();
+    recent_closeout_journal.sort_by(|left, right| {
+        right
+            .sequence
+            .cmp(&left.sequence)
+            .then_with(|| right.observed_at_ms.cmp(&left.observed_at_ms))
+    });
+    recent_closeout_journal.truncate(8);
+
     let mut recent_issues = resolve_training_recent_issues(config, &state, contexts.as_slice())?;
     recent_issues.sort_by(|left, right| {
         right
@@ -10561,6 +10851,7 @@ fn load_training_status_report_with_config(
         recent_issues,
         recent_closeouts,
         recent_closeout_progress,
+        recent_closeout_journal,
     })
 }
 
@@ -13159,6 +13450,7 @@ fn update_training_closeout_progress_observation(
     authority_window_state: Option<String>,
 ) -> bool {
     let key = training_closeout_progress_key(assignment_id, challenge_id);
+    let mut journal_entry = None;
     let Some(entry) = state.closeout_progress.get_mut(key.as_str()) else {
         return false;
     };
@@ -13179,6 +13471,10 @@ fn update_training_closeout_progress_observation(
     }
     if changed {
         entry.updated_at_ms = now_epoch_ms();
+        journal_entry = Some(entry.clone());
+    }
+    if let Some(entry) = journal_entry {
+        append_training_closeout_journal_entry(state, &entry, "observation_refresh");
     }
     changed
 }
@@ -14553,6 +14849,43 @@ fn training_closeout_progress_key(assignment_id: &str, challenge_id: Option<&str
         .unwrap_or_else(|| assignment_id.to_string())
 }
 
+fn next_training_closeout_journal_sequence(state: &PylonTrainingRuntimeState) -> u64 {
+    state
+        .closeout_journal
+        .last()
+        .map(|entry| entry.sequence.saturating_add(1))
+        .unwrap_or(1)
+}
+
+fn append_training_closeout_journal_entry(
+    state: &mut PylonTrainingRuntimeState,
+    entry: &PylonTrainingCloseoutProgressEntry,
+    transition_reason: &str,
+) {
+    let sequence = next_training_closeout_journal_sequence(state);
+    state
+        .closeout_journal
+        .push(PylonTrainingCloseoutJournalEntry {
+            sequence,
+            assignment_id: entry.assignment_id.clone(),
+            training_run_id: entry.training_run_id.clone(),
+            window_id: entry.window_id.clone(),
+            role: entry.role,
+            stage: entry.stage,
+            challenge_id: entry.challenge_id.clone(),
+            contribution_id: entry.contribution_id.clone(),
+            checkpoint_ref: entry.checkpoint_ref.clone(),
+            authority_assignment_state: entry.authority_assignment_state.clone(),
+            authority_window_state: entry.authority_window_state.clone(),
+            acceptance_state: entry.acceptance_state.clone(),
+            payout_state: entry.payout_state.clone(),
+            payout_receipt_id: entry.payout_receipt_id.clone(),
+            transition_reason: transition_reason.to_string(),
+            blocking_reason: entry.last_error.clone(),
+            observed_at_ms: entry.updated_at_ms,
+        });
+}
+
 const TRAINING_CLOSEOUT_AUTHORITY_POLL_INTERVAL_MS: i64 = 5_000;
 
 fn training_closeout_authority_poll_due(
@@ -14642,7 +14975,18 @@ fn record_training_closeout_progress_stage(
     let changed = previous.as_ref() != Some(&entry);
     if changed {
         entry.updated_at_ms = updated_at_ms;
-        state.closeout_progress.insert(key, entry);
+        let transition_reason = previous
+            .as_ref()
+            .map(|existing| {
+                if existing.stage != entry.stage {
+                    "stage_transition"
+                } else {
+                    "stage_metadata_refresh"
+                }
+            })
+            .unwrap_or("stage_transition");
+        state.closeout_progress.insert(key, entry.clone());
+        append_training_closeout_journal_entry(state, &entry, transition_reason);
     }
     changed
 }
@@ -24273,11 +24617,20 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         let config_path = temp_dir.path().join("config.json");
         let config = load_or_create_config(config_path.as_path())?;
         let state_path = training_runtime_state_path(&config);
+        let execution_state_path = super::training_execution_cache_state_path(&config);
+        let artifact_state_path = super::training_artifact_cache_state_path(&config);
+        let authority_sync_state_path = super::training_authority_sync_cache_state_path(&config);
         let state = load_or_create_training_runtime_state(&config)?;
 
         ensure(
             state_path.exists(),
             "loading the config should also create the separate training runtime state store",
+        )?;
+        ensure(
+            execution_state_path.exists()
+                && artifact_state_path.exists()
+                && authority_sync_state_path.exists(),
+            "loading the config should also create the layered training runtime state stores",
         )?;
         ensure(
             state == PylonTrainingRuntimeState::default(),
@@ -24863,6 +25216,222 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         ensure(
             reloaded_state == state,
             "the retained training runtime state should survive restart and preserve manifests, leases, windows, and TRN publication pointers",
+        )
+    }
+
+    #[test]
+    fn training_runtime_state_save_persists_layer_files() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let config = load_or_create_config(config_path.as_path())?;
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        state.active_runtime = Some(training_active_runtime_fixture());
+        state.manifest_cache.insert(
+            "manifest.run.alpha.worker".to_string(),
+            PylonTrainingManifestCacheEntry {
+                manifest_id: "manifest.run.alpha.worker".to_string(),
+                manifest_digest: "sha256:manifest-alpha".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                assignment_id: "assign.node01.window0001".to_string(),
+                lease_id: "lease.node01.window0001".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                cached_at_ms: 1_762_491_200_010,
+            },
+        );
+        state.publication_pointers.insert(
+            "assignment_ack::lease.node01.window0001".to_string(),
+            PylonTrainingPublicationPointer {
+                subject_kind: "assignment_ack".to_string(),
+                subject_id: "lease.node01.window0001".to_string(),
+                event_kind: TRN_TRAINING_RECEIPT_KIND,
+                event_id: "event-001".to_string(),
+                a_ref: Some("39511:coordinator:lease.node01.window0001".to_string()),
+                fingerprint: "sha256:assignment-ack".to_string(),
+                attempt_count: 1,
+                relay_outcomes: Vec::new(),
+                published_at_ms: 1_762_491_200_040,
+            },
+        );
+        state.closeout_progress.insert(
+            "assignment::assign.node01.window0001".to_string(),
+            super::PylonTrainingCloseoutProgressEntry {
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                stage: super::PylonTrainingCloseoutStage::CheckpointPublished,
+                challenge_id: None,
+                contribution_id: Some("contrib.alpha".to_string()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                authority_assignment_state: Some("accepted".to_string()),
+                authority_window_state: Some("sealed".to_string()),
+                acceptance_state: Some("accepted".to_string()),
+                payout_state: Some("pending".to_string()),
+                payout_receipt_id: None,
+                last_error: None,
+                updated_at_ms: 1_762_491_200_050,
+            },
+        );
+        state
+            .closeout_journal
+            .push(super::PylonTrainingCloseoutJournalEntry {
+                sequence: 1,
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                stage: super::PylonTrainingCloseoutStage::CheckpointPublished,
+                challenge_id: None,
+                contribution_id: Some("contrib.alpha".to_string()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                authority_assignment_state: Some("accepted".to_string()),
+                authority_window_state: Some("sealed".to_string()),
+                acceptance_state: Some("accepted".to_string()),
+                payout_state: Some("pending".to_string()),
+                payout_receipt_id: None,
+                transition_reason: "stage_transition".to_string(),
+                blocking_reason: None,
+                observed_at_ms: 1_762_491_200_050,
+            });
+
+        save_training_runtime_state(&config, &state)?;
+
+        let execution_state =
+            super::load_training_retained_state_file::<super::PylonTrainingExecutionCacheState>(
+                super::training_execution_cache_state_path(&config).as_path(),
+                "training execution state",
+            )?;
+        let artifact_state =
+            super::load_training_retained_state_file::<super::PylonTrainingArtifactCacheState>(
+                super::training_artifact_cache_state_path(&config).as_path(),
+                "training artifact state",
+            )?;
+        let authority_sync_state = super::load_training_retained_state_file::<
+            super::PylonTrainingAuthoritySyncCacheState,
+        >(
+            super::training_authority_sync_cache_state_path(&config).as_path(),
+            "training authority sync state",
+        )?;
+
+        ensure(
+            execution_state.active_runtime == state.active_runtime
+                && execution_state.manifest_cache == state.manifest_cache,
+            "execution-state.json should retain the execution slice of the training runtime state",
+        )?;
+        ensure(
+            artifact_state.publication_pointers == state.publication_pointers,
+            "artifact-state.json should retain the artifact publication slice of the training runtime state",
+        )?;
+        ensure(
+            authority_sync_state.closeout_progress == state.closeout_progress
+                && authority_sync_state.closeout_journal == state.closeout_journal,
+            "authority-sync-state.json should retain the closeout and authority-sync slice of the training runtime state",
+        )
+    }
+
+    #[test]
+    fn training_runtime_state_loads_from_layer_files_without_combined_blob()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let config_path = temp_dir.path().join("config.json");
+        let config = load_or_create_config(config_path.as_path())?;
+        let mut state = load_or_create_training_runtime_state(&config)?;
+        state.active_runtime = Some(training_active_runtime_fixture());
+        state.manifest_cache.insert(
+            "manifest.run.alpha.worker".to_string(),
+            PylonTrainingManifestCacheEntry {
+                manifest_id: "manifest.run.alpha.worker".to_string(),
+                manifest_digest: "sha256:manifest-alpha".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                assignment_id: "assign.node01.window0001".to_string(),
+                lease_id: "lease.node01.window0001".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                cached_at_ms: 1_762_491_200_010,
+            },
+        );
+        state.lease_cache.insert(
+            "lease.node01.window0001".to_string(),
+            PylonTrainingLeaseCacheEntry {
+                lease_id: "lease.node01.window0001".to_string(),
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                membership_revision: "members.rev1".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                state: "acked".to_string(),
+                manifest_digest: Some("sha256:manifest-alpha".to_string()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                expires_at_ms: Some(1_762_491_260_020),
+                network_id: Some("trainnet.alpha".to_string()),
+                challenge_id: None,
+                peer_node_pubkey: None,
+                peer_checkpoint_handoff_receipt_path: None,
+                validator_target_contribution_receipt_path: None,
+                validator_target_contribution_artifact_manifest_path: None,
+                validator_target_work_class: None,
+                grouped_stage_input_transport_path: None,
+                runtime_manifest_path: Some(
+                    "/tmp/run.alpha/manifests/invocation_manifest.json".to_string(),
+                ),
+                runtime_manifest_digest: Some("sha256:runtime-manifest-alpha".to_string()),
+                runtime_lane_id: Some(PSION_ACTUAL_PRETRAINING_LANE_ID.to_string()),
+                runtime_operation: Some("start".to_string()),
+                runtime_work_class: Some("full_island_local_update_training".to_string()),
+                updated_at_ms: 1_762_491_200_020,
+            },
+        );
+        state.publication_pointers.insert(
+            "assignment_ack::lease.node01.window0001".to_string(),
+            PylonTrainingPublicationPointer {
+                subject_kind: "assignment_ack".to_string(),
+                subject_id: "lease.node01.window0001".to_string(),
+                event_kind: TRN_TRAINING_RECEIPT_KIND,
+                event_id: "event-001".to_string(),
+                a_ref: Some("39511:coordinator:lease.node01.window0001".to_string()),
+                fingerprint: "sha256:assignment-ack".to_string(),
+                attempt_count: 1,
+                relay_outcomes: Vec::new(),
+                published_at_ms: 1_762_491_200_040,
+            },
+        );
+        state
+            .closeout_journal
+            .push(super::PylonTrainingCloseoutJournalEntry {
+                sequence: 1,
+                assignment_id: "assign.node01.window0001".to_string(),
+                training_run_id: "run.alpha".to_string(),
+                window_id: "window.0001".to_string(),
+                role: PylonTrainingRoleClaim::Worker,
+                stage: super::PylonTrainingCloseoutStage::WindowSealed,
+                challenge_id: Some("challenge.alpha".to_string()),
+                contribution_id: Some("contrib.alpha".to_string()),
+                checkpoint_ref: Some("checkpoint://run.alpha/0001".to_string()),
+                authority_assignment_state: Some("sealed".to_string()),
+                authority_window_state: Some("sealed".to_string()),
+                acceptance_state: Some("pending".to_string()),
+                payout_state: Some("pending".to_string()),
+                payout_receipt_id: None,
+                transition_reason: "stage_transition".to_string(),
+                blocking_reason: Some("waiting_for_validator_claim".to_string()),
+                observed_at_ms: 1_762_491_200_060,
+            });
+
+        save_training_runtime_state(&config, &state)?;
+
+        let runtime_state_path = training_runtime_state_path(&config);
+        std::fs::remove_file(runtime_state_path.as_path())?;
+
+        let recovered_state = load_or_create_training_runtime_state(&config)?;
+        ensure(
+            recovered_state == state,
+            "layered training state files should fully reconstruct the retained runtime state when the combined blob is missing",
+        )?;
+        ensure(
+            runtime_state_path.exists(),
+            "reloading from layer files should backfill the combined runtime-state.json compatibility blob",
         )
     }
 
@@ -30480,6 +31049,120 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         ensure(
             counts_after_third == counts,
             "recorded refusal receipts should dedupe across later serve loops",
+        )
+    }
+
+    #[test]
+    fn training_closeout_progress_appends_monotonic_journal_entries()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut state = PylonTrainingRuntimeState::default();
+
+        ensure(
+            super::record_training_closeout_progress_stage(
+                &mut state,
+                "assign.alpha",
+                "run.alpha",
+                "window.0001",
+                PylonTrainingRoleClaim::Worker,
+                super::PylonTrainingCloseoutStage::WorkerExitedSuccess,
+                None,
+                Some("checkpoint://run.alpha/0042".to_string()),
+                None,
+                None,
+                None,
+                None,
+            ) && super::record_training_closeout_progress_stage(
+                &mut state,
+                "assign.alpha",
+                "run.alpha",
+                "window.0001",
+                PylonTrainingRoleClaim::Worker,
+                super::PylonTrainingCloseoutStage::CheckpointPublished,
+                None,
+                Some("checkpoint://run.alpha/0042".to_string()),
+                None,
+                None,
+                None,
+                None,
+            ) && !super::record_training_closeout_progress_stage(
+                &mut state,
+                "assign.alpha",
+                "run.alpha",
+                "window.0001",
+                PylonTrainingRoleClaim::Worker,
+                super::PylonTrainingCloseoutStage::CheckpointPublished,
+                None,
+                Some("checkpoint://run.alpha/0042".to_string()),
+                None,
+                None,
+                None,
+                None,
+            ),
+            "closeout stage recording should append journal entries on real transitions and stay quiet on exact no-op repeats",
+        )?;
+
+        let progress = state
+            .closeout_progress
+            .get("assign.alpha")
+            .expect("closeout progress entry");
+        ensure(
+            progress.stage == super::PylonTrainingCloseoutStage::CheckpointPublished
+                && state.closeout_journal.len() == 2
+                && state.closeout_journal[0].sequence == 1
+                && state.closeout_journal[0].transition_reason == "stage_transition"
+                && state.closeout_journal[1].sequence == 2
+                && state.closeout_journal[1].stage
+                    == super::PylonTrainingCloseoutStage::CheckpointPublished,
+            "closeout journal should remain append-only and preserve the latest monotonic stage",
+        )
+    }
+
+    #[test]
+    fn training_closeout_observation_appends_journal_without_stage_regression()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut state = PylonTrainingRuntimeState::default();
+        ensure(
+            super::record_training_closeout_progress_stage(
+                &mut state,
+                "assign.alpha",
+                "run.alpha",
+                "window.0001",
+                PylonTrainingRoleClaim::Worker,
+                super::PylonTrainingCloseoutStage::WindowSealed,
+                None,
+                Some("checkpoint://run.alpha/0042".to_string()),
+                None,
+                None,
+                None,
+                None,
+            ) && super::update_training_closeout_progress_observation(
+                &mut state,
+                "assign.alpha",
+                None,
+                Some("contrib.alpha".to_string()),
+                Some("accepted".to_string()),
+                Some("sealed".to_string()),
+            ),
+            "closeout observation refreshes should extend journal history after a stage has been recorded",
+        )?;
+
+        let progress = state
+            .closeout_progress
+            .get("assign.alpha")
+            .expect("closeout progress entry");
+        let journal_entry = state
+            .closeout_journal
+            .last()
+            .expect("closeout journal entry");
+        ensure(
+            progress.stage == super::PylonTrainingCloseoutStage::WindowSealed
+                && progress.contribution_id.as_deref() == Some("contrib.alpha")
+                && progress.authority_assignment_state.as_deref() == Some("accepted")
+                && progress.authority_window_state.as_deref() == Some("sealed")
+                && state.closeout_journal.len() == 2
+                && journal_entry.transition_reason == "observation_refresh"
+                && journal_entry.stage == super::PylonTrainingCloseoutStage::WindowSealed,
+            "observation refreshes should append journal entries without regressing the effective closeout stage",
         )
     }
 

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -11522,12 +11522,41 @@ fn training_terminal_checkpoint_publication_candidate(
         return Ok(None);
     };
     let optimizer_step = resolve_training_checkpoint_optimizer_step(local_run_root)?;
-    let bundle_kind = optimizer_step
-        .map(|step| PylonTrainingArtifactBundleKind::CheckpointManifest {
-            optimizer_step: step,
+    let mut bundle = optimizer_step
+        .map(|step| {
+            inspect_training_artifact_bundle(
+                context,
+                PylonTrainingArtifactBundleKind::CheckpointManifest {
+                    optimizer_step: step,
+                },
+            )
         })
-        .unwrap_or(PylonTrainingArtifactBundleKind::LatestCheckpointPointer);
-    let bundle = inspect_training_artifact_bundle(context, bundle_kind)?;
+        .transpose()?;
+    if !bundle.as_ref().is_some_and(|bundle| {
+        bundle
+            .objects
+            .iter()
+            .any(|entry| entry.present && entry.digest.is_some())
+    }) {
+        bundle = inspect_manifest_local_artifacts(context)?
+            .into_iter()
+            .filter(|bundle| bundle.bundle_kind == "checkpoint_manifest")
+            .filter(|bundle| {
+                bundle
+                    .objects
+                    .iter()
+                    .any(|entry| entry.present && entry.digest.is_some())
+            })
+            .max_by(|left, right| {
+                training_checkpoint_manifest_bundle_step(left.bundle_id.as_str())
+                    .cmp(&training_checkpoint_manifest_bundle_step(right.bundle_id.as_str()))
+                    .then_with(|| left.bundle_id.cmp(&right.bundle_id))
+            });
+    }
+    let bundle = bundle.unwrap_or(inspect_training_artifact_bundle(
+        context,
+        PylonTrainingArtifactBundleKind::LatestCheckpointPointer,
+    )?);
     let Some(object) = bundle
         .objects
         .into_iter()
@@ -11544,6 +11573,12 @@ fn training_terminal_checkpoint_publication_candidate(
         artifact_locator: object.object_uri,
         artifact_digest,
     }))
+}
+
+fn training_checkpoint_manifest_bundle_step(bundle_id: &str) -> Option<u64> {
+    bundle_id
+        .strip_prefix("checkpoint_manifest:")
+        .and_then(|value| value.parse::<u64>().ok())
 }
 
 fn training_prefixed_sha256_digest(value: &str) -> Option<String> {
@@ -22466,6 +22501,35 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
         Ok(manifest)
     }
 
+    fn rewrite_training_checkpoint_manifest_to_bridge_shape(
+        local_run_root: &Path,
+        optimizer_step: u64,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let canonical_manifest_path = local_run_root
+            .join("checkpoints")
+            .join(format!("step-{optimizer_step}"))
+            .join("checkpoint_manifest.json");
+        let manifest_payload = std::fs::read(canonical_manifest_path.as_path())?;
+        std::fs::create_dir_all(local_run_root.join("checkpoints").join("step-0"))?;
+        std::fs::write(
+            local_run_root
+                .join("checkpoints")
+                .join("step-0")
+                .join("checkpoint_manifest.json"),
+            manifest_payload.as_slice(),
+        )?;
+        std::fs::create_dir_all(local_run_root.join("checkpoints").join("manifests"))?;
+        std::fs::write(
+            local_run_root
+                .join("checkpoints")
+                .join("manifests")
+                .join(format!("checkpoint_manifest_step-{optimizer_step:06}.json")),
+            manifest_payload.as_slice(),
+        )?;
+        std::fs::remove_file(canonical_manifest_path)?;
+        Ok(())
+    }
+
     fn write_training_terminal_status_packets(
         local_run_root: &Path,
         outcome: &str,
@@ -26621,6 +26685,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             local_run_root.as_path(),
             "gs://bucket",
         )?;
+        rewrite_training_checkpoint_manifest_to_bridge_shape(local_run_root.as_path(), 42)?;
         manifest.trn.relay_urls = vec![relay.url.clone()];
         manifest.manifest_digest = manifest.canonical_digest()?;
         let manifest_path = local_run_root.join("manifests").join("run_manifest.json");
@@ -27228,6 +27293,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
             local_run_root.as_path(),
             "gs://bucket",
         )?;
+        rewrite_training_checkpoint_manifest_to_bridge_shape(local_run_root.as_path(), 42)?;
         manifest.trn.relay_urls = vec![relay.url.clone()];
         manifest.manifest_digest = manifest.canonical_digest()?;
         let manifest_path = local_run_root.join("manifests").join("run_manifest.json");

--- a/apps/pylon/src/main.rs
+++ b/apps/pylon/src/main.rs
@@ -130,8 +130,12 @@ mod tests {
     fn explicit_subcommands_stay_on_cli_path() {
         assert!(!should_launch_tui(&["status".into()]).expect("status path"));
         assert!(
-            !should_launch_tui(&["--config-path".into(), "/tmp/pylon.json".into(), "status".into()])
-                .expect("status path with config")
+            !should_launch_tui(&[
+                "--config-path".into(),
+                "/tmp/pylon.json".into(),
+                "status".into()
+            ])
+            .expect("status path with config")
         );
     }
 }

--- a/apps/pylon/src/nip90_runtime.rs
+++ b/apps/pylon/src/nip90_runtime.rs
@@ -531,7 +531,8 @@ pub async fn run_provider_requests(config_path: &Path, seconds: u64) -> Result<P
         .into_iter()
         .map(|job| (job.id.clone(), job))
         .collect::<BTreeMap<_, _>>();
-    let processed_request_store = crate::ledger::load_processed_provider_request_store(config_path)?;
+    let processed_request_store =
+        crate::ledger::load_processed_provider_request_store(config_path)?;
     let mut wallet_payments: Option<Vec<PylonWalletPaymentRecord>> = None;
     let mut report_entries = Vec::new();
     let mut accepted_count = 0usize;
@@ -2569,15 +2570,15 @@ fn reconcile_processed_provider_requests(config_path: &Path) -> Result<()> {
     crate::ledger::mutate_processed_provider_request_store(
         config_path,
         |store: &mut crate::ledger::PylonProcessedProviderRequestStore| {
-        for job in &ledger.jobs {
-            if job.direction == "provider"
-                && provider_job_is_terminal_for_reintake_store(job.status.as_str())
-            {
-                store.remember(job.id.clone(), job.status.clone());
+            for job in &ledger.jobs {
+                if job.direction == "provider"
+                    && provider_job_is_terminal_for_reintake_store(job.status.as_str())
+                {
+                    store.remember(job.id.clone(), job.status.clone());
+                }
             }
-        }
-        Ok(())
-    },
+            Ok(())
+        },
     )?;
     Ok(())
 }
@@ -2864,7 +2865,11 @@ fn record_provider_settlement_outcome(
         Ok(())
     })?;
     if status.eq_ignore_ascii_case("settled") {
-        remember_processed_provider_request(config_path, entry.request_event_id.as_str(), "settled")?;
+        remember_processed_provider_request(
+            config_path,
+            entry.request_event_id.as_str(),
+            "settled",
+        )?;
     }
     Ok(settlement_id)
 }

--- a/apps/pylon/src/wallet_runtime.rs
+++ b/apps/pylon/src/wallet_runtime.rs
@@ -934,8 +934,9 @@ fn compute_wallet_credit_summary(
         if !wallet_payment_counts_as_credit(payment) {
             continue;
         }
-        credits.credited_lifetime_sats =
-            credits.credited_lifetime_sats.saturating_add(payment.amount_sats);
+        credits.credited_lifetime_sats = credits
+            .credited_lifetime_sats
+            .saturating_add(payment.amount_sats);
         if payment.created_at_ms / 86_400_000 == current_day {
             credits.credited_today_sats = credits
                 .credited_today_sats

--- a/crates/openagents-kernel-core/src/compute.rs
+++ b/crates/openagents-kernel-core/src/compute.rs
@@ -3142,12 +3142,10 @@ pub fn validate_compute_adapter_training_window(
     {
         return Err("compute_accepted_outcome_id_missing".to_string());
     }
-    if window.output_policy_revision.is_some() != window.output_checkpoint_pointer.is_some() {
-        return Err("compute_adapter_window_promotion_checkpoint_missing".to_string());
-    }
     match window.promotion_disposition {
         Some(ComputeAdapterPromotionDisposition::Promoted) => {
-            if window.output_policy_revision.is_none() {
+            if window.output_policy_revision.is_none() || window.output_checkpoint_pointer.is_none()
+            {
                 return Err("compute_adapter_window_promotion_checkpoint_missing".to_string());
             }
             if !window.hold_reason_codes.is_empty() {
@@ -3178,10 +3176,12 @@ pub fn validate_compute_adapter_training_window(
     }
     if let Some(output_checkpoint_pointer) = window.output_checkpoint_pointer.as_ref() {
         validate_compute_adapter_checkpoint_pointer(output_checkpoint_pointer)?;
+    }
+    if let Some(promoted_checkpoint_ref) = window.promoted_checkpoint_ref.as_deref() {
         if window
-            .promoted_checkpoint_ref
-            .as_deref()
-            .is_none_or(|value| value != output_checkpoint_pointer.checkpoint_ref)
+            .output_checkpoint_pointer
+            .as_ref()
+            .is_some_and(|pointer| pointer.checkpoint_ref != promoted_checkpoint_ref)
         {
             return Err("compute_adapter_promoted_checkpoint_ref_missing".to_string());
         }
@@ -5609,6 +5609,82 @@ mod tests {
         };
         validate_compute_adapter_training_window(&window)
             .expect("non-adapter window should validate");
+    }
+
+    #[test]
+    fn training_window_allows_output_checkpoint_pointer_before_promotion() {
+        let source_policy_revision = ComputeAdapterPolicyRevision {
+            policy_family: "policy://training/math/basic".to_string(),
+            revision_id: "policy-rev-42".to_string(),
+            revision_number: Some(42),
+            policy_digest: "sha256:policy-rev-42".to_string(),
+            parent_revision_id: Some("policy-rev-41".to_string()),
+            produced_at_ms: 1_762_000_700_000,
+        };
+        let source_checkpoint_pointer = ComputeAdapterCheckpointPointer {
+            scope_kind: "training_run".to_string(),
+            scope_id: "train.math.basic.alpha".to_string(),
+            checkpoint_family: "decoder".to_string(),
+            checkpoint_ref: "checkpoint://decoder/base".to_string(),
+            manifest_digest: "sha256:checkpoint-base".to_string(),
+            updated_at_ms: 1_762_000_700_100,
+            pointer_digest: "sha256:pointer-base".to_string(),
+        };
+        let output_checkpoint_pointer = ComputeAdapterCheckpointPointer {
+            scope_kind: "window".to_string(),
+            scope_id: "window.alpha.0042".to_string(),
+            checkpoint_family: "decoder".to_string(),
+            checkpoint_ref: "checkpoint://decoder/train.math.basic.alpha/window.0042".to_string(),
+            manifest_digest: "sha256:checkpoint-manifest".to_string(),
+            updated_at_ms: 1_762_000_700_200,
+            pointer_digest: "sha256:pointer-window".to_string(),
+        };
+        let window = ComputeAdapterTrainingWindow {
+            window_id: "window.alpha.0042".to_string(),
+            training_run_id: "train.math.basic.alpha".to_string(),
+            stage_id: "dense.pretrain".to_string(),
+            contributor_set_revision_id: "contributors.rev42".to_string(),
+            validator_policy_ref: "policy://validator/training".to_string(),
+            work_class: ComputeTrainingWorkClass::FullIslandLocalUpdateTraining,
+            replica_type: ComputeTrainingReplicaType::Island,
+            round_index: Some(42),
+            base_checkpoint_ref: source_checkpoint_pointer.checkpoint_ref.clone(),
+            planned_local_step_count: Some(500),
+            aggregation_rule: Some("weighted_avg".to_string()),
+            aggregation_weight_basis: Some("tokens".to_string()),
+            adapter_target_id: String::new(),
+            adapter_family: String::new(),
+            base_model_ref: "model://gpt-oss-20b".to_string(),
+            adapter_format: String::new(),
+            source_policy_revision,
+            source_checkpoint_pointer,
+            status: ComputeAdapterWindowStatus::Active,
+            total_contributions: 0,
+            admitted_contributions: 0,
+            accepted_contributions: 0,
+            quarantined_contributions: 0,
+            rejected_contributions: 0,
+            replay_required_contributions: 0,
+            replay_checked_contributions: 0,
+            held_out_average_score_bps: None,
+            benchmark_pass_rate_bps: None,
+            runtime_smoke_passed: None,
+            promotion_ready: false,
+            gate_reason_codes: Vec::new(),
+            window_summary_digest: "sha256:window-summary".to_string(),
+            promotion_disposition: None,
+            hold_reason_codes: Vec::new(),
+            aggregated_delta_digest: None,
+            accepted_aggregate_id: None,
+            output_policy_revision: None,
+            output_checkpoint_pointer: Some(output_checkpoint_pointer),
+            promoted_checkpoint_ref: None,
+            accepted_outcome_id: None,
+            recorded_at_ms: 1_762_000_700_200,
+            metadata: json!({"network_id": "trainnet.alpha"}),
+        };
+        validate_compute_adapter_training_window(&window)
+            .expect("window checkpoint publication should not require promotion metadata");
     }
 
     #[test]

--- a/docs/audits/2026-04-14-episode-224-end-to-end-demo-gap-audit.md
+++ b/docs/audits/2026-04-14-episode-224-end-to-end-demo-gap-audit.md
@@ -1,16 +1,18 @@
 # Episode 224 End-to-End Demo Gap Audit
 
 Date: 2026-04-14
+Updated: 2026-04-16
 Owner repo: `openagents`
 Related issues:
 
 - `openagents#4352`
+- `openagents#4368`
 - `openagents.com#24`
 - `psionic#943`
 
 ## Demo-Readiness Verdict
 
-Current classification: `ready with operator-only path`
+Current classification: `ready with operator launch path and checked-in autonomous closeout runtime`
 
 Why:
 
@@ -18,13 +20,18 @@ Why:
 - Nexus now exposes both the public named-run detail read model and a narrow
   admin launch endpoint for the bounded demo lane
 - the public run page and `/stats` linkout already exist in `openagents.com`
-- the missing piece for a fully site-native admin story is the website-side
-  trigger/control surface in `openagents.com#24`
+- `apps/pylon` now has a checked-in retained closeout path that can seal,
+  finalize validator replay, reconcile, and observe payout state from retained
+  worker output
+- the remaining missing pieces are a website-side admin trigger in
+  `openagents.com#24` and a fresh production run that proves accepted payout on
+  the current live fleet
 
 That means the system is no longer stuck at "proof exists but repeatable demo
-not ready." It has a legitimate operator control path. It is not yet fully
-"ready now" because the admin click path still needs to be wired through the
-website repo.
+not ready." It has a legitimate operator control path and a checked-in
+post-worker runtime path. It is not yet fully "ready now" because the admin
+click path still needs to be wired through the website repo and a fresh live
+run still needs to prove the accepted payout path outside retained tests.
 
 ## Gap Table
 
@@ -33,9 +40,9 @@ website repo.
 | Web UX | Public `/stats` board and named run page already exist in `openagents.com` | No website admin button yet for launching the bounded run | important | `openagents.com` | Add authenticated admin action that calls the Nexus launch endpoint and redirects to the returned run page |
 | Backend / Nexus contract | Public `/api/training/runs/{trainingRunId}` snapshot now exists; bounded launch endpoint now exists at `/v1/admin/training/demo-runs/cs336-a1/launch` | Production env must wire `NEXUS_CONTROL_ADMIN_BEARER_TOKEN` and the website-side caller | important | `openagents` + `openagents.com` | Configure the bearer token on Nexus and the matching website secret, then call the launch route server-side |
 | Training lane / Psionic | Canonical CS336 A1 demo lane contract exists and `psionic#943` added bounded-run verification | Live repeatability still depends on healthy manifests, admitted hosts, and current environment reachability | important | `psionic` | Keep the lane verifier in the operator loop and fail fast if manifest or environment resolution regresses |
-| Pylon distribution | Retained dual-host proof exists for `run.cs336.a1.demo`; scheduler role-plan remains bounded to two workers | Fresh live proof still depends on real online Pylons being admitted and healthy at launch time | important | `openagents` + live operators | Use the new launch route only when two demo-capable nodes are online and admitted for `trainnet.cs336.a1.demo` |
-| Payout / treasury / proof | Run-detail snapshot and public stats already expose treasury health, wallet runtime, contribution rows, and closeout/payout flags | Treasury and reconciliation are still not final-settlement truth; UI must not imply completed payout | important | `openagents` + `treasury` | Keep degraded wallet / validation caveats visible and label payout state as pending or degraded when appropriate |
-| Operator testability | There is now a legitimate server-side launch path plus public read surfaces for verification | Website click path is still separate work and live-demo success still depends on node health | important | `openagents.com` + operators | Ship the site button and keep the operator runbook attached to the admin surface |
+| Pylon distribution | Retained dual-host proof exists for `run.cs336.a1.demo`; scheduler role-plan remains bounded to two workers; checked-in Pylon runtime can continue retained worker output through seal, validator finalize, reconcile, and payout observation | Fresh live proof still depends on real online Pylons being admitted, healthy, and actually running the updated binary | important | `openagents` + live operators | Use the new launch route only when current demo-capable nodes are online, admitted, and on the current release line |
+| Payout / treasury / proof | Run-detail snapshot and public stats already expose treasury health, wallet runtime, contribution rows, and closeout/payout flags; Pylon now persists accepted and payout observation locally | Fresh production proof of accepted contribution plus payout receipt on the current fleet is still missing; UI must not imply completed payout before it is observed live | important | `openagents` + `treasury` | Keep degraded wallet / validation caveats visible, and only use paid language after the live run shows a real payout receipt |
+| Operator testability | There is now a legitimate server-side launch path, a checked-in autonomous closeout runtime, and a new retained end-to-end truth test from worker completion to paid receipt | Website click path is still separate work and live-demo success still depends on node health | important | `openagents.com` + operators | Ship the site button and keep the operator runbook attached to the admin surface while the live post-worker smoke remains manual |
 
 ## Explicit Answers
 
@@ -85,17 +92,23 @@ The live result still depends on real hosts being healthy and admitted.
 
 ### Can multiple Pylons reliably receive the same named run and produce a fresh proof window?
 
-Yes in principle, and there is retained proof that it already worked once on
-two hosts.
+Yes for the bounded worker-distribution path, and there is retained proof that
+it already worked once on two hosts.
 
 The remaining risk is operational, not architectural: online admitted nodes,
 manifest reachability, and current fleet health still determine whether a fresh
 live run succeeds on demand.
 
+The post-worker gap is narrower than it was in the April 14 snapshot. The
+checked-in `apps/pylon` runtime now drives retained worker output into seal,
+validator finalize, reconcile, and payout observation. What is still missing is
+a fresh production run that proves those same steps on the live updated fleet.
+
 ### Are payouts actually visible, or only implied?
 
-They are visible enough to support an honest demo, but not enough to overclaim
-full reconciliation.
+They are no longer only implied in checked-in runtime behavior. `Pylon` now
+persists acceptance and payout observation locally and can advance a retained
+assignment to `paid` in the new autonomous truth test.
 
 Visible now:
 
@@ -105,11 +118,13 @@ Visible now:
 - closeout status
 - payout eligibility flags
 - contribution acceptance state
+- payout receipt id when the authority surfaces one
 
 Not yet honest to claim:
 
-- final settled payout completion in every case
-- full reconciliation/validation closure
+- fresh production settled payout completion on demand
+- full live-fleet reconciliation or validation closure without watching the
+  real run
 
 ### What caveats must remain visible to keep the demo honest?
 
@@ -121,14 +136,32 @@ These caveats must stay on screen:
 - payout eligibility does not equal payout settled
 - live demo success still depends on real online admitted Pylons
 
+## Transcript 222 Promise Status
+
+Against `docs/plans/transcript-222-launch-truth-contract.md`, the current state
+is:
+
+- presence claims are supported by the live public stats fields
+- assigned-contributor claims are supported by the launch response and run
+  detail snapshot
+- accepted-contributor and model-progress claims are now supported by the
+  checked-in post-worker authority path, but they are still only honest as live
+  public claims after a fresh run actually reaches accepted outcome state
+- payout-linked claims remain conditional on observed payout receipts, not
+  payout eligibility alone
+
 ## Implementation Shipped In This Repo
 
 Files:
 
 - `apps/nexus-control/src/lib.rs`
+- `apps/pylon/src/lib.rs`
 - `docs/kernel/compute-training-authority.md`
+- `docs/pylon/distributed-training-launch-status.md`
+- `scripts/release/check-pylon-episode-223-cs336-a1-local.sh`
+- `scripts/release/check-pylon-transcript-222-canary.sh`
 
-Backend changes:
+Backend/runtime changes:
 
 - re-landed the public named-run detail endpoint
 - added the bounded admin launch route
@@ -136,11 +169,22 @@ Backend changes:
 - made the launch path seed missing CS336 demo registry contracts
 - made fresh launches expose the initial window id immediately instead of
   waiting for the first lease claim
+- added validator-claim target bindings so a validator Pylon can materialize
+  replay inputs from the authority response alone
+- made `Pylon` persist validator claim records and closeout progress in
+  retained runtime state
+- made retained worker output trigger seal, validator finalize, reconcile, and
+  payout observation automatically during terminal sync
+- promoted the new autonomous closeout truth test into the retained release
+  scripts instead of treating manual reconcile as the release gate
 
 Tests added or exercised:
 
 - `admin_cs336_demo_launch_route_requires_admin_bearer_token`
 - `admin_cs336_demo_launch_route_registers_contracts_creates_run_and_reuses_active_run`
+- `validator_challenge_claim_returns_target_bindings_for_homework_contributions`
+- `pylon_autonomously_closes_homework_assignment_from_worker_completion_to_paid_receipt`
+- `training_terminal_sync_seals_window_from_retained_worker_artifacts`
 - `training_run_detail_endpoint_surfaces_sealed_window_contributions_and_caveats`
 - `training_operator_summary_and_stats_surface_live_run_state`
 
@@ -169,12 +213,17 @@ curl -X POST \
 6. Watch for:
    - assigned contributors on the run
    - contribution rows from multiple hosts
-   - featured window status moving through active or sealed states
+   - featured window status moving through active, sealed, and reconciled
+     states
+   - accepted contribution rows
+   - payout receipt id only if it is actually observed
    - treasury and validation caveats remaining explicit
 
 Acceptable payout-state language for the demo:
 
 - `payout eligible`
+- `payout queued`
+- `payout confirmed`
 - `validation pending`
 - `treasury degraded`
 - `wallet runtime error`
@@ -188,6 +237,7 @@ Not acceptable:
 
 - `openagents.com` still needs the actual admin trigger button and server-side caller in `openagents.com#24`
 - the launch path is currently operator/server-side, not browser-native
-- live repeatability still depends on healthy admitted nodes and current manifest reachability
-- treasury degradation and reconciliation gaps remain real and must stay visible
-- payout visibility is truthful enough for "beginnings of paid distributed training" but not for a fully settled-economics claim
+- live repeatability still depends on healthy admitted nodes, current release binaries, and current manifest reachability
+- a fresh production run that proves accepted contribution plus payout receipt on the live fleet is still missing
+- treasury degradation and live reconciliation gaps remain real and must stay visible
+- payout visibility is truthful enough for "beginnings of paid distributed training" only when the run actually surfaces the receipt, not when it is merely eligible

--- a/docs/kernel/compute-training-authority.md
+++ b/docs/kernel/compute-training-authority.md
@@ -275,16 +275,19 @@ answers:
 - what artifacts and digests identify the accepted work
 - what public caveats still apply to settlement or validation
 
-## Episode 224 Admin Launch Path
+## Homework Admin Launch Path
 
-Nexus now also exposes one narrow write-side admin path for the bounded Episode
-224 CS336 demo:
+Nexus now exposes one authenticated homework-dispatch surface for the bounded
+Episode 224 / CS336-style training lane:
+
+- `POST /api/admin/homework/launch`
+
+The retained CS336 demo route remains as a backward-compatible shim:
 
 - `POST /v1/admin/training/demo-runs/cs336-a1/launch`
 
-This route is intentionally not a generic public training-run creation surface.
-It is a scoped operator path that exists so `openagents.com` can trigger the
-same bounded demo lane the retained proof already validated.
+The shim delegates into the generic homework launch path with fixed CS336 demo
+defaults. The generic route is the operator truth for current launch behavior.
 
 Authentication:
 
@@ -294,6 +297,44 @@ Authentication:
 - if that env var is absent, the route returns
   `service_unavailable/admin_bearer_token_unconfigured`
 
+Request contract:
+
+- course and run identity
+  - `course_id`
+  - `homework_id`
+  - `run_slug`
+  - optional `training_run_id`
+  - optional `network_id`
+  - optional `run_kind`
+  - optional `assignment_family`
+  - optional `artifact_prefix`
+- target selector
+  - `only_online`
+  - optional `min_pylon_version`
+  - `require_updated_build`
+  - `tags_any`
+  - `tags_all`
+- assignment policy
+  - `mode`
+  - optional `max_contributors`
+  - `window_duration_seconds`
+- payout policy
+  - `enabled`
+  - `rail`
+  - `amount_sats`
+  - `pay_only_on_accept`
+
+Response contract:
+
+- `training_run_id`
+- `run_status`
+- `current_window_id`
+- `matched_pylons`
+- `assigned_pylons`
+- `artifact_prefix`
+- `launch_receipt_id`
+- `run_detail`
+
 Behavior:
 
 - seeds the CS336 A1 demo registry contracts if they are missing
@@ -301,15 +342,44 @@ Behavior:
   - checkpoint-family policy
   - validator policy
   - training policy with run-definition metadata
-- reuses the latest active bounded demo run when `reuse_existing_run=true` and
-  no explicit run id is supplied
-- otherwise creates one new running bounded demo run with:
-  - training policy `policy://training/cs336/a1-demo/v1`
-  - environment ref `env.openagents.psionic.train.cs336-a1-demo`
-  - fixed network `trainnet.cs336.a1.demo`
-  - fixed worker target count `2`
+- filters eligible pylons at launch time from one explicit source of truth:
+  - heartbeat fresh
+  - online when `only_online=true`
+  - current release/build when `require_updated_build=true`
+  - optional semantic-version floor when `min_pylon_version` is supplied
+  - not draining or otherwise ineligible
+  - payout target present when payout is enabled
+- persists the matched and assigned pylon set on the launch response so the
+  operator can audit exactly which hosts the run targeted
+- materializes the first window inside the same launch contract instead of
+  returning a run row with no schedulable work
+- publishes the bootstrap triad before the run is considered ready:
+  - `run_manifest.json`
+  - `latest_pointer.json`
+  - `checkpoint_manifest.json`
+- exposes pylon-facing authority seams for the checked-in intake loop:
+  - assignment ack
+  - drain/failure notice
+  - window progress
+  - checkpoint publication
 - returns the run id plus the full public run-detail snapshot so the caller can
   redirect immediately into the proof page
+
+Current homework payout truth:
+
+- the bounded homework validator policy is now configured for pay-on-accept
+  behavior
+  - minimum distinct validators: `1`
+  - challenge window: `0 ms`
+- accepted-work payouts are queued exactly once per accepted contribution
+- `payout.amount_sats` is the per-window payout budget, not a per-contributor
+  fixed payment
+- if more than one accepted contributor shares the rewarded result, that window
+  budget is split by the authority payout projection
+  - for the current homework lane, the split follows aggregation weight when
+    the accepted contributions expose a valid weighting basis
+- queued accepted-work payouts still dispatch even when the global placeholder
+  payout budget is `0`
 
 Truth boundary:
 
@@ -318,6 +388,23 @@ Truth boundary:
 - the returned run-detail snapshot still carries treasury and validation caveats
 - website/UI consumers must keep those caveats visible rather than implying
   fully settled payout state
+
+Operator smoke checklist:
+
+1. `POST /api/admin/homework/launch` with `reuse_existing_run:false`.
+2. Confirm the response returns `training_run_id`, `current_window_id`,
+   non-empty `matched_pylons`, non-empty `assigned_pylons`, and one
+   `artifact_prefix`.
+3. Confirm the public/raw run surfaces show the same `featured_window_id`.
+4. Confirm the bootstrap triad exists under the launched artifact prefix.
+5. Confirm only current updated pylons were assigned.
+6. Confirm at least one assigned pylon claims its lease and sends assignment
+   ack.
+7. Confirm the pylon publishes progress and a checkpoint for the active window.
+8. Confirm reconcile records accepted contributions and queues accepted-work
+   payout records exactly once.
+9. Confirm a retry of the dispatch cycle does not create duplicate payout
+   sends.
 
 ## Work-Class Settlement Projection
 

--- a/docs/kernel/compute-training-authority.md
+++ b/docs/kernel/compute-training-authority.md
@@ -357,11 +357,16 @@ Behavior:
   - `run_manifest.json`
   - `latest_pointer.json`
   - `checkpoint_manifest.json`
-- exposes pylon-facing authority seams for the checked-in intake loop:
+- exposes pylon-facing authority seams for the checked-in worker and closeout
+  loop:
   - assignment ack
   - drain/failure notice
   - window progress
   - checkpoint publication
+  - window seal from retained worker artifacts
+  - validator-finalize from retained validator replay state
+  - window reconcile
+  - accepted-outcome and payout observation
 - returns the run id plus the full public run-detail snapshot so the caller can
   redirect immediately into the proof page
 
@@ -383,9 +388,13 @@ Current homework payout truth:
 
 Truth boundary:
 
-- this launch path does not claim treasury reconciliation is healthy
-- it does not bypass validator backlog or closeout state
+- this launch path now includes a checked-in autonomous post-worker closeout
+  path in `apps/pylon`
+- it still does not claim treasury reconciliation is healthy across production
+  by default
 - the returned run-detail snapshot still carries treasury and validation caveats
+- the operator must still verify accepted outcome and payout state on the live
+  run before calling it paid
 - website/UI consumers must keep those caveats visible rather than implying
   fully settled payout state
 
@@ -401,10 +410,16 @@ Operator smoke checklist:
 6. Confirm at least one assigned pylon claims its lease and sends assignment
    ack.
 7. Confirm the pylon publishes progress and a checkpoint for the active window.
-8. Confirm reconcile records accepted contributions and queues accepted-work
-   payout records exactly once.
-9. Confirm a retry of the dispatch cycle does not create duplicate payout
-   sends.
+8. Confirm retained closeout artifacts exist for the completed worker
+   assignment.
+9. Confirm the window is sealed without operator intervention once those
+   retained artifacts are present.
+10. Confirm validator work is claimed or retried, finalized, and pushed into
+    reconcile without a manual authority call.
+11. Confirm accepted contributions appear on the run and payout state advances
+    exactly once to queued, dispatched, or confirmed.
+12. Confirm a retry of the dispatch cycle or Pylon restart does not create
+    duplicate finalize, reconcile, or payout sends.
 
 ## Work-Class Settlement Projection
 

--- a/docs/pylon/2026-04-09-pylon-distributed-training-reference-audit.md
+++ b/docs/pylon/2026-04-09-pylon-distributed-training-reference-audit.md
@@ -119,7 +119,11 @@ The missing part is that current `Pylon` runtime detection still reports:
 
 - `adapter_training_contributor: ProviderAdapterTrainingContributorAvailability::default()`
 
-and inventory controls still default the training contributor lane off.
+At the time of this 2026-04-09 audit, inventory controls still defaulted the
+training contributor lane off. Fresh `Pylon` defaults were corrected in the
+issue-4368 hardening path on 2026-04-16, but the broader conclusion here was
+still accurate: capability detection and the live operator path were not yet
+finished.
 
 So today the training contributor product is mostly a declared capability
 surface, not a live distributed training operator.

--- a/docs/pylon/distributed-training-launch-status.md
+++ b/docs/pylon/distributed-training-launch-status.md
@@ -113,6 +113,43 @@ That local pass matters because it moves the blocker fully out of the code
 contract lane. The remaining blocker for Episode 223 is now live release and
 live fleet proof, not whether the Mac/Linux A1 path exists in the code at all.
 
+## 2026-04-16 Post-Worker Closeout Update
+
+The remaining blocker is no longer assignment launch or bounded worker
+execution. The checked-in runtime now closes the specific post-worker gap that
+was still making the public claim too wide.
+
+What changed:
+
+- `Pylon` now persists retained closeout progress and validator claim state
+  instead of treating seal, finalize, and reconcile as transient supervisor
+  behavior
+- successful retained worker artifacts can now trigger autonomous window seal
+  during terminal sync
+- retained validator replay state can now finalize the challenge, request
+  reconcile, and observe accepted and payout state without a manual authority
+  call
+- the Transcript 222 and Episode 223 release scripts now include the new
+  autonomous truth test instead of treating artifact upload alone as the final
+  release gate
+
+What this closes:
+
+- the checked-in truth is no longer just "Pylon ran the worker and uploaded
+  files"
+- the bounded CS336 A1 lane now has a retained codepath from worker completion
+  to accepted closeout and payout observation
+- restart safety now covers the post-worker authority chain rather than only
+  the worker runtime
+
+What still remains:
+
+- cutting and deploying the current non-RC `Pylon` build line onto the live
+  demo fleet
+- proving one fresh live run reaches accepted outcome and payout receipt on the
+  current updated Pylons
+- wiring the separate website admin trigger/control surface
+
 ## Short Version
 
 The original admitted-node distributed-training MVP is materially complete in
@@ -130,11 +167,12 @@ integration implied by the current public story. The operator can now rehearse:
 - joiner-side resume over Tailnet
 
 That is real distributed-training control-plane and runtime behavior. It is
-not yet the same thing as a zero-touch public training market where any running
-`Pylon` auto-updates, receives the right slice of work, moves all needed
-artifacts automatically, returns accepted output, gets paid for that output,
-and exposes the whole process cleanly on the public `Nexus` surfaces without
-operator assistance.
+still not the same thing as a zero-touch public training market where any
+running `Pylon` auto-updates, receives the right slice of work, moves all
+needed artifacts automatically, returns accepted output, gets paid for that
+output, and exposes the whole process cleanly on the public `Nexus` surfaces
+without operator assistance. The checked-in post-worker authority path now
+exists. The missing proof is a fresh live run on the upgraded release line.
 
 ## What The Roadmap Already Closed
 

--- a/docs/pylon/distributed-training-mvp-roadmap.md
+++ b/docs/pylon/distributed-training-mvp-roadmap.md
@@ -1099,6 +1099,9 @@ become the admitted-node supervisor around `Psionic`.
 ### 3.1 Real training capability detection
 
 - Replace the inert training contributor default in `apps/pylon/src/lib.rs`.
+- Fresh `Pylon` defaults now advertise the training contributor inventory by
+  default, and `pylon config set` now exposes
+  `backend.adapter_training_contributor_enabled`.
 - Use a live local probe rather than config-only claims:
   - resolve the sibling `Psionic` machine training surface
   - combine that with host GPU, disk, and network telemetry
@@ -2589,6 +2592,10 @@ detection
 **Summary**
 
 Implement real training capability detection in `Pylon`.
+
+Fresh `Pylon` defaults now advertise the training contributor inventory by
+default, but that only removes the inert-off footgun. This workstream still
+owns the deeper runtime detection and honest refusal path.
 
 **Why**
 

--- a/scripts/release/check-pylon-episode-223-cs336-a1-local.sh
+++ b/scripts/release/check-pylon-episode-223-cs336-a1-local.sh
@@ -120,6 +120,7 @@ did the run.
 | Pylon claims and acknowledges the assignment | `pylon_assignment_intake` |
 | Pylon launches the retained runtime | `pylon_runtime_launch` |
 | Pylon syncs terminal artifacts back to Nexus | `pylon_terminal_sync` |
+| Pylon autonomously closes retained worker output into accepted payout observation | `pylon_autonomous_closeout` |
 
 EOF
 
@@ -212,6 +213,11 @@ run_step \
   "pylon_terminal_sync" \
   "Pylon uploads retained artifacts and reports success back to Nexus without duplicate publication" \
   "cargo test -p pylon --manifest-path '$ROOT_DIR/Cargo.toml' --lib training_terminal_sync_uploads_artifacts_and_reports_success_to_nexus -- --nocapture"
+
+run_step \
+  "pylon_autonomous_closeout" \
+  "Pylon seals retained worker output, finalizes validator replay, reconciles the window, and observes the payout receipt without manual closeout calls" \
+  "cargo test -p pylon --manifest-path '$ROOT_DIR/Cargo.toml' --lib pylon_autonomously_closes_homework_assignment_from_worker_completion_to_paid_receipt -- --nocapture"
 
 printf '## Result\n\n' >>"$SUMMARY_MD"
 if ((failed == 0)); then

--- a/scripts/release/check-pylon-transcript-222-canary.sh
+++ b/scripts/release/check-pylon-transcript-222-canary.sh
@@ -102,7 +102,8 @@ Transcript 222 can claim a small-cohort canary:
 - weak-device validator replay emits the accepted weak-device proof bundle
 - `Pylon` automatically claims, acknowledges, materializes, and launches one
   retained assignment
-- `Pylon` automatically uploads terminal receipts and checkpoint publication
+- `Pylon` automatically turns retained worker output into seal, validator
+  finalize, reconcile, and payout observation
 - `Nexus` closes one weak-device accepted-work payout and one strong-lane
   accepted-work payout
 - `/api/stats`, `/api/training/summary`, and `/api/homepage` project the same
@@ -112,13 +113,13 @@ Transcript 222 can claim a small-cohort canary:
 
 | Gate | Covered by |
 | --- | --- |
-| Strong-node accepted lane | `psionic_actual_lane`, `pylon_assignment_intake`, `pylon_runtime_launch`, `pylon_terminal_sync`, `nexus_strong_lane_payout` |
+| Strong-node accepted lane | `psionic_actual_lane`, `pylon_assignment_intake`, `pylon_runtime_launch`, `pylon_autonomous_closeout`, `nexus_strong_lane_payout` |
 | Weak-device accepted lane | `psionic_weak_device_proof`, `nexus_weak_lane_payout` |
 | Zero-touch assignment intake | `pylon_assignment_intake` |
 | Zero-touch artifact fetch and runtime launch | `pylon_assignment_intake`, `pylon_runtime_launch` |
-| Automatic runtime receipt upload | `pylon_terminal_sync` |
+| Automatic post-worker closeout | `pylon_autonomous_closeout` |
 | Public stats truth | `nexus_public_stats_projection`, `nexus_homepage_projection` |
-| Payout-linked accepted closeout | `nexus_weak_lane_payout`, `nexus_strong_lane_payout` |
+| Payout-linked accepted closeout | `pylon_autonomous_closeout`, `nexus_weak_lane_payout`, `nexus_strong_lane_payout` |
 
 EOF
 
@@ -193,9 +194,9 @@ run_step \
   "cargo test -p pylon --manifest-path '$ROOT_DIR/Cargo.toml' --lib auto_launch_starts_supervisor_from_retained_assignment_and_preserves_packets -- --nocapture"
 
 run_step \
-  "pylon_terminal_sync" \
-  "Pylon terminal sync uploads retained artifacts and reports success to Nexus without duplicate publication" \
-  "cargo test -p pylon --manifest-path '$ROOT_DIR/Cargo.toml' --lib training_terminal_sync_uploads_artifacts_and_reports_success_to_nexus -- --nocapture"
+  "pylon_autonomous_closeout" \
+  "Pylon uses retained worker and validator state to seal, finalize, reconcile, and observe payout without manual closeout calls" \
+  "cargo test -p pylon --manifest-path '$ROOT_DIR/Cargo.toml' --lib pylon_autonomously_closes_homework_assignment_from_worker_completion_to_paid_receipt -- --nocapture"
 
 run_step \
   "nexus_public_stats_projection" \


### PR DESCRIPTION
## Summary
- merge the remaining issue-4368 implementation stack on top of the now-merged retained-state refactor
- keep the generic homework launch, autonomous pylon closeout, validator/reconcile/payout path, and production hardening fixes on the same `main` base
- carry the retained runtime layering and closeout journal work forward on the actual 4368 codepath

## Testing
- cargo test -p pylon training_runtime_state_ -- --nocapture
- cargo test -p pylon training_terminal_sync_ -- --nocapture
- cargo test -p pylon pylon_autonomously_closes_homework_assignment_from_worker_completion_to_paid_receipt -- --nocapture