### PR TITLE
P0: pylon world scene behind chat (glass chrome) [#5735]

### DIFF
--- a/apps/autopilot-desktop/src/ui/index.html
+++ b/apps/autopilot-desktop/src/ui/index.html
@@ -227,6 +227,22 @@
         .training-fullscreen-node-panel { left:12px; right:12px; bottom:12px; width:auto; }
       }
 
+      /* #5735: world scene behind chat (glass chrome). Mirrors the
+         .training-fullscreen-scene/-overlay pattern: a full-bleed 3D scene at
+         z-0 with the chat thread + composer as translucent glass at z-2. Only
+         applies when the chat-pane carries .chat-pane-world (flag CHAT_WORLD_SCENE);
+         with the flag off the plain .chat-pane is unchanged. */
+      .chat-pane-world { position:relative; min-height:100%; height:100%; }
+      .chat-scene-background { position:absolute; inset:0; z-index:0; overflow:hidden; background:#0c0f13; }
+      /* dim + slight blur so the chat glass stays readable over the scene */
+      .three-effect-chat-scene { display:block; width:100%; height:100%; min-height:100%; opacity:.5; filter:blur(2px) saturate(.85); }
+      .chat-scene-background::after { content:""; position:absolute; inset:0; background:radial-gradient(ellipse at 50% 40%, rgba(5,7,10,.35), rgba(5,7,10,.78)); pointer-events:none; }
+      .chat-content-overlay { position:relative; z-index:2; display:flex; flex-direction:column; gap:1rem; min-height:0; }
+      .chat-content-overlay .chat-thread-shell,
+      .chat-content-overlay .chat-composer { pointer-events:auto; border:1px solid rgba(226,232,240,.16); border-radius:.5rem; background:rgba(8,11,17,.66); box-shadow:0 18px 40px rgba(0,0,0,.4); backdrop-filter:blur(16px); padding:.85rem 1rem; box-sizing:border-box; }
+      .chat-content-overlay .chat-thread-shell { flex:1 1 auto; overflow:auto; min-height:0; }
+      .chat-content-overlay .chat-input { background:rgba(12,15,21,.72); }
+
       /* Forms (Ask / Spawn) */
       .text-input, .text-area, .select-input { width:100%; box-sizing:border-box; background:#151515; border:1px solid #525458; border-radius:6px; color:#d7d8e5; font-family:inherit; font-size:13px; padding:10px 12px; margin-bottom:8px; }
       .text-area { resize:vertical; line-height:1.5; }

--- a/apps/autopilot-desktop/src/ui/view.ts
+++ b/apps/autopilot-desktop/src/ui/view.ts
@@ -52,6 +52,13 @@ import {
   type DesktopProofReplayProjection,
 } from "../shared/proof-replays"
 import { isGatewayBalanceLow } from "../shared/inference-routing"
+// #5735: adapt the already-written pylon-network scene onto the three-effect
+// bezier graph so the chat can render as glass over a calm 3D world scene.
+import { pylonNetworkVisualizationOptions } from "./pylon-network-visualization"
+import type {
+  PylonNetworkNode,
+  PylonNetworkScene,
+} from "../shared/pylon-network-scene"
 
 import type {
   AccountRow,
@@ -5728,58 +5735,123 @@ const chatMessageView = (model: Model, message: ChatMessage): Html =>
     ],
   )
 
-const chatPane = (model: Model): Html =>
+// #5735: world-scene-behind-chat feature flag. Default OFF, so the chat surface
+// is byte-for-byte the current pane unless the flag is explicitly enabled. When
+// on, the chat thread + composer render as translucent glass over a full-bleed
+// 3D pylon scene (mirrors the .training-fullscreen-scene/-overlay pattern).
+// Live data is a separate issue (#5736); this seeds a static scene.
+const CHAT_WORLD_SCENE: boolean =
+  ((import.meta as { env?: Record<string, string | undefined> }).env
+    ?.VITE_CHAT_WORLD_SCENE ?? "0") === "1"
+
+// A calm static seed scene: one hub + ~8 ring pylons. A couple are "working"
+// so the graph reads as a living-but-idle network rather than dead. This is a
+// placeholder until #5736 wires the live PylonNetworkScene snapshot in.
+const CHAT_SCENE_RING_NODES: ReadonlyArray<PylonNetworkNode> = Array.from(
+  { length: 8 },
+  (_unused, index): PylonNetworkNode => {
+    const tone: PylonNetworkNode["tone"] =
+      index === 1 || index === 5 ? "working" : index % 3 === 0 ? "online" : "offline"
+    return {
+      id: `seed-pylon-${index}`,
+      label: "pylon",
+      tone,
+      flowing: tone === "working",
+    }
+  },
+)
+
+const CHAT_SCENE: PylonNetworkScene = {
+  activityIntensity: 0.18,
+  dormant: false,
+  onlineNow: 6,
+  sessionsOnlineNow: 2,
+  sellableOnlineNow: 2,
+  walletReadyNow: 4,
+  assignmentReadyNow: 2,
+  seen24h: 8,
+  registeredTotal: 8,
+  satsSettled24h: 0,
+  satsSettledTotal: 0,
+  trainingAssignedContributors: 0,
+  trainingAcceptedContributors: 0,
+  trainingProgressContributors: 0,
+  nodes: CHAT_SCENE_RING_NODES,
+  asOfLabel: null,
+}
+
+const chatSceneBackground = (): Html =>
+  h.div([cls("chat-scene-background")], [
+    trainingRunView<Message>(
+      [cls("three-effect-chat-scene")],
+      pylonNetworkVisualizationOptions(CHAT_SCENE),
+    ),
+  ])
+
+// The chat thread + composer, shared by both the plain and world-scene layouts.
+const chatThread = (model: Model): Html =>
   h.div(
-    [cls("chat-pane")],
+    [cls("chat-thread-shell")],
     [
-      paneTitle("Chat"),
-      h.div(
-        [cls("chat-thread-shell")],
-        [
-          h.ul(
-            [cls("chat-message-list")],
-            model.chatMessages.length === 0
-              ? [h.li([cls("chat-empty")], [emptyLine("No chat turns yet.")])]
-              : model.chatMessages.map(message => chatMessageView(model, message)),
-          ),
-        ],
+      h.ul(
+        [cls("chat-message-list")],
+        model.chatMessages.length === 0
+          ? [h.li([cls("chat-empty")], [emptyLine("No chat turns yet.")])]
+          : model.chatMessages.map(message => chatMessageView(model, message)),
       ),
-      h.div(
-        [cls("chat-composer")],
+    ],
+  )
+
+const chatComposer = (model: Model): Html =>
+  h.div(
+    [cls("chat-composer")],
+    [
+      h.textarea(
         [
-          h.textarea(
+          cls("text-area chat-input"),
+          h.Rows(4),
+          h.Placeholder("Ask Autopilot to continue a Blueprint program turn..."),
+          h.Value(model.chatInput),
+          h.OnInput((value: string) => ChangedChatInput({ value })),
+        ],
+        [],
+      ),
+      model.chatStatus.tone !== "idle"
+        ? h.p([cls(`spawn-status spawn-${model.chatStatus.tone}`)], [
+            model.chatStatus.text,
+          ])
+        : h.p([cls("spawn-status")], [" "]),
+      h.div(
+        [cls("chat-actions")],
+        [
+          h.button(
             [
-              cls("text-area chat-input"),
-              h.Rows(4),
-              h.Placeholder("Ask Autopilot to continue a Blueprint program turn..."),
-              h.Value(model.chatInput),
-              h.OnInput((value: string) => ChangedChatInput({ value })),
+              cls("primary-button"),
+              h.Type("button"),
+              h.Disabled(model.chatPending),
+              h.OnClick(ClickedChatSubmit()),
             ],
-            [],
-          ),
-          model.chatStatus.tone !== "idle"
-            ? h.p([cls(`spawn-status spawn-${model.chatStatus.tone}`)], [
-                model.chatStatus.text,
-              ])
-            : h.p([cls("spawn-status")], [" "]),
-          h.div(
-            [cls("chat-actions")],
-            [
-              h.button(
-                [
-                  cls("primary-button"),
-                  h.Type("button"),
-                  h.Disabled(model.chatPending),
-                  h.OnClick(ClickedChatSubmit()),
-                ],
-                [model.chatPending ? "Sending..." : "Send turn"],
-              ),
-            ],
+            [model.chatPending ? "Sending..." : "Send turn"],
           ),
         ],
       ),
     ],
   )
+
+const chatPane = (model: Model): Html =>
+  CHAT_WORLD_SCENE
+    ? h.div([cls("chat-pane chat-pane-world")], [
+        chatSceneBackground(),
+        h.div([cls("chat-content-overlay")], [
+          paneTitle("Chat"),
+          chatThread(model),
+          chatComposer(model),
+        ]),
+      ])
+    : h.div(
+        [cls("chat-pane")],
+        [paneTitle("Chat"), chatThread(model), chatComposer(model)],
+      )
 
 const composerPane = (model: Model): Html => {
   const node = modelNode(model)


### PR DESCRIPTION
Closes #5735. Part of #5730 (§6 P0).

## What

Mounts the already-written pylon-network scene behind `chatPane()` as a full-bleed 3D background, with the chat thread + composer rendered as translucent glass on top — mirroring the existing `.training-fullscreen-scene` / `.training-fullscreen-overlay` pattern.

- **Feature flag `CHAT_WORLD_SCENE` (default OFF).** Enable with `VITE_CHAT_WORLD_SCENE=1`. With the flag off, `chatPane()` renders the **identical DOM** as before (extracted `chatThread()`/`chatComposer()` helpers reused by both paths).
- **Background scene (z-0):** `.chat-scene-background` mounts `trainingRunView` via the existing `pylonNetworkVisualizationOptions` adapter (`pylon-network-visualization.ts`), fed a **static seed** `PylonNetworkScene` — a hub + 8 ring pylons (a couple "working"). Live data is a separate issue (#5736).
- **Glass overlay (z-2):** `.chat-content-overlay` holds the thread + composer in translucent black panels with `backdrop-filter: blur`; the scene is dimmed (`opacity .5`), blurred (`blur(2px)`), and radial-darkened so chat stays readable and the composer stays fully usable.

## Verify

- `bun install` (root workspace) ✓
- `bun build src/ui/main.ts --target browser` → 594 modules, no errors ✓
- `bun test tests/cl-53-foldkit.test.ts tests/cl-53-sanitize.test.ts` → 107 pass / 0 fail ✓
- No new type errors in the changed code (flag-off path is byte-identical DOM).

Did not run full `check:deploy` (slow), per task scope — only typecheck/build of the autopilot-desktop area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)