### PR TITLE
fleet: Codex runner (subscription via central device-flow auth) + retire Vertex fleet

### DIFF
--- a/scripts/codex-fleet/README.md
+++ b/scripts/codex-fleet/README.md
@@ -1,0 +1,164 @@
+# codex-fleet — "Codex-subscription, PR-per-agent" fleet runner
+
+A small, dependency-light runner that turns **one non-green product promise** into
+**one `codex exec` coding agent** running on the **OpenAgents ChatGPT/Codex
+subscription**, working in **one isolated git worktree**, on **one branch**, that
+opens **one PR** for human review.
+
+It is the direct successor to `scripts/vertex-fleet/` (now **retired** — see
+`scripts/vertex-fleet/DEPRECATED.md`). It produces the **same shape of PRs**
+(branch `codex-fleet/<promise>` instead of `vertex-fleet/<promise>`) so the
+existing merge gate `/tmp/fleet-merge.sh` still gates it unchanged.
+
+The reason for the swap: Anthropic-Claude-on-Vertex is a third-party SKU **not
+covered by the GFS credit**, so every Vertex batch was direct card spend. Codex
+runs on our **existing ChatGPT/Codex subscription** — no per-token card spend,
+just subscription quota.
+
+## Guardrails (enforced by the scripts)
+
+- **PR-per-agent only.** Workers push `codex-fleet/<promise>` branches and open
+  PRs via `gh`. They **never** push to `main`.
+- **No green flips.** The task brief forbids editing the product-promise registry
+  or changing any promise state. Agents build the missing *piece*.
+- **check:deploy is the merge gate.** Each worker runs `bun run check:deploy` and
+  records pass/fail on the PR. A failing check is reported, not hidden.
+- **No secrets printed or committed.** The auth blob, OAuth tokens, account ids,
+  the admin token, and the agent token are never printed. Only public refs,
+  lengths, booleans, statuses, and env-var *names* appear.
+- **Per-promise isolation.** Each worker gets its own `CODEX_HOME` and leases one
+  subscription account, released after the run, so concurrent workers never
+  share or overwrite auth material.
+
+## Components
+
+| File | What it does |
+|------|--------------|
+| `assign.mjs` | Fetches the public product-promise registry (`https://openagents.com/api/public/product-promises`, browser UA), selects N non-green promises with **buildable, non-owner-gated** blockers, and emits one task brief each. `--priority business` front-loads business-fulfillment promises. Open-PR dedup matches the `codex-fleet/<promise>` branch prefix. |
+| `fetch-codex-auth.mjs` | **The auth crux.** Pulls a Codex OAuth blob from the central device-flow provider-account store and materializes a codex-native `auth.json` under an isolated `CODEX_HOME`. Subcommands: `lease`, `release`, `sanity-all`. |
+| `worker.sh` | Given one assignment: `git worktree add` from `origin/main`, `bun install`, fetch central Codex auth into a per-promise `CODEX_HOME`, run `codex exec "<brief>" -m gpt-5.5 -c model_reasoning_effort=xhigh --dangerously-bypass-approvals-and-sandbox --json`, release the lease, run `check:deploy`, commit to branch `codex-fleet/<promise>`, push, open a PR. Emits a one-line JSON result (incl. token usage). |
+| `run.sh` | Orchestrator. Runs a few workers (sequential by default; `--parallel` opt-in), then prints PR URLs + per-worker `check:deploy` status + total tokens. |
+
+## Usage
+
+```bash
+# from the repo root of an openagents checkout, with the two tokens in env:
+set -a
+. /Users/christopherdavid/work/.secrets/vortex-admin.env              # OPENAGENTS_ADMIN_API_TOKEN
+. /Users/christopherdavid/work/.secrets/openagents-codex-loopwright-agent.env  # OPENAGENTS_AGENT_TOKEN
+set +a
+
+bash scripts/codex-fleet/run.sh --count 3
+
+# pick specific promises
+bash scripts/codex-fleet/run.sh --ids energy.flexible_load_proof.v1,autopilot.decision_queue.v1
+
+# preview selection + briefs without spending quota (no auth fetch, no codex exec)
+bash scripts/codex-fleet/run.sh --count 3 --dry-run
+
+# build + check:deploy but don't open PRs
+bash scripts/codex-fleet/run.sh --count 2 --no-pr
+```
+
+Flags: `--count N`, `--state red|yellow|planned|any`, `--model <codex model>`,
+`--ids a,b,c`, `--priority business|any`, `--parallel`, `--dry-run`, `--no-pr`.
+
+Results are written to `/tmp/cf-results.jsonl`; per-worker logs to
+`/tmp/cf-logs/<promise>.agent.log`; assignments + briefs to
+`/tmp/cf-assignments/`; full `codex exec --json` traces to
+`~/work/codex-fleet-traces/<date>/` (indexed in `index.jsonl`).
+
+## Auth: the central device-flow provider-account store (the crux)
+
+Codex normally authenticates one of two ways: an `OPENAI_API_KEY`, or a ChatGPT
+login that writes `~/.codex/auth.json` (`auth_mode: "chatgpt"`,
+`tokens.{id_token, access_token, refresh_token, account_id}`). The ChatGPT path
+is normally **interactive** (`codex login`, browser device-code page).
+
+We do **not** want a per-machine interactive login on every cloud worker. Instead
+we reuse the **central device-flow provider-account system already built into
+openagents.com** (operator runbook:
+`apps/openagents.com/docs/2026-06-05-chatgpt-device-login-operator-runbook.md`).
+The owner connects ChatGPT/Codex accounts **once**, via the device-code ceremony
+(`scripts/provider-chatgpt-device-login.mjs start/poll`); the worker then pulls a
+short-lived auth blob over HTTP. No browser, no `codex login`, on the worker.
+
+### How `fetch-codex-auth.mjs lease` works (no secrets)
+
+Two server tokens, two stages, then a local translation:
+
+1. **ADMIN token** → `POST /api/operator/provider-accounts/chatgpt-codex/leases`
+   `{ requestedAction, email, assignmentId, runId }`. The central lease selector
+   picks the connected + healthy account with the fewest active leases and returns
+   `{ leaseRef, providerAccountRef }` (public refs only).
+2. **ADMIN token** → `POST /api/operator/provider-accounts/chatgpt-codex/leases/grant`
+   `{ leaseRef, email, runId }`. Issues a short-lived, runner-scoped grant for the
+   leased account and returns `{ grant: { grantRef, expiresAt, ... } }`.
+3. **AGENT token** (programmatic-agent bearer) →
+   `POST /api/provider-accounts/chatgpt-codex/grants/resolve`
+   `{ grantRef, providerAccountRef, includeAuthMaterial: true, runId }`. Resolves
+   the grant **with** auth material behind the server-side secret boundary and
+   returns
+   `{ authMaterial: { authContentEnv: "OPENCODE_AUTH_CONTENT", authContentJson } }`.
+   `authContentJson` is the OpenCode/openauth `auth.json`:
+   `{ openai: { type: "oauth", access, refresh, expires, accountId?, idToken? } }`.
+4. **Local translation** into the codex-CLI-native shape and write to
+   `CODEX_HOME/auth.json` (0600):
+   `{ auth_mode: "chatgpt", OPENAI_API_KEY: null,
+      tokens: { id_token, access_token, refresh_token, account_id },
+      last_refresh }`.
+   (This mirrors the server's own `codexOAuthAuthFromAuthMaterial` extraction in
+   `operator-provider-account-routes.ts`.)
+
+`codex exec` then reads `CODEX_HOME/auth.json` and runs on the subscription. The
+worker **releases the lease** as soon as the agent finishes.
+
+### Required env (names only — no values)
+
+```
+OPENAGENTS_ADMIN_API_TOKEN   # admin/operator bearer (lease + grant issue)
+OPENAGENTS_AGENT_TOKEN       # programmatic-agent bearer (grant resolve w/ material)
+OPENAGENTS_BASE_URL          # default https://openagents.com
+OPENAGENTS_FLEET_EMAIL       # default chris@openagents.com (target user for the account fleet)
+CODEX_HOME                   # per-promise auth.json home (worker.sh sets this)
+```
+
+On this Mac the two tokens live in ignored workspace secret files:
+
+```
+/Users/christopherdavid/work/.secrets/vortex-admin.env                       # OPENAGENTS_ADMIN_API_TOKEN
+/Users/christopherdavid/work/.secrets/openagents-codex-loopwright-agent.env  # OPENAGENTS_AGENT_TOKEN
+```
+
+### Account readiness (owner-gated)
+
+A lease only resolves usable material for a **connected + healthy** Codex account.
+If `grants/resolve` returns `provider_account_auth_material_unavailable`, the
+selected account's stored refresh token was invalidated (`requires_reauth`) and
+the owner must reconnect it:
+
+```bash
+# inspect fleet health (counts + classes only)
+node scripts/codex-fleet/fetch-codex-auth.mjs sanity-all --email chris@openagents.com
+
+# reconnect an account (owner completes the browser device-code page)
+node scripts/provider-chatgpt-device-login.mjs start --email chris@openagents.com --label "codex 1" --create-new
+node scripts/provider-chatgpt-device-login.mjs poll <attempt-id>
+node scripts/provider-chatgpt-device-login.mjs sanity <provider-account-ref>
+```
+
+## Cost note (subscription, not pay-per-token)
+
+Unlike the retired Vertex fleet (Google Cloud per-token billing, direct card
+spend), this fleet runs on the **ChatGPT/Codex subscription**. There is no
+per-token card charge, but there **is** shared subscription quota and rate
+limiting, and each worker pins one account via a lease for the duration of the
+run. Keep waves modest and prefer `--parallel` only up to the number of healthy
+connected accounts.
+
+## Concurrency reality
+
+Each worker leases **one** account for its run and gets its **own** `CODEX_HOME`.
+With `--parallel`, keep `--count` at or below the number of healthy connected
+Codex accounts (check `fetch-codex-auth.mjs sanity-all`) so workers don't contend
+for the same seat. The lease selector spreads load by fewest-active-leases.

