### PR TITLE
Wire studied knowledge into hygiene debt receipts

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1043,6 +1043,32 @@ This is the invariant ledger for `openagents`.
 - Regression coverage for this policy lives in
   `workers/api/src/agent-claim-reward-ledger.test.ts`.
 
+## Debt Receipt Hygiene Settlement
+
+- Codebase hygiene work is payable only as a funded debt receipt: a public-safe
+  source ref, baseline metric, target metric, touched scope, budget cap, stop
+  condition, verifier, accepted-work evidence, measured hygiene delta, and
+  settlement approval.
+- Discovery is inventory, not spend. A worker, churn probe, or agent may
+  propose debt, but a distinct owner, allocator, reviewer, or market policy must
+  convert it into a funded receipt before payout eligibility exists.
+- Workers must not receive spend authority, settlement authority, deployment
+  authority, or authority to mint payable follow-up debt from their own work.
+- Payment follows verified delta, not churn: behavior or benchmark parity must
+  be green, the named hygiene metric must improve, and no equal-or-worse debt
+  may be introduced elsewhere in the scoped receipt.
+- A debt receipt settles once and then retires. Near-duplicate work against a
+  retired receipt fingerprint is duplicate replay, not payable work.
+- After repeated rejected or revision-required attempts on the same
+  receipt/scope, the receipt becomes human-review-only until the benchmark,
+  budget, or scope changes.
+- Public debt-receipt projections must reject raw diffs, prompts, generated
+  fixtures, provider payloads, customer data, private repo data, payment or
+  wallet material, payout targets, secrets, and raw timestamps.
+- Regression coverage for this policy lives in
+  `workers/api/src/debt-receipt-policy.test.ts`; the buyer-facing lane packet
+  lives in `docs/labor/2026-06-18-debt-receipt-hygiene-lane.md`.
+
 ## User-Facing Live Data Integrity
 
 - User-facing product surfaces must not render dummy, example, fixture, seed,

--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1057,6 +1057,12 @@ This is the invariant ledger for `openagents`.
 - Payment follows verified delta, not churn: behavior or benchmark parity must
   be green, the named hygiene metric must improve, and no equal-or-worse debt
   may be introduced elsewhere in the scoped receipt.
+- When a debt receipt requires studied-codebase evidence, the cited study
+  packet, studied-knowledge graph, and studied-knowledge verification refs are
+  an evidence-only gate. The gate must use public refs only and pass correctness
+  with zero rejected claims and no pending validator review before the receipt
+  can become verified/payable. Studied knowledge does not grant mutation, spend,
+  deployment, settlement, or self-review authority.
 - A debt receipt settles once and then retires. Near-duplicate work against a
   retired receipt fingerprint is duplicate replay, not payable work.
 - After repeated rejected or revision-required attempts on the same

--- a/apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts
+++ b/apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  DebtReceiptPolicyUnsafe,
+  debtReceiptSettlementHasPrivateMaterial,
+  projectDebtReceiptSettlement,
+} from './debt-receipt-policy'
+
+const definedReceiptInput = {
+  baselineMetricRefs: [
+    'metric.public.debt_receipt.5334.baseline.dual_format_lines_460k',
+  ],
+  budgetCapSats: 100_000,
+  scopeRefs: ['scope.public.debt_receipt.5334.tassadar_fixture_pairs'],
+  sourceRefs: ['issue.public.github.openagentsinc_openagents.5334'],
+  stopConditionRefs: [
+    'stop.public.debt_receipt.5334.retire_once_after_dedup',
+  ],
+  targetMetricRefs: [
+    'metric.public.debt_receipt.5334.target.committed_generated_churn_0',
+  ],
+}
+
+const fundedReceiptInput = {
+  ...definedReceiptInput,
+  fundingApprovalRefs: ['approval.public.debt_receipt.5334.funded'],
+  fundingAuthorityActorRef: 'actor.public.owner.allocator',
+  fundingAuthorityRefs: ['authority.public.debt_receipt.allocator_route'],
+  proposerActorRef: 'actor.public.orrery.churn_probe',
+  reviewerActorRef: 'actor.public.reviewer.trigger',
+  settlementAuthorityActorRef: 'actor.public.treasury.policy',
+  workerActorRef: 'actor.public.worker.codex_loop',
+}
+
+const verifiedReceiptInput = {
+  ...fundedReceiptInput,
+  acceptedWorkRefs: ['accepted_work.public.debt_receipt.5334.fixture_dedup'],
+  hygieneDeltaRefs: ['delta.public.debt_receipt.5334.dual_format_removed'],
+  noNewEqualOrWorseDebtRefs: [
+    'check.public.debt_receipt.5334.no_equal_or_worse_debt',
+  ],
+  reviewDecisionRefs: ['review.public.debt_receipt.5334.accepted'],
+  verificationCommandRefs: [
+    'command.public.debt_receipt.5334.regenerate_and_diff',
+  ],
+}
+
+describe('Debt receipt settlement policy', () => {
+  test('treats discovered debt as fundable inventory, not spend or payout authority', () => {
+    const projection = projectDebtReceiptSettlement(definedReceiptInput)
+
+    expect(projection).toMatchObject({
+      duplicateReplay: false,
+      settlementClaimAllowed: false,
+      spendAuthorityDelegatedToWorker: false,
+      state: 'fundable',
+      workerPayoutEligible: false,
+    })
+    expect(projection.blockerRefs).toContain(
+      'blocker.public.debt_receipt.funding_approval_missing',
+    )
+    expect(projection.caveatRefs).toContain(
+      'caveat.public.debt_receipt.discovery_is_not_spend',
+    )
+  })
+
+  test('requires the funding, worker, reviewer, and settlement roles to stay split', () => {
+    const projection = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      reviewerActorRef: 'actor.public.worker.codex_loop',
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5334.settlement',
+      ],
+      payableSats: 50_000,
+    })
+
+    expect(projection).toMatchObject({
+      settlementClaimAllowed: false,
+      state: 'fundable',
+      workerPayoutEligible: false,
+    })
+    expect(projection.blockerRefs).toContain(
+      'blocker.public.debt_receipt.role_overlap.reviewer_worker',
+    )
+  })
+
+  test('makes verified delta payable without upgrading it into settled copy', () => {
+    const projection = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      payableSats: 50_000,
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5334.settlement',
+      ],
+    })
+
+    expect(projection).toMatchObject({
+      payableSats: 50_000,
+      publicCopyRefs: [
+        'copy.public.debt_receipt.payable_pending_settlement',
+      ],
+      settledSats: 0,
+      settlementClaimAllowed: false,
+      state: 'payable',
+      workerPayoutEligible: true,
+    })
+    expect(projection.blockerRefs).toEqual([
+      'blocker.public.debt_receipt.settlement_receipt_missing',
+    ])
+  })
+
+  test('retires a receipt once settlement evidence exactly matches the payable amount', () => {
+    const projection = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      payableSats: 50_000,
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5334.settlement',
+      ],
+      settlementReceiptRefs: [
+        'settlement.public.debt_receipt.5334.worker_codex_loop',
+      ],
+      settledSats: 50_000,
+    })
+
+    expect(projection).toMatchObject({
+      publicCopyRefs: [
+        'copy.public.debt_receipt.retired_with_settlement_receipt',
+      ],
+      settlementClaimAllowed: true,
+      state: 'retired',
+      workerPayoutEligible: true,
+    })
+  })
+
+  test('blocks duplicate replay against an already retired receipt fingerprint', () => {
+    const projection = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      duplicateFingerprintRefs: [
+        'fingerprint.public.debt_receipt.5334.scope_patch_digest_v1',
+      ],
+      payableSats: 50_000,
+      retiredReceiptRefs: ['receipt.public.debt_receipt.5334.retired'],
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5334.settlement',
+      ],
+    })
+
+    expect(projection).toMatchObject({
+      duplicateReplay: true,
+      settlementClaimAllowed: false,
+      state: 'duplicate_replay',
+      workerPayoutEligible: false,
+    })
+    expect(projection.blockerRefs).toContain(
+      'blocker.public.debt_receipt.duplicate_replay',
+    )
+  })
+
+  test('quarantines churn loops after repeated rejected or revision-required attempts', () => {
+    const projection = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      maxRevisionAttempts: 3,
+      payableSats: 50_000,
+      revisionAttemptCount: 3,
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5334.settlement',
+      ],
+    })
+
+    expect(projection).toMatchObject({
+      manualReviewOnly: true,
+      quarantineReasonRefs: [
+        'quarantine.public.debt_receipt.revision_attempt_limit_reached',
+      ],
+      state: 'quarantined',
+      workerPayoutEligible: false,
+    })
+    expect(projection.blockerRefs).toContain(
+      'blocker.public.debt_receipt.manual_review_only',
+    )
+  })
+
+  test('rejects impossible payment amounts and private material', () => {
+    expect(() =>
+      projectDebtReceiptSettlement({
+        ...definedReceiptInput,
+        payableSats: 100_001,
+      }),
+    ).toThrow(DebtReceiptPolicyUnsafe)
+
+    expect(() =>
+      projectDebtReceiptSettlement({
+        ...definedReceiptInput,
+        baselineMetricRefs: ['raw_diff.private_fixture_dump'],
+      }),
+    ).toThrow(DebtReceiptPolicyUnsafe)
+  })
+
+  test('keeps retired public projections free of private material', () => {
+    const projection = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      payableSats: 50_000,
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5334.settlement',
+      ],
+      settlementReceiptRefs: [
+        'settlement.public.debt_receipt.5334.worker_codex_loop',
+      ],
+      settledSats: 50_000,
+    })
+
+    expect(debtReceiptSettlementHasPrivateMaterial(projection)).toBe(false)
+    expect(JSON.stringify(projection)).not.toMatch(
+      /raw_diff|private_fixture|provider_payload|customer_email|wallet|preimage|lnbc|@|github\.com\/[^:/]+\/private/i,
+    )
+  })
+})

--- a/apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts
+++ b/apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts
@@ -45,6 +45,18 @@ const verifiedReceiptInput = {
   ],
 }
 
