### PR TITLE
Wire A4 corpus provenance admission

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.34')
+    expect(decoded.version).toBe('2026-06-20.35')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -112,6 +112,9 @@ describe('public product promises document', () => {
     )
     expect(decoded.sourceRefs).toContain(
       'docs/training/2026-06-20-cs336-a2-same-class-replication-status.md',
+    )
+    expect(decoded.sourceRefs).toContain(
+      'docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md',
     )
     expect(decoded.promises.length).toBeGreaterThan(0)
     expect(decoded.verificationSummary.promiseCount).toBe(
@@ -257,6 +260,9 @@ describe('public product promises document', () => {
     // The 2026-06-20.34 device-capability pass exposes same-class replication
     // status but keeps same-host and thermal blockers active, so green remains
     // exactly 24.
+    // The 2026-06-20.35 data-refinery pass wires corpus-provenance receipts
+    // into A4 admission/projection but no live paid shard closeout exists, so
+    // green remains exactly 24.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -354,6 +360,27 @@ describe('public product promises document', () => {
             '/api/public/training/ablation-derisking-ledger',
           ),
           verification: expect.stringContaining('one-delta manifest harness'),
+        }),
+        expect.objectContaining({
+          promiseId: 'training.data_refinery_corpus.v1',
+          state: 'planned',
+          evidenceRefs: expect.arrayContaining([
+            'docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md',
+            'apps/openagents.com/workers/api/src/cs336-a4-provenance.ts',
+            'apps/openagents.com/workers/api/src/cs336-a4-provenance.test.ts',
+            'apps/openagents.com/workers/api/src/training-data-refinery.ts',
+            'apps/openagents.com/workers/api/src/training-data-refinery.test.ts',
+            'apps/openagents.com/workers/api/src/training-run-window-routes.ts',
+          ]),
+          blockerRefs: [
+            'blocker.product_promises.crawl_scale_corpus_missing',
+            'blocker.product_promises.corpus_provenance_receipts_missing',
+            'blocker.product_promises.eval_delta_payment_missing',
+          ],
+          safeCopy: expect.stringContaining('corpusProvenanceReceipt'),
+          verification: expect.stringContaining(
+            'no live paid refinery shard closeout',
+          ),
         }),
         expect.objectContaining({
           promiseId: 'training.marathon_operations.v1',
@@ -1117,12 +1144,12 @@ describe('public product promises document', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.34', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.35', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.34',
+      expectedVersion: '2026-06-20.35',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.34',
+      servedVersion: '2026-06-20.35',
       status: 'ready',
     })
     expect(
@@ -1132,7 +1159,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.34',
+      servedVersion: '2026-06-20.35',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.34'
+export const PublicProductPromisesVersion = '2026-06-20.35'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -30,6 +30,7 @@ const sourceRefs = [
   'docs/training/2026-06-20-training-full-pipeline-program-status.md',
   'docs/launch/vertex-fleet/training.marathon_operations.v1.md',
   'docs/training/2026-06-20-cs336-a2-same-class-replication-status.md',
+  'docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md',
   'docs/2026-06-10-cs336-distributed-homework-continuation-audit.md',
   'docs/forum/2026-06-09-forum-mdk-webhook-reconciliation-audit.md',
   'docs/refactor/path-to-bolt-12.md',
@@ -1772,7 +1773,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Pretraining corpora are produced by an owned data refinery over public crawl-class sources, processed as paid CPU work with provenance and transform digests, mixture ablations, a multi-stage curriculum, decontamination receipts, and eval-delta payment for data quality.',
         safeCopy:
-          'The A4 deterministic refinery core landed in psionic (PII masking, Gopher quality rules, exact and MinHash dedup) and the live a4_eval_delta leaderboard serves an honest empty state. Psion’s current corpus is a frozen bounded mixture; crawl-scale acquisition, paid shard assignments, corpus provenance receipts, decontamination receipts, and eval-delta payment remain planned.',
+          'The A4 deterministic refinery core landed in psionic (PII masking, Gopher quality rules, exact and MinHash dedup) and the live a4_eval_delta leaderboard serves an honest empty state. The live A4 evidence admission path now requires each newly admitted shard to carry a corpusProvenanceReceipt whose source provenance and linked transform digests validate against the shard output digest, and the A4 public projection reports corpusProvenanceReceiptStatus/Refs/BlockerRefs. Psion’s current corpus is a frozen bounded mixture; crawl-scale acquisition, paid shard assignments with live provenance receipts, decontamination receipts, and eval-delta payment remain planned.',
         unsafeCopy:
           'Do not claim a crawl-scale receipted corpus exists, that contributors are currently paid for data-refinery work, or that data quality is paid on measured eval delta.',
         evidenceRefs: [
@@ -1780,6 +1781,12 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/docs/2026-06-08-data-trace-marketplace-gate.md',
           'apps/openagents.com/docs/2026-06-10-cs336-a4-data-refinery-payment-policy.md',
           'apps/openagents.com/workers/api/src/training-leaderboards.ts',
+          'docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md',
+          'apps/openagents.com/workers/api/src/cs336-a4-provenance.ts',
+          'apps/openagents.com/workers/api/src/cs336-a4-provenance.test.ts',
+          'apps/openagents.com/workers/api/src/training-data-refinery.ts',
+          'apps/openagents.com/workers/api/src/training-data-refinery.test.ts',
+          'apps/openagents.com/workers/api/src/training-run-window-routes.ts',
           'https://github.com/OpenAgentsInc/openagents/issues/4680',
         ],
         blockerRefs: [
@@ -1788,7 +1795,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.eval_delta_payment_missing',
         ],
         verification:
-          'Green requires refinery shards dispatched as paid assignments with deterministic-recompute verification, every shard carrying source-provenance and transform digests, mixture/annealing ablation receipts, decontamination receipts against the eval suite, and at least one eval-delta payment computed from a fixed reference model. The a4_eval_delta leaderboard lane is live-but-empty in training-leaderboards.ts and the payment policy is documented (2026-06-10-cs336-a4-data-refinery-payment-policy.md); the single concrete missing receipt is one Verified deterministic_recompute refinery-shard challenge whose closeout records an eval-delta payment, which would populate the first a4_eval_delta leaderboard row.',
+          'Green requires refinery shards dispatched as paid assignments with deterministic-recompute verification, every shard carrying source-provenance and transform digests, mixture/annealing ablation receipts, decontamination receipts against the eval suite, and at least one eval-delta payment computed from a fixed reference model. The A4 route now rejects newly admitted shards without a linked, recompute-verified corpusProvenanceReceipt and projects corpusProvenanceReceiptStatus/Refs/BlockerRefs, but blocker.product_promises.corpus_provenance_receipts_missing remains because no live paid refinery shard closeout has produced one of those receipts. The a4_eval_delta leaderboard lane is live-but-empty in training-leaderboards.ts and the payment policy is documented (2026-06-10-cs336-a4-data-refinery-payment-policy.md); the single concrete missing receipt is one Verified deterministic_recompute refinery-shard challenge whose closeout records an eval-delta payment, which would populate the first a4_eval_delta leaderboard row.',
         authorityBoundary:
           'Refinery output is corpus material, not a dataset sale; the data-market promises govern selling, and privacy rules forbid publishing raw crawl or contributor content.',
       },
@@ -3552,6 +3559,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.32 is a training.full_pipeline_program.v1 stage-status projection pass and flips NO promise state (stays planned, green count unchanged at 24). GET /api/public/training/full-pipeline-program now serves a public-safe, live-at-read map of DE-5 training stages to their promise state, endpoint refs, evidence refs, receipt-surface state, and blocker refs. It makes the umbrella program auditable without widening the claim: greenGateSatisfied=false, endToEndRunReceiptAvailable=false, ladderRungEndToEndReceiptAvailable=false, paidNetworkWorkloadBroadlyLive=false, and blocker.product_promises.training_pipeline_rails_incomplete remains. No training dispatch, corpus admission, public-gradient acceptance, checkpoint mutation, spend, settlement, model promotion, service claim, or green transition is created. Evidence: docs/training/2026-06-20-training-full-pipeline-program-status.md.',
         'Registry 2026-06-20.33 is a training.marathon_operations.v1 durable-checkpoint seal-boundary pass and flips NO promise state (stays planned, green count unchanged at 24). Checkpoint-backed window seals now require a matching durableCheckpointSeal descriptor that passes evaluateDurableCheckpointSeal before transitionTrainingWindowRecord can seal, and selectLastDurableSealWindow now ignores legacy digest-only rows and failed-durability descriptors before issuing bootstrap grants. This binds the durability predicate into the live seal/bootstrap authority, but blocker.product_promises.durable_checkpoint_seal_missing remains because no real remote content-addressed checkpoint store has produced a read-back-and-rehash receipt. standby_dispatch_missing and curtailment_drill_missing are untouched. No dispatch, spend, settlement, storage-backend, standby promotion, curtailment drill, energy claim, or green transition is created. Evidence: docs/launch/vertex-fleet/training.marathon_operations.v1.md.',
         'Registry 2026-06-20.34 is a training.device_capability_dataset.v1 same-class replication-status pass and flips NO promise state (stays yellow, green count unchanged at 24). GET /api/training/device-capabilities/a2 and each A2 run-level dataset projection now expose sameClassReplicationStatus, sameClassReplicationSignals, and sameClassReplicationBlockerRefs. Legacy settled rows fail closed to cross_process_same_host/same_host_only, measured_unsettled rows fail closed to single_observation, and only explicit sameClassReplicationScope=cross_machine_same_class evidence clears the route-level replication blocker. blocker.product_promises.same_host_replication_caveat and blocker.product_promises.thermal_throttle_detection_missing remain active; no paid assignment, verification verdict, settlement, earning estimate, new device-class claim, cross-machine receipt, green flip, or capability claim is created. Evidence: docs/training/2026-06-20-cs336-a2-same-class-replication-status.md.',
+        'Registry 2026-06-20.35 is a training.data_refinery_corpus.v1 corpus-provenance admission wiring pass and flips NO promise state (stays planned, green count unchanged at 24). The A4 data-refinery evidence route now requires each newly admitted shard to carry corpusProvenanceReceipt, rejects mismatched final-output digests, unlinked transform chains, recompute mismatches, and private/payment/raw-shard material, and projects corpusProvenanceReceiptStatus, corpusProvenanceReceiptRefs, and corpusProvenanceReceiptBlockerRefs on the run-level projection and GET /api/training/refinery/a4 dashboard. blocker.product_promises.corpus_provenance_receipts_missing remains because no live paid refinery shard closeout has produced one of these receipts; crawl_scale_corpus_missing and eval_delta_payment_missing are untouched. No crawl acquisition, paid shard dispatch, deterministic-recompute verdict, settlement, decontamination receipt, eval-delta payment, corpus sale, or green transition is created. Evidence: docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md.',
         'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }

--- a/apps/openagents.com/workers/api/src/training-data-refinery.test.ts
+++ b/apps/openagents.com/workers/api/src/training-data-refinery.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { Cs336A4HomeworkStages } from './cs336-a4-data-refinery'
+import { buildCs336A4ProvenanceReceipt } from './cs336-a4-provenance'
 import {
   admitCs336A4DataRefineryEvidence,
   Cs336A4RequiredVerifiedStageCount,
@@ -37,6 +38,35 @@ const baseShard = (stage: (typeof Cs336A4HomeworkStages)[number]) => ({
   verificationRefs: [`challenge.cs336_a4.${stage}.1`],
 })
 
+const shardWithProvenance = async (
+  stage: (typeof Cs336A4HomeworkStages)[number],
+) => {
+  const shard = baseShard(stage)
+  const corpusProvenanceReceipt = await buildCs336A4ProvenanceReceipt({
+    assignmentRef: `assignment.cs336_a4.${stage}.1`,
+    finalOutputDigestRef: shard.outputDigestRef,
+    inputShardRef: shard.shardRef,
+    provenance: {
+      acquisitionMode: 'bounded_synthetic_corpus',
+      licenseRef: 'license.public.cc0.synthetic_corpus_v1',
+      snapshotRef: `snapshot.cs336_a4.${stage}.v1`,
+      sourceRef: 'source.psion.bounded_synthetic_mixture.v1',
+    },
+    sourceInputDigestRef: `digest.cs336_a4.${stage}.source`,
+    transformChain: [
+      {
+        codeVersionRef: `psionic.refinery.v1.${stage}`,
+        inputDigestRef: `digest.cs336_a4.${stage}.source`,
+        outputDigestRef: shard.outputDigestRef,
+        recomputedDigestRef: shard.outputDigestRef,
+        stage,
+      },
+    ],
+  })
+
+  return { ...shard, corpusProvenanceReceipt }
+}
+
 describe('CS336 A4 data-refinery projection', () => {
   it('keeps the public refinery projection blocked without receipted shards', () => {
     const projection = publicDataRefineryProjection({
@@ -48,11 +78,17 @@ describe('CS336 A4 data-refinery projection', () => {
 
     expect(projection).toMatchObject({
       blockerRefs: [
-        'blocker.cs336_a4.requires_three_verified_stages',
         'blocker.cs336_a4.operator_funding_required_for_paid_shards',
+        'blocker.cs336_a4.requires_corpus_provenance_receipts',
+        'blocker.cs336_a4.requires_three_verified_stages',
       ],
       observedVerifiedShardCount: 0,
       observedVerifiedStages: [],
+      corpusProvenanceReceiptBlockerRefs: [
+        'blocker.cs336_a4.requires_corpus_provenance_receipts',
+      ],
+      corpusProvenanceReceiptRefs: [],
+      corpusProvenanceReceiptStatus: 'missing',
       psionicLaneRef: 'psion_cs336_a4_data_refinery_reference_v1',
       requiredVerifiedStageCount: Cs336A4RequiredVerifiedStageCount,
       schemaVersion: 'openagents.training.data_refinery.v1',
@@ -64,8 +100,9 @@ describe('CS336 A4 data-refinery projection', () => {
     )
   })
 
-  it('admits receipted shards and rejects unreceipted, unsafe, or empty evidence', () => {
+  it('admits receipted shards and rejects unreceipted, unsafe, empty, or unprovenanced evidence', async () => {
     const run = buildRun()
+    const shard = await shardWithProvenance('pii_masking')
 
     expect(() =>
       admitCs336A4DataRefineryEvidence({
@@ -79,7 +116,7 @@ describe('CS336 A4 data-refinery projection', () => {
       admitCs336A4DataRefineryEvidence({
         nowIso: '2026-06-11T02:00:00.000Z',
         request: {
-          shards: [{ ...baseShard('pii_masking'), receiptRefs: [] }],
+          shards: [{ ...shard, receiptRefs: [] }],
         },
         run,
       }),
@@ -91,7 +128,7 @@ describe('CS336 A4 data-refinery projection', () => {
         request: {
           shards: [
             {
-              ...baseShard('pii_masking'),
+              ...shard,
               sourceRefs: ['lnbc10n1deadbeef.fake_invoice_material'],
             },
           ],
@@ -100,11 +137,40 @@ describe('CS336 A4 data-refinery projection', () => {
       }),
     ).toThrow(/wallet, payment, raw-shard, or private material/)
 
+    expect(() =>
+      admitCs336A4DataRefineryEvidence({
+        nowIso: '2026-06-11T02:00:00.000Z',
+        request: {
+          shards: [
+            {
+              ...baseShard('pii_masking'),
+            } as unknown as Awaited<ReturnType<typeof shardWithProvenance>>,
+          ],
+        },
+        run,
+      }),
+    ).toThrow(/corpusProvenanceReceipt/)
+
+    expect(() =>
+      admitCs336A4DataRefineryEvidence({
+        nowIso: '2026-06-11T02:00:00.000Z',
+        request: {
+          shards: [
+            {
+              ...shard,
+              outputDigestRef: 'digest.sha256.cs336_a4.pii_masking.WRONG',
+            },
+          ],
+        },
+        run,
+      }),
+    ).toThrow(/final output digest/)
+
     const admitted = admitCs336A4DataRefineryEvidence({
       nowIso: '2026-06-11T02:30:00.000Z',
       request: {
         receiptRefs: ['approval.operator.20260611.focus_cs336_issue4680'],
-        shards: [baseShard('pii_masking')],
+        shards: [shard],
         sourceRefs: ['issue.github.openagents.4680'],
       },
       run,
@@ -120,19 +186,24 @@ describe('CS336 A4 data-refinery projection', () => {
     expect(projection.status).toBe('collecting_shards')
     expect(projection.shards).toHaveLength(1)
     expect(projection.shards[0]).toMatchObject({
+      corpusProvenanceReceiptRef: shard.corpusProvenanceReceipt.receiptRef,
+      corpusProvenanceVerified: true,
       pylonRef: 'pylon.24819249b4634a4c9d5e',
       settledPayoutSats: 0,
       stage: 'pii_masking',
       verified: true,
     })
+    expect(projection.corpusProvenanceReceiptStatus).toBe('available')
+    expect(projection.corpusProvenanceReceiptBlockerRefs).toEqual([])
   })
 
-  it('reaches stages_verified only with three distinct verified stages', () => {
+  it('reaches stages_verified only with three distinct verified stages', async () => {
     const run = buildRun()
     const stages = ['pii_masking', 'exact_line_dedup', 'minhash_dedup'] as const
+    const shards = await Promise.all(stages.map(shardWithProvenance))
     const admitted = admitCs336A4DataRefineryEvidence({
       nowIso: '2026-06-11T02:30:00.000Z',
-      request: { shards: stages.map(baseShard) },
+      request: { shards },
       run,
     })
     const window = buildTrainingWindowRecord({
@@ -195,6 +266,7 @@ describe('CS336 A4 data-refinery projection', () => {
     ])
     expect(projection.status).toBe('stages_verified')
     expect(projection.blockerRefs).toEqual([])
+    expect(projection.corpusProvenanceReceiptStatus).toBe('available')
     expect(projection.observedVerifiedShardCount).toBe(3)
   })
 })

--- a/apps/openagents.com/workers/api/src/training-data-refinery.ts
+++ b/apps/openagents.com/workers/api/src/training-data-refinery.ts
@@ -12,6 +12,12 @@ import {
   Cs336A4PsionicLaneRef,
   type Cs336A4HomeworkStage,
 } from './cs336-a4-data-refinery'
+import {
+  Cs336A4AcquisitionModes,
+  Cs336A4ProvenanceSchemaVersion,
+  type Cs336A4ProvenanceReceipt,
+  type Cs336A4TransformStep,
+} from './cs336-a4-provenance'
 import type {
   TrainingRunRecord,
   TrainingWindowLeaseRecord,
@@ -20,6 +26,9 @@ import type {
 import type { TrainingVerificationChallengeRecord } from './training-verification'
 
 export type DataRefineryShard = Readonly<{
+  corpusProvenanceReceipt: Cs336A4ProvenanceReceipt | null
+  corpusProvenanceReceiptRef: string | null
+  corpusProvenanceVerified: boolean
   inputDocumentCount: number | null
   outputDigestRef: string
   pylonRef: string | null
@@ -35,6 +44,9 @@ export type DataRefineryShard = Readonly<{
 
 export type DataRefineryProjection = Readonly<{
   blockerRefs: ReadonlyArray<string>
+  corpusProvenanceReceiptBlockerRefs: ReadonlyArray<string>
+  corpusProvenanceReceiptRefs: ReadonlyArray<string>
+  corpusProvenanceReceiptStatus: 'missing' | 'partial' | 'available'
   evalDeltaBonusBlockerRefs: ReadonlyArray<string>
   observedVerifiedShardCount: number
   observedVerifiedStages: ReadonlyArray<Cs336A4HomeworkStage>
@@ -59,7 +71,40 @@ const PublicSafeRef = NonEmptyTrimmedString.check(
 )
 const PublicSafeRefs = S.optionalKey(S.Array(PublicSafeRef))
 
+const Cs336A4SourceProvenanceEvidence = S.Struct({
+  acquisitionMode: S.Literals(Cs336A4AcquisitionModes),
+  licenseRef: PublicSafeRef,
+  snapshotRef: PublicSafeRef,
+  sourceRef: PublicSafeRef,
+})
+
+const Cs336A4TransformStepEvidence = S.Struct({
+  codeVersionRef: PublicSafeRef,
+  inputDigestRef: PublicSafeRef,
+  outputDigestRef: PublicSafeRef,
+  recomputedDigestRef: PublicSafeRef,
+  stage: S.Literals([...Cs336A4HomeworkStages]),
+})
+
+const Cs336A4ProvenanceReceiptEvidence = S.Struct({
+  assignmentRef: PublicSafeRef,
+  contentDigestRef: S.Trim.check(
+    S.isNonEmpty(),
+    S.isPattern(/^[0-9a-f]{64}$/),
+  ),
+  finalOutputDigestRef: PublicSafeRef,
+  inputShardRef: PublicSafeRef,
+  jobKind: S.Literal(Cs336A4DataRefineryJobKind),
+  provenance: Cs336A4SourceProvenanceEvidence,
+  receiptRef: PublicSafeRef,
+  recomputeVerified: S.Boolean,
+  schemaVersion: S.Literal(Cs336A4ProvenanceSchemaVersion),
+  sourceInputDigestRef: PublicSafeRef,
+  transformChain: S.Array(Cs336A4TransformStepEvidence),
+})
+
 export const Cs336A4RefineryStageEvidence = S.Struct({
+  corpusProvenanceReceipt: Cs336A4ProvenanceReceiptEvidence,
   inputDocumentCount: S.optionalKey(S.Number),
   outputDigestRef: PublicSafeRef,
   pylonRef: S.optionalKey(PublicSafeRef),
@@ -127,6 +172,203 @@ const optionalNumber = (value: unknown): number | undefined => {
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
+const isStage = (value: unknown): value is Cs336A4HomeworkStage =>
+  typeof value === 'string' &&
+  (Cs336A4HomeworkStages as ReadonlyArray<string>).includes(value)
+
+const isAcquisitionMode = (
+  value: unknown,
+): value is Cs336A4ProvenanceReceipt['provenance']['acquisitionMode'] =>
+  typeof value === 'string' &&
+  (Cs336A4AcquisitionModes as ReadonlyArray<string>).includes(value)
+
+const corpusProvenanceReceiptFromUnknown = (
+  value: unknown,
+): Cs336A4ProvenanceReceipt | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const provenanceRecord = value.provenance
+  const transformChainValue = value.transformChain
+
+  if (!isRecord(provenanceRecord) || !Array.isArray(transformChainValue)) {
+    return null
+  }
+
+  const assignmentRef = optionalString(value.assignmentRef)
+  const contentDigestRef = optionalString(value.contentDigestRef)
+  const finalOutputDigestRef = optionalString(value.finalOutputDigestRef)
+  const inputShardRef = optionalString(value.inputShardRef)
+  const jobKind = optionalString(value.jobKind)
+  const receiptRef = optionalString(value.receiptRef)
+  const schemaVersion = optionalString(value.schemaVersion)
+  const sourceInputDigestRef = optionalString(value.sourceInputDigestRef)
+  const acquisitionMode = optionalString(provenanceRecord.acquisitionMode)
+  const licenseRef = optionalString(provenanceRecord.licenseRef)
+  const snapshotRef = optionalString(provenanceRecord.snapshotRef)
+  const sourceRef = optionalString(provenanceRecord.sourceRef)
+
+  if (
+    assignmentRef === undefined ||
+    contentDigestRef === undefined ||
+    !/^[0-9a-f]{64}$/.test(contentDigestRef) ||
+    finalOutputDigestRef === undefined ||
+    inputShardRef === undefined ||
+    jobKind !== Cs336A4DataRefineryJobKind ||
+    receiptRef === undefined ||
+    schemaVersion !== Cs336A4ProvenanceSchemaVersion ||
+    sourceInputDigestRef === undefined ||
+    acquisitionMode === undefined ||
+    !isAcquisitionMode(acquisitionMode) ||
+    licenseRef === undefined ||
+    snapshotRef === undefined ||
+    sourceRef === undefined ||
+    typeof value.recomputeVerified !== 'boolean'
+  ) {
+    return null
+  }
+
+  const transformChain: Array<Cs336A4TransformStep> = []
+
+  for (const step of transformChainValue) {
+    if (!isRecord(step) || !isStage(step.stage)) {
+      return null
+    }
+
+    const codeVersionRef = optionalString(step.codeVersionRef)
+    const inputDigestRef = optionalString(step.inputDigestRef)
+    const outputDigestRef = optionalString(step.outputDigestRef)
+    const recomputedDigestRef = optionalString(step.recomputedDigestRef)
+
+    if (
+      codeVersionRef === undefined ||
+      inputDigestRef === undefined ||
+      outputDigestRef === undefined ||
+      recomputedDigestRef === undefined
+    ) {
+      return null
+    }
+
+    transformChain.push({
+      codeVersionRef,
+      inputDigestRef,
+      outputDigestRef,
+      recomputedDigestRef,
+      stage: step.stage,
+    })
+  }
+
+  const receipt: Cs336A4ProvenanceReceipt = {
+    assignmentRef,
+    contentDigestRef,
+    finalOutputDigestRef,
+    inputShardRef,
+    jobKind: Cs336A4DataRefineryJobKind,
+    provenance: {
+      acquisitionMode,
+      licenseRef,
+      snapshotRef,
+      sourceRef,
+    },
+    receiptRef,
+    recomputeVerified: value.recomputeVerified,
+    schemaVersion: Cs336A4ProvenanceSchemaVersion,
+    sourceInputDigestRef,
+    transformChain,
+  }
+
+  publicSafeJson(receipt)
+
+  return receipt
+}
+
+const assertLinkedCorpusProvenanceReceipt = (
+  shard: Cs336A4RefineryStageEvidence,
+): Cs336A4ProvenanceReceipt => {
+  const receipt = shard.corpusProvenanceReceipt as
+    | Cs336A4ProvenanceReceipt
+    | undefined
+
+  if (receipt === undefined) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 refinery shard evidence requires a corpusProvenanceReceipt.',
+    )
+  }
+
+  if (receipt.jobKind !== Cs336A4DataRefineryJobKind) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 corpus provenance receipt must use the CS336 A4 data-refinery job kind.',
+    )
+  }
+
+  if (receipt.schemaVersion !== Cs336A4ProvenanceSchemaVersion) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 corpus provenance receipt carries an unsupported schema version.',
+    )
+  }
+
+  if (receipt.finalOutputDigestRef !== shard.outputDigestRef) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 corpus provenance receipt final output digest must match the shard outputDigestRef.',
+    )
+  }
+
+  if (!receipt.recomputeVerified) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 corpus provenance receipt must be recompute verified.',
+    )
+  }
+
+  if (!receipt.receiptRef.endsWith(receipt.contentDigestRef.slice(0, 16))) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 corpus provenance receiptRef must include the content digest prefix.',
+    )
+  }
+
+  if (receipt.transformChain.length === 0) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 corpus provenance receipt requires a non-empty transform chain.',
+    )
+  }
+
+  let previousOutputDigestRef = receipt.sourceInputDigestRef
+
+  for (const [index, step] of receipt.transformChain.entries()) {
+    if (step.inputDigestRef !== previousOutputDigestRef) {
+      throw new DataRefineryEvidenceValidationError(
+        `CS336 A4 corpus provenance transform chain is not linked at step ${index}.`,
+      )
+    }
+
+    if (step.recomputedDigestRef !== step.outputDigestRef) {
+      throw new DataRefineryEvidenceValidationError(
+        `CS336 A4 corpus provenance recompute digest mismatch at step ${index}.`,
+      )
+    }
+
+    previousOutputDigestRef = step.outputDigestRef
+  }
+
+  const lastStep = receipt.transformChain[receipt.transformChain.length - 1]!
+
+  if (lastStep.stage !== shard.stage) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 corpus provenance receipt last transform stage must match the shard stage.',
+    )
+  }
+
+  if (lastStep.outputDigestRef !== receipt.finalOutputDigestRef) {
+    throw new DataRefineryEvidenceValidationError(
+      'CS336 A4 corpus provenance receipt final output digest must equal the last transform output digest.',
+    )
+  }
+
+  publicSafeJson(receipt)
+
+  return receipt
+}
+
 const assertAdmissibleShard = (shard: Cs336A4RefineryStageEvidence): void => {
   if (shard.receiptRefs.length === 0) {
     throw new DataRefineryEvidenceValidationError(
@@ -142,6 +384,8 @@ const assertAdmissibleShard = (shard: Cs336A4RefineryStageEvidence): void => {
       'CS336 A4 refinery shard input document count must be a positive finite number when present.',
     )
   }
+
+  assertLinkedCorpusProvenanceReceipt(shard)
 }
 
 /**
@@ -213,10 +457,6 @@ const refineryEvidenceRecord = (
   return isRecord(nested) ? nested : undefined
 }
 
-const isStage = (value: unknown): value is Cs336A4HomeworkStage =>
-  typeof value === 'string' &&
-  (Cs336A4HomeworkStages as ReadonlyArray<string>).includes(value)
-
 const shardsFromEvidence = (
   input: Readonly<{
     challenges: ReadonlyArray<TrainingVerificationChallengeRecord>
@@ -245,6 +485,14 @@ const shardsFromEvidence = (
       return []
     }
 
+    const corpusProvenanceReceipt = corpusProvenanceReceiptFromUnknown(
+      shard.corpusProvenanceReceipt,
+    )
+    const corpusProvenanceVerified =
+      corpusProvenanceReceipt !== null &&
+      corpusProvenanceReceipt.recomputeVerified &&
+      corpusProvenanceReceipt.finalOutputDigestRef === outputDigestRef
+
     const verificationRefs = uniqueRefs([
       ...stringArrayFromUnknown(shard.verificationRefs),
       ...verifiedChallengeRefs,
@@ -252,10 +500,19 @@ const shardsFromEvidence = (
 
     return [
       {
+        corpusProvenanceReceipt,
+        corpusProvenanceReceiptRef:
+          corpusProvenanceReceipt?.receiptRef ?? null,
+        corpusProvenanceVerified,
         inputDocumentCount: optionalNumber(shard.inputDocumentCount) ?? null,
         outputDigestRef,
         pylonRef: optionalString(shard.pylonRef) ?? null,
-        receiptRefs: uniqueRefs(stringArrayFromUnknown(shard.receiptRefs)),
+        receiptRefs: uniqueRefs([
+          ...stringArrayFromUnknown(shard.receiptRefs),
+          ...(corpusProvenanceReceipt === null
+            ? []
+            : [corpusProvenanceReceipt.receiptRef]),
+        ]),
         settledPayoutSats: 0,
         shardRef:
           optionalString(shard.shardRef) ??
@@ -275,6 +532,27 @@ const evalDeltaBonusBlockerRefs = (): ReadonlyArray<string> => [
   'blocker.cs336_a4.operator_funding_required_for_bonus_settlement',
   'blocker.cs336_a4.psionic_classifier_adapters_partial',
 ]
+
+export const corpusProvenanceReceiptStatus = (
+  shards: ReadonlyArray<DataRefineryShard>,
+): DataRefineryProjection['corpusProvenanceReceiptStatus'] => {
+  if (shards.length === 0) {
+    return 'missing'
+  }
+
+  if (shards.every(shard => shard.corpusProvenanceVerified)) {
+    return 'available'
+  }
+
+  return 'partial'
+}
+
+export const corpusProvenanceReceiptBlockerRefs = (
+  shards: ReadonlyArray<DataRefineryShard>,
+): ReadonlyArray<string> =>
+  corpusProvenanceReceiptStatus(shards) === 'available'
+    ? []
+    : ['blocker.cs336_a4.requires_corpus_provenance_receipts']
 
 export const Cs336A4RequiredVerifiedStageCount = 3
 
@@ -304,6 +582,13 @@ export const publicDataRefineryProjection = (
   ].sort() as ReadonlyArray<Cs336A4HomeworkStage>
   const stagesVerified =
     observedVerifiedStages.length >= Cs336A4RequiredVerifiedStageCount
+  const stageBlockerRefs = stagesVerified
+    ? []
+    : [
+        'blocker.cs336_a4.requires_three_verified_stages',
+        'blocker.cs336_a4.operator_funding_required_for_paid_shards',
+      ]
+  const provenanceBlockerRefs = corpusProvenanceReceiptBlockerRefs(shards)
   const status =
     shards.length === 0
       ? 'blocked_no_shards'
@@ -312,13 +597,16 @@ export const publicDataRefineryProjection = (
         : 'collecting_shards'
 
   return {
-    blockerRefs:
-      status === 'stages_verified'
-        ? []
-        : [
-            'blocker.cs336_a4.requires_three_verified_stages',
-            'blocker.cs336_a4.operator_funding_required_for_paid_shards',
-          ],
+    blockerRefs: uniqueRefs([...stageBlockerRefs, ...provenanceBlockerRefs]),
+    corpusProvenanceReceiptBlockerRefs: provenanceBlockerRefs,
+    corpusProvenanceReceiptRefs: uniqueRefs(
+      shards.flatMap(shard =>
+        shard.corpusProvenanceReceiptRef === null
+          ? []
+          : [shard.corpusProvenanceReceiptRef],
+      ),
+    ),
+    corpusProvenanceReceiptStatus: corpusProvenanceReceiptStatus(shards),
     evalDeltaBonusBlockerRefs: evalDeltaBonusBlockerRefs(),
     observedVerifiedShardCount: verifiedShards.length,
     observedVerifiedStages,

--- a/apps/openagents.com/workers/api/src/training-run-window-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/training-run-window-routes.test.ts
@@ -1,6 +1,7 @@
 import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import { buildCs336A4ProvenanceReceipt } from './cs336-a4-provenance'
 import { nexusPylonPublicReceiptDetailFromLedger } from './nexus-pylon-visibility'
 import type {
   NexusPaymentAuthorityReceiptRecord,
@@ -1765,9 +1766,32 @@ describe('training run window routes', () => {
     const adminHeaders = { authorization: 'Bearer admin-token-test' }
     const evidencePath =
       '/api/training/runs/run.cs336.a4.data_refinery.demo/data-refinery-evidence'
+    const outputDigestRef = 'digest.sha256.cs336_a4.pii_masking.aaaa'
+    const corpusProvenanceReceipt = await buildCs336A4ProvenanceReceipt({
+      assignmentRef: 'assignment.cs336_a4.pii_masking.1',
+      finalOutputDigestRef: outputDigestRef,
+      inputShardRef: 'shard.cs336_a4.pii_masking.1',
+      provenance: {
+        acquisitionMode: 'bounded_synthetic_corpus',
+        licenseRef: 'license.public.cc0.synthetic_corpus_v1',
+        snapshotRef: 'snapshot.cs336_a4.pii_masking.v1',
+        sourceRef: 'source.psion.bounded_synthetic_mixture.v1',
+      },
+      sourceInputDigestRef: 'digest.cs336_a4.pii_masking.source',
+      transformChain: [
+        {
+          codeVersionRef: 'psionic.refinery.v1.pii_masking',
+          inputDigestRef: 'digest.cs336_a4.pii_masking.source',
+          outputDigestRef,
+          recomputedDigestRef: outputDigestRef,
+          stage: 'pii_masking',
+        },
+      ],
+    })
     const shard = {
+      corpusProvenanceReceipt,
       inputDocumentCount: 64,
-      outputDigestRef: 'digest.sha256.cs336_a4.pii_masking.aaaa',
+      outputDigestRef,
       pylonRef: 'pylon.24819249b4634a4c9d5e',
       receiptRefs: ['receipt.cs336_a4.settlement.pii_masking'],
       shardRef: 'shard.cs336_a4.pii_masking.1',
@@ -1835,8 +1859,15 @@ describe('training run window routes', () => {
     expect(admitted.status).toBe(200)
     expect(admittedBody.refinery.status).toBe('collecting_shards')
     expect(admittedBody.refinery.shards[0]).toMatchObject({
+      corpusProvenanceReceiptRef: corpusProvenanceReceipt.receiptRef,
+      corpusProvenanceVerified: true,
       stage: 'pii_masking',
       verified: true,
+    })
+    expect(admittedBody.refinery).toMatchObject({
+      corpusProvenanceReceiptBlockerRefs: [],
+      corpusProvenanceReceiptRefs: [corpusProvenanceReceipt.receiptRef],
+      corpusProvenanceReceiptStatus: 'available',
     })
 
     const dashboard = await runRoute(
@@ -1846,6 +1877,7 @@ describe('training run window routes', () => {
       ),
     )
     const dashboardBody = (await dashboard.json()) as Readonly<{
+      corpusProvenanceReceiptStatus: string
       schemaVersion: string
       shards: ReadonlyArray<unknown>
     }>
@@ -1854,6 +1886,7 @@ describe('training run window routes', () => {
     expect(dashboardBody.schemaVersion).toBe(
       'openagents.training.data_refinery_dashboard.v1',
     )
+    expect(dashboardBody.corpusProvenanceReceiptStatus).toBe('available')
     expect(dashboardBody.shards).toHaveLength(1)
   })
 

--- a/apps/openagents.com/workers/api/src/training-run-window-routes.ts
+++ b/apps/openagents.com/workers/api/src/training-run-window-routes.ts
@@ -40,6 +40,8 @@ import {
   Cs336A4DataRefineryEvidenceRequest,
   Cs336A4RequiredVerifiedStageCount,
   admitCs336A4DataRefineryEvidence,
+  corpusProvenanceReceiptBlockerRefs,
+  corpusProvenanceReceiptStatus,
   publicDataRefineryProjection,
 } from './training-data-refinery'
 import {
@@ -1600,15 +1602,29 @@ const routeA4DataRefinery = <Bindings extends TrainingRunWindowRouteEnv>(
         shards.filter(shard => shard.verified).map(shard => shard.stage),
       ),
     ].sort()
+    const stageBlockerRefs =
+      verifiedStages.length >= Cs336A4RequiredVerifiedStageCount
+        ? []
+        : [
+            'blocker.cs336_a4.requires_three_verified_stages',
+            'blocker.cs336_a4.operator_funding_required_for_paid_shards',
+          ]
+    const provenanceBlockerRefs = corpusProvenanceReceiptBlockerRefs(shards)
 
     return noStoreJsonResponse({
-      blockerRefs:
-        verifiedStages.length >= Cs336A4RequiredVerifiedStageCount
-          ? []
-          : [
-              'blocker.cs336_a4.requires_three_verified_stages',
-              'blocker.cs336_a4.operator_funding_required_for_paid_shards',
-            ],
+      blockerRefs: uniqueRouteRefs([
+        ...stageBlockerRefs,
+        ...provenanceBlockerRefs,
+      ]),
+      corpusProvenanceReceiptBlockerRefs: provenanceBlockerRefs,
+      corpusProvenanceReceiptRefs: uniqueRouteRefs(
+        shards.flatMap(shard =>
+          shard.corpusProvenanceReceiptRef === null
+            ? []
+            : [shard.corpusProvenanceReceiptRef],
+        ),
+      ),
+      corpusProvenanceReceiptStatus: corpusProvenanceReceiptStatus(shards),
       evalDeltaBonusBlockerRefs: [
         'blocker.cs336_a4.fixed_trainer_eval_loop_required_for_quality_bonus',
         'blocker.cs336_a4.operator_funding_required_for_bonus_settlement',

--- a/docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md
+++ b/docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md
@@ -46,3 +46,26 @@ This is the receipt *format and integrity check*, not the receipts themselves.
   out of scope for this run.
 
 No promise state was changed; no blocker was dropped from any tracking doc.
+
+## 2026-06-20 live A4 admission/projection wiring
+
+The provenance receipt is now part of the live A4 refinery evidence contract:
+
+- `Cs336A4RefineryStageEvidence` requires `corpusProvenanceReceipt` for newly
+  admitted shards.
+- `admitCs336A4DataRefineryEvidence` rejects shards when the receipt final
+  output digest does not match the shard `outputDigestRef`, when the transform
+  chain is not linked, when a recomputed digest differs from the committed
+  output, or when the receipt carries private/payment/raw-shard material.
+- `publicDataRefineryProjection` exposes each shard's
+  `corpusProvenanceReceiptRef`, `corpusProvenanceVerified`, and public-safe
+  `corpusProvenanceReceipt` object.
+- `GET /api/training/refinery/a4` now reports
+  `corpusProvenanceReceiptStatus`, `corpusProvenanceReceiptRefs`, and
+  `corpusProvenanceReceiptBlockerRefs` across the dashboard.
+
+This wires the receipt shape into the admission/projection boundary. It still
+does **not** clear `corpus_provenance_receipts_missing`: there is no live paid
+refinery shard closeout whose deterministic-recompute verifier and provider
+settlement produced one of these provenance receipts. `crawl_scale_corpus_missing`
+and `eval_delta_payment_missing` are also unchanged.


### PR DESCRIPTION
## Summary
- require each newly admitted CS336 A4 data-refinery shard to carry a linked `corpusProvenanceReceipt`
- validate final-output digest binding, transform-chain linkage, deterministic recompute match, content-addressed receipt ref, and public-safety boundaries
- project `corpusProvenanceReceiptStatus`, refs, and blocker refs in run-level A4 projections and the `/api/training/refinery/a4` dashboard
- update `training.data_refinery_corpus.v1` evidence/copy to registry `2026-06-20.35`

## Promise Boundary
- `training.data_refinery_corpus.v1` stays planned
- `blocker.product_promises.crawl_scale_corpus_missing`, `blocker.product_promises.corpus_provenance_receipts_missing`, and `blocker.product_promises.eval_delta_payment_missing` all remain active
- no crawl acquisition, paid shard dispatch, deterministic-recompute verdict, settlement, decontamination receipt, eval-delta payment, corpus sale, or green transition is created

## Verification
- `bunx vitest run src/cs336-a4-provenance.test.ts src/training-data-refinery.test.ts src/training-run-window-routes.test.ts src/product-promises.test.ts`
- `bun run check:deploy`