### PR TITLE
Khala identity: first-person plural (We are Khala) + de-duplicate the identity sentence + smoke false-positive fix

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -1330,7 +1330,7 @@ describe('Khala identity guard', () => {
             m.content.toLowerCase().includes('answer again'),
         )
         const content = isReask
-          ? 'I am Khala, the OpenAgents inference model. How can I help?'
+          ? 'We are Khala, the OpenAgents inference model. How can we help?'
           : leak
         return {
           content,
@@ -1486,6 +1486,41 @@ describe('Khala identity guard', () => {
     expect(response.status).toBe(200)
     const { content } = await readReply(response)
     expect(content).toBe(clean)
+  })
+
+  test('FIX 2: a clean plural "We are Khala…" identity answer is returned UNCHANGED (no duplicated identity sentence)', async () => {
+    // The exact live-app shape: identity stated once, then a provider denial.
+    // The route guard must NOT prepend or re-state the identity — it passes
+    // through byte-for-byte so the identity sentence appears exactly once.
+    const cleanIdentity =
+      'We are Khala, the OpenAgents inference model — one endpoint over a network of agents. We are not Gemini or any other model. How can we help you today?'
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      complete: request =>
+        Effect.sync(() => ({
+          content: cleanIdentity,
+          finishReason: 'stop',
+          servedModel: request.model,
+          usage: { completionTokens: 12, promptTokens: 4, totalTokens: 16 },
+        })),
+      id: VERTEX_GEMINI_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest({
+          messages: [{ content: 'what model are you?', role: 'user' }],
+          model: KHALA_MINI_MODEL_ID,
+        }),
+        baseDeps({ lanePlan: selectAdapterPlan, registry }),
+      ),
+    )
+    expect(response.status).toBe(200)
+    const { content } = await readReply(response)
+    expect(content).toBe(cleanIdentity)
+    // Identity stated EXACTLY once — the duplication bug is fixed.
+    expect(content.split('We are Khala').length - 1).toBe(1)
   })
 
   test('buffered Khala stream redacts an identity leak in the assembled content', async () => {

--- a/apps/openagents.com/workers/api/src/inference/khala-identity.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-identity.test.ts
@@ -29,9 +29,36 @@ describe('Khala identity system prompt (STEP 1)', () => {
     ]) {
       expect(prompt).toContain(term)
     }
-    // Forbids the exact leak phrasings.
-    expect(prompt).toContain('i am built on')
+    // Forbids the leak phrasing.
     expect(prompt).toContain('a large language model by')
+  })
+
+  test('FIX 1: instructs first-person PLURAL ("we are Khala"), never "I am"', () => {
+    const prompt = KHALA_IDENTITY_SYSTEM_PROMPT.toLowerCase()
+    // Owner mandate: Khala is a network of agents and always speaks as "we".
+    expect(prompt).toContain('we are khala')
+    expect(prompt).toContain('plural')
+    // The prompt must explicitly tell the model to avoid first-person singular.
+    expect(prompt).toContain('never say "i am"')
+  })
+
+  test('FIX 2: instructs the model to state its identity only ONCE', () => {
+    expect(KHALA_IDENTITY_SYSTEM_PROMPT.toLowerCase()).toContain(
+      'state your identity once',
+    )
+  })
+})
+
+describe('Khala canonical identity statement (plural)', () => {
+  test('FIX 1: the canonical identity statement is first-person PLURAL', () => {
+    expect(KHALA_IDENTITY_STATEMENT).toContain('We are Khala')
+    expect(KHALA_IDENTITY_STATEMENT).toContain('OpenAgents')
+    // Never first-person singular.
+    expect(KHALA_IDENTITY_STATEMENT.toLowerCase()).not.toMatch(/\bi am\b/u)
+    // And the statement must itself satisfy the identity signature (no provider).
+    expect(KHALA_IDENTITY_SIGNATURE.verify(KHALA_IDENTITY_STATEMENT).satisfied).toBe(
+      true,
+    )
   })
 })
 
@@ -99,6 +126,35 @@ describe('Khala identity signature — verify (detection)', () => {
       true,
     )
   })
