### PR TITLE
Khala acceptance-runner: deployable verdict runner + deploy plan

### DIFF
--- a/apps/acceptance-runner/Dockerfile
+++ b/apps/acceptance-runner/Dockerfile
@@ -1,0 +1,38 @@
+# Out-of-Worker Khala acceptance-verdict runner (EPIC #6017).
+#
+# A long-running Bun service that leases acceptance jobs from the openagents.com gateway,
+# runs the REAL Playwright/chromium headless acceptance suite OUT of the Worker, and POSTs
+# the verdict back to the authenticated callback. Chromium NEVER runs in the Worker — it
+# runs HERE. INERT without its host secrets (see docs/DEPLOY.md): with the required env
+# unset the service refuses to start and never invents work.
+#
+# Build context is the REPO ROOT (the service bridges into apps/openagents.com worker
+# source), e.g.:  docker build -f apps/acceptance-runner/Dockerfile -t oa-acceptance-runner .
+
+# Playwright's official image ships a matched chromium + all system deps already.
+FROM mcr.microsoft.com/playwright:v1.61.0-jammy
+
+# Bun (the service + the bridged worker source are Bun/Effect TypeScript).
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /app
+
+# Copy the workspace manifests first for a cached install layer, then the source the
+# service needs: its own dir + the bridged worker inference source + the catalog root.
+COPY package.json bun.lock* ./
+COPY apps/acceptance-runner ./apps/acceptance-runner
+COPY apps/openagents.com/package.json ./apps/openagents.com/package.json
+COPY apps/openagents.com/workers/api ./apps/openagents.com/workers/api
+
+# Install workspace deps (effect, playwright, the api worker's deps the bridge pulls).
+RUN bun install --frozen-lockfile || bun install
+
+# Use the chromium the Playwright base image already installed (do not re-download).
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# Cloud Run / GCE health: the daemon logs structured JSON to stdout; it has no HTTP
+# server of its own (it PULLS work). For a Cloud Run deployment that requires a listening
+# port, front it with a tiny health endpoint or run it as a GCE/Compute service instead
+# (see docs/DEPLOY.md — GCE is the recommended host).
+ENTRYPOINT ["bun", "run", "apps/acceptance-runner/src/service.ts"]

--- a/apps/acceptance-runner/README.md
+++ b/apps/acceptance-runner/README.md
@@ -1,0 +1,52 @@
+# @openagentsinc/acceptance-runner
+
+The out-of-Worker headless **Khala acceptance-verdict runner** (EPIC #6017).
+
+It is the gating piece for the live auto-settlement loop: **no runner → no executed
+verdicts → no verified outcomes → no payouts.** A Cloudflare Worker cannot run chromium,
+so this long-running Bun service runs the real Playwright acceptance suite OUT of the
+Worker: it leases a khala-code acceptance job from the gateway, runs the suite against the
+produced artifact in a real headless chromium, and POSTs the `AcceptanceVerdict` back to
+the authenticated callback so the receipt backfills `verified:true`.
+
+It **orchestrates** the canonical acceptance harness
+(`apps/openagents.com/workers/api/src/inference/acceptance-runner/`) — it forks nothing.
+
+## INERT by default
+
+The service reads a fail-closed config from env and **refuses to start** without:
+
+| env | meaning |
+|-----|---------|
+| `ACCEPTANCE_VERDICT_CALLBACK_URL` | the Worker verdict callback (POST target) |
+| `ACCEPTANCE_JOB_LEASE_URL` | the Worker job-lease endpoint (GET) |
+| `ACCEPTANCE_JOB_ACK_URL` | the Worker job-ack endpoint (POST) |
+| `ACCEPTANCE_VERDICT_CALLBACK_TOKEN` | the shared runner bearer token (never logged) |
+
+Optional tuning: `ACCEPTANCE_POLL_INTERVAL_MS`, `ACCEPTANCE_IDLE_BACKOFF_MS`,
+`ACCEPTANCE_NAV_TIMEOUT_MS`.
+
+## Run
+
+```sh
+# one-shot: run a local artifact through the real suite (local proof / manual replay)
+bunx playwright install chromium
+bun run src/run-once.ts ../../scripts/khala-demo/artifacts/khala-crossy-road-northstar-passing.v1.html
+
+# one-shot with a live callback (POSTs the verdict back)
+ACCEPTANCE_VERDICT_CALLBACK_TOKEN=<tok> \
+  bun run src/run-once.ts <artifact.html> --request-id <id> \
+  --callback-url https://openagents.com/v1/inference/acceptance-verdicts
+
+# the long-running daemon (reads the env table above)
+bun run src/service.ts
+
+# tests (browser-free daemon wiring + real-chromium end-to-end proof)
+bun test src/daemon.test.ts
+bun test src/e2e-local-proof.test.ts
+```
+
+## Deploy
+
+See **`docs/DEPLOY.md`** for the full chain diagram, host assessment (recommended: our
+GCE), the concrete image/build/run steps, and the exact owner flips to go live.

--- a/apps/acceptance-runner/docs/DEPLOY.md
+++ b/apps/acceptance-runner/docs/DEPLOY.md
@@ -1,0 +1,148 @@
+# Khala acceptance-verdict runner — deploy plan (EPIC #6017)
+
+The gating piece for the live auto-settlement loop: **no runner → no executed
+verdicts → no verified outcomes → no payouts.** This service is the out-of-Worker
+headless executor that takes a khala-code artifact, runs the acceptance suite in a real
+chromium, and POSTs a real `AcceptanceVerdict` back to the Worker so the receipt
+backfills `verified:true`.
+
+This doc is the **deploy plan only** — nothing here moves money or sets a prod secret.
+Everything stays INERT until an owner sets the flags + token below.
+
+## The full chain
+
+```
+ openagents.com Worker (CF, no chromium)            acceptance-runner (this service, node + chromium)
+ ┌───────────────────────────────────────┐         ┌──────────────────────────────────────────────┐
+ │ khala-code completion w/ executable    │         │  poll loop (src/daemon.ts):                    │
+ │ artifact                               │         │                                                │
+ │   └─ enqueueAcceptanceJob ──▶ pull queue (D1) ◀──┼── GET  /v1/inference/acceptance-jobs/lease     │
+ │      (acceptance-dispatch.ts,          │  lease  │      (authenticated; 204 when idle)            │
+ │       KHALA_ACCEPTANCE_DISPATCH_ENABLED)│        │   ├─ resolveArtifact(ref)  (R2-signed GET)     │
+ │                                        │         │   ├─ runAcceptanceSuite()  ▶ chromium  6/6     │
+ │  POST /v1/inference/acceptance-verdicts ◀────────┼── postVerdict(token)                           │
+ │   └─ handleAcceptanceVerdictCallback   │ verdict │   └─ POST /v1/inference/acceptance-jobs/ack    │
+ │      (auth: ACCEPTANCE_VERDICT_CALLBACK_TOKEN)   │      (delivered ▶ remove | retry ▶ re-pending) │
+ │   └─ backfill receipt: unverified ▶    │         └──────────────────────────────────────────────┘
+ │      test_passed / failed, verified    │
+ │   └─ (settlement sink fires IFF the    │   ← a SEPARATE lane owns the money path
+ │      khala-loop flag + owner gate armed)│      (khala-loop-integration.ts); untouched here
+ └───────────────────────────────────────┘
+```
+
+One shared bearer token (`ACCEPTANCE_VERDICT_CALLBACK_TOKEN`) authenticates the whole
+runner↔gateway channel: the lease GET, the ack POST, and the verdict POST.
+
+## What is built vs. what is a deploy step
+
+**Built (in this PR):**
+
+- `apps/acceptance-runner/` — the standalone long-running daemon:
+  - `src/daemon.ts` — the poll loop: lease → run the canonical harness → POST verdict →
+    ack. Fail-soft, constant-motion, graceful-stoppable.
+  - `src/service.ts` — the daemon entrypoint (reads fail-closed config from env; refuses
+    to start without its secrets).
+  - `src/run-once.ts` — one-shot mode: run a local artifact through the real suite and
+    optionally POST the verdict to a live callback (local proof / manual replay).
+  - `src/http-job-source.ts` + `src/job-source.ts` — the authenticated HTTP pull source.
+  - `src/config.ts` — fail-closed env config.
+  - `src/harness-bridge.ts` — the single import boundary into the canonical worker harness
+    (`apps/openagents.com/.../acceptance-runner/harness.ts` + `runner.ts`). The service
+    forks NOTHING; it only orchestrates the existing executor.
+  - `Dockerfile` — Playwright base image + Bun, for Cloud Run / GCE.
+- Worker pull-queue side (INERT): `acceptance-job-queue-store.ts` (D1 + in-memory),
+  `acceptance-job-lease-routes.ts` (authenticated lease/ack), migration
+  `0222_khala_acceptance_job_queue.sql`, and the two routes wired into `index.ts`.
+- A robustness fix to `runner.ts`: the single-press advance check now settles until the
+  hop animation lands (`settleUntilStable`) instead of a fixed wait shorter than the
+  artifact's hop, so a good artifact reads a full tile (the committed passing artifact now
+  scores a clean **6/6**). The broken fixtures still fail honestly.
+
+**Deploy steps (owner; NOT done here):**
+
+1. Host the runner (recommended: **our GCE**, see below).
+2. Mint + set the callback token on the Worker and the runner.
+3. Wire the dispatch producer to the pull queue (the one remaining gateway seam).
+4. Flip `KHALA_ACCEPTANCE_DISPATCH_ENABLED=true`.
+
+## Host options (assessment)
+
+| Host | Fit | Notes |
+|------|-----|-------|
+| **Our GCE (oa-codex-control + a Compute VM)** ✅ **recommended** | Best for an always-on PULL daemon | Matches the workspace rule "autonomous/unattended execution goes on OUR Google Cloud." A pull daemon has no inbound port, so it sidesteps Cloud Run's request/port model. chromium + system deps come free from the Playwright base image. One small VM runs the loop 24/7; restart via systemd. |
+| Cloud Run | Workable but awkward | Cloud Run wants an HTTP server + scales to zero; our daemon PULLS and has no inbound port. You'd add a dummy health server and a min-instance=1 (always-warm) to keep it polling, which is just a worse always-on VM. Use only if you specifically want Cloud Run ops. |
+| A Pylon node | Natural long-term home | A Pylon is already a programmatic chromium-capable environment and joins the verified-work revshare flywheel (workers run QC for pay). Good once the Pylon fleet is the execution substrate; for the FIRST live verdict, our GCE is the lowest-friction owner-operated box. |
+
+**Recommendation: our GCE.** It is the workspace's canonical home for unattended
+execution, fits a no-inbound-port pull daemon cleanly, and gets chromium for free from the
+Playwright image.
+
+### Concrete GCE steps
+
+1. **Build + push the image** (build context = repo root):
+   ```
+   docker build -f apps/acceptance-runner/Dockerfile -t \
+     us-docker.pkg.dev/openagentsgemini/oa/acceptance-runner:0.1.0 .
+   docker push us-docker.pkg.dev/openagentsgemini/oa/acceptance-runner:0.1.0
+   ```
+2. **Run it on the GCE box** (Container-Optimized OS or a plain VM with Docker), with the
+   host secrets injected as env (never baked into the image):
+   ```
+   docker run -d --restart=always --name oa-acceptance-runner \
+     -e ACCEPTANCE_VERDICT_CALLBACK_URL=https://openagents.com/v1/inference/acceptance-verdicts \
+     -e ACCEPTANCE_JOB_LEASE_URL=https://openagents.com/v1/inference/acceptance-jobs/lease \
+     -e ACCEPTANCE_JOB_ACK_URL=https://openagents.com/v1/inference/acceptance-jobs/ack \
+     -e ACCEPTANCE_VERDICT_CALLBACK_TOKEN="$(cat /run/secrets/acceptance_token)" \
+     us-docker.pkg.dev/openagentsgemini/oa/acceptance-runner:0.1.0
+   ```
+   The token should come from GCP Secret Manager (project `openagentsgemini`), not a
+   literal. `docker logs -f oa-acceptance-runner` shows the structured JSON poll log.
+3. Until the Worker flags are flipped, the runner just polls and gets `204` (idle). That
+   is the correct inert state.
+
+## The exact flips to go live (in order)
+
+Everything below is **NEEDS-OWNER**. Until all are done, the loop is inert: the producer
+enqueues nothing, the callback/lease routes reject everything (no token), and the runner
+idles on 204s.
+
+1. **Mint the token** (a long random secret), e.g. `openssl rand -hex 32`.
+2. **Set it on the Worker** (so the callback + lease/ack routes authenticate):
+   ```
+   cd apps/openagents.com/workers/api
+   wrangler secret put ACCEPTANCE_VERDICT_CALLBACK_TOKEN
+   ```
+3. **Set the SAME token on the runner host** (Secret Manager / the `-e` above).
+4. **Wire the dispatch producer to the pull queue.** Today `acceptanceDispatch.queue` is
+   `undefined` in `index.ts` (two sites: `/v1/chat/completions` and `/mpp/v1/...`). Replace
+   `queue: undefined` with a producer backed by `makeD1AcceptanceJobQueueStore(...)` (plus
+   an R2 `storeArtifact` that writes the runnable HTML to the `ARTIFACTS` bucket and
+   returns a signed GET URL as the `artifactRef`). This is the one remaining gateway seam;
+   it is owned by the dispatch lane and left untouched here on purpose.
+5. **Apply the migration** to prod D1:
+   ```
+   wrangler d1 migrations apply openagents-autopilot --remote
+   ```
+6. **Flip the dispatch flag** (`vars` in `wrangler.jsonc` or a deploy-time var):
+   `KHALA_ACCEPTANCE_DISPATCH_ENABLED=true`. (`INFERENCE_GATEWAY_ENABLED` is already
+   `true`, so the callback + lease routes arm as soon as the token is set.)
+7. **Deploy the Worker.** Now: a khala-code completion enqueues a job → the runner leases
+   it → runs the suite → POSTs the verdict → the receipt backfills `verified:true`.
+
+The money path stays separately gated: even with all of the above, real settlement fires
+only when the KHALA loop-arming flag AND the owner real-settlement gate are BOTH armed
+(owned by `khala-loop-integration.ts`, untouched here).
+
+## Local proof (already passing in this PR)
+
+- `bun apps/acceptance-runner/src/run-once.ts scripts/khala-demo/artifacts/khala-crossy-road-northstar-passing.v1.html`
+  → **6/6 verified**, exit 0 (runs the full job path: resolve → real headless suite →
+  verdict payload).
+- `bun test apps/acceptance-runner/src/e2e-local-proof.test.ts` → runs the REAL headless
+  suite against the committed passing artifact, POSTs the verdict through the REAL
+  `handleAcceptanceVerdictCallback` route (test token, in-memory store), and asserts the
+  receipt backfills `verified:true` / `test_passed`.
+- `bun test apps/acceptance-runner/src/daemon.test.ts` → the poll-loop wiring
+  (lease→run→post→ack, idle/error backoff), browser-free.
+- Worker side: `vitest run src/inference/acceptance-job-queue.test.ts` (queue + lease
+  routes) and the existing `acceptance-dispatch.test.ts` full-loop fixtures stay green.

