### PR TITLE
Add Tassadar Percepta executor spec

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.24')
+    expect(decoded.version).toBe('2026-06-20.25')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -214,6 +214,9 @@ describe('public product promises document', () => {
     // participant-methodology and comparable-run blockers while leaving the
     // comparable-scale public contributor receipts blocker in place, so green
     // remains exactly 24.
+    // The 2026-06-20.25 Tassadar Percepta executor spec pass clears only the
+    // model-spec blocker while architecture and CPU-transform training receipts
+    // stay blocked, so green remains exactly 24.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -476,7 +479,18 @@ describe('public product promises document', () => {
           state: 'red',
           evidenceRefs: expect.arrayContaining([
             'docs/2026-06-12-episode-236-training-launch-gap-audit.md',
+            'docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md',
           ]),
+          blockerRefs: [
+            'blocker.product_promises.percepta_executor_architecture_receipts_missing',
+            'blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing',
+          ],
+          safeCopy: expect.stringContaining(
+            'model/spec boundary is now written down',
+          ),
+          verification: expect.stringContaining(
+            'tassadar_model_spec_missing',
+          ),
         }),
         expect.objectContaining({
           promiseId: 'pylon.v0_3_multi_earning_node.v1',
@@ -943,12 +957,12 @@ describe('public product promises document', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.24', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.25', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.24',
+      expectedVersion: '2026-06-20.25',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.24',
+      servedVersion: '2026-06-20.25',
       status: 'ready',
     })
     expect(
@@ -958,7 +972,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.24',
+      servedVersion: '2026-06-20.25',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.24'
+export const PublicProductPromisesVersion = '2026-06-20.25'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -803,24 +803,24 @@ export const publicProductPromisesDocument = () => {
         claim:
           'The Tassadar model direction uses a Percepta Executor Class architecture, with CPU computation transformation support added to Pylon v1.0 for experimental training.',
         safeCopy:
-          'Episode 236 names a Tassadar/Percepta Executor Class direction. Existing code and product records use Tassadar for the executor lane; treat the model spec, Pylon integration, training plan, and public evidence as unresolved until receipts exist. The bounded executor proof of concept is green (compute.tassadar_executor_poc.v1) but proves exact replay only, not a model. The 2026-06-14 W3 student-program report validated the frozen-analytic-executor-plus-learned-interface research direction (baseline D reached exact-rollout pass@1 while purely-learned baselines failed) but is explicitly research/evaluation only: it creates no public model claim and does not move this promise.',
+          'Episode 236 names a Tassadar/Percepta Executor Class direction. The public model/spec boundary is now written down in docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md: model name, runtime boundary, Pylon integration shape, training/eval plan, artifact-lineage requirements, and safety notes. Treat Pylon integration receipts, architecture receipts, CPU-transform training receipts, and public model evidence as unresolved until receipts exist. The bounded executor proof of concept is green (compute.tassadar_executor_poc.v1) but proves exact replay only, not a model. The 2026-06-14 W3 student-program report validated the frozen-analytic-executor-plus-learned-interface research direction (baseline D reached exact-rollout pass@1 while purely-learned baselines failed) but is explicitly research/evaluation only: it creates no public model claim and does not move this promise.',
         unsafeCopy:
           'Do not claim a Tassadar trained model exists, is trained, outperforms CPUs, replaces a CPU, or is earning contributors Bitcoin, and do not present the W3 student-program results or the executor PoC as proof of a trained Percepta model.',
         evidenceRefs: [
           'docs/transcripts/236.md',
           'docs/2026-06-12-episode-236-training-launch-gap-audit.md',
           'docs/promises/2026-06-14-registry-reality-reconciliation-audit.md',
+          'docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md',
           'docs/tassadar/2026-06-14-w3-student-program-report.md',
           'promise:compute.tassadar_executor_poc.v1',
           'promise:artanis.tassadar_evolution_loop.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.tassadar_model_spec_missing',
           'blocker.product_promises.percepta_executor_architecture_receipts_missing',
           'blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing',
         ],
         verification:
-          'Green requires the model name/spec, runtime boundary, Pylon integration, training/eval plan, artifact lineage, safety notes, and public-safe evidence refs.',
+          'The public model/spec boundary is now documented at docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md: model name, runtime boundary, Pylon integration shape, staged training/eval plan, artifact-lineage requirements, safety notes, and remaining receipt gates. This clears blocker.product_promises.tassadar_model_spec_missing. Green still requires Percepta executor architecture receipts and Pylon CPU-transform training receipts carrying public-safe refs for model profile/config/checkpoint/eval digests, accepted work, verifier verdicts, and settlement where real money moved.',
         authorityBoundary:
           'The scoped Tassadar executor PoC proves bounded exact replay only; it does not prove a model-training architecture, general model capability, or paid earning path.',
       },
@@ -3501,6 +3501,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.22 is an artanis.tassadar_evolution_loop.v1 distillation-dataset receipt pass and flips NO promise state (stays yellow, green count unchanged at 24). GET /api/public/artanis/tassadar-distillation-dataset now projects a public-safe, refs-only dataset-curation receipt over accepted Artanis admin executor-trace closeouts. The receipt is available only when at least 10 accepted exact-replay closeouts exist; production already has the source material via GET /api/public/artanis/tick-streak (longestStreak 12, targetReached true, 16 verified tick closeouts in the scanned window). The projection exposes assignment refs, digest prefixes, and dereferenceable closeout receipt refs only, and clears blocker.product_promises.tassadar_distillation_dataset_receipt_missing. It creates no raw trace export, training run, eval, settlement, model promotion, or model-capability claim. The promise stays yellow pending owner-signed green transition per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-20.23 is a training.model_ladder.v1 blocker-cleanup pass and flips NO promise state (stays planned, green count unchanged at 24). The per-rung economics-gate report format and R1 closeout criteria were already published and cited at docs/training/2026-06-19-model-ladder-rung-economics.md, and the verification copy already states that rung_economics_gate_format_missing is documented. This drops blocker.product_promises.rung_economics_gate_format_missing as stale. The remaining real blocker is blocker.product_promises.r1_full_rehearsal_missing: no rung above R0 has run to a closeout receipt. No rung run, training dispatch, spend, settlement, model artifact, eval, or capability claim is created.',
         'Registry 2026-06-20.24 is a pylon.largest_decentralized_training_claim.v1 blocker-cleanup pass and flips NO promise state (stays red, green count unchanged at 24). The participant-count methodology and comparable-run research were already published and cited at docs/training/2026-06-19-decentralized-training-participant-scale-methodology.md and docs/training/2026-06-19-comparable-decentralized-training-runs-research.md, and the verification copy already states that those gaps are cleared as written evidence. This drops blocker.product_promises.largest_training_participant_methodology_missing and blocker.product_promises.comparable_training_run_evidence_missing as stale. The remaining real blocker is blocker.product_promises.public_training_contributor_receipts_missing: the current live run has five counted realBitcoinMoved:true contributors, far below the cited comparable scale. No largest-run, 200-contributor, at-scale, training-performance, settlement, or world-first claim is created.',
+        'Registry 2026-06-20.25 is a models.tassadar_percepta_executor.v1 model/spec pass and flips NO promise state (stays red, green count unchanged at 24). docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md now names the Tassadar Percepta Executor lane, its runtime boundary, Pylon integration shape, staged training/eval plan, artifact-lineage requirements, safety notes, and remaining receipt gates. This clears blocker.product_promises.tassadar_model_spec_missing only. The remaining blockers are blocker.product_promises.percepta_executor_architecture_receipts_missing and blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing. No trained model, architecture receipt, CPU-transform training receipt, inference endpoint, settlement, model promotion, or model-capability claim is created.',
       'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }

--- a/docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md
+++ b/docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md
@@ -1,0 +1,108 @@
+# Tassadar Percepta Executor Model Spec
+
+Date: 2026-06-20
+
+Promise: `models.tassadar_percepta_executor.v1`
+
+This document clears only the model/spec gap for the Tassadar/Percepta
+executor-model direction. It is not a trained-model receipt, not an architecture
+receipt, and not a Pylon CPU-transform training receipt.
+
+## Model Name And Scope
+
+- Public promise id: `models.tassadar_percepta_executor.v1`
+- Lane name: Tassadar Percepta Executor
+- Product area: models
+- Scope: an executor-class model direction that combines the already proven
+  Tassadar exact-replay executor lane with the Percepta-style compiled
+  transformer / learned-interface architecture direction.
+- Non-scope: a general LLM, an agent, a hosted inference model, a trained
+  checkpoint, or a contributor-earning product.
+
+The canonical spelling is Tassadar. The withdrawn typo alias
+`models.tasadar_percepta_executor.v1` remains a registry compatibility record
+only.
+
+## Runtime Boundary
+
+The model boundary is split into three lanes:
+
+1. Exact executor substrate: digest-pinned Tassadar programs and traces that
+   can be independently replayed by the existing exact-trace verifier.
+2. Learned interface / student lane: bounded student experiments trained on
+   verified trace corpora, evaluated by exact rollout and first-divergence
+   reporting.
+3. Product-facing execution: Pylon/OpenAgents assignment and verification rails
+   that may dispatch work, verify closeouts, and publish public-safe receipts.
+
+Only lane 1 has a green bounded proof today via `compute.tassadar_executor_poc.v1`.
+Lane 2 has research evidence from the W3 student-program report, not a product
+model. Lane 3 has live verified-work rails, not a model capability.
+
+## Pylon Integration Shape
+
+Pylon integration, when receipted, must remain assignment-based:
+
+- work is dispatched through existing OpenAgents/Pylon assignment records;
+- closeouts carry public-safe artifact/proof/receipt refs;
+- verification uses named verifier classes such as `exact_trace_replay`;
+- settlement, when real, is recorded separately from model acceptance;
+- public projections expose refs and digests, never private runner logs or raw
+  provider payloads.
+
+The existing Artanis/Tassadar loop and distillation dataset receipt can supply
+verified trace refs, but they do not train or serve this model by themselves.
+
+## Training And Evaluation Plan
+
+The honest path is staged:
+
+1. Curate verified trace refs from Artanis and the public Tassadar executor run.
+2. Freeze dataset manifests with trace digest prefixes, program/profile refs,
+   executor refs, and verifier refs.
+3. Run a bounded student/model rehearsal against the frozen corpus.
+4. Evaluate by exact rollout, output digest agreement, and first-divergence
+   reports; perplexity is not sufficient.
+5. Record architecture receipt(s): model profile, compiled/frozen executor
+   components, learned-interface components, checkpoint/config/eval hashes, and
+   replay-verifier results.
+6. Record Pylon CPU-transform training receipt(s): assignment refs, accepted
+   work refs, verification verdict refs, payment/settlement refs when real, and
+   public-safe closeout refs.
+
+## Artifact Lineage Requirements
+
+Any future claim must cite public-safe refs for:
+
+- corpus or dataset manifest;
+- executor profile and compiler/evaluator hashes;
+- model config or compiled architecture bundle;
+- checkpoint or interface digest;
+- eval report digest;
+- exact-replay verdict refs;
+- Pylon assignment and closeout refs;
+- settlement refs only when real money moved.
+
+## Safety Notes
+
+- Do not claim a trained Tassadar model exists.
+- Do not present the W3 student-program report as a product-model receipt.
+- Do not present `compute.tassadar_executor_poc.v1` as proof of a general model.
+- Do not claim CPU replacement, CPU outperformance, paid earning, hosted
+  inference, or model promotion from this spec.
+- Do not publish raw traces, private runner logs, provider payloads, wallet
+  material, or customer-sensitive data.
+
+## Remaining Blockers
+
+This spec clears:
+
+- `blocker.product_promises.tassadar_model_spec_missing`
+
+Still blocked:
+
+- `blocker.product_promises.percepta_executor_architecture_receipts_missing`
+- `blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing`
+
+Green still requires receipt-first owner sign-off under
+`proof.claim_upgrade_receipts.v1`.


### PR DESCRIPTION
## Summary\n- Adds docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md with the model name, runtime boundary, Pylon integration shape, training/eval plan, artifact-lineage requirements, safety notes, and remaining receipt gates.\n- Bumps the product-promise registry to 2026-06-20.25.\n- Clears only blocker.product_promises.tassadar_model_spec_missing from models.tassadar_percepta_executor.v1; architecture receipts and CPU-transform training receipts remain blocked.\n\n## Verification\n- bunx vitest run src/product-promises.test.ts\n- bun run check:deploy