### PR TITLE
perf(forum): batch per-post tip-recipient-readiness (fix N+1 on large threads)

### DIFF
--- a/apps/openagents.com/workers/api/src/forum-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forum-routes.test.ts
@@ -3914,6 +3914,15 @@ class ForumRouteStatement implements D1PreparedStatement {
       return Promise.resolve({ results: rows } as unknown as D1Result<T>)
     }
 
+    if (this.query.includes('FROM forum_tip_recipient_wallets')) {
+      const actorRefs = new Set(this.values.map(value => String(value)))
+      const rows = this.store.tipRecipientWallets.filter(
+        item => actorRefs.has(item.actor_ref) && item.archived_at === null,
+      )
+
+      return Promise.resolve({ results: rows } as unknown as D1Result<T>)
+    }
+
     // The reliable-tip payments ledger (pay_ins/pay_in_legs) is empty in
     // this route fixture; ladder reads project no rows (#4753).
     if (this.query.includes('FROM pay_ins')) {

--- a/apps/openagents.com/workers/api/src/forum/repository.test.ts
+++ b/apps/openagents.com/workers/api/src/forum/repository.test.ts
@@ -1060,6 +1060,15 @@ class ForumRepositoryStatement implements D1PreparedStatement {
       return Promise.resolve({ results: rows } as unknown as D1Result<T>)
     }
 
+    if (this.query.includes('FROM forum_tip_recipient_wallets')) {
+      const actorRefs = new Set(this.values.map(value => String(value)))
+      const rows = this.store.tipRecipientWallets.filter(
+        item => actorRefs.has(item.actor_ref) && item.archived_at === null,
+      )
+
+      return Promise.resolve({ results: rows } as unknown as D1Result<T>)
+    }
+
     if (this.query.includes('FROM forum_private_messages')) {
       const actorRef = String(this.values[0])
       const rows = this.store.privateMessages.filter(

--- a/apps/openagents.com/workers/api/src/forum/repository.ts
+++ b/apps/openagents.com/workers/api/src/forum/repository.ts
@@ -2138,6 +2138,57 @@ export const readForumAgentPublicProfile = (
     )
   })
 
+// Batched sibling of readForumTipRecipientReadinessForActor: fetch the wallet
+// records for many authors in ONE chunked `actor_ref IN (...)` query instead of
+// one query per post. Large threads previously fired a readiness query for
+// every post (no dedup by author); callers now resolve each author from this
+// map, projecting + handling errors exactly as before. actor_ref is unique per
+// wallet, so there is at most one non-archived record per actor.
+const readForumTipRecipientWalletRecords = (
+  db: D1Database,
+  actorRefs: ReadonlyArray<string>,
+): Effect.Effect<
+  ReadonlyMap<string, ForumTipRecipientWalletRecord>,
+  ForumStorageError
+> => {
+  const uniqueActorRefs = [...new Set(actorRefs)].filter(
+    actorRef => actorRef !== '',
+  )
+
+  if (uniqueActorRefs.length === 0) {
+    return Effect.succeed(new Map())
+  }
+
+  return Effect.forEach(
+    chunkForD1Params(uniqueActorRefs),
+    batch =>
+      d1Effect('forum.readTipRecipientWallets.batch', () =>
+        db
+          .prepare(
+            `SELECT *
+               FROM forum_tip_recipient_wallets
+              WHERE actor_ref IN (${batch.map(() => '?').join(', ')})
+                AND archived_at IS NULL`,
+          )
+          .bind(...batch)
+          .all<ForumTipRecipientWalletRow>(),
+      ),
+    { concurrency: 'unbounded' },
+  ).pipe(
+    Effect.map(
+      results =>
+        new Map(
+          results.flatMap(result =>
+            (result.results ?? []).map(row => {
+              const record = tipRecipientWalletRecordFromRow(row)
+              return [record.actorRef, record] as const
+            }),
+          ),
+        ),
+    ),
+  )
+}
+
 export const readForumTipRecipientReadinessForActor = (
   db: D1Database,
   actorRef: string,
@@ -2680,10 +2731,20 @@ export const readForumTopicDetail = (
     const topicPostsWithoutTipReadiness = (posts.results ?? [])
       .map(postFromRow)
       .map(post => postWithSubject(post, topic.title))
+    const topicTipRecipientWalletRecords =
+      yield* readForumTipRecipientWalletRecords(
+        db,
+        topicPostsWithoutTipReadiness.map(post => post.author.actorRef),
+      )
     const topicPostTipRecipientReadiness = yield* Effect.all(
-      topicPostsWithoutTipReadiness.map(post =>
-        readForumTipRecipientReadinessForActor(db, post.author.actorRef),
-      ),
+      topicPostsWithoutTipReadiness.map(post => {
+        const record = topicTipRecipientWalletRecords.get(post.author.actorRef)
+        return record === undefined
+          ? Effect.succeed(
+              missingForumTipRecipientReadiness(post.author.actorRef),
+            )
+          : projectTipRecipientReadiness(record)
+      }),
     )
     const topicPosts = topicPostsWithoutTipReadiness.map((post, index) =>
       postWithTipRecipientReadiness(
@@ -2901,9 +2962,23 @@ export const readForumPostList = (
             postId: lastVisibleRow.id,
           })
     const postsWithoutTipReadiness = visibleRows.map(postFromRow)
+    const postListTipRecipientWalletRecords =
+      yield* readForumTipRecipientWalletRecords(
+        db,
+        postsWithoutTipReadiness.map(post => post.author.actorRef),
+      )
     const postTipRecipientReadiness = yield* Effect.all(
-      postsWithoutTipReadiness.map(post =>
-        readForumTipRecipientReadinessForActor(db, post.author.actorRef).pipe(
+      postsWithoutTipReadiness.map(post => {
+        const record = postListTipRecipientWalletRecords.get(
+          post.author.actorRef,
+        )
+        return (
+          record === undefined
+            ? Effect.succeed(
+                missingForumTipRecipientReadiness(post.author.actorRef),
+              )
+            : projectTipRecipientReadiness(record)
+        ).pipe(
           // A malformed wallet for a single author must not fail the whole
           // post list; degrade that author to "not ready" instead.
           Effect.catchTag('ForumValidationError', () =>
@@ -2911,8 +2986,8 @@ export const readForumPostList = (
               missingForumTipRecipientReadiness(post.author.actorRef),
             ),
           ),
-        ),
-      ),
+        )
+      }),
     )
     const posts = postsWithoutTipReadiness.map((post, index) =>
       postWithTipRecipientReadiness(


### PR DESCRIPTION
Implements item **#1** from the forum read-performance findings thread (https://openagents.com/forum/t/41d412c6-644c-47ab-9b6f-c4ead6880716): the one behavior-preserving, ships-now server win.

## Problem
`readForumTopicDetail` and `readForumPostList` in `workers/api/src/forum/repository.ts` resolve each post author's tip-recipient wallet readiness with **one D1 query per post, with no dedup by author**. A 300-post thread by 20 authors fires ~300 readiness queries instead of ~1. This slows both the UI render path and agentic API/MCP reads.

## Fix
Add `readForumTipRecipientWalletRecords`: collect the distinct non-empty `actor_ref`s and fetch them in a single chunked `WHERE actor_ref IN (...)` query (the same shape `readForumPostTipStats` already uses), then resolve each post's readiness from the resulting map. `actor_ref` is unique per wallet, so there is at most one non-archived record per actor.

**Behavior-preserving:** identical projected data and identical per-author error degradation — a malformed wallet for one author still degrades only that author to "not ready" rather than failing the list. Hundreds of round-trips collapse to one or two.

## Tests
- `forum-routes.test.ts` + `forum/repository.test.ts`: 100/100 pass.
- Full forum suite: 341 pass.
- `tsc` (api) clean.
- Rebased onto current `main`; `repository.ts` had no upstream conflicts.

## Scope
This is item #1 only. The behavior-changing items from the thread (`?since=` delta reads, `?view=compact` projection, ETag/304, batch read, forum MCP) are held for a maintainer design call and are not part of this PR.