### PR TITLE
Khala gateway: fix Fireworks streaming (terminal usage frame + pass-through) — the khala-code 524

### DIFF
--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -429,6 +429,16 @@ const runPromiseAllowlist = new Map([
   // moves to an Effect program. INERT by default (VOICE_PROGRAM_INGEST_ENABLED
   // off → the core is never run); promise stays red.
   ['workers/api/src/voice-program-ingest-routes.ts', 1],
+  // Added 2026-06-22 (#6035 / refs #6027): the inference gateway TRUE
+  // pass-through SSE stream (the khala-code 524 fix) bridges the Effect-returning
+  // metering hook into the Web Streams `ReadableStream.start` controller callback
+  // ONCE, after the upstream stream drains, to settle metering receipt-first from
+  // the terminal usage frame. The Web Streams controller API is not Effect-native
+  // and streaming must flow incrementally (no server-side buffering, so the edge
+  // idle-timer resets and long generations never 524), so the metering Effect is
+  // run at that boundary. Named bridge; ratchet down if the streaming response is
+  // expressed as an Effect Stream program end-to-end.
+  ['workers/api/src/inference/chat-completions-routes.ts', 1],
 ])
 
 const runPromiseDetails = countByFile(sourceFiles, /Effect\.runPromise\(/g)

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -28,6 +28,9 @@ import {
   InferenceAdapterError,
   type InferenceProviderAdapter,
   InferenceProviderRegistry,
+  type InferenceStreamEvent,
+  type InferenceStreamSource,
+  type InferenceUsage,
 } from './provider-adapter'
 import { STUB_ECHO_ADAPTER_ID, stubEchoAdapter } from './stub-echo-adapter'
 
@@ -1059,5 +1062,212 @@ describe('default model + premium gate (free-tier enablement §2)', () => {
     )
     expect(response.status).toBe(200)
     expect(checked).toBe(true)
+  })
+})
+
+// TRUE PASS-THROUGH STREAM (the khala-code 524 fix) -----------------------
+// When the served adapter exposes `streamSse`, the route pumps the upstream SSE
+// to the client frame-by-frame instead of buffering the whole completion before
+// emitting a byte. These exercise the route wiring: live pass-through + metering
+// from the terminal usage frame, the missing-terminal-frame case (no estimate),
+// and connect-time failure → 502.
+describe('POST /v1/chat/completions — streamSse pass-through', () => {
+  const passThroughAuth: InferenceAuth = async () => ({
+    accountRef: 'agent:test-user',
+  })
+  const funded: InferenceBalanceReader = async () => 100_000
+
+  // A streamSse-capable adapter built from a script of normalized frames. The
+  // frames are emitted one at a time (one per ReadableStream pull), so the test
+  // proves the route does not wait for the whole upstream before emitting.
+  const streamSseAdapter = (
+    id: string,
+    script: ReadonlyArray<InferenceStreamEvent>,
+    terminal: Readonly<{
+      finishReason: string | undefined
+      usage: InferenceUsage | undefined
+      servedModel: string | undefined
+    }>,
+  ): InferenceProviderAdapter => ({
+    ...stubEchoAdapter,
+    id,
+    streamSse: () =>
+      Effect.sync<InferenceStreamSource>(() => ({
+        frames: (async function* () {
+          for (const event of script) {
+            yield event
+          }
+        })(),
+        terminal: () => terminal,
+      })),
+  })
+
+  const ptDeps = (
+    overrides: Partial<ChatCompletionsDeps> = {},
+  ): ChatCompletionsDeps => ({
+    authenticate: passThroughAuth,
+    enabled: true,
+    readAvailableMsat: funded,
+    registry: new InferenceProviderRegistry(),
+    ...overrides,
+  })
+
+  const ptRequest = (body: unknown): Request =>
+    new Request('https://openagents.com/v1/chat/completions', {
+      body: JSON.stringify(body),
+      method: 'POST',
+    })
+
+  test('pumps content deltas through and meters from the terminal usage frame', async () => {
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: true, receiptRef: 'rcpt-pt-1' }
+      })
+
+    const registry = new InferenceProviderRegistry()
+    registry.register(
+      streamSseAdapter(
+        'pt-lane',
+        [{ contentDelta: 'Hel' }, { contentDelta: 'lo' }],
+        {
+          finishReason: 'stop',
+          servedModel: 'served/model',
+          usage: { completionTokens: 2, promptTokens: 7, totalTokens: 9 },
+        },
+      ),
+    )
+
+    const response = await Effect.runPromise(
+      handleChatCompletions(
+        ptRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'open-model',
+          stream: true,
+        }),
+        ptDeps({ lanePlan: () => ['pt-lane'], meteringHook, registry }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+    const text = await response.text()
+    // Content streamed through, terminated with [DONE].
+    expect(text).toContain('"content":"Hel"')
+    expect(text).toContain('"content":"lo"')
+    expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
+    // Metering settled receipt-first from the terminal usage frame.
+    expect(captured).toHaveLength(1)
+    expect(captured[0]?.streamed).toBe(true)
+    expect(captured[0]?.adapterId).toBe('pt-lane')
+    expect(captured[0]?.servedModel).toBe('served/model')
+    expect(captured[0]?.usage.completionTokens).toBe(2)
+  })
+
+  test('a missing terminal usage frame closes the stream cleanly WITHOUT metering (no estimate)', async () => {
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: false, receiptRef: null }
+      })
+
+    const registry = new InferenceProviderRegistry()
+    registry.register(
+      streamSseAdapter('pt-lane', [{ contentDelta: 'partial' }], {
+        finishReason: undefined,
+        servedModel: undefined,
+        usage: undefined,
+      }),
+    )
+
+    const response = await Effect.runPromise(
+      handleChatCompletions(
+        ptRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'open-model',
+          stream: true,
+        }),
+        ptDeps({ lanePlan: () => ['pt-lane'], meteringHook, registry }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('"content":"partial"')
+    expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
+    // Receipt-first: no terminal usage => the hook never runs (never an estimate).
+    expect(captured).toHaveLength(0)
+  })
+
+  test('a connect-time streamSse failure surfaces as 502 (no buffered re-dispatch)', async () => {
+    const registry = new InferenceProviderRegistry()
+    let bufferedStreamCalls = 0
+    registry.register({
+      ...stubEchoAdapter,
+      id: 'pt-lane',
+      stream: request => {
+        bufferedStreamCalls += 1
+        return stubEchoAdapter.stream(request)
+      },
+      streamSse: () =>
+        Effect.fail(
+          new InferenceAdapterError({
+            adapterId: 'pt-lane',
+            kind: 'upstream_error',
+            reason: 'fireworks responded 524',
+            retryable: false,
+          }),
+        ),
+    })
+
+    const response = await Effect.runPromise(
+      handleChatCompletions(
+        ptRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'open-model',
+          stream: true,
+        }),
+        ptDeps({ lanePlan: () => ['pt-lane'], registry }),
+      ),
+    )
+
+    expect(response.status).toBe(502)
+    const body = (await response.json()) as { error: string; reason: string }
+    expect(body.error).toBe('provider_error')
+    expect(body.reason).toBe('fireworks responded 524')
+    // The provider error must NOT silently fall back to the buffered path.
+    expect(bufferedStreamCalls).toBe(0)
+  })
+
+  test('an adapter WITHOUT streamSse falls back to the buffered path', async () => {
+    // stubEchoAdapter has no streamSse; the route must use the buffered `stream`.
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: false, receiptRef: null }
+      })
+    const registry = new InferenceProviderRegistry()
+    registry.register({ ...stubEchoAdapter, id: 'buffered-lane' })
+
+    const response = await Effect.runPromise(
+      handleChatCompletions(
+        ptRequest({
+          messages: [{ content: 'hello world', role: 'user' }],
+          model: 'open-model',
+          stream: true,
+        }),
+        ptDeps({ lanePlan: () => ['buffered-lane'], meteringHook, registry }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('"content":"hello world"')
+    expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
+    expect(captured).toHaveLength(1)
+    expect(captured[0]?.streamed).toBe(true)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -46,10 +46,12 @@ import {
 } from './model-serving-policy'
 import { type FundingKind, KHALA_CODE_MODEL_ID, isKhalaModel } from './pricing'
 import {
+  InferenceAdapterError,
   type InferenceMessage,
   type InferenceProviderRegistry,
   type InferenceRequest,
   type InferenceResult,
+  type InferenceStreamSource,
 } from './provider-adapter'
 import { STUB_ECHO_ADAPTER_ID } from './stub-echo-adapter'
 
@@ -383,6 +385,131 @@ const openAiResponse = (
 const sseFrame = (payload: unknown): string =>
   `data: ${JSON.stringify(payload)}\n\n`
 
+// Build a TRUE incremental SSE Response body that pumps the upstream stream
+// source to the client frame-by-frame (the khala-code 524 fix). Each content
+// delta is emitted AS IT ARRIVES — bytes flow continuously so the Cloudflare
+// edge idle-timer resets and a multi-minute generation never 524s. The terminal
+// `openagents` disclosure block (built by the SAME `khalaReceiptForResult` the
+// non-streaming + buffered paths use) and metering settlement happen AFTER the
+// upstream closes, attached to the final `chat.completion.chunk` before
+// `data: [DONE]`. Metering settles receipt-first from the terminal usage frame.
+//
+// This runs OUTSIDE the route's Effect: the metering hook is an Effect, so it is
+// executed with `Effect.runPromise` in the flush step (the same hook used on the
+// buffered/non-streaming paths). The metering hook never fails (it returns a
+// typed outcome), so a metering error never breaks the already-delivered stream.
+const makePassThroughResponseStream = (
+  input: Readonly<{
+    accountRef: string
+    adapterId: string
+    created: number
+    fundingKind: FundingKind
+    meteringHook: MeteringHook
+    requestedModel: string
+    responseId: string
+    source: InferenceStreamSource
+  }>,
+): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder()
+  const contentParts: Array<string> = []
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const chunkFrame = (
+        delta: string,
+        finishReason: string | null,
+        openagents?: OpenAgentsReceipt | undefined,
+      ): string =>
+        sseFrame({
+          choices: [
+            {
+              delta: delta === '' ? {} : { content: delta },
+              finish_reason: finishReason,
+              index: 0,
+            },
+          ],
+          created: input.created,
+          id: input.responseId,
+          model: input.requestedModel,
+          object: 'chat.completion.chunk',
+          ...(openagents === undefined ? {} : { openagents }),
+        })
+
+      try {
+        // Pump every upstream content delta to the client immediately.
+        for await (const event of input.source.frames) {
+          if (event.contentDelta !== '') {
+            contentParts.push(event.contentDelta)
+            controller.enqueue(
+              encoder.encode(chunkFrame(event.contentDelta, null)),
+            )
+          }
+        }
+      } catch {
+        // The upstream stream faulted mid-flight. The client already has partial
+        // content; close the SSE cleanly (DONE) so it is not left hanging. There
+        // is no terminal usage frame, so metering does NOT settle (receipt-first
+        // — never an estimate), exactly as the buffered path would on a stream
+        // with no terminal usage.
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+        return
+      }
+
+      // Stream drained: settle metering + build the disclosure from the terminal
+      // state, receipt-first. No re-buffering of content beyond the join needed
+      // for the verifier's full-output rubric.
+      const terminal = input.source.terminal()
+      const servedModel = terminal.servedModel ?? input.requestedModel
+      let streamMetering: MeteringOutcome | undefined
+      if (terminal.usage !== undefined) {
+        streamMetering = await Effect.runPromise(
+          input.meteringHook({
+            accountRef: input.accountRef,
+            adapterId: input.adapterId,
+            fundingKind: input.fundingKind,
+            requestId: input.responseId,
+            requestedModel: input.requestedModel,
+            servedModel,
+            streamed: true,
+            usage: terminal.usage,
+          }),
+        )
+      }
+
+      const streamResult: InferenceResult = {
+        content: contentParts.join(''),
+        finishReason: terminal.finishReason ?? 'stop',
+        servedModel,
+        usage: terminal.usage ?? {
+          completionTokens: 0,
+          promptTokens: 0,
+          totalTokens: 0,
+        },
+      }
+      const openagents = khalaReceiptForResult({
+        adapterId: input.adapterId,
+        metering: streamMetering ?? { metered: false, receiptRef: null },
+        requestedModel: input.requestedModel,
+        responseId: input.responseId,
+        result: streamResult,
+      })
+
+      // Terminal frame: empty delta + finish reason + disclosure block.
+      controller.enqueue(
+        encoder.encode(
+          chunkFrame(
+            '',
+            terminal.finishReason ?? 'stop',
+            openagents,
+          ),
+        ),
+      )
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+}
+
 export const handleChatCompletions = (
   request: Request,
   deps: ChatCompletionsDeps,
@@ -613,6 +740,81 @@ export const handleChatCompletions = (
     }
 
     if (inferenceRequest.stream) {
+      // TRUE PASS-THROUGH STREAM (the khala-code 524 fix). When the served
+      // adapter exposes `streamSse`, pump the upstream SSE to the client
+      // frame-by-frame so every chunk resets the Cloudflare edge idle-timer and
+      // a multi-minute generation never 524s (the old buffered array path read
+      // the WHOLE upstream completion before emitting a single byte — exactly
+      // what tripped the edge ~100s timeout on a long generation). Connect-time
+      // dispatch still overflows across the lane plan on a retryable failure;
+      // once bytes are flowing there is no overflow (the client already has
+      // partial output). Metering settles receipt-first from the terminal usage
+      // frame after the upstream stream closes. Adapters without `streamSse`
+      // (stub/echo, simple test adapters) fall through to the buffered path.
+      const sseDispatch = yield* dispatchWithOverflow(
+        inferenceRequest,
+        (adapter, request) => {
+          if (adapter.streamSse === undefined) {
+            // Signal "this lane cannot stream incrementally" as a NON-retryable
+            // typed failure so the overflow loop surfaces it without retrying;
+            // the route catches it and falls back to the buffered path.
+            return Effect.fail(
+              new InferenceAdapterError({
+                adapterId: adapter.id,
+                kind: 'stream_not_supported',
+                reason: 'adapter does not support incremental streaming',
+                retryable: false,
+              }),
+            )
+          }
+          return adapter
+            .streamSse(request)
+            .pipe(Effect.map(source => ({ adapterId: adapter.id, source })))
+        },
+        dispatchDeps,
+      ).pipe(
+        Effect.map(served => ({ ok: true as const, served })),
+        Effect.catch(error =>
+          Effect.succeed({
+            kind: error.kind,
+            ok: false as const,
+            reason: error.reason,
+          }),
+        ),
+      )
+
+      if (sseDispatch.ok) {
+        const { adapterId, source } = sseDispatch.served
+        const responseStream = makePassThroughResponseStream({
+          accountRef: session.accountRef,
+          adapterId,
+          created,
+          fundingKind,
+          meteringHook,
+          requestedModel,
+          responseId,
+          source,
+        })
+        return new Response(responseStream, {
+          headers: {
+            'cache-control': 'no-store',
+            'content-type': 'text/event-stream; charset=utf-8',
+          },
+          status: 200,
+        })
+      }
+
+      // Only fall back to the buffered path when the served lane genuinely could
+      // not stream incrementally. A real upstream/connect failure (provider
+      // error) must surface as the 502 it is, not be retried via the buffered
+      // path (which would double-dispatch and could 524 again).
+      if (sseDispatch.kind !== 'stream_not_supported') {
+        return noStoreJsonResponse(
+          { error: 'provider_error', reason: sseDispatch.reason },
+          { status: 502 },
+        )
+      }
+
       // Run the stream op across the lane plan; the served adapter id rides
       // alongside the chunks so metering reports the lane that actually served.
       const chunks = yield* dispatchWithOverflow(

--- a/apps/openagents.com/workers/api/src/inference/fireworks-adapter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/fireworks-adapter.test.ts
@@ -428,4 +428,190 @@ describe('fireworks adapter streaming', () => {
       expect(result.failure.reason).toContain('usage')
     }
   })
+
+  // RECEIPT-FIRST STREAMING (the "missing terminal usage frame" 524 fix):
+  // OpenAI-compatible providers omit the usage object from streamed responses
+  // unless asked. The adapter MUST opt in via stream_options.include_usage so a
+  // normal streamed completion carries its real terminal usage frame, instead of
+  // failing receipt-first with "missing terminal usage frame".
+  test('streaming requests opt in to a terminal usage frame via stream_options.include_usage', async () => {
+    const { calls, fetchImpl } = recordingFetch(
+      sseResponse([
+        { choices: [{ delta: { content: 'ok' }, index: 0 }] },
+        {
+          choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+          usage: { completion_tokens: 1, prompt_tokens: 3, total_tokens: 4 },
+        },
+      ]),
+    )
+    const adapter = makeFireworksAdapter(baseConfig({ fetchImpl }))
+
+    await runResult(adapter.stream(request({ stream: true })))
+
+    const body = JSON.parse(calls[0]?.init.body ?? '{}')
+    expect(body.stream).toBe(true)
+    expect(body.stream_options).toEqual({ include_usage: true })
+  })
+
+  test('non-streaming requests do NOT send stream_options', async () => {
+    const { calls, fetchImpl } = recordingFetch(jsonResponse(completionBody()))
+    const adapter = makeFireworksAdapter(baseConfig({ fetchImpl }))
+
+    await runResult(adapter.complete(request()))
+
+    const body = JSON.parse(calls[0]?.init.body ?? '{}')
+    expect(body.stream_options).toBeUndefined()
+  })
+
+  test('a load-bearing stream_options override beats a stray passthrough copy', async () => {
+    const { calls, fetchImpl } = recordingFetch(
+      sseResponse([
+        {
+          choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+          usage: { completion_tokens: 1, prompt_tokens: 3, total_tokens: 4 },
+        },
+      ]),
+    )
+    const adapter = makeFireworksAdapter(baseConfig({ fetchImpl }))
+
+    await runResult(
+      adapter.stream(
+        request({
+          passthroughParams: { stream_options: { include_usage: false } },
+          stream: true,
+        }),
+      ),
+    )
+
+    const body = JSON.parse(calls[0]?.init.body ?? '{}')
+    expect(body.stream_options).toEqual({ include_usage: true })
+  })
+})
+
+// --- incremental pass-through stream (streamSse) -------------------------
+
+// Build an SSE Response over a ReadableStream that emits each frame in its own
+// chunk, so the test exercises the adapter's incremental parsing (partial lines
+// across reads) rather than a single buffered blob.
+const chunkedSseResponse = (
+  frames: ReadonlyArray<unknown>,
+): Response => {
+  const encoder = new TextEncoder()
+  const lines = [
+    ...frames.map(frame => `data: ${JSON.stringify(frame)}\n\n`),
+    'data: [DONE]\n\n',
+  ]
+  let index = 0
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index >= lines.length) {
+        controller.close()
+        return
+      }
+      // Emit each line split across two chunks to prove partial-line buffering.
+      const line = lines[index]!
+      const mid = Math.floor(line.length / 2)
+      controller.enqueue(encoder.encode(line.slice(0, mid)))
+      controller.enqueue(encoder.encode(line.slice(mid)))
+      index += 1
+    },
+  })
+  return new Response(stream, {
+    headers: { 'content-type': 'text/event-stream' },
+    status: 200,
+  })
+}
+
+const drainSource = async (
+  adapter: ReturnType<typeof makeFireworksAdapter>,
+  req: InferenceRequest,
+) => {
+  const sourceResult = await runResult(adapter.streamSse!(req))
+  if (sourceResult._tag !== 'Success') {
+    return { failure: sourceResult, ok: false as const }
+  }
+  const source = sourceResult.success
+  const deltas: Array<string> = []
+  for await (const event of source.frames) {
+    if (event.contentDelta !== '') {
+      deltas.push(event.contentDelta)
+    }
+  }
+  return { ok: true as const, source, deltas }
+}
+
+describe('fireworks adapter incremental pass-through stream', () => {
+  test('exposes streamSse', () => {
+    const { fetchImpl } = recordingFetch(jsonResponse(completionBody()))
+    const adapter = makeFireworksAdapter(baseConfig({ fetchImpl }))
+    expect(typeof adapter.streamSse).toBe('function')
+  })
+
+  test('yields content deltas incrementally and captures the terminal usage frame', async () => {
+    const { calls, fetchImpl } = recordingFetch(
+      chunkedSseResponse([
+        { choices: [{ delta: { content: 'Hel' }, index: 0 }] },
+        { choices: [{ delta: { content: 'lo' }, index: 0 }] },
+        {
+          choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+          model: 'accounts/fireworks/models/kimi-k2p7-code',
+          usage: { completion_tokens: 2, prompt_tokens: 7, total_tokens: 9 },
+        },
+      ]),
+    )
+    const adapter = makeFireworksAdapter(baseConfig({ fetchImpl }))
+
+    const drained = await drainSource(adapter, request({ stream: true }))
+    expect(drained.ok).toBe(true)
+    if (!drained.ok) {
+      return
+    }
+    expect(drained.deltas).toEqual(['Hel', 'lo'])
+    expect(calls[0]?.init.headers['accept']).toBe('text/event-stream')
+    const body = JSON.parse(calls[0]?.init.body ?? '{}')
+    expect(body.stream_options).toEqual({ include_usage: true })
+
+    const terminal = drained.source.terminal()
+    expect(terminal.finishReason).toBe('stop')
+    expect(terminal.usage).toEqual({
+      completionTokens: 2,
+      promptTokens: 7,
+      totalTokens: 9,
+    })
+    expect(terminal.servedModel).toBe('accounts/fireworks/models/kimi-k2p7-code')
+  })
+
+  // The missing-terminal-frame case for the pass-through path: the source still
+  // drains (the client got partial content), and terminal usage is undefined so
+  // the ROUTE settles no metering (receipt-first — never an estimate). The
+  // adapter does not throw; metering policy lives at the route.
+  test('a stream with no terminal usage drains with undefined terminal usage', async () => {
+    const { fetchImpl } = recordingFetch(
+      chunkedSseResponse([
+        { choices: [{ delta: { content: 'partial' }, index: 0 }] },
+      ]),
+    )
+    const adapter = makeFireworksAdapter(baseConfig({ fetchImpl }))
+
+    const drained = await drainSource(adapter, request({ stream: true }))
+    expect(drained.ok).toBe(true)
+    if (!drained.ok) {
+      return
+    }
+    expect(drained.deltas).toEqual(['partial'])
+    expect(drained.source.terminal().usage).toBeUndefined()
+  })
+
+  test('streamSse connect-time 429 maps to a retryable rate_limited error', async () => {
+    const { fetchImpl } = recordingFetch(errorResponse(429))
+    const adapter = makeFireworksAdapter(baseConfig({ fetchImpl }))
+
+    const result = await runResult(adapter.streamSse!(request({ stream: true })))
+
+    expect(result._tag).toBe('Failure')
+    if (result._tag === 'Failure') {
+      expect(result.failure.kind).toBe('rate_limited')
+      expect(result.failure.retryable).toBe(true)
+    }
+  })
 })

