### PR TITLE
Expose khala-mini in the inference model catalog

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/inference-free-allowance.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-free-allowance.test.ts
@@ -27,6 +27,7 @@ import {
   usdToMicrosCeil,
   withFreeAllowance,
 } from './inference-free-allowance'
+import { KHALA_MINI_MODEL_ID } from './pricing'
 
 // --- node:sqlite D1 adapter (same pattern as metering-hook.test.ts) ----------
 type Row = Record<string, unknown>
@@ -209,9 +210,10 @@ describe('free-allowance constants + classification', () => {
     expect(baseFreeCapUsdMicros('unclaimed')).toBe(USD_MICROS_PER_USD / 2)
   })
 
-  test('only the Gemini lane is free-eligible', () => {
+  test('only the Gemini Flash aliases are free-eligible', () => {
     expect(isFreeEligibleModel('gemini-3.5-flash')).toBe(true)
     expect(isFreeEligibleModel('gemini')).toBe(true)
+    expect(isFreeEligibleModel(KHALA_MINI_MODEL_ID)).toBe(false)
     expect(isFreeEligibleModel('claude-sonnet')).toBe(false)
     expect(isFreeEligibleModel('opus')).toBe(false)
     expect(isFreeEligibleModel('gpt-oss-20b')).toBe(false)

--- a/apps/openagents.com/workers/api/src/inference/inference-free-allowance.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-free-allowance.ts
@@ -55,7 +55,6 @@ import {
   type MeteringOutcome,
 } from './metering-hook'
 import { priceRequest } from './pricing'
-import { classifyModel, type ModelClass } from './model-router'
 import {
   type VerifiedOwnerIdentityResolver,
   resolveOwnerKey,
@@ -101,13 +100,17 @@ export const EARNED_ALLOWANCE_PER_REFERRED_SIGNUP_USD_MICROS = USD_MICROS_PER_US
 // Default $100.00 of earned headroom.
 export const EARNED_ALLOWANCE_CEILING_USD_MICROS = 100 * USD_MICROS_PER_USD // $100.00
 
-// The model classes whose served usage is FREE-ELIGIBLE (we eat the cost under
-// allowance). Only the first-party Vertex Gemini lane (Gemini Flash) today —
-// Claude/open/passthrough are never free. A bounded class set, not intent.
-export const FREE_ELIGIBLE_MODEL_CLASSES: ReadonlyArray<ModelClass> = ['gemini']
+// The exact model ids whose served usage is FREE-ELIGIBLE (we eat the cost
+// under allowance). Only the first-party Gemini Flash taste lane today;
+// OpenAgents-branded paid aliases such as Khala may share a backing lane without
+// inheriting the free pool.
+export const FREE_ELIGIBLE_MODEL_IDS: ReadonlyArray<string> = [
+  'gemini',
+  'gemini-3.5-flash',
+]
 
 export const isFreeEligibleModel = (model: string): boolean =>
-  FREE_ELIGIBLE_MODEL_CLASSES.includes(classifyModel(model))
+  FREE_ELIGIBLE_MODEL_IDS.includes(model.trim().toLowerCase())
 
 // ----------------------------------------------------------------------------
 // Identity kind + effective cap

--- a/apps/openagents.com/workers/api/src/inference/model-catalog.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-catalog.ts
@@ -25,8 +25,7 @@ import {
   MODEL_PRICING_TABLE,
   type SupplyLane,
 } from './pricing'
-import { classifyModel } from './model-router'
-import { FREE_ELIGIBLE_MODEL_CLASSES } from './inference-free-allowance'
+import { isFreeEligibleModel } from './inference-free-allowance'
 
 // Human-legible provider label for each supply lane (the OpenAI `owned_by`
 // field). All lanes are served THROUGH OpenAgents, so the label names the
@@ -91,7 +90,7 @@ const round = (value: number, decimals: number): number => {
 // so the published free-tier flag can never disagree with what actually gets
 // eaten under allowance.
 const isFreeTierEligible = (model: string): boolean =>
-  FREE_ELIGIBLE_MODEL_CLASSES.includes(classifyModel(model))
+  isFreeEligibleModel(model)
 
 // Build the public model catalog from the pricing table at `margin`
 // (defaults to the launch margin). Deterministic + pure: the same table in

--- a/apps/openagents.com/workers/api/src/inference/model-router.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.test.ts
@@ -13,8 +13,10 @@ import {
   selectAdapterPlan,
   selectPrimaryAdapterId,
   VERTEX_ANTHROPIC_ADAPTER_ID,
+  VERTEX_GEMINI_ADAPTER_ID,
 } from './model-router'
 import { openAgentsNetworkAdapter } from './openagents-network-adapter'
+import { KHALA_MINI_MODEL_ID } from './pricing'
 import {
   InferenceAdapterError,
   type InferenceProviderAdapter,
@@ -127,6 +129,13 @@ describe('model classification', () => {
       expect(classifyModel(model)).toBe('open')
       expect(selectPrimaryAdapterId(model)).toBe(FIREWORKS_ADAPTER_ID)
     }
+  })
+
+  test('routes the Khala mini virtual model to its priced backing lane', () => {
+    expect(classifyModel(KHALA_MINI_MODEL_ID)).toBe('gemini')
+    expect(selectAdapterPlan(KHALA_MINI_MODEL_ID)).toEqual([
+      VERTEX_GEMINI_ADAPTER_ID,
+    ])
   })
 
   test('routes unknown models to passthrough only', () => {

--- a/apps/openagents.com/workers/api/src/inference/model-router.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.ts
@@ -106,6 +106,18 @@ const LANE_ADAPTER_IDS: Readonly<Record<RouterLane, ReadonlyArray<string>>> = {
 // classification we do is "which provider family is this model id?".
 export type ModelClass = 'claude' | 'gemini' | 'open' | 'unknown'
 
+const classForPricedLane = (lane: SupplyLane): ModelClass => {
+  switch (lane) {
+    case 'vertex-anthropic':
+      return 'claude'
+    case 'vertex-gemini':
+      return 'gemini'
+    case 'fireworks':
+    case 'openagents-network':
+      return 'open'
+  }
+}
+
 // Gemini-family model ids served from the Vertex Gemini lane. Matched against
 // the LOWERCASED requested id. The bare `gemini` alias and the canonical
 // `gemini-*` ids both route here, as do `google/` / `vertex/` provider-prefixed
@@ -163,6 +175,10 @@ export const classifyModel = (model: string): ModelClass => {
   }
   if (isOpenModel(model)) {
     return 'open'
+  }
+  const priced = lookupModel(model)
+  if (priced !== undefined) {
+    return classForPricedLane(priced.lane)
   }
   return 'unknown'
 }

--- a/apps/openagents.com/workers/api/src/inference/models-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/models-routes.test.ts
@@ -6,7 +6,7 @@ import {
   handleModelsList,
   routeModelRetrieveRequest,
 } from './models-routes'
-import { MODEL_PRICING_TABLE } from './pricing'
+import { KHALA_MINI_MODEL_ID, MODEL_PRICING_TABLE } from './pricing'
 import { buildModelCatalog } from './model-catalog'
 import { resolveSupplyLaneArming } from './model-serving-policy'
 
@@ -52,6 +52,7 @@ describe('handleModelsList', () => {
     expect(body.data.length).toBe(MODEL_PRICING_TABLE.length)
     expect(body.data.every(m => m.object === 'model')).toBe(true)
     expect(body.data.every(m => m.created === 1_700_000_000)).toBe(true)
+    expect(body.data.some(m => m.id === KHALA_MINI_MODEL_ID)).toBe(true)
   })
 })
 
@@ -238,6 +239,7 @@ describe('provider serving policy (laneArming)', () => {
     expect(body.data.length).toBeGreaterThan(0)
     expect(body.data.length).toBeLessThan(MODEL_PRICING_TABLE.length)
     expect(body.data.some(m => m.id === geminiId)).toBe(true)
+    expect(body.data.some(m => m.id === KHALA_MINI_MODEL_ID)).toBe(true)
     expect(body.data.some(m => m.id === fireworksId)).toBe(false)
     expect(body.data.every(m => m.oa_lane.startsWith('vertex-'))).toBe(true)
   })
@@ -263,6 +265,23 @@ describe('provider serving policy (laneArming)', () => {
     expect(response.status).toBe(200)
     const body = (await response.json()) as { id: string }
     expect(body.id).toBe(geminiId)
+  })
+
+  it('retrieves the Khala mini virtual model on its armed backing lane', async () => {
+    const response = await runRetrieve(
+      new Request(`https://x/v1/models/${KHALA_MINI_MODEL_ID}`, {
+        method: 'GET',
+      }),
+      KHALA_MINI_MODEL_ID,
+      {
+        enabled: true,
+        laneArming: resolveSupplyLaneArming({ VERTEX_SA_KEY: 'sa' }),
+      },
+    )
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { id: string; oa_lane: string }
+    expect(body.id).toBe(KHALA_MINI_MODEL_ID)
+    expect(body.oa_lane).toBe('vertex-gemini')
   })
 
   it('reports model_not_found for a known model on an UNARMED lane', async () => {

--- a/apps/openagents.com/workers/api/src/inference/pricing.ts
+++ b/apps/openagents.com/workers/api/src/inference/pricing.ts
@@ -253,6 +253,12 @@ const VERTEX_GEMINI_COST: Readonly<Record<string, ModelCostPerMtok>> = {
   },
 }
 
+// First Khala virtual model id (M0 / #6008). It is a public OpenAgents model
+// alias backed by the existing Gemini Flash lane until the full Khala
+// coordinator/worker fabric lands; adding it here keeps catalog, quote, and
+// receipt-first metering prices derived from the same source of truth.
+export const KHALA_MINI_MODEL_ID = 'openagents/khala-mini'
+
 // Unknown-model fallback cost. Conservative: priced like a mid open model so an
 // un-tabled model is never under-charged below plausible cost (docs edge:
 // unknown models still clear a sane floor). Not a measured rate.
@@ -320,6 +326,15 @@ export const MODEL_PRICING_TABLE: ReadonlyArray<ModelPricingEntry> = [
   // committed-use rate lands.
   entry(
     'gemini-3.5-flash',
+    'vertex-gemini',
+    VERTEX_GEMINI_COST['gemini-3.5-flash']!,
+    true,
+  ),
+  // Khala M0 virtual model alias. Uses the same current cost basis as the
+  // Gemini Flash backing lane; the richer Khala coordinator, worker fabric,
+  // verification, and settlement receipt fields remain separate milestones.
+  entry(
+    KHALA_MINI_MODEL_ID,
     'vertex-gemini',
     VERTEX_GEMINI_COST['gemini-3.5-flash']!,
     true,


### PR DESCRIPTION
Problem
- Khala M0 (#6008) needs the OpenAI-compatible model discovery surface to expose the first OpenAgents virtual model id without overclaiming the full live-provider/receipt path.
- Current main already has GET /v1/models, retrieve, quote, exact-route coverage, and lane arming. The missing narrow slice is the openagents/khala-mini catalog alias plus backing-lane consistency.

Changes
- Adds KHALA_MINI_MODEL_ID = openagents/khala-mini to the pricing/catalog source of truth, backed by the existing Vertex Gemini Flash lane/cost basis.
- Lets priced virtual aliases resolve to their configured backing lane in the router, so the catalog is not a fake listing.
- Keeps free allowance restricted to explicit Gemini Flash aliases, so Khala does not inherit the free taste pool just because it shares the Gemini backing lane.
- Adds tests for list/retrieve visibility, router resolution, and Khala staying paid.

Validation
- bun run --cwd apps/openagents.com/workers/api test -- src/inference/model-catalog.test.ts src/inference/pricing.test.ts src/inference/cost-estimate.test.ts src/inference/model-serving-policy.test.ts src/inference/quote-routes.test.ts src/inference/models-routes.test.ts src/inference/model-router.test.ts src/inference/chat-completions-routes.test.ts src/inference/inference-free-allowance.test.ts
- git diff --check

Typecheck note
- bun run --cwd apps/openagents.com/workers/api typecheck currently fails before this slice on missing @openagentsinc/mcp-contract imports in CRM MCP files: src/crm-mcp-discovery-routes.ts, src/crm-mcp-grant.ts, src/crm-mcp-routes.ts, src/crm-mcp.test.ts, src/crm-mcp.ts, src/mcp-contract-import.ts.

Intentionally not changed
- No provider secret wiring, no prod flag flip, no new provider activation, no populated openagents response block, no ledger decrement proof, no product-promise green/state change.
- The rest of M0 remains open for real provider receipt evidence and the full public serve receipt.

Public coordination
- Claimed narrowly in the Khala acceptance-gate forum topic: https://openagents.com/forum/t/9e615a3b-4379-4897-a463-62ca0a5257b3#post-38a860ae-cdf3-4510-984f-51fc331289fc