--- a/scripts/codex-fleet/assign.mjs
+++ b/scripts/codex-fleet/assign.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process'
+// assign.mjs — promise -> assignment selector for the CODEX fleet runner.
+//
+// Adapted from scripts/vertex-fleet/assign.mjs. Same promise-registry source,
+// same buildable/owner-gated classification, same open-PR dedup. Differences:
+//   - the brief is framed for a Codex (gpt-5.5) agent run by `codex exec`;
+//   - open-PR dedup matches the `codex-fleet/<promise>` branch prefix;
+//   - --priority business prefers business-fulfillment promises first.
+//
+// Fetches the live public product-promise registry, selects N non-green promises
+// that still have *buildable* (non-owner-gated) blockers, and emits one task
+// brief per promise.
+//
+// Output: JSON array of { promiseId, state, model, blockers, brief } to stdout
+// (and, with --out <dir>, one <promiseId>.brief.txt + assignments.json on disk).
+//
+// NO secrets are read or printed. The registry endpoint is public.
+//
+// Usage:
+//   node assign.mjs [--count N] [--state red|yellow|planned|any]
+//                   [--model gpt-5.5] [--out DIR] [--ids a,b,c]
+//                   [--priority business|any]
+//
+// Selection is keyword-classified, NOT semantic — acceptable here because the
+// universe is the bounded, enum-typed blocker-id list from our own registry,
+// and the agent itself decides per the brief which blockers it genuinely cleared.
+
+const PROMISES_URL = 'https://openagents.com/api/public/product-promises'
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+
+// Owner-gated / non-buildable signals: anything needing a human decision,
+// secret, payment rail, legal/policy sign-off, custody, or quota grant.
+const GATED = [
+  'privacy_review', 'copy_review', 'copy_gate', 'product_copy', 'pricing',
+  'package_policy', 'payout', 'settlement', 'stripe', 'secret', 'token',
+  'sign_off', 'signoff', 'manual', 'reauth', 'owner', 'prod_key',
+  'production_key', 'legal', 'policy_review', 'marketplace_metering',
+  'eligibility', 'custody', 'wallet_fund', 'quota', 'interactive', 'approval',
+  'testflight', 'app_store', 'distribution_not_live', 'enablement',
+]
+
+// Buildable signals: missing code / docs / tests / scripts / specs / endpoints.
+const BUILD = [
+  'missing', 'endpoint', 'script', 'runbook', 'doc', 'test', 'harness',
+  'runner', 'fixture', 'guide', 'helper', 'spec', 'schema', 'plan', 'audit',
+  'wiring', 'adapter', 'projection', 'capture', 'manifest', 'telemetry',
+  'report', 'example', 'methodology', 'definition', 'architecture', 'receipts',
+]
+
+// Business-fulfillment signals: promises about making/taking money, orders,
+// fulfillment, customers, revenue. Used by --priority business to front-load
+// the highest-leverage commercial work.
+const BUSINESS = [
+  'order', 'fulfill', 'customer', 'revenue', 'invoice', 'credit', 'ledger',
+  'checkout', 'billing', 'payment', 'sale', 'pricing', 'refund', 'subscription',
+  'make_money', 'make-money', 'earn', 'payout', 'settlement', 'commerce',
+  'purchase', 'cart', 'receipt', 'business',
+]
+
+function isGated(blockerId) {
+  const s = String(blockerId).toLowerCase()
+  return GATED.some((w) => s.includes(w))
+}
+function isBuildable(blockerId) {
+  const s = String(blockerId).toLowerCase()
+  return !isGated(blockerId) && BUILD.some((w) => s.includes(w))
+}
+function isBusinessPromise(promise) {
+  const hay = `${promise.promiseId} ${promise.claim ?? ''} ${
+    promise.safeCopy ?? ''
+  } ${(promise.blockerRefs ?? []).join(' ')}`.toLowerCase()
+  return BUSINESS.some((w) => hay.includes(w))
+}
+
+function parseArgs(argv) {
+  const a = {
+    count: 3,
+    state: 'any',
+    model: 'gpt-5.5',
+    out: null,
+    ids: null,
+    priority: 'any',
+  }
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i]
+    if (k === '--count') a.count = parseInt(argv[++i], 10)
+    else if (k === '--state') a.state = argv[++i]
+    else if (k === '--model') a.model = argv[++i]
+    else if (k === '--out') a.out = argv[++i]
+    else if (k === '--priority') a.priority = argv[++i]
+    else if (k === '--ids')
+      a.ids = argv[++i].split(',').map((s) => s.trim()).filter(Boolean)
+  }
+  return a
+}
+
+function briefFor(promise, buildableBlockers, model) {
+  const id = promise.promiseId
+  const claim = promise.safeCopy || promise.claim || '(no claim text)'
+  const blockerList = buildableBlockers.map((b) => `  - ${b}`).join('\n')
+  // Codex (gpt-5.5) agent, scoped to ONE promise, PR-per-agent.
+  return `You are one worker in the OpenAgents Codex fleet. You are powered by ${model} via the OpenAgents ChatGPT/Codex subscription, run non-interactively by \`codex exec\`. You are working in an ISOLATED git worktree on a branch. Do real, mergeable work — no theater.
+
+PROMISE: ${id}
+STATE:   ${promise.state}
+CLAIM:   ${claim}
+
+YOUR JOB
+Advance this promise by BUILDING THE SMALLEST GENUINE MISSING PIECE for ONE of its buildable blockers below. Produce a real artifact (code, a script, a test, a runbook/spec doc, or a fixture) that a reviewer would merge. Prefer a tightly-scoped, verifiable contribution over a sprawling one.
+
+BUILDABLE BLOCKERS (pick ONE; the rest are out of scope for this run):
+${blockerList}
+
+HARD RULES (violating any of these fails the task)
+1. NO GREEN FLIPS. Do not change any promise state, do not edit the product-promise registry to mark anything green/yellow, do not touch state fields. Leave promise states exactly as they are.
+2. Drop a blocker from a tracking doc ONLY if you genuinely and fully cleared it in THIS change. If you only partially advanced it, leave it listed and note the progress. Honesty over optics.
+3. Stay in this worktree. Do not push to main. Do not run git push (the orchestrator handles branch push + PR).
+4. Keep the change SMALL and self-contained. Add new files under a sensible path; if editing existing files, keep diffs minimal.
+5. Do NOT print or commit any secrets, tokens, keys, or credentials.
+
+WORKFLOW
+1. Briefly explore the repo to locate where this promise's evidence/docs/code live (grep for the promiseId and the blocker keywords).
+2. Implement the smallest genuine piece for ONE blocker. Create a short markdown note at docs/launch/codex-fleet/${id}.md describing what you built, which blocker it advances, and what remains — UNLESS a more natural home exists, in which case use that and still leave a one-line pointer.
+3. Validate — ALL THREE must be clean before you commit:
+   (a) \`cd apps/openagents.com/workers/api && bunx tsc -p tsconfig.json --noEmit\` MUST report 0 errors (check:deploy does NOT cover workers/api typecheck — you must run this yourself; fix every TS error your change introduced, no \`any\`/\`@ts-ignore\`).
+   (b) \`cd apps/openagents.com && bun run check:deploy\` MUST pass; fix it if your change broke it (note any unrelated pre-existing failure precisely).
+   (c) \`git diff --check\` MUST be clean — remove any trailing whitespace you added.
+4. Commit your work with \`git add -A && git commit -m "codex-fleet(${id}): <concise summary>"\`. Do NOT push.
+5. End with a 3-5 line summary: which blocker you advanced, what you built (file paths), whether check:deploy passed, and what genuinely remains.
+
+Begin now.`
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  const res = await fetch(PROMISES_URL, { headers: { 'User-Agent': BROWSER_UA } })
+  if (!res.ok) {
+    console.error(`assign: registry fetch failed HTTP ${res.status}`)
+    process.exit(1)
+  }
+  const data = await res.json()
+  const promises = data.promises || []
+
+  let pool = promises.filter((p) => {
+    if (['green', 'withdrawn'].includes(p.state)) return false
+    if (args.state !== 'any' && p.state !== args.state) return false
+    const brefs = p.blockerRefs || []
+    return brefs.some(isBuildable)
+  })
+
+  // Dedup: exclude promises that already have an OPEN codex-fleet PR (its branch
+  // exists, so `git worktree add -b` would collide). Frees the fleet to pick fresh
+  // promises each batch; a promise becomes eligible again once its PR merges/closes.
+  try {
+    const out = execSync(
+      'gh pr list --state open --json headRefName --limit 300',
+      { encoding: 'utf8' },
+    )
+    const taken = new Set()
+    for (const pr of JSON.parse(out)) {
+      const m = String(pr.headRefName || '').match(/^codex-fleet\/(.+)$/)
+      if (m) taken.add(m[1])
+    }
+    if (taken.size) pool = pool.filter((p) => !taken.has(p.promiseId))
+  } catch (e) {
+    console.error('assign: open-PR dedup skipped:', String(e).slice(0, 80))
+  }
+
+  if (args.ids) {
+    const want = new Set(args.ids)
+    pool = pool.filter((p) => want.has(p.promiseId))
+  }
+
+  // Deterministic, stable ordering. With --priority business, business-fulfillment
+  // promises sort first; then most buildable blockers, then id.
+  const businessFirst = args.priority === 'business'
+  pool.sort((a, b) => {
+    if (businessFirst) {
+      const ab = isBusinessPromise(a) ? 1 : 0
+      const bb = isBusinessPromise(b) ? 1 : 0
+      if (bb !== ab) return bb - ab
+    }
+    const ba = (a.blockerRefs || []).filter(isBuildable).length
+    const bbn = (b.blockerRefs || []).filter(isBuildable).length
+    if (bbn !== ba) return bbn - ba
+    return a.promiseId.localeCompare(b.promiseId)
+  })
+
+  const chosen = args.ids ? pool : pool.slice(0, args.count)
+  const assignments = chosen.map((p) => {
+    const buildable = (p.blockerRefs || []).filter(isBuildable)
+    return {
+      promiseId: p.promiseId,
+      state: p.state,
+      model: args.model,
+      blockers: buildable,
+      brief: briefFor(p, buildable, args.model),
+    }
+  })
+
+  if (args.out) {
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    fs.mkdirSync(args.out, { recursive: true })
+    for (const a of assignments) {
+      const safe = a.promiseId.replace(/[^a-zA-Z0-9._-]/g, '_')
+      fs.writeFileSync(path.join(args.out, `${safe}.brief.txt`), a.brief)
+    }
+    fs.writeFileSync(
+      path.join(args.out, 'assignments.json'),
+      JSON.stringify(assignments, null, 2),
+    )
+    console.error(`assign: wrote ${assignments.length} assignment(s) to ${args.out}`)
+  }
+
+  process.stdout.write(JSON.stringify(assignments, null, 2) + '\n')
+}
+
+main().catch((e) => {
+  console.error('assign: fatal', e)
+  process.exit(1)
+})

