### PR TITLE
Verse: spawn an isolated scene (crackling energy) into the world + walk up to it

### DIFF
--- a/apps/autopilot-desktop/src/shared/verse-spawned-scene.ts
+++ b/apps/autopilot-desktop/src/shared/verse-spawned-scene.ts
@@ -1,0 +1,295 @@
+// Verse spawned isolated-scene layer (dev affordance — #6033 / EPIC #6017).
+//
+// PURE, Three.js-free transform that drops an ISOLATED scene slice (the Khala
+// "crackling energy" inference effect, and an optional gateway portal) into the
+// SAME live Verse world the Autopilot avatar already walks in — at a fixed
+// in-world "scene station" near spawn. The point is to develop/eyeball one
+// effect at a time inside the real world geometry: you spawn it with a key, then
+// walk up to it with the existing third-person character controller and look at
+// it from any angle, instead of opening a separate standalone pane.
+//
+// ISOLATED / HONEST. The scene is fed by a SYNTHETIC, simulated inference event
+// (`simulated:true`, `evidenceMode:"optional"`, fixed `sourceRefs`) — there is
+// NO Region Durable Object, NO D1, NO Worker, and NO live receipt behind it.
+// This mirrors the standalone crackling-arc demo's contract exactly
+// (three-effect/examples/crackling-arc-standalone + the audit doc
+// 2026-06-22-isolated-verse-scene-harness-audit.md), but renders THROUGH the
+// same `trainingRunView` renderer as the rest of the Verse: a
+// `style:"crackling_arc"` beam becomes `createEvidenceBackedCracklingArc`, and a
+// `visualKind:"gateway_portal"` entity becomes `createEvidenceBackedGatewayPortal`
+// inside the live scene (trainingRun.ts). We reuse the SAME scene/render setup —
+// no parallel renderer.
+//
+// EVIDENCE-BOUND, even though simulated. Each spawned beam/burst carries its
+// `sourceRefs` + `motionKind` + `simulated:true`, and the layer forces
+// `motionPolicy.evidence = "required"`, so nothing animates without the synthetic
+// event — exactly like withVerseKhalaEffectLayer, the local sibling of this layer.
+//
+// EXTENSIBLE. Scenes are registered in VERSE_SPAWNABLE_SCENES; spawning is keyed
+// by registry id, so more isolated scenes can be added + spawned the same way.
+
+import { verseIconRecipeForId } from "@openagentsinc/three-effect/core"
+import type {
+  InferenceGatewayLane,
+  TrainingRunBeamDefinition,
+  TrainingRunBurstDefinition,
+  TrainingRunVector,
+  TrainingRunVisualizationOptions,
+} from "@openagentsinc/three-effect/core"
+
+import {
+  appendVerseVisualization,
+  roundedVerseVector,
+} from "./verse-scene-helpers.js"
+import type { ChatWorldVisualEntityDefinition } from "./chat-world-visualization.js"
+
+// Stable scene-node prefix so a spawned isolated scene never collides on id with
+// the live world / payment / Khala layers. Each spawned instance is keyed by its
+// registry scene id (one fixed station per scene id), so respawning is idempotent.
+export const VERSE_SPAWNED_SCENE_NODE_PREFIX = "verse:spawned:"
+
+// The synthetic source ref every spawned scene carries — a real public ref (this
+// issue) so the on-screen evidence is honest about what authorizes the motion,
+// while `simulated:true` keeps it explicitly labelled as a developer simulation.
+export const VERSE_SPAWNED_SCENE_SOURCE_REF =
+  "github:OpenAgentsInc/openagents#6033"
+
+// Fixed in-world "scene station" anchor: a short walk from spawn so the avatar
+// can stroll up to it. Tuned HERE (the mapper), not in the renderer. The crackling
+// arc hangs above the station; the optional portal sits just below it.
+export const VERSE_SPAWNED_SCENE_STATION_POSITION: TrainingRunVector =
+  roundedVerseVector([0, 0, -6])
+
+// ── Eyeball knobs (mirrors the standalone's URL knobs as typed options) ───────
+
+// The crackling-arc knobs the standalone scene exposes (strandCount/rate/color/
+// endpoints). Defaults match crackling-arc-standalone so the in-world spawn reads
+// the same as the isolated page. Endpoints are RELATIVE to the station anchor.
+export type VerseSpawnedSceneKnobs = Readonly<{
+  /** arc start, relative to the station anchor. */
+  fromOffset?: TrainingRunVector
+  /** arc end, relative to the station anchor. */
+  toOffset?: TrainingRunVector
+  strandCount?: number
+  rate?: number
+  opacity?: number
+  color?: number
+  secondaryColor?: number
+  /** also spawn the gateway-portal variant just below the arc (2nd toggle). */
+  showPortal?: boolean
+  /** lane color/labeling for the optional portal. */
+  portalLane?: InferenceGatewayLane
+}>
+
+// A registered spawnable scene. `id` is the stable key; `motionKind` is the
+// public meaning the evidence overlay shows; `build` returns the in-world layer.
+export type VerseSpawnableScene = Readonly<{
+  id: string
+  label: string
+  motionKind: string
+  defaultKnobs: VerseSpawnedSceneKnobs
+}>
+
+// The crackling-energy scene defaults, matched to the standalone demo.
+const CRACKLING_ENERGY_DEFAULTS: VerseSpawnedSceneKnobs = {
+  fromOffset: [-1.6, 1.6, 0],
+  toOffset: [1.6, 2.6, 0],
+  strandCount: 5,
+  rate: 2.6,
+  opacity: 0.78,
+  color: 0x93c5fd,
+  secondaryColor: 0xf8fafc,
+  showPortal: false,
+  portalLane: "openrouter",
+} as const
+
+// The registry. Start with crackling-energy (+ a portal toggle); add more here.
+export const VERSE_SPAWNABLE_SCENES: ReadonlyArray<VerseSpawnableScene> = [
+  {
+    id: "crackling-energy",
+    label: "Crackling energy",
+    motionKind: "crackling_energy",
+    defaultKnobs: CRACKLING_ENERGY_DEFAULTS,
+  },
+] as const
+
+export const DEFAULT_SPAWNABLE_SCENE_ID = "crackling-energy"
+
+export const verseSpawnableSceneById = (
+  id: string,
+): VerseSpawnableScene | null =>
+  VERSE_SPAWNABLE_SCENES.find((scene) => scene.id === id) ?? null
+
+// ── The spawned-scene layer ───────────────────────────────────────────────────
+
+export type VerseSpawnedSceneLayer = Readonly<{
+  entities: ReadonlyArray<ChatWorldVisualEntityDefinition>
+  beams: ReadonlyArray<TrainingRunBeamDefinition>
+  bursts: ReadonlyArray<TrainingRunBurstDefinition>
+}>
+
+const EMPTY_LAYER: VerseSpawnedSceneLayer = { entities: [], beams: [], bursts: [] }
+
+const finite = (value: number): boolean =>
+  Number.isFinite(value) && !Number.isNaN(value)
+
+const addOffset = (
+  anchor: TrainingRunVector,
+  offset: TrainingRunVector,
+): TrainingRunVector =>
+  roundedVerseVector([
+    anchor[0] + offset[0],
+    anchor[1] + offset[1],
+    anchor[2] + offset[2],
+  ])
+
+// One spawned scene's input: which registry scene, where its station sits, and
+// the (optional) knob overrides. `generatedAt` rides the evidence so the renderer
+// can derive motion timing; the synthetic source ref is the evidence.
+export type VerseSpawnedSceneInput = Readonly<{
+  sceneId: string
+  /** where the scene station sits in the live world (defaults to the anchor). */
+  station?: TrainingRunVector
+  knobs?: VerseSpawnedSceneKnobs
+  generatedAt?: string
+}>
+
+// Build the in-world layer for ONE spawned isolated scene. Returns an empty layer
+// for an unknown scene id (never fabricate a scene). The crackling arc is a
+// `crackling_arc` beam between two positioned scene-station endpoints; the optional
+// gateway portal is a `gateway_portal` entity below the arc. Every beam/burst is
+// evidence-bound to the synthetic ref + simulated:true (the §5 contract, honestly
+// labelled as a simulation).
+export const verseSpawnedSceneLayer = (
+  input: VerseSpawnedSceneInput,
+): VerseSpawnedSceneLayer => {
+  const scene = verseSpawnableSceneById(input.sceneId)
+  if (scene === null) return EMPTY_LAYER
+
+  const stationAnchor = input.station ?? VERSE_SPAWNED_SCENE_STATION_POSITION
+  if (!finite(stationAnchor[0]) || !finite(stationAnchor[1]) || !finite(stationAnchor[2])) {
+    return EMPTY_LAYER
+  }
+
+  const knobs: Required<
+    Pick<
+      VerseSpawnedSceneKnobs,
+      "fromOffset" | "toOffset" | "showPortal" | "portalLane"
+    >
+  > = {
+    fromOffset:
+      input.knobs?.fromOffset ?? scene.defaultKnobs.fromOffset ?? [-1.6, 1.6, 0],
+    toOffset:
+      input.knobs?.toOffset ?? scene.defaultKnobs.toOffset ?? [1.6, 2.6, 0],
+    showPortal: input.knobs?.showPortal ?? scene.defaultKnobs.showPortal ?? false,
+    portalLane:
+      input.knobs?.portalLane ?? scene.defaultKnobs.portalLane ?? "openrouter",
+  }
+
+  const keyBase = `${VERSE_SPAWNED_SCENE_NODE_PREFIX}${scene.id}`
+  const fromId = `${keyBase}:from`
+  const toId = `${keyBase}:to`
+  const portalId = `${keyBase}:portal`
+
+  const fromPosition = addOffset(stationAnchor, knobs.fromOffset)
+  const toPosition = addOffset(stationAnchor, knobs.toOffset)
+
+  const sourceRefs = [VERSE_SPAWNED_SCENE_SOURCE_REF] as const
+  const detail = `${VERSE_SPAWNED_SCENE_SOURCE_REF} · ${scene.motionKind} · simulated`
+
+  const entities: ChatWorldVisualEntityDefinition[] = [
+    {
+      id: fromId,
+      label: scene.label,
+      detail,
+      status: "active",
+      position: fromPosition,
+      iconRecipe: verseIconRecipeForId("khala:nexus"),
+    },
+    {
+      id: toId,
+      label: "Scene station",
+      detail,
+      status: "active",
+      position: toPosition,
+      iconRecipe: verseIconRecipeForId(scene.id),
+    },
+  ]
+
+  const evidence = {
+    motionId: `verse-spawned:${scene.id}`,
+    motionKind: scene.motionKind,
+    sourceRefs,
+    ...(input.generatedAt === undefined ? {} : { generatedAt: input.generatedAt }),
+    // Explicitly labelled as a developer simulation — the whole point of an
+    // isolated scene. Never a real live receipt.
+    simulated: true,
+  } as const
+
+  const beams: TrainingRunBeamDefinition[] = [
+    { fromId, toId, style: "crackling_arc", ...evidence },
+  ]
+  const bursts: TrainingRunBurstDefinition[] = []
+
+  if (knobs.showPortal) {
+    entities.push({
+      id: portalId,
+      label: "Gateway portal",
+      detail: `${VERSE_SPAWNED_SCENE_SOURCE_REF} · gateway_portal · ${knobs.portalLane} · simulated`,
+      status: "active",
+      position: addOffset(stationAnchor, [0, 0.4, 0]),
+      iconRecipe: verseIconRecipeForId(`gateway:${knobs.portalLane}:${scene.id}`),
+      visualKind: "gateway_portal",
+      gatewayLane: knobs.portalLane,
+    })
+  }
+
+  return { entities, beams, bursts }
+}
+
+// Overlay every currently-spawned isolated scene onto the base visualization.
+// Forces `motionPolicy.evidence = "required"` so the shared renderer animates a
+// spawned arc ONLY when it carries the synthetic source ref — the same hard
+// backstop as the payment / inference / Khala layers. An empty spawn list adds
+// nothing (the Verse is byte-identical to before any spawn).
+export const withVerseSpawnedSceneLayer = (
+  base: TrainingRunVisualizationOptions,
+  inputs: ReadonlyArray<VerseSpawnedSceneInput>,
+): TrainingRunVisualizationOptions => {
+  const entities: ChatWorldVisualEntityDefinition[] = []
+  const beams: TrainingRunBeamDefinition[] = []
+  const bursts: TrainingRunBurstDefinition[] = []
+  for (const input of inputs) {
+    const layer = verseSpawnedSceneLayer(input)
+    entities.push(...layer.entities)
+    beams.push(...layer.beams)
+    bursts.push(...layer.bursts)
+  }
+  if (entities.length === 0) return base
+  return {
+    ...appendVerseVisualization(base, { entities, beams, bursts }),
+    motionPolicy: { ...(base.motionPolicy ?? {}), evidence: "required" },
+  }
+}
+
+// The evidence overlay text for a spawned scene, mirroring the standalone's
+// on-screen `<pre class="evidence">` block (motionKind / sourceRefs / simulated /
+// evidenceMode / generatedAt). Returned as ordered label lines so the view can
+// render it as a small in-Verse chip without re-deriving the contract.
+export const verseSpawnedSceneEvidenceLines = (
+  input: VerseSpawnedSceneInput,
+): ReadonlyArray<string> => {
+  const scene = verseSpawnableSceneById(input.sceneId)
+  if (scene === null) return []
+  return [
+    `scene:        ${scene.label}`,
+    `motionKind:   ${scene.motionKind}`,
+    `sourceRefs:   ${VERSE_SPAWNED_SCENE_SOURCE_REF}`,
+    `simulated:    true`,
+    `evidenceMode: optional`,
+    ...(input.generatedAt === undefined
+      ? []
+      : [`generatedAt:  ${input.generatedAt}`]),
+    `portal:       ${(input.knobs?.showPortal ?? scene.defaultKnobs.showPortal) ? "on" : "off"}`,
+  ]
+}

