### PR TITLE
Verse: MMO-style multiple characters per account (presence layer)

### DIFF
--- a/apps/autopilot-desktop/src/shared/chat-world-flags.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-flags.ts
@@ -55,6 +55,19 @@ export const agentCharacterCreationFlag = (): boolean =>
 export const chatWorldMultiplayerFlag = (): boolean =>
   verseFeatureFlag("VITE_CHAT_WORLD_MULTIPLAYER")
 
+// MMO character selection (#verse/mmo-characters-per-account). One account can
+// field MANY characters; this app launch picks ONE via OA_CHARACTER. Default
+// "main" so a single instance behaves exactly as before. Two instances on the
+// same account with OA_CHARACTER=main and OA_CHARACTER=alt become two distinct,
+// mutually-visible avatars. Resolved through the same env path as every other
+// Verse setting (Bun host env / Vite define), so there is no new RPC surface.
+// See docs/game/2026-06-21-mmo-characters-per-account-verse-presence.md.
+export const chatWorldCharacterId = (): string => {
+  const raw = envValue("OA_CHARACTER") ?? envValue("VITE_OA_CHARACTER")
+  const trimmed = raw?.trim()
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : "main"
+}
+
 // One switch for visible Verse HUD/actions. Default OFF for the current launch
 // pass: the world remains navigable, but bottom bars and global shortcuts stay
 // dark unless explicitly enabled.

--- a/apps/autopilot-desktop/src/shared/chat-world-multiplayer.test.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-multiplayer.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test"
 
 import {
   estimateChatWorldPresenceFeedLoad,
+  chatWorldDesktopAvatarRef,
   chatWorldMultiplayerSubscriptionQueries,
   chatWorldRegionRefForRun,
   projectChatWorldMultiplayer,
+  sanitizeChatWorldCharacterId,
 } from "./chat-world-multiplayer.js"
 
 const runRef = "run.tassadar.executor.20260615"
@@ -200,5 +202,59 @@ describe("chat world multiplayer projection (#5739)", () => {
     expect(projection.connected).toBe(false)
     expect(projection.projectedAtMs).toBe(1_000)
     expect(projection.agents).toEqual([])
+  })
+
+  test("carries the local per-character avatar key through the projection", () => {
+    const projection = projectChatWorldMultiplayer({
+      flagEnabled: true,
+      runRef,
+      nowMs: 1_000,
+      rows: { stations: [], avatars: [], positions: [], messages: [], attention: [] },
+      localAvatarRef: "avatar.identity.abc.char.alt",
+    })
+    expect(projection.localAvatarRef).toBe("avatar.identity.abc.char.alt")
+  })
+
+  test("defaults the local avatar key to null when no identity is known", () => {
+    const projection = projectChatWorldMultiplayer({
+      flagEnabled: true,
+      runRef,
+      nowMs: 1_000,
+      rows: { stations: [], avatars: [], positions: [], messages: [], attention: [] },
+    })
+    expect(projection.localAvatarRef).toBeNull()
+  })
+})
+
+describe("MMO characters per account avatar keys (#verse/mmo-characters-per-account)", () => {
+  test("builds avatar.identity.<id>.char.<character> keys", () => {
+    expect(chatWorldDesktopAvatarRef("abc123", "main")).toBe(
+      "avatar.identity.abc123.char.main",
+    )
+    expect(chatWorldDesktopAvatarRef("abc123", "alt")).toBe(
+      "avatar.identity.abc123.char.alt",
+    )
+  })
+
+  test("distinct characters under one account produce distinct keys", () => {
+    const main = chatWorldDesktopAvatarRef("abc123", "main")
+    const alt = chatWorldDesktopAvatarRef("abc123", "alt")
+    expect(main).not.toBe(alt)
+  })
+
+  test("same character on different accounts never collides", () => {
+    expect(chatWorldDesktopAvatarRef("aaa", "main")).not.toBe(
+      chatWorldDesktopAvatarRef("bbb", "main"),
+    )
+  })
+
+  test("sanitizes character ids in lockstep with the world module", () => {
+    expect(sanitizeChatWorldCharacterId("")).toBe("main")
+    expect(sanitizeChatWorldCharacterId("   ")).toBe("main")
+    expect(sanitizeChatWorldCharacterId("!!!")).toBe("main")
+    expect(sanitizeChatWorldCharacterId(undefined)).toBe("main")
+    expect(sanitizeChatWorldCharacterId(" alt-2 ")).toBe("alt-2")
+    expect(sanitizeChatWorldCharacterId("a/b c?d")).toBe("abcd")
+    expect(sanitizeChatWorldCharacterId("x".repeat(120)).length).toBe(64)
   })
 })

--- a/apps/autopilot-desktop/src/shared/chat-world-multiplayer.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-multiplayer.ts
@@ -6,7 +6,49 @@ export const PUBLIC_ACTIVITY_TIMELINE_WORLD_RUN_REF = "run.public_activity_timel
 // run ref; subscribe so forum_* events reach the desktop for pylon message icons.
 // Mirrors FORUM_ACTIVITY_WORLD_RUN_REF in chat-world-forum-activity.ts.
 export const PUBLIC_FORUM_ACTIVITY_WORLD_RUN_REF = "run.public_forum_activity"
+// Legacy placeholder for the local desktop avatar self-filter. Retained only as
+// the fallback when the live SpacetimeDB identity is not yet known (pre-connect)
+// so the projection still has a non-empty local ref. Once onConnect yields the
+// real identity, the self-filter uses the per-character key built by
+// `chatWorldDesktopAvatarRef` instead. See
+// docs/game/2026-06-21-mmo-characters-per-account-verse-presence.md.
 export const CHAT_WORLD_DESKTOP_AVATAR_REF = "avatar.desktop.local"
