### PR TITLE
Khala M8: head-to-head runner (stub-ready, live-flip-ready)

### DIFF
--- a/docs/inference/khala-head-to-head-demo.md
+++ b/docs/inference/khala-head-to-head-demo.md
@@ -28,13 +28,31 @@ cite or reproduce them. They are never mixed into OpenAgents measurements.
 
 - Fixture manifest:
   `docs/inference/fixtures/khala-head-to-head-dry-run.v1.json`
+- Runner (drives both lanes, emits the manifest):
+  `scripts/khala-demo/run-head-to-head.mjs`
 - Reducer/validator:
   `scripts/khala-demo/reduce-head-to-head.mjs`
 - Publication renderer:
   `scripts/khala-demo/render-publication.mjs`
 - Test:
-  `scripts/khala-demo/reduce-head-to-head.test.mjs` and
+  `scripts/khala-demo/run-head-to-head.test.mjs`,
+  `scripts/khala-demo/reduce-head-to-head.test.mjs`, and
   `scripts/khala-demo/render-publication.test.mjs`
+
+Run the runner against the built-in stub transport (no live gateway needed)
+and pipe it through the reducer:
+
+```sh
+bun scripts/khala-demo/run-head-to-head.mjs --stub \
+  | bun scripts/khala-demo/reduce-head-to-head.mjs /dev/stdin
+```
+
+Or write the stub manifest to a file first:
+
+```sh
+bun scripts/khala-demo/run-head-to-head.mjs --out /tmp/khala-h2h.json
+bun scripts/khala-demo/reduce-head-to-head.mjs /tmp/khala-h2h.json
+```
 
 Run the dry-run reducer:
 
