### PR TITLE
Add world-client stub feed helpers

### DIFF
--- a/packages/world-client/src/index.test.ts
+++ b/packages/world-client/src/index.test.ts
@@ -17,8 +17,11 @@ import {
   applyDeltaToReadModel,
   applyDeltaToState,
   commandAckFromReceipt,
+  createStubWorldClientTransport,
   createWorldClient,
   makeEmptyClientWorld,
+  makeStubWorldDelta,
+  makeStubWorldReadModel,
   projectWorldMinimapReadout,
   type WorldClientTransport,
 } from "./index.js"
@@ -93,6 +96,54 @@ const pylonRow = decodeWorldRow({
   position: { x: 25, y: 0, z: -25 },
   status: "working",
   updatedAt: observedAt,
+  safety,
+})
+
+const settlementRow = decodeWorldRow({
+  kind: "settlement_ref",
+  settlementRef: "settlement.khala.1",
+  runRef: "run.tassadar.executor.20260615",
+  label: "Khala mini completion receipt",
+  amountSats: 1,
+  updatedAt: observedAt,
+  safety,
+})
+
+const inferenceEventRow = decodeWorldRow({
+  kind: "world_event",
+  eventRef: "world_event.khala.inference.1",
+  regionRef,
+  runRef: "run.tassadar.executor.20260615",
+  eventKind: "inference.completion",
+  text: "Khala mini completion routed through the public proof feed.",
+  createdAt: observedAt,
+  sourceRefs: ["receipt.openagents.khala.1"],
+  inference: {
+    requestRef: "request.khala.1",
+    receiptRef: "receipt.openagents.khala.1",
+    model: "openagents/khala-mini",
+    route: "khala/fireworks",
+    workers: [
+      {
+        workerRef: "pylon.alpha",
+        workerKind: "pylon",
+        label: "Alpha Pylon",
+        role: "scene relay",
+        sourceRefs: ["pylon.alpha"],
+      },
+      {
+        workerRef: "gateway.fireworks",
+        workerKind: "gateway",
+        label: "Fireworks Gateway",
+        sourceRefs: ["gateway.fireworks"],
+      },
+    ],
+    verification: "test_passed",
+    costMsat: 125,
+    priceMsat: 250,
+    settled: true,
+    sourceRefs: ["receipt.openagents.khala.1"],
+  },
   safety,
 })
 
