### PR TITLE
Verse: talk to Khala from an in-world textbox (streamed + local crackling effect)

### DIFF
--- a/apps/autopilot-desktop/src/shared/verse-khala-effect.ts
+++ b/apps/autopilot-desktop/src/shared/verse-khala-effect.ts
@@ -1,0 +1,185 @@
+// Verse Khala in-world effect projection (EPIC #6017 — talk to Khala from a Verse
+// textbox; the audit doc 2026-06-22-talk-to-khala-from-verse-audit.md gap #3).
+//
+// PURE, Three.js-free transform that turns ONE local Khala cockpit turn receipt
+// (the `openagents` block projected by `khalaTurn` — see shared/khala-cockpit.ts)
+// plus the local avatar position into a crackling-arc layer the shared
+// three-effect `trainingRunView` renders IMMEDIATELY, without waiting on the
+// ~5–10s public-activity-timeline poll. The public-timeline projection
+// (chat-world-visualization.ts `chatWorldInferenceLayer`) still fires for other
+// viewers; this is the responsive LOCAL mirror.
+//
+// EVIDENCE-BOUND (the §5 motion contract). The arc only renders when the turn
+// carried a REAL receipt ref. No receipt → no effect. The receipt ref rides on
+// the beam (motion evidence) and on the clickable endpoint entities (click →
+// receipt detail), exactly like the gateway-backed inference layer, so the local
+// arc obeys the same `motionPolicy.evidence = "required"` backstop.
+//
+// This is the LOCAL sibling of `chatWorldInferenceLayer`: same crackling-arc
+// encoding (Khala nexus → avatar), keyed to the receipt instead of a projected
+// world `inference_event` row.
+
+import { verseIconRecipeForId } from "@openagentsinc/three-effect/core"
+import type {
+  TrainingRunBeamDefinition,
+  TrainingRunBurstDefinition,
+  TrainingRunVector,
+  TrainingRunVisualizationOptions,
+} from "@openagentsinc/three-effect/core"
+
+import type { KhalaReceiptProjection } from "./khala-cockpit.js"
+import { isLiveReceipt } from "./khala-cockpit.js"
+import {
+  appendVerseVisualization,
+  roundedVerseVector,
+} from "./verse-scene-helpers.js"
+import type { ChatWorldVisualEntityDefinition } from "./chat-world-visualization.js"
+
+// Stable scene-node prefix for the local Khala effect endpoints, distinct from
+// the world-projection inference prefix so a local arc and the later public-
+// timeline arc never collide on id.
+export const VERSE_KHALA_NEXUS_NODE_ID = "verse:khala:nexus"
+export const VERSE_KHALA_EFFECT_NODE_PREFIX = "verse:khala:effect:"
+
+// Where the local Khala nexus sits in the scene when we have no projected world
+// nexus position. Above the play space so the arc reads as energy coming down to
+// the avatar. Tuned here, not in the renderer.
+const DEFAULT_NEXUS_POSITION: TrainingRunVector = roundedVerseVector([0, 1.85, 0.6])
+
+// A tiny upward offset so the arc terminates at the avatar's torso, not its feet.
+const AVATAR_ARC_HEIGHT_OFFSET = 1.1
+
+// The local avatar anchor (the user's character) the arc terminates at.
+export type VerseKhalaAvatarAnchor = Readonly<{
+  x: number
+  y: number
+  z: number
+}>
+
+// One local Khala turn's effect input: the receipt projection (the evidence) and
+// the avatar anchor (where the arc lands). `generatedAt` lets the renderer derive
+// motion timing; the effect key is the receipt ref.
+export type VerseKhalaEffectInput = Readonly<{
+  receipt: KhalaReceiptProjection | null
+  avatar: VerseKhalaAvatarAnchor | null
+  generatedAt?: string
+}>
+
+export type VerseKhalaEffectLayer = Readonly<{
+  entities: ReadonlyArray<ChatWorldVisualEntityDefinition>
+  beams: ReadonlyArray<TrainingRunBeamDefinition>
+  bursts: ReadonlyArray<TrainingRunBurstDefinition>
+}>
+
+const EMPTY_LAYER: VerseKhalaEffectLayer = { entities: [], beams: [], bursts: [] }
+
+const finite = (value: number): boolean =>
+  Number.isFinite(value) && !Number.isNaN(value)
+
+const avatarVector = (
+  anchor: VerseKhalaAvatarAnchor | null,
+): TrainingRunVector | null => {
+  if (anchor === null) return null
+  if (!finite(anchor.x) || !finite(anchor.y) || !finite(anchor.z)) return null
+  return roundedVerseVector([anchor.x, anchor.y + AVATAR_ARC_HEIGHT_OFFSET, anchor.z])
+}
+
+// The verification class maps to the same scene status language the world
+// inference layer uses: a verified Khala turn glows gold-family ("verified"),
+// a failed one reads "blocked", anything else is a live but unverified "active".
+const receiptStatus = (receipt: KhalaReceiptProjection): string => {
+  if (receipt.verification === "failed") return "blocked"
+  if (receipt.verification === "test_passed") return "verified"
+  return "active"
+}
+
+// Build the evidence-bound local crackling-arc layer for ONE Khala turn. Returns
+// an empty layer (no motion) unless the turn carried a REAL receipt ref — the
+// evidence gate. The avatar anchor is required to land the arc; without it we
+// fall back to a fixed point near the nexus so the energy is still visible.
+export const verseKhalaEffectLayer = (
+  input: VerseKhalaEffectInput,
+): VerseKhalaEffectLayer => {
+  const receipt = input.receipt
+  // EVIDENCE GATE: only animate with a real receipt ref (audit §5; the same gate
+  // as the cockpit "live" badge — isLiveReceipt).
+  if (receipt === null || !isLiveReceipt(receipt) || receipt.receipt === null) {
+    return EMPTY_LAYER
+  }
+  const receiptRef = receipt.receipt
+
+  const avatar =
+    avatarVector(input.avatar) ?? roundedVerseVector([0.0, 0.6, 1.2])
+
+  const status = receiptStatus(receipt)
+  const fromId = VERSE_KHALA_NEXUS_NODE_ID
+  const toId = `${VERSE_KHALA_EFFECT_NODE_PREFIX}${receiptRef}`
+
+  const servedLabel =
+    receipt.servedModel.trim().length > 0 ? receipt.servedModel : "Khala"
+  const verifiedDetail =
+    receipt.verification === "test_passed"
+      ? "verified (tests passed)"
+      : receipt.verification === "failed"
+        ? "verification failed"
+        : "not verified"
+
+  const entities: ChatWorldVisualEntityDefinition[] = [
+    {
+      id: fromId,
+      label: "Khala",
+      detail: `${receiptRef} · ${receipt.requestedModel || "openagents/khala"} · ${receipt.lane} lane`,
+      status,
+      position: DEFAULT_NEXUS_POSITION,
+      iconRecipe: verseIconRecipeForId("khala:nexus"),
+    },
+    {
+      id: toId,
+      label: "You",
+      detail: `${receiptRef} · ${servedLabel} · ${verifiedDetail}`,
+      status,
+      position: avatar,
+      iconRecipe: verseIconRecipeForId(receiptRef),
+    },
+  ]
+
+  const evidence = {
+    motionId: `verse-khala:${receiptRef}`,
+    motionKind: "khala_in_world_inference",
+    sourceRefs: [receiptRef],
+    ...(input.generatedAt === undefined ? {} : { generatedAt: input.generatedAt }),
+    // A real local turn against the live gateway — never a labelled simulation.
+    simulated: false,
+  } as const
+
+  const beams: TrainingRunBeamDefinition[] = [
+    { fromId, toId, style: "crackling_arc", ...evidence },
+  ]
+  // A settlement-style burst at the avatar only when the turn actually verified.
+  const bursts: TrainingRunBurstDefinition[] =
+    receipt.verification === "test_passed"
+      ? [{ atId: toId, ...evidence }]
+      : []
+
+  return { entities, beams, bursts }
+}
+
+// Overlay the local Khala crackling-arc layer onto the base visualization. Forces
+// `motionPolicy.evidence = "required"` so the renderer animates the arc ONLY when
+// it carries the receipt ref — the same hard backstop as the payment/inference
+// layers. A no-receipt input adds nothing (no motion, no entities).
+export const withVerseKhalaEffectLayer = (
+  base: TrainingRunVisualizationOptions,
+  input: VerseKhalaEffectInput,
+): TrainingRunVisualizationOptions => {
+  const layer = verseKhalaEffectLayer(input)
+  if (layer.entities.length === 0) return base
+  return {
+    ...appendVerseVisualization(base, {
+      entities: layer.entities,
+      beams: layer.beams,
+      bursts: layer.bursts,
+    }),
+    motionPolicy: { ...(base.motionPolicy ?? {}), evidence: "required" },
+  }
+}

