### PR TITLE
Expand Nostr relay coordination kinds

### DIFF
--- a/apps/autopilot-desktop/electrobun.config.ts
+++ b/apps/autopilot-desktop/electrobun.config.ts
@@ -31,7 +31,7 @@ export default {
       // and resolves its GLB/font/image assets relative to the bundled view
       // module (`views://autopilot-desktop/assets/moksha/...`). Copy the whole
       // asset directory so WebKit does not get empty `views://` responses.
-      "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha":
+      "../../node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha":
         "views/autopilot-desktop/assets/moksha",
       // #5027 (Phase 2, packaged build): the bundled headless Pylon node, built
       // by `bun run build:pylon-node` before electrobun build. electrobun copies

--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -20,7 +20,7 @@
     "proof:shell-control": "bun --preload ./tests/preload.ts scripts/shell-control-proof.ts",
     "smoke:auto-onboarding-e2e": "bun scripts/auto-onboarding-e2e-smoke.ts",
     "verify:training": "bun test tests/cl-53-foldkit.test.ts tests/cl-53-sanitize.test.ts && bun run build:css && bun build src/ui/main.ts --outdir /tmp/autopilot-desktop-ui-build --target browser && bun build src/bun/index.ts --outdir /tmp/autopilot-desktop-bun-build --target bun && bun run smoke:training-scene",
-    "verify:deploy": "bun test tests/electrobun-config.test.ts && bun run verify:training && bun run build && test -s \"build/dev-macos-arm64/Autopilot-dev.app/Contents/Resources/app/views/autopilot-desktop/assets/moksha/diamond.glb\"",
+    "verify:deploy": "bun test tests/electrobun-config.test.ts && bun run verify:training && bun run build && asset=\"$(find build -path '*/Resources/app/views/autopilot-desktop/assets/moksha/diamond.glb' -type f -print -quit)\" && test -n \"$asset\" && test -s \"$asset\"",
     "test": "bash scripts/run-tests.sh",
     "notarize:macos": "bash scripts/notarize-macos.sh"
   },

--- a/apps/autopilot-desktop/tests/electrobun-config.test.ts
+++ b/apps/autopilot-desktop/tests/electrobun-config.test.ts
@@ -7,7 +7,7 @@ import { desktopApplicationMenu } from "../src/bun/application-menu"
 import config from "../electrobun.config"
 
 const mokshaAssetSource =
