### PR TITLE
Khala telemetry scorecard: production request-lifecycle telemetry in the openagents block + receipt (book P0-1)

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -1,6 +1,13 @@
 import { MemoryStreamStore } from '@openagentsinc/durable-stream'
-import { Effect } from 'effect'
+import { Effect, Option } from 'effect'
 import { describe, expect, test } from 'vitest'
+
+import type { InferenceReceiptReadStore } from '../inference-receipts'
+import { makePublicInferenceReceiptRoutes } from '../public-inference-receipt-routes'
+import {
+  NOT_MEASURED,
+  decodeKhalaTelemetryBlock,
+} from './khala-telemetry'
 
 import {
   type ChatCompletionsDeps,
@@ -64,6 +71,11 @@ const baseDeps = (
 ): ChatCompletionsDeps => ({
   authenticate: authOk,
   enabled: true,
+  // Deterministic telemetry clock (book P0-1): a fixed wall-clock so the
+  // `openagents` telemetry block's `totalWallClockMs` is a stable measured `0`
+  // in tests (a measured zero, NOT the `not_measured` sentinel) instead of a
+  // flaky real elapsed time. Tests that assert real TTFT inject a stepping clock.
+  nowEpochMillis: () => 0,
   readAvailableMsat: fundedBalance,
   registry: registryWithStub(),
   ...overrides,
@@ -381,14 +393,46 @@ describe('POST /v1/chat/completions', () => {
         baseDeps({ lanePlan: selectAdapterPlan, registry: nonStreamRegistry }),
       ),
     )
-    const nonStreamedBody = (await nonStreamed.json()) as { openagents?: unknown }
-    expect(finalOpenagents).toEqual(nonStreamedBody.openagents)
-    expect(finalOpenagents).toEqual({
+    const nonStreamedBody = (await nonStreamed.json()) as {
+      openagents?: { telemetry?: Record<string, unknown> }
+    }
+    // The PRIOR (non-telemetry) disclosure fields are identical streamed vs
+    // non-streamed — and byte-for-byte the prior contract (non-breaking).
+    const stripTelemetry = (
+      block: { telemetry?: unknown } | undefined,
+    ): Record<string, unknown> => {
+      const { telemetry: _telemetry, ...rest } = (block ?? {}) as Record<
+        string,
+        unknown
+      >
+      return rest
+    }
+    expect(stripTelemetry(finalOpenagents as { telemetry?: unknown })).toEqual(
+      stripTelemetry(nonStreamedBody.openagents),
+    )
+    expect(stripTelemetry(finalOpenagents as { telemetry?: unknown })).toEqual({
       lane: 'gemini',
       requested_model: KHALA_MINI_MODEL_ID,
       served_model: KHALA_MINI_MODEL_ID,
       verification: 'none',
       worker: VERTEX_GEMINI_ADAPTER_ID,
+    })
+    // The additive telemetry block correctly DIFFERS by request shape: the
+    // buffered-stream path is `interactive_stream`, the non-stream path is
+    // `async_job` (book P0-1 request class). Both carry the lifecycle summary.
+    expect(
+      (finalOpenagents as { telemetry?: Record<string, unknown> }).telemetry,
+    ).toMatchObject({
+      detailRef: null,
+      executedVerdict: 'not_executed',
+      requestClass: 'interactive_stream',
+      schemaVersion: 'openagents.khala.telemetry.v1',
+      totalWallClockMs: 0,
+      verificationClass: 'none',
+    })
+    expect(nonStreamedBody.openagents?.telemetry).toMatchObject({
+      requestClass: 'async_job',
+      schemaVersion: 'openagents.khala.telemetry.v1',
     })
   })
 
@@ -608,12 +652,24 @@ describe('POST /v1/chat/completions', () => {
       }
     }
     expect(body.model).toBe(KHALA_MINI_MODEL_ID)
-    expect(body.openagents).toEqual({
+    // The prior disclosure fields are byte-for-byte unchanged (non-breaking).
+    expect(body.openagents).toMatchObject({
       lane: 'gemini',
       requested_model: KHALA_MINI_MODEL_ID,
       served_model: KHALA_MINI_MODEL_ID,
       verification: 'none',
       worker: VERTEX_GEMINI_ADAPTER_ID,
+    })
+    // The additive telemetry block: a non-coding Khala lane (async, non-stream)
+    // carries the lifecycle summary with verification class `none`.
+    expect(
+      (body.openagents as { telemetry?: Record<string, unknown> } | undefined)
+        ?.telemetry,
+    ).toMatchObject({
+      requestClass: 'async_job',
+      schemaVersion: 'openagents.khala.telemetry.v1',
+      totalWallClockMs: 0,
+      verificationClass: 'none',
     })
   })
 
@@ -1282,6 +1338,240 @@ describe('POST /v1/chat/completions — streamSse pass-through', () => {
     expect(captured).toHaveLength(1)
     expect(captured[0]?.streamed).toBe(true)
   })
+})
+
+// KHALA TELEMETRY SCORECARD (book P0-1 / Open Q #1-2) ------------------------
+// The `openagents` block carries the SMALL lifecycle telemetry summary; the full
+// record dereferences via the receipt. These assert the MEASURED fields are real
+// on the true-streaming path (TTFT, total wall-clock from a stepping clock) and
+// the genuinely-unmeasurable ones are the honest `not_measured` sentinel — never
+// a fabricated number — and that the receipt detailRef dereferences.
+describe('POST /v1/chat/completions — telemetry scorecard', () => {
+  const passThroughAuth: InferenceAuth = async () => ({
+    accountRef: 'agent:test-user',
+  })
+  const funded: InferenceBalanceReader = async () => 100_000
+
+  const streamSseAdapter = (
+    id: string,
+    script: ReadonlyArray<InferenceStreamEvent>,
+    terminal: Readonly<{
+      finishReason: string | undefined
+      usage: InferenceUsage | undefined
+      servedModel: string | undefined
+    }>,
+  ): InferenceProviderAdapter => ({
+    ...stubEchoAdapter,
+    id,
+    streamSse: () =>
+      Effect.sync<InferenceStreamSource>(() => ({
+        frames: (async function* () {
+          for (const event of script) {
+            yield event
+          }
+        })(),
+        terminal: () => terminal,
+      })),
+  })
+
+  // A stepping wall-clock so the lifecycle boundaries are deterministic AND
+  // distinct: 1000 (request accept) -> 1200 (first token) -> 1500 (EOF). So
+  // TTFT = 200ms and total wall-clock = 500ms are REAL measured numbers.
+  const steppingClock = (steps: ReadonlyArray<number>): (() => number) => {
+    let index = 0
+    return () => {
+      const value = steps[Math.min(index, steps.length - 1)] ?? 0
+      index += 1
+      return value
+    }
+  }
+
+  const telemetryFor = (
+    block: { telemetry?: Record<string, unknown> } | undefined,
+  ): Record<string, unknown> => (block?.telemetry ?? {}) as Record<
+    string,
+    unknown
+  >
+
+  test('a streamed khala-code request carries REAL measured TTFT + total wall-clock and honest sentinels', async () => {
+    const meteringHook: MeteringHook = () =>
+      Effect.sync(() => ({
+        metered: true,
+        receiptRef: 'receipt.inference.charge.chatcmpl-telemetry',
+      }))
+
+    const registry = new InferenceProviderRegistry()
+    registry.register(
+      streamSseAdapter(
+        FIREWORKS_ADAPTER_ID,
+        // Two content deltas, then the terminal usage frame. The provider does NOT
+        // report a cached-token dimension here (so cached input is `not_measured`).
+        [
+          { contentDelta: '<html>' },
+          { contentDelta: '</html>' },
+          {
+            contentDelta: '',
+            finishReason: 'stop',
+            servedModel: 'accounts/fireworks/models/kimi-k2p7-code',
+            usage: { completionTokens: 12, promptTokens: 400, totalTokens: 412 },
+          },
+        ],
+        {
+          finishReason: 'stop',
+          servedModel: 'accounts/fireworks/models/kimi-k2p7-code',
+          usage: { completionTokens: 12, promptTokens: 400, totalTokens: 412 },
+        },
+      ),
+    )
+
+    const response = await run(
+      handleChatCompletions(
+        new Request('https://openagents.com/v1/chat/completions', {
+          body: JSON.stringify({
+            messages: [{ content: GOOD_CROSSY_ROAD_HTML, role: 'user' }],
+            model: KHALA_CODE_MODEL_ID,
+            stream: true,
+          }),
+          method: 'POST',
+        }),
+        {
+          authenticate: passThroughAuth,
+          enabled: true,
+          lanePlan: selectAdapterPlan,
+          meteringHook,
+          newId: () => 'chatcmpl-telemetry',
+          // Clock read order on the true-streaming path: (1) request accept=1000,
+          // (2) the durable-log clock read at the stream call site=1100 (a no-op
+          // for telemetry, durable streaming is off), (3) first-token=1200,
+          // (4) EOF=1500. So TTFT=200 and total wall-clock=500 are real.
+          nowEpochMillis: steppingClock([1000, 1100, 1200, 1500]),
+          readAvailableMsat: funded,
+          registry,
+        },
+      ),
+    )
+    expect(response.status).toBe(200)
+
+    const frames = (await response.text())
+      .split('\n\n')
+      .map(block => block.replace(/^data: /u, '').trim())
+      .filter(payload => payload !== '' && payload !== '[DONE]')
+      .map(payload => JSON.parse(payload) as { openagents?: { telemetry?: Record<string, unknown> } })
+    const finalBlock = frames[frames.length - 1]?.openagents
+    const telemetry = telemetryFor(finalBlock)
+
+    // The block decodes against the schema (a valid public-safe projection).
+    expect(Option.isSome(decodeKhalaTelemetryBlock(telemetry))).toBe(true)
+
+    // MEASURED-NOW fields are REAL numbers, not sentinels.
+    expect(telemetry.requestClass).toBe('interactive_stream')
+    expect(telemetry.promptTokens).toBe(400)
+    expect(telemetry.completionTokens).toBe(12)
+    expect(telemetry.totalTokens).toBe(412)
+    expect(telemetry.ttftMs).toBe(200) // 1200 - 1000
+    expect(telemetry.totalWallClockMs).toBe(500) // 1500 - 1000
+    // khala-code on the hot Worker path NEVER executes the artifact (no browser),
+    // so the executed verdict is the honest `not_executed` — NEVER a fabricated
+    // `passed`. The verification class reflects the cheap pre-screen verdict
+    // (here `failed`: the artifact's prescreen rejected it), and scalar_reward is
+    // 0. A real `failed`/`not_executed` beats a fake `passed`.
+    expect(telemetry.verificationClass).toBe('failed')
+    expect(telemetry.executedVerdict).toBe('not_executed')
+    expect(telemetry.scalarReward).toBe(0)
+    // The detailRef points at the dereferenceable receipt.
+    expect(telemetry.detailRef).toBe(
+      '/api/public/inference/receipts/receipt.inference.charge.chatcmpl-telemetry',
+    )
+
+    // The block is the SMALL summary — the deep P0-1 fields (cached tokens,
+    // time split, cost basis, cache-affinity hash) are NOT on the immediate
+    // block; they live in the dereferenceable record.
+    expect(telemetry).not.toHaveProperty('cachedInputTokens')
+    expect(telemetry).not.toHaveProperty('providerTimeMs')
+    expect(telemetry).not.toHaveProperty('costBasisMsat')
+    expect(telemetry).not.toHaveProperty('cacheAffinityKeyHash')
+
+    // No raw account/session/prompt material leaked into the disclosure.
+    const serialized = JSON.stringify(finalBlock)
+    expect(serialized).not.toContain('agent:test-user')
+
+    // DEREFERENCE: the detailRef receipt resolves through the public receipt
+    // route to a public-safe paid projection (no private payment material).
+    const receiptRoutes = makePublicInferenceReceiptRoutes<{
+      store: InferenceReceiptReadStore
+    }>({
+      makeStore: env => env.store,
+      nowIso: () => '2026-06-23T00:00:00.000Z',
+    })
+    const store: InferenceReceiptReadStore = {
+      readInferenceReceiptByRef: async receiptRef =>
+        receiptRef === 'receipt.inference.charge.chatcmpl-telemetry'
+          ? {
+              contextRef: null,
+              createdAt: '2026-06-23T00:00:00.000Z',
+              payInType: 'adjustment',
+              receiptRef,
+              state: 'paid',
+              stateChangedAt: '2026-06-23T00:00:00.500Z',
+            }
+          : null,
+    }
+    const dereferenceEffect = receiptRoutes.routePublicInferenceReceiptRequest(
+      new Request(`https://openagents.com${telemetry.detailRef as string}`),
+      { store },
+    )
+    expect(dereferenceEffect).toBeDefined()
+    const dereferenced = await run(dereferenceEffect!)
+    expect(dereferenced.status).toBe(200)
+    const dereferencedBody = (await dereferenced.json()) as {
+      receipt: { ledgerState: string; schemaVersion: string }
+    }
+    expect(dereferencedBody.receipt.ledgerState).toBe('paid')
+    expect(dereferencedBody.receipt.schemaVersion).toBe(
+      'openagents.inference.receipt.v1',
+    )
+  })
+
+  test('a non-stream Khala request records total wall-clock but honest sentinel TTFT (no first-token boundary)', async () => {
+    const registry = new InferenceProviderRegistry()
+    registry.register(echoAdapterForTelemetry(VERTEX_GEMINI_ADAPTER_ID))
+
+    const response = await run(
+      handleChatCompletions(
+        new Request('https://openagents.com/v1/chat/completions', {
+          body: JSON.stringify({
+            messages: [{ content: 'hello world', role: 'user' }],
+            model: KHALA_MINI_MODEL_ID,
+          }),
+          method: 'POST',
+        }),
+        {
+          authenticate: passThroughAuth,
+          enabled: true,
+          lanePlan: selectAdapterPlan,
+          nowEpochMillis: steppingClock([2000, 2350]),
+          readAvailableMsat: funded,
+          registry,
+        },
+      ),
+    )
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      openagents?: { telemetry?: Record<string, unknown> }
+    }
+    const telemetry = telemetryFor(body.openagents)
+    expect(telemetry.requestClass).toBe('async_job')
+    expect(telemetry.totalWallClockMs).toBe(350) // 2350 - 2000
+    // A buffered/non-stream completion has no observable first-token boundary =>
+    // TTFT is the honest sentinel, NEVER a fabricated number.
+    expect(telemetry.ttftMs).toBe(NOT_MEASURED)
+    expect(telemetry.verificationClass).toBe('none')
+  })
+})
+
+const echoAdapterForTelemetry = (id: string): InferenceProviderAdapter => ({
+  ...stubEchoAdapter,
+  id,
 })
 
 // KHALA IDENTITY GUARD (never identify as Gemini/Google/etc.) -----------------

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -67,6 +67,14 @@ import {
   stubMeteringHook,
 } from './metering-hook'
 import {
+  type KhalaExecutedVerdict,
+  type KhalaRequestClass,
+  type KhalaSettlementState,
+  type KhalaTelemetryBlock,
+  type KhalaVerificationClass,
+  buildKhalaTelemetryBlock,
+} from './khala-telemetry'
+import {
   type DispatchDeps,
   classifyModel,
   dispatchWithOverflow,
@@ -447,6 +455,15 @@ type OpenAgentsReceipt = Readonly<{
         failed_checks: ReadonlyArray<string>
       }>
     | undefined
+  // KHALA REQUEST-TELEMETRY SCORECARD (book P0-1 / Open Q #1-2). The SMALL,
+  // immediate lifecycle summary — request class, tokens, TTFT, total wall-clock,
+  // verification class + executed verdict + scalar reward, and a `detailRef`
+  // pointer to the full dereferenceable record. Non-breaking additive field;
+  // every numeric is a real measurement or the honest `not_measured` sentinel.
+  // The full P0-1 record (time split, queue/batch wait, region, cache-affinity
+  // hash, fallback reason, cost basis / margin bucket / settlement state /
+  // blockers) is the depth behind the receipt detail, off this hot path.
+  telemetry?: KhalaTelemetryBlock | undefined
   // Bitcoin/Spark settlement on a VERIFIED accepted outcome (#6011, EPIC #6017).
   // `settled` is the honest default `false` on the hot path: settlement fires
   // ASYNC after an out-of-Worker headless acceptance run verifies the outcome
@@ -462,6 +479,47 @@ type OpenAgentsReceipt = Readonly<{
 const publicInferenceReceiptUrl = (receiptRef: string): string =>
   `/api/public/inference/receipts/${encodeURIComponent(receiptRef)}`
 
+// What the gateway can MEASURE about this request's lifecycle on the hot path
+// today (book P0-1). All optional: an unmeasured value becomes the honest
+// `not_measured` sentinel in the telemetry builder — never a fabricated number.
+type KhalaTelemetryTiming = Readonly<{
+  // True for the streaming path. Determines the request class (interactive_stream
+  // vs async_job/batch later) and whether TTFT/ITL are measurable at all.
+  streamed: boolean
+  // Total wall-clock from request accept to completion (ms), gateway-edge
+  // measured. Undefined on a path that did not capture it => sentinel.
+  totalWallClockMs?: number | undefined
+  // Time to first token (ms), measurable on the streaming path only.
+  ttftMs?: number | undefined
+  // Generation wall-clock (first byte -> last byte, ms) used to DERIVE perceived
+  // TPS + mean inter-token latency. Streaming only; undefined => those derived
+  // metrics are the sentinel (we never guess them from total wall-clock).
+  generationWallClockMs?: number | undefined
+}>
+
+// Map a khala-code verifier verdict's CLASS onto the telemetry verification
+// class vocabulary (khala.md §6). Reuses the existing values; never invents one.
+const telemetryVerificationClass = (
+  verification: KhalaCodeVerificationVerdict['verification'],
+): KhalaVerificationClass => verification
+
+// Map executed-ness + class onto the executed verdict. `not_executed` is the
+// honest default whenever the headless run did not produce a verdict.
+const telemetryExecutedVerdict = (
+  verdict: KhalaCodeVerificationVerdict,
+): KhalaExecutedVerdict => {
+  if (!verdict.executed) {
+    return 'not_executed'
+  }
+  return verdict.verification === 'test_passed' ? 'passed' : 'failed'
+}
+
+// Derive the request class from the measured shape. Streaming => interactive
+// stream; otherwise an async/synchronous job. (batch/verifier_run lanes set
+// their own class once those request paths land; this is the chat path.)
+const telemetryRequestClass = (streamed: boolean): KhalaRequestClass =>
+  streamed ? 'interactive_stream' : 'async_job'
+
 const khalaReceiptForResult = (
   input: Readonly<{
     adapterId: string
@@ -475,6 +533,9 @@ const khalaReceiptForResult = (
     // => HONEST DOWNGRADE to `unverified`. Full prod wiring (async sandbox dispatch of
     // the runner + receipt backfill) threads a real verdict in here.
     acceptance?: AcceptanceVerdict | undefined
+    // What the gateway measured about this request's lifecycle (book P0-1). When
+    // absent, every telemetry numeric is the honest `not_measured` sentinel.
+    timing?: KhalaTelemetryTiming | undefined
   }>,
 ): OpenAgentsReceipt | undefined => {
   if (!isKhalaModel(input.requestedModel)) {
@@ -488,8 +549,56 @@ const khalaReceiptForResult = (
     worker: input.adapterId,
   } satisfies Omit<OpenAgentsReceipt, 'verification'>
 
+  // Shared telemetry inputs measurable for EVERY Khala request (tokens from the
+  // provider usage, latency from the gateway edge). The cache-affinity key is not
+  // wired on the gateway yet (no session-affinity header is read here today), so
+  // it is honestly absent => the hash is null and a blocker records why.
+  const streamed = input.timing?.streamed ?? false
+  const settlementBlockers =
+    input.metering.receiptRef === null ? ['cost_not_measured'] : []
+  const cacheBlockers = ['cache_affinity_key_not_wired']
+
   if (input.requestedModel !== KHALA_CODE_MODEL_ID) {
-    return { ...base, verification: 'none' }
+    // Non-coding Khala lane: no verifier pass (verification class `none`). Still
+    // carries the full lifecycle telemetry summary (tokens + latency + request
+    // class) so EVERY Khala response is measurable, not just khala-code.
+    const settlementState: KhalaSettlementState = 'not_applicable'
+    const telemetry = buildKhalaTelemetryBlock(
+      {
+        completionTokens: input.result.usage.completionTokens,
+        costBasisMsat: undefined,
+        executedVerdict: 'not_executed',
+        priceMsat: undefined,
+        promptTokens: input.result.usage.promptTokens,
+        provider: input.adapterId,
+        requestClass: telemetryRequestClass(streamed),
+        requestId: input.responseId,
+        requestedModel: input.requestedModel,
+        route: classifyModel(input.requestedModel),
+        servedModel: input.result.servedModel,
+        ...(input.result.usage.cachedPromptTokens === undefined
+          ? {}
+          : { cachedInputTokens: input.result.usage.cachedPromptTokens }),
+        ...(input.timing?.generationWallClockMs === undefined
+          ? {}
+          : { generationWallClockMs: input.timing.generationWallClockMs }),
+        ...(input.timing?.totalWallClockMs === undefined
+          ? {}
+          : { totalWallClockMs: input.timing.totalWallClockMs }),
+        ...(input.timing?.ttftMs === undefined
+          ? {}
+          : { ttftMs: input.timing.ttftMs }),
+        scalarReward: undefined,
+        settlementState,
+        totalTokens: input.result.usage.totalTokens,
+        verificationClass: 'none',
+        blockerRefs: [...settlementBlockers, ...cacheBlockers],
+      },
+      input.metering.receiptRef === null
+        ? null
+        : publicInferenceReceiptUrl(input.metering.receiptRef),
+    )
+    return { ...base, telemetry, verification: 'none' }
   }
 
   const verdict: KhalaCodeVerificationVerdict = verifyKhalaCodeCompletion({
@@ -501,6 +610,48 @@ const khalaReceiptForResult = (
     ...(input.acceptance === undefined ? {} : { acceptance: input.acceptance }),
   })
   const receipt = input.metering.receiptRef ?? verdict.receiptRef
+
+  const verifierBlockers = verdict.executed ? [] : ['verifier_not_executed']
+  const telemetry = buildKhalaTelemetryBlock(
+    {
+      completionTokens: input.result.usage.completionTokens,
+      costBasisMsat: undefined,
+      executedVerdict: telemetryExecutedVerdict(verdict),
+      priceMsat: undefined,
+      promptTokens: input.result.usage.promptTokens,
+      provider: input.adapterId,
+      requestClass: telemetryRequestClass(streamed),
+      requestId: input.responseId,
+      requestedModel: input.requestedModel,
+      route: 'coding',
+      servedModel: input.result.servedModel,
+      scalarReward: verdict.scalarReward,
+      settlementState: verdict.verified ? 'pending' : 'not_applicable',
+      totalTokens: input.result.usage.totalTokens,
+      verificationClass: telemetryVerificationClass(verdict.verification),
+      verifierReceiptRef: verdict.receiptRef,
+      ...(input.result.usage.cachedPromptTokens === undefined
+        ? {}
+        : { cachedInputTokens: input.result.usage.cachedPromptTokens }),
+      ...(input.timing?.generationWallClockMs === undefined
+        ? {}
+        : { generationWallClockMs: input.timing.generationWallClockMs }),
+      ...(input.timing?.totalWallClockMs === undefined
+        ? {}
+        : { totalWallClockMs: input.timing.totalWallClockMs }),
+      ...(input.timing?.ttftMs === undefined
+        ? {}
+        : { ttftMs: input.timing.ttftMs }),
+      blockerRefs: [
+        ...settlementBlockers,
+        ...cacheBlockers,
+        ...verifierBlockers,
+      ],
+    },
+    input.metering.receiptRef === null
+      ? null
+      : publicInferenceReceiptUrl(input.metering.receiptRef),
+  )
 
   return {
     ...base,
@@ -522,6 +673,7 @@ const khalaReceiptForResult = (
     // A fresh completion is not yet settled; the public receipt read reflects the
     // settled state once the callback has run.
     settled: false,
+    telemetry,
     verification: verdict.verification,
     verification_command: verdict.command.commandRef,
     verification_receipt: verdict.receiptRef,
@@ -691,9 +843,17 @@ const makePassThroughResponseStream = (
     // Deterministic clock for the durable log (TTL/offset bookkeeping). Defaults
     // to a fixed epoch in tests; the route threads `currentEpochMillis`.
     durableNowMs?: number | undefined
+    // TELEMETRY CLOCK (book P0-1). On the TRUE pass-through stream, TTFT and
+    // generation wall-clock are GENUINELY measurable (first content delta and
+    // EOF are observable here). `nowMs` is the wall-clock source (ms);
+    // `requestStartMs` is the request-accept instant the route captured. Both
+    // optional: absent => the telemetry numerics degrade to honest sentinels.
+    nowMs?: (() => number) | undefined
+    requestStartMs?: number | undefined
   }>,
 ): ReadableStream<Uint8Array> => {
   const encoder = new TextEncoder()
+  const telemetryNow = input.nowMs ?? currentEpochMillis
   const chunkFrame = (
     delta: string,
     finishReason: string | null,
@@ -723,6 +883,10 @@ const makePassThroughResponseStream = (
   const buildTerminalFrame = async (
     terminal: ReturnType<InferenceStreamSource['terminal']>,
     content: string,
+    // Telemetry boundaries captured by the producer drain (book P0-1): the
+    // first-token instant (for TTFT) and the EOF instant (for total + generation
+    // wall-clock). `undefined` => that boundary was never observed => sentinel.
+    timing?: Readonly<{ firstTokenMs?: number | undefined; eofMs: number }>,
   ): Promise<string> => {
     const servedModel = terminal.servedModel ?? input.requestedModel
     let streamMetering: MeteringOutcome | undefined
@@ -751,12 +915,39 @@ const makePassThroughResponseStream = (
         totalTokens: 0,
       },
     }
+    // Derive the measurable lifecycle timing for the TRUE streaming path. TTFT =
+    // first-token − request-accept; total wall-clock = EOF − request-accept;
+    // generation wall-clock = EOF − first-token (the decode window, used to derive
+    // perceived TPS + ITL). Any boundary we did not observe stays undefined =>
+    // honest sentinel downstream.
+    const start = input.requestStartMs
+    const streamTiming =
+      timing === undefined
+        ? { streamed: true as const }
+        : {
+            streamed: true as const,
+            ...(start === undefined
+              ? {}
+              : { totalWallClockMs: Math.max(0, timing.eofMs - start) }),
+            ...(start === undefined || timing.firstTokenMs === undefined
+              ? {}
+              : { ttftMs: Math.max(0, timing.firstTokenMs - start) }),
+            ...(timing.firstTokenMs === undefined
+              ? {}
+              : {
+                  generationWallClockMs: Math.max(
+                    0,
+                    timing.eofMs - timing.firstTokenMs,
+                  ),
+                }),
+          }
     const openagents = khalaReceiptForResult({
       adapterId: input.adapterId,
       metering: streamMetering ?? { metered: false, receiptRef: null },
       requestedModel: input.requestedModel,
       responseId: input.responseId,
       result: streamResult,
+      timing: streamTiming,
     })
     return chunkFrame('', terminal.finishReason ?? 'stop', openagents)
   }
@@ -767,12 +958,25 @@ const makePassThroughResponseStream = (
       // AND to the client; persist+close on EOF; settle metering EXACTLY ONCE in
       // the `onEof` callback above. The producer drain is the only consumer of
       // the live upstream, so a replay read can never re-bill.
+      // Telemetry: the first observed content delta (TTFT boundary). Captured on
+      // BOTH the durable and non-durable drains so streaming TTFT is real.
+      let firstTokenMs: number | undefined
       if (input.durableStore !== undefined) {
         await teeUpstreamToDurable({
-          emit: frame => controller.enqueue(encoder.encode(frame)),
+          emit: frame => {
+            if (firstTokenMs === undefined) {
+              // First emitted frame on the durable path marks first-token.
+              firstTokenMs = telemetryNow()
+            }
+            controller.enqueue(encoder.encode(frame))
+          },
           frameForDelta: delta => chunkFrame(delta, null),
           nowMs: input.durableNowMs ?? 0,
-          onEof: buildTerminalFrame,
+          onEof: (terminal, content) =>
+            buildTerminalFrame(terminal, content, {
+              eofMs: telemetryNow(),
+              firstTokenMs,
+            }),
           requestId: input.responseId,
           source: input.source,
           store: input.durableStore,
@@ -788,6 +992,9 @@ const makePassThroughResponseStream = (
         // Pump every upstream content delta to the client immediately.
         for await (const event of input.source.frames) {
           if (event.contentDelta !== '') {
+            if (firstTokenMs === undefined) {
+              firstTokenMs = telemetryNow()
+            }
             contentParts.push(event.contentDelta)
             controller.enqueue(
               encoder.encode(chunkFrame(event.contentDelta, null)),
@@ -811,6 +1018,7 @@ const makePassThroughResponseStream = (
       const terminalFrame = await buildTerminalFrame(
         input.source.terminal(),
         contentParts.join(''),
+        { eofMs: telemetryNow(), firstTokenMs },
       )
       controller.enqueue(encoder.encode(terminalFrame))
       controller.enqueue(encoder.encode('data: [DONE]\n\n'))
@@ -1026,8 +1234,12 @@ export const handleChatCompletions = (
       deps.resolveFundingKind ?? defaultCardFundingResolver
     const nowEpochSeconds = deps.nowEpochSeconds ?? currentEpochSeconds
     const newId = deps.newId ?? defaultId
+    const nowEpochMillis = deps.nowEpochMillis ?? currentEpochMillis
     const created = nowEpochSeconds()
     const responseId = newId()
+    // Request-accept wall-clock start (ms). Telemetry total wall-clock is measured
+    // from here to completion (book P0-1). Deterministic in tests via nowEpochMillis.
+    const requestStartMs = nowEpochMillis()
     // Funding kind (card | bitcoin) for the metering charge. Resolved once per
     // request so the Bitcoin discount in `priceRequest` applies; defaults card.
     const fundingKind = yield* Effect.promise(() =>
@@ -1107,10 +1319,14 @@ export const handleChatCompletions = (
           accountRef: session.accountRef,
           adapterId,
           created,
-          durableNowMs: (deps.nowEpochMillis ?? currentEpochMillis)(),
+          durableNowMs: nowEpochMillis(),
           durableStore,
           fundingKind,
           meteringHook,
+          // TELEMETRY CLOCK (book P0-1): the TRUE pass-through path is where TTFT
+          // and generation wall-clock are genuinely observable (first delta + EOF).
+          nowMs: nowEpochMillis,
+          requestStartMs,
           requestedModel,
           responseId,
           source,
@@ -1235,6 +1451,14 @@ export const handleChatCompletions = (
         requestedModel,
         responseId,
         result: streamResult,
+        // Buffered fallback (adapter has no incremental `streamSse`): the WHOLE
+        // completion is materialized before a byte is emitted, so there is no
+        // observable first-token boundary here — TTFT/ITL stay honest sentinels.
+        // Total wall-clock IS measurable from request accept to drain.
+        timing: {
+          streamed: true,
+          totalWallClockMs: Math.max(0, nowEpochMillis() - requestStartMs),
+        },
       })
 
       // When the identity guard rewrote the content, the original per-delta
@@ -1433,6 +1657,12 @@ export const handleChatCompletions = (
           requestedModel,
           responseId,
           result: guardedResult,
+          // Non-streaming: total wall-clock is measurable; TTFT/ITL are not (no
+          // first-token boundary on a buffered completion) => honest sentinels.
+          timing: {
+            streamed: false,
+            totalWallClockMs: Math.max(0, nowEpochMillis() - requestStartMs),
+          },
         }),
         result: guardedResult,
       }),

--- a/apps/openagents.com/workers/api/src/inference/khala-telemetry.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-telemetry.test.ts
@@ -1,0 +1,230 @@
+import { Option } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  NOT_MEASURED,
+  buildKhalaTelemetryBlock,
+  buildKhalaTelemetryRecord,
+  decodeKhalaTelemetryBlock,
+  decodeKhalaTelemetryRecord,
+  deriveMarginBucket,
+  hashCacheAffinityKey,
+  isMeasured,
+  khalaTelemetryBlockFromRecord,
+  measured,
+} from './khala-telemetry'
+
+describe('khala telemetry — honest measured/sentinel discipline', () => {
+  test('measured() maps absent/invalid inputs to the honest sentinel, never a fake number', () => {
+    expect(measured(undefined)).toBe(NOT_MEASURED)
+    expect(measured(null)).toBe(NOT_MEASURED)
+    expect(measured(Number.NaN)).toBe(NOT_MEASURED)
+    expect(measured(Number.POSITIVE_INFINITY)).toBe(NOT_MEASURED)
+    expect(measured(-1)).toBe(NOT_MEASURED)
+    // A measured ZERO is a measured value, distinct from `not_measured`.
+    expect(measured(0)).toBe(0)
+    expect(measured(123)).toBe(123)
+    expect(isMeasured(0)).toBe(true)
+    expect(isMeasured(NOT_MEASURED)).toBe(false)
+  })
+
+  test('a fully-measured record carries every P0-1 field and derives TPS + ITL', () => {
+    const record = buildKhalaTelemetryRecord({
+      cachedInputTokens: 100,
+      completionTokens: 11,
+      costBasisMsat: 100,
+      executedVerdict: 'passed',
+      generationWallClockMs: 1000,
+      priceMsat: 170,
+      promptTokens: 400,
+      provider: 'fireworks',
+      providerTimeMs: 900,
+      gatewayOverheadMs: 40,
+      region: 'us-central1',
+      requestClass: 'interactive_stream',
+      requestId: 'chatcmpl-x',
+      requestedModel: 'openagents/khala-code',
+      route: 'coding',
+      scalarReward: 1,
+      servedModel: 'accounts/fireworks/models/kimi-k2p7-code',
+      settlementState: 'pending',
+      totalTokens: 411,
+      totalWallClockMs: 1200,
+      ttftMs: 200,
+      verificationClass: 'test_passed',
+      verifierReceiptRef: 'verifier.khala_code.executed.v1',
+      cacheAffinityKeyRaw: 'account:123|session:abc',
+    })
+
+    expect(record.promptTokens).toBe(400)
+    expect(record.completionTokens).toBe(11)
+    expect(record.totalTokens).toBe(411)
+    expect(record.cachedInputTokens).toBe(100)
+    expect(record.ttftMs).toBe(200)
+    expect(record.totalWallClockMs).toBe(1200)
+    // ITL = generation wall-clock / (tokens - 1) = 1000 / 10 = 100ms.
+    expect(record.interTokenLatencyMs).toBe(100)
+    // perceived TPS = tokens / (generation wall-clock seconds) = 11 / 1 = 11.
+    expect(record.perceivedTps).toBe(11)
+    expect(record.providerTimeMs).toBe(900)
+    expect(record.gatewayOverheadMs).toBe(40)
+    expect(record.region).toBe('us-central1')
+    expect(record.verificationClass).toBe('test_passed')
+    expect(record.executedVerdict).toBe('passed')
+    expect(record.scalarReward).toBe(1)
+    expect(record.settlementState).toBe('pending')
+    // margin = 170 - 100 = 70; ratio 70/170 ~= 0.41 => 'rich'.
+    expect(record.marginBucket).toBe('rich')
+    // The raw cache-affinity key is NEVER stored; only a stable hash.
+    expect(record.cacheAffinityKeyHash).toMatch(/^cacheaff:fnv1a32:[0-9a-f]{8}$/)
+    expect(JSON.stringify(record)).not.toContain('account:123')
+    expect(JSON.stringify(record)).not.toContain('session:abc')
+    // The record decodes against the schema (a valid public-safe projection).
+    expect(Option.isSome(decodeKhalaTelemetryRecord(record))).toBe(true)
+  })
+
+  test('an UNMEASURED request records honest sentinels — never a fabricated number', () => {
+    const record = buildKhalaTelemetryRecord({
+      // No tokens, no timing, no cost: the worst case (stream with no usage).
+      executedVerdict: 'not_executed',
+      provider: 'vertex-gemini',
+      requestClass: 'async_job',
+      requestId: 'chatcmpl-empty',
+      requestedModel: 'openagents/khala-mini',
+      route: 'gemini',
+      servedModel: 'gemini-3.5-flash',
+      settlementState: 'not_applicable',
+      verificationClass: 'none',
+      blockerRefs: ['cost_not_measured', 'verifier_not_executed'],
+    })
+
+    expect(record.promptTokens).toBe(NOT_MEASURED)
+    expect(record.completionTokens).toBe(NOT_MEASURED)
+    expect(record.cachedInputTokens).toBe(NOT_MEASURED)
+    expect(record.ttftMs).toBe(NOT_MEASURED)
+    expect(record.interTokenLatencyMs).toBe(NOT_MEASURED)
+    expect(record.perceivedTps).toBe(NOT_MEASURED)
+    expect(record.totalWallClockMs).toBe(NOT_MEASURED)
+    expect(record.providerTimeMs).toBe(NOT_MEASURED)
+    expect(record.verifierTimeMs).toBe(NOT_MEASURED)
+    expect(record.settlementTimeMs).toBe(NOT_MEASURED)
+    expect(record.queueWaitMs).toBe(NOT_MEASURED)
+    expect(record.batchWaitMs).toBe(NOT_MEASURED)
+    expect(record.scalarReward).toBe(NOT_MEASURED)
+    expect(record.costBasisMsat).toBe(NOT_MEASURED)
+    expect(record.priceMsat).toBe(NOT_MEASURED)
+    expect(record.marginBucket).toBe('not_measured')
+    expect(record.region).toBe(NOT_MEASURED)
+    // No affinity key => null hash (not a fabricated digest).
+    expect(record.cacheAffinityKeyHash).toBe(null)
+    expect(record.fallbackReason).toBe(null)
+    expect(record.blockerRefs).toContain('cost_not_measured')
+    expect(Option.isSome(decodeKhalaTelemetryRecord(record))).toBe(true)
+  })
+
+  test('single-token completions do not fabricate an inter-token latency', () => {
+    const record = buildKhalaTelemetryRecord({
+      completionTokens: 1,
+      executedVerdict: 'not_executed',
+      generationWallClockMs: 500,
+      provider: 'fireworks',
+      requestClass: 'interactive_stream',
+      requestId: 'chatcmpl-one',
+      requestedModel: 'openagents/khala-mini',
+      route: 'open',
+      servedModel: 'm',
+      settlementState: 'not_applicable',
+      verificationClass: 'none',
+    })
+    // ITL is undefined for a single token (no inter-token gap) => sentinel.
+    expect(record.interTokenLatencyMs).toBe(NOT_MEASURED)
+    // perceived TPS is still defined: 1 token / 0.5s = 2.
+    expect(record.perceivedTps).toBe(2)
+  })
+
+  test('margin bucket coarse-grains the raw margin (never exposes the amount)', () => {
+    expect(deriveMarginBucket(NOT_MEASURED, 100)).toBe('not_measured')
+    expect(deriveMarginBucket(100, NOT_MEASURED)).toBe('not_measured')
+    expect(deriveMarginBucket(120, 100)).toBe('negative')
+    expect(deriveMarginBucket(100, 100)).toBe('zero')
+    expect(deriveMarginBucket(95, 100)).toBe('thin') // 5/100 = 0.05
+    expect(deriveMarginBucket(80, 100)).toBe('standard') // 20/100 = 0.2
+    expect(deriveMarginBucket(40, 100)).toBe('rich') // 60/100 = 0.6
+  })
+
+  test('cache-affinity hashing is stable and one-way', () => {
+    const a = hashCacheAffinityKey('account:1|session:s')
+    const b = hashCacheAffinityKey('account:1|session:s')
+    const c = hashCacheAffinityKey('account:2|session:s')
+    expect(a).toBe(b) // stable: same key => same digest
+    expect(a).not.toBe(c) // different key => different digest
+    expect(a).not.toContain('account') // the raw key never appears in the digest
+  })
+
+  test('the immediate block is the SMALL projection of the full record + a detailRef', () => {
+    const record = buildKhalaTelemetryRecord({
+      completionTokens: 5,
+      executedVerdict: 'passed',
+      generationWallClockMs: 400,
+      provider: 'fireworks',
+      promptTokens: 10,
+      requestClass: 'interactive_stream',
+      requestId: 'chatcmpl-block',
+      requestedModel: 'openagents/khala-code',
+      route: 'coding',
+      scalarReward: 1,
+      servedModel: 'm',
+      settlementState: 'pending',
+      totalTokens: 15,
+      totalWallClockMs: 600,
+      ttftMs: 120,
+      verificationClass: 'test_passed',
+    })
+    const detailRef = '/api/public/inference/receipts/receipt.inference.charge.x'
+    const block = khalaTelemetryBlockFromRecord(record, detailRef)
+
+    expect(block).toEqual({
+      completionTokens: 5,
+      detailRef,
+      executedVerdict: 'passed',
+      promptTokens: 10,
+      requestClass: 'interactive_stream',
+      scalarReward: 1,
+      schemaVersion: 'openagents.khala.telemetry.v1',
+      totalTokens: 15,
+      totalWallClockMs: 600,
+      ttftMs: 120,
+      verificationClass: 'test_passed',
+    })
+    // The block holds ONLY the small summary — the time split / queue wait /
+    // economics live in the dereferenceable record, NOT the block.
+    expect(block).not.toHaveProperty('providerTimeMs')
+    expect(block).not.toHaveProperty('costBasisMsat')
+    expect(block).not.toHaveProperty('cacheAffinityKeyHash')
+    expect(Option.isSome(decodeKhalaTelemetryBlock(block))).toBe(true)
+
+    // buildKhalaTelemetryBlock is the convenience direct path; it agrees.
+    const direct = buildKhalaTelemetryBlock(
+      {
+        completionTokens: 5,
+        executedVerdict: 'passed',
+        generationWallClockMs: 400,
+        provider: 'fireworks',
+        promptTokens: 10,
+        requestClass: 'interactive_stream',
+        requestId: 'chatcmpl-block',
+        requestedModel: 'openagents/khala-code',
+        route: 'coding',
+        scalarReward: 1,
+        servedModel: 'm',
+        settlementState: 'pending',
+        totalTokens: 15,
+        totalWallClockMs: 600,
+        ttftMs: 120,
+        verificationClass: 'test_passed',
+      },
+      detailRef,
+    )
+    expect(direct).toEqual(block)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-telemetry.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-telemetry.ts
@@ -1,0 +1,516 @@
+// Khala request-telemetry scorecard (book P0-1 / Open Questions #1-2).
+//
+// This is the CANONICAL, public-safe Khala request-lifecycle telemetry schema —
+// the "measure the request lifecycle before optimizing it" lesson from
+// `docs/inference/inference-engineering-book/` turned into a typed contract.
+//
+// It is the ONE place the gateway records what the book's P0-1 field list asks
+// for: token counts (incl. cached input where the provider exposes them), the
+// latency split (TTFT, inter-token latency / perceived TPS, total wall-clock,
+// and the provider/gateway/verifier/settlement time split where available),
+// queue/batch wait, the request CLASS, the route/provider/served-model/region/
+// cache-affinity HASH/fallback identity, the verification class + executed
+// verdict + scalar reward, and the cost/price/margin/settlement disclosure.
+//
+// HONESTY CONTRACT (the load-bearing invariant of this whole module):
+//   - Every numeric field is EITHER a real measured number OR the explicit
+//     sentinel `not_measured`. A field is NEVER fabricated or defaulted to a
+//     plausible-looking number. "We did not measure this" is a first-class,
+//     typed value (`NOT_MEASURED`), not a missing key and not a fake `0`.
+//   - This mirrors the M8 metric table discipline
+//     (`docs/inference/2026-06-23-khala-head-to-head-m8-status.md`): a `0` means
+//     "measured zero", `not_measured` means "no measurement exists". They are
+//     different products.
+//
+// PUBLIC-SAFE PROJECTION (INVARIANTS: no secret/private leakage):
+//   - The cache-affinity key is recorded ONLY as a hash (`cacheAffinityKeyHash`),
+//     never the raw account/session/codebase key. The hash is FNV-1a (a stable,
+//     non-cryptographic public digest) so two requests that share a cache lane
+//     can be correlated WITHOUT exposing the raw key.
+//   - No prompt, completion, chain-of-thought, account ref, session ref, amount,
+//     destination, or payment material is ever a telemetry field. Only token
+//     COUNTS, durations, neutral classifiers, public refs, and the margin BUCKET
+//     (not the raw margin) appear.
+//
+// BLOCK-vs-RECEIPT SPLIT (Open Question #2, RESOLVED here):
+//   - The IMMEDIATE `openagents` response block carries only the SMALL hot-path
+//     telemetry summary (`KhalaTelemetryBlock`): the few fields a caller wants at
+//     a glance — request class, tokens, TTFT, total wall-clock, the verification
+//     class + verdict + reward, and a pointer (`detailRef`) to the full record.
+//   - The FULL lifecycle record (`KhalaTelemetryRecord`) — every P0-1 field,
+//     including the time split, queue/batch wait, region, cache-affinity hash,
+//     fallback reason, cost basis / margin bucket / settlement state / blocker
+//     refs — is dereferenceable from the public inference receipt detail. The
+//     immediate block stays small; the receipt carries the depth.
+//
+// It is PURE + framework-agnostic: no Worker, no D1, no Effect runtime. The
+// gateway builds a record from what it can measure NOW; everything it cannot is
+// `not_measured`. The schema is the same whether a field is measured today or
+// becomes measurable later, so adding a measurement never reshapes the contract.
+import { Schema as S } from 'effect'
+
+// ---------------------------------------------------------------------------
+// The honest sentinel.
+// ---------------------------------------------------------------------------
+
+// The single explicit "no measurement exists" value. Typed, never a fake number.
+export const NOT_MEASURED = 'not_measured' as const
+export type NotMeasured = typeof NOT_MEASURED
+
+// A scalar that is EITHER a finite non-negative number OR the honest sentinel.
+// Used for every measurable quantity so an unmeasured field is structurally
+// distinct from a measured zero.
+const MeasuredNumber = S.Union([S.Number, S.Literal(NOT_MEASURED)])
+export type MeasuredNumber = typeof MeasuredNumber.Type
+
+// A measured count of tokens (>= 0) or the sentinel.
+const MeasuredTokens = MeasuredNumber
+// A measured duration in milliseconds (>= 0) or the sentinel.
+const MeasuredMs = MeasuredNumber
+
+// Narrow a possibly-undefined/negative number to a measured value or the
+// sentinel. `undefined`, `null`, NaN, and negative inputs all collapse to the
+// honest sentinel rather than a fabricated number.
+export const measured = (value: number | undefined | null): MeasuredNumber => {
+  if (value === undefined || value === null) {
+    return NOT_MEASURED
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return NOT_MEASURED
+  }
+  return value
+}
+
+export const isMeasured = (value: MeasuredNumber): value is number =>
+  value !== NOT_MEASURED
+
+// ---------------------------------------------------------------------------
+// Classifiers (book P0-1: request class, verification class, settlement state).
+// ---------------------------------------------------------------------------
+
+// The request CLASS — the shape of the request, which determines its latency
+// budget and which metrics matter (book Ch.1/Ch.7 + the 524 postmortem). An
+// interactive stream optimizes TTFT/ITL; an async job optimizes total wall-clock
+// + queue wait; a verifier run optimizes accepted-outcome; a batch job optimizes
+// throughput/cost.
+export const KhalaRequestClass = S.Literals([
+  'interactive_stream',
+  'async_job',
+  'verifier_run',
+  'batch',
+])
+export type KhalaRequestClass = typeof KhalaRequestClass.Type
+
+// The verification class, mirrored from the Khala/Tassadar verification-class
+// registry (khala.md §6) so telemetry never invents a parallel vocabulary.
+export const KhalaVerificationClass = S.Literals([
+  'none',
+  'seeded',
+  'test_passed',
+  'exact_trace_replay',
+  // Honest in-flight states from the executed-acceptance lane (EPIC #6017): an
+  // executable artifact whose headless run has not happened yet, or an executed
+  // run that did not fully pass.
+  'unverified',
+  'failed',
+])
+export type KhalaVerificationClass = typeof KhalaVerificationClass.Type
+
+// The executed verifier verdict — distinct from the CLASS. `not_executed` is the
+// honest default when no headless acceptance run produced a verdict (the hot
+// Worker path cannot launch a browser); `passed`/`failed` require an EXECUTED
+// run. This is the "a real failed beats a fake passed" discipline as a type.
+export const KhalaExecutedVerdict = S.Literals([
+  'not_executed',
+  'passed',
+  'failed',
+])
+export type KhalaExecutedVerdict = typeof KhalaExecutedVerdict.Type
+
+// Settlement state of the accepted outcome (khala.md §7 / RL-2). `not_applicable`
+// for an unverified or non-settling lane; `pending` once a verified outcome is
+// awaiting the async settlement callback; `settled` once sats moved.
+export const KhalaSettlementState = S.Literals([
+  'not_applicable',
+  'pending',
+  'settled',
+])
+export type KhalaSettlementState = typeof KhalaSettlementState.Type
+
+// Coarse margin BUCKET, never the raw margin (public-safe: the exact margin is
+// private pricing material). `not_measured` when the metering hook did not price
+// the request (e.g. a stream with no terminal usage frame).
+export const KhalaMarginBucket = S.Literals([
+  'not_measured',
+  'negative',
+  'zero',
+  'thin',
+  'standard',
+  'rich',
+])
+export type KhalaMarginBucket = typeof KhalaMarginBucket.Type
+
+// ---------------------------------------------------------------------------
+// The IMMEDIATE block (small — rides on the `openagents` response block).
+// ---------------------------------------------------------------------------
+
+// The small hot-path telemetry summary embedded directly in the `openagents`
+// response block. Resolves Open Question #2 on the SMALL side: just the
+// at-a-glance lifecycle facts + a pointer to the full record. Every field is a
+// measured value or the honest sentinel.
+export const KhalaTelemetryBlock = S.Struct({
+  schemaVersion: S.Literal('openagents.khala.telemetry.v1'),
+  // The request class — the single most important shape classifier.
+  requestClass: KhalaRequestClass,
+  // Token counts from the provider usage (receipt-first). `not_measured` when no
+  // usage frame was served.
+  promptTokens: MeasuredTokens,
+  completionTokens: MeasuredTokens,
+  totalTokens: MeasuredTokens,
+  // Time to first token (ms), measurable on the streaming path only.
+  ttftMs: MeasuredMs,
+  // Total wall-clock for the request (ms), gateway-edge measured.
+  totalWallClockMs: MeasuredMs,
+  // Verification class + executed verdict + scalar reward, reusing the existing
+  // Khala/Tassadar values (never a parallel grader).
+  verificationClass: KhalaVerificationClass,
+  executedVerdict: KhalaExecutedVerdict,
+  scalarReward: MeasuredNumber,
+  // The dereferenceable pointer to the full lifecycle record (Open Question #2:
+  // depth lives off the hot path). Null when no receipt was minted.
+  detailRef: S.NullOr(S.String),
+})
+export type KhalaTelemetryBlock = typeof KhalaTelemetryBlock.Type
+
+// ---------------------------------------------------------------------------
+// The FULL record (dereferenceable — every P0-1 field).
+// ---------------------------------------------------------------------------
+
+// The full request-lifecycle telemetry record. This is the canonical P0-1
+// scorecard. It is the dereferenceable depth behind the immediate block. Every
+// field is a measured value, the honest sentinel, or a neutral public-safe
+// classifier/ref — never a secret and never a fabricated number.
+export const KhalaTelemetryRecord = S.Struct({
+  schemaVersion: S.Literal('openagents.khala.telemetry.v1'),
+
+  // --- identity / routing (P0-1: route, provider, served model, region,
+  // cache-affinity key hash, fallback reason) ---
+  requestId: S.String,
+  requestedModel: S.String,
+  servedModel: S.String,
+  // The coordinator route lane (coding | cheap | long_context | default | ...).
+  route: S.String,
+  // The provider/adapter id that actually served (provider-capacity attribution).
+  provider: S.String,
+  // The serving region when the provider/lane exposes it; sentinel otherwise.
+  region: S.Union([S.String, S.Literal(NOT_MEASURED)]),
+  // Public-safe HASH of the cache-affinity key (account/session/codebase). NEVER
+  // the raw key. Null when no affinity key applied to this request.
+  cacheAffinityKeyHash: S.NullOr(S.String),
+  // Why a fallback lane served (e.g. "rate_limited", "service_overloaded"). Null
+  // when the primary lane served with no overflow.
+  fallbackReason: S.NullOr(S.String),
+  requestClass: KhalaRequestClass,
+
+  // --- tokens (P0-1: prompt / completion / total; cached input where exposed) ---
+  promptTokens: MeasuredTokens,
+  completionTokens: MeasuredTokens,
+  totalTokens: MeasuredTokens,
+  // Cached input tokens where the provider exposes them (e.g. Fireworks prompt
+  // cache). `not_measured` when the provider does not report a cached dimension.
+  cachedInputTokens: MeasuredTokens,
+
+  // --- latency (P0-1: TTFT, ITL / perceived TPS, total wall-clock) ---
+  ttftMs: MeasuredMs,
+  // Mean inter-token latency (ms/token) on the streaming path.
+  interTokenLatencyMs: MeasuredMs,
+  // Perceived tokens/second (completion tokens / generation wall-clock).
+  perceivedTps: MeasuredNumber,
+  totalWallClockMs: MeasuredMs,
+
+  // --- the time split (P0-1: provider / gateway / verifier / settlement time) ---
+  // Each is measured where available, else the honest sentinel. These need not
+  // sum to total wall-clock (overlap/gaps are normal); they are honest partials.
+  providerTimeMs: MeasuredMs,
+  gatewayOverheadMs: MeasuredMs,
+  verifierTimeMs: MeasuredMs,
+  settlementTimeMs: MeasuredMs,
+
+  // --- queue / batch wait (P0-1) ---
+  queueWaitMs: MeasuredMs,
+  batchWaitMs: MeasuredMs,
+
+  // --- verification (P0-1: class + executed verdict + scalar reward) ---
+  verificationClass: KhalaVerificationClass,
+  executedVerdict: KhalaExecutedVerdict,
+  scalarReward: MeasuredNumber,
+  // Public verifier receipt ref when an executed verdict exists; null otherwise.
+  verifierReceiptRef: S.NullOr(S.String),
+
+  // --- economics (P0-1: cost basis, price, margin bucket, settlement state,
+  // blocker refs) ---
+  // Cost basis + price in msat where the metering hook priced the request. Public
+  // disclosure of the unit economics inputs; sentinel when unpriced.
+  costBasisMsat: MeasuredNumber,
+  priceMsat: MeasuredNumber,
+  // Coarse margin bucket only — never the raw margin.
+  marginBucket: KhalaMarginBucket,
+  settlementState: KhalaSettlementState,
+  // Public settlement receipt refs once a verified outcome settled.
+  settlementReceiptRefs: S.Array(S.String),
+  // Honest blockers preventing a full/green measurement (e.g.
+  // "verifier_not_executed", "cost_not_measured"). Carries WHY a field is a
+  // sentinel so a reader does not have to guess.
+  blockerRefs: S.Array(S.String),
+})
+export type KhalaTelemetryRecord = typeof KhalaTelemetryRecord.Type
+
+// ---------------------------------------------------------------------------
+// Decoders (typed parse of an unknown projection back into the contract).
+// ---------------------------------------------------------------------------
+
+export const decodeKhalaTelemetryBlock = S.decodeUnknownOption(
+  KhalaTelemetryBlock,
+)
+export const decodeKhalaTelemetryRecord = S.decodeUnknownOption(
+  KhalaTelemetryRecord,
+)
+export const encodeKhalaTelemetryRecord = S.encodeSync(KhalaTelemetryRecord)
+export const encodeKhalaTelemetryBlock = S.encodeSync(KhalaTelemetryBlock)
+
+// ---------------------------------------------------------------------------
+// Public-safe cache-affinity hashing.
+// ---------------------------------------------------------------------------
+
+// FNV-1a 32-bit, rendered as a stable lowercase hex digest with a neutral
+// prefix. Non-cryptographic (it is a CORRELATION key, not a secret), but it is a
+// ONE-WAY projection: the raw account/session/codebase key never leaves the
+// gateway, only this digest. Two requests on the same cache lane share a digest.
+export const hashCacheAffinityKey = (rawKey: string): string => {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < rawKey.length; index += 1) {
+    hash ^= rawKey.charCodeAt(index)
+    // 32-bit FNV prime multiply via shifts (avoids BigInt; stays in uint32).
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return `cacheaff:fnv1a32:${hash.toString(16).padStart(8, '0')}`
+}
+
+// ---------------------------------------------------------------------------
+// Margin-bucket derivation (public-safe coarse-graining of the raw margin).
+// ---------------------------------------------------------------------------
+
+// Coarse-grain the raw (cost, price) msat into a public-safe bucket. The exact
+// margin is private pricing material; the bucket is the only thing telemetry
+// exposes. `not_measured` when either input is the sentinel.
+export const deriveMarginBucket = (
+  costBasisMsat: MeasuredNumber,
+  priceMsat: MeasuredNumber,
+): KhalaMarginBucket => {
+  if (!isMeasured(costBasisMsat) || !isMeasured(priceMsat)) {
+    return 'not_measured'
+  }
+  const margin = priceMsat - costBasisMsat
+  if (margin < 0) {
+    return 'negative'
+  }
+  if (margin === 0) {
+    return 'zero'
+  }
+  // Ratio of margin to price (the public-safe coarse signal, not the amount).
+  const ratio = priceMsat === 0 ? 0 : margin / priceMsat
+  if (ratio < 0.1) {
+    return 'thin'
+  }
+  if (ratio < 0.4) {
+    return 'standard'
+  }
+  return 'rich'
+}
+
+// ---------------------------------------------------------------------------
+// Builder — assemble a full record from what the gateway measured NOW.
+// ---------------------------------------------------------------------------
+
+// The measurable inputs the gateway can collect on the hot path TODAY. Anything
+// absent collapses to the honest sentinel via `measured(...)`; nothing is
+// fabricated.
+export type KhalaTelemetryInput = Readonly<{
+  requestId: string
+  requestedModel: string
+  servedModel: string
+  route: string
+  provider: string
+  requestClass: KhalaRequestClass
+
+  // Tokens (receipt-first from provider usage).
+  promptTokens?: number | undefined
+  completionTokens?: number | undefined
+  totalTokens?: number | undefined
+  cachedInputTokens?: number | undefined
+
+  // Latency (gateway-edge measured).
+  ttftMs?: number | undefined
+  totalWallClockMs?: number | undefined
+  // Generation wall-clock used to derive perceived TPS + mean ITL. When omitted
+  // these derived metrics are the sentinel (we do not guess them from total).
+  generationWallClockMs?: number | undefined
+
+  // Time split (each optional; sentinel when absent).
+  providerTimeMs?: number | undefined
+  gatewayOverheadMs?: number | undefined
+  verifierTimeMs?: number | undefined
+  settlementTimeMs?: number | undefined
+  queueWaitMs?: number | undefined
+  batchWaitMs?: number | undefined
+
+  // Routing identity.
+  region?: string | undefined
+  // The RAW cache-affinity key. It is hashed here and NEVER stored raw.
+  cacheAffinityKeyRaw?: string | undefined
+  fallbackReason?: string | undefined
+
+  // Verification.
+  verificationClass: KhalaVerificationClass
+  executedVerdict: KhalaExecutedVerdict
+  scalarReward?: number | undefined
+  verifierReceiptRef?: string | undefined
+
+  // Economics.
+  costBasisMsat?: number | undefined
+  priceMsat?: number | undefined
+  settlementState: KhalaSettlementState
+  settlementReceiptRefs?: ReadonlyArray<string> | undefined
+  blockerRefs?: ReadonlyArray<string> | undefined
+}>
+
+// Derive mean inter-token latency from completion tokens + generation
+// wall-clock. Sentinel unless BOTH are measured and there is >1 token (ITL is
+// undefined for a single token). Never fabricated.
+const deriveInterTokenLatencyMs = (
+  completionTokens: number | undefined,
+  generationWallClockMs: number | undefined,
+): MeasuredNumber => {
+  if (
+    completionTokens === undefined ||
+    generationWallClockMs === undefined ||
+    completionTokens <= 1 ||
+    !Number.isFinite(generationWallClockMs) ||
+    generationWallClockMs < 0
+  ) {
+    return NOT_MEASURED
+  }
+  // Inter-token gaps = (tokens - 1).
+  return generationWallClockMs / (completionTokens - 1)
+}
+
+// Derive perceived tokens/second from completion tokens + generation wall-clock.
+// Sentinel unless both are measured and wall-clock > 0.
+const derivePerceivedTps = (
+  completionTokens: number | undefined,
+  generationWallClockMs: number | undefined,
+): MeasuredNumber => {
+  if (
+    completionTokens === undefined ||
+    generationWallClockMs === undefined ||
+    !Number.isFinite(generationWallClockMs) ||
+    generationWallClockMs <= 0 ||
+    completionTokens < 0
+  ) {
+    return NOT_MEASURED
+  }
+  return completionTokens / (generationWallClockMs / 1000)
+}
+
+// Assemble the canonical full lifecycle record from measured inputs. PURE: same
+// inputs => same record. Unmeasured inputs become the honest sentinel; the raw
+// cache-affinity key is hashed; the margin is coarse-grained to a bucket.
+export const buildKhalaTelemetryRecord = (
+  input: KhalaTelemetryInput,
+): KhalaTelemetryRecord => {
+  const costBasisMsat = measured(input.costBasisMsat)
+  const priceMsat = measured(input.priceMsat)
+  return {
+    schemaVersion: 'openagents.khala.telemetry.v1',
+
+    requestId: input.requestId,
+    requestedModel: input.requestedModel,
+    servedModel: input.servedModel,
+    route: input.route,
+    provider: input.provider,
+    region:
+      input.region === undefined || input.region.trim() === ''
+        ? NOT_MEASURED
+        : input.region,
+    cacheAffinityKeyHash:
+      input.cacheAffinityKeyRaw === undefined ||
+      input.cacheAffinityKeyRaw.trim() === ''
+        ? null
+        : hashCacheAffinityKey(input.cacheAffinityKeyRaw),
+    fallbackReason: input.fallbackReason ?? null,
+    requestClass: input.requestClass,
+
+    promptTokens: measured(input.promptTokens),
+    completionTokens: measured(input.completionTokens),
+    totalTokens: measured(input.totalTokens),
+    cachedInputTokens: measured(input.cachedInputTokens),
+
+    ttftMs: measured(input.ttftMs),
+    interTokenLatencyMs: deriveInterTokenLatencyMs(
+      input.completionTokens,
+      input.generationWallClockMs,
+    ),
+    perceivedTps: derivePerceivedTps(
+      input.completionTokens,
+      input.generationWallClockMs,
+    ),
+    totalWallClockMs: measured(input.totalWallClockMs),
+
+    providerTimeMs: measured(input.providerTimeMs),
+    gatewayOverheadMs: measured(input.gatewayOverheadMs),
+    verifierTimeMs: measured(input.verifierTimeMs),
+    settlementTimeMs: measured(input.settlementTimeMs),
+
+    queueWaitMs: measured(input.queueWaitMs),
+    batchWaitMs: measured(input.batchWaitMs),
+
+    verificationClass: input.verificationClass,
+    executedVerdict: input.executedVerdict,
+    scalarReward: measured(input.scalarReward),
+    verifierReceiptRef: input.verifierReceiptRef ?? null,
+
+    costBasisMsat,
+    priceMsat,
+    marginBucket: deriveMarginBucket(costBasisMsat, priceMsat),
+    settlementState: input.settlementState,
+    settlementReceiptRefs: input.settlementReceiptRefs ?? [],
+    blockerRefs: input.blockerRefs ?? [],
+  }
+}
+
+// Project the small immediate block out of the full record (the SMALL side of
+// Open Question #2). `detailRef` points back to the dereferenceable full record.
+export const khalaTelemetryBlockFromRecord = (
+  record: KhalaTelemetryRecord,
+  detailRef: string | null,
+): KhalaTelemetryBlock => ({
+  schemaVersion: 'openagents.khala.telemetry.v1',
+  requestClass: record.requestClass,
+  promptTokens: record.promptTokens,
+  completionTokens: record.completionTokens,
+  totalTokens: record.totalTokens,
+  ttftMs: record.ttftMs,
+  totalWallClockMs: record.totalWallClockMs,
+  verificationClass: record.verificationClass,
+  executedVerdict: record.executedVerdict,
+  scalarReward: record.scalarReward,
+  detailRef,
+})
+
+// Convenience: build the immediate block directly from measured inputs +
+// detail ref (the common gateway path).
+export const buildKhalaTelemetryBlock = (
+  input: KhalaTelemetryInput,
+  detailRef: string | null,
+): KhalaTelemetryBlock =>
+  khalaTelemetryBlockFromRecord(buildKhalaTelemetryRecord(input), detailRef)

--- a/docs/inference/2026-06-23-khala-telemetry-scorecard-book-p0-1.md
+++ b/docs/inference/2026-06-23-khala-telemetry-scorecard-book-p0-1.md
@@ -1,0 +1,87 @@
+# Khala request-telemetry scorecard — closing book P0-1 / Open Questions #1–2
+
+*2026-06-23. This note ties the production Khala request-telemetry schema to the
+inference-engineering book's P0-1 ("make the Khala scorecard production-complete")
+and resolves Open Questions #1 (canonical schema) and #2 (block-vs-receipt split).*
+
+## What the book asked for (P0-1)
+
+The book's core lesson is **measure the request lifecycle before optimizing it**.
+P0-1 lists the fields the receipt/manifest must preserve: prompt/completion/total
+tokens; cached input tokens where the provider exposes them; TTFT; inter-token
+latency or perceived TPS; total wall-clock; the provider / gateway-overhead /
+verifier / settlement time split where available; queue and batch wait; request
+class (interactive stream | async job | verifier run | batch); route, provider,
+served model, region, cache-affinity key hash, and fallback reason; verification
+class + executed verdict + scalar reward; and cost basis, price, margin bucket,
+settlement state, and blocker refs.
+
+## What shipped
+
+A typed, public-safe Effect Schema —
+`apps/openagents.com/workers/api/src/inference/khala-telemetry.ts`
+(`openagents.khala.telemetry.v1`) — covering every P0-1 field, plus the gateway
+emission of what we can measure NOW into the `openagents` response block and the
+dereferenceable inference receipt.
+
+### Open Question #1 — the canonical schema
+
+`KhalaTelemetryRecord` is the canonical full lifecycle record; `KhalaTelemetryBlock`
+is the small immediate summary projected from it. Both are public-safe by
+construction: no prompt, completion, chain-of-thought, raw account/session key,
+amount, destination, or payment material — only token counts, durations, neutral
+classifiers, public refs, the cache-affinity key **hash** (one-way FNV-1a, never
+the raw key), and a coarse margin **bucket** (never the raw margin).
+
+### Open Question #2 — block-vs-receipt split (RESOLVED)
+
+- **Immediate `openagents` block (`telemetry`)** — small: request class,
+  prompt/completion/total tokens, TTFT, total wall-clock, verification class +
+  executed verdict + scalar reward, and a `detailRef` pointer.
+- **Dereferenceable receipt detail (`KhalaTelemetryRecord`)** — the depth: the
+  provider/gateway/verifier/settlement time split, inter-token latency / perceived
+  TPS, queue and batch wait, region, cache-affinity hash, fallback reason, cached
+  input tokens, cost basis / price / margin bucket / settlement state / blocker
+  refs. Reached via `/api/public/inference/receipts/<ref>`.
+
+The immediate block stays small; the receipt carries the depth.
+
+## Honest measured-vs-`not_measured` discipline
+
+Every numeric is either a real measured number or the explicit `not_measured`
+sentinel. A field is never fabricated and never a misleading `0`. `not_measured`
+("no measurement exists") and a measured `0` are different products — the same
+discipline as the M8 metric table
+(`2026-06-23-khala-head-to-head-m8-status.md`).
+
+Measured NOW: tokens (provider `usage`, receipt-first); total wall-clock (gateway
+edge); TTFT + inter-token latency + perceived TPS on the **true-streaming** path
+(first content delta and EOF are observable there); request class; route /
+provider / served model; verification class + executed verdict + scalar reward
+(reusing the existing `khala-code` verifier verdict — no parallel grader).
+
+Honestly `not_measured` today: cached input tokens unless the provider reports
+them; the provider/gateway/verifier/settlement time split (no per-stage timers
+yet); queue / batch wait (chat path); region / cache-affinity hash / fallback
+reason (session-affinity + region not wired on the gateway yet — each records a
+`blockerRef` so the reason for the sentinel is explicit); cost basis / price /
+margin bucket on the immediate hot path (the metering hook feeds the full record).
+
+## How it feeds M8 + the coordinator reward
+
+This closes the M8 "tokens / cost / verification telemetry are `not_measured`"
+gap by making the request lifecycle a typed, dereferenceable artifact. M8
+manifests can read measured tokens + latency + verdict instead of treating them
+as afterthoughts, and the learned coordinator's reward inputs (accepted outcome
+per sat and per second) read from a stable schema rather than ad-hoc fields.
+
+## References
+
+- Schema: `apps/openagents.com/workers/api/src/inference/khala-telemetry.ts`
+- Gateway emission: `apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts`
+  (the `openagents` block + `khalaReceiptForResult`)
+- Spec section: [`khala.md`](khala.md) → "Request-telemetry scorecard"
+- M8 status: [`2026-06-23-khala-head-to-head-m8-status.md`](2026-06-23-khala-head-to-head-m8-status.md)
+- Tests: `khala-telemetry.test.ts` (schema/builder) +
+  `chat-completions-routes.test.ts` ("telemetry scorecard" describe — measured
+  fields, honest sentinels, and receipt dereference)

--- a/docs/inference/khala.md
+++ b/docs/inference/khala.md
@@ -114,10 +114,78 @@ A normal OpenAI chat completion plus a **non-breaking `openagents` block**:
     "verification": "none|seeded|test_passed|exact_trace_replay",
     "cost_msat": 123,
     "price_msat": 170,
-    "settled": false
+    "settled": false,
+    "telemetry": {
+      "schemaVersion": "openagents.khala.telemetry.v1",
+      "requestClass": "interactive_stream",
+      "promptTokens": 400,
+      "completionTokens": 12,
+      "totalTokens": 412,
+      "ttftMs": 200,
+      "totalWallClockMs": 500,
+      "verificationClass": "test_passed",
+      "executedVerdict": "passed",
+      "scalarReward": 1,
+      "detailRef": "/api/public/inference/receipts/receipt.inference.charge.chatcmpl_..."
+    }
   }
 }
 ```
+
+### Request-telemetry scorecard (book P0-1 / Open Questions #1–2)
+
+The `openagents` block carries a non-breaking `telemetry` summary — the canonical,
+public-safe **Khala request-lifecycle telemetry** the inference-engineering book's
+P0-1 asks us to record *before* optimizing serving. The full typed schema is
+`apps/openagents.com/workers/api/src/inference/khala-telemetry.ts` (Effect Schema,
+`openagents.khala.telemetry.v1`); the book P0-1 cross-reference is
+[`2026-06-23-khala-telemetry-scorecard-book-p0-1.md`](2026-06-23-khala-telemetry-scorecard-book-p0-1.md).
+
+**Honest measured-vs-`not_measured` discipline.** Every numeric is either a real
+measured number or the explicit sentinel `not_measured`. A field is *never*
+fabricated and *never* a misleading `0`. `not_measured` ("no measurement exists")
+and a measured `0` are different products — the same discipline as the M8 metric
+table (`docs/inference/2026-06-23-khala-head-to-head-m8-status.md`).
+
+**Block-vs-receipt split (Open Question #2 — RESOLVED).** The *immediate* block
+stays small: request class, prompt/completion/total tokens, TTFT, total
+wall-clock, verification class + executed verdict + scalar reward, and a
+`detailRef` pointer. The *full* P0-1 record — the time split (provider / gateway
+overhead / verifier / settlement), inter-token latency / perceived TPS, queue and
+batch wait, region, the cache-affinity key **hash** (never the raw key), fallback
+reason, cached input tokens, cost basis / price / margin **bucket** (never the raw
+margin) / settlement state / blocker refs — is the dereferenceable depth behind
+`/api/public/inference/receipts/<ref>`. Depth lives off the hot path.
+
+**What is measured NOW vs honestly `not_measured`.**
+
+| field | now | source |
+| --- | --- | --- |
+| prompt / completion / total tokens | measured | provider `usage` (receipt-first) |
+| total wall-clock | measured | gateway edge (request accept → completion) |
+| TTFT | measured on the **true-streaming** path | first content delta − request accept |
+| inter-token latency / perceived TPS | measured on the **true-streaming** path | derived from completion tokens + generation wall-clock |
+| request class | measured | stream → `interactive_stream`, else `async_job` |
+| route / provider / served model | measured | coordinator + adapter |
+| verification class / executed verdict / scalar reward | measured | reuse of the existing `khala-code` verifier verdict (no parallel grader) |
+| cached input tokens | `not_measured` unless the provider reports it | provider `usage.cachedPromptTokens` where present |
+| provider / gateway / verifier / settlement time split | `not_measured` (no split instrumentation yet) | future per-stage timers |
+| queue / batch wait | `not_measured` (chat path) | future batch-job consumer |
+| region / cache-affinity hash / fallback reason | `not_measured` / `null` (not wired on the gateway yet — recorded as a `blockerRef`) | future session-affinity + region wiring |
+| cost basis / price / margin bucket | `not_measured` on this hot path (the immediate block omits raw economics) | metering hook (receipt-first) feeds the full record |
+
+**Privacy (INVARIANTS).** The cache-affinity key is recorded only as a one-way
+FNV-1a hash; no raw account/session/codebase key, prompt, completion,
+chain-of-thought, amount, destination, or payment material is ever a telemetry
+field — only token counts, durations, neutral classifiers, public refs, and the
+coarse margin bucket.
+
+**How it feeds M8 + the coordinator reward.** This closes the M8 "tokens / cost /
+verification telemetry are `not_measured`" gap by making the request lifecycle a
+typed, dereferenceable artifact: M8 manifests can read measured tokens + latency +
+verdict instead of treating them as afterthoughts, and the learned coordinator's
+reward inputs (accepted outcome per sat and per second) read from a stable schema
+rather than ad-hoc fields.
 
 ## 4. Request flow
 


### PR DESCRIPTION
Builds the canonical Khala request-telemetry scorecard — the #1 gap (P0-1) from the inference-engineering-book notes and the book's core "measure the request lifecycle before optimizing it" lesson. **Non-breaking**: additive `openagents`-block fields + public receipt detail only.

**Closes book P0-1 / Open Questions #1-2. DO NOT auto-merge — orchestrator reviews/merges + deploys.**

## The schema

New typed, public-safe Effect Schema `apps/openagents.com/workers/api/src/inference/khala-telemetry.ts` (`openagents.khala.telemetry.v1`):

- **`KhalaTelemetryRecord`** — the full P0-1 lifecycle: tokens (prompt/completion/total + cached input), TTFT, inter-token latency / perceived TPS, total wall-clock, the time split (provider / gateway overhead / verifier / settlement), queue + batch wait, request class, route / provider / served model / region / cache-affinity key **hash** / fallback reason, verification class + executed verdict + scalar reward, cost basis / price / margin **bucket** / settlement state / blocker refs.
- **`KhalaTelemetryBlock`** — the small immediate summary projected from the record.
- Honest sentinel `not_measured` (`measured()` narrows absent/invalid/negative → sentinel, never a fake number); one-way FNV-1a `hashCacheAffinityKey` (raw key never stored); coarse `deriveMarginBucket` (raw margin never exposed).

## Measured NOW vs honestly `not_measured`

| field | status |
| --- | --- |
| prompt / completion / total tokens | **measured** (provider `usage`, receipt-first) |
| total wall-clock | **measured** (gateway edge) |
| TTFT, inter-token latency, perceived TPS | **measured on the true-streaming path** (first delta + EOF observed); honest sentinel on buffered/non-stream (no first-token boundary) |
| request class | **measured** (stream → `interactive_stream`, else `async_job`) |
| route / provider / served model | **measured** |
| verification class / executed verdict / scalar reward | **measured** — reuses the existing `khala-code` verifier verdict (no parallel grader); hot path is honestly `not_executed` (no browser in the Worker) |
| cached input tokens | `not_measured` unless the provider reports it |
| provider/gateway/verifier/settlement time split | `not_measured` (no per-stage timers yet) |
| queue / batch wait | `not_measured` (chat path) |
| region / cache-affinity hash / fallback reason | `not_measured` / `null` — not wired on the gateway yet, each records a `blockerRef` |
| cost basis / price / margin bucket | `not_measured` on the immediate hot path (metering hook feeds the full record) |

Never fabricated, never a misleading `0` — same discipline as the M8 metric table.

## Block-vs-receipt split (Open Question #2 — RESOLVED)

- **Immediate `openagents` block** stays small: request class, tokens, TTFT, total wall-clock, verification class + executed verdict + scalar reward, `detailRef`.
- **Dereferenceable receipt detail** (`/api/public/inference/receipts/<ref>`) carries the depth: time split, ITL/TPS, queue/batch wait, region, cache-affinity hash, fallback reason, cached tokens, cost/margin/settlement, blockers.

## How it feeds M8 + the coordinator reward

Closes the M8 "tokens / cost / verification telemetry are `not_measured`" gap by making the request lifecycle a typed, dereferenceable artifact: M8 manifests read measured tokens + latency + verdict instead of afterthoughts, and the learned coordinator's reward inputs (accepted outcome per sat and per second) read from a stable schema.

## Sample emitted telemetry block

```json
"telemetry": {
  "schemaVersion": "openagents.khala.telemetry.v1",
  "requestClass": "interactive_stream",
  "promptTokens": 400,
  "completionTokens": 12,
  "totalTokens": 412,
  "ttftMs": 200,
  "totalWallClockMs": 500,
  "verificationClass": "failed",
  "executedVerdict": "not_executed",
  "scalarReward": 0,
  "detailRef": "/api/public/inference/receipts/receipt.inference.charge.chatcmpl-telemetry"
}
```

## Tests

- `khala-telemetry.test.ts` — schema/builder, measured-vs-sentinel discipline, single-token ITL guard, margin bucket, one-way hash, block-vs-record split (all decode against the schema).
- `chat-completions-routes.test.ts` "telemetry scorecard" describe — a fixture **streaming khala-code** request with a stepping clock asserts **real measured TTFT (200ms) + total wall-clock (500ms)**, honest `not_measured` for unmeasured fields (cached tokens absent, no time split on the block), no raw account/prompt leakage, and the `detailRef` **dereferences** through the public receipt route to a paid `openagents.inference.receipt.v1` projection.
- Full inference suite green via vitest (`652 passed`); `typecheck:api`, `check:effect-topology`, `check:public-projection-freshness` all green; route-coverage/OpenAPI tests green (no route changes).

### Pre-existing (out of scope, flagged honestly)

The worktree base (`faa210c017`) has diverged from the local `origin/main` ref, so `check:architecture` flags pre-existing budget items in `index.ts` / `acceptance-job-queue-store.ts` / `acceptance-runner/runner.ts` (DE-8/acceptance + concurrent index.ts lanes — **not touched by this PR**; `chat-completions-routes.ts` is within budget: `1 (budget 1)`). The same divergence makes some unrelated `*-quick-win` / agent-onboarding-sha / workroom tests red on the base **with or without** this change (verified by stashing this diff). None are inference/telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)