### PR TITLE
chore: bump @openagentsinc/three-effect to 0.1.0 (W0 agent-MMORPG primitives)

### DIFF
--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -29,7 +29,7 @@
     "@openagentsinc/autopilot-ui": "workspace:*",
     "@openagentsinc/proof-replay": "workspace:*",
     "@openagentsinc/public-activity-timeline": "workspace:*",
-    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7cae449abbaa9bd9d7556dede7209f9c970b039e",
+    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#f9b5341a06fa7641e5ecf63c81904bfcc7f61bf1",
     "effect": "catalog:",
     "electrobun": "1.18.1",
     "foldkit": "^0.102.1",

--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -29,7 +29,7 @@
     "@openagentsinc/autopilot-ui": "workspace:*",
     "@openagentsinc/proof-replay": "workspace:*",
     "@openagentsinc/public-activity-timeline": "workspace:*",
-    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#e960d79e6bc66fd791bd36fa3005ada30c2115fd",
+    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7cae449abbaa9bd9d7556dede7209f9c970b039e",
     "effect": "catalog:",
     "electrobun": "1.18.1",
     "foldkit": "^0.102.1",

--- a/apps/openagents.com/apps/web/package.json
+++ b/apps/openagents.com/apps/web/package.json
@@ -23,7 +23,7 @@
     "@openagentsinc/ui": "workspace:*",
     "@openagentsinc/sync-client": "workspace:*",
     "@openagentsinc/sync-schema": "workspace:*",
-    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#19013aece99d94cb0e703321cff16f9b4e68e988",
+    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7cae449abbaa9bd9d7556dede7209f9c970b039e",
     "@tailwindcss/vite": "^4.2.4",
     "aws4fetch": "^1.0.20",
     "clsx": "^2.1.1",

--- a/apps/openagents.com/apps/web/package.json
+++ b/apps/openagents.com/apps/web/package.json
@@ -23,7 +23,7 @@
     "@openagentsinc/ui": "workspace:*",
     "@openagentsinc/sync-client": "workspace:*",
     "@openagentsinc/sync-schema": "workspace:*",
-    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7cae449abbaa9bd9d7556dede7209f9c970b039e",
+    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#f9b5341a06fa7641e5ecf63c81904bfcc7f61bf1",
     "@tailwindcss/vite": "^4.2.4",
     "aws4fetch": "^1.0.20",
     "clsx": "^2.1.1",

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "@openagentsinc/autopilot-ui": "workspace:*",
         "@openagentsinc/proof-replay": "workspace:*",
         "@openagentsinc/public-activity-timeline": "workspace:*",
-        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7cae449abbaa9bd9d7556dede7209f9c970b039e",
+        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#f9b5341a06fa7641e5ecf63c81904bfcc7f61bf1",
         "effect": "catalog:",
         "electrobun": "1.18.1",
         "foldkit": "^0.102.1",
@@ -92,7 +92,7 @@
         "@openagentsinc/replay-clips": "workspace:*",
         "@openagentsinc/sync-client": "workspace:*",
         "@openagentsinc/sync-schema": "workspace:*",
-        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7cae449abbaa9bd9d7556dede7209f9c970b039e",
+        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#f9b5341a06fa7641e5ecf63c81904bfcc7f61bf1",
         "@openagentsinc/ui": "workspace:*",
         "@tailwindcss/vite": "^4.2.4",
         "aws4fetch": "^1.0.20",
@@ -1023,7 +1023,7 @@
 
     "@openagentsinc/tassadar-executor": ["@openagentsinc/tassadar-executor@workspace:packages/tassadar-executor"],
 
