### PR TITLE
Add Tassadar architecture receipt projection

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -33,6 +33,10 @@ import {
   handleTrainingAblationDeriskingLedgerApi,
 } from './training-ablation-derisking-ledger-routes'
 import {
+  TassadarPerceptaArchitectureReceiptsEndpoint,
+  handleTassadarPerceptaArchitectureReceiptsApi,
+} from './tassadar-percepta-architecture-receipts-routes'
+import {
   MarketplaceComposeListEndpoint,
   handleMarketplaceCompositionApi,
   isMarketplaceComposeAndListEnabled,
@@ -8045,6 +8049,16 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     // execution, spend, settlement, model promotion, or green claim.
     path: TrainingAblationDeriskingLedgerEndpoint,
     handler: request => handleTrainingAblationDeriskingLedgerApi(request),
+  },
+  {
+    // Tassadar Percepta executor architecture receipts (#5523 / DE-5 #5528;
+    // promise models.tassadar_percepta_executor.v1, red). Read-only refs and
+    // digest projection: clears only the architecture-receipt blocker while
+    // Pylon CPU-transform training receipts remain missing. No trained model,
+    // inference endpoint, spend, settlement, promotion, or green claim.
+    path: TassadarPerceptaArchitectureReceiptsEndpoint,
+    handler: request =>
+      handleTassadarPerceptaArchitectureReceiptsApi(request),
   },
   {
     path: '/api/public/demand-provenance',

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -159,6 +159,13 @@ describe('OpenAgents OpenAPI route', () => {
       ).operationId,
     ).toBe('getTrainingAblationDeriskingLedger')
     expect(
+      operationAt(
+        body,
+        '/api/public/models/tassadar-percepta-executor/architecture-receipts',
+        'get',
+      ).operationId,
+    ).toBe('getTassadarPerceptaArchitectureReceipts')
+    expect(
       operationAt(body, '/api/public/tassadar-run-summary', 'get').operationId,
     ).toBe('getPublicTassadarRunSummary')
     const activityTimelineOperation = operationAt(

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -21,6 +21,7 @@ import { ForumPostBodyTextMaxLength } from './forum-limits'
 import { OmniApiSdkSeedEndpoint } from './omni-api-sdk-seed'
 import { PublicProductPromisesVersion } from './product-promises'
 import { PublicLaunchDashboardEndpoint } from './public-launch-dashboard'
+import { TassadarPerceptaArchitectureReceiptsEndpoint } from './tassadar-percepta-architecture-receipts'
 import { TrainingAblationDeriskingLedgerEndpoint } from './training-ablation-derisking-ledger'
 
 export const OpenAgentsOpenApiEndpoint = '/api/openapi.json'
@@ -365,6 +366,92 @@ export const TrainingAblationDeriskingLedgerEnvelope: JsonSchema = {
   },
 }
 
+export const TassadarPerceptaArchitectureReceiptsEnvelope: JsonSchema = {
+  type: 'object',
+  additionalProperties: true,
+  description:
+    'Public-safe architecture-receipts projection for models.tassadar_percepta_executor.v1. Carries generatedAt, a live_at_read staleness contract, one architecture receipt bundle with compiled-executor, learned-interface, verifier, and artifact-lineage components, plus explicit gate fields showing architectureReceiptsAvailable=true, pylonCpuTransformTrainingReceiptsAvailable=false, and greenGateSatisfied=false. It exposes refs and digests only: no raw traces, private runner logs, provider payloads, wallet material, payment material, trained-model claim, inference endpoint, model promotion, or CPU-transform training claim.',
+  required: [
+    'authorityBoundary',
+    'endpoint',
+    'gate',
+    'generatedAt',
+    'promiseRef',
+    'promiseState',
+    'receiptSummary',
+    'receipts',
+    'schemaVersion',
+    'sourceRefs',
+    'staleness',
+    'status',
+    'unsafeCopy',
+  ],
+  properties: {
+    authorityBoundary: { type: 'string' },
+    endpoint: {
+      type: 'string',
+      enum: [TassadarPerceptaArchitectureReceiptsEndpoint],
+    },
+    gate: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'architectureReceiptsAvailable',
+        'clearsBlockerRefs',
+        'greenGateSatisfied',
+        'pylonCpuTransformTrainingReceiptsAvailable',
+        'publicProjectionAvailable',
+        'remainingBlockerRefs',
+      ],
+      properties: {
+        architectureReceiptsAvailable: { type: 'boolean' },
+        clearsBlockerRefs: { type: 'array', items: { type: 'string' } },
+        greenGateSatisfied: { type: 'boolean' },
+        pylonCpuTransformTrainingReceiptsAvailable: { type: 'boolean' },
+        publicProjectionAvailable: { type: 'boolean' },
+        remainingBlockerRefs: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    generatedAt: { type: 'string' },
+    promiseRef: { type: 'string' },
+    promiseState: { type: 'string', enum: ['red'] },
+    receiptSummary: {
+      type: 'object',
+      additionalProperties: true,
+    },
+    receipts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: true,
+        required: [
+          'receiptRef',
+          'receiptState',
+          'architectureFamily',
+          'components',
+          'clearsBlockerRefs',
+          'blockerRefs',
+          'authorityBoundary',
+        ],
+        properties: {
+          architectureFamily: { type: 'string' },
+          authorityBoundary: { type: 'string' },
+          blockerRefs: { type: 'array', items: { type: 'string' } },
+          clearsBlockerRefs: { type: 'array', items: { type: 'string' } },
+          components: { type: 'array', items: { type: 'object' } },
+          receiptRef: { type: 'string' },
+          receiptState: { type: 'string' },
+        },
+      },
+    },
+    schemaVersion: { type: 'string' },
+    sourceRefs: { type: 'array', items: { type: 'string' } },
+    staleness: { type: 'object' },
+    status: { type: 'string' },
+    unsafeCopy: { type: 'string' },
+  },
+}
+
 const hygieneDebtReceiptRef = (description: string): JsonSchema => ({
   type: 'string',
   minLength: 1,
@@ -641,6 +728,7 @@ const schemaComponents = (): JsonSchema => ({
     'Public-safe CS336 per-assignment leaderboard envelope keyed by lanes such as a1_loss, a2_throughput, a3_isoflop, a4_eval_delta, and a5_accuracy. Rows rank only verified closeout-backed entries, expose public-safe contributor refs, receipt refs, provenance labels, settledPayoutSats linked only from provider-confirmed settlement receipts, and source refs, and exclude unverified results from ranking. Pending, offered, claimed, or wallet-side records never count as paid.',
   ),
   TrainingAblationDeriskingLedgerEnvelope,
+  TassadarPerceptaArchitectureReceiptsEnvelope,
   TrainingA2DeviceCapabilityDashboardEnvelope: objectSummary(
     'Public-safe CS336 A2 device-capability dashboard envelope with anonymized device-class distributions, benchmark measurement refs, statistical cross-check state, blocker refs, privacy boundary refs, earning estimates explicitly labeled modeled-from-measured, and thermalThrottleSignals derived only from sustained_vs_burst_throughput_ratio rows. Each distribution carries a measurementProvenance (settled_cross_checked or measured_unsettled) and a crossCheckState; measured_unsettled rows are genuinely measured but not paid and not cross-check verified (verified:false, no earning estimate). The envelope reports observedDeviceClassCount (total observed classes), observedSettledDeviceClassCount (classes with at least one settled, cross-checked, verified row), thermalThrottleDetectionStatus, and thermalThrottleBlockerRefs. It excludes device identifiers, owner linkage, wallet material, payment material, and raw benchmark payloads.',
   ),
@@ -4636,6 +4724,23 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Training ablation derisking ledger.',
           '#/components/schemas/TrainingAblationDeriskingLedgerEnvelope',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  [TassadarPerceptaArchitectureReceiptsEndpoint]: {
+    get: operation({
+      operationId: 'getTassadarPerceptaArchitectureReceipts',
+      summary: 'Read Tassadar Percepta executor architecture receipts',
+      description:
+        'Returns the public-safe architecture-receipts projection for models.tassadar_percepta_executor.v1. The receipt bundle ties the public model profile to compiled/frozen executor refs, learned-interface refs, artifact-lineage hashes, and verifier refs. It clears only the architecture-receipt blocker; Pylon CPU-transform training receipts remain missing and greenGateSatisfied remains false. Read-only; grants no training dispatch, spend, settlement, model promotion, inference endpoint, CPU-transform training claim, or green product-promise authority.',
+      tags: ['Training', 'Public Proof'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Tassadar Percepta executor architecture receipts.',
+          '#/components/schemas/TassadarPerceptaArchitectureReceiptsEnvelope',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.27')
+    expect(decoded.version).toBe('2026-06-20.28')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -225,6 +225,10 @@ describe('public product promises document', () => {
     // eval_suite_reproduction_missing by projecting the retained Psion
     // checkpoint-eval decision; paid ablation dispatch remains blocked, so
     // green remains exactly 24.
+    // The 2026-06-20.28 Tassadar Percepta architecture-receipt pass clears
+    // only percepta_executor_architecture_receipts_missing by projecting a
+    // refs-only architecture bundle; CPU-transform training receipts remain
+    // blocked, so green remains exactly 24.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -488,16 +492,18 @@ describe('public product promises document', () => {
           evidenceRefs: expect.arrayContaining([
             'docs/2026-06-12-episode-236-training-launch-gap-audit.md',
             'docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md',
+            'docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md',
+            'route:/api/public/models/tassadar-percepta-executor/architecture-receipts',
+            'apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.ts',
           ]),
           blockerRefs: [
-            'blocker.product_promises.percepta_executor_architecture_receipts_missing',
             'blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing',
           ],
           safeCopy: expect.stringContaining(
-            'model/spec boundary is now written down',
+            'architecture receipt projection is now live',
           ),
           verification: expect.stringContaining(
-            'tassadar_model_spec_missing',
+            'percepta_executor_architecture_receipts_missing',
           ),
         }),
         expect.objectContaining({
@@ -968,12 +974,12 @@ describe('public product promises document', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.27', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.28', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.27',
+      expectedVersion: '2026-06-20.28',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.27',
+      servedVersion: '2026-06-20.28',
       status: 'ready',
     })
     expect(
@@ -983,7 +989,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.27',
+      servedVersion: '2026-06-20.28',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.27'
+export const PublicProductPromisesVersion = '2026-06-20.28'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -24,6 +24,7 @@ const sourceRefs = [
   'docs/training/2026-06-12-pluralis-to-pylon-adaptation-roadmap.md',
   'docs/training/2026-06-20-cs336-a2-thermal-throttle-classifier.md',
   'docs/training/2026-06-20-ablation-eval-reproduction-receipt.md',
+  'docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md',
   'docs/2026-06-10-cs336-distributed-homework-continuation-audit.md',
   'docs/forum/2026-06-09-forum-mdk-webhook-reconciliation-audit.md',
   'docs/refactor/path-to-bolt-12.md',
@@ -805,26 +806,28 @@ export const publicProductPromisesDocument = () => {
         claim:
           'The Tassadar model direction uses a Percepta Executor Class architecture, with CPU computation transformation support added to Pylon v1.0 for experimental training.',
         safeCopy:
-          'Episode 236 names a Tassadar/Percepta Executor Class direction. The public model/spec boundary is now written down in docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md: model name, runtime boundary, Pylon integration shape, training/eval plan, artifact-lineage requirements, and safety notes. Treat Pylon integration receipts, architecture receipts, CPU-transform training receipts, and public model evidence as unresolved until receipts exist. The bounded executor proof of concept is green (compute.tassadar_executor_poc.v1) but proves exact replay only, not a model. The 2026-06-14 W3 student-program report validated the frozen-analytic-executor-plus-learned-interface research direction (baseline D reached exact-rollout pass@1 while purely-learned baselines failed) but is explicitly research/evaluation only: it creates no public model claim and does not move this promise.',
+          'Episode 236 names a Tassadar/Percepta Executor Class direction. The public model/spec boundary is written down in docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md, and a public-safe architecture receipt projection is now live at GET /api/public/models/tassadar-percepta-executor/architecture-receipts with receipt.models.tassadar_percepta_executor.architecture.bundle.v1 tying the model profile to Psionic compiled-executor bundles, the W3 baseline-D frozen-executor learned-interface receipt, artifact-lineage hashes, and exact-trace verifier refs. Treat Pylon CPU-transform training receipts and public model evidence as unresolved until receipts exist. The bounded executor proof of concept is green (compute.tassadar_executor_poc.v1) but proves exact replay only, not a model. The 2026-06-14 W3 student-program report validated the frozen-analytic-executor-plus-learned-interface research direction (baseline D reached exact-rollout pass@1 while purely-learned baselines failed) but is explicitly research/evaluation only: it creates no trained-model claim and does not make this promise green.',
         unsafeCopy:
-          'Do not claim a Tassadar trained model exists, is trained, outperforms CPUs, replaces a CPU, or is earning contributors Bitcoin, and do not present the W3 student-program results or the executor PoC as proof of a trained Percepta model.',
+          'Do not claim a Tassadar trained model exists, is trained, outperforms CPUs, replaces a CPU, has run Pylon CPU-transform training, or is earning contributors Bitcoin, and do not present the architecture receipt, W3 student-program results, or executor PoC as proof of a trained Percepta model.',
         evidenceRefs: [
           'docs/transcripts/236.md',
           'docs/2026-06-12-episode-236-training-launch-gap-audit.md',
           'docs/promises/2026-06-14-registry-reality-reconciliation-audit.md',
           'docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md',
+          'docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md',
+          'route:/api/public/models/tassadar-percepta-executor/architecture-receipts',
+          'apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.ts',
           'docs/tassadar/2026-06-14-w3-student-program-report.md',
           'promise:compute.tassadar_executor_poc.v1',
           'promise:artanis.tassadar_evolution_loop.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.percepta_executor_architecture_receipts_missing',
           'blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing',
         ],
         verification:
-          'The public model/spec boundary is now documented at docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md: model name, runtime boundary, Pylon integration shape, staged training/eval plan, artifact-lineage requirements, safety notes, and remaining receipt gates. This clears blocker.product_promises.tassadar_model_spec_missing. Green still requires Percepta executor architecture receipts and Pylon CPU-transform training receipts carrying public-safe refs for model profile/config/checkpoint/eval digests, accepted work, verifier verdicts, and settlement where real money moved.',
+          'The public model/spec boundary is documented at docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md, and the architecture receipt projection at /api/public/models/tassadar-percepta-executor/architecture-receipts now carries receipt.models.tassadar_percepta_executor.architecture.bundle.v1 with public-safe refs for the model profile, Psionic compiled/frozen executor components, W3 baseline-D learned-interface components, checkpoint/interface/eval digests, and exact-trace verifier refs. This clears blocker.product_promises.tassadar_model_spec_missing and blocker.product_promises.percepta_executor_architecture_receipts_missing. Green still requires Pylon CPU-transform training receipts carrying assignment refs, accepted work, verifier verdicts, and settlement where real money moved.',
         authorityBoundary:
-          'The scoped Tassadar executor PoC proves bounded exact replay only; it does not prove a model-training architecture, general model capability, or paid earning path.',
+          'The scoped Tassadar executor PoC and architecture receipts prove bounded exact replay plus public architecture lineage only; they do not prove a trained model, Pylon CPU-transform training, general model capability, inference endpoint, settlement, or paid earning path.',
       },
       {
         ...basePromiseFields,
@@ -3509,6 +3512,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.25 is a models.tassadar_percepta_executor.v1 model/spec pass and flips NO promise state (stays red, green count unchanged at 24). docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md now names the Tassadar Percepta Executor lane, its runtime boundary, Pylon integration shape, staged training/eval plan, artifact-lineage requirements, safety notes, and remaining receipt gates. This clears blocker.product_promises.tassadar_model_spec_missing only. The remaining blockers are blocker.product_promises.percepta_executor_architecture_receipts_missing and blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing. No trained model, architecture receipt, CPU-transform training receipt, inference endpoint, settlement, model promotion, or model-capability claim is created.',
         'Registry 2026-06-20.26 is a training.device_capability_dataset.v1 thermal-classifier pass and flips NO promise state (stays yellow, green count unchanged at 24). GET /api/training/device-capabilities/a2 and each A2 run-level dataset projection now expose thermalThrottleSignals, thermalThrottleDetectionStatus, and thermalThrottleBlockerRefs derived only from admitted sustained_vs_burst_throughput_ratio rows. The deterministic rule uses the existing 0.8 sustained-vs-burst ratio floor: verified rows below the floor report thermal_throttle_observed; verified rows at or above it report thermal_throttle_not_observed; measured_unsettled or otherwise unverified rows report needs_verified_thermal_probe; missing rows report missing. The product blocker blocker.product_promises.thermal_throttle_detection_missing STAYS because no live production contributor row currently reports a verified sustained-vs-burst thermal probe, and this is a projection classifier, not continuous fleet monitoring. blocker.product_promises.same_host_replication_caveat is untouched. No paid assignment, verification verdict, settlement, earning estimate, green flip, or capability claim is created. Evidence: docs/training/2026-06-20-cs336-a2-thermal-throttle-classifier.md.',
         'Registry 2026-06-20.27 is a training.ablation_system.v1 eval-reproduction pass and flips NO promise state (stays planned, green count unchanged at 24). GET /api/public/training/ablation-derisking-ledger now carries evalReproductionReceipts with one retained Psion actual-pretraining checkpoint-eval decision projected as receipt.training_ablation.eval_reproduction.psion_actual_checkpoint_eval.v1, source schema psion.actual_pretraining_checkpoint_eval_decision.v1, frozen checkpoint eval pack benchmark://psion/actual_pretraining/checkpoint_eval@2026.04.02, four gates passed, aggregatePassRateBps 10000, aggregateScoreBps 8532, decisionState continue. This clears blocker.product_promises.eval_suite_reproduction_missing only. The promise remains planned on blocker.product_promises.paid_ablation_dispatch_missing: no OpenAgents ablation cell has been dispatched as paid work, no assignment settled, no ablation verdict was accepted, and no model promotion or training-decision claim is created. Evidence: docs/training/2026-06-20-ablation-eval-reproduction-receipt.md.',
+        'Registry 2026-06-20.28 is a models.tassadar_percepta_executor.v1 architecture-receipt pass and flips NO promise state (stays red, green count unchanged at 24). GET /api/public/models/tassadar-percepta-executor/architecture-receipts now serves a public-safe, live-at-read architecture receipt bundle receipt.models.tassadar_percepta_executor.architecture.bundle.v1 tying the model profile to Psionic compiled-executor bundles, the W3 baseline-D frozen-executor learned-interface receipt, artifact-lineage hashes, and exact-trace verifier refs. This clears blocker.product_promises.percepta_executor_architecture_receipts_missing only. The promise remains red on blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing: no Pylon CPU-transform training assignment has run, no accepted work or verifier verdict exists for that training path, no settlement moved, and no trained-model, inference, model-promotion, or capability claim is created. Evidence: docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md.',
       'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }

--- a/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts-routes.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts-routes.ts
@@ -1,0 +1,18 @@
+import { Effect } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import {
+  TassadarPerceptaArchitectureReceiptsEndpoint,
+  projectTassadarPerceptaArchitectureReceipts,
+} from './tassadar-percepta-architecture-receipts'
+
+export { TassadarPerceptaArchitectureReceiptsEndpoint }
+
+export const handleTassadarPerceptaArchitectureReceiptsApi = (
+  request: Request,
+) =>
+  request.method !== 'GET'
+    ? Effect.succeed(methodNotAllowed(['GET']))
+    : Effect.succeed(
+        noStoreJsonResponse(projectTassadarPerceptaArchitectureReceipts()),
+      )

--- a/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.test.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.test.ts
@@ -1,0 +1,150 @@
+import { Effect, Schema as S } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  TassadarPerceptaArchitectureReceiptBlocker,
+  TassadarPerceptaArchitectureReceiptsEndpoint,
+  TassadarPerceptaArchitectureReceiptsProjection,
+  TassadarPerceptaArchitectureReceiptRef,
+  TassadarPerceptaCpuTransformTrainingReceiptBlocker,
+  projectTassadarPerceptaArchitectureReceipts,
+} from './tassadar-percepta-architecture-receipts'
+import { handleTassadarPerceptaArchitectureReceiptsApi } from './tassadar-percepta-architecture-receipts-routes'
+
+type ArchitectureReceiptsBody = Readonly<{
+  endpoint: string
+  gate: Readonly<{
+    architectureReceiptsAvailable: boolean
+    greenGateSatisfied: boolean
+    pylonCpuTransformTrainingReceiptsAvailable: boolean
+  }>
+  promiseRef: string
+  promiseState: string
+}>
+
+describe('Tassadar Percepta architecture receipts projection', () => {
+  test('publishes architecture receipts without claiming a trained model', () => {
+    const projection = projectTassadarPerceptaArchitectureReceipts({
+      generatedAt: '2026-06-20T12:00:00.000Z',
+    })
+
+    expect(
+      S.decodeUnknownSync(TassadarPerceptaArchitectureReceiptsProjection)(
+        projection,
+      ),
+    ).toEqual(projection)
+    expect(projection.endpoint).toBe(
+      TassadarPerceptaArchitectureReceiptsEndpoint,
+    )
+    expect(projection.promiseRef).toBe(
+      'promise:models.tassadar_percepta_executor.v1',
+    )
+    expect(projection.promiseState).toBe('red')
+    expect(projection.staleness).toMatchObject({
+      composition: 'live_at_read',
+      contractVersion: 'projection_staleness.v1',
+      maxStalenessSeconds: 0,
+    })
+    expect(projection.gate).toEqual({
+      architectureReceiptsAvailable: true,
+      clearsBlockerRefs: [TassadarPerceptaArchitectureReceiptBlocker],
+      greenGateSatisfied: false,
+      pylonCpuTransformTrainingReceiptsAvailable: false,
+      publicProjectionAvailable: true,
+      remainingBlockerRefs: [
+        TassadarPerceptaCpuTransformTrainingReceiptBlocker,
+      ],
+    })
+    expect(projection.receiptSummary).toMatchObject({
+      architectureReceiptCount: 1,
+      componentCount: 4,
+      compiledExecutorDeploymentCount: 12,
+      greenGateSatisfied: false,
+      learnedInterfaceReceiptCount: 1,
+    })
+    expect(projection.receipts[0]).toMatchObject({
+      architectureFamily: 'percepta_executor_hybrid',
+      receiptRef: TassadarPerceptaArchitectureReceiptRef,
+      receiptState: 'available',
+      publicSafe: true,
+      learnedInterfaceMetrics: {
+        baselineRef: 'baseline_d_frozen_executor_learned_interface',
+        exactRolloutPassAt1Bps: 10000,
+        outputDigestMatchBps: 10000,
+        replayVerifierAcceptanceBps: 10000,
+      },
+      compiledExecutorCoverage: {
+        deploymentCount: 12,
+        exactnessPosture: 'exact_trace_and_output',
+        traceAbiRef: 'tassadar.trace.v1',
+      },
+    })
+    expect(projection.receipts[0]?.clearsBlockerRefs).toEqual([
+      TassadarPerceptaArchitectureReceiptBlocker,
+    ])
+    expect(projection.receipts[0]?.blockerRefs).toEqual([])
+    expect(
+      projection.receipts[0]?.components.map(component => component.componentKind),
+    ).toEqual([
+      'compiled_executor_bundle',
+      'learned_interface_bundle',
+      'verification_boundary',
+      'artifact_lineage',
+    ])
+    expect(JSON.stringify(projection)).toContain(
+      'fixtures/tassadar/w3_student_sweep_20260612/d/eval-report.json',
+    )
+    expect(JSON.stringify(projection)).toContain(
+      'compiled_kernel_suite_v0/deployments/forward_branch_kernel_branches_2/model_descriptor.json',
+    )
+  })
+
+  test('keeps authority and private material out of the public projection', () => {
+    const projection = projectTassadarPerceptaArchitectureReceipts({
+      generatedAt: '2026-06-20T12:00:00.000Z',
+    })
+    const serialized = JSON.stringify(projection)
+
+    expect(projection.authorityBoundary).toContain('grants no')
+    expect(projection.unsafeCopy).toContain('Do not claim a trained')
+    expect(serialized).not.toMatch(
+      /wallet|invoice|preimage|payment_hash|secret|raw_prompt|private_repo|\/home\/|\/Users\//i,
+    )
+    expect(serialized).not.toContain('Apple-M5-Max')
+  })
+
+  test('serves the public architecture receipt route as no-store JSON', async () => {
+    const response = await Effect.runPromise(
+      handleTassadarPerceptaArchitectureReceiptsApi(
+        new Request(
+          `https://openagents.com${TassadarPerceptaArchitectureReceiptsEndpoint}`,
+        ),
+      ),
+    )
+    const body = (await response.json()) as ArchitectureReceiptsBody
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body.endpoint).toBe(TassadarPerceptaArchitectureReceiptsEndpoint)
+    expect(body.promiseRef).toBe(
+      'promise:models.tassadar_percepta_executor.v1',
+    )
+    expect(body.promiseState).toBe('red')
+    expect(body.gate.architectureReceiptsAvailable).toBe(true)
+    expect(body.gate.pylonCpuTransformTrainingReceiptsAvailable).toBe(false)
+    expect(body.gate.greenGateSatisfied).toBe(false)
+  })
+
+  test('rejects non-GET methods', async () => {
+    const response = await Effect.runPromise(
+      handleTassadarPerceptaArchitectureReceiptsApi(
+        new Request(
+          `https://openagents.com${TassadarPerceptaArchitectureReceiptsEndpoint}`,
+          { method: 'POST' },
+        ),
+      ),
+    )
+
+    expect(response.status).toBe(405)
+  })
+})

--- a/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.ts
@@ -1,0 +1,395 @@
+import { Schema as S } from 'effect'
+
+import {
+  PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const TassadarPerceptaArchitectureReceiptsEndpoint =
+  '/api/public/models/tassadar-percepta-executor/architecture-receipts'
+export const TassadarPerceptaArchitectureReceiptsSchemaVersion =
+  'openagents.models.tassadar_percepta_executor.architecture_receipts.v1'
+export const TassadarPerceptaArchitectureReceiptRef =
+  'receipt.models.tassadar_percepta_executor.architecture.bundle.v1'
+export const TassadarPerceptaArchitectureReceiptsStaleness =
+  liveAtReadStaleness([
+    'tassadar_percepta_architecture_receipt_published',
+    'product_promise_registry_updated',
+  ])
+
+export const TassadarPerceptaArchitectureReceiptBlocker =
+  'blocker.product_promises.percepta_executor_architecture_receipts_missing'
+export const TassadarPerceptaCpuTransformTrainingReceiptBlocker =
+  'blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing'
+
+const unsafePublicMaterialPattern =
+  /(\"?(deviceId|deviceRef|nodeId|nodeRef|ownerId|ownerRef|pylonId|pylonRef|wallet[A-Za-z0-9_-]*|mnemonic|payment[A-Za-z0-9_-]*|preimage|invoice|bolt11|bolt12|lno1|secret[A-Za-z0-9_-]*|private[A-Za-z0-9_-]*)\"?\s*:|\/Users\/|\/home\/|api[_-]?key|bearer|lnbc|lntb|lno1|mnemonic|payment[_-]?(hash|preimage)|preimage|raw[_-]?(dataset|invoice|payment|payload|prompt|runner)|seed[_-]?phrase|sk-[a-z0-9]|wallet[_-]?(home|path|seed|mnemonic|private))/i
+
+const entryRefs = (
+  refs: ReadonlyArray<string>,
+): ReadonlyArray<string> => [...new Set(refs)].sort()
+
+export class TassadarPerceptaArchitectureReceiptsUnsafe extends Error {
+  readonly _tag = 'TassadarPerceptaArchitectureReceiptsUnsafe'
+}
+
+const assertPublicSafeValue = (label: string, value: unknown): void => {
+  if (unsafePublicMaterialPattern.test(JSON.stringify(value))) {
+    throw new TassadarPerceptaArchitectureReceiptsUnsafe(
+      `${label} contains material that is not public-safe.`,
+    )
+  }
+}
+
+export class TassadarPerceptaArchitectureComponent extends S.Class<TassadarPerceptaArchitectureComponent>(
+  'TassadarPerceptaArchitectureComponent',
+)({
+  caveatRefs: S.Array(S.String),
+  componentKind: S.Literals([
+    'compiled_executor_bundle',
+    'learned_interface_bundle',
+    'verification_boundary',
+    'artifact_lineage',
+  ]),
+  componentRef: S.String,
+  digestRefs: S.Array(S.String),
+  evidenceRefs: S.Array(S.String),
+  evidenceState: S.Literals([
+    'receipted_architecture_component',
+    'green_substrate',
+    'research_evaluation_receipt',
+  ]),
+  sourceRefs: S.Array(S.String),
+  summary: S.String,
+}) {}
+
+export class TassadarPerceptaArchitectureReceipt extends S.Class<TassadarPerceptaArchitectureReceipt>(
+  'TassadarPerceptaArchitectureReceipt',
+)({
+  architectureFamily: S.Literal('percepta_executor_hybrid'),
+  artifactLineage: S.Struct({
+    corpusManifestRefs: S.Array(S.String),
+    evalReportDigestRefs: S.Array(S.String),
+    learnedInterfaceDigestRefs: S.Array(S.String),
+    modelDescriptorRefs: S.Array(S.String),
+    verifierRefs: S.Array(S.String),
+  }),
+  authorityBoundary: S.String,
+  blockerRefs: S.Array(S.String),
+  caveatRefs: S.Array(S.String),
+  clearsBlockerRefs: S.Array(S.String),
+  compiledExecutorCoverage: S.Struct({
+    deploymentCount: S.Int,
+    exactnessPosture: S.Literal('exact_trace_and_output'),
+    profileRef: S.String,
+    sampleModelRef: S.String,
+    traceAbiRef: S.String,
+  }),
+  components: S.Array(TassadarPerceptaArchitectureComponent),
+  evidenceRefs: S.Array(S.String),
+  learnedInterfaceMetrics: S.Struct({
+    baselineRef: S.Literal(
+      'baseline_d_frozen_executor_learned_interface',
+    ),
+    exactRolloutPassAt1Bps: S.Int,
+    outputDigestMatchBps: S.Int,
+    replayVerifierAcceptanceBps: S.Int,
+    validPrefixMedianTokens: S.Int,
+  }),
+  modelProfileRef: S.String,
+  publicSafe: S.Literal(true),
+  receiptRef: S.Literal(TassadarPerceptaArchitectureReceiptRef),
+  receiptState: S.Literal('available'),
+  sourceRefs: S.Array(S.String),
+  unsafeCopy: S.String,
+}) {}
+
+export class TassadarPerceptaArchitectureReceiptsProjection extends S.Class<TassadarPerceptaArchitectureReceiptsProjection>(
+  'TassadarPerceptaArchitectureReceiptsProjection',
+)({
+  authorityBoundary: S.String,
+  endpoint: S.Literal(TassadarPerceptaArchitectureReceiptsEndpoint),
+  gate: S.Struct({
+    architectureReceiptsAvailable: S.Boolean,
+    clearsBlockerRefs: S.Array(S.String),
+    greenGateSatisfied: S.Boolean,
+    pylonCpuTransformTrainingReceiptsAvailable: S.Boolean,
+    publicProjectionAvailable: S.Boolean,
+    remainingBlockerRefs: S.Array(S.String),
+  }),
+  generatedAt: S.String,
+  promiseRef: S.Literal('promise:models.tassadar_percepta_executor.v1'),
+  promiseState: S.Literal('red'),
+  receiptSummary: S.Struct({
+    architectureReceiptCount: S.Int,
+    componentCount: S.Int,
+    compiledExecutorDeploymentCount: S.Int,
+    greenGateSatisfied: S.Boolean,
+    learnedInterfaceReceiptCount: S.Int,
+  }),
+  receipts: S.Array(TassadarPerceptaArchitectureReceipt),
+  schemaVersion: S.Literal(
+    TassadarPerceptaArchitectureReceiptsSchemaVersion,
+  ),
+  sourceRefs: S.Array(S.String),
+  staleness: PublicProjectionStalenessContract,
+  status: S.Literal('architecture_receipts_available'),
+  statusLabel: S.String,
+  unsafeCopy: S.String,
+}) {}
+
+const githubPsionicRef = (path: string): string =>
+  `https://github.com/OpenAgentsInc/psionic/blob/main/${path}`
+
+const githubPsionicTreeRef = (path: string): string =>
+  `https://github.com/OpenAgentsInc/psionic/tree/main/${path}`
+
+const buildArchitectureReceipt = (): TassadarPerceptaArchitectureReceipt => {
+  const compiledExecutorComponent =
+    new TassadarPerceptaArchitectureComponent({
+      caveatRefs: [
+        'caveat.models.tassadar.compiled_executor_fixture_not_trained_model',
+        'caveat.models.tassadar.hardware_validation_not_product_training',
+      ],
+      componentKind: 'compiled_executor_bundle',
+      componentRef: 'component.tassadar.compiled_kernel_suite_v0',
+      digestRefs: [
+        'model_descriptor.sha256.9057b23d919da7e6ca427baea9e0850c96368fb22709a188f9e7ff961f76bb70',
+        'trace_digest.5f9ad09571337c94b01dfd1fb09954784d0a025bcad384a72182982169771af9',
+        'weights.sha256.369d740e4acb6a75bc4dca9513a75efcaf8cd8f89aecd6108d62a7b88b5467c9',
+      ],
+      evidenceRefs: [
+        'receipt.models.tassadar.compiled_executor.kernel_suite_v0',
+        'model.tassadar-executor-article-i32-compute-v0-compiled-tassadar.compiled_kernel_suite.forward_branch.count_2.v1',
+        'tassadar://trace/compile-forward_branch_kernel_branches_2.compiled_executor/5f9ad09571337c94b01dfd1fb09954784d0a025bcad384a72182982169771af9',
+      ],
+      evidenceState: 'receipted_architecture_component',
+      sourceRefs: [
+        githubPsionicTreeRef(
+          'fixtures/tassadar/runs/compiled_kernel_suite_v0/deployments',
+        ),
+        githubPsionicRef(
+          'fixtures/tassadar/runs/compiled_kernel_suite_v0/deployments/forward_branch_kernel_branches_2/model_descriptor.json',
+        ),
+        githubPsionicRef(
+          'fixtures/tassadar/runs/compiled_kernel_suite_v0/deployments/forward_branch_kernel_branches_2/compile_evidence_bundle.json',
+        ),
+        githubPsionicRef(
+          'fixtures/tassadar/runs/compiled_kernel_suite_v0/deployments/forward_branch_kernel_branches_2/runtime_execution_proof_bundle.json',
+        ),
+      ],
+      summary:
+        'Psionic compiled-kernel suite contains 12 compiled executor deployments with model descriptors, trace ABI refs, compile evidence bundles, and runtime execution proof bundles.',
+    })
+  const learnedInterfaceComponent =
+    new TassadarPerceptaArchitectureComponent({
+      caveatRefs: [
+        'caveat.models.tassadar.w3_research_evaluation_not_product_model',
+      ],
+      componentKind: 'learned_interface_bundle',
+      componentRef:
+        'component.tassadar.w3_baseline_d_frozen_executor_learned_interface',
+      digestRefs: [
+        'dataset.sha256.d045a53d0cecbe6ffb1b4f0c1522ab76b02014491842f1770d34c12a885c8c3a',
+        'interface.sha256.1743636ec83c9592a85cbb7f293c480b810fbcf764ca94ec76b39669a13ee6bb',
+        'checkpoint.sha256.9eb153e360f576770a6de0e50abd07fbb6ece1237c80b08d2bf6c4ffbb6d0217',
+        'eval_report.sha256.a9b2bf9d95228d69f33f9dc4826d14536e3a70ddd15bb6d6b243888c3baebfd5',
+      ],
+      evidenceRefs: [
+        'receipt.models.tassadar.w3_student_sweep.baseline_d_frozen_interface.v1',
+        'corpus.tassadar_trace.v0_2.w3_100m',
+        'baseline_d_frozen_executor_learned_interface',
+      ],
+      evidenceState: 'research_evaluation_receipt',
+      sourceRefs: [
+        'docs/tassadar/2026-06-14-w3-student-program-report.md',
+        githubPsionicRef('fixtures/tassadar/w3_student_sweep_20260612/manifest.json'),
+        githubPsionicRef('fixtures/tassadar/w3_student_sweep_20260612/d/receipt.json'),
+        githubPsionicRef(
+          'fixtures/tassadar/w3_student_sweep_20260612/d/eval-report.json',
+        ),
+      ],
+      summary:
+        'W3 baseline D binds a frozen analytic executor to a learned interface and records checkpoint/interface/config/eval digests plus exact-rollout and replay-verifier metrics.',
+    })
+  const verifierComponent = new TassadarPerceptaArchitectureComponent({
+    caveatRefs: [
+      'caveat.models.tassadar.executor_poc_not_general_model_capability',
+    ],
+    componentKind: 'verification_boundary',
+    componentRef: 'component.tassadar.exact_trace_replay_boundary',
+    digestRefs: [],
+    evidenceRefs: [
+      'promise:compute.tassadar_executor_poc.v1',
+      'verifier_class.exact_trace_replay',
+      'packages/tassadar-executor/src/replay.ts',
+    ],
+    evidenceState: 'green_substrate',
+    sourceRefs: [
+      'docs/tassadar/2026-06-18-tassadar-run-actual-state-and-real-training-gap-audit.md',
+      'packages/tassadar-executor/src/replay.ts',
+      'promise:compute.tassadar_executor_poc.v1',
+    ],
+    summary:
+      'The architecture receipt is bounded by the existing exact-trace-replay verifier substrate; verifier success does not promote a product model.',
+  })
+  const artifactLineageComponent =
+    new TassadarPerceptaArchitectureComponent({
+      caveatRefs: [
+        'caveat.models.tassadar.lineage_refs_only_no_raw_artifact_export',
+      ],
+      componentKind: 'artifact_lineage',
+      componentRef: 'component.tassadar.percepta_executor_lineage_refs',
+      digestRefs: [
+        'train_prep.sha256.8095588b05ff1bc3b8a723431c35015882a25566f74d895b514071f5e1734350',
+        'eval_prep.sha256.512830dcbdd4f8e4842adbf1960522c70e8609475581aa4936f6424b4981102b',
+      ],
+      evidenceRefs: [
+        'docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md',
+        'docs/tassadar/2026-06-14-w3-student-program-report.md',
+        'receipt.models.tassadar.compiled_executor.kernel_suite_v0',
+      ],
+      evidenceState: 'receipted_architecture_component',
+      sourceRefs: [
+        'docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md',
+        'docs/tassadar/2026-06-14-w3-student-program-report.md',
+        githubPsionicTreeRef('fixtures/tassadar/w3_student_sweep_20260612'),
+        githubPsionicTreeRef('fixtures/tassadar/runs/compiled_kernel_suite_v0'),
+      ],
+      summary:
+        'The public architecture bundle links model profile, compiled/frozen executor components, learned-interface components, eval digests, and verifier refs without exposing raw traces or runner logs.',
+    })
+
+  const components = [
+    compiledExecutorComponent,
+    learnedInterfaceComponent,
+    verifierComponent,
+    artifactLineageComponent,
+  ]
+
+  const receipt = new TassadarPerceptaArchitectureReceipt({
+    architectureFamily: 'percepta_executor_hybrid',
+    artifactLineage: {
+      corpusManifestRefs: ['corpus.tassadar_trace.v0_2.w3_100m'],
+      evalReportDigestRefs: [
+        'eval_report.sha256.a9b2bf9d95228d69f33f9dc4826d14536e3a70ddd15bb6d6b243888c3baebfd5',
+      ],
+      learnedInterfaceDigestRefs: [
+        'interface.sha256.1743636ec83c9592a85cbb7f293c480b810fbcf764ca94ec76b39669a13ee6bb',
+        'checkpoint.sha256.9eb153e360f576770a6de0e50abd07fbb6ece1237c80b08d2bf6c4ffbb6d0217',
+      ],
+      modelDescriptorRefs: [
+        'model.tassadar-executor-article-i32-compute-v0-compiled-tassadar.compiled_kernel_suite.forward_branch.count_2.v1',
+      ],
+      verifierRefs: [
+        'verifier_class.exact_trace_replay',
+        'promise:compute.tassadar_executor_poc.v1',
+      ],
+    },
+    authorityBoundary:
+      'This architecture receipt proves only that the Tassadar Percepta Executor direction has public-safe model-profile, compiled/frozen executor, learned-interface, artifact-lineage, and verifier refs. It grants no trained-model, inference, dispatch, spend, settlement, model-promotion, CPU-transform training, or public green-claim authority.',
+    blockerRefs: [],
+    caveatRefs: [
+      'caveat.models.tassadar.architecture_receipt_not_trained_model',
+      'caveat.models.tassadar.architecture_receipt_not_pylon_cpu_transform_training',
+      'caveat.models.tassadar.no_model_promotion_or_inference_endpoint',
+    ],
+    clearsBlockerRefs: [TassadarPerceptaArchitectureReceiptBlocker],
+    compiledExecutorCoverage: {
+      deploymentCount: 12,
+      exactnessPosture: 'exact_trace_and_output',
+      profileRef: 'tassadar.wasm.article_i32_compute.v1',
+      sampleModelRef:
+        'tassadar-executor-article-i32-compute-v0-compiled-tassadar.compiled_kernel_suite.forward_branch.count_2.v1',
+      traceAbiRef: 'tassadar.trace.v1',
+    },
+    components,
+    evidenceRefs: entryRefs([
+      TassadarPerceptaArchitectureReceiptRef,
+      ...components.flatMap(component => component.evidenceRefs),
+      ...components.flatMap(component => component.digestRefs),
+    ]),
+    learnedInterfaceMetrics: {
+      baselineRef: 'baseline_d_frozen_executor_learned_interface',
+      exactRolloutPassAt1Bps: 10000,
+      outputDigestMatchBps: 10000,
+      replayVerifierAcceptanceBps: 10000,
+      validPrefixMedianTokens: 10240,
+    },
+    modelProfileRef: 'model_profile.tassadar_percepta_executor.v1',
+    publicSafe: true,
+    receiptRef: TassadarPerceptaArchitectureReceiptRef,
+    receiptState: 'available',
+    sourceRefs: entryRefs(components.flatMap(component => component.sourceRefs)),
+    unsafeCopy:
+      'Do not claim a trained Tassadar model exists, that Pylon CPU-transform training has run, that public contributors trained this model, that an inference endpoint exists, or that this architecture receipt makes the red promise green.',
+  })
+
+  assertPublicSafeValue('Tassadar Percepta architecture receipt', receipt)
+
+  return receipt
+}
+
+export const projectTassadarPerceptaArchitectureReceipts = (
+  input: { generatedAt?: string | undefined } = {},
+): TassadarPerceptaArchitectureReceiptsProjection => {
+  const receipts = [buildArchitectureReceipt()]
+  const componentCount = receipts.reduce(
+    (count, receipt) => count + receipt.components.length,
+    0,
+  )
+
+  const projection = new TassadarPerceptaArchitectureReceiptsProjection({
+    authorityBoundary:
+      'Read-only public architecture-receipt projection for models.tassadar_percepta_executor.v1. It narrows one product-promise blocker by publishing refs and digests only; it grants no dispatch, spend, settlement, model-promotion, inference, CPU-transform training, or green-claim authority.',
+    endpoint: TassadarPerceptaArchitectureReceiptsEndpoint,
+    gate: {
+      architectureReceiptsAvailable: true,
+      clearsBlockerRefs: [TassadarPerceptaArchitectureReceiptBlocker],
+      greenGateSatisfied: false,
+      pylonCpuTransformTrainingReceiptsAvailable: false,
+      publicProjectionAvailable: true,
+      remainingBlockerRefs: [
+        TassadarPerceptaCpuTransformTrainingReceiptBlocker,
+      ],
+    },
+    generatedAt: input.generatedAt ?? currentIsoTimestamp(),
+    promiseRef: 'promise:models.tassadar_percepta_executor.v1',
+    promiseState: 'red',
+    receiptSummary: {
+      architectureReceiptCount: receipts.length,
+      componentCount,
+      compiledExecutorDeploymentCount:
+        receipts[0]?.compiledExecutorCoverage.deploymentCount ?? 0,
+      greenGateSatisfied: false,
+      learnedInterfaceReceiptCount: receipts.filter(receipt =>
+        receipt.components.some(
+          component => component.componentKind === 'learned_interface_bundle',
+        ),
+      ).length,
+    },
+    receipts,
+    schemaVersion: TassadarPerceptaArchitectureReceiptsSchemaVersion,
+    sourceRefs: entryRefs([
+      'docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md',
+      'docs/tassadar/2026-06-14-w3-student-program-report.md',
+      'docs/tassadar/2026-06-18-tassadar-run-actual-state-and-real-training-gap-audit.md',
+      'apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.ts',
+      ...receipts.flatMap(receipt => receipt.sourceRefs),
+    ]),
+    staleness: TassadarPerceptaArchitectureReceiptsStaleness,
+    status: 'architecture_receipts_available',
+    statusLabel:
+      'Tassadar Percepta executor architecture receipts are available; Pylon CPU-transform training receipts remain missing.',
+    unsafeCopy:
+      'Do not claim a trained Tassadar Percepta model, public contributor CPU-transform training, an inference endpoint, settlement, model promotion, or a green promise. This projection clears only the architecture-receipt blocker.',
+  })
+
+  assertPublicSafeValue(
+    'Tassadar Percepta architecture receipts projection',
+    projection,
+  )
+
+  return projection
+}

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -17,6 +17,7 @@ const approvedExactRoutePaths = [
   '/api/public/product-promises/audit',
   '/api/public/metrics/accepted-outcomes-per-kwh',
   '/api/public/training/ablation-derisking-ledger',
+  '/api/public/models/tassadar-percepta-executor/architecture-receipts',
   '/api/public/demand-provenance',
   '/api/public/markets/open-markets',
   '/api/public/markets/liquidity/skeleton',

--- a/docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md
+++ b/docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md
@@ -1,0 +1,49 @@
+# Tassadar Percepta Architecture Receipt
+
+Date: 2026-06-20
+
+Promise: `models.tassadar_percepta_executor.v1`
+
+Public route:
+`/api/public/models/tassadar-percepta-executor/architecture-receipts`
+
+Receipt ref:
+`receipt.models.tassadar_percepta_executor.architecture.bundle.v1`
+
+## What This Clears
+
+This clears only:
+
+- `blocker.product_promises.percepta_executor_architecture_receipts_missing`
+
+The promise stays red because the remaining blocker is still real:
+
+- `blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing`
+
+## Receipt Contents
+
+The public projection binds the Tassadar Percepta Executor direction to four
+public-safe component sets:
+
+1. Psionic compiled-executor bundles:
+   `fixtures/tassadar/runs/compiled_kernel_suite_v0/deployments/`
+2. W3 baseline-D frozen-executor learned-interface artifacts:
+   `fixtures/tassadar/w3_student_sweep_20260612/`
+3. The exact-trace replay verifier boundary:
+   `promise:compute.tassadar_executor_poc.v1`
+4. Artifact-lineage refs from the model/spec and W3 report.
+
+The route exposes refs and digests only: model profile refs, compiled/frozen
+executor refs, learned-interface refs, checkpoint/interface/eval hashes, and
+verifier refs.
+
+## Boundaries
+
+This is not a trained-model receipt. It is not a Pylon CPU-transform training
+receipt. It does not create an inference endpoint, model promotion, settlement,
+paid contributor claim, or green product-promise transition.
+
+Green still requires Pylon CPU-transform training receipts with assignment
+refs, accepted work refs, verifier verdict refs, and settlement refs where real
+money moved, followed by owner-signed receipt-first upgrade under
+`proof.claim_upgrade_receipts.v1`.


### PR DESCRIPTION
## Summary

- adds a public-safe `/api/public/models/tassadar-percepta-executor/architecture-receipts` projection for `models.tassadar_percepta_executor.v1`
- publishes `receipt.models.tassadar_percepta_executor.architecture.bundle.v1` over Psionic compiled-executor refs, W3 baseline-D learned-interface refs, lineage hashes, and exact-trace verifier refs
- bumps product promises to `2026-06-20.28`, clears only `blocker.product_promises.percepta_executor_architecture_receipts_missing`, and leaves `blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing`

## Verification

- `bunx vitest run src/tassadar-percepta-architecture-receipts.test.ts src/openagents-openapi-routes.test.ts src/worker-exact-routes.test.ts src/product-promises.test.ts`
- `bun run check:deploy`
