### PR TITLE
Khala: finish the streaming/async split — batch-job consumer + terminal receipts + queue/batch-wait telemetry (book P0-3, #6086)

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0223_inference_batch_jobs_wait_timing.sql
+++ b/apps/openagents.com/workers/api/migrations/0223_inference_batch_jobs_wait_timing.sql
@@ -1,0 +1,21 @@
+-- Book P0-3 (#6086): finish the streaming/async split.
+--
+-- The async batch-job lane (#6028 / EPIC #6017) persists a row at submit and the
+-- consumer drives it to a terminal state OFF the request path. To make
+-- long-running work AUDITABLE the closeout receipt must disclose the batch WAIT —
+-- how long the job sat between being enqueued and the consumer actually starting
+-- it (the P0-1 telemetry `batchWaitMs` field). The original `0217` table only
+-- tracked `created_at`/`updated_at`, which cannot distinguish "submitted" from
+-- "consumer picked it up". These two timestamps close that gap:
+--
+--   - enqueued_at: when the submit route handed the executable message to the
+--     queue producer (the start of the batch wait).
+--   - started_at:  when the consumer began processing the job (the end of the
+--     batch wait). batchWaitMs = started_at - enqueued_at.
+--
+-- Both are NULLABLE: a job submitted before this migration, or a token-only job
+-- that was never enqueued, has no enqueue/start time, so the receipt honestly
+-- reports `not_measured` for batchWaitMs rather than a fabricated number.
+
+ALTER TABLE inference_batch_jobs ADD COLUMN enqueued_at TEXT;
+ALTER TABLE inference_batch_jobs ADD COLUMN started_at TEXT;

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -8447,6 +8447,10 @@ const makeBatchJobConsumerDeps = (env: BatchJobConsumerEnv) => {
       registry: inferenceProviderRegistry,
     },
     meteringHook: makeLedgerMeteringHook({ db: openAgentsDatabase(env) }),
+    // Book P0-3 (#6086): the consumer stamps the start-of-processing time (the
+    // END of the batch wait) with this clock so the closeout receipt can disclose
+    // an honest `batchWaitMs`.
+    nowIso: currentIsoTimestamp,
     store: makeD1BatchJobStore(openAgentsDatabase(env), currentIsoTimestamp),
   }
 }

--- a/apps/openagents.com/workers/api/src/inference/batch-job-closeout-receipts.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-closeout-receipts.test.ts
@@ -2,8 +2,17 @@ import { expect, test } from 'vitest'
 
 import {
   type BatchJobCloseoutReceipt,
+  buildBatchJobTelemetryRecord,
+  computeBatchWaitMs,
   projectBatchJobCloseoutReceipt,
 } from './batch-job-closeout-receipts'
+
+const telemetryFor = (batchWaitMs?: number) =>
+  buildBatchJobTelemetryRecord({
+    jobId: 'batch_123',
+    servedModel: 'inference.batch_job',
+    ...(batchWaitMs === undefined ? {} : { batchWaitMs }),
+  })
 
 test('projects public batch job closeout receipt safely', () => {
   const receipt: BatchJobCloseoutReceipt = {
@@ -17,6 +26,7 @@ test('projects public batch job closeout receipt safely', () => {
     totalCostMsat: 50000,
     completedAtIso: '2026-06-20T12:00:00.000Z',
     resultsR2Key: 'batch_jobs/batch_123/results.jsonl',
+    openagents: telemetryFor(4200),
   }
 
   const projection = projectBatchJobCloseoutReceipt(
@@ -27,4 +37,51 @@ test('projects public batch job closeout receipt safely', () => {
   expect(projection.receipt).toEqual(receipt)
   expect(projection.authorityBoundary).toContain('Public proof only')
   expect(projection.staleness.composition).toBe('live_at_read')
+})
+
+// Book P0-3: the terminal batch telemetry record distinguishes the detached job
+// (`requestClass: batch`) and discloses the wait honestly.
+test('terminal batch telemetry record carries requestClass batch + measured queue/batch wait', () => {
+  const record = telemetryFor(4200)
+  expect(record.requestClass).toBe('batch')
+  // A batch job never blocks the edge request path → measured zero edge wait.
+  expect(record.queueWaitMs).toBe(0)
+  // The real time the job sat in the async queue.
+  expect(record.batchWaitMs).toBe(4200)
+  expect(record.verificationClass).toBe('none')
+  expect(record.executedVerdict).toBe('not_executed')
+  expect(record.settlementState).toBe('not_applicable')
+  // Token counts are not aggregated at the closeout summary (metered per item).
+  expect(record.promptTokens).toBe('not_measured')
+})
+
+test('an unmeasured batch wait records a blocker, not a fabricated number', () => {
+  const record = telemetryFor(undefined)
+  expect(record.requestClass).toBe('batch')
+  // Honest sentinel — never a fake 0 for the batch wait.
+  expect(record.batchWaitMs).toBe('not_measured')
+  // The edge queue wait is still a measured zero (a batch job never blocks it).
+  expect(record.queueWaitMs).toBe(0)
+  expect(record.blockerRefs).toContain('batch_wait_not_measured')
+})
+
+test('computeBatchWaitMs returns the enqueue->start delta, or undefined when unmeasurable', () => {
+  expect(
+    computeBatchWaitMs(
+      '2026-06-22T00:00:00.000Z',
+      '2026-06-22T00:00:03.500Z',
+    ),
+  ).toBe(3500)
+  // Missing either timestamp → not measurable (honest undefined → not_measured).
+  expect(computeBatchWaitMs(null, '2026-06-22T00:00:03.500Z')).toBeUndefined()
+  expect(computeBatchWaitMs('2026-06-22T00:00:00.000Z', null)).toBeUndefined()
+  // A negative delta (clock skew / malformed) is rejected, never a fake number.
+  expect(
+    computeBatchWaitMs(
+      '2026-06-22T00:00:05.000Z',
+      '2026-06-22T00:00:00.000Z',
+    ),
+  ).toBeUndefined()
+  // Unparseable timestamps → undefined.
+  expect(computeBatchWaitMs('not-a-date', 'also-bad')).toBeUndefined()
 })

--- a/apps/openagents.com/workers/api/src/inference/batch-job-closeout-receipts.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-closeout-receipts.ts
@@ -4,6 +4,30 @@ import {
   type PublicProjectionStalenessContract,
   liveAtReadStaleness,
 } from '../public-projection-staleness'
+import {
+  type KhalaTelemetryRecord,
+  KhalaTelemetryRecord as KhalaTelemetryRecordSchema,
+  buildKhalaTelemetryRecord,
+} from './khala-telemetry'
+
+// ---------------------------------------------------------------------------
+// Batch-job closeout receipt (Khala async lane, #6028 / EPIC #6017).
+//
+// Book P0-3 (#6086): this is the TERMINAL, dereferenceable receipt for a DETACHED
+// async inference job — the async-lane analogue of the terminal `openagents` block
+// the interactive stream attaches at stream close. A completed batch job is
+// auditable here: its item tally, its charge, AND a Khala telemetry block whose
+// `requestClass` is `batch` (distinguishing detached work from an interactive
+// stream) and whose `batchWaitMs` / `queueWaitMs` disclose how long the job sat
+// before the consumer ran it. Honest `not_measured` where a wait could not be
+// computed (e.g. a job submitted before batch-wait timing existed).
+//
+// PUBLIC-SAFE (INVARIANTS): no prompt, completion, account ref, amount,
+// destination, or payment material — only item COUNTS, public refs, the msat
+// total already disclosed by the charge receipt, durations, and neutral
+// classifiers. The telemetry block reuses the canonical, public-safe
+// `openagents.khala.telemetry.v1` schema (no parallel vocabulary).
+// ---------------------------------------------------------------------------
 
 export const BatchJobCloseoutReceiptSchema = S.Struct({
   schemaVersion: S.Literal('openagents.inference.batch_job.closeout.v1'),
@@ -16,11 +40,83 @@ export const BatchJobCloseoutReceiptSchema = S.Struct({
   totalCostMsat: S.Number,
   completedAtIso: S.String,
   resultsR2Key: S.String,
+  // Book P0-3: the TERMINAL `openagents` telemetry record for the detached job —
+  // the async-lane counterpart of the interactive stream's stream-close receipt.
+  // This receipt IS the dereferenceable artifact, so it carries the FULL canonical
+  // record (not just the at-a-glance block): `requestClass: batch`, the measured
+  // edge `queueWaitMs` (0), and the real `batchWaitMs` (or `not_measured`). Reuses
+  // the canonical `openagents.khala.telemetry.v1` schema (no parallel vocabulary).
+  openagents: KhalaTelemetryRecordSchema,
 })
 
 export type BatchJobCloseoutReceipt = S.Schema.Type<
   typeof BatchJobCloseoutReceiptSchema
 >
+
+// ---------------------------------------------------------------------------
+// Terminal telemetry block for a completed batch job.
+// ---------------------------------------------------------------------------
+
+// Compute the batch WAIT (ms) between when the job was enqueued and when the
+// consumer started processing it. `undefined` (→ honest `not_measured` in the
+// telemetry builder) unless BOTH timestamps exist and parse to finite, ordered
+// instants. Never fabricated.
+export const computeBatchWaitMs = (
+  enqueuedAtIso: string | null,
+  startedAtIso: string | null,
+): number | undefined => {
+  if (enqueuedAtIso === null || startedAtIso === null) {
+    return undefined
+  }
+  const enqueued = Date.parse(enqueuedAtIso)
+  const started = Date.parse(startedAtIso)
+  if (!Number.isFinite(enqueued) || !Number.isFinite(started)) {
+    return undefined
+  }
+  const delta = started - enqueued
+  return delta >= 0 ? delta : undefined
+}
+
+export type BatchJobTelemetryInput = Readonly<{
+  jobId: string
+  servedModel: string
+  // The batch wait (ms) from enqueue to consumer start; undefined → not_measured.
+  batchWaitMs?: number | undefined
+}>
+
+// Build the terminal `openagents` telemetry record for a completed batch job. The
+// request class is ALWAYS `batch` (the detached async lane), distinguishing it
+// from an interactive stream's `interactive_stream`. A batch job never blocks the
+// edge request path, so `queueWaitMs` is a measured `0`; `batchWaitMs` is the real
+// in-queue wait (or the honest `not_measured` sentinel + a `blockerRef`). Token
+// counts are `not_measured` at the closeout summary (the per-item provider usage
+// is metered per item, not re-aggregated here) and verification is `none` — a
+// batch job is a detached completion, not a verified accepted outcome.
+export const buildBatchJobTelemetryRecord = (
+  input: BatchJobTelemetryInput,
+): KhalaTelemetryRecord =>
+  buildKhalaTelemetryRecord({
+    executedVerdict: 'not_executed',
+    provider: 'inference.batch_job',
+    // A batch job never blocks the edge request path, so its EDGE queue wait is a
+    // measured zero. The meaningful wait is the time it sat in the async queue,
+    // recorded as `batchWaitMs`.
+    queueWaitMs: 0,
+    ...(input.batchWaitMs === undefined
+      ? {}
+      : { batchWaitMs: input.batchWaitMs }),
+    requestClass: 'batch',
+    requestId: input.jobId,
+    requestedModel: input.servedModel,
+    route: 'batch',
+    servedModel: input.servedModel,
+    settlementState: 'not_applicable',
+    verificationClass: 'none',
+    blockerRefs:
+      input.batchWaitMs === undefined
+        ? ['batch_wait_not_measured', 'batch_token_usage_per_item']
+        : ['batch_token_usage_per_item'],
+  })
 
 export const projectBatchJobCloseoutReceipt = (
   receipt: BatchJobCloseoutReceipt,

--- a/apps/openagents.com/workers/api/src/inference/batch-job-consumer.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-consumer.test.ts
@@ -37,6 +37,7 @@ const makeFakeStore = (
     status: BatchJobStatus
     processedItems?: number
     failedItems?: number
+    startedAt?: string
   }>
 } => {
   let record = initial
@@ -44,6 +45,7 @@ const makeFakeStore = (
     status: BatchJobStatus
     processedItems?: number
     failedItems?: number
+    startedAt?: string
   }> = []
   const store: BatchJobStore = {
     getBatchJob: () => Effect.succeed(record),
@@ -60,6 +62,10 @@ const makeFakeStore = (
             updates.resultsR2Key === undefined
               ? record.resultsR2Key
               : updates.resultsR2Key,
+          startedAt:
+            updates.startedAt === undefined
+              ? record.startedAt
+              : updates.startedAt,
         }
       }
       return Effect.void
@@ -79,10 +85,12 @@ const pendingJob = (
   chargeReceiptRef: 'receipt.inference.batch_job_charge.batch_test',
   createdAt: '2026-06-22T00:00:00.000Z',
   datasetSize: 2,
+  enqueuedAt: '2026-06-22T00:00:00.000Z',
   failedItems: 0,
   jobId: 'batch_test',
   processedItems: 0,
   resultsR2Key: null,
+  startedAt: null,
   status: 'pending',
   updatedAt: '2026-06-22T00:00:00.000Z',
   ...overrides,
@@ -211,6 +219,36 @@ describe('executeBatchJob', () => {
     expect(terminal?.processedItems).toBe(2)
     expect(terminal?.failedItems).toBe(0)
     expect(fake.reads()?.status).toBe('completed')
+  })
+
+  it('stamps the consumer-start time (END of the batch wait) from the injected clock', async () => {
+    // Book P0-3: the consumer marks `startedAt` at the `processing` transition so
+    // the closeout receipt can disclose `batchWaitMs = startedAt - enqueuedAt`.
+    const fake = makeFakeStore(pendingJob({ datasetSize: 1 }))
+    const gateway = makeFakeAdapter('fireworks', {
+      kind: 'ok',
+      usage: { completionTokens: 5, promptTokens: 5, totalTokens: 10 },
+    })
+
+    await run(
+      executeBatchJob(
+        {
+          dispatch: dispatchDepsFor(gateway.adapter),
+          nowIso: () => '2026-06-22T00:00:03.000Z',
+          store: fake.store,
+        },
+        makeQueueMessage('batch_test', 1),
+      ),
+    )
+
+    // The processing transition carries the start time; the row reflects it, so a
+    // later closeout read computes a real batch wait (3s after the 00:00:00
+    // enqueue) rather than `not_measured`.
+    const processing = fake
+      .statusWrites()
+      .find(write => write.status === 'processing')
+    expect(processing?.startedAt).toBe('2026-06-22T00:00:03.000Z')
+    expect(fake.reads()?.startedAt).toBe('2026-06-22T00:00:03.000Z')
   })
 
   it('counts a failed item but still completes the job (partial success)', async () => {

--- a/apps/openagents.com/workers/api/src/inference/batch-job-consumer.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-consumer.ts
@@ -29,6 +29,7 @@
 import { Effect, Schema as S } from 'effect'
 
 import { workerLogEntry } from '../observability'
+import { currentIsoTimestamp } from '../runtime-primitives'
 import {
   type DispatchDeps,
   dispatchWithOverflow,
@@ -73,6 +74,13 @@ export class BatchJobQueueMessage extends S.Class<BatchJobQueueMessage>(
   schemaVersion: S.Literal('openagents.inference.batch_job.v1'),
   jobId: S.String,
   items: S.Array(BatchJobExecutableItemSchema),
+  // Book P0-3 (#6086): when the producer enqueued this message (ISO 8601), so the
+  // consumer can compute the batch WAIT (`startedAt - enqueuedAt`) and make a
+  // detached job's time-in-queue auditable in its closeout receipt. Optional so a
+  // message published before this field existed still decodes; when absent the
+  // receipt honestly reports `not_measured` for `batchWaitMs` rather than a
+  // fabricated number.
+  enqueuedAtIso: S.optionalKey(S.String),
 }) {}
 
 // Result of running a batch job, surfaced to the queue handler for ack/retry
@@ -107,6 +115,12 @@ export type BatchJobConsumerDeps = Readonly<{
   meteringHook?: MeteringHook | undefined
   // Funding kind for the metering context (card | bitcoin). Defaults to card.
   fundingKind?: MeteringContext['fundingKind'] | undefined
+  // Book P0-3 (#6086): the clock the consumer stamps the start-of-processing time
+  // with (the END of the batch wait). Defaults to the canonical
+  // `currentIsoTimestamp` primitive in prod; tests inject a deterministic clock so
+  // `batchWaitMs` is exactly assertable. Injectable so the consumer stays a pure
+  // function of its seams.
+  nowIso?: (() => string) | undefined
 }>
 
 const toInferenceRequest = (
@@ -132,6 +146,7 @@ export const executeBatchJob = (
   Effect.gen(function* () {
     const meteringHook = deps.meteringHook ?? stubMeteringHook
     const fundingKind = deps.fundingKind ?? 'card'
+    const nowIso = deps.nowIso ?? currentIsoTimestamp
     const receiptRef = batchJobCloseoutReceiptRef(message.jobId)
 
     const job = yield* deps.store.getBatchJob(message.jobId)
@@ -170,7 +185,11 @@ export const executeBatchJob = (
       }
     }
 
-    yield* deps.store.updateBatchJobStatus(message.jobId, 'processing', {})
+    // Stamp the start-of-processing time as the END of the batch wait (book
+    // P0-3). `batchWaitMs` (in the closeout receipt) = startedAt - enqueuedAt.
+    yield* deps.store.updateBatchJobStatus(message.jobId, 'processing', {
+      startedAt: nowIso(),
+    })
 
     let processedItems = 0
     let failedItems = 0

--- a/apps/openagents.com/workers/api/src/inference/batch-job-flow.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-flow.test.ts
@@ -55,6 +55,8 @@ type BatchRow = {
   results_r2_key: string | null
   created_at: string
   updated_at: string
+  enqueued_at: string | null
+  started_at: string | null
 }
 
 const makeStatefulDb = (): D1Database => {
@@ -96,16 +98,20 @@ const makeStatefulDb = (): D1Database => {
             resultsR2Key,
             createdAt,
             updatedAt,
+            enqueuedAt,
+            startedAt,
           ] = bindings
           rows.set(String(jobId), {
             account_ref: String(accountRef),
             charge_receipt_ref: String(chargeReceiptRef),
             created_at: String(createdAt),
             dataset_size: Number(datasetSize),
+            enqueued_at: enqueuedAt === null ? null : String(enqueuedAt),
             failed_items: Number(failedItems),
             job_id: String(jobId),
             processed_items: Number(processedItems),
             results_r2_key: resultsR2Key === null ? null : String(resultsR2Key),
+            started_at: startedAt === null ? null : String(startedAt),
             status: String(status),
             updated_at: String(updatedAt),
           })
@@ -134,6 +140,10 @@ const makeStatefulDb = (): D1Database => {
             }
             if (sql.includes('results_r2_key = ?')) {
               next.results_r2_key = String(bindings[cursor])
+              cursor += 1
+            }
+            if (sql.includes('started_at = ?')) {
+              next.started_at = String(bindings[cursor])
               cursor += 1
             }
             rows.set(jobId, next)
@@ -268,6 +278,9 @@ describe('async batch-job flow (submit -> queue -> consumer -> receipt)', () => 
     expect(captured[0]?.jobId).toBe(jobId)
     expect(captured[0]?.items).toHaveLength(1)
     expect(captured[0]?.items[0]?.model).toBe('gemini-3.5-flash')
+    // Book P0-3: the message carries the enqueue instant (START of the batch wait)
+    // so the consumer can compute the wait.
+    expect(captured[0]?.enqueuedAtIso).toBe('2026-06-22T00:00:00.000Z')
 
     // The receipt is NOT yet dereferenceable: the job is still pending.
     const earlyReceipt = await run(
@@ -290,6 +303,10 @@ describe('async batch-job flow (submit -> queue -> consumer -> receipt)', () => 
         {
           dispatch: dispatchDeps(fakeGatewayAdapter('fireworks')),
           meteringHook: metering.hook,
+          // Book P0-3: the consumer stamps the start-of-processing time (END of
+          // the batch wait) with this clock; with the 00:00:00 enqueue the receipt
+          // discloses a real batchWaitMs of 120000 (2 min in queue).
+          nowIso: () => '2026-06-22T00:02:00.000Z',
           store: makeD1BatchJobStore(db, () => '2026-06-22T00:02:00.000Z'),
         },
         message,
@@ -320,6 +337,13 @@ describe('async batch-job flow (submit -> queue -> consumer -> receipt)', () => 
         successfulItems: number
         failedItems: number
         totalCostMsat: number
+        openagents: {
+          requestClass: string
+          queueWaitMs: number | string
+          batchWaitMs: number | string
+          verificationClass: string
+          settlementState: string
+        }
       }
     }
     expect(receiptBody.receipt.jobId).toBe(jobId)
@@ -327,6 +351,18 @@ describe('async batch-job flow (submit -> queue -> consumer -> receipt)', () => 
     expect(receiptBody.receipt.successfulItems).toBe(1)
     expect(receiptBody.receipt.failedItems).toBe(0)
     expect(receiptBody.receipt.totalCostMsat).toBe(50_000)
+
+    // Book P0-3: the TERMINAL `openagents` telemetry record makes the detached job
+    // auditable — distinguishable from an interactive stream (`requestClass:
+    // batch`), with a measured zero edge queue wait and the REAL in-queue
+    // batch wait (00:00:00 enqueue -> 00:02:00 consumer start = 120000ms).
+    expect(receiptBody.receipt.openagents.requestClass).toBe('batch')
+    expect(receiptBody.receipt.openagents.queueWaitMs).toBe(0)
+    expect(receiptBody.receipt.openagents.batchWaitMs).toBe(120_000)
+    expect(receiptBody.receipt.openagents.verificationClass).toBe('none')
+    expect(receiptBody.receipt.openagents.settlementState).toBe(
+      'not_applicable',
+    )
   })
 
   it('re-delivering the same enqueued message is idempotent (no re-run, no re-charge)', async () => {

--- a/apps/openagents.com/workers/api/src/inference/batch-job-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-routes.test.ts
@@ -156,6 +156,9 @@ describe('handleBatchJobReceiptRead', () => {
                 results_r2_key: 'batch_123/results.jsonl',
                 created_at: '2026-06-20T12:00:00.000Z',
                 updated_at: '2026-06-20T12:05:00.000Z',
+                // Book P0-3: enqueue -> consumer-start timing for the batch wait.
+                enqueued_at: '2026-06-20T12:00:00.000Z',
+                started_at: '2026-06-20T12:00:30.000Z',
               }
             }
             if (sql.includes('pay_ins')) {
@@ -226,6 +229,61 @@ describe('handleBatchJobReceiptRead', () => {
     expect(body.receipt.failedItems).toBe(1)
     expect(body.receipt.totalCostMsat).toBe(50000)
     expect(body.staleness.composition).toBe('live_at_read')
+
+    // Book P0-3: the route attaches the TERMINAL `openagents` telemetry record so
+    // the detached job is auditable — distinguishable from an interactive stream
+    // (`requestClass: batch`), with a measured zero edge wait and the real
+    // in-queue batch wait (12:00:00 enqueue -> 12:00:30 start = 30000ms).
+    expect(body.receipt.openagents.requestClass).toBe('batch')
+    expect(body.receipt.openagents.queueWaitMs).toBe(0)
+    expect(body.receipt.openagents.batchWaitMs).toBe(30000)
+  })
+
+  it('reports batchWaitMs not_measured when timing is unavailable (no fabrication)', async () => {
+    // A completed job with no enqueue/start timing (e.g. submitted before the
+    // timing columns existed) must honestly report not_measured, never a fake 0.
+    const db = {
+      prepare: (sql: string) => ({
+        bind: () => ({
+          first: async () => {
+            if (sql.includes('inference_batch_jobs')) {
+              return {
+                job_id: 'batch_123',
+                account_ref: 'agent:123',
+                status: 'completed',
+                charge_receipt_ref:
+                  'receipt.inference.batch_job_charge.batch_123',
+                dataset_size: 100,
+                processed_items: 99,
+                failed_items: 1,
+                results_r2_key: 'batch_123/results.jsonl',
+                created_at: '2026-06-20T12:00:00.000Z',
+                updated_at: '2026-06-20T12:05:00.000Z',
+                enqueued_at: null,
+                started_at: null,
+              }
+            }
+            if (sql.includes('pay_ins')) {
+              return { cost_msat: 50000 }
+            }
+            return null
+          },
+        }),
+      }),
+    } as unknown as D1Database
+    const response = await run(
+      handleBatchJobReceiptRead(
+        makeReadRequest('receipt.inference.batch_job.closeout.batch_123'),
+        baseDeps({ db }),
+      ),
+    )
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as any
+    expect(body.receipt.openagents.requestClass).toBe('batch')
+    expect(body.receipt.openagents.batchWaitMs).toBe('not_measured')
+    expect(body.receipt.openagents.blockerRefs).toContain(
+      'batch_wait_not_measured',
+    )
   })
 })
 
@@ -248,6 +306,8 @@ describe('handleBatchJobStatusRead', () => {
                 results_r2_key: 'batch_123/results.jsonl',
                 created_at: '2026-06-20T12:00:00.000Z',
                 updated_at: '2026-06-20T12:05:00.000Z',
+                enqueued_at: '2026-06-20T12:00:00.000Z',
+                started_at: '2026-06-20T12:00:45.000Z',
               }
             }
             return null
@@ -313,5 +373,11 @@ describe('handleBatchJobStatusRead', () => {
     expect(body.datasetSize).toBe(100)
     expect(body.processedItems).toBe(99)
     expect(body.failedItems).toBe(1)
+    // Book P0-3: the status poll exposes the batch wait so long-running detached
+    // work is auditable without waiting for the closeout receipt (12:00:00
+    // enqueue -> 12:00:45 start = 45000ms).
+    expect(body.enqueuedAt).toBe('2026-06-20T12:00:00.000Z')
+    expect(body.startedAt).toBe('2026-06-20T12:00:45.000Z')
+    expect(body.batchWaitMs).toBe(45000)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/batch-job-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-routes.ts
@@ -8,7 +8,11 @@ import {
 } from './batch-job-consumer'
 import { settleBatchJobCharge } from './batch-job-metering'
 import { makeD1BatchJobStore } from './batch-job-store'
-import { projectBatchJobCloseoutReceipt } from './batch-job-closeout-receipts'
+import {
+  buildBatchJobTelemetryRecord,
+  computeBatchWaitMs,
+  projectBatchJobCloseoutReceipt,
+} from './batch-job-closeout-receipts'
 // public-projection-staleness
 import { estimateRequestCost } from './cost-estimate'
 
@@ -165,25 +169,12 @@ export const handleBatchJobsSubmit = (
       )
     }
 
-    const store = makeD1BatchJobStore(deps.db, deps.nowIso)
-    yield* store.insertBatchJob({
-      jobId,
-      accountRef: session.accountRef,
-      status: 'pending',
-      chargeReceiptRef: settle.receiptRef,
-      datasetSize: payload.dataset.length,
-      processedItems: 0,
-      failedItems: 0,
-      resultsR2Key: null,
-      createdAt: deps.nowIso(),
-    })
-
-    // Hand the job to the async consumer OFF the request path. Only rows that
-    // carry `messages` are executable; token-only rows are skipped (they priced
-    // the charge but have no prompt to run). When no producer is wired, or when
-    // no row is executable, nothing is enqueued — the job is still accepted and
-    // persisted (pending), preserving the pre-producer behaviour. The job id is
-    // the idempotency unit, so a re-enqueue is a safe no-op in the consumer.
+    // Book P0-3: the enqueue instant is the START of the batch wait. Computed
+    // ONCE here so the persisted row AND the queue message agree on the same
+    // timestamp; the consumer stamps the END (`startedAt`) when it begins, and
+    // the closeout receipt discloses `batchWaitMs = startedAt - enqueuedAt`. A
+    // token-only job (never enqueued for execution) keeps `enqueuedAt` null, so
+    // its receipt honestly reports `batchWaitMs: not_measured`.
     const executableItems: ReadonlyArray<BatchJobExecutableItem> =
       payload.dataset.flatMap(item =>
         item.messages === undefined
@@ -198,13 +189,40 @@ export const handleBatchJobsSubmit = (
               },
             ],
       )
+    const willEnqueue =
+      deps.enqueueBatchJob !== undefined && executableItems.length > 0
+    const enqueuedAtIso = willEnqueue ? deps.nowIso() : null
 
-    if (deps.enqueueBatchJob !== undefined && executableItems.length > 0) {
+    const store = makeD1BatchJobStore(deps.db, deps.nowIso)
+    yield* store.insertBatchJob({
+      jobId,
+      accountRef: session.accountRef,
+      status: 'pending',
+      chargeReceiptRef: settle.receiptRef,
+      datasetSize: payload.dataset.length,
+      processedItems: 0,
+      failedItems: 0,
+      resultsR2Key: null,
+      createdAt: deps.nowIso(),
+      enqueuedAt: enqueuedAtIso,
+      startedAt: null,
+    })
+
+    // Hand the job to the async consumer OFF the request path. Only rows that
+    // carry `messages` are executable; token-only rows are skipped (they priced
+    // the charge but have no prompt to run). When no producer is wired, or when
+    // no row is executable, nothing is enqueued — the job is still accepted and
+    // persisted (pending), preserving the pre-producer behaviour. The job id is
+    // the idempotency unit, so a re-enqueue is a safe no-op in the consumer. The
+    // message carries the same `enqueuedAtIso` stamped on the row so the consumer
+    // can compute the batch wait (book P0-3).
+    if (willEnqueue && deps.enqueueBatchJob !== undefined) {
       yield* deps.enqueueBatchJob(
         new BatchJobQueueMessage({
           schemaVersion: 'openagents.inference.batch_job.v1',
           jobId,
           items: executableItems,
+          ...(enqueuedAtIso === null ? {} : { enqueuedAtIso }),
         }),
       )
     }
@@ -269,6 +287,17 @@ export const handleBatchJobReceiptRead = (
 
     const costMsat = costMsatRaw ? costMsatRaw.cost_msat : 0
 
+    // Book P0-3: the TERMINAL `openagents` telemetry record for the detached job.
+    // `batchWaitMs` is the real enqueue→consumer-start wait (or `not_measured`
+    // when timing is unavailable); `requestClass` is `batch`, distinguishing this
+    // detached job from an interactive stream.
+    const batchWaitMs = computeBatchWaitMs(job.enqueuedAt, job.startedAt)
+    const openagents = buildBatchJobTelemetryRecord({
+      jobId: job.jobId,
+      servedModel: 'inference.batch_job',
+      ...(batchWaitMs === undefined ? {} : { batchWaitMs }),
+    })
+
     const receipt = {
       schemaVersion: 'openagents.inference.batch_job.closeout.v1' as const,
       receiptRef,
@@ -280,6 +309,7 @@ export const handleBatchJobReceiptRead = (
       totalCostMsat: costMsat,
       completedAtIso: job.updatedAt,
       resultsR2Key: job.resultsR2Key || '',
+      openagents,
     }
 
     return noStoreJsonResponse(
@@ -323,6 +353,10 @@ export const handleBatchJobStatusRead = (
       return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
     }
 
+    // Book P0-3: expose job state AND the batch wait so long-running detached work
+    // is auditable from the status poll, not only the closeout receipt. The wait
+    // is `null` (honest "not measured yet") until the consumer has started.
+    const batchWaitMs = computeBatchWaitMs(job.enqueuedAt, job.startedAt)
     return noStoreJsonResponse({
       jobId: job.jobId,
       status: job.status,
@@ -332,5 +366,8 @@ export const handleBatchJobStatusRead = (
       resultsR2Key: job.resultsR2Key,
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
+      enqueuedAt: job.enqueuedAt,
+      startedAt: job.startedAt,
+      batchWaitMs: batchWaitMs ?? null,
     })
   })

--- a/apps/openagents.com/workers/api/src/inference/batch-job-store.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-store.ts
@@ -13,6 +13,16 @@ export type BatchJobRecord = Readonly<{
   resultsR2Key: string | null
   createdAt: string
   updatedAt: string
+  // Book P0-3 (#6086): batch-wait timing for an auditable detached job.
+  // `enqueuedAt` is when the submit route handed the executable message to the
+  // queue producer (the START of the batch wait); `startedAt` is when the
+  // consumer began processing it (the END of the batch wait). Both are NULL for
+  // a job that was never enqueued (token-only) or submitted before migration
+  // `0223`, so the closeout receipt honestly reports `not_measured` for
+  // `batchWaitMs` rather than a fabricated number. `batchWaitMs = startedAt -
+  // enqueuedAt`.
+  enqueuedAt: string | null
+  startedAt: string | null
 }>
 
 export type BatchJobStore = Readonly<{
@@ -20,7 +30,12 @@ export type BatchJobStore = Readonly<{
   updateBatchJobStatus: (
     jobId: string,
     status: BatchJobStatus,
-    updates: Partial<Pick<BatchJobRecord, 'processedItems' | 'failedItems' | 'resultsR2Key'>>
+    updates: Partial<
+      Pick<BatchJobRecord, 'processedItems' | 'failedItems' | 'resultsR2Key'>
+    > &
+      // `startedAt` is only ever WRITTEN as a real timestamp (never reset to
+      // null), so narrow it to a non-null string here.
+      Readonly<{ startedAt?: string }>,
   ) => Effect.Effect<void>
   getBatchJob: (jobId: string) => Effect.Effect<BatchJobRecord | null>
 }>
@@ -31,9 +46,10 @@ export const makeD1BatchJobStore = (db: D1Database, nowIso: () => string): Batch
       db
         .prepare(
           `INSERT INTO inference_batch_jobs (
-             job_id, account_ref, status, charge_receipt_ref, dataset_size, 
-             processed_items, failed_items, results_r2_key, created_at, updated_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             job_id, account_ref, status, charge_receipt_ref, dataset_size,
+             processed_items, failed_items, results_r2_key, created_at, updated_at,
+             enqueued_at, started_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .bind(
           job.jobId,
@@ -45,7 +61,9 @@ export const makeD1BatchJobStore = (db: D1Database, nowIso: () => string): Batch
           job.failedItems,
           job.resultsR2Key,
           job.createdAt,
-          nowIso()
+          nowIso(),
+          job.enqueuedAt,
+          job.startedAt
         )
         .run()
     ).pipe(Effect.asVoid, Effect.orDie),
@@ -67,6 +85,12 @@ export const makeD1BatchJobStore = (db: D1Database, nowIso: () => string): Batch
         query += ', results_r2_key = ?'
         bindings.push(updates.resultsR2Key)
       }
+      // Book P0-3: stamp the consumer-start time (closes the batch wait). Only
+      // written once, when the consumer transitions the job to `processing`.
+      if (updates.startedAt !== undefined) {
+        query += ', started_at = ?'
+        bindings.push(updates.startedAt)
+      }
 
       query += ' WHERE job_id = ?'
       bindings.push(jobId)
@@ -78,8 +102,9 @@ export const makeD1BatchJobStore = (db: D1Database, nowIso: () => string): Batch
     Effect.tryPromise(() =>
       db
         .prepare(
-          `SELECT job_id, account_ref, status, charge_receipt_ref, dataset_size, 
-             processed_items, failed_items, results_r2_key, created_at, updated_at
+          `SELECT job_id, account_ref, status, charge_receipt_ref, dataset_size,
+             processed_items, failed_items, results_r2_key, created_at, updated_at,
+             enqueued_at, started_at
            FROM inference_batch_jobs WHERE job_id = ? LIMIT 1`
         )
         .bind(jobId)
@@ -98,6 +123,8 @@ export const makeD1BatchJobStore = (db: D1Database, nowIso: () => string): Batch
           resultsR2Key: row.results_r2_key ? String(row.results_r2_key) : null,
           createdAt: String(row.created_at),
           updatedAt: String(row.updated_at),
+          enqueuedAt: row.enqueued_at ? String(row.enqueued_at) : null,
+          startedAt: row.started_at ? String(row.started_at) : null,
         }
       }),
       Effect.orDie

--- a/docs/inference/inference-engineering-book/IMPLEMENTATION_LOG.md
+++ b/docs/inference/inference-engineering-book/IMPLEMENTATION_LOG.md
@@ -93,3 +93,77 @@ Conventions:
   `not_measured` (P0-1 follow-on, unchanged here).
 - **Status:** PR open against `main` (#6084); orchestrator reviews / merges /
   deploys / smokes. NOT deployed by this entry.
+
+---
+
+## P0-3 — Finish the streaming/async split — DONE (PR open, #6086)
+
+- **Notes ref:** `khala-investigation-notes.md` §P0 item 3 ("Finish The
+  Streaming/Async Split"); book Ch.7 (Production — streaming vs async / client
+  code); the local 524 postmortem
+  `docs/inference/2026-06-22-long-running-inference-response-strategies.md`.
+- **Already partial before this entry (NOT re-done):** the durable-stream EPIC
+  #6056 (single-client reconnect-resumable SSE proxy) merged; the
+  `openagents-inference-batch-jobs` queue exists in `wrangler.jsonc`; the submit
+  route + `inference_batch_jobs` D1 table (migration `0217`) + the public receipt
+  route + the `executeBatchJob` Queue consumer + the Worker `queue` handler
+  routing batch-job messages to it (all flag-gated by
+  `INFERENCE_BATCH_JOBS_ENABLED`) were already wired; and the **interactive
+  stream already attaches the terminal `openagents` receipt at stream close**
+  (`buildTerminalFrame` in `chat-completions-routes.ts`) with
+  `requestClass: interactive_stream`. So deliverable 2 (terminal receipt at
+  stream close) and the interactive-vs-async request-class distinction on the
+  chat path were already in place.
+- **What this entry FINISHED (the remaining gaps):**
+  1. **Batch closeout receipt is now an auditable terminal receipt.** The
+     dereferenceable batch closeout receipt
+     (`/api/public/inference/batch-job-receipts/<ref>`) now carries the canonical
+     `openagents.khala.telemetry.v1` **record** as its `openagents` block — the
+     async-lane counterpart of the interactive stream's stream-close receipt —
+     with `requestClass: batch` (distinguishing detached work from an interactive
+     stream), a measured `queueWaitMs: 0` (a batch job never blocks the edge), and
+     the real `batchWaitMs`. (`batch-job-closeout-receipts.ts`
+     `buildBatchJobTelemetryRecord` + `batch-job-routes.ts`.)
+  2. **Batch/queue wait is now measured.** Migration `0223` adds
+     `enqueued_at`/`started_at` to `inference_batch_jobs`; the submit route stamps
+     `enqueued_at` and the queue message carries `enqueuedAtIso` (the START of the
+     batch wait), the consumer stamps `started_at` from an injected clock (the
+     END), and `computeBatchWaitMs` derives `batchWaitMs = started_at -
+     enqueued_at`. Honest `not_measured` + a `batch_wait_not_measured` `blockerRef`
+     when timing is unavailable (a pre-`0223` job, a token-only job that was never
+     enqueued). Surfaced on the closeout receipt AND `GET
+     /v1/inference/batches/:jobId` (job state + wait, auditable from the poll).
+  3. **Durable-connection scope documented + confirmed (deliverable 4).** The
+     chat gateway uses a DO only for the #6056 single-client reconnect proxy (not
+     multi-subscriber); DO + hibernatable-WebSocket multi-subscriber transport is
+     reserved for the live Verse world (`apps/openagents-world`). Plain
+     request/response inference spins up no DO/WebSocket. Documented in
+     `docs/inference/khala.md` §4 "Streaming / async split".
+- **Where:** `apps/openagents.com/workers/api/migrations/0223_inference_batch_jobs_wait_timing.sql`,
+  `src/inference/batch-job-store.ts` (timing columns), `batch-job-consumer.ts`
+  (`enqueuedAtIso` on the message, `nowIso` clock, `started_at` stamp),
+  `batch-job-closeout-receipts.ts` (terminal telemetry record + `computeBatchWaitMs`),
+  `batch-job-routes.ts` (submit stamps enqueue time; receipt + status read populate
+  the telemetry/wait), minimal `index.ts` consumer-deps clock wiring. Docs:
+  `docs/inference/khala.md` (§3 telemetry table + §4 streaming/async split).
+- **Verification bar (green):** the inference test suites (703 tests),
+  `typecheck`, `check:architecture`, `check:effect-topology`,
+  `check:public-projection-freshness`, and the exact-route manifest test
+  (`worker-exact-routes.test.ts` — no route changes, the three batch routes were
+  already registered). New tests: a detached job enqueues → consumer runs it →
+  the closeout receipt dereferences with `requestClass: batch` + `queueWaitMs: 0`
+  + a real `batchWaitMs` (end-to-end `batch-job-flow.test.ts`); the consumer
+  stamps `started_at` from the injected clock; `computeBatchWaitMs` derives the
+  delta or rejects unmeasurable/negative inputs; an unmeasured wait records a
+  `batch_wait_not_measured` blocker rather than a fake `0`; the status poll exposes
+  the wait.
+- **Honest scope — still `not_measured` / inert:** the async consumer stays
+  flag-gated off (`INFERENCE_BATCH_JOBS_ENABLED`) until the orchestrator arms it;
+  the batch closeout telemetry record leaves per-item token counts `not_measured`
+  at the closeout summary (they are metered per item, not re-aggregated) with a
+  `batch_token_usage_per_item` blocker; the interactive-stream `queueWaitMs` stays
+  `not_measured` (no edge queue instrumentation); region + the
+  provider/gateway/verifier/settlement time split stay `not_measured` (P0-1
+  follow-on, unchanged here).
+- **Status:** PR open against `main` (#6086); orchestrator reviews / merges /
+  deploys / smokes. NOT deployed by this entry.

--- a/docs/inference/khala.md
+++ b/docs/inference/khala.md
@@ -165,13 +165,13 @@ margin) / settlement state / blocker refs — is the dereferenceable depth behin
 | total wall-clock | measured | gateway edge (request accept → completion) |
 | TTFT | measured on the **true-streaming** path | first content delta − request accept |
 | inter-token latency / perceived TPS | measured on the **true-streaming** path | derived from completion tokens + generation wall-clock |
-| request class | measured | stream → `interactive_stream`, else `async_job` |
+| request class | measured | stream → `interactive_stream`; detached batch job → `batch`; else `async_job` (book P0-3, #6086) |
 | route / provider / served model | measured | coordinator + adapter |
 | verification class / executed verdict / scalar reward | measured | reuse of the existing `khala-code` verifier verdict (no parallel grader) |
 | cached input tokens | measured when the provider reports a cached dimension (book P0-2, #6084); else `not_measured` | provider `usage.cachedPromptTokens` (Fireworks `prompt_tokens_details.cached_tokens`, Anthropic `cache_read_input_tokens`, Gemini `cachedContentTokenCount`) → block + record `cachedInputTokens` |
 | unaccounted tokens (`total − (prompt + completion)`) | measured when all three counts are measured (book P0-2, #6084) | reconciliation in the record builder; surfaces the real billed reasoning/thinking/tool-use dimension behind the live total-vs-sum gap |
 | provider / gateway / verifier / settlement time split | `not_measured` (no split instrumentation yet) | future per-stage timers |
-| queue / batch wait | `not_measured` (chat path) | future batch-job consumer |
+| queue / batch wait | chat path: `not_measured`. **Async batch lane (book P0-3, #6086): measured** — `queueWaitMs` = `0` (a batch job never blocks the edge), `batchWaitMs` = the real enqueue→consumer-start wait (or `not_measured` when timing is unavailable) | batch-job consumer stamps `enqueued_at`/`started_at`; surfaced on the closeout receipt + `GET /v1/inference/batches/:jobId` |
 | cache-affinity hash | measured for Khala requests with an account/session/codebase key (book P0-2, #6084); else `null` with a `cache_affinity_key_not_resolved` `blockerRef` | one-way `hashCacheAffinityKey(account/session/codebase)` |
 | region / fallback reason | `not_measured` / `null` (not wired on the gateway yet) | future region wiring |
 | cost basis / price / margin bucket | `not_measured` on this hot path (the immediate block omits raw economics) | metering hook (receipt-first) feeds the full record |
@@ -266,6 +266,58 @@ Components, mapped to existing seams: gateway route (#5476) · auth+balance
 **provider adapters/registry** (#5479/#5480/#5481 + Pylon + Tassadar) · verifier
 (verification-class registry) · **meter = `MeteringHook`** (#5477) · receipt +
 settlement (revenue-loop spine, EPIC #5457).
+
+### Streaming / async split (book P0-3 / #6086)
+
+Long synchronous inference through the Cloudflare edge is the wrong shape: the
+edge gives up on an origin that produces no bytes for ~100s and returns a `524`
+(the local 524 postmortem,
+[`2026-06-22-long-running-inference-response-strategies.md`](2026-06-22-long-running-inference-response-strategies.md),
+independently rediscovered the book's Ch.7 production lesson). The request lane is
+therefore chosen by the request *shape*, and the chosen lane is recorded as the
+telemetry `requestClass`:
+
+| Request shape | Transport | `requestClass` | Wait telemetry |
+|---|---|---|---|
+| **Interactive** (a human/agent waits on it) | **Streaming SSE** — `stream:true`, true pass-through (#6035); first byte ~1s, every chunk resets the edge idle-timer so a 3-min generation never 524s | `interactive_stream` | `queueWaitMs` ~`not_measured`/0 (no edge queue); no batch wait |
+| **Detached / minutes-long / agentic** | **Async batch job** — submit → `202 {jobId, receiptRef}` → a **Queue consumer** runs it OFF the request path → a dereferenceable **batch closeout receipt** | `batch` | `queueWaitMs` = measured `0` (never blocks the edge); `batchWaitMs` = real enqueue→consumer-start wait (or `not_measured`) |
+| **Live multi-subscriber UI** (cockpit, Verse projection) | **Durable Object + hibernatable WebSocket** | (world transport, not the chat gateway) | — |
+
+**Terminal receipt at the end of BOTH lanes.** The interactive stream attaches
+the terminal `openagents` disclosure block (built by the same
+`khalaReceiptForResult`) as the final `chat.completion.chunk` at stream close
+(EOF), settling metering receipt-first from the terminal usage frame. The async
+lane attaches the canonical `openagents.khala.telemetry.v1` *record* to the batch
+closeout receipt at `/api/public/inference/batch-job-receipts/<ref>`, with
+`requestClass: batch` and the batch/queue wait. Both classes are distinguishable,
+and both end with an auditable receipt.
+
+**Async lane internals (Khala, #6028 / EPIC #6017).** Submit
+(`handleBatchJobsSubmit`) prices + charges up front, persists a `pending`
+`inference_batch_jobs` row stamped with `enqueued_at` (the START of the batch
+wait), and hands the executable items to the queue producer. The Queue consumer
+(`executeBatchJob`, dispatched from the Worker `queue` handler when
+`INFERENCE_BATCH_JOBS_ENABLED` is armed) loads the row, stamps `started_at` (the
+END of the batch wait), runs each item against the **same provider-adapter
+registry** the interactive route uses, meters each through the **same
+`MeteringHook`** (per-item idempotency key → no double-charge on redelivery), and
+drives the row to `completed`/`failed`. Job state and the batch wait are queryable
+at `GET /v1/inference/batches/:jobId`; the closeout receipt becomes
+dereferenceable once the job is `completed`. Idempotent on the job id: a
+redelivered queue message is a safe no-op.
+
+**Durable-connection scope (deliverable 4).** The chat gateway uses Durable
+Objects in exactly one bounded place: the durable-stream proxy (#6056 /
+`durable-inference-proxy.ts`) tees a single client's paid token stream into a
+per-`requestId` offset log so a *reconnect* can replay the suffix — it is a
+single-subscriber resumability aid, not multi-subscriber fan-out, and metering
+still fires exactly once on the real upstream EOF (replays are free). DO +
+hibernatable-WebSocket **multi-subscriber** transport is reserved for the live
+Verse world (`apps/openagents-world` Region DO + `packages/world-client`), where a
+live "watch the energy flow" projection genuinely needs many subscribers on one
+long-lived generation. Plain request/response inference does **not** spin up a DO
+or WebSocket — that would be over-applying the heaviest transport to the lightest
+shape.
 
 ## 5. The coordinator (the missing middle)
 


### PR DESCRIPTION
Finishes book **P0-3** — the streaming/async split — so detached/minutes-long inference is auditable and structurally distinguishable from interactive streams, instead of timing out at the Cloudflare edge (the local `524` postmortem). Builds on the merged durable-stream EPIC #6056 and the existing batch-job queue + consumer (#6028 / EPIC #6017); **does not fork** either.

## Already partial (NOT re-done here)
- durable-stream EPIC #6056 (single-client reconnect-resumable SSE proxy) — **merged**.
- `openagents-inference-batch-jobs` queue in `wrangler.jsonc`; submit route + `inference_batch_jobs` table (migration `0217`) + public receipt route + `executeBatchJob` Queue consumer + the Worker `queue` handler routing batch messages to it (flag-gated by `INFERENCE_BATCH_JOBS_ENABLED`) — **already wired**.
- the **interactive stream already attaches the terminal `openagents` receipt at stream close** (`buildTerminalFrame`, `requestClass: interactive_stream`), settling metering receipt-first from the terminal usage frame.

## Finished now (the remaining gaps)

**1. Batch-job consumer → dereferenceable terminal batch receipt.** The closeout receipt at `/api/public/inference/batch-job-receipts/<ref>` now carries the canonical `openagents.khala.telemetry.v1` **record** as its `openagents` block — the async-lane counterpart of the interactive stream-close receipt — with `requestClass: batch`. Job state (queued/running/done/failed) + wait are queryable at `GET /v1/inference/batches/:jobId`.

**2. Terminal receipt at both lane ends.** Interactive: terminal `openagents` block at stream close (pre-existing). Detached: the terminal telemetry record on the batch closeout receipt. Both classes distinguishable; both end with an auditable receipt.

**3. Queue/batch wait in telemetry/receipts.** Migration `0223` adds `enqueued_at`/`started_at`. Submit stamps `enqueued_at` and the queue message carries `enqueuedAtIso` (START); the consumer stamps `started_at` from an injected clock (END); `computeBatchWaitMs` derives `batchWaitMs`. `queueWaitMs` = measured `0` for a batch job (never blocks the edge); `requestClass=batch`. Honest `not_measured` + a `batch_wait_not_measured` blocker where unavailable.

**4. Durable connection scope (confirmed + documented).** DO/WebSocket multi-subscriber transport is reserved for the live Verse world (`apps/openagents-world`). The chat gateway uses a DO only for the #6056 single-client reconnect proxy (single-subscriber resumability, metering still once on real EOF). Plain request/response inference spins up no DO/WebSocket. Documented in `docs/inference/khala.md` §4.

## Honest scope (still not_measured / inert)
- Consumer stays flag-gated off (`INFERENCE_BATCH_JOBS_ENABLED`) until armed by the orchestrator.
- Batch closeout leaves per-item token counts `not_measured` at the summary (metered per item, not re-aggregated) with a `batch_token_usage_per_item` blocker.
- Interactive-stream `queueWaitMs`, region, and the provider/gateway/verifier/settlement time split stay `not_measured` (P0-1 follow-on, unchanged).

## Tests / verification (green)
- 705 inference tests, `typecheck`, `check:architecture`, `check:effect-topology`, `check:public-projection-freshness`, exact-route manifest (`worker-exact-routes.test.ts` — no route changes; the three batch routes were already registered).
- New: end-to-end enqueue → consumer runs → closeout receipt dereferences with `requestClass: batch` + `queueWaitMs: 0` + a real `batchWaitMs`; consumer start-time stamp from the injected clock; `computeBatchWaitMs` delta / rejects unmeasurable+negative; an unmeasured wait records a blocker (no fake `0`); the status poll exposes the wait.

## Scope / invariants
Scoped to `apps/openagents.com/workers/api/src/inference/` + migration `0223` + minimal `index.ts` consumer-deps clock + the two docs. No proof/claim-upgrade, settlement money path, Psionic, pylon, or autopilot-desktop changes. Public-safe receipts honored (no prompt/account/amount/payment material).

Closes #6086. **DO NOT auto-merge — orchestrator reviews/merges/deploys/smokes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)