### PR TITLE
Extract Adjutant route method guard

### DIFF
--- a/apps/openagents.com/workers/api/src/operator-adjutant-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-adjutant-routes.test.ts
@@ -2327,6 +2327,49 @@ const attachApprovedOtecResearch = (
 }
 
 describe('operator Adjutant assignment API routes', () => {
+  test('rejects unsupported methods before session work', async () => {
+    const store = new OperatorAdjutantDbStore()
+    const assignGetResponse = await runRoute(
+      null,
+      store,
+      new Request(
+        'https://openagents.com/api/operator/adjutant/orders/software_order_otec/assign',
+        { method: 'GET' },
+      ),
+    )
+    const listPostResponse = await runRoute(
+      adminSession,
+      store,
+      new Request('https://openagents.com/api/operator/adjutant/assignments', {
+        method: 'POST',
+      }),
+    )
+    const researchPatchResponse = await runRoute(
+      null,
+      store,
+      new Request(
+        'https://openagents.com/api/operator/adjutant/assignments/assignment_otec/research-policy',
+        { method: 'PATCH' },
+      ),
+    )
+
+    expect(assignGetResponse.status).toBe(405)
+    expect(assignGetResponse.headers.get('allow')).toBe('POST')
+    await expect(assignGetResponse.json()).resolves.toEqual({
+      error: 'method_not_allowed',
+    })
+    expect(listPostResponse.status).toBe(405)
+    expect(listPostResponse.headers.get('allow')).toBe('GET')
+    await expect(listPostResponse.json()).resolves.toEqual({
+      error: 'method_not_allowed',
+    })
+    expect(researchPatchResponse.status).toBe(405)
+    expect(researchPatchResponse.headers.get('allow')).toBe('GET, POST')
+    await expect(researchPatchResponse.json()).resolves.toEqual({
+      error: 'method_not_allowed',
+    })
+  })
+
   test('returns unauthorized without a browser session', async () => {
     const response = await runRoute(
       null,

--- a/apps/openagents.com/workers/api/src/operator-adjutant-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-adjutant-routes.ts
@@ -1216,18 +1216,33 @@ const readOperatorGitHubIdentityToken = async (
   }
 }
 
+const rejectUnlessMethod = (
+  request: Request,
+  allowedMethods: readonly string[],
+): HttpResponse | null =>
+  allowedMethods.includes(request.method)
+    ? null
+    : methodNotAllowed([...allowedMethods])
+
 const runRoute = (
   env: OperatorAdjutantEnv,
+  request: Request,
+  allowedMethods: readonly string[],
   effect: Effect.Effect<
     HttpResponse,
     OperatorAdjutantRouteError,
     AdjutantAssignmentService
   >,
-): Effect.Effect<HttpResponse> =>
-  effect.pipe(
-    Effect.provide(AdjutantAssignmentService.layer(env)),
-    Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
-  )
+): Effect.Effect<HttpResponse> => {
+  const methodRejection = rejectUnlessMethod(request, allowedMethods)
+
+  return methodRejection === null
+    ? effect.pipe(
+        Effect.provide(AdjutantAssignmentService.layer(env)),
+        Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
+      )
+    : Effect.succeed(methodRejection)
+}
 
 const preflightD1Effect = <A>(
   operation: string,
@@ -4488,11 +4503,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -4527,11 +4540,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -4561,11 +4572,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['GET'],
       Effect.gen(function* () {
-        if (request.method !== 'GET') {
-          return methodNotAllowed(['GET'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -4590,11 +4599,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['GET'],
       Effect.gen(function* () {
-        if (request.method !== 'GET') {
-          return methodNotAllowed(['GET'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -4625,11 +4632,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['GET'],
       Effect.gen(function* () {
-        if (request.method !== 'GET') {
-          return methodNotAllowed(['GET'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -4660,11 +4665,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -4752,11 +4755,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['GET', 'POST'],
       Effect.gen(function* () {
-        if (request.method !== 'GET' && request.method !== 'POST') {
-          return methodNotAllowed(['GET', 'POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -4823,11 +4824,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -4867,11 +4866,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5066,11 +5063,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5123,11 +5118,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5177,11 +5170,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5265,11 +5256,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5388,11 +5377,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5501,11 +5488,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5624,11 +5609,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5684,11 +5667,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -5798,11 +5779,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -6093,11 +6072,9 @@ export const makeOperatorAdjutantRoutes = <
   ) =>
     runRoute(
       env,
+      request,
+      ['POST'],
       Effect.gen(function* () {
-        if (request.method !== 'POST') {
-          return methodNotAllowed(['POST'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,


### PR DESCRIPTION
## Summary
- centralize Operator Adjutant route method checks in `rejectUnlessMethod`
- pass the allowed-method contract through `runRoute` so route handlers stay focused on session/operation logic
- add a regression test proving unsupported methods return 405 before session work

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/operator-adjutant-routes.test.ts` (44 passed)
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`

## #5335 receipt note
This is a scoped hygiene/refactoring receipt for #5335. It is submitted under the adopted lane rule that merge is technical acceptance; payment/settlement status remains separate until the owner-funded settlement authority records receipt refs.