### PR TITLE
Resolve sessions exec approval decisions

### DIFF
--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -2011,6 +2011,13 @@ async function main() {
             const { result } = await runControlCommand({ type: "approvals.list" }, Bun.env)
             return result as { approvals: Array<{ approvalRef: string; kind: string }> }
           },
+          approvalsResolve: async (approvalRef, decision) => {
+            const { result } = await runControlCommand(
+              { type: "approvals.resolve", approvalRef, decision },
+              Bun.env,
+            )
+            return result
+          },
         }
         // W-3: when `auto` is selected, build the BOUNDED auto-approve policy and
         // pass its callback + audit accessor. The policy is scoped to the

--- a/apps/pylon/src/node/sessions-exec.ts
+++ b/apps/pylon/src/node/sessions-exec.ts
@@ -51,6 +51,13 @@ export type SessionsExecControl = {
   // empty list). W-3 (#5379) replaces the policy below with bounded
   // auto-approve; it does NOT belong here.
   approvalsList?: () => Promise<{ approvals: PendingApprovalSummary[] }>
+  // Optional exactly-once approval resolver owned by the running node. The
+  // driver may decide approve/deny, but the node still owns applying that
+  // decision to its approval queue.
+  approvalsResolve?: (
+    approvalRef: string,
+    decision: Extract<ApprovalDecision, "approve" | "deny">,
+  ) => Promise<unknown>
 }
 
 export type PendingApprovalSummary = {
@@ -289,8 +296,12 @@ export async function runSessionsExec(
         seenApprovalRefs.add(approval.approvalRef)
         const decision = await policy(approval)
         pendingApprovals.push({ approvalRef: approval.approvalRef, kind: approval.kind, decision })
+        if ((decision === "approve" || decision === "deny") && control.approvalsResolve) {
+          await control.approvalsResolve(approval.approvalRef, decision)
+        }
         if (decision === "deny") approvalDenied = true
-        // `pause`/`approve` are recorded; bounded approve execution is W-3.
+        // `pause` is recorded without mutation; `approve`/`deny` are applied by
+        // the node's approval queue when that resolver is available.
       }
     }
 

--- a/apps/pylon/tests/sessions-exec.test.ts
+++ b/apps/pylon/tests/sessions-exec.test.ts
@@ -260,9 +260,13 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
           input.abortSignal.addEventListener("abort", () => reject(new Error("cancelled")), { once: true })
         })
       const actions = createControlSessionActions({ executor, proofsDir: proofDir, summary })
+      const resolved: Array<{ approvalRef: string; decision: string }> = []
       const control: SessionsExecControl = {
         ...controlFrom(actions),
         approvalsList: async () => ({ approvals: [{ approvalRef: "approval.y", kind: "spend_gate" }] }),
+        approvalsResolve: async (approvalRef, decision) => {
+          resolved.push({ approvalRef, decision })
+        },
       }
       const result = await runSessionsExec(control, {
         adapter: "codex",
@@ -277,6 +281,7 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
       expect(result.pendingApprovals).toEqual([
         { approvalRef: "approval.y", kind: "spend_gate", decision: "deny" },
       ])
+      expect(resolved).toEqual([{ approvalRef: "approval.y", decision: "deny" }])
       expect(result.ok).toBe(false)
       await actions.cancel(result.sessionRef)
     })
@@ -289,6 +294,7 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
       const executor: ControlSessionExecutor = async () => executorResult("passed")
       const actions = createControlSessionActions({ executor, proofsDir: proofDir, summary })
       let calls = 0
