### PR TITLE
Extract public ref formatting helpers

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-probe-gepa-benchmark-summary.ts
+++ b/apps/openagents.com/workers/api/src/artanis-probe-gepa-benchmark-summary.ts
@@ -6,6 +6,7 @@ import {
   probeGepaCampaignPublicSummary,
 } from './probe-gepa-campaign-projection'
 import { ProbeGepaStage1ShadowPromotionResult } from './probe-gepa-stage1-shadow-promotion-gate'
+import { publicRefSegment, uniqueRefs } from './public-ref-format'
 
 export const ArtanisProbeGepaBenchmarkSummarySchemaVersion =
   'omega.artanis_probe_gepa_benchmark_summary.v1'
@@ -71,21 +72,6 @@ const safeRefPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,260}$/
 const unsafeRefPattern =
   /(@|\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer|callback[_-]?token|cookie|credential|customer[_-]?(email|name|value)|email[_-]?(address|body)|fixture[_-]?body|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|oauth|opencode_auth_content|payment[_-]?(hash|id|preimage|proof)|payout[_-]?(address|destination|target)|preimage|private[_-]?(channel|key|repo)|provider[_-]?(account|grant|payload|secret|token)|raw[_-]?(auth|benchmark|email|fixture|invoice|payment|payload|prompt|provider|runner|run[_-]?log|source[_-]?archive|trace|traces)|runner[_-]?log|secret|sk-[a-z0-9]|source[_-]?archive|token|wallet)/i
 const rawTimestampPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
