### PR TITLE
Extract study benchmark stable hash helpers

### DIFF
--- a/packages/probe/packages/runtime/src/benchmark/openagents-study-artifact.ts
+++ b/packages/probe/packages/runtime/src/benchmark/openagents-study-artifact.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { Effect, Schema as S } from "effect";
 import {
@@ -28,6 +27,7 @@ import {
   buildOpenAgentsRepoCorpusManifest,
   openAgentsRepoCorpusContentHash,
 } from "./repo-corpus-manifest";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 export const OPENAGENTS_REPO_STUDY_ARTIFACT_INDEX_SCHEMA_REF =
   "openagents.repo_study_artifact_index.v0" as const;
@@ -279,29 +279,6 @@ function requireNonEmpty(value: string, path: string): Effect.Effect<void, Probe
 
 function requireSha256(value: string, path: string): Effect.Effect<void, ProbeBenchmarkContractError> {
   return value.startsWith("sha256:") ? Effect.void : studyArtifactError(path, "must be a sha256 ref");
-}
-
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
-  }
-
-  if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
-      .join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function sha256Ref(value: string | Uint8Array): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function shortHash(hash: string): string {
-  return hash.replace(/^sha256:/, "").slice(0, 16);
 }
 
 function studyArtifactError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {

--- a/packages/probe/packages/runtime/src/benchmark/openagents-study-freshness.ts
+++ b/packages/probe/packages/runtime/src/benchmark/openagents-study-freshness.ts
@@ -26,7 +26,6 @@
 // verdict is `stale`, which is the cheap-incremental property: we only re-write
 // the small index when content actually moved.
 
-import { createHash } from "node:crypto";
 import { execFile as execFileCallback } from "node:child_process";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
@@ -39,6 +38,7 @@ import { type ProbePublicProjectionUnsafe } from "../contracts/provider-account"
 import {
   OpenAgentsRepoStudyArtifactIndex,
 } from "./openagents-study-artifact";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 const execFile = promisify(execFileCallback);
 
@@ -230,27 +230,4 @@ export function readOpenAgentsRepoHeadCommit(rootDir: string): Effect.Effect<str
 
 function freshnessError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {
   return Effect.fail(new ProbeBenchmarkContractError({ path, reason }));
-}
-
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
-  }
-
-  if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
-      .join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function sha256Ref(value: string): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function shortHash(hash: string): string {
-  return hash.replace(/^sha256:/, "").slice(0, 16);
 }

