### PR TITLE
feat(mobile): voice transcript ingestion endpoint (INERT, flag-gated) — DE-7 #5530

### DIFF
--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -360,6 +360,15 @@ const runPromiseAllowlist = new Map([
   // bridge; ratchet down if the operator billing handlers move to an Effect
   // program.
   ['workers/api/src/operator-billing-routes.ts', 1],
+  // Added 2026-06-19 (#5523 / DE-7 #5530): the voice-session transcript
+  // ingestion route runs the Effect-returning pure ingest core
+  // (`buildVoiceProgramIngestProposal`) once from the Promise-based,
+  // flag-gated `/api/mobile/voice-sessions/ingest` handler. The route awaits
+  // the request body (so the handler is Promise-shaped) and bridges the pure
+  // Effect mapping into it. Named bridge; ratchet down if the route handler
+  // moves to an Effect program. INERT by default (VOICE_PROGRAM_INGEST_ENABLED
+  // off → the core is never run); promise stays red.
+  ['workers/api/src/voice-program-ingest-routes.ts', 1],
 ])
 
 const runPromiseDetails = countByFile(sourceFiles, /Effect\.runPromise\(/g)

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -29,6 +29,16 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // red/inert) surface. Metering clears only the usage-metering blocker; the
   // settlement blocker stays owner-gated and the promise stays red regardless.
   SIGNATURE_USAGE_METERING_ENABLED?: string | undefined
+  // Voice-session transcript ingestion endpoint flag (EPIC #5523 / DE-7 #5530;
+  // promise mobile.voice_session_evidence_transcript_ingest.v1, red). Default
+  // OFF: the `/api/mobile/voice-sessions/ingest` route is INERT on the live
+  // Worker (returns an honest inert/red payload and never runs the ingest
+  // core). Set "true"/"1"/"on" to arm the endpoint so it decodes
+  // already-transcribed, redacted, ref-only segments and returns an
+  // approval-gated program-input proposal. Arming clears ONLY the
+  // ingestion-endpoint blocker; STT vendor + approval UI stay owner/product-
+  // gated and the promise stays red regardless.
+  VOICE_PROGRAM_INGEST_ENABLED?: string | undefined
   // Inference gateway feature flag (EPIC #5474, #5476). Default OFF: the
   // `/v1/chat/completions` route is inert on the live Worker until the
   // inference build lands. Set "true"/"1"/"on" to enable.

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -38,6 +38,11 @@ import {
   isSignatureUsageMeteringEnabled,
 } from './signature-usage-metering-routes'
 import {
+  VoiceProgramIngestEndpoint,
+  handleVoiceProgramIngestApi,
+  isVoiceProgramIngestEnabled,
+} from './voice-program-ingest-routes'
+import {
   AutopilotComposedRunEndpoint,
   handleAutopilotComposedRunApi,
   isAutopilotComposedRunEnabled,
@@ -7967,6 +7972,28 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
           env.SIGNATURE_USAGE_METERING_ENABLED,
         ),
       }),
