### PR TITLE
Khala M1: Autopilot calls Khala (cockpit + receipt UI)

### DIFF
--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -15,6 +15,7 @@
     "smoke:verse-launch": "bun scripts/verse-launch-smoke.ts",
     "smoke:forum-tipping-multiplayer": "bun test tests/forum-tipping-multiplayer-integration.test.ts",
     "smoke:apple-fm-local": "bun scripts/apple-fm-live-smoke.ts",
+    "smoke:khala-cockpit": "bun scripts/khala-cockpit-smoke.ts",
     "proof:verse-coding-overlay": "bun scripts/verse-launch-smoke.ts",
     "proof:composer": "bun scripts/composer-loop-proof.ts",
     "proof:account-picker": "bun scripts/account-picker-proof.ts",

--- a/apps/autopilot-desktop/scripts/khala-cockpit-smoke.ts
+++ b/apps/autopilot-desktop/scripts/khala-cockpit-smoke.ts
@@ -1,0 +1,125 @@
+// Khala cockpit smoke (M1, #6009, EPIC #6017) — Lane A.
+//
+// Stands up a tiny LOCAL STUB gateway that mimics the OpenAI-compatible
+// `/v1/chat/completions` shape + the NON-BREAKING `openagents` receipt block,
+// then runs the crossy-road north-star prompt through the real cockpit call
+// path (`buildKhalaTurn`) against `openagents/khala-mini` and
+// `openagents/khala-code`. Prints the rendered completion and the receipt
+// projection, and asserts the LIVE gate behaves: a receipt-bearing response is
+// live, a receipt-less response is not.
+//
+// SCAFFOLD, not product proof: this exercises the cockpit consumption path
+// against a STUB, so the prod gateway being inert/owner-gated does not block it.
+// Replace the stub with a real local/staging gateway to get a real receipt.
+
+import { buildKhalaTurn } from "../src/bun/khala-turn.js"
+import {
+  KHALA_CODE_MODEL_ID,
+  KHALA_MINI_MODEL_ID,
+  summarizeKhalaReceipt,
+} from "../src/shared/khala-cockpit.js"
+
+const CROSSY_ROAD_PROMPT =
+  "build a really high quality single html file crossy road game with three.js"
+
+const STUB_HTML =
+  "<!doctype html><html><head><title>Crossy Road</title></head>" +
+  "<body><script type=\"module\">/* three.js crossy road */</script></body></html>"
+
+// A stub gateway: khala-code returns a verified receipt; khala-mini returns a
+// no-receipt (free/stub) route. Mimics the gateway `openagents` block shape.
+const startStubGateway = (): { url: string; stop: () => void } => {
+  const server = Bun.serve({
+    port: 0,
+    fetch: async (req) => {
+      const body = (await req.json()) as { model: string }
+      const model = body.model
+      if (model === KHALA_CODE_MODEL_ID) {
+        return Response.json({
+          id: "chatcmpl_stub_code",
+          model,
+          choices: [
+            { index: 0, finish_reason: "stop", message: { role: "assistant", content: STUB_HTML } },
+          ],
+          usage: { prompt_tokens: 18, completion_tokens: 540, total_tokens: 558 },
+          openagents: {
+            requested_model: KHALA_CODE_MODEL_ID,
+            served_model: "stub-coder",
+            worker: "stub-fabric",
+            lane: "coding",
+            route: "coding",
+            verification: "test_passed",
+            verified: true,
+            receipt: "oa_receipt_stub_code_1",
+            receipt_url: "/api/public/inference/receipts/oa_receipt_stub_code_1",
+            rubric: {
+              ref: "rubric.crossy_road.v1",
+              passed_checks: ["single_html_file", "loads_and_runs_headless"],
+              failed_checks: [],
+            },
+          },
+        })
+      }
+      // khala-mini: a real answer but NO receipt (e.g. free/stub route).
+      return Response.json({
+        id: "chatcmpl_stub_mini",
+        model,
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "Here is a plan for a crossy road game..." },
+          },
+        ],
+        usage: { prompt_tokens: 18, completion_tokens: 60, total_tokens: 78 },
+      })
+    },
+  })
+  return { url: `http://127.0.0.1:${server.port}`, stop: () => server.stop(true) }
+}
+
+const main = async () => {
+  const gateway = startStubGateway()
+  const env = { OPENAGENTS_INFERENCE_GATEWAY_BASE_URL: gateway.url }
+  const agentToken = "stub-agent-token"
+  let failures = 0
+
+  const run = async (
+    label: string,
+    model: typeof KHALA_MINI_MODEL_ID | typeof KHALA_CODE_MODEL_ID,
+    expectLive: boolean,
+  ) => {
+    const r = await buildKhalaTurn({ prompt: CROSSY_ROAD_PROMPT, model, env, agentToken })
+    console.log(`\n=== ${label} (${model}) ===`)
+    console.log(`ok=${r.ok} live=${r.live}`)
+    console.log(`completion: ${r.text.slice(0, 80)}${r.text.length > 80 ? "..." : ""}`)
+    console.log(`receipt: ${summarizeKhalaReceipt(r.receipt)}`)
+    if (r.receipt !== null) {
+      console.log(
+        `  requested=${r.receipt.requestedModel} served=${r.receipt.servedModel} ` +
+          `worker=${r.receipt.worker} lane=${r.receipt.lane} ` +
+          `verification=${r.receipt.verification} receipt=${r.receipt.receipt ?? "—"}`,
+      )
+    }
+    if (!r.ok) {
+      console.error(`  FAIL: turn not ok`)
+      failures += 1
+    }
+    if (r.live !== expectLive) {
+      console.error(`  FAIL: expected live=${expectLive}, got live=${r.live}`)
+      failures += 1
+    }
+  }
+
+  await run("khala-mini (no receipt → not live)", KHALA_MINI_MODEL_ID, false)
+  await run("khala-code (verified receipt → live)", KHALA_CODE_MODEL_ID, true)
+
+  gateway.stop()
+  if (failures > 0) {
+    console.error(`\nSMOKE FAILED (${failures} assertion(s)) — SCAFFOLD evidence.`)
+    process.exit(1)
+  }
+  console.log("\nSMOKE PASSED — SCAFFOLD evidence (stub gateway, not product proof).")
+}
+
+await main()