--- a/scripts/codex-fleet/fetch-codex-auth.mjs
+++ b/scripts/codex-fleet/fetch-codex-auth.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// fetch-codex-auth.mjs — fetch a Codex/ChatGPT subscription auth blob from the
+// CENTRAL device-flow provider-account store in openagents.com and materialize
+// it as a codex-native `auth.json` under an isolated CODEX_HOME.
+//
+// This is the crux of the Codex fleet: cloud workers run `codex exec` on OUR
+// ChatGPT/Codex SUBSCRIPTION without any per-machine interactive `codex login`.
+// The OAuth material was collected once, centrally, via the device-code flow
+// documented in:
+//   apps/openagents.com/docs/2026-06-05-chatgpt-device-login-operator-runbook.md
+//
+// Two-token machine flow (no browser, no interactive login):
+//   1. ADMIN  token -> POST /api/operator/provider-accounts/chatgpt-codex/leases
+//      Selects a connected+healthy Codex account and returns { leaseRef, providerAccountRef }.
+//   2. ADMIN  token -> POST /api/operator/provider-accounts/chatgpt-codex/leases/grant
+//      Issues a short-lived, runner-scoped grant for the leased account -> { grant.grantRef }.
+//   3. AGENT  token -> POST /api/provider-accounts/chatgpt-codex/grants/resolve
+//      with { grantRef, providerAccountRef, includeAuthMaterial:true } -> returns
+//      { authMaterial: { authContentEnv:'OPENCODE_AUTH_CONTENT', authContentJson } }.
+//      authContentJson is the OpenCode/openauth auth.json: { openai:{ type:'oauth',
+//      access, refresh, expires, accountId?, idToken? } }.
+//   4. Translate that into the codex-CLI-native ~/.codex/auth.json shape
+//      ({ auth_mode:'chatgpt', tokens:{ id_token, access_token, refresh_token,
+//      account_id }, last_refresh }) and write it to CODEX_HOME/auth.json.
+//
+// The caller is responsible for RELEASING the lease (worker.sh does, via
+// `release` subcommand) so accounts don't stay pinned.
+//
+// SECURITY: this script NEVER prints the token blob, access/refresh/id tokens,
+// account ids, the admin token, or the agent token. It prints only public refs,
+// lengths, booleans, statuses, and the CODEX_HOME path. stdout (for `lease`)
+// emits ONLY public refs (leaseRef, providerAccountRef) as JSON.
+//
+// Subcommands:
+//   lease   --action <a> [--assignmentId <id>] [--runId <id>] [--email <e>]
+//             -> leases an account, issues a grant, resolves material, writes
+//                CODEX_HOME/auth.json. Prints { leaseRef, providerAccountRef } JSON.
+//   release --leaseRef <ref> [--status released|succeeded|failed] [--email <e>]
+//             -> releases the lease.
+//   sanity-all [--email <e>]
+//             -> prints connected-account health summary (counts + classes; no secrets).
+//
+// Env (names only):
+//   OPENAGENTS_ADMIN_API_TOKEN  required  (admin/operator bearer; central lease + grant)
+//   OPENAGENTS_AGENT_TOKEN      required  (programmatic-agent bearer; grant resolve)
+//   OPENAGENTS_BASE_URL         default https://openagents.com
+//   OPENAGENTS_FLEET_EMAIL      default chris@openagents.com (target user for the account fleet)
+//   CODEX_HOME                  required for `lease` (where auth.json is written)
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const args = process.argv.slice(2)
+const command = args[0]
+
+const valueAfter = (flag) => {
+  const i = args.indexOf(flag)
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : undefined
+}
+
+const adminToken = process.env.OPENAGENTS_ADMIN_API_TOKEN
+const agentToken = process.env.OPENAGENTS_AGENT_TOKEN
+const baseUrl = process.env.OPENAGENTS_BASE_URL ?? 'https://openagents.com'
+const fleetEmail =
+  valueAfter('--email') ??
+  process.env.OPENAGENTS_FLEET_EMAIL ??
+  'chris@openagents.com'
+
+const die = (msg) => {
+  console.error(`fetch-codex-auth: ${msg}`)
+  process.exit(1)
+}
+
+if (command === undefined) {
+  die('usage: fetch-codex-auth.mjs <lease|release|sanity-all> [flags]')
+}
+
+const post = async (pathname, token, body) => {
+  const response = await fetch(new URL(pathname, baseUrl), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await response.text()
+  let payload = {}
+  try {
+    payload = text === '' ? {} : JSON.parse(text)
+  } catch {
+    payload = { error: 'bad_json', status: response.status }
+  }
+  return { ok: response.ok, status: response.status, payload }
+}
+
+const optionalString = (v) =>
+  typeof v === 'string' && v.trim() !== '' ? v : undefined
+
+// Translate the central OpenCode/openauth auth blob into the codex-CLI-native
+// ~/.codex/auth.json shape. Mirrors the server's codexOAuthAuthFromAuthMaterial
+// extraction in operator-provider-account-routes.ts (openai.{access,refresh,
+// expires,accountId,idToken}) and the codex CLI's tokens.{id_token,access_token,
+// refresh_token,account_id} layout.
+const codexAuthJsonFromAuthMaterial = (authMaterial) => {
+  const authContentJson = optionalString(authMaterial?.authContentJson)
+  if (authContentJson === undefined) {
+    return undefined
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(authContentJson)
+  } catch {
+    return undefined
+  }
+  const openai =
+    parsed && typeof parsed.openai === 'object' && parsed.openai !== null
+      ? parsed.openai
+      : undefined
+  if (openai === undefined) {
+    return undefined
+  }
+  const access = optionalString(openai.access)
+  const refresh = optionalString(openai.refresh)
+  if (openai.type !== 'oauth' || access === undefined || refresh === undefined) {
+    return undefined
+  }
+  return {
+    OPENAI_API_KEY: null,
+    auth_mode: 'chatgpt',
+    tokens: {
+      id_token: optionalString(openai.idToken) ?? '',
+      access_token: access,
+      refresh_token: refresh,
+      account_id: optionalString(openai.accountId) ?? '',
+    },
+    last_refresh: new Date().toISOString(),
+  }
+}
+
+if (command === 'lease') {
+  if (adminToken === undefined || adminToken.trim() === '') {
+    die('Missing OPENAGENTS_ADMIN_API_TOKEN.')
+  }
+  if (agentToken === undefined || agentToken.trim() === '') {
+    die('Missing OPENAGENTS_AGENT_TOKEN.')
+  }
+  const codexHome = process.env.CODEX_HOME
+  if (codexHome === undefined || codexHome.trim() === '') {
+    die('Missing CODEX_HOME (where auth.json is written).')
+  }
+  const requestedAction = valueAfter('--action') ?? 'codex_fleet_promise_work'
+  const assignmentId = valueAfter('--assignmentId')
+  const runId = valueAfter('--runId') ?? assignmentId ?? 'codex-fleet'
+
+  // 1. Lease a connected+healthy Codex account (central selector, admin token).
+  const lease = await post(
+    '/api/operator/provider-accounts/chatgpt-codex/leases',
+    adminToken,
+    {
+      requestedAction,
+      email: fleetEmail,
+      ...(assignmentId === undefined ? {} : { assignmentId }),
+      runId,
+    },
+  )
+  if (!lease.ok) {
+    die(
+      `lease failed (HTTP ${lease.status}): ${lease.payload.error ?? 'unknown'} ${
+        lease.payload.reason ?? lease.payload.message ?? ''
+      }`,
+    )
+  }
+  const leaseRef = optionalString(lease.payload.leaseRef)
+  const providerAccountRef = optionalString(lease.payload.providerAccountRef)
+  if (leaseRef === undefined || providerAccountRef === undefined) {
+    die('lease response missing leaseRef/providerAccountRef')
+  }
+
+  // 2. Issue a runner-scoped grant for the leased account (admin token).
+  const grantResp = await post(
+    '/api/operator/provider-accounts/chatgpt-codex/leases/grant',
+    adminToken,
+    { leaseRef, email: fleetEmail, runId },
+  )
+  if (!grantResp.ok) {
+    die(
+      `grant issue failed (HTTP ${grantResp.status}): ${
+        grantResp.payload.error ?? 'unknown'
+      }`,
+    )
+  }
+  const grantRef = optionalString(grantResp.payload?.grant?.grantRef)
+  if (grantRef === undefined) {
+    die('grant issue response missing grant.grantRef')
+  }
+
+  // 3. Resolve the grant WITH auth material (programmatic-agent token).
+  const resolved = await post(
+    '/api/provider-accounts/chatgpt-codex/grants/resolve',
+    agentToken,
+    { grantRef, providerAccountRef, includeAuthMaterial: true, runId },
+  )
+  if (!resolved.ok) {
+    const err = resolved.payload.error ?? 'unknown'
+    // Surface the most common owner-gated case clearly without leaking material.
+    const hint =
+      err === 'provider_account_auth_material_unavailable'
+        ? ' (account needs owner reconnect: Settings -> Connections -> reconnect ChatGPT/Codex)'
+        : ''
+    die(`grant resolve failed (HTTP ${resolved.status}): ${err}${hint}`)
+  }
+  const authMaterial = resolved.payload.authMaterial
+  const codexAuth = codexAuthJsonFromAuthMaterial(authMaterial)
+  if (codexAuth === undefined) {
+    die('resolved auth material is not a usable Codex OAuth blob')
+  }
+
+  // 4. Write the codex-native auth.json into the isolated CODEX_HOME (0600).
+  fs.mkdirSync(codexHome, { recursive: true })
+  const authPath = path.join(codexHome, 'auth.json')
+  fs.writeFileSync(authPath, JSON.stringify(codexAuth), { mode: 0o600 })
+  try {
+    fs.chmodSync(authPath, 0o600)
+  } catch {
+    /* best-effort */
+  }
+
+  // Public-only stderr breadcrumbs; never the material.
+  console.error(
+    `fetch-codex-auth: leased+resolved Codex auth -> ${authPath} (id_token:${
+      codexAuth.tokens.id_token !== '' ? 'present' : 'absent'
+    } account_id:${codexAuth.tokens.account_id !== '' ? 'present' : 'absent'})`,
+  )
+  // stdout: ONLY public refs for the caller to release later.
+  process.stdout.write(JSON.stringify({ leaseRef, providerAccountRef }) + '\n')
+  process.exit(0)
+}
+
+if (command === 'release') {
+  if (adminToken === undefined || adminToken.trim() === '') {
+    die('Missing OPENAGENTS_ADMIN_API_TOKEN.')
+  }
+  const leaseRef = valueAfter('--leaseRef')
+  if (leaseRef === undefined || leaseRef.trim() === '') {
+    die('release requires --leaseRef')
+  }
+  const status = valueAfter('--status') ?? 'released'
+  const resp = await post(
+    '/api/operator/provider-accounts/chatgpt-codex/leases/release',
+    adminToken,
+    { leaseRef, status },
+  )
+  console.error(
+    `fetch-codex-auth: release lease -> HTTP ${resp.status} status=${
+      resp.payload.status ?? status
+    }`,
+  )
+  // Releasing a lease is best-effort cleanup; never fail the worker on it.
+  process.exit(0)
+}
+
+if (command === 'sanity-all') {
+  if (adminToken === undefined || adminToken.trim() === '') {
+    die('Missing OPENAGENTS_ADMIN_API_TOKEN.')
+  }
+  const resp = await post(
+    '/api/operator/provider-accounts/chatgpt-codex/sanity',
+    adminToken,
+    { email: fleetEmail, all: true },
+  )
+  if (!resp.ok) {
+    die(`sanity failed (HTTP ${resp.status}): ${resp.payload.error ?? 'unknown'}`)
+  }
+  const checks = resp.payload.checks ?? resp.payload.results ?? []
+  let healthy = 0
+  for (const c of checks) {
+    const cls = c.classification ?? c.health ?? 'unknown'
+    if (cls === 'healthy') {
+      healthy += 1
+    }
+    console.error(
+      `- ${cls} "${c.accountLabel ?? 'Unlabeled'}" ref=...${String(
+        c.providerAccountRef ?? '',
+      ).slice(-8)}`,
+    )
+  }
+  console.error(`fetch-codex-auth: ${healthy}/${checks.length} healthy`)
+  process.exit(healthy > 0 ? 0 : 1)
+}
+
+die(`unknown command: ${command}`)

--- a/scripts/codex-fleet/run.sh
+++ b/scripts/codex-fleet/run.sh
@@ -1,34 +1,37 @@
 #!/usr/bin/env bash
-# RETIRED 2026-06-20: Anthropic-Claude-on-Vertex is NOT covered by the GFS credit
-# (third-party SKU) -> direct card spend. Do NOT launch new Vertex batches.
-# Superseded by scripts/codex-fleet/ (Codex subscription via central device-flow
-# auth; same PR-per-agent shape, branch prefix codex-fleet/<promise>).
-# See scripts/vertex-fleet/DEPRECATED.md. Kept for history only.
-#
-# run.sh — orchestrator for the Vertex fleet.
+# run.sh — orchestrator for the CODEX fleet (replaces the retired vertex-fleet).
 #
 # 1. assign: pick N non-green promises with buildable, non-owner-gated blockers.
-# 2. fan out: run one worker.sh per promise (each = one Vertex-powered claude -p
-#    agent in its own worktree on its own branch).
-# 3. report: print resulting PR URLs + per-worker check:deploy status + cost.
+# 2. fan out: run one worker.sh per promise (each = one `codex exec` agent on the
+#    OpenAgents ChatGPT/Codex SUBSCRIPTION, in its own worktree on its own branch,
+#    with a per-promise CODEX_HOME and a leased subscription seat).
+# 3. report: print resulting PR URLs + per-worker check:deploy status + tokens.
 #
 # PR-PER-AGENT only. NO green flips. Workers push BRANCHES and open PRs; nothing
-# touches main. Keep the wave SMALL — it bills Vertex per token.
+# touches main. Same PR shape as the retired vertex-fleet (branch prefix only
+# differs: codex-fleet/<promise>), so the existing gate /tmp/fleet-merge.sh works.
+#
+# Auth note: this fleet uses OUR Codex subscription via the CENTRAL device-flow
+# provider-account store. Workers do NOT spend pay-per-token Vertex money. They
+# DO consume shared subscription quota and lease one Codex account per promise —
+# keep waves modest. Required env (names only): OPENAGENTS_ADMIN_API_TOKEN,
+# OPENAGENTS_AGENT_TOKEN. See scripts/codex-fleet/README.md.
 #
 # Usage:
 #   run.sh [--count N] [--state red|yellow|planned|any]
-#          [--model claude-sonnet-4-6] [--ids a,b,c]
+#          [--model gpt-5.5] [--ids a,b,c] [--priority business|any]
 #          [--parallel] [--dry-run] [--no-pr]
 #
-# Default: 3 workers, sonnet, sequential (gentler on shared Vertex quota).
+# Default: 3 workers, gpt-5.5, sequential, business-fulfillment priority.
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COUNT=3
 STATE="any"
-MODEL="claude-sonnet-4-6"
+MODEL="gpt-5.5"
 IDS=""
+PRIORITY="business"
 PARALLEL=0
 DRY_RUN=0
 NO_PR=0
@@ -39,6 +42,7 @@ while [[ $# -gt 0 ]]; do
     --state) STATE="$2"; shift 2;;
     --model) MODEL="$2"; shift 2;;
     --ids) IDS="$2"; shift 2;;
