### PR TITLE
Khala M4: fabric supply adapter (whole-small-model) + parity receipt

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -331,6 +331,7 @@ import {
   InferenceAdapterError,
   InferenceProviderRegistry,
 } from './inference/provider-adapter'
+import { makePsionicFabricAdapter } from './inference/psionic-fabric-serve'
 import { handleQuote } from './inference/quote-routes'
 import { stubEchoAdapter } from './inference/stub-echo-adapter'
 import {
@@ -8172,6 +8173,38 @@ const registerPassthroughAdapters = (
   }
 }
 
+// OpenAgents serving-fabric lane (#5483 / Khala M4 #6012) — the `openagents-
+// network` adapter wired to a Psionic serve transport. The lane is routed AHEAD
+// of passthrough for the OPEN class (model-router.ts), but stays INERT until a
+// LIVE Psionic serve transport is wired: with no transport bound the lane is
+// simply NOT registered, and `dispatchWithOverflow` (which filters the plan to
+// registered adapters) skips it and overflows to passthrough — never a faked
+// serve. The live fabric is owner-gated / Psionic-planned (decentralized-serving
+// -shard-wan.md §7), so no transport is bound here today; the concrete dispatch
+// (ask-plan -> execute -> consume EXACT-PARITY receipt; no parity -> no success)
+// is proven against a local/fake serve in psionic-fabric-serve.test.ts and
+// registers behind this seam with no routing change once a transport lands.
+//
+// The Worker env carries no live fabric serve binding yet, so this narrow env
+// slice has no transport field to read; the function is the activation point a
+// future wiring fills in (mirroring registerPassthroughAdapters). It is a no-op
+// today and keeps the lane honestly skipped.
+type FabricServeEnv = Readonly<Record<string, unknown>>
+
+const registerFabricServeAdapter = (
+  registry: InferenceProviderRegistry,
+  _env: FabricServeEnv,
+): void => {
+  // No live Psionic serve transport is bound in this repo (owner-gated). When a
+  // real transport client lands, build it from the env here and register:
+  //   registry.register(makePsionicFabricAdapter({ transport }))
+  // Until then the lane stays unregistered and routing skips it. The unused
+  // factory import is intentionally referenced so the seam stays type-checked
+  // and the registration path cannot silently rot.
+  void makePsionicFabricAdapter
+  void registry
+}
+
 // Per-request env holder for env-dependent inference adapters. A Cloudflare
 // Worker has no env at module scope, so the module-level adapter registry reads
 // the live env (set by the /v1/chat/completions handler before dispatch) when
