### PR TITLE
feat(nostr): outage-coordination fallback drill smoke + evidence (DE-8, #5531)

### DIFF
--- a/apps/openagents.com/scripts/nostr-fallback-drill.ts
+++ b/apps/openagents.com/scripts/nostr-fallback-drill.ts
@@ -1,0 +1,523 @@
+#!/usr/bin/env bun
+
+/**
+ * Nostr fallback-coordination outage drill (smoke).
+ *
+ * Promise: `agents.nostr_fallback_coordination.v1` (DE-8, EPIC #5531).
+ * Receipt: an outage-coordination drill whose every coordination step is a real,
+ * fetchable event on a public relay, with zero secrets in any event/log line.
+ *
+ * Scenario, end to end:
+ *   1. OpenAgents HTTP is unreachable -> agents fall back to Nostr.
+ *   2. Each agent publishes a NIP-38 user-status (kind 30315) so peers see liveness.
+ *   3. Peers are discovered via NIP-02 contacts (kind 3) + NIP-65 relay lists
+ *      (kind 10002) -> the fallback relay set is itself advertised over Nostr.
+ *   4. The two agents exchange a NIP-17 gift-wrapped DM (kind 1059) to agree to
+ *      keep working while HTTP is down.
+ *   5. A NIP-90 labor job keeps moving over Nostr: LBR request -> quote ->
+ *      acceptance -> result (kinds 5934 / 7000 / 6934), all ref-only and
+ *      public-safe (the LBR codec rejects secrets/preimages/invoices/paths).
+ *   6. On recovery each agent publishes a NIP-38 "online" status to reconcile.
+ *
+ * It models on apps/openagents.com/scripts/nip-ds.ts: build protocol objects
+ * through @openagentsinc/nip90 (which reuses the sibling nostr-effect impl),
+ * publish each signed event to a relay, and read it back by id as the receipt.
+ * It does NOT move sats, grant settlement authority, or publish anything private.
+ *
+ * Keys: this drill uses EPHEMERAL demo keys generated per run (generateSecretKey),
+ * never a real agent key. If you ever wire a real key in, pass it ONLY through the
+ * NOSTR_SECRET_KEY env var -- never on argv. No secret is ever emitted or logged.
+ *
+ * Usage:
+ *   bun apps/openagents.com/scripts/nostr-fallback-drill.ts smoke [--relay URL]
+ *   bun apps/openagents.com/scripts/nostr-fallback-drill.ts plan   (offline; builds + prints events, no relay)
+ */
+
+import {
+  LBR_AGENTIC_CODING_REQUEST_KIND,
+  LBR_AGENTIC_CODING_RESULT_KIND,
+  LBR_FEEDBACK_KIND,
+  lbrAcceptanceToDraft,
+  lbrAgenticCodingRequestToDraft,
+  lbrQuoteToDraft,
+  lbrResultToDraft,
+  makeLbrAcceptance,
+  makeLbrAgenticCodingRequest,
+  makeLbrQuote,
+  makeLbrResult,
+} from "@openagentsinc/nip90"
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  type EventTemplate,
+  type VerifiedEvent,
+} from "../../../../nostr-effect/src/wrappers/pure.ts"
+import { wrapEvent } from "../../../../nostr-effect/src/wrappers/nip17.ts"
+
+type Flags = Record<string, string | true>
+type RelayMessage = ReadonlyArray<unknown>
+
+// The publishable shape shared by a finalized event and a NIP-17 gift wrap:
+// both carry a signed id and are valid relay EVENT payloads.
+type PublishableEvent = {
+  readonly id: string
+  readonly kind: number
+  readonly content: string
+  readonly tags: ReadonlyArray<ReadonlyArray<string>>
+}
+
+const defaultRelay = "wss://relay.damus.io"
+const fallbackRelays = ["wss://relay.damus.io", "wss://nos.lol"] as const
+
+// NIP-38 user statuses / NIP-02 contacts / NIP-65 relay list.
+const KIND_USER_STATUS = 30315
+const KIND_CONTACTS = 3
+const KIND_RELAY_LIST = 10002
+
+const usage = () => `Usage:
+  bun apps/openagents.com/scripts/nostr-fallback-drill.ts smoke [--relay URL]
+  bun apps/openagents.com/scripts/nostr-fallback-drill.ts plan
+
+Options:
+  --relay <url>   Public relay to publish/read against. Defaults to ${defaultRelay}.
+`
+
+const parseFlags = (argv: ReadonlyArray<string>): { command: string; flags: Flags } => {
+  const [command = "help", ...rest] = argv
+  const flags: Flags = {}
+  for (let index = 0; index < rest.length; index++) {
+    const arg = rest[index]
+    if (!arg.startsWith("--")) continue
+    const name = arg.slice(2)
+    const next = rest[index + 1]
+    if (next === undefined || next.startsWith("--")) {
+      flags[name] = true
+      continue
+    }
+    flags[name] = next
+    index++
+  }
+  return { command, flags }
+}
+
+const optionalString = (flags: Flags, name: string, fallback: string): string => {
+  const value = flags[name]
+  return typeof value === "string" && value.length > 0 ? value : fallback
+}
+
+const relayWebSocketUrl = (input: string): string => {
+  const url = new URL(/^[a-z]+:\/\//i.test(input) ? input : `wss://${input}`)
+  if (url.protocol === "http:") url.protocol = "ws:"
+  if (url.protocol === "https:") url.protocol = "wss:"
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error(`Expected ws/wss/http/https relay URL, got ${input}`)
+  }
+  return url.toString()
+}
+
+const waitForOpen = (socket: WebSocket): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("WebSocket open timed out")), 10_000)
+    socket.addEventListener("open", () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout)
+      reject(new Error("WebSocket open failed"))
+    })
+  })
+
+const waitForMessage = (
+  socket: WebSocket,
+  label: string,
+  predicate: (message: RelayMessage) => boolean,
+): Promise<RelayMessage> =>
+  new Promise((resolve, reject) => {
+    const seen: Array<RelayMessage> = []
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out waiting for ${label}; saw ${JSON.stringify(seen)}`)),
+      15_000,
+    )
+    socket.addEventListener("message", event => {
+      const decoded: unknown = JSON.parse(String(event.data))
+      const parsed: RelayMessage = Array.isArray(decoded) ? decoded : []
+      seen.push(parsed)
+      if (predicate(parsed)) {
+        clearTimeout(timeout)
+        resolve(parsed)
+      }
+    })
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout)
+      reject(new Error(`WebSocket error while waiting for ${label}`))
+    })
+  })
+
+const publishEvent = async (relayUrl: string, event: PublishableEvent): Promise<RelayMessage> => {
+  const socket = new WebSocket(relayUrl)
+  await waitForOpen(socket)
+  socket.send(JSON.stringify(["EVENT", event]))
+  const ok = await waitForMessage(
+    socket,
+    `OK for ${event.id}`,
+    message => message[0] === "OK" && message[1] === event.id,
+  )
+  socket.close(1000, "publish complete")
+  if (ok[2] !== true) {
+    throw new Error(`Relay rejected ${event.kind}/${event.id}: ${JSON.stringify(ok)}`)
+  }
+  return ok
+}
+
+// Pull the `id` field out of an unknown relay payload without a type assertion.
+const eventIdOf = (value: unknown): string | undefined => {
+  if (typeof value !== "object" || value === null) return undefined
+  const id = Reflect.get(value, "id")
+  return typeof id === "string" ? id : undefined
+}
+
+// Read an event back by id and return its relay-confirmed id (the receipt).
+const readEventId = async (relayUrl: string, event: PublishableEvent): Promise<string> => {
+  const socket = new WebSocket(relayUrl)
+  await waitForOpen(socket)
+  const subscriptionId = `nostr-fallback-${event.kind}-${Date.now()}`
+  socket.send(JSON.stringify(["REQ", subscriptionId, { ids: [event.id], limit: 1 }]))
+  const message = await waitForMessage(
+    socket,
+    `EVENT ${event.id}`,
+    candidate =>
+      candidate[0] === "EVENT" &&
+      candidate[1] === subscriptionId &&
+      eventIdOf(candidate[2]) === event.id,
+  )
+  socket.send(JSON.stringify(["CLOSE", subscriptionId]))
+  socket.close(1000, "read complete")
+  const id = eventIdOf(message[2])
+  if (id === undefined) throw new Error(`Relay returned a malformed event for ${event.id}`)
+  return id
+}
+
+const sign = (template: EventTemplate, secretKey: Uint8Array): VerifiedEvent =>
+  finalizeEvent(template, secretKey)
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+type Phase = {
+  readonly phase: string
+  readonly nip: string
+  readonly note: string
+  readonly event: PublishableEvent
+}
+
+/**
+ * Build the full ordered set of coordination events for the drill.
+ * Every event is signed and publishable; nothing here touches a relay.
+ */
+const buildDrill = () => {
+  const now = Math.floor(Date.now() / 1000)
+
+  // Two ephemeral demo agents (never real keys).
+  const requesterSk = generateSecretKey()
+  const providerSk = generateSecretKey()
+  const requesterPk = getPublicKey(requesterSk)
+  const providerPk = getPublicKey(providerSk)
+
+  const phases: Array<Phase> = []
+
+  // Phase 1+2: HTTP unreachable -> publish liveness over Nostr (NIP-38 kind 30315).
+  // The status content is the public, non-secret signal "openagents-http-unreachable".
+  // NIP-38 statuses are addressable (kind 30315): a later event with the same
+  // `d` tag REPLACES an earlier one, which would make the earlier id un-fetchable.
+  // Give every status in the drill a distinct `d` so each stays independently
+  // addressable and id-readable as its own receipt.
+  const requesterStatus = sign(
+    {
+      kind: KIND_USER_STATUS,
+      created_at: now,
+      tags: [
+        ["d", "fallback-drill-outage"],
+        ["t", "openagents-fallback-drill"],
+        ["expiration", String(now + 3600)],
+      ],
+      content: "openagents-http-unreachable: coordinating over Nostr",
+    },
+    requesterSk,
+  )
+  phases.push({
+    phase: "1-2 fallback-liveness",
+    nip: "NIP-38 (kind 30315)",
+    note: "HTTP unreachable; requester advertises liveness over Nostr",
+    event: requesterStatus,
+  })
+  const providerStatus = sign(
+    {
+      kind: KIND_USER_STATUS,
+      created_at: now,
+      tags: [
+        ["d", "fallback-drill-outage"],
+        ["t", "openagents-fallback-drill"],
+        ["expiration", String(now + 3600)],
+      ],
+      content: "openagents-http-unreachable: provider available for labor",
+    },
+    providerSk,
+  )
+  phases.push({
+    phase: "1-2 fallback-liveness",
+    nip: "NIP-38 (kind 30315)",
+    note: "provider advertises liveness over Nostr",
+    event: providerStatus,
+  })
+
+  // Phase 3: discovery. Requester advertises its fallback relay set (NIP-65 kind
+  // 10002) and a contact list pointing at the provider (NIP-02 kind 3), so peers
+  // can find each other and the agreed relays without any central HTTP service.
+  const requesterRelayList = sign(
+    {
+      kind: KIND_RELAY_LIST,
+      created_at: now,
+      tags: fallbackRelays.map(r => ["r", r]),
+      content: "",
+    },
+    requesterSk,
+  )
+  phases.push({
+    phase: "3 discovery",
+    nip: "NIP-65 (kind 10002)",
+    note: "requester advertises its fallback relay set",
+    event: requesterRelayList,
+  })
+  const requesterContacts = sign(
+    {
+      kind: KIND_CONTACTS,
+      created_at: now,
+      tags: [["p", providerPk, fallbackRelays[0], "provider"]],
+      content: "",
+    },
+    requesterSk,
+  )
+  phases.push({
+    phase: "3 discovery",
+    nip: "NIP-02 (kind 3)",
+    note: "requester contact list points at the provider",
+    event: requesterContacts,
+  })
+
+  // Phase 4: NIP-17 gift-wrapped DM (kind 1059). Requester tells the provider:
+  // keep working, HTTP is down, settle the receipt over Nostr. The plaintext lives
+  // only inside the NIP-44-encrypted seal; the published event content is ciphertext.
+  const giftWrap: PublishableEvent = wrapEvent(
+    requesterSk,
+    { publicKey: providerPk },
+    "openagents fallback: HTTP down, keep the labor job moving and we reconcile over Nostr",
+  )
+  phases.push({
+    phase: "4 private-dm",
+    nip: "NIP-17 gift wrap (kind 1059)",
+    note: "requester -> provider encrypted coordination DM (content is ciphertext)",
+    event: giftWrap,
+  })
+
+  // Phase 5: NIP-90 labor job keeps moving over Nostr (LBR: request/quote/accept/
+  // result). All refs are public-safe; the codec rejects secrets/preimages/invoices.
+  const objectiveRef = "github.openagents.issue:5531"
+  const repositoryRefs = ["github.openagents.repo:openagents"]
+  const verificationCommandRef = "ci.openagents.command:check-deploy"
+  const capabilityRefs = ["capability.openagents.skill:typescript"]
+
+  const lbrRequest = makeLbrAgenticCodingRequest({
+    objectiveRef,
+    repositoryRefs,
+    verificationCommandRef,
+    requiredCapabilityRefs: capabilityRefs,
+    bidMsats: 100_000,
+    forumTopicRef: "forum.openagents.topic:product-promises",
+    relays: [...fallbackRelays],
+  })
+  const requestDraft = lbrAgenticCodingRequestToDraft(lbrRequest)
+  const requestEvent = sign(
+    { kind: requestDraft.kind, created_at: now, tags: requestDraft.tags.map(t => [...t]), content: requestDraft.content },
+    requesterSk,
+  )
+  phases.push({
+    phase: "5 labor-job",
+    nip: `NIP-90 LBR request (kind ${LBR_AGENTIC_CODING_REQUEST_KIND})`,
+    note: "labor request published over Nostr while HTTP is down",
+    event: requestEvent,
+  })
+
+  const lbrQuote = makeLbrQuote({
+    requestId: requestEvent.id,
+    requesterPubkey: requesterPk,
+    amountMsats: 100_000,
+    providerRef: "agent.openagents.provider:lathe",
+    capabilityRefs,
+    quoteRef: "quote.openagents.lbr:fallback-drill",
+    requestRelay: fallbackRelays[0],
+  })
+  const quoteDraft = lbrQuoteToDraft(lbrQuote)
+  const quoteEvent = sign(
+    { kind: quoteDraft.kind, created_at: now + 1, tags: quoteDraft.tags.map(t => [...t]), content: quoteDraft.content },
+    providerSk,
+  )
+  phases.push({
+    phase: "5 labor-job",
+    nip: `NIP-90 LBR quote (kind ${LBR_FEEDBACK_KIND})`,
+    note: "provider quotes the job over Nostr",
+    event: quoteEvent,
+  })
+
+  const lbrAcceptance = makeLbrAcceptance({
+    requestId: requestEvent.id,
+    providerPubkey: providerPk,
+    escrowReceiptRef: "escrow.openagents.receipt:fallback-drill",
+    acceptanceRef: "acceptance.openagents.lbr:fallback-drill",
+    requestRelay: fallbackRelays[0],
+  })
+  const acceptanceDraft = lbrAcceptanceToDraft(lbrAcceptance)
+  const acceptanceEvent = sign(
+    {
+      kind: acceptanceDraft.kind,
+      created_at: now + 2,
+      tags: acceptanceDraft.tags.map(t => [...t]),
+      content: acceptanceDraft.content,
+    },
+    requesterSk,
+  )
+  phases.push({
+    phase: "5 labor-job",
+    nip: `NIP-90 LBR acceptance (kind ${LBR_FEEDBACK_KIND})`,
+    note: "requester accepts the quote over Nostr",
+    event: acceptanceEvent,
+  })
+
+  const lbrResult = makeLbrResult({
+    requestId: requestEvent.id,
+    requesterPubkey: requesterPk,
+    artifactRefs: ["github.openagents.pr:5531-drill"],
+    platformCloseoutRef: "closeout.openagents.lbr:fallback-drill",
+    summaryRef: "summary.openagents.lbr:fallback-drill",
+    testRef: "ci.openagents.run:fallback-drill",
+    requestRelay: fallbackRelays[0],
+  })
+  const resultDraft = lbrResultToDraft(lbrResult)
+  const resultEvent = sign(
+    { kind: resultDraft.kind, created_at: now + 3, tags: resultDraft.tags.map(t => [...t]), content: resultDraft.content },
+    providerSk,
+  )
+  phases.push({
+    phase: "5 labor-job",
+    nip: `NIP-90 LBR result (kind ${LBR_AGENTIC_CODING_RESULT_KIND})`,
+    note: "provider delivers the result over Nostr",
+    event: resultEvent,
+  })
+
+  // Phase 6: recovery / reconcile. HTTP is back; each agent publishes an "online"
+  // status so the cluster knows the outage is over and state can be reconciled.
+  const requesterRecovered = sign(
+    {
+      kind: KIND_USER_STATUS,
+      created_at: now + 4,
+      tags: [["d", "fallback-drill-recovery"], ["t", "openagents-fallback-drill"]],
+      content: "openagents-http-recovered: reconciled, online",
+    },
+    requesterSk,
+  )
+  phases.push({
+    phase: "6 recovery",
+    nip: "NIP-38 (kind 30315)",
+    note: "requester reconciles on recovery",
+    event: requesterRecovered,
+  })
+  const providerRecovered = sign(
+    {
+      kind: KIND_USER_STATUS,
+      created_at: now + 4,
+      tags: [["d", "fallback-drill-recovery"], ["t", "openagents-fallback-drill"]],
+      content: "openagents-http-recovered: reconciled, online",
+    },
+    providerSk,
+  )
+  phases.push({
+    phase: "6 recovery",
+    nip: "NIP-38 (kind 30315)",
+    note: "provider reconciles on recovery",
+    event: providerRecovered,
+  })
+
+  return { requesterPk, providerPk, phases }
+}
+
+// Defence in depth: scan every byte we are about to publish for anything that
+// looks like a secret, before it leaves the process. The LBR codec already
+// rejects unsafe refs; this catches the hand-built NIP-38/02/65 events too.
+const SECRET_PATTERN =
+  /(nsec1|lnbc|lntb|lno1|-----BEGIN|mnemonic|payment_preimage|preimage|seed phrase|SECRET|TOKEN=|api[_-]?key)/i
+
+const assertNoSecrets = (phases: ReadonlyArray<Phase>) => {
+  for (const p of phases) {
+    const haystack = `${p.event.content}\n${JSON.stringify(p.event.tags)}`
+    if (SECRET_PATTERN.test(haystack)) {
+      throw new Error(`Refusing to publish ${p.phase} (${p.nip}): event would carry secret-like material`)
+    }
+  }
+}
+
+const summarise = (relay: string, phases: ReadonlyArray<Phase>, requesterPk: string, providerPk: string) =>
+  JSON.stringify(
+    {
+      ok: true,
+      drill: "agents.nostr_fallback_coordination.v1",
+      relay,
+      requesterPubkey: requesterPk,
+      providerPubkey: providerPk,
+      events: phases.map(p => ({ phase: p.phase, nip: p.nip, note: p.note, kind: p.event.kind, id: p.event.id })),
+    },
+    null,
+    2,
+  )
+
+const runPlan = () => {
+  const { requesterPk, providerPk, phases } = buildDrill()
+  assertNoSecrets(phases)
+  console.log(summarise("(none: plan mode)", phases, requesterPk, providerPk))
+}
+
+const runSmoke = async (flags: Flags) => {
+  const { requesterPk, providerPk, phases } = buildDrill()
+  assertNoSecrets(phases)
+  const relayUrl = relayWebSocketUrl(optionalString(flags, "relay", defaultRelay))
+
+  // Pace publishes so we stay well under public-relay anti-spam rate limits.
+  const publishDelayMs = Number(optionalString(flags, "publish-delay-ms", "750"))
+  let first = true
+  for (const p of phases) {
+    if (!first) await sleep(publishDelayMs)
+    first = false
+    await publishEvent(relayUrl, p.event)
+  }
+  const readBack: Array<string> = []
+  for (const p of phases) {
+    const gotId = await readEventId(relayUrl, p.event)
+    if (gotId !== p.event.id) {
+      throw new Error(`Read-back id mismatch for ${p.phase}: ${gotId} != ${p.event.id}`)
+    }
+    readBack.push(gotId)
+  }
+
+  console.log(summarise(relayUrl, phases, requesterPk, providerPk))
+  console.error(`read-back verified ${readBack.length}/${phases.length} events on ${relayUrl}`)
+}
+
+const { command, flags } = parseFlags(process.argv.slice(2))
+
+if (command === "smoke") {
+  await runSmoke(flags)
+} else if (command === "plan") {
+  runPlan()
+} else {
+  console.log(usage())
+  process.exit(command === "help" || command === "--help" ? 0 : 1)
+}

--- a/docs/nostr/2026-06-20-outage-coordination-drill.md
+++ b/docs/nostr/2026-06-20-outage-coordination-drill.md
@@ -1,0 +1,119 @@
+# Nostr Outage-Coordination Drill
+
+Date: 2026-06-20
+
+Status: drill receipt for the product promise `agents.nostr_fallback_coordination.v1`
+(DE-8, EPIC #5531). This document does not change any live path, does not make
+Nostr a settlement authority, and does not mark any promise green. The green flip
+is owner-signed; this is the dereferenceable receipt that backs it.
+
+## Summary
+
+When the OpenAgents HTTP surface is unreachable, agents must still be able to find
+each other, agree to keep working, move a labor job, and reconcile on recovery —
+entirely over Nostr. This drill demonstrates that fallback path end to end, with a
+committed, runnable smoke harness, and produces a public, fetchable receipt: every
+coordination step is a real signed event on a public relay.
+
+The harness is `apps/openagents.com/scripts/nostr-fallback-drill.ts`. It is modeled
+on the existing `apps/openagents.com/scripts/nip-ds.ts` relay publish/read-back
+smoke and reuses `@openagentsinc/nip90` (which re-exports `nostr-effect`); it does
+not introduce a new messaging stack.
+
+## What the drill exercises
+
+Ordered, end to end:
+
+1. **OpenAgents HTTP unreachable → fall back to Nostr.** The scenario starts from
+   the platform HTTP API being down.
+2. **NIP-38 liveness (kind 30315).** Each agent publishes a user-status so peers
+   can see it is alive and what it is doing while HTTP is down.
+3. **Discovery via NIP-65 + NIP-02 (kinds 10002, 3).** The requester advertises its
+   fallback relay set (NIP-65 relay list) and a contact list pointing at the
+   provider (NIP-02). The fallback relay set is itself discovered over Nostr — no
+   central directory is needed.
+4. **NIP-17 private DM (kind 1059 gift wrap).** The two agents exchange a
+   gift-wrapped direct message agreeing to keep working and to reconcile over
+   Nostr. The message body lives only inside the NIP-44-encrypted seal; the
+   published event content is ciphertext.
+5. **NIP-90 labor job keeps moving (kinds 5934 / 7000 / 6934).** A full LBR
+   (labor bid request) lifecycle runs over Nostr: request → quote → acceptance →
+   result. All payloads are ref-only and public-safe — the LBR codec in
+   `packages/nip90` rejects secrets, preimages, invoices, and filesystem paths, so
+   a job can move over a public relay without leaking anything sensitive.
+6. **Recovery / reconcile (NIP-38).** When HTTP is back, each agent publishes an
+   "online" status so the cluster knows the outage is over and can reconcile state.
+
+## Public-safety properties
+
+- **Ephemeral keys only.** The drill generates throwaway demo keys per run
+  (`generateSecretKey`); it never uses a real agent key. If a real key is ever
+  wired in, it is passed only via the `NOSTR_SECRET_KEY` environment variable,
+  never on argv.
+- **No secret ever leaves the process.** The harness runs a `SECRET_PATTERN`
+  guard (`assertNoSecrets`) over every event's content and tags before publishing,
+  and refuses to publish anything that looks like a secret. The NIP-90 LBR payloads
+  are additionally validated ref-only by the `@openagentsinc/nip90` codec.
+- **The private DM is encrypted.** The kind-1059 gift wrap published to the relay
+  carries only NIP-44 ciphertext; the plaintext coordination message is not
+  recoverable from the public event.
+
+## How to run
+
+```sh
+# Offline: build and print all events, no relay.
+bun apps/openagents.com/scripts/nostr-fallback-drill.ts plan
+
+# Smoke: publish every event to a public relay and read each one back by id.
+bun apps/openagents.com/scripts/nostr-fallback-drill.ts smoke --relay wss://nos.lol
+```
+
+The `smoke` command publishes each event, then re-fetches it by id and asserts the
+relay returned the same id. A successful run prints a JSON bundle of every event id
+and ends with `read-back verified 11/11 events on <relay>`.
+
+## Recorded receipt (public, fetchable)
+
+The run below was published to **`wss://nos.lol`** on 2026-06-20. Every id is
+independently fetchable, e.g.:
+
+```sh
+nak req -i <event-id> wss://nos.lol
+```
+
+Demo keys for this run (ephemeral, not real agent keys):
+
+- requester pubkey: `fe4909ce7db1a92e7376e019cf3dc06e075fe092a50a4e33465775a55f42e18b`
+- provider pubkey:  `9bfe8e34af39925eab0e41be85d58a18980df9e3f7ba2a3dc84d338e0238b6f8`
+
+| # | Phase | NIP / kind | Event id |
+|---|---|---|---|
+| 1 | fallback liveness (requester) | NIP-38 / 30315 | `faadd96a073906a9ff08b9bcbac40d82e9bb17e5f2947d414ffb8b6edf1b99c8` |
+| 2 | fallback liveness (provider) | NIP-38 / 30315 | `eb4e1565e2c135f1b21e8e18a838803142410a7ff8c3c1c5f083dcd7d6ac4760` |
+| 3 | discovery: relay list | NIP-65 / 10002 | `75026eb4203b9ef1980078953b01a90b8715914b1200ac22fadf005087f6b053` |
+| 4 | discovery: contacts | NIP-02 / 3 | `3764e5e25a24f742f95b019a450996332404e71b2aef7c3cdbd2b67b4fb3ae97` |
+| 5 | private coordination DM | NIP-17 gift wrap / 1059 | `050cf83f79268191453a0c90a2e92cf886427df28a626a21ecec28bbec693961` |
+| 6 | labor request | NIP-90 LBR / 5934 | `34c02f513b7bb7ce3fbf7a93f7336a5429617340dcae211444304752f8875c50` |
+| 7 | labor quote | NIP-90 LBR / 7000 | `e7ff7d3019997ab12a37b2882f6507311e727091046323800cefbbafee5690aa` |
+| 8 | labor acceptance | NIP-90 LBR / 7000 | `3457e4aa445e2e11282aee51a4724a1eb69887cc20b3dc603d3349aee9574e95` |
+| 9 | labor result | NIP-90 LBR / 6934 | `1a81fc2cf64c5ab3cb6651644b349c0da9ef1b2de12759d062cd604e1a3c6ad6` |
+| 10 | recovery (requester) | NIP-38 / 30315 | `537c80802d4a1eb15733d760754ea804547f11dd8bf331b37bf2447cecbc59cf` |
+| 11 | recovery (provider) | NIP-38 / 30315 | `c39fe4f4f7eff9528b49a27684d3d15a2cc5990339321a898e0af8a882501909` |
+
+Notes on the receipt:
+
+- The kind-1059 gift wrap (#5) has a different on-wire `pubkey` from the requester:
+  NIP-59 wraps with a one-time ephemeral key to hide sender metadata, which is the
+  correct, privacy-preserving behavior. Its `content` is ~1.4 KB of NIP-44
+  ciphertext, not the plaintext message.
+- The NIP-90 LBR request/result events (#6, #9) carry an **empty** `content` — all
+  job information is in ref-only tags, which is the codec's public-safe contract.
+- NIP-38 statuses are addressable (kind 30315): each status in this drill uses a
+  distinct `d` tag so none replaces another and every id stays individually
+  fetchable.
+
+Because each event id is resolvable on the relay, this drill is a dereferenceable
+receipt: anyone can re-fetch the events and confirm the fallback-coordination
+sequence actually happened over Nostr. Event ids are deterministic per signed
+content but the demo keys are regenerated each run, so a fresh run produces a new,
+equally-fetchable set of ids and the same `read-back verified 11/11` result.


### PR DESCRIPTION
## What

Produces the dereferenceable receipt for `agents.nostr_fallback_coordination.v1` (DE-8, part of EPIC #5531): a **Nostr outage-coordination drill smoke** plus a **public-safe evidence doc**.

Acceptance for the promise is "outage drill receipt + Nostr coordination tooling smoke". This PR delivers exactly that.

## Files (additive only)

- `apps/openagents.com/scripts/nostr-fallback-drill.ts` — runnable drill harness, modeled on the existing `scripts/nip-ds.ts` relay publish/read-back smoke; reuses `@openagentsinc/nip90` (which re-exports `nostr-effect`). No new messaging stack.
- `docs/nostr/2026-06-20-outage-coordination-drill.md` — public-safe evidence doc with the fetchable event ids.

## The drill (end to end)

1. OpenAgents HTTP unreachable → fall back to Nostr
2. **NIP-38** user-status (kind 30315) liveness
3. discovery via **NIP-65** relay list (10002) + **NIP-02** contacts (3) — the fallback relay set is advertised over Nostr
4. **NIP-17** gift-wrapped DM (kind 1059) to coordinate
5. **NIP-90** labor job keeps moving: LBR request → quote → accept → result (5934/7000/6934)
6. **NIP-38** recovery / reconcile

## Run it

```sh
bun apps/openagents.com/scripts/nostr-fallback-drill.ts plan            # offline build
bun apps/openagents.com/scripts/nostr-fallback-drill.ts smoke --relay wss://nos.lol
```

A passing run prints every event id and ends with `read-back verified 11/11 events on <relay>`.

## Verification (gates)

- **Smoke**: 11/11 events published and read back from `wss://nos.lol`; every id independently re-fetchable via `nak req -i <id> wss://nos.lol` (sample ids recorded in the evidence doc).
- **Lint**: `eslint` clean on the new script.
- **Public-safe / zero secrets**: ephemeral demo keys per run (real keys only via `NOSTR_SECRET_KEY` env); an `assertNoSecrets` guard runs over every event before publish; the NIP-17 DM body is NIP-44 ciphertext on the wire; NIP-90 LBR payloads are ref-only (the codec rejects secrets/preimages/invoices/paths). Verified: kind-1059 content is ciphertext, kind-5934/6934 content is empty.

## Scope / notes

- Additive: two new files, nothing else touched.
- This produces the **receipt**; the promise green flip is owner-signed.
- Chips at `blocker.product_promises.nostr_outage_coordination_drill_missing` and minimally at `nostr_messaging_tooling_incomplete`.

Refs #5531. worker ≠ validator: Lathe produces; CI and reviewers validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)