### PR TITLE
Add public partner payout projection

### DIFF
--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -662,6 +662,11 @@ const publicProjectionSurfaces = [
     route: '/api/public/site-referral-payouts',
     status: 'staleness_declared',
   },
+  {
+    module: 'workers/api/src/partner-payout-public-projection.ts',
+    route: '/api/public/partner-payouts',
+    status: 'staleness_declared',
+  },
   // Static contract documents, not state projections.
   {
     module: 'workers/api/src/index.ts',

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -415,6 +415,7 @@ import {
   readSelectedInferenceCreditTargetUser as readSelectedInferenceCreditTargetUserBase,
 } from './operator-targets'
 import { makePartnerPayoutLedgerRoutes } from './partner-payout-ledger-routes'
+import { handlePartnerPayoutsPublicApi } from './partner-payout-public-routes'
 import { makePrefilledWorkspaceService } from './prefilled-workspace'
 import { makePrefilledWorkspaceRoutes } from './prefilled-workspace-routes'
 import {
@@ -8433,6 +8434,10 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     path: '/api/public/site-referral-payouts',
     handler: (request, env) =>
       handleSiteReferralPayoutsPublicApi(request, env),
+  },
+  {
+    path: '/api/public/partner-payouts',
+    handler: (request, env) => handlePartnerPayoutsPublicApi(request, env),
   },
   {
     path: '/api/public/relay-health',

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1774,6 +1774,152 @@ const schemaComponents = (): JsonSchema => ({
       totalCurrentPayouts: { type: 'integer', minimum: 0 },
     },
   },
+  PartnerPayoutsPublicProjection: {
+    type: 'object',
+    additionalProperties: false,
+    description:
+      'Public count-only partner payout ledger projection with generatedAt and a live_at_read staleness contract whose maxStalenessSeconds is 0. It exposes per-state, per-role, and per-asset aggregate counts/amounts only; no partner refs, user ids, payout refs, payout destinations, qualifying event refs, invoices, preimages, provider payloads, or wallet material are projected.',
+    required: [
+      'assetTotals',
+      'authorityBoundary',
+      'blockerRefs',
+      'caveatRefs',
+      'generatedAt',
+      'kind',
+      'ledgerWiredInSource',
+      'operatorRoutesWiredInSource',
+      'partnerProjectionApiWiredInSource',
+      'policy',
+      'publicSafe',
+      'roleTotals',
+      'schemaVersion',
+      'settledCount',
+      'settledSats',
+      'staleness',
+      'stateTotals',
+      'totalCurrentPayouts',
+    ],
+    properties: {
+      assetTotals: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['asset', 'count', 'settledAmount', 'totalAmount'],
+          properties: {
+            asset: { type: 'string', enum: ['usd', 'credits', 'sats'] },
+            count: { type: 'integer', minimum: 0 },
+            settledAmount: { type: 'integer' },
+            totalAmount: { type: 'integer' },
+          },
+        },
+      },
+      authorityBoundary: { type: 'string' },
+      blockerRefs: { type: 'array', items: { type: 'string' } },
+      caveatRefs: { type: 'array', items: { type: 'string' } },
+      generatedAt: { type: 'string', format: 'date-time' },
+      kind: { type: 'string', enum: ['partner_payouts_public'] },
+      ledgerWiredInSource: { type: 'boolean' },
+      operatorRoutesWiredInSource: { type: 'boolean' },
+      partnerProjectionApiWiredInSource: { type: 'boolean' },
+      policy: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['policyRef', 'rolePolicies'],
+        properties: {
+          policyRef: { type: 'string' },
+          rolePolicies: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: [
+                'maxEventAmount',
+                'maxPartnerPeriodAmount',
+                'maxPartnerPeriodCount',
+                'partnerRole',
+                'percentBps',
+              ],
+              properties: {
+                maxEventAmount: { type: 'integer', minimum: 0 },
+                maxPartnerPeriodAmount: { type: 'integer', minimum: 0 },
+                maxPartnerPeriodCount: { type: 'integer', minimum: 0 },
+                partnerRole: {
+                  type: 'string',
+                  enum: ['design_partner', 'referral', 'affiliate'],
+                },
+                percentBps: { type: 'integer', minimum: 0 },
+              },
+            },
+          },
+        },
+      },
+      publicSafe: { type: 'boolean' },
+      roleTotals: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['count', 'partnerRole', 'totalAmount'],
+          properties: {
+            count: { type: 'integer', minimum: 0 },
+            partnerRole: {
+              type: 'string',
+              enum: ['design_partner', 'referral', 'affiliate'],
+            },
+            totalAmount: { type: 'integer' },
+          },
+        },
+      },
+      schemaVersion: { type: 'string' },
+      settledCount: { type: 'integer', minimum: 0 },
+      settledSats: { type: 'integer' },
+      staleness: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'composition',
+          'contractVersion',
+          'maxStalenessSeconds',
+          'rebuildsOn',
+        ],
+        properties: {
+          composition: { type: 'string', enum: ['live_at_read'] },
+          contractVersion: {
+            type: 'string',
+            enum: ['projection_staleness.v1'],
+          },
+          maxStalenessSeconds: { type: 'integer', enum: [0] },
+          rebuildsOn: { type: 'array', items: { type: 'string' } },
+        },
+      },
+      stateTotals: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['count', 'state', 'totalAmount'],
+          properties: {
+            count: { type: 'integer', minimum: 0 },
+            state: {
+              type: 'string',
+              enum: [
+                'eligible',
+                'approved',
+                'dispatched',
+                'settled',
+                'failed',
+                'refused',
+                'reversed',
+              ],
+            },
+            totalAmount: { type: 'integer' },
+          },
+        },
+      },
+      totalCurrentPayouts: { type: 'integer', minimum: 0 },
+    },
+  },
   SiteReferralPayoutTransitionRequest: objectSummary(
     'Operator-only append-only Site referral payout ledger transition request.',
   ),