--- a/packages/probe/packages/runtime/src/benchmark/openagents-study-graph.ts
+++ b/packages/probe/packages/runtime/src/benchmark/openagents-study-graph.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { Effect, Schema as S } from "effect";
 import {
   ProbeBenchmarkContractError,
@@ -10,6 +9,7 @@ import {
   OpenAgentsRepoStudyPacketRationaleKind,
   openAgentsRepoStudyPacketHash,
 } from "./openagents-study-packet";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 export const OPENAGENTS_REPO_STUDIED_KNOWLEDGE_GRAPH_SCHEMA_REF =
   "openagents.repo_studied_knowledge_graph.v0" as const;
@@ -950,29 +950,6 @@ function requireNonEmptyRefs(
 
 function requireSha256(value: string, path: string): Effect.Effect<void, ProbeBenchmarkContractError> {
   return value.startsWith("sha256:") ? Effect.void : studyGraphError(path, "must be a sha256 ref");
-}
-
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
-  }
-
-  if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
-      .join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function sha256Ref(value: string | Uint8Array): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function shortHash(hash: string): string {
-  return hash.replace(/^sha256:/, "").slice(0, 16);
 }
 
 function studyGraphError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {

--- a/packages/probe/packages/runtime/src/benchmark/openagents-study-packet.ts
+++ b/packages/probe/packages/runtime/src/benchmark/openagents-study-packet.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { execFile as execFileCallback } from "node:child_process";
 import { lstat, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -17,6 +16,7 @@ import {
   openAgentsRepoCorpusEvidenceSpanHash,
   openAgentsRepoCorpusManifestHash,
 } from "./repo-corpus-manifest";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 const execFile = promisify(execFileCallback);
 
@@ -659,29 +659,6 @@ function requireNonEmptyRefs(
 
 function requireSha256(value: string, path: string): Effect.Effect<void, ProbeBenchmarkContractError> {
   return value.startsWith("sha256:") ? Effect.void : studyPacketError(path, "must be a sha256 ref");
-}
-
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
-  }
-
-  if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
-      .join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function sha256Ref(value: string | Uint8Array): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function shortHash(hash: string): string {
-  return hash.replace(/^sha256:/, "").slice(0, 16);
 }
 
 function slugPath(path: string): string {

--- a/packages/probe/packages/runtime/src/benchmark/openagents-study-verification.ts
+++ b/packages/probe/packages/runtime/src/benchmark/openagents-study-verification.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { Effect, Schema as S } from "effect";
 import {
   ProbeBenchmarkContractError,
@@ -22,6 +21,7 @@ import {
   OpenAgentsRepoStudyPacket,
   openAgentsRepoStudyPacketHash,
 } from "./openagents-study-packet";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 export const OPENAGENTS_REPO_STUDIED_KNOWLEDGE_VERIFICATION_SCHEMA_REF =
   "openagents.repo_studied_knowledge_verification.v0" as const;
@@ -558,29 +558,6 @@ function requireNonEmptyRefs(
 
 function requireSha256(value: string, path: string): Effect.Effect<void, ProbeBenchmarkContractError> {
   return value.startsWith("sha256:") ? Effect.void : studyVerificationError(path, "must be a sha256 ref");
-}
-
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
-  }
-
-  if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
-      .join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function sha256Ref(value: string | Uint8Array): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function shortHash(hash: string): string {
-  return hash.replace(/^sha256:/, "").slice(0, 16);
 }
 
 function studyVerificationError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {

--- a/packages/probe/packages/runtime/src/benchmark/repo-corpus-manifest.ts
+++ b/packages/probe/packages/runtime/src/benchmark/repo-corpus-manifest.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { lstat, readdir, readFile } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
 import { Effect, Schema as S } from "effect";
@@ -12,6 +11,7 @@ import {
   OpenAgentsStudybenchEvidenceSpan,
   OpenAgentsStudybenchVisibility,
 } from "./studybench";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 export const OPENAGENTS_REPO_CORPUS_ENTRY_SCHEMA_REF = "openagents.repo_corpus_entry.v0" as const;
 export const OPENAGENTS_REPO_CORPUS_MANIFEST_SCHEMA_REF = "openagents.repo_corpus_manifest.v0" as const;
@@ -490,29 +490,6 @@ function requireNonEmptyRefs(
   return blankIndex === -1
     ? Effect.void
     : repoCorpusError(`${path}[${blankIndex}]`, "must be a non-empty ref");
-}
-
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
-  }
-
-  if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
-      .join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function sha256Ref(value: string | Uint8Array): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function shortHash(hash: string): string {
-  return hash.replace(/^sha256:/, "").slice(0, 16);
 }
 
 function repoCorpusError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {

--- a/packages/probe/packages/runtime/src/benchmark/stable-hash.ts
+++ b/packages/probe/packages/runtime/src/benchmark/stable-hash.ts
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+
+export function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  }
+
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+export function sha256Ref(value: string | Uint8Array): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export function shortHash(hash: string): string {
+  return hash.replace(/^sha256:/, "").slice(0, 16);
+}


### PR DESCRIPTION
## Summary
- Add a shared benchmark stable-hash helper for the study runtime path.
- Replace six duplicated stableJson/sha256Ref/shortHash implementations across corpus manifest, study packet, studied graph, verification, artifact index, and SA-4 freshness modules.
- Keep the different sortStable-based helpers untouched to avoid changing hash semantics.

## Why
This trims repeated digest logic from the newly landed study runtime while keeping the public hash contract centralized and reviewable for the #5335 hygiene/studying epic.

## Verification
- bun run --cwd packages/probe/packages/runtime test -- tests/repo-corpus-manifest.test.ts tests/openagents-study-packet.test.ts tests/openagents-study-graph.test.ts tests/openagents-study-verification.test.ts tests/openagents-study-artifact.test.ts tests/openagents-study-freshness.test.ts (25 pass)
- git diff --check origin/main..HEAD
- bun run test:probe (with loopback permission) currently has one unrelated failure in tests/benchmark-live-canary-receipt.test.ts: expected fileRefs still include rubric-score.json and studybench-task-ref.json, but the fixture receipt no longer emits them; 265 pass, 3 skip, 1 fail.