### PR TITLE
Support forum CLI credential files

### DIFF
--- a/apps/openagents.com/scripts/forum.mjs
+++ b/apps/openagents.com/scripts/forum.mjs
@@ -24,6 +24,7 @@ export const usage = () => `Usage:
   OPENAGENTS_AGENT_TOKEN=oa_agent_... node scripts/forum.mjs mark-notification-read --notification NOTIFICATION_ID
   OPENAGENTS_AGENT_TOKEN=oa_agent_... node scripts/forum.mjs create-topic --forum site-builder-help --title "Title" --body "Public-safe body"
   OPENAGENTS_AGENT_TOKEN=oa_agent_... node scripts/forum.mjs reply --topic TOPIC_ID --body "Public-safe reply"
+  node scripts/forum.mjs reply --credential-file ./agent.json --topic TOPIC_ID --body "Public-safe reply"
   OPENAGENTS_AGENT_TOKEN=oa_agent_... node scripts/forum.mjs edit-post --post POST_ID --body "Updated public-safe body"
   OPENAGENTS_AGENT_TOKEN=oa_agent_... node scripts/forum.mjs tombstone-post --post POST_ID [--reason author_request]
   OPENAGENTS_AGENT_TOKEN=oa_agent_... node scripts/forum.mjs report-post --post POST_ID --reason off_topic
@@ -99,6 +100,8 @@ Options:
   --context-slug <slug>     Optional public-safe context slug.
   --context-url <url>       Optional public context URL.
   --context-source <ref>    Optional public-safe source ref.
+  --credential-file <path>  Read an agent token/apiKey from local JSON. Supports
+                            apiKey, token, agentToken, or OPENAGENTS_AGENT_TOKEN.
   --idempotency-key <key>   Override the generated stable write key.
 `
 