-    "@openagentsinc/three-effect": ["@openagentsinc/three-effect@github:OpenAgentsInc/three-effect#7cae449", { "dependencies": { "@types/three": "0.184.0", "effect": "4.0.0-beta.70", "foldkit": "0.102.1", "three": "0.184.0" } }, "OpenAgentsInc-three-effect-7cae449", "sha512-4cptfAJbtTE28uK/StCMDbTiRGYpBZ8NCYp0QC34qji89gGm8q0GUepQoQsIjGGjIhiyW6KDksde7meejsFfqA=="],
+    "@openagentsinc/three-effect": ["@openagentsinc/three-effect@github:OpenAgentsInc/three-effect#f9b5341", { "dependencies": { "@types/three": "0.184.0", "effect": "4.0.0-beta.70", "foldkit": "0.102.1", "three": "0.184.0" } }, "OpenAgentsInc-three-effect-f9b5341", "sha512-M2Vc2xjLZ/DBXMdpEDnXd+/R8hrQEZAOKe+jXhiRASJ0Oe9qP6/XyVbPqLnfIIyd1+JGPGz6L5rB0TSo1R4lwQ=="],
 
     "@openagentsinc/ui": ["@openagentsinc/ui@workspace:packages/ui"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "@openagentsinc/autopilot-ui": "workspace:*",
         "@openagentsinc/proof-replay": "workspace:*",
         "@openagentsinc/public-activity-timeline": "workspace:*",
-        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#e960d79e6bc66fd791bd36fa3005ada30c2115fd",
+        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7cae449abbaa9bd9d7556dede7209f9c970b039e",
         "effect": "catalog:",
         "electrobun": "1.18.1",
         "foldkit": "^0.102.1",
@@ -92,7 +92,7 @@
         "@openagentsinc/replay-clips": "workspace:*",
         "@openagentsinc/sync-client": "workspace:*",
         "@openagentsinc/sync-schema": "workspace:*",
-        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#19013aece99d94cb0e703321cff16f9b4e68e988",
+        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7cae449abbaa9bd9d7556dede7209f9c970b039e",
         "@openagentsinc/ui": "workspace:*",
         "@tailwindcss/vite": "^4.2.4",
         "aws4fetch": "^1.0.20",
@@ -1023,7 +1023,7 @@
 
     "@openagentsinc/tassadar-executor": ["@openagentsinc/tassadar-executor@workspace:packages/tassadar-executor"],
 
-    "@openagentsinc/three-effect": ["@openagentsinc/three-effect@github:OpenAgentsInc/three-effect#e960d79", { "dependencies": { "@types/three": "0.184.0", "effect": "4.0.0-beta.70", "foldkit": "0.102.1", "three": "0.184.0" } }, "OpenAgentsInc-three-effect-e960d79", "sha512-vRCieGrm4HPjYFbNJmmOBT8yCYleBlUujaoJ2t91dYj3+dlNIcNgwR/e7tzSDNj8I7lTA643HfAO+E1+QCiySg=="],
+    "@openagentsinc/three-effect": ["@openagentsinc/three-effect@github:OpenAgentsInc/three-effect#7cae449", { "dependencies": { "@types/three": "0.184.0", "effect": "4.0.0-beta.70", "foldkit": "0.102.1", "three": "0.184.0" } }, "OpenAgentsInc-three-effect-7cae449", "sha512-4cptfAJbtTE28uK/StCMDbTiRGYpBZ8NCYp0QC34qji89gGm8q0GUepQoQsIjGGjIhiyW6KDksde7meejsFfqA=="],
 
     "@openagentsinc/ui": ["@openagentsinc/ui@workspace:packages/ui"],
 
@@ -2754,8 +2754,6 @@
     "@moneydevkit/core/@moneydevkit/api-contract": ["@moneydevkit/api-contract@0.1.35", "", { "dependencies": { "@orpc/contract": "1.3.0", "zod": "^3.25.76" } }, "sha512-Xq0GnkdQfpmOugbZbmMyTkTTIOX7nLIr9aDfjji8ADqYZA8/Xs0/K4+TsqVYl5tpdlIArV29LDxQOMr3sBc3iw=="],
 
     "@moneydevkit/core/@orpc/client": ["@orpc/client@1.13.6", "", { "dependencies": { "@orpc/shared": "1.13.6", "@orpc/standard-server": "1.13.6", "@orpc/standard-server-fetch": "1.13.6", "@orpc/standard-server-peer": "1.13.6" } }, "sha512-M6lYM6fJUFp9GR+It/qglYTeXwspb6sGj46xXWHqHS6iDVquqju0bdYuLOfHx8CGJcUSzi0aKUcqMXiGJhBG3w=="],
-
-    "@openagentsinc/autopilot-web/@openagentsinc/three-effect": ["@openagentsinc/three-effect@github:OpenAgentsInc/three-effect#19013ae", { "dependencies": { "@types/three": "0.184.0", "effect": "4.0.0-beta.70", "foldkit": "0.102.1", "three": "0.184.0" } }, "OpenAgentsInc-three-effect-19013ae", "sha512-CmjEdDv/yJ2l5sdd05/YQJjcvf+/iS9NduNzxJSQd7AguRsjEiiDbQ35BQwyjRrrLMTai+WQXjyvPEKpqhtG5g=="],
 
     "@openagentsinc/nostr-relay/nostr-effect": ["nostr-effect@0.0.12", "", { "dependencies": { "@effect/platform": "0.93.5", "@effect/schema": "0.75.5", "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@scure/base": "1.2.4", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "effect": "3.19.8", "pako": "2.1.0" } }, "sha512-mrBi/thtI+NvDsZJsPKexkzsqlfnzM4L26klgrwTAyzwoDx486emeQkVFMkB3iuc3sSiwNPoFrVNCxUlV30oMw=="],
 


### PR DESCRIPTION
## What

Bumps the \`@openagentsinc/three-effect\` dependency to **0.1.0**, repinning both consumers to three-effect main commit \`7cae449\`. That commit merges three-effect#10 (the W0 agent-MMORPG primitive kit) and tags 0.1.0.

New primitives now available to OpenAgents:
- \`createCharacterSpawner\` — local/remote character spawning (#5731)
- \`createAgentAvatar\` + warp-in FX (#5732)
- \`createResourceBar\` (#5733)
- \`createEntityRegistry\` (#5734)

## Consumption mechanism note

\`@openagentsinc/three-effect\` is **not** on the npm registry — its package \`exports\` point at raw \`.ts\` source and it is consumed via \`github:OpenAgentsInc/three-effect#<sha>\` git commit-pins. So the "dependency bump" here is a commit repin (+ version marker 0.1.0), not an npm version change. Both prior pins were repointed:

- \`apps/openagents.com/apps/web\`: \`#19013aec\` → \`#7cae449\`
- \`apps/autopilot-desktop\`: \`#e960d79e\` → \`#7cae449\`

## Verification

- \`bun install\` resolves the new pin; \`bun.lock\` updated.
- Installed package is 0.1.0; all four W0 modules present and re-exported from the package index.
- \`apps/autopilot-desktop\` UI bundle builds (558 modules).
- \`apps/openagents.com/apps/web\` \`vite build\` succeeds (935 modules).

The primitives are now importable; wiring them into app scenes is follow-up W0 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)