### PR TITLE
Khala: tolerate Fireworks streams without usage

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/fireworks-adapter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/fireworks-adapter.test.ts
@@ -412,20 +412,31 @@ describe('fireworks adapter streaming', () => {
     }
   })
 
-  test('a stream with no terminal usage fails typed (never an estimate)', async () => {
+  test('a stream with no terminal usage returns an unmetered terminal chunk', async () => {
     const { fetchImpl } = recordingFetch(
       sseResponse([
-        { choices: [{ delta: { content: 'partial' }, index: 0 }] },
+        {
+          choices: [{ delta: { content: 'partial' }, index: 0 }],
+          model: 'accounts/fireworks/models/deepseek-v4-pro',
+        },
+        { choices: [{ delta: {}, finish_reason: 'stop', index: 0 }] },
       ]),
     )
     const adapter = makeFireworksAdapter(baseConfig({ fetchImpl }))
 
     const result = await runResult(adapter.stream(request({ stream: true })))
 
-    expect(result._tag).toBe('Failure')
-    if (result._tag === 'Failure') {
-      expect(result.failure.kind).toBe('malformed_response')
-      expect(result.failure.reason).toContain('usage')
+    expect(result._tag).toBe('Success')
+    if (result._tag === 'Success') {
+      const chunks = result.success
+      expect(chunks.map(chunk => chunk.contentDelta).join('')).toBe('partial')
+      const terminal = chunks[chunks.length - 1]
+      expect(terminal?.contentDelta).toBe('')
+      expect(terminal?.finishReason).toBe('stop')
+      expect(terminal?.servedModel).toBe(
+        'accounts/fireworks/models/deepseek-v4-pro',
+      )
+      expect(terminal?.usage).toBeUndefined()
     }
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/fireworks-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/fireworks-adapter.ts
@@ -418,24 +418,14 @@ export const makeFireworksAdapter = (
         }
       }
 
-      // Receipt-first: the terminal frame carries finishReason + usage. When
-      // Fireworks omits a usage frame (some stream modes), surface a typed
-      // malformed-response error so metering never settles on an estimate.
-      if (usage === undefined) {
-        return yield* Effect.fail(
-          adapterError({
-            kind: 'malformed_response',
-            reason: 'fireworks stream missing terminal usage frame',
-            retryable: false,
-          }),
-        )
-      }
-
+      // Receipt-first: some Fireworks stream modes omit terminal usage. Return
+      // the terminal chunk without usage so the route can disclose an unmetered
+      // stream instead of failing or settling on an estimate.
       const terminalChunk: InferenceStreamChunk = {
         contentDelta: '',
         finishReason: finishReason ?? 'stop',
         servedModel,
-        usage,
+        ...(usage === undefined ? {} : { usage }),
       }
       return [...contentChunks, terminalChunk]
     }),


### PR DESCRIPTION
## Problem

Refs #6035. `khala-code` short streaming requests were failing with `fireworks stream missing terminal usage frame` when Fireworks returned usable SSE deltas but omitted the terminal `usage` object.

## Change

- Fireworks stream parsing now returns the terminal chunk even when no provider usage frame arrives.
- The terminal chunk still carries `finishReason` and `servedModel`.
- No token counts are fabricated; `usage` remains absent so the route's existing no-usage path can disclose an unmetered stream instead of charging on an estimate.

## Files Touched

- `apps/openagents.com/workers/api/src/inference/fireworks-adapter.ts`
- `apps/openagents.com/workers/api/src/inference/fireworks-adapter.test.ts`

## Validation

- `bun test apps/openagents.com/workers/api/src/inference/fireworks-adapter.test.ts`
- `bun test apps/openagents.com/workers/api/src/inference/fireworks-adapter.test.ts apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts`
- `git diff --check`

## Value

This clears the first, narrow gateway-side blocker from #6035: short Fireworks/Khala streaming responses that lack a terminal usage frame no longer become 502s, while receipt-first metering remains honest.

## Not Changed

- No gateway pass-through streaming rewrite.
- No prod crossy-road validation.
- No fallback model/timeout changes for the longer upstream 524 path.
