### PR TITLE
Fix live canary receipt file assertions

### DIFF
--- a/packages/probe/packages/runtime/tests/benchmark-live-canary-receipt.test.ts
+++ b/packages/probe/packages/runtime/tests/benchmark-live-canary-receipt.test.ts
@@ -1,10 +1,9 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 import {
-  PROBE_BENCHMARK_CLOSEOUT_BUNDLE_FILE_NAMES,
   decodeProbeBenchmarkCloseout,
   decodeProbeBenchmarkRouteScorecard,
   decodeProbeBenchmarkRun,
@@ -13,6 +12,19 @@ import {
 const testDir = dirname(fileURLToPath(import.meta.url));
 const canaryDir = join(testDir, "../../../docs/benchmarks/canaries/20260608151057");
 const bundleDir = join(canaryDir, "closeout-bundle");
+const CANARY_CLOSEOUT_BUNDLE_FILE_NAMES = [
+  "probe-run-record.json",
+  "probe-closeout.json",
+  "decision-trace-summary.json",
+  "selected-signatures.json",
+  "tool-menu.json",
+  "candidate-ref.json",
+  "artifact-refs.json",
+  "resource-usage-ref.json",
+  "policy-findings.json",
+  "failure-classification.json",
+  "route-scorecard.json",
+] as const;
 
 const readJson = async (path: string): Promise<unknown> => JSON.parse(await readFile(path, "utf8"));
 
@@ -60,9 +72,9 @@ describe("live Probe GEPA Terminal-Bench canary receipt", () => {
       "task.public.terminal_bench_2.configure_git_webserver.retained",
       "task.public.terminal_bench_2.filter_js_from_html.retained",
     ]);
-    expect(receipt.closeoutBundle.fileRefs.sort()).toEqual(
-      [...PROBE_BENCHMARK_CLOSEOUT_BUNDLE_FILE_NAMES].sort(),
-    );
+    const bundleFileNames = await readdir(bundleDir);
+    expect(receipt.closeoutBundle.fileRefs.sort()).toEqual([...CANARY_CLOSEOUT_BUNDLE_FILE_NAMES].sort());
+    expect(bundleFileNames.sort()).toEqual([...CANARY_CLOSEOUT_BUNDLE_FILE_NAMES].sort());
 
     expect(receipt.pylonLifecycle.assignmentState).toBe("accepted_work");
     expect(receipt.pylonLifecycle.leaseState).toBe("terminal");


### PR DESCRIPTION
## Summary
- Decouple the historical live Probe GEPA canary receipt test from the current closeout writer file-name constant.
- Assert the recorded canary fileRefs against the actual canary bundle files instead.
- Keep current writer coverage in benchmark-closeout-writer.test.ts, where the full generated bundle constant still belongs.

## Why
The committed 2026-06-08 canary is historical unpaid smoke evidence. New optional StudyBench closeout summaries were added to the writer later, but the historical fixture correctly has only the files that existed in that receipt. This repair turns the test back into a check of the receipt's own public-safe evidence instead of a moving assertion against today's writer shape.

## Verification
- bun run --cwd packages/probe/packages/runtime test -- tests/benchmark-live-canary-receipt.test.ts
- bun run test:probe (with loopback permission): 266 pass, 3 skip, 0 fail
- git diff --check