### PR TITLE
fleet: Gemini-on-GCP runner via opencode (credit-covered, first-party SKU)

### DIFF
--- a/scripts/gemini-fleet/README.md
+++ b/scripts/gemini-fleet/README.md
@@ -1,0 +1,145 @@
+# gemini-fleet — "Gemini-on-GCP via opencode, PR-per-agent" fleet runner
+
+A small, dependency-light runner that turns **one non-green product promise** into
+**one [opencode](https://opencode.ai) coding agent driven by a first-party Google
+Gemini model on Vertex AI**, working in **one isolated git worktree**, on **one
+branch**, that opens **one PR** for human review.
+
+It is the Gemini twin of `scripts/vertex-fleet/`. The engine is different
+(opencode + Gemini instead of Claude Code + Claude-on-Vertex) but the **PR shape
+is identical** — branch prefix `gemini-fleet/<promise>` — so the merge gate
+`/tmp/fleet-merge.sh` treats these PRs the same way.
+
+## Why Gemini-on-Vertex (cost)
+
+Gemini is a **first-party Google model**. Run through **Vertex AI**, its usage
+bills as a **Google Cloud SKU on project `openagentsgemini`**, which is covered by
+the **GFS cloud credit ($85k)** — *not* charged to a card. That is the whole
+point of this variant: keep the fleet running on credit-covered Google compute.
+
+(Contrast: third-party/partner models on Vertex, and pay-per-token subscription
+seats, still cost real money. Gemini-on-Vertex does not, while the credit lasts.)
+
+## Engine: opencode, headless
+
+opencode (`/Users/christopherdavid/.opencode/bin/opencode`, v1.17.8) is a
+provider-agnostic Bun-based coding agent. It runs **non-interactively** via:
+
+```bash
+opencode run --model google-vertex/gemini-2.5-pro \
+  --format json \
+  --dangerously-skip-permissions \
+  "<the task brief>"
+```
+
+- `opencode run [message..]` is the headless one-shot path (no TUI).
+- `--model google-vertex/<gemini>` selects the Gemini model on the built-in
+  `google-vertex` provider.
+- `--format json` emits the raw JSON event stream (one event per line) → we save
+  it as the run trace and parse `properties.info.cost` for cost.
+- `--dangerously-skip-permissions` auto-approves edit/bash so the agent can do
+  real work unattended. (opencode defaults to *allow* anyway; this is explicit
+  and survives any restrictive global `opencode.json`.)
+- opencode operates in its **current working directory**, so `worker.sh` `cd`s
+  into the per-promise worktree before invoking it.
+
+## The Gemini model
+
+Default: **`gemini-2.5-pro`** (GA, strong coding model). opencode also lists
+`gemini-2.5-flash` (cheaper/faster), and preview `gemini-3.x` ids. Override with
+`--model`, e.g. `--model gemini-2.5-flash` or a fully-qualified
+`--model google-vertex/gemini-3.1-pro-preview`. A bare id (`gemini-2.5-pro`) is
+auto-prefixed to `google-vertex/gemini-2.5-pro` by `worker.sh`.
+
+Proven live: `opencode run -m google-vertex/gemini-2.5-pro "...PONG..."` returned
+`PONG` (exit 0) against project `openagentsgemini` / `us-central1`.
+
+## Auth: ADC (credit-covered), local vs unattended GCE
+
+opencode's `google-vertex` provider **auto-loads** when a project env var is set
+and signs every request via `google-auth-library` with the `cloud-platform`
+scope — i.e. **Application Default Credentials (ADC)**. No API key is read or
+printed by these scripts.
+
+Env (names only — no secret values; `worker.sh` exports these, overridable):
+
+```
+GOOGLE_VERTEX_PROJECT=openagentsgemini     # (or GOOGLE_CLOUD_PROJECT)
+GOOGLE_CLOUD_PROJECT=openagentsgemini
+GOOGLE_VERTEX_LOCATION=us-central1         # (or VERTEX_LOCATION; "global" also valid)
+VERTEX_LOCATION=us-central1
+```
+
+- **Local (this Mac):** uses the owner's `gcloud auth application-default`
+  credentials (already authed for `openagentsgemini`). RAPT can expire and need
+  an interactive `gcloud auth application-default login` — the only "needs-owner"
+  step locally.
+- **Unattended GCE fleet:** the same code path uses the **service-account
+  metadata-server ADC** (no key files, no reauth) — identical to how
+  `oa-codex-control` authenticates. Grant the runner SA `roles/aiplatform.user`
+  (+ `roles/serviceusage.serviceUsageConsumer`) on `openagentsgemini`; the env
+  block above works unchanged.
+
+> Fallback (documented, not used here): Google **AI Studio** API key
+> (`GEMINI_API_KEY` on opencode's `google` provider, `google/gemini-2.5-pro`) has
+> a free tier. The Vertex/ADC path is preferred because it bills the GFS credit
+> and matches our existing GCP auth — so this runner ships on Vertex.
+
+## Guardrails (enforced by the scripts)
+
+- **PR-per-agent only.** Workers push `gemini-fleet/<promise>` branches and open
+  PRs via `gh`. They **never** push to `main`.
+- **No green flips.** The task brief forbids editing the product-promise registry
+  or changing any promise state. Agents build the missing *piece*.
+- **check:deploy is the merge gate.** Each worker runs `bun run check:deploy` and
+  records pass/fail on the PR.
+- **Open-PR dedup.** `assign.mjs` skips promises that already have an open
+  `gemini-fleet/*` PR (so `git worktree add -b` can't collide).
+- **No secrets printed or committed.** Only env-var *names* and public endpoints
+  appear anywhere.
+
+## Components
+
+| File | What it does |
+|------|--------------|
+| `assign.mjs` | Fetches the public product-promise registry (`https://openagents.com/api/public/product-promises`, browser UA), selects N non-green promises with **buildable, non-owner-gated** blockers, emits one task brief each, and dedups against open `gemini-fleet/*` PRs. Same selector as vertex-fleet. |
+| `worker.sh` | Given one assignment: `git worktree add` from `origin/main`, `bun install`, run `opencode run --model google-vertex/<gemini> --format json --dangerously-skip-permissions "<brief>"` with the Vertex ADC env, run `check:deploy`, commit to branch `gemini-fleet/<promise>`, push, open a PR with `gh pr create`. Emits a one-line JSON result; writes a full JSON-event trace. |
+| `run.sh` | Orchestrator. Runs a few workers (sequential by default; `--parallel` opt-in), then prints PR URLs + per-worker `check:deploy` status + total cost. |
+
+## Usage
+
+```bash
+# from the repo root of an openagents checkout
+bash scripts/gemini-fleet/run.sh --count 3 --model gemini-2.5-pro
+
+# pick specific promises
+bash scripts/gemini-fleet/run.sh --ids energy.flexible_load_proof.v1,autopilot.decision_queue.v1
+
+# preview selection + briefs without spending tokens
+bash scripts/gemini-fleet/run.sh --count 3 --dry-run
+
+# build + check:deploy but don't open PRs
+bash scripts/gemini-fleet/run.sh --count 2 --no-pr
+```
+
+Flags: `--count N`, `--state red|yellow|planned|any`, `--model <gemini model>`,
+`--ids a,b,c`, `--parallel`, `--dry-run`, `--no-pr`.
+
+Results are written to `/tmp/gf-results.jsonl`; per-worker logs to
+`/tmp/gf-logs/<promise>.agent.log`; assignments + briefs to `/tmp/gf-assignments/`;
+full JSON-event traces to `~/work/gemini-fleet-traces/<date>/` (indexed in
+`~/work/gemini-fleet-traces/index.jsonl`).
+
+## Concurrency reality
+
+All instances authenticate as project `openagentsgemini` and **share that
+project's per-model Vertex quota** (RPM/TPM). Keep waves small and raise Gemini
+quota deliberately via Cloud Quotas before going wide. See
+`docs/2026-06-13-vertex-ai-anthropic-claude-runbook.md` and
+`docs/launch/2026-06-20-cloud-agent-fleet-audit.md`.
+
+## How this maps to the bigger fleet
+
+This is the Gemini-on-credit twin of the PR-per-agent automation. To take it to
+unattended GCE scale: run `run.sh` from a GCE instance (or have
+`oa-codex-control` launch `worker.sh`) using the SA metadata ADC.

--- a/scripts/gemini-fleet/assign.mjs
+++ b/scripts/gemini-fleet/assign.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+// assign.mjs — promise -> assignment selector for the GEMINI fleet runner.
+//
+// Mirrors scripts/vertex-fleet/assign.mjs. Fetches the live public
+// product-promise registry, selects N non-green promises that still have
+// *buildable* (non-owner-gated) blockers, and emits one task brief per promise.
+//
+// The ONLY differences from the Vertex selector are cosmetic: the brief says the
+// worker is powered by a Gemini model on Google Vertex AI, and the open-PR dedup
+// matches the `gemini-fleet/<promise>` branch prefix instead of `vertex-fleet/`.
+// Same PR-per-promise shape, so /tmp/fleet-merge.sh gates these PRs identically.
+//
+// Output: JSON array of { promiseId, state, model, blockers, brief } to stdout
+// (and, with --out <dir>, one <promiseId>.brief.txt + assignments.json on disk).
+//
+// NO secrets are read or printed. The registry endpoint is public.
+//
+// Usage:
+//   node assign.mjs [--count N] [--state red|yellow|planned|any]
+//                   [--model gemini-2.5-pro] [--out DIR] [--ids a,b,c]
+//
+// Selection is keyword-classified, NOT semantic — acceptable here because the
+// universe is the bounded, enum-typed blocker-id list from our own registry,
+// and the agent itself decides per the brief which blockers it genuinely cleared.
+
+const PROMISES_URL = "https://openagents.com/api/public/product-promises";
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+// Default Gemini model. First-party Google SKU on Vertex AI => billed to the
+// GFS cloud credit, not cards. Override with --model.
+const DEFAULT_MODEL = "gemini-2.5-pro";
+
+// Owner-gated / non-buildable signals: anything needing a human decision,
+// secret, payment rail, legal/policy sign-off, custody, or quota grant.
+const GATED = [
+  "privacy_review", "copy_review", "copy_gate", "product_copy", "pricing",
+  "package_policy", "payout", "settlement", "stripe", "secret", "token",
+  "sign_off", "signoff", "manual", "reauth", "owner", "prod_key",
+  "production_key", "legal", "policy_review", "marketplace_metering",
+  "eligibility", "custody", "wallet_fund", "quota", "interactive", "approval",
+  "testflight", "app_store", "distribution_not_live", "enablement",
+];
+
+// Buildable signals: missing code / docs / tests / scripts / specs / endpoints.
+const BUILD = [
+  "missing", "endpoint", "script", "runbook", "doc", "test", "harness",
+  "runner", "fixture", "guide", "helper", "spec", "schema", "plan", "audit",
+  "wiring", "adapter", "projection", "capture", "manifest", "telemetry",
+  "report", "example", "methodology", "definition", "architecture", "receipts",
+];
+
+function isGated(blockerId) {
+  const s = String(blockerId).toLowerCase();
+  return GATED.some((w) => s.includes(w));
+}
+function isBuildable(blockerId) {
+  const s = String(blockerId).toLowerCase();
+  return !isGated(blockerId) && BUILD.some((w) => s.includes(w));
+}
+
+function parseArgs(argv) {
+  const a = { count: 3, state: "any", model: DEFAULT_MODEL, out: null, ids: null };
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--count") a.count = parseInt(argv[++i], 10);
+    else if (k === "--state") a.state = argv[++i];
+    else if (k === "--model") a.model = argv[++i];
+    else if (k === "--out") a.out = argv[++i];
+    else if (k === "--ids") a.ids = argv[++i].split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  return a;
+}
+
+function briefFor(promise, buildableBlockers, model) {
+  const id = promise.promiseId;
+  const claim = promise.safeCopy || promise.claim || "(no claim text)";
+  const blockerList = buildableBlockers.map((b) => `  - ${b}`).join("\n");
+  // The weekend-assault template, scoped to ONE promise and PR-per-agent.
+  return `You are one worker in the OpenAgents Gemini fleet. You are powered by ${model} on Google Vertex AI (a first-party Google model). You are working in an ISOLATED git worktree on a branch. Do real, mergeable work — no theater.
+
+PROMISE: ${id}
+STATE:   ${promise.state}
+CLAIM:   ${claim}
+
+YOUR JOB
+Advance this promise by BUILDING THE SMALLEST GENUINE MISSING PIECE for ONE of its buildable blockers below. Produce a real artifact (code, a script, a test, a runbook/spec doc, or a fixture) that a reviewer would merge. Prefer a tightly-scoped, verifiable contribution over a sprawling one.
+
+BUILDABLE BLOCKERS (pick ONE; the rest are out of scope for this run):
+${blockerList}
+
+HARD RULES (violating any of these fails the task)
+1. NO GREEN FLIPS. Do not change any promise state, do not edit the product-promise registry to mark anything green/yellow, do not touch state fields. Leave promise states exactly as they are.
+2. Drop a blocker from a tracking doc ONLY if you genuinely and fully cleared it in THIS change. If you only partially advanced it, leave it listed and note the progress. Honesty over optics.
+3. Stay in this worktree. Do not push to main. Do not run git push (the orchestrator handles branch push + PR).
+4. Keep the change SMALL and self-contained. Add new files under a sensible path; if editing existing files, keep diffs minimal.
+5. Do NOT print or commit any secrets, tokens, keys, or credentials.
+
+WORKFLOW
+1. Briefly explore the repo to locate where this promise's evidence/docs/code live (grep for the promiseId and the blocker keywords).
+2. Implement the smallest genuine piece for ONE blocker. Create a short markdown note at docs/launch/gemini-fleet/${id}.md describing what you built, which blocker it advances, and what remains — UNLESS a more natural home exists, in which case use that and still leave a one-line pointer.
+3. Validate — ALL THREE must be clean before you commit:\n   (a) \`cd apps/openagents.com/workers/api && bunx tsc -p tsconfig.json --noEmit\` MUST report 0 errors (check:deploy does NOT cover workers/api typecheck — you must run this yourself; fix every TS error your change introduced, no \`any\`/\`@ts-ignore\`).\n   (b) \`cd apps/openagents.com && bun run check:deploy\` MUST pass; fix it if your change broke it (note any unrelated pre-existing failure precisely).\n   (c) \`git diff --check\` MUST be clean — remove any trailing whitespace you added.
+4. Commit your work with \`git add -A && git commit -m "gemini-fleet(${id}): <concise summary>"\`. Do NOT push.
+5. End with a 3-5 line summary: which blocker you advanced, what you built (file paths), whether check:deploy passed, and what genuinely remains.
+
+Begin now.`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const res = await fetch(PROMISES_URL, { headers: { "User-Agent": BROWSER_UA } });
+  if (!res.ok) {
+    console.error(`assign: registry fetch failed HTTP ${res.status}`);
+    process.exit(1);
+  }
+  const data = await res.json();
+  const promises = data.promises || [];
+
+  let pool = promises.filter((p) => {
+    if (["green", "withdrawn"].includes(p.state)) return false;
+    if (args.state !== "any" && p.state !== args.state) return false;
+    const brefs = p.blockerRefs || [];
+    return brefs.some(isBuildable);
+  });
+
+  // Dedup: exclude promises that already have an OPEN gemini-fleet PR (its branch
+  // exists, so `git worktree add -b` would collide). Frees the fleet to pick fresh
+  // promises each batch; a promise becomes eligible again once its PR merges/closes.
+  try {
+    const out = execSync('gh pr list --state open --json headRefName --limit 300', { encoding: 'utf8' });
+    const taken = new Set();
+    for (const pr of JSON.parse(out)) {
+      const m = String(pr.headRefName || '').match(/^gemini-fleet\/(.+)$/);
+      if (m) taken.add(m[1]);
+    }
+    if (taken.size) pool = pool.filter((p) => !taken.has(p.promiseId));
+  } catch (e) {
+    console.error('assign: open-PR dedup skipped:', String(e).slice(0, 80));
+  }
+
+  if (args.ids) {
+    const want = new Set(args.ids);
+    pool = pool.filter((p) => want.has(p.promiseId));
+  }
+
+  // Deterministic, stable ordering: most buildable blockers first, then id.
+  pool.sort((a, b) => {
+    const ba = (a.blockerRefs || []).filter(isBuildable).length;
+    const bb = (b.blockerRefs || []).filter(isBuildable).length;
+    if (bb !== ba) return bb - ba;
+    return a.promiseId.localeCompare(b.promiseId);
+  });
+
+  const chosen = args.ids ? pool : pool.slice(0, args.count);
+  const assignments = chosen.map((p) => {
+    const buildable = (p.blockerRefs || []).filter(isBuildable);
+    return {
+      promiseId: p.promiseId,
+      state: p.state,
+      model: args.model,
+      blockers: buildable,
+      brief: briefFor(p, buildable, args.model),
+    };
+  });
+
+  if (args.out) {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    fs.mkdirSync(args.out, { recursive: true });
+    for (const a of assignments) {
+      const safe = a.promiseId.replace(/[^a-zA-Z0-9._-]/g, "_");
+      fs.writeFileSync(path.join(args.out, `${safe}.brief.txt`), a.brief);
+    }
+    fs.writeFileSync(
+      path.join(args.out, "assignments.json"),
+      JSON.stringify(assignments, null, 2),
+    );
+    console.error(`assign: wrote ${assignments.length} assignment(s) to ${args.out}`);
+  }
+
+  process.stdout.write(JSON.stringify(assignments, null, 2) + "\n");
+}
+
+main().catch((e) => {
+  console.error("assign: fatal", e);
+  process.exit(1);
+});

--- a/scripts/gemini-fleet/run.sh
+++ b/scripts/gemini-fleet/run.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# run.sh — orchestrator for the GEMINI fleet (opencode + Gemini on Vertex AI).
+#
+# 1. assign: pick N non-green promises with buildable, non-owner-gated blockers.
+# 2. fan out: run one worker.sh per promise (each = one opencode agent driven by
+#    a first-party Gemini model on Vertex, in its own worktree on its own branch).
+# 3. report: print resulting PR URLs + per-worker check:deploy status + cost.
+#
+# PR-PER-AGENT only. NO green flips. Workers push BRANCHES (gemini-fleet/<promise>)
+# and open PRs; nothing touches main. Same PR shape as the Vertex fleet, so
+# /tmp/fleet-merge.sh gates these identically.
+#
+# COST: first-party Google Gemini SKU on Vertex => billed to the GFS cloud
+# credit, NOT cards. Keep the wave SMALL anyway (it's still real model usage).
+#
+# Usage:
+#   run.sh [--count N] [--state red|yellow|planned|any]
+#          [--model gemini-2.5-pro] [--ids a,b,c]
+#          [--parallel] [--dry-run] [--no-pr]
+#
+# Default: 3 workers, gemini-2.5-pro, sequential (gentler on shared quota).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COUNT=3
+STATE="any"
+MODEL="gemini-2.5-pro"
+IDS=""
+PARALLEL=0
+DRY_RUN=0
+NO_PR=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --count) COUNT="$2"; shift 2;;
+    --state) STATE="$2"; shift 2;;
+    --model) MODEL="$2"; shift 2;;
+    --ids) IDS="$2"; shift 2;;
+    --parallel) PARALLEL=1; shift;;
+    --dry-run) DRY_RUN=1; shift;;
+    --no-pr) NO_PR=1; shift;;
+    *) echo "run: unknown arg $1" >&2; exit 2;;
+  esac
+done
+
+OUT_DIR="/tmp/gf-assignments"
+RESULTS="/tmp/gf-results.jsonl"
+: > "$RESULTS"
+
+echo "==> gemini-fleet orchestrator (opencode + Gemini on Vertex)" >&2
+echo "    count=$COUNT state=$STATE model=$MODEL parallel=$PARALLEL dry_run=$DRY_RUN no_pr=$NO_PR" >&2
+
+# 1. assignments
+ASSIGN_ARGS=(--count "$COUNT" --state "$STATE" --model "$MODEL" --out "$OUT_DIR")
+[[ -n "$IDS" ]] && ASSIGN_ARGS+=(--ids "$IDS")
+node "$SCRIPT_DIR/assign.mjs" "${ASSIGN_ARGS[@]}" >/dev/null || { echo "run: assign failed" >&2; exit 1; }
+
+# bash 3.2 compatible (macOS): no mapfile.
+PROMISE_IDS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && PROMISE_IDS+=("$line")
+done < <(node -e '
+  const a=require("'"$OUT_DIR"'/assignments.json");
+  for (const x of a) console.log(x.promiseId);
+')
+
+if [[ "${#PROMISE_IDS[@]}" == "0" ]]; then
+  echo "run: no assignments selected" >&2; exit 1
+fi
+
+echo "==> selected ${#PROMISE_IDS[@]} promise(s):" >&2
+for p in "${PROMISE_IDS[@]}"; do echo "      - $p" >&2; done
+
+run_one() {
+  local promise="$1"
+  local safe; safe="$(printf '%s' "$promise" | tr -c 'a-zA-Z0-9._-' '_')"
+  local brief="$OUT_DIR/${safe}.brief.txt"
+  local wargs=(--promise "$promise" --brief-file "$brief" --model "$MODEL")
+  [[ "$DRY_RUN" == "1" ]] && wargs+=(--dry-run)
+  [[ "$NO_PR" == "1" ]] && wargs+=(--no-pr)
+  local line
+  line="$(bash "$SCRIPT_DIR/worker.sh" "${wargs[@]}")"
+  echo "$line" >> "$RESULTS"
+  echo "$line"
+}
+
+# 2. fan out
+if [[ "$PARALLEL" == "1" ]]; then
+  echo "==> running ${#PROMISE_IDS[@]} workers in PARALLEL" >&2
+  pids=()
+  for p in "${PROMISE_IDS[@]}"; do run_one "$p" & pids+=($!); done
+  for pid in "${pids[@]}"; do wait "$pid"; done
+else
+  echo "==> running ${#PROMISE_IDS[@]} workers SEQUENTIALLY" >&2
+  for p in "${PROMISE_IDS[@]}"; do run_one "$p"; done
+fi
+
+# 3. report
+echo "" >&2
+echo "================ GEMINI FLEET RESULTS ================" >&2
+node -e '
+  const fs=require("fs");
+  const lines=fs.readFileSync("'"$RESULTS"'","utf8").trim().split("\n").filter(Boolean);
+  let total=0, n=0;
+  for (const l of lines) {
+    let r; try { r=JSON.parse(l); } catch { console.error("  [bad result line]", l); continue; }
+    const cost = (r.cost_usd==null) ? "n/a" : ("$"+Number(r.cost_usd).toFixed(4));
+    if (r.cost_usd!=null) { total+=Number(r.cost_usd); n++; }
+    console.error(`  ${r.promise}`);
+    console.error(`      status=${r.status}  check:deploy=${r.check_deploy}  cost=${cost}`);
+    console.error(`      PR=${r.pr_url||"(none)"}`);
+  }
+  console.error("  ---------------------------------------------------");
+  console.error(`  workers=${lines.length}  with_cost=${n}  total_cost=$${total.toFixed(4)} (Gemini = GFS-credit-covered)`);
+'
+echo "=====================================================" >&2
+echo "results: $RESULTS" >&2

--- a/scripts/gemini-fleet/worker.sh
+++ b/scripts/gemini-fleet/worker.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# worker.sh — one opencode agent driven by a GEMINI model on Google Vertex AI
+# works one promise in an isolated worktree, runs check:deploy, commits to a
+# BRANCH, pushes the branch, opens a PR.
+#
+# PR-PER-AGENT: this script NEVER pushes to main. It pushes gemini-fleet/<promise>
+# and opens a PR for human review. Same PR shape as scripts/vertex-fleet, so
+# /tmp/fleet-merge.sh gates these identically.
+#
+# Engine:  opencode (provider-agnostic coding agent), run HEADLESS via
+#          `opencode run -m google-vertex/<gemini model> "<brief>"`.
+# Model:   a first-party Google Gemini model on Vertex AI (default
+#          gemini-2.5-pro). First-party Google SKU => billed to the GFS cloud
+#          credit, NOT cards.
+# Auth:    Google Cloud Application Default Credentials (ADC). opencode's
+#          google-vertex provider auto-loads when GOOGLE_VERTEX_PROJECT /
+#          GOOGLE_CLOUD_PROJECT is set and signs requests with
+#          google-auth-library (cloud-platform scope). Locally that's the
+#          owner's `gcloud auth application-default` creds; on an unattended GCE
+#          instance the same code path uses the service-account metadata ADC
+#          (no reauth). NO key material is read or printed by this script.
+#
+# Usage:
+#   worker.sh --promise <promiseId> --brief-file <path>
+#             [--model <gemini model, e.g. gemini-2.5-pro>]
+#             [--base origin/main] [--no-pr] [--dry-run]
+#
+# Emits a single-line JSON result to stdout (last line) and human logs to stderr.
+
+set -uo pipefail
+
+# ---- Vertex / Gemini env (names only; no secret values) ----------------------
+# opencode google-vertex provider reads these. We export both the
+# GOOGLE_VERTEX_* names (what models.dev advertises) and the wider GOOGLE_CLOUD_*
+# names so existing ADC setups autoload regardless of which the provider checks.
+export GOOGLE_VERTEX_PROJECT="${GOOGLE_VERTEX_PROJECT:-${GOOGLE_CLOUD_PROJECT:-openagentsgemini}}"
+export GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT:-$GOOGLE_VERTEX_PROJECT}"
+# global endpoint = better availability at no extra cost; us-central1 is the
+# safe default for Gemini availability. Keep both names in sync.
+export GOOGLE_VERTEX_LOCATION="${GOOGLE_VERTEX_LOCATION:-${VERTEX_LOCATION:-us-central1}}"
+export VERTEX_LOCATION="${VERTEX_LOCATION:-$GOOGLE_VERTEX_LOCATION}"
+
+PROMISE=""
+BRIEF_FILE=""
+MODEL="gemini-2.5-pro"
+BASE="origin/main"
+OPEN_PR=1
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --promise) PROMISE="$2"; shift 2;;
+    --brief-file) BRIEF_FILE="$2"; shift 2;;
+    --model) MODEL="$2"; shift 2;;
+    --base) BASE="$2"; shift 2;;
+    --no-pr) OPEN_PR=0; shift;;
+    --dry-run) DRY_RUN=1; shift;;
+    *) echo "worker: unknown arg $1" >&2; exit 2;;
+  esac
+done
+
+if [[ -z "$PROMISE" || -z "$BRIEF_FILE" ]]; then
+  echo "worker: --promise and --brief-file are required" >&2; exit 2
+fi
+if [[ ! -f "$BRIEF_FILE" ]]; then
+  echo "worker: brief file not found: $BRIEF_FILE" >&2; exit 2
+fi
+
+# opencode model spec: provider/model. The Gemini models live under google-vertex.
+# Accept a bare model id (gemini-2.5-pro) OR a fully-qualified one (google-vertex/...).
+if [[ "$MODEL" == */* ]]; then
+  OC_MODEL="$MODEL"
+else
+  OC_MODEL="google-vertex/${MODEL}"
+fi
+
+SAFE="$(printf '%s' "$PROMISE" | tr -c 'a-zA-Z0-9._-' '_')"
+WORKTREE="/tmp/gf-${SAFE}"
+BRANCH="gemini-fleet/${SAFE}"
+LOG_DIR="/tmp/gf-logs"
+mkdir -p "$LOG_DIR"
+AGENT_LOG="${LOG_DIR}/${SAFE}.agent.log"
+
+# Full-trajectory trace (opencode --format json events): persisted + indexed.
+RUN_ID="$(date +%Y%m%dT%H%M%S)-$$"
+GF_TRACE_ROOT="${GF_TRACE_DIR:-$HOME/work/gemini-fleet-traces}"
+TRACE_DIR="${GF_TRACE_ROOT}/$(date +%Y-%m-%d)"
+mkdir -p "$TRACE_DIR"
+TRACE="${TRACE_DIR}/${SAFE}.${RUN_ID}.trace.jsonl"
+TRACE_INDEX="${GF_TRACE_ROOT}/index.jsonl"
+
+log() { echo "[worker:${PROMISE}] $*" >&2; }
+
+emit() { # emit final JSON result line
+  printf '%s\n' "$1"
+}
+
+result_json() {
+  local status="$1" pr="$2" check="$3" cost="$4" note="$5"
+  printf '{"promise":"%s","engine":"opencode","model":"%s","branch":"%s","status":"%s","pr_url":"%s","check_deploy":"%s","cost_usd":%s,"note":"%s"}' \
+    "$PROMISE" "$OC_MODEL" "$BRANCH" "$status" "$pr" "$check" "${cost:-null}" "$note"
+}
+
+# Find the source repo (this script lives inside a checkout). We add the
+# worktree against origin/main so the agent starts from a clean, current base.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_REPO="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$SRC_REPO" ]]; then
+  log "FATAL: not inside a git checkout"
+  emit "$(result_json error "" skipped null "not_in_git_checkout")"; exit 1
+fi
+
+log "src repo: $SRC_REPO"
+log "engine:   opencode ($(command -v opencode 2>/dev/null || echo 'not on PATH'))"
+log "model:    $OC_MODEL (Vertex, location=$GOOGLE_VERTEX_LOCATION, project=$GOOGLE_VERTEX_PROJECT)"
+log "worktree: $WORKTREE  branch: $BRANCH"
+
+if ! command -v opencode >/dev/null 2>&1; then
+  log "FATAL: opencode not on PATH"
+  emit "$(result_json error "" skipped null "opencode_not_installed")"; exit 1
+fi
+
+# Fresh worktree from origin/main on a new branch.
+# Serialize git-worktree setup: concurrent `git worktree add` on one repo races
+# on git's index/worktree locks. Agent runs stay parallel; only this fast setup
+# is mutually exclusive (mkdir = atomic, macOS-safe).
+GF_GIT_LOCK="${SRC_REPO}/.git/gf-worktree.lock"
+_gf_n=0
+while ! mkdir "$GF_GIT_LOCK" 2>/dev/null; do sleep 0.5; _gf_n=$((_gf_n+1)); [ "$_gf_n" -gt 600 ] && { log "WARN: worktree lock wait timeout; proceeding"; break; }; done
+git -C "$SRC_REPO" fetch origin main --quiet 2>>"$AGENT_LOG" || true
+git -C "$SRC_REPO" worktree remove "$WORKTREE" --force >/dev/null 2>&1 || true
+git -C "$SRC_REPO" worktree prune >/dev/null 2>&1 || true
+git -C "$SRC_REPO" branch -D "$BRANCH" >/dev/null 2>&1 || true
+git -C "$SRC_REPO" worktree add -b "$BRANCH" "$WORKTREE" "$BASE" >>"$AGENT_LOG" 2>&1
+GF_ADD_RC=$?
+rmdir "$GF_GIT_LOCK" 2>/dev/null || true
+if [ "$GF_ADD_RC" != 0 ]; then
+  log "FATAL: could not create worktree (rc=$GF_ADD_RC)"
+  emit "$(result_json error "" skipped null "worktree_add_failed")"; exit 1
+fi
+
+cd "$WORKTREE" || { emit "$(result_json error "" skipped null "cd_worktree_failed")"; exit 1; }
+
+# Pin the base to a fixed SHA. BASE (e.g. "origin/main") is a moving ref: a
+# concurrent push or a later `git fetch` advances it mid-run, which would make
+# the ahead-of-base count below misfire and a real commit look like no_changes.
+BASE_SHA="$(git rev-parse HEAD)"
+log "base pinned: ${BASE_SHA}"
+
+# Install deps so check:deploy can run. Reuse bun's global cache (fast).
+log "installing deps (bun install)..."
+bun install >>"$AGENT_LOG" 2>&1 || log "WARN: bun install returned nonzero (continuing)"
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "DRY RUN: skipping opencode agent; brief is:"
+  sed 's/^/    /' "$BRIEF_FILE" >&2
+  emit "$(result_json dry_run "" skipped 0 "dry_run")"; exit 0
+fi
+
+# ---- Run the Gemini-on-Vertex opencode agent (HEADLESS) ----------------------
+# `opencode run` is the non-interactive headless path. We:
+#   --model google-vertex/<gemini>   pick the first-party Gemini model on Vertex
+#   --format json                    emit raw JSON events -> the trace file
+#   --dangerously-skip-permissions   auto-approve edits/bash so the agent can
+#                                    actually do work unattended (opencode
+#                                    defaults to allow, but this is explicit and
+#                                    survives any restrictive global config)
+# opencode runs IN the worktree because we cd'd into it above (it uses cwd).
+BRIEF="$(cat "$BRIEF_FILE")"
+log "running opencode run (headless, --format json) on $OC_MODEL..."
+set +e
+opencode run \
+  --model "$OC_MODEL" \
+  --format json \
+  --dangerously-skip-permissions \
+  "$BRIEF" \
+  >"$TRACE" 2>>"$AGENT_LOG"
+AGENT_RC=$?
+set -e 2>/dev/null || true
+
+# Extract cost from opencode's JSON event stream. Assistant message.updated
+# events carry properties.info.cost (USD). Sum the max-seen per message; if
+# models.dev has no Gemini pricing yet, cost is 0 (still billed to the GFS
+# credit on the Vertex side, not to this number).
+COST="null"
+if [[ -s "$TRACE" ]]; then
+  COST="$(node -e '
+    try {
+      const fs=require("fs");
+      const lines=fs.readFileSync(process.argv[1],"utf8").trim().split("\n");
+      const seen=new Map();
+      for (const l of lines) {
+        try {
+          const j=JSON.parse(l);
+          const info = j?.properties?.info ?? j?.info;
+          if (info && info.role==="assistant" && typeof info.cost==="number") {
+            seen.set(info.id ?? Math.random(), info.cost);
+          }
+        } catch(e){}
+      }
+      let c=0; for (const v of seen.values()) c+=v;
+      process.stdout.write(seen.size? String(c) : "null");
+    } catch(e){ process.stdout.write("null"); }
+  ' "$TRACE" 2>/dev/null || echo null)"
+fi
+log "agent rc=$AGENT_RC cost_usd=$COST  trace=$TRACE"
+# Index this run for later traversal.
+printf '{"promise":"%s","engine":"opencode","model":"%s","run_id":"%s","branch":"%s","trace":"%s","agent_rc":%s,"cost_usd":%s,"ts":"%s"}\n' \
+  "$PROMISE" "$OC_MODEL" "$RUN_ID" "$BRANCH" "$TRACE" "$AGENT_RC" "${COST:-null}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$TRACE_INDEX" 2>/dev/null || true
+
+if [[ "$AGENT_RC" != "0" ]]; then
+  log "agent failed (rc=$AGENT_RC); see $AGENT_LOG"
+  emit "$(result_json agent_failed "" skipped "$COST" "agent_rc_${AGENT_RC}")"; exit 0
+fi
+
+# ---- Did the agent actually change anything? --------------------------------
+if git diff --quiet HEAD 2>/dev/null && [[ -z "$(git status --porcelain)" ]]; then
+  AHEAD="$(git rev-list --count "${BASE_SHA}..HEAD" 2>/dev/null || echo 0)"
+  if [[ "$AHEAD" == "0" ]]; then
+    log "agent produced no changes"
+    emit "$(result_json no_changes "" skipped "$COST" "agent_made_no_changes")"; exit 0
+  fi
+fi
+
+# Commit anything the agent left uncommitted.
+if [[ -n "$(git status --porcelain)" ]]; then
+  git add -A
+  git commit -q -m "gemini-fleet(${PROMISE}): agent changes (${OC_MODEL} via opencode on Vertex)" || true
+fi
+
+AHEAD="$(git rev-list --count "${BASE_SHA}..HEAD" 2>/dev/null || echo 0)"
+if [[ "$AHEAD" == "0" ]]; then
+  log "no commits ahead of base after commit attempt"
+  emit "$(result_json no_changes "" skipped "$COST" "no_commits_ahead")"; exit 0
+fi
+
+# ---- check:deploy (the merge gate) ------------------------------------------
+log "running check:deploy..."
+CHECK="fail"
+if bun run check:deploy >>"$AGENT_LOG" 2>&1; then
+  CHECK="pass"
+  log "check:deploy PASSED"
+else
+  CHECK="fail"
+  log "check:deploy FAILED (see $AGENT_LOG)"
+fi
+
+# ---- push branch + open PR (PR-per-agent; NEVER main) ------------------------
+if [[ "$OPEN_PR" != "1" ]]; then
+  emit "$(result_json built_no_pr "" "$CHECK" "$COST" "pr_skipped_by_flag")"; exit 0
+fi
+
+log "pushing branch $BRANCH..."
+if ! git push -u origin "$BRANCH" --force-with-lease >>"$AGENT_LOG" 2>&1; then
+  log "branch push failed"
+  emit "$(result_json push_failed "" "$CHECK" "$COST" "branch_push_failed")"; exit 0
+fi
+
+PR_TITLE="gemini-fleet: advance ${PROMISE}"
+PR_BODY="Automated PR opened by an opencode agent driven by a first-party Google Gemini model on Vertex AI (model: ${OC_MODEL}, location: ${GOOGLE_VERTEX_LOCATION}).
+
+First-party Google SKU => billed to the GFS cloud credit, not cards.
+
+Promise: \`${PROMISE}\`
+
+check:deploy: **${CHECK}**
+
+Guardrails honored by the worker: PR-per-agent (branch only, never main), no green flips, isolated worktree. Review before merge.
+
+DO NOT MERGE automatically — owner/Raynor reviews and merges.
+
+🤖 Generated with opencode + Gemini on GCP"
+
+set +e
+PR_URL="$(gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base main --head "$BRANCH" --repo OpenAgentsInc/openagents 2>>"$AGENT_LOG")"
+PR_RC=$?
+set -e 2>/dev/null || true
+
+if [[ "$PR_RC" != "0" || -z "$PR_URL" ]]; then
+  log "gh pr create failed (rc=$PR_RC)"
+  emit "$(result_json pr_failed "" "$CHECK" "$COST" "gh_pr_create_failed")"; exit 0
+fi
+
+log "PR opened: $PR_URL"
+emit "$(result_json pr_open "$PR_URL" "$CHECK" "$COST" "ok")"


### PR DESCRIPTION
Adds a Gemini fleet (first-party Google model = GFS-credit-covered, not card-billed) driven by opencode. Same PR-per-promise shape (branch gemini-fleet/*) so /tmp/fleet-merge.sh gates it.

**opencode invocation (headless):** `opencode run --model google-vertex/gemini-2.5-pro --format json --dangerously-skip-permissions "<brief>"`, run inside a per-promise worktree (opencode uses cwd). `opencode run` is opencode's non-interactive one-shot path; `--format json` streams JSON events to the trace file (cost parsed from `properties.info.cost`).

**Gemini model:** `gemini-2.5-pro` by default (GA, strong coding). Override with `--model` (e.g. `gemini-2.5-flash`, or fully-qualified `google-vertex/gemini-3.1-pro-preview`). Bare ids are auto-prefixed to `google-vertex/`.

**Auth path:** Google Cloud Application Default Credentials (ADC) for project `openagentsgemini`. opencode's built-in `google-vertex` provider auto-loads on `GOOGLE_VERTEX_PROJECT`/`GOOGLE_CLOUD_PROJECT` and signs every request via `google-auth-library` (cloud-platform scope) — locally the owner's gcloud ADC, on GCE the SA metadata ADC (no reauth). No keys read or printed. AI Studio key path documented as fallback but **not used** — Vertex/ADC is preferred so usage bills the GFS credit.

**Credit-covered:** Gemini on Vertex is a first-party Google SKU billed to the GFS cloud credit, not cards.

**Files:** `scripts/gemini-fleet/{run.sh,worker.sh,assign.mjs,README.md}` — mirrors `scripts/vertex-fleet/` (same selector, same guardrails: PR-per-agent, no green flips, check:deploy gate, open-PR dedup on `gemini-fleet/*`).

**Verified:** `node --check assign.mjs` clean; `bash -n` clean on both shell scripts; assign.mjs selects live promises with gemini-2.5-pro; and a live single headless run `opencode run -m google-vertex/gemini-2.5-pro` returned `PONG` (exit 0) against `openagentsgemini`/`us-central1` — auth + headless mode proven. No full batch launched (wiring proof only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)