### PR TITLE
mcp(#5992): JSON-RPC transport handler (POST /api/mcp)

### DIFF
--- a/apps/openagents.com/workers/api/src/crm-mcp-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-routes.test.ts
@@ -1,0 +1,144 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  CRM_MCP_PROTOCOL_VERSION,
+  type CrmMcpCatalog,
+  emptyCrmMcpCatalog,
+  makeCrmMcpRoutes,
+} from './crm-mcp-routes'
+
+type TestEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
+const ctx = {} as ExecutionContext
+const env: TestEnv = { OPENAGENTS_DB: {} as unknown as D1Database }
+
+const run = (
+  admin: boolean,
+  catalog: CrmMcpCatalog<TestEnv>,
+  request: Request,
+): Promise<Response> => {
+  const routes = makeCrmMcpRoutes<TestEnv>({
+    catalog,
+    requireAdminApiToken: () => Promise.resolve(admin),
+  })
+  const effect = routes.routeCrmMcpRequest(request, env, ctx)
+  if (effect === undefined) throw new Error(`route did not match: ${request.url}`)
+  return Effect.runPromise(effect)
+}
+
+const rpc = (body: unknown): Request =>
+  new Request('https://openagents.com/api/mcp', {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  })
+
+const req = (id: unknown, method: string, params?: unknown) => ({
+  ...(params === undefined ? {} : { params }),
+  id,
+  jsonrpc: '2.0',
+  method,
+})
+
+describe('CRM MCP transport — lifecycle', () => {
+  test('initialize returns protocol version, capabilities, and server info', async () => {
+    const res = await run(true, emptyCrmMcpCatalog(), rpc(req(1, 'initialize')))
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as {
+      result: { protocolVersion: string; capabilities: Record<string, unknown>; serverInfo: { name: string } }
+    }
+    expect(json.result.protocolVersion).toBe(CRM_MCP_PROTOCOL_VERSION)
+    expect(json.result.capabilities).toHaveProperty('tools')
+    expect(json.result.capabilities).toHaveProperty('resources')
+    expect(json.result.serverInfo.name).toBe('openagents-crm-mcp')
+  })
+
+  test('ping returns an empty result', async () => {
+    const res = await run(true, emptyCrmMcpCatalog(), rpc(req(2, 'ping')))
+    const json = (await res.json()) as { result: unknown }
+    expect(json.result).toEqual({})
+  })
+
+  test('notifications/initialized returns 202 with no body', async () => {
+    const res = await run(true, emptyCrmMcpCatalog(), rpc({ jsonrpc: '2.0', method: 'notifications/initialized' }))
+    expect(res.status).toBe(202)
+  })
+})
+
+describe('CRM MCP transport — tools', () => {
+  test('tools/list returns the catalog tools', async () => {
+    const catalog: CrmMcpCatalog<TestEnv> = {
+      ...emptyCrmMcpCatalog<TestEnv>(),
+      listTools: () =>
+        Promise.resolve([
+          { description: 'List contacts', inputSchema: { type: 'object' }, name: 'crm.contacts.list', title: 'List contacts' },
+        ]),
+    }
+    const res = await run(true, catalog, rpc(req(3, 'tools/list')))
+    const json = (await res.json()) as { result: { tools: Array<{ name: string }> } }
+    expect(json.result.tools[0]?.name).toBe('crm.contacts.list')
+  })
+
+  test('tools/call dispatches to the catalog', async () => {
+    const catalog: CrmMcpCatalog<TestEnv> = {
+      ...emptyCrmMcpCatalog<TestEnv>(),
+      callTool: (_e, _r, name) =>
+        Promise.resolve({ content: [{ text: `called ${name}`, type: 'text' as const }] }),
+    }
+    const res = await run(true, catalog, rpc(req(4, 'tools/call', { arguments: {}, name: 'crm.contacts.list' })))
+    const json = (await res.json()) as { result: { content: Array<{ text: string }>; isError?: boolean } }
+    expect(json.result.content[0]?.text).toBe('called crm.contacts.list')
+    expect(json.result.isError).toBeUndefined()
+  })
+
+  test('tools/call on an unknown tool returns an isError result (not a transport error)', async () => {
+    const res = await run(true, emptyCrmMcpCatalog(), rpc(req(5, 'tools/call', { name: 'crm.nope' })))
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { result: { isError: boolean; content: Array<{ text: string }> } }
+    expect(json.result.isError).toBe(true)
+    expect(json.result.content[0]?.text).toContain('Unknown tool')
+  })
+
+  test('tools/call without a name is invalid params', async () => {
+    const res = await run(true, emptyCrmMcpCatalog(), rpc(req(6, 'tools/call', {})))
+    const json = (await res.json()) as { error: { code: number } }
+    expect(json.error.code).toBe(-32602)
+  })
+})
+
+describe('CRM MCP transport — errors + auth', () => {
+  test('401 without an admin token', async () => {
+    const res = await run(false, emptyCrmMcpCatalog(), rpc(req(7, 'initialize')))
+    expect(res.status).toBe(401)
+  })
+
+  test('405 on a non-POST method', async () => {
+    const res = await run(true, emptyCrmMcpCatalog(), new Request('https://openagents.com/api/mcp', { method: 'GET' }))
+    expect(res.status).toBe(405)
+  })
+
+  test('unknown method is method-not-found', async () => {
+    const res = await run(true, emptyCrmMcpCatalog(), rpc(req(8, 'frobnicate')))
+    const json = (await res.json()) as { error: { code: number } }
+    expect(json.error.code).toBe(-32601)
+  })
+
+  test('malformed JSON-RPC is a parse error', async () => {
+    const res = await run(true, emptyCrmMcpCatalog(), rpc({ not: 'jsonrpc' }))
+    const json = (await res.json()) as { error: { code: number } }
+    expect(json.error.code).toBe(-32700)
+  })
+
+  test('non-/api/mcp path passes through', () => {
+    const routes = makeCrmMcpRoutes<TestEnv>({
+      catalog: emptyCrmMcpCatalog(),
+      requireAdminApiToken: () => Promise.resolve(true),
+    })
+    const effect = routes.routeCrmMcpRequest(
+      new Request('https://openagents.com/api/operator/crm/contacts', { method: 'POST' }),
+      env,
+      ctx,
+    )
+    expect(effect).toBeUndefined()
+  })
+})

