### PR TITLE
Khala-code: pre-screen allows pinned CDN libs (three.js) + inject acceptance contract for verifiable games

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/acceptance-spec.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-spec.ts
@@ -114,6 +114,54 @@ const looksLikeCrossyRoad = (text: string): boolean => {
   )
 }
 
+// ---------------------------------------------------------------------------
+// ACCEPTANCE-CONTRACT GUIDANCE (EPIC #6017 — "turn intent into tests it must
+// pass"). A generated game is only execution-VERIFIABLE if it EXPOSES the state
+// hooks the headless runner drives. Left unsaid, a model writes a self-contained
+// game that plays fine for a human but exposes nothing the runner can read, so
+// every executed check fails honestly and the artifact never reaches an accepted
+// outcome. So we tell the model the contract up front, gateway-side, as guidance
+// — additive to (never clobbering) the identity prompt. This is the SAME `window`
+// state contract the runner asserts (`acceptance-runner/runner.ts`).
+//
+// SCOPED + EXTENSIBLE: the contract text is keyed on the spec `kind`, so the
+// crossy-road target gets the crossy-road hooks and a future lane adds its own
+// branch here without touching the route. A request with no executable lane gets
+// no contract guidance (returns undefined).
+// ---------------------------------------------------------------------------
+
+// The crossy-road `window` state contract, mirrored from the runner's documented
+// hooks. Concrete and copy-pasteable so the model wires it deterministically.
+const CROSSY_ROAD_ACCEPTANCE_CONTRACT_GUIDANCE = [
+  'ACCEPTANCE CONTRACT (REQUIRED so the game is automatically verifiable):',
+  'In addition to building a great playable game, you MUST expose these hooks on `window` so an automated runner can drive and check it:',
+  '- `window.__openagentsCrossyRoadState()` returns an object: { player: { x, y, z }, camera: { position: { x, y, z } }, progress: number, worldRowsAhead?: number, started?: boolean, loopTicks?: number }. `player` is the player world-unit position; `camera.position` is the camera world position; `progress` is forward tiles travelled; `worldRowsAhead` is distinct rows generated ahead of the player; `started` is true once play begins; `loopTicks` increments each update tick.',
+  '- A PLAY control: either `window.__openagentsCrossyRoadStart()` OR a clickable element with id `start-btn` or `play` that hides the start overlay and begins the update loop.',
+  '- `window.__openagentsCrossyRoadRestart()` resets the player position and progress back to the start.',
+  'Keep these hooks accurate every frame (e.g. update `progress`, `loopTicks`, and the player/camera positions as the game runs). They are read-only probes for verification and must not change the gameplay a human sees.',
+].join('\n')
+
+// Map a selected acceptance spec to its model-facing contract guidance. Keyed on
+// `kind` so each lane owns its contract; exhaustive so a new lane must add text.
+export const acceptanceContractGuidanceForSpec = (
+  spec: AcceptanceSpec,
+): string => {
+  switch (spec.kind) {
+    case 'crossy_road_single_html':
+      return CROSSY_ROAD_ACCEPTANCE_CONTRACT_GUIDANCE
+  }
+}
+
+// Resolve the acceptance-contract guidance for a request, or undefined when the
+// request has no executable acceptance lane (so no contract is injected). Pure +
+// Worker-safe; the route injects the returned text as a leading system message.
+export const acceptanceContractGuidanceForRequest = (
+  request: AcceptanceIntentRequest,
+): string | undefined => {
+  const spec = intentToAcceptanceSpec(request)
+  return spec === undefined ? undefined : acceptanceContractGuidanceForSpec(spec)
+}
+
 // Intent -> AcceptanceSpec. For the khala-code crossy-road lane this returns the
 // concrete bounded spec. For other prompts in the khala-code lane today it falls back
 // to the crossy-road spec (the only executable lane built so far); a future

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -9,6 +9,11 @@ import {
   handleChatCompletions,
   isInferenceGatewayEnabled,
 } from './chat-completions-routes'