+  },
+  {
+    // Voice-session transcript ingestion endpoint (#5523 / DE-7 #5530; promise
+    // mobile.voice_session_evidence_transcript_ingest.v1, red). INERT by
+    // default: when VOICE_PROGRAM_INGEST_ENABLED is OFF the endpoint returns an
+    // honest inert/red payload and never runs the ingest core. When armed it
+    // decodes already-transcribed, redacted, ref-only segments and runs the
+    // existing pure buildVoiceProgramIngestProposal core to return an
+    // approval-gated program-input proposal (no STT, no audio capture, no
+    // mutation, no execution, no settlement). This clears ONLY
+    // blocker.product_promises.voice_ingestion_endpoint_missing; the
+    // transcription-service and approval-UI blockers stay owner/product-gated
+    // and the promise stays red. POST only.
+    path: VoiceProgramIngestEndpoint,
+    handler: (request, env) =>
+      Effect.promise(() =>
+        handleVoiceProgramIngestApi(request, {
+          enabled: isVoiceProgramIngestEnabled(
+            env.VOICE_PROGRAM_INGEST_ENABLED,
+          ),
+        }),
+      ),
   },
   {
     // Autopilot all-in-one composed-run scaffold (#5510, #5519). INERT: the

--- a/apps/openagents.com/workers/api/src/voice-program-ingest-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/voice-program-ingest-routes.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  OMNI_VOICE_SESSION_READ_ONLY_AUTHORITY,
+  exampleOmniVoiceTranscriptSegment,
+} from './omni-voice-session-evidence'
+import { exampleVoiceProgramIngestSessionMetadata } from './voice-program-ingest'
+import {
+  VOICE_PROGRAM_INGEST_BLOCKERS,
+  VoiceProgramIngestEndpoint,
+  handleVoiceProgramIngestApi,
+  isVoiceProgramIngestEnabled,
+} from './voice-program-ingest-routes'
+
+const ingestUrl = `https://example.com${VoiceProgramIngestEndpoint}`
+
+const postRequest = (body: unknown): Request =>
+  new Request(ingestUrl, {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  })
+
+const exampleBody = (overrides: Record<string, unknown> = {}) => ({
+  metadata: exampleVoiceProgramIngestSessionMetadata(),
+  segments: [
+    exampleOmniVoiceTranscriptSegment({
+      confidenceBps: 9200,
+      evidenceRefs: ['evidence.public.voice_segment_1_transcript'],
+      segmentRef: 'segment.public.voice_001',
+      sourceRefs: ['source.public.browser_audio_summary'],
+      speakerRole: 'user',
+      textRef: 'text.public.brand_origin_summary',
+    }),
+    exampleOmniVoiceTranscriptSegment({
+      confidenceBps: 8800,
+      evidenceRefs: ['evidence.public.voice_segment_2_transcript'],
+      segmentRef: 'segment.public.voice_002',
+      sourceRefs: ['source.public.browser_audio_summary'],
+      speakerRole: 'operator',
+      startMillis: 11_000,
+      textRef: 'text.public.brand_values_summary',
+    }),
+  ],
+  ...overrides,
+})
+
+describe('isVoiceProgramIngestEnabled', () => {
+  test('defaults OFF and only arms on explicit truthy tokens', () => {
+    expect(isVoiceProgramIngestEnabled(undefined)).toBe(false)
+    expect(isVoiceProgramIngestEnabled('')).toBe(false)
+    expect(isVoiceProgramIngestEnabled('false')).toBe(false)
+    expect(isVoiceProgramIngestEnabled('0')).toBe(false)
+    expect(isVoiceProgramIngestEnabled('off')).toBe(false)
+    expect(isVoiceProgramIngestEnabled('true')).toBe(true)
+    expect(isVoiceProgramIngestEnabled('1')).toBe(true)
+    expect(isVoiceProgramIngestEnabled('ON')).toBe(true)
+    expect(isVoiceProgramIngestEnabled(' yes ')).toBe(true)
+  })
+})
+
+describe('handleVoiceProgramIngestApi', () => {
+  test('rejects non-POST with 405', async () => {
+    const response = await handleVoiceProgramIngestApi(
+      new Request(ingestUrl, { method: 'GET' }),
+      { enabled: true },
+    )
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('POST')
+  })
+
+  test('INERT by default: disabled returns an honest red payload and never runs the core', async () => {
+    const response = await handleVoiceProgramIngestApi(
+      postRequest(exampleBody()),
+      { enabled: false },
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.inert).toBe(true)
+    expect(payload.enabled).toBe(false)
+    expect(payload.promiseState).toBe('red')
+    expect(payload.promiseId).toBe(
+      'mobile.voice_session_evidence_transcript_ingest.v1',
+    )
+    expect(payload.executesProgramRun).toBe(false)
+    expect(payload.callsTranscriptionService).toBe(false)
+    expect(payload.capturesAudio).toBe(false)
+    // The named blocker this endpoint clears, and the two that stay gated.
+    expect(payload.blockerCleared).toBe(VOICE_PROGRAM_INGEST_BLOCKERS.cleared)
+    expect(payload.blockerCleared).toBe(
+      'blocker.product_promises.voice_ingestion_endpoint_missing',
+    )
+    expect(payload.remainingBlockers).toEqual([
+      'blocker.product_promises.voice_transcription_service_missing',
+      'blocker.product_promises.voice_proposal_and_approval_ui_missing',
+    ])
+    // No proposal is produced while inert.
+    expect(payload.proposal).toBeUndefined()
+  })
+
+  test('ARMED: decodes ref-only segments and returns the approval-gated program-input proposal', async () => {
+    const response = await handleVoiceProgramIngestApi(
+      postRequest(exampleBody()),
+      { enabled: true },
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.promiseState).toBe('red')
+    expect(payload.enabled).toBe(true)
+    // The envelope echoes that nothing executes; only program INPUT is proposed.
+    expect(payload.executesProgramRun).toBe(false)
+    expect(payload.proposesProgramInputOnly).toBe(true)
+    // The blocker this clears stays surfaced; settlement-adjacent blockers stay.
+    expect(payload.blockerCleared).toBe(
+      'blocker.product_promises.voice_ingestion_endpoint_missing',
+    )
+
+    const proposal = payload.proposal as Record<string, unknown>
+    expect(proposal).toBeDefined()
+    expect(proposal.stage).toBe('brand-story')
+    expect(proposal.proposesProgramInputOnly).toBe(true)
+    expect(proposal.executesProgramRun).toBe(false)
+    expect(proposal.admittedSegmentCount).toBe(2)
+    expect(proposal.skippedSegmentCount).toBe(0)
+    expect(proposal.meanConfidenceBps).toBe(9000)
+    expect(
+      (proposal.segmentInputs as ReadonlyArray<{ segmentRef: string }>).map(
+        input => input.segmentRef,
+      ),
+    ).toEqual(['segment.public.voice_001', 'segment.public.voice_002'])
+
+    // Read-only authority is echoed: the proposal asserts no mutation/execution.
+    const authority = proposal.authority as Record<string, unknown>
+    expect(authority.authorityBoundary).toBe(
+      OMNI_VOICE_SESSION_READ_ONLY_AUTHORITY.authorityBoundary,
+    )
+    expect(authority.noCommandExecution).toBe(true)
+    expect(authority.noTranscriptMutation).toBe(true)
+    expect(authority.noPaymentMutation).toBe(true)
+    expect(authority.noAudioCaptureMutation).toBe(true)
+  })
+
+  test('ARMED: a malformed body is safely rejected with 400 (no leak)', async () => {
+    const response = await handleVoiceProgramIngestApi(
+      postRequest({ metadata: { not: 'valid' }, segments: 'nope' }),
+      { enabled: true },
+    )
+    expect(response.status).toBe(400)
+    const payload = (await response.json()) as Record<string, unknown>
+    // Generic safe message, no transcript content or internal detail.
+    expect(JSON.stringify(payload)).not.toContain('nope')
+  })
+
+  test('ARMED: a non-read-only authority is rejected by the core as unsafe (422)', async () => {
+    const unsafeMetadata = {
+      ...exampleVoiceProgramIngestSessionMetadata(),
+      authority: {
+        ...OMNI_VOICE_SESSION_READ_ONLY_AUTHORITY,
+        // Flip a single read-only guard off: the core must refuse.
+        noCommandExecution: false,
+      },
+    }
+    const response = await handleVoiceProgramIngestApi(
+      postRequest({ ...exampleBody(), metadata: unsafeMetadata }),
+      { enabled: true },
+    )
+    expect(response.status).toBe(422)
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.error).toBe('voice_program_ingest_unsafe')
+    expect(typeof payload.reason).toBe('string')
+  })
+})

