### PR TITLE
test(khala): lock verifier receipt invariant

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -27,6 +27,10 @@ import {
   BROKEN_EXTERNAL_ASSET_CROSSY_ROAD_HTML,
   GOOD_CROSSY_ROAD_HTML,
 } from './khala-code-verifier.fixtures'
+import {
+  KHALA_CODE_HEADLESS_COMMAND_REF,
+  KHALA_CODE_VERIFIER_WORKER_ID,
+} from './khala-code-verifier'
 import { type MeteringContext, type MeteringHook } from './metering-hook'
 import {
   FIREWORKS_ADAPTER_ID,
@@ -716,6 +720,7 @@ describe('POST /v1/chat/completions', () => {
         scalar_reward: number
         served_model: string
         verification: string
+        verification_command: string
         verification_receipt: string
         verified: boolean
         executed: boolean
@@ -736,13 +741,20 @@ describe('POST /v1/chat/completions', () => {
       scalar_reward: 0,
       served_model: KHALA_CODE_MODEL_ID,
       verification: 'unverified',
+      verification_command: KHALA_CODE_HEADLESS_COMMAND_REF,
       verified: false,
       worker: FIREWORKS_ADAPTER_ID,
-      workers: [FIREWORKS_ADAPTER_ID, 'khala-code-crossy-road-verifier'],
+      workers: [FIREWORKS_ADAPTER_ID, KHALA_CODE_VERIFIER_WORKER_ID],
     })
+    expect(body.openagents?.verified).not.toBe(true)
+    expect(body.openagents?.verification).not.toBe('test_passed')
+    expect(body.openagents?.verification_command).toBe(
+      KHALA_CODE_HEADLESS_COMMAND_REF,
+    )
     expect(body.openagents?.verification_receipt).toMatch(
       /^receipt\.inference\.khala_code\.verification\.chatcmpl-khala-code-pass\./u,
     )
+    expect(body.openagents?.workers).toContain(KHALA_CODE_VERIFIER_WORKER_ID)
     expect(body.openagents?.reward_handoff).toContain(
       'accepted_outcome.khala_code.crossy_road.',
     )

--- a/docs/inference/khala-buildout-roadmap.md
+++ b/docs/inference/khala-buildout-roadmap.md
@@ -224,9 +224,11 @@ settlement, Pylon payout, Verse rendering, or learned coordinator promotion.
   verifier verdict shape.
 - **#6010-D — Receipt bridge:** `POST /v1/chat/completions` now recognizes
   `openagents/khala-code`, routes it through the priced open/code lane, and
-  attaches `verification: test_passed|failed`, `verified`, rubric checks,
-  verifier receipt, charge receipt URL when metered, and worker provenance in
-  the `openagents` block.
+  attaches `verification: unverified|failed|test_passed`, `executed`, `verified`,
+  rubric checks, verifier receipt, verifier command ref, charge receipt URL when
+  metered, and worker provenance in the `openagents` block. A fresh hot-path
+  artifact that only passes the cheap pre-screen stays `unverified` until the
+  out-of-Worker acceptance runner posts an executed verdict callback.
 - **#6010-E — Reward handoff:** the verdict carries `scalar_reward` plus a
   public-safe `accepted_outcome.khala_code.crossy_road...` handoff ref for Psion
   and later accepted-outcome pricing.

--- a/docs/inference/khala.md
+++ b/docs/inference/khala.md
@@ -355,8 +355,10 @@ verification-class registry (`docs/sakana/tassadar-run-integration.md`):
 | Khala `verification` | Meaning | When |
 |---|---|---|
 | `none` | unverified single-model answer | cheap chat, `khala-mini` default |
+| `unverified` | runnable artifact produced, but the out-of-Worker acceptance suite has not executed yet | fresh `khala-code` hot-path response |
 | `seeded` | re-run under `seeded_replication` (fixed seed/temp) | stochastic LLM outcomes |
 | `test_passed` | a deterministic test / verification command passed | `khala-code` |
+| `failed` | cheap pre-screen failed, or an executed acceptance suite rejected the artifact | `khala-code` |
 | `exact_trace_replay` | independent device re-executed; digests matched | executor / kernel-parity work |
 
 Why independent verification, not self-grading: TMAX (App. D.6) showed an RL'd
@@ -369,6 +371,15 @@ at different prices.
 Receipts (the `openagents` block) carry the receipt id, route, workers,
 verification class, cost/price in msat, and settled state — enough for a stranger
 to re-check without exposing CoT.
+
+For `openagents/khala-code`, `verified: true` is reserved for an executed
+acceptance result: `verification: "test_passed"` plus a verifier receipt,
+verifier command ref, and verifier worker provenance. The hot Worker route may
+pre-screen and enqueue a runnable artifact, but a pre-screen alone remains
+`verification: "unverified"`, `executed: false`, and `verified: false` until the
+out-of-Worker runner posts the callback. The supported product path is acceptance
+contract injection; bare-prompt success remains residual, with arbitrary-task
+contract discovery tracked as #6010-F / Q4.
 
 **Quantization disclosure (book P1-7 / #6090).** A model served at a reduced
 precision (FP8 / MXFP8 / NVFP4 / INT4 / …) is **not the same product** as the


### PR DESCRIPTION
## Problem

#6087 is mostly complete, but the remaining closeout needs the Khala-code response contract to stay explicit: `verified: true` must not be available from the hot Worker pre-screen alone, and the residual bare-prompt path needs to be documented as outside the supported closeout path. The public docs still summarized the receipt bridge as `test_passed|failed`, which could be read as stronger than the current executed-callback boundary.

Public claim: https://openagents.com/forum/t/7c4decf6-eb5d-4dc0-b69c-4d36cf502c26#post-76b3b66d-90a9-4091-b27d-9ac026c9d2b3

## Changes

- Tightens the Khala-code route test so a pre-screen-passing artifact explicitly remains `verification: "unverified"`, `verified: false`, and not `test_passed`, while still carrying the verifier command ref, verifier receipt ref, and verifier worker provenance.
- Updates `docs/inference/khala.md` with the `unverified` and `failed` verification states plus the invariant that `verified: true` is reserved for an executed acceptance result.
- Updates the Khala buildout roadmap so #6010-D describes `unverified|failed|test_passed`, `executed`, verifier command refs, and the out-of-Worker callback boundary.

## Validation

- `bun install --frozen-lockfile` (restored missing local workspace links; lockfile unchanged)
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/chat-completions-routes.test.ts` (63 passed)
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`
- `git diff --cached --check`

## Value

This protects the M8/product-proof path from overclaiming a pre-screen as an executed verifier result. It keeps Khala evidence receipt-first, makes the reviewer boundary crisp, and closes the #6087 residual without widening runtime behavior.

## Not Changed

- No live verifier dispatch or callback implementation.
- No M8 evidence bundle.
- No telemetry scorecard persistence/projection.
- No settlement/live-money arming.
- No product-promise state flip.

Fixes #6087
