### PR TITLE
Khala QC: async acceptance-verification dispatch (run the runner, backfill the receipt)

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0221_khala_acceptance_verdicts.sql
+++ b/apps/openagents.com/workers/api/migrations/0221_khala_acceptance_verdicts.sql
@@ -1,0 +1,26 @@
+-- Khala acceptance-verification verdict store (EPIC #6017).
+--
+-- The hot gateway path writes the HONEST `unverified` row at completion time for a
+-- khala-code completion with an executable artifact; the out-of-Worker headless
+-- runner posts an executed `AcceptanceVerdict` to the authenticated verdict callback,
+-- which BACKFILLS this row to `test_passed`/`failed`, `verified`, `scalar_reward`, and
+-- per-test results. The public receipt read projects from this row.
+--
+-- This is the EXECUTION verdict (did we run it and did it do what the user asked) —
+-- distinct from the financial `pay_ins` charge ledger (`inference-receipts.ts`).
+CREATE TABLE IF NOT EXISTS khala_acceptance_verdicts (
+    request_id TEXT PRIMARY KEY,
+    verification TEXT NOT NULL,
+    verified INTEGER NOT NULL DEFAULT 0,
+    executed INTEGER NOT NULL DEFAULT 0,
+    scalar_reward REAL NOT NULL DEFAULT 0,
+    rubric_ref TEXT NOT NULL,
+    passed_checks TEXT NOT NULL DEFAULT '[]',
+    failed_checks TEXT NOT NULL DEFAULT '[]',
+    verification_receipt_ref TEXT NOT NULL,
+    version INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_khala_acceptance_verdicts_state
+    ON khala_acceptance_verdicts (verification, updated_at DESC);

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -101,6 +101,17 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // detached/long-running inference execution path. The submit/status/receipt
   // routes stay gated by INFERENCE_GATEWAY_ENABLED independently.
   INFERENCE_BATCH_JOBS_ENABLED?: string | undefined
+  // Async acceptance-verification DISPATCH feature flag (Khala, EPIC #6017).
+  // Default OFF: the gateway does NOT enqueue out-of-Worker verification jobs for
+  // executable khala-code artifacts until a node-side runner host (Pylon /
+  // oa-workroomd sandbox / Cloud Run) is deployed. With this off the honest
+  // `unverified` downgrade stands. Set "true"/"1"/"on" to arm enqueue.
+  KHALA_ACCEPTANCE_DISPATCH_ENABLED?: string | undefined
+  // The runner-callback bearer token. A node-side runner posts its executed
+  // `AcceptanceVerdict` to `/v1/inference/acceptance-verdicts` with this token;
+  // the gateway rejects any verdict that does not present it. Worker secret; never
+  // committed/logged. Absent => the callback is closed (every verdict rejected).
+  ACCEPTANCE_VERDICT_CALLBACK_TOKEN?: string | undefined
   // Cloud primitive scaffold feature flags (EPIC #5510, #5516/#5517). Default
   // OFF: the `/v1/fine_tuning/jobs` and `/v1/sandboxes` routes are inert on the
   // live Worker until those builds land. Set "true"/"1"/"on" to enable. The

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -311,6 +311,11 @@ import {
   handleChatCompletions,
   isInferenceGatewayEnabled,
 } from './inference/chat-completions-routes'
+import {
+  isAcceptanceDispatchEnabled,
+  makeD1KhalaVerificationStore,
+} from './inference/acceptance-dispatch'
+import { handleAcceptanceVerdictCallback } from './inference/acceptance-verdict-callback-routes'
 import { fireworksAdapter } from './inference/fireworks-adapter'
 import { handleGatewayReadiness } from './inference/gateway-readiness-routes'
 import {
@@ -9827,9 +9832,40 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
           db: openAgentsDatabase(env),
           resolveOwnerIdentity,
         }),
+        // ACCEPTANCE-DISPATCH (EPIC #6017): when khala-code produces an executable
+        // artifact, enqueue an out-of-Worker verification job (a node-side runner —
+        // Pylon / sandbox / Cloud Run — runs the headless suite and posts the verdict
+        // back to the callback below, which backfills the receipt). DEFAULT OFF +
+        // UNWIRED: `queue` is left undefined until a runner host is deployed, so even
+        // with the flag on nothing is enqueued. Chromium never runs in the Worker.
+        // Wiring the queue producer here (and the runner host) is the remaining
+        // step to make verified khala-code true in prod.
+        acceptanceDispatch: {
+          enabled: isAcceptanceDispatchEnabled(
+            env.KHALA_ACCEPTANCE_DISPATCH_ENABLED,
+          ),
+          // NEEDS-OWNER: bind a Cloudflare Queue producer + an R2 artifact store
+          // here once a runner host exists. Until then the seam is inert.
+          queue: undefined,
+        },
         registry: inferenceProviderRegistry,
       })
     },