--- a/apps/openagents.com/workers/api/src/voice-program-ingest-routes.ts
+++ b/apps/openagents.com/workers/api/src/voice-program-ingest-routes.ts
@@ -1,0 +1,276 @@
+// Voice-session transcript ingestion endpoint
+// (EPIC #5523 / DE-7 #5530; promise
+// mobile.voice_session_evidence_transcript_ingest.v1, red).
+//
+// INERT by default. This route is wired into the live Worker but is gated by
+// VOICE_PROGRAM_INGEST_ENABLED. When the flag is OFF (default) the endpoint
+// NEVER touches the ingest core: it returns an honest inert JSON
+// (`inert: true`, `promiseState: 'red'`, all three named blockers listed) so
+// no behavior changes on the deployed Worker.
+//
+// When the flag is ARMED, the endpoint decodes ALREADY-TRANSCRIBED, redacted,
+// ref-only voice transcript segments + session metadata and runs the EXISTING
+// pure, deterministic `buildVoiceProgramIngestProposal` core
+// (voice-program-ingest.ts, #4992) to return an approval-gated program-input
+// proposal (`proposesProgramInputOnly: true`, `executesProgramRun: false`).
+//
+// Authority boundary (carried verbatim from the ingest core): a voice
+// transcript is EVIDENCE of intent, not command authority. This endpoint:
+//   - performs NO speech-to-text (no STT vendor is chosen or called here);
+//   - performs NO audio capture;
+//   - performs NO mutation (transcripts/proposals/providers/payments);
+//   - executes NO program run, NO command, NO payment, NO settlement, NO spend;
+//   - upgrades NO public claim.
+// It only PROPOSES a structured program input that downstream Blueprint
+// program runs consume behind their own approval/release gates.
+//
+// This wiring clears ONLY blocker.product_promises.voice_ingestion_endpoint_missing.
+// The other two blockers stay open and owner/product-gated:
+//   - blocker.product_promises.voice_transcription_service_missing (STT vendor
+//     + live audio capture is a product decision), and
+//   - blocker.product_promises.voice_proposal_and_approval_ui_missing (the
+//     approval UI).
+// The promise stays red; no green flip is claimed (owner-signed per
+// proof.claim_upgrade_receipts.v1).
+
+import { badRequest, jsonResponse } from '@openagentsinc/sync-worker'
+import { Effect, Exit } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import { decodeUnknownWithSchema, readJsonObject } from './json-boundary'
+import {
+  OmniVoiceTranscriptSegment,
+} from './omni-voice-session-evidence'
+import {
+  buildVoiceProgramIngestProposal,
+  VOICE_INGEST_SUPPORTED_STAGES,
+  VoiceProgramIngestSessionMetadata,
+  VoiceProgramIngestUnsafe,
+  type VoiceIngestSupportedStage,
+  type VoiceProgramIngestOptions,
+} from './voice-program-ingest'
+
+type HttpResponse = globalThis.Response
+
+export const VoiceProgramIngestEndpoint = '/api/mobile/voice-sessions/ingest'
+
+export const VOICE_PROGRAM_INGEST_PROMISE_ID =
+  'mobile.voice_session_evidence_transcript_ingest.v1'
+
+// The three named blockers on the promise. This endpoint clears the first; the
+// other two stay owner/product-gated and are always surfaced honestly.
+export const VOICE_PROGRAM_INGEST_BLOCKERS = {
+  cleared: 'blocker.product_promises.voice_ingestion_endpoint_missing',
+  remaining: [
+    'blocker.product_promises.voice_transcription_service_missing',
+    'blocker.product_promises.voice_proposal_and_approval_ui_missing',
+  ],
+} as const
+
+// Parse the VOICE_PROGRAM_INGEST_ENABLED flag. Default OFF: anything other than
+// an explicit truthy token leaves the endpoint inert.
+export const isVoiceProgramIngestEnabled = (
+  value: string | undefined,
+): boolean => {
+  if (value === undefined) {
+    return false
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+export type VoiceProgramIngestDeps = Readonly<{
+  // Whether the ingestion endpoint is armed. When false (default) the endpoint
+  // returns the inert response and never runs the ingest core.
+  enabled: boolean
+}>
+
+// The honest inert/disabled payload. Read-only, no live capability claimed.
+const inertPayload = (): Record<string, unknown> => ({
+  promiseId: VOICE_PROGRAM_INGEST_PROMISE_ID,
+  promiseState: 'red',
+  inert: true,
+  enabled: false,
+  // Echo the read-only authority boundary so callers can see this endpoint
+  // never executes, mutates, captures audio, or settles.
+  authorityBoundary: 'read_only_voice_session_evidence',
+  executesProgramRun: false,
+  proposesProgramInputOnly: true,
+  capturesAudio: false,
+  callsTranscriptionService: false,
+  blockerCleared: VOICE_PROGRAM_INGEST_BLOCKERS.cleared,
+  remainingBlockers: VOICE_PROGRAM_INGEST_BLOCKERS.remaining,
+  note:
+    'Voice transcript ingestion is flag-gated and INERT by default. Arm ' +
+    'VOICE_PROGRAM_INGEST_ENABLED to accept already-transcribed, redacted, ' +
+    'ref-only segments and return an approval-gated program-input proposal. ' +
+    'No STT vendor or approval UI is wired; the promise stays red.',
+})
+
+interface VoiceProgramIngestRequest {
+  readonly metadata: VoiceProgramIngestSessionMetadata
+  readonly segments: ReadonlyArray<OmniVoiceTranscriptSegment>
+  readonly stage: VoiceIngestSupportedStage | undefined
+  readonly confidenceFloorBps: number | undefined
+  readonly includeSpeakerRoles: ReadonlyArray<string> | undefined
+}
+
+const SUPPORTED_STAGE_VALUES: ReadonlyArray<string> = [
+  ...VOICE_INGEST_SUPPORTED_STAGES.literals,
+]
+
+const isSupportedStage = (value: unknown): value is VoiceIngestSupportedStage =>
+  typeof value === 'string' && SUPPORTED_STAGE_VALUES.includes(value)
+
+// Decode the request body into the typed ingest inputs. Throws (caught by the
+// caller into a safe 400) on any schema or shape violation — no raw body or
+// internal detail leaks.
+const decodeRequest = (
+  body: Record<string, unknown>,
+): VoiceProgramIngestRequest => {
+  const metadata = decodeUnknownWithSchema(
+    VoiceProgramIngestSessionMetadata,
+    body.metadata,
+  )
+
+  const rawSegments = Array.isArray(body.segments) ? body.segments : []
+  const segments = rawSegments.map(segment =>
+    decodeUnknownWithSchema(OmniVoiceTranscriptSegment, segment),
+  )
+
+  const stage = isSupportedStage(body.stage) ? body.stage : undefined
+
+  const confidenceFloorBps =
+    typeof body.confidenceFloorBps === 'number'
+      ? body.confidenceFloorBps
+      : undefined
+
+  const includeSpeakerRoles: ReadonlyArray<string> | undefined =
+    Array.isArray(body.includeSpeakerRoles) &&
+    body.includeSpeakerRoles.every(role => typeof role === 'string')
+      ? body.includeSpeakerRoles.filter(
+          (role): role is string => typeof role === 'string',
+        )
+      : undefined
+
+  return {
+    confidenceFloorBps,
+    includeSpeakerRoles,
+    metadata,
+    segments,
+    stage,
+  }
+}
+
+// Extract the safe failure reason from a failed ingest Exit. The core fails
+// (via Effect.try) with a VoiceProgramIngestUnsafe carried in a `Fail` cause
+// node; we read it structurally so no Cause namespace helper is required, and
+// fall back to a generic safe reason if the shape is unexpected. Never leaks
+// transcript content.
+const FALLBACK_INGEST_REASON =
+  'Voice program ingest failed to build a proposal.'
+
+// Read the `error` payload from a `Fail` cause node without a type assertion.
+const failCauseError = (cause: unknown): unknown => {
+  if (
+    typeof cause === 'object' &&
+    cause !== null &&
+    '_tag' in cause &&
+    cause._tag === 'Fail' &&
+    'error' in cause
+  ) {
+    return cause.error
+  }
+  return undefined
+}
+
+const voiceIngestFailureReason = (
+  exit: Exit.Exit<unknown, VoiceProgramIngestUnsafe>,
+): string => {
+  if (exit._tag !== 'Failure') {
+    return FALLBACK_INGEST_REASON
+  }
+  const error = failCauseError(exit.cause)
+  return error instanceof VoiceProgramIngestUnsafe
+    ? error.reason
+    : FALLBACK_INGEST_REASON
+}
+
+/**
+ * Handle a voice-session transcript ingestion request.
+ *
+ * POST only. Flag-gated: returns the inert payload when disabled (default).
+ * When armed, decodes ref-only segments + metadata and returns the
+ * approval-gated program-input proposal from the pure ingest core. No STT, no
+ * mutation, no execution.
+ */
+export const handleVoiceProgramIngestApi = async (
+  request: Request,
+  deps: VoiceProgramIngestDeps,
+): Promise<HttpResponse> => {
+  if (request.method !== 'POST') {
+    return methodNotAllowed(['POST'])
+  }
+
+  if (!deps.enabled) {
+    return noStoreJsonResponse(inertPayload())
+  }
+
+  let decoded: VoiceProgramIngestRequest
+  try {
+    const body = await readJsonObject(request)
+    decoded = decodeRequest(body)
+  } catch {
+    return badRequest(
+      'Invalid voice ingest request: expected { metadata, segments } with ' +
+        'read-only authority and ref-only redacted transcript segments.',
+    )
+  }
+
+  // The core is a pure Effect that fails with VoiceProgramIngestUnsafe on any
+  // read-only-authority or ref-safety violation. Fold success/failure into a
+  // tagged Exit, then branch on it (no Cause traversal needed). A failure
+  // surfaces the safe reason without leaking any transcript content.
+  // Build the options object with only the keys the caller actually provided,
+  // so exactOptionalPropertyTypes is satisfied (no explicit-undefined keys).
+  const ingestOptions: VoiceProgramIngestOptions = {
+    ...(decoded.stage !== undefined ? { stage: decoded.stage } : {}),
+    ...(decoded.confidenceFloorBps !== undefined
+      ? { confidenceFloorBps: decoded.confidenceFloorBps }
+      : {}),
+    ...(decoded.includeSpeakerRoles !== undefined
+      ? { includeSpeakerRoles: decoded.includeSpeakerRoles }
+      : {}),
+  }
+
+  const exit = await Effect.runPromiseExit(
+    buildVoiceProgramIngestProposal(
+      decoded.segments,
+      decoded.metadata,
+      ingestOptions,
+    ),
+  )
+
+  if (exit._tag === 'Failure') {
+    return jsonResponse(
+      {
+        error: 'voice_program_ingest_unsafe',
+        reason: voiceIngestFailureReason(exit),
+      },
+      { status: 422 },
+    )
+  }
+
+  const proposal = exit.value
+
+  // Honest envelope: the proposal proposes program INPUT only; nothing executed.
+  return noStoreJsonResponse({
+    promiseId: VOICE_PROGRAM_INGEST_PROMISE_ID,
+    promiseState: 'red' as const,
+    enabled: true as const,
+    executesProgramRun: false as const,
+    proposesProgramInputOnly: true as const,
+    blockerCleared: VOICE_PROGRAM_INGEST_BLOCKERS.cleared,
+    remainingBlockers: VOICE_PROGRAM_INGEST_BLOCKERS.remaining,
+    proposal,
+  })
+}

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -20,6 +20,7 @@ const approvedExactRoutePaths = [
   '/api/public/markets/risk/skeleton',
   '/api/public/marketplace/composed-products',
   '/api/public/markets/signature-monetization/metering',
+  '/api/mobile/voice-sessions/ingest',
   '/api/public/autopilot/composed-runs',
   '/api/public/autopilot/labor-products',
   '/api/public/customer-one-cohort',


### PR DESCRIPTION
## What

Wires a **flag-gated, INERT-by-default voice-session transcript ingestion endpoint** that clears `blocker.product_promises.voice_ingestion_endpoint_missing` for `mobile.voice_session_evidence_transcript_ingest.v1` (red) — EPIC #5523 / DE-7 #5530.

Today `voice-program-ingest.ts` ships the pure, deterministic `buildVoiceProgramIngestProposal` core (#4992, WS-G), and the core's own header documents "COORDINATOR WIRING (integration deferred; do NOT wire in this lane)". Nothing in the repo wires it to an HTTP ingestion endpoint — that missing wiring is exactly the named blocker. This PR is that wiring.

## How (additive, behavior-preserving, INERT by default)

Modeled on the proven `signature-usage-metering-routes.ts` (#5538) / `agentic-labor-product-routes.ts` route-handler pattern:

- **New `voice-program-ingest-routes.ts`** — `POST /api/mobile/voice-sessions/ingest`, gated by `VOICE_PROGRAM_INGEST_ENABLED` (default OFF).
  - **Disabled (default):** returns an honest inert JSON (`inert: true`, `promiseState: 'red'`, `blockerCleared` + the two remaining blockers listed) and **never touches the ingest core**. No behavior changes on the deployed Worker.
  - **Armed:** decodes already-transcribed, redacted, **ref-only** segments + session metadata via the existing Effect Schemas and runs the existing pure `buildVoiceProgramIngestProposal` to return the approval-gated program-input proposal (`proposesProgramInputOnly: true`, `executesProgramRun: false`).
  - Non-POST → 405; malformed body → safe 400 (no leak); non-read-only authority → the core's `VoiceProgramIngestUnsafe` → safe 422.
- **`config.ts`** — adds the `VOICE_PROGRAM_INGEST_ENABLED` flag (documented default-OFF/inert).
- **`index.ts`** — registers the route in the exact-route table (after the signature-metering route).
- **`worker-exact-routes.test.ts`** — adds the new path to the approved manifest.
- **`check-zero-debt-architecture.mjs`** — adds the route to the named `Effect.runPromise` bridge allowlist (the handler awaits the request body, so it bridges the pure ingest Effect into a Promise-shaped handler; named bridge, ratchet-down note included).

The endpoint is **not** under `/api/public/*`, so it adds no public-projection-staleness ledger surface.

## Integrity scope

This clears the **ingestion-endpoint** blocker only. The other two named blockers stay **open and owner/product-gated**:
- `voice_transcription_service_missing` — STT vendor + live audio capture is a product decision (this endpoint performs **no** STT and **no** audio capture);
- `voice_proposal_and_approval_ui_missing` — the approval UI.

A voice transcript is **evidence of intent, not command authority**: the endpoint performs no mutation, executes no program run / command / payment / settlement / spend, and upgrades no public claim. The promise **stays red**; **no green flip** is made — the flip is owner-signed per `proof.claim_upgrade_receipts.v1`.

## Receipt (re-runnable by anyone)

`voice-program-ingest-routes.test.ts` — 6 tests:
- flag defaults OFF and only arms on explicit truthy tokens;
- non-POST → 405;
- **disabled returns the inert/red payload and never runs the core** (no proposal produced);
- **armed returns the approval-gated proposal** echoing the read-only authority (`noCommandExecution`/`noTranscriptMutation`/`noPaymentMutation`/`noAudioCaptureMutation` all true, `executesProgramRun: false`);
- malformed body → safe 400 (no leak);
- non-read-only authority → safe 422.

```
bun run --cwd apps/openagents.com test -- workers/api/src/voice-program-ingest-routes.test.ts
# 6 passed
```

Touched-file typecheck (`typecheck:api`) = 0 errors; the pre-existing core test (`voice-program-ingest.test.ts`, 8 pass) and `worker-exact-routes`/`product-promises` manifests unaffected; `check:architecture`, `check:public-projection-freshness`, `check:conflict-markers`, `check:effect-topology` all green. Zero secrets; flags via env only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZFxMcQuTX1mVkXiqdPcFY