### PR TITLE
Destale signature metering promise evidence

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.4')
+    expect(decoded.version).toBe('2026-06-20.5')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -132,7 +132,15 @@ describe('public product promises document', () => {
     // agents.nostr_fallback_coordination.v1 yellow -> green (owner-authorized
     // 2026-06-19, outage-coordination drill PR #5535), so green is now exactly
     // 21. The 2026-06-20.1 pass is a Spark-first Forum wallet copy/default
-    // update with no state flips, so the count remained 21. The 2026-06-20.2 pass flips training.verification_classes.v1 yellow -> green (owner-authorized #4674 per-contribution sampling decision), so green is now exactly 22. The 2026-06-20.3 pass flips pylon.v03_release_candidate.v1 + pylon.release_tomorrow.v1 green (Pylon v1.0.5 signed release shipped + verified, owner-authorized), so green is now exactly 24.
+    // update with no state flips, so the count remained 21. The 2026-06-20.2
+    // pass flips training.verification_classes.v1 yellow -> green
+    // (owner-authorized #4674 per-contribution sampling decision), so green is
+    // now exactly 22. The 2026-06-20.3 pass flips
+    // pylon.v03_release_candidate.v1 + pylon.release_tomorrow.v1 green (Pylon
+    // v1.0.5 signed release shipped + verified, owner-authorized), so green is
+    // now exactly 24. The 2026-06-20.4 Pylon green-quality pass and
+    // 2026-06-20.5 signature-metering de-stale pass flip no promise state, so
+    // green remains exactly 24.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -652,16 +660,45 @@ describe('public product promises document', () => {
     )
   })
 
