### PR TITLE
Extract order triage record requirement helper

### DIFF
--- a/apps/openagents.com/workers/api/src/operator-order-triage-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-order-triage-routes.ts
@@ -1239,6 +1239,20 @@ const readRecordByOrderId = (
       .first<OrderTriageRow>(),
   ).pipe(Effect.map(row => (row === null ? null : rowToRecord(row))))
 
+const requireTriageRecordByOrderId = (
+  db: D1Database,
+  softwareOrderId: string,
+): Effect.Effect<OperatorOrderTriageRecord, OrderTriageError> =>
+  Effect.gen(function* () {
+    const record = yield* readRecordByOrderId(db, softwareOrderId)
+
+    if (record === null) {
+      return yield* new OrderTriageSoftwareOrderNotFound({ softwareOrderId })
+    }
+
+    return record
+  })
+
 const requireSoftwareOrder = (
   db: D1Database,
   softwareOrderId: string,
@@ -1370,13 +1384,7 @@ const upsertTriageRecord = (
       )
     }
 
-    const record = yield* readRecordByOrderId(db, softwareOrderId)
-
-    if (record === null) {
-      return yield* new OrderTriageSoftwareOrderNotFound({ softwareOrderId })
-    }
-
-    return record
+    return yield* requireTriageRecordByOrderId(db, softwareOrderId)
   })
 
 const summarizeFirstBatch = (
@@ -1741,11 +1749,7 @@ const prepareOrderFulfillment = (
   AdjutantAssignmentService | AutopilotSitesService
 > =>
   Effect.gen(function* () {
-    const record = yield* readRecordByOrderId(db, softwareOrderId)
-
-    if (record === null) {
-      return yield* new OrderTriageSoftwareOrderNotFound({ softwareOrderId })
-    }
+    const record = yield* requireTriageRecordByOrderId(db, softwareOrderId)
 
     return yield* createFirstBatchAssignment(
       db,


### PR DESCRIPTION
## Summary

- Extract `requireTriageRecordByOrderId` for order triage read-or-404 behavior.
- Reuse the helper in triage upsert readback and fulfillment preparation.
- Leave payment-policy missing-record handling unchanged because it intentionally returns a bad-request reason.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/operator-order-triage-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`

Note: typecheck still prints the existing Effect advisory in `src/tassadar-trace-contribution-routes.ts`.
