### PR TITLE
Make relay receive, connect, and publish fanout concurrent with bounded per-relay timeouts.

### DIFF
--- a/apps/nexus-control/src/lib.rs
+++ b/apps/nexus-control/src/lib.rs
@@ -15405,6 +15405,7 @@ async fn build_training_trn_relay_pool(relay_urls: &[String]) -> Result<RelayPoo
     let pool = RelayPool::new(PoolConfig {
         max_relays: relay_urls.len().max(1),
         relay_config,
+        fanout_timeout: Duration::from_secs(10),
     });
     for relay_url in relay_urls {
         pool.add_relay(relay_url.as_str())

--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -20826,6 +20826,7 @@ async fn build_training_relay_pool(
     let pool = RelayPool::new(PoolConfig {
         max_relays: relay_urls.len().max(1),
         relay_config,
+        fanout_timeout: Duration::from_secs(config.relay_connect_timeout_seconds.max(1).min(10)),
     });
     for relay_url in relay_urls {
         pool.add_relay(relay_url.as_str())

--- a/apps/pylon/src/nip90_runtime.rs
+++ b/apps/pylon/src/nip90_runtime.rs
@@ -133,6 +133,26 @@ struct ProviderRequestCollection {
     observed: Vec<ObservedProviderRequest>,
 }
 
+struct RelayTaskAbortGuard(Vec<tokio::task::JoinHandle<()>>);
+
+impl RelayTaskAbortGuard {
+    fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    fn push(&mut self, task: tokio::task::JoinHandle<()>) {
+        self.0.push(task);
+    }
+}
+
+impl Drop for RelayTaskAbortGuard {
+    fn drop(&mut self) {
+        for task in self.0.drain(..) {
+            task.abort();
+        }
+    }
+}
+
 pub struct ProviderOnlineIntake {
     pool: RelayPool,
     subscription_id: String,
@@ -166,16 +186,25 @@ impl ProviderOnlineIntake {
                 .or_insert(request);
         }
         while std::time::Instant::now() < deadline {
+            let relays = self.pool.relays().await;
+            let mut relay_polls = Vec::new();
+            for relay in relays {
+                relay_polls.push(tokio::spawn(async move {
+                    let relay_url = relay.url().to_string();
+                    match tokio::time::timeout(poll_step, relay.recv()).await {
+                        Ok(Ok(Some(RelayMessage::Event(_, event)))) => Some((relay_url, event)),
+                        Ok(Ok(Some(_))) | Ok(Ok(None)) | Ok(Err(_)) | Err(_) => None,
+                    }
+                }));
+            }
             let mut received_any = false;
-            for relay in self.pool.relays().await {
-                let Ok(Ok(Some(RelayMessage::Event(_, event)))) =
-                    tokio::time::timeout(poll_step, relay.recv()).await
-                else {
+            for relay_poll in relay_polls {
+                let Ok(Some((relay_url, event))) = relay_poll.await else {
                     continue;
                 };
                 received_any = true;
                 let entry = classify_provider_request(
-                    relay.url(),
+                    relay_url.as_str(),
                     self.provider_pubkey.as_str(),
                     self.spec.as_ref(),
                     &event,
@@ -591,7 +620,7 @@ pub async fn start_provider_online_intake(config_path: &Path) -> Result<Provider
     let spec = announcement_spec(&config, &status);
     let pool = build_relay_pool(&config, &identity).await?;
     let subscription_id = format!("pylon-provider-online-{}", crate::now_epoch_ms());
-    let (event_tx, event_rx) = mpsc::channel(1000);
+    let (_event_tx, event_rx) = mpsc::channel(1000);
     pool.subscribe_filters(
         subscription_id.as_str(),
         vec![json!({
@@ -600,37 +629,7 @@ pub async fn start_provider_online_intake(config_path: &Path) -> Result<Provider
     )
     .await
     .context("failed to subscribe persistent provider intake")?;
-    let mut relay_tasks = Vec::new();
-    for relay in pool.relays().await {
-        let relay_url = relay.url().to_string();
-        let provider_pubkey = identity.public_key_hex.clone();
-        let spec = spec.clone();
-        let event_tx = event_tx.clone();
-        relay_tasks.push(tokio::spawn(async move {
-            loop {
-                match relay.recv().await {
-                    Ok(Some(RelayMessage::Event(_, event))) => {
-                        let entry = classify_provider_request(
-                            relay_url.as_str(),
-                            provider_pubkey.as_str(),
-                            spec.as_ref(),
-                            &event,
-                        );
-                        if event_tx
-                            .send(ObservedProviderRequest { event, entry })
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    Ok(Some(_)) => {}
-                    Ok(None) | Err(_) => break,
-                }
-            }
-        }));
-    }
-    drop(event_tx);
+    let relay_tasks = Vec::new();
 
     Ok(ProviderOnlineIntake {
         pool,
@@ -1663,78 +1662,93 @@ where
     let mut feedback_count = 0usize;
     let mut result_count = 0usize;
 
+    let (event_tx, mut event_rx) = mpsc::channel::<(String, Event)>(1000);
+    let mut relay_tasks = RelayTaskAbortGuard::new();
+    for relay in pool.relays().await {
+        let relay_url = relay.url().to_string();
+        let event_tx = event_tx.clone();
+        relay_tasks.push(tokio::spawn(async move {
+            loop {
+                match relay.recv().await {
+                    Ok(Some(RelayMessage::Event(_, event))) => {
+                        if event_tx.send((relay_url.clone(), event)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Some(_)) => {}
+                    Ok(None) | Err(_) => break,
+                }
+            }
+        }));
+    }
+    drop(event_tx);
+
     while std::time::Instant::now() < deadline {
-        let relays = pool.relays().await;
-        for relay in relays {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            if remaining.is_zero() {
-                break;
-            }
-            let wait = remaining.min(poll_step);
-            let recv = tokio::time::timeout(wait, relay.recv()).await;
-            let message = match recv {
-                Ok(Ok(Some(message))) => message,
-                Ok(Ok(None)) | Ok(Err(_)) | Err(_) => continue,
-            };
-            let RelayMessage::Event(_, event) = message else {
-                continue;
-            };
-            if !seen_event_ids.insert(event.id.clone()) {
-                continue;
-            }
-            let Some(entry) = classify_buyer_job_event(relay.url(), &tracked, &event) else {
-                continue;
-            };
-            persist_buyer_job_event(config_path, &entry)?;
-            if entry.event_kind == "feedback" {
-                feedback_count += 1;
-            } else if entry.event_kind == "result" {
-                result_count += 1;
-            }
-            on_event(entry.clone());
-            entries.push(entry);
-            if auto_pay_enabled
-                && entries.last().is_some_and(|entry| {
-                    entry.event_kind == "feedback" && entry.status == "payment-required"
-                })
-            {
-                let latest = entries.last().cloned().expect("latest entry");
-                match approve_buyer_job_payment(config_path, latest.request_event_id.as_str()).await
-                {
-                    Ok(report) => {
-                        let payment_entry = BuyerJobWatchEntry {
-                            request_event_id: report.request_event_id.clone(),
-                            provider_pubkey: latest.provider_pubkey.clone(),
-                            relay_url: None,
-                            event_id: report
-                                .payment_id
-                                .clone()
-                                .unwrap_or_else(|| format!("payment:{}", report.request_event_id)),
-                            event_kind: "payment".to_string(),
-                            status: report.status.clone(),
-                            amount_msats: report.amount_msats,
-                            bolt11: report.bolt11.clone(),
-                            result_preview: None,
-                            detail: report.detail.clone(),
-                        };
-                        on_event(payment_entry.clone());
-                        entries.push(payment_entry);
-                    }
-                    Err(error) => {
-                        let payment_entry = record_buyer_payment_failure(
-                            config_path,
-                            latest.request_event_id.as_str(),
-                            latest.amount_msats,
-                            latest.bolt11.as_deref(),
-                            error.to_string().as_str(),
-                        )?;
-                        on_event(payment_entry.clone());
-                        entries.push(payment_entry);
-                    }
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let Some((relay_url, event)) =
+            tokio::time::timeout(remaining.min(poll_step), event_rx.recv())
+                .await
+                .ok()
+                .flatten()
+        else {
+            continue;
+        };
+        if !seen_event_ids.insert(event.id.clone()) {
+            continue;
+        }
+        let Some(entry) = classify_buyer_job_event(relay_url.as_str(), &tracked, &event) else {
+            continue;
+        };
+        persist_buyer_job_event(config_path, &entry)?;
+        if entry.event_kind == "feedback" {
+            feedback_count += 1;
+        } else if entry.event_kind == "result" {
+            result_count += 1;
+        }
+        on_event(entry.clone());
+        entries.push(entry);
+        if auto_pay_enabled
+            && entries.last().is_some_and(|entry| {
+                entry.event_kind == "feedback" && entry.status == "payment-required"
+            })
+            && let Some(latest) = entries.last().cloned()
+        {
+            match approve_buyer_job_payment(config_path, latest.request_event_id.as_str()).await {
+                Ok(report) => {
+                    let payment_entry = BuyerJobWatchEntry {
+                        request_event_id: report.request_event_id.clone(),
+                        provider_pubkey: latest.provider_pubkey.clone(),
+                        relay_url: None,
+                        event_id: report
+                            .payment_id
+                            .clone()
+                            .unwrap_or_else(|| format!("payment:{}", report.request_event_id)),
+                        event_kind: "payment".to_string(),
+                        status: report.status.clone(),
+                        amount_msats: report.amount_msats,
+                        bolt11: report.bolt11.clone(),
+                        result_preview: None,
+                        detail: report.detail.clone(),
+                    };
+                    on_event(payment_entry.clone());
+                    entries.push(payment_entry);
+                }
+                Err(error) => {
+                    let payment_entry = record_buyer_payment_failure(
+                        config_path,
+                        latest.request_event_id.as_str(),
+                        latest.amount_msats,
+                        latest.bolt11.as_deref(),
+                        error.to_string().as_str(),
+                    )?;
+                    on_event(payment_entry.clone());
+                    entries.push(payment_entry);
                 }
             }
         }
-        tokio::time::sleep(Duration::from_millis(30)).await;
     }
     let _ = pool.unsubscribe(subscription_id.as_str()).await;
 
@@ -2513,6 +2527,7 @@ async fn build_relay_pool(
     let pool = RelayPool::new(PoolConfig {
         max_relays: config.relay_urls.len().max(1),
         relay_config,
+        fanout_timeout: Duration::from_secs(config.relay_connect_timeout_seconds.max(1).min(10)),
     });
     for relay in &config.relay_urls {
         pool.add_relay(relay.as_str())

--- a/crates/nostr/client/src/pool.rs
+++ b/crates/nostr/client/src/pool.rs
@@ -7,6 +7,7 @@ use nostr::Event;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::debug;
 
@@ -17,6 +18,8 @@ pub struct PoolConfig {
     pub max_relays: usize,
     /// Relay configuration template.
     pub relay_config: RelayConfig,
+    /// Maximum time to wait for one relay fanout operation.
+    pub fanout_timeout: Duration,
 }
 
 impl Default for PoolConfig {
@@ -24,6 +27,7 @@ impl Default for PoolConfig {
         Self {
             max_relays: 16,
             relay_config: RelayConfig::default(),
+            fanout_timeout: Duration::from_secs(5),
         }
     }
 }
@@ -76,11 +80,23 @@ impl RelayPool {
     pub async fn connect_all(&self) -> Result<()> {
         let relays: Vec<Arc<RelayConnection>> =
             self.relays.read().await.values().cloned().collect();
-        let mut successful = 0usize;
-        for relay in relays {
+        let results = futures_util::future::join_all(relays.into_iter().map(|relay| async move {
+            let relay_url = relay.url().to_string();
             match relay.connect().await {
-                Ok(()) => successful += 1,
-                Err(error) => debug!("relay connect failed: {}", error),
+                Ok(()) => (relay_url, true, None),
+                Err(error) => (relay_url, false, Some(error.to_string())),
+            }
+        }))
+        .await;
+
+        let successful = results.iter().filter(|(_, ok, _)| *ok).count();
+        for (relay_url, ok, error) in results {
+            if !ok {
+                debug!(
+                    "relay connect failed on {}: {}",
+                    relay_url,
+                    error.as_deref().unwrap_or("unknown error")
+                );
             }
         }
         if successful == 0 {
@@ -109,19 +125,33 @@ impl RelayPool {
             return Err(ClientError::NotConnected);
         }
 
-        let mut confirmations = Vec::new();
-        for relay in relays {
-            match relay.publish(event).await {
-                Ok(confirmation) => confirmations.push(confirmation),
-                Err(error) => confirmations.push(PublishConfirmation {
-                    relay_url: relay.url().to_string(),
-                    event_id: event.id.clone(),
-                    accepted: false,
-                    message: error.to_string(),
-                }),
-            }
-        }
-        Ok(confirmations)
+        let event = Arc::new(event.clone());
+        let fanout_timeout = self.config.fanout_timeout;
+        Ok(
+            futures_util::future::join_all(relays.into_iter().map(|relay| {
+                let event = Arc::clone(&event);
+                async move {
+                    let relay_url = relay.url().to_string();
+                    match tokio::time::timeout(fanout_timeout, relay.publish(event.as_ref())).await
+                    {
+                        Ok(Ok(confirmation)) => confirmation,
+                        Ok(Err(error)) => PublishConfirmation {
+                            relay_url,
+                            event_id: event.id.clone(),
+                            accepted: false,
+                            message: error.to_string(),
+                        },
+                        Err(_) => PublishConfirmation {
+                            relay_url,
+                            event_id: event.id.clone(),
+                            accepted: false,
+                            message: format!("publish timeout after {:?}", fanout_timeout),
+                        },
+                    }
+                }
+            }))
+            .await,
+        )
     }
 
     /// Send subscription to all connected relays.
@@ -131,14 +161,46 @@ impl RelayPool {
         if relays.is_empty() {
             return Err(ClientError::NotConnected);
         }
-        let mut successful = 0usize;
-        let mut failures = Vec::new();
-        for relay in relays {
-            match relay.subscribe(subscription.clone()).await {
-                Ok(()) => successful += 1,
-                Err(error) => failures.push(format!("{}: {}", relay.url(), error)),
+
+        let fanout_timeout = self.config.fanout_timeout;
+        let results = futures_util::future::join_all(relays.into_iter().map(|relay| {
+            let subscription = subscription.clone();
+            async move {
+                let relay_url = relay.url().to_string();
+                let subscription_id = subscription.id.clone();
+                match tokio::time::timeout(fanout_timeout, relay.subscribe(subscription)).await {
+                    Ok(Ok(())) => (relay_url, true, None),
+                    Ok(Err(error)) => (relay_url, false, Some(error.to_string())),
+                    Err(_) => {
+                        relay
+                            .remove_subscription_local(subscription_id.as_str())
+                            .await;
+                        (
+                            relay_url,
+                            false,
+                            Some(format!("subscribe timeout after {:?}", fanout_timeout)),
+                        )
+                    }
+                }
             }
-        }
+        }))
+        .await;
+
+        let successful = results.iter().filter(|(_, ok, _)| *ok).count();
+        let failures = results
+            .into_iter()
+            .filter_map(|(relay_url, ok, error)| {
+                if ok {
+                    None
+                } else {
+                    Some(format!(
+                        "{}: {}",
+                        relay_url,
+                        error.unwrap_or_else(|| "unknown error".to_string())
+                    ))
+                }
+            })
+            .collect::<Vec<_>>();
         if successful == 0 {
             if failures.is_empty() {
                 return Err(ClientError::NotConnected);
@@ -185,11 +247,152 @@ impl RelayPool {
 #[cfg(test)]
 mod tests {
     use super::{PoolConfig, RelayPool};
+    use crate::relay::RelayConfig;
     use crate::subscription::Subscription;
     use futures_util::{SinkExt, StreamExt};
+    use nostr::{Event, EventTemplate, finalize_event};
     use serde_json::json;
+    use std::time::{Duration, Instant};
     use tokio::net::TcpListener;
     use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    fn test_event() -> Event {
+        finalize_event(
+            &EventTemplate {
+                created_at: 1,
+                kind: 1,
+                tags: Vec::new(),
+                content: "relay fanout test".to_string(),
+            },
+            &[7u8; 32],
+        )
+        .expect("sign test event")
+    }
+
+    async fn live_relay_task(listener: TcpListener) -> tokio::task::JoinHandle<Vec<String>> {
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept client");
+            let mut socket = accept_async(stream).await.expect("upgrade websocket");
+            let mut payloads = Vec::new();
+            while let Some(message) = socket.next().await {
+                let Ok(Message::Text(payload)) = message else {
+                    continue;
+                };
+                let payload = payload.to_string();
+                payloads.push(payload.clone());
+                if payload.contains("\"REQ\"") {
+                    socket
+                        .send(Message::Text("[\"EOSE\",\"test-subscription\"]".into()))
+                        .await
+                        .expect("send eose");
+                    break;
+                }
+                if payload.contains("\"EVENT\"") {
+                    break;
+                }
+            }
+            payloads
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_all_does_not_wait_serially_for_slow_relays() {
+        let slow_one = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind slow relay one");
+        let slow_one_url = format!("ws://{}", slow_one.local_addr().expect("slow one addr"));
+        let slow_two = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind slow relay two");
+        let slow_two_url = format!("ws://{}", slow_two.local_addr().expect("slow two addr"));
+        let live = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind live relay");
+        let live_url = format!("ws://{}", live.local_addr().expect("live addr"));
+        let live_task = live_relay_task(live).await;
+
+        let pool = RelayPool::new(PoolConfig {
+            max_relays: 3,
+            relay_config: RelayConfig {
+                connect_timeout: Duration::from_millis(250),
+                ..RelayConfig::default()
+            },
+            fanout_timeout: Duration::from_millis(250),
+        });
+        pool.add_relay(slow_one_url.as_str())
+            .await
+            .expect("add slow relay one");
+        pool.add_relay(slow_two_url.as_str())
+            .await
+            .expect("add slow relay two");
+        pool.add_relay(live_url.as_str())
+            .await
+            .expect("add live relay");
+
+        let started = Instant::now();
+        pool.connect_all()
+            .await
+            .expect("connect at least one relay");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(450),
+            "connect_all should be bounded by one timeout window, elapsed={elapsed:?}"
+        );
+        pool.disconnect_all().await.expect("disconnect pool");
+        live_task.abort();
+        drop(slow_one);
+        drop(slow_two);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn publish_fanout_reports_partial_relay_failures() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind relay");
+        let relay_addr = listener.local_addr().expect("relay addr");
+        let live_relay_url = format!("ws://{relay_addr}");
+
+        let missing_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind missing relay");
+        let missing_relay_url = format!("ws://{}", missing_listener.local_addr().expect("addr"));
+        drop(missing_listener);
+
+        let relay_task = live_relay_task(listener).await;
+        let pool = RelayPool::new(PoolConfig {
+            max_relays: 2,
+            fanout_timeout: Duration::from_millis(250),
+            ..PoolConfig::default()
+        });
+        pool.add_relay(live_relay_url.as_str())
+            .await
+            .expect("add live relay");
+        pool.add_relay(missing_relay_url.as_str())
+            .await
+            .expect("add missing relay");
+        pool.connect_all()
+            .await
+            .expect("connect at least one relay");
+
+        let confirmations = pool.publish(&test_event()).await.expect("publish fanout");
+        assert!(
+            confirmations
+                .iter()
+                .any(|confirmation| confirmation.accepted),
+            "one relay should accept the event"
+        );
+        assert!(
+            confirmations
+                .iter()
+                .any(|confirmation| !confirmation.accepted),
+            "failed relay should be reported as a partial failure"
+        );
+        pool.disconnect_all().await.expect("disconnect pool");
+        let payloads = relay_task.await.expect("relay task");
+        assert!(
+            payloads.iter().any(|payload| payload.contains("\"EVENT\"")),
+            "live relay should receive the event payload"
+        );
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn subscribe_succeeds_when_at_least_one_relay_is_connected() {
@@ -203,23 +406,7 @@ mod tests {
         let missing_relay_url = format!("ws://{}", missing_listener.local_addr().expect("addr"));
         drop(missing_listener);
 
-        let relay_task = tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.expect("accept client");
-            let mut socket = accept_async(stream).await.expect("upgrade websocket");
-            while let Some(message) = socket.next().await {
-                let Ok(Message::Text(payload)) = message else {
-                    continue;
-                };
-                if payload.contains("\"REQ\"") {
-                    socket
-                        .send(Message::Text("[\"EOSE\",\"test-subscription\"]".into()))
-                        .await
-                        .expect("send eose");
-                    return payload.to_string();
-                }
-            }
-            panic!("relay did not receive subscription payload");
-        });
+        let relay_task = live_relay_task(listener).await;
 
         let pool = RelayPool::new(PoolConfig::default());
         pool.add_relay(live_relay_url.as_str())
@@ -238,9 +425,9 @@ mod tests {
         .await
         .expect("subscribe with one live relay");
 
-        let payload = relay_task.await.expect("relay task");
+        let payloads = relay_task.await.expect("relay task");
         assert!(
-            payload.contains("\"REQ\""),
+            payloads.iter().any(|payload| payload.contains("\"REQ\"")),
             "live relay should receive the subscription request"
         );
         pool.disconnect_all().await.expect("disconnect pool");

--- a/crates/nostr/client/src/relay.rs
+++ b/crates/nostr/client/src/relay.rs
@@ -317,6 +317,11 @@ impl RelayConnection {
         Ok(())
     }
 
+    /// Remove a locally registered subscription without sending a CLOSE frame.
+    pub async fn remove_subscription_local(&self, subscription_id: &str) {
+        self.subscriptions.lock().await.remove(subscription_id);
+    }
+
     /// Subscribe with raw filters.
     pub async fn subscribe_filters(
         &self,


### PR DESCRIPTION
### Summary

 This changes relay fanout from serial/blocking behavior to concurrent best-effort behavior:
    
    - relay connect fanout runs concurrently
    - relay publish fanout runs concurrently
    - relay subscribe fanout runs concurrently
    - each relay fanout operation is bounded by PoolConfig::fanout_timeout
    - connect/subscribe succeeds when at least one relay succeeds
    - publish returns per-relay confirmations, including timeout/error failures
    - slow or dead relays no longer block healthy relays from receiving subscriptions or published events
    
 ---
      
      ## Expected Performance Gain
      
      - Connect latency no longer scales with relay count when relays are slow or unreachable.
      - Publish latency becomes bounded by the slowest per-relay timeout, not by the sum of relay delays.
      - One healthy relay can carry NIP-90 feedback/result visibility while degraded relays are recorded as partial failures.
      - Buyer/provider receive paths stop serially spending watch budget per relay.
      - The expected user-facing improvement is faster feedback/result visibility and fewer cases where a 
             degraded relay makes the provider look stuck.
       - Relay connect latency should move from roughly sum-of-relay-delays to max-of-relay-delays within 
            the configured timeout.
      - Publish/subscribe fanout no longer blocks all healthy relays behind one slow relay.
      - Buyer watch can receive from healthy relays without serially waiting on slow relays.
      - Provider intake fallback avoids serial per-relay polling delay.
      - After this fix, Pylon can continue through healthy relays. The earn loop is less sensitive to one bad relay:
    
                Go Online → receive paid work → complete job → publish result → earn sats
---
    **Files changed**
    
    - crates/nostr/client/src/pool.rs
      - Adds PoolConfig::fanout_timeout
      - Makes connect_all, publish, and subscribe concurrent
      - Adds per-relay timeout handling
      - Adds regression coverage for concurrent connect and partial publish failure behavior
    
    - crates/nostr/client/src/relay.rs
      - Adds local subscription cleanup for subscribe timeout cancellation paths
    
    - apps/pylon/src/nip90_runtime.rs
      - Sets bounded fanout timeout for Pylon relay pools
      - Makes provider intake fallback relay polling concurrent
      - Makes buyer watch use per-relay receive tasks feeding a bounded channel
      - Adds receive-task abort guard for cleanup on early return/error
    
    - apps/pylon/src/lib.rs
      - Sets fanout timeout for training relay pool setup
    
    - apps/nexus-control/src/lib.rs
      - Sets fanout timeout for Nexus training relay pool setup
    

    Validation
    
    Passed:
    
    bash
    cargo fmt --check
    cargo check -p nostr-client
    cargo check -p pylon
    cargo check -p nexus-control
    cargo test -p nostr-client -- --nocapture
    cargo test -p pylon serve_online_mode_runs_provider_intake_automatically -- --nocapture
    cargo test -p pylon provider_scan_filters_targeted_requests -- --nocapture
    cargo test -p pylon provider_run_processes_matching_request_locally -- --nocapture
    cargo test -p pylon provider_run_skips_request_ids_persisted_in_processed_store -- --nocapture
    cargo test -p pylon buyer_ -- --nocapture
    
    
    Known caveat
    
    scripts/lint/touched-clippy-gate.sh still fails because of existing clippy-deny expect() errors in openagents-kernel-core, outside this change:
    
    - crates/openagents-kernel-core/src/authority.rs
    - crates/openagents-kernel-core/src/compute.rs
    
    Focused package checks and tests for the touched Pylon/Nostr/Nexus paths pass.