### PR TITLE
Add demand provenance projection

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1711,6 +1711,13 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     the receipt-backed accepted-outcome seed, metric definition, and product
     promise registry — compliant (`generatedAt`, contract, evidence-state
     labels, caveats, and modeled-vs-measured gate).
+  - `GET /api/public/demand-provenance` — live at read over revenue-bearing
+    public surfaces that carry typed internal/external demand splits — compliant
+    (`generatedAt`, `projection_staleness.v1` live-at-read contract, AO/kWh
+    surface summary, internal/external/unlabeled counts, zero external-demand
+    claim, remaining coverage refs, and authority boundary). It is proof-copy
+    discipline only: no revenue, demand, payout, settlement, reporting, or
+    public-claim upgrade authority.
   - `GET /api/public/marketplace/composed-products` — live at read over the
     INERT compose-and-list listing store (EPIC #5510, #5515; promise
     `marketplace.compose_and_list_products.v1`, planned) — compliant

--- a/apps/openagents.com/apps/web/public/AGENTS.md
+++ b/apps/openagents.com/apps/web/public/AGENTS.md
@@ -713,6 +713,7 @@ These surfaces are live for public, unauthenticated inspection:
 | OTEC public proof               | `GET /api/public/proof/otec`                                                               |
 | Public Pylon stats              | `GET /api/public/pylon-stats`                                                              |
 | Accepted Outcomes per kWh       | `GET /api/public/metrics/accepted-outcomes-per-kwh`                                        |
+| Demand provenance projection    | `GET /api/public/demand-provenance`                                                        |
 | Public launch dashboard         | `GET /api/public/launch-dashboard`                                                         |
 | Public Nexus/Pylon receipt API  | `GET /api/public/nexus-pylon/receipts/{receiptRef}`                                        |
 | Public Nexus/Pylon receipt page | `https://openagents.com/nexus-pylon/receipts/{receiptRef}`                                 |

--- a/apps/openagents.com/apps/web/public/SURFACES.md
+++ b/apps/openagents.com/apps/web/public/SURFACES.md
@@ -622,6 +622,7 @@ yet fully live up to something it says or implies.
 - Browser forum: `https://openagents.com/forum/f/product-promises`
 - Versioned promise JSON: `https://openagents.com/api/public/product-promises`
 - Accepted Outcomes per kWh metric: `https://openagents.com/api/public/metrics/accepted-outcomes-per-kwh`
+- Demand provenance projection: `https://openagents.com/api/public/demand-provenance`
 - API forum slug: `product-promises`
 - API write route: `POST /api/forum/forums/product-promises/topics`
 

--- a/apps/openagents.com/docs/live/AGENTS.md
+++ b/apps/openagents.com/docs/live/AGENTS.md
@@ -713,6 +713,7 @@ These surfaces are live for public, unauthenticated inspection:
 | OTEC public proof               | `GET /api/public/proof/otec`                                                               |
 | Public Pylon stats              | `GET /api/public/pylon-stats`                                                              |
 | Accepted Outcomes per kWh       | `GET /api/public/metrics/accepted-outcomes-per-kwh`                                        |
+| Demand provenance projection    | `GET /api/public/demand-provenance`                                                        |
 | Public launch dashboard         | `GET /api/public/launch-dashboard`                                                         |
 | Public Nexus/Pylon receipt API  | `GET /api/public/nexus-pylon/receipts/{receiptRef}`                                        |
 | Public Nexus/Pylon receipt page | `https://openagents.com/nexus-pylon/receipts/{receiptRef}`                                 |

--- a/apps/openagents.com/docs/live/SURFACES.md
+++ b/apps/openagents.com/docs/live/SURFACES.md
@@ -622,6 +622,7 @@ yet fully live up to something it says or implies.
 - Browser forum: `https://openagents.com/forum/f/product-promises`
 - Versioned promise JSON: `https://openagents.com/api/public/product-promises`
 - Accepted Outcomes per kWh metric: `https://openagents.com/api/public/metrics/accepted-outcomes-per-kwh`
