### PR TITLE
mcp(#5993): CRM read-only tool catalog (Wave 1)

### DIFF
--- a/apps/openagents.com/workers/api/src/crm-mcp.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp.test.ts
@@ -1,0 +1,91 @@
+import { assertValidOpenAgentsMcpName } from '@openagentsinc/mcp-contract'
+import { describe, expect, test } from 'vitest'
+
+import { CRM_MCP_READ_TOOLS, makeCrmMcpReadCatalog } from './crm-mcp'
+
+const contactRow = {
+  contact_type: 'investor',
+  created_at: '2026-06-22T00:00:00.000Z',
+  full_name: 'Ada Lovelace',
+  id: 'crm_contact_1',
+  primary_email: 'ada@example.com',
+  tenant_ref: 'tenant.openagents',
+  updated_at: '2026-06-22T00:00:00.000Z',
+}
+
+const cannedDb = (): D1Database => {
+  const firstFor = (q: string): Record<string, unknown> | null =>
+    q.includes('FROM crm_contacts') ? contactRow : null
+  const allFor = (q: string): Array<Record<string, unknown>> =>
+    q.includes('FROM crm_contacts') ? [contactRow] : []
+  const statement = (q: string): D1PreparedStatement =>
+    ({
+      bind: () => statement(q),
+      first: <T,>() => Promise.resolve(firstFor(q) as T | null),
+      all: <T,>() =>
+        Promise.resolve({ meta: {} as D1Meta, results: allFor(q) as unknown as Array<T>, success: true } as D1Result<T>),
+      run: () => Promise.resolve({ meta: {} as D1Meta, results: [], success: true } as unknown as D1Result),
+      raw: () => Promise.reject(new Error('raw')),
+    }) as unknown as D1PreparedStatement
+  return {
+    batch: () => Promise.reject(new Error('batch')),
+    dump: () => Promise.reject(new Error('dump')),
+    exec: () => Promise.reject(new Error('exec')),
+    prepare: (q: string) => statement(q),
+    withSession: () => {
+      throw new Error('session')
+    },
+  } as unknown as D1Database
+}
+
+type TestEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
+const env: TestEnv = { OPENAGENTS_DB: cannedDb() }
+const req = new Request('https://openagents.com/api/mcp', { method: 'POST' })
+const catalog = makeCrmMcpReadCatalog<TestEnv>()
+
+describe('CRM MCP read catalog — listing', () => {
+  test('exposes 15 read tools with valid names + input schemas', async () => {
+    const tools = await catalog.listTools(env, req)
+    expect(tools).toHaveLength(15)
+    for (const tool of tools) {
+      expect(() => assertValidOpenAgentsMcpName(tool.name)).not.toThrow()
+      expect(tool.inputSchema).toHaveProperty('type', 'object')
+      expect(tool.annotations).toMatchObject({ readOnlyHint: true })
+    }
+    expect(tools.map(t => t.name)).toContain('crm.contacts.list')
+    expect(tools.map(t => t.name)).toContain('crm.contact.render')
+  })
+
+  test('every descriptor is operator_read + read_only with no receipt', () => {
+    for (const d of CRM_MCP_READ_TOOLS) {
+      expect(d.requiredAuthorities).toEqual(['operator_read'])
+      expect(d.riskClass).toBe('read_only')
+      expect(d.receiptBehavior).toBe('none')
+    }
+  })
+})
+
+describe('CRM MCP read catalog — dispatch', () => {
+  test('crm.contacts.list returns structured contacts + JSON text', async () => {
+    const outcome = await catalog.callTool(env, req, 'crm.contacts.list', { limit: 10 })
+    expect(outcome.isError).toBe(false)
+    expect(Array.isArray(outcome.structuredContent)).toBe(true)
+    const list = outcome.structuredContent as Array<{ primaryEmail: string }>
+    expect(list[0]?.primaryEmail).toBe('ada@example.com')
+    expect(outcome.content[0]?.text).toContain('ada@example.com')
+  })
+
+  test('crm.contact.get resolves a contact by id', async () => {
+    const outcome = await catalog.callTool(env, req, 'crm.contact.get', { contactId: 'crm_contact_1' })
+    const contact = outcome.structuredContent as { id: string }
+    expect(contact.id).toBe('crm_contact_1')
+  })
+
+  test('crm.contact.get without contactId is a tool error (rejects)', async () => {
+    await expect(catalog.callTool(env, req, 'crm.contact.get', {})).rejects.toThrow('contactId is required')
+  })
+
+  test('an unknown tool rejects with unknown_tool', async () => {
+    await expect(catalog.callTool(env, req, 'crm.nope', {})).rejects.toThrow('unknown_tool')
+  })
+})

--- a/apps/openagents.com/workers/api/src/crm-mcp.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp.ts
@@ -1,0 +1,268 @@
+/**
+ * CRM MCP tool catalog — Wave 1, read-only (epic #5991, sub-issue #5993).
+ *
+ * Builds the catalog the transport (#5992) delegates to: schema-bound MCP tool
+ * descriptors (from `@openagentsinc/mcp-contract`) for the read surface of the
+ * CRM, dispatch to the existing `crm-*` store/read functions, and result
+ * projection through the contract's output-safety helpers. No new authority —
+ * each tool wraps a read the admin HTTP routes already expose. All
+ * `operator_read`, `read_only`, no receipts. Resources land in #5994; grant
+ * filtering + tenant binding in #5995.
+ */
+import {
+  type OpenAgentsMcpToolDescriptor,
+  projectOpenAgentsMcpOutput,
+} from '@openagentsinc/mcp-contract'
+
+import {
+  composeCrmEmailForContact,
+  listCrmEmailMessagesForContact,
+  listCrmEmailTemplates,
+  listCrmQueuedGmailMessages,
+} from './crm-email'
+import { listCrmCommands } from './crm-command'
+import type { CrmMcpCatalog, McpToolCallOutcome, McpToolListing } from './crm-mcp-routes'
+import {
+  DEFAULT_CRM_TENANT_REF,
+  getCrmAccountById,
+  getCrmContactById,
+  getCrmEngagementSnapshot,
+  getCrmOpportunityById,
+  listCrmAccounts,
+  listCrmActivitiesForContact,
+  listCrmContactLists,
+  listCrmContacts,
+  listCrmOpportunities,
+  listCrmSourceImportRuns,
+} from './crm-store'
+import { readEmailSendEligibility } from './email-preferences'
+import { openAgentsDatabase } from './runtime'
+
+type CrmMcpEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
+
+const SOURCE = 'docs/mcp/2026-06-22-crm-mcp-server-phase-1-audit.md'
+
+/**
+ * Typed tool error. The transport (crm-mcp-routes) inspects `instanceof Error` +
+ * `.message` (e.g. `unknown_tool`) to shape an isError result, so this stays an
+ * Error subclass rather than a generic thrown Error.
+ */
+class CrmMcpToolError extends Error {}
+
+// --- input arg helpers ------------------------------------------------------
+
+const args = (value: unknown): Record<string, unknown> =>
+  typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
+
+const tenantOf = (a: Record<string, unknown>): string =>
+  typeof a.tenant === 'string' && a.tenant.trim() !== '' ? a.tenant.trim() : DEFAULT_CRM_TENANT_REF
+
+const requiredId = (a: Record<string, unknown>, key: string): string => {
+  const value = a[key]
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new CrmMcpToolError(`${key} is required`)
+  }
+  return value.trim()
+}
+
+const optLimit = (a: Record<string, unknown>): number | undefined => {
+  const value = a.limit
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+const optSearch = (a: Record<string, unknown>): string | undefined =>
+  typeof a.search === 'string' ? a.search : undefined
+
+// --- JSON Schemas emitted in tools/list (the wire `inputSchema`) ------------
+
+const TENANT_PROP = { description: 'Tenant ref (defaults to the bound tenant).', type: 'string' }
+const LIMIT_PROP = { description: 'Max rows to return.', type: 'integer' }
+
+const listSchema = (): Record<string, unknown> => ({
+  additionalProperties: false,
+  properties: { limit: LIMIT_PROP, tenant: TENANT_PROP },
+  type: 'object',
+})
+
+const idSchema = (idKey: string, idDesc: string): Record<string, unknown> => ({
+  additionalProperties: false,
+  properties: { [idKey]: { description: idDesc, type: 'string' }, tenant: TENANT_PROP },
+  required: [idKey],
+  type: 'object',
+})
+
+const CRM_MCP_INPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
+  'crm.account.get': idSchema('accountId', 'CRM account id.'),
+  'crm.accounts.list': listSchema(),
+  'crm.commands.list': {
+    additionalProperties: false,
+    properties: {
+      limit: LIMIT_PROP,
+      status: { description: 'Filter by command status (e.g. proposed).', type: 'string' },
+      tenant: TENANT_PROP,
+    },
+    type: 'object',
+  },
+  'crm.contact.activities.list': idSchema('contactId', 'CRM contact id.'),
+  'crm.contact.emails.list': idSchema('contactId', 'CRM contact id.'),
+  'crm.contact.engagement.get': idSchema('contactId', 'CRM contact id.'),
+  'crm.contact.get': idSchema('contactId', 'CRM contact id.'),
+  'crm.contact.render': {
+    additionalProperties: false,
+    properties: {
+      contactId: { description: 'CRM contact id.', type: 'string' },
+      template: { description: 'Template slug to render.', type: 'string' },
+      tenant: TENANT_PROP,
+    },
+    required: ['contactId', 'template'],
+    type: 'object',
+  },
+  'crm.contacts.list': {
+    additionalProperties: false,
+    properties: {
+      limit: LIMIT_PROP,
+      search: { description: 'Substring match on email or full name.', type: 'string' },
+      tenant: TENANT_PROP,
+    },
+    type: 'object',
+  },
+  'crm.gmail.queue.list': listSchema(),
+  'crm.imports.list': listSchema(),
+  'crm.lists.list': { additionalProperties: false, properties: { tenant: TENANT_PROP }, type: 'object' },
+  'crm.opportunities.list': listSchema(),
+  'crm.opportunity.get': idSchema('opportunityId', 'CRM opportunity id.'),
+  'crm.templates.list': { additionalProperties: false, properties: { tenant: TENANT_PROP }, type: 'object' },
+}
+
+// --- tool descriptors -------------------------------------------------------
+
+const readTool = (
+  name: string,
+  title: string,
+  description: string,
+): OpenAgentsMcpToolDescriptor => ({
+  description,
+  inputSchemaRef: `${name}.input`,
+  name,
+  outputSchemaRef: `${name}.output`,
+  progressBehavior: 'none',
+  publicSummary: title,
+  receiptBehavior: 'none',
+  requiredAuthorities: ['operator_read'],
+  riskClass: 'read_only',
+  sourceRefs: [SOURCE],
+  title,
+})
+
+export const CRM_MCP_READ_TOOLS: ReadonlyArray<OpenAgentsMcpToolDescriptor> = [
+  readTool('crm.contacts.list', 'List contacts', 'List CRM contacts for the tenant (optional search + limit).'),
+  readTool('crm.contact.get', 'Get contact', 'Read one CRM contact by id.'),
+  readTool('crm.contact.activities.list', 'List contact activities', "Read a contact's activity timeline."),
+  readTool('crm.contact.engagement.get', 'Get contact engagement', "Read a contact's engagement snapshot."),
+  readTool('crm.contact.emails.list', 'List contact emails', "Read a contact's CRM send ledger."),
+  readTool('crm.accounts.list', 'List accounts', 'List CRM accounts for the tenant.'),
+  readTool('crm.account.get', 'Get account', 'Read one CRM account by id.'),
+  readTool('crm.lists.list', 'List contact lists', 'List CRM contact lists (segments).'),
+  readTool('crm.opportunities.list', 'List opportunities', 'List CRM opportunities for the tenant.'),
+  readTool('crm.opportunity.get', 'Get opportunity', 'Read one CRM opportunity by id.'),
+  readTool('crm.imports.list', 'List import runs', 'List CRM CSV import-run audit rows.'),
+  readTool('crm.templates.list', 'List email templates', 'List CRM email templates for the tenant.'),
+  readTool('crm.contact.render', 'Render contact email', 'Compose a personalized email preview for a contact + report send eligibility. Sends nothing.'),
+  readTool('crm.gmail.queue.list', 'List Gmail queue', 'List queued Gmail (gws) messages awaiting the local executor.'),
+  readTool('crm.commands.list', 'List send commands', 'List approval-gated send_email commands (e.g. status=proposed).'),
+]
+
+// --- dispatch (read fns) ----------------------------------------------------
+
+type CrmReadHandler = (db: D1Database, a: Record<string, unknown>) => Promise<unknown>
+
+const CRM_MCP_READ_DISPATCH: Readonly<Record<string, CrmReadHandler>> = {
+  'crm.account.get': (db, a) => getCrmAccountById(db, tenantOf(a), requiredId(a, 'accountId')),
+  'crm.accounts.list': (db, a) => listCrmAccounts(db, tenantOf(a), { limit: optLimit(a) }),
+  'crm.commands.list': (db, a) =>
+    listCrmCommands(db, tenantOf(a), {
+      limit: optLimit(a),
+      status: typeof a.status === 'string' ? a.status : undefined,
+    }),
+  'crm.contact.activities.list': (db, a) =>
+    listCrmActivitiesForContact(db, tenantOf(a), requiredId(a, 'contactId'), { limit: optLimit(a) }),
+  'crm.contact.emails.list': (db, a) =>
+    listCrmEmailMessagesForContact(db, tenantOf(a), requiredId(a, 'contactId'), { limit: optLimit(a) }),
+  'crm.contact.engagement.get': (db, a) =>
+    getCrmEngagementSnapshot(db, tenantOf(a), requiredId(a, 'contactId')),
+  'crm.contact.get': (db, a) => getCrmContactById(db, tenantOf(a), requiredId(a, 'contactId')),
+  'crm.contact.render': async (db, a) => {
+    const composed = await composeCrmEmailForContact(db, {
+      contactId: requiredId(a, 'contactId'),
+      templateSlug: requiredId(a, 'template'),
+      tenantRef: tenantOf(a),
+    })
+    const eligibility = await readEmailSendEligibility(db, {
+      category: 'marketing',
+      email: composed.toEmail,
+    })
+    return {
+      eligibility,
+      message: {
+        bodyHtml: composed.bodyHtml,
+        bodyMarkdown: composed.bodyMarkdown,
+        contactId: composed.contact.id,
+        subject: composed.subject,
+        templateId: composed.template.id,
+        toEmail: composed.toEmail,
+      },
+    }
+  },
+  'crm.contacts.list': (db, a) =>
+    listCrmContacts(db, tenantOf(a), { limit: optLimit(a), search: optSearch(a) }),
+  'crm.gmail.queue.list': (db, a) => listCrmQueuedGmailMessages(db, tenantOf(a), { limit: optLimit(a) }),
+  'crm.imports.list': (db, a) => listCrmSourceImportRuns(db, tenantOf(a), { limit: optLimit(a) }),
+  'crm.lists.list': (db, a) => listCrmContactLists(db, tenantOf(a)),
+  'crm.opportunities.list': (db, a) => listCrmOpportunities(db, tenantOf(a), { limit: optLimit(a) }),
+  'crm.opportunity.get': (db, a) => getCrmOpportunityById(db, tenantOf(a), requiredId(a, 'opportunityId')),
+  'crm.templates.list': (db, a) => listCrmEmailTemplates(db, tenantOf(a)),
+}
+
+// --- catalog ----------------------------------------------------------------
+
+const toolListing = (descriptor: OpenAgentsMcpToolDescriptor): McpToolListing => ({
+  annotations: { readOnlyHint: true },
+  description: descriptor.description,
+  inputSchema: CRM_MCP_INPUT_SCHEMAS[descriptor.name] ?? { type: 'object' },
+  name: descriptor.name,
+  title: descriptor.title,
+})
+
+/** Project read data into a safe MCP tool result (operator class). */
+const projectReadOutcome = (name: string, data: unknown): McpToolCallOutcome => {
+  const text = JSON.stringify(data, null, 2)
+  const projection = projectOpenAgentsMcpOutput({
+    maxTextBytes: 131072,
+    outputRef: `mcp.crm.${name}`,
+    safetyClass: 'operator',
+    sourceRefs: [`tool.${name}`],
+    text,
+  })
+  if (projection.text === undefined) {
+    return { content: [{ text: projection.summary, type: 'text' }], isError: true }
+  }
+  return {
+    content: [{ text: projection.text, type: 'text' }],
+    isError: false,
+    structuredContent: data,
+  }
+}
+
+export const makeCrmMcpReadCatalog = <Bindings extends CrmMcpEnv>(): CrmMcpCatalog<Bindings> => ({
+  callTool: async (env, _request, name, callArgs) => {
+    const handler = CRM_MCP_READ_DISPATCH[name]
+    if (handler === undefined) {
+      throw new CrmMcpToolError('unknown_tool')
+    }
+    const data = await handler(openAgentsDatabase(env), args(callArgs))
+    return projectReadOutcome(name, data)
+  },
+  listResources: () => Promise.resolve([]),
+  listTools: () => Promise.resolve(CRM_MCP_READ_TOOLS.map(toolListing)),
+  readResource: () => Promise.reject(new CrmMcpToolError('unknown_resource')),
+})

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -444,7 +444,8 @@ import {
   readSelectedInferenceCreditTargetUser as readSelectedInferenceCreditTargetUserBase,
 } from './operator-targets'
 import { makeCrmBatchRoutes } from './crm-batch-routes'