-  "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha"
+  "../../node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha"
 
 describe("ElectroBun packaging", () => {
   test("uses the concise Autopilot app title", () => {

--- a/apps/nostr-relay/README.md
+++ b/apps/nostr-relay/README.md
@@ -1,9 +1,9 @@
-# OpenAgents Scoped Market Relay
+# OpenAgents Market and Coordination Relay
 
 Issue: <https://github.com/OpenAgentsInc/openagents/issues/4636>
 
-This app runs the scoped OpenAgents market-event Nostr relay. It wraps the
-`nostr-effect` Cloudflare Durable Object relay backend and adds an
+This app runs the scoped OpenAgents market-event and coordination Nostr relay.
+It wraps the `nostr-effect` Cloudflare Durable Object relay backend and adds an
 OpenAgents-specific transport policy before messages reach the shared relay
 handler.
 
@@ -14,8 +14,15 @@ own receipt-backed systems.
 
 ## Allowed Events
 
-The relay accepts only the market event kinds needed for the five Bitcoin
-revenue-stream rails:
+The relay accepts the market event kinds needed for the five Bitcoin
+revenue-stream rails plus the coordination/discovery kinds OpenAgents agents use
+for outage fallback and agent-to-agent status:
+
+- NIP-01 text notes: `1`
+- NIP-02 contact lists: `3`
+- NIP-17/44/59 private direct-message transport: `13`, `14`, `1059`
+- NIP-38 user statuses: `30315`
+- NIP-65 relay lists: `10002`
 
 - NIP-90 job requests: `5000` through `5999`
 - NIP-90 job results: `6000` through `6999`
@@ -23,7 +30,9 @@ revenue-stream rails:
 - NIP-DS listing and offer kinds: `30404`, `30406`
 - NIP-89 handler information: `31989`, `31990`
 
-All other event kinds are rejected before storage or broadcast.
+All other event kinds are rejected before storage or broadcast. The expanded
+coordination scope does not add authority: the relay remains transport-only and
+does not verify identity, authorize work, moderate content, or settle payments.
 
 ## Limits
 
@@ -44,12 +53,17 @@ REQ limits:
 REQ filters that name disallowed kinds are closed without creating a
 subscription.
 
+General coordination writes are intentionally covered by the same anti-abuse
+posture as market writes: per-pubkey publish rate limits, bounded event content,
+bounded REQ filters, and an explicit allowlist of supported event kinds. NIP-42
+AUTH is not advertised until an authenticated write policy is implemented.
+
 ## Retention
 
-Stored market events are retained for `30` days. NIP-89 handler information is
-retained for `180` days because handler advertisements change less often and
-are useful for discovery. Retention cleanup runs opportunistically on health
-checks and valid WebSocket messages.
+Stored market and coordination events are retained for `30` days. NIP-89
+handler information is retained for `180` days because handler advertisements
+change less often and are useful for discovery. Retention cleanup runs
+opportunistically on health checks and valid WebSocket messages.
 
 ## Routes
 

--- a/apps/nostr-relay/src/index.ts
+++ b/apps/nostr-relay/src/index.ts
@@ -8,9 +8,11 @@ import {
   MarketRelayPolicy,
   type PublishBucket,
   isAllowedMarketKind,
+  isParameterizedReplaceableMarketKind,
   marketKindBucket,
   marketKindPolicySummary,
   nextPublishBucket,
+  relayInformationDocument,
   validateReqFilters,
 } from "./market-policy"
 
@@ -26,6 +28,16 @@ const json = (value: unknown, init: ResponseInit = {}) =>
       ...init.headers,
     },
   })
+
+const relayInfoResponse = () =>
+  json(relayInformationDocument, {
+    headers: { "content-type": "application/nostr+json; charset=utf-8" },
+  })
+
+const isRelayInfoRequest = (request: Request, url: URL): boolean =>
+  request.method === "GET" &&
+  url.pathname === "/" &&
+  (request.headers.get("accept") ?? "").includes("application/nostr+json")
 
 type SqlStorage = {
   exec<T = Record<string, unknown>>(
@@ -69,7 +81,7 @@ type MarketRelayMetrics = Readonly<{
   }>
 }>
 
-const marketRelayName = "openagents-scoped-market-relay"
+const marketRelayName = "openagents-market-and-coordination-relay"
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
@@ -122,6 +134,11 @@ const filtersFromReqMessage = (message: unknown): ReadonlyArray<Record<string, u
     : null
 
 const kindCountsDefault = () => ({
+  nip01_text_note: 0,
+  nip02_contacts: 0,
+  nip17_private_dm: 0,
+  nip38_status: 0,
+  nip65_relay_list: 0,
   nip90_request: 0,
   nip90_result: 0,
   nip90_feedback: 0,
@@ -178,6 +195,10 @@ export class NostrRelayDO extends BaseNostrRelayDO {
       return json(this.metrics())
     }
 
+    if (isRelayInfoRequest(request, url)) {
+      return relayInfoResponse()
+    }
+
     return super.fetch(request)
   }
 
@@ -203,8 +224,9 @@ export class NostrRelayDO extends BaseNostrRelayDO {
     const event = eventFromMessage(parsed)
     if (
       event !== null &&
-      (event.kind === 30404 || event.kind === 30406) &&
-      this.storeAddressableMarketEvent(event, ws)
+      typeof event.kind === "number" &&
+      isParameterizedReplaceableMarketKind(event.kind) &&
+      this.storeParameterizedReplaceableMarketEvent(event, ws)
     ) {
       return
     }
@@ -247,7 +269,7 @@ export class NostrRelayDO extends BaseNostrRelayDO {
       return relayOk(
         event.id,
         false,
-        `blocked: kind ${event.kind} is outside the OpenAgents scoped market relay policy`,
+        `blocked: kind ${event.kind} is outside the OpenAgents scoped market and coordination relay policy`,
       )
     }
 
@@ -273,12 +295,14 @@ export class NostrRelayDO extends BaseNostrRelayDO {
       : relayOk(event.id, false, "rate-limited: per-pubkey publish limit exceeded")
   }
 
-  private storeAddressableMarketEvent(
+  private storeParameterizedReplaceableMarketEvent(
     event: MarketRelayEvent,
     ws: WebSocket,
   ): boolean {
     if (!isSignedNostrEvent(event)) {
-      ws.send(relayOk(event.id, false, "blocked: malformed addressable market event"))
+      ws.send(
+        relayOk(event.id, false, "blocked: malformed parameterized replaceable event"),
+      )
       return true
     }
 
@@ -289,7 +313,13 @@ export class NostrRelayDO extends BaseNostrRelayDO {
 
     const dTag = dTagValue(event)
     if (dTag === null) {
-      ws.send(relayOk(event.id, false, "blocked: addressable market event requires d tag"))
+      ws.send(
+        relayOk(
+          event.id,
+          false,
+          "blocked: parameterized replaceable event requires d tag",
+        ),
+      )
       return true
     }
 
@@ -341,7 +371,7 @@ export class NostrRelayDO extends BaseNostrRelayDO {
         relayOk(
           event.id,
           false,
-          `error: addressable market storage failed: ${(error as Error).message}`,
+          `error: parameterized replaceable storage failed: ${(error as Error).message}`,
         ),
       )
       return true
@@ -442,6 +472,10 @@ export default {
       const id = env.NOSTR_RELAY.idFromName("global")
       const stub = env.NOSTR_RELAY.get(id)
       return stub.fetch(request)
+    }
+
+    if (isRelayInfoRequest(request, url)) {
+      return relayInfoResponse()
     }
 
     return relayWorker.fetch(request, env)

--- a/apps/nostr-relay/src/market-policy.test.ts
+++ b/apps/nostr-relay/src/market-policy.test.ts
@@ -3,13 +3,22 @@ import { describe, expect, test } from "bun:test"
 import {
   MarketRelayPolicy,
   isAllowedMarketKind,
+  isParameterizedReplaceableMarketKind,
   marketKindBucket,
   nextPublishBucket,
+  relayInformationDocument,
   validateReqFilters,
 } from "./market-policy"
 
 describe("market relay policy", () => {
-  test("allows only scoped market event kinds", () => {
+  test("allows scoped market and OpenAgents coordination event kinds", () => {
+    expect(isAllowedMarketKind(1)).toBe(true)
+    expect(isAllowedMarketKind(3)).toBe(true)
+    expect(isAllowedMarketKind(13)).toBe(true)
+    expect(isAllowedMarketKind(14)).toBe(true)
+    expect(isAllowedMarketKind(1059)).toBe(true)
+    expect(isAllowedMarketKind(10002)).toBe(true)
+    expect(isAllowedMarketKind(30315)).toBe(true)
     expect(isAllowedMarketKind(5000)).toBe(true)
     expect(isAllowedMarketKind(5050)).toBe(true)
     expect(isAllowedMarketKind(5999)).toBe(true)
@@ -21,18 +30,24 @@ describe("market relay policy", () => {
     expect(isAllowedMarketKind(31989)).toBe(true)
     expect(isAllowedMarketKind(31990)).toBe(true)
 
-    expect(isAllowedMarketKind(1)).toBe(false)
     expect(isAllowedMarketKind(4999)).toBe(false)
     expect(isAllowedMarketKind(60000)).toBe(false)
   })
 
   test("classifies health metrics buckets", () => {
+    expect(marketKindBucket(1)).toBe("nip01_text_note")
+    expect(marketKindBucket(3)).toBe("nip02_contacts")
+    expect(marketKindBucket(13)).toBe("nip17_private_dm")
+    expect(marketKindBucket(14)).toBe("nip17_private_dm")
+    expect(marketKindBucket(1059)).toBe("nip17_private_dm")
+    expect(marketKindBucket(10002)).toBe("nip65_relay_list")
+    expect(marketKindBucket(30315)).toBe("nip38_status")
     expect(marketKindBucket(5050)).toBe("nip90_request")
     expect(marketKindBucket(6050)).toBe("nip90_result")
     expect(marketKindBucket(7000)).toBe("nip90_feedback")
     expect(marketKindBucket(30404)).toBe("nip_ds")
     expect(marketKindBucket(31989)).toBe("nip89_handler")
-    expect(marketKindBucket(1)).toBeNull()
+    expect(marketKindBucket(60000)).toBeNull()
   })
 
   test("allows NIP-LBR labor transport kinds", () => {
@@ -78,10 +93,31 @@ describe("market relay policy", () => {
   })
 
   test("rejects disallowed kind filters", () => {
-    expect(validateReqFilters([{ kinds: [5050, 1], limit: 10 }])).toContain(
-      "kind 1",
+    expect(validateReqFilters([{ kinds: [5050, 60000], limit: 10 }])).toContain(
+      "kind 60000",
     )
-    expect(validateReqFilters([{ kinds: [5050], limit: 10 }])).toBeNull()
+    expect(
+      validateReqFilters([{ kinds: [5050, 1, 3, 10002], limit: 10 }]),
+    ).toBeNull()
+  })
+
+  test("identifies parameterized replaceable coordination and market kinds", () => {
+    expect(isParameterizedReplaceableMarketKind(30315)).toBe(true)
+    expect(isParameterizedReplaceableMarketKind(30404)).toBe(true)
+    expect(isParameterizedReplaceableMarketKind(30406)).toBe(true)
+    expect(isParameterizedReplaceableMarketKind(31989)).toBe(true)
+    expect(isParameterizedReplaceableMarketKind(31990)).toBe(true)
+    expect(isParameterizedReplaceableMarketKind(10002)).toBe(false)
+    expect(isParameterizedReplaceableMarketKind(1)).toBe(false)
+  })
+
+  test("advertises expanded coordination scope in NIP-11 metadata", () => {
+    expect(relayInformationDocument.supported_nips).toContain(17)
+    expect(relayInformationDocument.supported_nips).toContain(38)
+    expect(relayInformationDocument.supported_nips).toContain(59)
+    expect(relayInformationDocument.supported_nips).toContain(65)
+    expect(relayInformationDocument.supported_nips).toContain(90)
+    expect(relayInformationDocument.limitation.restricted_writes).toBe(true)
   })
 
   test("enforces per-pubkey publish buckets", () => {

--- a/apps/nostr-relay/src/market-policy.ts
+++ b/apps/nostr-relay/src/market-policy.ts
@@ -1,4 +1,9 @@
 export type MarketKindBucket =
+  | "nip01_text_note"
+  | "nip02_contacts"
+  | "nip17_private_dm"
+  | "nip38_status"
+  | "nip65_relay_list"
   | "nip90_request"
   | "nip90_result"
   | "nip90_feedback"
@@ -36,7 +41,32 @@ export const MarketRelayPolicy = {
   publishRateLimitWindowMs: 60_000,
 } as const
 
+const privateDirectMessageKinds = [13, 14, 1059] as const
+
+const isPrivateDirectMessageKind = (kind: number): boolean =>
+  privateDirectMessageKinds.some(candidate => candidate === kind)
+
 export const marketKindBucket = (kind: number): MarketKindBucket | null => {
+  if (kind === 1) {
+    return "nip01_text_note"
+  }
+
+  if (kind === 3) {
+    return "nip02_contacts"
+  }
+
+  if (isPrivateDirectMessageKind(kind)) {
+    return "nip17_private_dm"
+  }
+
+  if (kind === 10002) {
+    return "nip65_relay_list"
+  }
+
+  if (kind === 30315) {
+    return "nip38_status"
+  }
+
   if (kind >= 5000 && kind <= 5999) {
     return "nip90_request"
   }
@@ -63,8 +93,20 @@ export const marketKindBucket = (kind: number): MarketKindBucket | null => {
 export const isAllowedMarketKind = (kind: number): boolean =>
   marketKindBucket(kind) !== null
 
+export const isParameterizedReplaceableMarketKind = (kind: number): boolean =>
+  kind >= 30000 && kind <= 39999 && isAllowedMarketKind(kind)
+
+export const relaySupportedNips = [
+  1, 2, 11, 17, 38, 44, 59, 65, 89, 90,
+] as const
+
 export const marketKindPolicySummary = {
   allowedKinds: {
+    nip01TextNotes: [1],
+    nip02Contacts: [3],
+    nip17PrivateDirectMessages: privateDirectMessageKinds,
+    nip38UserStatuses: [30315],
+    nip65RelayLists: [10002],
     nip90Requests: "5000-5999",
     nip90Results: "6000-6999",
     nip90Feedback: [7000],
@@ -87,6 +129,53 @@ export const marketKindPolicySummary = {
     maxEvents: MarketRelayPolicy.publishRateLimitMaxEvents,
     windowMs: MarketRelayPolicy.publishRateLimitWindowMs,
   },
+  antiAbuse: {
+    perPubkeyPublishLimit: true,
+    maxEventContentBytes: MarketRelayPolicy.maxEventContentBytes,
+    boundedReqFilters: true,
+    authority:
+      "event_transport_only_no_payment_identity_moderation_assignment_or_settlement_authority",
+  },
+} as const
+
+export const relayInformationDocument = {
+  name: "OpenAgents Market and Coordination Relay",
+  description:
+    "OpenAgents-owned Nostr relay for scoped market events and OpenAgents coordination/discovery traffic. Event transport only; no payment, identity, moderation, assignment, payout, or settlement authority.",
+  pubkey: "",
+  contact: "https://openagents.com",
+  supported_nips: relaySupportedNips,
+  software:
+    "https://github.com/OpenAgentsInc/openagents/tree/main/apps/nostr-relay",
+  version: "0.1.0",
+  limitation: {
+    max_content_length: MarketRelayPolicy.maxEventContentBytes,
+    max_filters: MarketRelayPolicy.maxFiltersPerReq,
+    max_limit: MarketRelayPolicy.maxReqLimit,
+    auth_required: false,
+    payment_required: false,
+    restricted_writes: true,
+  },
+  retention: [
+    { kinds: [31989, 31990], time: MarketRelayPolicy.handlerRetentionSeconds },
+    {
+      kinds: [
+        1,
+        3,
+        13,
+        14,
+        1059,
+        7000,
+        10002,
+        30315,
+        30404,
+        30406,
+        [5000, 5999],
+        [6000, 6999],
+      ],
+      time: MarketRelayPolicy.eventRetentionSeconds,
+    },
+  ],
 } as const
 
 const arrayLength = (value: unknown): number =>
@@ -171,7 +260,7 @@ export const validateReqFilters = (
       )
 
       if (typeof disallowedKind === "number") {
-        return `kind ${disallowedKind} is outside the OpenAgents scoped market relay policy`
+        return `kind ${disallowedKind} is outside the OpenAgents scoped market and coordination relay policy`
       }
     }
   }


### PR DESCRIPTION
Fixes #5537.

Summary:
- expands the relay allowlist beyond scoped market kinds to include NIP-01 text notes, NIP-02 contacts, NIP-17/44/59 direct-message transport, NIP-38 statuses, and NIP-65 relay lists
- adds NIP-11 relay metadata with supported NIPs, limits, retention, and transport-only authority language
- routes all allowed parameterized replaceable relay events through d-tag replacement storage
- updates relay docs and market-policy tests for the expanded coordination scope
- fixes the desktop deploy gate Moksha asset source path from the workspace root so check:deploy can verify packaged assets

Verification:
- bun run --cwd apps/nostr-relay test
- bun run --cwd apps/nostr-relay typecheck
- bun test tests/electrobun-config.test.ts (from apps/autopilot-desktop)
- bun run --cwd apps/openagents.com check:deploy