### PR TITLE
Classify docs receipts as credit-only

### DIFF
--- a/apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts
+++ b/apps/openagents.com/workers/api/src/debt-receipt-policy.test.ts
@@ -116,11 +116,40 @@ describe('Debt receipt settlement policy', () => {
       settledSats: 0,
       settlementClaimAllowed: false,
       state: 'payable',
+      workClass: 'code_hygiene',
       workerPayoutEligible: true,
     })
     expect(projection.blockerRefs).toEqual([
       'blocker.public.debt_receipt.settlement_receipt_missing',
     ])
+  })
+
+  test('classifies documentation and journal work as credit instead of payable', () => {
+    const projection = projectDebtReceiptSettlement({
+      ...verifiedReceiptInput,
+      payableSats: 50_000,
+      settlementApprovalRefs: ['approval.public.debt_receipt.5334.settlement'],
+      settlementReceiptRefs: [
+        'settlement.public.debt_receipt.5334.worker_codex_loop',
+      ],
+      settledSats: 0,
+      workClass: 'documentation_or_journal',
+    })
+
+    expect(projection).toMatchObject({
+      payableSats: 0,
+      publicCopyRefs: ['copy.public.debt_receipt.credit_class_not_payable'],
+      settlementClaimAllowed: false,
+      state: 'credit_class',
+      workClass: 'documentation_or_journal',
+      workerPayoutEligible: false,
+    })
+    expect(projection.blockerRefs).toEqual([
+      'blocker.public.debt_receipt.documentation_or_journal_credit_not_payable',
+    ])
+    expect(projection.caveatRefs).toContain(
+      'caveat.public.debt_receipt.documentation_or_journal_not_size_scaled',
+    )
   })
 
   test('uses studied knowledge as evidence for hygiene receipts without granting authority', () => {

--- a/apps/openagents.com/workers/api/src/debt-receipt-policy.ts
+++ b/apps/openagents.com/workers/api/src/debt-receipt-policy.ts
@@ -27,6 +27,7 @@ export const DebtReceiptSettlementState = S.Literals([
   'fundable',
   'funded',
   'verified',
+  'credit_class',
   'payable',
   'retired',
   'duplicate_replay',
@@ -34,6 +35,12 @@ export const DebtReceiptSettlementState = S.Literals([
 ])
 export type DebtReceiptSettlementState =
   typeof DebtReceiptSettlementState.Type
+
+export const DebtReceiptWorkClass = S.Literals([
+  'code_hygiene',
+  'documentation_or_journal',
+])
+export type DebtReceiptWorkClass = typeof DebtReceiptWorkClass.Type
 
 export const DebtReceiptStudiedKnowledgeVerificationSchemaRef =
   'openagents.repo_studied_knowledge_verification.v0' as const
@@ -94,6 +101,7 @@ export const DebtReceiptSettlementProjection = S.Struct({
   studiedKnowledgeSourceRefs: S.Array(S.String),
   targetMetricRefs: S.Array(S.String),
   verificationCommandRefs: S.Array(S.String),
+  workClass: DebtReceiptWorkClass,
   workerPayoutEligible: S.Boolean,
 })
 export type DebtReceiptSettlementProjection =
@@ -132,6 +140,7 @@ export type DebtReceiptSettlementInput = Readonly<{
   studiedKnowledgeSource?: DebtReceiptStudiedKnowledgeSource | null | undefined
   targetMetricRefs?: ReadonlyArray<string> | undefined
   verificationCommandRefs?: ReadonlyArray<string> | undefined
+  workClass?: DebtReceiptWorkClass | undefined
   workerActorRef?: string | null | undefined
 }>
 
@@ -216,6 +225,10 @@ const safeNonNegativeInteger = (
 
   return normalized
 }
+
+const safeWorkClass = (
+  value: DebtReceiptWorkClass | undefined,
+): DebtReceiptWorkClass => value ?? 'code_hygiene'
 
 const safeStudiedKnowledgeSource = (
   source: DebtReceiptStudiedKnowledgeSource | null | undefined,
@@ -440,11 +453,17 @@ export const projectDebtReceiptSettlement = (
     'budgetCapSats',
     input.budgetCapSats,
   )
+  const workClass = safeWorkClass(input.workClass)
+  const documentationCreditOnly = workClass === 'documentation_or_journal'
   const maxRevisionAttempts = safeNonNegativeInteger(
     'maxRevisionAttempts',
     input.maxRevisionAttempts ?? 3,
   )
-  const payableSats = safeNonNegativeInteger('payableSats', input.payableSats)
+  const requestedPayableSats = safeNonNegativeInteger(
+    'payableSats',
+    input.payableSats,
+  )
+  const payableSats = documentationCreditOnly ? 0 : requestedPayableSats
   const revisionAttemptCount = safeNonNegativeInteger(
     'revisionAttemptCount',
     input.revisionAttemptCount,
@@ -513,7 +532,7 @@ export const projectDebtReceiptSettlement = (
     studiedKnowledgeRequired,
   )
 
-  if (payableSats > budgetCapSats) {
+  if (requestedPayableSats > budgetCapSats) {
     throw new DebtReceiptPolicyUnsafe({
       reason: 'Debt receipt payable sats cannot exceed the budget cap.',
     })
@@ -571,11 +590,17 @@ export const projectDebtReceiptSettlement = (
     hasRefs(settlementApprovalRefs) &&
     payableSats > 0 &&
     !duplicateReplay &&
-    !manualReviewOnly
+    !manualReviewOnly &&
+    !documentationCreditOnly
   const retired =
     payable &&
     hasRefs(settlementReceiptRefs) &&
     settledSats === payableSats
+  const creditClass =
+    documentationCreditOnly &&
+    verified &&
+    !duplicateReplay &&
+    !manualReviewOnly
   const state: DebtReceiptSettlementState = duplicateReplay
     ? 'duplicate_replay'
     : manualReviewOnly
@@ -584,13 +609,15 @@ export const projectDebtReceiptSettlement = (
         ? 'retired'
         : payable
           ? 'payable'
-          : verified
-            ? 'verified'
-            : funded
-              ? 'funded'
-              : defined
-                ? 'fundable'
-                : 'blocked'
+          : creditClass
+            ? 'credit_class'
+            : verified
+              ? 'verified'
+              : funded
+                ? 'funded'
+                : defined
+                  ? 'fundable'
+                  : 'blocked'
 
   const duplicateBlockerRefs = duplicateReplay
     ? [
@@ -604,37 +631,54 @@ export const projectDebtReceiptSettlement = (
           : []),
       ]
     : []
+  const creditClassBlockerRefs = documentationCreditOnly
+    ? ['blocker.public.debt_receipt.documentation_or_journal_credit_not_payable']
+    : []
+  const missingBlockerRefs = missingEvidenceBlockers({
+    acceptedWorkRefs,
+    baselineMetricRefs,
+    budgetCapSats,
+    fundingApprovalRefs,
+    fundingAuthorityRefs,
+    hygieneDeltaRefs,
+    noNewEqualOrWorseDebtRefs,
+    reviewDecisionRefs,
+    scopeRefs,
+    settlementApprovalRefs,
+    settlementReceiptRefs,
+    sourceRefs,
+    stopConditionRefs,
+    targetMetricRefs,
+    verificationCommandRefs,
+  }).filter(
+    ref =>
+      !documentationCreditOnly ||
+      (ref !== 'blocker.public.debt_receipt.settlement_approval_missing' &&
+        ref !== 'blocker.public.debt_receipt.settlement_receipt_missing'),
+  )
 
   return decodeProjection({
     acceptedWorkRefs,
     baselineMetricRefs,
     blockerRefs: [
-      ...missingEvidenceBlockers({
-        acceptedWorkRefs,
-        baselineMetricRefs,
-        budgetCapSats,
-        fundingApprovalRefs,
-        fundingAuthorityRefs,
-        hygieneDeltaRefs,
-        noNewEqualOrWorseDebtRefs,
-        reviewDecisionRefs,
-        scopeRefs,
-        settlementApprovalRefs,
-        settlementReceiptRefs,
-        sourceRefs,
-        stopConditionRefs,
-        targetMetricRefs,
-        verificationCommandRefs,
-      }),
+      ...missingBlockerRefs,
       ...roleBlockers,
       ...studiedKnowledgeBlockerRefs,
       ...duplicateBlockerRefs,
+      ...creditClassBlockerRefs,
       ...(manualReviewOnly
         ? ['blocker.public.debt_receipt.manual_review_only']
         : []),
     ].sort(),
     budgetCapSats,
-    caveatRefs: baseCaveatRefs,
+    caveatRefs: [
+      ...baseCaveatRefs,
+      ...(documentationCreditOnly
+        ? [
+            'caveat.public.debt_receipt.documentation_or_journal_not_size_scaled',
+          ]
+        : []),
+    ],
     debtReceiptKey,
     duplicateFingerprintRefs,
     duplicateReplay,
@@ -645,13 +689,15 @@ export const projectDebtReceiptSettlement = (
     noNewEqualOrWorseDebtRefs,
     patchNoveltyKey,
     payableSats,
-    publicCopyRefs: retired
-      ? ['copy.public.debt_receipt.retired_with_settlement_receipt']
-      : payable
-        ? ['copy.public.debt_receipt.payable_pending_settlement']
-        : defined
-          ? ['copy.public.debt_receipt.defined_not_settled']
-          : ['copy.public.debt_receipt.blocked'],
+    publicCopyRefs: creditClass
+      ? ['copy.public.debt_receipt.credit_class_not_payable']
+      : retired
+        ? ['copy.public.debt_receipt.retired_with_settlement_receipt']
+        : payable
+          ? ['copy.public.debt_receipt.payable_pending_settlement']
+          : defined
+            ? ['copy.public.debt_receipt.defined_not_settled']
+            : ['copy.public.debt_receipt.blocked'],
     quarantineReasonRefs,
     retiredReceiptRefs,
     reviewDecisionRefs,
@@ -671,6 +717,7 @@ export const projectDebtReceiptSettlement = (
     studiedKnowledgeSourceRefs,
     targetMetricRefs,
     verificationCommandRefs,
+    workClass,
     workerPayoutEligible: payable || retired,
   })
 }
@@ -680,6 +727,7 @@ export const debtReceiptSettlementHasPrivateMaterial = (
 ): boolean => {
   const publicValues = [
     projection.state,
+    projection.workClass,
     ...(projection.debtReceiptKey === null ? [] : [projection.debtReceiptKey]),
     ...(projection.patchNoveltyKey === null ? [] : [projection.patchNoveltyKey]),
     ...projection.acceptedWorkRefs,

--- a/apps/openagents.com/workers/api/src/hygiene-debt-receipt-store.test.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-debt-receipt-store.test.ts
@@ -81,6 +81,14 @@ describe('buildHygieneDebtReceiptRecord', () => {
     ).toThrow(HygieneDebtReceiptStoreError)
   })
 
+  it('refuses documentation or journal credit as a payable receipt', () => {
+    expect(() =>
+      buildHygieneDebtReceiptRecord(
+        createInput({ workClass: 'documentation_or_journal' }),
+      ),
+    ).toThrow(HygieneDebtReceiptStoreError)
+  })
+
   it('refuses an input with no DebtReceiptKey input', () => {
     expect(() =>
       buildHygieneDebtReceiptRecord(

--- a/apps/openagents.com/workers/api/src/hygiene-debt-receipt-store.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-debt-receipt-store.ts
@@ -152,8 +152,9 @@ export const buildHygieneDebtReceiptRecord = (
   }
 
   // A funded, payable receipt is the unit. Anything that does not reach the
-  // `payable` state (blocked / fundable / funded / verified / retired /
-  // duplicate_replay / quarantined) is NOT a payable receipt and is refused.
+  // `payable` state (blocked / fundable / funded / verified / credit_class /
+  // retired / duplicate_replay / quarantined) is NOT a payable receipt and is
+  // refused.
   if (projection.state !== 'payable') {
     throw new HygieneDebtReceiptStoreError({
       kind: 'not_payable',

--- a/apps/openagents.com/workers/api/src/hygiene-lane-debt-receipt-create-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-lane-debt-receipt-create-routes.test.ts
@@ -313,6 +313,22 @@ describe('POST /api/hygiene-lane/debt-receipts (create payable receipt, #5335 st
     expect(store.rows.size).toBe(0)
   })
 
+  it('refuses documentation or journal credit before it can become payable', async () => {
+    const { routes, store } = makeRoutes()
+
+    const response = await runRoute(
+      routes.routeHygieneLaneSettlementRequest(
+        createRequest(createBody({ workClass: 'documentation_or_journal' })),
+        {},
+      ),
+    )
+
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { reason: string }
+    expect(json.reason).toContain('not_payable:credit_class')
+    expect(store.rows.size).toBe(0)
+  })
+
   it('rejects an unsafe ref (payment/wallet material) before persisting', async () => {
     const { routes, store } = makeRoutes()
 

--- a/apps/openagents.com/workers/api/src/hygiene-lane-settlement-routes.ts
+++ b/apps/openagents.com/workers/api/src/hygiene-lane-settlement-routes.ts
@@ -4,6 +4,7 @@ import { sha256Hex } from './agent-registration'
 import {
   type DebtReceiptSettlementInput,
   type DebtReceiptSettlementProjection,
+  DebtReceiptWorkClass,
   DebtReceiptPolicyUnsafe,
 } from './debt-receipt-policy'
 import {
@@ -181,6 +182,9 @@ export const HygieneDebtReceiptCreateRequest = S.Struct({
   // positive integer <= budgetCap (the policy enforces this).
   budgetCapSats: NonNegativeInteger,
   payableSats: NonNegativeInteger,
+  // Defaults to code hygiene. Documentation/journal work is credit-class and
+  // cannot create a payable debt receipt through this hygiene-lane path.
+  workClass: S.optionalKey(DebtReceiptWorkClass),
   // The evidence refs the policy needs to reach `payable`.
   sourceRefs: DebtReceiptRefArray,
   baselineMetricRefs: DebtReceiptRefArray,
@@ -228,6 +232,7 @@ const settlementInputFromCreateRequest = (
   stopConditionRefs: body.stopConditionRefs,
   targetMetricRefs: body.targetMetricRefs,
   verificationCommandRefs: body.verificationCommandRefs,
+  workClass: body.workClass,
   workerActorRef: body.workerActorRef,
 })
 

--- a/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
+++ b/docs/labor/2026-06-18-debt-receipt-hygiene-lane.md
@@ -68,6 +68,8 @@ Every payable receipt needs these public-safe refs:
 - baseline metric: current debt measurement;
 - target metric: what must improve;
 - scope: files, package, subsystem, or artifact class;
+- work class: code hygiene by default, or `documentation_or_journal` when the
+  work is process notes, journals, docs, receipts, or discussion cleanup;
 - budget cap: maximum payable sats or buyer credit;
 - stop condition: when the receipt is retired;
 - verifier: command or benchmark that proves behavior did not regress;
@@ -93,6 +95,11 @@ authorities.
 - `credit_class`: accepted and credited work where no owner-funded hygiene-lane
   settlement path has been armed. This is recognition, not a pending Bitcoin
   payout.
+  Documentation, journal, forum-process, and receipt-only hygiene work is
+  `credit_class` by default, even when it carries good evidence. It should not be
+  size/depth-scaled by the code hygiene payout formula. If the owner wants paid
+  docs/process work, create a separate funded labor contract with its own budget,
+  verifier, and settlement authority.
 - `payable_class`: accepted work against an owner-approved funded receipt or
   batch. The receipt has a budget cap, verifier, and settlement authority, but
   the worker still must not call it paid.
@@ -168,6 +175,13 @@ validator review — fails the gate **even when studied knowledge is optional**.
 Bad optional evidence may not leave a contribution payable while attaching
 blockers. A required source must additionally be present.
 
+**Work-class gate (reviewer-flagged #5387 fix):** `documentation_or_journal`
+receipts project to `credit_class`, zero their projected payable sats, and add a
+public blocker/caveat explaining that docs/journals are not size-scaled code
+hygiene payouts. The durable debt-receipt store accepts only `payable`
+projections, so credit-class docs cannot be persisted as payable receipts by
+accident.
+
 Workers may propose findings, but a separate allocator has to fund them.
 Workers do not receive spend authority, deployment authority, settlement
 authority, or authority to mint payable follow-ups.
@@ -219,6 +233,8 @@ the receipt payable when the implementation diff exists.
   duplicate work, not payable work.
 - Bad optional studied-knowledge evidence fails closed; it cannot leave a
   contribution payable.
+- Documentation, journal, and process-discussion work is credit-class by default;
+  it does not enter the code hygiene size/depth payout formula.
 - After repeated rejected or revision-required attempts, the receipt/scope goes
   human-review-only until the benchmark, budget, or scope changes.
 


### PR DESCRIPTION
## Summary
- add a debt-receipt workClass projection with code_hygiene as the default
- classify documentation_or_journal receipts as credit_class, zero projected payable sats, and block payout eligibility
- thread workClass through the hygiene debt-receipt create route and document the process guard

## Why
Reviewer/process feedback on the hygiene lane flagged docs/journal PRs as credit-class work, not size/depth-scaled payable code hygiene. This makes that distinction executable in the debt-receipt policy and durable create path.

## Verification
- bun run --cwd apps/openagents.com/workers/api test -- src/debt-receipt-policy.test.ts src/hygiene-debt-receipt-store.test.ts src/hygiene-lane-debt-receipt-create-routes.test.ts src/hygiene-lane-settlement-routes.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck
- git diff --check