### PR TITLE
Clean up event foreign-key orphans

### DIFF
--- a/apps/autopilot-desktop/electrobun.config.ts
+++ b/apps/autopilot-desktop/electrobun.config.ts
@@ -31,7 +31,7 @@ export default {
       // and resolves its GLB/font/image assets relative to the bundled view
       // module (`views://autopilot-desktop/assets/moksha/...`). Copy the whole
       // asset directory so WebKit does not get empty `views://` responses.
-      "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha":
+      "../../node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha":
         "views/autopilot-desktop/assets/moksha",
       // #5027 (Phase 2, packaged build): the bundled headless Pylon node, built
       // by `bun run build:pylon-node` before electrobun build. electrobun copies

--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -20,7 +20,7 @@
     "proof:shell-control": "bun --preload ./tests/preload.ts scripts/shell-control-proof.ts",
     "smoke:auto-onboarding-e2e": "bun scripts/auto-onboarding-e2e-smoke.ts",
     "verify:training": "bun test tests/cl-53-foldkit.test.ts tests/cl-53-sanitize.test.ts && bun run build:css && bun build src/ui/main.ts --outdir /tmp/autopilot-desktop-ui-build --target browser && bun build src/bun/index.ts --outdir /tmp/autopilot-desktop-bun-build --target bun && bun run smoke:training-scene",
-    "verify:deploy": "bun test tests/electrobun-config.test.ts && bun run verify:training && bun run build && test -s \"build/dev-macos-arm64/Autopilot-dev.app/Contents/Resources/app/views/autopilot-desktop/assets/moksha/diamond.glb\"",
+    "verify:deploy": "bun test tests/electrobun-config.test.ts && bun run verify:training && bun run build && asset=\"$(find build -path '*/Resources/app/views/autopilot-desktop/assets/moksha/diamond.glb' -type f -print -quit)\" && test -n \"$asset\" && test -s \"$asset\"",
     "test": "bash scripts/run-tests.sh",
     "notarize:macos": "bash scripts/notarize-macos.sh"
   },

--- a/apps/autopilot-desktop/tests/electrobun-config.test.ts
+++ b/apps/autopilot-desktop/tests/electrobun-config.test.ts
@@ -7,7 +7,7 @@ import { desktopApplicationMenu } from "../src/bun/application-menu"
 import config from "../electrobun.config"
 
 const mokshaAssetSource =
-  "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha"
+  "../../node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha"
 
 describe("ElectroBun packaging", () => {
   test("uses the concise Autopilot app title", () => {

--- a/apps/openagents.com/workers/api/migrations/0212_site_adjutant_event_fk_orphan_cleanup.sql
+++ b/apps/openagents.com/workers/api/migrations/0212_site_adjutant_event_fk_orphan_cleanup.sql
@@ -1,0 +1,92 @@
+-- Prod FK drift cleanup (#5506).
+--
+-- D1 batch migrations historically ran with foreign key enforcement disabled,
+-- which allowed a small number of event rows to retain references whose parent
+-- rows no longer exist. Clear that drift by FK predicate only, not hard-coded
+-- prod row ids.
+
+DELETE FROM site_events
+WHERE NOT EXISTS (
+        SELECT 1
+          FROM site_projects
+         WHERE site_projects.id = site_events.site_id
+      )
+   OR (
+        version_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM site_versions
+           WHERE site_versions.id = site_events.version_id
+        )
+      )
+   OR (
+        deployment_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM site_deployments
+           WHERE site_deployments.id = site_events.deployment_id
+        )
+      )
+   OR (
+        actor_user_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM users
+           WHERE users.id = site_events.actor_user_id
+        )
+      )
+   OR (
+        actor_run_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM agent_runs
+           WHERE agent_runs.id = site_events.actor_run_id
+        )
+      );
+
+DELETE FROM adjutant_assignment_events
+WHERE NOT EXISTS (
+        SELECT 1
+          FROM adjutant_assignments
+         WHERE adjutant_assignments.id = adjutant_assignment_events.assignment_id
+      )
+   OR (
+        software_order_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM software_orders
+           WHERE software_orders.id = adjutant_assignment_events.software_order_id
+        )
+      )
+   OR (
+        site_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM site_projects
+           WHERE site_projects.id = adjutant_assignment_events.site_id
+        )
+      )
+   OR (
+        goal_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM agent_goals
+           WHERE agent_goals.id = adjutant_assignment_events.goal_id
+        )
+      )
+   OR (
+        run_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM agent_runs
+           WHERE agent_runs.id = adjutant_assignment_events.run_id
+        )
+      )
+   OR (
+        actor_user_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM users
+           WHERE users.id = adjutant_assignment_events.actor_user_id
+        )
+      );