+import {
+  acceptanceContractGuidanceForRequest,
+  crossyRoadAcceptanceSpec,
+  acceptanceContractGuidanceForSpec,
+} from './acceptance-spec'
 import { replayFromOffset } from './durable-inference-proxy'
 import { decideFairShare, decideSpendCap } from './inference-abuse-controls'
 import {
@@ -1819,5 +1824,125 @@ describe('POST /v1/chat/completions — durable-stream resumable inference (#605
     expect(text).toContain('"content":"safe"')
     expect(text.trimEnd().endsWith('data: [DONE]')).toBe(true)
     expect(captured).toHaveLength(1)
+  })
+})
+
+// GAP 2 (EPIC #6017 — "turn intent into tests it must pass"): the gateway must
+// inject the acceptance-contract guidance for an `openagents/khala-code` coding
+// request so a produced game is drivable/verifiable by default — ADDITIVELY,
+// without clobbering the identity prompt, and scoped to khala-code (not all Khala
+// models, not non-coding).
+describe('Khala-code acceptance-contract injection', () => {
+  const recordingAdapter = (
+    id: string,
+    captured: Array<ReadonlyArray<{ role: string; content: string }>>,
+  ): InferenceProviderAdapter => ({
+    complete: request =>
+      Effect.sync(() => {
+        captured.push(
+          request.messages.map(m => ({ content: m.content, role: m.role })),
+        )
+        return {
+          content: 'ok',
+          finishReason: 'stop',
+          servedModel: request.model,
+          usage: { completionTokens: 4, promptTokens: 4, totalTokens: 8 },
+        }
+      }),
+    id,
+    stream: () => Effect.sync(() => []),
+  })
+
+  test('injects the acceptance contract AND the identity prompt for khala-code (additive)', async () => {
+    const captured: Array<ReadonlyArray<{ role: string; content: string }>> = []
+    const registry = new InferenceProviderRegistry()
+    registry.register(recordingAdapter(FIREWORKS_ADAPTER_ID, captured))
+
+    await run(
+      handleChatCompletions(
+        chatRequest({
+          messages: [
+            {
+              content: 'build a really high quality crossy road game with three.js',
+              role: 'user',
+            },
+          ],
+          model: KHALA_CODE_MODEL_ID,
+        }),
+        baseDeps({ lanePlan: selectAdapterPlan, registry }),
+      ),
+    )
+    expect(captured).toHaveLength(1)
+    const messages = captured[0]!
+    const systemContents = messages
+      .filter(m => m.role === 'system')
+      .map(m => m.content)
+    // The identity prompt is still present (not clobbered).
+    expect(systemContents).toContain(KHALA_IDENTITY_SYSTEM_PROMPT)
+    // The acceptance contract is present and names the runner's state hooks.
+    const contract = acceptanceContractGuidanceForSpec(crossyRoadAcceptanceSpec())
+    expect(systemContents).toContain(contract)
+    expect(contract).toContain('__openagentsCrossyRoadState')
+    expect(contract).toContain('__openagentsCrossyRoadRestart')
+    // The original user intent is preserved.
+    expect(
+      messages.some(m => m.role === 'user' && m.content.includes('crossy road')),
+    ).toBe(true)
+  })
+
+  test('does NOT inject the acceptance contract for a non-code Khala model', async () => {
+    const captured: Array<ReadonlyArray<{ role: string; content: string }>> = []
+    const registry = new InferenceProviderRegistry()
+    registry.register(recordingAdapter(VERTEX_GEMINI_ADAPTER_ID, captured))
+
+    await run(
+      handleChatCompletions(
+        chatRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: KHALA_MINI_MODEL_ID,
+        }),
+        baseDeps({ lanePlan: selectAdapterPlan, registry }),
+      ),
+    )
+    expect(captured).toHaveLength(1)
+    const systemContents = captured[0]!
+      .filter(m => m.role === 'system')
+      .map(m => m.content)
+    // khala-mini still gets identity, but NOT the code acceptance contract.
+    expect(systemContents).toContain(KHALA_IDENTITY_SYSTEM_PROMPT)
+    expect(
+      systemContents.some(c => c.includes('__openagentsCrossyRoadState')),
+    ).toBe(false)
+  })
+
+  test('does NOT inject the acceptance contract for a non-Khala model', async () => {
+    const captured: Array<ReadonlyArray<{ role: string; content: string }>> = []
+    const registry = new InferenceProviderRegistry()
+    registry.register(recordingAdapter(STUB_ECHO_ADAPTER_ID, captured))
+
+    await run(
+      handleChatCompletions(
+        chatRequest({
+          messages: [{ content: 'build a crossy road game', role: 'user' }],
+          model: 'stub-model',
+        }),
+        baseDeps({ registry }),
+      ),
+    )
+    expect(captured).toHaveLength(1)
+    const systemContents = captured[0]!
+      .filter(m => m.role === 'system')
+      .map(m => m.content)
+    expect(systemContents).toHaveLength(0)
+  })
+
+  test('the contract resolver is scoped to a khala-code intent and is extensible', () => {
+    // A crossy-road intent resolves the crossy-road contract.
+    const guidance = acceptanceContractGuidanceForRequest({
+      messages: [{ content: 'build a crossy road game', role: 'user' }],
+      model: KHALA_CODE_MODEL_ID,
+    })
+    expect(guidance).toBeDefined()
+    expect(guidance).toContain('__openagentsCrossyRoadState')
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -39,7 +39,10 @@ import {
   type AcceptanceJobQueue,
   enqueueAcceptanceJob,
 } from './acceptance-dispatch'
-import { intentToAcceptanceSpec } from './acceptance-spec'
+import {
+  acceptanceContractGuidanceForRequest,
+  intentToAcceptanceSpec,
+} from './acceptance-spec'
 import {
   KHALA_CODE_VERIFIER_WORKER_ID,
   type KhalaCodeVerificationVerdict,
@@ -342,6 +345,40 @@ const withKhalaIdentitySystemPrompt = (
   ]
 }
 
+// GATEWAY-SIDE KHALA-CODE ACCEPTANCE-CONTRACT INJECTION (EPIC #6017 — "turn intent
+// into tests it must pass"). For an `openagents/khala-code` CODING request whose
+// intent maps to an executable acceptance lane, prepend the acceptance-contract
+// guidance (the runner's `window` state hooks the artifact must expose) as a
+// leading `system` message, so a game Khala-code produces is drivable/verifiable
+// by default. It is scoped to khala-code (not all Khala models / not all code) and
+// to the matched rubric/target (today: crossy-road); a request with no executable
+// lane gets no contract. ADDITIVE: it composes WITH the identity prompt and never
+// clobbers it — `withKhalaIdentitySystemPrompt` runs first and prepends identity,
+// then this prepends the contract AHEAD of identity (identity stays leading-most
+// after both run, so the identity contract is never weakened).
+const withKhalaCodeAcceptanceContract = (
+  messages: ReadonlyArray<InferenceMessage>,
+  requestedModel: string,
+  clientMessages: ReadonlyArray<InferenceMessage>,
+): ReadonlyArray<InferenceMessage> => {
+  if (requestedModel !== KHALA_CODE_MODEL_ID) {
+    return messages
+  }
+  // Derive the contract from the ORIGINAL client intent (not the gateway-injected
+  // system messages). Undefined => no executable lane => no contract injected.
+  const guidance = acceptanceContractGuidanceForRequest({
+    messages: clientMessages.map(message => ({
+      content: message.content,
+      role: message.role,
+    })),
+    model: requestedModel,
+  })
+  if (guidance === undefined) {
+    return messages
+  }
+  return [{ content: guidance, role: 'system' }, ...messages]
+}
+
 const toInferenceRequest = (
   body: typeof ChatCompletionsRequestBody.Type,
   raw: Record<string, unknown>,
@@ -350,7 +387,19 @@ const toInferenceRequest = (
   const clientMessages: ReadonlyArray<InferenceMessage> = body.messages.map(
     message => ({ content: message.content, role: message.role }),
   )
-  const messages = withKhalaIdentitySystemPrompt(clientMessages, requestedModel)
+  // Compose gateway-side guidance: identity first (so it lands ahead of client
+  // steer), then the khala-code acceptance contract prepended ahead of identity.
+  // Order after both: [acceptance-contract, identity, ...client]. Both are
+  // additive; neither clobbers the other.
+  const withIdentity = withKhalaIdentitySystemPrompt(
+    clientMessages,
+    requestedModel,
+  )
+  const messages = withKhalaCodeAcceptanceContract(
+    withIdentity,
+    requestedModel,
+    clientMessages,
+  )
   const { messages: _messages, model: _model, stream: _stream, ...rest } = raw
   return {
     messages,

--- a/apps/openagents.com/workers/api/src/inference/khala-code-verifier.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-code-verifier.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, test } from 'vitest'
 
 import type { AcceptanceVerdict } from './acceptance-runner/verdict'
@@ -121,5 +124,110 @@ describe('Khala code verifier — honest downgrade (EPIC #6017)', () => {
     expect(verdict.scalarReward).toBeGreaterThan(0)
     expect(verdict.scalarReward).toBeLessThan(1)
     expect(verdict.failedChecks.length).toBeGreaterThan(0)
+  })
+})
+
+// GAP 1 (EPIC #6017): the pre-screen must ALLOW a faithful three.js game that
+// loads three.js from a pinned, well-known CDN (so it reaches the authoritative
+// execution verifier), while STILL rejecting arbitrary/unknown external assets.
+describe('Khala code verifier — pinned-CDN library allowance', () => {
+  const threeJsGame = (cdnUrl: string): string => `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>three.js crossy road</title>
+<style>body{margin:0}#game{display:block}</style>
+<script src="${cdnUrl}"></script>
+</head>
+<body>
+  <canvas id="game" width="960" height="540"></canvas>
+  <script>
+    const scene = new THREE.Scene();
+    function loop(){ requestAnimationFrame(loop); }
+    loop();
+  </script>
+</body>
+</html>`
+
+  test('a three.js game from each allowlisted CDN PASSES the pre-screen (reaches execution)', () => {
+    const cdnUrls = [
+      'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js',
+      'https://unpkg.com/three@0.160.0/build/three.min.js',
+      'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js',
+      'https://esm.sh/three@0.160.0',
+    ]
+    for (const url of cdnUrls) {
+      const prescreen = prescreenKhalaCodeArtifact(threeJsGame(url))
+      expect(prescreen.attemptExecution).toBe(true)
+      expect(
+        prescreen.checks.find(c => c.id === 'single_html_file')?.passed,
+      ).toBe(true)
+      expect(prescreen.allowedCdnLibraries.map(l => l.url)).toContain(url)
+      expect(prescreen.allowedCdnLibraries.every(l => l.pinned)).toBe(true)
+    }
+  })
+
+  test('an ES-module import of three.js from an allowlisted CDN also PASSES', () => {
+    const html = `<!doctype html>
+<html><head><meta charset="utf-8"><title>g</title></head>
+<body>
+  <canvas id="game"></canvas>
+  <script type="module">
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+    const scene = new THREE.Scene();
+  </script>
+</body></html>`
+    const prescreen = prescreenKhalaCodeArtifact(html)
+    expect(prescreen.attemptExecution).toBe(true)
+    expect(prescreen.allowedCdnLibraries).toHaveLength(1)
+    expect(prescreen.allowedCdnLibraries[0]?.host).toBe('cdn.jsdelivr.net')
+  })
+
+  test('an arbitrary/unknown external script is STILL rejected', () => {
+    const prescreen = prescreenKhalaCodeArtifact(
+      threeJsGame('https://evil.example.test/three.min.js'),
+    )
+    expect(prescreen.attemptExecution).toBe(false)
+    expect(
+      prescreen.checks.find(c => c.id === 'single_html_file')?.passed,
+    ).toBe(false)
+    expect(prescreen.allowedCdnLibraries).toHaveLength(0)
+  })
+
+  test('an external stylesheet/image is STILL rejected even with an allowlisted script', () => {
+    const html = `<!doctype html>
+<html><head>
+  <link rel="stylesheet" href="https://unpkg.com/some-theme/style.css">
+  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+</head><body><canvas id="game"></canvas></body></html>`
+    expect(prescreenKhalaCodeArtifact(html).attemptExecution).toBe(false)
+  })
+
+  test('a mix of allowlisted + one unknown script host is rejected', () => {
+    const html = `<!doctype html>
+<html><head>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+  <script src="https://random-host.example/extra.js"></script>
+</head><body><canvas id="game"></canvas></body></html>`
+    expect(prescreenKhalaCodeArtifact(html).attemptExecution).toBe(false)
+  })
+
+  test('the committed passing north-star artifact now PASSES the pre-screen', () => {
+    const artifactPath = fileURLToPath(
+      new URL(
+        '../../../../../../scripts/khala-demo/artifacts/khala-crossy-road-northstar-passing.v1.html',
+        import.meta.url,
+      ),
+    )
+    const html = readFileSync(artifactPath, 'utf8')
+    const prescreen = prescreenKhalaCodeArtifact(html)
+    expect(prescreen.attemptExecution).toBe(true)
+    expect(
+      prescreen.checks.find(c => c.id === 'single_html_file')?.passed,
+    ).toBe(true)
+    // It pulls three.js from cdnjs (pinned to r128) — exactly the allowance.
+    expect(
+      prescreen.allowedCdnLibraries.some(
+        l => l.host === 'cdnjs.cloudflare.com' && l.pinned,
+      ),
+    ).toBe(true)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/khala-code-verifier.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-code-verifier.ts
@@ -50,12 +50,27 @@ export type KhalaCodePrescreenCheck = Readonly<{
   failureReason?: string | undefined
 }>
 
+// A single external library reference the pre-screen ALLOWED through (an
+// allowlisted CDN host). `pinned` records whether it carries a concrete version
+// token — we prefer pinned (a `@latest`/unversioned URL can change under us),
+// but an allowlisted-yet-unpinned URL is allowed (execution is the authority).
+export type KhalaCodeAllowedCdnLibrary = Readonly<{
+  url: string
+  host: string
+  pinned: boolean
+}>
+
 export type KhalaCodePrescreen = Readonly<{
   // Whether the artifact is worth ATTEMPTING to execute (one self-contained HTML file
   // with a script + a game surface). This gates execution; it never verifies behavior.
   attemptExecution: boolean
   checks: ReadonlyArray<KhalaCodePrescreenCheck>
   html: string | undefined
+  // The external library references the pre-screen allowed through (allowlisted
+  // CDN hosts only). Empty for a fully self-contained artifact. Surfaced so the
+  // receipt/runner can see exactly which pinned CDN libs an artifact pulled and
+  // flag any that are unpinned.
+  allowedCdnLibraries: ReadonlyArray<KhalaCodeAllowedCdnLibrary>
 }>
 
 export type KhalaCodeVerificationCommand = Readonly<{
@@ -104,12 +119,132 @@ export type KhalaCodeVerifierInput = Readonly<{
   acceptance?: AcceptanceVerdict | undefined
 }>
 
-const externalAssetPattern =
-  /<(?:script|link|img|audio|video)\b[^>]*(?:src|href)\s*=\s*["'](?:https?:)?\/\//iu
+// ALLOWLISTED CDN LIBRARY HOSTS (EPIC #6017 — pre-screen CDN allowance).
+//
+// WHY: the north-star prompt is "build a crossy road game WITH three.js". A
+// FAITHFUL artifact loads three.js (and its standard addons) from a well-known
+// CDN, so a blanket "any external <script src> => reject" gate fails a correct
+// artifact at the cheap pre-screen and it never reaches the AUTHORITATIVE
+// execution verifier. The fix is conservative: a small allowlist of pinned,
+// well-known library CDN HOSTS for `<script src>` only — three.js + its
+// addons load from these in practice. Everything else external is STILL
+// rejected: an unknown/arbitrary script host, and ANY external stylesheet,
+// image, audio, or video. The gate's real purpose (no random external assets)
+// is preserved; the only relaxation is "a script tag pointing at a known
+// library CDN is allowed through the pre-screen so the runner can execute it."
+//
+// This is NOT intent routing or retrieval selection — it is a bounded, exact,
+// documented host allowlist over a static source gate (workspace semantic-routing
+// rule §"Deterministic parsing is acceptable ... for bounded fields").
+const ALLOWLISTED_CDN_HOSTS: ReadonlyArray<string> = [
+  'unpkg.com',
+  'cdn.jsdelivr.net',
+  'cdnjs.cloudflare.com',
+  'esm.sh',
+  'esm.run',
+  'ga.jspm.io',
+]
 
-const scriptSrcPattern = /<script\b[^>]*\bsrc\s*=/iu
-const linkedStylesheetPattern =
-  /<link\b[^>]*\brel\s*=\s*["'][^"']*stylesheet[^"']*["'][^>]*\bhref\s*=/iu
+// A host is allowlisted iff it exactly matches an entry or is a subdomain of one
+// (e.g. `fastly.jsdelivr.net` for `cdn.jsdelivr.net`'s parent is NOT auto-allowed;
+// only declared hosts and their subdomains). Case-insensitive.
+const isAllowlistedCdnHost = (host: string): boolean => {
+  const lower = host.toLowerCase()
+  return ALLOWLISTED_CDN_HOSTS.some(
+    allowed => lower === allowed || lower.endsWith(`.${allowed}`),
+  )
+}
+
+// Heuristic "looks version-pinned" check over a CDN URL. We PREFER pinned
+// versions (a stale `@latest` / unversioned path can silently change under us),
+// so an allowlisted-but-unpinned URL is still allowed through the pre-screen
+// (execution is the authority) but we record it. A URL is treated as pinned when
+// it carries a concrete version token: `@1.2.3`, `/three.js/r128/`, `/0.160.0/`,
+// `?v=...`, etc. Bounded + documented; never used to REJECT, only to annotate.
+const looksVersionPinned = (url: string): boolean =>
+  /@\d|\/(?:r?\d+(?:\.\d+)*)\//iu.test(url) || /[?&]v(?:er(?:sion)?)?=/iu.test(url)
+
+// Pull the host out of an absolute or protocol-relative URL. Returns undefined
+// for a relative/inline reference (which is never an EXTERNAL asset anyway).
+const externalUrlHost = (url: string): string | undefined => {
+  const normalized = url.startsWith('//') ? `https:${url}` : url
+  try {
+    return new URL(normalized).host
+  } catch {
+    return undefined
+  }
+}
+
+// Match each `<script ... src="URL">` (classic script tag). `src` may be quoted
+// or unquoted; the URL is captured for host classification.
+const scriptSrcUrlPattern =
+  /<script\b[^>]*\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s">]+))/giu
+
+// Any EXTERNAL stylesheet / image / audio / video, or an external `<link>` of
+// any rel — NONE of these are allowlisted (the allowance is for library scripts
+// only). Protocol-relative or absolute http(s).
+const externalNonScriptAssetPattern =
+  /<(?:link|img|audio|video)\b[^>]*(?:src|href)\s*=\s*["'](?:https?:)?\/\//iu
+
+// An ES-module / importmap reference to an external URL inside a `<script>`
+// body, e.g. `import * as THREE from 'https://.../three.module.js'` or an
+// `<script type="importmap">{ "imports": { "three": "https://..." } }`. These
+// are classified the same way as a classic `src` (allowlisted CDN host => ok).
+const moduleImportUrlPattern =
+  /(?:\bimport\b[^'"]*?|["'])((?:https?:)?\/\/[^\s'"]+)/giu
+
+// Collect every EXTERNAL (protocol-relative/absolute) script `src` + module /
+// importmap URL referenced by the HTML. Bare specifiers and relative paths are
+// not external and are ignored.
+const collectExternalScriptUrls = (html: string): ReadonlyArray<string> => {
+  const urls: Array<string> = []
+
+  for (const match of html.matchAll(scriptSrcUrlPattern)) {
+    const url = match[1] ?? match[2] ?? match[3]
+    if (url !== undefined && /^(?:https?:)?\/\//iu.test(url)) {
+      urls.push(url)
+    }
+  }
+
+  // Module imports / importmap URLs inside <script> bodies (e.g. esm.sh /
+  // jsdelivr `three.module.js`).
+  for (const match of html.matchAll(moduleImportUrlPattern)) {
+    const url = match[1]
+    if (url !== undefined && /^(?:https?:)?\/\//iu.test(url)) {
+      urls.push(url)
+    }
+  }
+
+  return urls
+}
+
+// Classify the external script/module URLs into (a) whether EVERY one resolves
+// to an allowlisted CDN host — false on the FIRST non-allowlisted URL, so an
+// unknown CDN / random script host is rejected — and (b) the allowed library
+// references (host + pinned annotation) for the receipt/runner.
+const classifyExternalScripts = (
+  html: string,
+): Readonly<{
+  allAllowlisted: boolean
+  allowed: ReadonlyArray<KhalaCodeAllowedCdnLibrary>
+}> => {
+  // Dedupe URLs — a classic `<script src>` URL is also caught as a quoted string
+  // by the module-import pattern, so the same URL can appear twice.
+  const urls = Array.from(new Set(collectExternalScriptUrls(html)))
+  const allowed: Array<KhalaCodeAllowedCdnLibrary> = []
+  let allAllowlisted = true
+
+  for (const url of urls) {
+    const host = externalUrlHost(url)
+    if (host !== undefined && isAllowlistedCdnHost(host)) {
+      allowed.push({ host, pinned: looksVersionPinned(url), url })
+    } else {
+      allAllowlisted = false
+    }
+  }
+
+  return { allAllowlisted, allowed }
+}
 
 export const extractSingleHtmlArtifact = (
   content: string,
@@ -175,13 +310,28 @@ export const prescreenKhalaCodeArtifact = (
   const artifactText = html ?? content.trim()
   const lower = artifactText.toLowerCase()
 
+  // Classify external script/module refs once: are they ALL allowlisted CDN
+  // libraries, and which allowed library refs (host + pinned) did we see?
+  const externalScripts =
+    html === undefined
+      ? { allAllowlisted: true, allowed: [] as ReadonlyArray<KhalaCodeAllowedCdnLibrary> }
+      : classifyExternalScripts(html)
+
+  // SINGLE-FILE GATE (with the pinned-CDN-library allowance, EPIC #6017):
+  //   - one `<html>...</html>` document, AND
+  //   - NO external stylesheet/image/audio/video and NO external `<link>` of any
+  //     kind (those must be inlined — the gate's real purpose), AND
+  //   - every external `<script src>` / module-import URL resolves to an
+  //     allowlisted, well-known library CDN host (three.js + addons load from
+  //     these). An UNKNOWN/arbitrary external script host fails the gate.
+  // A purely self-contained artifact (no external refs at all) still passes, as
+  // before — `classifyExternalScripts` is vacuously `allAllowlisted` with no URLs.
   const hasSingleHtml =
     html !== undefined &&
     /<html\b/iu.test(html) &&
     /<\/html>/iu.test(html) &&
-    !externalAssetPattern.test(html) &&
-    !scriptSrcPattern.test(html) &&
-    !linkedStylesheetPattern.test(html)
+    !externalNonScriptAssetPattern.test(html) &&
+    externalScripts.allAllowlisted
 
   const hasRunnableSurface =
     hasSingleHtml &&
@@ -195,13 +345,14 @@ export const prescreenKhalaCodeArtifact = (
   const checks: ReadonlyArray<KhalaCodePrescreenCheck> = [
     {
       id: 'single_html_file',
-      label: 'The delivered artifact is one self-contained HTML file.',
+      label:
+        'The delivered artifact is one self-contained HTML file (pinned, well-known CDN library scripts allowed).',
       passed: hasSingleHtml,
       ...(hasSingleHtml
         ? {}
         : {
             failureReason:
-              'Expected one self-contained HTML file with no external script/style/media dependencies.',
+              'Expected one self-contained HTML file: inline all styles/media, and load scripts inline or from a pinned, well-known CDN (three.js + addons via unpkg/jsdelivr/cdnjs/esm.sh). No arbitrary external scripts, stylesheets, images, audio, or video.',
           }),
     },
     {
@@ -219,6 +370,7 @@ export const prescreenKhalaCodeArtifact = (
   ]
 
   return {
+    allowedCdnLibraries: externalScripts.allowed,
     attemptExecution: hasSingleHtml && hasRunnableSurface,
     checks,
     html,


### PR DESCRIPTION
Fixes two real gaps in the Khala-code verification path that the passing-game lane surfaced (`docs/inference/2026-06-23-khala-head-to-head-m8-status.md`, the "genuine executed pass" section). Scope: `apps/openagents.com/workers/api`. **DO NOT auto-merge — orchestrator reviews/merges.**

## GAP 1 (the bug) — pre-screen rejected faithful three.js games

The north-star prompt is "build a crossy road game **with three.js**". A faithful artifact loads three.js from a CDN, but `prescreenKhalaCodeArtifact`'s `single_html_file` check failed on **any** external `<script src>` — so a correct, executable artifact was pre-screen-rejected (`verification:failed`) and never reached the authoritative execution verifier.

**Fix — a conservative pinned-CDN-library allowlist** in the single-HTML pre-screen:

- **Allowlisted CDN hosts** (script tags only): `unpkg.com`, `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `esm.sh`, `esm.run`, `ga.jspm.io` (exact host or a subdomain of one). Covers three.js + its standard addons across the major CDNs.
- Classifies **both** classic `<script src="...">` and **ES-module / importmap URLs** inside `<script>` bodies (`import * as THREE from 'https://.../three.module.js'`). An external script/module URL must resolve to an allowlisted host, or the gate fails.
- **Pinned-version policy:** we *prefer* pinned versions (an `@latest`/unversioned URL can change under us) and record `pinned` per allowed lib on the new `allowedCdnLibraries` field, but an allowlisted-yet-unpinned URL is still allowed through — execution is the authority, not the pre-screen.
- **Still rejected** (the gate's real purpose): an unknown/arbitrary external script host, **and any** external stylesheet, image, audio, or video, and any external `<link>` of any rel — those must be inlined.
- A purely self-contained artifact (no external refs) still passes exactly as before.

The committed passing artifact `scripts/khala-demo/artifacts/khala-crossy-road-northstar-passing.v1.html` (which pulls three.js **r128 from cdnjs**) now **passes the pre-screen** (`attemptExecution:true`) and reaches the verdict path.

This allowlist is a bounded, exact, documented host check over a static source gate — not intent routing or retrieval selection.

## GAP 2 (alignment) — inject the acceptance contract so games are verifiable by default

A generated game is only execution-verifiable if it **exposes the state hooks the headless runner drives**. Left unsaid, a model writes a game that plays fine for a human but exposes nothing the runner can read, so every executed check fails honestly and it never reaches an accepted outcome.

**Fix — gateway-side acceptance-contract injection**, done the same way the just-merged identity prompt is injected:

- For an `openagents/khala-code` coding request whose intent maps to an executable acceptance lane, the gateway prepends the **acceptance contract** (the runner's `window.__openagentsCrossyRoad{State,Start,Restart}` state hooks + the `start-btn`/`play` PLAY control the runner clicks) as a leading `system` message.
- **Scope:** khala-code only (not all Khala models, not all code) and the matched rubric/target — today crossy-road — via `intentToAcceptanceSpec`. A request with no executable lane gets **no** contract.
- **Composition with identity:** additive. `withKhalaIdentitySystemPrompt` runs first (identity prepended), then the contract is prepended ahead of it; final order `[acceptance-contract, identity, ...client]`. Neither clobbers the other; the identity contract is never weakened.
- **Extensible:** the contract text is keyed on the acceptance spec `kind`, so a future lane adds its own branch (`acceptanceContractGuidanceForSpec`) without touching the route.

## Tests

- `khala-code-verifier.test.ts`: a three.js game from each allowlisted CDN passes; an ES-module import from an allowlisted CDN passes; an arbitrary/unknown external script is still rejected; an external stylesheet alongside an allowlisted script is still rejected; a mix of allowlisted + one unknown host is rejected; **the committed north-star artifact now passes**.
- `chat-completions-routes.test.ts`: a khala-code coding request carries **both** the acceptance contract and the identity prompt; khala-mini gets identity but **not** the contract; a non-Khala model gets neither; the contract resolver is scoped + extensible.
- Full inference suite green (**610**), `typecheck` + `check:architecture` + `check:effect-topology` green. No route changes; exact-route manifest unchanged. **Not deployed.**

DO NOT auto-merge — orchestrator reviews/merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)