### PR TITLE
DE-9 #5532: omni client-delivery business-object projection (flag-gated INERT)

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1793,6 +1793,24 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     `multi_earning_settlement_refs_missing`) stay owner-gated and are surfaced
     as `remainingOwnerGatedBlockers`. It records no real earnings, moves no
     money, and admits no install as closed (#5527).
+  - `GET /api/public/omni/client-delivery-projection` — live at read over the
+    INERT client-delivery workroom store (promise
+    `workrooms.omni_client_delivery_workrooms.v1`, yellow) — compliant
+    (`generatedAt`, `live_at_read` contract). The surface is flag-gated
+    (`OMNI_CLIENT_DELIVERY_PROJECTION_ENABLED`, default off => empty store) and
+    the payload always reports `effectsApplied: false`. When armed it projects
+    the existing source-authorized business-object delivery seam
+    (`buildOmniBusinessObjectDeliveryPlan`) over an injected workroom store:
+    per-write approval-gated decisions plus the integration gate verdict. It
+    applies no business-object write, sends nothing, settles nothing, spends
+    nothing, mutates no connector, notifies nobody, launches no runner, and
+    upgrades no public claim. It is the read-only delivery-projection
+    deliverable (clearing
+    `blocker.product_promises.omni_client_delivery_projection_missing`); the
+    live-integration, owner-sign-off, and closeout-receipt blockers
+    (`integration_inert_disabled`, `owner_sign_off_missing`,
+    `closeout_receipt_missing`) stay owner-gated and are surfaced as
+    `remainingBlockers`, so the promise stays yellow (DE-9 / #5532).
   - `GET /api/public/customer-one-cohort` — live at read over Customer #1
     cohort source rows and privacy-review evidence — compliant (`generatedAt`,
     contract, evidence-only opaque cohort refs, generic labels, counts, blockers,

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -283,7 +283,16 @@ const budgetChecks = [
     // returns `Effect.Effect<Response>` like the sibling public read handlers.
     // Ratchet back down when these public-projection handlers are extracted
     // behind shared route mappers.
-    budget: 92,
+    // +1 (92 -> 93) for the Omni client-delivery business-object projection
+    // surface (omni-client-delivery-projection-routes.ts,
+    // workrooms.omni_client_delivery_workrooms.v1, yellow): a flag-gated INERT
+    // read-only projection over the existing source-authorized
+    // business-object delivery seam, clearing only
+    // blocker.product_promises.omni_client_delivery_projection_missing. The
+    // handler returns `Response` directly (wrapped in `Effect.succeed` at the
+    // mount). Ratchet back down when these public-projection handlers are
+    // extracted behind shared route mappers.
+    budget: 93,
     description:
       'Worker domain and route modules may not grow Response-returning surfaces while route mappers are extracted.',
     details: countByFile(
@@ -625,6 +634,11 @@ const publicProjectionSurfaces = [
   {
     module: 'workers/api/src/pylon-multi-earning-node.ts',
     route: '/api/public/pylon/multi-earning-node',
+    status: 'staleness_declared',
+  },
+  {
+    module: 'workers/api/src/omni-client-delivery-projection-routes.ts',
+    route: '/api/public/omni/client-delivery-projection',
     status: 'staleness_declared',
   },
   {

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -69,6 +69,14 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // voice-command approval receipts + cross-device sync stay open and the
   // promise stays yellow regardless.
   MOBILE_WORKROOM_APPROVAL_PROJECTION_ENABLED?: string | undefined
+  // Omni client-delivery business-object projection flag (DE-9 / EPIC #5532;
+  // promise workrooms.omni_client_delivery_workrooms.v1, yellow). Default OFF:
+  // the `/api/public/omni/client-delivery-projection` route is INERT (empty
+  // store) on the live Worker. Set "true"/"1"/"on" to arm the read-only
+  // delivery-plan projection over an injected store. It clears only the missing
+  // read-only delivery-projection blocker; the live integration, owner sign-off,
+  // and closeout receipt stay owner-gated and the promise stays yellow.
+  OMNI_CLIENT_DELIVERY_PROJECTION_ENABLED?: string | undefined
   // Pylon multi-earning-node projection flag (EPIC #5523 / DE-4 #5527; promise
   // pylon.v0_3_multi_earning_node.v1, red). Default OFF: the
   // `/api/public/pylon/multi-earning-node` surface is INERT (empty store) on

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -53,6 +53,11 @@ import {
   isMobileWorkroomApprovalProjectionEnabled,
 } from './mobile-workroom-approval-projection-routes'
 import {
+  OmniClientDeliveryProjectionEndpoint,
+  handleOmniClientDeliveryProjectionApi,
+  isOmniClientDeliveryProjectionEnabled,
+} from './omni-client-delivery-projection-routes'
+import {
   VoiceProgramIngestEndpoint,
   handleVoiceProgramIngestApi,
   isVoiceProgramIngestEnabled,
@@ -8101,6 +8106,30 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         ),
         nowIso: currentIsoTimestamp,
       }),
+  },
+  {
+    // Omni client-delivery business-object projection (DE-9 / EPIC #5532;
+    // promise workrooms.omni_client_delivery_workrooms.v1, yellow). INERT by
+    // default: the store is empty unless OMNI_CLIENT_DELIVERY_PROJECTION_ENABLED
+    // is armed. When armed it projects the existing source-authorized
+    // business-object delivery seam (buildOmniBusinessObjectDeliveryPlan) over
+    // an injected client-delivery workroom store: per-write approval-gated
+    // decisions plus the integration gate verdict. It applies no write, sends,
+    // settles, spends, mutates a connector, notifies, launches a runner, or
+    // upgrades a public claim (effectsApplied is always false). This clears ONLY
+    // blocker.product_promises.omni_client_delivery_projection_missing; the
+    // live-integration, owner-sign-off, and closeout-receipt blockers stay
+    // owner-gated and the promise stays yellow. GET only.
+    path: OmniClientDeliveryProjectionEndpoint,
+    handler: (request, env) =>
+      Effect.succeed(
+        handleOmniClientDeliveryProjectionApi(request, {
+          enabled: isOmniClientDeliveryProjectionEnabled(
+            env.OMNI_CLIENT_DELIVERY_PROJECTION_ENABLED,
+          ),
+          nowIso: currentIsoTimestamp,
+        }),
+      ),
   },
   {
     // Voice-session transcript ingestion endpoint (#5523 / DE-7 #5530; promise

--- a/apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.test.ts
@@ -1,0 +1,177 @@
+import { Schema as S } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  OMNI_BUSINESS_OBJECT_WRITE_FIXTURE,
+  OMNI_SOURCE_AUTHORITY_BINDING_FIXTURE,
+} from './omni-source-authorized-business-objects'
+import { OmniWorkroomRecord } from './omni-workrooms'
+import {
+  OMNI_CLIENT_DELIVERY_PROJECTION_BLOCKERS,
+  OMNI_CLIENT_DELIVERY_PROJECTION_PROMISE_ID,
+  OmniClientDeliveryProjectionEndpoint,
+  type OmniClientDeliveryProjectionDeps,
+  emptyOmniClientDeliveryProjectionStore,
+  handleOmniClientDeliveryProjectionApi,
+  isOmniClientDeliveryProjectionEnabled,
+  makeInMemoryOmniClientDeliveryProjectionStore,
+} from './omni-client-delivery-projection-routes'
+
+const nowIso = '2026-06-19T05:30:00.000Z'
+
+const workroomFixture: OmniWorkroomRecord = {
+  acceptedOutcomeContractId: null,
+  archivedAt: null,
+  artifactRefs: [],
+  assignmentId: null,
+  blockerRefs: [],
+  classificationCaveatRef: 'classification_caveat_unreviewed',
+  createdAt: '2026-06-19T05:00:00.000Z',
+  customerIntentRef: 'customer_intent.acme_delivery',
+  dataClassification: 'customer',
+  emailRefs: [],
+  id: 'workroom.acme_delivery',
+  idempotencyKey: 'idem.acme_delivery',
+  metadata: {},
+  publicReceiptRef: 'omni_workroom:order:idem',
+  receiptRefs: [],
+  siteId: null,
+  softwareOrderId: 'software_order.acme',
+  sourceRefs: [],
+  status: 'active',
+  taskPacketRef: null,
+  trustTier: 'unverified',
+  updatedAt: '2026-06-19T05:00:00.000Z',
+  visibility: 'customer',
+  workKind: 'business',
+}
+
+const workroom = (): OmniWorkroomRecord =>
+  S.decodeUnknownSync(OmniWorkroomRecord)(workroomFixture)
+
+const armedStore = () =>
+  makeInMemoryOmniClientDeliveryProjectionStore([
+    {
+      bindings: [OMNI_SOURCE_AUTHORITY_BINDING_FIXTURE],
+      workroom: workroom(),
+      writes: [OMNI_BUSINESS_OBJECT_WRITE_FIXTURE],
+    },
+  ])
+
+const deps = (
+  override: Partial<OmniClientDeliveryProjectionDeps> = {},
+): OmniClientDeliveryProjectionDeps => ({
+  enabled: false,
+  nowIso: () => nowIso,
+  ...override,
+})
+
+const get = (url = 'https://example.com' + OmniClientDeliveryProjectionEndpoint) =>
+  new Request(url, { method: 'GET' })
+
+describe('Omni client-delivery projection endpoint (INERT)', () => {
+  test('flag parser only arms on truthy values', () => {
+    for (const on of ['1', 'true', 'TRUE', 'yes', 'on', ' On ']) {
+      expect(isOmniClientDeliveryProjectionEnabled(on)).toBe(true)
+    }
+    for (const off of [undefined, '', '0', 'false', 'no', 'off', 'maybe']) {
+      expect(isOmniClientDeliveryProjectionEnabled(off)).toBe(false)
+    }
+  })
+
+  test('disabled: inert, empty, no projection, promise stays yellow', async () => {
+    const res = handleOmniClientDeliveryProjectionApi(
+      get(),
+      deps({ enabled: false, store: armedStore() }),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.promiseId).toBe(OMNI_CLIENT_DELIVERY_PROJECTION_PROMISE_ID)
+    expect(body.promiseState).toBe('yellow')
+    expect(body.enabled).toBe(false)
+    expect(body.inert).toBe(true)
+    expect(body.effectsApplied).toBe(false)
+    expect(body.workroomCount).toBe(0)
+    expect(body.proposedWriteCount).toBe(0)
+    expect(body.applyableWriteCount).toBe(0)
+    expect(body.plans).toEqual([])
+    expect(body.blockerCleared).toBe(
+      OMNI_CLIENT_DELIVERY_PROJECTION_BLOCKERS.cleared,
+    )
+  })
+
+  test('enabled but no store: still inert/empty', async () => {
+    const res = handleOmniClientDeliveryProjectionApi(
+      get(),
+      deps({ enabled: true }),
+    )
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.enabled).toBe(true)
+    expect(body.inert).toBe(false)
+    expect(body.workroomCount).toBe(0)
+    expect(body.plans).toEqual([])
+  })
+
+  test('enabled with armed store: projects the delivery plan, holds writes inert', async () => {
+    const res = handleOmniClientDeliveryProjectionApi(
+      get(),
+      deps({ enabled: true, store: armedStore() }),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.enabled).toBe(true)
+    expect(body.inert).toBe(false)
+    expect(body.effectsApplied).toBe(false)
+    expect(body.applyableWriteCount).toBe(0)
+    expect(body.workroomCount).toBe(1)
+    expect(body.proposedWriteCount).toBe(1)
+    const plans = body.plans as ReadonlyArray<Record<string, unknown>>
+    expect(plans).toHaveLength(1)
+    expect(plans[0]?.effectsApplied).toBe(false)
+    expect(plans[0]?.gateState).toBe('inert_disabled')
+    expect(plans[0]?.applyableCount).toBe(0)
+    expect(plans[0]?.workroomId).toBe('workroom.acme_delivery')
+  })
+
+  test('empty store factory yields no workrooms', () => {
+    expect(emptyOmniClientDeliveryProjectionStore.listWorkrooms()).toEqual([])
+  })
+
+  test('invalid audience -> 400', async () => {
+    const res = handleOmniClientDeliveryProjectionApi(
+      get(
+        'https://example.com' +
+          OmniClientDeliveryProjectionEndpoint +
+          '?audience=bogus',
+      ),
+      deps({ enabled: true, store: armedStore() }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  test('valid audience query is honored', async () => {
+    const res = handleOmniClientDeliveryProjectionApi(
+      get(
+        'https://example.com' +
+          OmniClientDeliveryProjectionEndpoint +
+          '?audience=operator',
+      ),
+      deps({ enabled: true, store: armedStore() }),
+    )
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.audience).toBe('operator')
+  })
+
+  test('non-GET -> 405', () => {
+    const res = handleOmniClientDeliveryProjectionApi(
+      new Request(
+        'https://example.com' + OmniClientDeliveryProjectionEndpoint,
+        { method: 'POST' },
+      ),
+      deps({ enabled: true, store: armedStore() }),
+    )
+    expect(res.status).toBe(405)
+    expect(res.headers.get('allow')).toBe('GET')
+  })
+})

--- a/apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.ts
+++ b/apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.ts
@@ -1,0 +1,231 @@
+// Omni client-delivery business-object projection endpoint
+// (promise workrooms.omni_client_delivery_workrooms.v1, yellow; DE-9 / EPIC #5532).
+//
+// INERT by default. The route is wired into the live Worker but reads from an
+// injected store that the Worker leaves EMPTY unless the surface flag is
+// explicitly armed (OMNI_CLIENT_DELIVERY_PROJECTION_ENABLED). When armed it
+// projects the EXISTING source-authorized business-object delivery seam
+// (buildOmniBusinessObjectDeliveryPlan) over the live client-delivery workroom
+// surface: per-write approval-gated decisions plus the integration gate verdict.
+// It NEVER applies a business-object write, sends, settles, spends, mutates a
+// connector, notifies, launches a runner, or upgrades a public claim
+// (effectsApplied is ALWAYS false; the delivery gate is held inert_disabled
+// unless its own owner-gated config is armed independently of this surface flag).
+//
+// This clears ONLY the missing read-only delivery projection blocker. The
+// live-integration / owner-sign-off / closeout-receipt blockers stay
+// owner-gated, so workrooms.omni_client_delivery_workrooms.v1 stays yellow and
+// no green flip is claimed here (the flip is owner-signed per
+// proof.claim_upgrade_receipts.v1).
+
+import { badRequest } from '@openagentsinc/sync-worker'
+import { Schema as S } from 'effect'
+
+import type { OmniProjectionAudience } from './omni-data-classification'
+import {
+  OmniBusinessObjectDeliveryPlan,
+  buildOmniBusinessObjectDeliveryPlan,
+} from './omni-workroom-business-object-delivery'
+import type { OmniBusinessObjectDeliveryConfig } from './omni-workroom-business-object-delivery'
+import type {
+  OmniBusinessObjectWriteRecord,
+  OmniSourceAuthorityBinding,
+} from './omni-source-authorized-business-objects'
+import type { OmniWorkroomRecord } from './omni-workrooms'
+import {
+  type PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+
+export const OmniClientDeliveryProjectionEndpoint =
+  '/api/public/omni/client-delivery-projection'
+
+export const OMNI_CLIENT_DELIVERY_PROJECTION_PROMISE_ID =
+  'workrooms.omni_client_delivery_workrooms.v1'
+
+/**
+ * Staleness contract for the projection: built fresh from the injected store on
+ * every request, so it is `live_at_read` (maxStaleness 0).
+ */
+export const OmniClientDeliveryProjectionStaleness:
+  PublicProjectionStalenessContract = liveAtReadStaleness([
+    'omni_client_delivery_workroom_changed',
+    'omni_business_object_write_proposed',
+    'omni_source_authority_binding_changed',
+  ])
+
+export const OMNI_CLIENT_DELIVERY_PROJECTION_BLOCKERS = {
+  cleared: 'blocker.product_promises.omni_client_delivery_projection_missing',
+  remaining: [
+    'blocker.business_object_delivery.integration_inert_disabled',
+    'blocker.business_object_delivery.owner_sign_off_missing',
+    'blocker.business_object_delivery.closeout_receipt_missing',
+  ],
+} as const
+
+/**
+ * A single live client-delivery workroom plus the source-authority bindings and
+ * proposed business-object writes the delivery seam reasons over. The store
+ * yields these; the projection runs the existing pure plan builder per entry.
+ */
+export type OmniClientDeliveryProjectionWorkroom = Readonly<{
+  bindings: ReadonlyArray<OmniSourceAuthorityBinding>
+  config?: OmniBusinessObjectDeliveryConfig | undefined
+  workroom: OmniWorkroomRecord
+  writes: ReadonlyArray<OmniBusinessObjectWriteRecord>
+}>
+
+export type OmniClientDeliveryProjectionStore = Readonly<{
+  listWorkrooms: () => ReadonlyArray<OmniClientDeliveryProjectionWorkroom>
+}>
+
+export const emptyOmniClientDeliveryProjectionStore:
+  OmniClientDeliveryProjectionStore = {
+    listWorkrooms: () => [],
+  }
+
+export const makeInMemoryOmniClientDeliveryProjectionStore = (
+  workrooms: ReadonlyArray<OmniClientDeliveryProjectionWorkroom>,
+): OmniClientDeliveryProjectionStore => ({
+  listWorkrooms: () => [...workrooms],
+})
+
+export const isOmniClientDeliveryProjectionEnabled = (
+  value: string | undefined,
+): boolean => {
+  if (value === undefined) {
+    return false
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+export type OmniClientDeliveryProjectionDeps = Readonly<{
+  enabled: boolean
+  nowIso: () => string
+  store?: OmniClientDeliveryProjectionStore
+}>
+
+const projectionAudienceValues: ReadonlyArray<OmniProjectionAudience> = [
+  'public',
+  'customer',
+  'agent',
+  'team',
+  'operator',
+  'private',
+]
+
+const isProjectionAudience = (
+  value: string,
+): value is OmniProjectionAudience =>
+  projectionAudienceValues.includes(value as OmniProjectionAudience)
+
+const audienceFromRequest = (
+  request: Request,
+): OmniProjectionAudience | null => {
+  const audience = new URL(request.url).searchParams.get('audience')
+
+  if (audience === null) {
+    return 'public'
+  }
+
+  return isProjectionAudience(audience) ? audience : null
+}
+
+const resolveStore = (
+  deps: OmniClientDeliveryProjectionDeps,
+): OmniClientDeliveryProjectionStore =>
+  deps.enabled && deps.store !== undefined
+    ? deps.store
+    : emptyOmniClientDeliveryProjectionStore
+
+const projectionPayload = (
+  deps: OmniClientDeliveryProjectionDeps,
+  audience: OmniProjectionAudience,
+): Record<string, unknown> => {
+  const store = resolveStore(deps)
+  const nowIso = deps.nowIso()
+
+  const plans = store.listWorkrooms().map(entry =>
+    S.encodeSync(OmniBusinessObjectDeliveryPlan)(
+      buildOmniBusinessObjectDeliveryPlan({
+        audience,
+        bindings: entry.bindings,
+        config: entry.config,
+        nowIso,
+        workroom: entry.workroom,
+        writes: entry.writes,
+      }),
+    ),
+  )
+
+  const proposedCount = plans.reduce(
+    (count, plan) => count + plan.proposedCount,
+    0,
+  )
+  const applyableCount = plans.reduce(
+    (count, plan) => count + plan.applyableCount,
+    0,
+  )
+
+  return {
+    promiseId: OMNI_CLIENT_DELIVERY_PROJECTION_PROMISE_ID,
+    promiseState: 'yellow' as const,
+    enabled: deps.enabled,
+    inert: !deps.enabled,
+    projectionAvailable: true as const,
+    // Public-projection staleness contract (epic #4751). Composed live from the
+    // injected store at read, so maxStaleness is 0.
+    generatedAt: nowIso,
+    maxStalenessSeconds: OmniClientDeliveryProjectionStaleness.maxStalenessSeconds,
+    staleness: OmniClientDeliveryProjectionStaleness,
+    audience,
+    // The delivery seam is read-only: it plans approval-gated writes but never
+    // applies one. These flags make that boundary machine-checkable.
+    effectsApplied: false as const,
+    writeMutationAllowed: false as const,
+    connectorWriteAllowed: false as const,
+    notificationMutationAllowed: false as const,
+    paymentMutationAllowed: false as const,
+    settlementAllowed: false as const,
+    runnerLaunchAllowed: false as const,
+    publicClaimUpgradeAllowed: false as const,
+    blockerCleared: OMNI_CLIENT_DELIVERY_PROJECTION_BLOCKERS.cleared,
+    remainingBlockers: OMNI_CLIENT_DELIVERY_PROJECTION_BLOCKERS.remaining,
+    workroomCount: plans.length,
+    proposedWriteCount: proposedCount,
+    applyableWriteCount: applyableCount,
+    plans,
+    note:
+      'Omni client-delivery business-object projection is read-only. It plans ' +
+      'approval-gated writes via the existing delivery seam and clears only ' +
+      'the missing read-only delivery-projection blocker; the live ' +
+      'integration, owner sign-off, and closeout receipt remain owner-gated, ' +
+      'so the promise stays yellow.',
+  }
+}
+
+/**
+ * GET the omni client-delivery business-object projection. Read-only,
+ * no-store JSON. GET only.
+ */
+export const handleOmniClientDeliveryProjectionApi = (
+  request: Request,
+  deps: OmniClientDeliveryProjectionDeps,
+): Response => {
+  if (request.method !== 'GET') {
+    return methodNotAllowed(['GET'])
+  }
+
+  const audience = audienceFromRequest(request)
+  if (audience === null) {
+    return badRequest(
+      'Invalid omni client-delivery projection request: audience must be one ' +
+        'of ' +
+        projectionAudienceValues.join(', ') +
+        '.',
+    )
+  }
+
+  return noStoreJsonResponse(projectionPayload(deps, audience))
+}

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -25,6 +25,7 @@ const approvedExactRoutePaths = [
   '/api/public/markets/signature-monetization/metering',
   '/api/public/pylon/multi-earning-node',
   '/api/mobile/workroom-approval-projection',
+  '/api/public/omni/client-delivery-projection',
   '/api/mobile/voice-sessions/ingest',
   '/api/public/autopilot/composed-runs',
   '/api/public/autopilot/labor-products',


### PR DESCRIPTION
## Omni client-delivery business-object projection (DE-9 / EPIC #5532)

Flag-gated, default-OFF, INERT read-only public projection giving the **existing** source-authorized business-object delivery seam (`buildOmniBusinessObjectDeliveryPlan`, landed registry 2026-06-19.10) the producer endpoint it was missing.

**Promise:** `workrooms.omni_client_delivery_workrooms.v1` (yellow). Clears exactly ONE named blocker — the missing read-only **delivery projection** — leaving live-integration / owner-sign-off / closeout-receipt blockers owner-gated. No green flip is claimed; the flip stays owner-signed per `proof.claim_upgrade_receipts.v1`.

### Consumer-exists-needs-producer
`omni-workroom-business-object-delivery.ts` already builds an INERT delivery **plan** per workroom (per-write approval-gated decisions + integration gate verdict, `effectsApplied` always false), exercised only by a unit test + referenced in `product-promises.ts` — but nothing exposed it as a request surface. This adds that surface.

### What landed (additive; mirrors the proven `mobile-workroom-approval-projection` / `pylon-multi-earning-node` flag-gated INERT pattern)
- **NEW** `omni-client-delivery-projection-routes.ts` — `GET /api/public/omni/client-delivery-projection`. INERT by default (empty injected store). When `OMNI_CLIENT_DELIVERY_PROJECTION_ENABLED` is armed it projects the existing delivery seam over an injected workroom store. Read-only: applies no write, sends/settles/spends nothing, mutates no connector, notifies nobody, launches no runner, upgrades no claim. Declares the public-projection staleness contract (`live_at_read`, `generatedAt`, epic #4751).
- **NEW** `omni-client-delivery-projection-routes.test.ts` — fetchable receipt: flag-parser truthiness; disabled→inert/empty; enabled-no-store→empty; enabled+armed→real plan projected with writes held inert (`gateState: inert_disabled`, `applyableCount: 0`, `effectsApplied: false`); invalid/valid audience (400 / honored); non-GET→405. Re-runnable: `vitest run src/omni-client-delivery-projection-routes.test.ts`.
- **additive** `config.ts` flag, `index.ts` mount, `worker-exact-routes.test.ts` approved path, `INVARIANTS.md` inventory row, `check-zero-debt-architecture.mjs` projection-surface ledger row + Response-surface budget ratchet.

### Gates run locally on fresh `main` HEAD + this change
- `tsc -p tsconfig.json --noEmit` (workers/api) — clean
- `vitest run` new test + `worker-exact-routes.test.ts` — green
- `check:architecture` (zero-debt) — passed (route in projection-surface ledger + INVARIANTS inventory)
- `check:public-projection-freshness` — passed

Additive / default-OFF / behavior-preserving. No secrets. worker != validator: Lathe produces; CI and reviewers validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZFxMcQuTX1mVkXiqdPcFY
