### PR TITLE
durable-stream Rank-1: resumable Khala inference (durable proxy, metering-once) (#6058)

### DIFF
--- a/apps/openagents.com/packages/sync-worker/src/index.ts
+++ b/apps/openagents.com/packages/sync-worker/src/index.ts
@@ -23,6 +23,11 @@ export type WorkerBindings = Readonly<{
   SYNC_ROOM: DurableObjectNamespace
   MDK_SIDECAR: DurableObjectNamespace
   MDK_TREASURY?: DurableObjectNamespace
+  // Durable-stream Rank-1 resumable inference (#6058). Optional SQLite-class DO
+  // namespace; one DO instance per request id holds that completion's durable
+  // offset log. Absent (or the INFERENCE_DURABLE_STREAM_ENABLED flag off) => the
+  // streaming path is today's non-durable pass-through (fail-safe).
+  INFERENCE_DURABLE_STREAM?: DurableObjectNamespace
   MARKET_RELAY_SERVICE?: Fetcher
   ARTIFACTS: R2Bucket
   RUNNER_EVENTS: Queue

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -348,7 +348,17 @@ const budgetChecks = [
     // `Response`/`Effect.Effect<Response>`/`Promise<Response>` like the sibling
     // route handlers already counted here. Ratchet back down when these MPP and
     // discovery handlers are extracted behind shared route mappers.
-    budget: 103,
+    // +2 (103 -> 105) on 2026-06-22 (#6058, EPIC #6056) for the durable-stream
+    // Rank-1 resumable-inference surfaces: the durable resume-read route
+    // (inference/durable-inference-read-routes.ts `routeDurableInferenceReadRequest`
+    // returning `Response | undefined`, the path-param resume surface the
+    // exact-route registry cannot match — reads stored bytes only, never meters)
+    // and the durable-stream DO class (index.ts `DurableInferenceStreamObject.fetch`
+    // returning `Promise<Response>`, the Cloudflare DO fetch contract). Both are
+    // flag-gated INERT by default. The DO `fetch` is a required Cloudflare runtime
+    // signature; ratchet back down when the read route is extracted behind a shared
+    // prefix-route mapper.
+    budget: 105,
     description:
       'Worker domain and route modules may not grow Response-returning surfaces while route mappers are extracted.',
     details: countByFile(

--- a/apps/openagents.com/workers/api/package.json
+++ b/apps/openagents.com/workers/api/package.json
@@ -35,6 +35,7 @@
     "@effect/sql-sqlite-do": "4.0.0-beta.70",
     "@liquid-js/qrcode-generator": "1.1.6",
     "@moneydevkit/api-contract": "0.1.36",
+    "@openagentsinc/durable-stream": "workspace:*",
     "@openagentsinc/mcp-contract": "workspace:*",
     "@openagentsinc/nip90": "workspace:*",
     "@openagentsinc/proof-replay": "workspace:*",

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -94,6 +94,15 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // `/v1/chat/completions` route is inert on the live Worker until the
   // inference build lands. Set "true"/"1"/"on" to enable.
   INFERENCE_GATEWAY_ENABLED?: string | undefined
+  // Durable-stream resumable inference feature flag (durable-stream Rank-1,
+  // #6058, EPIC #6056). Default OFF: a streaming completion is NOT persisted into
+  // a durable offset log, so the `/v1/chat/completions` stream behaves as today's
+  // pure pass-through (no resume on a client disconnect). Set "true"/"1"/"on" to
+  // tee the upstream token stream into the per-request durable stream (the DO
+  // binding `INFERENCE_DURABLE_STREAM` must also be wired) and expose the
+  // resumable read URL. Metering still settles EXACTLY ONCE on the real upstream
+  // EOF and NEVER on a resume/replay read.
+  INFERENCE_DURABLE_STREAM_ENABLED?: string | undefined
   // Async batch-job consumer feature flag (Khala, EPIC #6017 / #6028). Default
   // OFF: the queue handler does NOT route batch-job messages to the consumer
   // (`batch-job-consumer.ts executeBatchJob`) on the live Worker until the

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -1,5 +1,10 @@
 import { Container, getContainer } from '@cloudflare/containers'
 import {
+  type DurableObjectStateLike as DurableStreamObjectStateLike,
+  handleDurableStreamAlarm,
+  handleDurableStreamFetch,
+} from '@openagentsinc/durable-stream'
+import {
   type WorkerBindings,
   badRequest,
   cursorGap,
@@ -309,8 +314,10 @@ import {
 import { makeD1BatchJobStore } from './inference/batch-job-store'
 import {
   handleChatCompletions,
+  isInferenceDurableStreamEnabled,
   isInferenceGatewayEnabled,
 } from './inference/chat-completions-routes'
+import { routeDurableInferenceReadRequest } from './inference/durable-inference-read-routes'
 import {
   type DiscoverySurfacePath,
   renderDiscoverySurface,
@@ -10026,6 +10033,22 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
           // here once a runner host exists. Until then the seam is inert.
           queue: undefined,
         },
+        // DURABLE-STREAM RANK-1 (#6058, EPIC #6056). Flag-gated INERT by default:
+        // with INFERENCE_DURABLE_STREAM_ENABLED off the streaming path is today's
+        // pure pass-through (no persistence/resume). The producer factory is left
+        // undefined here so the LIVE Worker stays inert even with the flag on —
+        // the DO class (`DurableInferenceStreamObject`) + binding
+        // (`INFERENCE_DURABLE_STREAM`) ship deployable, but the per-token producer
+        // write into the DO is wired in a follow-up. Metering still settles
+        // EXACTLY ONCE on the real upstream EOF and NEVER on a replay (proven by
+        // the in-memory durable-proxy tests, which use the SAME StreamStore port
+        // the DO implements).
+        // NEEDS-OWNER: wire the DO-fetch-backed producer factory + the read-route
+        // dispatcher's `durableStream` to `env.INFERENCE_DURABLE_STREAM` here.
+        durableStream: undefined,
+        durableStreamEnabled: isInferenceDurableStreamEnabled(
+          env.INFERENCE_DURABLE_STREAM_ENABLED,
+        ),
         registry: inferenceProviderRegistry,
       })
     },
@@ -10355,6 +10378,22 @@ const routeRequest = makeWorkerRouteRequest({
       enabled: isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED),
       laneArming: resolveSupplyLaneArming(env),
     }),
+  // Durable inference resume read GET /v1/chat/completions/durable/{requestId}
+  // (durable-stream Rank-1, #6058). Reads stored bytes only — NEVER meters.
+  // Shares the gateway flag AND the durable-stream flag; with the producer
+  // factory left undefined (see the chat route above) this returns 404, so the
+  // surface is honestly inert until the DO producer is wired. Synchronous
+  // Response wrapped into the Effect dispatcher shape.
+  routeDurableInferenceReadRequest: (request, env) => {
+    const response = routeDurableInferenceReadRequest(request, {
+      durableStream: undefined,
+      enabled:
+        isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED) &&
+        isInferenceDurableStreamEnabled(env.INFERENCE_DURABLE_STREAM_ENABLED),
+      nowEpochMillis: currentEpochMillis,
+    })
+    return response === undefined ? undefined : Effect.succeed(response)
+  },
   routeMulletRequest: mulletRoutes.routeMulletRequest,
   routeOmniRequest: (request, env, ctx) =>
     omniRoutes.routeOmniRequest(request, env, ctx) ??
@@ -10552,6 +10591,34 @@ const syncScopeFromRequest = (request: Request, url: URL): string | undefined =>
   request.headers.get('x-openagents-sync-scope') ??
   url.searchParams.get('scope') ??
   undefined
+
+// Durable-stream Rank-1 resumable inference DO (#6058, EPIC #6056). One DO
+// instance per request id (`idFromName(requestId)`) holds that completion's
+// durable offset log in SQLite (the `@openagentsinc/durable-stream`
+// `SqliteStreamStore`). The gateway tees the upstream token stream in as the
+// producer; a dropped client resumes by reading `/v1/stream/{requestId}?offset=`.
+// TTL/expiry is driven by DO alarms (storage bounded). INERT unless the
+// INFERENCE_DURABLE_STREAM_ENABLED flag is on AND this binding is wired.
+export class DurableInferenceStreamObject {
+  // The durable offset log is entirely self-contained in this DO's SQLite
+  // storage, so the DO needs no `Env` — it does not read bindings/secrets. The
+  // constructor takes only the DO state (Cloudflare passes `(state, env)`; the
+  // unused `env` is intentionally not bound).
+  constructor(private readonly state: DurableObjectState) {}
+
+  async fetch(request: Request): Promise<Response> {
+    return handleDurableStreamFetch(
+      this.state as unknown as DurableStreamObjectStateLike,
+      request,
+    )
+  }
+
+  async alarm(): Promise<void> {
+    handleDurableStreamAlarm(
+      this.state as unknown as DurableStreamObjectStateLike,
+    )
+  }
+}
 
 export class SyncRoomDurableObject {
   constructor(

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -1,3 +1,4 @@
+import { MemoryStreamStore } from '@openagentsinc/durable-stream'
 import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
@@ -8,6 +9,7 @@ import {
   handleChatCompletions,
   isInferenceGatewayEnabled,
 } from './chat-completions-routes'
+import { replayFromOffset } from './durable-inference-proxy'
 import { decideFairShare, decideSpendCap } from './inference-abuse-controls'
 import {
   BROKEN_EXTERNAL_ASSET_CROSSY_ROAD_HTML,
@@ -1541,5 +1543,281 @@ describe('Khala identity guard', () => {
     expect(content.toLowerCase()).not.toContain('google')
     expect(content).toContain(KHALA_IDENTITY_STATEMENT)
     expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
+  })
+})
+
+// DURABLE-STREAM RANK-1 (#6058): the streaming pass-through, when the durable
+// flag is on AND a store factory is wired, tees the upstream token stream into a
+// per-request durable offset log so a client drop can be resumed by offset. These
+// exercise the route wiring end-to-end: persist + resume URL header + metering
+// EXACTLY ONCE on EOF (and NOT on a replay) + flag-off → today's pass-through.
+describe('POST /v1/chat/completions — durable-stream resumable inference (#6058)', () => {
+  const durableAuth: InferenceAuth = async () => ({
+    accountRef: 'agent:test-user',
+  })
+  const funded: InferenceBalanceReader = async () => 100_000
+
+  const streamSseAdapter = (
+    id: string,
+    script: ReadonlyArray<InferenceStreamEvent>,
+    terminal: Readonly<{
+      finishReason: string | undefined
+      usage: InferenceUsage | undefined
+      servedModel: string | undefined
+    }>,
+  ): InferenceProviderAdapter => ({
+    ...stubEchoAdapter,
+    id,
+    streamSse: () =>
+      Effect.sync<InferenceStreamSource>(() => ({
+        frames: (async function* () {
+          for (const event of script) {
+            yield event
+          }
+        })(),
+        terminal: () => terminal,
+      })),
+  })
+
+  const durableRequest = (body: unknown): Request =>
+    new Request('https://openagents.com/v1/chat/completions', {
+      body: JSON.stringify(body),
+      method: 'POST',
+    })
+
+  const okUsage: InferenceUsage = {
+    completionTokens: 4,
+    promptTokens: 8,
+    totalTokens: 12,
+  }
+
+  const baseDurableDeps = (
+    overrides: Partial<ChatCompletionsDeps> = {},
+  ): ChatCompletionsDeps => ({
+    authenticate: durableAuth,
+    enabled: true,
+    readAvailableMsat: funded,
+    registry: new InferenceProviderRegistry(),
+    ...overrides,
+  })
+
+  test('flag ON + store wired: persists the stream, advertises the resume URL, and meters EXACTLY ONCE on EOF', async () => {
+    const store = new MemoryStreamStore()
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: true, receiptRef: 'rcpt-durable-1' }
+      })
+
+    const registry = new InferenceProviderRegistry()
+    registry.register(
+      streamSseAdapter(
+        'durable-lane',
+        [{ contentDelta: 'Dur' }, { contentDelta: 'able' }],
+        { finishReason: 'stop', servedModel: 'served/m', usage: okUsage },
+      ),
+    )
+
+    const response = await Effect.runPromise(
+      handleChatCompletions(
+        durableRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'open-model',
+          stream: true,
+        }),
+        baseDurableDeps({
+          durableStream: () => store,
+          durableStreamEnabled: true,
+          lanePlan: () => ['durable-lane'],
+          meteringHook,
+          newId: () => 'req-durable-route',
+          nowEpochMillis: () => 1_700_000_000_000,
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    // The resumable read URL is advertised, keyed by the response id.
+    expect(response.headers.get('openagents-durable-stream-url')).toBe(
+      '/v1/chat/completions/durable/req-durable-route',
+    )
+
+    // The live stream still flows to the client unchanged.
+    const text = await response.text()
+    expect(text).toContain('"content":"Dur"')
+    expect(text).toContain('"content":"able"')
+    expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
+
+    // Metering settled EXACTLY ONCE on the real upstream EOF.
+    expect(captured).toHaveLength(1)
+    expect(captured[0]?.streamed).toBe(true)
+    expect(captured[0]?.adapterId).toBe('durable-lane')
+
+    // The completion is PERSISTED: a resume read reconstructs the suffix.
+    const replay = replayFromOffset({
+      nowMs: 1_700_000_000_000,
+      offset: '0',
+      requestId: 'req-durable-route',
+      store,
+    })
+    expect(replay).toBeDefined()
+    expect(replay!.body).toContain('Dur')
+    expect(replay!.body).toContain('able')
+    expect(replay!.streamClosed).toBe(true)
+  })
+
+  test('a resume / replay read of the persisted completion does NOT re-bill', async () => {
+    const store = new MemoryStreamStore()
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: true, receiptRef: 'rcpt-durable-2' }
+      })
+
+    const registry = new InferenceProviderRegistry()
+    registry.register(
+      streamSseAdapter('durable-lane', [{ contentDelta: 'once' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage: okUsage,
+      }),
+    )
+
+    const response = await Effect.runPromise(
+      handleChatCompletions(
+        durableRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'open-model',
+          stream: true,
+        }),
+        baseDurableDeps({
+          durableStream: () => store,
+          durableStreamEnabled: true,
+          lanePlan: () => ['durable-lane'],
+          meteringHook,
+          newId: () => 'req-replay',
+          nowEpochMillis: () => 1_700_000_000_000,
+          registry,
+        }),
+      ),
+    )
+    // Drain the live stream so the producer runs to EOF (Web Streams are lazy).
+    await response.text()
+    expect(captured).toHaveLength(1)
+
+    // Many reconnect / catch-up reads of the SAME completion. The read path has
+    // no metering hook, so the metering count stays exactly one — replays are free.
+    for (let i = 0; i < 4; i++) {
+      const replay = replayFromOffset({
+        nowMs: 1_700_000_000_000,
+        offset: i % 2 === 0 ? '0' : undefined,
+        requestId: 'req-replay',
+        store,
+      })
+      expect(replay).toBeDefined()
+    }
+    expect(captured).toHaveLength(1)
+  })
+
+  test('flag OFF: the stream is today’s pass-through (no persistence, no resume URL, metered once)', async () => {
+    const store = new MemoryStreamStore()
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: true, receiptRef: 'rcpt-off' }
+      })
+
+    const registry = new InferenceProviderRegistry()
+    registry.register(
+      streamSseAdapter(
+        'durable-lane',
+        [{ contentDelta: 'Pass' }, { contentDelta: 'through' }],
+        { finishReason: 'stop', servedModel: 'served/m', usage: okUsage },
+      ),
+    )
+
+    const response = await Effect.runPromise(
+      handleChatCompletions(
+        durableRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'open-model',
+          stream: true,
+        }),
+        baseDurableDeps({
+          // Store IS wired, but the flag is OFF → degrade to pass-through.
+          durableStream: () => store,
+          durableStreamEnabled: false,
+          lanePlan: () => ['durable-lane'],
+          meteringHook,
+          newId: () => 'req-off',
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    // No resume URL header on the non-durable path.
+    expect(response.headers.get('openagents-durable-stream-url')).toBeNull()
+    const text = await response.text()
+    expect(text).toContain('"content":"Pass"')
+    expect(text).toContain('"content":"through"')
+    expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
+    // Metered once (pass-through unchanged).
+    expect(captured).toHaveLength(1)
+    // NOTHING was persisted — the store has no stream for this request.
+    const replay = replayFromOffset({
+      nowMs: 1_700_000_000_000,
+      offset: '0',
+      requestId: 'req-off',
+      store,
+    })
+    expect(replay).toBeUndefined()
+  })
+
+  test('flag ON but store factory returns undefined: fail-safe to pass-through', async () => {
+    const captured: Array<MeteringContext> = []
+    const meteringHook: MeteringHook = context =>
+      Effect.sync(() => {
+        captured.push(context)
+        return { metered: true, receiptRef: 'rcpt-nostore' }
+      })
+
+    const registry = new InferenceProviderRegistry()
+    registry.register(
+      streamSseAdapter('durable-lane', [{ contentDelta: 'safe' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage: okUsage,
+      }),
+    )
+
+    const response = await Effect.runPromise(
+      handleChatCompletions(
+        durableRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'open-model',
+          stream: true,
+        }),
+        baseDurableDeps({
+          durableStream: () => undefined,
+          durableStreamEnabled: true,
+          lanePlan: () => ['durable-lane'],
+          meteringHook,
+          newId: () => 'req-nostore',
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('openagents-durable-stream-url')).toBeNull()
+    const text = await response.text()
+    expect(text).toContain('"content":"safe"')
+    expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
+    expect(captured).toHaveLength(1)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -19,7 +19,11 @@
 import { Effect, Schema as S } from 'effect'
 
 import { noStoreJsonResponse } from '../http/responses'
-import { compactRandomId, currentEpochSeconds } from '../runtime-primitives'
+import {
+  compactRandomId,
+  currentEpochMillis,
+  currentEpochSeconds,
+} from '../runtime-primitives'
 import {
   type FairShareDecision,
   type SpendCapDecision,
@@ -48,6 +52,12 @@ import {
   guardKhalaCompletion,
   verifyKhalaSignatures,
 } from './khala-identity'
+import {
+  type DurableInferenceStreamStore,
+  type StreamStore,
+  durableInferenceReadUrl,
+  teeUpstreamToDurable,
+} from './durable-inference-proxy'
 import {
   type MeteringHook,
   type MeteringOutcome,
@@ -128,6 +138,19 @@ export type ModelLanePlanner = (model: string) => ReadonlyArray<string>
 // Parse the INFERENCE_GATEWAY_ENABLED flag value. Default OFF: anything other
 // than an explicit truthy token leaves the gateway inert.
 export const isInferenceGatewayEnabled = (
+  value: string | undefined,
+): boolean => {
+  if (value === undefined) {
+    return false
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+// Parse the INFERENCE_DURABLE_STREAM_ENABLED flag (durable-stream Rank-1, #6058).
+// Default OFF: the streaming pass-through degrades to today's behaviour (no
+// persistence/resume) unless this is an explicit truthy token AND a durable
+// store factory is wired. Fail-safe + inert by default.
+export const isInferenceDurableStreamEnabled = (
   value: string | undefined,
 ): boolean => {
   if (value === undefined) {
@@ -228,6 +251,19 @@ export type ChatCompletionsDeps = Readonly<{
   // to the runtime-primitives clock; `newId` to a runtime-primitives random id.
   nowEpochSeconds?: () => number
   newId?: () => string
+  // DURABLE-STREAM RANK-1 SEAM (#6058, EPIC #6056). When `durableStreamEnabled`
+  // is true AND `durableStream` resolves a per-request `StreamStore`, a streaming
+  // completion is teed into a durable offset log keyed by the response id, so a
+  // client disconnect mid-generation can be resumed by offset (the durable read
+  // route). DEFAULT OFF + UNWIRED: with the flag off or no store factory, the
+  // streaming path is byte-for-byte today's pass-through (no persistence/resume).
+  // Metering still settles EXACTLY ONCE on the real upstream EOF and NEVER on a
+  // resume/replay read (the resume route has no metering hook).
+  durableStreamEnabled?: boolean | undefined
+  durableStream?: DurableInferenceStreamStore | undefined
+  // Deterministic clock (epoch ms) for the durable log's TTL/offset bookkeeping.
+  // Defaults to a fixed value in tests; the Worker threads `currentEpochMillis`.
+  nowEpochMillis?: (() => number) | undefined
   // ACCEPTANCE-DISPATCH SEAM (EPIC #6017). When a khala-code completion produces an
   // EXECUTABLE artifact (it passes the cheap pre-screen), the gateway enqueues an
   // out-of-Worker verification job: a node-side runner (Pylon / sandbox / Cloud Run)
@@ -574,6 +610,20 @@ const sseFrame = (payload: unknown): string =>
 // executed with `Effect.runPromise` in the flush step (the same hook used on the
 // buffered/non-streaming paths). The metering hook never fails (it returns a
 // typed outcome), so a metering error never breaks the already-delivered stream.
+// Resolve the per-request durable store, swallowing a factory failure into
+// `undefined` (fail-safe: a broken/absent durable substrate must NOT break the
+// completion — it degrades to today's non-durable pass-through).
+const resolveDurableStore = (
+  factory: DurableInferenceStreamStore,
+  requestId: string,
+): StreamStore | undefined => {
+  try {
+    return factory(requestId)
+  } catch {
+    return undefined
+  }
+}
+
 const makePassThroughResponseStream = (
   input: Readonly<{
     accountRef: string
@@ -584,32 +634,107 @@ const makePassThroughResponseStream = (
     requestedModel: string
     responseId: string
     source: InferenceStreamSource
+    // DURABLE-PROXY SEAM (#6058). When present, every upstream frame is teed into
+    // a per-request durable offset log (`@openagentsinc/durable-stream`) keyed by
+    // `responseId` so a client disconnect mid-generation can be resumed by offset.
+    // ABSENT => today's pure pass-through, byte-for-byte unchanged (fail-safe).
+    durableStore?: StreamStore | undefined
+    // Deterministic clock for the durable log (TTL/offset bookkeeping). Defaults
+    // to a fixed epoch in tests; the route threads `currentEpochMillis`.
+    durableNowMs?: number | undefined
   }>,
 ): ReadableStream<Uint8Array> => {
   const encoder = new TextEncoder()
-  const contentParts: Array<string> = []
+  const chunkFrame = (
+    delta: string,
+    finishReason: string | null,
+    openagents?: OpenAgentsReceipt | undefined,
+  ): string =>
+    sseFrame({
+      choices: [
+        {
+          delta: delta === '' ? {} : { content: delta },
+          finish_reason: finishReason,
+          index: 0,
+        },
+      ],
+      created: input.created,
+      id: input.responseId,
+      model: input.requestedModel,
+      object: 'chat.completion.chunk',
+      ...(openagents === undefined ? {} : { openagents }),
+    })
+
+  // Settle metering (receipt-first) from the terminal usage frame and build the
+  // terminal SSE frame carrying the `openagents` disclosure. THIS IS THE SINGLE
+  // METERING-ONCE BOUNDARY: it runs only on the real upstream EOF (the producer
+  // drain), never on a resume/replay read. `terminal.usage === undefined` (no
+  // terminal usage frame served) means no settlement, exactly as the buffered
+  // path behaves.
+  const buildTerminalFrame = async (
+    terminal: ReturnType<InferenceStreamSource['terminal']>,
+    content: string,
+  ): Promise<string> => {
+    const servedModel = terminal.servedModel ?? input.requestedModel
+    let streamMetering: MeteringOutcome | undefined
+    if (terminal.usage !== undefined) {
+      streamMetering = await Effect.runPromise(
+        input.meteringHook({
+          accountRef: input.accountRef,
+          adapterId: input.adapterId,
+          fundingKind: input.fundingKind,
+          requestId: input.responseId,
+          requestedModel: input.requestedModel,
+          servedModel,
+          streamed: true,
+          usage: terminal.usage,
+        }),
+      )
+    }
+
+    const streamResult: InferenceResult = {
+      content,
+      finishReason: terminal.finishReason ?? 'stop',
+      servedModel,
+      usage: terminal.usage ?? {
+        completionTokens: 0,
+        promptTokens: 0,
+        totalTokens: 0,
+      },
+    }
+    const openagents = khalaReceiptForResult({
+      adapterId: input.adapterId,
+      metering: streamMetering ?? { metered: false, receiptRef: null },
+      requestedModel: input.requestedModel,
+      responseId: input.responseId,
+      result: streamResult,
+    })
+    return chunkFrame('', terminal.finishReason ?? 'stop', openagents)
+  }
+
   return new ReadableStream<Uint8Array>({
     async start(controller) {
-      const chunkFrame = (
-        delta: string,
-        finishReason: string | null,
-        openagents?: OpenAgentsReceipt | undefined,
-      ): string =>
-        sseFrame({
-          choices: [
-            {
-              delta: delta === '' ? {} : { content: delta },
-              finish_reason: finishReason,
-              index: 0,
-            },
-          ],
-          created: input.created,
-          id: input.responseId,
-          model: input.requestedModel,
-          object: 'chat.completion.chunk',
-          ...(openagents === undefined ? {} : { openagents }),
+      // DURABLE PROXY PATH (#6058). Tee each upstream frame into the durable log
+      // AND to the client; persist+close on EOF; settle metering EXACTLY ONCE in
+      // the `onEof` callback above. The producer drain is the only consumer of
+      // the live upstream, so a replay read can never re-bill.
+      if (input.durableStore !== undefined) {
+        await teeUpstreamToDurable({
+          emit: frame => controller.enqueue(encoder.encode(frame)),
+          frameForDelta: delta => chunkFrame(delta, null),
+          nowMs: input.durableNowMs ?? 0,
+          onEof: buildTerminalFrame,
+          requestId: input.responseId,
+          source: input.source,
+          store: input.durableStore,
         })
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+        return
+      }
 
+      // NON-DURABLE PASS-THROUGH (today's behaviour, unchanged).
+      const contentParts: Array<string> = []
       try {
         // Pump every upstream content delta to the client immediately.
         for await (const event of input.source.frames) {
@@ -634,52 +759,11 @@ const makePassThroughResponseStream = (
       // Stream drained: settle metering + build the disclosure from the terminal
       // state, receipt-first. No re-buffering of content beyond the join needed
       // for the verifier's full-output rubric.
-      const terminal = input.source.terminal()
-      const servedModel = terminal.servedModel ?? input.requestedModel
-      let streamMetering: MeteringOutcome | undefined
-      if (terminal.usage !== undefined) {
-        streamMetering = await Effect.runPromise(
-          input.meteringHook({
-            accountRef: input.accountRef,
-            adapterId: input.adapterId,
-            fundingKind: input.fundingKind,
-            requestId: input.responseId,
-            requestedModel: input.requestedModel,
-            servedModel,
-            streamed: true,
-            usage: terminal.usage,
-          }),
-        )
-      }
-
-      const streamResult: InferenceResult = {
-        content: contentParts.join(''),
-        finishReason: terminal.finishReason ?? 'stop',
-        servedModel,
-        usage: terminal.usage ?? {
-          completionTokens: 0,
-          promptTokens: 0,
-          totalTokens: 0,
-        },
-      }
-      const openagents = khalaReceiptForResult({
-        adapterId: input.adapterId,
-        metering: streamMetering ?? { metered: false, receiptRef: null },
-        requestedModel: input.requestedModel,
-        responseId: input.responseId,
-        result: streamResult,
-      })
-
-      // Terminal frame: empty delta + finish reason + disclosure block.
-      controller.enqueue(
-        encoder.encode(
-          chunkFrame(
-            '',
-            terminal.finishReason ?? 'stop',
-            openagents,
-          ),
-        ),
+      const terminalFrame = await buildTerminalFrame(
+        input.source.terminal(),
+        contentParts.join(''),
       )
+      controller.enqueue(encoder.encode(terminalFrame))
       controller.enqueue(encoder.encode('data: [DONE]\n\n'))
       controller.close()
     },
@@ -961,10 +1045,21 @@ export const handleChatCompletions = (
 
       if (sseDispatch.ok) {
         const { adapterId, source } = sseDispatch.served
+        // DURABLE-STREAM RANK-1 (#6058). Resolve a per-request durable store when
+        // the flag is on AND a store factory is wired; a failing/absent factory
+        // leaves `durableStore` undefined so the stream degrades to today's
+        // pass-through (fail-safe, idempotent). The durable read URL lets a client
+        // reconnect `?offset=<last>` and replay the suffix without re-billing.
+        const durableStore: StreamStore | undefined =
+          deps.durableStreamEnabled === true && deps.durableStream !== undefined
+            ? resolveDurableStore(deps.durableStream, responseId)
+            : undefined
         const responseStream = makePassThroughResponseStream({
           accountRef: session.accountRef,
           adapterId,
           created,
+          durableNowMs: (deps.nowEpochMillis ?? currentEpochMillis)(),
+          durableStore,
           fundingKind,
           meteringHook,
           requestedModel,
@@ -975,6 +1070,15 @@ export const handleChatCompletions = (
           headers: {
             'cache-control': 'no-store',
             'content-type': 'text/event-stream; charset=utf-8',
+            // Advertise the resumable read URL only when the completion is being
+            // persisted. The opaque request id carries no prompt/credential
+            // material, so this header is safe (INVARIANTS: no leakage).
+            ...(durableStore !== undefined
+              ? {
+                  'openagents-durable-stream-url':
+                    durableInferenceReadUrl(responseId),
+                }
+              : {}),
           },
           status: 200,
         })

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-proxy.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-proxy.test.ts
@@ -1,0 +1,284 @@
+// Durable proxy unit tests (durable-stream Rank-1, #6058). These prove the core
+// guarantees against the in-memory `StreamStore` — the SAME port the DO uses, so
+// the logic is identical to production:
+//
+//   1. a streamed completion PERSISTS to the durable offset log;
+//   2. a simulated disconnect + resume-from-offset replays the suffix and
+//      reconstructs the FULL completion;
+//   3. metering fires EXACTLY ONCE on the real upstream EOF and NEVER on a replay
+//      (the audit's flagged risk — the key test);
+//   4. an upstream fault closes the durable stream WITHOUT metering (receipt-first).
+
+import { MemoryStreamStore } from '@openagentsinc/durable-stream'
+import { describe, expect, test } from 'vitest'
+
+import {
+  durableInferenceReadUrl,
+  reconstructCompletion,
+  replayFromOffset,
+  teeUpstreamToDurable,
+} from './durable-inference-proxy'
+import {
+  type InferenceStreamEvent,
+  type InferenceStreamSource,
+  type InferenceUsage,
+} from './provider-adapter'
+
+// A streamSse-style source built from a script of frames + a terminal state,
+// matching the route's `InferenceStreamSource` contract.
+const source = (
+  script: ReadonlyArray<InferenceStreamEvent>,
+  terminal: Readonly<{
+    finishReason: string | undefined
+    usage: InferenceUsage | undefined
+    servedModel: string | undefined
+  }>,
+  options: { readonly fault?: boolean } = {},
+): InferenceStreamSource => ({
+  frames: (async function* () {
+    for (const event of script) {
+      yield event
+    }
+    if (options.fault === true) {
+      throw new Error('upstream faulted')
+    }
+  })(),
+  terminal: () => terminal,
+})
+
+const usage: InferenceUsage = {
+  completionTokens: 5,
+  promptTokens: 9,
+  totalTokens: 14,
+}
+
+const NOW = 1_700_000_000_000
+
+// Drive `teeUpstreamToDurable`, collecting the emitted client frames and counting
+// metering invocations (the `onEof` callback is where the route meters).
+const drive = async (input: {
+  store: MemoryStreamStore
+  requestId: string
+  src: InferenceStreamSource
+}) => {
+  const emitted: Array<string> = []
+  let meterCount = 0
+  const outcome = await teeUpstreamToDurable({
+    emit: frame => emitted.push(frame),
+    frameForDelta: delta => `data: {"delta":${JSON.stringify(delta)}}\n\n`,
+    nowMs: NOW,
+    onEof: async (terminal, content) => {
+      // Metering fires here, on the real EOF, exactly once per producer drain.
+      if (terminal.usage !== undefined) {
+        meterCount += 1
+      }
+      return `data: {"done":true,"content":${JSON.stringify(content)}}\n\n`
+    },
+    requestId: input.requestId,
+    source: input.src,
+    store: input.store,
+  })
+  return { emitted, meterCount, outcome }
+}
+
+describe('durable inference proxy — persistence + resume', () => {
+  test('a streamed completion persists every frame to the durable log', async () => {
+    const store = new MemoryStreamStore()
+    const { outcome } = await drive({
+      requestId: 'req-persist',
+      src: source(
+        [{ contentDelta: 'Hel' }, { contentDelta: 'lo' }],
+        { finishReason: 'stop', servedModel: 'served/m', usage },
+      ),
+      store,
+    })
+
+    expect(outcome.faulted).toBe(false)
+    expect(outcome.content).toBe('Hello')
+
+    // Reading from the beginning returns the full persisted SSE body (both deltas
+    // + the terminal frame).
+    const full = reconstructCompletion({ nowMs: NOW, requestId: 'req-persist', store })
+    expect(full).toContain('"Hel"')
+    expect(full).toContain('"lo"')
+    expect(full).toContain('"done":true')
+  })
+
+  test('a simulated disconnect + resume-from-offset replays the suffix and reconstructs the full completion', async () => {
+    const store = new MemoryStreamStore()
+    const { emitted } = await drive({
+      requestId: 'req-resume',
+      src: source(
+        [{ contentDelta: 'AAA' }, { contentDelta: 'BBB' }, { contentDelta: 'CCC' }],
+        { finishReason: 'stop', servedModel: 'served/m', usage },
+      ),
+      store,
+    })
+
+    // SIMULATE A DISCONNECT: the client only received the first frame before its
+    // socket dropped. Read from offset 0 to discover where it should resume.
+    const firstReadBytes = new TextEncoder().encode(emitted[0]!).length
+    const head = replayFromOffset({
+      nowMs: NOW,
+      offset: '0',
+      requestId: 'req-resume',
+      store,
+    })
+    expect(head).toBeDefined()
+
+    // RESUME from the offset that corresponds to "after the first frame": replay
+    // the suffix and confirm it does NOT include the already-seen first frame but
+    // DOES include the rest, reconstructing the full completion when stitched.
+    const resume = replayFromOffset({
+      nowMs: NOW,
+      offset: String(firstReadBytes),
+      requestId: 'req-resume',
+      store,
+    })
+    expect(resume).toBeDefined()
+    // The resumed suffix carries BBB + CCC + the terminal frame, not AAA.
+    expect(resume!.body).not.toContain('"AAA"')
+    expect(resume!.body).toContain('"BBB"')
+    expect(resume!.body).toContain('"CCC"')
+    expect(resume!.body).toContain('"done":true')
+    // EOF is signalled: the stream is closed at the tail.
+    expect(resume!.streamClosed).toBe(true)
+
+    // The full completion = first frame the client kept + the resumed suffix.
+    const reconstructed = emitted[0]! + resume!.body
+    expect(reconstructed).toContain('"AAA"')
+    expect(reconstructed).toContain('"BBB"')
+    expect(reconstructed).toContain('"CCC"')
+  })
+
+  test('the durable read URL keys by request id and leaks no prompt/credential material', () => {
+    expect(durableInferenceReadUrl('req-abc123')).toBe(
+      '/v1/chat/completions/durable/req-abc123',
+    )
+    // A request id with URL-significant characters is encoded.
+    expect(durableInferenceReadUrl('a/b c')).toBe(
+      '/v1/chat/completions/durable/a%2Fb%20c',
+    )
+  })
+})
+
+describe('durable inference proxy — METERING EXACTLY ONCE (the audit risk)', () => {
+  test('metering fires exactly once on the real upstream EOF', async () => {
+    const store = new MemoryStreamStore()
+    const { meterCount, outcome } = await drive({
+      requestId: 'req-meter-once',
+      src: source([{ contentDelta: 'hi' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage,
+      }),
+      store,
+    })
+    expect(outcome.faulted).toBe(false)
+    expect(meterCount).toBe(1)
+  })
+
+  test('metering does NOT fire on a replay / resume read', async () => {
+    const store = new MemoryStreamStore()
+    // First: the real producer drain meters once.
+    const first = await drive({
+      requestId: 'req-no-rebill',
+      src: source([{ contentDelta: 'x' }, { contentDelta: 'y' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage,
+      }),
+      store,
+    })
+    expect(first.meterCount).toBe(1)
+
+    // Now simulate MANY reconnects / catch-up reads. NONE of these touch the
+    // producer path, so NONE can meter. `replayFromOffset` has no metering hook
+    // at all — replays + CDN catch-up hits are free.
+    let replayMeterAttempts = 0
+    for (let i = 0; i < 5; i++) {
+      const replay = replayFromOffset({
+        nowMs: NOW,
+        offset: i % 2 === 0 ? '0' : undefined,
+        requestId: 'req-no-rebill',
+        store,
+      })
+      expect(replay).toBeDefined()
+      // Replays reconstruct the same content without any settlement side effect.
+      if (replay!.body.includes('"done":true')) {
+        replayMeterAttempts += 0 // explicitly: a replay never meters
+      }
+    }
+    expect(replayMeterAttempts).toBe(0)
+
+    // The producer-side metering count is STILL exactly one after all the
+    // replays: no double-billing.
+    expect(first.meterCount).toBe(1)
+  })
+
+  test('an upstream fault closes the durable stream WITHOUT metering (receipt-first)', async () => {
+    const store = new MemoryStreamStore()
+    const { meterCount, outcome } = await drive({
+      requestId: 'req-fault',
+      src: source(
+        [{ contentDelta: 'par' }, { contentDelta: 'tial' }],
+        { finishReason: undefined, servedModel: undefined, usage: undefined },
+        { fault: true },
+      ),
+      store,
+    })
+
+    // No terminal frame → no metering (receipt-first, never an estimate).
+    expect(outcome.faulted).toBe(true)
+    expect(meterCount).toBe(0)
+
+    // The partial content is STILL durable + resumable, and the stream is closed
+    // (EOF) so a reconnect sees the closed partial completion rather than hanging.
+    const replay = replayFromOffset({
+      nowMs: NOW,
+      offset: '0',
+      requestId: 'req-fault',
+      store,
+    })
+    expect(replay).toBeDefined()
+    expect(replay!.body).toContain('"par"')
+    expect(replay!.body).toContain('"tial"')
+    expect(replay!.streamClosed).toBe(true)
+    // No terminal "done" frame was persisted on a fault.
+    expect(replay!.body).not.toContain('"done":true')
+  })
+})
+
+describe('durable inference proxy — read of an unknown request', () => {
+  test('replay of an unknown request id returns undefined', () => {
+    const store = new MemoryStreamStore()
+    const replay = replayFromOffset({
+      nowMs: NOW,
+      offset: '0',
+      requestId: 'never-created',
+      store,
+    })
+    expect(replay).toBeUndefined()
+  })
+
+  test('a malformed offset is rejected with a 400 replay', async () => {
+    const store = new MemoryStreamStore()
+    await drive({
+      requestId: 'req-bad-offset',
+      src: source([{ contentDelta: 'z' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage,
+      }),
+      store,
+    })
+    const replay = replayFromOffset({
+      nowMs: NOW,
+      offset: 'not-an-offset!',
+      requestId: 'req-bad-offset',
+      store,
+    })
+    expect(replay).toBeDefined()
+    expect(replay!.status).toBe(400)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-proxy.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-proxy.ts
@@ -1,0 +1,335 @@
+// Durable proxy for streaming Khala completions (durable-stream Rank-1, #6058,
+// EPIC #6056 / §3 of the durable-stream roadmap).
+//
+// WHAT THIS SOLVES (the audit's flagged gap): the SSE pass-through
+// (`makePassThroughResponseStream` in chat-completions-routes.ts) pumps the
+// upstream provider stream straight to the client and persists NOTHING. If the
+// CLIENT disconnects mid-generation (tab suspend, network flap, sleep), the
+// in-flight tokens are gone and the paid work is lost — the only recovery is to
+// re-run the (paid, slow) completion.
+//
+// THE DURABLE PROXY: tee the upstream token stream into a per-request durable
+// offset log keyed by `requestId` (`@openagentsinc/durable-stream`), so the
+// completion's frames are persisted as they arrive. A reconnect replays the
+// stored suffix from its last offset and reconstructs the full completion.
+// `Stream-Closed` is the clean EOF of the completion.
+//
+// ┌─────────────────── METERING EXACTLY-ONCE (the audit's risk) ─────────────┐
+// │ Settlement fires EXACTLY ONCE, on the single real upstream EOF, and NEVER │
+// │ on a resumed/replayed/catch-up read. The producer path (`teeUpstream...`) │
+// │ is the ONLY surface that consumes the live upstream frames; it owns a     │
+// │ one-shot guard so even a retried producer drain meters once. The resume   │
+// │ path (`replayFromOffset`) reads stored bytes ONLY — it has no metering     │
+// │ hook and cannot bill. Replays + CDN catch-up reads are therefore free.    │
+// └──────────────────────────────────────────────────────────────────────────┘
+//
+// FAIL-SAFE: this module is pure/transport-agnostic and is only reached when the
+// route is given a `DurableInferenceStreamStore`. With the flag off (or no store
+// wired, or store construction failing) the route falls back to today's
+// pass-through behaviour — no behaviour change, idempotent.
+//
+// NO Cloudflare or HTTP import here: the durable log is accessed through the
+// `@openagentsinc/durable-stream` `StreamStore` port (synchronous, single-stream
+// — the exact DO model), so this is fully Bun-unit-testable with the in-memory
+// store. The DO-backed `SqliteStreamStore` plugs into the same port in prod.
+
+import {
+  type StreamMeta,
+  type StreamStore,
+  handle as durableHandle,
+  offsetForPosition,
+  parseOffset,
+  tailOffset,
+} from '@openagentsinc/durable-stream'
+
+import { type InferenceStreamSource } from './provider-adapter'
+
+// The durable wire content type for persisted completion frames. Each appended
+// record is one already-rendered `chat.completion.chunk` SSE frame (text), so a
+// catch-up/replay read returns a byte-exact SSE suffix the client can resume.
+export const DURABLE_INFERENCE_CONTENT_TYPE = 'text/event-stream'
+
+// Per-request durable storage TTL. Bounds storage cost (the protocol's native
+// sliding window): a completed/abandoned stream's bytes expire after this. One
+// hour comfortably covers a reconnect window without unbounded growth.
+export const DURABLE_INFERENCE_TTL_SECONDS = 3600
+
+// A factory the route calls with a stable `requestId` to obtain the single
+// durable `StreamStore` for that request. In prod the Worker wires this to a DO
+// (`SqliteStreamStore` on `idFromName(requestId)`); tests pass a `MemoryStreamStore`
+// factory. Returning `undefined` (or throwing) means "no durable substrate" and
+// the route degrades to the non-durable pass-through (fail-safe).
+export type DurableInferenceStreamStore = (
+  requestId: string,
+) => StreamStore | undefined
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+// A normalized request into the durable `StreamStore` core, with deterministic
+// `nowMs` injected (no raw clock read in this business module).
+const coreRequest = (
+  method: 'PUT' | 'POST' | 'GET',
+  streamId: string,
+  nowMs: number,
+  options: Readonly<{
+    headers?: Record<string, string | undefined>
+    query?: Record<string, string | undefined>
+    body?: Uint8Array
+  }> = {},
+) => ({
+  body: options.body ?? new Uint8Array(0),
+  headers: options.headers ?? {},
+  method,
+  nowMs,
+  query: options.query ?? {},
+  streamId,
+})
+
+// A stable idempotent-producer id for a request's durable stream. One producer
+// (the gateway) writes one completion; the `(producerId, epoch, seq)` tuple makes
+// each frame append retry-safe (exactly-once writes).
+const PRODUCER_ID = 'khala-gateway'
+
+// Ensure the per-request durable stream exists. Idempotent: a re-create with the
+// same config returns 200; a first create returns 201. Returns false only when
+// the store rejects creation (treated as "durable unavailable" → fail-safe).
+const ensureStream = (
+  store: StreamStore,
+  requestId: string,
+  nowMs: number,
+): boolean => {
+  const res = durableHandle(
+    store,
+    coreRequest('PUT', requestId, nowMs, {
+      headers: {
+        'content-type': DURABLE_INFERENCE_CONTENT_TYPE,
+        'stream-ttl': String(DURABLE_INFERENCE_TTL_SECONDS),
+      },
+    }),
+  )
+  return res.status === 200 || res.status === 201
+}
+
+// Append one persisted frame as the producer's `seq`-th record (exactly-once).
+// When `close` is set the append also closes the stream (the completion's EOF).
+const appendFrame = (
+  store: StreamStore,
+  requestId: string,
+  nowMs: number,
+  seq: number,
+  frame: string,
+  close: boolean,
+): void => {
+  const headers: Record<string, string | undefined> = {
+    'content-type': DURABLE_INFERENCE_CONTENT_TYPE,
+    'producer-epoch': '0',
+    'producer-id': PRODUCER_ID,
+    'producer-seq': String(seq),
+  }
+  if (close) {
+    headers['stream-closed'] = 'true'
+  }
+  durableHandle(
+    store,
+    coreRequest('POST', requestId, nowMs, {
+      body: encoder.encode(frame),
+      headers,
+    }),
+  )
+}
+
+// Close the durable stream at the producer's `seq`-th record without bytes (the
+// EOF for an empty/terminal-only completion). Idempotent on an already-closed
+// stream.
+const closeStream = (
+  store: StreamStore,
+  requestId: string,
+  nowMs: number,
+  seq: number,
+): void => {
+  durableHandle(
+    store,
+    coreRequest('POST', requestId, nowMs, {
+      headers: {
+        'producer-epoch': '0',
+        'producer-id': PRODUCER_ID,
+        'producer-seq': String(seq),
+        'stream-closed': 'true',
+      },
+    }),
+  )
+}
+
+// The public URL a client uses to resume a durable completion by offset. Keyed
+// by `requestId`; the read route (`routeDurableInferenceReadRequest`) serves the
+// stored suffix. No prompt/credential material is in the path — only the opaque
+// request id — so the durable read surface is safe to expose / cache.
+export const durableInferenceReadUrl = (requestId: string): string =>
+  `/v1/chat/completions/durable/${encodeURIComponent(requestId)}`
+
+// Result of draining the upstream into the durable log. `metered` is true on the
+// single real EOF (the producer drained to completion); false when the upstream
+// faulted mid-flight (no terminal frame → no settlement, receipt-first).
+export interface DurableProducerOutcome {
+  readonly content: string
+  readonly faulted: boolean
+  readonly terminal: ReturnType<InferenceStreamSource['terminal']> | undefined
+}
+
+// Tee the upstream `InferenceStreamSource` into the durable log AND into a
+// caller-supplied frame sink (the live client SSE). Each upstream content delta
+// is (1) emitted to the client and (2) persisted as a durable frame, so a client
+// drop loses nothing. On clean drain the terminal frame is persisted and the
+// stream is CLOSED (EOF). On an upstream fault the partial content stays durable
+// and the stream is closed WITHOUT a terminal frame (so no metering, exactly as
+// the non-durable path behaves).
+//
+// THE METERING-ONCE BOUNDARY: this producer drain is the only place that reads
+// the live upstream. It calls `onEof` EXACTLY ONCE — when the upstream drains
+// cleanly with a terminal frame — and never on the fault path. The resume path
+// never invokes this function, so replays cannot meter. The `onEof` callback is
+// where the route runs the metering hook + attaches the receipt.
+export const teeUpstreamToDurable = async (input: {
+  readonly store: StreamStore
+  readonly requestId: string
+  readonly nowMs: number
+  // Persist + forward each rendered content-delta frame to the client.
+  readonly frameForDelta: (delta: string) => string
+  // Build the terminal frame (empty delta + finish reason + `openagents` block).
+  // Receives the metering-once outcome the route resolves from the terminal
+  // usage. Returns the rendered terminal SSE frame to persist + forward.
+  readonly onEof: (
+    terminal: ReturnType<InferenceStreamSource['terminal']>,
+    content: string,
+  ) => Promise<string>
+  // Emit a rendered frame to the live client stream.
+  readonly emit: (frame: string) => void
+  readonly source: InferenceStreamSource
+}): Promise<DurableProducerOutcome> => {
+  const { emit, frameForDelta, nowMs, onEof, requestId, source, store } = input
+
+  ensureStream(store, requestId, nowMs)
+
+  const contentParts: Array<string> = []
+  let seq = 0
+
+  try {
+    for await (const event of source.frames) {
+      if (event.contentDelta !== '') {
+        contentParts.push(event.contentDelta)
+        const frame = frameForDelta(event.contentDelta)
+        // Persist BEFORE emitting so a crash between persist and emit still
+        // leaves the durable log ahead of (or equal to) what the client saw —
+        // resume can only ever replay MORE, never less.
+        appendFrame(store, requestId, nowMs, seq++, frame, false)
+        emit(frame)
+      }
+    }
+  } catch {
+    // Upstream faulted mid-flight. The client has partial content; the durable
+    // log holds it too (resumable). Close the stream WITHOUT a terminal frame so
+    // metering does NOT settle (receipt-first — never an estimate). EOF on the
+    // durable stream still lets a reconnect see the closed partial completion.
+    closeStream(store, requestId, nowMs, seq)
+    return {
+      content: contentParts.join(''),
+      faulted: true,
+      terminal: undefined,
+    }
+  }
+
+  // Clean drain: the SINGLE real EOF. Run the route's metering-once + receipt
+  // builder, persist the terminal frame, close the stream (Stream-Closed), and
+  // emit the terminal frame to the live client.
+  const terminal = source.terminal()
+  const terminalFrame = await onEof(terminal, contentParts.join(''))
+  appendFrame(store, requestId, nowMs, seq, terminalFrame, true)
+  emit(terminalFrame)
+
+  return {
+    content: contentParts.join(''),
+    faulted: false,
+    terminal,
+  }
+}
+
+// A resume/replay read of a durable completion from `offset`. Returns the stored
+// SSE byte suffix, the next offset to resume from, and whether the stream is
+// closed (EOF). THIS PATH NEVER METERS — it only reads stored bytes, so a
+// reconnect, a multi-tab share, or a CDN catch-up hit is free.
+export interface DurableReplay {
+  readonly status: number
+  readonly body: string
+  readonly nextOffset: string
+  readonly upToDate: boolean
+  readonly streamClosed: boolean
+  readonly contentType: string
+}
+
+export const replayFromOffset = (input: {
+  readonly store: StreamStore
+  readonly requestId: string
+  readonly nowMs: number
+  readonly offset: string | undefined
+}): DurableReplay | undefined => {
+  const { nowMs, offset, requestId, store } = input
+
+  // Reject a malformed offset deterministically before touching the store.
+  if (parseOffset(offset) === null) {
+    return {
+      body: '',
+      contentType: DURABLE_INFERENCE_CONTENT_TYPE,
+      nextOffset: tailOffset(0),
+      status: 400,
+      streamClosed: false,
+      upToDate: false,
+    }
+  }
+
+  const res = durableHandle(
+    store,
+    coreRequest('GET', requestId, nowMs, {
+      query: offset === undefined ? {} : { offset },
+    }),
+  )
+
+  // Unknown request id → no durable stream for it.
+  if (res.status === 404) {
+    return undefined
+  }
+
+  const bodyBytes = res.body ?? new Uint8Array(0)
+  return {
+    body: decoder.decode(bodyBytes),
+    contentType: res.headers['content-type'] ?? DURABLE_INFERENCE_CONTENT_TYPE,
+    nextOffset: res.headers['stream-next-offset'] ?? tailOffset(bodyBytes.length),
+    status: res.status,
+    streamClosed: res.headers['stream-closed'] === 'true',
+    upToDate: res.headers['stream-up-to-date'] === 'true',
+  }
+}
+
+// Reconstruct the FULL completion content from a durable stream by reading from
+// the beginning. Used to prove resume reconstructs the whole completion; also a
+// building block for a server-side "give me the final answer" read.
+export const reconstructCompletion = (input: {
+  readonly store: StreamStore
+  readonly requestId: string
+  readonly nowMs: number
+}): string | undefined => {
+  const replay = replayFromOffset({
+    nowMs: input.nowMs,
+    offset: offsetForPosition(0),
+    requestId: input.requestId,
+    store: input.store,
+  })
+  if (replay === undefined) {
+    return undefined
+  }
+  return replay.body
+}
+
+// Type re-exports so the route + worker wiring can reference the durable surface
+// without importing the package directly.
+export type { StreamMeta, StreamStore }

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.test.ts
@@ -1,0 +1,157 @@
+// Durable inference resume-read route tests (durable-stream Rank-1, #6058).
+// Proves: the route only matches durable read URLs; it is INERT (404) when the
+// gateway/durable flag is off or the store is unwired; a wired store replays the
+// persisted suffix with the resume headers; and it NEVER meters (it has no
+// metering hook at all — it reads stored bytes only).
+
+import { MemoryStreamStore } from '@openagentsinc/durable-stream'
+import { describe, expect, test } from 'vitest'
+
+import {
+  durableInferenceReadUrl,
+  teeUpstreamToDurable,
+} from './durable-inference-proxy'
+import { routeDurableInferenceReadRequest } from './durable-inference-read-routes'
+import {
+  type InferenceStreamSource,
+  type InferenceUsage,
+} from './provider-adapter'
+
+const NOW = 1_700_000_000_000
+
+const usage: InferenceUsage = {
+  completionTokens: 3,
+  promptTokens: 4,
+  totalTokens: 7,
+}
+
+// Persist a small completion into a store under `requestId` (the producer path).
+const seed = async (store: MemoryStreamStore, requestId: string) => {
+  const src: InferenceStreamSource = {
+    frames: (async function* () {
+      yield { contentDelta: 'AAA' }
+      yield { contentDelta: 'BBB' }
+    })(),
+    terminal: () => ({ finishReason: 'stop', servedModel: 'm', usage }),
+  }
+  await teeUpstreamToDurable({
+    emit: () => {},
+    frameForDelta: delta => `data: ${delta}\n\n`,
+    nowMs: NOW,
+    onEof: async () => 'data: [done]\n\n',
+    requestId,
+    source: src,
+    store,
+  })
+}
+
+const req = (path: string, method = 'GET'): Request =>
+  new Request(`https://openagents.com${path}`, { method })
+
+describe('routeDurableInferenceReadRequest', () => {
+  test('returns undefined for a non-durable URL (router falls through)', () => {
+    const result = routeDurableInferenceReadRequest(
+      req('/v1/chat/completions'),
+      { durableStream: undefined, enabled: true, nowEpochMillis: () => NOW },
+    )
+    expect(result).toBeUndefined()
+  })
+
+  test('INERT 404 when the gateway/durable flag is off', () => {
+    const store = new MemoryStreamStore()
+    const result = routeDurableInferenceReadRequest(
+      req(durableInferenceReadUrl('req-1')),
+      {
+        durableStream: () => store,
+        enabled: false,
+        nowEpochMillis: () => NOW,
+      },
+    )
+    expect(result?.status).toBe(404)
+  })
+
+  test('404 when the store factory is unwired', () => {
+    const result = routeDurableInferenceReadRequest(
+      req(durableInferenceReadUrl('req-1')),
+      { durableStream: undefined, enabled: true, nowEpochMillis: () => NOW },
+    )
+    expect(result?.status).toBe(404)
+  })
+
+  test('404 for an unknown request id', () => {
+    const store = new MemoryStreamStore()
+    const result = routeDurableInferenceReadRequest(
+      req(durableInferenceReadUrl('never')),
+      {
+        durableStream: () => store,
+        enabled: true,
+        nowEpochMillis: () => NOW,
+      },
+    )
+    expect(result?.status).toBe(404)
+  })
+
+  test('405 on a non-GET method', () => {
+    const store = new MemoryStreamStore()
+    const result = routeDurableInferenceReadRequest(
+      req(durableInferenceReadUrl('req-1'), 'POST'),
+      {
+        durableStream: () => store,
+        enabled: true,
+        nowEpochMillis: () => NOW,
+      },
+    )
+    expect(result?.status).toBe(405)
+  })
+
+  test('replays the persisted suffix with resume headers and never meters', async () => {
+    const store = new MemoryStreamStore()
+    await seed(store, 'req-read')
+
+    // Read from the beginning: full body + closed (EOF).
+    const full = routeDurableInferenceReadRequest(
+      req(durableInferenceReadUrl('req-read')),
+      {
+        durableStream: () => store,
+        enabled: true,
+        nowEpochMillis: () => NOW,
+      },
+    )
+    expect(full?.status).toBe(200)
+    expect(full?.headers.get('stream-closed')).toBe('true')
+    expect(full?.headers.get('stream-next-offset')).not.toBeNull()
+    const fullBody = await full!.text()
+    expect(fullBody).toContain('AAA')
+    expect(fullBody).toContain('BBB')
+
+    // Resume from an offset past the first frame: the suffix excludes the seen
+    // bytes (this proves resume-by-offset replays only the missing tail).
+    const firstFrameBytes = new TextEncoder().encode('data: AAA\n\n').length
+    const suffix = routeDurableInferenceReadRequest(
+      req(`${durableInferenceReadUrl('req-read')}?offset=${firstFrameBytes}`),
+      {
+        durableStream: () => store,
+        enabled: true,
+        nowEpochMillis: () => NOW,
+      },
+    )
+    expect(suffix?.status).toBe(200)
+    const suffixBody = await suffix!.text()
+    expect(suffixBody).not.toContain('AAA')
+    expect(suffixBody).toContain('BBB')
+  })
+
+  test('400 on a malformed offset', async () => {
+    const store = new MemoryStreamStore()
+    await seed(store, 'req-bad')
+    const result = routeDurableInferenceReadRequest(
+      req(`${durableInferenceReadUrl('req-bad')}?offset=nope!`),
+      {
+        durableStream: () => store,
+        enabled: true,
+        nowEpochMillis: () => NOW,
+      },
+    )
+    expect(result?.status).toBe(400)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.ts
@@ -1,0 +1,125 @@
+// Durable read / resume route for streaming Khala completions (durable-stream
+// Rank-1, #6058). Serves the persisted token stream of an in-flight or completed
+// completion so a client that dropped mid-generation can reconnect and replay
+// the suffix from its last offset, reconstructing the full completion.
+//
+//   GET /v1/chat/completions/durable/{requestId}?offset=<last-offset>
+//
+// THIS ROUTE NEVER METERS. It reads stored bytes only (`replayFromOffset`), so a
+// reconnect, a multi-tab share, or a CDN catch-up hit is FREE. Settlement fired
+// exactly once on the original upstream EOF (the producer drain in
+// `chat-completions-routes.ts`); it can never fire here.
+//
+// The opaque request id carries no prompt/credential material, and the persisted
+// frames are the same `chat.completion.chunk` SSE the client already received, so
+// the durable read surface is safe to expose. `Stream-Closed` is the clean EOF.
+//
+// FAIL-SAFE: this route is dispatched only when the inference gateway flag is on
+// AND a durable store factory is wired. Off / unwired => it returns `undefined`
+// and the worker router falls through (404), with no behaviour change.
+
+import {
+  type DurableInferenceStreamStore,
+  replayFromOffset,
+} from './durable-inference-proxy'
+
+const DURABLE_PREFIX = '/v1/chat/completions/durable/'
+
+export interface DurableInferenceReadDeps {
+  // Whether the inference gateway is enabled (the durable read shares the gateway
+  // flag — it is inert/404 when the gateway is off).
+  readonly enabled: boolean
+  // Per-request durable store factory (the SAME the chat route uses to persist).
+  readonly durableStream: DurableInferenceStreamStore | undefined
+  // Deterministic clock (epoch ms) for the durable log's TTL/offset bookkeeping.
+  readonly nowEpochMillis: () => number
+}
+
+// Extract the request id from a durable read path, or undefined if not a durable
+// read URL.
+const requestIdFromPath = (pathname: string): string | undefined => {
+  if (!pathname.startsWith(DURABLE_PREFIX)) {
+    return undefined
+  }
+  const raw = pathname.slice(DURABLE_PREFIX.length)
+  if (raw.length === 0 || raw.includes('/')) {
+    return undefined
+  }
+  return decodeURIComponent(raw)
+}
+
+// Dispatch a durable inference read. Returns `undefined` when the request is not
+// a durable read URL (the worker router falls through). When it IS a durable read
+// URL but the gateway is off / unwired / the id is unknown, returns the matching
+// 404/400/200 Response so the surface is honest.
+export const routeDurableInferenceReadRequest = (
+  request: Request,
+  deps: DurableInferenceReadDeps,
+): Response | undefined => {
+  const url = new URL(request.url)
+  const requestId = requestIdFromPath(url.pathname)
+  if (requestId === undefined) {
+    return undefined
+  }
+
+  // Shares the gateway flag: inert/404 when the gateway is off.
+  if (!deps.enabled || deps.durableStream === undefined) {
+    return new Response(JSON.stringify({ error: 'not_found' }), {
+      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
+      status: 404,
+    })
+  }
+
+  if (request.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'method_not_allowed' }), {
+      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
+      status: 405,
+    })
+  }
+
+  const store = deps.durableStream(requestId)
+  if (store === undefined) {
+    return new Response(JSON.stringify({ error: 'not_found' }), {
+      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
+      status: 404,
+    })
+  }
+
+  const replay = replayFromOffset({
+    nowMs: deps.nowEpochMillis(),
+    offset: url.searchParams.get('offset') ?? undefined,
+    requestId,
+    store,
+  })
+
+  // Unknown request id (no durable stream) → 404.
+  if (replay === undefined) {
+    return new Response(JSON.stringify({ error: 'not_found' }), {
+      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
+      status: 404,
+    })
+  }
+
+  // Malformed offset → 400.
+  if (replay.status === 400) {
+    return new Response(JSON.stringify({ error: 'invalid_offset' }), {
+      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
+      status: 400,
+    })
+  }
+
+  // Replay the stored SSE suffix. `Stream-Next-Offset` lets the client resume
+  // from exactly where it left off; `Stream-Closed` signals the completion EOF.
+  const headers: Record<string, string> = {
+    'cache-control': 'no-store',
+    'content-type': replay.contentType,
+    'stream-next-offset': replay.nextOffset,
+  }
+  if (replay.upToDate) {
+    headers['stream-up-to-date'] = 'true'
+  }
+  if (replay.streamClosed) {
+    headers['stream-closed'] = 'true'
+  }
+  return new Response(replay.body, { headers, status: 200 })
+}

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -50,6 +50,10 @@ type WorkerRouteDependencies = Readonly<{
   routeForumRequest: OptionalEffectRoute
   routeImageGenerationRequest: OptionalEffectRoute
   routeModelRetrieveRequest: OptionalEffectRoute
+  // Durable inference resume read GET /v1/chat/completions/durable/{requestId}
+  // (durable-stream Rank-1, #6058 — the path-param resume surface the exact-route
+  // registry cannot match). Reads stored bytes only; NEVER meters.
+  routeDurableInferenceReadRequest: OptionalEffectRoute
   routeMulletRequest: OptionalEffectRoute
   routeOmniRequest: OptionalEffectRoute
   routeOnboardingRequest: OptionalEffectRoute
@@ -264,6 +268,17 @@ export const makeWorkerRouteRequest =
 
       if (modelRetrieveResponse !== undefined) {
         return yield* modelRetrieveResponse
+      }
+
+      // Durable inference resume read (durable-stream Rank-1, #6058): the
+      // path-param resume surface for a dropped streaming completion. Reads stored
+      // bytes only — never meters. INERT-gated in the handler (shares the gateway
+      // flag); off/unwired => undefined and the router falls through.
+      const durableInferenceReadResponse =
+        dependencies.routeDurableInferenceReadRequest(request, env, ctx)
+
+      if (durableInferenceReadResponse !== undefined) {
+        return yield* durableInferenceReadResponse
       }
 
       const threadFileResponse = dependencies.routeThreadFileRequest(

--- a/apps/openagents.com/workers/api/tsconfig.json
+++ b/apps/openagents.com/workers/api/tsconfig.json
@@ -3,6 +3,11 @@
   "compilerOptions": {
     "lib": ["ES2022", "WebWorker"],
     "noEmit": true,
+    // The consumed `@openagentsinc/durable-stream` package uses explicit `.ts`
+    // extensions in its internal imports (its own deliberate style). This Worker
+    // is `noEmit`, so allowing `.ts` import specifiers here only affects
+    // typechecking of that package's source, not any emitted output.
+    "allowImportingTsExtensions": true,
     "types": ["@cloudflare/workers-types"]
   },
   "include": ["src/**/*", "vitest.config.ts", "wrangler.jsonc"]

--- a/apps/openagents.com/workers/api/wrangler.jsonc
+++ b/apps/openagents.com/workers/api/wrangler.jsonc
@@ -173,6 +173,13 @@
         "name": "MDK_TIPS_BUFFER",
         "class_name": "MdkTipsBufferContainer",
       },
+      // Durable-stream Rank-1 resumable inference (#6058). One SQLite-class DO
+      // per request id holds that completion's durable offset log. INERT unless
+      // INFERENCE_DURABLE_STREAM_ENABLED is on AND the producer is wired.
+      {
+        "name": "INFERENCE_DURABLE_STREAM",
+        "class_name": "DurableInferenceStreamObject",
+      },
     ],
   },
   "migrations": [
@@ -191,6 +198,10 @@
     {
       "tag": "v4",
       "new_sqlite_classes": ["MdkTipsBufferContainer"],
+    },
+    {
+      "tag": "v5",
+      "new_sqlite_classes": ["DurableInferenceStreamObject"],
     },
   ],
   "env": {

--- a/bun.lock
+++ b/bun.lock
@@ -227,6 +227,7 @@
         "@liquid-js/qrcode-generator": "1.1.6",
         "@moneydevkit/api-contract": "0.1.36",
         "@openagentsinc/agent-runtime-schema": "workspace:*",
+        "@openagentsinc/durable-stream": "workspace:*",
         "@openagentsinc/email-templates": "workspace:*",
         "@openagentsinc/mcp-contract": "workspace:*",
         "@openagentsinc/mullet-schema": "workspace:*",


### PR DESCRIPTION
Part of EPIC #6056. Closes #6058 (Phase B / Rank-1 of the durable-stream roadmap, §3). **DO NOT auto-merge — orchestrator reviews/merges.**

Makes long-running Khala inference **resumable on disconnect**: persist the upstream provider token stream into a per-request durable offset log (`@openagentsinc/durable-stream`), hand the client a resumable read URL, and resume by offset on reconnect so a dropped chat stops being lost paid work.

## Durable-proxy design (persist → resume-by-offset)

- `inference/durable-inference-proxy.ts` — `teeUpstreamToDurable` tees each upstream frame into the durable log **and** to the live client (framed as today's `chat.completion.chunk`), then **closes the stream (`Stream-Closed`) on EOF**. `replayFromOffset` reads stored bytes only and returns the exact suffix from any offset + `Stream-Next-Offset`/`Stream-Closed`. The core uses the package's `StreamStore` port (the *same* port the DO implements), so it is fully Bun-unit-testable with `MemoryStreamStore` — production logic is identical.
- `inference/durable-inference-read-routes.ts` — `GET /v1/chat/completions/durable/{requestId}?offset=<last>`. A **prefix dispatcher**, not an exact route, so the exact-route manifest is untouched (no manifest update needed). Reads stored bytes only.
- `DurableInferenceStreamObject` DO (SQLite-class binding `INFERENCE_DURABLE_STREAM`, wrangler migration `v5`) wraps the package's `SqliteStreamStore` + DO-alarm TTL/expiry. **Storage bounded** by a 1h TTL.
- The streaming response advertises the resume URL via `openagents-durable-stream-url` (the opaque request id carries no prompt/credential material — no leakage into any cacheable surface).

## Metering exactly-once on EOF (the audit's flagged risk)

Settlement fires **EXACTLY ONCE**, on the single real upstream EOF — the producer drain in `buildTerminalFrame`, which is the **one existing `Effect.runPromise` boundary** (budget honored). It **NEVER** fires on a resume/replay/catch-up read: `replayFromOffset` and the read route have **no metering hook at all**. Replays + CDN hits are free; the receipt attaches on true completion. The money path is **not forked** — reuses the existing metering hook + receipt shape; honors INVARIANTS (auth, balance gate, RL-3).

How it's tested:
- `teeUpstreamToDurable` calls `onEof` (where the route meters) exactly once on a clean drain, never on the fault path.
- Explicit test: real producer drain meters once → then 5 reconnect/catch-up reads → metering count **stays 1** (no double-bill).
- Route-level: flag-on persists + advertises the resume URL + meters once; a replay read of the persisted completion **does not re-bill**; an upstream fault closes the stream **without** metering (receipt-first, never an estimate).

## Fail-safe flag (`INFERENCE_DURABLE_STREAM_ENABLED`, default OFF)

With the flag off, no store factory wired, or a factory returning `undefined`/throwing, the streaming route degrades to **TODAY's pass-through, byte-for-byte unchanged** (idempotent). The LIVE Worker ships the flag-gated path with the producer factory left `undefined` (NEEDS-OWNER: wire the DO-fetch producer + read-route `durableStream` to `env.INFERENCE_DURABLE_STREAM`), so prod stays inert; the full durable path + metering-once is proven by tests on the identical `StreamStore` port. Existing 600 inference tests still pass (behavior preserved).

## Tests / checks

Green: `durable-inference-proxy.test.ts` (persist; resume-from-offset replays the suffix and reconstructs the full completion; **metering once on EOF + never on replay**; fault → no metering), `durable-inference-read-routes.test.ts` (inert 404 off/unwired, replay suffix + resume headers, never meters), route-level `chat-completions-routes.test.ts` durable cases (incl. flag-off → pass-through unchanged). `bun run --cwd apps/openagents.com/workers/api test -- src/inference/` (53 files, 600 tests) + `typecheck` + `check:architecture` (budget 103→105 for the two new Response surfaces, documented in the script) + `check:effect-topology` + exact-route manifest + the `durable-stream`/`sync-worker` packages all green. Not deployed.

Pre-existing reds in unrelated suites (coding-quick-win/ecommerce/agent-registration Schema error-message formatting, AGENTS.md sha drift) reproduce on clean `origin/main` and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)