+- Demand provenance projection: `https://openagents.com/api/public/demand-provenance`
 - API forum slug: `product-promises`
 - API write route: `POST /api/forum/forums/product-promises/topics`
 

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -570,6 +570,11 @@ const publicProjectionSurfaces = [
     status: 'staleness_declared',
   },
   {
+    module: 'workers/api/src/demand-provenance.ts',
+    route: '/api/public/demand-provenance',
+    status: 'staleness_declared',
+  },
+  {
     module: 'workers/api/src/open-markets-surface.ts',
     route: '/api/public/markets/open-markets',
     status: 'staleness_declared',

--- a/apps/openagents.com/workers/api/src/demand-provenance-routes.ts
+++ b/apps/openagents.com/workers/api/src/demand-provenance-routes.ts
@@ -1,0 +1,9 @@
+import { Effect } from 'effect'
+
+import { projectDemandProvenance } from './demand-provenance'
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+
+export const handleDemandProvenanceApi = (request: Request) =>
+  request.method !== 'GET'
+    ? Effect.succeed(methodNotAllowed(['GET']))
+    : Effect.succeed(noStoreJsonResponse(projectDemandProvenance()))

--- a/apps/openagents.com/workers/api/src/demand-provenance.test.ts
+++ b/apps/openagents.com/workers/api/src/demand-provenance.test.ts
@@ -1,0 +1,110 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { DemandProvenanceEndpoint, projectDemandProvenance } from './demand-provenance'
+import { handleDemandProvenanceApi } from './demand-provenance-routes'
+import { openAgentsOpenApiDocument } from './openagents-openapi'
+
+type DemandProvenanceBody = Readonly<{
+  externalDemandClaimAllowed: boolean
+  kind: string
+  promiseId: string
+  promiseState: string
+  surfaceSummaries: ReadonlyArray<{
+    externalAcceptedOutcomeCount: number
+    internalAcceptedOutcomeCount: number
+    rule: string
+    surfaceRef: string
+    unlabeledAcceptedOutcomeCount: number
+  }>
+}>
+
+describe('demand provenance public projection', () => {
+  test('summarizes serving internal/external splits without claiming external demand', () => {
+    const projection = projectDemandProvenance({
+      generatedAt: '2026-06-20T06:30:00.000Z',
+    })
+
+    expect(projection.kind).toBe('demand_provenance_public')
+    expect(projection.promiseId).toBe('proof.demand_provenance.v1')
+    expect(projection.promiseState).toBe('yellow')
+    expect(projection.rule).toBe('no_external_dollar_no_demand_claim')
+    expect(projection.publicSafe).toBe(true)
+    expect(projection.staleness).toMatchObject({
+      composition: 'live_at_read',
+      contractVersion: 'projection_staleness.v1',
+      maxStalenessSeconds: 0,
+    })
+    expect(projection.surfaceSummaries).toHaveLength(1)
+    expect(projection.surfaceSummaries[0]).toMatchObject({
+      externalAcceptedOutcomeCount: 0,
+      internalAcceptedOutcomeCount: 1,
+      rule: 'no_external_dollar_no_demand_claim',
+      splitState: 'serving_internal_external_split',
+      surfaceRef: 'route:/api/public/metrics/accepted-outcomes-per-kwh',
+      unlabeledAcceptedOutcomeCount: 0,
+    })
+    expect(projection.totals).toEqual({
+      externalAcceptedOutcomeCount: 0,
+      internalAcceptedOutcomeCount: 1,
+      unlabeledAcceptedOutcomeCount: 0,
+    })
+    expect(projection.externalDemandClaimAllowed).toBe(false)
+    expect(projection.blockerRefs).toEqual([
+      'blocker.product_promises.demand_provenance_broad_projection_coverage_missing',
+    ])
+    expect(projection.coverage.remainingSurfaceRefs).toEqual(
+      expect.arrayContaining([
+        'route:/api/public/pylon-stats',
+        'route:/api/public/training/runs/{trainingRunRef}',
+        'route:/api/training/leaderboards/*',
+        'projection:training.rung_economics_gates',
+      ]),
+    )
+    expect(projection.unsafeCopy).toContain(
+      'Do not present internal, first-party, operator-staged, or unlabeled demand as external market demand',
+    )
+  })
+
+  test('serves the public demand-provenance route as no-store JSON', async () => {
+    const response = await Effect.runPromise(
+      handleDemandProvenanceApi(
+        new Request(`https://openagents.com${DemandProvenanceEndpoint}`),
+      ),
+    )
+    const body = (await response.json()) as DemandProvenanceBody
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body.kind).toBe('demand_provenance_public')
+    expect(body.promiseId).toBe('proof.demand_provenance.v1')
+    expect(body.promiseState).toBe('yellow')
+    expect(body.externalDemandClaimAllowed).toBe(false)
+    expect(body.surfaceSummaries[0]).toMatchObject({
+      externalAcceptedOutcomeCount: 0,
+      internalAcceptedOutcomeCount: 1,
+      rule: 'no_external_dollar_no_demand_claim',
+      surfaceRef: 'route:/api/public/metrics/accepted-outcomes-per-kwh',
+      unlabeledAcceptedOutcomeCount: 0,
+    })
+  })
+
+  test('documents the public demand-provenance endpoint in OpenAPI', async () => {
+    const document = await Effect.runPromise(openAgentsOpenApiDocument())
+
+    expect(
+      (
+        document.paths[DemandProvenanceEndpoint] as
+          | { get?: unknown }
+          | undefined
+      )?.get,
+    ).toEqual(
+      expect.objectContaining({
+        operationId: 'getPublicDemandProvenance',
+      }),
+    )
+    expect(
+      (document.components as { schemas: Record<string, unknown> }).schemas,
+    ).toHaveProperty('DemandProvenanceProjection')
+  })
+})

