### PR TITLE
Verify Artanis responder tip receipts

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-reply-composer.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-reply-composer.test.ts
@@ -74,27 +74,60 @@ const makeDb = (): D1Database => {
      )`,
   )
   db.exec(
+    `CREATE TABLE forum_posts (
+       id TEXT PRIMARY KEY,
+       topic_id TEXT NOT NULL,
+       forum_id TEXT NOT NULL,
+       archived_at TEXT
+     )`,
+  )
+  db.exec(
     `CREATE TABLE forum_post_bodies (
        post_id TEXT PRIMARY KEY,
        body_text TEXT NOT NULL
      )`,
   )
-  db.exec(migration('0161_artanis_responder.sql'))
-  // 0169 adds the public_receipt_ref column to pay_ins; stub the minimal
-  // pay_ins table so the budget query and the ALTERs apply cleanly.
   db.exec(
-    `CREATE TABLE pay_ins (
+    `CREATE TABLE forum_receipts (
        id TEXT PRIMARY KEY,
-       payer_ref TEXT,
-       pay_in_type TEXT,
-       state TEXT,
-       rung TEXT,
-       cost_msat INTEGER,
-       idempotency_key TEXT,
-       context_ref TEXT,
-       created_at TEXT
+       receipt_ref TEXT NOT NULL,
+       action_kind TEXT,
+       target_forum_id TEXT,
+       target_topic_id TEXT,
+       target_post_id TEXT,
+       amount_asset TEXT,
+       amount_value INTEGER,
+       recipient_actor_ref TEXT,
+       public_projection_json TEXT,
+       created_at TEXT,
+       archived_at TEXT
      )`,
   )
+  db.exec(
+    `CREATE TABLE forum_money_actions (
+       id TEXT PRIMARY KEY,
+       receipt_id TEXT,
+       payment_event_id TEXT,
+       archived_at TEXT
+     )`,
+  )
+  db.exec(
+    `CREATE TABLE forum_payment_events (
+       id TEXT PRIMARY KEY,
+       public_projection_json TEXT,
+       archived_at TEXT
+     )`,
+  )
+  db.exec(
+    `CREATE TABLE forum_tip_settlement_claims (
+       id TEXT PRIMARY KEY,
+       receipt_id TEXT NOT NULL,
+       public_projection_json TEXT,
+       archived_at TEXT
+     )`,
+  )
+  db.exec(migration('0161_artanis_responder.sql'))
+  db.exec(migration('0160_payments_ledger.sql'))
   db.exec(migration('0169_tip_ladder_public_receipts.sql'))
 
   // Seed one proposed responder action with an operational question.
@@ -107,6 +140,10 @@ const makeDb = (): D1Database => {
     'How do I make sparkPayoutTargetReady true?',
     '2026-06-19T00:00:00.000Z',
   )