--- a/apps/autopilot-desktop/src/bun/index.ts
+++ b/apps/autopilot-desktop/src/bun/index.ts
@@ -60,6 +60,7 @@ import {
 import { projectInstallReadiness } from "../shared/install-readiness.js"
 import { buildInferenceGatewayReadiness } from "./inference-gateway.js"
 import { buildShellTurn, resolveShellAgentToken } from "./shell-turn.js"
+import { buildKhalaTurn } from "./khala-turn.js"
 import { buildVerseTurn } from "./verse-turn.js"
 import {
   addManagedAccount,
@@ -1035,6 +1036,23 @@ const rpc = BrowserView.defineRPC<DesktopRPCSchema>({
       async verseTurn(params) {
         return buildVerseTurn({
           prompt: params.prompt,
+          env: Bun.env,
+          agentToken: resolveShellAgentToken(Bun.env, () => {
+            const home = onboardingHome()
+            return home === null
+              ? null
+              : (loadPersistedCredential(home)?.token ?? null)
+          }),
+        })
+      },
+      // M1 (#6009, EPIC #6017): one Khala cockpit turn. Submits to a
+      // `openagents/khala-*` model and returns the answer plus the public-safe
+      // `openagents` receipt projection. Reuses the same host-side agent token
+      // resolution as shellTurn; the raw token never crosses to the webview.
+      async khalaTurn(params) {
+        return buildKhalaTurn({
+          prompt: params.prompt,
+          ...(params.model === undefined ? {} : { model: params.model }),
           env: Bun.env,
           agentToken: resolveShellAgentToken(Bun.env, () => {
             const home = onboardingHome()

--- a/apps/autopilot-desktop/src/bun/khala-turn.ts
+++ b/apps/autopilot-desktop/src/bun/khala-turn.ts
@@ -1,0 +1,190 @@
+// Bun-host Khala cockpit turn (M1, #6009, EPIC #6017).
+//
+// Lane A — Cockpit. Submits a cockpit prompt to a `openagents/khala-*` model on
+// the OpenAI-compatible `POST /v1/chat/completions` gateway, projects the
+// assistant answer AND the NON-BREAKING `openagents` receipt block back to the
+// webview, and computes the LIVE gate (only true when a real receipt ref is
+// present).
+//
+// This is the Khala-specific sibling of `shell-turn.ts`. It deliberately keeps
+// the Khala model id explicit (the cockpit chooses khala-mini / khala-code)
+// instead of the free-tier default, and — unlike the plain shell turn — it
+// surfaces the receipt so a Khala completion is auditable, not opaque.
+//
+// SECRET BOUNDARY: the agent token lives ONLY in the Bun host. It is placed in
+// the outbound Authorization header here and NEVER crosses the RPC boundary.
+//
+// HONEST, NEVER-FAKE: no token, or a gateway/network error, returns a clean
+// in-conversation message and `live:false` with no receipt. It never invents an
+// answer and never claims "live" without a receipt.
+//
+// NOT OWNER-DEPENDENT: works against a local/stub or staging gateway via the
+// base-url env override. The prod gateway is inert/owner-gated; this path does
+// not depend on it — the live badge is gated on a real receipt, not on prod.
+
+import {
+  inferenceGatewayChatCompletionsUrl,
+  resolveInferenceGatewaySettings,
+} from "../shared/inference-gateway.js"
+import {
+  isKhalaCockpitModelId,
+  isLiveReceipt,
+  parseKhalaReceipt,
+  type KhalaCockpitModelId,
+  type KhalaTurnResult,
+  KHALA_MINI_MODEL_ID,
+} from "../shared/khala-cockpit.js"
+
+// A short, neutral system steer so Khala answers as the cockpit agent.
+export const KHALA_COCKPIT_SYSTEM_PROMPT =
+  "You are Autopilot, the OpenAgents desktop agent. Answer the user's message directly. " +
+  "When asked to build something, return complete, runnable code."
+
+const NO_TOKEN_MESSAGE =
+  "I can't reach Khala yet — no OpenAgents account token is configured. " +
+  "Set OPENAGENTS_AGENT_TOKEN in the desktop app's environment (the same token " +
+  "the app uses to talk to openagents.com) and submit again. " +
+  "You can create or copy a token from your account at https://openagents.com."
+
+type KhalaTurnEnv = Readonly<Record<string, string | undefined>>
+
+export type BuildKhalaTurnInput = Readonly<{
+  prompt: string
+  // The Khala model id to submit to. Defaults to khala-mini.
+  model?: KhalaCockpitModelId
+  env: KhalaTurnEnv
+  // The OpenAgents agent token (kept in the Bun host); never crosses to webview.
+  agentToken: string | null
+  fetchFn?: typeof fetch
+}>
+
+// Pull the assistant text out of an OpenAI-compatible chat-completions body.
+const parseAssistantText = (body: unknown): string | null => {
+  if (typeof body !== "object" || body === null) return null
+  const choices = (body as { choices?: unknown }).choices
+  if (!Array.isArray(choices) || choices.length === 0) return null
+  const first = choices[0] as { message?: { content?: unknown } } | undefined
+  const content = first?.message?.content
+  return typeof content === "string" && content.trim().length > 0
+    ? content
+    : null
+}
+
+const parseErrorMessage = (body: unknown, status: number): string => {
+  if (typeof body === "object" && body !== null) {
+    const record = body as { error?: unknown; message?: unknown }
+    if (typeof record.message === "string" && record.message.trim().length > 0) {
+      return record.message
+    }
+    if (typeof record.error === "string" && record.error.trim().length > 0) {
+      return record.error
+    }
+  }
+  return `request failed (${status})`
+}
+
+const errorResult = (text: string): KhalaTurnResult => ({
+  ok: false,
+  text,
+  receipt: null,
+  live: false,
+})
+
+export const buildKhalaTurn = async (
+  input: BuildKhalaTurnInput,
+): Promise<KhalaTurnResult> => {
+  const fetchFn = input.fetchFn ?? fetch
+  const settings = resolveInferenceGatewaySettings(input.env)
+  const model: KhalaCockpitModelId =
+    input.model && isKhalaCockpitModelId(input.model)
+      ? input.model
+      : KHALA_MINI_MODEL_ID
+  const url = inferenceGatewayChatCompletionsUrl(settings.baseUrl)
+  const prompt = input.prompt.trim()
+
+  if (prompt === "") {
+    return errorResult("Type a message and submit to get a response.")
+  }
+
+  const token =
+    input.agentToken !== null && input.agentToken.trim().length > 0
+      ? input.agentToken.trim()
+      : null
+  if (token === null) {
+    return errorResult(NO_TOKEN_MESSAGE)
+  }
+
+  try {
+    const res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        stream: false,
+        messages: [
+          { role: "system", content: KHALA_COCKPIT_SYSTEM_PROMPT },
+          { role: "user", content: prompt },
+        ],
+      }),
+    })
+
+    let body: unknown = null
+    try {
+      body = await res.json()
+    } catch {
+      body = null
+    }
+
+    if (!res.ok) {
+      const reason = parseErrorMessage(body, res.status)
+      if (res.status === 401 || res.status === 403) {
+        return errorResult(
+          "I couldn't authenticate with openagents.com. The configured " +
+            "account token may be invalid or expired — refresh it and try again.",
+        )
+      }
+      if (res.status === 402) {
+        return errorResult(
+          "Your credit balance is empty. Add credit at https://openagents.com " +
+            "to keep running Khala.",
+        )
+      }
+      if (res.status === 404) {
+        return errorResult(
+          "Khala isn't available right now. Please try again in a moment.",
+        )
+      }
+      return errorResult(
+        `I couldn't get a response right now: ${reason}. Please try again.`,
+      )
+    }
+
+    const text = parseAssistantText(body)
+    const receipt = parseKhalaReceipt(body)
+    if (text === null) {
+      // No answer text: still surface the receipt if one came back, but the turn
+      // is not "ok".
+      return {
+        ok: false,
+        text: "Khala returned an empty response. Please try again.",
+        receipt,
+        live: isLiveReceipt(receipt),
+      }
+    }
+    return {
+      ok: true,
+      text,
+      receipt,
+      live: isLiveReceipt(receipt),
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : "network error"
+    return errorResult(
+      `I couldn't reach Khala (${reason}). Check your connection and try again.`,
+    )
+  }
+}

--- a/apps/autopilot-desktop/src/shared/khala-cockpit.ts
+++ b/apps/autopilot-desktop/src/shared/khala-cockpit.ts
@@ -1,0 +1,170 @@
+// Khala cockpit shared projection (M1, #6009, EPIC #6017).
+//
+// Lane A — Cockpit. This module is the single PURE, DOM-free home for the
+// Autopilot cockpit's Khala call path: which `openagents/khala-*` model ids the
+// cockpit may submit to, and how to parse the NON-BREAKING `openagents`
+// disclosure block off an OpenAI-compatible chat-completions response into a
+// public-safe projection the webview can render.
+//
+// CONSUME-ONLY: the `openagents` block shape is OWNED by the gateway
+// (`apps/openagents.com/.../inference/chat-completions-routes.ts`,
+// `OpenAgentsReceipt`). This module only READS it; it never defines or mutates
+// that shape. If the cockpit needs a new field, that is a gateway PR — see the
+// roadmap "Lane A" collision rule.
+//
+// LIVE-GATING: a cockpit "live" indicator is a product claim. It is TRUE only
+// when the response carries a real receipt ref in the `openagents` block. A
+// completion with no receipt (e.g. a stub/free route) renders as a real answer
+// but an UNVERIFIED / not-live badge. Never claim "live" off a missing receipt.
+
+// The Khala virtual model ids the cockpit can submit to. Mirrors the gateway
+// catalog (`khala.md` §3). Kept as a closed union so the cockpit cannot submit
+// to an unknown "khala-*" id by typo.
+export const KHALA_MINI_MODEL_ID = "openagents/khala-mini" as const
+export const KHALA_CODE_MODEL_ID = "openagents/khala-code" as const
+
+export type KhalaCockpitModelId =
+  | typeof KHALA_MINI_MODEL_ID
+  | typeof KHALA_CODE_MODEL_ID
+
+export const KHALA_COCKPIT_MODEL_IDS: ReadonlyArray<KhalaCockpitModelId> = [
+  KHALA_MINI_MODEL_ID,
+  KHALA_CODE_MODEL_ID,
+]
+
+export const isKhalaCockpitModelId = (
+  value: string,
+): value is KhalaCockpitModelId =>
+  (KHALA_COCKPIT_MODEL_IDS as ReadonlyArray<string>).includes(value)
+
+// The public-safe projection of the gateway `openagents` block for the cockpit.
+// This is what crosses the RPC boundary to the webview and what the receipt UI
+// renders. It carries ONLY the disclosed routing/verification fields; no
+// prompts, credentials, or chain-of-thought.
+export type KhalaReceiptProjection = Readonly<{
+  // The model the cockpit requested (e.g. `openagents/khala-code`).
+  requestedModel: string
+  // The concrete model that actually served the request (e.g. a provider id).
+  servedModel: string
+  // The worker/adapter that served it.
+  worker: string
+  // The route lane the coordinator picked (e.g. `coding`, `cheap`, `default`).
+  lane: string
+  // The verification class outcome.
+  verification: "none" | "test_passed" | "failed"
+  // Whether the run is verified (only meaningful for verified lanes).
+  verified: boolean | null
+  // The dereferenceable receipt ref, when present. Its presence is the LIVE gate.
+  receipt: string | null
+  // A relative URL to the public receipt, when the gateway metered the run.
+  receiptUrl: string | null
+  // For `khala-code`: the rubric checks that passed / failed.
+  rubric:
+    | Readonly<{
+        ref: string
+        passedChecks: ReadonlyArray<string>
+        failedChecks: ReadonlyArray<string>
+      }>
+    | null
+}>
+
+// A cockpit turn result: the rendered answer text plus the receipt projection.
+export type KhalaTurnResult = Readonly<{
+  ok: boolean
+  // The assistant answer (or an honest in-conversation error message). Never a
+  // faked answer.
+  text: string
+  // The receipt projection, when the response carried an `openagents` block.
+  receipt: KhalaReceiptProjection | null
+  // The LIVE gate: true ONLY when `receipt.receipt` is a non-empty ref. A real
+  // completion with no receipt is `live: false` (rendered as unverified).
+  live: boolean
+}>
+
+const asString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : null
+
+const asStringArray = (value: unknown): ReadonlyArray<string> => {
+  if (!Array.isArray(value)) return []
+  return value.filter((v): v is string => typeof v === "string")
+}
+
+const asVerification = (
+  value: unknown,
+): "none" | "test_passed" | "failed" => {
+  if (value === "test_passed" || value === "failed") return value
+  return "none"
+}
+
+// Parse the gateway `openagents` block off a chat-completions body into the
+// cockpit projection. Tolerant: an absent or malformed block yields `null`
+// (the cockpit then renders the answer as not-live), never a thrown error.
+export const parseKhalaReceipt = (
+  body: unknown,
+): KhalaReceiptProjection | null => {
+  if (typeof body !== "object" || body === null) return null
+  const block = (body as { openagents?: unknown }).openagents
+  if (typeof block !== "object" || block === null) return null
+  const record = block as Record<string, unknown>
+
+  const requestedModel = asString(record.requested_model)
+  const servedModel = asString(record.served_model)
+  const worker = asString(record.worker)
+  const lane = asString(record.lane)
+  // The minimum disclosure for a real Khala route. A block missing all of these
+  // is not a recognizable Khala receipt.
+  if (requestedModel === null && servedModel === null && worker === null) {
+    return null
+  }
+
+  const rubricRaw = record.rubric
+  const rubric =
+    typeof rubricRaw === "object" && rubricRaw !== null
+      ? (() => {
+          const r = rubricRaw as Record<string, unknown>
+          const ref = asString(r.ref)
+          if (ref === null) return null
+          return {
+            ref,
+            passedChecks: asStringArray(r.passed_checks),
+            failedChecks: asStringArray(r.failed_checks),
+          }
+        })()
+      : null
+
+  return {
+    requestedModel: requestedModel ?? "",
+    servedModel: servedModel ?? "",
+    worker: worker ?? "",
+    lane: lane ?? "default",
+    verification: asVerification(record.verification),
+    verified: typeof record.verified === "boolean" ? record.verified : null,
+    receipt: asString(record.receipt),
+    receiptUrl: asString(record.receipt_url),
+    rubric,
+  }
+}
+
+// The LIVE gate. A cockpit run is "live" ONLY when the response carried a real,
+// non-empty receipt ref. Everything else (no block, no receipt) is not-live.
+export const isLiveReceipt = (
+  receipt: KhalaReceiptProjection | null,
+): boolean => receipt !== null && receipt.receipt !== null
+
+// A short, public-safe one-line summary of the receipt for the cockpit HUD.
+// Jargon-free where possible; carries only disclosed fields.
+export const summarizeKhalaReceipt = (
+  receipt: KhalaReceiptProjection | null,
+): string => {
+  if (receipt === null) return "No receipt — answer is not verified."
+  const verifiedLabel =
+    receipt.verification === "test_passed"
+      ? "verified (tests passed)"
+      : receipt.verification === "failed"
+        ? "verification failed"
+        : "not verified"
+  const served =
+    receipt.servedModel.length > 0 ? receipt.servedModel : "unknown model"
+  const liveLabel = isLiveReceipt(receipt) ? "live" : "no receipt"
+  return `${served} via ${receipt.lane} lane — ${verifiedLabel} — ${liveLabel}`
+}

--- a/apps/autopilot-desktop/src/shared/rpc.ts
+++ b/apps/autopilot-desktop/src/shared/rpc.ts
@@ -701,6 +701,36 @@ export type ShellTurnResponse = {
   readonly text: string
 }
 
+// M1 (#6009, EPIC #6017) — Lane A Cockpit. One Khala cockpit turn: the Bun host
+// submits the prompt to a `openagents/khala-*` model on the OpenAI-compatible
+// `/v1/chat/completions` gateway, and projects back the plain answer text PLUS
+// the NON-BREAKING `openagents` receipt block (requested/served model, worker,
+// lane, verification, receipt ref/url, rubric) so a Khala completion is
+// auditable. `live` is TRUE only when the response carried a real receipt ref —
+// never claim live off a stub/free route. The raw token never crosses here.
+export type KhalaReceiptProjectionResponse = {
+  readonly requestedModel: string
+  readonly servedModel: string
+  readonly worker: string
+  readonly lane: string
+  readonly verification: "none" | "test_passed" | "failed"
+  readonly verified: boolean | null
+  readonly receipt: string | null
+  readonly receiptUrl: string | null
+  readonly rubric: {
+    readonly ref: string
+    readonly passedChecks: readonly string[]
+    readonly failedChecks: readonly string[]
+  } | null
+}
+
+export type KhalaTurnResponse = {
+  readonly ok: boolean
+  readonly text: string
+  readonly receipt: KhalaReceiptProjectionResponse | null
+  readonly live: boolean
+}
+
 // #5821: the Verse chat bar talks to Tassadar/OpenAgents by default. Bun owns
 // the OpenAgents token and public context fetches; the webview receives only the
 // plain response, source refs, and public-safe blocker refs. No raw token, raw
@@ -977,6 +1007,18 @@ export type DesktopRPCSchema = {
       readonly shellTurn: {
         readonly params: { prompt: string }
         readonly response: ShellTurnResponse
+      }
+      // M1 (#6009, EPIC #6017): one Khala cockpit turn. The Bun host submits the
+      // prompt to a `openagents/khala-*` model on the gateway and returns the
+      // plain answer PLUS the public-safe `openagents` receipt projection. `live`
+      // is gated on a real receipt ref. Works against local/stub or staging; the
+      // raw token never crosses this boundary.
+      readonly khalaTurn: {
+        readonly params: {
+          readonly prompt: string
+          readonly model?: "openagents/khala-mini" | "openagents/khala-code"
+        }
+        readonly response: KhalaTurnResponse
       }
       // #5821: one default Verse/Tassadar turn. The Bun host builds a bounded
       // public context pack from /api/public/tassadar-run-summary,

--- a/apps/autopilot-desktop/tests/khala-cockpit.test.ts
+++ b/apps/autopilot-desktop/tests/khala-cockpit.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "bun:test"
+
+import { buildKhalaTurn } from "../src/bun/khala-turn"
+import {
+  isKhalaCockpitModelId,
+  isLiveReceipt,
+  parseKhalaReceipt,
+  summarizeKhalaReceipt,
+  KHALA_CODE_MODEL_ID,
+  KHALA_COCKPIT_MODEL_IDS,
+  KHALA_MINI_MODEL_ID,
+} from "../src/shared/khala-cockpit"
+
+// M1 (#6009, EPIC #6017) — Lane A Cockpit. The crossy-road smoke prompt the
+// roadmap names as the north-star task.
+const CROSSY_ROAD_PROMPT =
+  "build a really high quality single html file crossy road game with three.js"
+
+describe("khala-cockpit model ids", () => {
+  test("exposes khala-mini and khala-code", () => {
+    expect(KHALA_COCKPIT_MODEL_IDS).toEqual([
+      KHALA_MINI_MODEL_ID,
+      KHALA_CODE_MODEL_ID,
+    ])
+    expect(KHALA_MINI_MODEL_ID).toBe("openagents/khala-mini")
+    expect(KHALA_CODE_MODEL_ID).toBe("openagents/khala-code")
+  })
+
+  test("type guard accepts only known khala ids", () => {
+    expect(isKhalaCockpitModelId("openagents/khala-mini")).toBe(true)
+    expect(isKhalaCockpitModelId("openagents/khala-code")).toBe(true)
+    expect(isKhalaCockpitModelId("openagents/khala-typo")).toBe(false)
+    expect(isKhalaCockpitModelId("gemini-3.5-flash")).toBe(false)
+  })
+})
+
+describe("parseKhalaReceipt — consumes the gateway openagents block", () => {
+  test("parses a khala-mini receipt (verification none, no metering)", () => {
+    const body = {
+      choices: [{ message: { content: "hi" } }],
+      openagents: {
+        requested_model: "openagents/khala-mini",
+        served_model: "gemini-3.5-flash",
+        worker: "vertex-gemini",
+        lane: "cheap",
+        verification: "none",
+      },
+    }
+    const r = parseKhalaReceipt(body)
+    expect(r).not.toBeNull()
+    expect(r?.requestedModel).toBe("openagents/khala-mini")
+    expect(r?.servedModel).toBe("gemini-3.5-flash")
+    expect(r?.worker).toBe("vertex-gemini")
+    expect(r?.lane).toBe("cheap")
+    expect(r?.verification).toBe("none")
+    expect(r?.receipt).toBeNull()
+    // No receipt => not live.
+    expect(isLiveReceipt(r)).toBe(false)
+  })
+
+  test("parses a khala-code receipt with rubric, receipt, and verified pass", () => {
+    const body = {
+      choices: [{ message: { content: "<html>...</html>" } }],
+      openagents: {
+        requested_model: "openagents/khala-code",
+        served_model: "fireworks-coder",
+        worker: "fireworks",
+        lane: "coding",
+        route: "coding",
+        verification: "test_passed",
+        verified: true,
+        receipt: "oa_receipt_abc",
+        receipt_url: "/api/public/inference/receipts/oa_receipt_abc",
+        workers: ["fireworks", "khala-code-verifier"],
+        rubric: {
+          ref: "rubric.crossy_road.v1",
+          passed_checks: ["single_html_file", "loads_and_runs_headless"],
+          failed_checks: [],
+        },
+      },
+    }
+    const r = parseKhalaReceipt(body)
+    expect(r?.lane).toBe("coding")
+    expect(r?.verification).toBe("test_passed")
+    expect(r?.verified).toBe(true)
+    expect(r?.receipt).toBe("oa_receipt_abc")
+    expect(r?.receiptUrl).toBe("/api/public/inference/receipts/oa_receipt_abc")
+    expect(r?.rubric?.ref).toBe("rubric.crossy_road.v1")
+    expect(r?.rubric?.passedChecks).toContain("single_html_file")
+    // Real receipt ref => LIVE.
+    expect(isLiveReceipt(r)).toBe(true)
+  })
+
+  test("returns null on a non-khala / missing openagents block (renders not-live)", () => {
+    expect(parseKhalaReceipt({ choices: [] })).toBeNull()
+    expect(parseKhalaReceipt({ openagents: null })).toBeNull()
+    expect(parseKhalaReceipt({ openagents: {} })).toBeNull()
+    expect(parseKhalaReceipt(null)).toBeNull()
+    expect(parseKhalaReceipt("nope")).toBeNull()
+  })
+
+  test("summary is public-safe and reflects live/not-live", () => {
+    const verified = parseKhalaReceipt({
+      openagents: {
+        requested_model: "openagents/khala-code",
+        served_model: "fireworks-coder",
+        worker: "fireworks",
+        lane: "coding",
+        verification: "test_passed",
+        verified: true,
+        receipt: "oa_receipt_abc",
+      },
+    })
+    expect(summarizeKhalaReceipt(verified)).toContain("verified (tests passed)")
+    expect(summarizeKhalaReceipt(verified)).toContain("live")
+    expect(summarizeKhalaReceipt(null)).toContain("not verified")
+  })
+})
+
+describe("buildKhalaTurn — cockpit call path (stub gateway)", () => {
+  const env = { OPENAGENTS_INFERENCE_GATEWAY_BASE_URL: "https://gw.test" }
+
+  test("no token: honest message, no network call, not live", async () => {
+    let called = false
+    const fetchFn = (() => {
+      called = true
+      return Promise.resolve(new Response("{}"))
+    }) as unknown as typeof fetch
+    const r = await buildKhalaTurn({
+      prompt: CROSSY_ROAD_PROMPT,
+      env,
+      agentToken: null,
+      fetchFn,
+    })
+    expect(called).toBe(false)
+    expect(r.ok).toBe(false)
+    expect(r.live).toBe(false)
+    expect(r.receipt).toBeNull()
+    expect(r.text).toContain("OPENAGENTS_AGENT_TOKEN")
+  })
+
+  test("crossy-road smoke against khala-code: renders completion + LIVE receipt", async () => {
+    let sentUrl = ""
+    let sentBody: unknown = null
+    const fetchFn = ((url: string, init?: RequestInit) => {
+      sentUrl = url
+      sentBody = init?.body ? JSON.parse(init.body as string) : null
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "chatcmpl_x",
+            model: "openagents/khala-code",
+            choices: [
+              {
+                index: 0,
+                finish_reason: "stop",
+                message: {
+                  role: "assistant",
+                  content: "<!doctype html><html><!-- crossy road --></html>",
+                },
+              },
+            ],
+            usage: { prompt_tokens: 10, completion_tokens: 200, total_tokens: 210 },
+            openagents: {
+              requested_model: "openagents/khala-code",
+              served_model: "fireworks-coder",
+              worker: "fireworks",
+              lane: "coding",
+              route: "coding",
+              verification: "test_passed",
+              verified: true,
+              receipt: "oa_receipt_live_1",
+              receipt_url: "/api/public/inference/receipts/oa_receipt_live_1",
+              rubric: {
+                ref: "rubric.crossy_road.v1",
+                passed_checks: ["single_html_file"],
+                failed_checks: [],
+              },
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      )
+    }) as unknown as typeof fetch
+
+    const r = await buildKhalaTurn({
+      prompt: CROSSY_ROAD_PROMPT,
+      model: KHALA_CODE_MODEL_ID,
+      env,
+      agentToken: "agent-token",
+      fetchFn,
+    })
+
+    expect(sentUrl).toBe("https://gw.test/v1/chat/completions")
+    expect((sentBody as { model?: string }).model).toBe("openagents/khala-code")
+    expect(r.ok).toBe(true)
+    expect(r.text).toContain("crossy road")
+    expect(r.receipt?.servedModel).toBe("fireworks-coder")
+    expect(r.receipt?.verification).toBe("test_passed")
+    // Real receipt ref => the cockpit may show a LIVE badge.
+    expect(r.live).toBe(true)
+  })
+
+  test("khala-mini stub with NO receipt: real answer but NOT live", async () => {
+    const fetchFn = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: "an answer" } }],
+            // No openagents block (e.g. a stub/free route).
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      )) as unknown as typeof fetch
+    const r = await buildKhalaTurn({
+      prompt: "hello",
+      env,
+      agentToken: "agent-token",
+      fetchFn,
+    })
+    expect(r.ok).toBe(true)
+    expect(r.text).toBe("an answer")
+    expect(r.receipt).toBeNull()
+    // The LIVE gate must be false without a receipt — never claim live off a stub.
+    expect(r.live).toBe(false)
+  })
+
+  test("defaults to khala-mini when no model given", async () => {
+    let sentModel = ""
+    const fetchFn = ((_url: string, init?: RequestInit) => {
+      sentModel = init?.body
+        ? (JSON.parse(init.body as string) as { model: string }).model
+        : ""
+      return Promise.resolve(
+        new Response(JSON.stringify({ choices: [{ message: { content: "x" } }] })),
+      )
+    }) as unknown as typeof fetch
+    await buildKhalaTurn({ prompt: "hi", env, agentToken: "t", fetchFn })
+    expect(sentModel).toBe("openagents/khala-mini")
+  })
+
+  test("402 maps to an actionable credit message, not a faked answer", async () => {
+    const fetchFn = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "insufficient credits" }), {
+          status: 402,
+        }),
+      )) as unknown as typeof fetch
+    const r = await buildKhalaTurn({
+      prompt: "hi",
+      env,
+      agentToken: "t",
+      fetchFn,
+    })
+    expect(r.ok).toBe(false)
+    expect(r.live).toBe(false)
+    expect(r.text).toContain("credit")
+  })
+})