--- a/apps/acceptance-runner/package.json
+++ b/apps/acceptance-runner/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@openagentsinc/acceptance-runner",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Out-of-Worker headless Khala acceptance-verdict runner (EPIC #6017). Leases acceptance jobs from the openagents.com gateway, runs the real Playwright/chromium acceptance suite OUT of the Worker, and POSTs the verdict back to the authenticated callback so the receipt backfills verified:true. INERT without its host secrets.",
+  "scripts": {
+    "serve": "bun run src/service.ts",
+    "run-once": "bun run src/run-once.ts",
+    "test": "bun test src/daemon.test.ts",
+    "playwright:install": "playwright install --with-deps chromium"
+  },
+  "dependencies": {
+    "effect": "catalog:",
+    "playwright": "^1.61.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250601.0",
+    "bun-types": "^1.3.14",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/acceptance-runner/src/config.ts
+++ b/apps/acceptance-runner/src/config.ts
@@ -1,0 +1,84 @@
+// Runner-service configuration (EPIC #6017). Reads the host's local env into a typed,
+// FAIL-CLOSED config. The service is INERT without its required secrets: no callback URL
+// or no bearer token => the service refuses to start the poll loop (it has nowhere to
+// deliver verdicts and nothing authenticates it), so a half-configured host never runs.
+//
+// The bearer token is the SAME ACCEPTANCE_VERDICT_CALLBACK_TOKEN the Worker's verdict
+// callback verifies — ONE secret authenticates the whole runner<->gateway channel
+// (lease + ack + verdict POST). It is read from env, NEVER hard-coded, and never logged.
+
+export type RunnerServiceConfig = Readonly<{
+  // Where the runner POSTs verdicts back (the Worker verdict callback). REQUIRED.
+  verdictCallbackUrl: string
+  // The authenticated job-lease endpoint (GET) on the Worker. REQUIRED for daemon mode.
+  jobLeaseUrl: string
+  // The authenticated job-ack endpoint (POST) on the Worker. REQUIRED for daemon mode.
+  jobAckUrl: string
+  // The runner bearer token (ACCEPTANCE_VERDICT_CALLBACK_TOKEN). REQUIRED. Never logged.
+  bearerToken: string
+  // How an artifact ref resolves to HTML. 'http' (default) treats the ref as a URL the
+  // runner GETs (an R2-signed URL minted by the Worker). Extensible for a local store.
+  artifactResolveMode: 'http'
+  // Poll cadence + idle backoff (ms). Bounded so a misconfigured value can't busy-spin.
+  pollIntervalMs: number
+  idleBackoffMs: number
+  // Per-job nav timeout passed to the headless suite (ms).
+  navTimeoutMs: number
+}>
+
+export type RunnerServiceConfigResult =
+  | Readonly<{ ok: true; config: RunnerServiceConfig }>
+  | Readonly<{ ok: false; missing: ReadonlyArray<string> }>
+
+const clampInt = (
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number => {
+  if (raw === undefined) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.min(max, Math.max(min, parsed))
+}
+
+const nonEmpty = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim()
+  return trimmed === undefined || trimmed === '' ? undefined : trimmed
+}
+
+// Read the daemon config from a plain env record (process.env in prod, a fixture in
+// tests). FAIL-CLOSED: returns the missing required keys rather than a partial config.
+export const readRunnerServiceConfig = (
+  env: Readonly<Record<string, string | undefined>>,
+): RunnerServiceConfigResult => {
+  const verdictCallbackUrl = nonEmpty(env.ACCEPTANCE_VERDICT_CALLBACK_URL)
+  const jobLeaseUrl = nonEmpty(env.ACCEPTANCE_JOB_LEASE_URL)
+  const jobAckUrl = nonEmpty(env.ACCEPTANCE_JOB_ACK_URL)
+  const bearerToken = nonEmpty(env.ACCEPTANCE_VERDICT_CALLBACK_TOKEN)
+
+  const missing: string[] = []
+  if (verdictCallbackUrl === undefined) {
+    missing.push('ACCEPTANCE_VERDICT_CALLBACK_URL')
+  }
+  if (jobLeaseUrl === undefined) missing.push('ACCEPTANCE_JOB_LEASE_URL')
+  if (jobAckUrl === undefined) missing.push('ACCEPTANCE_JOB_ACK_URL')
+  if (bearerToken === undefined) {
+    missing.push('ACCEPTANCE_VERDICT_CALLBACK_TOKEN')
+  }
+  if (missing.length > 0) return { missing, ok: false }
+
+  return {
+    config: {
+      artifactResolveMode: 'http',
+      bearerToken: bearerToken!,
+      idleBackoffMs: clampInt(env.ACCEPTANCE_IDLE_BACKOFF_MS, 5_000, 250, 60_000),
+      jobAckUrl: jobAckUrl!,
+      jobLeaseUrl: jobLeaseUrl!,
+      navTimeoutMs: clampInt(env.ACCEPTANCE_NAV_TIMEOUT_MS, 15_000, 1_000, 120_000),
+      pollIntervalMs: clampInt(env.ACCEPTANCE_POLL_INTERVAL_MS, 1_000, 100, 60_000),
+      verdictCallbackUrl: verdictCallbackUrl!,
+    },
+    ok: true,
+  }
+}

--- a/apps/acceptance-runner/src/daemon.test.ts
+++ b/apps/acceptance-runner/src/daemon.test.ts
@@ -1,0 +1,180 @@
+// Unit proof for the out-of-Worker runner DAEMON loop (EPIC #6017).
+//
+// No chromium, no network: a fake JobSource hands a job, a fake RunnerTransport returns
+// a verdict and records the POST, and we assert the daemon tick leases -> runs -> posts
+// -> acks, and that the idle/lease-error cases back off without fabricating work. The
+// REAL headless run is proven separately by run-once.ts against the committed artifact
+// and by the worker-side acceptance-dispatch.test.ts.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  AcceptanceJobMessage,
+  type AcceptanceVerdict,
+  crossyRoadAcceptanceSpec,
+  type RunAcceptanceJobResult,
+  type RunnerTransport,
+  type VerdictCallbackPayload,
+} from './harness-bridge'
+import { runDaemonTick, type RunJobFn, type RunnerDaemonDeps } from './daemon'
+import type { JobSource, LeasedJob } from './job-source'
+import type { RunnerServiceConfig } from './config'
+
+const config: RunnerServiceConfig = {
+  artifactResolveMode: 'http',
+  bearerToken: 'tok',
+  idleBackoffMs: 1,
+  jobAckUrl: 'https://x/ack',
+  jobLeaseUrl: 'https://x/lease',
+  navTimeoutMs: 5000,
+  pollIntervalMs: 1,
+  verdictCallbackUrl: 'https://x/verdict',
+}
+
+const message = (requestId: string): AcceptanceJobMessage => {
+  const spec = crossyRoadAcceptanceSpec()
+  return AcceptanceJobMessage.make({
+    artifactRef: `artifact://${requestId}`,
+    meteringReceiptRef: null,
+    requestId,
+    schemaVersion: 'openagents.inference.acceptance_job.v1',
+    servedModel: 'openagents/khala-code',
+    spec: {
+      checks: spec.checks,
+      kind: spec.kind,
+      params: spec.params,
+      rubricRef: spec.rubricRef,
+    },
+    worker: 'w',
+  })
+}
+
+// A fake transport that records the verdict it would POST (no browser, no network).
+const fakeTransport = (posted: VerdictCallbackPayload[]): RunnerTransport => ({
+  postVerdict: async payload => {
+    posted.push(payload)
+  },
+  resolveArtifact: async () => '<html><body>ok</body></html>',
+})
+
+const passVerdict = (): AcceptanceVerdict => {
+  const spec = crossyRoadAcceptanceSpec()
+  return {
+    checks: spec.checks.map(id => ({ detail: 'ok', id, passed: true })),
+    consoleErrors: [],
+    executed: true,
+    failedChecks: [],
+    kind: spec.kind,
+    pageErrors: [],
+    passedChecks: spec.checks,
+    rubricRef: spec.rubricRef,
+    scalarReward: 1,
+    verified: true,
+  }
+}
+
+// A browser-free `runJob` that mirrors the harness contract: resolve the artifact, then
+// post the verdict (delivered = post succeeded). Proves the daemon loop wiring without
+// launching chromium; the REAL headless run is proven by run-once.ts + the worker test.
+const makeFakeRunJob =
+  (verdict: AcceptanceVerdict): RunJobFn =>
+  async (transport, message): Promise<RunAcceptanceJobResult> => {
+    await transport.resolveArtifact(message.artifactRef)
+    const delivered = await transport
+      .postVerdict({
+        meteringReceiptRef: message.meteringReceiptRef ?? null,
+        requestId: message.requestId,
+        schemaVersion: 'openagents.inference.acceptance_verdict.v1',
+        servedModel: message.servedModel,
+        verdict,
+        worker: message.worker,
+      })
+      .then(() => true)
+      .catch(() => false)
+    return { delivered, verdict }
+  }
+
+const fakeSource = (
+  queue: LeasedJob[],
+  acks: Array<{ leaseId: string; delivered: boolean }>,
+  opts?: { leaseThrows?: boolean },
+): JobSource => ({
+  ack: async input => {
+    acks.push(input)
+  },
+  label: 'fake',
+  lease: async () => {
+    if (opts?.leaseThrows) throw new Error('lease boom')
+    return queue.shift() ?? null
+  },
+})
+
+describe('runner daemon tick', () => {
+  test('lease -> run -> post verdict -> ack delivered', async () => {
+    const posted: VerdictCallbackPayload[] = []
+    const acks: Array<{ leaseId: string; delivered: boolean }> = []
+    const deps: RunnerDaemonDeps = {
+      config,
+      runJob: makeFakeRunJob(passVerdict()),
+      source: fakeSource([{ leaseId: 'L1', message: message('r1') }], acks),
+      transport: fakeTransport(posted),
+    }
+    const outcome = await runDaemonTick(deps)
+    expect(outcome.kind).toBe('ran')
+    // The harness ran the (fake) artifact and posted a verdict for the right request.
+    expect(posted).toHaveLength(1)
+    expect(posted[0]!.requestId).toBe('r1')
+    expect(posted[0]!.schemaVersion).toBe(
+      'openagents.inference.acceptance_verdict.v1',
+    )
+    // Delivered -> acked delivered (the Worker removes the job).
+    expect(acks).toEqual([{ delivered: true, leaseId: 'L1' }])
+  })
+
+  test('delivery failure -> ack retryable (job re-leased later)', async () => {
+    const acks: Array<{ leaseId: string; delivered: boolean }> = []
+    const failingTransport: RunnerTransport = {
+      postVerdict: async () => {
+        throw new Error('callback down')
+      },
+      resolveArtifact: async () => '<html></html>',
+    }
+    const deps: RunnerDaemonDeps = {
+      config,
+      runJob: makeFakeRunJob(passVerdict()),
+      source: fakeSource([{ leaseId: 'L2', message: message('r2') }], acks),
+      transport: failingTransport,
+    }
+    const outcome = await runDaemonTick(deps)
+    expect(outcome.kind).toBe('ran')
+    expect(acks).toEqual([{ delivered: false, leaseId: 'L2' }])
+  })
+
+  test('empty queue -> idle (no post, no ack)', async () => {
+    const posted: VerdictCallbackPayload[] = []
+    const acks: Array<{ leaseId: string; delivered: boolean }> = []
+    const deps: RunnerDaemonDeps = {
+      config,
+      source: fakeSource([], acks),
+      transport: fakeTransport(posted),
+    }
+    const outcome = await runDaemonTick(deps)
+    expect(outcome.kind).toBe('idle')
+    expect(posted).toHaveLength(0)
+    expect(acks).toHaveLength(0)
+  })
+
+  test('lease transport fault -> lease_error (no fabricated verdict)', async () => {
+    const posted: VerdictCallbackPayload[] = []
+    const acks: Array<{ leaseId: string; delivered: boolean }> = []
+    const deps: RunnerDaemonDeps = {
+      config,
+      source: fakeSource([], acks, { leaseThrows: true }),
+      transport: fakeTransport(posted),
+    }
+    const outcome = await runDaemonTick(deps)
+    expect(outcome.kind).toBe('lease_error')
+    expect(posted).toHaveLength(0)
+    expect(acks).toHaveLength(0)
+  })
+})

