### PR TITLE
Clarify hygiene settlement states

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1054,6 +1054,12 @@ This is the invariant ledger for `openagents`.
   convert it into a funded receipt before payout eligibility exists.
 - Workers must not receive spend authority, settlement authority, deployment
   authority, or authority to mint payable follow-up debt from their own work.
+- Merged PRs, review approvals, and verifier passes are accepted-work evidence
+  only. Without an owner-funded receipt or approved batch plus settlement
+  authority, accepted hygiene work is recognition/credit-class work, not a
+  pending Bitcoin payout. `payable_pending_settlement` requires settlement
+  approval or escrow/payout processing evidence, and `settled_bitcoin` requires
+  settlement receipt refs.
 - Payment follows verified delta, not churn: behavior or benchmark parity must
   be green, the named hygiene metric must improve, and no equal-or-worse debt
   may be introduced elsewhere in the scoped receipt.

--- a/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
+++ b/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
@@ -77,6 +77,31 @@ Every payable receipt needs these public-safe refs:
 - settlement approval: separate from the worker;
 - settlement receipt: required before calling it paid or settled.
 
+## Acceptance And Settlement States
+
+Use distinct labels for the lane state. Collapsing them makes workers think a
+merged cleanup is already money, and makes reviewers look like settlement
+authorities.
+
+- `discovery`: a worker, churn probe, buyer, or reviewer found debt. This is
+  inventory, not spend.
+- `accepted_verified`: a reviewer or verifier accepted the patch and evidence.
+  A merged PR can be accepted-work evidence, but it is not payout authority.
+- `credit_class`: accepted and credited work where no owner-funded hygiene-lane
+  settlement path has been armed. This is recognition, not a pending Bitcoin
+  payout.
+- `payable_class`: accepted work against an owner-approved funded receipt or
+  batch. The receipt has a budget cap, verifier, and settlement authority, but
+  the worker still must not call it paid.
+- `payable_pending_settlement`: settlement authority has approved release or
+  escrow/payout processing, and settlement refs are expected but not complete.
+- `settled`: settlement refs exist. Only this state may be described as paid
+  or settled.
+
+Funding may be per receipt, or a named batch such as
+`#5335 hygiene batch N`. A batch still needs an approved target list, budget
+cap, verifier command, per-PR acceptance evidence, and one settlement closeout.
+
 ## Typed Fingerprint Keys
 
 Invariant #6 of the debt-receipt invariants (dup/novelty fingerprint) is made


### PR DESCRIPTION
## Summary
- document the #5335 hygiene-lane state ladder: discovery, accepted_verified, credit_class, payable_class, payable_pending_settlement, settled
- state explicitly that merged PRs and verifier passes are accepted-work evidence, not payout authority
- record the batch-funding shape discussed on #5335 / the Forum: approved target list, budget cap, verifier command, per-PR acceptance evidence, and settlement closeout

## Verification
- `git diff --check`

## Process note
This codifies the adopted lane rule that merge/review is technical acceptance, while payment/settlement requires owner-funded settlement authority and receipt refs.