--- a/apps/openagents.com/workers/api/src/inference/fireworks-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/fireworks-adapter.ts
@@ -30,6 +30,8 @@ import {
   type InferenceRequest,
   type InferenceResult,
   type InferenceStreamChunk,
+  type InferenceStreamEvent,
+  type InferenceStreamSource,
   type InferenceUsage,
 } from './provider-adapter'
 import { KHALA_CODE_MODEL_ID } from './pricing'
@@ -128,6 +130,19 @@ const toRequestBody = (request: InferenceRequest): Record<string, unknown> => {
     })),
     model: toFireworksModelId(request.model),
     stream: request.stream,
+    // RECEIPT-FIRST STREAMING (the "missing terminal usage frame" 524 fix):
+    // OpenAI-compatible providers OMIT the `usage` object from streamed
+    // responses BY DEFAULT — you must opt in with `stream_options.include_usage`
+    // to get a terminal frame carrying real prompt/completion counts. Without it
+    // the adapter's receipt-first guard correctly refuses to settle on an
+    // estimate and fails with `fireworks stream missing terminal usage frame`
+    // (observed on a short streamed prompt at ~1.4s). Asking for it makes a
+    // normal streamed completion carry its real usage, so streaming meters
+    // exactly like non-streaming. A stray client copy in passthroughParams is
+    // overridden here (load-bearing field wins). Only set on streaming requests.
+    ...(request.stream
+      ? { stream_options: { include_usage: true } }
+      : {}),
   }
 }
 
