### PR TITLE
Enforce durable checkpoint seal descriptors

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.32')
+    expect(decoded.version).toBe('2026-06-20.33')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -106,6 +106,9 @@ describe('public product promises document', () => {
     )
     expect(decoded.sourceRefs).toContain(
       'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
+    )
+    expect(decoded.sourceRefs).toContain(
+      'docs/launch/vertex-fleet/training.marathon_operations.v1.md',
     )
     expect(decoded.promises.length).toBeGreaterThan(0)
     expect(decoded.verificationSummary.promiseCount).toBe(
@@ -245,6 +248,9 @@ describe('public product promises document', () => {
     // The 2026-06-20.32 full-pipeline program pass adds a public stage-status
     // projection but keeps training_pipeline_rails_incomplete active, so green
     // remains exactly 24.
+    // The 2026-06-20.33 marathon pass binds durable-checkpoint seal evaluation
+    // into live seal/bootstrap authority but keeps real remote checkpoint,
+    // standby, and curtailment blockers active, so green remains exactly 24.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -342,6 +348,25 @@ describe('public product promises document', () => {
             '/api/public/training/ablation-derisking-ledger',
           ),
           verification: expect.stringContaining('one-delta manifest harness'),
+        }),
+        expect.objectContaining({
+          promiseId: 'training.marathon_operations.v1',
+          state: 'planned',
+          evidenceRefs: expect.arrayContaining([
+            'docs/launch/vertex-fleet/training.marathon_operations.v1.md',
+            'apps/openagents.com/workers/api/src/training-durable-checkpoint-seal.ts',
+            'apps/openagents.com/workers/api/src/training-run-window-authority.ts',
+            'apps/openagents.com/workers/api/src/training-window-bootstrap.ts',
+          ]),
+          blockerRefs: [
+            'blocker.product_promises.durable_checkpoint_seal_missing',
+            'blocker.product_promises.standby_dispatch_missing',
+            'blocker.product_promises.curtailment_drill_missing',
+          ],
+          safeCopy: expect.stringContaining('durableCheckpointSeal'),
+          verification: expect.stringContaining(
+            'no real remote content-addressed checkpoint store',
+          ),
         }),
         expect.objectContaining({
           promiseId: 'training.post_training_arc.v1',
@@ -1068,12 +1093,12 @@ describe('public product promises document', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.32', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.33', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.32',
+      expectedVersion: '2026-06-20.33',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.32',
+      servedVersion: '2026-06-20.33',
       status: 'ready',
     })
     expect(
@@ -1083,7 +1108,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.32',
+      servedVersion: '2026-06-20.33',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.32'
+export const PublicProductPromisesVersion = '2026-06-20.33'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -28,6 +28,7 @@ const sourceRefs = [
   'docs/training/2026-06-20-psion-instruct-sft-lane-receipt.md',
   'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
   'docs/training/2026-06-20-training-full-pipeline-program-status.md',
+  'docs/launch/vertex-fleet/training.marathon_operations.v1.md',
   'docs/2026-06-10-cs336-distributed-homework-continuation-audit.md',
   'docs/forum/2026-06-09-forum-mdk-webhook-reconciliation-audit.md',
   'docs/refactor/path-to-bolt-12.md',
@@ -1827,7 +1828,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Long training runs operate with marathon discipline: preflight qualification, monitoring against a reference trajectory, loss-spike triage with window rewind, durable checkpoint-sealed windows, standby contributors, written restart criteria, and a schedulable curtailment drill.',
         safeCopy:
-          'Psionic’s actual-pretraining lane has local hardware qualification, checkpoint/resume drills, and continue/hold/restart checkpoint decisions. Durable remote checkpoint storage bound into the window seal, standby-Pylon dispatch, public run monitoring against a prior rung’s eval series, restart-decision receipts, and the scheduled curtailment drill are planned. Contract-level pieces landed 2026-06-12: window-seal metadata carrying staleness, churn, and verification-overhead fields (#4849), bootstrap-from-durable-seal grants behind a seal-in-flight join barrier that fails toward queueing (#4850/#4851), and collective failure semantics with ban-for-round, partial-result preservation, and standby-gated abort (psionic#1126). Durable remote checkpoint storage, a live standby promotion, and the drill itself remain unproven.',
+          'Psionic’s actual-pretraining lane has local hardware qualification, checkpoint/resume drills, and continue/hold/restart checkpoint decisions. Durable remote checkpoint storage bound into the window seal, standby-Pylon dispatch, public run monitoring against a prior rung’s eval series, restart-decision receipts, and the scheduled curtailment drill are planned. Contract-level pieces landed 2026-06-12: window-seal metadata carrying staleness, churn, and verification-overhead fields (#4849), bootstrap-from-durable-seal grants behind a seal-in-flight join barrier that fails toward queueing (#4850/#4851), and collective failure semantics with ban-for-round, partial-result preservation, and standby-gated abort (psionic#1126). The seal boundary now requires checkpoint-backed window seals to carry a durableCheckpointSeal descriptor that passes the durable checkpoint evaluator, and bootstrap grants ignore legacy digest-only or failed-durability seal rows. A real remote checkpoint-store read-back receipt, a live standby promotion, and the drill itself remain unproven.',
         unsafeCopy:
           'Do not claim multi-day or multi-week network training runs are operationally supported, or that training load is proven dispatchable/curtailable for grid value.',
         evidenceRefs: [
@@ -1835,6 +1836,13 @@ export const publicProductPromisesDocument = () => {
           'https://github.com/OpenAgentsInc/psionic/blob/main/docs/PSION_ACTUAL_PRETRAINING_RUNBOOK.md',
           'https://github.com/OpenAgentsInc/openagents/issues/4673',
           'docs/training/2026-06-12-pluralis-to-pylon-adaptation-roadmap.md',
+          'docs/launch/vertex-fleet/training.marathon_operations.v1.md',
+          'apps/openagents.com/workers/api/src/training-durable-checkpoint-seal.ts',
+          'apps/openagents.com/workers/api/src/training-durable-checkpoint-seal.test.ts',
+          'apps/openagents.com/workers/api/src/training-run-window-authority.ts',
+          'apps/openagents.com/workers/api/src/training-run-window-authority.test.ts',
+          'apps/openagents.com/workers/api/src/training-window-bootstrap.ts',
+          'apps/openagents.com/workers/api/src/training-window-bootstrap.test.ts',
           'https://github.com/OpenAgentsInc/openagents/issues/4849',
           'https://github.com/OpenAgentsInc/openagents/issues/4850',
           'https://github.com/OpenAgentsInc/openagents/issues/4851',
@@ -1846,7 +1854,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.curtailment_drill_missing',
         ],
         verification:
-          'Green requires a window sealed only on durable content-addressed checkpoint storage, a standby contributor promoted into a live run, one restart-or-continue decision recorded as a receipt, and a scheduled drill that sheds part of the fleet on time, resumes from checkpoints, and publishes the receipt — the same drill that becomes evidence for energy.flexible_load_proof.v1.',
+          'Checkpoint-backed window seals now require a matching durableCheckpointSeal descriptor, the descriptor must pass evaluateDurableCheckpointSeal before transitionTrainingWindowRecord can seal, and selectLastDurableSealWindow ignores legacy digest-only or failed-durability rows before issuing bootstrap grants. This narrows the durable-seal path but does not clear durable_checkpoint_seal_missing: no real remote content-addressed checkpoint store has produced a read-back-and-rehash receipt yet. Green requires a window sealed only on durable content-addressed checkpoint storage backed by that real retrieval receipt, a standby contributor promoted into a live run, one restart-or-continue decision recorded as a receipt, and a scheduled drill that sheds part of the fleet on time, resumes from checkpoints, and publishes the receipt — the same drill that becomes evidence for energy.flexible_load_proof.v1.',
         authorityBoundary:
           'Marathon machinery is run-operations authority only; it does not move energy, payout, or settlement promises, and a drill receipt is not a grid-services revenue claim.',
       },
@@ -3538,7 +3546,8 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.30 partially advances autopilot.decision_queue.v1 on blocker.product_promises.receipt_backed_command_closeout_missing and flips NO promise state (stays planned, green count unchanged at 24). Adds DecisionCloseoutReceipt (packages/autopilot-control-protocol/src/decision-closeout-receipt.ts) — the canonical, tamper-verifiable receipt type for a resolved remote Pylon bridge decision: captures requestId (exactly-once key), actionRef, verb (approve/deny/answer), terminal outcome (applied/duplicate/expired/revoked/stale/unauthorized/unsupported/error), client surface (desktop/web/expo), actor, decidedAt, hasAnswer, and a deterministic line reconstructed by validateDecisionCloseoutReceipt for audit integrity. 20 tests across all terminal outcomes, all client surfaces, answer-verb hasAnswer, terminal-vs-transient classification, and field-tamper detection. Transient outcomes (offline/overloaded) excluded by type — the queue replays them on drain. No receipt storage layer, no HTTP surface change, no end-to-end proof: the remaining gap on receipt_backed_command_closeout_missing is a persistent store and at least one live receipt from a real paired-node resolution. decision_queue_api_missing and cross_client_exactly_once_decisions_missing remain fully open. Evidence: docs/launch/vertex-fleet/autopilot.decision_queue.v1.md.',
         'Registry 2026-06-20.31 is a training.post_training_arc.v1 fixture-sync receipt pass and flips NO promise state (stays planned, green count unchanged at 24). Psionic PR #1132 synchronizes the committed fixtures/psion/instruct/psion_instruct_sft_lane_report_v1.json report with deterministic generator output, and scripts/check-psion-instruct-sft-lane.sh now verifies the committed fixture with report digest sha256:76b5524234b4dd6507560c0cda6f28e782fe097c1fb022108aaaae40794d6871. GET /api/public/training/post-training-arc/instruct-sft-lane now reports committedReportFixtureSyncAvailable=true and drops blocker.product_promises.instruct_sft_fixture_sync_missing only. The promise remains planned because no paid OpenAgents SFT assignment has run, preference/DPO pairwise rollout work is still missing, and no reviewed vibe-test closeout artifact exists. No assignment, spend, settlement, instruct model, fine-tuning service, preference optimization, model promotion, or green claim is created. Evidence: docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md and https://github.com/OpenAgentsInc/psionic/pull/1132.',
         'Registry 2026-06-20.32 is a training.full_pipeline_program.v1 stage-status projection pass and flips NO promise state (stays planned, green count unchanged at 24). GET /api/public/training/full-pipeline-program now serves a public-safe, live-at-read map of DE-5 training stages to their promise state, endpoint refs, evidence refs, receipt-surface state, and blocker refs. It makes the umbrella program auditable without widening the claim: greenGateSatisfied=false, endToEndRunReceiptAvailable=false, ladderRungEndToEndReceiptAvailable=false, paidNetworkWorkloadBroadlyLive=false, and blocker.product_promises.training_pipeline_rails_incomplete remains. No training dispatch, corpus admission, public-gradient acceptance, checkpoint mutation, spend, settlement, model promotion, service claim, or green transition is created. Evidence: docs/training/2026-06-20-training-full-pipeline-program-status.md.',
-      'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
+        'Registry 2026-06-20.33 is a training.marathon_operations.v1 durable-checkpoint seal-boundary pass and flips NO promise state (stays planned, green count unchanged at 24). Checkpoint-backed window seals now require a matching durableCheckpointSeal descriptor that passes evaluateDurableCheckpointSeal before transitionTrainingWindowRecord can seal, and selectLastDurableSealWindow now ignores legacy digest-only rows and failed-durability descriptors before issuing bootstrap grants. This binds the durability predicate into the live seal/bootstrap authority, but blocker.product_promises.durable_checkpoint_seal_missing remains because no real remote content-addressed checkpoint store has produced a read-back-and-rehash receipt. standby_dispatch_missing and curtailment_drill_missing are untouched. No dispatch, spend, settlement, storage-backend, standby promotion, curtailment drill, energy claim, or green transition is created. Evidence: docs/launch/vertex-fleet/training.marathon_operations.v1.md.',
+        'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }
 

--- a/apps/openagents.com/workers/api/src/training-run-window-authority.test.ts
+++ b/apps/openagents.com/workers/api/src/training-run-window-authority.test.ts
@@ -222,6 +222,68 @@ describe('training run window authority', () => {
     expect(JSON.parse(sealed.publicProjectionJson).sealMetadata).toBeNull()
   })
 
+  it('requires checkpoint-backed seals to carry a passing durable checkpoint descriptor', () => {
+    const checkpointDigestRef = `sha256:${'a'.repeat(64)}`
+    const sealMetadata: TrainingWindowSealMetadata = {
+      checkpointDigestRef,
+      churn: { joinCount: 0, lossCount: 0, standbyPromotionCount: 0 },
+      durableCheckpointSeal: {
+        checkpointDigestRef,
+        replicationFactor: 2,
+        retrievalProofRef: 'receipt.training.checkpoint_readback.window.0001',
+        retrievalVerified: true,
+        sizeBytes: 1_048_576,
+        storageClass: 'content_addressed_object_store',
+        windowRef: 'training.window.0001',
+      },
+      staleness: {
+        contributionCount: 0,
+        stepsBehindMax: 0,
+        stepsBehindMin: 0,
+        stepsBehindP50: 0,
+        stepsBehindP90: 0,
+      },
+      verificationOverhead: {
+        fraction: 0.1,
+        ladderRungRef: 'ladder.rung.r1',
+      },
+    }
+    const active = transitionTrainingWindowRecord({
+      actorRef: 'operator.training',
+      eventId: 'activate',
+      nextState: 'active',
+      nowIso: '2026-06-12T10:05:00.000Z',
+      receiptRef: 'receipt.training.activate',
+      transitionKind: 'window_activate',
+      window: buildTrainingWindowRecord({
+        makeId: () => 'window',
+        nowIso: '2026-06-12T10:00:00.000Z',
+        request: {
+          trainingRunRef: 'training.run.0001',
+          windowRef: 'training.window.0001',
+        },
+      }),
+    }).window
+
+    const sealed = transitionTrainingWindowRecord({
+      actorRef: 'operator.training',
+      eventId: 'seal',
+      nextState: 'sealed',
+      nowIso: '2026-06-12T10:10:00.000Z',
+      receiptRef: 'receipt.training.seal',
+      sealMetadata,
+      transitionKind: 'window_seal',
+      window: active,
+    }).window
+
+    expect(sealed.sealMetadata?.durableCheckpointSeal).toMatchObject({
+      checkpointDigestRef,
+      retrievalVerified: true,
+      storageClass: 'content_addressed_object_store',
+      windowRef: 'training.window.0001',
+    })
+  })
+
   it('rejects malformed or misplaced seal metadata', () => {
     const validSealMetadata: TrainingWindowSealMetadata = {
       churn: { joinCount: 0, lossCount: 0, standbyPromotionCount: 0 },
@@ -369,6 +431,45 @@ describe('training run window authority', () => {
         },
       }),
       /more join refs than the declared join count/,
+    )
+
+    const checkpointDigestRef = `sha256:${'b'.repeat(64)}`
+    expectSealValidationError(
+      sealAttempt({
+        ...validSealMetadata,
+        checkpointDigestRef,
+      }),
+      /requires a durableCheckpointSeal descriptor/,
+    )
+    expectSealValidationError(
+      sealAttempt({
+        ...validSealMetadata,
+        checkpointDigestRef,
+        durableCheckpointSeal: {
+          checkpointDigestRef,
+          replicationFactor: 1,
+          retrievalVerified: true,
+          sizeBytes: 1_048_576,
+          storageClass: 'content_addressed_object_store',
+          windowRef: 'training.window.0001',
+        },
+      }),
+      /replication_factor_below_durable_minimum/,
+    )
+    expectSealValidationError(
+      sealAttempt({
+        ...validSealMetadata,
+        checkpointDigestRef,
+        durableCheckpointSeal: {
+          checkpointDigestRef,
+          replicationFactor: 2,
+          retrievalVerified: true,
+          sizeBytes: 1_048_576,
+          storageClass: 'content_addressed_object_store',
+          windowRef: 'training.window.other',
+        },
+      }),
+      /must match the sealed windowRef/,
     )
   })
 

--- a/apps/openagents.com/workers/api/src/training-run-window-authority.ts
+++ b/apps/openagents.com/workers/api/src/training-run-window-authority.ts
@@ -14,6 +14,10 @@ import {
 } from './public-projection-staleness'
 import { isoTimestampAfterIso } from './runtime-primitives'
 import {
+  DurableCheckpointSeal,
+  evaluateDurableCheckpointSeal,
+} from './training-durable-checkpoint-seal'
+import {
   type TrainingVerificationChallengeRecord,
   type TrainingVerificationRow,
   rowToTrainingVerificationChallenge,
@@ -162,6 +166,7 @@ export type TrainingWindowSealVerificationOverhead =
 export const TrainingWindowSealMetadata = S.Struct({
   checkpointDigestRef: S.optionalKey(PublicSafeRef),
   churn: TrainingWindowSealChurnSummary,
+  durableCheckpointSeal: S.optionalKey(DurableCheckpointSeal),
   staleness: TrainingWindowSealStalenessSummary,
   verificationOverhead: TrainingWindowSealVerificationOverhead,
 })
@@ -1577,6 +1582,7 @@ export const assertValidTrainingWindowSealMetadata = (
   }
 
   const checkpointDigestRef = metadata.checkpointDigestRef
+  const durableCheckpointSeal = metadata.durableCheckpointSeal
 
   if (
     checkpointDigestRef !== undefined &&
@@ -1585,6 +1591,32 @@ export const assertValidTrainingWindowSealMetadata = (
       !TrainingPublicSafeRefPattern.test(checkpointDigestRef))
   ) {
     throw sealValidationError('checkpointDigestRef must be a public-safe ref.')
+  }
+
+  if (checkpointDigestRef !== undefined && durableCheckpointSeal === undefined) {
+    throw sealValidationError(
+      'checkpointDigestRef requires a durableCheckpointSeal descriptor.',
+    )
+  }
+
+  if (durableCheckpointSeal !== undefined) {
+    if (checkpointDigestRef === undefined) {
+      throw sealValidationError(
+        'durableCheckpointSeal requires checkpointDigestRef.',
+      )
+    }
+    if (durableCheckpointSeal.checkpointDigestRef !== checkpointDigestRef) {
+      throw sealValidationError(
+        'durableCheckpointSeal.checkpointDigestRef must match checkpointDigestRef.',
+      )
+    }
+
+    const gate = evaluateDurableCheckpointSeal(durableCheckpointSeal)
+    if (!gate.durable) {
+      throw sealValidationError(
+        `durableCheckpointSeal must pass durable checkpoint evaluation before sealing. Reasons: ${gate.reasons.join(', ') || 'unknown'}.`,
+      )
+    }
   }
 }
 
@@ -1623,6 +1655,15 @@ export const transitionTrainingWindowRecord = (
 
   if (input.sealMetadata !== undefined) {
     assertValidTrainingWindowSealMetadata(input.sealMetadata)
+    if (
+      input.sealMetadata.durableCheckpointSeal !== undefined &&
+      input.sealMetadata.durableCheckpointSeal.windowRef !==
+        input.window.windowRef
+    ) {
+      throw sealValidationError(
+        'durableCheckpointSeal.windowRef must match the sealed windowRef.',
+      )
+    }
   }
 
   const nextWindow: TrainingWindowRecord = {

--- a/apps/openagents.com/workers/api/src/training-run-window-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/training-run-window-routes.test.ts
@@ -2432,9 +2432,21 @@ describe('training run window routes', () => {
       nowIso: () => currentIso,
       requireAdminApiToken: async () => true,
     })
-    const sealMetadataWithDigest = (checkpointDigestRef: string) => ({
+    const sealMetadataWithDigest = (
+      checkpointDigestRef: string,
+      windowRef: string,
+    ) => ({
       checkpointDigestRef,
       churn: { joinCount: 0, lossCount: 0, standbyPromotionCount: 0 },
+      durableCheckpointSeal: {
+        checkpointDigestRef,
+        replicationFactor: 2,
+        retrievalProofRef: `receipt.${windowRef}.checkpoint.readback`,
+        retrievalVerified: true,
+        sizeBytes: 1_048_576,
+        storageClass: 'content_addressed_object_store',
+        windowRef,
+      },
       staleness: {
         contributionCount: 0,
         stepsBehindMax: 0,
@@ -2469,7 +2481,7 @@ describe('training run window routes', () => {
         routes.routeTrainingRunWindowRequest(
           jsonRequest(`/api/training/windows/${windowRef}/seal`, {
             receiptRef: `receipt.${windowRef}.seal`,
-            sealMetadata: sealMetadataWithDigest(digestRef),
+            sealMetadata: sealMetadataWithDigest(digestRef, windowRef),
           }),
           {},
         ),
@@ -2511,7 +2523,8 @@ describe('training run window routes', () => {
 
     // First durable seal: grant pins its checkpoint digest. The seal
     // route raised and cleared the run-level barrier around the write.
-    await sealWindow('training.window.4850.a', 'digest.checkpoint.a')
+    const firstDigestRef = `sha256:${'a'.repeat(64)}`
+    await sealWindow('training.window.4850.a', firstDigestRef)
     expect(barrierCalls).toEqual([
       'begin:training.run.4850',
       'clear:training.run.4850',
@@ -2519,7 +2532,7 @@ describe('training run window routes', () => {
     expect(await requestGrant()).toMatchObject({
       outcome: {
         grant: {
-          checkpointDigestRef: 'digest.checkpoint.a',
+          checkpointDigestRef: firstDigestRef,
           joinerReceiptRefs: ['receipt.joiner.qualification'],
           joinerRef: 'pylon.joiner.1',
           sealReceiptRefs: [
@@ -2548,11 +2561,12 @@ describe('training run window routes', () => {
     // proceeds against the NEW last durable seal.
     await store.clearRunSealBarrier('training.run.4850')
     currentIso = '2026-06-12T11:00:00.000Z'
-    await sealWindow('training.window.4850.b', 'digest.checkpoint.b')
+    const secondDigestRef = `sha256:${'b'.repeat(64)}`
+    await sealWindow('training.window.4850.b', secondDigestRef)
     expect(await requestGrant()).toMatchObject({
       outcome: {
         grant: {
-          checkpointDigestRef: 'digest.checkpoint.b',
+          checkpointDigestRef: secondDigestRef,
           sealedWindowRef: 'training.window.4850.b',
         },
         kind: 'granted',

--- a/apps/openagents.com/workers/api/src/training-window-bootstrap.test.ts
+++ b/apps/openagents.com/workers/api/src/training-window-bootstrap.test.ts
@@ -37,8 +37,22 @@ const makeRun = (
 
 const sealMetadata = (
   checkpointDigestRef: string | undefined,
+  windowRef = 'training.window.1',
 ): TrainingWindowSealMetadata => ({
-  ...(checkpointDigestRef === undefined ? {} : { checkpointDigestRef }),
+  ...(checkpointDigestRef === undefined
+    ? {}
+    : {
+        checkpointDigestRef,
+        durableCheckpointSeal: {
+          checkpointDigestRef,
+          replicationFactor: 2,
+          retrievalProofRef: `receipt.training.checkpoint_readback.${windowRef}`,
+          retrievalVerified: true,
+          sizeBytes: 1_048_576,
+          storageClass: 'content_addressed_object_store',
+          windowRef,
+        },
+      }),
   churn: {
     joinCount: 0,
     lossCount: 0,
@@ -85,7 +99,7 @@ const sealedWindow = (
   checkpointDigestRef: string | undefined,
 ): TrainingWindowRecord =>
   makeWindow({
-    sealMetadata: sealMetadata(checkpointDigestRef),
+    sealMetadata: sealMetadata(checkpointDigestRef, windowRef),
     sealedAt,
     state: 'sealed',
     windowRef,
@@ -96,12 +110,12 @@ describe('selectLastDurableSealWindow', () => {
     const older = sealedWindow(
       'training.window.older',
       '2026-06-12T08:00:00.000Z',
-      'digest.checkpoint.older',
+      `sha256:${'6'.repeat(64)}`,
     )
     const newest = sealedWindow(
       'training.window.newest',
       '2026-06-12T09:30:00.000Z',
-      'digest.checkpoint.newest',
+      `sha256:${'7'.repeat(64)}`,
     )
 
     expect(
@@ -118,7 +132,7 @@ describe('selectLastDurableSealWindow', () => {
     const durable = sealedWindow(
       'training.window.durable',
       '2026-06-12T08:00:00.000Z',
-      'digest.checkpoint.durable',
+      `sha256:${'8'.repeat(64)}`,
     )
 
     expect(
@@ -126,10 +140,54 @@ describe('selectLastDurableSealWindow', () => {
     ).toBe('training.window.durable')
   })
 
+  it('skips legacy digest-only seals and failed durability descriptors', () => {
+    const legacyDigestOnly = makeWindow({
+      sealMetadata: {
+        ...sealMetadata(undefined),
+        checkpointDigestRef: `sha256:${'a'.repeat(64)}`,
+      },
+      sealedAt: '2026-06-12T09:45:00.000Z',
+      state: 'sealed',
+      windowRef: 'training.window.legacy',
+    })
+    const failedDurability = makeWindow({
+      sealMetadata: {
+        ...sealMetadata(`sha256:${'b'.repeat(64)}`, 'training.window.failed'),
+        durableCheckpointSeal: {
+          checkpointDigestRef: `sha256:${'b'.repeat(64)}`,
+          replicationFactor: 1,
+          retrievalVerified: true,
+          sizeBytes: 1_048_576,
+          storageClass: 'content_addressed_object_store',
+          windowRef: 'training.window.failed',
+        },
+      },
+      sealedAt: '2026-06-12T09:50:00.000Z',
+      state: 'sealed',
+      windowRef: 'training.window.failed',
+    })
+    const durable = sealedWindow(
+      'training.window.durable',
+      '2026-06-12T08:00:00.000Z',
+      `sha256:${'c'.repeat(64)}`,
+    )
+
+    expect(
+      selectLastDurableSealWindow([legacyDigestOnly, failedDurability, durable])
+        ?.windowRef,
+    ).toBe('training.window.durable')
+    expect(
+      selectLastDurableSealWindow([legacyDigestOnly, failedDurability]),
+    ).toBeUndefined()
+  })
+
   it('counts reconciled windows as durable seals but never active or planned ones', () => {
     const reconciled = makeWindow({
       reconciledAt: '2026-06-12T09:00:00.000Z',
-      sealMetadata: sealMetadata('digest.checkpoint.reconciled'),
+      sealMetadata: sealMetadata(
+        `sha256:${'d'.repeat(64)}`,
+        'training.window.reconciled',
+      ),
       sealedAt: '2026-06-12T08:30:00.000Z',
       state: 'reconciled',
       windowRef: 'training.window.reconciled',
@@ -162,19 +220,19 @@ describe('decideTrainingWindowBootstrapGrant', () => {
         sealedWindow(
           'training.window.older',
           '2026-06-12T08:00:00.000Z',
-          'digest.checkpoint.older',
+          `sha256:${'1'.repeat(64)}`,
         ),
         sealedWindow(
           'training.window.newest',
           '2026-06-12T09:30:00.000Z',
-          'digest.checkpoint.newest',
+          `sha256:${'2'.repeat(64)}`,
         ),
       ],
     })
 
     expect(outcome).toMatchObject({
       grant: {
-        checkpointDigestRef: 'digest.checkpoint.newest',
+        checkpointDigestRef: `sha256:${'2'.repeat(64)}`,
         grantRef: 'training.bootstrap.grant.0001',
         joinerReceiptRefs: ['receipt.joiner.qualification'],
         joinerRef: 'pylon.joiner.1',
@@ -217,7 +275,7 @@ describe('decideTrainingWindowBootstrapGrant', () => {
         sealedWindow(
           'training.window.durable',
           '2026-06-12T09:00:00.000Z',
-          'digest.checkpoint.durable',
+          `sha256:${'3'.repeat(64)}`,
         ),
       ],
     })
@@ -235,7 +293,7 @@ describe('decideTrainingWindowBootstrapGrant', () => {
       sealedWindow(
         'training.window.before',
         '2026-06-12T09:00:00.000Z',
-        'digest.checkpoint.before',
+        `sha256:${'4'.repeat(64)}`,
       ),
     ]
     const queued = decideTrainingWindowBootstrapGrant({
@@ -257,14 +315,14 @@ describe('decideTrainingWindowBootstrapGrant', () => {
         sealedWindow(
           'training.window.after',
           '2026-06-12T10:00:00.000Z',
-          'digest.checkpoint.after',
+          `sha256:${'5'.repeat(64)}`,
         ),
       ],
     })
 
     expect(replayed).toMatchObject({
       grant: {
-        checkpointDigestRef: 'digest.checkpoint.after',
+        checkpointDigestRef: `sha256:${'5'.repeat(64)}`,
         sealedWindowRef: 'training.window.after',
       },
       kind: 'granted',

--- a/apps/openagents.com/workers/api/src/training-window-bootstrap.ts
+++ b/apps/openagents.com/workers/api/src/training-window-bootstrap.ts
@@ -1,6 +1,7 @@
 import { Schema as S } from 'effect'
 
 import { friendlyBlueprintMissionBriefingTime } from './blueprint/services/continuation-mission-briefing'
+import { evaluateDurableCheckpointSeal } from './training-durable-checkpoint-seal'
 import {
   type PylonJoinLifecycleEventRecord,
   type PylonJoinLifecycleReasonCode,
@@ -112,12 +113,19 @@ export const selectLastDurableSealWindow = (
   windows: ReadonlyArray<TrainingWindowRecord>,
 ): TrainingWindowRecord | undefined =>
   windows
-    .filter(
-      window =>
+    .filter(window => {
+      const durableCheckpointSeal = window.sealMetadata?.durableCheckpointSeal
+
+      return (
         (window.state === 'sealed' || window.state === 'reconciled') &&
         window.sealedAt !== null &&
-        window.sealMetadata?.checkpointDigestRef !== undefined,
-    )
+        durableCheckpointSeal !== undefined &&
+        window.sealMetadata?.checkpointDigestRef ===
+          durableCheckpointSeal.checkpointDigestRef &&
+        durableCheckpointSeal.windowRef === window.windowRef &&
+        evaluateDurableCheckpointSeal(durableCheckpointSeal).durable
+      )
+    })
     .sort(
       (left, right) =>
         right.sealedAt!.localeCompare(left.sealedAt!) ||

--- a/docs/launch/vertex-fleet/training.marathon_operations.v1.md
+++ b/docs/launch/vertex-fleet/training.marathon_operations.v1.md
@@ -29,16 +29,29 @@ contract-level module:
     digest, sub-minimum replication, and missing read-back each HOLD; malformed
     descriptor fails toward HOLD; well-formed untrusted descriptor decodes.
 
-No promise state, registry field, or blocker list was changed. This grants no
-dispatch, settlement, or green-claim authority.
+## 2026-06-20 live-boundary wiring
+
+The durability predicate is now bound into the live seal/bootstrap authority:
+
+- `TrainingWindowSealMetadata` may carry a `checkpointDigestRef` only when it
+  also carries a matching `durableCheckpointSeal` descriptor.
+- `transitionTrainingWindowRecord` rejects checkpoint-backed seals unless the
+  descriptor passes `evaluateDurableCheckpointSeal`, and the descriptor's
+  `windowRef` matches the sealed window.
+- `selectLastDurableSealWindow` now ignores legacy digest-only rows and any
+  descriptor that fails durability evaluation, so bootstrap grants are issued
+  only from evaluator-approved durable seal metadata.
+- Tests cover successful descriptor-backed sealing, missing-descriptor
+  rejection, failed-durability rejection, window-ref mismatch rejection, and
+  bootstrap skipping of legacy/failed durable-seal rows.
+
+No promise state or blocker list was changed. This grants no dispatch,
+settlement, storage-backend, or green-claim authority.
 
 ## What genuinely remains for this blocker
 
-- Bind `evaluateDurableCheckpointSeal` into the live window-seal transition in
-  `training-run-window-authority.ts` so a window seal is rejected/queued when the
-  checkpoint is not durable.
 - Prove it end-to-end against a real remote content-addressed checkpoint store
-  (the read-back is currently a declared flag, not a wired fetch).
+  (the read-back is still a declared descriptor/proof ref, not a wired fetch).
 
 ## Other blockers (out of scope this run)
 


### PR DESCRIPTION
## Summary
- require checkpoint-backed training window seals to carry a matching durableCheckpointSeal descriptor that passes evaluateDurableCheckpointSeal before sealing
- make bootstrap grants ignore legacy digest-only and failed-durability seal rows
- bump product promises registry to 2026-06-20.33 for training.marathon_operations.v1 without changing promise state or blockers

## Promise boundaries
- training.marathon_operations.v1 remains planned
- blocker.product_promises.durable_checkpoint_seal_missing stays active because no real remote content-addressed checkpoint store has produced a read-back-and-rehash receipt
- standby_dispatch_missing and curtailment_drill_missing are untouched
- no dispatch, spend, settlement, storage backend, standby promotion, curtailment drill, energy claim, or green transition is created

## Tests
- bunx vitest run src/training-run-window-routes.test.ts src/training-window-bootstrap.test.ts src/training-run-window-authority.test.ts src/training-durable-checkpoint-seal.test.ts src/product-promises.test.ts
- bun run check:deploy

Refs #5528