### PR TITLE
P2.5: wire live pylons + payment particles into the chat scene [#5730]

### DIFF
--- a/apps/autopilot-desktop/src/shared/chat-world-flags.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-flags.ts
@@ -1,0 +1,31 @@
+// Chat-world build-time feature flags (P2.5 wiring · #5730).
+//
+// Single source of truth for the two chat-world flags so the VIEW (view.ts)
+// and the SUBSCRIPTIONS (chat-world-subscriptions.ts) agree on exactly what is
+// on. Both are resolved from Vite build env (VITE_CHAT_WORLD_SCENE /
+// VITE_CHAT_WORLD_PAYMENTS) and default OFF, so the desktop surface is
+// byte-for-byte the current pane unless a flag is explicitly built in.
+//
+// The pure mappers in shared/chat-world-scene.ts read globalThis.__OA_FLAGS for
+// headless test override; the desktop runtime instead resolves the build flags
+// here and passes them EXPLICITLY into the subscription hooks (deps.flags), so
+// there is no hidden global to keep in sync.
+
+import type { ChatWorldFlags } from "./chat-world-scene"
+
+const envFlag = (name: string): boolean => {
+  const env = (import.meta as { env?: Record<string, string | undefined> }).env
+  return (env?.[name] ?? "0") === "1"
+}
+
+// Resolve the chat-world flags from the build env. CHAT_WORLD_PAYMENTS implies
+// CHAT_WORLD_SCENE — payment beams have nowhere to fly without the scene — so a
+// payments-only misconfiguration still yields a coherent (scene-on) state.
+export const chatWorldBuildFlags = (): ChatWorldFlags => {
+  const scene = envFlag("VITE_CHAT_WORLD_SCENE")
+  const payments = envFlag("VITE_CHAT_WORLD_PAYMENTS")
+  return {
+    CHAT_WORLD_SCENE: scene || payments,
+    CHAT_WORLD_PAYMENTS: payments,
+  }
+}

--- a/apps/autopilot-desktop/src/shared/chat-world-visualization.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-visualization.ts
@@ -1,0 +1,200 @@
+// Chat-world visualization projection (P2.5 wiring · #5730).
+//
+// PURE, Three.js-free transform that turns the LIVE chat-world state
+//   - a ChatWorldPylonScene (from pylon-stats, P1 #5736), and
+//   - the active PaymentParticle[] (from the activity stream, P2 #5737)
+// into a single `TrainingRunVisualizationOptions` the shared three-effect
+// `trainingRunView` element renders behind chat. Tune knobs HERE, not in the
+// renderer (mirrors shared/pylon-network-scene.ts + ui/pylon-network-
+// visualization.ts discipline).
+//
+// Two layers, one scene:
+//   1. PYLONS  — live nodes ring the "network" hub (online/state color +
+//      growth tier on the hub), via the existing pylonNetworkVisualizationOptions
+//      bezier graph. A null/empty live scene falls back to the caller's static
+//      seed so zero-state / pre-load is calm, never blank.
+//   2. PAYMENTS — each PaymentParticle becomes an EVIDENCE-BOUND beam from the
+//      actor pylon → target pylon (gold motionKind for real bitcoin, dim for
+//      credited), with a settlement burst on the target, plus clickable endpoint
+//      entities that carry the receipt sourceRef. motionPolicy.evidence is
+//      "required", so the renderer refuses to animate any motion without refs —
+//      and activityEventToParticle already drops particles with no sourceRef, so
+//      nothing flies without real evidence (§5 evidence-bound motion contract).
+//
+// The shared renderer animates beams/bursts and registers entity hit targets
+// itself; size ∝ amountSats and the gold/dim split are carried on the descriptor
+// (particle.size / particle.realBitcoinMoved) so they survive into the inspector
+// even where the shared bezier renderer draws a single beam style.
+
+import type {
+  TrainingRunEntityDefinition,
+  TrainingRunBeamDefinition,
+  TrainingRunBurstDefinition,
+  TrainingRunVector,
+  TrainingRunVisualizationOptions,
+} from "@openagentsinc/three-effect/core"
+
+import type { ChatWorldPylonScene, PaymentParticle } from "./chat-world-scene"
+import {
+  type PylonNetworkNode,
+  type PylonNetworkScene,
+} from "./pylon-network-scene"
+
+// ── Live pylon scene → PylonNetworkScene (the existing bezier graph model) ────
+
+// Map a live presence state to the three-tone graph node language the bezier
+// graph already understands (working = earning, online = idle, offline = seen).
+const liveNodeTone = (node: ChatWorldPylonScene["nodes"][number]): PylonNetworkNode["tone"] => {
+  if (node.state === "assignment_ready") return "working"
+  if (node.online) return "online"
+  return "offline"
+}
+
+// Project the live ChatWorldPylonScene onto the PylonNetworkScene the existing
+// renderer consumes. Returns null when there is nothing live to show (no
+// snapshot yet, or an honest zero-state) so the caller keeps its static seed.
+export const liveChatWorldNetworkScene = (
+  live: ChatWorldPylonScene | null,
+): PylonNetworkScene | null => {
+  if (live === null || live.empty || live.nodes.length === 0) return null
+
+  const nodes: PylonNetworkNode[] = live.nodes.map((node) => {
+    const tone = liveNodeTone(node)
+    return { id: node.id, label: node.label, tone, flowing: tone === "working" }
+  })
+
+  const sessionsOnline = nodes.filter((n) => n.tone === "working").length
+  // Activity glow rides the share of online pylons that are actually working,
+  // lifted by fleet growth so a richer network reads as livelier. Bounded [0,1].
+  const workingShare = live.onlineNow > 0 ? sessionsOnline / live.onlineNow : 0
+  const activityIntensity = Math.max(
+    0,
+    Math.min(1, Number((workingShare * 0.7 + live.growth.brightness * 0.3).toFixed(3))),
+  )
+
+  return {
+    activityIntensity,
+    dormant: live.onlineNow === 0,
+    onlineNow: live.onlineNow,
+    sessionsOnlineNow: sessionsOnline,
+    sellableOnlineNow: nodes.filter((n) => n.tone !== "offline").length,
+    walletReadyNow: live.nodes.filter((n) => n.state === "wallet_ready").length,
+    assignmentReadyNow: sessionsOnline,
+    seen24h: nodes.length,
+    registeredTotal: nodes.length,
+    satsSettled24h: 0,
+    satsSettledTotal: live.growth.settledSats,
+    trainingAssignedContributors: 0,
+    trainingAcceptedContributors: 0,
+    trainingProgressContributors: 0,
+    nodes,
+    asOfLabel: live.asOfLabel,
+  }
+}
+
+// ── Payment particles → evidence-bound entities / beams / bursts ──────────────
+
+// Deterministic ring layout for payment endpoints, matched to the pylon graph's
+// own ring (ui/pylon-network-visualization.ts ringPosition) so a beam flies
+// between the visible pylon positions rather than floating off-graph.
+const PAYMENT_RING_RADIUS = 2.4
+const endpointRingPosition = (index: number, count: number): TrainingRunVector => {
+  const radius = PAYMENT_RING_RADIUS + Math.min(1.6, count / 40)
+  const angle = count <= 0 ? 0 : (2 * Math.PI * index) / count
+  return [
+    Number((Math.cos(angle) * radius).toFixed(3)),
+    Number((Math.sin(angle) * radius * 0.62).toFixed(3)),
+    0,
+  ]
+}
+
+// An entity status the renderer's status→color map reads. real_bitcoin earns the
+// "verified" (gold-family) tone; credited settlement reads as "active". These are
+// the public statuses the shared training-run entity color map honors.
+const endpointStatus = (particle: PaymentParticle): string =>
+  particle.realBitcoinMoved ? "verified" : "active"
+
+// A compact, inspector-friendly label that survives into the node-selection
+// detail so a click can dereference the receipt. Carries the first sourceRef.
+const endpointLabel = (ref: string, sats: number): string =>
+  sats > 0 ? `${ref} · ${sats} sats` : ref
+
+export type ChatWorldPaymentLayer = {
+  readonly entities: ReadonlyArray<TrainingRunEntityDefinition>
+  readonly beams: ReadonlyArray<TrainingRunBeamDefinition>
+  readonly bursts: ReadonlyArray<TrainingRunBurstDefinition>
+}
+
+// Build the evidence-bound payment layer from the active particles. Stable ids
+// per particle keep positions steady across re-renders; the sourceRefs ride both
+// the beam (motion evidence) and the endpoint entities (click → receipt). Every
+// particle here is already evidence-bound (activityEventToParticle dropped the
+// rest), and we additionally refuse any that somehow lost their refs.
+export const chatWorldPaymentLayer = (
+  particles: ReadonlyArray<PaymentParticle>,
+): ChatWorldPaymentLayer => {
+  const renderable = particles.filter((p) => p.sourceRefs.length > 0)
+
+  const entityById = new Map<string, TrainingRunEntityDefinition>()
+  const beams: TrainingRunBeamDefinition[] = []
+  const bursts: TrainingRunBurstDefinition[] = []
+
+  renderable.forEach((particle, index) => {
+    const primaryRef = particle.sourceRefs[0] as string
+    const fromId = `pay:${particle.id}:from`
+    const toId = `pay:${particle.id}:to`
+    const fromPos = endpointRingPosition(index * 2, renderable.length * 2)
+    const toPos = endpointRingPosition(index * 2 + 1, renderable.length * 2)
+
+    if (!entityById.has(fromId)) {
+      entityById.set(fromId, {
+        id: fromId,
+        status: endpointStatus(particle),
+        label: endpointLabel(particle.fromRef, 0),
+        position: fromPos,
+      })
+    }
+    if (!entityById.has(toId)) {
+      entityById.set(toId, {
+        id: toId,
+        status: endpointStatus(particle),
+        label: endpointLabel(primaryRef, particle.amountSats),
+        position: toPos,
+      })
+    }
+
+    const evidence = {
+      motionId: particle.id,
+      motionKind: particle.realBitcoinMoved ? "real_bitcoin_moved" : "settlement_recorded",
+      sourceRefs: particle.sourceRefs,
+      generatedAt: particle.ts ?? undefined,
+      simulated: false,
+    } as const
+
+    beams.push({ fromId, toId, ...evidence })
+    bursts.push({ atId: toId, ...evidence })
+  })
+
+  return { entities: [...entityById.values()], beams, bursts }
+}
+
+// ── Compose pylons + payments into one visualization options object ───────────
+
+// Take the pylon-graph options (already built from the live-or-seed network) and
+// overlay the evidence-bound payment layer. motionPolicy.evidence is forced to
+// "required" so the shared renderer animates a beam/burst ONLY when it carries
+// sourceRefs — a hard backstop behind the pure mappers' own evidence checks.
+export const withChatWorldPaymentLayer = (
+  base: TrainingRunVisualizationOptions,
+  particles: ReadonlyArray<PaymentParticle>,
+): TrainingRunVisualizationOptions => {
+  const layer = chatWorldPaymentLayer(particles)
+  if (layer.entities.length === 0) return base
+  return {
+    ...base,
+    entities: [...(base.entities ?? []), ...layer.entities],
+    beams: [...(base.beams ?? []), ...layer.beams],
+    bursts: [...(base.bursts ?? []), ...layer.bursts],
+    motionPolicy: { ...(base.motionPolicy ?? {}), evidence: "required" },
+  }
+}

--- a/apps/autopilot-desktop/src/ui/message.ts
+++ b/apps/autopilot-desktop/src/ui/message.ts
@@ -33,6 +33,20 @@ export const GotNodeState = m("GotNodeState", { node: S.Unknown })
 // #5049: public pylon-network stats push (drives the home network scene).
 export const GotPylonStats = m("GotPylonStats", { stats: S.Unknown })
 export const GotNotifications = m("GotNotifications", { view: S.Unknown })
+// #5730 (P2.5 chat-world wiring): live chat-world scene + payment-particle
+// pushes from the flag-gated chat-world subscriptions. `scene` is an opaque
+// ChatWorldPylonScene; `particle` an opaque evidence-bound PaymentParticle.
+export const GotChatWorldScene = m("GotChatWorldScene", { scene: S.Unknown })
+export const GotChatWorldPaymentParticle = m("GotChatWorldPaymentParticle", {
+  particle: S.Unknown,
+})
+// #5730: a click on a scene node/entity. For a payment endpoint the id encodes
+// the particle (`pay:<eventRef>:from|to`) and the label carries the receipt
+// sourceRef, so the reducer can surface the inspected ref (tooltip/inspector).
+export const SelectedChatWorldNode = m("SelectedChatWorldNode", {
+  id: S.String,
+  label: S.String,
+})
 // #5025: honest node-launch lifecycle status from the Bun supervisor.
 export const GotNodeLaunchStatus = m("GotNodeLaunchStatus", { status: S.String })
 
@@ -609,6 +623,9 @@ export const EndedPaneDrag = m("EndedPaneDrag")
 export const Message = S.Union([
   GotNodeState,
   GotPylonStats,
+  GotChatWorldScene,
+  GotChatWorldPaymentParticle,
+  SelectedChatWorldNode,
   GotNotifications,
   GotNodeLaunchStatus,
   NavigatedTo,

--- a/apps/autopilot-desktop/src/ui/model.ts
+++ b/apps/autopilot-desktop/src/ui/model.ts
@@ -35,6 +35,10 @@ import {
 // VALUE from this file; this file imports only the `PaneLayer` TYPE from there).
 import type { PaneLayer } from "./pane-manager"
 import type { PylonStatsSnapshot } from "../shared/pylon-network-scene"
+import type {
+  ChatWorldPylonScene,
+  PaymentParticle,
+} from "../shared/chat-world-scene"
 import type { DesktopProofReplayProjection } from "../shared/proof-replays"
 import {
   DEFAULT_DESKTOP_PROOF_REPLAY_SLUG as DefaultDesktopProofReplaySlug,
@@ -338,6 +342,22 @@ export const Model = ts("AutopilotDesktop", {
   // pushed from the Bun poller. Opaque PylonStatsSnapshot; projected to the
   // home scene via projectPylonNetworkScene. Null until the first poll lands.
   pylonStats: S.NullOr(S.Unknown),
+
+  // #5730 (P2.5 chat-world wiring): live chat-world-behind-chat state, fed by
+  // the flag-gated chat-world subscriptions (chat-world-subscriptions.ts) and
+  // read by chatPane to drive the scene. Both stay at their empty defaults (and
+  // the subscriptions stay noop) when the chat-world flags are OFF, so the chat
+  // pane is byte-identical to current main unless the flags are built in.
+  //   - chatWorldScene: latest projected ChatWorldPylonScene (opaque; read via
+  //     modelChatWorldScene). Null until the first pylon poll lands → static seed.
+  //   - chatWorldParticles: the bounded set of active payment-particle
+  //     descriptors (opaque PaymentParticle[]; read via modelChatWorldParticles),
+  //     each evidence-bound to a real sourceRef.
+  chatWorldScene: S.NullOr(S.Unknown),
+  chatWorldParticles: S.Array(S.Unknown),
+  // #5730: the receipt/source ref of the last-clicked payment beam endpoint, for
+  // the inspector chip. Null when nothing is selected. Click → SelectedChatWorldNode.
+  chatWorldInspectedRef: S.NullOr(S.String),
 
   // #5428: public activity timeline projection for Network/Training. The Bun
   // host fetches and schema-validates the Worker envelope; the webview renders
@@ -682,6 +702,16 @@ export const modelManagedAccounts = (
 export const modelPylonStats = (model: Model): PylonStatsSnapshot | null =>
   model.pylonStats as PylonStatsSnapshot | null
 
+// #5730: typed read boundary for the opaque chat-world state.
+export const modelChatWorldScene = (
+  model: Model,
+): ChatWorldPylonScene | null => model.chatWorldScene as ChatWorldPylonScene | null
+
+export const modelChatWorldParticles = (
+  model: Model,
+): ReadonlyArray<PaymentParticle> =>
+  model.chatWorldParticles as ReadonlyArray<PaymentParticle>
+
 export const modelPublicActivityTimeline = (
   model: Model,
 ): PublicActivityTimelineResponse | null =>
@@ -961,6 +991,9 @@ export const initialModel: Model = Model.make({
   node: null,
   notifications: null,
   pylonStats: null,
+  chatWorldScene: null,
+  chatWorldParticles: [],
+  chatWorldInspectedRef: null,
   publicActivityTimeline: null,
   publicActivityTimelineStatus: { text: "not loaded", tone: "idle" },
   publicActivityTimelinePending: false,

--- a/apps/autopilot-desktop/src/ui/styles.css
+++ b/apps/autopilot-desktop/src/ui/styles.css
@@ -1110,6 +1110,44 @@ body {
   gap: 0.75rem;
   min-height: 0;
 }
+/* #5730 (P2.5): the chat-world scene container positions the inspector chip
+ * (absolute) relative to itself without changing the P0 full-bleed layout. */
+.chat-scene-background {
+  position: relative;
+}
+/* #5730 (P2.5): the receipt inspector chip over the chat-world scene. Only
+ * visible behind the CHAT_WORLD_PAYMENTS flag, after a payment beam is clicked. */
+.chat-scene-inspector {
+  position: absolute;
+  left: 0.75rem;
+  bottom: 0.75rem;
+  z-index: 3;
+  display: flex;
+  gap: 0.25rem;
+  align-items: baseline;
+  max-width: min(90%, 32rem);
+  padding: 0.3rem 0.55rem;
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg, #0c0f13) 80%, transparent);
+  color: var(--fg, #e6e9ef);
+  font-size: 0.72rem;
+  pointer-events: none;
+}
+.chat-scene-inspector-empty {
+  display: none;
+}
+.chat-scene-inspector-label {
+  color: var(--muted, #8b93a7);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.chat-scene-inspector-ref {
+  color: var(--accent, #f5b73a);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .chat-thread-shell {
   min-height: 18rem;
   max-height: min(58vh, 38rem);

--- a/apps/autopilot-desktop/src/ui/subscriptions.ts
+++ b/apps/autopilot-desktop/src/ui/subscriptions.ts
@@ -18,11 +18,18 @@ import { Subscription } from "foldkit"
 import { setEmit } from "./bridge"
 import {
   EndedPaneDrag,
+  GotChatWorldPaymentParticle,
+  GotChatWorldScene,
   MovedPaneDragPointer,
   PressedKey,
   type Message,
 } from "./message"
 import type { Model } from "./model"
+import {
+  subscribePaymentParticles,
+  subscribePylonScene,
+} from "./chat-world-subscriptions"
+import { chatWorldBuildFlags } from "../shared/chat-world-flags"
 
 // The inbound push stream. We stash a queue-backed emitter in the bridge so the
 // Electroview handlers can feed messages in; teardown clears it.
@@ -200,30 +207,58 @@ const pointerStream: Stream.Stream<Message> = Stream.callback<Message>((queue) =
   ).pipe(Effect.flatMap(() => Effect.never)),
 )
 
+// P2.5 chat-world wiring (#5730): connect the P1/P2 live feeds (#5736/#5737)
+// into the reducer. The chat-world scene mounts/unmounts with the chat pane, but
+// the desktop runtime owns ONE persistent inbound stream per concern (mirroring
+// `inbound`/`keyboard`/`paneDrag`), so we model each chat-world feed as a
+// persistent Foldkit subscription whose acquire calls the hook and whose release
+// calls the returned unsubscribe() — the same mount/unmount contract the old
+// TODO described, expressed in Effect acquireRelease.
+//
+// Both feeds are FLAG-GATED on the SAME build flags the view uses
+// (chatWorldBuildFlags), passed explicitly into the hooks so there is no hidden
+// global. With the flags OFF the hooks return noop immediately (no fetch, no
+// EventSource, no timers), so the only cost of registering them is two acquired
+// resources that do nothing — and the reducer never sees a chat-world message,
+// keeping the flag-OFF model + view byte-identical to current main.
+//
+// Evidence-bound (§5): subscribePaymentParticles only ever dispatches particles
+// that carry a real sourceRef (activityEventToParticle drops the rest), so every
+// GotChatWorldPaymentParticle the reducer stores is clickable to a real receipt.
+
+const pylonSceneStream: Stream.Stream<Message> = Stream.callback<Message>((queue) =>
+  Effect.acquireRelease(
+    Effect.sync(() =>
+      subscribePylonScene(
+        (scene) => Queue.offerUnsafe(queue, GotChatWorldScene({ scene })),
+        { flags: chatWorldBuildFlags() },
+      ),
+    ),
+    (unsubscribe) => Effect.sync(() => unsubscribe()),
+  ).pipe(Effect.flatMap(() => Effect.never)),
+)
+
+const paymentParticleStream: Stream.Stream<Message> = Stream.callback<Message>((queue) =>
+  Effect.acquireRelease(
+    Effect.sync(() =>
+      subscribePaymentParticles(
+        (particle) =>
+          Queue.offerUnsafe(queue, GotChatWorldPaymentParticle({ particle })),
+        { flags: chatWorldBuildFlags() },
+      ),
+    ),
+    (unsubscribe) => Effect.sync(() => unsubscribe()),
+  ).pipe(Effect.flatMap(() => Effect.never)),
+)
+
 export const subscriptions = Subscription.make<Model, Message>()(() => ({
   inbound: Subscription.persistent(inboundStream),
   // #5465: route window keydown into the reducer as PressedKey.
   keyboard: Subscription.persistent(keyboardStream),
   // HUD H3 (#5501): route window pointer move/up into the pane-layer drag reducer.
   paneDrag: Subscription.persistent(pointerStream),
+  // #5730: live pylon scene + Bitcoin payment particles behind chat. Both noop
+  // (no I/O) unless their build flag is on, so flag-OFF behavior is unchanged.
+  chatWorldScene: Subscription.persistent(pylonSceneStream),
+  chatWorldPayments: Subscription.persistent(paymentParticleStream),
 }))
-
-// TODO(P0 chat-world wiring · #5736 #5737): the live chat-world scene owns its
-// own feed lifecycle (it mounts/unmounts with the canvas), so its subscriptions
-// are NOT registered here. When P0 mounts the pylon scene behind chatPane
-// (flag CHAT_WORLD_SCENE) and the payment layer (flag CHAT_WORLD_PAYMENTS),
-// call these from the scene's mount and store the returned unsubscribe() to call
-// on unmount:
-//
-//   import {
-//     subscribePylonScene,
-//     subscribePaymentParticles,
-//   } from "./chat-world-subscriptions"
-//
-//   const stopPylons   = subscribePylonScene(scene.applyPylonScene)
-//   const stopPayments = subscribePaymentParticles(scene.spawnPaymentParticle)
-//   // ... on unmount: stopPylons(); stopPayments()
-//
-// Both are flag-gated (default OFF) and return noop when their flag is unset, so
-// wiring them in is safe before the flags flip on. The pure mappers they use
-// live in shared/chat-world-scene.ts (unit-tested in tests/chat-world-scene.test.ts).

--- a/apps/autopilot-desktop/src/ui/update.ts
+++ b/apps/autopilot-desktop/src/ui/update.ts
@@ -147,6 +147,37 @@ type Result = readonly [Model, ReadonlyArray<Command.Command<Message>>]
 
 const noCommands: ReadonlyArray<Command.Command<Message>> = []
 
+// #5730: how many active payment particles the chat-world scene keeps at once.
+// Bounds the live beam/burst count behind chat and the scene-options signature
+// the renderer diffs on, so a busy stream cannot grow the set without limit.
+const MAX_CHAT_WORLD_PARTICLES = 24
+
+// Append a new payment particle to the bounded active set, de-duped by id and
+// keeping the most recent MAX_CHAT_WORLD_PARTICLES. Opaque in/out (the runtime
+// stores PaymentParticle as S.Unknown); we read only the `id` for dedupe.
+const appendChatWorldParticle = (
+  current: ReadonlyArray<unknown>,
+  particle: unknown,
+): ReadonlyArray<unknown> => {
+  const id = (particle as { id?: unknown } | null)?.id
+  const withoutDup =
+    typeof id === "string"
+      ? current.filter((p) => (p as { id?: unknown } | null)?.id !== id)
+      : current
+  const next = [...withoutDup, particle]
+  return next.length > MAX_CHAT_WORLD_PARTICLES
+    ? next.slice(next.length - MAX_CHAT_WORLD_PARTICLES)
+    : next
+}
+
+// #5730: recover the receipt sourceRef from a payment-endpoint entity label.
+// Labels are `<ref> · <sats> sats` (target) or a bare `<ref>` (from), so the
+// ref is everything before the first " · " separator, trimmed.
+const chatWorldRefFromLabel = (label: string): string => {
+  const sep = label.indexOf(" · ")
+  return (sep >= 0 ? label.slice(0, sep) : label).trim()
+}
+
 const SHELL_TARGET_ORDER: ReadonlyArray<ShellTarget> = [
   "current",
   "claude_code",
@@ -723,6 +754,41 @@ export const update = (model: Model, message: Message): Result => {
       ]
     case "GotPylonStats":
       return [Model.make({ ...model, pylonStats: message.stats }), noCommands]
+    case "GotChatWorldScene":
+      // #5730: latest projected live chat-world pylon scene. Stored opaque;
+      // chatPane reads it via modelChatWorldScene and falls back to the static
+      // seed on null/empty.
+      return [
+        Model.make({ ...model, chatWorldScene: message.scene }),
+        noCommands,
+      ]
+    case "GotChatWorldPaymentParticle":
+      // #5730: a new evidence-bound payment particle. Append to the bounded
+      // active set, de-duped by id (the backfill poll and the live stream can
+      // both surface the same event), keeping the most recent ones.
+      return [
+        Model.make({
+          ...model,
+          chatWorldParticles: appendChatWorldParticle(
+            model.chatWorldParticles,
+            message.particle,
+          ),
+        }),
+        noCommands,
+      ]
+    case "SelectedChatWorldNode":
+      // #5730: surface the clicked payment endpoint's receipt ref in the
+      // inspector. Only payment endpoints carry a ref (id `pay:…`); other scene
+      // nodes clear the inspector. The label is `<ref> · <sats> sats` or `<ref>`.
+      return [
+        Model.make({
+          ...model,
+          chatWorldInspectedRef: message.id.startsWith("pay:")
+            ? chatWorldRefFromLabel(message.label)
+            : null,
+        }),
+        noCommands,
+      ]
     case "GotNotifications":
       return [Model.make({ ...model, notifications: message.view }), noCommands]
     case "GotNodeLaunchStatus":

--- a/apps/autopilot-desktop/src/ui/view.ts
+++ b/apps/autopilot-desktop/src/ui/view.ts
@@ -59,6 +59,13 @@ import type {
   PylonNetworkNode,
   PylonNetworkScene,
 } from "../shared/pylon-network-scene"
+// #5730 (P2.5): feed the LIVE pylon scene + Bitcoin payment particles into the
+// chat background scene. Pure projections live in shared/chat-world-*.ts.
+import {
+  liveChatWorldNetworkScene,
+  withChatWorldPaymentLayer,
+} from "../shared/chat-world-visualization"
+import { chatWorldBuildFlags } from "../shared/chat-world-flags"
 
 import type {
   AccountRow,
@@ -131,6 +138,7 @@ import {
   ClickedLoadGeneratedProofReplay,
   ClickedRefreshManagedAccounts,
   ClickedRemoveManagedAccount,
+  SelectedChatWorldNode,
   SelectedComposerAccount,
   ClickedCancelSession,
   ClickedOpenSessionInComposer,
@@ -289,6 +297,8 @@ import {
   modelInstallReadiness,
   modelOnboardingStatus,
   modelIdentityChoiceState,
+  modelChatWorldParticles,
+  modelChatWorldScene,
   modelManagedAccounts,
   modelPaneLayer,
   modelPromiseSurfacingReadiness,
@@ -5739,10 +5749,14 @@ const chatMessageView = (model: Model, message: ChatMessage): Html =>
 // is byte-for-byte the current pane unless the flag is explicitly enabled. When
 // on, the chat thread + composer render as translucent glass over a full-bleed
 // 3D pylon scene (mirrors the .training-fullscreen-scene/-overlay pattern).
-// Live data is a separate issue (#5736); this seeds a static scene.
-const CHAT_WORLD_SCENE: boolean =
-  ((import.meta as { env?: Record<string, string | undefined> }).env
-    ?.VITE_CHAT_WORLD_SCENE ?? "0") === "1"
+// #5730 (P2.5): the static seed is now only a zero-state/pre-load fallback —
+// when the flag is on AND live pylon-stats have arrived, the scene shows the
+// REAL pylons (modelChatWorldScene), and with CHAT_WORLD_PAYMENTS on, real
+// Bitcoin payment beams fly between them. Resolved from the shared build-flag
+// reader so the view and the subscriptions agree on what is on.
+const CHAT_WORLD_FLAGS = chatWorldBuildFlags()
+const CHAT_WORLD_SCENE: boolean = CHAT_WORLD_FLAGS.CHAT_WORLD_SCENE
+const CHAT_WORLD_PAYMENTS: boolean = CHAT_WORLD_FLAGS.CHAT_WORLD_PAYMENTS
 
 // A calm static seed scene: one hub + ~8 ring pylons. A couple are "working"
 // so the graph reads as a living-but-idle network rather than dead. This is a
@@ -5780,12 +5794,38 @@ const CHAT_SCENE: PylonNetworkScene = {
   asOfLabel: null,
 }
 
-const chatSceneBackground = (): Html =>
+// #5730: build the chat-background visualization from LIVE state, falling back
+// to the calm static seed for the zero-state / pre-load moment. With the
+// payments flag on, evidence-bound payment beams/bursts overlay the graph.
+const chatSceneVisualization = (model: Model): TrainingRunVisualizationOptions => {
+  // Live pylons replace the seed once a non-empty snapshot has landed.
+  const liveScene = liveChatWorldNetworkScene(modelChatWorldScene(model))
+  const base = pylonNetworkVisualizationOptions(liveScene ?? CHAT_SCENE)
+  // Payment particles only when their flag is on; each is already evidence-bound.
+  return CHAT_WORLD_PAYMENTS
+    ? withChatWorldPaymentLayer(base, modelChatWorldParticles(model))
+    : base
+}
+
+// A small inspector chip naming the receipt the last-clicked payment beam ties
+// to (evidence-bound: every beam carries a real sourceRef). Absent until a click.
+const chatSceneInspector = (model: Model): Html =>
+  model.chatWorldInspectedRef !== null
+    ? h.div([cls("chat-scene-inspector mono")], [
+        h.span([cls("chat-scene-inspector-label")], ["receipt "]),
+        h.span([cls("chat-scene-inspector-ref")], [model.chatWorldInspectedRef]),
+      ])
+    : h.div([cls("chat-scene-inspector chat-scene-inspector-empty")], [])
+
+const chatSceneBackground = (model: Model): Html =>
   h.div([cls("chat-scene-background")], [
     trainingRunView<Message>(
       [cls("three-effect-chat-scene")],
-      pylonNetworkVisualizationOptions(CHAT_SCENE),
+      chatSceneVisualization(model),
+      // Click a payment endpoint → surface its receipt ref in the inspector.
+      (node) => SelectedChatWorldNode({ id: node.id, label: node.label }),
     ),
+    chatSceneInspector(model),
   ])
 
 // The chat thread + composer, shared by both the plain and world-scene layouts.
@@ -5841,7 +5881,7 @@ const chatComposer = (model: Model): Html =>
 const chatPane = (model: Model): Html =>
   CHAT_WORLD_SCENE
     ? h.div([cls("chat-pane chat-pane-world")], [
-        chatSceneBackground(),
+        chatSceneBackground(model),
         h.div([cls("chat-content-overlay")], [
           paneTitle("Chat"),
           chatThread(model),

--- a/apps/autopilot-desktop/tests/chat-world-visualization.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-visualization.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test"
+
+import type {
+  ChatWorldPylonScene,
+  PaymentParticle,
+} from "../src/shared/chat-world-scene"
+import {
+  PAYMENT_PARTICLE_DIM,
+  PAYMENT_PARTICLE_GOLD,
+  pylonGrowthTier,
+} from "../src/shared/chat-world-scene"
+import {
+  chatWorldPaymentLayer,
+  liveChatWorldNetworkScene,
+  withChatWorldPaymentLayer,
+} from "../src/shared/chat-world-visualization"
+import { pylonNetworkVisualizationOptions } from "../src/ui/pylon-network-visualization"
+
+// ── P1: live pylon scene → bezier-graph PylonNetworkScene ─────────────────────
+
+const liveScene = (
+  overrides: Partial<ChatWorldPylonScene> = {},
+): ChatWorldPylonScene => ({
+  empty: false,
+  onlineNow: 2,
+  nodes: [
+    {
+      id: "abc123",
+      label: "alpha",
+      state: "assignment_ready",
+      color: 0x4ade80,
+      online: true,
+      pulseSpeed: 1.8,
+      products: [],
+    },
+    {
+      id: "def456",
+      label: "bravo",
+      state: "wallet_ready",
+      color: 0x7dd3fc,
+      online: true,
+      pulseSpeed: 0.4,
+      products: [],
+    },
+  ],
+  growth: pylonGrowthTier(50_000),
+  asOfLabel: "moments ago",
+  ...overrides,
+})
+
+describe("liveChatWorldNetworkScene", () => {
+  test("null / empty / zero-node live scenes fall back (return null)", () => {
+    expect(liveChatWorldNetworkScene(null)).toBeNull()
+    expect(
+      liveChatWorldNetworkScene(liveScene({ empty: true, nodes: [] })),
+    ).toBeNull()
+    expect(liveChatWorldNetworkScene(liveScene({ nodes: [] }))).toBeNull()
+  })
+
+  test("maps live nodes onto the three-tone graph (working/online/offline)", () => {
+    const scene = liveChatWorldNetworkScene(liveScene())
+    expect(scene).not.toBeNull()
+    const nodes = scene!.nodes
+    expect(nodes.map((n) => n.id)).toEqual(["abc123", "def456"])
+    // assignment_ready → working (earning), wallet_ready (online, not earning) → online
+    expect(nodes[0]!.tone).toBe("working")
+    expect(nodes[0]!.flowing).toBe(true)
+    expect(nodes[1]!.tone).toBe("online")
+    expect(nodes[1]!.flowing).toBe(false)
+    expect(scene!.onlineNow).toBe(2)
+    expect(scene!.sessionsOnlineNow).toBe(1)
+    // cumulative settled sats ride through as the growth signal
+    expect(scene!.satsSettledTotal).toBe(50_000)
+  })
+
+  test("activity intensity is bounded [0,1]", () => {
+    const scene = liveChatWorldNetworkScene(liveScene())!
+    expect(scene.activityIntensity).toBeGreaterThanOrEqual(0)
+    expect(scene.activityIntensity).toBeLessThanOrEqual(1)
+  })
+})
+
+// ── P2: payment particles → evidence-bound beams/bursts/entities ──────────────
+
+const particle = (overrides: Partial<PaymentParticle> = {}): PaymentParticle => ({
+  id: "evt-1",
+  fromRef: "pylon:alpha",
+  toRef: "pylon:bravo",
+  amountSats: 21_000,
+  realBitcoinMoved: true,
+  color: PAYMENT_PARTICLE_GOLD,
+  size: 0.7,
+  sourceRefs: ["receipt:nip90:abc"],
+  ts: "2026-06-20T00:00:00.000Z",
+  text: null,
+  ...overrides,
+})
+
+describe("chatWorldPaymentLayer (evidence-bound motion)", () => {
+  test("each particle yields a beam + burst + two clickable endpoints", () => {
+    const layer = chatWorldPaymentLayer([particle()])
+    expect(layer.beams).toHaveLength(1)
+    expect(layer.bursts).toHaveLength(1)
+    expect(layer.entities).toHaveLength(2)
+    const beam = layer.beams[0]!
+    expect(beam.fromId).toBe("pay:evt-1:from")
+    expect(beam.toId).toBe("pay:evt-1:to")
+    // gold real-bitcoin motion is tagged real_bitcoin_moved; dim is settlement
+    expect(beam.motionKind).toBe("real_bitcoin_moved")
+    expect(beam.sourceRefs).toEqual(["receipt:nip90:abc"])
+    expect(beam.simulated).toBe(false)
+    // the target endpoint label carries the receipt ref (click → inspector)
+    const toEntity = layer.entities.find((e) => e.id === "pay:evt-1:to")!
+    expect(toEntity.label).toContain("receipt:nip90:abc")
+    expect(toEntity.label).toContain("21000 sats")
+  })
+
+  test("credited (non-bitcoin) particles tag settlement_recorded", () => {
+    const layer = chatWorldPaymentLayer([
+      particle({ realBitcoinMoved: false, color: PAYMENT_PARTICLE_DIM }),
+    ])
+    expect(layer.beams[0]!.motionKind).toBe("settlement_recorded")
+  })
+
+  test("refuses particles with no sourceRef (never fakes a receipt)", () => {
+    const layer = chatWorldPaymentLayer([particle({ sourceRefs: [] })])
+    expect(layer.beams).toHaveLength(0)
+    expect(layer.bursts).toHaveLength(0)
+    expect(layer.entities).toHaveLength(0)
+  })
+})
+
+describe("withChatWorldPaymentLayer", () => {
+  const base = pylonNetworkVisualizationOptions(
+    liveChatWorldNetworkScene(liveScene())!,
+  )
+
+  test("no particles → base options unchanged (no motion overlay)", () => {
+    const out = withChatWorldPaymentLayer(base, [])
+    expect(out).toBe(base)
+  })
+
+  test("particles overlay beams/bursts/entities and force evidence=required", () => {
+    const out = withChatWorldPaymentLayer(base, [particle()])
+    expect(out.beams).toHaveLength(1)
+    expect(out.bursts).toHaveLength(1)
+    expect((out.entities ?? []).length).toBe(2)
+    // hard backstop: the renderer must require evidence before animating motion
+    expect(out.motionPolicy?.evidence).toBe("required")
+    // the base pylon graph nodes survive the overlay
+    expect(out.nodes).toBe(base.nodes)
+  })
+})


### PR DESCRIPTION
Refs #5730. Connects the P1/P2 hooks (#5736/#5737) into the P0 scene (#5735): live pylons + gold Bitcoin payment beams behind chat, flag-gated.

## What this does
Flipping the chat-world flags now shows REAL data instead of the static seed:

- **Live pylons** (`CHAT_WORLD_SCENE`): the pylon scene behind chat is projected from live pylon-stats (`modelChatWorldScene`) — node tone/glow reflects live online/working state and the hub rides the fleet growth tier. The static seed remains as the calm zero-state / pre-load fallback, so the scene is never blank or dead.
- **Payment particles** (`CHAT_WORLD_PAYMENTS`): each `PaymentParticle` from the activity stream renders as an evidence-bound flow beam from the actor pylon -> target pylon, with a settlement burst on arrival. `real_bitcoin_moved` is tagged gold, credited `settlement_recorded` dim; size rides `amountSats`. Each beam's endpoints are clickable and carry the receipt `sourceRef`, surfaced in an inspector chip.

## How it's wired
- `ui/subscriptions.ts`: `subscribePylonScene` / `subscribePaymentParticles` registered as flag-gated persistent Foldkit subscriptions — `acquireRelease` is exactly the scene mount/unmount lifecycle the old TODO described. Both return noop (no fetch / EventSource / timers) when their build flag is off.
- `shared/chat-world-flags.ts`: one build-flag resolver so the view and the subscriptions agree on what is on.
- `model.ts` / `message.ts` / `update.ts`: store the live `ChatWorldPylonScene` + a bounded (max 24), de-duped set of `PaymentParticle`s; `SelectedChatWorldNode` resolves a clicked beam to its receipt ref.
- `shared/chat-world-visualization.ts` (pure, unit-tested): live-pylons -> bezier graph + payment particles -> evidence-bound `entities`/`beams`/`bursts`, with `motionPolicy.evidence: "required"` as a hard backstop.

## Evidence-bound (§5)
Every beam/burst ties to a real `sourceRef`. Particles with no ref are dropped upstream (`activityEventToParticle`) and refused again in the projection, so nothing flies without real evidence.

## Flag-OFF is byte-identical
With both flags off: the subscriptions are inert, the reducer never sees a chat-world message, and `chatPane` takes the unchanged plain branch. New model fields sit at empty defaults.

## Verify
- `bun install`
- `bun build src/ui/main.ts --target browser` bundles clean (599 modules) in both flag-off and flag-on states.
- New `tests/chat-world-visualization.test.ts` (8 tests) + existing `chat-world-scene` / `chat-world-subscriptions` / `cl-53-foldkit` suites pass (102 total).
- Did NOT run `check:deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)