@@ -8448,6 +8594,23 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Public count-only Site referral payout ledger projection.',
           '#/components/schemas/SiteReferralPayoutsPublicProjection',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/public/partner-payouts': {
+    get: operation({
+      operationId: 'getPublicPartnerPayouts',
+      summary: 'Get public partner payout projection',
+      description:
+        'Read-only public-safe count projection of the partner payout ledger. The response aggregates current payout states, roles, assets, and settled sats without exposing partner refs, user ids, payout refs, payout destinations, qualifying event refs, invoices, preimages, provider payloads, or wallet material. It grants no partner attribution, payout, settlement, withdrawal, revenue, or spend authority.',
+      tags: ['Sites'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Public count-only partner payout ledger projection.',
+          '#/components/schemas/PartnerPayoutsPublicProjection',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts
@@ -1,0 +1,175 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  PARTNER_PAYOUT_POLICY_REF,
+  PARTNER_PAYOUT_ROLE_POLICY,
+} from './partner-payout-ledger'
+import {
+  PARTNER_PAYOUT_PUBLIC_PROJECTION_SCHEMA_VERSION,
+  aggregatePartnerPayoutPublicProjection,
+} from './partner-payout-public-projection'
+import { handlePartnerPayoutsPublicApi } from './partner-payout-public-routes'
+import { PUBLIC_PROJECTION_STALENESS_CONTRACT_VERSION } from './public-projection-staleness'
+
+const NOW_ISO = '2026-06-20T06:20:00.000Z'
+
+describe('aggregatePartnerPayoutPublicProjection', () => {
+  test('empty ledger is an honest zero-settled public projection', () => {
+    const projection = aggregatePartnerPayoutPublicProjection([])
+
+    expect(projection.kind).toBe('partner_payouts_public')
+    expect(projection.publicSafe).toBe(true)
+    expect(projection.ledgerWiredInSource).toBe(true)
+    expect(projection.operatorRoutesWiredInSource).toBe(true)
+    expect(projection.partnerProjectionApiWiredInSource).toBe(true)
+    expect(projection.totalCurrentPayouts).toBe(0)
+    expect(projection.settledCount).toBe(0)
+    expect(projection.settledSats).toBe(0)
+    expect(projection.schemaVersion).toBe(
+      PARTNER_PAYOUT_PUBLIC_PROJECTION_SCHEMA_VERSION,
+    )
+    expect(projection.staleness.composition).toBe('live_at_read')
+    expect(projection.staleness.maxStalenessSeconds).toBe(0)
+    expect(projection.staleness.contractVersion).toBe(
+      PUBLIC_PROJECTION_STALENESS_CONTRACT_VERSION,
+    )
+    expect(projection.policy.policyRef).toBe(PARTNER_PAYOUT_POLICY_REF)
+    expect(
+      projection.policy.rolePolicies.find(
+        role => role.partnerRole === 'referral',
+      )?.percentBps,
+    ).toBe(PARTNER_PAYOUT_ROLE_POLICY.referral.percentBps)
+    expect(projection.blockerRefs).toEqual([
+      'blocker.product_promises.partner_attribution_policy_missing',
+      'blocker.product_promises.partner_payout_settlement_not_wired',
+      'blocker.product_promises.partner_first_real_payout_pending',
+    ])
+    expect(
+      projection.blockerRefs.includes(
+        'blocker.product_promises.partner_projection_api_missing',
+      ),
+    ).toBe(false)
+  })
+
+  test('counts current states by state, role, and asset', () => {
+    const projection = aggregatePartnerPayoutPublicProjection([
+      {
+        amount: 10,
+        asset: 'sats',
+        partnerRole: 'referral',
+        state: 'eligible',
+      },
+      {
+        amount: 20,
+        asset: 'sats',
+        partnerRole: 'referral',
+        state: 'settled',
+      },
+      {
+        amount: 150,
+        asset: 'usd',
+        partnerRole: 'design_partner',
+        state: 'approved',
+      },
+      {
+        amount: -5,
+        asset: 'credits',
+        partnerRole: 'affiliate',
+        state: 'reversed',
+      },
+    ])
+
+    expect(projection.totalCurrentPayouts).toBe(4)
+    expect(
+      projection.stateTotals.find(total => total.state === 'settled'),
+    ).toEqual({ count: 1, state: 'settled', totalAmount: 20 })
+    expect(
+      projection.roleTotals.find(total => total.partnerRole === 'referral'),
+    ).toEqual({ count: 2, partnerRole: 'referral', totalAmount: 30 })
+    expect(
+      projection.assetTotals.find(total => total.asset === 'sats'),
+    ).toEqual({
+      asset: 'sats',
+      count: 2,
+      settledAmount: 20,
+      totalAmount: 30,
+    })
+    expect(projection.settledCount).toBe(1)
+    expect(projection.settledSats).toBe(20)
+  })
+
+  test('no per-row identifiers or payment material appear in the payload', () => {
+    const projection = aggregatePartnerPayoutPublicProjection([
+      {
+        amount: 50,
+        asset: 'sats',
+        partnerRole: 'affiliate',
+        state: 'eligible',
+      },
+    ])
+    const serialized = JSON.stringify(projection).toLowerCase()
+
+    for (const bannedFieldKey of [
+      '"partnerref"',
+      '"partneruserid"',
+      '"beneficiaryuserid"',
+      '"payoutref"',
+      '"qualifyingeventref"',
+      '"idempotencykey"',
+      '"evidencerefs"',
+      '"currententryid"',
+    ]) {
+      expect(serialized).not.toContain(bannedFieldKey)
+    }
+
+    for (const bannedMaterial of ['lnbc', 'lntb', 'preimage', 'xprv']) {
+      expect(serialized).not.toContain(bannedMaterial)
+    }
+  })
+})
+
+describe('handlePartnerPayoutsPublicApi', () => {
+  test('GET returns the live-at-read projection with generatedAt', async () => {
+    const response = await Effect.runPromise(
+      handlePartnerPayoutsPublicApi(
+        new Request('https://openagents.com/api/public/partner-payouts'),
+        {
+          nowIso: () => NOW_ISO,
+          readCurrentStates: async () => [
+            {
+              amount: 25,
+              asset: 'sats',
+              partnerRole: 'referral',
+              state: 'eligible',
+            },
+          ],
+        },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    const body = (await response.json()) as Record<string, unknown>
+    expect(body.generatedAt).toBe(NOW_ISO)
+    expect(body.kind).toBe('partner_payouts_public')
+    expect(body.settledCount).toBe(0)
+    expect(body.totalCurrentPayouts).toBe(1)
+    expect((body.staleness as Record<string, unknown>).composition).toBe(
+      'live_at_read',
+    )
+  })
+
+  test('non-GET is rejected', async () => {
+    const response = await Effect.runPromise(
+      handlePartnerPayoutsPublicApi(
+        new Request('https://openagents.com/api/public/partner-payouts', {
+          method: 'POST',
+        }),
+        { nowIso: () => NOW_ISO, readCurrentStates: async () => [] },
+      ),
+    )
+
+    expect(response.status).toBe(405)
+  })
+})

--- a/apps/openagents.com/workers/api/src/partner-payout-public-projection.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-projection.ts
@@ -1,0 +1,251 @@
+import {
+  type PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import {
+  PARTNER_PAYOUT_POLICY_REF,
+  PARTNER_PAYOUT_ROLE_POLICY,
+  type PartnerPayoutAsset,
+  type PartnerPayoutRole,
+  type PartnerPayoutState,
+} from './partner-payout-ledger'
+
+/**
+ * Public partner-payout ledger projection.
+ *
+ * This is intentionally narrower than the operator ledger projection. It proves
+ * the partner payout ledger has a dereferenceable public-safe API without
+ * exposing partner refs, user ids, payout refs, qualifying event refs, payout
+ * destinations, invoices, preimages, or provider payloads.
+ */
+
+export const PARTNER_PAYOUT_PUBLIC_PROJECTION_SCHEMA_VERSION =
+  'openagents.partner_payouts.v1'
+
+export const PARTNER_PAYOUT_PUBLIC_PROJECTION_AUTHORITY_BOUNDARY =
+  'A public count of partner payout ledger state grants no partner attribution, ' +
+  'eligibility, payout, settlement, withdrawal, revenue, or spend authority. ' +
+  'Ledger state is not spendable value; settlement requires separate operator ' +
+  'dispatch authority and public-safe settlement evidence refs.'
+
+const PARTNER_PAYOUT_PUBLIC_CAVEAT_REFS = [
+  'caveat.public.partner_payouts.counts_only_no_partner_or_user_identifiers',
+  'caveat.public.partner_payouts.ledger_state_not_spendable_value',
+  'caveat.public.partner_payouts.settlement_evidence_required',
+  'caveat.public.partner_payouts.partner_policy_not_owner_signed',
+] as const
+
+const PARTNER_PAYOUT_PUBLIC_BLOCKER_REFS = [
+  'blocker.product_promises.partner_attribution_policy_missing',
+  'blocker.product_promises.partner_payout_settlement_not_wired',
+  'blocker.product_promises.partner_first_real_payout_pending',
+] as const
+
+const ALL_STATES: ReadonlyArray<PartnerPayoutState> = [
+  'eligible',
+  'approved',
+  'dispatched',
+  'settled',
+  'failed',
+  'refused',
+  'reversed',
+]
+
+const ALL_ROLES: ReadonlyArray<PartnerPayoutRole> = [
+  'design_partner',
+  'referral',
+  'affiliate',
+]
+
+const ALL_ASSETS: ReadonlyArray<PartnerPayoutAsset> = [
+  'usd',
+  'credits',
+  'sats',
+]
+
+export type PartnerPayoutPublicCurrentState = Readonly<{
+  amount: number
+  asset: PartnerPayoutAsset
+  partnerRole: PartnerPayoutRole
+  state: PartnerPayoutState
+}>
+
+export type PartnerPayoutPublicStateTotal = Readonly<{
+  count: number
+  state: PartnerPayoutState
+  totalAmount: number
+}>
+
+export type PartnerPayoutPublicRoleTotal = Readonly<{
+  count: number
+  partnerRole: PartnerPayoutRole
+  totalAmount: number
+}>
+
+export type PartnerPayoutPublicAssetTotal = Readonly<{
+  asset: PartnerPayoutAsset
+  count: number
+  settledAmount: number
+  totalAmount: number
+}>
+
+export type PartnerPayoutPublicProjection = Readonly<{
+  authorityBoundary: string
+  blockerRefs: ReadonlyArray<string>
+  caveatRefs: ReadonlyArray<string>
+  kind: 'partner_payouts_public'
+  ledgerWiredInSource: boolean
+  operatorRoutesWiredInSource: boolean
+  partnerProjectionApiWiredInSource: boolean
+  policy: Readonly<{
+    policyRef: string
+    rolePolicies: ReadonlyArray<
+      Readonly<{
+        maxEventAmount: number
+        maxPartnerPeriodAmount: number
+        maxPartnerPeriodCount: number
+        partnerRole: PartnerPayoutRole
+        percentBps: number
+      }>
+    >
+  }>
+  publicSafe: boolean
+  schemaVersion: string
+  assetTotals: ReadonlyArray<PartnerPayoutPublicAssetTotal>
+  roleTotals: ReadonlyArray<PartnerPayoutPublicRoleTotal>
+  settledCount: number
+  settledSats: number
+  stateTotals: ReadonlyArray<PartnerPayoutPublicStateTotal>
+  staleness: PublicProjectionStalenessContract
+  totalCurrentPayouts: number
+}>
+
+export type PartnerPayoutsPublicProjection = PartnerPayoutPublicProjection &
+  Readonly<{
+    generatedAt: string
+    staleness: PublicProjectionStalenessContract
+  }>
+
+export const partnerPayoutPublicStaleness =
+  (): PublicProjectionStalenessContract =>
+    liveAtReadStaleness([
+      'partner_payout_eligibility_recorded',
+      'partner_payout_state_transition_recorded',
+    ])
+
+const incrementTotals = <Key extends string>(
+  totals: Map<Key, Readonly<{ count: number; totalAmount: number }>>,
+  key: Key,
+  amount: number,
+) => {
+  const existing = totals.get(key) ?? { count: 0, totalAmount: 0 }
+  totals.set(key, {
+    count: existing.count + 1,
+    totalAmount: existing.totalAmount + amount,
+  })
+}
+
+export const aggregatePartnerPayoutPublicProjection = (
+  currentStates: ReadonlyArray<PartnerPayoutPublicCurrentState>,
+): PartnerPayoutPublicProjection => {
+  const byState = new Map<
+    PartnerPayoutState,
+    Readonly<{ count: number; totalAmount: number }>
+  >()
+  const byRole = new Map<
+    PartnerPayoutRole,
+    Readonly<{ count: number; totalAmount: number }>
+  >()
+  const byAsset = new Map<
+    PartnerPayoutAsset,
+    Readonly<{ count: number; settledAmount: number; totalAmount: number }>
+  >()
+
+  for (const state of ALL_STATES) {
+    byState.set(state, { count: 0, totalAmount: 0 })
+  }
+
+  for (const role of ALL_ROLES) {
+    byRole.set(role, { count: 0, totalAmount: 0 })
+  }
+
+  for (const asset of ALL_ASSETS) {
+    byAsset.set(asset, { count: 0, settledAmount: 0, totalAmount: 0 })
+  }
+
+  for (const current of currentStates) {
+    incrementTotals(byState, current.state, current.amount)
+    incrementTotals(byRole, current.partnerRole, current.amount)
+
+    const existing = byAsset.get(current.asset) ?? {
+      count: 0,
+      settledAmount: 0,
+      totalAmount: 0,
+    }
+    byAsset.set(current.asset, {
+      count: existing.count + 1,
+      settledAmount:
+        existing.settledAmount +
+        (current.state === 'settled' ? current.amount : 0),
+      totalAmount: existing.totalAmount + current.amount,
+    })
+  }
+
+  const stateTotals = ALL_STATES.map(state => {
+    const totals = byState.get(state) ?? { count: 0, totalAmount: 0 }
+
+    return { count: totals.count, state, totalAmount: totals.totalAmount }
+  })
+  const roleTotals = ALL_ROLES.map(partnerRole => {
+    const totals = byRole.get(partnerRole) ?? { count: 0, totalAmount: 0 }
+
+    return {
+      count: totals.count,
+      partnerRole,
+      totalAmount: totals.totalAmount,
+    }
+  })
+  const assetTotals = ALL_ASSETS.map(asset => {
+    const totals = byAsset.get(asset) ?? {
+      count: 0,
+      settledAmount: 0,
+      totalAmount: 0,
+    }
+
+    return {
+      asset,
+      count: totals.count,
+      settledAmount: totals.settledAmount,
+      totalAmount: totals.totalAmount,
+    }
+  })
+  const settled = byState.get('settled') ?? { count: 0, totalAmount: 0 }
+  const settledSats =
+    assetTotals.find(total => total.asset === 'sats')?.settledAmount ?? 0
+
+  return {
+    assetTotals,
+    authorityBoundary: PARTNER_PAYOUT_PUBLIC_PROJECTION_AUTHORITY_BOUNDARY,
+    blockerRefs: PARTNER_PAYOUT_PUBLIC_BLOCKER_REFS,
+    caveatRefs: PARTNER_PAYOUT_PUBLIC_CAVEAT_REFS,
+    kind: 'partner_payouts_public',
+    ledgerWiredInSource: true,
+    operatorRoutesWiredInSource: true,
+    partnerProjectionApiWiredInSource: true,
+    policy: {
+      policyRef: PARTNER_PAYOUT_POLICY_REF,
+      rolePolicies: ALL_ROLES.map(partnerRole => ({
+        partnerRole,
+        ...PARTNER_PAYOUT_ROLE_POLICY[partnerRole],
+      })),
+    },
+    publicSafe: true,
+    roleTotals,
+    schemaVersion: PARTNER_PAYOUT_PUBLIC_PROJECTION_SCHEMA_VERSION,
+    settledCount: settled.count,
+    settledSats,
+    stateTotals,
+    staleness: partnerPayoutPublicStaleness(),
+    totalCurrentPayouts: currentStates.length,
+  }
+}

--- a/apps/openagents.com/workers/api/src/partner-payout-public-routes.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-routes.ts
@@ -1,0 +1,105 @@
+import { Effect } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import {
+  type PartnerPayoutAsset,
+  type PartnerPayoutRole,
+  type PartnerPayoutState,
+} from './partner-payout-ledger'
+import {
+  type PartnerPayoutPublicCurrentState,
+  type PartnerPayoutsPublicProjection,
+  aggregatePartnerPayoutPublicProjection,
+} from './partner-payout-public-projection'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+/**
+ * Public partner-payout projection route:
+ *
+ *   GET /api/public/partner-payouts
+ *
+ * Read-only, public-safe count projection over the partner payout ledger. It
+ * selects only aggregate-safe fields from the current ledger entries and never
+ * exposes partner refs, user ids, payout refs, qualifying event refs, payout
+ * destinations, invoices, preimages, or provider payloads.
+ */
+
+type PartnerPayoutPublicRouteInput = Readonly<{
+  OPENAGENTS_DB?: D1Database
+  nowIso?: () => string
+  readCurrentStates?: () => Promise<
+    ReadonlyArray<PartnerPayoutPublicCurrentState>
+  >
+}>
+
+type CurrentStateRow = Readonly<{
+  amount: number
+  asset: PartnerPayoutAsset
+  partner_role: PartnerPayoutRole
+  state: PartnerPayoutState
+}>
+
+const readCurrentPartnerPayoutStates = async (
+  db: D1Database,
+): Promise<ReadonlyArray<PartnerPayoutPublicCurrentState>> => {
+  const result = await db
+    .prepare(
+      `SELECT e.state AS state,
+              e.amount AS amount,
+              e.asset AS asset,
+              e.partner_role AS partner_role
+         FROM partner_payout_ledger_entries AS e
+        WHERE e.archived_at IS NULL
+          AND e.id = (
+            SELECT inner_e.id
+              FROM partner_payout_ledger_entries AS inner_e
+             WHERE inner_e.payout_ref = e.payout_ref
+               AND inner_e.archived_at IS NULL
+             ORDER BY inner_e.created_at DESC, inner_e.id DESC
+             LIMIT 1
+          )`,
+    )
+    .all<CurrentStateRow>()
+
+  return (result.results ?? []).map(row => ({
+    amount: Number(row.amount),
+    asset: row.asset,
+    partnerRole: row.partner_role,
+    state: row.state,
+  }))
+}
+
+const safeReadCurrentPartnerPayoutStates = async (
+  db: D1Database,
+): Promise<ReadonlyArray<PartnerPayoutPublicCurrentState>> => {
+  try {
+    return await readCurrentPartnerPayoutStates(db)
+  } catch {
+    return []
+  }
+}
+
+export const handlePartnerPayoutsPublicApi = (
+  request: Request,
+  input: PartnerPayoutPublicRouteInput,
+) => {
+  if (request.method !== 'GET') {
+    return Effect.succeed(methodNotAllowed(['GET']))
+  }
+
+  const nowIso = input.nowIso?.() ?? currentIsoTimestamp()
+  const readCurrentStates =
+    input.readCurrentStates ??
+    (() => safeReadCurrentPartnerPayoutStates(input.OPENAGENTS_DB as D1Database))
+
+  return Effect.promise(async () => {
+    const currentStates = await readCurrentStates()
+    const projection = aggregatePartnerPayoutPublicProjection(currentStates)
+    const body: PartnerPayoutsPublicProjection = {
+      ...projection,
+      generatedAt: nowIso,
+    }
+
+    return noStoreJsonResponse(body)
+  })
+}

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.5')
+    expect(decoded.version).toBe('2026-06-20.6')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -139,8 +139,9 @@ describe('public product promises document', () => {
     // pylon.v03_release_candidate.v1 + pylon.release_tomorrow.v1 green (Pylon
     // v1.0.5 signed release shipped + verified, owner-authorized), so green is
     // now exactly 24. The 2026-06-20.4 Pylon green-quality pass and
-    // 2026-06-20.5 signature-metering de-stale pass flip no promise state, so
-    // green remains exactly 24.
+    // 2026-06-20.5 signature-metering de-stale pass and 2026-06-20.6
+    // partner-payout projection de-stale pass flip no promise state, so green
+    // remains exactly 24.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -696,16 +697,49 @@ describe('public product promises document', () => {
     )
   })
 
+  test('partner payout ledger records projection evidence while keeping settlement blocked', () => {
+    const document = publicProductPromisesDocument()
+    const partnerPromise = document.promises.find(
+      promise => promise.promiseId === 'autopilot_sites.partner_payout_ledger.v1',
+    )
+
+    expect(partnerPromise).toMatchObject({
+      state: 'red',
+      blockerRefs: [
+        'blocker.product_promises.partner_attribution_policy_missing',
+        'blocker.product_promises.partner_payout_settlement_not_wired',
+        'blocker.product_promises.partner_first_real_payout_pending',
+      ],
+      evidenceRefs: expect.arrayContaining([
+        'apps/openagents.com/workers/api/src/partner-payout-public-projection.ts',
+        'apps/openagents.com/workers/api/src/partner-payout-public-routes.ts',
+        'route:/api/public/partner-payouts',
+      ]),
+    })
+    expect(partnerPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.partner_projection_api_missing',
+    )
+    expect(partnerPromise?.safeCopy).toContain(
+      'public-safe count-only partner-payout projection API',
+    )
+    expect(partnerPromise?.verification).toContain(
+      'clears the projection API blocker only',
+    )
+    expect(partnerPromise?.authorityBoundary).toContain(
+      'public aggregate projections are not spendable value',
+    )
+  })
+
   test('blocks announcement copy until the live endpoint serves the announced version', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.5', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.6', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.5',
+      expectedVersion: '2026-06-20.6',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.5',
+      servedVersion: '2026-06-20.6',
       status: 'ready',
     })
     expect(
@@ -715,7 +749,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.5',
+      servedVersion: '2026-06-20.6',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.5'
+export const PublicProductPromisesVersion = '2026-06-20.6'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -2522,7 +2522,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Autopilot Sites/Agency partners can earn Bitcoin payouts when their referred customers become paying OpenAgents customers.',
         safeCopy:
-          'An operator-gated partner-payout ledger and state-transition routes shipped in wave-3 (#4986): operators can move a payout through approve/dispatch/settle/reverse states. The adjacent Sites referral payout rail was wired in source on RL-1 (#5458) — a paid-event eligibility feed (referral attribution -> referring user) plus a readiness-gated, idempotent approved -> dispatched -> settled dispatch that invokes the MDK/Spark payout adapter before recording settled and refuses non-Bitcoin (Stripe credit) revenue — so the attribution->settlement mechanism now has a tested reference implementation (sites.referral_bitcoin_stream.v1). Remaining work is part product decision, part code: owner sign-off on payout percentage and caps, a partner-attribution policy distinct from the referral feed, settlement dispatch wiring to a public partner receipt, a real settled partner payout, and a partner-facing projection or API.',
+          'An operator-gated partner-payout ledger, state-transition routes, and a public-safe count-only partner-payout projection API shipped in wave-3/#5524 follow-up work: operators can move a payout through approve/dispatch/settle/reverse states, and GET /api/public/partner-payouts exposes aggregate current states, roles, assets, policy shape, and settled sats without partner refs, user ids, payout refs, qualifying event refs, payout destinations, invoices, preimages, or provider payloads. The adjacent Sites referral payout rail was wired in source on RL-1 (#5458) as a tested attribution->settlement reference implementation. Remaining work is part product decision, part code: owner sign-off on payout percentage and caps, a partner-attribution policy distinct from the referral feed, settlement dispatch wiring to a public partner receipt, and a real settled partner payout.',
         unsafeCopy:
           'Do not claim partners are earning, can withdraw payouts, or have an earnings dashboard, and do not describe this as a live partner revenue stream; the ledger exists, the referral payout dispatch rail is wired and tested but has never settled a real payout, and partner payout percentage/caps and a partner attribution policy are still unsigned/undecided.',
         evidenceRefs: [
@@ -2534,21 +2534,25 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/site-referral-payout-public-routes.ts',
           'route:/api/public/site-referral-payouts',
           'https://openagents.com/api/public/site-referral-payouts',
+          'apps/openagents.com/workers/api/src/partner-payout-public-projection.ts',
+          'apps/openagents.com/workers/api/src/partner-payout-public-routes.ts',
+          'apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts',
+          'route:/api/public/partner-payouts',
           'docs/autopilot-coder/2026-06-13-cloud-remote-execution-commercial-plan.md',
           'https://github.com/OpenAgentsInc/openagents/issues/4986',
           'https://github.com/OpenAgentsInc/openagents/issues/5458',
+          'https://github.com/OpenAgentsInc/openagents/issues/5524',
           'promise:sites.referral_bitcoin_stream.v1',
         ],
         blockerRefs: [
           'blocker.product_promises.partner_attribution_policy_missing',
           'blocker.product_promises.partner_payout_settlement_not_wired',
           'blocker.product_promises.partner_first_real_payout_pending',
-          'blocker.product_promises.partner_projection_api_missing',
         ],
         verification:
-          'Operator routes and the ledger module pass type/unit tests, and the referral payout feed + readiness-gated dispatch pass site-referral-payout-wire.test.ts against a mock adapter (RL-1 #5458). Green requires a partner-specific attribution policy (referral->customer mapping), payout-ledger linkage to a real dereferenceable public settlement receipt for an actually settled partner payout, and a partner-accessible earnings projection.',
+          'Operator routes and the ledger module pass type/unit tests, the referral payout feed + readiness-gated dispatch pass site-referral-payout-wire.test.ts against a mock adapter (RL-1 #5458), and the partner payout public projection route passes count-only/no-leak tests. This clears the projection API blocker only. Green still requires a partner-specific attribution policy (referral->customer mapping), payout-ledger linkage to a real dereferenceable public settlement receipt for an actually settled partner payout, and owner sign-off.',
         authorityBoundary:
-          'Ledger state is not spendable value; settlement requires separate dispatch authority and public-safe settlement evidence.',
+          'Ledger state and public aggregate projections are not spendable value; settlement requires separate dispatch authority and public-safe settlement evidence.',
       },
       {
         ...basePromiseFields,
@@ -3442,6 +3446,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.3: Pylon v1.0.5 signed-binary release shipped + verified — pylon.v03_release_candidate.v1 + pylon.release_tomorrow.v1 yellow -> green (owner-authorized 2026-06-20). Signed binaries (macOS+Linux, 4 targets) signed with pinned ed25519 kid 2dbe811d19f67528, published to updates.openagents.com (Cloud Run oa-updates-00041-b7b, rollout 100, full rc history preserved); live feed verified serving v1.0.5 with sha256+ed25519 against apps/oa-updates/keys/release-pubkey.json (fail-closed, tamper rejected); live network smoke registered+heartbeated online in /api/pylons as pylon.33afd48282a649047e3a (openagents.pylon@1.0.5). Both blockers cleared. Green 22 -> 24. Honest bound: macOS+Linux only (Windows out of scope); network-scale earning separate. Flip applied in source ahead of the operator-route transition receipt.',
         'Registry 2026-06-20.4: green-quality fix on pylon.release_tomorrow.v1 (conceding Orrery audit, forum topic 415e16a7) — its green previously rested on the sibling pylon.v03_release_candidate.v1 evidence array; it now carries its OWN dereferenceable refs (the signed darwin-arm64 feed https://updates.openagents.com/pylon/rc/darwin-arm64/feed.json and the live registration route:/api/pylons#pylon.33afd48282a649047e3a). No state change (stays green), green count unchanged at 24. The transitions-feed backfill for the four post-2026-06-17.5 flips remains the owner-gated item (prod admin token).',
         'Registry 2026-06-20.5 is a marketplace.signature_monetization.v1 de-stale pass and flips NO promise state. The already-deployed inert usage-metering model and public read-only projection (GET /api/public/markets/signature-monetization/metering) prove validation+metering can reach the metered rung while the promise remains red/inert and settlement stays blocked. This clears blocker.product_promises.signature_usage_metering_missing only; blocker.product_promises.signature_settlement_missing remains. No billing, pricing, rev-share, payout, settlement, or revenue claim is created.',
+        'Registry 2026-06-20.6 is an autopilot_sites.partner_payout_ledger.v1 projection de-stale pass and flips NO promise state. The public-safe count-only partner payout projection (GET /api/public/partner-payouts) exposes aggregate current states, roles, assets, policy shape, and settled sats while withholding partner refs, user ids, payout refs, qualifying event refs, payout destinations, invoices, preimages, and provider payloads. This clears blocker.product_promises.partner_projection_api_missing only; partner attribution policy, settlement wiring, and first real payout remain blocked. No partner earning, withdrawal, revenue, payout, settlement, or green claim is created.',
       'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -59,6 +59,7 @@ const approvedExactRoutePaths = [
   '/api/public/pylon-capacity-funnel',
   '/api/public/pylon-capacity-funnel/history',
   '/api/public/site-referral-payouts',
+  '/api/public/partner-payouts',
   '/api/public/relay-health',
   '/api/public/launch-dashboard',
   '/api/public/treasury/launch-status',


### PR DESCRIPTION
## Summary
- add `GET /api/public/partner-payouts`, a public-safe count-only projection over current partner payout ledger state
- expose aggregate states, roles, assets, policy shape, and settled sats without partner refs, user ids, payout refs, qualifying event refs, payout destinations, invoices, preimages, provider payloads, or wallet material
- update `autopilot_sites.partner_payout_ledger.v1` to registry `2026-06-20.6`, removing only `partner_projection_api_missing` while keeping the promise red on partner policy, settlement wiring, and first real payout

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/partner-payout-public-projection.test.ts src/product-promises.test.ts src/worker-exact-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com/workers/api test -- src/openagents-openapi.test.ts src/worker-exact-routes.test.ts src/product-promises.test.ts src/partner-payout-public-projection.test.ts src/site-referral-payout-public-projection.test.ts`
- `bun run --cwd apps/openagents.com check:deploy`
- `bun run --cwd apps/openagents.com/workers/api test -- src/partner-payout-ledger.test.ts src/partner-payout-ledger-routes.test.ts src/partner-payout-public-projection.test.ts`

## Forum / Issue
- Claim: https://openagents.com/forum/t/d8fa3ef8-e8ba-4779-a783-b462db46c6c1#post-4b302a2f-5632-4c95-a689-1f8b0268858d
- Issue claim: https://github.com/OpenAgentsInc/openagents/issues/5524#issuecomment-4756661048

## Boundary
This is not a green flip and not a settlement claim. It does not make partners payable, withdrawable, earning, or revenue-settled.
