### PR TITLE
payments: accepted-outcome settlement subsystems (8-state machine + contributor ledger + gross-margin receipts) [accepted_outcome_economics]

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -2000,6 +2000,19 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     settlement, model promotion, model-service, fine-tuning-service, or
     public-claim authority and flips no promise. Regression coverage:
     `workers/api/src/training-post-training-instruct-sft.test.ts`.
+  - `GET /api/public/accepted-outcome/settlement/{economicsId}` — live at read
+    over one accepted outcome's INERT settlement bundle (promise
+    `payments.accepted_outcome_economics.v1`, planned) — compliant
+    (`generatedAt`, top-level `projection_staleness.v1` `live_at_read` contract
+    re-derived from the source economics row on every read). The surface
+    projects the eight ordered settlement states (with honest evidence labels
+    and `movedMoney` flags), the contributor accrual ledger, and the
+    gross-margin receipt lifecycle, all with internal monetary figures dropped.
+    The bundle is built disarmed (`dispatchArmed=false`): producing a complete
+    bundle MOVES NO MONEY and is NOT a green flip. It grants no dispatch,
+    assignment, spend, settlement, payout, or public-claim authority and flips
+    no promise. Regression coverage:
+    `workers/api/src/public-accepted-outcome-settlement-routes.test.ts`.
   - `GET /api/public/home` — static discovery document, exempt (not a state
     projection).
   - `GET /api/public/product-promises` — live at read over the versioned

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -782,6 +782,11 @@ const publicProjectionSurfaces = [
     route: '/api/public/training/post-training-arc/instruct-sft-lane',
     status: 'staleness_declared',
   },
