### PR TITLE
Deterministic Effect-style environment testing: full-input-path harness + headless pixel verification

### DIFF
--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -16,6 +16,7 @@
     "smoke:forum-tipping-multiplayer": "bun test tests/forum-tipping-multiplayer-integration.test.ts",
     "smoke:apple-fm-local": "bun scripts/apple-fm-live-smoke.ts",
     "smoke:khala-cockpit": "bun scripts/khala-cockpit-smoke.ts",
+    "proof:crackling-arc-pixels": "bun scripts/crackling-arc-pixel-regression.ts",
     "proof:verse-coding-overlay": "bun scripts/verse-launch-smoke.ts",
     "proof:composer": "bun scripts/composer-loop-proof.ts",
     "proof:account-picker": "bun scripts/account-picker-proof.ts",

--- a/apps/autopilot-desktop/scripts/crackling-arc-entry.ts
+++ b/apps/autopilot-desktop/scripts/crackling-arc-entry.ts
@@ -1,0 +1,109 @@
+// Headless render entry: the SPAWNED crackling arc, through the REAL render path.
+//
+// This mounts the real `oa-training-run` three-effect element with the
+// visualization produced by the REAL `withVerseSpawnedSceneLayer` mapper (the
+// same function `verseSceneVisualization` uses for a spawned scene). It is built
+// into a browser bundle and loaded by the headless-pixel harness, which then
+// advances deterministic frames and screenshots.
+//
+// A query param `?broken=1` produces the Mode-2 failure: the beam is STILL in
+// the model, but its evidence `sourceRefs` are stripped. The renderer's
+// `evidence: "required"` gate then suppresses the arc, so it renders NOTHING —
+// exactly the "model says it's there, screen shows nothing" bug. The regression
+// asserts the fixed variant lights up bright pixels and the broken one does not.
+
+import {
+  registerTrainingRunElement,
+  trainingRunTagName,
+} from "@openagentsinc/three-effect/foldkit"
+import {
+  trainingRunVisualizationOptionsFromSnapshot,
+  type TrainingRunVisualizationOptions,
+} from "@openagentsinc/three-effect/core"
+
+import {
+  withVerseSpawnedSceneLayer,
+  VERSE_SPAWNED_SCENE_STATION_POSITION,
+  DEFAULT_SPAWNABLE_SCENE_ID,
+} from "../src/shared/verse-spawned-scene.js"
+
+registerTrainingRunElement()
+
+// A minimal, deterministic base world (mirrors the training-scene smoke seed,
+// trimmed). The arc is positioned at the fixed scene station and aimed at the
+// camera-facing band so it lights the upper-mid region of the frame.
+const baseVisualization: TrainingRunVisualizationOptions =
+  trainingRunVisualizationOptionsFromSnapshot({
+    activeWindowCount: 0,
+    assignedContributorCount: 0,
+    blockerRefCount: 0,
+    closeoutSatisfied: false,
+    deviceObserved: 0,
+    deviceRequired: 0,
+    externalStatus: "observed",
+    finalValidationLoss: 3,
+    freivaldsRefCount: 0,
+    gradientCloseoutRefCount: 0,
+    lifecycleCounts: {
+      active: 0,
+      qualified: 0,
+      registered: 0,
+      state_synced: 0,
+      sync_reentry: 0,
+      warmup: 0,
+    },
+    maxAllowedStaleSteps: 5,
+    maxValidationLoss: 3.5,
+    operatorSignals: [],
+    pendingPayoutCount: 0,
+    plannedWindowCount: 0,
+    promiseSignals: [],
+    receiptRefCount: 0,
+    reconciledWindowCount: 0,
+    rejectedWorkCount: 0,
+    runDetail: "render-harness.crackling",
+    runLabel: "render-harness.crackling",
+    runState: "active",
+    sealInFlight: false,
+    sealedWindowCount: 0,
+    settledPayoutSats: 0,
+    verifiedWorkCount: 0,
+  })
+
+// The REAL spawned-scene render path: a crackling_arc beam evidence-bound to its
+// synthetic source ref, with motionPolicy.evidence = "required".
+const spawned = withVerseSpawnedSceneLayer(baseVisualization, [
+  {
+    sceneId: DEFAULT_SPAWNABLE_SCENE_ID,
+    station: VERSE_SPAWNED_SCENE_STATION_POSITION,
+    generatedAt: "2026-06-22T00:00:00.000Z",
+  },
+])
+
+const broken = new URLSearchParams(globalThis.location?.search ?? "").get(
+  "broken",
+)
+
+// Broken variant: strip the beams' evidence refs so the renderer's
+// evidence:required gate suppresses them. The beam is STILL in the model.
+const visualization: TrainingRunVisualizationOptions =
+  broken === "1"
+    ? {
+        ...spawned,
+        beams: (spawned.beams ?? []).map((beam) => ({
+          ...beam,
+          sourceRefs: [],
+        })),
+      }
+    : spawned
+
+const host = document.createElement(trainingRunTagName) as HTMLElement & {
+  visualization: TrainingRunVisualizationOptions
+}
+host.id = "crackling-scene"
+host.style.display = "block"
+host.style.width = "960px"
+host.style.height = "540px"
+host.style.minHeight = "540px"
+host.visualization = visualization
+document.getElementById("scene")?.append(host)

