### PR TITLE
Fix: Verse spawn keybinding (⌘⇧E) never forwarded — register bindings + correct context gate

### DIFF
--- a/apps/autopilot-desktop/src/ui/keyboard.ts
+++ b/apps/autopilot-desktop/src/ui/keyboard.ts
@@ -141,14 +141,20 @@ export const interpretKey = (model: Model, event: KeyEvent): KeyIntent => {
     return { kind: "toggle-verse" }
   }
 
-  // ── Dev affordance (#6033): spawn an isolated scene station into the live ──
-  // Verse, and toggle its portal. Explore mode only (so coding overlay keys are
-  // untouched), and only while the Verse is on-screen.
-  if (isVerseExploreActionContext(model) && isModified(event) && event.shift) {
-    if (key.toLowerCase() === "e") {
+  // ── Dev affordance (#6033 / #6041): spawn an isolated scene station into the ─
+  // live Verse, and toggle its portal. Explore mode only (so coding overlay keys
+  // are untouched), and only while the Verse is on-screen. Driven by the
+  // registered `verse.spawn_scene` / `verse.toggle_scene_portal` input bindings
+  // (verse_explore context) rather than a hand-written raw-key check, so this
+  // path stays aligned with the same action catalog the subscription forward
+  // gate consults — the mismatch the #6041 bug came from. `actionIdsForKey`
+  // already filters to verse_explore + isVerseExploreActionContext(model).
+  {
+    const actionIds = actionIdsForKey(model, event)
+    if (actionIds.includes("verse.spawn_scene")) {
       return { kind: "spawn-verse-scene", sceneId: DEFAULT_SPAWNABLE_SCENE_ID }
     }
-    if (key.toLowerCase() === "p") {
+    if (actionIds.includes("verse.toggle_scene_portal")) {
       return {
         kind: "toggle-verse-scene-portal",
         sceneId: DEFAULT_SPAWNABLE_SCENE_ID,

--- a/apps/autopilot-desktop/src/ui/subscriptions.ts
+++ b/apps/autopilot-desktop/src/ui/subscriptions.ts
@@ -86,6 +86,13 @@ const DESKTOP_SHORTCUT_ACTION_IDS = new Set([
   "app.pane_next",
   "app.pane_previous",
   "hud.toggle_code_overlay",
+  // Dev affordance (#6033 / #6041): ⌘⇧E spawn / ⌘⇧P portal in the live Verse.
+  // These must be in the desktop forward allowlist so the keyboard subscription
+  // forwards them into the reducer (interpretKey already maps them). Without
+  // this they resolved to no action ids → forward=false → the keys were dropped
+  // before interpretKey ran, which is exactly why #6041's keys did nothing.
+  "verse.spawn_scene",
+  "verse.toggle_scene_portal",
   "palette.close",
   "palette.run",
   "palette.move_up",
@@ -129,7 +136,9 @@ export const keyboardForwardDecision = (input: {
   const modifiedShortcut = actionIds.some((actionId) =>
     actionId === "app.command_palette" ||
     actionId === "app.submit" ||
-    actionId === "hud.toggle_code_overlay"
+    actionId === "hud.toggle_code_overlay" ||
+    actionId === "verse.spawn_scene" ||
+    actionId === "verse.toggle_scene_portal"
   )
   const escapeKey = actionIds.includes("palette.close")
   const bareNavKey = actionIds.some((actionId) =>

--- a/apps/autopilot-desktop/tests/verse-spawned-scene.test.ts
+++ b/apps/autopilot-desktop/tests/verse-spawned-scene.test.ts
@@ -32,6 +32,7 @@ import { initialModel, Model } from "../src/ui/model"
 import { update } from "../src/ui/update"
 import { interpretKey } from "../src/ui/keyboard"
 import { verseSceneVisualization } from "../src/ui/view"
+import { keyboardForwardDecision } from "../src/ui/subscriptions"
 import { SpawnedVerseScene, ToggledVerseScenePortal, PressedKey } from "../src/ui/message"
 
 const CRACKLING = DEFAULT_SPAWNABLE_SCENE_ID
@@ -173,6 +174,96 @@ describe("spawn keyboard intents (#6033)", () => {
     expect(
       interpretKey(codeModel, { key: "e", meta: true, ctrl: false, shift: true, inEditable: false }).kind,
     ).not.toBe("spawn-verse-scene")
+  })
+})
+
+// #6041 REGRESSION: the FULL key path, from the keyboard subscription's forward
+// decision all the way to the spawned scene appearing in the world. The original
+// #6041 bug shipped because only interpretKey + the reducer were tested: the
+// spawn keys were never registered as input bindings, so the subscription forward
+// gate (keyboardForwardDecision) resolved them to NO action ids → forward=false →
+// the keydown was DROPPED before interpretKey ever ran. These tests construct the
+// EXACT model state that exists WHEN THE VERSE IS ON SCREEN — pane:"chat",
+// verseEnabled:true, verseMode:"explore" (see view.ts: the explore world renders
+// only at `model.pane === "chat" && verseVisible(model)`) — and drive a ⌘⇧E /
+// ⌘⇧P event through ALL THREE layers. They FAIL on pre-fix main (forward===false)
+// and pass after the input bindings are registered.
+describe("#6041 full key path: forward gate → interpretKey → reducer (the layer the original bug lived in)", () => {
+  // The real on-screen Verse explore state (view.ts gate, line ~8762).
+  const verseOnScreen = Model.make({
+    ...initialModel,
+    pane: "chat",
+    verseEnabled: true,
+    verseMode: "explore",
+    commandPaletteOpen: false,
+  })
+  // Sanity: this really is the state where the Verse world is shown — the
+  // explore visualization renders the walkable third-person world.
+  test("the constructed model is the actual on-screen Verse explore state", () => {
+    const viz = verseSceneVisualization(verseOnScreen)
+    expect(viz.controller).toBe("third_person_character")
+    expect(verseOnScreen.pane).toBe("chat")
+    expect(verseOnScreen.verseEnabled).toBe(true)
+    expect(verseOnScreen.verseMode).toBe("explore")
+  })
+
+  const spawnEvent = {
+    key: "e",
+    meta: true,
+    ctrl: false,
+    shift: true,
+    inEditable: false,
+  } as const
+  const portalEvent = {
+    key: "p",
+    meta: true,
+    ctrl: false,
+    shift: true,
+    inEditable: false,
+  } as const
+
+  test("⌘⇧E: subscription FORWARDS it (forward===true) — fails before the binding fix", () => {
+    const decision = keyboardForwardDecision(spawnEvent)
+    // This is the assertion the original bug fails: actionIds was empty so
+    // forward was false and the keydown never reached interpretKey/the reducer.
+    expect(decision.forward).toBe(true)
+    expect(decision.preventDefault).toBe(true)
+  })
+
+  test("⌘⇧E: interpretKey maps it to spawn-verse-scene in the on-screen Verse", () => {
+    const intent = interpretKey(verseOnScreen, spawnEvent)
+    expect(intent.kind).toBe("spawn-verse-scene")
+    if (intent.kind === "spawn-verse-scene") expect(intent.sceneId).toBe(CRACKLING)
+  })
+
+  test("⌘⇧E: full path — forwarded PressedKey spawns the scene into the world viz", () => {
+    // Gate the message exactly like the subscription does, then run the reducer.
+    expect(keyboardForwardDecision(spawnEvent).forward).toBe(true)
+    const [next] = update(verseOnScreen, PressedKey(spawnEvent))
+    expect(next.verseSpawnedScenes.map((s) => s.sceneId)).toEqual([CRACKLING])
+    // And the spawned arc is actually present in the SAME world visualization.
+    const viz = verseSceneVisualization(next)
+    const entityIds = (viz.entities ?? []).map((e) => e.id)
+    expect(entityIds).toContain(fromId)
+    expect(entityIds).toContain(toId)
+    expect((viz.beams ?? []).some((b) => b.fromId === fromId && b.style === "crackling_arc")).toBe(true)
+  })
+
+  test("⌘⇧P: subscription FORWARDS it (forward===true) — fails before the binding fix", () => {
+    const decision = keyboardForwardDecision(portalEvent)
+    expect(decision.forward).toBe(true)
+    expect(decision.preventDefault).toBe(true)
+  })
+
+  test("⌘⇧P: full path — toggles the gateway portal on an already-spawned scene", () => {
+    const [spawned] = update(verseOnScreen, PressedKey(spawnEvent))
+    expect(keyboardForwardDecision(portalEvent).forward).toBe(true)
+    const [next] = update(spawned, PressedKey(portalEvent))
+    expect(next.verseSpawnedScenes[0]!.showPortal).toBe(true)
+    const viz = verseSceneVisualization(next)
+    const portal = (viz.entities ?? []).find((e) => e.id === portalId)
+    expect(portal).toBeDefined()
+    expect((portal as { visualKind?: string } | undefined)?.visualKind).toBe("gateway_portal")
   })
 })
 

--- a/packages/input-bindings/src/index.ts
+++ b/packages/input-bindings/src/index.ts
@@ -361,6 +361,32 @@ export const openAgentsInputActionSpecs: ReadonlyArray<OpenAgentsInputActionSpec
     contexts: ["verse_explore", "verse_code_overlay"],
     defaultBindings: [],
   }),
+  // Dev affordance (#6033 / #6041): spawn an isolated crackling-energy scene
+  // station into the live Verse world (toggle in/out), and toggle that scene's
+  // optional gateway-portal variant. Explore-mode only, so the coding overlay
+  // keys are untouched. Registered as real input bindings (the #6041 author
+  // wired interpretKey + the reducer but never registered these, so the
+  // subscription forward gate dropped the keys before interpretKey ran). The
+  // ⌘⇧V toggle-code-overlay binding above is the working precedent for a
+  // primary+shift letter chord in verse_explore; ⌘⇧E / ⌘⇧P mirror it. The bare
+  // `interact.primary` (KeyE, no modifiers) is a keyboard_code binding and does
+  // not collide with this primary+shift keyboard_key chord.
+  action({
+    id: "verse.spawn_scene",
+    title: "Spawn Verse Scene",
+    category: "Verse",
+    kind: "toggle",
+    contexts: ["verse_explore"],
+    defaultBindings: [binding.key("e", { primary: true, shift: true })],
+  }),
+  action({
+    id: "verse.toggle_scene_portal",
+    title: "Toggle Verse Scene Portal",
+    category: "Verse",
+    kind: "toggle",
+    contexts: ["verse_explore"],
+    defaultBindings: [binding.key("p", { primary: true, shift: true })],
+  }),
   action({
     id: "app.command_palette",
     title: "Command Palette",


### PR DESCRIPTION
## Root cause

In the Autopilot desktop app, ⌘⇧E (spawn isolated Verse scene, #6041) and ⌘⇧P (scene portal toggle) did nothing — the keypress never took effect.

Two gates sit between a keydown and the reducer:

1. **Forward gate (`src/ui/subscriptions.ts`) — the actual bug.** The keyboard subscription only forwards a keydown when `forward = actionIds.length > 0`, where `actionIds` comes from the `@openagentsinc/input-bindings` registry (filtered to the desktop allowlist + active contexts). The #6041 author added ⌘⇧E/⌘⇧P cases to `interpretKey` and to the reducer, but **never registered them as input bindings**, so `resolveDesktopKeyboardActionIds` returned `[]` → `forward = false` → the keydown was dropped *before* `interpretKey` ever ran. Contrast ⌘⇧V (toggle code overlay), which is registered (`hud.toggle_code_overlay`) and works. Proven empirically on pre-fix main: `keyboardForwardDecision` returns `{forward:false}` for ⌘⇧E and ⌘⇧P, but `{forward:true}` for ⌘⇧V.

2. **Context gate — verified correct, no change needed.** `interpretKey`'s `isVerseExploreActionContext` requires `pane === "chat" && verseEnabled && verseMode === "explore"`. `view.ts` (~line 8762) renders the Verse explore world exactly at `model.pane === "chat" && verseVisible(model)`, with the default `verseMode === "explore"`. So when the Verse is on screen the gate already matches reality. (The default `pane` is `"network"`, the network home, not the Verse.) The gate was left as-is.

## The fix

- Registered two real action bindings in `@openagentsinc/input-bindings`:
  - `verse.spawn_scene` → `⌘⇧E` (`binding.key("e", { primary: true, shift: true })`)
  - `verse.toggle_scene_portal` → `⌘⇧P` (`binding.key("p", { primary: true, shift: true })`)
  - both scoped to the `verse_explore` context, mirroring the working ⌘⇧V (`hud.toggle_code_overlay`) precedent.
- Added both action ids to `DESKTOP_SHORTCUT_ACTION_IDS` and the `modifiedShortcut` preventDefault set in `subscriptions.ts`, so the forward gate now returns `forward:true, preventDefault:true` for these chords.
- Reworked `interpretKey` to resolve these via the registered action ids (`actionIdsForKey`) rather than a hand-written raw-key check, so the interpret path stays aligned with the same catalog the forward gate consults (the mismatch the bug came from).

No keybinding collision: ⌘⇧E does not collide with bare `interact.primary` (`KeyE`, no modifiers, a `keyboard_code` binding); the new chord is a primary+shift `keyboard_key` binding. Conflict detection over the default profile reports no conflicts for either new action. The two requested keys (⌘⇧E / ⌘⇧P) were kept as-is.

## Full-path test (fails before, passes after)

`apps/autopilot-desktop/tests/verse-spawned-scene.test.ts` gains a `#6041 full key path` describe block. The original bug shipped because only `interpretKey` + the reducer were tested — never the forward gate. The new tests construct the exact on-screen Verse state (`pane:"chat", verseEnabled:true, verseMode:"explore"`) and drive ⌘⇧E / ⌘⇧P through **all three layers**:

- `keyboardForwardDecision(...)` → asserts `forward === true` (+ `preventDefault`)
- `interpretKey(...)` → asserts `spawn-verse-scene` / `toggle-verse-scene-portal`
- the reducer (`update(model, PressedKey(...))`) → asserts the scene actually spawns into `verseSpawnedScenes` AND appears in the world visualization (`verseSceneVisualization`: crackling-arc beam + endpoints; portal entity).

Proven by reverting the source fix (`git stash`) and re-running: **4 fail on pre-fix source** (the forward-gate + full-path assertions), all pass after the fix. Full file: 21 pass / 0 fail.

## Verification

- `bun run --cwd apps/autopilot-desktop typecheck` — clean.
- `packages/input-bindings`: 16 pass, typecheck clean (incl. no-conflict check).
- `tests/verse-spawned-scene.test.ts`: 21 pass.
- **Full desktop suite via `bash scripts/run-tests.sh` (the per-file runner): all 90 test files pass, exit 0.** (Bare `bun test` wedges on the documented #5026 bun load-time deadlock — `__ulock_wait2` — unrelated to this change; the per-file runner is the repo's sanctioned way to run the whole suite.)
- Live keypress: **NOT confirmed.** The Electrobun dev renderer (`http://localhost:50000`) was not running, and a bare headless load of that URL would not initialize the Electrobun native bridge / Foldkit runtime that the `globalThis` keydown subscription attaches to, so a headless dispatch would not faithfully exercise the path. The fix is verified by the full-path test, which covers exactly the layer (the forward gate) the bug lived in.

## To reproduce / use in the app

Open the Verse (the chat-pane explore world is the default product surface, or toggle it with ⌘⇧V), then:
- **⌘⇧E** — spawn / unspawn the isolated crackling-energy scene station.
- **⌘⇧P** — toggle that scene's gateway-portal variant (only after it is spawned).

Fixes the #6041 keybinding.

**DO NOT auto-merge — orchestrator reviews/merges.**
