### PR TITLE
Make Pylon TUI exit fast and clean on Ctrl+C

### DIFF
--- a/apps/pylon-tui/src/lib.rs
+++ b/apps/pylon-tui/src/lib.rs
@@ -4584,8 +4584,21 @@ async fn run_pylon_tui_with_config(config: TuiLaunchConfig) -> Result<()> {
     let mut app = AppShell::new(config.config_path);
     app.attach_managed_worker_launch(managed_worker_launch);
     let result = run_loop(&mut terminal, &mut app).await;
-    app.report_provider_presence_offline().await;
+    // Restore the terminal immediately on exit, before any best-effort
+    // shutdown work, so Ctrl+C is instant and clean: raw mode, the alternate
+    // screen, and mouse capture are torn down at once. Doing this first means
+    // a slow Nexus call below cannot freeze the screen or leave mouse-motion
+    // reports leaking to the shell prompt.
     let cleanup_result = restore_terminal(&mut terminal);
+    // Best-effort "going offline" notice to Nexus, tightly bounded: when Nexus
+    // is unreachable this call would otherwise block exit for the full HTTP
+    // timeout (tens of seconds). A skipped notice is harmless -- missed
+    // heartbeats convey the same thing.
+    let _ = tokio::time::timeout(
+        Duration::from_secs(2),
+        app.report_provider_presence_offline(),
+    )
+    .await;
 
     result.and(cleanup_result)
 }


### PR DESCRIPTION
  ## Problem

  Pressing Ctrl+C to quit the Pylon TUI takes 15–45 seconds to return to the
  shell, and on exit garbage like `35;84;35M35;82;36M...` is printed at the
  prompt. Both are most visible when the TUI is showing a Nexus error.

  Cause: on exit the TUI calls `report_provider_presence_offline()` — a Nexus
  HTTP request — *before* it restores the terminal. When Nexus is slow or
  unreachable that call blocks for the full HTTP timeout (tens of seconds). For
  that entire window the terminal is still in raw mode with mouse capture
  enabled and no event loop draining input, so mouse-motion reports accumulate
  in the input buffer and spill to the shell as `<row>;<col>;<btn>M` sequences
  once the process finally exits.

  ## Fix

  Reorder the exit path and bound the network call:

  - **Restore the terminal first.** `restore_terminal` (disable raw mode, leave
    the alternate screen, disable mouse capture, show cursor) now runs the
    instant the event loop ends, before any shutdown network work. Ctrl+C
    can run — nothing leaks to the shell.
  - **Bound the offline notice.** The best-effort "going offline" report to
    Nexus is wrapped in a 2s `tokio::time::timeout`. A healthy Nexus acks well
    within that; an unreachable one no longer stalls exit. A skipped notice is
    harmless — Nexus infers the same from missed heartbeats.

  The in-loop `refresh()` already offloads its Nexus calls to a background
  thread, so it does not delay Ctrl+C — the offline report was the only
  blocking call on the exit path.

  ## Verification

  - `cargo check -p pylon-tui` — clean.
  - No unit test: this is terminal- and network-teardown ordering on the
    process exit path, with no meaningful unit-test surface short of mocking the
    terminal and HTTP layers.
  - Confirm interactively: launch the TUI, press Ctrl+C while a Nexus error is
    displayed, and check it returns to a clean prompt within ~2s.

  ## Notes

  Independent of the Nexus 503 capacity issue (#4515) — it doesn't fix Nexus, it
  stops a slow Nexus from hanging the TUI on exit.