-
-const uniqueRefs = (
-  refs: ReadonlyArray<string> | undefined,
-): ReadonlyArray<string> =>
-  [
-    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
-  ].sort()
-
-const publicRefSegment = (value: string): string =>
-  value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 120) || 'summary'
 
 const assertSafeRefs = (label: string, refs: ReadonlyArray<string>): void => {
   const unsafe = uniqueRefs(refs).find(
@@ -281,7 +267,7 @@ export const buildArtanisProbeGepaBenchmarkSummary = (
       forumTopicRef: decoded.forumTopicRef,
       idempotencyKey: [
         'forum-artanis-probe-gepa',
-        publicRefSegment(projection.campaignRef),
+        publicRefSegment(projection.campaignRef, 'summary'),
         evidenceLabel,
       ].join('-'),
       noDistributedTrainingOverclaim: true,
@@ -296,6 +282,7 @@ export const buildArtanisProbeGepaBenchmarkSummary = (
       sourceEvidenceRefs,
       summaryRef: `summary.artanis.probe_gepa.${publicRefSegment(
         projection.campaignRef,
+        'summary',
       )}.${evidenceLabel}`,
       title: titleFor(evidenceLabel),
     }),

--- a/apps/openagents.com/workers/api/src/probe-gepa-forum-summary.ts
+++ b/apps/openagents.com/workers/api/src/probe-gepa-forum-summary.ts
@@ -10,6 +10,7 @@ import {
   ProbeGepaOutcomeMetricsProjection,
   probeGepaOutcomeMetricSummary,
 } from './probe-gepa-outcome-metrics'
+import { publicRefSegment, uniqueRefs } from './public-ref-format'
 
 export const ProbeGepaForumSummarySchemaVersion =
   'omega.probe_gepa_forum_summary.v1'
@@ -59,13 +60,6 @@ const unsafeRefPattern =
   /(@|\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer|callback[_-]?token|cookie|credential|customer[_-]?(email|name|value)|email[_-]?(address|body)|fixture[_-]?body|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|oauth|opencode_auth_content|payment[_-]?(hash|id|preimage|proof)|payout[_-]?(address|destination|target)|preimage|private[_-]?(channel|key|repo)|provider[_-]?(account|grant|payload|secret|token)|raw[_-]?(auth|benchmark|email|fixture|invoice|payment|payload|prompt|provider|runner|run[_-]?log|source[_-]?archive|trace|traces)|runner[_-]?log|secret|sk-[a-z0-9]|source[_-]?archive|token|wallet)/i
 const rawTimestampPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
 
-const uniqueRefs = (
-  refs: ReadonlyArray<string> | undefined,
-): ReadonlyArray<string> =>
-  [
-    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
-  ].sort()
-
 const assertSafeRefs = (label: string, refs: ReadonlyArray<string>): void => {
   const unsafe = uniqueRefs(refs).find(
     ref =>
@@ -80,14 +74,6 @@ const assertSafeRefs = (label: string, refs: ReadonlyArray<string>): void => {
     })
   }
 }
-
-const publicRefSegment = (value: string): string =>
-  value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 120) || 'campaign'
 
 export const generateProbeGepaForumSummary = (
   input: ProbeGepaForumSummaryInput,
@@ -127,7 +113,7 @@ export const generateProbeGepaForumSummary = (
   const title = `Probe GEPA ${projection.stage} summary: ${projection.campaignRef}`
   const idempotencyKey = [
     'forum_summary.probe_gepa',
-    publicRefSegment(projection.campaignRef),
+    publicRefSegment(projection.campaignRef, 'campaign'),
     projection.stage,
     projection.claimState,
     String(projection.completedMetricCalls),

--- a/apps/openagents.com/workers/api/src/probe-gepa-paid-mode-ladder.ts
+++ b/apps/openagents.com/workers/api/src/probe-gepa-paid-mode-ladder.ts
@@ -10,6 +10,7 @@ import {
   assertPylonGepaMetricCallPublicRefs,
 } from './pylon-gepa-metric-call-assignments'
 import type { PylonGepaMetricCallCoordinatorImport } from './pylon-gepa-metric-call-assignments'
+import { publicRefSegment, uniqueRefs } from './public-ref-format'
 
 export const ProbeGepaPaidModeCampaignLadderSchemaVersion =
   'omega.probe_gepa_paid_mode_campaign_ladder.v1'
@@ -125,23 +126,8 @@ export class ProbeGepaPaidModeCampaignLadderUnsafe extends S.TaggedErrorClass<Pr
   },
 ) {}
 
-const uniqueRefs = (
-  refs: ReadonlyArray<string> | undefined,
-): ReadonlyArray<string> =>
-  [
-    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
-  ].sort()
-
 const hasRefs = (refs: ReadonlyArray<string>): boolean =>
   Arr.isReadonlyArrayNonEmpty(refs)
-
-const publicRefSegment = (value: string): string =>
-  value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 120) || 'record'
 
 const assertPublicRefs = (
   label: string,
@@ -188,7 +174,7 @@ const duplicateRefs = (
 
   refs.forEach(ref => {
     if (seen.has(ref)) {
-      duplicates.add(`${label}.${publicRefSegment(ref)}`)
+      duplicates.add(`${label}.${publicRefSegment(ref, 'record')}`)
     }
     seen.add(ref)
   })
@@ -224,6 +210,7 @@ const bridgeReplayBlockers = (
         ? [
             `blocker.probe_gepa.paid_ladder.duplicate_replay_missing_source.${publicRefSegment(
               attempt.bridgeAttemptRef,
+              'record',
             )}`,
           ]
         : []),
@@ -232,6 +219,7 @@ const bridgeReplayBlockers = (
         ? [
             `blocker.probe_gepa.paid_ladder.duplicate_replay_has_new_receipts.${publicRefSegment(
               attempt.bridgeAttemptRef,
+              'record',
             )}`,
           ]
         : []),

--- a/apps/openagents.com/workers/api/src/probe-gepa-settlement-readiness.ts
+++ b/apps/openagents.com/workers/api/src/probe-gepa-settlement-readiness.ts
@@ -6,6 +6,7 @@ import {
   assertPylonGepaMetricCallPublicRefs,
   pylonGepaMetricCallAcceptedWorkClaimAllowed,
 } from './pylon-gepa-metric-call-assignments'
+import { publicRefSegment, uniqueRefs } from './public-ref-format'
 
 export const ProbeGepaSettlementReadinessSchemaVersion =
   'omega.probe_gepa_settlement_readiness.v1'
@@ -99,21 +100,6 @@ export class ProbeGepaSettlementReadinessUnsafe extends S.TaggedErrorClass<Probe
     reason: S.String,
   },
 ) {}
