### PR TITLE
Khala M3: auto Bitcoin settlement on verified accepted outcomes (#6011)

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -323,7 +323,15 @@ import {
   isAcceptanceDispatchEnabled,
   makeD1KhalaVerificationStore,
 } from './inference/acceptance-dispatch'
-import { handleAcceptanceVerdictCallback } from './inference/acceptance-verdict-callback-routes'
+import {
+  type AcceptedOutcomeSettlementSink,
+  handleAcceptanceVerdictCallback,
+} from './inference/acceptance-verdict-callback-routes'
+import {
+  settleVerifiedAcceptedOutcome,
+  summarizeAcceptedOutcomeSettlement,
+} from './inference/khala-accepted-outcome-settlement'
+import { readKhalaLoopArming } from './inference/khala-loop-integration'
 import { fireworksAdapter } from './inference/fireworks-adapter'
 import { handleGatewayReadiness } from './inference/gateway-readiness-routes'
 import {
@@ -1060,6 +1068,123 @@ const fetchMdkTreasuryPath = (
         method: init?.method ?? 'GET',
         ...(init?.signal === undefined ? {} : { signal: init.signal }),
       }),
+    )
+}
+
+// Build the accepted-outcome settlement sink (#6011, EPIC #6017) the verdict-callback
+// route fires when a VERIFIED + EXECUTED accepted outcome backfills for the first time.
+// REUSES the proven Spark dispatch core (`dispatchRealRunSettlementCore` +
+// `makeSparkTreasuryPayoutAdapter` + `resolveSparkPayoutDestination`) and the owner
+// real-settlement gate (`readTassadarRealSettlementGate`) — NO parallel money path.
+//
+// INERT BY DEFAULT, double-gated:
+//   - returns `undefined` (no settlement attempted at all) unless the KHALA loop-arming
+//     flag is armed (`readKhalaLoopArming`) — the FIRST default-OFF gate; and
+//   - even when armed, every per-party leg independently fail-closes on the owner
+//     real-settlement gate (default OFF), the per-payout cap, the daily budget, and a
+//     registered Spark destination — the SECOND gate stack, inside the engine.
+// So arming a real accepted-outcome payout requires BOTH the loop flag AND the owner
+// gate; with either OFF no sats move. The serving-run ref is derived from the
+// verification receipt ref so the gate allowlist enrolls a specific accepted outcome.
+const makeAcceptedOutcomeSettlementSink = (
+  env: Env,
+): AcceptedOutcomeSettlementSink | undefined => {
+  // FIRST gate: the loop-arming flag. OFF (default) => no sink => no settlement.
+  if (!readKhalaLoopArming(env as unknown as Record<string, unknown>).loopArmed) {
+    return undefined
+  }
+
+  const db = openAgentsDatabase(env)
+  const ledger = makeD1NexusTreasuryPayoutLedgerStore(db)
+  const sparkTargetStore = makeD1PylonSparkPayoutTargetStore(db)
+  const contributionStore = makeD1TrainingTraceContributionStore(db)
+
+  // Owner resolver for a contributor's Spark payout destination — same shape as the
+  // Tassadar autostream: direct registered-pylon lookup, then the owner-scoped fallback
+  // via the contributor's most-recent worker pylon. Never crosses agent ownership.
+  const resolveContributorOwnerAgentUserId = async (
+    contributorRef: string,
+  ): Promise<string | undefined> => {
+    const pylonApiStore = makeD1PylonApiStore(db)
+    const direct = await pylonApiStore
+      .readRegistration(contributorRef)
+      .then(registration => registration?.ownerAgentUserId)
+    if (direct !== undefined && direct.trim() !== '') {
+      return direct
+    }
+    const pylonRefForDevice =
+      await contributionStore.readMostRecentPylonRefByDeviceRef(contributorRef)
+    if (pylonRefForDevice === undefined) {
+      return undefined
+    }
+    return pylonApiStore
+      .readRegistration(pylonRefForDevice)
+      .then(registration => registration?.ownerAgentUserId)
+  }
+
+  return outcome =>
+    settleVerifiedAcceptedOutcome(
+      {
+        dispatchRealSettlement: dispatchInput =>
+          dispatchRealRunSettlementCore<WorkerBindings>(
+            {
+              env,
+              makeSettlementPaymentAuthority: (authorityEnv, context) =>
+                makeTreasuryPaymentAuthority({
+                  adapters: [
+                    makeSparkTreasuryPayoutAdapter({
+                      fetchTreasury: fetchMdkTreasuryPath(authorityEnv),
+                      providerRef: context.providerRef,
+                      resolveDestination: () =>
+                        Effect.succeed(context.privatePayoutDestination),
+                    }),
+                  ],
+                  ledgerStore: context.ledgerStore,
+                }),
+              readSettlementWalletReadiness: async authorityEnv => {
+                const fetchTreasury = fetchMdkTreasuryPath(authorityEnv)
+                if (fetchTreasury === undefined) {
+                  return 'absent'
+                }
+                try {
+                  const response = await fetchTreasury('/spark/balance')
+                  return response.ok ? 'ready' : 'absent'
+                } catch {
+                  return 'absent'
+                }
+              },
+              resolveSettlementPayoutDestination: (_authorityEnv, ref) =>
+                resolveSparkPayoutDestination(
+                  sparkTargetStore,
+                  ref,
+                  resolveContributorOwnerAgentUserId,
+                ),
+            },
+            {
+              contributorRef: dispatchInput.contributorRef,
+              ledger,
+              settlement: dispatchInput.settlement,
+            },
+          ),
+        ledger,
+        nowIso: currentIsoTimestamp(),
+        readGate: () => readTassadarRealSettlementGate(env),
+        resolvePayoutDestination: ref =>
+          resolveSparkPayoutDestination(
+            sparkTargetStore,
+            ref,
+            resolveContributorOwnerAgentUserId,
+          ),
+        // The gate allowlist enrolls a specific accepted outcome by its derived run ref.
+        settlementRunRef: `accepted_outcome.${outcome.verificationReceiptRef
+          .replace(/[^A-Za-z0-9_.:/-]/g, '_')
+          .slice(0, 180)}`,
+      },
+      outcome,
+    ).pipe(
+      Effect.map(result =>
+        summarizeAcceptedOutcomeSettlement(outcome, result),
+      ),
     )
 }
 
@@ -9978,6 +10103,13 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         enabled: isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED),
         nowIso: currentIsoTimestamp,
         store: makeD1KhalaVerificationStore(openAgentsDatabase(env)),
