### PR TITLE
Add training full pipeline status projection

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -33,6 +33,10 @@ import {
   handleTrainingAblationDeriskingLedgerApi,
 } from './training-ablation-derisking-ledger-routes'
 import {
+  TrainingFullPipelineProgramEndpoint,
+  handleTrainingFullPipelineProgramApi,
+} from './training-full-pipeline-program-routes'
+import {
   TrainingPostTrainingInstructSftEndpoint,
   handleTrainingPostTrainingInstructSftApi,
 } from './training-post-training-instruct-sft-routes'
@@ -8044,6 +8048,15 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
   {
     path: '/api/public/metrics/accepted-outcomes-per-kwh',
     handler: request => handleAcceptedOutcomesPerKwhApi(request),
+  },
+  {
+    // Full training-pipeline program status (#5523 / DE-5 #5528; promise
+    // training.full_pipeline_program.v1, planned). Read-only stage map: exposes
+    // current stage receipt surfaces and blockers while keeping the umbrella
+    // blocker active. No dispatch, spend, settlement, model promotion, or green
+    // claim.
+    path: TrainingFullPipelineProgramEndpoint,
+    handler: request => handleTrainingFullPipelineProgramApi(request),
   },
   {
     // Training ablation derisking ledger projection (#5523 / DE-5 #5528;

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -154,6 +154,13 @@ describe('OpenAgents OpenAPI route', () => {
     expect(
       operationAt(
         body,
+        '/api/public/training/full-pipeline-program',
+        'get',
+      ).operationId,
+    ).toBe('getTrainingFullPipelineProgramStatus')
+    expect(
+      operationAt(
+        body,
         '/api/public/training/ablation-derisking-ledger',
         'get',
       ).operationId,

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -23,6 +23,7 @@ import { PublicProductPromisesVersion } from './product-promises'
 import { PublicLaunchDashboardEndpoint } from './public-launch-dashboard'
 import { TassadarPerceptaArchitectureReceiptsEndpoint } from './tassadar-percepta-architecture-receipts'
 import { TrainingAblationDeriskingLedgerEndpoint } from './training-ablation-derisking-ledger'
+import { TrainingFullPipelineProgramEndpoint } from './training-full-pipeline-program'
 import { TrainingPostTrainingInstructSftEndpoint } from './training-post-training-instruct-sft'
 
 export const OpenAgentsOpenApiEndpoint = '/api/openapi.json'
@@ -453,6 +454,100 @@ export const TassadarPerceptaArchitectureReceiptsEnvelope: JsonSchema = {
   },
 }
 
+export const TrainingFullPipelineProgramEnvelope: JsonSchema = {
+  type: 'object',
+  additionalProperties: true,
+  description:
+    'Public-safe full training-pipeline program status projection for training.full_pipeline_program.v1. Carries generatedAt, registryVersion, a live_at_read staleness contract, stage rows for the DE-5 training workstreams, endpoint refs, evidence refs, blocker refs, and a gate that keeps endToEndRunReceiptAvailable=false, ladderRungEndToEndReceiptAvailable=false, paidNetworkWorkloadBroadlyLive=false, and greenGateSatisfied=false until the remaining stage receipts exist. It exposes refs and status only: no raw datasets, private runner logs, provider payloads, wallet material, payment material, dispatch authority, settlement, model promotion, or green product-promise authority.',
+  required: [
+    'authorityBoundary',
+    'endpoint',
+    'gate',
+    'generatedAt',
+    'promiseRef',
+    'promiseState',
+    'registryVersion',
+    'schemaVersion',
+    'sourceRefs',
+    'stageSummary',
+    'stages',
+    'staleness',
+    'status',
+    'unsafeCopy',
+  ],
+  properties: {
+    authorityBoundary: { type: 'string' },
+    endpoint: {
+      type: 'string',
+      enum: [TrainingFullPipelineProgramEndpoint],
+    },
+    gate: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'endToEndRunReceiptAvailable',
+        'everyWorkstreamAtLeastYellow',
+        'greenGateSatisfied',
+        'ladderRungEndToEndReceiptAvailable',
+        'paidNetworkWorkloadBroadlyLive',
+        'publicProjectionAvailable',
+        'remainingBlockerRefs',
+      ],
+      properties: {
+        endToEndRunReceiptAvailable: { type: 'boolean' },
+        everyWorkstreamAtLeastYellow: { type: 'boolean' },
+        greenGateSatisfied: { type: 'boolean' },
+        ladderRungEndToEndReceiptAvailable: { type: 'boolean' },
+        paidNetworkWorkloadBroadlyLive: { type: 'boolean' },
+        publicProjectionAvailable: { type: 'boolean' },
+        remainingBlockerRefs: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    generatedAt: { type: 'string' },
+    promiseRef: {
+      type: 'string',
+      enum: ['promise:training.full_pipeline_program.v1'],
+    },
+    promiseState: { type: 'string', enum: ['planned'] },
+    registryVersion: { type: 'string' },
+    schemaVersion: { type: 'string' },
+    sourceRefs: { type: 'array', items: { type: 'string' } },
+    stageSummary: { type: 'object', additionalProperties: true },
+    stages: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: true,
+        required: [
+          'blockerRefs',
+          'endpointRefs',
+          'evidenceRefs',
+          'promiseId',
+          'promiseState',
+          'receiptState',
+          'role',
+          'stageId',
+          'statusLabel',
+        ],
+        properties: {
+          blockerRefs: { type: 'array', items: { type: 'string' } },
+          endpointRefs: { type: 'array', items: { type: 'string' } },
+          evidenceRefs: { type: 'array', items: { type: 'string' } },
+          promiseId: { type: 'string' },
+          promiseState: { type: 'string' },
+          receiptState: { type: 'string' },
+          role: { type: 'string' },
+          stageId: { type: 'string' },
+          statusLabel: { type: 'string' },
+        },
+      },
+    },
+    staleness: { type: 'object' },
+    status: { type: 'string' },
+    unsafeCopy: { type: 'string' },
+  },
+}
+
 export const TrainingPostTrainingInstructSftEnvelope: JsonSchema = {
   type: 'object',
   additionalProperties: true,
@@ -837,6 +932,7 @@ const schemaComponents = (): JsonSchema => ({
   TrainingLeaderboardsEnvelope: objectSummary(
     'Public-safe CS336 per-assignment leaderboard envelope keyed by lanes such as a1_loss, a2_throughput, a3_isoflop, a4_eval_delta, and a5_accuracy. Rows rank only verified closeout-backed entries, expose public-safe contributor refs, receipt refs, provenance labels, settledPayoutSats linked only from provider-confirmed settlement receipts, and source refs, and exclude unverified results from ranking. Pending, offered, claimed, or wallet-side records never count as paid.',
   ),
+  TrainingFullPipelineProgramEnvelope,
   TrainingAblationDeriskingLedgerEnvelope,
   TassadarPerceptaArchitectureReceiptsEnvelope,
   TrainingPostTrainingInstructSftEnvelope,
@@ -4818,6 +4914,23 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Public training-run settlement rows.',
           '#/components/schemas/TrainingRunSettlementsEnvelope',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  [TrainingFullPipelineProgramEndpoint]: {
+    get: operation({
+      operationId: 'getTrainingFullPipelineProgramStatus',
+      summary: 'Read full training-pipeline program status',
+      description:
+        'Returns the public-safe full training-pipeline program status projection for training.full_pipeline_program.v1. It maps the current DE-5 training workstreams to their promise states, endpoint refs, evidence refs, receipt-surface state, and blocker refs, while keeping greenGateSatisfied=false and the umbrella training_pipeline_rails_incomplete blocker active. Read-only; grants no training-dispatch, spend, settlement, canonical-checkpoint mutation, model-promotion, model-service, or public-claim authority.',
+      tags: ['Training', 'Public Proof'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Full training-pipeline program status.',
+          '#/components/schemas/TrainingFullPipelineProgramEnvelope',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.31')
+    expect(decoded.version).toBe('2026-06-20.32')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -242,6 +242,9 @@ describe('public product promises document', () => {
     // The 2026-06-20.31 fixture-sync receipt pass clears only the fixture-sync
     // blocker; paid dispatch, preference rollout, and vibe-test gates remain
     // blocked, so green remains exactly 24.
+    // The 2026-06-20.32 full-pipeline program pass adds a public stage-status
+    // projection but keeps training_pipeline_rails_incomplete active, so green
+    // remains exactly 24.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -309,7 +312,18 @@ describe('public product promises document', () => {
           state: 'planned',
           evidenceRefs: expect.arrayContaining([
             'docs/training/2026-06-10-psion-full-pipeline-buildout-plan.md',
+            'docs/training/2026-06-20-training-full-pipeline-program-status.md',
+            'route:/api/public/training/full-pipeline-program',
+            'apps/openagents.com/workers/api/src/training-full-pipeline-program.ts',
+            'apps/openagents.com/workers/api/src/training-full-pipeline-program.test.ts',
           ]),
+          blockerRefs: [
+            'blocker.product_promises.training_pipeline_rails_incomplete',
+          ],
+          safeCopy: expect.stringContaining(
+            '/api/public/training/full-pipeline-program',
+          ),
+          verification: expect.stringContaining('greenGateSatisfied=false'),
         }),
         expect.objectContaining({
           promiseId: 'training.ablation_system.v1',
@@ -1054,12 +1068,12 @@ describe('public product promises document', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.31', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.32', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.31',
+      expectedVersion: '2026-06-20.32',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.31',
+      servedVersion: '2026-06-20.32',
       status: 'ready',
     })
     expect(
@@ -1069,7 +1083,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.31',
+      servedVersion: '2026-06-20.32',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.31'
+export const PublicProductPromisesVersion = '2026-06-20.32'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -27,6 +27,7 @@ const sourceRefs = [
   'docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md',
   'docs/training/2026-06-20-psion-instruct-sft-lane-receipt.md',
   'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
+  'docs/training/2026-06-20-training-full-pipeline-program-status.md',
   'docs/2026-06-10-cs336-distributed-homework-continuation-audit.md',
   'docs/forum/2026-06-09-forum-mdk-webhook-reconciliation-audit.md',
   'docs/refactor/path-to-bolt-12.md',
@@ -1704,13 +1705,17 @@ export const publicProductPromisesDocument = () => {
         claim:
           'OpenAgents will operate a full owned LLM training pipeline — data refinery, ablation system, architecture derisking, marathon operations, post-training, and infrastructure measurement — as paid, verified work on the Pylon network.',
         safeCopy:
-          'A written buildout plan exists (docs/training/2026-06-10-psion-full-pipeline-buildout-plan.md) extending the CS336 program (#4673-#4684) with the Smol Training Playbook as operational reference; psionic holds bounded CS336 reference lanes and a retained tri-host pretraining rehearsal. No full pipeline stage is live as a broadly paid network workload.',
+          'A written buildout plan exists (docs/training/2026-06-10-psion-full-pipeline-buildout-plan.md) extending the CS336 program (#4673-#4684) with the Smol Training Playbook as operational reference, and a public status projection is live at GET /api/public/training/full-pipeline-program. The projection maps the DE-5 stage promises to current route/evidence/blocker status: ablation, device-capability, verification-class, Artanis, architecture, and instruct-SFT receipt surfaces are visible, while public gradients, marathon operations, paid corpus work, paid ablations, paid SFT/preference work, and R1+ ladder rungs remain incomplete. No full pipeline stage is live as a broadly paid network workload.',
         unsafeCopy:
           'Do not claim OpenAgents currently operates an end-to-end training pipeline, trains world-class or frontier-class models, or that the network is training models for buyers.',
         evidenceRefs: [
           'docs/training/2026-06-10-psion-full-pipeline-buildout-plan.md',
           'docs/2026-06-10-cs336-distributed-homework-continuation-audit.md',
           'docs/training/2026-06-12-pluralis-to-pylon-adaptation-roadmap.md',
+          'docs/training/2026-06-20-training-full-pipeline-program-status.md',
+          'route:/api/public/training/full-pipeline-program',
+          'apps/openagents.com/workers/api/src/training-full-pipeline-program.ts',
+          'apps/openagents.com/workers/api/src/training-full-pipeline-program.test.ts',
           'https://github.com/OpenAgentsInc/openagents/issues/4855',
           'https://github.com/OpenAgentsInc/psionic/tree/main/docs/smol',
           'https://github.com/OpenAgentsInc/psionic/blob/main/docs/PSION_ACTUAL_PRETRAINING_RUNBOOK.md',
@@ -1719,7 +1724,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.training_pipeline_rails_incomplete',
         ],
         verification:
-          'This umbrella promise tracks the program; each workstream and ladder rung carries its own training.* promise with its own evidence. Green requires every workstream promise at green or yellow plus at least one ladder rung completed end to end with public receipts.',
+          'This umbrella promise tracks the program; each workstream and ladder rung carries its own training.* promise with its own evidence. GET /api/public/training/full-pipeline-program is a live-at-read stage-status projection that reports each DE-5 stage promise, endpoint refs, evidence refs, receipt-surface state, and blocker refs, with greenGateSatisfied=false and remainingBlockerRefs=[training_pipeline_rails_incomplete]. It does not clear the umbrella blocker because several workstreams are still planned/red and no R1+ rung has completed end to end. Green requires every workstream promise at green or yellow plus at least one ladder rung completed end to end with public receipts.',
         authorityBoundary:
           'A written plan grants no capability, training, payout, or settlement authority, and does not move any other promise. Internal pipeline demand is plumbing proof, not market proof.',
       },
@@ -3532,6 +3537,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.29 is a training.post_training_arc.v1 instruct-SFT lane receipt pass and flips NO promise state (stays planned, green count unchanged at 24). GET /api/public/training/post-training-arc/instruct-sft-lane now serves a public-safe, live-at-read receipt receipt.training.post_training_arc.instruct_sft_lane.psion_fixture.v1 for the bounded Psionic lane psion_instruct_sft_v1: owned chat template, assistant-token generation mask, repo-owned example corpus, deterministic smoke run, and bit-exact resume drill from deterministic generator output. This clears blocker.product_promises.instruct_sft_lane_missing only by replacing it with sharper blockers: blocker.product_promises.instruct_sft_fixture_sync_missing for the current Psionic committed-report drift from generator output, and blocker.product_promises.instruct_sft_paid_dispatch_missing for the missing paid OpenAgents SFT assignment. The promise remains planned because no paid OpenAgents SFT assignment has run, preference/DPO pairwise rollout work is still missing, and no reviewed vibe-test closeout artifact exists. No assignment, spend, settlement, instruct model, fine-tuning service, preference optimization, model promotion, or green claim is created. Evidence: docs/training/2026-06-20-psion-instruct-sft-lane-receipt.md.',
         'Registry 2026-06-20.30 partially advances autopilot.decision_queue.v1 on blocker.product_promises.receipt_backed_command_closeout_missing and flips NO promise state (stays planned, green count unchanged at 24). Adds DecisionCloseoutReceipt (packages/autopilot-control-protocol/src/decision-closeout-receipt.ts) — the canonical, tamper-verifiable receipt type for a resolved remote Pylon bridge decision: captures requestId (exactly-once key), actionRef, verb (approve/deny/answer), terminal outcome (applied/duplicate/expired/revoked/stale/unauthorized/unsupported/error), client surface (desktop/web/expo), actor, decidedAt, hasAnswer, and a deterministic line reconstructed by validateDecisionCloseoutReceipt for audit integrity. 20 tests across all terminal outcomes, all client surfaces, answer-verb hasAnswer, terminal-vs-transient classification, and field-tamper detection. Transient outcomes (offline/overloaded) excluded by type — the queue replays them on drain. No receipt storage layer, no HTTP surface change, no end-to-end proof: the remaining gap on receipt_backed_command_closeout_missing is a persistent store and at least one live receipt from a real paired-node resolution. decision_queue_api_missing and cross_client_exactly_once_decisions_missing remain fully open. Evidence: docs/launch/vertex-fleet/autopilot.decision_queue.v1.md.',
         'Registry 2026-06-20.31 is a training.post_training_arc.v1 fixture-sync receipt pass and flips NO promise state (stays planned, green count unchanged at 24). Psionic PR #1132 synchronizes the committed fixtures/psion/instruct/psion_instruct_sft_lane_report_v1.json report with deterministic generator output, and scripts/check-psion-instruct-sft-lane.sh now verifies the committed fixture with report digest sha256:76b5524234b4dd6507560c0cda6f28e782fe097c1fb022108aaaae40794d6871. GET /api/public/training/post-training-arc/instruct-sft-lane now reports committedReportFixtureSyncAvailable=true and drops blocker.product_promises.instruct_sft_fixture_sync_missing only. The promise remains planned because no paid OpenAgents SFT assignment has run, preference/DPO pairwise rollout work is still missing, and no reviewed vibe-test closeout artifact exists. No assignment, spend, settlement, instruct model, fine-tuning service, preference optimization, model promotion, or green claim is created. Evidence: docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md and https://github.com/OpenAgentsInc/psionic/pull/1132.',
+        'Registry 2026-06-20.32 is a training.full_pipeline_program.v1 stage-status projection pass and flips NO promise state (stays planned, green count unchanged at 24). GET /api/public/training/full-pipeline-program now serves a public-safe, live-at-read map of DE-5 training stages to their promise state, endpoint refs, evidence refs, receipt-surface state, and blocker refs. It makes the umbrella program auditable without widening the claim: greenGateSatisfied=false, endToEndRunReceiptAvailable=false, ladderRungEndToEndReceiptAvailable=false, paidNetworkWorkloadBroadlyLive=false, and blocker.product_promises.training_pipeline_rails_incomplete remains. No training dispatch, corpus admission, public-gradient acceptance, checkpoint mutation, spend, settlement, model promotion, service claim, or green transition is created. Evidence: docs/training/2026-06-20-training-full-pipeline-program-status.md.',
       'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }

--- a/apps/openagents.com/workers/api/src/training-full-pipeline-program-routes.ts
+++ b/apps/openagents.com/workers/api/src/training-full-pipeline-program-routes.ts
@@ -1,0 +1,14 @@
+import { Effect } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import {
+  TrainingFullPipelineProgramEndpoint,
+  projectTrainingFullPipelineProgram,
+} from './training-full-pipeline-program'
+
+export { TrainingFullPipelineProgramEndpoint }
+
+export const handleTrainingFullPipelineProgramApi = (request: Request) =>
+  request.method !== 'GET'
+    ? Effect.succeed(methodNotAllowed(['GET']))
+    : Effect.succeed(noStoreJsonResponse(projectTrainingFullPipelineProgram()))

--- a/apps/openagents.com/workers/api/src/training-full-pipeline-program.test.ts
+++ b/apps/openagents.com/workers/api/src/training-full-pipeline-program.test.ts
@@ -1,0 +1,164 @@
+import { Effect, Schema as S } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  TrainingFullPipelineProgramBlocker,
+  TrainingFullPipelineProgramEndpoint,
+  TrainingFullPipelineProgramProjection,
+  projectTrainingFullPipelineProgram,
+} from './training-full-pipeline-program'
+import { handleTrainingFullPipelineProgramApi } from './training-full-pipeline-program-routes'
+
+type FullPipelineBody = Readonly<{
+  endpoint: string
+  gate: Readonly<{
+    everyWorkstreamAtLeastYellow: boolean
+    greenGateSatisfied: boolean
+    ladderRungEndToEndReceiptAvailable: boolean
+    publicProjectionAvailable: boolean
+    remainingBlockerRefs: ReadonlyArray<string>
+  }>
+  promiseRef: string
+  promiseState: string
+  stageSummary: Readonly<{
+    greenReadyOwnerGatedStageCount: number
+    liveEndpointCount: number
+    partialReceiptSurfaceCount: number
+    stageCount: number
+  }>
+  stages: ReadonlyArray<{
+    blockerRefs: ReadonlyArray<string>
+    endpointRefs: ReadonlyArray<string>
+    promiseId: string
+    promiseState: string
+    receiptState: string
+    stageId: string
+  }>
+}>
+
+describe('training full pipeline program status projection', () => {
+  test('publishes stage reachability without clearing the umbrella blocker', () => {
+    const projection = projectTrainingFullPipelineProgram({
+      generatedAt: '2026-06-20T12:00:00.000Z',
+    })
+
+    expect(
+      S.decodeUnknownSync(TrainingFullPipelineProgramProjection)(projection),
+    ).toEqual(projection)
+    expect(projection.endpoint).toBe(TrainingFullPipelineProgramEndpoint)
+    expect(projection.promiseRef).toBe(
+      'promise:training.full_pipeline_program.v1',
+    )
+    expect(projection.promiseState).toBe('planned')
+    expect(projection.staleness).toMatchObject({
+      composition: 'live_at_read',
+      contractVersion: 'projection_staleness.v1',
+      maxStalenessSeconds: 0,
+    })
+    expect(projection.gate).toEqual({
+      endToEndRunReceiptAvailable: false,
+      everyWorkstreamAtLeastYellow: false,
+      greenGateSatisfied: false,
+      ladderRungEndToEndReceiptAvailable: false,
+      paidNetworkWorkloadBroadlyLive: false,
+      publicProjectionAvailable: true,
+      remainingBlockerRefs: [TrainingFullPipelineProgramBlocker],
+    })
+    expect(projection.stageSummary).toMatchObject({
+      greenReadyOwnerGatedStageCount: 1,
+      liveEndpointCount: 8,
+      partialReceiptSurfaceCount: 6,
+      stageCount: 11,
+    })
+    expect(projection.stages.map(stage => stage.stageId)).toEqual([
+      'data_refinery',
+      'ablation',
+      'public_gradient_windows',
+      'public_distributed_run',
+      'marathon_operations',
+      'post_training',
+      'model_ladder',
+      'device_capability',
+      'verification_classes',
+      'tassadar_percepta_executor',
+      'artanis_evolution_loop',
+    ])
+    expect(
+      projection.stages.find(stage => stage.stageId === 'ablation'),
+    ).toMatchObject({
+      endpointRefs: ['/api/public/training/ablation-derisking-ledger'],
+      promiseId: 'training.ablation_system.v1',
+      receiptState: 'partial_receipt_surface_live',
+    })
+    expect(
+      projection.stages.find(
+        stage => stage.stageId === 'artanis_evolution_loop',
+      ),
+    ).toMatchObject({
+      blockerRefs: [],
+      promiseId: 'artanis.tassadar_evolution_loop.v1',
+      promiseState: 'yellow',
+      receiptState: 'green_ready_owner_gated',
+    })
+  })
+
+  test('keeps authority and private material out of the public projection', () => {
+    const projection = projectTrainingFullPipelineProgram({
+      generatedAt: '2026-06-20T12:00:00.000Z',
+    })
+    const serialized = JSON.stringify(projection)
+
+    expect(projection.authorityBoundary).toContain('grants no')
+    expect(projection.unsafeCopy).toContain('Do not claim')
+    expect(serialized).not.toMatch(
+      /wallet|invoice|preimage|payment_hash|secret|raw_prompt|private_repo|\/home\/|\/Users\//i,
+    )
+  })
+
+  test('serves the public route as no-store JSON', async () => {
+    const response = await Effect.runPromise(
+      handleTrainingFullPipelineProgramApi(
+        new Request(
+          `https://openagents.com${TrainingFullPipelineProgramEndpoint}`,
+        ),
+      ),
+    )
+    const body = (await response.json()) as FullPipelineBody
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body.endpoint).toBe(TrainingFullPipelineProgramEndpoint)
+    expect(body.promiseRef).toBe('promise:training.full_pipeline_program.v1')
+    expect(body.promiseState).toBe('planned')
+    expect(body.gate.publicProjectionAvailable).toBe(true)
+    expect(body.gate.greenGateSatisfied).toBe(false)
+    expect(body.gate.remainingBlockerRefs).toEqual([
+      TrainingFullPipelineProgramBlocker,
+    ])
+    expect(body.stageSummary.stageCount).toBe(11)
+    expect(
+      body.stages.some(
+        stage =>
+          stage.stageId === 'post_training' &&
+          stage.endpointRefs.includes(
+            '/api/public/training/post-training-arc/instruct-sft-lane',
+          ),
+      ),
+    ).toBe(true)
+  })
+
+  test('rejects non-GET methods', async () => {
+    const response = await Effect.runPromise(
+      handleTrainingFullPipelineProgramApi(
+        new Request(
+          `https://openagents.com${TrainingFullPipelineProgramEndpoint}`,
+          {
+            method: 'POST',
+          },
+        ),
+      ),
+    )
+
+    expect(response.status).toBe(405)
+  })
+})

--- a/apps/openagents.com/workers/api/src/training-full-pipeline-program.ts
+++ b/apps/openagents.com/workers/api/src/training-full-pipeline-program.ts
@@ -1,0 +1,378 @@
+import { Schema as S } from 'effect'
+
+import {
+  PublicProductPromisesVersion,
+  publicProductPromisesDocument,
+} from './product-promises'
+import {
+  PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const TrainingFullPipelineProgramEndpoint =
+  '/api/public/training/full-pipeline-program'
+export const TrainingFullPipelineProgramSchemaVersion =
+  'openagents.training.full_pipeline_program.v1'
+export const TrainingFullPipelineProgramBlocker =
+  'blocker.product_promises.training_pipeline_rails_incomplete'
+
+export const TrainingFullPipelineProgramStaleness = liveAtReadStaleness([
+  'product_promise_registry_updated',
+  'training_pipeline_stage_receipt_published',
+  'training_pipeline_stage_route_published',
+])
+
+const unsafePublicMaterialPattern =
+  /(\"?(deviceId|deviceRef|nodeId|nodeRef|ownerId|ownerRef|pylonId|pylonRef|wallet[A-Za-z0-9_-]*|mnemonic|payment[A-Za-z0-9_-]*|preimage|invoice|bolt11|bolt12|lno1|secret[A-Za-z0-9_-]*|private[A-Za-z0-9_-]*)\"?\s*:|\/Users\/|\/home\/|api[_-]?key|bearer|lnbc|lntb|lno1|mnemonic|payment[_-]?(hash|preimage)|preimage|raw[_-]?(dataset|invoice|payment|payload|prompt|runner)|seed[_-]?phrase|sk-[a-z0-9]|wallet[_-]?(home|path|seed|mnemonic|private))/i
+
+const promiseStates = ['green', 'yellow', 'red', 'planned', 'degraded'] as const
+const receiptStates = [
+  'green_receipts_live',
+  'partial_receipt_surface_live',
+  'green_ready_owner_gated',
+  'methodology_only',
+  'contract_only',
+  'missing',
+] as const
+
+type PromiseState = (typeof promiseStates)[number]
+type ReceiptState = (typeof receiptStates)[number]
+
+export class TrainingFullPipelineProgramStage extends S.Class<TrainingFullPipelineProgramStage>(
+  'TrainingFullPipelineProgramStage',
+)({
+  blockerRefs: S.Array(S.String),
+  endpointRefs: S.Array(S.String),
+  evidenceRefs: S.Array(S.String),
+  promiseId: S.String,
+  promiseState: S.Literals(promiseStates),
+  receiptState: S.Literals(receiptStates),
+  role: S.String,
+  stageId: S.String,
+  statusLabel: S.String,
+}) {}
+
+export class TrainingFullPipelineProgramProjection extends S.Class<TrainingFullPipelineProgramProjection>(
+  'TrainingFullPipelineProgramProjection',
+)({
+  authorityBoundary: S.String,
+  endpoint: S.Literal(TrainingFullPipelineProgramEndpoint),
+  gate: S.Struct({
+    endToEndRunReceiptAvailable: S.Boolean,
+    everyWorkstreamAtLeastYellow: S.Boolean,
+    greenGateSatisfied: S.Boolean,
+    ladderRungEndToEndReceiptAvailable: S.Boolean,
+    paidNetworkWorkloadBroadlyLive: S.Boolean,
+    publicProjectionAvailable: S.Boolean,
+    remainingBlockerRefs: S.Array(S.String),
+  }),
+  generatedAt: S.String,
+  promiseRef: S.Literal('promise:training.full_pipeline_program.v1'),
+  promiseState: S.Literal('planned'),
+  registryVersion: S.Literal(PublicProductPromisesVersion),
+  schemaVersion: S.Literal(TrainingFullPipelineProgramSchemaVersion),
+  sourceRefs: S.Array(S.String),
+  stageSummary: S.Struct({
+    greenReadyOwnerGatedStageCount: S.Int,
+    liveEndpointCount: S.Int,
+    partialReceiptSurfaceCount: S.Int,
+    stageCount: S.Int,
+    states: S.Record(S.String, S.Int),
+  }),
+  stages: S.Array(TrainingFullPipelineProgramStage),
+  staleness: PublicProjectionStalenessContract,
+  status: S.Literal('training_pipeline_program_status_projection'),
+  statusLabel: S.String,
+  unsafeCopy: S.String,
+}) {}
+
+export class TrainingFullPipelineProgramUnsafe extends Error {
+  readonly _tag = 'TrainingFullPipelineProgramUnsafe'
+}
+
+type StageDefinition = Readonly<{
+  evidenceRefs: ReadonlyArray<string>
+  endpointRefs: ReadonlyArray<string>
+  promiseId: string
+  receiptState: ReceiptState
+  role: string
+  stageId: string
+  statusLabel: string
+}>
+
+const stageDefinitions: ReadonlyArray<StageDefinition> = [
+  {
+    endpointRefs: ['/api/training/refinery/a4'],
+    evidenceRefs: [
+      'apps/openagents.com/workers/api/src/training-data-refinery.ts',
+      'apps/openagents.com/workers/api/src/training-leaderboards.ts',
+      'apps/openagents.com/docs/2026-06-10-cs336-a4-data-refinery-payment-policy.md',
+    ],
+    promiseId: 'training.data_refinery_corpus.v1',
+    receiptState: 'partial_receipt_surface_live',
+    role: 'Corpus refinery and eval-delta lane.',
+    stageId: 'data_refinery',
+    statusLabel:
+      'A4 deterministic refinery and empty eval-delta leaderboard exist; crawl-scale paid shards and eval-delta payment remain missing.',
+  },
+  {
+    endpointRefs: ['/api/public/training/ablation-derisking-ledger'],
+    evidenceRefs: [
+      'docs/training/2026-06-20-ablation-one-delta-harness.md',
+      'docs/training/2026-06-20-ablation-eval-reproduction-receipt.md',
+    ],
+    promiseId: 'training.ablation_system.v1',
+    receiptState: 'partial_receipt_surface_live',
+    role: 'One-delta ablation harness and eval-reproduction ledger.',
+    stageId: 'ablation',
+    statusLabel:
+      'Ablation ledger, one-delta manifest checks, and retained eval reproduction are live; paid ablation dispatch remains missing.',
+  },
+  {
+    endpointRefs: [],
+    evidenceRefs: [
+      'apps/openagents.com/workers/api/src/tassadar-gradient-window-regime.ts',
+      'apps/openagents.com/workers/api/src/tassadar-gradient-window-regime.test.ts',
+    ],
+    promiseId: 'training.public_gradient_windows.v1',
+    receiptState: 'contract_only',
+    role: 'Public gradient-window quarantine, recompute, canary, promotion, and rollback gate.',
+    stageId: 'public_gradient_windows',
+    statusLabel:
+      'The promotion regime is code-backed, but no public contributor gradient window has been accepted, promoted, paid, or settled.',
+  },
+  {
+    endpointRefs: [
+      '/api/public/training/runs/run.tassadar.executor.20260615',
+      '/api/public/training/runs/run.tassadar.executor.20260615/settlements',
+    ],
+    evidenceRefs: [
+      'docs/promises/2026-06-19-training-live-run-evidence-destale.md',
+      'docs/training/2026-06-19-public-distributed-training-run-scale-methodology.md',
+    ],
+    promiseId: 'training.public_distributed_training_run.v1',
+    receiptState: 'partial_receipt_surface_live',
+    role: 'Public distributed run scale, accepted work, validation, and settlement.',
+    stageId: 'public_distributed_run',
+    statusLabel:
+      'The bounded live run has canary-scale accepted and settled receipts; network-scale broad receipts remain missing.',
+  },
+  {
+    endpointRefs: [],
+    evidenceRefs: [
+      'apps/openagents.com/workers/api/src/training-window-bootstrap.ts',
+      'apps/openagents.com/workers/api/src/training-run-window-authority.ts',
+      'docs/training/2026-06-12-pluralis-to-pylon-adaptation-roadmap.md',
+    ],
+    promiseId: 'training.marathon_operations.v1',
+    receiptState: 'contract_only',
+    role: 'Durable seals, standby contributors, restart criteria, and curtailment drill.',
+    stageId: 'marathon_operations',
+    statusLabel:
+      'Seal/bootstrap contracts exist; durable remote checkpoint storage, standby dispatch, and curtailment drill receipts remain missing.',
+  },
+  {
+    endpointRefs: ['/api/public/training/post-training-arc/instruct-sft-lane'],
+    evidenceRefs: [
+      'docs/training/2026-06-20-psion-instruct-sft-lane-receipt.md',
+      'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
+    ],
+    promiseId: 'training.post_training_arc.v1',
+    receiptState: 'partial_receipt_surface_live',
+    role: 'Instruct SFT, preference rollout, and vibe-test artifacts.',
+    stageId: 'post_training',
+    statusLabel:
+      'Fixture-scale instruct-SFT lane and fixture sync receipts exist; paid SFT dispatch, preference work, and vibe-test artifact remain missing.',
+  },
+  {
+    endpointRefs: [],
+    evidenceRefs: [
+      'docs/training/2026-06-19-model-ladder-rung-economics.md',
+      'https://github.com/OpenAgentsInc/psionic/blob/main/docs/PSION_ACTUAL_PRETRAINING_RUNBOOK.md',
+    ],
+    promiseId: 'training.model_ladder.v1',
+    receiptState: 'methodology_only',
+    role: 'R0 through R4 rung sequencing and economics gates.',
+    stageId: 'model_ladder',
+    statusLabel:
+      'R0 is retained and the R1 closeout/economics format is documented; no rung above R0 has run to a closeout receipt.',
+  },
+  {
+    endpointRefs: ['/api/training/device-capabilities/a2'],
+    evidenceRefs: [
+      'docs/training/2026-06-20-cs336-a2-second-device-class-x86_64-linux-intel.md',
+      'docs/training/2026-06-20-cs336-a2-thermal-throttle-classifier.md',
+    ],
+    promiseId: 'training.device_capability_dataset.v1',
+    receiptState: 'partial_receipt_surface_live',
+    role: 'Device-capability measurements and thermal/replication labels.',
+    stageId: 'device_capability',
+    statusLabel:
+      'The public dataset covers two observed classes and a thermal classifier; verified thermal rows and cross-machine replication remain missing.',
+  },
+  {
+    endpointRefs: [
+      '/api/public/training/verification-challenges/{challengeRef}',
+    ],
+    evidenceRefs: [
+      'docs/promises/2026-06-20-verification-class-sampling-policy.md',
+    ],
+    promiseId: 'training.verification_classes.v1',
+    receiptState: 'green_receipts_live',
+    role: 'Named verification classes on training work.',
+    stageId: 'verification_classes',
+    statusLabel:
+      'Verification-class policy is green and exact-trace replay is exercised on real paid work.',
+  },
+  {
+    endpointRefs: [
+      '/api/public/models/tassadar-percepta-executor/architecture-receipts',
+    ],
+    evidenceRefs: [
+      'docs/tassadar/2026-06-20-tassadar-percepta-executor-model-spec.md',
+      'docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md',
+    ],
+    promiseId: 'models.tassadar_percepta_executor.v1',
+    receiptState: 'partial_receipt_surface_live',
+    role: 'Tassadar Percepta executor model/spec and architecture receipts.',
+    stageId: 'tassadar_percepta_executor',
+    statusLabel:
+      'Model/spec and architecture receipts exist; Pylon CPU-transform training receipts remain missing.',
+  },
+  {
+    endpointRefs: [
+      '/api/public/artanis/tick-streak',
+      '/api/public/artanis/tassadar-distillation-dataset',
+    ],
+    evidenceRefs: [
+      'docs/training/2026-06-20-artanis-distillation-dataset-receipt.md',
+    ],
+    promiseId: 'artanis.tassadar_evolution_loop.v1',
+    receiptState: 'green_ready_owner_gated',
+    role: 'Artanis unattended tick streak and Tassadar distillation dataset.',
+    stageId: 'artanis_evolution_loop',
+    statusLabel:
+      'Both acceptance legs are receipted and blockerRefs are empty; green transition remains owner-signed.',
+  },
+]
+
+const assertPublicSafeValue = (label: string, value: unknown): void => {
+  if (unsafePublicMaterialPattern.test(JSON.stringify(value))) {
+    throw new TrainingFullPipelineProgramUnsafe(
+      `${label} contains material that is not public-safe.`,
+    )
+  }
+}
+
+const promiseById = () => {
+  const document = publicProductPromisesDocument()
+
+  return new Map(
+    document.promises.map(promise => [
+      promise.promiseId,
+      {
+        blockerRefs: promise.blockerRefs,
+        evidenceRefs: promise.evidenceRefs,
+        state: promise.state,
+      },
+    ]),
+  )
+}
+
+const toPromiseState = (state: string | undefined): PromiseState =>
+  promiseStates.find(candidate => candidate === state) ?? 'planned'
+
+const buildStages = (): ReadonlyArray<TrainingFullPipelineProgramStage> => {
+  const promises = promiseById()
+
+  return stageDefinitions.map(definition => {
+    const promise = promises.get(definition.promiseId)
+    const evidenceRefs = [
+      ...new Set([
+        ...definition.evidenceRefs,
+        ...(promise?.evidenceRefs.filter(
+          ref => ref.startsWith('route:') || ref.startsWith('docs/training/'),
+        ) ?? []),
+      ]),
+    ].sort()
+
+    return new TrainingFullPipelineProgramStage({
+      blockerRefs: [...(promise?.blockerRefs ?? [])].sort(),
+      endpointRefs: [...definition.endpointRefs].sort(),
+      evidenceRefs,
+      promiseId: definition.promiseId,
+      promiseState: toPromiseState(promise?.state),
+      receiptState: definition.receiptState,
+      role: definition.role,
+      stageId: definition.stageId,
+      statusLabel: definition.statusLabel,
+    })
+  })
+}
+
+const countByState = (
+  stages: ReadonlyArray<TrainingFullPipelineProgramStage>,
+): Record<string, number> =>
+  stages.reduce<Record<string, number>>((counts, stage) => {
+    counts[stage.promiseState] = (counts[stage.promiseState] ?? 0) + 1
+
+    return counts
+  }, {})
+
+export const projectTrainingFullPipelineProgram = (
+  input: { generatedAt?: string | undefined } = {},
+): TrainingFullPipelineProgramProjection => {
+  const stages = buildStages()
+  const everyWorkstreamAtLeastYellow = stages.every(stage =>
+    ['green', 'yellow'].includes(stage.promiseState),
+  )
+  const projection = new TrainingFullPipelineProgramProjection({
+    authorityBoundary:
+      'Read-only public training-pipeline program status projection for training.full_pipeline_program.v1. It reports stage receipts and blockers only; it grants no assignment, dispatch, spend, settlement, canonical-checkpoint mutation, model promotion, service availability, or green product-promise authority.',
+    endpoint: TrainingFullPipelineProgramEndpoint,
+    gate: {
+      endToEndRunReceiptAvailable: false,
+      everyWorkstreamAtLeastYellow,
+      greenGateSatisfied: false,
+      ladderRungEndToEndReceiptAvailable: false,
+      paidNetworkWorkloadBroadlyLive: false,
+      publicProjectionAvailable: true,
+      remainingBlockerRefs: [TrainingFullPipelineProgramBlocker],
+    },
+    generatedAt: input.generatedAt ?? currentIsoTimestamp(),
+    promiseRef: 'promise:training.full_pipeline_program.v1',
+    promiseState: 'planned',
+    registryVersion: PublicProductPromisesVersion,
+    schemaVersion: TrainingFullPipelineProgramSchemaVersion,
+    sourceRefs: [
+      'docs/training/2026-06-10-psion-full-pipeline-buildout-plan.md',
+      'docs/training/2026-06-10-training-program-status.md',
+      'docs/training/2026-06-20-training-full-pipeline-program-status.md',
+      'apps/openagents.com/workers/api/src/training-full-pipeline-program.ts',
+    ],
+    stageSummary: {
+      greenReadyOwnerGatedStageCount: stages.filter(
+        stage => stage.receiptState === 'green_ready_owner_gated',
+      ).length,
+      liveEndpointCount: stages.filter(stage => stage.endpointRefs.length > 0)
+        .length,
+      partialReceiptSurfaceCount: stages.filter(
+        stage => stage.receiptState === 'partial_receipt_surface_live',
+      ).length,
+      stageCount: stages.length,
+      states: countByState(stages),
+    },
+    stages,
+    staleness: TrainingFullPipelineProgramStaleness,
+    status: 'training_pipeline_program_status_projection',
+    statusLabel:
+      'Training pipeline stage status projection is live; the full-pipeline umbrella remains planned until every workstream is at least yellow and a ladder rung completes end to end with receipts.',
+    unsafeCopy:
+      'Do not claim OpenAgents operates an end-to-end training pipeline, that all stages are paid network workloads, that a rung above R0 has run, or that public gradients, model promotion, settlement, or full-pipeline green status are live.',
+  })
+
+  assertPublicSafeValue('Training full pipeline program projection', projection)
+
+  return projection
+}

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -16,6 +16,7 @@ const approvedExactRoutePaths = [
   '/api/public/product-promises/transitions',
   '/api/public/product-promises/audit',
   '/api/public/metrics/accepted-outcomes-per-kwh',
+  '/api/public/training/full-pipeline-program',
   '/api/public/training/ablation-derisking-ledger',
   '/api/public/training/post-training-arc/instruct-sft-lane',
   '/api/public/models/tassadar-percepta-executor/architecture-receipts',

--- a/docs/training/2026-06-20-training-full-pipeline-program-status.md
+++ b/docs/training/2026-06-20-training-full-pipeline-program-status.md
@@ -1,0 +1,58 @@
+# Training Full Pipeline Program Status Projection
+
+Date: 2026-06-20
+
+Promise: `training.full_pipeline_program.v1` (stays **planned**; no green
+flip).
+
+Registry edit: `2026-06-20.32`.
+
+Issue lineage: `OpenAgentsInc/openagents#5528`.
+
+Public route:
+`/api/public/training/full-pipeline-program`
+
+## What this clears
+
+This does not clear the umbrella blocker:
+
+- `blocker.product_promises.training_pipeline_rails_incomplete`
+
+The route is a status projection, not an end-to-end pipeline run receipt.
+
+## Receipt contents
+
+The projection maps the DE-5 training workstreams to their current public-safe
+status:
+
+- data refinery: A4 route and eval-delta lane evidence, with crawl-scale paid
+  corpus/provenance/eval-delta payment still missing.
+- ablation: public derisking ledger, one-delta harness, and retained eval
+  reproduction receipt, with paid ablation dispatch still missing.
+- public gradient windows: code-backed promotion regime only, with no accepted,
+  promoted, paid, or settled public gradient window.
+- public distributed run: bounded live run receipts below network scale.
+- marathon operations: seal/bootstrap contracts only, with durable remote
+  checkpoint, standby, and curtailment drill receipts missing.
+- post-training: instruct-SFT fixture lane and fixture-sync receipts, with paid
+  SFT dispatch, preference work, and vibe-test artifact missing.
+- model ladder: R0 retained and R1 economics/closeout format documented, with no
+  rung above R0 run to closeout.
+- device capability: A2 dataset, second observed device class, and thermal
+  classifier, with verified thermal rows and cross-machine replication missing.
+- verification classes: green receipt-backed policy.
+- Tassadar Percepta executor: model/spec and architecture receipts, with
+  Pylon CPU-transform training receipts missing.
+- Artanis evolution loop: acceptance legs receipted and blockerRefs empty,
+  pending owner-signed green transition.
+
+## Boundaries
+
+This route is read-only. It does not dispatch training work, admit a corpus
+shard, accept public gradients, mutate a checkpoint, spend, settle, promote a
+model, claim service availability, or transition any product promise.
+
+Green for `training.full_pipeline_program.v1` still requires every workstream to
+be at least yellow and at least one ladder rung completed end to end with public
+receipts, followed by the normal owner-signed receipt-first upgrade under
+`proof.claim_upgrade_receipts.v1`.


### PR DESCRIPTION
## Summary
- Adds `GET /api/public/training/full-pipeline-program`, a read-only live-at-read stage-status projection for `training.full_pipeline_program.v1`.
- Maps the current DE-5 training workstreams to promise state, endpoint refs, evidence refs, receipt-surface state, and blocker refs.
- Bumps the product-promise registry to `2026-06-20.32` while keeping `training_pipeline_rails_incomplete` active and `greenGateSatisfied=false`.

## Boundaries
- No training dispatch, corpus admission, public-gradient acceptance, checkpoint mutation, spend, settlement, model promotion, service claim, or green transition.
- `training.full_pipeline_program.v1` remains planned.

## Validation
- `bunx vitest run src/training-full-pipeline-program.test.ts src/openagents-openapi-routes.test.ts src/worker-exact-routes.test.ts src/product-promises.test.ts`
- `bun run check:deploy`
