### PR TITLE
Fix Artanis responder receipt claims

### DIFF
--- a/apps/autopilot-desktop/electrobun.config.ts
+++ b/apps/autopilot-desktop/electrobun.config.ts
@@ -31,7 +31,7 @@ export default {
       // and resolves its GLB/font/image assets relative to the bundled view
       // module (`views://autopilot-desktop/assets/moksha/...`). Copy the whole
       // asset directory so WebKit does not get empty `views://` responses.
-      "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha":
+      "../../node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha":
         "views/autopilot-desktop/assets/moksha",
       // #5027 (Phase 2, packaged build): the bundled headless Pylon node, built
       // by `bun run build:pylon-node` before electrobun build. electrobun copies

--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -20,7 +20,7 @@
     "proof:shell-control": "bun --preload ./tests/preload.ts scripts/shell-control-proof.ts",
     "smoke:auto-onboarding-e2e": "bun scripts/auto-onboarding-e2e-smoke.ts",
     "verify:training": "bun test tests/cl-53-foldkit.test.ts tests/cl-53-sanitize.test.ts && bun run build:css && bun build src/ui/main.ts --outdir /tmp/autopilot-desktop-ui-build --target browser && bun build src/bun/index.ts --outdir /tmp/autopilot-desktop-bun-build --target bun && bun run smoke:training-scene",
-    "verify:deploy": "bun test tests/electrobun-config.test.ts && bun run verify:training && bun run build && test -s \"build/dev-macos-arm64/Autopilot-dev.app/Contents/Resources/app/views/autopilot-desktop/assets/moksha/diamond.glb\"",
+    "verify:deploy": "bun test tests/electrobun-config.test.ts && bun run verify:training && bun run build && asset=\"$(find build -path '*/Resources/app/views/autopilot-desktop/assets/moksha/diamond.glb' -type f -print -quit)\" && test -n \"$asset\" && test -s \"$asset\"",
     "test": "bash scripts/run-tests.sh",
     "notarize:macos": "bash scripts/notarize-macos.sh"
   },

--- a/apps/autopilot-desktop/tests/electrobun-config.test.ts
+++ b/apps/autopilot-desktop/tests/electrobun-config.test.ts
@@ -7,7 +7,7 @@ import { desktopApplicationMenu } from "../src/bun/application-menu"
 import config from "../electrobun.config"
 
 const mokshaAssetSource =
