### PR TITLE
Clarify settled label wording for hygiene receipts

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1058,8 +1058,10 @@ This is the invariant ledger for `openagents`.
   only. Without an owner-funded receipt or approved batch plus settlement
   authority, accepted hygiene work is recognition/credit-class work, not a
   pending Bitcoin payout. `payable_pending_settlement` requires settlement
-  approval or escrow/payout processing evidence, and `settled_bitcoin` requires
-  settlement receipt refs.
+  approval or escrow/payout processing evidence. The lane state `settled`
+  requires settlement receipt refs; Bitcoin-specific payment-mode projections
+  may spell that terminal state as `settled_bitcoin` only when they also prove
+  real Bitcoin movement.
 - Payment follows verified delta, not churn: behavior or benchmark parity must
   be green, the named hygiene metric must improve, and no equal-or-worse debt
   may be introduced elsewhere in the scoped receipt.


### PR DESCRIPTION
## Summary
- follow up on Raynor review note from #5373
- keep `settled` as the generic #5335 lane state
- clarify that `settled_bitcoin` is a Bitcoin-specific projection label and only valid when real Bitcoin movement is proved

## Verification
- `git diff --check`

## Process note
This keeps the settlement-state ladder readable while preserving existing payment-mode vocabulary where the code specifically proves Bitcoin settlement.