@@ -367,5 +418,99 @@ describe("world-client", () => {
     expect(ack.appliedSeq).toBe(7)
     expect(state.commandAcks["command.move.1"]?.appliedSeq).toBe(7)
     expect(commandAckFromReceipt(delta.receipt!).rejectedSeq).toBeUndefined()
+  })
+
+  test("stub read-model fixtures hydrate pylon, payment, and inference proof rows", () => {
+    const readModel = makeStubWorldReadModel({
+      regionRef,
+      generatedAt: observedAt,
+      rows: [regionRow, pylonRow, runRow, settlementRow, inferenceEventRow],
+    })
+
+    expect(readModel.pylons["pylon.alpha"]?.status).toBe("working")
+    expect(readModel.settlementRefs["settlement.khala.1"]?.amountSats).toBe(1)
+    expect(readModel.events["world_event.khala.inference.1"]?.inference).toMatchObject({
+      model: "openagents/khala-mini",
+      route: "khala/fireworks",
+      verification: "test_passed",
+      settled: true,
+    })
+  })
+
+  test("stub transport feeds fixture deltas through createWorldClient without backend services", async () => {
+    const transport = createStubWorldClientTransport({
+      regionRef,
+      generatedAt: observedAt,
+      rows: [regionRow, pylonRow, runRow, settlementRow, inferenceEventRow],
+      selectedRefs: ["pylon.alpha", "world_event.khala.inference.1"],
+    })
+    const client = createWorldClient({ transport, initialRegionRef: regionRef, now: () => observedAt })
+    const state = await Effect.runPromise(client.connect())
+    const plan = await Effect.runPromise(client.subscribe({
+      selectedRefs: ["settlement.khala.1"],
+    }))
+
+    expect(state.socketUrl).toBe(`stub://world-client/${regionRef}`)
+    expect(state.readModel.pylons["pylon.alpha"]?.label).toBe("Alpha Pylon")
+    expect(state.readModel.settlementRefs["settlement.khala.1"]?.label).toBe(
+      "Khala mini completion receipt",
+    )
+    expect(state.readModel.events["world_event.khala.inference.1"]?.inference?.priceMsat).toBe(250)
+    expect(plan.interest.selectedRefs.map(String)).toEqual(["settlement.khala.1"])
+  })
+
+  test("stub transport command handlers can append contract-checked fixture deltas", async () => {
+    const command: WorldCommandEnvelope = decodeWorldCommandEnvelope({
+      schemaVersion: "openagents.world_contract.v1",
+      commandRef: "command.focus.pylon.1",
+      command: "focus_pylon",
+      actorClass: "browser",
+      actorRef: "actor.alice",
+      regionRef,
+      seq: 9,
+      issuedAt: observedAt,
+      payload: { pylonRef: "pylon.alpha" },
+    })
+    const transport = createStubWorldClientTransport({
+      regionRef,
+      generatedAt: observedAt,
+      rows: [regionRow, pylonRow],
+      onCommand: (received, context) =>
+        makeStubWorldDelta({
+          regionRef,
+          cursor: `cursor.${regionRef}.stub.command.${context.sequence}`,
+          generatedAt: observedAt,
+          rows: [
+            {
+              kind: "agent_intent",
+              intentRef: "intent.focus.pylon.1",
+              avatarRef: "avatar.alice",
+              regionRef,
+              intent: "focus_pylon:pylon.alpha",
+              targetRef: "pylon.alpha",
+              createdAt: observedAt,
+              expiresAt: "2026-06-22T00:00:05.000Z",
+              safety,
+            },
+          ],
+          receipt: {
+            receiptRef: "receipt.focus.pylon.1",
+            commandRef: received.commandRef,
+            command: received.command,
+            status: "applied",
+            actorClass: received.actorClass,
+            acceptedSeq: context.sequence,
+            appliedSeq: context.sequence,
+            observedAt,
+            changedRefs: ["intent.focus.pylon.1"],
+          },
+        }),
+    })
+    const client = createWorldClient({ transport, initialRegionRef: regionRef, now: () => observedAt })
+    const ack = await Effect.runPromise(client.callCommand(command))
+    const readModel = await Effect.runPromise(client.readModel())
+
+    expect(ack.status).toBe("applied")
+    expect(String(readModel.intents["intent.focus.pylon.1"]?.targetRef)).toBe("pylon.alpha")
   })
 })

--- a/packages/world-client/src/index.ts
+++ b/packages/world-client/src/index.ts
@@ -1,6 +1,7 @@
 import { Data, Effect } from "effect"
 
 import {
+  WORLD_DELTA_SCHEMA_VERSION,
   WORLD_READ_MODEL_SCHEMA_VERSION,
   WORLD_CONTRACT_SCHEMA_VERSION,
   decodeWorldDelta,
@@ -390,6 +391,252 @@ export const makeEmptyClientWorld = (
     events: {},
     diagnostics: [],
   })