### PR DESCRIPTION
**Lane:** A — Cockpit (Khala M1). Part of #6009 / EPIC #6017.

## What landed
The Autopilot cockpit can now submit a prompt to `openagents/khala-mini` and `openagents/khala-code` over the OpenAI-compatible `/v1/chat/completions` gateway, render the completion, and surface the non-breaking `openagents` disclosure block (`requested_model`, `served_model`, `worker`, `lane`, `verification`, `receipt`/`receipt_url`, `rubric`).

- `apps/autopilot-desktop/src/shared/khala-cockpit.ts` — pure, DOM-free home for the cockpit Khala path: the `openagents/khala-*` model-id union + type guard, a tolerant parser for the gateway `openagents` block into a public-safe `KhalaReceiptProjection`, the **LIVE gate** (`isLiveReceipt` — true ONLY when a real receipt ref is present), and a public-safe one-line summary.
- `apps/autopilot-desktop/src/bun/khala-turn.ts` — Bun-host turn builder (sibling of `shell-turn.ts`). Submits the chosen Khala model, projects the answer + receipt + `live` flag. Honest no-token / 401 / 402 / 404 / network paths; never fakes an answer; the agent token never crosses the RPC boundary.
- `apps/autopilot-desktop/src/shared/rpc.ts` — `khalaTurn` RPC verb + `KhalaTurnResponse` / `KhalaReceiptProjectionResponse` contract.
- `apps/autopilot-desktop/src/bun/index.ts` — `khalaTurn` handler, reusing the existing `shellTurn` host-side token resolution.
- `apps/autopilot-desktop/scripts/khala-cockpit-smoke.ts` (`bun run smoke:khala-cockpit`) — the crossy-road north-star prompt round-trips through a **local stub gateway** against both models and asserts the LIVE gate.

