### PR TITLE
Reuse short hash helper in StudyBench runners

### DIFF
--- a/packages/probe/packages/runtime/src/benchmark/candidate-execution.ts
+++ b/packages/probe/packages/runtime/src/benchmark/candidate-execution.ts
@@ -12,6 +12,7 @@ import {
 import { JsonValue, ProbePublicProjectionUnsafe, validateProbePublicProjection } from "../contracts/provider-account";
 import { makeProbeBenchmarkCloseoutBundle, type ProbeBenchmarkCloseoutBundle } from "./closeout-writer";
 import { type ProbeRetainedBenchmarkFixture, type ProbeBenchmarkToolMenuConstraints } from "./fixtures";
+import { shortHash } from "./stable-hash";
 
 export const PROBE_GEPA_CANDIDATE_MANIFEST_SCHEMA_VERSION = "psionic.probe_gepa_candidate_manifest.v1" as const;
 export const PROBE_GEPA_PROBE_IMPORT_SCHEMA_VERSION = "probe.prompt_candidate_import.v1" as const;
@@ -493,10 +494,6 @@ function containsUnsafeCandidateText(value: string): boolean {
 
 function defaultRunRef(taskId: string, candidateHash: string, baseline: boolean): string {
   return `probe_run.retained.${taskId}.${baseline ? "baseline" : shortHash(candidateHash)}`;
-}
-
-function shortHash(hash: string): string {
-  return hash.startsWith("sha256:") ? hash.slice("sha256:".length, "sha256:".length + 16) : hash.slice(0, 16);
 }
 
 function requireNonEmpty(value: string, path: string): Effect.Effect<void, ProbeBenchmarkCandidateExecutionError> {

--- a/packages/probe/packages/runtime/src/benchmark/studybench-answer-runner.ts
+++ b/packages/probe/packages/runtime/src/benchmark/studybench-answer-runner.ts
@@ -29,6 +29,7 @@ import {
   buildProbeStudybenchRubricScore,
   type ProbeStudybenchScoringMode,
 } from "./studybench-score";
+import { shortHash } from "./stable-hash";
 
 export const PROBE_STUDYBENCH_ANSWER_CANDIDATE_INPUT_SCHEMA_REF =
   "probe.studybench_answer_candidate_input.v0" as const;
@@ -298,10 +299,6 @@ function visibilityRefPart(visibility: OpenAgentsStudybenchTask["visibility"]): 
     case "openagents_private_holdout":
       return "private_holdout";
   }
-}
-
-function shortHash(value: string): string {
-  return value.replace(/^sha256:/, "").slice(0, 16);
 }
 
 function answerRunnerError(path: string, reason: string): Effect.Effect<never, ProbeStudybenchAnswerRunnerError> {

--- a/packages/probe/packages/runtime/src/benchmark/studybench-gepa-feedback.ts
+++ b/packages/probe/packages/runtime/src/benchmark/studybench-gepa-feedback.ts
@@ -15,6 +15,7 @@ import {
   validateProbeStudybenchScoreVector,
   type ProbeStudybenchScoringMode,
 } from "./studybench-score";
+import { shortHash } from "./stable-hash";
 
 export const PROBE_STUDYBENCH_GEPA_FEEDBACK_SCHEMA_REF =
   "probe.studybench_gepa_feedback.v0" as const;
@@ -160,10 +161,6 @@ function validateFeedbackRefs(
 
 function uniqueStrings(values: ReadonlyArray<string>): ReadonlyArray<string> {
   return [...new Set(values)];
-}
-
-function shortHash(value: string): string {
-  return value.replace(/^sha256:/, "").slice(0, 16);
 }
 
 function gepaFeedbackError(path: string, reason: string): Effect.Effect<never, ProbeBenchmarkContractError> {

--- a/packages/probe/packages/runtime/src/benchmark/studybench-patch-runner.ts
+++ b/packages/probe/packages/runtime/src/benchmark/studybench-patch-runner.ts
@@ -29,6 +29,7 @@ import {
   buildProbeStudybenchRubricScore,
   type ProbeStudybenchScoringMode,
 } from "./studybench-score";
+import { shortHash } from "./stable-hash";
 
 export const PROBE_STUDYBENCH_PATCH_CANDIDATE_INPUT_SCHEMA_REF =
   "probe.studybench_patch_candidate_input.v0" as const;
@@ -425,10 +426,6 @@ function requireNonEmptyRefs(
   return blankIndex === -1
     ? Effect.void
     : patchRunnerError(`${path}[${blankIndex}]`, "must be a non-empty ref");
-}
-
-function shortHash(value: string): string {
-  return value.replace(/^sha256:/, "").slice(0, 16);
 }
 
 function patchRunnerError(path: string, reason: string): Effect.Effect<never, ProbeStudybenchPatchRunnerError> {


### PR DESCRIPTION
## Summary

- Reuse the shared benchmark `shortHash` helper in four StudyBench runner/feedback modules.
- Remove local `shortHash` copies from:
  - `candidate-execution.ts`
  - `studybench-answer-runner.ts`
  - `studybench-gepa-feedback.ts`
  - `studybench-patch-runner.ts`
- Keep this separate from #5367 so each helper-consolidation slice stays small and easy to review.

## Verification

- `bun run --cwd packages/probe/packages/runtime test -- tests/studybench-answer-runner.test.ts tests/studybench-patch-runner.test.ts tests/studybench-gepa-feedback.test.ts tests/benchmark-candidate-execution.test.ts`
- `bun run test:probe` with loopback permission (266 pass / 3 skip / 0 fail)
- `git diff --check`
