### PR TITLE
Diagnose #4515: Nexus control-API capacity exhaustion (root cause + reproduction)

### DIFF
--- a/apps/nexus-control/Cargo.toml
+++ b/apps/nexus-control/Cargo.toml
@@ -41,7 +41,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 workspace = true
 
 [dev-dependencies]
+axum = "0.8"
 http-body-util = "0.1"
+serde_json = "1"
 tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }

--- a/apps/nexus-control/tests/issue_4515_control_api_capacity.rs
+++ b/apps/nexus-control/tests/issue_4515_control_api_capacity.rs
@@ -1,0 +1,222 @@
+//! Local reproduction for issue #4515 — Nexus control-API capacity exhaustion.
+//!
+//! The relay returns `503 embedded Nexus control API capacity exhausted` once
+//! its 256-permit authority-slot budget fills. That is a symptom. The cause is
+//! in `nexus-control`: every mutating handler serializes on one
+//! `RwLock<ControlStore>`, and the admission path, under that lock, persists
+//! the *entire* kernel state (`persist_compute_authority_state`: clone ~30
+//! collections, `serde_json::to_vec_pretty`, `fs::write` + `fs::rename`) and
+//! recomputes a snapshot over *all* receipts. Per-mutation cost is therefore
+//! O(accumulated state), and because the lock is a blocking `std::sync::RwLock`
+//! on a 4-worker runtime, concurrent mutations fully serialize.
+//!
+//! This test drives admissions through the real `nexus-control` router and
+//! prints two measurements:
+//!   Phase A — per-admission latency as kernel state accumulates,
+//!   Phase B — throughput under 4-way concurrency vs. sequential.
+//!
+//! It is `#[ignore]`d because it is a measurement reproduction, not a fast
+//! pass/fail unit test. Run it explicitly:
+//!
+//! ```text
+//! cargo test -p nexus-control --test issue_4515_control_api_capacity \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! `ISSUE_4515_ADMISSIONS` overrides the admission count (default 800).
+
+// This is a measurement reproduction: printing a report to stdout and using
+// test assertions in a `Result`-returning test are intentional here, though
+// the workspace lints restrict both in normal code.
+#![allow(clippy::print_stdout, clippy::panic_in_result_fn)]
+
+use std::path::Path;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+type TestError = Box<dyn std::error::Error + Send + Sync>;
+type TestResult<T = ()> = Result<T, TestError>;
+
+const ADMISSION_PATH: &str = "/api/training/nodes/admission";
+
+fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as i64)
+        .unwrap_or_default()
+}
+
+/// Build a `nexus-control` router backed by a real on-disk kernel state file
+/// under `state_dir`, with treasury and auto-dispatch disabled.
+fn build_test_router(state_dir: &Path) -> TestResult<Router> {
+    let mut config = nexus_control::ServiceConfig::from_env()?;
+    config.kernel_state_path = Some(state_dir.join("kernel-state.json"));
+    config.receipt_log_path = Some(state_dir.join("receipt-log.jsonl"));
+    config.training_trn_identity_path = state_dir.join("trn-identity.mnemonic");
+    config.treasury.enabled = false;
+    config.cs336_homework_auto_dispatch_enabled = false;
+    Ok(nexus_control::build_router(config))
+}
+
+/// Send one training-node admission; return its HTTP status and latency.
+///
+/// The request omits a capability envelope, so the kernel records the
+/// admission and then refuses it (`training_node_capability_missing`). The
+/// persistence path under test is identical either way: a receipt is written,
+/// a snapshot is recomputed over every receipt, and the full kernel state is
+/// rewritten to disk.
+async fn admit(app: &Router, tag: &str, idx: usize) -> TestResult<(StatusCode, Duration)> {
+    let body = serde_json::json!({
+        "idempotency_key": format!("issue4515-{tag}-{idx:06}"),
+        "requested_at_ms": now_unix_ms(),
+        "node_pubkey_hex": format!("issue4515-{tag}-node-{idx:06}"),
+        "release_id": "openagents.pylon@issue4515",
+        "build_digest": "issue4515-build-digest",
+        "role_claims": ["worker"],
+        "node_label": format!("issue #4515 reproduction node {idx}"),
+        "allowed_networks": ["mainnet"],
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri(ADMISSION_PATH)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body)?))?;
+    let started = Instant::now();
+    let response = app.clone().oneshot(request).await?;
+    let elapsed = started.elapsed();
+    let status = response.status();
+    to_bytes(response.into_body(), usize::MAX).await?;
+    Ok((status, elapsed))
+}
+
+fn avg(samples: &[Duration]) -> Duration {
+    if samples.is_empty() {
+        return Duration::ZERO;
+    }
+    samples.iter().sum::<Duration>() / samples.len() as u32
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "issue #4515 measurement reproduction; run with --ignored --nocapture"]
+async fn issue_4515_control_api_mutation_latency_scales_with_state() -> TestResult {
+    let total: usize = std::env::var("ISSUE_4515_ADMISSIONS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(800);
+    let window = (total / 10).max(1);
+    let burst = (window * 2).max(2);
+
+    let state_dir = tempfile::tempdir()?;
+    let app = build_test_router(state_dir.path())?;
+
+    println!();
+    println!("issue #4515 reproduction — nexus-control mutation latency vs accumulated state");
+    println!("  worker threads: 4 (matches embedded control API default)");
+    println!("  admissions:     {total} (override with ISSUE_4515_ADMISSIONS)");
+    println!();
+
+    // ---- Phase A: per-admission latency as kernel state accumulates ----
+    println!("Phase A — sequential admissions, latency per {window}-admission window:");
+    println!(
+        "  {:>9}  {:>13}  {:>13}  {:>13}",
+        "admitted", "avg", "min", "max"
+    );
+    let mut window_samples: Vec<Duration> = Vec::with_capacity(window);
+    let mut window_avgs: Vec<Duration> = Vec::new();
+    for idx in 0..total {
+        let (status, elapsed) = admit(&app, "seq", idx).await?;
+        assert_eq!(status, StatusCode::OK, "admission {idx} returned {status}");
+        window_samples.push(elapsed);
+        if window_samples.len() == window {
+            let a = avg(&window_samples);
+            let mn = window_samples.iter().copied().min().unwrap_or_default();
+            let mx = window_samples.iter().copied().max().unwrap_or_default();
+            println!("  {:>9}  {a:>13?}  {mn:>13?}  {mx:>13?}", idx + 1);
+            window_avgs.push(a);
+            window_samples.clear();
+        }
+    }
+    let first_window_avg = window_avgs.first().copied().unwrap_or_default();
+    let last_window_avg = window_avgs.last().copied().unwrap_or_default();
+    let growth =
+        last_window_avg.as_secs_f64() / first_window_avg.as_secs_f64().max(f64::MIN_POSITIVE);
+    let state_bytes = std::fs::metadata(state_dir.path().join("kernel-state.json"))
+        .map(|meta| meta.len())
+        .unwrap_or_default();
+    println!();
+    println!("  first window avg: {first_window_avg:?}");
+    println!("  last  window avg: {last_window_avg:?}");
+    println!("  growth factor:    {growth:.1}x");
+    println!("  kernel-state.json after {total} admissions: {state_bytes} bytes");
+    println!();
+
+    // ---- Phase B: 4-way concurrency yields no throughput gain because the
+    //      single RwLock serializes every mutation ----
+    println!("Phase B — sequential vs 4-way concurrent throughput at depth {total}:");
+    let seq_started = Instant::now();
+    for idx in 0..burst {
+        let (status, _) = admit(&app, "seqB", idx).await?;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let seq_total = seq_started.elapsed();
+
+    let conc_started = Instant::now();
+    let mut handles = Vec::with_capacity(burst);
+    for idx in 0..burst {
+        let app = app.clone();
+        handles.push(tokio::spawn(
+            async move { admit(&app, "concB", idx).await },
+        ));
+    }
+    let mut conc_latencies = Vec::with_capacity(burst);
+    for handle in handles {
+        let (status, elapsed) = handle.await??;
+        assert_eq!(status, StatusCode::OK);
+        conc_latencies.push(elapsed);
+    }
+    let conc_total = conc_started.elapsed();
+    conc_latencies.sort_unstable();
+    let p50 = conc_latencies
+        .get(conc_latencies.len() / 2)
+        .copied()
+        .unwrap_or_default();
+    let p99_idx = (conc_latencies.len() * 99 / 100).min(conc_latencies.len().saturating_sub(1));
+    let p99 = conc_latencies.get(p99_idx).copied().unwrap_or_default();
+    let speedup = seq_total.as_secs_f64() / conc_total.as_secs_f64().max(f64::MIN_POSITIVE);
+    let conc_throughput = burst as f64 / conc_total.as_secs_f64().max(f64::MIN_POSITIVE);
+    let conc_latency_ms = avg(&conc_latencies).as_secs_f64() * 1000.0;
+
+    println!("  {burst} admissions sequential : {seq_total:?}");
+    println!("  {burst} admissions concurrent : {conc_total:?} (4 workers)");
+    println!("  concurrency speedup        : {speedup:.2}x (1.0x == fully serialized)");
+    println!("  concurrent latency p50/p99 : {p50:?} / {p99:?}");
+    println!();
+    println!("Conclusion:");
+    println!("  Per-admission latency grew {growth:.1}x across this run because every");
+    println!("  mutation persists the full kernel state (clone + JSON + fsync) under one");
+    println!("  RwLock. 4-way concurrency gave only {speedup:.2}x throughput, so the control");
+    println!("  API is serialized: a ceiling of ~{conc_throughput:.0} mutations/sec, falling");
+    println!("  as kernel state grows. Each request also holds its relay authority-slot");
+    println!("  permit for its full ~{conc_latency_ms:.0}ms. Sustained fleet load above the");
+    println!("  ceiling drives the relay's in-flight count to its 256-permit limit -> 503");
+    println!("  'embedded Nexus control API capacity exhausted'. The relay semaphore is");
+    println!("  the symptom, not the cause.");
+    println!();
+
+    assert!(
+        last_window_avg > first_window_avg,
+        "expected per-admission latency to grow with accumulated kernel state \
+         (first window {first_window_avg:?}, last window {last_window_avg:?})"
+    );
+    assert!(
+        speedup < 2.0,
+        "expected ~serialized throughput (speedup near 1x); got {speedup:.2}x"
+    );
+    assert!(state_bytes > 0, "kernel state was not persisted to disk");
+
+    Ok(())
+}

--- a/apps/nexus-control/tests/issue_4515_control_api_capacity.rs
+++ b/apps/nexus-control/tests/issue_4515_control_api_capacity.rs
@@ -11,11 +11,13 @@
 //! on a 4-worker runtime, concurrent mutations fully serialize.
 //!
 //! This test drives requests through the real `nexus-control` router and
-//! prints three measurements:
+//! prints four measurements:
 //!   Phase A — per-admission latency as kernel state accumulates,
 //!   Phase B — admission throughput under 4-way concurrency vs. sequential,
 //!   Phase C — validator-challenge claim latency, idle vs. under admission
-//!             load (the validator backlog drains through the same lock).
+//!             load (the validator backlog drains through the same lock),
+//!   Phase D — artifact-resolver and signed-access read-handler latency,
+//!             idle vs. under admission load.
 //!
 //! It is `#[ignore]`d because it is a measurement reproduction, not a fast
 //! pass/fail unit test. Run it explicitly:
@@ -122,11 +124,62 @@ async fn claim(app: &Router, idx: usize) -> TestResult<(StatusCode, String, Dura
     Ok((status, body, elapsed))
 }
 
+/// Probe the artifact resolver for a missing artifact. The handler acquires
+/// `store.read()`, fails the lookup, and returns — so the latency is the time
+/// spent acquiring that read lock. (Read path: `get_kernel_compute_training_
+/// artifact_resolver`.)
+async fn resolve_probe(app: &Router, idx: usize) -> TestResult<(StatusCode, String, Duration)> {
+    let uri = format!("/v1/kernel/compute/training/artifacts/issue4515-missing-{idx:06}");
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())?;
+    let started = Instant::now();
+    let response = app.clone().oneshot(request).await?;
+    let elapsed = started.elapsed();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+    Ok((status, String::from_utf8_lossy(&bytes).into_owned(), elapsed))
+}
+
+/// Probe signed-access for a missing artifact. The handler acquires
+/// `store.read()` and resolves the artifact *before* it reaches signed-URL
+/// signing, so a missing artifact fails right after the read lock — the
+/// latency is again the read-lock acquire. (Read path:
+/// `post_kernel_compute_training_artifact_signed_access`.)
+async fn signed_access_probe(
+    app: &Router,
+    idx: usize,
+) -> TestResult<(StatusCode, String, Duration)> {
+    let uri = format!(
+        "/v1/kernel/compute/training/artifacts/issue4515-missing-{idx:06}/signed-access"
+    );
+    let body = serde_json::json!({ "mode": "read" });
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body)?))?;
+    let started = Instant::now();
+    let response = app.clone().oneshot(request).await?;
+    let elapsed = started.elapsed();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+    Ok((status, String::from_utf8_lossy(&bytes).into_owned(), elapsed))
+}
+
 fn avg(samples: &[Duration]) -> Duration {
     if samples.is_empty() {
         return Duration::ZERO;
     }
     samples.iter().sum::<Duration>() / samples.len() as u32
+}
+
+fn pctl99(sorted: &[Duration]) -> Duration {
+    sorted
+        .get((sorted.len() * 99 / 100).min(sorted.len().saturating_sub(1)))
+        .copied()
+        .unwrap_or_default()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -286,6 +339,79 @@ async fn issue_4515_control_api_mutation_latency_scales_with_state() -> TestResu
     println!("  claim slowdown under load:  {claim_slowdown:.0}x");
     println!();
 
+    // ---- Phase D: read handlers (artifact resolver, signed access) ----
+    // The resolver and signed-access endpoints are read paths: each takes
+    // state.store.read() before its (fast) work. A request for a missing
+    // artifact still acquires that read lock, so its latency measures how long
+    // a reader waits while writers hold the lock. These map to the production
+    // "Artifact resolver latency" and "Signed access latency" health metrics.
+    println!("Phase D — read-handler latency, idle vs under admission load:");
+    let probe_count = 30usize;
+
+    let mut resolver_idle = Vec::with_capacity(probe_count);
+    let mut signed_idle = Vec::with_capacity(probe_count);
+    let mut resolver_status = StatusCode::OK;
+    let mut signed_status = StatusCode::OK;
+    let mut resolver_body = String::new();
+    let mut signed_body = String::new();
+    for idx in 0..probe_count {
+        let (rs, rb, rl) = resolve_probe(&app, idx).await?;
+        resolver_status = rs;
+        resolver_body = rb;
+        resolver_idle.push(rl);
+        let (ss, sb, sl) = signed_access_probe(&app, idx).await?;
+        signed_status = ss;
+        signed_body = sb;
+        signed_idle.push(sl);
+    }
+
+    let read_flood = burst * 2;
+    let mut read_flood_handles = Vec::with_capacity(read_flood);
+    for idx in 0..read_flood {
+        let app = app.clone();
+        read_flood_handles.push(tokio::spawn(
+            async move { admit(&app, "floodD", idx).await },
+        ));
+    }
+    let mut resolver_loaded = Vec::with_capacity(probe_count);
+    let mut signed_loaded = Vec::with_capacity(probe_count);
+    for idx in 0..probe_count {
+        let (.., rl) = resolve_probe(&app, probe_count + idx).await?;
+        resolver_loaded.push(rl);
+        let (.., sl) = signed_access_probe(&app, probe_count + idx).await?;
+        signed_loaded.push(sl);
+    }
+    for handle in read_flood_handles {
+        let (status, _) = handle.await??;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    resolver_idle.sort_unstable();
+    resolver_loaded.sort_unstable();
+    signed_idle.sort_unstable();
+    signed_loaded.sort_unstable();
+    let resolver_idle_avg = avg(&resolver_idle);
+    let resolver_loaded_avg = avg(&resolver_loaded);
+    let signed_idle_avg = avg(&signed_idle);
+    let signed_loaded_avg = avg(&signed_loaded);
+    let resolver_loaded_p99 = pctl99(&resolver_loaded);
+    let signed_loaded_p99 = pctl99(&signed_loaded);
+    let resolver_slowdown =
+        resolver_loaded_avg.as_secs_f64() / resolver_idle_avg.as_secs_f64().max(f64::MIN_POSITIVE);
+    let signed_slowdown =
+        signed_loaded_avg.as_secs_f64() / signed_idle_avg.as_secs_f64().max(f64::MIN_POSITIVE);
+    println!("  resolver      : HTTP {resolver_status}");
+    println!(
+        "    idle {resolver_idle_avg:?}  ->  under load {resolver_loaded_avg:?} \
+         / p99 {resolver_loaded_p99:?}  ({resolver_slowdown:.0}x)"
+    );
+    println!("  signed-access : HTTP {signed_status}");
+    println!(
+        "    idle {signed_idle_avg:?}  ->  under load {signed_loaded_avg:?} \
+         / p99 {signed_loaded_p99:?}  ({signed_slowdown:.0}x)"
+    );
+    println!();
+
     println!("Conclusion:");
     println!("  Per-admission latency grew {growth:.1}x across this run because every");
     println!("  mutation persists the full kernel state (clone + JSON + fsync) under one");
@@ -299,6 +425,9 @@ async fn issue_4515_control_api_mutation_latency_scales_with_state() -> TestResu
     println!("  Validator claim/finalize are the same store.write() mutations: under");
     println!("  admission load, validator claim latency rose {claim_slowdown:.0}x here, so the");
     println!("  validator backlog cannot drain while the control plane is saturated.");
+    println!("  The artifact resolver and signed-access endpoints are read paths; under");
+    println!("  admission load they stalled {resolver_slowdown:.0}x / {signed_slowdown:.0}x waiting for the same");
+    println!("  lock — the mechanism behind the resolver/signed-access latency alerts.");
     println!();
 
     assert!(
@@ -323,6 +452,22 @@ async fn issue_4515_control_api_mutation_latency_scales_with_state() -> TestResu
         loaded_claim_avg > idle_claim_avg * 2,
         "expected validator claims to stall under admission load \
          (idle avg {idle_claim_avg:?}, under-load avg {loaded_claim_avg:?})"
+    );
+    assert!(
+        resolver_status.is_client_error() && signed_status.is_client_error(),
+        "expected resolver/signed-access probes to reach the handler \
+         (resolver {resolver_status} body {resolver_body}; \
+          signed-access {signed_status} body {signed_body})"
+    );
+    assert!(
+        resolver_loaded_avg > resolver_idle_avg * 2,
+        "expected the artifact resolver to stall under admission load \
+         (idle {resolver_idle_avg:?}, under-load {resolver_loaded_avg:?})"
+    );
+    assert!(
+        signed_loaded_avg > signed_idle_avg * 2,
+        "expected signed-access to stall under admission load \
+         (idle {signed_idle_avg:?}, under-load {signed_loaded_avg:?})"
     );
 
     Ok(())

--- a/apps/nexus-control/tests/issue_4515_control_api_capacity.rs
+++ b/apps/nexus-control/tests/issue_4515_control_api_capacity.rs
@@ -10,10 +10,12 @@
 //! O(accumulated state), and because the lock is a blocking `std::sync::RwLock`
 //! on a 4-worker runtime, concurrent mutations fully serialize.
 //!
-//! This test drives admissions through the real `nexus-control` router and
-//! prints two measurements:
+//! This test drives requests through the real `nexus-control` router and
+//! prints three measurements:
 //!   Phase A — per-admission latency as kernel state accumulates,
-//!   Phase B — throughput under 4-way concurrency vs. sequential.
+//!   Phase B — admission throughput under 4-way concurrency vs. sequential,
+//!   Phase C — validator-challenge claim latency, idle vs. under admission
+//!             load (the validator backlog drains through the same lock).
 //!
 //! It is `#[ignore]`d because it is a measurement reproduction, not a fast
 //! pass/fail unit test. Run it explicitly:
@@ -91,6 +93,33 @@ async fn admit(app: &Router, tag: &str, idx: usize) -> TestResult<(StatusCode, D
     let status = response.status();
     to_bytes(response.into_body(), usize::MAX).await?;
     Ok((status, elapsed))
+}
+
+/// Send one validator-challenge claim; return its status, body, and latency.
+///
+/// The claim targets a node that was never admitted, so the handler acquires
+/// the global `store` write lock, finds no such node, and returns a client
+/// error. Claim/finalize are `store.write()` mutations like admission, so the
+/// claim's latency is dominated by the time spent waiting to *acquire* that
+/// lock — which is what Phase C measures under contention.
+async fn claim(app: &Router, idx: usize) -> TestResult<(StatusCode, String, Duration)> {
+    let body = serde_json::json!({
+        "idempotency_key": format!("issue4515-claim-{idx:06}"),
+        "requested_at_ms": now_unix_ms(),
+        "node_pubkey_hex": format!("issue4515-validator-{idx:06}"),
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/training/validator-challenges/claim")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body)?))?;
+    let started = Instant::now();
+    let response = app.clone().oneshot(request).await?;
+    let elapsed = started.elapsed();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+    let body = String::from_utf8_lossy(&bytes).into_owned();
+    Ok((status, body, elapsed))
 }
 
 fn avg(samples: &[Duration]) -> Duration {
@@ -195,6 +224,68 @@ async fn issue_4515_control_api_mutation_latency_scales_with_state() -> TestResu
     println!("  concurrency speedup        : {speedup:.2}x (1.0x == fully serialized)");
     println!("  concurrent latency p50/p99 : {p50:?} / {p99:?}");
     println!();
+
+    // ---- Phase C: validator-challenge requests stall on the same lock ----
+    // Validator claim/retry/finalize are `store.write()` mutations too. A claim
+    // for a never-admitted node still acquires the global write lock before it
+    // fails, so its latency measures time waiting for that lock. Measured idle
+    // and then under a concurrent admission flood.
+    println!("Phase C — validator-challenge claim latency, idle vs under admission load:");
+    let claim_count = 60usize;
+
+    let mut idle_claims = Vec::with_capacity(claim_count);
+    let mut claim_status = StatusCode::OK;
+    let mut claim_body = String::new();
+    for idx in 0..claim_count {
+        let (status, body, elapsed) = claim(&app, idx).await?;
+        claim_status = status;
+        claim_body = body;
+        idle_claims.push(elapsed);
+    }
+
+    let flood = burst * 3;
+    let mut flood_handles = Vec::with_capacity(flood);
+    for idx in 0..flood {
+        let app = app.clone();
+        flood_handles.push(tokio::spawn(
+            async move { admit(&app, "floodC", idx).await },
+        ));
+    }
+    let mut loaded_claims = Vec::with_capacity(claim_count);
+    for idx in 0..claim_count {
+        let (_status, _body, elapsed) = claim(&app, claim_count + idx).await?;
+        loaded_claims.push(elapsed);
+    }
+    for handle in flood_handles {
+        let (status, _) = handle.await??;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    idle_claims.sort_unstable();
+    loaded_claims.sort_unstable();
+    let idle_claim_avg = avg(&idle_claims);
+    let loaded_claim_avg = avg(&loaded_claims);
+    let idle_p99 = idle_claims
+        .get((idle_claims.len() * 99 / 100).min(idle_claims.len().saturating_sub(1)))
+        .copied()
+        .unwrap_or_default();
+    let loaded_p99 = loaded_claims
+        .get((loaded_claims.len() * 99 / 100).min(loaded_claims.len().saturating_sub(1)))
+        .copied()
+        .unwrap_or_default();
+    let claim_slowdown =
+        loaded_claim_avg.as_secs_f64() / idle_claim_avg.as_secs_f64().max(f64::MIN_POSITIVE);
+    let claim_reached = if claim_body.contains("training_node_not_found") {
+        "reached handler (training_node_not_found)"
+    } else {
+        "UNEXPECTED body"
+    };
+    println!("  claim handler:              HTTP {claim_status} — {claim_reached}");
+    println!("  idle       claim avg/p99 :  {idle_claim_avg:?} / {idle_p99:?}");
+    println!("  under-load claim avg/p99 :  {loaded_claim_avg:?} / {loaded_p99:?}");
+    println!("  claim slowdown under load:  {claim_slowdown:.0}x");
+    println!();
+
     println!("Conclusion:");
     println!("  Per-admission latency grew {growth:.1}x across this run because every");
     println!("  mutation persists the full kernel state (clone + JSON + fsync) under one");
@@ -205,6 +296,9 @@ async fn issue_4515_control_api_mutation_latency_scales_with_state() -> TestResu
     println!("  ceiling drives the relay's in-flight count to its 256-permit limit -> 503");
     println!("  'embedded Nexus control API capacity exhausted'. The relay semaphore is");
     println!("  the symptom, not the cause.");
+    println!("  Validator claim/finalize are the same store.write() mutations: under");
+    println!("  admission load, validator claim latency rose {claim_slowdown:.0}x here, so the");
+    println!("  validator backlog cannot drain while the control plane is saturated.");
     println!();
 
     assert!(
@@ -217,6 +311,19 @@ async fn issue_4515_control_api_mutation_latency_scales_with_state() -> TestResu
         "expected ~serialized throughput (speedup near 1x); got {speedup:.2}x"
     );
     assert!(state_bytes > 0, "kernel state was not persisted to disk");
+    assert!(
+        claim_body.contains("training_node_not_found"),
+        "validator claim did not reach the handler; body: {claim_body}"
+    );
+    assert!(
+        claim_status.is_client_error(),
+        "expected a client error from the unadmitted-node claim; got {claim_status}"
+    );
+    assert!(
+        loaded_claim_avg > idle_claim_avg * 2,
+        "expected validator claims to stall under admission load \
+         (idle avg {idle_claim_avg:?}, under-load avg {loaded_claim_avg:?})"
+    );
 
     Ok(())
 }

--- a/docs/reports/nexus/2026-05-22-issue-4515-root-cause-diagnosis.md
+++ b/docs/reports/nexus/2026-05-22-issue-4515-root-cause-diagnosis.md
@@ -148,6 +148,28 @@ a throughput ceiling of ~128 mutations/sec at this depth, and falling as state
 grows. Each mutation also holds a relay authority-slot permit for its full
 ~31 ms.
 
+### Phase C — validator-challenge requests stall on the same lock (depth 800)
+
+Validator challenge claim/retry/finalize are `store.write()` mutations too, so
+the validator backlog drains through the same global lock. Phase C times a
+validator-challenge `claim` for an unadmitted node — it acquires the write
+lock, fails the node lookup, and returns, so its latency is essentially the
+time spent acquiring the lock:
+
+| condition                            | claim latency avg / p99 |
+| -------------------------------------- | ----------------------- |
+| idle control plane                     | 5.6 µs / 62 µs |
+| under a concurrent admission flood     | 7.9 ms / 36 ms |
+
+Idle, a claim is microseconds. Under admission load it rises by three orders of
+magnitude — every validator mutation queues behind the same serialized
+O(total-state) persists. The idle baseline being microseconds inflates the raw
+ratio; the figure that matters is the absolute under-load latency, and on
+production scale (far more accumulated state, sustained real fleet load) it is
+correspondingly worse. This is the mechanism behind a validator backlog that
+does not drain: the work to clear it cannot get through the saturated control
+API.
+
 ## Why relay-side changes do not fix this
 
 The relay's semaphore is downstream of the bottleneck. Specifically:

--- a/docs/reports/nexus/2026-05-22-issue-4515-root-cause-diagnosis.md
+++ b/docs/reports/nexus/2026-05-22-issue-4515-root-cause-diagnosis.md
@@ -1,0 +1,216 @@
+# Issue #4515 — Nexus control-API capacity exhaustion: root-cause diagnosis
+
+Date: 2026-05-22
+Status: root cause verified by local reproduction; fix direction is a
+nexus-control architecture decision (see "Fixing it")
+
+## Summary
+
+Issue #4515 reports the public Nexus relay returning
+`503 embedded Nexus control API capacity exhausted`, which blocks training-node
+admission and provider presence heartbeats for the Pylon fleet.
+
+The 503 is a **symptom**. The cause is in `nexus-control`, not the relay: every
+mutating control-API request is serialized through one global lock, and inside
+that lock the mutation persists the **entire** kernel state to disk. Per-mutation
+cost is O(total accumulated state), so the control API has a throughput ceiling
+that **degrades as the fleet runs**. When sustained fleet load exceeds that
+ceiling, requests pile up at the relay until its fixed authority-slot budget
+(256) is full, and the relay returns the 503.
+
+## The symptom
+
+The relay proxies control-API requests behind a semaphore:
+
+- `apps/nexus-relay/src/durable.rs:458` — `proxy_authority_http_request`
+  acquires an `authority_slots` permit with `try_acquire_owned()`.
+- The permit is held for the **entire** proxied request, including the upstream
+  HTTP call to the embedded control API (timeout
+  `DEFAULT_AUTHORITY_HTTP_TIMEOUT_MS` = 180 s).
+- Budget is `DEFAULT_AUTHORITY_MAX_IN_FLIGHT` = 256
+  (`NEXUS_RELAY_AUTHORITY_MAX_IN_FLIGHT`).
+- When all 256 permits are held, the next request gets
+  `503 embedded Nexus control API capacity exhausted`.
+
+For 256 permits to fill, 256 requests must be in flight at once. That happens
+only when control-API requests take a long time — so the real question is why
+control-API requests are slow.
+
+## Root cause (in `nexus-control`)
+
+### 1. One global lock serializes every mutation
+
+`apps/nexus-control/src/lib.rs:1977` — `AppState.store` is a single
+`Arc<RwLock<ControlStore>>` (a `std::sync::RwLock`). `ControlStore`
+(`lib.rs:1991`) holds sessions, provider presence, the training scheduler,
+treasury, economy, and the kernel — all behind that one lock.
+
+Every mutating handler takes `state.store.write()`:
+
+- `record_provider_presence_heartbeat` — `lib.rs:13519`
+- `record_training_node_admission` — `lib.rs:13729`
+- `record_training_node_heartbeat` — `lib.rs:13769`
+- and the other training/treasury/session mutation handlers.
+
+All mutations are therefore fully serialized. `std::sync::RwLock::write()` is a
+blocking call, and the embedded control API runs on only 4 tokio worker threads
+(`DEFAULT_AUTHORITY_TOKIO_WORKER_THREADS` = 4 in `durable.rs`). Under load all 4
+worker threads block on `.write()`.
+
+### 2. Each mutation persists the full kernel state under that lock
+
+The admission path, under the write lock, reaches:
+
+```
+record_training_node_admission (handler, lib.rs:13722)
+  -> kernel.record_training_node_admission (kernel.rs:3308)
+    -> refresh_snapshot_for (kernel.rs:3457 / defined 15110)
+      -> persist_compute_authority_state (kernel.rs:15118 / defined 4496)
+```
+
+`persist_compute_authority_state` (`kernel.rs:4496`):
+
+- clones ~30 kernel collections (`admitted_training_nodes`,
+  `compute_training_runs`, `receipt_store`, `snapshots`, ...),
+- serializes the whole thing with `serde_json::to_vec_pretty`,
+- writes it with `fs::write` to a temp file and `fs::rename`s it into place.
+
+`refresh_snapshot_for` also calls `compute_snapshot_for` (`kernel.rs:15122`),
+which runs `receipt_store.list_receipts()` and market-metrics passes over
+**every** receipt.
+
+Both are O(total accumulated state) and both run **inside the global write
+lock**. The heartbeat handler additionally does a synchronous
+`store.persist_training_scheduler_state()` disk write under the lock
+(`lib.rs:13811`).
+
+### 3. Consequence
+
+Throughput is capped at one full-state persist at a time, and that cap **falls
+as state grows** (more admitted nodes, more receipts, more snapshots → larger
+clone + larger JSON + larger write). Each in-flight request holds its relay
+authority-slot permit for its full duration. Once sustained fleet load pushes
+in-flight count to 256, the relay returns the 503. This matches the observed
+behavior: the failure appears under fleet load and worsens the longer Nexus
+runs.
+
+## Reproduction
+
+`apps/nexus-control/tests/issue_4515_control_api_capacity.rs` —
+`issue_4515_control_api_mutation_latency_scales_with_state`
+(`#[tokio::test(flavor = "multi_thread", worker_threads = 4)]`, `#[ignore]`d).
+
+It drives admissions through the real `nexus-control` router (`build_router`)
+on a 4-worker runtime with a real on-disk `kernel_state_path`. Run:
+
+```
+cargo test -p nexus-control --test issue_4515_control_api_capacity \
+    -- --ignored --nocapture
+```
+
+`ISSUE_4515_ADMISSIONS` overrides the admission count (default 800).
+
+The reproduction sends minimal admission requests (no capability envelope), so
+the kernel records each admission and then refuses it. The persistence path
+exercised is identical to an accepted admission — receipt write, snapshot
+recompute, full kernel-state rewrite — and because each stored object is
+smaller than a real Pylon's, the measured growth below is a **conservative
+lower bound**; production admissions carry full capability envelopes and
+accumulate state faster.
+
+### Phase A — per-admission latency vs. accumulated state (depth 800 run)
+
+| admissions recorded | avg admission latency |
+| ------------------: | --------------------: |
+|                  80 |               0.65 ms |
+|                 240 |               1.82 ms |
+|                 400 |               2.92 ms |
+|                 560 |               3.67 ms |
+|                 800 |               5.42 ms |
+
+Latency grows monotonically — 8.3x across this run. The kernel state file
+reached 1.82 MB after 800 admissions, and per-mutation cost tracks that growth,
+exactly as the full-state persist predicts. (An earlier run that sent full
+fixture capability envelopes showed ~12-13x over the same depth.)
+
+### Phase B — concurrency vs. sequential (at depth 800)
+
+| measurement                           | result |
+| -------------------------------------- | ------ |
+| 160 admissions sequential              | 1.04 s |
+| 160 admissions concurrent (4 workers)  | 1.25 s |
+| concurrency speedup                    | 0.83x  |
+| concurrent latency p50 / p99           | 30.6 ms / 47.6 ms |
+
+4-way concurrency produces **no** throughput gain (0.83x — slightly worse,
+because lock contention adds overhead). The control API is fully serialized:
+a throughput ceiling of ~128 mutations/sec at this depth, and falling as state
+grows. Each mutation also holds a relay authority-slot permit for its full
+~31 ms.
+
+## Why relay-side changes do not fix this
+
+The relay's semaphore is downstream of the bottleneck. Specifically:
+
+- Raising `NEXUS_RELAY_AUTHORITY_MAX_IN_FLIGHT` above 256 only lets more
+  requests pile up against the same serialized control API; it delays the 503
+  and inflates latency instead of removing the failure.
+- Replacing the relay's fail-fast `try_acquire_owned()` with a bounded wait
+  queue cannot raise a serialized server's throughput ceiling; it changes when
+  the 503 is returned, not whether the system keeps up.
+
+The fix has to remove the per-mutation O(total-state) work from the control
+API's critical path.
+
+## Fixing it: options and the durability constraint
+
+The per-mutation cost is O(total accumulated state) because every mutation
+rewrites the entire kernel state file under the global lock. Removing that
+requires one of:
+
+- **Background / debounced persistence** — mutations update memory and mark
+  state dirty; a background task writes periodically (and on shutdown). Removes
+  the persist from the mutation hot path, but a crash loses the un-persisted
+  window.
+- **Incremental persistence** — append the per-mutation delta and replay it on
+  load, compacting periodically. Keeps per-mutation cost flat as state grows
+  and preserves today's write-through durability.
+
+The durability constraint is decisive, and it was checked rather than assumed.
+The kernel state file is the **authoritative** record of kernel authority
+state, not a reconstructable cache:
+`KernelState::new_with_persistence` -> `load_persisted_compute_authority_state`
+(`kernel.rs:4407`) is the only loader, and it loads all ~30 collections
+directly from the single JSON file. There is no receipt-log replay or other
+reconstruction path. (`economy`'s receipt log is a separate, narrower record;
+it does not rebuild kernel state.)
+
+Consequently:
+
+- Background / debounced persistence would lose authoritative kernel state on
+  any crash within the un-persisted window. That conflicts with the repo
+  guardrail that sync and state continuity must remain deterministic and
+  replay-safe.
+- Incremental persistence preserves durability but is a substantial change to
+  the authority kernel's persistence layer.
+
+A smaller, durability-preserving partial step is possible — keep the persist
+write-through but move the serialize + `fs::write` off the global lock (clone
+under the lock, write after releasing it, with writer ordering by sequence
+number). That removes serialize + fsync from the lock's critical section, but
+each mutation still does O(total-state) work, so it mitigates rather than
+removes the scaling problem.
+
+Which direction to take is an architecture decision for the nexus-control
+maintainers. This report and the reproduction test provide the evidence to make
+that decision; a fix is intentionally not included here so the decision is not
+pre-empted.
+
+## Artifacts
+
+- Reproduction test:
+  `apps/nexus-control/tests/issue_4515_control_api_capacity.rs`.
+- Relay 503 site: `apps/nexus-relay/src/durable.rs:458`.
+- Persist hot path: `apps/nexus-control/src/kernel.rs:4496`
+  (`persist_compute_authority_state`), reached via
+  `refresh_snapshot_for` (`kernel.rs:15110`).

--- a/docs/reports/nexus/2026-05-22-issue-4515-root-cause-diagnosis.md
+++ b/docs/reports/nexus/2026-05-22-issue-4515-root-cause-diagnosis.md
@@ -170,6 +170,29 @@ correspondingly worse. This is the mechanism behind a validator backlog that
 does not drain: the work to clear it cannot get through the saturated control
 API.
 
+### Phase D — artifact resolver and signed-access stall on the same lock (depth 800)
+
+The artifact resolver (`get_kernel_compute_training_artifact_resolver`) and
+signed-access (`post_kernel_compute_training_artifact_signed_access`) endpoints
+are read paths: each takes `store.read()` before fast work (an in-memory
+lookup; for signed-access a local GCS v4 signing step with no network call).
+Phase D probes both for a missing artifact — the handler acquires the read
+lock, fails the lookup, and returns — idle and then under a concurrent
+admission flood:
+
+| endpoint          | idle  | under admission load (avg / p99) |
+| ------------------ | ----- | -------------------------------- |
+| artifact resolver  | ~8 µs | 4.5 ms / 87 ms |
+| signed-access      | ~7 µs | 13.2 ms / 57 ms |
+
+Idle, both are microseconds. Under admission write-load they stall to
+milliseconds with a long p99 tail — `store.read()` cannot be acquired while
+writers hold the lock for O(total-state) persists. This is the mechanism behind
+the production "Artifact resolver latency" and "Signed access latency" health
+alerts (each p95 ~4.5 s). As in the other phases, the raw idle→load ratio is
+inflated by the microsecond baseline; the figure that matters is the absolute
+under-load latency, and production scale is worse.
+
 ## Why relay-side changes do not fix this
 
 The relay's semaphore is downstream of the bottleneck. Specifically:


### PR DESCRIPTION
  ## What this is

  A verified root-cause diagnosis and a runnable reproduction for #4515. It
  reproduces all four symptoms currently visible on the Nexus health panel —
  control-API capacity, validator backlog, artifact-resolver latency, and
  signed-access latency — and traces them to a single root cause. It
  deliberately does **not** include a fix — see "Fix direction" below.

  ## Root cause

  The relay's `503 embedded Nexus control API capacity exhausted` is a symptom.
  The cause is in `nexus-control`:

  - Every mutating handler takes one global `RwLock<ControlStore>`
    (`lib.rs` — presence heartbeat, training admission, training heartbeat,
    validator challenge claim/finalize, …), so all mutations are serialized.
  - Under that lock, the admission path persists the **entire** kernel state —
    `persist_compute_authority_state` (`kernel.rs:4496`) clones ~30 collections,
    `serde_json::to_vec_pretty`s the whole thing, and `fs::write` + `fs::rename`s
    it — reached via `refresh_snapshot_for` (`kernel.rs:15110`), which also
    recomputes a snapshot over every receipt.
  - Per-mutation cost is therefore O(total accumulated state), and on the
    embedded control API's 4-worker runtime the blocking lock fully serializes
    concurrent mutations.

  So the control API has a throughput ceiling that **degrades as the fleet
  runs**. When sustained load exceeds it, requests pile up at the relay until its
  256 authority-slot permits are full, and it returns the 503.

  ## Reproduction

  `apps/nexus-control/tests/issue_4515_control_api_capacity.rs` — an `#[ignore]`d
  measurement test driving requests through the real router:

  cargo test -p nexus-control --test issue_4515_control_api_capacity
      -- --ignored --nocapture

  - **Phase A:** per-admission latency grows **8.3×** as state accumulates
    (0.65 ms → 5.42 ms; kernel state file reaches 1.82 MB at 800 admissions).
  - **Phase B:** 4-way concurrency gives **0.83×** throughput — no gain; the
    control API is fully serialized.
  - **Phase C:** a validator-challenge `claim` goes from ~6 µs idle to ~8 ms avg
    / 36 ms p99 under a concurrent admission flood. Validator claim/finalize are
    `store.write()` mutations too, so the validator backlog drains through the
    same lock — it cannot drain while the control plane is saturated.
  - **Phase D:** the artifact resolver and signed-access endpoints — read paths
    that take `store.read()` — go from ~7–8 µs idle to milliseconds under a
    concurrent admission flood (resolver 4.5 ms avg / 87 ms p99; signed-access
    13.2 ms / 57 ms p99). Readers stall on the same lock, reproducing the
    production "Artifact resolver latency" / "Signed access latency" alerts.

  ## Why relay-side changes don't fix it

  Raising `NEXUS_RELAY_AUTHORITY_MAX_IN_FLIGHT` or adding a wait queue to the
  relay's semaphore cannot raise a serialized server's throughput ceiling — they
  change when the 503 appears, not whether the API keeps up.

  ## Fix direction (left to maintainers)

  The fix must remove the O(total-state) work from the mutation path — either
  debounced/background persistence or incremental persistence. This is an
  architecture decision: the kernel state file is the **authoritative** record
  (`load_persisted_compute_authority_state` is the only loader, no replay path),
  so debouncing it regresses durability, while incremental persistence preserves
  it but is a larger change. The full report
  (`docs/reports/nexus/2026-05-22-issue-4515-root-cause-diagnosis.md`) lays out
  the options. Happy to implement whichever direction you choose.

  ## Notes

  - The reproduction lives in a new `tests/` file; `axum`/`serde_json`/`tokio`
    were added as dev-dependencies for it.
  - `scripts/lint/workspace-dependency-drift-check.sh` has a pre-existing failure
    on `main` (`thiserror`, `tokio`) unrelated to this change.