+
+export type StubWorldSubscriptionPlanInput = Readonly<{
+  regionRef: string
+  planRef?: string
+  scope?: WorldSubscriptionPlan["scope"]
+  runRef?: string
+  selectedEntityRef?: string
+  selectedRefs?: ReadonlyArray<string>
+  resumeCursor?: string
+  center?: Readonly<{ x: number; y: number; z: number }>
+  enterRadius?: number
+  dropRadius?: number
+  nearRadius?: number
+  farRadius?: number
+  nearUpdateMs?: number
+  farUpdateMs?: number
+}>
+
+export const makeStubWorldSubscriptionPlan = (
+  input: StubWorldSubscriptionPlanInput,
+): WorldSubscriptionPlan =>
+  decodeWorldSubscriptionPlan({
+    planRef: input.planRef ?? `plan.stub.${input.regionRef}`,
+    regionRef: input.regionRef,
+    scope: input.scope ?? "region",
+    ...(input.runRef === undefined ? {} : { runRef: input.runRef }),
+    ...(input.selectedEntityRef === undefined ? {} : { selectedEntityRef: input.selectedEntityRef }),
+    interest: {
+      center: input.center ?? { x: 0, y: 0, z: 0 },
+      enterRadius: input.enterRadius ?? 90,
+      dropRadius: input.dropRadius ?? 120,
+      nearRadius: input.nearRadius ?? 32,
+      farRadius: input.farRadius ?? 120,
+      selectedRefs: [...(input.selectedRefs ?? [])],
+    },
+    nearUpdateMs: input.nearUpdateMs ?? 100,
+    farUpdateMs: input.farUpdateMs ?? 1000,
+    ...(input.resumeCursor === undefined ? {} : { resumeCursor: input.resumeCursor }),
+  })
+
+export type StubWorldDeltaInput = Readonly<{
+  regionRef: string
+  cursor: string
+  generatedAt: string
+  deltaRef?: string
+  kind?: WorldDelta["kind"]
+  rows?: ReadonlyArray<unknown>
+  patches?: ReadonlyArray<unknown>
+  deletedRefs?: ReadonlyArray<string>
+  receipt?: unknown
+  diagnostic?: unknown
+}>
+
+export const makeStubWorldDelta = (input: StubWorldDeltaInput): WorldDelta =>
+  decodeWorldDelta({
+    schemaVersion: WORLD_DELTA_SCHEMA_VERSION,
+    deltaRef: input.deltaRef ?? `delta.${input.cursor}`,
+    kind: input.kind ?? "update",
+    regionRef: input.regionRef,
+    cursor: input.cursor,
+    generatedAt: input.generatedAt,
+    ...(
+      input.rows === undefined
+        ? {}
+        : { rows: input.rows.map(row => decodeWorldRow(row)) }
+    ),
+    ...(input.patches === undefined ? {} : { patches: [...input.patches] }),
+    ...(input.deletedRefs === undefined ? {} : { deletedRefs: [...input.deletedRefs] }),
+    ...(input.receipt === undefined ? {} : { receipt: input.receipt }),
+    ...(input.diagnostic === undefined ? {} : { diagnostic: input.diagnostic }),
+  })
+
+export type StubWorldReadModelInput = Readonly<{
+  regionRef: string
+  generatedAt?: string
+  cursor?: string
+  rows?: ReadonlyArray<unknown>
+  deltas?: ReadonlyArray<unknown>
+}>
+
+export const makeStubWorldReadModel = (
+  input: StubWorldReadModelInput,
+): ClientWorld => {
+  const generatedAt = input.generatedAt ?? worldClientNowIso()
+  const cursor = input.cursor ?? `cursor.${input.regionRef}.stub.0`
+  const seedDeltas = [
+    ...(
+      input.rows === undefined
+        ? []
+        : [
+            makeStubWorldDelta({
+              regionRef: input.regionRef,
+              cursor,
+              deltaRef: `delta.${cursor}`,
+              generatedAt,
+              kind: "snapshot",
+              rows: input.rows,
+            }),
+          ]
+    ),
+    ...(input.deltas ?? []).map(delta => decodeWorldDelta(delta)),
+  ]
+
+  return seedDeltas.reduce(
+    (readModel, delta) => applyDeltaToReadModel(readModel, delta),
+    makeEmptyClientWorld(input.regionRef, generatedAt, cursor),
+  )
+}
+
+export type StubWorldClientCommandContext = Readonly<{
+  regionRef: string
+  generatedAt: string
+  cursor: string
+  sequence: number
+  readModel: ClientWorld
+}>
+
+export type StubWorldClientCommandHandler = (
+  command: WorldCommandEnvelope,
+  context: StubWorldClientCommandContext,
+) => WorldDelta | undefined
+
+export type StubWorldClientTransportInput = Readonly<{
+  regionRef: string
+  socketUrl?: string
+  generatedAt?: string
+  cursor?: string
+  rows?: ReadonlyArray<unknown>
+  deltas?: ReadonlyArray<unknown>
+  selectedRefs?: ReadonlyArray<string>
+  subscriptionPlan?: WorldSubscriptionPlan
+  onCommand?: StubWorldClientCommandHandler
+}>
+
+export const createStubWorldClientTransport = (
+  input: StubWorldClientTransportInput,
+): WorldClientTransport => {
+  const regionRef = input.regionRef
+  const generatedAt = input.generatedAt ?? worldClientNowIso()
+  const cursor = input.cursor ?? `cursor.${regionRef}.stub.0`
+  const seedDeltas = [
+    ...(
+      input.rows === undefined
+        ? []
+        : [
+            makeStubWorldDelta({
+              regionRef,
+              cursor,
+              deltaRef: `delta.${cursor}`,
+              generatedAt,
+              kind: "snapshot",
+              rows: input.rows,
+            }),
+          ]
+    ),
+    ...(input.deltas ?? []).map(delta => decodeWorldDelta(delta)),
+  ]
+  const socketUrl = input.socketUrl ?? `stub://world-client/${regionRef}`
+  let historyDeltas = seedDeltas
+  let readModel = makeStubWorldReadModel({
+    regionRef,
+    generatedAt,
+    cursor,
+    deltas: historyDeltas,
+  })
+  let commandSequence = historyDeltas.length
+
+  const planFor = (request: WorldClientConnectRequest): WorldSubscriptionPlan => {
+    if (input.subscriptionPlan !== undefined) return input.subscriptionPlan
+    const selectedRefs = request.selectedRefs ?? input.selectedRefs
+    return makeStubWorldSubscriptionPlan({
+      regionRef,
+      scope: request.scope ?? "region",
+      ...(request.runRef === undefined ? {} : { runRef: request.runRef }),
+      ...(request.selectedEntityRef === undefined ? {} : { selectedEntityRef: request.selectedEntityRef }),
+      ...(selectedRefs === undefined ? {} : { selectedRefs }),
+      ...(request.resumeCursor === undefined ? {} : { resumeCursor: request.resumeCursor }),
+    })
+  }
+
+  const connect = (
+    request: WorldClientConnectRequest,
+    phase: "connect" | "subscribe",
+  ): Effect.Effect<WorldClientConnectResult, WorldClientError> =>
+    Effect.tryPromise({
+      try: async () => ({
+        regionRef,
+        socketUrl,
+        subscriptionPlan: planFor(request),
+        deltas: request.resumeCursor === readModel.cursor ? [] : historyDeltas,
+      }),
+      catch: error => new WorldClientError({
+        phase,
+        reason: error instanceof Error ? error.message : "Stub world transport failed to connect.",
+        retryable: false,
+        sourceRefs: ["world-client.stub.connect"],
+      }),
+    })
+
+  return {
+    connect: request => connect(request, "connect"),
+    subscribe: request => connect(request, "subscribe"),
+    command: command =>
+      Effect.tryPromise({
+        try: async () => {
+          commandSequence += 1
+          const nextGeneratedAt = worldClientNowIso()
+          const nextCursor = `cursor.${regionRef}.stub.command.${commandSequence}`
+          const delta = input.onCommand?.(command, {
+            regionRef,
+            generatedAt: nextGeneratedAt,
+            cursor: readModel.cursor,
+            sequence: commandSequence,
+            readModel,
+          }) ?? makeStubWorldDelta({
+            regionRef,
+            cursor: nextCursor,
+            deltaRef: `delta.stub.command.${commandSequence}`,
+            generatedAt: nextGeneratedAt,
+            receipt: {
+              receiptRef: `receipt.stub.${command.commandRef}`,
+              commandRef: command.commandRef,
+              command: command.command,
+              status: "accepted",
+              actorClass: command.actorClass,
+              acceptedSeq: commandSequence,
+              observedAt: nextGeneratedAt,
+              changedRefs: [],
+            },
+          })
+          historyDeltas = [...historyDeltas, delta]
+          readModel = applyDeltaToReadModel(readModel, delta)
+          return delta
+        },
+        catch: error => error instanceof WorldClientError
+          ? error
+          : new WorldClientError({
+              phase: "command",
+              reason: error instanceof Error ? error.message : "Stub world command failed.",
+              retryable: false,
+              sourceRefs: ["world-client.stub.command"],
+            }),
+      }),
+    disconnect: () => Effect.void,
+  }
+}
 
 export type WorldMinimapMarkerKind =
   | "assignment"


### PR DESCRIPTION
## Problem

#6033 needs an in-repo world-client stub feed slice so isolated scene runners can hydrate useful public-proof fixtures without Region DO, D1, Worker, or live receipt services.

## Changes

- Adds contract-checked `makeStubWorldSubscriptionPlan`, `makeStubWorldDelta`, and `makeStubWorldReadModel` helpers.
- Adds `createStubWorldClientTransport`, an Effect-shaped transport that replays fixture history on connect/subscribe and can append command deltas.
- Adds tests for pylon, settlement/payment, and inference event fixtures flowing through `createWorldClient`, plus a command-handler delta path.

## Validation

- `bun run --cwd packages/world-client test`
- `bun run --cwd packages/world-client typecheck`

## Maintenance / Revenue Value

This gives the isolated Verse/scene work from #6033 a reusable public-proof feed input in `packages/world-client`, while keeping product-promise boundaries explicit: fixtures can represent pylon/payment/inference projection state without claiming backend settlement or provider usage.

## Intentionally Not Changed

- No `three-effect` scene-runner convention or headless capture work.
- No app-local visual renderer changes.
- No live payment, provider, receipt, or settlement behavior.
