### PR TITLE
Khala verified-work must EXECUTE: headless acceptance runner + honest downgrade (no more regex verified:true)

### DIFF
--- a/apps/openagents.com/workers/api/package.json
+++ b/apps/openagents.com/workers/api/package.json
@@ -56,5 +56,8 @@
     "stripe": "^22.2.0",
     "@openagentsinc/agent-runtime-schema": "workspace:*",
     "@openagentsinc/tassadar-executor": "workspace:*"
+  },
+  "devDependencies": {
+    "playwright": "^1.61.0"
   }
 }

--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/cli.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/cli.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env bun
+// CLI for the headless Khala acceptance runner (EPIC #6017).
+//
+// Runs OUT of the CF Worker. Given an HTML artifact file, it derives the crossy-road
+// acceptance spec, runs the real headless suite, prints the verdict JSON, and exits
+// non-zero when not verified — so a coder worker / CI loop can gate on it.
+//
+// Usage:
+//   bun src/inference/acceptance-runner/cli.ts <artifact.html>
+//   cat artifact.html | bun src/inference/acceptance-runner/cli.ts -
+//
+// Prereq: `bunx playwright install chromium` (chromium must be installed).
+
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+
+import { crossyRoadAcceptanceSpec } from '../acceptance-spec'
+import { runAcceptanceSuite } from './runner'
+
+const readStdin = async (): Promise<string> => {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+const readArtifact = async (path: string): Promise<string> =>
+  path === '-' ? readStdin() : readFile(path, 'utf8')
+
+const main = async (): Promise<void> => {
+  const path = process.argv[2]
+  if (path === undefined) {
+    console.error(
+      'Usage: bun acceptance-runner/cli.ts <artifact.html|->\n' +
+        'Reads a single-file HTML artifact and runs the crossy-road acceptance suite.',
+    )
+    process.exit(2)
+  }
+
+  const artifactHtml = await readArtifact(path)
+  const spec = crossyRoadAcceptanceSpec()
+  const verdict = await runAcceptanceSuite({ artifactHtml, spec })
+
+  console.log(JSON.stringify(verdict, null, 2))
+  process.exit(verdict.verified ? 0 : 1)
+}
+
+await main()

--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/fixtures/crossy-road-broken.html.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/fixtures/crossy-road-broken.html.ts
@@ -1,0 +1,141 @@
+// BROKEN crossy-road artifact fixture — the 4-bug version (EPIC #6017).
+//
+// This reproduces the EXACT four defects the regex verifier missed and certified as
+// verified:true (docs/inference/2026-06-22-verified-work-must-execute-the-artifact.md):
+//   1. CRASH ON LOAD — the constructor calls updateScoreUI() BEFORE assigning the DOM
+//      refs -> "Cannot read/set properties of undefined". A page error fires and the
+//      start-btn click listener is never attached.
+//   2. DEAD PLAY BUTTON — the game-over/start overlay uses opacity:0 with no
+//      display:none, stays full-screen at z-index:20, and .btn{pointer-events:auto}
+//      overrides .hidden{pointer-events:none}, so it intercepts the PLAY click.
+//   3. 100x CAMERA — updateCamera multiplies player.z (already world units) by
+//      TILE_SIZE again, so the camera flies ~32x per hop.
+//   4. WORLD STOPS GENERATING — only ~10 rows are ever seeded; none are appended as
+//      the player advances, so the world runs out (blue sky).
+//
+// The runner must FAIL these per-test. To make the camera/world bugs OBSERVABLE even
+// though the constructor crashes, the state reader is bound to the half-built instance
+// the crashing constructor leaves behind (the crash happens AFTER position/camera are
+// set up but BEFORE the start listener is wired) — exactly the partial-init a real
+// crash-on-load leaves. The reader is also wrapped so it never throws into the runner.
+
+export const CROSSY_ROAD_BROKEN_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Khala Crossy Road (broken)</title>
+  <style>
+    html, body { margin: 0; height: 100%; background: #1d2830; color: #fff; font-family: system-ui; }
+    #game { display: block; width: 100vw; height: 100vh; background: #6bbf59; }
+    /* BUG #2: overlay hides via opacity only and keeps pointer-events. */
+    #overlay {
+      position: fixed; inset: 0; z-index: 20;
+      display: flex; align-items: center; justify-content: center;
+      background: rgba(0,0,0,0.6);
+    }
+    #overlay.hidden { opacity: 0; pointer-events: none; }
+    .btn { font-size: 20px; padding: 12px 28px; cursor: pointer; pointer-events: auto; }
+  </style>
+</head>
+<body>
+  <canvas id="game" width="1280" height="720"></canvas>
+  <div id="overlay">
+    <button id="start-btn" class="btn" type="button">PLAY</button>
+  </div>
+  <button id="restart" class="btn" type="button" style="position:fixed;right:12px;bottom:12px;">Restart</button>
+  <script>
+    'use strict';
+    const TILE_SIZE = 32;
+    var brokenGame = null;
+
+    class Game {
+      constructor() {
+        this.startPosition = { x: 0, y: 0, z: 0 };
+        this.player = { x: 0, y: 0, z: 0 };
+        this.progress = 0;
+        this.score = 0;
+        this.camera = { offset: { x: 0, y: 8, z: 12 }, position: { x: 0, y: 8, z: 12 } };
+        // BUG #4: seed only ~10 rows; never append more as the player advances.
+        this.generatedRows = 10;
+        this.started = false;
+        this.loopTicks = 0;
+        // expose for the runner BEFORE the crash so the camera/world bugs are observable.
+        brokenGame = this;
+        this.updateCamera();
+
+        // BUG #1: call a UI update that touches DOM refs that were never assigned.
+        // this.context / this.startBtn are undefined -> throws. The start listener
+        // below is never reached, so PLAY is dead even ignoring the overlay bug.
+        this.updateScoreUI();
+
+        // UNREACHABLE because of BUG #1:
+        this.startBtn = document.getElementById('start-btn');
+        this.startBtn.addEventListener('click', () => this.start());
+        window.addEventListener('keydown', (event) => this.onKey(event));
+      }
+
+      updateScoreUI() {
+        // this.context was never assigned -> TypeError (the crash on load).
+        this.context.fillText('Score: ' + this.score, 10, 10);
+      }
+
+      updateCamera() {
+        // BUG #3: player.z is ALREADY world units; multiplying by TILE_SIZE again
+        // makes the camera fly ~32x per hop.
+        this.camera.position = {
+          x: this.player.x + this.camera.offset.x,
+          y: this.player.y + this.camera.offset.y,
+          z: this.player.z * TILE_SIZE + this.camera.offset.z
+        };
+      }
+
+      move(direction) {
+        if (direction === 'forward') { this.player.z += 1; this.progress += 1; this.score += 10; }
+        if (direction === 'backward') this.player.z -= 1;
+        if (direction === 'left') this.player.x -= 1;
+        if (direction === 'right') this.player.x += 1;
+        // BUG #4: no row generation here -> generatedRows stays 10.
+        this.updateCamera();
+      }
+
+      onKey(event) {
+        if (event.key === 'ArrowUp' || event.key === 'w') this.move('forward');
+        if (event.key === 'ArrowDown' || event.key === 's') this.move('backward');
+        if (event.key === 'ArrowLeft' || event.key === 'a') this.move('left');
+        if (event.key === 'ArrowRight' || event.key === 'd') this.move('right');
+      }
+
+      start() { this.started = true; }
+      restart() {
+        this.player = { x: 0, y: 0, z: 0 };
+        this.progress = 0;
+        this.updateCamera();
+      }
+
+      state() {
+        return {
+          camera: { position: { ...this.camera.position } },
+          loopTicks: this.loopTicks,
+          player: { ...this.player },
+          progress: this.progress,
+          score: this.score,
+          started: this.started,
+          worldRowsAhead: this.generatedRows - this.player.z
+        };
+      }
+    }
+
+    // State reader is resilient: even though construction throws, brokenGame was
+    // assigned before the crash, so the runner can still MEASURE the camera/world bugs.
+    window.__openagentsCrossyRoadState = () => {
+      try { return brokenGame ? brokenGame.state() : undefined; } catch (e) { return undefined; }
+    };
+    // Restart hook works on the half-built instance (so the restart check is fair).
+    window.__openagentsCrossyRoadRestart = () => { if (brokenGame) brokenGame.restart(); };
+    // NOTE: no working __openagentsCrossyRoadStart — BUG #1 stops the constructor
+    // before any start wiring, so the game can never start.
+
+    new Game();
+  </script>
+</body>
+</html>`

--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/fixtures/crossy-road-fixed.html.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/fixtures/crossy-road-fixed.html.ts
@@ -1,0 +1,161 @@
+// FIXED crossy-road artifact fixture (EPIC #6017).
+//
+// A self-contained single-file crossy-road game that PASSES every executed acceptance
+// check. It exposes the runner state contract (see runner.ts header):
+//   window.__openagentsCrossyRoadState(), __openagentsCrossyRoadStart(),
+//   __openagentsCrossyRoadRestart().
+// It is the paired counterpart to crossy-road-broken.html.ts (the 4-bug version): the
+// runner must PASS this and FAIL the broken one. Kept as a TS string export so the
+// test imports it without a bundler/asset step.
+//
+// Behavior, fixed (vs. the four documented defects):
+//   1. Loads cleanly — DOM refs assigned BEFORE first UI update; no crash.
+//   2. PLAY starts — the start overlay is display:none after start (no click intercept).
+//   3. Camera follows by ~1 unit per hop — z is NOT multiplied by TILE_SIZE twice.
+//   4. World keeps generating — rows are appended ahead as the player advances.
+
+export const CROSSY_ROAD_FIXED_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Khala Crossy Road (fixed)</title>
+  <style>
+    html, body { margin: 0; height: 100%; background: #1d2830; color: #fff; font-family: system-ui; }
+    #game { display: block; width: 100vw; height: 100vh; background: #6bbf59; }
+    #overlay {
+      position: fixed; inset: 0; z-index: 20;
+      display: flex; align-items: center; justify-content: center;
+      background: rgba(0,0,0,0.6);
+    }
+    #overlay.hidden { display: none; }
+    .btn { font-size: 20px; padding: 12px 28px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <canvas id="game" width="1280" height="720"></canvas>
+  <div id="overlay">
+    <button id="start-btn" class="btn" type="button">PLAY</button>
+  </div>
+  <button id="restart" class="btn" type="button" style="position:fixed;right:12px;bottom:12px;">Restart</button>
+  <script>
+    'use strict';
+    const TILE_SIZE = 32;
+
+    class Game {
+      constructor() {
+        // FIX #1: assign DOM refs BEFORE any UI update.
+        this.canvas = document.getElementById('game');
+        this.context = this.canvas.getContext('2d');
+        this.overlay = document.getElementById('overlay');
+        this.startBtn = document.getElementById('start-btn');
+        this.restartBtn = document.getElementById('restart');
+
+        this.startPosition = { x: 0, y: 0, z: 0 };
+        this.reset();
+        this.started = false;
+        this.loopTicks = 0;
+        this.rafId = null;
+
+        this.startBtn.addEventListener('click', () => this.start());
+        this.restartBtn.addEventListener('click', () => this.restart());
+        window.addEventListener('keydown', (event) => this.onKey(event));
+
+        this.updateUI();
+      }
+
+      reset() {
+        this.player = { x: 0, y: 0, z: 0 };
+        this.progress = 0;
+        this.score = 0;
+        this.difficulty = 1;
+        this.camera = { offset: { x: 0, y: 8, z: 12 }, position: { x: 0, y: 8, z: 12 } };
+        // World rows generated AHEAD of the player. Seed enough to start.
+        this.generatedRows = 16;
+        this.updateCamera();
+      }
+
+      updateUI() {
+        // Safe no-op draw target; runs only after refs exist.
+        if (this.context) {
+          this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        }
+      }
+
+      updateCamera() {
+        // FIX #3: follow by world units directly — do NOT multiply by TILE_SIZE.
+        this.camera.position = {
+          x: this.player.x + this.camera.offset.x,
+          y: this.player.y + this.camera.offset.y,
+          z: this.player.z + this.camera.offset.z
+        };
+      }
+
+      ensureWorldAhead() {
+        // FIX #4: keep generating rows ahead of the player as they advance.
+        const needed = this.player.z + 16;
+        if (this.generatedRows < needed) {
+          this.generatedRows = needed;
+        }
+      }
+
+      move(direction) {
+        if (!this.started) return;
+        if (direction === 'forward') { this.player.z += 1; this.progress += 1; this.score += 10; }
+        if (direction === 'backward') this.player.z = Math.max(0, this.player.z - 1);
+        if (direction === 'left') this.player.x -= 1;
+        if (direction === 'right') this.player.x += 1;
+        this.difficulty = Math.min(8, 1 + this.progress * 0.2);
+        this.ensureWorldAhead();
+        this.updateCamera();
+      }
+
+      onKey(event) {
+        if (event.key === 'ArrowUp' || event.key === 'w') this.move('forward');
+        if (event.key === 'ArrowDown' || event.key === 's') this.move('backward');
+        if (event.key === 'ArrowLeft' || event.key === 'a') this.move('left');
+        if (event.key === 'ArrowRight' || event.key === 'd') this.move('right');
+      }
+
+      start() {
+        if (this.started) return;
+        this.started = true;
+        // FIX #2: fully hide the overlay (display:none) so it can't intercept input.
+        this.overlay.classList.add('hidden');
+        this.loop();
+      }
+
+      restart() {
+        this.reset();
+        this.started = true;
+        this.overlay.classList.add('hidden');
+      }
+
+      loop() {
+        this.loopTicks += 1;
+        this.updateUI();
+        if (this.started) {
+          this.rafId = requestAnimationFrame(() => this.loop());
+        }
+      }
+
+      state() {
+        return {
+          camera: { position: { ...this.camera.position } },
+          difficulty: this.difficulty,
+          loopTicks: this.loopTicks,
+          player: { ...this.player },
+          progress: this.progress,
+          score: this.score,
+          started: this.started,
+          worldRowsAhead: this.generatedRows - this.player.z
+        };
+      }
+    }
+
+    const game = new Game();
+    window.__openagentsCrossyRoadState = () => game.state();
+    window.__openagentsCrossyRoadStart = () => game.start();
+    window.__openagentsCrossyRoadRestart = () => game.restart();
+  </script>
+</body>
+</html>`

--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/runner.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/runner.test.ts
@@ -1,0 +1,145 @@
+// Regression proof for the headless acceptance runner (EPIC #6017).
+//
+// THIS IS THE PROOF THE VERIFIER NOW MEANS SOMETHING: the runner must FAIL the
+// 4-bug crossy-road artifact (per-test) and PASS the fixed one. If this test passes,
+// `verified` is execution-backed, not a regex over source.
+//
+// Requires a real headless chromium (Playwright). Run with:
+//   bun run --cwd apps/openagents.com/workers/api test -- src/inference/acceptance-runner/
+//   (chromium installed via `bunx playwright install chromium`)
+//
+// A single shared browser is reused across cases for speed.
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { chromium, type Browser } from 'playwright'
+
+import { crossyRoadAcceptanceSpec } from '../acceptance-spec'
+import { runAcceptanceSuite } from './runner'
+import { assembleAcceptanceVerdict } from './verdict'
+import { CROSSY_ROAD_BROKEN_HTML } from './fixtures/crossy-road-broken.html'
+import { CROSSY_ROAD_FIXED_HTML } from './fixtures/crossy-road-fixed.html'
+
+let browser: Browser
+
+beforeAll(async () => {
+  browser = await chromium.launch({ headless: true })
+}, 60_000)
+
+afterAll(async () => {
+  await browser.close().catch(() => undefined)
+})
+
+describe('headless acceptance runner — verdict assembly (pure)', () => {
+  test('scalarReward is the fraction passing; verified only when all pass', () => {
+    const spec = crossyRoadAcceptanceSpec()
+    const allPass = assembleAcceptanceVerdict({
+      checks: spec.checks.map(id => ({ detail: 'ok', id, passed: true })),
+      consoleErrors: [],
+      pageErrors: [],
+      spec,
+    })
+    expect(allPass.verified).toBe(true)
+    expect(allPass.scalarReward).toBe(1)
+
+    const halfPass = assembleAcceptanceVerdict({
+      checks: spec.checks.map((id, index) => ({
+        detail: 'x',
+        id,
+        passed: index % 2 === 0,
+      })),
+      consoleErrors: [],
+      pageErrors: [],
+      spec,
+    })
+    expect(halfPass.verified).toBe(false)
+    expect(halfPass.scalarReward).toBeLessThan(1)
+    expect(halfPass.scalarReward).toBeGreaterThan(0)
+  })
+})
+
+describe('headless acceptance runner — executes the artifact', () => {
+  test('PASSES the fixed crossy-road artifact (every check green)', async () => {
+    const verdict = await runAcceptanceSuite(
+      { artifactHtml: CROSSY_ROAD_FIXED_HTML, spec: crossyRoadAcceptanceSpec() },
+      { browser },
+    )
+    expect(verdict.executed).toBe(true)
+    expect(verdict.consoleErrors).toEqual([])
+    expect(verdict.pageErrors).toEqual([])
+    expect(verdict.failedChecks, JSON.stringify(verdict.checks, null, 2)).toEqual(
+      [],
+    )
+    expect(verdict.verified).toBe(true)
+    expect(verdict.scalarReward).toBe(1)
+  }, 60_000)
+
+  test('FAILS the 4-bug crossy-road artifact, per-test', async () => {
+    const verdict = await runAcceptanceSuite(
+      {
+        artifactHtml: CROSSY_ROAD_BROKEN_HTML,
+        spec: crossyRoadAcceptanceSpec(),
+      },
+      { browser },
+    )
+    expect(verdict.executed).toBe(true)
+    expect(verdict.verified).toBe(false)
+    expect(verdict.scalarReward).toBeLessThan(1)
+
+    // BUG #1 — crashed on load: a page error was captured.
+    expect(verdict.pageErrors.length).toBeGreaterThan(0)
+    expect(verdict.failedChecks).toContain('loads_without_errors')
+
+    // BUG #2 / #1 — PLAY does not start the game.
+    expect(verdict.failedChecks).toContain('play_starts_game')
+
+    // PLAY dead -> forward input cannot advance the player.
+    expect(verdict.failedChecks).toContain('forward_input_advances_player')
+
+    // BUG #4 — world stopped generating ahead.
+    expect(verdict.failedChecks).toContain('world_keeps_generating_ahead')
+  }, 60_000)
+
+  test('catches the 100x camera bug by MEASURED delta when moves do land', async () => {
+    // Drive the broken game's camera directly through its exposed instance to prove
+    // the camera-delta check FAILS on the 100x multiply even when input is wired:
+    // we force forward moves via the restart+move path and read the camera delta.
+    const page = await browser.newPage()
+    try {
+      await page.setContent(CROSSY_ROAD_BROKEN_HTML, { waitUntil: 'load' })
+      await page.waitForTimeout(200)
+      // Read camera before and after one forced forward move on the half-built game.
+      const deltas = await page.evaluate(() => {
+        const w = globalThis as unknown as {
+          __openagentsCrossyRoadState?: () => {
+            camera?: { position?: { x?: number; y?: number; z?: number } }
+          }
+          brokenGame?: unknown
+        }
+        // Reach into the broken instance the fixture left on window/global.
+        const g = w.brokenGame as
+          | {
+              move: (d: string) => void
+              camera: { position: { x: number; y: number; z: number } }
+            }
+          | undefined
+        const read = () => {
+          const s = w.__openagentsCrossyRoadState?.()
+          return s?.camera?.position
+        }
+        const before = read()
+        if (g !== undefined && typeof g.move === 'function') g.move('forward')
+        const after = read()
+        if (before === undefined || after === undefined) return null
+        return {
+          dz: Math.abs((after.z ?? 0) - (before.z ?? 0)),
+        }
+      })
+      // The 100x bug moves the camera by ~TILE_SIZE (32) units in z for a one-tile hop.
+      // Our bound is 5 -> this is far over it, which is exactly why the check fails.
+      expect(deltas).not.toBeNull()
+      expect(deltas?.dz ?? 0).toBeGreaterThan(crossyRoadAcceptanceSpec().params.maxCameraDeltaPerMove)
+    } finally {
+      await page.close().catch(() => undefined)
+    }
+  }, 60_000)
+})

--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/runner.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/runner.ts
@@ -1,0 +1,324 @@
+// Headless acceptance runner for the Khala crossy-road lane (EPIC #6017).
+//
+// THIS RUNS OUT OF THE CF WORKER. It launches a real headless chromium (Playwright),
+// loads the produced single-file HTML artifact, and runs the deterministic acceptance
+// suite from `acceptance-spec.ts` against the LIVE page — load → no errors → click
+// PLAY → press forward N times → read exposed state. The fraction of checks passing
+// is the honest `scalarReward`; `verified` is true only when ALL pass. This is the
+// real verification the regex `khala-code-verifier.ts` only pretended to do.
+//
+// It is import-safe to load in Node/Bun but NOT in the Worker (it imports playwright).
+// The route imports only `./verdict` (pure) and consumes a verdict produced here.
+//
+// THE STATE CONTRACT (what a crossy-road artifact must expose for execution).
+// The artifact must define on `window`:
+//   - `__openagentsCrossyRoadState(): {
+//        player:  { x, y, z },           // world-unit position
+//        camera:  { position: { x,y,z } },
+//        progress: number,               // forward tiles travelled
+//        worldRowsAhead?: number,        // distinct rows generated ahead of player
+//        started?: boolean,              // true once PLAY started the loop
+//        loopTicks?: number,             // increments while the update loop runs
+//      }`
+//   - `__openagentsCrossyRoadStart?()` OR a `#start-btn` / `#play` clickable element
+//      that hides the start overlay and starts the loop.
+//   - `__openagentsCrossyRoadRestart()` to reset to the start.
+// This contract is how we EXECUTE the game deterministically; an artifact that does
+// not expose it cannot be execution-verified (its checks fail honestly, never a false
+// green).
+
+import { chromium, type Browser, type Page } from 'playwright'
+
+import type { AcceptanceSpec } from '../acceptance-spec'
+import {
+  type AcceptanceCheckResult,
+  type AcceptanceVerdict,
+  assembleAcceptanceVerdict,
+} from './verdict'
+
+// The shape we read back out of the page. `unknown`-guarded at the boundary.
+type GameState = {
+  player?: { x?: number; y?: number; z?: number }
+  camera?: { position?: { x?: number; y?: number; z?: number } }
+  progress?: number
+  worldRowsAhead?: number
+  started?: boolean
+  loopTicks?: number
+}
+
+const num = (value: unknown): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : Number.NaN
+
+const vecDelta = (
+  a: { x?: number; y?: number; z?: number } | undefined,
+  b: { x?: number; y?: number; z?: number } | undefined,
+): number => {
+  if (a === undefined || b === undefined) return Number.NaN
+  const dx = num(a.x) - num(b.x)
+  const dy = num(a.y) - num(b.y)
+  const dz = num(a.z) - num(b.z)
+  return Math.sqrt(dx * dx + dy * dy + dz * dz)
+}
+
+// Read the page's exposed state hook. Returns `undefined` if the artifact never
+// exposed the contract (e.g. it crashed on load before defining it).
+const readState = async (page: Page): Promise<GameState | undefined> => {
+  // NOTE: the body of every `page.evaluate` callback runs IN THE BROWSER, not in the
+  // Worker tsconfig's WebWorker lib. Browser globals are reached through `globalThis`
+  // casts so this module typechecks without pulling the DOM lib into the Worker build.
+  return page.evaluate(() => {
+    const w = globalThis as unknown as {
+      __openagentsCrossyRoadState?: () => unknown
+    }
+    if (typeof w.__openagentsCrossyRoadState !== 'function') return undefined
+    try {
+      return w.__openagentsCrossyRoadState() as unknown
+    } catch {
+      return undefined
+    }
+  }) as Promise<GameState | undefined>
+}
+
+// Try to start the game the way a user would: prefer a real PLAY/start click (this is
+// what catches the dead-button overlay defect — a click that does nothing leaves
+// `started` false), then fall back to the explicit start hook.
+const startGame = async (page: Page): Promise<void> => {
+  const clicked = await page.evaluate(() => {
+    const doc = (globalThis as unknown as { document: unknown })
+      .document as {
+      querySelector: (selector: string) => { click: () => void } | null
+    }
+    const selectors = ['#start-btn', '#play', '#play-btn', '#start', 'button']
+    for (const selector of selectors) {
+      const element = doc.querySelector(selector)
+      if (element !== null) {
+        element.click()
+        return true
+      }
+    }
+    return false
+  })
+  // Always also try the explicit hook so a hook-only artifact can start, but a
+  // click-driven artifact's dead button is still exercised first (above).
+  await page.evaluate(() => {
+    const w = globalThis as unknown as {
+      __openagentsCrossyRoadStart?: () => void
+    }
+    if (typeof w.__openagentsCrossyRoadStart === 'function') {
+      w.__openagentsCrossyRoadStart()
+    }
+  })
+  if (!clicked) {
+    // No obvious start control and no hook ran is fine; the started check will
+    // measure whether the loop is actually running.
+  }
+}
+
+const pressForward = async (page: Page): Promise<void> => {
+  await page.keyboard.press('ArrowUp')
+}
+
+const settle = async (page: Page, ms: number): Promise<void> => {
+  await page.waitForTimeout(ms)
+}
+
+// Run the full crossy-road acceptance suite against a live page. PURE w.r.t. the spec
+// + page (no global state); returns one result per spec check.
+const runCrossyRoadChecks = async (
+  page: Page,
+  spec: AcceptanceSpec,
+  consoleErrors: ReadonlyArray<string>,
+  pageErrors: ReadonlyArray<string>,
+): Promise<ReadonlyArray<AcceptanceCheckResult>> => {
+  const results: AcceptanceCheckResult[] = []
+  const { params } = spec
+
+  // 1. loads_without_errors — captured during navigation.
+  const loadOk = consoleErrors.length === 0 && pageErrors.length === 0
+  results.push({
+    detail: loadOk
+      ? 'No console or page errors during load.'
+      : `Console errors: ${consoleErrors.length}; page errors: ${pageErrors.length}. First: ${(pageErrors[0] ?? consoleErrors[0] ?? '').slice(0, 200)}`,
+    id: 'loads_without_errors',
+    passed: loadOk,
+  })
+
+  // 2. play_starts_game — click PLAY/start, then verify the loop actually runs and
+  //    the game reports started. This catches the dead-button overlay (click does
+  //    nothing -> started stays false / loop never ticks).
+  const before = await readState(page)
+  await startGame(page)
+  await settle(page, 250)
+  const afterStart = await readState(page)
+  const ticksBefore = num(before?.loopTicks)
+  const ticksAfter = num(afterStart?.loopTicks)
+  const loopRunning =
+    (Number.isFinite(ticksBefore) &&
+      Number.isFinite(ticksAfter) &&
+      ticksAfter > ticksBefore) ||
+    afterStart?.started === true
+  results.push({
+    detail: loopRunning
+      ? `Game started (started=${String(afterStart?.started)}, loopTicks ${ticksBefore}->${ticksAfter}).`
+      : `PLAY did not start the game (started=${String(afterStart?.started)}, loopTicks ${ticksBefore}->${ticksAfter}). Dead button / overlay?`,
+    id: 'play_starts_game',
+    passed: loopRunning,
+  })
+
+  // 3. forward_input_advances_player — one forward press advances ~one tile.
+  const preMove = await readState(page)
+  await pressForward(page)
+  await settle(page, 80)
+  const postMove = await readState(page)
+  const advance = vecDelta(postMove?.player, preMove?.player)
+  const advancedOneTile =
+    Number.isFinite(advance) &&
+    advance >= params.expectedForwardAdvance * 0.5 &&
+    advance <= params.expectedForwardAdvance * 2
+  results.push({
+    detail: advancedOneTile
+      ? `Forward input advanced player by ~${advance.toFixed(2)} (expected ~${params.expectedForwardAdvance}).`
+      : `Forward input advanced player by ${advance.toFixed(2)}; expected ~${params.expectedForwardAdvance}.`,
+    id: 'forward_input_advances_player',
+    passed: advancedOneTile,
+  })
+
+  // 4 & 5. Drive N forward moves; track max camera delta per move AND world rows
+  //        ahead. This catches both the 100x camera bug and the blue-sky bug.
+  let prevState = await readState(page)
+  let maxCameraDelta = 0
+  for (let move = 0; move < params.forwardMoves; move += 1) {
+    await pressForward(page)
+    await settle(page, 60)
+    const next = await readState(page)
+    const camDelta = vecDelta(next?.camera?.position, prevState?.camera?.position)
+    if (Number.isFinite(camDelta)) {
+      maxCameraDelta = Math.max(maxCameraDelta, camDelta)
+    }
+    prevState = next
+  }
+  const finalState = await readState(page)
+
+  const cameraBounded =
+    Number.isFinite(maxCameraDelta) &&
+    maxCameraDelta > 0 &&
+    maxCameraDelta <= params.maxCameraDeltaPerMove
+  results.push({
+    detail: cameraBounded
+      ? `Max camera delta per move ${maxCameraDelta.toFixed(2)} <= bound ${params.maxCameraDeltaPerMove}.`
+      : `Max camera delta per move ${maxCameraDelta.toFixed(2)} exceeds bound ${params.maxCameraDeltaPerMove} (100x camera bug?).`,
+    id: 'camera_follow_delta_bounded',
+    passed: cameraBounded,
+  })
+
+  const rowsAhead = num(finalState?.worldRowsAhead)
+  const worldGenerating =
+    Number.isFinite(rowsAhead) && rowsAhead >= params.minWorldRowsAhead
+  results.push({
+    detail: worldGenerating
+      ? `World has ${rowsAhead} rows ahead after ${params.forwardMoves} moves (>= ${params.minWorldRowsAhead}).`
+      : `World has ${Number.isFinite(rowsAhead) ? rowsAhead : 'unknown'} rows ahead after ${params.forwardMoves} moves; need >= ${params.minWorldRowsAhead} (blue sky?).`,
+    id: 'world_keeps_generating_ahead',
+    passed: worldGenerating,
+  })
+
+  // 6. restart_resets_state — restart returns player + progress to start.
+  await page.evaluate(() => {
+    const w = globalThis as unknown as {
+      __openagentsCrossyRoadRestart?: () => void
+    }
+    if (typeof w.__openagentsCrossyRoadRestart === 'function') {
+      w.__openagentsCrossyRoadRestart()
+    }
+  })
+  await settle(page, 80)
+  const afterRestart = await readState(page)
+  const playerBackToStart =
+    Number.isFinite(num(afterRestart?.player?.x)) &&
+    Math.abs(num(afterRestart?.player?.x)) < 0.001 &&
+    Math.abs(num(afterRestart?.player?.z)) < 0.001
+  const progressReset = num(afterRestart?.progress) === 0
+  const restartOk = playerBackToStart && progressReset
+  results.push({
+    detail: restartOk
+      ? 'Restart reset player to origin and progress to 0.'
+      : `Restart did not fully reset (player x=${num(afterRestart?.player?.x)}, z=${num(afterRestart?.player?.z)}, progress=${num(afterRestart?.progress)}).`,
+    id: 'restart_resets_state',
+    passed: restartOk,
+  })
+
+  return results
+}
+
+export type AcceptanceRunOptions = Readonly<{
+  // Inject a browser (test reuse). When absent the runner launches its own chromium.
+  browser?: Browser | undefined
+  // Per-step settle budget is internal; this caps total navigation wait.
+  navTimeoutMs?: number | undefined
+}>
+
+// Run the acceptance suite against a single-file HTML artifact string. Launches (or
+// reuses) headless chromium, loads the artifact via `setContent` (no server needed
+// for a self-contained file), captures console/page errors, and runs the suite.
+// ALWAYS returns a verdict (never throws into the caller): a crash on load shows up as
+// `loads_without_errors: false` plus failing downstream checks — an honest red, never
+// a false green.
+export const runAcceptanceSuite = async (
+  input: Readonly<{ artifactHtml: string; spec: AcceptanceSpec }>,
+  options?: AcceptanceRunOptions,
+): Promise<AcceptanceVerdict> => {
+  const ownBrowser = options?.browser === undefined
+  const browser =
+    options?.browser ?? (await chromium.launch({ headless: true }))
+  const consoleErrors: string[] = []
+  const pageErrors: string[] = []
+  let page: Page | undefined
+  try {
+    page = await browser.newPage({ viewport: { height: 720, width: 1280 } })
+    page.on('console', message => {
+      if (message.type() === 'error') consoleErrors.push(message.text())
+    })
+    page.on('pageerror', error => {
+      pageErrors.push(error.message)
+    })
+    await page.setContent(input.artifactHtml, {
+      timeout: options?.navTimeoutMs ?? 15_000,
+      waitUntil: 'load',
+    })
+    // Let any deferred construction / first frame run so a load-time crash surfaces.
+    await page.waitForTimeout(300)
+    const checks = await runCrossyRoadChecks(
+      page,
+      input.spec,
+      consoleErrors,
+      pageErrors,
+    )
+    return assembleAcceptanceVerdict({
+      checks,
+      consoleErrors,
+      pageErrors,
+      spec: input.spec,
+    })
+  } catch (error) {
+    // A runner-level failure (e.g. navigation timeout) is reported as an all-fail
+    // verdict with the error captured — never a silent pass.
+    const message = error instanceof Error ? error.message : String(error)
+    pageErrors.push(`runner_error: ${message}`)
+    const checks: ReadonlyArray<AcceptanceCheckResult> = input.spec.checks.map(
+      id => ({
+        detail: `Runner aborted before this check could execute: ${message.slice(0, 160)}`,
+        id,
+        passed: false,
+      }),
+    )
+    return assembleAcceptanceVerdict({
+      checks,
+      consoleErrors,
+      pageErrors,
+      spec: input.spec,
+    })
+  } finally {
+    if (page !== undefined) await page.close().catch(() => undefined)
+    if (ownBrowser) await browser.close().catch(() => undefined)
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/verdict.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/verdict.ts
@@ -1,0 +1,71 @@
+// The executed-acceptance verdict shape (EPIC #6017).
+//
+// This module is PURE and Worker-safe (no Playwright, no browser). The headless
+// runner (`runner.ts`, runs OUT of the CF Worker) produces an `AcceptanceVerdict`;
+// the route consumes it to derive `verified` / `scalarReward` / `verification_receipt`
+// when (and only when) a real execution actually ran. Keeping the verdict shape here
+// means the route never transitively imports chromium.
+
+import type {
+  AcceptanceSpec,
+  CrossyRoadAcceptanceCheckId,
+} from '../acceptance-spec'
+
+// One executed acceptance check result. `passed` is the verdict of running a PROGRAM
+// against the live page — never a regex over source. `detail` is a public-safe,
+// human-readable note (measured values / failure reason), never raw artifact bytes.
+export type AcceptanceCheckResult = Readonly<{
+  id: CrossyRoadAcceptanceCheckId
+  passed: boolean
+  detail: string
+}>
+
+// The full executed-acceptance verdict. `executed` is always true here — this shape
+// is only produced AFTER a real headless run. `scalarReward` is the fraction of
+// checks passing (a dense, honest signal). `verified` is true ONLY when every check
+// passed. `consoleErrors` / `pageErrors` are the captured browser diagnostics that
+// caught the "crashed on load" defect.
+export type AcceptanceVerdict = Readonly<{
+  kind: AcceptanceSpec['kind']
+  executed: true
+  rubricRef: string
+  checks: ReadonlyArray<AcceptanceCheckResult>
+  passedChecks: ReadonlyArray<CrossyRoadAcceptanceCheckId>
+  failedChecks: ReadonlyArray<CrossyRoadAcceptanceCheckId>
+  scalarReward: number
+  verified: boolean
+  consoleErrors: ReadonlyArray<string>
+  pageErrors: ReadonlyArray<string>
+}>
+
+// Assemble the verdict from the executed per-check results. PURE — the runner calls
+// this after running the page so the scoring math is testable in isolation.
+export const assembleAcceptanceVerdict = (
+  input: Readonly<{
+    spec: AcceptanceSpec
+    checks: ReadonlyArray<AcceptanceCheckResult>
+    consoleErrors: ReadonlyArray<string>
+    pageErrors: ReadonlyArray<string>
+  }>,
+): AcceptanceVerdict => {
+  const passedChecks = input.checks
+    .filter(item => item.passed)
+    .map(item => item.id)
+  const failedChecks = input.checks
+    .filter(item => !item.passed)
+    .map(item => item.id)
+  const total = input.checks.length
+  const scalarReward = total === 0 ? 0 : passedChecks.length / total
+  return {
+    checks: input.checks,
+    consoleErrors: input.consoleErrors,
+    executed: true,
+    failedChecks,
+    kind: input.spec.kind,
+    pageErrors: input.pageErrors,
+    passedChecks,
+    rubricRef: input.spec.rubricRef,
+    scalarReward,
+    verified: failedChecks.length === 0 && total > 0,
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/acceptance-spec.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-spec.ts
@@ -1,0 +1,136 @@
+// Intent -> acceptance spec seam for the Khala verified-work lane (EPIC #6017).
+//
+// THE PRINCIPLE (docs/inference/2026-06-22-verified-work-must-execute-the-artifact.md):
+// `verified:true` must mean "we ran it and it did what the user asked." A verifier
+// that only pattern-matches source is a keyword filter, not a verifier. This module
+// turns a request's INTENT into a structured, deterministic AcceptanceSpec — a list
+// of checkable tests, not prose — that an out-of-Worker execution runner runs against
+// the produced artifact. The runner's per-test pass/fail and the fraction passing are
+// the honest `verified` / `scalarReward` signal.
+//
+// This module is pure and Worker-safe (no browser, no I/O). The runner
+// (`acceptance-runner/`) consumes the spec; the route consumes the runner verdict.
+
+// The deterministic check ids for the crossy-road / khala-code lane. Each id is a
+// PROGRAM the runner executes against a live page, NOT a regex over source. The ids
+// map 1:1 to the four real defects the regex verifier missed plus the obvious
+// must-haves (see the spec doc "The failure, with the receipt").
+export type CrossyRoadAcceptanceCheckId =
+  // Loads with ZERO console/page errors (catches "crashed on load").
+  | 'loads_without_errors'
+  // PLAY starts the game: start/overlay screen hides AND an update loop advances
+  // (catches the dead PLAY button intercepted by a full-screen .hidden overlay).
+  | 'play_starts_game'
+  // A forward input advances the player ~one tile (catches "PLAY did nothing").
+  | 'forward_input_advances_player'
+  // The camera follow delta per move is BOUNDED (catches the 100x camera bug).
+  | 'camera_follow_delta_bounded'
+  // The world keeps generating ahead of the player for N moves (catches blue sky).
+  | 'world_keeps_generating_ahead'
+  // Restart resets the player position and progress to the start.
+  | 'restart_resets_state'
+
+// A typed acceptance spec: the structured, executable contract derived from intent.
+// `kind` discriminates the lane so we can generalize to other prompts later while the
+// runner stays deterministic per lane. The crossy-road lane carries the concrete,
+// bounded thresholds the runner asserts against the page's exposed state hooks.
+export type CrossyRoadAcceptanceSpec = Readonly<{
+  kind: 'crossy_road_single_html'
+  rubricRef: string
+  // The ordered checks to run. The runner runs ALL of them and reports each.
+  checks: ReadonlyArray<CrossyRoadAcceptanceCheckId>
+  // Bounded, deterministic parameters the runner uses. Concrete numbers, never prose.
+  params: Readonly<{
+    // Number of forward moves to drive when checking world generation + advance.
+    forwardMoves: number
+    // Max allowed camera-position delta magnitude per single move (world units).
+    // The known-good game moves the camera ~1 unit per hop; the 100x bug moves it
+    // ~TILE_SIZE*1 -> far over this bound. Pick a bound that passes good, fails 100x.
+    maxCameraDeltaPerMove: number
+    // Expected per-forward-move player advance (tiles). Tolerance is +/- this value's
+    // own slack window so a clean 1-tile hop passes and a no-op (0) fails.
+    expectedForwardAdvance: number
+    // Min number of distinct world rows/tiles that must exist ahead of the player
+    // after `forwardMoves` forward moves (catches "stopped generating after ~10").
+    minWorldRowsAhead: number
+  }>
+}>
+
+// The generalization seam: other lanes get their own spec variants. Today only the
+// crossy-road lane is concrete; the union makes the runner + route forward-compatible.
+export type AcceptanceSpec = CrossyRoadAcceptanceSpec
+
+// A minimal shape of the inference request the seam reads. Kept structural so callers
+// (the route) can pass their own `InferenceRequest` without a hard import cycle.
+export type AcceptanceIntentRequest = Readonly<{
+  model?: string | undefined
+  messages?:
+    | ReadonlyArray<Readonly<{ role: string; content: string }>>
+    | undefined
+}>
+
+export const CROSSY_ROAD_ACCEPTANCE_RUBRIC_REF =
+  'rubric.khala_code.crossy_road.executed_acceptance.v1'
+
+// The full ordered crossy-road check list (the four caught bugs + must-haves).
+export const CROSSY_ROAD_ACCEPTANCE_CHECKS: ReadonlyArray<CrossyRoadAcceptanceCheckId> =
+  [
+    'loads_without_errors',
+    'play_starts_game',
+    'forward_input_advances_player',
+    'camera_follow_delta_bounded',
+    'world_keeps_generating_ahead',
+    'restart_resets_state',
+  ]
+
+// The default, bounded crossy-road spec. The thresholds are chosen so the known-good
+// fixture passes every check and each of the four real defects fails its check.
+export const crossyRoadAcceptanceSpec = (
+  overrides?: Partial<CrossyRoadAcceptanceSpec['params']>,
+): CrossyRoadAcceptanceSpec => ({
+  checks: CROSSY_ROAD_ACCEPTANCE_CHECKS,
+  kind: 'crossy_road_single_html',
+  params: {
+    expectedForwardAdvance: 1,
+    forwardMoves: 12,
+    maxCameraDeltaPerMove: 5,
+    minWorldRowsAhead: 12,
+    ...overrides,
+  },
+  rubricRef: CROSSY_ROAD_ACCEPTANCE_RUBRIC_REF,
+})
+
+// Lightweight intent signal: is this a crossy-road-shaped coding ask? Kept as a
+// bounded keyword check ONLY for lane selection (NOT for the verification verdict) —
+// once a lane is selected the runner does the real, executed verification. A broader
+// semantic selector replaces this when the lane set grows.
+const looksLikeCrossyRoad = (text: string): boolean => {
+  const lower = text.toLowerCase()
+  return (
+    lower.includes('crossy') ||
+    (lower.includes('road') &&
+      (lower.includes('game') || lower.includes('frogger'))) ||
+    lower.includes('frogger')
+  )
+}
+
+// Intent -> AcceptanceSpec. For the khala-code crossy-road lane this returns the
+// concrete bounded spec. For other prompts in the khala-code lane today it falls back
+// to the crossy-road spec (the only executable lane built so far); a future
+// coordinator/verifier generates lane-appropriate specs here. Returns `undefined`
+// when there is no executable acceptance lane for the request (the route then must
+// NOT claim execution-backed verification).
+export const intentToAcceptanceSpec = (
+  request: AcceptanceIntentRequest,
+): AcceptanceSpec | undefined => {
+  const text = (request.messages ?? [])
+    .map(message => message.content)
+    .join('\n')
+  if (looksLikeCrossyRoad(text)) {
+    return crossyRoadAcceptanceSpec()
+  }
+  // No prose match — but the khala-code lane today only ships the crossy-road
+  // executable suite. Default to it so the lane's artifacts are executed rather than
+  // regex-stamped. (Generalize per-lane here later.)
+  return crossyRoadAcceptanceSpec()
+}

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -10,7 +10,7 @@ import {
 } from './chat-completions-routes'
 import { decideFairShare, decideSpendCap } from './inference-abuse-controls'
 import {
-  BROKEN_CONTROLS_CROSSY_ROAD_HTML,
+  BROKEN_EXTERNAL_ASSET_CROSSY_ROAD_HTML,
   GOOD_CROSSY_ROAD_HTML,
 } from './khala-code-verifier.fixtures'
 import { type MeteringContext, type MeteringHook } from './metering-hook'
@@ -606,7 +606,10 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
-  test('a khala-code accepted artifact returns test_passed with receipt metadata', async () => {
+  // EPIC #6017 honest downgrade: the hot Worker route cannot launch a browser, so it
+  // does NOT execute the artifact. A prescreen-passing artifact comes back `unverified`
+  // (we did not run it) with scalar_reward 0 — NEVER test_passed / 1 from regex.
+  test('a khala-code prescreen-passing artifact returns UNVERIFIED (not certified) with receipt metadata', async () => {
     const registry = new InferenceProviderRegistry()
     registry.register(echoAdapter(FIREWORKS_ADAPTER_ID))
     const meteringHook: MeteringHook = () =>
@@ -648,6 +651,7 @@ describe('POST /v1/chat/completions', () => {
         verification: string
         verification_receipt: string
         verified: boolean
+        executed: boolean
         worker: string
         workers: ReadonlyArray<string>
       }
@@ -655,23 +659,20 @@ describe('POST /v1/chat/completions', () => {
 
     expect(body.model).toBe(KHALA_CODE_MODEL_ID)
     expect(body.openagents).toMatchObject({
+      executed: false,
       lane: 'open',
       receipt: 'receipt.inference.charge.chatcmpl-khala-code-pass',
       receipt_url:
         '/api/public/inference/receipts/receipt.inference.charge.chatcmpl-khala-code-pass',
       requested_model: KHALA_CODE_MODEL_ID,
       route: 'coding',
-      scalar_reward: 1,
+      scalar_reward: 0,
       served_model: KHALA_CODE_MODEL_ID,
-      verification: 'test_passed',
-      verified: true,
+      verification: 'unverified',
+      verified: false,
       worker: FIREWORKS_ADAPTER_ID,
       workers: [FIREWORKS_ADAPTER_ID, 'khala-code-crossy-road-verifier'],
     })
-    expect(body.openagents?.rubric.failed_checks).toEqual([])
-    expect(body.openagents?.rubric.passed_checks).toContain(
-      'restart_resets_character',
-    )
     expect(body.openagents?.verification_receipt).toMatch(
       /^receipt\.inference\.khala_code\.verification\.chatcmpl-khala-code-pass\./u,
     )
@@ -680,7 +681,7 @@ describe('POST /v1/chat/completions', () => {
     )
   })
 
-  test('a khala-code deliberately broken artifact reports verified false', async () => {
+  test('a khala-code artifact that fails the cheap prescreen reports failed (not even worth running)', async () => {
     const registry = new InferenceProviderRegistry()
     registry.register(echoAdapter(FIREWORKS_ADAPTER_ID))
 
@@ -688,7 +689,7 @@ describe('POST /v1/chat/completions', () => {
       handleChatCompletions(
         chatRequest({
           messages: [
-            { content: BROKEN_CONTROLS_CROSSY_ROAD_HTML, role: 'user' },
+            { content: BROKEN_EXTERNAL_ASSET_CROSSY_ROAD_HTML, role: 'user' },
           ],
           model: KHALA_CODE_MODEL_ID,
         }),
@@ -706,15 +707,15 @@ describe('POST /v1/chat/completions', () => {
         scalar_reward: number
         verification: string
         verified: boolean
+        executed: boolean
       }
     }
 
     expect(body.openagents?.verification).toBe('failed')
     expect(body.openagents?.verified).toBe(false)
-    expect(body.openagents?.rubric.failed_checks).toContain(
-      'direction_controls',
-    )
-    expect(body.openagents?.scalar_reward).toBeLessThan(1)
+    expect(body.openagents?.executed).toBe(false)
+    expect(body.openagents?.rubric.failed_checks).toContain('single_html_file')
+    expect(body.openagents?.scalar_reward).toBe(0)
   })
 
   test('a non-Khala request omits the openagents block', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -25,6 +25,10 @@ import {
   type SpendCapDecision,
 } from './inference-abuse-controls'
 import { type PremiumAccessDecision } from './inference-premium-allowlist'
+// PURE verdict type only — the route NEVER imports the headless runner (playwright)
+// into the Worker bundle. The runner executes out of the Worker; its verdict shape is
+// the only thing the route consumes (EPIC #6017).
+import { type AcceptanceVerdict } from './acceptance-runner/verdict'
 import {
   KHALA_CODE_VERIFIER_WORKER_ID,
   type KhalaCodeVerificationVerdict,
@@ -276,7 +280,14 @@ type OpenAgentsReceipt = Readonly<{
   served_model: string
   worker: string
   lane: string
-  verification: 'none' | 'test_passed' | 'failed'
+  // `unverified` is the HONEST default for an executable artifact we have not actually
+  // run yet (EPIC #6017): the regex pre-screen passed but the out-of-Worker headless
+  // acceptance runner has not executed it, so we do NOT certify it. `test_passed` is
+  // reserved for an EXECUTED acceptance suite that fully passed.
+  verification: 'none' | 'test_passed' | 'unverified' | 'failed'
+  // Whether a real headless acceptance run produced this verdict. False => the
+  // verdict is the honest pre-screen-only downgrade, not an execution result.
+  executed?: boolean | undefined
   verified?: boolean | undefined
   receipt?: string | undefined
   receipt_url?: string | undefined
@@ -305,6 +316,12 @@ const khalaReceiptForResult = (
     requestedModel: string
     responseId: string
     result: InferenceResult
+    // The executed-acceptance verdict from the out-of-Worker headless runner, when an
+    // execution actually ran (EPIC #6017). PRESENT => `verified`/`scalarReward` derive
+    // from EXECUTION. ABSENT (the hot Worker path today, which cannot launch a browser)
+    // => HONEST DOWNGRADE to `unverified`. Full prod wiring (async sandbox dispatch of
+    // the runner + receipt backfill) threads a real verdict in here.
+    acceptance?: AcceptanceVerdict | undefined
   }>,
 ): OpenAgentsReceipt | undefined => {
   if (!isKhalaModel(input.requestedModel)) {
@@ -328,11 +345,13 @@ const khalaReceiptForResult = (
     requestId: input.responseId,
     servedModel: input.result.servedModel,
     worker: input.adapterId,
+    ...(input.acceptance === undefined ? {} : { acceptance: input.acceptance }),
   })
   const receipt = input.metering.receiptRef ?? verdict.receiptRef
 
   return {
     ...base,
+    executed: verdict.executed,
     receipt,
     ...(input.metering.receiptRef === null
       ? {}

--- a/apps/openagents.com/workers/api/src/inference/khala-code-verifier.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-code-verifier.test.ts
@@ -1,30 +1,49 @@
 import { describe, expect, test } from 'vitest'
 
+import type { AcceptanceVerdict } from './acceptance-runner/verdict'
+import { crossyRoadAcceptanceSpec } from './acceptance-spec'
+import { assembleAcceptanceVerdict } from './acceptance-runner/verdict'
 import {
   KHALA_CODE_CROSSY_ROAD_RUBRIC_REF,
   KHALA_CODE_HEADLESS_COMMAND_REF,
   discoverKhalaCodeVerificationCommand,
   extractSingleHtmlArtifact,
+  prescreenKhalaCodeArtifact,
   verifyKhalaCodeCompletion,
 } from './khala-code-verifier'
 import {
-  BROKEN_CONTROLS_CROSSY_ROAD_HTML,
-  BROKEN_DIFFICULTY_CROSSY_ROAD_HTML,
   BROKEN_EXTERNAL_ASSET_CROSSY_ROAD_HTML,
-  BROKEN_RESTART_CROSSY_ROAD_HTML,
   GOOD_CROSSY_ROAD_HTML,
 } from './khala-code-verifier.fixtures'
 
-const verify = (content: string) =>
+const verify = (
+  content: string,
+  acceptance?: AcceptanceVerdict | undefined,
+) =>
   verifyKhalaCodeCompletion({
     content,
     meteringReceiptRef: 'receipt.inference.charge.chatcmpl-fixture',
     requestId: 'chatcmpl-fixture',
     servedModel: 'openagents/khala-code',
     worker: 'fireworks',
+    ...(acceptance === undefined ? {} : { acceptance }),
   })
 
-describe('Khala code crossy-road verifier', () => {
+const executedVerdict = (allPass: boolean): AcceptanceVerdict => {
+  const spec = crossyRoadAcceptanceSpec()
+  return assembleAcceptanceVerdict({
+    checks: spec.checks.map((id, index) => ({
+      detail: 'x',
+      id,
+      passed: allPass ? true : index === 0,
+    })),
+    consoleErrors: [],
+    pageErrors: [],
+    spec,
+  })
+}
+
+describe('Khala code verifier — honest downgrade (EPIC #6017)', () => {
   test('extracts a single HTML artifact from raw or fenced assistant content', () => {
     expect(extractSingleHtmlArtifact(GOOD_CROSSY_ROAD_HTML)).toBe(
       GOOD_CROSSY_ROAD_HTML,
@@ -45,16 +64,47 @@ describe('Khala code crossy-road verifier', () => {
     })
   })
 
-  test('accepts the known-good crossy-road single-file fixture', () => {
+  test('prescreen is a gate-to-attempt, not a verdict', () => {
+    const pass = prescreenKhalaCodeArtifact(GOOD_CROSSY_ROAD_HTML)
+    expect(pass.attemptExecution).toBe(true)
+    const fail = prescreenKhalaCodeArtifact(
+      BROKEN_EXTERNAL_ASSET_CROSSY_ROAD_HTML,
+    )
+    expect(fail.attemptExecution).toBe(false)
+    expect(fail.checks.find(c => c.id === 'single_html_file')?.passed).toBe(
+      false,
+    )
+  })
+
+  test('a prescreen-passing artifact that was NOT executed is unverified — NOT test_passed', () => {
     const verdict = verify(GOOD_CROSSY_ROAD_HTML)
 
-    expect(verdict.verified).toBe(true)
+    // This is the core of the honest downgrade: looks fine on paper, but we did not
+    // run it, so we do NOT certify it.
+    expect(verdict.verification).toBe('unverified')
+    expect(verdict.verified).toBe(false)
+    expect(verdict.executed).toBe(false)
+    expect(verdict.scalarReward).toBe(0)
+    expect(verdict.reward.scalar).toBe(0)
+    expect(verdict.prescreen.attemptExecution).toBe(true)
+  })
+
+  test('an artifact that fails the prescreen is failed and not executed', () => {
+    const verdict = verify(BROKEN_EXTERNAL_ASSET_CROSSY_ROAD_HTML)
+    expect(verdict.verification).toBe('failed')
+    expect(verdict.verified).toBe(false)
+    expect(verdict.executed).toBe(false)
+    expect(verdict.scalarReward).toBe(0)
+    expect(verdict.failedChecks).toContain('single_html_file')
+  })
+
+  test('verdict is test_passed only when an EXECUTED acceptance suite fully passed', () => {
+    const verdict = verify(GOOD_CROSSY_ROAD_HTML, executedVerdict(true))
+    expect(verdict.executed).toBe(true)
     expect(verdict.verification).toBe('test_passed')
+    expect(verdict.verified).toBe(true)
     expect(verdict.scalarReward).toBe(1)
     expect(verdict.failedChecks).toEqual([])
-    expect(verdict.receiptRef).toMatch(
-      /^receipt\.inference\.khala_code\.verification\.chatcmpl-fixture\./u,
-    )
     expect(verdict.sourceRefs).toContain(
       'receipt.inference.charge.chatcmpl-fixture',
     )
@@ -63,34 +113,13 @@ describe('Khala code crossy-road verifier', () => {
     )
   })
 
-  test('rejects a deliberately broken control mapping', () => {
-    const verdict = verify(BROKEN_CONTROLS_CROSSY_ROAD_HTML)
-
-    expect(verdict.verified).toBe(false)
+  test('an executed acceptance suite that did not fully pass is failed with a dense reward', () => {
+    const verdict = verify(GOOD_CROSSY_ROAD_HTML, executedVerdict(false))
+    expect(verdict.executed).toBe(true)
     expect(verdict.verification).toBe('failed')
-    expect(verdict.failedChecks).toContain('direction_controls')
+    expect(verdict.verified).toBe(false)
+    expect(verdict.scalarReward).toBeGreaterThan(0)
     expect(verdict.scalarReward).toBeLessThan(1)
-  })
-
-  test('rejects a deliberately broken restart reset', () => {
-    const verdict = verify(BROKEN_RESTART_CROSSY_ROAD_HTML)
-
-    expect(verdict.verified).toBe(false)
-    expect(verdict.failedChecks).toContain('restart_resets_character')
-  })
-
-  test('rejects an artifact that depends on an external script', () => {
-    const verdict = verify(BROKEN_EXTERNAL_ASSET_CROSSY_ROAD_HTML)
-
-    expect(verdict.verified).toBe(false)
-    expect(verdict.failedChecks).toContain('single_html_file')
-    expect(verdict.failedChecks).toContain('direction_controls')
-  })
-
-  test('rejects an artifact without progress-driven difficulty ramping', () => {
-    const verdict = verify(BROKEN_DIFFICULTY_CROSSY_ROAD_HTML)
-
-    expect(verdict.verified).toBe(false)
-    expect(verdict.failedChecks).toContain('difficulty_ramps_with_progress')
+    expect(verdict.failedChecks.length).toBeGreaterThan(0)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/khala-code-verifier.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-code-verifier.ts
@@ -1,11 +1,27 @@
-// Deterministic verifier substrate for the Khala coding lane (#6010).
+// Khala coding-lane verifier substrate (#6010, EPIC #6017).
 //
-// The hot Worker route cannot launch a browser, so this module keeps the
-// request-time gate pure and receipt-shaped while exposing a stable headless
-// command contract for the runner that executes generated HTML artifacts outside
-// the Worker. The current crossy-road rubric is deliberately narrow and fixture
-// backed: one single-file HTML artifact, bounded controls/camera/difficulty/
-// restart checks, and an explicit scalar reward for the later Psion handoff.
+// HONEST DOWNGRADE (docs/inference/2026-06-22-verified-work-must-execute-the-artifact.md):
+// This module USED to return `verification: 'test_passed'` / `verified: true` /
+// `scalarReward: 1` from REGEX over the HTML source — it never ran the artifact. That
+// certified a crossy-road game that crashed on load, had a dead PLAY button, a 100x
+// camera, and stopped generating world. `verified:true` must mean "we ran it and it
+// did what the user asked." So:
+//
+//   - The regex checks remain ONLY as a cheap PRE-SCREEN: a gate to decide whether the
+//     artifact is even worth attempting to execute (is it one self-contained HTML file
+//     with a script + game surface?). They are NOT the verification verdict.
+//   - With no executed-acceptance result, the verdict is `unverified`, `verified:false`,
+//     `scalarReward:0`. Better to say "we didn't run it" than to falsely certify.
+//   - When the out-of-Worker headless acceptance runner (`acceptance-runner/`) HAS run
+//     the artifact, the route passes its `AcceptanceVerdict` in and the verdict is
+//     derived from EXECUTION: `verified` = all acceptance tests passed; `scalarReward` =
+//     fraction passing.
+//
+// The hot Worker route cannot launch a browser, so the actual execution happens out of
+// the Worker (a sandbox / Pylon) via the runner; this module stays pure + receipt-shaped
+// and accepts the runner's verdict.
+
+import type { AcceptanceVerdict } from './acceptance-runner/verdict'
 
 export const KHALA_CODE_CROSSY_ROAD_RUBRIC_REF =
   'rubric.khala_code.crossy_road.single_html.v1'
@@ -15,22 +31,31 @@ export const KHALA_CODE_HEADLESS_COMMAND_REF =
 
 export const KHALA_CODE_VERIFIER_WORKER_ID = 'khala-code-crossy-road-verifier'
 
-export type KhalaCodeVerification = 'test_passed' | 'failed'
+// The verification verdict states. `unverified` is the HONEST default for an
+// executable artifact we have NOT actually run yet (the prescreen passed but no runner
+// executed it). `test_passed` is reserved for an EXECUTED acceptance suite that fully
+// passed. `failed` is an executed suite that did not fully pass, or an artifact that
+// failed the prescreen (not even worth attempting to run).
+export type KhalaCodeVerification = 'test_passed' | 'unverified' | 'failed'
 
-export type KhalaCodeRubricCheckId =
+// The prescreen check ids — a cheap source gate, NOT the verification verdict.
+export type KhalaCodePrescreenCheckId =
   | 'single_html_file'
-  | 'loads_and_runs_headless'
-  | 'direction_controls'
-  | 'sane_follow_camera'
-  | 'difficulty_ramps_with_progress'
-  | 'restart_resets_character'
+  | 'has_runnable_surface'
 
-export type KhalaCodeRubricCheck = Readonly<{
-  id: KhalaCodeRubricCheckId
+export type KhalaCodePrescreenCheck = Readonly<{
+  id: KhalaCodePrescreenCheckId
   label: string
   passed: boolean
-  evidenceRefs: ReadonlyArray<string>
   failureReason?: string | undefined
+}>
+
+export type KhalaCodePrescreen = Readonly<{
+  // Whether the artifact is worth ATTEMPTING to execute (one self-contained HTML file
+  // with a script + a game surface). This gates execution; it never verifies behavior.
+  attemptExecution: boolean
+  checks: ReadonlyArray<KhalaCodePrescreenCheck>
+  html: string | undefined
 }>
 
 export type KhalaCodeVerificationCommand = Readonly<{
@@ -46,16 +71,20 @@ export type KhalaCodeVerificationVerdict = Readonly<{
     fingerprint: string
     kind: 'single_html'
   }>
-  checks: ReadonlyArray<KhalaCodeRubricCheck>
+  // The cheap source pre-screen (gate-to-attempt only).
+  prescreen: KhalaCodePrescreen
   command: KhalaCodeVerificationCommand
-  failedChecks: ReadonlyArray<KhalaCodeRubricCheckId>
-  passedChecks: ReadonlyArray<KhalaCodeRubricCheckId>
+  // Per-acceptance-check ids when an executed suite ran; otherwise empty.
+  failedChecks: ReadonlyArray<string>
+  passedChecks: ReadonlyArray<string>
+  // Whether a real headless acceptance run produced this verdict.
+  executed: boolean
   receiptRef: string
   reward: Readonly<{
     handoffRef: string
     scalar: number
   }>
-  rubricRef: typeof KHALA_CODE_CROSSY_ROAD_RUBRIC_REF
+  rubricRef: string
   scalarReward: number
   sourceRefs: ReadonlyArray<string>
   summary: string
@@ -69,40 +98,11 @@ export type KhalaCodeVerifierInput = Readonly<{
   requestId: string
   servedModel: string
   worker: string
+  // The executed-acceptance verdict from the out-of-Worker headless runner, when
+  // available. PRESENT => the verdict is derived from EXECUTION. ABSENT => honest
+  // downgrade to `unverified` (we did not run it).
+  acceptance?: AcceptanceVerdict | undefined
 }>
-
-const CHECK_LABELS: Readonly<Record<KhalaCodeRubricCheckId, string>> = {
-  direction_controls:
-    'Arrow/WASD direction controls are wired to character movement.',
-  difficulty_ramps_with_progress:
-    'Difficulty or traffic speed ramps as score/progress increases.',
-  loads_and_runs_headless:
-    'The artifact has a runnable game surface and animation/update loop.',
-  restart_resets_character:
-    'Restart/reset places the character back at the starting position.',
-  sane_follow_camera:
-    'The camera or viewport follows the character with explicit framing.',
-  single_html_file: 'The delivered artifact is one self-contained HTML file.',
-}
-
-const check = (
-  id: KhalaCodeRubricCheckId,
-  passed: boolean,
-  evidenceRefs: ReadonlyArray<string>,
-  failureReason: string,
-): KhalaCodeRubricCheck => ({
-  id,
-  label: CHECK_LABELS[id],
-  passed,
-  evidenceRefs,
-  ...(passed ? {} : { failureReason }),
-})
-
-const includesAll = (value: string, needles: ReadonlyArray<string>): boolean =>
-  needles.every(needle => value.includes(needle.toLowerCase()))
-
-const hasAny = (value: string, patterns: ReadonlyArray<RegExp>): boolean =>
-  patterns.some(pattern => pattern.test(value))
 
 const externalAssetPattern =
   /<(?:script|link|img|audio|video)\b[^>]*(?:src|href)\s*=\s*["'](?:https?:)?\/\//iu
@@ -165,26 +165,15 @@ export const discoverKhalaCodeVerificationCommand =
     target: 'crossy-road-single-html',
   })
 
-export const verifyKhalaCodeCompletion = (
-  input: KhalaCodeVerifierInput,
-): KhalaCodeVerificationVerdict => {
-  const html = extractSingleHtmlArtifact(input.content)
-  const artifactText = html ?? input.content.trim()
+// CHEAP PRE-SCREEN ONLY. Decides whether an artifact is worth ATTEMPTING to execute:
+// is it one self-contained HTML file with a script + a plausible game surface and no
+// obvious fatal marker? This NEVER verifies behavior — it only gates execution.
+export const prescreenKhalaCodeArtifact = (
+  content: string,
+): KhalaCodePrescreen => {
+  const html = extractSingleHtmlArtifact(content)
+  const artifactText = html ?? content.trim()
   const lower = artifactText.toLowerCase()
-  const difficultyBlock =
-    /function\s+(?:rampDifficulty|updateDifficulty|increaseDifficulty)\s*\([^)]*\)\s*\{([\s\S]*?)\}/iu
-      .exec(artifactText)?.[1]
-      ?.toLowerCase() ?? lower
-  const restartBlock =
-    /function\s+(?:restartGame|restart|resetGame|startOver)\s*\([^)]*\)\s*\{([\s\S]*?)\}/iu
-      .exec(artifactText)?.[1]
-      ?.toLowerCase() ?? lower
-  const fingerprint = stableFingerprint(artifactText)
-  const evidencePrefix = `artifact:${fingerprint}`
-  const receiptRef = khalaCodeVerificationReceiptRef({
-    artifactFingerprint: fingerprint,
-    requestId: input.requestId,
-  })
 
   const hasSingleHtml =
     html !== undefined &&
@@ -194,115 +183,109 @@ export const verifyKhalaCodeCompletion = (
     !scriptSrcPattern.test(html) &&
     !linkedStylesheetPattern.test(html)
 
-  const loadsAndRuns =
+  const hasRunnableSurface =
     hasSingleHtml &&
     /<script\b/iu.test(artifactText) &&
-    hasAny(lower, [/<canvas\b/iu, /\bid=["']game["']/iu, /\bgame\b/iu]) &&
-    hasAny(lower, [
-      /requestanimationframe/iu,
-      /\bsetinterval\s*\(/iu,
-      /\bfunction\s+(?:loop|tick|update|animate)\b/iu,
-    ]) &&
-    !hasAny(lower, [/throw\s+new\s+error/iu, /todo:\s*not\s+implemented/iu])
+    (/<canvas\b/iu.test(lower) ||
+      /\bid=["']game["']/iu.test(lower) ||
+      /\bgame\b/iu.test(lower)) &&
+    !/throw\s+new\s+error/iu.test(lower) &&
+    !/todo:\s*not\s+implemented/iu.test(lower)
 
-  const hasDirectionControls =
-    includesAll(lower, ['arrowup', 'arrowdown', 'arrowleft', 'arrowright']) &&
-    includesAll(lower, ["'w'", "'a'", "'s'", "'d'"]) &&
-    hasAny(lower, [
-      /addEventListener\s*\(\s*["']keydown/iu,
-      /onkeydown/iu,
-      /keyboard/iu,
-    ]) &&
-    hasAny(lower, [/\bmove\s*\(/iu, /\bdirection\b/iu, /\bturn\b/iu])
-
-  const hasSaneCamera =
-    hasAny(lower, [
-      /\bcamera\b/iu,
-      /\bviewport\b/iu,
-      /\bfollow\b/iu,
-      /\bisometric\b/iu,
-      /\bthird[_ -]?person\b/iu,
-    ]) &&
-    hasAny(lower, [/\blookat\b/iu, /\boffset\b/iu, /\btrack/iu, /\bplayer\b/iu])
-
-  const hasDifficultyRamp =
-    hasAny(lower, [
-      /\bdifficulty\b/iu,
-      /\bspeed\b/iu,
-      /\bspawnrate\b/iu,
-      /\btraffic\b/iu,
-      /\blevel\b/iu,
-    ]) &&
-    hasAny(lower, [/\bprogress\b/iu, /\bscore\b/iu, /\bdistance\b/iu]) &&
-    hasAny(difficultyBlock, [
-      /\bprogress\b/iu,
-      /\bscore\b/iu,
-      /\bdistance\b/iu,
-    ]) &&
-    hasAny(difficultyBlock, [
-      /\+=/iu,
-      /math\.min/iu,
-      /math\.max/iu,
-      /\bdifficulty\s*=/iu,
-      /\bspeed\s*=/iu,
-    ])
-
-  const hasRestartReset =
-    hasAny(lower, [/\brestart/iu, /\bresetgame\b/iu, /\bstartover\b/iu]) &&
-    hasAny(restartBlock, [
-      /\bstart(?:x|y|z|position)\b/iu,
-      /\bspawn(?:x|y|z|position)\b/iu,
-      /\binitial(?:x|y|z|position)\b/iu,
-      /\bplayer\.(?:x|y|z)\s*=\s*0\b/iu,
-    ]) &&
-    hasAny(restartBlock, [/\bprogress\s*=\s*0\b/iu, /\bscore\s*=\s*0\b/iu])
-
-  const checks: ReadonlyArray<KhalaCodeRubricCheck> = [
-    check(
-      'single_html_file',
-      hasSingleHtml,
-      [`${evidencePrefix}:single_html_file`],
-      'Expected one self-contained HTML file with no external script/style/media dependencies.',
-    ),
-    check(
-      'loads_and_runs_headless',
-      loadsAndRuns,
-      [`${evidencePrefix}:headless_load_probe`],
-      'Expected a runnable game surface with an animation/update loop and no obvious fatal marker.',
-    ),
-    check(
-      'direction_controls',
-      hasDirectionControls,
-      [`${evidencePrefix}:keyboard_probe`],
-      'Expected Arrow and WASD direction controls wired through a key handler.',
-    ),
-    check(
-      'sane_follow_camera',
-      hasSaneCamera,
-      [`${evidencePrefix}:camera_probe`],
-      'Expected explicit camera/viewport follow framing for the character.',
-    ),
-    check(
-      'difficulty_ramps_with_progress',
-      hasDifficultyRamp,
-      [`${evidencePrefix}:difficulty_probe`],
-      'Expected difficulty/speed/traffic to update from score, distance, or progress.',
-    ),
-    check(
-      'restart_resets_character',
-      hasRestartReset,
-      [`${evidencePrefix}:restart_probe`],
-      'Expected restart/reset to restore character position and progress or score.',
-    ),
+  const checks: ReadonlyArray<KhalaCodePrescreenCheck> = [
+    {
+      id: 'single_html_file',
+      label: 'The delivered artifact is one self-contained HTML file.',
+      passed: hasSingleHtml,
+      ...(hasSingleHtml
+        ? {}
+        : {
+            failureReason:
+              'Expected one self-contained HTML file with no external script/style/media dependencies.',
+          }),
+    },
+    {
+      id: 'has_runnable_surface',
+      label:
+        'The artifact has a script and a plausible game surface to execute.',
+      passed: hasRunnableSurface,
+      ...(hasRunnableSurface
+        ? {}
+        : {
+            failureReason:
+              'Expected a <script> plus a canvas/game surface and no obvious fatal marker.',
+          }),
+    },
   ]
 
-  const passedChecks = checks.filter(item => item.passed).map(item => item.id)
-  const failedChecks = checks.filter(item => !item.passed).map(item => item.id)
-  const scalarReward = passedChecks.length / checks.length
-  const verified = failedChecks.length === 0
-  const verification: KhalaCodeVerification = verified
-    ? 'test_passed'
-    : 'failed'
+  return {
+    attemptExecution: hasSingleHtml && hasRunnableSurface,
+    checks,
+    html,
+  }
+}
+
+export const verifyKhalaCodeCompletion = (
+  input: KhalaCodeVerifierInput,
+): KhalaCodeVerificationVerdict => {
+  const prescreen = prescreenKhalaCodeArtifact(input.content)
+  const artifactText = prescreen.html ?? input.content.trim()
+  const fingerprint = stableFingerprint(artifactText)
+  const receiptRef = khalaCodeVerificationReceiptRef({
+    artifactFingerprint: fingerprint,
+    requestId: input.requestId,
+  })
+
+  const acceptance = input.acceptance
+
+  // VERDICT DERIVATION.
+  //   - Prescreen failed => `failed` (not even worth running). scalarReward 0.
+  //   - Executed acceptance present => derive from EXECUTION.
+  //   - Otherwise => HONEST DOWNGRADE to `unverified` (we did not run it).
+  let verification: KhalaCodeVerification
+  let verified: boolean
+  let scalarReward: number
+  let executed: boolean
+  let passedChecks: ReadonlyArray<string>
+  let failedChecks: ReadonlyArray<string>
+  let rubricRef: string
+  let summary: string
+
+  if (!prescreen.attemptExecution) {
+    verification = 'failed'
+    verified = false
+    scalarReward = 0
+    executed = false
+    passedChecks = []
+    failedChecks = prescreen.checks
+      .filter(check => !check.passed)
+      .map(check => check.id)
+    rubricRef = KHALA_CODE_CROSSY_ROAD_RUBRIC_REF
+    summary =
+      'Artifact failed the cheap pre-screen (not a runnable single-file HTML game); not executed.'
+  } else if (acceptance !== undefined && acceptance.executed) {
+    verified = acceptance.verified
+    scalarReward = acceptance.scalarReward
+    verification = verified ? 'test_passed' : 'failed'
+    executed = true
+    passedChecks = acceptance.passedChecks
+    failedChecks = acceptance.failedChecks
+    rubricRef = acceptance.rubricRef
+    summary = verified
+      ? 'Crossy-road artifact PASSED every executed acceptance check (ran in a real headless browser).'
+      : `Crossy-road artifact FAILED ${acceptance.failedChecks.length} executed acceptance check(s).`
+  } else {
+    // HONEST DOWNGRADE: prescreen passed, but no execution happened.
+    verification = 'unverified'
+    verified = false
+    scalarReward = 0
+    executed = false
+    passedChecks = []
+    failedChecks = []
+    rubricRef = KHALA_CODE_CROSSY_ROAD_RUBRIC_REF
+    summary =
+      'Artifact passed the pre-screen but was NOT executed; verification is pending the headless acceptance runner. Not certified.'
+  }
 
   return {
     artifact: {
@@ -310,16 +293,17 @@ export const verifyKhalaCodeCompletion = (
       fingerprint,
       kind: 'single_html',
     },
-    checks,
     command: discoverKhalaCodeVerificationCommand(),
+    executed,
     failedChecks,
     passedChecks,
+    prescreen,
     receiptRef,
     reward: {
       handoffRef: khalaCodeAcceptedOutcomeHandoffRef(receiptRef),
       scalar: scalarReward,
     },
-    rubricRef: KHALA_CODE_CROSSY_ROAD_RUBRIC_REF,
+    rubricRef,
     scalarReward,
     sourceRefs: [
       KHALA_CODE_CROSSY_ROAD_RUBRIC_REF,
@@ -332,9 +316,7 @@ export const verifyKhalaCodeCompletion = (
       `model:${input.servedModel}`,
       `worker:${input.worker}`,
     ],
-    summary: verified
-      ? 'Crossy-road single-file HTML artifact passed every deterministic rubric check.'
-      : `Crossy-road artifact failed ${failedChecks.length} deterministic rubric check(s).`,
+    summary,
     verification,
     verified,
   }

--- a/bun.lock
+++ b/bun.lock
@@ -252,6 +252,9 @@
         "nostr-effect": "github:OpenAgentsInc/nostr-effect#4c52847",
         "stripe": "^22.2.0",
       },
+      "devDependencies": {
+        "playwright": "^1.61.0",
+      },
     },
     "apps/pylon": {
       "name": "@openagentsinc/pylon",


### PR DESCRIPTION
## Why

The Khala coding verifier (`khala-code-verifier.ts`) returned `verified:true` / `verification:"test_passed"` / `scalar_reward:1` from **regex over the HTML source -- it never ran the artifact**. It certified a crossy-road game that crashed on load, had a dead PLAY button, a 100x-scaled camera, and stopped generating world after ~10 tiles. This PR makes `verified` mean what it says: **"we ran it and it did what the user asked."**

Refs **EPIC #6017** and the spec doc `docs/inference/2026-06-22-verified-work-must-execute-the-artifact.md`.

## 1. The honest downgrade (stop the false green now)

`verifyKhalaCodeCompletion` no longer produces a green verdict from regex:

- The regex checks are now a cheap **pre-screen only** (`prescreenKhalaCodeArtifact`) -- a gate to decide whether an artifact is even worth *attempting* to execute (one self-contained HTML file with a script + game surface). They are **never** the verification verdict.
- With **no** executed-acceptance result, an executable artifact is `verification:"unverified"`, `verified:false`, `scalarReward:0`. Better to say "we didn't run it" than to falsely certify.
- A pre-screen failure is `failed` (not even worth running).
- `test_passed` / `scalarReward:1` are reserved for an **executed** acceptance suite that fully passed.

Route + receipt wiring updated: the `openagents` receipt gains an `executed` flag and the `unverified` verification state. The hot Worker route (which cannot launch a browser) now honestly returns `unverified` for a prescreen-passing artifact instead of a regex green.

## 2. Headless acceptance runner (`acceptance-runner/`)

Bun + Playwright/chromium, **runs OUT of the CF Worker** -- a standalone module (`runner.ts`) + CLI (`cli.ts`). Given an HTML artifact + an `AcceptanceSpec`, it loads the page in real chromium and runs deterministic tests, emitting a verdict (per-test pass/fail + `scalarReward` = fraction passing):

- **loads_without_errors** -- zero console/page errors (catches *crashed on load*).
- **play_starts_game** -- start overlay hides + loop runs (catches the *dead PLAY button*).
- **forward_input_advances_player** -- a forward press advances the player ~one tile.
- **camera_follow_delta_bounded** -- camera follow delta per move stays under a bound (**catches the 100x camera bug**).
- **world_keeps_generating_ahead** -- world keeps generating ahead for N moves (**catches blue-sky**).
- **restart_resets_state** -- restart resets player + progress.

The route imports only the **pure verdict type** (`acceptance-runner/verdict.ts`), never playwright -- chromium never enters the Worker bundle. Playwright added as a dev dep on the api-worker package (`bunx playwright install chromium`).

## 3. Regression proof (the verifier now means something)

Two committed fixtures: `crossy-road-broken.html.ts` (the exact 4-bug version) and `crossy-road-fixed.html.ts`. `runner.test.ts` asserts the runner:

- **FAILS the broken one, per-test**: a page error is captured on load, PLAY does not start, forward input cannot advance, world does not keep generating -- plus a separate case proving a **measured ~32x camera-delta** blows past the bound.
- **PASSES the fixed one**: every check green, `scalarReward:1`, zero console/page errors.

CLI verified end-to-end: fixed -> exit 0 / `verified:true`; broken -> exit 1 / `verified:false` / `scalarReward ~0.17`.

## 4. Intent -> spec seam

Typed `AcceptanceSpec` + `intentToAcceptanceSpec(request)` in `acceptance-spec.ts` -- concrete for the crossy-road / khala-code lane, with a clear interface to generalize to other prompts later. The route's `verified` / `scalarReward` / `verification_receipt` derive from the runner verdict when one is threaded in.

## What's left for full prod wiring

Async out-of-Worker **sandbox dispatch** of the runner (Pylon / `oa-workroomd`) + receipt backfill, so the live route attaches a real `AcceptanceVerdict` instead of the honest `unverified` default. The seam (`khalaReceiptForResult(... acceptance)`) is already in place.

## Tests

- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/`: **39 files / 479 tests green**, including the new runner suite (real headless chromium).
- `bun run --cwd apps/openagents.com/workers/api typecheck`: clean.
- Note: the broader api-worker suite has **14 pre-existing failures unrelated to this change** (Effect Schema validation-message-format drift in `coding-quick-win-*` / `business-quick-win-*` / `shard-wan` / `ecommerce` / `omni-workroom` / `agent-registration`, and a `docs/live/AGENTS.md` sha256 drift). They are on clean `origin/main`, touch no inference/verifier code, and are out of scope for the verified-work QC lane -- flagged here, not silently absorbed.

**DO NOT auto-merge -- orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)