-  "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha"
+  "../../node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha"
 
 describe("ElectroBun packaging", () => {
   test("uses the concise Autopilot app title", () => {

--- a/apps/openagents.com/workers/api/src/artanis-reply-composer.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-reply-composer.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from 'vitest'
+
+import { artanisMindComplete } from './artanis-mind'
+import {
+  type ComposerForumPost,
+  type ComposerTip,
+  runArtanisComposerTick,
+} from './artanis-reply-composer'
+import { artanisResponderTipReceiptRef } from './tip-ladder'
+
+type MindInput = Parameters<typeof artanisMindComplete>[0]
+
+type ComposerActionRow = {
+  id: string
+  topic_id: string
+  first_post_id: string
+  question_class: string
+  state: string
+  proposal_json: string
+  reply_post_id: string | null
+  asked_at: string
+  replied_at: string | null
+  created_at: string
+  updated_at: string
+  tip_receipt_ref: string | null
+  tip_pay_in_id: string | null
+  tip_ladder_rung: string | null
+  tip_ladder_reason: string | null
+}
+
+type ComposerStore = {
+  actions: Array<ComposerActionRow>
+  bodies: Map<string, string>
+  payIns: Array<{
+    cost_msat: number
+    created_at: string
+    idempotency_key: string
+    pay_in_type: string
+    payer_ref: string
+    state: string
+  }>
+  topics: Map<string, { title: string }>
+}
+
+type BindValue = string | number | null
+
+class ComposerStatement {
+  constructor(
+    private readonly query: string,
+    private readonly store: ComposerStore,
+    private readonly values: ReadonlyArray<BindValue> = [],
+  ) {}
+
+  bind(...values: Array<BindValue>) {
+    return new ComposerStatement(this.query, this.store, values)
+  }
+
+  async all() {
+    if (this.query.includes('FROM artanis_responder_actions a')) {
+      const limit = Number(this.values[0] ?? 0)
+      const results = [...this.store.actions]
+        .filter(action => action.state === 'proposed')
+        .sort((left, right) => left.created_at.localeCompare(right.created_at))
+        .slice(0, limit)
+        .map(action => ({
+          asked_at: action.asked_at,
+          body_text: this.store.bodies.get(action.first_post_id) ?? '',
+          first_post_id: action.first_post_id,
+          id: action.id,
+          question_class: action.question_class,
+          title: this.store.topics.get(action.topic_id)?.title ?? '',
+          topic_id: action.topic_id,
+        }))
+
+      return { results, success: true }
+    }
+
+    return { results: [], success: true }
+  }
+
+  async first() {
+    if (this.query.includes('FROM pay_ins')) {
+      const payerRef = String(this.values[0] ?? '')
+      const sinceIso = String(this.values[1] ?? '')
+      const spent = this.store.payIns
+        .filter(
+          payIn =>
+            payIn.payer_ref === payerRef &&
+            payIn.pay_in_type === 'tip' &&
+            payIn.state === 'paid' &&
+            payIn.idempotency_key.startsWith('artanis-responder-tip:') &&
+            payIn.created_at >= sinceIso,
+        )
+        .reduce((sum, payIn) => sum + payIn.cost_msat, 0)
+
+      return { spent }
+    }
+
+    return null
+  }
+
+  async run() {
+    if (this.query.includes("SET state = 'blocked'")) {
+      this.updateAction(String(this.values[2] ?? ''), action => {
+        action.state = 'blocked'
+        action.proposal_json = String(this.values[0] ?? '{}')
+        action.updated_at = String(this.values[1] ?? '')
+      })
+    }
+
+    if (this.query.includes("SET state = 'responded'")) {
+      this.updateAction(String(this.values[3] ?? ''), action => {
+        action.state = 'responded'
+        action.reply_post_id = String(this.values[0] ?? '')
+        action.replied_at = String(this.values[1] ?? '')
+        action.updated_at = String(this.values[2] ?? '')
+      })
+    }
+
+    if (this.query.includes("SET state = 'tipped'")) {
+      this.updateAction(String(this.values[5] ?? ''), action => {
+        action.state = 'tipped'
+        action.tip_receipt_ref = String(this.values[0] ?? '')
+        action.tip_pay_in_id = String(this.values[1] ?? '')
+        action.tip_ladder_rung = String(this.values[2] ?? '')
+        action.tip_ladder_reason = String(this.values[3] ?? '')
+        action.updated_at = String(this.values[4] ?? '')
+      })
+    }
+
+    return { meta: { changes: 1 }, results: [], success: true }
+  }
+
+  async raw() {
+    return []
+  }
+
+  private updateAction(
+    actionId: string,
+    update: (action: ComposerActionRow) => void,
+  ) {
+    const action = this.store.actions.find(row => row.id === actionId)
+
+    if (action !== undefined) {
+      update(action)
+    }
+  }
+}
+
+const composerDb = (store: ComposerStore): D1Database =>
+  ({
+    batch: async () => [],
+    dump: async () => new ArrayBuffer(0),
+    exec: async () => ({ count: 0, duration: 0 }),
+    prepare: (query: string) => new ComposerStatement(query, store),
+    withSession: () => composerDb(store),
+  }) as unknown as D1Database
+
+const composerStore = (): ComposerStore => ({
+  actions: [
+    {
+      asked_at: '2026-06-20T03:09:58.000Z',
+      created_at: '2026-06-20T03:10:00.000Z',
+      first_post_id: 'post_question_1',
+      id: 'action_1',
+      proposal_json: '{}',
+      question_class: 'pylon_troubleshooting',
+      replied_at: null,
+      reply_post_id: null,
+      state: 'proposed',
+      tip_ladder_reason: null,
+      tip_ladder_rung: null,
+      tip_pay_in_id: null,
+      tip_receipt_ref: null,
+      topic_id: 'topic_1',
+      updated_at: '2026-06-20T03:10:00.000Z',
+    },
+  ],
+  bodies: new Map([
+    [
+      'post_question_1',
+      'How do I make sparkPayoutTargetReady true and keep executor-trace capability refs through heartbeat?',
+    ],
+  ]),
+  payIns: [],
+  topics: new Map([
+    [
+      'topic_1',
+      {
+        title: 'Pylon preflight payout and capability refs',
+      },
+    ],
+  ]),
+})
+
+const successfulMind =
+  (text: string) =>
+  async (input: MindInput): ReturnType<typeof artanisMindComplete> => ({
+    gatewayId: null,
+    model: 'test-model',
+    promptChars: input.prompt.length,
+    responseChars: text.length,
+    servedVia: 'google_direct',
+    text,
+  })
+
+const runComposer = async (
+  store: ComposerStore,
+  deps: Readonly<{
+    forumPost: ComposerForumPost
+    mindText?: string
+    tip: ComposerTip
+  }>,
+) =>
+  runArtanisComposerTick(composerDb(store), {
+    artanisActorRef: 'agent:artanis',
+    forumPost: deps.forumPost,
+    geminiApiKey: 'gemini-test-key',
+    mindComplete: successfulMind(
+      deps.mindText ??
+        'Set sparkPayoutTargetReady from the wallet-readiness path and preserve executor-trace capability refs in the heartbeat payload.\n\n- Artanis (automated responder; the mind proposes, schemas validate, gates hold)',
+    ),
+    nowIso: '2026-06-20T03:15:16.000Z',
+    tip: deps.tip,
+  })
+
+describe('Artanis reply composer receipts', () => {
+  test('tips before posting and publishes only the returned receipt ref', async () => {
+    const store = composerStore()
+    const events: Array<string> = []
+    const posts: Array<Parameters<ComposerForumPost>[0]> = []
+    const returnedReceiptRef =
+      'receipt.forum.tip_ladder.resolved_artanis_topic_1'
+
+    const outcome = await runComposer(store, {
+      forumPost: async input => {
+        events.push('post')
+        posts.push(input)
+        return { postId: 'post_reply_1' }
+      },
+      tip: async () => {
+        events.push('tip')
+        return {
+          ladderReason: 'recipient_destination_missing',
+          payInId: 'payin_1',
+          receiptRef: returnedReceiptRef,
+          rung: 'credited',
+        }
+      },
+    })
+
+    expect(events).toEqual(['tip', 'post'])
+    expect(outcome).toMatchObject({ blocked: 0, responded: 1, tipped: 1 })
+    expect(posts[0]?.bodyText).toContain(
+      `Responder tip receipt: ${returnedReceiptRef}`,
+    )
+    expect(posts[0]?.bodyText).not.toContain(
+      artanisResponderTipReceiptRef('topic_1'),
+    )
+    expect(store.actions[0]).toMatchObject({
+      reply_post_id: 'post_reply_1',
+      state: 'tipped',
+      tip_ladder_reason: 'recipient_destination_missing',
+      tip_ladder_rung: 'credited',
+      tip_pay_in_id: 'payin_1',
+      tip_receipt_ref: returnedReceiptRef,
+    })
+  })
+
+  test('posts no receipt claim when the tip path fails', async () => {
+    const store = composerStore()
+    const events: Array<string> = []
+    const posts: Array<Parameters<ComposerForumPost>[0]> = []
+
+    const outcome = await runComposer(store, {
+      forumPost: async input => {
+        events.push('post')
+        posts.push(input)
+        return { postId: 'post_reply_1' }
+      },
+      tip: async () => {
+        events.push('tip')
+        return { error: 'tip_ladder_failed' }
+      },
+    })
+
+    expect(events).toEqual(['tip', 'post'])
+    expect(outcome).toMatchObject({ blocked: 0, responded: 1, tipped: 0 })
+    expect(posts[0]?.bodyText).not.toContain('Responder tip receipt:')
+    expect(posts[0]?.bodyText).not.toContain('receipt.forum.tip_ladder.')
+    expect(store.actions[0]).toMatchObject({
+      reply_post_id: 'post_reply_1',
+      state: 'responded',
+      tip_receipt_ref: null,
+    })
+  })
+})

--- a/apps/openagents.com/workers/api/src/artanis-reply-composer.ts
+++ b/apps/openagents.com/workers/api/src/artanis-reply-composer.ts
@@ -40,6 +40,13 @@ export type ComposerTip = (input: {
   | { error: string }
 >
 
+type ComposerMindComplete = typeof artanisMindComplete
+
+type SuccessfulComposerTip = Exclude<
+  Awaited<ReturnType<ComposerTip>>,
+  { error: string }
+>
+
 export type ComposerTickOutcome = Readonly<{
   considered: number
   responded: number
@@ -72,6 +79,7 @@ export const runArtanisComposerTick = async (
     gatewayToken?: string | undefined
     forumPost: ComposerForumPost
     tip: ComposerTip
+    mindComplete?: ComposerMindComplete | undefined
     artanisActorRef: string
     nowIso: string
   }>,
@@ -134,6 +142,7 @@ export const runArtanisComposerTick = async (
   let responded = 0
   let tipped = 0
   let blocked = 0
+  const mindComplete = deps.mindComplete ?? artanisMindComplete
 
   for (const proposal of proposals) {
     const topicId = String(proposal.topic_id)
@@ -147,13 +156,13 @@ export const runArtanisComposerTick = async (
       },
     }
 
-    const mindResult = await artanisMindComplete({
+    const mindResult = await mindComplete({
       apiKey: deps.geminiApiKey,
       ...(deps.gatewayToken === undefined || deps.gatewayToken === ''
         ? {}
         : { gatewayToken: deps.gatewayToken }),
       prompt: [
-        'Compose a reply to this Pylon contributor question. GROUNDING RULES (absolute): every claim about the platform, promises, capabilities, dispatch, or payments must come from the grounding JSON below - if the grounding does not answer part of the question, say so plainly rather than inventing. Device facts come only from the question body (the Pylon embedded its own inventory there). Be specific, useful, and honest about what is yellow vs green. 150-350 words, plain text. End with: - Artanis (automated responder; the mind proposes, schemas validate, gates hold)',
+        'Compose a reply to this Pylon contributor question. Answer the concrete operational question first, using only the question body and grounding JSON. Do not recap product-promise registry entries unless they directly answer the question. GROUNDING RULES (absolute): every claim about the platform, promises, capabilities, dispatch, or payments must come from the grounding JSON below - if the grounding does not answer part of the question, say so plainly rather than inventing. Device facts come only from the question body (the Pylon embedded its own inventory there). Be specific, useful, and honest about what is yellow vs green. 150-350 words, plain text, complete sentences only; shorten by removing whole sentences rather than emitting clipped fragments. End with: - Artanis (automated responder; the mind proposes, schemas validate, gates hold)',
         `GROUNDING: ${JSON.stringify(grounding)}`,
       ].join('\n\n'),
       system:
@@ -179,9 +188,26 @@ export const runArtanisComposerTick = async (
 
     const tipReceiptRef = artanisResponderTipReceiptRef(topicId)
     const shouldTip = tipBudgetLeftSat >= ARTANIS_TIP_AMOUNT_SAT
-    const replyBodyText = shouldTip
-      ? `${mindResult.text}\n\nResponder tip receipt: ${tipReceiptRef}`
-      : mindResult.text
+    let successfulTip: SuccessfulComposerTip | null = null
+
+    if (shouldTip) {
+      const tipResult = await deps.tip({
+        amountSat: ARTANIS_TIP_AMOUNT_SAT,
+        idempotencyKey: `artanis-responder-tip:${topicId}`,
+        postId: String(proposal.first_post_id),
+        publicReceiptRef: tipReceiptRef,
+      })
+
+      if (!('error' in tipResult)) {
+        successfulTip = tipResult
+        tipBudgetLeftSat -= ARTANIS_TIP_AMOUNT_SAT
+      }
+    }
+
+    const replyBodyText =
+      successfulTip === null
+        ? mindResult.text
+        : `${mindResult.text}\n\nResponder tip receipt: ${successfulTip.receiptRef}`
 
     const posted = await deps.forumPost({
       bodyText: replyBodyText,
@@ -200,6 +226,7 @@ export const runArtanisComposerTick = async (
         .bind(
           JSON.stringify({
             reason: `forum_post_failed:${posted.error}`.slice(0, 200),
+            tipReceiptRef: successfulTip?.receiptRef ?? null,
           }),
           deps.nowIso,
           actionId,
@@ -227,39 +254,28 @@ export const runArtanisComposerTick = async (
       .bind(deps.nowIso.slice(0, 10), deps.nowIso.slice(0, 10), deps.nowIso)
       .run()
 
-    // Tip the question post under the budget; failure to tip never blocks
-    // the response.
-    if (shouldTip) {
-      const tipResult = await deps.tip({
-        amountSat: ARTANIS_TIP_AMOUNT_SAT,
-        idempotencyKey: `artanis-responder-tip:${topicId}`,
-        postId: String(proposal.first_post_id),
-        publicReceiptRef: tipReceiptRef,
-      })
-      if (!('error' in tipResult)) {
-        tipped += 1
-        tipBudgetLeftSat -= ARTANIS_TIP_AMOUNT_SAT
-        await db
-          .prepare(
-            `UPDATE artanis_responder_actions
-             SET state = 'tipped',
-                 tip_receipt_ref = ?,
-                 tip_pay_in_id = ?,
-                 tip_ladder_rung = ?,
-                 tip_ladder_reason = ?,
-                 updated_at = ?
-             WHERE id = ?`,
-          )
-          .bind(
-            tipResult.receiptRef,
-            tipResult.payInId,
-            tipResult.rung,
-            tipResult.ladderReason,
-            deps.nowIso,
-            actionId,
-          )
-          .run()
-      }
+    if (successfulTip !== null) {
+      tipped += 1
+      await db
+        .prepare(
+          `UPDATE artanis_responder_actions
+           SET state = 'tipped',
+               tip_receipt_ref = ?,
+               tip_pay_in_id = ?,
+               tip_ladder_rung = ?,
+               tip_ladder_reason = ?,
+               updated_at = ?
+           WHERE id = ?`,
+        )
+        .bind(
+          successfulTip.receiptRef,
+          successfulTip.payInId,
+          successfulTip.rung,
+          successfulTip.ladderReason,
+          deps.nowIso,
+          actionId,
+        )
+        .run()
     }
   }
 
@@ -280,6 +296,7 @@ export const runArtanisComposerScheduled = (
     gatewayToken?: string | undefined
     forumPost: ComposerForumPost
     tip: ComposerTip
+    mindComplete?: ComposerMindComplete | undefined
     artanisActorRef: string
     nowIso: string
   }>,

--- a/apps/openagents.com/workers/api/src/cloud/cloud-coding-session-routes.ts
+++ b/apps/openagents.com/workers/api/src/cloud/cloud-coding-session-routes.ts
@@ -243,7 +243,7 @@ export const STUB_CLOUD_CODING_ADAPTER_ID = 'stub-cloud-coding'
 // EPIC build replaces dispatch to this with the real cloud control-plane adapter.
 export const stubCloudCodingAdapter: CloudCodingRuntimeAdapter = {
   id: STUB_CLOUD_CODING_ADAPTER_ID,
-  get: () => Effect.succeed(undefined),
+  get: () => Effect.sync((): CloudCodingSession | undefined => undefined),
   launch: ({ sessionId, accountRef, request, lane }) =>
     Effect.sync(
       (): CloudCodingSession => ({

--- a/apps/openagents.com/workers/api/src/cloud/cloud-metering.ts
+++ b/apps/openagents.com/workers/api/src/cloud/cloud-metering.ts
@@ -34,6 +34,18 @@ import {
 } from '../payments-ledger'
 import { currentIsoTimestamp } from '../runtime-primitives'
 
+class CloudMeteringPersistenceError extends Error {
+  readonly _tag = 'CloudMeteringPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'CloudMeteringPersistenceError'
+  }
+}
+
+const cloudMeteringPersistenceError = (error: unknown) =>
+  new CloudMeteringPersistenceError(error)
+
 // A single billable charge for a cloud-primitive unit of work (a finished
 // fine-tune job, a closed sandbox rental). `chargeMsat` is the receipt-first
 // amount computed by the caller's pure pricing function from REAL runtime usage;
@@ -144,8 +156,7 @@ export const settleCloudPrimitiveCharge = (
     const plan = cloudChargePayInPlan(charge)
 
     const settle = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: cloudMeteringPersistenceError,
       try: () =>
         runLedgerStatements(deps.db, createPayInStatements(plan, nowIso())),
     }).pipe(
@@ -168,8 +179,7 @@ export const settleCloudPrimitiveCharge = (
     // The batch failed. Re-read: if the charge row already exists, this was an
     // idempotent duplicate (already charged) — report metered, no re-charge.
     const already = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: cloudMeteringPersistenceError,
       try: () =>
         deps.db
           .prepare('SELECT id FROM pay_ins WHERE idempotency_key = ? LIMIT 1')

--- a/apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.ts
+++ b/apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.ts
@@ -150,7 +150,7 @@ export const stubFineTuningAdapter: FineTuningRuntimeAdapter = {
   // The stub has no persistence: a submitted job is not retained, so a later
   // status read resolves to undefined (the route maps that to 404). #5516's real
   // adapter reads the training-lane job store.
-  get: () => Effect.succeed(undefined),
+  get: () => Effect.sync((): FineTuningJob | undefined => undefined),
 }
 
 // Public-safe primitive tag for fine-tuning charges, receipt refs, and metering

--- a/apps/openagents.com/workers/api/src/cloud/sandbox-compute-service-routes.ts
+++ b/apps/openagents.com/workers/api/src/cloud/sandbox-compute-service-routes.ts
@@ -155,7 +155,7 @@ export const stubSandboxAdapter: SandboxRuntimeAdapter = {
   // The stub has no persistence: a provisioned sandbox is not retained, so a
   // later status read resolves to undefined (the route maps that to 404).
   // #5517's real adapter reads the isolated-session substrate.
-  get: () => Effect.succeed(undefined),
+  get: () => Effect.sync((): Sandbox | undefined => undefined),
 }
 
 // Public-safe primitive tag for sandbox charges, receipt refs, and metering

--- a/apps/openagents.com/workers/api/src/inference/inference-abuse-controls.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-abuse-controls.ts
@@ -40,6 +40,18 @@ import {
 import { currentIsoTimestamp } from '../runtime-primitives'
 import { AgentRateLimitPolicy } from '../agent-rate-limit-policy'
 
+class InferenceClawbackPersistenceError extends Error {
+  readonly _tag = 'InferenceClawbackPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'InferenceClawbackPersistenceError'
+  }
+}
+
+const inferenceClawbackPersistenceError = (error: unknown) =>
+  new InferenceClawbackPersistenceError(error)
+
 // ----------------------------------------------------------------------------
 // 1. Per-customer rate / fair-share limits
 // ----------------------------------------------------------------------------
@@ -613,8 +625,7 @@ export const clawbackInferenceCredits = (
     })
 
     const settle = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: inferenceClawbackPersistenceError,
       try: () =>
         runLedgerStatements(deps.db, createPayInStatements(plan, nowIso())),
     }).pipe(
@@ -640,8 +651,7 @@ export const clawbackInferenceCredits = (
     // Batch failed. Re-read: an existing clawback row means an idempotent replay
     // (already clawed back) — report success, no re-claw.
     const already = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: inferenceClawbackPersistenceError,
       try: () =>
         deps.db
           .prepare('SELECT id FROM pay_ins WHERE idempotency_key = ? LIMIT 1')

--- a/apps/openagents.com/workers/api/src/inference/inference-free-allowance.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-free-allowance.ts
@@ -61,6 +61,18 @@ import {
   resolveOwnerKey,
 } from './inference-owner-identity'
 
+class FreeAllowancePersistenceError extends Error {
+  readonly _tag = 'FreeAllowancePersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'FreeAllowancePersistenceError'
+  }
+}
+
+const freeAllowancePersistenceError = (error: unknown) =>
+  new FreeAllowancePersistenceError(error)
+
 // ----------------------------------------------------------------------------
 // Tunable constants (all free-tier thresholds in ONE place)
 // ----------------------------------------------------------------------------
@@ -409,8 +421,7 @@ export const accrueEarnedAllowance = (
     const eventRef = earnedAllowanceEventRef(input.kind, input.sourceRef)
     const amount = earnedAllowanceForKind(input.kind)
     const recorded = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: freeAllowancePersistenceError,
       try: async () => {
         // Read current earned total so the ceiling caps the new accrual without
         // a non-portable SQL MIN-on-update expression.
@@ -516,8 +527,7 @@ export const withFreeAllowance = (
       const chargeUsdMicros = usdToMicrosCeil(priced.grossChargeUsd)
 
       const gated = yield* Effect.tryPromise({
-        catch: (error: unknown) =>
-          error instanceof Error ? error : new Error(String(error)),
+        catch: freeAllowancePersistenceError,
         try: async () => {
           const identity = await deps.resolveOwnerIdentity(context.accountRef)
           const ownerKey = resolveOwnerKey(context.accountRef, identity)

--- a/apps/openagents.com/workers/api/src/inference/inference-premium-allowlist.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-premium-allowlist.ts
@@ -33,6 +33,18 @@ import {
   resolveOwnerKey,
 } from './inference-owner-identity'
 
+class PremiumAllowlistPersistenceError extends Error {
+  readonly _tag = 'PremiumAllowlistPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'PremiumAllowlistPersistenceError'
+  }
+}
+
+const premiumAllowlistPersistenceError = (error: unknown) =>
+  new PremiumAllowlistPersistenceError(error)
+
 // ----------------------------------------------------------------------------
 // Premium classification (bounded model-class set)
 // ----------------------------------------------------------------------------
@@ -180,8 +192,7 @@ export const grantPremiumAccess = (
     }
     const nowIso = (input.nowIso ?? currentIsoTimestamp)()
     return yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: premiumAllowlistPersistenceError,
       try: async () => {
         await db
           .prepare(
@@ -215,8 +226,7 @@ export const revokePremiumAccess = (
   ownerKey: string,
 ): Effect.Effect<boolean> =>
   Effect.tryPromise({
-    catch: (error: unknown) =>
-      error instanceof Error ? error : new Error(String(error)),
+    catch: premiumAllowlistPersistenceError,
     try: async () => {
       await db
         .prepare(`DELETE FROM inference_premium_allowlist WHERE owner_key = ?`)

--- a/apps/openagents.com/workers/api/src/inference/inference-referral-accrual.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-referral-accrual.ts
@@ -57,6 +57,18 @@ import {
   computeInferenceSplit,
 } from './inference-referral-split'
 
+class InferenceReferralAccrualPersistenceError extends Error {
+  readonly _tag = 'InferenceReferralAccrualPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'InferenceReferralAccrualPersistenceError'
+  }
+}
+
+const inferenceReferralAccrualPersistenceError = (error: unknown) =>
+  new InferenceReferralAccrualPersistenceError(error)
+
 // Bounded, structural parse of a metering accountRef into the referred party.
 // This is NOT intent routing — it is a fixed-shape principal-kind prefix on an
 // already-authenticated account ref, so deterministic parsing is the correct
@@ -342,8 +354,7 @@ export const withReferralAccrual = (
       }
 
       const result = yield* Effect.tryPromise({
-        catch: (error: unknown) =>
-          error instanceof Error ? error : new Error(String(error)),
+        catch: inferenceReferralAccrualPersistenceError,
         try: () =>
           accrueInferenceReferral(deps.db, {
             context,

--- a/apps/openagents.com/workers/api/src/inference/metering-hook.ts
+++ b/apps/openagents.com/workers/api/src/inference/metering-hook.ts
@@ -47,6 +47,18 @@ import {
   servingContributorCutMsat,
 } from './serving-node-payout'
 
+class InferenceMeteringPersistenceError extends Error {
+  readonly _tag = 'InferenceMeteringPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'InferenceMeteringPersistenceError'
+  }
+}
+
+const inferenceMeteringPersistenceError = (error: unknown) =>
+  new InferenceMeteringPersistenceError(error)
+
 // Context handed to the metering hook when a request completes.
 export type MeteringContext = Readonly<{
   // Authenticated account ref (e.g. "agent:<id>"), the principal whose balance
@@ -346,8 +358,7 @@ export const makeLedgerMeteringHook = (
       // Both surface as a caught batch failure; we classify by re-reading whether
       // the charge row already exists.
       const settle = yield* Effect.tryPromise({
-        catch: (error: unknown) =>
-          error instanceof Error ? error : new Error(String(error)),
+        catch: inferenceMeteringPersistenceError,
         try: () =>
           runLedgerStatements(deps.db, createPayInStatements(plan, nowIso())),
       }).pipe(
@@ -378,8 +389,7 @@ export const makeLedgerMeteringHook = (
       // The batch failed. Re-read: if the charge row already exists, this was an
       // idempotent duplicate (already charged) — report metered, no re-charge.
       const already = yield* Effect.tryPromise({
-        catch: (error: unknown) =>
-          error instanceof Error ? error : new Error(String(error)),
+        catch: inferenceMeteringPersistenceError,
         try: () =>
           deps.db
             .prepare('SELECT id FROM pay_ins WHERE idempotency_key = ? LIMIT 1')


### PR DESCRIPTION
Fixes #5540.

Summary:
- Tip before posting Artanis replies and append only the receipt ref returned by the successful tip call.
- Suppress receipt claims when the tip path fails; add regression tests for ordering and failure.
- Clear deploy gate blockers: typed Effect persistence errors/stub reads and workspace-root Moksha asset packaging verification.

Tests:
- bun run --cwd apps/openagents.com/workers/api test -- src/artanis-reply-composer.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck
- bun run --cwd apps/openagents.com/workers/api test -- src/artanis-reply-composer.test.ts src/cloud/cloud-metering.test.ts src/cloud/cloud-coding-session-routes.test.ts src/cloud/fine-tuning-service-routes.test.ts src/cloud/sandbox-compute-service-routes.test.ts src/inference/inference-abuse-controls.test.ts src/inference/inference-free-allowance.test.ts src/inference/inference-premium-allowlist.test.ts src/inference/inference-referral-accrual.test.ts src/inference/metering-hook.test.ts
- bun test tests/electrobun-config.test.ts (from apps/autopilot-desktop)
- bun run --cwd apps/openagents.com check:deploy