### PR TITLE
CND-004: Protect open source Pylon boundary

### DIFF
--- a/crates/pylon-core/src/lib.rs
+++ b/crates/pylon-core/src/lib.rs
@@ -12,6 +12,25 @@ pub const PYLON_CORE_SCHEMA_VERSION: &str = "openagents.pylon_core.v1";
 pub const DEFAULT_PYLON_HEARTBEAT_ROUTE: &str = "/api/provider-presence/heartbeat";
 pub const DEFAULT_PYLON_HEARTBEAT_INTERVAL_MS: u64 = 30_000;
 
+pub const CONTRIBUTOR_OPEN_SOURCE_SURFACES: &[&str] = &[
+    "installable_app",
+    "tui",
+    "contributor_wallet_ux",
+    "provider_inventory_truth",
+    "payout_behavior",
+    "public_receipts",
+];
+
+pub const PRIVATE_CLOUD_DEPENDENCY_MARKERS: &[&str] = &[
+    "OpenAgentsInc/cloud",
+    "openagentsinc/cloud",
+    "../cloud",
+    "../../cloud",
+    "openagents-cloud-contract",
+    "oa-node",
+    "oa-workroomd",
+];
+
 pub const PUBLIC_BOUNDARY_FORBIDDEN_KEYS: &[&str] = &[
     "wallet_seed",
     "node_entropy",
@@ -393,6 +412,20 @@ pub fn assert_public_json_boundary(value: &Value) -> Result<(), PylonCoreBoundar
     )))
 }
 
