### PR TITLE
Verse: hotbar toggle for the game-world view (default ON) [#5730]

### DIFF
--- a/apps/autopilot-desktop/src/ui/keyboard.ts
+++ b/apps/autopilot-desktop/src/ui/keyboard.ts
@@ -34,6 +34,8 @@ export type KeyIntent =
   // explicit "open panes" can always be undone, so you never get trapped in
   // the full UI (owner directive 2026-06-19).
   | Readonly<{ kind: "back-to-shell" }>
+  // #5730 The Verse: ⌘⇧V / Ctrl-⇧V toggles the game-world view on/off.
+  | Readonly<{ kind: "toggle-verse" }>
 
 const isModified = (event: KeyEvent): boolean => event.meta || event.ctrl
 
@@ -74,6 +76,11 @@ export const interpretKey = (model: Model, event: KeyEvent): KeyIntent => {
 
   // ── Cmd/Ctrl-K opens the palette from anywhere (even while typing) ────────
   if (key.toLowerCase() === "k" && isModified(event)) return { kind: "open-palette" }
+
+  // ── Cmd/Ctrl-Shift-V toggles the Verse (game-world view) from anywhere ────
+  if (key.toLowerCase() === "v" && isModified(event) && event.shift) {
+    return { kind: "toggle-verse" }
+  }
 
   // ── Cmd/Ctrl-Enter submits the chat/composer turn ─────────────────────────
   if (key === "Enter" && isModified(event)) {

--- a/apps/autopilot-desktop/src/ui/message.ts
+++ b/apps/autopilot-desktop/src/ui/message.ts
@@ -100,6 +100,10 @@ export const ToggledDiffFile = m("ToggledDiffFile", { path: S.String })
 export const ToggledDiffViewMode = m("ToggledDiffViewMode")
 export const ToggledArtifactBrowser = m("ToggledArtifactBrowser")
 
+// #5730 The Verse: flip the runtime toggle for the game-world view that renders
+// behind chat. Pure model toggle — no control verb / RPC.
+export const ToggleVerse = m("ToggleVerse")
+
 // Chat: expand/collapse a single chat message's "program details" disclosure
 // (the scoped-step / Tassadar scaffolding). Collapsed by default so the chat
 // opens to a clean conversation. Pure model toggle — no control verb / RPC.
@@ -642,6 +646,7 @@ export const Message = S.Union([
   ToggledDiffFile,
   ToggledDiffViewMode,
   ToggledArtifactBrowser,
+  ToggleVerse,
   ToggledChatMessageDetails,
   ClickedCoordinatorToggle,
   SettledCoordinatorToggle,

--- a/apps/autopilot-desktop/src/ui/model.ts
+++ b/apps/autopilot-desktop/src/ui/model.ts
@@ -450,6 +450,11 @@ export const Model = ts("AutopilotDesktop", {
   // expanded (the ref rows under the artifact summary line).
   artifactBrowserOpen: S.Boolean,
 
+  // #5730 The Verse: runtime toggle for the game-world view that renders behind
+  // the chat surface. Defaults TRUE (the Verse shows by default). The build flag
+  // CHAT_WORLD_SCENE remains a hard kill-switch; this is the user-facing control.
+  verseEnabled: S.Boolean,
+
   // Approvals optimistically resolved this session (hidden until the next poll
   // confirms). Keyed by approvalRef.
   resolvedApprovals: S.Array(S.String),
@@ -1037,6 +1042,8 @@ export const initialModel: Model = Model.make({
   expandedDiffFiles: [],
   diffViewMode: "unified",
   artifactBrowserOpen: false,
+  // #5730 The Verse: on by default so the game-world view is visible now.
+  verseEnabled: true,
   resolvedApprovals: [],
   spawnAdapter: "codex",
   spawnObjective: "",

--- a/apps/autopilot-desktop/src/ui/nav.ts
+++ b/apps/autopilot-desktop/src/ui/nav.ts
@@ -345,6 +345,7 @@ export const SHORTCUTS: ReadonlyArray<ShortcutSpec> = [
   { chord: "Enter", description: "Run the selected command", when: "palette open" },
   { chord: "⌘↵ / Ctrl-↵", description: "Submit the chat / composer turn", when: "Chat or Composer" },
   { chord: "j / k", description: "Move to the next / previous sub-pane in the group", when: "anywhere (not while typing)" },
+  { chord: "⌘⇧V / Ctrl-⇧V", description: "Toggle the Verse (game-world view)", when: "anywhere" },
 ]
 
 // ── HUD H1: the hotbar (#5499) ───────────────────────────────────────────────
@@ -367,6 +368,13 @@ export type HotbarSlot =
       label: string
       chord: string
     }>
+  // #5730 The Verse: a toggle slot that shows/hides the game-world view behind
+  // chat. Lit when on (default ON). Carries a keyboard chord like the ⌘K slot.
+  | Readonly<{
+      kind: "verse"
+      label: string
+      chord: string
+    }>
 
 // The blank slots are exactly the primary nav groups, keyed by their accel so
 // count/order follow the registry without reintroducing click behavior.
@@ -382,5 +390,7 @@ const groupHotbarSlots: ReadonlyArray<HotbarSlot> = [...NAV_GROUPS]
 
 export const HOTBAR_SLOTS: ReadonlyArray<HotbarSlot> = [
   ...groupHotbarSlots,
+  // #5730 The Verse: a toggle for the game-world view behind chat (default ON).
+  { kind: "verse" as const, label: "Verse", chord: "⌘⇧V" },
   { kind: "palette" as const, label: "Command palette", chord: "⌘K" },
 ]

--- a/apps/autopilot-desktop/src/ui/styles.css
+++ b/apps/autopilot-desktop/src/ui/styles.css
@@ -431,6 +431,31 @@ body {
   color: var(--hud-primary, #fff);
   border-color: color-mix(in srgb, var(--hud-primary) 65%, transparent);
 }
+/* #5730 The Verse: the game-world toggle slot. Wider than a square so the short
+   "Verse" label fits; lit (glowing) when the view is on, dim when off. */
+.hotbar-slot-verse {
+  width: auto;
+  min-width: 3rem;
+  padding: 0 0.7rem;
+}
+.hotbar-slot-label {
+  font-family: ui-monospace, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+.hotbar-slot-verse-on {
+  color: var(--hud-primary, #fff);
+  border-color: color-mix(in srgb, var(--hud-primary) 70%, transparent);
+  background: color-mix(in srgb, var(--hud-primary) 14%, transparent);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--hud-primary) 35%, transparent);
+}
+.hotbar-slot-verse-on:hover,
+.hotbar-slot-verse-on:focus-visible {
+  border-color: color-mix(in srgb, var(--hud-primary) 85%, transparent);
+}
 /* HUD H7 (#5504): the live status/meters overlay. A small top-right corner card
    (the game-HUD status layer) rendered by the three-effect H2 kit. Sits clear of
    the left sidebar and the bottom-center hotbar so it never occludes the shell

--- a/apps/autopilot-desktop/src/ui/update.ts
+++ b/apps/autopilot-desktop/src/ui/update.ts
@@ -1015,6 +1015,13 @@ export const update = (model: Model, message: Message): Result => {
           const submit = submitTurnMessage(model, intent.pane)
           return submit ? update(model, submit) : [model, noCommands]
         }
+        case "toggle-verse":
+          // #5730 The Verse: inline the toggle (message constructors are
+          // type-only imports here). Byte-identical to the ToggleVerse reducer.
+          return [
+            Model.make({ ...model, verseEnabled: !model.verseEnabled }),
+            noCommands,
+          ]
       }
     }
 
@@ -1050,6 +1057,11 @@ export const update = (model: Model, message: Message): Result => {
       ]
     case "ToggledArtifactBrowser":
       return [Model.make({ ...model, artifactBrowserOpen: !model.artifactBrowserOpen }), noCommands]
+
+    // #5730 The Verse: flip the runtime toggle for the game-world view. Pure
+    // model toggle — the view gates the scene render on this + the build flag.
+    case "ToggleVerse":
+      return [Model.make({ ...model, verseEnabled: !model.verseEnabled }), noCommands]
 
     // Chat: flip a single message's "program details" disclosure (scoped-step /
     // Tassadar scaffolding). Collapsed by default; pure model toggle.

--- a/apps/autopilot-desktop/src/ui/view.ts
+++ b/apps/autopilot-desktop/src/ui/view.ts
@@ -192,6 +192,7 @@ import {
   ToggledEvent,
   ToggledDiffFile,
   ToggledDiffViewMode,
+  ToggleVerse,
   ToggledArtifactBrowser,
   ToggledChatMessageDetails,
   ChangedShellInput,
@@ -575,7 +576,7 @@ const commandPalette = (model: Model): Html => {
 // Rendered inside the zero-base shell input row on the bottom-left, and as a
 // floating bottom-left compact strip on the full UI. Group slots are decorative
 // blanks; ⌘K remains clickable.
-const hotbarSlotView = (slot: HotbarSlot): Html => {
+const hotbarSlotView = (model: Model, slot: HotbarSlot): Html => {
   if (slot.kind === "palette") {
     const title = `${slot.label} (${slot.chord})`
     return h.button(
@@ -592,20 +593,49 @@ const hotbarSlotView = (slot: HotbarSlot): Html => {
       ],
     )
   }
+  // #5730 The Verse: an active toggle slot. Lit (on) when the runtime toggle is
+  // enabled; clicking (or ⌘⇧V) flips it. The world view itself only renders when
+  // the CHAT_WORLD_SCENE build flag is also on, but the toggle is always shown so
+  // the user-facing control is discoverable.
+  if (slot.kind === "verse") {
+    const on = model.verseEnabled
+    const title = `${slot.label}: ${on ? "on" : "off"} (${slot.chord})`
+    return h.button(
+      [
+        cls(
+          `hotbar-slot hotbar-slot-button hotbar-slot-verse${
+            on ? " hotbar-slot-verse-on" : ""
+          }`,
+        ),
+        h.Type("button"),
+        h.Title(title),
+        h.AriaLabel(title),
+        h.AriaPressed(on ? "true" : "false"),
+        h.OnClick(ToggleVerse()),
+      ],
+      [
+        h.span([cls("hotbar-slot-label")], [slot.label]),
+        h.span([cls("hotbar-slot-tooltip")], [title]),
+      ],
+    )
+  }
   return h.div(
     [cls("hotbar-slot hotbar-slot-empty"), h.AriaHidden(true)],
     [],
   )
 }
 
-const hotbar = (placement: "floating" | "inline" = "floating"): Html =>
+const hotbar = (
+  model: Model,
+  placement: "floating" | "inline" = "floating",
+): Html =>
   h.div(
     [
       cls(`hotbar hotbar-${placement}`),
       h.Role("toolbar"),
       h.AriaLabel("Hotbar"),
     ],
-    HOTBAR_SLOTS.map((slot) => hotbarSlotView(slot)),
+    HOTBAR_SLOTS.map((slot) => hotbarSlotView(model, slot)),
   )
 
 // ── Nodes pane ────────────────────────────────────────────────────────────────
@@ -5878,8 +5908,15 @@ const chatComposer = (model: Model): Html =>
     ],
   )
 
+// #5730 The Verse: the game-world scene renders behind chat when the build flag
+// CHAT_WORLD_SCENE is on (hard kill-switch) AND the runtime toggle
+// `model.verseEnabled` is true (user-facing control, default ON). Toggling the
+// Verse off falls back to the byte-for-byte plain chat pane.
+const verseVisible = (model: Model): boolean =>
+  CHAT_WORLD_SCENE && model.verseEnabled
+
 const chatPane = (model: Model): Html =>
-  CHAT_WORLD_SCENE
+  verseVisible(model)
     ? h.div([cls("chat-pane chat-pane-world")], [
         chatSceneBackground(model),
         h.div([cls("chat-content-overlay")], [
@@ -6142,7 +6179,7 @@ const shellPane = (model: Model): Html =>
         [
           // Bottom-left hotbar; blank cells are inert, and the chat input sits
           // immediately to its right.
-          hotbar("inline"),
+          hotbar(model, "inline"),
           shellTargetTabs(model.shellTarget),
           h.input([
             cls("shell-input"),
@@ -6559,7 +6596,7 @@ const rootView = (model: Model): Html => {
   if (model.pane === "network") {
     return h.div(
       [cls("app-shell app-shell-network"), themeData],
-      [networkPane(model), managedPaneLayer(model), hotbar(), commandPalette(model)],
+      [networkPane(model), managedPaneLayer(model), hotbar(model), commandPalette(model)],
     )
   }
   const fullscreenTraining = model.pane === "training-fullscreen"
@@ -6602,7 +6639,7 @@ const rootView = (model: Model): Html => {
       ),
       // HUD H1 (#5499): the same blank bottom-left command strip across the full
       // UI. Hidden in immersive training fullscreen so it does not occlude the scene.
-      fullscreenTraining ? h.empty : hotbar(),
+      fullscreenTraining ? h.empty : hotbar(model),
       // HUD H7 (#5504): the live status/meters overlay, top-right corner. Hidden
       // in fullscreen training (same anti-occlusion rule as the hotbar).
       fullscreenTraining ? h.empty : statusHudOverlay(model),

--- a/apps/autopilot-desktop/tests/nav-shell.test.ts
+++ b/apps/autopilot-desktop/tests/nav-shell.test.ts
@@ -374,19 +374,38 @@ describe("#5499 HUD H1 hotbar — blank group cells plus ⌘K", () => {
     expect(tree).toContain("hotbar-slot-chord")
     expect(tree).not.toContain("hotbar-slot-icon")
     expect(tree).not.toContain("hotbar-slot-key")
-    expect(tree).not.toContain("hotbar-slot-label")
     expect(tree).toContain("⌘K")
   })
 
-  test("the hotbar face is blank except the command-palette control", () => {
+  // #5730 The Verse: the hotbar now carries one active toggle slot ("Verse")
+  // alongside the ⌘K palette control; the group cells stay blank.
+  test("the hotbar face is blank except the palette and the Verse toggle", () => {
     const tree = serializeView(view(Model.make({ ...initialModel, pane: "composer" })).body)
     expect(tree).toContain("hotbar-slot-empty")
     expect(tree).toContain("hotbar-slot-palette")
     expect(tree).toContain("Command palette (⌘K)")
+    expect(tree).toContain("hotbar-slot-verse")
+    expect(tree).toContain("Verse")
     expect(tree).toContain("hotbar-slot-tooltip")
     expect(tree).not.toContain("viewBox")
     expect(tree).not.toContain("Code — press")
-    expect(tree).not.toContain("hotbar-slot-label")
+  })
+
+  // #5730 The Verse: defaults ON, so the toggle slot renders lit.
+  test("the Verse toggle slot is lit by default (verseEnabled defaults ON)", () => {
+    const tree = serializeView(view(Model.make({ ...initialModel, pane: "composer" })).body)
+    expect(tree).toContain("hotbar-slot-verse-on")
+    expect(tree).toContain("Verse: on (⌘⇧V)")
+  })
+
+  // #5730 The Verse: toggling off drops the lit class but keeps the slot.
+  test("the Verse toggle slot is dim when verseEnabled is off", () => {
+    const tree = serializeView(
+      view(Model.make({ ...initialModel, pane: "composer", verseEnabled: false })).body,
+    )
+    expect(tree).toContain("hotbar-slot-verse")
+    expect(tree).not.toContain("hotbar-slot-verse-on")
+    expect(tree).toContain("Verse: off (⌘⇧V)")
   })
 
   test("the hotbar renders on the full UI as a bottom-left floating strip without active group highlighting", () => {
@@ -403,8 +422,8 @@ describe("#5499 HUD H1 hotbar — blank group cells plus ⌘K", () => {
     expect(tree).not.toContain("hotbar-slot")
   })
 
-  test("the slot count = nav groups + the palette slot (grows automatically with the registry)", () => {
-    expect(HOTBAR_SLOTS.length).toBe(NAV_GROUPS.length + 1)
+  test("the slot count = nav groups + the Verse toggle + the palette slot (#5730)", () => {
+    expect(HOTBAR_SLOTS.length).toBe(NAV_GROUPS.length + 2)
   })
 })
 

--- a/apps/autopilot-desktop/tests/verse-toggle.test.ts
+++ b/apps/autopilot-desktop/tests/verse-toggle.test.ts
@@ -1,0 +1,70 @@
+// #5730 The Verse: the runtime toggle for the game-world view behind chat.
+//
+// Covers, without a live node:
+//   1. the default — verseEnabled is ON so the Verse shows by default now.
+//   2. the ToggleVerse reducer — flips the boolean and is its own inverse.
+//   3. the ⌘⇧V keyboard path through PressedKey resolves to the same toggle.
+//   4. the hotbar carries a labeled "Verse" toggle slot (lit when on).
+
+import { describe, expect, test } from "bun:test"
+
+import { initialModel } from "../src/ui/model"
+import { update } from "../src/ui/update"
+import { interpretKey } from "../src/ui/keyboard"
+import { HOTBAR_SLOTS } from "../src/ui/nav"
+import { PressedKey, ToggleVerse } from "../src/ui/message"
+
+describe("The Verse runtime toggle (#5730)", () => {
+  test("defaults ON so the Verse shows by default", () => {
+    expect(initialModel.verseEnabled).toBe(true)
+  })
+
+  test("ToggleVerse flips the flag and is its own inverse", () => {
+    const [off] = update(initialModel, ToggleVerse())
+    expect(off.verseEnabled).toBe(false)
+    const [backOn] = update(off, ToggleVerse())
+    expect(backOn.verseEnabled).toBe(true)
+  })
+
+  test("⌘⇧V resolves to the toggle-verse intent and flips the flag", () => {
+    const intent = interpretKey(initialModel, {
+      key: "v",
+      meta: true,
+      ctrl: false,
+      shift: true,
+      inEditable: false,
+    })
+    expect(intent.kind).toBe("toggle-verse")
+
+    // Through the reducer's PressedKey path (Ctrl variant, while typing — the
+    // toggle is a deliberate global shortcut).
+    const [next] = update(
+      initialModel,
+      PressedKey({
+        key: "v",
+        meta: false,
+        ctrl: true,
+        shift: true,
+        inEditable: true,
+      }),
+    )
+    expect(next.verseEnabled).toBe(false)
+  })
+
+  test("bare V (no modifier) does not toggle the Verse", () => {
+    const intent = interpretKey(initialModel, {
+      key: "v",
+      meta: false,
+      ctrl: false,
+      shift: false,
+      inEditable: false,
+    })
+    expect(intent.kind).not.toBe("toggle-verse")
+  })
+
+  test("the hotbar carries a labeled Verse toggle slot", () => {
+    const verse = HOTBAR_SLOTS.find((slot) => slot.kind === "verse")
+    expect(verse).toBeDefined()
+    expect(verse?.kind === "verse" ? verse.label : "").toBe("Verse")
+  })
+})


### PR DESCRIPTION
Refs #5730. Names the game world 'The Verse'; adds a hotbar toggle (default ON) that shows/hides the Verse view behind the Autopilot chat at runtime. Bundle builds clean; 5 focused toggle tests pass. (Finished from the build agent's worktree after it hung on the unnecessary full suite.)