@@ -56,6 +74,56 @@ Render the publication draft:
 bun scripts/khala-demo/render-publication.mjs \
   docs/inference/fixtures/khala-head-to-head-dry-run.v1.json
 ```
+
+## Runner
+
+`scripts/khala-demo/run-head-to-head.mjs` drives the head-to-head and feeds the
+harness above. It sends the crossy-road prompt to two OpenAI-compatible lanes,
+collects what the responses actually report, and emits a manifest in the exact
+`openagents.khala_head_to_head_evidence.v1` shape the reducer consumes.
+
+- **Khala lane:** `POST {KHALA_BASE_URL}/chat/completions` with model
+  `openagents/khala-code` (override with `--khala-model`). It reads the
+  non-breaking `openagents` response block (`receipt`, `route`, `workers`,
+  `verification`, `cost_msat`, `price_msat`, `settled`, and any optional
+  settlement/Verse/in-world/energy fields).
+- **Frontier baseline lane:** the same OpenAI-compatible call against a
+  separate base URL/token/model.
+
+Configuration (CLI flag or env var):
+
+| Flag | Env | Default |
+|---|---|---|
+| `--khala-base-url` | `KHALA_BASE_URL` | — (stub if unset) |
+| `--khala-token` | `KHALA_AGENT_TOKEN` | — |
+| `--khala-model` | `KHALA_MODEL` | `openagents/khala-code` |
+| `--frontier-base-url` | `FRONTIER_BASE_URL` | — (stub if unset) |
+| `--frontier-token` | `FRONTIER_TOKEN` | — |
+| `--frontier-model` | `FRONTIER_MODEL` | `frontier-baseline` |
+| `--msat-per-usd` | `KHALA_MSAT_PER_USD` | — (USD stays unmeasured) |
+| `--stub` | `KHALA_RUNNER_STUB=1` | force the built-in stub |
+| `--out <path>` | — | write manifest to file (else stdout) |
+
+**Stub vs live.** With no live base URLs (or `--stub`) the runner uses a
+deterministic, public-safe stub transport and emits an `evidenceMode:
+fixture_scaffold` manifest. Only when **both** lanes have a real base URL and
+the stub is not forced does it emit `evidenceMode: live`. The live gateway is
+owner-gated, so the runner is "flip-ready": set the env vars and drop `--stub`.
+
+**Honesty contract (enforced by the runner, not just the reducer).** The runner
+never fabricates metrics:
+
+- Tokens/cost/wall-clock come only from the response and the measured clock.
+- `costUsd` is `0` (with a `cost_usd_not_measured` blocker) unless the response
+  carries `cost_usd`, or `cost_msat` plus a `--msat-per-usd` conversion rate.
+- A missing verifier verdict is `verificationClass: none`, not accepted.
+- Settlement is `settled: false` unless the response explicitly says settled and
+  supplies worker/validator receipt refs.
+- Verse playback, in-world artifact, and energy kWh stay `null` unless the
+  response provides them; energy is never estimated.
+- Because the owner-gated live gateway does not yet return settlement, Verse,
+  in-world, or energy evidence, a current live run still keeps
+  `closureAudit.canClose: false` — exactly like the stub and fixture.
 
 ## Manifest Contract
 

--- a/scripts/khala-demo/run-head-to-head.mjs
+++ b/scripts/khala-demo/run-head-to-head.mjs
@@ -1,0 +1,598 @@
+#!/usr/bin/env bun
+
+/**
+ * Khala M8 head-to-head runner.
+ *
+ * Drives the crossy-road prompt against two lanes:
+ *   - `khala`           -> OpenAgents OpenAI-compatible endpoint (model openagents/khala-code)
+ *   - `frontier_baseline` -> a frontier OpenAI-compatible endpoint
+ *
+ * It collects tokens / cost / wall-clock and the `openagents` verification +
+ * receipt refs per side, then emits a manifest in the EXACT shape consumed by
+ * `reduce-head-to-head.mjs` (schema openagents.khala_head_to_head_evidence.v1).
+ *
+ * SAFETY / HONESTY RULES (enforced here, not just by the reducer):
+ *   - The runner NEVER fabricates measurements. Fields the endpoint does not
+ *     report stay null / empty / `not_measured` semantics, which keeps the
+ *     reducer's closureAudit.canClose === false until real live evidence
+ *     exists.
+ *   - A stub/fixture endpoint produces a `fixture_scaffold` manifest. Only a
+ *     real, non-stub endpoint produces `evidenceMode: "live"`, and even then
+ *     all the missing live-evidence pieces (settlement receipts, Verse
+ *     playback, in-world artifact, measured energy) remain blockers until they
+ *     are actually present in the response.
+ *   - No secrets, tokens, or local paths are written into the manifest.
+ *
+ * Usage:
+ *   bun scripts/khala-demo/run-head-to-head.mjs [options]
+ *
+ * Options (all also read from env):
+ *   --khala-base-url <url>      KHALA_BASE_URL      OpenAI-compatible base, e.g. https://openagents.com/v1
+ *   --khala-token <token>       KHALA_AGENT_TOKEN   bearer token for the Khala lane
+ *   --khala-model <id>          KHALA_MODEL         default openagents/khala-code
+ *   --frontier-base-url <url>   FRONTIER_BASE_URL   OpenAI-compatible base for the baseline
+ *   --frontier-token <token>    FRONTIER_TOKEN      bearer token for the baseline lane
+ *   --frontier-model <id>       FRONTIER_MODEL      default frontier-baseline
+ *   --stub                      KHALA_RUNNER_STUB=1 force the built-in deterministic stub transport
+ *   --out <path>                write the manifest JSON to a file instead of stdout
+ *
+ * If no live base URL is supplied (or --stub is passed), the runner uses a
+ * deterministic, public-safe stub transport so the harness is exercised end to
+ * end without the owner-gated live gateway.
+ */
+
+import { writeFileSync } from "node:fs";
+
+export const NOT_MEASURED = "not_measured";
+
+export const CROSSY_ROAD_PROMPT =
+  "build a really high quality single html file crossy road game with three.js";
+
+const MANIFEST_SCHEMA = "openagents.khala_head_to_head_evidence.v1";
+const DEFAULT_KHALA_MODEL = "openagents/khala-code";
+const DEFAULT_FRONTIER_MODEL = "frontier-baseline";
+
+const SCOPE = {
+  issueRef: "github:OpenAgentsInc/openagents#6016",
+  parentIssueRef: "github:OpenAgentsInc/openagents#6017",
+  roadmapRef:
+    "docs/inference/khala-buildout-roadmap.md#agent-demo--benchmark-metrics-and-publication-pack",
+  runbookRef: "docs/inference/khala-head-to-head-demo.md",
+  prompt: CROSSY_ROAD_PROMPT,
+  benchmarkRef: "benchmark.khala.crossy_road_threejs.single_html.v1",
+};
+
+/**
+ * Convert provider msat figures to USD only when we are explicitly told a
+ * conversion rate. We never invent a price; without an msat figure and a rate
+ * the dollars value stays 0 and the missing-cost blocker is recorded.
+ */
+function msatToUsd(msat, msatPerUsd) {
+  if (
+    typeof msat !== "number" ||
+    !Number.isFinite(msat) ||
+    typeof msatPerUsd !== "number" ||
+    !Number.isFinite(msatPerUsd) ||
+    msatPerUsd <= 0
+  ) {
+    return null;
+  }
+  return msat / msatPerUsd;
+}
+
+function numberOrNull(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Build a single manifest `run` from an OpenAI-compatible chat completion
+ * response and the wall-clock we measured around the call.
+ *
+ * `live` controls whether this run is allowed to claim `live` evidence. Even
+ * when `live` is true, every field that the response did not actually provide
+ * is recorded as missing (null / [] / blocker), never fabricated.
+ */
+export function buildRunFromCompletion({
+  lane,
+  label,
+  model,
+  provider,
+  response,
+  startedAt,
+  completedAt,
+  wallClockMs,
+  live,
+  msatPerUsd = null,
+}) {
+  const evidenceMode = live ? "live" : "fixture_scaffold";
+  const oa = (response && typeof response === "object" && response.openagents) || {};
+  const usage = (response && typeof response === "object" && response.usage) || {};
+
+  const promptTokens = numberOrNull(usage.prompt_tokens) ?? 0;
+  const completionTokens = numberOrNull(usage.completion_tokens) ?? 0;
+  const totalTokens =
+    numberOrNull(usage.total_tokens) ?? promptTokens + completionTokens;
+
+  const costMsat = numberOrNull(oa.cost_msat) ?? 0;
+  const priceMsat = numberOrNull(oa.price_msat) ?? costMsat;
+
+  // Cost in USD is only real if the provider gave us cost_msat AND we were
+  // given a conversion rate. Otherwise we keep 0 and flag it as a blocker so
+  // the reducer's cost-per-accepted-outcome is honest.
+  const derivedUsd = msatToUsd(costMsat, msatPerUsd);
+  const costUsd = numberOrNull(oa.cost_usd) ?? derivedUsd ?? 0;
+
+  const verificationClass =
+    typeof oa.verification === "string" && oa.verification.length > 0
+      ? oa.verification
+      : "none";
+  const accepted =
+    verificationClass !== "none" &&
+    verificationClass !== "seeded" &&
+    oa.accepted !== false;
+
+  const receiptRef =
+    typeof oa.receipt === "string" && oa.receipt.length > 0
+      ? oa.receipt
+      : `${lane}.receipt.missing.${evidenceMode}`;
+  const verdictRef =
+    typeof oa.verdict_ref === "string" && oa.verdict_ref.length > 0
+      ? oa.verdict_ref
+      : `${lane}.verdict.${verificationClass}.${evidenceMode}`;
+  const verifierRef =
+    typeof oa.verifier_ref === "string" && oa.verifier_ref.length > 0
+      ? oa.verifier_ref
+      : `${lane}.verifier.missing.${evidenceMode}`;
+  const artifactRef =
+    typeof oa.artifact_ref === "string" && oa.artifact_ref.length > 0
+      ? oa.artifact_ref
+      : `${lane}.artifact.crossy_road.single_html.${evidenceMode}`;
+
+  const coordinatorMode =
+    typeof oa.coordinator_mode === "string" && oa.coordinator_mode.length > 0
+      ? oa.coordinator_mode
+      : lane === "khala"
+        ? "fixture_conductor_shape"
+        : "single_model";
+
+  // Settlement: only claim settled when the response explicitly says so AND
+  // gives us worker/validator receipt refs.
+  const settlementReceiptRefs = Array.isArray(oa.settlement_receipt_refs)
+    ? oa.settlement_receipt_refs.filter((ref) => typeof ref === "string" && ref.length > 0)
+    : [];
+  const settled = oa.settled === true && settlementReceiptRefs.length > 0;
+
+  // Verse playback / in-world artifact: only present if the response provided
+  // them. The M8 head-to-head live gateway is owner-gated, so by default these
+  // are missing and become blockers.
+  const versePlaybackRef =
+    typeof oa.verse_playback_ref === "string" && oa.verse_playback_ref.length > 0
+      ? oa.verse_playback_ref
+      : null;
+  const playableInWorldRef =
+    typeof oa.playable_in_world_ref === "string" && oa.playable_in_world_ref.length > 0
+      ? oa.playable_in_world_ref
+      : null;
+  const inWorldWorkUnits = numberOrNull(oa.in_world_work_units) ?? 0;
+  const gatewayWorkUnits = numberOrNull(oa.gateway_work_units) ?? 0;
+
+  // Energy telemetry: never estimated. Only a measured kWh + measurement ref
+  // counts; otherwise AO/kWh stays not_measured downstream.
+  const kwhMeasured = numberOrNull(oa.kwh_measured);
+  const energyMeasurementRef =
+    typeof oa.energy_measurement_ref === "string" && oa.energy_measurement_ref.length > 0
+      ? oa.energy_measurement_ref
+      : null;
+
+  const acceptedBlockers = [];
+  if (verificationClass === "none") {
+    acceptedBlockers.push("blocker.khala_demo.verifier_verdict_missing");
+  }
+  if (!live) {
+    acceptedBlockers.push("blocker.khala_demo.fixture_verifier_not_live");
+  }
+
+  const artifactBlockers = [];
+  if (playableInWorldRef === null) {
+    artifactBlockers.push(
+      lane === "khala"
+        ? "blocker.khala_demo.artifact_not_playable_in_world"
+        : "blocker.khala_demo.frontier_artifact_not_playable_in_world",
+    );
+  }
+
+  const settlementBlockers = [];
+  if (!settled) {
+    if (lane === "khala") {
+      settlementBlockers.push("blocker.khala_demo.worker_settlement_missing");
+      settlementBlockers.push("blocker.khala_demo.validator_settlement_missing");
+    } else {
+      settlementBlockers.push("blocker.khala_demo.frontier_no_settlement_expected");
+    }
+  }
+
+  const verseBlockers = [];
+  if (versePlaybackRef === null) {
+    verseBlockers.push(
+      lane === "khala"
+        ? "blocker.khala_demo.verse_playback_missing"
+        : "blocker.khala_demo.frontier_verse_playback_missing",
+    );
+  } else if (!live) {
+    verseBlockers.push("blocker.khala_demo.verse_playback_fixture_only");
+  }
+
+  const energyBlockers = [];
+  if (kwhMeasured === null || kwhMeasured <= 0 || energyMeasurementRef === null) {
+    energyBlockers.push("blocker.khala_demo.energy_telemetry_missing");
+  }
+
+  const costBlockers = [];
+  if (costUsd === 0) {
+    costBlockers.push("blocker.khala_demo.cost_usd_not_measured");
+  }
+
+  const runBlockers = [];
+  if (!live) {
+    runBlockers.push("blocker.khala_demo.fixture_scaffold_not_live");
+  }
+  if (lane === "khala" && coordinatorMode !== "live_conductor") {
+    runBlockers.push("blocker.khala_demo.m7_live_conductor_missing");
+  }
+
+  return {
+    runId: `${lane}.crossy_road.${evidenceMode}.v1`,
+    lane,
+    label,
+    model,
+    provider,
+    coordinator: {
+      mode: coordinatorMode,
+      policyRef:
+        typeof oa.policy_ref === "string" && oa.policy_ref.length > 0
+          ? oa.policy_ref
+          : `${lane}.policy.${evidenceMode}.v1`,
+      promoted: oa.coordinator_promoted === true,
+    },
+    evidenceMode,
+    startedAt,
+    completedAt,
+    wallClockMs,
+    usage: {
+      promptTokens,
+      completionTokens,
+      totalTokens,
+    },
+    costUsd,
+    costMsat,
+    priceMsat,
+    acceptedOutcome: {
+      accepted,
+      verificationClass,
+      verdictRef,
+      verifierRef,
+      receiptRef,
+      evidenceRefs: [artifactRef],
+      blockerRefs: acceptedBlockers,
+    },
+    artifact: {
+      kind: "single_html",
+      artifactRef,
+      playableInWorldRef,
+      blockerRefs: artifactBlockers,
+    },
+    settlement: {
+      settled,
+      receiptRefs: settlementReceiptRefs,
+      blockerRefs: settlementBlockers,
+    },
+    verse: {
+      playbackRef: versePlaybackRef,
+      sourceRefs: versePlaybackRef === null ? [] : [receiptRef],
+      inWorldWorkUnits,
+      gatewayWorkUnits,
+      blockerRefs: verseBlockers,
+    },
+    energy: {
+      kwhMeasured,
+      measurementRef: energyMeasurementRef,
+      blockerRefs: energyBlockers,
+    },
+    sourceRefs: [
+      "docs/inference/khala-buildout-roadmap.md",
+      "docs/inference/khala-head-to-head-demo.md",
+    ],
+    blockerRefs: [...runBlockers, ...costBlockers],
+  };
+}
+
+/**
+ * Deterministic, public-safe stub transport. It mimics the OpenAI-compatible
+ * shape (choices + usage + the non-breaking `openagents` block) without any
+ * settlement, Verse, in-world, or energy telemetry, so that a stub run keeps
+ * the closure audit blocked exactly like the fixture scaffold.
+ */
+export function stubTransport({ lane, model }) {
+  if (lane === "khala") {
+    return {
+      id: "chatcmpl_stub_khala",
+      model,
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: { role: "assistant", content: "<!doctype html><!-- stub crossy-road artifact -->" },
+        },
+      ],
+      usage: { prompt_tokens: 18420, completion_tokens: 71180, total_tokens: 89600 },
+      openagents: {
+        receipt: "stub.receipt.khala.crossy_road.accepted.v1",
+        route: "coding",
+        workers: ["stub-coding-worker", "stub-validator"],
+        verification: "test_passed",
+        cost_msat: 1150000,
+        price_msat: 1540000,
+        settled: false,
+        // Deliberately NO settlement_receipt_refs, verse_playback_ref,
+        // playable_in_world_ref, kwh_measured, or live_conductor mode: the
+        // stub is honest about being incomplete evidence.
+        in_world_work_units: 3,
+        gateway_work_units: 2,
+      },
+    };
+  }
+  return {
+    id: "chatcmpl_stub_frontier",
+    model,
+    choices: [
+      {
+        index: 0,
+        finish_reason: "stop",
+        message: { role: "assistant", content: "<!doctype html><!-- stub frontier artifact -->" },
+      },
+    ],
+    usage: { prompt_tokens: 21000, completion_tokens: 919000, total_tokens: 940000 },
+    openagents: {
+      receipt: "stub.receipt.frontier.crossy_road.accepted.v1",
+      route: "default",
+      workers: ["stub-frontier-model"],
+      verification: "test_passed",
+      cost_msat: 5947000,
+      price_msat: 5947000,
+      settled: false,
+      in_world_work_units: 0,
+      gateway_work_units: 1,
+    },
+  };
+}
+
+/**
+ * Live transport: POST an OpenAI-compatible chat completion. Kept tiny on
+ * purpose; the runner is "flip-ready" by swapping the stub for this once the
+ * gateway is enabled and a base URL + token are provided.
+ */
+export async function liveTransport({ baseUrl, token, model, prompt, fetchImpl = fetch }) {
+  const url = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
+  const headers = { "content-type": "application/json" };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0.2,
+      stream: false,
+    }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`lane request failed: ${res.status} ${res.statusText} ${detail.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+/**
+ * Run one lane: time the transport call, then build the manifest run.
+ */
+export async function runLane({ lane, label, model, provider, transport, live, msatPerUsd, clock = Date.now }) {
+  const startMs = clock();
+  const startedAt = new Date(startMs).toISOString();
+  const response = await transport({ lane, model });
+  const endMs = clock();
+  const completedAt = new Date(endMs).toISOString();
+  const wallClockMs = Math.max(0, endMs - startMs);
+
+  return buildRunFromCompletion({
+    lane,
+    label,
+    model,
+    provider,
+    response,
+    startedAt,
+    completedAt,
+    wallClockMs,
+    live,
+    msatPerUsd,
+  });
+}
+
+/**
+ * Drive both lanes and assemble the head-to-head manifest.
+ *
+ * `live` is true only when BOTH lanes have a real base URL and the stub was not
+ * forced. The manifest's top-level evidenceMode and per-run evidenceMode follow
+ * from that. The external reported claims and publication block stay as
+ * unverified / draft scaffolding — promoting them is owner-gated and out of the
+ * runner's scope.
+ */
+export async function runHeadToHead(options = {}) {
+  const {
+    khalaTransport,
+    frontierTransport,
+    live = false,
+    msatPerUsd = null,
+    khalaModel = DEFAULT_KHALA_MODEL,
+    frontierModel = DEFAULT_FRONTIER_MODEL,
+    khalaProvider = live ? "openagents" : "openagents-stub",
+    frontierProvider = live ? "external" : "external-stub",
+    generatedAt = new Date().toISOString(),
+    clock = Date.now,
+  } = options;
+
+  const khalaRun = await runLane({
+    lane: "khala",
+    label: live ? "Khala live run" : "Khala stub run",
+    model: khalaModel,
+    provider: khalaProvider,
+    transport: khalaTransport,
+    live,
+    msatPerUsd,
+    clock,
+  });
+
+  const frontierRun = await runLane({
+    lane: "frontier_baseline",
+    label: live ? "Frontier baseline live run" : "Frontier baseline stub run",
+    model: frontierModel,
+    provider: frontierProvider,
+    transport: frontierTransport,
+    live,
+    msatPerUsd,
+    clock,
+  });
+
+  const evidenceMode = live ? "live" : "fixture_scaffold";
+
+  return {
+    schema: MANIFEST_SCHEMA,
+    manifestRef: live
+      ? "live.khala.head_to_head.demo.v1"
+      : "stub.khala.head_to_head.demo.v1",
+    evidenceMode,
+    generatedAt,
+    scope: SCOPE,
+    runs: [khalaRun, frontierRun],
+    externalReportedClaims: [
+      {
+        claimRef: "reported.sakana_fugu_ultra.crossy_road.external_unverified.v1",
+        label: "Sakana Fugu Ultra reported comparison",
+        citationStatus: "reported_without_primary_url",
+        tokens: 89000,
+        costUsd: 7.32,
+        wallClockMs: 1320000,
+        verdictSummary:
+          "Reported faster and cheaper; issues included inverted turn direction, wonky camera, no SFX, and not identical to Crossy Road.",
+        blockerRefs: ["blocker.khala_demo.external_claim_primary_url_missing"],
+      },
+      {
+        claimRef: "reported.claude_opus_4_8_ultracode.crossy_road.external_unverified.v1",
+        label: "Claude Opus 4.8 Ultracode reported comparison",
+        citationStatus: "reported_without_primary_url",
+        tokens: 940000,
+        costUsd: 37.85,
+        wallClockMs: 4740000,
+        verdictSummary:
+          "Reported higher quality; issues included retry loops and wrong restart character position.",
+        blockerRefs: ["blocker.khala_demo.external_claim_primary_url_missing"],
+      },
+    ],
+    publication: {
+      status: "draft_scaffold",
+      publicationRef: null,
+      claimUpgradeRefs: [],
+      blockerRefs: [
+        "blocker.khala_demo.live_runs_missing",
+        "blocker.khala_demo.publication_missing",
+        "blocker.khala_demo.owner_signed_claim_upgrade_missing",
+      ],
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const opts = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--stub") {
+      opts.stub = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        opts[key] = true;
+      } else {
+        opts[key] = next;
+        i += 1;
+      }
+    }
+  }
+  return opts;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const env = process.env;
+
+  const khalaBaseUrl = args["khala-base-url"] || env.KHALA_BASE_URL || null;
+  const khalaToken = args["khala-token"] || env.KHALA_AGENT_TOKEN || null;
+  const khalaModel = args["khala-model"] || env.KHALA_MODEL || DEFAULT_KHALA_MODEL;
+  const frontierBaseUrl = args["frontier-base-url"] || env.FRONTIER_BASE_URL || null;
+  const frontierToken = args["frontier-token"] || env.FRONTIER_TOKEN || null;
+  const frontierModel = args["frontier-model"] || env.FRONTIER_MODEL || DEFAULT_FRONTIER_MODEL;
+  const msatPerUsd = numberOrNull(Number(args["msat-per-usd"] || env.KHALA_MSAT_PER_USD));
+
+  const forceStub = args.stub === true || env.KHALA_RUNNER_STUB === "1";
+  // Live only when the stub is not forced AND both lanes have a real base URL.
+  const live = !forceStub && Boolean(khalaBaseUrl) && Boolean(frontierBaseUrl);
+
+  const khalaTransport = live
+    ? () =>
+        liveTransport({
+          baseUrl: khalaBaseUrl,
+          token: khalaToken,
+          model: khalaModel,
+          prompt: CROSSY_ROAD_PROMPT,
+        })
+    : stubTransport;
+  const frontierTransport = live
+    ? () =>
+        liveTransport({
+          baseUrl: frontierBaseUrl,
+          token: frontierToken,
+          model: frontierModel,
+          prompt: CROSSY_ROAD_PROMPT,
+        })
+    : stubTransport;
+
+  const manifest = await runHeadToHead({
+    khalaTransport,
+    frontierTransport,
+    live,
+    msatPerUsd,
+    khalaModel,
+    frontierModel,
+  });
+
+  const json = `${JSON.stringify(manifest, null, 2)}\n`;
+  const outPath = args.out;
+  if (typeof outPath === "string") {
+    writeFileSync(outPath, json);
+    process.stderr.write(
+      `wrote ${manifest.evidenceMode} manifest to ${outPath} (live=${live})\n`,
+    );
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    process.stderr.write(`run-head-to-head failed: ${error?.message ?? error}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/khala-demo/run-head-to-head.test.mjs
+++ b/scripts/khala-demo/run-head-to-head.test.mjs
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+
+import { reduceKhalaHeadToHeadManifest } from "./reduce-head-to-head.mjs";
+import {
+  buildRunFromCompletion,
+  CROSSY_ROAD_PROMPT,
+  liveTransport,
+  runHeadToHead,
+  stubTransport,
+} from "./run-head-to-head.mjs";
+
+function counterClock(startMs = 1_000_000) {
+  let now = startMs;
+  return () => {
+    const value = now;
+    now += 1000;
+    return value;
+  };
+}
+
+describe("Khala head-to-head runner (stub)", () => {
+  test("emits a reducer-consumable manifest that still refuses to close #6016", async () => {
+    const manifest = await runHeadToHead({
+      khalaTransport: stubTransport,
+      frontierTransport: stubTransport,
+      live: false,
+      clock: counterClock(),
+      generatedAt: "2026-06-22T18:00:00.000Z",
+    });
+
+    expect(manifest.schema).toBe("openagents.khala_head_to_head_evidence.v1");
+    expect(manifest.evidenceMode).toBe("fixture_scaffold");
+    expect(manifest.runs).toHaveLength(2);
+    expect(manifest.runs.map((run) => run.lane)).toEqual(["khala", "frontier_baseline"]);
+
+    // The reducer accepts it and computes a scoreboard.
+    const metrics = reduceKhalaHeadToHeadManifest(manifest);
+    expect(metrics.summary.runCount).toBe(2);
+
+    const khala = metrics.scoreboard.find((run) => run.lane === "khala");
+    expect(khala.tokens).toBe(89600);
+    expect(khala.inWorldVsGatewaySplit.inWorldShare).toBe(0.6);
+
+    // Stub evidence MUST keep the closure audit blocked.
+    expect(metrics.closureAudit.canClose).toBe(false);
+    expect(metrics.livePromotionAudit.status).toBe("blocked");
+  });
+
+  test("never fabricates settlement, verse, in-world, or energy telemetry", async () => {
+    const manifest = await runHeadToHead({
+      khalaTransport: stubTransport,
+      frontierTransport: stubTransport,
+      live: false,
+      clock: counterClock(),
+    });
+    const khala = manifest.runs.find((run) => run.lane === "khala");
+
+    expect(khala.settlement.settled).toBe(false);
+    expect(khala.settlement.receiptRefs).toEqual([]);
+    expect(khala.verse.playbackRef).toBeNull();
+    expect(khala.artifact.playableInWorldRef).toBeNull();
+    expect(khala.energy.kwhMeasured).toBeNull();
+    expect(khala.energy.measurementRef).toBeNull();
+
+    const metrics = reduceKhalaHeadToHeadManifest(manifest);
+    const khalaMetric = metrics.scoreboard.find((run) => run.lane === "khala");
+    expect(khalaMetric.acceptedOutcomesPerKwh).toBe("not_measured");
+    expect(metrics.summary.acceptedOutcomesPerKwh).toBe("not_measured");
+  });
+
+  test("records the wall-clock measured around the transport call", async () => {
+    const manifest = await runHeadToHead({
+      khalaTransport: stubTransport,
+      frontierTransport: stubTransport,
+      live: false,
+      clock: counterClock(),
+    });
+    for (const run of manifest.runs) {
+      expect(run.wallClockMs).toBe(1000);
+      expect(run.startedAt).toBeDefined();
+      expect(run.completedAt).toBeDefined();
+    }
+  });
+});
+
+describe("buildRunFromCompletion honesty", () => {
+  test("flags missing cost when the response carries no cost_msat", () => {
+    const run = buildRunFromCompletion({
+      lane: "khala",
+      label: "no cost",
+      model: "openagents/khala-code",
+      provider: "openagents",
+      response: { usage: { total_tokens: 100 }, openagents: { verification: "test_passed" } },
+      startedAt: "2026-06-22T16:00:00.000Z",
+      completedAt: "2026-06-22T16:01:00.000Z",
+      wallClockMs: 60000,
+      live: false,
+    });
+    expect(run.costUsd).toBe(0);
+    expect(run.blockerRefs).toContain("blocker.khala_demo.cost_usd_not_measured");
+  });
+
+  test("treats a missing verifier verdict as not-accepted with a blocker", () => {
+    const run = buildRunFromCompletion({
+      lane: "khala",
+      label: "no verdict",
+      model: "openagents/khala-code",
+      provider: "openagents",
+      response: { usage: { total_tokens: 100 }, openagents: {} },
+      startedAt: "2026-06-22T16:00:00.000Z",
+      completedAt: "2026-06-22T16:01:00.000Z",
+      wallClockMs: 60000,
+      live: true,
+    });
+    expect(run.acceptedOutcome.accepted).toBe(false);
+    expect(run.acceptedOutcome.verificationClass).toBe("none");
+    expect(run.acceptedOutcome.blockerRefs).toContain(
+      "blocker.khala_demo.verifier_verdict_missing",
+    );
+  });
+
+  test("derives USD from cost_msat only when a conversion rate is supplied", () => {
+    const base = {
+      lane: "khala",
+      label: "rate",
+      model: "openagents/khala-code",
+      provider: "openagents",
+      response: {
+        usage: { total_tokens: 100 },
+        openagents: { verification: "test_passed", cost_msat: 1_000_000 },
+      },
+      startedAt: "2026-06-22T16:00:00.000Z",
+      completedAt: "2026-06-22T16:01:00.000Z",
+      wallClockMs: 60000,
+      live: true,
+    };
+    const withoutRate = buildRunFromCompletion(base);
+    expect(withoutRate.costUsd).toBe(0);
+
+    const withRate = buildRunFromCompletion({ ...base, msatPerUsd: 1_000_000 });
+    expect(withRate.costUsd).toBe(1);
+  });
+
+  test("honors explicit live settlement / verse / energy evidence when present", () => {
+    const run = buildRunFromCompletion({
+      lane: "khala",
+      label: "full live",
+      model: "openagents/khala",
+      provider: "openagents",
+      response: {
+        usage: { total_tokens: 100 },
+        openagents: {
+          verification: "test_passed",
+          cost_usd: 5,
+          cost_msat: 1000,
+          price_msat: 1200,
+          receipt: "github:OpenAgentsInc/openagents#6016-receipt",
+          coordinator_mode: "live_conductor",
+          coordinator_promoted: true,
+          settled: true,
+          settlement_receipt_refs: [
+            "github:OpenAgentsInc/openagents#6016-worker",
+            "github:OpenAgentsInc/openagents#6016-validator",
+          ],
+          verse_playback_ref: "github:OpenAgentsInc/openagents#6016-verse",
+          playable_in_world_ref: "github:OpenAgentsInc/openagents#6016-world",
+          kwh_measured: 0.5,
+          energy_measurement_ref: "github:OpenAgentsInc/openagents#6016-energy",
+        },
+      },
+      startedAt: "2026-06-22T16:00:00.000Z",
+      completedAt: "2026-06-22T16:01:00.000Z",
+      wallClockMs: 60000,
+      live: true,
+    });
+    expect(run.settlement.settled).toBe(true);
+    expect(run.settlement.receiptRefs).toHaveLength(2);
+    expect(run.verse.playbackRef).not.toBeNull();
+    expect(run.artifact.playableInWorldRef).not.toBeNull();
+    expect(run.energy.kwhMeasured).toBe(0.5);
+    expect(run.coordinator.mode).toBe("live_conductor");
+    expect(run.blockerRefs).not.toContain("blocker.khala_demo.m7_live_conductor_missing");
+  });
+});
+
+describe("liveTransport wiring", () => {
+  test("posts an OpenAI-compatible chat completion with bearer auth", async () => {
+    const calls = [];
+    const fakeFetch = async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        async json() {
+          return { id: "x", choices: [], usage: { total_tokens: 1 }, openagents: {} };
+        },
+      };
+    };
+
+    await liveTransport({
+      baseUrl: "https://openagents.com/v1/",
+      token: "agent-token",
+      model: "openagents/khala-code",
+      prompt: CROSSY_ROAD_PROMPT,
+      fetchImpl: fakeFetch,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://openagents.com/v1/chat/completions");
+    expect(calls[0].init.headers.authorization).toBe("Bearer agent-token");
+    const body = JSON.parse(calls[0].init.body);
+    expect(body.model).toBe("openagents/khala-code");
+    expect(body.messages[0].content).toBe(CROSSY_ROAD_PROMPT);
+    expect(body.stream).toBe(false);
+  });
+
+  test("throws with a public-safe error on a non-ok response", async () => {
+    const fakeFetch = async () => ({
+      ok: false,
+      status: 402,
+      statusText: "Payment Required",
+      async text() {
+        return "insufficient credits";
+      },
+    });
+    await expect(
+      liveTransport({
+        baseUrl: "https://openagents.com/v1",
+        token: null,
+        model: "openagents/khala-code",
+        prompt: CROSSY_ROAD_PROMPT,
+        fetchImpl: fakeFetch,
+      }),
+    ).rejects.toThrow("402");
+  });
+});


### PR DESCRIPTION
## What landed

`scripts/khala-demo/run-head-to-head.mjs` — the M8 **runner** that drives the head-to-head and feeds the existing M8 harness (reducer + publication renderer + fixtures).

It:
1. Sends the crossy-road prompt to two OpenAI-compatible lanes — `khala` (`openagents/khala-code` via `POST {base}/chat/completions`) and a `frontier_baseline` — reading the non-breaking `openagents` response block (`receipt`, `route`, `workers`, `verification`, `cost_msat`, `price_msat`, `settled`, plus optional settlement/Verse/in-world/energy fields).
2. Collects tokens / cost / wall-clock and the verification + receipt refs per side.
3. Emits a manifest in the **exact** `openagents.khala_head_to_head_evidence.v1` shape that `reduce-head-to-head.mjs` consumes.

Also: `scripts/khala-demo/run-head-to-head.test.mjs` (8 tests) and a Runner section in `docs/inference/khala-head-to-head-demo.md`.

Scope held to `scripts/khala-demo/` + the demo doc. The reducer, publication renderer, and gateway code are **consumed, not modified**.

## Stub vs live

- **Stub (now):** with no live base URLs (or `--stub`), a deterministic public-safe stub transport produces an `evidenceMode: fixture_scaffold` manifest. Verified end-to-end: stub → reducer → `canClose: false`, AO/kWh `not_measured`, 10 blockers.
- **Live (flip-ready):** set `KHALA_BASE_URL` / `KHALA_AGENT_TOKEN` and `FRONTIER_BASE_URL` / `FRONTIER_TOKEN` and drop `--stub`; both lanes present + non-stub ⇒ `evidenceMode: live`. `liveTransport` posts the OpenAI-compatible request with bearer auth (injectable `fetchImpl` for tests).

## Honesty contract (enforced in the runner)

No fabricated metrics. Unmeasured fields stay `0` / `none` / `false` / `null` with explicit blockers:
- `costUsd` is `0` (+ `cost_usd_not_measured`) unless the response carries `cost_usd`, or `cost_msat` plus a `--msat-per-usd` rate.
- Missing verdict ⇒ `verificationClass: none`, not accepted.
- Settlement only `settled: true` with explicit worker/validator receipt refs.
- Verse playback, in-world artifact, energy kWh stay `null` unless the response provides them; energy is never estimated.

Because the owner-gated gateway does not yet return settlement / Verse / in-world / energy evidence, even a current live run keeps `closureAudit.canClose: false`.

## Tests

`bun test scripts/khala-demo/*.test.mjs` → **15 pass / 0 fail** (8 new + 7 existing). The reducer still refuses to close on fixture/stub evidence.

## Blockers

- A real live run needs the inference gateway enabled (owner-gated). Until then the runner exercises the harness via the stub.

Part of #6016 / EPIC #6017.

**DO NOT auto-merge.**