### PR TITLE
Add largest training claim status projection

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -53,6 +53,10 @@ import {
   handleTrainingPublicDistributedRunScaleApi,
 } from './training-public-distributed-run-scale-routes'
 import {
+  PylonLargestDecentralizedTrainingClaimEndpoint,
+  handlePylonLargestDecentralizedTrainingClaimStatusApi,
+} from './pylon-largest-decentralized-training-claim-status-routes'
+import {
   TrainingPostTrainingInstructSftEndpoint,
   handleTrainingPostTrainingInstructSftApi,
 } from './training-post-training-instruct-sft-routes'
@@ -8020,6 +8024,11 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     path: TrainingPublicDistributedRunScaleEndpoint,
     handler: (request, env) =>
       handleTrainingPublicDistributedRunScaleApi(request, env),
+  },
+  {
+    path: PylonLargestDecentralizedTrainingClaimEndpoint,
+    handler: (request, env) =>
+      handlePylonLargestDecentralizedTrainingClaimStatusApi(request, env),
   },
   {
     path: '/api/public/activity-timeline',

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -189,6 +189,13 @@ describe('OpenAgents OpenAPI route', () => {
     expect(
       operationAt(
         body,
+        '/api/public/pylon/largest-decentralized-training-claim',
+        'get',
+      ).operationId,
+    ).toBe('getPylonLargestDecentralizedTrainingClaimStatus')
+    expect(
+      operationAt(
+        body,
         '/api/public/training/public-gradient-windows',
         'get',
       ).operationId,
@@ -641,6 +648,13 @@ describe('OpenAgents OpenAPI route', () => {
       operationAt(
         body,
         '/api/public/training/public-distributed-run-scale',
+        'get',
+      ).security,
+    ).toEqual([])
+    expect(
+      operationAt(
+        body,
+        '/api/public/pylon/largest-decentralized-training-claim',
         'get',
       ).security,
     ).toEqual([])

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -21,6 +21,7 @@ import { ForumPostBodyTextMaxLength } from './forum-limits'
 import { OmniApiSdkSeedEndpoint } from './omni-api-sdk-seed'
 import { PublicProductPromisesVersion } from './product-promises'
 import { PublicLaunchDashboardEndpoint } from './public-launch-dashboard'
+import { PylonLargestDecentralizedTrainingClaimEndpoint } from './pylon-largest-decentralized-training-claim-status'
 import { TassadarPerceptaArchitectureReceiptsEndpoint } from './tassadar-percepta-architecture-receipts'
 import { TrainingAblationDeriskingLedgerEndpoint } from './training-ablation-derisking-ledger'
 import { TrainingFullPipelineProgramEndpoint } from './training-full-pipeline-program'
@@ -781,6 +782,14 @@ export const TrainingPublicDistributedRunScaleEnvelope: JsonSchema = {
     'Public-safe scale-status projection for training.public_distributed_training_run.v1. Carries generatedAt, registryVersion, a live_at_read staleness contract, the documented >=50 qualified-contributor network-scale threshold, current public run counters, scale axes, and explicit blocker refs. It keeps networkScaleThresholdMet=false for the current bounded run, keeps ownerSignedUpgradeAvailable=false, and keeps greenGateSatisfied=false until comparable-scale accepted-work and real-settlement receipts plus owner signoff exist. It exposes refs and counters only: no private runner logs, provider payloads, wallet material, payment material, dispatch authority, settlement authority, largest-run claim, model-quality claim, or green product-promise authority.',
 }
 
+export const PylonLargestDecentralizedTrainingClaimStatusEnvelope: JsonSchema =
+  {
+    type: 'object',
+    additionalProperties: true,
+    description:
+      'Public-safe largest-run claim status projection for pylon.largest_decentralized_training_claim.v1. Carries generatedAt, registryVersion, a live_at_read staleness contract, the documented ~70 contributor comparable benchmark, the 200 contributor transcript target, current public run counters, comparison rows, and explicit blocker refs. It keeps concreteComparableThresholdMet=false, transcriptTargetThresholdMet=false, ownerSignedUpgradeAvailable=false, and greenGateSatisfied=false for the current bounded run. It exposes refs and counters only: no private runner logs, provider payloads, wallet material, payment material, dispatch authority, settlement authority, largest-run claim, benchmark-victory claim, network-scale claim, or green product-promise authority.',
+  }
+
 export const TrainingPublicGradientWindowsEnvelope: JsonSchema = {
   type: 'object',
   additionalProperties: true,
@@ -1395,6 +1404,7 @@ const schemaComponents = (): JsonSchema => ({
   TrainingMarathonOperationsEnvelope,
   TrainingModelLadderRungsEnvelope,
   TrainingPublicDistributedRunScaleEnvelope,
+  PylonLargestDecentralizedTrainingClaimStatusEnvelope,
   TrainingPublicGradientWindowsEnvelope,
   TrainingAblationDeriskingLedgerEnvelope,
   TassadarPerceptaArchitectureReceiptsEnvelope,
@@ -5452,6 +5462,23 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Public distributed-run scale status.',
           '#/components/schemas/TrainingPublicDistributedRunScaleEnvelope',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  [PylonLargestDecentralizedTrainingClaimEndpoint]: {
+    get: operation({
+      operationId: 'getPylonLargestDecentralizedTrainingClaimStatus',
+      summary: 'Read largest decentralized training claim status',
+      description:
+        'Returns the public-safe status projection for pylon.largest_decentralized_training_claim.v1. It compares the current public training-run qualified-contributor count against the cited ~70 contributor comparable and the 200 contributor transcript target while keeping concreteComparableThresholdMet=false, transcriptTargetThresholdMet=false, ownerSignedUpgradeAvailable=false, and greenGateSatisfied=false for the bounded run. Read-only; grants no contributor admission, training dispatch, spend, settlement, largest-run claim, benchmark-victory claim, network-scale claim, or public-claim authority.',
+      tags: ['Pylon', 'Public Proof'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Largest decentralized training claim status.',
+          '#/components/schemas/PylonLargestDecentralizedTrainingClaimStatusEnvelope',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -88,7 +88,7 @@ describe('public product promises document', () => {
       publicProductPromisesDocument(),
     )
 
-    expect(decoded.version).toBe('2026-06-20.42')
+    expect(decoded.version).toBe('2026-06-20.43')
     expect(decoded.registryVersion).toBe(decoded.version)
     expect(Date.parse(decoded.generatedAt)).not.toBeNaN()
     expect(decoded.maxStalenessSeconds).toBe(0)
@@ -109,6 +109,9 @@ describe('public product promises document', () => {
     )
     expect(decoded.sourceRefs).toContain(
       'docs/launch/vertex-fleet/training.public_distributed_training_run.v1.md',
+    )
+    expect(decoded.sourceRefs).toContain(
+      'docs/launch/vertex-fleet/pylon.largest_decentralized_training_claim.v1.md',
     )
     expect(decoded.sourceRefs).toContain(
       'docs/launch/vertex-fleet/training.marathon_operations.v1.md',
@@ -270,6 +273,8 @@ describe('public product promises document', () => {
     // receipt-backed live standby promotion exists, so green remains exactly 24.
     // The 2026-06-20.42 public distributed-run scale pass adds a public status
     // projection but keeps the network-scale receipt blocker active.
+    // The 2026-06-20.43 largest-run claim pass adds a public benchmark
+    // projection but keeps the contributor-receipts blocker active.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
     ).toBe(24)
@@ -545,12 +550,16 @@ describe('public product promises document', () => {
           evidenceRefs: expect.arrayContaining([
             'docs/training/2026-06-19-decentralized-training-participant-scale-methodology.md',
             'docs/training/2026-06-19-comparable-decentralized-training-runs-research.md',
+            'docs/launch/vertex-fleet/pylon.largest_decentralized_training_claim.v1.md',
+            'route:/api/public/pylon/largest-decentralized-training-claim',
+            'apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.ts',
+            'apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.test.ts',
           ]),
           safeCopy: expect.stringContaining(
-            'count methodology plus comparable training-run research are now documented',
+            'GET /api/public/pylon/largest-decentralized-training-claim',
           ),
           verification: expect.stringContaining(
-            'five counted realBitcoinMoved:true contributors',
+            'transcriptTargetThresholdMet=false',
           ),
         }),
         expect.objectContaining({
@@ -1034,6 +1043,8 @@ describe('public product promises document', () => {
       expect.arrayContaining([
         'docs/training/2026-06-19-decentralized-training-participant-scale-methodology.md',
         'docs/training/2026-06-19-comparable-decentralized-training-runs-research.md',
+        'route:/api/public/pylon/largest-decentralized-training-claim',
+        'apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.ts',
       ]),
     )
     expect(
@@ -1235,12 +1246,12 @@ describe('public product promises document', () => {
     const document = publicProductPromisesDocument()
 
     expect(
-      publicProductPromisesAnnouncementReadiness('2026-06-20.42', document),
+      publicProductPromisesAnnouncementReadiness('2026-06-20.43', document),
     ).toMatchObject({
       blockerRefs: [],
-      expectedVersion: '2026-06-20.42',
+      expectedVersion: '2026-06-20.43',
       maxStalenessSeconds: 0,
-      servedVersion: '2026-06-20.42',
+      servedVersion: '2026-06-20.43',
       status: 'ready',
     })
     expect(
@@ -1250,7 +1261,7 @@ describe('public product promises document', () => {
         'product-promises-announcement-blocker:expected-version-not-served:2026-06-12.1',
       ],
       expectedVersion: '2026-06-12.1',
-      servedVersion: '2026-06-20.42',
+      servedVersion: '2026-06-20.43',
       status: 'blocked',
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-20.42'
+export const PublicProductPromisesVersion = '2026-06-20.43'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -29,6 +29,7 @@ const sourceRefs = [
   'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
   'docs/training/2026-06-20-training-full-pipeline-program-status.md',
   'docs/launch/vertex-fleet/training.public_distributed_training_run.v1.md',
+  'docs/launch/vertex-fleet/pylon.largest_decentralized_training_claim.v1.md',
   'docs/launch/vertex-fleet/training.marathon_operations.v1.md',
   'docs/training/2026-06-20-cs336-a2-same-class-replication-status.md',
   'docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md',
@@ -598,7 +599,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'OpenAgents/Pylon can make or beat a largest decentralized training run claim against a 200-contributor benchmark.',
         safeCopy:
-          'Do not make a largest-run claim yet; Episode 236 renews the target, and the count methodology plus comparable training-run research are now documented, but the current public run remains far below comparable scale.',
+          'Do not make a largest-run claim yet; Episode 236 renews the target, and the count methodology plus comparable training-run research are now documented. GET /api/public/pylon/largest-decentralized-training-claim compares the current public run to the ~70 contributor comparable and 200 contributor target, and it reports the current run remains far below comparable scale.',
         unsafeCopy:
           'Do not say OpenAgents has the largest decentralized training run, has beaten Bittensor, or has 200+ contributors unless current comparable evidence exists.',
         evidenceRefs: [
@@ -609,14 +610,19 @@ export const publicProductPromisesDocument = () => {
           'docs/training/2026-06-19-decentralized-training-participant-scale-methodology.md',
           'docs/training/2026-06-19-comparable-decentralized-training-runs-research.md',
           'docs/promises/2026-06-19-pylon-non-green-promise-assault-assessment.md',
+          'docs/launch/vertex-fleet/pylon.largest_decentralized_training_claim.v1.md',
+          'route:/api/public/pylon/largest-decentralized-training-claim',
+          'apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.ts',
+          'apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status-routes.ts',
+          'apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.test.ts',
         ],
         blockerRefs: [
           'blocker.product_promises.public_training_contributor_receipts_missing',
         ],
         verification:
-          'Green requires participant count methodology, run definition, training evidence, accepted-work receipts, public verification, and a comparison rule that is current and comparable. The qualified-contributor counting rule is now written and dereferenceable (docs/training/2026-06-19-decentralized-training-participant-scale-methodology.md, enforced in training-run-window-authority.ts) and the comparable runs are documented with citations (docs/training/2026-06-19-comparable-decentralized-training-runs-research.md: Templar Covenant-72B ~70 contributors, ~200 is the transcript target). This clears the methodology and comparable-evidence gaps as written evidence only; the promise stays red because the live run has five counted realBitcoinMoved:true contributors, far below the comparable scale, so public_training_contributor_receipts_missing is unmet. No green flip without an actual comparable-scale run and an owner-signed receipt-first upgrade.',
+          'Green requires participant count methodology, run definition, training evidence, accepted-work receipts, public verification, and a comparison rule that is current and comparable. The qualified-contributor counting rule is now written and dereferenceable (docs/training/2026-06-19-decentralized-training-participant-scale-methodology.md, enforced in training-run-window-authority.ts) and the comparable runs are documented with citations (docs/training/2026-06-19-comparable-decentralized-training-runs-research.md: Templar Covenant-72B ~70 contributors, ~200 is the transcript target). As of registry 2026-06-20.43, GET /api/public/pylon/largest-decentralized-training-claim reads the public distributed-run scale projection and reports qualifiedContributorCount=5, concreteComparableThresholdMet=false, transcriptTargetThresholdMet=false, ownerSignedUpgradeAvailable=false, and greenGateSatisfied=false. This clears the methodology and comparable-evidence gaps as written evidence only; the promise stays red because the live run has five counted realBitcoinMoved:true contributors, far below the comparable scale, so public_training_contributor_receipts_missing is unmet. No green flip without an actual comparable-scale run and an owner-signed receipt-first upgrade.',
         authorityBoundary:
-          'Marketing comparisons do not grant proof. Public copy must degrade to the receipts actually available.',
+          'Marketing comparisons and public status projections do not grant proof. Public copy must degrade to the receipts actually available; this projection grants no contributor admission, training dispatch, spend, settlement, benchmark victory, largest-run claim, network-scale claim, or product-promise transition authority.',
       },
       {
         ...basePromiseFields,
@@ -3600,6 +3606,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-20.40 is a training.model_ladder.v1 public rung-status projection pass and flips NO promise state (stays planned, green count unchanged at 24). GET /api/public/training/model-ladder-rungs now serves a public-safe, live-at-read projection over R0-R4 rung definitions, the retained R0 rehearsal, the six R1 closeout criteria, and the five-field economics-gate format. It reports rungEconomicsGateFormatAvailable=true and publicProjectionAvailable=true, but r1FullRehearsalAvailable=false, r1CloseoutReceiptAvailable=false, r2NetworkRungReceiptAvailable=false, r1PopulatedReportAvailable=false, settledNetworkEconomicsAvailable=false, and greenGateSatisfied=false. blocker.product_promises.r1_full_rehearsal_missing remains because no rung above R0 has run to a closeout receipt; pylon.first_real_model_training_run.v1 still needs blocker.product_promises.model_ladder_network_rungs_not_run cleared by a real R2-or-above network rung. No rung run, training dispatch, spend, settlement, model artifact, eval, model promotion, capability claim, network-training claim, or green transition is created. Evidence: docs/training/2026-06-19-model-ladder-rung-economics.md and apps/openagents.com/workers/api/src/training-model-ladder-rungs.ts.',
         'Registry 2026-06-20.41 is a training.marathon_operations.v1 public status projection pass and flips NO promise state (stays planned, green count unchanged at 24). GET /api/public/training/marathon-operations now serves a public-safe, live-at-read projection over durable-checkpoint sealing, standby dispatch, and curtailment drill gates. It reports durable checkpoint and standby predicates visible, but durableCheckpointRemoteReadbackReceiptAvailable=false, liveStandbyPromotionReceiptAvailable=false, curtailmentDrillReceiptAvailable=false, marathonCloseoutReceiptAvailable=false, receiptBackedLiveOperationCount=0, and greenGateSatisfied=false. All blockers remain active: durable_checkpoint_seal_missing, standby_dispatch_missing, and curtailment_drill_missing. No checkpoint store read-back, standby promotion, training dispatch, spend, settlement, curtailment event, flexible-load evidence, model promotion, or green transition is created. Evidence: docs/launch/vertex-fleet/training.marathon_operations.v1.md and apps/openagents.com/workers/api/src/training-marathon-operations.ts.',
         'Registry 2026-06-20.42 is a training.public_distributed_training_run.v1 public scale-status projection pass and flips NO promise state (stays red, green count unchanged at 24). GET /api/public/training/public-distributed-run-scale now reads the existing public training-run summary and settlement reconciliation and projects the current bounded run against the documented >=50 qualified-contributor network-scale threshold: qualifiedContributorCount=5, acceptedTraceCount=11, realSettlementReceiptCount=5, networkScaleThresholdMet=false, ownerSignedUpgradeAvailable=false, and greenGateSatisfied=false. blocker.product_promises.public_distributed_training_run_receipts_missing remains active because the five bounded canary-scale settlements satisfy existence of multi-contributor real settlement but not comparable network-scale accepted-work receipts. No participant-scale run, at-scale dispatch, spend, settlement, largest-run claim, model-quality claim, public training capability claim, yellow/green transition, or owner-signed upgrade is created. Evidence: docs/launch/vertex-fleet/training.public_distributed_training_run.v1.md and apps/openagents.com/workers/api/src/training-public-distributed-run-scale.ts.',
+        'Registry 2026-06-20.43 is a pylon.largest_decentralized_training_claim.v1 public status projection pass and flips NO promise state (stays red, green count unchanged at 24). GET /api/public/pylon/largest-decentralized-training-claim now reads the public distributed-run scale projection and compares the current bounded run to both the cited ~70 contributor Templar Covenant-72B comparable and the Episode 236 200 contributor target: qualifiedContributorCount=5, acceptedTraceCount=11, realSettlementReceiptCount=5, concreteComparableThresholdMet=false, transcriptTargetThresholdMet=false, ownerSignedUpgradeAvailable=false, and greenGateSatisfied=false. blocker.product_promises.public_training_contributor_receipts_missing remains active because the five bounded canary-scale contributors are far below comparable largest-run scale. No participant-scale run, at-scale dispatch, spend, settlement, benchmark-victory claim, largest-run claim, network-scale claim, yellow/green transition, or owner-signed upgrade is created. Evidence: docs/launch/vertex-fleet/pylon.largest_decentralized_training_claim.v1.md and apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.ts.',
         'Do not post secrets, wallet material, provider payloads, private repository data, raw invoices, preimages, or customer-sensitive content in public reports.',
     ],
   }

--- a/apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status-routes.ts
@@ -1,0 +1,45 @@
+import { Effect } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import { buildPublicTassadarRunSummaryEnvelopeForRequest } from './public-tassadar-run-summary-routes'
+import {
+  PylonLargestDecentralizedTrainingClaimEndpoint,
+  projectPylonLargestDecentralizedTrainingClaimStatusFromEnvelope,
+} from './pylon-largest-decentralized-training-claim-status'
+
+export { PylonLargestDecentralizedTrainingClaimEndpoint }
+
+type PylonLargestClaimStatusDependencies<Bindings> = Readonly<{
+  buildSummaryEnvelope?: (
+    request: Request,
+    env: Bindings,
+  ) => Promise<Record<string, unknown>>
+}>
+
+const defaultBuildSummaryEnvelope =
+  buildPublicTassadarRunSummaryEnvelopeForRequest as (
+    request: Request,
+    env: unknown,
+  ) => Promise<Record<string, unknown>>
+
+export const handlePylonLargestDecentralizedTrainingClaimStatusApi = <Bindings>(
+  request: Request,
+  env: Bindings,
+  dependencies: PylonLargestClaimStatusDependencies<Bindings> = {},
+) =>
+  request.method !== 'GET'
+    ? Effect.succeed(methodNotAllowed(['GET']))
+    : Effect.promise(() =>
+        (dependencies.buildSummaryEnvelope ?? defaultBuildSummaryEnvelope)(
+          request,
+          env,
+        ),
+      ).pipe(
+        Effect.map(envelope =>
+          noStoreJsonResponse(
+            projectPylonLargestDecentralizedTrainingClaimStatusFromEnvelope(
+              envelope,
+            ),
+          ),
+        ),
+      )

--- a/apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.test.ts
@@ -1,0 +1,216 @@
+import { Effect, Schema as S } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  PylonLargestConcreteComparableContributorBenchmark,
+  PylonLargestDecentralizedTrainingClaimBlocker,
+  PylonLargestDecentralizedTrainingClaimEndpoint,
+  PylonLargestDecentralizedTrainingClaimProjection,
+  PylonLargestTranscriptTargetContributorBenchmark,
+  projectPylonLargestDecentralizedTrainingClaimStatusFromEnvelope,
+} from './pylon-largest-decentralized-training-claim-status'
+import { handlePylonLargestDecentralizedTrainingClaimStatusApi } from './pylon-largest-decentralized-training-claim-status-routes'
+import { TrainingPublicDistributedRunScaleEndpoint } from './training-public-distributed-run-scale'
+
+const liveRunLikeEnvelope = {
+  corpus: {
+    acceptedTraceCount: 11,
+    traceRefs: ['training.verification.challenge.example.trace'],
+    verdictRefs: ['verdict.training.exact_trace_replay.example'],
+  },
+  generatedAt: '2026-06-20T12:00:00.000Z',
+  metrics: {
+    providerConfirmedSettledPayoutSats: {
+      sourceRefs: [
+        'training.run.run.tassadar.executor.20260615.provider_confirmed_settlements',
+      ],
+      value: 1020,
+    },
+    qualifiedContributorCount: {
+      sourceRefs: [
+        'pylon.qualified.example.1',
+        'receipt.nexus.tassadar_run_settlement.example.1',
+      ],
+      value: 5,
+    },
+    verifiedWorkCount: {
+      sourceRefs: ['training.verification.challenge.example.trace'],
+      value: 11,
+    },
+  },
+  runRef: 'run.tassadar.executor.20260615',
+  runState: 'active',
+  schemaVersion: 'openagents.public_tassadar_run_summary.v1',
+  settlement: {
+    settledPayoutSats: 1020,
+    settledReceiptCount: 5,
+    sourceRefs: [
+      'training.run.run.tassadar.executor.20260615.provider_confirmed_settlements',
+    ],
+  },
+  sourceRefs: [
+    'route:/api/public/training/runs/run.tassadar.executor.20260615',
+    'route:/api/public/training/runs/run.tassadar.executor.20260615/settlements',
+  ],
+} as const
+
+describe('pylon largest decentralized training claim status projection', () => {
+  test('compares the current run to largest-run benchmarks without clearing the blocker', () => {
+    const projection =
+      projectPylonLargestDecentralizedTrainingClaimStatusFromEnvelope(
+        liveRunLikeEnvelope,
+      )
+
+    expect(
+      S.decodeUnknownSync(PylonLargestDecentralizedTrainingClaimProjection)(
+        projection,
+      ),
+    ).toEqual(projection)
+    expect(projection.endpoint).toBe(
+      PylonLargestDecentralizedTrainingClaimEndpoint,
+    )
+    expect(projection.promiseRef).toBe(
+      'promise:pylon.largest_decentralized_training_claim.v1',
+    )
+    expect(projection.promiseState).toBe('red')
+    expect(projection.gate).toMatchObject({
+      clearsBlockerRefs: [],
+      comparableRunResearchAvailable: true,
+      concreteComparableThresholdMet: false,
+      greenGateSatisfied: false,
+      ownerSignedUpgradeAvailable: false,
+      participantCountMethodologyAvailable: true,
+      publicContributorReceiptsAtClaimBenchmarkAvailable: false,
+      publicRunScaleProjectionAvailable: true,
+      remainingBlockerRefs: [PylonLargestDecentralizedTrainingClaimBlocker],
+      transcriptTargetThresholdMet: false,
+    })
+    expect(projection.benchmark).toMatchObject({
+      concreteComparableContributorBenchmark:
+        PylonLargestConcreteComparableContributorBenchmark,
+      transcriptTargetContributorBenchmark:
+        PylonLargestTranscriptTargetContributorBenchmark,
+    })
+    expect(projection.runScale).toMatchObject({
+      acceptedTraceCount: 11,
+      currentScaleLabel: 'canary_scale',
+      providerConfirmedSettledPayoutSats: 1020,
+      qualifiedContributorCount: 5,
+      realSettlementReceiptCount: 5,
+      runRef: 'run.tassadar.executor.20260615',
+      runState: 'active',
+      sourceScaleEndpoint: TrainingPublicDistributedRunScaleEndpoint,
+    })
+    expect(projection.comparisonRows.map(row => row.benchmarkId)).toEqual([
+      'templar_covenant_72b_published_comparable',
+      'episode_236_transcript_target',
+    ])
+    expect(projection.comparisonRows[0]).toMatchObject({
+      currentQualifiedContributorCount: 5,
+      deficit: 65,
+      requiredQualifiedContributorCount: 70,
+      thresholdMet: false,
+    })
+    expect(projection.comparisonRows[1]).toMatchObject({
+      currentQualifiedContributorCount: 5,
+      deficit: 195,
+      requiredQualifiedContributorCount: 200,
+      thresholdMet: false,
+    })
+  })
+
+  test('keeps owner signoff and green gates closed even when counters reach the target', () => {
+    const projection =
+      projectPylonLargestDecentralizedTrainingClaimStatusFromEnvelope({
+        ...liveRunLikeEnvelope,
+        corpus: { ...liveRunLikeEnvelope.corpus, acceptedTraceCount: 210 },
+        metrics: {
+          ...liveRunLikeEnvelope.metrics,
+          qualifiedContributorCount: {
+            sourceRefs: ['receipt.example.benchmark'],
+            value: 200,
+          },
+          verifiedWorkCount: {
+            sourceRefs: ['training.verification.challenge.example.benchmark'],
+            value: 210,
+          },
+        },
+        settlement: {
+          ...liveRunLikeEnvelope.settlement,
+          settledReceiptCount: 200,
+        },
+      })
+
+    expect(projection.gate.concreteComparableThresholdMet).toBe(true)
+    expect(projection.gate.transcriptTargetThresholdMet).toBe(true)
+    expect(
+      projection.gate.publicContributorReceiptsAtClaimBenchmarkAvailable,
+    ).toBe(true)
+    expect(projection.gate.ownerSignedUpgradeAvailable).toBe(false)
+    expect(projection.gate.greenGateSatisfied).toBe(false)
+    expect(projection.statusLabel).toContain('owner-signed')
+  })
+
+  test('keeps authority and private material out of the public projection', () => {
+    const projection =
+      projectPylonLargestDecentralizedTrainingClaimStatusFromEnvelope(
+        liveRunLikeEnvelope,
+      )
+    const serialized = JSON.stringify(projection)
+
+    expect(projection.authorityBoundary).toContain('grants no')
+    expect(projection.unsafeCopy).toContain('Do not say')
+    expect(serialized).not.toMatch(
+      /wallet|invoice|preimage|payment_hash|secret|raw_prompt|private_repo|\/home\/|\/Users\//i,
+    )
+  })
+
+  test('serves the public route as no-store JSON', async () => {
+    const response = await Effect.runPromise(
+      handlePylonLargestDecentralizedTrainingClaimStatusApi(
+        new Request(
+          `https://openagents.com${PylonLargestDecentralizedTrainingClaimEndpoint}`,
+        ),
+        {},
+        {
+          buildSummaryEnvelope: async () => liveRunLikeEnvelope,
+        },
+      ),
+    )
+    const body = (await response.json()) as Readonly<{
+      endpoint: string
+      gate: Readonly<{
+        greenGateSatisfied: boolean
+        remainingBlockerRefs: ReadonlyArray<string>
+        transcriptTargetThresholdMet: boolean
+      }>
+      runScale: Readonly<{
+        qualifiedContributorCount: number
+      }>
+    }>
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body.endpoint).toBe(PylonLargestDecentralizedTrainingClaimEndpoint)
+    expect(body.gate.transcriptTargetThresholdMet).toBe(false)
+    expect(body.gate.greenGateSatisfied).toBe(false)
+    expect(body.gate.remainingBlockerRefs).toEqual([
+      PylonLargestDecentralizedTrainingClaimBlocker,
+    ])
+    expect(body.runScale.qualifiedContributorCount).toBe(5)
+  })
+
+  test('rejects non-GET methods', async () => {
+    const response = await Effect.runPromise(
+      handlePylonLargestDecentralizedTrainingClaimStatusApi(
+        new Request(
+          `https://openagents.com${PylonLargestDecentralizedTrainingClaimEndpoint}`,
+          { method: 'POST' },
+        ),
+        {},
+      ),
+    )
+
+    expect(response.status).toBe(405)
+  })
+})

--- a/apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.ts
+++ b/apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.ts
@@ -1,0 +1,225 @@
+import { Schema as S } from 'effect'
+
+import { PublicProductPromisesVersion } from './product-promises'
+import {
+  PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import {
+  TrainingPublicDistributedRunNetworkScaleQualifiedContributorThreshold,
+  TrainingPublicDistributedRunScaleEndpoint,
+  projectTrainingPublicDistributedRunScaleFromEnvelope,
+} from './training-public-distributed-run-scale'
+
+export const PylonLargestDecentralizedTrainingClaimEndpoint =
+  '/api/public/pylon/largest-decentralized-training-claim'
+export const PylonLargestDecentralizedTrainingClaimSchemaVersion =
+  'openagents.pylon.largest_decentralized_training_claim.status.v1'
+export const PylonLargestDecentralizedTrainingClaimBlocker =
+  'blocker.product_promises.public_training_contributor_receipts_missing'
+export const PylonLargestConcreteComparableContributorBenchmark = 70
+export const PylonLargestTranscriptTargetContributorBenchmark = 200
+
+export const PylonLargestDecentralizedTrainingClaimStaleness =
+  liveAtReadStaleness([
+    'training_run_state_transition_recorded',
+    'training_verification_challenge_verified_transition_recorded',
+    'training_run_settlement_receipt_recorded',
+    'product_promise_registry_updated',
+  ])
+
+const unsafePublicMaterialPattern =
+  /(\"?(deviceId|deviceRef|nodeId|nodeRef|ownerId|ownerRef|pylonId|pylonRef|wallet[A-Za-z0-9_-]*|mnemonic|payment[A-Za-z0-9_-]*|preimage|invoice|bolt11|bolt12|lno1|secret[A-Za-z0-9_-]*|private[A-Za-z0-9_-]*)\"?\s*:|\/Users\/|\/home\/|api[_-]?key|bearer|lnbc|lntb|lno1|mnemonic|payment[_-]?(hash|preimage)|preimage|raw[_-]?(dataset|invoice|payment|payload|prompt|runner)|seed[_-]?phrase|sk-[a-z0-9]|wallet[_-]?(home|path|seed|mnemonic|private))/i
+
+const uniqueRefs = (refs: ReadonlyArray<string>): ReadonlyArray<string> =>
+  [...new Set(refs.map(ref => ref.trim()).filter(ref => ref !== ''))].sort()
+
+const thresholdDeficit = (current: number, required: number): number =>
+  Math.max(0, required - current)
+
+export class PylonLargestTrainingBenchmarkRow extends S.Class<PylonLargestTrainingBenchmarkRow>(
+  'PylonLargestTrainingBenchmarkRow',
+)({
+  benchmarkId: S.String,
+  currentQualifiedContributorCount: S.Int,
+  deficit: S.Int,
+  label: S.String,
+  requiredQualifiedContributorCount: S.Int,
+  sourceRefs: S.Array(S.String),
+  thresholdMet: S.Boolean,
+}) {}
+
+export class PylonLargestDecentralizedTrainingClaimProjection extends S.Class<PylonLargestDecentralizedTrainingClaimProjection>(
+  'PylonLargestDecentralizedTrainingClaimProjection',
+)({
+  authorityBoundary: S.String,
+  benchmark: S.Struct({
+    concreteComparableContributorBenchmark: S.Int,
+    concreteComparableDocRef: S.String,
+    networkScaleQualifiedContributorThreshold: S.Int,
+    transcriptTargetContributorBenchmark: S.Int,
+  }),
+  comparisonRows: S.Array(PylonLargestTrainingBenchmarkRow),
+  endpoint: S.Literal(PylonLargestDecentralizedTrainingClaimEndpoint),
+  gate: S.Struct({
+    clearsBlockerRefs: S.Array(S.String),
+    comparableRunResearchAvailable: S.Boolean,
+    concreteComparableThresholdMet: S.Boolean,
+    greenGateSatisfied: S.Boolean,
+    ownerSignedUpgradeAvailable: S.Boolean,
+    participantCountMethodologyAvailable: S.Boolean,
+    publicContributorReceiptsAtClaimBenchmarkAvailable: S.Boolean,
+    publicRunScaleProjectionAvailable: S.Boolean,
+    remainingBlockerRefs: S.Array(S.String),
+    transcriptTargetThresholdMet: S.Boolean,
+  }),
+  generatedAt: S.String,
+  promiseRef: S.Literal(
+    'promise:pylon.largest_decentralized_training_claim.v1',
+  ),
+  promiseState: S.Literal('red'),
+  registryVersion: S.Literal(PublicProductPromisesVersion),
+  runScale: S.Struct({
+    acceptedTraceCount: S.Int,
+    currentScaleLabel: S.Literals(['idle', 'canary_scale', 'network_scale']),
+    providerConfirmedSettledPayoutSats: S.Int,
+    qualifiedContributorCount: S.Int,
+    realSettlementReceiptCount: S.Int,
+    runRef: S.String,
+    runState: S.String,
+    sourceScaleEndpoint: S.Literal(TrainingPublicDistributedRunScaleEndpoint),
+  }),
+  schemaVersion: S.Literal(PylonLargestDecentralizedTrainingClaimSchemaVersion),
+  sourceRefs: S.Array(S.String),
+  staleness: PublicProjectionStalenessContract,
+  status: S.Literal('largest_decentralized_training_claim_status_projection'),
+  statusLabel: S.String,
+  unsafeCopy: S.String,
+}) {}
+
+export class PylonLargestDecentralizedTrainingClaimUnsafe extends Error {
+  readonly _tag = 'PylonLargestDecentralizedTrainingClaimUnsafe'
+}
+
+const assertPublicSafeValue = (label: string, value: unknown): void => {
+  if (unsafePublicMaterialPattern.test(JSON.stringify(value))) {
+    throw new PylonLargestDecentralizedTrainingClaimUnsafe(
+      `${label} contains material that is not public-safe.`,
+    )
+  }
+}
+
+export const projectPylonLargestDecentralizedTrainingClaimStatusFromEnvelope = (
+  envelope: Record<string, unknown>,
+): PylonLargestDecentralizedTrainingClaimProjection => {
+  const scaleProjection =
+    projectTrainingPublicDistributedRunScaleFromEnvelope(envelope)
+  const qualifiedContributorCount =
+    scaleProjection.runScale.qualifiedContributorCount
+  const concreteComparableThresholdMet =
+    qualifiedContributorCount >= PylonLargestConcreteComparableContributorBenchmark
+  const transcriptTargetThresholdMet =
+    qualifiedContributorCount >= PylonLargestTranscriptTargetContributorBenchmark
+  const sourceRefs = uniqueRefs([
+    'docs/launch/vertex-fleet/pylon.largest_decentralized_training_claim.v1.md',
+    'docs/training/2026-06-19-decentralized-training-participant-scale-methodology.md',
+    'docs/training/2026-06-19-comparable-decentralized-training-runs-research.md',
+    'docs/training/2026-06-19-public-distributed-training-run-scale-methodology.md',
+    'apps/openagents.com/workers/api/src/pylon-largest-decentralized-training-claim-status.ts',
+    'apps/openagents.com/workers/api/src/training-public-distributed-run-scale.ts',
+    TrainingPublicDistributedRunScaleEndpoint,
+    ...scaleProjection.sourceRefs,
+  ])
+
+  const projection =
+    new PylonLargestDecentralizedTrainingClaimProjection({
+      authorityBoundary:
+        'Read-only largest-run claim status projection for pylon.largest_decentralized_training_claim.v1. It compares existing public training-run counters to documented benchmarks only; it grants no contributor admission, training dispatch, spend, settlement, benchmark victory, largest-run claim, network-scale claim, or green product-promise authority.',
+      benchmark: {
+        concreteComparableContributorBenchmark:
+          PylonLargestConcreteComparableContributorBenchmark,
+        concreteComparableDocRef:
+          'docs/training/2026-06-19-comparable-decentralized-training-runs-research.md',
+        networkScaleQualifiedContributorThreshold:
+          TrainingPublicDistributedRunNetworkScaleQualifiedContributorThreshold,
+        transcriptTargetContributorBenchmark:
+          PylonLargestTranscriptTargetContributorBenchmark,
+      },
+      comparisonRows: [
+        new PylonLargestTrainingBenchmarkRow({
+          benchmarkId: 'templar_covenant_72b_published_comparable',
+          currentQualifiedContributorCount: qualifiedContributorCount,
+          deficit: thresholdDeficit(
+            qualifiedContributorCount,
+            PylonLargestConcreteComparableContributorBenchmark,
+          ),
+          label:
+            'Cited public comparable: Templar Covenant-72B at about 70 contributors.',
+          requiredQualifiedContributorCount:
+            PylonLargestConcreteComparableContributorBenchmark,
+          sourceRefs,
+          thresholdMet: concreteComparableThresholdMet,
+        }),
+        new PylonLargestTrainingBenchmarkRow({
+          benchmarkId: 'episode_236_transcript_target',
+          currentQualifiedContributorCount: qualifiedContributorCount,
+          deficit: thresholdDeficit(
+            qualifiedContributorCount,
+            PylonLargestTranscriptTargetContributorBenchmark,
+          ),
+          label:
+            'Episode 236 target benchmark for the largest-run claim: 200 contributors.',
+          requiredQualifiedContributorCount:
+            PylonLargestTranscriptTargetContributorBenchmark,
+          sourceRefs,
+          thresholdMet: transcriptTargetThresholdMet,
+        }),
+      ],
+      endpoint: PylonLargestDecentralizedTrainingClaimEndpoint,
+      gate: {
+        clearsBlockerRefs: [],
+        comparableRunResearchAvailable: true,
+        concreteComparableThresholdMet,
+        greenGateSatisfied: false,
+        ownerSignedUpgradeAvailable: false,
+        participantCountMethodologyAvailable: true,
+        publicContributorReceiptsAtClaimBenchmarkAvailable:
+          transcriptTargetThresholdMet,
+        publicRunScaleProjectionAvailable: true,
+        remainingBlockerRefs: [PylonLargestDecentralizedTrainingClaimBlocker],
+        transcriptTargetThresholdMet,
+      },
+      generatedAt: scaleProjection.generatedAt,
+      promiseRef: 'promise:pylon.largest_decentralized_training_claim.v1',
+      promiseState: 'red',
+      registryVersion: PublicProductPromisesVersion,
+      runScale: {
+        acceptedTraceCount: scaleProjection.runScale.acceptedTraceCount,
+        currentScaleLabel: scaleProjection.runScale.currentScaleLabel,
+        providerConfirmedSettledPayoutSats:
+          scaleProjection.runScale.providerConfirmedSettledPayoutSats,
+        qualifiedContributorCount,
+        realSettlementReceiptCount:
+          scaleProjection.runScale.realSettlementReceiptCount,
+        runRef: scaleProjection.runScale.runRef,
+        runState: scaleProjection.runScale.runState,
+        sourceScaleEndpoint: TrainingPublicDistributedRunScaleEndpoint,
+      },
+      schemaVersion: PylonLargestDecentralizedTrainingClaimSchemaVersion,
+      sourceRefs,
+      staleness: PylonLargestDecentralizedTrainingClaimStaleness,
+      status: 'largest_decentralized_training_claim_status_projection',
+      statusLabel: transcriptTargetThresholdMet
+        ? 'The 200-contributor benchmark is met in current counters, but owner-signed receipt-first upgrade remains required before any largest-run claim.'
+        : `Current public run has ${qualifiedContributorCount}/${PylonLargestTranscriptTargetContributorBenchmark} qualified contributors, so the largest decentralized training claim remains red.`,
+      unsafeCopy:
+        'Do not say OpenAgents has the largest decentralized training run, has beaten Bittensor or Templar, has 200+ contributors, or has public training at largest-run scale unless benchmark-level qualified-contributor receipts and owner signoff exist.',
+    })
+
+  assertPublicSafeValue(
+    'Pylon largest decentralized training claim projection',
+    projection,
+  )
+
+  return projection
+}

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -8,6 +8,7 @@ const approvedExactRoutePaths = [
   '/api/public/business-signup',
   '/api/public/tassadar-run-summary',
   '/api/public/training/public-distributed-run-scale',
+  '/api/public/pylon/largest-decentralized-training-claim',
   '/api/public/activity-timeline',
   '/api/public/activity-timeline/stream',
   '/api/public/tassadar/compiled-module-marketplace',

--- a/docs/launch/vertex-fleet/pylon.largest_decentralized_training_claim.v1.md
+++ b/docs/launch/vertex-fleet/pylon.largest_decentralized_training_claim.v1.md
@@ -1,0 +1,45 @@
+# pylon.largest_decentralized_training_claim.v1
+
+Date: 2026-06-20
+State: red
+Registry pass: 2026-06-20.43
+
+## Status Projection
+
+`GET /api/public/pylon/largest-decentralized-training-claim` is the
+public-safe status projection for the largest decentralized training run claim.
+It reads the existing public Tassadar run summary through the same scale-status
+path used by `training.public_distributed_training_run.v1`, then compares the
+current qualified-contributor count to the documented comparable benchmarks.
+
+Current bounded run status:
+
+- qualified contributors: 5
+- accepted exact-trace work units: 11
+- real settlement receipts: 5
+- provider-confirmed settled payout: 1,020 sats
+- current scale label: canary scale
+
+Comparison benchmarks:
+
+- Templar Covenant-72B public comparable: about 70 contributors
+- Episode 236 target benchmark: 200 contributors
+
+The current run is below both. The route therefore reports
+`concreteComparableThresholdMet=false`,
+`transcriptTargetThresholdMet=false`, `ownerSignedUpgradeAvailable=false`, and
+`greenGateSatisfied=false`.
+
+## Boundary
+
+This projection does not create or widen a claim. It grants no contributor
+admission, training dispatch, spend, settlement, benchmark victory, largest-run
+claim, network-scale claim, or product-promise transition authority.
+
+The only remaining blocker stays active:
+
+- `blocker.product_promises.public_training_contributor_receipts_missing`
+
+Green requires a comparable-scale run with public per-contributor qualified
+receipts, plus an owner-signed receipt-first upgrade under
+`proof.claim_upgrade_receipts.v1`.


### PR DESCRIPTION
## Summary

Adds a public-safe status projection for `pylon.largest_decentralized_training_claim.v1`:

- `GET /api/public/pylon/largest-decentralized-training-claim`
- compares the current public Tassadar run scale counters to the cited ~70 contributor comparable and the Episode 236 200 contributor target
- bumps the product-promise registry to `2026-06-20.43`
- adds a vertex-fleet worklog and OpenAPI / exact-route coverage

## Promise Boundary

No green flip. `pylon.largest_decentralized_training_claim.v1` stays red.

The projection reports the current bounded state:

- `qualifiedContributorCount=5`
- `acceptedTraceCount=11`
- `realSettlementReceiptCount=5`
- `concreteComparableThresholdMet=false`
- `transcriptTargetThresholdMet=false`
- `ownerSignedUpgradeAvailable=false`
- `greenGateSatisfied=false`

Remaining blocker stays active:

- `blocker.product_promises.public_training_contributor_receipts_missing`

No participant-scale run, at-scale dispatch, spend, settlement, benchmark-victory claim, largest-run claim, network-scale claim, yellow/green transition, or owner-signed upgrade is created.

## Verification

- `bunx vitest run src/pylon-largest-decentralized-training-claim-status.test.ts src/training-public-distributed-run-scale.test.ts src/openagents-openapi-routes.test.ts src/worker-exact-routes.test.ts src/product-promises.test.ts`
- `git diff --check`
- registry sanity script for `2026-06-20.43`, green count 24, target promise red with blocker intact
- `bun run check:deploy`