--- a/apps/autopilot-desktop/src/ui/bridge.ts
+++ b/apps/autopilot-desktop/src/ui/bridge.ts
@@ -25,6 +25,7 @@ import type {
   ChooseIdentityParams,
   ChooseIdentityResponse,
   IdentityChoiceStateResponse,
+  KhalaTurnResponse,
   ManagedAccountMutationResponse,
   ManagedAccountsResponse,
   OnboardingStatusResponse,
@@ -80,6 +81,15 @@ export type DesktopRequests = {
   shellTurn(p: { prompt: string }): Promise<ShellTurnResponse>
   // Verse/Tassadar first-paint chat turn.
   verseTurn(p: { prompt: string }): Promise<VerseTurnResponse>
+  // EPIC #6017: one streamed Khala cockpit turn from the in-world Verse textbox.
+  // Bun owns the agent token; the webview sends the prompt + model + turnId and
+  // receives the terminal answer + public-safe receipt. Live token deltas arrive
+  // separately on the `khalaToken` Bun→webview push (correlated by turnId).
+  khalaTurn(p: {
+    prompt: string
+    model?: "openagents/khala-mini" | "openagents/khala-code"
+    turnId?: string
+  }): Promise<KhalaTurnResponse>
   installReadiness(
     p: Record<string, never>,
   ): Promise<InstallReadinessResponse>

--- a/apps/autopilot-desktop/src/ui/commands.ts
+++ b/apps/autopilot-desktop/src/ui/commands.ts
@@ -80,6 +80,8 @@ import {
   GotPublicActivityTimeline,
   FailedVerseTurn,
   RespondedShell,
+  RespondedVerseKhala,
+  FailedVerseKhala,
 } from "./message.js"
 
 const errorText = commandErrorText
@@ -1435,6 +1437,51 @@ export const RespondToVerseInput = Command.define(
       Effect.succeed(
         FailedVerseTurn({
           error: errorText(error) || VERSE_BRIDGE_ERROR_TEXT,
+        }),
+      ),
+    ),
+  ),
+)
+
+// EPIC #6017: one streamed Khala cockpit turn from the IN-WORLD Verse textbox.
+// Reuses the existing `khalaTurn` RPC + host-side token resolution UNCHANGED
+// (the gateway/verifier are owned by another lane). The `turnId` correlates the
+// live `khalaToken` deltas (pushed Bun→webview, landed as GotVerseKhalaToken) to
+// this turn so concurrent/stale turns never cross-render. The terminal answer +
+// the public-safe receipt ride on this command's result; the receipt's ref is the
+// evidence gate that drives the LOCAL crackling-arc effect. The Bun host returns
+// honest user-facing `text` for ok:false too (402 add-credit / no token / error),
+// so we render it verbatim; FailedVerseKhala only fires if the RPC bridge throws.
+const VERSE_KHALA_BRIDGE_ERROR_TEXT =
+  "I couldn't reach the local app service to talk to Khala. Please try again in a moment."
+
+export const RunVerseKhalaTurn = Command.define(
+  "RunVerseKhalaTurn",
+  { prompt: S.String, turnId: S.String },
+  RespondedVerseKhala,
+  FailedVerseKhala,
+)(({ prompt, turnId }) =>
+  Effect.tryPromise(() =>
+    getRequest().khalaTurn({
+      prompt,
+      model: "openagents/khala-mini",
+      turnId,
+    }),
+  ).pipe(
+    Effect.map((result) =>
+      RespondedVerseKhala({
+        turnId,
+        ok: result.ok,
+        text: result.text,
+        receipt: result.receipt,
+        live: result.live,
+      }),
+    ),
+    Effect.catch((error) =>
+      Effect.succeed(
+        FailedVerseKhala({
+          turnId,
+          error: errorText(error) || VERSE_KHALA_BRIDGE_ERROR_TEXT,
         }),
       ),
     ),

--- a/apps/autopilot-desktop/src/ui/main.ts
+++ b/apps/autopilot-desktop/src/ui/main.ts
@@ -32,6 +32,7 @@ import {
   GotNodeState,
   GotNotifications,
   GotPylonStats,
+  GotVerseKhalaToken,
   NavigatedTo,
   OpenedManagedPane,
   SelectedComposerAccount,
@@ -153,6 +154,14 @@ const rpc = Electroview.defineRPC<DesktopRPCSchema>({
         } else {
           pushInbound(SubmittedShell())
         }
+      },
+      // EPIC #6017: live Khala token deltas for the in-world Verse textbox. The
+      // Bun host consumes the SSE stream and pushes each content delta here
+      // (turnId-correlated); the reducer appends it to the active response bubble.
+      khalaToken(message) {
+        pushInbound(
+          GotVerseKhalaToken({ turnId: message.turnId, delta: message.delta }),
+        )
       },
     },
   },

--- a/apps/autopilot-desktop/src/ui/message.ts
+++ b/apps/autopilot-desktop/src/ui/message.ts
@@ -677,6 +677,36 @@ export const FailedShellCodingTurn = m("FailedShellCodingTurn", {
 export const OpenedPanes = m("OpenedPanes")
 export const ClosedPanes = m("ClosedPanes")
 
+// ── EPIC #6017: talk to Khala from an in-world Verse textbox ────────────────
+// `ChangedVerseKhalaInput` tracks the in-world input bar; `SubmittedVerseKhala`
+// fires the streamed `khalaTurn` (turnId-correlated); `GotVerseKhalaToken` lands
+// each live `khalaToken` delta (pushed Bun→webview, routed through the inbound
+// stream like shellControl); `RespondedVerseKhala` lands the terminal turn result
+// (the final answer + the public-safe receipt that drives the LOCAL crackling
+// effect). `FailedVerseKhala` lands an honest bridge-error message. The receipt
+// is the evidence gate: a real receipt ref drives the arc, no ref = no effect.
+export const ChangedVerseKhalaInput = m("ChangedVerseKhalaInput", {
+  value: S.String,
+})
+export const SubmittedVerseKhala = m("SubmittedVerseKhala")
+export const GotVerseKhalaToken = m("GotVerseKhalaToken", {
+  turnId: S.String,
+  delta: S.String,
+})
+export const RespondedVerseKhala = m("RespondedVerseKhala", {
+  turnId: S.String,
+  ok: S.Boolean,
+  text: S.String,
+  // The public-safe receipt projection (opaque struct; read via the typed model
+  // accessor). Null when the turn carried no `openagents` block — then no effect.
+  receipt: S.NullOr(S.Unknown),
+  live: S.Boolean,
+})
+export const FailedVerseKhala = m("FailedVerseKhala", {
+  turnId: S.String,
+  error: S.String,
+})
+
 // ── HUD H3: the managed pane layer (#5501) ──────────────────────────────────
 // Open/close/focus a managed pane (pane-as-data) + the drag/resize gesture
 // verbs. Each maps to one `PaneLayerAction` in update.ts (the pure PaneManager
@@ -897,6 +927,11 @@ export const Message = S.Union([
   RespondedShell,
   SucceededShellCodingTurn,
   FailedShellCodingTurn,
+  ChangedVerseKhalaInput,
+  SubmittedVerseKhala,
+  GotVerseKhalaToken,
+  RespondedVerseKhala,
+  FailedVerseKhala,
   OpenedPanes,
   ClosedPanes,
   OpenedManagedPane,

--- a/apps/autopilot-desktop/src/ui/model.ts
+++ b/apps/autopilot-desktop/src/ui/model.ts
@@ -42,6 +42,7 @@ import type {
   PaymentParticle,
 } from "../shared/chat-world-scene.js"
 import type { ChatWorldMultiplayerProjection } from "../shared/chat-world-multiplayer.js"
+import type { KhalaReceiptProjection } from "../shared/khala-cockpit.js"
 import type { DesktopProofReplayProjection } from "../shared/proof-replays.js"
 import {
   DEFAULT_DESKTOP_PROOF_REPLAY_SLUG as DefaultDesktopProofReplaySlug,
@@ -196,6 +197,24 @@ export const ChatStatus = S.Struct({
   tone: S.Literals(["error", "info", "success", "idle"]),
 })
 export type ChatStatus = typeof ChatStatus.Type
+
+// EPIC #6017: the public-safe Khala receipt projection kept in the model so the
+// in-world textbox can drive the LOCAL crackling-arc effect (evidence-bound) the
+// instant the turn returns, and the receipt inspector line can render. Mirrors
+// `KhalaReceiptProjection` (shared/khala-cockpit.ts) as an Effect Schema struct so
+// it can live in the serializable Foldkit model. The `receipt` ref is the LIVE/
+// effect gate — null ref ⇒ no effect.
+export const VerseKhalaReceipt = S.Struct({
+  requestedModel: S.String,
+  servedModel: S.String,
+  worker: S.String,
+  lane: S.String,
+  verification: S.Literals(["none", "test_passed", "failed"]),
+  verified: S.NullOr(S.Boolean),
+  receipt: S.NullOr(S.String),
+  receiptUrl: S.NullOr(S.String),
+})
+export type VerseKhalaReceipt = typeof VerseKhalaReceipt.Type
 
 export const ChatStepStatus = S.Literals([
   "pending",
@@ -613,6 +632,22 @@ export const Model = ts("AutopilotDesktop", {
   chatPending: S.Boolean,
   chatSessionRef: S.NullOr(S.String),
 
+  // EPIC #6017: talk to Khala from an in-world Verse textbox. `verseKhalaInput`
+  // is the in-world input bar; `verseKhalaResponse` is the live response bubble
+  // text (appended token-by-token as `khalaToken` deltas arrive); `verseKhalaTurnId`
+  // correlates the active streaming turn to its token push; `verseKhalaInFlight`
+  // gates the input while a turn is live; `verseKhalaStatus` carries the honest
+  // state (info/error, e.g. 402 add-credit); `verseKhalaReceipt` is the public-safe
+  // receipt that drives the LOCAL crackling-arc effect (null = no effect, evidence-
+  // bound). These are desktop-only Verse fields; the cockpit RPC + token resolution
+  // are reused unchanged.
+  verseKhalaInput: S.String,
+  verseKhalaResponse: S.String,
+  verseKhalaTurnId: S.NullOr(S.String),
+  verseKhalaInFlight: S.Boolean,
+  verseKhalaStatus: ChatStatus,
+  verseKhalaReceipt: S.NullOr(VerseKhalaReceipt),
+
   // CS-A1: account-management surface state (add/select/priority over the
   // node's local dev.accounts config). `managedAccounts` holds the last
   // ManagedAccountsResponse projection (opaque, read via the typed accessor);
@@ -792,6 +827,28 @@ export const modelCodeModeSync = (
 
 export const modelPylonStats = (model: Model): PylonStatsSnapshot | null =>
   model.pylonStats as PylonStatsSnapshot | null
+
+// EPIC #6017: project the model's serializable Khala receipt into the
+// `KhalaReceiptProjection` shape the local effect mapper / cockpit summarizer
+// consume. The model struct omits `rubric` (only the routing/verification fields
+// the effect needs are persisted); we add `rubric: null` so the shape matches.
+export const modelVerseKhalaReceipt = (
+  model: Model,
+): KhalaReceiptProjection | null => {
+  const receipt = model.verseKhalaReceipt
+  if (receipt === null) return null
+  return {
+    requestedModel: receipt.requestedModel,
+    servedModel: receipt.servedModel,
+    worker: receipt.worker,
+    lane: receipt.lane,
+    verification: receipt.verification,
+    verified: receipt.verified,
+    receipt: receipt.receipt,
+    receiptUrl: receipt.receiptUrl,
+    rubric: null,
+  }
+}
 
 // #5730: typed read boundary for the opaque chat-world state.
 export const modelChatWorldScene = (
@@ -1180,6 +1237,12 @@ export const initialModel: Model = Model.make({
   chatStatus: { text: "", tone: "idle" },
   chatPending: false,
   chatSessionRef: null,
+  verseKhalaInput: "",
+  verseKhalaResponse: "",
+  verseKhalaTurnId: null,
+  verseKhalaInFlight: false,
+  verseKhalaStatus: { text: "", tone: "idle" },
+  verseKhalaReceipt: null,
   managedAccounts: null,
   codeModeSync: null,
   managedAccountsPending: false,

--- a/apps/autopilot-desktop/src/ui/styles.css
+++ b/apps/autopilot-desktop/src/ui/styles.css
@@ -3178,3 +3178,137 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* EPIC #6017: the in-world Khala textbox overlay (HUD over the Verse scene). */
+.verse-khala-overlay {
+  position: absolute;
+  bottom: clamp(0.9rem, 3vh, 1.8rem);
+  left: 50%;
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  gap: 0.42rem;
+  width: min(34rem, calc(100% - 2rem));
+  transform: translateX(-50%);
+  /* The panel itself is click-through except the interactive children below,
+     so it never blocks walking/clicking in the scene around the input. */
+  pointer-events: none;
+}
+
+.verse-khala-bubble {
+  align-self: stretch;
+  max-height: 38vh;
+  overflow-y: auto;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid rgb(120 180 255 / 0.28);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgb(10 16 26 / 0.74), rgb(4 8 14 / 0.66));
+  box-shadow:
+    0 14px 42px rgb(0 0 0 / 0.34),
+    inset 0 0 0 1px rgb(120 180 255 / 0.06);
+  color: rgb(244 247 251 / 0.95);
+  pointer-events: auto;
+}
+
+.verse-khala-bubble[data-verse-khala-bubble="streaming"] {
+  border-color: rgb(120 180 255 / 0.5);
+}
+
+.verse-khala-bubble-speaker {
+  display: block;
+  margin-bottom: 0.2rem;
+  color: color-mix(in srgb, #8fd0ff 70%, #fff);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.verse-khala-bubble-body {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.42;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.verse-khala-receipt {
+  margin: 0;
+  padding: 0 0.2rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  line-height: 1.3;
+  pointer-events: auto;
+}
+
+.verse-khala-receipt-live {
+  color: color-mix(in srgb, var(--accent, #f5b73a) 78%, #fff);
+}
+
+.verse-khala-receipt-none {
+  color: rgb(255 255 255 / 0.5);
+}
+
+.verse-khala-status {
+  margin: 0;
+  padding: 0 0.2rem;
+  font-size: 0.74rem;
+  line-height: 1.3;
+  pointer-events: auto;
+}
+
+.verse-khala-status-info {
+  color: rgb(150 200 255 / 0.85);
+}
+
+.verse-khala-status-success {
+  color: color-mix(in srgb, var(--accent, #f5b73a) 80%, #fff);
+}
+
+.verse-khala-status-error {
+  color: rgb(255 150 150 / 0.92);
+}
+
+.verse-khala-bar {
+  display: flex;
+  gap: 0.45rem;
+  align-items: stretch;
+  pointer-events: auto;
+}
+
+.verse-khala-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.5rem 0.72rem;
+  border: 1px solid rgb(120 180 255 / 0.34);
+  border-radius: 8px;
+  background: rgb(6 10 16 / 0.78);
+  color: rgb(244 247 251 / 0.96);
+  font-size: 0.92rem;
+}
+
+.verse-khala-input:focus {
+  border-color: rgb(120 180 255 / 0.62);
+  outline: none;
+}
+
+.verse-khala-send {
+  flex: 0 0 auto;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid rgb(120 180 255 / 0.34);
+  border-radius: 8px;
+  background: rgb(18 40 66 / 0.92);
+  color: rgb(244 247 251 / 0.96);
+  font-size: 0.86rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.verse-khala-send:hover:not(:disabled) {
+  border-color: rgb(120 180 255 / 0.62);
+}
+
+.verse-khala-send:disabled {
+  cursor: default;
+  opacity: 0.55;
+}

--- a/apps/autopilot-desktop/src/ui/update.ts
+++ b/apps/autopilot-desktop/src/ui/update.ts
@@ -44,6 +44,7 @@ import {
   RequestTrainingBootstrapGrant,
   RespondToVerseInput,
   RespondToShellInput,
+  RunVerseKhalaTurn,
   ResolveApproval,
   ResolveManagedWorktree,
   SetCoordinatorPaused,
@@ -135,6 +136,7 @@ import {
   type ProofReplayCommandRequest,
   type ShellCodingTarget,
   type ShellTarget,
+  type VerseKhalaReceipt,
 } from "./model.js"
 // #5466 (EPIC #5461): live Blueprint chat — SEMANTIC signature routing + runtime
 // step derivation from real session events (replaces the seeded path).
@@ -831,6 +833,35 @@ const chatMessageId = (prefix: string): string =>
   `${prefix}.${Date.now().toString(36)}`
 
 const chatTimestamp = (): string => new Date().toISOString()
+
+// EPIC #6017: coerce the opaque `RespondedVerseKhala.receipt` (a public-safe
+// KhalaReceiptProjection over the RPC) into the serializable VerseKhalaReceipt
+// the model holds. Tolerant: a missing/malformed block (or a turn that carried no
+// `openagents` block) yields null so no effect fires. We persist only the
+// routing/verification fields the effect + inspector need (rubric is dropped).
+const verseKhalaReceiptFromUnknown = (
+  value: unknown,
+): VerseKhalaReceipt | null => {
+  if (typeof value !== "object" || value === null) return null
+  const record = value as Record<string, unknown>
+  const asStr = (v: unknown): string => (typeof v === "string" ? v : "")
+  const asNullableStr = (v: unknown): string | null =>
+    typeof v === "string" && v.trim().length > 0 ? v : null
+  const verification =
+    record.verification === "test_passed" || record.verification === "failed"
+      ? record.verification
+      : "none"
+  return {
+    requestedModel: asStr(record.requestedModel),
+    servedModel: asStr(record.servedModel),
+    worker: asStr(record.worker),
+    lane: asStr(record.lane).length > 0 ? asStr(record.lane) : "default",
+    verification,
+    verified: typeof record.verified === "boolean" ? record.verified : null,
+    receipt: asNullableStr(record.receipt),
+    receiptUrl: asNullableStr(record.receiptUrl),
+  }
+}
 
 // #5466: the objective embeds the SEMANTICALLY-selected signature ref (not a
 // hardcoded one) so the bounded session runs the program the router chose. The
@@ -3765,6 +3796,90 @@ export const update = (model: Model, message: Message): Result => {
         }),
         noCommands,
       ]
+    // ── EPIC #6017: talk to Khala from an in-world Verse textbox ────────────
+    case "ChangedVerseKhalaInput":
+      return [
+        Model.make({ ...model, verseKhalaInput: message.value }),
+        noCommands,
+      ]
+    case "SubmittedVerseKhala": {
+      const prompt = model.verseKhalaInput.trim()
+      // Empty submit / a turn already in flight is a no-op (no error chrome).
+      if (prompt === "" || model.verseKhalaInFlight) return [model, noCommands]
+      const turnId = chatMessageId("verse.khala")
+      return [
+        Model.make({
+          ...model,
+          verseKhalaInput: "",
+          verseKhalaInFlight: true,
+          verseKhalaTurnId: turnId,
+          // Reset the live response bubble + the prior effect; a new turn's
+          // effect only fires on its OWN real receipt (evidence-bound).
+          verseKhalaResponse: "",
+          verseKhalaReceipt: null,
+          verseKhalaStatus: { text: "asking Khala…", tone: "info" },
+        }),
+        [RunVerseKhalaTurn({ prompt, turnId })],
+      ]
+    }
+    case "GotVerseKhalaToken": {
+      // Append the live delta ONLY for the active turn — a stale/concurrent
+      // turn's deltas never cross-render into the current bubble.
+      if (message.turnId !== model.verseKhalaTurnId) return [model, noCommands]
+      return [
+        Model.make({
+          ...model,
+          verseKhalaResponse: model.verseKhalaResponse + message.delta,
+        }),
+        noCommands,
+      ]
+    }
+    case "RespondedVerseKhala": {
+      // Ignore a terminal result for a turn that is no longer the active one.
+      if (message.turnId !== model.verseKhalaTurnId) return [model, noCommands]
+      const receipt = verseKhalaReceiptFromUnknown(message.receipt)
+      return [
+        Model.make({
+          ...model,
+          verseKhalaInFlight: false,
+          // The streamed bubble already holds the live text; fall back to the
+          // terminal text when no deltas streamed (non-streaming route / error).
+          verseKhalaResponse:
+            model.verseKhalaResponse.trim().length > 0
+              ? model.verseKhalaResponse
+              : message.text,
+          // EVIDENCE GATE: keep the receipt only when it carries a real ref so
+          // the LOCAL crackling effect fires for genuine turns only.
+          verseKhalaReceipt:
+            receipt !== null && receipt.receipt !== null ? receipt : null,
+          verseKhalaStatus: {
+            text: message.live
+              ? "Khala answered — verified receipt"
+              : message.ok
+                ? "Khala answered (no receipt — unverified)"
+                : message.text,
+            tone: message.live ? "success" : message.ok ? "info" : "error",
+          },
+        }),
+        noCommands,
+      ]
+    }
+    case "FailedVerseKhala": {
+      if (message.turnId !== model.verseKhalaTurnId) return [model, noCommands]
+      return [
+        Model.make({
+          ...model,
+          verseKhalaInFlight: false,
+          verseKhalaReceipt: null,
+          verseKhalaResponse:
+            model.verseKhalaResponse.trim().length > 0
+              ? model.verseKhalaResponse
+              : message.error,
+          verseKhalaStatus: { text: message.error, tone: "error" },
+        }),
+        noCommands,
+      ]
+    }
     // The explicit open: reveal the KEPT full multi-pane UI behind the advanced
     // Code group. The Verse chat pane is now immersive by default (#5820), so
     // this lands on Composer to make the sidebar/code tools explicit.

--- a/apps/autopilot-desktop/src/ui/verse-khala-input.ts
+++ b/apps/autopilot-desktop/src/ui/verse-khala-input.ts
@@ -1,0 +1,141 @@
+// In-world Khala textbox (EPIC #6017 — talk to Khala from a Verse textbox).
+//
+// A Foldkit HUD surface anchored OVER the rendered 3D Verse scene: a one-line
+// input bar + a live response bubble + a receipt line. The user types a prompt,
+// hits Enter (or Send), and Khala answers — tokens stream into the bubble live,
+// and the LOCAL crackling-arc effect fires from the Khala nexus to the avatar the
+// moment a real receipt lands (driven in view.ts via withVerseKhalaEffectLayer).
+//
+// This is a pure projection of the model's `verseKhala*` fields into Html; the
+// streaming, token resolution, and receipt all live in the Bun host + reducer.
+// Honest states: 402 add-credit / no-token / errors arrive as the response text +
+// an error-toned status (the Bun host never fabricates an answer). No receipt ⇒
+// no effect, and the receipt line says "no receipt — unverified".
+
+import type { Attribute, Html } from "foldkit/html"
+import { html } from "foldkit/html"
+import { Option } from "effect"
+
+import type { Message } from "./message.js"
+import {
+  ChangedVerseKhalaInput,
+  SubmittedVerseKhala,
+} from "./message.js"
+import type { Model } from "./model.js"
+import { modelVerseKhalaReceipt } from "./model.js"
+import { summarizeKhalaReceipt } from "../shared/khala-cockpit.js"
+
+const h = html<Message>()
+const cls = (value: string): Attribute<Message> => h.Class(value)
+
+// The receipt line: a short, public-safe one-liner. With a real receipt it shows
+// the served model / lane / verification / live; with none, "no receipt".
+const verseKhalaReceiptLine = (model: Model): Html => {
+  const receipt = modelVerseKhalaReceipt(model)
+  if (receipt === null && !model.verseKhalaInFlight && model.verseKhalaResponse === "") {
+    return h.empty
+  }
+  const text = summarizeKhalaReceipt(receipt)
+  const tone = receipt !== null && receipt.receipt !== null ? "live" : "none"
+  return h.p(
+    [
+      cls(`verse-khala-receipt verse-khala-receipt-${tone}`),
+      h.DataAttribute("verse-khala-receipt", tone),
+      ...(receipt?.receipt === undefined || receipt?.receipt === null
+        ? []
+        : [h.DataAttribute("verse-khala-receipt-ref", receipt.receipt)]),
+    ],
+    [text],
+  )
+}
+
+// The live response bubble: appends token deltas as they stream in. Hidden until
+// there is something to show (a turn in flight, or a landed response).
+const verseKhalaResponseBubble = (model: Model): Html => {
+  const visible =
+    model.verseKhalaInFlight || model.verseKhalaResponse.trim().length > 0
+  if (!visible) return h.empty
+  const body =
+    model.verseKhalaResponse.trim().length > 0
+      ? model.verseKhalaResponse
+      : "…"
+  return h.div(
+    [
+      cls("verse-khala-bubble"),
+      h.DataAttribute(
+        "verse-khala-bubble",
+        model.verseKhalaInFlight ? "streaming" : "settled",
+      ),
+    ],
+    [
+      h.span([cls("verse-khala-bubble-speaker mono")], ["Khala"]),
+      h.p([cls("verse-khala-bubble-body")], [body]),
+    ],
+  )
+}
+
+// The one-line input bar + Send button. Enter submits (Shift+Enter inserts a
+// newline only in a textarea; this is a single-line input, so Enter always
+// submits). The input stays enabled while a turn is in flight (the reducer
+// no-ops a concurrent submit) so focus is never dropped mid-stream.
+const verseKhalaInputBar = (model: Model): Html =>
+  h.div(
+    [cls("verse-khala-bar"), h.DataAttribute("verse-khala-bar", "ready")],
+    [
+      h.input([
+        cls("verse-khala-input"),
+        h.Type("text"),
+        h.Placeholder("Talk to Khala…"),
+        h.Value(model.verseKhalaInput),
+        h.AriaLabel("Talk to Khala"),
+        h.OnInput((value: string) => ChangedVerseKhalaInput({ value })),
+        h.OnKeyDownPreventDefault((key, mods) =>
+          key === "Enter" && !mods.shiftKey
+            ? Option.some(SubmittedVerseKhala())
+            : Option.none(),
+        ),
+      ]),
+      h.button(
+        [
+          cls("verse-khala-send"),
+          h.Type("button"),
+          h.Disabled(model.verseKhalaInFlight),
+          h.OnClick(SubmittedVerseKhala()),
+        ],
+        // "Ask" (not "Send") — the legacy chat-composer "Send" chrome is
+        // intentionally absent from the Verse first paint (verse-launch-checklist).
+        [model.verseKhalaInFlight ? "Asking…" : "Ask"],
+      ),
+    ],
+  )
+
+// The status line (info/error), including the honest 402 add-credit message that
+// the Bun host returns as the response text + an error tone here.
+const verseKhalaStatusLine = (model: Model): Html => {
+  if (model.verseKhalaStatus.tone === "idle") return h.empty
+  return h.p(
+    [
+      cls(`verse-khala-status verse-khala-status-${model.verseKhalaStatus.tone}`),
+      h.DataAttribute("verse-khala-status", model.verseKhalaStatus.tone),
+    ],
+    [model.verseKhalaStatus.text],
+  )
+}
+
+// The whole in-world Khala overlay panel, anchored over the Verse scene.
+export const verseKhalaInputOverlay = (model: Model): Html =>
+  h.div(
+    [
+      cls("verse-khala-overlay"),
+      h.DataAttribute(
+        "verse-khala-overlay",
+        model.verseKhalaInFlight ? "in-flight" : "idle",
+      ),
+    ],
+    [
+      verseKhalaResponseBubble(model),
+      verseKhalaReceiptLine(model),
+      verseKhalaStatusLine(model),
+      verseKhalaInputBar(model),
+    ],
+  )

--- a/apps/autopilot-desktop/src/ui/view.ts
+++ b/apps/autopilot-desktop/src/ui/view.ts
@@ -96,6 +96,8 @@ import {
   withChatWorldMultiplayerLayer,
   withChatWorldPaymentLayer,
 } from "../shared/chat-world-visualization.js"
+import { withVerseKhalaEffectLayer } from "../shared/verse-khala-effect.js"
+import { verseKhalaInputOverlay } from "./verse-khala-input.js"
 import {
   VERSE_TRAINING_NODE_PREFIX,
   withVerseTrainingLayer,
@@ -402,6 +404,7 @@ import {
   modelChatWorldParticles,
   modelChatWorldMultiplayer,
   modelChatWorldScene,
+  modelVerseKhalaReceipt,
   modelCodeModeSync,
   modelManagedAccounts,
   modelPaneLayer,
@@ -7095,6 +7098,22 @@ export const verseSceneVisualization = (model: Model): TrainingRunVisualizationO
     localAvatarRef: multiplayer?.localAvatarRef ?? CHAT_WORLD_DESKTOP_AVATAR_REF,
   })
   const withInference = withChatWorldInferenceLayer(withWorld, multiplayer)
+  // EPIC #6017: the LOCAL Khala crackling-arc effect, driven directly from the
+  // in-world textbox turn's receipt (evidence-bound; no receipt = no arc), so it
+  // fires immediately rather than waiting on the ~5–10s public-timeline poll. The
+  // arc terminates at the local avatar's last pose; the world projection still
+  // fires the same arc for other viewers via withChatWorldInferenceLayer above.
+  const withKhalaEffect = withVerseKhalaEffectLayer(withInference, {
+    receipt: modelVerseKhalaReceipt(model),
+    avatar:
+      model.verseSceneRestorePose === null
+        ? null
+        : {
+            x: model.verseSceneRestorePose.x,
+            y: model.verseSceneRestorePose.y,
+            z: model.verseSceneRestorePose.z,
+          },
+  })
   const inputBindings = verseInputBindingProjection(
     model.inputProfile,
     model.verseMode === "code" ? "verse_code_overlay" : "verse_explore",
@@ -7114,11 +7133,11 @@ export const verseSceneVisualization = (model: Model): TrainingRunVisualizationO
           capturedAtMs: model.verseSceneRestorePose.capturedAtMs,
         }
   const navigable = {
-    ...withInference,
+    ...withKhalaEffect,
     cameraMode: "perspective_walk" as const,
     controller: "third_person_character" as const,
     keyboardTargeting: {
-      ...(withInference.keyboardTargeting ?? {}),
+      ...(withKhalaEffect.keyboardTargeting ?? {}),
       ...inputBindings.keyboardTargeting,
     },
     thirdPersonController: {
@@ -7131,7 +7150,7 @@ export const verseSceneVisualization = (model: Model): TrainingRunVisualizationO
       gravity: -13.5,
     },
     sceneChrome: {
-      ...(withInference.sceneChrome ?? {}),
+      ...(withKhalaEffect.sceneChrome ?? {}),
       lossPanel: "hidden" as const,
       statusChart: "hidden" as const,
     },
@@ -7490,6 +7509,10 @@ const versePane = (model: Model): Html =>
   h.div([cls("chat-pane chat-pane-world verse-pane")], [
     chatSceneBackground(model),
     verseRunHud(model),
+    // EPIC #6017: the in-world Khala textbox (HUD over the scene). Submitting it
+    // streams a Khala answer into a response bubble and fires the local crackling
+    // effect from verseSceneVisualization once a real receipt lands.
+    verseKhalaInputOverlay(model),
   ])
 
 const compactSessionRef = (ref: string): string => {

--- a/apps/autopilot-desktop/tests/verse-khala-effect.test.ts
+++ b/apps/autopilot-desktop/tests/verse-khala-effect.test.ts
@@ -1,0 +1,312 @@
+// EPIC #6017: talk to Khala from an in-world Verse textbox.
+//
+// Covers the two new, load-bearing pieces with NO node and NO live gateway:
+//   1. the receipt → LOCAL crackling-arc effect mapper (evidence-bound):
+//      a real receipt ref produces a crackling_arc beam Khala-nexus → avatar,
+//      a missing receipt ref produces NOTHING (the §5 motion contract).
+//   2. the in-world textbox → khalaTurn reducer flow: input change, submit
+//      (emits the streamed turn command + flips in-flight), live token append,
+//      the terminal receipt landing (drives the effect), and the honest 402
+//      add-credit state.
+//   3. a render assertion: a model carrying a real receipt makes the Khala
+//      effect nodes + the crackling arc appear in verseSceneVisualization.
+
+import { describe, expect, test } from "bun:test"
+
+import {
+  verseKhalaEffectLayer,
+  withVerseKhalaEffectLayer,
+  VERSE_KHALA_NEXUS_NODE_ID,
+  VERSE_KHALA_EFFECT_NODE_PREFIX,
+} from "../src/shared/verse-khala-effect"
+import type { KhalaReceiptProjection } from "../src/shared/khala-cockpit"
+import { initialModel, Model } from "../src/ui/model"
+import { update } from "../src/ui/update"
+import { verseSceneVisualization } from "../src/ui/view"
+import {
+  ChangedVerseKhalaInput,
+  SubmittedVerseKhala,
+  GotVerseKhalaToken,
+  RespondedVerseKhala,
+  FailedVerseKhala,
+} from "../src/ui/message"
+
+const liveReceipt = (
+  overrides: Partial<KhalaReceiptProjection> = {},
+): KhalaReceiptProjection => ({
+  requestedModel: "openagents/khala-mini",
+  servedModel: "khala-mini-served",
+  worker: "pylon.worker.abc",
+  lane: "cheap",
+  verification: "test_passed",
+  verified: true,
+  receipt: "receipt.khala.req_abc123",
+  receiptUrl: "/receipts/req_abc123",
+  rubric: null,
+  ...overrides,
+})
+
+const avatar = { x: 4, y: 0, z: -2 }
+
+describe("verseKhalaEffectLayer (evidence-bound local crackling arc)", () => {
+  test("a real receipt ref produces a crackling_arc beam Khala → avatar", () => {
+    const layer = verseKhalaEffectLayer({
+      receipt: liveReceipt(),
+      avatar,
+      generatedAt: "2026-06-22T00:00:00.000Z",
+    })
+    expect(layer.beams).toHaveLength(1)
+    const beam = layer.beams[0]!
+    expect(beam.style).toBe("crackling_arc")
+    expect(beam.fromId).toBe(VERSE_KHALA_NEXUS_NODE_ID)
+    expect(beam.toId).toBe(
+      `${VERSE_KHALA_EFFECT_NODE_PREFIX}receipt.khala.req_abc123`,
+    )
+    // The receipt ref is the motion evidence (the §5 contract).
+    expect(beam.sourceRefs).toEqual(["receipt.khala.req_abc123"])
+    expect(beam.simulated).toBe(false)
+    // Two endpoint entities (nexus + avatar) carry the receipt for the inspector.
+    expect(layer.entities).toHaveLength(2)
+    expect(layer.entities.every((e) => e.detail?.includes("receipt.khala.req_abc123"))).toBe(true)
+    // A verified turn bursts at the avatar.
+    expect(layer.bursts).toHaveLength(1)
+  })
+
+  test("NO receipt ref ⇒ no motion (the evidence gate)", () => {
+    const noRef = verseKhalaEffectLayer({
+      receipt: liveReceipt({ receipt: null }),
+      avatar,
+    })
+    expect(noRef.beams).toHaveLength(0)
+    expect(noRef.entities).toHaveLength(0)
+    expect(noRef.bursts).toHaveLength(0)
+
+    const noReceipt = verseKhalaEffectLayer({ receipt: null, avatar })
+    expect(noReceipt.beams).toHaveLength(0)
+    expect(noReceipt.entities).toHaveLength(0)
+  })
+
+  test("a failed verification arcs but does not burst", () => {
+    const layer = verseKhalaEffectLayer({
+      receipt: liveReceipt({ verification: "failed", verified: false }),
+      avatar,
+    })
+    expect(layer.beams).toHaveLength(1)
+    expect(layer.bursts).toHaveLength(0)
+    expect(layer.entities.every((e) => e.status === "blocked")).toBe(true)
+  })
+
+  test("withVerseKhalaEffectLayer forces evidence:required and is a no-op with no receipt", () => {
+    const base = { nodes: [], entities: [], beams: [], bursts: [] } as never
+    const withReceipt = withVerseKhalaEffectLayer(base, {
+      receipt: liveReceipt(),
+      avatar,
+    })
+    expect(withReceipt.motionPolicy?.evidence).toBe("required")
+    expect((withReceipt.beams ?? []).length).toBe(1)
+
+    const withoutReceipt = withVerseKhalaEffectLayer(base, {
+      receipt: null,
+      avatar,
+    })
+    expect(withoutReceipt).toBe(base)
+  })
+})
+
+describe("in-world Khala textbox → khalaTurn reducer flow (#6017)", () => {
+  test("typing tracks the in-world input bar", () => {
+    const [next] = update(
+      initialModel,
+      ChangedVerseKhalaInput({ value: "build crossy road" }),
+    )
+    expect(next.verseKhalaInput).toBe("build crossy road")
+  })
+
+  test("submit emits a streamed Khala turn command and flips in-flight", () => {
+    const typed = Model.make({
+      ...initialModel,
+      verseKhalaInput: "hello khala",
+    })
+    const [next, commands] = update(typed, SubmittedVerseKhala())
+    expect(next.verseKhalaInFlight).toBe(true)
+    expect(next.verseKhalaInput).toBe("")
+    expect(next.verseKhalaResponse).toBe("")
+    expect(next.verseKhalaReceipt).toBeNull()
+    expect(next.verseKhalaTurnId).not.toBeNull()
+    // One command was scheduled (the RunVerseKhalaTurn turn). It is NOT executed
+    // here — the reducer is pure — so no node/gateway is touched.
+    expect(commands).toHaveLength(1)
+  })
+
+  test("an empty or in-flight submit is a no-op", () => {
+    const [empty, emptyCmds] = update(initialModel, SubmittedVerseKhala())
+    expect(empty.verseKhalaInFlight).toBe(false)
+    expect(emptyCmds).toHaveLength(0)
+
+    const inFlight = Model.make({
+      ...initialModel,
+      verseKhalaInput: "x",
+      verseKhalaInFlight: true,
+      verseKhalaTurnId: "verse.khala.1",
+    })
+    const [stillInFlight, cmds] = update(inFlight, SubmittedVerseKhala())
+    expect(stillInFlight.verseKhalaInput).toBe("x")
+    expect(cmds).toHaveLength(0)
+  })
+
+  test("live tokens append to the active turn's bubble; stale turns are ignored", () => {
+    const active = Model.make({
+      ...initialModel,
+      verseKhalaInFlight: true,
+      verseKhalaTurnId: "verse.khala.active",
+    })
+    const [one] = update(
+      active,
+      GotVerseKhalaToken({ turnId: "verse.khala.active", delta: "Hel" }),
+    )
+    const [two] = update(
+      one,
+      GotVerseKhalaToken({ turnId: "verse.khala.active", delta: "lo" }),
+    )
+    expect(two.verseKhalaResponse).toBe("Hello")
+    // A delta for a different (stale) turn never cross-renders.
+    const [stale] = update(
+      two,
+      GotVerseKhalaToken({ turnId: "verse.khala.other", delta: "XXX" }),
+    )
+    expect(stale.verseKhalaResponse).toBe("Hello")
+  })
+
+  test("the terminal receipt lands, keeps a real receipt, and clears in-flight", () => {
+    const active = Model.make({
+      ...initialModel,
+      verseKhalaInFlight: true,
+      verseKhalaTurnId: "verse.khala.active",
+      verseKhalaResponse: "streamed answer",
+    })
+    const [next] = update(
+      active,
+      RespondedVerseKhala({
+        turnId: "verse.khala.active",
+        ok: true,
+        text: "streamed answer",
+        receipt: liveReceipt(),
+        live: true,
+      }),
+    )
+    expect(next.verseKhalaInFlight).toBe(false)
+    expect(next.verseKhalaReceipt?.receipt).toBe("receipt.khala.req_abc123")
+    expect(next.verseKhalaStatus.tone).toBe("success")
+  })
+
+  test("a no-receipt answer is kept but drives NO effect (unverified)", () => {
+    const active = Model.make({
+      ...initialModel,
+      verseKhalaInFlight: true,
+      verseKhalaTurnId: "verse.khala.active",
+    })
+    const [next] = update(
+      active,
+      RespondedVerseKhala({
+        turnId: "verse.khala.active",
+        ok: true,
+        text: "an answer with no receipt",
+        receipt: liveReceipt({ receipt: null, receiptUrl: null }),
+        live: false,
+      }),
+    )
+    expect(next.verseKhalaReceipt).toBeNull()
+    expect(next.verseKhalaStatus.tone).toBe("info")
+  })
+
+  test("a 402 add-credit answer surfaces as the response text + error tone", () => {
+    // The Bun host returns ok:false with an honest add-credit message as `text`.
+    const active = Model.make({
+      ...initialModel,
+      verseKhalaInFlight: true,
+      verseKhalaTurnId: "verse.khala.active",
+    })
+    const addCredit =
+      "Your credit balance is empty. Add credit at https://openagents.com to keep running Khala."
+    const [next] = update(
+      active,
+      RespondedVerseKhala({
+        turnId: "verse.khala.active",
+        ok: false,
+        text: addCredit,
+        receipt: null,
+        live: false,
+      }),
+    )
+    expect(next.verseKhalaInFlight).toBe(false)
+    expect(next.verseKhalaResponse).toBe(addCredit)
+    expect(next.verseKhalaReceipt).toBeNull()
+    expect(next.verseKhalaStatus.tone).toBe("error")
+    expect(next.verseKhalaStatus.text).toBe(addCredit)
+  })
+
+  test("a bridge failure clears in-flight with an honest error", () => {
+    const active = Model.make({
+      ...initialModel,
+      verseKhalaInFlight: true,
+      verseKhalaTurnId: "verse.khala.active",
+    })
+    const [next] = update(
+      active,
+      FailedVerseKhala({
+        turnId: "verse.khala.active",
+        error: "I couldn't reach the local app service to talk to Khala.",
+      }),
+    )
+    expect(next.verseKhalaInFlight).toBe(false)
+    expect(next.verseKhalaReceipt).toBeNull()
+    expect(next.verseKhalaStatus.tone).toBe("error")
+  })
+})
+
+describe("verseSceneVisualization renders the local Khala arc from a receipt (#6017)", () => {
+  test("a model with a real receipt makes the Khala effect nodes + arc appear", () => {
+    const withReceipt = Model.make({
+      ...initialModel,
+      pane: "chat",
+      verseSceneRestorePose: {
+        regionRef: "world.region.tassadar",
+        x: 4,
+        y: 0,
+        z: -2,
+        yaw: 0,
+        animation: "idle",
+        capturedAtMs: 1,
+      },
+      verseKhalaReceipt: {
+        requestedModel: "openagents/khala-mini",
+        servedModel: "khala-mini-served",
+        worker: "pylon.worker.abc",
+        lane: "cheap",
+        verification: "test_passed",
+        verified: true,
+        receipt: "receipt.khala.req_render",
+        receiptUrl: "/receipts/req_render",
+      },
+    })
+    const visualization = verseSceneVisualization(withReceipt)
+    const entityIds = (visualization.entities ?? []).map((e) => e.id)
+    expect(entityIds).toContain(VERSE_KHALA_NEXUS_NODE_ID)
+    expect(entityIds).toContain(
+      `${VERSE_KHALA_EFFECT_NODE_PREFIX}receipt.khala.req_render`,
+    )
+    const khalaArc = (visualization.beams ?? []).find(
+      (b) => b.fromId === VERSE_KHALA_NEXUS_NODE_ID && b.style === "crackling_arc",
+    )
+    expect(khalaArc).toBeDefined()
+    expect(khalaArc?.sourceRefs).toEqual(["receipt.khala.req_render"])
+    expect(visualization.motionPolicy?.evidence).toBe("required")
+
+    // No receipt ⇒ no Khala effect nodes (evidence-bound).
+    const withoutReceipt = Model.make({ ...withReceipt, verseKhalaReceipt: null })
+    const bare = verseSceneVisualization(withoutReceipt)
+    expect((bare.entities ?? []).map((e) => e.id)).not.toContain(
+      VERSE_KHALA_NEXUS_NODE_ID,
+    )
+  })
+})


### PR DESCRIPTION
## What landed

A user can now type a prompt into a textbox **in the Verse world** and talk to Khala — the streamed answer renders in-world, and a **local crackling-energy effect** fires from the Khala nexus to the user's avatar.

- **In-world textbox** (`apps/autopilot-desktop/src/ui/verse-khala-input.ts`): a Foldkit HUD over the Verse scene — input bar + live response bubble + receipt line + honest status. Mounted in `versePane` (`src/ui/view.ts`).
- **Submit → `khalaTurn`**: `RunVerseKhalaTurn` command calls the existing `khalaTurn` RPC with a generated `turnId` and `model:"openagents/khala-mini"`. The Bun host's existing agent-token resolution is reused unchanged; the token never crosses to the webview. **No change to the gateway or verifier** (owned by another lane).
- **Streamed tokens in-world**: the `khalaToken` Bun→webview push is wired through `main.ts` → `GotVerseKhalaToken` and appended to the active turn's response bubble (turnId-correlated; stale turns are ignored).
- **Immediate local crackling effect from the receipt** (`src/shared/verse-khala-effect.ts`, the main new render wiring): on the `khalaTurn` receipt, `withVerseKhalaEffectLayer` drives a LOCAL `createCracklingArc` beam (Khala nexus → the user's avatar pose) via the same three-effect `style:"crackling_arc"` encoding the M5 inference layer uses — **keyed to the receipt ref, evidence-bound**. Fires immediately, not on the ~5–10s public-timeline poll (which still fires for other viewers).
- **Honest states**: 402 insufficient_credits → the Bun host's clear in-world "add credit at https://openagents.com" message + error tone; **no receipt ⇒ no effect** (evidence-bound), receipt line reads "no receipt — unverified".

## How to see it

```
cd apps/autopilot-desktop && bun run dev
```

Then in the Verse (first paint, explore mode), type into the bottom-center "Talk to Khala…" box and press Enter (or click **Ask**). With a funded agent token the answer streams into the bubble and the crackling arc fires from the Khala nexus to your avatar; the receipt line shows the served model / lane / verified / live.

## Tests

`bun test tests/verse-khala-effect.test.ts` (run from `apps/autopilot-desktop`) — the receipt→effect mapper evidence gate (real ref → crackling arc; no ref → nothing), the textbox→turn reducer flow (input/submit/live-token-append/terminal-receipt/402/error), and a headless render assertion that the effect nodes + crackling arc appear in `verseSceneVisualization` from a receipt (and vanish without one).

All relevant desktop suites green + typecheck clean:
```
bun test tests/verse-khala-effect.test.ts tests/verse-toggle.test.ts tests/verse-launch-checklist.test.ts tests/chat-world-visualization.test.ts tests/chat-world-cloudflare.test.ts tests/chat-world-subscriptions.test.ts tests/khala-cockpit.test.ts tests/verse-turn.test.ts tests/cl-53-foldkit.test.ts tests/cl-53-sanitize.test.ts tests/conformance.test.ts ...
# 238 pass, 0 fail
bun run --cwd apps/autopilot-desktop typecheck   # clean
```
(The full `bun test` includes node/integration tests that hang waiting on a live node — unrelated to this change; the relevant pure suites are all green.)

## Desktop-only vs future web

Desktop MVP: solved — the owner's agent token + credit balance is reused, no per-user flow. A web/multi-user Verse (per-user authenticated identity + their own funded balance) is the larger later piece — out of scope here.

Refs EPIC #6017 + `docs/game/2026-06-22-talk-to-khala-from-verse-audit.md`

**DO NOT auto-merge — orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)