--- a/apps/acceptance-runner/src/daemon.ts
+++ b/apps/acceptance-runner/src/daemon.ts
@@ -1,0 +1,193 @@
+// The out-of-Worker acceptance-runner DAEMON (EPIC #6017).
+//
+// THE MISSING PIECE. The gateway already dispatches jobs (inert) and ingests verdicts
+// (inert), and the harness (`runAcceptanceJob`) already runs one job end to end. What
+// did not exist was a long-running SERVICE that sits on a node with chromium and turns
+// the loop: lease a pending job -> run the real headless acceptance suite -> POST the
+// verdict back -> ack the job. This daemon is exactly that, and NOTHING ELSE — it owns
+// no money path, no settlement, no receipt logic; it only ORCHESTRATES the canonical
+// harness on a host that can run a browser.
+//
+//   gateway (Worker)  ─lease──▶  DAEMON (this) ──runAcceptanceJob──▶ chromium
+//        ▲   ▲                       │                                  │
+//        │   └──────── ack ──────────┘                                  │
+//        └──────────── verdict POST (bearer token) ────────────────────┘
+//
+// CONSTANT-MOTION SAFE + FAIL-SOFT: one tick leases AT MOST one job; an empty lease
+// backs off `idleBackoffMs`; a lease/transport fault backs off too (never a busy-spin,
+// never a fabricated verdict). A run NEVER throws into the loop — a crashed artifact is
+// an honest all-fail verdict from the harness, posted back so the receipt backfills to
+// `failed`. A verdict-delivery failure acks the job as retryable so it is re-leased.
+
+import {
+  type AcceptanceJobMessage,
+  type RunAcceptanceJobResult,
+  type RunnerTransport,
+  makeFetchVerdictPoster,
+  runAcceptanceJob,
+} from './harness-bridge'
+import type { RunnerServiceConfig } from './config'
+import type { JobSource } from './job-source'
+
+// The job-runner seam: takes a transport + a job message + options and returns the
+// run result. The default is the canonical `runAcceptanceJob` (real Playwright/chromium
+// harness); tests inject a browser-free fake. This keeps the daemon's LOOP logic
+// (lease/run/post/ack/backoff) unit-testable without standing up a browser, while prod
+// runs the real headless suite unchanged.
+export type RunJobFn = (
+  transport: RunnerTransport,
+  message: AcceptanceJobMessage,
+  options?: Readonly<{ navTimeoutMs?: number }>,
+) => Promise<RunAcceptanceJobResult>
+
+// Resolve an artifact ref to its HTML over HTTP. The Worker mints a dereferenceable ref
+// (an R2-signed GET URL) and carries it on the job; the runner GETs the bytes. A non-2xx
+// rejects so the harness turns it into an honest all-fail verdict (never a silent skip).
+export const makeHttpArtifactResolver =
+  (fetchFn: typeof fetch = fetch): RunnerTransport['resolveArtifact'] =>
+  async (artifactRef: string): Promise<string> => {
+    const response = await fetchFn(artifactRef, { method: 'GET' })
+    if (!response.ok) {
+      throw new Error(`artifact_fetch_failed: ${response.status}`)
+    }
+    return response.text()
+  }
+
+// A structured, public-safe log line (no token, no artifact bytes, no prompt). The host
+// captures stdout; we keep it greppable and free of secrets.
+export type DaemonLogEvent =
+  | Readonly<{ kind: 'idle'; source: string }>
+  | Readonly<{ kind: 'lease_error'; source: string; message: string }>
+  | Readonly<{
+      kind: 'verdict'
+      requestId: string
+      verified: boolean
+      scalarReward: number
+      passed: number
+      total: number
+      delivered: boolean
+    }>
+
+export type RunnerDaemonDeps = Readonly<{
+  config: RunnerServiceConfig
+  source: JobSource
+  // Injectable so tests drive the daemon without a real browser / network. Defaults to
+  // the real HTTP resolver + the real fetch-backed verdict poster built from config.
+  transport?: RunnerTransport
+  log?: (event: DaemonLogEvent) => void
+  // Injectable clock for the idle backoff (tests pass a no-op).
+  sleep?: (ms: number) => Promise<void>
+  // Injectable job runner (defaults to the real headless harness). Tests pass a
+  // browser-free fake so the LOOP wiring is provable without chromium.
+  runJob?: RunJobFn
+}>
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms))
+
+// Build the real `RunnerTransport` from config: HTTP artifact resolution + a
+// fetch-backed verdict poster authenticated by the bearer token. The token is read from
+// config (the host's local secret), never hard-coded, never logged.
+export const makeRunnerTransport = (
+  config: RunnerServiceConfig,
+  fetchFn: typeof fetch = fetch,
+): RunnerTransport => ({
+  postVerdict: makeFetchVerdictPoster({
+    bearerToken: config.bearerToken,
+    callbackUrl: config.verdictCallbackUrl,
+    fetchFn,
+  }),
+  resolveArtifact: makeHttpArtifactResolver(fetchFn),
+})
+
+// Run EXACTLY ONE daemon tick: lease at most one job, run it, post + ack. Returns what
+// happened so a caller (the loop, or a test) can decide whether to back off. Pure w.r.t.
+// the injected deps — no global state, no hidden I/O.
+export const runDaemonTick = async (
+  deps: RunnerDaemonDeps,
+): Promise<
+  | Readonly<{ kind: 'idle' }>
+  | Readonly<{ kind: 'lease_error'; message: string }>
+  | Readonly<{ kind: 'ran'; result: RunAcceptanceJobResult }>
+> => {
+  const transport = deps.transport ?? makeRunnerTransport(deps.config)
+  const log = deps.log ?? (() => undefined)
+
+  let leased
+  try {
+    leased = await deps.source.lease()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log({ kind: 'lease_error', message, source: deps.source.label })
+    return { kind: 'lease_error', message }
+  }
+
+  if (leased === null) {
+    log({ kind: 'idle', source: deps.source.label })
+    return { kind: 'idle' }
+  }
+
+  // Run the canonical harness end to end. It NEVER throws into us — a load crash / an
+  // unresolvable artifact is an honest all-fail verdict, already posted by the harness.
+  const runJob = deps.runJob ?? runAcceptanceJob
+  const result = await runJob(transport, leased.message, {
+    navTimeoutMs: deps.config.navTimeoutMs,
+  })
+
+  // Ack the lease: delivered when the verdict POST succeeded (the Worker backfilled the
+  // receipt), retryable otherwise (re-lease so the verdict is not lost). The ack itself
+  // is fail-soft — an ack hiccup does not crash the loop; the job's lease simply expires
+  // and it is re-leased.
+  await deps.source
+    .ack({ delivered: result.delivered, leaseId: leased.leaseId })
+    .catch(() => undefined)
+
+  log({
+    delivered: result.delivered,
+    kind: 'verdict',
+    passed: result.verdict.passedChecks.length,
+    requestId: leased.message.requestId,
+    scalarReward: result.verdict.scalarReward,
+    total: result.verdict.checks.length,
+    verified: result.verdict.verified,
+  })
+  return { kind: 'ran', result }
+}
+
+export type RunnerDaemonHandle = Readonly<{
+  // Resolves when the loop has stopped after a `stop()` request and the in-flight tick
+  // (if any) finished.
+  done: Promise<void>
+  // Request a graceful stop. The current tick finishes; no new tick starts.
+  stop: () => void
+}>
+
+// Start the long-running poll loop. CONSTANT MOTION between jobs (poll cadence) with a
+// longer idle/error backoff so an empty queue or a transport blip never busy-spins. The
+// loop is graceful-stoppable for clean shutdown (SIGTERM on the host).
+export const startRunnerDaemon = (
+  deps: RunnerDaemonDeps,
+): RunnerDaemonHandle => {
+  const sleep = deps.sleep ?? defaultSleep
+  let stopped = false
+  const loop = async (): Promise<void> => {
+    while (!stopped) {
+      const outcome = await runDaemonTick(deps)
+      if (stopped) break
+      if (outcome.kind === 'ran') {
+        // Pulled a job; immediately try for the next (constant motion).
+        await sleep(deps.config.pollIntervalMs)
+      } else {
+        // Idle queue or a transport fault: back off before polling again.
+        await sleep(deps.config.idleBackoffMs)
+      }
+    }
+  }
+  const done = loop()
+  return {
+    done,
+    stop: () => {
+      stopped = true
+    },
+  }
+}

