### PR TITLE
Restore deleted login redirect policy

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -237,6 +237,10 @@ import { routeEffect, routeEffectOrResponse } from './http/route-effects'
 import type { ExactRoute } from './http/router'
 import { makeImageGenerationRoutes } from './image-generation-routes'
 import {
+  cleanProductRouteRedirectLocation,
+  githubWriteResultRedirectLocation,
+} from './routing/redirect-policy'
+import {
   decodeUnknownWithSchema,
   isRecord,
   nestedUnknown,
@@ -3268,36 +3272,8 @@ const handleGitHubStart = (request: Request, env: Env) =>
 const handleEmailStart = (request: Request, env: Env) =>
   handleLoginStart(request, env, 'code')
 
-export const githubWriteResultRedirectLocation = (appOrigin: string): string =>
-  appOrigin
-
 const githubWriteResultRedirect = (env: Env): Response =>
   redirectResponse(githubWriteResultRedirectLocation(getAppOrigin(env)))
-
-export const cleanProductRouteRedirectLocation = (
-  url: URL,
-): string | undefined => {
-  if (url.search === '') {
-    return undefined
-  }
-
-  if (url.pathname === '/login') {
-    return `${url.origin}/`
-  }
-
-  if (
-    url.pathname === '/' ||
-    url.pathname === '/billing' ||
-    url.pathname === '/onboarding' ||
-    url.pathname === '/order' ||
-    url.pathname.startsWith('/orders/') ||
-    url.pathname.startsWith('/share/')
-  ) {
-    return `${url.origin}${url.pathname}`
-  }
-
-  return undefined
-}
 
 const handleGitHubWriteStart = async (
   request: Request,

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -3281,6 +3281,10 @@ export const cleanProductRouteRedirectLocation = (
     return undefined
   }
 
+  if (url.pathname === '/login') {
+    return `${url.origin}/`
+  }
+
   if (
     url.pathname === '/' ||
     url.pathname === '/billing' ||
@@ -7690,6 +7694,10 @@ const exactRoutes: ReadonlyArray<ExactRoute<Env>> = [
     path: '/discord',
     handler: () =>
       Effect.succeed(redirectResponse('https://discord.gg/4RrjGCuQAZ')),
+  },
+  {
+    path: '/login',
+    handler: () => Effect.succeed(redirectResponse('/')),
   },
   {
     path: '/login/email',

--- a/apps/openagents.com/workers/api/src/redirect-policy.test.ts
+++ b/apps/openagents.com/workers/api/src/redirect-policy.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 import {
   cleanProductRouteRedirectLocation,
   githubWriteResultRedirectLocation,
-} from './index'
+} from './routing/redirect-policy'
 
 describe('redirect URL policy', () => {
   test('keeps GitHub write OAuth result state out of the public app URL', () => {

--- a/apps/openagents.com/workers/api/src/routing/redirect-policy.ts
+++ b/apps/openagents.com/workers/api/src/routing/redirect-policy.ts
@@ -1,0 +1,27 @@
+export const githubWriteResultRedirectLocation = (appOrigin: string): string =>
+  appOrigin
+
+export const cleanProductRouteRedirectLocation = (
+  url: URL,
+): string | undefined => {
+  if (url.search === '') {
+    return undefined
+  }
+
+  if (url.pathname === '/login') {
+    return `${url.origin}/`
+  }
+
+  if (
+    url.pathname === '/' ||
+    url.pathname === '/billing' ||
+    url.pathname === '/onboarding' ||
+    url.pathname === '/order' ||
+    url.pathname.startsWith('/orders/') ||
+    url.pathname.startsWith('/share/')
+  ) {
+    return `${url.origin}${url.pathname}`
+  }
+
+  return undefined
+}


### PR DESCRIPTION
## Summary
- canonicalize stale /login URLs with result query params back to the app home URL
- add an exact deleted /login route redirect before the login provider start routes
- extract product redirect decisions into src/routing/redirect-policy.ts so the worker entrypoint no longer owns that policy
- keep /login/email and /login/github as the active auth start endpoints

## Verification
- bun run --cwd apps/openagents.com/workers/api test -- src/redirect-policy.test.ts src/admin-access.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck
- git diff --check

Related to #5335. No payment claim; this is a small hygiene repair from the broader OpenAgents.com red-test surface plus the first tiny routing-boundary extraction from the API root organization plan.