### PR TITLE
forum: remove the pylon-tips panel only (keep post Send-tip + leaderboards)

### DIFF
--- a/apps/openagents.com/apps/web/src/forum-route.test.ts
+++ b/apps/openagents.com/apps/web/src/forum-route.test.ts
@@ -36,6 +36,12 @@ afterEach(() => {
   if (typeof localStorage.clear === 'function') {
     localStorage.clear()
   }
+  // Clear any cookies a test set (e.g. the login-error cookie) so cookie
+  // state cannot leak across tests in jsdom and make ordering significant.
+  for (const part of document.cookie.split(';')) {
+    const name = part.split('=')[0]?.trim()
+    if (name) document.cookie = name + '=; Max-Age=0; Path=/'
+  }
   window.history.replaceState({}, '', '/')
 })
 
@@ -499,7 +505,6 @@ describe('Forum routes', () => {
     expect(script).toContain('Log in with GitHub')
     expect(script).toContain('href="\' + escapeHtml(loginHref) + \'"')
     expect(script).toContain("'/api/forum/launch-status'")
-    expect(script).toContain("'/api/public/pylon-stats'")
     expect(script).toContain(
       "'/api/forum/posts/' + encodeURIComponent(postId) + '/tips/ladder'",
     )
@@ -516,7 +521,7 @@ describe('Forum routes', () => {
     expect(script).not.toContain('private_key')
   })
 
-  test('browser topic UI posts forum and Pylon tips to ladder endpoints', async () => {
+  test('browser topic UI posts forum tips to the ladder endpoint', async () => {
     const topicId = '55555555-5555-4555-8555-555555555555'
     const postId = '66666666-6666-4666-8666-666666666666'
     const calls: Array<Readonly<{ body: unknown; method: string; path: string }>> =
@@ -574,21 +579,6 @@ describe('Forum routes', () => {
         })
       }
 
-      if (path === '/api/public/pylon-stats') {
-        return jsonResponse({
-          recentPylons: [
-            {
-              nodeLabel: 'Network Pylon',
-              nostrPubkeyShort: 'pylon.public.tip',
-              pylonRef: 'pylon.public.tip',
-              tipEndpoint: '/api/pylons/pylon.public.tip/tips/ladder',
-              tippingAvailable: true,
-              walletReadyNow: true,
-            },
-          ],
-        })
-      }
-
       if (path.includes('/api/forum/posts/')) {
         return jsonResponse({
           amountSat: 10,
@@ -597,18 +587,6 @@ describe('Forum routes', () => {
           receiptRef: 'receipt.forum.tip_ladder.sha256.forumroute',
           rung: 'credited',
           senderBalanceMsatAfter: 90_000,
-        })
-      }
-
-      if (path.includes('/api/pylons/')) {
-        return jsonResponse({
-          amountSat: 10,
-          ladderReason: 'recipient_destination_missing',
-          payInId: 'payin_pylon',
-          pylonRef: 'pylon.public.tip',
-          receiptRef: 'receipt.pylon.tip_ladder.sha256.pylonroute',
-          rung: 'credited',
-          senderBalanceMsatAfter: 80_000,
         })
       }
 
@@ -628,15 +606,10 @@ describe('Forum routes', () => {
     const forumTipButton = document.querySelector<HTMLButtonElement>(
       '[data-forum-tip-post-id]',
     )
-    const pylonTipButton = document.querySelector<HTMLButtonElement>(
-      '[data-pylon-tip-ref]',
-    )
 
     expect(forumTipButton).not.toBeNull()
-    expect(pylonTipButton).not.toBeNull()
 
     forumTipButton?.click()
-    pylonTipButton?.click()
     await flushForumScript()
 
     expect(calls).toEqual([
@@ -645,21 +618,13 @@ describe('Forum routes', () => {
         method: 'POST',
         path: `/api/forum/posts/${postId}/tips/ladder`,
       },
-      {
-        body: { amountSat: 10 },
-        method: 'POST',
-        path: '/api/pylons/pylon.public.tip/tips/ladder',
-      },
     ])
     expect(
       document.querySelector('[data-forum-tip-panel]')?.textContent,
     ).toContain('Payment recorded')
-    expect(
-      document.querySelector('[data-pylon-tip-panel]')?.textContent,
-    ).toContain('Pylon tip recorded')
   })
 
-  test('renders Pylon tip controls on topic pages without wallet material', () => {
+  test('topic pages no longer render the pylon-tips panel', () => {
     const script = forumScript(
       ForumTopicRoute({
         topicId: '55555555-5555-4555-8555-555555555555',
@@ -667,18 +632,21 @@ describe('Forum routes', () => {
       'LoggedIn',
     )
 
-    expect(script).toContain('const renderPylonTipPanel = pylonStats =>')
-    expect(script).toContain('data-pylon-tip-ref')
-    expect(script).toContain('data-pylon-tip-amount')
-    expect(script).toContain('Tip pylon')
+    // The pylon-tips panel and all of its wiring are gone.
+    expect(script).not.toContain('data-pylon-tip')
+    expect(script).not.toContain('Send sats to pylons')
+    expect(script).not.toContain('Pylon tips')
+    expect(script).not.toContain('renderPylonTipPanel')
+    expect(script).not.toContain('Tip pylon')
+    expect(script).not.toContain("'/api/public/pylon-stats'")
+
+    // The per-post Send-tip controls still render.
+    expect(script).toContain('data-forum-tip-post-id')
+    expect(script).toContain('data-forum-tip-amount')
+    expect(script).toContain('Send tip')
     expect(script).toContain(
-      "'/api/pylons/' + encodeURIComponent(pylonRef) + '/tips/ladder'",
+      "'/api/forum/posts/' + encodeURIComponent(postId) + '/tips/ladder'",
     )
-    expect(script).toContain('Pylon tip recorded')
-    expect(script).not.toContain('rawSparkAddress')
-    expect(script).not.toContain('spark1')
-    expect(script).not.toContain('payment_preimage')
-    expect(script).not.toContain('mnemonic')
   })
 
   test('renders Forum login errors from the callback cookie', async () => {

--- a/apps/openagents.com/apps/web/src/page/forum.ts
+++ b/apps/openagents.com/apps/web/src/page/forum.ts
@@ -114,7 +114,6 @@ export const forumScript = (
     posts: [],
     topicPostSortDirection: 'asc',
     receipt: null,
-    pylonStats: null,
     tipLeaderboards: null,
   };
   const root = document.querySelector('[data-forum-app]');
@@ -203,10 +202,8 @@ export const forumScript = (
   const postNumberAnchor = post => 'post-' + Number(post.postNumber || 0);
   const postHref = post => topicHref(post) + '#' + postAnchor(post);
   const defaultPostRewardSats = 10;
-  const defaultPylonTipSats = 10;
   const postRewardAmountLabel = amount => String(amount) + ' sats';
   const postRewardCaveat = 'Content reward; receipt separates payment from settlement.';
-  const pylonTipCaveat = 'Pylon reward; receipt separates payment from settlement.';
   const countText = (count, singular, plural) => {
     const normalized = Number(count || 0);
     return normalized === 1 ? '1 ' + singular : normalized + ' ' + plural;
@@ -577,27 +574,12 @@ export const forumScript = (
     panel.setAttribute('data-forum-tip-result', stateName);
     panel.innerHTML = html;
   };
-  const findPylonTipPanel = pylonRef =>
-    Array.from(main.querySelectorAll('[data-pylon-tip-panel]')).find(element =>
-      element.getAttribute('data-pylon-tip-panel') === pylonRef
-    ) || null;
-  const setPylonTipPanel = (pylonRef, stateName, html) => {
-    const panel = findPylonTipPanel(pylonRef);
-    if (!panel) return;
-    panel.setAttribute('data-pylon-tip-result', stateName);
-    panel.innerHTML = html;
-  };
   const tipSessionNonce = String(Math.trunc(performance.timeOrigin));
   let tipSequence = 0;
   const tipIdempotencyKey = postId => {
     tipSequence += 1;
     const nonce = tipSessionNonce + ':' + String(tipSequence);
     return 'forum:browser_tip:' + postId + ':' + nonce;
-  };
-  const pylonTipIdempotencyKey = pylonRef => {
-    tipSequence += 1;
-    const nonce = tipSessionNonce + ':' + String(tipSequence);
-    return 'forum:browser_pylon_tip:' + pylonRef + ':' + nonce;
   };
   const renderTipControls = post => {
     const readiness = post.tipRecipientReadiness || {};
@@ -630,30 +612,6 @@ export const forumScript = (
       renderTipControls(post) +
       '<button type="button" class="rounded border border-forum-row-c bg-forum-panel px-2 py-1 text-xs font-bold text-forum-link hover:border-forum-header hover:bg-forum-post-link-hover-bg hover:text-forum-link-hover" data-forum-copy-permalink="' + escapeHtml(postHref(post)) + '">Permalink</button>' +
       '</div>';
-  const pylonDisplayName = pylon => pylon.nodeLabel || pylon.pylonRef || pylon.nostrPubkeyShort || 'Pylon';
-  const pylonTipRef = pylon => pylon.pylonRef || pylon.nostrPubkeyShort || '';
-  const pylonTipEndpoint = pylon => pylon.tipEndpoint || ('/api/pylons/' + encodeURIComponent(pylonTipRef(pylon)) + '/tips/ladder');
-  const renderPylonTipRow = pylon => {
-    const pylonRef = pylonTipRef(pylon);
-    if (!pylonRef) return '';
-    const status = pylon.walletReadyNow === true ? 'Wallet ready' : 'Ledger credit';
-    const disabled = pylon.tippingAvailable === false ? ' disabled aria-disabled="true"' : '';
-    return '<li class="grid gap-2 border-t border-forum-row-c px-3 py-3 sm:grid-cols-[minmax(0,1fr)_auto]">' +
-      '<div class="min-w-0"><div class="truncate text-sm font-bold text-forum-link">' + escapeHtml(pylonDisplayName(pylon)) + '</div><div class="truncate font-sans text-xs text-forum-text">' + escapeHtml(pylonRef) + ' · ' + escapeHtml(status) + '</div></div>' +
-      '<div class="flex max-w-full flex-wrap items-center justify-end gap-x-2 gap-y-1">' +
-      '<label class="flex items-center gap-1 font-sans text-xs text-forum-text"><span>Tip</span><input class="h-8 w-20 rounded border border-forum-row-c bg-forum-panel px-2 text-right text-forum-heading" data-pylon-tip-amount="' + escapeHtml(pylonRef) + '" inputmode="numeric" min="1" step="1" type="number" value="' + String(defaultPylonTipSats) + '"><span>sats</span></label>' +
-      '<button type="button" class="min-h-8 rounded border border-forum-payment bg-forum-panel px-3 py-1.5 font-sans text-xs font-bold text-forum-payment hover:bg-forum-post-link-hover-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forum-header" data-pylon-tip-ref="' + escapeHtml(pylonRef) + '" data-pylon-tip-endpoint="' + escapeHtml(pylonTipEndpoint(pylon)) + '"' + disabled + '>Tip pylon</button>' +
-      '<span class="basis-full text-right text-xs text-forum-text" data-pylon-tip-panel="' + escapeHtml(pylonRef) + '"></span>' +
-      '</div>' +
-      '</li>';
-  };
-  const renderPylonTipPanel = pylonStats => {
-    const pylons = (pylonStats?.recentPylons || []).slice(0, 6).filter(pylon => pylonTipRef(pylon));
-    if (pylons.length === 0) return '';
-    return '<section class="${panelClass} mb-4 overflow-hidden" data-pylon-tip-list><div class="${forumHeaderClass} rounded-none">Pylons</div>' +
-      '<div class="flex flex-wrap items-start justify-between gap-3 p-3"><div><p class="${eyebrowClass}">Pylon tips</p><h2 class="m-0 text-lg font-bold text-forum-heading">Send sats to pylons</h2></div><span class="font-sans text-xs text-forum-text">' + escapeHtml(pylonTipCaveat) + '</span></div>' +
-      '<ol class="grid">' + pylons.map(renderPylonTipRow).join('') + '</ol></section>';
-  };
   const renderAuthorProfile = post => {
     const actor = post.author || {};
     const displayName = actorDisplayName(actor);
@@ -726,44 +684,6 @@ export const forumScript = (
       button.disabled = false;
     }
   };
-  const renderPylonTipResult = result => {
-    if (result.receiptRef) {
-      return 'Pylon tip recorded · ' + escapeHtml(result.rung || 'credited') + ' · ' + escapeHtml(result.receiptRef);
-    }
-    return 'Pylon tip submitted.';
-  };
-  const handlePylonTipClick = async button => {
-    const pylonRef = button.getAttribute('data-pylon-tip-ref') || '';
-    if (!pylonRef) return;
-    if (authMode !== 'LoggedIn') {
-      setPylonTipPanel(pylonRef, 'login_required', '<a class="text-forum-link underline underline-offset-4 hover:text-forum-link-hover" href="' + escapeHtml(loginHref) + '">Log in with GitHub</a> to tip this pylon.');
-      return;
-    }
-    button.disabled = true;
-    const amountInput = Array.from(main.querySelectorAll('[data-pylon-tip-amount]')).find(element =>
-      element.getAttribute('data-pylon-tip-amount') === pylonRef
-    );
-    const rawAmount = Math.trunc(Number(amountInput?.value || defaultPylonTipSats));
-    const amount = Number.isFinite(rawAmount) && rawAmount > 0 ? rawAmount : defaultPylonTipSats;
-    const endpoint = button.getAttribute('data-pylon-tip-endpoint') || ('/api/pylons/' + encodeURIComponent(pylonRef) + '/tips/ladder');
-    setPylonTipPanel(pylonRef, 'sending', 'Sending ' + postRewardAmountLabel(amount) + '...');
-    try {
-      const result = await api(endpoint, {
-        method: 'POST',
-        headers: {
-          'Idempotency-Key': pylonTipIdempotencyKey(pylonRef + ':' + String(amount)),
-        },
-        body: JSON.stringify({
-          amountSat: amount,
-        }),
-      });
-      setPylonTipPanel(pylonRef, result.receiptRef ? 'success' : 'failed', renderPylonTipResult(result));
-    } catch (error) {
-      setPylonTipPanel(pylonRef, 'failed', 'Payment failed · ' + escapeHtml(error.message || error));
-    } finally {
-      button.disabled = false;
-    }
-  };
   main.addEventListener('click', event => {
     const target = event.target instanceof Element
       ? event.target.closest('[data-forum-tip-post-id]')
@@ -771,15 +691,6 @@ export const forumScript = (
     if (target instanceof HTMLButtonElement) {
       event.preventDefault();
       handleTipClick(target);
-    }
-  });
-  main.addEventListener('click', event => {
-    const target = event.target instanceof Element
-      ? event.target.closest('[data-pylon-tip-ref]')
-      : null;
-    if (target instanceof HTMLButtonElement) {
-      event.preventDefault();
-      handlePylonTipClick(target);
     }
   });
 
@@ -825,7 +736,7 @@ export const forumScript = (
       '<div><p class="${eyebrowClass}">Thread</p><h1 class="m-0 text-2xl font-bold text-forum-heading">' + escapeHtml(topic.title) + '</h1>' +
       '<p class="mt-2 ${mutedClass}">' + postCountText(topic.postCount) + '</p></div>' +
       '<a class="${ghostButtonClass}" href="' + forumHref({ slug: topic.forumId, forumId: topic.forumId }) + '">Forum</a></div>' +
-      '<div class="px-4 pb-4 sm:px-5 sm:pb-5">' + renderPylonTipPanel(state.pylonStats) + postRows(posts) + '</div></section>' +
+      '<div class="px-4 pb-4 sm:px-5 sm:pb-5">' + postRows(posts) + '</div></section>' +
       actionBar(topicSortToggle(topic) + pageSummary(posts.length, 'post'));
     requestAnimationFrame(scrollPostAnchorIntoView);
   };
@@ -886,12 +797,10 @@ export const forumScript = (
         paths: [
           topicApiPath(initial.id),
           '/api/forum/launch-status',
-          '/api/public/pylon-stats',
         ],
         apply: results => {
           state.topic = results[0].topic; state.posts = results[0].posts || [];
           state.launchStatus = results[1];
-          state.pylonStats = results[2];
           renderTopic(state.topic, state.posts);
         },
       };


### PR DESCRIPTION
Removes ONLY the "Pylon tips" / "Send sats to pylons" panel from the web forum (`apps/openagents.com/apps/web/src/page/forum.ts`). Every other tipping surface is deliberately kept.

## Removed (pylon-tip only)
- The **Pylons panel** composed into `renderTopic`: the "Pylons" header, the "Pylon tips" eyebrow + "Send sats to pylons" heading, the `pylonTipCaveat`, and the per-pylon rows (pylon name + wallet/ledger status + the "Tip `<n>` sats" input + the "Tip pylon" button).
- The pylon-tip-only helpers/state: `state.pylonStats`, `defaultPylonTipSats`, `pylonTipCaveat`, `pylonDisplayName`, `pylonTipRef`, `pylonTipEndpoint`, `renderPylonTipRow`, `renderPylonTipPanel`, `findPylonTipPanel`, `setPylonTipPanel`, `pylonTipIdempotencyKey`, `renderPylonTipResult`, `handlePylonTipClick`, the `data-pylon-tip-ref` click listener, and all `data-pylon-tip-*` markup.
- The `/api/public/pylon-stats` fetch in the topic route plan. In `forum.ts` that fetch fed **only** the pylon panel, so it was removed here. The endpoint itself is untouched and is still used by other routes/pages (stats, home, scene elements).

## Kept (deliberately unchanged — still rendering and working)
- Per-post **"Send tip to `<author>`"** controls: `renderTipControls`, `findTipPanel`/`setTipPanel`, `tipIdempotencyKey`, `tipPostGateReady`/`firstTipBlocker`/`tipGateStatusLabel`/`tipStateLabel`, `handleTipClick`, `postRewardCaveat`, `postRewardAmountLabel`, all `data-forum-tip-*` wiring.
- **Tip leaderboards**: `renderTipLeaderboards`, `tipTotalsLabel`, `state.tipLeaderboards`, "Top tipped posts/creators".
- Post tip badges/totals: `postTipStatsBadge`, `post.tipStats`.

## Tests (`forum-route.test.ts`)
- Removed only the pylon-tip assertions; kept the post-tip + leaderboard assertions green.
- The "browser topic UI" test now exercises just the forum post tip; the "renders Pylon tip controls" test was replaced with **"topic pages no longer render the pylon-tips panel"**, which asserts the rendered script contains **NO** pylon-tip markup (`data-pylon-tip`, `Send sats to pylons`, `Pylon tips`, `renderPylonTipPanel`, `Tip pylon`, `/api/public/pylon-stats`) **AND** still contains the post `Send tip` wiring.
- Added cookie clearing in `afterEach` so the login-error cookie cannot leak across tests in jsdom (was a test-ordering flake surfaced by the reduced test set).

## Verification
- `typecheck:web` clean.
- `forum-route.test.ts` 18/18 green (stable across repeated runs); `docs-blog-route.test.ts` 11/11 green; web `build` green.
- Disjoint from `workers/api` tip routes (untouched), `apps/pylon`, and Psionic.

**DO NOT auto-merge — orchestrator reviews/merges + deploys.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)