--- a/apps/acceptance-runner/src/e2e-local-proof.test.ts
+++ b/apps/acceptance-runner/src/e2e-local-proof.test.ts
@@ -1,0 +1,124 @@
+// LOCAL END-TO-END PROOF for the out-of-Worker acceptance runner (EPIC #6017).
+//
+// Proves the FULL chain in process, no mocks of the load-bearing steps:
+//
+//   committed passing artifact
+//     -> runAcceptanceJob (REAL Playwright/chromium headless suite)   [6/6 verdict]
+//     -> postVerdict POSTs to the REAL handleAcceptanceVerdictCallback route
+//        (authenticated with a TEST token, against an in-memory verification store)
+//     -> the route BACKFILLS the receipt to verified:true / test_passed.
+//
+// This is the deployable runner's exact runtime behaviour, with the only substitutions
+// being (a) the artifact comes from a local file instead of an R2 ref and (b) the
+// callback is invoked in-process instead of over the network — neither of which changes
+// the verdict or the backfill. Requires a real headless chromium (Playwright); if
+// chromium is missing the run produces an honest all-fail verdict (never a fake green),
+// so this test would FAIL rather than disguise a missing browser.
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+import { Effect } from 'effect'
+
+import {
+  type RunnerTransport,
+  AcceptanceJobMessage,
+  crossyRoadAcceptanceSpec,
+  handleAcceptanceVerdictCallback,
+  makeInMemoryKhalaVerificationStore,
+  runAcceptanceJob,
+} from './harness-bridge'
+
+const here = dirname(fileURLToPath(import.meta.url))
+// apps/acceptance-runner/src -> repo root -> scripts/khala-demo/artifacts
+const PASSING_ARTIFACT = resolve(
+  here,
+  '../../..',
+  'scripts/khala-demo/artifacts/khala-crossy-road-northstar-passing.v1.html',
+)
+
+const TEST_TOKEN = 'local-proof-token'
+const REQUEST_ID = 'acceptance.e2e.local-proof.crossy_road.v1'
+
+describe('local end-to-end: real headless run -> real callback -> receipt backfill', () => {
+  test(
+    'committed passing artifact => 6/6 verdict => callback backfills verified:true',
+    async () => {
+      const html = readFileSync(PASSING_ARTIFACT, 'utf8')
+      const spec = crossyRoadAcceptanceSpec()
+
+      // The in-memory verification store the REAL route backfills into.
+      const store = makeInMemoryKhalaVerificationStore()
+
+      // The verdict poster delivers to the REAL route in-process (no network). It mints a
+      // Request exactly like a node-side runner's fetch POST would, with the bearer token.
+      const callbackPoster: RunnerTransport['postVerdict'] = async payload => {
+        const request = new Request('https://x/v1/inference/acceptance-verdicts', {
+          body: JSON.stringify(payload),
+          headers: {
+            authorization: `Bearer ${TEST_TOKEN}`,
+            'content-type': 'application/json',
+          },
+          method: 'POST',
+        })
+        const response = await Effect.runPromise(
+          handleAcceptanceVerdictCallback(request, {
+            callbackToken: TEST_TOKEN,
+            enabled: true,
+            nowIso: () => new Date().toISOString(),
+            store,
+          }),
+        )
+        if (!response.ok) {
+          throw new Error(`callback_failed: ${response.status}`)
+        }
+      }
+
+      const transport: RunnerTransport = {
+        postVerdict: callbackPoster,
+        resolveArtifact: async () => html,
+      }
+
+      const message = AcceptanceJobMessage.make({
+        artifactRef: `file://${PASSING_ARTIFACT}`,
+        meteringReceiptRef: null,
+        requestId: REQUEST_ID,
+        schemaVersion: 'openagents.inference.acceptance_job.v1',
+        servedModel: 'openagents/khala-code',
+        spec: {
+          checks: spec.checks,
+          kind: spec.kind,
+          params: spec.params,
+          rubricRef: spec.rubricRef,
+        },
+        worker: 'khala-code-crossy-road-verifier',
+      })
+
+      // RUN: real headless suite, then deliver the verdict through the real route.
+      const result = await runAcceptanceJob(transport, message)
+
+      // The runner really executed and got 6/6.
+      expect(result.verdict.executed).toBe(true)
+      expect(result.verdict.verified).toBe(true)
+      expect(result.verdict.scalarReward).toBe(1)
+      expect(result.verdict.passedChecks.length).toBe(6)
+      expect(result.verdict.failedChecks.length).toBe(0)
+
+      // The verdict was DELIVERED and the route ACCEPTED it.
+      expect(result.delivered).toBe(true)
+
+      // The receipt was BACKFILLED to verified:true / test_passed (the gating signal the
+      // settlement loop reads). Read straight from the store the route wrote into.
+      const record = await Effect.runPromise(store.read(REQUEST_ID))
+      expect(record).not.toBeNull()
+      expect(record!.executed).toBe(true)
+      expect(record!.verified).toBe(true)
+      expect(record!.verification).toBe('test_passed')
+      expect(record!.scalarReward).toBe(1)
+      expect(record!.failedChecks.length).toBe(0)
+    },
+    120_000,
+  )
+})

--- a/apps/acceptance-runner/src/harness-bridge.ts
+++ b/apps/acceptance-runner/src/harness-bridge.ts
@@ -1,0 +1,39 @@
+// The single import boundary between the standalone runner service and the canonical
+// acceptance-runner harness that lives in the openagents.com worker source (EPIC #6017).
+//
+// WHY A BRIDGE. The real headless executor (`runner.ts`), the pluggable host seam
+// (`harness.ts`), the verdict/spec types, and the wire `AcceptanceJobMessage` schema all
+// live under `apps/openagents.com/workers/api/src/inference/` — that is their canonical
+// home and a concurrent lane owns them. The standalone service MUST NOT fork or
+// re-implement any of that logic; it only ORCHESTRATES it on a node with chromium. This
+// module is the ONE place the service reaches into the worker source, so the rest of the
+// service imports `./harness-bridge` and never deep-imports the worker tree. If the
+// harness moves to a published package later, only this file changes.
+//
+// Relative path from apps/acceptance-runner/src to the worker inference source.
+
+export {
+  type RunnerTransport,
+  type RunAcceptanceJobResult,
+  type VerdictCallbackPayload,
+  AcceptanceJobMessage,
+  runAcceptanceJob,
+  makeFetchVerdictPoster,
+  specFromJobSpec,
+  VerdictCallbackDeliveryError,
+} from '../../openagents.com/workers/api/src/inference/acceptance-runner/harness'
+
+export { runAcceptanceSuite } from '../../openagents.com/workers/api/src/inference/acceptance-runner/runner'
+export type { AcceptanceVerdict } from '../../openagents.com/workers/api/src/inference/acceptance-runner/verdict'
+export { crossyRoadAcceptanceSpec } from '../../openagents.com/workers/api/src/inference/acceptance-spec'
+
+// The verdict-callback ingest + verification store, re-exported for the in-process
+// end-to-end proof (run the real headless suite -> POST the verdict through the REAL
+// route -> assert the receipt backfills verified:true). Prod uses the D1 store; the
+// proof uses the in-memory reference store.
+export {
+  handleAcceptanceVerdictCallback,
+} from '../../openagents.com/workers/api/src/inference/acceptance-verdict-callback-routes'
+export {
+  makeInMemoryKhalaVerificationStore,
+} from '../../openagents.com/workers/api/src/inference/acceptance-dispatch'

