### PR TITLE
Add Pylon cloud node v1 fixture

### DIFF
--- a/apps/pylon/tests/cloud_node_v1_fixture.rs
+++ b/apps/pylon/tests/cloud_node_v1_fixture.rs
@@ -1,0 +1,62 @@
+use serde_json::Value;
+
+const CONTRIBUTOR_FIXTURE: &str =
+    include_str!("../../../docs/pylon/fixtures/cloud_node_v1/contributor-pylon.json");
+
+#[test]
+fn contributor_cloud_node_v1_fixture_is_public_safe() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture: Value = serde_json::from_str(CONTRIBUTOR_FIXTURE)?;
+
+    assert_eq!(
+        fixture.pointer("/contract_version").and_then(Value::as_str),
+        Some("openagents.cloud_node.v1")
+    );
+    assert_eq!(
+        fixture
+            .pointer("/policy/settlement_policy")
+            .and_then(Value::as_str),
+        Some("contributor_wallet")
+    );
+    assert!(
+        matches!(
+            fixture.pointer("/capabilities/workroom_capacity"),
+            Some(Value::Null)
+        ),
+        "contributor Pylon must not claim managed workroom capacity"
+    );
+    assert_eq!(
+        fixture
+            .pointer("/capabilities/ingress_support/ready")
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+
+    for forbidden_key in [
+        "wallet_seed",
+        "node_entropy",
+        "private_key",
+        "preimage",
+        "bearer_token",
+        "api_key",
+        "private_topology",
+        "capacity_pool_secret",
+        "internal_accounting_credential",
+    ] {
+        assert!(
+            !json_contains_key(&fixture, forbidden_key),
+            "fixture must not expose forbidden key {forbidden_key}"
+        );
+    }
+
+    Ok(())
+}
+
+fn json_contains_key(value: &Value, needle: &str) -> bool {
+    match value {
+        Value::Object(map) => map
+            .iter()
+            .any(|(key, value)| key == needle || json_contains_key(value, needle)),
+        Value::Array(values) => values.iter().any(|value| json_contains_key(value, needle)),
+        _ => false,
+    }
+}

--- a/docs/pylon/CLOUD_NODE_V1_COMPATIBILITY.md
+++ b/docs/pylon/CLOUD_NODE_V1_COMPATIBILITY.md
@@ -1,0 +1,27 @@
+# Pylon Cloud Node v1 Compatibility
+
+Status: public contributor compatibility fixture
+
+Private managed OpenAgents Cloud implementation lives in the private `cloud`
+repo. Contributor Pylon stays open source in this repo.
+
+Pylon may implement the public subset of `openagents.cloud_node.v1` so private
+managed nodes and public contributor nodes can be compared by Nexus, Forge, and
+operator tooling without moving private fleet policy into public Pylon.
+
+The public fixture lives at:
+
+```text
+docs/pylon/fixtures/cloud_node_v1/contributor-pylon.json
+```
+
+Compatibility rules:
+
+- contributor wallet behavior remains public Pylon behavior;
+- managed `oa-node` and `oa-workroomd` behavior stays in the private `cloud`
+  repo;
+- private fleet topology, private capacity placement, internal accounting
+  adapters, capability broker internals, and workroom sidecar policy do not
+  enter public Pylon;
+- the fixture must not include wallet seeds, node entropy, private keys,
+  preimages, bearer tokens, raw API keys, or private topology.

--- a/docs/pylon/README.md
+++ b/docs/pylon/README.md
@@ -28,6 +28,11 @@ The v0.2 built-in LDK wallet operator docs live in:
 - `docs/pylon/LDK_WALLET_REGTEST_HARNESS.md`
 - `docs/pylon/LDK_WALLET_TELEMETRY.md`
 
+Public Cloud node compatibility lives in:
+
+- `docs/pylon/CLOUD_NODE_V1_COMPATIBILITY.md`
+- `docs/pylon/fixtures/cloud_node_v1/contributor-pylon.json`
+
 Use those docs for different questions:
 
 - roadmap and phase tracker: what the admitted-node MVP implementation closed

--- a/docs/pylon/fixtures/cloud_node_v1/contributor-pylon.json
+++ b/docs/pylon/fixtures/cloud_node_v1/contributor-pylon.json
@@ -1,0 +1,75 @@
+{
+  "contract_version": "openagents.cloud_node.v1",
+  "identity": {
+    "node_id": "pylon.contrib.example",
+    "operator_identity": "npub1examplecontributor",
+    "account_or_org_binding": "account.example.contributor",
+    "signing_key_ref": "pylon-local-identity"
+  },
+  "host": {
+    "os": "darwin",
+    "arch": "aarch64",
+    "cpu": "apple_silicon",
+    "memory": "32gb",
+    "disk": "1tb",
+    "accelerator_inventory": ["metal"],
+    "site_or_power_metadata": "contributor-owned"
+  },
+  "lifecycle": {
+    "desired_mode": "online",
+    "observed_status": "online",
+    "degradation_reason": null,
+    "service_manager": "pylon-tui",
+    "update_channel": "pylon-public-release",
+    "last_started_at": "2026-05-25T00:00:00Z",
+    "last_heartbeat_at": "2026-05-25T00:01:00Z"
+  },
+  "capabilities": {
+    "inference_products": [
+      {
+        "product_id": "local_gemma_inference",
+        "enabled": true,
+        "backend_ready": true,
+        "eligible": true,
+        "capability_summary": "local contributor inference"
+      }
+    ],
+    "training_products": [],
+    "sandbox_profiles": [],
+    "workroom_capacity": null,
+    "ingress_support": {
+      "supported": false,
+      "enabled": false,
+      "ready": false,
+      "detail": "public Pylon is not a managed workroom ingress node"
+    },
+    "artifact_support": {
+      "supported": true,
+      "enabled": true,
+      "ready": true,
+      "detail": "provider receipt artifacts"
+    }
+  },
+  "policy": {
+    "accepted_work_policy": "public-compute-market",
+    "sandbox_policy": "disabled_until_profiled",
+    "network_policy": "provider-declared",
+    "filesystem_policy": "provider-local",
+    "secret_policy": "no-raw-platform-secrets",
+    "settlement_policy": "contributor_wallet"
+  },
+  "runtime": {
+    "local_admin_endpoint": "http://127.0.0.1:46349",
+    "heartbeat_endpoint": "https://nexus.openagents.com/provider/heartbeat",
+    "job_intake_modes": ["pylon_provider_intake"],
+    "receipt_sink": "pylon-ledger",
+    "artifact_sink": "pylon-local-artifacts"
+  },
+  "evidence": {
+    "current_snapshot_digest": "sha256:contributor-fixture",
+    "health_events": [],
+    "job_receipts": [],
+    "artifact_receipts": [],
+    "payout_or_accounting_receipts": ["pylon-wallet-receipt-redacted"]
+  }
+}


### PR DESCRIPTION
## Summary\n- add public contributor Pylon openagents.cloud_node.v1 fixture\n- add Pylon compatibility doc for the public/private cloud boundary\n- add a Pylon integration test that parses and checks the public-safe fixture\n\n## Verification\n- cargo fmt --check -p pylon\n- cargo test -p pylon --test cloud_node_v1_fixture\n\nRelated: OpenAgentsInc/cloud#1