### PR TITLE
Centralize site referral inspection method guard

### DIFF
--- a/apps/openagents.com/workers/api/src/site-referral-inspection-routes.ts
+++ b/apps/openagents.com/workers/api/src/site-referral-inspection-routes.ts
@@ -141,11 +141,15 @@ const readLimit = (request: Request): number => {
 }
 
 const runRoute = (
+  request: Request,
+  allowedMethods: readonly string[],
   effect: Effect.Effect<HttpResponse, SiteReferralInspectionRouteError>,
 ): Effect.Effect<HttpResponse> =>
-  effect.pipe(
-    Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
-  )
+  allowedMethods.includes(request.method)
+    ? effect.pipe(
+        Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
+      )
+    : Effect.succeed(methodNotAllowed([...allowedMethods]))
 
 export const makeSiteReferralInspectionRoutes = <
   Session extends SiteReferralInspectionSession,
@@ -159,11 +163,9 @@ export const makeSiteReferralInspectionRoutes = <
     ctx: ExecutionContext,
   ) =>
     runRoute(
+      request,
+      ['GET'],
       Effect.gen(function* () {
-        if (request.method !== 'GET') {
-          return methodNotAllowed(['GET'])
-        }
-
         const session = yield* requireSession(dependencies, request, env, ctx)
         const overview = yield* Effect.tryPromise({
           catch: error =>
@@ -194,11 +196,9 @@ export const makeSiteReferralInspectionRoutes = <
     ctx: ExecutionContext,
   ) =>
     runRoute(
+      request,
+      ['GET'],
       Effect.gen(function* () {
-        if (request.method !== 'GET') {
-          return methodNotAllowed(['GET'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,
@@ -233,11 +233,9 @@ export const makeSiteReferralInspectionRoutes = <
     ctx: ExecutionContext,
   ) =>
     runRoute(
+      request,
+      ['GET'],
       Effect.gen(function* () {
-        if (request.method !== 'GET') {
-          return methodNotAllowed(['GET'])
-        }
-
         const session = yield* requireAdminSession(
           dependencies,
           request,

--- a/apps/openagents.com/workers/api/src/site-referral-inspection.test.ts
+++ b/apps/openagents.com/workers/api/src/site-referral-inspection.test.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import {
   readOperatorSiteReferralInspection,
@@ -260,7 +260,10 @@ const siteReferralInspectionDb = (
   },
 })
 
-const makeRoutes = (session: TestSession | null) =>
+const makeRoutes = (
+  session: TestSession | null,
+  requireBrowserSession = () => Promise.resolve(session ?? undefined),
+) =>
   makeSiteReferralInspectionRoutes({
     appendRefreshedSessionCookies: response => {
       response.headers.set('x-session-refreshed', 'true')
@@ -268,7 +271,7 @@ const makeRoutes = (session: TestSession | null) =>
       return response
     },
     isOpenAgentsAdminEmail: email => email === 'admin@openagents.com',
-    requireBrowserSession: () => Promise.resolve(session ?? undefined),
+    requireBrowserSession,
   })
 
 const runRoute = (
@@ -368,6 +371,37 @@ describe('Site referral inspection projections', () => {
 })
 
 describe('Site referral inspection routes', () => {
+  test('rejects unsupported methods before session lookup', async () => {
+    const requireBrowserSession = vi.fn(() =>
+      Promise.resolve({
+        user: {
+          email: 'admin@openagents.com',
+          userId: 'github:admin',
+        },
+      }),
+    )
+    const response = await Effect.runPromise(
+      makeRoutes(null, requireBrowserSession).routeSiteReferralInspectionRequest(
+        new Request('https://openagents.com/api/sites/referrals/overview', {
+          method: 'POST',
+        }),
+        {
+          OPENAGENTS_DB: siteReferralInspectionDb(
+            new SiteReferralInspectionStore(),
+          ),
+        },
+        executionContext(),
+      )!,
+    )
+
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('GET')
+    await expect(response.json()).resolves.toEqual({
+      error: 'method_not_allowed',
+    })
+    expect(requireBrowserSession).not.toHaveBeenCalled()
+  })
+
   test('requires a browser session for owner overview', async () => {
     const response = await runRoute(
       new Request('https://openagents.com/api/sites/referrals/overview'),


### PR DESCRIPTION
## Summary
- pass allowed methods through the site referral inspection `runRoute` helper
- remove three repeated GET-only guards from route handlers
- add a regression proving unsupported methods return 405 before browser-session lookup

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/site-referral-inspection.test.ts` (8 passed)
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`

## #5335 receipt note
Small route-boundary hygiene receipt: no behavior change intended beyond preserving method-first rejection in one shared helper.