### PR TITLE
Add mobile workroom approval projection

### DIFF
--- a/apps/autopilot-desktop/electrobun.config.ts
+++ b/apps/autopilot-desktop/electrobun.config.ts
@@ -1,3 +1,19 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const desktopRoot = fileURLToPath(new URL(".", import.meta.url));
+const workspaceMokshaAssetSource =
+  "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha";
+const rootMokshaAssetSource =
+  "../../node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha";
+
+export const mokshaAssetSource = existsSync(
+  join(desktopRoot, workspaceMokshaAssetSource),
+)
+  ? workspaceMokshaAssetSource
+  : rootMokshaAssetSource;
+
 export default {
   app: {
     name: "Autopilot",
@@ -31,8 +47,7 @@ export default {
       // and resolves its GLB/font/image assets relative to the bundled view
       // module (`views://autopilot-desktop/assets/moksha/...`). Copy the whole
       // asset directory so WebKit does not get empty `views://` responses.
-      "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha":
-        "views/autopilot-desktop/assets/moksha",
+      [mokshaAssetSource]: "views/autopilot-desktop/assets/moksha",
       // #5027 (Phase 2, packaged build): the bundled headless Pylon node, built
       // by `bun run build:pylon-node` before electrobun build. electrobun copies
       // `build.copy` dests under `<RESOURCES_FOLDER>/app/`, so this dest lands at

--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -20,7 +20,7 @@
     "proof:shell-control": "bun --preload ./tests/preload.ts scripts/shell-control-proof.ts",
     "smoke:auto-onboarding-e2e": "bun scripts/auto-onboarding-e2e-smoke.ts",
     "verify:training": "bun test tests/cl-53-foldkit.test.ts tests/cl-53-sanitize.test.ts && bun run build:css && bun build src/ui/main.ts --outdir /tmp/autopilot-desktop-ui-build --target browser && bun build src/bun/index.ts --outdir /tmp/autopilot-desktop-bun-build --target bun && bun run smoke:training-scene",
-    "verify:deploy": "bun test tests/electrobun-config.test.ts && bun run verify:training && bun run build && test -s \"build/dev-macos-arm64/Autopilot-dev.app/Contents/Resources/app/views/autopilot-desktop/assets/moksha/diamond.glb\"",
+    "verify:deploy": "bun test tests/electrobun-config.test.ts && bun run verify:training && bun run build && bun scripts/verify-packaged-moksha-asset.ts",
     "test": "bash scripts/run-tests.sh",
     "notarize:macos": "bash scripts/notarize-macos.sh"
   },

--- a/apps/autopilot-desktop/scripts/verify-packaged-moksha-asset.ts
+++ b/apps/autopilot-desktop/scripts/verify-packaged-moksha-asset.ts
@@ -1,0 +1,34 @@
+import { existsSync, statSync } from "node:fs"
+
+const mokshaAssetSuffix =
+  "views/autopilot-desktop/assets/moksha/diamond.glb"
+
+const candidateAssetPaths = [
+  `build/dev-macos-arm64/Autopilot-dev.app/Contents/Resources/app/${mokshaAssetSuffix}`,
+  `build/dev-macos-x64/Autopilot-dev.app/Contents/Resources/app/${mokshaAssetSuffix}`,
+  `build/dev-linux-x64/Autopilot-dev/Resources/app/${mokshaAssetSuffix}`,
+  `build/dev-linux-arm64/Autopilot-dev/Resources/app/${mokshaAssetSuffix}`,
+  `build/dev-windows-x64/Autopilot-dev/resources/app/${mokshaAssetSuffix}`,
+  `build/dev-windows-arm64/Autopilot-dev/resources/app/${mokshaAssetSuffix}`,
+]
+
+const packagedAssetPath = candidateAssetPaths.find(path => {
+  if (!existsSync(path)) {
+    return false
+  }
+
+  return statSync(path).size > 0
+})
+
+if (packagedAssetPath === undefined) {
+  console.error(
+    [
+      "Packaged Moksha diamond asset is missing.",
+      "Checked:",
+      ...candidateAssetPaths.map(path => `- ${path}`),
+    ].join("\n"),
+  )
+  process.exit(1)
+}
+
+console.log(`Packaged Moksha diamond asset verified: ${packagedAssetPath}`)

--- a/apps/autopilot-desktop/tests/electrobun-config.test.ts
+++ b/apps/autopilot-desktop/tests/electrobun-config.test.ts
@@ -4,10 +4,7 @@ import { describe, expect, test } from "bun:test"
 
 import { DESKTOP_RPC_MAX_REQUEST_TIME_MS } from "../src/shared/rpc"
 import { desktopApplicationMenu } from "../src/bun/application-menu"
-import config from "../electrobun.config"
-
-const mokshaAssetSource =
-  "node_modules/@openagentsinc/three-effect/packages/core/src/assets/moksha"
+import config, { mokshaAssetSource } from "../electrobun.config"
 
 describe("ElectroBun packaging", () => {
   test("uses the concise Autopilot app title", () => {

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -39,6 +39,14 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // ingestion-endpoint blocker; STT vendor + approval UI stay owner/product-
   // gated and the promise stays red regardless.
   VOICE_PROGRAM_INGEST_ENABLED?: string | undefined
+  // Mobile workroom approval projection flag (promise
+  // mobile.voice_approval_companion.v1, planned). Default OFF: the
+  // `/api/mobile/workroom-approval-projection` route is INERT (empty store) on
+  // the live Worker. Set "true"/"1"/"on" to arm the read-only projection over
+  // an injected authorized store. It clears only the mobile-projection blocker;
+  // voice-command approval receipts + cross-device sync stay open and the
+  // promise stays planned regardless.
+  MOBILE_WORKROOM_APPROVAL_PROJECTION_ENABLED?: string | undefined
   // Pylon multi-earning-node projection flag (EPIC #5523 / DE-4 #5527; promise
   // pylon.v0_3_multi_earning_node.v1, red). Default OFF: the
   // `/api/public/pylon/multi-earning-node` surface is INERT (empty store) on

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -43,6 +43,11 @@ import {
   isSignatureUsageMeteringEnabled,
 } from './signature-usage-metering-routes'
 import {
+  MobileWorkroomApprovalProjectionEndpoint,
+  handleMobileWorkroomApprovalProjectionApi,
+  isMobileWorkroomApprovalProjectionEnabled,
+} from './mobile-workroom-approval-projection-routes'
+import {
   VoiceProgramIngestEndpoint,
   handleVoiceProgramIngestApi,
   isVoiceProgramIngestEnabled,
@@ -7977,6 +7982,25 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         enabled: isPylonMultiEarningProjectionEnabled(
           env.PYLON_MULTI_EARNING_PROJECTION_ENABLED,
         ),
+      }),
+  },
+  {
+    // Mobile workroom approval projection (promise
+    // mobile.voice_approval_companion.v1, planned). INERT by default: the store
+    // is empty unless MOBILE_WORKROOM_APPROVAL_PROJECTION_ENABLED is armed. When
+    // armed it returns the existing read-only mobile approval-card projection:
+    // no approval, execution, notification, payment, provider mutation, runner
+    // launch, or public-claim upgrade. This clears ONLY
+    // blocker.product_promises.mobile_projection_missing; voice-command
+    // approval receipts and cross-device sync stay open, and the promise stays
+    // planned. GET only.
+    path: MobileWorkroomApprovalProjectionEndpoint,
+    handler: (request, env) =>
+      handleMobileWorkroomApprovalProjectionApi(request, {
+        enabled: isMobileWorkroomApprovalProjectionEnabled(
+          env.MOBILE_WORKROOM_APPROVAL_PROJECTION_ENABLED,
+        ),
+        nowIso: currentIsoTimestamp,
       }),
   },
   {

--- a/apps/openagents.com/workers/api/src/mobile-workroom-approval-projection-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/mobile-workroom-approval-projection-routes.test.ts
@@ -1,0 +1,166 @@
+import { Effect, Schema as S } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  OmniMobileWorkroomProjection,
+  exampleOmniMobileApprovalCard,
+  exampleOmniMobileApprovalCards,
+  exampleOmniMobileWorkroom,
+} from './omni-mobile-workroom-approval-cards'
+import {
+  MOBILE_WORKROOM_APPROVAL_PROJECTION_BLOCKERS,
+  MobileWorkroomApprovalProjectionEndpoint,
+  handleMobileWorkroomApprovalProjectionApi,
+  isMobileWorkroomApprovalProjectionEnabled,
+  makeInMemoryMobileWorkroomApprovalProjectionStore,
+} from './mobile-workroom-approval-projection-routes'
+
+const nowIso = '2026-06-06T22:30:00.000Z'
+
+const request = (suffix = '', init: RequestInit = {}) =>
+  new Request(
+    `https://openagents.com${MobileWorkroomApprovalProjectionEndpoint}${suffix}`,
+    init,
+  )
+
+const exampleStore = () =>
+  makeInMemoryMobileWorkroomApprovalProjectionStore(
+    [exampleOmniMobileWorkroom()],
+    exampleOmniMobileApprovalCards(),
+  )
+
+describe('mobile workroom approval projection flag', () => {
+  test('defaults OFF and only arms on explicit truthy tokens', () => {
+    expect(isMobileWorkroomApprovalProjectionEnabled(undefined)).toBe(false)
+    expect(isMobileWorkroomApprovalProjectionEnabled('')).toBe(false)
+    expect(isMobileWorkroomApprovalProjectionEnabled('false')).toBe(false)
+    expect(isMobileWorkroomApprovalProjectionEnabled('0')).toBe(false)
+    expect(isMobileWorkroomApprovalProjectionEnabled('off')).toBe(false)
+    expect(isMobileWorkroomApprovalProjectionEnabled('true')).toBe(true)
+    expect(isMobileWorkroomApprovalProjectionEnabled('1')).toBe(true)
+    expect(isMobileWorkroomApprovalProjectionEnabled('ON')).toBe(true)
+    expect(isMobileWorkroomApprovalProjectionEnabled(' yes ')).toBe(true)
+  })
+})
+
+describe('mobile workroom approval projection route', () => {
+  test('rejects non-GET with 405', async () => {
+    const response = await Effect.runPromise(
+      handleMobileWorkroomApprovalProjectionApi(
+        request('', { method: 'POST' }),
+        { enabled: true, nowIso: () => nowIso, store: exampleStore() },
+      ),
+    )
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('GET')
+  })
+
+  test('INERT by default: disabled ignores an injected store and stays planned', async () => {
+    const response = await Effect.runPromise(
+      handleMobileWorkroomApprovalProjectionApi(request(), {
+        enabled: false,
+        nowIso: () => nowIso,
+        store: exampleStore(),
+      }),
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.promiseId).toBe('mobile.voice_approval_companion.v1')
+    expect(payload.promiseState).toBe('planned')
+    expect(payload.enabled).toBe(false)
+    expect(payload.inert).toBe(true)
+    expect(payload.projectionAvailable).toBe(true)
+    expect(payload.workroomCount).toBe(0)
+    expect(payload.pendingApprovalCount).toBe(0)
+    expect(payload.approvalMutationAllowed).toBe(false)
+    expect(payload.executionMutationAllowed).toBe(false)
+    expect(payload.paymentMutationAllowed).toBe(false)
+    expect(payload.blockerCleared).toBe(
+      MOBILE_WORKROOM_APPROVAL_PROJECTION_BLOCKERS.cleared,
+    )
+    expect(payload.remainingBlockers).toEqual([
+      'blocker.product_promises.voice_command_approval_receipts_missing',
+      'blocker.product_promises.cross_device_workroom_sync_missing',
+    ])
+  })
+
+  test('ARMED: projects read-only workroom approval cards by audience', async () => {
+    const response = await Effect.runPromise(
+      handleMobileWorkroomApprovalProjectionApi(request('?audience=public'), {
+        enabled: true,
+        nowIso: () => nowIso,
+        store: exampleStore(),
+      }),
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.promiseState).toBe('planned')
+    expect(payload.enabled).toBe(true)
+    expect(payload.inert).toBe(false)
+    expect(payload.audience).toBe('public')
+    expect(payload.workroomCount).toBe(1)
+    expect(payload.pendingApprovalCount).toBe(1)
+    expect(payload.blockedApprovalCount).toBe(1)
+    expect(payload.criticalApprovalCount).toBe(1)
+    expect(payload.expiredApprovalCount).toBe(1)
+
+    const workrooms = payload.workrooms as ReadonlyArray<unknown>
+    expect(workrooms).toHaveLength(1)
+    const projection = S.decodeUnknownSync(OmniMobileWorkroomProjection)(
+      workrooms[0],
+    )
+    expect(projection).toMatchObject({
+      approvalMutationAllowed: false,
+      audience: 'public',
+      executionMutationAllowed: false,
+      providerMutationAllowed: false,
+      publicClaimUpgradeAllowed: false,
+      runnerLaunchAllowed: false,
+      statusLabel: 'Waiting for review',
+      updatedAtDisplay: '5 minutes ago',
+    })
+    expect(JSON.stringify(payload)).not.toContain('2026-06-06T')
+    expect(JSON.stringify(payload)).not.toMatch(
+      /(approval|artifact|provider|receipt|server_authority|source|wallet)\.private/,
+    )
+  })
+
+  test('rejects invalid audiences with a safe 400', async () => {
+    const response = await Effect.runPromise(
+      handleMobileWorkroomApprovalProjectionApi(request('?audience=owner'), {
+        enabled: true,
+        nowIso: () => nowIso,
+        store: exampleStore(),
+      }),
+    )
+    expect(response.status).toBe(400)
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(JSON.stringify(payload)).toContain('audience')
+  })
+
+  test('rejects unsafe projected records with 422 and no raw ref leak', async () => {
+    const response = await Effect.runPromise(
+      handleMobileWorkroomApprovalProjectionApi(request('?audience=operator'), {
+        enabled: true,
+        nowIso: () => nowIso,
+        store: makeInMemoryMobileWorkroomApprovalProjectionStore(
+          [exampleOmniMobileWorkroom()],
+          [
+            exampleOmniMobileApprovalCard({
+              receiptRefs: ['receipt.public.payment_hash_abcd'],
+            }),
+          ],
+        ),
+      }),
+    )
+    expect(response.status).toBe(422)
+    const payload = (await response.json()) as Record<string, unknown>
+    expect(payload.error).toBe('mobile_workroom_approval_projection_unsafe')
+    expect(typeof payload.reason).toBe('string')
+    expect(JSON.stringify(payload)).not.toContain('payment_hash_abcd')
+  })
+})

--- a/apps/openagents.com/workers/api/src/mobile-workroom-approval-projection-routes.ts
+++ b/apps/openagents.com/workers/api/src/mobile-workroom-approval-projection-routes.ts
@@ -1,0 +1,200 @@
+// Mobile workroom approval projection endpoint
+// (promise mobile.voice_approval_companion.v1, planned).
+//
+// INERT by default. The route is wired into the live Worker but reads from an
+// injected store that the Worker leaves EMPTY unless the surface flag is
+// explicitly armed (MOBILE_WORKROOM_APPROVAL_PROJECTION_ENABLED). When armed it
+// projects existing workroom + approval-card records through the read-only
+// mobile projection core. It never approves, executes, notifies, spends, mutates
+// providers, launches runners, or upgrades public claims.
+
+import { badRequest, jsonResponse } from '@openagentsinc/sync-worker'
+import { Effect } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import {
+  OMNI_MOBILE_WORKROOM_READ_ONLY_AUTHORITY,
+  type OmniMobileApprovalCardRecord,
+  type OmniMobileWorkroomAudience,
+  OmniMobileWorkroomApprovalUnsafe,
+  type OmniMobileWorkroomCompactRecord,
+  projectOmniMobileWorkroom,
+} from './omni-mobile-workroom-approval-cards'
+
+export const MobileWorkroomApprovalProjectionEndpoint =
+  '/api/mobile/workroom-approval-projection'
+
+export const MOBILE_WORKROOM_APPROVAL_PROJECTION_PROMISE_ID =
+  'mobile.voice_approval_companion.v1'
+
+export const MOBILE_WORKROOM_APPROVAL_PROJECTION_BLOCKERS = {
+  cleared: 'blocker.product_promises.mobile_projection_missing',
+  remaining: [
+    'blocker.product_promises.voice_command_approval_receipts_missing',
+    'blocker.product_promises.cross_device_workroom_sync_missing',
+  ],
+} as const
+
+export type MobileWorkroomApprovalProjectionStore = Readonly<{
+  listApprovalCards: () => ReadonlyArray<OmniMobileApprovalCardRecord>
+  listWorkrooms: () => ReadonlyArray<OmniMobileWorkroomCompactRecord>
+}>
+
+export const emptyMobileWorkroomApprovalProjectionStore:
+  MobileWorkroomApprovalProjectionStore = {
+    listApprovalCards: () => [],
+    listWorkrooms: () => [],
+  }
+
+export const makeInMemoryMobileWorkroomApprovalProjectionStore = (
+  workrooms: ReadonlyArray<OmniMobileWorkroomCompactRecord>,
+  approvalCards: ReadonlyArray<OmniMobileApprovalCardRecord>,
+): MobileWorkroomApprovalProjectionStore => ({
+  listApprovalCards: () => [...approvalCards],
+  listWorkrooms: () => [...workrooms],
+})
+
+export const isMobileWorkroomApprovalProjectionEnabled = (
+  value: string | undefined,
+): boolean => {
+  if (value === undefined) {
+    return false
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+export type MobileWorkroomApprovalProjectionDeps = Readonly<{
+  enabled: boolean
+  nowIso: () => string
+  store?: MobileWorkroomApprovalProjectionStore
+}>
+
+const mobileWorkroomAudienceValues: ReadonlyArray<OmniMobileWorkroomAudience> =
+  ['public', 'agent', 'customer', 'team', 'operator']
+
+const isMobileWorkroomAudience = (
+  value: string,
+): value is OmniMobileWorkroomAudience =>
+  mobileWorkroomAudienceValues.includes(
+    value as OmniMobileWorkroomAudience,
+  )
+
+const audienceFromRequest = (
+  request: Request,
+): OmniMobileWorkroomAudience | null => {
+  const audience = new URL(request.url).searchParams.get('audience')
+
+  if (audience === null) {
+    return 'public'
+  }
+
+  return isMobileWorkroomAudience(audience) ? audience : null
+}
+
+const resolveStore = (
+  deps: MobileWorkroomApprovalProjectionDeps,
+): MobileWorkroomApprovalProjectionStore =>
+  deps.enabled && deps.store !== undefined
+    ? deps.store
+    : emptyMobileWorkroomApprovalProjectionStore
+
+const projectionPayload = (
+  deps: MobileWorkroomApprovalProjectionDeps,
+  audience: OmniMobileWorkroomAudience,
+): Record<string, unknown> => {
+  const store = resolveStore(deps)
+  const nowIso = deps.nowIso()
+  const approvalCards = store.listApprovalCards()
+  const workrooms = store
+    .listWorkrooms()
+    .map(workroom =>
+      projectOmniMobileWorkroom(workroom, approvalCards, audience, nowIso),
+    )
+
+  return {
+    promiseId: MOBILE_WORKROOM_APPROVAL_PROJECTION_PROMISE_ID,
+    promiseState: 'planned' as const,
+    enabled: deps.enabled,
+    inert: !deps.enabled,
+    projectionAvailable: true as const,
+    audience,
+    authority: OMNI_MOBILE_WORKROOM_READ_ONLY_AUTHORITY,
+    approvalMutationAllowed: false as const,
+    executionMutationAllowed: false as const,
+    notificationMutationAllowed: false as const,
+    paymentMutationAllowed: false as const,
+    providerMutationAllowed: false as const,
+    publicClaimUpgradeAllowed: false as const,
+    runnerLaunchAllowed: false as const,
+    blockerCleared: MOBILE_WORKROOM_APPROVAL_PROJECTION_BLOCKERS.cleared,
+    remainingBlockers: MOBILE_WORKROOM_APPROVAL_PROJECTION_BLOCKERS.remaining,
+    workroomCount: workrooms.length,
+    pendingApprovalCount: workrooms.reduce(
+      (count, workroom) => count + workroom.pendingApprovalCount,
+      0,
+    ),
+    blockedApprovalCount: workrooms.reduce(
+      (count, workroom) => count + workroom.blockedApprovalCount,
+      0,
+    ),
+    criticalApprovalCount: workrooms.reduce(
+      (count, workroom) => count + workroom.criticalApprovalCount,
+      0,
+    ),
+    expiredApprovalCount: workrooms.reduce(
+      (count, workroom) => count + workroom.expiredApprovalCount,
+      0,
+    ),
+    workrooms,
+    note:
+      'Mobile workroom approval projection is read-only. It clears the ' +
+      'mobile projection blocker only; voice-command approval receipts and ' +
+      'cross-device workroom sync remain open, so the promise stays planned.',
+  }
+}
+
+/**
+ * GET the mobile workroom approval projection. Read-only, no-store JSON.
+ */
+export const handleMobileWorkroomApprovalProjectionApi = (
+  request: Request,
+  deps: MobileWorkroomApprovalProjectionDeps,
+) => {
+  if (request.method !== 'GET') {
+    return Effect.succeed(methodNotAllowed(['GET']))
+  }
+
+  const audience = audienceFromRequest(request)
+  if (audience === null) {
+    return Effect.succeed(
+      badRequest(
+        'Invalid mobile workroom projection request: audience must be one of ' +
+          mobileWorkroomAudienceValues.join(', ') +
+          '.',
+      ),
+    )
+  }
+
+  try {
+    return Effect.succeed(noStoreJsonResponse(projectionPayload(deps, audience)))
+  } catch (error) {
+    if (error instanceof OmniMobileWorkroomApprovalUnsafe) {
+      return Effect.succeed(
+        jsonResponse(
+          {
+            error: 'mobile_workroom_approval_projection_unsafe',
+            reason: error.reason,
+          },
+          { status: 422 },
+        ),
+      )
+    }
+
+    return Effect.succeed(
+      jsonResponse(
+        { error: 'mobile_workroom_approval_projection_failed' },
+        { status: 500 },
+      ),
+    )
+  }
+}

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -170,6 +170,13 @@ describe('public product promises document', () => {
         expect.objectContaining({
           promiseId: 'mobile.voice_approval_companion.v1',
           state: 'planned',
+          evidenceRefs: expect.arrayContaining([
+            'apps/openagents.com/workers/api/src/mobile-workroom-approval-projection-routes.ts',
+            'route:/api/mobile/workroom-approval-projection',
+          ]),
+          blockerRefs: expect.not.arrayContaining([
+            'blocker.product_promises.mobile_projection_missing',
+          ]),
         }),
         expect.objectContaining({
           promiseId: 'pylon.no_dark_capacity_accounting.v1',

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1446,20 +1446,24 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Voice and mobile should let users inspect workrooms, review pending approvals, issue bounded commands, and see the same approval receipts without bypassing server-side policy.',
         safeCopy:
-          'Voice/mobile approval is planned. Any current voice or mobile language must say approvals remain server-side and receipt-backed.',
+          'Voice/mobile approval is planned. A read-only mobile workroom approval projection is wired at GET /api/mobile/workroom-approval-projection and defaults inert; any current voice or mobile language must say approvals remain server-side and receipt-backed.',
         unsafeCopy:
           'Do not claim a voice transcript or mobile tap can directly mutate CRM, send email, create PRs, spend money, launch paid runners, or publish claims.',
         evidenceRefs: [
           'docs/promises/2026-06-09-product-promises-green-roadmap.md',
           'apps/openagents.com/workers/api/src/omni-voice-session-evidence.ts',
+          'apps/openagents.com/workers/api/src/omni-mobile-workroom-approval-cards.ts',
+          'apps/openagents.com/workers/api/src/omni-mobile-workroom-approval-cards.test.ts',
+          'apps/openagents.com/workers/api/src/mobile-workroom-approval-projection-routes.ts',
+          'apps/openagents.com/workers/api/src/mobile-workroom-approval-projection-routes.test.ts',
+          'route:/api/mobile/workroom-approval-projection',
         ],
         blockerRefs: [
-          'blocker.product_promises.mobile_projection_missing',
           'blocker.product_promises.voice_command_approval_receipts_missing',
           'blocker.product_promises.cross_device_workroom_sync_missing',
         ],
         verification:
-          'Green requires a voice command or mobile approval flow that records transcript/source refs, proposed action, approval decision, and matching workroom receipt.',
+          'Green requires a voice command or mobile approval flow that records transcript/source refs, proposed action, approval decision, cross-device workroom sync, and matching workroom receipt.',
         authorityBoundary:
           'Voice transcripts are evidence of user intent, not final mutation, spend, deploy, or publication authority.',
       },

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -21,6 +21,7 @@ const approvedExactRoutePaths = [
   '/api/public/marketplace/composed-products',
   '/api/public/markets/signature-monetization/metering',
   '/api/public/pylon/multi-earning-node',
+  '/api/mobile/workroom-approval-projection',
   '/api/mobile/voice-sessions/ingest',
   '/api/public/autopilot/composed-runs',
   '/api/public/autopilot/labor-products',


### PR DESCRIPTION
## Summary
- Add GET /api/mobile/workroom-approval-projection behind MOBILE_WORKROOM_APPROVAL_PROJECTION_ENABLED, defaulting to an inert empty store and projecting through the existing read-only mobile approval-card core when armed.
- Update the mobile.voice_approval_companion.v1 promise evidence to clear only blocker.product_promises.mobile_projection_missing while keeping approval-receipt and cross-device-sync blockers open.
- Make desktop Moksha asset copy and deploy verification work with the root-hoisted three-effect install and Linux/macOS/Windows package layouts, preserving check:deploy in a fresh worktree.

## Verification
- bun run test -- src/mobile-workroom-approval-projection-routes.test.ts src/omni-mobile-workroom-approval-cards.test.ts src/product-promises.test.ts src/worker-exact-routes.test.ts
- bun test tests/electrobun-config.test.ts
- bun run check:deploy

Note: standalone workers/api typecheck still reports existing Effect diagnostics in cloud/inference files not touched by this PR; check:deploy is green.