### PR TITLE
Stream Khala head-to-head runner calls

### DIFF
--- a/scripts/khala-demo/run-head-to-head.mjs
+++ b/scripts/khala-demo/run-head-to-head.mjs
@@ -366,10 +366,87 @@ export function stubTransport({ lane, model }) {
   };
 }
 
+function parseSseFrames(text) {
+  const frames = [];
+  for (const rawFrame of text.split(/\r?\n\r?\n/)) {
+    const dataLines = rawFrame
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).replace(/^ /, ""));
+    if (dataLines.length === 0) {
+      continue;
+    }
+    const data = dataLines.join("\n");
+    if (data === "[DONE]") {
+      break;
+    }
+    try {
+      frames.push(JSON.parse(data));
+    } catch (error) {
+      throw new Error(`stream frame was not JSON: ${error?.message ?? error}`);
+    }
+  }
+  return frames;
+}
+
+export function completionFromSseText(text, fallbackModel) {
+  const frames = parseSseFrames(text);
+  if (frames.length === 0) {
+    throw new Error("stream ended without chat completion chunks");
+  }
+
+  let id = null;
+  let model = fallbackModel;
+  let finishReason = null;
+  let openagents = undefined;
+  let usage = undefined;
+  const contentParts = [];
+
+  for (const frame of frames) {
+    if (typeof frame.id === "string" && frame.id.length > 0) {
+      id = frame.id;
+    }
+    if (typeof frame.model === "string" && frame.model.length > 0) {
+      model = frame.model;
+    }
+    if (frame.openagents !== undefined) {
+      openagents = frame.openagents;
+    }
+    if (frame.usage !== undefined) {
+      usage = frame.usage;
+    }
+
+    const choice = Array.isArray(frame.choices) ? frame.choices[0] : undefined;
+    const delta = choice && typeof choice === "object" ? choice.delta : undefined;
+    if (delta && typeof delta.content === "string") {
+      contentParts.push(delta.content);
+    }
+    if (choice && typeof choice.finish_reason === "string") {
+      finishReason = choice.finish_reason;
+    }
+  }
+
+  return {
+    choices: [
+      {
+        finish_reason: finishReason ?? "stop",
+        index: 0,
+        message: { content: contentParts.join(""), role: "assistant" },
+      },
+    ],
+    id: id ?? "chatcmpl_stream",
+    model,
+    object: "chat.completion",
+    ...(usage === undefined ? {} : { usage }),
+    ...(openagents === undefined ? {} : { openagents }),
+  };
+}
+
 /**
- * Live transport: POST an OpenAI-compatible chat completion. Kept tiny on
- * purpose; the runner is "flip-ready" by swapping the stub for this once the
- * gateway is enabled and a base URL + token are provided.
+ * Live transport: POST an OpenAI-compatible streaming chat completion. The
+ * gateway emits OpenAI SSE chunks and attaches `openagents` only to the terminal
+ * frame, so the runner reconstructs a normal completion envelope before feeding
+ * the existing manifest builder.
  */
 export async function liveTransport({ baseUrl, token, model, prompt, fetchImpl = fetch }) {
   const url = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
@@ -384,14 +461,15 @@ export async function liveTransport({ baseUrl, token, model, prompt, fetchImpl =
       model,
       messages: [{ role: "user", content: prompt }],
       temperature: 0.2,
-      stream: false,
+      stream: true,
     }),
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => "");
     throw new Error(`lane request failed: ${res.status} ${res.statusText} ${detail.slice(0, 200)}`);
   }
