### PR TITLE
Reuse stable hash helpers in StudyBench modules

### DIFF
--- a/packages/probe/packages/runtime/src/benchmark/external-repo-studying-product.ts
+++ b/packages/probe/packages/runtime/src/benchmark/external-repo-studying-product.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { Effect, Schema as S } from "effect";
 import {
@@ -35,6 +34,7 @@ import {
   buildOpenAgentsRepoCorpusManifest,
   type OpenAgentsRepoCorpusManifest,
 } from "./repo-corpus-manifest";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 export const OPENAGENTS_EXTERNAL_REPO_STUDY_PRODUCT_SURFACE_SCHEMA_REF =
   "openagents.external_repo_study_product_surface.v0" as const;
@@ -525,34 +525,6 @@ function slugRepo(repo: string): string {
     .replace(/^_+|_+$/g, "")
     .toLowerCase()
     .slice(0, 80);
-}
-
-function shortHash(value: string): string {
-  return value.replace(/^sha256:/, "").slice(0, 16);
-}
-
-function sha256Ref(value: string): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function stableJson(value: unknown): string {
-  return JSON.stringify(sortStable(value));
-}
-
-function sortStable(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => sortStable(entry));
-  }
-
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, sortStable(entry)]),
-  );
 }
 
 function externalStudyError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {

--- a/packages/probe/packages/runtime/src/benchmark/openagents-autopilot-coder-studied-runtime.ts
+++ b/packages/probe/packages/runtime/src/benchmark/openagents-autopilot-coder-studied-runtime.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { Effect, Schema as S } from "effect";
 import { ProbeBenchmarkContractError } from "../contracts/benchmark";
 import { type ProbePublicProjectionUnsafe } from "../contracts/provider-account";
@@ -14,6 +13,7 @@ import {
   generateOpenAgentsRepoStudyArtifact,
   type GenerateOpenAgentsRepoStudyArtifactInput,
 } from "./openagents-study-artifact";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 export const OPENAGENTS_AUTOPILOT_CODER_STUDIED_RUNTIME_SCHEMA_REF =
   "openagents.autopilot_coder_studied_runtime_context.v0" as const;
@@ -239,34 +239,6 @@ function requireSha256(value: string, path: string): Effect.Effect<void, ProbeBe
   return /^sha256:[a-f0-9]{64}$/.test(value)
     ? Effect.void
     : runtimeContextError(path, "must be a sha256 hash ref");
-}
-
-function shortHash(value: string): string {
-  return value.replace(/^sha256:/, "").slice(0, 16);
-}
-
-function sha256Ref(value: string): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-function stableJson(value: unknown): string {
-  return JSON.stringify(sortStable(value));
-}
-
-function sortStable(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => sortStable(entry));
-  }
-
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, sortStable(entry)]),
-  );
 }
 
 function runtimeContextError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {

--- a/packages/probe/packages/runtime/src/benchmark/openagents-studybench-eval-harness.ts
+++ b/packages/probe/packages/runtime/src/benchmark/openagents-studybench-eval-harness.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { Effect, Schema as S } from "effect";
 import {
   ProbeBenchmarkContractError,
@@ -33,6 +32,7 @@ import {
   PROBE_STUDYBENCH_SCORER_REFS,
   buildProbeStudybenchRubricScore,
 } from "./studybench-score";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
 
 export const OPENAGENTS_STUDYBENCH_HIDDEN_EDIT_EXAM_SCHEMA_REF =
   "openagents.studybench_hidden_edit_exam.v0" as const;
@@ -941,10 +941,6 @@ function slugPath(path: string): string {
     .slice(0, 96);
 }
 
-function shortHash(value: string): string {
-  return value.replace(/^sha256:/, "").slice(0, 16);
-}
-
 function requireNonEmpty(value: string, path: string): Effect.Effect<void, ProbeBenchmarkContractError> {
   return value.trim().length === 0
     ? harnessError(path, "must be a non-empty ref")
@@ -973,28 +969,4 @@ function requireSha256(value: string, path: string): Effect.Effect<void, ProbeBe
 
 function harnessError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {
   return Effect.fail(new ProbeBenchmarkContractError({ path, reason }));
-}
-
-function stableJson(value: unknown): string {
-  return JSON.stringify(sortStable(value));
-}
-
-function sortStable(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => sortStable(entry));
-  }
-
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, sortStable(entry)]),
-  );
-}
-
-function sha256Ref(value: string): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
 }


### PR DESCRIPTION
## Summary

- Reuse the shared benchmark `stable-hash` helpers in three remaining studying/StudyBench modules.
- Remove local `createHash`, `shortHash`, `sha256Ref`, `stableJson`, and `sortStable` helper copies from:
  - `external-repo-studying-product.ts`
  - `openagents-autopilot-coder-studied-runtime.ts`
  - `openagents-studybench-eval-harness.ts`
- Keep the change scoped to modules with direct tests, leaving unrelated hash helpers for separate review.

## Verification

- `bun run --cwd packages/probe/packages/runtime test -- tests/external-repo-studying-product.test.ts tests/openagents-autopilot-coder-studied-runtime.test.ts tests/openagents-studybench-eval-harness.test.ts`
- `bun run test:probe` (266 pass / 3 skip / 0 fail; rerun with loopback permission after sandbox-only `Bun.serve({ port: 0 })` failures)
- `git diff --check`
