### PR TITLE
P1+P2: live pylons + Bitcoin payment particles + pylon growth [#5736 #5737]

### DIFF
--- a/apps/autopilot-desktop/src/shared/chat-world-scene.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-scene.ts
@@ -1,0 +1,361 @@
+// Chat-World scene mappers (P1 #5736 + P2 #5737).
+//
+// PURE, Three.js-free transforms that feed the "agent MMORPG" scene that hangs
+// behind the Autopilot chat (docs/launch/2026-06-20-agent-mmorpg-hud-autopilot-
+// audit-and-plan.md §3.3 live data, §6 P1/P2). Tune knobs HERE, not in the
+// renderer (mirrors the discipline in shared/pylon-network-scene.ts).
+//
+// Two responsibilities:
+//   P1 — map a live /api/public/pylon-stats snapshot's recentPylons[] into
+//        richer LIVE scene nodes (online glow, heartbeat-age pulse, wallet/
+//        assignment-ready state colors, honest zero-state) + a per-Pylon growth
+//        tier from cumulative settled sats.
+//   P2 — map a /api/public/activity-timeline event (real_bitcoin_moved /
+//        settlement_recorded) into an EVIDENCE-BOUND payment-particle descriptor
+//        the scene renders via three-effect flowEffectPrimitives /
+//        eventBurstPrimitives. Every particle carries its sourceRefs so it is
+//        clickable to its receipt.
+//
+// Evidence-bound motion contract (§5): nothing moves/pulses/bursts unless it is
+// bound to a real public ref or a live state transition. These mappers refuse
+// to emit a particle that has no sourceRef.
+
+import type { PylonStatsSnapshot } from "./pylon-network-scene"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Feature flags (default OFF). The renderer / P0 integration reads these before
+// mounting the scene or wiring the subscriptions. Resolved from globalThis so
+// the same code works in the webview (window.__OA_FLAGS) and in tests.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ChatWorldFlags = {
+  /** P0/P1: mount the live pylon scene behind chat. */
+  readonly CHAT_WORLD_SCENE: boolean
+  /** P2: fly Bitcoin payment particles + grow pylons from settled sats. */
+  readonly CHAT_WORLD_PAYMENTS: boolean
+}
+
+const flagBag = (): Record<string, unknown> => {
+  const g = globalThis as unknown as { __OA_FLAGS?: Record<string, unknown> }
+  return g.__OA_FLAGS ?? {}
+}
+
+const readFlag = (name: keyof ChatWorldFlags): boolean => flagBag()[name] === true
+
+export const chatWorldFlags = (): ChatWorldFlags => ({
+  CHAT_WORLD_SCENE: readFlag("CHAT_WORLD_SCENE"),
+  CHAT_WORLD_PAYMENTS: readFlag("CHAT_WORLD_PAYMENTS"),
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P1 — live pylon nodes from pylon-stats
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The richer RecentPylon shape the chat-world scene consumes. Superset of the
+// home-screen RecentPylon (shared/pylon-network-scene.ts) — the worker owns the
+// full schema in apps/openagents.com/workers/api/src/public-pylon-stats.ts. All
+// fields optional/nullable so a partial snapshot is safe and never faked.
+export type LiveRecentPylon = {
+  readonly nodeLabel?: string | null
+  readonly nostrPubkeyShort?: string
+  readonly runtimeState?: string | null
+  readonly onlineNow?: boolean | null
+  readonly walletReadyNow?: boolean | null
+  readonly assignmentReadyNow?: boolean | null
+  readonly lastHeartbeatAgeSeconds?: number | null
+  readonly products?: ReadonlyArray<string> | null
+}
+
+// A live presence state with a distinct visual encoding (§5: online ≠ assigned
+// ≠ wallet-ready ≠ offline). offline = seen but not online now.
+export type LivePylonState =
+  | "offline"
+  | "online"
+  | "wallet_ready"
+  | "assignment_ready"
+
+// Distinct state colors (hex ints for three-effect materials). Gold is reserved
+// for real bitcoin motion (P2), so pylon states stay in the blue/green family.
+export const LIVE_PYLON_STATE_COLOR: Readonly<Record<LivePylonState, number>> = {
+  offline: 0x3a4150, // dim grey — seen but offline
+  online: 0xcdd3e0, // off-white — online, idle
+  wallet_ready: 0x7dd3fc, // blue — can receive
+  assignment_ready: 0x4ade80, // green — working / earning
+} as const
+
+// Pylon growth tiers (#5737): cumulative settled sats → crystal scale/facets/
+// brightness. Thresholds in sats; tier index grows monotonically. Returned as a
+// descriptor so the renderer maps tier → scale/facet/brightness consistently.
+export const PYLON_GROWTH_TIER_THRESHOLDS_SATS: ReadonlyArray<number> = [
+  0, // tier 0 — no settled earnings yet (honest still crystal)
+  1_000,
+  10_000,
+  100_000,
+  1_000_000,
+  10_000_000,
+] as const
+
+export type PylonGrowthTier = {
+  /** 0..N tier index. */
+  readonly tier: number
+  /** [1,_] crystal scale multiplier the renderer applies. */
+  readonly scale: number
+  /** facet count hint for the crystal mesh. */
+  readonly facets: number
+  /** [0,1] extra glow brightness from accumulated earnings. */
+  readonly brightness: number
+  /** the cumulative settled sats that produced this tier (evidence). */
+  readonly settledSats: number
+}
+
+export const pylonGrowthTier = (settledSats: number): PylonGrowthTier => {
+  const sats = Number.isFinite(settledSats) && settledSats > 0 ? settledSats : 0
+  let tier = 0
+  for (let i = 1; i < PYLON_GROWTH_TIER_THRESHOLDS_SATS.length; i += 1) {
+    if (sats >= (PYLON_GROWTH_TIER_THRESHOLDS_SATS[i] ?? Infinity)) tier = i
+  }
+  const max = PYLON_GROWTH_TIER_THRESHOLDS_SATS.length - 1
+  const frac = max <= 0 ? 0 : tier / max
+  return {
+    tier,
+    scale: Number((1 + 0.18 * tier).toFixed(3)),
+    facets: 6 + tier * 2,
+    brightness: Number(frac.toFixed(3)),
+    settledSats: sats,
+  }
+}
+
+// Heartbeat-age pulse: a fresh heartbeat pulses fast, an aging one slows toward
+// a slow idle breath, and a stale node (no recent heartbeat) stops pulsing.
+// Returns pulses/sec in [0, fast]; 0 means "do not pulse" (honest stillness).
+const HEARTBEAT_FRESH_SECONDS = 15
+const HEARTBEAT_STALE_SECONDS = 120
+const PULSE_FAST = 1.8
+const PULSE_SLOW = 0.4
+
+export const heartbeatPulseSpeed = (
+  lastHeartbeatAgeSeconds: number | null | undefined,
+): number => {
+  if (
+    typeof lastHeartbeatAgeSeconds !== "number" ||
+    !Number.isFinite(lastHeartbeatAgeSeconds) ||
+    lastHeartbeatAgeSeconds < 0
+  ) {
+    return 0 // unknown age → no pulse (do not fake liveness)
+  }
+  if (lastHeartbeatAgeSeconds >= HEARTBEAT_STALE_SECONDS) return 0
+  if (lastHeartbeatAgeSeconds <= HEARTBEAT_FRESH_SECONDS) return PULSE_FAST
+  const span = HEARTBEAT_STALE_SECONDS - HEARTBEAT_FRESH_SECONDS
+  const aged = (lastHeartbeatAgeSeconds - HEARTBEAT_FRESH_SECONDS) / span
+  return Number((PULSE_FAST - (PULSE_FAST - PULSE_SLOW) * aged).toFixed(3))
+}
+
+export const livePylonState = (pylon: LiveRecentPylon): LivePylonState => {
+  if (pylon.onlineNow !== true) return "offline"
+  if (pylon.assignmentReadyNow === true) return "assignment_ready"
+  if (pylon.walletReadyNow === true) return "wallet_ready"
+  return "online"
+}
+
+export type LivePylonNode = {
+  /** stable id (the short pubkey) so positions are stable across polls. */
+  readonly id: string
+  readonly label: string
+  readonly state: LivePylonState
+  /** state color the renderer applies to glow/material. */
+  readonly color: number
+  /** online nodes glow; offline ones sit dim. */
+  readonly online: boolean
+  /** pulses/sec from heartbeat age (0 = still). */
+  readonly pulseSpeed: number
+  /** public capability tags (products) for the inspector. */
+  readonly products: ReadonlyArray<string>
+}
+
+export type ChatWorldPylonScene = {
+  /** true when the fleet snapshot is unavailable/empty — honest zero-state. */
+  readonly empty: boolean
+  readonly onlineNow: number
+  /** per-pylon live nodes (the named, inspectable ones). */
+  readonly nodes: ReadonlyArray<LivePylonNode>
+  /** fleet-wide growth tier from cumulative settled sats (drives center pylon). */
+  readonly growth: PylonGrowthTier
+  readonly asOfLabel: string | null
+}
+
+const cumulativeSettledSatsTotal = (snapshot: PylonStatsSnapshot): number => {
+  const m = snapshot.nip90MarketSettlementStats
+  if (!m) return 0
+  const total =
+    (m.compute?.satsSettledTotal ?? 0) +
+    (m.data?.satsSettledTotal ?? 0) +
+    (m.labor?.satsSettledTotal ?? 0)
+  return Number.isFinite(total) && total > 0 ? total : 0
+}
+
+// Map a live pylon-stats snapshot into the chat-world pylon scene. Honest
+// zero-state: an unavailable/empty snapshot yields empty:true with no nodes.
+export const projectChatWorldPylonScene = (
+  snapshot: PylonStatsSnapshot | null,
+): ChatWorldPylonScene => {
+  const unavailable =
+    snapshot === null ||
+    snapshot.available === false ||
+    snapshot.status === "unavailable"
+
+  if (unavailable) {
+    return {
+      empty: true,
+      onlineNow: 0,
+      nodes: [],
+      growth: pylonGrowthTier(0),
+      asOfLabel: snapshot?.asOfLabel ?? null,
+    }
+  }
+
+  const recent = (snapshot.recentPylons ?? []) as ReadonlyArray<LiveRecentPylon>
+  const nodes: LivePylonNode[] = recent.map((pylon, index) => {
+    const state = livePylonState(pylon)
+    return {
+      id: pylon.nostrPubkeyShort ?? `recent-${index}`,
+      label: pylon.nodeLabel ?? pylon.nostrPubkeyShort ?? "pylon",
+      state,
+      color: LIVE_PYLON_STATE_COLOR[state],
+      online: pylon.onlineNow === true,
+      pulseSpeed:
+        pylon.onlineNow === true
+          ? heartbeatPulseSpeed(pylon.lastHeartbeatAgeSeconds)
+          : 0,
+      products: (pylon.products ?? []).filter((p): p is string => typeof p === "string"),
+    }
+  })
+
+  const onlineNow =
+    typeof snapshot.pylonsOnlineNow === "number" && snapshot.pylonsOnlineNow > 0
+      ? snapshot.pylonsOnlineNow
+      : 0
+
+  return {
+    empty: nodes.length === 0 && onlineNow === 0,
+    onlineNow,
+    nodes,
+    growth: pylonGrowthTier(cumulativeSettledSatsTotal(snapshot)),
+    asOfLabel: snapshot.asOfLabel ?? null,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P2 — payment particles from activity-timeline events
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The minimal activity-timeline event shape we consume. The worker / package
+// @openagentsinc/public-activity-timeline owns the full schema; we keep a
+// structural subset so this stays Three.js- and Effect-Schema-free and
+// unit-testable. All money fields optional so a partial event is safe.
+export type ActivityEvent = {
+  readonly eventRef: string
+  readonly kind: string
+  readonly ts?: string
+  readonly actorRef?: string
+  readonly targetRef?: string
+  readonly amountSats?: number
+  readonly realBitcoinMoved?: boolean
+  readonly sourceRefs?: ReadonlyArray<string>
+  readonly text?: string
+}
+
+// A renderer-agnostic descriptor for one payment particle. The P0 scene maps
+// fromRef/toRef → node positions and feeds size/color/evidence into
+// three-effect createFlowBeam + createEvidenceBackedEventBurst. EVIDENCE-BOUND:
+// sourceRefs is required and non-empty, so a particle is always clickable to a
+// real receipt/event.
+export type PaymentParticle = {
+  readonly id: string
+  /** sender node ref (actorRef). */
+  readonly fromRef: string
+  /** recipient node ref (targetRef). */
+  readonly toRef: string
+  readonly amountSats: number
+  /** real bitcoin (gold) vs credited/non-bitcoin (dim). */
+  readonly realBitcoinMoved: boolean
+  /** gold for real bitcoin, dim blue for credited flows. */
+  readonly color: number
+  /** [0.2,1] visual size ∝ amountSats (log-scaled, clamped). */
+  readonly size: number
+  /** receipt/event refs — what a click resolves to (≥1, evidence-bound). */
+  readonly sourceRefs: ReadonlyArray<string>
+  readonly ts: string | null
+  readonly text: string | null
+}
+
+export const PAYMENT_PARTICLE_GOLD = 0xf5b73a // real bitcoin moved
+export const PAYMENT_PARTICLE_DIM = 0x4a5570 // credited / non-bitcoin
+
+// Kinds that produce a sender→recipient money particle.
+const PAYMENT_EVENT_KINDS = new Set(["real_bitcoin_moved", "settlement_recorded"])
+
+export const isPaymentEvent = (event: ActivityEvent): boolean =>
+  PAYMENT_EVENT_KINDS.has(event.kind)
+
+// Log-scale size in [0.2, 1] so a 10-sat tip and a 10M-sat settlement both read,
+// with bigger amounts visibly larger. 0 sats → smallest visible particle.
+const PARTICLE_SIZE_MIN = 0.2
+const PARTICLE_SIZE_MAX = 1
+const PARTICLE_SIZE_LOG_CAP = Math.log10(10_000_000) // 10M sats reads as max
+
+export const particleSize = (amountSats: number): number => {
+  const sats = Number.isFinite(amountSats) && amountSats > 0 ? amountSats : 0
+  if (sats <= 0) return PARTICLE_SIZE_MIN
+  const frac = Math.min(1, Math.log10(sats + 1) / PARTICLE_SIZE_LOG_CAP)
+  return Number(
+    (PARTICLE_SIZE_MIN + (PARTICLE_SIZE_MAX - PARTICLE_SIZE_MIN) * frac).toFixed(3),
+  )
+}
+
+// Map a single activity event into a payment-particle descriptor, or null when
+// it cannot be honestly rendered. We REFUSE to emit a particle that lacks:
+//   - a payment kind,
+//   - both endpoints (actorRef → targetRef), or
+//   - at least one sourceRef (evidence-bound contract §5).
+export const activityEventToParticle = (
+  event: ActivityEvent,
+): PaymentParticle | null => {
+  if (!isPaymentEvent(event)) return null
+
+  const fromRef = event.actorRef
+  const toRef = event.targetRef
+  if (!fromRef || !toRef) return null
+
+  const sourceRefs = (event.sourceRefs ?? []).filter(
+    (r): r is string => typeof r === "string" && r.length > 0,
+  )
+  if (sourceRefs.length === 0) return null // never fake a clickable receipt
+
+  const real = event.realBitcoinMoved === true
+  const amountSats =
+    typeof event.amountSats === "number" && event.amountSats > 0
+      ? event.amountSats
+      : 0
+
+  return {
+    id: event.eventRef,
+    fromRef,
+    toRef,
+    amountSats,
+    realBitcoinMoved: real,
+    color: real ? PAYMENT_PARTICLE_GOLD : PAYMENT_PARTICLE_DIM,
+    size: particleSize(amountSats),
+    sourceRefs,
+    ts: event.ts ?? null,
+    text: event.text ?? null,
+  }
+}
+
+// Map a batch (e.g. an activity-timeline poll / backfill) into particles,
+// dropping any that are not honestly renderable.
+export const activityEventsToParticles = (
+  events: ReadonlyArray<ActivityEvent>,
+): ReadonlyArray<PaymentParticle> =>
+  events
+    .map(activityEventToParticle)
+    .filter((p): p is PaymentParticle => p !== null)

--- a/apps/autopilot-desktop/src/ui/chat-world-subscriptions.ts
+++ b/apps/autopilot-desktop/src/ui/chat-world-subscriptions.ts
@@ -1,0 +1,225 @@
+// Chat-World live subscriptions (P1 #5736 + P2 #5737).
+//
+// Browser-side feeds for the "agent MMORPG" scene behind chat
+// (docs/launch/2026-06-20-agent-mmorpg-hud-autopilot-audit-and-plan.md §3.3):
+//   - subscribePylonScene(dispatch)      P1: poll /api/public/pylon-stats →
+//                                        ChatWorldPylonScene (live nodes + growth)
+//   - subscribePaymentParticles(dispatch) P2: SSE /api/public/activity-timeline/
+//                                        stream (poll fallback) → PaymentParticle
+//
+// Both are FLAG-GATED (default OFF) and return an unsubscribe() the scene calls
+// on teardown. They are intentionally NOT registered in the static Foldkit
+// `subscriptions` (subscriptions.ts) — the P0 scene owns its own lifecycle and
+// will call these when the scene mounts (see the TODO in subscriptions.ts).
+//
+// "browser UA": these run inside the Electrobun webview and fetch the public
+// openagents.com endpoints directly, so requests carry the webview's browser
+// User-Agent (no node/bun UA), matching how the public site is served.
+//
+// Evidence-bound (§5): subscribePaymentParticles only ever dispatches particles
+// that carry a real sourceRef (activityEventToParticle drops the rest).
+
+import {
+  activityEventToParticle,
+  chatWorldFlags,
+  projectChatWorldPylonScene,
+  type ActivityEvent,
+  type ChatWorldPylonScene,
+  type PaymentParticle,
+} from "../shared/chat-world-scene"
+import type { PylonStatsSnapshot } from "../shared/pylon-network-scene"
+
+const PUBLIC_BASE_URL = "https://openagents.com"
+const PYLON_STATS_PATH = "/api/public/pylon-stats"
+const ACTIVITY_POLL_PATH = "/api/public/activity-timeline"
+const ACTIVITY_STREAM_PATH = "/api/public/activity-timeline/stream"
+
+const PYLON_POLL_INTERVAL_MS = 4_000
+const ACTIVITY_POLL_INTERVAL_MS = 5_000
+
+export type Unsubscribe = () => void
+
+const noop: Unsubscribe = () => {}
+
+// Injectable seams so the subscriptions are testable headlessly.
+export type ChatWorldSubscriptionDeps = {
+  readonly baseUrl?: string
+  readonly fetchFn?: typeof fetch
+  /** EventSource ctor (browser global); omit to use the platform one. */
+  readonly eventSourceCtor?: typeof EventSource
+  readonly setInterval?: (handler: () => void, ms: number) => unknown
+  readonly clearInterval?: (handle: unknown) => void
+  /** override flags (default: chatWorldFlags() from globalThis.__OA_FLAGS). */
+  readonly flags?: { readonly CHAT_WORLD_SCENE?: boolean; readonly CHAT_WORLD_PAYMENTS?: boolean }
+}
+
+const resolveBaseUrl = (deps?: ChatWorldSubscriptionDeps): string =>
+  (deps?.baseUrl ?? PUBLIC_BASE_URL).replace(/\/+$/, "")
+
+const resolveSetInterval = (
+  deps?: ChatWorldSubscriptionDeps,
+): ((handler: () => void, ms: number) => unknown) =>
+  deps?.setInterval ??
+  ((handler, ms) => (globalThis as unknown as { setInterval: (h: () => void, m: number) => unknown }).setInterval(handler, ms))
+
+const resolveClearInterval = (
+  deps?: ChatWorldSubscriptionDeps,
+): ((handle: unknown) => void) =>
+  deps?.clearInterval ??
+  ((handle) => (globalThis as unknown as { clearInterval: (h: unknown) => void }).clearInterval(handle))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P1 — live pylons
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type PylonSceneDispatch = (scene: ChatWorldPylonScene) => void
+
+// Poll pylon-stats and push a projected scene to `dispatch`. Fail-soft: a fetch
+// error pushes the honest zero-state (projectChatWorldPylonScene(null)) rather
+// than throwing or freezing the last snapshot. Returns unsubscribe().
+export const subscribePylonScene = (
+  dispatch: PylonSceneDispatch,
+  deps?: ChatWorldSubscriptionDeps,
+): Unsubscribe => {
+  const flags = deps?.flags ?? chatWorldFlags()
+  if (flags.CHAT_WORLD_SCENE !== true) return noop
+
+  const baseUrl = resolveBaseUrl(deps)
+  const fetchFn = deps?.fetchFn ?? fetch
+  const url = `${baseUrl}${PYLON_STATS_PATH}`
+  let stopped = false
+
+  const poll = async (): Promise<void> => {
+    try {
+      const response = await fetchFn(url, { headers: { accept: "application/json" } })
+      if (stopped) return
+      if (!response.ok) {
+        dispatch(projectChatWorldPylonScene(null))
+        return
+      }
+      const snapshot = (await response.json()) as PylonStatsSnapshot
+      if (stopped) return
+      dispatch(projectChatWorldPylonScene(snapshot))
+    } catch {
+      if (!stopped) dispatch(projectChatWorldPylonScene(null))
+    }
+  }
+
+  void poll()
+  const handle = resolveSetInterval(deps)(() => void poll(), PYLON_POLL_INTERVAL_MS)
+
+  return () => {
+    stopped = true
+    resolveClearInterval(deps)(handle)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P2 — payment particles
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type PaymentParticleDispatch = (particle: PaymentParticle) => void
+
+// Parse one SSE `data:` payload ({ event: <ActivityEvent> }) into a particle.
+// Tolerant of either { event: {...} } (the worker's frame shape) or a bare event
+// object. Returns null when it is not an honestly-renderable payment.
+export const parseActivityStreamData = (raw: string): PaymentParticle | null => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  const candidate =
+    parsed && typeof parsed === "object" && "event" in (parsed as Record<string, unknown>)
+      ? (parsed as { event: unknown }).event
+      : parsed
+  if (!candidate || typeof candidate !== "object") return null
+  const event = candidate as ActivityEvent
+  if (typeof event.eventRef !== "string" || typeof event.kind !== "string") return null
+  return activityEventToParticle(event)
+}
+
+// Backfill / poll: pull the activity-timeline envelope once and push particles
+// for every payment event it carries (used for "backfill last N on connect" and
+// as the no-EventSource fallback).
+const pollActivityOnce = async (
+  baseUrl: string,
+  fetchFn: typeof fetch,
+  dispatch: PaymentParticleDispatch,
+  isStopped: () => boolean,
+): Promise<void> => {
+  try {
+    const response = await fetchFn(`${baseUrl}${ACTIVITY_POLL_PATH}`, {
+      headers: { accept: "application/json" },
+    })
+    if (isStopped() || !response.ok) return
+    const envelope = (await response.json()) as { events?: ReadonlyArray<ActivityEvent> }
+    if (isStopped()) return
+    for (const event of envelope.events ?? []) {
+      const particle = activityEventToParticle(event)
+      if (particle) dispatch(particle)
+    }
+  } catch {
+    // fail-soft: no particles rather than throwing
+  }
+}
+
+// Subscribe to the activity SSE stream and push a PaymentParticle per real
+// money event. Prefers EventSource (live SSE); if EventSource is unavailable,
+// falls back to polling the envelope. Always does one backfill poll on connect
+// so the scene starts populated. Returns unsubscribe().
+export const subscribePaymentParticles = (
+  dispatch: PaymentParticleDispatch,
+  deps?: ChatWorldSubscriptionDeps,
+): Unsubscribe => {
+  const flags = deps?.flags ?? chatWorldFlags()
+  if (flags.CHAT_WORLD_PAYMENTS !== true) return noop
+
+  const baseUrl = resolveBaseUrl(deps)
+  const fetchFn = deps?.fetchFn ?? fetch
+  let stopped = false
+  const isStopped = (): boolean => stopped
+
+  // Backfill last N events on connect (evidence-bound; non-payments dropped).
+  void pollActivityOnce(baseUrl, fetchFn, dispatch, isStopped)
+
+  const EventSourceCtor =
+    deps?.eventSourceCtor ??
+    (globalThis as unknown as { EventSource?: typeof EventSource }).EventSource
+
+  // No EventSource (headless / older webview): poll the envelope on an interval.
+  if (typeof EventSourceCtor !== "function") {
+    const handle = resolveSetInterval(deps)(
+      () => void pollActivityOnce(baseUrl, fetchFn, dispatch, isStopped),
+      ACTIVITY_POLL_INTERVAL_MS,
+    )
+    return () => {
+      stopped = true
+      resolveClearInterval(deps)(handle)
+    }
+  }
+
+  const source = new EventSourceCtor(`${baseUrl}${ACTIVITY_STREAM_PATH}`)
+  // The worker frames each event with `event: <kind>` and data { event }. We
+  // listen to the two payment kinds by name, plus the default `message` handler
+  // as a safety net for servers that do not set the SSE event field.
+  const onMessage = (raw: unknown): void => {
+    if (stopped) return
+    const data = (raw as { data?: string }).data
+    if (typeof data !== "string") return
+    const particle = parseActivityStreamData(data)
+    if (particle) dispatch(particle)
+  }
+  source.addEventListener("real_bitcoin_moved", onMessage as EventListener)
+  source.addEventListener("settlement_recorded", onMessage as EventListener)
+  source.addEventListener("message", onMessage as EventListener)
+
+  return () => {
+    stopped = true
+    source.removeEventListener("real_bitcoin_moved", onMessage as EventListener)
+    source.removeEventListener("settlement_recorded", onMessage as EventListener)
+    source.removeEventListener("message", onMessage as EventListener)
+    source.close()
+  }
+}

--- a/apps/autopilot-desktop/src/ui/subscriptions.ts
+++ b/apps/autopilot-desktop/src/ui/subscriptions.ts
@@ -207,3 +207,23 @@ export const subscriptions = Subscription.make<Model, Message>()(() => ({
   // HUD H3 (#5501): route window pointer move/up into the pane-layer drag reducer.
   paneDrag: Subscription.persistent(pointerStream),
 }))
+
+// TODO(P0 chat-world wiring · #5736 #5737): the live chat-world scene owns its
+// own feed lifecycle (it mounts/unmounts with the canvas), so its subscriptions
+// are NOT registered here. When P0 mounts the pylon scene behind chatPane
+// (flag CHAT_WORLD_SCENE) and the payment layer (flag CHAT_WORLD_PAYMENTS),
+// call these from the scene's mount and store the returned unsubscribe() to call
+// on unmount:
+//
+//   import {
+//     subscribePylonScene,
+//     subscribePaymentParticles,
+//   } from "./chat-world-subscriptions"
+//
+//   const stopPylons   = subscribePylonScene(scene.applyPylonScene)
+//   const stopPayments = subscribePaymentParticles(scene.spawnPaymentParticle)
+//   // ... on unmount: stopPylons(); stopPayments()
+//
+// Both are flag-gated (default OFF) and return noop when their flag is unset, so
+// wiring them in is safe before the flags flip on. The pure mappers they use
+// live in shared/chat-world-scene.ts (unit-tested in tests/chat-world-scene.test.ts).

--- a/apps/autopilot-desktop/tests/chat-world-scene.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-scene.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  activityEventToParticle,
+  activityEventsToParticles,
+  heartbeatPulseSpeed,
+  isPaymentEvent,
+  LIVE_PYLON_STATE_COLOR,
+  livePylonState,
+  particleSize,
+  PAYMENT_PARTICLE_DIM,
+  PAYMENT_PARTICLE_GOLD,
+  projectChatWorldPylonScene,
+  pylonGrowthTier,
+  type ActivityEvent,
+  type LiveRecentPylon,
+} from "../src/shared/chat-world-scene"
+import type { PylonStatsSnapshot } from "../src/shared/pylon-network-scene"
+
+// ── P1: pylon-stats → scene ──────────────────────────────────────────────────
+
+const snapshot = (overrides: Partial<PylonStatsSnapshot> = {}): PylonStatsSnapshot => ({
+  available: true,
+  status: "live",
+  asOfLabel: "moments ago",
+  ...overrides,
+})
+
+describe("livePylonState (§5 distinct presence encodings)", () => {
+  const cases: ReadonlyArray<[LiveRecentPylon, string]> = [
+    [{ onlineNow: false }, "offline"],
+    [{ onlineNow: true }, "online"],
+    [{ onlineNow: true, walletReadyNow: true }, "wallet_ready"],
+    [{ onlineNow: true, assignmentReadyNow: true }, "assignment_ready"],
+    // assignment-ready outranks wallet-ready
+    [{ onlineNow: true, walletReadyNow: true, assignmentReadyNow: true }, "assignment_ready"],
+    // wallet/assignment ready but offline → offline (not online → no glow)
+    [{ onlineNow: false, assignmentReadyNow: true }, "offline"],
+  ]
+  for (const [pylon, expected] of cases) {
+    test(`${JSON.stringify(pylon)} → ${expected}`, () => {
+      expect(livePylonState(pylon)).toBe(expected)
+    })
+  }
+
+  test("every state has a distinct color", () => {
+    const colors = Object.values(LIVE_PYLON_STATE_COLOR)
+    expect(new Set(colors).size).toBe(colors.length)
+  })
+})
+
+describe("heartbeatPulseSpeed (§3.3 heartbeat-age pulse)", () => {
+  test("fresh heartbeat pulses fast", () => {
+    expect(heartbeatPulseSpeed(2)).toBeGreaterThan(1)
+  })
+  test("aging heartbeat slows monotonically", () => {
+    const fresh = heartbeatPulseSpeed(20)
+    const older = heartbeatPulseSpeed(80)
+    expect(older).toBeLessThan(fresh)
+    expect(older).toBeGreaterThan(0)
+  })
+  test("stale or unknown age → no pulse (honest stillness)", () => {
+    expect(heartbeatPulseSpeed(600)).toBe(0)
+    expect(heartbeatPulseSpeed(null)).toBe(0)
+    expect(heartbeatPulseSpeed(undefined)).toBe(0)
+    expect(heartbeatPulseSpeed(-5)).toBe(0)
+  })
+})
+
+describe("pylonGrowthTier (#5737 settled-sats → tier)", () => {
+  test("zero earnings → tier 0, scale 1", () => {
+    const t = pylonGrowthTier(0)
+    expect(t.tier).toBe(0)
+    expect(t.scale).toBe(1)
+    expect(t.brightness).toBe(0)
+  })
+  test("tier and scale grow monotonically with sats", () => {
+    const small = pylonGrowthTier(5_000)
+    const big = pylonGrowthTier(5_000_000)
+    expect(big.tier).toBeGreaterThan(small.tier)
+    expect(big.scale).toBeGreaterThan(small.scale)
+    expect(big.facets).toBeGreaterThan(small.facets)
+    expect(big.brightness).toBeGreaterThanOrEqual(small.brightness)
+  })
+  test("carries the settled sats as evidence", () => {
+    expect(pylonGrowthTier(12_345).settledSats).toBe(12_345)
+    expect(pylonGrowthTier(-1).settledSats).toBe(0)
+  })
+})
+
+describe("projectChatWorldPylonScene", () => {
+  test("null/unavailable snapshot → honest empty zero-state", () => {
+    expect(projectChatWorldPylonScene(null).empty).toBe(true)
+    expect(projectChatWorldPylonScene(null).nodes).toHaveLength(0)
+    expect(projectChatWorldPylonScene(snapshot({ status: "unavailable" })).empty).toBe(true)
+    expect(projectChatWorldPylonScene(snapshot({ available: false })).empty).toBe(true)
+  })
+
+  test("maps recentPylons into live nodes with state colors + products", () => {
+    const scene = projectChatWorldPylonScene(
+      snapshot({
+        pylonsOnlineNow: 2,
+        recentPylons: [
+          {
+            nostrPubkeyShort: "abc123",
+            nodeLabel: "orrery",
+            onlineNow: true,
+            assignmentReadyNow: true,
+            lastHeartbeatAgeSeconds: 5,
+            products: ["compute", "labor"],
+          } satisfies LiveRecentPylon,
+          {
+            nostrPubkeyShort: "def456",
+            onlineNow: false,
+          } satisfies LiveRecentPylon,
+        ] as never,
+      }),
+    )
+    expect(scene.empty).toBe(false)
+    expect(scene.onlineNow).toBe(2)
+    expect(scene.nodes).toHaveLength(2)
+    const [orrery, offline] = scene.nodes
+    expect(orrery!.id).toBe("abc123")
+    expect(orrery!.label).toBe("orrery")
+    expect(orrery!.state).toBe("assignment_ready")
+    expect(orrery!.color).toBe(LIVE_PYLON_STATE_COLOR.assignment_ready)
+    expect(orrery!.online).toBe(true)
+    expect(orrery!.pulseSpeed).toBeGreaterThan(0)
+    expect(orrery!.products).toEqual(["compute", "labor"])
+    // offline node sits still (no pulse, no glow)
+    expect(offline!.state).toBe("offline")
+    expect(offline!.online).toBe(false)
+    expect(offline!.pulseSpeed).toBe(0)
+  })
+
+  test("fleet growth tier comes from cumulative settled sats total", () => {
+    const scene = projectChatWorldPylonScene(
+      snapshot({
+        pylonsOnlineNow: 1,
+        recentPylons: [{ nostrPubkeyShort: "x", onlineNow: true }] as never,
+        nip90MarketSettlementStats: {
+          compute: { satsSettledTotal: 600_000 },
+          data: { satsSettledTotal: 300_000 },
+          labor: { satsSettledTotal: 200_000 },
+        },
+      }),
+    )
+    // 1.1M total → tier ≥ the 1M threshold
+    expect(scene.growth.settledSats).toBe(1_100_000)
+    expect(scene.growth.tier).toBeGreaterThanOrEqual(4)
+  })
+
+  test("empty recentPylons with zero online → empty zero-state", () => {
+    expect(projectChatWorldPylonScene(snapshot({ pylonsOnlineNow: 0 })).empty).toBe(true)
+  })
+})
+
+// ── P2: activity event → payment particle ────────────────────────────────────
+
+const receiptRef = "receipt.settlement.abc"
+
+const paymentEvent = (overrides: Partial<ActivityEvent> = {}): ActivityEvent => ({
+  eventRef: "evt-1",
+  kind: "real_bitcoin_moved",
+  ts: "2026-06-20T00:00:00Z",
+  actorRef: "pylon:payer",
+  targetRef: "pylon:payee",
+  amountSats: 21_000,
+  realBitcoinMoved: true,
+  sourceRefs: [receiptRef],
+  text: "settled",
+  ...overrides,
+})
+
+describe("isPaymentEvent / particleSize", () => {
+  test("only payment kinds are payment events", () => {
+    expect(isPaymentEvent(paymentEvent())).toBe(true)
+    expect(isPaymentEvent(paymentEvent({ kind: "settlement_recorded" }))).toBe(true)
+    expect(isPaymentEvent(paymentEvent({ kind: "forum_posted" }))).toBe(false)
+    expect(isPaymentEvent(paymentEvent({ kind: "artanis_tick" }))).toBe(false)
+  })
+
+  test("size grows with amount and is clamped to [0.2,1]", () => {
+    const small = particleSize(10)
+    const big = particleSize(10_000_000)
+    expect(small).toBeGreaterThanOrEqual(0.2)
+    expect(big).toBeLessThanOrEqual(1)
+    expect(big).toBeGreaterThan(small)
+    expect(particleSize(0)).toBe(0.2)
+    expect(particleSize(1_000_000_000)).toBeLessThanOrEqual(1)
+  })
+})
+
+describe("activityEventToParticle (evidence-bound §5)", () => {
+  test("real bitcoin → gold particle carrying sourceRefs", () => {
+    const p = activityEventToParticle(paymentEvent())!
+    expect(p).not.toBeNull()
+    expect(p.id).toBe("evt-1")
+    expect(p.fromRef).toBe("pylon:payer")
+    expect(p.toRef).toBe("pylon:payee")
+    expect(p.realBitcoinMoved).toBe(true)
+    expect(p.color).toBe(PAYMENT_PARTICLE_GOLD)
+    expect(p.amountSats).toBe(21_000)
+    expect(p.sourceRefs).toContain(receiptRef)
+  })
+
+  test("credited / non-bitcoin flow renders dim", () => {
+    const p = activityEventToParticle(
+      paymentEvent({ kind: "settlement_recorded", realBitcoinMoved: false }),
+    )!
+    expect(p.realBitcoinMoved).toBe(false)
+    expect(p.color).toBe(PAYMENT_PARTICLE_DIM)
+  })
+
+  test("refuses non-payment kinds", () => {
+    expect(activityEventToParticle(paymentEvent({ kind: "forum_posted" }))).toBeNull()
+  })
+
+  test("refuses an event missing an endpoint", () => {
+    expect(activityEventToParticle(paymentEvent({ actorRef: undefined }))).toBeNull()
+    expect(activityEventToParticle(paymentEvent({ targetRef: undefined }))).toBeNull()
+  })
+
+  test("refuses an event with no sourceRef (never fakes a clickable receipt)", () => {
+    expect(activityEventToParticle(paymentEvent({ sourceRefs: [] }))).toBeNull()
+    expect(activityEventToParticle(paymentEvent({ sourceRefs: undefined }))).toBeNull()
+  })
+
+  test("batch maps drop non-renderable events", () => {
+    const particles = activityEventsToParticles([
+      paymentEvent({ eventRef: "ok" }),
+      paymentEvent({ eventRef: "bad", sourceRefs: [] }),
+      paymentEvent({ eventRef: "skip", kind: "forum_posted" }),
+    ])
+    expect(particles).toHaveLength(1)
+    expect(particles[0]!.id).toBe("ok")
+  })
+})

--- a/apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  parseActivityStreamData,
+  subscribePaymentParticles,
+  subscribePylonScene,
+} from "../src/ui/chat-world-subscriptions"
+import type {
+  ChatWorldPylonScene,
+  PaymentParticle,
+} from "../src/shared/chat-world-scene"
+
+const jsonResponse = (body: unknown, ok = true): Response =>
+  ({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  }) as unknown as Response
+
+describe("subscribePylonScene (flag-gated poll)", () => {
+  test("returns noop and does not fetch when CHAT_WORLD_SCENE is off", () => {
+    let fetched = 0
+    const stop = subscribePylonScene(() => {}, {
+      flags: { CHAT_WORLD_SCENE: false },
+      fetchFn: (async () => {
+        fetched += 1
+        return jsonResponse({})
+      }) as unknown as typeof fetch,
+    })
+    stop()
+    expect(fetched).toBe(0)
+  })
+
+  test("polls pylon-stats and dispatches a projected scene when flag on", async () => {
+    const scenes: ChatWorldPylonScene[] = []
+    const stop = subscribePylonScene((s) => scenes.push(s), {
+      flags: { CHAT_WORLD_SCENE: true },
+      setInterval: () => 0, // suppress repeat; we test the immediate poll
+      clearInterval: () => {},
+      fetchFn: (async () =>
+        jsonResponse({
+          available: true,
+          status: "live",
+          pylonsOnlineNow: 1,
+          recentPylons: [{ nostrPubkeyShort: "abc", onlineNow: true }],
+        })) as unknown as typeof fetch,
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    stop()
+    expect(scenes.length).toBeGreaterThanOrEqual(1)
+    expect(scenes[0]!.onlineNow).toBe(1)
+    expect(scenes[0]!.nodes[0]!.id).toBe("abc")
+  })
+
+  test("dispatches honest zero-state on a failed fetch", async () => {
+    const scenes: ChatWorldPylonScene[] = []
+    const stop = subscribePylonScene((s) => scenes.push(s), {
+      flags: { CHAT_WORLD_SCENE: true },
+      setInterval: () => 0,
+      clearInterval: () => {},
+      fetchFn: (async () => jsonResponse({}, false)) as unknown as typeof fetch,
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    stop()
+    expect(scenes[0]!.empty).toBe(true)
+  })
+})
+
+describe("parseActivityStreamData", () => {
+  const payment = {
+    eventRef: "evt-1",
+    kind: "real_bitcoin_moved",
+    actorRef: "a",
+    targetRef: "b",
+    amountSats: 100,
+    realBitcoinMoved: true,
+    sourceRefs: ["receipt.x"],
+  }
+
+  test("parses the worker { event } frame shape", () => {
+    const p = parseActivityStreamData(JSON.stringify({ event: payment }))
+    expect(p?.id).toBe("evt-1")
+    expect(p?.realBitcoinMoved).toBe(true)
+  })
+
+  test("parses a bare event object too", () => {
+    const p = parseActivityStreamData(JSON.stringify(payment))
+    expect(p?.id).toBe("evt-1")
+  })
+
+  test("returns null for malformed / non-payment data", () => {
+    expect(parseActivityStreamData("not json")).toBeNull()
+    expect(parseActivityStreamData(JSON.stringify({ event: { eventRef: "x", kind: "forum_posted" } }))).toBeNull()
+    expect(parseActivityStreamData(JSON.stringify({ nope: 1 }))).toBeNull()
+  })
+})
+
+describe("subscribePaymentParticles (flag-gated, evidence-bound)", () => {
+  test("noop when CHAT_WORLD_PAYMENTS off", () => {
+    let fetched = 0
+    const stop = subscribePaymentParticles(() => {}, {
+      flags: { CHAT_WORLD_PAYMENTS: false },
+      fetchFn: (async () => {
+        fetched += 1
+        return jsonResponse({})
+      }) as unknown as typeof fetch,
+    })
+    stop()
+    expect(fetched).toBe(0)
+  })
+
+  test("backfills payment particles from the envelope poll on connect", async () => {
+    const particles: PaymentParticle[] = []
+    const stop = subscribePaymentParticles((p) => particles.push(p), {
+      flags: { CHAT_WORLD_PAYMENTS: true },
+      // no EventSource → poll path; suppress repeat interval
+      eventSourceCtor: undefined,
+      setInterval: () => 0,
+      clearInterval: () => {},
+      fetchFn: (async () =>
+        jsonResponse({
+          events: [
+            {
+              eventRef: "ok",
+              kind: "real_bitcoin_moved",
+              actorRef: "a",
+              targetRef: "b",
+              amountSats: 5,
+              realBitcoinMoved: true,
+              sourceRefs: ["receipt.ok"],
+            },
+            // dropped: no sourceRef
+            {
+              eventRef: "bad",
+              kind: "real_bitcoin_moved",
+              actorRef: "a",
+              targetRef: "b",
+              sourceRefs: [],
+            },
+          ],
+        })) as unknown as typeof fetch,
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    stop()
+    expect(particles).toHaveLength(1)
+    expect(particles[0]!.id).toBe("ok")
+    expect(particles[0]!.sourceRefs).toContain("receipt.ok")
+  })
+})


### PR DESCRIPTION
Refs #5736 #5737. Part of #5730 (§6 P1/P2). Built off `origin/main` in an isolated worktree as NEW modules + a flag-gated subscription hook (no `chatPane` rewrite) to minimize conflicts with the P0 agent.

## P1 — live pylons (#5736)
`apps/autopilot-desktop/src/shared/chat-world-scene.ts` maps a `/api/public/pylon-stats` snapshot's `recentPylons[]` → live scene nodes:
- **online glow** (`online`), **heartbeat-age pulse** (`heartbeatPulseSpeed` — fast when fresh, slows with age, stops when stale/unknown so liveness is never faked)
- **distinct state colors** for `offline` / `online` / `wallet_ready` / `assignment_ready` (§5: distinct encodings for distinct truths; gold reserved for real bitcoin)
- public `products[]` carried for the click-inspector
- **honest zero-state** (`empty:true`, no nodes) when the snapshot is null/unavailable/empty
- **pylon growth tier** (`pylonGrowthTier`) from cumulative settled sats → scale / facets / brightness on the pylon node

## P2 — payment particles + pylon growth (#5737)
Same module maps `activity-timeline` `real_bitcoin_moved` / `settlement_recorded` events → **evidence-bound** `PaymentParticle` descriptors:
- `actorRef → targetRef`, size ∝ `amountSats` (log-scaled, clamped), **gold** if `realBitcoinMoved` else **dim** (real-vs-credited distinct, §5.5)
- **every particle carries `sourceRefs`** (clickable to its receipt); events missing an endpoint or any sourceRef are **refused** (no fake clickable receipts, §5.1)
- renderer-agnostic descriptors so the P0 scene feeds them into three-effect `flowEffectPrimitives` (`createFlowBeam`) + `eventBurstPrimitives` (`createEvidenceBackedEventBurst`)

## Subscriptions (clean hooks for P0)
`apps/autopilot-desktop/src/ui/chat-world-subscriptions.ts`:
- `subscribePylonScene(dispatch)` — polls `/api/public/pylon-stats` (~4s, browser UA in the webview), fail-soft to honest zero-state, returns `unsubscribe()`
- `subscribePaymentParticles(dispatch)` — SSE `/api/public/activity-timeline/stream` (parses the worker's `event:`/`{ event }` frames), with envelope-poll fallback when `EventSource` is unavailable, and a backfill poll on connect
- Both **flag-gated** (`CHAT_WORLD_SCENE` / `CHAT_WORLD_PAYMENTS`, default OFF; resolved from `globalThis.__OA_FLAGS`) and return `noop` when off, so they are safe to wire before the flags flip.

A TODO in `subscriptions.ts` marks exactly where P0/`chatPane` should call these on scene mount/unmount.

## Verification
- `bun install` (root workspace) — clean
- New unit tests for both mappers and the subscription seams: **33 tests pass** (`tests/chat-world-scene.test.ts`, `tests/chat-world-subscriptions.test.ts`)
- `bun build apps/autopilot-desktop/src/ui/main.ts --target browser` bundles cleanly (includes the edited `subscriptions.ts`)
- New files introduce no type errors beyond the repo-wide `TS2835` `.js`-extension noise that every file in this package already has (the package builds via the bun bundler, not `tsc` emit); imports follow the established no-extension convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)