--- a/apps/autopilot-desktop/scripts/crackling-arc-pixel-regression.ts
+++ b/apps/autopilot-desktop/scripts/crackling-arc-pixel-regression.ts
@@ -1,0 +1,69 @@
+// Runnable headless pixel regression for the spawned crackling arc.
+//
+// Mounts the REAL three-effect element with the REAL spawned-scene
+// visualization in headless Chromium, advances DETERMINISTIC fixed frames, and
+// asserts the crackling arc actually paints pixels — and that suppressing it
+// (evidence refs stripped → evidence:required gate) collapses its footprint.
+//
+// This is the script form of tests/crackling-arc-pixel-regression.test.ts, for
+// running outside `bun test` (e.g. a proof gate). Exits non-zero on failure.
+
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
+
+import {
+  renderVisualizationAndProbe,
+  resolveChromePathOrNull,
+} from "../src/testing/headless-pixel"
+
+const ARC_REGION = { x0: 0.2, y0: 0.0, x1: 0.85, y1: 0.6 } as const
+const FRAME_STEPS = 120
+const FRAME_DELTA_MS = 16
+
+const main = async (): Promise<void> => {
+  if (resolveChromePathOrNull() === null) {
+    console.log(
+      "crackling-arc-pixel-regression: no Chromium binary found (set CHROME_PATH); skipping.",
+    )
+    return
+  }
+  const here = dirname(fileURLToPath(import.meta.url))
+  const entryModulePath = join(here, "./crackling-arc-entry.ts")
+
+  const fixed = await renderVisualizationAndProbe({
+    entryModulePath,
+    frameSteps: FRAME_STEPS,
+    frameDeltaMs: FRAME_DELTA_MS,
+  })
+  const broken = await renderVisualizationAndProbe({
+    entryModulePath,
+    frameSteps: FRAME_STEPS,
+    frameDeltaMs: FRAME_DELTA_MS,
+    pageQuery: "broken=1",
+  })
+
+  const fixedScore = fixed.score(ARC_REGION)
+  const brokenScore = broken.score(ARC_REGION)
+  const arcContribution = fixedScore.brightPixels - brokenScore.brightPixels
+
+  const result = {
+    canvasWidth: fixed.canvasWidth,
+    canvasHeight: fixed.canvasHeight,
+    framesAdvanced: fixed.framesAdvanced,
+    fixedBrightPixels: fixedScore.brightPixels,
+    brokenBrightPixels: brokenScore.brightPixels,
+    arcContribution,
+    ok: arcContribution > 400 && brokenScore.brightPixels < fixedScore.brightPixels,
+  }
+  console.log(JSON.stringify(result, null, 2))
+  if (!result.ok) {
+    throw new Error(
+      `crackling arc did not render its expected pixel footprint (contribution=${arcContribution})`,
+    )
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/apps/autopilot-desktop/src/testing/deterministic-env.ts
+++ b/apps/autopilot-desktop/src/testing/deterministic-env.ts
@@ -1,0 +1,92 @@
+// Effect Layer-injected deterministic test environment.
+//
+// The rule (effect-solutions `testing`): code under test must NOT reach for
+// `Date.now`, `Math.random`, or `requestAnimationFrame`/wall-clock. Those come
+// from INJECTED services so a test fully controls them, and the same input
+// always produces the same output. This module provides the small, reusable
+// service set those tests share:
+//
+//   • Clock      → Effect TestClock (advance time explicitly via TestClock.adjust)
+//   • Random     → seeded (Random.withSeed) — reproducible "randomness"
+//   • Transport  → a scripted stub (no network) injected by Layer
+//
+// Effect 4 (beta.70) APIs: TestClock lives in `effect/testing`, deterministic
+// randomness is `Random.withSeed("seed")`, and services are `Context.Service`.
+
+import { Context, Effect, Layer, Random } from "effect"
+import { TestClock } from "effect/testing"
+
+// ── Transport service (stubbed by Layer) ──────────────────────────────────────
+//
+// A minimal request/response transport. Production wires a real fetch/RPC layer;
+// tests wire `stubTransportLayer(scriptedResponses)` so a service under test
+// talks to a scripted fake instead of the network. This is the "stub transport"
+// the harness reuses.
+export type TransportRequest = Readonly<{ method: string; payload: unknown }>
+
+export class Transport extends Context.Service<
+  Transport,
+  {
+    readonly call: (
+      request: TransportRequest,
+    ) => Effect.Effect<unknown, TransportError>
+    // Every request the transport has seen, in order — so a test can assert the
+    // exact calls a service made.
+    readonly calls: Effect.Effect<ReadonlyArray<TransportRequest>>
+  }
+>()("autopilot-desktop/testing/Transport") {}
+
+export class TransportError {
+  readonly _tag = "TransportError"
+  constructor(readonly reason: string) {}
+}
+
+// A deterministic stub transport: returns scripted responses keyed by method,
+// records every call, and fails (never hangs) on an unscripted method.
+export const stubTransportLayer = (
+  responses: Readonly<Record<string, unknown>>,
+): Layer.Layer<Transport> =>
+  Layer.effect(
+    Transport,
+    Effect.sync(() => {
+      const recorded: TransportRequest[] = []
+      return {
+        call: (request: TransportRequest) =>
+          Effect.sync(() => recorded.push(request)).pipe(
+            Effect.flatMap(() =>
+              request.method in responses
+                ? Effect.succeed(responses[request.method])
+                : Effect.fail(
+                    new TransportError(`unscripted method: ${request.method}`),
+                  ),
+            ),
+          ),
+        calls: Effect.sync(() => [...recorded]),
+      }
+    }),
+  )
+
+// ── The deterministic environment layer ───────────────────────────────────────
+//
+// Combines the TestClock (deterministic, explicit time) with a stub transport.
+// Randomness is applied per-effect with `withSeed` (below) rather than baked in,
+// so each test can pick its own seed and have it recorded as evidence.
+export const TestEnvironmentLayer = (
+  responses: Readonly<Record<string, unknown>> = {},
+): Layer.Layer<Transport> =>
+  Layer.mergeAll(TestClock.layer(), stubTransportLayer(responses))
+
+// Run an effect under a fixed RNG seed so "random" is reproducible. `seed` is
+// returned alongside the value so a test can record it as evidence.
+export const withSeed = <A, E, R>(
+  seed: string,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => Random.withSeed(seed)(effect)
+
+// Convenience: read the current TestClock time (ms). Starts at 0 and only moves
+// when a test calls `TestClock.adjust`.
+export const currentMillis: Effect.Effect<number> = Effect.clockWith((clock) =>
+  clock.currentTimeMillis,
+)
+
+export { TestClock }

--- a/apps/autopilot-desktop/src/testing/full-input-path.ts
+++ b/apps/autopilot-desktop/src/testing/full-input-path.ts
@@ -1,0 +1,158 @@
+// Full-input-path test harness (#6041 class of bugs).
+//
+// WHY: the original ⌘⇧E / ⌘⇧P bug (#6041) shipped with a GREEN reducer test
+// because the test started at `update(model, PressedKey(...))` — AFTER the part
+// that was broken. The live desktop path is:
+//
+//   keydown (DOM)
+//     → keyboardForwardDecision(...)   FORWARD GATE (subscriptions.ts)
+//       → PressedKey queued            (only if forward === true)
+//         → interpretKey(model, ev)    (keyboard.ts)
+//           → reducer update(...)      (update.ts)
+//             → next Model
+//               → verseSceneVisualization(model)  (view.ts — feeds the renderer)
+//
+// The bug lived in the FORWARD GATE: the spawn keys resolved to zero action ids,
+// so `forward` was false and the keydown was dropped before `interpretKey` ran.
+// A reducer-only test can never see that.
+//
+// THIS HARNESS drives the WHOLE path in one call, in the SAME order the live DOM
+// handler in subscriptions.ts uses, calling the REAL `keyboardForwardDecision`,
+// the REAL reducer, and the REAL visualization projection. If the gate drops the
+// key, `dispatched` is false and `nextModel === model` — i.e. the #6041 bug is
+// directly observable. Any new input feature tested through this util is tested
+// end to end, so we stop shipping keybindings whose reducer test is green but
+// whose live key does nothing.
+
+import type { OpenAgentsInputActionMap } from "@openagentsinc/input-bindings"
+
+import { keyboardForwardDecision } from "../ui/subscriptions.js"
+import { interpretKey, type KeyEvent, type KeyIntent } from "../ui/keyboard.js"
+import { update } from "../ui/update.js"
+import { PressedKey } from "../ui/message.js"
+import type { Model } from "../ui/model.js"
+import { verseSceneVisualization } from "../ui/view.js"
+import { VERSE_SPAWNED_SCENE_NODE_PREFIX } from "../shared/verse-spawned-scene.js"
+
+export type FullInputPathOptions = Readonly<{
+  // Inject an alternate input action map to prove the harness fails on a
+  // deliberately-broken binding set and passes on the real one. Defaults to the
+  // production desktop action map (whatever keyboardForwardDecision uses).
+  actionMap?: OpenAgentsInputActionMap
+}>
+
+export type FullInputPathOutcome = Readonly<{
+  // The forward gate (subscriptions.ts). `false` here is exactly the #6041 bug.
+  forwarded: boolean
+  preventDefault: boolean
+  // Did a PressedKey actually reach the reducer? Mirrors the live handler:
+  // the message is only queued when the gate forwards.
+  dispatched: boolean
+  // What interpretKey resolved the key to (only meaningful when dispatched).
+  intent: KeyIntent
+  // Reducer output. Identical to the input model when the gate dropped the key.
+  nextModel: Model
+  // The world visualization the renderer consumes for `nextModel`.
+  visualization: ReturnType<typeof verseSceneVisualization>
+  // Convenience projection: scene ids spawned in the resulting model.
+  spawnedSceneIds: ReadonlyArray<string>
+  // Convenience projection: spawned-scene entity ids present in the rendered viz.
+  spawnedVizEntityIds: ReadonlyArray<string>
+  // Convenience projection: crackling_arc beams present in the rendered viz.
+  cracklingArcBeamCount: number
+}>
+
+const NO_INTENT: KeyIntent = { kind: "none" }
+
+// Drive a raw keyboard event + model state through the REAL full input path and
+// return the observable outcome. This is the single source of truth a test
+// should use to assert an input feature works end to end.
+export const runKeyEventThroughFullPath = (
+  model: Model,
+  event: KeyEvent,
+  options: FullInputPathOptions = {},
+): FullInputPathOutcome => {
+  // 1. FORWARD GATE — the exact decision the DOM keydown handler makes. We pass
+  //    the optional override map through to the real function so a test can
+  //    inject a broken map.
+  const decision =
+    options.actionMap === undefined
+      ? keyboardForwardDecision({
+          key: event.key,
+          ...(event.code === undefined ? {} : { code: event.code }),
+          meta: event.meta,
+          ctrl: event.ctrl,
+          shift: event.shift,
+          inEditable: event.inEditable,
+        })
+      : keyboardForwardDecision(
+          {
+            key: event.key,
+            ...(event.code === undefined ? {} : { code: event.code }),
+            meta: event.meta,
+            ctrl: event.ctrl,
+            shift: event.shift,
+            inEditable: event.inEditable,
+          },
+          options.actionMap,
+        )
+
+  // 2. If the gate does not forward, the live handler returns early and NO
+  //    message is queued — the reducer never runs. The model is unchanged.
+  if (!decision.forward) {
+    return {
+      forwarded: false,
+      preventDefault: decision.preventDefault,
+      dispatched: false,
+      intent: NO_INTENT,
+      nextModel: model,
+      visualization: verseSceneVisualization(model),
+      spawnedSceneIds: model.verseSpawnedScenes.map((scene) => scene.sceneId),
+      spawnedVizEntityIds: [],
+      cracklingArcBeamCount: 0,
+    }
+  }
+
+  // 3. The gate forwarded — build the SAME PressedKey the subscription queues and
+  //    run the REAL reducer. interpretKey is reported for visibility (the reducer
+  //    also calls it internally; we surface it so a test can assert the mapping).
+  const intent = interpretKey(model, event)
+  const pressed =
+    event.code === undefined
+      ? PressedKey({
+          key: event.key,
+          meta: event.meta,
+          ctrl: event.ctrl,
+          shift: event.shift,
+          inEditable: event.inEditable,
+        })
+      : PressedKey({
+          key: event.key,
+          code: event.code,
+          meta: event.meta,
+          ctrl: event.ctrl,
+          shift: event.shift,
+          inEditable: event.inEditable,
+        })
+  const [nextModel] = update(model, pressed)
+
+  // 4. Project the REAL visualization the renderer consumes.
+  const visualization = verseSceneVisualization(nextModel)
+  const entities = visualization.entities ?? []
+  const beams = visualization.beams ?? []
+
+  return {
+    forwarded: true,
+    preventDefault: decision.preventDefault,
+    dispatched: true,
+    intent,
+    nextModel,
+    visualization,
+    spawnedSceneIds: nextModel.verseSpawnedScenes.map((scene) => scene.sceneId),
+    spawnedVizEntityIds: entities
+      .map((entity) => entity.id)
+      .filter((id) => id.startsWith(VERSE_SPAWNED_SCENE_NODE_PREFIX)),
+    cracklingArcBeamCount: beams.filter((beam) => beam.style === "crackling_arc")
+      .length,
+  }
+}

--- a/apps/autopilot-desktop/src/testing/headless-pixel.ts
+++ b/apps/autopilot-desktop/src/testing/headless-pixel.ts
@@ -1,0 +1,529 @@
+// Headless deterministic pixel verification (first-class render testing).
+//
+// WHY: model-shape tests ("the beam is in the visualization") pass while the
+// scene renders NOTHING. A beam can be in the model yet invisible: the renderer
+// gates it by `motionAllowedByPolicy` (evidence:required), resolves positions
+// from entity ids, and only advances on frame ticks. None of that is observable
+// from the model. This helper RUNS the real three-effect element and OBSERVES
+// real pixels — the same "execute + observe" model as the inference
+// acceptance-runner, generalized for the desktop render path.
+//
+// DETERMINISM: the three-effect element builds its loop with
+// createManagedFrameClock({ mode: "always" }), which calls the GLOBAL
+// requestAnimationFrame + performance.now. Before the element mounts we replace
+// those globals with a DRIVER-CONTROLLED fake clock, then advance EXACTLY N
+// frames of EXACTLY `frameDeltaMs` each from a fixed start time. No real rAF, no
+// wall-clock — identical pixels every run. We do this WITHOUT modifying
+// three-effect, because the element already reads the injectable globals.
+//
+// CONSTRAINTS: Electrobun's native bridge is not faithfully headless, so we
+// drive the element directly in headless Chromium (WebGL under SwiftShader, no
+// GPU). #5026 (bun load-hang) is irrelevant here — this is a `bun run` script /
+// per-file test, not the bare full-suite `bun test`.
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { join } from "node:path"
+import { inflateSync } from "node:zlib"
+import net from "node:net"
+
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+  "/usr/bin/google-chrome",
+  "/usr/bin/google-chrome-stable",
+  "/usr/bin/chromium",
+  "/usr/bin/chromium-browser",
+  "/opt/google/chrome/chrome",
+].filter((candidate): candidate is string => candidate !== undefined)
+
+// Resolve a Chromium-family binary, or null when none is installed (so callers
+// can skip cleanly in environments without a browser).
+export const resolveChromePathOrNull = (): string | null =>
+  CHROME_CANDIDATES.find((candidate) => existsSync(candidate)) ?? null
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+const getFreePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.unref()
+    server.on("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (address === null || typeof address === "string") {
+        server.close(() => reject(new Error("failed to allocate port")))
+        return
+      }
+      const { port } = address
+      server.close((error) => {
+        if (error !== undefined) reject(error)
+        else resolve(port)
+      })
+    })
+  })
+
+type CdpMessage = {
+  readonly id?: number
+  readonly result?: unknown
+  readonly error?: { readonly message?: string }
+}
+
+type CdpClient = {
+  readonly close: () => void
+  readonly send: <Result>(
+    method: string,
+    params?: Record<string, unknown>,
+  ) => Promise<Result>
+}
+
+const connectCdp = (webSocketUrl: string): Promise<CdpClient> =>
+  new Promise((resolve, reject) => {
+    const socket = new WebSocket(webSocketUrl)
+    let nextId = 1
+    const pending = new Map<
+      number,
+      {
+        readonly resolve: (value: unknown) => void
+        readonly reject: (error: Error) => void
+      }
+    >()
+    socket.addEventListener("open", () => {
+      resolve({
+        close: () => socket.close(),
+        send: <Result>(
+          method: string,
+          params: Record<string, unknown> = {},
+        ): Promise<Result> => {
+          const id = nextId++
+          return new Promise<Result>((messageResolve, messageReject) => {
+            pending.set(id, {
+              resolve: (value) => messageResolve(value as Result),
+              reject: messageReject,
+            })
+            socket.send(JSON.stringify({ id, method, params }))
+          })
+        },
+      })
+    })
+    socket.addEventListener("error", () => {
+      reject(new Error(`failed to connect to Chrome CDP at ${webSocketUrl}`))
+    })
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data)) as CdpMessage
+      if (message.id === undefined) return
+      const handler = pending.get(message.id)
+      if (handler === undefined) return
+      pending.delete(message.id)
+      if (message.error !== undefined) {
+        handler.reject(new Error(message.error.message ?? "CDP command failed"))
+        return
+      }
+      handler.resolve(message.result)
+    })
+  })
+
+const waitForPageWebSocket = async (debugPort: number): Promise<string> => {
+  const deadline = Date.now() + 10_000
+  let lastError: unknown = null
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${debugPort}/json/list`)
+      if (response.ok) {
+        const targets = (await response.json()) as Array<{
+          readonly type?: string
+          readonly webSocketDebuggerUrl?: string
+        }>
+        const page = targets.find(
+          (target) =>
+            target.type === "page" &&
+            typeof target.webSocketDebuggerUrl === "string",
+        )
+        if (page?.webSocketDebuggerUrl !== undefined) {
+          return page.webSocketDebuggerUrl
+        }
+      }
+    } catch (error) {
+      lastError = error
+    }
+    await wait(100)
+  }
+  throw new Error(`Chrome CDP page target unavailable: ${String(lastError)}`)
+}
+
+// ── PNG decode (no image deps) ────────────────────────────────────────────────
+
+type PngImage = { readonly data: Uint8Array; readonly height: number; readonly width: number }
+
+const paethPredictor = (left: number, up: number, upLeft: number): number => {
+  const estimate = left + up - upLeft
+  const leftDistance = Math.abs(estimate - left)
+  const upDistance = Math.abs(estimate - up)
+  const upLeftDistance = Math.abs(estimate - upLeft)
+  if (leftDistance <= upDistance && leftDistance <= upLeftDistance) return left
+  if (upDistance <= upLeftDistance) return up
+  return upLeft
+}
+
+const decodePng = (png: Buffer): PngImage => {
+  if (png.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
+    throw new Error("Chrome screenshot was not a PNG")
+  }
+  let offset = 8
+  let width = 0
+  let height = 0
+  let colorType = 0
+  const idatChunks: Buffer[] = []
+  while (offset < png.length) {
+    const length = png.readUInt32BE(offset)
+    const type = png.subarray(offset + 4, offset + 8).toString("ascii")
+    const data = png.subarray(offset + 8, offset + 8 + length)
+    offset += 12 + length
+    if (type === "IHDR") {
+      width = data.readUInt32BE(0)
+      height = data.readUInt32BE(4)
+      const bitDepth = data[8] ?? 0
+      colorType = data[9] ?? 0
+      if (bitDepth !== 8) throw new Error(`unsupported PNG bit depth ${bitDepth}`)
+      if (colorType !== 2 && colorType !== 6) {
+        throw new Error(`unsupported PNG color type ${colorType}`)
+      }
+      if ((data[12] ?? 0) !== 0) throw new Error("interlaced PNG unsupported")
+    } else if (type === "IDAT") {
+      idatChunks.push(Buffer.from(data))
+    } else if (type === "IEND") {
+      break
+    }
+  }
+  if (width <= 0 || height <= 0 || idatChunks.length === 0) {
+    throw new Error("invalid PNG screenshot")
+  }
+  const bytesPerPixel = colorType === 6 ? 4 : 3
+  const stride = width * bytesPerPixel
+  const inflated = inflateSync(Buffer.concat(idatChunks))
+  const output = new Uint8Array(width * height * 4)
+  let inputOffset = 0
+  let previous = new Uint8Array(stride)
+  for (let y = 0; y < height; y += 1) {
+    const filter = inflated[inputOffset]
+    inputOffset += 1
+    const row = new Uint8Array(stride)
+    for (let x = 0; x < stride; x += 1) {
+      const raw = inflated[inputOffset + x] ?? 0
+      const left = x >= bytesPerPixel ? row[x - bytesPerPixel] ?? 0 : 0
+      const up = previous[x] ?? 0
+      const upLeft = x >= bytesPerPixel ? previous[x - bytesPerPixel] ?? 0 : 0
+      switch (filter) {
+        case 0: row[x] = raw; break
+        case 1: row[x] = (raw + left) & 0xff; break
+        case 2: row[x] = (raw + up) & 0xff; break
+        case 3: row[x] = (raw + Math.floor((left + up) / 2)) & 0xff; break
+        case 4: row[x] = (raw + paethPredictor(left, up, upLeft)) & 0xff; break
+        default: throw new Error(`unsupported PNG filter ${filter}`)
+      }
+    }
+    inputOffset += stride
+    for (let x = 0; x < width; x += 1) {
+      const source = x * bytesPerPixel
+      const target = (y * width + x) * 4
+      output[target] = row[source] ?? 0
+      output[target + 1] = row[source + 1] ?? 0
+      output[target + 2] = row[source + 2] ?? 0
+      output[target + 3] = colorType === 6 ? row[source + 3] ?? 255 : 255
+    }
+    previous = row
+  }
+  return { data: output, height, width }
+}
+
+// A fractional region of the frame to score, in [0,1]. Defaults to the whole
+// frame. Use a sub-region to assert a SPECIFIC effect lit up where it should.
+export type PixelRegion = Readonly<{ x0: number; y0: number; x1: number; y1: number }>
+
+const FULL_FRAME: PixelRegion = { x0: 0, y0: 0, x1: 1, y1: 1 }
+
+export type RegionScore = Readonly<{
+  brightPixels: number
+  distinctLumaBuckets: number
+  sampledPixels: number
+}>
+
+const scoreRegion = (image: PngImage, region: PixelRegion): RegionScore => {
+  const px0 = Math.max(0, Math.floor(region.x0 * image.width))
+  const py0 = Math.max(0, Math.floor(region.y0 * image.height))
+  const px1 = Math.min(image.width, Math.ceil(region.x1 * image.width))
+  const py1 = Math.min(image.height, Math.ceil(region.y1 * image.height))
+  let brightPixels = 0
+  let sampledPixels = 0
+  const buckets = new Set<number>()
+  for (let y = py0; y < py1; y += 1) {
+    for (let x = px0; x < px1; x += 1) {
+      const offset = (y * image.width + x) * 4
+      const luma =
+        (image.data[offset] ?? 0) +
+        (image.data[offset + 1] ?? 0) +
+        (image.data[offset + 2] ?? 0)
+      if (luma > 80) brightPixels += 1
+      buckets.add(Math.floor(luma / 32))
+      sampledPixels += 1
+    }
+  }
+  return { brightPixels, distinctLumaBuckets: buckets.size, sampledPixels }
+}
+
+export type HeadlessRenderOptions = Readonly<{
+  // Absolute path to a TS module that, when imported, mounts an `oa-training-run`
+  // element into `#scene` and sets its `.visualization`. (See the regression
+  // script for an example.) It runs AFTER the deterministic clock is installed.
+  entryModulePath: string
+  width?: number
+  height?: number
+  // Number of FIXED deterministic frames to advance. No rAF / wall-clock.
+  frameSteps?: number
+  // Milliseconds advanced per fixed frame.
+  frameDeltaMs?: number
+  // Optional query string (no leading "?") appended to the page URL so the entry
+  // module can branch on `location.search` (e.g. a deliberately-broken variant).
+  pageQuery?: string
+}>
+
+export type HeadlessRenderResult = Readonly<{
+  canvasWidth: number
+  canvasHeight: number
+  framesAdvanced: number
+  image: PngImage
+  screenshotBase64: string
+  // Score a fractional region of the captured frame.
+  score: (region?: PixelRegion) => RegionScore
+}>
+
+// The page bootstrap. It installs a deterministic fake clock OVER the global
+// requestAnimationFrame + performance.now BEFORE the entry module imports (and
+// thus before three-effect's "always" frame clock captures them), exposes a
+// `__stepFrames(n, deltaMs)` driver, then imports the entry module.
+const pageBootstrap = (): string => `
+let __fakeNow = 0
+const __rafQueue = []
+performance.now = () => __fakeNow
+globalThis.requestAnimationFrame = (cb) => {
+  const id = __rafQueue.length + 1
+  __rafQueue.push({ id, cb })
+  return id
+}
+globalThis.cancelAnimationFrame = (id) => {
+  const idx = __rafQueue.findIndex((entry) => entry.id === id)
+  if (idx >= 0) __rafQueue.splice(idx, 1)
+}
+// Drive EXACTLY n frames; each advances the fake clock by a fixed delta and
+// flushes the rAF queue that was pending at the start of that frame (the loop
+// re-registers itself for the next frame, matching how the managed clock works).
+globalThis.__stepFrames = (n, deltaMs) => {
+  for (let i = 0; i < n; i += 1) {
+    __fakeNow += deltaMs
+    const pending = __rafQueue.splice(0, __rafQueue.length)
+    for (const entry of pending) entry.cb(__fakeNow)
+  }
+}
+globalThis.__pendingFrameCount = () => __rafQueue.length
+`
+
+const pageHtml = (width: number, height: number): string => `
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Headless render harness</title>
+    <style>
+      :root { color-scheme: dark; background: #050505; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #050505; }
+      #scene { width: ${width}px; height: ${height}px; background: #050505; }
+    </style>
+    <script>${pageBootstrap()}</script>
+  </head>
+  <body>
+    <div id="scene"></div>
+    <script type="module" src="/dist/headless-render-entry.js"></script>
+  </body>
+</html>
+`
+
+// Mount the entry module's visualization in headless Chromium, advance a fixed
+// number of deterministic frames, screenshot, and return the decoded image plus
+// a region scorer. Throws if the canvas never mounts.
+export const renderVisualizationAndProbe = async (
+  options: HeadlessRenderOptions,
+): Promise<HeadlessRenderResult> => {
+  const chromePath = resolveChromePathOrNull()
+  if (chromePath === null) {
+    throw new Error(
+      "Chrome/Chromium not found. Set CHROME_PATH to a Chromium-family binary.",
+    )
+  }
+  const width = options.width ?? 960
+  const height = options.height ?? 540
+  const frameSteps = options.frameSteps ?? 90
+  const frameDeltaMs = options.frameDeltaMs ?? 16
+
+  const tmpRoot = mkdtempSync(join(process.cwd(), ".headless-render-"))
+  const userDataDir = join(tmpRoot, "chrome-profile")
+  const distDir = join(tmpRoot, "dist")
+  const htmlPath = join(tmpRoot, "index.html")
+  mkdirSync(distDir, { recursive: true })
+  mkdirSync(userDataDir, { recursive: true })
+  writeFileSync(htmlPath, pageHtml(width, height))
+
+  let server: ReturnType<typeof Bun.serve> | null = null
+  let chrome: Bun.Subprocess | null = null
+  let cdp: CdpClient | null = null
+  try {
+    const build = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "build",
+        options.entryModulePath,
+        "--outdir",
+        distDir,
+        "--target",
+        "browser",
+        "--format",
+        "esm",
+      ],
+      stderr: "pipe",
+      stdout: "pipe",
+    })
+    if (!build.success) {
+      const stderr = new TextDecoder().decode(build.stderr)
+      if (stderr.trim().length > 0) console.error(stderr)
+      throw new Error("failed to build headless render entry bundle")
+    }
+    // The bundle is emitted under the entry's basename; serve it as the fixed
+    // path the HTML references.
+    const builtName = options.entryModulePath
+      .split("/")
+      .pop()!
+      .replace(/\.ts$/, ".js")
+
+    server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url)
+        if (url.pathname === "/") {
+          return new Response(readFileSync(htmlPath), {
+            headers: { "content-type": "text/html; charset=utf-8" },
+          })
+        }
+        if (url.pathname === "/dist/headless-render-entry.js") {
+          return new Response(readFileSync(join(distDir, builtName)), {
+            headers: { "content-type": "text/javascript; charset=utf-8" },
+          })
+        }
+        return new Response("not found", { status: 404 })
+      },
+    })
+
+    const debugPort = await getFreePort()
+    const query =
+      options.pageQuery === undefined || options.pageQuery.length === 0
+        ? ""
+        : `?${options.pageQuery}`
+    const url = `http://127.0.0.1:${server.port}/${query}`
+    chrome = Bun.spawn({
+      cmd: [
+        chromePath,
+        "--headless=new",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--disable-background-networking",
+        "--disable-extensions",
+        "--disable-sync",
+        "--enable-webgl",
+        "--ignore-gpu-blocklist",
+        "--use-angle=swiftshader",
+        "--enable-unsafe-swiftshader",
+        `--window-size=${width},${height}`,
+        `--remote-debugging-port=${debugPort}`,
+        `--user-data-dir=${userDataDir}`,
+        url,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    const pageWebSocket = await waitForPageWebSocket(debugPort)
+    cdp = await connectCdp(pageWebSocket)
+    await cdp.send("Runtime.enable")
+    await cdp.send("Page.enable")
+    await cdp.send("Page.navigate", { url })
+
+    // Wait for the custom element to define + mount its canvas (NOT for an
+    // animation — frames are driven below). Polling, not rAF, so this is robust.
+    const mountProbe = await cdp.send<{
+      readonly result?: { readonly value?: { ok: boolean; w: number; h: number } }
+      readonly exceptionDetails?: unknown
+    }>("Runtime.evaluate", {
+      expression: `(async () => {
+        await customElements.whenDefined("oa-training-run")
+        const host = document.querySelector("oa-training-run")
+        // Give synchronous mount a moment; the canvas mounts inside connectedCallback.
+        for (let i = 0; i < 200; i += 1) {
+          const c = host?.shadowRoot?.querySelector("canvas")
+          if (c instanceof HTMLCanvasElement && c.width > 0) {
+            return { ok: true, w: c.width, h: c.height }
+          }
+          await new Promise((r) => setTimeout(r, 10))
+        }
+        return { ok: false, w: 0, h: 0 }
+      })()`,
+      awaitPromise: true,
+      returnByValue: true,
+    })
+    if (mountProbe.exceptionDetails !== undefined) {
+      throw new Error(
+        `headless render threw at mount: ${JSON.stringify(mountProbe.exceptionDetails)}`,
+      )
+    }
+    const mount = mountProbe.result?.value
+    if (mount === undefined || !mount.ok) {
+      throw new Error("oa-training-run canvas never mounted")
+    }
+
+    // DETERMINISTIC FRAME STEPPING: advance exactly `frameSteps` fixed frames.
+    await cdp.send("Runtime.evaluate", {
+      expression: `__stepFrames(${frameSteps}, ${frameDeltaMs})`,
+      awaitPromise: false,
+      returnByValue: true,
+    })
+
+    const screenshot = await cdp.send<{ readonly data: string }>(
+      "Page.captureScreenshot",
+      { format: "png", fromSurface: true },
+    )
+    const image = decodePng(Buffer.from(screenshot.data, "base64"))
+    return {
+      canvasWidth: mount.w,
+      canvasHeight: mount.h,
+      framesAdvanced: frameSteps,
+      image,
+      screenshotBase64: screenshot.data,
+      score: (region: PixelRegion = FULL_FRAME) => scoreRegion(image, region),
+    }
+  } finally {
+    cdp?.close()
+    if (chrome !== null) {
+      chrome.kill()
+      await chrome.exited.catch(() => null)
+    }
+    server?.stop(true)
+    rmSync(tmpRoot, { force: true, recursive: true })
+  }
+}

--- a/apps/autopilot-desktop/src/testing/synthetic-event-service.ts
+++ b/apps/autopilot-desktop/src/testing/synthetic-event-service.ts
@@ -1,0 +1,53 @@
+// Demonstrator service that consumes the deterministic environment.
+//
+// This models exactly the kind of seam that was previously written with
+// `Date.now()` + `Math.random()` inline (untestable, flaky): minting a synthetic
+// in-world event (a timestamp + a seeded id) and shipping it over a transport.
+// Here every nondeterministic input is an INJECTED service, so the same seed +
+// the same TestClock produce byte-identical output every run, and the transport
+// call is observable. This is the pattern other services should follow.
+
+import { Context, Effect, Layer, Random } from "effect"
+
+import { Transport, type TransportError } from "./deterministic-env.js"
+
+export type SyntheticEvent = Readonly<{
+  id: string
+  // Minted from the (test) Clock — deterministic, not wall-clock.
+  generatedAtMillis: number
+}>
+
+export class SyntheticEventService extends Context.Service<
+  SyntheticEventService,
+  {
+    // Mint a synthetic event and ship it over the transport. The id is derived
+    // from the seeded RNG; the timestamp from the injected Clock.
+    readonly emit: (
+      kind: string,
+    ) => Effect.Effect<SyntheticEvent, TransportError>
+  }
+>()("autopilot-desktop/testing/SyntheticEventService") {}
+
+export const SyntheticEventServiceLayer = Layer.effect(
+  SyntheticEventService,
+  Effect.gen(function* () {
+    const transport = yield* Transport
+    return {
+      emit: (kind: string) =>
+        Effect.gen(function* () {
+          // Injected randomness — reproducible under withSeed.
+          const roll = yield* Random.nextIntBetween(0, 1_000_000)
+          // Injected clock — TestClock in tests, real clock in production.
+          const generatedAtMillis = yield* Effect.clockWith((clock) =>
+            clock.currentTimeMillis,
+          )
+          const id = `${kind}-${generatedAtMillis}-${roll.toString(36)}`
+          yield* transport.call({
+            method: "world.emitSyntheticEvent",
+            payload: { id, kind, generatedAtMillis },
+          })
+          return { id, generatedAtMillis }
+        }),
+    }
+  }),
+)

--- a/apps/autopilot-desktop/tests/crackling-arc-pixel-regression.test.ts
+++ b/apps/autopilot-desktop/tests/crackling-arc-pixel-regression.test.ts
@@ -1,0 +1,130 @@
+// Headless pixel regression for the spawned crackling arc (Mode 2: model-shape
+// green, screen blank). This is the test that would have caught "the beam is in
+// the model but nothing renders."
+//
+// It mounts the REAL three-effect `oa-training-run` element with the REAL
+// spawned-scene visualization in headless Chromium, advances DETERMINISTIC fixed
+// frames (no rAF/wall-clock — injected fake clock), screenshots, and scores
+// pixels in the arc's REGION. Then it does the same for a deliberately-broken
+// variant (evidence refs stripped so the renderer's evidence:required gate
+// suppresses the arc) and asserts that one is dark.
+//
+// FIXED variant  → bright pixels in the arc region (PASS).
+// BROKEN variant → far fewer bright pixels (the regression that fails on broken).
+//
+// Determinism: the fake frame clock means identical input → identical pixels.
+// Skips cleanly (with a logged note) where no Chromium binary is installed, so
+// the per-file runner (scripts/run-tests.sh) never goes red for lack of a
+// browser.
+
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
+
+import { describe, expect, test } from "bun:test"
+
+import {
+  renderVisualizationAndProbe,
+  resolveChromePathOrNull,
+  type PixelRegion,
+} from "../src/testing/headless-pixel"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const entryModulePath = join(here, "../scripts/crackling-arc-entry.ts")
+
+// The arc hangs above the fixed scene station and is aimed up-and-across, so it
+// lights the upper-middle band of the frame. Score that band specifically — a
+// full-frame score could be fooled by base-scene chrome.
+const ARC_REGION: PixelRegion = { x0: 0.2, y0: 0.0, x1: 0.85, y1: 0.6 }
+
+const FRAME_STEPS = 120
+const FRAME_DELTA_MS = 16
+
+const chrome = resolveChromePathOrNull()
+
+describe("crackling arc headless pixel regression (Mode 2)", () => {
+  if (chrome === null) {
+    test.skip("skipped: no Chromium binary (set CHROME_PATH)", () => {})
+    return
+  }
+
+  test(
+    "the spawned crackling arc renders bright pixels in its region",
+    async () => {
+      const fixed = await renderVisualizationAndProbe({
+        entryModulePath,
+        frameSteps: FRAME_STEPS,
+        frameDeltaMs: FRAME_DELTA_MS,
+      })
+      expect(fixed.canvasWidth).toBeGreaterThanOrEqual(480)
+      expect(fixed.canvasHeight).toBeGreaterThanOrEqual(270)
+
+      const score = fixed.score(ARC_REGION)
+      // The arc region must paint bright, varied pixels — not a blank region.
+      expect(score.brightPixels).toBeGreaterThan(300)
+      expect(score.distinctLumaBuckets).toBeGreaterThanOrEqual(3)
+    },
+    60_000,
+  )
+
+  test(
+    "the arc's pixel contribution vanishes when the renderer suppresses it",
+    async () => {
+      // The arc's scene-station ICONS render in both variants (entities are not
+      // evidence-gated), so the region's absolute brightness is dominated by the
+      // base scene + icons. The arc's signal is its CONTRIBUTION: the bright
+      // pixels the crackling beam adds OVER the no-arc baseline. The broken
+      // variant (evidence refs stripped → evidence:required gate suppresses the
+      // beam) is exactly that no-arc baseline. So the faithful Mode-2 assertion
+      // is: the fixed arc contributes a clear positive footprint, and the broken
+      // one contributes essentially nothing.
+      const fixed = await renderVisualizationAndProbe({
+        entryModulePath,
+        frameSteps: FRAME_STEPS,
+        frameDeltaMs: FRAME_DELTA_MS,
+      })
+      const broken = await renderVisualizationAndProbe({
+        entryModulePath,
+        frameSteps: FRAME_STEPS,
+        frameDeltaMs: FRAME_DELTA_MS,
+        pageQuery: "broken=1",
+      })
+
+      const fixedScore = fixed.score(ARC_REGION)
+      const brokenScore = broken.score(ARC_REGION)
+      const arcContribution = fixedScore.brightPixels - brokenScore.brightPixels
+
+      // The arc adds a clear, visible footprint when it renders. This is the
+      // assertion that FAILS if a future change drops the arc geometry while
+      // leaving the beam "in the model" — the exact Mode-2 bug. (~1100+ bright
+      // pixels of crackling beam under SwiftShader; floor well below that.)
+      expect(arcContribution).toBeGreaterThan(400)
+      // And the broken variant is genuinely the no-arc baseline: it is dimmer
+      // than the fixed render, never brighter.
+      expect(brokenScore.brightPixels).toBeLessThan(fixedScore.brightPixels)
+    },
+    90_000,
+  )
+
+  test(
+    "deterministic: rendering the same visualization twice yields the same score",
+    async () => {
+      const a = await renderVisualizationAndProbe({
+        entryModulePath,
+        frameSteps: FRAME_STEPS,
+        frameDeltaMs: FRAME_DELTA_MS,
+      })
+      const b = await renderVisualizationAndProbe({
+        entryModulePath,
+        frameSteps: FRAME_STEPS,
+        frameDeltaMs: FRAME_DELTA_MS,
+      })
+      const sa = a.score(ARC_REGION)
+      const sb = b.score(ARC_REGION)
+      // Same fixed frames + injected clock ⇒ bright-pixel count is stable. Allow
+      // a tiny tolerance for SwiftShader rounding at the bright-pixel threshold.
+      const delta = Math.abs(sa.brightPixels - sb.brightPixels)
+      expect(delta).toBeLessThanOrEqual(Math.max(8, sa.brightPixels * 0.02))
+    },
+    90_000,
+  )
+})

--- a/apps/autopilot-desktop/tests/deterministic-env.test.ts
+++ b/apps/autopilot-desktop/tests/deterministic-env.test.ts
@@ -1,0 +1,91 @@
+// Deterministic Effect environment: TestClock + seeded RNG + stub transport.
+//
+// Demonstrates the reusable layer set and proves the property that matters: with
+// injected clock/random/transport, the SAME seed + the SAME clock produce
+// byte-identical output every run, and the transport calls are observable. No
+// `Date.now`, no `Math.random`, no real network. Runs under bun test via
+// Effect.runPromise (this repo uses bun test, not @effect/vitest).
+
+import { describe, expect, test } from "bun:test"
+
+import { Effect } from "effect"
+import { TestClock } from "effect/testing"
+
+import {
+  Transport,
+  TestEnvironmentLayer,
+  withSeed,
+  currentMillis,
+} from "../src/testing/deterministic-env"
+import {
+  SyntheticEventService,
+  SyntheticEventServiceLayer,
+} from "../src/testing/synthetic-event-service"
+
+describe("deterministic environment (TestClock + seeded RNG + stub transport)", () => {
+  test("TestClock starts at 0 and only moves on explicit adjust", async () => {
+    const program = Effect.gen(function* () {
+      const before = yield* currentMillis
+      yield* TestClock.adjust("1 minute")
+      const after = yield* currentMillis
+      return { before, after }
+    })
+    const { before, after } = await Effect.runPromise(
+      program.pipe(Effect.provide(TestEnvironmentLayer())),
+    )
+    expect(before).toBe(0)
+    expect(after).toBe(60_000)
+  })
+
+  test("the synthetic-event service is fully deterministic across runs", async () => {
+    const responses = { "world.emitSyntheticEvent": { ok: true } }
+
+    const run = () => {
+      const program = Effect.gen(function* () {
+        const service = yield* SyntheticEventService
+        const transport = yield* Transport
+        // Advance the test clock to a fixed time, then emit two events.
+        yield* TestClock.adjust("1500 millis")
+        const a = yield* service.emit("crackling_energy")
+        const b = yield* service.emit("gateway_portal")
+        const calls = yield* transport.calls
+        return { a, b, calls }
+      })
+      return Effect.runPromise(
+        // Seed the RNG so "random" ids are reproducible.
+        withSeed("verse-spawned-scene", program).pipe(
+          Effect.provide(SyntheticEventServiceLayer),
+          Effect.provide(TestEnvironmentLayer(responses)),
+        ),
+      )
+    }
+
+    const first = await run()
+    const second = await run()
+
+    // Same seed + same TestClock ⇒ identical ids and timestamps.
+    expect(first.a).toEqual(second.a)
+    expect(first.b).toEqual(second.b)
+    // The timestamp came from the (test) clock, not wall-clock.
+    expect(first.a.generatedAtMillis).toBe(1500)
+    expect(first.b.generatedAtMillis).toBe(1500)
+    // The two ids differ (RNG advanced), but are reproducible.
+    expect(first.a.id).not.toBe(first.b.id)
+    // The transport saw exactly the two scripted calls, in order — no network.
+    expect(first.calls.map((call) => call.method)).toEqual([
+      "world.emitSyntheticEvent",
+      "world.emitSyntheticEvent",
+    ])
+  })
+
+  test("an unscripted transport method fails deterministically (never hangs)", async () => {
+    const program = Effect.gen(function* () {
+      const transport = yield* Transport
+      return yield* transport.call({ method: "not.scripted", payload: null })
+    })
+    const exit = await Effect.runPromiseExit(
+      program.pipe(Effect.provide(TestEnvironmentLayer({}))),
+    )
+    expect(exit._tag).toBe("Failure")
+  })
+})

--- a/apps/autopilot-desktop/tests/full-input-path-harness.test.ts
+++ b/apps/autopilot-desktop/tests/full-input-path-harness.test.ts
@@ -1,0 +1,205 @@
+// Full-input-path harness regression (#6041 class).
+//
+// This is the test that would have caught the original ⌘⇧E / ⌘⇧P keybinding bug.
+// It drives the REAL desktop key path through ONE reusable harness:
+//
+//   keyboardForwardDecision (forward gate)
+//     → PressedKey (only if forwarded)
+//       → interpretKey → reducer (update)
+//         → verseSceneVisualization (what the renderer consumes)
+//
+// The original bug shipped because the spawn keys were never registered as input
+// bindings, so the FORWARD GATE resolved them to zero action ids and dropped the
+// keydown BEFORE the reducer ran — yet a reducer-only test was green. Here we:
+//
+//   • PASS on current main (the bindings are registered): the gate forwards and
+//     the scene spawns + renders into the SAME world visualization.
+//   • FAIL on a deliberately-broken binding map (spawn bindings removed — the
+//     exact pre-#6042 state): the gate does NOT forward, no PressedKey is
+//     dispatched, and nothing spawns. This proves the harness catches the bug at
+//     the layer the bug lived in.
+//
+// Determinism: pure functions, no clock/random/rAF — running twice is identical.
+
+import { describe, expect, test } from "bun:test"
+
+import {
+  openAgentsDefaultInputProfile,
+  openAgentsInputActionMapFromProfile,
+  type OpenAgentsInputActionMap,
+} from "@openagentsinc/input-bindings"
+
+import { runKeyEventThroughFullPath } from "../src/testing/full-input-path"
+import { initialModel, Model } from "../src/ui/model"
+import {
+  DEFAULT_SPAWNABLE_SCENE_ID,
+  VERSE_SPAWNED_SCENE_NODE_PREFIX,
+  VERSE_SPAWNED_SCENE_SOURCE_REF,
+} from "../src/shared/verse-spawned-scene"
+
+const CRACKLING = DEFAULT_SPAWNABLE_SCENE_ID
+const fromId = `${VERSE_SPAWNED_SCENE_NODE_PREFIX}${CRACKLING}:from`
+const toId = `${VERSE_SPAWNED_SCENE_NODE_PREFIX}${CRACKLING}:to`
+const portalId = `${VERSE_SPAWNED_SCENE_NODE_PREFIX}${CRACKLING}:portal`
+
+// The EXACT on-screen Verse explore state: pane "chat", verse enabled, explore
+// mode — the only state where the spawn keys are live (view.ts gate).
+const verseOnScreen = Model.make({
+  ...initialModel,
+  pane: "chat",
+  verseEnabled: true,
+  verseMode: "explore",
+  commandPaletteOpen: false,
+})
+
+const spawnEvent = {
+  key: "e",
+  meta: true,
+  ctrl: false,
+  shift: true,
+  inEditable: false,
+} as const
+
+const portalEvent = {
+  key: "p",
+  meta: true,
+  ctrl: false,
+  shift: true,
+  inEditable: false,
+} as const
+
+// The deliberately-broken binding map: the real default map MINUS the two spawn
+// action ids. This reproduces the pre-#6042 world where keyboardForwardDecision
+// resolved ⌘⇧E / ⌘⇧P to nothing → forward=false → keydown dropped.
+const brokenActionMap: OpenAgentsInputActionMap = (() => {
+  const real = openAgentsInputActionMapFromProfile(openAgentsDefaultInputProfile)
+  const copy: Record<string, (typeof real)[string]> = { ...real }
+  delete copy["verse.spawn_scene"]
+  delete copy["verse.toggle_scene_portal"]
+  return copy
+})()
+
+describe("full-input-path harness: ⌘⇧E spawn (the #6041 bug layer)", () => {
+  test("PASS on current bindings: gate forwards, scene spawns AND renders", () => {
+    const outcome = runKeyEventThroughFullPath(verseOnScreen, spawnEvent)
+
+    // The forward gate — the exact layer the original bug lived in.
+    expect(outcome.forwarded).toBe(true)
+    expect(outcome.preventDefault).toBe(true)
+    expect(outcome.dispatched).toBe(true)
+
+    // interpretKey mapping.
+    expect(outcome.intent.kind).toBe("spawn-verse-scene")
+
+    // Reducer result.
+    expect(outcome.spawnedSceneIds).toEqual([CRACKLING])
+
+    // Renders into the SAME world visualization the renderer consumes.
+    expect(outcome.spawnedVizEntityIds).toContain(fromId)
+    expect(outcome.spawnedVizEntityIds).toContain(toId)
+    expect(outcome.cracklingArcBeamCount).toBe(1)
+
+    // The arc carries its synthetic evidence ref so the evidence:required gate
+    // in the renderer lets it animate (otherwise it would be invisible).
+    const arc = (outcome.visualization.beams ?? []).find(
+      (beam) => beam.fromId === fromId && beam.style === "crackling_arc",
+    )
+    expect(arc?.sourceRefs).toEqual([VERSE_SPAWNED_SCENE_SOURCE_REF])
+    expect(outcome.visualization.motionPolicy?.evidence).toBe("required")
+
+    // Spawning preserves the walkable third-person controller.
+    expect(outcome.visualization.controller).toBe("third_person_character")
+  })
+
+  test("FAIL-on-broken: with spawn bindings removed, the gate drops the key", () => {
+    const outcome = runKeyEventThroughFullPath(verseOnScreen, spawnEvent, {
+      actionMap: brokenActionMap,
+    })
+
+    // This is the #6041 bug, now directly observable: the gate does not forward,
+    // no PressedKey reaches the reducer, and nothing spawns or renders.
+    expect(outcome.forwarded).toBe(false)
+    expect(outcome.dispatched).toBe(false)
+    expect(outcome.spawnedSceneIds).toEqual([])
+    expect(outcome.spawnedVizEntityIds).toEqual([])
+    expect(outcome.cracklingArcBeamCount).toBe(0)
+
+    // A test that only checked the reducer would have been GREEN here too,
+    // because it would never have run the gate. The harness catches it.
+  })
+})
+
+describe("full-input-path harness: ⌘⇧P portal toggle", () => {
+  test("PASS: portal forwards and toggles on an already-spawned scene", () => {
+    const [spawned] = (() => {
+      const out = runKeyEventThroughFullPath(verseOnScreen, spawnEvent)
+      return [out.nextModel] as const
+    })()
+
+    const outcome = runKeyEventThroughFullPath(spawned, portalEvent)
+    expect(outcome.forwarded).toBe(true)
+    expect(outcome.dispatched).toBe(true)
+    expect(outcome.intent.kind).toBe("toggle-verse-scene-portal")
+    expect(outcome.nextModel.verseSpawnedScenes[0]?.showPortal).toBe(true)
+
+    const portal = (outcome.visualization.entities ?? []).find(
+      (entity) => entity.id === portalId,
+    )
+    expect(portal).toBeDefined()
+    expect((portal as { visualKind?: string } | undefined)?.visualKind).toBe(
+      "gateway_portal",
+    )
+  })
+
+  test("FAIL-on-broken: portal binding removed → gate drops the key", () => {
+    const [spawned] = (() => {
+      const out = runKeyEventThroughFullPath(verseOnScreen, spawnEvent)
+      return [out.nextModel] as const
+    })()
+    const outcome = runKeyEventThroughFullPath(spawned, portalEvent, {
+      actionMap: brokenActionMap,
+    })
+    expect(outcome.forwarded).toBe(false)
+    expect(outcome.dispatched).toBe(false)
+    // Portal stays off because the key never reached the reducer.
+    expect(outcome.nextModel.verseSpawnedScenes[0]?.showPortal).toBe(false)
+  })
+})
+
+describe("full-input-path harness: determinism + negative contexts", () => {
+  test("identical outcome when run twice (no clock/random/rAF)", () => {
+    const a = runKeyEventThroughFullPath(verseOnScreen, spawnEvent)
+    const b = runKeyEventThroughFullPath(verseOnScreen, spawnEvent)
+    expect(b.forwarded).toBe(a.forwarded)
+    expect(b.dispatched).toBe(a.dispatched)
+    expect(b.intent.kind).toBe(a.intent.kind)
+    expect(b.spawnedSceneIds).toEqual(a.spawnedSceneIds)
+    expect(b.spawnedVizEntityIds).toEqual(a.spawnedVizEntityIds)
+    expect(b.cracklingArcBeamCount).toBe(a.cracklingArcBeamCount)
+  })
+
+  test("code mode does not spawn (coding overlay owns its keys)", () => {
+    const codeModel = Model.make({
+      ...initialModel,
+      pane: "chat",
+      verseEnabled: true,
+      verseMode: "code",
+    })
+    const outcome = runKeyEventThroughFullPath(codeModel, spawnEvent)
+    // interpretKey only emits spawn in explore context, so even if forwarded the
+    // reducer must not spawn here.
+    expect(outcome.intent.kind).not.toBe("spawn-verse-scene")
+    expect(outcome.spawnedSceneIds).toEqual([])
+  })
+
+  test("editable target: a bare letter never spawns or forwards a command", () => {
+    const outcome = runKeyEventThroughFullPath(verseOnScreen, {
+      key: "e",
+      meta: false,
+      ctrl: false,
+      shift: false,
+      inEditable: true,
+    })
+    expect(outcome.spawnedSceneIds).toEqual([])
+  })
+})

--- a/docs/testing/2026-06-22-deterministic-environment-testing.md
+++ b/docs/testing/2026-06-22-deterministic-environment-testing.md
@@ -1,0 +1,206 @@
+# Deterministic environment testing for `apps/autopilot-desktop` + `three-effect`
+
+Date: 2026-06-22
+Scope: `apps/autopilot-desktop` (the Electrobun desktop UI) and the
+`@openagentsinc/three-effect` render path it consumes.
+
+## Why this exists: green tests, broken features
+
+Every failure below is real and happened in this codebase. In each case a unit
+test was **green** while the actual user-facing behavior was **broken**, because
+the test exercised a *fragment* of the path rather than the *whole* path, or
+asserted on a *model* instead of an *observable outcome*.
+
+### Mode 1 — reducer-only tests pass, the live key does nothing
+
+The Verse spawn keybinding (⌘⇧E / ⌘⇧P, #6033) had a green reducer test:
+
+```ts
+const [next] = update(exploreModel, PressedKey({ key: "e", meta: true, shift: true, ... }))
+expect(next.verseSpawnedScenes...).toEqual([CRACKLING])  // GREEN
+```
+
+…but the live key did nothing (#6041). The real desktop path is:
+
+```
+keydown (DOM)
+  → keyboardForwardDecision(...)   ← FORWARD GATE (subscriptions.ts)
+    → PressedKey message queued
+      → interpretKey(model, event)  ← keyboard.ts
+        → reducer (update.ts)
+          → resulting Model
+            → verseSceneVisualization(model)  ← the render-feeding viz
+```
+
+The bug lived entirely in the **forward gate**: the spawn keys were never
+registered as input bindings, so `keyboardForwardDecision` resolved them to
+**zero** action ids → `forward: false` → the keydown was **dropped before
+`interpretKey` ever ran**. The reducer-only test started *after* the gate, so it
+could never see the bug. Tests that begin in the middle of a path cannot catch
+bugs at the start of it.
+
+### Mode 2 — data-model tests pass, nothing renders
+
+The spawned crackling arc had green tests asserting the beam is "in the model":
+
+```ts
+expect((after.beams ?? []).some(b => b.style === "crackling_arc")).toBe(true)  // GREEN
+```
+
+…but no test ever rendered the scene and looked at pixels. A beam can be in the
+`TrainingRunVisualizationOptions` and still be invisible on screen: the renderer
+applies `motionAllowedByPolicy(beam, motionPolicy)` (an `evidence: "required"`
+gate), positions are resolved from `entityPositions`, and the animation only
+advances on frame ticks. Any of those can silently drop the geometry while the
+model-level test stays green. **No model assertion is a render assertion.**
+
+### Mode 3 — `verified: true` on a non-running artifact
+
+A verifier reported `verified: true` for an artifact that did not actually run.
+The fix was the headless **acceptance runner**
+(`apps/openagents.com/workers/api/src/inference/acceptance-runner/`): it stops
+inspecting declared shape and instead **executes + observes**. That is the right
+model and this harness generalizes it to the desktop render path: *run the real
+thing in a real engine and observe the real output.*
+
+### Constraint A — `bun test` wedges (#5026)
+
+Loading the whole desktop suite into one `bun test` process deadlocks at module
+graph load (`__ulock_wait2`). The sanctioned runner is per-file:
+
+```
+bash apps/autopilot-desktop/scripts/run-tests.sh
+```
+
+which runs each `tests/*.test.ts` in its own `bun test` process. All harness
+tests here are per-file safe and pick up automatically.
+
+### Constraint B — the Electrobun native bridge is not faithfully headless
+
+Electrobun's native webview bridge cannot be driven headlessly with fidelity, so
+"mount the actual Electrobun app and press a key" is not a reliable CI gate. The
+harness works around this by splitting the path at the seam that is already
+faithful:
+
+- The **input path** (`keyboardForwardDecision → interpretKey → reducer →
+  visualization`) is **pure TypeScript** with no Electrobun dependency. The only
+  thing the native bridge adds is the literal `keydown` → forward-gate dispatch,
+  and `subscriptions.ts` already factors that decision into a pure
+  `keyboardForwardDecision`. So the harness reconstructs the *exact* DOM-handler
+  logic (forward gate → queue `PressedKey` → reducer) in-process and asserts the
+  whole chain. This is faithful because it calls the **same** `keyboardForward
+  Decision` and the **same** reducer the live handler calls.
+- The **render path** is driven in **headless Chromium via CDP** against the
+  **real** `@openagentsinc/three-effect` custom element (`oa-training-run`), the
+  same element the desktop app mounts. WebGL runs under SwiftShader so no GPU is
+  required.
+
+## Architecture
+
+### 1. Effect Layer-injected deterministic environment
+
+`src/testing/deterministic-env.ts` provides a small `TestEnvironment` service
+plus a `TestEnvironmentLayer` built from Effect's `TestClock` + a deterministic
+seeded RNG service. The rule (per `effect-solutions show testing`): **no
+`Date.now`, no `Math.random`, no `requestAnimationFrame`/wall-clock in tested
+logic** — those come from injected services so a test fully controls them.
+
+- `Clock` → Effect `TestClock` (advance time explicitly; no real sleeps).
+- `DeterministicRandom` → a seeded splitmix64 service (`next`, `nextInt`,
+  `seedOf`) so "random" is reproducible and `seed` is part of the recorded
+  evidence.
+- Transports/RPC → stubbed via Layer so a service under test talks to a
+  scripted fake, not the network.
+
+These are demonstrated by migrating two seams onto them (see §4) and are reused
+by the harnesses for any timing/seed they need.
+
+### 2. Full-input-path harness (`src/testing/full-input-path.ts`)
+
+A single reusable function:
+
+```ts
+runKeyEventThroughFullPath(model, keyEvent, { actionMap? })
+  → {
+      forwarded: boolean,          // keyboardForwardDecision.forward
+      preventDefault: boolean,
+      dispatched: boolean,         // did a PressedKey actually reach the reducer?
+      intent: KeyIntent,           // what interpretKey resolved
+      nextModel: Model,            // reducer output
+      visualization,               // verseSceneVisualization(nextModel)
+      spawnedSceneIds: string[],   // convenience projections
+    }
+```
+
+It runs the **real** `keyboardForwardDecision`; **only if it forwards** does it
+build the `PressedKey` message and run the **real** reducer (`update`), then
+project the **real** `verseSceneVisualization`. This is the exact ordering of the
+live DOM handler in `subscriptions.ts`, so a feature tested through it is tested
+end to end. Crucially, if the forward gate drops the key, `dispatched` is
+`false` and `nextModel === model` — which is precisely the #6041 bug, now
+observable. The harness accepts an optional `actionMap` so a test can prove the
+harness *fails on a deliberately-broken binding map* and *passes on the real one*
+(determinism + fail-on-broken proof).
+
+### 3. Headless deterministic pixel verification (`src/testing/headless-pixel.ts`)
+
+Generalizes `scripts/training-scene-canvas-smoke.ts` and the acceptance-runner
+"execute + observe" model into a reusable helper:
+
+```ts
+renderVisualizationAndProbe({
+  entryModulePath,       // a module that mounts oa-training-run with a viz
+  frameSteps,            // N FIXED deterministic frame steps
+  frameDeltaMs,          // ms advanced per step (fixed, not wall-clock)
+  pageQuery?,            // optional query string (e.g. "broken=1") for variants
+}) → { canvasWidth, canvasHeight, framesAdvanced, image,
+       score(region?) → { brightPixels, distinctLumaBuckets, sampledPixels } }
+```
+
+The entry module (`scripts/crackling-arc-entry.ts`) lives under `scripts/`
+because it imports the *real* three-effect element and is built standalone by
+`bun build`, while `src/` is typechecked against local `.d.ts` shims that do not
+declare the element registration functions.
+
+Determinism comes from **replacing the page's `requestAnimationFrame` and
+`performance.now` with a driver-controlled fake clock before the element
+mounts**. The three-effect element builds its render loop with
+`createManagedFrameClock({ mode: "always" })`, which calls the *global* rAF and
+`performance.now`; by installing a fake rAF queue + a monotonic fake clock, the
+harness advances **exactly `frameSteps` frames of exactly `frameDeltaMs` each**,
+with no real animation frames and no wall-clock — identical pixels every run.
+This is the "drive the managed frame clock N fixed steps" requirement, achieved
+without modifying three-effect (it already reads the injectable globals).
+
+The helper screenshots via CDP `Page.captureScreenshot`, decodes the PNG
+in-process (no image deps), and scores bright pixels **inside a region** so a
+test can assert e.g. "the crackling arc lights up bright pixels in the upper-mid
+band of the frame." A regression test asserts the arc is visible; a
+deliberately-broken variant (beam dropped / evidence ref removed so the
+`evidence: "required"` gate suppresses it) renders a dark region and the test
+**fails** — catching Mode 2.
+
+### 4. Demonstrated service migrations
+
+Two seams consume the deterministic layer to model the pattern (seeded RNG +
+TestClock), with tests that run twice and assert identical output.
+
+## How this would have caught the two bugs
+
+- **Keybinding (#6041):** the full-input-path harness runs
+  `keyboardForwardDecision` first; on broken bindings `forwarded === false`,
+  `dispatched === false`, and the scene never spawns — a hard failure at the
+  exact layer the bug lived in, instead of a reducer-only green.
+- **No-render:** the headless pixel harness steps deterministic frames and scores
+  pixels in the arc's region; an invisible arc (geometry dropped, evidence gate,
+  zero frames advanced) yields too-few bright pixels and fails, instead of a
+  model-shape green.
+
+## Running
+
+- Pure harness tests (input path + deterministic layers): per-file via
+  `bash apps/autopilot-desktop/scripts/run-tests.sh`, or individually with
+  `bun test apps/autopilot-desktop/tests/full-input-path-harness.test.ts`.
+- Headless pixel regression (needs Chrome/Chromium; set `CHROME_PATH` if not at
+  the default macOS location): `bun apps/autopilot-desktop/scripts/crackling-arc-pixel-regression.ts`.
+  Gated behind a binary check so it skips cleanly where no Chromium is present.


### PR DESCRIPTION
**DO NOT auto-merge — orchestrator reviews/merges.**

## Why
This session shipped three things whose unit tests were green but that did not actually work:
- **Reducer-only test passed, the live key did nothing.** ⌘⇧E/⌘⇧P had a green `update(model, PressedKey(...))` test, but the live key was dropped by the **forward gate** (`keyboardForwardDecision`) *before* `interpretKey` ran — the test started after the broken layer.
- **Data-model test passed, nothing rendered.** A `crackling_arc` beam was "in the model" (green) while the arc painted no pixels on screen — no test ever looked at pixels.
- **`verified: true` on a non-running artifact** — fixed by the headless acceptance-runner's *execute + observe* model, which this generalizes.

Design doc: `docs/testing/2026-06-22-deterministic-environment-testing.md` (the modes above + the architecture; honest about the bun #5026 load-hang and the non-headless Electrobun bridge and how the harness routes around both).

## The two harnesses

**1. Full-input-path harness** (`src/testing/full-input-path.ts`)
`runKeyEventThroughFullPath(model, keyEvent, { actionMap? })` drives the **real** `keyboardForwardDecision → (PressedKey only if forwarded) → interpretKey → reducer → verseSceneVisualization` in one call, in the **exact order the live DOM handler uses**. If the gate drops the key, `dispatched=false` and `nextModel===model` — the #6041 bug, now observable. *Catches:* any input feature whose reducer test is green but whose live key is dropped at the gate.

**2. Headless deterministic pixel verification** (`src/testing/headless-pixel.ts`)
Mounts the **real** three-effect `oa-training-run` element in headless Chromium (WebGL/SwiftShader) and steps the frame clock **N fixed frames** by injecting a driver-controlled fake `requestAnimationFrame`/`performance.now` **before mount** (no rAF/wall-clock). Screenshots via CDP, decodes the PNG in-process (no image deps), scores pixels in a region. Generalizes the existing training-scene smoke + the acceptance-runner pattern. *Catches:* geometry that is "in the model" but renders nothing.

Plus reusable **deterministic Effect layers** (`src/testing/deterministic-env.ts`): `TestEnvironment` = Effect `TestClock` + seeded `Random.withSeed` + stub transport, with a demonstrator service consuming all three.

## The two retrofitted regression proofs

| | pass-on-fixed | fail-on-broken |
|---|---|---|
| **Input path** (`full-input-path-harness.test.ts`) | real bindings: `forwarded=true`, scene spawns + renders | spawn bindings removed (pre-#6042 state): `forwarded=false`, nothing spawns. The identical `forwarded===true` assertion gives `Received: false` on broken — proven. |
| **Render path** (`crackling-arc-pixel-regression.test.ts` + `scripts/crackling-arc-pixel-regression.ts`) | arc contributes `1161` bright pixels in-region | geometry dropped → `arcContribution=0`, `Expected > 400` fails — proven |

## Determinism proof
The pixel harness produces **identical** scores every run (`fixed=19629`, `broken=18468`, `contribution=1161`, exactly, across repeated runs). The input + layer tests are pure (no clock/random/rAF); run twice → identical.

## How this would have caught the bugs
- **Keybinding:** the input harness runs the forward gate first; on broken bindings it hard-fails at that layer instead of a reducer-only green.
- **No-render:** the pixel harness steps deterministic frames and scores the arc's region; a dropped arc collapses the contribution and fails.

## Notes
- **No new dependencies** (raw CDP + in-process PNG decode; no Playwright added).
- `typecheck` clean. New suites pass per-file via the sanctioned `scripts/run-tests.sh` model (avoids the #5026 bun load-hang). The pixel suite skips cleanly where no Chromium is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)