--- a/apps/acceptance-runner/src/http-job-source.ts
+++ b/apps/acceptance-runner/src/http-job-source.ts
@@ -1,0 +1,93 @@
+// HTTP job source: leases acceptance jobs from the gateway over an authenticated pull
+// endpoint (EPIC #6017).
+//
+// The out-of-Worker runner CANNOT be a Cloudflare Queue consumer (a consumer is a
+// Worker; chromium never runs in a Worker), so it PULLS its work. This source polls an
+// authenticated `GET <leaseUrl>` that returns the next pending acceptance job (or 204 /
+// `{ job: null }` when the queue is empty), runs it, and reports the outcome back with
+// `POST <ackUrl>`. Both calls carry the runner bearer token. The lease/ack endpoints are
+// the Worker-side counterpart (`acceptance-job-lease-routes.ts`), INERT by default.
+//
+// FAIL-CLOSED: a missing token or URL means no source (the daemon does nothing). A
+// non-2xx is a typed transport fault the daemon treats as a transient idle (back off,
+// retry) — it never fabricates a job or a verdict.
+
+import { AcceptanceJobMessage } from './harness-bridge'
+import {
+  type JobSource,
+  type LeasedJob,
+  JobLeaseTransportError,
+} from './job-source'
+
+export type HttpJobSourceConfig = Readonly<{
+  // The authenticated lease endpoint (GET). Returns the next job or an empty signal.
+  leaseUrl: string
+  // The authenticated ack endpoint (POST). Reports delivered / retryable per leaseId.
+  ackUrl: string
+  // The runner bearer token (the SAME ACCEPTANCE_VERDICT_CALLBACK_TOKEN the verdict
+  // callback uses, so one secret authenticates the whole runner<->gateway channel).
+  bearerToken: string
+  // Injectable for tests.
+  fetchFn?: typeof fetch
+}>
+
+// Decode the lease response body into a typed leased job, or null. The Worker returns
+// `{ leaseId, job }` for a leased job, or `{ job: null }` / 204 for the idle case. The
+// `job` is decoded through the SAME `AcceptanceJobMessage` schema the dispatch produces.
+const decodeLeasedJob = (value: unknown): LeasedJob | null => {
+  if (value === null || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  if (record.job === null || record.job === undefined) return null
+  const leaseId = record.leaseId
+  if (typeof leaseId !== 'string' || leaseId.trim() === '') return null
+  // Throws on a malformed job — a malformed lease is a transport fault, not a silent
+  // skip; the daemon backs off rather than running garbage.
+  const message = AcceptanceJobMessage.make(
+    AcceptanceJobMessageFromUnknown(record.job),
+  )
+  return { leaseId, message }
+}
+
+// AcceptanceJobMessage.make wants the decoded fields; the wire carries them as plain
+// JSON. We decode through the class' schema to validate the shape at the boundary.
+const AcceptanceJobMessageFromUnknown = (
+  value: unknown,
+): AcceptanceJobMessage => {
+  // The class is an Effect Schema class; decoding an unknown validates every field
+  // (schemaVersion literal, spec params, etc.). A bad payload throws here.
+  return AcceptanceJobMessage.make(value as AcceptanceJobMessage)
+}
+
+export const makeHttpJobSource = (config: HttpJobSourceConfig): JobSource => {
+  const fetchFn = config.fetchFn ?? fetch
+  const authHeaders = {
+    authorization: `Bearer ${config.bearerToken}`,
+    'content-type': 'application/json',
+  }
+  return {
+    ack: async ({ leaseId, delivered }) => {
+      const response = await fetchFn(config.ackUrl, {
+        body: JSON.stringify({ delivered, leaseId }),
+        headers: authHeaders,
+        method: 'POST',
+      })
+      if (!response.ok) {
+        throw new JobLeaseTransportError('ack', response.status)
+      }
+    },
+    label: `http:${config.leaseUrl}`,
+    lease: async () => {
+      const response = await fetchFn(config.leaseUrl, {
+        headers: authHeaders,
+        method: 'GET',
+      })
+      // 204 = no pending job (the idle case).
+      if (response.status === 204) return null
+      if (!response.ok) {
+        throw new JobLeaseTransportError('lease', response.status)
+      }
+      const body = (await response.json().catch(() => null)) as unknown
+      return decodeLeasedJob(body)
+    },
+  }
+}

--- a/apps/acceptance-runner/src/job-source.ts
+++ b/apps/acceptance-runner/src/job-source.ts
@@ -1,0 +1,52 @@
+// The JOB-SOURCE seam for the out-of-Worker acceptance runner (EPIC #6017).
+//
+// THE PROBLEM. The gateway (a Cloudflare Worker) must hand acceptance jobs to a node
+// with chromium — but a Cloudflare Queue CONSUMER is itself a Worker, and chromium can
+// NEVER run in a Worker. So the out-of-Worker runner cannot be a Queue consumer; it has
+// to PULL its work over an authenticated HTTP endpoint (a job lease) OR be handed a
+// single job locally for a one-shot run. This module is the pluggable seam for "where
+// does the next job come from", mirroring the `RunnerTransport` seam in the harness
+// (`acceptance-runner/harness.ts`) for "where does the artifact come from / where does
+// the verdict go".
+//
+// FAIL-CLOSED + INERT: the HTTP job source is configured out of band (the runner host's
+// local secret). With no lease URL / no bearer token the daemon has no job source and
+// does nothing — it never invents work. A poll that returns "no job" is the normal idle
+// state, not an error.
+
+import type { AcceptanceJobMessage } from './harness-bridge'
+
+// One leased job plus the lease handle the source needs to ack/extend it. `leaseId` is
+// opaque to the runner — it is echoed back to the source so the Worker can mark the job
+// done / retryable. `message` is the typed `AcceptanceJobMessage` the harness runs.
+export type LeasedJob = Readonly<{
+  leaseId: string
+  message: AcceptanceJobMessage
+}>
+
+// The pluggable job source. `lease()` returns the next pending job or `null` when the
+// queue is empty (the idle case — NOT an error). `ack()` reports the terminal outcome of
+// a leased job back to the source so it can be removed (delivered) or re-queued
+// (retryable). A source that has no ack concept (a one-shot file source) implements
+// `ack` as a no-op.
+export type JobSource = Readonly<{
+  lease: () => Promise<LeasedJob | null>
+  ack: (
+    input: Readonly<{ leaseId: string; delivered: boolean }>,
+  ) => Promise<void>
+  // A human label for logs (e.g. "http:https://openagents.com/...", "file:job.json").
+  readonly label: string
+}>
+
+// A typed lease-transport fault so a non-2xx lease/ack response is legible (status as a
+// field, not parsed from a string) — the same `*Error extends Error` discipline the
+// harness uses for delivery faults. The daemon treats a lease fault as a transient idle
+// (back off and retry), never as a reason to fabricate a verdict.
+export class JobLeaseTransportError extends Error {
+  readonly status: number
+  constructor(operation: string, status: number) {
+    super(`job_lease_${operation}_failed: ${status}`)
+    this.name = 'JobLeaseTransportError'
+    this.status = status
+  }
+}

--- a/apps/acceptance-runner/src/run-once.ts
+++ b/apps/acceptance-runner/src/run-once.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env bun
+// One-shot ENTRYPOINT for the out-of-Worker acceptance runner (EPIC #6017).
+//
+// Runs the SAME canonical harness the daemon runs, but against a LOCAL artifact file and
+// for exactly ONE job — no lease loop. Two uses:
+//   1. Local proof / manual replay: run a committed artifact through the real headless
+//      suite and print the verdict (exit non-zero when not verified), like the worker
+//      `acceptance-runner/cli.ts` but exercising the full `runAcceptanceJob` job path
+//      (artifact resolve -> run -> build verdict payload).
+//   2. End-to-end smoke against a live callback: with --callback-url + a token it POSTs
+//      the produced verdict to the gateway verdict callback (the real delivery the
+//      daemon does), so you can prove the receipt backfills `verified:true` without
+//      standing up the lease loop.
+//
+// Usage:
+//   bun src/run-once.ts <artifact.html> [--request-id <id>] [--served-model <m>]
+//                       [--worker <w>] [--callback-url <url>] [--json]
+//   ACCEPTANCE_VERDICT_CALLBACK_TOKEN=<tok> bun src/run-once.ts art.html --callback-url <url>
+//
+// Prereq: `bunx playwright install chromium`.
+
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+
+import {
+  type RunnerTransport,
+  AcceptanceJobMessage,
+  crossyRoadAcceptanceSpec,
+  makeFetchVerdictPoster,
+  runAcceptanceJob,
+} from './harness-bridge'
+
+type Args = Readonly<{
+  artifactPath: string
+  requestId: string
+  servedModel: string
+  worker: string
+  callbackUrl: string | undefined
+  json: boolean
+}>
+
+const parseArgs = (argv: ReadonlyArray<string>): Args | undefined => {
+  const positional: string[] = []
+  const flags = new Map<string, string>()
+  let json = false
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!
+    if (arg === '--json') {
+      json = true
+    } else if (arg.startsWith('--')) {
+      const value = argv[i + 1]
+      if (value === undefined) return undefined
+      flags.set(arg.slice(2), value)
+      i += 1
+    } else {
+      positional.push(arg)
+    }
+  }
+  const artifactPath = positional[0]
+  if (artifactPath === undefined) return undefined
+  return {
+    artifactPath,
+    callbackUrl: flags.get('callback-url'),
+    json,
+    requestId:
+      flags.get('request-id') ?? 'acceptance.runner.run-once.local-proof.v1',
+    servedModel: flags.get('served-model') ?? 'openagents/khala-code',
+    worker: flags.get('worker') ?? 'khala-code-crossy-road-verifier',
+  }
+}
+
+const main = async (): Promise<void> => {
+  const args = parseArgs(process.argv.slice(2))
+  if (args === undefined) {
+    console.error(
+      'Usage: bun src/run-once.ts <artifact.html> [--request-id id] ' +
+        '[--served-model m] [--worker w] [--callback-url url] [--json]',
+    )
+    process.exit(2)
+    return
+  }
+
+  const html = await readFile(args.artifactPath, 'utf8')
+  const spec = crossyRoadAcceptanceSpec()
+
+  // Build the SAME job message the gateway dispatch would enqueue. The artifact ref is a
+  // local marker here; the transport's resolver returns the file bytes directly.
+  const message = AcceptanceJobMessage.make({
+    artifactRef: `file://${args.artifactPath}`,
+    meteringReceiptRef: null,
+    requestId: args.requestId,
+    schemaVersion: 'openagents.inference.acceptance_job.v1',
+    servedModel: args.servedModel,
+    spec: {
+      checks: spec.checks,
+      kind: spec.kind,
+      params: spec.params,
+      rubricRef: spec.rubricRef,
+    },
+    worker: args.worker,
+  })
+
+  // Local transport: resolve the artifact from the already-read file, and either POST the
+  // verdict to a live callback (the real delivery) or record it locally (proof print).
+  let recorded = false
+  const token = process.env.ACCEPTANCE_VERDICT_CALLBACK_TOKEN
+  const postVerdict: RunnerTransport['postVerdict'] =
+    args.callbackUrl !== undefined && token !== undefined && token.trim() !== ''
+      ? makeFetchVerdictPoster({
+          bearerToken: token,
+          callbackUrl: args.callbackUrl,
+        })
+      : async () => {
+          recorded = true
+        }
+
+  const transport: RunnerTransport = {
+    postVerdict,
+    resolveArtifact: async () => html,
+  }
+
+  const result = await runAcceptanceJob(transport, message)
+  const { verdict } = result
+
+  if (args.json) {
+    console.log(JSON.stringify({ delivered: result.delivered, verdict }, null, 2))
+  } else {
+    console.log('=== EXECUTED ACCEPTANCE VERDICT (run-once) ===')
+    console.log('requestId:', args.requestId)
+    console.log('verified:', verdict.verified)
+    console.log('scalarReward:', verdict.scalarReward)
+    console.log(
+      'passed:',
+      `${verdict.passedChecks.length}/${verdict.checks.length}`,
+    )
+    console.log('failedChecks:', verdict.failedChecks.join(', ') || '(none)')
+    for (const check of verdict.checks) {
+      console.log(`  [${check.passed ? 'PASS' : 'FAIL'}] ${check.id}: ${check.detail}`)
+    }
+    if (args.callbackUrl !== undefined) {
+      console.log('callbackUrl:', args.callbackUrl)
+      console.log('delivered:', result.delivered)
+    } else if (recorded) {
+      console.log('(no --callback-url: verdict not delivered; printed only)')
+    }
+  }
+
+  process.exit(verdict.verified ? 0 : 1)
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/apps/acceptance-runner/src/service.ts
+++ b/apps/acceptance-runner/src/service.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+// Long-running daemon ENTRYPOINT for the out-of-Worker acceptance runner (EPIC #6017).
+//
+// This is what runs on the host (our GCE box / Cloud Run / a Pylon). It reads the
+// FAIL-CLOSED config from env, builds the HTTP job source + transport, and starts the
+// poll loop. With required secrets missing it exits non-zero WITHOUT polling — a
+// half-configured host never runs and never invents work.
+//
+// Required env (the host's local secrets — see apps/acceptance-runner/docs/DEPLOY.md):
+//   ACCEPTANCE_VERDICT_CALLBACK_URL   the Worker verdict callback (POST target)
+//   ACCEPTANCE_JOB_LEASE_URL          the Worker job-lease endpoint (GET)
+//   ACCEPTANCE_JOB_ACK_URL            the Worker job-ack endpoint (POST)
+//   ACCEPTANCE_VERDICT_CALLBACK_TOKEN the shared runner bearer token (never logged)
+// Optional: ACCEPTANCE_POLL_INTERVAL_MS, ACCEPTANCE_IDLE_BACKOFF_MS,
+//   ACCEPTANCE_NAV_TIMEOUT_MS.
+//
+// Prereq on the host: `bunx playwright install --with-deps chromium`.
+
+import process from 'node:process'
+
+import { readRunnerServiceConfig } from './config'
+import { startRunnerDaemon, type DaemonLogEvent } from './daemon'
+import { makeHttpJobSource } from './http-job-source'
+
+const logEvent = (event: DaemonLogEvent): void => {
+  // Structured, secret-free JSON line to stdout (the host captures it). Never the token,
+  // artifact bytes, or prompt.
+  console.log(JSON.stringify({ at: new Date().toISOString(), ...event }))
+}
+
+const main = async (): Promise<void> => {
+  const result = readRunnerServiceConfig(process.env)
+  if (!result.ok) {
+    console.error(
+      `acceptance-runner: refusing to start — missing required env: ${result.missing.join(', ')}`,
+    )
+    process.exit(2)
+  }
+  const { config } = result
+
+  const source = makeHttpJobSource({
+    ackUrl: config.jobAckUrl,
+    bearerToken: config.bearerToken,
+    leaseUrl: config.jobLeaseUrl,
+  })
+
+  console.log(
+    JSON.stringify({
+      at: new Date().toISOString(),
+      kind: 'start',
+      pollIntervalMs: config.pollIntervalMs,
+      source: source.label,
+      verdictCallback: config.verdictCallbackUrl,
+    }),
+  )
+
+  const handle = startRunnerDaemon({ config, log: logEvent, source })
+
+  const shutdown = (signal: string): void => {
+    console.log(
+      JSON.stringify({ at: new Date().toISOString(), kind: 'shutdown', signal }),
+    )
+    handle.stop()
+  }
+  process.on('SIGTERM', () => shutdown('SIGTERM'))
+  process.on('SIGINT', () => shutdown('SIGINT'))
+
+  await handle.done
+  process.exit(0)
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/apps/acceptance-runner/tsconfig.json
+++ b/apps/acceptance-runner/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    // bun-types for the runtime; @cloudflare/workers-types supplies the ambient D1/Queue/
+    // R2 globals referenced by the bridged worker harness source (the runner never CALLS
+    // those D1 paths — they are dead branches here — but `tsc` follows the imports, so
+    // the ambient types must resolve for a clean typecheck).
+    "types": ["bun-types", "@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/openagents.com/workers/api/migrations/0222_khala_acceptance_job_queue.sql
+++ b/apps/openagents.com/workers/api/migrations/0222_khala_acceptance_job_queue.sql
@@ -1,0 +1,35 @@
+-- Out-of-Worker acceptance-runner PULL queue (EPIC #6017).
+--
+-- The gateway dispatch enqueues acceptance jobs, but the out-of-Worker runner CANNOT be
+-- a Cloudflare Queue consumer (a consumer is a Worker; chromium never runs in a Worker),
+-- so it PULLS its work over an authenticated lease endpoint. This table is the durable
+-- pull queue the lease/ack routes operate on: a job is `pending` until leased, then
+-- `leased` with a lease expiry (so a crashed runner's job is re-leasable after the
+-- timeout), then removed when the verdict callback backfills (acked delivered) or
+-- re-`pending` (acked retryable / lease expired).
+--
+-- INERT: nothing writes rows here until the dispatch producer is wired to enqueue into
+-- this table (a NEEDS-OWNER step owned by the dispatch lane) AND the lease routes are
+-- armed. With no rows, the lease endpoint always returns "no job" (204) and the runner
+-- idles. This table only stores a dereferenceable artifact ref + the typed job payload,
+-- NEVER raw artifact bytes (those live in R2) and NEVER prompts/credentials.
+CREATE TABLE IF NOT EXISTS khala_acceptance_jobs (
+    -- The inference response id the verdict backfills (one job per khala-code outcome).
+    request_id TEXT PRIMARY KEY,
+    -- 'pending' (available to lease) | 'leased' (in flight, lease_expires_at set).
+    status TEXT NOT NULL DEFAULT 'pending',
+    -- The full typed AcceptanceJobMessage as JSON text (schema-validated on lease).
+    job_payload TEXT NOT NULL,
+    -- The opaque lease handle the runner echoes back to ack; null while pending.
+    lease_id TEXT,
+    -- When the current lease expires and the job becomes re-leasable; null while pending.
+    lease_expires_at TEXT,
+    -- How many times this job has been leased (a poison job can be capped by the routes).
+    attempts INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+-- Lease query: oldest pending (or lease-expired) job first.
+CREATE INDEX IF NOT EXISTS idx_khala_acceptance_jobs_lease
+    ON khala_acceptance_jobs (status, lease_expires_at, created_at);

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -335,6 +335,11 @@ import {
   handleAcceptanceVerdictCallback,
 } from './inference/acceptance-verdict-callback-routes'
 import {
+  handleAcceptanceJobAck,
+  handleAcceptanceJobLease,
+} from './inference/acceptance-job-lease-routes'
+import { makeD1AcceptanceJobQueueStore } from './inference/acceptance-job-queue-store'
+import {
   settleVerifiedAcceptedOutcome,
   summarizeAcceptedOutcomeSettlement,
 } from './inference/khala-accepted-outcome-settlement'
@@ -10133,6 +10138,48 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         ...((sink => (sink === undefined ? {} : { settlement: sink }))(
           makeAcceptedOutcomeSettlementSink(env),
         )),
+      }),
+  },
+  {
+    // Out-of-Worker runner JOB LEASE (EPIC #6017). The runner CANNOT be a Cloudflare
+    // Queue consumer (a consumer is a Worker; chromium never runs in a Worker), so it
+    // PULLS work here: an authenticated GET leases the next pending acceptance job (or
+    // 204 when idle). The runner runs the headless suite OUT of the Worker and POSTs the
+    // verdict to the callback above. INERT by default: gated by INFERENCE_GATEWAY_ENABLED
+    // AND closed unless ACCEPTANCE_VERDICT_CALLBACK_TOKEN is configured (every request
+    // 401), AND empty until the dispatch producer enqueues into the pull queue (a
+    // NEEDS-OWNER step owned by the dispatch lane). The lease uses the SAME bearer token
+    // as the verdict callback — one secret authenticates the whole runner<->gateway
+    // channel.
+    path: '/v1/inference/acceptance-jobs/lease',
+    handler: (request, env) =>
+      handleAcceptanceJobLease(request, {
+        callbackToken: env.ACCEPTANCE_VERDICT_CALLBACK_TOKEN,
+        enabled: isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED),
+        newLeaseId: () => crypto.randomUUID(),
+        nowIso: currentIsoTimestamp,
+        store: makeD1AcceptanceJobQueueStore(
+          openAgentsDatabase(env),
+          currentIsoTimestamp,
+        ),
+      }),
+  },
+  {
+    // Out-of-Worker runner JOB ACK (EPIC #6017). The runner reports a leased job's
+    // terminal outcome: delivered (the verdict was posted + the receipt backfilled) =>
+    // remove the job; retryable (delivery failed) => return it to pending for re-lease.
+    // Same INERT gate + bearer auth as the lease route.
+    path: '/v1/inference/acceptance-jobs/ack',
+    handler: (request, env) =>
+      handleAcceptanceJobAck(request, {
+        callbackToken: env.ACCEPTANCE_VERDICT_CALLBACK_TOKEN,
+        enabled: isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED),
+        newLeaseId: () => crypto.randomUUID(),
+        nowIso: currentIsoTimestamp,
+        store: makeD1AcceptanceJobQueueStore(
+          openAgentsDatabase(env),
+          currentIsoTimestamp,
+        ),
       }),
   },
   {

--- a/apps/openagents.com/workers/api/src/inference/acceptance-job-lease-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-job-lease-routes.ts
@@ -1,0 +1,145 @@
+// Authenticated job-LEASE + ACK routes for the out-of-Worker acceptance runner (EPIC
+// #6017).
+//
+// The out-of-Worker runner cannot be a Cloudflare Queue consumer (a consumer is a
+// Worker; chromium never runs in a Worker), so it PULLS its work here:
+//   GET  <lease>  -> 204 (no job) | 200 { leaseId, job } (a claimed AcceptanceJobMessage)
+//   POST <ack>    -> 200 { acked } for { leaseId, delivered }
+// Both are authenticated with the SAME bearer token the verdict callback verifies
+// (`ACCEPTANCE_VERDICT_CALLBACK_TOKEN`) — ONE secret authenticates the whole
+// runner<->gateway channel (lease + ack + verdict POST).
+//
+// FAIL-CLOSED + INERT:
+//   - gated by INFERENCE_GATEWAY_ENABLED (404 when off), like the verdict callback;
+//   - closed unless the callback token is configured (every request 401);
+//   - with no enqueued jobs the lease always returns 204 and the runner idles.
+// So prod behaviour is unchanged until the dispatch producer is wired to enqueue into
+// the pull queue AND a runner host is armed with the token.
+
+import { Effect, Schema as S } from 'effect'
+
+import { noStoreJsonResponse } from '../http/responses'
+import { parseJsonUnknown } from '../json-boundary'
+import {
+  AcceptanceJobMessage,
+  authenticateVerdictCallback,
+} from './acceptance-dispatch'
+import type { AcceptanceJobQueueStore } from './acceptance-job-queue-store'
+
+// Default lease TTL: a runner that crashes mid-job has its job re-leasable after this.
+// Generous relative to a headless suite (a few seconds) so a slow-but-live runner is not
+// double-leased, bounded so a crash does not strand a job for long.
+export const DEFAULT_ACCEPTANCE_LEASE_TTL_MS = 120_000
+
+export type AcceptanceJobLeaseDeps = Readonly<{
+  // Gateway flag (INFERENCE_GATEWAY_ENABLED). Default OFF => 404.
+  enabled: boolean
+  // The shared runner bearer token. Undefined => closed (every request 401). Never logged.
+  callbackToken: string | undefined
+  store: AcceptanceJobQueueStore
+  nowIso: () => string
+  // Unique lease-id minter (crypto.randomUUID in prod; deterministic in tests).
+  newLeaseId: () => string
+  leaseTtlMs?: number | undefined
+}>
+
+const unauthorized = () =>
+  noStoreJsonResponse(
+    { error: 'unauthorized' },
+    { headers: new Headers({ 'www-authenticate': 'Bearer' }), status: 401 },
+  )
+
+const AckBody = S.Struct({
+  leaseId: S.String,
+  delivered: S.Boolean,
+})
+
+// GET: lease the next claimable acceptance job. 204 when the queue is empty (idle).
+export const handleAcceptanceJobLease = (
+  request: Request,
+  deps: AcceptanceJobLeaseDeps,
+) =>
+  Effect.gen(function* () {
+    if (!deps.enabled) {
+      return noStoreJsonResponse(
+        { error: 'inference_gateway_disabled' },
+        { status: 404 },
+      )
+    }
+    if (request.method !== 'GET') {
+      return noStoreJsonResponse({ error: 'method_not_allowed' }, { status: 405 })
+    }
+    if (
+      !authenticateVerdictCallback({
+        authorizationHeader: request.headers.get('authorization'),
+        configuredToken: deps.callbackToken,
+      })
+    ) {
+      return unauthorized()
+    }
+
+    const leased = yield* deps.store.lease({
+      leaseTtlMs: deps.leaseTtlMs ?? DEFAULT_ACCEPTANCE_LEASE_TTL_MS,
+      newLeaseId: deps.newLeaseId(),
+      nowIso: deps.nowIso(),
+    })
+    if (leased === null) {
+      return new Response(null, { status: 204 })
+    }
+    return noStoreJsonResponse(
+      {
+        // Encode the typed message back to plain JSON for the wire; the runner re-decodes
+        // it through the SAME schema before running.
+        job: S.encodeSync(AcceptanceJobMessage)(leased.message),
+        leaseId: leased.leaseId,
+      },
+      { status: 200 },
+    )
+  })
+
+// POST: ack a leased job as delivered (remove) or retryable (return to pending).
+export const handleAcceptanceJobAck = (
+  request: Request,
+  deps: AcceptanceJobLeaseDeps,
+) =>
+  Effect.gen(function* () {
+    if (!deps.enabled) {
+      return noStoreJsonResponse(
+        { error: 'inference_gateway_disabled' },
+        { status: 404 },
+      )
+    }
+    if (request.method !== 'POST') {
+      return noStoreJsonResponse({ error: 'method_not_allowed' }, { status: 405 })
+    }
+    if (
+      !authenticateVerdictCallback({
+        authorizationHeader: request.headers.get('authorization'),
+        configuredToken: deps.callbackToken,
+      })
+    ) {
+      return unauthorized()
+    }
+
+    const text = yield* Effect.promise(() => request.text().catch(() => ''))
+    if (text === '') {
+      return noStoreJsonResponse({ error: 'invalid_json' }, { status: 400 })
+    }
+    const body = (() => {
+      try {
+        return S.decodeUnknownSync(AckBody)(parseJsonUnknown(text))
+      } catch {
+        return undefined
+      }
+    })()
+    if (body === undefined) {
+      return noStoreJsonResponse({ error: 'invalid_ack' }, { status: 400 })
+    }
+
+    yield* deps.store.ack({
+      delivered: body.delivered,
+      leaseId: body.leaseId,
+      nowIso: deps.nowIso(),
+    })
+    return noStoreJsonResponse({ acked: true }, { status: 200 })
+  })

--- a/apps/openagents.com/workers/api/src/inference/acceptance-job-queue-store.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-job-queue-store.ts
@@ -1,0 +1,205 @@
+// The durable PULL queue store for out-of-Worker acceptance jobs (EPIC #6017).
+//
+// The dispatch (`acceptance-dispatch.ts`) enqueues a job for each khala-code completion
+// with an executable artifact. The out-of-Worker runner cannot be a Cloudflare Queue
+// consumer (a consumer is a Worker; chromium never runs in a Worker), so it PULLS work
+// over an authenticated lease endpoint. This store is the pull queue those lease/ack
+// routes operate on. It is Worker-safe (D1 only; no Playwright, no chromium).
+//
+// LEASE SEMANTICS (at-least-once, idempotent downstream):
+//   - `enqueue(message)` inserts a `pending` row keyed by request id (ON CONFLICT keeps
+//     the existing row so a duplicate dispatch never resets an in-flight lease).
+//   - `lease(now, ttlMs)` atomically claims the oldest claimable job — `pending` OR a
+//     `leased` row whose lease has EXPIRED (a crashed runner's job becomes re-leasable)
+//     — stamping a fresh `leaseId` + expiry and bumping `attempts`. Returns null when
+//     nothing is claimable (the idle case).
+//   - `ack(leaseId, delivered)` removes the job when the runner delivered the verdict
+//     (the verdict callback backfilled the receipt), or returns it to `pending` when the
+//     delivery failed (re-leasable). An ack for a stale/unknown lease is a no-op.
+// Downstream idempotency: the verdict callback's backfill is already idempotent, so an
+// at-least-once re-lease (e.g. an ack lost after delivery) never double-writes a receipt.
+
+import { Effect, Schema as S } from 'effect'
+
+import { AcceptanceJobMessage } from './acceptance-dispatch'
+
+export type AcceptanceQueueStatus = 'pending' | 'leased'
+
+export type LeasedAcceptanceJob = Readonly<{
+  leaseId: string
+  message: AcceptanceJobMessage
+}>
+
+export type AcceptanceJobQueueStore = Readonly<{
+  // Insert a pending job. Idempotent per request id (a duplicate dispatch is ignored).
+  enqueue: (message: AcceptanceJobMessage) => Effect.Effect<void>
+  // Claim the next available job (pending or lease-expired). Null when none claimable.
+  lease: (
+    input: Readonly<{ nowIso: string; leaseTtlMs: number; newLeaseId: string }>,
+  ) => Effect.Effect<LeasedAcceptanceJob | null>
+  // Terminal ack: delivered => remove; retryable => return to pending. No-op for an
+  // unknown/stale lease id.
+  ack: (
+    input: Readonly<{ leaseId: string; delivered: boolean; nowIso: string }>,
+  ) => Effect.Effect<void>
+}>
+
+const decodeJobPayload = (text: string): AcceptanceJobMessage =>
+  S.decodeUnknownSync(AcceptanceJobMessage)(JSON.parse(text))
+
+const encodeJobPayload = (message: AcceptanceJobMessage): string =>
+  JSON.stringify(S.encodeSync(AcceptanceJobMessage)(message))
+
+// An in-memory queue store: the reference implementation tests run against and the D1
+// store mirrors. Pure + synchronous under the Effect wrapper. The `lease` claim is
+// single-threaded here (Effect.sync), matching D1's single-statement atomic UPDATE.
+export const makeInMemoryAcceptanceJobQueueStore =
+  (): AcceptanceJobQueueStore => {
+    type Row = {
+      requestId: string
+      status: AcceptanceQueueStatus
+      payload: string
+      leaseId: string | null
+      leaseExpiresAt: string | null
+      attempts: number
+      createdAt: string
+    }
+    const rows = new Map<string, Row>()
+
+    return {
+      ack: ({ leaseId, delivered, nowIso }) =>
+        Effect.sync(() => {
+          for (const row of rows.values()) {
+            if (row.leaseId === leaseId && row.status === 'leased') {
+              if (delivered) {
+                rows.delete(row.requestId)
+              } else {
+                row.status = 'pending'
+                row.leaseId = null
+                row.leaseExpiresAt = null
+              }
+              void nowIso
+              return
+            }
+          }
+        }),
+      enqueue: message =>
+        Effect.sync(() => {
+          if (rows.has(message.requestId)) return
+          rows.set(message.requestId, {
+            attempts: 0,
+            createdAt: new Date().toISOString(),
+            leaseExpiresAt: null,
+            leaseId: null,
+            payload: encodeJobPayload(message),
+            requestId: message.requestId,
+            status: 'pending',
+          })
+        }),
+      lease: ({ nowIso, leaseTtlMs, newLeaseId }) =>
+        Effect.sync(() => {
+          const now = Date.parse(nowIso)
+          const claimable = [...rows.values()]
+            .filter(
+              row =>
+                row.status === 'pending' ||
+                (row.status === 'leased' &&
+                  row.leaseExpiresAt !== null &&
+                  Date.parse(row.leaseExpiresAt) <= now),
+            )
+            .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+          const row = claimable[0]
+          if (row === undefined) return null
+          row.status = 'leased'
+          row.leaseId = newLeaseId
+          row.leaseExpiresAt = new Date(now + leaseTtlMs).toISOString()
+          row.attempts += 1
+          return { leaseId: newLeaseId, message: decodeJobPayload(row.payload) }
+        }),
+    }
+  }
+
+// A D1-backed queue store (prod). Mirrors the in-memory reference against the
+// `khala_acceptance_jobs` table (migration 0222). The lease claim is a single atomic
+// UPDATE ... WHERE request_id = (subselect oldest claimable) so two concurrent runner
+// pulls cannot lease the same job.
+export const makeD1AcceptanceJobQueueStore = (
+  db: D1Database,
+  nowIso: () => string,
+): AcceptanceJobQueueStore => ({
+  ack: ({ leaseId, delivered, nowIso: at }) =>
+    Effect.tryPromise(() =>
+      delivered
+        ? db
+            .prepare(
+              `DELETE FROM khala_acceptance_jobs
+                 WHERE lease_id = ? AND status = 'leased'`,
+            )
+            .bind(leaseId)
+            .run()
+        : db
+            .prepare(
+              `UPDATE khala_acceptance_jobs
+                  SET status = 'pending', lease_id = NULL, lease_expires_at = NULL,
+                      updated_at = ?
+                WHERE lease_id = ? AND status = 'leased'`,
+            )
+            .bind(at, leaseId)
+            .run(),
+    ).pipe(Effect.asVoid, Effect.orDie),
+
+  enqueue: message =>
+    Effect.tryPromise(() =>
+      db
+        .prepare(
+          `INSERT INTO khala_acceptance_jobs (
+             request_id, status, job_payload, lease_id, lease_expires_at,
+             attempts, created_at, updated_at
+           ) VALUES (?, 'pending', ?, NULL, NULL, 0, ?, ?)
+           ON CONFLICT(request_id) DO NOTHING`,
+        )
+        .bind(message.requestId, encodeJobPayload(message), nowIso(), nowIso())
+        .run(),
+    ).pipe(Effect.asVoid, Effect.orDie),
+
+  lease: ({ nowIso: at, leaseTtlMs, newLeaseId }) =>
+    Effect.tryPromise(async () => {
+      const expiresAt = new Date(Date.parse(at) + leaseTtlMs).toISOString()
+      // Atomic claim: stamp the oldest claimable row (pending OR lease-expired).
+      await db
+        .prepare(
+          `UPDATE khala_acceptance_jobs
+              SET status = 'leased', lease_id = ?, lease_expires_at = ?,
+                  attempts = attempts + 1, updated_at = ?
+            WHERE request_id = (
+              SELECT request_id FROM khala_acceptance_jobs
+               WHERE status = 'pending'
+                  OR (status = 'leased' AND lease_expires_at IS NOT NULL
+                      AND lease_expires_at <= ?)
+               ORDER BY created_at ASC
+               LIMIT 1
+            )`,
+        )
+        .bind(newLeaseId, expiresAt, at, at)
+        .run()
+      // Read back the row we just claimed by our unique lease id.
+      const row = await db
+        .prepare(
+          `SELECT job_payload FROM khala_acceptance_jobs
+             WHERE lease_id = ? AND status = 'leased' LIMIT 1`,
+        )
+        .bind(newLeaseId)
+        .first<{ job_payload: string }>()
+      return row
+    }).pipe(
+      Effect.map(row =>
+        row === null
+          ? null
+          : {
+              leaseId: newLeaseId,
+              message: decodeJobPayload(String(row.job_payload)),
+            },
+      ),
+      Effect.orDie,
+    ),
+})

--- a/apps/openagents.com/workers/api/src/inference/acceptance-job-queue.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-job-queue.test.ts
@@ -1,0 +1,190 @@
+// Unit proof for the out-of-Worker acceptance-runner PULL queue (EPIC #6017).
+//
+// Covers the queue store lease semantics (enqueue idempotency, claim oldest-first,
+// expired-lease re-claim, ack delivered/retryable) and the authenticated lease/ack
+// routes (INERT gate, fail-closed auth, 204 idle, 200 lease, ack round-trip). No
+// chromium — this is the Worker-safe pull side only.
+
+import { describe, expect, test } from 'vitest'
+import { Effect } from 'effect'
+
+import { AcceptanceJobMessage } from './acceptance-dispatch'
+import { crossyRoadAcceptanceSpec } from './acceptance-spec'
+import { acceptanceJobSpecFromSpec } from './acceptance-dispatch'
+import { makeInMemoryAcceptanceJobQueueStore } from './acceptance-job-queue-store'
+import {
+  handleAcceptanceJobAck,
+  handleAcceptanceJobLease,
+} from './acceptance-job-lease-routes'
+
+const job = (requestId: string): AcceptanceJobMessage =>
+  AcceptanceJobMessage.make({
+    artifactRef: `r2://artifacts/${requestId}.html`,
+    meteringReceiptRef: null,
+    requestId,
+    schemaVersion: 'openagents.inference.acceptance_job.v1',
+    servedModel: 'openagents/khala-code',
+    spec: acceptanceJobSpecFromSpec(crossyRoadAcceptanceSpec()),
+    worker: 'khala-code-crossy-road-verifier',
+  })
+
+const run = <A>(eff: Effect.Effect<A>): Promise<A> => Effect.runPromise(eff)
+
+const TOKEN = 'test-runner-token'
+let leaseCounter = 0
+const newLeaseId = () => `lease-${(leaseCounter += 1)}`
+
+describe('acceptance job queue store', () => {
+  test('enqueue is idempotent per request id', async () => {
+    const store = makeInMemoryAcceptanceJobQueueStore()
+    await run(store.enqueue(job('r1')))
+    await run(store.enqueue(job('r1')))
+    const a = await run(
+      store.lease({ leaseTtlMs: 1000, newLeaseId: 'l1', nowIso: new Date().toISOString() }),
+    )
+    const b = await run(
+      store.lease({ leaseTtlMs: 1000, newLeaseId: 'l2', nowIso: new Date().toISOString() }),
+    )
+    expect(a?.message.requestId).toBe('r1')
+    // Only ONE row existed despite the duplicate enqueue.
+    expect(b).toBeNull()
+  })
+
+  test('leases oldest pending first, then idles', async () => {
+    const store = makeInMemoryAcceptanceJobQueueStore()
+    await run(store.enqueue(job('older')))
+    await new Promise(r => setTimeout(r, 5))
+    await run(store.enqueue(job('newer')))
+    const first = await run(
+      store.lease({ leaseTtlMs: 1000, newLeaseId: 'l1', nowIso: new Date().toISOString() }),
+    )
+    const second = await run(
+      store.lease({ leaseTtlMs: 1000, newLeaseId: 'l2', nowIso: new Date().toISOString() }),
+    )
+    const third = await run(
+      store.lease({ leaseTtlMs: 1000, newLeaseId: 'l3', nowIso: new Date().toISOString() }),
+    )
+    expect(first?.message.requestId).toBe('older')
+    expect(second?.message.requestId).toBe('newer')
+    expect(third).toBeNull()
+  })
+
+  test('an EXPIRED lease becomes re-claimable; a live lease does not', async () => {
+    const store = makeInMemoryAcceptanceJobQueueStore()
+    await run(store.enqueue(job('r1')))
+    const t0 = '2026-06-22T00:00:00.000Z'
+    const leased = await run(
+      store.lease({ leaseTtlMs: 60_000, newLeaseId: 'l1', nowIso: t0 }),
+    )
+    expect(leased?.leaseId).toBe('l1')
+    // Still within TTL: not re-claimable.
+    const stillLeased = await run(
+      store.lease({ leaseTtlMs: 60_000, newLeaseId: 'l2', nowIso: '2026-06-22T00:00:30.000Z' }),
+    )
+    expect(stillLeased).toBeNull()
+    // After TTL: re-claimable (a crashed runner's job).
+    const reclaimed = await run(
+      store.lease({ leaseTtlMs: 60_000, newLeaseId: 'l3', nowIso: '2026-06-22T00:02:00.000Z' }),
+    )
+    expect(reclaimed?.leaseId).toBe('l3')
+    expect(reclaimed?.message.requestId).toBe('r1')
+  })
+
+  test('ack delivered removes the job; ack retryable returns it to pending', async () => {
+    const store = makeInMemoryAcceptanceJobQueueStore()
+    await run(store.enqueue(job('deliver')))
+    await run(store.enqueue(job('retry')))
+
+    const a = await run(
+      store.lease({ leaseTtlMs: 1000, newLeaseId: 'la', nowIso: new Date().toISOString() }),
+    )
+    await run(store.ack({ delivered: true, leaseId: a!.leaseId, nowIso: new Date().toISOString() }))
+
+    const b = await run(
+      store.lease({ leaseTtlMs: 1000, newLeaseId: 'lb', nowIso: new Date().toISOString() }),
+    )
+    await run(store.ack({ delivered: false, leaseId: b!.leaseId, nowIso: new Date().toISOString() }))
+
+    // 'deliver' is gone; 'retry' is pending again and re-leasable.
+    const next = await run(
+      store.lease({ leaseTtlMs: 1000, newLeaseId: 'lc', nowIso: new Date().toISOString() }),
+    )
+    expect(next?.message.requestId).toBe('retry')
+  })
+})
+
+describe('acceptance job lease/ack routes', () => {
+  const baseDeps = () => ({
+    callbackToken: TOKEN,
+    enabled: true,
+    newLeaseId,
+    nowIso: () => new Date().toISOString(),
+    store: makeInMemoryAcceptanceJobQueueStore(),
+  })
+
+  const get = (token?: string) =>
+    new Request('https://x/v1/inference/acceptance-jobs/lease', {
+      headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
+      method: 'GET',
+    })
+
+  test('INERT: 404 when the gateway is disabled', async () => {
+    const res = await run(
+      handleAcceptanceJobLease(get(TOKEN), { ...baseDeps(), enabled: false }),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  test('fail-closed: 401 without the token, 401 with a wrong token', async () => {
+    const deps = baseDeps()
+    expect((await run(handleAcceptanceJobLease(get(), deps))).status).toBe(401)
+    expect((await run(handleAcceptanceJobLease(get('nope'), deps))).status).toBe(401)
+  })
+
+  test('closed: 401 when no callback token is configured at all', async () => {
+    const deps = { ...baseDeps(), callbackToken: undefined }
+    expect((await run(handleAcceptanceJobLease(get(TOKEN), deps))).status).toBe(401)
+  })
+
+  test('204 when the queue is empty (idle)', async () => {
+    const res = await run(handleAcceptanceJobLease(get(TOKEN), baseDeps()))
+    expect(res.status).toBe(204)
+  })
+
+  test('200 leases a job, ack delivered removes it, then idle 204', async () => {
+    const deps = baseDeps()
+    await run(deps.store.enqueue(job('r-route')))
+
+    const leaseRes = await run(handleAcceptanceJobLease(get(TOKEN), deps))
+    expect(leaseRes.status).toBe(200)
+    const leaseBody = (await leaseRes.json()) as {
+      leaseId: string
+      job: { requestId: string; schemaVersion: string }
+    }
+    expect(leaseBody.job.requestId).toBe('r-route')
+    expect(leaseBody.job.schemaVersion).toBe(
+      'openagents.inference.acceptance_job.v1',
+    )
+
+    const ackReq = new Request('https://x/v1/inference/acceptance-jobs/ack', {
+      body: JSON.stringify({ delivered: true, leaseId: leaseBody.leaseId }),
+      headers: { authorization: `Bearer ${TOKEN}`, 'content-type': 'application/json' },
+      method: 'POST',
+    })
+    const ackRes = await run(handleAcceptanceJobAck(ackReq, deps))
+    expect(ackRes.status).toBe(200)
+
+    // Job removed: next lease idles.
+    expect((await run(handleAcceptanceJobLease(get(TOKEN), deps))).status).toBe(204)
+  })
+
+  test('ack rejects a malformed body 400', async () => {
+    const deps = baseDeps()
+    const bad = new Request('https://x/v1/inference/acceptance-jobs/ack', {
+      body: JSON.stringify({ nope: true }),
+      headers: { authorization: `Bearer ${TOKEN}`, 'content-type': 'application/json' },
+      method: 'POST',
+    })
+    expect((await run(handleAcceptanceJobAck(bad, deps))).status).toBe(400)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/acceptance-runner/runner.ts
+++ b/apps/openagents.com/workers/api/src/inference/acceptance-runner/runner.ts
@@ -122,6 +122,55 @@ const settle = async (page: Page, ms: number): Promise<void> => {
   await page.waitForTimeout(ms)
 }
 
+// Settle until the player STOPS MOVING (the hop/move animation has completed), then
+// return the final state — bounded by `maxMs` so a stuck/never-settling artifact still
+// returns honestly rather than hanging. A fixed `settle(ms)` samples MID-ANIMATION when
+// the artifact's hop tween is slower than the wait (e.g. a ~125ms hop sampled at 80ms
+// reads ~0.2-0.7 of a tile, not a full tile), which made the single-press
+// `forward_input_advances_player` check measure a partial hop and fail an otherwise
+// good artifact. Polling for position stability measures the COMPLETED advance — the
+// honest intent of the check ("one forward press advances ~one tile") — without
+// weakening the pass threshold. Stops as soon as the player position is unchanged
+// between two consecutive polls (within an epsilon), or when `maxMs` elapses.
+const settleUntilStable = async (
+  page: Page,
+  options?: Readonly<{
+    pollMs?: number
+    maxMs?: number
+    epsilon?: number
+    stableReads?: number
+  }>,
+): Promise<GameState | undefined> => {
+  const pollMs = options?.pollMs ?? 60
+  const maxMs = options?.maxMs ?? 900
+  const epsilon = options?.epsilon ?? 1e-4
+  // Require TWO consecutive unchanged polls before declaring stable. The artifact's
+  // render loop is requestAnimationFrame-driven and throttled in headless chromium
+  // (~25fps), so a SINGLE zero-delta between two close polls can be a skipped frame
+  // mid-hop, not the landed position. Requiring consecutive stable reads (with a poll
+  // step coarser than a frame) waits for the hop tween to truly plateau before we
+  // measure the advance. Still bounded by `maxMs` so a never-settling artifact returns
+  // honestly rather than hanging.
+  const stableReads = Math.max(2, options?.stableReads ?? 2)
+  let previous = await readState(page)
+  let stable = 0
+  const deadline = Date.now() + maxMs
+  for (;;) {
+    await settle(page, pollMs)
+    const current = await readState(page)
+    const moved = vecDelta(current?.player, previous?.player)
+    previous = current
+    if (Number.isFinite(moved) && moved <= epsilon) {
+      stable += 1
+    } else {
+      stable = 0
+    }
+    if (stable >= stableReads || Date.now() >= deadline) {
+      return current
+    }
+  }
+}
+
 // Run the full crossy-road acceptance suite against a live page. PURE w.r.t. the spec
 // + page (no global state); returns one result per spec check.
 const runCrossyRoadChecks = async (
@@ -165,11 +214,13 @@ const runCrossyRoadChecks = async (
     passed: loopRunning,
   })
 
-  // 3. forward_input_advances_player — one forward press advances ~one tile.
+  // 3. forward_input_advances_player — one forward press advances ~one tile. Settle
+  //    UNTIL the hop animation lands (not a fixed wait) so we measure the COMPLETED
+  //    advance, not a mid-hop fraction; a fixed wait shorter than the artifact's hop
+  //    duration under-measures the tile and fails a good artifact.
   const preMove = await readState(page)
   await pressForward(page)
-  await settle(page, 80)
-  const postMove = await readState(page)
+  const postMove = await settleUntilStable(page)
   const advance = vecDelta(postMove?.player, preMove?.player)
   const advancedOneTile =
     Number.isFinite(advance) &&
@@ -189,8 +240,9 @@ const runCrossyRoadChecks = async (
   let maxCameraDelta = 0
   for (let move = 0; move < params.forwardMoves; move += 1) {
     await pressForward(page)
-    await settle(page, 60)
-    const next = await readState(page)
+    // Snapshot AFTER the hop lands so each per-move camera delta is measured between
+    // settled positions (consistent with the single-press check), not mid-tween.
+    const next = await settleUntilStable(page)
     const camDelta = vecDelta(next?.camera?.position, prevState?.camera?.position)
     if (Number.isFinite(camDelta)) {
       maxCameraDelta = Math.max(maxCameraDelta, camDelta)

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -138,6 +138,8 @@ const approvedExactRoutePaths = [
   '/v1/chat/completions',
   '/mpp/v1/chat/completions',
   '/v1/inference/acceptance-verdicts',
+  '/v1/inference/acceptance-jobs/lease',
+  '/v1/inference/acceptance-jobs/ack',
   '/v1/models',
   '/v1/quote',
   '/v1/gateway/readiness',

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,19 @@
         "typescript": "catalog:",
       },
     },
+    "apps/acceptance-runner": {
+      "name": "@openagentsinc/acceptance-runner",
+      "version": "0.1.0",
+      "dependencies": {
+        "effect": "catalog:",
+        "playwright": "^1.61.0",
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250601.0",
+        "bun-types": "^1.3.14",
+        "typescript": "^6.0.3",
+      },
+    },
     "apps/autopilot-desktop": {
       "name": "@openagentsinc/autopilot-desktop",
       "version": "0.0.1",
@@ -1065,6 +1078,8 @@
     "@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
 
     "@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@openagentsinc/acceptance-runner": ["@openagentsinc/acceptance-runner@workspace:apps/acceptance-runner"],
 
     "@openagentsinc/agent-runtime-schema": ["@openagentsinc/agent-runtime-schema@workspace:packages/agent-runtime-schema"],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
       "apps/openagents.com/packages/*",
       "apps/openagents.com/services/*",
       "apps/openagents.com/workers/*",
+      "apps/acceptance-runner",
       "apps/autopilot-desktop",
       "apps/forum",
       "apps/oa-updates",


### PR DESCRIPTION
## What this is

The **gating piece for the live auto-settlement loop**: the out-of-Worker headless executor that takes a khala-code artifact, runs the acceptance suite in a real chromium, and POSTs a real `AcceptanceVerdict` back to the Worker so the receipt backfills `verified:true`. No runner -> no executed verdicts -> no verified outcomes -> no payouts.

## The full chain (all INERT until the owner flips the flags)

```
 openagents.com Worker (CF, no chromium)          acceptance-runner (this PR, node + chromium)
   khala-code completion w/ executable artifact
     └ enqueueAcceptanceJob ─▶ pull queue (D1) ◀── GET  /v1/inference/acceptance-jobs/lease  (auth; 204 idle)
       (KHALA_ACCEPTANCE_DISPATCH_ENABLED)            ├ resolveArtifact (R2-signed GET)
                                                      ├ runAcceptanceSuite ▶ chromium  → 6/6
   POST /v1/inference/acceptance-verdicts ◀────────── postVerdict (bearer token)
     └ handleAcceptanceVerdictCallback                └ POST /v1/inference/acceptance-jobs/ack (delivered|retry)
       (ACCEPTANCE_VERDICT_CALLBACK_TOKEN)
     └ backfill receipt: unverified ▶ test_passed/failed, verified
     └ settlement sink fires IFF khala-loop flag + owner gate armed  ← SEPARATE lane, untouched here
```

One shared bearer token authenticates the whole runner↔gateway channel (lease + ack + verdict POST).

## What I built vs. what is a deploy step

**Built** — `apps/acceptance-runner/` standalone daemon (orchestrates the canonical worker harness, forks nothing): `daemon.ts` (lease→run→post→ack loop, fail-soft, graceful-stop, injectable runner so the loop is browser-free unit-testable), `service.ts` (fail-closed entrypoint), `run-once.ts` (one-shot local proof / live-callback POST), `http-job-source.ts` + `job-source.ts` + `config.ts`, `harness-bridge.ts`, `Dockerfile` (Playwright base + Bun). Plus the Worker pull-queue side (INERT): `acceptance-job-queue-store.ts` (D1 + in-memory, atomic lease, expired-lease re-claim, delivered/retryable ack), `acceptance-job-lease-routes.ts` (authed GET/POST), migration `0222`, routes wired into `index.ts`, exact-routes manifest updated. Plus a runner robustness fix (`settleUntilStable`) so the single-press advance check measures the **completed** hop — the committed passing artifact now scores a clean **6/6**, broken fixtures still fail honestly.

**Deploy steps (owner; NOT done here):** host the runner, mint+set the token, wire the dispatch producer (`queue: undefined`) to the pull queue + R2 artifact store, flip `KHALA_ACCEPTANCE_DISPATCH_ENABLED=true`, apply migration 0222, deploy. Full detail + diagram in `apps/acceptance-runner/docs/DEPLOY.md`.

## Recommended host

**Our GCE** (matches "unattended execution goes on OUR Google Cloud"): a no-inbound-port pull daemon fits a VM cleanly (Cloud Run wants an HTTP server + always-warm min-instance, which is just a worse always-on VM); chromium + deps come free from the Playwright base image. A Pylon node is the natural long-term home once the fleet is the execution substrate. Concrete `docker build`/`docker run` steps are in DEPLOY.md.

## Stays INERT until armed

`INFERENCE_GATEWAY_ENABLED` is already `true` in prod, but the callback + new lease/ack routes are **closed** until `ACCEPTANCE_VERDICT_CALLBACK_TOKEN` is set (every request 401), and the pull queue is **empty** until the dispatch producer is wired (still `queue: undefined`, owned by the dispatch lane). `KHALA_ACCEPTANCE_DISPATCH_ENABLED` is off. The runner refuses to start without its host secrets. No money path touched (`khala-loop-integration.ts` is a separate lane).

## Local end-to-end proof (passing)

- `run-once.ts` against the committed `khala-crossy-road-northstar-passing.v1.html` → **6/6 verified**, exit 0.
- `e2e-local-proof.test.ts` → REAL headless suite → POST through the REAL `handleAcceptanceVerdictCallback` route (test token, in-memory store) → receipt backfills `verified:true` / `test_passed`. Also verified over a live local HTTP server (run-once → network POST → read-back `verified=true`).
- `daemon.test.ts` (loop wiring, browser-free), worker `acceptance-job-queue.test.ts` (queue + lease routes), existing `acceptance-dispatch.test.ts` full-loop fixtures, `worker-exact-routes.test.ts` — all green. Worker API typecheck clean (0 errors).

**DO NOT auto-merge — orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)