+        // Accepted-outcome settlement (#6011): fires worker+validator Bitcoin payout on
+        // the first VERIFIED+EXECUTED backfill. Double-gated + inert by default (undefined
+        // unless the KHALA loop flag is armed; even then the owner real-settlement gate +
+        // caps + destination fail-close inside the engine). NEEDS-OWNER to arm real money.
+        ...((sink => (sink === undefined ? {} : { settlement: sink }))(
+          makeAcceptedOutcomeSettlementSink(env),
+        )),
       }),
   },
   {

--- a/apps/openagents.com/workers/api/src/inference/acceptance-verdict-callback-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-verdict-callback-routes.ts
@@ -31,6 +31,21 @@ import {
   backfillVerdictIntoVerification,
   type KhalaVerificationStore,
 } from './acceptance-dispatch'
+import {
+  type AcceptedOutcomeSettledSummary,
+  type KhalaAcceptedOutcome,
+} from './khala-accepted-outcome-settlement'
+import { KHALA_CODE_VERIFIER_WORKER_ID } from './khala-code-verifier'
+
+// The accepted-outcome settlement sink the callback fires when a verified, executed
+// outcome BACKFILLS for the FIRST time. Returns the settled summary so the route can
+// surface `settled:true` + the settlement receipt refs in the response. The wiring
+// layer (`index.ts`) builds this from `settleVerifiedAcceptedOutcome` +
+// `summarizeAcceptedOutcomeSettlement` behind the loop-arming flag + the M3 owner gate;
+// a test passes a mock. Effect (fail-soft): it must never throw into the route.
+export type AcceptedOutcomeSettlementSink = (
+  outcome: KhalaAcceptedOutcome,
+) => Effect.Effect<AcceptedOutcomeSettledSummary>
 
 export type AcceptanceVerdictCallbackDeps = Readonly<{
   // Gateway flag (INFERENCE_GATEWAY_ENABLED). Default OFF => 404.
@@ -42,6 +57,12 @@ export type AcceptanceVerdictCallbackDeps = Readonly<{
   // in tests). The public receipt read projects from this store.
   store: KhalaVerificationStore
   nowIso: () => string
+  // The accepted-outcome settlement sink (#6011). OPTIONAL: absent => no settlement is
+  // attempted (the honest default before the loop is armed). When present, it fires
+  // ONLY on the FIRST backfill of a VERIFIED + EXECUTED outcome (a redelivered/idempotent
+  // callback never re-fires it, so settlement is at-most-once per accepted outcome). The
+  // sink itself fail-closes by default (owner gate OFF) and is fail-soft.
+  settlement?: AcceptedOutcomeSettlementSink | undefined
 }>
 
 const safeJsonParse = (text: string): unknown => {
@@ -114,6 +135,45 @@ export const handleAcceptanceVerdictCallback = (
       body,
     )
 
+    // ACCEPTED-OUTCOME SETTLEMENT (#6011, EPIC #6017). Fire the settlement sink ONLY on
+    // the FIRST backfill of a VERIFIED + EXECUTED accepted outcome — so a verify is what
+    // pays the worker + validator, and a redelivered/idempotent callback never re-fires
+    // it (at-most-once per accepted outcome). The sink itself fail-closes by default
+    // (owner real-settlement gate OFF) and is fail-soft; we additionally swallow here so
+    // a settlement error never regresses the already-backfilled receipt response.
+    let settled: AcceptedOutcomeSettledSummary | null = null
+    if (
+      deps.settlement !== undefined &&
+      outcome.backfilled &&
+      outcome.record.verified &&
+      outcome.record.executed
+    ) {
+      settled = yield* deps
+        .settlement({
+          executed: outcome.record.executed,
+          requestId: outcome.record.requestId,
+          scalarReward: outcome.record.scalarReward,
+          servedModel: body.servedModel,
+          // The VALIDATOR is the independent verifier that ran the headless acceptance
+          // suite (a distinct party from the producer). The SERVING WORKER that produced
+          // the accepted artifact is echoed back on `body.worker` (the dispatch carried
+          // the serving adapter id through to the runner).
+          validatorRef: KHALA_CODE_VERIFIER_WORKER_ID,
+          verificationReceiptRef: outcome.record.verificationReceiptRef,
+          verified: outcome.record.verified,
+          workerRef: body.worker,
+        })
+        .pipe(
+          Effect.orElseSucceed(
+            (): AcceptedOutcomeSettledSummary => ({
+              settled: false,
+              settledParties: [],
+              settlementReceiptRefs: [],
+            }),
+          ),
+        )
+    }
+
     return noStoreJsonResponse(
       {
         backfilled: outcome.backfilled,
@@ -121,6 +181,16 @@ export const handleAcceptanceVerdictCallback = (
         passedChecks: outcome.record.passedChecks,
         requestId: outcome.record.requestId,
         scalarReward: outcome.record.scalarReward,
+        // Settlement surface (#6011): `settled:true` + the per-party settlement receipt
+        // refs when the worker + validator were actually paid; the honest inert default
+        // (`settled:false`, empty refs) until the loop + owner gate are armed.
+        ...(settled === null
+          ? {}
+          : {
+              settled: settled.settled,
+              settledParties: settled.settledParties,
+              settlementReceiptRefs: settled.settlementReceiptRefs,
+            }),
         verificationReceiptRef: outcome.record.verificationReceiptRef,
         verified: outcome.record.verified,
         verdict: outcome.record.verification,

--- a/apps/openagents.com/workers/api/src/inference/acceptance-verdict-callback-settlement.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-verdict-callback-settlement.test.ts
@@ -1,0 +1,181 @@
+// Khala M3 — the verdict callback fires accepted-outcome settlement on the FIRST
+// verified backfill, surfaces `settled:true` + receipt refs, and is at-most-once
+// (#6011, EPIC #6017). The settlement sink is MOCKED here (no money path exercised at
+// this layer — the engine has its own fail-closed tests); this proves the callback
+// WIRES the trigger correctly: verified+executed => settle, idempotent replay => no
+// re-fire, unverified => no settle.
+
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  makeInMemoryKhalaVerificationStore,
+} from './acceptance-dispatch'
+import { crossyRoadAcceptanceSpec } from './acceptance-spec'
+import {
+  type AcceptedOutcomeSettlementSink,
+  handleAcceptanceVerdictCallback,
+} from './acceptance-verdict-callback-routes'
+import { type KhalaAcceptedOutcome } from './khala-accepted-outcome-settlement'
+
+const CALLBACK_TOKEN = 'runner-callback-token-test'
+const nowIso = () => '2026-06-22T18:00:00.000Z'
+
+const verdictBody = (
+  requestId: string,
+  overrides: { verified?: boolean } = {},
+) => ({
+  requestId,
+  schemaVersion: 'openagents.inference.acceptance_verdict.v1' as const,
+  servedModel: 'openagents/khala-code',
+  verdict: {
+    checks: crossyRoadAcceptanceSpec().checks.map(id => ({
+      detail: 'ok',
+      id,
+      passed: overrides.verified !== false,
+    })),
+    consoleErrors: [] as string[],
+    executed: true as const,
+    failedChecks:
+      overrides.verified === false ? [...crossyRoadAcceptanceSpec().checks] : [],
+    kind: 'crossy_road_single_html' as const,
+    pageErrors: [] as string[],
+    passedChecks:
+      overrides.verified === false ? [] : [...crossyRoadAcceptanceSpec().checks],
+    rubricRef: crossyRoadAcceptanceSpec().rubricRef,
+    scalarReward: overrides.verified === false ? 0 : 1,
+    verified: overrides.verified !== false,
+  },
+  worker: 'pylon-worker-1',
+})
+
+const makeRequest = (body: unknown) =>
+  new Request('https://openagents.com/v1/inference/acceptance-verdicts', {
+    body: JSON.stringify(body),
+    headers: {
+      authorization: `Bearer ${CALLBACK_TOKEN}`,
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  })
+
+// A capturing mock settlement sink: records the outcomes it was asked to settle and
+// returns a settled summary naming both parties. Proves the callback fired settlement
+// with the right party refs without exercising the real money path.
+const capturingSink = () => {
+  const calls: KhalaAcceptedOutcome[] = []
+  const sink: AcceptedOutcomeSettlementSink = outcome =>
+    Effect.sync(() => {
+      calls.push(outcome)
+      return {
+        settled: true,
+        settledParties: ['serving_worker', 'validator'],
+        settlementReceiptRefs: [
+          `receipt.nexus.khala_serving_settlement.${outcome.workerRef}`,
+          `receipt.nexus.khala_serving_settlement.${outcome.validatorRef}`,
+        ],
+      }
+    })
+  return { calls, sink }
+}
+
+describe('verdict callback -> accepted-outcome settlement wiring (#6011)', () => {
+  test('a VERIFIED+EXECUTED first backfill fires settlement and surfaces settled:true', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const { calls, sink } = capturingSink()
+
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(makeRequest(verdictBody('req_1')), {
+        callbackToken: CALLBACK_TOKEN,
+        enabled: true,
+        nowIso,
+        settlement: sink,
+        store,
+      }),
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as Record<string, unknown>
+    expect(json.backfilled).toBe(true)
+    expect(json.verified).toBe(true)
+    // settled:true + per-party receipt refs are surfaced in the response.
+    expect(json.settled).toBe(true)
+    expect(json.settledParties).toEqual(['serving_worker', 'validator'])
+    expect((json.settlementReceiptRefs as string[]).length).toBe(2)
+
+    // The sink fired ONCE with the worker = the serving worker and validator = the
+    // independent verifier worker id (a distinct party).
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.workerRef).toBe('pylon-worker-1')
+    expect(calls[0]!.validatorRef).toBe('khala-code-crossy-road-verifier')
+    expect(calls[0]!.verified).toBe(true)
+    expect(calls[0]!.executed).toBe(true)
+  })
+
+  test('a redelivered callback is at-most-once: settlement does NOT re-fire', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const { calls, sink } = capturingSink()
+    const deps = {
+      callbackToken: CALLBACK_TOKEN,
+      enabled: true,
+      nowIso,
+      settlement: sink,
+      store,
+    }
+
+    await Effect.runPromise(
+      handleAcceptanceVerdictCallback(makeRequest(verdictBody('req_2')), deps),
+    )
+    expect(calls).toHaveLength(1)
+
+    // Redeliver the SAME verdict: the backfill is now idempotent (already executed), so
+    // `backfilled:false` and the settlement sink is NOT fired again.
+    const second = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(makeRequest(verdictBody('req_2')), deps),
+    )
+    const secondJson = (await second.json()) as Record<string, unknown>
+    expect(secondJson.backfilled).toBe(false)
+    expect(calls).toHaveLength(1)
+  })
+
+  test('a FAILED (unverified) outcome does NOT fire settlement', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const { calls, sink } = capturingSink()
+
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(
+        makeRequest(verdictBody('req_3', { verified: false })),
+        {
+          callbackToken: CALLBACK_TOKEN,
+          enabled: true,
+          nowIso,
+          settlement: sink,
+          store,
+        },
+      ),
+    )
+    const json = (await response.json()) as Record<string, unknown>
+    expect(json.backfilled).toBe(true)
+    expect(json.verified).toBe(false)
+    // No settlement fired for a failed outcome: the sink is gated on verified+executed,
+    // so it is never called and no `settled` key is surfaced.
+    expect('settled' in json).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('with NO settlement sink wired (inert default), the callback still backfills', async () => {
+    const store = makeInMemoryKhalaVerificationStore()
+    const response = await Effect.runPromise(
+      handleAcceptanceVerdictCallback(makeRequest(verdictBody('req_4')), {
+        callbackToken: CALLBACK_TOKEN,
+        enabled: true,
+        nowIso,
+        store,
+      }),
+    )
+    const json = (await response.json()) as Record<string, unknown>
+    expect(json.backfilled).toBe(true)
+    expect(json.verified).toBe(true)
+    // No `settled` key at all when no sink is wired (the honest pre-arm default).
+    expect('settled' in json).toBe(false)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -332,6 +332,16 @@ type OpenAgentsReceipt = Readonly<{
         failed_checks: ReadonlyArray<string>
       }>
     | undefined
+  // Bitcoin/Spark settlement on a VERIFIED accepted outcome (#6011, EPIC #6017).
+  // `settled` is the honest default `false` on the hot path: settlement fires
+  // ASYNC after an out-of-Worker headless acceptance run verifies the outcome
+  // (the verdict-callback path settles the worker + validator and flips this to
+  // `true`), so a fresh completion is `verified:false`/`settled:false` until the
+  // runner verifies it. The field exists so the receipt shape is stable and a
+  // settled accepted outcome surfaces `settled:true` + the settlement receipt
+  // refs alongside `verified`/`scalar_reward`.
+  settled?: boolean | undefined
+  settlement_receipts?: ReadonlyArray<string> | undefined
 }>
 
 const publicInferenceReceiptUrl = (receiptRef: string): string =>
@@ -392,6 +402,11 @@ const khalaReceiptForResult = (
       ref: verdict.rubricRef,
     },
     scalar_reward: verdict.scalarReward,
+    // Honest hot-path default: settlement fires ASYNC after the headless acceptance
+    // verdict callback verifies the outcome and pays the worker + validator (#6011).
+    // A fresh completion is not yet settled; the public receipt read reflects the
+    // settled state once the callback has run.
+    settled: false,
     verification: verdict.verification,
     verification_command: verdict.command.commandRef,
     verification_receipt: verdict.receiptRef,

--- a/apps/openagents.com/workers/api/src/inference/khala-accepted-outcome-settlement.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-accepted-outcome-settlement.test.ts
@@ -1,0 +1,452 @@
+// Khala M3 — verified ACCEPTED-OUTCOME -> worker + validator Bitcoin settlement
+// (#6011, EPIC #6017). Proves the issue's "Done when": a verified accepted outcome
+// settles sats to the serving worker AND the validator with public settlement receipts;
+// the path is INERT by default (owner gate OFF), idempotent (a re-verify never
+// double-pays), and reuses the SAME proven Spark settlement engine (no parallel money
+// path). The guinea-pig Pylon's real Spark address is read from the gitignored
+// `.secrets/khala-test-payout.env` when present (placeholder fallback in CI) and only
+// ever handed to the test destination resolver — never asserted on, never committed.
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import type {
+  NexusPaymentAuthorityReceiptRecord,
+  NexusTreasuryPayoutAttemptRecord,
+  NexusTreasuryPayoutIntentRecord,
+  NexusTreasuryPayoutLedgerStore,
+  NexusTreasuryPayoutReconciliationEventRecord,
+} from '../nexus-treasury-payout-ledger'
+import {
+  disabledTassadarRealSettlementGate,
+  type TassadarRealSettlementGate,
+} from '../tassadar-run-settlement-gate'
+import {
+  type KhalaAcceptedOutcome,
+  acceptedOutcomeServingRunRef,
+  buildAcceptedOutcomeDecision,
+  settleVerifiedAcceptedOutcome,
+  summarizeAcceptedOutcomeSettlement,
+} from './khala-accepted-outcome-settlement'
+import { type KhalaSettlementDeps } from './khala-verified-work-settlement'
+import {
+  KHALA_CODE_ACCEPTED_OUTCOME_PRICE,
+  acceptedOutcomeSettlementShares,
+  lookupAcceptedOutcomePrice,
+} from './pricing'
+import { KHALA_CODE_MODEL_ID } from './pricing'
+import {
+  authorizeInferenceMonetization,
+} from '../inference-resale-authorization'
+import { validateAssetBoundary } from '../asset-bitcoin-boundary'
+
+const nowIso = '2026-06-22T18:00:00.000Z'
+
+// The serving WORKER (guinea-pig Pylon, paid first) and the VALIDATOR (the verifier).
+const WORKER_REF = 'pylon.khala.guinea_pig'
+const VALIDATOR_REF = 'khala-code-crossy-road-verifier'
+
+const VERIFICATION_RECEIPT_REF =
+  'receipt.inference.khala_code.verification.req_abc.fnv1a32.deadbeef'
+
+// The derived serving-run ref the settlement (and the gate allowlist) key on.
+const DERIVED_RUN_REF = acceptedOutcomeServingRunRef(VERIFICATION_RECEIPT_REF)
+
+const readGuineaPigSparkAddress = (): string => {
+  try {
+    const raw = readFileSync(
+      join(homedir(), 'work', '.secrets', 'khala-test-payout.env'),
+      'utf8',
+    )
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim()
+      if (trimmed.startsWith('KHALA_TEST_PAYOUT_SPARK_ADDRESS=')) {
+        const value = trimmed
+          .slice('KHALA_TEST_PAYOUT_SPARK_ADDRESS='.length)
+          .trim()
+        if (value !== '') return value
+      }
+    }
+  } catch {
+    // File absent (CI): fall through to the placeholder.
+  }
+  return 'spark1guineapigplaceholderxxxxxxxxxxxxxxxxxxxxxxx'
+}
+
+// A VERIFIED + EXECUTED accepted outcome for khala-code (the payable trigger).
+const verifiedOutcome = (
+  overrides: Partial<KhalaAcceptedOutcome> = {},
+): KhalaAcceptedOutcome => ({
+  executed: true,
+  requestId: 'req_abc',
+  scalarReward: 1,
+  servedModel: KHALA_CODE_MODEL_ID,
+  validatorRef: VALIDATOR_REF,
+  verificationReceiptRef: VERIFICATION_RECEIPT_REF,
+  verified: true,
+  workerRef: WORKER_REF,
+  ...overrides,
+})
+
+// The owner real-settlement gate, ARMED in TEST mode with run-scoped streaming so both
+// the worker and the validator contributor refs qualify on the allowlisted run. Tiny +
+// treasury-bounded caps — this is real money.
+const armedRealSettlementGate = (
+  overrides: Partial<TassadarRealSettlementGate> = {},
+): TassadarRealSettlementGate => ({
+  allowedAdapterKind: 'spark_treasury',
+  allowedContributorRefs: [],
+  allowedRunRefs: [DERIVED_RUN_REF],
+  enabled: true,
+  maxDailyPayoutSats: 100,
+  maxPayoutSats: 100,
+  runScopedStreaming: true,
+  ...overrides,
+})
+
+class MemoryLedgerStore implements NexusTreasuryPayoutLedgerStore {
+  attempts = new Map<string, NexusTreasuryPayoutAttemptRecord>()
+  attemptsByIdempotency = new Map<string, NexusTreasuryPayoutAttemptRecord>()
+  events = new Map<string, NexusTreasuryPayoutReconciliationEventRecord>()
+  intents = new Map<string, NexusTreasuryPayoutIntentRecord>()
+  intentsByIdempotency = new Map<string, NexusTreasuryPayoutIntentRecord>()
+  receipts = new Map<string, NexusPaymentAuthorityReceiptRecord>()
+
+  createPayoutAttempt = async (record: NexusTreasuryPayoutAttemptRecord) => {
+    this.attempts.set(record.payoutAttemptRef, record)
+    this.attemptsByIdempotency.set(record.idempotencyKeyHash, record)
+  }
+
+  createPayoutIntent = async (record: NexusTreasuryPayoutIntentRecord) => {
+    this.intents.set(record.payoutIntentRef, record)
+    this.intentsByIdempotency.set(record.idempotencyKeyHash, record)
+  }
+
+  createPayoutTargetApproval = async () => {}
+
+  createPaymentAuthorityReceipt = async (
+    record: NexusPaymentAuthorityReceiptRecord,
+  ) => {
+    this.receipts.set(record.receiptRef, record)
+  }
+
+  createReconciliationEvent = async (
+    record: NexusTreasuryPayoutReconciliationEventRecord,
+  ) => {
+    this.events.set(record.eventRef, record)
+  }
+
+  createReleaseGate = async () => {}
+
+  listPaymentAuthorityReceipts = async (limit: number) =>
+    [...this.receipts.values()].slice(0, limit)
+
+  readPayoutAttemptByRef = async (ref: string) => this.attempts.get(ref)
+
+  readPayoutAttemptByIdempotencyKeyHash = async (hash: string) =>
+    this.attemptsByIdempotency.get(hash)
+
+  readPayoutIntentByIdempotencyKeyHash = async (hash: string) =>
+    this.intentsByIdempotency.get(hash)
+
+  readPayoutIntentByBuyerPaymentRef = async (buyerPaymentRef: string) =>
+    [...this.intents.values()].find(i => i.buyerPaymentRef === buyerPaymentRef)
+
+  readPayoutIntentByRef = async (ref: string) => this.intents.get(ref)
+
+  readPaymentAuthorityReceiptByRef = async (ref: string) =>
+    this.receipts.get(ref)
+
+  readReconciliationEventByRef = async (ref: string) => this.events.get(ref)
+}
+
+// A test dispatch that mirrors the proven receipt-first idempotent Spark dispatch:
+// short-circuit if the settlement receipt already exists (idempotency), else count the
+// call and persist the realBitcoinMoved-shaped settlement receipt. MOCKED — no real
+// Bitcoin ever moves in tests.
+const makeDeps = (
+  options: Readonly<{
+    gate: TassadarRealSettlementGate
+    ledger: MemoryLedgerStore
+    targets: ReadonlyMap<string, string>
+    dispatchCount: { value: number }
+  }>,
+): KhalaSettlementDeps => ({
+  dispatchRealSettlement: input =>
+    Effect.gen(function* () {
+      const existing = yield* Effect.promise(() =>
+        options.ledger.readPaymentAuthorityReceiptByRef(
+          input.settlement.settlementReceiptRef,
+        ),
+      )
+      if (existing !== undefined) {
+        return
+      }
+      options.dispatchCount.value += 1
+      yield* Effect.promise(() =>
+        options.ledger.createPaymentAuthorityReceipt(
+          input.settlement.settlementReceipt,
+        ),
+      )
+    }),
+  ledger: options.ledger,
+  nowIso,
+  readGate: () => options.gate,
+  resolvePayoutDestination: async ref => options.targets.get(ref),
+  settlementRunRef: DERIVED_RUN_REF,
+})
+
+const armedTargets = () =>
+  new Map([
+    [WORKER_REF, readGuineaPigSparkAddress()],
+    [VALIDATOR_REF, readGuineaPigSparkAddress()],
+  ])
+
+describe('accepted-outcome pricing (per accepted outcome alongside per-token)', () => {
+  it('khala-code has an accepted-outcome price that splits worker/validator and conserves', () => {
+    const price = lookupAcceptedOutcomePrice(KHALA_CODE_MODEL_ID)
+    expect(price).toBeDefined()
+    expect(price!.priceMsat).toBe(KHALA_CODE_ACCEPTED_OUTCOME_PRICE.priceMsat)
+
+    const { workerMsat, validatorMsat } = acceptedOutcomeSettlementShares(price!)
+    // 5_000 msat split 60/40 = 3000 / 2000, summing EXACTLY to the price (no dust).
+    expect(workerMsat).toBe(3_000)
+    expect(validatorMsat).toBe(2_000)
+    expect(workerMsat + validatorMsat).toBe(price!.priceMsat)
+  })
+
+  it('non-accepted-outcome models have no accepted-outcome price (per-token only)', () => {
+    expect(lookupAcceptedOutcomePrice('openagents/khala-mini')).toBeUndefined()
+    expect(lookupAcceptedOutcomePrice('gpt-oss-20b')).toBeUndefined()
+  })
+})
+
+describe('buildAcceptedOutcomeDecision (two-party split)', () => {
+  it('builds a worker-first, validator-second two-share decision from the price', () => {
+    const decision = buildAcceptedOutcomeDecision({
+      outcome: verifiedOutcome(),
+      price: KHALA_CODE_ACCEPTED_OUTCOME_PRICE,
+    })
+    expect(decision.servingRunRef).toBe(DERIVED_RUN_REF)
+    expect(decision.split.shares).toHaveLength(2)
+    // Worker is paid FIRST (the guinea-pig Pylon).
+    expect(decision.split.shares[0]!.nodeRef).toBe(WORKER_REF)
+    expect(decision.split.shares[1]!.nodeRef).toBe(VALIDATOR_REF)
+    // 3 sats worker, 2 sats validator (msat in the share, floored to sat by the engine).
+    expect(decision.split.shares[0]!.amountMsat).toBe(3_000)
+    expect(decision.split.shares[1]!.amountMsat).toBe(2_000)
+  })
+})
+
+describe('settleVerifiedAcceptedOutcome — worker + validator paid (TEST-armed)', () => {
+  it('settles real sats to BOTH the worker and the validator with dereferenceable receipts', async () => {
+    const ledger = new MemoryLedgerStore()
+    const dispatchCount = { value: 0 }
+    const deps = makeDeps({
+      dispatchCount,
+      gate: armedRealSettlementGate(),
+      ledger,
+      targets: armedTargets(),
+    })
+
+    const result = await Effect.runPromise(
+      settleVerifiedAcceptedOutcome(deps, verifiedOutcome()),
+    )
+
+    expect(result.eligible).toBe(true)
+    expect(result.settlement).not.toBeNull()
+    expect(result.settlement!.legs).toHaveLength(2)
+
+    const [workerLeg, validatorLeg] = result.settlement!.legs
+    expect(workerLeg!.contributorRef).toBe(WORKER_REF)
+    expect(workerLeg!.settled).toBe(true)
+    expect(workerLeg!.realBitcoinMoved).toBe(true)
+    expect(workerLeg!.amountSats).toBe(3)
+    expect(validatorLeg!.contributorRef).toBe(VALIDATOR_REF)
+    expect(validatorLeg!.settled).toBe(true)
+    expect(validatorLeg!.realBitcoinMoved).toBe(true)
+    expect(validatorLeg!.amountSats).toBe(2)
+
+    // One dispatch per party.
+    expect(dispatchCount.value).toBe(2)
+
+    // The settled summary surfaces settled:true + BOTH receipt refs + both parties.
+    const summary = summarizeAcceptedOutcomeSettlement(verifiedOutcome(), result)
+    expect(summary.settled).toBe(true)
+    expect(summary.settlementReceiptRefs).toHaveLength(2)
+    expect(summary.settledParties).toEqual(['serving_worker', 'validator'])
+
+    // Both receipts are dereferenceable + realBitcoinMoved-shaped; no raw Spark address.
+    for (const ref of summary.settlementReceiptRefs) {
+      const receipt = await ledger.readPaymentAuthorityReceiptByRef(ref)
+      expect(receipt).toBeDefined()
+      const projection = JSON.parse(receipt!.publicProjectionJson)
+      expect(projection.state).toBe('settled')
+      expect(projection.moneyMovement).toBe('real_bitcoin')
+      expect(receipt!.publicProjectionJson).not.toMatch(/spark1/i)
+    }
+  })
+
+  it('is IDEMPOTENT: a re-verify of the same accepted outcome never double-pays', async () => {
+    const ledger = new MemoryLedgerStore()
+    const dispatchCount = { value: 0 }
+    const deps = makeDeps({
+      dispatchCount,
+      gate: armedRealSettlementGate(),
+      ledger,
+      targets: armedTargets(),
+    })
+
+    await Effect.runPromise(
+      settleVerifiedAcceptedOutcome(deps, verifiedOutcome()),
+    )
+    expect(dispatchCount.value).toBe(2)
+
+    // Second settle for the SAME accepted outcome (a re-verify / redelivered callback):
+    // the receipt refs are deterministic from the verification receipt ref, so the
+    // receipt-first dispatch short-circuits — NO second payout.
+    const second = await Effect.runPromise(
+      settleVerifiedAcceptedOutcome(deps, verifiedOutcome()),
+    )
+    expect(dispatchCount.value).toBe(2)
+    // The legs still report settled (the receipts already exist) but moved no new money.
+    expect(second.settlement!.legs.every(l => l.settled)).toBe(true)
+    expect(ledger.receipts.size).toBe(2)
+  })
+})
+
+describe('settleVerifiedAcceptedOutcome — fail-closed + inert by default', () => {
+  it('is INERT by default: the disabled owner gate pays neither party (no money moves)', async () => {
+    const ledger = new MemoryLedgerStore()
+    const dispatchCount = { value: 0 }
+    const deps = makeDeps({
+      dispatchCount,
+      gate: disabledTassadarRealSettlementGate,
+      ledger,
+      targets: armedTargets(),
+    })
+
+    const result = await Effect.runPromise(
+      settleVerifiedAcceptedOutcome(deps, verifiedOutcome()),
+    )
+    expect(result.eligible).toBe(true)
+    expect(result.settlement!.legs.every(l => !l.settled)).toBe(true)
+    expect(
+      result.settlement!.legs.every(l => l.skipped === 'gate_not_authorized'),
+    ).toBe(true)
+    expect(dispatchCount.value).toBe(0)
+    expect(ledger.receipts.size).toBe(0)
+
+    const summary = summarizeAcceptedOutcomeSettlement(verifiedOutcome(), result)
+    expect(summary.settled).toBe(false)
+    expect(summary.settlementReceiptRefs).toHaveLength(0)
+  })
+
+  it('an UNVERIFIED or un-executed outcome is INELIGIBLE — never pays', async () => {
+    const ledger = new MemoryLedgerStore()
+    const dispatchCount = { value: 0 }
+    const deps = makeDeps({
+      dispatchCount,
+      gate: armedRealSettlementGate(),
+      ledger,
+      targets: armedTargets(),
+    })
+
+    const unverified = await Effect.runPromise(
+      settleVerifiedAcceptedOutcome(deps, verifiedOutcome({ verified: false })),
+    )
+    expect(unverified.eligible).toBe(false)
+    expect(unverified.settlement).toBeNull()
+
+    const unexecuted = await Effect.runPromise(
+      settleVerifiedAcceptedOutcome(deps, verifiedOutcome({ executed: false })),
+    )
+    expect(unexecuted.eligible).toBe(false)
+
+    expect(dispatchCount.value).toBe(0)
+    expect(ledger.receipts.size).toBe(0)
+  })
+
+  it('a model with no accepted-outcome price is INELIGIBLE', async () => {
+    const ledger = new MemoryLedgerStore()
+    const dispatchCount = { value: 0 }
+    const deps = makeDeps({
+      dispatchCount,
+      gate: armedRealSettlementGate(),
+      ledger,
+      targets: armedTargets(),
+    })
+
+    const result = await Effect.runPromise(
+      settleVerifiedAcceptedOutcome(
+        deps,
+        verifiedOutcome({ servedModel: 'openagents/khala-mini' }),
+      ),
+    )
+    expect(result.eligible).toBe(false)
+    expect(dispatchCount.value).toBe(0)
+  })
+})
+
+describe('RL-3 — Khala api-inference-resale authorized + asset boundary holds', () => {
+  // The full ref chain proving the api_inference_gateway_resale lane (Khala is the
+  // ALLOWED case; the no-resale restriction is scoped to SUBSCRIPTION accounts).
+  const fullResaleRefs = {
+    assignmentReceiptRef: 'ref.assignment',
+    dispatchRef: 'ref.dispatch',
+    meteringReceiptRef: 'ref.metering',
+    pricingPolicyRef: 'ref.pricing',
+    providerGrantRef: 'ref.grant',
+    routePolicyRef: 'ref.route',
+    settlementReceiptRef: 'ref.settlement',
+    tosBoundaryRef: 'ref.tos',
+  }
+
+  it('AUTHORIZES Khala api_inference_gateway_resale on our own api_key account', () => {
+    const decision = authorizeInferenceMonetization({
+      accountAuthMode: 'api_key',
+      kind: 'api_inference_gateway_resale',
+      refs: fullResaleRefs,
+    })
+    expect(decision.authorized).toBe(true)
+    expect(decision.blockerRefs).toHaveLength(0)
+  })
+
+  it('still FORBIDS subscription-seat resale (the non-waivable lane)', () => {
+    const decision = authorizeInferenceMonetization({
+      kind: 'subscription_capacity_resale',
+    })
+    expect(decision.authorized).toBe(false)
+  })
+
+  it('asset boundary ALLOWS bitcoin revenue -> bitcoin worker/validator share', () => {
+    expect(
+      validateAssetBoundary({
+        contributorAsset: 'bitcoin',
+        movement: 'payout',
+        revenueAsset: 'bitcoin',
+      }),
+    ).toBeNull()
+  })
+
+  it('asset boundary DENIES credit/free revenue -> withdrawable bitcoin share', () => {
+    expect(
+      validateAssetBoundary({
+        contributorAsset: 'bitcoin',
+        movement: 'payout',
+        revenueAsset: 'credit',
+      }),
+    ).not.toBeNull()
+    expect(
+      validateAssetBoundary({
+        contributorAsset: 'bitcoin',
+        movement: 'payout',
+        revenueAsset: 'free',
+      }),
+    ).not.toBeNull()
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-accepted-outcome-settlement.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-accepted-outcome-settlement.ts
@@ -1,0 +1,249 @@
+// Khala M3 — VERIFIED ACCEPTED-OUTCOME -> Bitcoin/Spark settlement to the serving
+// WORKER + the VALIDATOR (EPIC #6017, #6011).
+//
+// THE TRIGGER (issue #6011). The `khala-code` verifier (`khala-code-verifier.ts`)
+// produces `verified:true` + `scalarReward` + an `accepted_outcome` handoff ref ONLY
+// from an EXECUTED acceptance verdict — a crossy-road build that actually passed the
+// headless acceptance suite (not a regex over source). That EXECUTED accepted outcome
+// is the money trigger: the worker that served it and the validator that independently
+// verified it both get paid in Bitcoin, with a public settlement receipt, and the
+// `openagents` response block flips `settled:true`.
+//
+// REUSE — DO NOT FORK THE MONEY PATH. This module does NOT build a new payout authority.
+// It maps the accepted outcome onto the SAME proven primitives the parity-serving M3
+// path already uses:
+//   - the accepted-outcome PRICE (`pricing.ts` `KHALA_CODE_ACCEPTED_OUTCOME_PRICE`)
+//     splits worker/validator (`acceptedOutcomeSettlementShares`);
+//   - the two shares become a synthetic `ServingNodePayoutDecision.split` (one share
+//     per party), so `settleVerifiedServingPayout` (`khala-verified-work-settlement.ts`)
+//     runs its EXACT fail-closed gate stack + Spark dispatch + `realBitcoinMoved`-shaped
+//     receipt chain over each party — no parallel money path, no new receipt shape;
+//   - the serving-run ref is DERIVED from the verification receipt ref, so idempotency
+//     is keyed on the ACCEPTANCE/RECEIPT ref: a re-verify or a redelivered callback for
+//     the same accepted outcome settles AT MOST ONCE per party (the settlement receipt
+//     refs are deterministic; the dispatch is receipt-first and short-circuits).
+//
+// SAFETY (real money — conservative; the same discipline as the parity path):
+//   - FAIL-CLOSED gates, in order, each falling back to a skip: the outcome must be
+//     VERIFIED + EXECUTED (an `unverified`/`failed`/un-executed outcome NEVER pays); the
+//     RL-3 asset boundary (only Bitcoin revenue funds a withdrawable Bitcoin share); the
+//     owner-armed real-settlement gate (default OFF everywhere -> every leg is
+//     `gate_not_authorized`); the per-payout cap; the cumulative daily budget; and a
+//     registered Spark destination per party.
+//   - IDEMPOTENT on the acceptance/receipt ref: a replay pays AT MOST ONCE per party.
+//   - FAIL-SOFT: never throws into the caller (the verdict callback forwards this
+//     fire-and-forget; a settlement error never regresses the backfilled receipt).
+//   - INERT BY DEFAULT: with the owner real-settlement gate OFF this module is fully
+//     inert (no real sats move); arming real Bitcoin beyond the bounded guinea-pig test
+//     path is a NEEDS-OWNER step, never an agent workaround. Tests mock the dispatch.
+
+import { Effect } from 'effect'
+
+import {
+  type KhalaSettlementDeps,
+  type KhalaSettlementOutcome,
+  settleVerifiedServingPayout,
+} from './khala-verified-work-settlement'
+import {
+  type AcceptedOutcomePrice,
+  acceptedOutcomeSettlementShares,
+  lookupAcceptedOutcomePrice,
+} from './pricing'
+import {
+  type ServingNodePayoutDecision,
+  type ServingPayoutShare,
+} from './serving-node-payout'
+
+// The two settlement parties for a verified accepted outcome.
+export type AcceptedOutcomeSettlementParty = 'serving_worker' | 'validator'
+
+// Public-safe policy ref stamped on an accepted-outcome settlement.
+export const KHALA_ACCEPTED_OUTCOME_SETTLEMENT_POLICY_REF =
+  'policy.khala_accepted_outcome_settlement.v1'
+
+// The minimal, public-safe accepted-outcome the settlement consumes. It is the
+// EXECUTED verifier verdict reduced to exactly what the money path needs — no
+// prompts, no artifact bytes, no chain-of-thought. `verified` + `executed` are the
+// gate; `verificationReceiptRef` is the idempotency anchor; the two refs name the
+// parties paid.
+export type KhalaAcceptedOutcome = Readonly<{
+  // The inference response id the accepted outcome belongs to (diagnostics only).
+  requestId: string
+  // The model the accepted outcome was produced for (must have an accepted-outcome
+  // price; otherwise no settlement). Canonical id.
+  servedModel: string
+  // Whether the outcome was VERIFIED by an EXECUTED acceptance run. Both must be
+  // true to settle — an `unverified`/`failed`/un-executed outcome never pays.
+  verified: boolean
+  executed: boolean
+  // The verifier's scalar reward (diagnostics only; the PRICE, not the scalar, sets
+  // the payout — the scalar is the training/quality signal, not the amount).
+  scalarReward: number
+  // The verification receipt ref — the public, dereferenceable anchor the settlement
+  // idempotency keys on (so a re-verify never double-pays).
+  verificationReceiptRef: string
+  // The serving WORKER that produced the accepted artifact (payout recipient).
+  workerRef: string
+  // The VALIDATOR that independently verified it (payout recipient).
+  validatorRef: string
+}>
+
+// A neutral, public-safe serving-run ref derived from the verification receipt ref.
+// This is what makes the settlement idempotency key on the ACCEPTANCE/RECEIPT ref:
+// `settleVerifiedServingPayout` derives every per-party settlement receipt ref from
+// this run ref + the party node ref, so a replay produces the SAME refs and the
+// receipt-first dispatch short-circuits.
+export const acceptedOutcomeServingRunRef = (
+  verificationReceiptRef: string,
+): string => {
+  const suffix = verificationReceiptRef
+    .replace(/[^A-Za-z0-9_.:/-]/g, '_')
+    .slice(0, 180)
+  return `accepted_outcome.${suffix}`
+}
+
+// Build the synthetic, two-party serving-payout DECISION for a verified accepted
+// outcome. PURE. The worker + validator shares (from the accepted-outcome price) become
+// the `split.shares`, so the proven settlement engine settles each party identically to
+// a serving stage. The decision is ALWAYS marked `armed` here because the real
+// fail-closed authority lives DOWNSTREAM in `settleVerifiedServingPayout`'s own gate
+// stack (owner gate, caps, destination) — this decision is just the apportionment the
+// engine consumes, never an authorization. A non-positive/zero split yields no shares.
+//
+// NOTE: `settleVerifiedServingPayout` treats `share.amountMsat` as a SAT-denominated
+// share (it floors msat->sat at its boundary). The accepted-outcome price is msat; we
+// hand the engine sat-denominated shares directly so the on-wire amount is the intended
+// few-sat accepted-outcome payout.
+export const buildAcceptedOutcomeDecision = (
+  input: Readonly<{
+    outcome: KhalaAcceptedOutcome
+    price: AcceptedOutcomePrice
+  }>,
+): ServingNodePayoutDecision => {
+  const { outcome, price } = input
+  const servingRunRef = acceptedOutcomeServingRunRef(
+    outcome.verificationReceiptRef,
+  )
+  const split = acceptedOutcomeSettlementShares(price)
+
+  // Convert msat shares to whole-sat shares for the engine (which floors at its
+  // boundary anyway; doing it here keeps the on-wire amount legible + conserved).
+  const workerSats = Math.floor(split.workerMsat / 1000)
+  const validatorSats = Math.floor(split.validatorMsat / 1000)
+
+  const shares: ReadonlyArray<ServingPayoutShare> = [
+    // Worker FIRST (the guinea-pig serving Pylon is paid first, per owner direction).
+    { amountMsat: workerSats * 1000, nodeRef: outcome.workerRef, weight: 1 },
+    { amountMsat: validatorSats * 1000, nodeRef: outcome.validatorRef, weight: 1 },
+  ]
+
+  const totalMsat = shares.reduce((sum, s) => sum + s.amountMsat, 0)
+
+  return {
+    armed: true,
+    blockerRefs: [],
+    idempotencyKey: `serving:payout:${servingRunRef}`,
+    policyRefs: [KHALA_ACCEPTED_OUTCOME_SETTLEMENT_POLICY_REF],
+    receiptRef: `receipt.serving.payout.${servingRunRef}`,
+    schema: 'openagents.serving_node_payout.v1',
+    servingRunRef,
+    split: { shares, totalMsat },
+  }
+}
+
+export type KhalaAcceptedOutcomeSettlementResult = Readonly<{
+  // Whether the outcome was even ELIGIBLE to settle (verified + executed + has an
+  // accepted-outcome price). False => no settlement attempted (honest, not a payout).
+  eligible: boolean
+  // The party->settlement outcome from the proven engine, present only when eligible.
+  // Each leg carries `settled` + `settlementReceiptRef` exactly like the parity path.
+  settlement: KhalaSettlementOutcome | null
+}>
+
+// Settle a VERIFIED accepted outcome to the serving worker + validator in Bitcoin over
+// Spark, reusing the proven engine. FAIL-CLOSED + FAIL-SOFT + IDEMPOTENT.
+//
+//   1. ELIGIBILITY (pure, fail-closed): the outcome must be `verified` AND `executed`,
+//      and the model must have an accepted-outcome price. Any miss => `{ eligible:false,
+//      settlement:null }` — no settlement attempted, no money moved.
+//   2. The eligible outcome becomes a two-party decision (worker + validator) and runs
+//      through `settleVerifiedServingPayout`, which applies its OWN fail-closed gates
+//      (owner real-settlement gate default OFF, per-payout cap, daily budget, registered
+//      destination) per party and dispatches the SAME receipt-first idempotent Spark
+//      settlement. `parityVerified` is passed `true` because the accepted-outcome
+//      EXECUTION verdict IS the checkable-outcome gate this path stands on (the verifier
+//      ran the artifact); the engine's gate stack still independently fail-closes
+//      everything money-related.
+//
+// Returns the structured result; never throws into the caller.
+export const settleVerifiedAcceptedOutcome = (
+  deps: KhalaSettlementDeps,
+  outcome: KhalaAcceptedOutcome,
+): Effect.Effect<KhalaAcceptedOutcomeSettlementResult> =>
+  Effect.gen(function* () {
+    // GATE 1 — verified + executed accepted outcome (fail-closed). Only an EXECUTED,
+    // verified outcome is a payable accepted outcome.
+    if (!(outcome.verified && outcome.executed)) {
+      return { eligible: false, settlement: null }
+    }
+
+    // GATE 2 — the model must have an accepted-outcome price.
+    const price = lookupAcceptedOutcomePrice(outcome.servedModel)
+    if (price === undefined) {
+      return { eligible: false, settlement: null }
+    }
+
+    const decision = buildAcceptedOutcomeDecision({ outcome, price })
+
+    // The proven engine: per-party gate stack + Spark dispatch + receipt chain. The
+    // accepted-outcome EXECUTION verdict is the checkable outcome, so parity is true;
+    // every money gate downstream still fail-closes by default.
+    const settlement = yield* settleVerifiedServingPayout(deps, {
+      decision,
+      parityVerified: true,
+      servedModel: outcome.servedModel,
+    })
+
+    return { eligible: true, settlement }
+  })
+
+// The settled summary the route surfaces into the `openagents` receipt block. PURE.
+// Derived from the engine's leg outcomes: `settled` is true iff at least one party leg
+// actually settled (real Bitcoin moved); `settlementReceiptRefs` lists the
+// dereferenceable per-party settlement receipts; `parties` names which parties settled.
+// With every gate OFF (the default) this is `{ settled:false, refs:[], parties:[] }` —
+// the honest inert default the receipt shows alongside `verified:true`.
+export type AcceptedOutcomeSettledSummary = Readonly<{
+  settled: boolean
+  settlementReceiptRefs: ReadonlyArray<string>
+  settledParties: ReadonlyArray<AcceptedOutcomeSettlementParty>
+}>
+
+export const summarizeAcceptedOutcomeSettlement = (
+  outcome: KhalaAcceptedOutcome,
+  result: KhalaAcceptedOutcomeSettlementResult,
+): AcceptedOutcomeSettledSummary => {
+  if (!result.eligible || result.settlement === null) {
+    return { settled: false, settledParties: [], settlementReceiptRefs: [] }
+  }
+
+  const refs: string[] = []
+  const parties: AcceptedOutcomeSettlementParty[] = []
+  for (const leg of result.settlement.legs) {
+    if (leg.settled && leg.settlementReceiptRef !== null) {
+      refs.push(leg.settlementReceiptRef)
+      // Map the leg's contributor ref back to its party label.
+      parties.push(
+        leg.contributorRef === outcome.workerRef
+          ? 'serving_worker'
+          : 'validator',
+      )
+    }
+  }
+
+  return {
+    settled: refs.length > 0,
+    settledParties: parties,
+    settlementReceiptRefs: refs,
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/khala-verified-work-settlement.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-verified-work-settlement.ts
@@ -36,6 +36,7 @@ import { Effect } from 'effect'
 
 import type {
   NexusPaymentAuthorityReceiptRecord,
+  NexusPayoutTargetApprovalRecord,
   NexusTreasuryPayoutAttemptRecord,
   NexusTreasuryPayoutIntentRecord,
   NexusTreasuryPayoutLedgerStore,
@@ -68,6 +69,10 @@ export type KhalaSettlementRecords = Readonly<{
   reconciliationEvent: NexusTreasuryPayoutReconciliationEventRecord
   settlementReceipt: NexusPaymentAuthorityReceiptRecord
   settlementReceiptRef: string
+  // The payout-target approval record. Carried so these records are directly
+  // dispatchable through the SAME proven `dispatchRealRunSettlementCore` the
+  // Tassadar autostream uses (it requires a `targetApproval`) — no parallel path.
+  targetApproval: NexusPayoutTargetApprovalRecord
 }>
 
 // Public-safe ref helpers (neutral; never payment material).
@@ -120,7 +125,7 @@ export const buildKhalaSettlementRecords = (
     'metadata.khala.verified_work_settlement.accepted_work',
   ])
 
-  const targetApproval = {
+  const targetApproval: NexusPayoutTargetApprovalRecord = {
     agentRef: 'agent.artanis',
     approvalPolicyRef: KHALA_SETTLEMENT_PAYOUT_TARGET_APPROVAL_POLICY_REF,
     approvalRef: `payout_target_approval.khala_serving_settlement.${suffix}`,
@@ -258,6 +263,7 @@ export const buildKhalaSettlementRecords = (
     reconciliationEvent,
     settlementReceipt,
     settlementReceiptRef,
+    targetApproval,
   }
 }
 

--- a/apps/openagents.com/workers/api/src/inference/pricing.ts
+++ b/apps/openagents.com/workers/api/src/inference/pricing.ts
@@ -493,6 +493,84 @@ export const priceRequest = (input: PriceInput): PriceResult => {
   }
 }
 
+// ----------------------------------------------------------------------------
+// Accepted-outcome pricing (Khala M3 / #6011, EPIC #6017)
+// ----------------------------------------------------------------------------
+//
+// `khala-code` is paid TWICE over: per-token (the metered charge above) AND per
+// ACCEPTED OUTCOME — a flat price the customer is charged (and the worker +
+// validator are settled against) when a verified, EXECUTED accepted outcome is
+// produced (a crossy-road build that actually passed the headless acceptance
+// suite). Per-token covers the compute; the accepted-outcome price covers the
+// VERIFIED RESULT — the thing the customer actually wanted. Pure config, like
+// every other number here; the settlement path derives the worker/validator
+// shares from it (`khala-accepted-outcome-settlement.ts`).
+//
+// Denominated in msat so it slots straight into the Bitcoin/Spark settlement
+// path (1 sat = 1000 msat). Kept deliberately TINY + treasury-bounded for the
+// guinea-pig test wave: a few sats per accepted outcome, well under the gate's
+// per-payout cap. Tune here; the catalog + settlement re-solve.
+export type AcceptedOutcomePrice = Readonly<{
+  // The model the accepted-outcome price applies to (canonical id).
+  model: string
+  // The flat price per accepted (verified, executed) outcome, in integer msat.
+  priceMsat: number
+  // The fraction of the accepted-outcome price that goes to the serving WORKER
+  // (the rest goes to the VALIDATOR). The validator earns a smaller, published
+  // share for the independent verification. Worker + validator shares sum to 1.
+  workerShare: number
+}>
+
+// The published accepted-outcome price for khala-code. 5 sats total (5_000 msat)
+// split 60/40 worker/validator: the worker that produced the accepted artifact
+// earns the larger share; the validator earns a real, published cut for the
+// independent headless verification that made the outcome trustworthy. Both
+// well under the owner gate's per-payout cap. TINY + treasury-bounded by design.
+export const KHALA_CODE_ACCEPTED_OUTCOME_PRICE: AcceptedOutcomePrice = {
+  model: KHALA_CODE_MODEL_ID,
+  priceMsat: 5_000,
+  workerShare: 0.6,
+}
+
+// The accepted-outcome price table, keyed by lowercased model id. Only models
+// with a verified accepted-outcome rubric have an entry; everything else has no
+// accepted-outcome price (per-token only).
+const ACCEPTED_OUTCOME_PRICE_INDEX: ReadonlyMap<string, AcceptedOutcomePrice> =
+  new Map([
+    [KHALA_CODE_MODEL_ID.toLowerCase(), KHALA_CODE_ACCEPTED_OUTCOME_PRICE],
+  ])
+
+// Resolve a model's accepted-outcome price (case-insensitive). Returns undefined
+// when the model has no accepted-outcome lane (per-token pricing only). PURE.
+export const lookupAcceptedOutcomePrice = (
+  model: string,
+): AcceptedOutcomePrice | undefined =>
+  ACCEPTED_OUTCOME_PRICE_INDEX.get(model.trim().toLowerCase())
+
+// The integer-msat worker + validator split of an accepted-outcome price. PURE +
+// deterministic: the worker share floors and the validator share takes the exact
+// remainder, so worker + validator sum EXACTLY to `priceMsat` (no dust lost or
+// minted). A non-positive price yields a zero split.
+export const acceptedOutcomeSettlementShares = (
+  price: AcceptedOutcomePrice,
+): Readonly<{ workerMsat: number; validatorMsat: number }> => {
+  const total =
+    Number.isFinite(price.priceMsat) && price.priceMsat > 0
+      ? Math.floor(price.priceMsat)
+      : 0
+  if (total <= 0) {
+    return { validatorMsat: 0, workerMsat: 0 }
+  }
+  const share =
+    Number.isFinite(price.workerShare) && price.workerShare > 0
+      ? Math.min(price.workerShare, 1)
+      : 0
+  const workerMsat = Math.floor(total * share)
+  // Validator takes the EXACT remainder so the split conserves the price.
+  const validatorMsat = total - workerMsat
+  return { validatorMsat, workerMsat }
+}
+
 // Convenience: published sell price $/Mtok for a model + dimension, for the
 // pricing table / public price page. Pure, derived from cost × (1 + margin).
 export const sellPricePerMtok = (


### PR DESCRIPTION
Part of EPIC #6017. Closes the M3 task in #6011: pay the serving worker + validator in Bitcoin automatically when a Khala `khala-code` outcome **verifies**, via the revenue-loop spine.

**DO NOT auto-merge — orchestrator reviews/merges.** No deploy, no real money moved.

## How a verified outcome drives RL-2 escrow→firm-up→Spark payout

The trigger is the EXECUTED acceptance verdict from `khala-code-verifier.ts` (the independent headless runner, worker ≠ verifier) backfilling a khala-code receipt to `verified:true`/`executed:true`. On the **first** such backfill, the verdict-callback route (`/v1/inference/acceptance-verdicts`) fires accepted-outcome settlement to the **serving worker** and the **validator**.

**Reuse — no fork of the money path.** New `khala-accepted-outcome-settlement.ts`:
- takes the **accepted-outcome price** (new in `pricing.ts`) and splits it worker/validator (`acceptedOutcomeSettlementShares`);
- turns the two shares into a two-party `ServingNodePayoutDecision` consumed by the existing `settleVerifiedServingPayout` engine — the **same** fail-closed gate stack (verified-gate, RL-3 asset boundary, owner real-settlement gate, per-payout cap, daily budget, registered destination), the **same** Spark dispatch core (`dispatchRealRunSettlementCore` + `makeSparkTreasuryPayoutAdapter` + `resolveSparkPayoutDestination`), and the **same** `realBitcoinMoved`-shaped receipt chain the Tassadar autostream already proved out.
- `KhalaSettlementRecords` now carries `targetApproval` so it is directly dispatchable through that core.

## Idempotency + fail-safe arming

- **At most once per accepted outcome, per party.** The settlement run ref is derived from the verification/receipt ref, so every per-party settlement receipt ref is deterministic; the dispatch is receipt-first and short-circuits. A re-verify or a redelivered callback never double-pays (the callback also only fires the sink on the FIRST `backfilled:true` of a verified+executed outcome).
- **Double-gated, inert by default.** No settlement sink is even built unless the `OPENAGENTS_KHALA_LOOP_ARMED` loop flag is armed; even then, every leg independently fail-closes on the owner real-settlement gate (`OPENAGENTS_REAL_SETTLEMENT_GATE`, default OFF) + caps + a registered Spark destination. With either OFF, **no sats move**. Tests mock the dispatch; **no real Bitcoin is dispatched in tests or by default.**
- Fail-soft: a settlement error never regresses the already-backfilled receipt.

## `settled:true` receipt surface

- The `openagents` block (`chat-completions-routes.ts`) carries `settled` (honest default `false` on the hot path — settlement is async) + `settlement_receipts`, alongside the existing `verified`/`scalar_reward`.
- The verdict-callback response surfaces `settled:true` + `settledParties` (`['serving_worker','validator']`) + `settlementReceiptRefs` once the worker + validator are paid.

## Accepted-outcome pricing

`khala-code` now has a flat **price per accepted outcome** (5 sats, split 60/40 worker/validator) **alongside** per-token pricing (`KHALA_CODE_ACCEPTED_OUTCOME_PRICE`, `lookupAcceptedOutcomePrice`, `acceptedOutcomeSettlementShares`). Tiny + treasury-bounded, well under the gate's per-payout cap.

## RL-1 / RL-3 confirmation

- **RL-1** referral accrual continues to fire off the metering receipt (`withReferralAccrual`, unchanged) — confirmed by existing passing tests.
- **RL-3** authorizes Khala `api_inference_gateway_resale` on our own `api_key` account (Khala is the ALLOWED case; subscription-seat resale stays forbidden), and the credit↔Bitcoin **asset boundary** holds (only Bitcoin revenue funds a withdrawable Bitcoin share). Asserted directly in the test.

## Tests

`bun test src/inference/` → **540 passing** (16 new); `typecheck` clean. Exact-route manifest unchanged (settlement rides the existing verdict-callback route — no new routes). New tests prove: a verified khala-code outcome settles worker+validator with dereferenceable receipts (mocked payout); `settled:true` + receipt refs surface; idempotent (second verify = no second payout); INERT by default (owner gate OFF = `gate_not_authorized`); unverified/un-executed/no-price = ineligible; accepted-outcome pricing splits + conserves; RL-3 authorization + asset boundary.

The guinea-pig Pylon's Spark address is read from the gitignored `.secrets/khala-test-payout.env` at the test layer only — never committed, never asserted on.

**Pre-existing red flagged (not introduced here):** `check:architecture` already fails on clean `origin/main` (`Worker throw new Error calls: 13/12` — an unrelated budget overage in `index.ts`, far from these changes). Verified by running the check in a clean `origin/main` worktree.

## NEEDS-OWNER go-live arming (real Bitcoin)

Real worker+validator payout requires BOTH, on the staging/preview Worker:
1. `OPENAGENTS_KHALA_LOOP_ARMED=armed` — builds the settlement sink.
2. `OPENAGENTS_REAL_SETTLEMENT_GATE` armed (`spark_treasury`, `runScopedStreaming`, the accepted-outcome run ref enrolled in `allowedRunRefs`, tiny per-payout + daily caps), **plus** the runner host + `ACCEPTANCE_VERDICT_CALLBACK_TOKEN` so verdicts can backfill, **plus** registered Spark targets for the worker + verifier (the guinea-pig Pylon's address from `.secrets/khala-test-payout.env`).

With either flag OFF the path is fully inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)