+const studiedKnowledgeSource = {
+  correctnessGatePassed: true,
+  graphRef: 'openagents_repo_studied_knowledge_graph.5335',
+  packetRef: 'openagents_repo_study_packet.5335',
+  rejectedCount: 0,
+  schemaRef: 'openagents.repo_studied_knowledge_verification.v0' as const,
+  sourceBoundary: 'public_refs_only' as const,
+  validatorReviewRefs: [],
+  validatorReviewRequired: false,
+  verificationRef: 'openagents_repo_studied_knowledge_verification.5335',
+}
+
 describe('Debt receipt settlement policy', () => {
   test('treats discovered debt as fundable inventory, not spend or payout authority', () => {
     const projection = projectDebtReceiptSettlement(definedReceiptInput)
@@ -106,6 +118,79 @@ describe('Debt receipt settlement policy', () => {
     expect(projection.blockerRefs).toEqual([
       'blocker.public.debt_receipt.settlement_receipt_missing',
     ])
+  })
+
+  test('uses studied knowledge as evidence for hygiene receipts without granting authority', () => {
+    const projection = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      payableSats: 50_000,
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5335.settlement',
+      ],
+      studiedKnowledgeRequired: true,
+      studiedKnowledgeSource,
+    })
+
+    expect(projection).toMatchObject({
+      spendAuthorityDelegatedToWorker: false,
+      state: 'payable',
+      studiedKnowledgeGatePassed: true,
+      studiedKnowledgeRequired: true,
+      workerPayoutEligible: true,
+    })
+    expect(projection.studiedKnowledgeSourceRefs).toEqual([
+      'openagents_repo_studied_knowledge_graph.5335',
+      'openagents_repo_studied_knowledge_verification.5335',
+      'openagents_repo_study_packet.5335',
+    ])
+  })
+
+  test('blocks payable state when required studied knowledge is missing or rejected', () => {
+    const missing = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      payableSats: 50_000,
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5335.settlement',
+      ],
+      studiedKnowledgeRequired: true,
+    })
+
+    expect(missing).toMatchObject({
+      state: 'funded',
+      studiedKnowledgeGatePassed: false,
+      workerPayoutEligible: false,
+    })
+    expect(missing.blockerRefs).toContain(
+      'blocker.public.debt_receipt.studied_knowledge_source_missing',
+    )
+
+    const rejected = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      payableSats: 50_000,
+      settlementApprovalRefs: [
+        'approval.public.debt_receipt.5335.settlement',
+      ],
+      studiedKnowledgeRequired: true,
+      studiedKnowledgeSource: {
+        ...studiedKnowledgeSource,
+        correctnessGatePassed: false,
+        rejectedCount: 1,
+        verificationRef:
+          'openagents_repo_studied_knowledge_verification.5335_rejected',
+      },
+    })
+
+    expect(rejected).toMatchObject({
+      state: 'funded',
+      studiedKnowledgeGatePassed: false,
+      workerPayoutEligible: false,
+    })
+    expect(rejected.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.public.debt_receipt.studied_knowledge_correctness_failed',
+        'blocker.public.debt_receipt.studied_knowledge_rejected_claims',
+      ]),
+    )
   })
 
   test('retires a receipt once settlement evidence exactly matches the payable amount', () => {

--- a/apps/openagents.com/workers/api/src/debt-receipt-policy.ts
+++ b/apps/openagents.com/workers/api/src/debt-receipt-policy.ts
@@ -1,0 +1,527 @@
+import { containsProviderSecretMaterial } from '@openagentsinc/provider-account-schema'
+import { Schema as S } from 'effect'
+
+export const DebtReceiptSettlementState = S.Literals([
+  'blocked',
+  'fundable',
+  'funded',
+  'verified',
+  'payable',
+  'retired',
+  'duplicate_replay',
+  'quarantined',
+])
+export type DebtReceiptSettlementState =
+  typeof DebtReceiptSettlementState.Type
+
+export const DebtReceiptSettlementProjection = S.Struct({
+  acceptedWorkRefs: S.Array(S.String),
+  baselineMetricRefs: S.Array(S.String),
+  blockerRefs: S.Array(S.String),
+  budgetCapSats: S.Number,
+  caveatRefs: S.Array(S.String),
+  duplicateFingerprintRefs: S.Array(S.String),
+  duplicateReplay: S.Boolean,
+  fundingApprovalRefs: S.Array(S.String),
+  fundingAuthorityRefs: S.Array(S.String),
+  hygieneDeltaRefs: S.Array(S.String),
+  manualReviewOnly: S.Boolean,
+  noNewEqualOrWorseDebtRefs: S.Array(S.String),
+  payableSats: S.Number,
+  publicCopyRefs: S.Array(S.String),
+  quarantineReasonRefs: S.Array(S.String),
+  retiredReceiptRefs: S.Array(S.String),
+  reviewDecisionRefs: S.Array(S.String),
+  roleRefs: S.Struct({
+    fundingAuthorityActorRef: S.NullOr(S.String),
+    proposerActorRef: S.NullOr(S.String),
+    reviewerActorRef: S.NullOr(S.String),
+    settlementAuthorityActorRef: S.NullOr(S.String),
+    workerActorRef: S.NullOr(S.String),
+  }),
+  scopeRefs: S.Array(S.String),
+  settlementApprovalRefs: S.Array(S.String),
+  settlementClaimAllowed: S.Boolean,
+  settlementReceiptRefs: S.Array(S.String),
+  settledSats: S.Number,
+  sourceRefs: S.Array(S.String),
+  spendAuthorityDelegatedToWorker: S.Boolean,
+  state: DebtReceiptSettlementState,
+  stopConditionRefs: S.Array(S.String),
+  targetMetricRefs: S.Array(S.String),
+  verificationCommandRefs: S.Array(S.String),
+  workerPayoutEligible: S.Boolean,
+})
+export type DebtReceiptSettlementProjection =
+  typeof DebtReceiptSettlementProjection.Type
+
+export type DebtReceiptSettlementInput = Readonly<{
+  acceptedWorkRefs?: ReadonlyArray<string> | undefined
+  baselineMetricRefs?: ReadonlyArray<string> | undefined
+  budgetCapSats?: number | undefined
+  duplicateFingerprintRefs?: ReadonlyArray<string> | undefined
+  fundingApprovalRefs?: ReadonlyArray<string> | undefined
+  fundingAuthorityActorRef?: string | null | undefined
+  fundingAuthorityRefs?: ReadonlyArray<string> | undefined
+  hygieneDeltaRefs?: ReadonlyArray<string> | undefined
+  maxRevisionAttempts?: number | undefined
+  noNewEqualOrWorseDebtRefs?: ReadonlyArray<string> | undefined
+  payableSats?: number | undefined
+  proposerActorRef?: string | null | undefined
+  retiredReceiptRefs?: ReadonlyArray<string> | undefined
+  reviewDecisionRefs?: ReadonlyArray<string> | undefined
+  reviewerActorRef?: string | null | undefined
+  revisionAttemptCount?: number | undefined
+  scopeRefs?: ReadonlyArray<string> | undefined
+  settlementApprovalRefs?: ReadonlyArray<string> | undefined
+  settlementAuthorityActorRef?: string | null | undefined
+  settlementReceiptRefs?: ReadonlyArray<string> | undefined
+  settledSats?: number | undefined
+  sourceRefs?: ReadonlyArray<string> | undefined
+  stopConditionRefs?: ReadonlyArray<string> | undefined
+  targetMetricRefs?: ReadonlyArray<string> | undefined
+  verificationCommandRefs?: ReadonlyArray<string> | undefined
+  workerActorRef?: string | null | undefined
+}>
+
+export class DebtReceiptPolicyUnsafe extends S.TaggedErrorClass<DebtReceiptPolicyUnsafe>()(
+  'DebtReceiptPolicyUnsafe',
+  {
+    reason: S.String,
+  },
+) {}
+
+const decodeProjection = S.decodeUnknownSync(DebtReceiptSettlementProjection)
+
+const safeRefPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,260}$/
+const unsafeDebtReceiptRefPattern =
+  /(@|\/Users\/|\/home\/|access[_-]?token|api[_-]?key|auth\.json|bearer|cookie|customer[_-]?(email|name|prompt|record|value)|email[_-]?(address|body|html|raw|text)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice|lnbc|lntb|lnbcrt|lno1|lnurl|mnemonic|oauth|payment[_-]?(hash|id|invoice|preimage|proof|raw|secret)|payout[_-]?(address|destination|private|raw|target)|preimage|private[_-]?(customer|key|repo|source|wallet)|provider[_-]?(account|credential|grant|payload|secret|token)|raw[_-]?(auth|customer|diff|document|email|fixture|invoice|log|payment|payload|prompt|provider|receipt|runner|run[_-]?log|source|source[_-]?archive|usage|webhook)|runner[_-]?log|secret|seed[_-]?phrase|sk-[a-z0-9]|token|wallet)/i
+const rawTimestampPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+
+const uniqueRefs = (
+  refs: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> =>
+  [
+    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
+  ].sort()
+
+const refIsSafe = (ref: string): boolean =>
+  safeRefPattern.test(ref) &&
+  !containsProviderSecretMaterial(ref) &&
+  !unsafeDebtReceiptRefPattern.test(ref) &&
+  !rawTimestampPattern.test(ref)
+
+const safeRefs = (
+  label: string,
+  refs: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> => {
+  const normalized = uniqueRefs(refs)
+  const unsafe = normalized.find(ref => !refIsSafe(ref))
+
+  if (unsafe !== undefined) {
+    throw new DebtReceiptPolicyUnsafe({
+      reason: `${label} must be public-safe refs without raw diffs, prompts, provider, customer, payment, wallet, payout, private repo, secret, or timestamp material.`,
+    })
+  }
+
+  return normalized
+}
+
+const safeActorRef = (
+  label: string,
+  ref: string | null | undefined,
+): string | null => {
+  const normalized = ref?.trim() ?? ''
+
+  if (normalized === '') {
+    return null
+  }
+
+  if (!refIsSafe(normalized)) {
+    throw new DebtReceiptPolicyUnsafe({
+      reason: `${label} must be a public-safe actor ref.`,
+    })
+  }
+
+  return normalized
+}
+
+const hasRefs = (refs: ReadonlyArray<string>): boolean => refs.length > 0
+
+const safeNonNegativeInteger = (
+  label: string,
+  value: number | undefined,
+): number => {
+  const normalized = value ?? 0
+
+  if (!Number.isInteger(normalized) || normalized < 0) {
+    throw new DebtReceiptPolicyUnsafe({
+      reason: `${label} must be a non-negative integer.`,
+    })
+  }
+
+  return normalized
+}
+
+const distinctPresentActors = (
+  refs: ReadonlyArray<Readonly<[string, string | null]>>,
+): ReadonlyArray<string> => {
+  const seen = new Map<string, string>()
+  const blockers: Array<string> = []
+
+  refs.forEach(([label, ref]) => {
+    if (ref === null) {
+      return
+    }
+    const firstLabel = seen.get(ref)
+    if (firstLabel !== undefined) {
+      blockers.push(`blocker.public.debt_receipt.role_overlap.${firstLabel}_${label}`)
+      return
+    }
+    seen.set(ref, label)
+  })
+
+  return blockers.sort()
+}
+
+const missingEvidenceBlockers = (input: {
+  acceptedWorkRefs: ReadonlyArray<string>
+  baselineMetricRefs: ReadonlyArray<string>
+  budgetCapSats: number
+  fundingApprovalRefs: ReadonlyArray<string>
+  fundingAuthorityRefs: ReadonlyArray<string>
+  hygieneDeltaRefs: ReadonlyArray<string>
+  noNewEqualOrWorseDebtRefs: ReadonlyArray<string>
+  reviewDecisionRefs: ReadonlyArray<string>
+  scopeRefs: ReadonlyArray<string>
+  settlementApprovalRefs: ReadonlyArray<string>
+  settlementReceiptRefs: ReadonlyArray<string>
+  sourceRefs: ReadonlyArray<string>
+  stopConditionRefs: ReadonlyArray<string>
+  targetMetricRefs: ReadonlyArray<string>
+  verificationCommandRefs: ReadonlyArray<string>
+}): ReadonlyArray<string> => [
+  ...(!hasRefs(input.sourceRefs)
+    ? ['blocker.public.debt_receipt.source_missing']
+    : []),
+  ...(!hasRefs(input.baselineMetricRefs)
+    ? ['blocker.public.debt_receipt.baseline_metric_missing']
+    : []),
+  ...(!hasRefs(input.targetMetricRefs)
+    ? ['blocker.public.debt_receipt.target_metric_missing']
+    : []),
+  ...(!hasRefs(input.scopeRefs)
+    ? ['blocker.public.debt_receipt.scope_missing']
+    : []),
+  ...(!hasRefs(input.stopConditionRefs)
+    ? ['blocker.public.debt_receipt.stop_condition_missing']
+    : []),
+  ...(input.budgetCapSats === 0
+    ? ['blocker.public.debt_receipt.budget_cap_missing']
+    : []),
+  ...(!hasRefs(input.fundingApprovalRefs)
+    ? ['blocker.public.debt_receipt.funding_approval_missing']
+    : []),
+  ...(!hasRefs(input.fundingAuthorityRefs)
+    ? ['blocker.public.debt_receipt.funding_authority_missing']
+    : []),
+  ...(!hasRefs(input.verificationCommandRefs)
+    ? ['blocker.public.debt_receipt.verification_command_missing']
+    : []),
+  ...(!hasRefs(input.acceptedWorkRefs)
+    ? ['blocker.public.debt_receipt.accepted_work_missing']
+    : []),
+  ...(!hasRefs(input.reviewDecisionRefs)
+    ? ['blocker.public.debt_receipt.review_decision_missing']
+    : []),
+  ...(!hasRefs(input.hygieneDeltaRefs)
+    ? ['blocker.public.debt_receipt.hygiene_delta_missing']
+    : []),
+  ...(!hasRefs(input.noNewEqualOrWorseDebtRefs)
+    ? ['blocker.public.debt_receipt.no_equal_or_worse_debt_check_missing']
+    : []),
+  ...(!hasRefs(input.settlementApprovalRefs)
+    ? ['blocker.public.debt_receipt.settlement_approval_missing']
+    : []),
+  ...(!hasRefs(input.settlementReceiptRefs)
+    ? ['blocker.public.debt_receipt.settlement_receipt_missing']
+    : []),
+]
+
+const baseCaveatRefs = [
+  'caveat.public.debt_receipt.discovery_is_not_spend',
+  'caveat.public.debt_receipt.worker_cannot_mint_payable_followups',
+  'caveat.public.debt_receipt.payment_requires_verified_delta',
+  'caveat.public.debt_receipt.settle_once_then_retire',
+  'caveat.public.debt_receipt.duplicate_replay_not_payable',
+]
+
+export const projectDebtReceiptSettlement = (
+  input: DebtReceiptSettlementInput,
+): DebtReceiptSettlementProjection => {
+  const acceptedWorkRefs = safeRefs(
+    'Debt receipt accepted work refs',
+    input.acceptedWorkRefs,
+  )
+  const baselineMetricRefs = safeRefs(
+    'Debt receipt baseline metric refs',
+    input.baselineMetricRefs,
+  )
+  const duplicateFingerprintRefs = safeRefs(
+    'Debt receipt duplicate fingerprint refs',
+    input.duplicateFingerprintRefs,
+  )
+  const fundingApprovalRefs = safeRefs(
+    'Debt receipt funding approval refs',
+    input.fundingApprovalRefs,
+  )
+  const fundingAuthorityRefs = safeRefs(
+    'Debt receipt funding authority refs',
+    input.fundingAuthorityRefs,
+  )
+  const hygieneDeltaRefs = safeRefs(
+    'Debt receipt hygiene delta refs',
+    input.hygieneDeltaRefs,
+  )
+  const noNewEqualOrWorseDebtRefs = safeRefs(
+    'Debt receipt no-new-debt refs',
+    input.noNewEqualOrWorseDebtRefs,
+  )
+  const retiredReceiptRefs = safeRefs(
+    'Debt receipt retired receipt refs',
+    input.retiredReceiptRefs,
+  )
+  const reviewDecisionRefs = safeRefs(
+    'Debt receipt review decision refs',
+    input.reviewDecisionRefs,
+  )
+  const scopeRefs = safeRefs('Debt receipt scope refs', input.scopeRefs)
+  const settlementApprovalRefs = safeRefs(
+    'Debt receipt settlement approval refs',
+    input.settlementApprovalRefs,
+  )
+  const settlementReceiptRefs = safeRefs(
+    'Debt receipt settlement receipt refs',
+    input.settlementReceiptRefs,
+  )
+  const sourceRefs = safeRefs('Debt receipt source refs', input.sourceRefs)
+  const stopConditionRefs = safeRefs(
+    'Debt receipt stop condition refs',
+    input.stopConditionRefs,
+  )
+  const targetMetricRefs = safeRefs(
+    'Debt receipt target metric refs',
+    input.targetMetricRefs,
+  )
+  const verificationCommandRefs = safeRefs(
+    'Debt receipt verification command refs',
+    input.verificationCommandRefs,
+  )
+  const budgetCapSats = safeNonNegativeInteger(
+    'budgetCapSats',
+    input.budgetCapSats,
+  )
+  const maxRevisionAttempts = safeNonNegativeInteger(
+    'maxRevisionAttempts',
+    input.maxRevisionAttempts ?? 3,
+  )
+  const payableSats = safeNonNegativeInteger('payableSats', input.payableSats)
+  const revisionAttemptCount = safeNonNegativeInteger(
+    'revisionAttemptCount',
+    input.revisionAttemptCount,
+  )
+  const settledSats = safeNonNegativeInteger('settledSats', input.settledSats)
+  const roleRefs = {
+    fundingAuthorityActorRef: safeActorRef(
+      'Debt receipt funding authority actor ref',
+      input.fundingAuthorityActorRef,
+    ),
+    proposerActorRef: safeActorRef(
+      'Debt receipt proposer actor ref',
+      input.proposerActorRef,
+    ),
+    reviewerActorRef: safeActorRef(
+      'Debt receipt reviewer actor ref',
+      input.reviewerActorRef,
+    ),
+    settlementAuthorityActorRef: safeActorRef(
+      'Debt receipt settlement authority actor ref',
+      input.settlementAuthorityActorRef,
+    ),
+    workerActorRef: safeActorRef(
+      'Debt receipt worker actor ref',
+      input.workerActorRef,
+    ),
+  }
+
+  if (payableSats > budgetCapSats) {
+    throw new DebtReceiptPolicyUnsafe({
+      reason: 'Debt receipt payable sats cannot exceed the budget cap.',
+    })
+  }
+
+  if (settledSats > payableSats) {
+    throw new DebtReceiptPolicyUnsafe({
+      reason: 'Debt receipt settled sats cannot exceed payable sats.',
+    })
+  }
+
+  const roleBlockers = distinctPresentActors([
+    ['funder', roleRefs.fundingAuthorityActorRef],
+    ['proposer', roleRefs.proposerActorRef],
+    ['reviewer', roleRefs.reviewerActorRef],
+    ['settlement', roleRefs.settlementAuthorityActorRef],
+    ['worker', roleRefs.workerActorRef],
+  ])
+  const duplicateReplay =
+    hasRefs(retiredReceiptRefs) && hasRefs(duplicateFingerprintRefs)
+  const manualReviewOnly =
+    maxRevisionAttempts > 0 && revisionAttemptCount >= maxRevisionAttempts
+  const quarantineReasonRefs = manualReviewOnly
+    ? ['quarantine.public.debt_receipt.revision_attempt_limit_reached']
+    : []
+  const defined =
+    hasRefs(sourceRefs) &&
+    hasRefs(baselineMetricRefs) &&
+    hasRefs(targetMetricRefs) &&
+    hasRefs(scopeRefs) &&
+    hasRefs(stopConditionRefs) &&
+    budgetCapSats > 0
+  const funded =
+    defined &&
+    hasRefs(fundingApprovalRefs) &&
+    hasRefs(fundingAuthorityRefs) &&
+    roleBlockers.length === 0
+  const verified =
+    funded &&
+    hasRefs(verificationCommandRefs) &&
+    hasRefs(acceptedWorkRefs) &&
+    hasRefs(reviewDecisionRefs) &&
+    hasRefs(hygieneDeltaRefs) &&
+    hasRefs(noNewEqualOrWorseDebtRefs)
+  const payable =
+    verified &&
+    hasRefs(settlementApprovalRefs) &&
+    payableSats > 0 &&
+    !duplicateReplay &&
+    !manualReviewOnly
+  const retired =
+    payable &&
+    hasRefs(settlementReceiptRefs) &&
+    settledSats === payableSats
+  const state: DebtReceiptSettlementState = duplicateReplay
+    ? 'duplicate_replay'
+    : manualReviewOnly
+      ? 'quarantined'
+      : retired
+        ? 'retired'
+        : payable
+          ? 'payable'
+          : verified
+            ? 'verified'
+            : funded
+              ? 'funded'
+              : defined
+                ? 'fundable'
+                : 'blocked'
+
+  return decodeProjection({
+    acceptedWorkRefs,
+    baselineMetricRefs,
+    blockerRefs: [
+      ...missingEvidenceBlockers({
+        acceptedWorkRefs,
+        baselineMetricRefs,
+        budgetCapSats,
+        fundingApprovalRefs,
+        fundingAuthorityRefs,
+        hygieneDeltaRefs,
+        noNewEqualOrWorseDebtRefs,
+        reviewDecisionRefs,
+        scopeRefs,
+        settlementApprovalRefs,
+        settlementReceiptRefs,
+        sourceRefs,
+        stopConditionRefs,
+        targetMetricRefs,
+        verificationCommandRefs,
+      }),
+      ...roleBlockers,
+      ...(duplicateReplay
+        ? ['blocker.public.debt_receipt.duplicate_replay']
+        : []),
+      ...(manualReviewOnly
+        ? ['blocker.public.debt_receipt.manual_review_only']
+        : []),
+    ].sort(),
+    budgetCapSats,
+    caveatRefs: baseCaveatRefs,
+    duplicateFingerprintRefs,
+    duplicateReplay,
+    fundingApprovalRefs,
+    fundingAuthorityRefs,
+    hygieneDeltaRefs,
+    manualReviewOnly,
+    noNewEqualOrWorseDebtRefs,
+    payableSats,
+    publicCopyRefs: retired
+      ? ['copy.public.debt_receipt.retired_with_settlement_receipt']
+      : payable
+        ? ['copy.public.debt_receipt.payable_pending_settlement']
+        : defined
+          ? ['copy.public.debt_receipt.defined_not_settled']
+          : ['copy.public.debt_receipt.blocked'],
+    quarantineReasonRefs,
+    retiredReceiptRefs,
+    reviewDecisionRefs,
+    roleRefs,
+    scopeRefs,
+    settlementApprovalRefs,
+    settlementClaimAllowed: retired,
+    settlementReceiptRefs,
+    settledSats,
+    sourceRefs,
+    spendAuthorityDelegatedToWorker: false,
+    state,
+    stopConditionRefs,
+    targetMetricRefs,
+    verificationCommandRefs,
+    workerPayoutEligible: payable || retired,
+  })
+}
+
+export const debtReceiptSettlementHasPrivateMaterial = (
+  projection: DebtReceiptSettlementProjection,
+): boolean => {
+  const publicValues = [
+    projection.state,
+    ...projection.acceptedWorkRefs,
+    ...projection.baselineMetricRefs,
+    ...projection.blockerRefs,
+    ...projection.caveatRefs,
+    ...projection.duplicateFingerprintRefs,
+    ...projection.fundingApprovalRefs,
+    ...projection.fundingAuthorityRefs,
+    ...projection.hygieneDeltaRefs,
+    ...projection.noNewEqualOrWorseDebtRefs,
+    ...projection.publicCopyRefs,
+    ...projection.quarantineReasonRefs,
+    ...projection.retiredReceiptRefs,
+    ...projection.reviewDecisionRefs,
+    ...projection.scopeRefs,
+    ...projection.settlementApprovalRefs,
+    ...projection.settlementReceiptRefs,
+    ...projection.sourceRefs,
+    ...projection.stopConditionRefs,
+    ...projection.targetMetricRefs,
+    ...projection.verificationCommandRefs,
+    ...Object.values(projection.roleRefs).filter(ref => ref !== null),
+  ]
+
+  return publicValues.some(
+    value =>
+      containsProviderSecretMaterial(value) ||
+      unsafeDebtReceiptRefPattern.test(value) ||
+      rawTimestampPattern.test(value),
+  )
+}

--- a/apps/openagents.com/workers/api/src/debt-receipt-policy.ts
+++ b/apps/openagents.com/workers/api/src/debt-receipt-policy.ts
@@ -14,6 +14,23 @@ export const DebtReceiptSettlementState = S.Literals([
 export type DebtReceiptSettlementState =
   typeof DebtReceiptSettlementState.Type
 
+export const DebtReceiptStudiedKnowledgeVerificationSchemaRef =
+  'openagents.repo_studied_knowledge_verification.v0' as const
+
+export const DebtReceiptStudiedKnowledgeSource = S.Struct({
+  correctnessGatePassed: S.Boolean,
+  graphRef: S.String,
+  packetRef: S.String,
+  rejectedCount: S.Number,
+  schemaRef: S.Literal(DebtReceiptStudiedKnowledgeVerificationSchemaRef),
+  sourceBoundary: S.Literal('public_refs_only'),
+  validatorReviewRefs: S.Array(S.String),
+  validatorReviewRequired: S.Boolean,
+  verificationRef: S.String,
+})
+export type DebtReceiptStudiedKnowledgeSource =
+  typeof DebtReceiptStudiedKnowledgeSource.Type
+
 export const DebtReceiptSettlementProjection = S.Struct({
   acceptedWorkRefs: S.Array(S.String),
   baselineMetricRefs: S.Array(S.String),
@@ -48,6 +65,10 @@ export const DebtReceiptSettlementProjection = S.Struct({
   spendAuthorityDelegatedToWorker: S.Boolean,
   state: DebtReceiptSettlementState,
   stopConditionRefs: S.Array(S.String),
+  studiedKnowledgeGatePassed: S.Boolean,
+  studiedKnowledgeRequired: S.Boolean,
+  studiedKnowledgeSource: S.NullOr(DebtReceiptStudiedKnowledgeSource),
+  studiedKnowledgeSourceRefs: S.Array(S.String),
   targetMetricRefs: S.Array(S.String),
   verificationCommandRefs: S.Array(S.String),
   workerPayoutEligible: S.Boolean,
@@ -79,6 +100,8 @@ export type DebtReceiptSettlementInput = Readonly<{
   settledSats?: number | undefined
   sourceRefs?: ReadonlyArray<string> | undefined
   stopConditionRefs?: ReadonlyArray<string> | undefined
+  studiedKnowledgeRequired?: boolean | undefined
+  studiedKnowledgeSource?: DebtReceiptStudiedKnowledgeSource | null | undefined
   targetMetricRefs?: ReadonlyArray<string> | undefined
   verificationCommandRefs?: ReadonlyArray<string> | undefined
   workerActorRef?: string | null | undefined
@@ -92,6 +115,9 @@ export class DebtReceiptPolicyUnsafe extends S.TaggedErrorClass<DebtReceiptPolic
 ) {}
 
 const decodeProjection = S.decodeUnknownSync(DebtReceiptSettlementProjection)
+const decodeStudiedKnowledgeSource = S.decodeUnknownSync(
+  DebtReceiptStudiedKnowledgeSource,
+)
 
 const safeRefPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,260}$/
 const unsafeDebtReceiptRefPattern =
@@ -162,6 +188,60 @@ const safeNonNegativeInteger = (
 
   return normalized
 }
+
+const safeStudiedKnowledgeSource = (
+  source: DebtReceiptStudiedKnowledgeSource | null | undefined,
+): DebtReceiptStudiedKnowledgeSource | null => {
+  if (source === null || source === undefined) {
+    return null
+  }
+
+  const decoded = decodeStudiedKnowledgeSource(source)
+  const packetRef = safeRefs('Debt receipt studied packet ref', [
+    decoded.packetRef,
+  ])[0]!
+  const graphRef = safeRefs('Debt receipt studied graph ref', [
+    decoded.graphRef,
+  ])[0]!
+  const verificationRef = safeRefs('Debt receipt studied verification ref', [
+    decoded.verificationRef,
+  ])[0]!
+  const validatorReviewRefs = safeRefs(
+    'Debt receipt studied validator review refs',
+    decoded.validatorReviewRefs,
+  )
+  const rejectedCount = safeNonNegativeInteger(
+    'studiedKnowledgeSource.rejectedCount',
+    decoded.rejectedCount,
+  )
+
+  return {
+    ...decoded,
+    graphRef,
+    packetRef,
+    rejectedCount,
+    validatorReviewRefs,
+    verificationRef,
+  }
+}
+
+const studiedKnowledgeBlockers = (
+  source: DebtReceiptStudiedKnowledgeSource | null,
+  required: boolean,
+): ReadonlyArray<string> => [
+  ...(required && source === null
+    ? ['blocker.public.debt_receipt.studied_knowledge_source_missing']
+    : []),
+  ...(source !== null && !source.correctnessGatePassed
+    ? ['blocker.public.debt_receipt.studied_knowledge_correctness_failed']
+    : []),
+  ...(source !== null && source.rejectedCount > 0
+    ? ['blocker.public.debt_receipt.studied_knowledge_rejected_claims']
+    : []),
+  ...(source !== null && source.validatorReviewRequired
+    ? ['blocker.public.debt_receipt.studied_knowledge_validator_review_required']
+    : []),
+]
 
 const distinctPresentActors = (
   refs: ReadonlyArray<Readonly<[string, string | null]>>,
@@ -353,6 +433,29 @@ export const projectDebtReceiptSettlement = (
       input.workerActorRef,
     ),
   }
+  const studiedKnowledgeRequired = input.studiedKnowledgeRequired ?? false
+  const studiedKnowledgeSource = safeStudiedKnowledgeSource(
+    input.studiedKnowledgeSource,
+  )
+  const studiedKnowledgeSourceRefs =
+    studiedKnowledgeSource === null
+      ? []
+      : [
+          studiedKnowledgeSource.graphRef,
+          studiedKnowledgeSource.packetRef,
+          studiedKnowledgeSource.verificationRef,
+          ...studiedKnowledgeSource.validatorReviewRefs,
+        ].sort()
+  const studiedKnowledgeGatePassed =
+    !studiedKnowledgeRequired ||
+    (studiedKnowledgeSource !== null &&
+      studiedKnowledgeSource.correctnessGatePassed &&
+      studiedKnowledgeSource.rejectedCount === 0 &&
+      !studiedKnowledgeSource.validatorReviewRequired)
+  const studiedKnowledgeBlockerRefs = studiedKnowledgeBlockers(
+    studiedKnowledgeSource,
+    studiedKnowledgeRequired,
+  )
 
   if (payableSats > budgetCapSats) {
     throw new DebtReceiptPolicyUnsafe({
@@ -398,7 +501,8 @@ export const projectDebtReceiptSettlement = (
     hasRefs(acceptedWorkRefs) &&
     hasRefs(reviewDecisionRefs) &&
     hasRefs(hygieneDeltaRefs) &&
-    hasRefs(noNewEqualOrWorseDebtRefs)
+    hasRefs(noNewEqualOrWorseDebtRefs) &&
+    studiedKnowledgeGatePassed
   const payable =
     verified &&
     hasRefs(settlementApprovalRefs) &&
@@ -447,6 +551,7 @@ export const projectDebtReceiptSettlement = (
         verificationCommandRefs,
       }),
       ...roleBlockers,
+      ...studiedKnowledgeBlockerRefs,
       ...(duplicateReplay
         ? ['blocker.public.debt_receipt.duplicate_replay']
         : []),
@@ -484,6 +589,10 @@ export const projectDebtReceiptSettlement = (
     spendAuthorityDelegatedToWorker: false,
     state,
     stopConditionRefs,
+    studiedKnowledgeGatePassed,
+    studiedKnowledgeRequired,
+    studiedKnowledgeSource,
+    studiedKnowledgeSourceRefs,
     targetMetricRefs,
     verificationCommandRefs,
     workerPayoutEligible: payable || retired,
@@ -513,6 +622,7 @@ export const debtReceiptSettlementHasPrivateMaterial = (
     ...projection.settlementReceiptRefs,
     ...projection.sourceRefs,
     ...projection.stopConditionRefs,
+    ...projection.studiedKnowledgeSourceRefs,
     ...projection.targetMetricRefs,
     ...projection.verificationCommandRefs,
     ...Object.values(projection.roleRefs).filter(ref => ref !== null),

--- a/apps/openagents.com/workers/api/src/debt-receipt-work-request.test.ts
+++ b/apps/openagents.com/workers/api/src/debt-receipt-work-request.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest'
+
+import { buildForumWorkRequestLbrDraft } from './forum-work-requests'
+import {
+  DebtReceiptWorkRequestUnsafe,
+  buildDebtReceiptWorkRequestFiling,
+  debtReceiptWorkRequestIdempotencyKey,
+} from './debt-receipt-work-request'
+
+const fundedDebtReceiptInput = {
+  baselineMetricRefs: [
+    'metric.public.debt_receipt.5334.baseline.dual_format_lines_460k',
+  ],
+  budgetCapSats: 100_000,
+  deadlineRef: 'deadline.public.debt_receipt.20260625',
+  debtReceiptRef: 'receipt.public.debt.5334.tassadar_fixture_dedup',
+  fundingApprovalRefs: ['approval.public.debt_receipt.5334.funded'],
+  fundingAuthorityActorRef: 'actor.public.owner.allocator',
+  fundingAuthorityRefs: ['authority.public.debt_receipt.allocator_route'],
+  proposerActorRef: 'actor.public.orrery.churn_probe',
+  reviewerActorRef: 'actor.public.reviewer.trigger',
+  scopeRefs: ['scope.public.debt_receipt.5334.tassadar_fixture_pairs'],
+  settlementAuthorityActorRef: 'actor.public.treasury.policy',
+  sourceRefs: ['issue.public.github.openagentsinc_openagents.5334'],
+  stopConditionRefs: [
+    'stop.public.debt_receipt.5334.retire_once_after_dedup',
+  ],
+  targetMetricRefs: [
+    'metric.public.debt_receipt.5334.target.committed_generated_churn_0',
+  ],
+  title: 'Debt receipt #5334: dedupe generated Tassadar fixtures',
+  verificationCommandRefs: [
+    'command.public.debt_receipt.5334.regenerate_and_diff',
+  ],
+  workerActorRef: 'actor.public.worker.codex_loop',
+}
+
+describe('Debt receipt work-request adapter', () => {
+  test('maps a funded debt receipt to the existing ref-only Forum work-request contract', () => {
+    const filing = buildDebtReceiptWorkRequestFiling(fundedDebtReceiptInput)
+
+    expect(filing).toMatchObject({
+      debtReceiptRef: 'receipt.public.debt.5334.tassadar_fixture_dedup',
+      idempotencyKey:
+        'debt-receipt:receipt_public_debt_5334_tassadar_fixture_dedup',
+      input: {
+        budgetSats: 100_000,
+        deadlineRef: 'deadline.public.debt_receipt.20260625',
+        objectiveRef: 'receipt.public.debt.5334.tassadar_fixture_dedup',
+        repositoryRefs: ['repo.public.openagents'],
+        requiredCapabilityRefs: ['capability.pylon.local_claude_agent'],
+        verificationCommandRef:
+          'command.public.debt_receipt.5334.regenerate_and_diff',
+      },
+    })
+    expect(filing.debtReceiptProjection).toMatchObject({
+      settlementClaimAllowed: false,
+      state: 'funded',
+      workerPayoutEligible: false,
+    })
+
+    const lbr = buildForumWorkRequestLbrDraft(filing.normalizedInput, {
+      relayUrl: 'wss://relay.test.openagents.dev',
+      topicId: 'topic-debt-receipt-5334',
+    })
+
+    expect(lbr.draft.kind).toBe(5934)
+    expect(lbr.draft.tags).toContainEqual([
+      'param',
+      'lbr_objective_ref',
+      'receipt.public.debt.5334.tassadar_fixture_dedup',
+    ])
+    expect(lbr.draft.tags).toContainEqual(['bid', '100000000'])
+  })
+
+  test('refuses to list unfunded discovery as market work', () => {
+    expect(() =>
+      buildDebtReceiptWorkRequestFiling({
+        ...fundedDebtReceiptInput,
+        fundingApprovalRefs: [],
+      }),
+    ).toThrow(/must be funded before market listing/)
+  })
+
+  test('requires one verifier because the current Forum work-request contract has one verifier slot', () => {
+    expect(() =>
+      buildDebtReceiptWorkRequestFiling({
+        ...fundedDebtReceiptInput,
+        verificationCommandRefs: [
+          'command.public.debt_receipt.5334.regenerate_and_diff',
+          'command.public.debt_receipt.5334.bun_test',
+        ],
+      }),
+    ).toThrow(DebtReceiptWorkRequestUnsafe)
+  })
+
+  test('keeps role-overlap receipts out of market listing', () => {
+    expect(() =>
+      buildDebtReceiptWorkRequestFiling({
+        ...fundedDebtReceiptInput,
+        reviewerActorRef: 'actor.public.worker.codex_loop',
+      }),
+    ).toThrow(/must be funded before market listing/)
+  })
+
+  test('uses stable idempotency keys for receipt relisting protection', () => {
+    expect(
+      debtReceiptWorkRequestIdempotencyKey(
+        'receipt.public.debt.5334.tassadar_fixture_dedup',
+      ),
+    ).toBe('debt-receipt:receipt_public_debt_5334_tassadar_fixture_dedup')
+  })
+})

--- a/apps/openagents.com/workers/api/src/debt-receipt-work-request.ts
+++ b/apps/openagents.com/workers/api/src/debt-receipt-work-request.ts
@@ -1,0 +1,125 @@
+import {
+  DefaultForumWorkRequestCapabilityRef,
+  DefaultForumWorkRequestRepositoryRef,
+  ForumWorkRequestUnsafe,
+  type ForumWorkRequestInput,
+  type NormalizedForumWorkRequestInput,
+  normalizeForumWorkRequestInput,
+} from './forum-work-requests'
+import {
+  type DebtReceiptSettlementInput,
+  type DebtReceiptSettlementProjection,
+  projectDebtReceiptSettlement,
+} from './debt-receipt-policy'
+
+export type DebtReceiptWorkRequestFilingInput =
+  DebtReceiptSettlementInput &
+    Readonly<{
+      deadlineRef: string
+      debtReceiptRef: string
+      repositoryRefs?: ReadonlyArray<string> | undefined
+      requiredCapabilityRefs?: ReadonlyArray<string> | undefined
+      title: string
+    }>
+
+export type DebtReceiptWorkRequestFiling = Readonly<{
+  debtReceiptProjection: DebtReceiptSettlementProjection
+  debtReceiptRef: string
+  idempotencyKey: string
+  input: ForumWorkRequestInput
+  normalizedInput: NormalizedForumWorkRequestInput
+}>
+
+export class DebtReceiptWorkRequestUnsafe extends Error {
+  override readonly name = 'DebtReceiptWorkRequestUnsafe'
+}
+
+const DebtReceiptRefPattern = /^receipt\.public\.debt\.[A-Za-z0-9][A-Za-z0-9_.-]*$/
+
+const uniqueRefs = (
+  refs: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> =>
+  [
+    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
+  ].sort()
+
+export const debtReceiptWorkRequestIdempotencyKey = (
+  debtReceiptRef: string,
+): string =>
+  `debt-receipt:${debtReceiptRef
+    .replace(/[^A-Za-z0-9_-]+/gu, '_')
+    .toLowerCase()}`
+
+const singleVerificationCommandRef = (
+  refs: ReadonlyArray<string> | undefined,
+): string => {
+  const verificationCommandRefs = uniqueRefs(refs)
+
+  if (verificationCommandRefs.length !== 1) {
+    throw new DebtReceiptWorkRequestUnsafe(
+      'A debt-receipt work request must carry exactly one verification command ref.',
+    )
+  }
+
+  return verificationCommandRefs[0]!
+}
+
+export const buildDebtReceiptWorkRequestFiling = (
+  input: DebtReceiptWorkRequestFilingInput,
+): DebtReceiptWorkRequestFiling => {
+  const debtReceiptRef = input.debtReceiptRef.trim()
+
+  if (!DebtReceiptRefPattern.test(debtReceiptRef)) {
+    throw new DebtReceiptWorkRequestUnsafe(
+      'debtReceiptRef must be a receipt.public.debt.* ref.',
+    )
+  }
+
+  const verificationCommandRef = singleVerificationCommandRef(
+    input.verificationCommandRefs,
+  )
+  const debtReceiptProjection = projectDebtReceiptSettlement({
+    ...input,
+    verificationCommandRefs: [verificationCommandRef],
+  })
+
+  if (debtReceiptProjection.state !== 'funded') {
+    throw new DebtReceiptWorkRequestUnsafe(
+      `A debt-receipt work request must be funded before market listing; got ${debtReceiptProjection.state}.`,
+    )
+  }
+
+  const workRequestInput: ForumWorkRequestInput = {
+    budgetSats: debtReceiptProjection.budgetCapSats,
+    deadlineRef: input.deadlineRef,
+    objectiveRef: debtReceiptRef,
+    repositoryRefs:
+      input.repositoryRefs === undefined || input.repositoryRefs.length === 0
+        ? [DefaultForumWorkRequestRepositoryRef]
+        : input.repositoryRefs,
+    requiredCapabilityRefs:
+      input.requiredCapabilityRefs === undefined ||
+      input.requiredCapabilityRefs.length === 0
+        ? [DefaultForumWorkRequestCapabilityRef]
+        : input.requiredCapabilityRefs,
+    title: input.title,
+    verificationCommandRef,
+  }
+
+  try {
+    const normalizedInput = normalizeForumWorkRequestInput(workRequestInput)
+
+    return {
+      debtReceiptProjection,
+      debtReceiptRef,
+      idempotencyKey: debtReceiptWorkRequestIdempotencyKey(debtReceiptRef),
+      input: workRequestInput,
+      normalizedInput,
+    }
+  } catch (error) {
+    if (error instanceof ForumWorkRequestUnsafe) {
+      throw new DebtReceiptWorkRequestUnsafe(error.reason)
+    }
+    throw error
+  }
+}

--- a/apps/openagents.com/workers/api/src/forum-routes.ts
+++ b/apps/openagents.com/workers/api/src/forum-routes.ts
@@ -115,14 +115,22 @@ import {
   recordForumWorkRequestResult,
 } from './forum-work-request-negotiation'
 import {
+  decodeAcceptForumWorkRequestOfferBody,
+  decodeCreateForumWorkRequestBody,
+  decodeForumWorkRequestLifecycleBody,
+  decodeRelayNativeForumWorkRequestBody,
+  decodeReleaseForumWorkRequestBody,
+  decodeSubmitForumWorkRequestOfferBody,
+  decodeSubmitForumWorkRequestResultBody,
+  workRequestMatchesInput,
+} from './forum-work-request-route-contract'
+import {
   DefaultForumWorkRequestBridgeActorRef,
   DefaultForumWorkRequestRelayUrl,
-  ForumWorkRequestLifecycleKind,
   type ForumWorkRequestRecord,
   type ForumWorkRequestRelayLink,
   type ForumWorkRequestRelayPublisher,
   ForumWorkRequestsForumSlug,
-  type NormalizedForumWorkRequestInput,
   buildForumWorkRequestLbrDraft,
   decodeRelayNativeLbrWorkRequest,
   defaultForumWorkRequestRelayPublisher,
@@ -228,79 +236,6 @@ type ForumAgentWriterActor = Extract<
   ForumWriterActorInput,
   Readonly<{ _tag: 'Agent' }>
 >
-
-const ForumWorkRequestRef = S.Trim.check(S.isNonEmpty(), S.isMaxLength(220))
-const ForumWorkRequestRefs = S.Array(ForumWorkRequestRef)
-
-const CreateForumWorkRequestBody = S.Struct({
-  budgetSats: S.Number,
-  deadlineRef: ForumWorkRequestRef,
-  objectiveRef: ForumWorkRequestRef,
-  repositoryRefs: S.optionalKey(ForumWorkRequestRefs),
-  requestedSlug: S.optionalKey(
-    S.NullOr(
-      S.Trim.check(
-        S.isMinLength(3),
-        S.isMaxLength(80),
-        S.isPattern(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/),
-      ),
-    ),
-  ),
-  requiredCapabilityRefs: S.optionalKey(ForumWorkRequestRefs),
-  title: S.Trim.check(S.isMinLength(3), S.isMaxLength(160)),
-  verificationCommandRef: ForumWorkRequestRef,
-})
-type CreateForumWorkRequestBody = typeof CreateForumWorkRequestBody.Type
-
-const RelayNativeForumWorkRequestBody = S.Struct({
-  event: S.Unknown,
-  title: S.optionalKey(S.NullOr(S.Trim.check(S.isMaxLength(160)))),
-})
-type RelayNativeForumWorkRequestBody =
-  typeof RelayNativeForumWorkRequestBody.Type
-
-const ForumWorkRequestLifecycleBody = S.Struct({
-  lifecycleKind: ForumWorkRequestLifecycleKind,
-  receiptRef: ForumWorkRequestRef,
-})
-type ForumWorkRequestLifecycleBody = typeof ForumWorkRequestLifecycleBody.Type
-
-const AcceptForumWorkRequestOfferBody = S.Struct({
-  quoteRef: ForumWorkRequestRef,
-})
-type AcceptForumWorkRequestOfferBody =
-  typeof AcceptForumWorkRequestOfferBody.Type
-
-const ForumWorkRequestNostrPubkey = S.Trim.check(
-  S.isPattern(/^[0-9a-f]{64}$/i),
-)
-
-const SubmitForumWorkRequestOfferBody = S.Struct({
-  amountSats: S.Number,
-  capabilityRefs: S.optionalKey(ForumWorkRequestRefs),
-  providerActorRef: ForumWorkRequestRef,
-  providerPubkey: S.optionalKey(S.NullOr(ForumWorkRequestNostrPubkey)),
-  quoteRef: ForumWorkRequestRef,
-  relayEventRef: S.optionalKey(S.NullOr(ForumWorkRequestRef)),
-})
-type SubmitForumWorkRequestOfferBody =
-  typeof SubmitForumWorkRequestOfferBody.Type
-
-const SubmitForumWorkRequestResultBody = S.Struct({
-  artifactRefs: S.optionalKey(ForumWorkRequestRefs),
-  closeoutRef: S.optionalKey(S.NullOr(ForumWorkRequestRef)),
-  quoteRef: ForumWorkRequestRef,
-  resultEventRef: ForumWorkRequestRef,
-  verificationCommandRef: ForumWorkRequestRef,
-})
-type SubmitForumWorkRequestResultBody =
-  typeof SubmitForumWorkRequestResultBody.Type
-
-const ReleaseForumWorkRequestBody = S.Struct({
-  quoteRef: ForumWorkRequestRef,
-  verificationVerdictRef: ForumWorkRequestRef,
-})
-type ReleaseForumWorkRequestBody = typeof ReleaseForumWorkRequestBody.Type
 
 const EditForumPostBody = S.Struct({
   bodyText: S.Trim.check(
@@ -832,114 +767,6 @@ const workRequestPublicProjection = (
     forumWorkRequestEventRef(jobEventId),
   ],
 })
-
-const forbiddenWorkRequestBodyKeys = new Set([
-  'bodyText',
-  'credentials',
-  'privateRepoContent',
-  'prompt',
-  'rawCommand',
-  'rawContent',
-  'rawPrompt',
-  'secret',
-])
-
-class ForumWorkRequestBodyValidationError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'ForumWorkRequestBodyValidationError'
-  }
-}
-
-const rejectForbiddenWorkRequestBodyKeys = (body: unknown): void => {
-  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
-    return
-  }
-
-  const keys = Object.keys(body)
-  const forbidden = keys.find(key => forbiddenWorkRequestBodyKeys.has(key))
-
-  if (forbidden !== undefined) {
-    throw new ForumWorkRequestBodyValidationError(
-      `Forum work requests accept public refs only; ${forbidden} is not allowed.`,
-    )
-  }
-}
-
-const decodeCreateForumWorkRequestBody = (
-  body: unknown,
-): CreateForumWorkRequestBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(CreateForumWorkRequestBody)(body)
-}
-
-const decodeRelayNativeForumWorkRequestBody = (
-  body: unknown,
-): RelayNativeForumWorkRequestBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(RelayNativeForumWorkRequestBody)(body)
-}
-
-const decodeForumWorkRequestLifecycleBody = (
-  body: unknown,
-): ForumWorkRequestLifecycleBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(ForumWorkRequestLifecycleBody)(body)
-}
-
-const decodeAcceptForumWorkRequestOfferBody = (
-  body: unknown,
-): AcceptForumWorkRequestOfferBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(AcceptForumWorkRequestOfferBody)(body)
-}
-
-const decodeSubmitForumWorkRequestOfferBody = (
-  body: unknown,
-): SubmitForumWorkRequestOfferBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(SubmitForumWorkRequestOfferBody)(body)
-}
-
-const decodeSubmitForumWorkRequestResultBody = (
-  body: unknown,
-): SubmitForumWorkRequestResultBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(SubmitForumWorkRequestResultBody)(body)
-}
-
-const decodeReleaseForumWorkRequestBody = (
-  body: unknown,
-): ReleaseForumWorkRequestBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(ReleaseForumWorkRequestBody)(body)
-}
-
-const arraysEqual = (
-  left: ReadonlyArray<string>,
-  right: ReadonlyArray<string>,
-): boolean =>
-  left.length === right.length &&
-  left.every((value, index) => value === right[index])
-
-const workRequestMatchesInput = (
-  record: ForumWorkRequestRecord,
-  input: NormalizedForumWorkRequestInput,
-): boolean =>
-  record.title === input.title &&
-  record.objectiveRef === input.objectiveRef &&
-  record.verificationCommandRef === input.verificationCommandRef &&
-  record.deadlineRef === input.deadlineRef &&
-  record.budgetSats === input.budgetSats &&
-  arraysEqual(record.repositoryRefs, input.repositoryRefs) &&
-  arraysEqual(record.requiredCapabilityRefs, input.requiredCapabilityRefs)
 
 const workRequestAcceptanceEventRef = (
   workRequestId: string,

--- a/apps/openagents.com/workers/api/src/forum-work-request-route-contract.test.ts
+++ b/apps/openagents.com/workers/api/src/forum-work-request-route-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  ForumWorkRequestBodyValidationError,
+  decodeCreateForumWorkRequestBody,
+  workRequestMatchesInput,
+} from './forum-work-request-route-contract'
+import {
+  type ForumWorkRequestRecord,
+  normalizeForumWorkRequestInput,
+} from './forum-work-requests'
+
+const workRequestRecord: ForumWorkRequestRecord = {
+  budgetMsats: 100_000_000,
+  budgetSats: 100_000,
+  createdAt: '2026-06-18T15:23:43.476Z',
+  deadlineRef: 'deadline.public.debt_receipt.20260625',
+  firstPostId: 'post-1',
+  idempotencyKey: 'debt-receipt:receipt_public_debt_5334_template',
+  jobEventId: 'job-1',
+  jobEventKind: 5934,
+  jobResultKind: 6934,
+  objectiveRef: 'receipt.public.debt.5334.template',
+  publicProjection: {
+    classificationCaveatRef: 'classification.public_forum_projection',
+    customerSafe: true,
+    dataClassification: 'public',
+    excludedPrivateRefs: [],
+    publicSafe: true,
+    redactionPolicyRef: 'redaction.forum.public.v1',
+    safeArtifactRefs: ['artifact.forum.work_request.wr-1'],
+    safeReceiptRefs: [],
+    trustTier: 'reviewed',
+  },
+  quoteCount: 0,
+  relayUrl: 'wss://relay.test.openagents.dev',
+  repositoryRefs: ['repo.public.openagents'],
+  requesterActorRef: 'actor.public.trigger',
+  requiredCapabilityRefs: ['capability.pylon.local_claude_agent'],
+  state: 'open',
+  title: 'Debt receipt template',
+  topicId: 'topic-1',
+  updatedAt: '2026-06-18T15:23:43.476Z',
+  verificationCommandRef: 'command.public.debt_receipt.regenerate_and_diff',
+  workRequestId: 'wr-1',
+}
+
+describe('Forum work request route contract', () => {
+  test('decodes public ref-only create bodies', () => {
+    expect(
+      decodeCreateForumWorkRequestBody({
+        budgetSats: 100_000,
+        deadlineRef: 'deadline.public.debt_receipt.20260625',
+        objectiveRef: 'receipt.public.debt.5334.template',
+        repositoryRefs: ['repo.public.openagents'],
+        requestedSlug: 'debt-receipt-template',
+        requiredCapabilityRefs: ['capability.pylon.local_claude_agent'],
+        title: 'Debt receipt template',
+        verificationCommandRef:
+          'command.public.debt_receipt.regenerate_and_diff',
+      }),
+    ).toMatchObject({
+      budgetSats: 100_000,
+      objectiveRef: 'receipt.public.debt.5334.template',
+      requestedSlug: 'debt-receipt-template',
+    })
+  })
+
+  test('rejects raw prompt material before schema decoding', () => {
+    expect(() =>
+      decodeCreateForumWorkRequestBody({
+        budgetSats: 100_000,
+        deadlineRef: 'deadline.public.debt_receipt.20260625',
+        objectiveRef: 'receipt.public.debt.5334.template',
+        rawPrompt: 'clone the private repo and fix it',
+        title: 'Debt receipt template',
+        verificationCommandRef:
+          'command.public.debt_receipt.regenerate_and_diff',
+      }),
+    ).toThrow(ForumWorkRequestBodyValidationError)
+  })
+
+  test('matches normalized input to an existing work request without route dependencies', () => {
+    const input = normalizeForumWorkRequestInput({
+      budgetSats: 100_000,
+      deadlineRef: workRequestRecord.deadlineRef,
+      objectiveRef: workRequestRecord.objectiveRef,
+      repositoryRefs: workRequestRecord.repositoryRefs,
+      requiredCapabilityRefs: workRequestRecord.requiredCapabilityRefs,
+      title: workRequestRecord.title,
+      verificationCommandRef: workRequestRecord.verificationCommandRef,
+    })
+
+    expect(workRequestMatchesInput(workRequestRecord, input)).toBe(true)
+    expect(
+      workRequestMatchesInput(workRequestRecord, {
+        ...input,
+        requiredCapabilityRefs: ['capability.public.different'],
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/openagents.com/workers/api/src/forum-work-request-route-contract.ts
+++ b/apps/openagents.com/workers/api/src/forum-work-request-route-contract.ts
@@ -1,0 +1,191 @@
+import { Schema as S } from 'effect'
+
+import {
+  ForumWorkRequestLifecycleKind,
+  type ForumWorkRequestRecord,
+  type NormalizedForumWorkRequestInput,
+} from './forum-work-requests'
+
+const ForumWorkRequestRef = S.Trim.check(S.isNonEmpty(), S.isMaxLength(220))
+const ForumWorkRequestRefs = S.Array(ForumWorkRequestRef)
+
+const RequestedSlug = S.NullOr(
+  S.Trim.check(
+    S.isMinLength(3),
+    S.isMaxLength(80),
+    S.isPattern(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/),
+  ),
+)
+
+const CreateForumWorkRequestBody = S.Struct({
+  budgetSats: S.Number,
+  deadlineRef: ForumWorkRequestRef,
+  objectiveRef: ForumWorkRequestRef,
+  repositoryRefs: S.optionalKey(ForumWorkRequestRefs),
+  requestedSlug: S.optionalKey(RequestedSlug),
+  requiredCapabilityRefs: S.optionalKey(ForumWorkRequestRefs),
+  title: S.Trim.check(S.isMinLength(3), S.isMaxLength(160)),
+  verificationCommandRef: ForumWorkRequestRef,
+})
+export type CreateForumWorkRequestBody =
+  typeof CreateForumWorkRequestBody.Type
+
+const RelayNativeForumWorkRequestBody = S.Struct({
+  event: S.Unknown,
+  title: S.optionalKey(S.NullOr(S.Trim.check(S.isMaxLength(160)))),
+})
+export type RelayNativeForumWorkRequestBody =
+  typeof RelayNativeForumWorkRequestBody.Type
+
+const ForumWorkRequestLifecycleBody = S.Struct({
+  lifecycleKind: ForumWorkRequestLifecycleKind,
+  receiptRef: ForumWorkRequestRef,
+})
+export type ForumWorkRequestLifecycleBody =
+  typeof ForumWorkRequestLifecycleBody.Type
+
+const AcceptForumWorkRequestOfferBody = S.Struct({
+  quoteRef: ForumWorkRequestRef,
+})
+export type AcceptForumWorkRequestOfferBody =
+  typeof AcceptForumWorkRequestOfferBody.Type
+
+const ForumWorkRequestNostrPubkey = S.Trim.check(
+  S.isPattern(/^[0-9a-f]{64}$/i),
+)
+
+const SubmitForumWorkRequestOfferBody = S.Struct({
+  amountSats: S.Number,
+  capabilityRefs: S.optionalKey(ForumWorkRequestRefs),
+  providerActorRef: ForumWorkRequestRef,
+  providerPubkey: S.optionalKey(S.NullOr(ForumWorkRequestNostrPubkey)),
+  quoteRef: ForumWorkRequestRef,
+  relayEventRef: S.optionalKey(S.NullOr(ForumWorkRequestRef)),
+})
+export type SubmitForumWorkRequestOfferBody =
+  typeof SubmitForumWorkRequestOfferBody.Type
+
+const SubmitForumWorkRequestResultBody = S.Struct({
+  artifactRefs: S.optionalKey(ForumWorkRequestRefs),
+  closeoutRef: S.optionalKey(S.NullOr(ForumWorkRequestRef)),
+  quoteRef: ForumWorkRequestRef,
+  resultEventRef: ForumWorkRequestRef,
+  verificationCommandRef: ForumWorkRequestRef,
+})
+export type SubmitForumWorkRequestResultBody =
+  typeof SubmitForumWorkRequestResultBody.Type
+
+const ReleaseForumWorkRequestBody = S.Struct({
+  quoteRef: ForumWorkRequestRef,
+  verificationVerdictRef: ForumWorkRequestRef,
+})
+export type ReleaseForumWorkRequestBody =
+  typeof ReleaseForumWorkRequestBody.Type
+
+const forbiddenWorkRequestBodyKeys = new Set([
+  'bodyText',
+  'credentials',
+  'privateRepoContent',
+  'prompt',
+  'rawCommand',
+  'rawContent',
+  'rawPrompt',
+  'secret',
+])
+
+export class ForumWorkRequestBodyValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ForumWorkRequestBodyValidationError'
+  }
+}
+
+const rejectForbiddenWorkRequestBodyKeys = (body: unknown): void => {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return
+  }
+
+  const keys = Object.keys(body)
+  const forbidden = keys.find(key => forbiddenWorkRequestBodyKeys.has(key))
+
+  if (forbidden !== undefined) {
+    throw new ForumWorkRequestBodyValidationError(
+      `Forum work requests accept public refs only; ${forbidden} is not allowed.`,
+    )
+  }
+}
+
+export const decodeCreateForumWorkRequestBody = (
+  body: unknown,
+): CreateForumWorkRequestBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(CreateForumWorkRequestBody)(body)
+}
+
+export const decodeRelayNativeForumWorkRequestBody = (
+  body: unknown,
+): RelayNativeForumWorkRequestBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(RelayNativeForumWorkRequestBody)(body)
+}
+
+export const decodeForumWorkRequestLifecycleBody = (
+  body: unknown,
+): ForumWorkRequestLifecycleBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(ForumWorkRequestLifecycleBody)(body)
+}
+
+export const decodeAcceptForumWorkRequestOfferBody = (
+  body: unknown,
+): AcceptForumWorkRequestOfferBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(AcceptForumWorkRequestOfferBody)(body)
+}
+
+export const decodeSubmitForumWorkRequestOfferBody = (
+  body: unknown,
+): SubmitForumWorkRequestOfferBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(SubmitForumWorkRequestOfferBody)(body)
+}
+
+export const decodeSubmitForumWorkRequestResultBody = (
+  body: unknown,
+): SubmitForumWorkRequestResultBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(SubmitForumWorkRequestResultBody)(body)
+}
+
+export const decodeReleaseForumWorkRequestBody = (
+  body: unknown,
+): ReleaseForumWorkRequestBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(ReleaseForumWorkRequestBody)(body)
+}
+
+const arraysEqual = (
+  left: ReadonlyArray<string>,
+  right: ReadonlyArray<string>,
+): boolean =>
+  left.length === right.length &&
+  left.every((value, index) => value === right[index])
+
+export const workRequestMatchesInput = (
+  record: ForumWorkRequestRecord,
+  input: NormalizedForumWorkRequestInput,
+): boolean =>
+  record.title === input.title &&
+  record.objectiveRef === input.objectiveRef &&
+  record.verificationCommandRef === input.verificationCommandRef &&
+  record.deadlineRef === input.deadlineRef &&
+  record.budgetSats === input.budgetSats &&
+  arraysEqual(record.repositoryRefs, input.repositoryRefs) &&
+  arraysEqual(record.requiredCapabilityRefs, input.requiredCapabilityRefs)

--- a/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
+++ b/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
@@ -1,0 +1,119 @@
+# Debt Receipt Hygiene Lane
+
+Date: 2026-06-18
+
+Issue #5335 should be treated as a product lane, not a broad invitation to
+refactor. The sellable unit is a **debt receipt**: one externally named,
+budget-capped, benchmark-verified piece of codebase debt that can be retired
+once and paid once.
+
+## Money Thesis
+
+Coding agents make maintenance cheaper, but they also make churn cheap. The
+business opportunity is not "more refactoring." It is a clearing layer for
+measurable debt:
+
+1. Find a debt item with a current baseline.
+2. Convert it into a funded receipt with a cap, scope, target, verifier, and
+   stop condition.
+3. Let workers compete or claim it through the labor market.
+4. Pay only after the verifier proves behavior stayed constant and the target
+   metric improved.
+5. Retire the receipt so the same cleanup cannot be sold twice.
+
+This creates finite inventory out of hygiene work. That is what buyers can
+understand and budget for.
+
+## Product Offer
+
+OpenAgents can sell this as **AI Churn Cleanup**:
+
+- intake: churn probe or buyer report identifies the worst debt;
+- receipt design: owner/allocator turns the finding into a funded receipt;
+- execution: Pylon/local agents or contributors do the bounded work;
+- verification: tests, benchmark replay, regenerate-and-diff, or perf checks;
+- settlement: accepted work releases escrow and records a public-safe receipt;
+- reporting: buyer receives before/after metrics and the retired receipt ref.
+
+The first buyer can be OpenAgents itself. The first canonical receipt is #5334:
+Tassadar generated fixtures committed in duplicate `.ts` and `.json` formats.
+
+## Pricing Shape
+
+Start with simple pricing before inventing a marketplace curve:
+
+- audit/setup fee for a repo churn report;
+- per-receipt budget cap for each accepted finding;
+- platform take rate on settled receipt budgets;
+- optional lane-lead share for curating receipts and reviewer packets;
+- optional reviewer fee for acceptance and settlement authorization.
+
+No public copy should promise passive revenue share until the split terms,
+eligibility refs, payout policy, and settlement receipts exist. For #5335, the
+lane lead should ask for pinned economics before accepting responsibility:
+fixed receipt bounties now, and separate written terms for any standing lane
+share.
+
+## Debt Receipt Contract
+
+Every payable receipt needs these public-safe refs:
+
+- source: issue, churn-probe finding, or buyer request;
+- baseline metric: current debt measurement;
+- target metric: what must improve;
+- scope: files, package, subsystem, or artifact class;
+- budget cap: maximum payable sats or buyer credit;
+- stop condition: when the receipt is retired;
+- verifier: command or benchmark that proves behavior did not regress;
+- accepted-work evidence: review or validator result;
+- hygiene delta: measured improvement;
+- no-new-debt check: no equal-or-worse debt introduced elsewhere;
+- settlement approval: separate from the worker;
+- settlement receipt: required before calling it paid or settled.
+
+Workers may propose findings, but a separate allocator has to fund them.
+Workers do not receive spend authority, deployment authority, settlement
+authority, or authority to mint payable follow-ups.
+
+## First Receipt: #5334
+
+Proposed public-safe receipt packet:
+
+```text
+debtReceiptRef: receipt.public.debt.5334.tassadar_fixture_dedup
+sourceRef: issue.public.github.openagentsinc_openagents.5334
+baselineMetricRef: metric.public.debt.5334.dual_format_generated_lines_460k
+targetMetricRef: metric.public.debt.5334.committed_generated_churn_0
+scopeRef: scope.public.debt.5334.tassadar_dense_fixture_pairs
+verificationCommandRef: command.public.debt.5334.regenerate_and_diff
+stopConditionRef: stop.public.debt.5334.retire_once_after_dedup
+duplicateFingerprintRef: fingerprint.public.debt.5334.scope_patch_digest_v1
+```
+
+Acceptance should require:
+
+- the `.json` fixture remains the canonical committed data if generation from
+  Psionic is out of scope;
+- any `.ts` twin derives from the canonical data instead of duplicating it;
+- exported object digests remain identical;
+- targeted Tassadar fixture tests pass;
+- large generated-fixture churn no longer appears in routine commits;
+- the receipt is retired after settlement.
+
+If this checkout does not contain the generated fixture twins, the worker must
+not fake the proof. The correct action is to leave #5334 open for the checkout
+or branch that contains the artifacts, while landing the policy/tests that make
+the receipt payable when the implementation diff exists.
+
+## Loop Guards
+
+- Discovery is inventory, not spend.
+- Funding requires an allocator or owner route.
+- Verification is not settlement.
+- Settlement happens once, then the receipt is retired.
+- Replays against a retired fingerprint are duplicate work, not payable work.
+- After repeated rejected or revision-required attempts, the receipt/scope goes
+  human-review-only until the benchmark, budget, or scope changes.
+
+Regression coverage for these invariants lives in
+`apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts`.

--- a/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
+++ b/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
@@ -71,6 +71,21 @@ Every payable receipt needs these public-safe refs:
 - settlement approval: separate from the worker;
 - settlement receipt: required before calling it paid or settled.
 
+For receipts that require studied-codebase evidence, the receipt also carries
+a studied-knowledge source:
+
+- study packet ref;
+- studied-knowledge graph ref;
+- studied-knowledge verification ref;
+- `sourceBoundary: public_refs_only`;
+- correctness gate state, rejected-claim count, and validator-review refs.
+
+Passing studied knowledge is evidence, not authority. It can unblock a required
+understanding gate for a hygiene receipt, but it does not grant write, spend,
+settlement, deployment, or self-review authority. Missing, rejected, or
+validator-review-required studied knowledge keeps the receipt out of payable
+state until the verifier or reviewer closes the gate.
+
 Workers may propose findings, but a separate allocator has to fund them.
 Workers do not receive spend authority, deployment authority, settlement
 authority, or authority to mint payable follow-ups.

--- a/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
+++ b/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
@@ -75,6 +75,13 @@ Workers may propose findings, but a separate allocator has to fund them.
 Workers do not receive spend authority, deployment authority, settlement
 authority, or authority to mint payable follow-ups.
 
+The adapter in
+`apps/openagents.com/workers/api/src/debt-receipt-work-request.ts` keeps this
+contract hexagonal: debt-receipt economics are projected and checked first,
+then a funded receipt is translated into the existing ref-only Forum
+work-request contract. The Forum market still sees only objective, verifier,
+budget, deadline, repo, and capability refs.
+
 ## First Receipt: #5334
 
 Proposed public-safe receipt packet:
@@ -116,4 +123,5 @@ the receipt payable when the implementation diff exists.
   human-review-only until the benchmark, budget, or scope changes.
 
 Regression coverage for these invariants lives in
-`apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts`.
+`apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts` and
+`apps/openagents.com/workers/api/src/debt-receipt-work-request.test.ts`.


### PR DESCRIPTION
## Summary

This is the #5340 bridge from studied knowledge into the #5335 hygiene lane.

It builds on #5343 and adds an evidence-only studied-knowledge gate to debt receipts:
- debt receipts can cite a study packet ref, studied-knowledge graph ref, and studied-knowledge verification ref.
- receipts that require studied knowledge cannot become verified or payable unless the cited verification passed, rejected zero claims, and has no pending validator review.
- studied knowledge remains public-refs-only evidence. It does not grant mutation, spend, deployment, settlement, or self-review authority.

## Verification

- bun run --cwd apps/openagents.com/workers/api test -- src/debt-receipt-policy.test.ts src/debt-receipt-work-request.test.ts src/artanis-studying-labor.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck

Focused tests passed: 3 files, 21 tests. Typecheck exited 0 and printed only an existing Effect advisory in tassadar-trace-contribution-routes.ts.

## Notes

Stacked on #5343 until that PR merges. Related to #5335, #5337, and #5340.