### PR TITLE
verse: plumb OA_CHARACTER into the desktop webview (two windows -> two distinct avatars)

### DIFF
--- a/apps/autopilot-desktop/src/bun/index.ts
+++ b/apps/autopilot-desktop/src/bun/index.ts
@@ -1259,6 +1259,38 @@ const window = new BrowserWindow({
   rpc,
 })
 
+// #verse/mmo-characters-per-account: the per-instance Verse character.
+//
+// OA_CHARACTER is set on THIS Bun launcher process, but the renderer cannot see
+// it: it is not VITE_-prefixed (so it is absent from the build-time
+// `import.meta.env` define) and there is no `process.env` in the webview. So we
+// resolve it here once and inject it as a global the renderer reads first
+// (chatWorldCharacterId in src/shared/chat-world-flags.ts). Default "main" keeps
+// a single instance identical to before. Two instances launched with
+// OA_CHARACTER=main and OA_CHARACTER=alt become two distinct, mutually-visible
+// avatars.
+const verseCharacter = ((): string => {
+  const trimmed = Bun.env.OA_CHARACTER?.trim()
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : "main"
+})()
+console.log(`[autopilot-desktop] verse character: ${verseCharacter}`)
+const injectVerseCharacter = (): void => {
+  try {
+    window.webview.executeJavascript(
+      `globalThis.__OA_CHARACTER = ${JSON.stringify(verseCharacter)}`,
+    )
+  } catch {
+    // Fail-soft: a missing webview/executeJavascript just leaves the renderer on
+    // its env-fallback ("main"); we re-inject on dom-ready below regardless.
+  }
+}
+// Belt-and-suspenders: inject as early as we can AND once the DOM is ready, so
+// the value is present whether the renderer reads it before or after first
+// paint. The renderer also resolves the character LAZILY (at joinRegion /
+// setAvatarPosition time, well after this fires), so dom-ready timing cannot
+// lose the value.
+injectVerseCharacter()
+
 // CL-30: each poll, fold the session list into the notifier so a session that
 // newly enters a notify-worthy state (needs_decision / failed / completed)
 // updates the in-app notification center.