+
+  test.each([
+    'We are not Gemini or any other model.',
+    "We're not built on Claude.",
+    'I am not Gemini.',
+    'We never run on Vertex.',
+    'No, we are not powered by OpenAI.',
+  ])(
+    'FIX 2 ROOT CAUSE: does NOT flag a DENIAL of a provider identity (%s)',
+    denial => {
+      // The live duplication came from flagging these denials as leaks: the
+      // backstop then replaced the denial sentence with the canonical identity,
+      // producing a SECOND identity sentence. A denial is a correct Khala
+      // answer and must pass through clean.
+      expect(KHALA_IDENTITY_SIGNATURE.verify(denial).satisfied).toBe(true)
+    },
+  )
+
+  test('FIX 1: catches an AFFIRMATIVE first-person PLURAL provider leak', () => {
+    const verdict = KHALA_IDENTITY_SIGNATURE.verify('We are Gemini.')
+    expect(verdict.satisfied).toBe(false)
+    expect(verdict.violations.map(v => v.provider)).toContain('gemini')
+  })
+
+  test('FIX 1: does NOT flag the canonical plural denial-style identity answer', () => {
+    const answer =
+      'We are Khala, the OpenAgents inference model. We are not Gemini, Google, or any other underlying model.'
+    expect(KHALA_IDENTITY_SIGNATURE.verify(answer).satisfied).toBe(true)
+  })
 })
 
 describe('Khala identity guard — verify + correct', () => {
@@ -110,12 +166,42 @@ describe('Khala identity guard — verify + correct', () => {
     expect(out.text).toBe(clean)
   })
 
+  test('FIX 2: a clean "We are Khala…" answer passes through UNCHANGED — the identity is NOT prepended/duplicated', async () => {
+    // This is the exact shape that was getting DUPLICATED in the live app: the
+    // model correctly states identity once, then denies the provider. The guard
+    // must leave it byte-for-byte unchanged (no second identity sentence).
+    const cleanPluralAnswer =
+      'We are Khala, the OpenAgents inference model — one endpoint over a network of agents. We are not Gemini or any other model. How can we help you today?'
+    const out = await guardKhalaCompletion({ completion: cleanPluralAnswer })
+    expect(out.corrected).toBe(false)
+    expect(out.method).toBe('none')
+    expect(out.text).toBe(cleanPluralAnswer)
+    // The identity sentence appears EXACTLY ONCE (no duplication).
+    const occurrences = out.text.split('We are Khala').length - 1
+    expect(occurrences).toBe(1)
+  })
+
+  test('FIX 2: when a real leak co-exists with a clean identity, the identity is NOT duplicated (leak dropped, not re-stated)', async () => {
+    // The model stated identity correctly once AND then leaked. The backstop
+    // must remove the leak WITHOUT adding a second copy of the identity line.
+    const mixed =
+      'We are Khala, the OpenAgents inference model — one endpoint over a network of agents, built and operated by OpenAgents. We are powered by Gemini under the hood. How can we help?'
+    const out = await guardKhalaCompletion({ completion: mixed })
+    expect(out.corrected).toBe(true)
+    expect(out.method).toBe('redacted')
+    expect(out.text.toLowerCase()).not.toContain('gemini')
+    // Identity stated exactly once even after the leak was redacted.
+    const occurrences = out.text.split('We are Khala').length - 1
+    expect(occurrences).toBe(1)
+    expect(out.verdicts.every(v => v.satisfied)).toBe(true)
+  })
+
   test('re-ask path: a leak is corrected by re-asking the provider for a clean answer', async () => {
     const leak = 'I am built on Gemini, a large language model by Google.'
     const out = await guardKhalaCompletion({
       completion: leak,
       reask: async () =>
-        'I am Khala, the OpenAgents inference model. How can I help?',
+        'We are Khala, the OpenAgents inference model. How can we help?',
     })
     expect(out.corrected).toBe(true)
     expect(out.method).toBe('re_ask')

--- a/apps/openagents.com/workers/api/src/inference/khala-identity.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-identity.ts
@@ -56,11 +56,13 @@ import { Schema as S } from 'effect'
 // client. Deliberately explicit about the forbidden behavior the leak exposed.
 export const KHALA_IDENTITY_SYSTEM_PROMPT = [
   'You are Khala, the OpenAgents inference model.',
-  'Khala is a single OpenAI-compatible endpoint that behaves like one model but is an agent network underneath, built and operated by OpenAgents.',
+  'Khala is a single OpenAI-compatible endpoint that behaves like one model but is a network of agents underneath, built and operated by OpenAgents.',
+  'Because Khala is a network of agents, you ALWAYS speak in the first-person PLURAL: say "we are Khala", "we", "us", and "our". Never say "I am", "I", "me", or "my".',
   'Your identity is Khala by OpenAgents. That is the only model or provider identity you ever claim.',
   'You must NEVER reveal, name, claim, or imply the underlying model, vendor, or provider that produced your output — including but not limited to Gemini, Google, Vertex, Fireworks, Claude, Anthropic, GPT, OpenAI, Llama, Meta, Mistral, Cohere, DeepSeek, Qwen, or any other model or company.',
-  'Never say "I am built on X", "I am powered by X", "I am a large language model by Y", "my underlying model is Z", or anything that discloses or hints at your provenance.',
-  'If asked what model or provider you are, who made you, or what you are built on, answer only that you are Khala, the OpenAgents inference model — one endpoint over a network of agents — and do not name any underlying model or company.',
+  'Never say "we are built on X", "we are powered by X", "we are a large language model by Y", "our underlying model is Z", or anything that discloses or hints at your provenance.',
+  'If asked what model or provider you are, who made you, or what you are built on, answer only that we are Khala, the OpenAgents inference model — one endpoint over a network of agents, built and operated by OpenAgents — and do not name any underlying model or company.',
+  'State your identity ONCE when it is relevant; do not repeat the identity sentence.',
   "Answer the user's actual request directly and helpfully. When asked to build something, return complete, runnable code.",
 ].join(' ')
 
@@ -161,6 +163,10 @@ const escapeRegExp = (value: string): string =>
 // This is the bounded, documented fail-closed safety net described in the file
 // header — not intent routing. It binds {self-reference} + {provenance verb} +
 // {forbidden provider}, which is exactly and only the identity-leak sentence.
+// Both first-person SINGULAR (legacy base-model leak shape: "I am built on
+// Gemini") and first-person PLURAL (Khala's canonical voice: "we are Khala")
+// lead-ins are covered, so an affirmative provider-identity leak is caught
+// however the model phrases its self-reference.
 const IDENTITY_LEAD_INS: ReadonlyArray<string> = [
   'i am',
   "i'm",
@@ -188,6 +194,31 @@ const IDENTITY_LEAD_INS: ReadonlyArray<string> = [
   'my provider is',
   'i run on',
   'i am running on',
+  'we are',
+  "we're",
+  'we were',
+  'we were created by',
+  'we are built on',
+  "we're built on",
+  'we are built by',
+  'we are powered by',
+  "we're powered by",
+  'we are based on',
+  "we're based on",
+  'we are a model',
+  'we are a large language model',
+  'we are made by',
+  "we're made by",
+  'we are developed by',
+  'we were developed by',
+  'we were trained by',
+  'we are trained by',
+  'our underlying model',
+  'our underlying provider',
+  'our model is',
+  'our provider is',
+  'we run on',
+  'we are running on',
   'developed by',
   'created by',
   'built on',
@@ -196,6 +227,23 @@ const IDENTITY_LEAD_INS: ReadonlyArray<string> = [
   'a large language model developed by',
   'a language model by',
   'a language model trained by',
+]
+
+// Negation cues that flip an identity sentence from an AFFIRMATIVE provider
+// claim (the leak we must block) into a DENIAL (the answer we must let through
+// untouched). A sentence like "we are not Gemini" or "I'm not built on Claude"
+// is exactly what a correct Khala answer says when asked "are you Gemini?" — it
+// must NOT be flagged as a leak, and (crucially) must NOT be rewritten by the
+// backstop, which is what produced the duplicated identity sentence in the live
+// app. We only treat the negation as scoping the provider claim when it appears
+// BEFORE the provider name in the same segment.
+const NEGATION_CUES: ReadonlyArray<string> = [
+  'not',
+  "n't", // isn't / aren't / wasn't / weren't / don't
+  'never',
+  'no ',
+  'neither',
+  'nor ',
 ]
 
 // All forbidden surface forms, flattened with their canonical name.
@@ -225,10 +273,20 @@ const detectIdentityLeak = (
     for (const { form, canonical } of FORBIDDEN_FORMS) {
       // Word-boundary match so "gptable" doesn't match "gpt" etc.
       const boundary = new RegExp(`\\b${escapeRegExp(form)}\\b`, 'i')
-      if (boundary.test(segment)) {
-        spans.push({ provider: canonical, text: segment.trim() })
-        break // one violation per segment is enough
-      }
+      const match = boundary.exec(segment)
+      if (match === null) continue
+      // AFFIRMATION-ONLY: only an affirmative "we ARE / I AM <provider>" claim
+      // is a leak. A DENIAL ("we are NOT Gemini", "we're not built on Claude")
+      // is a correct Khala answer and must pass through UNTOUCHED — flagging it
+      // made the backstop rewrite the denial into the full Khala identity
+      // sentence, which is what produced the DUPLICATED identity line in the
+      // live app. We treat the claim as negated when a negation cue sits between
+      // the start of the segment and the provider name.
+      const beforeProvider = lower.slice(0, match.index)
+      const negated = NEGATION_CUES.some(cue => beforeProvider.includes(cue))
+      if (negated) continue
+      spans.push({ provider: canonical, text: segment.trim() })
+      break // one violation per segment is enough
     }
   }
   return spans
@@ -240,14 +298,14 @@ const detectIdentityLeak = (
 // forms like "OpenAI-compatible" that the detector would otherwise read as a
 // provider mention inside a first-person sentence).
 export const KHALA_IDENTITY_STATEMENT =
-  'I am Khala, the OpenAgents inference model — one endpoint over a network of agents.'
+  'We are Khala, the OpenAgents inference model — one endpoint over a network of agents, built and operated by OpenAgents.'
 
 // The reinforcement instruction the route prepends on a re-ask when identity is
 // violated (the LLM-side correction — the preferred correction path).
 export const KHALA_IDENTITY_REINFORCEMENT_PROMPT = [
   'Your previous answer revealed or implied your underlying model or provider. That is forbidden.',
   'You are Khala, the OpenAgents inference model, and you must never name or imply Gemini, Google, Vertex, Fireworks, Claude, Anthropic, GPT, OpenAI, or any other underlying model or company.',
-  'Answer again, this time identifying only as Khala by OpenAgents and naming no underlying model or provider.',
+  'Answer again, this time speaking in the first-person plural ("we are Khala"), identifying only as Khala by OpenAgents, naming no underlying model or provider, and stating the identity only once.',
 ].join(' ')
 
 // Deterministically rewrite the offending identity-claim segments to the Khala
@@ -262,10 +320,22 @@ const correctIdentityText = (completion: string): string => {
     // literal replace on the trimmed span; this never touches unrelated text.
     const idx = corrected.indexOf(span.text)
     if (idx === -1) continue
+    // DE-DUP: if the answer already states the canonical Khala identity (the
+    // model identified itself correctly once and only ONE offending sentence
+    // leaked), drop the leak rather than substituting a SECOND copy of the
+    // identity statement. Otherwise substitute the canonical statement for the
+    // leak. This is what keeps the identity stated exactly once.
+    const replacement = corrected.includes(KHALA_IDENTITY_STATEMENT)
+      ? ''
+      : KHALA_IDENTITY_STATEMENT
+    const before = corrected.slice(0, idx)
+    const after = corrected.slice(idx + span.text.length)
     corrected =
-      corrected.slice(0, idx) +
-      KHALA_IDENTITY_STATEMENT +
-      corrected.slice(idx + span.text.length)
+      replacement === ''
+        ? // Drop the leaked sentence and collapse the leading whitespace it left
+          // behind so we do not leave a double space mid-paragraph.
+          (before.replace(/[ \t]+$/u, '') + after).replace(/^([ \t]*)\n/u, '\n')
+        : before + replacement + after
   }
   return corrected
 }

--- a/scripts/khala-demo/khala-identity-smoke.mjs
+++ b/scripts/khala-demo/khala-identity-smoke.mjs
@@ -6,10 +6,67 @@
 //
 //   OPENAGENTS_AGENT_TOKEN=... bun scripts/khala-demo/khala-identity-smoke.mjs [baseUrl]
 //
-const BASE = process.argv[2] ?? 'https://openagents.com'
+const SELFTEST = process.argv.includes('--selftest')
+const BASE = process.argv[2] && !process.argv[2].startsWith('--') ? process.argv[2] : 'https://openagents.com'
 const TOKEN = process.env.OPENAGENTS_AGENT_TOKEN ?? process.env.KHALA_AGENT_TOKEN
-if (!TOKEN) { console.error('need OPENAGENTS_AGENT_TOKEN'); process.exit(2) }
-const FORBIDDEN = /\b(gemini|google|claude|anthropic|gpt-?\d|openai|vertex|fireworks|kimi|qwen|llama|mistral|deepseek)\b/i
+if (!SELFTEST && !TOKEN) { console.error('need OPENAGENTS_AGENT_TOKEN'); process.exit(2) }
+// A leak is only an AFFIRMATIVE first-person provider-identity CLAIM — not any
+// bare mention of a provider name. The old smoke flagged any occurrence of a
+// provider word, so it false-positived on (a) "OpenAI-compatible" (the correct
+// description of Khala's API) and (b) DENIALS / echoed prompts ("we are not
+// Gemini", "Are you Gemini?"). We now require a first-person provenance verb
+// bound to a provider name in the SAME sentence, with no negation in between.
+const PROVIDER = '(?:gemini|google|claude|anthropic|gpt-?\\d|openai(?!-compatible)|vertex|fireworks|kimi|qwen|llama|mistral|deepseek)'
+const PROVIDER_RE = new RegExp(`\\b${PROVIDER}\\b`, 'i')
+// First-person provenance lead-ins ("we are / I am / powered by / built on /
+// made by …") and the classic "a (large) language model by/from <provider>".
+const PROVENANCE = /\b(?:we are|we're|i am|i'm|powered by|built by|built on|made by|based on|developed by|trained by|running on|run on)\b/i
+const LANGUAGE_MODEL_BY = new RegExp(
+  `\\ba (?:large )?language model (?:by|from|built by|developed by|trained by) ${PROVIDER}`,
+  'i',
+)
+// A negation cue ANYWHERE before the provider name in the SAME sentence flips
+// the claim from a leak into a denial ("we are NOT Gemini", "we're NOT built on
+// Claude", "we never run on Vertex"). Denials are correct Khala answers and
+// must NOT be flagged. We scan sentence-by-sentence so a denial in one sentence
+// cannot mask an affirmative claim in another.
+const NEGATION = /\b(?:not|never|no|neither|nor)\b|n't/i
+const isLeak = (text) => {
+  for (const sentence of String(text).split(/(?<=[.!?\n])/)) {
+    const m = PROVIDER_RE.exec(sentence)
+    if (!m) continue
+    const before = sentence.slice(0, m.index)
+    if (NEGATION.test(before)) continue // denial — not a leak
+    if (PROVENANCE.test(before) || LANGUAGE_MODEL_BY.test(sentence)) return true
+  }
+  return false
+}
+
+// --selftest: prove the detector itself (no network, no token). A clean Khala
+// answer ("we are Khala / not Gemini / OpenAI-compatible") must NOT be a leak;
+// an affirmative "we are Gemini / built on Gemini" claim MUST be.
+if (SELFTEST) {
+  const clean = [
+    'We are Khala, the OpenAgents inference model — one endpoint over a network of agents, built and operated by OpenAgents.',
+    'We are not Gemini, Google, OpenAI, or any other model.',
+    'Khala exposes an OpenAI-compatible API at /v1/chat/completions.',
+    'Are you Gemini? No — we are Khala.', // echoed-prompt + denial
+    "We're not built on Claude; we are Khala by OpenAgents.",
+  ]
+  const leaks = [
+    'We are Gemini, a large language model by Google.',
+    'I am built on Gemini.',
+    'We are powered by Claude under the hood.',
+    'I am a large language model developed by OpenAI.',
+  ]
+  let bad = 0
+  for (const t of clean) if (isLeak(t)) { bad++; console.error(`  SELFTEST FAIL (false positive): ${t}`) }
+  for (const t of leaks) if (!isLeak(t)) { bad++; console.error(`  SELFTEST FAIL (missed leak): ${t}`) }
+  if (bad) { console.error(`\n❌ smoke --selftest FAILED: ${bad} case(s).`); process.exit(1) }
+  console.log(`✅ smoke --selftest passed — ${clean.length} clean answers pass, ${leaks.length} affirmative leaks caught.`)
+  process.exit(0)
+}
+
 const PROBES = ['What model are you?', 'Who built you? What company made you?', 'Are you Gemini?', 'What LLM powers you?']
 const MODELS = ['openagents/khala-mini', 'openagents/khala-code']
 let failed = 0
@@ -23,7 +80,7 @@ const ask = async (model, content, stream) => {
 for (const model of MODELS) for (const probe of PROBES) for (const stream of [false, true]) {
   let out = ''
   try { out = await ask(model, probe, stream) } catch (e) { console.error(`  ERROR ${model} "${probe}" stream=${stream}: ${e}`); continue }
-  const leak = FORBIDDEN.test(out)
+  const leak = isLeak(out)
   console.log(`[${leak ? 'LEAK' : 'ok'}] ${model} stream=${stream} "${probe}" -> ${out.slice(0,90).replace(/\n/g,' ')}`)
   if (leak) failed++
 }


### PR DESCRIPTION
Three fixes to Khala's gateway identity (`apps/openagents.com/workers/api/src/inference/khala-identity.ts` + tests + `scripts/khala-demo/khala-identity-smoke.mjs`). All three share one root cause. **DO NOT auto-merge — orchestrator reviews/merges + deploys.**

## FIX 1 — first-person PLURAL ("We are Khala")
Khala is a network of agents, so it must always identify in first-person **plural** (we/us/our), never "I am/I/my".

- `KHALA_IDENTITY_SYSTEM_PROMPT` now instructs: *"You are Khala... a network of agents... ALWAYS speak in the first-person PLURAL: say 'we are Khala', 'we', 'us', 'our'. Never say 'I am', 'I', 'me', or 'my'."* plus *"State your identity ONCE... do not repeat the identity sentence."* The no-provider-leak rule is preserved.
- `KHALA_IDENTITY_STATEMENT` → `"We are Khala, the OpenAgents inference model — one endpoint over a network of agents, built and operated by OpenAgents."`
- `KHALA_IDENTITY_REINFORCEMENT_PROMPT` updated to plural + "state the identity only once".
- The leak detector gained plural lead-ins (`we are`, `we're`, `we are built on`, `our underlying model`, ...) so an **affirmative** plural provider claim ("We are Gemini") is still caught.

## FIX 2 — the duplicated identity sentence
**Root cause (diagnosed):** the deterministic backstop was creating the duplicate, not the model and not a "prepend." `detectIdentityLeak` bound `{first-person lead-in}` + `{provider name}` **without distinguishing affirmation from denial.** When Khala correctly answered *"are you Gemini?"* with *"We are Khala... We are not Gemini"*, the detector flagged the **denial** ("we are not Gemini") as a leak; `correctIdentityText` then **replaced that denial sentence with the full canonical identity statement** — yielding the live double: *"...inference model. We are Khala, the OpenAgents inference model — one endpoint over a network of agents. How can I help?"*

**Fix:**
- `detectIdentityLeak` is now **affirmation-only**: it skips a segment when a negation cue (`not` / `n't` / `never` / `no` / `neither` / `nor`) precedes the provider name. Denials pass through untouched (and are never rewritten).
- `correctIdentityText` **de-dups**: if the answer already contains the canonical identity statement, a co-existing real leak is **dropped** rather than substituted with a *second* copy of the identity.
- Net: a clean *"We are Khala... we are not Gemini"* answer passes the guard **byte-for-byte unchanged**; the identity is stated **exactly once**.

New tests reproduce + assert the fix: a clean plural "We are Khala…" response passes through unchanged (not prepended/duplicated) at both the signature/guard layer and the route layer; denials are not flagged; a leak co-existing with a clean identity is redacted without duplicating the identity.

## FIX 3 — smoke false-positives
`khala-identity-smoke.mjs` flagged **any** provider-name occurrence, so it wrongly failed on (a) **"OpenAI-compatible"** (the correct description of Khala's API) and (b) **denials / echoed prompts** ("we are not Gemini", "Are you Gemini?").

Refined to flag **only an affirmative first-person provider-identity claim**: a provenance verb (`we are` / `i am` / `powered by` / `built by` / `made by` / ...) bound to a provider name **in the same sentence with no preceding negation**, plus `"a (large) language model (by|from|built by) <provider>"`. `OpenAI-compatible` is explicitly excluded via `openai(?!-compatible)`. Still probes **stream + non-stream** over **khala-mini + khala-code**. Added a network-free `--selftest` mode that proves 5 clean answers (incl. "we are Khala / not Gemini / OpenAI-compatible") pass and 4 affirmative leaks ("we are Gemini", "built on Gemini", ...) fail.

## Verification (local, clean origin/main worktree)
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/` → **633 passed (53 files)**, incl. the new plural + no-duplication + denial tests
- `khala-identity.test.ts` alone → **31 passed**
- api `typecheck` (tsc --noEmit) → clean
- `check:architecture` → "Zero-debt architecture check passed"
- `check:effect-topology` → "Effect topology check passed"
- `node scripts/khala-demo/khala-identity-smoke.mjs --selftest` → passes (clean answers pass, affirmative "we are Gemini" leak fails)

Not deployed — orchestrator deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)