### PR TITLE
durable-stream Rank-2: Verse-world bounded delta-replay buffer (#6059)

### DIFF
--- a/apps/openagents-world/src/index.ts
+++ b/apps/openagents-world/src/index.ts
@@ -44,6 +44,7 @@ import {
   makeDiagnostic,
   makeDiagnosticFrame,
   makeDiagnosticResponse,
+  makeHeartbeatFrame,
   makeInitialSessionAttachment,
   makeReconnectPlan,
   makeSnapshotFrame,
@@ -54,10 +55,20 @@ import {
   serializeWorldFrame,
   socketUrlForRegion,
   stableWorldRef,
+  type ReconnectPlan,
   type RegionSocketSessionAttachment,
   type WorldBridgeQueueMessage,
   type WorldRuntimeConfig,
 } from "./protocol"
+import {
+  type DeltaReplayBufferRow,
+  type ReplayBufferConfig,
+  makeReplayBufferRow,
+  planReplayBufferReconnect,
+  regionDeltaReplayBufferMigrationStatements,
+  replayBufferConfigFromEnv,
+  replayBufferEvictionPlan,
+} from "./replay-buffer"
 import {
   approveSubscriptionPlan,
   entitiesFromRows,
@@ -81,6 +92,9 @@ export interface Env {
   readonly OPENAGENTS_WORLD_ACTIVITY_TIMELINE_LIMIT?: string
   readonly OPENAGENTS_WORLD_MODERATION_HARD_TOKENS_JSON?: string
   readonly OPENAGENTS_WORLD_MODERATION_SOFT_TOKENS_JSON?: string
+  readonly OPENAGENTS_WORLD_DELTA_REPLAY?: string
+  readonly OPENAGENTS_WORLD_DELTA_REPLAY_MAX_DELTAS?: string
+  readonly OPENAGENTS_WORLD_DELTA_REPLAY_MAX_BYTES?: string
 }
 
 type RegionSqlRow = Readonly<Record<string, unknown>>
@@ -664,9 +678,11 @@ const normalizeSubscriptionPolicyError = (error: unknown): WorldSubscriptionPoli
 export class RegionDurableObject extends DurableObject<Env> {
   private initialized: Promise<void>
   private hotState: WorldHotState | null = null
+  private readonly replayConfig: ReplayBufferConfig
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env)
+    this.replayConfig = replayBufferConfigFromEnv(env)
     this.initialized = ctx.blockConcurrencyWhile(async () => {
       this.migrateRegionStorage()
       this.restoreHibernatedSessions()
@@ -693,7 +709,12 @@ export class RegionDurableObject extends DurableObject<Env> {
     const [client, server] = Object.values(pair)
     const connectedAt = new Date().toISOString()
     const clock = this.readRegionClock(regionRef)
-    const reconnectPlan = makeReconnectPlan(regionRef, url.searchParams.get("cursor"), clock, connectedAt)
+    const reconnectPlan = this.resolveReconnectPlan(
+      regionRef,
+      url.searchParams.get("cursor"),
+      clock,
+      connectedAt,
+    )
     const snapshotRows = reconnectPlan.kind === "fresh_snapshot"
       ? await readSnapshotProjectionRows(this.env.WORLD_DB, regionRef)
       : []
@@ -789,6 +810,12 @@ export class RegionDurableObject extends DurableObject<Env> {
       this.writeRegionClock(result.state.regionRef, result.state.sequence, result.state.minReplaySeq, observedAt)
       this.persistExpiryRefs(result.state)
       await this.scheduleNextExpiryAlarm(result.state)
+      // Buffer only sequence-advancing deltas (accepted commands). Rejected
+      // commands emit a `diagnostic` delta that keeps the prior sequence and
+      // must NOT collide with the accepted payload already at that offset.
+      if (result.delta.kind !== "diagnostic") {
+        this.appendReplayBufferDelta(result.delta, result.state.sequence, observedAt)
+      }
       this.broadcastCommandDelta(result.delta, observedAt)
     } catch (error) {
       const diagnostic = makeDiagnostic({
@@ -897,6 +924,9 @@ export class RegionDurableObject extends DurableObject<Env> {
     this.writeRegionClock(plan.state.regionRef, plan.state.sequence, plan.state.minReplaySeq, now)
     this.persistExpiryRefs(plan.state)
     if (plan.delta !== null) {
+      // Expiry advances the sequence and emits a `delete` delta; buffer it so a
+      // reconnect across an expiry boundary still gets gap replay.
+      this.appendReplayBufferDelta(plan.delta, plan.state.sequence, now)
       const frame = serializeWorldFrame(expiryDeltaFrame(plan.delta))
       for (const webSocket of this.ctx.getWebSockets()) {
         webSocket.send(frame)
@@ -911,6 +941,9 @@ export class RegionDurableObject extends DurableObject<Env> {
 
   private migrateRegionStorage(): void {
     for (const statement of regionDurableObjectMigrationStatements) {
+      this.sql.exec(statement)
+    }
+    for (const statement of regionDeltaReplayBufferMigrationStatements) {
       this.sql.exec(statement)
     }
 
@@ -989,6 +1022,107 @@ export class RegionDurableObject extends DurableObject<Env> {
       lastSeenAt,
       JSON.stringify(attachment),
     )
+  }
+
+  /**
+   * Resolve the reconnect plan, preferring TRUE gap replay from the bounded
+   * delta-replay buffer when the cursor is within the buffered window. Falls
+   * back to the existing heartbeat / fresh-snapshot reconnect plan when the
+   * feature flag is off, the buffer is unavailable, or the cursor is older than
+   * the buffered window (evicted). Fail-safe by construction: any uncertainty
+   * degrades to today's snapshot behavior.
+   */
+  private resolveReconnectPlan(
+    regionRef: string,
+    reconnectCursor: string | null,
+    clock: { currentSeq: number; minReplaySeq: number },
+    connectedAt: string,
+  ): ReconnectPlan {
+    if (!this.replayConfig.enabled) {
+      return makeReconnectPlan(regionRef, reconnectCursor, clock, connectedAt)
+    }
+
+    const gap = planReplayBufferReconnect({
+      regionRef,
+      reconnectCursor,
+      currentSeq: clock.currentSeq,
+      bufferedRows: this.readReplayBufferRows(regionRef),
+      generatedAt: connectedAt,
+      makeHeartbeatFrame: (cursor, generatedAt) => makeHeartbeatFrame(regionRef, cursor, generatedAt),
+    })
+
+    if (gap.kind === "gap_replay") {
+      // TRUE gap replay: the exact buffered delta suffix, no snapshot.
+      return { kind: "resume", cursor: gap.cursor, frames: gap.frames }
+    }
+    if (gap.kind === "at_tail") {
+      return { kind: "resume", cursor: gap.cursor, frames: gap.frames }
+    }
+
+    // snapshot_fallback (evicted / empty / no cursor): defer to the existing
+    // reconnect planner so stale-cursor diagnostics + the fresh snapshot are
+    // produced exactly as before.
+    return makeReconnectPlan(regionRef, reconnectCursor, clock, connectedAt)
+  }
+
+  private readReplayBufferRows(regionRef: string): ReadonlyArray<DeltaReplayBufferRow> {
+    const rows = this.sql.exec<{
+      sequence: number
+      byte_len: number
+      delta_json: string
+      generated_at: string
+    }>(
+      "SELECT sequence, byte_len, delta_json, generated_at FROM region_delta_replay_buffer WHERE region_ref = ? ORDER BY sequence ASC",
+      regionRef,
+    ).toArray()
+    return rows.map(row => ({
+      regionRef,
+      sequence: Number(row.sequence),
+      byteLen: Number(row.byte_len),
+      deltaJson: row.delta_json,
+      generatedAt: row.generated_at,
+    }))
+  }
+
+  /**
+   * Append a broadcast delta into the bounded replay buffer and evict the oldest
+   * rows so it respects both the count cap and the byte cap. Bounded growth: the
+   * retained set is always a contiguous suffix ending at the live sequence.
+   */
+  private appendReplayBufferDelta(delta: WorldDelta, sequence: number, generatedAt: string): void {
+    if (!this.replayConfig.enabled) {
+      return
+    }
+    const regionRef = delta.regionRef
+    const row = makeReplayBufferRow({ regionRef, sequence, delta, generatedAt })
+    const existing = this.readReplayBufferRows(regionRef).filter(r => r.sequence !== row.sequence)
+    const plan = replayBufferEvictionPlan(existing, row, this.replayConfig)
+
+    this.sql.exec(
+      `INSERT INTO region_delta_replay_buffer (
+        region_ref,
+        sequence,
+        byte_len,
+        delta_json,
+        generated_at
+      ) VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(region_ref, sequence) DO UPDATE SET
+        byte_len = excluded.byte_len,
+        delta_json = excluded.delta_json,
+        generated_at = excluded.generated_at`,
+      regionRef,
+      row.sequence,
+      row.byteLen,
+      row.deltaJson,
+      row.generatedAt,
+    )
+    for (const evicted of plan.evictedSequences) {
+      this.sql.exec(
+        "DELETE FROM region_delta_replay_buffer WHERE region_ref = ? AND sequence = ?",
+        regionRef,
+        evicted,
+      )
+    }
   }
 
   private readRegionClock(regionRef: string): { currentSeq: number; minReplaySeq: number } {

--- a/apps/openagents-world/src/replay-buffer.test.ts
+++ b/apps/openagents-world/src/replay-buffer.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  WORLD_DELTA_SCHEMA_VERSION,
+  decodeWorldDelta,
+  type WorldDelta,
+} from "@openagentsinc/world-contract"
+
+import { cursorForSequence, makeHeartbeatFrame } from "./protocol"
+import {
+  type DeltaReplayBufferRow,
+  type ReplayBufferConfig,
+  makeReplayBufferRow,
+  planGapReplay,
+  planReplayBufferReconnect,
+  replayBufferConfigFromEnv,
+  replayBufferEvictionPlan,
+} from "./replay-buffer"
+
+const REGION = "region.run.1"
+const AT = "2026-06-22T00:00:00.000Z"
+
+/** A real `update` delta carrying one avatar row at the given sequence. */
+const deltaAtSequence = (sequence: number): WorldDelta =>
+  decodeWorldDelta({
+    schemaVersion: WORLD_DELTA_SCHEMA_VERSION,
+    deltaRef: `delta.world.command.seq.${sequence}`,
+    kind: "update",
+    regionRef: REGION,
+    cursor: cursorForSequence(REGION, sequence),
+    generatedAt: AT,
+    rows: [
+      {
+        kind: "agent_avatar",
+        avatarRef: `avatar.seq.${sequence}`,
+        characterId: "char.alpha",
+        regionRef: REGION,
+        label: `Avatar ${sequence}`,
+        avatarKind: "human",
+        updatedAt: AT,
+        safety: {
+          publicProjectionAllowed: true,
+          sourceRefs: ["source.public.test"],
+          blockerRefs: [],
+          caveatRefs: [],
+        },
+      },
+    ],
+  })
+
+const rowAtSequence = (sequence: number): DeltaReplayBufferRow =>
+  makeReplayBufferRow({ regionRef: REGION, sequence, delta: deltaAtSequence(sequence), generatedAt: AT })
+
+/** Build a contiguous buffer covering `[from, to]` ascending. */
+const bufferRange = (from: number, to: number): Array<DeltaReplayBufferRow> => {
+  const rows: Array<DeltaReplayBufferRow> = []
+  for (let seq = from; seq <= to; seq += 1) rows.push(rowAtSequence(seq))
+  return rows
+}
+
+describe("replay-buffer config", () => {
+  test("defaults to enabled with the 256-delta / 1 MiB caps", () => {
+    const config = replayBufferConfigFromEnv({})
+    expect(config.enabled).toBe(true)
+    expect(config.maxDeltas).toBe(256)
+    expect(config.maxBytes).toBe(1024 * 1024)
+  })
+
+  test("flag is fail-safe: off/false/0/disabled all disable replay", () => {
+    for (const flag of ["off", "false", "0", "disabled", "no"]) {
+      expect(replayBufferConfigFromEnv({ OPENAGENTS_WORLD_DELTA_REPLAY: flag }).enabled).toBe(false)
+    }
+    expect(replayBufferConfigFromEnv({ OPENAGENTS_WORLD_DELTA_REPLAY: "on" }).enabled).toBe(true)
+  })
+
+  test("clamps cap overrides into a bounded range", () => {
+    const config = replayBufferConfigFromEnv({
+      OPENAGENTS_WORLD_DELTA_REPLAY_MAX_DELTAS: "10",
+      OPENAGENTS_WORLD_DELTA_REPLAY_MAX_BYTES: "2048",
+    })
+    expect(config.maxDeltas).toBe(10)
+    expect(config.maxBytes).toBe(2048)
+    // Garbage/negative falls back to the default, never unbounded.
+    expect(replayBufferConfigFromEnv({ OPENAGENTS_WORLD_DELTA_REPLAY_MAX_DELTAS: "-5" }).maxDeltas).toBe(256)
+  })
+})
+
+describe("planGapReplay (offset-resumption oracle)", () => {
+  // Oracle: a read from a stored offset returns the EXACT suffix after it.
+  test("within-window cursor yields the exact delta suffix (cursorSeq, currentSeq]", () => {
+    const decision = planGapReplay({
+      cursorSeq: 2,
+      currentSeq: 5,
+      bufferedSequences: [1, 2, 3, 4, 5],
+    })
+    expect(decision.kind).toBe("within_window")
+    if (decision.kind !== "within_window") throw new Error("expected within_window")
+    expect(decision.replaySequences).toEqual([3, 4, 5])
+  })
+
+  test("cursor at the tail replays nothing (heartbeat-only)", () => {
+    const decision = planGapReplay({ cursorSeq: 5, currentSeq: 5, bufferedSequences: [3, 4, 5] })
+    expect(decision.kind).toBe("at_tail")
+  })
+
+  test("cursor older than the earliest buffered sequence falls back (evicted)", () => {
+    const decision = planGapReplay({ cursorSeq: 1, currentSeq: 9, bufferedSequences: [5, 6, 7, 8, 9] })
+    expect(decision.kind).toBe("out_of_window")
+    if (decision.kind !== "out_of_window") throw new Error("expected out_of_window")
+    expect(decision.reason).toBe("evicted")
+  })
+
+  test("empty buffer / null cursor / future cursor all fall back", () => {
+    expect(planGapReplay({ cursorSeq: 2, currentSeq: 5, bufferedSequences: [] }).kind).toBe("out_of_window")
+    expect(planGapReplay({ cursorSeq: null, currentSeq: 5, bufferedSequences: [3, 4, 5] }).kind).toBe(
+      "out_of_window",
+    )
+    expect(planGapReplay({ cursorSeq: 9, currentSeq: 5, bufferedSequences: [3, 4, 5] }).kind).toBe(
+      "out_of_window",
+    )
+  })
+
+  test("a hole inside the window fails safe rather than replaying a non-contiguous suffix", () => {
+    const decision = planGapReplay({ cursorSeq: 2, currentSeq: 6, bufferedSequences: [3, 5, 6] })
+    expect(decision.kind).toBe("out_of_window")
+    if (decision.kind !== "out_of_window") throw new Error("expected out_of_window")
+    expect(decision.reason).toBe("missing_payload")
+  })
+
+  test("earliest == cursorSeq + 1 is exactly within window (boundary)", () => {
+    const decision = planGapReplay({ cursorSeq: 2, currentSeq: 5, bufferedSequences: [3, 4, 5] })
+    expect(decision.kind).toBe("within_window")
+  })
+})
+
+describe("replayBufferEvictionPlan (bounded growth)", () => {
+  test("count cap evicts the oldest rows so the retained set is a contiguous suffix", () => {
+    const config: ReplayBufferConfig = { enabled: true, maxDeltas: 3, maxBytes: 10 * 1024 * 1024 }
+    const existing = bufferRange(1, 3)
+    const plan = replayBufferEvictionPlan(existing, rowAtSequence(4), config)
+    expect(plan.retainedCount).toBe(3)
+    expect(plan.evictedSequences).toEqual([1])
+    expect(plan.minRetainedSequence).toBe(2)
+  })
+
+  test("byte cap evicts oldest rows independently of the count cap", () => {
+    const sample = rowAtSequence(1).byteLen
+    // Cap admits exactly two rows by bytes; count cap is generous.
+    const config: ReplayBufferConfig = { enabled: true, maxDeltas: 1000, maxBytes: sample * 2 + 1 }
+    const existing = bufferRange(1, 4)
+    const plan = replayBufferEvictionPlan(existing, rowAtSequence(5), config)
+    expect(plan.retainedCount).toBe(2)
+    expect(plan.retainedBytes).toBeLessThanOrEqual(config.maxBytes)
+    expect(plan.evictedSequences).toEqual([1, 2, 3])
+    expect(plan.minRetainedSequence).toBe(4)
+  })
+
+  test("the newest row is never evicted even when it alone exceeds the byte cap", () => {
+    const config: ReplayBufferConfig = { enabled: true, maxDeltas: 1000, maxBytes: 1 }
+    const plan = replayBufferEvictionPlan(bufferRange(1, 2), rowAtSequence(3), config)
+    expect(plan.retainedCount).toBe(1)
+    expect(plan.minRetainedSequence).toBe(3)
+  })
+
+  test("repeated appends with the count cap keep the buffer at exactly the cap", () => {
+    const config: ReplayBufferConfig = { enabled: true, maxDeltas: 4, maxBytes: 10 * 1024 * 1024 }
+    let buffer: Array<DeltaReplayBufferRow> = []
+    let lastMin = 0
+    for (let seq = 1; seq <= 20; seq += 1) {
+      const plan = replayBufferEvictionPlan(buffer, rowAtSequence(seq), config)
+      const evicted = new Set(plan.evictedSequences)
+      buffer = [...buffer, rowAtSequence(seq)].filter(row => !evicted.has(row.sequence))
+      lastMin = plan.minRetainedSequence
+      expect(buffer.length).toBeLessThanOrEqual(config.maxDeltas)
+    }
+    expect(buffer.length).toBe(4)
+    expect(buffer.map(r => r.sequence)).toEqual([17, 18, 19, 20])
+    expect(lastMin).toBe(17)
+  })
+})
+
+describe("planReplayBufferReconnect (DO-facing plan)", () => {
+  const make = (reconnectCursor: string | null, currentSeq: number, bufferedRows: Array<DeltaReplayBufferRow>) =>
+    planReplayBufferReconnect({
+      regionRef: REGION,
+      reconnectCursor,
+      currentSeq,
+      bufferedRows,
+      generatedAt: AT,
+      makeHeartbeatFrame: (cursor, generatedAt) => makeHeartbeatFrame(REGION, cursor, generatedAt),
+    })
+
+  test("within-window reconnect produces TRUE gap replay (delta frames, NOT a snapshot)", () => {
+    const plan = make(cursorForSequence(REGION, 2), 5, bufferRange(1, 5))
+    expect(plan.kind).toBe("gap_replay")
+    if (plan.kind !== "gap_replay") throw new Error("expected gap_replay")
+    // Exact suffix: sequences 3, 4, 5 — three delta frames, no snapshot frame.
+    expect(plan.replayedSequences).toEqual([3, 4, 5])
+    expect(plan.frames).toHaveLength(3)
+    expect(plan.frames.every(frame => frame.frameKind === "delta")).toBe(true)
+    expect(plan.frames.some(frame => frame.frameKind === "snapshot")).toBe(false)
+    // The replayed payloads are exactly the buffered deltas, in order.
+    expect(plan.frames.map(frame => String(frame.delta.cursor))).toEqual([
+      cursorForSequence(REGION, 3),
+      cursorForSequence(REGION, 4),
+      cursorForSequence(REGION, 5),
+    ])
+    // Resume cursor is the live tail.
+    expect(plan.cursor).toBe(cursorForSequence(REGION, 5))
+  })
+
+  test("tail reconnect is a heartbeat-only resume (no replay)", () => {
+    const plan = make(cursorForSequence(REGION, 5), 5, bufferRange(1, 5))
+    expect(plan.kind).toBe("at_tail")
+    if (plan.kind !== "at_tail") throw new Error("expected at_tail")
+    expect(plan.frames[0]?.delta.kind).toBe("heartbeat")
+  })
+
+  test("out-of-window reconnect signals snapshot fallback with a stale-cursor diagnostic", () => {
+    const plan = make(cursorForSequence(REGION, 1), 9, bufferRange(5, 9))
+    expect(plan.kind).toBe("snapshot_fallback")
+    if (plan.kind !== "snapshot_fallback") throw new Error("expected snapshot_fallback")
+    expect(plan.reason).toBe("evicted")
+    expect(plan.diagnostic?.tag).toBe("cursor")
+  })
+})

--- a/apps/openagents-world/src/replay-buffer.ts
+++ b/apps/openagents-world/src/replay-buffer.ts
@@ -1,0 +1,366 @@
+/**
+ * Bounded delta-replay buffer for the Verse-world Region Durable Object
+ * (durable-stream Rank-2 / EPIC #6056, issue #6059).
+ *
+ * The Region DO already persists the transport CLOCK (`current_seq` /
+ * `min_replay_seq`) but NOT the delta PAYLOADS, so an in-window reconnect could
+ * only send a heartbeat + a fresh snapshot — never gap-free replay. This module
+ * adds an additive, bounded, offset-addressed buffer of recent delta payloads,
+ * keyed on the existing `WorldSequence` (the integer behind every
+ * `cursor.<region>.<seq>` token).
+ *
+ * It ports the offset-log IDEA from `@openagentsinc/durable-stream` (read at a
+ * stored offset → the exact suffix; offsets monotonic + opaque) WITHOUT adopting
+ * its HTTP wire format. The Durable Streams offset-resumption / streaming-
+ * equivalence conformance cases are the test ORACLE for the replay semantics
+ * here, not a mandate to reshape `world-contract`.
+ *
+ * This module is pure and Cloudflare-free so it is unit-testable under Bun. The
+ * Region DO wires it to `ctx.storage.sql`.
+ */
+import type { WorldDelta } from "@openagentsinc/world-contract"
+
+import { cursorForSequence, makeDiagnostic, sequenceFromCursor, type WorldTransportFrame } from "./protocol"
+import type { WorldDiagnostic } from "@openagentsinc/world-contract"
+
+/** Default count cap: matches the existing `sequence - 256` replay window. */
+export const DEFAULT_REPLAY_BUFFER_MAX_DELTAS = 256
+
+/**
+ * Default byte cap (~1 MiB of serialized delta payloads per region). Bounds DO
+ * SQLite storage independently of the count cap so a burst of large deltas can
+ * never grow the buffer without limit.
+ */
+export const DEFAULT_REPLAY_BUFFER_MAX_BYTES = 1024 * 1024
+
+export type ReplayBufferConfig = Readonly<{
+  enabled: boolean
+  maxDeltas: number
+  maxBytes: number
+}>
+
+export const DEFAULT_REPLAY_BUFFER_CONFIG: ReplayBufferConfig = {
+  enabled: true,
+  maxDeltas: DEFAULT_REPLAY_BUFFER_MAX_DELTAS,
+  maxBytes: DEFAULT_REPLAY_BUFFER_MAX_BYTES,
+}
+
+/**
+ * A single buffered delta payload. `sequence` is the `WorldSequence` offset; it
+ * is the integer behind the delta's `cursor.<region>.<seq>` token and is
+ * monotonic + unique per region (the DO's single-threaded command loop advances
+ * it by one per accepted command).
+ */
+export type DeltaReplayBufferRow = Readonly<{
+  regionRef: string
+  sequence: number
+  byteLen: number
+  /** Serialized `WorldDelta` JSON (the exact payload the live broadcast sent). */
+  deltaJson: string
+  generatedAt: string
+}>
+
+export type ReplayBufferEntryInput = Readonly<{
+  regionRef: string
+  sequence: number
+  delta: WorldDelta
+  generatedAt: string
+}>
+
+/** SQLite migration for the per-region bounded delta-replay buffer. */
+export const regionDeltaReplayBufferMigrationStatements = [
+  `CREATE TABLE IF NOT EXISTS region_delta_replay_buffer (
+    region_ref TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    byte_len INTEGER NOT NULL,
+    delta_json TEXT NOT NULL,
+    generated_at TEXT NOT NULL,
+    PRIMARY KEY (region_ref, sequence)
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_region_delta_replay_buffer_region_seq
+    ON region_delta_replay_buffer(region_ref, sequence)`,
+] as const
+
+const clampPositiveInt = (value: number, fallback: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return fallback
+  }
+  const floored = Math.floor(value)
+  if (floored < 1) {
+    return fallback
+  }
+  return Math.min(floored, max)
+}
+
+/**
+ * Build the replay-buffer config from Cloudflare string env. Fail-safe: any
+ * value that disables the feature (`"0"`/`"false"`/`"off"`) degrades the DO to
+ * the existing heartbeat + fresh-snapshot reconnect behavior.
+ */
+export const replayBufferConfigFromEnv = (env: {
+  readonly OPENAGENTS_WORLD_DELTA_REPLAY?: string
+  readonly OPENAGENTS_WORLD_DELTA_REPLAY_MAX_DELTAS?: string
+  readonly OPENAGENTS_WORLD_DELTA_REPLAY_MAX_BYTES?: string
+}): ReplayBufferConfig => {
+  const flag = (env.OPENAGENTS_WORLD_DELTA_REPLAY ?? "").trim().toLowerCase()
+  const enabled = flag === "" ? true : !["0", "false", "off", "no", "disabled"].includes(flag)
+  return {
+    enabled,
+    maxDeltas: clampPositiveInt(
+      Number(env.OPENAGENTS_WORLD_DELTA_REPLAY_MAX_DELTAS),
+      DEFAULT_REPLAY_BUFFER_MAX_DELTAS,
+      4096,
+    ),
+    maxBytes: clampPositiveInt(
+      Number(env.OPENAGENTS_WORLD_DELTA_REPLAY_MAX_BYTES),
+      DEFAULT_REPLAY_BUFFER_MAX_BYTES,
+      32 * 1024 * 1024,
+    ),
+  }
+}
+
+/** Serialize a delta into a buffer row, measuring its byte length once. */
+export const makeReplayBufferRow = (input: ReplayBufferEntryInput): DeltaReplayBufferRow => {
+  const deltaJson = JSON.stringify(input.delta)
+  return {
+    regionRef: input.regionRef,
+    sequence: Math.max(0, Math.floor(input.sequence)),
+    byteLen: new TextEncoder().encode(deltaJson).length,
+    deltaJson,
+    generatedAt: input.generatedAt,
+  }
+}
+
+export type ReplayBufferEvictionPlan = Readonly<{
+  /** Sequences to delete (oldest first) so the buffer respects both caps. */
+  evictedSequences: ReadonlyArray<number>
+  /** The minimum retained sequence after eviction (== the live `min_replay_seq`). */
+  minRetainedSequence: number
+  retainedCount: number
+  retainedBytes: number
+}>
+
+/**
+ * Given the EXISTING buffered rows (ascending by sequence) plus the row being
+ * appended, decide which oldest rows to evict so the buffer stays within BOTH
+ * the count cap and the byte cap. Eviction is always from the oldest end, which
+ * keeps the retained set a contiguous suffix — exactly what offset-addressed
+ * replay needs (`min_replay_seq .. current_seq`).
+ *
+ * `existing` MUST be ascending and MUST NOT already contain `incoming.sequence`.
+ */
+export const replayBufferEvictionPlan = (
+  existing: ReadonlyArray<DeltaReplayBufferRow>,
+  incoming: DeltaReplayBufferRow,
+  config: ReplayBufferConfig,
+): ReplayBufferEvictionPlan => {
+  const ordered = [...existing, incoming].sort((a, b) => a.sequence - b.sequence)
+  const maxDeltas = Math.max(1, config.maxDeltas)
+  const maxBytes = Math.max(1, config.maxBytes)
+
+  // Drop from the oldest end until both caps are satisfied. The newest row is
+  // never evicted (so a single oversized delta still replays as the tail).
+  let startIndex = 0
+  let totalBytes = ordered.reduce((sum, row) => sum + row.byteLen, 0)
+  while (
+    startIndex < ordered.length - 1 &&
+    (ordered.length - startIndex > maxDeltas || totalBytes > maxBytes)
+  ) {
+    totalBytes -= ordered[startIndex]!.byteLen
+    startIndex += 1
+  }
+
+  const evictedSequences = ordered.slice(0, startIndex).map(row => row.sequence)
+  const retained = ordered.slice(startIndex)
+  return {
+    evictedSequences,
+    minRetainedSequence: retained[0]?.sequence ?? incoming.sequence,
+    retainedCount: retained.length,
+    retainedBytes: retained.reduce((sum, row) => sum + row.byteLen, 0),
+  }
+}
+
+export type GapReplayFallbackReason =
+  | "no_cursor"
+  | "evicted"
+  | "buffer_empty"
+  | "missing_payload"
+  | "future_cursor"
+
+export type GapReplayDecision =
+  | Readonly<{
+      kind: "at_tail"
+      /** Cursor is already at the live tail; nothing to replay. */
+      fromSequence: number
+    }>
+  | Readonly<{
+      kind: "within_window"
+      /** Exact suffix of sequences to replay (`cursorSeq + 1 .. currentSeq`). */
+      replaySequences: ReadonlyArray<number>
+    }>
+  | Readonly<{
+      kind: "out_of_window"
+      reason: GapReplayFallbackReason
+    }>
+
+/**
+ * Decide how to serve a reconnect from `cursorSeq`, using the SEQUENCES actually
+ * present in the buffer (`bufferedSequences`, ascending). This is the oracle-
+ * faithful core: a read from a stored offset returns the EXACT suffix after it,
+ * provided that suffix is still buffered; otherwise we fall back.
+ *
+ *  - cursor at the tail (`cursorSeq === currentSeq`) → `at_tail` (heartbeat-only)
+ *  - cursor strictly inside the buffered window AND every intervening sequence is
+ *    present → `within_window` with the exact suffix (true gap replay)
+ *  - cursor older than the earliest buffered sequence (evicted), buffer empty,
+ *    or a gap in the buffered payloads → `out_of_window` (snapshot fallback)
+ */
+export const planGapReplay = (input: {
+  readonly cursorSeq: number | null
+  readonly currentSeq: number
+  readonly bufferedSequences: ReadonlyArray<number>
+}): GapReplayDecision => {
+  const { cursorSeq, currentSeq } = input
+  if (cursorSeq === null) {
+    return { kind: "out_of_window", reason: "no_cursor" }
+  }
+  if (cursorSeq > currentSeq) {
+    return { kind: "out_of_window", reason: "future_cursor" }
+  }
+  if (cursorSeq === currentSeq) {
+    return { kind: "at_tail", fromSequence: cursorSeq }
+  }
+
+  const buffered = [...input.bufferedSequences].sort((a, b) => a - b)
+  if (buffered.length === 0) {
+    return { kind: "out_of_window", reason: "buffer_empty" }
+  }
+
+  const earliest = buffered[0]!
+  // The client needs sequences (cursorSeq, currentSeq]. The earliest buffered
+  // payload must cover the first sequence the client is missing.
+  if (earliest > cursorSeq + 1) {
+    return { kind: "out_of_window", reason: "evicted" }
+  }
+
+  const present = new Set(buffered)
+  const replaySequences: Array<number> = []
+  for (let seq = cursorSeq + 1; seq <= currentSeq; seq += 1) {
+    if (!present.has(seq)) {
+      // A hole inside the window (e.g. partial eviction) — fail safe to snapshot
+      // rather than apply a non-contiguous suffix.
+      return { kind: "out_of_window", reason: "missing_payload" }
+    }
+    replaySequences.push(seq)
+  }
+
+  return { kind: "within_window", replaySequences }
+}
+
+/** Decode a buffered row's JSON back into a live `delta` transport frame. */
+export const replayFrameFromBufferRow = (row: DeltaReplayBufferRow): WorldTransportFrame => ({
+  frameKind: "delta",
+  delta: JSON.parse(row.deltaJson) as WorldDelta,
+})
+
+export type GapReplayPlan =
+  | Readonly<{
+      kind: "gap_replay"
+      cursor: string
+      frames: ReadonlyArray<WorldTransportFrame>
+      replayedSequences: ReadonlyArray<number>
+    }>
+  | Readonly<{
+      kind: "at_tail"
+      cursor: string
+      frames: ReadonlyArray<WorldTransportFrame>
+    }>
+  | Readonly<{
+      kind: "snapshot_fallback"
+      cursor: string
+      reason: GapReplayFallbackReason
+      diagnostic?: WorldDiagnostic
+    }>
+
+/**
+ * Build the concrete reconnect plan for a cursor against the buffered rows.
+ * Pure: the DO supplies `bufferedRows` (ascending) read from SQLite and the
+ * heartbeat-frame factory; this returns either the exact gap-replay suffix, a
+ * tail no-op, or a fallback signal the DO turns into the existing snapshot path.
+ */
+export const planReplayBufferReconnect = (input: {
+  readonly regionRef: string
+  readonly reconnectCursor: string | null
+  readonly currentSeq: number
+  readonly bufferedRows: ReadonlyArray<DeltaReplayBufferRow>
+  readonly generatedAt: string
+  readonly makeHeartbeatFrame: (cursor: string, generatedAt: string) => WorldTransportFrame
+}): GapReplayPlan => {
+  const currentCursor = cursorForSequence(input.regionRef, input.currentSeq)
+  const cursorSeq =
+    input.reconnectCursor === null || input.reconnectCursor.length === 0
+      ? null
+      : sequenceFromCursor(input.reconnectCursor, input.regionRef)
+
+  const byteSeq = new Map(input.bufferedRows.map(row => [row.sequence, row]))
+  const decision = planGapReplay({
+    cursorSeq,
+    currentSeq: input.currentSeq,
+    bufferedSequences: input.bufferedRows.map(row => row.sequence),
+  })
+
+  if (decision.kind === "at_tail") {
+    return {
+      kind: "at_tail",
+      cursor: currentCursor,
+      frames: [input.makeHeartbeatFrame(currentCursor, input.generatedAt)],
+    }
+  }
+
+  if (decision.kind === "within_window") {
+    const frames: Array<WorldTransportFrame> = []
+    for (const seq of decision.replaySequences) {
+      const row = byteSeq.get(seq)
+      if (row === undefined) {
+        // Defensive: planGapReplay already guaranteed presence, but never apply
+        // a non-contiguous suffix — fall back to a snapshot instead.
+        return {
+          kind: "snapshot_fallback",
+          cursor: currentCursor,
+          reason: "missing_payload",
+          diagnostic: makeStaleReplayDiagnostic(input.reconnectCursor, input.generatedAt),
+        }
+      }
+      frames.push(replayFrameFromBufferRow(row))
+    }
+    return {
+      kind: "gap_replay",
+      cursor: currentCursor,
+      frames,
+      replayedSequences: decision.replaySequences,
+    }
+  }
+
+  // out_of_window: the DO maps this to the existing fresh-snapshot path.
+  return {
+    kind: "snapshot_fallback",
+    cursor: currentCursor,
+    reason: decision.reason,
+    ...(decision.reason === "no_cursor"
+      ? {}
+      : { diagnostic: makeStaleReplayDiagnostic(input.reconnectCursor, input.generatedAt) }),
+  }
+}
+
+const makeStaleReplayDiagnostic = (
+  reconnectCursor: string | null,
+  generatedAt: string,
+): WorldDiagnostic =>
+  makeDiagnostic({
+    tag: "cursor",
+    severity: "warn",
+    message:
+      "World reconnect cursor is older than the buffered delta-replay window; sending a fresh snapshot.",
+    observedAt: generatedAt,
+    sourceRefs: reconnectCursor === null ? [] : [reconnectCursor],
+  })

--- a/packages/world-client/src/index.test.ts
+++ b/packages/world-client/src/index.test.ts
@@ -513,4 +513,78 @@ describe("world-client", () => {
     expect(ack.status).toBe("applied")
     expect(String(readModel.intents["intent.focus.pylon.1"]?.targetRef)).toBe("pylon.alpha")
   })
+
+  // durable-stream Rank-2 (#6059): when the Region DO serves an in-window
+  // reconnect as TRUE gap replay, the connect-result carries the exact missing
+  // delta suffix (NOT a fresh snapshot). The client must resume from its cursor
+  // and apply every gap delta into the WorldReadModel in order.
+  test("resumes from its cursor and applies a gap-replay delta suffix into the read model (no re-snapshot)", async () => {
+    const avatarAt = (seq: number, label: string) =>
+      decodeWorldRow({
+        kind: "agent_avatar",
+        avatarRef: `avatar.gap.${seq}`,
+        characterId: `char.${seq}`,
+        regionRef,
+        label,
+        avatarKind: "human",
+        updatedAt: observedAt,
+        safety,
+      })
+
+    let resumeCursorSeen: string | undefined
+    const transport: WorldClientTransport = {
+      // First connect: a snapshot establishing the client at sequence 2.
+      // Reconnect from `cursor.region.run.1.2`: gap replay of sequences 3 and 4
+      // as plain delta payloads — the server never re-snapshots.
+      connect: (request) =>
+        Effect.sync(() => {
+          resumeCursorSeen = request.resumeCursor
+          if (request.resumeCursor === undefined) {
+            return {
+              regionRef,
+              socketUrl: "wss://world.test/regions/region.run.1/socket",
+              subscriptionPlan: plan(),
+              deltas: [
+                makeStubWorldDelta({
+                  regionRef,
+                  cursor: "cursor.region.run.1.2",
+                  generatedAt: observedAt,
+                  kind: "snapshot",
+                  rows: [avatarAt(2, "Avatar 2")],
+                }),
+              ],
+            }
+          }
+          return {
+            regionRef,
+            socketUrl: "wss://world.test/regions/region.run.1/socket",
+            subscriptionPlan: plan(),
+            deltas: [
+              rowDelta([avatarAt(3, "Avatar 3")], "cursor.region.run.1.3"),
+              rowDelta([avatarAt(4, "Avatar 4")], "cursor.region.run.1.4"),
+            ],
+          }
+        }),
+      command: () =>
+        Effect.fail(new WorldClientError({ phase: "command", reason: "unused", retryable: false, sourceRefs: ["test"] })),
+      disconnect: () => Effect.void,
+    }
+
+    const client = createWorldClient({ transport, initialRegionRef: regionRef, now: () => observedAt })
+    const connected = await Effect.runPromise(client.connect())
+    expect(connected.readModel.avatars["avatar.gap.2"]?.label).toBe("Avatar 2")
+    expect(String(connected.readModel.cursor)).toBe("cursor.region.run.1.2")
+
+    const reconnected = await Effect.runPromise(client.reconnect())
+
+    // The client resumed from the cursor it had applied through.
+    expect(resumeCursorSeen).toBe("cursor.region.run.1.2")
+    // Every gap delta landed; the pre-gap avatar was preserved (additive, not a
+    // replacing snapshot).
+    expect(reconnected.readModel.avatars["avatar.gap.2"]?.label).toBe("Avatar 2")
+    expect(reconnected.readModel.avatars["avatar.gap.3"]?.label).toBe("Avatar 3")
+    expect(reconnected.readModel.avatars["avatar.gap.4"]?.label).toBe("Avatar 4")
+    // The read model advanced to the live tail via the last applied delta.
+    expect(String(reconnected.readModel.cursor)).toBe("cursor.region.run.1.4")
+  })
 })


### PR DESCRIPTION
Closes the in-window reconnect correctness gap from EPIC #6056 §4 (Phase C / Rank-2). The Region Durable Object persisted only the transport **clock** (`current_seq` / `min_replay_seq`), not the delta **payloads**, so an in-window reconnect could only send a heartbeat + a fresh snapshot — never gap-free replay. This adds an additive, bounded, offset-addressed delta-replay buffer behind the existing WebSocket transport.

## Buffer design (keyed on `WorldSequence`, bounded)

- New `apps/openagents-world/src/replay-buffer.ts`: pure, Cloudflare-free, Bun-testable buffer logic. Offset = the existing `WorldSequence` (the integer behind every `cursor.<region>.<seq>` token), which the DO's single-threaded command loop advances monotonically by one per accepted command. Ports the offset-log **idea** from `@openagentsinc/durable-stream` (read at a stored offset → the exact suffix) **without** adopting its HTTP wire format.
- New `region_delta_replay_buffer` SQLite table in the Region DO. Every sequence-advancing delta (accepted commands **and** expiry `delete` deltas) is appended; rejected commands emit a `diagnostic` delta at the prior sequence and are deliberately **not** buffered (no offset collision).
- **Bounded growth, two independent caps:** count cap (`OPENAGENTS_WORLD_DELTA_REPLAY_MAX_DELTAS`, default **256** — matching the existing `sequence - 256` replay window) and byte cap (`OPENAGENTS_WORLD_DELTA_REPLAY_MAX_BYTES`, default **1 MiB**). Eviction is always from the oldest end, so the retained set stays a **contiguous suffix** ending at the live sequence — exactly what offset-addressed replay needs. The newest row is never evicted (a single oversized delta still replays as the tail).

## Within-window gap replay vs out-of-window snapshot fallback

`planReplayBufferReconnect` decides per reconnect cursor:
- **within window** (`cursorSeq < currentSeq`, earliest buffered ≤ `cursorSeq + 1`, no holes) → **TRUE gap replay**: the exact buffered delta suffix `(cursorSeq, currentSeq]` as plain `delta` frames, **no snapshot**.
- **at tail** (`cursorSeq == currentSeq`) → heartbeat-only resume.
- **out of window** (evicted / buffer empty / no cursor / non-contiguous hole / future cursor) → defers to the **existing** `makeReconnectPlan` fresh-snapshot path with its stale-cursor diagnostic. Fail-safe by construction.

## Flag

`OPENAGENTS_WORLD_DELTA_REPLAY` (default **on**). `off` / `false` / `0` / `disabled` / `no` degrade the DO to today's heartbeat + fresh-snapshot reconnect behavior. Cap overrides are clamped into a bounded range; garbage falls back to the default — never unbounded.

## `world-contract` is unchanged

No envelope, cursor, delta, sequence, WoC interest tier, moderation, command receipt, or sight-policy change. `world-client` **implementation** is also unchanged: its existing `applyDeltaToReadModel` / `applyDeltaToState` already mirror gap deltas into `WorldReadModel`, so a resumed gap suffix applies correctly with no re-snapshot.

## Conformance-oracle tests

The Durable Streams **offset-resumption / streaming-equivalence** cases are used as the replay-semantics oracle (read from a stored offset → the exact suffix):
- `apps/openagents-world/src/replay-buffer.test.ts` (16 tests): within-window → exact `(cursorSeq, currentSeq]` suffix; at-tail → no replay; out-of-window → fallback; **eviction holds both caps** (count + byte) keeping a contiguous suffix; a hole inside the window **fails safe** rather than replaying a non-contiguous suffix; flag fail-safe + cap clamping.
- `packages/world-client/src/index.test.ts` (+1 test): client **resumes from its cursor** and applies a multi-delta gap suffix into `WorldReadModel` in order, preserving pre-gap state (additive, not a replacing snapshot), advancing the cursor to the live tail.

## Verification

- `apps/openagents-world` suite: 71 pass / 0 fail. `packages/world-client`: 12 pass / 0 fail. `packages/world-contract`: 10 pass / 0 fail.
- Typecheck green: `typecheck:openagents-world`, `typecheck:world-client`, `typecheck:world-contract`.
- Not deployed.

Part of EPIC #6056. **DO NOT auto-merge — orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)