### PR TITLE
feat(sites): flag-gated site page form-capture route mount — DE-9 #5532

### DIFF
--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -39,6 +39,16 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // ingestion-endpoint blocker; STT vendor + approval UI stay owner/product-
   // gated and the promise stays red regardless.
   VOICE_PROGRAM_INGEST_ENABLED?: string | undefined
+  // Site page form-capture wiring flag (#5523 / DE-9 #5532; promise
+  // autopilot_sites.native_email_sequences.v1, yellow). Default OFF: the public
+  // capture route (POST /api/sites/forms/:formId/submit) stays unmounted and
+  // the omni dispatch chain falls through exactly as today. Set "true"/"1"/"on"
+  // to mount it — the route resolves a page's FormCaptureSpec from the active
+  // site version metadata via site-form-spec-registry and persists leads via
+  // the native-lists addSubscriber sink. Arming clears ONLY the
+  // route-unmounted blocker; the customer UI, send service, and deliverability
+  // stay owner/product-gated and the promise stays yellow.
+  SITE_FORM_CAPTURE_ENABLED?: string | undefined
   // Inference gateway feature flag (EPIC #5474, #5476). Default OFF: the
   // `/v1/chat/completions` route is inert on the live Worker until the
   // inference build lands. Set "true"/"1"/"on" to enable.

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -347,6 +347,11 @@ import {
 import { makeMulletRoutes } from './mullet/routes'
 import { makeNativeListsService } from './native-lists'
 import { makeNativeListsRoutes } from './native-lists-routes'
+import {
+  isSiteFormCaptureEnabled,
+  makeSitePageFormCaptureRoutes,
+} from './site-page-form-capture-routes'
+import { resolveSiteFormSpec } from './site-form-spec-registry'
 import { makeNexusPylonVisibilityRoutes } from './nexus-pylon-visibility-routes'
 import { makeD1NexusTreasuryPayoutLedgerStore } from './nexus-treasury-payout-ledger'
 import { makeD1Nip90MarketReceiptStore } from './nip90-market-receipts'
@@ -6751,6 +6756,59 @@ const nativeListsRoutes = makeNativeListsRoutes<WorkerBindings>({
   requireOperator: (request, env) => requireAdminApiToken(request, env),
 })
 
+// Site page form-capture wiring (#5523 / DE-9 #5532; promise
+// autopilot_sites.native_email_sequences.v1, yellow). Default OFF via
+// SITE_FORM_CAPTURE_ENABLED: when the flag is unset the route returns undefined
+// for every request and the omni chain falls through exactly as today. When
+// armed it resolves a page's FormCaptureSpec from the active site version's
+// metadata_json (via site-form-spec-registry) and persists captured leads
+// through the native-lists addSubscriber sink. The registry is the authority on
+// whether a formId is published (spec.id === formId); the SQL only narrows
+// candidate active versions whose metadata_json mentions the form key.
+const sitePageFormCaptureRoutes = makeSitePageFormCaptureRoutes<WorkerBindings>({
+  isEnabled: env =>
+    isSiteFormCaptureEnabled(
+      (env as unknown as { SITE_FORM_CAPTURE_ENABLED?: string })
+        .SITE_FORM_CAPTURE_ENABLED,
+    ),
+  makeSink: env => ({
+    addSubscriber: makeNativeListsService(openAgentsDatabase(env)).addSubscriber,
+  }),
+  readSiteFormMetadata: async (env, formId) => {
+    const row = await openAgentsDatabase(env)
+      .prepare(
+        `SELECT site_versions.metadata_json AS metadata_json
+           FROM site_projects
+           JOIN site_versions
+             ON site_versions.id = site_projects.active_version_id
+            AND site_versions.site_id = site_projects.id
+          WHERE site_projects.archived_at IS NULL
+            AND site_projects.active_version_id IS NOT NULL
+            AND json_extract(site_versions.metadata_json, '$.formSpecs')
+                IS NOT NULL
+            AND instr(site_versions.metadata_json, ?1) > 0
+          ORDER BY site_versions.created_at DESC
+          LIMIT 25`,
+      )
+      .bind(formId)
+      .all<{ metadata_json: string }>()
+      .then(result => result.results)
+
+    // The registry validates spec.id === formId and decodes defensively, so the
+    // first candidate whose metadata actually publishes this formId wins; a
+    // metadata blob that merely mentions the id as a substring resolves to
+    // undefined here and is skipped.
+    for (const candidate of row) {
+      const spec = resolveSiteFormSpec(candidate.metadata_json, formId)
+      if (spec !== undefined) {
+        return candidate.metadata_json
+      }
+    }
+
+    return undefined
+  },
+})
+
 const prefilledWorkspaceRoutes = makePrefilledWorkspaceRoutes<WorkerBindings>({
   makeStore: env => makePrefilledWorkspaceService(openAgentsDatabase(env)),
   requireHolderUserId: async (request, env, ctx) => {
@@ -9145,6 +9203,11 @@ const routeRequest = makeWorkerRouteRequest({
     omniBundleRoutes.routeOmniBundleRequest(request, env, ctx) ??
     omniHandoffRoutes.routeOmniHandoffRequest(request, env, ctx) ??
     nativeListsRoutes.routeNativeListsRequest(request, env, ctx) ??
+    sitePageFormCaptureRoutes.routeSitePageFormCaptureRequest(
+      request,
+      env,
+      ctx,
+    ) ??
     prefilledWorkspaceRoutes.routePrefilledWorkspaceRequest(
       request,
       env,

--- a/apps/openagents.com/workers/api/src/site-page-form-capture-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/site-page-form-capture-routes.test.ts
@@ -1,0 +1,324 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { Effect } from 'effect'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+import {
+  makeNativeListsService,
+  type NativeListsRuntime,
+} from './native-lists'
+import {
+  isSiteFormCaptureEnabled,
+  makeSitePageFormCaptureRoutes,
+  resolveSiteFormSpecFromMetadata,
+  SITE_FORM_CAPTURE_BLOCKER_CLEARED,
+  SITE_FORM_CAPTURE_PROMISE_ID,
+} from './site-page-form-capture-routes'
+
+// Real-SQL D1 adapter backed by node:sqlite (mirrors site-page-form-routes.test
+// and native-lists.test) so the sink exercises genuine idempotency against
+// migration 0181 — the wiring is proven end to end, not against a stub sink.
+type Row = Record<string, unknown>
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+
+  async first<T = Row>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...(this.bound as never[]))
+    return (row ?? null) as T | null
+  }
+
+  async all<T = Row>(): Promise<{ results: T[] }> {
+    const results = this.db
+      .prepare(this.sql)
+      .all(...(this.bound as never[])) as T[]
+    return { results }
+  }
+
+  async run(): Promise<{ success: true }> {
+    this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { success: true }
+  }
+}
+
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+}
+
+const migrationSql = readFileSync(
+  join(__dirname, '..', 'migrations', '0181_native_lists_subscribers.sql'),
+  'utf8',
+)
+
+const makeDb = (): D1Database => {
+  const db = new DatabaseSync(':memory:')
+  db.exec('CREATE TABLE users (id TEXT PRIMARY KEY)')
+  db.exec('CREATE TABLE teams (id TEXT PRIMARY KEY)')
+  db.exec('PRAGMA foreign_keys = ON')
+  db.exec(migrationSql)
+  return new SqliteD1(db) as unknown as D1Database
+}
+
+let counter = 0
+const runtime: NativeListsRuntime = {
+  makeId: (prefix: string) => `${prefix}_${(counter += 1)}`,
+  nowIso: () => '2026-06-14T12:00:00.000Z',
+}
+
+const FORM_ID = 'opt_in_hero'
+
+type TestBindings = Readonly<Record<string, unknown>>
+
+const ctx = {} as ExecutionContext
+const env: TestBindings = {}
+
+const post = (formId: string, body: unknown): Request =>
+  new Request(`https://openagents.com/api/sites/forms/${formId}/submit`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+// Build the flag-gated capture routes over a real native-lists sink, resolving
+// the FormCaptureSpec from a published-site metadata_json blob via the registry
+// (the join that was previously missing). The list is created first so the
+// spec's listId points at a real subscriber_lists row.
+const makeHarness = async (enabled: boolean) => {
+  const service = makeNativeListsService(makeDb(), runtime)
+  const list = await service.createList({
+    name: 'Opt-in Waitlist',
+    sourceAuthorityRef: 'site.form.v1',
+  })
+
+  // A realistic published-site metadata_json carrying a formSpecs map — exactly
+  // what site_versions.metadata_json holds in production.
+  const siteMetadataJson = JSON.stringify({
+    title: 'Acme launch site',
+    formSpecs: {
+      [FORM_ID]: {
+        id: FORM_ID,
+        listId: list.id,
+        fields: [
+          { name: 'email', kind: 'email', required: true },
+          { name: 'name', kind: 'text', required: true },
+        ],
+      },
+    },
+  })
+
+  const routes = makeSitePageFormCaptureRoutes<TestBindings>({
+    isEnabled: () => enabled,
+    makeSink: () => ({ addSubscriber: service.addSubscriber }),
+    // Stand-in for the index.ts D1 read of the active site version's
+    // metadata_json that owns this formId. Only the known form resolves.
+    readSiteFormMetadata: async (_env, formId) =>
+      formId === FORM_ID ? siteMetadataJson : undefined,
+    nowIso: () => '2026-06-14T12:00:00.000Z',
+  })
+
+  return { routes, service, listId: list.id }
+}
+
+const run = async (
+  routes: Awaited<ReturnType<typeof makeHarness>>['routes'],
+  request: Request,
+): Promise<Response> => {
+  const effect = routes.routeSitePageFormCaptureRequest(request, env, ctx)
+  if (effect === undefined) {
+    throw new Error('route did not match (flag off or non-matching path)')
+  }
+  return Effect.runPromise(effect)
+}
+
+beforeEach(() => {
+  counter = 0
+})
+
+describe('site form-capture feature flag', () => {
+  test('absent / non-truthy values disable the route', () => {
+    expect(isSiteFormCaptureEnabled(undefined)).toBe(false)
+    expect(isSiteFormCaptureEnabled('')).toBe(false)
+    expect(isSiteFormCaptureEnabled('false')).toBe(false)
+    expect(isSiteFormCaptureEnabled('0')).toBe(false)
+    expect(isSiteFormCaptureEnabled('off')).toBe(false)
+  })
+
+  test('truthy values enable the route', () => {
+    for (const value of ['1', 'true', 'yes', 'on', 'TRUE', ' On ']) {
+      expect(isSiteFormCaptureEnabled(value)).toBe(true)
+    }
+  })
+})
+
+describe('site page form-capture wiring (flag OFF → inert)', () => {
+  test('every request falls through (undefined) when disabled', async () => {
+    const { routes } = await makeHarness(false)
+
+    // A request that WOULD be a valid capture when armed still returns
+    // undefined, so the omni dispatch chain falls through unchanged.
+    expect(
+      routes.routeSitePageFormCaptureRequest(
+        post(FORM_ID, { email: 'lead@example.com', name: 'Ada' }),
+        env,
+        ctx,
+      ),
+    ).toBeUndefined()
+
+    // Non-matching paths are also undefined (no accidental capture).
+    expect(
+      routes.routeSitePageFormCaptureRequest(
+        new Request('https://openagents.com/api/lists/abc', { method: 'POST' }),
+        env,
+        ctx,
+      ),
+    ).toBeUndefined()
+  })
+})
+
+describe('site page form-capture wiring (flag ON → registry-resolved)', () => {
+  test('valid submission resolves the spec from metadata and captures → 201', async () => {
+    const { routes, service, listId } = await makeHarness(true)
+
+    const response = await run(
+      routes,
+      post(FORM_ID, {
+        email: 'LEAD@example.com',
+        name: 'Ada Lovelace',
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    const json = (await response.json()) as Record<string, unknown>
+    expect(json.idempotent).toBe(false)
+    expect(json.email).toBe('lead@example.com')
+    expect(json.listId).toBe(listId)
+
+    const subscribers = await service.listSubscribers({ listId })
+    expect(subscribers).toHaveLength(1)
+    expect(subscribers[0]?.sourceRef).toBe(`site_form.${FORM_ID}`)
+  })
+
+  test('replayed submission is idempotent → 200', async () => {
+    const { routes, service, listId } = await makeHarness(true)
+
+    const first = await run(
+      routes,
+      post(FORM_ID, { email: 'lead@example.com', name: 'Ada' }),
+    )
+    expect(first.status).toBe(201)
+
+    const replay = await run(
+      routes,
+      post(FORM_ID, { email: 'Lead@Example.com', name: 'Ada' }),
+    )
+    expect(replay.status).toBe(200)
+    const json = (await replay.json()) as Record<string, unknown>
+    expect(json.idempotent).toBe(true)
+
+    const subscribers = await service.listSubscribers({ listId })
+    expect(subscribers).toHaveLength(1)
+  })
+
+  test('missing required field fails validation → 400', async () => {
+    const { routes, service, listId } = await makeHarness(true)
+
+    const response = await run(routes, post(FORM_ID, { name: 'No Email' }))
+    expect(response.status).toBe(400)
+
+    const subscribers = await service.listSubscribers({ listId })
+    expect(subscribers).toHaveLength(0)
+  })
+
+  test('unknown formId (no published spec in metadata) → 404', async () => {
+    const { routes } = await makeHarness(true)
+
+    const response = await run(
+      routes,
+      post('does_not_exist', { email: 'lead@example.com', name: 'Ada' }),
+    )
+    expect(response.status).toBe(404)
+    const json = (await response.json()) as Record<string, unknown>
+    expect(json.error).toBe('site_page_form_not_found')
+  })
+
+  test('non-POST method → 405', async () => {
+    const { routes } = await makeHarness(true)
+
+    const response = await run(
+      routes,
+      new Request(
+        `https://openagents.com/api/sites/forms/${FORM_ID}/submit`,
+        { method: 'GET' },
+      ),
+    )
+    expect(response.status).toBe(405)
+  })
+})
+
+describe('resolveSiteFormSpecFromMetadata (registry join)', () => {
+  test('decodes a published metadata_json into a typed FormCaptureSpec', async () => {
+    const metadataJson = JSON.stringify({
+      formSpecs: {
+        [FORM_ID]: {
+          id: FORM_ID,
+          listId: 'list.newsletter',
+          fields: [{ name: 'email', kind: 'email', required: true }],
+        },
+      },
+    })
+
+    const spec = await resolveSiteFormSpecFromMetadata(
+      async (_env: TestBindings, _formId) => metadataJson,
+      env,
+      FORM_ID,
+    )
+
+    expect(spec?.id).toBe(FORM_ID)
+    expect(spec?.listId).toBe('list.newsletter')
+  })
+
+  test('malformed metadata degrades to undefined (route renders 404)', async () => {
+    const spec = await resolveSiteFormSpecFromMetadata(
+      async (_env: TestBindings, _formId) => 'not json {',
+      env,
+      FORM_ID,
+    )
+    expect(spec).toBeUndefined()
+  })
+
+  test('absent published site (no metadata) degrades to undefined', async () => {
+    const spec = await resolveSiteFormSpecFromMetadata(
+      async (_env: TestBindings, _formId) => undefined,
+      env,
+      FORM_ID,
+    )
+    expect(spec).toBeUndefined()
+  })
+})
+
+describe('site form-capture blocker/promise refs (honest scope)', () => {
+  test('clears only the route-unmounted blocker; promise stays yellow', () => {
+    expect(SITE_FORM_CAPTURE_PROMISE_ID).toBe(
+      'autopilot_sites.native_email_sequences.v1',
+    )
+    expect(SITE_FORM_CAPTURE_BLOCKER_CLEARED).toBe(
+      'blocker.product_promises.site_form_capture_route_unmounted',
+    )
+  })
+})

--- a/apps/openagents.com/workers/api/src/site-page-form-capture-routes.ts
+++ b/apps/openagents.com/workers/api/src/site-page-form-capture-routes.ts
@@ -1,0 +1,134 @@
+// SITE PAGE FORM-CAPTURE WIRING (#5523 / DE-9 #5532; promise
+// autopilot_sites.native_email_sequences.v1, yellow).
+//
+// `site-page-form-routes.ts` builds the transport-only public capture route
+// (POST /api/sites/forms/:formId/submit) and deliberately injects both its
+// lead-persistence sink and its `lookupFormSpec(env, formId)` resolver.
+// `site-form-spec-registry.ts` decodes a published site/version `metadata_json`
+// into typed `FormCaptureSpec`s. Until now NOTHING joined those two to a real
+// request environment, so the capture route was unmounted — the open blocker
+// `blocker.product_promises.site_form_capture_route_unmounted`.
+//
+// This module is that last-mile glue, gated by an additive, default-OFF feature
+// flag (`SITE_FORM_CAPTURE_ENABLED`) so it changes nothing on the live Worker
+// until armed:
+//   - it resolves a page's `FormCaptureSpec` from the active site version's
+//     `metadata_json` via the registry (`resolveSiteFormSpec`), through an
+//     injected `readSiteFormMetadata` reader so the resolver stays testable
+//     without D1, and
+//   - it persists captured leads through the already-landed native-lists
+//     `addSubscriber` sink (migration 0181, table `list_subscribers`).
+//
+// When the flag is OFF, `routeSitePageFormCaptureRequest` returns `undefined`
+// for every request, so the omni dispatch chain falls through exactly as it
+// does today (no new live surface, no anonymous write path). Arming the flag
+// clears ONLY the route-unmounted blocker; the customer authoring UI, the
+// wired send service, and deliverability/bounce handling stay owner/product-
+// gated and the promise stays yellow (no green flip — that is owner-signed per
+// proof.claim_upgrade_receipts.v1).
+
+import type { Effect } from 'effect'
+
+import { resolveSiteFormSpec } from './site-form-spec-registry'
+import {
+  type SitePageFormRoutesDependencies,
+  makeSitePageFormRoutes,
+} from './site-page-form-routes'
+import type { FormCaptureSink, FormCaptureSpec } from './site-page-kinds'
+
+type HttpResponse = globalThis.Response
+
+export const SITE_FORM_CAPTURE_PROMISE_ID =
+  'autopilot_sites.native_email_sequences.v1'
+
+// The single blocker this wiring clears once armed. The other blockers on the
+// promise (customer UI, send-service integration, deliverability) are NOT
+// touched here and stay owner/product-gated.
+export const SITE_FORM_CAPTURE_BLOCKER_CLEARED =
+  'blocker.product_promises.site_form_capture_route_unmounted'
+
+// Additive, default-OFF feature flag. Mirrors the established
+// isVoiceProgramIngestEnabled / isSignatureUsageMeteringEnabled convention:
+// absent or any non-truthy value => disabled.
+export const isSiteFormCaptureEnabled = (
+  value: string | undefined,
+): boolean => {
+  if (value === undefined) {
+    return false
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+// Resolve the published `FormCaptureSpec` that owns `formId` from the active
+// site version's metadata. `readSiteFormMetadata` returns the raw
+// `metadata_json` (string, parsed object, or undefined when no published site
+// owns the form). The registry turns any malformed/absent metadata into
+// `undefined`, which the capture route renders as a 404 — anonymous capture can
+// never crash on a broken metadata blob.
+export const resolveSiteFormSpecFromMetadata = async <Bindings>(
+  readSiteFormMetadata: (
+    env: Bindings,
+    formId: string,
+  ) => Promise<unknown>,
+  env: Bindings,
+  formId: string,
+): Promise<FormCaptureSpec | undefined> => {
+  const metadataJson = await readSiteFormMetadata(env, formId)
+
+  return resolveSiteFormSpec(metadataJson, formId)
+}
+
+export type SitePageFormCaptureDependencies<Bindings> = Readonly<{
+  // Per-request gate. When it returns false the route is fully inert and
+  // returns undefined (omni-chain fallthrough). Evaluated per request so the
+  // flag is read from the live request environment, not at module init.
+  isEnabled: (env: Bindings) => boolean
+  // Build the lead-persistence sink for the request environment. Wired to
+  // makeNativeListsService(openAgentsDatabase(env)).addSubscriber in index.ts.
+  makeSink: (env: Bindings) => FormCaptureSink
+  // Read the raw active-site-version metadata_json that owns `formId`.
+  readSiteFormMetadata: (env: Bindings, formId: string) => Promise<unknown>
+  nowIso?: () => string
+}>
+
+// Build the flag-gated, fully-wired site page form-capture routes. When the
+// per-request gate returns false the route returns undefined (no behavior
+// change). When true, requests to the capture route are served by the
+// underlying transport route with a registry-backed spec resolver and the
+// native-lists sink.
+export const makeSitePageFormCaptureRoutes = <
+  Bindings extends Readonly<Record<string, unknown>>,
+>(
+  dependencies: SitePageFormCaptureDependencies<Bindings>,
+) => {
+  const routeDependencies: SitePageFormRoutesDependencies<Bindings> = {
+    makeSink: dependencies.makeSink,
+    lookupFormSpec: (env, formId) =>
+      resolveSiteFormSpecFromMetadata(
+        dependencies.readSiteFormMetadata,
+        env,
+        formId,
+      ),
+    // Only forward nowIso when provided — exactOptionalPropertyTypes forbids
+    // assigning `undefined` to an optional property.
+    ...(dependencies.nowIso === undefined
+      ? {}
+      : { nowIso: dependencies.nowIso }),
+  }
+
+  const routes = makeSitePageFormRoutes<Bindings>(routeDependencies)
+
+  return {
+    routeSitePageFormCaptureRequest: (
+      request: Request,
+      env: Bindings,
+      ctx: ExecutionContext,
+    ): Effect.Effect<HttpResponse> | undefined => {
+      if (!dependencies.isEnabled(env)) {
+        return undefined
+      }
+
+      return routes.routeSitePageFormRequest(request, env, ctx)
+    },
+  }
+}


### PR DESCRIPTION
## What

Mount the site page form-capture route (`POST /api/sites/forms/:formId/submit`) behind an additive, default-OFF feature flag, clearing the `blocker.product_promises.site_form_capture_route_unmounted` blocker on `autopilot_sites.native_email_sequences.v1` (DE-9 #5532).

The transport route factory `makeSitePageFormRoutes` (#4982) and the metadata->spec resolver `resolveSiteFormSpec` in `site-form-spec-registry.ts` (#4983/#4984) both already existed and were tested, but nothing joined them to a real request environment and mounted the route — it was unmounted. This PR is that last-mile wiring.

## How (additive, default-OFF, modeled on #5538 / #5542)

- New `site-page-form-capture-routes.ts`: binds the route's injected `lookupFormSpec` to the registry (`resolveSiteFormSpec` over the active site version's `metadata_json`, via an injected `readSiteFormMetadata` reader so it stays testable without D1) and its sink to the already-landed native-lists `addSubscriber` (migration 0181).
- Per-request flag gate `SITE_FORM_CAPTURE_ENABLED` (default OFF): when unset, `routeSitePageFormCaptureRequest` returns `undefined` for every request and the omni dispatch chain falls through exactly as today — no new live surface, no anonymous-write path.
- `index.ts`: construction with a D1 reader for the active-version metadata that publishes a given `formId` (registry-authoritative; the SQL only narrows candidates via `json_extract`/`instr`) + omni-chain mount after `nativeListsRoutes`. `config.ts`: the flag.

## Receipt (re-runnable)

`bun run --cwd apps/openagents.com test -- src/site-page-form-capture-routes.test.ts` — 12 pass:
- flag OFF -> every request falls through (undefined);
- flag ON -> valid submission captures 201, replay idempotent 200, missing-required 400, unknown/unpublished formId 404, non-POST 405 (driven through the real `captureFormSubmission` gate + a real native-lists sink over node:sqlite);
- `resolveSiteFormSpecFromMetadata` decodes a real published `metadata_json` and degrades malformed/absent metadata to undefined.

Touched-file `tsc -p tsconfig.json --noEmit` = 0 errors. `check:effect-topology`, `check:architecture` (zero-debt), `check:public-projection-freshness`, `check:conflict-markers` all green. The route is path-pattern dispatched (not an exact-path entry), so the `exactRoutePathManifest` allowlist is unaffected.

## Integrity / scope

Clears the **route-unmounted** blocker only. The other three blockers stay open and owner/product-gated: `email_sequence_customer_ui_missing`, `email_send_service_integration_missing`, `email_deliverability_unproven`. The promise stays **yellow** — no green flip is claimed; the flip is owner-signed per `proof.claim_upgrade_receipts.v1`. No money moves, no send service is chosen, no UI is added.

worker != validator: Lathe produces; CI and reviewers validate.

Closes a blocker on #5532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZFxMcQuTX1mVkXiqdPcFY