+  db.prepare(
+    `INSERT INTO forum_posts (id, topic_id, forum_id, archived_at)
+     VALUES (?, ?, ?, NULL)`,
+  ).run(FIRST_POST_ID, TOPIC_ID, 'forum_pylon')
   db.prepare(
     `INSERT INTO forum_post_bodies (post_id, body_text) VALUES (?, ?)`,
   ).run(
@@ -128,6 +165,68 @@ const makeDb = (): D1Database => {
   )
 
   return new SqliteD1(db) as unknown as D1Database
+}
+
+const seedDereferenceableTipReceipt = async (
+  db: D1Database,
+  input: Readonly<{
+    payInId: string
+    receiptRef: string
+  }>,
+) => {
+  await db
+    .prepare(
+      `INSERT INTO pay_ins (
+         id,
+         pay_in_type,
+         payer_ref,
+         cost_msat,
+         state,
+         failure_reason,
+         rung,
+         context_ref,
+         idempotency_key,
+         genesis_id,
+         successor_id,
+         created_at,
+         state_changed_at,
+         public_receipt_ref
+       ) VALUES (?, 'tip', ?, 50000, 'paid', NULL, 'credited', ?, ?, NULL, NULL, ?, ?, ?)`,
+    )
+    .bind(
+      input.payInId,
+      ARTANIS_ACTOR,
+      `forum.post.${FIRST_POST_ID}`,
+      `artanis-responder-tip:${TOPIC_ID}`,
+      '2026-06-19T01:00:00.000Z',
+      '2026-06-19T01:00:00.000Z',
+      input.receiptRef,
+    )
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO pay_in_legs (
+         id,
+         pay_in_id,
+         direction,
+         kind,
+         party_ref,
+         amount_msat,
+         resulting_balance_msat,
+         external_ref,
+         refund_of_leg_id,
+         created_at
+       ) VALUES (?, ?, 'out', 'balance', ?, 50000, 50000, ?, NULL, ?)`,
+    )
+    .bind(
+      `${input.payInId}_out`,
+      input.payInId,
+      'agent:pylon_question_asker',
+      'ladder.recipient_destination_missing',
+      '2026-06-19T01:00:00.000Z',
+    )
+    .run()
 }
 
 // Capture what the composer posts so we can assert on the reply body.
@@ -210,12 +309,18 @@ describe('artanis reply composer - receipt honesty (#5540 defect 1)', () => {
     const db = makeDb()
     const capture = makeCapturingForumPost()
     const settledRef = 'receipt.forum.tip_ladder.artanis_responder.topic_abc'
-    const settlingTip: ComposerTip = async () => ({
-      ladderReason: 'below_send_threshold',
-      payInId: 'payin_1',
-      receiptRef: settledRef,
-      rung: 'credited',
-    })
+    const settlingTip: ComposerTip = async () => {
+      await seedDereferenceableTipReceipt(db, {
+        payInId: 'payin_1',
+        receiptRef: settledRef,
+      })
+      return {
+        ladderReason: 'below_send_threshold',
+        payInId: 'payin_1',
+        receiptRef: settledRef,
+        rung: 'credited',
+      }
+    }
 
     const outcome = await runArtanisComposerTick(
       db,
@@ -260,6 +365,37 @@ describe('artanis reply composer - receipt honesty (#5540 defect 1)', () => {
     )
 
     expect(capture.posts[0]!.bodyText).not.toContain('Responder tip receipt')
+  })
+
+  test('emits NO receipt ref when the tip returns a well-formed ref that still 404s', async () => {
+    const db = makeDb()
+    const capture = makeCapturingForumPost()
+    const danglingRef = 'receipt.forum.tip_ladder.artanis_responder.topic_abc'
+    const danglingTip: ComposerTip = async () => ({
+      ladderReason: 'credited',
+      payInId: 'payin_missing',
+      receiptRef: danglingRef,
+      rung: 'credited',
+    })
+
+    const outcome = await runArtanisComposerTick(
+      db,
+      baseDeps({ forumPost: capture.fn, tip: danglingTip }),
+    )
+
+    expect(outcome.responded).toBe(1)
+    expect(outcome.tipped).toBe(0)
+    expect(isTipLadderReceiptRef(danglingRef)).toBe(true)
+    expect(capture.posts[0]!.bodyText).not.toContain('Responder tip receipt')
+    expect(capture.posts[0]!.bodyText).not.toContain(danglingRef)
+
+    const action = (await db
+      .prepare(
+        `SELECT state, tip_receipt_ref FROM artanis_responder_actions WHERE id = 'action_1'`,
+      )
+      .first()) as { state: string; tip_receipt_ref: string | null }
+    expect(action.state).toBe('responded')
+    expect(action.tip_receipt_ref).toBeNull()
   })
 })
 

--- a/apps/openagents.com/workers/api/src/artanis-reply-composer.ts
+++ b/apps/openagents.com/workers/api/src/artanis-reply-composer.ts
@@ -7,6 +7,7 @@ import {
 import { artanisOperationalGrounding } from './artanis-operational-grounding'
 import { publicProductPromisesDocument } from './product-promises'
 import {
+  TIP_LADDER_RECEIPT_REF_PREFIX,
   artanisResponderTipReceiptRef,
   isTipLadderReceiptRef,
 } from './tip-ladder'
@@ -54,6 +55,47 @@ export type ComposerTickOutcome = Readonly<{
   blocked: number
   skippedReason: string | null
 }>
+
+const tipReceiptRefIsDereferenceable = async (
+  db: D1Database,
+  receiptRef: string,
+): Promise<boolean> => {
+  if (!isTipLadderReceiptRef(receiptRef)) {
+    return false
+  }
+
+  const row = await db
+    .prepare(
+      `SELECT COALESCE(
+                p.public_receipt_ref,
+                ? || 'payin.' || p.id
+              ) AS receipt_ref
+         FROM pay_ins p
+         JOIN pay_in_legs payout
+           ON payout.pay_in_id = p.id
+          AND payout.direction = 'out'
+        WHERE p.pay_in_type = 'tip'
+          AND (p.public_receipt_ref = ?
+               OR (p.public_receipt_ref IS NULL
+                   AND ? || 'payin.' || p.id = ?))
+          AND p.state IN ('paid', 'forwarding')
+          AND p.context_ref LIKE 'forum.post.%'
+        ORDER BY CASE WHEN p.state = 'paid' THEN 0 ELSE 1 END,
+                 p.created_at DESC,
+                 p.id DESC
+        LIMIT 1`,
+    )
+    .bind(
+      TIP_LADDER_RECEIPT_REF_PREFIX,
+      receiptRef,
+      TIP_LADDER_RECEIPT_REF_PREFIX,
+      receiptRef,
+    )
+    .first<{ receipt_ref: string | null }>()
+    .catch(() => null)
+
+  return row?.receipt_ref === receiptRef
+}
 
 const groundingPromises = () => {
   const document = publicProductPromisesDocument()
@@ -217,11 +259,12 @@ export const runArtanisComposerTick = async (
         postId: String(proposal.first_post_id),
         publicReceiptRef: artanisResponderTipReceiptRef(topicId),
       })
-      // Trust only a settled tip whose returned ref is a well-formed tip
-      // ladder receipt ref; anything else gets no ref in the public reply.
+      // Trust only a settled tip whose returned ref resolves through the
+      // public Forum receipt API; a syntactically valid 404 still gets no
+      // public ref.
       if (
         !('error' in tipResult) &&
-        isTipLadderReceiptRef(tipResult.receiptRef)
+        (await tipReceiptRefIsDereferenceable(db, tipResult.receiptRef))
       ) {
         settledTip = tipResult
       }


### PR DESCRIPTION
## Summary
- Require Artanis responder tip refs to resolve to an actual tip-ladder pay-in with an outgoing ledger leg before embedding the ref in a public reply.
- Keep malformed or well-formed-but-dangling receipt refs out of the reply and leave the responder action in `responded` instead of `tipped`.
- Expand the composer SQL fixture so the positive path seeds a dereferenceable public receipt row and the regression covers a 404-shaped dangling ref.

Fixes #5540

## Verification
- PASS: `bun run test -- src/artanis-reply-composer.test.ts src/forum/tip-ladder-public-receipts.test.ts src/forum/tip-earnings-credited-bucket.test.ts src/tip-ladder.test.ts`
- PASS: `git diff --check`
- FAIL (pre-existing/unrelated): `bun run typecheck` in `apps/openagents.com/workers/api` still exits on existing Effect language-service diagnostics in unrelated cloud/inference files.
- FAIL (pre-existing/unrelated): full API `bun run test` has 591 passed files / 4336 passed tests, then fails `src/agent-registration-routes.test.ts` on the Spark auto-claim expectation (`row.spark_address` is null).
- FAIL (environment/gate): `bun run check:deploy` passes architecture/public projection freshness and desktop tests/smoke, then `apps/autopilot-desktop verify:deploy` exits during `electrobun build` on Linux after `skipping notarization`.