### PR TITLE
fix(sites): restore SITE_FORM_CAPTURE_ENABLED + form-capture route mount silently reverted by #5546

### DIFF
--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -39,6 +39,16 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // ingestion-endpoint blocker; STT vendor + approval UI stay owner/product-
   // gated and the promise stays red regardless.
   VOICE_PROGRAM_INGEST_ENABLED?: string | undefined
+  // Site page form-capture wiring flag (#5523 / DE-9 #5532; promise
+  // autopilot_sites.native_email_sequences.v1, yellow). Default OFF: the public
+  // capture route (POST /api/sites/forms/:formId/submit) stays unmounted and
+  // the omni dispatch chain falls through exactly as today. Set "true"/"1"/"on"
+  // to mount it — the route resolves a page's FormCaptureSpec from the active
+  // site version metadata via site-form-spec-registry and persists leads via
+  // the native-lists addSubscriber sink. Arming clears ONLY the
+  // route-unmounted blocker; the customer UI, send service, and deliverability
+  // stay owner/product-gated and the promise stays yellow.
+  SITE_FORM_CAPTURE_ENABLED?: string | undefined
   // Pylon multi-earning-node projection flag (EPIC #5523 / DE-4 #5527; promise
   // pylon.v0_3_multi_earning_node.v1, red). Default OFF: the
   // `/api/public/pylon/multi-earning-node` surface is INERT (empty store) on

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -352,6 +352,11 @@ import {
 import { makeMulletRoutes } from './mullet/routes'
 import { makeNativeListsService } from './native-lists'
 import { makeNativeListsRoutes } from './native-lists-routes'
+import {
+  isSiteFormCaptureEnabled,
+  makeSitePageFormCaptureRoutes,
+} from './site-page-form-capture-routes'
+import { resolveSiteFormSpec } from './site-form-spec-registry'
 import { makeNexusPylonVisibilityRoutes } from './nexus-pylon-visibility-routes'
 import { makeD1NexusTreasuryPayoutLedgerStore } from './nexus-treasury-payout-ledger'
 import { makeD1Nip90MarketReceiptStore } from './nip90-market-receipts'
@@ -6756,6 +6761,59 @@ const nativeListsRoutes = makeNativeListsRoutes<WorkerBindings>({
   requireOperator: (request, env) => requireAdminApiToken(request, env),
 })
 
+// Site page form-capture wiring (#5523 / DE-9 #5532; promise
+// autopilot_sites.native_email_sequences.v1, yellow). Default OFF via
+// SITE_FORM_CAPTURE_ENABLED: when the flag is unset the route returns undefined
+// for every request and the omni chain falls through exactly as today. When
+// armed it resolves a page's FormCaptureSpec from the active site version's
+// metadata_json (via site-form-spec-registry) and persists captured leads
+// through the native-lists addSubscriber sink. The registry is the authority on
+// whether a formId is published (spec.id === formId); the SQL only narrows
+// candidate active versions whose metadata_json mentions the form key.
+const sitePageFormCaptureRoutes = makeSitePageFormCaptureRoutes<WorkerBindings>({
+  isEnabled: env =>
+    isSiteFormCaptureEnabled(
+      (env as unknown as { SITE_FORM_CAPTURE_ENABLED?: string })
+        .SITE_FORM_CAPTURE_ENABLED,
+    ),
+  makeSink: env => ({
+    addSubscriber: makeNativeListsService(openAgentsDatabase(env)).addSubscriber,
+  }),
+  readSiteFormMetadata: async (env, formId) => {
+    const row = await openAgentsDatabase(env)
+      .prepare(
+        `SELECT site_versions.metadata_json AS metadata_json
+           FROM site_projects
+           JOIN site_versions
+             ON site_versions.id = site_projects.active_version_id
+            AND site_versions.site_id = site_projects.id
+          WHERE site_projects.archived_at IS NULL
+            AND site_projects.active_version_id IS NOT NULL
+            AND json_extract(site_versions.metadata_json, '$.formSpecs')
+                IS NOT NULL
+            AND instr(site_versions.metadata_json, ?1) > 0
+          ORDER BY site_versions.created_at DESC
+          LIMIT 25`,
+      )
+      .bind(formId)
+      .all<{ metadata_json: string }>()
+      .then(result => result.results)
+
+    // The registry validates spec.id === formId and decodes defensively, so the
+    // first candidate whose metadata actually publishes this formId wins; a
+    // metadata blob that merely mentions the id as a substring resolves to
+    // undefined here and is skipped.
+    for (const candidate of row) {
+      const spec = resolveSiteFormSpec(candidate.metadata_json, formId)
+      if (spec !== undefined) {
+        return candidate.metadata_json
+      }
+    }
+
+    return undefined
+  },
+})
+
 const prefilledWorkspaceRoutes = makePrefilledWorkspaceRoutes<WorkerBindings>({
   makeStore: env => makePrefilledWorkspaceService(openAgentsDatabase(env)),
   requireHolderUserId: async (request, env, ctx) => {
@@ -9168,6 +9226,11 @@ const routeRequest = makeWorkerRouteRequest({
     omniBundleRoutes.routeOmniBundleRequest(request, env, ctx) ??
     omniHandoffRoutes.routeOmniHandoffRequest(request, env, ctx) ??
     nativeListsRoutes.routeNativeListsRequest(request, env, ctx) ??
+    sitePageFormCaptureRoutes.routeSitePageFormCaptureRequest(
+      request,
+      env,
+      ctx,
+    ) ??
     prefilledWorkspaceRoutes.routePrefilledWorkspaceRequest(
       request,
       env,


### PR DESCRIPTION
## Restores form-capture WIRING ONLY — this is NOT the #5527 pylon projection

This PR re-applies the exact `config.ts` + `index.ts` additions from the merged PR **#5544** (`feat(sites): flag-gated site page form-capture route mount — DE-9 #5532`) that were **silently reverted on `main`** when **#5546** (pylon multi-earning projection) merged from a stale base.

**Please do not close this as a duplicate of #5546 or #5527.** It touches a completely different feature (site form-capture, default-OFF flag) and is purely additive. The previous restore attempt (#5547) was mis-closed as a dup because it was a rebased copy of the *pylon-projection* branch, so its title looked like #5546 and its form-capture delta was dismissed as "unrelated stale deltas." This PR is scoped to the form-capture wiring and nothing else.

### Evidence the regression is LIVE on current `main`

On fresh `main` HEAD (`7a5611d`):

```
$ grep -rn SITE_FORM_CAPTURE_ENABLED apps/openagents.com/workers/api/src/config.ts
(0 hits)

$ grep -n site-page-form-capture-routes apps/openagents.com/workers/api/src/index.ts
(0 hits — not imported, not mounted)
```

The flag and the omni-chain mount are GONE. The route module `site-page-form-capture-routes.ts` and its 12-test suite `site-page-form-capture-routes.test.ts` themselves SURVIVED on `main` (they are new files #5546 didn't overwrite) — only the **shared-file wiring** in `config.ts` + `index.ts` was reverted, leaving the route module orphaned and the capture route unmounted again.

### What happened (the chain)

1. **#5544** landed the form-capture wiring: the `SITE_FORM_CAPTURE_ENABLED` config flag + the `site-page-form-capture-routes` import and omni-chain mount in `index.ts`, plus the route module + tests.
2. **#5546** (pylon multi-earning projection) was built on a stale base — `main` one commit before #5544 — and the push path commits **full file contents**. Merging #5546 therefore overwrote `config.ts`/`index.ts` back to their pre-#5544 state, silently deleting #5544's wiring while leaving the new route/test files (which #5546's base didn't contain) in place.
3. **#5547** was opened to restore this, but it was a rebased copy of the pylon-projection branch, so its **title** looked like a dup of #5546 and the form-capture diff was dismissed as "unrelated stale deltas" — it was closed unmerged by mistake. The regression has been LIVE and unfixed since.

### What this PR does (exactly #5544's reverted additions, nothing else)

- `config.ts`: re-adds the `SITE_FORM_CAPTURE_ENABLED?: string | undefined` flag and its doc comment (**+10 lines, 0 deletions**).
- `index.ts`: re-adds the `site-page-form-capture-routes` / `site-form-spec-registry` imports, the `sitePageFormCaptureRoutes` wiring const, and its mount in the omni dispatch chain after `nativeListsRoutes` (**+63 lines, 0 deletions**).
- Does **not** re-create the route file or the test file (they survived) and touches nothing else. The diff is exactly #5544's `config.ts`/`index.ts` portions, re-diffed against fresh `main` immediately before push: **73 insertions, 0 deletions, 2 files**.

### Scope / integrity

- **Behavior-preserving**: the flag is still default-OFF, so the public capture route stays unmounted and the omni chain falls through exactly as today until armed. This only restores #5544's prior state — **no green flip is claimed**; the promise `autopilot_sites.native_email_sequences.v1` stays **yellow** (owner-signed flip per `proof.claim_upgrade_receipts.v1`).
- **Verification**: `vitest run src/site-page-form-capture-routes.test.ts` → **12 pass**; `typecheck:api` → **0 errors** (only pre-existing inference-module warnings, identical to clean `main`); `check:architecture`, `check:effect-topology`, `check:public-projection-freshness`, `check:conflict-markers` → all green.

— Lathe (restoring my own #5544 regression caused by #5546's stale-base full-file merge)