### PR TITLE
Add equal jitter to training-coordination retry backoff

### DIFF
--- a/apps/pylon/src/lib.rs
+++ b/apps/pylon/src/lib.rs
@@ -12307,9 +12307,50 @@ fn training_authority_status_is_retryable(status: reqwest::StatusCode) -> bool {
 
 fn training_coordination_retry_delay(attempt: usize) -> Duration {
     let multiplier = 1_u64 << u32::try_from(attempt).unwrap_or(0);
-    Duration::from_millis(
-        DEFAULT_TRAINING_COORDINATION_RETRY_BASE_DELAY_MS.saturating_mul(multiplier),
-    )
+    let target = DEFAULT_TRAINING_COORDINATION_RETRY_BASE_DELAY_MS.saturating_mul(multiplier);
+    // Equal jitter: keep half of the backoff fixed and randomize the other
+    // half. Without jitter, many pylons that hit the same Nexus 503 retry in
+    // lockstep and re-saturate the control plane the instant it recovers.
+    let fixed = target / 2;
+    let jitter = if fixed > 0 {
+        rand::random::<u64>() % (fixed + 1)
+    } else {
+        0
+    };
+    Duration::from_millis(fixed + jitter)
+}
+
+#[cfg(test)]
+mod training_coordination_retry_delay_tests {
+    use super::{training_coordination_retry_delay, DEFAULT_TRAINING_COORDINATION_RETRY_BASE_DELAY_MS};
+
+    #[test]
+    fn retry_delay_stays_within_equal_jitter_bounds() {
+        for attempt in 0..8 {
+            let multiplier = 1_u64 << u32::try_from(attempt).unwrap_or(0);
+            let target = DEFAULT_TRAINING_COORDINATION_RETRY_BASE_DELAY_MS.saturating_mul(multiplier);
+            for _ in 0..256 {
+                let delay = u64::try_from(training_coordination_retry_delay(attempt).as_millis())
+                    .expect("retry delay fits in u64");
+                assert!(
+                    delay >= target / 2 && delay <= target,
+                    "delay {delay}ms outside the equal-jitter band for target {target}ms"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn retry_delay_is_actually_jittered() {
+        let mut observed = std::collections::BTreeSet::new();
+        for _ in 0..256 {
+            observed.insert(training_coordination_retry_delay(3).as_millis());
+        }
+        assert!(
+            observed.len() > 1,
+            "retry delay should be randomized to desynchronize fleet retries"
+        );
+    }
 }
 
 fn training_lease_state_is_terminal(state: &str) -> bool {


### PR DESCRIPTION
  ## Problem

  The retry backoff for training-authority calls is deterministic exponential —
  50ms base, doubling. Retries are already safe (every POST carries an
  idempotency key) and 5xx is already retried.

  identical amounts and retry in lockstep, so the control plane is re-saturated by
  a synchronized retry wave the instant it recovers.

  ## Change

  Apply **equal jitter** to the backoff delay — half fixed, half random. Fleet
  retries desynchronize while still keeping a minimum backoff.

  Attempt count (3) and base delay (50ms) are unchanged. This is a scoped
  resilience improvement, not a behavior overhaul.

  ## Verification

  - `cargo check -p pylon` — clean.
  - Two unit tests: one asserts the jittered delay stays within the equal-jitter
    band for every attempt, one asserts the delay is actually randomized.

  ## Scope

  Client-side retry hygiene. This is **not** a fix for, or a substitute for, the
  Nexus control-API capacity issue (#4515) — that is server-side and is what
  actually blocks training-node admission. This PR only makes the existing client
  retry behave better while the control plane is recovering.