@@ -1412,6 +1444,7 @@ const autoUpdate = () =>
   })
 
 window.webview.on("dom-ready", () => {
+  injectVerseCharacter()
   poller.start()
   void autoUpdate()
   autoUpdateTimer = setInterval(() => void autoUpdate(), autoUpdateIntervalMs(Bun.env))

--- a/apps/autopilot-desktop/src/shared/chat-world-flags.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-flags.ts
@@ -59,10 +59,21 @@ export const chatWorldMultiplayerFlag = (): boolean =>
 // field MANY characters; this app launch picks ONE via OA_CHARACTER. Default
 // "main" so a single instance behaves exactly as before. Two instances on the
 // same account with OA_CHARACTER=main and OA_CHARACTER=alt become two distinct,
-// mutually-visible avatars. Resolved through the same env path as every other
-// Verse setting (Bun host env / Vite define), so there is no new RPC surface.
-// See docs/game/2026-06-21-mmo-characters-per-account-verse-presence.md.
+// mutually-visible avatars.
+//
+// Plumbing note: OA_CHARACTER is set on the Bun LAUNCHER process at runtime and
+// is NOT VITE_-prefixed, so it is absent from both `import.meta.env` (a
+// build-time Vite define) and the renderer's (non-existent) `process.env`. The
+// Bun host therefore injects the resolved value into the webview as the global
+// `globalThis.__OA_CHARACTER` (see src/bun/index.ts), and we read that FIRST.
+// The env paths remain as fallbacks for Vite builds/tests. See
+// docs/game/2026-06-21-mmo-characters-per-account-verse-presence.md.
 export const chatWorldCharacterId = (): string => {
+  const injected = (globalThis as { __OA_CHARACTER?: unknown }).__OA_CHARACTER
+  if (typeof injected === "string") {
+    const trimmedInjected = injected.trim()
+    if (trimmedInjected.length > 0) return trimmedInjected
+  }
   const raw = envValue("OA_CHARACTER") ?? envValue("VITE_OA_CHARACTER")
   const trimmed = raw?.trim()
   return trimmed !== undefined && trimmed.length > 0 ? trimmed : "main"

--- a/apps/autopilot-desktop/src/ui/chat-world-subscriptions.ts
+++ b/apps/autopilot-desktop/src/ui/chat-world-subscriptions.ts
@@ -64,6 +64,16 @@ export type Unsubscribe = () => void
 
 const noop: Unsubscribe = () => {}
 
+// The character id dep may be an eager value or a lazy getter. Resolving lazily
+// lets a late globalThis.__OA_CHARACTER injection (Bun host → dom-ready) reach
+// join/move-time reducer calls even if the subscription mounted first.
+type ChatWorldCharacterIdInput = string | null | (() => string | null)
+
+const resolveChatWorldCharacterId = (
+  input: ChatWorldCharacterIdInput | undefined,
+): string | null | undefined =>
+  typeof input === "function" ? input() : input
+
 // Injectable seams so the subscriptions are testable headlessly.
 export type ChatWorldSubscriptionDeps = {
   readonly baseUrl?: string
@@ -341,8 +351,11 @@ export type ChatWorldSpacetimeSubscriptionDeps = ChatWorldSubscriptionDeps & {
     readonly fallbackActorRef?: string | null
   }
   // The character this app launch fields (from OA_CHARACTER). Defaults to
-  // "main" so a single instance behaves exactly as before.
-  readonly characterId?: string | null
+  // "main" so a single instance behaves exactly as before. Accepts a getter so
+  // the value can be resolved LAZILY at join/move time — the Bun host injects
+  // globalThis.__OA_CHARACTER (read by chatWorldCharacterId) and that injection
+  // may land after this subscription mounts, so an eager capture could miss it.
+  readonly characterId?: string | null | (() => string | null)
 }
 
 export type SpacetimeWorldDispatch = (
@@ -543,12 +556,17 @@ export const createVerseMultiplayerClient = (input: {
   readonly worldUrl: string
   // The character this instance fields. One account can run many instances,
   // each with a distinct characterId, and every distinct character is its own
-  // visible avatar in the world. Omitted/blank → "main".
-  readonly characterId?: string | null
+  // visible avatar in the world. Omitted/blank → "main". Accepts a getter so the
+  // value is resolved LAZILY at join/move time, after the Bun host has injected
+  // globalThis.__OA_CHARACTER into the webview.
+  readonly characterId?: string | null | (() => string | null)
 }): VerseMultiplayerClient => {
   const lastAcceptedByRegion = new Map<string, ReturnType<typeof localPreviousFromWrite>>()
   let joinedRegionRef: string | null = null
-  const characterId = sanitizeChatWorldCharacterId(input.characterId)
+  // Resolve lazily on every reducer call so a late globalThis.__OA_CHARACTER
+  // injection (dom-ready) is reflected by the time join/move actually fire.
+  const characterId = (): string =>
+    sanitizeChatWorldCharacterId(resolveChatWorldCharacterId(input.characterId))
 
   const projection = () =>
     projectChatWorldSpacetimeRows({
@@ -567,7 +585,7 @@ export const createVerseMultiplayerClient = (input: {
     invokeMaybePromise(input.connection.reducers?.joinRegion?.({
       regionRef: region.regionRef,
       displayName: input.displayName,
-      characterId,
+      characterId: characterId(),
     }))
   }
 
@@ -575,7 +593,7 @@ export const createVerseMultiplayerClient = (input: {
     if (joinedRegionRef === null) return
     invokeMaybePromise(input.connection.reducers?.leaveRegion?.({
       regionRef: joinedRegionRef,
-      characterId,
+      characterId: characterId(),
     }))
     joinedRegionRef = null
   }
@@ -605,7 +623,7 @@ export const createVerseMultiplayerClient = (input: {
       yaw: pose.yaw,
       pitch: 0,
       movementMode: movementModeForVerseAnimation(pose.animation),
-      characterId,
+      characterId: characterId(),
     })
     if (plan.ok !== true) return plan
     if (!publishSpacetimeAvatarPosition(input.connection, plan)) {
@@ -637,7 +655,9 @@ const attachWorldConnection = (input: {
   readonly nowMs: () => number
   readonly worldUrl: string
   readonly displayName: string
-  readonly characterId: string
+  // Lazy character resolver (see resolveChatWorldCharacterId): read at join/move
+  // time so a late globalThis.__OA_CHARACTER injection is honored.
+  readonly characterId: ChatWorldCharacterIdInput
   // Latest resolved per-character self-filter key, or null before the live
   // identity is known. Read lazily so snapshots dispatched after onConnect
   // carry the real key.
@@ -747,7 +767,12 @@ export const subscribeSpacetimeWorld = (
   const maxReconnectAttempts = deps?.maxReconnectAttempts ?? Number.POSITIVE_INFINITY
   const reconnectBaseMs = deps?.reconnectBaseMs ?? 2_000
   const identity = chatWorldDesktopAvatarIdentity(deps?.identity ?? {})
-  const characterId = sanitizeChatWorldCharacterId(deps?.characterId ?? DEFAULT_OA_CHARACTER_ID)
+  // Resolve lazily: the value is read at join/move and self-filter time, after
+  // the Bun host has injected globalThis.__OA_CHARACTER into the webview.
+  const characterId = (): string =>
+    sanitizeChatWorldCharacterId(
+      resolveChatWorldCharacterId(deps?.characterId) ?? DEFAULT_OA_CHARACTER_ID,
+    )
 
   let stopped = false
   let retryHandle: unknown = null
@@ -759,7 +784,7 @@ export const subscribeSpacetimeWorld = (
   let redispatchSnapshot: (() => void) | null = null
   const localAvatarRef = (): string | null =>
     liveIdentityHex !== null && liveIdentityHex.length > 0
-      ? chatWorldDesktopAvatarRef(liveIdentityHex, characterId)
+      ? chatWorldDesktopAvatarRef(liveIdentityHex, characterId())
       : null
 
   const dispatchUnavailable = (): void => {

--- a/apps/autopilot-desktop/src/ui/subscriptions.ts
+++ b/apps/autopilot-desktop/src/ui/subscriptions.ts
@@ -379,7 +379,12 @@ const spacetimeWorldStream: Stream.Stream<Message> = Stream.callback<Message>((q
     Effect.sync(() =>
       subscribeSpacetimeWorld(
         (world) => Queue.offerUnsafe(queue, GotChatWorldMultiplayer({ world })),
-        { flags: chatWorldSubscriptionFlags(), characterId: chatWorldCharacterId() },
+        // Pass the character resolver LAZILY (a getter), not an eager string.
+        // The Bun host injects globalThis.__OA_CHARACTER (chatWorldCharacterId
+        // reads it) and the dom-ready injection may land after this subscription
+        // mounts; resolving at join/move time — after the async SpacetimeDB
+        // connect — makes the value deterministic regardless of inject timing.
+        { flags: chatWorldSubscriptionFlags(), characterId: () => chatWorldCharacterId() },
       ),
     ),
     (unsubscribe) => Effect.sync(() => unsubscribe()),

--- a/apps/autopilot-desktop/tests/chat-world-character.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-character.test.ts
@@ -1,0 +1,80 @@
+// #verse/mmo-characters-per-account: resolving the per-instance Verse character.
+//
+// The bug: OA_CHARACTER is set on the Bun launcher process at runtime but is NOT
+// VITE_-prefixed, so it never reaches the webview/renderer (absent from the
+// build-time `import.meta.env` define, and there is no `process.env` in the
+// renderer). Two Autopilot windows therefore both fell back to "main" and shared
+// one avatar. The fix injects the resolved value into the webview as
+// `globalThis.__OA_CHARACTER`, which chatWorldCharacterId() now reads FIRST.
+//
+// These tests pin that precedence and the "main" default, without a live node.
+
+import { afterEach, describe, expect, test } from "bun:test"
+
+import { chatWorldCharacterId } from "../src/shared/chat-world-flags"
+
+const CHAR_ENV_KEYS = ["OA_CHARACTER", "VITE_OA_CHARACTER"] as const
+
+const savedEnv = new Map<string, string | undefined>(
+  CHAR_ENV_KEYS.map((key) => [key, process.env[key]]),
+)
+
+const injected = (): { __OA_CHARACTER?: unknown } =>
+  globalThis as { __OA_CHARACTER?: unknown }
+
+afterEach(() => {
+  for (const key of CHAR_ENV_KEYS) {
+    const value = savedEnv.get(key)
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  delete injected().__OA_CHARACTER
+})
+
+const clearCharEnv = (): void => {
+  for (const key of CHAR_ENV_KEYS) delete process.env[key]
+  delete injected().__OA_CHARACTER
+}
+
+describe("chatWorldCharacterId resolution", () => {
+  test("defaults to 'main' when nothing is set (single-instance behavior unchanged)", () => {
+    clearCharEnv()
+    expect(chatWorldCharacterId()).toBe("main")
+  })
+
+  test("reads the injected globalThis.__OA_CHARACTER (the webview-plumbing fix)", () => {
+    clearCharEnv()
+    injected().__OA_CHARACTER = "alt"
+    expect(chatWorldCharacterId()).toBe("alt")
+  })
+
+  test("injected value takes precedence over the env fallbacks", () => {
+    clearCharEnv()
+    process.env.OA_CHARACTER = "from-env"
+    process.env.VITE_OA_CHARACTER = "from-vite"
+    injected().__OA_CHARACTER = "from-inject"
+    expect(chatWorldCharacterId()).toBe("from-inject")
+  })
+
+  test("falls back to OA_CHARACTER, then VITE_OA_CHARACTER, when not injected", () => {
+    clearCharEnv()
+    process.env.VITE_OA_CHARACTER = "from-vite"
+    expect(chatWorldCharacterId()).toBe("from-vite")
+    process.env.OA_CHARACTER = "from-env"
+    expect(chatWorldCharacterId()).toBe("from-env")
+  })
+
+  test("trims and ignores a blank/whitespace injected value (falls through to default)", () => {
+    clearCharEnv()
+    injected().__OA_CHARACTER = "   "
+    expect(chatWorldCharacterId()).toBe("main")
+    injected().__OA_CHARACTER = "  alt  "
+    expect(chatWorldCharacterId()).toBe("alt")
+  })
+
+  test("ignores a non-string injected value", () => {
+    clearCharEnv()
+    ;(injected() as { __OA_CHARACTER?: unknown }).__OA_CHARACTER = 42
+    expect(chatWorldCharacterId()).toBe("main")
+  })
+})

--- a/apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts
@@ -428,6 +428,117 @@ describe("subscribeSpacetimeWorld", () => {
     expect(disconnected).toBe(true)
   })
 
+  test("resolves the characterId LAZILY at join time, so a late OA_CHARACTER injection wins", () => {
+    // Regression for the webview-plumbing bug: the Bun host injects
+    // globalThis.__OA_CHARACTER (read by chatWorldCharacterId), and that
+    // injection may land AFTER the subscription mounts. The subscription must
+    // therefore read the character via a getter at join/move time, not capture
+    // it once at construction. Here we pass a getter, then set the value AFTER
+    // constructing the subscription but BEFORE applied()/join fires, and assert
+    // the join (and the self-filter key) use the late value, not a stale capture.
+    const joins: unknown[] = []
+    const leaves: unknown[] = []
+    const rows = fakeWorldRows()
+    let applied: (() => void) | null = null
+    const worlds: ChatWorldMultiplayerProjection[] = []
+    const identityHex = "1122334455667788990011223344556677"
+
+    let liveCharacter: string | null = "main"
+    const stop = subscribeSpacetimeWorld((world) => worlds.push(world), {
+      flags: { CHAT_WORLD_MULTIPLAYER: true },
+      runRef,
+      nowMs: () => 1_000,
+      // Lazy getter, exactly like the real wiring (() => chatWorldCharacterId()).
+      characterId: () => liveCharacter,
+      storage: { getItem: () => null, setItem: () => {} },
+      connect: (input) => {
+        input.onConnected("tok", identityHex)
+        const builder = {
+          onApplied: (cb: () => void) => {
+            applied = cb
+            return builder
+          },
+          onError: () => builder,
+          subscribe: () => ({ unsubscribe: () => {} }),
+        }
+        return {
+          db: rows,
+          reducers: {
+            joinRegion: (args: unknown) => joins.push(args),
+            leaveRegion: (args: unknown) => leaves.push(args),
+          },
+          subscriptionBuilder: () => builder,
+          disconnect: () => {},
+        }
+      },
+    })
+
+    // The injection lands AFTER mount, BEFORE join. A stale eager capture would
+    // still say "main"; the lazy getter must observe "alt".
+    liveCharacter = "alt"
+    applied?.()
+
+    expect(joins).toEqual([{
+      regionRef,
+      displayName: "Autopilot Desktop",
+      characterId: "alt",
+    }])
+    // The self-filter key for this instance must use the SAME late value.
+    expect(worlds.at(-1)!.localAvatarRef).toBe(
+      chatWorldDesktopAvatarRef(identityHex, "alt"),
+    )
+
+    stop()
+    expect(leaves).toEqual([{ regionRef, characterId: "alt" }])
+  })
+
+  test("two distinct resolved character ids produce two distinct avatar / self-filter keys", () => {
+    // Two instances on the SAME account but different OA_CHARACTER values must
+    // become two distinct, mutually-visible avatars (distinct self-filter keys).
+    const identityHex = "00ff112233445566778899aabbccddee"
+    const mainRef = chatWorldDesktopAvatarRef(identityHex, "main")
+    const altRef = chatWorldDesktopAvatarRef(identityHex, "alt")
+    expect(mainRef).not.toBe(altRef)
+
+    const keyFor = (character: string): string | null => {
+      const rows = fakeWorldRows()
+      let applied: (() => void) | null = null
+      const worlds: ChatWorldMultiplayerProjection[] = []
+      const stop = subscribeSpacetimeWorld((world) => worlds.push(world), {
+        flags: { CHAT_WORLD_MULTIPLAYER: true },
+        runRef,
+        nowMs: () => 1_000,
+        characterId: character,
+        storage: { getItem: () => null, setItem: () => {} },
+        connect: (input) => {
+          input.onConnected("tok", identityHex)
+          const builder = {
+            onApplied: (cb: () => void) => {
+              applied = cb
+              return builder
+            },
+            onError: () => builder,
+            subscribe: () => ({ unsubscribe: () => {} }),
+          }
+          return {
+            db: rows,
+            reducers: { joinRegion: () => {}, leaveRegion: () => {} },
+            subscriptionBuilder: () => builder,
+            disconnect: () => {},
+          }
+        },
+      })
+      applied?.()
+      const key = worlds.at(-1)!.localAvatarRef
+      stop()
+      return key
+    }
+
+    expect(keyFor("main")).toBe(mainRef)
+    expect(keyFor("alt")).toBe(altRef)
+    expect(keyFor("main")).not.toBe(keyFor("alt"))
+  })
+
   test("self-filters only the local character once the identity is known, rendering other characters of the same account", () => {
     // MMO model: one account (identity) fields many characters. This instance
     // is OA_CHARACTER=main; the SAME account also runs OA_CHARACTER=alt in a


### PR DESCRIPTION
## Diagnosis

The Autopilot Desktop `OA_CHARACTER` env var never reached the webview/renderer.
It is set on the **Bun launcher process** at runtime and is **not** `VITE_`-prefixed,
so it is absent from the build-time `import.meta.env` define, and there is no
`process.env` in the renderer. `chatWorldCharacterId()` (which runs in the
renderer) therefore always fell back to `"main"`.

Result: two `autopilot2` windows both resolved character `"main"`, shared one
avatar in the Verse, and could not see each other. The SpacetimeDB server side
(per-character `character_id` reducers/bindings) was already fixed/deployed in
#5951 — this PR closes the purely client-side env-plumbing gap.

## Fix

1. **Bun host → webview injection** (`src/bun/index.ts`): resolve the character
   once from `Bun.env.OA_CHARACTER` (trim; empty → `"main"`), log it
   (`[autopilot-desktop] verse character: …`), and inject it into the webview as
   `globalThis.__OA_CHARACTER` via `window.webview.executeJavascript(...)` — both
   at window creation and on `dom-ready` (belt-and-suspenders), `JSON.stringify`-
   quoted and fail-soft.
2. **Renderer read** (`src/shared/chat-world-flags.ts`): `chatWorldCharacterId()`
   reads `globalThis.__OA_CHARACTER` **first** (string, trimmed, non-empty), then
   falls back to the existing `OA_CHARACTER` / `VITE_OA_CHARACTER` env paths, then
   `"main"`.
3. **Lazy read** (`src/ui/subscriptions.ts`, `src/ui/chat-world-subscriptions.ts`):
   the `characterId` dep is now threaded as a getter (`() => chatWorldCharacterId()`)
   and resolved at `joinRegion` / `setAvatarPosition` / `localAvatarRef` time —
   after the async SpacetimeDB connect — so a `dom-ready` injection that lands
   after the subscription mounts can't be missed by an eager capture. The
   self-filter key uses the same lazily-resolved id.

**Default behavior is unchanged:** with no `OA_CHARACTER` set, every path resolves
`"main"` exactly as before.

## How to test

- Launch two `autopilot2` desktop instances, one with `OA_CHARACTER=main` and one
  with `OA_CHARACTER=alt`. Each window now logs its resolved character, joins the
  Verse as a **distinct** avatar, and the two windows see each other (the
  self-filter only hides the local instance's own character).
- Unit/integration:
  - `apps/autopilot-desktop/tests/chat-world-character.test.ts` — `__OA_CHARACTER`
    precedence, env fallback order, `"main"` default, trimming, non-string rejection.
  - `apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts` — the id is read
    **lazily** (set after constructing the subscription, before join) and two distinct
    character ids yield two distinct avatar / self-filter keys.
- `cd apps/openagents.com && bun install && bun run check:deploy` → exit 0
  (desktop typecheck + Verse test bundle + web/api typechecks/tests all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)