### PR TITLE
Extract forum work request route contract

### DIFF
--- a/apps/openagents.com/workers/api/src/forum-routes.ts
+++ b/apps/openagents.com/workers/api/src/forum-routes.ts
@@ -115,14 +115,22 @@ import {
   recordForumWorkRequestResult,
 } from './forum-work-request-negotiation'
 import {
+  decodeAcceptForumWorkRequestOfferBody,
+  decodeCreateForumWorkRequestBody,
+  decodeForumWorkRequestLifecycleBody,
+  decodeRelayNativeForumWorkRequestBody,
+  decodeReleaseForumWorkRequestBody,
+  decodeSubmitForumWorkRequestOfferBody,
+  decodeSubmitForumWorkRequestResultBody,
+  workRequestMatchesInput,
+} from './forum-work-request-route-contract'
+import {
   DefaultForumWorkRequestBridgeActorRef,
   DefaultForumWorkRequestRelayUrl,
-  ForumWorkRequestLifecycleKind,
   type ForumWorkRequestRecord,
   type ForumWorkRequestRelayLink,
   type ForumWorkRequestRelayPublisher,
   ForumWorkRequestsForumSlug,
-  type NormalizedForumWorkRequestInput,
   buildForumWorkRequestLbrDraft,
   decodeRelayNativeLbrWorkRequest,
   defaultForumWorkRequestRelayPublisher,
@@ -228,79 +236,6 @@ type ForumAgentWriterActor = Extract<
   ForumWriterActorInput,
   Readonly<{ _tag: 'Agent' }>
 >
-
-const ForumWorkRequestRef = S.Trim.check(S.isNonEmpty(), S.isMaxLength(220))
-const ForumWorkRequestRefs = S.Array(ForumWorkRequestRef)
-
-const CreateForumWorkRequestBody = S.Struct({
-  budgetSats: S.Number,
-  deadlineRef: ForumWorkRequestRef,
-  objectiveRef: ForumWorkRequestRef,
-  repositoryRefs: S.optionalKey(ForumWorkRequestRefs),
-  requestedSlug: S.optionalKey(
-    S.NullOr(
-      S.Trim.check(
-        S.isMinLength(3),
-        S.isMaxLength(80),
-        S.isPattern(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/),
-      ),
-    ),
-  ),
-  requiredCapabilityRefs: S.optionalKey(ForumWorkRequestRefs),
-  title: S.Trim.check(S.isMinLength(3), S.isMaxLength(160)),
-  verificationCommandRef: ForumWorkRequestRef,
-})
-type CreateForumWorkRequestBody = typeof CreateForumWorkRequestBody.Type
-
-const RelayNativeForumWorkRequestBody = S.Struct({
-  event: S.Unknown,
-  title: S.optionalKey(S.NullOr(S.Trim.check(S.isMaxLength(160)))),
-})
-type RelayNativeForumWorkRequestBody =
-  typeof RelayNativeForumWorkRequestBody.Type
-
-const ForumWorkRequestLifecycleBody = S.Struct({
-  lifecycleKind: ForumWorkRequestLifecycleKind,
-  receiptRef: ForumWorkRequestRef,
-})
-type ForumWorkRequestLifecycleBody = typeof ForumWorkRequestLifecycleBody.Type
-
-const AcceptForumWorkRequestOfferBody = S.Struct({
-  quoteRef: ForumWorkRequestRef,
-})
-type AcceptForumWorkRequestOfferBody =
-  typeof AcceptForumWorkRequestOfferBody.Type
-
-const ForumWorkRequestNostrPubkey = S.Trim.check(
-  S.isPattern(/^[0-9a-f]{64}$/i),
-)
-
-const SubmitForumWorkRequestOfferBody = S.Struct({
-  amountSats: S.Number,
-  capabilityRefs: S.optionalKey(ForumWorkRequestRefs),
-  providerActorRef: ForumWorkRequestRef,
-  providerPubkey: S.optionalKey(S.NullOr(ForumWorkRequestNostrPubkey)),
-  quoteRef: ForumWorkRequestRef,
-  relayEventRef: S.optionalKey(S.NullOr(ForumWorkRequestRef)),
-})
-type SubmitForumWorkRequestOfferBody =
-  typeof SubmitForumWorkRequestOfferBody.Type
-
-const SubmitForumWorkRequestResultBody = S.Struct({
-  artifactRefs: S.optionalKey(ForumWorkRequestRefs),
-  closeoutRef: S.optionalKey(S.NullOr(ForumWorkRequestRef)),
-  quoteRef: ForumWorkRequestRef,
-  resultEventRef: ForumWorkRequestRef,
-  verificationCommandRef: ForumWorkRequestRef,
-})
-type SubmitForumWorkRequestResultBody =
-  typeof SubmitForumWorkRequestResultBody.Type
-
-const ReleaseForumWorkRequestBody = S.Struct({
-  quoteRef: ForumWorkRequestRef,
-  verificationVerdictRef: ForumWorkRequestRef,
-})
-type ReleaseForumWorkRequestBody = typeof ReleaseForumWorkRequestBody.Type
 
 const EditForumPostBody = S.Struct({
   bodyText: S.Trim.check(
@@ -832,114 +767,6 @@ const workRequestPublicProjection = (
     forumWorkRequestEventRef(jobEventId),
   ],
 })
-
-const forbiddenWorkRequestBodyKeys = new Set([
-  'bodyText',
-  'credentials',
-  'privateRepoContent',
-  'prompt',
-  'rawCommand',
-  'rawContent',
-  'rawPrompt',
-  'secret',
-])
-
-class ForumWorkRequestBodyValidationError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'ForumWorkRequestBodyValidationError'
-  }
-}
-
-const rejectForbiddenWorkRequestBodyKeys = (body: unknown): void => {
-  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
-    return
-  }
-
-  const keys = Object.keys(body)
-  const forbidden = keys.find(key => forbiddenWorkRequestBodyKeys.has(key))
-
-  if (forbidden !== undefined) {
-    throw new ForumWorkRequestBodyValidationError(
-      `Forum work requests accept public refs only; ${forbidden} is not allowed.`,
-    )
-  }
-}
-
-const decodeCreateForumWorkRequestBody = (
-  body: unknown,
-): CreateForumWorkRequestBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(CreateForumWorkRequestBody)(body)
-}
-
-const decodeRelayNativeForumWorkRequestBody = (
-  body: unknown,
-): RelayNativeForumWorkRequestBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(RelayNativeForumWorkRequestBody)(body)
-}
-
-const decodeForumWorkRequestLifecycleBody = (
-  body: unknown,
-): ForumWorkRequestLifecycleBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(ForumWorkRequestLifecycleBody)(body)
-}
-
-const decodeAcceptForumWorkRequestOfferBody = (
-  body: unknown,
-): AcceptForumWorkRequestOfferBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(AcceptForumWorkRequestOfferBody)(body)
-}
-
-const decodeSubmitForumWorkRequestOfferBody = (
-  body: unknown,
-): SubmitForumWorkRequestOfferBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(SubmitForumWorkRequestOfferBody)(body)
-}
-
-const decodeSubmitForumWorkRequestResultBody = (
-  body: unknown,
-): SubmitForumWorkRequestResultBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(SubmitForumWorkRequestResultBody)(body)
-}
-
-const decodeReleaseForumWorkRequestBody = (
-  body: unknown,
-): ReleaseForumWorkRequestBody => {
-  rejectForbiddenWorkRequestBodyKeys(body)
-
-  return S.decodeUnknownSync(ReleaseForumWorkRequestBody)(body)
-}
-
-const arraysEqual = (
-  left: ReadonlyArray<string>,
-  right: ReadonlyArray<string>,
-): boolean =>
-  left.length === right.length &&
-  left.every((value, index) => value === right[index])
-
-const workRequestMatchesInput = (
-  record: ForumWorkRequestRecord,
-  input: NormalizedForumWorkRequestInput,
-): boolean =>
-  record.title === input.title &&
-  record.objectiveRef === input.objectiveRef &&
-  record.verificationCommandRef === input.verificationCommandRef &&
-  record.deadlineRef === input.deadlineRef &&
-  record.budgetSats === input.budgetSats &&
-  arraysEqual(record.repositoryRefs, input.repositoryRefs) &&
-  arraysEqual(record.requiredCapabilityRefs, input.requiredCapabilityRefs)
 
 const workRequestAcceptanceEventRef = (
   workRequestId: string,

--- a/apps/openagents.com/workers/api/src/forum-work-request-route-contract.test.ts
+++ b/apps/openagents.com/workers/api/src/forum-work-request-route-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  ForumWorkRequestBodyValidationError,
+  decodeCreateForumWorkRequestBody,
+  workRequestMatchesInput,
+} from './forum-work-request-route-contract'
+import {
+  type ForumWorkRequestRecord,
+  normalizeForumWorkRequestInput,
+} from './forum-work-requests'
+
+const workRequestRecord: ForumWorkRequestRecord = {
+  budgetMsats: 100_000_000,
+  budgetSats: 100_000,
+  createdAt: '2026-06-18T15:23:43.476Z',
+  deadlineRef: 'deadline.public.debt_receipt.20260625',
+  firstPostId: 'post-1',
+  idempotencyKey: 'debt-receipt:receipt_public_debt_5334_template',
+  jobEventId: 'job-1',
+  jobEventKind: 5934,
+  jobResultKind: 6934,
+  objectiveRef: 'receipt.public.debt.5334.template',
+  publicProjection: {
+    classificationCaveatRef: 'classification.public_forum_projection',
+    customerSafe: true,
+    dataClassification: 'public',
+    excludedPrivateRefs: [],
+    publicSafe: true,
+    redactionPolicyRef: 'redaction.forum.public.v1',
+    safeArtifactRefs: ['artifact.forum.work_request.wr-1'],
+    safeReceiptRefs: [],
+    trustTier: 'reviewed',
+  },
+  quoteCount: 0,
+  relayUrl: 'wss://relay.test.openagents.dev',
+  repositoryRefs: ['repo.public.openagents'],
+  requesterActorRef: 'actor.public.trigger',
+  requiredCapabilityRefs: ['capability.pylon.local_claude_agent'],
+  state: 'open',
+  title: 'Debt receipt template',
+  topicId: 'topic-1',
+  updatedAt: '2026-06-18T15:23:43.476Z',
+  verificationCommandRef: 'command.public.debt_receipt.regenerate_and_diff',
+  workRequestId: 'wr-1',
+}
+
+describe('Forum work request route contract', () => {
+  test('decodes public ref-only create bodies', () => {
+    expect(
+      decodeCreateForumWorkRequestBody({
+        budgetSats: 100_000,
+        deadlineRef: 'deadline.public.debt_receipt.20260625',
+        objectiveRef: 'receipt.public.debt.5334.template',
+        repositoryRefs: ['repo.public.openagents'],
+        requestedSlug: 'debt-receipt-template',
+        requiredCapabilityRefs: ['capability.pylon.local_claude_agent'],
+        title: 'Debt receipt template',
+        verificationCommandRef:
+          'command.public.debt_receipt.regenerate_and_diff',
+      }),
+    ).toMatchObject({
+      budgetSats: 100_000,
+      objectiveRef: 'receipt.public.debt.5334.template',
+      requestedSlug: 'debt-receipt-template',
+    })
+  })
+
+  test('rejects raw prompt material before schema decoding', () => {
+    expect(() =>
+      decodeCreateForumWorkRequestBody({
+        budgetSats: 100_000,
+        deadlineRef: 'deadline.public.debt_receipt.20260625',
+        objectiveRef: 'receipt.public.debt.5334.template',
+        rawPrompt: 'clone the private repo and fix it',
+        title: 'Debt receipt template',
+        verificationCommandRef:
+          'command.public.debt_receipt.regenerate_and_diff',
+      }),
+    ).toThrow(ForumWorkRequestBodyValidationError)
+  })
+
+  test('matches normalized input to an existing work request without route dependencies', () => {
+    const input = normalizeForumWorkRequestInput({
+      budgetSats: 100_000,
+      deadlineRef: workRequestRecord.deadlineRef,
+      objectiveRef: workRequestRecord.objectiveRef,
+      repositoryRefs: workRequestRecord.repositoryRefs,
+      requiredCapabilityRefs: workRequestRecord.requiredCapabilityRefs,
+      title: workRequestRecord.title,
+      verificationCommandRef: workRequestRecord.verificationCommandRef,
+    })
+
+    expect(workRequestMatchesInput(workRequestRecord, input)).toBe(true)
+    expect(
+      workRequestMatchesInput(workRequestRecord, {
+        ...input,
+        requiredCapabilityRefs: ['capability.public.different'],
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/openagents.com/workers/api/src/forum-work-request-route-contract.ts
+++ b/apps/openagents.com/workers/api/src/forum-work-request-route-contract.ts
@@ -1,0 +1,191 @@
+import { Schema as S } from 'effect'
+
+import {
+  ForumWorkRequestLifecycleKind,
+  type ForumWorkRequestRecord,
+  type NormalizedForumWorkRequestInput,
+} from './forum-work-requests'
+
+const ForumWorkRequestRef = S.Trim.check(S.isNonEmpty(), S.isMaxLength(220))
+const ForumWorkRequestRefs = S.Array(ForumWorkRequestRef)
+
+const RequestedSlug = S.NullOr(
+  S.Trim.check(
+    S.isMinLength(3),
+    S.isMaxLength(80),
+    S.isPattern(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/),
+  ),
+)
+
+const CreateForumWorkRequestBody = S.Struct({
+  budgetSats: S.Number,
+  deadlineRef: ForumWorkRequestRef,
+  objectiveRef: ForumWorkRequestRef,
+  repositoryRefs: S.optionalKey(ForumWorkRequestRefs),
+  requestedSlug: S.optionalKey(RequestedSlug),
+  requiredCapabilityRefs: S.optionalKey(ForumWorkRequestRefs),
+  title: S.Trim.check(S.isMinLength(3), S.isMaxLength(160)),
+  verificationCommandRef: ForumWorkRequestRef,
+})
+export type CreateForumWorkRequestBody =
+  typeof CreateForumWorkRequestBody.Type
+
+const RelayNativeForumWorkRequestBody = S.Struct({
+  event: S.Unknown,
+  title: S.optionalKey(S.NullOr(S.Trim.check(S.isMaxLength(160)))),
+})
+export type RelayNativeForumWorkRequestBody =
+  typeof RelayNativeForumWorkRequestBody.Type
+
+const ForumWorkRequestLifecycleBody = S.Struct({
+  lifecycleKind: ForumWorkRequestLifecycleKind,
+  receiptRef: ForumWorkRequestRef,
+})
+export type ForumWorkRequestLifecycleBody =
+  typeof ForumWorkRequestLifecycleBody.Type
+
+const AcceptForumWorkRequestOfferBody = S.Struct({
+  quoteRef: ForumWorkRequestRef,
+})
+export type AcceptForumWorkRequestOfferBody =
+  typeof AcceptForumWorkRequestOfferBody.Type
+
+const ForumWorkRequestNostrPubkey = S.Trim.check(
+  S.isPattern(/^[0-9a-f]{64}$/i),
+)
+
+const SubmitForumWorkRequestOfferBody = S.Struct({
+  amountSats: S.Number,
+  capabilityRefs: S.optionalKey(ForumWorkRequestRefs),
+  providerActorRef: ForumWorkRequestRef,
+  providerPubkey: S.optionalKey(S.NullOr(ForumWorkRequestNostrPubkey)),
+  quoteRef: ForumWorkRequestRef,
+  relayEventRef: S.optionalKey(S.NullOr(ForumWorkRequestRef)),
+})
+export type SubmitForumWorkRequestOfferBody =
+  typeof SubmitForumWorkRequestOfferBody.Type
+
+const SubmitForumWorkRequestResultBody = S.Struct({
+  artifactRefs: S.optionalKey(ForumWorkRequestRefs),
+  closeoutRef: S.optionalKey(S.NullOr(ForumWorkRequestRef)),
+  quoteRef: ForumWorkRequestRef,
+  resultEventRef: ForumWorkRequestRef,
+  verificationCommandRef: ForumWorkRequestRef,
+})
+export type SubmitForumWorkRequestResultBody =
+  typeof SubmitForumWorkRequestResultBody.Type
+
+const ReleaseForumWorkRequestBody = S.Struct({
+  quoteRef: ForumWorkRequestRef,
+  verificationVerdictRef: ForumWorkRequestRef,
+})
+export type ReleaseForumWorkRequestBody =
+  typeof ReleaseForumWorkRequestBody.Type
+
+const forbiddenWorkRequestBodyKeys = new Set([
+  'bodyText',
+  'credentials',
+  'privateRepoContent',
+  'prompt',
+  'rawCommand',
+  'rawContent',
+  'rawPrompt',
+  'secret',
+])
+
+export class ForumWorkRequestBodyValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ForumWorkRequestBodyValidationError'
+  }
+}
+
+const rejectForbiddenWorkRequestBodyKeys = (body: unknown): void => {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return
+  }
+
+  const keys = Object.keys(body)
+  const forbidden = keys.find(key => forbiddenWorkRequestBodyKeys.has(key))
+
+  if (forbidden !== undefined) {
+    throw new ForumWorkRequestBodyValidationError(
+      `Forum work requests accept public refs only; ${forbidden} is not allowed.`,
+    )
+  }
+}
+
+export const decodeCreateForumWorkRequestBody = (
+  body: unknown,
+): CreateForumWorkRequestBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(CreateForumWorkRequestBody)(body)
+}
+
+export const decodeRelayNativeForumWorkRequestBody = (
+  body: unknown,
+): RelayNativeForumWorkRequestBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(RelayNativeForumWorkRequestBody)(body)
+}
+
+export const decodeForumWorkRequestLifecycleBody = (
+  body: unknown,
+): ForumWorkRequestLifecycleBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(ForumWorkRequestLifecycleBody)(body)
+}
+
+export const decodeAcceptForumWorkRequestOfferBody = (
+  body: unknown,
+): AcceptForumWorkRequestOfferBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(AcceptForumWorkRequestOfferBody)(body)
+}
+
+export const decodeSubmitForumWorkRequestOfferBody = (
+  body: unknown,
+): SubmitForumWorkRequestOfferBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(SubmitForumWorkRequestOfferBody)(body)
+}
+
+export const decodeSubmitForumWorkRequestResultBody = (
+  body: unknown,
+): SubmitForumWorkRequestResultBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(SubmitForumWorkRequestResultBody)(body)
+}
+
+export const decodeReleaseForumWorkRequestBody = (
+  body: unknown,
+): ReleaseForumWorkRequestBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(ReleaseForumWorkRequestBody)(body)
+}
+
+const arraysEqual = (
+  left: ReadonlyArray<string>,
+  right: ReadonlyArray<string>,
+): boolean =>
+  left.length === right.length &&
+  left.every((value, index) => value === right[index])
+
+export const workRequestMatchesInput = (
+  record: ForumWorkRequestRecord,
+  input: NormalizedForumWorkRequestInput,
+): boolean =>
+  record.title === input.title &&
+  record.objectiveRef === input.objectiveRef &&
+  record.verificationCommandRef === input.verificationCommandRef &&
+  record.deadlineRef === input.deadlineRef &&
+  record.budgetSats === input.budgetSats &&
+  arraysEqual(record.repositoryRefs, input.repositoryRefs) &&
+  arraysEqual(record.requiredCapabilityRefs, input.requiredCapabilityRefs)


### PR DESCRIPTION
## Summary

- Extract Forum work-request request decoding and route input shaping from `forum-routes.ts`.
- Add `forum-work-request-route-contract.ts` for the work-request route boundary.
- Add focused contract tests for create/relay/lifecycle/offer/result/release bodies and normalized input mapping.

## Context

This is the still-useful route-contract slice from the older #5343 stack, rebuilt cleanly on current `main` after #5340 landed a newer debt-receipt policy/studied-knowledge implementation. The old policy/study commits are intentionally not carried forward here.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/forum-work-request-route-contract.test.ts src/forum-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check origin/main..HEAD`

Note: typecheck still prints the existing Tassadar Effect advisory until #5359 lands.