+      const resolved: Array<{ approvalRef: string; decision: string }> = []
       const control: SessionsExecControl = {
         ...controlFrom(actions),
         approvalsList: async () => {
@@ -296,6 +302,9 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
           return calls === 1
             ? { approvals: [{ approvalRef: "approval.z", kind: "bounded_safe" }] }
             : { approvals: [] }
+        },
+        approvalsResolve: async (approvalRef, decision) => {
+          resolved.push({ approvalRef, decision })
         },
       }
       const result = await runSessionsExec(control, {
@@ -311,6 +320,7 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
       expect(result.pendingApprovals).toEqual([
         { approvalRef: "approval.z", kind: "bounded_safe", decision: "approve" },
       ])
+      expect(resolved).toEqual([{ approvalRef: "approval.z", decision: "approve" }])
       // An approve does NOT pause: the session is allowed to reach its terminal.
       expect(result.outcome).toBe("completed")
       expect(result.ok).toBe(true)
@@ -325,6 +335,7 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
       const executor: ControlSessionExecutor = async () => executorResult("passed")
       const actions = createControlSessionActions({ executor, proofsDir: proofDir, summary })
       let calls = 0
+      const resolved: Array<{ approvalRef: string; decision: string }> = []
       const control: SessionsExecControl = {
         ...controlFrom(actions),
         approvalsList: async () => {
@@ -332,6 +343,9 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
           return calls === 1
             ? { approvals: [{ approvalRef: "approval.edit", kind: "file_edit", paths: [`${worktree}/src/x.ts`] }] }
             : { approvals: [] }
+        },
+        approvalsResolve: async (approvalRef, decision) => {
+          resolved.push({ approvalRef, decision })
         },
       }
       const auto = createBoundedAutoApprovalPolicy({ scopeRoot: worktree })
@@ -352,6 +366,7 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
       expect(result.pendingApprovals).toEqual([
         { approvalRef: "approval.edit", kind: "file_edit", decision: "approve" },
       ])
+      expect(resolved).toEqual([{ approvalRef: "approval.edit", decision: "approve" }])
       expect(result.autoApprovals).toEqual([
         {
           approvalRef: "approval.edit",
@@ -373,11 +388,15 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
           input.abortSignal.addEventListener("abort", () => reject(new Error("cancelled")), { once: true })
         })
       const actions = createControlSessionActions({ executor, proofsDir: proofDir, summary })
+      const resolved: Array<{ approvalRef: string; decision: string }> = []
       const control: SessionsExecControl = {
         ...controlFrom(actions),
         approvalsList: async () => ({
           approvals: [{ approvalRef: "approval.spend", kind: "spend_gate", prompt: "pay 1000 sats" }],
         }),
+        approvalsResolve: async (approvalRef, decision) => {
+          resolved.push({ approvalRef, decision })
+        },
       }
       const auto = createBoundedAutoApprovalPolicy({ scopeRoot: worktree })
       const result = await runSessionsExec(control, {
@@ -394,6 +413,7 @@ describe("pylon sessions exec (W-1 run-to-completion)", () => {
 
       expect(result.ok).toBe(false)
       expect(result.pendingApprovals[0]?.decision).toBe("deny")
+      expect(resolved).toEqual([{ approvalRef: "approval.spend", decision: "deny" }])
       expect(result.autoApprovals[0]).toMatchObject({
         approvalRef: "approval.spend",
         category: "deny",


### PR DESCRIPTION
## Summary

- add an optional `approvalsResolve` hook to the `sessions exec` driver
- wire the CLI adapter to the node's existing `approvals.resolve` command
- make `approve`/`deny` policy decisions actually resolve the pending approval instead of only recording the decision in the exec result

## Why

After W-3, `sessions exec --on-approval auto` could decide `approve`, but the thin control surface only listed approvals. A real blocked session would still wait on the node queue. This keeps the authority where it already lives: the node approval queue remains exactly-once, while `sessions exec` merely asks it to apply the bounded decision.

## Verification

- `bun run --cwd apps/pylon test -- tests/sessions-exec.test.ts`
- `bun run --cwd apps/pylon test -- tests/approval-queue.test.ts tests/cross-surface-decision-exactly-once.test.ts tests/sessions-exec.test.ts`
- `bun --cwd apps/pylon src/index.ts help sessions`
- `git diff --check`

Additional note: `bunx tsc -p apps/pylon/tsconfig.json --noEmit` is not a useful focused gate right now; it fails on many pre-existing NodeNext extension / implicit-any issues across `apps/pylon` and `packages/autopilot-control-protocol` before this patch.

Refs #5376, #5377, #5379.