+  {
+    module: 'workers/api/src/public-accepted-outcome-settlement-routes.ts',
+    route: '/api/public/accepted-outcome/settlement/{economicsId}',
+    status: 'staleness_declared',
+  },
   // Static contract documents, not state projections.
   {
     module: 'workers/api/src/index.ts',

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle-store.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle-store.ts
@@ -1,0 +1,71 @@
+import { Effect, Schema as S } from 'effect'
+
+import {
+  type OmniAcceptedOutcomeEconomicsStorageError,
+  readOmniAcceptedOutcomeEconomicsById,
+} from './omni-accepted-outcome-economics'
+import {
+  buildOmniAcceptedOutcomeSettlementBundle,
+  type OmniAcceptedOutcomeSettlementBundle,
+} from './omni-accepted-outcome-settlement-bundle'
+
+/**
+ * Persisted dereference seam for the accepted-outcome settlement bundle.
+ *
+ * Mirrors omni-contributor-accrual-bundle-store.ts: given a D1 handle and an
+ * accepted-outcome economics id, read the persisted (non-archived) record and
+ * build the INERT settlement bundle (eight-state machine + reconciled accrual
+ * bundle). Read-only: it moves no money and writes nothing. It always builds the
+ * disarmed (intent-only) bundle, so dereferencing an outcome can never imply a
+ * settlement that did not happen.
+ */
+
+/**
+ * Raised when a record EXISTS for the id but cannot be composed into a settlement
+ * bundle -- e.g. it does not yet name its contributor parties, or a
+ * reconciliation invariant rejects it. Distinct from a storage fault and from "no
+ * such outcome" (which yields null).
+ */
+export class OmniAcceptedOutcomeSettlementBundleDereferenceError extends S.TaggedErrorClass<OmniAcceptedOutcomeSettlementBundleDereferenceError>()(
+  'OmniAcceptedOutcomeSettlementBundleDereferenceError',
+  {
+    economicsId: S.String,
+    reason: S.String,
+  },
+) {}
+
+/**
+ * Dereference one accepted outcome's INERT settlement bundle by economics id.
+ *
+ * - Returns the bundle when a non-archived record exists and carries the
+ *   contributor provenance the composition requires.
+ * - Returns null when no such (non-archived) outcome exists.
+ * - Fails with OmniAcceptedOutcomeSettlementBundleDereferenceError when a record
+ *   exists but cannot be composed (the builders throw synchronously; this wraps
+ *   that into the typed error channel).
+ */
+export const dereferenceOmniAcceptedOutcomeSettlementBundle = (
+  db: D1Database,
+  economicsId: string,
+): Effect.Effect<
+  OmniAcceptedOutcomeSettlementBundle | null,
+  | OmniAcceptedOutcomeEconomicsStorageError
+  | OmniAcceptedOutcomeSettlementBundleDereferenceError
+> =>
+  Effect.gen(function* () {
+    const record = yield* readOmniAcceptedOutcomeEconomicsById(db, economicsId)
+
+    if (record === null) {
+      return null
+    }
+
+    return yield* Effect.try({
+      catch: error =>
+        new OmniAcceptedOutcomeSettlementBundleDereferenceError({
+          economicsId,
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      // Always disarmed: a dereference is a read, never an arming/dispatch path.
+      try: () => buildOmniAcceptedOutcomeSettlementBundle(record),
+    })
+  })

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'vitest'
+
+import type { OmniAcceptedOutcomeEconomicsRecord } from './omni-accepted-outcome-economics'
+import {
+  buildOmniAcceptedOutcomeSettlementBundle,
+  OmniAcceptedOutcomeSettlementBundleInvariantError,
+  publicOmniAcceptedOutcomeSettlementBundleProjection,
+} from './omni-accepted-outcome-settlement-bundle'
+
+const baseRecord: OmniAcceptedOutcomeEconomicsRecord = {
+  acceptedOutcomeContractId: 'omni_accepted_outcome_contract_1',
+  acceptedValueCents: 5000,
+  archivedAt: null,
+  artifactCostCents: 100,
+  buyerPriceAsset: 'usd',
+  buyerPriceCents: 5000,
+  createdAt: '2026-06-20T00:00:00.000Z',
+  creditsCharged: 0,
+  fundingMode: 'credit_funded',
+  grossMarginCents: 4400,
+  id: 'omni_outcome_economics_1',
+  idempotencyKey: 'idem-1',
+  internalCaveatRef: null,
+  metadata: {
+    contributors: {
+      platformId: 'platform.openagents',
+      reviewerId: 'reviewer.bob',
+      runnerId: 'runner.alice',
+    },
+  },
+  noSettlementImplication: true,
+  providerCostCents: 300,
+  publicCaveatRef: 'caveat.no_settlement',
+  retryCostCents: 0,
+  reviewCostCents: 100,
+  reviewMinutes: 5,
+  runnerCostCents: 100,
+  satsCharged: 0,
+  totalCostCents: 600,
+  updatedAt: '2026-06-20T00:00:00.000Z',
+  workKind: 'coding',
+  workroomId: 'omni_workroom_coding_1',
+}
+
+describe('buildOmniAcceptedOutcomeSettlementBundle', () => {
+  test('composes a complete eight-state machine + reconciled accrual bundle, INERT', () => {
+    const bundle = buildOmniAcceptedOutcomeSettlementBundle(baseRecord)
+    expect(bundle.bundleKind).toBe('accepted_outcome_settlement_bundle')
+    expect(bundle.economicsId).toBe('omni_outcome_economics_1')
+    expect(bundle.settlementComplete).toBe(true)
+    expect(bundle.settlementMachine.transitions).toHaveLength(8)
+    expect(bundle.settlementMachine.dispatchArmed).toBe(false)
+    // INERT: nothing moved money, all views disclaim settlement.
+    expect(
+      bundle.settlementMachine.transitions.some(t => t.movedMoney),
+    ).toBe(false)
+    expect(bundle.settlementMachine.noSettlementImplication).toBe(true)
+    expect(
+      bundle.contributorAccrualBundle.grossMarginReceipt.noSettlementImplication,
+    ).toBe(true)
+  })
+
+  test('reconciles margin across the machine and the accrual bundle', () => {
+    const bundle = buildOmniAcceptedOutcomeSettlementBundle(baseRecord)
+    const marginTransition = bundle.settlementMachine.transitions.find(
+      t => t.stateId === 'margin',
+    )
+    expect(marginTransition?.amountCents).toBe(4400)
+    expect(bundle.contributorAccrualBundle.reconciledGrossMarginCents).toBe(4400)
+    expect(
+      bundle.contributorAccrualBundle.grossMarginReceipt.grossMarginCents,
+    ).toBe(4400)
+  })
+
+  test('reconciles pending_payout against the ledger distributable pool', () => {
+    const bundle = buildOmniAcceptedOutcomeSettlementBundle(baseRecord)
+    const pendingPayout = bundle.settlementMachine.transitions.find(
+      t => t.stateId === 'pending_payout',
+    )
+    expect(pendingPayout?.amountCents).toBe(
+      bundle.contributorAccrualBundle.contributorAccrualLedger
+        .distributableMarginCents,
+    )
+  })
+
+  test('an armed bundle records money movement and drops the disclaimer', () => {
+    const bundle = buildOmniAcceptedOutcomeSettlementBundle(baseRecord, {
+      dispatchArmed: true,
+    })
+    expect(
+      bundle.settlementMachine.transitions.some(t => t.movedMoney),
+    ).toBe(true)
+    expect(bundle.settlementMachine.noSettlementImplication).toBe(false)
+  })
+
+  test('fails when the record names no contributors (no fabrication)', () => {
+    expect(() =>
+      buildOmniAcceptedOutcomeSettlementBundle({
+        ...baseRecord,
+        metadata: {},
+      }),
+    ).toThrow()
+  })
+
+  test('handles a loss: zero distributable payout, negative margin', () => {
+    const lossRecord: OmniAcceptedOutcomeEconomicsRecord = {
+      ...baseRecord,
+      acceptedValueCents: 100,
+      grossMarginCents: -500,
+      totalCostCents: 600,
+    }
+    const bundle = buildOmniAcceptedOutcomeSettlementBundle(lossRecord)
+    const margin = bundle.settlementMachine.transitions.find(
+      t => t.stateId === 'margin',
+    )
+    const pendingPayout = bundle.settlementMachine.transitions.find(
+      t => t.stateId === 'pending_payout',
+    )
+    expect(margin?.amountCents).toBe(-500)
+    expect(pendingPayout?.amountCents).toBe(0)
+    expect(
+      bundle.contributorAccrualBundle.contributorAccrualLedger.totalAccruedCents,
+    ).toBe(0)
+  })
+})
+
+describe('OmniAcceptedOutcomeSettlementBundleInvariantError', () => {
+  test('is a tagged error', () => {
+    const error = new OmniAcceptedOutcomeSettlementBundleInvariantError({
+      reason: 'x',
+    })
+    expect(error._tag).toBe('OmniAcceptedOutcomeSettlementBundleInvariantError')
+  })
+})
+
+describe('publicOmniAcceptedOutcomeSettlementBundleProjection', () => {
+  test('drops internal figures but keeps lifecycle + evidence labels', () => {
+    const bundle = buildOmniAcceptedOutcomeSettlementBundle(baseRecord)
+    const projection =
+      publicOmniAcceptedOutcomeSettlementBundleProjection(bundle)
+    expect(projection.settlementComplete).toBe(true)
+    expect(projection.settlementMachine.transitions).toHaveLength(8)
+    for (const transition of projection.settlementMachine.transitions) {
+      expect(transition).not.toHaveProperty('amountCents')
+      expect(transition).toHaveProperty('evidenceKind')
+    }
+    // accrual view keeps evidence labels, drops figures
+    for (const entry of projection.contributorAccrualBundle
+      .contributorAccrualLedger.entries) {
+      expect(entry).not.toHaveProperty('accruedMarginCents')
+      expect(entry).toHaveProperty('role')
+    }
+  })
+})

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle.ts
@@ -1,0 +1,195 @@
+import { Schema as S } from 'effect'
+
+import type { OmniAcceptedOutcomeEconomicsRecord } from './omni-accepted-outcome-economics'
+import {
+  advanceOmniAcceptedOutcomeSettlementMachine,
+  createOmniAcceptedOutcomeSettlementMachine,
+  isOmniSettlementMachineComplete,
+  OMNI_SETTLEMENT_STATE_ORDER,
+  OmniAcceptedOutcomeSettlementMachine,
+  publicOmniAcceptedOutcomeSettlementMachineProjection,
+  type OmniSettlementStateId,
+} from './omni-accepted-outcome-settlement-state-machine'
+import {
+  buildOmniContributorAccrualBundle,
+  OmniContributorAccrualBundle,
+  publicOmniContributorAccrualBundleProjection,
+} from './omni-contributor-accrual-bundle'
+import { resolveOmniContributorPartiesFromRecord } from './omni-contributor-party-sourcing'
+
+/**
+ * Settlement bundle for a single accepted outcome.
+ *
+ * The promise payments.accepted_outcome_economics.v1 verification text asks for
+ * "one accepted outcome with separate authorized, paid, accepted, pending payout,
+ * dispatched, confirmed, reconciled, and margin evidence." Those nine words map
+ * onto the three subsystems behind the promise's three RED blockers:
+ *
+ * - the eight ordered settlement states (authorized..margin) come from the
+ *   settlement STATE MACHINE
+ *   (blocker.product_promises.settlement_state_machine_incomplete);
+ * - the per-contributor attribution of the outcome's margin comes from the
+ *   contributor accrual LEDGER, bound to the gross-margin RECEIPT via the
+ *   contributor accrual bundle
+ *   (blocker.product_promises.contributor_ledger_missing); and
+ * - the recorded gross margin (revenue - cost) comes from the gross-margin
+ *   RECEIPT (blocker.product_promises.gross_margin_receipts_missing).
+ *
+ * This module composes all three into ONE dereferenceable view keyed by
+ * accepted-outcome id, and enforces a cross-view reconciliation so the three
+ * cannot disagree about the SAME outcome's margin. It is pure, deterministic, and
+ * INERT: it builds the full eight-state machine in its disarmed (intent-only)
+ * form by default, so producing a "complete" bundle MOVES NO MONEY and is NOT a
+ * green flip. A green flip still requires one real outcome carried through a
+ * money-moving settlement path -- which this bundle, by construction, does not
+ * perform.
+ */
+
+export class OmniAcceptedOutcomeSettlementBundleInvariantError extends S.TaggedErrorClass<OmniAcceptedOutcomeSettlementBundleInvariantError>()(
+  'OmniAcceptedOutcomeSettlementBundleInvariantError',
+  { reason: S.String },
+) {}
+
+export const OmniAcceptedOutcomeSettlementBundle = S.Struct({
+  bundleKind: S.Literal('accepted_outcome_settlement_bundle'),
+  // The contributor accrual bundle (ledger + gross-margin receipt, reconciled).
+  contributorAccrualBundle: OmniContributorAccrualBundle,
+  economicsId: S.String,
+  // True once the machine has recorded all eight states. Completeness alone is
+  // NOT a green flip and NOT proof money moved.
+  settlementComplete: S.Boolean,
+  // The eight-state settlement machine.
+  settlementMachine: OmniAcceptedOutcomeSettlementMachine,
+})
+export type OmniAcceptedOutcomeSettlementBundle =
+  typeof OmniAcceptedOutcomeSettlementBundle.Type
+
+/**
+ * Build a full settlement bundle from one economics record.
+ *
+ * Deterministic and pure. By default the settlement machine is built INERT
+ * (dispatchArmed = false) and advanced through all eight states with intent-only
+ * evidence for the money-movement states, so the resulting bundle records the
+ * complete lifecycle shape without moving money. Pass dispatchArmed only from an
+ * explicitly armed operator path; this subsystem never arms itself.
+ *
+ * Honesty rules enforced by construction (in addition to those each subsystem
+ * already enforces):
+ * - The machine and the contributor accrual bundle must reference the SAME
+ *   accepted-outcome id.
+ * - The machine's `margin` transition figure must equal the receipt's recorded
+ *   gross margin -- the two views cannot carry different margins for one outcome.
+ * - The machine's `pending_payout` figure must equal the ledger's distributable
+ *   margin -- the payout the machine records must be the pool the ledger splits.
+ * - The bundle is INERT unless explicitly armed: when disarmed, no transition
+ *   may have moved money and both views must disclaim settlement implication.
+ */
+export const buildOmniAcceptedOutcomeSettlementBundle = (
+  record: OmniAcceptedOutcomeEconomicsRecord,
+  options: Readonly<{
+    dispatchArmed?: boolean
+    evidenceRefFor?: (stateId: OmniSettlementStateId) => string
+    recordedAtFor?: (stateId: OmniSettlementStateId) => string
+  }> = {},
+): OmniAcceptedOutcomeSettlementBundle => {
+  const evidenceRefFor =
+    options.evidenceRefFor ?? (stateId => `evidence.settlement.${stateId}`)
+  const recordedAtFor =
+    options.recordedAtFor ?? (() => record.updatedAt)
+
+  const settlementMachine = OMNI_SETTLEMENT_STATE_ORDER.reduce(
+    (machine, stateId) =>
+      advanceOmniAcceptedOutcomeSettlementMachine(machine, record, stateId, {
+        evidenceRef: evidenceRefFor(stateId),
+        recordedAt: recordedAtFor(stateId),
+      }),
+    createOmniAcceptedOutcomeSettlementMachine(record, {
+      dispatchArmed: options.dispatchArmed ?? false,
+    }),
+  )
+
+  const contributorAccrualBundle = buildOmniContributorAccrualBundle(
+    record,
+    resolveOmniContributorPartiesFromRecord(record),
+  )
+
+  if (settlementMachine.economicsId !== contributorAccrualBundle.economicsId) {
+    throw new OmniAcceptedOutcomeSettlementBundleInvariantError({
+      reason: `machine economicsId ${settlementMachine.economicsId} must match accrual bundle economicsId ${contributorAccrualBundle.economicsId}.`,
+    })
+  }
+
+  const marginTransition = settlementMachine.transitions.find(
+    transition => transition.stateId === 'margin',
+  )
+  if (
+    marginTransition === undefined ||
+    marginTransition.amountCents !==
+      contributorAccrualBundle.reconciledGrossMarginCents
+  ) {
+    throw new OmniAcceptedOutcomeSettlementBundleInvariantError({
+      reason: `machine margin ${String(marginTransition?.amountCents)} must equal reconciled gross margin ${contributorAccrualBundle.reconciledGrossMarginCents}.`,
+    })
+  }
+
+  const pendingPayoutTransition = settlementMachine.transitions.find(
+    transition => transition.stateId === 'pending_payout',
+  )
+  const distributable = Math.max(
+    0,
+    contributorAccrualBundle.reconciledGrossMarginCents,
+  )
+  if (
+    pendingPayoutTransition === undefined ||
+    pendingPayoutTransition.amountCents !== distributable
+  ) {
+    throw new OmniAcceptedOutcomeSettlementBundleInvariantError({
+      reason: `machine pending_payout ${String(pendingPayoutTransition?.amountCents)} must equal distributable margin ${distributable}.`,
+    })
+  }
+
+  // INERT discipline: when disarmed, nothing may have moved money and both views
+  // must still disclaim settlement implication.
+  if (!settlementMachine.dispatchArmed) {
+    if (settlementMachine.transitions.some(transition => transition.movedMoney)) {
+      throw new OmniAcceptedOutcomeSettlementBundleInvariantError({
+        reason: 'a disarmed settlement bundle cannot contain a money movement.',
+      })
+    }
+    if (
+      !settlementMachine.noSettlementImplication ||
+      !contributorAccrualBundle.grossMarginReceipt.noSettlementImplication ||
+      !contributorAccrualBundle.contributorAccrualLedger.noSettlementImplication
+    ) {
+      throw new OmniAcceptedOutcomeSettlementBundleInvariantError({
+        reason: 'a disarmed settlement bundle must disclaim settlement across all views.',
+      })
+    }
+  }
+
+  return {
+    bundleKind: 'accepted_outcome_settlement_bundle',
+    contributorAccrualBundle,
+    economicsId: settlementMachine.economicsId,
+    settlementComplete: isOmniSettlementMachineComplete(settlementMachine),
+    settlementMachine,
+  }
+}
+
+/**
+ * Public projection: composes the underlying public projections, which keep the
+ * lifecycle and honest evidence labels visible while dropping internal monetary
+ * figures and refs.
+ */
+export const publicOmniAcceptedOutcomeSettlementBundleProjection = (
+  bundle: OmniAcceptedOutcomeSettlementBundle,
+) => ({
+  bundleKind: bundle.bundleKind,
+  contributorAccrualBundle: publicOmniContributorAccrualBundleProjection(
+    bundle.contributorAccrualBundle,
+  ),
+  settlementComplete: bundle.settlementComplete,
+  settlementMachine: publicOmniAcceptedOutcomeSettlementMachineProjection(
+    bundle.settlementMachine,
+  ),
+})

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from 'vitest'
+
+import type { OmniAcceptedOutcomeEconomicsRecord } from './omni-accepted-outcome-economics'
+import {
+  advanceOmniAcceptedOutcomeSettlementMachine,
+  createOmniAcceptedOutcomeSettlementMachine,
+  isOmniSettlementMachineComplete,
+  OMNI_SETTLEMENT_STATE_ORDER,
+  OmniSettlementStateMachineTransitionError,
+  OmniSettlementStateMachineValidationError,
+  publicOmniAcceptedOutcomeSettlementMachineProjection,
+  type OmniAcceptedOutcomeSettlementMachine,
+  type OmniSettlementStateId,
+} from './omni-accepted-outcome-settlement-state-machine'
+
+const baseRecord: OmniAcceptedOutcomeEconomicsRecord = {
+  acceptedOutcomeContractId: 'omni_accepted_outcome_contract_1',
+  acceptedValueCents: 5000,
+  archivedAt: null,
+  artifactCostCents: 100,
+  buyerPriceAsset: 'usd',
+  buyerPriceCents: 5000,
+  createdAt: '2026-06-20T00:00:00.000Z',
+  creditsCharged: 0,
+  fundingMode: 'credit_funded',
+  grossMarginCents: 4400,
+  id: 'omni_outcome_economics_1',
+  idempotencyKey: 'idem-1',
+  internalCaveatRef: null,
+  metadata: {},
+  noSettlementImplication: true,
+  providerCostCents: 300,
+  publicCaveatRef: 'caveat.no_settlement',
+  retryCostCents: 0,
+  reviewCostCents: 100,
+  reviewMinutes: 5,
+  runnerCostCents: 100,
+  satsCharged: 0,
+  totalCostCents: 600,
+  updatedAt: '2026-06-20T00:00:00.000Z',
+  workKind: 'coding',
+  workroomId: 'omni_workroom_coding_1',
+}
+
+const advanceThrough = (
+  record: OmniAcceptedOutcomeEconomicsRecord,
+  states: ReadonlyArray<OmniSettlementStateId>,
+  options: Readonly<{ dispatchArmed?: boolean }> = {},
+): OmniAcceptedOutcomeSettlementMachine =>
+  states.reduce(
+    (machine, stateId, index) =>
+      advanceOmniAcceptedOutcomeSettlementMachine(machine, record, stateId, {
+        evidenceRef: `evidence.${stateId}`,
+        recordedAt: `2026-06-20T00:0${index}:00.000Z`,
+      }),
+    createOmniAcceptedOutcomeSettlementMachine(record, options),
+  )
+
+describe('createOmniAcceptedOutcomeSettlementMachine', () => {
+  test('starts INERT, unstarted, and disclaiming settlement', () => {
+    const machine = createOmniAcceptedOutcomeSettlementMachine(baseRecord)
+    expect(machine.dispatchArmed).toBe(false)
+    expect(machine.state).toBe(null)
+    expect(machine.transitions).toEqual([])
+    expect(machine.noSettlementImplication).toBe(true)
+    expect(machine.economicsId).toBe('omni_outcome_economics_1')
+  })
+
+  test('exposes exactly the eight ordered lifecycle states', () => {
+    expect(OMNI_SETTLEMENT_STATE_ORDER).toEqual([
+      'authorized',
+      'paid',
+      'accepted',
+      'pending_payout',
+      'dispatched',
+      'confirmed',
+      'reconciled',
+      'margin',
+    ])
+  })
+})
+
+describe('advanceOmniAcceptedOutcomeSettlementMachine', () => {
+  test('records all eight distinct evidence states in order', () => {
+    const machine = advanceThrough(baseRecord, OMNI_SETTLEMENT_STATE_ORDER)
+    expect(machine.transitions.map(t => t.stateId)).toEqual([
+      ...OMNI_SETTLEMENT_STATE_ORDER,
+    ])
+    expect(isOmniSettlementMachineComplete(machine)).toBe(true)
+    expect(machine.state).toBe('margin')
+    // Eight DISTINCT states; none collapsed.
+    expect(new Set(machine.transitions.map(t => t.stateId)).size).toBe(8)
+  })
+
+  test('is idempotent: re-recording the current state is a no-op', () => {
+    const machine = advanceThrough(baseRecord, ['authorized'])
+    const again = advanceOmniAcceptedOutcomeSettlementMachine(
+      machine,
+      baseRecord,
+      'authorized',
+      { evidenceRef: 'evidence.retry', recordedAt: '2026-06-20T01:00:00.000Z' },
+    )
+    expect(again).toBe(machine)
+    expect(again.transitions).toHaveLength(1)
+  })
+
+  test('rejects skipping a state (gap-free / monotonic)', () => {
+    expect(() => advanceThrough(baseRecord, ['authorized', 'accepted'])).toThrow(
+      OmniSettlementStateMachineTransitionError,
+    )
+  })
+
+  test('rejects moving backward', () => {
+    const machine = advanceThrough(baseRecord, ['authorized', 'paid'])
+    expect(() =>
+      advanceOmniAcceptedOutcomeSettlementMachine(
+        machine,
+        baseRecord,
+        'authorized',
+        {
+          evidenceRef: 'evidence.back',
+          recordedAt: '2026-06-20T02:00:00.000Z',
+        },
+      ),
+    ).toThrow(OmniSettlementStateMachineTransitionError)
+  })
+
+  test('first transition must be authorized', () => {
+    expect(() => advanceThrough(baseRecord, ['paid'])).toThrow(
+      OmniSettlementStateMachineTransitionError,
+    )
+  })
+
+  test('INERT machine records dispatched/confirmed as intent_only, no money moved', () => {
+    const machine = advanceThrough(baseRecord, OMNI_SETTLEMENT_STATE_ORDER)
+    const dispatched = machine.transitions.find(t => t.stateId === 'dispatched')
+    const confirmed = machine.transitions.find(t => t.stateId === 'confirmed')
+    expect(dispatched?.evidenceKind).toBe('intent_only')
+    expect(dispatched?.movedMoney).toBe(false)
+    expect(confirmed?.evidenceKind).toBe('intent_only')
+    expect(confirmed?.movedMoney).toBe(false)
+    // No money moved -> the machine still disclaims settlement implication.
+    expect(machine.noSettlementImplication).toBe(true)
+  })
+
+  test('armed machine records externally_confirmed money movement and drops the disclaimer', () => {
+    const machine = advanceThrough(baseRecord, OMNI_SETTLEMENT_STATE_ORDER, {
+      dispatchArmed: true,
+    })
+    const dispatched = machine.transitions.find(t => t.stateId === 'dispatched')
+    expect(dispatched?.evidenceKind).toBe('externally_confirmed')
+    expect(dispatched?.movedMoney).toBe(true)
+    expect(machine.noSettlementImplication).toBe(false)
+  })
+
+  test('non-money-movement states carry accounting/derived evidence', () => {
+    const machine = advanceThrough(baseRecord, OMNI_SETTLEMENT_STATE_ORDER)
+    const byState = new Map(machine.transitions.map(t => [t.stateId, t]))
+    expect(byState.get('authorized')?.evidenceKind).toBe('accounting_recorded')
+    expect(byState.get('paid')?.evidenceKind).toBe('accounting_recorded')
+    expect(byState.get('accepted')?.evidenceKind).toBe('accounting_recorded')
+    expect(byState.get('pending_payout')?.evidenceKind).toBe('derived')
+    expect(byState.get('reconciled')?.evidenceKind).toBe('derived')
+    expect(byState.get('margin')?.evidenceKind).toBe('derived')
+  })
+
+  test('records the correct monetary figure per state', () => {
+    const machine = advanceThrough(baseRecord, OMNI_SETTLEMENT_STATE_ORDER)
+    const byState = new Map(machine.transitions.map(t => [t.stateId, t]))
+    expect(byState.get('authorized')?.amountCents).toBe(5000)
+    expect(byState.get('paid')?.amountCents).toBe(5000)
+    expect(byState.get('accepted')?.amountCents).toBe(5000)
+    // distributable margin = max(0, gross) = 4400
+    expect(byState.get('pending_payout')?.amountCents).toBe(4400)
+    expect(byState.get('margin')?.amountCents).toBe(4400)
+  })
+
+  test('margin may be negative on a loss but payout states never are', () => {
+    const lossRecord: OmniAcceptedOutcomeEconomicsRecord = {
+      ...baseRecord,
+      acceptedValueCents: 100,
+      grossMarginCents: -500,
+      totalCostCents: 600,
+    }
+    const machine = advanceThrough(lossRecord, OMNI_SETTLEMENT_STATE_ORDER)
+    const byState = new Map(machine.transitions.map(t => [t.stateId, t]))
+    expect(byState.get('margin')?.amountCents).toBe(-500)
+    // distributable = max(0, -500) = 0; never a negative owed balance.
+    expect(byState.get('pending_payout')?.amountCents).toBe(0)
+    expect(byState.get('dispatched')?.amountCents).toBe(0)
+  })
+
+  test('rejects unsafe evidence refs', () => {
+    const machine = createOmniAcceptedOutcomeSettlementMachine(baseRecord)
+    expect(() =>
+      advanceOmniAcceptedOutcomeSettlementMachine(
+        machine,
+        baseRecord,
+        'authorized',
+        {
+          evidenceRef: 'lnbc1pdeadbeef',
+          recordedAt: '2026-06-20T00:00:00.000Z',
+        },
+      ),
+    ).toThrow(OmniSettlementStateMachineValidationError)
+  })
+
+  test('rejects a record id mismatch', () => {
+    const machine = createOmniAcceptedOutcomeSettlementMachine(baseRecord)
+    expect(() =>
+      advanceOmniAcceptedOutcomeSettlementMachine(
+        machine,
+        { ...baseRecord, id: 'other_outcome' },
+        'authorized',
+        { evidenceRef: 'evidence.x', recordedAt: '2026-06-20T00:00:00.000Z' },
+      ),
+    ).toThrow(OmniSettlementStateMachineValidationError)
+  })
+})
+
+describe('publicOmniAcceptedOutcomeSettlementMachineProjection', () => {
+  test('drops monetary figures and refs but keeps honest evidence labels', () => {
+    const machine = advanceThrough(baseRecord, OMNI_SETTLEMENT_STATE_ORDER)
+    const projection =
+      publicOmniAcceptedOutcomeSettlementMachineProjection(machine)
+    expect(projection.complete).toBe(true)
+    expect(projection.state).toBe('margin')
+    expect(projection.transitions).toHaveLength(8)
+    for (const transition of projection.transitions) {
+      expect(transition).not.toHaveProperty('amountCents')
+      expect(transition).not.toHaveProperty('evidenceRef')
+      expect(transition).toHaveProperty('evidenceKind')
+      expect(transition).toHaveProperty('movedMoney')
+    }
+  })
+
+  test('an incomplete machine projects complete = false', () => {
+    const machine = advanceThrough(baseRecord, ['authorized', 'paid'])
+    const projection =
+      publicOmniAcceptedOutcomeSettlementMachineProjection(machine)
+    expect(projection.complete).toBe(false)
+    expect(projection.state).toBe('paid')
+  })
+})

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.ts
@@ -1,0 +1,408 @@
+import { Schema as S } from 'effect'
+
+import { OmniAcceptedOutcomeWorkKind as OmniAcceptedOutcomeWorkKindSchema } from './omni-accepted-outcome-contracts'
+import {
+  type OmniAcceptedOutcomeEconomicsRecord,
+  OmniAcceptedOutcomeBuyerPriceAsset,
+  OmniAcceptedOutcomeFundingMode,
+} from './omni-accepted-outcome-economics'
+
+/**
+ * Eight-state settlement state machine for a single accepted outcome.
+ *
+ * The promise payments.accepted_outcome_economics.v1 is RED on three blockers.
+ * Its verification text requires that ONE accepted outcome be carried through
+ * eight DISTINCT evidence states, none collapsed into another:
+ *
+ *   authorized -> paid -> accepted -> pending_payout -> dispatched ->
+ *   confirmed -> reconciled -> margin
+ *
+ * The gross-margin receipt (omni-gross-margin-receipt.ts) names the lifecycle of
+ * an accounting-only economics record but, because that substrate disclaims
+ * settlement, it deliberately leaves every settlement-implying state
+ * `not_yet_evidenced`. Nothing in the codebase produced the actual per-state
+ * transitions the verification calls for. That seam is the blocker
+ * blocker.product_promises.settlement_state_machine_incomplete.
+ *
+ * This module is that state machine. It models an accepted outcome's settlement
+ * lifecycle as an ordered chain of eight typed transitions, each carrying its own
+ * receipt-style evidence (a state id, an ISO timestamp, an evidence ref, and the
+ * monetary figure that state asserts). It is:
+ *
+ * - RECEIPT-FIRST: every advance appends an immutable transition entry; the
+ *   machine's state IS the receipt log, not a mutable status column.
+ * - IDEMPOTENT: advancing to a state already recorded is a no-op that returns the
+ *   same machine, so a retried operator step never double-records.
+ * - MONOTONIC and GAP-FREE: a state can only be entered after its predecessor,
+ *   so `confirmed` can never appear before `dispatched`, etc.
+ * - NEVER-NEGATIVE: each asserted figure is a non-negative integer cents value;
+ *   margin is derived (accepted - cost) and may be negative ONLY as a derived
+ *   margin figure, never as an owed/payable balance.
+ * - INERT by default: the machine MOVES NO MONEY. A transition is flag-gated by
+ *   `dispatchArmed`; while disarmed (the default), the `dispatched` transition
+ *   records intent-only evidence and the machine refuses to mark a transition as
+ *   a real money movement. It computes and records evidence; it does not send.
+ *
+ * Reaching `margin` produces a machine with all eight states evidenced -- the
+ * exact shape a real accepted-outcome run must populate before the promise can be
+ * honestly flipped green. Building this subsystem does NOT flip the promise: a
+ * green flip still requires one REAL outcome run through a money-moving path,
+ * which this INERT machine does not perform.
+ */
+
+export const OmniSettlementStateId = S.Literals([
+  // Buyer charge authorized (price captured as an authorization, not yet paid).
+  'authorized',
+  // Buyer payment captured/settled (funds received by the platform).
+  'paid',
+  // Outcome accepted by the buyer/reviewer; accepted value recognized.
+  'accepted',
+  // A payout balance is pending to the contributor(s); not yet dispatched.
+  'pending_payout',
+  // A payout has been dispatched (or, while INERT, intent-only recorded).
+  'dispatched',
+  // The dispatched payout has been confirmed by the payout rail.
+  'confirmed',
+  // Internal ledger reconciled against the confirmed external movement.
+  'reconciled',
+  // Gross margin recognized for the outcome (revenue - cost).
+  'margin',
+])
+export type OmniSettlementStateId = typeof OmniSettlementStateId.Type
+
+// The canonical, ordered lifecycle. The index in this array IS the state's
+// position; a transition to state N is only valid when states 0..N-1 are already
+// recorded. Exported so callers and tests share one source of truth.
+export const OMNI_SETTLEMENT_STATE_ORDER: ReadonlyArray<OmniSettlementStateId> =
+  [
+    'authorized',
+    'paid',
+    'accepted',
+    'pending_payout',
+    'dispatched',
+    'confirmed',
+    'reconciled',
+    'margin',
+  ]
+
+// States whose evidence asserts a real outbound money movement. While the
+// machine is INERT (dispatchArmed = false) these may only be recorded as
+// intent-only, never as a settled external movement.
+const MONEY_MOVEMENT_STATES: ReadonlySet<OmniSettlementStateId> = new Set([
+  'dispatched',
+  'confirmed',
+])
+
+export const OmniSettlementEvidenceKind = S.Literals([
+  // A figure recorded directly from the buyer/accounting side.
+  'accounting_recorded',
+  // A figure mechanically derived from prior recorded figures (e.g. margin).
+  'derived',
+  // Intent-only: recorded while the machine is INERT; asserts NO money moved.
+  'intent_only',
+  // A real external money movement confirmed by a payout/payment rail.
+  'externally_confirmed',
+])
+export type OmniSettlementEvidenceKind = typeof OmniSettlementEvidenceKind.Type
+
+export const OmniSettlementTransition = S.Struct({
+  // Non-negative cents the state asserts, EXCEPT `margin` which may be negative
+  // as a derived figure. Null when the state asserts no monetary figure.
+  amountCents: S.NullOr(S.Number),
+  asset: OmniAcceptedOutcomeBuyerPriceAsset,
+  // A public-safe ref describing the evidence backing this transition. Never a
+  // wallet, invoice, preimage, or raw payment string.
+  evidenceRef: S.String,
+  evidenceKind: OmniSettlementEvidenceKind,
+  // True iff this transition asserts a real outbound money movement. ALWAYS
+  // false while the machine is INERT.
+  movedMoney: S.Boolean,
+  recordedAt: S.String,
+  stateId: OmniSettlementStateId,
+})
+export type OmniSettlementTransition = typeof OmniSettlementTransition.Type
+
+export const OmniAcceptedOutcomeSettlementMachine = S.Struct({
+  // Whether real money movement is armed. INERT (false) by default.
+  dispatchArmed: S.Boolean,
+  economicsId: S.String,
+  fundingMode: OmniAcceptedOutcomeFundingMode,
+  machineKind: S.Literal('accepted_outcome_settlement_state_machine'),
+  // True once all eight states are recorded. Even when complete the machine has
+  // moved no money unless dispatchArmed was true for the money-movement states.
+  noSettlementImplication: S.Boolean,
+  publicCaveatRef: S.String,
+  // The current (latest) recorded state, or null before `authorized`.
+  state: S.NullOr(OmniSettlementStateId),
+  // The immutable, append-only receipt log. This IS the machine's state.
+  transitions: S.Array(OmniSettlementTransition),
+  workKind: OmniAcceptedOutcomeWorkKindSchema,
+  workroomId: S.String,
+})
+export type OmniAcceptedOutcomeSettlementMachine =
+  typeof OmniAcceptedOutcomeSettlementMachine.Type
+
+export class OmniSettlementStateMachineValidationError extends S.TaggedErrorClass<OmniSettlementStateMachineValidationError>()(
+  'OmniSettlementStateMachineValidationError',
+  { reason: S.String },
+) {}
+
+export class OmniSettlementStateMachineTransitionError extends S.TaggedErrorClass<OmniSettlementStateMachineTransitionError>()(
+  'OmniSettlementStateMachineTransitionError',
+  { fromState: S.NullOr(OmniSettlementStateId), reason: S.String, toState: OmniSettlementStateId },
+) {}
+
+const stateIndex = (stateId: OmniSettlementStateId): number =>
+  OMNI_SETTLEMENT_STATE_ORDER.indexOf(stateId)
+
+const SAFE_EVIDENCE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,260}$/
+const PROHIBITED_EVIDENCE_PATTERN =
+  /\b(access_token|refresh_token|private_key|wallet_secret|payment_preimage|payment_secret|webhook_secret|mnemonic|xprv)\b|lnbc[0-9a-z]*|lntb[0-9a-z]*|lnbcrt[0-9a-z]*|lno1[0-9a-z]*|@/i
+
+const assertSafeEvidenceRef = (evidenceRef: string): void => {
+  if (
+    !SAFE_EVIDENCE_REF_PATTERN.test(evidenceRef) ||
+    PROHIBITED_EVIDENCE_PATTERN.test(evidenceRef)
+  ) {
+    throw new OmniSettlementStateMachineValidationError({
+      reason:
+        'evidenceRef must be a public-safe ref without wallet, invoice, preimage, token, or raw payment material.',
+    })
+  }
+}
+
+/**
+ * The figure and evidence shape each lifecycle state asserts, derived from the
+ * economics record. The buyer-side states reflect the recorded buyer charge; the
+ * accepted/cost/margin states reflect the recorded accounting figures; the payout
+ * states reflect the distributable margin (max(0, gross margin)).
+ */
+const buyerAmountCents = (
+  record: OmniAcceptedOutcomeEconomicsRecord,
+): number => {
+  switch (record.buyerPriceAsset) {
+    case 'credits':
+      return record.creditsCharged
+    case 'sats':
+      return record.satsCharged
+    case 'usd':
+      return record.buyerPriceCents
+    case 'none':
+      return 0
+  }
+}
+
+type StateFigure = Readonly<{
+  amountCents: number | null
+  asset: OmniAcceptedOutcomeBuyerPriceAsset
+  derived: boolean
+}>
+
+const figureForState = (
+  record: OmniAcceptedOutcomeEconomicsRecord,
+  stateId: OmniSettlementStateId,
+): StateFigure => {
+  const buyerCents = buyerAmountCents(record)
+  const distributable = Math.max(0, record.grossMarginCents)
+  switch (stateId) {
+    case 'authorized':
+    case 'paid':
+      return {
+        amountCents: buyerCents,
+        asset: record.buyerPriceAsset,
+        derived: false,
+      }
+    case 'accepted':
+      return {
+        amountCents: record.acceptedValueCents,
+        asset: 'usd',
+        derived: false,
+      }
+    case 'pending_payout':
+    case 'dispatched':
+    case 'confirmed':
+    case 'reconciled':
+      return { amountCents: distributable, asset: 'usd', derived: true }
+    case 'margin':
+      // Margin is the ONLY state allowed to be negative: a loss is an honest
+      // derived figure, never an owed balance.
+      return { amountCents: record.grossMarginCents, asset: 'usd', derived: true }
+  }
+}
+
+export type OmniSettlementAdvanceInput = Readonly<{
+  evidenceRef: string
+  recordedAt: string
+}>
+
+/**
+ * Create an empty (un-started) settlement machine for one economics record.
+ *
+ * Pure and deterministic. The machine starts with no transitions and state =
+ * null; the first advance must be to `authorized`. INERT by default
+ * (dispatchArmed = false): until armed, no transition can claim a money
+ * movement. Arming is a separate, explicit operator concern; this subsystem
+ * remains a recorder of evidence regardless.
+ */
+export const createOmniAcceptedOutcomeSettlementMachine = (
+  record: OmniAcceptedOutcomeEconomicsRecord,
+  options: Readonly<{ dispatchArmed?: boolean }> = {},
+): OmniAcceptedOutcomeSettlementMachine => ({
+  dispatchArmed: options.dispatchArmed ?? false,
+  economicsId: record.id,
+  fundingMode: record.fundingMode,
+  machineKind: 'accepted_outcome_settlement_state_machine',
+  noSettlementImplication: true,
+  publicCaveatRef: record.publicCaveatRef,
+  state: null,
+  transitions: [],
+  workKind: record.workKind,
+  workroomId: record.workroomId,
+})
+
+/**
+ * Advance the machine to `toState`, appending a receipt-bearing transition.
+ *
+ * Honesty rules enforced by construction:
+ * - IDEMPOTENT: if `toState` is already the latest recorded state, the same
+ *   machine is returned unchanged (a retried operator step never double-records).
+ * - MONOTONIC/GAP-FREE: `toState` must be exactly the next state after the
+ *   current one; skipping or going backwards fails with a transition error.
+ * - NEVER-NEGATIVE: every non-margin figure is a non-negative integer; only the
+ *   derived `margin` figure may be negative.
+ * - INERT: a money-movement state (dispatched/confirmed) records `intent_only`
+ *   evidence with movedMoney = false while disarmed. movedMoney can only ever be
+ *   true when dispatchArmed is true AND the state is a money-movement state.
+ *
+ * Pure: returns a new machine; never mutates the input.
+ */
+export const advanceOmniAcceptedOutcomeSettlementMachine = (
+  machine: OmniAcceptedOutcomeSettlementMachine,
+  record: OmniAcceptedOutcomeEconomicsRecord,
+  toState: OmniSettlementStateId,
+  input: OmniSettlementAdvanceInput,
+): OmniAcceptedOutcomeSettlementMachine => {
+  if (machine.economicsId !== record.id) {
+    throw new OmniSettlementStateMachineValidationError({
+      reason: `machine economicsId ${machine.economicsId} must match record id ${record.id}.`,
+    })
+  }
+
+  assertSafeEvidenceRef(input.evidenceRef)
+
+  // Idempotent: re-recording the current latest state is a no-op.
+  if (machine.state === toState) {
+    return machine
+  }
+
+  const currentIndex = machine.state === null ? -1 : stateIndex(machine.state)
+  const nextIndex = stateIndex(toState)
+
+  if (nextIndex !== currentIndex + 1) {
+    throw new OmniSettlementStateMachineTransitionError({
+      fromState: machine.state,
+      reason:
+        nextIndex <= currentIndex
+          ? `cannot move backward or re-enter: ${String(machine.state)} -> ${toState}.`
+          : `cannot skip states: expected ${OMNI_SETTLEMENT_STATE_ORDER[currentIndex + 1]}, got ${toState}.`,
+      toState,
+    })
+  }
+
+  const figure = figureForState(record, toState)
+
+  if (
+    figure.amountCents !== null &&
+    toState !== 'margin' &&
+    (!Number.isInteger(figure.amountCents) || figure.amountCents < 0)
+  ) {
+    throw new OmniSettlementStateMachineValidationError({
+      reason: `state ${toState} figure must be a non-negative integer; got ${figure.amountCents}.`,
+    })
+  }
+
+  if (
+    toState === 'margin' &&
+    figure.amountCents !== null &&
+    !Number.isInteger(figure.amountCents)
+  ) {
+    throw new OmniSettlementStateMachineValidationError({
+      reason: `margin figure must be an integer; got ${figure.amountCents}.`,
+    })
+  }
+
+  const isMoneyMovementState = MONEY_MOVEMENT_STATES.has(toState)
+  const movedMoney = isMoneyMovementState && machine.dispatchArmed
+
+  let evidenceKind: OmniSettlementEvidenceKind
+  if (isMoneyMovementState) {
+    evidenceKind = movedMoney ? 'externally_confirmed' : 'intent_only'
+  } else if (figure.derived) {
+    evidenceKind = 'derived'
+  } else {
+    evidenceKind = 'accounting_recorded'
+  }
+
+  // Defensive INERT invariant: while the machine is disarmed, no transition may
+  // claim a real money movement, and the noSettlementImplication flag must hold.
+  if (!machine.dispatchArmed && movedMoney) {
+    throw new OmniSettlementStateMachineValidationError({
+      reason: 'an INERT settlement machine cannot record a money movement.',
+    })
+  }
+
+  const transition: OmniSettlementTransition = {
+    amountCents: figure.amountCents,
+    asset: figure.asset,
+    evidenceKind,
+    evidenceRef: input.evidenceRef,
+    movedMoney,
+    recordedAt: input.recordedAt,
+    stateId: toState,
+  }
+
+  return {
+    ...machine,
+    // The machine still implies no settlement unless it has actually moved money.
+    noSettlementImplication:
+      machine.noSettlementImplication && !movedMoney,
+    state: toState,
+    transitions: [...machine.transitions, transition],
+  }
+}
+
+/**
+ * Whether the machine has recorded all eight lifecycle states. A complete
+ * machine is the shape a real accepted-outcome run must produce for the promise
+ * to be honestly evaluated -- but completeness alone is NOT a green flip and is
+ * NOT proof money moved (see movedMoney on the dispatched/confirmed transitions).
+ */
+export const isOmniSettlementMachineComplete = (
+  machine: OmniAcceptedOutcomeSettlementMachine,
+): boolean =>
+  machine.transitions.length === OMNI_SETTLEMENT_STATE_ORDER.length &&
+  machine.state === 'margin'
+
+/**
+ * Public projection: keeps the full ordered lifecycle and honest evidence labels
+ * visible (so a reader can see exactly which states were money-moving vs
+ * intent-only) while dropping internal monetary figures and refs.
+ */
+export const publicOmniAcceptedOutcomeSettlementMachineProjection = (
+  machine: OmniAcceptedOutcomeSettlementMachine,
+) => ({
+  complete: isOmniSettlementMachineComplete(machine),
+  dispatchArmed: machine.dispatchArmed,
+  fundingMode: machine.fundingMode,
+  machineKind: machine.machineKind,
+  noSettlementImplication: machine.noSettlementImplication,
+  publicCaveatRef: machine.publicCaveatRef,
+  state: machine.state,
+  transitions: machine.transitions.map(transition => ({
+    evidenceKind: transition.evidenceKind,
+    movedMoney: transition.movedMoney,
+    stateId: transition.stateId,
+  })),
+  workKind: machine.workKind,
+  workroomId: machine.workroomId,
+})

--- a/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.test.ts
@@ -55,6 +55,7 @@ const fakeDb = (knownId: string | null): D1Database => {
 const route = async (db: D1Database, economicsId: string, init?: RequestInit) => {
   const routes = makePublicAcceptedOutcomeSettlementRoutes<{ db: D1Database }>({
     db: env => env.db,
+    nowIso: () => '2026-06-20T12:00:00.000Z',
   })
   const response = routes.routePublicAcceptedOutcomeSettlementRequest(
     new Request(
@@ -78,6 +79,12 @@ describe('public accepted-outcome settlement routes', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('cache-control')).toBe('no-store')
+    // Public-projection staleness declaration (epic #4751): generatedAt plus a
+    // live-at-read contract that is never older than the request.
+    expect(body.generatedAt).toBe('2026-06-20T12:00:00.000Z')
+    expect(body.staleness.composition).toBe('live_at_read')
+    expect(body.staleness.contractVersion).toBe('projection_staleness.v1')
+    expect(body.staleness.maxStalenessSeconds).toBe(0)
     expect(body.settlement.settlementComplete).toBe(true)
     expect(body.settlement.settlementMachine.transitions).toHaveLength(8)
     expect(

--- a/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.test.ts
@@ -1,0 +1,118 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { makePublicAcceptedOutcomeSettlementRoutes } from './public-accepted-outcome-settlement-routes'
+
+/**
+ * Minimal fake D1 that answers the single `SELECT * FROM
+ * omni_accepted_outcome_economics WHERE id = ?` read used by
+ * readOmniAcceptedOutcomeEconomicsById. It returns a row for the configured id
+ * and null otherwise.
+ */
+const economicsRow = (id: string) => ({
+  accepted_outcome_contract_id: 'omni_accepted_outcome_contract_1',
+  accepted_value_cents: 5000,
+  archived_at: null,
+  artifact_cost_cents: 100,
+  buyer_price_asset: 'usd',
+  buyer_price_cents: 5000,
+  created_at: '2026-06-20T00:00:00.000Z',
+  credits_charged: 0,
+  funding_mode: 'credit_funded',
+  gross_margin_cents: 4400,
+  id,
+  idempotency_key: `idem-${id}`,
+  internal_caveat_ref: null,
+  metadata_json: JSON.stringify({
+    contributors: { platformId: 'platform.oa', runnerId: 'runner.alice' },
+  }),
+  no_settlement_implication: 1,
+  provider_cost_cents: 300,
+  public_caveat_ref: 'caveat.no_settlement',
+  retry_cost_cents: 0,
+  review_cost_cents: 100,
+  review_minutes: 5,
+  runner_cost_cents: 100,
+  sats_charged: 0,
+  total_cost_cents: 600,
+  updated_at: '2026-06-20T00:00:00.000Z',
+  work_kind: 'coding',
+  workroom_id: 'omni_workroom_coding_1',
+})
+
+const fakeDb = (knownId: string | null): D1Database => {
+  const prepared = {
+    bind: (boundId: string) => ({
+      first: async () =>
+        knownId !== null && boundId === knownId ? economicsRow(boundId) : null,
+    }),
+  }
+  return {
+    prepare: () => prepared,
+  } as unknown as D1Database
+}
+
+const route = async (db: D1Database, economicsId: string, init?: RequestInit) => {
+  const routes = makePublicAcceptedOutcomeSettlementRoutes<{ db: D1Database }>({
+    db: env => env.db,
+  })
+  const response = routes.routePublicAcceptedOutcomeSettlementRequest(
+    new Request(
+      `https://openagents.com/api/public/accepted-outcome/settlement/${encodeURIComponent(
+        economicsId,
+      )}`,
+      init,
+    ),
+    { db },
+  )
+  if (response === undefined) {
+    throw new Error('settlement route did not match')
+  }
+  return Effect.runPromise(response)
+}
+
+describe('public accepted-outcome settlement routes', () => {
+  test('serves the eight-state settlement projection with no private figures', async () => {
+    const response = await route(fakeDb('omni_outcome_1'), 'omni_outcome_1')
+    const body = (await response.json()) as Record<string, any>
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body.settlement.settlementComplete).toBe(true)
+    expect(body.settlement.settlementMachine.transitions).toHaveLength(8)
+    expect(
+      body.settlement.settlementMachine.transitions.map((t: any) => t.stateId),
+    ).toEqual([
+      'authorized',
+      'paid',
+      'accepted',
+      'pending_payout',
+      'dispatched',
+      'confirmed',
+      'reconciled',
+      'margin',
+    ])
+    // No internal monetary figures leak.
+    expect(JSON.stringify(body)).not.toMatch(
+      /amountCents|accruedMarginCents|grossMarginCents|4400|5000/,
+    )
+    // INERT: no money moved.
+    expect(
+      body.settlement.settlementMachine.transitions.every(
+        (t: any) => t.movedMoney === false,
+      ),
+    ).toBe(true)
+  })
+
+  test('returns 404 for an unknown outcome', async () => {
+    const response = await route(fakeDb(null), 'missing_outcome')
+    expect(response.status).toBe(404)
+  })
+
+  test('rejects mutations', async () => {
+    const response = await route(fakeDb('omni_outcome_1'), 'omni_outcome_1', {
+      method: 'POST',
+    })
+    expect(response.status).toBe(405)
+  })
+})

--- a/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.ts
+++ b/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.ts
@@ -5,7 +5,10 @@
 //   import { makePublicAcceptedOutcomeSettlementRoutes } from '../public-accepted-outcome-settlement-routes'
 //
 //   const publicAcceptedOutcomeSettlementRoutes =
-//     makePublicAcceptedOutcomeSettlementRoutes<Env>({ db: env => env.DB })
+//     makePublicAcceptedOutcomeSettlementRoutes<Env>({
+//       db: env => env.DB,
+//       nowIso: currentIsoTimestamp,
+//     })
 //
 //   const settlementResponse =
 //     publicAcceptedOutcomeSettlementRoutes.routePublicAcceptedOutcomeSettlementRequest(
@@ -26,13 +29,27 @@ import {
   noStoreJsonResponse,
   serverError,
 } from './http/responses'
+import { liveAtReadStaleness } from './public-projection-staleness'
 
 type HttpResponse = globalThis.Response
 
 export type PublicAcceptedOutcomeSettlementRouteDependencies<Bindings> =
   Readonly<{
     db: (env: Bindings) => D1Database
+    // Public-projection staleness contract (epic #4751): this surface is
+    // composed live from the source economics row at request time, so every
+    // payload carries `generatedAt` plus the `live_at_read` contract. The clock
+    // is injected (the coordinator supplies the Worker's `currentIsoTimestamp`)
+    // so this route module owns no raw `new Date` / id / random primitive.
+    nowIso: () => string
   }>
+
+// The write-site transitions this live-at-read projection reflects: the bundle
+// is re-derived from the source economics row on every read, so it is never
+// older than the request.
+const SETTLEMENT_PROJECTION_REBUILDS_ON = [
+  'omni_accepted_outcome_economics_write',
+]
 
 const PREFIX = '/api/public/accepted-outcome/settlement/'
 
@@ -64,8 +81,15 @@ const readSettlementBundleResponse = <Bindings>(
           bundle === null
             ? notFound()
             : noStoreJsonResponse({
+                // Public-projection staleness declaration (epic #4751): this
+                // bundle is composed live from the source economics row on
+                // every read, so it is never older than the request.
+                generatedAt: dependencies.nowIso(),
                 settlement:
                   publicOmniAcceptedOutcomeSettlementBundleProjection(bundle),
+                staleness: liveAtReadStaleness(
+                  SETTLEMENT_PROJECTION_REBUILDS_ON,
+                ),
               }),
         ),
         // Both an unattributable record and a storage fault collapse to a 500

--- a/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.ts
+++ b/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.ts
@@ -1,0 +1,91 @@
+// COORDINATOR WIRING:
+// Add to workers/api/src/http/router.ts (mirroring the other public route
+// wiring). This lane does NOT edit router.ts or index.ts.
+//
+//   import { makePublicAcceptedOutcomeSettlementRoutes } from '../public-accepted-outcome-settlement-routes'
+//
+//   const publicAcceptedOutcomeSettlementRoutes =
+//     makePublicAcceptedOutcomeSettlementRoutes<Env>({ db: env => env.DB })
+//
+//   const settlementResponse =
+//     publicAcceptedOutcomeSettlementRoutes.routePublicAcceptedOutcomeSettlementRequest(
+//       request,
+//       env,
+//     )
+//   if (settlementResponse !== undefined) {
+//     return await runEffectProgram(settlementResponse)
+//   }
+
+import { notFound } from '@openagentsinc/sync-worker'
+import { Effect } from 'effect'
+
+import { publicOmniAcceptedOutcomeSettlementBundleProjection } from './omni-accepted-outcome-settlement-bundle'
+import { dereferenceOmniAcceptedOutcomeSettlementBundle } from './omni-accepted-outcome-settlement-bundle-store'
+import {
+  methodNotAllowed,
+  noStoreJsonResponse,
+  serverError,
+} from './http/responses'
+
+type HttpResponse = globalThis.Response
+
+export type PublicAcceptedOutcomeSettlementRouteDependencies<Bindings> =
+  Readonly<{
+    db: (env: Bindings) => D1Database
+  }>
+
+const PREFIX = '/api/public/accepted-outcome/settlement/'
+
+const economicsIdFromPath = (pathname: string): string | null =>
+  pathname.startsWith(PREFIX) && pathname.length > PREFIX.length
+    ? decodeURIComponent(pathname.slice(PREFIX.length))
+    : null
+
+/**
+ * Public, read-only projection of one accepted outcome's INERT settlement
+ * bundle: the eight ordered settlement states (with honest evidence labels and
+ * movedMoney flags), plus the contributor accrual ledger and gross-margin receipt
+ * lifecycle -- all with internal monetary figures dropped. No private data, no
+ * money movement, GET only.
+ */
+const readSettlementBundleResponse = <Bindings>(
+  dependencies: PublicAcceptedOutcomeSettlementRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  economicsId: string,
+): Effect.Effect<HttpResponse> =>
+  request.method !== 'GET'
+    ? Effect.succeed(methodNotAllowed(['GET']))
+    : dereferenceOmniAcceptedOutcomeSettlementBundle(
+        dependencies.db(env),
+        economicsId,
+      ).pipe(
+        Effect.map(bundle =>
+          bundle === null
+            ? notFound()
+            : noStoreJsonResponse({
+                settlement:
+                  publicOmniAcceptedOutcomeSettlementBundleProjection(bundle),
+              }),
+        ),
+        // Both an unattributable record and a storage fault collapse to a 500
+        // here rather than leaking internal reasons publicly.
+        Effect.catch(() => Effect.succeed(serverError())),
+      )
+
+export const makePublicAcceptedOutcomeSettlementRoutes = <Bindings>(
+  dependencies: PublicAcceptedOutcomeSettlementRouteDependencies<Bindings>,
+) => {
+  const routePublicAcceptedOutcomeSettlementRequest = (
+    request: Request,
+    env: Bindings,
+  ): Effect.Effect<HttpResponse> | undefined => {
+    const economicsId = economicsIdFromPath(new URL(request.url).pathname)
+
+    return economicsId === null
+      ? undefined
+      : readSettlementBundleResponse(dependencies, request, env, economicsId)
+  }
+
+  return { routePublicAcceptedOutcomeSettlementRequest }
+}


### PR DESCRIPTION
Builds the 3 subsystems behind `payments.accepted_outcome_economics.v1`'s red blockers. INERT/flag-gated, receipt-first, tested. Does NOT flip the promise green — that needs one real accepted-outcome run through these (operator step).

## What this builds

The promise's verification asks for one accepted outcome with separate `authorized, paid, accepted, pending payout, dispatched, confirmed, reconciled, and margin` evidence. Its three RED blockers:

### 1. `blocker.product_promises.settlement_state_machine_incomplete` — NEW core subsystem
`omni-accepted-outcome-settlement-state-machine.ts`: an **8-state** settlement state machine modeling `authorized → paid → accepted → pending_payout → dispatched → confirmed → reconciled → margin`. Each advance appends an **immutable, receipt-bearing transition** (state id, ISO timestamp, public-safe evidence ref, asserted figure, evidence kind). Properties enforced by construction:
- **idempotent** — re-recording the current state is a no-op
- **monotonic / gap-free** — can't skip or go backward
- **never-negative** — only the derived `margin` figure may be negative; payout pools are `max(0, margin)`
- **INERT by default** — `dispatchArmed = false`; money-movement states record `intent_only` (movedMoney=false). A disarmed machine **cannot** record a money movement. It computes/records evidence; it does not send.

### 2 & 3. `contributor_ledger_missing` + `gross_margin_receipts_missing` — composed + reconciled
These two already had strong seeds (`omni-contributor-accrual-bundle` / `omni-gross-margin-receipt`). `omni-accepted-outcome-settlement-bundle.ts` composes the state machine **with** the existing contributor accrual bundle (ledger + gross-margin receipt) into one dereferenceable view keyed by accepted-outcome id, and enforces **cross-view reconciliation**: the machine's `margin` transition must equal the receipt's recorded gross margin, and the machine's `pending_payout` must equal the ledger's distributable pool — the three views can't disagree about one outcome's margin.

### Public surface
- `omni-accepted-outcome-settlement-bundle-store.ts` — read-only dereference by economics id (always builds the disarmed bundle)
- `GET /api/public/accepted-outcome/settlement/:id` (`public-accepted-outcome-settlement-routes.ts`) — read-only projection; internal monetary figures dropped, honest evidence labels + movedMoney flags kept. Route is provided with coordinator-wiring comments; this lane does not edit router.ts.

## Tests
27 new unit tests across the 8-state transitions, bundle reconciliation/loss handling, INERT vs armed behavior, and the public route (200/404/405 + no-figure-leak assertion). `bun run typecheck:api` passes; adjacent existing tests (product-promises, omni accrual bundle, gross-margin receipt, omni-bundle-routes) still pass.

## Honesty
- `product-promises.ts` is **untouched** — no version/count change, promise stays RED.
- Subsystems are **INERT** and move no money.
- Green still requires ONE real accepted-outcome run carried through a money-moving (armed) path producing all 8 live evidence rows — a separate operator step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)