### PR TITLE
mcp(#5995): scoped MCP grant + tenant binding

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0220_crm_mcp_grants.sql
+++ b/apps/openagents.com/workers/api/migrations/0220_crm_mcp_grants.sql
@@ -1,0 +1,25 @@
+-- 0220_crm_mcp_grants.sql
+--
+-- Scoped MCP grants for the CRM MCP server (epic #5991, sub-issue #5995).
+--
+-- A scoped MCP credential is server-authoritative: it binds a set of authority
+-- classes (e.g. operator_read) AND a single tenant_ref to a hashed token. The
+-- MCP transport authenticates a request to exactly one principal — the admin
+-- token (full grant) or a scoped grant row here — and the catalog filters
+-- tools/resources by the granted authorities and reads only the bound tenant.
+-- The raw token is never stored (only its SHA-256), and is shown once at mint.
+
+CREATE TABLE IF NOT EXISTS crm_mcp_grants (
+  id TEXT PRIMARY KEY NOT NULL,
+  grant_ref TEXT NOT NULL UNIQUE,
+  token_hash TEXT NOT NULL UNIQUE,
+  tenant_ref TEXT NOT NULL,
+  authority_classes_json TEXT NOT NULL DEFAULT '[]',
+  label TEXT,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked')),
+  created_at TEXT NOT NULL,
+  expires_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS crm_mcp_grants_tenant_idx
+  ON crm_mcp_grants(tenant_ref, created_at DESC);

--- a/apps/openagents.com/workers/api/src/crm-mcp-grant-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-grant-routes.test.ts
@@ -1,0 +1,115 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { makeCrmMcpGrantRoutes } from './crm-mcp-grant-routes'
+
+type GrantRow = {
+  grant_ref: string
+  token_hash: string
+  tenant_ref: string
+  authority_classes_json: string
+  label: string | null
+  status: string
+  created_at: string
+  expires_at: string | null
+}
+
+const makeDb = () => {
+  const rows: Array<GrantRow> = []
+  const statement = (q: string, bound: ReadonlyArray<unknown> = []): D1PreparedStatement =>
+    ({
+      bind: (...v: ReadonlyArray<unknown>) => statement(q, v),
+      first: <T,>() => Promise.resolve(null as T | null),
+      all: <T,>() => {
+        const tenant = String(bound[0] ?? '')
+        return Promise.resolve({
+          meta: {} as D1Meta,
+          results: rows.filter(r => r.tenant_ref === tenant) as unknown as Array<T>,
+          success: true,
+        } as D1Result<T>)
+      },
+      run: () => {
+        if (q.includes('INSERT INTO crm_mcp_grants')) {
+          const [, grantRef, tokenHash, tenantRef, authoritiesJson, label, createdAt, expiresAt] = bound
+          rows.push({
+            authority_classes_json: String(authoritiesJson),
+            created_at: String(createdAt),
+            expires_at: expiresAt === null ? null : String(expiresAt),
+            grant_ref: String(grantRef),
+            label: label === null ? null : String(label),
+            status: 'active',
+            tenant_ref: String(tenantRef),
+            token_hash: String(tokenHash),
+          })
+          return Promise.resolve({ meta: { changes: 1 } as D1Meta, results: [], success: true } as unknown as D1Result)
+        }
+        return Promise.resolve({ meta: { changes: 0 } as D1Meta, results: [], success: true } as unknown as D1Result)
+      },
+      raw: () => Promise.reject(new Error('raw')),
+    }) as unknown as D1PreparedStatement
+  return {
+    batch: () => Promise.reject(new Error('batch')),
+    dump: () => Promise.reject(new Error('dump')),
+    exec: () => Promise.reject(new Error('exec')),
+    prepare: (q: string) => statement(q),
+    withSession: () => {
+      throw new Error('session')
+    },
+  } as unknown as D1Database
+}
+
+type Env = Readonly<{ OPENAGENTS_DB: D1Database }>
+const ctx = {} as ExecutionContext
+
+const run = (admin: boolean, db: D1Database, request: Request): Promise<Response> => {
+  const routes = makeCrmMcpGrantRoutes<Env>({
+    requireAdminApiToken: () => Promise.resolve(admin),
+  })
+  const effect = routes.routeCrmMcpGrantRequest(request, { OPENAGENTS_DB: db }, ctx)
+  if (effect === undefined) throw new Error(`route did not match: ${request.url}`)
+  return Effect.runPromise(effect)
+}
+
+const url = 'https://openagents.com/api/operator/crm/mcp-grants'
+const post = (body: unknown): Request =>
+  new Request(url, { body: JSON.stringify(body), headers: { 'content-type': 'application/json' }, method: 'POST' })
+
+describe('CRM MCP grant routes', () => {
+  test('POST mints a grant and returns the token once (201)', async () => {
+    const res = await run(true, makeDb(), post({ authorities: ['operator_read'], label: 'bot', tenant: 'tenant.acme' }))
+    expect(res.status).toBe(201)
+    const json = (await res.json()) as { grant: { tenantRef: string }; token: string }
+    expect(json.token.startsWith('oa_mcp_')).toBe(true)
+    expect(json.grant.tenantRef).toBe('tenant.acme')
+  })
+
+  test('POST with no valid authorities is a 400', async () => {
+    const res = await run(true, makeDb(), post({ authorities: ['bogus'] }))
+    expect(res.status).toBe(400)
+  })
+
+  test('GET lists grants for the tenant', async () => {
+    const db = makeDb()
+    const run1 = (request: Request) => run(true, db, request)
+    await run1(post({ authorities: ['operator_read'], tenant: 'tenant.acme' }))
+    const res = await run1(new Request(`${url}?tenant=tenant.acme`, { method: 'GET' }))
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { grants: Array<{ authorities: string[] }> }
+    expect(json.grants).toHaveLength(1)
+  })
+
+  test('401 without an admin token', async () => {
+    const res = await run(false, makeDb(), post({ authorities: ['operator_read'] }))
+    expect(res.status).toBe(401)
+  })
+
+  test('non-grant path passes through', () => {
+    const routes = makeCrmMcpGrantRoutes<Env>({ requireAdminApiToken: () => Promise.resolve(true) })
+    const effect = routes.routeCrmMcpGrantRequest(
+      new Request('https://openagents.com/api/operator/crm/contacts'),
+      { OPENAGENTS_DB: makeDb() },
+      ctx,
+    )
+    expect(effect).toBeUndefined()
+  })
+})

--- a/apps/openagents.com/workers/api/src/crm-mcp-grant-routes.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-grant-routes.ts
@@ -1,0 +1,131 @@
+/**
+ * Admin routes to mint / list / revoke scoped CRM MCP grants (epic #5991, #5995).
+ *
+ *   POST   /api/operator/crm/mcp-grants   { tenant?, authorities[], label?, expiresAt? }
+ *          -> { grant: summary, token }   (token shown ONCE)
+ *   GET    /api/operator/crm/mcp-grants?tenant=   -> { grants: summary[] }
+ *   DELETE /api/operator/crm/mcp-grants/:grantRef -> { revoked: boolean }
+ *
+ * Admin-gated. The minted token authenticates an MCP client at `POST /api/mcp`
+ * with exactly the declared authorities + bound tenant.
+ */
+import { Effect, Schema as S } from 'effect'
+
+import {
+  CRM_MCP_AUTHORITY_CLASSES,
+  listCrmMcpGrants,
+  mintCrmMcpGrant,
+  revokeCrmMcpGrant,
+} from './crm-mcp-grant'
+import { DEFAULT_CRM_TENANT_REF } from './crm-store'
+import { isRecord, stringArrayFromUnknown } from './json-boundary'
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import { openAgentsDatabase } from './runtime'
+
+type HttpResponse = globalThis.Response
+
+class CrmMcpGrantRouteError extends S.TaggedErrorClass<CrmMcpGrantRouteError>()(
+  'CrmMcpGrantRouteError',
+  { message: S.String },
+) {}
+
+type CrmMcpGrantEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
+
+type CrmMcpGrantRouteDependencies<Bindings extends CrmMcpGrantEnv> = Readonly<{
+  requireAdminApiToken: (request: Request, env: Bindings) => Promise<boolean>
+}>
+
+const COLLECTION = /^\/api\/operator\/crm\/mcp-grants$/
+const ITEM = /^\/api\/operator\/crm\/mcp-grants\/([^/]+)$/
+
+const tenantOf = (url: URL, bodyTenant?: unknown): string => {
+  if (typeof bodyTenant === 'string' && bodyTenant.trim() !== '') return bodyTenant.trim()
+  const value = url.searchParams.get('tenant')
+  return value === null || value.trim() === '' ? DEFAULT_CRM_TENANT_REF : value.trim()
+}
+
+export const makeCrmMcpGrantRoutes = <Bindings extends CrmMcpGrantEnv>(
+  dependencies: CrmMcpGrantRouteDependencies<Bindings>,
+) => {
+  const guard = (
+    request: Request,
+    env: Bindings,
+    body: (db: D1Database) => Promise<HttpResponse>,
+  ): Effect.Effect<HttpResponse> =>
+    Effect.gen(function* () {
+      const authorized = yield* Effect.tryPromise({
+        catch: () => false as const,
+        try: () => dependencies.requireAdminApiToken(request, env),
+      })
+      if (!authorized) {
+        return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
+      }
+      return yield* Effect.tryPromise({
+        catch: error =>
+          new CrmMcpGrantRouteError({
+            message: error instanceof Error ? error.message : String(error),
+          }),
+        try: () => body(openAgentsDatabase(env)),
+      })
+    }).pipe(
+      Effect.catch(() =>
+        Effect.succeed(noStoreJsonResponse({ error: 'crm_mcp_grant_error' }, { status: 500 })),
+      ),
+    )
+
+  return {
+    routeCrmMcpGrantRequest: (
+      request: Request,
+      env: Bindings,
+      _ctx?: ExecutionContext,
+    ): Effect.Effect<HttpResponse> | undefined => {
+      const url = new URL(request.url)
+      const path = url.pathname
+
+      if (COLLECTION.test(path)) {
+        if (request.method === 'GET') {
+          return guard(request, env, async db =>
+            noStoreJsonResponse({ grants: await listCrmMcpGrants(db, tenantOf(url)) }),
+          )
+        }
+        if (request.method === 'POST') {
+          return guard(request, env, async db => {
+            const body = (await request.json().catch(() => null)) as Record<string, unknown> | null
+            if (!isRecord(body)) {
+              return noStoreJsonResponse({ error: 'bad_request', reason: 'json body required' }, { status: 400 })
+            }
+            const authorities = stringArrayFromUnknown(body.authorities)
+            const valid = authorities.filter(a => (CRM_MCP_AUTHORITY_CLASSES as ReadonlyArray<string>).includes(a))
+            if (valid.length === 0) {
+              return noStoreJsonResponse(
+                { error: 'bad_request', reason: `authorities[] required (one of ${CRM_MCP_AUTHORITY_CLASSES.join(', ')})` },
+                { status: 400 },
+              )
+            }
+            const minted = await mintCrmMcpGrant(db, {
+              authorities: valid,
+              expiresAt: typeof body.expiresAt === 'string' ? body.expiresAt : null,
+              label: typeof body.label === 'string' ? body.label : null,
+              tenantRef: tenantOf(url, body.tenant),
+            })
+            return noStoreJsonResponse({ grant: minted.summary, token: minted.token }, { status: 201 })
+          })
+        }
+        return Effect.succeed(methodNotAllowed(['GET', 'POST']))
+      }
+
+      const item = ITEM.exec(path)
+      if (item !== null) {
+        if (request.method !== 'DELETE') {
+          return Effect.succeed(methodNotAllowed(['DELETE']))
+        }
+        const grantRef = decodeURIComponent(item[1] ?? '')
+        return guard(request, env, async db =>
+          noStoreJsonResponse({ revoked: await revokeCrmMcpGrant(db, tenantOf(url), grantRef) }),
+        )
+      }
+
+      return undefined
+    },
+  }
+}

--- a/apps/openagents.com/workers/api/src/crm-mcp-grant.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-grant.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  crmMcpAdminPrincipal,
+  listCrmMcpGrants,
+  mintCrmMcpGrant,
+  resolveCrmMcpGrantPrincipal,
+  revokeCrmMcpGrant,
+} from './crm-mcp-grant'
+
+type GrantRow = {
+  id: string
+  grant_ref: string
+  token_hash: string
+  tenant_ref: string
+  authority_classes_json: string
+  label: string | null
+  status: string
+  created_at: string
+  expires_at: string | null
+}
+
+const makeGrantDb = () => {
+  const rows: Array<GrantRow> = []
+  const statement = (q: string, bound: ReadonlyArray<unknown> = []): D1PreparedStatement =>
+    ({
+      bind: (...v: ReadonlyArray<unknown>) => statement(q, v),
+      first: <T,>() => {
+        if (q.includes('WHERE token_hash')) {
+          const hash = String(bound[0] ?? '')
+          return Promise.resolve((rows.find(r => r.token_hash === hash && r.status === 'active') ?? null) as T | null)
+        }
+        return Promise.resolve(null as T | null)
+      },
+      all: <T,>() => {
+        const tenant = String(bound[0] ?? '')
+        return Promise.resolve({
+          meta: {} as D1Meta,
+          results: rows.filter(r => r.tenant_ref === tenant) as unknown as Array<T>,
+          success: true,
+        } as D1Result<T>)
+      },
+      run: () => {
+        if (q.includes('INSERT INTO crm_mcp_grants')) {
+          const [id, grantRef, tokenHash, tenantRef, authoritiesJson, label, createdAt, expiresAt] = bound
+          rows.push({
+            authority_classes_json: String(authoritiesJson),
+            created_at: String(createdAt),
+            expires_at: expiresAt === null ? null : String(expiresAt),
+            grant_ref: String(grantRef),
+            id: String(id),
+            label: label === null ? null : String(label),
+            status: 'active',
+            tenant_ref: String(tenantRef),
+            token_hash: String(tokenHash),
+          })
+          return Promise.resolve({ meta: { changes: 1 } as D1Meta, results: [], success: true } as unknown as D1Result)
+        }
+        if (q.includes('UPDATE crm_mcp_grants')) {
+          const [tenantRef, grantRef] = bound
+          const row = rows.find(
+            r => r.tenant_ref === String(tenantRef) && r.grant_ref === String(grantRef) && r.status === 'active',
+          )
+          let changes = 0
+          if (row !== undefined) {
+            row.status = 'revoked'
+            changes = 1
+          }
+          return Promise.resolve({ meta: { changes } as D1Meta, results: [], success: true } as unknown as D1Result)
+        }
+        return Promise.resolve({ meta: {} as D1Meta, results: [], success: true } as unknown as D1Result)
+      },
+      raw: () => Promise.reject(new Error('raw')),
+    }) as unknown as D1PreparedStatement
+  return {
+    db: {
+      batch: () => Promise.reject(new Error('batch')),
+      dump: () => Promise.reject(new Error('dump')),
+      exec: () => Promise.reject(new Error('exec')),
+      prepare: (q: string) => statement(q),
+      withSession: () => {
+        throw new Error('session')
+      },
+    } as unknown as D1Database,
+    rows,
+  }
+}
+
+const NOW = '2026-06-22T00:00:00.000Z'
+const runtime = { makeId: (p: string) => `${p}_t`, nowIso: () => NOW }
+
+describe('crmMcpAdminPrincipal', () => {
+  test('grants the full CRM authority set on the bound tenant', () => {
+    const principal = crmMcpAdminPrincipal('tenant.acme', NOW)
+    expect(principal.tenantRef).toBe('tenant.acme')
+    const authorities = principal.grants.map(g => g.authorityClass)
+    expect(authorities).toContain('operator_read')
+    expect(authorities).toContain('approval_resolution')
+    expect(principal.grants.every(g => g.decision === 'granted')).toBe(true)
+  })
+})
+
+describe('mint + resolve scoped grant', () => {
+  test('a minted token resolves to a principal with bound tenant + declared authorities', async () => {
+    const { db } = makeGrantDb()
+    const minted = await mintCrmMcpGrant(
+      db,
+      { authorities: ['operator_read'], label: 'read bot', tenantRef: 'tenant.acme' },
+      runtime,
+    )
+    expect(minted.token.startsWith('oa_mcp_')).toBe(true)
+    expect(minted.summary.tenantRef).toBe('tenant.acme')
+
+    const principal = await resolveCrmMcpGrantPrincipal(db, minted.token, NOW)
+    expect(principal).not.toBeNull()
+    expect(principal?.tenantRef).toBe('tenant.acme')
+    expect(principal?.grants.map(g => g.authorityClass)).toEqual(['operator_read'])
+  })
+
+  test('an unknown token resolves to null', async () => {
+    const { db } = makeGrantDb()
+    expect(await resolveCrmMcpGrantPrincipal(db, 'oa_mcp_nope', NOW)).toBeNull()
+  })
+
+  test('an expired grant resolves to null', async () => {
+    const { db } = makeGrantDb()
+    const minted = await mintCrmMcpGrant(
+      db,
+      { authorities: ['operator_read'], expiresAt: '2020-01-01T00:00:00.000Z', tenantRef: 'tenant.acme' },
+      runtime,
+    )
+    expect(await resolveCrmMcpGrantPrincipal(db, minted.token, NOW)).toBeNull()
+  })
+
+  test('minting with no valid authority throws', async () => {
+    const { db } = makeGrantDb()
+    await expect(
+      mintCrmMcpGrant(db, { authorities: ['bogus'], tenantRef: 'tenant.acme' }, runtime),
+    ).rejects.toThrow()
+  })
+
+  test('revoking a grant makes its token stop resolving', async () => {
+    const { db } = makeGrantDb()
+    const minted = await mintCrmMcpGrant(db, { authorities: ['operator_read'], tenantRef: 'tenant.acme' }, runtime)
+    expect(await resolveCrmMcpGrantPrincipal(db, minted.token, NOW)).not.toBeNull()
+    const revoked = await revokeCrmMcpGrant(db, 'tenant.acme', minted.grantRef, runtime)
+    expect(revoked).toBe(true)
+    expect(await resolveCrmMcpGrantPrincipal(db, minted.token, NOW)).toBeNull()
+  })
+
+  test('listCrmMcpGrants returns the tenant grants', async () => {
+    const { db } = makeGrantDb()
+    await mintCrmMcpGrant(db, { authorities: ['operator_read'], tenantRef: 'tenant.acme' }, runtime)
+    const grants = await listCrmMcpGrants(db, 'tenant.acme')
+    expect(grants).toHaveLength(1)
+    expect(grants[0]?.authorities).toEqual(['operator_read'])
+  })
+})

--- a/apps/openagents.com/workers/api/src/crm-mcp-grant.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-grant.ts
@@ -1,0 +1,215 @@
+/**
+ * Scoped MCP grants + principals for the CRM MCP server (epic #5991, #5995).
+ *
+ * Server-authoritative: a scoped credential is a `crm_mcp_grants` row binding a
+ * set of authority classes + a single tenant to a hashed token. The transport
+ * authenticates a request to exactly one `McpPrincipal` — the admin token (full
+ * CRM authority on a header/default tenant) or a scoped grant — and the catalog
+ * filters tools/resources by the principal's grants and reads ONLY its bound
+ * tenant. Raw tokens are never stored (only SHA-256) and shown once at mint.
+ */
+import {
+  type OpenAgentsMcpAuthorityClass,
+  type OpenAgentsMcpGrant,
+} from '@openagentsinc/mcp-contract'
+
+import { type CrmRuntime, DEFAULT_CRM_TENANT_REF, defaultCrmRuntime } from './crm-store'
+import type { McpPrincipal } from './crm-mcp-routes'
+import { parseJsonStringArray } from './json-boundary'
+
+/** Authority classes the CRM MCP tools use across all waves. */
+export const CRM_MCP_AUTHORITY_CLASSES: ReadonlyArray<OpenAgentsMcpAuthorityClass> = [
+  'operator_read',
+  'approval_resolution',
+  'workspace_write',
+]
+
+const MCP_TOKEN_PREFIX = 'oa_mcp_'
+
+/** Typed grant error (named subclass, not a generic thrown Error). */
+class CrmMcpGrantError extends Error {}
+
+export const readMcpBearerToken = (request: Request): string | undefined => {
+  const header = request.headers.get('authorization')
+  if (header === null) return undefined
+  const [scheme, token] = header.split(' ')
+  return scheme?.toLowerCase() === 'bearer' && token !== undefined ? token : undefined
+}
+
+export const mcpTenantHeader = (request: Request): string => {
+  const value = request.headers.get('x-openagents-tenant')
+  return value === null || value.trim() === '' ? DEFAULT_CRM_TENANT_REF : value.trim()
+}
+
+/** SHA-256 hex of a token (Web Crypto; available in the Worker runtime). */
+export const hashCrmMcpToken = async (token: string): Promise<string> => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token))
+  return [...new Uint8Array(digest)].map(b => b.toString(16).padStart(2, '0')).join('')
+}
+
+const grantsFor = (
+  grantRef: string,
+  subjectRef: string,
+  authorities: ReadonlyArray<OpenAgentsMcpAuthorityClass>,
+  grantedAt: string,
+): ReadonlyArray<OpenAgentsMcpGrant> =>
+  authorities.map(authorityClass => ({
+    authorityClass,
+    decision: 'granted' as const,
+    grantRef,
+    grantedAt,
+    scopeRefs: [],
+    sourceRefs: ['crm_mcp_grants'],
+    subjectRef,
+  }))
+
+/** The admin principal: full CRM authority on the requested/default tenant. */
+export const crmMcpAdminPrincipal = (
+  tenantRef: string,
+  nowIso: string,
+): McpPrincipal => ({
+  grants: grantsFor('grant.admin', 'admin', CRM_MCP_AUTHORITY_CLASSES, nowIso),
+  subjectRef: 'admin',
+  tenantRef,
+})
+
+// --- store ------------------------------------------------------------------
+
+export type CrmMcpGrantSummary = Readonly<{
+  grantRef: string
+  tenantRef: string
+  authorities: ReadonlyArray<string>
+  label: string | null
+  status: string
+  createdAt: string
+  expiresAt: string | null
+}>
+
+const VALID_AUTHORITIES = new Set<string>(CRM_MCP_AUTHORITY_CLASSES)
+
+export const mintCrmMcpGrant = async (
+  db: D1Database,
+  input: Readonly<{
+    tenantRef: string
+    authorities: ReadonlyArray<string>
+    label?: string | null
+    expiresAt?: string | null
+  }>,
+  runtime: CrmRuntime = defaultCrmRuntime,
+): Promise<Readonly<{ grantRef: string; token: string; summary: CrmMcpGrantSummary }>> => {
+  const authorities = input.authorities.filter(a => VALID_AUTHORITIES.has(a))
+  if (authorities.length === 0) {
+    throw new CrmMcpGrantError('at least one valid authority class is required')
+  }
+  const grantRef = runtime.makeId('crm_mcp_grant')
+  const token = runtime.makeId(MCP_TOKEN_PREFIX.replace(/_$/, ''))
+  const tokenHash = await hashCrmMcpToken(token)
+  const now = runtime.nowIso()
+  await db
+    .prepare(
+      `INSERT INTO crm_mcp_grants (
+         id, grant_ref, token_hash, tenant_ref, authority_classes_json, label,
+         status, created_at, expires_at
+       ) VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
+    )
+    .bind(
+      runtime.makeId('crm_mcp_grant_row'),
+      grantRef,
+      tokenHash,
+      input.tenantRef,
+      JSON.stringify(authorities),
+      input.label ?? null,
+      now,
+      input.expiresAt ?? null,
+    )
+    .run()
+  return {
+    grantRef,
+    summary: {
+      authorities,
+      createdAt: now,
+      expiresAt: input.expiresAt ?? null,
+      grantRef,
+      label: input.label ?? null,
+      status: 'active',
+      tenantRef: input.tenantRef,
+    },
+    token,
+  }
+}
+
+type GrantRow = Readonly<{
+  grant_ref: string
+  tenant_ref: string
+  authority_classes_json: string
+  label: string | null
+  status: string
+  created_at: string
+  expires_at: string | null
+}>
+
+const validAuthority = (value: string): value is OpenAgentsMcpAuthorityClass =>
+  VALID_AUTHORITIES.has(value)
+
+/** Resolve a scoped bearer token to a principal, or null if invalid/expired/revoked. */
+export const resolveCrmMcpGrantPrincipal = async (
+  db: D1Database,
+  token: string,
+  nowIso: string,
+): Promise<McpPrincipal | null> => {
+  const tokenHash = await hashCrmMcpToken(token)
+  const row = await db
+    .prepare(
+      `SELECT grant_ref, tenant_ref, authority_classes_json, label, status, created_at, expires_at
+         FROM crm_mcp_grants WHERE token_hash = ? AND status = 'active' LIMIT 1`,
+    )
+    .bind(tokenHash)
+    .first<GrantRow>()
+  if (row === null) return null
+  if (row.expires_at !== null && row.expires_at <= nowIso) return null
+  const authorities = parseJsonStringArray(row.authority_classes_json).filter(validAuthority)
+  if (authorities.length === 0) return null
+  return {
+    grants: grantsFor(row.grant_ref, row.grant_ref, authorities, row.created_at),
+    subjectRef: row.grant_ref,
+    tenantRef: row.tenant_ref,
+  }
+}
+
+export const listCrmMcpGrants = async (
+  db: D1Database,
+  tenantRef: string,
+): Promise<ReadonlyArray<CrmMcpGrantSummary>> => {
+  const result = await db
+    .prepare(
+      `SELECT grant_ref, tenant_ref, authority_classes_json, label, status, created_at, expires_at
+         FROM crm_mcp_grants WHERE tenant_ref = ? ORDER BY created_at DESC LIMIT 200`,
+    )
+    .bind(tenantRef)
+    .all<GrantRow>()
+  return (result.results ?? []).map(row => ({
+    authorities: parseJsonStringArray(row.authority_classes_json),
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    grantRef: row.grant_ref,
+    label: row.label,
+    status: row.status,
+    tenantRef: row.tenant_ref,
+  }))
+}
+
+export const revokeCrmMcpGrant = async (
+  db: D1Database,
+  tenantRef: string,
+  grantRef: string,
+  runtime: CrmRuntime = defaultCrmRuntime,
+): Promise<boolean> => {
+  void runtime
+  const result = await db
+    .prepare(
+      `UPDATE crm_mcp_grants SET status = 'revoked' WHERE tenant_ref = ? AND grant_ref = ? AND status = 'active'`,
+    )
+    .bind(tenantRef, grantRef)
+    .run()
+  return (result.meta?.changes ?? 0) > 0
+}

--- a/apps/openagents.com/workers/api/src/crm-mcp-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-routes.test.ts
@@ -12,14 +12,30 @@ type TestEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
 const ctx = {} as ExecutionContext
 const env: TestEnv = { OPENAGENTS_DB: {} as unknown as D1Database }
 
+const testPrincipal = {
+  grants: [
+    {
+      authorityClass: 'operator_read' as const,
+      decision: 'granted' as const,
+      grantRef: 'g',
+      grantedAt: '2026-06-22T00:00:00.000Z',
+      scopeRefs: [],
+      sourceRefs: [],
+      subjectRef: 'admin',
+    },
+  ],
+  subjectRef: 'admin',
+  tenantRef: 'tenant.openagents',
+}
+
 const run = (
   admin: boolean,
   catalog: CrmMcpCatalog<TestEnv>,
   request: Request,
 ): Promise<Response> => {
   const routes = makeCrmMcpRoutes<TestEnv>({
+    authenticate: () => Promise.resolve(admin ? testPrincipal : null),
     catalog,
-    requireAdminApiToken: () => Promise.resolve(admin),
   })
   const effect = routes.routeCrmMcpRequest(request, env, ctx)
   if (effect === undefined) throw new Error(`route did not match: ${request.url}`)
@@ -82,7 +98,7 @@ describe('CRM MCP transport — tools', () => {
   test('tools/call dispatches to the catalog', async () => {
     const catalog: CrmMcpCatalog<TestEnv> = {
       ...emptyCrmMcpCatalog<TestEnv>(),
-      callTool: (_e, _r, name) =>
+      callTool: (_e, _r, _principal, name) =>
         Promise.resolve({ content: [{ text: `called ${name}`, type: 'text' as const }] }),
     }
     const res = await run(true, catalog, rpc(req(4, 'tools/call', { arguments: {}, name: 'crm.contacts.list' })))
@@ -132,7 +148,7 @@ describe('CRM MCP transport — errors + auth', () => {
   test('non-/api/mcp path passes through', () => {
     const routes = makeCrmMcpRoutes<TestEnv>({
       catalog: emptyCrmMcpCatalog(),
-      requireAdminApiToken: () => Promise.resolve(true),
+      authenticate: () => Promise.resolve(testPrincipal),
     })
     const effect = routes.routeCrmMcpRequest(
       new Request('https://openagents.com/api/operator/crm/contacts', { method: 'POST' }),

--- a/apps/openagents.com/workers/api/src/crm-mcp-routes.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-routes.ts
@@ -16,9 +16,24 @@
  */
 import { Effect, Schema as S } from 'effect'
 
+import type { OpenAgentsMcpGrant } from '@openagentsinc/mcp-contract'
+
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 
 type HttpResponse = globalThis.Response
+
+/**
+ * The authenticated MCP caller: a bound tenant + a set of authority grants.
+ * Resolved at the transport boundary (admin token = full grant; a scoped MCP
+ * grant row = its declared authorities + bound tenant). The catalog filters
+ * tools/resources by these grants and reads ONLY `tenantRef` — client-supplied
+ * tenant is never trusted. (#5995)
+ */
+export type McpPrincipal = Readonly<{
+  subjectRef: string
+  tenantRef: string
+  grants: ReadonlyArray<OpenAgentsMcpGrant>
+}>
 
 /**
  * Typed adapter error so catalog promise calls use `Effect.tryPromise` with a
@@ -82,17 +97,27 @@ export type McpResourceReadOutcome = Readonly<{
  * `(env, request)` give it the D1 binding + the caller (for grant/tenant).
  */
 export type CrmMcpCatalog<Bindings> = Readonly<{
-  listTools: (env: Bindings, request: Request) => Promise<ReadonlyArray<McpToolListing>>
+  listTools: (
+    env: Bindings,
+    request: Request,
+    principal: McpPrincipal,
+  ) => Promise<ReadonlyArray<McpToolListing>>
   callTool: (
     env: Bindings,
     request: Request,
+    principal: McpPrincipal,
     name: string,
     args: unknown,
   ) => Promise<McpToolCallOutcome>
-  listResources: (env: Bindings, request: Request) => Promise<ReadonlyArray<McpResourceListing>>
+  listResources: (
+    env: Bindings,
+    request: Request,
+    principal: McpPrincipal,
+  ) => Promise<ReadonlyArray<McpResourceListing>>
   readResource: (
     env: Bindings,
     request: Request,
+    principal: McpPrincipal,
     uri: string,
   ) => Promise<McpResourceReadOutcome>
 }>
@@ -139,7 +164,8 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 type CrmMcpEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
 
 type CrmMcpRouteDependencies<Bindings extends CrmMcpEnv> = Readonly<{
-  requireAdminApiToken: (request: Request, env: Bindings) => Promise<boolean>
+  /** Resolve the caller to a principal (admin or scoped grant); null = 401. */
+  authenticate: (request: Request, env: Bindings) => Promise<McpPrincipal | null>
   catalog: CrmMcpCatalog<Bindings>
 }>
 
@@ -160,12 +186,12 @@ export const makeCrmMcpRoutes = <Bindings extends CrmMcpEnv>(
     }
 
     return Effect.gen(function* () {
-      // Transport-level auth (admin token first; scoped grants in #5995).
-      const authorized = yield* Effect.tryPromise({
-        catch: () => false as const,
-        try: () => dependencies.requireAdminApiToken(request, env),
+      // Transport-level auth → a bound principal (admin or scoped grant).
+      const principal = yield* Effect.tryPromise({
+        catch: () => null,
+        try: () => dependencies.authenticate(request, env),
       })
-      if (!authorized) {
+      if (principal === null) {
         // 401 at the transport boundary, matching the contract's needs_auth status.
         return noStoreJsonResponse(
           { error: { code: INVALID_REQUEST, message: 'unauthorized' }, id: null, jsonrpc: JSONRPC },
@@ -204,7 +230,7 @@ export const makeCrmMcpRoutes = <Bindings extends CrmMcpEnv>(
         case 'tools/list':
           return yield* Effect.tryPromise({
             catch: adapterError,
-            try: () => dependencies.catalog.listTools(env, request),
+            try: () => dependencies.catalog.listTools(env, request, principal),
           }).pipe(
             Effect.map(tools => rpcResult(id, { tools })),
             Effect.catch(() => Effect.succeed(rpcError(id, INTERNAL_ERROR, 'tools/list failed'))),
@@ -217,7 +243,7 @@ export const makeCrmMcpRoutes = <Bindings extends CrmMcpEnv>(
           const args = isRecord(params.arguments) ? params.arguments : {}
           return yield* Effect.tryPromise({
             catch: adapterError,
-            try: () => dependencies.catalog.callTool(env, request, name, args),
+            try: () => dependencies.catalog.callTool(env, request, principal, name, args),
           }).pipe(
             Effect.map(outcome => rpcResult(id, outcome)),
             Effect.catch(error =>
@@ -240,7 +266,7 @@ export const makeCrmMcpRoutes = <Bindings extends CrmMcpEnv>(
         case 'resources/list':
           return yield* Effect.tryPromise({
             catch: adapterError,
-            try: () => dependencies.catalog.listResources(env, request),
+            try: () => dependencies.catalog.listResources(env, request, principal),
           }).pipe(
             Effect.map(resources => rpcResult(id, { resources })),
             Effect.catch(() => Effect.succeed(rpcError(id, INTERNAL_ERROR, 'resources/list failed'))),
@@ -252,7 +278,7 @@ export const makeCrmMcpRoutes = <Bindings extends CrmMcpEnv>(
           }
           return yield* Effect.tryPromise({
             catch: adapterError,
-            try: () => dependencies.catalog.readResource(env, request, uri),
+            try: () => dependencies.catalog.readResource(env, request, principal, uri),
           }).pipe(
             Effect.map(outcome => rpcResult(id, outcome)),
             Effect.catch(error =>

--- a/apps/openagents.com/workers/api/src/crm-mcp.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp.test.ts
@@ -43,9 +43,25 @@ const env: TestEnv = { OPENAGENTS_DB: cannedDb() }
 const req = new Request('https://openagents.com/api/mcp', { method: 'POST' })
 const catalog = makeCrmMcpReadCatalog<TestEnv>()
 
+const principal = {
+  grants: [
+    {
+      authorityClass: 'operator_read' as const,
+      decision: 'granted' as const,
+      grantRef: 'g',
+      grantedAt: '2026-06-22T00:00:00.000Z',
+      scopeRefs: [],
+      sourceRefs: [],
+      subjectRef: 'admin',
+    },
+  ],
+  subjectRef: 'admin',
+  tenantRef: 'tenant.openagents',
+}
+
 describe('CRM MCP read catalog — listing', () => {
   test('exposes 15 read tools with valid names + input schemas', async () => {
-    const tools = await catalog.listTools(env, req)
+    const tools = await catalog.listTools(env, req, principal)
     expect(tools).toHaveLength(15)
     for (const tool of tools) {
       expect(() => assertValidOpenAgentsMcpName(tool.name)).not.toThrow()
@@ -67,7 +83,7 @@ describe('CRM MCP read catalog — listing', () => {
 
 describe('CRM MCP read catalog — dispatch', () => {
   test('crm.contacts.list returns structured contacts + JSON text', async () => {
-    const outcome = await catalog.callTool(env, req, 'crm.contacts.list', { limit: 10 })
+    const outcome = await catalog.callTool(env, req, principal, 'crm.contacts.list', { limit: 10 })
     expect(outcome.isError).toBe(false)
     expect(Array.isArray(outcome.structuredContent)).toBe(true)
     const list = outcome.structuredContent as Array<{ primaryEmail: string }>
@@ -76,23 +92,51 @@ describe('CRM MCP read catalog — dispatch', () => {
   })
 
   test('crm.contact.get resolves a contact by id', async () => {
-    const outcome = await catalog.callTool(env, req, 'crm.contact.get', { contactId: 'crm_contact_1' })
+    const outcome = await catalog.callTool(env, req, principal, 'crm.contact.get', { contactId: 'crm_contact_1' })
     const contact = outcome.structuredContent as { id: string }
     expect(contact.id).toBe('crm_contact_1')
   })
 
   test('crm.contact.get without contactId is a tool error (rejects)', async () => {
-    await expect(catalog.callTool(env, req, 'crm.contact.get', {})).rejects.toThrow('contactId is required')
+    await expect(catalog.callTool(env, req, principal, 'crm.contact.get', {})).rejects.toThrow('contactId is required')
   })
 
   test('an unknown tool rejects with unknown_tool', async () => {
-    await expect(catalog.callTool(env, req, 'crm.nope', {})).rejects.toThrow('unknown_tool')
+    await expect(catalog.callTool(env, req, principal, 'crm.nope', {})).rejects.toThrow('unknown_tool')
+  })
+})
+
+describe('CRM MCP grant filtering + tenant binding', () => {
+  const noGrant = { grants: [], subjectRef: 'anon', tenantRef: 'tenant.openagents' }
+
+  test('a principal without operator_read sees no tools or resources', async () => {
+    expect(await catalog.listTools(env, req, noGrant)).toHaveLength(0)
+    expect(await catalog.listResources(env, req, noGrant)).toHaveLength(0)
+  })
+
+  test('an ungranted tool is absent: calling it is unknown_tool', async () => {
+    await expect(catalog.callTool(env, req, noGrant, 'crm.contacts.list', {})).rejects.toThrow('unknown_tool')
+  })
+
+  test('an ungranted resource read is unknown_resource', async () => {
+    await expect(
+      catalog.readResource(env, req, noGrant, 'mcp://openagents/worker/crm/contacts'),
+    ).rejects.toThrow('unknown_resource')
+  })
+
+  test('client-supplied args.tenant is ignored; the principal tenant is used', async () => {
+    // The canned DB returns the same row regardless of tenant; assert the bound
+    // tenant flows by checking the call still succeeds with a foreign args.tenant.
+    const outcome = await catalog.callTool(env, req, principal, 'crm.contacts.list', {
+      tenant: 'tenant.attacker',
+    })
+    expect(outcome.isError).toBe(false)
   })
 })
 
 describe('CRM MCP resources', () => {
   test('listResources advertises the worker/crm collections', async () => {
-    const resources = await catalog.listResources(env, req)
+    const resources = await catalog.listResources(env, req, principal)
     const uris = resources.map(r => r.uri)
     expect(uris).toContain('mcp://openagents/worker/crm/contacts')
     expect(uris).toContain('mcp://openagents/worker/crm/commands')
@@ -100,24 +144,24 @@ describe('CRM MCP resources', () => {
   })
 
   test('readResource reads a collection as JSON contents', async () => {
-    const outcome = await catalog.readResource(env, req, 'mcp://openagents/worker/crm/contacts')
+    const outcome = await catalog.readResource(env, req, principal, 'mcp://openagents/worker/crm/contacts')
     expect(outcome.contents[0]?.uri).toBe('mcp://openagents/worker/crm/contacts')
     expect(outcome.contents[0]?.mimeType).toBe('application/json')
     expect(outcome.contents[0]?.text).toContain('ada@example.com')
   })
 
   test('readResource reads a single contact by URI', async () => {
-    const outcome = await catalog.readResource(env, req, 'mcp://openagents/worker/crm/contact/crm_contact_1')
+    const outcome = await catalog.readResource(env, req, principal, 'mcp://openagents/worker/crm/contact/crm_contact_1')
     expect(outcome.contents[0]?.text).toContain('crm_contact_1')
   })
 
   test('a non-worker namespace is an unknown resource', async () => {
     await expect(
-      catalog.readResource(env, req, 'mcp://openagents/pylon/node/status'),
+      catalog.readResource(env, req, principal, 'mcp://openagents/pylon/node/status'),
     ).rejects.toThrow('unknown_resource')
   })
 
   test('a malformed URI throws (transport maps to invalid params)', async () => {
-    await expect(catalog.readResource(env, req, 'not-a-uri')).rejects.toThrow()
+    await expect(catalog.readResource(env, req, principal, 'not-a-uri')).rejects.toThrow()
   })
 })

--- a/apps/openagents.com/workers/api/src/crm-mcp.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp.ts
@@ -10,6 +10,9 @@
  * filtering + tenant binding in #5995.
  */
 import {
+  filterOpenAgentsMcpDescriptorsByGrantSet,
+  openAgentsMcpDescriptorIsGranted,
+  openAgentsMcpGrantedAuthoritySet,
   type OpenAgentsMcpToolDescriptor,
   parseOpenAgentsMcpResourceUri,
   projectOpenAgentsMcpOutput,
@@ -30,7 +33,6 @@ import type {
   McpToolListing,
 } from './crm-mcp-routes'
 import {
-  DEFAULT_CRM_TENANT_REF,
   getCrmAccountById,
   getCrmContactById,
   getCrmEngagementSnapshot,
@@ -60,9 +62,6 @@ class CrmMcpToolError extends Error {}
 
 const args = (value: unknown): Record<string, unknown> =>
   typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {}
-
-const tenantOf = (a: Record<string, unknown>): string =>
-  typeof a.tenant === 'string' && a.tenant.trim() !== '' ? a.tenant.trim() : DEFAULT_CRM_TENANT_REF
 
 const requiredId = (a: Record<string, unknown>, key: string): string => {
   const value = a[key]
@@ -181,28 +180,33 @@ export const CRM_MCP_READ_TOOLS: ReadonlyArray<OpenAgentsMcpToolDescriptor> = [
 
 // --- dispatch (read fns) ----------------------------------------------------
 
-type CrmReadHandler = (db: D1Database, a: Record<string, unknown>) => Promise<unknown>
+// Tenant is the principal's bound tenant — never client-supplied `args.tenant`.
+type CrmReadHandler = (
+  db: D1Database,
+  tenant: string,
+  a: Record<string, unknown>,
+) => Promise<unknown>
 
 const CRM_MCP_READ_DISPATCH: Readonly<Record<string, CrmReadHandler>> = {
-  'crm.account.get': (db, a) => getCrmAccountById(db, tenantOf(a), requiredId(a, 'accountId')),
-  'crm.accounts.list': (db, a) => listCrmAccounts(db, tenantOf(a), { limit: optLimit(a) }),
-  'crm.commands.list': (db, a) =>
-    listCrmCommands(db, tenantOf(a), {
+  'crm.account.get': (db, tenant, a) => getCrmAccountById(db, tenant, requiredId(a, 'accountId')),
+  'crm.accounts.list': (db, tenant, a) => listCrmAccounts(db, tenant, { limit: optLimit(a) }),
+  'crm.commands.list': (db, tenant, a) =>
+    listCrmCommands(db, tenant, {
       limit: optLimit(a),
       status: typeof a.status === 'string' ? a.status : undefined,
     }),
-  'crm.contact.activities.list': (db, a) =>
-    listCrmActivitiesForContact(db, tenantOf(a), requiredId(a, 'contactId'), { limit: optLimit(a) }),
-  'crm.contact.emails.list': (db, a) =>
-    listCrmEmailMessagesForContact(db, tenantOf(a), requiredId(a, 'contactId'), { limit: optLimit(a) }),
-  'crm.contact.engagement.get': (db, a) =>
-    getCrmEngagementSnapshot(db, tenantOf(a), requiredId(a, 'contactId')),
-  'crm.contact.get': (db, a) => getCrmContactById(db, tenantOf(a), requiredId(a, 'contactId')),
-  'crm.contact.render': async (db, a) => {
+  'crm.contact.activities.list': (db, tenant, a) =>
+    listCrmActivitiesForContact(db, tenant, requiredId(a, 'contactId'), { limit: optLimit(a) }),
+  'crm.contact.emails.list': (db, tenant, a) =>
+    listCrmEmailMessagesForContact(db, tenant, requiredId(a, 'contactId'), { limit: optLimit(a) }),
+  'crm.contact.engagement.get': (db, tenant, a) =>
+    getCrmEngagementSnapshot(db, tenant, requiredId(a, 'contactId')),
+  'crm.contact.get': (db, tenant, a) => getCrmContactById(db, tenant, requiredId(a, 'contactId')),
+  'crm.contact.render': async (db, tenant, a) => {
     const composed = await composeCrmEmailForContact(db, {
       contactId: requiredId(a, 'contactId'),
       templateSlug: requiredId(a, 'template'),
-      tenantRef: tenantOf(a),
+      tenantRef: tenant,
     })
     const eligibility = await readEmailSendEligibility(db, {
       category: 'marketing',
@@ -220,14 +224,14 @@ const CRM_MCP_READ_DISPATCH: Readonly<Record<string, CrmReadHandler>> = {
       },
     }
   },
-  'crm.contacts.list': (db, a) =>
-    listCrmContacts(db, tenantOf(a), { limit: optLimit(a), search: optSearch(a) }),
-  'crm.gmail.queue.list': (db, a) => listCrmQueuedGmailMessages(db, tenantOf(a), { limit: optLimit(a) }),
-  'crm.imports.list': (db, a) => listCrmSourceImportRuns(db, tenantOf(a), { limit: optLimit(a) }),
-  'crm.lists.list': (db, a) => listCrmContactLists(db, tenantOf(a)),
-  'crm.opportunities.list': (db, a) => listCrmOpportunities(db, tenantOf(a), { limit: optLimit(a) }),
-  'crm.opportunity.get': (db, a) => getCrmOpportunityById(db, tenantOf(a), requiredId(a, 'opportunityId')),
-  'crm.templates.list': (db, a) => listCrmEmailTemplates(db, tenantOf(a)),
+  'crm.contacts.list': (db, tenant, a) =>
+    listCrmContacts(db, tenant, { limit: optLimit(a), search: optSearch(a) }),
+  'crm.gmail.queue.list': (db, tenant, a) => listCrmQueuedGmailMessages(db, tenant, { limit: optLimit(a) }),
+  'crm.imports.list': (db, tenant, a) => listCrmSourceImportRuns(db, tenant, { limit: optLimit(a) }),
+  'crm.lists.list': (db, tenant) => listCrmContactLists(db, tenant),
+  'crm.opportunities.list': (db, tenant, a) => listCrmOpportunities(db, tenant, { limit: optLimit(a) }),
+  'crm.opportunity.get': (db, tenant, a) => getCrmOpportunityById(db, tenant, requiredId(a, 'opportunityId')),
+  'crm.templates.list': (db, tenant) => listCrmEmailTemplates(db, tenant),
 }
 
 // --- catalog ----------------------------------------------------------------
@@ -274,16 +278,16 @@ export const CRM_MCP_RESOURCES: ReadonlyArray<McpResourceListing> = [
   { description: 'Approval-gated send_email commands.', mimeType: 'application/json', name: 'crm.commands', title: 'CRM send commands', uri: `${RESOURCE_PREFIX}crm/commands` },
 ]
 
-/** Resolve a parsed `crm/...` resource path to its read data (default tenant). */
+/** Resolve a parsed `crm/...` resource path to its read data (bound tenant). */
 const readCrmResourceData = async (
   db: D1Database,
+  tenant: string,
   path: string,
 ): Promise<unknown> => {
   const segments = path.split('/').filter(part => part !== '')
   if (segments[0] !== 'crm') {
     throw new CrmMcpToolError('unknown_resource')
   }
-  const tenant = DEFAULT_CRM_TENANT_REF
   const [, head, id, sub] = segments
   switch (head) {
     case 'contacts':
@@ -315,22 +319,37 @@ const readCrmResourceData = async (
 }
 
 export const makeCrmMcpReadCatalog = <Bindings extends CrmMcpEnv>(): CrmMcpCatalog<Bindings> => ({
-  callTool: async (env, _request, name, callArgs) => {
+  callTool: async (env, _request, principal, name, callArgs) => {
+    // Ungranted tools are ABSENT: an ungranted/unknown name is unknown_tool.
+    const grantedAuthorities = openAgentsMcpGrantedAuthoritySet(principal.grants)
+    const descriptor = CRM_MCP_READ_TOOLS.find(d => d.name === name)
+    if (descriptor === undefined || !openAgentsMcpDescriptorIsGranted(descriptor, grantedAuthorities)) {
+      throw new CrmMcpToolError('unknown_tool')
+    }
     const handler = CRM_MCP_READ_DISPATCH[name]
     if (handler === undefined) {
       throw new CrmMcpToolError('unknown_tool')
     }
-    const data = await handler(openAgentsDatabase(env), args(callArgs))
+    const data = await handler(openAgentsDatabase(env), principal.tenantRef, args(callArgs))
     return projectReadOutcome(name, data)
   },
-  listResources: () => Promise.resolve(CRM_MCP_RESOURCES),
-  listTools: () => Promise.resolve(CRM_MCP_READ_TOOLS.map(toolListing)),
-  readResource: async (env, _request, uri): Promise<McpResourceReadOutcome> => {
+  listResources: (_env, _request, principal) =>
+    Promise.resolve(
+      openAgentsMcpGrantedAuthoritySet(principal.grants).has('operator_read') ? CRM_MCP_RESOURCES : [],
+    ),
+  listTools: (_env, _request, principal) =>
+    Promise.resolve(
+      filterOpenAgentsMcpDescriptorsByGrantSet(CRM_MCP_READ_TOOLS, principal.grants).map(toolListing),
+    ),
+  readResource: async (env, _request, principal, uri): Promise<McpResourceReadOutcome> => {
+    if (!openAgentsMcpGrantedAuthoritySet(principal.grants).has('operator_read')) {
+      throw new CrmMcpToolError('unknown_resource')
+    }
     const parsed = parseOpenAgentsMcpResourceUri(uri)
     if (parsed.namespace !== 'worker') {
       throw new CrmMcpToolError('unknown_resource')
     }
-    const data = await readCrmResourceData(openAgentsDatabase(env), parsed.path)
+    const data = await readCrmResourceData(openAgentsDatabase(env), principal.tenantRef, parsed.path)
     const projection = projectOpenAgentsMcpOutput({
       maxTextBytes: 131072,
       outputRef: uri,

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -445,6 +445,13 @@ import {
 } from './operator-targets'
 import { makeCrmBatchRoutes } from './crm-batch-routes'
 import { makeCrmMcpReadCatalog } from './crm-mcp'
+import {
+  crmMcpAdminPrincipal,
+  mcpTenantHeader,
+  readMcpBearerToken,
+  resolveCrmMcpGrantPrincipal,
+} from './crm-mcp-grant'
+import { makeCrmMcpGrantRoutes } from './crm-mcp-grant-routes'
 import { makeCrmMcpRoutes } from './crm-mcp-routes'
 import { makeCrmCommandRoutes } from './crm-command-routes'
 import { makeCrmEmailRoutes } from './crm-email-routes'
@@ -7121,10 +7128,26 @@ const crmBatchRoutes = makeCrmBatchRoutes<WorkerBindings>({
   resolveResendDeps: resolveCrmResendDeps,
 })
 
-// CRM MCP server (epic #5991): read-only tool catalog (#5993). Resources
-// (#5994) and grant filtering (#5995) extend this same catalog.
+// CRM MCP server (epic #5991): read-only catalog (#5993) + resources (#5994),
+// authenticated to a bound principal — admin token = full CRM authority on the
+// header/default tenant; a scoped grant (#5995) = its declared authorities +
+// bound tenant. The catalog filters tools/resources by the principal's grants.
 const crmMcpRoutes = makeCrmMcpRoutes<WorkerBindings>({
+  authenticate: async (request, env) => {
+    const isAdmin = await requireAdminApiToken(request, env)
+    if (isAdmin) {
+      return crmMcpAdminPrincipal(mcpTenantHeader(request), currentIsoTimestamp())
+    }
+    const token = readMcpBearerToken(request)
+    if (token === undefined) {
+      return null
+    }
+    return resolveCrmMcpGrantPrincipal(openAgentsDatabase(env), token, currentIsoTimestamp())
+  },
   catalog: makeCrmMcpReadCatalog<WorkerBindings>(),
+})
+
+const crmMcpGrantRoutes = makeCrmMcpGrantRoutes<WorkerBindings>({
   requireAdminApiToken: (request, env) => requireAdminApiToken(request, env),
 })
 
@@ -10023,6 +10046,7 @@ const routeRequest = makeWorkerRouteRequest({
     crmSendRoutes.routeCrmSendRequest(request, env, ctx) ??
     crmCommandRoutes.routeCrmCommandRequest(request, env, ctx) ??
     crmBatchRoutes.routeCrmBatchRequest(request, env, ctx) ??
+    crmMcpGrantRoutes.routeCrmMcpGrantRequest(request, env, ctx) ??
     crmMcpRoutes.routeCrmMcpRequest(request, env, ctx) ??
     crmRoutes.routeCrmRequest(request, env, ctx),
   routeOnboardingRequest: onboardingRoutes.routeOnboardingRequest,


### PR DESCRIPTION
Part of epic #5991. Server-authoritative scoped grants (migration 0220 `crm_mcp_grants`): hashed token → authority classes + bound tenant. Transport authenticates to an `McpPrincipal` (admin OR scoped grant; null→401) and threads it to the catalog, which filters tools/resources by granted authorities (ungranted = absent) and reads ONLY the bound tenant (client `args.tenant` ignored). Admin mint/list/revoke routes. 12 new tests + updated existing; `check:deploy` green.

Closes #5995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)