### PR TITLE
DE-4: advance pylon.v0_3_multi_earning_node — Pylon node machinery + receipt, owner-flip-ready (#5527)

### DIFF
--- a/apps/pylon/README.md
+++ b/apps/pylon/README.md
@@ -558,6 +558,24 @@ state. The headless snapshot is for support and service-manager runs: it shows
 refs, blockers, readiness, and recovery gates without exposing raw wallet
 material, provider tokens, private repo content, or local cache paths.
 
+## Multi-Earning Ledger (cross-mode projection)
+
+```sh
+pylon multi-earning ledger --json
+```
+
+A read-only, no-network projection of the local cross-mode earning ledger for
+`pylon.v0_3_multi_earning_node.v1`. It rolls per-mode earning records into a
+node-level summary, distinguishes the `modeled`/`observed`/`pending`/`paid`/`settled`
+amount classes, and honestly counts how many distinct modes carry a SETTLED
+receipt (the `>=2` bar). It is INERT by default — with
+`PYLON_MULTI_EARNING_LEDGER_ENABLED` off it emits an empty projection
+(`inert: true`, zero settled modes, promise `red`) and ingests no live earning
+records. It moves no money, reads no wallet, and never prints raw payment
+material; amounts are aggregate sats only. The green flip stays owner-signed.
+See `docs/promises/2026-06-23-pylon-multi-earning-node-receipt-machinery.md` in
+the repo root.
+
 ## Release Gate
 
 ```sh

--- a/apps/pylon/src/cli-catalog.ts
+++ b/apps/pylon/src/cli-catalog.ts
@@ -293,6 +293,19 @@ export const PYLON_COMMAND_CATALOG: readonly PylonCommandEntry[] = [
     ],
   },
   {
+    command: "multi-earning",
+    summary:
+      "Project the local cross-mode earning ledger (settled receipts across >=2 modes). INERT unless PYLON_MULTI_EARNING_LEDGER_ENABLED=1.",
+    mutates: false,
+    spends: false,
+    needsNetwork: false,
+    json: true,
+    args: [
+      pos("subcommand", "ledger (the only subcommand).", false),
+      flag("--json", "Emit JSON; this command is JSON-only."),
+    ],
+  },
+  {
     command: "receipts",
     summary: "Fetch public settlement receipts for a training run.",
     mutates: false,

--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -218,6 +218,7 @@ import {
   type PylonAssignmentLease,
 } from "./assignment.js"
 import { discoverHostInventory } from "./inventory.js"
+import { summarizeMultiEarning } from "./multi-earning-ledger.js"
 import {
   autoUpdateDisabledReason,
   checkForUpdate,
@@ -2909,6 +2910,22 @@ async function main() {
   if (args[0] === "inventory" && args.includes("--json")) {
     const inventory = await discoverHostInventory({ env: Bun.env })
     process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`)
