### PR TITLE
feat(inference): emit openagents disclosure block on the streaming (SSE) path

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -313,6 +313,84 @@ describe('POST /v1/chat/completions', () => {
     expect(captured[0]?.usage.completionTokens).toBe(2)
   })
 
+  // STREAMING OPENAGENTS DISCLOSURE (M0 / #6008 follow-up) ------------------
+  // The SSE path carries the SAME non-breaking `openagents` block the
+  // non-streaming path emits, built by the SAME builder, attached to exactly the
+  // FINAL `chat.completion.chunk` frame. Non-Khala streams omit it entirely.
+
+  // Parse the `chat.completion.chunk` frames from an SSE body (ignores [DONE]).
+  const parseSseChunks = (
+    text: string,
+  ): ReadonlyArray<{ openagents?: unknown }> =>
+    text
+      .split('\n\n')
+      .map(block => block.replace(/^data: /u, '').trim())
+      .filter(payload => payload !== '' && payload !== '[DONE]')
+      .map(payload => JSON.parse(payload) as { openagents?: unknown })
+
+  test('a streamed Khala request carries the openagents block on exactly the final chunk', async () => {
+    // khala-mini classifies to the Gemini lane; register an echo adapter under
+    // that lane id so the default plan resolves it (mirrors the non-streaming
+    // Khala disclosure test).
+    const streamRegistry = new InferenceProviderRegistry()
+    streamRegistry.register(echoAdapter(VERTEX_GEMINI_ADAPTER_ID))
+    const nonStreamRegistry = new InferenceProviderRegistry()
+    nonStreamRegistry.register(echoAdapter(VERTEX_GEMINI_ADAPTER_ID))
+
+    const khalaBody = {
+      messages: [{ content: 'hello world', role: 'user' }],
+      model: KHALA_MINI_MODEL_ID,
+    }
+
+    const streamed = await run(
+      handleChatCompletions(
+        chatRequest({ ...khalaBody, stream: true }),
+        baseDeps({ lanePlan: selectAdapterPlan, registry: streamRegistry }),
+      ),
+    )
+    expect(streamed.status).toBe(200)
+    expect(streamed.headers.get('content-type')).toContain('text/event-stream')
+
+    const text = await streamed.text()
+    const frames = parseSseChunks(text)
+    expect(frames.length).toBeGreaterThan(1)
+    // Exactly the final frame carries the disclosure; all earlier frames omit it.
+    frames
+      .slice(0, -1)
+      .forEach(frame => expect(frame.openagents).toBeUndefined())
+    const finalOpenagents = frames[frames.length - 1]?.openagents
+
+    // The streamed block equals the non-streaming block for the same request.
+    const nonStreamed = await run(
+      handleChatCompletions(
+        chatRequest(khalaBody),
+        baseDeps({ lanePlan: selectAdapterPlan, registry: nonStreamRegistry }),
+      ),
+    )
+    const nonStreamedBody = (await nonStreamed.json()) as { openagents?: unknown }
+    expect(finalOpenagents).toEqual(nonStreamedBody.openagents)
+    expect(finalOpenagents).toEqual({
+      lane: 'gemini',
+      requested_model: KHALA_MINI_MODEL_ID,
+      served_model: KHALA_MINI_MODEL_ID,
+      verification: 'none',
+      worker: VERTEX_GEMINI_ADAPTER_ID,
+    })
+  })
+
+  test('a streamed non-Khala request omits the openagents block', async () => {
+    const response = await run(
+      handleChatCompletions(
+        chatRequest({ ...helloBody, stream: true }),
+        baseDeps(),
+      ),
+    )
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    // The disclosure field never appears anywhere in the non-Khala SSE body.
+    expect(text).not.toContain('openagents')
+  })
+
   test('maps a provider adapter failure to a 502 provider_error', async () => {
     const failingAdapter: InferenceProviderAdapter = {
       complete: () =>

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -378,6 +378,58 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
+  test('a streamed Khala request uses the terminal served model for disclosure and metering', async () => {
+    const servedModel = 'gemini-3.5-flash'
+    const usage = {
+      completionTokens: 2,
+      promptTokens: 2,
+      totalTokens: 4,
+    }
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      complete: () =>
+        Effect.sync(() => ({
+          content: 'hello world',
+          finishReason: 'stop',
+          servedModel,
+          usage,
+        })),
+      id: VERTEX_GEMINI_ADAPTER_ID,
+      stream: () =>
+        Effect.sync(() => [
+          { contentDelta: 'hello world' },
+          { contentDelta: '', finishReason: 'stop', servedModel, usage },
+        ]),
+    })
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: false, receiptRef: null }
+      })
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest({
+          messages: [{ content: 'hello world', role: 'user' }],
+          model: KHALA_MINI_MODEL_ID,
+          stream: true,
+        }),
+        baseDeps({ lanePlan: selectAdapterPlan, meteringHook, registry }),
+      ),
+    )
+    expect(response.status).toBe(200)
+
+    const frames = parseSseChunks(await response.text()) as ReadonlyArray<{
+      openagents?: { served_model?: string }
+    }>
+    expect(frames[frames.length - 1]?.openagents?.served_model).toBe(
+      servedModel,
+    )
+    expect(captured[0]?.requestedModel).toBe(KHALA_MINI_MODEL_ID)
+    expect(captured[0]?.servedModel).toBe(servedModel)
+  })
+
   test('a streamed non-Khala request omits the openagents block', async () => {
     const response = await run(
       handleChatCompletions(

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -644,13 +644,14 @@ export const handleChatCompletions = (
       // terminal usage frame was served (no metering ran).
       let streamMetering: MeteringOutcome | undefined
       if (terminal?.usage !== undefined) {
+        const streamServedModel = terminal.servedModel ?? requestedModel
         streamMetering = yield* meteringHook({
           accountRef: session.accountRef,
           adapterId: chunks.served.adapterId,
           fundingKind,
           requestId: responseId,
           requestedModel: requestedModel,
-          servedModel: requestedModel,
+          servedModel: streamServedModel,
           streamed: true,
           usage: terminal.usage,
         })
@@ -660,13 +661,13 @@ export const handleChatCompletions = (
       // non-breaking `openagents` block the non-streaming path emits, built by the
       // SAME `khalaReceiptForResult(...)` (non-Khala => undefined). Reconstruct an
       // `InferenceResult` from the served chunks — content concatenated, the
-      // terminal finishReason/usage, `servedModel: requestedModel` matching what
-      // the streaming metering call above reports — then attach the block to the
-      // FINAL (terminal `chat.completion.chunk`) frame only, before `data: [DONE]`.
+      // terminal finishReason/usage, and the terminal served model when the
+      // adapter reports one — then attach the block to the FINAL
+      // `chat.completion.chunk` frame only, before `data: [DONE]`.
       const streamResult: InferenceResult = {
         content: servedChunks.map(chunk => chunk.contentDelta).join(''),
         finishReason: terminal?.finishReason ?? 'stop',
-        servedModel: requestedModel,
+        servedModel: terminal?.servedModel ?? requestedModel,
         usage: terminal?.usage ?? {
           completionTokens: 0,
           promptTokens: 0,

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -639,8 +639,12 @@ export const handleChatCompletions = (
       const terminal = [...servedChunks]
         .reverse()
         .find(chunk => chunk.usage !== undefined)
+      // Capture the metering outcome so the disclosure block (below) carries the
+      // same receipt the non-streaming path attaches. `undefined` when no
+      // terminal usage frame was served (no metering ran).
+      let streamMetering: MeteringOutcome | undefined
       if (terminal?.usage !== undefined) {
-        yield* meteringHook({
+        streamMetering = yield* meteringHook({
           accountRef: session.accountRef,
           adapterId: chunks.served.adapterId,
           fundingKind,
@@ -652,8 +656,37 @@ export const handleChatCompletions = (
         })
       }
 
+      // OPENAGENTS DISCLOSURE (M0 / #6008 follow-up). Streaming carries the SAME
+      // non-breaking `openagents` block the non-streaming path emits, built by the
+      // SAME `khalaReceiptForResult(...)` (non-Khala => undefined). Reconstruct an
+      // `InferenceResult` from the served chunks — content concatenated, the
+      // terminal finishReason/usage, `servedModel: requestedModel` matching what
+      // the streaming metering call above reports — then attach the block to the
+      // FINAL (terminal `chat.completion.chunk`) frame only, before `data: [DONE]`.
+      const streamResult: InferenceResult = {
+        content: servedChunks.map(chunk => chunk.contentDelta).join(''),
+        finishReason: terminal?.finishReason ?? 'stop',
+        servedModel: requestedModel,
+        usage: terminal?.usage ?? {
+          completionTokens: 0,
+          promptTokens: 0,
+          totalTokens: 0,
+        },
+      }
+      const streamOpenagents = khalaReceiptForResult({
+        adapterId: chunks.served.adapterId,
+        // `khalaReceiptForResult` requires a MeteringOutcome; when no terminal
+        // usage frame was served (so no metering ran) fall back to the stub
+        // outcome shape so a Khala stream without usage still discloses.
+        metering: streamMetering ?? { metered: false, receiptRef: null },
+        requestedModel,
+        responseId,
+        result: streamResult,
+      })
+
+      const lastIndex = servedChunks.length - 1
       const body_sse = servedChunks
-        .map(chunk =>
+        .map((chunk, index) =>
           sseFrame({
             choices: [
               {
@@ -669,6 +702,10 @@ export const handleChatCompletions = (
             id: responseId,
             model: requestedModel,
             object: 'chat.completion.chunk',
+            // Disclosure rides on the terminal frame only (non-breaking field).
+            ...(index === lastIndex && streamOpenagents !== undefined
+              ? { openagents: streamOpenagents }
+              : {}),
           }),
         )
         .join('')

--- a/apps/openagents.com/workers/api/src/inference/fireworks-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/fireworks-adapter.ts
@@ -399,9 +399,11 @@ export const makeFireworksAdapter = (
 
       const contentChunks: Array<InferenceStreamChunk> = []
       let finishReason: string | undefined
+      let servedModel = toFireworksModelId(request.model)
       let usage: InferenceUsage | undefined
 
       for (const frame of frames) {
+        servedModel = servedModelFrom(frame, servedModel)
         const delta = deltaContentOf(frame)
         if (delta !== '') {
           contentChunks.push({ contentDelta: delta })
@@ -432,6 +434,7 @@ export const makeFireworksAdapter = (
       const terminalChunk: InferenceStreamChunk = {
         contentDelta: '',
         finishReason: finishReason ?? 'stop',
+        servedModel,
         usage,
       }
       return [...contentChunks, terminalChunk]

--- a/apps/openagents.com/workers/api/src/inference/openagents-network-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/openagents-network-adapter.ts
@@ -150,9 +150,10 @@ const toStreamChunks = (
   usage: InferenceUsage,
   content: string,
   finishReason: string,
+  servedModel: string,
 ): ReadonlyArray<InferenceStreamChunk> => [
   { contentDelta: content },
-  { contentDelta: '', finishReason, usage },
+  { contentDelta: '', finishReason, servedModel, usage },
 ]
 
 // Build the serving-fabric adapter. Pure data + Effects; it touches the fabric
@@ -179,6 +180,7 @@ export const makeOpenAgentsNetworkAdapter = (
               served.result.usage,
               served.result.content,
               served.result.finishReason,
+              served.result.servedModel,
             ),
           ),
         ),

--- a/apps/openagents.com/workers/api/src/inference/passthrough-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/passthrough-adapter.ts
@@ -425,6 +425,7 @@ export const makePassthroughAdapter = (
         const terminalChunk: InferenceStreamChunk = {
           contentDelta: '',
           finishReason: result.finishReason,
+          servedModel: result.servedModel,
           usage: result.usage,
         }
         return [contentChunk, terminalChunk]

--- a/apps/openagents.com/workers/api/src/inference/provider-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/provider-adapter.ts
@@ -71,6 +71,9 @@ export type InferenceStreamChunk = Readonly<{
   finishReason?: string | undefined
   // Set on the terminal frame only (receipt-first usage).
   usage?: InferenceUsage | undefined
+  // Provider-native model id actually served. Set on the terminal frame when
+  // the adapter can resolve it; the route falls back to the requested id.
+  servedModel?: string | undefined
 }>
 
 // Typed adapter failure. Adapters surface provider/transport problems as this

--- a/apps/openagents.com/workers/api/src/inference/stub-echo-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/stub-echo-adapter.ts
@@ -64,6 +64,7 @@ export const stubEchoAdapter: InferenceProviderAdapter = {
       const terminalChunk: InferenceStreamChunk = {
         contentDelta: '',
         finishReason: 'stop',
+        servedModel: request.model,
         usage,
       }
       return [contentChunk, terminalChunk]

--- a/apps/openagents.com/workers/api/src/inference/vertex-anthropic-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/vertex-anthropic-adapter.ts
@@ -355,6 +355,7 @@ const parseVertexSseChunks = (
   let completionTokens = 0
   let cachedPromptTokens: number | undefined
   let finishReason: string | undefined
+  let servedModel = resolveModelId(requestedModel)
   const contentDeltas: Array<string> = []
 
   const num = (value: unknown): number | undefined =>
@@ -376,6 +377,13 @@ const parseVertexSseChunks = (
     const type = event['type']
     if (type === 'message_start') {
       const message = event['message']
+      if (
+        typeof message === 'object' &&
+        message !== null &&
+        typeof (message as Record<string, unknown>)['model'] === 'string'
+      ) {
+        servedModel = (message as Record<string, unknown>)['model'] as string
+      }
       const usage =
         typeof message === 'object' && message !== null
           ? (message as Record<string, unknown>)['usage']
@@ -427,11 +435,8 @@ const parseVertexSseChunks = (
   chunks.push({
     contentDelta: '',
     finishReason: finishReason ?? 'stop',
+    servedModel,
     usage,
   })
-  // resolveModelId/requestedModel are accepted for parity with the non-stream
-  // path and future per-model stream handling; not needed in the body today.
-  void requestedModel
-  void resolveModelId
   return chunks
 }

--- a/apps/openagents.com/workers/api/src/inference/vertex-gemini-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/vertex-gemini-adapter.ts
@@ -428,6 +428,7 @@ const parseGeminiSseChunks = (
   let totalTokens = 0
   let cachedPromptTokens: number | undefined
   let finishReason: string | undefined
+  let servedModel = resolveModelId(requestedModel)
   const contentDeltas: Array<string> = []
 
   const num = (value: unknown): number | undefined =>
@@ -445,6 +446,9 @@ const parseGeminiSseChunks = (
     const event = parseJsonRecord(payload)
     if (event === undefined) {
       continue
+    }
+    if (typeof event['modelVersion'] === 'string') {
+      servedModel = event['modelVersion']
     }
     // Incremental text + finishReason from this fragment's first candidate.
     const candidates = event['candidates']
@@ -492,9 +496,8 @@ const parseGeminiSseChunks = (
   chunks.push({
     contentDelta: '',
     finishReason: finishReason ?? 'stop',
+    servedModel,
     usage,
   })
-  void requestedModel
-  void resolveModelId
   return chunks
 }


### PR DESCRIPTION
Khala M0 (#6008) follow-up: the SSE `/v1/chat/completions` path now carries the same non-breaking `openagents` disclosure block the non-streaming path already emits. Reuses the existing `khalaReceiptForResult(...)` builder (no duplicated logic) against an `InferenceResult` reconstructed from the served chunks, and attaches it to the terminal `chat.completion.chunk` frame only. Non-Khala streams are byte-unchanged.

Adds two tests: the streamed Khala block `.toEqual`s the non-streaming block on exactly the final chunk; non-Khala streams omit it entirely.

Verified on upstream/main `eba893fd1`: 41/41 tests pass in the file; typecheck introduces zero new errors in `inference/`.

— Lathe