### PR TITLE
Khala M4: Pylon serving workers in the pool — fabric supply adapter (#6012)

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/harness.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/harness.ts
@@ -145,6 +145,22 @@ export const runAcceptanceJob = async (
   return { delivered, verdict }
 }
 
+// Typed delivery failure for the `fetch`-backed verdict poster. A non-2xx
+// callback response is an EXPECTED, retryable delivery fault (the consumer
+// retries the job), so it is a named error class rather than a generic
+// `throw new Error` — the same `*Error extends Error` discipline the rest of the
+// Worker uses. `runAcceptanceJob` catches any `postVerdict` rejection and maps it
+// to `delivered: false`, so the typed class does not change behavior; it only
+// makes the failure legible (status carried as a field, not parsed from a string).
+export class VerdictCallbackDeliveryError extends Error {
+  readonly status: number
+  constructor(status: number) {
+    super(`verdict_callback_failed: ${status}`)
+    this.name = 'VerdictCallbackDeliveryError'
+    this.status = status
+  }
+}
+
 // A `fetch`-backed `postVerdict` builder for the real hosts (Pylon / Cloud Run). It
 // POSTs the verdict to the gateway's callback URL with the bearer token. The token is
 // supplied out of band (the host's local secret), NEVER hard-coded. Rejects on a
@@ -167,7 +183,7 @@ export const makeFetchVerdictPoster = (
       method: 'POST',
     })
     if (!response.ok) {
-      throw new Error(`verdict_callback_failed: ${response.status}`)
+      throw new VerdictCallbackDeliveryError(response.status)
     }
   }
 }