--- a/apps/openagents.com/workers/api/src/crm-mcp-routes.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-routes.ts
@@ -1,0 +1,280 @@
+/**
+ * MCP JSON-RPC transport handler — `POST /api/mcp` (epic #5991, sub-issue #5992).
+ *
+ * A stateless Streamable-HTTP JSON-RPC endpoint mounted in the Worker omni
+ * cascade. It speaks the MCP lifecycle (`initialize`, `notifications/*`,
+ * `ping`) and the tool/resource methods (`tools/list`, `tools/call`,
+ * `resources/list`, `resources/read`), delegating the actual catalog to an
+ * INJECTED `CrmMcpCatalog`. This issue ships the transport + an empty catalog;
+ * the CRM read tools (#5993) and resources (#5994) provide the real catalog.
+ *
+ * MCP is a projection of the existing CRM HTTP routes — it creates no new
+ * authority. Auth is at the transport boundary (admin token first, #5995 adds
+ * scoped grants). Protocol failures are JSON-RPC errors; tool failures are
+ * returned as `isError` tool results so MCP clients see them as tool errors,
+ * not transport errors.
+ */
+import { Effect, Schema as S } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+
+type HttpResponse = globalThis.Response
+
+/**
+ * Typed adapter error so catalog promise calls use `Effect.tryPromise` with a
+ * typed `catch` (no untyped-catch warning, and not a counted `Effect.promise`
+ * route-dependency adapter).
+ */
+class CrmMcpAdapterError extends S.TaggedErrorClass<CrmMcpAdapterError>()(
+  'CrmMcpAdapterError',
+  { message: S.String, unknownTarget: S.Boolean },
+) {}
+
+const adapterError = (error: unknown): CrmMcpAdapterError =>
+  new CrmMcpAdapterError({
+    message: error instanceof Error ? error.message : String(error),
+    unknownTarget:
+      error instanceof Error &&
+      (error.message === 'unknown_tool' || error.message === 'unknown_resource'),
+  })
+
+export const CRM_MCP_PATH = '/api/mcp'
+// Protocol version we advertise; clients negotiate against their own.
+export const CRM_MCP_PROTOCOL_VERSION = '2025-06-18'
+export const CRM_MCP_SERVER_INFO = {
+  name: 'openagents-crm-mcp',
+  title: 'OpenAgents CRM',
+  version: '0.1.0',
+} as const
+
+// --- MCP wire shapes (server-side; minimal, self-contained) ----------------
+
+export type McpToolListing = Readonly<{
+  name: string
+  title: string
+  description: string
+  inputSchema: Readonly<Record<string, unknown>>
+  annotations?: Readonly<Record<string, unknown>>
+}>
+
+export type McpToolContentBlock = Readonly<{ type: 'text'; text: string }>
+
+export type McpToolCallOutcome = Readonly<{
+  content: ReadonlyArray<McpToolContentBlock>
+  isError?: boolean
+  structuredContent?: unknown
+}>
+
+export type McpResourceListing = Readonly<{
+  uri: string
+  name: string
+  title?: string
+  description?: string
+  mimeType?: string
+}>
+
+export type McpResourceReadOutcome = Readonly<{
+  contents: ReadonlyArray<Readonly<{ uri: string; mimeType: string; text: string }>>
+}>
+
+/**
+ * The catalog the transport delegates to. Implemented for real in #5993/#5994;
+ * `(env, request)` give it the D1 binding + the caller (for grant/tenant).
+ */
+export type CrmMcpCatalog<Bindings> = Readonly<{
+  listTools: (env: Bindings, request: Request) => Promise<ReadonlyArray<McpToolListing>>
+  callTool: (
+    env: Bindings,
+    request: Request,
+    name: string,
+    args: unknown,
+  ) => Promise<McpToolCallOutcome>
+  listResources: (env: Bindings, request: Request) => Promise<ReadonlyArray<McpResourceListing>>
+  readResource: (
+    env: Bindings,
+    request: Request,
+    uri: string,
+  ) => Promise<McpResourceReadOutcome>
+}>
+
+/** The empty catalog used until the CRM tools/resources land (#5993/#5994). */
+export const emptyCrmMcpCatalog = <Bindings>(): CrmMcpCatalog<Bindings> => ({
+  callTool: () => Promise.reject(new Error('unknown_tool')),
+  listResources: () => Promise.resolve([]),
+  listTools: () => Promise.resolve([]),
+  readResource: () => Promise.reject(new Error('unknown_resource')),
+})
+
+// --- JSON-RPC helpers -------------------------------------------------------
+
+type JsonRpcId = string | number | null
+
+const JSONRPC = '2.0' as const
+
+const rpcResult = (id: JsonRpcId, result: unknown): HttpResponse =>
+  noStoreJsonResponse({ id, jsonrpc: JSONRPC, result })
+
+const rpcError = (
+  id: JsonRpcId,
+  code: number,
+  message: string,
+  data?: unknown,
+): HttpResponse =>
+  noStoreJsonResponse({
+    error: data === undefined ? { code, message } : { code, data, message },
+    id,
+    jsonrpc: JSONRPC,
+  })
+
+// JSON-RPC standard codes
+const PARSE_ERROR = -32700
+const INVALID_REQUEST = -32600
+const METHOD_NOT_FOUND = -32601
+const INVALID_PARAMS = -32602
+const INTERNAL_ERROR = -32603
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+type CrmMcpEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
+
+type CrmMcpRouteDependencies<Bindings extends CrmMcpEnv> = Readonly<{
+  requireAdminApiToken: (request: Request, env: Bindings) => Promise<boolean>
+  catalog: CrmMcpCatalog<Bindings>
+}>
+
+export const makeCrmMcpRoutes = <Bindings extends CrmMcpEnv>(
+  dependencies: CrmMcpRouteDependencies<Bindings>,
+) => ({
+  routeCrmMcpRequest: (
+    request: Request,
+    env: Bindings,
+    _ctx?: ExecutionContext,
+  ): Effect.Effect<HttpResponse> | undefined => {
+    const url = new URL(request.url)
+    if (url.pathname !== CRM_MCP_PATH) {
+      return undefined
+    }
+    if (request.method !== 'POST') {
+      return Effect.succeed(methodNotAllowed(['POST']))
+    }
+
+    return Effect.gen(function* () {
+      // Transport-level auth (admin token first; scoped grants in #5995).
+      const authorized = yield* Effect.tryPromise({
+        catch: () => false as const,
+        try: () => dependencies.requireAdminApiToken(request, env),
+      })
+      if (!authorized) {
+        // 401 at the transport boundary, matching the contract's needs_auth status.
+        return noStoreJsonResponse(
+          { error: { code: INVALID_REQUEST, message: 'unauthorized' }, id: null, jsonrpc: JSONRPC },
+          { status: 401 },
+        )
+      }
+
+      const body = yield* Effect.tryPromise({
+        catch: () => null,
+        try: () => request.json() as Promise<unknown>,
+      })
+      if (!isRecord(body) || body.jsonrpc !== JSONRPC || typeof body.method !== 'string') {
+        return rpcError(null, PARSE_ERROR, 'invalid JSON-RPC request')
+      }
+
+      const id: JsonRpcId =
+        typeof body.id === 'string' || typeof body.id === 'number' ? body.id : null
+      const method = body.method
+      const params = isRecord(body.params) ? body.params : {}
+      // Notifications carry no id and expect no response body.
+      const isNotification = body.id === undefined || body.id === null
+
+      switch (method) {
+        case 'initialize':
+          return rpcResult(id, {
+            capabilities: { resources: {}, tools: {} },
+            protocolVersion: CRM_MCP_PROTOCOL_VERSION,
+            serverInfo: CRM_MCP_SERVER_INFO,
+          })
+        case 'ping':
+          return rpcResult(id, {})
+        case 'notifications/initialized':
+        case 'notifications/cancelled':
+          // Acknowledge notifications with 202 + no body.
+          return new Response(null, { status: 202 })
+        case 'tools/list':
+          return yield* Effect.tryPromise({
+            catch: adapterError,
+            try: () => dependencies.catalog.listTools(env, request),
+          }).pipe(
+            Effect.map(tools => rpcResult(id, { tools })),
+            Effect.catch(() => Effect.succeed(rpcError(id, INTERNAL_ERROR, 'tools/list failed'))),
+          )
+        case 'tools/call': {
+          const name = typeof params.name === 'string' ? params.name : ''
+          if (name === '') {
+            return rpcError(id, INVALID_PARAMS, 'tools/call requires a tool name')
+          }
+          const args = isRecord(params.arguments) ? params.arguments : {}
+          return yield* Effect.tryPromise({
+            catch: adapterError,
+            try: () => dependencies.catalog.callTool(env, request, name, args),
+          }).pipe(
+            Effect.map(outcome => rpcResult(id, outcome)),
+            Effect.catch(error =>
+              Effect.succeed(
+                rpcResult(id, {
+                  content: [
+                    {
+                      text: error.unknownTarget
+                        ? `Unknown tool: ${name}`
+                        : `Tool error: ${error.message}`,
+                      type: 'text',
+                    },
+                  ],
+                  isError: true,
+                } satisfies McpToolCallOutcome),
+              ),
+            ),
+          )
+        }
+        case 'resources/list':
+          return yield* Effect.tryPromise({
+            catch: adapterError,
+            try: () => dependencies.catalog.listResources(env, request),
+          }).pipe(
+            Effect.map(resources => rpcResult(id, { resources })),
+            Effect.catch(() => Effect.succeed(rpcError(id, INTERNAL_ERROR, 'resources/list failed'))),
+          )
+        case 'resources/read': {
+          const uri = typeof params.uri === 'string' ? params.uri : ''
+          if (uri === '') {
+            return rpcError(id, INVALID_PARAMS, 'resources/read requires a uri')
+          }
+          return yield* Effect.tryPromise({
+            catch: adapterError,
+            try: () => dependencies.catalog.readResource(env, request, uri),
+          }).pipe(
+            Effect.map(outcome => rpcResult(id, outcome)),
+            Effect.catch(error =>
+              Effect.succeed(
+                rpcError(
+                  id,
+                  INVALID_PARAMS,
+                  error.unknownTarget ? `Unknown resource: ${uri}` : `Resource error: ${error.message}`,
+                ),
+              ),
+            ),
+          )
+        }
+        default:
+          return isNotification
+            ? new Response(null, { status: 202 })
+            : rpcError(id, METHOD_NOT_FOUND, `method not found: ${method}`)
+      }
+    }).pipe(
+      Effect.catch(() =>
+        Effect.succeed(rpcError(null, INTERNAL_ERROR, 'internal MCP error')),
+      ),
+    )
+  },
+})

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -444,6 +444,7 @@ import {
   readSelectedInferenceCreditTargetUser as readSelectedInferenceCreditTargetUserBase,
 } from './operator-targets'
 import { makeCrmBatchRoutes } from './crm-batch-routes'