+pub fn assert_no_private_cloud_dependency_text(
+    label: &str,
+    text: &str,
+) -> Result<(), PylonCoreBoundaryError> {
+    for marker in PRIVATE_CLOUD_DEPENDENCY_MARKERS {
+        if text.contains(marker) {
+            return Err(PylonCoreBoundaryError::Invalid(format!(
+                "{label} must not depend on private cloud marker '{marker}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn collect_forbidden_keys(value: &Value, path: &str, violations: &mut Vec<String>) {
     match value {
         Value::Object(map) => {
@@ -443,6 +476,12 @@ mod tests {
 
     const CONTRIBUTOR_CLOUD_NODE_FIXTURE: &str =
         include_str!("../../../docs/pylon/fixtures/cloud_node_v1/contributor-pylon.json");
+    const ROOT_CARGO: &str = include_str!("../../../Cargo.toml");
+    const PYLON_CARGO: &str = include_str!("../../../apps/pylon/Cargo.toml");
+    const PYLON_TUI_CARGO: &str = include_str!("../../../apps/pylon-tui/Cargo.toml");
+    const PYLON_CORE_CARGO: &str = include_str!("../Cargo.toml");
+    const OPEN_SOURCE_BOUNDARY_DOC: &str =
+        include_str!("../../../docs/pylon/OPEN_SOURCE_CONTRIBUTOR_BOUNDARY.md");
 
     #[test]
     fn provider_status_projects_public_pylon_core_without_tui() {
@@ -500,6 +539,29 @@ mod tests {
             .unwrap_or_else(|error| panic!("contributor Cloud Node fixture should parse: {error}"));
         assert_public_json_boundary(&fixture)
             .unwrap_or_else(|error| panic!("fixture should be public safe: {error}"));
+    }
+
+    #[test]
+    fn contributor_pylon_manifests_do_not_depend_on_private_cloud_repo() {
+        for (label, text) in [
+            ("root Cargo.toml", ROOT_CARGO),
+            ("apps/pylon/Cargo.toml", PYLON_CARGO),
+            ("apps/pylon-tui/Cargo.toml", PYLON_TUI_CARGO),
+            ("crates/pylon-core/Cargo.toml", PYLON_CORE_CARGO),
+        ] {
+            assert_no_private_cloud_dependency_text(label, text)
+                .unwrap_or_else(|error| panic!("{label} should stay public-only: {error}"));
+        }
+    }
+
+    #[test]
+    fn open_source_boundary_doc_names_required_public_surfaces() {
+        for surface in CONTRIBUTOR_OPEN_SOURCE_SURFACES {
+            assert!(
+                OPEN_SOURCE_BOUNDARY_DOC.contains(surface),
+                "boundary doc must name public surface {surface}"
+            );
+        }
     }
 
     #[test]

--- a/docs/OWNERSHIP.md
+++ b/docs/OWNERSHIP.md
@@ -66,6 +66,8 @@ Owns:
   and contributor payout flows.
 - App-specific orchestration that turns public provider-domain primitives into
   a user-run supply connector.
+- Public auditable contributor payout and inventory behavior. Contributor
+  Pylon must remain usable and inspectable without the private `cloud` repo.
 
 Must not own:
 
@@ -90,6 +92,7 @@ Must not own:
 - Private managed Cloud node behavior owned by the private `cloud` repo.
 - Product-agnostic provider substrate state machines already owned by
   `crates/openagents-provider-substrate`.
+- Private `cloud` repo crates or source paths as dependencies.
 
 ## `crates/wgpui`
 

--- a/docs/pylon/CLOUD_NODE_V1_COMPATIBILITY.md
+++ b/docs/pylon/CLOUD_NODE_V1_COMPATIBILITY.md
@@ -5,6 +5,13 @@ Status: public contributor compatibility fixture
 Private managed OpenAgents Cloud implementation lives in the private `cloud`
 repo. Contributor Pylon stays open source in this repo.
 
+The full contributor app, TUI, wallet UX, provider inventory truth, payout
+behavior, and public receipts are protected by:
+
+```text
+docs/pylon/OPEN_SOURCE_CONTRIBUTOR_BOUNDARY.md
+```
+
 Pylon may implement the public subset of `openagents.cloud_node.v1` so private
 managed nodes and public contributor nodes can be compared by Nexus, Forge, and
 operator tooling without moving private fleet policy into public Pylon.

--- a/docs/pylon/OPEN_SOURCE_CONTRIBUTOR_BOUNDARY.md
+++ b/docs/pylon/OPEN_SOURCE_CONTRIBUTOR_BOUNDARY.md
@@ -1,0 +1,50 @@
+# Pylon Open Source Contributor Boundary
+
+Status: contributor Pylon must remain open source
+
+Contributor Pylon is the public, installable supply connector for people who
+run OpenAgents on their own machines. It must stay auditable without access to
+the private `OpenAgentsInc/cloud` repo.
+
+## Public Surfaces
+
+These surfaces remain public in this repo:
+
+- `installable_app`: `apps/pylon`, release scripts, and the npm bootstrap path.
+- `tui`: `apps/pylon-tui` and the explicit `pylon tui` shell.
+- `contributor_wallet_ux`: built-in LDK wallet setup, backup, channel,
+  invoice, payment, and withdraw surfaces.
+- `provider_inventory_truth`: public provider availability, inventory,
+  capability, and local status projections.
+- `payout_behavior`: contributor payout target registration, accepted-work
+  settlement records, wallet history, and payout proofs.
+- `public_receipts`: contributor-facing receipts, local proof receipts, and
+  public compatibility fixtures.
+
+The private Cloud repo may build managed node and workroom infrastructure, but
+it must not become a dependency of contributor Pylon. Public Pylon may share
+public contract shapes such as `openagents.cloud_node.v1`, and it may expose
+public-safe projections through `crates/pylon-core`.
+
+## Audit Requirements
+
+Contributor payout behavior remains auditable from public source:
+
+- LDK wallet behavior is documented under `docs/pylon/LDK_*.md`.
+- Pylon ledger, wallet, payout, and settlement record types live under
+  `apps/pylon/src/`.
+- Local proof runtime behavior is documented in `docs/pylon/README.md` and can
+  run without private Cloud code.
+- Cloud compatibility fixtures live under
+  `docs/pylon/fixtures/cloud_node_v1/` and are validated by `crates/pylon-core`.
+
+Private fleet topology, managed workroom sidecar policy, capacity-pool
+placement, internal accounting credentials, and private rollout/quarantine
+policy belong in the private `cloud` repo, not in contributor Pylon.
+
+## Verification
+
+```bash
+cargo test -p pylon-core
+cargo test -p pylon --test cloud_node_v1_fixture
+```

--- a/docs/pylon/README.md
+++ b/docs/pylon/README.md
@@ -32,6 +32,7 @@ Public Cloud node compatibility lives in:
 
 - `docs/pylon/CLOUD_NODE_V1_COMPATIBILITY.md`
 - `docs/pylon/fixtures/cloud_node_v1/contributor-pylon.json`
+- `docs/pylon/OPEN_SOURCE_CONTRIBUTOR_BOUNDARY.md`
 
 The public contributor boundary helpers live in:
 
@@ -40,6 +41,11 @@ The public contributor boundary helpers live in:
 That crate covers identity, admin state, availability, inventory, lifecycle,
 heartbeat, receipt projections, and public-safe JSON validation without
 launching the Pylon TUI.
+
+Contributor Pylon itself remains open source: the installable app, TUI,
+contributor wallet UX, provider inventory truth, payout behavior, and public
+receipts stay in this repo and must remain auditable without private Cloud repo
+access.
 
 Use those docs for different questions:
 


### PR DESCRIPTION
## Summary
- add an explicit open-source contributor Pylon boundary doc
- add pylon-core guards for required public surfaces and private cloud dependency markers
- update Pylon/Cloud Node ownership docs to keep app, TUI, wallet UX, inventory truth, payout behavior, and public receipts auditable without the private cloud repo

## Verification
- cargo fmt --check
- cargo test -p pylon-core
- cargo test -p pylon --test cloud_node_v1_fixture
- git diff --check

Closes #4541