### PR TITLE
keep provider NIP-90 intake online

### DIFF
--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -132,13 +132,14 @@ pub use nip90_runtime::{
     AnnouncementAction, AnnouncementReport, BuyerJobHistoryReport, BuyerJobPaymentReport,
     BuyerJobReplayReport, BuyerJobSubmitReport, BuyerJobSubmitRequest, BuyerJobWatchEntry,
     BuyerJobWatchReport, BuyerPaymentPolicyMode, BuyerPaymentPolicyReport, ProviderIntakeReport,
-    ProviderRunReport, apply_buyer_payment_policy, approve_buyer_job_payment,
+    ProviderOnlineIntake, ProviderRunReport, apply_buyer_payment_policy, approve_buyer_job_payment,
     deny_buyer_job_payment, load_announcement_report, load_buyer_job_history,
     load_buyer_job_replay, publish_announcement_report, render_announcement_report,
     render_buyer_job_history_report, render_buyer_job_payment_report,
     render_buyer_job_replay_report, render_buyer_job_submit_report, render_buyer_job_watch_report,
     render_buyer_payment_policy_report, render_provider_intake_report, render_provider_run_report,
-    run_provider_requests, scan_provider_requests, submit_buyer_job, watch_buyer_jobs,
+    run_provider_online_intake_once, run_provider_requests, scan_provider_requests,
+    start_provider_online_intake, submit_buyer_job, watch_buyer_jobs,
 };
 pub use wallet_runtime::{
     WalletAddressReport, WalletBalanceSnapshot, WalletCreditSummaryReport, WalletHistoryReport,
@@ -164,7 +165,6 @@ const DEFAULT_PROVIDER_AUTO_RUN_INTERVAL_MS: u64 = 10_000;
 const DEFAULT_CODEX_WORKLOAD_TIMEOUT_SECONDS: u64 = 600;
 const DEFAULT_CODEX_WORKLOAD_CANCEL_POLL_SECONDS: u64 = 2;
 const DEFAULT_TRAINING_ASSIGNMENT_INTAKE_INTERVAL_MS: u64 = 30_000;
-const DEFAULT_PROVIDER_AUTO_RUN_WINDOW_SECONDS: u64 = 1;
 const DEFAULT_PROVIDER_PAYOUT_TARGET_SYNC_INTERVAL_MS: u64 = 300_000;
 const DEFAULT_PROVIDER_HOST_TELEMETRY_REFRESH_INTERVAL_MS: u64 = 30_000;
 const DEFAULT_TRAINING_COORDINATION_RETRY_ATTEMPTS: usize = 3;
@@ -21987,17 +21987,16 @@ async fn serve(config_path: &Path, mut config: PylonConfig) -> Result<()> {
     let identity = ensure_identity(config.identity_path.as_path())?;
     let provider_presence_session_id = new_provider_presence_session_id();
     let provider_presence_heartbeat_interval = provider_presence_heartbeat_interval();
-    let provider_auto_run_interval = provider_auto_run_interval();
     let training_assignment_intake_interval = training_assignment_intake_interval();
     let provider_payout_target_sync_interval = provider_payout_target_sync_interval();
     let mut next_provider_presence_heartbeat_at = Instant::now();
-    let mut next_provider_auto_run_at = Instant::now();
     let mut next_training_assignment_intake_at = Instant::now();
     let mut next_provider_payout_target_sync_at = Instant::now();
     let mut provider_presence_online = false;
     let mut provider_presence_error = None::<String>;
     let mut provider_payout_target_error = None::<String>;
     let mut previous_snapshot = None::<Arc<ProviderPersistedSnapshot>>;
+    let mut provider_online_intake = None::<ProviderOnlineIntake>;
     let mut training_supervisor_process = None::<PylonTrainingSupervisorProcess>;
     let mut needs_sync = true;
     loop {
@@ -22064,6 +22063,9 @@ async fn serve(config_path: &Path, mut config: PylonConfig) -> Result<()> {
         }
 
         if desired_mode != ProviderDesiredMode::Online && provider_presence_online {
+            if let Some(intake) = provider_online_intake.take() {
+                intake.shutdown().await;
+            }
             if let Err(error) = report_provider_presence_offline(
                 &presence_client,
                 &config,
@@ -22079,7 +22081,6 @@ async fn serve(config_path: &Path, mut config: PylonConfig) -> Result<()> {
             }
             provider_presence_online = false;
             next_provider_presence_heartbeat_at = Instant::now();
-            next_provider_auto_run_at = Instant::now();
             next_training_assignment_intake_at = Instant::now();
             next_provider_payout_target_sync_at = Instant::now();
             if update_provider_control_plane_error(&mut provider_presence_error, None) {
@@ -22141,15 +22142,43 @@ async fn serve(config_path: &Path, mut config: PylonConfig) -> Result<()> {
         if let Some(snapshot) = previous_snapshot.as_deref() {
             if desired_mode == ProviderDesiredMode::Online
                 && snapshot.runtime.authoritative_status.as_deref() == Some("online")
-                && Instant::now() >= next_provider_auto_run_at
             {
-                if let Err(error) =
-                    run_provider_requests(config_path, DEFAULT_PROVIDER_AUTO_RUN_WINDOW_SECONDS)
-                        .await
-                {
-                    eprintln!("warning: automatic pylon provider intake pass failed: {error}");
+                if provider_online_intake.is_none() {
+                    match start_provider_online_intake(config_path).await {
+                        Ok(intake) => {
+                            eprintln!(
+                                "pylon: provider NIP-90 intake connected for {}",
+                                intake.provider_pubkey()
+                            );
+                            provider_online_intake = Some(intake);
+                        }
+                        Err(error) => {
+                            eprintln!(
+                                "warning: failed to start persistent pylon provider intake: {error}"
+                            );
+                        }
+                    }
                 }
-                next_provider_auto_run_at = Instant::now() + provider_auto_run_interval;
+                if let Some(intake) = provider_online_intake.as_mut() {
+                    match run_provider_online_intake_once(config_path, intake).await {
+                        Ok(Some(report)) => eprintln!(
+                            "pylon: provider intake processed {} entries (completed={}, failed={}, dropped={})",
+                            report.entries.len(),
+                            report.completed_count,
+                            report.failed_count,
+                            report.dropped_count
+                        ),
+                        Ok(None) => {}
+                        Err(error) => {
+                            eprintln!("warning: automatic pylon provider intake pass failed: {error}");
+                            if let Some(intake) = provider_online_intake.take() {
+                                intake.shutdown().await;
+                            }
+                        }
+                    }
+                }
+            } else if let Some(intake) = provider_online_intake.take() {
+                intake.shutdown().await;
             }
             if desired_mode == ProviderDesiredMode::Online
                 && Instant::now() >= next_training_assignment_intake_at
@@ -22255,6 +22284,9 @@ async fn serve(config_path: &Path, mut config: PylonConfig) -> Result<()> {
         tokio::select! {
             result = tokio::signal::ctrl_c() => {
                 result.context("failed waiting for ctrl-c")?;
+                if let Some(intake) = provider_online_intake.take() {
+                    intake.shutdown().await;
+                }
                 if provider_presence_online {
                     if let Err(error) = report_provider_presence_offline(
                         &presence_client,
@@ -50677,7 +50709,13 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                         continue;
                     };
                     if !request_sent && payload.contains("\"REQ\"") {
-                        let matching = json!(["EVENT", "run", {
+                        let req_frame: serde_json::Value =
+                            serde_json::from_str(payload.as_str()).expect("parse req frame");
+                        let subscription_id = req_frame[1]
+                            .as_str()
+                            .expect("subscription id")
+                            .to_string();
+                        let matching = json!(["EVENT", subscription_id, {
                             "id": "run-job-auto-001",
                             "pubkey": "buyer-pubkey-auto-001",
                             "created_at": 1_760_000_210u64,
@@ -50694,7 +50732,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                             .await
                             .expect("send matching request");
                         request_sent = true;
-                        break;
+                        continue;
                     }
                     if !payload.contains("\"EVENT\"") {
                         continue;
@@ -50711,7 +50749,7 @@ pub const PSIONIC_TRAIN_CS336_A1_DEMO_ENVIRONMENT_REF: &str = \"psionic.environm
                     if value[1]["kind"] == 7000 || value[1]["kind"] == 6050 {
                         published.push(value[1].clone());
                     } else {
-                        break;
+                        continue;
                     }
                     if published.len() == 2 {
                         return published;

--- a/apps/pylon/src/nip90_runtime.rs
+++ b/apps/pylon/src/nip90_runtime.rs
@@ -12,6 +12,7 @@ use nostr::nip90::{
 use nostr::{Event, EventTemplate, finalize_event};
 use nostr_client::{PoolConfig, RelayConfig, RelayMessage, RelayPool};
 use openagents_provider_substrate::ProviderAdvertisedProduct;
+use tokio::sync::mpsc;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::json;
@@ -125,10 +126,76 @@ struct ObservedProviderRequest {
 
 #[derive(Clone, Debug)]
 struct ProviderRequestCollection {
+    seconds: u64,
     provider_pubkey: String,
     desired_mode: openagents_provider_substrate::ProviderDesiredMode,
     spec: Option<AnnouncementSpec>,
     observed: Vec<ObservedProviderRequest>,
+}
+
+pub struct ProviderOnlineIntake {
+    pool: RelayPool,
+    subscription_id: String,
+    provider_pubkey: String,
+    desired_mode: openagents_provider_substrate::ProviderDesiredMode,
+    spec: Option<AnnouncementSpec>,
+    event_rx: mpsc::Receiver<ObservedProviderRequest>,
+    relay_tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl ProviderOnlineIntake {
+    pub fn provider_pubkey(&self) -> &str {
+        self.provider_pubkey.as_str()
+    }
+
+    pub async fn shutdown(mut self) {
+        let _ = self.pool.unsubscribe(self.subscription_id.as_str()).await;
+        for task in self.relay_tasks.drain(..) {
+            task.abort();
+        }
+        let _ = self.pool.disconnect_all().await;
+    }
+
+    async fn collect_available(&mut self) -> ProviderRequestCollection {
+        let deadline = std::time::Instant::now() + Duration::from_millis(250);
+        let poll_step = Duration::from_millis(25);
+        let mut observed = BTreeMap::<String, ObservedProviderRequest>::new();
+        while let Ok(request) = self.event_rx.try_recv() {
+            observed
+                .entry(request.entry.request_event_id.clone())
+                .or_insert(request);
+        }
+        while std::time::Instant::now() < deadline {
+            let mut received_any = false;
+            for relay in self.pool.relays().await {
+                let Ok(Ok(Some(RelayMessage::Event(_, event)))) =
+                    tokio::time::timeout(poll_step, relay.recv()).await
+                else {
+                    continue;
+                };
+                received_any = true;
+                let entry = classify_provider_request(
+                    relay.url(),
+                    self.provider_pubkey.as_str(),
+                    self.spec.as_ref(),
+                    &event,
+                );
+                observed
+                    .entry(entry.request_event_id.clone())
+                    .or_insert(ObservedProviderRequest { event, entry });
+            }
+            if !received_any {
+                break;
+            }
+        }
+        ProviderRequestCollection {
+            seconds: 0,
+            provider_pubkey: self.provider_pubkey.clone(),
+            desired_mode: self.desired_mode,
+            spec: self.spec.clone(),
+            observed: observed.into_values().collect(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -517,8 +584,88 @@ pub fn render_provider_intake_report(report: &ProviderIntakeReport) -> String {
     lines.join("\n")
 }
 
+pub async fn start_provider_online_intake(config_path: &Path) -> Result<ProviderOnlineIntake> {
+    let config = crate::ensure_local_setup(config_path)?;
+    let identity = ensure_identity(config.identity_path.as_path())?;
+    let (_, status) = load_config_and_status(config_path).await?;
+    let spec = announcement_spec(&config, &status);
+    let pool = build_relay_pool(&config, &identity).await?;
+    let subscription_id = format!("pylon-provider-online-{}", crate::now_epoch_ms());
+    let (event_tx, event_rx) = mpsc::channel(1000);
+    pool.subscribe_filters(
+        subscription_id.as_str(),
+        vec![json!({
+            "kinds": [ANNOUNCEMENT_KIND_TEXT_GENERATION],
+        })],
+    )
+    .await
+    .context("failed to subscribe persistent provider intake")?;
+    let mut relay_tasks = Vec::new();
+    for relay in pool.relays().await {
+        let relay_url = relay.url().to_string();
+        let provider_pubkey = identity.public_key_hex.clone();
+        let spec = spec.clone();
+        let event_tx = event_tx.clone();
+        relay_tasks.push(tokio::spawn(async move {
+            loop {
+                match relay.recv().await {
+                    Ok(Some(RelayMessage::Event(_, event))) => {
+                        let entry = classify_provider_request(
+                            relay_url.as_str(),
+                            provider_pubkey.as_str(),
+                            spec.as_ref(),
+                            &event,
+                        );
+                        if event_tx
+                            .send(ObservedProviderRequest { event, entry })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(Some(_)) => {}
+                    Ok(None) | Err(_) => break,
+                }
+            }
+        }));
+    }
+    drop(event_tx);
+
+    Ok(ProviderOnlineIntake {
+        pool,
+        subscription_id,
+        provider_pubkey: identity.public_key_hex,
+        desired_mode: status.desired_mode,
+        spec,
+        event_rx,
+        relay_tasks,
+    })
+}
+
+pub async fn run_provider_online_intake_once(
+    config_path: &Path,
+    intake: &mut ProviderOnlineIntake,
+) -> Result<Option<ProviderRunReport>> {
+    let collected = intake.collect_available().await;
+    if collected.observed.is_empty() {
+        return Ok(None);
+    }
+    run_provider_request_collection(config_path, collected, Some(&intake.pool))
+        .await
+        .map(Some)
+}
+
 pub async fn run_provider_requests(config_path: &Path, seconds: u64) -> Result<ProviderRunReport> {
     let collected = collect_provider_requests(config_path, seconds).await?;
+    run_provider_request_collection(config_path, collected, None).await
+}
+
+async fn run_provider_request_collection(
+    config_path: &Path,
+    collected: ProviderRequestCollection,
+    publish_pool_ref: Option<&RelayPool>,
+) -> Result<ProviderRunReport> {
     let local_target = collected.spec.as_ref().map(spec_to_local_target);
     let price_msats = collected.spec.as_ref().and_then(|spec| spec.price_msats);
     let config = crate::ensure_local_setup(config_path)?;
@@ -946,12 +1093,15 @@ pub async fn run_provider_requests(config_path: &Path, seconds: u64) -> Result<P
                         continue;
                     }
                 };
-                let pool = match publish_pool.as_ref() {
+                let pool = match publish_pool_ref {
                     Some(pool) => pool,
-                    None => {
-                        publish_pool = Some(build_relay_pool(&config, &identity).await?);
-                        publish_pool.as_ref().expect("publish pool should exist")
-                    }
+                    None => match publish_pool.as_ref() {
+                        Some(pool) => pool,
+                        None => {
+                            publish_pool = Some(build_relay_pool(&config, &identity).await?);
+                            publish_pool.as_ref().expect("publish pool should exist")
+                        }
+                    },
                 };
                 let payment_event = match publish_payment_required_feedback(
                     pool,
@@ -1046,12 +1196,15 @@ pub async fn run_provider_requests(config_path: &Path, seconds: u64) -> Result<P
             None,
             None,
         )?;
-        let pool = match publish_pool.as_ref() {
+        let pool = match publish_pool_ref {
             Some(pool) => pool,
-            None => {
-                publish_pool = Some(build_relay_pool(&config, &identity).await?);
-                publish_pool.as_ref().expect("publish pool should exist")
-            }
+            None => match publish_pool.as_ref() {
+                Some(pool) => pool,
+                None => {
+                    publish_pool = Some(build_relay_pool(&config, &identity).await?);
+                    publish_pool.as_ref().expect("publish pool should exist")
+                }
+            },
         };
         let processing_event = match publish_processing_feedback(
             pool,
@@ -1307,7 +1460,7 @@ pub async fn run_provider_requests(config_path: &Path, seconds: u64) -> Result<P
     }
 
     Ok(ProviderRunReport {
-        seconds,
+        seconds: collected.seconds,
         provider_pubkey: collected.provider_pubkey,
         local_model: local_target.map(|target| target.model),
         accepted_count,
@@ -2424,6 +2577,7 @@ async fn collect_provider_requests(
     let _ = pool.unsubscribe(subscription_id.as_str()).await;
 
     Ok(ProviderRequestCollection {
+        seconds,
         provider_pubkey: identity.public_key_hex,
         desired_mode: status.desired_mode,
         spec,

--- a/crates/nostr/client/src/relay.rs
+++ b/crates/nostr/client/src/relay.rs
@@ -306,11 +306,14 @@ impl RelayConnection {
 
     /// Register and send subscription request.
     pub async fn subscribe(&self, subscription: Subscription) -> Result<()> {
-        self.send_json(&build_req_payload(&subscription)).await?;
         self.subscriptions
             .lock()
             .await
-            .insert(subscription.id.clone(), subscription);
+            .insert(subscription.id.clone(), subscription.clone());
+        if let Err(error) = self.send_json(&build_req_payload(&subscription)).await {
+            self.subscriptions.lock().await.remove(&subscription.id);
+            return Err(error);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
  ## Summary
    
    Provider online mode rebuilt its NIP-90 relay intake on a short periodic scan loop. That meant an online provider was only actively subscribed during scan windows, then tore down and recreated relay state again on the next pass.
    
    This changes online provider mode to keep a persistent relay intake session alive while the provider is online.
    
    Before:
    
    1. Online mode waited for the provider auto-run interval.
    2. It built a relay pool and subscription for a short scan window.
    3. It collected matching NIP-90 requests.
    4. It dropped the pool/subscription.
    5. It repeated the same setup again on the next interval.
    
    That made “Go Online” less truthful for users because paid jobs could arrive between scan windows and be missed or delayed.
    
    After:
    
    1. Online mode starts one ProviderOnlineIntake when the provider is online.
    2. The relay pool and NIP-90 subscription stay connected for the online session.
    3. Incoming provider requests are drained from the persistent intake path.
    4. Existing provider admission, auto-accept, execution, feedback, result publish, and processed-request dedupe behavior is reused.
    5. Intake shuts down explicitly when the provider leaves online mode or receives ctrl-c.
    
    Files changed
    
    - apps/pylon/src/nip90_runtime.rs
      - Adds ProviderOnlineIntake.
      - Adds start_provider_online_intake().
      - Adds run_provider_online_intake_once().
      - Adds persistent relay receive tasks with bounded intake queueing.
      - Refactors provider request processing so legacy scan mode and persistent online intake share the same runner.
      - Keeps run_provider_requests() available for explicit scan/manual paths.
    
    - apps/pylon/src/lib.rs
      - Replaces the 10s interval / 1s scan-window online provider intake loop.
      - Owns Option<ProviderOnlineIntake> in the serve loop.
      - Starts intake once when desired provider mode is Online and authoritative status is online.
      - Processes available intake requests every serve-loop pass.
      - Shuts intake down on offline transition and ctrl-c.
      - Updates the automatic provider intake regression test mock relay to use the real subscription id.
    
    - crates/nostr/client/src/relay.rs
      - Registers relay subscriptions before sending the REQ frame.
      - Prevents an early EVENT response from arriving before local subscription state exists.
    
    
    What improvements should we expect?
    
    - Online providers stay subscribed to NIP-90 request relays instead of periodically reconnecting.
    - Lower job discovery latency for paid work.
    - Fewer missed jobs caused by requests arriving between short scan windows.
    - Less repeated WebSocket/subscription setup overhead.
    - “Click Go Online → receive paid work → complete job → earn sats” is more reliable because provider intake is continuously listening while online.
    - Existing scan/manual command paths still work, so this is a narrow online-mode behavior change.
    
    Validation
    
    Passed:
    
    - cargo check -p pylon
    - cargo test -p pylon serve_online_mode_runs_provider_intake_automatically -- --nocapture
    - cargo test -p pylon provider_scan_filters_targeted_requests -- --nocapture
    - cargo test -p pylon provider_run_processes_matching_request_locally -- --nocapture
    - cargo test -p pylon provider_run_skips_request_ids_persisted_in_processed_store -- --nocapture
    - cargo test -p nostr-client subscribe_succeeds_when_at_least_one_relay_is_connected -- --nocapture
    
    Known unrelated failure
    
    The broader provider test filter still has one failing test:
    
    - cargo test -p pylon provider_run_settles_paid_request_and_projects_retained_views -- --nocapture
    
    Failure:
    
    - “earnings report should project retained provider settlement totals”
    
    This test also fails when run standalone and is in the retained settlement projection path, not the NIP-90 online intake path changed here.