+
+/** Default character id when OA_CHARACTER is unset (one stable character per install). */
+export const DEFAULT_OA_CHARACTER_ID = "main"
+
+const MAX_CHARACTER_ID_CHARS = 64
+
+/**
+ * Normalize a character id the same way the world module's `sanitize_character_id`
+ * does, so the client-computed self-filter key matches the avatar_ref the module
+ * actually writes. Keep this in lockstep with the Rust helper.
+ */
+export const sanitizeChatWorldCharacterId = (
+  characterId: string | null | undefined,
+): string => {
+  const cleaned = (characterId ?? "")
+    .trim()
+    .split("")
+    .filter((ch) => /[A-Za-z0-9._-]/.test(ch))
+    .join("")
+    .slice(0, MAX_CHARACTER_ID_CHARS)
+  return cleaned.length > 0 ? cleaned : DEFAULT_OA_CHARACTER_ID
+}
+
+/**
+ * Build the MMO avatar key for an account identity + chosen character. Mirrors
+ * the world module's `avatar_ref_for_sender`:
+ *   avatar.identity.<identity>.char.<sanitized character id>
+ * Embedding the identity makes ownership automatic (a client only writes under
+ * its own identity) while letting ONE account field MANY simultaneous visible
+ * characters.
+ */
+export const chatWorldDesktopAvatarRef = (
+  identity: string,
+  characterId: string,
+): string =>
+  `avatar.identity.${identity.trim()}.char.${sanitizeChatWorldCharacterId(characterId)}`
 
 export type ChatWorldStationRow = Readonly<{
   pylonRef: string
@@ -99,6 +141,10 @@ export type ChatWorldMultiplayerProjection = Readonly<{
   agents: ReadonlyArray<ChatWorldMultiplayerAgent>
   stations: ReadonlyArray<ChatWorldMultiplayerStation>
   proximityChatCount: number
+  // The local instance's OWN character avatar key, used by the scene to
+  // self-filter (hide only this character, render all others — including other
+  // characters of the same account). Null until the live identity is known.
+  localAvatarRef: string | null
 }>
 
 export type ChatWorldPresenceFeedMode = "single-region" | "split-near-far"
@@ -279,8 +325,10 @@ export const projectChatWorldMultiplayer = (input: {
   readonly nowMs: number
   readonly worldUrl?: string
   readonly database?: string
+  readonly localAvatarRef?: string | null
 }): ChatWorldMultiplayerProjection => {
   const regionRef = chatWorldRegionRefForRun(input.runRef)
+  const localAvatarRef = input.localAvatarRef ?? null
   const rows = input.rows
   if (input.flagEnabled !== true || rows === null) {
     return {
@@ -292,6 +340,7 @@ export const projectChatWorldMultiplayer = (input: {
       agents: [],
       stations: [],
       proximityChatCount: 0,
+      localAvatarRef,
     }
   }
 
@@ -385,5 +434,6 @@ export const projectChatWorldMultiplayer = (input: {
       (count, agent) => count + agent.chatMessages.length,
       0,
     ),
+    localAvatarRef,
   }
 }

--- a/apps/autopilot-desktop/src/shared/chat-world-spacetimedb.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-spacetimedb.ts
@@ -6,6 +6,7 @@ import {
   type ChatWorldMultiplayerRows,
   type ChatWorldPylonAttentionRow,
   type ChatWorldStationRow,
+  DEFAULT_OA_CHARACTER_ID,
   chatWorldRegionRefForRun,
   projectChatWorldMultiplayer,
 } from "./chat-world-multiplayer.js"
@@ -64,6 +65,9 @@ export type ChatWorldAvatarPositionWrite = Readonly<{
   yaw: number
   pitch: number
   movementMode: "idle" | "walking" | "running" | "ghost" | "inspecting"
+  // The character this account is moving. Threaded to the world module so one
+  // account can move many distinct characters; defaults to "main".
+  characterId: string
 }>
 
 export type ChatWorldAvatarPositionPlan =
@@ -323,10 +327,14 @@ export const projectChatWorldSpacetimeRows = (input: {
   readonly nowMs: number
   readonly worldUrl?: string
   readonly database?: string
+  readonly localAvatarRef?: string | null
 }): ChatWorldSpacetimeProjection => {
   const multiplayerOptions = {
     ...(input.worldUrl !== undefined ? { worldUrl: input.worldUrl } : {}),
     ...(input.database !== undefined ? { database: input.database } : {}),
+    ...(input.localAvatarRef !== undefined
+      ? { localAvatarRef: input.localAvatarRef }
+      : {}),
   }
   if (input.rows === null) {
     return {
@@ -399,6 +407,7 @@ export const planChatWorldAvatarPositionWrite = (input: {
   readonly yaw?: number
   readonly pitch?: number
   readonly movementMode?: string
+  readonly characterId?: string
 }): ChatWorldAvatarPositionPlan => {
   const region = input.region
   if (region === null) return { ok: false, reason: "region unavailable" }
@@ -455,6 +464,7 @@ export const planChatWorldAvatarPositionWrite = (input: {
       yaw: Number(yaw.toFixed(3)),
       pitch: Number(pitch.toFixed(3)),
       movementMode: movementMode as ChatWorldAvatarPositionWrite["movementMode"],
+      characterId: input.characterId ?? DEFAULT_OA_CHARACTER_ID,
     },
   }
 }

--- a/apps/autopilot-desktop/src/ui/chat-world-subscriptions.ts
+++ b/apps/autopilot-desktop/src/ui/chat-world-subscriptions.ts
@@ -30,10 +30,13 @@ import {
 } from "../shared/chat-world-scene.js"
 import {
   CHAT_WORLD_DESKTOP_AVATAR_REF,
+  DEFAULT_OA_CHARACTER_ID,
   DEFAULT_TASSADAR_WORLD_RUN_REF,
   OPENAGENTS_WORLD_DATABASE,
   OPENAGENTS_WORLD_URL,
+  chatWorldDesktopAvatarRef,
   chatWorldMultiplayerSubscriptionQueries,
+  sanitizeChatWorldCharacterId,
   type ChatWorldMultiplayerProjection,
 } from "../shared/chat-world-multiplayer.js"
 import {
@@ -268,6 +271,7 @@ export type SpacetimeWorldConnection = Readonly<{
     readonly joinRegion?: (args: {
       readonly regionRef: string
       readonly displayName: string
+      readonly characterId: string
     }) => unknown
     readonly setAvatarPosition?: (args: {
       readonly regionRef: string
@@ -277,9 +281,11 @@ export type SpacetimeWorldConnection = Readonly<{
       readonly yaw: number
       readonly pitch: number
       readonly movementMode: string
+      readonly characterId: string
     }) => unknown
     readonly leaveRegion?: (args: {
       readonly regionRef: string
+      readonly characterId: string
     }) => unknown
   }
   subscriptionBuilder?: () => {
@@ -294,7 +300,10 @@ type SpacetimeWorldConnectInput = Readonly<{
   database: string
   token: string | null
   worldUrl: string
-  onConnected: (token: string | null) => void
+  // `identity` is the live SpacetimeDB account identity (hex). It is the
+  // account axis of the MMO model and is needed to build this instance's own
+  // per-character avatar key for the scene self-filter.
+  onConnected: (token: string | null, identity: string | null) => void
   onDisconnected: () => void
   onUnavailable: () => void
 }>
@@ -331,6 +340,9 @@ export type ChatWorldSpacetimeSubscriptionDeps = ChatWorldSubscriptionDeps & {
     readonly nodeLabel?: string | null
     readonly fallbackActorRef?: string | null
   }
+  // The character this app launch fields (from OA_CHARACTER). Defaults to
+  // "main" so a single instance behaves exactly as before.
+  readonly characterId?: string | null
 }
 
 export type SpacetimeWorldDispatch = (
@@ -383,6 +395,35 @@ const resolveClearTimeout = (
     (globalThis as unknown as { clearTimeout: (h: unknown) => void })
       .clearTimeout(handle))
 
+// The SpacetimeDB SDK hands back an Identity object (or, in older shapes, a
+// hex string). Normalize to the same hex string the module uses in
+// `format!("avatar.identity.{}", ctx.sender())` so the client-computed
+// self-filter key matches the avatar_ref the module writes.
+const identityToHex = (identity: unknown): string | null => {
+  if (typeof identity === "string") {
+    const trimmed = identity.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  if (identity !== null && typeof identity === "object") {
+    const candidate = identity as {
+      toHexString?: () => unknown
+      toString?: () => unknown
+    }
+    const hex =
+      typeof candidate.toHexString === "function"
+        ? candidate.toHexString()
+        : typeof candidate.toString === "function"
+          ? candidate.toString()
+          : null
+    if (typeof hex === "string") {
+      const trimmed = hex.trim()
+      // Object.prototype.toString gives "[object Object]"; reject it.
+      if (trimmed.length > 0 && !trimmed.startsWith("[object")) return trimmed
+    }
+  }
+  return null
+}
+
 const defaultSpacetimeConnect = (
   input: SpacetimeWorldConnectInput,
 ): SpacetimeWorldConnection => {
@@ -391,8 +432,11 @@ const defaultSpacetimeConnect = (
   let builder = builderFactory()
     .withUri(input.worldUrl)
     .withDatabaseName(input.database)
-    .onConnect((_ctx: unknown, _identity: unknown, token: string) =>
-      input.onConnected(typeof token === "string" ? token : null),
+    .onConnect((_ctx: unknown, identity: unknown, token: string) =>
+      input.onConnected(
+        typeof token === "string" ? token : null,
+        identityToHex(identity),
+      ),
     )
     .onConnectError(() => input.onUnavailable())
     .onDisconnect(() => input.onDisconnected())
@@ -497,9 +541,14 @@ export const createVerseMultiplayerClient = (input: {
   readonly runRef: string
   readonly nowMs: () => number
   readonly worldUrl: string
+  // The character this instance fields. One account can run many instances,
+  // each with a distinct characterId, and every distinct character is its own
+  // visible avatar in the world. Omitted/blank → "main".
+  readonly characterId?: string | null
 }): VerseMultiplayerClient => {
   const lastAcceptedByRegion = new Map<string, ReturnType<typeof localPreviousFromWrite>>()
   let joinedRegionRef: string | null = null
+  const characterId = sanitizeChatWorldCharacterId(input.characterId)
 
   const projection = () =>
     projectChatWorldSpacetimeRows({
@@ -518,6 +567,7 @@ export const createVerseMultiplayerClient = (input: {
     invokeMaybePromise(input.connection.reducers?.joinRegion?.({
       regionRef: region.regionRef,
       displayName: input.displayName,
+      characterId,
     }))
   }
 
@@ -525,6 +575,7 @@ export const createVerseMultiplayerClient = (input: {
     if (joinedRegionRef === null) return
     invokeMaybePromise(input.connection.reducers?.leaveRegion?.({
       regionRef: joinedRegionRef,
+      characterId,
     }))
     joinedRegionRef = null
   }
@@ -554,6 +605,7 @@ export const createVerseMultiplayerClient = (input: {
       yaw: pose.yaw,
       pitch: 0,
       movementMode: movementModeForVerseAnimation(pose.animation),
+      characterId,
     })
     if (plan.ok !== true) return plan
     if (!publishSpacetimeAvatarPosition(input.connection, plan)) {
@@ -585,9 +637,18 @@ const attachWorldConnection = (input: {
   readonly nowMs: () => number
   readonly worldUrl: string
   readonly displayName: string
+  readonly characterId: string
+  // Latest resolved per-character self-filter key, or null before the live
+  // identity is known. Read lazily so snapshots dispatched after onConnect
+  // carry the real key.
+  readonly getLocalAvatarRef: () => string | null
   readonly onUnavailable: () => void
   readonly onClientReady?: (client: VerseMultiplayerClient) => void
   readonly onClientGone?: (client: VerseMultiplayerClient) => void
+  // Exposes this connection's snapshot dispatcher so the outer subscription can
+  // force a re-paint once the live identity (and thus the self-filter key)
+  // becomes available after onConnect.
+  readonly onSnapshotReady?: (dispatchSnapshot: () => void) => void
 }): Unsubscribe => {
   const tables = [
     input.connection.db?.worldRegion,
@@ -610,6 +671,7 @@ const attachWorldConnection = (input: {
     runRef: input.runRef,
     nowMs: input.nowMs,
     worldUrl: input.worldUrl,
+    characterId: input.characterId,
   })
   input.onClientReady?.(client)
 
@@ -621,9 +683,11 @@ const attachWorldConnection = (input: {
       nowMs: input.nowMs(),
       worldUrl: input.worldUrl,
       database: input.database,
+      localAvatarRef: input.getLocalAvatarRef(),
     })
     input.dispatch(projection.world)
   }
+  input.onSnapshotReady?.(dispatchSnapshot)
 
   const onRowsChanged = (): void => dispatchSnapshot()
 
@@ -683,11 +747,20 @@ export const subscribeSpacetimeWorld = (
   const maxReconnectAttempts = deps?.maxReconnectAttempts ?? Number.POSITIVE_INFINITY
   const reconnectBaseMs = deps?.reconnectBaseMs ?? 2_000
   const identity = chatWorldDesktopAvatarIdentity(deps?.identity ?? {})
+  const characterId = sanitizeChatWorldCharacterId(deps?.characterId ?? DEFAULT_OA_CHARACTER_ID)
 
   let stopped = false
   let retryHandle: unknown = null
   let cleanupConnection: Unsubscribe | null = null
   let reconnectAttempt = 0
+  // The live SpacetimeDB account identity, once onConnect yields it. Combined
+  // with characterId it gives this instance's own avatar key for self-filter.
+  let liveIdentityHex: string | null = null
+  let redispatchSnapshot: (() => void) | null = null
+  const localAvatarRef = (): string | null =>
+    liveIdentityHex !== null && liveIdentityHex.length > 0
+      ? chatWorldDesktopAvatarRef(liveIdentityHex, characterId)
+      : null
 
   const dispatchUnavailable = (): void => {
     dispatch(projectChatWorldSpacetimeRows({
@@ -727,13 +800,24 @@ export const subscribeSpacetimeWorld = (
     cleanupConnection?.()
     cleanupConnection = null
     try {
+      redispatchSnapshot = null
       const connection = connect({
         database,
         token: storage?.getItem(SPACETIME_TOKEN_STORAGE_KEY) ?? null,
         worldUrl,
-        onConnected: (token) => {
+        onConnected: (token, connectedIdentity) => {
           reconnectAttempt = 0
           if (token !== null) storage?.setItem(SPACETIME_TOKEN_STORAGE_KEY, token)
+          if (
+            typeof connectedIdentity === "string" &&
+            connectedIdentity.length > 0 &&
+            connectedIdentity !== liveIdentityHex
+          ) {
+            liveIdentityHex = connectedIdentity
+            // Re-paint so the scene self-filter switches from the pre-connect
+            // fallback to this instance's real per-character avatar key.
+            redispatchSnapshot?.()
+          }
         },
         onDisconnected: unavailable,
         onUnavailable: unavailable,
@@ -743,10 +827,15 @@ export const subscribeSpacetimeWorld = (
         database,
         dispatch,
         displayName: identity.displayName,
+        characterId,
+        getLocalAvatarRef: localAvatarRef,
         nowMs,
         onUnavailable: unavailable,
         runRef,
         worldUrl,
+        onSnapshotReady: (dispatchSnapshot) => {
+          redispatchSnapshot = dispatchSnapshot
+        },
         onClientReady: (client) => {
           activeVerseMultiplayerClient = client
         },

--- a/apps/autopilot-desktop/src/ui/subscriptions.ts
+++ b/apps/autopilot-desktop/src/ui/subscriptions.ts
@@ -43,6 +43,7 @@ import {
 } from "./chat-world-subscriptions.js"
 import {
   chatWorldBuildFlags,
+  chatWorldCharacterId,
   chatWorldMultiplayerFlag,
 } from "../shared/chat-world-flags.js"
 
@@ -359,7 +360,7 @@ const spacetimeWorldStream: Stream.Stream<Message> = Stream.callback<Message>((q
     Effect.sync(() =>
       subscribeSpacetimeWorld(
         (world) => Queue.offerUnsafe(queue, GotChatWorldMultiplayer({ world })),
-        { flags: chatWorldSubscriptionFlags() },
+        { flags: chatWorldSubscriptionFlags(), characterId: chatWorldCharacterId() },
       ),
     ),
     (unsubscribe) => Effect.sync(() => unsubscribe()),

--- a/apps/autopilot-desktop/src/ui/view.ts
+++ b/apps/autopilot-desktop/src/ui/view.ts
@@ -6872,7 +6872,12 @@ export const verseSceneVisualization = (model: Model): TrainingRunVisualizationO
   const withBase = withPylonBaseLayer(withBulletin, pylonBase)
   const multiplayer = modelChatWorldMultiplayer(model)
   const withWorld = withChatWorldMultiplayerLayer(withBase, multiplayer, {
-    localAvatarRef: CHAT_WORLD_DESKTOP_AVATAR_REF,
+    // Self-filter on THIS instance's own per-character avatar key (computed from
+    // the live SpacetimeDB identity + OA_CHARACTER once known), so each instance
+    // hides only its own character and renders every other avatar — including
+    // other characters of the same account. Falls back to the legacy constant
+    // before the identity lands (pre-connect), when there are no remote rows yet.
+    localAvatarRef: multiplayer?.localAvatarRef ?? CHAT_WORLD_DESKTOP_AVATAR_REF,
   })
   const lastPose =
     model.verseSceneRestorePose === null

--- a/apps/autopilot-desktop/tests/chat-world-spacetimedb.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-spacetimedb.test.ts
@@ -223,8 +223,28 @@ describe("planChatWorldAvatarPositionWrite", () => {
         yaw: 0.123,
         pitch: 0.543,
         movementMode: "walking",
+        // Defaults to the stable single-character id when OA_CHARACTER is unset.
+        characterId: "main",
       },
     })
+  })
+
+  test("threads an explicit characterId into the position write", () => {
+    const plan = planChatWorldAvatarPositionWrite({
+      region: regionRow,
+      previous: null,
+      nowMs: 1_000,
+      x: 0,
+      y: 0,
+      z: 0,
+      characterId: "alt",
+    })
+    expect(plan.ok).toBe(true)
+    if (plan.ok) {
+      // One account moving its "alt" character: the world module derives a
+      // distinct avatar_ref from sender + "alt", so this is its own avatar.
+      expect(plan.write.characterId).toBe("alt")
+    }
   })
 
   test("rejects unsafe local avatar movement writes", () => {

--- a/apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts
@@ -14,6 +14,7 @@ import type {
   PaymentParticle,
 } from "../src/shared/chat-world-scene"
 import {
+  chatWorldDesktopAvatarRef,
   chatWorldRegionRefForRun,
   type ChatWorldMultiplayerProjection,
 } from "../src/shared/chat-world-multiplayer"
@@ -406,6 +407,7 @@ describe("subscribeSpacetimeWorld", () => {
     expect(joins).toEqual([{
       regionRef,
       displayName: "Local Pylon",
+      characterId: "main",
     }])
 
     rows.avatarPosition.insert({
@@ -421,9 +423,81 @@ describe("subscribeSpacetimeWorld", () => {
     expect(worlds.length).toBeGreaterThanOrEqual(2)
 
     stop()
-    expect(leaves).toEqual([{ regionRef }])
+    expect(leaves).toEqual([{ regionRef, characterId: "main" }])
     expect(unsubscribed).toBe(true)
     expect(disconnected).toBe(true)
+  })
+
+  test("self-filters only the local character once the identity is known, rendering other characters of the same account", () => {
+    // MMO model: one account (identity) fields many characters. This instance
+    // is OA_CHARACTER=main; the SAME account also runs OA_CHARACTER=alt in a
+    // second instance. Both characters' avatars exist in the world. The scene
+    // must hide ONLY this instance's own character (main) and render every other
+    // avatar — including the same account's "alt" character and unrelated
+    // remote avatars.
+    const identityHex = "00ff112233445566778899aabbccddee"
+    const localRef = chatWorldDesktopAvatarRef(identityHex, "main")
+    const sameAccountAltRef = chatWorldDesktopAvatarRef(identityHex, "alt")
+    const remoteRef = chatWorldDesktopAvatarRef("99887766554433221100", "main")
+
+    const rows = fakeWorldRows()
+    rows.agentAvatar = new FakeTable([
+      { avatarRef: localRef, actorRef: "a", actorKind: "guest", displayName: "Me (main)" },
+      { avatarRef: sameAccountAltRef, actorRef: "b", actorKind: "guest", displayName: "Me (alt)" },
+      { avatarRef: remoteRef, actorRef: "c", actorKind: "guest", displayName: "Someone else" },
+    ])
+    rows.avatarPosition = new FakeTable([
+      { avatarRef: localRef, regionRef, positionX: 0, positionY: 0, positionZ: 0, yaw: 0, movementMode: "idle", lastSeenEpochMs: 1_000 },
+      { avatarRef: sameAccountAltRef, regionRef, positionX: 2, positionY: 0, positionZ: 2, yaw: 0, movementMode: "idle", lastSeenEpochMs: 1_000 },
+      { avatarRef: remoteRef, regionRef, positionX: 4, positionY: 0, positionZ: 4, yaw: 0, movementMode: "idle", lastSeenEpochMs: 1_000 },
+    ])
+
+    const worlds: ChatWorldMultiplayerProjection[] = []
+    let applied: (() => void) | null = null
+
+    const stop = subscribeSpacetimeWorld((world) => worlds.push(world), {
+      flags: { CHAT_WORLD_MULTIPLAYER: true },
+      runRef,
+      nowMs: () => 1_000,
+      characterId: "main",
+      storage: { getItem: () => null, setItem: () => {} },
+      connect: (input) => {
+        // onConnect yields BOTH the token and the live account identity.
+        input.onConnected("tok", identityHex)
+        const builder = {
+          onApplied: (cb: () => void) => {
+            applied = cb
+            return builder
+          },
+          onError: () => builder,
+          subscribe: () => ({ unsubscribe: () => {} }),
+        }
+        return {
+          db: rows,
+          reducers: { joinRegion: () => {}, leaveRegion: () => {} },
+          subscriptionBuilder: () => builder,
+          disconnect: () => {},
+        }
+      },
+    })
+
+    applied?.()
+    const latest = worlds.at(-1)!
+    // Projection carries this instance's own per-character key.
+    expect(latest.localAvatarRef).toBe(localRef)
+
+    // The scene self-filters on that key: local character hidden, the same
+    // account's other character and the unrelated remote both rendered.
+    const layer = chatWorldMultiplayerLayer(latest, {
+      localAvatarRef: latest.localAvatarRef,
+      nowMs: 1_000,
+    })
+    const rendered = layer.remoteAvatars.map((avatar) => avatar.id)
+    expect(rendered).not.toContain(localRef)
+    expect(rendered).toContain(sameAccountAltRef)
+    expect(rendered).toContain(remoteRef)
+
+    stop()
   })
 
   test("dispatches disconnected fallback and removes stale token when connect fails", () => {
@@ -721,7 +795,7 @@ describe("subscribeSpacetimeWorld", () => {
       capturedAtMs: 2_000,
     })
 
-    expect(joins).toEqual([{ regionRef, displayName: "Local Pylon" }])
+    expect(joins).toEqual([{ regionRef, displayName: "Local Pylon", characterId: "main" }])
     expect(plan).toMatchObject({ ok: true })
     expect(writes).toEqual([{
       regionRef,
@@ -731,6 +805,7 @@ describe("subscribeSpacetimeWorld", () => {
       yaw: 0.123,
       pitch: 0,
       movementMode: "walking",
+      characterId: "main",
     }])
   })
 

--- a/apps/openagents-world-spacetimedb/src/lib.rs
+++ b/apps/openagents-world-spacetimedb/src/lib.rs
@@ -905,10 +905,11 @@ pub fn join_region(
     ctx: &ReducerContext,
     region_ref: String,
     display_name: String,
+    character_id: String,
 ) -> Result<(), String> {
     let region_ref = clean_ref(region_ref, "region_ref", 160)?;
     validate_position_in_region(ctx, &region_ref, 0.0, 0.0, 0.0)?;
-    let avatar_ref = avatar_ref_for_sender(ctx);
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     let display_name = clean_optional_text(display_name, 64)
         .unwrap_or_else(|| format!("agent {}", ctx.sender().to_abbreviated_hex()));
     let existing = ctx.db.agent_avatar().avatar_ref().find(avatar_ref.clone());
@@ -954,8 +955,12 @@ pub fn join_region(
 }
 
 #[spacetimedb::reducer]
-pub fn leave_region(ctx: &ReducerContext, region_ref: String) -> Result<(), String> {
-    let avatar_ref = avatar_ref_for_sender(ctx);
+pub fn leave_region(
+    ctx: &ReducerContext,
+    region_ref: String,
+    character_id: String,
+) -> Result<(), String> {
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     let region_ref = clean_ref(region_ref, "region_ref", 160)?;
     if let Some(position) = ctx
         .db
@@ -1008,6 +1013,7 @@ pub fn set_avatar_position(
     yaw: f64,
     pitch: f64,
     movement_mode: String,
+    character_id: String,
 ) -> Result<(), String> {
     let region_ref = clean_ref(region_ref, "region_ref", 160)?;
     let region = validate_position_in_region(ctx, &region_ref, position_x, position_y, position_z)?;
@@ -1019,7 +1025,7 @@ pub fn set_avatar_position(
         "movement_mode",
         &["idle", "walking", "running", "ghost", "inspecting"],
     )?;
-    let avatar_ref = avatar_ref_for_sender(ctx);
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     ensure_avatar_for_sender(ctx, avatar_ref.clone(), None)?;
     let now_ms = ctx_epoch_ms(ctx);
     if let Some(existing) = ctx
@@ -1064,6 +1070,7 @@ pub fn focus_pylon(
     attention_kind: String,
     distance_meters: f64,
     source_entity_ref: Option<String>,
+    character_id: String,
 ) -> Result<(), String> {
     let pylon_ref = clean_ref(pylon_ref, "pylon_ref", 160)?;
     if ctx
@@ -1080,7 +1087,7 @@ pub fn focus_pylon(
         "attention_kind",
         &["approaching", "nearby", "looking", "inspecting", "talking"],
     )?;
-    let avatar_ref = avatar_ref_for_sender(ctx);
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     ensure_avatar_for_sender(ctx, avatar_ref.clone(), None)?;
     let attention_ref = format!("attention.{pylon_ref}.{avatar_ref}");
     let existing = ctx
@@ -1109,9 +1116,13 @@ pub fn focus_pylon(
 }
 
 #[spacetimedb::reducer]
-pub fn clear_pylon_focus(ctx: &ReducerContext, pylon_ref: String) -> Result<(), String> {
+pub fn clear_pylon_focus(
+    ctx: &ReducerContext,
+    pylon_ref: String,
+    character_id: String,
+) -> Result<(), String> {
     let pylon_ref = clean_ref(pylon_ref, "pylon_ref", 160)?;
-    let avatar_ref = avatar_ref_for_sender(ctx);
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     ctx.db
         .pylon_attention()
         .attention_ref()
@@ -1126,10 +1137,11 @@ pub fn send_local_message(
     target_ref: Option<String>,
     radius_meters: f64,
     body: String,
+    character_id: String,
 ) -> Result<(), String> {
     let region_ref = clean_ref(region_ref, "region_ref", 160)?;
     ensure_world_region(ctx, &region_ref)?;
-    let avatar_ref = avatar_ref_for_sender(ctx);
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     ensure_avatar_for_sender(ctx, avatar_ref.clone(), None)?;
     insert_local_message(
         ctx,
@@ -1148,6 +1160,7 @@ pub fn send_pylon_message(
     ctx: &ReducerContext,
     pylon_ref: String,
     body: String,
+    character_id: String,
 ) -> Result<(), String> {
     let pylon_ref = clean_ref(pylon_ref, "pylon_ref", 160)?;
     let station = ctx
@@ -1156,7 +1169,7 @@ pub fn send_pylon_message(
         .pylon_ref()
         .find(pylon_ref.clone())
         .ok_or_else(|| "pylon message requires an existing pylon_station".to_string())?;
-    let avatar_ref = avatar_ref_for_sender(ctx);
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     ensure_avatar_for_sender(ctx, avatar_ref.clone(), None)?;
     insert_local_message(
         ctx,
@@ -1176,10 +1189,11 @@ pub fn send_emote(
     region_ref: String,
     emote_kind: String,
     target_ref: Option<String>,
+    character_id: String,
 ) -> Result<(), String> {
     let region_ref = clean_ref(region_ref, "region_ref", 160)?;
     ensure_world_region(ctx, &region_ref)?;
-    let avatar_ref = avatar_ref_for_sender(ctx);
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     ensure_avatar_for_sender(ctx, avatar_ref.clone(), None)?;
     let emote_kind = validate_choice(
         emote_kind,
@@ -1204,8 +1218,9 @@ pub fn set_agent_intent(
     ctx: &ReducerContext,
     intent_kind: String,
     target_ref: Option<String>,
+    character_id: String,
 ) -> Result<(), String> {
-    let avatar_ref = avatar_ref_for_sender(ctx);
+    let avatar_ref = avatar_ref_for_sender(ctx, &character_id);
     ensure_avatar_for_sender(ctx, avatar_ref.clone(), None)?;
     let intent_kind = validate_choice(
         intent_kind,
@@ -1766,8 +1781,55 @@ fn insert_local_message(
     Ok(())
 }
 
-fn avatar_ref_for_sender(ctx: &ReducerContext) -> String {
-    format!("avatar.identity.{}", ctx.sender())
+const DEFAULT_CHARACTER_ID: &str = "main";
+const MAX_CHARACTER_ID_CHARS: usize = 64;
+
+/// Derive the avatar key for the sending account + chosen character.
+///
+/// The avatar key embeds the SpacetimeDB identity (the account) AND the
+/// client-supplied `character_id`, so a single account can field many
+/// simultaneously-visible characters while ownership stays automatic: a client
+/// can only ever write under its own `ctx.sender()`.
+fn avatar_ref_for_sender(ctx: &ReducerContext, character_id: &str) -> String {
+    avatar_ref_for_identity(&ctx.sender().to_string(), character_id)
+}
+
+/// Pure avatar-key construction shared by the reducer path and tests.
+///
+/// The key is `avatar.identity.<identity>.char.<sanitized character id>`. The
+/// `<identity>` segment is the account; the `<character id>` segment is the
+/// distinct visible character within that account. Two different sanitized
+/// character ids under the same identity therefore produce two distinct keys
+/// (and thus two distinct `agent_avatar` / `avatar_position` rows, since
+/// `avatar_ref` is the primary key), while ownership stays automatic because a
+/// client can only write under its own identity.
+fn avatar_ref_for_identity(identity: &str, character_id: &str) -> String {
+    format!(
+        "avatar.identity.{}.char.{}",
+        identity,
+        sanitize_character_id(character_id)
+    )
+}
+
+/// Normalize a client-supplied character id into a safe, bounded token.
+///
+/// Trims, lowercases nothing (ids are case-sensitive), keeps only
+/// alphanumeric / dot / dash / underscore, bounds length, and falls back to
+/// `"main"` when the result would otherwise be empty. This never errors so the
+/// presence layer keeps working even if a client sends a junk id; the worst
+/// case is two junk ids collapsing onto the `main` character for that account.
+fn sanitize_character_id(character_id: &str) -> String {
+    let cleaned: String = character_id
+        .trim()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '.' || *ch == '-' || *ch == '_')
+        .take(MAX_CHARACTER_ID_CHARS)
+        .collect();
+    if cleaned.is_empty() {
+        DEFAULT_CHARACTER_ID.to_string()
+    } else {
+        cleaned
+    }
 }
 
 fn ctx_epoch_ms(ctx: &ReducerContext) -> i64 {
@@ -2040,5 +2102,79 @@ fn clean_optional_text(value: String, max_chars: usize) -> Option<String> {
         None
     } else {
         Some(cleaned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SENDER_A: &str = "00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee";
+    const SENDER_B: &str = "11ee223344556677889900aabbccddeeff00112233445566778899aabbccddff";
+
+    #[test]
+    fn distinct_character_ids_under_one_account_produce_distinct_avatar_keys() {
+        // MMO model: one account (identity) can field MANY characters
+        // simultaneously. Each character is a distinct primary-key avatar_ref,
+        // so it becomes its own agent_avatar / avatar_position row with an
+        // independent position. Two desktop instances on the SAME account with
+        // OA_CHARACTER=main and OA_CHARACTER=alt therefore each get their own
+        // visible avatar instead of colliding onto one row.
+        let main = avatar_ref_for_identity(SENDER_A, "main");
+        let alt = avatar_ref_for_identity(SENDER_A, "alt");
+        assert_eq!(main, format!("avatar.identity.{SENDER_A}.char.main"));
+        assert_eq!(alt, format!("avatar.identity.{SENDER_A}.char.alt"));
+        assert_ne!(
+            main, alt,
+            "distinct character ids must key to distinct avatar rows"
+        );
+    }
+
+    #[test]
+    fn same_character_id_under_one_account_is_stable() {
+        // A single character on one account is one stable row across calls
+        // (join/move/leave all derive the same key), so leave_region(character_id)
+        // can target exactly that character's row.
+        let first = avatar_ref_for_identity(SENDER_A, "scout");
+        let second = avatar_ref_for_identity(SENDER_A, "scout");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn ownership_is_partitioned_by_identity() {
+        // Same character id on DIFFERENT accounts must never collide: the
+        // identity segment guarantees a client only ever writes under its own
+        // account, so account A's "main" and account B's "main" are two avatars.
+        let a_main = avatar_ref_for_identity(SENDER_A, "main");
+        let b_main = avatar_ref_for_identity(SENDER_B, "main");
+        assert_ne!(a_main, b_main);
+        assert!(a_main.starts_with(&format!("avatar.identity.{SENDER_A}.char.")));
+        assert!(b_main.starts_with(&format!("avatar.identity.{SENDER_B}.char.")));
+    }
+
+    #[test]
+    fn character_id_is_sanitized_and_bounded() {
+        // Empty / whitespace / junk falls back to "main".
+        assert_eq!(sanitize_character_id(""), DEFAULT_CHARACTER_ID);
+        assert_eq!(sanitize_character_id("   "), DEFAULT_CHARACTER_ID);
+        assert_eq!(sanitize_character_id("!!!"), DEFAULT_CHARACTER_ID);
+        // Surrounding whitespace is trimmed; safe charset is preserved.
+        assert_eq!(sanitize_character_id("  alt-2 "), "alt-2");
+        assert_eq!(sanitize_character_id("Hero_01.beta"), "Hero_01.beta");
+        // Unsafe characters are dropped, not allowed through.
+        assert_eq!(sanitize_character_id("a/b c?d"), "abcd");
+        // Length is bounded.
+        let long = "x".repeat(MAX_CHARACTER_ID_CHARS + 50);
+        assert_eq!(sanitize_character_id(&long).chars().count(), MAX_CHARACTER_ID_CHARS);
+    }
+
+    #[test]
+    fn distinct_raw_ids_that_sanitize_equal_share_a_character() {
+        // " main " and "main" are the same character (sanitization is the
+        // identity of a character within an account).
+        assert_eq!(
+            avatar_ref_for_identity(SENDER_A, " main "),
+            avatar_ref_for_identity(SENDER_A, "main")
+        );
     }
 }

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/clear_pylon_focus_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/clear_pylon_focus_reducer.ts
@@ -12,4 +12,5 @@ import {
 
 export default {
   pylonRef: __t.string(),
+  characterId: __t.string(),
 };

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/focus_pylon_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/focus_pylon_reducer.ts
@@ -15,4 +15,5 @@ export default {
   attentionKind: __t.string(),
   distanceMeters: __t.f64(),
   sourceEntityRef: __t.option(__t.string()),
+  characterId: __t.string(),
 };

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/join_region_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/join_region_reducer.ts
@@ -13,4 +13,5 @@ import {
 export default {
   regionRef: __t.string(),
   displayName: __t.string(),
+  characterId: __t.string(),
 };

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/leave_region_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/leave_region_reducer.ts
@@ -12,4 +12,5 @@ import {
 
 export default {
   regionRef: __t.string(),
+  characterId: __t.string(),
 };

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/send_emote_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/send_emote_reducer.ts
@@ -14,4 +14,5 @@ export default {
   regionRef: __t.string(),
   emoteKind: __t.string(),
   targetRef: __t.option(__t.string()),
+  characterId: __t.string(),
 };

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/send_local_message_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/send_local_message_reducer.ts
@@ -15,4 +15,5 @@ export default {
   targetRef: __t.option(__t.string()),
   radiusMeters: __t.f64(),
   body: __t.string(),
+  characterId: __t.string(),
 };

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/send_pylon_message_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/send_pylon_message_reducer.ts
@@ -13,4 +13,5 @@ import {
 export default {
   pylonRef: __t.string(),
   body: __t.string(),
+  characterId: __t.string(),
 };

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/set_agent_intent_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/set_agent_intent_reducer.ts
@@ -13,4 +13,5 @@ import {
 export default {
   intentKind: __t.string(),
   targetRef: __t.option(__t.string()),
+  characterId: __t.string(),
 };

--- a/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/set_avatar_position_reducer.ts
+++ b/apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/set_avatar_position_reducer.ts
@@ -18,4 +18,5 @@ export default {
   yaw: __t.f64(),
   pitch: __t.f64(),
   movementMode: __t.string(),
+  characterId: __t.string(),
 };

--- a/docs/game/2026-06-21-mmo-characters-per-account-verse-presence.md
+++ b/docs/game/2026-06-21-mmo-characters-per-account-verse-presence.md
@@ -1,0 +1,164 @@
+# MMO-style multiple characters per account — Verse presence layer
+
+Date: 2026-06-21
+Branch: `verse/mmo-characters-per-account`
+Scope: **presence layer only** (avatar identity + rendering). No inventory,
+stats, save-game, or per-character progression — just "who is visible, and as
+whom."
+
+## Problem
+
+Two Autopilot Desktop instances cannot see each other's avatars in the Verse.
+
+Root cause: the world module derives the avatar key **only** from the
+SpacetimeDB identity. In `apps/openagents-world-spacetimedb/src/lib.rs`:
+
+```rust
+fn avatar_ref_for_sender(ctx: &ReducerContext) -> String {
+    format!("avatar.identity.{}", ctx.sender())
+}
+```
+
+`join_region` / `set_avatar_position` / `leave_region` (and the chat/emote/
+intent/attention reducers) all call this with no notion of a character. Since
+`avatar_ref` is the primary key of `agent_avatar` and `avatar_position`, one
+account = exactly one avatar row. Two instances sharing one account/token
+collapse onto the **same** row and overwrite each other's position.
+
+The desktop client compounded the confusion: it self-filtered remote avatars
+against a hardcoded constant `CHAT_WORLD_DESKTOP_AVATAR_REF =
+"avatar.desktop.local"` (`apps/autopilot-desktop/src/shared/chat-world-multiplayer.ts`),
+a value that never matched any real avatar key the module wrote.
+
+## The model
+
+Two orthogonal axes:
+
+- **Account** = the SpacetimeDB identity (`ctx.sender()`) / Pylon agent. A token
+  shared across instances is fine and expected. Ownership: a client can only
+  ever write avatars under its own identity.
+- **Character** = a client-supplied `character_id`. One account can field MANY
+  characters simultaneously, each a distinct, separately-visible avatar.
+
+The avatar key becomes:
+
+```
+avatar.identity.<sender>.char.<character_id>
+```
+
+Embedding the sender keeps ownership automatic (the identity segment is server-
+authoritative — the module always uses `ctx.sender()`, never a client value),
+while the `<character_id>` segment lets one account split into many avatars.
+
+### Character selection
+
+A character is chosen **per app launch** via the `OA_CHARACTER` env var,
+defaulting to a stable per-install value `"main"`. Resolved through the same env
+path as every other Verse setting (`chatWorldCharacterId()` in
+`apps/autopilot-desktop/src/shared/chat-world-flags.ts`), so there is no new RPC
+surface.
+
+```
+OA_CHARACTER=main  ./AutopilotDesktop   # instance A
+OA_CHARACTER=alt   ./AutopilotDesktop   # instance B, SAME account
+```
+
+→ two characters, both visible to each other and to everyone else.
+
+### The separate "distinct account" axis
+
+Multiple *accounts* (rather than multiple characters of one account) remain a
+separate axis: give each instance its own `PYLON_HOME` / profile and webview
+`partition` so they obtain distinct SpacetimeDB identities. That path is out of
+scope for this PR, which focuses on **multiple characters per one account**.
+Because the identity segment partitions the key space, the two axes compose
+cleanly: account A's `main`/`alt` and account B's `main` are three distinct
+avatars.
+
+## Changes
+
+### 1. World module (`apps/openagents-world-spacetimedb/src/lib.rs`)
+
+- Added a `character_id: String` parameter to every reducer that derives an
+  avatar key: `join_region`, `set_avatar_position`, `leave_region`,
+  `focus_pylon`, `clear_pylon_focus`, `send_local_message`, `send_pylon_message`,
+  `send_emote`, `set_agent_intent`.
+- Changed the helper to `avatar_ref_for_sender(ctx, character_id) ->
+  "avatar.identity.<sender>.char.<sanitized id>"`, factored through a pure
+  `avatar_ref_for_identity(identity, character_id)` so it is unit-testable.
+- Added `sanitize_character_id`: trims, keeps only `[A-Za-z0-9._-]`, bounds to
+  64 chars, and falls back to `"main"` when empty. It never errors, so a junk id
+  degrades gracefully (worst case: two junk ids collapse onto `main` for that
+  one account) rather than breaking presence.
+- All other behavior is identical (validation, rate limits, region bounds,
+  stale expiry, attention/chat/emote/intent semantics).
+
+### 2. Regenerated TS bindings
+
+`apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/` regenerated
+with `spacetime generate` (CLI 2.6.0) after a clean WASM build. The diff is
+purely additive: a `characterId: __t.string()` field on each affected reducer
+schema. `index.ts` is unchanged (the regen's incidental `@ts-nocheck`/trailing-
+newline churn was reverted to keep the diff tight).
+
+### 3. Desktop client (`apps/autopilot-desktop`)
+
+- `chatWorldCharacterId()` resolves `OA_CHARACTER` (default `"main"`).
+- `subscribeSpacetimeWorld` resolves the character id and plumbs it into the
+  multiplayer client. The `joinRegion` / `setAvatarPosition` / `leaveRegion`
+  reducer calls now carry `characterId`.
+- The connection's `onConnect(ctx, identity, token)` callback now yields the
+  live SpacetimeDB identity (hex) up through `onConnected`. Once known, the
+  client computes `localAvatarRef = "avatar.identity." + identity + ".char." +
+  characterId` and re-paints so the scene picks it up.
+- Self-filter fix: the projection carries `localAvatarRef`; `view.ts` feeds
+  `multiplayer.localAvatarRef` (falling back to the legacy constant only pre-
+  connect, when there are no remote rows yet) into the scene layer. Each
+  instance now hides **only its own character** and renders all others —
+  including other characters of the same account.
+
+The hex normalization (`identityToHex`) and character-id sanitization
+(`sanitizeChatWorldCharacterId`) mirror the Rust helpers so the client-computed
+self-filter key matches the `avatar_ref` the module actually writes.
+
+## How two instances now render each other
+
+1. Both launch with the same account token but `OA_CHARACTER=main` and
+   `OA_CHARACTER=alt`.
+2. Each `join_region("...", display, character_id)` → the module writes a
+   distinct `agent_avatar` + `avatar_position` row keyed
+   `avatar.identity.<sender>.char.main` and `...char.alt`.
+3. Each instance subscribes to the region's avatars/positions and self-filters
+   on its **own** per-character key, so instance A (main) renders alt, and
+   instance B (alt) renders main. Both avatars move independently.
+
+## Scene stability
+
+This change is additive to the presence projection and reducer args. Avatar/
+pose/stream updates still flow through the same dispatch path; nothing here
+remounts the Three scene or resets pose. The self-filter switch from the
+pre-connect fallback to the real per-character key happens via a normal snapshot
+re-dispatch, not a scene rebuild.
+
+## Test / verify plan
+
+Deterministic checks (no manual screenshots):
+
+- **World module** (`cargo test` in `apps/openagents-world-spacetimedb`):
+  distinct `character_id`s under one sender → distinct avatar keys (→ distinct
+  rows); same id is stable (so `leave_region(character_id)` targets exactly one
+  character); same id on different identities never collides; sanitization is
+  bounded and safe.
+- **Desktop**
+  (`apps/autopilot-desktop/src/shared/chat-world-multiplayer.test.ts`,
+  `tests/chat-world-subscriptions.test.ts`,
+  `tests/chat-world-spacetimedb.test.ts`): avatar-key construction +
+  sanitization; the projection carries `localAvatarRef`; reducer calls carry
+  `characterId`; and an integration-style test that, once the identity is known,
+  the scene self-filters **only** the local character while rendering the same
+  account's other character and unrelated remotes.
+- **Gate**: `bun run check:deploy` (includes the desktop typecheck + Verse test
+  bundle) green.
+
+Manual confirmation (optional): launch two instances with `OA_CHARACTER=a` and
+`OA_CHARACTER=b` on the same account → two avatars visible to each other.


### PR DESCRIPTION
## The model

Two orthogonal axes for Verse presence:

- **Account** = the SpacetimeDB identity (`ctx.sender()`) / Pylon agent. A shared token across instances is fine and expected.
- **Character** = a client-supplied `character_id`. One account can field MANY characters simultaneously, each a distinct, separately-visible avatar.

The avatar key becomes `avatar.identity.<sender>.char.<character_id>`. Embedding the sender keeps ownership automatic (the identity segment is always `ctx.sender()`, never a client value) while letting one account split into many avatars. Character is chosen **per app launch** via `OA_CHARACTER` (default `"main"`).

Honest framing: **this is the presence layer only** — avatar identity + rendering. No inventory, stats, save-game, or per-character progression.

### The bug this fixes
The world module keyed avatars only by identity (`avatar.identity.<sender>`), so two instances sharing one account collapsed onto the same primary-key row and overwrote each other's position. The desktop also self-filtered against a hardcoded `CHAT_WORLD_DESKTOP_AVATAR_REF = "avatar.desktop.local"` that never matched a real key.

### Distinct-account axis (out of scope here)
Multiple *accounts* remain a separate axis via distinct `PYLON_HOME`/profile + webview `partition` (distinct identities). This PR focuses on **multiple characters per one account**; the axes compose because the identity segment partitions the key space.

## Files changed

- **World module** (`apps/openagents-world-spacetimedb/src/lib.rs`): added `character_id: String` to every avatar-scoped reducer (`join_region`, `set_avatar_position`, `leave_region`, `focus_pylon`, `clear_pylon_focus`, `send_local_message`, `send_pylon_message`, `send_emote`, `set_agent_intent`); changed the helper to build `avatar.identity.<sender>.char.<sanitized id>` via a pure, testable `avatar_ref_for_identity`; added `sanitize_character_id` (trim, `[A-Za-z0-9._-]`, ≤64, fallback `"main"`, never errors). All other behavior identical.
- **Desktop** (`apps/autopilot-desktop`): `chatWorldCharacterId()` resolves `OA_CHARACTER`; `subscribeSpacetimeWorld` plumbs it into the multiplayer client and the join/move/leave reducer calls; `onConnect` now surfaces the live SpacetimeDB identity, from which the client computes `localAvatarRef = avatar.identity.<identity>.char.<characterId>`; the projection carries `localAvatarRef` and `view.ts` self-filters on it (falling back to the legacy constant only pre-connect). Each instance now hides only its own character and renders all others.
- **Doc**: `docs/game/2026-06-21-mmo-characters-per-account-verse-presence.md`.

## Bindings

**Regenerated** (not hand-edited) with `spacetime generate --lang typescript` (CLI 2.6.0) after a clean WASM build, into `apps/openagents.com/apps/web/src/scene/spacetimeWorldBindings/`. The diff is purely additive — a `characterId: __t.string()` field on each affected reducer schema. `index.ts` left unchanged (incidental regen churn reverted to keep the diff tight).

## How to test

Deterministic:
- `cd apps/openagents-world-spacetimedb && cargo test` — 5 pass (distinct character_ids → distinct keys/rows; stable single character; ownership partitioned by identity; sanitize bounds).
- `cd apps/openagents.com && bun run check:deploy` — **literal exit 0** (includes the desktop typecheck + Verse test bundle, web/api typechecks + vitest).

Manual:
- Launch two instances with `OA_CHARACTER=a` and `OA_CHARACTER=b` on the **same account** → two avatars, visible to each other.

## Scene stability

Additive to the presence projection + reducer args; avatar/pose/stream updates flow through the same dispatch path. Nothing remounts the Three scene or resets pose; the self-filter switch from the pre-connect fallback to the real per-character key is a normal snapshot re-dispatch.

Do not merge — Raynor/owner reviews.