-import { emptyCrmMcpCatalog, makeCrmMcpRoutes } from './crm-mcp-routes'
+import { makeCrmMcpReadCatalog } from './crm-mcp'
+import { makeCrmMcpRoutes } from './crm-mcp-routes'
 import { makeCrmCommandRoutes } from './crm-command-routes'
 import { makeCrmEmailRoutes } from './crm-email-routes'
 import { makeCrmImportRoutes } from './crm-import-routes'
@@ -7120,10 +7121,10 @@ const crmBatchRoutes = makeCrmBatchRoutes<WorkerBindings>({
   resolveResendDeps: resolveCrmResendDeps,
 })
 
-// CRM MCP server (epic #5991). The transport ships with an empty catalog;
-// CRM read tools (#5993) + resources (#5994) provide the real catalog.
+// CRM MCP server (epic #5991): read-only tool catalog (#5993). Resources
+// (#5994) and grant filtering (#5995) extend this same catalog.
 const crmMcpRoutes = makeCrmMcpRoutes<WorkerBindings>({
-  catalog: emptyCrmMcpCatalog<WorkerBindings>(),
+  catalog: makeCrmMcpReadCatalog<WorkerBindings>(),
   requireAdminApiToken: (request, env) => requireAdminApiToken(request, env),
 })
 


### PR DESCRIPTION
Part of epic #5991. Adds the CRM read-only MCP tool catalog (`crm-mcp.ts`): 15 schema-bound tools wrapping the existing CRM reads, a JSON-Schema catalog for `tools/list`, dispatch to the store/read fns, and `projectOpenAgentsMcpOutput` (operator safety) on every result. Swaps the empty catalog for the real one. No new authority. 6 tests; `check:deploy` green.

Closes #5993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)