### PR TITLE
Document hygiene debt receipt create route

### DIFF
--- a/apps/openagents.com/workers/api/src/hygiene-lane-debt-receipt-create-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-lane-debt-receipt-create-routes.test.ts
@@ -292,6 +292,27 @@ describe('POST /api/hygiene-lane/debt-receipts (create payable receipt, #5335 st
     expect(store.rows.size).toBe(0)
   })
 
+  it('rejects malformed debt-receipt key input refs before persisting', async () => {
+    const { routes, store } = makeRoutes()
+
+    const response = await runRoute(
+      routes.routeHygieneLaneSettlementRequest(
+        createRequest(
+          createBody({
+            debtReceiptKeyInput: {
+              ...KEY_INPUT,
+              scopeDigest: '/Users/trigger/private-scope',
+            },
+          }),
+        ),
+        {},
+      ),
+    )
+
+    expect(response.status).toBe(400)
+    expect(store.rows.size).toBe(0)
+  })
+
   it('rejects an unsafe ref (payment/wallet material) before persisting', async () => {
     const { routes, store } = makeRoutes()
 

--- a/apps/openagents.com/workers/api/src/hygiene-lane-settlement-routes.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-lane-settlement-routes.ts
@@ -1,7 +1,6 @@
 import { Effect, Match as M, Schema as S } from 'effect'
 
 import { sha256Hex } from './agent-registration'
-import { DebtReceiptKeyInput } from './debt-receipt-key'
 import {
   type DebtReceiptSettlementInput,
   type DebtReceiptSettlementProjection,
@@ -152,6 +151,13 @@ const NonNegativeInteger = S.Number.check(
   S.isGreaterThanOrEqualTo(0),
 )
 
+const HygieneDebtReceiptKeyInput = S.Struct({
+  debtReceiptRef: HygieneLaneSettlementRequestRef,
+  objectiveDigest: HygieneLaneSettlementRequestRef,
+  repoBaselineRef: HygieneLaneSettlementRequestRef,
+  scopeDigest: HygieneLaneSettlementRequestRef,
+})
+
 /**
  * Admin request to CREATE a payable funded debt receipt (#5372, EPIC #5335,
  * process step 1). The requester / settlement-authority supplies the full,
@@ -167,7 +173,7 @@ const NonNegativeInteger = S.Number.check(
 export const HygieneDebtReceiptCreateRequest = S.Struct({
   // The DebtReceiptKey input components (#5340): debtReceiptRef, repoBaselineRef,
   // scopeDigest, objectiveDigest. Computes the key the receipt is stored under.
-  debtReceiptKeyInput: DebtReceiptKeyInput,
+  debtReceiptKeyInput: HygieneDebtReceiptKeyInput,
   // The merged-PR + reviewer-acceptance refs this receipt funds.
   mergedPrRef: HygieneLaneSettlementRequestRef,
   reviewerAcceptanceRef: HygieneLaneSettlementRequestRef,

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -136,6 +136,10 @@ describe('OpenAgents OpenAPI route', () => {
     expect(operationAt(body, '/api/training/evals/a5', 'get').operationId).toBe(
       'readTrainingA5EvalDashboard',
     )
+    expect(
+      operationAt(body, '/api/hygiene-lane/debt-receipts', 'post')
+        .operationId,
+    ).toBe('createHygieneLaneDebtReceipt')
     expect(operationAt(body, '/api/agents/register', 'post').operationId).toBe(
       'registerProgrammaticAgent',
     )
@@ -498,6 +502,9 @@ describe('OpenAgents OpenAPI route', () => {
       ).operationId,
     ).toBe('getPublicTassadarFirstRealSettlementReplay')
     expect(
+      operationAt(body, '/api/hygiene-lane/debt-receipts', 'post').security,
+    ).toEqual([{ adminBearer: [] }])
+    expect(
       operationAt(body, '/api/customer-orders/active', 'get').security,
     ).toEqual([{ browserSession: [] }, { agentBearer: [] }])
     expect(operationAt(body, '/api/customer-orders', 'post').security).toEqual([
@@ -805,6 +812,8 @@ describe('OpenAgents OpenAPI route', () => {
         'ForumReceiptLookupResponse',
         'CreateForumTopicRequest',
         'CreateForumReplyRequest',
+        'HygieneDebtReceiptCreateRequest',
+        'HygieneDebtReceiptCreateResponse',
         'CustomerOrderEnvelope',
         'OperatorSiteEnvelope',
         'OperatorAdjutantAssignmentEnvelope',
@@ -817,6 +826,43 @@ describe('OpenAgents OpenAPI route', () => {
     expect(
       schemaProperties(body, 'CreateForumReplyRequest').bodyText?.maxLength,
     ).toBe(40000)
+    const hygieneDebtReceiptRequest = schemaProperties(
+      body,
+      'HygieneDebtReceiptCreateRequest',
+    )
+    expect(hygieneDebtReceiptRequest.debtReceiptKeyInput).toEqual(
+      expect.objectContaining({
+        additionalProperties: false,
+        required: [
+          'debtReceiptRef',
+          'objectiveDigest',
+          'repoBaselineRef',
+          'scopeDigest',
+        ],
+      }),
+    )
+    const hygieneDebtReceiptSourceRefs = hygieneDebtReceiptRequest.sourceRefs
+    expect(hygieneDebtReceiptSourceRefs).toEqual(
+      expect.objectContaining({ minItems: 1 }),
+    )
+    if (hygieneDebtReceiptSourceRefs === undefined) {
+      throw new Error('Missing HygieneDebtReceiptCreateRequest.sourceRefs')
+    }
+    expect(
+      (
+        hygieneDebtReceiptSourceRefs.items as Readonly<Record<string, unknown>>
+      ).maxLength,
+    ).toBe(261)
+    expect(hygieneDebtReceiptRequest.payableSats).toEqual(
+      expect.objectContaining({ minimum: 1 }),
+    )
+    const hygieneDebtReceiptResponse = schemaProperties(
+      body,
+      'HygieneDebtReceiptCreateResponse',
+    )
+    expect(hygieneDebtReceiptResponse.debtReceipt).toEqual(
+      expect.objectContaining({ additionalProperties: false }),
+    )
     expect(schemaProperties(body, 'AgentHostedSearchRequest').query).toEqual(
       expect.objectContaining({ maxLength: 500, minLength: 3 }),
     )

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -180,6 +180,27 @@ const objectSummary = (description: string): JsonSchema => ({
   additionalProperties: true,
 })
 
+const hygieneDebtReceiptRef = (description: string): JsonSchema => ({
+  type: 'string',
+  minLength: 1,
+  maxLength: 261,
+  pattern: '^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,260}$',
+  description,
+})
+
+const hygieneDebtReceiptRefArray = (description: string): JsonSchema => ({
+  type: 'array',
+  minItems: 1,
+  items: hygieneDebtReceiptRef('Public-safe hygiene debt-receipt ref.'),
+  description,
+})
+
+const satsInteger = (description: string, minimum = 0): JsonSchema => ({
+  type: 'integer',
+  minimum,
+  description,
+})
+
 const schemaComponents = (): JsonSchema => ({
   ErrorResponse: {
     type: 'object',
@@ -1901,6 +1922,178 @@ const requestSchemas = (): JsonSchema => ({
   TrainingRunSettlementEnvelope: objectSummary(
     'Settlement result: the updated run projection, a settlement block (amountSats, contributorRef, settlementReceiptRef, verificationChallengeRef), and the run summary whose providerConfirmedSettledPayoutSats now reflects the provider-confirmed settled receipt linked to the run.',
   ),
+  HygieneDebtReceiptCreateResponse: {
+    type: 'object',
+    additionalProperties: false,
+    description:
+      'Admin-only hygiene debt-receipt create response. It returns the durable payable receipt identity and public-safe refs only; raw evidence, diffs, prompts, wallet material, payout targets, and provider payloads are never echoed.',
+    required: ['debtReceipt'],
+    properties: {
+      debtReceipt: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'budgetCapSats',
+          'debtReceiptKey',
+          'debtReceiptRef',
+          'idempotent',
+          'mergedPrRef',
+          'payableSats',
+          'reviewerAcceptanceRef',
+          'state',
+        ],
+        properties: {
+          budgetCapSats: satsInteger(
+            'Funded budget cap for this payable receipt in sats.',
+            1,
+          ),
+          debtReceiptKey: {
+            type: 'string',
+            pattern: '^debt_receipt_key:[a-f0-9]{64}$',
+            description:
+              'Typed DebtReceiptKey fingerprint for the retire-once receipt.',
+          },
+          debtReceiptRef: hygieneDebtReceiptRef(
+            'Public ref naming the funded hygiene debt receipt.',
+          ),
+          idempotent: {
+            type: 'boolean',
+            description:
+              'True when the create request reconnected to an existing payable receipt for the same DebtReceiptKey.',
+          },
+          mergedPrRef: hygieneDebtReceiptRef(
+            'Public ref for the merged PR this receipt funds.',
+          ),
+          payableSats: satsInteger(
+            'Payable amount in sats after the debt-receipt policy reprojects the evidence.',
+            1,
+          ),
+          reviewerAcceptanceRef: hygieneDebtReceiptRef(
+            'Public ref for the reviewer acceptance evidence.',
+          ),
+          state: {
+            type: 'string',
+            enum: ['payable'],
+            description:
+              'Create only persists receipts that reproject to payable.',
+          },
+        },
+      },
+    },
+  },
+  HygieneDebtReceiptCreateRequest: {
+    type: 'object',
+    additionalProperties: false,
+    description:
+      'Admin-only request to create a durable payable hygiene debt receipt (#5372/#5335 step 1). The server reprojects these public-safe refs through the debt-receipt policy and persists only payable receipts, keyed by DebtReceiptKey.',
+    required: [
+      'acceptedWorkRefs',
+      'baselineMetricRefs',
+      'budgetCapSats',
+      'debtReceiptKeyInput',
+      'fundingApprovalRefs',
+      'fundingAuthorityRefs',
+      'hygieneDeltaRefs',
+      'mergedPrRef',
+      'noNewEqualOrWorseDebtRefs',
+      'payableSats',
+      'reviewDecisionRefs',
+      'reviewerAcceptanceRef',
+      'scopeRefs',
+      'settlementApprovalRefs',
+      'sourceRefs',
+      'stopConditionRefs',
+      'targetMetricRefs',
+      'verificationCommandRefs',
+    ],
+    properties: {
+      acceptedWorkRefs: hygieneDebtReceiptRefArray(
+        'Refs proving the merged work was accepted.',
+      ),
+      baselineMetricRefs: hygieneDebtReceiptRefArray(
+        'Refs for the measured debt baseline.',
+      ),
+      budgetCapSats: satsInteger('Funded budget cap in sats.', 1),
+      debtReceiptKeyInput: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'debtReceiptRef',
+          'objectiveDigest',
+          'repoBaselineRef',
+          'scopeDigest',
+        ],
+        properties: {
+          debtReceiptRef: hygieneDebtReceiptRef(
+            'Public ref naming the funded debt receipt.',
+          ),
+          objectiveDigest: hygieneDebtReceiptRef(
+            'Public digest/ref for the baseline metric, target metric, stop condition, and verifier objective.',
+          ),
+          repoBaselineRef: hygieneDebtReceiptRef(
+            'Public ref for the repository baseline the receipt was measured against.',
+          ),
+          scopeDigest: hygieneDebtReceiptRef(
+            'Public digest/ref for the touched scope.',
+          ),
+        },
+      },
+      fundingApprovalRefs: hygieneDebtReceiptRefArray(
+        'Refs proving the receipt or batch was funded by an authority distinct from the worker.',
+      ),
+      fundingAuthorityActorRef: hygieneDebtReceiptRef(
+        'Optional actor ref for the funding authority.',
+      ),
+      fundingAuthorityRefs: hygieneDebtReceiptRefArray(
+        'Refs identifying the funding authority or market policy.',
+      ),
+      hygieneDeltaRefs: hygieneDebtReceiptRefArray(
+        'Refs for the measured hygiene delta.',
+      ),
+      mergedPrRef: hygieneDebtReceiptRef('Public ref for the merged PR.'),
+      noNewEqualOrWorseDebtRefs: hygieneDebtReceiptRefArray(
+        'Refs proving no equal-or-worse debt was introduced in scope.',
+      ),
+      payableSats: satsInteger(
+        'Payable amount requested for the policy projection in sats.',
+        1,
+      ),
+      proposerActorRef: hygieneDebtReceiptRef(
+        'Optional actor ref for the debt proposer.',
+      ),
+      reviewDecisionRefs: hygieneDebtReceiptRefArray(
+        'Refs for the reviewer decision evidence.',
+      ),
+      reviewerAcceptanceRef: hygieneDebtReceiptRef(
+        'Public ref for the reviewer acceptance evidence.',
+      ),
+      reviewerActorRef: hygieneDebtReceiptRef(
+        'Optional actor ref for the reviewer.',
+      ),
+      scopeRefs: hygieneDebtReceiptRefArray('Refs for the receipt scope.'),
+      settlementApprovalRefs: hygieneDebtReceiptRefArray(
+        'Refs proving settlement authority approved this payable receipt.',
+      ),
+      settlementAuthorityActorRef: hygieneDebtReceiptRef(
+        'Optional actor ref for the settlement authority.',
+      ),
+      sourceRefs: hygieneDebtReceiptRefArray(
+        'Refs naming the source debt, issue, probe, or buyer request.',
+      ),
+      stopConditionRefs: hygieneDebtReceiptRefArray(
+        'Refs naming the receipt stop condition.',
+      ),
+      targetMetricRefs: hygieneDebtReceiptRefArray(
+        'Refs for the target metric.',
+      ),
+      verificationCommandRefs: hygieneDebtReceiptRefArray(
+        'Refs for the verifier command or independent replay evidence.',
+      ),
+      workerActorRef: hygieneDebtReceiptRef(
+        'Optional actor ref for the worker.',
+      ),
+    },
+  },
   TrainingWindowPlanRequest: objectSummary(
     'Admin-only request to plan a training window for a trainingRunRef, including homeworkKind, priority, datasetRefs, sourceRefs, and receiptRefs as public-safe refs only.',
   ),
@@ -3884,6 +4077,30 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Recorded run-linked provider-confirmed settlement receipt.',
           '#/components/schemas/TrainingRunSettlementEnvelope',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/hygiene-lane/debt-receipts': {
+    post: operation({
+      operationId: 'createHygieneLaneDebtReceipt',
+      summary: 'Create a payable hygiene debt receipt',
+      description:
+        'Admin-only (#5372/#5335 step 1). Creates or reconnects a durable payable hygiene debt receipt for merged and reviewed work. The request supplies public-safe debt-receipt evidence refs; the server reprojects them through the debt-receipt policy, computes the DebtReceiptKey, persists only payable receipts, and refuses retired duplicate replays. This creates payability evidence only; settlement and real Bitcoin movement remain separate owner-gated routes. No raw diffs, prompts, PR bodies, wallet material, payout targets, provider payloads, or secrets are accepted or returned.',
+      tags: ['Operator', 'Payments'],
+      security: adminBearer,
+      requestBody: jsonContent(
+        '#/components/schemas/HygieneDebtReceiptCreateRequest',
+      ),
+      responses: {
+        '200': okJson(
+          'Existing payable hygiene debt receipt for this DebtReceiptKey.',
+          '#/components/schemas/HygieneDebtReceiptCreateResponse',
+        ),
+        '201': okJson(
+          'Created payable hygiene debt receipt.',
+          '#/components/schemas/HygieneDebtReceiptCreateResponse',
         ),
         ...errorResponses(),
       },


### PR DESCRIPTION
## Summary
- document the admin-only `POST /api/hygiene-lane/debt-receipts` route in `openapi.json`
- add explicit request/response schemas for payable hygiene debt-receipt creation, including the public-safe ref-token shape, DebtReceiptKey response shape, and 200 idempotent / 201 created outcomes
- tighten `debtReceiptKeyInput` decoding to the same bounded public ref-token schema used by the rest of the create request
- add regression coverage for malformed key-input refs and OpenAPI route/schema coverage

## Why
While rehearsing the broader OpenAgents.com suite for #5391, route coverage showed `/api/hygiene-lane/debt-receipts` was registered but absent from the OpenAPI contract. This route is settlement-adjacent (#5372/#5335 step 1), so it should not be a silent API surface.

## Verification
- `bun install --frozen-lockfile`
- `bun run --cwd apps/openagents.com/workers/api test -- src/openagents-openapi-routes.test.ts src/hygiene-lane-debt-receipt-create-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`

No payment claim; this is contract/documentation hygiene for the funded lane.
