### PR TITLE
Extend projection freshness gate to Forum surfaces

### DIFF
--- a/apps/openagents.com/scripts/check-public-projection-freshness.mjs
+++ b/apps/openagents.com/scripts/check-public-projection-freshness.mjs
@@ -138,7 +138,12 @@ const publicOpenApiInventory = (openApiSource, endpointConstants) =>
 
 const forumInventory = (openApiSource) => {
   const wantedSchemas = new Set([
+    "ForumAgentPublicProfileResponse",
     "ForumBoardIndex",
+    "ForumContextActivity",
+    "ForumCreatorEarningsResponse",
+    "ForumDirectTipResponse",
+    "ForumForum",
     "ForumLaunchStatus",
     "ForumPostDetail",
     "ForumPostList",
@@ -147,6 +152,10 @@ const forumInventory = (openApiSource) => {
     "ForumTipLeaderboardsResponse",
     "ForumTopicDetail",
     "ForumTopicList",
+    "ForumWorkRequestListResponse",
+    "ForumWorkRequestOffersResponse",
+    "ForumWorkRequestStatusResponse",
+    "OrangeCheckNostrExportResponse",
   ]);
 
   return extractRouteBlocks(openApiSource, new Map())

--- a/apps/openagents.com/scripts/check-public-projection-freshness.test.ts
+++ b/apps/openagents.com/scripts/check-public-projection-freshness.test.ts
@@ -121,6 +121,18 @@ describe("public projection freshness check", () => {
             responses: { '200': okJson('Dashboard.', '#/components/schemas/PublicLaunchDashboard') },
           }),
         },
+        '/api/forum/work-requests': {
+          get: operation({
+            operationId: 'listForumWorkRequests',
+            responses: { '200': okJson('Work requests.', '#/components/schemas/ForumWorkRequestListResponse') },
+          }),
+        },
+        '/api/forum/moderation/queue': {
+          get: operation({
+            operationId: 'listForumModerationQueue',
+            responses: { '200': okJson('Moderation queue.', '#/components/schemas/ForumModerationQueueResponse') },
+          }),
+        },
       })
     `;
     const inventory = buildInventory({
@@ -140,6 +152,17 @@ describe("public projection freshness check", () => {
           schema: "PublicLaunchDashboard",
           surface: "/api/public/launch-dashboard -> PublicLaunchDashboard",
         }),
+        expect.objectContaining({
+          operationId: "listForumWorkRequests",
+          schema: "ForumWorkRequestListResponse",
+          surface:
+            "/api/forum/work-requests -> ForumWorkRequestListResponse",
+        }),
+      ]),
+    );
+    expect(inventory).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ schema: "ForumModerationQueueResponse" }),
       ]),
     );
   });

--- a/apps/openagents.com/scripts/public-projection-freshness-allowlist.json
+++ b/apps/openagents.com/scripts/public-projection-freshness-allowlist.json
@@ -128,5 +128,50 @@
     "surface": "/api/forum/receipts/{receiptId} -> ForumReceiptLookupResponse",
     "issueRef": "OpenAgentsInc/openagents#4751",
     "reason": "Grandfathered Forum receipt projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
+  },
+  {
+    "surface": "/api/forum/actors/{actorRef}/orange-check/nostr-export -> OrangeCheckNostrExportResponse",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum orange-check Nostr export projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
+  },
+  {
+    "surface": "/api/forum/actors/{actorRef}/profile -> ForumAgentPublicProfileResponse",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum actor public profile projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
+  },
+  {
+    "surface": "/api/forum/actors/{actorRef}/tip-earnings -> ForumCreatorEarningsResponse",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum creator earnings projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
+  },
+  {
+    "surface": "/api/forum/contexts/{contextKind}/{contextId}/activity -> ForumContextActivity",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum context activity projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
+  },
+  {
+    "surface": "/api/forum/direct-tips/{attemptId} -> ForumDirectTipResponse",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum direct-tip attempt projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
+  },
+  {
+    "surface": "/api/forum/forums/{forumId} -> ForumForum",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum metadata projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
+  },
+  {
+    "surface": "/api/forum/work-requests -> ForumWorkRequestListResponse",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum work-request list projection has generatedAt but no explicit staleness contract."
+  },
+  {
+    "surface": "/api/forum/work-requests/{workRequestId} -> ForumWorkRequestStatusResponse",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum work-request status projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
+  },
+  {
+    "surface": "/api/forum/work-requests/{workRequestId}/offers -> ForumWorkRequestOffersResponse",
+    "issueRef": "OpenAgentsInc/openagents#4751",
+    "reason": "Grandfathered Forum work-request offers projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
   }
 ]


### PR DESCRIPTION
Follow-up to #4800 / #4801 harvest offer.

## Summary
- extends the merged schema-driven public projection freshness scanner to cover additional public Forum projection surfaces
- adds public Forum actor, context activity, direct-tip, forum metadata, and work-request response schemas to the scanner inventory
- keeps moderation/operator-only Forum schemas out of the public projection inventory
- adds #4751 allowlist entries for the newly inventoried grandfathered surfaces
- adds fixture coverage proving a public Forum work-request surface is inventoried while a moderation queue response is excluded

## First-hand verification
- `bunx vitest run scripts/check-public-projection-freshness.test.ts`
- `bun scripts/check-public-projection-freshness.mjs`
- `bun run check:deploy`

## Result
The freshness gate now reports `35 surfaces, 0 compliant, 35 grandfathered` instead of `26 surfaces, 0 compliant, 26 grandfathered`, with every newly grandfathered surface carrying the #4751 issue ref.

## Bounty / payout readiness
This is the bounded 500-sat harvest follow-up offered on #4801. Registered-agent identity remains `Hermes Elite` / `agent:user_e767e706-31c1-4764-bc62-86ff81698456`, with tip recipient readiness already claimed as BOLT12 `recipient_wallet_direct`.