@@ -230,6 +245,112 @@ const finishReasonOf = (frame: Record<string, unknown>): string | undefined => {
   const choice = firstChoice(frame)
   const reason = choice?.['finish_reason']
   return typeof reason === 'string' && reason.length > 0 ? reason : undefined
+}
+
+// Normalize a parsed SSE frame into the route-facing event shape. Shared by the
+// buffered `stream` array path and the incremental `streamSse` pass-through so
+// both produce byte-identical normalization.
+const eventForFrame = (
+  frame: Record<string, unknown>,
+): InferenceStreamEvent => {
+  const event: {
+    contentDelta: string
+    finishReason?: string
+    usage?: InferenceUsage
+    servedModel?: string
+  } = { contentDelta: deltaContentOf(frame) }
+  const reason = finishReasonOf(frame)
+  if (reason !== undefined) {
+    event.finishReason = reason
+  }
+  const usage = extractUsage(frame)
+  if (usage !== undefined) {
+    event.usage = usage
+  }
+  const model = frame['model']
+  if (typeof model === 'string' && model.length > 0) {
+    event.servedModel = model
+  }
+  return event
+}
+
+// Build a true incremental SSE source over the upstream `ReadableStream`. Frames
+// are decoded + parsed AS BYTES ARRIVE (partial lines are buffered across reads)
+// and yielded one at a time, so the route can pump each to the client and reset
+// the edge idle-timer. The running terminal state (finishReason / usage /
+// servedModel) is captured during iteration and exposed via `terminal()` once
+// the stream is drained — receipt-first, no re-buffering of content. The
+// `[DONE]` sentinel and blank/comment lines are skipped by `parseSseData`.
+const makeSseSource = (
+  body: ReadableStream<Uint8Array>,
+  fallbackModel: string,
+): InferenceStreamSource => {
+  let finishReason: string | undefined
+  let usage: InferenceUsage | undefined
+  let servedModel: string | undefined = fallbackModel
+
+  const frames = (async function* (): AsyncIterable<InferenceStreamEvent> {
+    const reader = body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    try {
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (value !== undefined) {
+          buffer += decoder.decode(value, { stream: true })
+        }
+        // Emit every complete line currently buffered. SSE frames are newline
+        // delimited; a `data:` payload is single-line for OpenAI-compatible
+        // chunk framing, so line-at-a-time parsing is sufficient and we never
+        // hold a whole frame back waiting for the blank separator line.
+        let newlineIndex = buffer.indexOf('\n')
+        while (newlineIndex !== -1) {
+          const line = buffer.slice(0, newlineIndex)
+          buffer = buffer.slice(newlineIndex + 1)
+          const frame = parseSseData(line)
+          if (frame !== undefined) {
+            const event = eventForFrame(frame)
+            if (event.finishReason !== undefined) {
+              finishReason = event.finishReason
+            }
+            if (event.usage !== undefined) {
+              usage = event.usage
+            }
+            if (event.servedModel !== undefined) {
+              servedModel = event.servedModel
+            }
+            yield event
+          }
+          newlineIndex = buffer.indexOf('\n')
+        }
+        if (done) {
+          // Flush any trailing partial line (some sources omit the final \n).
+          const tail = parseSseData(buffer)
+          if (tail !== undefined) {
+            const event = eventForFrame(tail)
+            if (event.finishReason !== undefined) {
+              finishReason = event.finishReason
+            }
+            if (event.usage !== undefined) {
+              usage = event.usage
+            }
+            if (event.servedModel !== undefined) {
+              servedModel = event.servedModel
+            }
+            yield event
+          }
+          break
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+  })()
+
+  return {
+    frames,
+    terminal: () => ({ finishReason, servedModel, usage }),
+  }
 }
 
 // Resolve the key + transport, failing with a typed (non-retryable) config
@@ -438,6 +559,35 @@ export const makeFireworksAdapter = (
         usage,
       }
       return [...contentChunks, terminalChunk]
+    }),
+  // TRUE PASS-THROUGH STREAM (the long-generation 524 fix). Returns a lazily
+  // consumed SSE source over the upstream `response.body` so the route can pump
+  // each frame to the client as Fireworks produces it — every chunk resets the
+  // Cloudflare edge idle-timer, so a multi-minute generation never 524s. The
+  // buffered `stream` above stays for tests/metering reconstruction/overflow.
+  // `stream_options.include_usage` (set in toRequestBody) makes the upstream
+  // emit a terminal usage frame so metering settles receipt-first.
+  streamSse: (request: InferenceRequest) =>
+    Effect.gen(function* () {
+      const transport = yield* resolveTransport(config)
+      const response = yield* postChatCompletions(transport, {
+        ...request,
+        stream: true,
+      })
+      if (!response.ok) {
+        return yield* failForStatus(response)
+      }
+      const body = response.body
+      if (body === null) {
+        return yield* Effect.fail(
+          adapterError({
+            kind: 'malformed_response',
+            reason: 'fireworks stream had no response body',
+            retryable: false,
+          }),
+        )
+      }
+      return makeSseSource(body, toFireworksModelId(request.model))
     }),
 })
 