--- a/apps/openagents.com/workers/api/src/inference/khala-loop-integration.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-loop-integration.test.ts
@@ -241,6 +241,7 @@ const baseConfig = (
     payoutGate?: KhalaLoopConfig['payoutGate']
     resaleRefs?: KhalaLoopConfig['resaleRefs']
     transport?: PylonServeTransport
+    admission?: KhalaLoopConfig['admission']
   }>,
 ): KhalaLoopConfig => ({
   arming: options.arming,
@@ -251,6 +252,28 @@ const baseConfig = (
   revenueAsset: 'bitcoin',
   settlementDeps: options.settlementDeps,
   transport: options.transport ?? fakePylonTransport(),
+  ...(options.admission === undefined ? {} : { admission: options.admission }),
+})
+
+// A fully-ready admission snapshot for the guinea-pig Pylon, plus the M4 admission
+// config the loop gates on. Tests degrade one field to prove the safe fall-back.
+const REQUIRED_SERVING_CAP = 'capability.serving.khala_mini.v1'
+const admittedSnapshot = () => ({
+  capabilityRefs: [REQUIRED_SERVING_CAP],
+  latestHeartbeatAt: '2026-06-22T17:59:30.000Z', // 30s before nowMs — fresh
+  latestHeartbeatStatus: 'ok',
+  pylonRef: GUINEA_PIG_NODE_REF,
+  servingLaneRefs: ['lane.nip90.serving.v1'],
+  sparkPayoutTargetRef: 'payout.spark.deadbeef',
+  status: 'active' as const,
+  walletReady: true,
+})
+const admissionConfig = (
+  snapshot: ReturnType<typeof admittedSnapshot> = admittedSnapshot(),
+): KhalaLoopConfig['admission'] => ({
+  nowMs: Date.parse('2026-06-22T18:00:00.000Z'),
+  requiredCapabilityRef: REQUIRED_SERVING_CAP,
+  snapshot,
 })
 
 describe('readKhalaLoopArming (flag, default OFF)', () => {
@@ -294,8 +317,8 @@ describe('runKhalaLoopOnce — verified-serve -> dry-run Spark payout (M3↔M4)'
     )
 
     // The serve + parity receipt still happen (M4 works); nothing settled.
-    expect(outcome.receipt.parityVerified).toBe(true)
-    expect(outcome.served.result.content).toContain('guinea-pig')
+    expect(outcome.receipt!.parityVerified).toBe(true)
+    expect(outcome.served!.result.content).toContain('guinea-pig')
     expect(outcome.forwardedToSettlement).toBe(false)
     expect(outcome.settlement).toBeNull()
     expect(dispatchCount.value).toBe(0)
@@ -320,7 +343,7 @@ describe('runKhalaLoopOnce — verified-serve -> dry-run Spark payout (M3↔M4)'
     )
 
     expect(outcome.forwardedToSettlement).toBe(true)
-    expect(outcome.decision.armed).toBe(true)
+    expect(outcome.decision!.armed).toBe(true)
     expect(outcome.settlement).not.toBeNull()
     const legs = outcome.settlement!.legs
     expect(legs).toHaveLength(1)
@@ -415,7 +438,7 @@ describe('runKhalaLoopOnce — verified-serve -> dry-run Spark payout (M3↔M4)'
       ),
     )
 
-    expect(outcome.decision.armed).toBe(false)
+    expect(outcome.decision!.armed).toBe(false)
     expect(outcome.forwardedToSettlement).toBe(false)
     expect(outcome.settlement).toBeNull()
     expect(dispatchCount.value).toBe(0)
@@ -473,6 +496,115 @@ describe('runKhalaLoopOnce — verified-serve -> dry-run Spark payout (M3↔M4)'
 
     expect(outcome.settlement!.legs[0]!.skipped).toBe('no_payout_destination')
     expect(outcome.settlement!.legs[0]!.settled).toBe(false)
+    expect(dispatchCount.value).toBe(0)
+  })
+
+  // --------------------------------------------------------------------------
+  // M4 ADMISSION GATE: route only to admitted Pylons; degrade safely otherwise.
+  // --------------------------------------------------------------------------
+
+  it('ADMITTED Pylon (capability + fresh heartbeat + wallet/payout ready): serves and settles', async () => {
+    const store = new MemoryLedgerStore()
+    const dispatchCount = { value: 0 }
+    const settlementDeps = makeSettlementDeps({
+      dispatchCount,
+      gate: armedRealSettlementGate(),
+      store,
+      targets: new Map([[GUINEA_PIG_NODE_REF, readGuineaPigSparkAddress()]]),
+    })
+
+    const outcome = await Effect.runPromise(
+      runKhalaLoopOnce(
+        baseConfig({
+          admission: admissionConfig(),
+          arming: { loopArmed: true },
+          settlementDeps,
+        }),
+        request,
+      ),
+    )
+
+    // Admission passed -> the Pylon was routed to, served, and settled.
+    expect(outcome.admission).not.toBeNull()
+    expect(outcome.admission!.admitted).toBe(true)
+    expect(outcome.admittedAndServed).toBe(true)
+    expect(outcome.receipt!.parityVerified).toBe(true)
+    expect(outcome.forwardedToSettlement).toBe(true)
+    expect(outcome.settlement!.legs[0]!.settled).toBe(true)
+  })
+
+  it('NON-ADMITTED Pylon (stale heartbeat): no routing, no serve, no settle (safe fall-back)', async () => {
+    const store = new MemoryLedgerStore()
+    const dispatchCount = { value: 0 }
+    const settlementDeps = makeSettlementDeps({
+      dispatchCount,
+      gate: armedRealSettlementGate(),
+      store,
+      targets: new Map([[GUINEA_PIG_NODE_REF, readGuineaPigSparkAddress()]]),
+    })
+
+    // The transport must NEVER be touched when admission refuses. A throwing
+    // transport proves the loop short-circuits BEFORE dispatching to the Pylon.
+    const throwingTransport: PylonServeTransport = () => {
+      throw new Error('transport must not be called for a non-admitted Pylon')
+    }
+
+    const outcome = await Effect.runPromise(
+      runKhalaLoopOnce(
+        baseConfig({
+          // Stale heartbeat (5 min old vs the 90s default TTL) => not admitted.
+          admission: admissionConfig({
+            ...admittedSnapshot(),
+            latestHeartbeatAt: '2026-06-22T17:55:00.000Z',
+          }),
+          arming: { loopArmed: true },
+          settlementDeps,
+          transport: throwingTransport,
+        }),
+        request,
+      ),
+    )
+
+    expect(outcome.admission!.admitted).toBe(false)
+    expect(outcome.admittedAndServed).toBe(false)
+    expect(outcome.served).toBeNull()
+    expect(outcome.receipt).toBeNull()
+    expect(outcome.decision).toBeNull()
+    expect(outcome.settlement).toBeNull()
+    expect(outcome.forwardedToSettlement).toBe(false)
+    // Nothing was dispatched or recorded — the request falls back to cloud.
+    expect(dispatchCount.value).toBe(0)
+    expect(store.receipts.size).toBe(0)
+  })
+
+  it('NON-ADMITTED Pylon (missing capability): refused before any serve, even with the loop armed', async () => {
+    const store = new MemoryLedgerStore()
+    const dispatchCount = { value: 0 }
+    const settlementDeps = makeSettlementDeps({
+      dispatchCount,
+      gate: armedRealSettlementGate(),
+      store,
+      targets: new Map([[GUINEA_PIG_NODE_REF, readGuineaPigSparkAddress()]]),
+    })
+
+    const outcome = await Effect.runPromise(
+      runKhalaLoopOnce(
+        baseConfig({
+          admission: admissionConfig({
+            ...admittedSnapshot(),
+            capabilityRefs: ['capability.unrelated.v1'],
+          }),
+          arming: { loopArmed: true },
+          settlementDeps,
+        }),
+        request,
+      ),
+    )
+
+    expect(outcome.admittedAndServed).toBe(false)
+    expect(outcome.admission!.blockerRefs).toContain(
+      'blocker.pylon_admission.capability_not_advertised',
+    )
     expect(dispatchCount.value).toBe(0)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/khala-loop-integration.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-loop-integration.ts
@@ -80,6 +80,11 @@ import {
 } from './serving-node-payout'
 import { type InferenceResaleRefs } from '../inference-resale-authorization'
 import { type MdkPayoutModeGateProjection } from '../mdk-payout-mode-gate'
+import {
+  type PylonAdmissionDecision,
+  type PylonServingSnapshot,
+  decidePylonAdmission,
+} from './khala-pylon-admission'
 
 // ----------------------------------------------------------------------------
 // (1) Pluggable Pylon transport — the seam a real Pylon drops into
@@ -254,18 +259,32 @@ export const makeKhalaLoopSettlementSink = (
 export type KhalaLoopRevenueAsset = ServingRevenueAsset
 
 export type KhalaLoopOutcome = Readonly<{
-  // The parity-verified serving receipt the fabric dispatch produced.
-  receipt: ServingReceipt
-  // The full served completion result (content + receipt-first usage).
-  served: NetworkServedResult
-  // The computed (possibly unarmed) per-stage payout decision.
-  decision: ServingNodePayoutDecision
+  // The M4 Pylon admission decision (capability + heartbeat + wallet/payout
+  // readiness), when an admission snapshot was supplied. null when the caller did
+  // not gate on admission (e.g. the local/fake test path). When present and NOT
+  // admitted, the loop refused to route to the Pylon: `served`/`receipt`/
+  // `decision` are null and `admittedAndServed` is false (safe fall-back to the
+  // existing cloud adapters happens at the caller).
+  admission: PylonAdmissionDecision | null
+  // Whether the Pylon was admitted AND actually served. False when admission
+  // refused (no Pylon routing) — the honest "fell back to cloud" signal.
+  admittedAndServed: boolean
+  // The parity-verified serving receipt the fabric dispatch produced. null when
+  // admission refused (no serve was attempted).
+  receipt: ServingReceipt | null
+  // The full served completion result (content + receipt-first usage). null when
+  // admission refused.
+  served: NetworkServedResult | null
+  // The computed (possibly unarmed) per-stage payout decision. null when
+  // admission refused (nothing to settle).
+  decision: ServingNodePayoutDecision | null
   // The settlement outcome from the M3 sink. Present only when the loop flag is
   // armed AND the decision was armed; otherwise null (the loop short-circuited
   // before forwarding to M3). A null outcome with an unarmed decision is the
   // honest inert default.
   settlement: KhalaSettlementOutcome | null
-  // Whether the loop forwarded to M3 at all (loop flag armed AND decision armed).
+  // Whether the loop forwarded to M3 at all (admitted + served + loop flag armed
+  // AND decision armed).
   forwardedToSettlement: boolean
 }>
 
@@ -291,6 +310,21 @@ export type KhalaLoopConfig = Readonly<{
   // RL-3 resale-authorization refs for the api_inference_gateway_resale lane.
   // Required for the decision to ARM; omitted in the honest inert default.
   resaleRefs?: Partial<InferenceResaleRefs> | undefined
+  // M4 ADMISSION GATE (the issue's "capability/registration" task). When present,
+  // the loop checks the candidate Pylon is ADMITTED (advertises the required
+  // capability + has a fresh healthy heartbeat + is wallet/payout ready) BEFORE
+  // dispatching to its transport. A non-admitted Pylon is NOT routed to: the loop
+  // short-circuits with `admittedAndServed: false` and the caller falls back to
+  // the existing cloud adapters — never a serve/pay against an unready node. When
+  // omitted (the local/fake test path), no admission gate runs (admission: null).
+  admission?:
+    | Readonly<{
+        snapshot: PylonServingSnapshot
+        requiredCapabilityRef: string
+        nowMs: number
+        heartbeatTtlMs?: number | undefined
+      }>
+    | undefined
 }>
 
 // Run the loop ONCE for a single inference request: serve via the M4 fabric
@@ -311,6 +345,41 @@ export const runKhalaLoopOnce = (
   request: InferenceRequest,
 ): Effect.Effect<KhalaLoopOutcome, unknown> =>
   Effect.gen(function* () {
+    // M4 ADMISSION GATE (capability + heartbeat + wallet/payout readiness). When
+    // an admission snapshot is supplied, decide whether the candidate Pylon is
+    // admitted BEFORE touching the transport. A non-admitted Pylon is NOT routed
+    // to: short-circuit with no serve, no receipt, no decision, no settlement —
+    // the caller falls back to the existing cloud adapters. PURE + fail-closed.
+    const admission =
+      config.admission === undefined
+        ? null
+        : decidePylonAdmission({
+            nowMs: config.admission.nowMs,
+            requiredCapabilityRef: config.admission.requiredCapabilityRef,
+            snapshot: config.admission.snapshot,
+            ...(config.admission.heartbeatTtlMs === undefined
+              ? {}
+              : { heartbeatTtlMs: config.admission.heartbeatTtlMs }),
+          })
+
+    if (admission !== null && !admission.admitted) {
+      yield* Effect.logInfo(
+        workerLogEntry('inference.khala_loop.pylon_not_admitted', {
+          blockerCount: admission.blockerRefs.length,
+          pylonRef: admission.pylonRef,
+        }),
+      )
+      return {
+        admission,
+        admittedAndServed: false,
+        decision: null,
+        forwardedToSettlement: false,
+        receipt: null,
+        served: null,
+        settlement: null,
+      }
+    }
+
     // M4: serve through the parity-gated fabric dispatch. We need the RECEIPT
     // (not just the completion), so we call the dispatch directly rather than
     // through the InferenceProviderAdapter (which surfaces only the result).
@@ -346,6 +415,8 @@ export const runKhalaLoopOnce = (
     const forwardedToSettlement = config.arming.loopArmed && decision.armed
     if (!forwardedToSettlement) {
       return {
+        admission,
+        admittedAndServed: true,
         decision,
         forwardedToSettlement: false,
         receipt,
@@ -378,6 +449,8 @@ export const runKhalaLoopOnce = (
     })
 
     return {
+      admission,
+      admittedAndServed: true,
       decision,
       forwardedToSettlement: true,
       receipt,

--- a/apps/openagents.com/workers/api/src/inference/khala-pylon-admission.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-pylon-admission.test.ts
@@ -1,0 +1,189 @@
+// Khala M4 — Pylon serving ADMISSION gate tests (EPIC #6017, #6012).
+//
+// Proves the supply-side admission decision: a Pylon is admitted to serve a Khala
+// request ONLY when it advertises the required capability + a serving lane, has a
+// fresh healthy heartbeat, and is wallet/payout ready. Every gate fails CLOSED
+// (refuse + neutral blocker ref), so a missing capability / stale heartbeat /
+// unready wallet degrades safely (no routing) rather than serving against an
+// unready node. PURE: the freshness clock is injected, no Date.now().
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_HEARTBEAT_TTL_MS,
+  PYLON_ADMISSION_CAPABILITY_MISSING_REF,
+  PYLON_ADMISSION_HEARTBEAT_STALE_REF,
+  PYLON_ADMISSION_HEARTBEAT_UNHEALTHY_REF,
+  PYLON_ADMISSION_NOT_ACTIVE_REF,
+  PYLON_ADMISSION_NO_HEARTBEAT_REF,
+  PYLON_ADMISSION_NO_PAYOUT_TARGET_REF,
+  PYLON_ADMISSION_NO_SERVING_LANE_REF,
+  PYLON_ADMISSION_POLICY_REF,
+  PYLON_ADMISSION_WALLET_NOT_READY_REF,
+  type PylonServingSnapshot,
+  decidePylonAdmission,
+} from './khala-pylon-admission'
+
+const REQUIRED_CAP = 'capability.serving.khala_mini.v1'
+const NOW_MS = Date.parse('2026-06-22T18:00:00.000Z')
+const FRESH_HEARTBEAT = '2026-06-22T17:59:30.000Z' // 30s ago — fresh
+const STALE_HEARTBEAT = '2026-06-22T17:55:00.000Z' // 5 min ago — stale
+
+// A fully-ready, admissible serving snapshot. Individual tests degrade one field.
+const readySnapshot = (
+  overrides: Partial<PylonServingSnapshot> = {},
+): PylonServingSnapshot => ({
+  capabilityRefs: [REQUIRED_CAP, 'capability.other.v1'],
+  latestHeartbeatAt: FRESH_HEARTBEAT,
+  latestHeartbeatStatus: 'ok',
+  pylonRef: 'pylon.khala.guinea_pig',
+  servingLaneRefs: ['lane.nip90.serving.v1'],
+  sparkPayoutTargetRef: 'payout.spark.deadbeef',
+  status: 'active',
+  walletReady: true,
+  ...overrides,
+})
+
+const decide = (snapshot: PylonServingSnapshot) =>
+  decidePylonAdmission({
+    nowMs: NOW_MS,
+    requiredCapabilityRef: REQUIRED_CAP,
+    snapshot,
+  })
+
+describe('decidePylonAdmission — Khala M4 supply-side admission gate', () => {
+  it('ADMITS a fully-ready Pylon (active + capability + lane + fresh heartbeat + wallet/payout ready)', () => {
+    const decision = decide(readySnapshot())
+    expect(decision.admitted).toBe(true)
+    expect(decision.blockerRefs).toEqual([])
+    expect(decision.policyRefs).toContain(PYLON_ADMISSION_POLICY_REF)
+    expect(decision.pylonRef).toBe('pylon.khala.guinea_pig')
+    expect(decision.schema).toBe('openagents.khala_pylon_admission.v1')
+  })
+
+  it('REFUSES a non-active registration (blocked/retired)', () => {
+    for (const status of ['blocked', 'retired'] as const) {
+      const decision = decide(readySnapshot({ status }))
+      expect(decision.admitted).toBe(false)
+      expect(decision.blockerRefs).toContain(PYLON_ADMISSION_NOT_ACTIVE_REF)
+    }
+  })
+
+  it('REFUSES when the required capability is not advertised', () => {
+    const decision = decide(
+      readySnapshot({ capabilityRefs: ['capability.other.v1'] }),
+    )
+    expect(decision.admitted).toBe(false)
+    expect(decision.blockerRefs).toContain(
+      PYLON_ADMISSION_CAPABILITY_MISSING_REF,
+    )
+  })
+
+  it('REFUSES when no serving lane is advertised', () => {
+    const decision = decide(readySnapshot({ servingLaneRefs: [] }))
+    expect(decision.admitted).toBe(false)
+    expect(decision.blockerRefs).toContain(PYLON_ADMISSION_NO_SERVING_LANE_REF)
+  })
+
+  it('REFUSES when there is no heartbeat at all', () => {
+    const decision = decide(readySnapshot({ latestHeartbeatAt: null }))
+    expect(decision.admitted).toBe(false)
+    expect(decision.blockerRefs).toContain(PYLON_ADMISSION_NO_HEARTBEAT_REF)
+  })
+
+  it('REFUSES when the heartbeat is stale (older than the TTL)', () => {
+    const decision = decide(readySnapshot({ latestHeartbeatAt: STALE_HEARTBEAT }))
+    expect(decision.admitted).toBe(false)
+    expect(decision.blockerRefs).toContain(PYLON_ADMISSION_HEARTBEAT_STALE_REF)
+  })
+
+  it('REFUSES when the heartbeat status is unhealthy/unknown', () => {
+    for (const status of ['draining', 'degraded', null]) {
+      const decision = decide(
+        readySnapshot({ latestHeartbeatStatus: status }),
+      )
+      expect(decision.admitted).toBe(false)
+      expect(decision.blockerRefs).toContain(
+        PYLON_ADMISSION_HEARTBEAT_UNHEALTHY_REF,
+      )
+    }
+  })
+
+  it('REFUSES when the wallet is not receive-ready', () => {
+    const decision = decide(readySnapshot({ walletReady: false }))
+    expect(decision.admitted).toBe(false)
+    expect(decision.blockerRefs).toContain(
+      PYLON_ADMISSION_WALLET_NOT_READY_REF,
+    )
+  })
+
+  it('REFUSES when no Spark payout target is registered', () => {
+    for (const ref of [null, '   ']) {
+      const decision = decide(readySnapshot({ sparkPayoutTargetRef: ref }))
+      expect(decision.admitted).toBe(false)
+      expect(decision.blockerRefs).toContain(
+        PYLON_ADMISSION_NO_PAYOUT_TARGET_REF,
+      )
+    }
+  })
+
+  it('accumulates ALL blockers for a wholly-unready node (multiple gates fail at once)', () => {
+    const decision = decide({
+      capabilityRefs: [],
+      latestHeartbeatAt: null,
+      latestHeartbeatStatus: null,
+      pylonRef: 'pylon.unready',
+      servingLaneRefs: [],
+      sparkPayoutTargetRef: null,
+      status: 'retired',
+      walletReady: false,
+    })
+    expect(decision.admitted).toBe(false)
+    expect(decision.blockerRefs).toEqual(
+      expect.arrayContaining([
+        PYLON_ADMISSION_NOT_ACTIVE_REF,
+        PYLON_ADMISSION_CAPABILITY_MISSING_REF,
+        PYLON_ADMISSION_NO_SERVING_LANE_REF,
+        PYLON_ADMISSION_NO_HEARTBEAT_REF,
+        PYLON_ADMISSION_WALLET_NOT_READY_REF,
+        PYLON_ADMISSION_NO_PAYOUT_TARGET_REF,
+      ]),
+    )
+  })
+
+  it('treats a heartbeat exactly at the TTL boundary as fresh, and just past it as stale', () => {
+    const atBoundary = new Date(NOW_MS - DEFAULT_HEARTBEAT_TTL_MS).toISOString()
+    const pastBoundary = new Date(
+      NOW_MS - DEFAULT_HEARTBEAT_TTL_MS - 1,
+    ).toISOString()
+    expect(decide(readySnapshot({ latestHeartbeatAt: atBoundary })).admitted).toBe(
+      true,
+    )
+    expect(
+      decide(readySnapshot({ latestHeartbeatAt: pastBoundary })).admitted,
+    ).toBe(false)
+  })
+
+  it('does not treat a future-dated heartbeat (clock skew) as stale', () => {
+    const future = new Date(NOW_MS + 10_000).toISOString()
+    const decision = decide(readySnapshot({ latestHeartbeatAt: future }))
+    expect(decision.admitted).toBe(true)
+  })
+
+  it('honors a custom heartbeat TTL', () => {
+    // 5-min-old heartbeat is stale under the default but fresh under a 10-min TTL.
+    const tight = decidePylonAdmission({
+      nowMs: NOW_MS,
+      requiredCapabilityRef: REQUIRED_CAP,
+      snapshot: readySnapshot({ latestHeartbeatAt: STALE_HEARTBEAT }),
+    })
+    expect(tight.admitted).toBe(false)
+    const loose = decidePylonAdmission({
+      heartbeatTtlMs: 600_000,
+      nowMs: NOW_MS,
+      requiredCapabilityRef: REQUIRED_CAP,
+      snapshot: readySnapshot({ latestHeartbeatAt: STALE_HEARTBEAT }),
+    })
+    expect(loose.admitted).toBe(true)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-pylon-admission.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-pylon-admission.ts
@@ -1,0 +1,217 @@
+// Khala M4 — Pylon serving ADMISSION gate (EPIC #6017, #6012; Workstream C).
+//
+// THE M4 SUPPLY-SIDE GAP this module fills. The serving-fabric dispatch
+// (`psionic-fabric-serve.ts`), the per-stage payout decision
+// (`serving-node-payout.ts`), and the end-to-end serve->parity->settle loop
+// (`khala-loop-integration.ts`) all already exist and are tested. What was
+// MISSING is the issue's "Capability/registration" task:
+//
+//   "route to Pylons advertising the right capability + wallet/assignment
+//    readiness (NIP-89 refs + heartbeat)."
+//
+// Nothing in the inference path consumed the live Pylon registration/heartbeat
+// surface (`pylon-api.ts`) to decide whether a target Pylon is actually ADMITTED
+// to serve a Khala request before dispatching to it. This module is that gate: a
+// PURE, fail-closed admission decision over a public-safe projection of a Pylon's
+// registration record. The loop consults it FIRST; a non-admitted Pylon is never
+// routed to, so a missing capability / stale heartbeat / unready wallet degrades
+// SAFELY (the request falls back to the existing cloud adapters) and never serves
+// or pays against an unready node.
+//
+// BOUNDARIES. This module holds NO money authority and never reaches into Psionic
+// execution. It is PURE: it consumes a projection + the required capability + a
+// reference clock and returns a typed decision. It never reads D1, never calls a
+// transport, never throws, never logs. The actual registration record + Spark
+// payout-target readiness are resolved upstream (`pylon-api.ts`) and projected
+// into this gate's input; the gate only decides admit/refuse from that snapshot.
+//
+// PUBLIC-SAFE. The input carries only attribution refs (node ref, capability
+// refs, NIP-90 lane refs, the redacted `payout.spark.<digest>` ref) and boolean
+// readiness — never a raw `spark1…` address, invoice, preimage, or pubkey-bound
+// payment material. The blocker refs are neutral, stable strings.
+
+// ----------------------------------------------------------------------------
+// Public-safe blocker reason refs (neutral; never payment material)
+// ----------------------------------------------------------------------------
+
+export const PYLON_ADMISSION_NOT_ACTIVE_REF =
+  'blocker.pylon_admission.registration_not_active'
+export const PYLON_ADMISSION_CAPABILITY_MISSING_REF =
+  'blocker.pylon_admission.capability_not_advertised'
+export const PYLON_ADMISSION_NO_HEARTBEAT_REF =
+  'blocker.pylon_admission.no_heartbeat'
+export const PYLON_ADMISSION_HEARTBEAT_UNHEALTHY_REF =
+  'blocker.pylon_admission.heartbeat_not_healthy'
+export const PYLON_ADMISSION_HEARTBEAT_STALE_REF =
+  'blocker.pylon_admission.heartbeat_stale'
+export const PYLON_ADMISSION_NO_SERVING_LANE_REF =
+  'blocker.pylon_admission.no_serving_lane_advert'
+export const PYLON_ADMISSION_WALLET_NOT_READY_REF =
+  'blocker.pylon_admission.wallet_not_ready'
+export const PYLON_ADMISSION_NO_PAYOUT_TARGET_REF =
+  'blocker.pylon_admission.no_spark_payout_target'
+
+// Public-safe policy ref stamped on every admission decision.
+export const PYLON_ADMISSION_POLICY_REF = 'policy.khala_pylon_admission.v1'
+
+// The default heartbeat freshness window (ms). A heartbeat older than this is
+// STALE — the node is not provably online right now, so it is not admitted to
+// take live serving work. Conservative default; tunable per call.
+export const DEFAULT_HEARTBEAT_TTL_MS = 90_000
+
+// The heartbeat statuses that count as a HEALTHY, serve-ready node. Anything else
+// (degraded / draining / blocked / unknown) is refused. Kept narrow + explicit so
+// a new status string fails closed (not admitted) until it is deliberately added.
+const HEALTHY_HEARTBEAT_STATUSES: ReadonlySet<string> = new Set([
+  'ok',
+  'healthy',
+  'active',
+  'ready',
+])
+
+// ----------------------------------------------------------------------------
+// The public-safe Pylon serving snapshot the gate consumes
+// ----------------------------------------------------------------------------
+
+// A minimal, public-safe projection of a Pylon's live registration + heartbeat +
+// payout readiness — exactly the fields the admission decision needs. Built
+// upstream from `PylonApiRegistrationRecord` + the Spark payout-target store
+// (`pylon-api.ts`); this gate never sees the raw record or any payment material.
+export type PylonServingSnapshot = Readonly<{
+  // Public-safe node id of the candidate serving Pylon (the would-be payout
+  // recipient). Attribution ref only, never wallet material.
+  pylonRef: string
+  // The registration status. Only `active` is admissible.
+  status: 'active' | 'blocked' | 'retired'
+  // The capability refs the node ADVERTISES (NIP-89 handler-information style).
+  // The required serving capability must be present for admission.
+  capabilityRefs: ReadonlyArray<string>
+  // The NIP-90 serving lane refs the node advertises (its serving offer). At
+  // least one must be present so the node is actually offering serving work.
+  servingLaneRefs: ReadonlyArray<string>
+  // ISO timestamp of the node's latest heartbeat, or null if it never sent one.
+  // null / stale (older than the TTL) => not provably online => refused.
+  latestHeartbeatAt: string | null
+  // The node's latest heartbeat status string (e.g. 'ok'). Must be a healthy,
+  // serve-ready status. null / unknown => refused (fails closed).
+  latestHeartbeatStatus: string | null
+  // Whether the node's wallet is receive-ready (published by the heartbeat,
+  // recomputed from the live payout-target store). Must be true to admit — an
+  // admitted serving node must be able to RECEIVE its Bitcoin payout.
+  walletReady: boolean
+  // The redacted `payout.spark.<digest>` ref when a Spark payout target is
+  // registered + ready, else null. A ready target is required so the eventual
+  // RL-2/RL-3 settlement has a registered destination (never the raw address).
+  sparkPayoutTargetRef: string | null
+}>
+
+// ----------------------------------------------------------------------------
+// The admission decision
+// ----------------------------------------------------------------------------
+
+export type PylonAdmissionInput = Readonly<{
+  // The candidate Pylon's public-safe serving snapshot.
+  snapshot: PylonServingSnapshot
+  // The capability ref the Khala request REQUIRES (e.g. the small-model serving
+  // capability for `openagents/khala-mini`). The node must advertise it.
+  requiredCapabilityRef: string
+  // The reference clock (ms since epoch) heartbeat freshness is measured against.
+  // Injected (the gate never reads the wall clock itself) so it stays PURE + the
+  // freshness check is deterministic in tests.
+  nowMs: number
+  // Heartbeat freshness window (ms). Defaults to DEFAULT_HEARTBEAT_TTL_MS.
+  heartbeatTtlMs?: number | undefined
+}>
+
+export type PylonAdmissionDecision = Readonly<{
+  schema: 'openagents.khala_pylon_admission.v1'
+  pylonRef: string
+  // Whether the Pylon is admitted to take a live Khala serving request. True ONLY
+  // when EVERY gate passes; any failure => false + the neutral blocker refs.
+  admitted: boolean
+  // Public-safe blocker refs (empty iff admitted). Neutral, stable strings.
+  blockerRefs: ReadonlyArray<string>
+  // Public-safe policy refs.
+  policyRefs: ReadonlyArray<string>
+}>
+
+// Parse an ISO timestamp to ms since epoch, or undefined if unparseable. Pure;
+// no exceptions (an invalid timestamp is treated as "no usable heartbeat").
+const isoToMs = (iso: string | null): number | undefined => {
+  if (iso === null) return undefined
+  const ms = Date.parse(iso)
+  return Number.isFinite(ms) ? ms : undefined
+}
+
+// Decide whether a candidate Pylon is admitted to serve a Khala request. PURE +
+// FAIL-CLOSED: runs every readiness gate and admits ONLY when all pass. The gates,
+// each contributing a neutral blocker ref on failure:
+//   1. registration is `active`;
+//   2. the required serving capability is advertised (NIP-89 refs);
+//   3. a serving lane is advertised (the node is actually offering serving work);
+//   4. a heartbeat exists, is a healthy status, and is FRESH within the TTL
+//      (the node is provably online right now);
+//   5. the wallet is receive-ready AND a Spark payout target is registered
+//      (the node can RECEIVE its eventual Bitcoin payout).
+// Never throws, never logs, never moves money.
+export const decidePylonAdmission = (
+  input: PylonAdmissionInput,
+): PylonAdmissionDecision => {
+  const { snapshot } = input
+  const ttl =
+    typeof input.heartbeatTtlMs === 'number' && input.heartbeatTtlMs > 0
+      ? input.heartbeatTtlMs
+      : DEFAULT_HEARTBEAT_TTL_MS
+
+  const blockerRefs: string[] = []
+
+  // GATE 1 — registration is active.
+  if (snapshot.status !== 'active') {
+    blockerRefs.push(PYLON_ADMISSION_NOT_ACTIVE_REF)
+  }
+
+  // GATE 2 — the required serving capability is advertised.
+  if (!snapshot.capabilityRefs.includes(input.requiredCapabilityRef)) {
+    blockerRefs.push(PYLON_ADMISSION_CAPABILITY_MISSING_REF)
+  }
+
+  // GATE 3 — a serving lane is advertised (the node is offering serving work).
+  if (snapshot.servingLaneRefs.length === 0) {
+    blockerRefs.push(PYLON_ADMISSION_NO_SERVING_LANE_REF)
+  }
+
+  // GATE 4 — a fresh, healthy heartbeat (provably online right now).
+  const heartbeatMs = isoToMs(snapshot.latestHeartbeatAt)
+  if (heartbeatMs === undefined) {
+    blockerRefs.push(PYLON_ADMISSION_NO_HEARTBEAT_REF)
+  } else {
+    const status = snapshot.latestHeartbeatStatus
+    if (status === null || !HEALTHY_HEARTBEAT_STATUSES.has(status)) {
+      blockerRefs.push(PYLON_ADMISSION_HEARTBEAT_UNHEALTHY_REF)
+    }
+    // Stale if older than the TTL. A future-dated heartbeat (clock skew) is NOT
+    // stale; only past-the-window staleness fails this gate.
+    if (input.nowMs - heartbeatMs > ttl) {
+      blockerRefs.push(PYLON_ADMISSION_HEARTBEAT_STALE_REF)
+    }
+  }
+
+  // GATE 5 — wallet/payout readiness (the node can receive its Bitcoin payout).
+  if (!snapshot.walletReady) {
+    blockerRefs.push(PYLON_ADMISSION_WALLET_NOT_READY_REF)
+  }
+  if (
+    snapshot.sparkPayoutTargetRef === null ||
+    snapshot.sparkPayoutTargetRef.trim() === ''
+  ) {
+    blockerRefs.push(PYLON_ADMISSION_NO_PAYOUT_TARGET_REF)
+  }
+
+  return {
+    admitted: blockerRefs.length === 0,
+    blockerRefs,
+    policyRefs: [PYLON_ADMISSION_POLICY_REF],
+    pylonRef: snapshot.pylonRef,
+    schema: 'openagents.khala_pylon_admission.v1',
+  }
+}


### PR DESCRIPTION
Part of EPIC #6017. **DO NOT auto-merge — orchestrator reviews/merges.**

## Assessment first (work was further along than the issue implies)

The serving-fabric supply lane (EPIC #5474/#5483/#5484) and the M3 settlement engine (#6011) **already implement most of M4's deliverable**:

- `openagents-network-adapter.ts` — the inert `InferenceProviderAdapter` seam + `ServingReceipt` / `NetworkFabricDispatch` (registering a configured adapter activates the `openagents-network` lane with no routing change; unregistered today so routing cleanly skips it).
- `psionic-fabric-serve.ts` — the concrete **ask-plan → execute → consume exact-parity receipt** dispatch for the **whole-small-model** lane (`/v1/chat/completions`-shaped), parity-gated (`exact_greedy_parity` + `parityVerified` — **no parity, no success**), fails closed on malformed/sharded/unverified, shard-WAN explicitly deferred.
- `serving-node-payout.ts` — the gated, owner-armed, RL-3 no-resale + asset-boundary, PayIn-shaped **per-stage Bitcoin payout decision** consuming the receipt.
- `khala-verified-work-settlement.ts` / `settleVerifiedServingPayout` — the M3 Spark settlement engine (parity, asset boundary, owner real-settlement gate, per-payout cap, daily budget, registered destination — all fail-closed).
- `khala-loop-integration.ts` / `runKhalaLoopOnce` — the **end-to-end serve → parity receipt → payout decision → M3 settlement** bridge, **inert by default** behind `OPENAGENTS_KHALA_LOOP_ARMED` (a second flag on top of the M3 owner gate), with a dry-run dispatch that records a dereferenceable receipt but performs no Spark send.

## What this PR builds — the genuine M4 gap

The one missing M4 task was the issue's **"capability/registration"**: route to Pylons advertising the right capability + wallet/assignment readiness (**NIP-89 refs + heartbeat**). Nothing in the inference path consumed the live Pylon registration/heartbeat surface (`pylon-api.ts`) to **admit** a node before serving.

**`khala-pylon-admission.ts`** — a PURE, fail-closed admission gate over a public-safe `PylonServingSnapshot` (status, advertised capability refs, NIP-90 serving lane refs, heartbeat freshness+status, `walletReady`, redacted `payout.spark.<digest>` ref). Gates, each contributing a neutral blocker ref:
1. registration `active`; 2. required serving capability advertised; 3. a serving lane advertised; 4. a **fresh, healthy heartbeat** within a TTL (injected clock — provably online now); 5. **wallet receive-ready AND a registered Spark payout target** (the node can receive its eventual Bitcoin payout).

**`runKhalaLoopOnce` now consults the gate FIRST** (the ask-plan→execute→parity-receipt→settle flow above). A **non-admitted Pylon is never routed to**: the loop short-circuits with no serve / no receipt / no decision / no settlement, the transport is never touched, and the caller falls back to the existing cloud adapters — never a serve or pay against an unready node. When no admission snapshot is supplied (local/fake test path), the gate is skipped (`admission: null`).

The gate holds **no money authority**, reaches into no Psionic execution, never throws/logs, and carries only attribution refs — never a raw `spark1…` / invoice / preimage / pubkey-bound material.

### Settlement reuses the M3 path (money path not forked)
The payout still flows through the existing `decideServingNodePayout` → `settleVerifiedServingPayout` (RL-2/RL-3) to the admitted Pylon's registered Lightning/Spark target. **No new money path, no new receipt shape**, RL-3 honored.

### Whole-small-model only; shard-WAN deferred
Maps to Psionic's `/v1/chat/completions` whole-small-model serve. Shard-WAN large-model serving is explicitly a later lane (the fabric dispatch typed-refuses multi-stage plans today).

## Fail-safe + flagged inert by default
No Pylon routing / no real serving / no payout unless armed: `OPENAGENTS_KHALA_LOOP_ARMED` (loop) **and** the M3 owner real-settlement gate (both default OFF). Missing capability / heartbeat / parity degrades safely (admission refusal → fall back to cloud; parity-unverified → typed non-retryable failure → routing overflow). Idempotent on the serving-run ref.

## check:architecture fix
Ratcheted the zero-debt **"Worker throw new Error" budget from 13 → 12** by converting the one raw `throw new Error` in `acceptance-runner/harness.ts` (verdict-callback non-2xx) to a typed **`VerdictCallbackDeliveryError extends Error`** — the same `*Error extends Error` pattern the codebase uses (`InferenceAdapterError`, `ComposedRunExecutionError`, …). Behavior identical: `runAcceptanceJob` already catches the rejection → `delivered: false`.

> **HONEST FLAG — check:architecture is NOT green after this fix, and was never green on clean `main`.** The issue's premise (only the throw ratchet at 13/12 is over) is outdated. Clean `origin/main` has **five other** pre-existing budget overages: `raw JSON.parse 2/0`, `raw time/id/random 4/0`, `raw Env 163/162`, `raw console 2/0`, `service/domain HTTP 2/0`, `Response surfaces 103/98` — introduced by recently-merged concurrent Khala lanes (MPP/Stripe-Directory discovery #6049/#6051, async acceptance-dispatch #6040). They live in files unrelated to the serving-pool path and owned by other lanes. Per the issue's "STOP and report instead of bumping the budget" instruction, I fixed the one throw ratchet I was asked to and **did not bump the other five**. **This change adds ZERO new debt** (verified: time/id/random stayed at the 4 baseline after rewording a comment that tripped the scanner).

## Tests
- `khala-pylon-admission.test.ts` — every admission gate (active/capability/lane/heartbeat-missing/stale/unhealthy/wallet/payout-target), multi-blocker accumulation, TTL boundary, clock-skew tolerance, custom TTL.
- `khala-loop-integration.test.ts` — **admitted Pylon → serves + settles** (mocked Psionic serve + mocked Spark payout); **non-admitted (stale heartbeat) → no routing, no serve, no settle, transport never touched, nothing recorded**; **non-admitted (missing capability) → refused before serve even with the loop armed**.
- Full `src/inference/` suite green (**556 passed**); `typecheck:api` green; the M3 parity/no-parity→no-pay and inert-by-default behaviors are covered by the existing (still-green) loop/fabric/payout tests.

Verification:
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/` → 50 files, 556 tests pass
- `bun run --cwd apps/openagents.com typecheck:api` → clean
- `bun run --cwd apps/openagents.com check:architecture` → throw budget now 12/12 (green); still exits red on the 5 unrelated pre-existing overages above (flagged, not bumped)
- No route changes → exact-route manifest test unaffected.

## NEEDS-OWNER go-live arming (nothing live in this PR)
1. `OPENAGENTS_KHALA_LOOP_ARMED=armed` on a staging/preview Worker.
2. M3 owner real-settlement gate enabled (per-payout cap + daily budget bounded; `spark_treasury` adapter).
3. The guinea-pig Pylon registered + admitted (capability advertised, fresh heartbeat, `walletReady`, registered Spark payout target) — its raw `spark1…` resolved at the wiring/test layer from gitignored `.secrets/khala-test-payout.env`, never committed.
4. Real Spark dispatch (`dispatchRealRunSettlementCore`) dropped in where the dry-run dispatch sits.

No Psionic-repo changes were required (the whole-small-model serve contract and exact-parity receipt shape already exist on the Psionic side and are consumed at the product layer here).