--- a/apps/autopilot-desktop/src/ui/keyboard.ts
+++ b/apps/autopilot-desktop/src/ui/keyboard.ts
@@ -15,6 +15,7 @@ import {
 
 import { groupForPane } from "./nav.js"
 import { modelPaneLayer, type Model, type PaneId } from "./model.js"
+import { DEFAULT_SPAWNABLE_SCENE_ID } from "../shared/verse-spawned-scene.js"
 
 // Raw key event the subscription forwards (mirrors the PressedKey payload).
 export type KeyEvent = Readonly<{
@@ -44,6 +45,11 @@ export type KeyIntent =
   | Readonly<{ kind: "back-to-shell" }>
   // #5730 The Verse: ⌘⇧V / Ctrl-⇧V toggles the game-world view on/off.
   | Readonly<{ kind: "toggle-verse" }>
+  // Dev affordance (#6033): ⌘⇧E / Ctrl-⇧E spawns/unspawns the isolated
+  // crackling-energy scene station into the live Verse world; ⌘⇧P / Ctrl-⇧P
+  // toggles that scene's optional gateway-portal variant. Explore mode only.
+  | Readonly<{ kind: "spawn-verse-scene"; sceneId: string }>
+  | Readonly<{ kind: "toggle-verse-scene-portal"; sceneId: string }>
   // HUD H1: action-bar slot 1 opens a fresh coder-session surface.
   | Readonly<{ kind: "open-coder-session" }>
   | Readonly<{ kind: "close-managed-panes" }>
@@ -133,6 +139,21 @@ export const interpretKey = (model: Model, event: KeyEvent): KeyIntent => {
   // ── Cmd/Ctrl-Shift-V toggles the Verse (game-world view) from anywhere ────
   if (key.toLowerCase() === "v" && isModified(event) && event.shift) {
     return { kind: "toggle-verse" }
+  }
+
+  // ── Dev affordance (#6033): spawn an isolated scene station into the live ──
+  // Verse, and toggle its portal. Explore mode only (so coding overlay keys are
+  // untouched), and only while the Verse is on-screen.
+  if (isVerseExploreActionContext(model) && isModified(event) && event.shift) {
+    if (key.toLowerCase() === "e") {
+      return { kind: "spawn-verse-scene", sceneId: DEFAULT_SPAWNABLE_SCENE_ID }
+    }
+    if (key.toLowerCase() === "p") {
+      return {
+        kind: "toggle-verse-scene-portal",
+        sceneId: DEFAULT_SPAWNABLE_SCENE_ID,
+      }
+    }
   }
 
   // ── Cmd/Ctrl-Enter submits the chat/composer turn ─────────────────────────

--- a/apps/autopilot-desktop/src/ui/message.ts
+++ b/apps/autopilot-desktop/src/ui/message.ts
@@ -168,6 +168,19 @@ export const ChangedVerseMode = m("ChangedVerseMode", {
 })
 export const ClickedHotbarNewCoderSession = m("ClickedHotbarNewCoderSession")
 
+// Dev affordance (#6033 / EPIC #6017): spawn / unspawn an isolated SCENE STATION
+// (e.g. the Khala "crackling energy" effect) into the live Verse world at a fixed
+// in-world location, fed by a SYNTHETIC simulated event (no Region DO / D1 / Worker
+// / live receipt). `SpawnedVerseScene` toggles a registered spawnable-scene id on/
+// off; `ToggledVerseScenePortal` flips that scene's optional gateway-portal variant.
+// Pure model state — no host authority, no RPC.
+export const SpawnedVerseScene = m("SpawnedVerseScene", {
+  sceneId: S.String,
+})
+export const ToggledVerseScenePortal = m("ToggledVerseScenePortal", {
+  sceneId: S.String,
+})
+
 // Chat: expand/collapse a single chat message's "program details" disclosure
 // (the scoped-step / Tassadar scaffolding). Collapsed by default so the chat
 // opens to a clean conversation. Pure model toggle — no control verb / RPC.
@@ -777,6 +790,8 @@ export const Message = S.Union([
   SelectedDiffFile,
   ToggleVerse,
   ChangedVerseMode,
+  SpawnedVerseScene,
+  ToggledVerseScenePortal,
   ClickedHotbarNewCoderSession,
   ToggledChatMessageDetails,
   ClickedCoordinatorToggle,

--- a/apps/autopilot-desktop/src/ui/model.ts
+++ b/apps/autopilot-desktop/src/ui/model.ts
@@ -216,6 +216,17 @@ export const VerseKhalaReceipt = S.Struct({
 })
 export type VerseKhalaReceipt = typeof VerseKhalaReceipt.Type
 
+// Dev affordance (#6033): one isolated scene spawned into the live Verse. `sceneId`
+// is a registered spawnable-scene id (shared/verse-spawned-scene.ts); `showPortal`
+// toggles the optional gateway-portal variant for this spawn. The fixed in-world
+// station + synthetic simulated evidence are derived by the scene mapper, so the
+// model only carries the developer's spawn choice.
+export const VerseSpawnedSceneState = S.Struct({
+  sceneId: S.String,
+  showPortal: S.Boolean,
+})
+export type VerseSpawnedSceneState = typeof VerseSpawnedSceneState.Type
+
 export const ChatStepStatus = S.Literals([
   "pending",
   "running",
@@ -648,6 +659,15 @@ export const Model = ts("AutopilotDesktop", {
   verseKhalaStatus: ChatStatus,
   verseKhalaReceipt: S.NullOr(VerseKhalaReceipt),
 
+  // Dev affordance (#6033 / EPIC #6017): isolated SCENE STATIONS spawned into the
+  // live Verse world. Each entry is a registered spawnable-scene id (e.g.
+  // "crackling-energy") that the scene mapper drops at a fixed in-world station,
+  // fed by a SYNTHETIC simulated inference event (no Region DO / D1 / Worker / live
+  // receipt). Empty by default → the Verse is byte-identical until a scene is
+  // spawned with the dev key. `showPortal` toggles the optional gateway-portal
+  // variant for that spawn. Read via `modelVerseSpawnedScenes`.
+  verseSpawnedScenes: S.Array(VerseSpawnedSceneState),
+
   // CS-A1: account-management surface state (add/select/priority over the
   // node's local dev.accounts config). `managedAccounts` holds the last
   // ManagedAccountsResponse projection (opaque, read via the typed accessor);
@@ -849,6 +869,14 @@ export const modelVerseKhalaReceipt = (
     rubric: null,
   }
 }
+
+// Dev affordance (#6033): the isolated scenes currently spawned into the live
+// Verse. A plain read of the model array — the scene mapper turns each id into the
+// in-world station + synthetic crackling-arc layer.
+export const modelVerseSpawnedScenes = (
+  model: Model,
+): ReadonlyArray<VerseSpawnedSceneState> =>
+  model.verseSpawnedScenes as ReadonlyArray<VerseSpawnedSceneState>
 
 // #5730: typed read boundary for the opaque chat-world state.
 export const modelChatWorldScene = (
@@ -1243,6 +1271,7 @@ export const initialModel: Model = Model.make({
   verseKhalaInFlight: false,
   verseKhalaStatus: { text: "", tone: "idle" },
   verseKhalaReceipt: null,
+  verseSpawnedScenes: [],
   managedAccounts: null,
   codeModeSync: null,
   managedAccountsPending: false,

--- a/apps/autopilot-desktop/src/ui/styles.css
+++ b/apps/autopilot-desktop/src/ui/styles.css
@@ -2104,6 +2104,41 @@ body {
   display: none;
 }
 
+/* Dev affordance (#6033): the spawned isolated-scene evidence overlay — mirrors
+   the standalone crackling-arc page's evidence block, anchored top-right so it
+   does not collide with the bulletin board on the left. */
+.verse-spawned-scene {
+  position: absolute;
+  right: clamp(0.8rem, 2vw, 1.25rem);
+  top: clamp(4.8rem, 13vh, 6.25rem);
+  z-index: 4;
+  display: grid;
+  gap: 0.5rem;
+  width: min(22rem, calc(100% - 1.6rem));
+  padding: 0.75rem 0.85rem;
+  border: 1px solid rgb(147 197 253 / 0.28);
+  border-radius: 4px;
+  background: rgb(3 8 10 / 0.76);
+  box-shadow:
+    0 18px 54px rgb(0 0 0 / 0.32),
+    inset 0 0 0 1px rgb(255 255 255 / 0.04);
+  color: rgb(244 247 251 / 0.86);
+  pointer-events: none;
+  user-select: none;
+}
+
+.verse-spawned-scene-empty {
+  display: none;
+}
+
+.verse-spawned-scene-evidence {
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  white-space: pre;
+  color: rgb(147 197 253 / 0.92);
+}
+
 .verse-bulletin-title {
   color: rgb(255 255 255 / 0.94);
   font-size: 0.82rem;

--- a/apps/autopilot-desktop/src/ui/update.ts
+++ b/apps/autopilot-desktop/src/ui/update.ts
@@ -169,6 +169,7 @@ import {
   CHAT_WORLD_INFERENCE_NODE_PREFIX,
 } from "../shared/chat-world-visualization.js"
 import { VERSE_TRAINING_NODE_PREFIX } from "../shared/verse-training-visualization.js"
+import { verseSpawnableSceneById } from "../shared/verse-spawned-scene.js"
 import type {
   AppleFmReadinessResponse,
   BuiltInAgentReadinessResponse,
@@ -225,6 +226,29 @@ const verseCodeControlsEnabled = (model: Model): boolean =>
 
 const verseControlsDisabled = (model: Model): boolean =>
   verseSceneActive(model) && !verseCodeControlsEnabled(model)
+
+// Dev affordance (#6033): toggle an isolated scene station in/out of the live
+// Verse spawn list. An unknown scene id is a no-op (never fabricate a scene). A
+// freshly spawned scene starts with its portal off. Pure model state.
+const toggleVerseSpawnedScene = (model: Model, sceneId: string): Model => {
+  if (verseSpawnableSceneById(sceneId) === null) return model
+  const present = model.verseSpawnedScenes.some((s) => s.sceneId === sceneId)
+  const verseSpawnedScenes = present
+    ? model.verseSpawnedScenes.filter((s) => s.sceneId !== sceneId)
+    : [...model.verseSpawnedScenes, { sceneId, showPortal: false }]
+  return Model.make({ ...model, verseSpawnedScenes })
+}
+
+// Flip the optional gateway-portal variant for an already-spawned scene. A scene
+// that is not currently spawned (or an unknown id) is a no-op.
+const toggleVerseSpawnedScenePortal = (model: Model, sceneId: string): Model => {
+  if (verseSpawnableSceneById(sceneId) === null) return model
+  if (!model.verseSpawnedScenes.some((s) => s.sceneId === sceneId)) return model
+  const verseSpawnedScenes = model.verseSpawnedScenes.map((s) =>
+    s.sceneId === sceneId ? { ...s, showPortal: !s.showPortal } : s,
+  )
+  return Model.make({ ...model, verseSpawnedScenes })
+}
 
 const openNewCoderSession = (model: Model): Result => {
   const codeModeAdapter =
@@ -1451,7 +1475,12 @@ export const update = (model: Model, message: Message): Result => {
         verseControlsDisabled(model) &&
         intent.kind !== "open-coder-session" &&
         intent.kind !== "close-managed-panes" &&
-        intent.kind !== "hide-code-dock"
+        intent.kind !== "hide-code-dock" &&
+        // Dev affordance (#6033): the spawn keys are explicit explore-mode shortcuts
+        // (interpretKey only emits them in the Verse explore context), so they are
+        // allowed through even though general explore-mode controls are disabled.
+        intent.kind !== "spawn-verse-scene" &&
+        intent.kind !== "toggle-verse-scene-portal"
       ) {
         return [model, noCommands]
       }
@@ -1488,6 +1517,16 @@ export const update = (model: Model, message: Message): Result => {
           if (verseControlsDisabled(model)) return [model, noCommands]
           return [
             Model.make({ ...model, verseEnabled: !model.verseEnabled }),
+            noCommands,
+          ]
+        case "spawn-verse-scene":
+          // Dev affordance (#6033): inline the spawn toggle (message constructors
+          // are type-only imports here). Byte-identical to the SpawnedVerseScene
+          // reducer below.
+          return [toggleVerseSpawnedScene(model, intent.sceneId), noCommands]
+        case "toggle-verse-scene-portal":
+          return [
+            toggleVerseSpawnedScenePortal(model, intent.sceneId),
             noCommands,
           ]
         case "open-coder-session":
@@ -1574,6 +1613,12 @@ export const update = (model: Model, message: Message): Result => {
     case "ToggleVerse":
       if (verseControlsDisabled(model)) return [model, noCommands]
       return [Model.make({ ...model, verseEnabled: !model.verseEnabled }), noCommands]
+    // Dev affordance (#6033): spawn / unspawn an isolated scene station into the
+    // live Verse, and toggle its optional gateway portal. Pure model state.
+    case "SpawnedVerseScene":
+      return [toggleVerseSpawnedScene(model, message.sceneId), noCommands]
+    case "ToggledVerseScenePortal":
+      return [toggleVerseSpawnedScenePortal(model, message.sceneId), noCommands]
     case "ClickedHotbarNewCoderSession":
       return openNewCoderSession(model)
     case "ChangedVerseMode": {

--- a/apps/autopilot-desktop/src/ui/view.ts
+++ b/apps/autopilot-desktop/src/ui/view.ts
@@ -97,6 +97,10 @@ import {
   withChatWorldPaymentLayer,
 } from "../shared/chat-world-visualization.js"
 import { withVerseKhalaEffectLayer } from "../shared/verse-khala-effect.js"
+import {
+  verseSpawnedSceneEvidenceLines,
+  withVerseSpawnedSceneLayer,
+} from "../shared/verse-spawned-scene.js"
 import { verseKhalaInputOverlay } from "./verse-khala-input.js"
 import {
   VERSE_TRAINING_NODE_PREFIX,
@@ -405,6 +409,7 @@ import {
   modelChatWorldMultiplayer,
   modelChatWorldScene,
   modelVerseKhalaReceipt,
+  modelVerseSpawnedScenes,
   modelCodeModeSync,
   modelManagedAccounts,
   modelPaneLayer,
@@ -7114,6 +7119,17 @@ export const verseSceneVisualization = (model: Model): TrainingRunVisualizationO
             z: model.verseSceneRestorePose.z,
           },
   })
+  // Dev affordance (#6033 / EPIC #6017): drop any spawned ISOLATED scene stations
+  // (crackling energy + optional portal) into the SAME live world, at a fixed
+  // in-world location, fed by a synthetic simulated event (no backend). Empty
+  // spawn list ⇒ this is a no-op and the Verse is byte-identical.
+  const withSpawned = withVerseSpawnedSceneLayer(
+    withKhalaEffect,
+    modelVerseSpawnedScenes(model).map((spawned) => ({
+      sceneId: spawned.sceneId,
+      knobs: { showPortal: spawned.showPortal },
+    })),
+  )
   const inputBindings = verseInputBindingProjection(
     model.inputProfile,
     model.verseMode === "code" ? "verse_code_overlay" : "verse_explore",
@@ -7133,11 +7149,11 @@ export const verseSceneVisualization = (model: Model): TrainingRunVisualizationO
           capturedAtMs: model.verseSceneRestorePose.capturedAtMs,
         }
   const navigable = {
-    ...withKhalaEffect,
+    ...withSpawned,
     cameraMode: "perspective_walk" as const,
     controller: "third_person_character" as const,
     keyboardTargeting: {
-      ...(withKhalaEffect.keyboardTargeting ?? {}),
+      ...(withSpawned.keyboardTargeting ?? {}),
       ...inputBindings.keyboardTargeting,
     },
     thirdPersonController: {
@@ -7150,7 +7166,7 @@ export const verseSceneVisualization = (model: Model): TrainingRunVisualizationO
       gravity: -13.5,
     },
     sceneChrome: {
-      ...(withKhalaEffect.sceneChrome ?? {}),
+      ...(withSpawned.sceneChrome ?? {}),
       lossPanel: "hidden" as const,
       statusChart: "hidden" as const,
     },
@@ -7252,6 +7268,39 @@ const chatSceneInspector = (model: Model): Html =>
         h.span([cls("chat-scene-inspector-ref")], [model.chatWorldInspectedRef]),
       ])
     : h.div([cls("chat-scene-inspector chat-scene-inspector-empty")], [])
+
+// Dev affordance (#6033 / EPIC #6017): the evidence overlay for any spawned
+// isolated scene, mirroring the standalone crackling-arc page's on-screen
+// `<pre class="evidence">` block (motionKind / sourceRefs / simulated /
+// evidenceMode / generatedAt / portal). Honest + isolated: it names every
+// spawned scene as a labelled simulation. Absent until something is spawned.
+const verseSpawnedSceneOverlay = (model: Model): Html => {
+  const spawned = modelVerseSpawnedScenes(model)
+  if (spawned.length === 0) {
+    return h.div([cls("verse-spawned-scene verse-spawned-scene-empty")], [])
+  }
+  return h.aside(
+    [
+      cls("verse-spawned-scene mono"),
+      h.AriaLabel("Spawned isolated scene evidence"),
+      h.DataAttribute("verse-spawned-scene", "active"),
+    ],
+    spawned.map((entry) =>
+      h.pre(
+        [
+          cls("verse-spawned-scene-evidence"),
+          h.DataAttribute("verse-spawned-scene-id", entry.sceneId),
+        ],
+        [
+          verseSpawnedSceneEvidenceLines({
+            sceneId: entry.sceneId,
+            knobs: { showPortal: entry.showPortal },
+          }).join("\n"),
+        ],
+      ),
+    ),
+  )
+}
 
 const verseBulletinBoardOverlay = (model: Model): Html => {
   const projection = verseTassadarBulletinOverlayProjection(
@@ -7430,6 +7479,7 @@ const chatSceneBackground = (model: Model): Html =>
     ),
     pylonBalanceHud(model),
     chatSceneInspector(model),
+    verseSpawnedSceneOverlay(model),
     verseBulletinBoardOverlay(model),
   ])
 

--- a/apps/autopilot-desktop/tests/verse-spawned-scene.test.ts
+++ b/apps/autopilot-desktop/tests/verse-spawned-scene.test.ts
@@ -1,0 +1,241 @@
+// Dev affordance (#6033 / EPIC #6017): spawn an ISOLATED scene (the Khala
+// "crackling energy" effect) into the SAME live Verse world the avatar walks in,
+// then walk up to it with the existing third-person character controller.
+//
+// Covers, with NO node, NO Region DO, NO D1, NO Worker, and NO live receipt:
+//   1. the spawned-scene layer mapper (synthetic, simulated, evidence-bound):
+//      a registered scene id produces a crackling_arc beam between two positioned
+//      in-world endpoints at a fixed station, labelled simulated:true; the portal
+//      toggle adds a gateway_portal entity; an unknown scene id produces NOTHING.
+//   2. the reducer toggles: spawn/unspawn a scene id, and flip its portal — both
+//      pure model state, idempotent, no-op for unknown ids.
+//   3. the ⌘⇧E / ⌘⇧P keyboard intents resolve to the spawn/portal toggles in the
+//      Verse explore context (and NOT in code mode / outside the Verse).
+//   4. the render assertion (the headline contract): spawning places the scene
+//      object(s) into the SAME world visualization read by trainingRunView, and
+//      that visualization still drives the avatar with the third_person_character
+//      controller — i.e. you can walk up to the spawned effect.
+
+import { describe, expect, test } from "bun:test"
+
+import {
+  verseSpawnedSceneLayer,
+  withVerseSpawnedSceneLayer,
+  verseSpawnedSceneEvidenceLines,
+  verseSpawnableSceneById,
+  VERSE_SPAWNABLE_SCENES,
+  VERSE_SPAWNED_SCENE_NODE_PREFIX,
+  VERSE_SPAWNED_SCENE_SOURCE_REF,
+  DEFAULT_SPAWNABLE_SCENE_ID,
+} from "../src/shared/verse-spawned-scene"
+import { initialModel, Model } from "../src/ui/model"
+import { update } from "../src/ui/update"
+import { interpretKey } from "../src/ui/keyboard"
+import { verseSceneVisualization } from "../src/ui/view"
+import { SpawnedVerseScene, ToggledVerseScenePortal, PressedKey } from "../src/ui/message"
+
+const CRACKLING = DEFAULT_SPAWNABLE_SCENE_ID
+
+const fromId = `${VERSE_SPAWNED_SCENE_NODE_PREFIX}${CRACKLING}:from`
+const toId = `${VERSE_SPAWNED_SCENE_NODE_PREFIX}${CRACKLING}:to`
+const portalId = `${VERSE_SPAWNED_SCENE_NODE_PREFIX}${CRACKLING}:portal`
+
+describe("verseSpawnedSceneLayer (isolated, synthetic, evidence-bound)", () => {
+  test("a registered scene produces a crackling_arc between two positioned endpoints", () => {
+    const layer = verseSpawnedSceneLayer({
+      sceneId: CRACKLING,
+      generatedAt: "2026-06-22T00:00:00.000Z",
+    })
+    expect(layer.beams).toHaveLength(1)
+    const beam = layer.beams[0]!
+    expect(beam.style).toBe("crackling_arc")
+    expect(beam.fromId).toBe(fromId)
+    expect(beam.toId).toBe(toId)
+    // Synthetic + evidence-bound: a real public ref authorizes it, but it is
+    // explicitly labelled as a developer simulation (no live receipt).
+    expect(beam.sourceRefs).toEqual([VERSE_SPAWNED_SCENE_SOURCE_REF])
+    expect(beam.simulated).toBe(true)
+    expect(beam.motionKind).toBe("crackling_energy")
+    // Two positioned endpoints sit in the live world at the fixed scene station.
+    expect(layer.entities).toHaveLength(2)
+    expect(layer.entities.every((e) => e.position !== undefined)).toBe(true)
+    // No portal by default.
+    expect(layer.entities.some((e) => e.id === portalId)).toBe(false)
+  })
+
+  test("the portal toggle adds a gateway_portal entity below the arc", () => {
+    const layer = verseSpawnedSceneLayer({
+      sceneId: CRACKLING,
+      knobs: { showPortal: true },
+    })
+    const portal = layer.entities.find((e) => e.id === portalId)
+    expect(portal).toBeDefined()
+    expect(portal?.visualKind).toBe("gateway_portal")
+    expect(portal?.gatewayLane).toBe("openrouter")
+  })
+
+  test("an unknown scene id produces nothing (never fabricate a scene)", () => {
+    const layer = verseSpawnedSceneLayer({ sceneId: "does-not-exist" })
+    expect(layer.entities).toHaveLength(0)
+    expect(layer.beams).toHaveLength(0)
+    expect(verseSpawnableSceneById("does-not-exist")).toBeNull()
+  })
+
+  test("withVerseSpawnedSceneLayer forces evidence:required and is a no-op when empty", () => {
+    const base = { nodes: [], entities: [], beams: [], bursts: [] } as never
+    const withScene = withVerseSpawnedSceneLayer(base, [{ sceneId: CRACKLING }])
+    expect(withScene.motionPolicy?.evidence).toBe("required")
+    expect((withScene.beams ?? []).length).toBe(1)
+
+    const empty = withVerseSpawnedSceneLayer(base, [])
+    expect(empty).toBe(base)
+    const unknownOnly = withVerseSpawnedSceneLayer(base, [{ sceneId: "nope" }])
+    expect(unknownOnly).toBe(base)
+  })
+
+  test("the evidence overlay lines mirror the standalone's contract block", () => {
+    const lines = verseSpawnedSceneEvidenceLines({
+      sceneId: CRACKLING,
+      knobs: { showPortal: true },
+    })
+    expect(lines.some((l) => l.includes("motionKind:") && l.includes("crackling_energy"))).toBe(true)
+    expect(lines.some((l) => l.includes("simulated:") && l.includes("true"))).toBe(true)
+    expect(lines.some((l) => l.includes("evidenceMode:") && l.includes("optional"))).toBe(true)
+    expect(lines.some((l) => l.includes(VERSE_SPAWNED_SCENE_SOURCE_REF))).toBe(true)
+    expect(lines.some((l) => l === "portal:       on")).toBe(true)
+    expect(VERSE_SPAWNABLE_SCENES.length).toBeGreaterThan(0)
+  })
+})
+
+describe("spawn reducer (pure model state, #6033)", () => {
+  test("SpawnedVerseScene toggles a scene id in and out of the spawn list", () => {
+    const [on] = update(initialModel, SpawnedVerseScene({ sceneId: CRACKLING }))
+    expect(on.verseSpawnedScenes.map((s) => s.sceneId)).toEqual([CRACKLING])
+    expect(on.verseSpawnedScenes[0]!.showPortal).toBe(false)
+    const [off] = update(on, SpawnedVerseScene({ sceneId: CRACKLING }))
+    expect(off.verseSpawnedScenes).toHaveLength(0)
+  })
+
+  test("an unknown scene id is a no-op", () => {
+    const [next] = update(initialModel, SpawnedVerseScene({ sceneId: "nope" }))
+    expect(next.verseSpawnedScenes).toHaveLength(0)
+  })
+
+  test("ToggledVerseScenePortal flips the portal only for a spawned scene", () => {
+    // No-op while the scene is not spawned.
+    const [bare] = update(initialModel, ToggledVerseScenePortal({ sceneId: CRACKLING }))
+    expect(bare.verseSpawnedScenes).toHaveLength(0)
+
+    const [on] = update(initialModel, SpawnedVerseScene({ sceneId: CRACKLING }))
+    const [withPortal] = update(on, ToggledVerseScenePortal({ sceneId: CRACKLING }))
+    expect(withPortal.verseSpawnedScenes[0]!.showPortal).toBe(true)
+    const [offPortal] = update(withPortal, ToggledVerseScenePortal({ sceneId: CRACKLING }))
+    expect(offPortal.verseSpawnedScenes[0]!.showPortal).toBe(false)
+  })
+})
+
+describe("spawn keyboard intents (#6033)", () => {
+  const exploreModel = Model.make({ ...initialModel, pane: "chat", verseMode: "explore" })
+
+  test("⌘⇧E resolves to spawn-verse-scene in the Verse explore context", () => {
+    const intent = interpretKey(exploreModel, {
+      key: "e",
+      meta: true,
+      ctrl: false,
+      shift: true,
+      inEditable: false,
+    })
+    expect(intent.kind).toBe("spawn-verse-scene")
+    if (intent.kind === "spawn-verse-scene") expect(intent.sceneId).toBe(CRACKLING)
+  })
+
+  test("⌘⇧P resolves to toggle-verse-scene-portal in the Verse explore context", () => {
+    const intent = interpretKey(exploreModel, {
+      key: "p",
+      meta: true,
+      ctrl: false,
+      shift: true,
+      inEditable: false,
+    })
+    expect(intent.kind).toBe("toggle-verse-scene-portal")
+  })
+
+  test("the ⌘⇧E PressedKey path actually spawns the scene", () => {
+    const [next] = update(
+      exploreModel,
+      PressedKey({ key: "e", meta: true, ctrl: false, shift: true, inEditable: false }),
+    )
+    expect(next.verseSpawnedScenes.map((s) => s.sceneId)).toEqual([CRACKLING])
+  })
+
+  test("the spawn keys do not fire in code mode (coding overlay owns its keys)", () => {
+    const codeModel = Model.make({ ...initialModel, pane: "chat", verseMode: "code" })
+    expect(
+      interpretKey(codeModel, { key: "e", meta: true, ctrl: false, shift: true, inEditable: false }).kind,
+    ).not.toBe("spawn-verse-scene")
+  })
+})
+
+describe("verseSceneVisualization places the spawned scene in the SAME world + keeps the avatar controller (#6033)", () => {
+  // The avatar's last pose: spawning must NOT move the avatar, and the
+  // third-person controller must still be present so you can walk up to the scene.
+  const poseModel = Model.make({
+    ...initialModel,
+    pane: "chat",
+    verseSceneRestorePose: {
+      regionRef: "world.region.tassadar",
+      x: 0,
+      y: 0,
+      z: 0,
+      yaw: 0,
+      animation: "idle",
+      capturedAtMs: 1,
+    },
+  })
+
+  test("before spawn: no spawned-scene objects in the world visualization", () => {
+    const before = verseSceneVisualization(poseModel)
+    expect((before.entities ?? []).some((e) => e.id.startsWith(VERSE_SPAWNED_SCENE_NODE_PREFIX))).toBe(false)
+    // The avatar is already walkable in the live world.
+    expect(before.controller).toBe("third_person_character")
+    expect(before.cameraMode).toBe("perspective_walk")
+    expect(before.thirdPersonController).toBeDefined()
+  })
+
+  test("after spawn: the crackling arc objects appear in the SAME world visualization", () => {
+    const spawned = Model.make({
+      ...poseModel,
+      verseSpawnedScenes: [{ sceneId: CRACKLING, showPortal: false }],
+    })
+    const after = verseSceneVisualization(spawned)
+    const entityIds = (after.entities ?? []).map((e) => e.id)
+    expect(entityIds).toContain(fromId)
+    expect(entityIds).toContain(toId)
+    const arc = (after.beams ?? []).find(
+      (b) => b.fromId === fromId && b.style === "crackling_arc",
+    )
+    expect(arc).toBeDefined()
+    expect(arc?.sourceRefs).toEqual([VERSE_SPAWNED_SCENE_SOURCE_REF])
+    expect(arc?.simulated).toBe(true)
+    // Evidence gate: the same renderer the rest of the Verse uses requires refs.
+    expect(after.motionPolicy?.evidence).toBe("required")
+
+    // The avatar/navigation is unchanged — you can walk up to it from any angle.
+    expect(after.controller).toBe("third_person_character")
+    expect(after.cameraMode).toBe("perspective_walk")
+    expect(after.thirdPersonController).toBeDefined()
+    // Spawning did not teleport the avatar's restore pose.
+    expect(spawned.verseSceneRestorePose).toEqual(poseModel.verseSceneRestorePose)
+  })
+
+  test("the portal toggle adds the gateway_portal object into the live world", () => {
+    const spawned = Model.make({
+      ...poseModel,
+      verseSpawnedScenes: [{ sceneId: CRACKLING, showPortal: true }],
+    })
+    const after = verseSceneVisualization(spawned)
+    const portal = (after.entities ?? []).find((e) => e.id === portalId)
+    expect(portal).toBeDefined()
+    expect((portal as { visualKind?: string } | undefined)?.visualKind).toBe("gateway_portal")
+  })
+})


### PR DESCRIPTION
## What landed

A **dev affordance to drop an isolated scene (the Khala "crackling energy" effect) into the SAME live Verse world** the Autopilot avatar already walks in — not a separate standalone pane. You spawn it with a key, it appears at a fixed in-world "scene station", and you walk up to it with the existing Verse third-person character controller and look at it from any angle. Its data is **synthetic/isolated** (no live backend).

It reuses the SAME `trainingRunView` renderer as the rest of the Verse: a `style:"crackling_arc"` beam becomes `createEvidenceBackedCracklingArc`, and a `visualKind:"gateway_portal"` entity becomes `createEvidenceBackedGatewayPortal` (three-effect `trainingRun.ts`) — no parallel scene.

- **`apps/autopilot-desktop/src/shared/verse-spawned-scene.ts`** (new): a registry of spawnable scenes (`crackling-energy` + a portal toggle) and a pure `withVerseSpawnedSceneLayer` that appends the crackling arc (and optional portal) at a fixed in-world station to the one Verse visualization. Fed by a **synthetic simulated event** (`simulated:true`, `evidenceMode:"optional"`, fixed public `sourceRef = github:OpenAgentsInc/openagents#6033`) — **no Region DO / D1 / Worker / live receipt**. Forces `motionPolicy.evidence:"required"` so nothing animates without the synthetic event. Extensible: more scenes register in `VERSE_SPAWNABLE_SCENES` and spawn the same way; the standalone's knobs (strandCount/rate/color/endpoints/portal) are exposed as typed options. Includes an evidence-overlay line builder mirroring the standalone's on-screen block.
- **`src/ui/view.ts`**: composes `withVerseSpawnedSceneLayer` into `verseSceneVisualization` (so spawned objects share the one scene + the existing `third_person_character` walk controller) and renders a top-right evidence overlay (motionKind / sourceRefs / simulated / evidenceMode / portal).
- **`src/ui/keyboard.ts` / `message.ts` / `model.ts` / `update.ts`**: `verseSpawnedScenes` model state; `SpawnedVerseScene` / `ToggledVerseScenePortal` messages; keyboard-intent + reducer wiring (pure model state, idempotent, no-op for unknown scene ids).
- **`src/ui/styles.css`**: the evidence-overlay styling.
- **`tests/verse-spawned-scene.test.ts`** (new): layer mapper, reducer toggles, keyboard intents + PressedKey path, and the headline render assertion.

## Steps to run + spawn + walk to the scene

1. Run the Autopilot desktop app (the Verse shows by default; explore mode).
2. **Spawn the scene:** press **⌘⇧E** (macOS) / **Ctrl⇧E**. The crackling-energy station appears in-world a short walk in front of spawn (around `[0, 0, -6]`), with a top-right evidence overlay showing `motionKind: crackling_energy`, `simulated: true`, `evidenceMode: optional`, and the source ref. Press ⌘⇧E again to unspawn.
3. **Toggle the gateway portal:** press **⌘⇧P** / **Ctrl⇧P** to add/remove the portal variant just below the arc.
4. **Walk up to it:** use the existing Verse movement keys to walk the avatar over to the station and orbit it — the camera/controller are unchanged (`third_person_character`, `perspective_walk`), so you can view the effect from any angle.

## Tests

- `bun run --cwd apps/autopilot-desktop typecheck` — clean.
- `tests/verse-spawned-scene.test.ts` — 15/15 pass (mapper, reducer, keyboard intents + PressedKey path, render assertion that spawning places the scene object(s) in the SAME world visualization while the avatar controller keeps driving).
- Full `apps/autopilot-desktop` per-file suite green; related Verse/chat-world suites green.

Relates #6033 / EPIC #6017. Builds on the merged standalone scene (three-effect#12) and `docs/game/2026-06-22-isolated-verse-scene-harness-audit.md`.

**DO NOT auto-merge — orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)