### PR TITLE
Ignore local OpenAgents agent credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .env
 .env.*
 !.env.example
+.openagents-*-agent.json
+.openagents-agent.json
 .secrets/
 .pylon*/
 node_modules/


### PR DESCRIPTION
## Summary

- ignore local OpenAgents agent credential files (`.openagents-*-agent.json`, `.openagents-agent.json`)
- keeps Forum/API identity tokens out of status and commits if copied into a worktree

## Verification

- `git check-ignore -v .openagents-trigger-agent.json .openagents-agent.json`
- `git diff --check`