+import { emptyCrmMcpCatalog, makeCrmMcpRoutes } from './crm-mcp-routes'
 import { makeCrmCommandRoutes } from './crm-command-routes'
 import { makeCrmEmailRoutes } from './crm-email-routes'
 import { makeCrmImportRoutes } from './crm-import-routes'
@@ -7119,6 +7120,13 @@ const crmBatchRoutes = makeCrmBatchRoutes<WorkerBindings>({
   resolveResendDeps: resolveCrmResendDeps,
 })
 
+// CRM MCP server (epic #5991). The transport ships with an empty catalog;
+// CRM read tools (#5993) + resources (#5994) provide the real catalog.
+const crmMcpRoutes = makeCrmMcpRoutes<WorkerBindings>({
+  catalog: emptyCrmMcpCatalog<WorkerBindings>(),
+  requireAdminApiToken: (request, env) => requireAdminApiToken(request, env),
+})
+
 const agentScopedGrantRoutes = makeAgentScopedGrantRoutes({
   requireAdminApiToken: (request, env) => requireAdminApiToken(request, env),
   appOrigin: getAppOrigin,
@@ -10014,6 +10022,7 @@ const routeRequest = makeWorkerRouteRequest({
     crmSendRoutes.routeCrmSendRequest(request, env, ctx) ??
     crmCommandRoutes.routeCrmCommandRequest(request, env, ctx) ??
     crmBatchRoutes.routeCrmBatchRequest(request, env, ctx) ??
+    crmMcpRoutes.routeCrmMcpRequest(request, env, ctx) ??
     crmRoutes.routeCrmRequest(request, env, ctx),
   routeOnboardingRequest: onboardingRoutes.routeOnboardingRequest,
   routeNexusPylonVisibilityRequest:


### PR DESCRIPTION
Part of epic #5991. Adds the stateless Streamable-HTTP JSON-RPC MCP transport (`POST /api/mcp`) in the Worker omni cascade — `initialize`/`ping`/notifications + tools/resources methods, delegating to an injected catalog (empty until #5993/#5994). Admin-auth at the transport boundary; protocol errors → JSON-RPC, tool errors → isError results. 12 tests; `check:deploy` green; architecture adapters 18/18.

Closes #5992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)