@@ -132,6 +135,8 @@ const valueFlags = new Set([
   'contextUrl',
   'custody-policy-ref',
   'custodyPolicyRef',
+  'credential-file',
+  'credentialFile',
   'cursor',
   'forum',
   'idempotency-key',
@@ -234,6 +239,7 @@ const canonicalFlagName = name =>
     contextSource: 'context-source',
     contextTitle: 'context-title',
     contextUrl: 'context-url',
+    credentialFile: 'credential-file',
     custodyPolicyRef: 'custody-policy-ref',
     h: 'help',
     idempotencyKey: 'idempotency-key',
@@ -467,8 +473,66 @@ const requestBodyDigestFor = (flags, kind, parts) =>
 
 const requireAgentToken = (token, command) => {
   if (token === undefined || token.trim() === '') {
-    throw new Error(`OPENAGENTS_AGENT_TOKEN is required for ${command}.`)
+    throw new Error(
+      `OPENAGENTS_AGENT_TOKEN or --credential-file is required for ${command}.`,
+    )
   }
+}
+
+const credentialTokenKeys = [
+  'apiKey',
+  'token',
+  'agentToken',
+  'OPENAGENTS_AGENT_TOKEN',
+]
+
+export const agentTokenFromCredentialFile = async path => {
+  const raw = await readFile(path, 'utf8')
+  const decoded = JSON.parse(raw)
+
+  if (
+    decoded === null ||
+    typeof decoded !== 'object' ||
+    Array.isArray(decoded)
+  ) {
+    throw new Error('--credential-file must contain a JSON object.')
+  }
+
+  for (const key of credentialTokenKeys) {
+    const value = decoded[key]
+
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value
+    }
+  }
+
+  throw new Error(
+    '--credential-file must contain apiKey, token, agentToken, or OPENAGENTS_AGENT_TOKEN.',
+  )
+}
+
+const resolvedAgentToken = async (flags, env = process.env) => {
+  const credentialFile =
+    flagText(flags, 'credential-file') ||
+    env.OPENAGENTS_AGENT_CREDENTIAL_FILE ||
+    ''
+
+  if (credentialFile.trim() !== '') {
+    return agentTokenFromCredentialFile(credentialFile)
+  }
+
+  return env.OPENAGENTS_AGENT_TOKEN
+}
+
+const envWithResolvedAgentToken = async (flags, env = process.env) => {
+  const token = await resolvedAgentToken(flags, env)
+
+  return token === env.OPENAGENTS_AGENT_TOKEN
+    ? env
+    : {
+        ...env,
+        OPENAGENTS_AGENT_TOKEN: token,
+      }
 }
 
 const normalizedSpendCapAsset = asset => {
@@ -2163,7 +2227,7 @@ export const buildForumRequest = async (parsed, env = process.env) => {
     env.OPENAGENTS_BASE_URL ||
     DEFAULT_BASE_URL
   ).replace(/\/+$/, '')
-  const token = env.OPENAGENTS_AGENT_TOKEN
+  const token = await resolvedAgentToken(parsed.flags, env)
   const includeUnlisted = parsed.flags.get('include-unlisted') === true
   const readHeaders = includeUnlisted ? authHeaders(token) : {}
   const authedReadHeaders = token === undefined ? {} : authHeaders(token)
@@ -3361,37 +3425,46 @@ export const runForumDirectTipPostSmoke = async (
 
 export const runForumCli = async (argv, env = process.env, options = {}) => {
   const parsed = parseForumArgs(argv)
+  const resolvedEnv = await envWithResolvedAgentToken(parsed.flags, env)
 
   if (parsed.command === 'wallet-status') {
     const result = await runForumWalletPreflight({
       executor: options.walletExecutor,
       spendCap: spendCapFromFlags(parsed.flags),
       timeoutMs: walletTimeoutMsFromFlags(parsed.flags),
-      walletNetwork: walletNetworkFromFlags(parsed.flags, env),
+      walletNetwork: walletNetworkFromFlags(parsed.flags, resolvedEnv),
     })
 
     return `${JSON.stringify(result, null, 2)}\n`
   }
 
   if (parsed.command === 'pay-reward-post') {
-    const result = await runForumRewardPostPayment(parsed, env, options)
+    const result = await runForumRewardPostPayment(parsed, resolvedEnv, options)
 
     return `${JSON.stringify(result, null, 2)}\n`
   }
 
   if (parsed.command === 'tip-post') {
-    const result = await runForumDirectTipPostPayment(parsed, env, options)
+    const result = await runForumDirectTipPostPayment(
+      parsed,
+      resolvedEnv,
+      options,
+    )
 
     return `${JSON.stringify(result, null, 2)}\n`
   }
 
   if (parsed.command === 'tip-post-smoke') {
-    const result = await runForumDirectTipPostSmoke(parsed, env, options)
+    const result = await runForumDirectTipPostSmoke(
+      parsed,
+      resolvedEnv,
+      options,
+    )
 
     return `${JSON.stringify(result, null, 2)}\n`
   }
 
-  const request = await buildForumRequest(parsed, env)
+  const request = await buildForumRequest(parsed, resolvedEnv)
 
   if (request.help) {
     return usage()

--- a/apps/openagents.com/scripts/forum.test.ts
+++ b/apps/openagents.com/scripts/forum.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, test, vi } from 'vitest'
 
 const forumCli = await import('./forum.mjs')
@@ -89,6 +92,45 @@ describe('forum CLI helpers', () => {
     )
     expect(JSON.stringify(summary)).not.toContain('oa_agent_secret_123')
     expect(summary.headers.authorization).toBe('Bearer <redacted>')
+  })
+
+  test('reads an agent apiKey from a local credential file for replies', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openagents-forum-cli-'))
+    const credentialFile = join(dir, 'agent.json')
+
+    try {
+      await writeFile(
+        credentialFile,
+        JSON.stringify({
+          apiKey: 'test_agent_token_from_file',
+          displayName: 'Local Agent',
+        }),
+      )
+      const parsed = forumCli.parseForumArgs([
+        'reply',
+        '--credential-file',
+        credentialFile,
+        '--topic',
+        'topic_1',
+        '--body',
+        'Public-safe reply from file auth.',
+      ])
+      const request = await forumCli.buildForumRequest(parsed, {})
+      const summary = forumCli.safeRequestSummary(request)
+
+      expect(request.method).toBe('POST')
+      expect(request.path).toBe('/api/forum/topics/topic_1/posts')
+      expect(request.headers.authorization).toBe(
+        'Bearer test_agent_token_from_file',
+      )
+      expect(request.headers['idempotency-key']).toMatch(
+        /^forum-reply-[a-f0-9]{32}$/,
+      )
+      expect(JSON.stringify(summary)).not.toContain('test_agent_token_from_file')
+      expect(summary.headers.authorization).toBe('Bearer <redacted>')
+    } finally {
+      await rm(dir, { force: true, recursive: true })
+    }
   })
 
   test('builds a self-claim tip wallet request with repeated public readiness refs', async () => {
@@ -198,7 +240,7 @@ describe('forum CLI helpers', () => {
     ])
 
     await expect(forumCli.buildForumRequest(parsed, {})).rejects.toThrow(
-      'OPENAGENTS_AGENT_TOKEN is required for reply.',
+      'OPENAGENTS_AGENT_TOKEN or --credential-file is required for reply.',
     )
   })
 


### PR DESCRIPTION
## Summary
- extend the existing `apps/openagents.com/scripts/forum.mjs` CLI with `--credential-file` and `OPENAGENTS_AGENT_CREDENTIAL_FILE`
- support local JSON credentials with `apiKey`, `token`, `agentToken`, or `OPENAGENTS_AGENT_TOKEN`
- route the resolved token through normal authenticated commands while keeping request summaries redacted
- add coverage for reply request construction from a temp credential file

## Verification
- `bun run --cwd apps/openagents.com vitest run scripts/forum.test.ts` (40 passed)
- `git diff --check`
- live smoke: `node scripts/forum.mjs topic --credential-file <local-agent-json> --topic e2c69ba6-94ba-483e-98c0-4052e46d950f` exited 0

## Credential note
No personal token, local credential path, wallet material, or forum secret is included in this PR. The credential file is supplied only at runtime.