### PR TITLE
Khala: stream interactive completions (M8 runner + cockpit) — kill the 524

### DIFF
--- a/apps/autopilot-desktop/src/bun/index.ts
+++ b/apps/autopilot-desktop/src/bun/index.ts
@@ -1050,6 +1050,14 @@ const rpc = BrowserView.defineRPC<DesktopRPCSchema>({
       // `openagents` receipt projection. Reuses the same host-side agent token
       // resolution as shellTurn; the raw token never crosses to the webview.
       async khalaTurn(params) {
+        // M8 streaming (#6027): the turn STREAMS by default. The Bun host
+        // consumes the SSE stream server-side (each chunk resets the edge idle
+        // timer — the 524 fix); when the webview supplied a turnId, push each
+        // content delta back so the cockpit renders tokens live. The final
+        // reconstructed answer + the terminal `openagents` receipt block ride on
+        // this RPC response (attached on stream close). Token text only crosses
+        // the push; the raw agent token never does.
+        const turnId = params.turnId
         return buildKhalaTurn({
           prompt: params.prompt,
           ...(params.model === undefined ? {} : { model: params.model }),
@@ -1060,6 +1068,13 @@ const rpc = BrowserView.defineRPC<DesktopRPCSchema>({
               ? null
               : (loadPersistedCredential(home)?.token ?? null)
           }),
+          ...(turnId === undefined
+            ? {}
+            : {
+                onToken: (delta: string) => {
+                  rpc.send.khalaToken({ turnId, delta })
+                },
+              }),
         })
       },
       async installReadiness() {

--- a/apps/autopilot-desktop/src/bun/khala-turn.ts
+++ b/apps/autopilot-desktop/src/bun/khala-turn.ts
@@ -21,15 +21,29 @@
 // NOT OWNER-DEPENDENT: works against a local/stub or staging gateway via the
 // base-url env override. The prod gateway is inert/owner-gated; this path does
 // not depend on it — the live badge is gated on a real receipt, not on prod.
+//
+// STREAMING IS THE DEFAULT (the 524 fix). The cockpit submits `stream:true` and
+// consumes the SSE stream INCREMENTALLY: each chunk resets the Cloudflare edge
+// idle timer, so a multi-minute generation (the crossy-road north-star prompt)
+// never trips the ~100s edge timeout and returns 524. A blocking `stream:false`
+// request buffered the whole completion server-side and was the root cause of
+// the 524 (see
+// docs/inference/2026-06-22-long-running-inference-response-strategies.md).
+// `onToken` lets the cockpit render tokens live; the terminal `openagents`
+// receipt block rides on the FINAL chunk and is attached on stream close. The
+// path still consumes a non-streaming JSON body for a server/route that does not
+// stream, so it degrades gracefully.
 
 import {
   inferenceGatewayChatCompletionsUrl,
   resolveInferenceGatewaySettings,
 } from "../shared/inference-gateway.js"
 import {
+  isEventStreamResponse,
   isKhalaCockpitModelId,
   isLiveReceipt,
   parseKhalaReceipt,
+  reconstructKhalaCompletionFromSse,
   type KhalaCockpitModelId,
   type KhalaTurnResult,
   KHALA_MINI_MODEL_ID,
@@ -56,6 +70,13 @@ export type BuildKhalaTurnInput = Readonly<{
   // The OpenAgents agent token (kept in the Bun host); never crosses to webview.
   agentToken: string | null
   fetchFn?: typeof fetch
+  // INTERACTIVE STREAMING DEFAULT (the 524 fix). When true (default), submit
+  // `stream:true` and consume the SSE stream incrementally. Set false only for
+  // explicit blocking comparison/debug.
+  stream?: boolean
+  // Optional live-render hook, fired per content delta as the stream arrives.
+  // Public-safe (token text only); never carries credentials or the receipt.
+  onToken?: (delta: string) => void
 }>
 
 // Pull the assistant text out of an OpenAI-compatible chat-completions body.
@@ -90,6 +111,57 @@ const errorResult = (text: string): KhalaTurnResult => ({
   live: false,
 })
 
+// Read an SSE response body incrementally and reconstruct the completion. The
+// incremental `reader.read()` loop is what resets the edge idle timer per chunk
+// (the 524 fix); `onToken` fires live as deltas arrive. Falls back to
+// `res.text()` for fetch impls without a readable body (e.g. test fakes).
+const consumeSseBody = async (
+  res: Response,
+  onToken?: (delta: string) => void,
+): Promise<unknown> => {
+  const body = res.body
+  if (body && typeof body.getReader === "function") {
+    const reader = body.getReader()
+    const decoder = new TextDecoder()
+    let rawText = ""
+    let pending = ""
+    for (;;) {
+      const { value, done } = await reader.read()
+      if (done) break
+      const piece = decoder.decode(value, { stream: true })
+      rawText += piece
+      if (onToken !== undefined) {
+        // Emit deltas as soon as a complete frame arrives.
+        pending += piece
+        const frames = pending.split("\n\n")
+        pending = frames.pop() ?? ""
+        for (const frame of frames) {
+          for (const line of frame.split("\n")) {
+            if (!line.startsWith("data:")) continue
+            const payload = line.slice(line.indexOf(":") + 1).trim()
+            if (payload === "" || payload === "[DONE]") continue
+            try {
+              const parsed = JSON.parse(payload) as {
+                choices?: Array<{ delta?: { content?: unknown } }>
+              }
+              const delta = parsed.choices?.[0]?.delta?.content
+              if (typeof delta === "string" && delta.length > 0) onToken(delta)
+            } catch {
+              // ignore partial / non-JSON frames
+            }
+          }
+        }
+      }
+    }
+    // Authoritative reconstruction from the full text (no double onToken — we
+    // already streamed above when a reader was available).
+    return reconstructKhalaCompletionFromSse(rawText)
+  }
+  // No reader: read the whole text and reconstruct (onToken fires once here).
+  const rawText = await res.text()
+  return reconstructKhalaCompletionFromSse(rawText, onToken)
+}
+
 export const buildKhalaTurn = async (
   input: BuildKhalaTurnInput,
 ): Promise<KhalaTurnResult> => {
@@ -114,17 +186,20 @@ export const buildKhalaTurn = async (
     return errorResult(NO_TOKEN_MESSAGE)
   }
 
+  // Streaming is the interactive default; `stream:false` only on explicit opt-out.
+  const useStream = input.stream !== false
+
   try {
     const res = await fetchFn(url, {
       method: "POST",
       headers: {
-        accept: "application/json",
+        accept: useStream ? "text/event-stream" : "application/json",
         authorization: `Bearer ${token}`,
         "content-type": "application/json",
       },
       body: JSON.stringify({
         model,
-        stream: false,
+        stream: useStream,
         messages: [
           { role: "system", content: KHALA_COCKPIT_SYSTEM_PROMPT },
           { role: "user", content: prompt },
@@ -132,11 +207,25 @@ export const buildKhalaTurn = async (
       }),
     })
 
+    // Consume the response body. When the gateway streams SSE, read it
+    // INCREMENTALLY so every chunk resets the edge idle timer (the 524 fix),
+    // firing onToken live, then reconstruct the full completion + the terminal
+    // `openagents` receipt block. Otherwise parse the non-streaming JSON body.
+    // Error responses (non-2xx) are JSON, so parse those as JSON regardless.
     let body: unknown = null
-    try {
-      body = await res.json()
-    } catch {
-      body = null
+    const contentType =
+      typeof res.headers?.get === "function"
+        ? res.headers.get("content-type")
+        : null
+    const streamed = res.ok && useStream && isEventStreamResponse(contentType)
+    if (streamed) {
+      body = await consumeSseBody(res, input.onToken)
+    } else {
+      try {
+        body = await res.json()
+      } catch {
+        body = null
+      }
     }
 
     if (!res.ok) {

--- a/apps/autopilot-desktop/src/shared/khala-cockpit.ts
+++ b/apps/autopilot-desktop/src/shared/khala-cockpit.ts
@@ -151,6 +151,93 @@ export const isLiveReceipt = (
   receipt: KhalaReceiptProjection | null,
 ): boolean => receipt !== null && receipt.receipt !== null
 
+// The non-streaming body shape both the streaming and non-streaming paths
+// produce, so `parseAssistantText` / `parseKhalaReceipt` consume one shape.
+export type ReconstructedCompletion = Readonly<{
+  choices: ReadonlyArray<{
+    readonly index: number
+    readonly finish_reason: string
+    readonly message: { readonly role: "assistant"; readonly content: string }
+  }>
+  usage?: unknown
+  // The terminal `openagents` receipt/verification block (the gateway emits it
+  // on the FINAL stream chunk, after verification runs on the full output).
+  openagents?: unknown
+}>
+
+// Pull the content delta off one parsed `chat.completion.chunk` frame.
+const sseChunkDelta = (parsed: unknown): string | null => {
+  if (typeof parsed !== "object" || parsed === null) return null
+  const choices = (parsed as { choices?: unknown }).choices
+  if (!Array.isArray(choices) || choices.length === 0) return null
+  const delta = (choices[0] as { delta?: { content?: unknown } } | undefined)
+    ?.delta?.content
+  return typeof delta === "string" && delta.length > 0 ? delta : null
+}
+
+// Reconstruct a non-streaming completion body from the gateway's SSE chunk
+// stream. Each frame is a `data: {...,object:"chat.completion.chunk"}` line; the
+// terminal `openagents` block rides on the FINAL chunk before `data: [DONE]`.
+// This is the cockpit-side mirror of the gateway's SSE framing — CONSUME-ONLY.
+// `onToken` is an optional live-render hook (fired per content delta).
+export const reconstructKhalaCompletionFromSse = (
+  rawText: string,
+  onToken?: (delta: string) => void,
+): ReconstructedCompletion => {
+  let content = ""
+  let finishReason = "stop"
+  let usage: unknown
+  let openagents: unknown
+  for (const frame of rawText.split("\n\n")) {
+    for (const line of frame.split("\n")) {
+      if (!line.startsWith("data:")) continue
+      const payload = line.slice(line.indexOf(":") + 1).trim()
+      if (payload === "" || payload === "[DONE]") continue
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(payload)
+      } catch {
+        continue
+      }
+      const delta = sseChunkDelta(parsed)
+      if (delta !== null) {
+        content += delta
+        onToken?.(delta)
+      }
+      const record = parsed as {
+        choices?: Array<{ finish_reason?: unknown }>
+        usage?: unknown
+        openagents?: unknown
+      }
+      const fr = record.choices?.[0]?.finish_reason
+      if (typeof fr === "string") finishReason = fr
+      if (record.usage !== undefined && record.usage !== null) {
+        usage = record.usage
+      }
+      if (record.openagents !== undefined && record.openagents !== null) {
+        openagents = record.openagents
+      }
+    }
+  }
+  return {
+    choices: [
+      {
+        index: 0,
+        finish_reason: finishReason,
+        message: { role: "assistant", content },
+      },
+    ],
+    ...(usage === undefined ? {} : { usage }),
+    ...(openagents === undefined ? {} : { openagents }),
+  }
+}
+
+// Heuristic: does this response carry an SSE event-stream body? The gateway sets
+// `content-type: text/event-stream` for `stream:true`. Tolerant of charset
+// suffixes; falls back to false (treat as JSON) when the header is absent.
+export const isEventStreamResponse = (contentType: string | null): boolean =>
+  contentType !== null && contentType.toLowerCase().includes("text/event-stream")
+
 // A short, public-safe one-line summary of the receipt for the cockpit HUD.
 // Jargon-free where possible; carries only disclosed fields.
 export const summarizeKhalaReceipt = (

--- a/apps/autopilot-desktop/src/shared/rpc.ts
+++ b/apps/autopilot-desktop/src/shared/rpc.ts
@@ -1017,6 +1017,10 @@ export type DesktopRPCSchema = {
         readonly params: {
           readonly prompt: string
           readonly model?: "openagents/khala-mini" | "openagents/khala-code"
+          // M8 streaming (#6027): correlates this turn to its live token push
+          // (`webview.messages.khalaToken`). Omitted by callers that do not want
+          // live tokens; the Bun host then streams server-side without pushing.
+          readonly turnId?: string
         }
         readonly response: KhalaTurnResponse
       }
@@ -1265,6 +1269,18 @@ export type DesktopRPCSchema = {
       readonly shellControl: {
         readonly action: "set-input" | "submit"
         readonly value?: string
+      }
+      // M8 streaming (#6027, EPIC #6017): Bun→webview live token push for a Khala
+      // cockpit turn. The `khalaTurn` RPC submits `stream:true` and consumes the
+      // SSE stream server-side (each chunk resets the Cloudflare edge idle timer —
+      // the 524 fix), pushing each content delta here so the cockpit renders
+      // tokens live. The terminal `openagents` receipt block is NOT pushed here;
+      // it rides on the `khalaTurn` RPC response, attached on stream close.
+      // `turnId` correlates a delta stream to its turn so concurrent/!stale turns
+      // don't cross-render. Public-safe: token text only, no token/credentials.
+      readonly khalaToken: {
+        readonly turnId: string
+        readonly delta: string
       }
     }
   }

--- a/apps/autopilot-desktop/tests/khala-cockpit.test.ts
+++ b/apps/autopilot-desktop/tests/khala-cockpit.test.ts
@@ -2,14 +2,58 @@ import { describe, expect, test } from "bun:test"
 
 import { buildKhalaTurn } from "../src/bun/khala-turn"
 import {
+  isEventStreamResponse,
   isKhalaCockpitModelId,
   isLiveReceipt,
   parseKhalaReceipt,
+  reconstructKhalaCompletionFromSse,
   summarizeKhalaReceipt,
   KHALA_CODE_MODEL_ID,
   KHALA_COCKPIT_MODEL_IDS,
   KHALA_MINI_MODEL_ID,
 } from "../src/shared/khala-cockpit"
+
+// Build the SSE wire bytes the gateway emits for a streamed completion: a series
+// of `chat.completion.chunk` frames, the terminal `openagents` block on the
+// FINAL chunk, then `data: [DONE]`.
+function buildKhalaSseWire(
+  deltas: string[],
+  opts: { openagents?: unknown; usage?: unknown; finishReason?: string } = {},
+): string {
+  const { openagents, usage, finishReason = "stop" } = opts
+  const frames = deltas.map((delta, index) => {
+    const last = index === deltas.length - 1
+    return `data: ${JSON.stringify({
+      id: "chatcmpl_stream_x",
+      model: "openagents/khala-code",
+      object: "chat.completion.chunk",
+      choices: [
+        {
+          index: 0,
+          delta: delta === "" ? {} : { content: delta },
+          finish_reason: last ? finishReason : null,
+        },
+      ],
+      ...(last && usage !== undefined ? { usage } : {}),
+      ...(last && openagents !== undefined ? { openagents } : {}),
+    })}\n\n`
+  })
+  return `${frames.join("")}data: [DONE]\n\n`
+}
+
+// A Response-like object backed by a real ReadableStream so the incremental
+// reader path in consumeSseBody runs.
+function sseResponse(wire: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(wire))
+      controller.close()
+    },
+  })
+  return new Response(stream, {
+    headers: { "content-type": "text/event-stream; charset=utf-8" },
+  })
+}
 
 // M1 (#6009, EPIC #6017) — Lane A Cockpit. The crossy-road smoke prompt the
 // roadmap names as the north-star task.
@@ -255,5 +299,120 @@ describe("buildKhalaTurn — cockpit call path (stub gateway)", () => {
     expect(r.ok).toBe(false)
     expect(r.live).toBe(false)
     expect(r.text).toContain("credit")
+  })
+
+  test("STREAMS by default: sends stream:true and reconstructs from SSE", async () => {
+    let sentBody: { stream?: boolean; model?: string } = {}
+    const wire = buildKhalaSseWire(["<!doctype ", "html>", "<!-- crossy -->"], {
+      usage: { prompt_tokens: 10, completion_tokens: 200, total_tokens: 210 },
+      openagents: {
+        requested_model: "openagents/khala-code",
+        served_model: "fireworks-coder",
+        worker: "fireworks",
+        lane: "coding",
+        verification: "test_passed",
+        verified: true,
+        receipt: "oa_receipt_stream_live",
+        receipt_url: "/api/public/inference/receipts/oa_receipt_stream_live",
+      },
+    })
+    const fetchFn = ((_url: string, init?: RequestInit) => {
+      sentBody = init?.body ? JSON.parse(init.body as string) : {}
+      return Promise.resolve(sseResponse(wire))
+    }) as unknown as typeof fetch
+
+    const tokens: string[] = []
+    const r = await buildKhalaTurn({
+      prompt: CROSSY_ROAD_PROMPT,
+      model: KHALA_CODE_MODEL_ID,
+      env,
+      agentToken: "agent-token",
+      fetchFn,
+      onToken: (t) => tokens.push(t),
+    })
+
+    // Default is streaming.
+    expect(sentBody.stream).toBe(true)
+    expect(r.ok).toBe(true)
+    expect(r.text).toBe("<!doctype html><!-- crossy -->")
+    // Tokens streamed live during consumption.
+    expect(tokens.join("")).toBe("<!doctype html><!-- crossy -->")
+    // Terminal openagents receipt attached on stream close => LIVE.
+    expect(r.receipt?.servedModel).toBe("fireworks-coder")
+    expect(r.receipt?.verification).toBe("test_passed")
+    expect(r.receipt?.receipt).toBe("oa_receipt_stream_live")
+    expect(r.live).toBe(true)
+  })
+
+  test("streamed completion with NO receipt: real answer but NOT live", async () => {
+    const wire = buildKhalaSseWire(["plain ", "answer"])
+    const fetchFn = (() =>
+      Promise.resolve(sseResponse(wire))) as unknown as typeof fetch
+    const r = await buildKhalaTurn({
+      prompt: "hello",
+      env,
+      agentToken: "agent-token",
+      fetchFn,
+    })
+    expect(r.ok).toBe(true)
+    expect(r.text).toBe("plain answer")
+    expect(r.receipt).toBeNull()
+    expect(r.live).toBe(false)
+  })
+
+  test("stream:false opt-out still parses the blocking JSON body", async () => {
+    let sentStream: boolean | undefined
+    const fetchFn = ((_url: string, init?: RequestInit) => {
+      sentStream = init?.body
+        ? (JSON.parse(init.body as string) as { stream?: boolean }).stream
+        : undefined
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ choices: [{ message: { content: "blocking" } }] }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      )
+    }) as unknown as typeof fetch
+    const r = await buildKhalaTurn({
+      prompt: "hi",
+      env,
+      agentToken: "t",
+      fetchFn,
+      stream: false,
+    })
+    expect(sentStream).toBe(false)
+    expect(r.ok).toBe(true)
+    expect(r.text).toBe("blocking")
+  })
+})
+
+describe("reconstructKhalaCompletionFromSse + isEventStreamResponse", () => {
+  test("concatenates deltas, keeps terminal openagents + usage", () => {
+    const wire = buildKhalaSseWire(["a", "b", "c"], {
+      usage: { total_tokens: 3 },
+      openagents: { requested_model: "openagents/khala-code", receipt: "r1" },
+    })
+    const body = reconstructKhalaCompletionFromSse(wire)
+    expect(body.choices[0].message.content).toBe("abc")
+    expect(body.choices[0].finish_reason).toBe("stop")
+    expect((body.usage as { total_tokens: number }).total_tokens).toBe(3)
+    expect((body.openagents as { receipt: string }).receipt).toBe("r1")
+
+    // The reconstructed body parses through the same receipt parser.
+    const receipt = parseKhalaReceipt(body)
+    expect(receipt?.receipt).toBe("r1")
+  })
+
+  test("fires onToken per delta", () => {
+    const wire = buildKhalaSseWire(["x", "y"])
+    const tokens: string[] = []
+    reconstructKhalaCompletionFromSse(wire, (t) => tokens.push(t))
+    expect(tokens).toEqual(["x", "y"])
+  })
+
+  test("isEventStreamResponse detects the SSE content-type", () => {
+    expect(isEventStreamResponse("text/event-stream; charset=utf-8")).toBe(true)
+    expect(isEventStreamResponse("application/json")).toBe(false)
+    expect(isEventStreamResponse(null)).toBe(false)
   })
 })

--- a/scripts/khala-demo/run-head-to-head.mjs
+++ b/scripts/khala-demo/run-head-to-head.mjs
@@ -34,11 +34,19 @@
  *   --frontier-token <token>    FRONTIER_TOKEN      bearer token for the baseline lane
  *   --frontier-model <id>       FRONTIER_MODEL      default frontier-baseline
  *   --stub                      KHALA_RUNNER_STUB=1 force the built-in deterministic stub transport
+ *   --no-stream                 KHALA_RUNNER_NO_STREAM=1 use the legacy blocking (stream:false) transport
  *   --out <path>                write the manifest JSON to a file instead of stdout
  *
  * If no live base URL is supplied (or --stub is passed), the runner uses a
  * deterministic, public-safe stub transport so the harness is exercised end to
  * end without the owner-gated live gateway.
+ *
+ * STREAMING DEFAULT: a live run streams SSE (`stream:true`) by default and
+ * reconstructs the full completion + the terminal `openagents` receipt block on
+ * stream close. This is the 524 fix — a long generation buffered synchronously
+ * trips the Cloudflare edge timeout; consuming the stream resets the idle timer
+ * on every chunk. See
+ * docs/inference/2026-06-22-long-running-inference-response-strategies.md.
  */
 
 import { writeFileSync } from "node:fs";
@@ -367,9 +375,14 @@ export function stubTransport({ lane, model }) {
 }
 
 /**
- * Live transport: POST an OpenAI-compatible chat completion. Kept tiny on
- * purpose; the runner is "flip-ready" by swapping the stub for this once the
- * gateway is enabled and a base URL + token are provided.
+ * Live transport: POST a NON-streaming OpenAI-compatible chat completion.
+ *
+ * Retained for callers that explicitly want the blocking shape, but it is NO
+ * LONGER the default for interactive runs: a long generation (the crossy-road
+ * north-star prompt) buffered synchronously trips the Cloudflare ~100s edge
+ * timeout and returns 524 (see
+ * docs/inference/2026-06-22-long-running-inference-response-strategies.md).
+ * `liveStreamTransport` is the interactive default.
  */
 export async function liveTransport({ baseUrl, token, model, prompt, fetchImpl = fetch }) {
   const url = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
@@ -392,6 +405,158 @@ export async function liveTransport({ baseUrl, token, model, prompt, fetchImpl =
     throw new Error(`lane request failed: ${res.status} ${res.statusText} ${detail.slice(0, 200)}`);
   }
   return res.json();
+}
+
+/**
+ * Reconstruct a non-streaming-shaped chat completion from the SSE chunk stream
+ * the gateway emits for `stream:true`. Each frame is a
+ * `data: {choices:[{delta:{content},finish_reason,index}],...,object:"chat.completion.chunk"}`
+ * line; the terminal `openagents` receipt block rides on the FINAL chunk (the
+ * gateway emits it only after verification runs on the full output), followed by
+ * `data: [DONE]`. We concatenate the content deltas, keep the last seen
+ * finish_reason / usage / openagents block, and return a body shaped EXACTLY
+ * like the non-streaming response so `buildRunFromCompletion` is unchanged.
+ *
+ * Crucially, this consumes the stream INCREMENTALLY (`reader.read()` loop), so
+ * every chunk resets the edge idle timer and a multi-minute generation never
+ * trips the 524. `onToken` is an optional live-render hook (the manifest runner
+ * ignores tokens; the cockpit renders them).
+ */
+export function reconstructCompletionFromSse(rawText, { onToken } = {}) {
+  let content = "";
+  let finishReason = "stop";
+  let usage;
+  let openagents;
+  let id;
+  let model;
+  const frames = rawText.split("\n\n");
+  for (const frame of frames) {
+    for (const line of frame.split("\n")) {
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(line.indexOf(":") + 1).trim();
+      if (payload === "" || payload === "[DONE]") continue;
+      let parsed;
+      try {
+        parsed = JSON.parse(payload);
+      } catch {
+        continue;
+      }
+      if (typeof parsed.id === "string") id = parsed.id;
+      if (typeof parsed.model === "string") model = parsed.model;
+      const choice = Array.isArray(parsed.choices) ? parsed.choices[0] : undefined;
+      const delta = choice?.delta?.content;
+      if (typeof delta === "string" && delta.length > 0) {
+        content += delta;
+        if (typeof onToken === "function") onToken(delta);
+      }
+      if (typeof choice?.finish_reason === "string") {
+        finishReason = choice.finish_reason;
+      }
+      if (parsed.usage && typeof parsed.usage === "object") usage = parsed.usage;
+      // The terminal openagents receipt/verification block rides on the final
+      // chunk; capture it so the reconstructed completion is verifiable.
+      if (parsed.openagents && typeof parsed.openagents === "object") {
+        openagents = parsed.openagents;
+      }
+    }
+  }
+  return {
+    id,
+    model,
+    choices: [
+      {
+        index: 0,
+        finish_reason: finishReason,
+        message: { role: "assistant", content },
+      },
+    ],
+    ...(usage === undefined ? {} : { usage }),
+    ...(openagents === undefined ? {} : { openagents }),
+  };
+}
+
+/**
+ * Streaming live transport (the INTERACTIVE DEFAULT). POSTs `stream:true`,
+ * consumes the SSE stream incrementally so the edge idle timer is reset by every
+ * chunk (this is the 524 fix), reconstructs the full completion, and attaches the
+ * terminal `openagents` receipt/verification block emitted on stream close.
+ *
+ * Returns the SAME body shape as `liveTransport`, so `buildRunFromCompletion`
+ * needs no changes and unmeasured fields stay honest.
+ */
+export async function liveStreamTransport({
+  baseUrl,
+  token,
+  model,
+  prompt,
+  fetchImpl = fetch,
+  onToken,
+}) {
+  const url = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
+  const headers = { "content-type": "application/json", accept: "text/event-stream" };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0.2,
+      stream: true,
+    }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`lane request failed: ${res.status} ${res.statusText} ${detail.slice(0, 200)}`);
+  }
+
+  // Consume the body incrementally. Prefer the byte stream so each chunk resets
+  // the edge idle timer; fall back to res.text() for fetch impls without a
+  // readable body (e.g. test fakes).
+  let rawText = "";
+  const body = res.body;
+  if (body && typeof body.getReader === "function") {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    // Parse incrementally so onToken fires live; we re-parse the full text at the
+    // end for the authoritative reconstruction (terminal openagents block).
+    let pending = "";
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const piece = decoder.decode(value, { stream: true });
+      rawText += piece;
+      if (typeof onToken === "function") {
+        pending += piece;
+        const frames = pending.split("\n\n");
+        pending = frames.pop() ?? "";
+        for (const frame of frames) {
+          for (const line of frame.split("\n")) {
+            if (!line.startsWith("data:")) continue;
+            const payload = line.slice(line.indexOf(":") + 1).trim();
+            if (payload === "" || payload === "[DONE]") continue;
+            try {
+              const parsed = JSON.parse(payload);
+              const delta = Array.isArray(parsed.choices)
+                ? parsed.choices[0]?.delta?.content
+                : undefined;
+              if (typeof delta === "string" && delta.length > 0) onToken(delta);
+            } catch {
+              // ignore partial / non-JSON frames
+            }
+          }
+        }
+      }
+    }
+  } else {
+    rawText = await res.text();
+  }
+
+  // Authoritative reconstruction from the full stream text (no double onToken:
+  // we already streamed above when a reader was used).
+  return reconstructCompletionFromSse(rawText, {});
 }
 
 /**
@@ -550,9 +715,17 @@ async function main() {
   // Live only when the stub is not forced AND both lanes have a real base URL.
   const live = !forceStub && Boolean(khalaBaseUrl) && Boolean(frontierBaseUrl);
 
+  // STREAMING IS THE INTERACTIVE DEFAULT (the 524 fix). The long crossy-road
+  // generation buffered synchronously (`stream:false`) trips the Cloudflare edge
+  // timeout and returns 524; consuming the SSE stream resets the idle timer on
+  // every chunk so a multi-minute generation completes. `--no-stream` forces the
+  // legacy blocking transport for explicit comparison/debug only.
+  const useStream = !(args["no-stream"] === true || env.KHALA_RUNNER_NO_STREAM === "1");
+  const liveLaneTransport = useStream ? liveStreamTransport : liveTransport;
+
   const khalaTransport = live
     ? () =>
-        liveTransport({
+        liveLaneTransport({
           baseUrl: khalaBaseUrl,
           token: khalaToken,
           model: khalaModel,
@@ -561,7 +734,7 @@ async function main() {
     : stubTransport;
   const frontierTransport = live
     ? () =>
-        liveTransport({
+        liveLaneTransport({
           baseUrl: frontierBaseUrl,
           token: frontierToken,
           model: frontierModel,

--- a/scripts/khala-demo/run-head-to-head.test.mjs
+++ b/scripts/khala-demo/run-head-to-head.test.mjs
@@ -4,7 +4,9 @@ import { reduceKhalaHeadToHeadManifest } from "./reduce-head-to-head.mjs";
 import {
   buildRunFromCompletion,
   CROSSY_ROAD_PROMPT,
+  liveStreamTransport,
   liveTransport,
+  reconstructCompletionFromSse,
   runHeadToHead,
   stubTransport,
 } from "./run-head-to-head.mjs";
@@ -231,5 +233,161 @@ describe("liveTransport wiring", () => {
         fetchImpl: fakeFetch,
       }),
     ).rejects.toThrow("402");
+  });
+});
+
+// Build the SSE wire bytes the gateway emits for a streamed completion: a series
+// of `chat.completion.chunk` frames, the terminal `openagents` block on the FINAL
+// chunk, then `data: [DONE]`.
+function buildKhalaSseWire(deltas, { openagents, usage, finishReason = "stop" } = {}) {
+  const frames = [];
+  deltas.forEach((delta, index) => {
+    const last = index === deltas.length - 1;
+    frames.push(
+      `data: ${JSON.stringify({
+        id: "chatcmpl_stream_x",
+        model: "openagents/khala-code",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            index: 0,
+            delta: delta === "" ? {} : { content: delta },
+            finish_reason: last ? finishReason : null,
+          },
+        ],
+        ...(last && usage !== undefined ? { usage } : {}),
+        ...(last && openagents !== undefined ? { openagents } : {}),
+      })}\n\n`,
+    );
+  });
+  return `${frames.join("")}data: [DONE]\n\n`;
+}
+
+describe("reconstructCompletionFromSse", () => {
+  test("concatenates content deltas and attaches the terminal openagents block", () => {
+    const wire = buildKhalaSseWire(["<!doctype ", "html>", "<!-- crossy -->"], {
+      usage: { prompt_tokens: 10, completion_tokens: 200, total_tokens: 210 },
+      openagents: {
+        requested_model: "openagents/khala-code",
+        served_model: "fireworks-coder",
+        worker: "fireworks",
+        lane: "coding",
+        verification: "test_passed",
+        verified: true,
+        receipt: "oa_receipt_stream_1",
+      },
+    });
+    const body = reconstructCompletionFromSse(wire);
+    expect(body.choices[0].message.content).toBe(
+      "<!doctype html><!-- crossy -->",
+    );
+    expect(body.choices[0].finish_reason).toBe("stop");
+    expect(body.usage.total_tokens).toBe(210);
+    expect(body.openagents.receipt).toBe("oa_receipt_stream_1");
+    expect(body.openagents.verification).toBe("test_passed");
+
+    // It feeds buildRunFromCompletion exactly like the non-streaming shape.
+    const run = buildRunFromCompletion({
+      lane: "khala",
+      label: "stream",
+      model: "openagents/khala-code",
+      provider: "openagents",
+      response: body,
+      startedAt: "2026-06-22T16:00:00.000Z",
+      completedAt: "2026-06-22T16:03:00.000Z",
+      wallClockMs: 180000,
+      live: true,
+    });
+    expect(run.usage.totalTokens).toBe(210);
+    expect(run.acceptedOutcome.verificationClass).toBe("test_passed");
+    expect(run.acceptedOutcome.receiptRef).toBe("oa_receipt_stream_1");
+  });
+
+  test("fires onToken per content delta", () => {
+    const wire = buildKhalaSseWire(["a", "b", "c"]);
+    const tokens = [];
+    reconstructCompletionFromSse(wire, { onToken: (t) => tokens.push(t) });
+    expect(tokens).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("liveStreamTransport (the interactive default — 524 fix)", () => {
+  test("posts stream:true and reconstructs the completion from a byte-stream body", async () => {
+    const wire = buildKhalaSseWire(["full ", "answer"], {
+      openagents: {
+        requested_model: "openagents/khala-code",
+        served_model: "fireworks-coder",
+        worker: "fireworks",
+        lane: "coding",
+        verification: "test_passed",
+        receipt: "oa_receipt_live_stream",
+      },
+    });
+    let sentBody = null;
+    const fakeFetch = async (_url, init) => {
+      sentBody = JSON.parse(init.body);
+      // A real ReadableStream body so the incremental reader path runs.
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(wire));
+          controller.close();
+        },
+      });
+      return { ok: true, body: stream, async text() { return wire; } };
+    };
+
+    const tokens = [];
+    const body = await liveStreamTransport({
+      baseUrl: "https://openagents.com/v1",
+      token: "agent-token",
+      model: "openagents/khala-code",
+      prompt: CROSSY_ROAD_PROMPT,
+      fetchImpl: fakeFetch,
+      onToken: (t) => tokens.push(t),
+    });
+
+    expect(sentBody.stream).toBe(true);
+    expect(body.choices[0].message.content).toBe("full answer");
+    expect(body.openagents.receipt).toBe("oa_receipt_live_stream");
+    // Tokens streamed live during consumption.
+    expect(tokens.join("")).toBe("full answer");
+  });
+
+  test("falls back to res.text() when the body has no reader", async () => {
+    const wire = buildKhalaSseWire(["x", "y"]);
+    const fakeFetch = async () => ({
+      ok: true,
+      async text() {
+        return wire;
+      },
+    });
+    const body = await liveStreamTransport({
+      baseUrl: "https://openagents.com/v1",
+      token: null,
+      model: "openagents/khala-code",
+      prompt: CROSSY_ROAD_PROMPT,
+      fetchImpl: fakeFetch,
+    });
+    expect(body.choices[0].message.content).toBe("xy");
+  });
+
+  test("throws a public-safe error on a non-ok response", async () => {
+    const fakeFetch = async () => ({
+      ok: false,
+      status: 524,
+      statusText: "A Timeout Occurred",
+      async text() {
+        return "cloudflare 524";
+      },
+    });
+    await expect(
+      liveStreamTransport({
+        baseUrl: "https://openagents.com/v1",
+        token: null,
+        model: "openagents/khala-code",
+        prompt: CROSSY_ROAD_PROMPT,
+        fetchImpl: fakeFetch,
+      }),
+    ).rejects.toThrow("524");
   });
 });


### PR DESCRIPTION
## What landed

Streaming SSE is now the **default for interactive khala calls** — the 524 fix per `docs/inference/2026-06-22-long-running-inference-response-strategies.md` Strategy 1.

- **M8 runner** (`scripts/khala-demo/run-head-to-head.mjs`): new `liveStreamTransport` (the interactive default) POSTs `stream:true`, consumes the SSE body incrementally via `reader.read()` so every chunk resets the edge idle timer, and `reconstructCompletionFromSse` rebuilds the full completion + attaches the terminal `openagents` receipt/verification block from the final chunk. `--no-stream` / `KHALA_RUNNER_NO_STREAM=1` is a blocking opt-out. **Manifest output shape is unchanged** (still feeds `reduce-head-to-head.mjs`); unmeasured fields stay `not_measured`; the stub/fixture still keeps `canClose:false`.
- **Cockpit** (`apps/autopilot-desktop`): `khala-turn.ts` submits `stream:true` by default, consumes SSE incrementally (dual SSE/JSON consumer — degrades to a blocking JSON body for a non-streaming route), fires an optional `onToken` live-render hook, and attaches the receipt block on stream close. New pure consume-only helpers `reconstructKhalaCompletionFromSse` + `isEventStreamResponse` in `shared/khala-cockpit.ts`. A `turnId`-correlated `khalaToken` Bun→webview push (`shared/rpc.ts` + `bun/index.ts`) streams live deltas to the cockpit; the terminal receipt rides on the RPC response, not the push.
- The gateway route (`chat-completions-routes.ts`) was **not changed** — consumed as-is.

## Live streaming acceptance (prod, `https://openagents.com`)

Run against prod with the artanis agent token. **Honest result: the SSE client path works, but `khala-code` streaming is blocked by a gateway-side Fireworks-adapter bug — the 524 is NOT yet cleared for `khala-code`.**

| case | result |
|---|---|
| `khala-mini` **stream:true**, short + haiku prompts | ✅ 200 `text/event-stream`; `liveStreamTransport` consumed real `data:` chunks and reconstructed content. Client streaming proven end-to-end. (no `openagents` receipt — khala-mini is the `verification:none` cheap lane) |
| `khala-code` **stream:false**, north-star crossy-road prompt | ❌ **502 `{"error":"provider_error","reason":"fireworks responded 524: error code: 524"}`** after ~125s — reproduces the original postmortem exactly |
| `khala-code` **stream:true**, north-star crossy-road prompt | ❌ socket closed unexpectedly at ~180s, **0 tokens received** (no first byte) |
| `khala-code` **stream:true**, *short* prompt | ❌ **502 `{"error":"provider_error","reason":"fireworks stream missing terminal usage frame"}`** in ~1.4s |

### Diagnosis
- The streaming SSE **client** is correct: it consumes prod's real SSE for `khala-mini` and reconstructs the completion + would attach a terminal `openagents` block when present.
- `khala-code` **streaming fails regardless of prompt length** with a *different* error than the 524: the gateway's Fireworks streaming adapter does not emit a terminal usage frame, so the gateway rejects the upstream stream (502 `fireworks stream missing terminal usage frame`). For the long prompt the upstream also closes the socket past ~180s before any byte arrives — i.e. the gateway's `stream` branch appears to buffer the upstream stream server-side (it awaits all chunks into an array before emitting SSE), so it does not actually reset the edge timer for `khala-code`.
- So the crossy-road generation does **not** complete via SSE on prod yet, and it is **not** because of the client — it is a gateway/upstream-adapter issue, which is **out of this PR's scope** (gateway route contract is read-only here).

### What's needed to finish the 524 fix (gateway-side, EPIC #6017 follow-up)
1. Fix the gateway Fireworks **streaming** adapter to emit a terminal usage frame (the `fireworks stream missing terminal usage frame` 502).
2. Make the gateway `stream` branch **pass chunks through as they arrive** rather than buffering the full upstream stream before emitting SSE, so the edge idle timer is actually reset for `khala-code`.
3. Likely also need a faster coder model and/or a higher upstream `max_tokens`/timeout for the full crossy-road generation, since even non-streaming hits the upstream 524 at ~125s.

No success was faked: the client fix is real and proven on a streaming model; the `khala-code` blocker is reported as-is.

## Tests
- `bun test scripts/khala-demo/*.test.mjs` → 20 pass (added `reconstructCompletionFromSse` + `liveStreamTransport` coverage incl. byte-stream reader, text fallback, terminal receipt, non-ok error).
- cockpit `bun test khala-cockpit/shell-turn/verse-turn/inference-gateway` → 42 pass (added streaming-default, no-receipt-not-live, `stream:false` opt-out, and SSE-reconstruction/`isEventStreamResponse` coverage).
- `apps/autopilot-desktop` typecheck → clean. Root `bun run typecheck` → exit 0.

## Blockers
- `khala-code` streaming + long-generation completion on prod is blocked by the gateway Fireworks streaming adapter (`missing terminal usage frame`) and the gateway's server-side stream buffering — gateway-side, out of scope here.

Part of #6027 / EPIC #6017

**DO NOT auto-merge — orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)