### PR TITLE
Finish #6046: migrate component styles onto central @openagentsinc/ui tokens (Part of #6046)

### DIFF
--- a/apps/openagents.com/apps/web/package.json
+++ b/apps/openagents.com/apps/web/package.json
@@ -14,6 +14,7 @@
     "@effect/platform-browser": "4.0.0-beta.70",
     "@openagentsinc/autopilot-control-protocol": "workspace:*",
     "@openagentsinc/autopilot-ui": "workspace:*",
+    "@openagentsinc/design-tokens": "workspace:*",
     "@openagentsinc/mcp-contract": "workspace:*",
     "@openagentsinc/mullet-schema": "workspace:*",
     "@openagentsinc/mullet-sim": "workspace:*",

--- a/apps/openagents.com/apps/web/src/styles.css
+++ b/apps/openagents.com/apps/web/src/styles.css
@@ -1,6 +1,21 @@
 @import 'tailwindcss';
 @source "../../../workers/api/src";
 
+/*
+ * #6046: central theme injection.
+ *
+ * The ONE typed token source is `@openagentsinc/design-tokens` (re-exported via
+ * `@openagentsinc/ui/tokens`). `theme.css` is its generated `:root { --oa-*: … }`
+ * projection — importing it makes every `--oa-*` token resolvable here. The two
+ * component barrels below are the ports of the deleted StyleX `create()` blocks
+ * (the `oa-ui-*` / `oa-ai-*` / `oa-autopilot-*` classes); they now reference the
+ * `--oa-*` tokens, so importing them styles the components from the central
+ * theme instead of leaving them unstyled.
+ */
+@import '@openagentsinc/design-tokens/theme.css';
+@import '@openagentsinc/ui/styles.css';
+@import '@openagentsinc/autopilot-ui/styles.css';
+
 @theme {
   --color-background-base: var(--background-base);
   --color-background-stronger: var(--background-stronger);

--- a/apps/openagents.com/apps/web/vite.config.ts
+++ b/apps/openagents.com/apps/web/vite.config.ts
@@ -2,12 +2,12 @@ import { foldkit } from '@foldkit/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 
-// #6046: StyleX removed. The @openagentsinc/ui and @openagentsinc/autopilot-ui
-// packages were already listed as StyleX `externalPackages` here, so their
-// StyleX `create()` blocks were never compiled into this app's CSS — the
-// components render from their own Tailwind utility classes. Removing the
-// StyleX plugin is therefore a no-op for the rendered output, and drops the
-// `@stylexjs/*` dependency from the web build.
+// #6046: theming is centralized in @openagentsinc/design-tokens (the typed
+// --oa-* token source, re-exported via @openagentsinc/ui/tokens) with no build
+// plugin. The @openagentsinc/ui and @openagentsinc/autopilot-ui component
+// stylesheets (and the design-tokens theme.css :root projection) are imported
+// from src/styles.css as plain CSS, so Tailwind/Vite bundle them normally — no
+// style compiler plugin is needed here.
 
 export default defineConfig({
   build: {

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "@effect/platform-browser": "4.0.0-beta.70",
         "@openagentsinc/autopilot-control-protocol": "workspace:*",
         "@openagentsinc/autopilot-ui": "workspace:*",
+        "@openagentsinc/design-tokens": "workspace:*",
         "@openagentsinc/mcp-contract": "workspace:*",
         "@openagentsinc/mullet-schema": "workspace:*",
         "@openagentsinc/mullet-sim": "workspace:*",

--- a/packages/autopilot-ui/package.json
+++ b/packages/autopilot-ui/package.json
@@ -6,7 +6,8 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
-    "./tokens": "./src/tokens.ts"
+    "./tokens": "./src/tokens.ts",
+    "./styles.css": "./src/styles.css"
   },
   "files": [
     "src",

--- a/packages/autopilot-ui/src/domain-styles.css
+++ b/packages/autopilot-ui/src/domain-styles.css
@@ -10,10 +10,10 @@
   gap: 12px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg-secondary);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg-secondary, #151515);
   padding: 16px;
-  color: var(--text);
+  color: var(--oa-color-text, #d7d8e5);
 }
 
 .oa-autopilot-domain-inline-panel {
@@ -23,11 +23,11 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg-secondary);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg-secondary, #151515);
   padding-block: 8px;
   padding-inline: 12px;
-  color: var(--text);
+  color: var(--oa-color-text, #d7d8e5);
 }
 
 .oa-autopilot-domain-sub-panel {
@@ -35,7 +35,7 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
+  border-color: var(--oa-color-outline, #525458);
   background-color: transparent;
   padding: 12px;
 }
@@ -90,27 +90,27 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 14px;
   font-weight: 700;
-  color: var(--primary);
+  color: var(--oa-color-primary, #fff);
 }
 
 .oa-autopilot-domain-label {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
   text-transform: uppercase;
-  color: var(--text-secondary);
+  color: var(--oa-color-text-secondary, #8a8c93);
 }
 
 .oa-autopilot-domain-muted {
   margin: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--oa-color-text-secondary, #8a8c93);
 }
 
 .oa-autopilot-domain-empty {
   margin: 0;
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--oa-color-text-secondary, #8a8c93);
 }
 
 .oa-autopilot-domain-code-primary {
@@ -120,7 +120,7 @@
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 14px;
-  color: var(--primary);
+  color: var(--oa-color-primary, #fff);
 }
 
 .oa-autopilot-domain-code-muted {
@@ -130,7 +130,7 @@
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--oa-color-text-secondary, #8a8c93);
 }
 
 .oa-autopilot-domain-value {
@@ -141,14 +141,14 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 18px;
   font-weight: 700;
-  color: var(--primary);
+  color: var(--oa-color-primary, #fff);
 }
 
 .oa-autopilot-domain-success-value {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
   font-weight: 700;
-  color: var(--success);
+  color: var(--oa-color-success, #00c853);
 }
 
 .oa-autopilot-domain-action-button {
@@ -156,15 +156,15 @@
   height: 32px;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
+  border-radius: var(--oa-radius-md, 4px);
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
+  border-color: var(--oa-color-outline, #525458);
   padding-inline: 12px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
   font-weight: 700;
-  color: var(--primary);
+  color: var(--oa-color-primary, #fff);
 }
 
 .oa-autopilot-domain-action-button:disabled {
@@ -176,10 +176,10 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg-secondary);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg-secondary, #151515);
   padding: 12px;
-  color: var(--text);
+  color: var(--oa-color-text, #d7d8e5);
 }
 
 @media (min-width: 640px) {
@@ -194,8 +194,8 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg, #000);
   padding: 12px;
 }
 
@@ -211,10 +211,10 @@
   gap: 12px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg-secondary);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg-secondary, #151515);
   padding: 12px;
-  color: var(--text);
+  color: var(--oa-color-text, #d7d8e5);
 }
 
 @media (min-width: 640px) {
@@ -229,10 +229,10 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg-secondary);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg-secondary, #151515);
   padding: 12px;
-  color: var(--text);
+  color: var(--oa-color-text, #d7d8e5);
 }
 
 @media (min-width: 640px) {
@@ -247,10 +247,10 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg-secondary);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg-secondary, #151515);
   padding: 12px;
-  color: var(--text);
+  color: var(--oa-color-text, #d7d8e5);
 }
 
 @media (min-width: 640px) {
@@ -265,7 +265,7 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
+  border-color: var(--oa-color-outline, #525458);
   background-color: transparent;
   padding: 12px;
 }
@@ -282,8 +282,8 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg-secondary);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg-secondary, #151515);
   padding: 12px;
 }
 
@@ -302,16 +302,16 @@
 .oa-autopilot-domain-progress-track {
   height: 8px;
   overflow: hidden;
-  border-radius: 4px;
+  border-radius: var(--oa-radius-md, 4px);
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg, #000);
 }
 
 .oa-autopilot-domain-progress-bar {
   height: 100%;
-  background-color: var(--info);
+  background-color: var(--oa-color-info, #2979ff);
 }
 
 .oa-autopilot-domain-command-block {
@@ -319,16 +319,16 @@
   min-width: 0;
   overflow-x: auto;
   white-space: pre;
-  border-radius: 4px;
+  border-radius: var(--oa-radius-md, 4px);
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline);
-  background-color: var(--bg);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg, #000);
   padding-block: 8px;
   padding-inline: 12px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
-  color: var(--primary);
+  color: var(--oa-color-primary, #fff);
 }
 
 .oa-autopilot-domain-chip {
@@ -336,7 +336,7 @@
   height: 24px;
   align-items: center;
   white-space: nowrap;
-  border-radius: 4px;
+  border-radius: var(--oa-radius-md, 4px);
   border-width: 1px;
   border-style: solid;
   padding-inline: 8px;
@@ -347,31 +347,31 @@
 }
 
 .oa-autopilot-domain-chip-neutral {
-  border-color: var(--outline);
+  border-color: var(--oa-color-outline, #525458);
   background-color: transparent;
-  color: var(--text-secondary);
+  color: var(--oa-color-text-secondary, #8a8c93);
 }
 
 .oa-autopilot-domain-chip-success {
-  border-color: var(--success);
-  background-color: color-mix(in srgb, var(--success) 12%, transparent);
-  color: var(--success);
+  border-color: var(--oa-color-success, #00c853);
+  background-color: color-mix(in srgb, var(--oa-color-success, #00c853) 12%, transparent);
+  color: var(--oa-color-success, #00c853);
 }
 
 .oa-autopilot-domain-chip-warning {
-  border-color: var(--warning);
-  background-color: color-mix(in srgb, var(--warning) 12%, transparent);
-  color: var(--warning);
+  border-color: var(--oa-color-warning, #ffb400);
+  background-color: color-mix(in srgb, var(--oa-color-warning, #ffb400) 12%, transparent);
+  color: var(--oa-color-warning, #ffb400);
 }
 
 .oa-autopilot-domain-chip-danger {
-  border-color: var(--danger);
-  background-color: color-mix(in srgb, var(--danger) 12%, transparent);
-  color: var(--danger);
+  border-color: var(--oa-color-danger, #d32f2f);
+  background-color: color-mix(in srgb, var(--oa-color-danger, #d32f2f) 12%, transparent);
+  color: var(--oa-color-danger, #d32f2f);
 }
 
 .oa-autopilot-domain-chip-info {
-  border-color: var(--info);
-  background-color: color-mix(in srgb, var(--info) 12%, transparent);
-  color: var(--info);
+  border-color: var(--oa-color-info, #2979ff);
+  background-color: color-mix(in srgb, var(--oa-color-info, #2979ff) 12%, transparent);
+  color: var(--oa-color-info, #2979ff);
 }

--- a/packages/autopilot-ui/src/view.css
+++ b/packages/autopilot-ui/src/view.css
@@ -10,10 +10,10 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: var(--outline,#525458);
-  background-color: var(--bg-secondary,#151515);
+  border-color: var(--oa-color-outline, #525458);
+  background-color: var(--oa-color-bg-secondary, #151515);
   padding: 12px;
-  color: var(--text,#d7d8e5);
+  color: var(--oa-color-text, #d7d8e5);
 }
 
 @media (min-width: 640px) {
@@ -30,13 +30,13 @@
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 14px;
-  color: var(--primary,#fff);
+  color: var(--oa-color-primary, #fff);
 }
 
 .oa-autopilot-session-adapter {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
-  color: var(--text-secondary,#8a8c93);
+  color: var(--oa-color-text-secondary, #8a8c93);
 }
 
 .oa-autopilot-session-progress-ref {
@@ -46,11 +46,11 @@
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
-  color: var(--text-secondary,#8a8c93);
+  color: var(--oa-color-text-secondary, #8a8c93);
 }
 
 .oa-autopilot-session-empty {
   margin: 0;
   font-size: 14px;
-  color: var(--text-secondary,#8a8c93);
+  color: var(--oa-color-text-secondary, #8a8c93);
 }

--- a/packages/autopilot-ui/test/stylex-migration.test.ts
+++ b/packages/autopilot-ui/test/stylex-migration.test.ts
@@ -69,44 +69,44 @@ const renderHtml = (html: Html): string => {
 describe("Autopilot UI StyleX migration coverage", () => {
   test("selected domain components route through shared StyleX fallback classes", () => {
     const session = {
-      sessionRef: "session.stylex.fixture",
+      sessionRef: "session.token.fixture",
       adapter: "codex",
       state: "running",
     }
     const decision = pendingDecision(decisionRequestFixture)
     const rendered = [
-      NodeStatusBadge({ nodeRef: "node.stylex.fixture", online: true }),
+      NodeStatusBadge({ nodeRef: "node.token.fixture", online: true }),
       ProviderStatusList({
-        providers: [{ provider: "provider.stylex.fixture", online: false }],
+        providers: [{ provider: "provider.token.fixture", online: false }],
       }),
       CloudQuotaPanel({
         creditBalance: 42,
-        compute: { usedRef: "quota.stylex.fixture", meterLabel: "compute" },
+        compute: { usedRef: "quota.token.fixture", meterLabel: "compute" },
       }),
       EarningsPanel({
         balanceSats: 21,
-        entries: [{ ref: "earning.stylex.fixture", amountSats: 21, at: "2026-06-22T00:00:00Z" }],
+        entries: [{ ref: "earning.token.fixture", amountSats: 21, at: "2026-06-22T00:00:00Z" }],
       }),
       DecisionCard({ decision }),
       DecisionActions({
-        decision: { requestId: "decision.stylex.fixture", state: "pending" },
+        decision: { requestId: "decision.token.fixture", state: "pending" },
         readOnly: false,
       }),
       SessionDetail(session, { events: [1] }),
       SessionActions({ session, readOnly: false }),
       AssignmentList({
-        assignments: [{ ref: "assignment.stylex.fixture", state: "available", progress: 50 }],
+        assignments: [{ ref: "assignment.token.fixture", state: "available", progress: 50 }],
       }),
       ArtifactList({
-        artifacts: [{ name: "artifact.txt", digestRef: "digest.stylex.artifact.fixture" }],
+        artifacts: [{ name: "artifact.txt", digestRef: "digest.token.artifact.fixture" }],
       }),
       ReceiptList({
-        receipts: [{ kind: "verify", digestRef: "digest.stylex.receipt.fixture", status: "ok" }],
+        receipts: [{ kind: "verify", digestRef: "digest.token.receipt.fixture", status: "ok" }],
       }),
       VerifyStatus({
         command: ["bun", "test"],
         status: "pending",
-        requiredArtifacts: [{ ref: "artifact.stylex.required", present: true }],
+        requiredArtifacts: [{ ref: "artifact.token.required", present: true }],
       }),
       EventTimeline({ events: sessionEventStreamFixture.slice(0, 1) }),
     ].map(renderHtml).join("")
@@ -123,7 +123,7 @@ describe("Autopilot UI StyleX migration coverage", () => {
     expect(rendered).toContain("oa-autopilot-domain-action-button")
     expect(rendered).toContain("oa-autopilot-domain-chip")
     expect(rendered).toContain('data-autopilot-decision-id="decision.fixture.req01"')
-    expect(rendered).toContain('data-autopilot-session-ref="session.stylex.fixture"')
+    expect(rendered).toContain('data-autopilot-session-ref="session.token.fixture"')
     expect(rendered).toContain('data-autopilot-verify-command=""')
   })
 })

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./theme.css": "./src/theme.css"
   },
   "files": [
     "src",

--- a/packages/design-tokens/src/theme.css
+++ b/packages/design-tokens/src/theme.css
@@ -1,0 +1,108 @@
+/*
+ * GENERATED — do not edit by hand.
+ *
+ * This is the checked-in projection of themeCss() from ./src/theme.ts: the
+ * single typed token source (#6046). CSS consumers @import this to get the
+ * --oa-* :root custom properties. A test (theme-css-parity) pins this file to
+ * the live themeCss() output so it can never drift from the typed source.
+ */
+:root {
+  --oa-color-bg: #000;
+  --oa-color-bg-secondary: #151515;
+  --oa-color-text: #d7d8e5;
+  --oa-color-text-secondary: #8a8c93;
+  --oa-color-outline: #525458;
+  --oa-color-primary: #fff;
+  --oa-color-success: #00c853;
+  --oa-color-warning: #ffb400;
+  --oa-color-danger: #d32f2f;
+  --oa-color-info: #2979ff;
+  --oa-color-text-bright: #e6e9ef;
+  --oa-color-text-muted: #8b93a7;
+  --oa-color-surface-raised: #101317;
+  --oa-color-surface-sunken: #0c0f13;
+  --oa-color-surface-deep: #0b0d12;
+  --oa-color-surface-blackish: #050607;
+  --oa-color-accent: #f5b73a;
+  --oa-color-accent-soft: #f5c542;
+  --oa-color-accent-warm: #f59e0b;
+  --oa-color-hud-primary: #ffffff;
+  --oa-color-hud-secondary: #f2f4f8;
+  --oa-color-hud-success: #2bd576;
+  --oa-color-hud-info: #ffffff;
+  --oa-color-hud-warning: #f5c542;
+  --oa-color-hud-error: #ff4d4d;
+  --oa-color-hud-neutral: #9aa6b2;
+  --oa-color-hud-line: #e6e9ef;
+  --oa-color-hud-bg: #0b0d12;
+  --oa-color-component-text: #f1efe8;
+  --oa-color-component-border: #222;
+  --oa-color-component-border-strong: #333;
+  --oa-color-component-surface: #080808;
+  --oa-color-component-surface-deep: #010102;
+  --oa-color-component-surface-active: #141414;
+  --oa-color-component-input-bg: #030303;
+  --oa-color-danger-hover: #ff6f00;
+  --oa-color-text-on-dark60: rgba(255, 255, 255, 0.6);
+  --oa-color-text-on-dark55: rgba(255, 255, 255, 0.55);
+  --oa-color-text-on-dark45: rgba(255, 255, 255, 0.45);
+  --oa-color-text-on-dark35: rgba(255, 255, 255, 0.35);
+  --oa-color-text-on-dark30: rgba(255, 255, 255, 0.3);
+  --oa-color-review-border: #30363d;
+  --oa-color-review-border-strong: #21262d;
+  --oa-color-review-danger: #f85149;
+  --oa-color-review-danger-soft: #ffd5d5;
+  --oa-color-review-success: #3fb950;
+  --oa-color-review-success-soft: #4ade80;
+  --oa-color-review-success-tint: #d7f7df;
+  --oa-color-review-warning: #d29922;
+  --oa-color-review-text: #f0f6fc;
+  --oa-color-review-text-soft: #f0f1f4;
+  --oa-color-review-text-faint: #8b949e;
+  --oa-color-review-surface: #f1efe8;
+  --oa-color-review-surface-soft: #f4f4f5;
+  --oa-color-review-link: #66aaff;
+  --oa-color-review-link-soft: #8fd0ff;
+  --oa-color-review-danger-strong: #ff7070;
+  --oa-color-review-warning-tint: #fff8e6;
+  --oa-color-review-neutral: #d7dee7;
+  --oa-space-0: 0;
+  --oa-space-1: 0.25rem;
+  --oa-space-2: 0.5rem;
+  --oa-space-3: 0.75rem;
+  --oa-space-4: 1rem;
+  --oa-space-5: 1.25rem;
+  --oa-space-6: 1.5rem;
+  --oa-space-8: 2rem;
+  --oa-space-10: 2.5rem;
+  --oa-space-12: 3rem;
+  --oa-space-px: 1px;
+  --oa-radius-none: 0;
+  --oa-radius-sm: 3px;
+  --oa-radius-md: 4px;
+  --oa-radius-lg: 6px;
+  --oa-radius-xl: 8px;
+  --oa-radius-2xl: 10px;
+  --oa-radius-3xl: 12px;
+  --oa-radius-full: 9999px;
+  --oa-font-sans: inherit;
+  --oa-font-mono: ui-monospace, monospace;
+  --oa-font-size-xs: 0.68rem;
+  --oa-font-size-sm: 0.72rem;
+  --oa-font-size-base: 0.78rem;
+  --oa-font-size-md: 0.96rem;
+  --oa-font-size-lg: 1rem;
+  --oa-line-height-tight: 1;
+  --oa-line-height-snug: 1.45;
+  --oa-line-height-normal: 1.5;
+  --oa-letter-spacing-none: 0;
+  --oa-letter-spacing-wide: 0.04em;
+  --oa-letter-spacing-wider: 0.07em;
+  --oa-letter-spacing-widest: 0.08em;
+  --oa-shadow-pane: 0 24px 64px rgb(0 0 0 / 0.6);
+  --oa-z-pane-layer: 30;
+  --oa-z-pane-window-base: 100;
+  --oa-z-return-button: 9999;
+  --oa-motion-fast: 0.14s;
+  --oa-motion-easing: ease;
+}

--- a/packages/design-tokens/src/theme.ts
+++ b/packages/design-tokens/src/theme.ts
@@ -60,6 +60,27 @@ export const colorTokens = {
   hudLine: "#e6e9ef",
   hudBg: "#0b0d12",
 
+  // Component chrome neutrals (#6046 part 2): the bone-white face/text plus the
+  // near-black surface + border ramp the `oa-ui-*` / `oa-ai-*` component
+  // stylesheets previously hardcoded. Values are kept EXACT so migrating the
+  // component CSS onto these tokens renders identically.
+  componentText: "#f1efe8",
+  componentBorder: "#222",
+  componentBorderStrong: "#333",
+  componentSurface: "#080808",
+  componentSurfaceDeep: "#010102",
+  componentSurfaceActive: "#141414",
+  componentInputBg: "#030303",
+  dangerHover: "#ff6f00",
+
+  // Translucent white text ramp used by the component chrome over the dark
+  // surfaces (muted labels, placeholders, ghost-button text).
+  textOnDark60: "rgba(255, 255, 255, 0.6)",
+  textOnDark55: "rgba(255, 255, 255, 0.55)",
+  textOnDark45: "rgba(255, 255, 255, 0.45)",
+  textOnDark35: "rgba(255, 255, 255, 0.35)",
+  textOnDark30: "rgba(255, 255, 255, 0.3)",
+
   // GitHub-ish review/diff accents (diff-review, status surfaces).
   reviewBorder: "#30363d",
   reviewBorderStrong: "#21262d",

--- a/packages/design-tokens/test/theme-css-parity.test.ts
+++ b/packages/design-tokens/test/theme-css-parity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+import { colorTokens, themeCss, themeCssVars } from "../src/index"
+
+const themeCssPath = fileURLToPath(new URL("../src/theme.css", import.meta.url))
+
+describe("design-tokens theme.css (#6046 part 2)", () => {
+  // The checked-in src/theme.css is the static projection that CSS consumers
+  // @import to resolve the --oa-* custom properties. It MUST stay byte-identical
+  // to the live themeCss() output (minus the generated banner), so the typed
+  // source in theme.ts remains the single source of truth.
+  test("theme.css ends with exactly the live themeCss() :root block", () => {
+    const file = readFileSync(themeCssPath, "utf8")
+    expect(file.endsWith(themeCss())).toBe(true)
+  })
+
+  test("theme.css exposes the new component-chrome + translucent text tokens", () => {
+    const file = readFileSync(themeCssPath, "utf8")
+    const vars = themeCssVars()
+    for (const [name, value] of [
+      ["--oa-color-component-text", "#f1efe8"],
+      ["--oa-color-component-border", "#222"],
+      ["--oa-color-component-border-strong", "#333"],
+      ["--oa-color-component-surface", "#080808"],
+      ["--oa-color-component-surface-deep", "#010102"],
+      ["--oa-color-component-surface-active", "#141414"],
+      ["--oa-color-component-input-bg", "#030303"],
+      ["--oa-color-danger-hover", "#ff6f00"],
+      ["--oa-color-text-on-dark60", "rgba(255, 255, 255, 0.6)"],
+      ["--oa-color-text-on-dark55", "rgba(255, 255, 255, 0.55)"],
+      ["--oa-color-text-on-dark45", "rgba(255, 255, 255, 0.45)"],
+      ["--oa-color-text-on-dark35", "rgba(255, 255, 255, 0.35)"],
+      ["--oa-color-text-on-dark30", "rgba(255, 255, 255, 0.3)"],
+    ] as const) {
+      expect(vars[name]).toBe(value)
+      expect(file).toContain(`${name}: ${value};`)
+    }
+  })
+
+  test("the new tokens carry their exact original values on the typed source", () => {
+    expect(colorTokens.componentText).toBe("#f1efe8")
+    expect(colorTokens.componentBorder).toBe("#222")
+    expect(colorTokens.componentBorderStrong).toBe("#333")
+    expect(colorTokens.componentSurface).toBe("#080808")
+    expect(colorTokens.componentSurfaceDeep).toBe("#010102")
+    expect(colorTokens.componentSurfaceActive).toBe("#141414")
+    expect(colorTokens.componentInputBg).toBe("#030303")
+    expect(colorTokens.dangerHover).toBe("#ff6f00")
+    expect(colorTokens.textOnDark60).toBe("rgba(255, 255, 255, 0.6)")
+    expect(colorTokens.textOnDark55).toBe("rgba(255, 255, 255, 0.55)")
+    expect(colorTokens.textOnDark45).toBe("rgba(255, 255, 255, 0.45)")
+    expect(colorTokens.textOnDark35).toBe("rgba(255, 255, 255, 0.35)")
+    expect(colorTokens.textOnDark30).toBe("rgba(255, 255, 255, 0.3)")
+  })
+})

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./icon": "./src/icon.ts",
+    "./styles.css": "./src/styles.css",
     "./*": "./src/*.ts"
   },
   "files": [

--- a/packages/ui/src/ai-elements/prompt-input.css
+++ b/packages/ui/src/ai-elements/prompt-input.css
@@ -6,8 +6,8 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: #222;
-  background-color: #010102;
+  border-color: var(--oa-color-component-border, #222);
+  background-color: var(--oa-color-component-surface-deep, #010102);
   padding: 8px;
 }
 
@@ -28,12 +28,12 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.8125rem;
   line-height: 1.35;
-  color: #f1efe8;
+  color: var(--oa-color-component-text, #f1efe8);
   outline-style: none;
 }
 
 .oa-ai-prompt-input-textarea::placeholder {
-  color: rgba(255, 255, 255, 0.3);
+  color: var(--oa-color-text-on-dark30, rgba(255, 255, 255, 0.3));
 }
 
 .oa-ai-prompt-input-footer {
@@ -54,7 +54,7 @@
   line-height: 1.2;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.35);
+  color: var(--oa-color-text-on-dark35, rgba(255, 255, 255, 0.35));
 }
 
 .oa-ai-prompt-input-button {
@@ -65,16 +65,16 @@
   gap: 6px;
   border-width: 1px;
   border-style: solid;
-  border-color: #333;
+  border-color: var(--oa-color-component-border-strong, #333);
   background-color: transparent;
   padding-inline: 10px;
   font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--oa-color-text-on-dark60, rgba(255, 255, 255, 0.6));
 }
 
 .oa-ai-prompt-input-button:hover {
-  border-color: #ffb400;
-  color: #f1efe8;
+  border-color: var(--oa-color-warning, #ffb400);
+  color: var(--oa-color-component-text, #f1efe8);
 }
 
 .oa-ai-prompt-input-button:disabled {
@@ -90,16 +90,16 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: #f1efe8;
-  background-color: #f1efe8;
+  border-color: var(--oa-color-component-text, #f1efe8);
+  background-color: var(--oa-color-component-text, #f1efe8);
   padding-inline: 12px;
   font-size: 0.8125rem;
   font-weight: 500;
-  color: #000;
+  color: var(--oa-color-bg, #000);
 }
 
 .oa-ai-prompt-input-submit:hover {
-  border-color: #ffb400;
+  border-color: var(--oa-color-warning, #ffb400);
 }
 
 .oa-ai-prompt-input-submit:disabled {

--- a/packages/ui/src/feedback.css
+++ b/packages/ui/src/feedback.css
@@ -6,8 +6,8 @@
   gap: 12px;
   border-width: 1px;
   border-style: dashed;
-  border-color: #333;
-  background-color: #010102;
+  border-color: var(--oa-color-component-border-strong, #333);
+  background-color: var(--oa-color-component-surface-deep, #010102);
   padding: 24px;
 }
 

--- a/packages/ui/src/forms.css
+++ b/packages/ui/src/forms.css
@@ -5,28 +5,28 @@
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
-  border-color: #333;
+  border-color: var(--oa-color-component-border-strong, #333);
   background-color: transparent;
   padding-inline: 10px;
   font-family: inherit;
   font-size: 0.8125rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--oa-color-text-on-dark60, rgba(255, 255, 255, 0.6));
 }
 
 .oa-ui-form-compact-button:hover {
-  background-color: #080808;
-  color: #f1efe8;
+  background-color: var(--oa-color-component-surface, #080808);
+  color: var(--oa-color-component-text, #f1efe8);
 }
 
 .oa-ui-form-compact-button-strong {
-  border-color: #f1efe8;
-  background-color: #f1efe8;
-  color: #000;
+  border-color: var(--oa-color-component-text, #f1efe8);
+  background-color: var(--oa-color-component-text, #f1efe8);
+  color: var(--oa-color-bg, #000);
 }
 
 .oa-ui-form-compact-button-strong:hover {
-  background-color: #f1efe8;
-  color: #000;
+  background-color: var(--oa-color-component-text, #f1efe8);
+  color: var(--oa-color-bg, #000);
 }
 
 .oa-ui-form-group {
@@ -49,7 +49,7 @@
   display: block;
   font-size: 0.875rem;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--oa-color-text-on-dark60, rgba(255, 255, 255, 0.6));
 }
 
 .oa-ui-form-input {
@@ -57,24 +57,24 @@
   min-width: 0;
   border-width: 1px;
   border-style: solid;
-  border-color: #222;
-  background-color: #030303;
+  border-color: var(--oa-color-component-border, #222);
+  background-color: var(--oa-color-component-input-bg, #030303);
   padding-inline: 12px;
   padding-block: 10px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.8125rem;
   line-height: 1.35;
-  color: #f1efe8;
+  color: var(--oa-color-component-text, #f1efe8);
   outline-style: none;
 }
 
 .oa-ui-form-input::placeholder {
-  color: rgba(255, 255, 255, 0.3);
+  color: var(--oa-color-text-on-dark30, rgba(255, 255, 255, 0.3));
 }
 
 .oa-ui-form-input:focus {
-  border-color: #ffb400;
-  box-shadow: 0 0 0 1px #ffb400;
+  border-color: var(--oa-color-warning, #ffb400);
+  box-shadow: 0 0 0 1px var(--oa-color-warning, #ffb400);
 }
 
 .oa-ui-form-textarea {
@@ -84,15 +84,15 @@
 
 .oa-ui-form-indicator-info {
   font-size: 0.875rem;
-  color: #2979ff;
+  color: var(--oa-color-info, #2979ff);
 }
 
 .oa-ui-form-indicator-success {
   font-size: 0.875rem;
-  color: #00c853;
+  color: var(--oa-color-success, #00c853);
 }
 
 .oa-ui-form-error {
   font-size: 0.875rem;
-  color: #d32f2f;
+  color: var(--oa-color-danger, #d32f2f);
 }

--- a/packages/ui/src/shared.css
+++ b/packages/ui/src/shared.css
@@ -9,7 +9,7 @@
   font-weight: 500;
   line-height: 1.1;
   letter-spacing: 0;
-  color: #f1efe8;
+  color: var(--oa-color-component-text, #f1efe8);
 }
 
 .oa-ui-heading-title-level-1 {
@@ -36,7 +36,7 @@
   max-width: 58ch;
   font-size: 0.875rem;
   line-height: 1.5;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--oa-color-text-on-dark55, rgba(255, 255, 255, 0.55));
 }
 
 .oa-ui-button {
@@ -74,61 +74,61 @@
 }
 
 .oa-ui-button-primary {
-  border-color: #f1efe8;
-  background-color: #f1efe8;
-  color: #000;
+  border-color: var(--oa-color-component-text, #f1efe8);
+  background-color: var(--oa-color-component-text, #f1efe8);
+  color: var(--oa-color-bg, #000);
 }
 
 .oa-ui-button-primary:hover {
-  border-color: #ffb400;
+  border-color: var(--oa-color-warning, #ffb400);
 }
 
 .oa-ui-button-secondary {
-  border-color: #222;
+  border-color: var(--oa-color-component-border, #222);
   background-color: transparent;
-  color: #f1efe8;
+  color: var(--oa-color-component-text, #f1efe8);
 }
 
 .oa-ui-button-secondary:hover {
-  border-color: #ffb400;
+  border-color: var(--oa-color-warning, #ffb400);
 }
 
 .oa-ui-button-ghost {
   border-color: transparent;
   background-color: transparent;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--oa-color-text-on-dark60, rgba(255, 255, 255, 0.6));
 }
 
 .oa-ui-button-ghost:hover {
-  border-color: #333;
-  background-color: #080808;
-  color: #f1efe8;
+  border-color: var(--oa-color-component-border-strong, #333);
+  background-color: var(--oa-color-component-surface, #080808);
+  color: var(--oa-color-component-text, #f1efe8);
 }
 
 .oa-ui-button-danger {
-  border-color: #d32f2f;
-  background-color: #d32f2f;
-  color: #fff;
+  border-color: var(--oa-color-danger, #d32f2f);
+  background-color: var(--oa-color-danger, #d32f2f);
+  color: var(--oa-color-primary, #fff);
 }
 
 .oa-ui-button-danger:hover {
-  border-color: #ff6f00;
+  border-color: var(--oa-color-danger-hover, #ff6f00);
 }
 
 .oa-ui-text-link {
-  color: #f1efe8;
+  color: var(--oa-color-component-text, #f1efe8);
   text-decoration-line: underline;
   text-underline-offset: 3px;
 }
 
 .oa-ui-text-link:hover {
-  color: #ffb400;
+  color: var(--oa-color-warning, #ffb400);
 }
 
 .oa-ui-avatar-image {
   border-width: 1px;
   border-style: solid;
-  border-color: #222;
+  border-color: var(--oa-color-component-border, #222);
   object-fit: cover;
 }
 
@@ -137,9 +137,9 @@
   place-items: center;
   border-width: 1px;
   border-style: solid;
-  border-color: #222;
-  background-color: #080808;
-  color: rgba(255, 255, 255, 0.45);
+  border-color: var(--oa-color-component-border, #222);
+  background-color: var(--oa-color-component-surface, #080808);
+  color: var(--oa-color-text-on-dark45, rgba(255, 255, 255, 0.45));
 }
 
 .oa-ui-avatar-sm {
@@ -178,8 +178,8 @@
   gap: 8px;
   border-width: 1px;
   border-style: solid;
-  border-color: #222;
-  background-color: #010102;
+  border-color: var(--oa-color-component-border, #222);
+  background-color: var(--oa-color-component-surface-deep, #010102);
   padding: 8px;
 }
 
@@ -191,12 +191,12 @@
   gap: 12px;
   border-width: 1px;
   border-style: solid;
-  border-color: #333;
-  background-color: #080808;
+  border-color: var(--oa-color-component-border-strong, #333);
+  background-color: var(--oa-color-component-surface, #080808);
   padding-inline: 12px;
   font-family: inherit;
   font-size: 0.875rem;
-  color: #f1efe8;
+  color: var(--oa-color-component-text, #f1efe8);
   text-align: left;
 }
 
@@ -217,20 +217,20 @@
   padding-inline: 10px;
   padding-block: 8px;
   font-size: 0.875rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--oa-color-text-on-dark60, rgba(255, 255, 255, 0.6));
   text-decoration-line: none;
 }
 
 .oa-ui-dropdown-item:hover {
-  border-color: #333;
-  background-color: #080808;
-  color: #f1efe8;
+  border-color: var(--oa-color-component-border-strong, #333);
+  background-color: var(--oa-color-component-surface, #080808);
+  color: var(--oa-color-component-text, #f1efe8);
 }
 
 .oa-ui-dropdown-item-active {
-  border-color: #333;
-  background-color: #141414;
-  color: #f1efe8;
+  border-color: var(--oa-color-component-border-strong, #333);
+  background-color: var(--oa-color-component-surface-active, #141414);
+  color: var(--oa-color-component-text, #f1efe8);
 }
 
 .oa-ui-dropdown-label {

--- a/packages/ui/src/stylex-foldkit.ts
+++ b/packages/ui/src/stylex-foldkit.ts
@@ -4,10 +4,10 @@ import { html } from 'foldkit/html'
 /**
  * #6046: StyleX removed.
  *
- * This module used to bridge `@stylexjs/stylex` compiled styles into Foldkit
- * attributes. StyleX's `stylex.create` runs `window`-dependent code at module
- * load, which threw `window is not defined` whenever the renderer's import
- * graph was mounted headless (the desktop app-replica harness) and forced the
+ * This module used to bridge StyleX compiled styles into Foldkit attributes.
+ * The old StyleX style factory ran `window`-dependent code at module load,
+ * which threw `window is not defined` whenever the renderer's import graph was
+ * mounted headless (the desktop app-replica harness) and forced the
  * `OA_STYLEX_RUNTIME_FALLBACK` shim hack.
  *
  * The bridge is now a thin class-name carrier with NO StyleX dependency: a

--- a/packages/ui/src/workroom-styles.css
+++ b/packages/ui/src/workroom-styles.css
@@ -229,7 +229,7 @@
 .oa-ui-workroom-bash-output {
   width: 100%;
   border: 1px solid var(--border-weak-base);
-  border-radius: 6px;
+  border-radius: var(--oa-radius-lg, 6px);
   background: transparent;
   position: relative;
   overflow: hidden;

--- a/packages/ui/test/component-token-migration.test.ts
+++ b/packages/ui/test/component-token-migration.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { themeCssVars } from '@openagentsinc/design-tokens'
+
+// #6046 part 2: the component stylesheets (ports of the deleted StyleX
+// create() blocks) must reference the central --oa-* tokens, and every
+// var(--oa-*, FALLBACK) fallback must EQUAL the token's canonical value so the
+// migration is theme-preserving. We also assert NO raw hex colors remain.
+
+const here = (rel: string) => fileURLToPath(new URL(rel, import.meta.url))
+
+const componentCssFiles = [
+  // @openagentsinc/ui
+  here('../src/shared.css'),
+  here('../src/forms.css'),
+  here('../src/feedback.css'),
+  here('../src/workroom-styles.css'),
+  here('../src/ai-elements/prompt-input.css'),
+  // @openagentsinc/autopilot-ui
+  here('../../autopilot-ui/src/view.css'),
+  here('../../autopilot-ui/src/domain-styles.css'),
+]
+
+const read = (file: string) => readFileSync(file, 'utf8')
+
+// Strip /* … */ comments so the `#6046` marker (and any other commentary) does
+// not count as a color or a token reference.
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, '')
+
+// Matches `var(--oa-<name>, <fallback>)` capturing the var name and the literal
+// fallback (which may itself contain commas, e.g. rgba(...)). The fallback runs
+// up to the matching close paren of the var(), so we balance one level of
+// nested parens (rgba/color-mix never nest var()s in our fallbacks).
+const varRefRe = /var\(\s*(--oa-[a-z0-9-]+)\s*,\s*((?:[^()]|\([^()]*\))*?)\s*\)/g
+
+describe('component CSS is migrated onto the central --oa-* tokens', () => {
+  const vars = themeCssVars()
+
+  test('every var(--oa-*, fallback) fallback equals the canonical token value', () => {
+    let checked = 0
+    for (const file of componentCssFiles) {
+      const css = stripComments(read(file))
+      for (const match of css.matchAll(varRefRe)) {
+        const name = match[1]
+        const fallback = match[2].trim()
+        expect(vars).toHaveProperty(name)
+        // theme-preserving: the inline fallback must be the exact token value,
+        // so resolved-or-fallback renders identically to the original literal.
+        expect(`${name} -> ${fallback}`).toBe(`${name} -> ${vars[name]}`)
+        checked += 1
+      }
+    }
+    // Guard against the regex silently matching nothing.
+    expect(checked).toBeGreaterThan(40)
+  })
+
+  test('0 raw hex colors remain in any component stylesheet', () => {
+    const hexRe = /#[0-9a-fA-F]{3,8}\b/g
+    for (const file of componentCssFiles) {
+      const css = stripComments(read(file))
+      // Remove the var() fallbacks (which legitimately carry the hex literal as
+      // a safety fallback) before scanning for stray raw hex.
+      const withoutVarFallbacks = css.replace(varRefRe, 'var($1)')
+      const stray = withoutVarFallbacks.match(hexRe) ?? []
+      expect({ file, stray }).toEqual({ file, stray: [] })
+    }
+  })
+
+  test('every component stylesheet references at least one --oa-* token', () => {
+    for (const file of componentCssFiles) {
+      const css = stripComments(read(file))
+      expect({ file, hasOaToken: css.includes('var(--oa-') }).toEqual({
+        file,
+        hasOaToken: true,
+      })
+    }
+  })
+})


### PR DESCRIPTION
**Part of #6046.** Finishes the part-2 work left open after #6050: puts the `oa-ui-*` / `oa-autopilot-*` component layer onto the ONE central typed token source and actually wires it into the web consumer. **DO NOT auto-merge — orchestrator reviews/merges** (visual change).

## The migration (7 component CSS files, every hardcoded value → `--oa-*` token)

Theme-preserving: each value is replaced with `var(--oa-*, <exact-original>)` so resolved-or-fallback renders identically.

- **`packages/ui`** — `shared.css`, `forms.css`, `feedback.css`, `ai-elements/prompt-input.css`, `workroom-styles.css`: every hardcoded hex / `rgba()` / radius → the matching `--oa-*` token.
- **`packages/autopilot-ui`** — `view.css`, `domain-styles.css`: the bare `--outline` / `--bg` / `--bg-secondary` / `--text` / `--text-secondary` / `--primary` / `--success` / `--warning` / `--danger` / `--info` vars repointed at the canonical `--oa-color-*` names (exact-value fallbacks preserved; `color-mix(...)` chips preserved).

**Result: 0 raw hex in any component stylesheet; every component style references `--oa-*`.**

### New tokens added to the typed source (`packages/design-tokens/src/theme.ts`)

For values that had no value-equal token I **extended the typed source** (no one-offs), keeping the exact original value:

- color: `componentText #f1efe8`, `componentBorder #222`, `componentBorderStrong #333`, `componentSurface #080808`, `componentSurfaceDeep #010102`, `componentSurfaceActive #141414`, `componentInputBg #030303`, `dangerHover #ff6f00`
- translucent-white text ramp: `textOnDark60/55/45/35/30` (`rgba(255,255,255,.6/.55/.45/.35/.3)`)

Existing value-equal tokens were reused for `#000`/`#fff`/`#d32f2f`/`#ffb400`/`#2979ff`/`#00c853`/`#8a8c93`/`#525458`/`#151515`/`#d7d8e5`, plus radius `4px`→`--oa-radius-md`, `6px`→`--oa-radius-lg`.

## How the components are now consumed (web)

Part 1 ported the StyleX blocks to `*.css` but **never injected them** — components were unstyled. This PR wires the canonical injection:

- Added **`packages/design-tokens/src/theme.css`** — the generated `:root { --oa-*: … }` projection of `themeCss()` — and exported it (`./theme.css`). A parity test pins it byte-for-byte to the live `themeCss()` so it can't drift from the typed source.
- Exported **`./styles.css`** barrels from `@openagentsinc/ui` and `@openagentsinc/autopilot-ui`.
- `apps/openagents.com` web `src/styles.css` now `@import`s the theme + both component barrels (and the web now depends on `@openagentsinc/design-tokens`).

**Bundle proof:** `vite build` emits `dist/assets/openagents.css` containing both the `:root` `--oa-*` vars **and** every component class, e.g.
`.oa-ui-button-primary{border-color:var(--oa-color-component-text,#f1efe8);…}` and `.oa-autopilot-session-row{…border-color:var(--oa-color-outline,#525458);…}` — the components render styled from the central theme, theme-preserving.

## Residual StyleX sweep (in-scope)

Removed the textual `@stylexjs` / `stylex.` residue in my turf: `packages/ui/src/stylex-foldkit.ts` comment, the web `vite.config.ts` comment, and the `autopilot-ui` `stylex-migration.test.ts` fixture strings (`.stylex.` → `.token.`). **0 `@stylexjs`/`stylex.` references remain in `packages/ui`, `packages/autopilot-ui`, `packages/design-tokens`, and `apps/openagents.com`.**

## Theme-preserving proof / verify

- **`packages/design-tokens/test/theme-css-parity.test.ts`** — `theme.css` === live `themeCss()`; the new tokens carry their exact original values.
- **`packages/ui/test/component-token-migration.test.ts`** — parses every `var(--oa-*, fallback)` across the 7 component stylesheets and asserts each fallback **equals** the canonical token value (`themeCssVars()[name]`); asserts **0 raw hex** remain and every file references `--oa-*`.
- typecheck clean: design-tokens, ui, autopilot-ui, **web**, **desktop**.
- suites green: design-tokens **14/14**, ui **29/29**, autopilot-ui **54/54**, web vitest **1163/1163**.
- web `vite build` succeeds; `bun.lock` is StyleX-free (0 `@stylexjs`).

## What remains for #6046 (why "Part of", not "Closes")

Scoped out by the collision guard — `apps/autopilot-desktop` (`src/ui/build-css.ts` / `src/ui/styles.css` + the Verse render/bloom work) is owned by a concurrent glow-up lane, so this PR does **not** touch it:

1. **Desktop component-CSS consumption.** The desktop already has the `--oa-*` `:root` vars (Part 1) and styles the `autopilot-ui` components via Tailwind arbitrary classes resolving against `var(--outline,…)` — unchanged and still rendering. To consume the migrated `oa-autopilot-*` component CSS it just needs a one-line `@import '@openagentsinc/autopilot-ui/styles.css'` in the glow-up's owned `src/ui/styles.css` (the export now exists). **Tiny follow-up — left to the desktop/glow-up lane.**
2. **Desktop StyleX comment residue.** ~15 dead `@stylexjs`/`stylex.` mentions remain in `apps/autopilot-desktop` comments/test docstrings (collision lane). Trivial comment cleanup for that lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)