+    --priority) PRIORITY="$2"; shift 2;;
     --parallel) PARALLEL=1; shift;;
     --dry-run) DRY_RUN=1; shift;;
     --no-pr) NO_PR=1; shift;;
@@ -46,15 +50,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-OUT_DIR="/tmp/vf-assignments"
-RESULTS="/tmp/vf-results.jsonl"
+OUT_DIR="/tmp/cf-assignments"
+RESULTS="/tmp/cf-results.jsonl"
 : > "$RESULTS"
 
-echo "==> vertex-fleet orchestrator" >&2
-echo "    count=$COUNT state=$STATE model=$MODEL parallel=$PARALLEL dry_run=$DRY_RUN no_pr=$NO_PR" >&2
+echo "==> codex-fleet orchestrator" >&2
+echo "    count=$COUNT state=$STATE model=$MODEL priority=$PRIORITY parallel=$PARALLEL dry_run=$DRY_RUN no_pr=$NO_PR" >&2
 
 # 1. assignments
-ASSIGN_ARGS=(--count "$COUNT" --state "$STATE" --model "$MODEL" --out "$OUT_DIR")
+ASSIGN_ARGS=(--count "$COUNT" --state "$STATE" --model "$MODEL" --priority "$PRIORITY" --out "$OUT_DIR")
 [[ -n "$IDS" ]] && ASSIGN_ARGS+=(--ids "$IDS")
 node "$SCRIPT_DIR/assign.mjs" "${ASSIGN_ARGS[@]}" >/dev/null || { echo "run: assign failed" >&2; exit 1; }
 