@@ -9640,6 +9673,10 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     path: '/v1/chat/completions',
     handler: (request, env) => {
       registerPassthroughAdapters(inferenceProviderRegistry, env)
+      // Serving-fabric lane (#5483 / Khala M4 #6012). No-op today (no live
+      // Psionic serve transport bound); keeps the lane honestly skipped until a
+      // transport lands, with no routing change required to activate it.
+      registerFabricServeAdapter(inferenceProviderRegistry, env)
       // Capture the live env so env-dependent adapters (Vertex #5480) can mint
       // credentials from Worker secrets at call time. INERT regardless: the
       // gateway is gated by INFERENCE_GATEWAY_ENABLED below.

--- a/apps/openagents.com/workers/api/src/inference/psionic-fabric-serve.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/psionic-fabric-serve.test.ts
@@ -1,0 +1,241 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  makeOpenAgentsNetworkAdapter,
+  OPENAGENTS_NETWORK_ADAPTER_ID,
+} from './openagents-network-adapter'
+import {
+  dispatchPsionicServe,
+  FABRIC_MALFORMED_RESPONSE_KIND,
+  FABRIC_PARITY_UNVERIFIED_KIND,
+  FABRIC_PARITY_UNVERIFIED_REASON,
+  FABRIC_SHARDED_UNSUPPORTED_KIND,
+  makePsionicFabricAdapter,
+  type PsionicServeRequest,
+  type PsionicServeResponse,
+  type PsionicServeTransport,
+} from './psionic-fabric-serve'
+import {
+  InferenceAdapterError,
+  type InferenceRequest,
+} from './provider-adapter'
+
+const runResult = <A>(effect: Effect.Effect<A, InferenceAdapterError>) =>
+  Effect.runPromise(Effect.result(effect))
+
+// The intended PRIMARY test worker is the guinea-pig Pylon (Khala M4, #6012):
+// a live admitted node we control whose serve -> exact-parity receipt is the
+// first loop we want, and whose Bitcoin/Spark payout Lane E settles. Its Spark
+// receive address is payment material that lives ONLY in
+// `.secrets/khala-test-payout.env` and is NEVER committed; the serving receipt
+// identifies the node by a public-safe attribution ref (`ServingStage.nodeRef`),
+// not by any wallet address. This ref is the stable handle the per-stage payout
+// split keys on downstream.
+const GUINEA_PIG_NODE_REF = 'pylon.khala-test-payout.primary'
+
+// A small open model — the whole-small-model lane this wave serves end-to-end on
+// one Pylon (shard-WAN large-model serving is deferred).
+const SMALL_MODEL = 'qwen3-0p6b'
+
+const request = (model = SMALL_MODEL): InferenceRequest => ({
+  messages: [{ content: 'serve this on a whole small model', role: 'user' }],
+  model,
+  passthroughParams: { max_tokens: 64, temperature: 0 },
+  stream: false,
+})
+
+// A LOCAL/FAKE Psionic serve: a whole-small-model serve on the guinea-pig Pylon
+// that ran the same-engine reference greedy decode and PASSED exact-greedy
+// parity. This is the first end-to-end loop we want to prove.
+const parityPassingServe = (
+  overrides: Partial<PsionicServeResponse> = {},
+): PsionicServeResponse => ({
+  content: 'served by the guinea-pig Pylon, parity-verified',
+  finishReason: 'stop',
+  parityMode: 'exact_greedy_parity',
+  parityVerified: true,
+  servedModel: SMALL_MODEL,
+  servingRunRef: 'serve.run.guinea-pig.0001',
+  stages: [
+    { layerEnd: 24, layerStart: 0, nodeRef: GUINEA_PIG_NODE_REF, role: 'stage' },
+  ],
+  usage: { completionTokens: 7, promptTokens: 9, totalTokens: 16 },
+  ...overrides,
+})
+
+const fakeServe =
+  (response: PsionicServeResponse | string): PsionicServeTransport =>
+  () =>
+    Effect.succeed(response)
+
+describe('psionic-fabric-serve dispatch — whole-small-model + exact-parity gate', () => {
+  test('serves the guinea-pig Pylon and consumes its exact-parity receipt', async () => {
+    let captured: PsionicServeRequest | undefined
+    const transport: PsionicServeTransport = serveRequest => {
+      captured = serveRequest
+      return Effect.succeed(parityPassingServe())
+    }
+    const dispatch = dispatchPsionicServe({ transport })
+
+    const outcome = await runResult(dispatch(request()))
+    expect(outcome._tag).toBe('Success')
+    if (outcome._tag === 'Success') {
+      // The completion result rides through receipt-first.
+      expect(outcome.success.result.content).toContain('guinea-pig')
+      expect(outcome.success.result.usage.totalTokens).toBe(16)
+      expect(outcome.success.result.servedModel).toBe(SMALL_MODEL)
+      // The serving receipt names the guinea-pig node and its (whole-model)
+      // layer block — the apportionment + parity input the payout split keys on.
+      expect(outcome.success.receipt.servingRunRef).toBe(
+        'serve.run.guinea-pig.0001',
+      )
+      expect(outcome.success.receipt.sharded).toBe(false)
+      expect(outcome.success.receipt.stages).toHaveLength(1)
+      expect(outcome.success.receipt.stages[0]!.nodeRef).toBe(
+        GUINEA_PIG_NODE_REF,
+      )
+      expect(outcome.success.receipt.parityMode).toBe('exact_greedy_parity')
+      expect(outcome.success.receipt.parityVerified).toBe(true)
+    }
+    // The gateway asked the fabric for the exact-greedy-parity posture.
+    expect(captured?.requireExactGreedyParity).toBe(true)
+    expect(captured?.model).toBe(SMALL_MODEL)
+  })
+
+  test('NO PARITY -> NO SUCCESS: parityVerified:false typed-fails non-retryably', async () => {
+    const dispatch = dispatchPsionicServe({
+      transport: fakeServe(parityPassingServe({ parityVerified: false })),
+    })
+    const outcome = await runResult(dispatch(request()))
+    expect(outcome._tag).toBe('Failure')
+    if (outcome._tag === 'Failure') {
+      expect(outcome.failure.kind).toBe(FABRIC_PARITY_UNVERIFIED_KIND)
+      expect(outcome.failure.reason).toBe(FABRIC_PARITY_UNVERIFIED_REASON)
+      // NON-retryable: a structurally unpayable run overflows to the next lane.
+      expect(outcome.failure.retryable).toBe(false)
+      expect(outcome.failure.adapterId).toBe(OPENAGENTS_NETWORK_ADAPTER_ID)
+    }
+  })
+
+  test('NO PARITY -> NO SUCCESS: parityMode:none typed-fails (served but unverified)', async () => {
+    const dispatch = dispatchPsionicServe({
+      transport: fakeServe(
+        parityPassingServe({ parityMode: 'none', parityVerified: true }),
+      ),
+    })
+    const outcome = await runResult(dispatch(request()))
+    expect(outcome._tag).toBe('Failure')
+    if (outcome._tag === 'Failure') {
+      expect(outcome.failure.kind).toBe(FABRIC_PARITY_UNVERIFIED_KIND)
+    }
+  })
+
+  test('shard-WAN multi-stage plan is REFUSED (deferred this wave)', async () => {
+    const dispatch = dispatchPsionicServe({
+      transport: fakeServe(
+        parityPassingServe({
+          stages: [
+            { layerEnd: 12, layerStart: 0, nodeRef: 'pylon.a', role: 'stage' },
+            { layerEnd: 24, layerStart: 12, nodeRef: 'pylon.b', role: 'stage' },
+          ],
+        }),
+      ),
+    })
+    const outcome = await runResult(dispatch(request()))
+    expect(outcome._tag).toBe('Failure')
+    if (outcome._tag === 'Failure') {
+      expect(outcome.failure.kind).toBe(FABRIC_SHARDED_UNSUPPORTED_KIND)
+      expect(outcome.failure.retryable).toBe(false)
+    }
+  })
+
+  test('a malformed serve response fails closed (never serves garbage)', async () => {
+    const dispatch = dispatchPsionicServe({
+      transport: fakeServe('{"content":"missing usage and stages"}'),
+    })
+    const outcome = await runResult(dispatch(request()))
+    expect(outcome._tag).toBe('Failure')
+    if (outcome._tag === 'Failure') {
+      expect(outcome.failure.kind).toBe(FABRIC_MALFORMED_RESPONSE_KIND)
+      expect(outcome.failure.retryable).toBe(false)
+    }
+  })
+
+  test('accepts a JSON-string serve response (real HTTP serve shape)', async () => {
+    const dispatch = dispatchPsionicServe({
+      transport: fakeServe(JSON.stringify(parityPassingServe())),
+    })
+    const outcome = await runResult(dispatch(request()))
+    expect(outcome._tag).toBe('Success')
+    if (outcome._tag === 'Success') {
+      expect(outcome.success.receipt.parityVerified).toBe(true)
+    }
+  })
+
+  test('a transport refusal/fault surfaces verbatim (already typed)', async () => {
+    const transport: PsionicServeTransport = () =>
+      Effect.fail(
+        new InferenceAdapterError({
+          adapterId: OPENAGENTS_NETWORK_ADAPTER_ID,
+          kind: 'service_overloaded',
+          reason: 'guinea-pig Pylon is shedding load',
+          retryable: true,
+        }),
+      )
+    const outcome = await runResult(dispatchPsionicServe({ transport })(request()))
+    expect(outcome._tag).toBe('Failure')
+    if (outcome._tag === 'Failure') {
+      expect(outcome.failure.kind).toBe('service_overloaded')
+      expect(outcome.failure.retryable).toBe(true)
+    }
+  })
+})
+
+describe('psionic-fabric-serve adapter — registration-ready behind the seam', () => {
+  test('makePsionicFabricAdapter is the openagents-network lane adapter with a live dispatch', async () => {
+    const adapter = makePsionicFabricAdapter({
+      transport: fakeServe(parityPassingServe()),
+    })
+    expect(adapter.id).toBe(OPENAGENTS_NETWORK_ADAPTER_ID)
+
+    // complete returns the parity-verified completion.
+    const complete = await runResult(adapter.complete(request()))
+    expect(complete._tag).toBe('Success')
+    if (complete._tag === 'Success') {
+      expect(complete.success.content).toContain('guinea-pig')
+      expect(complete.success.usage.totalTokens).toBe(16)
+    }
+
+    // stream maps the served result into a content frame + terminal usage frame
+    // (the receipt-first usage metering settles from).
+    const stream = await runResult(adapter.stream(request()))
+    expect(stream._tag).toBe('Success')
+    if (stream._tag === 'Success') {
+      expect(stream.success).toHaveLength(2)
+      expect(stream.success[0]!.contentDelta).toContain('guinea-pig')
+      expect(stream.success[1]!.usage?.totalTokens).toBe(16)
+      expect(stream.success[1]!.finishReason).toBe('stop')
+    }
+  })
+
+  test('the adapter enforces the parity gate through the complete() path too', async () => {
+    const adapter = makePsionicFabricAdapter({
+      transport: fakeServe(parityPassingServe({ parityVerified: false })),
+    })
+    const outcome = await runResult(adapter.complete(request()))
+    expect(outcome._tag).toBe('Failure')
+    if (outcome._tag === 'Failure') {
+      expect(outcome.failure.kind).toBe(FABRIC_PARITY_UNVERIFIED_KIND)
+    }
+  })
+
+  // Sanity: the inert default network adapter (no dispatch) is unchanged — it
+  // still typed-fails, so registering THIS live adapter is the only thing that
+  // activates the lane.
+  test('the inert default network adapter still typed-fails (no fabricated serve)', async () => {
+    const inert = makeOpenAgentsNetworkAdapter()
+    const outcome = await runResult(inert.complete(request()))
+    expect(outcome._tag).toBe('Failure')
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/psionic-fabric-serve.ts
+++ b/apps/openagents.com/workers/api/src/inference/psionic-fabric-serve.ts
@@ -1,0 +1,377 @@
+// Psionic fabric serve dispatch for the OpenAgents serving-fabric lane
+// (EPIC #5474, #5483; Khala M4, #6012 / EPIC #6017; design:
+// docs/inference/2026-06-19-decentralized-serving-shard-wan.md §1, §3, §5, §8).
+//
+// This is the CONCRETE `NetworkFabricDispatch` the inert
+// `openagents-network-adapter.ts` seam was built to receive. It speaks the
+// product-layer view of the Psionic serve wire contract:
+//
+//   ask-plan -> execute -> consume an EXACT-PARITY receipt
+//
+// against a single admitted Pylon serving a WHOLE SMALL MODEL (the near-term,
+// low-risk lane; doc §1 / §6 "Build order"). Shard-WAN large-model serving is
+// DEFERRED entirely (doc §7 "Honest gaps": that path is Psionic-planned /
+// partly hardware-blocked) — this module typed-refuses any serve plan that
+// declares more than one stage.
+//
+// THE NON-NEGOTIABLE GATE (doc §3a): payment clears against a CHECKABLE
+// outcome, not a self-report. Psionic's acceptance gate is EXACT-GREEDY PARITY:
+// a served run must produce tokens identical to the same-engine reference
+// greedy decode. This module enforces "NO PARITY -> NO SUCCESS" at the dispatch
+// layer: a serve response that does not carry `exact_greedy_parity` with
+// `parityVerified: true` is a typed NON-RETRYABLE failure, never a fabricated
+// success. The downstream payout gate (serving-node-payout.ts GATE 1) re-checks
+// parity independently; this is the first, earliest fail-closed point.
+//
+// BOUNDARIES (doc §5, the Psionic boundary): this is a PRODUCT-layer dispatch.
+// It asks the fabric for a plan + offered posture, consumes the served result +
+// receipt, and never reaches into Psionic execution, never holds money
+// authority, and never prices or pays. Pricing (#5478), metering (#5477), and
+// the per-stage payout split (#5484) consume the receipt downstream.
+//
+// TRANSPORT INJECTION: the serve transport is injectable so tests prove the
+// dispatch against a LOCAL or FAKE Psionic serve, and a real Psionic
+// `psionic-serve` HTTP endpoint can be wired later with no contract change. The
+// live fabric is NOT wired in this repo (owner-gated, Psionic-planned); this
+// module never fakes a LIVE serve — it only consumes whatever serve a wired
+// transport returns.
+
+import { parseJsonRecord, recordFromUnknown } from '../json-boundary'
+import {
+  makeOpenAgentsNetworkAdapter,
+  type NetworkFabricDispatch,
+  type NetworkServedResult,
+  OPENAGENTS_NETWORK_ADAPTER_ID,
+  type ServingReceipt,
+  type ServingStage,
+} from './openagents-network-adapter'
+import {
+  InferenceAdapterError,
+  type InferenceRequest,
+  type InferenceResult,
+  type InferenceUsage,
+} from './provider-adapter'
+
+import { Effect } from 'effect'
+
+// ----------------------------------------------------------------------------
+// Stable, neutral failure-classification kinds + reason refs (public-safe)
+// ----------------------------------------------------------------------------
+
+// Stable adapter id used on every typed failure from this dispatch — the same
+// id the lane is registered under, so routing/metrics attribute the failure to
+// the serving-fabric lane.
+const FABRIC_ADAPTER_ID = OPENAGENTS_NETWORK_ADAPTER_ID
+
+// A serve response that does not carry a verified exact-greedy parity result.
+// NON-retryable: a missing/failed parity gate is not a transient fault — the
+// run is structurally unpayable, so routing must overflow to the next viable
+// lane (Vertex / passthrough) rather than back off against the fabric.
+export const FABRIC_PARITY_UNVERIFIED_KIND = 'fabric_parity_unverified'
+export const FABRIC_PARITY_UNVERIFIED_REASON =
+  'fabric serve did not return a verified exact-greedy parity receipt'
+
+// A serve plan that declares a sharded (multi-stage) run. DEFERRED this wave
+// (whole-small-model only). NON-retryable: shard-WAN is not wired, so a sharded
+// plan must typed-refuse and fall back, never be served unverified.
+export const FABRIC_SHARDED_UNSUPPORTED_KIND = 'fabric_sharded_unsupported'
+export const FABRIC_SHARDED_UNSUPPORTED_REASON =
+  'shard-WAN multi-stage serving is deferred; whole-small-model only this wave'
+
+// The serve transport returned a malformed / unparseable response. NON-retryable:
+// a malformed serve is a contract fault, not a transient one; metering must
+// never settle on a fabricated/estimated usage, so this fails closed.
+export const FABRIC_MALFORMED_RESPONSE_KIND = 'malformed_response'
+
+// The serve transport itself faulted (network/transport). Retryable so routing
+// may overflow to the next viable lane.
+export const FABRIC_TRANSPORT_ERROR_KIND = 'transport_error'
+
+const fabricError = (
+  input: Readonly<{
+    reason: string
+    kind: string
+    retryable?: boolean | undefined
+    httpStatus?: number | undefined
+  }>,
+): InferenceAdapterError =>
+  new InferenceAdapterError({
+    adapterId: FABRIC_ADAPTER_ID,
+    httpStatus: input.httpStatus,
+    kind: input.kind,
+    reason: input.reason,
+    retryable: input.retryable ?? false,
+  })
+
+// ----------------------------------------------------------------------------
+// The product-layer Psionic serve wire contract
+// ----------------------------------------------------------------------------
+
+// The serve REQUEST handed to the Psionic serve transport. This is the
+// product-layer "ask-plan + execute" payload: the normalized model + messages
+// plus the requested verifiable posture. A wired transport serializes this onto
+// the real `psionic-serve` endpoint; a local/fake serve in tests consumes it
+// directly. The gateway declares it REQUIRES exact-greedy parity — the fabric
+// must serve verifiably or refuse (doc §3a).
+export type PsionicServeRequest = Readonly<{
+  // The model artifact to serve (the gateway alias / provider-native id).
+  model: string
+  // The normalized chat messages, OpenAI-Chat-Completions-shaped.
+  messages: ReadonlyArray<Readonly<{ role: string; content: string }>>
+  // Sampling params forwarded verbatim (temperature, max_tokens, ...). The
+  // serve applies only the ones it supports; greedy decode is implied for the
+  // parity reference regardless of these.
+  passthroughParams: Readonly<Record<string, unknown>>
+  // The gateway's required verifiable posture. Pinned to exact-greedy parity:
+  // the serve must run the same-engine reference greedy decode and compare, or
+  // the run does not clear the payment gate.
+  requireExactGreedyParity: true
+}>
+
+// The serve RESPONSE the Psionic serve transport returns. Mirrors (at the
+// product layer) the typed receipt shape Psionic emits
+// (`psionic.serve.pipeline_sharded_run_receipt.v1`, doc §3b): which node served
+// which layer-block, plus the exact-greedy parity result that is the payment
+// gate. The transport may return this as a parsed object (a local/fake serve)
+// or as a JSON string (a real HTTP serve); `dispatchPsionicServe` accepts both.
+export type PsionicServeResponse = Readonly<{
+  // The assistant completion content for the single choice.
+  content: string
+  // Provider-reported finish reason ("stop" / "length" / ...).
+  finishReason: string
+  // Receipt-first token usage (NEVER an estimate — the metering source of
+  // truth).
+  usage: InferenceUsage
+  // The model artifact actually served.
+  servedModel: string
+  // Stable, public-safe serving-run id. One per served request; used to build
+  // the idempotent payout key downstream so a replay never double-pays.
+  servingRunRef: string
+  // The stages that participated, in pipeline order. For whole-small-model
+  // serving there is EXACTLY ONE stage holding the whole model.
+  stages: ReadonlyArray<ServingStage>
+  // Whether the serve declares it ran the same-engine reference greedy decode
+  // and compared (the parity mode). Anything other than `exact_greedy_parity`
+  // fails the gate.
+  parityMode: 'exact_greedy_parity' | 'none'
+  // Whether the declared parity check PASSED (token-identical to the reference
+  // greedy decode). Only `exact_greedy_parity` && `true` clears the gate.
+  parityVerified: boolean
+}>
+
+// The injectable serve transport — the ask-plan / execute seam to Psionic. A
+// test passes a LOCAL or FAKE serve; a real wiring passes an HTTP client that
+// posts to `psionic-serve`. Returns the parsed response, a JSON string, or a
+// typed adapter error (a retryable transport/overload fault, or a non-retryable
+// refusal). The dispatch normalizes + parity-gates whatever it returns.
+export type PsionicServeTransport = (
+  request: PsionicServeRequest,
+) => Effect.Effect<PsionicServeResponse | string, InferenceAdapterError>
+
+// ----------------------------------------------------------------------------
+// Parse + validate a serve response (fails closed on anything malformed)
+// ----------------------------------------------------------------------------
+
+const asInteger = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isInteger(value) ? value : undefined
+
+const parseUsage = (raw: unknown): InferenceUsage | undefined => {
+  const record = recordFromUnknown(raw)
+  if (record === undefined) return undefined
+  const promptTokens = asInteger(record['promptTokens'])
+  const completionTokens = asInteger(record['completionTokens'])
+  const totalTokens = asInteger(record['totalTokens'])
+  if (
+    promptTokens === undefined ||
+    completionTokens === undefined ||
+    totalTokens === undefined ||
+    promptTokens < 0 ||
+    completionTokens < 0 ||
+    totalTokens < 0
+  ) {
+    return undefined
+  }
+  const cached = asInteger(record['cachedPromptTokens'])
+  return {
+    completionTokens,
+    promptTokens,
+    totalTokens,
+    ...(cached === undefined ? {} : { cachedPromptTokens: cached }),
+  }
+}
+
+const parseStage = (raw: unknown): ServingStage | undefined => {
+  const record = recordFromUnknown(raw)
+  if (record === undefined) return undefined
+  const nodeRef = record['nodeRef']
+  const layerStart = asInteger(record['layerStart'])
+  const layerEnd = asInteger(record['layerEnd'])
+  const role = record['role']
+  if (
+    typeof nodeRef !== 'string' ||
+    nodeRef.trim() === '' ||
+    layerStart === undefined ||
+    layerEnd === undefined ||
+    (role !== 'stage' && role !== 'coordinator' && role !== 'draft')
+  ) {
+    return undefined
+  }
+  return { layerEnd, layerStart, nodeRef, role }
+}
+
+const parseStages = (raw: unknown): ReadonlyArray<ServingStage> | undefined => {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined
+  const parsed = raw.map(parseStage)
+  if (parsed.some(stage => stage === undefined)) return undefined
+  return parsed as ReadonlyArray<ServingStage>
+}
+
+// Normalize whatever the transport returned (object or JSON string) into a
+// validated `PsionicServeResponse`, or undefined when it is malformed. Fails
+// closed: any missing/ill-typed load-bearing field yields undefined so the
+// caller raises a typed malformed-response failure rather than serving garbage.
+const normalizeServeResponse = (
+  raw: PsionicServeResponse | string,
+): PsionicServeResponse | undefined => {
+  const record =
+    typeof raw === 'string' ? parseJsonRecord(raw) : recordFromUnknown(raw)
+  if (record === undefined) return undefined
+
+  const content = record['content']
+  const finishReason = record['finishReason']
+  const servedModel = record['servedModel']
+  const servingRunRef = record['servingRunRef']
+  const parityMode = record['parityMode']
+  const parityVerified = record['parityVerified']
+  const usage = parseUsage(record['usage'])
+  const stages = parseStages(record['stages'])
+
+  if (
+    typeof content !== 'string' ||
+    typeof finishReason !== 'string' ||
+    finishReason.trim() === '' ||
+    typeof servedModel !== 'string' ||
+    servedModel.trim() === '' ||
+    typeof servingRunRef !== 'string' ||
+    servingRunRef.trim() === '' ||
+    (parityMode !== 'exact_greedy_parity' && parityMode !== 'none') ||
+    typeof parityVerified !== 'boolean' ||
+    usage === undefined ||
+    stages === undefined
+  ) {
+    return undefined
+  }
+
+  return {
+    content,
+    finishReason,
+    parityMode,
+    parityVerified,
+    servedModel,
+    servingRunRef,
+    stages,
+    usage,
+  }
+}
+
+// ----------------------------------------------------------------------------
+// The dispatch (ask-plan -> execute -> consume exact-parity receipt)
+// ----------------------------------------------------------------------------
+
+export type PsionicFabricServeConfig = Readonly<{
+  // The injectable serve transport (local/fake in tests, HTTP in a wiring).
+  transport: PsionicServeTransport
+}>
+
+// Build the `NetworkServedResult` (completion result + serving receipt) from a
+// validated, parity-passing serve response.
+const toServedResult = (serve: PsionicServeResponse): NetworkServedResult => {
+  const result: InferenceResult = {
+    content: serve.content,
+    finishReason: serve.finishReason,
+    servedModel: serve.servedModel,
+    usage: serve.usage,
+  }
+  const receipt: ServingReceipt = {
+    parityMode: serve.parityMode,
+    parityVerified: serve.parityVerified,
+    servedModel: serve.servedModel,
+    // Whole-small-model: exactly one stage => not sharded. Carried explicitly
+    // for legibility (doc §3b); >1 stage is refused before we ever get here.
+    sharded: serve.stages.length > 1,
+    servingRunRef: serve.servingRunRef,
+    stages: serve.stages,
+  }
+  return { receipt, result }
+}
+
+// The concrete `NetworkFabricDispatch`. Asks the transport to serve the request
+// with the exact-greedy-parity posture, then:
+//   1. surfaces a transport refusal/fault verbatim (already typed),
+//   2. fails closed on a malformed serve (NON-retryable malformed_response),
+//   3. REFUSES a sharded multi-stage plan (deferred this wave; NON-retryable),
+//   4. enforces NO PARITY -> NO SUCCESS (NON-retryable parity-unverified), and
+//   5. only then returns the served result + receipt.
+export const dispatchPsionicServe =
+  (config: PsionicFabricServeConfig): NetworkFabricDispatch =>
+  (request: InferenceRequest) =>
+    Effect.gen(function* () {
+      const raw = yield* config.transport({
+        messages: request.messages,
+        model: request.model,
+        passthroughParams: request.passthroughParams,
+        requireExactGreedyParity: true,
+      })
+
+      const serve = normalizeServeResponse(raw)
+      if (serve === undefined) {
+        return yield* Effect.fail(
+          fabricError({
+            kind: FABRIC_MALFORMED_RESPONSE_KIND,
+            reason: 'fabric serve returned a malformed serve response',
+            retryable: false,
+          }),
+        )
+      }
+
+      // Shard-WAN is deferred: whole-small-model only this wave. A multi-stage
+      // plan is refused before any parity/result handling.
+      if (serve.stages.length > 1) {
+        return yield* Effect.fail(
+          fabricError({
+            kind: FABRIC_SHARDED_UNSUPPORTED_KIND,
+            reason: FABRIC_SHARDED_UNSUPPORTED_REASON,
+            retryable: false,
+          }),
+        )
+      }
+
+      // THE GATE: no verified exact-greedy parity -> no success. This is the
+      // earliest fail-closed point; serving-node-payout.ts re-checks parity
+      // independently before any payout.
+      if (
+        !(serve.parityMode === 'exact_greedy_parity' && serve.parityVerified)
+      ) {
+        return yield* Effect.fail(
+          fabricError({
+            kind: FABRIC_PARITY_UNVERIFIED_KIND,
+            reason: FABRIC_PARITY_UNVERIFIED_REASON,
+            retryable: false,
+          }),
+        )
+      }
+
+      return toServedResult(serve)
+    })
+
+// Build the serving-fabric adapter wired to a Psionic serve transport. This is
+// the registration-ready factory: a wiring passes a configured transport (HTTP
+// to `psionic-serve` once owner-gated), and tests pass a local/fake serve. The
+// returned adapter is the `openagents-network` lane adapter with a LIVE dispatch
+// (vs the inert default `openAgentsNetworkAdapter`).
+export const makePsionicFabricAdapter = (config: PsionicFabricServeConfig) =>
+  // Re-uses the adapter shape from openagents-network-adapter via its public
+  // factory so the stream/complete mapping + receipt wiring stay in one place.
+  // This module owns the concrete parity-gated dispatch; the network adapter
+  // owns the InferenceProviderAdapter shape.
+  makeOpenAgentsNetworkAdapter({ dispatch: dispatchPsionicServe(config) })


### PR DESCRIPTION
**Lane:** B — Supply / Pylon (Khala M4). Part of #6012 / EPIC #6017.

## What landed

A concrete **Psionic fabric serve dispatch** behind the existing `InferenceProviderAdapter` / `openagents-network` lane seam — the first landable slice of M4 (whole-small-model serving on one admitted Pylon; shard-WAN deferred entirely).

- **`inference/psionic-fabric-serve.ts`** — a `NetworkFabricDispatch` that speaks the product-layer view of the Psionic serve wire contract: **ask-plan → execute → consume an exact-parity receipt**. It:
  - serves a **whole small model on one Pylon** and maps the serve into the normalized completion result + the typed `ServingReceipt` (who served which layer-block) the per-stage payout split consumes downstream;
  - **enforces "no parity → no success" at the dispatch layer** — a serve that is not `exact_greedy_parity` with `parityVerified: true` is a typed **NON-retryable** failure (`fabric_parity_unverified`), never a fabricated success. This is the earliest fail-closed point; `serving-node-payout.ts` re-checks parity independently before any payout;
  - **refuses sharded multi-stage plans** (`fabric_sharded_unsupported`) — shard-WAN is deferred;
  - **fails closed on a malformed serve** (`malformed_response`) and accepts both a parsed object and a JSON-string serve (real HTTP serve shape);
  - takes an **injectable transport**, so it is proven against a **local/fake Psionic serve** — the live fabric is owner-gated / Psionic-planned and is **never faked**.
- **Registration behind the adapter registry** (`index.ts`): a `registerFabricServeAdapter` activation hook wired into the `/v1/chat/completions` path alongside `registerPassthroughAdapters`. It is a **no-op today** (no live serve transport bound), so the `openagents-network` lane stays honestly **skipped** by `dispatchWithOverflow` and overflows to passthrough — and activates with **no routing change** once a transport lands.

**Guinea-pig test worker:** the new tests use the designated primary test Pylon (`.secrets/khala-test-payout.env`) as the primary serving worker via a **public-safe `nodeRef`** (`pylon.khala-test-payout.primary`). Its Spark receive address is payment material — it is **not** committed; the serving receipt identifies the node by attribution ref only (verified: staged diff scanned, no address leak).

## Tests + results

`bun run --cwd workers/api test -- src/inference/` → **431 passed (33 files)**. New `psionic-fabric-serve.test.ts` adds 9 cases: parity-passing guinea-pig serve, parity gate (both `parityVerified:false` and `parityMode:none`), shard refusal, malformed fail-closed, JSON-string serve, transport-fault passthrough, registration-ready adapter (`complete`/`stream`), and inert-default sanity.

`bun run typecheck` → **green** (packages + web + api).

## Blockers / NEEDS-OWNER

- **NEEDS-OWNER (live fabric):** binding a live Psionic `psionic-serve` transport is owner-gated / Psionic-planned (see `2026-06-19-decentralized-serving-shard-wan.md` §7). The dispatch + receipt + parity gate are proven against a local/fake serve; activating the live lane is a one-line `registry.register(makePsionicFabricAdapter({ transport }))` once a transport client exists. This is **scaffold evidence proven against a fake serve, not a live product proof**.
- The first real Bitcoin/Spark payout to the guinea-pig Pylon is **Lane E (Ledger)** + owner-armed; this lane only emits the parity-gated serving receipt that loop consumes.

Part of #6012 / EPIC #6017.

**DO NOT auto-merge — orchestrator will review/merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)