### PR TITLE
mcp(#5997): Wave 3 gated execution tools

### DIFF
--- a/apps/openagents.com/workers/api/src/crm-mcp.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp.test.ts
@@ -1,7 +1,7 @@
 import { assertValidOpenAgentsMcpName } from '@openagentsinc/mcp-contract'
 import { describe, expect, test } from 'vitest'
 
-import { CRM_MCP_READ_TOOLS, makeCrmMcpReadCatalog } from './crm-mcp'
+import { CRM_MCP_READ_TOOLS, makeCrmMcpCatalog } from './crm-mcp'
 
 const contactRow = {
   contact_type: 'investor',
@@ -38,9 +38,22 @@ const templateRow = {
 }
 
 const cannedDb = (): D1Database => {
+  const messageRow = {
+    body_markdown: 'Hi Ada',
+    channel: 'gmail_gws',
+    contact_id: 'crm_contact_1',
+    created_at: '2026-06-22T00:00:00.000Z',
+    id: 'crm_email_q',
+    status: 'queued',
+    subject: 'Hello',
+    tenant_ref: 'tenant.openagents',
+    to_email: 'ada@example.com',
+    updated_at: '2026-06-22T00:00:00.000Z',
+  }
   const firstFor = (q: string): Record<string, unknown> | null => {
     if (q.includes('FROM crm_contact_commands')) return commandRow
     if (q.includes('FROM crm_email_templates')) return templateRow
+    if (q.includes('FROM crm_email_messages')) return messageRow
     if (q.includes('FROM crm_contacts')) return contactRow
     return null
   }
@@ -69,7 +82,9 @@ const cannedDb = (): D1Database => {
 type TestEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
 const env: TestEnv = { OPENAGENTS_DB: cannedDb() }
 const req = new Request('https://openagents.com/api/mcp', { method: 'POST' })
-const catalog = makeCrmMcpReadCatalog<TestEnv>()
+const catalog = makeCrmMcpCatalog<TestEnv>({
+  resolveResendDeps: () => ({ enabled: false, fromEmail: null, sender: null }),
+})
 
 const grant = (authorityClass: 'operator_read' | 'workspace_write' | 'approval_resolution') => ({
   authorityClass,
@@ -98,7 +113,7 @@ const readPrincipal = {
 describe('CRM MCP read catalog — listing', () => {
   test('full-authority principal sees all read + write tools with valid names', async () => {
     const tools = await catalog.listTools(env, req, principal)
-    expect(tools).toHaveLength(17) // 15 read + 2 write
+    expect(tools).toHaveLength(21) // 15 read + 6 write
     for (const tool of tools) {
       expect(() => assertValidOpenAgentsMcpName(tool.name)).not.toThrow()
       expect(tool.inputSchema).toHaveProperty('type', 'object')
@@ -107,6 +122,9 @@ describe('CRM MCP read catalog — listing', () => {
     expect(names).toContain('crm.contacts.list')
     expect(names).toContain('crm.send.command.propose')
     expect(names).toContain('crm.template.upsert')
+    expect(names).toContain('crm.send.command.approve')
+    expect(names).toContain('crm.import.run')
+    expect(names).toContain('crm.batch.send')
   })
 
   test('every descriptor is operator_read + read_only with no receipt', () => {
@@ -182,6 +200,59 @@ describe('CRM MCP Wave 2 — propose + template (no send)', () => {
         slug: 'x',
         subjectTemplate: 'x',
       }),
+    ).rejects.toThrow('unknown_tool')
+  })
+})
+
+describe('CRM MCP Wave 3 — gated execution', () => {
+  test('crm.send.command.approve executes (suppression gate still applies) + approval receipt', async () => {
+    const outcome = await catalog.callTool(env, req, principal, 'crm.send.command.approve', {
+      commandId: 'crm_cmd_1',
+    })
+    expect(outcome.isError).toBe(false)
+    const sc = outcome.structuredContent as { receipt: { kind: string }; result: { kind: string } }
+    expect(sc.receipt.kind).toBe('approval')
+  })
+
+  test('crm.send.command.reject is allowed for approval_resolution', async () => {
+    const outcome = await catalog.callTool(env, req, principal, 'crm.send.command.reject', {
+      commandId: 'crm_cmd_1',
+      reason: 'not now',
+    })
+    expect(outcome.isError).toBe(false)
+  })
+
+  test('crm.import.run imports CSV (workspace_write) + mutation receipt', async () => {
+    const outcome = await catalog.callTool(env, req, principal, 'crm.import.run', {
+      csv: 'email\nada@example.com',
+      sourceLabel: 'mcp:test',
+    })
+    expect(outcome.isError).toBe(false)
+    const sc = outcome.structuredContent as { receipt: { kind: string }; result: { totalRows: number } }
+    expect(sc.receipt.kind).toBe('mutation')
+    expect(sc.result.totalRows).toBe(1)
+  })
+
+  test('crm.batch.send is DRY-RUN only over MCP (plans, sends nothing)', async () => {
+    const outcome = await catalog.callTool(env, req, principal, 'crm.batch.send', {
+      channel: 'gmail_gws',
+      contactIds: ['crm_contact_1'],
+      templateSlug: 'welcome',
+    })
+    expect(outcome.isError).toBe(false)
+    const summary = outcome.structuredContent as { dryRun: boolean; counts: { would_send: number } }
+    expect(summary.dryRun).toBe(true)
+    expect(summary.counts.would_send).toBe(1)
+  })
+
+  test('a read+propose principal cannot approve or import (ungranted = absent)', async () => {
+    const names = (await catalog.listTools(env, req, readPrincipal)).map(t => t.name)
+    expect(names).not.toContain('crm.send.command.approve')
+    expect(names).not.toContain('crm.import.run')
+    // batch.send is operator_read, so it IS visible (dry-run only)
+    expect(names).toContain('crm.batch.send')
+    await expect(
+      catalog.callTool(env, req, readPrincipal, 'crm.send.command.approve', { commandId: 'x' }),
     ).rejects.toThrow('unknown_tool')
   })
 })

--- a/apps/openagents.com/workers/api/src/crm-mcp.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp.ts
@@ -27,7 +27,15 @@ import {
   listCrmQueuedGmailMessages,
   upsertCrmEmailTemplate,
 } from './crm-email'
-import { listCrmCommands, proposeCrmSendCommand } from './crm-command'
+import {
+  approveAndExecuteCrmSendCommand,
+  listCrmCommands,
+  proposeCrmSendCommand,
+  rejectCrmCommand,
+} from './crm-command'
+import { runCrmBatch } from './crm-batch'
+import { crmImportDepsFromDb, importCrmContactsFromCsv } from './crm-import'
+import type { CrmDispatchDeps } from './crm-send'
 import type {
   CrmMcpCatalog,
   McpResourceListing,
@@ -48,6 +56,7 @@ import {
   listCrmSourceImportRuns,
 } from './crm-store'
 import { readEmailSendEligibility } from './email-preferences'
+import { stringArrayFromUnknown } from './json-boundary'
 import { openAgentsDatabase } from './runtime'
 
 type CrmMcpEnv = Readonly<{ OPENAGENTS_DB: D1Database }>
@@ -111,6 +120,46 @@ const CRM_MCP_INPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> =
       tenant: TENANT_PROP,
     },
     required: ['contactId', 'templateSlug'],
+    type: 'object',
+  },
+  'crm.send.command.approve': {
+    additionalProperties: false,
+    properties: { commandId: { description: 'Command id to approve + execute.', type: 'string' }, tenant: TENANT_PROP },
+    required: ['commandId'],
+    type: 'object',
+  },
+  'crm.send.command.reject': {
+    additionalProperties: false,
+    properties: {
+      commandId: { description: 'Command id to reject.', type: 'string' },
+      reason: { description: 'Optional rejection reason.', type: 'string' },
+      tenant: TENANT_PROP,
+    },
+    required: ['commandId'],
+    type: 'object',
+  },
+  'crm.import.run': {
+    additionalProperties: false,
+    properties: {
+      csv: { description: 'CSV text (header row + contacts).', type: 'string' },
+      listName: { description: 'Optional list display name.', type: 'string' },
+      listSlug: { description: 'Optional list slug to add imported contacts to.', type: 'string' },
+      sourceLabel: { description: 'Audit label for the import run.', type: 'string' },
+      tenant: TENANT_PROP,
+    },
+    required: ['csv'],
+    type: 'object',
+  },
+  'crm.batch.send': {
+    additionalProperties: false,
+    properties: {
+      channel: { description: 'Send channel.', enum: ['gmail_gws', 'resend'], type: 'string' },
+      contactIds: { description: 'Contact ids to plan a send for.', items: { type: 'string' }, type: 'array' },
+      sendReason: { description: 'Optional reason.', type: 'string' },
+      templateSlug: { description: 'Template slug.', type: 'string' },
+      tenant: TENANT_PROP,
+    },
+    required: ['contactIds', 'templateSlug'],
     type: 'object',
   },
   'crm.template.upsert': {
@@ -226,6 +275,43 @@ const writeTool = (
   title,
 })
 
+const approvalTool = (
+  name: string,
+  title: string,
+  description: string,
+): OpenAgentsMcpToolDescriptor => ({
+  description,
+  inputSchemaRef: `${name}.input`,
+  name,
+  outputSchemaRef: `${name}.output`,
+  progressBehavior: 'none',
+  publicSummary: title,
+  receiptBehavior: 'approval_receipt',
+  requiredAuthorities: ['approval_resolution'],
+  riskClass: 'medium',
+  sourceRefs: [SOURCE],
+  title,
+})
+
+// Dry-run-only batch: operator_read, no receipt (mutates nothing over MCP).
+const readishTool = (
+  name: string,
+  title: string,
+  description: string,
+): OpenAgentsMcpToolDescriptor => ({
+  description,
+  inputSchemaRef: `${name}.input`,
+  name,
+  outputSchemaRef: `${name}.output`,
+  progressBehavior: 'none',
+  publicSummary: title,
+  receiptBehavior: 'none',
+  requiredAuthorities: ['operator_read'],
+  riskClass: 'low',
+  sourceRefs: [SOURCE],
+  title,
+})
+
 export const CRM_MCP_WRITE_TOOLS: ReadonlyArray<OpenAgentsMcpToolDescriptor> = [
   writeTool(
     'crm.send.command.propose',
@@ -239,6 +325,28 @@ export const CRM_MCP_WRITE_TOOLS: ReadonlyArray<OpenAgentsMcpToolDescriptor> = [
     'Create or update a CRM email template for the tenant.',
     ['workspace_write'],
   ),
+  // --- Wave 3: gated execution ---
+  approvalTool(
+    'crm.send.command.approve',
+    'Approve + execute a send command',
+    'Approve a pending send_email command and execute it (the suppression/unsubscribe gate still applies).',
+  ),
+  approvalTool(
+    'crm.send.command.reject',
+    'Reject a send command',
+    'Reject a pending send_email command (nothing is sent).',
+  ),
+  writeTool(
+    'crm.import.run',
+    'Import contacts from CSV',
+    'Import contacts from CSV text into the tenant CRM, recording an audited import run.',
+    ['workspace_write'],
+  ),
+  readishTool(
+    'crm.batch.send',
+    'Plan a batch send (dry-run)',
+    'Plan a batch send across contacts. Over MCP this is DRY-RUN ONLY: it reports would_send/suppressed/failed counts and sends nothing.',
+  ),
 ]
 
 /** All CRM MCP tools (read + write), filtered per-principal at list time. */
@@ -250,7 +358,7 @@ export const CRM_MCP_TOOLS: ReadonlyArray<OpenAgentsMcpToolDescriptor> = [
 // --- dispatch (read fns) ----------------------------------------------------
 
 // Tenant is the principal's bound tenant — never client-supplied `args.tenant`.
-type CrmToolContext = Readonly<{ subjectRef: string }>
+type CrmToolContext = Readonly<{ subjectRef: string; dispatchDeps: CrmDispatchDeps }>
 type CrmToolHandler = (
   db: D1Database,
   tenant: string,
@@ -323,6 +431,37 @@ const CRM_MCP_WRITE_DISPATCH: Readonly<Record<string, CrmToolHandler>> = {
       subjectTemplate: requiredId(a, 'subjectTemplate'),
       tenantRef: tenant,
     }),
+  // --- Wave 3: gated execution ---
+  'crm.batch.send': (db, tenant, a, ctx) =>
+    runCrmBatch(db, ctx.dispatchDeps, {
+      channel: a.channel === 'resend' ? 'resend' : 'gmail_gws',
+      contactIds: stringArrayFromUnknown(a.contactIds),
+      dryRun: true, // MCP batch is DRY-RUN ONLY
+      sendReason: typeof a.sendReason === 'string' ? a.sendReason : null,
+      templateSlug: requiredId(a, 'templateSlug'),
+      tenantRef: tenant,
+    }),
+  'crm.import.run': (db, tenant, a) =>
+    importCrmContactsFromCsv(crmImportDepsFromDb(db), {
+      csv: requiredId(a, 'csv'),
+      listName: typeof a.listName === 'string' ? a.listName : null,
+      listSlug: typeof a.listSlug === 'string' ? a.listSlug : null,
+      sourceLabel:
+        typeof a.sourceLabel === 'string' && a.sourceLabel.trim() !== '' ? a.sourceLabel : 'mcp:import',
+      tenantRef: tenant,
+    }),
+  'crm.send.command.approve': (db, tenant, a, ctx) =>
+    approveAndExecuteCrmSendCommand(db, ctx.dispatchDeps, {
+      approvedByRef: ctx.subjectRef,
+      commandId: requiredId(a, 'commandId'),
+      tenantRef: tenant,
+    }),
+  'crm.send.command.reject': (db, tenant, a) =>
+    rejectCrmCommand(db, {
+      commandId: requiredId(a, 'commandId'),
+      reason: typeof a.reason === 'string' ? a.reason : null,
+      tenantRef: tenant,
+    }),
 }
 
 const CRM_MCP_DISPATCH: Readonly<Record<string, CrmToolHandler>> = {
@@ -343,7 +482,8 @@ const makeWriteReceipt = (
       : typeof record.updatedAt === 'string'
         ? record.updatedAt
         : ''
-  const kind: OpenAgentsMcpReceiptKind = 'mutation'
+  const kind: OpenAgentsMcpReceiptKind =
+    descriptor.receiptBehavior === 'approval_receipt' ? 'approval' : 'mutation'
   return {
     artifactRefs: [receiptRef],
     authorityClass: descriptor.requiredAuthorities[0] ?? 'operator_read',
@@ -459,7 +599,13 @@ const readCrmResourceData = async (
   }
 }
 
-export const makeCrmMcpReadCatalog = <Bindings extends CrmMcpEnv>(): CrmMcpCatalog<Bindings> => ({
+export type CrmMcpCatalogDeps<Bindings extends CrmMcpEnv> = Readonly<{
+  resolveResendDeps: (env: Bindings) => CrmDispatchDeps['resend']
+}>
+
+export const makeCrmMcpCatalog = <Bindings extends CrmMcpEnv>(
+  deps: CrmMcpCatalogDeps<Bindings>,
+): CrmMcpCatalog<Bindings> => ({
   callTool: async (env, _request, principal, name, callArgs) => {
     // Ungranted tools are ABSENT: an ungranted/unknown name is unknown_tool.
     const grantedAuthorities = openAgentsMcpGrantedAuthoritySet(principal.grants)
@@ -472,6 +618,7 @@ export const makeCrmMcpReadCatalog = <Bindings extends CrmMcpEnv>(): CrmMcpCatal
       throw new CrmMcpToolError('unknown_tool')
     }
     const data = await handler(openAgentsDatabase(env), principal.tenantRef, args(callArgs), {
+      dispatchDeps: { resend: deps.resolveResendDeps(env) },
       subjectRef: principal.subjectRef,
     })
     return descriptor.receiptBehavior === 'none'

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -444,7 +444,7 @@ import {
   readSelectedInferenceCreditTargetUser as readSelectedInferenceCreditTargetUserBase,
 } from './operator-targets'
 import { makeCrmBatchRoutes } from './crm-batch-routes'
-import { makeCrmMcpReadCatalog } from './crm-mcp'
+import { makeCrmMcpCatalog } from './crm-mcp'
 import {
   crmMcpAdminPrincipal,
   mcpTenantHeader,
@@ -7144,7 +7144,7 @@ const crmMcpRoutes = makeCrmMcpRoutes<WorkerBindings>({
     }
     return resolveCrmMcpGrantPrincipal(openAgentsDatabase(env), token, currentIsoTimestamp())
   },
-  catalog: makeCrmMcpReadCatalog<WorkerBindings>(),
+  catalog: makeCrmMcpCatalog<WorkerBindings>({ resolveResendDeps: resolveCrmResendDeps }),
 })
 
 const crmMcpGrantRoutes = makeCrmMcpGrantRoutes<WorkerBindings>({


### PR DESCRIPTION
Part of epic #5991. Adds `crm.send.command.approve`/`.reject` (approval_resolution; suppression gate still applies; approval receipts), `crm.import.run` (workspace_write), and `crm.batch.send` (operator_read, **dry-run forced** over MCP). Grant-filtered; tenant bound to the principal. 23 catalog tests; `check:deploy` green.

Closes #5997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)