-
-const uniqueRefs = (
-  refs: ReadonlyArray<string> | undefined,
-): ReadonlyArray<string> =>
-  [
-    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
-  ].sort()
-
-const publicRefSegment = (value: string): string =>
-  value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 120) || 'batch'
 
 const publicClaimRank = (
   publicClaimState: ProbeGepaSettlementPublicClaimState,
@@ -253,6 +239,7 @@ const accountingEvidenceBlockers = (
     return [
       `blocker.probe_gepa.settlement.accounting_missing.${publicRefSegment(
         assignment.assignmentRef,
+        'batch',
       )}`,
     ]
   }
@@ -265,6 +252,7 @@ const accountingEvidenceBlockers = (
       ? [
           `blocker.probe_gepa.settlement.closeout_accounting_missing.${publicRefSegment(
             assignment.assignmentRef,
+            'batch',
           )}`,
         ]
       : []),
@@ -272,6 +260,7 @@ const accountingEvidenceBlockers = (
       ? [
           `blocker.probe_gepa.settlement.proof_accounting_missing.${publicRefSegment(
             assignment.assignmentRef,
+            'batch',
           )}`,
         ]
       : []),
@@ -282,6 +271,7 @@ const accountingEvidenceBlockers = (
       ? [
           `blocker.probe_gepa.settlement.resource_accounting_missing.${publicRefSegment(
             assignment.assignmentRef,
+            'batch',
           )}`,
         ]
       : []),
@@ -292,6 +282,7 @@ const accountingEvidenceBlockers = (
       ? [
           `blocker.probe_gepa.settlement.verifier_accounting_missing.${publicRefSegment(
             assignment.assignmentRef,
+            'batch',
           )}`,
         ]
       : []),
@@ -319,6 +310,7 @@ const receiptBlockers = (
       ? [
           `blocker.probe_gepa.settlement.payment_receipt_missing.${publicRefSegment(
             assignment.assignmentRef,
+            'batch',
           )}`,
         ]
       : []),
@@ -326,6 +318,7 @@ const receiptBlockers = (
       ? [
           `blocker.probe_gepa.settlement.settlement_receipt_missing.${publicRefSegment(
             assignment.assignmentRef,
+            'batch',
           )}`,
         ]
       : []),
@@ -446,6 +439,7 @@ export const evaluateProbeGepaSettlementReadiness = (
     publicSummaryLabel: publicSummaryLabelFor(readinessState),
     readinessDecisionRef: `settlement_readiness.probe_gepa.${publicRefSegment(
       normalized.batchRef,
+      'batch',
     )}.${readinessState}`,
     readinessState,
     requestedPaymentMode: normalized.requestedPaymentMode,

--- a/apps/openagents.com/workers/api/src/public-ref-format.ts
+++ b/apps/openagents.com/workers/api/src/public-ref-format.ts
@@ -1,0 +1,17 @@
+export const uniqueRefs = (
+  refs: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> =>
+  [
+    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
+  ].sort()
+
+export const publicRefSegment = (
+  value: string,
+  fallback: string,
+): string =>
+  value
+    .trim()
+    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
+    .replaceAll(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 120) || fallback

--- a/apps/openagents.com/workers/api/src/pylon-gepa-metric-call-assignments.ts
+++ b/apps/openagents.com/workers/api/src/pylon-gepa-metric-call-assignments.ts
@@ -1,5 +1,7 @@
 import { Schema as S } from 'effect'
 
+import { publicRefSegment, uniqueRefs } from './public-ref-format'
+
 export const PylonGepaMetricCallAssignmentSchemaVersion =
   'omega.pylon_gepa_metric_call_assignment.v1'
 export const PylonGepaMetricCallCoordinatorImportSchemaVersion =
@@ -137,26 +139,12 @@ const unsafeRefPattern =
   /(@|\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer|callback[_-]?token|cookie|customer[_-]?(email|name|value)|email[_-]?(address|body)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|oauth|opencode_auth_content|payment[_-]?(hash|id|preimage|proof)|payout[_-]?(address|destination|target)|preimage|private[_-]?(channel|key|repo)|provider[_-]?(grant|payload|secret|token)|raw[_-]?(auth|email|invoice|payment|payload|prompt|provider|runner|run[_-]?log|source[_-]?archive|webhook)|runner[_-]?log|secret|sk-[a-z0-9]|source[_-]?archive|token|wallet)/i
 const rawTimestampPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
 
-const uniqueRefs = (
-  refs: ReadonlyArray<string> | undefined,
-): ReadonlyArray<string> =>
-  [
-    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
-  ].sort()
-
-const publicRefSegment = (value: string): string =>
-  value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 120) || 'record'
-
 const defaultAssignmentRef = (
   input: PylonGepaMetricCallAssignmentInput,
 ): string =>
   `assignment.public.pylon_gepa_metric_call.${publicRefSegment(
     `${input.campaignId}.${input.taskRef}.${input.candidateHash}`,
+    'record',
   )}`
 
 const assertSafeRefs = (label: string, refs: ReadonlyArray<string>): void => {

--- a/apps/openagents.com/workers/api/src/pylon-marketplace-service.ts
+++ b/apps/openagents.com/workers/api/src/pylon-marketplace-service.ts
@@ -17,6 +17,7 @@ import {
 } from './pylon-marketplace-jobs'
 import { PylonResourceMode } from './pylon-resource-mode-setup'
 import { decodeUnknownWithSchema, parseJsonUnknown } from './json-boundary'
+import { publicRefSegment, uniqueRefs } from './public-ref-format'
 
 export const PylonMarketplaceTriageOutcome = S.Literals([
   'accepted_for_review',
@@ -205,12 +206,6 @@ type StoredTriageActionRow = Readonly<{
   target_intake_ref: string
 }>
 
-const uniqueRefs = (
-  refs: ReadonlyArray<string> | undefined,
-): ReadonlyArray<string> =>
-  [...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== ''))]
-    .sort()
-
 const requiredRefs = (
   label: string,
   refs: ReadonlyArray<string>,
@@ -245,16 +240,8 @@ const stableValue = (value: unknown): unknown => {
 
 const stableJson = (value: unknown): string => JSON.stringify(stableValue(value))
 
-const publicRefSegment = (value: string): string =>
-  value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 120) || 'record'
-
 const recordId = (prefix: string, value: string): string =>
-  `${prefix}.${publicRefSegment(value)}`
+  `${prefix}.${publicRefSegment(value, 'record')}`
 
 const defaultPrivacyClass = (
   source: PylonMarketplaceJobSource,
@@ -368,7 +355,7 @@ const makeIntakeRecord = (
 ): PylonMarketplaceJobIntakeRecord => {
   const source = request.source ?? 'openagents_seeded'
   const privacyClass = request.privacyClass ?? defaultPrivacyClass(source)
-  const suffix = publicRefSegment(`${source}_${request.jobKind}_${input.id}`)
+  const suffix = publicRefSegment(`${source}_${request.jobKind}_${input.id}`, 'record')
   const intakeRef =
     request.intakeRef ?? recordId('intake.public.pylon_marketplace', suffix)
   const jobRef =

--- a/apps/openagents.com/workers/api/src/qwen-remote-pylon-finetune-gate.ts
+++ b/apps/openagents.com/workers/api/src/qwen-remote-pylon-finetune-gate.ts
@@ -1,6 +1,8 @@
 import { containsProviderSecretMaterial } from '@openagentsinc/provider-account-schema'
 import { Schema as S } from 'effect'
 
+import { publicRefSegment, uniqueRefs } from './public-ref-format'
+
 export const QwenRemotePylonFineTuneGateSchemaVersion =
   'omega.qwen_remote_pylon_finetune_gate.v1'
 
@@ -112,22 +114,7 @@ const unsafeRefPattern =
   /(@|\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer|callback[_-]?token|cookie|customer[_-]?(email|name|phone|prompt|record|value)|dataset\.(raw|private)|email[_-]?(address|body|html|raw|text)|full[_-]?(prompt|source|trace)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice[_-]?(id|raw)|lnbc|lntb|lnbcrt|lno1|lnurl|macaroon|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|model[_-]?(weights|raw|secret)|oauth|opencode_auth_content|payment[_-]?(hash|id|invoice|preimage|proof|raw|secret)|payout[_-]?(address|destination|private|raw|target)|preimage|private[_-]?(archive|customer|dataset|key|prompt|source|trace|wallet)|provider[_-]?(account|credential|grant|payload|secret|token)|raw[_-]?(artifact|auth|customer|dataset|email|invoice|model|payment|payload|payout|prompt|provider|record|repo|runner|run[_-]?log|source|state|target|telemetry|text|trace|training|weights|webhook)|recovery[_-]?phrase|runner[_-]?(payload|secret|token)|secret|seed[_-]?phrase|sk-[a-z0-9]|source[_-]?(archive|raw)|token|wallet[._-](key|material|mnemonic|payment|preimage|secret|seed)|weights\.(bin|gguf|safetensors|pt|pth))/i
 const rawTimestampPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
 
-const uniqueRefs = (
-  refs: ReadonlyArray<string> | undefined,
-): ReadonlyArray<string> =>
-  [
-    ...new Set((refs ?? []).map(ref => ref.trim()).filter(ref => ref !== '')),
-  ].sort()
-
 const hasRefs = (refs: ReadonlyArray<string>): boolean => refs.length > 0
-
-const publicRefSegment = (value: string): string =>
-  value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 120) || 'qwen'
 
 const assertSafeRefs = (
   label: string,
@@ -293,6 +280,7 @@ export const projectQwenRemotePylonFineTuneGate = (
       : [
           `blocker.public.qwen_remote_finetune.shard_receipts_missing.required_${publicRefSegment(
             String(normalized.requiredShardCount),
+            'qwen',
           )}`,
         ]),
     ...(everyWorkerHasArtifactRefs && hasRefs(artifactRefs)


### PR DESCRIPTION
## Summary
- Add a shared public-ref-format helper for public ref normalization and suffix formatting.
- Replace seven duplicated uniqueRefs/publicRefSegment blocks across GEPA, Qwen, Artanis, and Pylon marketplace modules.
- Preserve every existing fallback segment explicitly at each call site (`record`, `batch`, `campaign`, `summary`, `qwen`).

## Why
These modules all build public-safe refs and blocker refs with the same trim/dedupe/sort and slugging rules. Keeping the rules in one helper reduces drift risk while leaving each module's domain-specific safety regexes local.

## Verification
- bun run --cwd apps/openagents.com/workers/api test -- src/probe-gepa-paid-mode-ladder.test.ts src/probe-gepa-settlement-readiness.test.ts src/probe-gepa-forum-summary.test.ts src/pylon-gepa-metric-call-assignments.test.ts src/qwen-remote-pylon-finetune-gate.test.ts src/artanis-probe-gepa-benchmark-summary.test.ts src/operator-pylon-marketplace-routes.test.ts (41 pass)
- bun run --cwd apps/openagents.com/workers/api typecheck (exit 0; existing Effect advisory in src/tassadar-trace-contribution-routes.ts)
- git diff --check
