### PR TITLE
mcp(#5998): public discovery doc + docs

### DIFF
--- a/apps/openagents.com/workers/api/src/crm-mcp-discovery-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-discovery-routes.test.ts
@@ -1,0 +1,58 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { makeCrmMcpDiscoveryRoutes } from './crm-mcp-discovery-routes'
+
+const ctx = {} as ExecutionContext
+const routes = makeCrmMcpDiscoveryRoutes()
+
+const run = (request: Request): Promise<Response> => {
+  const effect = routes.routeCrmMcpDiscoveryRequest(request, {}, ctx)
+  if (effect === undefined) throw new Error(`route did not match: ${request.url}`)
+  return Effect.runPromise(effect)
+}
+
+describe('CRM MCP discovery doc', () => {
+  test('GET /.well-known/openagents-mcp.json advertises the server, transport, and public tool catalog', async () => {
+    const res = await run(new Request('https://openagents.com/.well-known/openagents-mcp.json'))
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as {
+      server: { name: string }
+      transport: { endpoint: string; kind: string }
+      tools: Array<{ name: string; requiredAuthorities: string[] }>
+      resources: Array<{ uri: string }>
+    }
+    expect(doc.server.name).toBe('openagents-crm-mcp')
+    expect(doc.transport.endpoint).toBe('/api/mcp')
+    expect(doc.transport.kind).toBe('streamable_http')
+    expect(doc.tools.length).toBeGreaterThanOrEqual(21)
+    expect(doc.tools.map(t => t.name)).toContain('crm.contacts.list')
+    expect(doc.resources.map(r => r.uri)).toContain('mcp://openagents/worker/crm/contacts')
+  })
+
+  test('does not leak data — tools carry only metadata (name/title/authorities/risk)', async () => {
+    const res = await run(new Request('https://openagents.com/.well-known/openagents-mcp.json'))
+    const doc = (await res.json()) as { tools: Array<Record<string, unknown>> }
+    for (const tool of doc.tools) {
+      expect(Object.keys(tool).sort()).toEqual(
+        ['name', 'requiredAuthorities', 'riskClass', 'summary', 'title'].sort(),
+      )
+    }
+  })
+
+  test('non-GET is a 405', async () => {
+    const res = await run(
+      new Request('https://openagents.com/.well-known/openagents-mcp.json', { method: 'POST' }),
+    )
+    expect(res.status).toBe(405)
+  })
+
+  test('other paths pass through', () => {
+    const effect = routes.routeCrmMcpDiscoveryRequest(
+      new Request('https://openagents.com/api/mcp', { method: 'GET' }),
+      {},
+      ctx,
+    )
+    expect(effect).toBeUndefined()
+  })
+})

--- a/apps/openagents.com/workers/api/src/crm-mcp-discovery-routes.ts
+++ b/apps/openagents.com/workers/api/src/crm-mcp-discovery-routes.ts
@@ -1,0 +1,70 @@
+/**
+ * Public MCP discovery doc (epic #5991, sub-issue #5998).
+ *
+ *   GET /.well-known/openagents-mcp.json   (public, refs-only)
+ *
+ * Advertises the CRM MCP server: schema/protocol version, transport + endpoint,
+ * the auth model, and a PUBLIC-SAFE tool/resource catalog (names, titles,
+ * required authority classes, risk class — NO data, NO secrets). Clients use
+ * this to discover the endpoint; actual `tools/list` is grant-filtered per
+ * caller at `POST /api/mcp`.
+ */
+import { Effect } from 'effect'
+
+import { OPENAGENTS_MCP_SCHEMA_VERSION } from '@openagentsinc/mcp-contract'
+
+import { CRM_MCP_RESOURCES, CRM_MCP_TOOLS } from './crm-mcp'
+import { CRM_MCP_PATH, CRM_MCP_PROTOCOL_VERSION, CRM_MCP_SERVER_INFO } from './crm-mcp-routes'
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+
+type HttpResponse = globalThis.Response
+
+const DISCOVERY_PATH = '/.well-known/openagents-mcp.json'
+
+const SOURCE = 'docs/mcp/2026-06-22-crm-mcp-server-phase-1-audit.md'
+
+const discoveryDocument = () => ({
+  authority: {
+    model: 'admin_token_or_scoped_grant',
+    note:
+      'Authenticate at the endpoint with an admin Bearer token (full CRM authority on the X-OpenAgents-Tenant / default tenant) or a scoped MCP grant token (its declared authority classes + bound tenant). tools/list is filtered by the caller grant; ungranted tools are absent.',
+    tenantHeader: 'X-OpenAgents-Tenant',
+  },
+  resources: CRM_MCP_RESOURCES.map(resource => ({
+    description: resource.description,
+    name: resource.name,
+    uri: resource.uri,
+  })),
+  schemaVersion: OPENAGENTS_MCP_SCHEMA_VERSION,
+  server: CRM_MCP_SERVER_INFO,
+  sourceRefs: [SOURCE],
+  tools: CRM_MCP_TOOLS.map(tool => ({
+    name: tool.name,
+    requiredAuthorities: tool.requiredAuthorities,
+    riskClass: tool.riskClass,
+    summary: tool.publicSummary,
+    title: tool.title,
+  })),
+  transport: {
+    endpoint: CRM_MCP_PATH,
+    kind: 'streamable_http',
+    protocolVersion: CRM_MCP_PROTOCOL_VERSION,
+  },
+})
+
+export const makeCrmMcpDiscoveryRoutes = () => ({
+  routeCrmMcpDiscoveryRequest: (
+    request: Request,
+    _env?: unknown,
+    _ctx?: ExecutionContext,
+  ): Effect.Effect<HttpResponse> | undefined => {
+    const url = new URL(request.url)
+    if (url.pathname !== DISCOVERY_PATH) {
+      return undefined
+    }
+    if (request.method !== 'GET') {
+      return Effect.succeed(methodNotAllowed(['GET']))
+    }
+    return Effect.succeed(noStoreJsonResponse(discoveryDocument()))
+  },
+})

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -445,6 +445,7 @@ import {
 } from './operator-targets'
 import { makeCrmBatchRoutes } from './crm-batch-routes'
 import { makeCrmMcpCatalog } from './crm-mcp'
+import { makeCrmMcpDiscoveryRoutes } from './crm-mcp-discovery-routes'
 import {
   crmMcpAdminPrincipal,
   mcpTenantHeader,
@@ -7151,6 +7152,8 @@ const crmMcpGrantRoutes = makeCrmMcpGrantRoutes<WorkerBindings>({
   requireAdminApiToken: (request, env) => requireAdminApiToken(request, env),
 })
 
+const crmMcpDiscoveryRoutes = makeCrmMcpDiscoveryRoutes()
+
 const agentScopedGrantRoutes = makeAgentScopedGrantRoutes({
   requireAdminApiToken: (request, env) => requireAdminApiToken(request, env),
   appOrigin: getAppOrigin,
@@ -10046,6 +10049,7 @@ const routeRequest = makeWorkerRouteRequest({
     crmSendRoutes.routeCrmSendRequest(request, env, ctx) ??
     crmCommandRoutes.routeCrmCommandRequest(request, env, ctx) ??
     crmBatchRoutes.routeCrmBatchRequest(request, env, ctx) ??
+    crmMcpDiscoveryRoutes.routeCrmMcpDiscoveryRequest(request, env, ctx) ??
     crmMcpGrantRoutes.routeCrmMcpGrantRequest(request, env, ctx) ??
     crmMcpRoutes.routeCrmMcpRequest(request, env, ctx) ??
     crmRoutes.routeCrmRequest(request, env, ctx),

--- a/docs/mcp/2026-06-22-crm-mcp-server-phase-1-audit.md
+++ b/docs/mcp/2026-06-22-crm-mcp-server-phase-1-audit.md
@@ -18,6 +18,25 @@
 
 ---
 
+## Implementation status (epic #5991, merged to main)
+
+Build log — landed on main (per-issue PRs):
+
+- ✅ **#5992 — JSON-RPC transport.** `crm-mcp-routes.ts`: `POST /api/mcp` (initialize/ping/notifications + tools/resources methods), injected catalog, tagged-error mapping.
+- ✅ **#5993 — read-only tool catalog.** `crm-mcp.ts`: 15 read tools + JSON-Schema catalog + dispatch + `projectOpenAgentsMcpOutput`.
+- ✅ **#5994 — resources.** `resources/list` + `resources/read` over `mcp://openagents/worker/crm/*`.
+- ✅ **#5995 — scoped grant + tenant binding.** Migration `0220 crm_mcp_grants`; `crm-mcp-grant.ts` (mint/resolve/revoke, hashed tokens) + admin grant routes; transport authenticates to an `McpPrincipal`; catalog filters tools/resources by grant (ungranted absent) and reads only the bound tenant.
+- ✅ **#5996 — Wave 2 propose + template.** `crm.send.command.propose` (sends nothing) + `crm.template.upsert`, with mutation receipts.
+- ✅ **#5997 — Wave 3 gated execution.** `crm.send.command.approve`/`.reject` (approval_resolution), `crm.import.run` (workspace_write), `crm.batch.send` (dry-run only over MCP).
+- ✅ **#5998 — discovery + docs.** `GET /.well-known/openagents-mcp.json` (public, refs-only) + `docs/mcp/README.md`.
+- ⏳ **#5999 — client compatibility smoke** — in progress.
+
+The full tool set is **21 tools** (15 read + 6 write), grant-filtered per caller. Every gate is preserved: suppression/unsubscribe, dry-run, the approval-gated command, tenant isolation. No new authority beyond the CRM HTTP routes.
+
+> **Note:** the web MCP server-export / capability-catalog projection lanes are not yet wired to the live CRM MCP ref; the public discovery doc (`/.well-known/openagents-mcp.json`) is the live refs-only surface, and the web lanes can consume it as a thin follow-up.
+
+---
+
 ## 1. Current MCP status (review)
 
 ### 1.1 Phase 0 contract — complete

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -34,16 +34,29 @@ defines typed contracts, validation helpers, import markers, and docs only; it
 does not start a stdio server, loopback listener, remote bridge, or external
 MCP client connector.
 
-**Next implementation epic (re-sequenced 2026-06-22): expose the CRM as the
-first OpenAgents MCP server** — a stateless Streamable-HTTP JSON-RPC facade
-(`POST /api/mcp`) in the existing Worker, scoped to the CRM, using
-`@openagentsinc/mcp-contract` for descriptors, authority filtering, output
-safety, tagged errors, and receipts. The CRM (epic #5980) is the cleanest,
-already-shipped, bounded surface to prove the full MCP authority model
-end-to-end (read tools → propose → approval-gated execute), and it doubles as
-the template for customers exposing their own tenant CRM over MCP. The
-read-only **local Pylon stdio server** becomes the next MCP server after the
-CRM epic, reusing the transport + grant patterns proven there. See
+**The CRM MCP server (epic #5991) is built** — the first OpenAgents function
+served over MCP.
+
+- **Endpoint:** `POST /api/mcp` (stateless Streamable-HTTP JSON-RPC:
+  `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`,
+  `ping`).
+- **Discovery:** `GET /.well-known/openagents-mcp.json` (public, refs-only:
+  server + transport + the public-safe tool/resource catalog).
+- **Auth:** admin Bearer token (full CRM authority on the `X-OpenAgents-Tenant`
+  / default tenant) OR a scoped MCP grant token (declared authority classes +
+  bound tenant). Mint/list/revoke at `POST/GET/DELETE /api/operator/crm/mcp-grants`.
+- **Tools (grant-filtered, ungranted = absent):** read tools (`operator_read`)
+  over contacts/accounts/lists/activities/engagement/opportunities/imports/
+  templates/commands/queue + `crm.contact.render`; `crm.send.command.propose`
+  (proposes only — sends nothing); `crm.template.upsert` (workspace_write);
+  `crm.send.command.approve`/`.reject` (approval_resolution); `crm.import.run`
+  (workspace_write); `crm.batch.send` (dry-run only over MCP).
+- **Safety:** results output-safety-projected (operator class); tenant bound to
+  the credential (client `args.tenant` ignored); agent sends are
+  propose → human-approve. Built on `@openagentsinc/mcp-contract`.
+
+The read-only **local Pylon stdio server** is the next MCP server after this
+epic, reusing the transport + grant patterns proven here. See
 `2026-06-22-crm-mcp-server-phase-1-audit.md`.
 
 ## Documents


### PR DESCRIPTION
Part of epic #5991. Adds public refs-only `GET /.well-known/openagents-mcp.json` (server, transport, public-safe tool/resource catalog) and updates `docs/mcp/README.md` + the phase-1 audit build log. 4 tests; `check:deploy` green.

Closes #5998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)