**Collision rule honored:** consumes the `openagents` block **read-only**; does not touch `provider-adapter.ts`, `metering-hook.ts`, or `chat-completions-routes.ts`. The block shape is unchanged (no field additions requested).

**Owner-independence:** works against a local/stub or staging gateway; does NOT depend on the inert/owner-gated prod gateway. The "live" indicator is gated on a **real receipt**, not on prod.

## Tests run + results
- `bun test tests/khala-cockpit.test.ts` → **11 pass / 0 fail** (51 expects). Covers model-id guard, receipt parsing (khala-mini none, khala-code verified+rubric, malformed/missing → null), the LIVE gate, summary, and the crossy-road smoke against a stub fetch (live khala-code, not-live khala-mini, no-token, 402, default-model).
- `bun run typecheck` (`tsc -p tsconfig.typecheck.json --noEmit`) → **exit 0, clean**.
- `bun test` shell-turn + inference-gateway + conformance + verse-turn → **37 pass / 0 fail** (no regressions; conformance validates the RPC contract).
- `bun run smoke:khala-cockpit` → **SMOKE PASSED (SCAFFOLD)**: crossy-road prompt renders a completion and the receipt block; khala-code (with receipt) is `live:true`, khala-mini (no receipt) is `live:false`.

All smoke/stub results are **scaffold evidence (stub gateway), not product proof.** A real receipt requires a live local/staging gateway (M0-live is NEEDS-OWNER).

## Blockers / NEEDS-OWNER
- **NEEDS-OWNER (M0-live, unblocks a real cockpit receipt):** wire one provider secret + `INFERENCE_GATEWAY_ENABLED=on` on a staging/preview Worker so the cockpit can show a real (non-stub) `openagents` receipt. No agent can flip prod/staging secrets. Until then the cockpit renders against stub/staging only and the live badge stays correctly gated on a receipt.
- No UI surface wiring (a chat pane button) is included in this slice — this lands the call path + RPC verb + receipt projection + smoke. A follow-up can bind a cockpit pane to the `khalaTurn` verb. Flagging for the orchestrator if the UI binding is wanted in M1 scope.

Part of #6009 / EPIC #6017.

**DO NOT auto-merge — orchestrator session will review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)