### PR TITLE
Document owned hygiene verification receipts

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1063,6 +1063,11 @@ This is the invariant ledger for `openagents`.
 - Payment follows verified delta, not churn: behavior or benchmark parity must
   be green, the named hygiene metric must improve, and no equal-or-worse debt
   may be introduced elsewhere in the scoped receipt.
+- For hygiene work that depends on tests or typechecks, "green" must be
+  dereferenceable as an OpenAgents-owned runner check-run or an independent
+  verifier replay before it can support payout. GitHub-hosted Actions are not
+  an allowed trust anchor for this lane. Local worker assertions are useful
+  progress notes, but they are not settlement evidence.
 - Duplicate/novelty is enforced by typed fingerprint keys, not loose ref
   matching: `DebtReceiptKey = sha256(debtReceiptRef | repoBaselineRef |
   scopeDigest | objectiveDigest)` and `PatchNoveltyKey = sha256(DebtReceiptKey |
@@ -1124,7 +1129,8 @@ This is the invariant ledger for `openagents`.
   nothing was paid. Every stored column is a public-safe ref or a bounded
   integer, and the policy re-validates ref safety on every reprojection, so the
   store never relies on itself to keep secrets out.
-- Regression coverage for this policy lives in
+- Regression coverage for this policy lives in the OpenAgents-owned
+  verification runner / independent replay plan plus
   `workers/api/src/debt-receipt-key.test.ts`,
   `workers/api/src/debt-receipt-policy.test.ts`,
   `workers/api/src/debt-receipt-work-request.test.ts`,

--- a/apps/openagents.com/apps/web/src/product-policy.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.ts
@@ -301,6 +301,7 @@ export const browserCommandProductIntents = {
   LoadCustomerSiteBuilderFiles: 'customer.order.site-builder.files.load',
   LoadCustomerSiteBuilderSession: 'customer.order.site-builder.session.load',
   LoadCustomerSiteFeedback: 'customer.order.site-feedback.load',
+  LoadCustomerOneCohort: 'forge.customer-one.cohort.load',
   LoadCustomerFulfillmentArtifacts: 'customer.order.fulfillment-artifacts.load',
   LoadCustomerSiteRevisions: 'customer.order.site-revisions.load',
   LoadExternal: 'navigation.external.load',

--- a/apps/openagents.com/packages/email-templates/src/index.test.ts
+++ b/apps/openagents.com/packages/email-templates/src/index.test.ts
@@ -171,6 +171,7 @@ describe('email template package', () => {
       'drip.signup_day_2.v1',
       'autopilot_decisions.decision_required.v1',
       'autopilot_decisions.work_delivered.v1',
+      'team_workspace_invite.v1',
     ])
   })
 })

--- a/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
+++ b/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
@@ -87,6 +87,9 @@ authorities.
   inventory, not spend.
 - `accepted_verified`: a reviewer or verifier accepted the patch and evidence.
   A merged PR can be accepted-work evidence, but it is not payout authority.
+  When the verifier is a test or typecheck command, the accepted-work evidence
+  should dereference to an OpenAgents-owned runner check-run or independent
+  verifier replay, not a worker-authored comment or GitHub-hosted Actions run.
 - `credit_class`: accepted and credited work where no owner-funded hygiene-lane
   settlement path has been armed. This is recognition, not a pending Bitcoin
   payout.


### PR DESCRIPTION
## Summary
- remove the proposed GitHub Actions workflow after invariant review; this PR no longer adds anything under `.github/workflows/`
- document that payout-grade hygiene test/typecheck evidence must dereference to an OpenAgents-owned runner check-run or an independent verifier replay, not a worker-authored comment or GitHub-hosted Actions run
- keep two stale OpenAgents.com contract expectation fixes discovered while rehearsing broader app coverage: email preview catalog includes `team_workspace_invite.v1`, and `LoadCustomerOneCohort` has a browser product intent

## Why
Orrery's #5372 flag was right: real-sats hygiene settlement should not depend on local worker assertions. AtlantisPleb/Raynor's review was also right: the repository has a hard no-GitHub-hosted-CI invariant, so the trust anchor must be OpenAgents-owned infra or an independent verifier replay.

This PR keeps the verification standard and removes the forbidden runner implementation.

## Verification
- `bun run --cwd apps/openagents.com/packages/email-templates test`
- `bun run --cwd apps/openagents.com/apps/web test -- src/product-policy.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/debt-receipt-key.test.ts src/debt-receipt-policy.test.ts src/debt-receipt-work-request.test.ts src/hygiene-lane-settlement.test.ts src/hygiene-lane-settlement-routes.test.ts src/hygiene-debt-receipt-store.test.ts src/hygiene-lane-debt-receipt-create-routes.test.ts src/artanis-studying-labor.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run typecheck`
- `git diff --check`

Attempted `HOME=/private/tmp/openagents-ci-home bun run test` after the correction; it is not a usable receipt on this host right now because unrelated Pylon/Probe loopback tests fail with `Bun.serve({ port: 0 })` reporting `EADDRINUSE`. The focused settlement-adjacent checks above are green.

Follow-up to #5372 / #5335.
