### PR TITLE
Recover direct tip sends after wallet timeouts

### DIFF
--- a/apps/openagents.com/scripts/forum.mjs
+++ b/apps/openagents.com/scripts/forum.mjs
@@ -73,6 +73,7 @@ Options:
   --diagnostic              Let tip-post-smoke report recovery as a known blocker instead of failing.
   --reward-amount <n>       Optional sats amount for Forum post rewards.
   --recovery-wait-ms <n>    tip-post timeout recovery wait. Defaults to 120000.
+  --recovery-poll-ms <n>    tip-post timeout recovery poll interval. Defaults to 1000.
   --tip-amount <n>          Required sats amount for direct BOLT 12 Forum tips.
   --target-forum <id>       Generic paid-action forum target.
   --target-post <id>        Generic paid-action post target.
@@ -161,7 +162,9 @@ const valueFlags = new Set([
   'request-body-digest',
   'requestBodyDigest',
   'recovery-wait-ms',
+  'recovery-poll-ms',
   'recoveryWaitMs',
+  'recoveryPollMs',
   'receipt',
   'reward-amount',
   'rewardAmount',
@@ -243,6 +246,7 @@ const canonicalFlagName = name =>
     quotePost: 'quote-post',
     readinessRef: 'readiness-ref',
     receiveCapabilityRef: 'receive-capability-ref',
+    recoveryPollMs: 'recovery-poll-ms',
     requestBodyDigest: 'request-body-digest',
     recoveryWaitMs: 'recovery-wait-ms',
     rewardAmount: 'reward-amount',
@@ -576,6 +580,22 @@ const recoveryWaitMsFromFlags = flags => {
 
   if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new Error('--recovery-wait-ms must be a positive integer.')
+  }
+
+  return parsed
+}
+
+const recoveryPollMsFromFlags = flags => {
+  const raw = flagText(flags, 'recovery-poll-ms')
+
+  if (raw === undefined) {
+    return DEFAULT_DIRECT_TIP_RECOVERY_POLL_MS
+  }
+
+  const parsed = Number(raw)
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error('--recovery-poll-ms must be a non-negative integer.')
   }
 
   return parsed
@@ -1220,17 +1240,24 @@ const privateL402CredentialFromPreview = preview => {
 const paymentPreimageFromWalletOutput = value =>
   firstStringField(value, ['payment_preimage', 'paymentPreimage', 'preimage'])
 
+const walletPaymentIdentifierNames = [
+  'payment_hash',
+  'paymentHash',
+  'payment_id',
+  'paymentId',
+  'payment_ref',
+  'paymentRef',
+  'hash',
+  'id',
+]
+
+const walletPaymentIdentifiersFromOutput = value =>
+  walletPaymentIdentifierNames
+    .map(name => firstStringField(value, [name]))
+    .filter(identifier => typeof identifier === 'string')
+
 const walletPaymentIdentifierFromOutput = value =>
-  firstStringField(value, [
-    'payment_hash',
-    'paymentHash',
-    'payment_id',
-    'paymentId',
-    'payment_ref',
-    'paymentRef',
-    'hash',
-    'id',
-  ])
+  walletPaymentIdentifiersFromOutput(value)[0]
 
 const publicRefDigest = value =>
   createHash('sha256').update(String(value)).digest('hex').slice(0, 32)
@@ -1758,10 +1785,29 @@ const directTipEvidenceFromWalletBlocker = ({
   }
 }
 
-const paymentRowStatus = row =>
-  typeof row?.status === 'string' ? row.status.trim().toLowerCase() : null
+const paymentRowStatus = row => {
+  const normalized =
+    typeof row?.status === 'string' ? row.status.trim().toLowerCase() : null
 
-const paymentRowMatches = (row, paymentIdentifier) => {
+  if (
+    ['completed', 'paid', 'settled', 'succeeded', 'success'].includes(
+      normalized,
+    )
+  ) {
+    return 'completed'
+  }
+
+  if (['canceled', 'cancelled', 'error', 'failed'].includes(normalized)) {
+    return 'failed'
+  }
+
+  return normalized
+}
+
+const paymentRowAmountSats = row =>
+  Number(row?.amountSats ?? row?.amount_sats ?? row?.amount)
+
+const paymentRowMatches = (row, paymentIdentifier, amountSats) => {
   if (row === null || typeof row !== 'object' || Array.isArray(row)) {
     return false
   }
@@ -1774,9 +1820,11 @@ const paymentRowMatches = (row, paymentIdentifier) => {
     return false
   }
 
-  const rowIdentifier = walletPaymentIdentifierFromOutput(row)
+  if (Number.isFinite(amountSats) && paymentRowAmountSats(row) !== amountSats) {
+    return false
+  }
 
-  return rowIdentifier === paymentIdentifier
+  return walletPaymentIdentifiersFromOutput(row).includes(paymentIdentifier)
 }
 
 const newestPaymentRow = rows =>
@@ -1796,12 +1844,21 @@ const walletPaymentsRows = result => {
 }
 
 const pollDirectTipPaymentRecovery = async ({
+  amountSats,
   executor,
   paymentIdentifier,
   pollMs = DEFAULT_DIRECT_TIP_RECOVERY_POLL_MS,
   sleepFn = sleep,
   waitMs,
 }) => {
+  if (typeof paymentIdentifier !== 'string' || paymentIdentifier.length === 0) {
+    return {
+      payment: null,
+      polls: 0,
+      status: 'no_identifier',
+    }
+  }
+
   const maxAttempts = Math.max(1, Math.ceil(waitMs / Math.max(pollMs, 1)) + 1)
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
@@ -1809,7 +1866,7 @@ const pollDirectTipPaymentRecovery = async ({
       () => null,
     )
     const matching = walletPaymentsRows(payments).filter(row =>
-      paymentRowMatches(row, paymentIdentifier),
+      paymentRowMatches(row, paymentIdentifier, amountSats),
     )
 
     if (matching.length > 0) {
@@ -2920,6 +2977,7 @@ export const runForumDirectTipPostPayment = async (
   const spendCap = directTipSpendCapFromFlags(parsed.flags, amount)
   const timeoutMs = walletTimeoutMsFromFlags(parsed.flags)
   const recoveryWaitMs = recoveryWaitMsFromFlags(parsed.flags)
+  const recoveryPollMs = recoveryPollMsFromFlags(parsed.flags)
   const walletNetwork = walletNetworkFromFlags(parsed.flags, env)
   const walletExecutor =
     options.walletExecutor || createAgentWalletExecutor({ timeoutMs })
@@ -3025,12 +3083,13 @@ export const runForumDirectTipPostPayment = async (
 
     if (timedOut) {
       const recovery = await pollDirectTipPaymentRecovery({
+        amountSats: amount.amount,
         executor: walletExecutor,
         paymentIdentifier: paymentIdentifier ?? null,
         pollMs:
           typeof options.recoveryPollMs === 'number'
             ? options.recoveryPollMs
-            : DEFAULT_DIRECT_TIP_RECOVERY_POLL_MS,
+            : recoveryPollMs,
         sleepFn: options.sleep || sleep,
         waitMs: recoveryWaitMs,
       })

--- a/apps/openagents.com/scripts/forum.mjs
+++ b/apps/openagents.com/scripts/forum.mjs
@@ -7,6 +7,8 @@ import { pathToFileURL } from 'node:url'
 
 const DEFAULT_BASE_URL = 'https://openagents.com'
 const DEFAULT_AGENT_WALLET_TIMEOUT_MS = 5_000
+const DEFAULT_DIRECT_TIP_RECOVERY_WAIT_MS = 120_000
+const DEFAULT_DIRECT_TIP_RECOVERY_POLL_MS = 1_000
 
 export const usage = () => `Usage:
   node scripts/forum.mjs board
@@ -70,6 +72,7 @@ Options:
   --strict-smooth           Fail tip-post-smoke when timeout recovery is needed.
   --diagnostic              Let tip-post-smoke report recovery as a known blocker instead of failing.
   --reward-amount <n>       Optional sats amount for Forum post rewards.
+  --recovery-wait-ms <n>    tip-post timeout recovery wait. Defaults to 120000.
   --tip-amount <n>          Required sats amount for direct BOLT 12 Forum tips.
   --target-forum <id>       Generic paid-action forum target.
   --target-post <id>        Generic paid-action post target.
@@ -157,6 +160,8 @@ const valueFlags = new Set([
   'receiveCapabilityRef',
   'request-body-digest',
   'requestBodyDigest',
+  'recovery-wait-ms',
+  'recoveryWaitMs',
   'receipt',
   'reward-amount',
   'rewardAmount',
@@ -239,6 +244,7 @@ const canonicalFlagName = name =>
     readinessRef: 'readiness-ref',
     receiveCapabilityRef: 'receive-capability-ref',
     requestBodyDigest: 'request-body-digest',
+    recoveryWaitMs: 'recovery-wait-ms',
     rewardAmount: 'reward-amount',
     routeParamsJson: 'route-params-json',
     sourceRef: 'source-ref',
@@ -558,6 +564,25 @@ const walletTimeoutMsFromFlags = flags => {
 
   return parsed
 }
+
+const recoveryWaitMsFromFlags = flags => {
+  const raw = flagText(flags, 'recovery-wait-ms')
+
+  if (raw === undefined) {
+    return DEFAULT_DIRECT_TIP_RECOVERY_WAIT_MS
+  }
+
+  const parsed = Number(raw)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error('--recovery-wait-ms must be a positive integer.')
+  }
+
+  return parsed
+}
+
+const sleep = ms =>
+  ms <= 0 ? Promise.resolve() : new Promise(resolve => setTimeout(resolve, ms))
 
 const normalizedWalletNetwork = value => {
   const normalized = String(value || 'any')
@@ -1043,6 +1068,8 @@ const parseWalletJson = (spec, result) => {
 
   return { blocker: null, exitCode, parsed }
 }
+
+const timedOutWalletJson = result => walletJsonObjectFromOutput(result?.stdout)
 
 const walletErrorText = parsed =>
   parsed === null || typeof parsed !== 'object'
@@ -1616,7 +1643,10 @@ const runAgentWalletSendPayment = async ({ amount, destination, executor }) => {
   if (parsed.blocker !== null) {
     return {
       blocker: parsed.blocker,
-      parsed: null,
+      parsed:
+        parsed.blocker.reasonRef === 'reason.public.agent_wallet_send_timeout'
+          ? timedOutWalletJson(result)
+          : null,
       status: 'blocked',
     }
   }
@@ -1728,11 +1758,99 @@ const directTipEvidenceFromWalletBlocker = ({
   }
 }
 
+const paymentRowStatus = row =>
+  typeof row?.status === 'string' ? row.status.trim().toLowerCase() : null
+
+const paymentRowMatches = (row, paymentIdentifier) => {
+  if (row === null || typeof row !== 'object' || Array.isArray(row)) {
+    return false
+  }
+
+  if (paymentIdentifier === null) {
+    return false
+  }
+
+  if (row.direction !== undefined && row.direction !== 'outbound') {
+    return false
+  }
+
+  const rowIdentifier = walletPaymentIdentifierFromOutput(row)
+
+  return rowIdentifier === paymentIdentifier
+}
+
+const newestPaymentRow = rows =>
+  rows.reduce((latest, row) =>
+    Number(row.timestamp ?? row.createdAtUnixMs ?? row.updatedAtUnixMs ?? 0) >=
+    Number(
+      latest.timestamp ?? latest.createdAtUnixMs ?? latest.updatedAtUnixMs ?? 0,
+    )
+      ? row
+      : latest,
+  )
+
+const walletPaymentsRows = result => {
+  const parsed = walletJsonObjectFromOutput(result?.stdout)
+
+  return Array.isArray(parsed?.payments) ? parsed.payments : []
+}
+
+const pollDirectTipPaymentRecovery = async ({
+  executor,
+  paymentIdentifier,
+  pollMs = DEFAULT_DIRECT_TIP_RECOVERY_POLL_MS,
+  sleepFn = sleep,
+  waitMs,
+}) => {
+  const maxAttempts = Math.max(1, Math.ceil(waitMs / Math.max(pollMs, 1)) + 1)
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const payments = await executor(walletCommandSpecs.payments).catch(
+      () => null,
+    )
+    const matching = walletPaymentsRows(payments).filter(row =>
+      paymentRowMatches(row, paymentIdentifier),
+    )
+
+    if (matching.length > 0) {
+      const row = newestPaymentRow(matching)
+      const status = paymentRowStatus(row)
+
+      if (status === 'completed') {
+        return {
+          payment: row,
+          polls: attempt + 1,
+          status: 'completed',
+        }
+      }
+
+      if (status === 'failed') {
+        return {
+          payment: row,
+          polls: attempt + 1,
+          status: 'failed',
+        }
+      }
+    }
+
+    if (attempt < maxAttempts - 1) {
+      await sleepFn(pollMs)
+    }
+  }
+
+  return {
+    payment: null,
+    polls: maxAttempts,
+    status: 'deadline',
+  }
+}
+
 const submitDirectTipEvidence = async ({
   amount,
   baseUrl,
   env,
   evidence,
+  idempotencyKey = null,
   parsed,
   post,
   requestJson,
@@ -1743,11 +1861,13 @@ const submitDirectTipEvidence = async ({
       amount,
       paymentEvidence: evidence,
     },
-    idempotencyKey: idempotencyKeyFor(parsed.flags, 'direct-tip', {
-      amount,
-      externalRef: evidence.externalRef,
-      post,
-    }),
+    idempotencyKey:
+      idempotencyKey ??
+      idempotencyKeyFor(parsed.flags, 'direct-tip', {
+        amount,
+        externalRef: evidence.externalRef,
+        post,
+      }),
     method: 'POST',
     path: `/api/forum/posts/${encoded(post)}/direct-tips`,
     token: env.OPENAGENTS_AGENT_TOKEN,
@@ -2799,6 +2919,7 @@ export const runForumDirectTipPostPayment = async (
   const amount = requiredSatsAmountFromFlags(parsed.flags, 'tip-amount')
   const spendCap = directTipSpendCapFromFlags(parsed.flags, amount)
   const timeoutMs = walletTimeoutMsFromFlags(parsed.flags)
+  const recoveryWaitMs = recoveryWaitMsFromFlags(parsed.flags)
   const walletNetwork = walletNetworkFromFlags(parsed.flags, env)
   const walletExecutor =
     options.walletExecutor || createAgentWalletExecutor({ timeoutMs })
@@ -2898,6 +3019,92 @@ export const runForumDirectTipPostPayment = async (
     const timedOut =
       walletPayment.blocker?.reasonRef ===
       'reason.public.agent_wallet_send_timeout'
+    const paymentIdentifier = walletPaymentIdentifierFromOutput(
+      walletPayment.parsed,
+    )
+
+    if (timedOut) {
+      const recovery = await pollDirectTipPaymentRecovery({
+        executor: walletExecutor,
+        paymentIdentifier: paymentIdentifier ?? null,
+        pollMs:
+          typeof options.recoveryPollMs === 'number'
+            ? options.recoveryPollMs
+            : DEFAULT_DIRECT_TIP_RECOVERY_POLL_MS,
+        sleepFn: options.sleep || sleep,
+        waitMs: recoveryWaitMs,
+      })
+
+      if (recovery.status === 'completed') {
+        const evidence = directTipEvidenceFromWalletPayment({
+          amount,
+          parsed: recovery.payment,
+          post,
+          status: 'confirmed',
+          walletNetwork,
+        })
+        const recoveredPaymentIdentifier =
+          walletPaymentIdentifierFromOutput(recovery.payment) ??
+          paymentIdentifier ??
+          evidence.externalRef
+        const recorded = await submitDirectTipEvidence({
+          amount,
+          baseUrl: postRequest.baseUrl,
+          env,
+          evidence,
+          idempotencyKey: stableIdempotencyKey('direct-tip-recovered-payment', {
+            paymentIdentifier: recoveredPaymentIdentifier,
+            post,
+          }),
+          parsed,
+          post,
+          requestJson,
+        })
+
+        return directTipResult({
+          livePaymentAttempted: true,
+          payment: {
+            commandRef: 'mdk_agent_wallet.send',
+            evidenceRef: evidence.redactedEvidenceRef,
+            preimageCaptured:
+              paymentPreimageFromWalletOutput(recovery.payment) !== undefined,
+            recoveredAfterTimeout: true,
+            recoveryPolls: recovery.polls,
+            status: 'paid',
+            walletPaymentRef: 'wallet_payment.public.mdk_agent_wallet.redacted',
+          },
+          preflight,
+          receipt: recorded.receipt ?? null,
+          selfPayCheck,
+          status: recorded.status === 'settled' ? 'settled' : recorded.status,
+          attemptId: recorded.attemptId ?? null,
+          target: {
+            ...target,
+            postLink: recorded.targetPostPermalink ?? target.postLink,
+          },
+        })
+      }
+
+      if (recovery.status === 'failed') {
+        return directTipResult({
+          livePaymentAttempted: true,
+          payment: {
+            commandRef: 'mdk_agent_wallet.send',
+            reasonRef: 'reason.public.agent_wallet_send_failed',
+            recoveredAfterTimeout: true,
+            recoveryPolls: recovery.polls,
+            status: 'failed',
+          },
+          preflight,
+          reasonRef: 'reason.public.agent_wallet_send_failed',
+          receipt: null,
+          selfPayCheck,
+          status: 'payment_failed',
+          target,
+        })
+      }
+    }
+
     const failureClassification = timedOut
       ? await classifyStalledTipSend(walletExecutor, amount.amount)
       : null
@@ -2928,18 +3135,24 @@ export const runForumDirectTipPostPayment = async (
           ? {}
           : {
               failureClassification,
-              failureClassificationReasonRef:
-                tipFailureClassificationReasonRef(failureClassification),
+              failureClassificationReasonRef: tipFailureClassificationReasonRef(
+                failureClassification,
+              ),
             }),
         reasonRef:
           walletPayment.blocker?.reasonRef ??
           'reason.public.agent_wallet_send_failed',
         status: timedOut ? 'recovery_pending' : 'failed',
+        ...(timedOut
+          ? {
+              recoveryDeadlineHit: true,
+              recoveryWaitMs,
+            }
+          : {}),
         // #4704: recovery_pending attempts archive after 24h if the
         // provider callback never reconciles them. For balance-funded
         // tips that can never half-record, prefer the ladder route:
         // POST /api/forum/posts/{postId}/tips/ladder (pylon tip <post> <sats>).
-
       },
       preflight,
       reasonRef:

--- a/apps/openagents.com/scripts/forum.test.ts
+++ b/apps/openagents.com/scripts/forum.test.ts
@@ -125,8 +125,7 @@ describe('forum CLI helpers', () => {
       /^forum-tip-wallet-claim-[a-f0-9]{32}$/,
     )
     expect(request.body).toMatchObject({
-      bolt12Offer:
-        'lno1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3j',
+      bolt12Offer: 'lno1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3j',
       caveatRefs: ['caveat.public.forum_tip_recipient.claim_doc_pending'],
       claimPolicyRefs: ['policy.public.forum_tip_recipient.claimed_by_cli'],
       custodyPolicyRefs: ['policy.public.forum_tip_recipient.self_custody'],
@@ -1140,7 +1139,10 @@ describe('forum CLI helpers', () => {
       }
 
       if (request.path === '/api/forum/posts/post_1/direct-tips') {
-        expect(request.body.amount).toStrictEqual({ amount: 15, asset: 'sats' })
+        expect(request.body.amount).toStrictEqual({
+          amount: 15,
+          asset: 'sats',
+        })
         expect(request.body.paymentEvidence).toMatchObject({
           paymentMode: 'live',
           providerRef: 'provider.public.mdk_agent_wallet',
@@ -1488,6 +1490,346 @@ describe('forum CLI helpers', () => {
     })
   })
 
+  test('tip-post recovers a completed wallet payment after send timeout and records confirmed evidence', async () => {
+    const walletExecutor = readyWalletExecutor()
+    const paymentsSeen: string[] = []
+    const requestJson = vi.fn(async request => {
+      if (request.path === '/api/forum/posts/post_1') {
+        return {
+          post: {
+            permalink: 'https://openagents.com/forum/t/topic_1#post-post_1',
+            postId: 'post_1',
+            tipRecipientReadiness: {
+              actorRef: 'actor.recipient',
+              directPayment: {
+                bolt12Offer:
+                  'lno1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3j',
+                kind: 'bolt12_offer',
+                settlementAuthority: 'recipient_wallet_direct',
+              },
+              state: 'ready',
+              tippingAvailable: true,
+            },
+          },
+        }
+      }
+
+      if (request.path === '/api/forum/posts/post_1/direct-tips') {
+        expect(request.idempotencyKey).toMatch(
+          /^forum-direct-tip-recovered-payment-[a-f0-9]{32}$/,
+        )
+        expect(request.idempotencyKey).not.toContain('wallet_payment_1')
+        expect(request.body.paymentEvidence).toMatchObject({
+          paymentMode: 'live',
+          providerRef: 'provider.public.mdk_agent_wallet',
+          status: 'confirmed',
+        })
+        expect(JSON.stringify(request)).not.toContain('lno1qpzry9')
+        expect(JSON.stringify(request)).not.toContain('wallet_payment_1')
+
+        return {
+          amount: { amount: 15, asset: 'sats' },
+          attemptId: '77777777-7777-4777-8777-777777777777',
+          idempotent: true,
+          payerActorRef: 'agent:payer',
+          paymentEvidence: request.body.paymentEvidence,
+          postId: 'post_1',
+          receipt: {
+            receiptRef: 'receipt.forum.direct.recovered',
+            tipSettlement: {
+              creatorReceivedSpendableValue: true,
+              state: 'settled',
+            },
+          },
+          recipientActorRef: 'actor.recipient',
+          status: 'settled',
+          targetPostPermalink:
+            'https://openagents.com/forum/t/topic_1#post-post_1',
+        }
+      }
+
+      throw new Error(`Unexpected request: ${request.path}`)
+    })
+    walletExecutor.mockImplementation(async commandSpec => {
+      if (commandSpec.command === 'send') {
+        return {
+          exitCode: 124,
+          stdout: '{"paymentId":"wallet_payment_1"}',
+          timedOut: true,
+        }
+      }
+
+      if (commandSpec.command === 'payments') {
+        paymentsSeen.push('payments')
+
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            payments: [
+              {
+                amountSats: 15,
+                direction: 'outbound',
+                paymentId: 'wallet_payment_1',
+                status: paymentsSeen.length === 1 ? 'pending' : 'completed',
+                timestamp: paymentsSeen.length,
+              },
+            ],
+          }),
+        }
+      }
+
+      return readyWalletExecutor()(commandSpec)
+    })
+
+    const output = await forumCli.runForumCli(
+      [
+        'tip-post',
+        '--post',
+        'post_1',
+        '--tip-amount',
+        '15',
+        '--approve-live-spend',
+        '--recovery-wait-ms',
+        '2',
+      ],
+      {
+        OPENAGENTS_AGENT_TOKEN: 'oa_agent_secret_123',
+      },
+      {
+        recoveryPollMs: 0,
+        requestJson,
+        sleep: async () => {},
+        walletExecutor,
+      },
+    )
+    const body = JSON.parse(output)
+
+    expect(body).toMatchObject({
+      kind: 'forum_direct_bolt12_tip',
+      livePaymentAttempted: true,
+      payment: {
+        commandRef: 'mdk_agent_wallet.send',
+        recoveredAfterTimeout: true,
+        recoveryPolls: 2,
+        status: 'paid',
+      },
+      receipt: {
+        receiptRef: 'receipt.forum.direct.recovered',
+        tipSettlement: {
+          creatorReceivedSpendableValue: true,
+          state: 'settled',
+        },
+      },
+      status: 'settled',
+    })
+    expect(output).not.toContain('lno1qpzry9')
+    expect(output).not.toContain('wallet_payment_1')
+  })
+
+  test('tip-post reports payment_failed when timeout recovery finds a failed payment', async () => {
+    const walletExecutor = readyWalletExecutor()
+    const requestJson = vi.fn(async request => {
+      if (request.path === '/api/forum/posts/post_1') {
+        return {
+          post: {
+            permalink: 'https://openagents.com/forum/t/topic_1#post-post_1',
+            postId: 'post_1',
+            tipRecipientReadiness: {
+              actorRef: 'actor.recipient',
+              directPayment: {
+                bolt12Offer:
+                  'lno1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3j',
+                kind: 'bolt12_offer',
+                settlementAuthority: 'recipient_wallet_direct',
+              },
+              state: 'ready',
+              tippingAvailable: true,
+            },
+          },
+        }
+      }
+
+      throw new Error(`Unexpected request: ${request.path}`)
+    })
+    walletExecutor.mockImplementation(async commandSpec => {
+      if (commandSpec.command === 'send') {
+        return {
+          exitCode: 124,
+          stdout: '{"paymentId":"wallet_payment_failed"}',
+          timedOut: true,
+        }
+      }
+
+      if (commandSpec.command === 'payments') {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            payments: [
+              {
+                amountSats: 15,
+                direction: 'outbound',
+                paymentId: 'wallet_payment_failed',
+                status: 'failed',
+                timestamp: 1,
+              },
+            ],
+          }),
+        }
+      }
+
+      return readyWalletExecutor()(commandSpec)
+    })
+
+    const output = await forumCli.runForumCli(
+      [
+        'tip-post',
+        '--post',
+        'post_1',
+        '--tip-amount',
+        '15',
+        '--approve-live-spend',
+        '--recovery-wait-ms',
+        '1',
+      ],
+      {
+        OPENAGENTS_AGENT_TOKEN: 'oa_agent_secret_123',
+      },
+      {
+        recoveryPollMs: 0,
+        requestJson,
+        sleep: async () => {},
+        walletExecutor,
+      },
+    )
+    const body = JSON.parse(output)
+
+    expect(body).toMatchObject({
+      payment: {
+        commandRef: 'mdk_agent_wallet.send',
+        reasonRef: 'reason.public.agent_wallet_send_failed',
+        recoveredAfterTimeout: true,
+        status: 'failed',
+      },
+      reasonRef: 'reason.public.agent_wallet_send_failed',
+      receipt: null,
+      status: 'payment_failed',
+    })
+    expect(requestJson).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/forum/posts/post_1/direct-tips',
+      }),
+    )
+  })
+
+  test('tip-post keeps recovery_pending when timeout recovery reaches its deadline', async () => {
+    const walletExecutor = readyWalletExecutor()
+    const requestJson = vi.fn(async request => {
+      if (request.path === '/api/forum/posts/post_1') {
+        return {
+          post: {
+            permalink: 'https://openagents.com/forum/t/topic_1#post-post_1',
+            postId: 'post_1',
+            tipRecipientReadiness: {
+              actorRef: 'actor.recipient',
+              directPayment: {
+                bolt12Offer:
+                  'lno1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3j',
+                kind: 'bolt12_offer',
+                settlementAuthority: 'recipient_wallet_direct',
+              },
+              state: 'ready',
+              tippingAvailable: true,
+            },
+          },
+        }
+      }
+
+      if (request.path === '/api/forum/posts/post_1/direct-tips') {
+        expect(request.body.paymentEvidence.status).toBe('observed')
+
+        return {
+          amount: { amount: 15, asset: 'sats' },
+          attemptId: '77777777-7777-4777-8777-777777777777',
+          idempotent: false,
+          payerActorRef: 'agent:payer',
+          paymentEvidence: request.body.paymentEvidence,
+          postId: 'post_1',
+          receipt: null,
+          recipientActorRef: 'actor.recipient',
+          status: 'recovery_pending',
+          targetPostPermalink:
+            'https://openagents.com/forum/t/topic_1#post-post_1',
+        }
+      }
+
+      throw new Error(`Unexpected request: ${request.path}`)
+    })
+    walletExecutor.mockImplementation(async commandSpec => {
+      if (commandSpec.command === 'send') {
+        return {
+          exitCode: 124,
+          stdout: '{"paymentId":"wallet_payment_pending"}',
+          timedOut: true,
+        }
+      }
+
+      if (commandSpec.command === 'payments') {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            payments: [
+              {
+                amountSats: 15,
+                direction: 'outbound',
+                paymentId: 'wallet_payment_pending',
+                status: 'pending',
+                timestamp: 1,
+              },
+            ],
+          }),
+        }
+      }
+
+      return readyWalletExecutor()(commandSpec)
+    })
+
+    const output = await forumCli.runForumCli(
+      [
+        'tip-post',
+        '--post',
+        'post_1',
+        '--tip-amount',
+        '15',
+        '--approve-live-spend',
+        '--recovery-wait-ms',
+        '1',
+      ],
+      {
+        OPENAGENTS_AGENT_TOKEN: 'oa_agent_secret_123',
+      },
+      {
+        recoveryPollMs: 0,
+        requestJson,
+        sleep: async () => {},
+        walletExecutor,
+      },
+    )
+    const body = JSON.parse(output)
+
+    expect(body).toMatchObject({
+      attemptId: '77777777-7777-4777-8777-777777777777',
+      payment: {
+        commandRef: 'mdk_agent_wallet.send',
+        recoveryDeadlineHit: true,
+        recoveryWaitMs: 1,
+        status: 'recovery_pending',
+      },
+      status: 'recovery_pending',
+    })
+    expect(output).not.toContain('lno1qpzry9')
+    expect(output).not.toContain('wallet_payment_pending')
+  })
+
   test('tip-post-smoke strict mode fails when timeout recovery is needed', async () => {
     const walletExecutor = readyWalletExecutor()
     const requestJson = vi.fn(async request => {
@@ -1556,13 +1898,17 @@ describe('forum CLI helpers', () => {
         '--tip-amount',
         '15',
         '--approve-live-spend',
+        '--recovery-wait-ms',
+        '1',
         '--strict-smooth',
       ],
       {
         OPENAGENTS_AGENT_TOKEN: 'oa_agent_secret_123',
       },
       {
+        recoveryPollMs: 0,
         requestJson,
+        sleep: async () => {},
         walletExecutor,
       },
     )
@@ -1602,7 +1948,9 @@ describe('forum CLI helpers', () => {
 describe('forum tip failure classification and self-pay preflight', () => {
   const BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
 
-  const syntheticOffer = (records: Array<{ type: number; value: number[] }>) => {
+  const syntheticOffer = (
+    records: Array<{ type: number; value: number[] }>,
+  ) => {
     const bytes: number[] = []
 
     for (const record of records) {
@@ -1730,9 +2078,9 @@ describe('forum tip failure classification and self-pay preflight', () => {
     expect(
       forumCli.offersShareSelfPayIdentity(sharedIssuerA, sharedIssuerB),
     ).toBe(true)
-    expect(forumCli.offersShareSelfPayIdentity('not-an-offer', sharedPathA)).toBe(
-      null,
-    )
+    expect(
+      forumCli.offersShareSelfPayIdentity('not-an-offer', sharedPathA),
+    ).toBe(null)
   })
 
   test('does not treat a shared LSP introduction pubkey as self-pay identity', () => {
@@ -1784,7 +2132,14 @@ describe('forum tip failure classification and self-pay preflight', () => {
     })
 
     const output = await forumCli.runForumCli(
-      ['tip-post', '--post', 'post_self', '--tip-amount', '15', '--approve-live-spend'],
+      [
+        'tip-post',
+        '--post',
+        'post_self',
+        '--tip-amount',
+        '15',
+        '--approve-live-spend',
+      ],
       { OPENAGENTS_AGENT_TOKEN: 'oa_agent_secret_123' },
       { requestJson, walletExecutor },
     )
@@ -1878,10 +2233,12 @@ describe('forum tip failure classification and self-pay preflight', () => {
         '--tip-amount',
         '15',
         '--approve-live-spend',
+        '--recovery-wait-ms',
+        '1',
         '--strict-smooth',
       ],
       { OPENAGENTS_AGENT_TOKEN: 'oa_agent_secret_123' },
-      { requestJson, walletExecutor },
+      { recoveryPollMs: 0, requestJson, sleep: async () => {}, walletExecutor },
     )
     const body = JSON.parse(output)
 

--- a/apps/openagents.com/scripts/forum.test.ts
+++ b/apps/openagents.com/scripts/forum.test.ts
@@ -1567,10 +1567,17 @@ describe('forum CLI helpers', () => {
           stdout: JSON.stringify({
             payments: [
               {
+                amountSats: 16,
+                direction: 'outbound',
+                paymentId: 'wallet_payment_1',
+                status: 'completed',
+                timestamp: 100,
+              },
+              {
                 amountSats: 15,
                 direction: 'outbound',
                 paymentId: 'wallet_payment_1',
-                status: paymentsSeen.length === 1 ? 'pending' : 'completed',
+                status: paymentsSeen.length === 1 ? 'pending' : 'settled',
                 timestamp: paymentsSeen.length,
               },
             ],


### PR DESCRIPTION
## Summary

- Adds `--recovery-wait-ms` for `forum.mjs tip-post` timeout recovery, defaulting to 120s.
- When `agent-wallet send` times out but returns a payment identifier, polls `agent-wallet payments` until that initiated payment reaches `completed` or `failed`.
- On `completed`, submits confirmed direct-tip evidence to `/api/forum/posts/{postId}/direct-tips` and uses a deterministic idempotency key derived from the recovered payment identifier.
- On `failed`, reports `payment_failed` without creating a public receipt.
- On deadline or missing initiated payment id, keeps the existing `recovery_pending` observed-evidence behavior and includes a deadline note in the public-safe payment summary.

Refs #4797.

## Verified first-hand

- `npx --yes bun@latest test scripts/forum.test.ts`
  - `39 pass`, `0 fail`
- `git diff --check`
  - passed
- `npx --yes bun@latest run scripts/forum.mjs --help | rg 'recovery-wait-ms'`
  - confirmed the new CLI flag is visible

## Not verified locally

- I did not run a live BOLT12/signet timeout transcript. This checkout does not have a funded live/signet MDK wallet and reachable recipient node configured.
- I did not run full `bun run check:deploy`; the prior local checkout state lacked installed workspace dependencies for the web typecheck path. The touched suite for this issue is `scripts/forum.test.ts`, which is green.

## Notes

The recovery path only auto-confirms when the timed-out send yields a payment identifier and `payments` returns the same identifier in a terminal state. If no initiated payment id is available, the CLI does not guess from amount alone; it falls back to the existing `recovery_pending` behavior.
