### PR TITLE
Hash hygiene settlement idempotency refs

### DIFF
--- a/apps/openagents.com/workers/api/src/hygiene-lane-settlement-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-lane-settlement-routes.test.ts
@@ -1,6 +1,7 @@
 import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import { sha256Hex } from './agent-registration'
 import { deriveDebtReceiptKey } from './debt-receipt-key'
 import {
   type DebtReceiptSettlementInput,
@@ -362,6 +363,41 @@ describe('POST /api/hygiene-lane/settlement-receipt (honest dispatch, #5372)', (
         receipt => receipt.receiptKind === 'settlement_recorded',
       ),
     ).toHaveLength(1)
+  })
+
+  it('hashes idempotency refs before deriving settlement receipt refs', async () => {
+    const commonPrefix = `idem.${'a'.repeat(160)}`
+    const firstIdempotencyRef = `${commonPrefix}.first`
+    const secondIdempotencyRef = `${commonPrefix}.second`
+
+    const receiptRefFor = async (idempotencyRef: string): Promise<string> => {
+      const routes = makeRoutes()
+      const response = await runRoute(
+        routes.routeHygieneLaneSettlementRequest(
+          jsonRequest(settlementBody({ idempotencyRef })),
+          {},
+        ),
+      )
+
+      expect(response.status).toBe(200)
+      const json = (await response.json()) as {
+        settlement: { settlementReceiptRef: string }
+      }
+
+      return json.settlement.settlementReceiptRef
+    }
+
+    const firstReceiptRef = await receiptRefFor(firstIdempotencyRef)
+    const secondReceiptRef = await receiptRefFor(secondIdempotencyRef)
+
+    expect(firstReceiptRef).not.toBe(secondReceiptRef)
+    expect(firstReceiptRef).toContain(
+      `sha256_${(await sha256Hex(firstIdempotencyRef)).slice(0, 32)}`,
+    )
+    expect(secondReceiptRef).toContain(
+      `sha256_${(await sha256Hex(secondIdempotencyRef)).slice(0, 32)}`,
+    )
+    expect(firstReceiptRef).not.toContain(commonPrefix.slice(0, 120))
   })
 
   it('a duplicate-replay debt receipt is never payable (one settlement per key, #5340)', async () => {

--- a/apps/openagents.com/workers/api/src/hygiene-lane-settlement-routes.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-lane-settlement-routes.ts
@@ -1,5 +1,6 @@
 import { Effect, Match as M, Schema as S } from 'effect'
 
+import { sha256Hex } from './agent-registration'
 import { DebtReceiptKeyInput } from './debt-receipt-key'
 import {
   type DebtReceiptSettlementInput,
@@ -336,12 +337,16 @@ const routeHygieneLaneSettlement = <
     // 'none'); on the real branch it is `spark_treasury` (moneyMovement
     // 'real_bitcoin'). The resolved adapter — not the raw request — drives the
     // builder, so the simulation path never claims real money.
+    const idempotencyDigestHex = yield* Effect.tryPromise({
+      catch: trainingAuthorityStoreErrorFromUnknown,
+      try: () => sha256Hex(body.idempotencyRef),
+    })
     const settlement = buildHygieneLaneSettlement({
       adapterKind: decision.gateDecision?.adapterKind ?? 'simulation',
       amountSats: decision.amount.payoutSats,
       contributorRef: body.contributorRef,
       debtReceiptKeyRef: body.debtReceiptKeyRef,
-      idempotencyRef: body.idempotencyRef,
+      idempotencyDigestHex,
       mergedPrRef: body.mergedPrRef,
       nowIso,
       operatorApprovalRef: body.operatorApprovalRef,

--- a/apps/openagents.com/workers/api/src/hygiene-lane-settlement.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-lane-settlement.ts
@@ -467,7 +467,7 @@ export const buildHygieneLaneSettlement = (
     amountSats: number
     contributorRef: string
     debtReceiptKeyRef: string
-    idempotencyRef: string
+    idempotencyDigestHex: string
     mergedPrRef: string
     nowIso: string
     operatorApprovalRef: string
@@ -479,9 +479,11 @@ export const buildHygieneLaneSettlement = (
 ): HygieneLaneSettlementRecords => {
   const adapterKind = input.adapterKind
   const moneyMovement = realSettlementMovementMode(adapterKind)
-  const suffix = stableSuffix(input.idempotencyRef)
+  const suffix = stableSuffix(`sha256_${input.idempotencyDigestHex}`)
   const contributorRef = input.contributorRef.trim()
   const amount = bitcoinAmount(input.amountSats)
+  const idempotencyHash = (stage: string): string =>
+    `hash.hygiene_lane_settlement.${stage}.${input.idempotencyDigestHex}`
   // The accepted-work basis is the HONEST hygiene evidence: merged PR + reviewer
   // acceptance + the debt receipt. No verification-challenge ref appears.
   const acceptedWorkRefs = uniqueRefs([
@@ -509,7 +511,7 @@ export const buildHygieneLaneSettlement = (
     createdAt: input.nowIso,
     expiresAt: null,
     id: `nexus_payout_target_approval_hygiene_lane_${suffix}`,
-    idempotencyKeyHash: `hash.hygiene_lane_settlement.approval.${suffix}`,
+    idempotencyKeyHash: idempotencyHash('approval'),
     ownerUserId: 'user_openagents_operator',
     payoutTargetRef: input.payoutTargetRef,
     publicProjectionJson: JSON.stringify({
@@ -540,7 +542,7 @@ export const buildHygieneLaneSettlement = (
     buyerPaymentRef: null,
     createdAt: input.nowIso,
     id: `nexus_treasury_payout_intent_hygiene_lane_${suffix}`,
-    idempotencyKeyHash: `hash.hygiene_lane_settlement.intent.${suffix}`,
+    idempotencyKeyHash: idempotencyHash('intent'),
     metadataRefs,
     ownerUserId: null,
     payoutIntentRef: `payout_intent.hygiene_lane_settlement.${suffix}`,
@@ -571,7 +573,7 @@ export const buildHygieneLaneSettlement = (
     archivedAt: null,
     createdAt: input.nowIso,
     id: `nexus_treasury_payout_attempt_hygiene_lane_${suffix}`,
-    idempotencyKeyHash: `hash.hygiene_lane_settlement.attempt.${suffix}`,
+    idempotencyKeyHash: idempotencyHash('attempt'),
     metadataRefs,
     payoutAttemptRef: `payout_attempt.hygiene_lane_settlement.${suffix}`,
     payoutIntentRef: intent.payoutIntentRef,
@@ -595,7 +597,7 @@ export const buildHygieneLaneSettlement = (
     eventRef: `reconciliation.hygiene_lane_settlement.${suffix}`,
     externalEventRef: `external_event.hygiene_lane_settlement.${adapterKind}.${suffix}`,
     id: `nexus_treasury_reconciliation_hygiene_lane_${suffix}`,
-    idempotencyKeyHash: `hash.hygiene_lane_settlement.reconciliation.${suffix}`,
+    idempotencyKeyHash: idempotencyHash('reconciliation'),
     metadataRefs,
     payoutAttemptRef: attempt.payoutAttemptRef,
     payoutIntentRef: intent.payoutIntentRef,


### PR DESCRIPTION
## Summary

- hash the hygiene-lane settlement `idempotencyRef` before deriving ledger receipt IDs and idempotency hashes
- keep the raw operator idempotency material out of deterministic receipt refs
- add a regression proving two long refs with the same visible prefix derive distinct settlement receipt refs

## Why

The #5372 dispatch path was already idempotent, but its suffix came from a sanitized/truncated request ref. For settlement-adjacent records, truncation should not be the collision boundary. This keeps the readable receipt shape while anchoring it to a SHA-256 digest.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/hygiene-lane-settlement-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`

Refs #5372, #5335.