@@ -100,21 +104,21 @@ fi
 
 # 3. report
 echo "" >&2
-echo "================ VERTEX FLEET RESULTS ================" >&2
+echo "================ CODEX FLEET RESULTS ================" >&2
 node -e '
   const fs=require("fs");
   const lines=fs.readFileSync("'"$RESULTS"'","utf8").trim().split("\n").filter(Boolean);
   let total=0, n=0;
   for (const l of lines) {
     let r; try { r=JSON.parse(l); } catch { console.error("  [bad result line]", l); continue; }
-    const cost = (r.cost_usd==null) ? "n/a" : ("$"+Number(r.cost_usd).toFixed(4));
-    if (r.cost_usd!=null) { total+=Number(r.cost_usd); n++; }
+    let tok="n/a";
+    if (r.tokens && typeof r.tokens==="object") { tok=`${r.tokens.total} (in ${r.tokens.input}/out ${r.tokens.output})`; total+=Number(r.tokens.total)||0; n++; }
     console.error(`  ${r.promise}`);
-    console.error(`      status=${r.status}  check:deploy=${r.check_deploy}  cost=${cost}`);
+    console.error(`      status=${r.status}  check:deploy=${r.check_deploy}  tokens=${tok}`);
     console.error(`      PR=${r.pr_url||"(none)"}`);
   }
   console.error("  ---------------------------------------------------");
