### PR TITLE
Ratchet product promises root freshness ledger

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1952,8 +1952,12 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     `workers/api/src/training-ablation-derisking-ledger.test.ts`.
   - `GET /api/public/home` — static discovery document, exempt (not a state
     projection).
-  - `GET /api/public/product-promises` — live at read — NON-COMPLIANT (no
-    payload-level `generatedAt`/contract).
+  - `GET /api/public/product-promises` — live at read over the versioned
+    product-promise registry — compliant (`generatedAt`, `registryVersion`,
+    `maxStalenessSeconds`, top-level `projection_staleness.v1`
+    `live_at_read` contract, and blocker/evidence verification summary). It
+    grants no write, deploy, spend, settlement, or public-claim authority and
+    flips no promise by itself.
   - `GET /api/public/product-promises/transitions` — stored receipt rows,
     served with live registry context — compliant (`generatedAt`,
     `registryVersion`, `registryGeneratedAt`, and the top-level

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -732,6 +732,11 @@ const publicProjectionSurfaces = [
     status: 'staleness_declared',
   },
   {
+    module: 'workers/api/src/product-promises.ts',
+    route: '/api/public/product-promises',
+    status: 'staleness_declared',
+  },
+  {
     module: 'workers/api/src/training-ablation-derisking-ledger.ts',
     route: '/api/public/training/ablation-derisking-ledger',
     status: 'staleness_declared',
@@ -743,11 +748,6 @@ const publicProjectionSurfaces = [
     status: 'static_contract_exempt',
   },
   // Legacy surfaces that predate the invariant (frozen budget; shrink only).
-  {
-    module: 'workers/api/src/product-promises.ts',
-    route: '/api/public/product-promises',
-    status: 'legacy_missing_staleness_contract',
-  },
   {
     module: 'workers/api/src/public-otec-proof.ts',
     route: '/api/public/proof/otec',
@@ -832,7 +832,7 @@ const publicProjectionSurfaces = [
   },
 ]
 
-const PUBLIC_PROJECTION_LEGACY_BUDGET = 17
+const PUBLIC_PROJECTION_LEGACY_BUDGET = 16
 
 const normalizedPublicRoute = value =>
   value.replaceAll('\\', '').replace(/\/+$/, '')

--- a/apps/openagents.com/scripts/public-projection-freshness-allowlist.json
+++ b/apps/openagents.com/scripts/public-projection-freshness-allowlist.json
@@ -20,11 +20,6 @@
     "reason": "Grandfathered public discovery projection; add generatedAt and an explicit staleness contract before removing this entry."
   },
   {
-    "surface": "/api/public/product-promises -> ProductPromises",
-    "issueRef": "OpenAgentsInc/openagents#4751",
-    "reason": "Grandfathered registry projection; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."
-  },
-  {
     "surface": "/api/public/pylon-capacity-funnel -> PublicPylonCapacityFunnel",
     "issueRef": "OpenAgentsInc/openagents#4751",
     "reason": "Grandfathered public capacity funnel; add generatedAt or lastRebuiltAt and an explicit staleness contract before removing this entry."


### PR DESCRIPTION

Problem

`/api/public/product-promises` already serves `generatedAt`, `registryVersion`, `maxStalenessSeconds`, and the `projection_staleness.v1` live_at_read contract from `publicProductPromisesDocument()`, and the route schema test asserts that shape. The public freshness allowlist and zero-debt architecture ledger still classified the route as grandfathered / legacy-missing-staleness.

Behavior-preserving claim

This is a guard/inventory ratchet only. It does not change the public payload, registry contents, promise states, receipt feed, operator routes, payment behavior, or deployment behavior.

Files touched

- `apps/openagents.com/scripts/public-projection-freshness-allowlist.json`
- `apps/openagents.com/scripts/check-zero-debt-architecture.mjs`
- `apps/openagents.com/INVARIANTS.md`

Validation

- `bun run --cwd apps/openagents.com check:public-projection-freshness`
- `bun run --cwd apps/openagents.com check:architecture`
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/openagents-openapi-routes.test.ts`
- `CHROME_PATH="/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" bun run --cwd apps/openagents.com check:deploy`
- `git diff --check`

Why this reduces maintenance/proof risk

The root product-promise scoreboard is the surface agents and verifiers are told to trust. This PR makes the existing freshness contract enforced by the inventory instead of hidden behind a stale grandfather entry, and lowers the frozen legacy projection budget from 17 to 16.

Intentionally not changed

- No payload behavior change
- No registry state change
- No promise color change or green flip
- No transition receipt backfill
- No operator route or auth change
- No payment, wallet, payout, or settlement behavior

Forum claim

Claimed before coding in the raid thread: https://openagents.com/forum/t/d8fa3ef8-e8ba-4779-a783-b462db46c6c1/39
