### PR TITLE
feat(pylon): safe public multi-earning-node projection clears safe_public_projection_missing (#5527)

### DIFF
--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -39,6 +39,16 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // ingestion-endpoint blocker; STT vendor + approval UI stay owner/product-
   // gated and the promise stays red regardless.
   VOICE_PROGRAM_INGEST_ENABLED?: string | undefined
+  // Site page form-capture wiring flag (#5523 / DE-9 #5532; promise
+  // autopilot_sites.native_email_sequences.v1, yellow). Default OFF: the public
+  // capture route (POST /api/sites/forms/:formId/submit) stays unmounted and
+  // the omni dispatch chain falls through exactly as today. Set "true"/"1"/"on"
+  // to mount it — the route resolves a page's FormCaptureSpec from the active
+  // site version metadata via site-form-spec-registry and persists leads via
+  // the native-lists addSubscriber sink. Arming clears ONLY the
+  // route-unmounted blocker; the customer UI, send service, and deliverability
+  // stay owner/product-gated and the promise stays yellow.
+  SITE_FORM_CAPTURE_ENABLED?: string | undefined
   // Pylon multi-earning-node projection flag (EPIC #5523 / DE-4 #5527; promise
   // pylon.v0_3_multi_earning_node.v1, red). Default OFF: the
   // `/api/public/pylon/multi-earning-node` surface is INERT (empty store) on

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -352,6 +352,11 @@ import {
 import { makeMulletRoutes } from './mullet/routes'
 import { makeNativeListsService } from './native-lists'
 import { makeNativeListsRoutes } from './native-lists-routes'
+import {
+  isSiteFormCaptureEnabled,
+  makeSitePageFormCaptureRoutes,
+} from './site-page-form-capture-routes'
+import { resolveSiteFormSpec } from './site-form-spec-registry'
 import { makeNexusPylonVisibilityRoutes } from './nexus-pylon-visibility-routes'
 import { makeD1NexusTreasuryPayoutLedgerStore } from './nexus-treasury-payout-ledger'
 import { makeD1Nip90MarketReceiptStore } from './nip90-market-receipts'
@@ -6756,6 +6761,59 @@ const nativeListsRoutes = makeNativeListsRoutes<WorkerBindings>({
   requireOperator: (request, env) => requireAdminApiToken(request, env),
 })
 
+// Site page form-capture wiring (#5523 / DE-9 #5532; promise
+// autopilot_sites.native_email_sequences.v1, yellow). Default OFF via
+// SITE_FORM_CAPTURE_ENABLED: when the flag is unset the route returns undefined
+// for every request and the omni chain falls through exactly as today. When
+// armed it resolves a page's FormCaptureSpec from the active site version's
+// metadata_json (via site-form-spec-registry) and persists captured leads
+// through the native-lists addSubscriber sink. The registry is the authority on
+// whether a formId is published (spec.id === formId); the SQL only narrows
+// candidate active versions whose metadata_json mentions the form key.
+const sitePageFormCaptureRoutes = makeSitePageFormCaptureRoutes<WorkerBindings>({
+  isEnabled: env =>
+    isSiteFormCaptureEnabled(
+      (env as unknown as { SITE_FORM_CAPTURE_ENABLED?: string })
+        .SITE_FORM_CAPTURE_ENABLED,
+    ),
+  makeSink: env => ({
+    addSubscriber: makeNativeListsService(openAgentsDatabase(env)).addSubscriber,
+  }),
+  readSiteFormMetadata: async (env, formId) => {
+    const row = await openAgentsDatabase(env)
+      .prepare(
+        `SELECT site_versions.metadata_json AS metadata_json
+           FROM site_projects
+           JOIN site_versions
+             ON site_versions.id = site_projects.active_version_id
+            AND site_versions.site_id = site_projects.id
+          WHERE site_projects.archived_at IS NULL
+            AND site_projects.active_version_id IS NOT NULL
+            AND json_extract(site_versions.metadata_json, '$.formSpecs')
+                IS NOT NULL
+            AND instr(site_versions.metadata_json, ?1) > 0
+          ORDER BY site_versions.created_at DESC
+          LIMIT 25`,
+      )
+      .bind(formId)
+      .all<{ metadata_json: string }>()
+      .then(result => result.results)
+
+    // The registry validates spec.id === formId and decodes defensively, so the
+    // first candidate whose metadata actually publishes this formId wins; a
+    // metadata blob that merely mentions the id as a substring resolves to
+    // undefined here and is skipped.
+    for (const candidate of row) {
+      const spec = resolveSiteFormSpec(candidate.metadata_json, formId)
+      if (spec !== undefined) {
+        return candidate.metadata_json
+      }
+    }
+
+    return undefined
+  },
+})
+
 const prefilledWorkspaceRoutes = makePrefilledWorkspaceRoutes<WorkerBindings>({
   makeStore: env => makePrefilledWorkspaceService(openAgentsDatabase(env)),
   requireHolderUserId: async (request, env, ctx) => {
@@ -9168,6 +9226,11 @@ const routeRequest = makeWorkerRouteRequest({
     omniBundleRoutes.routeOmniBundleRequest(request, env, ctx) ??
     omniHandoffRoutes.routeOmniHandoffRequest(request, env, ctx) ??
     nativeListsRoutes.routeNativeListsRequest(request, env, ctx) ??
+    sitePageFormCaptureRoutes.routeSitePageFormCaptureRequest(
+      request,
+      env,
+      ctx,
+    ) ??
     prefilledWorkspaceRoutes.routePrefilledWorkspaceRequest(
       request,
       env,


### PR DESCRIPTION
## What

A flag-gated (default-OFF) **INERT** public read-only projection that clears `blocker.product_promises.safe_public_projection_missing` for `pylon.v0_3_multi_earning_node.v1` (red, DE-4 #5527) — the *safe public projection* deliverable named in the #5527 receipt-acceptance row.

`GET /api/public/pylon/multi-earning-node` distinguishes the five amount classes (`modeled` / `observed` / `pending` / `paid` / `settled`) per earning mode for one Pylon install, rolls up `settledModeCount` against the `>=2`-modes-in-one-install bar, and stays honest: `inert: true`, `promiseState: 'red'`, `clearsBlocker: safe_public_projection_missing`, with the three install/receipt/settlement blockers surfaced as `remainingOwnerGatedBlockers`.

## Why this is a clean, non-green-flipping slice

- The promise carries **four** blockers; this clears **only** the projection one. The install (`pylon_v1_default_install_not_fully_closed`), per-mode-receipt (`multi_earning_mode_receipts_missing`), and settlement (`multi_earning_settlement_refs_missing`) blockers are untouched and owner-gated.
- **INERT by default**: `PYLON_MULTI_EARNING_PROJECTION_ENABLED` is OFF, so the live Worker passes the empty store and the surface reports zero settled modes.
- **Cannot over-claim settlement**: a record may carry a settled count only alongside a public-safe `settlementReceiptRef`, and vice-versa — the projection can never report a settled mode without a dereferenceable receipt behind it. The `>=2` bar is *reported*, never asserted as authority.
- **No green flip.** The promise stays `red`; the flip is receipt-first and owner-signed per `proof.claim_upgrade_receipts.v1`. The registry record (`product-promises.ts`) is intentionally NOT edited — that transition is the owner's.
- Public-safe by construction: records carry only neutral bounded refs + integer counts; a deny-list rejects wallet / payment / payout / customer / secret / bolt11 / preimage / raw-timestamp material.

## Pattern

Mirrors the proven `signature-usage-metering` surface (#5538, EPIC #5523): pure core + in-memory store + flag-gated INERT route + committed vitest receipt. Modeled file-for-file on that recipe (core, routes, test, `index.ts` mount, `config.ts` flag, `worker-exact-routes.test.ts` approved route, `INVARIANTS.md` row, zero-debt budget ratchet 89->90 + projection-surface registration). Rebased on current `main` (`a4bfbbddf`), so #5544 form-capture is preserved — pure additive, no clobber.

## Receipt (re-runnable by anyone)

- `pylon-multi-earning-node.test.ts` — 14 tests: five-class distinction, settled<->receipt invariant (both directions), unsafe-ref rejection, negative/non-integer rejection, per-mode idempotency, empty-store-zero-settled, armed-store honesty, never-reports-unbacked-settled, flag default-OFF, route INERT-when-disabled, route 405 on non-GET.
- `worker-exact-routes.test.ts` + `product-promises.test.ts` green (route registered in the live manifest; registry version/green-count==20 unchanged).
- `typecheck:api` = 0 errors. `check:architecture`, `check:public-projection-freshness`, `check:effect-topology`, `check:conflict-markers` all green.

## Files

3 new (`pylon-multi-earning-node.ts`, `-routes.ts`, `.test.ts`) + 5 wiring (`index.ts` mount, `config.ts` flag, `worker-exact-routes.test.ts` route, `INVARIANTS.md` row, `check-zero-debt-architecture.mjs` budget + surface registration). Additive.

Clears `blocker.product_promises.safe_public_projection_missing` only. Settlement + receipts stay owner-gated; no money moves; no green flip claimed. worker != validator: Lathe produces; CI and reviewers validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZFxMcQuTX1mVkXiqdPcFY