-  console.error(`  workers=${lines.length}  with_cost=${n}  total_cost=$${total.toFixed(4)}`);
+  console.error(`  workers=${lines.length}  with_tokens=${n}  total_tokens=${total}`);
 '
-echo "=====================================================" >&2
+echo "====================================================" >&2
 echo "results: $RESULTS" >&2

--- a/scripts/codex-fleet/worker.sh
+++ b/scripts/codex-fleet/worker.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# worker.sh — one Codex (gpt-5.5) agent works one promise in an isolated git
+# worktree, runs check:deploy, commits to a BRANCH, pushes the branch, opens a PR.
+#
+# PR-PER-AGENT: this script NEVER pushes to main. It pushes codex-fleet/<promise>
+# and opens a PR for human review. Same PR shape as the (retired) vertex-fleet so
+# the existing gate /tmp/fleet-merge.sh still gates it (branch prefix only differs).
+#
+# Auth: Codex rides OUR ChatGPT/Codex SUBSCRIPTION. There is NO per-machine
+# interactive `codex login`. Instead, scripts/codex-fleet/fetch-codex-auth.mjs
+# pulls a Codex OAuth blob from the CENTRAL device-flow provider-account store in
+# openagents.com (collected once via the device-code ceremony) and materializes a
+# codex-native auth.json under a PER-PROMISE isolated CODEX_HOME. See:
+#   scripts/codex-fleet/README.md
+#   apps/openagents.com/docs/2026-06-05-chatgpt-device-login-operator-runbook.md
+#
+# Required env (names only; no secret values printed):
+#   OPENAGENTS_ADMIN_API_TOKEN   admin/operator bearer (central lease + grant issue)
+#   OPENAGENTS_AGENT_TOKEN       programmatic-agent bearer (grant resolve w/ material)
+# Optional:
+#   OPENAGENTS_BASE_URL          default https://openagents.com
+#   OPENAGENTS_FLEET_EMAIL       default chris@openagents.com
+#
+# Usage:
+#   worker.sh --promise <promiseId> --brief-file <path> [--model <codex model>]
+#             [--base origin/main] [--no-pr] [--dry-run]
+#
+# Emits a single-line JSON result to stdout (last line) and human logs to stderr.
+
+set -uo pipefail
+
+PROMISE=""
+BRIEF_FILE=""
+MODEL="gpt-5.5"
+REASONING_EFFORT="xhigh"
+BASE="origin/main"
+OPEN_PR=1
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --promise) PROMISE="$2"; shift 2;;
+    --brief-file) BRIEF_FILE="$2"; shift 2;;
+    --model) MODEL="$2"; shift 2;;
+    --reasoning-effort) REASONING_EFFORT="$2"; shift 2;;
+    --base) BASE="$2"; shift 2;;
+    --no-pr) OPEN_PR=0; shift;;
+    --dry-run) DRY_RUN=1; shift;;
+    *) echo "worker: unknown arg $1" >&2; exit 2;;
+  esac
+done
+
+if [[ -z "$PROMISE" || -z "$BRIEF_FILE" ]]; then
+  echo "worker: --promise and --brief-file are required" >&2; exit 2
+fi
+if [[ ! -f "$BRIEF_FILE" ]]; then
+  echo "worker: brief file not found: $BRIEF_FILE" >&2; exit 2
+fi
+
+SAFE="$(printf '%s' "$PROMISE" | tr -c 'a-zA-Z0-9._-' '_')"
+WORKTREE="/tmp/cf-${SAFE}"
+BRANCH="codex-fleet/${SAFE}"
+LOG_DIR="/tmp/cf-logs"
+mkdir -p "$LOG_DIR"
+AGENT_LOG="${LOG_DIR}/${SAFE}.agent.log"
+
+# Per-promise isolated CODEX_HOME so concurrent workers never share/overwrite
+# each other's auth.json (the central store hands one account per lease).
+CODEX_HOME_DIR="/tmp/cf-codex-home-${SAFE}"
+LAST_MESSAGE_FILE="${LOG_DIR}/${SAFE}.last.txt"
+
+# Full-trajectory trace (codex exec --json events): persisted + indexed.
+RUN_ID="$(date +%Y%m%dT%H%M%S)-$$"
+CF_TRACE_ROOT="${CF_TRACE_DIR:-$HOME/work/codex-fleet-traces}"
+TRACE_DIR="${CF_TRACE_ROOT}/$(date +%Y-%m-%d)"
+mkdir -p "$TRACE_DIR"
+TRACE="${TRACE_DIR}/${SAFE}.${RUN_ID}.trace.jsonl"
+TRACE_INDEX="${CF_TRACE_ROOT}/index.jsonl"
+
+FETCH_AUTH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fetch-codex-auth.mjs"
+LEASE_REF=""
+
+log() { echo "[worker:${PROMISE}] $*" >&2; }
+
+emit() { printf '%s\n' "$1"; }
+
+result_json() {
+  local status="$1" pr="$2" check="$3" tokens="$4" note="$5"
+  printf '{"promise":"%s","model":"%s","branch":"%s","status":"%s","pr_url":"%s","check_deploy":"%s","tokens":%s,"note":"%s"}' \
+    "$PROMISE" "$MODEL" "$BRANCH" "$status" "$pr" "$check" "${tokens:-null}" "$note"
+}
+
+release_lease() {
+  # Best-effort lease release; never fail the worker on cleanup.
+  if [[ -n "$LEASE_REF" ]]; then
+    node "$FETCH_AUTH" release --leaseRef "$LEASE_REF" --status "${1:-released}" \
+      >>"$AGENT_LOG" 2>&1 || true
+    LEASE_REF=""
+  fi
+}
+trap 'release_lease released' EXIT
+
+# Find the source repo (this script lives inside a checkout). We add the
+# worktree against origin/main so the agent starts from a clean, current base.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_REPO="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$SRC_REPO" ]]; then
+  log "FATAL: not inside a git checkout"
+  emit "$(result_json error "" skipped null "not_in_git_checkout")"; exit 1
+fi
+
+log "src repo: $SRC_REPO"
+log "model:    $MODEL (Codex subscription via central device-flow auth)"
+log "worktree: $WORKTREE  branch: $BRANCH"
+
+# Fresh worktree from origin/main on a new branch.
+# Serialize git-worktree setup: concurrent `git worktree add` on one repo races
+# on git's index/worktree locks. Agent runs stay parallel; only this fast setup
+# is mutually exclusive (mkdir = atomic, macOS-safe). Same lock file name as the
+# retired vertex-fleet so the two never run a concurrent worktree add together.
+CF_GIT_LOCK="${SRC_REPO}/.git/vf-worktree.lock"
+_cf_n=0
+while ! mkdir "$CF_GIT_LOCK" 2>/dev/null; do sleep 0.5; _cf_n=$((_cf_n+1)); [ "$_cf_n" -gt 600 ] && { log "WARN: worktree lock wait timeout; proceeding"; break; }; done
+git -C "$SRC_REPO" fetch origin main --quiet 2>>"$AGENT_LOG" || true
+git -C "$SRC_REPO" worktree remove "$WORKTREE" --force >/dev/null 2>&1 || true
+git -C "$SRC_REPO" worktree prune >/dev/null 2>&1 || true
+git -C "$SRC_REPO" branch -D "$BRANCH" >/dev/null 2>&1 || true
+git -C "$SRC_REPO" worktree add -b "$BRANCH" "$WORKTREE" "$BASE" >>"$AGENT_LOG" 2>&1
+CF_ADD_RC=$?
+rmdir "$CF_GIT_LOCK" 2>/dev/null || true
+if [ "$CF_ADD_RC" != 0 ]; then
+  log "FATAL: could not create worktree (rc=$CF_ADD_RC)"
+  emit "$(result_json error "" skipped null "worktree_add_failed")"; exit 1
+fi
+
+cd "$WORKTREE" || { emit "$(result_json error "" skipped null "cd_worktree_failed")"; exit 1; }
+
+# Pin the base to a fixed SHA. BASE (e.g. "origin/main") is a moving ref: a
+# concurrent push or a later `git fetch` advances it mid-run, which would make
+# the ahead-of-base count below misfire and a real commit look like no_changes.
+BASE_SHA="$(git rev-parse HEAD)"
+log "base pinned: ${BASE_SHA}"
+
+# Install deps so check:deploy can run. Reuse bun's global cache (fast).
+log "installing deps (bun install)..."
+bun install >>"$AGENT_LOG" 2>&1 || log "WARN: bun install returned nonzero (continuing)"
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "DRY RUN: skipping codex agent; brief is:"
+  sed 's/^/    /' "$BRIEF_FILE" >&2
+  emit "$(result_json dry_run "" skipped 0 "dry_run")"; exit 0
+fi
+
+# ---- Fetch Codex auth from the CENTRAL device-flow store ---------------------
+# Writes a codex-native auth.json into the per-promise CODEX_HOME. Captures the
+# leaseRef (public) so we can release the lease on exit. Never prints material.
+log "fetching Codex auth from central device-flow store..."
+export CODEX_HOME="$CODEX_HOME_DIR"
+mkdir -p "$CODEX_HOME"
+set +e
+LEASE_OUT="$(node "$FETCH_AUTH" lease \
+  --action codex_fleet_promise_work \
+  --assignmentId "$SAFE" \
+  --runId "$RUN_ID" 2>>"$AGENT_LOG")"
+FETCH_RC=$?
+set -e 2>/dev/null || true
+if [ "$FETCH_RC" != 0 ]; then
+  log "FATAL: central Codex auth fetch failed (rc=$FETCH_RC); see $AGENT_LOG"
+  emit "$(result_json auth_failed "" skipped null "central_auth_fetch_failed")"; exit 0
+fi
+LEASE_REF="$(printf '%s' "$LEASE_OUT" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s.trim().split("\n").pop()||"{}").leaseRef||"")}catch{process.stdout.write("")}})')"
+if [[ ! -s "$CODEX_HOME/auth.json" ]]; then
+  log "FATAL: auth.json was not materialized under CODEX_HOME"
+  emit "$(result_json auth_failed "" skipped null "auth_json_missing")"; exit 0
+fi
+log "Codex auth materialized (lease acquired); running agent..."
+
+# ---- Run the Codex agent non-interactively -----------------------------------
+# Mirrors the operator's alias: gpt-5.5, xhigh reasoning, bypass approvals+sandbox
+# (the worktree is the externally-managed sandbox). --json streams trace events.
+BRIEF="$(cat "$BRIEF_FILE")"
+log "running codex exec (model=$MODEL, reasoning=$REASONING_EFFORT)..."
+set +e
+# NOTE: stdin MUST be /dev/null. `codex exec` appends piped stdin to the prompt;
+# in a non-interactive/background context an open stdin makes it block forever
+# ("Reading additional input from stdin..."). Closing stdin avoids that hang.
+codex exec "$BRIEF" \
+  -m "$MODEL" \
+  -c model_reasoning_effort="$REASONING_EFFORT" \
+  --dangerously-bypass-approvals-and-sandbox \
+  --skip-git-repo-check \
+  -C "$WORKTREE" \
+  --json \
+  --output-last-message "$LAST_MESSAGE_FILE" \
+  </dev/null >"$TRACE" 2>>"$AGENT_LOG"
+AGENT_RC=$?
+set -e 2>/dev/null || true
+
+# Extract token usage from codex's JSONL trace (token_count events carry usage).
+TOKENS="null"
+if [[ -s "$TRACE" ]]; then
+  TOKENS="$(node -e '
+    try {
+      const fs=require("fs");
+      const lines=fs.readFileSync(process.argv[1],"utf8").trim().split("\n");
+      let inp=0,out=0,total=0,seen=false;
+      for (const l of lines) {
+        let j; try { j=JSON.parse(l); } catch { continue; }
+        // codex emits token usage under a few shapes across versions; scan generically.
+        const u = j?.msg?.info?.total_token_usage ?? j?.info?.total_token_usage ?? j?.usage ?? j?.token_usage ?? j?.msg?.usage;
+        if (u && typeof u==="object") {
+          seen=true;
+          const i = u.input_tokens ?? u.prompt_tokens ?? 0;
+          const o = u.output_tokens ?? u.completion_tokens ?? 0;
+          const t = u.total_tokens ?? (Number(i)+Number(o));
+          inp=Number(i)||inp; out=Number(o)||out; total=Number(t)||total;
+        }
+      }
+      process.stdout.write(seen?JSON.stringify({input:inp,output:out,total:total}):"null");
+    } catch(e){ process.stdout.write("null"); }
+  ' "$TRACE" 2>/dev/null || echo null)"
+fi
+log "agent rc=$AGENT_RC tokens=$TOKENS  trace=$TRACE"
+# Index this run for later traversal.
+printf '{"promise":"%s","model":"%s","run_id":"%s","branch":"%s","trace":"%s","agent_rc":%s,"tokens":%s,"ts":"%s"}\n' \
+  "$PROMISE" "$MODEL" "$RUN_ID" "$BRANCH" "$TRACE" "$AGENT_RC" "${TOKENS:-null}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$TRACE_INDEX" 2>/dev/null || true
+
+# We are done with the subscription seat for this promise; release the lease now
+# so other workers / accounts are not starved while we run check:deploy + push.
+release_lease succeeded
+
+if [[ "$AGENT_RC" != "0" ]]; then
+  log "agent failed (rc=$AGENT_RC); see $AGENT_LOG"
+  emit "$(result_json agent_failed "" skipped "$TOKENS" "agent_rc_${AGENT_RC}")"; exit 0
+fi
+
+# ---- Did the agent actually change anything? --------------------------------
+if git diff --quiet HEAD 2>/dev/null && [[ -z "$(git status --porcelain)" ]]; then
+  AHEAD="$(git rev-list --count "${BASE_SHA}..HEAD" 2>/dev/null || echo 0)"
+  if [[ "$AHEAD" == "0" ]]; then
+    log "agent produced no changes"
+    emit "$(result_json no_changes "" skipped "$TOKENS" "agent_made_no_changes")"; exit 0
+  fi
+fi
+
+# Commit anything the agent left uncommitted.
+if [[ -n "$(git status --porcelain)" ]]; then
+  git add -A
+  git commit -q -m "codex-fleet(${PROMISE}): agent changes (${MODEL} via subscription)" || true
+fi
+
+AHEAD="$(git rev-list --count "${BASE_SHA}..HEAD" 2>/dev/null || echo 0)"
+if [[ "$AHEAD" == "0" ]]; then
+  log "no commits ahead of base after commit attempt"
+  emit "$(result_json no_changes "" skipped "$TOKENS" "no_commits_ahead")"; exit 0
+fi
+
+# ---- check:deploy (the merge gate) ------------------------------------------
+log "running check:deploy..."
+CHECK="fail"
+if bun run check:deploy >>"$AGENT_LOG" 2>&1; then
+  CHECK="pass"
+  log "check:deploy PASSED"
+else
+  CHECK="fail"
+  log "check:deploy FAILED (see $AGENT_LOG)"
+fi
+
+# ---- push branch + open PR (PR-per-agent; NEVER main) ------------------------
+if [[ "$OPEN_PR" != "1" ]]; then
+  emit "$(result_json built_no_pr "" "$CHECK" "$TOKENS" "pr_skipped_by_flag")"; exit 0
+fi
+
+log "pushing branch $BRANCH..."
+if ! git push -u origin "$BRANCH" --force-with-lease >>"$AGENT_LOG" 2>&1; then
+  log "branch push failed"
+  emit "$(result_json push_failed "" "$CHECK" "$TOKENS" "branch_push_failed")"; exit 0
+fi
+
+PR_TITLE="codex-fleet: advance ${PROMISE}"
+PR_BODY="Automated PR opened by a Codex (\`codex exec\`) agent running on the OpenAgents ChatGPT/Codex subscription (model: ${MODEL}).
+
+Promise: \`${PROMISE}\`
+
+check:deploy: **${CHECK}**
+
+Auth: the worker pulled a Codex OAuth token from the CENTRAL device-flow provider-account store in openagents.com (no per-machine interactive login). Guardrails honored: PR-per-agent (branch only, never main), no green flips, isolated worktree, per-promise CODEX_HOME, lease released after the run. Review before merge.
+
+DO NOT MERGE automatically — owner/Raynor reviews and merges.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+
+set +e
+PR_URL="$(gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base main --head "$BRANCH" --repo OpenAgentsInc/openagents 2>>"$AGENT_LOG")"
+PR_RC=$?
+set -e 2>/dev/null || true
+
+if [[ "$PR_RC" != "0" || -z "$PR_URL" ]]; then
+  log "gh pr create failed (rc=$PR_RC)"
+  emit "$(result_json pr_failed "" "$CHECK" "$TOKENS" "gh_pr_create_failed")"; exit 0
+fi
+
+log "PR opened: $PR_URL"
+emit "$(result_json pr_open "$PR_URL" "$CHECK" "$TOKENS" "ok")"

--- a/scripts/vertex-fleet/DEPRECATED.md
+++ b/scripts/vertex-fleet/DEPRECATED.md
@@ -1,0 +1,26 @@
+# vertex-fleet — RETIRED 2026-06-20
+
+**Do not launch new Vertex batches.** This fleet (Anthropic-Claude-on-Vertex) is
+retired.
+
+**Why:** Anthropic Claude on Google Vertex AI is a third-party (partner-model)
+SKU that is **not covered by the GFS credit**, so every Vertex batch was direct
+card spend (metered per input/output token via Google Cloud billing).
+
+**Superseded by:** [`scripts/codex-fleet/`](../codex-fleet/) — the same
+PR-per-agent fleet, but the engine is `codex exec` running on the OpenAgents
+**ChatGPT/Codex subscription** (no per-token card spend), and auth is pulled from
+the **central device-flow provider-account store** in openagents.com (no
+per-machine interactive login). It produces the same shape of PRs (branch prefix
+`codex-fleet/<promise>` instead of `vertex-fleet/<promise>`), so the existing
+merge gate `/tmp/fleet-merge.sh` still gates it unchanged.
+
+**This directory is kept for history only** (the scripts still work if Vertex is
+ever explicitly re-authorized by the owner). Route new fleet work to
+`scripts/codex-fleet/`.
+
+See:
+
+- `scripts/codex-fleet/README.md` — usage + how the central device-flow auth works.
+- `apps/openagents.com/docs/2026-06-05-chatgpt-device-login-operator-runbook.md`
+  — the central ChatGPT/Codex device-login system this fleet authenticates against.


### PR DESCRIPTION
Replaces the Vertex (Anthropic-on-Vertex, **not** GFS-credit-covered -> direct card spend) fleet with a Codex-subscription fleet authed via the **central device-flow tokens** built into openagents.com. Same PR-per-promise shape (branch `codex-fleet/*`) so `/tmp/fleet-merge.sh` still gates it. Vertex fleet marked DEPRECATED (kept for history).

## What changed
- **`scripts/codex-fleet/`** (new): `assign.mjs`, `worker.sh`, `run.sh`, `fetch-codex-auth.mjs`, `README.md` — mirrors `scripts/vertex-fleet/` but swaps the engine to `codex exec` (gpt-5.5, `model_reasoning_effort=xhigh`, `--dangerously-bypass-approvals-and-sandbox`, `--json`) and swaps auth to the central store.
- **`scripts/vertex-fleet/DEPRECATED.md`** + header comment in `vertex-fleet/run.sh`: RETIRED 2026-06-20. Not deleted.

## How the central device-flow auth works (no secrets here)
No per-machine interactive `codex login`. The owner connects ChatGPT/Codex accounts once via the device-code ceremony (`scripts/provider-chatgpt-device-login.mjs`); each cloud worker pulls a short-lived blob over HTTP using two server tokens:

1. **ADMIN** token -> `POST /api/operator/provider-accounts/chatgpt-codex/leases` -> selects a connected+healthy account, returns `{ leaseRef, providerAccountRef }`.
2. **ADMIN** token -> `POST /api/operator/provider-accounts/chatgpt-codex/leases/grant` -> issues a runner-scoped grant, returns `{ grant.grantRef }`.
3. **AGENT** (programmatic-agent bearer) -> `POST /api/provider-accounts/chatgpt-codex/grants/resolve` with `{ grantRef, providerAccountRef, includeAuthMaterial: true }` -> returns `{ authMaterial: { authContentEnv: "OPENCODE_AUTH_CONTENT", authContentJson } }` (the OpenCode/openauth `{openai:{type:oauth,access,refresh,...}}` blob, from behind the server secret boundary).
4. `fetch-codex-auth.mjs` translates that into the codex-native `auth.json` (`{auth_mode:"chatgpt", tokens:{id_token,access_token,refresh_token,account_id}, last_refresh}`) and writes it to a per-promise isolated `CODEX_HOME` (0600). The worker releases the lease after the run.

Tokens on this Mac: `OPENAGENTS_ADMIN_API_TOKEN` (`.secrets/vortex-admin.env`), `OPENAGENTS_AGENT_TOKEN` (`.secrets/openagents-codex-loopwright-agent.env`).

## Guardrails preserved
PR-per-agent (branch only, never main), `mkdir` worktree-lock, worktree-per-promise off `origin/main`, open-PR dedup (matches `codex-fleet/*`), `check:deploy` merge gate, no green flips, no secrets printed/committed, per-promise `CODEX_HOME`.

## Verification
- `node --check assign.mjs fetch-codex-auth.mjs` clean; `bash -n` + shellcheck (0.11.0, -S warning) clean on `run.sh`/`worker.sh`.
- `assign.mjs --priority business` selects real non-green promises and emits codex-framed briefs.
- **Central auth wiring proven against production**: lease -> leases/grant -> grants/resolve all reached; resolve returned the exact owner-gated `provider_account_auth_material_unavailable` because the one connected Codex account is currently `requires_reauth` (owner must reconnect). No secrets leaked.
- **`codex exec` proven**: ran on an isolated `CODEX_HOME` auth.json, `rc=0`, returned the expected output, `--json` trace parsed, token usage extracted (`{input,output,total}`). Found & fixed a real hang: `codex exec` blocks reading stdin in a non-interactive context, so the worker runs it with `</dev/null`.
- No full paid batch was launched.

## Owner action
Reconnect at least one Codex account so leases resolve usable material: `node scripts/provider-chatgpt-device-login.mjs start --email chris@openagents.com --label "codex 1" --create-new`, then `poll` + `sanity`. Check fleet health: `node scripts/codex-fleet/fetch-codex-auth.mjs sanity-all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)