### PR TITLE
feat(forum): add light/dark theme selector

### DIFF
--- a/apps/openagents.com/apps/web/src/page/forum.ts
+++ b/apps/openagents.com/apps/web/src/page/forum.ts
@@ -19,7 +19,7 @@ type ForumRouteValue =
 type ForumAuthMode = PublicHeaderAuthState<unknown>['_tag']
 
 const shellClass =
-  'h-dvh overflow-auto overscroll-contain bg-forum-page text-forum-text [color-scheme:light]'
+  'h-dvh overflow-auto overscroll-contain bg-forum-page text-forum-text'
 const containerClass =
   'mx-auto grid w-[min(100%,1180px)] gap-4 border-x border-forum-wrap-border bg-forum-wrap px-3 py-4 font-sans shadow-[0_0_0_1px_rgba(237,237,237,0.8)] sm:px-4 sm:py-5'
 const panelClass = 'rounded-md border border-forum-row-c bg-forum-panel'
@@ -62,6 +62,50 @@ export const forumScript = (
   const initial = ${JSON.stringify(initial)};
   const authMode = initial.authMode || 'LoggedOut';
   const loginHref = ${JSON.stringify(loginHref)};
+  // ---- Forum theme (light / dark / system) ----
+  // Preference is stored as 'light' | 'dark'; absence means "follow system".
+  // The resolved theme is written to <html data-forum-theme="..."> which the
+  // stylesheet keys the forum's --color-forum-* tokens off of. This runs
+  // before the root/main guard so the theme always applies, even on pages
+  // that re-render their own content.
+  const THEME_KEY = 'oa.forum.v1:theme';
+  const themeMedia = window.matchMedia('(prefers-color-scheme: dark)');
+  const readThemePref = () => {
+    try {
+      const stored = localStorage.getItem(THEME_KEY);
+      return stored === 'light' || stored === 'dark' ? stored : 'system';
+    } catch (_) {
+      return 'system';
+    }
+  };
+  const resolveTheme = pref =>
+    pref === 'light' || pref === 'dark'
+      ? pref
+      : themeMedia.matches ? 'dark' : 'light';
+  const applyTheme = pref => {
+    document.documentElement.setAttribute('data-forum-theme', resolveTheme(pref));
+  };
+  const syncThemeSelect = pref => {
+    const select = document.querySelector('[data-forum-theme-select]');
+    if (select && select.value !== pref) select.value = pref;
+  };
+  applyTheme(readThemePref());
+  syncThemeSelect(readThemePref());
+  document.addEventListener('change', event => {
+    const target = event.target;
+    const select = target && target.closest ? target.closest('[data-forum-theme-select]') : null;
+    if (!select) return;
+    const value = select.value;
+    const pref = value === 'light' || value === 'dark' ? value : 'system';
+    try {
+      if (pref === 'system') localStorage.removeItem(THEME_KEY);
+      else localStorage.setItem(THEME_KEY, pref);
+    } catch (_) {}
+    applyTheme(pref);
+  });
+  themeMedia.addEventListener('change', () => {
+    if (readThemePref() === 'system') applyTheme('system');
+  });
   const state = {
     forum: null,
     launchStatus: null,
@@ -816,7 +860,7 @@ export const view = <Message>(
   const loginHref = forumLoginHref(route)
 
   return h.div(
-    [Ui.className<Message>(shellClass)],
+    [h.DataAttribute('forum-shell', ''), Ui.className<Message>(shellClass)],
     [
       PublicHeader.view(authState, 'forum', loginHref),
       h.main(

--- a/apps/openagents.com/apps/web/src/page/publicHeader.ts
+++ b/apps/openagents.com/apps/web/src/page/publicHeader.ts
@@ -47,6 +47,30 @@ const loginPanelSecondaryLinkClass =
 
 export type PublicHeaderVariant = 'dark' | 'forum'
 
+const forumThemeSelectClass =
+  'rounded border border-white/25 bg-white/10 px-2 py-1 font-sans text-sm text-white transition hover:bg-white/[0.16] focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-white [&>option]:text-black'
+
+// Forum-only light/dark/system selector. It carries no foldkit handler: the
+// forum page's inline script reads the value, resolves it, and persists the
+// choice (see forumScript in page/forum.ts). The script also sets the live
+// selection on load, so 'System' is just the initial markup default.
+const forumThemeSelector = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.select(
+    [
+      h.DataAttribute('forum-theme-select', ''),
+      h.AriaLabel('Forum theme'),
+      Ui.className<Message>(forumThemeSelectClass),
+    ],
+    [
+      h.option([h.Value('system'), h.Selected(true)], ['System theme']),
+      h.option([h.Value('light')], ['Light']),
+      h.option([h.Value('dark')], ['Dark']),
+    ],
+  )
+}
+
 const loggedOutLoginPopover = <Message>(
   loginHref: string,
   triggerClass: string,
@@ -200,22 +224,25 @@ export const view = <Message>(
           ),
           h.div(
             [Ui.className<Message>('flex items-center gap-2')],
-            authState._tag === 'LoggedIn'
-              ? [
-                  h.a(
-                    [h.Href(chatRouter()), Ui.className<Message>(linkClass)],
-                    ['Workroom'],
-                  ),
-                  h.button(
-                    [
-                      h.Type('button'),
-                      h.OnClick(authState.onLogout),
-                      Ui.className<Message>(linkClass),
-                    ],
-                    ['Log out'],
-                  ),
-                ]
-              : [loggedOutLoginPopover(loginHref, linkClass)],
+            [
+              ...(isForum ? [forumThemeSelector<Message>()] : []),
+              ...(authState._tag === 'LoggedIn'
+                ? [
+                    h.a(
+                      [h.Href(chatRouter()), Ui.className<Message>(linkClass)],
+                      ['Workroom'],
+                    ),
+                    h.button(
+                      [
+                        h.Type('button'),
+                        h.OnClick(authState.onLogout),
+                        Ui.className<Message>(linkClass),
+                      ],
+                      ['Log out'],
+                    ),
+                  ]
+                : [loggedOutLoginPopover(loginHref, linkClass)]),
+            ],
           ),
           h.details(
             [Ui.className<Message>('w-full lg:hidden')],

--- a/apps/openagents.com/apps/web/src/styles.css
+++ b/apps/openagents.com/apps/web/src/styles.css
@@ -35,6 +35,55 @@
   --font-sans: var(--font-family-sans);
 }
 
+/*
+ * Forum theme switching (light / dark).
+ *
+ * The forum's --color-forum-* tokens default to light (defined in @theme
+ * above). The theme selector in the public header writes the resolved theme
+ * to <html data-forum-theme="light|dark">; the "System" option resolves to
+ * one of those via prefers-color-scheme before being written. Dark mode just
+ * re-points the same tokens, so every bg-forum-* / text-forum-* utility
+ * follows automatically. color-scheme is scoped to the forum shell so the
+ * dark-only core app is never affected by a forum theme choice.
+ */
+[data-forum-shell] {
+  color-scheme: light;
+}
+
+:root[data-forum-theme='dark'] [data-forum-shell] {
+  color-scheme: dark;
+}
+
+:root[data-forum-theme='dark'] {
+  --color-forum-alert: #ff6088;
+  --color-forum-heading: #e6edf3;
+  --color-forum-header: #3a6ea5;
+  --color-forum-link: #6cb0f5;
+  --color-forum-link-hover: #ff6088;
+  --color-forum-navbar: #1c3346;
+  --color-forum-online: #85de39;
+  --color-forum-page: #0e1217;
+  --color-forum-panel: #161c24;
+  --color-forum-payment: #d9942f;
+  --color-forum-post-link: #5aa6ef;
+  --color-forum-post-link-hover-bg: #213447;
+  --color-forum-row-a: #161d26;
+  --color-forum-row-b: #1b2531;
+  --color-forum-row-c: #2b3744;
+  --color-forum-text: #9aa7b8;
+  --color-forum-wrap: #151a21;
+  --color-forum-wrap-border: #262e39;
+}
+
+/*
+ * The forum container paints a 1px light ring via an arbitrary shadow
+ * utility; re-point it to the themed border colour so it doesn't glow in
+ * dark mode.
+ */
+:root[data-forum-theme='dark'] [data-forum-app] {
+  box-shadow: 0 0 0 1px var(--color-forum-wrap-border);
+}
+
 @layer base {
   @font-face {
     font-family: 'Berkeley Mono';


### PR DESCRIPTION
## Forum dark mode + theme selector

Adds a user-facing **theme selector** to the forum and a dark palette for the
forum surface, requested via maintainer feedback. The forum was previously
hard-coded to light (`[color-scheme:light]`).

### What you get
- A **System / Light / Dark** `<select>` in the forum header (forum header
  variant only — the core app stays dark-only).
- Preference persists in `localStorage` (`oa.forum.v1:theme`). **System**
  follows `prefers-color-scheme` and reacts live to OS changes; explicit
  Light/Dark overrides it.

### How it works
- Dark mode just **re-points the existing `--color-forum-*` tokens** under
  `:root[data-forum-theme='dark']`, so every `bg-forum-*` / `text-forum-*`
  utility adapts automatically — no per-component edits.
- The forum page's inline script resolves the stored preference and writes the
  effective theme to `<html data-forum-theme="light|dark">` before content
  renders, and wires the selector via event delegation (survives re-render).
- `color-scheme` is **scoped to the forum shell** (`[data-forum-shell]`), so a
  forum theme choice never leaks into the dark-only core app.

### Files
- `apps/web/src/styles.css` — dark `--color-forum-*` token block + scoped
  `color-scheme` + container ring fix.
- `apps/web/src/page/forum.ts` — `data-forum-shell` hook; theme controller in
  `forumScript` (persist / resolve / apply / system-watch).
- `apps/web/src/page/publicHeader.ts` — `forumThemeSelector` rendered for the
  forum variant.

### Scope / safety
- No new dependencies; no API/routing/auth/payment surfaces touched.
- Light mode is unchanged (same token values); dark is purely additive.
- Build verified locally: `bun run build:web` green (921 modules); the dark
  tokens, selector, and theme JS are present in the emitted bundle.

> Note for reviewers: dark palette values are a first pass — happy to tune
> specific tokens (contrast/links/accent) to taste.