+    return
+  }
+
+  // `pylon multi-earning ledger` — INERT, read-only, no-network cross-mode
+  // earning projection for pylon.v0_3_multi_earning_node.v1. With the flag off
+  // (default) it emits an honest empty projection: zero settled modes, the bar
+  // unmet, the promise red, and the three remaining owner-gated blockers named.
+  // It moves no money, reads no wallet, and ingests no live earning records;
+  // the live earning paths feed it only when an operator wires real settled
+  // receipts. This is the dereferenceable receipt that addresses
+  // `multi_earning_mode_receipts_missing` — the green flip stays owner-signed.
+  if (args[0] === "multi-earning") {
+    const summary = summarizeMultiEarning([], new Date().toISOString(), {
+      env: Bun.env,
+    })
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`)
     return
   }
 

--- a/apps/pylon/src/multi-earning-ledger.test.ts
+++ b/apps/pylon/src/multi-earning-ledger.test.ts
@@ -1,0 +1,333 @@
+// Tests for the INERT, flag-gated multi-earning-node local ledger.
+//
+// Promise: pylon.v0_3_multi_earning_node.v1
+// Blocker:  blocker.product_promises.multi_earning_mode_receipts_missing
+//
+// This suite is itself the re-runnable receipt: `bun test src/multi-earning-ledger.test.ts`
+// proves the ledger distinguishes all five amount classes, only counts SETTLED
+// modes toward the >=2 green bar, stays inert (empty) by default, rejects
+// leak-prone entries, and produces a fail-closed, self-verifying receipt.
+import { describe, expect, it } from "bun:test"
+import {
+  buildMultiEarningReceiptRef,
+  captureMultiEarningReceipt,
+  type MultiEarningLedgerEntry,
+  type MultiEarningMode,
+  MULTI_EARNING_AMOUNT_CLASSES,
+  MULTI_EARNING_LEDGER_ENV,
+  serializeMultiEarningReceipt,
+  summarizeMultiEarning,
+  verifyMultiEarningEntry,
+  verifyMultiEarningReceipt,
+} from "./multi-earning-ledger.js"
+
+const OBSERVED_AT = "2026-06-23T00:00:00.000Z"
+
+function entry(
+  overrides: Partial<MultiEarningLedgerEntry> & { mode: MultiEarningMode },
+): MultiEarningLedgerEntry {
+  return {
+    schema: "openagents.pylon.multi_earning_entry.v0.1",
+    mode: overrides.mode,
+    amountClass: overrides.amountClass ?? "settled",
+    amountSats: overrides.amountSats ?? 21,
+    receiptRef: overrides.receiptRef ?? `receipt.pylon.${overrides.mode}.001`,
+    sourceRef: overrides.sourceRef ?? `source.pylon.${overrides.mode}.001`,
+    observedAt: overrides.observedAt ?? OBSERVED_AT,
+    contentRedacted: true,
+  }
+}
+
+describe("summarizeMultiEarning — inert by default", () => {
+  it("is INERT with the flag off: empty projection, zero settled modes, red", () => {
+    const summary = summarizeMultiEarning(
+      [entry({ mode: "compute" }), entry({ mode: "tips" })],
+      OBSERVED_AT,
+      { env: {} },
+    )
+    expect(summary.inert).toBe(true)
+    expect(summary.enabled).toBe(false)
+    expect(summary.modes).toEqual([])
+    expect(summary.settledModeCount).toBe(0)
+    expect(summary.meetsMultiEarningBar).toBe(false)
+    expect(summary.promiseState).toBe("red")
+    expect(summary.clearsBlocker).toBe(
+      "blocker.product_promises.multi_earning_mode_receipts_missing",
+    )
+  })
+
+  it("arms only via the explicit env flag", () => {
+    const summary = summarizeMultiEarning([entry({ mode: "compute" })], OBSERVED_AT, {
+      env: { [MULTI_EARNING_LEDGER_ENV]: "1" },
+    })
+    expect(summary.inert).toBe(false)
+    expect(summary.enabled).toBe(true)
+  })
+
+  it("arms via explicit enabled:true override", () => {
+    const summary = summarizeMultiEarning([entry({ mode: "compute" })], OBSERVED_AT, {
+      enabled: true,
+      env: {},
+    })
+    expect(summary.inert).toBe(false)
+  })
+
+  it("surfaces the three owner-gated blockers it does NOT clear", () => {
+    const summary = summarizeMultiEarning([], OBSERVED_AT, { env: {} })
+    expect(summary.remainingOwnerGatedBlockers).toEqual([
+      "blocker.product_promises.pylon_v1_default_install_not_fully_closed",
+      "blocker.product_promises.multi_earning_settlement_refs_missing",
+      "blocker.product_promises.safe_public_projection_missing",
+    ])
+  })
+})
+
+describe("summarizeMultiEarning — honest settled-mode counting", () => {
+  it("distinguishes all five amount classes per mode", () => {
+    const entries = MULTI_EARNING_AMOUNT_CLASSES.map((cls, i) =>
+      entry({
+        mode: "compute",
+        amountClass: cls,
+        amountSats: (i + 1) * 10,
+        receiptRef: `receipt.pylon.compute.${cls}`,
+      }),
+    )
+    const summary = summarizeMultiEarning(entries, OBSERVED_AT, { enabled: true })
+    const compute = summary.modes.find((m) => m.mode === "compute")!
+    expect(compute.amountSatsByClass.modeled).toBe(10)
+    expect(compute.amountSatsByClass.observed).toBe(20)
+    expect(compute.amountSatsByClass.pending).toBe(30)
+    expect(compute.amountSatsByClass.paid).toBe(40)
+    expect(compute.amountSatsByClass.settled).toBe(50)
+    expect(compute.recordCountByClass.settled).toBe(1)
+  })
+
+  it("counts a mode toward green ONLY when it carries a settled receipt", () => {
+    // compute settled, labor only paid (not settled): exactly ONE settled mode.
+    const summary = summarizeMultiEarning(
+      [
+        entry({ mode: "compute", amountClass: "settled" }),
+        entry({ mode: "labor", amountClass: "paid" }),
+      ],
+      OBSERVED_AT,
+      { enabled: true },
+    )
+    expect(summary.settledModes).toEqual(["compute"])
+    expect(summary.settledModeCount).toBe(1)
+    expect(summary.meetsMultiEarningBar).toBe(false)
+  })
+
+  it("meets the >=2 bar with settled receipts from two distinct modes", () => {
+    const summary = summarizeMultiEarning(
+      [
+        entry({ mode: "compute", amountClass: "settled" }),
+        entry({ mode: "tips", amountClass: "settled" }),
+      ],
+      OBSERVED_AT,
+      { enabled: true },
+    )
+    expect(summary.settledModeCount).toBe(2)
+    expect(summary.settledModes).toEqual(["compute", "tips"])
+    expect(summary.meetsMultiEarningBar).toBe(true)
+    // Still red: the projection never flips the promise.
+    expect(summary.promiseState).toBe("red")
+  })
+
+  it("does NOT double-count two settled receipts in the SAME mode as two modes", () => {
+    const summary = summarizeMultiEarning(
+      [
+        entry({ mode: "compute", amountClass: "settled", receiptRef: "receipt.a" }),
+        entry({ mode: "compute", amountClass: "settled", receiptRef: "receipt.b" }),
+      ],
+      OBSERVED_AT,
+      { enabled: true },
+    )
+    expect(summary.settledModeCount).toBe(1)
+    expect(summary.meetsMultiEarningBar).toBe(false)
+    const compute = summary.modes.find((m) => m.mode === "compute")!
+    expect(compute.settledReceiptRefs).toEqual(["receipt.a", "receipt.b"])
+  })
+
+  it("dedupes identical settled receipt refs within a mode", () => {
+    const summary = summarizeMultiEarning(
+      [
+        entry({ mode: "tips", amountClass: "settled", receiptRef: "receipt.dup", sourceRef: "s1" }),
+        entry({ mode: "tips", amountClass: "settled", receiptRef: "receipt.dup", sourceRef: "s2" }),
+      ],
+      OBSERVED_AT,
+      { enabled: true },
+    )
+    const tips = summary.modes.find((m) => m.mode === "tips")!
+    expect(tips.settledReceiptRefs).toEqual(["receipt.dup"])
+  })
+})
+
+describe("verifyMultiEarningEntry — public-safety guard", () => {
+  it("accepts a well-formed entry", () => {
+    expect(verifyMultiEarningEntry(entry({ mode: "compute" })).valid).toBe(true)
+  })
+
+  it("rejects an unknown key (leak vector)", () => {
+    const bad = { ...entry({ mode: "compute" }), rawSparkAddress: "sp1qxyz" }
+    const v = verifyMultiEarningEntry(bad)
+    expect(v.valid).toBe(false)
+    expect(v.reasons).toContain("unexpected-key:rawSparkAddress")
+  })
+
+  it("rejects a ref carrying whitespace (free-text / leak shape)", () => {
+    const v = verifyMultiEarningEntry(entry({ mode: "compute", receiptRef: "lnbc1 raw invoice" }))
+    expect(v.valid).toBe(false)
+    expect(v.reasons).toContain("bad-receipt-ref")
+  })
+
+  it("rejects a negative or non-integer amount", () => {
+    expect(verifyMultiEarningEntry(entry({ mode: "compute", amountSats: -1 })).valid).toBe(false)
+    expect(verifyMultiEarningEntry(entry({ mode: "compute", amountSats: 1.5 })).valid).toBe(false)
+  })
+
+  it("rejects a non-canonical timestamp", () => {
+    const v = verifyMultiEarningEntry(entry({ mode: "compute", observedAt: "yesterday" }))
+    expect(v.valid).toBe(false)
+    expect(v.reasons).toContain("bad-observed-at")
+  })
+
+  it("rejects an unknown mode and amount class", () => {
+    expect(verifyMultiEarningEntry({ ...entry({ mode: "compute" }), mode: "moon" }).valid).toBe(false)
+    expect(
+      verifyMultiEarningEntry({ ...entry({ mode: "compute" }), amountClass: "imaginary" }).valid,
+    ).toBe(false)
+  })
+
+  it("rejects unsafe entries inside summarize, counting them, never crediting", () => {
+    const summary = summarizeMultiEarning(
+      [
+        entry({ mode: "compute", amountClass: "settled" }),
+        { ...entry({ mode: "tips", amountClass: "settled" }), leak: "raw" } as unknown as MultiEarningLedgerEntry,
+      ],
+      OBSERVED_AT,
+      { enabled: true },
+    )
+    expect(summary.rejectedEntryCount).toBe(1)
+    expect(summary.settledModes).toEqual(["compute"])
+    expect(summary.meetsMultiEarningBar).toBe(false)
+  })
+})
+
+describe("captureMultiEarningReceipt — fail-closed dereferenceable receipt", () => {
+  it("does not capture when inert", () => {
+    const result = captureMultiEarningReceipt(
+      [entry({ mode: "compute" }), entry({ mode: "tips" })],
+      OBSERVED_AT,
+      { env: {} },
+    )
+    expect(result.captured).toBe(false)
+    if (!result.captured) expect(result.reasons).toContain("inert")
+  })
+
+  it("does not capture below the >=2 settled-mode bar", () => {
+    const result = captureMultiEarningReceipt(
+      [entry({ mode: "compute", amountClass: "settled" })],
+      OBSERVED_AT,
+      { enabled: true },
+    )
+    expect(result.captured).toBe(false)
+    if (!result.captured) expect(result.reasons).toContain("below-bar:1")
+  })
+
+  it("captures a self-verifying, round-trip-clean receipt at >=2 settled modes", () => {
+    const result = captureMultiEarningReceipt(
+      [
+        entry({ mode: "compute", amountClass: "settled", receiptRef: "receipt.compute.001" }),
+        entry({ mode: "tips", amountClass: "settled", receiptRef: "receipt.tips.001" }),
+      ],
+      OBSERVED_AT,
+      { enabled: true },
+    )
+    expect(result.captured).toBe(true)
+    if (!result.captured) throw new Error("expected capture")
+    expect(result.receipt.settledModeCount).toBe(2)
+    expect(result.receipt.settledModes).toEqual(["compute", "tips"])
+    expect(result.receipt.settledReceiptRefs).toEqual([
+      "receipt.compute.001",
+      "receipt.tips.001",
+    ])
+    expect(result.receipt.ref).toBe(buildMultiEarningReceiptRef(2))
+    // The serialized artifact re-audits clean.
+    const reaudit = verifyMultiEarningReceipt(JSON.parse(result.serialized))
+    expect(reaudit.clearsBlocker).toBe(true)
+  })
+
+  it("serializes deterministically regardless of key insertion order", () => {
+    const result = captureMultiEarningReceipt(
+      [
+        entry({ mode: "compute", amountClass: "settled" }),
+        entry({ mode: "labor", amountClass: "settled" }),
+      ],
+      OBSERVED_AT,
+      { enabled: true },
+    )
+    if (!result.captured) throw new Error("expected capture")
+    const shuffled = {
+      contentRedacted: true as const,
+      observedAt: result.receipt.observedAt,
+      meetsMultiEarningBar: true as const,
+      settledReceiptRefs: result.receipt.settledReceiptRefs,
+      settledModes: result.receipt.settledModes,
+      settledModeCount: result.receipt.settledModeCount,
+      promiseId: result.receipt.promiseId,
+      ref: result.receipt.ref,
+      schema: result.receipt.schema,
+    }
+    expect(serializeMultiEarningReceipt(shuffled)).toBe(result.serialized)
+  })
+})
+
+describe("verifyMultiEarningReceipt — auditor gate", () => {
+  it("rejects a receipt claiming the bar with only one settled mode", () => {
+    const v = verifyMultiEarningReceipt({
+      schema: "openagents.pylon.multi_earning_receipt.v0.1",
+      ref: buildMultiEarningReceiptRef(1),
+      promiseId: "pylon.v0_3_multi_earning_node.v1",
+      settledModeCount: 1,
+      settledModes: ["compute"],
+      settledReceiptRefs: ["receipt.a"],
+      meetsMultiEarningBar: true,
+      observedAt: OBSERVED_AT,
+      contentRedacted: true,
+    })
+    expect(v.clearsBlocker).toBe(false)
+  })
+
+  it("rejects a ref whose encoded count does not match the body", () => {
+    const v = verifyMultiEarningReceipt({
+      schema: "openagents.pylon.multi_earning_receipt.v0.1",
+      ref: buildMultiEarningReceiptRef(5),
+      promiseId: "pylon.v0_3_multi_earning_node.v1",
+      settledModeCount: 2,
+      settledModes: ["compute", "tips"],
+      settledReceiptRefs: ["receipt.a", "receipt.b"],
+      meetsMultiEarningBar: true,
+      observedAt: OBSERVED_AT,
+      contentRedacted: true,
+    })
+    expect(v.clearsBlocker).toBe(false)
+    expect(v.reasons).toContain("ref-count-mismatch")
+  })
+
+  it("rejects an unknown key (leak vector) in a captured receipt", () => {
+    const v = verifyMultiEarningReceipt({
+      schema: "openagents.pylon.multi_earning_receipt.v0.1",
+      ref: buildMultiEarningReceiptRef(2),
+      promiseId: "pylon.v0_3_multi_earning_node.v1",
+      settledModeCount: 2,
+      settledModes: ["compute", "tips"],
+      settledReceiptRefs: ["receipt.a", "receipt.b"],
+      meetsMultiEarningBar: true,
+      observedAt: OBSERVED_AT,
+      contentRedacted: true,
+      rawMnemonic: "twelve words here",
+    })
+    expect(v.clearsBlocker).toBe(false)
+    expect(v.reasons).toContain("unexpected-key:rawMnemonic")
+  })
+})

--- a/apps/pylon/src/multi-earning-ledger.ts
+++ b/apps/pylon/src/multi-earning-ledger.ts
@@ -1,0 +1,659 @@
+// Multi-earning-node local ledger — INERT, flag-gated, contributor-node surface.
+//
+// Promise: pylon.v0_3_multi_earning_node.v1
+// Blocker:  blocker.product_promises.multi_earning_mode_receipts_missing
+//
+// The multi-earning-node promise ("one Pylon install earns Bitcoin across more
+// than one mode") cannot go green until there are SETTLED receipts for >=2
+// earning modes captured FROM ONE INSTALL. Pylon already produces per-mode
+// earning records, but each lives in its OWN type-specific store with its own
+// shape:
+//
+//   - NIP-90 provider earnings (`ProviderEarningRecord` in provider-nip90.ts)
+//   - assignment closeouts (`AssignmentCloseout.receiptRefs` in assignment.ts)
+//   - training worker receipts (`TrainingWorkerReceipt` in assignment.ts)
+//   - forum tips (tips.ts) / Tassadar executor / data / labor / referral
+//
+// There is no unified, dereferenceable interface that reads those per-mode
+// records, distinguishes amount classes, and HONESTLY counts how many DISTINCT
+// modes carry a settled receipt from one install. That missing interface IS the
+// named blocker. This module supplies it WITHOUT changing any live behavior:
+//
+//   - It is INERT by default. The cross-mode ledger only ingests entries an
+//     operator/contributor explicitly hands it (the live earning paths do not
+//     auto-feed it yet), and the CLI projection is empty unless the install
+//     opts in via `PYLON_MULTI_EARNING_LEDGER_ENABLED=1`.
+//   - It is PURE and side-effect-free: it classifies, aggregates, self-verifies,
+//     and canonically serializes, but reads no wallet, spawns no process, moves
+//     no funds, and writes nothing itself.
+//   - It is public-safe by construction: a closed key allowlist rejects any
+//     entry that would smuggle a raw address, balance, invoice, mnemonic,
+//     credential, or local path into a "receipt". Amounts are carried only as
+//     sats integers (an aggregate the public projection already exposes), never
+//     raw payment material.
+//   - It is HONEST: it counts a mode toward the >=2 green bar ONLY when that
+//     mode carries a `settled` receipt. Modeled / observed / pending / paid
+//     entries are tracked and surfaced but never counted as settled.
+//
+// When the live earning paths later wire real settled receipts (one operator
+// spend / settlement at a time), they feed `MultiEarningLedgerEntry` records
+// into `summarizeMultiEarning` to emit the dereferenceable receipt that clears
+// the blocker. Until then the flag stays off and nothing changes.
+
+// The earning modes a single Pylon install can carry. This is the mode taxonomy
+// the multi-earning promise stacks; each maps to an existing per-mode earning
+// source on the contributor node.
+export type MultiEarningMode =
+  | "compute" // GEPA / Tassadar executor training + benchmark assignments
+  | "labor" // NIP-90 compliant-usage labor jobs
+  | "tips" // Forum / Site content tips
+  | "data" // consented, redacted, valued trace sales
+  | "referral" // creator / referral settlement
+  | "inference" // NIP-90 text-inference jobs
+
+export const MULTI_EARNING_MODES: readonly MultiEarningMode[] = [
+  "compute",
+  "labor",
+  "tips",
+  "data",
+  "referral",
+  "inference",
+]
+
+// The amount classes a per-mode earning record can be in. Only `settled` counts
+// toward the green bar; the rest are honest in-flight or projected states.
+//
+//   - modeled   — a projected/estimated amount; no real event occurred.
+//   - observed  — a real earning event was seen but not yet credited.
+//   - pending   — credited and awaiting settlement.
+//   - paid       — paid out but not yet confirmed settled on-chain/rail.
+//   - settled    — fully settled; a real, dereferenceable settlement receipt.
+export type MultiEarningAmountClass =
+  | "modeled"
+  | "observed"
+  | "pending"
+  | "paid"
+  | "settled"
+
+export const MULTI_EARNING_AMOUNT_CLASSES: readonly MultiEarningAmountClass[] = [
+  "modeled",
+  "observed",
+  "pending",
+  "paid",
+  "settled",
+]
+
+export const MULTI_EARNING_LEDGER_ENV =
+  "PYLON_MULTI_EARNING_LEDGER_ENABLED" as const
+
+// A single per-mode earning record fed into the cross-mode ledger. Public-safe
+// by construction: it carries only an aggregate sats amount and dereferenceable
+// refs, NEVER raw payment material.
+export type MultiEarningLedgerEntry = {
+  schema: "openagents.pylon.multi_earning_entry.v0.1"
+  // Which earning mode this record belongs to.
+  mode: MultiEarningMode
+  // The amount class of this record. Only `settled` counts toward green.
+  amountClass: MultiEarningAmountClass
+  // Aggregate sats for this record. >= 0 integer. Never raw invoice material.
+  amountSats: number
+  // A dereferenceable, public-safe receipt ref (e.g. a settlement receipt ref,
+  // a provider earning receiptRef, an assignment closeout receiptRef). Must be a
+  // single non-whitespace token; never a raw address/invoice/path.
+  receiptRef: string
+  // Public-safe ref for the source record this entry was derived from (e.g. a
+  // resultEventId, assignmentRef, training run ref). Single token.
+  sourceRef: string
+  // ISO-8601 timestamp of the observation. Canonical (round-trips).
+  observedAt: string
+  // Always true; the entry is redacted by construction.
+  contentRedacted: true
+}
+
+export type MultiEarningLedgerOptions = {
+  // Explicit override. When undefined, falls back to the env flag.
+  enabled?: boolean
+  env?: NodeJS.ProcessEnv
+}
+
+function isLedgerEnabled(
+  options: MultiEarningLedgerOptions,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  if (options.enabled !== undefined) return options.enabled
+  // INERT by default: only an explicit opt-in turns the projection on.
+  const flag = env[MULTI_EARNING_LEDGER_ENV]
+  return flag === "1" || flag === "true"
+}
+
+// ---------------------------------------------------------------------------
+// Entry validation: public-safe + well-formed.
+// ---------------------------------------------------------------------------
+
+// The exact, closed set of keys a public-safe entry may carry. Any extra key is
+// rejected: an unknown field is exactly how a raw target/balance/credential
+// could be smuggled into a "receipt" that is then surfaced.
+const ALLOWED_ENTRY_KEYS: ReadonlySet<string> = new Set<string>([
+  "schema",
+  "mode",
+  "amountClass",
+  "amountSats",
+  "receiptRef",
+  "sourceRef",
+  "observedAt",
+  "contentRedacted",
+])
+
+const MODE_SET: ReadonlySet<string> = new Set<string>(MULTI_EARNING_MODES)
+const AMOUNT_CLASS_SET: ReadonlySet<string> = new Set<string>(
+  MULTI_EARNING_AMOUNT_CLASSES,
+)
+
+// A public-safe ref must be a non-empty, single-token string (no whitespace).
+// This rejects free-text and the obvious shapes a raw address/invoice/path
+// would take if smuggled in as a "ref".
+function isSafeRef(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && !/\s/.test(value)
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) return false
+  // Round-trip guard: only accept canonical ISO-8601, so loose/ambiguous date
+  // strings cannot pass as a "receipt" timestamp.
+  return new Date(parsed).toISOString() === value
+}
+
+function isNonNegativeIntegerSats(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+}
+
+export type MultiEarningEntryVerification = {
+  valid: boolean
+  reasons: string[]
+}
+
+/**
+ * Audit a candidate per-mode earning entry parsed from untrusted input.
+ *
+ * Pure and side-effect-free. Rejects any entry that is malformed OR that would
+ * leak private material (a key outside the closed allowlist, a ref carrying
+ * whitespace, a non-integer/negative amount, a non-canonical timestamp).
+ */
+export function verifyMultiEarningEntry(
+  candidate: unknown,
+): MultiEarningEntryVerification {
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    Array.isArray(candidate)
+  ) {
+    return { valid: false, reasons: ["not-an-object"] }
+  }
+
+  const record = candidate as Record<string, unknown>
+  const reasons: string[] = []
+
+  // Public-safety: reject any key outside the closed allowlist before reading
+  // values, so a leaked field (balance, raw address, invoice) fails the audit.
+  for (const key of Object.keys(record)) {
+    if (!ALLOWED_ENTRY_KEYS.has(key)) {
+      reasons.push(`unexpected-key:${key}`)
+    }
+  }
+
+  if (record.schema !== "openagents.pylon.multi_earning_entry.v0.1") {
+    reasons.push("bad-schema")
+  }
+  if (typeof record.mode !== "string" || !MODE_SET.has(record.mode)) {
+    reasons.push("bad-mode")
+  }
+  if (
+    typeof record.amountClass !== "string" ||
+    !AMOUNT_CLASS_SET.has(record.amountClass)
+  ) {
+    reasons.push("bad-amount-class")
+  }
+  if (!isNonNegativeIntegerSats(record.amountSats)) {
+    reasons.push("bad-amount-sats")
+  }
+  if (!isSafeRef(record.receiptRef)) {
+    reasons.push("bad-receipt-ref")
+  }
+  if (!isSafeRef(record.sourceRef)) {
+    reasons.push("bad-source-ref")
+  }
+  if (!isIsoTimestamp(record.observedAt)) {
+    reasons.push("bad-observed-at")
+  }
+  if (record.contentRedacted !== true) {
+    reasons.push("not-redacted")
+  }
+
+  return { valid: reasons.length === 0, reasons }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-mode aggregation.
+// ---------------------------------------------------------------------------
+
+// Per-mode rollup: how much is in each amount class, plus the distinct settled
+// receipt refs for that mode (the evidence a mode "counts" toward green).
+export type MultiEarningModeRollup = {
+  mode: MultiEarningMode
+  // Sum of sats per amount class.
+  amountSatsByClass: Record<MultiEarningAmountClass, number>
+  // Total record count per amount class.
+  recordCountByClass: Record<MultiEarningAmountClass, number>
+  // Distinct settled receipt refs for this mode (sorted, deduped).
+  settledReceiptRefs: string[]
+  // True when this mode carries >=1 distinct settled receipt.
+  hasSettledReceipt: boolean
+}
+
+export type MultiEarningSummary = {
+  schema: "openagents.pylon.multi_earning_summary.v0.1"
+  promiseId: "pylon.v0_3_multi_earning_node.v1"
+  // Mirrors the registry: the promise is RED until owner-flipped.
+  promiseState: "red"
+  // The single blocker this ledger addresses.
+  clearsBlocker: "blocker.product_promises.multi_earning_mode_receipts_missing"
+  // INERT projection (no entries) unless the install opted in.
+  enabled: boolean
+  inert: boolean
+  // Per-mode rollups, only for modes that carry >=1 valid entry, mode-sorted.
+  modes: MultiEarningModeRollup[]
+  // Count of DISTINCT modes carrying >=1 settled receipt. This is the value
+  // compared against the >=2 green bar.
+  settledModeCount: number
+  // The distinct mode names that carry a settled receipt (sorted).
+  settledModes: MultiEarningMode[]
+  // The >=2 bar the promise requires.
+  requiredSettledModes: 2
+  // True ONLY when settledModeCount >= 2. This does NOT flip the promise; it is
+  // the honest machine-readable signal that the receipt bar is met.
+  meetsMultiEarningBar: boolean
+  // The remaining blockers that stay owner-gated regardless of this ledger.
+  remainingOwnerGatedBlockers: string[]
+  // Count of entries rejected by the public-safety/well-formedness audit.
+  rejectedEntryCount: number
+  observedAt: string
+  contentRedacted: true
+}
+
+const REMAINING_OWNER_GATED_BLOCKERS: readonly string[] = [
+  "blocker.product_promises.pylon_v1_default_install_not_fully_closed",
+  "blocker.product_promises.multi_earning_settlement_refs_missing",
+  "blocker.product_promises.safe_public_projection_missing",
+]
+
+function emptyClassRecord(): Record<MultiEarningAmountClass, number> {
+  return {
+    modeled: 0,
+    observed: 0,
+    pending: 0,
+    paid: 0,
+    settled: 0,
+  }
+}
+
+/**
+ * Summarize a set of per-mode earning entries into a cross-mode multi-earning
+ * projection from one install.
+ *
+ * Pure and side-effect-free. Default-inert: with the flag off (and no explicit
+ * `enabled: true`) the projection reports `inert: true`, ingests no entries, and
+ * reports zero settled modes — exactly today's behavior. When armed, it audits
+ * every entry with `verifyMultiEarningEntry`, drops the rejects (counting them),
+ * rolls valid entries per mode + amount class, and HONESTLY counts how many
+ * distinct modes carry a settled receipt. It never flips the promise; it only
+ * reports whether the >=2 settled-mode bar is met.
+ */
+export function summarizeMultiEarning(
+  entries: ReadonlyArray<MultiEarningLedgerEntry>,
+  observedAt: string,
+  options: MultiEarningLedgerOptions = {},
+): MultiEarningSummary {
+  const env = options.env ?? process.env
+  const enabled = isLedgerEnabled(options, env)
+
+  const base: MultiEarningSummary = {
+    schema: "openagents.pylon.multi_earning_summary.v0.1",
+    promiseId: "pylon.v0_3_multi_earning_node.v1",
+    promiseState: "red",
+    clearsBlocker:
+      "blocker.product_promises.multi_earning_mode_receipts_missing",
+    enabled,
+    inert: !enabled,
+    modes: [],
+    settledModeCount: 0,
+    settledModes: [],
+    requiredSettledModes: 2,
+    meetsMultiEarningBar: false,
+    remainingOwnerGatedBlockers: [...REMAINING_OWNER_GATED_BLOCKERS],
+    rejectedEntryCount: 0,
+    observedAt,
+    contentRedacted: true,
+  }
+
+  // INERT by default: ingest nothing, report an honest empty projection. This is
+  // the production default, so the live earning paths are untouched.
+  if (!enabled) {
+    return base
+  }
+
+  const accumulators = new Map<
+    MultiEarningMode,
+    {
+      amountSatsByClass: Record<MultiEarningAmountClass, number>
+      recordCountByClass: Record<MultiEarningAmountClass, number>
+      settledReceiptRefs: Set<string>
+    }
+  >()
+
+  let rejectedEntryCount = 0
+
+  for (const entry of entries) {
+    const verification = verifyMultiEarningEntry(entry)
+    if (!verification.valid) {
+      rejectedEntryCount += 1
+      continue
+    }
+
+    const mode = entry.mode
+    let acc = accumulators.get(mode)
+    if (!acc) {
+      acc = {
+        amountSatsByClass: emptyClassRecord(),
+        recordCountByClass: emptyClassRecord(),
+        settledReceiptRefs: new Set<string>(),
+      }
+      accumulators.set(mode, acc)
+    }
+
+    acc.amountSatsByClass[entry.amountClass] += entry.amountSats
+    acc.recordCountByClass[entry.amountClass] += 1
+    // Only a `settled` record contributes a settled receipt ref.
+    if (entry.amountClass === "settled") {
+      acc.settledReceiptRefs.add(entry.receiptRef)
+    }
+  }
+
+  const modeRollups: MultiEarningModeRollup[] = []
+  const settledModes: MultiEarningMode[] = []
+
+  for (const mode of MULTI_EARNING_MODES) {
+    const acc = accumulators.get(mode)
+    if (!acc) continue
+    const settledReceiptRefs = [...acc.settledReceiptRefs].sort()
+    const hasSettledReceipt = settledReceiptRefs.length > 0
+    if (hasSettledReceipt) settledModes.push(mode)
+    modeRollups.push({
+      mode,
+      amountSatsByClass: acc.amountSatsByClass,
+      recordCountByClass: acc.recordCountByClass,
+      settledReceiptRefs,
+      hasSettledReceipt,
+    })
+  }
+
+  const settledModeCount = settledModes.length
+
+  return {
+    ...base,
+    modes: modeRollups,
+    settledModeCount,
+    settledModes,
+    meetsMultiEarningBar: settledModeCount >= 2,
+    rejectedEntryCount,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed receipt capture: summarize -> SELF-VERIFY the bar -> serialize.
+//
+// The summary above is the projection; this is the dereferenceable RECEIPT a
+// capture persists ONLY when the >=2 settled-mode bar is actually met. Like the
+// spark-helper-autostart capture, it is fail-closed: it returns `captured: true`
+// only when the summary honestly meets the bar AND survives a JSON round-trip
+// re-audit, so any emitted artifact is gate-valid by construction. It does NOT
+// flip the promise; clearing the blocker still needs a REAL summary built from
+// real settled receipts AND owner sign-off.
+// ---------------------------------------------------------------------------
+
+export type MultiEarningReceipt = {
+  schema: "openagents.pylon.multi_earning_receipt.v0.1"
+  ref: string
+  promiseId: "pylon.v0_3_multi_earning_node.v1"
+  settledModeCount: number
+  settledModes: MultiEarningMode[]
+  // The distinct settled receipt refs that back this multi-earning attestation,
+  // sorted and deduped across modes.
+  settledReceiptRefs: string[]
+  meetsMultiEarningBar: true
+  observedAt: string
+  contentRedacted: true
+}
+
+export function buildMultiEarningReceiptRef(
+  settledModeCount: number,
+): string {
+  return `receipt.pylon.multi_earning_node.modes_${settledModeCount}.v0.1`
+}
+
+const RECEIPT_KEY_ORDER: readonly (keyof MultiEarningReceipt)[] = [
+  "schema",
+  "ref",
+  "promiseId",
+  "settledModeCount",
+  "settledModes",
+  "settledReceiptRefs",
+  "meetsMultiEarningBar",
+  "observedAt",
+  "contentRedacted",
+]
+
+/**
+ * Serialize a multi-earning receipt to canonical, deterministic JSON over the
+ * closed key order (trailing newline). Independent of the object's own key
+ * insertion order, so the persisted artifact is stable and re-auditable.
+ */
+export function serializeMultiEarningReceipt(receipt: MultiEarningReceipt): string {
+  const source = receipt as Record<string, unknown>
+  const ordered: Record<string, unknown> = {}
+  for (const key of RECEIPT_KEY_ORDER) {
+    ordered[key] = source[key]
+  }
+  return `${JSON.stringify(ordered, null, 2)}\n`
+}
+
+const ALLOWED_RECEIPT_KEYS: ReadonlySet<string> = new Set<string>(
+  RECEIPT_KEY_ORDER as readonly string[],
+)
+
+export type MultiEarningReceiptVerification = {
+  valid: boolean
+  // True only when valid AND it attests >=2 settled modes. This is the bar a
+  // captured receipt must meet before it could be cited against the blocker.
+  clearsBlocker: boolean
+  reasons: string[]
+}
+
+/**
+ * Audit a candidate multi-earning receipt parsed from untrusted input.
+ *
+ * Pure and side-effect-free. Rejects malformed or leak-prone artifacts and only
+ * reports `clearsBlocker` when the receipt honestly attests >=2 settled modes
+ * with a settled receipt ref per settled mode.
+ */
+export function verifyMultiEarningReceipt(
+  candidate: unknown,
+): MultiEarningReceiptVerification {
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    Array.isArray(candidate)
+  ) {
+    return { valid: false, clearsBlocker: false, reasons: ["not-an-object"] }
+  }
+
+  const record = candidate as Record<string, unknown>
+  const reasons: string[] = []
+
+  for (const key of Object.keys(record)) {
+    if (!ALLOWED_RECEIPT_KEYS.has(key)) {
+      reasons.push(`unexpected-key:${key}`)
+    }
+  }
+
+  if (record.schema !== "openagents.pylon.multi_earning_receipt.v0.1") {
+    reasons.push("bad-schema")
+  }
+  if (record.promiseId !== "pylon.v0_3_multi_earning_node.v1") {
+    reasons.push("bad-promise-id")
+  }
+  if (record.meetsMultiEarningBar !== true) {
+    reasons.push("does-not-meet-bar")
+  }
+  if (record.contentRedacted !== true) {
+    reasons.push("not-redacted")
+  }
+  if (!isIsoTimestamp(record.observedAt)) {
+    reasons.push("bad-observed-at")
+  }
+
+  const settledModes = record.settledModes
+  const settledModesOk =
+    Array.isArray(settledModes) &&
+    settledModes.length >= 2 &&
+    settledModes.every((m) => typeof m === "string" && MODE_SET.has(m)) &&
+    new Set(settledModes).size === settledModes.length
+  if (!settledModesOk) {
+    reasons.push("bad-settled-modes")
+  }
+
+  if (
+    typeof record.settledModeCount !== "number" ||
+    !Number.isInteger(record.settledModeCount) ||
+    record.settledModeCount < 2 ||
+    (Array.isArray(settledModes) &&
+      record.settledModeCount !== settledModes.length)
+  ) {
+    reasons.push("bad-settled-mode-count")
+  }
+
+  const settledReceiptRefs = record.settledReceiptRefs
+  const settledReceiptRefsOk =
+    Array.isArray(settledReceiptRefs) &&
+    settledReceiptRefs.length >= 2 &&
+    settledReceiptRefs.every((r) => isSafeRef(r)) &&
+    new Set(settledReceiptRefs).size === settledReceiptRefs.length
+  if (!settledReceiptRefsOk) {
+    reasons.push("bad-settled-receipt-refs")
+  }
+
+  const refMatch =
+    typeof record.ref === "string" &&
+    /^receipt\.pylon\.multi_earning_node\.modes_(\d+)\.v0\.1$/.test(record.ref)
+  if (!refMatch) {
+    reasons.push("bad-ref")
+  } else if (
+    typeof record.settledModeCount === "number" &&
+    record.ref !== buildMultiEarningReceiptRef(record.settledModeCount)
+  ) {
+    reasons.push("ref-count-mismatch")
+  }
+
+  const valid = reasons.length === 0
+  return { valid, clearsBlocker: valid, reasons }
+}
+
+export type MultiEarningCaptureResult =
+  | {
+      captured: false
+      // Why no artifact was emitted (e.g. `inert`, `below-bar:<n>`,
+      // `self-verify-failed:<reason>`, `round-trip-failed:<reason>`).
+      reasons: string[]
+      summary: MultiEarningSummary
+    }
+  | {
+      captured: true
+      summary: MultiEarningSummary
+      receipt: MultiEarningReceipt
+      verification: MultiEarningReceiptVerification
+      // Canonical JSON the capture path should persist verbatim.
+      serialized: string
+    }
+
+/**
+ * Capture a multi-earning receipt from a set of per-mode entries, fail-closed.
+ *
+ * Pure and side-effect-free: it summarizes, builds, self-verifies, and produces
+ * the canonical serialization, but writes nothing. The capture path calls this
+ * and persists `result.serialized` only when `result.captured` — so an artifact
+ * that does not honestly meet the >=2 settled-mode bar (or would leak a field)
+ * is never emitted. This does NOT clear the blocker; clearing it still needs a
+ * REAL set of settled receipts from one install AND owner sign-off.
+ */
+export function captureMultiEarningReceipt(
+  entries: ReadonlyArray<MultiEarningLedgerEntry>,
+  observedAt: string,
+  options: MultiEarningLedgerOptions = {},
+): MultiEarningCaptureResult {
+  const summary = summarizeMultiEarning(entries, observedAt, options)
+
+  if (summary.inert) {
+    return { captured: false, reasons: ["inert"], summary }
+  }
+  if (!summary.meetsMultiEarningBar) {
+    return {
+      captured: false,
+      reasons: [`below-bar:${summary.settledModeCount}`],
+      summary,
+    }
+  }
+
+  const settledReceiptRefs = [
+    ...new Set(
+      summary.modes
+        .filter((m) => m.hasSettledReceipt)
+        .flatMap((m) => m.settledReceiptRefs),
+    ),
+  ].sort()
+
+  const receipt: MultiEarningReceipt = {
+    schema: "openagents.pylon.multi_earning_receipt.v0.1",
+    ref: buildMultiEarningReceiptRef(summary.settledModeCount),
+    promiseId: "pylon.v0_3_multi_earning_node.v1",
+    settledModeCount: summary.settledModeCount,
+    settledModes: [...summary.settledModes],
+    settledReceiptRefs,
+    meetsMultiEarningBar: true,
+    observedAt,
+    contentRedacted: true,
+  }
+
+  // Self-audit: never emit an artifact that does not pass its own gate.
+  const verification = verifyMultiEarningReceipt(receipt)
+  if (!verification.clearsBlocker) {
+    return {
+      captured: false,
+      reasons: verification.reasons.map((r) => `self-verify-failed:${r}`),
+      summary,
+    }
+  }
+
+  // Round-trip guard: the persisted form is what an auditor re-reads.
+  const serialized = serializeMultiEarningReceipt(receipt)
+  const roundTrip = verifyMultiEarningReceipt(JSON.parse(serialized))
+  if (!roundTrip.clearsBlocker) {
+    return {
+      captured: false,
+      reasons: roundTrip.reasons.map((r) => `round-trip-failed:${r}`),
+      summary,
+    }
+  }
+
+  return { captured: true, summary, receipt, verification, serialized }
+}

--- a/docs/promises/2026-06-23-pylon-multi-earning-node-receipt-machinery.md
+++ b/docs/promises/2026-06-23-pylon-multi-earning-node-receipt-machinery.md
@@ -1,0 +1,87 @@
+# Pylon multi-earning-node — cross-mode receipt machinery + capture runbook
+
+Date: 2026-06-23
+Branch: `feat/de4-pylon-promise`
+Promise: `pylon.v0_3_multi_earning_node.v1` (DE-4, EPIC #5527)
+Blocker addressed: `blocker.product_promises.multi_earning_mode_receipts_missing`
+HARD RULE: this does NOT flip the promise green. Green stays owner-signed per
+`proof.claim_upgrade_receipts.v1`, with a real settled receipt from each of >=2
+earning modes captured from one install.
+
+## Why this promise / blocker
+
+The multi-earning-node promise needs "settled receipts for >=2 earning modes in
+one install" (assessment doc `2026-06-19-pylon-non-green-promise-assault-assessment.md`,
+row 6). Pylon already produces per-mode earning records, but each lives in its
+OWN type-specific store with its own shape:
+
+- NIP-90 provider earnings — `ProviderEarningRecord` (`src/provider-nip90.ts`)
+- assignment closeouts — `AssignmentCloseout.receiptRefs` (`src/assignment.ts`)
+- training worker receipts — `TrainingWorkerReceipt` (`src/assignment.ts`)
+- forum tips — `src/tips.ts`; Tassadar executor; data; labor; referral
+
+There was no unified, dereferenceable interface that reads those per-mode records,
+distinguishes amount classes, and HONESTLY counts how many distinct modes carry a
+settled receipt from one install. That missing interface IS the named blocker.
+(The public-projection blocker `safe_public_projection_missing` is a separate,
+workers/api-side deliverable owned by another lane and is untouched here.)
+
+## What this change builds (contributor-node surface only)
+
+`apps/pylon/src/multi-earning-ledger.ts` — pure, INERT, flag-gated:
+
+- A typed per-mode earning entry (`MultiEarningLedgerEntry`) over a closed mode
+  taxonomy (`compute`, `labor`, `tips`, `data`, `referral`, `inference`) and the
+  five amount classes (`modeled`/`observed`/`pending`/`paid`/`settled`).
+- `summarizeMultiEarning(entries, observedAt, opts)` — audits every entry with a
+  closed-key public-safety guard, rolls valid entries per mode + amount class,
+  and counts how many DISTINCT modes carry a `settled` receipt. Only `settled`
+  counts toward the `>=2` bar. INERT by default (`PYLON_MULTI_EARNING_LEDGER_ENABLED`
+  off → empty projection, zero settled modes, promise red).
+- `captureMultiEarningReceipt(...)` — fail-closed: emits a self-verifying,
+  round-trip-clean `MultiEarningReceipt` ONLY when the `>=2` bar is honestly met;
+  otherwise returns `captured: false` with reasons and emits nothing.
+- `verifyMultiEarningEntry` / `verifyMultiEarningReceipt` — deterministic auditor
+  gates a reviewer runs over untrusted captured artifacts.
+
+CLI: `pylon multi-earning ledger --json` — read-only, no-network. Emits the honest
+projection (INERT by default). It ingests no live earning records yet (fail-safe);
+the live earning paths feed `summarizeMultiEarning` only when an operator wires
+real settled receipts.
+
+Public-safety by construction: a closed key allowlist rejects any entry/receipt
+that would smuggle a raw address, balance, invoice, mnemonic, credential, or local
+path. Amounts are carried only as non-negative integer sats (an aggregate the
+public surfaces already expose), never raw payment material.
+
+## Dereferenceable receipt (re-runnable now)
+
+- `bun test apps/pylon/src/multi-earning-ledger.test.ts` — 23 tests: distinguishes
+  all five amount classes, only counts settled modes toward the bar, stays inert
+  by default, rejects leak-prone entries (counting them, never crediting), and the
+  capture is fail-closed + round-trip-clean.
+- `bun apps/pylon/src/index.ts multi-earning ledger --json` — emits the honest
+  INERT projection (`inert: true`, `settledModeCount: 0`, `promiseState: "red"`,
+  the three remaining owner-gated blockers named).
+
+## Exact remaining owner step (single arm/flip)
+
+The machinery is built and proven up to the live earning event. To reach green,
+the owner (one arm/flip):
+
+1. On one install, set `PYLON_MULTI_EARNING_LEDGER_ENABLED=1` and wire the live
+   per-mode earning sources to feed `summarizeMultiEarning` (the existing
+   `ProviderEarningRecord` / `AssignmentCloseout.receiptRefs` / tips records, each
+   mapped to a `MultiEarningLedgerEntry` with `amountClass: "settled"`).
+2. Earn and SETTLE a real receipt in >=2 distinct modes from that one install
+   (e.g. a settled Tassadar/compute receipt + a settled forum-tip receipt). This
+   requires real compute / a real earning event + operator spend/settlement
+   approval — owner-gated.
+3. Run `captureMultiEarningReceipt(...)`; confirm `captured: true` and that the
+   serialized artifact re-audits clean via `verifyMultiEarningReceipt`.
+4. Owner-sign the green flip per `proof.claim_upgrade_receipts.v1`, citing the
+   captured `receipt.pylon.multi_earning_node.modes_N.v0.1` ref.
+
+No money moved, no install claimed closed, no green flipped here. The projection
+is INERT by default and honest when armed (never reports a settled mode the store
+did not carry).


### PR DESCRIPTION
## Promise picked + why most-ready

**`pylon.v0_3_multi_earning_node.v1`** (red), addressing its named blocker
**`blocker.product_promises.multi_earning_mode_receipts_missing`** — the
contributor-node-surface half of the promise, which the assessment doc
(`docs/promises/2026-06-19-pylon-non-green-promise-assault-assessment.md`, row 6)
states needs "settled receipts for >=2 earning modes in one install."

It is the most-ready, highest-leverage in-scope pick on the `apps/pylon` surface:
Pylon already produces per-mode earning records, but each lives in its OWN
type-specific store (NIP-90 `ProviderEarningRecord`, `AssignmentCloseout.receiptRefs`,
`TrainingWorkerReceipt`, tips) with no unified, dereferenceable interface that
counts how many distinct modes carry a settled receipt from one install. That
missing interface IS the named blocker. It lives purely on the contributor node
(CLI/runtime), so it does NOT collide with the public-projection blocker
(`safe_public_projection_missing`) which is a separate workers/api-side deliverable
owned by another lane (untouched here).

## What I built (apps/pylon + docs/promises only)

- **`apps/pylon/src/multi-earning-ledger.ts`** — pure, side-effect-free, INERT,
  flag-gated (`PYLON_MULTI_EARNING_LEDGER_ENABLED`, default off). Typed per-mode
  earning entry over a closed mode taxonomy + the five amount classes
  (`modeled`/`observed`/`pending`/`paid`/`settled`). `summarizeMultiEarning`
  audits every entry with a closed-key public-safety guard, rolls valid entries
  per mode + class, and counts how many DISTINCT modes carry a `settled` receipt —
  only `settled` counts toward the `>=2` bar. `captureMultiEarningReceipt` is
  fail-closed: emits a self-verifying, round-trip-clean receipt ONLY when the bar
  is honestly met. Modeled on the proven `spark-helper-autostart.ts` scaffold.
- **`pylon multi-earning ledger --json`** (`index.ts` + `cli-catalog.ts`) —
  read-only, no-network; emits the honest INERT projection; discoverable in
  `pylon help --json`.
- **Docs**: `docs/promises/2026-06-23-pylon-multi-earning-node-receipt-machinery.md`
  + README section.

Public-safe by construction: a closed key allowlist rejects any entry/receipt
that would smuggle a raw address, balance, invoice, mnemonic, credential, or
local path. Amounts are aggregate sats only.

## Dereferenceable receipt / proof

- `bun test apps/pylon/src/multi-earning-ledger.test.ts` → **23 pass**: distinguishes
  all five amount classes; only counts settled modes; INERT by default; rejects
  leak-prone entries (counts them, never credits); capture is fail-closed +
  round-trip-clean.
- `bun apps/pylon/src/index.ts multi-earning ledger --json` → honest INERT
  projection (`inert: true`, `settledModeCount: 0`, `promiseState: "red"`, three
  remaining owner-gated blockers named).

## EXACT remaining owner step (single arm/flip)

1. On one install set `PYLON_MULTI_EARNING_LEDGER_ENABLED=1` and map the live
   per-mode earning sources into `MultiEarningLedgerEntry` with `amountClass: "settled"`.
2. Earn + SETTLE a real receipt in **>=2 distinct modes** from that one install
   (real compute / real earning event + operator spend/settlement approval).
3. Run `captureMultiEarningReceipt(...)`; confirm `captured: true` and the
   serialized artifact re-audits clean via `verifyMultiEarningReceipt`.
4. Owner-sign the green flip per `proof.claim_upgrade_receipts.v1`, citing the
   captured `receipt.pylon.multi_earning_node.modes_N.v0.1` ref.

No money moved, no install claimed closed, no green flipped here. Promise stays red.

## Tests

- New: `apps/pylon/src/multi-earning-ledger.test.ts` (23 pass).
- Full pylon suite: **1525 pass / 0 fail / 3 skip**.
- `apps/pylon` typecheck: clean.
- No pre-existing reds encountered in pylon scope. (Root `check:deploy` runs in
  the out-of-scope `apps/openagents.com` worker and is unaffected by this
  pylon-only change.)

Part of EPIC #5527. DO NOT auto-merge — orchestrator reviews/merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)