--- a/apps/openagents.com/workers/api/src/cloud/cloud-coding-session-routes.ts
+++ b/apps/openagents.com/workers/api/src/cloud/cloud-coding-session-routes.ts
@@ -243,7 +243,7 @@ export const STUB_CLOUD_CODING_ADAPTER_ID = 'stub-cloud-coding'
 // EPIC build replaces dispatch to this with the real cloud control-plane adapter.
 export const stubCloudCodingAdapter: CloudCodingRuntimeAdapter = {
   id: STUB_CLOUD_CODING_ADAPTER_ID,
-  get: () => Effect.succeed(undefined),
+  get: () => Effect.sync((): CloudCodingSession | undefined => undefined),
   launch: ({ sessionId, accountRef, request, lane }) =>
     Effect.sync(
       (): CloudCodingSession => ({

--- a/apps/openagents.com/workers/api/src/cloud/cloud-metering.ts
+++ b/apps/openagents.com/workers/api/src/cloud/cloud-metering.ts
@@ -34,6 +34,18 @@ import {
 } from '../payments-ledger'
 import { currentIsoTimestamp } from '../runtime-primitives'
 
+class CloudMeteringPersistenceError extends Error {
+  readonly _tag = 'CloudMeteringPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'CloudMeteringPersistenceError'
+  }
+}
+
+const cloudMeteringPersistenceError = (error: unknown) =>
+  new CloudMeteringPersistenceError(error)
+
 // A single billable charge for a cloud-primitive unit of work (a finished
 // fine-tune job, a closed sandbox rental). `chargeMsat` is the receipt-first
 // amount computed by the caller's pure pricing function from REAL runtime usage;
@@ -144,8 +156,7 @@ export const settleCloudPrimitiveCharge = (
     const plan = cloudChargePayInPlan(charge)
 
     const settle = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: cloudMeteringPersistenceError,
       try: () =>
         runLedgerStatements(deps.db, createPayInStatements(plan, nowIso())),
     }).pipe(
@@ -168,8 +179,7 @@ export const settleCloudPrimitiveCharge = (
     // The batch failed. Re-read: if the charge row already exists, this was an
     // idempotent duplicate (already charged) — report metered, no re-charge.
     const already = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: cloudMeteringPersistenceError,
       try: () =>
         deps.db
           .prepare('SELECT id FROM pay_ins WHERE idempotency_key = ? LIMIT 1')

--- a/apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.ts
+++ b/apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.ts
@@ -150,7 +150,7 @@ export const stubFineTuningAdapter: FineTuningRuntimeAdapter = {
   // The stub has no persistence: a submitted job is not retained, so a later
   // status read resolves to undefined (the route maps that to 404). #5516's real
   // adapter reads the training-lane job store.
-  get: () => Effect.succeed(undefined),
+  get: () => Effect.sync((): FineTuningJob | undefined => undefined),
 }
 
 // Public-safe primitive tag for fine-tuning charges, receipt refs, and metering

--- a/apps/openagents.com/workers/api/src/cloud/sandbox-compute-service-routes.ts
+++ b/apps/openagents.com/workers/api/src/cloud/sandbox-compute-service-routes.ts
@@ -155,7 +155,7 @@ export const stubSandboxAdapter: SandboxRuntimeAdapter = {
   // The stub has no persistence: a provisioned sandbox is not retained, so a
   // later status read resolves to undefined (the route maps that to 404).
   // #5517's real adapter reads the isolated-session substrate.
-  get: () => Effect.succeed(undefined),
+  get: () => Effect.sync((): Sandbox | undefined => undefined),
 }
 
 // Public-safe primitive tag for sandbox charges, receipt refs, and metering

--- a/apps/openagents.com/workers/api/src/inference/inference-abuse-controls.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-abuse-controls.ts
@@ -40,6 +40,18 @@ import {
 import { currentIsoTimestamp } from '../runtime-primitives'
 import { AgentRateLimitPolicy } from '../agent-rate-limit-policy'
 
+class InferenceClawbackPersistenceError extends Error {
+  readonly _tag = 'InferenceClawbackPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'InferenceClawbackPersistenceError'
+  }
+}
+
+const inferenceClawbackPersistenceError = (error: unknown) =>
+  new InferenceClawbackPersistenceError(error)
+
 // ----------------------------------------------------------------------------
 // 1. Per-customer rate / fair-share limits
 // ----------------------------------------------------------------------------
@@ -613,8 +625,7 @@ export const clawbackInferenceCredits = (
     })
 
     const settle = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: inferenceClawbackPersistenceError,
       try: () =>
         runLedgerStatements(deps.db, createPayInStatements(plan, nowIso())),
     }).pipe(
@@ -640,8 +651,7 @@ export const clawbackInferenceCredits = (
     // Batch failed. Re-read: an existing clawback row means an idempotent replay
     // (already clawed back) — report success, no re-claw.
     const already = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: inferenceClawbackPersistenceError,
       try: () =>
         deps.db
           .prepare('SELECT id FROM pay_ins WHERE idempotency_key = ? LIMIT 1')

--- a/apps/openagents.com/workers/api/src/inference/inference-free-allowance.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-free-allowance.ts
@@ -61,6 +61,18 @@ import {
   resolveOwnerKey,
 } from './inference-owner-identity'
 
+class FreeAllowancePersistenceError extends Error {
+  readonly _tag = 'FreeAllowancePersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'FreeAllowancePersistenceError'
+  }
+}
+
+const freeAllowancePersistenceError = (error: unknown) =>
+  new FreeAllowancePersistenceError(error)
+
 // ----------------------------------------------------------------------------
 // Tunable constants (all free-tier thresholds in ONE place)
 // ----------------------------------------------------------------------------
@@ -409,8 +421,7 @@ export const accrueEarnedAllowance = (
     const eventRef = earnedAllowanceEventRef(input.kind, input.sourceRef)
     const amount = earnedAllowanceForKind(input.kind)
     const recorded = yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: freeAllowancePersistenceError,
       try: async () => {
         // Read current earned total so the ceiling caps the new accrual without
         // a non-portable SQL MIN-on-update expression.
@@ -516,8 +527,7 @@ export const withFreeAllowance = (
       const chargeUsdMicros = usdToMicrosCeil(priced.grossChargeUsd)
 
       const gated = yield* Effect.tryPromise({
-        catch: (error: unknown) =>
-          error instanceof Error ? error : new Error(String(error)),
+        catch: freeAllowancePersistenceError,
         try: async () => {
           const identity = await deps.resolveOwnerIdentity(context.accountRef)
           const ownerKey = resolveOwnerKey(context.accountRef, identity)

--- a/apps/openagents.com/workers/api/src/inference/inference-premium-allowlist.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-premium-allowlist.ts
@@ -33,6 +33,18 @@ import {
   resolveOwnerKey,
 } from './inference-owner-identity'
 
+class PremiumAllowlistPersistenceError extends Error {
+  readonly _tag = 'PremiumAllowlistPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'PremiumAllowlistPersistenceError'
+  }
+}
+
+const premiumAllowlistPersistenceError = (error: unknown) =>
+  new PremiumAllowlistPersistenceError(error)
+
 // ----------------------------------------------------------------------------
 // Premium classification (bounded model-class set)
 // ----------------------------------------------------------------------------
@@ -180,8 +192,7 @@ export const grantPremiumAccess = (
     }
     const nowIso = (input.nowIso ?? currentIsoTimestamp)()
     return yield* Effect.tryPromise({
-      catch: (error: unknown) =>
-        error instanceof Error ? error : new Error(String(error)),
+      catch: premiumAllowlistPersistenceError,
       try: async () => {
         await db
           .prepare(
@@ -215,8 +226,7 @@ export const revokePremiumAccess = (
   ownerKey: string,
 ): Effect.Effect<boolean> =>
   Effect.tryPromise({
-    catch: (error: unknown) =>
-      error instanceof Error ? error : new Error(String(error)),
+    catch: premiumAllowlistPersistenceError,
     try: async () => {
       await db
         .prepare(`DELETE FROM inference_premium_allowlist WHERE owner_key = ?`)

--- a/apps/openagents.com/workers/api/src/inference/inference-referral-accrual.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-referral-accrual.ts
@@ -57,6 +57,18 @@ import {
   computeInferenceSplit,
 } from './inference-referral-split'
 
+class InferenceReferralAccrualPersistenceError extends Error {
+  readonly _tag = 'InferenceReferralAccrualPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'InferenceReferralAccrualPersistenceError'
+  }
+}
+
+const inferenceReferralAccrualPersistenceError = (error: unknown) =>
+  new InferenceReferralAccrualPersistenceError(error)
+
 // Bounded, structural parse of a metering accountRef into the referred party.
 // This is NOT intent routing — it is a fixed-shape principal-kind prefix on an
 // already-authenticated account ref, so deterministic parsing is the correct
@@ -342,8 +354,7 @@ export const withReferralAccrual = (
       }
 
       const result = yield* Effect.tryPromise({
-        catch: (error: unknown) =>
-          error instanceof Error ? error : new Error(String(error)),
+        catch: inferenceReferralAccrualPersistenceError,
         try: () =>
           accrueInferenceReferral(deps.db, {
             context,

--- a/apps/openagents.com/workers/api/src/inference/metering-hook.ts
+++ b/apps/openagents.com/workers/api/src/inference/metering-hook.ts
@@ -47,6 +47,18 @@ import {
   servingContributorCutMsat,
 } from './serving-node-payout'
 
+class InferenceMeteringPersistenceError extends Error {
+  readonly _tag = 'InferenceMeteringPersistenceError'
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'InferenceMeteringPersistenceError'
+  }
+}
+
+const inferenceMeteringPersistenceError = (error: unknown) =>
+  new InferenceMeteringPersistenceError(error)
+
 // Context handed to the metering hook when a request completes.
 export type MeteringContext = Readonly<{
   // Authenticated account ref (e.g. "agent:<id>"), the principal whose balance
@@ -346,8 +358,7 @@ export const makeLedgerMeteringHook = (
       // Both surface as a caught batch failure; we classify by re-reading whether
       // the charge row already exists.
       const settle = yield* Effect.tryPromise({
-        catch: (error: unknown) =>
-          error instanceof Error ? error : new Error(String(error)),
+        catch: inferenceMeteringPersistenceError,
         try: () =>
           runLedgerStatements(deps.db, createPayInStatements(plan, nowIso())),
       }).pipe(
@@ -378,8 +389,7 @@ export const makeLedgerMeteringHook = (
       // The batch failed. Re-read: if the charge row already exists, this was an
       // idempotent duplicate (already charged) — report metered, no re-charge.
       const already = yield* Effect.tryPromise({
-        catch: (error: unknown) =>
-          error instanceof Error ? error : new Error(String(error)),
+        catch: inferenceMeteringPersistenceError,
         try: () =>
           deps.db
             .prepare('SELECT id FROM pay_ins WHERE idempotency_key = ? LIMIT 1')

--- a/apps/openagents.com/workers/api/src/site-adjutant-event-fk-cleanup-migration.test.ts
+++ b/apps/openagents.com/workers/api/src/site-adjutant-event-fk-cleanup-migration.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { describe, expect, test } from 'vitest'
+
+const migrationSql = readFileSync(
+  join(
+    __dirname,
+    '..',
+    'migrations',
+    '0212_site_adjutant_event_fk_orphan_cleanup.sql',
+  ),
+  'utf8',
+)
+
+const rows = (db: DatabaseSync, query: string) =>
+  db.prepare(query).all() as Array<Record<string, unknown>>
+
+const createSchema = (db: DatabaseSync) => {
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE agent_runs (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE software_orders (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE agent_goals (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE site_projects (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE site_versions (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE site_deployments (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE adjutant_assignments (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+
+    CREATE TABLE site_events (
+      id TEXT PRIMARY KEY NOT NULL,
+      site_id TEXT NOT NULL REFERENCES site_projects(id) ON DELETE CASCADE,
+      version_id TEXT REFERENCES site_versions(id) ON DELETE SET NULL,
+      deployment_id TEXT REFERENCES site_deployments(id) ON DELETE SET NULL,
+      actor_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+      actor_run_id TEXT REFERENCES agent_runs(id) ON DELETE SET NULL
+    );
+
+    CREATE TABLE adjutant_assignment_events (
+      id TEXT PRIMARY KEY NOT NULL,
+      assignment_id TEXT NOT NULL REFERENCES adjutant_assignments(id) ON DELETE CASCADE,
+      software_order_id TEXT REFERENCES software_orders(id) ON DELETE SET NULL,
+      site_id TEXT REFERENCES site_projects(id) ON DELETE SET NULL,
+      goal_id TEXT REFERENCES agent_goals(id) ON DELETE SET NULL,
+      run_id TEXT REFERENCES agent_runs(id) ON DELETE SET NULL,
+      actor_user_id TEXT REFERENCES users(id) ON DELETE SET NULL
+    );
+  `)
+}
+
+const seedParents = (db: DatabaseSync) => {
+  db.exec(`
+    INSERT INTO users (id) VALUES ('user-ok');
+    INSERT INTO agent_runs (id) VALUES ('run-ok');
+    INSERT INTO software_orders (id) VALUES ('order-ok');
+    INSERT INTO agent_goals (id) VALUES ('goal-ok');
+    INSERT INTO site_projects (id) VALUES ('site-ok');
+    INSERT INTO site_versions (id) VALUES ('version-ok');
+    INSERT INTO site_deployments (id) VALUES ('deployment-ok');
+    INSERT INTO adjutant_assignments (id) VALUES ('assignment-ok');
+  `)
+}
+
+const seedForeignKeyDrift = (db: DatabaseSync) => {
+  db.exec(`
+    PRAGMA foreign_keys = OFF;
+
+    INSERT INTO site_events (
+      id,
+      site_id,
+      version_id,
+      deployment_id,
+      actor_user_id,
+      actor_run_id
+    ) VALUES
+      ('site-event-valid', 'site-ok', 'version-ok', 'deployment-ok', 'user-ok', 'run-ok'),
+      ('site-event-missing-required-site', 'site-missing', NULL, NULL, NULL, NULL),
+      ('site-event-missing-optional-refs', 'site-ok', 'version-missing', 'deployment-missing', 'user-missing', 'run-missing');
+
+    INSERT INTO adjutant_assignment_events (
+      id,
+      assignment_id,
+      software_order_id,
+      site_id,
+      goal_id,
+      run_id,
+      actor_user_id
+    ) VALUES
+      ('assignment-event-valid', 'assignment-ok', 'order-ok', 'site-ok', 'goal-ok', 'run-ok', 'user-ok'),
+      ('assignment-event-missing-required-assignment', 'assignment-missing', NULL, NULL, NULL, NULL, NULL),
+      ('assignment-event-missing-optional-refs', 'assignment-ok', 'order-missing', 'site-missing', 'goal-missing', 'run-missing', 'user-missing');
+
+    PRAGMA foreign_keys = ON;
+  `)
+}
+
+describe('site/adjutant event FK cleanup migration', () => {
+  test('clears child-table FK drift and remains rerunnable', () => {
+    const db = new DatabaseSync(':memory:')
+    createSchema(db)
+    seedParents(db)
+    seedForeignKeyDrift(db)
+
+    expect(rows(db, 'PRAGMA foreign_key_check')).toHaveLength(11)
+
+    db.exec(migrationSql)
+
+    expect(rows(db, 'PRAGMA foreign_key_check')).toEqual([])
+    expect(
+      rows(
+        db,
+        'SELECT id FROM site_events ORDER BY id',
+      ).map(row => row.id),
+    ).toEqual(['site-event-valid'])
+    expect(
+      rows(
+        db,
+        'SELECT id FROM adjutant_assignment_events ORDER BY id',
+      ).map(row => row.id),
+    ).toEqual(['assignment-event-valid'])
+
+    db.exec(migrationSql)
+
+    expect(rows(db, 'PRAGMA foreign_key_check')).toEqual([])
+    expect(rows(db, 'SELECT id FROM site_events')).toHaveLength(1)
+    expect(rows(db, 'SELECT id FROM adjutant_assignment_events')).toHaveLength(
+      1,
+    )
+    db.close()
+  })
+})


### PR DESCRIPTION
Fixes #5506.

Summary:
- Add migration 0212 to delete site/adjutant event rows whose FK targets are missing, using FK predicates rather than prod row ids.
- Add a real node:sqlite regression test that seeds FK drift with foreign_keys off, applies the migration, asserts PRAGMA foreign_key_check is empty, and proves the migration is rerunnable.
- Clear current deploy-gate blockers encountered on origin/main: typed Effect persistence catches/stub reads, plus workspace-root Moksha asset packaging verification for desktop builds.

Tests:
- bun run --cwd apps/openagents.com/workers/api test -- src/site-adjutant-event-fk-cleanup-migration.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck
- bun run --cwd apps/openagents.com/workers/api test -- src/site-adjutant-event-fk-cleanup-migration.test.ts src/cloud/cloud-metering.test.ts src/cloud/cloud-coding-session-routes.test.ts src/cloud/fine-tuning-service-routes.test.ts src/cloud/sandbox-compute-service-routes.test.ts src/inference/inference-abuse-controls.test.ts src/inference/inference-free-allowance.test.ts src/inference/inference-premium-allowlist.test.ts src/inference/inference-referral-accrual.test.ts src/inference/metering-hook.test.ts
- bun test tests/electrobun-config.test.ts (from apps/autopilot-desktop)
- bun run --cwd apps/openagents.com check:deploy