### PR TITLE
mcp(#5996): Wave 2 propose + template tools (no send)

### DIFF
--- a/apps/openagents.com/workers/api/src/crm-mcp.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp.test.ts
@@ -13,9 +13,37 @@ const contactRow = {
   updated_at: '2026-06-22T00:00:00.000Z',
 }
 
+const commandRow = {
+  approval_state: 'pending_approval',
+  command_kind: 'send_email',
+  contact_id: 'crm_contact_1',
+  created_at: '2026-06-22T00:00:00.000Z',
+  id: 'crm_cmd_1',
+  payload_json: '{"channel":"gmail_gws","templateSlug":"welcome"}',
+  result_json: '{}',
+  status: 'proposed',
+  tenant_ref: 'tenant.openagents',
+  updated_at: '2026-06-22T00:00:00.000Z',
+}
+const templateRow = {
+  body_markdown_template: 'Hi {{ contact.first_name }}',
+  created_at: '2026-06-22T00:00:00.000Z',
+  id: 'crm_template_1',
+  name: 'Welcome',
+  slug: 'welcome',
+  status: 'active',
+  subject_template: 'Hello',
+  tenant_ref: 'tenant.openagents',
+  updated_at: '2026-06-22T00:00:00.000Z',
+}
+
 const cannedDb = (): D1Database => {
-  const firstFor = (q: string): Record<string, unknown> | null =>
-    q.includes('FROM crm_contacts') ? contactRow : null
+  const firstFor = (q: string): Record<string, unknown> | null => {
+    if (q.includes('FROM crm_contact_commands')) return commandRow
+    if (q.includes('FROM crm_email_templates')) return templateRow
+    if (q.includes('FROM crm_contacts')) return contactRow
+    return null
+  }
   const allFor = (q: string): Array<Record<string, unknown>> =>
     q.includes('FROM crm_contacts') ? [contactRow] : []
   const statement = (q: string): D1PreparedStatement =>
@@ -43,33 +71,42 @@ const env: TestEnv = { OPENAGENTS_DB: cannedDb() }
 const req = new Request('https://openagents.com/api/mcp', { method: 'POST' })
 const catalog = makeCrmMcpReadCatalog<TestEnv>()
 
+const grant = (authorityClass: 'operator_read' | 'workspace_write' | 'approval_resolution') => ({
+  authorityClass,
+  decision: 'granted' as const,
+  grantRef: 'g',
+  grantedAt: '2026-06-22T00:00:00.000Z',
+  scopeRefs: [],
+  sourceRefs: [],
+  subjectRef: 'admin',
+})
+
+// Full CRM authority (admin-equivalent).
 const principal = {
-  grants: [
-    {
-      authorityClass: 'operator_read' as const,
-      decision: 'granted' as const,
-      grantRef: 'g',
-      grantedAt: '2026-06-22T00:00:00.000Z',
-      scopeRefs: [],
-      sourceRefs: [],
-      subjectRef: 'admin',
-    },
-  ],
+  grants: [grant('operator_read'), grant('workspace_write'), grant('approval_resolution')],
   subjectRef: 'admin',
   tenantRef: 'tenant.openagents',
 }
 
+// Read + propose only (no workspace_write).
+const readPrincipal = {
+  grants: [grant('operator_read')],
+  subjectRef: 'reader',
+  tenantRef: 'tenant.openagents',
+}
+
 describe('CRM MCP read catalog — listing', () => {
-  test('exposes 15 read tools with valid names + input schemas', async () => {
+  test('full-authority principal sees all read + write tools with valid names', async () => {
     const tools = await catalog.listTools(env, req, principal)
-    expect(tools).toHaveLength(15)
+    expect(tools).toHaveLength(17) // 15 read + 2 write
     for (const tool of tools) {
       expect(() => assertValidOpenAgentsMcpName(tool.name)).not.toThrow()
       expect(tool.inputSchema).toHaveProperty('type', 'object')
-      expect(tool.annotations).toMatchObject({ readOnlyHint: true })
     }
-    expect(tools.map(t => t.name)).toContain('crm.contacts.list')
-    expect(tools.map(t => t.name)).toContain('crm.contact.render')
+    const names = tools.map(t => t.name)
+    expect(names).toContain('crm.contacts.list')
+    expect(names).toContain('crm.send.command.propose')
+    expect(names).toContain('crm.template.upsert')
   })
 
   test('every descriptor is operator_read + read_only with no receipt', () => {
@@ -103,6 +140,49 @@ describe('CRM MCP read catalog — dispatch', () => {
 
   test('an unknown tool rejects with unknown_tool', async () => {
     await expect(catalog.callTool(env, req, principal, 'crm.nope', {})).rejects.toThrow('unknown_tool')
+  })
+})
+
+describe('CRM MCP Wave 2 — propose + template (no send)', () => {
+  test('crm.send.command.propose records a pending command + a receipt (sends nothing)', async () => {
+    const outcome = await catalog.callTool(env, req, principal, 'crm.send.command.propose', {
+      channel: 'gmail_gws',
+      contactId: 'crm_contact_1',
+      templateSlug: 'welcome',
+    })
+    expect(outcome.isError).toBe(false)
+    const sc = outcome.structuredContent as {
+      result: { status: string; commandKind: string }
+      receipt: { kind: string; status: string; receiptRef: string }
+    }
+    expect(sc.result.commandKind).toBe('send_email')
+    expect(sc.result.status).toBe('proposed')
+    expect(sc.receipt.kind).toBe('mutation')
+    expect(sc.receipt.status).toBe('recorded')
+  })
+
+  test('crm.template.upsert is available to a workspace_write principal', async () => {
+    const outcome = await catalog.callTool(env, req, principal, 'crm.template.upsert', {
+      bodyMarkdownTemplate: 'Hi {{ contact.first_name }}',
+      name: 'Welcome',
+      slug: 'welcome',
+      subjectTemplate: 'Hello',
+    })
+    expect(outcome.isError).toBe(false)
+  })
+
+  test('a read+propose principal can propose but NOT upsert templates', async () => {
+    const tools = (await catalog.listTools(env, req, readPrincipal)).map(t => t.name)
+    expect(tools).toContain('crm.send.command.propose')
+    expect(tools).not.toContain('crm.template.upsert')
+    await expect(
+      catalog.callTool(env, req, readPrincipal, 'crm.template.upsert', {
+        bodyMarkdownTemplate: 'x',
+        name: 'x',
+        slug: 'x',
+        subjectTemplate: 'x',
+      }),
+    ).rejects.toThrow('unknown_tool')
   })
 })
 

--- a/apps/openagents.com/workers/api/src/crm-mcp.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp.ts
@@ -13,6 +13,8 @@ import {
   filterOpenAgentsMcpDescriptorsByGrantSet,
   openAgentsMcpDescriptorIsGranted,
   openAgentsMcpGrantedAuthoritySet,
+  type OpenAgentsMcpReceipt,
+  type OpenAgentsMcpReceiptKind,
   type OpenAgentsMcpToolDescriptor,
   parseOpenAgentsMcpResourceUri,
   projectOpenAgentsMcpOutput,
@@ -23,8 +25,9 @@ import {
   listCrmEmailMessagesForContact,
   listCrmEmailTemplates,
   listCrmQueuedGmailMessages,
+  upsertCrmEmailTemplate,
 } from './crm-email'
-import { listCrmCommands } from './crm-command'
+import { listCrmCommands, proposeCrmSendCommand } from './crm-command'
 import type {
   CrmMcpCatalog,
   McpResourceListing,
@@ -98,6 +101,30 @@ const idSchema = (idKey: string, idDesc: string): Record<string, unknown> => ({
 })
 
 const CRM_MCP_INPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
+  'crm.send.command.propose': {
+    additionalProperties: false,
+    properties: {
+      channel: { description: "Send channel.", enum: ['gmail_gws', 'resend'], type: 'string' },
+      contactId: { description: 'CRM contact id.', type: 'string' },
+      sendReason: { description: 'Optional reason recorded with the command.', type: 'string' },
+      templateSlug: { description: 'Template slug to send.', type: 'string' },
+      tenant: TENANT_PROP,
+    },
+    required: ['contactId', 'templateSlug'],
+    type: 'object',
+  },
+  'crm.template.upsert': {
+    additionalProperties: false,
+    properties: {
+      bodyMarkdownTemplate: { description: 'Markdown body template ({{ contact.first_name }} etc.).', type: 'string' },
+      name: { description: 'Human template name.', type: 'string' },
+      slug: { description: 'Template slug (stable id within the tenant).', type: 'string' },
+      subjectTemplate: { description: 'Subject template.', type: 'string' },
+      tenant: TENANT_PROP,
+    },
+    required: ['slug', 'name', 'subjectTemplate', 'bodyMarkdownTemplate'],
+    type: 'object',
+  },
   'crm.account.get': idSchema('accountId', 'CRM account id.'),
   'crm.accounts.list': listSchema(),
   'crm.commands.list': {
@@ -178,16 +205,60 @@ export const CRM_MCP_READ_TOOLS: ReadonlyArray<OpenAgentsMcpToolDescriptor> = [
   readTool('crm.commands.list', 'List send commands', 'List approval-gated send_email commands (e.g. status=proposed).'),
 ]
 
+// --- Wave 2 write tools (propose-only; no send) -----------------------------
+
+const writeTool = (
+  name: string,
+  title: string,
+  description: string,
+  requiredAuthorities: ReadonlyArray<OpenAgentsMcpToolDescriptor['requiredAuthorities'][number]>,
+): OpenAgentsMcpToolDescriptor => ({
+  description,
+  inputSchemaRef: `${name}.input`,
+  name,
+  outputSchemaRef: `${name}.output`,
+  progressBehavior: 'none',
+  publicSummary: title,
+  receiptBehavior: 'mutation_receipt',
+  requiredAuthorities,
+  riskClass: 'low',
+  sourceRefs: [SOURCE],
+  title,
+})
+
+export const CRM_MCP_WRITE_TOOLS: ReadonlyArray<OpenAgentsMcpToolDescriptor> = [
+  writeTool(
+    'crm.send.command.propose',
+    'Propose a send',
+    'Propose an approval-gated send_email command for a contact. Records a pending_approval command — SENDS NOTHING. A human approves it separately.',
+    ['operator_read'],
+  ),
+  writeTool(
+    'crm.template.upsert',
+    'Upsert email template',
+    'Create or update a CRM email template for the tenant.',
+    ['workspace_write'],
+  ),
+]
+
+/** All CRM MCP tools (read + write), filtered per-principal at list time. */
+export const CRM_MCP_TOOLS: ReadonlyArray<OpenAgentsMcpToolDescriptor> = [
+  ...CRM_MCP_READ_TOOLS,
+  ...CRM_MCP_WRITE_TOOLS,
+]
+
 // --- dispatch (read fns) ----------------------------------------------------
 
 // Tenant is the principal's bound tenant — never client-supplied `args.tenant`.
-type CrmReadHandler = (
+type CrmToolContext = Readonly<{ subjectRef: string }>
+type CrmToolHandler = (
   db: D1Database,
   tenant: string,
   a: Record<string, unknown>,
+  ctx: CrmToolContext,
 ) => Promise<unknown>
 
-const CRM_MCP_READ_DISPATCH: Readonly<Record<string, CrmReadHandler>> = {
+const CRM_MCP_READ_DISPATCH: Readonly<Record<string, CrmToolHandler>> = {
   'crm.account.get': (db, tenant, a) => getCrmAccountById(db, tenant, requiredId(a, 'accountId')),
   'crm.accounts.list': (db, tenant, a) => listCrmAccounts(db, tenant, { limit: optLimit(a) }),
   'crm.commands.list': (db, tenant, a) =>
@@ -232,6 +303,76 @@ const CRM_MCP_READ_DISPATCH: Readonly<Record<string, CrmReadHandler>> = {
   'crm.opportunities.list': (db, tenant, a) => listCrmOpportunities(db, tenant, { limit: optLimit(a) }),
   'crm.opportunity.get': (db, tenant, a) => getCrmOpportunityById(db, tenant, requiredId(a, 'opportunityId')),
   'crm.templates.list': (db, tenant) => listCrmEmailTemplates(db, tenant),
+}
+
+const CRM_MCP_WRITE_DISPATCH: Readonly<Record<string, CrmToolHandler>> = {
+  'crm.send.command.propose': (db, tenant, a, ctx) =>
+    proposeCrmSendCommand(db, {
+      channel: a.channel === 'resend' ? 'resend' : 'gmail_gws',
+      contactId: requiredId(a, 'contactId'),
+      proposedByRef: ctx.subjectRef,
+      sendReason: typeof a.sendReason === 'string' ? a.sendReason : null,
+      templateSlug: requiredId(a, 'templateSlug'),
+      tenantRef: tenant,
+    }),
+  'crm.template.upsert': (db, tenant, a) =>
+    upsertCrmEmailTemplate(db, {
+      bodyMarkdownTemplate: requiredId(a, 'bodyMarkdownTemplate'),
+      name: requiredId(a, 'name'),
+      slug: requiredId(a, 'slug'),
+      subjectTemplate: requiredId(a, 'subjectTemplate'),
+      tenantRef: tenant,
+    }),
+}
+
+const CRM_MCP_DISPATCH: Readonly<Record<string, CrmToolHandler>> = {
+  ...CRM_MCP_READ_DISPATCH,
+  ...CRM_MCP_WRITE_DISPATCH,
+}
+
+/** Build a mutation receipt for a write tool result (best-effort refs). */
+const makeWriteReceipt = (
+  descriptor: OpenAgentsMcpToolDescriptor,
+  data: unknown,
+): OpenAgentsMcpReceipt => {
+  const record = (data ?? {}) as Record<string, unknown>
+  const receiptRef = typeof record.id === 'string' ? record.id : `receipt.${descriptor.name}`
+  const generatedAt =
+    typeof record.createdAt === 'string'
+      ? record.createdAt
+      : typeof record.updatedAt === 'string'
+        ? record.updatedAt
+        : ''
+  const kind: OpenAgentsMcpReceiptKind = 'mutation'
+  return {
+    artifactRefs: [receiptRef],
+    authorityClass: descriptor.requiredAuthorities[0] ?? 'operator_read',
+    generatedAt,
+    kind,
+    receiptRef,
+    sourceRefs: [SOURCE],
+    status: 'recorded',
+    summary: `${descriptor.name} recorded`,
+    targetRef: typeof record.contactId === 'string' ? record.contactId : receiptRef,
+  }
+}
+
+const projectWriteOutcome = (
+  descriptor: OpenAgentsMcpToolDescriptor,
+  data: unknown,
+): McpToolCallOutcome => {
+  const payload = { receipt: makeWriteReceipt(descriptor, data), result: data }
+  const projection = projectOpenAgentsMcpOutput({
+    maxTextBytes: 131072,
+    outputRef: `mcp.crm.${descriptor.name}`,
+    safetyClass: 'operator',
+    sourceRefs: [`tool.${descriptor.name}`],
+    text: JSON.stringify(payload, null, 2),
+  })
+  if (projection.text === undefined) {
+    return { content: [{ text: projection.summary, type: 'text' }], isError: true }
+  }
+  return { content: [{ text: projection.text, type: 'text' }], isError: false, structuredContent: payload }
 }
 
 // --- catalog ----------------------------------------------------------------
@@ -322,16 +463,20 @@ export const makeCrmMcpReadCatalog = <Bindings extends CrmMcpEnv>(): CrmMcpCatal
   callTool: async (env, _request, principal, name, callArgs) => {
     // Ungranted tools are ABSENT: an ungranted/unknown name is unknown_tool.
     const grantedAuthorities = openAgentsMcpGrantedAuthoritySet(principal.grants)
-    const descriptor = CRM_MCP_READ_TOOLS.find(d => d.name === name)
+    const descriptor = CRM_MCP_TOOLS.find(d => d.name === name)
     if (descriptor === undefined || !openAgentsMcpDescriptorIsGranted(descriptor, grantedAuthorities)) {
       throw new CrmMcpToolError('unknown_tool')
     }
-    const handler = CRM_MCP_READ_DISPATCH[name]
+    const handler = CRM_MCP_DISPATCH[name]
     if (handler === undefined) {
       throw new CrmMcpToolError('unknown_tool')
     }
-    const data = await handler(openAgentsDatabase(env), principal.tenantRef, args(callArgs))
-    return projectReadOutcome(name, data)
+    const data = await handler(openAgentsDatabase(env), principal.tenantRef, args(callArgs), {
+      subjectRef: principal.subjectRef,
+    })
+    return descriptor.receiptBehavior === 'none'
+      ? projectReadOutcome(name, data)
+      : projectWriteOutcome(descriptor, data)
   },
   listResources: (_env, _request, principal) =>
     Promise.resolve(
@@ -339,7 +484,7 @@ export const makeCrmMcpReadCatalog = <Bindings extends CrmMcpEnv>(): CrmMcpCatal
     ),
   listTools: (_env, _request, principal) =>
     Promise.resolve(
-      filterOpenAgentsMcpDescriptorsByGrantSet(CRM_MCP_READ_TOOLS, principal.grants).map(toolListing),
+      filterOpenAgentsMcpDescriptorsByGrantSet(CRM_MCP_TOOLS, principal.grants).map(toolListing),
     ),
   readResource: async (env, _request, principal, uri): Promise<McpResourceReadOutcome> => {
     if (!openAgentsMcpGrantedAuthoritySet(principal.grants).has('operator_read')) {


### PR DESCRIPTION
Part of epic #5991. Adds `crm.send.command.propose` (operator_read — records a pending_approval command, **sends nothing**) and `crm.template.upsert` (workspace_write) to the CRM MCP catalog, with mutation receipts. Grant-filtered combined catalog; tenant stays the bound principal's. 18 catalog tests; `check:deploy` green.

Closes #5996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)