+  },
+  {
+    // Verdict-callback ingest (EPIC #6017). A node-side runner posts its executed
+    // `AcceptanceVerdict` here; the authenticated route backfills the khala-code
+    // verification verdict (`unverified` -> `test_passed`/`failed`). INERT by
+    // default: gated by INFERENCE_GATEWAY_ENABLED AND closed unless
+    // ACCEPTANCE_VERDICT_CALLBACK_TOKEN is configured (every verdict rejected).
+    path: '/v1/inference/acceptance-verdicts',
+    handler: (request, env) =>
+      handleAcceptanceVerdictCallback(request, {
+        callbackToken: env.ACCEPTANCE_VERDICT_CALLBACK_TOKEN,
+        enabled: isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED),
+        nowIso: currentIsoTimestamp,
+        store: makeD1KhalaVerificationStore(openAgentsDatabase(env)),
+      }),
   },
   {
     // Public model catalog (OpenAI-compatible GET /v1/models) for the inference

--- a/apps/openagents.com/workers/api/src/inference/acceptance-dispatch.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-dispatch.test.ts
@@ -1,0 +1,380 @@
+// Full-loop proof for the async acceptance-verification dispatch (EPIC #6017).
+//
+// PROVES THE WHOLE CHAIN against the COMMITTED crossy-road fixtures, end to end:
+//
+//   gateway enqueues a job  ->  node-side harness runs the REAL headless runner
+//   (Playwright/chromium)   ->  posts the verdict to the authenticated callback
+//                           ->  the callback BACKFILLS the verification receipt.
+//
+//   - broken fixture  => verdict `failed` (per-test) => receipt backfilled to
+//                        `failed`, scalarReward < 1.
+//   - fixed fixture   => verdict `test_passed`        => receipt backfilled to
+//                        `test_passed`, verified, scalarReward 1.
+//
+// Plus the unit-level guarantees the loop relies on: enqueue is INERT when the flag
+// is off; the callback REJECTS unauthenticated/forged verdicts; backfill is
+// idempotent. Requires a real headless chromium (Playwright); a single browser is
+// reused across cases.
+//
+// Run with:
+//   bun run --cwd apps/openagents.com/workers/api test -- src/inference/acceptance-dispatch
+//   (chromium installed via `bunx playwright install chromium`)
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { chromium, type Browser } from 'playwright'
+import { Effect } from 'effect'
+
+import {
+  type AcceptanceJobMessage,
+  type AcceptanceJobQueue,
+  authenticateVerdictCallback,
+  backfillVerdictIntoVerification,
+  enqueueAcceptanceJob,
+  isAcceptanceDispatchEnabled,
+  makeInMemoryKhalaVerificationStore,
+} from './acceptance-dispatch'
+import { handleAcceptanceVerdictCallback } from './acceptance-verdict-callback-routes'
+import {
+  type RunnerTransport,
+  runAcceptanceJob,
+  type VerdictCallbackPayload,
+} from './acceptance-runner/harness'
+import { crossyRoadAcceptanceSpec } from './acceptance-spec'
+import { CROSSY_ROAD_BROKEN_HTML } from './acceptance-runner/fixtures/crossy-road-broken.html'
+import { CROSSY_ROAD_FIXED_HTML } from './acceptance-runner/fixtures/crossy-road-fixed.html'
+
+let browser: Browser
+
+beforeAll(async () => {
+  browser = await chromium.launch({ headless: true })
+}, 60_000)
+
+afterAll(async () => {
+  await browser.close().catch(() => undefined)
+})
+
+const CALLBACK_TOKEN = 'test-runner-callback-token'
+
+// Wire the full loop against in-memory seams: a fake queue records the enqueued job;
+// the harness transport resolves the artifact from a fixture map and posts the verdict
+// straight into the verdict-callback ROUTE (with the real bearer token), which
+// backfills the in-memory verification store. This is the production data flow with
+// only the infra boundaries faked.
+const runFullLoop = async (
+  fixtureHtml: string,
+): Promise<{
+  enqueuedMessage: AcceptanceJobMessage
+  callbackStatus: number
+  callbackBody: Record<string, unknown>
+  storeRequestId: string
+}> => {
+  const store = makeInMemoryKhalaVerificationStore(() => '2026-06-22T00:00:00.000Z')
+  const requestId = 'chatcmpl-loop-1'
+  const artifactRef = 'r2://artifacts/loop-1.html'
+
+  // (1) GATEWAY: enqueue the verification job (flag ON, fake queue).
+  const sent: AcceptanceJobMessage[] = []
+  const queue: AcceptanceJobQueue = {
+    send: async message => {
+      sent.push(message)
+    },
+  }
+  const enqueueOutcome = await Effect.runPromise(
+    enqueueAcceptanceJob({
+      artifactRef,
+      enabled: true,
+      meteringReceiptRef: 'receipt.inference.charge.loop-1',
+      queue,
+      requestId,
+      servedModel: 'served/crossy',
+      spec: crossyRoadAcceptanceSpec(),
+      worker: 'pylon-worker-1',
+    }),
+  )
+  expect(enqueueOutcome.enqueued).toBe(true)
+  expect(sent).toHaveLength(1)
+  const enqueuedMessage = sent[0]!
+
+  // (2) NODE-SIDE HARNESS: resolve the artifact + run the REAL headless runner, then
+  //     post the verdict into the verdict-callback ROUTE with the bearer token.
+  let callbackStatus = 0
+  let callbackBody: Record<string, unknown> = {}
+  const transport: RunnerTransport = {
+    resolveArtifact: async ref => {
+      expect(ref).toBe(artifactRef)
+      return fixtureHtml
+    },
+    postVerdict: async (payload: VerdictCallbackPayload) => {
+      const request = new Request(
+        'https://openagents.com/v1/inference/acceptance-verdicts',
+        {
+          body: JSON.stringify(payload),
+          headers: {
+            authorization: `Bearer ${CALLBACK_TOKEN}`,
+            'content-type': 'application/json',
+          },
+          method: 'POST',
+        },
+      )
+      // (3) GATEWAY CALLBACK: authenticate + backfill the receipt.
+      const response = await Effect.runPromise(
+        handleAcceptanceVerdictCallback(request, {
+          callbackToken: CALLBACK_TOKEN,
+          enabled: true,
+          nowIso: () => '2026-06-22T00:00:01.000Z',
+          store,
+        }),
+      )
+      callbackStatus = response.status
+      callbackBody = (await response.json()) as Record<string, unknown>
+      if (!response.ok) {
+        throw new Error(`callback_failed: ${response.status}`)
+      }
+    },
+  }
+
+  const result = await runAcceptanceJob(transport, enqueuedMessage, { browser })
+  expect(result.delivered).toBe(true)
+
+  // (4) The store row is now backfilled from EXECUTION.
+  const record = await Effect.runPromise(store.read(requestId))
+  expect(record).not.toBeNull()
+
+  return {
+    callbackBody,
+    callbackStatus,
+    enqueuedMessage,
+    storeRequestId: requestId,
+  }
+}
+
+describe('acceptance-dispatch — full loop against committed fixtures', () => {
+  test('FIXED fixture: job -> runner -> verdict test_passed -> receipt backfilled, reward 1', async () => {
+    const out = await runFullLoop(CROSSY_ROAD_FIXED_HTML)
+
+    expect(out.enqueuedMessage.schemaVersion).toBe(
+      'openagents.inference.acceptance_job.v1',
+    )
+    expect(out.callbackStatus).toBe(200)
+    expect(out.callbackBody.verdict).toBe('test_passed')
+    expect(out.callbackBody.verified).toBe(true)
+    expect(out.callbackBody.scalarReward).toBe(1)
+    expect(out.callbackBody.backfilled).toBe(true)
+    expect(out.callbackBody.failedChecks).toEqual([])
+  }, 90_000)
+
+  test('BROKEN fixture: job -> runner -> verdict failed (per-test) -> receipt backfilled failed, low reward', async () => {
+    const out = await runFullLoop(CROSSY_ROAD_BROKEN_HTML)
+
+    expect(out.callbackStatus).toBe(200)
+    expect(out.callbackBody.verdict).toBe('failed')
+    expect(out.callbackBody.verified).toBe(false)
+    expect(out.callbackBody.scalarReward).toBeLessThan(1)
+    expect(out.callbackBody.backfilled).toBe(true)
+    // The four caught bugs surface as per-test failures.
+    const failed = out.callbackBody.failedChecks as ReadonlyArray<string>
+    expect(failed).toContain('loads_without_errors')
+    expect(failed).toContain('play_starts_game')
+  }, 90_000)
+})
+
+describe('acceptance-dispatch — enqueue is inert by default', () => {
+  test('flag OFF: nothing is enqueued; the message shape is still derivable', async () => {
+    const sent: AcceptanceJobMessage[] = []
+    const queue: AcceptanceJobQueue = {
+      send: async m => {
+        sent.push(m)
+      },
+    }
+    const outcome = await Effect.runPromise(
+      enqueueAcceptanceJob({
+        artifactRef: 'r2://x.html',
+        enabled: false,
+        queue,
+        requestId: 'chatcmpl-inert',
+        servedModel: 'm',
+        spec: crossyRoadAcceptanceSpec(),
+        worker: 'w',
+      }),
+    )
+    expect(outcome.enqueued).toBe(false)
+    expect(sent).toHaveLength(0)
+    expect(outcome.message.requestId).toBe('chatcmpl-inert')
+  })
+
+  test('flag parsing fails closed', () => {
+    expect(isAcceptanceDispatchEnabled('on')).toBe(true)
+    expect(isAcceptanceDispatchEnabled('true')).toBe(true)
+    expect(isAcceptanceDispatchEnabled('1')).toBe(true)
+    expect(isAcceptanceDispatchEnabled('')).toBe(false)
+    expect(isAcceptanceDispatchEnabled(undefined)).toBe(false)
+    expect(isAcceptanceDispatchEnabled('armed-ish')).toBe(false)
+  })
+})
+
+describe('acceptance-verdict-callback — fail-closed auth + idempotent backfill', () => {
+  const verdictBody = (requestId: string) => ({
+    requestId,
+    schemaVersion: 'openagents.inference.acceptance_verdict.v1' as const,
+    servedModel: 'm',
+    verdict: {
+      checks: crossyRoadAcceptanceSpec().checks.map(id => ({
+        detail: 'ok',
+        id,
+        passed: true,
+      })),
+      consoleErrors: [] as string[],
+      executed: true as const,
+      failedChecks: [] as string[],
+      kind: 'crossy_road_single_html' as const,
+      pageErrors: [] as string[],
+      passedChecks: [...crossyRoadAcceptanceSpec().checks],
+      rubricRef: crossyRoadAcceptanceSpec().rubricRef,
+      scalarReward: 1,
+      verified: true,
+    },
+    worker: 'w',
+  })
+
+  const makeRequest = (token: string | null, body: unknown) =>
+    new Request('https://openagents.com/v1/inference/acceptance-verdicts', {
+      body: JSON.stringify(body),
+      headers: {
+        ...(token === null ? {} : { authorization: `Bearer ${token}` }),
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    })
+
+  test('rejects a missing bearer token (401) and writes nothing', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(makeRequest(null, verdictBody('r1')), {
+        callbackToken: CALLBACK_TOKEN,
+        enabled: true,
+        nowIso: () => 'now',
+        store,
+      }),
+    )
+    expect(response.status).toBe(401)
+    expect(await Effect.runPromise(store.read('r1'))).toBeNull()
+  })
+
+  test('rejects a forged/mismatched token (401)', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(
+        makeRequest('wrong-token', verdictBody('r2')),
+        {
+          callbackToken: CALLBACK_TOKEN,
+          enabled: true,
+          nowIso: () => 'now',
+          store,
+        },
+      ),
+    )
+    expect(response.status).toBe(401)
+  })
+
+  test('closed when no token is configured (401), even with a bearer present', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(
+        makeRequest(CALLBACK_TOKEN, verdictBody('r3')),
+        {
+          callbackToken: undefined,
+          enabled: true,
+          nowIso: () => 'now',
+          store,
+        },
+      ),
+    )
+    expect(response.status).toBe(401)
+  })
+
+  test('rejects a malformed body (400)', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(
+        makeRequest(CALLBACK_TOKEN, { schemaVersion: 'nope' }),
+        {
+          callbackToken: CALLBACK_TOKEN,
+          enabled: true,
+          nowIso: () => 'now',
+          store,
+        },
+      ),
+    )
+    expect(response.status).toBe(400)
+  })
+
+  test('404 when the gateway flag is off', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(
+        makeRequest(CALLBACK_TOKEN, verdictBody('r4')),
+        {
+          callbackToken: CALLBACK_TOKEN,
+          enabled: false,
+          nowIso: () => 'now',
+          store,
+        },
+      ),
+    )
+    expect(response.status).toBe(404)
+  })
+
+  test('backfill is idempotent: a redelivered executed verdict does not double-write', async () => {
+    const store = makeInMemoryKhalaVerificationStore(() => 'now')
+    const body = await import('./acceptance-dispatch').then(m =>
+      m.AcceptanceVerdictCallbackBody.make(verdictBody('r5')),
+    )
+
+    const first = await Effect.runPromise(
+      backfillVerdictIntoVerification({ nowIso: () => 'now', store }, body),
+    )
+    expect(first.backfilled).toBe(true)
+    expect(first.record.version).toBe(1)
+    expect(first.record.verification).toBe('test_passed')
+
+    const second = await Effect.runPromise(
+      backfillVerdictIntoVerification({ nowIso: () => 'now', store }, body),
+    )
+    expect(second.backfilled).toBe(false)
+    expect(second.record.version).toBe(1)
+  })
+
+  test('a valid authenticated verdict backfills (200)', async () => {
+    const store = makeInMemoryKhalaVerificationStore(() => 'now')
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(
+        makeRequest(CALLBACK_TOKEN, verdictBody('r6')),
+        {
+          callbackToken: CALLBACK_TOKEN,
+          enabled: true,
+          nowIso: () => 'now',
+          store,
+        },
+      ),
+    )
+    expect(response.status).toBe(200)
+    const record = await Effect.runPromise(store.read('r6'))
+    expect(record?.verified).toBe(true)
+    expect(record?.executed).toBe(true)
+  })
+
+  test('constant-time bearer compare matches only on exact equality', () => {
+    expect(
+      authenticateVerdictCallback({
+        authorizationHeader: `Bearer ${CALLBACK_TOKEN}`,
+        configuredToken: CALLBACK_TOKEN,
+      }),
+    ).toBe(true)
+    expect(
+      authenticateVerdictCallback({
+        authorizationHeader: `Bearer ${CALLBACK_TOKEN}x`,
+        configuredToken: CALLBACK_TOKEN,
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/acceptance-dispatch.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-dispatch.ts
@@ -1,0 +1,510 @@
+// Async acceptance-verification DISPATCH for the Khala verified-work lane
+// (EPIC #6017; design: docs/inference/2026-06-22-verified-work-must-execute-the-artifact.md).
+//
+// THE PROBLEM THIS MODULE SOLVES. The merged QC fix (#6038) added a real headless
+// acceptance runner (`acceptance-runner/runner.ts`) and an HONEST `unverified`
+// default in `khala-code-verifier.ts` — but the live gateway never invokes the
+// runner, so prod khala-code receipts are ALWAYS `unverified`. Playwright/chromium
+// cannot run in a CF Worker (nor in a Queue-consumer Worker), so the runner must
+// run on a NODE with chromium (a Pylon / `oa-workroomd` sandbox / a small runner
+// service). This module owns the seam that connects the two:
+//
+//   gateway (Worker) ─enqueue job─▶ Queue ─▶ node-side runner harness (chromium)
+//        ▲                                              │
+//        └────────── verdict callback (authenticated) ──┘   ─▶ backfill the receipt
+//
+// WHAT THIS MODULE OWNS (Worker-safe; no Playwright, no chromium ever):
+//   (1) `AcceptanceJobMessage` — the typed `openagents.inference.acceptance_job.v1`
+//       payload the gateway enqueues when khala-code produces an executable
+//       artifact (mirrors `BatchJobQueueMessage`). It carries the request id, an
+//       artifact REF (not raw bytes on the hot path — bytes live in R2/the store),
+//       and the derived `AcceptanceSpec`.
+//   (2) `enqueueAcceptanceJob` — the producer over a pluggable `AcceptanceJobQueue`
+//       seam (a Cloudflare `Queue` in prod, a fake in tests), BEHIND A FLAG, default
+//       OFF. With the flag off it is a no-op: nothing is enqueued, prod behaviour is
+//       unchanged, the receipt stays `unverified`.
+//   (3) The verdict CALLBACK ingest: authentication of the runner's POST
+//       (`authenticateVerdictCallback`, a constant-time bearer check against
+//       `ACCEPTANCE_VERDICT_CALLBACK_TOKEN`) + the pure receipt-backfill
+//       (`backfillVerdictIntoVerification`): apply an `AcceptanceVerdict` to the
+//       stored `unverified` verification so it becomes `test_passed`/`failed`,
+//       `verified`, `scalarReward`, with per-test results. Idempotent;
+//       receipt-first; a forged/unauthenticated verdict is rejected.
+//
+// INERT BY DEFAULT. The enqueue flag (`KHALA_ACCEPTANCE_DISPATCH_ENABLED`) is OFF,
+// so the gateway emits no jobs and the honest `unverified` downgrade stands until a
+// runner host is deployed and the flag is flipped. The callback route is independent
+// and only acts on an authenticated POST.
+
+import { Effect, Schema as S } from 'effect'
+
+import type { AcceptanceSpec } from './acceptance-spec'
+import type { AcceptanceVerdict } from './acceptance-runner/verdict'
+import {
+  type KhalaCodeVerification,
+  type KhalaCodeVerificationVerdict,
+  verifyKhalaCodeCompletion,
+} from './khala-code-verifier'
+
+// ----------------------------------------------------------------------------
+// (1) The typed verification-job message
+// ----------------------------------------------------------------------------
+
+// The acceptance-spec carried on the wire. The runner needs the spec to know which
+// deterministic checks to run + the bounded thresholds. Kept structural (decoded by
+// the runner harness) so the job message stays a stable Effect Schema class without
+// re-encoding every spec field — the spec is a small JSON object the runner re-reads
+// through `acceptance-spec.ts`.
+export const AcceptanceJobSpecSchema = S.Struct({
+  kind: S.Literal('crossy_road_single_html'),
+  rubricRef: S.String,
+  checks: S.Array(S.String),
+  params: S.Struct({
+    forwardMoves: S.Number,
+    maxCameraDeltaPerMove: S.Number,
+    expectedForwardAdvance: S.Number,
+    minWorldRowsAhead: S.Number,
+  }),
+})
+
+// The queue payload that triggers an out-of-Worker acceptance run for ONE khala-code
+// completion. `requestId` is the inference response id the receipt is keyed on (the
+// runner echoes it back so the verdict backfills the right receipt). `artifactRef`
+// is a dereferenceable handle (an R2 key / store ref) the runner resolves to the
+// HTML bytes — NEVER the raw artifact on the hot enqueue path. `spec` is the derived
+// `AcceptanceSpec`. `servedModel` / `worker` are carried so the backfilled verdict
+// re-derives the same receipt shape the hot path produced.
+export class AcceptanceJobMessage extends S.Class<AcceptanceJobMessage>(
+  'AcceptanceJobMessage',
+)({
+  schemaVersion: S.Literal('openagents.inference.acceptance_job.v1'),
+  requestId: S.String,
+  artifactRef: S.String,
+  servedModel: S.String,
+  worker: S.String,
+  meteringReceiptRef: S.optionalKey(S.NullOr(S.String)),
+  spec: AcceptanceJobSpecSchema,
+}) {}
+
+export type AcceptanceJobSpec = S.Schema.Type<typeof AcceptanceJobSpecSchema>
+
+// Build the wire spec from a typed `AcceptanceSpec` (the runner re-reads it back into
+// the same shape). One place so the encode stays in sync with `acceptance-spec.ts`.
+export const acceptanceJobSpecFromSpec = (
+  spec: AcceptanceSpec,
+): AcceptanceJobSpec => ({
+  checks: spec.checks,
+  kind: spec.kind,
+  params: {
+    expectedForwardAdvance: spec.params.expectedForwardAdvance,
+    forwardMoves: spec.params.forwardMoves,
+    maxCameraDeltaPerMove: spec.params.maxCameraDeltaPerMove,
+    minWorldRowsAhead: spec.params.minWorldRowsAhead,
+  },
+  rubricRef: spec.rubricRef,
+})
+
+// ----------------------------------------------------------------------------
+// (2) The enqueue flag — default OFF (nothing is dispatched in prod yet)
+// ----------------------------------------------------------------------------
+
+// The Worker env key for the acceptance-dispatch arming flag. Default OFF: absent /
+// anything other than an explicit on-token keeps the gateway from enqueuing ANY
+// verification job, so the honest `unverified` downgrade stands and prod behaviour is
+// byte-for-byte unchanged. NEEDS-OWNER to flip on (after a runner host is deployed).
+export const KHALA_ACCEPTANCE_DISPATCH_ENABLED_ENV_KEY =
+  'KHALA_ACCEPTANCE_DISPATCH_ENABLED'
+
+const ON_TOKENS = new Set(['1', 'on', 'true', 'yes'])
+
+// Fail-closed flag read. Absent / non-string / any non-on value => disabled.
+export const isAcceptanceDispatchEnabled = (
+  value: unknown,
+): boolean =>
+  typeof value === 'string' && ON_TOKENS.has(value.trim().toLowerCase())
+
+// The minimal queue producer seam. A Cloudflare `Queue.send` satisfies this; tests
+// pass a fake that records the sent message. The producer never touches a concrete
+// Queue type so the module stays unit-testable with no infra.
+export type AcceptanceJobQueue = Readonly<{
+  send: (message: AcceptanceJobMessage) => Promise<void>
+}>
+
+export type EnqueueAcceptanceJobInput = Readonly<{
+  enabled: boolean
+  queue: AcceptanceJobQueue | undefined
+  requestId: string
+  artifactRef: string
+  servedModel: string
+  worker: string
+  meteringReceiptRef?: string | null | undefined
+  spec: AcceptanceSpec
+}>
+
+export type EnqueueAcceptanceJobOutcome = Readonly<{
+  // Whether a job was actually enqueued. False when the flag is off or no queue is
+  // wired (the honest inert default) — the caller's receipt stays `unverified`.
+  enqueued: boolean
+  // The message that was (or would have been) enqueued, for the caller's diagnostics
+  // and the test assertions. Present even when `enqueued` is false so the test can
+  // prove the SHAPE without a live send.
+  message: AcceptanceJobMessage
+}>
+
+// Enqueue a verification job for a khala-code completion that produced an executable
+// artifact. FAILS SOFT + INERT: with the flag off OR no queue wired it returns
+// `{ enqueued: false }` and sends nothing; a `send` rejection is swallowed (logged by
+// the caller) so a queue hiccup never breaks the already-delivered completion. The
+// receipt stays the honest `unverified` until a verdict callback backfills it.
+export const enqueueAcceptanceJob = (
+  input: EnqueueAcceptanceJobInput,
+): Effect.Effect<EnqueueAcceptanceJobOutcome> =>
+  Effect.gen(function* () {
+    const message = AcceptanceJobMessage.make({
+      artifactRef: input.artifactRef,
+      meteringReceiptRef: input.meteringReceiptRef ?? null,
+      requestId: input.requestId,
+      schemaVersion: 'openagents.inference.acceptance_job.v1',
+      servedModel: input.servedModel,
+      spec: acceptanceJobSpecFromSpec(input.spec),
+      worker: input.worker,
+    })
+
+    if (!input.enabled || input.queue === undefined) {
+      return { enqueued: false, message }
+    }
+
+    const sent = yield* Effect.tryPromise(() => input.queue!.send(message)).pipe(
+      Effect.as(true),
+      Effect.orElseSucceed(() => false),
+    )
+    return { enqueued: sent, message }
+  })
+
+// ----------------------------------------------------------------------------
+// (3a) Verdict callback authentication — reject forged/unauthenticated verdicts
+// ----------------------------------------------------------------------------
+
+// The Worker env key for the runner-callback bearer token. A node-side runner posts
+// its verdict with `Authorization: Bearer <token>`; the gateway rejects any verdict
+// that does not present the exact configured token. Absent token => the callback is
+// CLOSED (every verdict rejected) so an unconfigured Worker never accepts a forged
+// verdict. NEEDS-OWNER to set on the Worker alongside arming the runner host.
+export const ACCEPTANCE_VERDICT_CALLBACK_TOKEN_ENV_KEY =
+  'ACCEPTANCE_VERDICT_CALLBACK_TOKEN'
+
+// Constant-time-ish string compare (length-independent equality without early exit on
+// the first mismatched byte). Avoids leaking the token length/prefix via timing.
+const safeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let index = 0; index < a.length; index += 1) {
+    diff |= a.charCodeAt(index) ^ b.charCodeAt(index)
+  }
+  return diff === 0
+}
+
+const parseBearer = (header: string | null): string | undefined => {
+  if (header === null) return undefined
+  const match = /^Bearer\s+(.+)$/iu.exec(header.trim())
+  return match?.[1]?.trim()
+}
+
+// Authenticate a runner verdict callback. FAILS CLOSED: an absent configured token, a
+// missing/malformed `Authorization` header, or a token mismatch all reject. Only an
+// exact bearer match authenticates. Never logs the token.
+export const authenticateVerdictCallback = (
+  input: Readonly<{
+    authorizationHeader: string | null
+    configuredToken: string | undefined
+  }>,
+): boolean => {
+  const configured = input.configuredToken?.trim()
+  if (configured === undefined || configured === '') return false
+  const presented = parseBearer(input.authorizationHeader)
+  if (presented === undefined || presented === '') return false
+  return safeEqual(presented, configured)
+}
+
+// ----------------------------------------------------------------------------
+// (3b) The verdict the runner posts back
+// ----------------------------------------------------------------------------
+
+// The body a node-side runner POSTs to the verdict callback. It carries the request
+// id (which receipt to backfill) and the executed `AcceptanceVerdict` produced by the
+// merged runner. Validated by the route; an absent/empty `requestId` or a verdict
+// whose `executed` is not true is rejected (we only backfill from a REAL run).
+export const AcceptanceCheckResultSchema = S.Struct({
+  id: S.String,
+  passed: S.Boolean,
+  detail: S.String,
+})
+
+export const AcceptanceVerdictWireSchema = S.Struct({
+  kind: S.Literal('crossy_road_single_html'),
+  executed: S.Literal(true),
+  rubricRef: S.String,
+  checks: S.Array(AcceptanceCheckResultSchema),
+  passedChecks: S.Array(S.String),
+  failedChecks: S.Array(S.String),
+  scalarReward: S.Number,
+  verified: S.Boolean,
+  consoleErrors: S.Array(S.String),
+  pageErrors: S.Array(S.String),
+})
+
+export class AcceptanceVerdictCallbackBody extends S.Class<AcceptanceVerdictCallbackBody>(
+  'AcceptanceVerdictCallbackBody',
+)({
+  schemaVersion: S.Literal('openagents.inference.acceptance_verdict.v1'),
+  requestId: S.String,
+  // The runner echoes the served-model/worker so the backfilled verdict re-derives
+  // the SAME receipt shape the hot path produced (no parallel receipt-ref math).
+  servedModel: S.String,
+  worker: S.String,
+  meteringReceiptRef: S.optionalKey(S.NullOr(S.String)),
+  verdict: AcceptanceVerdictWireSchema,
+}) {}
+
+// ----------------------------------------------------------------------------
+// (3c) The stored verification verdict + receipt backfill
+// ----------------------------------------------------------------------------
+
+// The persisted khala-code verification verdict, keyed by the inference response id
+// (`requestId`). The hot gateway path writes the HONEST `unverified` row at completion
+// time; the verdict callback BACKFILLS it to `test_passed`/`failed` once the runner
+// has executed the artifact. The public receipt read projects from this store.
+//
+// This is the verification verdict store — NOT the financial `pay_ins` ledger
+// (`inference-receipts.ts`), which records the CHARGE. The charge is settled at
+// completion; the EXECUTION verdict is what flips from `unverified` to verified here.
+export type KhalaVerificationRecord = Readonly<{
+  requestId: string
+  verification: KhalaCodeVerification
+  verified: boolean
+  executed: boolean
+  scalarReward: number
+  rubricRef: string
+  passedChecks: ReadonlyArray<string>
+  failedChecks: ReadonlyArray<string>
+  verificationReceiptRef: string
+  // The verdict version: the hot path writes `1` (the unverified downgrade); each
+  // successful backfill bumps it. Used for idempotency + last-writer diagnostics.
+  version: number
+  updatedAt: string
+}>
+
+export type KhalaVerificationStore = Readonly<{
+  // Read the current verdict row for a request id (null when none written yet).
+  read: (requestId: string) => Effect.Effect<KhalaVerificationRecord | null>
+  // Upsert the verdict row. Idempotent at the call site via `version`.
+  upsert: (record: KhalaVerificationRecord) => Effect.Effect<void>
+}>
+
+// An in-memory verification store. Used by tests + as the reference implementation a
+// D1-backed store mirrors. Pure + synchronous under the Effect wrapper.
+export const makeInMemoryKhalaVerificationStore = (
+  nowIso: () => string = () => new Date().toISOString(),
+): KhalaVerificationStore => {
+  const rows = new Map<string, KhalaVerificationRecord>()
+  return {
+    read: requestId => Effect.sync(() => rows.get(requestId) ?? null),
+    upsert: record =>
+      Effect.sync(() => {
+        rows.set(record.requestId, { ...record, updatedAt: nowIso() })
+      }),
+  }
+}
+
+// A D1-backed verification store (prod). Mirrors `makeInMemoryKhalaVerificationStore`
+// against the `khala_acceptance_verdicts` table (migration 0221). Arrays are stored as
+// JSON text. `upsert` is an INSERT ... ON CONFLICT replace so a backfill overwrites the
+// `unverified` row; the caller's `version` guard keeps it idempotent.
+export const makeD1KhalaVerificationStore = (
+  db: D1Database,
+  nowIso: () => string = () => new Date().toISOString(),
+): KhalaVerificationStore => ({
+  read: requestId =>
+    Effect.tryPromise(() =>
+      db
+        .prepare(
+          `SELECT request_id, verification, verified, executed, scalar_reward,
+                  rubric_ref, passed_checks, failed_checks, verification_receipt_ref,
+                  version, updated_at
+             FROM khala_acceptance_verdicts WHERE request_id = ? LIMIT 1`,
+        )
+        .bind(requestId)
+        .first<Record<string, unknown>>(),
+    ).pipe(
+      Effect.map(row => {
+        if (row === null) return null
+        const parseArray = (value: unknown): ReadonlyArray<string> => {
+          try {
+            const parsed = JSON.parse(String(value ?? '[]'))
+            return Array.isArray(parsed) ? parsed.map(String) : []
+          } catch {
+            return []
+          }
+        }
+        return {
+          executed: Number(row.executed) === 1,
+          failedChecks: parseArray(row.failed_checks),
+          passedChecks: parseArray(row.passed_checks),
+          requestId: String(row.request_id),
+          rubricRef: String(row.rubric_ref),
+          scalarReward: Number(row.scalar_reward),
+          updatedAt: String(row.updated_at),
+          verification: String(row.verification) as KhalaCodeVerification,
+          verificationReceiptRef: String(row.verification_receipt_ref),
+          verified: Number(row.verified) === 1,
+          version: Number(row.version),
+        }
+      }),
+      Effect.orDie,
+    ),
+  upsert: record =>
+    Effect.tryPromise(() =>
+      db
+        .prepare(
+          `INSERT INTO khala_acceptance_verdicts (
+             request_id, verification, verified, executed, scalar_reward, rubric_ref,
+             passed_checks, failed_checks, verification_receipt_ref, version, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(request_id) DO UPDATE SET
+             verification = excluded.verification,
+             verified = excluded.verified,
+             executed = excluded.executed,
+             scalar_reward = excluded.scalar_reward,
+             rubric_ref = excluded.rubric_ref,
+             passed_checks = excluded.passed_checks,
+             failed_checks = excluded.failed_checks,
+             verification_receipt_ref = excluded.verification_receipt_ref,
+             version = excluded.version,
+             updated_at = excluded.updated_at`,
+        )
+        .bind(
+          record.requestId,
+          record.verification,
+          record.verified ? 1 : 0,
+          record.executed ? 1 : 0,
+          record.scalarReward,
+          record.rubricRef,
+          JSON.stringify(record.passedChecks),
+          JSON.stringify(record.failedChecks),
+          record.verificationReceiptRef,
+          record.version,
+          nowIso(),
+        )
+        .run(),
+    ).pipe(Effect.asVoid, Effect.orDie),
+})
+
+// Map a `KhalaCodeVerificationVerdict` (the verifier's output) onto a stored record.
+export const verificationRecordFromVerdict = (
+  input: Readonly<{
+    requestId: string
+    verdict: KhalaCodeVerificationVerdict
+    version: number
+    nowIso: string
+  }>,
+): KhalaVerificationRecord => ({
+  executed: input.verdict.executed,
+  failedChecks: input.verdict.failedChecks,
+  passedChecks: input.verdict.passedChecks,
+  requestId: input.requestId,
+  rubricRef: input.verdict.rubricRef,
+  scalarReward: input.verdict.scalarReward,
+  updatedAt: input.nowIso,
+  verification: input.verdict.verification,
+  verificationReceiptRef: input.verdict.receiptRef,
+  verified: input.verdict.verified,
+  version: input.version,
+})
+
+export type BackfillVerdictOutcome = Readonly<{
+  // Whether the receipt was backfilled by this call. False on an idempotent replay of
+  // an already-executed verdict (the row is already terminal at >= this version).
+  backfilled: boolean
+  // The resulting (or pre-existing) stored record.
+  record: KhalaVerificationRecord
+}>
+
+// Convert the runner's wire `AcceptanceVerdict` back into the strongly-typed verdict
+// shape the verifier consumes. The wire schema validated `executed: true` already.
+export const acceptanceVerdictFromWire = (
+  wire: S.Schema.Type<typeof AcceptanceVerdictWireSchema>,
+): AcceptanceVerdict => ({
+  checks: wire.checks.map(check => ({
+    detail: check.detail,
+    id: check.id as AcceptanceVerdict['checks'][number]['id'],
+    passed: check.passed,
+  })),
+  consoleErrors: wire.consoleErrors,
+  executed: true,
+  failedChecks: wire.failedChecks as AcceptanceVerdict['failedChecks'],
+  kind: wire.kind,
+  pageErrors: wire.pageErrors,
+  passedChecks: wire.passedChecks as AcceptanceVerdict['passedChecks'],
+  rubricRef: wire.rubricRef,
+  scalarReward: wire.scalarReward,
+  verified: wire.verified,
+})
+
+// Backfill a stored verification verdict from an authenticated runner callback.
+// RECEIPT-FIRST + IDEMPOTENT:
+//   - re-derive the verdict from EXECUTION via the SAME `verifyKhalaCodeCompletion`
+//     the hot path uses (so the receipt ref + shape are identical), passing the
+//     executed `AcceptanceVerdict` so the verdict is `test_passed`/`failed`;
+//   - if the stored row is already executed at a version >= the new one, no-op
+//     (a redelivered callback never regresses or double-writes);
+//   - otherwise upsert the executed verdict, bumping the version.
+// The content the verifier re-derives from is the artifact the runner already ran;
+// since the callback carries the executed verdict directly, we pass an empty content
+// (the prescreen is irrelevant once an executed verdict is in hand — the verdict is
+// derived from EXECUTION, the prescreen branch is not taken).
+export const backfillVerdictIntoVerification = (
+  deps: Readonly<{
+    store: KhalaVerificationStore
+    nowIso: () => string
+  }>,
+  body: AcceptanceVerdictCallbackBody,
+): Effect.Effect<BackfillVerdictOutcome> =>
+  Effect.gen(function* () {
+    const existing = yield* deps.store.read(body.requestId)
+    const acceptance = acceptanceVerdictFromWire(body.verdict)
+
+    // Re-derive through the verifier so the receipt ref + verification states are the
+    // SAME ones the hot path computes — never a parallel mapping. We pass the artifact
+    // HTML the runner has already validated as runnable via the executed acceptance;
+    // an executed acceptance always takes the EXECUTION branch regardless of content,
+    // so we hand a minimal runnable-shaped marker that the verifier ignores in favour
+    // of the executed verdict.
+    const verdict = verifyKhalaCodeCompletion({
+      acceptance,
+      // A minimal self-contained HTML so the prescreen does not short-circuit to
+      // `failed`; the EXECUTION branch is taken because `acceptance.executed` is true.
+      content:
+        '<!doctype html><html><body><canvas id="game"></canvas><script>/* executed */</script></body></html>',
+      meteringReceiptRef: body.meteringReceiptRef ?? null,
+      requestId: body.requestId,
+      servedModel: body.servedModel,
+      worker: body.worker,
+    })
+
+    // Idempotent: once a row is EXECUTED (a runner verdict has landed), a redelivered
+    // callback is a terminal no-op — never regress or double-write. The hot path's
+    // initial `unverified` row is NOT executed, so the FIRST backfill always applies.
+    if (existing !== null && existing.executed) {
+      return { backfilled: false, record: existing }
+    }
+
+    const nextVersion = (existing?.version ?? 0) + 1
+    const record = verificationRecordFromVerdict({
+      nowIso: deps.nowIso(),
+      requestId: body.requestId,
+      verdict,
+      version: nextVersion,
+    })
+    yield* deps.store.upsert(record)
+    return { backfilled: true, record }
+  })

--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/harness.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/harness.ts
@@ -1,0 +1,178 @@
+// Node-side acceptance-runner HARNESS (EPIC #6017).
+//
+// THIS RUNS OUT OF THE CF WORKER, on a node with chromium (a Pylon /
+// `oa-workroomd` sandbox / a small Cloud Run runner service). It is the consumer
+// end of the async dispatch: it takes an `AcceptanceJobMessage`, resolves the
+// artifact bytes, runs the merged headless acceptance suite (`runner.ts`,
+// Playwright), and posts the resulting `AcceptanceVerdict` back to the gateway's
+// authenticated verdict-callback. The gateway then backfills the receipt
+// (`unverified` -> `test_passed`/`failed`).
+//
+// PLUGGABLE EXECUTION HOST. The harness never hard-codes WHERE the artifact comes
+// from or HOW the verdict is delivered — both are `RunnerTransport` seams:
+//   - `resolveArtifact(artifactRef)` -> the HTML bytes. A Pylon reads its local
+//     content store; an `oa-workroomd` sandbox reads the mounted artifact; a Cloud
+//     Run service GETs an R2-signed URL.
+//   - `postVerdict(callback)` -> POST the verdict to the gateway with the bearer
+//     token. A real transport uses `fetch`; a test passes a fake that records it.
+// So the SAME harness runs on any host; only the transport differs.
+//
+// RECOMMENDED HOST (see the PR body / spec doc §"Infra we already have"): a Pylon
+// is the natural first host — it is already a programmatic environment (the former
+// Probe runtime), it joins the verified-work flywheel (workers run QC for
+// revshare), and chromium is the same dependency `three-effect` already uses for
+// headless capture. An `oa-workroomd` sandbox is the hardened second option for
+// untrusted artifacts; a tiny Cloud Run service is the simplest owner-operated
+// fallback. The harness is identical across all three.
+//
+// IMPORT SAFETY: this module imports `runner.ts`, which imports Playwright, so it is
+// NODE/BUN-ONLY and must NEVER be imported by the Worker build. The Worker side
+// imports only `../acceptance-dispatch` (pure) for enqueue + callback ingest.
+
+import {
+  AcceptanceJobMessage,
+  type AcceptanceJobSpec,
+} from '../acceptance-dispatch'
+import {
+  type AcceptanceSpec,
+  crossyRoadAcceptanceSpec,
+} from '../acceptance-spec'
+import type { AcceptanceVerdict } from './verdict'
+import { type AcceptanceRunOptions, runAcceptanceSuite } from './runner'
+
+// Re-hydrate the typed `AcceptanceSpec` from the on-the-wire job spec. The runner
+// asserts against bounded params, so the harness re-reads them through the SAME
+// `acceptance-spec.ts` factory (overriding with the carried thresholds) rather than
+// trusting raw wire numbers blindly. Today only the crossy-road lane exists.
+export const specFromJobSpec = (jobSpec: AcceptanceJobSpec): AcceptanceSpec =>
+  crossyRoadAcceptanceSpec({
+    expectedForwardAdvance: jobSpec.params.expectedForwardAdvance,
+    forwardMoves: jobSpec.params.forwardMoves,
+    maxCameraDeltaPerMove: jobSpec.params.maxCameraDeltaPerMove,
+    minWorldRowsAhead: jobSpec.params.minWorldRowsAhead,
+  })
+
+// The verdict the harness delivers back to the gateway. Mirrors the
+// `AcceptanceVerdictCallbackBody` wire shape (kept structural here so the harness has
+// no Effect Schema dependency — it builds a plain object the transport serializes).
+export type VerdictCallbackPayload = Readonly<{
+  schemaVersion: 'openagents.inference.acceptance_verdict.v1'
+  requestId: string
+  servedModel: string
+  worker: string
+  meteringReceiptRef: string | null
+  verdict: AcceptanceVerdict
+}>
+
+// THE PLUGGABLE EXECUTION-HOST SEAM. A Pylon / sandbox / Cloud Run service supplies
+// the two host-specific operations; everything else (run the suite, build the
+// payload) is host-independent and lives in `runAcceptanceJob`.
+export type RunnerTransport = Readonly<{
+  // Resolve an artifact ref to its HTML bytes. Host-specific: local store, mounted
+  // file, or a signed R2 GET. Rejects when the ref cannot be resolved (the harness
+  // turns that into an honest all-fail verdict, never a silent skip).
+  resolveArtifact: (artifactRef: string) => Promise<string>
+  // Deliver the verdict back to the gateway's authenticated callback. Host-specific:
+  // a real `fetch` POST with the bearer token, or a fake in tests. The harness treats
+  // a delivery failure as retryable (it returns the failure to the queue consumer).
+  postVerdict: (payload: VerdictCallbackPayload) => Promise<void>
+}>
+
+export type RunAcceptanceJobResult = Readonly<{
+  // The verdict the runner produced (always present — a crash is an all-fail verdict,
+  // never a throw). Useful for the host's own logging/CI gating.
+  verdict: AcceptanceVerdict
+  // Whether the verdict was successfully delivered back to the gateway. False when the
+  // transport's `postVerdict` rejected (the consumer should retry the job).
+  delivered: boolean
+}>
+
+// Run one acceptance job end to end on the node host:
+//   resolve artifact -> run the merged headless suite -> post the verdict back.
+// The suite NEVER throws into the harness (a load crash is `loads_without_errors:
+// false` + downstream fails). An artifact-resolution failure is itself turned into an
+// honest all-fail verdict (the artifact we could not load cannot be verified), so the
+// receipt is backfilled to `failed`, never left dangling. Only a verdict-DELIVERY
+// failure is surfaced as `delivered: false` for the consumer to retry.
+export const runAcceptanceJob = async (
+  transport: RunnerTransport,
+  message: AcceptanceJobMessage,
+  options?: AcceptanceRunOptions,
+): Promise<RunAcceptanceJobResult> => {
+  const spec = specFromJobSpec(message.spec)
+
+  let verdict: AcceptanceVerdict
+  try {
+    const artifactHtml = await transport.resolveArtifact(message.artifactRef)
+    verdict = await runAcceptanceSuite({ artifactHtml, spec }, options)
+  } catch (error) {
+    // Could not even resolve/load the artifact -> honest all-fail verdict. We mark
+    // every spec check failed with the resolution error, so the receipt backfills to
+    // `failed` (never a false green, never a silent skip).
+    const messageText = error instanceof Error ? error.message : String(error)
+    verdict = {
+      checks: spec.checks.map(id => ({
+        detail: `Could not resolve/run artifact ${message.artifactRef}: ${messageText.slice(0, 160)}`,
+        id,
+        passed: false,
+      })),
+      consoleErrors: [],
+      executed: true,
+      failedChecks: spec.checks,
+      kind: spec.kind,
+      pageErrors: [`resolve_error: ${messageText.slice(0, 200)}`],
+      passedChecks: [],
+      rubricRef: spec.rubricRef,
+      scalarReward: 0,
+      verified: false,
+    }
+  }
+
+  const payload: VerdictCallbackPayload = {
+    meteringReceiptRef: message.meteringReceiptRef ?? null,
+    requestId: message.requestId,
+    schemaVersion: 'openagents.inference.acceptance_verdict.v1',
+    servedModel: message.servedModel,
+    verdict,
+    worker: message.worker,
+  }
+
+  const delivered = await transport
+    .postVerdict(payload)
+    .then(() => true)
+    .catch(() => false)
+
+  return { delivered, verdict }
+}
+
+// A `fetch`-backed `postVerdict` builder for the real hosts (Pylon / Cloud Run). It
+// POSTs the verdict to the gateway's callback URL with the bearer token. The token is
+// supplied out of band (the host's local secret), NEVER hard-coded. Rejects on a
+// non-2xx so the consumer retries.
+export const makeFetchVerdictPoster = (
+  config: Readonly<{
+    callbackUrl: string
+    bearerToken: string
+    fetchFn?: typeof fetch
+  }>,
+): RunnerTransport['postVerdict'] => {
+  const fetchFn = config.fetchFn ?? fetch
+  return async payload => {
+    const response = await fetchFn(config.callbackUrl, {
+      body: JSON.stringify(payload),
+      headers: {
+        authorization: `Bearer ${config.bearerToken}`,
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    })
+    if (!response.ok) {
+      throw new Error(`verdict_callback_failed: ${response.status}`)
+    }
+  }
+}
+
+// Decode an unknown queue body into a typed `AcceptanceJobMessage`, so a real queue
+// consumer on the host validates the payload before running. Re-exported here so the
+// host-side entrypoint needs only this module.
+export { AcceptanceJobMessage }

--- a/apps/openagents.com/workers/api/src/inference/acceptance-verdict-callback-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-verdict-callback-routes.ts
@@ -1,0 +1,130 @@
+// Verdict-callback ingest route for the Khala acceptance-dispatch loop (EPIC #6017).
+//
+// A node-side runner (a Pylon / `oa-workroomd` sandbox / Cloud Run service) runs the
+// headless acceptance suite OUT of the Worker and POSTs its `AcceptanceVerdict` back
+// here. This authenticated route BACKFILLS the khala-code verification verdict for the
+// request: `unverified` -> `test_passed`/`failed`, with `verified`, `scalarReward`,
+// and per-test results. So a real `verified` (and the M6 training reward) finally
+// means "we ran it and it did what the user asked," not a regex over source.
+//
+// FAIL-CLOSED + RECEIPT-FIRST + IDEMPOTENT:
+//   - rejects an unauthenticated / forged verdict (constant-time bearer check against
+//     ACCEPTANCE_VERDICT_CALLBACK_TOKEN; absent token => every verdict rejected);
+//   - rejects a malformed body or a verdict that did not actually execute;
+//   - backfills through the SAME `verifyKhalaCodeCompletion` the hot path uses, so the
+//     receipt ref + verification states are identical (no parallel mapping);
+//   - a redelivered callback for an already-executed verdict is a no-op (200, no
+//     regression, no double-write).
+//
+// INERT BY DEFAULT: gated by INFERENCE_GATEWAY_ENABLED like the rest of the gateway,
+// AND closed unless the callback token is configured. With either off the route is a
+// 404 / rejects everything, so prod behaviour is unchanged until a runner host is
+// deployed and the token is set.
+
+import { Effect, Schema as S } from 'effect'
+
+import { noStoreJsonResponse } from '../http/responses'
+import { parseJsonUnknown } from '../json-boundary'
+import {
+  AcceptanceVerdictCallbackBody,
+  authenticateVerdictCallback,
+  backfillVerdictIntoVerification,
+  type KhalaVerificationStore,
+} from './acceptance-dispatch'
+
+export type AcceptanceVerdictCallbackDeps = Readonly<{
+  // Gateway flag (INFERENCE_GATEWAY_ENABLED). Default OFF => 404.
+  enabled: boolean
+  // The configured runner-callback bearer token (ACCEPTANCE_VERDICT_CALLBACK_TOKEN).
+  // Undefined => the callback is closed (every verdict rejected). Never logged.
+  callbackToken: string | undefined
+  // The verification verdict store the backfill upserts into (D1 in prod, in-memory
+  // in tests). The public receipt read projects from this store.
+  store: KhalaVerificationStore
+  nowIso: () => string
+}>
+
+const safeJsonParse = (text: string): unknown => {
+  try {
+    return parseJsonUnknown(text)
+  } catch {
+    return null
+  }
+}
+
+const decodeBody = (
+  value: unknown,
+): AcceptanceVerdictCallbackBody | undefined => {
+  try {
+    return S.decodeUnknownSync(AcceptanceVerdictCallbackBody)(value)
+  } catch {
+    return undefined
+  }
+}
+
+export const handleAcceptanceVerdictCallback = (
+  request: Request,
+  deps: AcceptanceVerdictCallbackDeps,
+) =>
+  Effect.gen(function* () {
+    // INERT GATE.
+    if (!deps.enabled) {
+      return noStoreJsonResponse(
+        { error: 'inference_gateway_disabled' },
+        { status: 404 },
+      )
+    }
+
+    if (request.method !== 'POST') {
+      return noStoreJsonResponse({ error: 'method_not_allowed' }, { status: 405 })
+    }
+
+    // AUTHENTICATE the runner. Fail-closed: absent configured token, missing/malformed
+    // header, or mismatch all reject 401. Reject BEFORE reading the body so a forged
+    // verdict never reaches the store.
+    const authed = authenticateVerdictCallback({
+      authorizationHeader: request.headers.get('authorization'),
+      configuredToken: deps.callbackToken,
+    })
+    if (!authed) {
+      const headers = new Headers({ 'www-authenticate': 'Bearer' })
+      return noStoreJsonResponse(
+        { error: 'unauthorized' },
+        { headers, status: 401 },
+      )
+    }
+
+    const text = yield* Effect.promise(() => request.text().catch(() => ''))
+    if (text === '') {
+      return noStoreJsonResponse({ error: 'invalid_json' }, { status: 400 })
+    }
+    const parsed = safeJsonParse(text)
+    const body = decodeBody(parsed)
+    if (body === undefined) {
+      // Malformed, or a verdict whose `executed` is not true (we only backfill from a
+      // REAL run — the schema requires `executed: true`).
+      return noStoreJsonResponse(
+        { error: 'invalid_acceptance_verdict' },
+        { status: 400 },
+      )
+    }
+
+    const outcome = yield* backfillVerdictIntoVerification(
+      { nowIso: deps.nowIso, store: deps.store },
+      body,
+    )
+
+    return noStoreJsonResponse(
+      {
+        backfilled: outcome.backfilled,
+        failedChecks: outcome.record.failedChecks,
+        passedChecks: outcome.record.passedChecks,
+        requestId: outcome.record.requestId,
+        scalarReward: outcome.record.scalarReward,
+        verificationReceiptRef: outcome.record.verificationReceiptRef,
+        verified: outcome.record.verified,
+        verdict: outcome.record.verification,
+      },
+      { status: 200 },
+    )
+  })

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -29,9 +29,17 @@ import { type PremiumAccessDecision } from './inference-premium-allowlist'
 // into the Worker bundle. The runner executes out of the Worker; its verdict shape is
 // the only thing the route consumes (EPIC #6017).
 import { type AcceptanceVerdict } from './acceptance-runner/verdict'
+// PURE dispatch producer only — enqueues an out-of-Worker verification job; never
+// imports the headless runner (playwright) into the Worker bundle (EPIC #6017).
+import {
+  type AcceptanceJobQueue,
+  enqueueAcceptanceJob,
+} from './acceptance-dispatch'
+import { intentToAcceptanceSpec } from './acceptance-spec'
 import {
   KHALA_CODE_VERIFIER_WORKER_ID,
   type KhalaCodeVerificationVerdict,
+  prescreenKhalaCodeArtifact,
   verifyKhalaCodeCompletion,
 } from './khala-code-verifier'
 import {
@@ -214,6 +222,26 @@ export type ChatCompletionsDeps = Readonly<{
   // to the runtime-primitives clock; `newId` to a runtime-primitives random id.
   nowEpochSeconds?: () => number
   newId?: () => string
+  // ACCEPTANCE-DISPATCH SEAM (EPIC #6017). When a khala-code completion produces an
+  // EXECUTABLE artifact (it passes the cheap pre-screen), the gateway enqueues an
+  // out-of-Worker verification job: a node-side runner (Pylon / sandbox / Cloud Run)
+  // runs the real headless acceptance suite and posts the verdict back to the
+  // authenticated callback, which backfills the receipt (`unverified` ->
+  // `test_passed`/`failed`). DEFAULT OFF + UNWIRED: with `acceptanceDispatch.enabled`
+  // false or no `queue`/`artifactStore` wired, NOTHING is enqueued and the receipt
+  // stays the honest `unverified`. The Worker wires this once a runner host is
+  // deployed and the flag (KHALA_ACCEPTANCE_DISPATCH_ENABLED) is on. Chromium NEVER
+  // runs in the Worker; this only enqueues a job (pure producer).
+  acceptanceDispatch?: Readonly<{
+    enabled: boolean
+    queue: AcceptanceJobQueue | undefined
+    // Persist the artifact bytes and return a dereferenceable ref the runner
+    // resolves (an R2 key). Absent => no job is enqueued (the runner would have no
+    // artifact to fetch). Receives the request id + the runnable HTML.
+    storeArtifact?: (
+      input: Readonly<{ requestId: string; html: string }>,
+    ) => Promise<string>
+  }>
 }>
 
 // REQUEST SCHEMA ----------------------------------------------------------
@@ -371,6 +399,80 @@ const khalaReceiptForResult = (
     workers: [input.adapterId, KHALA_CODE_VERIFIER_WORKER_ID],
   }
 }
+
+// Enqueue an out-of-Worker acceptance-verification job for a khala-code completion
+// that produced an EXECUTABLE artifact (EPIC #6017). INERT + FAIL-SOFT: returns
+// immediately (no enqueue) for a non-khala-code model, a flag-off dispatch, a missing
+// queue/artifact store, or an artifact that fails the cheap pre-screen (not even worth
+// running). When it does enqueue, it derives the spec from intent (reusing
+// `intentToAcceptanceSpec`), persists the artifact to get a dereferenceable ref, and
+// sends the typed job. A failure to store/enqueue is swallowed (the completion is
+// already delivered; the receipt simply stays the honest `unverified`).
+const maybeEnqueueAcceptanceJob = (
+  input: Readonly<{
+    dispatch: ChatCompletionsDeps['acceptanceDispatch']
+    requestedModel: string
+    requestMessages: ReadonlyArray<InferenceMessage>
+    responseId: string
+    result: InferenceResult
+    adapterId: string
+    meteringReceiptRef: string | null
+  }>,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const dispatch = input.dispatch
+    if (
+      dispatch === undefined ||
+      !dispatch.enabled ||
+      dispatch.queue === undefined ||
+      dispatch.storeArtifact === undefined ||
+      input.requestedModel !== KHALA_CODE_MODEL_ID
+    ) {
+      return
+    }
+
+    // Only enqueue a RUNNABLE artifact (the cheap pre-screen gates execution; it is
+    // NOT the verdict). A non-runnable artifact already verifies as `failed` on the
+    // hot path; nothing to execute.
+    const prescreen = prescreenKhalaCodeArtifact(input.result.content)
+    if (!prescreen.attemptExecution || prescreen.html === undefined) {
+      return
+    }
+
+    const spec = intentToAcceptanceSpec({
+      messages: input.requestMessages.map(message => ({
+        content: message.content,
+        role: message.role,
+      })),
+      model: input.requestedModel,
+    })
+    if (spec === undefined) {
+      return
+    }
+
+    // Persist the artifact -> dereferenceable ref the runner resolves. A store failure
+    // means no runnable handle, so we do not enqueue (receipt stays `unverified`).
+    const artifactRef = yield* Effect.tryPromise(() =>
+      dispatch.storeArtifact!({
+        html: prescreen.html as string,
+        requestId: input.responseId,
+      }),
+    ).pipe(Effect.map(ref => ref as string | undefined), Effect.orElseSucceed(() => undefined))
+    if (artifactRef === undefined) {
+      return
+    }
+
+    yield* enqueueAcceptanceJob({
+      artifactRef,
+      enabled: dispatch.enabled,
+      meteringReceiptRef: input.meteringReceiptRef,
+      queue: dispatch.queue,
+      requestId: input.responseId,
+      servedModel: input.result.servedModel,
+      spec,
+      worker: input.adapterId,
+    }).pipe(Effect.asVoid)
+  })
 
 // OpenAI non-streaming response envelope.
 const openAiResponse = (
@@ -971,6 +1073,21 @@ export const handleChatCompletions = (
       servedModel: result.served.value.servedModel,
       streamed: false,
       usage: result.served.value.usage,
+    })
+
+    // ACCEPTANCE-DISPATCH (EPIC #6017): when khala-code produced a runnable artifact,
+    // enqueue an out-of-Worker verification job (flagged; inert by default). The
+    // node-side runner executes the suite and the verdict callback backfills the
+    // receipt from `unverified` -> `test_passed`/`failed`. Fire-and-forget: never
+    // blocks or fails the already-priced completion.
+    yield* maybeEnqueueAcceptanceJob({
+      adapterId: result.served.adapterId,
+      dispatch: deps.acceptanceDispatch,
+      meteringReceiptRef: metering.receiptRef,
+      requestMessages: inferenceRequest.messages,
+      requestedModel,
+      responseId,
+      result: result.served.value,
     })
 
     return noStoreJsonResponse(

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -132,6 +132,7 @@ const approvedExactRoutePaths = [
   '/v1/inference/batches',
   '/v1/inference/batches/:jobId',
   '/v1/chat/completions',
+  '/v1/inference/acceptance-verdicts',
   '/v1/models',
   '/v1/quote',
   '/v1/gateway/readiness',


### PR DESCRIPTION
## Problem

The merged QC fix (#6038) added a real headless acceptance runner (`acceptance-runner/runner.ts`) and an honest `unverified` default in `khala-code-verifier.ts` — but **the live gateway never invoked the runner**, so prod `khala-code` receipts are *always* `unverified`. This wires the async, out-of-Worker dispatch so a real `AcceptanceVerdict` flows back and the receipt becomes a true `test_passed`/`failed` with `scalarReward` = fraction passing.

Chromium can't run in a CF Worker (nor in a Queue-consumer Worker), so the architecture is the loop the spec doc names:

```
gateway (Worker) ─enqueue job─▶ Queue ─▶ node-side runner harness (chromium)
     ▲                                              │
     └────────── verdict callback (authenticated) ──┘   ─▶ backfill the receipt
```

## The loop, end to end

1. **Enqueue a verification job** — when a `khala-code` completion produces an *executable* artifact (passes the cheap pre-screen), the gateway derives the `AcceptanceSpec` (reusing `intentToAcceptanceSpec`), persists the artifact to a dereferenceable ref, and enqueues a typed `openagents.inference.acceptance_job.v1` message (mirrors the `BatchJobQueueMessage` pattern). **Behind `KHALA_ACCEPTANCE_DISPATCH_ENABLED`, default OFF**, and the queue producer is left unwired — so nothing is enqueued in prod today.
2. **Node-side runner harness** (`acceptance-runner/harness.ts`) — consumes a job, runs the merged Playwright acceptance suite, and posts the `AcceptanceVerdict` back. The execution host is **pluggable via a `RunnerTransport` interface** (`resolveArtifact` + `postVerdict`), so it can be a **Pylon (recommended)**, an `oa-workroomd` sandbox (hardened, for untrusted artifacts), or a small Cloud Run service. Ships a `fetch`-backed verdict poster. Not deployed.
3. **Verdict callback ingest** (`/v1/inference/acceptance-verdicts`) — authenticated (constant-time bearer check against `ACCEPTANCE_VERDICT_CALLBACK_TOKEN`; absent token ⇒ every verdict rejected), **receipt-first**, **idempotent**. Backfills the verification verdict through the *same* `verifyKhalaCodeCompletion` the hot path uses (identical receipt ref + states): `unverified` → `test_passed`/`failed`, `verified`, `scalarReward`, per-test results. Forged/unauthenticated/malformed verdicts are rejected before touching the store. A new D1 verdict store (`khala_acceptance_verdicts`, migration 0221) persists the row.

## Proof (full loop, committed fixtures)

`acceptance-dispatch.test.ts` wires the *real* loop (fake queue + fake transport → the real callback route → real headless runner):

- **broken** crossy-road fixture → runner → verdict `failed` (per-test: `loads_without_errors`, `play_starts_game`, …) → receipt backfilled to `failed`, `scalarReward < 1`.
- **fixed** fixture → verdict `test_passed` → receipt backfilled, `verified`, `scalarReward 1`.

Plus: enqueue inert when flag off; callback rejects missing/forged/absent-token verdicts (401), malformed (400), flag-off (404); backfill idempotent.

## Verify

- `bun run test -- src/inference/` → **491 passed (40 files), 0 failures** (includes the new 12).
- `bun run typecheck` → clean.
- The known **~14 pre-existing unrelated failures** on clean `main` (quick-win, omni-workroom, agent-onboarding sha, shard-wan payout, ecommerce self-serve, agent-registration) are untouched — flagged, not caused here.

## What's left to make it live in prod

1. **Deploy a runner host** (a Pylon with chromium is the recommended first host) running the harness against the queue.
2. Bind a **Cloudflare Queue producer + an R2 artifact store** to the gateway's `acceptanceDispatch` seam in `index.ts` (currently `queue: undefined`), set `ACCEPTANCE_VERDICT_CALLBACK_TOKEN`, and flip `KHALA_ACCEPTANCE_DISPATCH_ENABLED` on. Apply migration 0221.

Refs EPIC #6017 + `docs/inference/2026-06-22-verified-work-must-execute-the-artifact.md`.

**DO NOT auto-merge — orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)