### PR TITLE
chore: bump three-effect pin to merged main (game-screen #17)

### DIFF
--- a/apps/autopilot-desktop/package.json
+++ b/apps/autopilot-desktop/package.json
@@ -41,7 +41,7 @@
     "@openagentsinc/mcp-contract": "workspace:*",
     "@openagentsinc/proof-replay": "workspace:*",
     "@openagentsinc/public-activity-timeline": "workspace:*",
-    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#bc3c6bc",
+    "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7c6df05",
     "@openagentsinc/ui": "workspace:*",
     "@openagentsinc/world-client": "workspace:*",
     "@openagentsinc/world-contract": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "@openagentsinc/mcp-contract": "workspace:*",
         "@openagentsinc/proof-replay": "workspace:*",
         "@openagentsinc/public-activity-timeline": "workspace:*",
-        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#bc3c6bc",
+        "@openagentsinc/three-effect": "github:OpenAgentsInc/three-effect#7c6df05",
         "@openagentsinc/ui": "workspace:*",
         "@openagentsinc/world-client": "workspace:*",
         "@openagentsinc/world-contract": "workspace:*",
@@ -1172,7 +1172,7 @@
 
     "@openagentsinc/tassadar-executor": ["@openagentsinc/tassadar-executor@workspace:packages/tassadar-executor"],
 
-    "@openagentsinc/three-effect": ["@openagentsinc/three-effect@github:OpenAgentsInc/three-effect#bc3c6bc", { "dependencies": { "@types/three": "0.184.0", "effect": "4.0.0-beta.70", "foldkit": "0.102.1", "three": "0.184.0" } }, "OpenAgentsInc-three-effect-bc3c6bc", "sha512-bGwH5ZTOwK9asgF0NdACur9k6Ww9l6biIMomMeGYUknlcmi1bm4j8HhcrTVv4lYFsGgmB6Q+xi6JiMAghx476w=="],
+    "@openagentsinc/three-effect": ["@openagentsinc/three-effect@github:OpenAgentsInc/three-effect#7c6df05", { "dependencies": { "@types/three": "0.184.0", "effect": "4.0.0-beta.70", "foldkit": "0.102.1", "three": "0.184.0" } }, "OpenAgentsInc-three-effect-7c6df05", "sha512-6J9c3WOs36Mzsz/2oJlME+guOQvuR/GOb/7j7JU47ghK6lZH+J9A+3lpwxoA/E8Hmn4eA/XOu5lJbrfNLAuQUg=="],
 
     "@openagentsinc/ui": ["@openagentsinc/ui@workspace:packages/ui"],
 


### PR DESCRIPTION
## What

Bumps the `@openagentsinc/three-effect` pin in `apps/autopilot-desktop/package.json` from the now-deleted PR #17 branch commit (`bc3c6bc`) to the merged three-effect `main` tip (`7c6df05`).

## Why

three-effect PR #17 ("core: in-world game-screen surface") was CONFLICTING against three-effect main (main had #15 spark-burst + #16 glow-up/bloom merged since #17 branched). openagents `main` #6077 (playable-in-world) was already merged and pinned a loose commit on the #17 *branch* (`bc3c6bc`) — building by fetching a branch SHA is fragile.

This PR follows the resolution:
- three-effect #17 was rebased onto three-effect `origin/main` (dropping two duplicate bloom commits whose content was byte-identical to merged #16, replaying the 4 game-screen commits cleanly), then squash-merged to three-effect `main` as `7c6df05`.
- The merged `7c6df05` carries **both** the #16 glow-up/bloom work **and** the #17 `gameScreenPrimitives` surface.

## Verification

- three-effect (rebased branch, pre-merge): `269 pass / 0 fail`, typecheck clean.
- openagents `apps/autopilot-desktop` typecheck: clean (exit 0) with the new pin.
- `apps/autopilot-desktop` `tests/verse-game-screen.test.ts`: `2 pass / 0 fail` (after `build:css`).
- Only `apps/autopilot-desktop/package.json` + `bun.lock` change. The separate `apps/web` pin (`b3bdc2a`, a different main ancestor) is intentionally untouched.

Do not auto-merge — orchestrator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)