### PR TITLE
Extract runtime receipt URL redaction

### DIFF
--- a/apps/pylon/packages/runtime/src/backends/apple-fm/receipts.ts
+++ b/apps/pylon/packages/runtime/src/backends/apple-fm/receipts.ts
@@ -1,4 +1,5 @@
 import { Schema as S } from "effect";
+import { redactReceiptUrl } from "../../receipt-redaction";
 import {
   APPLE_FM_BACKEND_KIND,
   type AppleFmUnavailableReason,
@@ -66,7 +67,7 @@ export function makeAppleFmAvailabilityReceipt(
     backendKind: APPLE_FM_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     ready: input.ready,
     unavailableReason: input.unavailableReason,
     message: input.message,
@@ -88,7 +89,7 @@ export function makeAppleFmFailureReceipt(input: {
     backendKind: APPLE_FM_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     failureClass: input.failureClass,
     message: input.message,
     observedAt: input.observedAt ?? new Date().toISOString(),
@@ -113,15 +114,4 @@ export function makeAppleFmTranscriptReceipt(input: {
   };
 }
 
-export function redactUrl(value: string): string {
-  try {
-    const url = new URL(value);
-    url.username = "";
-    url.password = "";
-    url.search = "";
-    url.hash = "";
-    return url.toString().replace(/\/$/, "");
-  } catch {
-    return "[redacted-invalid-url]";
-  }
-}
+export { redactReceiptUrl as redactUrl };

--- a/apps/pylon/packages/runtime/src/backends/gemini/receipts.ts
+++ b/apps/pylon/packages/runtime/src/backends/gemini/receipts.ts
@@ -1,5 +1,6 @@
 import { Schema as S } from "effect";
 import { ProbeLlmUsage } from "../../llm/usage";
+import { redactReceiptUrl } from "../../receipt-redaction";
 import { GEMINI_BACKEND_KIND } from "./contract";
 
 export const GeminiBackendAvailabilityReceipt = S.Struct({
@@ -71,7 +72,7 @@ export function makeGeminiAvailabilityReceipt(input: {
     backendKind: GEMINI_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     ready: input.ready,
     apiKeySource: input.apiKeySource,
     apiKeyRedacted: true,
@@ -95,7 +96,7 @@ export function makeGeminiFailureReceipt(input: {
     backendKind: GEMINI_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     failureClass: input.failureClass,
     message: input.message,
     observedAt: input.observedAt ?? new Date().toISOString(),
@@ -143,15 +144,4 @@ export function makeGeminiToolCallReceipt(input: {
   };
 }
 
-export function redactUrl(value: string): string {
-  try {
-    const url = new URL(value);
-    url.username = "";
-    url.password = "";
-    url.search = "";
-    url.hash = "";
-    return url.toString().replace(/\/$/, "");
-  } catch {
-    return "[redacted-invalid-url]";
-  }
-}
+export { redactReceiptUrl as redactUrl };

--- a/apps/pylon/packages/runtime/src/backends/psionic-qwen/receipts.ts
+++ b/apps/pylon/packages/runtime/src/backends/psionic-qwen/receipts.ts
@@ -1,5 +1,6 @@
 import { Schema as S } from "effect";
 import { ProbeLlmUsage } from "../../llm/usage";
+import { redactReceiptUrl } from "../../receipt-redaction";
 import { PSIONIC_QWEN_BACKEND_KIND } from "./contract";
 
 export const PsionicQwenAvailabilityReceipt = S.Struct({
@@ -74,7 +75,7 @@ export function makePsionicQwenAvailabilityReceipt(input: {
     backendKind: PSIONIC_QWEN_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     ready: input.ready,
     status: input.status,
     modelRefs: [...input.modelRefs],
@@ -99,7 +100,7 @@ export function makePsionicQwenFailureReceipt(input: {
     backendKind: PSIONIC_QWEN_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     failureClass: input.failureClass,
     message: input.message,
     observedAt: input.observedAt ?? new Date().toISOString(),
@@ -147,15 +148,4 @@ export function makePsionicQwenToolCallReceipt(input: {
   };
 }
 
-export function redactUrl(value: string): string {
-  try {
-    const url = new URL(value);
-    url.username = "";
-    url.password = "";
-    url.search = "";
-    url.hash = "";
-    return url.toString().replace(/\/$/, "");
-  } catch {
-    return "[redacted-invalid-url]";
-  }
-}
+export { redactReceiptUrl as redactUrl };

--- a/apps/pylon/packages/runtime/src/fleet/backend-capability.ts
+++ b/apps/pylon/packages/runtime/src/fleet/backend-capability.ts
@@ -1,7 +1,6 @@
 import { Effect, Schema as S } from "effect";
 import { makeAppleFmClient } from "../backends/apple-fm/client";
 import { APPLE_FM_BACKEND_KIND } from "../backends/apple-fm/contract";
-import { redactUrl } from "../backends/apple-fm/receipts";
 import { resolveGeminiApiKey } from "../backends/gemini/auth";
 import {
   GEMINI_API_PROFILE_ID,
@@ -18,6 +17,7 @@ import {
   type BlueprintProgramRegistryProjection as BlueprintProgramRegistryProjectionType,
 } from "../blueprint/contracts";
 import { STATIC_BLUEPRINT_PROGRAM_REGISTRY, STATIC_BLUEPRINT_REGISTRY_VERSION_REF } from "../blueprint/fixtures";
+import { redactReceiptUrl } from "../receipt-redaction";
 import { PROBE_APPLE_FM_BACKEND_CAPABILITY, type ProbeRunnerIdentity } from "../runner/identity";
 
 const APPLE_FM_BLUEPRINT_TOOL_PROJECTION_ADAPTER = "adapter.probe.apple_fm.blueprint_tools.v1" as const;
@@ -181,7 +181,7 @@ export function reportAppleFmBackendCapability(
           advertisedCapabilities,
           available: blueprintRunnable,
           status: readiness.ready && !blueprintRunnable ? "malformed" : readiness.status,
-          baseUrl: redactUrl(client.profile.baseUrl),
+          baseUrl: redactReceiptUrl(client.profile.baseUrl),
           platform: readiness.health?.platform,
           version: readiness.health?.version,
           unavailableReason:
@@ -303,7 +303,7 @@ export function reportGeminiBackendCapability(
           advertisedCapabilities: [PROBE_GEMINI_BACKEND_CAPABILITY],
           available: true,
           status: "ready" as const,
-          baseUrl: redactUrl(profile.baseUrl),
+          baseUrl: redactReceiptUrl(profile.baseUrl),
           requirements: {
             apiKey: "required" as const,
             liveHealth: "not_required" as const,
@@ -336,7 +336,7 @@ export function reportGeminiBackendCapability(
             advertisedCapabilities: [],
             available: false,
             status: "unavailable" as const,
-            baseUrl: redactUrl(profile.baseUrl),
+            baseUrl: redactReceiptUrl(profile.baseUrl),
             unavailableReason: "missing_credential",
             message: error.reason,
             requirements: {
@@ -375,7 +375,7 @@ export function reportGeminiBackendCapability(
         advertisedCapabilities: [],
         available: false,
         status: "malformed" as const,
-        baseUrl: redactUrl(GEMINI_DEFAULT_BASE_URL),
+        baseUrl: redactReceiptUrl(GEMINI_DEFAULT_BASE_URL),
         unavailableReason: "malformed_backend_profile",
         message: "Gemini backend capability profile could not be resolved",
         requirements: {

--- a/apps/pylon/packages/runtime/src/receipt-redaction.ts
+++ b/apps/pylon/packages/runtime/src/receipt-redaction.ts
@@ -1,0 +1,12 @@
+export function redactReceiptUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return "[redacted-invalid-url]";
+  }
+}

--- a/packages/probe/packages/runtime/src/backends/apple-fm/receipts.ts
+++ b/packages/probe/packages/runtime/src/backends/apple-fm/receipts.ts
@@ -1,4 +1,5 @@
 import { Schema as S } from "effect";
+import { redactReceiptUrl } from "../../receipt-redaction";
 import {
   APPLE_FM_BACKEND_KIND,
   type AppleFmUnavailableReason,
@@ -66,7 +67,7 @@ export function makeAppleFmAvailabilityReceipt(
     backendKind: APPLE_FM_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     ready: input.ready,
     unavailableReason: input.unavailableReason,
     message: input.message,
@@ -88,7 +89,7 @@ export function makeAppleFmFailureReceipt(input: {
     backendKind: APPLE_FM_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     failureClass: input.failureClass,
     message: input.message,
     observedAt: input.observedAt ?? new Date().toISOString(),
@@ -113,15 +114,4 @@ export function makeAppleFmTranscriptReceipt(input: {
   };
 }
 
-export function redactUrl(value: string): string {
-  try {
-    const url = new URL(value);
-    url.username = "";
-    url.password = "";
-    url.search = "";
-    url.hash = "";
-    return url.toString().replace(/\/$/, "");
-  } catch {
-    return "[redacted-invalid-url]";
-  }
-}
+export { redactReceiptUrl as redactUrl };

--- a/packages/probe/packages/runtime/src/backends/gemini/receipts.ts
+++ b/packages/probe/packages/runtime/src/backends/gemini/receipts.ts
@@ -1,5 +1,6 @@
 import { Schema as S } from "effect";
 import { ProbeLlmUsage } from "../../llm/usage";
+import { redactReceiptUrl } from "../../receipt-redaction";
 import { GEMINI_BACKEND_KIND } from "./contract";
 
 export const GeminiBackendAvailabilityReceipt = S.Struct({
@@ -71,7 +72,7 @@ export function makeGeminiAvailabilityReceipt(input: {
     backendKind: GEMINI_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     ready: input.ready,
     apiKeySource: input.apiKeySource,
     apiKeyRedacted: true,
@@ -95,7 +96,7 @@ export function makeGeminiFailureReceipt(input: {
     backendKind: GEMINI_BACKEND_KIND,
     profileId: input.profileId,
     model: input.model,
-    baseUrl: redactUrl(input.baseUrl),
+    baseUrl: redactReceiptUrl(input.baseUrl),
     failureClass: input.failureClass,
     message: input.message,
     observedAt: input.observedAt ?? new Date().toISOString(),
@@ -143,15 +144,4 @@ export function makeGeminiToolCallReceipt(input: {
   };
 }
 
-export function redactUrl(value: string): string {
-  try {
-    const url = new URL(value);
-    url.username = "";
-    url.password = "";
-    url.search = "";
-    url.hash = "";
-    return url.toString().replace(/\/$/, "");
-  } catch {
-    return "[redacted-invalid-url]";
-  }
-}
+export { redactReceiptUrl as redactUrl };

--- a/packages/probe/packages/runtime/src/fleet/backend-capability.ts
+++ b/packages/probe/packages/runtime/src/fleet/backend-capability.ts
@@ -1,7 +1,6 @@
 import { Effect, Schema as S } from "effect";
 import { makeAppleFmClient } from "../backends/apple-fm/client";
 import { APPLE_FM_BACKEND_KIND } from "../backends/apple-fm/contract";
-import { redactUrl } from "../backends/apple-fm/receipts";
 import { resolveGeminiApiKey } from "../backends/gemini/auth";
 import {
   GEMINI_API_PROFILE_ID,
@@ -18,6 +17,7 @@ import {
   type BlueprintProgramRegistryProjection as BlueprintProgramRegistryProjectionType,
 } from "../blueprint/contracts";
 import { STATIC_BLUEPRINT_PROGRAM_REGISTRY, STATIC_BLUEPRINT_REGISTRY_VERSION_REF } from "../blueprint/fixtures";
+import { redactReceiptUrl } from "../receipt-redaction";
 import { PROBE_APPLE_FM_BACKEND_CAPABILITY, type ProbeRunnerIdentity } from "../runner/identity";
 
 const APPLE_FM_BLUEPRINT_TOOL_PROJECTION_ADAPTER = "adapter.probe.apple_fm.blueprint_tools.v1" as const;
@@ -181,7 +181,7 @@ export function reportAppleFmBackendCapability(
           advertisedCapabilities,
           available: blueprintRunnable,
           status: readiness.ready && !blueprintRunnable ? "malformed" : readiness.status,
-          baseUrl: redactUrl(client.profile.baseUrl),
+          baseUrl: redactReceiptUrl(client.profile.baseUrl),
           platform: readiness.health?.platform,
           version: readiness.health?.version,
           unavailableReason:
@@ -303,7 +303,7 @@ export function reportGeminiBackendCapability(
           advertisedCapabilities: [PROBE_GEMINI_BACKEND_CAPABILITY],
           available: true,
           status: "ready" as const,
-          baseUrl: redactUrl(profile.baseUrl),
+          baseUrl: redactReceiptUrl(profile.baseUrl),
           requirements: {
             apiKey: "required" as const,
             liveHealth: "not_required" as const,
@@ -336,7 +336,7 @@ export function reportGeminiBackendCapability(
             advertisedCapabilities: [],
             available: false,
             status: "unavailable" as const,
-            baseUrl: redactUrl(profile.baseUrl),
+            baseUrl: redactReceiptUrl(profile.baseUrl),
             unavailableReason: "missing_credential",
             message: error.reason,
             requirements: {
@@ -375,7 +375,7 @@ export function reportGeminiBackendCapability(
         advertisedCapabilities: [],
         available: false,
         status: "malformed" as const,
-        baseUrl: redactUrl(GEMINI_DEFAULT_BASE_URL),
+        baseUrl: redactReceiptUrl(GEMINI_DEFAULT_BASE_URL),
         unavailableReason: "malformed_backend_profile",
         message: "Gemini backend capability profile could not be resolved",
         requirements: {

--- a/packages/probe/packages/runtime/src/receipt-redaction.ts
+++ b/packages/probe/packages/runtime/src/receipt-redaction.ts
@@ -1,0 +1,12 @@
+export function redactReceiptUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return "[redacted-invalid-url]";
+  }
+}


### PR DESCRIPTION
## Summary
- add package-local `redactReceiptUrl` helpers for Probe runtime and Pylon runtime receipts
- replace five copied backend `redactUrl` implementations while preserving the receipt-module `redactUrl` export alias
- remove the accidental fleet capability dependency on Apple FM receipts for generic Gemini/Apple URL redaction

## Measured shape
- 9 files changed
- 54 insertions / 80 deletions
- 5 duplicated redaction function bodies removed

## Verification
- `bun run --cwd packages/probe/packages/runtime test` (266 pass / 3 skip / 0 fail)
- `bun run --cwd apps/pylon/packages/runtime test` (224 pass / 3 skip / 0 fail)
- `bun run --cwd apps/pylon test` (1289 pass / 3 skip / 0 fail)
- `git diff --check`

## Notes
The first sandboxed focused run hit the known `Bun.serve({ port: 0 })` loopback `EADDRINUSE`; the same focused slices and full suites passed with loopback permission.