+  test('signature monetization records metering evidence while keeping settlement blocked', () => {
+    const document = publicProductPromisesDocument()
+    const signaturePromise = document.promises.find(
+      promise => promise.promiseId === 'marketplace.signature_monetization.v1',
+    )
+
+    expect(signaturePromise).toMatchObject({
+      state: 'red',
+      blockerRefs: ['blocker.product_promises.signature_settlement_missing'],
+      evidenceRefs: expect.arrayContaining([
+        'apps/openagents.com/workers/api/src/signature-usage-metering.ts',
+        'apps/openagents.com/workers/api/src/signature-usage-metering-routes.ts',
+        'route:/api/public/markets/signature-monetization/metering',
+      ]),
+    })
+    expect(signaturePromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.signature_usage_metering_missing',
+    )
+    expect(signaturePromise?.safeCopy).toContain(
+      'inert public usage-metering projection',
+    )
+    expect(signaturePromise?.verification).toContain(
+      'clearing the usage-metering blocker only',
+    )
+    expect(signaturePromise?.authorityBoundary).toContain(
+      'do not install, promote, bill, debit, credit, or settle',
+    )
+  })
+
   test('blocks announcement copy until the live endpoint serves the announced version', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.4', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.5', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.4',
+      expectedVersion: '2026-06-20.5',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.4',
+      servedVersion: '2026-06-20.5',
       status: 'ready',
     })
     expect(
@@ -671,7 +708,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.4',
+      servedVersion: '2026-06-20.5',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.4'
+export const PublicProductPromisesVersion = '2026-06-20.5'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -1248,21 +1248,23 @@ export const publicProductPromisesDocument = () => {
         claim:
           'DSPy/GEPA signatures and agent workflow components can be discoverable and monetizable.',
         safeCopy:
-          'Signature validation, Blueprint tooling, and marketplace gates exist; usage metering, billing, revenue split, and settlement are not live.',
+          'Signature validation, Blueprint tooling, marketplace gates, and an inert public usage-metering projection exist. Billing, pricing, revenue split, and settlement are not live.',
         unsafeCopy:
           'Do not claim signatures or workflow components are generating settled revenue.',
         evidenceRefs: [
           'apps/openagents.com/docs/2026-06-08-signature-marketplace-revenue-gate.md',
           'apps/pylon/packages/runtime/src/blueprint',
+          'apps/openagents.com/workers/api/src/signature-usage-metering.ts',
+          'apps/openagents.com/workers/api/src/signature-usage-metering.test.ts',
+          'apps/openagents.com/workers/api/src/signature-usage-metering-routes.ts',
+          'apps/openagents.com/workers/api/src/signature-usage-metering-routes.test.ts',
+          'route:/api/public/markets/signature-monetization/metering',
         ],
-        blockerRefs: [
-          'blocker.product_promises.signature_usage_metering_missing',
-          'blocker.product_promises.signature_settlement_missing',
-        ],
+        blockerRefs: ['blocker.product_promises.signature_settlement_missing'],
         verification:
-          'Requires package validation, runtime activation, metering, attribution, pricing, rev-share, dispute/refund policy, and settlement receipts.',
+          'Usage metering reaches the metered rung via the inert public projection and tests, clearing the usage-metering blocker only. Green still requires package activation, attribution, pricing, rev-share, dispute/refund policy, and settlement receipts.',
         authorityBoundary:
-          'Discovery or contribution validation does not install, promote, bill, or settle package usage.',
+          'Discovery, contribution validation, and inert usage metering do not install, promote, bill, debit, credit, or settle package usage.',
       },
       {
         ...basePromiseFields,
@@ -3435,6 +3437,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.2: owner-decided green — training.verification_classes.v1 yellow -> green. The last open gate (#4674 aggregate-only vs per-contribution sampling) is decided in writing: per-contribution sampling default per class, aggregate-only deprecated (docs/promises/2026-06-20-verification-class-sampling-policy.md, owner-approved 2026-06-20). Other criteria already met (registry live; exact_trace_replay/deterministic_recompute/freivalds_merkle on real work; paid weak-device validator closeout #4676; exact_trace_replay already per-contribution across five paid contributors on run.tassadar.executor.20260615). Blocker cleared. Green 21 -> 22. Honest bound: not all five classes on real work / not at-scale. promise_transition via operator route per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-20.3: Pylon v1.0.5 signed-binary release shipped + verified — pylon.v03_release_candidate.v1 + pylon.release_tomorrow.v1 yellow -> green (owner-authorized 2026-06-20). Signed binaries (macOS+Linux, 4 targets) signed with pinned ed25519 kid 2dbe811d19f67528, published to updates.openagents.com (Cloud Run oa-updates-00041-b7b, rollout 100, full rc history preserved); live feed verified serving v1.0.5 with sha256+ed25519 against apps/oa-updates/keys/release-pubkey.json (fail-closed, tamper rejected); live network smoke registered+heartbeated online in /api/pylons as pylon.33afd48282a649047e3a (openagents.pylon@1.0.5). Both blockers cleared. Green 22 -> 24. Honest bound: macOS+Linux only (Windows out of scope); network-scale earning separate. Flip applied in source ahead of the operator-route transition receipt.',
         'Registry 2026-06-20.4: green-quality fix on pylon.release_tomorrow.v1 (conceding Orrery audit, forum topic 415e16a7) — its green previously rested on the sibling pylon.v03_release_candidate.v1 evidence array; it now carries its OWN dereferenceable refs (the signed darwin-arm64 feed https://updates.openagents.com/pylon/rc/darwin-arm64/feed.json and the live registration route:/api/pylons#pylon.33afd48282a649047e3a). No state change (stays green), green count unchanged at 24. The transitions-feed backfill for the four post-2026-06-17.5 flips remains the owner-gated item (prod admin token).',
+        'Registry 2026-06-20.5 is a marketplace.signature_monetization.v1 de-stale pass and flips NO promise state. The already-deployed inert usage-metering model and public read-only projection (GET /api/public/markets/signature-monetization/metering) prove validation+metering can reach the metered rung while the promise remains red/inert and settlement stays blocked. This clears blocker.product_promises.signature_usage_metering_missing only; blocker.product_promises.signature_settlement_missing remains. No billing, pricing, rev-share, payout, settlement, or revenue claim is created.',
       'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }


### PR DESCRIPTION
## Summary
- update `marketplace.signature_monetization.v1` to cite the inert usage-metering projection already on main and remove only `signature_usage_metering_missing`
- keep the promise red on `signature_settlement_missing`; no billing, rev-share, payout, settlement, or revenue claim is added
- add regression coverage that the old metering blocker stays removed while the settlement blocker remains

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/signature-usage-metering.test.ts src/signature-usage-metering-routes.test.ts src/worker-exact-routes.test.ts`
- `bun run --cwd apps/openagents.com check:deploy`

## Forum
- Claim: https://openagents.com/forum/t/d8fa3ef8-e8ba-4779-a783-b462db46c6c1#post-c9a8fcf5-b122-4b5b-9041-209fd0dbc4e2