-  return res.json();
+  const text = await res.text();
+  return completionFromSseText(text, model);
 }
 
 /**

--- a/scripts/khala-demo/run-head-to-head.test.mjs
+++ b/scripts/khala-demo/run-head-to-head.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { reduceKhalaHeadToHeadManifest } from "./reduce-head-to-head.mjs";
 import {
   buildRunFromCompletion,
+  completionFromSseText,
   CROSSY_ROAD_PROMPT,
   liveTransport,
   runHeadToHead,
@@ -184,19 +185,47 @@ describe("buildRunFromCompletion honesty", () => {
 });
 
 describe("liveTransport wiring", () => {
-  test("posts an OpenAI-compatible chat completion with bearer auth", async () => {
+  test("parses OpenAI SSE chunks into the completion envelope consumed by the runner", () => {
+    const completion = completionFromSseText(
+      [
+        'data: {"id":"chatcmpl_stream","model":"openagents/khala-code","choices":[{"index":0,"delta":{"content":"<!doctype html>"},"finish_reason":null}]}',
+        "",
+        'data: {"id":"chatcmpl_stream","model":"openagents/khala-code","choices":[{"index":0,"delta":{"content":"<!-- crossy road -->"},"finish_reason":null}]}',
+        "",
+        'data: {"id":"chatcmpl_stream","model":"openagents/khala-code","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"openagents":{"receipt":"receipt.live","verification":"test_passed","cost_msat":42},"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}',
+        "",
+        "data: [DONE]",
+        "",
+      ].join("\n"),
+      "openagents/khala-code",
+    );
+
+    expect(completion.choices[0].message.content).toBe(
+      "<!doctype html><!-- crossy road -->",
+    );
+    expect(completion.choices[0].finish_reason).toBe("stop");
+    expect(completion.openagents.receipt).toBe("receipt.live");
+    expect(completion.usage.total_tokens).toBe(30);
+  });
+
+  test("posts an OpenAI-compatible streaming chat completion with bearer auth", async () => {
     const calls = [];
     const fakeFetch = async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        async json() {
-          return { id: "x", choices: [], usage: { total_tokens: 1 }, openagents: {} };
-        },
-      };
+      return new Response(
+        [
+          'data: {"id":"x","model":"openagents/khala-code","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}',
+          "",
+          'data: {"id":"x","model":"openagents/khala-code","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"openagents":{"receipt":"receipt.live","verification":"test_passed"}}',
+          "",
+          "data: [DONE]",
+          "",
+        ].join("\n"),
+        { headers: { "content-type": "text/event-stream" } },
+      );
     };
 
-    await liveTransport({
+    const completion = await liveTransport({
       baseUrl: "https://openagents.com/v1/",
       token: "agent-token",
       model: "openagents/khala-code",
@@ -210,7 +239,9 @@ describe("liveTransport wiring", () => {
     const body = JSON.parse(calls[0].init.body);
     expect(body.model).toBe("openagents/khala-code");
     expect(body.messages[0].content).toBe(CROSSY_ROAD_PROMPT);
-    expect(body.stream).toBe(false);
+    expect(body.stream).toBe(true);
+    expect(completion.choices[0].message.content).toBe("hello");
+    expect(completion.openagents.receipt).toBe("receipt.live");
   });
 
   test("throws with a public-safe error on a non-ok response", async () => {


### PR DESCRIPTION
Refs #6027.

Problem: the M8 runner still used non-streaming chat completions for the long Crossy Road prompt, which is the path that can hit the edge timeout.

Changes:
- `liveTransport` now sends `stream:true` for live runner calls.
- OpenAI SSE frames are parsed back into the normal completion envelope consumed by the existing manifest builder.
- Terminal `openagents` evidence and usage are preserved when the stream provides them.
- Stub transport and reducer manifest shape are unchanged.

Validation:
- `bun test scripts/khala-demo/run-head-to-head.test.mjs scripts/khala-demo/reduce-head-to-head.test.mjs`
- `git diff --check`
- `bun scripts/khala-demo/run-head-to-head.mjs --stub --out /private/tmp/khala-h2h-runner-sse.json`
- `bun scripts/khala-demo/reduce-head-to-head.mjs /private/tmp/khala-h2h-runner-sse.json`

Intentionally not changed: Autopilot cockpit streaming and gateway route contract changes remain out of scope for this narrow runner slice.