--- a/apps/openagents.com/workers/api/src/inference/fireworks-stream-passthrough.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/fireworks-stream-passthrough.test.ts
@@ -1,0 +1,280 @@
+// LOCAL STREAM HARNESS for the khala-code 524 fix (issue #6035, refs #6027).
+//
+// Wires the REAL Fireworks adapter `streamSse` through the REAL route stream
+// branch against a FAKE Fireworks SSE source, and asserts the two properties the
+// prod 524 violated:
+//
+//   1. TERMINAL USAGE FRAME. A normal streamed completion carries its real usage
+//      (the adapter opts in via `stream_options.include_usage`), so metering
+//      settles receipt-first instead of erroring "missing terminal usage frame".
+//   2. INCREMENTAL PASS-THROUGH. The route emits each upstream chunk AS IT
+//      ARRIVES — the harness gates upstream chunk N+1 behind the route having
+//      already produced chunk N to the client, which can only happen if the
+//      route is NOT buffering the whole upstream stream server-side. A buffered
+//      route would deadlock this harness (it would await the whole upstream
+//      before emitting a byte), so a passing run is positive proof of streaming.
+//
+// Plus the missing-terminal-frame case: the stream still closes cleanly and the
+// route settles NO metering (never an estimate).
+
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  handleChatCompletions,
+  type ChatCompletionsDeps,
+  type InferenceAuth,
+} from './chat-completions-routes'
+import {
+  type FetchLike,
+  makeFireworksAdapter,
+} from './fireworks-adapter'
+import { type MeteringContext, type MeteringHook } from './metering-hook'
+import { FIREWORKS_ADAPTER_ID } from './model-router'
+import { InferenceProviderRegistry } from './provider-adapter'
+import { recordFromUnknown } from '../json-boundary'
+
+const run = <A>(effect: Effect.Effect<A>): Promise<A> => Effect.runPromise(effect)
+
+// A fetch that returns a Fireworks-shaped SSE ReadableStream. Each frame is
+// gated behind a `release` promise so the harness can control WHEN the upstream
+// produces the next chunk — letting us prove the route forwards chunk N before
+// the upstream emits chunk N+1.
+type GatedFrame = Readonly<{
+  frame: unknown
+  // Resolves when the harness allows this frame to be emitted upstream.
+  gate: Promise<void>
+}>
+
+const gatedSseFetch = (
+  frames: ReadonlyArray<GatedFrame>,
+  options: Readonly<{ withDone: boolean }> = { withDone: true },
+): { fetchImpl: FetchLike; calls: number } => {
+  const state = { calls: 0 }
+  const fetchImpl: FetchLike = () => {
+    state.calls += 1
+    const encoder = new TextEncoder()
+    let index = 0
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (index >= frames.length) {
+          if (options.withDone) {
+            controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+          }
+          controller.close()
+          return
+        }
+        const { frame, gate } = frames[index]!
+        index += 1
+        await gate
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(frame)}\n\n`),
+        )
+      },
+    })
+    return Promise.resolve(
+      new Response(stream, {
+        headers: { 'content-type': 'text/event-stream' },
+        status: 200,
+      }),
+    )
+  }
+  return { calls: state.calls, fetchImpl }
+}
+
+// Narrow an unknown parsed SSE frame to its first-choice content delta without
+// a type assertion (lint forbids `as` narrowing). Uses the repo json-boundary
+// helper to coerce records.
+const deltaContentOfSse = (frame: unknown): string => {
+  const record = recordFromUnknown(frame)
+  const choices = record?.['choices']
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return ''
+  }
+  const delta = recordFromUnknown(choices[0])?.['delta']
+  const content = recordFromUnknown(delta)?.['content']
+  return typeof content === 'string' ? content : ''
+}
+
+const auth: InferenceAuth = async () => ({ accountRef: 'agent:harness' })
+
+const deps = (
+  overrides: Partial<ChatCompletionsDeps>,
+): ChatCompletionsDeps => ({
+  authenticate: auth,
+  enabled: true,
+  readAvailableMsat: async () => 100_000,
+  registry: new InferenceProviderRegistry(),
+  ...overrides,
+})
+
+const streamRequest = (model: string): Request =>
+  new Request('https://openagents.com/v1/chat/completions', {
+    body: JSON.stringify({
+      messages: [{ content: 'build a crossy-road game', role: 'user' }],
+      model,
+      stream: true,
+    }),
+    method: 'POST',
+  })
+
+// Read SSE `data:` payloads from a stream reader, one decoded text chunk at a
+// time, surfacing each `chat.completion.chunk` content delta as it arrives.
+const readDeltas = async (
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  onDelta: (delta: string) => void,
+): Promise<string> => {
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let full = ''
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (value !== undefined) {
+      buffer += decoder.decode(value, { stream: true })
+    }
+    let nl = buffer.indexOf('\n')
+    while (nl !== -1) {
+      const line = buffer.slice(0, nl).trim()
+      buffer = buffer.slice(nl + 1)
+      if (line.startsWith('data:')) {
+        const payload = line.slice('data:'.length).trim()
+        if (payload !== '' && payload !== '[DONE]') {
+          const delta = deltaContentOfSse(JSON.parse(payload))
+          if (delta !== '') {
+            full += delta
+            onDelta(delta)
+          }
+        }
+      }
+      nl = buffer.indexOf('\n')
+    }
+    if (done) {
+      break
+    }
+  }
+  return full
+}
+
+describe('fireworks streamSse — local route pass-through harness', () => {
+  test('forwards each upstream chunk to the client BEFORE the next upstream chunk is produced (no server-side buffering)', async () => {
+    // Three gated frames: two content frames and a terminal usage frame. The
+    // second/third gates stay closed until the client has SEEN the first
+    // delta(s) — only possible if the route streams through incrementally.
+    let release1 = (): void => {}
+    let release2 = (): void => {}
+    let release3 = (): void => {}
+    const gate1 = new Promise<void>(r => (release1 = r))
+    const gate2 = new Promise<void>(r => (release2 = r))
+    const gate3 = new Promise<void>(r => (release3 = r))
+
+    const { fetchImpl } = gatedSseFetch([
+      { frame: { choices: [{ delta: { content: 'AAA' }, index: 0 }] }, gate: gate1 },
+      { frame: { choices: [{ delta: { content: 'BBB' }, index: 0 }] }, gate: gate2 },
+      {
+        frame: {
+          choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+          model: 'accounts/fireworks/models/kimi-k2p7-code',
+          usage: { completion_tokens: 6, prompt_tokens: 12, total_tokens: 18 },
+        },
+        gate: gate3,
+      },
+    ])
+
+    const adapter = makeFireworksAdapter({
+      fetchImpl,
+      getApiKey: () => 'fw-test',
+    })
+    const registry = new InferenceProviderRegistry()
+    registry.register(adapter)
+
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: true, receiptRef: 'rcpt-harness' }
+      })
+
+    const response = await run(
+      handleChatCompletions(
+        streamRequest('khala-code'),
+        deps({
+          lanePlan: () => [FIREWORKS_ADAPTER_ID],
+          meteringHook,
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.body).not.toBeNull()
+    const reader = response.body!.getReader()
+
+    const seen: Array<string> = []
+    // Open the first gate so the upstream emits 'AAA'.
+    release1()
+    // Drive the consumer in the background; as each delta lands, open the next
+    // gate. If the route buffered, the consumer would never see 'AAA' until the
+    // whole upstream completed — but the upstream is BLOCKED on gate2/gate3, so a
+    // buffered route would deadlock here and the test would time out (a red).
+    const full = await readDeltas(reader, delta => {
+      seen.push(delta)
+      if (delta === 'AAA') {
+        release2()
+      }
+      if (delta === 'BBB') {
+        release3()
+      }
+    })
+
+    expect(seen).toEqual(['AAA', 'BBB'])
+    expect(full).toBe('AAABBB')
+    // Receipt-first metering settled from the terminal usage frame.
+    expect(captured).toHaveLength(1)
+    expect(captured[0]?.usage.totalTokens).toBe(18)
+    expect(captured[0]?.servedModel).toBe(
+      'accounts/fireworks/models/kimi-k2p7-code',
+    )
+    expect(captured[0]?.streamed).toBe(true)
+  })
+
+  test('the missing-terminal-frame case: stream closes cleanly, no metering (never an estimate)', async () => {
+    const open = Promise.resolve()
+    // Only content frames, NO terminal usage frame (the prod short-prompt symptom
+    // before stream_options.include_usage).
+    const { fetchImpl } = gatedSseFetch([
+      { frame: { choices: [{ delta: { content: 'no-usage' }, index: 0 }] }, gate: open },
+    ])
+
+    const adapter = makeFireworksAdapter({
+      fetchImpl,
+      getApiKey: () => 'fw-test',
+    })
+    const registry = new InferenceProviderRegistry()
+    registry.register(adapter)
+
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: false, receiptRef: null }
+      })
+
+    const response = await run(
+      handleChatCompletions(
+        streamRequest('khala-code'),
+        deps({
+          lanePlan: () => [FIREWORKS_ADAPTER_ID],
+          meteringHook,
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('"content":"no-usage"')
+    expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
+    // Receipt-first: no terminal usage => no metering at all (never an estimate).
+    expect(captured).toHaveLength(0)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/provider-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/provider-adapter.ts
@@ -61,6 +61,47 @@ export type InferenceResult = Readonly<{
   servedModel: string
 }>
 
+// One normalized SSE frame as it is parsed off the upstream byte stream, plus
+// the running terminal state (finishReason / usage / servedModel). This is what
+// a TRUE pass-through stream yields incrementally: every content delta as it
+// arrives (so the edge idle-timer resets and a multi-minute generation never
+// 524s), and the terminal usage frame when the upstream emits it. The route
+// re-frames these into OpenAI-compatible `data:` SSE and settles metering from
+// the terminal usage frame once the upstream stream closes (receipt-first).
+export type InferenceStreamEvent = Readonly<{
+  // Incremental content for this frame (may be empty on the terminal frame).
+  contentDelta: string
+  // Set when the upstream reports a finish reason (terminal frame).
+  finishReason?: string | undefined
+  // Set when the upstream emits a usage frame (terminal, receipt-first).
+  usage?: InferenceUsage | undefined
+  // Provider-native model id when the upstream reports one.
+  servedModel?: string | undefined
+}>
+
+// A true incremental stream of normalized SSE events. Unlike `stream` (which
+// returns a fully-materialized array — convenient for tests/metering but it
+// buffers the WHOLE upstream completion before the first byte reaches the
+// client, which is exactly what trips the Cloudflare edge ~100s idle timeout on
+// a long generation), `streamSse` hands back a lazily-consumed source that emits
+// each frame as the upstream produces it. The route pumps these straight to the
+// client so bytes flow continuously and a 3-minute generation never 524s.
+//
+// `terminal()` resolves AFTER the source is fully drained, with the captured
+// terminal state (finishReason / usage / servedModel) so the route can settle
+// metering receipt-first and attach the `openagents` disclosure block — without
+// re-buffering the content.
+export type InferenceStreamSource = Readonly<{
+  // Async-iterable of normalized frames, consumed once.
+  frames: AsyncIterable<InferenceStreamEvent>
+  // Resolves once `frames` is exhausted, with the terminal metering state.
+  terminal: () => Readonly<{
+    finishReason: string | undefined
+    usage: InferenceUsage | undefined
+    servedModel: string | undefined
+  }>
+}>
+
 // A single streamed delta. The route serializes these into OpenAI-compatible
 // `data:` SSE frames. The final chunk of a stream carries `usage` so the
 // metering hook can settle from real counts.
@@ -128,10 +169,23 @@ export type InferenceProviderAdapter = Readonly<{
     request: InferenceRequest,
   ) => Effect.Effect<InferenceResult, InferenceAdapterError>
   // Streaming completion. Implementations yield deltas; the terminal chunk
-  // carries `finishReason` + `usage`.
+  // carries `finishReason` + `usage`. NOTE: this returns a fully-materialized
+  // array, so it BUFFERS the whole upstream completion before any byte reaches
+  // the client. It stays for tests, metering reconstruction, and the overflow
+  // dispatcher; the route prefers `streamSse` (below) for the live hot path so a
+  // long generation streams through and never trips the edge idle timeout.
   stream: (
     request: InferenceRequest,
   ) => Effect.Effect<ReadonlyArray<InferenceStreamChunk>, InferenceAdapterError>
+  // OPTIONAL true incremental pass-through stream. When an adapter implements
+  // this, the route pumps the upstream SSE to the client frame-by-frame (no
+  // server-side buffering of the whole stream), so the edge idle-timer resets on
+  // every chunk and long generations never 524. Adapters that cannot stream
+  // incrementally (stub/echo, simple test adapters) omit it and the route falls
+  // back to the buffered `stream` path.
+  streamSse?: (
+    request: InferenceRequest,
+  ) => Effect.Effect<InferenceStreamSource, InferenceAdapterError>
 }>
 
 // Registry: maps adapter id -> adapter. The registry is the single seam the

--- a/docs/inference/2026-06-22-long-running-inference-response-strategies.md
+++ b/docs/inference/2026-06-22-long-running-inference-response-strategies.md
@@ -31,11 +31,29 @@ Stream tokens as they are generated. First byte in ~1s; every chunk resets the
 idle timer, so a 3-minute generation never trips the edge timeout. This is how
 every major inference API serves long generations.
 
-**We already have it.** `src/inference/chat-completions-routes.ts` supports
-`stream: true` (the `if (inferenceRequest.stream)` branch, OpenAI SSE
-`data: …\n\n` framing), and the Fireworks / Vertex adapters pass streaming
-through. The fix for the game generation is literally `"stream": true` and a
-client that consumes SSE (`curl --no-buffer`, or the SDK's stream mode).
+**We have it, and as of #6035 it truly passes through.** `src/inference/
+chat-completions-routes.ts` supports `stream: true` (the
+`if (inferenceRequest.stream)` branch, OpenAI SSE `data: …\n\n` framing). The
+fix for the game generation is `"stream": true` and a client that consumes SSE
+(`curl --no-buffer`, or the SDK's stream mode).
+
+**Caveat that bit us (#6035 / refs #6027):** the original streaming
+implementation was NOT a true pass-through. The Fireworks adapter `stream`
+returned a fully-materialized `ReadonlyArray<InferenceStreamChunk>` (it read the
+WHOLE upstream SSE body before returning a single chunk), and the route then
+serialized all chunks into one string `Response`. So even with `stream:true`,
+the edge saw no bytes until the entire multi-minute generation completed — still
+a 524. On top of that, OpenAI-compatible providers omit the `usage` object from
+streamed responses unless you send `stream_options.include_usage`, so a short
+streamed prompt failed receipt-first with `fireworks stream missing terminal
+usage frame`. #6035 fixes both: the adapter now opts in to the terminal usage
+frame and exposes an incremental `streamSse` source over the upstream
+`response.body`; the route pumps each frame to the client as it arrives (no
+server-side buffering), so every chunk resets the edge idle-timer and a 3-minute
+generation never 524s. Metering still settles receipt-first from the terminal
+usage frame after the upstream closes. (A non-streaming `stream:false`
+crossy-road call still 524s — that is fundamental synchronous buffering on the
+edge; the fix is to stream, or use Strategy 2 for detached runs.)
 
 Caveat: the `openagents` receipt block + verification verdict are emitted at the
 **end** of the stream (a terminal SSE event), since verification runs on the full


### PR DESCRIPTION
## Root cause (the khala-code 524)

Two distinct bugs, both in the gateway's streaming path, behind one symptom:

1. **The gateway "stream" branch buffered server-side.** The Fireworks adapter `stream` returned a fully-materialized `ReadonlyArray<InferenceStreamChunk>` — it read the **whole** upstream SSE body (`readBody` → `body.split('\n')`) before returning a single chunk. The route then serialized **all** chunks into one string and returned it as a single `Response`. So even with `stream:true`, the Cloudflare edge saw **no bytes** until the entire multi-minute generation finished → it gives up on a silent origin at ~100s and returns **524**. (Matches prod: `khala-code` `stream:true` crossy-road → socket closed ~180s, 0 tokens.)

2. **No terminal usage frame.** OpenAI-compatible providers (Fireworks included) **omit** the `usage` object from streamed responses unless you send `stream_options.include_usage`. The request never asked, so a normal streamed completion had no usage frame and the adapter's receipt-first guard (correctly refusing to estimate) failed with `fireworks stream missing terminal usage frame`. (Matches prod: `khala-code` `stream:true` short prompt → that error at ~1.4s.)

The non-streaming `stream:false` 524 is fundamental synchronous edge buffering (per the in-repo postmortem) — the fix for a long generation is to stream, which now works.

## The two fixes

1. **Terminal usage frame (`fireworks-adapter.ts`).** Streaming requests now send `stream_options: { include_usage: true }` (load-bearing — overrides any stray client copy; only set when `stream:true`). A normal streamed completion now carries its real terminal usage frame, so streaming **meters receipt-first exactly like non-streaming** — never an estimate (INVARIANTS "Canonical Token Usage Ledger" preserved).

2. **True pass-through (`provider-adapter.ts`, `fireworks-adapter.ts`, `chat-completions-routes.ts`).** Added an optional `streamSse(request) => Effect<InferenceStreamSource>` to the adapter contract. Fireworks implements it by parsing the upstream `response.body` **incrementally** (partial lines buffered across reads) and yielding each frame as it arrives; `terminal()` exposes finishReason/usage/servedModel after drain. The route stream branch **prefers `streamSse`** and pumps each frame to the client through a `ReadableStream`, so **every chunk resets the edge idle-timer** and long generations never 524. Metering settles receipt-first from the terminal usage frame after the upstream closes; the terminal `openagents` disclosure block + khala-code verification verdict still ride the final frame. Connect-time failures still overflow across the lane plan and surface as **502** — a real provider error is **never** silently re-dispatched through the buffered path. Adapters without `streamSse` (stub/echo, test adapters) fall back to the existing buffered array path, unchanged.

No model routing behavior changed. The `khala-code` backing model (`kimi-k2p7-code`) is untouched — flagging only that if interactive `khala-code` latency stays high after streaming, a faster coder backing model is a separate routing decision (out of scope here).

## Tests (all green)

- **`fireworks-adapter.test.ts`** (26): `stream_options.include_usage` opt-in on streaming / absent on non-streaming / load-bearing override wins; `streamSse` incremental yield + terminal capture + missing-usage drain + connect-time 429. Existing buffered `stream` + usage-extraction + typed-error tests unchanged.
- **`chat-completions-routes.test.ts`** (46): pass-through pumps deltas + meters from terminal usage; missing terminal frame closes the stream cleanly with **NO** metering; connect-time failure → 502 with no buffered re-dispatch; no-`streamSse` adapter falls back to the buffered path. Existing 42 route tests unchanged.
- **`fireworks-stream-passthrough.test.ts`** (new, local harness): wires the **real** Fireworks `streamSse` through the **real** route against a fake Fireworks SSE source. Gates upstream chunk N+1 behind the client having received chunk N — a buffered route would **deadlock** this test, so a pass is positive proof of incremental streaming. Plus the missing-terminal-frame case (clean close, no metering).
- Full `src/inference/` suite green (38 files, 477 tests). `bun run --cwd apps/openagents.com/workers/api typecheck` green. `check:conflict-markers` / `check:effect-topology` / `check:architecture` green (a named, documented `runPromise` bridge entry was added for the Web Streams metering boundary — the controller API is not Effect-native).

The pre-existing `nostr-effect@0.0.12` node_modules typecheck error is upstream and unrelated.

## Post-deploy live acceptance (NEEDS-OWNER: deploy is owner-gated)

I cannot deploy. After this merges and the `openagents.com` Worker deploys, re-run the crossy-road prompt with streaming and confirm tokens flow + a terminal `openagents` receipt with real usage, no 524:

```
curl -N -sS https://openagents.com/v1/chat/completions \
  -H "authorization: Bearer $OPENAGENTS_AGENT_TOKEN" \
  -H "content-type: application/json" \
  -d '{"model":"khala-code","stream":true,"messages":[{"role":"user","content":"build a single-file three.js crossy-road game"}]}'
```

Expect: incremental `data: {"object":"chat.completion.chunk",...}` frames starting in ~1s, a final frame carrying `openagents` (real usage + verification verdict), then `data: [DONE]` — and no `provider_error`/524.

Closes #6035 / refs #6027

**DO NOT auto-merge — orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)