--- a/apps/openagents.com/workers/api/src/demand-provenance.ts
+++ b/apps/openagents.com/workers/api/src/demand-provenance.ts
@@ -1,0 +1,181 @@
+import { Schema as S } from 'effect'
+
+import {
+  AcceptedOutcomesPerKwhEndpoint,
+  type AcceptedOutcomesPerKwhProjection,
+  projectAcceptedOutcomesPerKwh,
+} from './accepted-outcomes-per-kwh'
+import {
+  PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const DemandProvenanceEndpoint = '/api/public/demand-provenance'
+export const DemandProvenanceSchemaVersion =
+  'openagents.demand_provenance.v1'
+
+export const DemandProvenanceRemainingBlockerRefs = [
+  'blocker.product_promises.demand_provenance_broad_projection_coverage_missing',
+] as const
+
+export class DemandProvenanceSurfaceSummary extends S.Class<DemandProvenanceSurfaceSummary>(
+  'DemandProvenanceSurfaceSummary',
+)({
+  caveatRefs: S.Array(S.String),
+  externalAcceptedOutcomeCount: S.Int,
+  externalDemandClaimAllowed: S.Boolean,
+  internalAcceptedOutcomeCount: S.Int,
+  promiseRefs: S.Array(S.String),
+  rule: S.Literal('no_external_dollar_no_demand_claim'),
+  sourceRefs: S.Array(S.String),
+  splitState: S.Literal('serving_internal_external_split'),
+  surfaceRef: S.String,
+  unlabeledAcceptedOutcomeCount: S.Int,
+}) {}
+
+export class DemandProvenanceCoverage extends S.Class<DemandProvenanceCoverage>(
+  'DemandProvenanceCoverage',
+)({
+  coveredRevenueBearingSurfaceCount: S.Int,
+  remainingSurfaceRefs: S.Array(S.String),
+}) {}
+
+export class DemandProvenanceTotals extends S.Class<DemandProvenanceTotals>(
+  'DemandProvenanceTotals',
+)({
+  externalAcceptedOutcomeCount: S.Int,
+  internalAcceptedOutcomeCount: S.Int,
+  unlabeledAcceptedOutcomeCount: S.Int,
+}) {}
+
+export class DemandProvenanceProjection extends S.Class<DemandProvenanceProjection>(
+  'DemandProvenanceProjection',
+)({
+  schemaVersion: S.String,
+  generatedAt: S.String,
+  staleness: PublicProjectionStalenessContract,
+  kind: S.Literal('demand_provenance_public'),
+  promiseId: S.Literal('proof.demand_provenance.v1'),
+  promiseState: S.Literal('yellow'),
+  publicSafe: S.Boolean,
+  rule: S.Literal('no_external_dollar_no_demand_claim'),
+  surfaceSummaries: S.Array(DemandProvenanceSurfaceSummary),
+  totals: DemandProvenanceTotals,
+  coverage: DemandProvenanceCoverage,
+  externalDemandClaimAllowed: S.Boolean,
+  blockerRefs: S.Array(S.String),
+  caveatRefs: S.Array(S.String),
+  authorityBoundary: S.String,
+  unsafeCopy: S.String,
+}) {}
+
+export const DemandProvenanceStaleness = liveAtReadStaleness([
+  'accepted_outcome_receipt_published',
+  'labor_escrow_release_receipt_published',
+  'energy_telemetry_ingested',
+  'product_promise_registry_updated',
+])
+
+const remainingSurfaceRefs = [
+  'route:/api/public/pylon-stats',
+  'route:/api/public/training/runs/{trainingRunRef}',
+  'route:/api/training/leaderboards/*',
+  'projection:training.rung_economics_gates',
+] as const
+
+const summarizeAcceptedOutcomesPerKwh = (
+  projection: AcceptedOutcomesPerKwhProjection,
+): DemandProvenanceSurfaceSummary => {
+  const internalAcceptedOutcomeCount =
+    projection.demandProvenance.internalAcceptedOutcomeCount
+  const externalAcceptedOutcomeCount =
+    projection.demandProvenance.externalAcceptedOutcomeCount
+  const unlabeledAcceptedOutcomeCount = Math.max(
+    0,
+    projection.acceptedOutcomeCounter.count -
+      internalAcceptedOutcomeCount -
+      externalAcceptedOutcomeCount,
+  )
+
+  return new DemandProvenanceSurfaceSummary({
+    caveatRefs: projection.demandProvenance.caveatRefs,
+    externalAcceptedOutcomeCount,
+    externalDemandClaimAllowed:
+      projection.demandProvenance.externalDemandClaimAllowed,
+    internalAcceptedOutcomeCount,
+    promiseRefs: [
+      projection.promiseRef,
+      projection.demandProvenance.contractRef,
+    ],
+    rule: projection.demandProvenance.rule,
+    sourceRefs: [
+      `route:${AcceptedOutcomesPerKwhEndpoint}`,
+      ...projection.sourceRefs,
+    ],
+    splitState: 'serving_internal_external_split',
+    surfaceRef: `route:${AcceptedOutcomesPerKwhEndpoint}`,
+    unlabeledAcceptedOutcomeCount,
+  })
+}
+
+export const projectDemandProvenance = (
+  input: {
+    acceptedOutcomesPerKwh?: AcceptedOutcomesPerKwhProjection | undefined
+    generatedAt?: string | undefined
+  } = {},
+): DemandProvenanceProjection => {
+  const generatedAt = input.generatedAt ?? currentIsoTimestamp()
+  const acceptedOutcomesPerKwh =
+    input.acceptedOutcomesPerKwh ??
+    projectAcceptedOutcomesPerKwh({ generatedAt })
+  const surfaceSummaries = [
+    summarizeAcceptedOutcomesPerKwh(acceptedOutcomesPerKwh),
+  ]
+  const totals = surfaceSummaries.reduce(
+    (sum, surface) => ({
+      externalAcceptedOutcomeCount:
+        sum.externalAcceptedOutcomeCount +
+        surface.externalAcceptedOutcomeCount,
+      internalAcceptedOutcomeCount:
+        sum.internalAcceptedOutcomeCount +
+        surface.internalAcceptedOutcomeCount,
+      unlabeledAcceptedOutcomeCount:
+        sum.unlabeledAcceptedOutcomeCount +
+        surface.unlabeledAcceptedOutcomeCount,
+    }),
+    {
+      externalAcceptedOutcomeCount: 0,
+      internalAcceptedOutcomeCount: 0,
+      unlabeledAcceptedOutcomeCount: 0,
+    },
+  )
+
+  return new DemandProvenanceProjection({
+    authorityBoundary:
+      'Demand provenance is a public labeling projection only. It grants no revenue, demand, payout, settlement, dispatch, treasury, reporting, or public-claim upgrade authority.',
+    blockerRefs: [...DemandProvenanceRemainingBlockerRefs],
+    caveatRefs: [
+      'caveat.demand_provenance.internal_demand_is_plumbing_not_market',
+      'caveat.demand_provenance.no_external_dollar_no_demand_claim',
+      'caveat.demand_provenance.partial_coverage_not_green',
+    ],
+    coverage: new DemandProvenanceCoverage({
+      coveredRevenueBearingSurfaceCount: surfaceSummaries.length,
+      remainingSurfaceRefs: [...remainingSurfaceRefs],
+    }),
+    externalDemandClaimAllowed: totals.externalAcceptedOutcomeCount > 0,
+    generatedAt,
+    kind: 'demand_provenance_public',
+    promiseId: 'proof.demand_provenance.v1',
+    promiseState: 'yellow',
+    publicSafe: true,
+    rule: 'no_external_dollar_no_demand_claim',
+    schemaVersion: DemandProvenanceSchemaVersion,
+    staleness: DemandProvenanceStaleness,
+    surfaceSummaries,
+    totals: new DemandProvenanceTotals(totals),
+    unsafeCopy:
+      'Do not present internal, first-party, operator-staged, or unlabeled demand as external market demand. Do not claim demand provenance is green until the remaining revenue-bearing projections carry the same typed split and a receipt-first transition is recorded.',
+  })
+}

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -22,6 +22,7 @@ import { Exit } from 'effect'
 import { WorkerEnvironment } from 'effect-cf'
 
 import { handleAcceptedOutcomesPerKwhApi } from './accepted-outcomes-per-kwh-routes'
+import { handleDemandProvenanceApi } from './demand-provenance-routes'
 import {
   handleLiquidityMarketSkeletonApi,
   handleOpenMarketsSurfaceApi,
@@ -8014,6 +8015,10 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     // or green claim.
     path: TrainingAblationDeriskingLedgerEndpoint,
     handler: request => handleTrainingAblationDeriskingLedgerApi(request),
+  },
+  {
+    path: '/api/public/demand-provenance',
+    handler: request => handleDemandProvenanceApi(request),
   },
   {
     path: '/api/public/markets/open-markets',

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -3,6 +3,7 @@ import { Effect, Schema as S } from 'effect'
 
 import { AcceptedOutcomesPerKwhEndpoint } from './accepted-outcomes-per-kwh'
 import { PublicAgentProposalRecoveryRoute } from './agent-rate-limit-recovery'
+import { DemandProvenanceEndpoint } from './demand-provenance'
 import {
   LiquidityMarketSkeletonEndpoint,
   RiskMarketSkeletonEndpoint,
@@ -477,6 +478,9 @@ const schemaComponents = (): JsonSchema => ({
   ),
   AcceptedOutcomesPerKwhProjection: objectSummary(
     'Public-safe Accepted Outcomes per Kilowatt-Hour projection. Includes generatedAt, the declared staleness contract, the frozen metric definition ref, receipt-backed accepted-outcome counter, modeled/measured energy evidence labels, a typed internal/external demand-provenance split (proof.demand_provenance.v1, rule no_external_dollar_no_demand_claim, with externalDemandClaimAllowed gating market-demand claims), gate state, blocker refs, caveats, and published datapoints. Modeled seed datapoints are clearly labeled and do not grant payout, settlement, dispatch, energy-market, investment, or grid-operation authority, and internal demand is never presented as external market demand.',
+  ),
+  DemandProvenanceProjection: objectSummary(
+    'Public-safe demand-provenance projection. Includes generatedAt and the projection_staleness.v1 live_at_read staleness contract with maxStalenessSeconds 0. Summarizes revenue-bearing public surfaces that carry typed internal/external demand splits, starts with the AO/kWh surface, reports internal/external/unlabeled accepted-outcome counts, enforces the no_external_dollar_no_demand_claim copy gate, names remaining coverage gaps, and grants no revenue, demand, payout, settlement, reporting, or public-claim upgrade authority.',
   ),
   OpenMarketsSurfaceProjection: objectSummary(
     'Public-safe unified open-markets surface enumerating the six Episode 213 markets (compute, data, labor, liquidity, risk, verification). Includes generatedAt, the declared live_at_read staleness contract, honest per-market state (live_scoped/shipped_not_broadly_live/skeleton/unbuilt), whether a settled receipt exists, protocol and promise refs, evidence refs, blockers, state counts, and the skeleton market ids. It is evidence-only and grants no market-making, matching, quoting, settlement, custody, underwriting, payout, or public-market-claim authority; liquidity and risk are inert skeletons.',
@@ -3096,6 +3100,23 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Accepted Outcomes per kWh metric.',
           '#/components/schemas/AcceptedOutcomesPerKwhProjection',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  [DemandProvenanceEndpoint]: {
+    get: operation({
+      operationId: 'getPublicDemandProvenance',
+      summary: 'Read public demand-provenance projection',
+      description:
+        'Returns the public demand-provenance projection for revenue-bearing public numbers. The current response summarizes the AO/kWh internal/external split, reports zero external accepted outcomes, keeps externalDemandClaimAllowed false, names remaining coverage gaps, and grants no revenue, demand, payout, settlement, reporting, or public-claim upgrade authority.',
+      tags: ['Public Proof'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Public demand-provenance projection.',
+          '#/components/schemas/DemandProvenanceProjection',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.13')
+    expect(decoded.version).toBe('2026-06-20.14')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -163,7 +163,10 @@ describe('public product promises document', () => {
     // drops second_device_class_missing on
     // training.device_capability_dataset.v1 (the dataset gains a genuine
     // measured_unsettled x86_64-Linux/Intel class); the promise STAYS yellow,
-    // so green remains exactly 24.
+    // so green remains exactly 24. The 2026-06-20.14 demand-provenance
+    // projection
+    // pass moves proof.demand_provenance.v1 planned -> yellow without flipping
+    // green, so green remains exactly 24.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -407,7 +410,16 @@ describe('public product promises document', () => {
         }),
         expect.objectContaining({
           promiseId: 'proof.demand_provenance.v1',
-          state: 'planned',
+          state: 'yellow',
+          evidenceRefs: expect.arrayContaining([
+            'route:/api/public/demand-provenance',
+            'apps/openagents.com/workers/api/src/demand-provenance.ts',
+            'apps/openagents.com/workers/api/src/demand-provenance-routes.ts',
+            'apps/openagents.com/workers/api/src/demand-provenance.test.ts',
+          ]),
+          blockerRefs: expect.not.arrayContaining([
+            'blocker.product_promises.demand_provenance_projection_missing',
+          ]),
         }),
         expect.objectContaining({
           promiseId: 'proof.claim_upgrade_receipts.v1',
@@ -814,16 +826,42 @@ describe('public product promises document', () => {
     )
   })
 
+  test('keeps demand provenance yellow after the first public projection', () => {
+    const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
+      publicProductPromisesDocument(),
+    )
+    const demandProvenancePromise = decoded.promises.find(
+      promise => promise.promiseId === 'proof.demand_provenance.v1',
+    )
+
+    expect(demandProvenancePromise?.state).toBe('yellow')
+    expect(demandProvenancePromise?.blockerRefs).toEqual([
+      'blocker.product_promises.demand_provenance_broad_projection_coverage_missing',
+    ])
+    expect(demandProvenancePromise?.safeCopy).toContain(
+      'GET /api/public/demand-provenance',
+    )
+    expect(demandProvenancePromise?.safeCopy).toContain(
+      'externalDemandClaimAllowed:false',
+    )
+    expect(demandProvenancePromise?.verification).toContain(
+      'summarizes the AO/kWh internal/external split',
+    )
+    expect(demandProvenancePromise?.authorityBoundary).toContain(
+      'grants no settlement or reporting authority',
+    )
+  })
+
   test('blocks announcement copy until the live endpoint serves the announced version', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.13', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.14', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.13',
+      expectedVersion: '2026-06-20.14',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.13',
+      servedVersion: '2026-06-20.14',
       status: 'ready',
     })
     expect(
@@ -833,7 +871,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.13',
+      servedVersion: '2026-06-20.14',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.13'
+export const PublicProductPromisesVersion = '2026-06-20.14'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -1943,25 +1943,29 @@ export const publicProductPromisesDocument = () => {
         promiseId: 'proof.demand_provenance.v1',
         productArea: 'public proof',
         audience: ['agent', 'operator', 'public'],
-        state: 'planned',
+        state: 'yellow',
         claim:
           'Every revenue-bearing public number carries demand provenance — internal versus external dollars — as strictly as modeled versus measured versus settled, under the rule: no external dollar, no demand claim.',
         safeCopy:
-          'Provenance discipline already exists for promise states and settlement evidence, and the training program explicitly labels its own internal demand (ablations, sweeps, corpus work, conformance runs) as plumbing proof rather than market proof. First serving surface: the AO/kWh metric (GET /api/public/metrics/accepted-outcomes-per-kwh) now carries a typed internal/external demand split with the rule no_external_dollar_no_demand_claim — every datapoint is labeled internal or external, the projection serves reconciling internal/external counts, externalDemandClaimAllowed stays false until a real external dollar backs an outcome, and the copy gate forbids presenting the operator-staged #4777 outcome as market demand. Broad coverage across the other revenue-bearing projections (stats, leaderboards, run pages, economics gates) is still planned.',
+          'Demand provenance is partially live. GET /api/public/demand-provenance summarizes revenue-bearing public surfaces that carry typed internal/external demand splits, currently starting with AO/kWh (GET /api/public/metrics/accepted-outcomes-per-kwh). It reports the operator-staged #4777 outcome as internal demand, zero external accepted outcomes, zero unlabeled outcomes, externalDemandClaimAllowed:false, and the rule no_external_dollar_no_demand_claim. Broad coverage across the other revenue-bearing projections (stats, leaderboards, run pages, economics gates) is still missing.',
         unsafeCopy:
           'Do not present first-party or internally-dispatched demand as market demand, and do not aggregate internal and external revenue into one undifferentiated public number.',
         evidenceRefs: [
           'docs/training/2026-06-10-psion-full-pipeline-buildout-plan.md',
           'docs/promises/2026-06-09-product-promises-gap-audit.md',
+          'route:/api/public/demand-provenance',
+          'apps/openagents.com/workers/api/src/demand-provenance.ts',
+          'apps/openagents.com/workers/api/src/demand-provenance-routes.ts',
+          'apps/openagents.com/workers/api/src/demand-provenance.test.ts',
           'route:/api/public/metrics/accepted-outcomes-per-kwh',
           'apps/openagents.com/workers/api/src/accepted-outcomes-per-kwh.ts',
           'apps/openagents.com/workers/api/src/accepted-outcomes-per-kwh.test.ts',
         ],
         blockerRefs: [
-          'blocker.product_promises.demand_provenance_projection_missing',
+          'blocker.product_promises.demand_provenance_broad_projection_coverage_missing',
         ],
         verification:
-          'Green requires revenue-bearing public projections (stats, leaderboards, run pages, economics gates) to carry a typed internal/external demand field, with at least one surface serving real split data and a copy gate forbidding unlabeled aggregates. First serving surface met by the AO/kWh metric (accepted-outcomes-per-kwh.test.ts: demand-provenance split reconciles to the accepted-outcome total, externalDemandClaimAllowed is false, copy gate present); green still requires the remaining revenue-bearing projections to carry the same typed split and a transition receipt.',
+          'Yellow is supported by GET /api/public/demand-provenance and demand-provenance.test.ts: the route is no-store, live-at-read, public-safe, summarizes the AO/kWh internal/external split, reconciles internal/external/unlabeled counts, keeps externalDemandClaimAllowed false, and names remaining coverage gaps. Green still requires the remaining revenue-bearing projections (stats, leaderboards, run pages, economics gates) to carry the same typed split plus a receipt-first transition.',
         authorityBoundary:
           'Demand provenance is a labeling discipline; it does not validate any revenue claim by itself and grants no settlement or reporting authority.',
       },
@@ -3474,6 +3478,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.9 advances mobile.voice_approval_companion.v1 from planned to yellow without clearing the remaining command/sync blockers. The live read-only mobile workroom approval projection (GET /api/mobile/workroom-approval-projection) returns projectionAvailable:true, mutation permissions false, and blockerCleared:blocker.product_promises.mobile_projection_missing, so the promise is no longer roadmap-only. Voice command approval receipts and cross-device workroom sync remain blocked; no approval mutation, command execution, notification, spend, deployment, or green claim is created.',
         'Registry 2026-06-20.11 is a training.ablation_system.v1 derisking-ledger projection pass and flips NO promise state. GET /api/public/training/ablation-derisking-ledger now serves a public-safe, read-only, live-at-read candidate ledger with publicProjectionAvailable=true and greenGateSatisfied=false. This clears blocker.product_promises.ablation_ledger_projection_missing only; blocker.product_promises.ablation_harness_missing and blocker.product_promises.eval_suite_reproduction_missing remain. No ablation execution, paid dispatch, spend, settlement, eval reproduction, accepted verdict, model promotion, or public capability claim is created, so the green count remains exactly 24.',
         'Registry 2026-06-20.12 builds the missing piece of the Artanis unattended-tick-streak gate on artanis.tassadar_evolution_loop.v1 and flips NO promise state (stays yellow; green count unchanged at 24). The registry verification gate requires "at least ten consecutive unattended ticks whose receipts include executor dispatch and exact-replay verdicts", but nothing computed that CONSECUTIVE streak — the tick monitor (artanis-tick-monitor.ts) projected individual decisions and counts-by-state only. This pass adds the counter/projection: apps/openagents.com/workers/api/src/artanis-tick-streak.ts joins the tick-decision ledger (artanis_admin_tick_decisions) to the exact-replay closeout-verdict ledger (artanis_closeout_verdicts) and computes currentStreak / longestStreak / verifiedTickCount over the window, where a tick QUALIFIES only when it is a dispatched admin-tick decision whose assignment carries an ACCEPTED exact-replay verdict (outcome=verified, accept_state=accepted); a pending, rejected, or unverified tick can only shorten the streak, never lengthen it, and the projection cannot create a tick or a verdict. It is exposed read-only and public-safe at GET /api/public/artanis/tick-streak (registered in the OpenAPI as getPublicArtanisTickStreak and in the exact-route registry), returning streakTarget (10), targetReached, and currentStreakAssignmentRefs — each dereferenceable as receipt.nexus_pylon.artanis_admin_closeout.<assignmentRef> for independent replay-verdict inspection. New tests: 8 in artanis-tick-streak.test.ts (qualifying run, head-break, pending/rejected non-qualification, target flip at 10, longest>current, smuggled-value redaction, bounded limits, the join reader). blocker.product_promises.artanis_unattended_tick_streak_missing STAYS on the record: this ships the tracking + public surface, but NO real ten-tick streak has been driven live (that requires the production cron running over eligible fleet Pylons across consecutive ticks, which this environment cannot drive). What the live surface now shows is the honest current streak; green for this dimension requires the deployed /api/public/artanis/tick-streak surface to report longestStreak >= 10 on real dereferenceable closeout receipts, plus owner sign-off per proof.claim_upgrade_receipts.v1. blocker.product_promises.tassadar_distillation_dataset_receipt_missing is untouched. Zero green flips.',
+        'Registry 2026-06-20.14 advances proof.demand_provenance.v1 from planned to yellow and flips NO promise green. GET /api/public/demand-provenance is now a public-safe live-at-read projection summarizing revenue-bearing public surfaces with typed internal/external demand splits, currently the AO/kWh surface. It reports one internal accepted outcome, zero external accepted outcomes, zero unlabeled outcomes, externalDemandClaimAllowed:false, and the rule no_external_dollar_no_demand_claim. This clears blocker.product_promises.demand_provenance_projection_missing only; broad coverage across remaining revenue-bearing projections stays blocked on blocker.product_promises.demand_provenance_broad_projection_coverage_missing. No revenue, demand, payout, settlement, reporting, or public-claim upgrade authority is created.',
       'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -17,6 +17,7 @@ const approvedExactRoutePaths = [
   '/api/public/product-promises/audit',
   '/api/public/metrics/accepted-outcomes-per-kwh',
   '/api/public/training/ablation-derisking-ledger',
+  '/api/public/demand-provenance',
   '/api/public/markets/open-markets',
   '/api/public/markets/liquidity/skeleton',
   '/api/public/markets/risk/skeleton',


### PR DESCRIPTION
## Summary
- Adds `GET /api/public/demand-provenance`, a public-safe live-at-read projection for typed internal/external demand provenance.
- Advances `proof.demand_provenance.v1` from planned to yellow at registry `2026-06-20.10`.
- Clears only the projection-missing blocker and keeps broad coverage blocked on `blocker.product_promises.demand_provenance_broad_projection_coverage_missing`.

## Safety
- Does not flip any promise green.
- Does not create revenue, demand, payout, settlement, reporting, or public-claim upgrade authority.
- Current projection reports one internal accepted outcome, zero external accepted outcomes, zero unlabeled outcomes, and `externalDemandClaimAllowed:false`.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/demand-provenance.test.ts src/accepted-outcomes-per-kwh.test.ts src/product-promises.test.ts src/worker-exact-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:public-projection-freshness`
- `bun run --cwd apps/openagents.com check:deploy`

Refs #5524
