### PR TITLE
Khala provider/engine benchmark harness: typed matrix + fixture runner + dereferenceable report (book P1-5, #6088)

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/benchmark/fixtures.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/fixtures.ts
@@ -1,0 +1,120 @@
+// A concrete, public-safe SAMPLE matrix config (book P1-5 / #6088).
+//
+// This is the "first run produces a dereferenceable report comparing at least
+// Fireworks vs Vertex on chat + khala-code workloads" deliverable from the
+// issue's done-when, expressed as a typed config the fixture runner can execute
+// deterministically. It is the MINIMUM DECISION SUITE shape (notes Q5): the two
+// real managed lanes (Fireworks, Vertex-Anthropic) plus the two named future
+// lanes (Pylon whole-small, Psionic shard-WAN, labeled not-yet-available), over
+// the chat / khala-code / verifier / long-context workloads.
+//
+// The sequence shapes here are SYNTHETIC and labeled as such — they are
+// plausible placeholders, NOT sampled from real Khala traffic. Until real
+// traffic shapes replace them (and an owner arms a real sweep), every number this
+// produces is illustrative. That honesty is encoded in `provenance: 'synthetic'`,
+// which makes the report flag every group `syntheticOnly` and `decisionGrade:
+// false`.
+import type {
+  BenchmarkMatrixConfig,
+  SamplingSettings,
+  SequenceShape,
+} from './matrix'
+
+// Synthetic sequence shapes spanning the dimensions the book cares about: a
+// short interactive chat turn, a code-generation request with a large reusable
+// system prefix (exercises the prompt cache), and a long-context codebase
+// question (large input, modest output). All marked synthetic.
+const SHORT_CHAT_SHAPE: SequenceShape = {
+  id: 'short-chat',
+  inputTokens: 350,
+  outputTokens: 220,
+  cacheablePrefixTokens: 180,
+  concurrency: 1,
+  provenance: 'synthetic',
+}
+
+const CODE_ARTIFACT_SHAPE: SequenceShape = {
+  id: 'code-artifact-large-prefix',
+  inputTokens: 2400,
+  outputTokens: 1800,
+  // A large stable system/tool/acceptance prefix is reusable across requests.
+  cacheablePrefixTokens: 1600,
+  concurrency: 4,
+  provenance: 'synthetic',
+}
+
+const LONG_CONTEXT_SHAPE: SequenceShape = {
+  id: 'long-codebase-32k',
+  inputTokens: 32000,
+  outputTokens: 600,
+  cacheablePrefixTokens: 28000,
+  concurrency: 2,
+  provenance: 'synthetic',
+}
+
+const DEFAULT_SAMPLING: SamplingSettings = {
+  temperature: 0.2,
+  reasoningEffort: 'off',
+}
+
+const REASONING_SAMPLING: SamplingSettings = {
+  temperature: 0.7,
+  reasoningEffort: 'medium',
+}
+
+// The sample/minimum-decision-suite config. Fireworks vs Vertex-Anthropic on
+// the four workloads, plus the two future lanes for shape completeness, over the
+// three synthetic shapes, both transports, both sampling settings, 5 samples per
+// cell (book §4.5.2: enough traffic to read percentiles, not be swayed by one
+// outlier).
+export const SAMPLE_DECISION_SUITE_CONFIG: BenchmarkMatrixConfig = {
+  id: 'khala-decision-suite-v1',
+  description:
+    'Minimum Khala lane decision suite: Fireworks vs Vertex-Anthropic on chat / ' +
+    'khala-code / verifier / long-context, with Pylon whole-small and Psionic ' +
+    'shard-WAN named as not-yet-available future lanes. Synthetic shapes — ' +
+    'illustrative until real traffic + an owner-armed sweep replace them.',
+  targets: [
+    { lane: 'fireworks', engine: 'provider-native' },
+    { lane: 'vertex-anthropic', engine: 'provider-native' },
+    { lane: 'pylon-whole-small', engine: 'vllm' },
+    { lane: 'psionic-shard-wan', engine: 'sglang' },
+  ],
+  workloads: [
+    'chat',
+    'khala-code-artifact-gen',
+    'verifier-run',
+    'long-context-codebase-question',
+  ],
+  shapes: [SHORT_CHAT_SHAPE, CODE_ARTIFACT_SHAPE, LONG_CONTEXT_SHAPE],
+  transports: ['streaming', 'batch'],
+  sampling: [DEFAULT_SAMPLING, REASONING_SAMPLING],
+  samplesPerCell: 5,
+}
+
+// A tiny config used by tests for exact, hand-checkable expansion + aggregation.
+// One real lane, one future lane, one workload, one shape, one transport, one
+// sampling, 4 samples — so the expected cell count and per-group math are trivial
+// to assert by hand.
+export const TINY_TEST_CONFIG: BenchmarkMatrixConfig = {
+  id: 'tiny-test-v1',
+  description: 'Tiny deterministic config for harness tests.',
+  targets: [
+    { lane: 'fireworks', engine: 'provider-native' },
+    { lane: 'pylon-whole-small', engine: 'vllm' },
+  ],
+  workloads: ['khala-code-artifact-gen'],
+  shapes: [
+    {
+      id: 'tiny-shape',
+      inputTokens: 1000,
+      outputTokens: 100,
+      cacheablePrefixTokens: 500,
+      concurrency: 1,
+      provenance: 'synthetic',
+    },
+  ],
+  transports: ['streaming'],
+  sampling: [{ temperature: 0, reasoningEffort: 'off' }],
+  samplesPerCell: 4,
+}

--- a/apps/openagents.com/workers/api/src/inference/benchmark/index.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/index.ts
@@ -1,0 +1,13 @@
+// Khala provider/engine benchmark harness barrel (book P1-5 / #6088).
+//
+// The typed benchmark matrix, the pluggable lane seam (deterministic fixture lane
+// + owner-gated real lane), the runner that records canonical
+// `openagents.khala.telemetry.v1` records per sample, and the public-safe
+// dereferenceable report (latency percentiles, perceived TPS,
+// cost-per-accepted-outcome, verification rate). See the sibling modules for the
+// honesty/public-safety discipline.
+export * from './matrix'
+export * from './lane-seam'
+export * from './runner'
+export * from './report'
+export * from './fixtures'

--- a/apps/openagents.com/workers/api/src/inference/benchmark/lane-seam.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/lane-seam.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest'
+
+import { TINY_TEST_CONFIG } from './fixtures'
+import {
+  RealLaneNotArmedError,
+  makeFixtureLaneSeam,
+  makeRealLaneSeam,
+} from './lane-seam'
+import { expandMatrix } from './matrix'
+
+const firstCell = () =>
+  expandMatrix(TINY_TEST_CONFIG).find(c => c.lane === 'fireworks')!
+
+describe('fixture lane seam — deterministic, spend-free', () => {
+  test('cannot spend', () => {
+    expect(makeFixtureLaneSeam().canSpend).toBe(false)
+    expect(makeFixtureLaneSeam().id).toBe('fixture')
+  })
+
+  test('same cell + same sample index → identical sample (pure)', () => {
+    const seam = makeFixtureLaneSeam()
+    const cell = firstCell()
+    expect(seam.sample(cell, 0)).toEqual(seam.sample(cell, 0))
+  })
+
+  test('repeated samples spread deterministically (so percentiles are non-degenerate)', () => {
+    const seam = makeFixtureLaneSeam()
+    const cell = firstCell()
+    const a = seam.sample(cell, 0)
+    const b = seam.sample(cell, 1)
+    const c = seam.sample(cell, 2)
+    // Jitter moves wall-clock around the base; not all identical.
+    const wallClocks = [a.totalWallClockMs, b.totalWallClockMs, c.totalWallClockMs]
+    expect(new Set(wallClocks).size).toBeGreaterThan(1)
+  })
+
+  test('cached input tokens follow the cacheable prefix × hit fraction', () => {
+    const seam = makeFixtureLaneSeam()
+    const cell = firstCell()
+    const sample = seam.sample(cell, 0)
+    // Fireworks fixture cacheHitFraction 0.8 over a 500-token cacheable prefix.
+    expect(sample.cachedInputTokens).toBe(Math.round(500 * 0.8))
+  })
+
+  test('artifact-gen cell carries an executed passed verdict (scored on outcome)', () => {
+    const seam = makeFixtureLaneSeam()
+    const cell = firstCell()
+    const sample = seam.sample(cell, 0)
+    expect(sample.verificationClass).toBe('test_passed')
+    expect(sample.executedVerdict).toBe('passed')
+    expect(sample.scalarReward).toBe(1)
+    expect(sample.verifierTimeMs).toBeGreaterThan(0)
+  })
+
+  test('token counts mirror the sequence shape', () => {
+    const seam = makeFixtureLaneSeam()
+    const cell = firstCell()
+    const sample = seam.sample(cell, 0)
+    expect(sample.promptTokens).toBe(1000)
+    expect(sample.completionTokens).toBe(100)
+    expect(sample.totalTokens).toBe(1100)
+  })
+})
+
+describe('real lane seam — owner/spend-gated, default OFF', () => {
+  test('unarmed seam cannot spend and refuses to sample (no network ever)', () => {
+    const seam = makeRealLaneSeam({ armRealSweep: false })
+    expect(seam.canSpend).toBe(false)
+    expect(() => seam.sample(firstCell(), 0)).toThrow(RealLaneNotArmedError)
+  })
+
+  test('armed flag WITHOUT an executor still cannot spend (refuses)', () => {
+    const seam = makeRealLaneSeam({ armRealSweep: true })
+    expect(seam.canSpend).toBe(false)
+    expect(() => seam.sample(firstCell(), 0)).toThrow(RealLaneNotArmedError)
+  })
+
+  test('a non-true arming value is treated as OFF (no truthy-coercion bypass)', () => {
+    // @ts-expect-error — exercising a defensive runtime guard against a bad flag.
+    const seam = makeRealLaneSeam({ armRealSweep: 1, executor: () => firstCell() })
+    expect(seam.canSpend).toBe(false)
+    expect(() => seam.sample(firstCell(), 0)).toThrow(RealLaneNotArmedError)
+  })
+
+  test('only an explicit true + executor arms the seam (owner-confirmed path)', () => {
+    const seam = makeRealLaneSeam({
+      armRealSweep: true,
+      executor: (cell, sampleIndex) => ({
+        promptTokens: 10,
+        completionTokens: 5,
+        totalTokens: 15,
+        cachedInputTokens: 0,
+        ttftMs: 100 + sampleIndex,
+        totalWallClockMs: 500,
+        generationWallClockMs: 400,
+        providerTimeMs: 480,
+        gatewayOverheadMs: 20,
+        verificationClass: 'none',
+        executedVerdict: 'not_executed',
+        scalarReward: 0,
+        verifierTimeMs: 0,
+        costBasisMsat: 100,
+        region: cell.lane,
+      }),
+    })
+    expect(seam.canSpend).toBe(true)
+    expect(seam.sample(firstCell(), 0).promptTokens).toBe(10)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/benchmark/lane-seam.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/lane-seam.ts
@@ -1,0 +1,351 @@
+// The pluggable LANE SEAM the benchmark runner executes a cell against (book
+// P1-5 / #6088).
+//
+// The book's gold standard (§4.5) is SHADOWING real production traffic. We
+// cannot shadow real provider traffic from inside a deterministic test, and a
+// real provider sweep COSTS MONEY and is owner/spend-gated. So the runner talks
+// to a `BenchmarkLaneSeam` — an abstract "given a cell, produce a measured
+// sample" interface — and there are two implementations:
+//
+//   1. `makeFixtureLaneSeam` (DEFAULT): a fully DETERMINISTIC, network-free,
+//      spend-free lane. Given a scenario table, it returns the SAME measured
+//      sample for the same cell every time. Its numbers are clearly labeled
+//      ILLUSTRATIVE — they let us prove the harness, the telemetry plumbing, and
+//      the report math without touching a provider. No clock, no randomness.
+//
+//   2. `makeRealLaneSeam` (FLAG/OWNER-GATED, default OFF): the seam that would
+//      actually hit a live provider adapter and measure a real request. It is
+//      constructed only when an explicit owner arming flag is set; absent the
+//      flag it refuses to run (so a test or an un-armed environment can NEVER
+//      issue a real, billable request). This module does NOT implement the live
+//      provider calls — that is the owner-armed sweep — it implements the GATE
+//      so the default path is provably spend-free.
+//
+// This file is PURE/Worker-safe: no Worker bindings, no Effect runtime, no
+// network, no Date.now/Math.random. The fixture lane derives its numbers
+// arithmetically from the cell + scenario so the whole harness is reproducible.
+import type {
+  KhalaExecutedVerdict,
+  KhalaVerificationClass,
+} from '../khala-telemetry'
+import type { BenchmarkCell } from './matrix'
+
+// ---------------------------------------------------------------------------
+// The measured sample a seam returns for one execution of one cell.
+// ---------------------------------------------------------------------------
+
+// The raw measured outputs of executing a cell ONCE. These are the inputs the
+// runner feeds into the canonical telemetry builder (`buildKhalaTelemetryRecord`),
+// so the field names line up with the telemetry input contract. Every value is a
+// concrete measured number here (the fixture lane always measures); the telemetry
+// builder is what later collapses an absent value to the honest sentinel.
+export type BenchmarkLaneSample = Readonly<{
+  // Token counts (receipt-first from the provider usage, fixture-derived here).
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  cachedInputTokens: number
+  // Latency split (ms).
+  ttftMs: number
+  totalWallClockMs: number
+  generationWallClockMs: number
+  providerTimeMs: number
+  gatewayOverheadMs: number
+  // Verification outcome (the headline of P1-5). The fixture lane assigns these
+  // deterministically per scenario; a real lane would carry the executed runner's
+  // verdict.
+  verificationClass: KhalaVerificationClass
+  executedVerdict: KhalaExecutedVerdict
+  scalarReward: number
+  // Verifier time when an executed verdict exists; 0 for a non-verified workload.
+  verifierTimeMs: number
+  // Cost basis in msat where known (the provider's unit cost for the request).
+  // The benchmark records cost so the report can compute cost-per-accepted-outcome.
+  costBasisMsat: number
+  // The serving region the lane reports (public-safe coarse region string).
+  region: string
+}>
+
+// The pluggable seam. Given a cell, return a measured sample. PURE for the
+// fixture lane (same cell → same sample); the real lane would perform IO behind
+// this same signature but is gated off by default.
+export type BenchmarkLaneSeam = Readonly<{
+  // Stable id of the seam implementation ("fixture" | "real").
+  id: string
+  // Whether this seam may issue real, billable provider requests. The fixture
+  // seam is always `false`; the real seam is `true` ONLY when owner-armed.
+  canSpend: boolean
+  // Execute one sample of one cell. The runner calls this `samplesPerCell` times
+  // (or once for a not-yet-available lane, which the seam reports as unexecuted).
+  sample: (cell: BenchmarkCell, sampleIndex: number) => BenchmarkLaneSample
+}>
+
+// ---------------------------------------------------------------------------
+// Fixture scenario table — the deterministic, illustrative numbers.
+// ---------------------------------------------------------------------------
+
+// A per-lane fixture profile: the synthetic-but-plausible performance shape used
+// to PROVE the harness. These are NOT real measurements — they are illustrative
+// constants chosen so the report math is exercised (different lanes get visibly
+// different latency/cost so percentiles and rankings are non-degenerate). The
+// report labels every fixture-sourced number as illustrative.
+export type FixtureLaneProfile = Readonly<{
+  // Baseline TTFT (ms) for a small streaming request on this lane.
+  baseTtftMs: number
+  // Mean per-output-token generation time (ms/token) — drives perceived TPS.
+  msPerOutputToken: number
+  // Fixed gateway overhead (ms) the edge adds regardless of lane.
+  gatewayOverheadMs: number
+  // Msat cost per 1000 prompt tokens and per 1000 completion tokens.
+  costPerKPromptMsat: number
+  costPerKCompletionMsat: number
+  // Fraction (0..1) of the cacheable prefix this lane actually serves from cache
+  // (book P0-2): a lane with a prompt cache discounts repeated prefix tokens.
+  cacheHitFraction: number
+  // Coarse region label this lane reports.
+  region: string
+}>
+
+// The default illustrative profiles. Deliberately distinct so the report can
+// show a meaningful (illustrative) ranking. A real sweep replaces these with
+// measured numbers; the SHAPE of the report does not change.
+export const DEFAULT_FIXTURE_PROFILES: Readonly<
+  Partial<Record<BenchmarkCell['lane'], FixtureLaneProfile>>
+> = {
+  fireworks: {
+    baseTtftMs: 240,
+    msPerOutputToken: 8,
+    gatewayOverheadMs: 30,
+    costPerKPromptMsat: 1500,
+    costPerKCompletionMsat: 4500,
+    cacheHitFraction: 0.8,
+    region: 'us-central',
+  },
+  'vertex-anthropic': {
+    baseTtftMs: 420,
+    msPerOutputToken: 14,
+    gatewayOverheadMs: 35,
+    costPerKPromptMsat: 6000,
+    costPerKCompletionMsat: 30000,
+    cacheHitFraction: 0.9,
+    region: 'us-central1',
+  },
+  'vertex-gemini': {
+    baseTtftMs: 300,
+    msPerOutputToken: 10,
+    gatewayOverheadMs: 35,
+    costPerKPromptMsat: 1200,
+    costPerKCompletionMsat: 4800,
+    cacheHitFraction: 0.75,
+    region: 'us-central1',
+  },
+  'partner-passthrough': {
+    baseTtftMs: 360,
+    msPerOutputToken: 12,
+    gatewayOverheadMs: 45,
+    costPerKPromptMsat: 3000,
+    costPerKCompletionMsat: 9000,
+    cacheHitFraction: 0.5,
+    region: 'partner',
+  },
+}
+
+// A neutral fallback profile for a lane with no explicit fixture entry (e.g. a
+// not-yet-available lane that is still expanded into the matrix). It is bland on
+// purpose; the report flags the lane as unavailable regardless.
+const FALLBACK_PROFILE: FixtureLaneProfile = {
+  baseTtftMs: 500,
+  msPerOutputToken: 16,
+  gatewayOverheadMs: 50,
+  costPerKPromptMsat: 2000,
+  costPerKCompletionMsat: 6000,
+  cacheHitFraction: 0,
+  region: 'unknown',
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic fixture sample derivation.
+// ---------------------------------------------------------------------------
+
+// A tiny deterministic spread so repeated samples of one cell are not identical
+// (so percentiles are meaningful) WITHOUT any randomness. The spread is a fixed
+// function of the sample index: a small triangular jitter around the base.
+const deterministicJitter = (sampleIndex: number): number => {
+  // Cycles 0, +1, -1, +2, -2, ... as a fraction-of-percent multiplier.
+  const magnitude = Math.ceil((sampleIndex + 1) / 2)
+  const sign = sampleIndex % 2 === 0 ? 1 : -1
+  return 1 + (sign * magnitude) / 100
+}
+
+// Derive the executed verification outcome for a fixture cell from its expected
+// class. Artifact-gen / verifier-run cells "execute" and PASS in the fixture
+// (scalarReward 1) so the report's accepted-outcome math has accepted outcomes;
+// chat is unverified work (`none`, `not_executed`); a seeded long-context
+// question is `seeded` with a partial reward. A real lane carries the real
+// runner verdict instead.
+const fixtureVerification = (
+  cell: BenchmarkCell,
+): Pick<
+  BenchmarkLaneSample,
+  'verificationClass' | 'executedVerdict' | 'scalarReward' | 'verifierTimeMs'
+> => {
+  switch (cell.verificationExpectation) {
+    case 'none':
+      return {
+        verificationClass: 'none',
+        executedVerdict: 'not_executed',
+        scalarReward: 0,
+        verifierTimeMs: 0,
+      }
+    case 'seeded':
+      return {
+        verificationClass: 'seeded',
+        executedVerdict: 'not_executed',
+        scalarReward: 0.6,
+        verifierTimeMs: 0,
+      }
+    case 'test_passed':
+      return {
+        verificationClass: 'test_passed',
+        executedVerdict: 'passed',
+        scalarReward: 1,
+        verifierTimeMs: 1800,
+      }
+    case 'exact_trace_replay':
+      return {
+        verificationClass: 'exact_trace_replay',
+        executedVerdict: 'passed',
+        scalarReward: 1,
+        verifierTimeMs: 900,
+      }
+  }
+}
+
+// Build the deterministic fixture lane seam. Given the profile table, it derives
+// every sample arithmetically from the cell + scenario. Same inputs → same
+// sample. `canSpend: false` always.
+export const makeFixtureLaneSeam = (
+  profiles: Readonly<
+    Partial<Record<BenchmarkCell['lane'], FixtureLaneProfile>>
+  > = DEFAULT_FIXTURE_PROFILES,
+): BenchmarkLaneSeam => ({
+  id: 'fixture',
+  canSpend: false,
+  sample: (cell, sampleIndex) => {
+    const profile = profiles[cell.lane] ?? FALLBACK_PROFILE
+    const jitter = deterministicJitter(sampleIndex)
+
+    const promptTokens = cell.shape.inputTokens
+    const completionTokens = cell.shape.outputTokens
+    // Cached input tokens: the cacheable prefix served from cache at the lane's
+    // hit fraction (book P0-2). Streaming-only effect on TTFT below.
+    const cachedInputTokens = Math.round(
+      cell.shape.cacheablePrefixTokens * profile.cacheHitFraction,
+    )
+
+    // Generation wall-clock scales with output length and the lane's per-token
+    // cost; the deterministic jitter spreads repeated samples.
+    const generationWallClockMs = Math.round(
+      completionTokens * profile.msPerOutputToken * jitter,
+    )
+    // TTFT: a cache hit on the prefix shaves the prefill, so a higher cache hit
+    // fraction lowers TTFT — the streaming path only. A batch transport has no
+    // meaningful TTFT (the book: batch optimizes throughput, not first-token), so
+    // we set it equal to the full wall-clock there to keep the field honest.
+    const cacheTtftDiscount =
+      cell.transport === 'streaming'
+        ? 1 - 0.3 * profile.cacheHitFraction
+        : 1
+    const ttftMs =
+      cell.transport === 'streaming'
+        ? Math.round(profile.baseTtftMs * cacheTtftDiscount * jitter)
+        : Math.round(
+            (profile.baseTtftMs + generationWallClockMs) * jitter,
+          )
+
+    const providerTimeMs = ttftMs + generationWallClockMs
+    const totalWallClockMs = providerTimeMs + profile.gatewayOverheadMs
+
+    // Cost basis: prompt + completion priced per-1k; cached prefix tokens are
+    // discounted 50% (the standard prompt-cache discount), matching the metering
+    // hook's treatment of `cachedPromptTokens`.
+    const billablePromptTokens = promptTokens - cachedInputTokens * 0.5
+    const costBasisMsat = Math.round(
+      (billablePromptTokens / 1000) * profile.costPerKPromptMsat +
+        (completionTokens / 1000) * profile.costPerKCompletionMsat,
+    )
+
+    const totalTokens = promptTokens + completionTokens
+
+    return {
+      promptTokens,
+      completionTokens,
+      totalTokens,
+      cachedInputTokens,
+      ttftMs,
+      totalWallClockMs,
+      generationWallClockMs,
+      providerTimeMs,
+      gatewayOverheadMs: profile.gatewayOverheadMs,
+      costBasisMsat,
+      region: profile.region,
+      ...fixtureVerification(cell),
+    }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Real lane seam — FLAG/OWNER-GATED, default OFF.
+// ---------------------------------------------------------------------------
+
+// Raised when the real-lane seam is constructed without the owner arming flag.
+// It is a typed refusal, not a silent fallback, so a caller can never
+// accidentally believe it is hitting a real lane when it is not — and it can
+// never issue a billable request unarmed.
+export class RealLaneNotArmedError extends Error {
+  readonly _tag = 'RealLaneNotArmedError'
+  constructor() {
+    super(
+      'Real benchmark lane is owner/spend-gated and not armed. ' +
+        'Set armRealSweep:true (owner-confirmed) to run a real, billable sweep.',
+    )
+    this.name = 'RealLaneNotArmedError'
+  }
+}
+
+// The injected dependency the real lane would call to actually execute a cell
+// against a live provider adapter and measure it. The benchmark module does NOT
+// implement this (the live calls + spend live in the owner-armed sweep); it only
+// types the seam and the gate, so the default code path is provably spend-free.
+export type RealLaneExecutor = (
+  cell: BenchmarkCell,
+  sampleIndex: number,
+) => BenchmarkLaneSample
+
+export type RealLaneSeamOptions = Readonly<{
+  // The owner arming flag. MUST be explicitly true to construct a spending seam.
+  // Anything else (false / undefined) yields a refusing seam.
+  armRealSweep: boolean
+  // The injected live executor. Required only when armed.
+  executor?: RealLaneExecutor | undefined
+}>
+
+// Construct the real lane seam. When `armRealSweep` is not exactly `true`, the
+// returned seam's `sample` THROWS `RealLaneNotArmedError` and `canSpend` is
+// false — so the default/test path can construct it and prove it refuses to
+// spend. When armed (and given an executor), it delegates to the executor.
+export const makeRealLaneSeam = (
+  options: RealLaneSeamOptions,
+): BenchmarkLaneSeam => {
+  const armed = options.armRealSweep === true && options.executor !== undefined
+  return {
+    id: 'real',
+    canSpend: armed,
+    sample: (cell, sampleIndex) => {
+      if (!armed || options.executor === undefined) {
+        throw new RealLaneNotArmedError()
+      }
+      return options.executor(cell, sampleIndex)
+    },
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/benchmark/matrix.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/matrix.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  SAMPLE_DECISION_SUITE_CONFIG,
+  TINY_TEST_CONFIG,
+} from './fixtures'
+import {
+  buildCellId,
+  decodeBenchmarkMatrixConfig,
+  expandMatrix,
+  expectedCellCount,
+  laneAvailability,
+  verificationExpectationForWorkload,
+} from './matrix'
+
+describe('benchmark matrix — expansion', () => {
+  test('expands to exactly the cross-product cardinality', () => {
+    const cells = expandMatrix(SAMPLE_DECISION_SUITE_CONFIG)
+    // 4 targets × 4 workloads × 3 shapes × 2 transports × 2 sampling = 192.
+    expect(expectedCellCount(SAMPLE_DECISION_SUITE_CONFIG)).toBe(192)
+    expect(cells.length).toBe(192)
+  })
+
+  test('tiny config expands to a hand-checkable cell count', () => {
+    // 2 targets × 1 workload × 1 shape × 1 transport × 1 sampling = 2.
+    expect(expectedCellCount(TINY_TEST_CONFIG)).toBe(2)
+    expect(expandMatrix(TINY_TEST_CONFIG).length).toBe(2)
+  })
+
+  test('expansion is deterministic — identical config yields identical ordered cell ids', () => {
+    const a = expandMatrix(SAMPLE_DECISION_SUITE_CONFIG).map(c => c.cellId)
+    const b = expandMatrix(SAMPLE_DECISION_SUITE_CONFIG).map(c => c.cellId)
+    expect(a).toEqual(b)
+    // No duplicate cell ids (each axis combination is unique).
+    expect(new Set(a).size).toBe(a.length)
+  })
+
+  test('cell id encodes every axis value', () => {
+    const id = buildCellId({
+      lane: 'fireworks',
+      engine: 'provider-native',
+      workload: 'chat',
+      shapeId: 'short-chat',
+      transport: 'streaming',
+      sampling: { temperature: 0.2, reasoningEffort: 'medium' },
+    })
+    expect(id).toBe(
+      'fireworks|provider-native|chat|short-chat|streaming|t0.2|rmedium',
+    )
+  })
+
+  test('each cell carries the honest lane-availability label', () => {
+    const cells = expandMatrix(SAMPLE_DECISION_SUITE_CONFIG)
+    const fireworks = cells.find(c => c.lane === 'fireworks')
+    const pylon = cells.find(c => c.lane === 'pylon-whole-small')
+    const psionic = cells.find(c => c.lane === 'psionic-shard-wan')
+    expect(fireworks?.laneAvailability).toBe('available')
+    expect(pylon?.laneAvailability).toBe('not_yet_available')
+    expect(psionic?.laneAvailability).toBe('not_yet_available')
+  })
+
+  test('verification expectation is derived from workload (scored on outcome)', () => {
+    expect(verificationExpectationForWorkload('chat')).toBe('none')
+    expect(verificationExpectationForWorkload('khala-code-artifact-gen')).toBe(
+      'test_passed',
+    )
+    expect(verificationExpectationForWorkload('verifier-run')).toBe(
+      'test_passed',
+    )
+    expect(
+      verificationExpectationForWorkload('long-context-codebase-question'),
+    ).toBe('seeded')
+  })
+
+  test('lane availability table is the single source of truth', () => {
+    expect(laneAvailability('vertex-anthropic')).toBe('available')
+    expect(laneAvailability('fireworks')).toBe('available')
+    expect(laneAvailability('partner-passthrough')).toBe('available')
+    expect(laneAvailability('pylon-whole-small')).toBe('not_yet_available')
+    expect(laneAvailability('psionic-shard-wan')).toBe('not_yet_available')
+  })
+
+  test('the sample + tiny configs decode against the schema', () => {
+    expect(() =>
+      decodeBenchmarkMatrixConfig(SAMPLE_DECISION_SUITE_CONFIG),
+    ).not.toThrow()
+    expect(() => decodeBenchmarkMatrixConfig(TINY_TEST_CONFIG)).not.toThrow()
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/benchmark/matrix.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/matrix.ts
@@ -1,0 +1,314 @@
+// Khala provider/engine benchmark MATRIX (book P1-5 / #6088).
+//
+// The book's Ch.4 §4.5 lesson, turned into a typed contract: "faster" is
+// meaningless until you say faster at WHAT, on WHICH lane, under WHICH traffic
+// shape, judged on WHICH outcome. So a benchmark is not an ad-hoc script with
+// hard-coded numbers — it is a MATRIX that varies the dimensions the book calls
+// out (lane, engine, workload, sequence shape, streaming-vs-batch,
+// temperature/reasoning) and is scored on VERIFICATION OUTCOME, not just raw
+// token speed.
+//
+// This module owns ONLY the typed configuration + the deterministic expansion of
+// a matrix config into the concrete (lane × engine × workload × shape × …) cells
+// a runner executes. It is PURE and framework-agnostic: no Worker, no network,
+// no Effect runtime, no clock. The runner (`runner.ts`) executes the cells; the
+// report (`report.ts`) aggregates the results. Keeping the matrix declarative
+// means the benchmark is auditable and reproducible: the same config always
+// expands to the same ordered cell list.
+//
+// HONESTY: a lane/engine that does NOT yet exist as a real Khala serving path is
+// still a first-class matrix axis VALUE, but it is marked `availability:
+// 'not_yet_available'`. The benchmark never pretends an unbuilt lane was
+// measured; it expands the cell, records WHY it is unavailable, and the report
+// labels it. This mirrors the telemetry schema's `not_measured` discipline.
+import { Schema as S } from 'effect'
+
+// ---------------------------------------------------------------------------
+// Axis values (the book's matrix dimensions, as closed literal unions).
+// ---------------------------------------------------------------------------
+
+// The supply LANE under test. Matches the provider-adapter seam ids plus the
+// not-yet-built decentralized lanes the notes call out (Pylon whole-small,
+// Psionic shard-WAN). The benchmark can name a lane that does not exist yet; the
+// `LANE_AVAILABILITY` table below records whether it is real.
+export const BenchmarkLane = S.Literals([
+  'vertex-anthropic',
+  'vertex-gemini',
+  'fireworks',
+  'partner-passthrough',
+  'pylon-whole-small',
+  'psionic-shard-wan',
+])
+export type BenchmarkLane = typeof BenchmarkLane.Type
+
+// The serving ENGINE behind a lane (book P1-5 + notes §6). A managed provider is
+// `provider-native`; self-hosted lanes pick a concrete open engine. Recorded so
+// a future "Fireworks-native vs our-own-vLLM" comparison is a matrix axis, not a
+// rewrite.
+export const BenchmarkEngine = S.Literals([
+  'provider-native',
+  'vllm',
+  'sglang',
+  'tensorrt-llm',
+])
+export type BenchmarkEngine = typeof BenchmarkEngine.Type
+
+// The WORKLOAD shape — the kind of Khala request. Each one optimizes different
+// metrics (the request-class lesson): chat optimizes TTFT/ITL; artifact gen
+// optimizes accepted-outcome; a verifier run optimizes verified-rate; a
+// long-context codebase question stresses input length + prefix cache.
+export const BenchmarkWorkload = S.Literals([
+  'chat',
+  'khala-code-artifact-gen',
+  'verifier-run',
+  'long-context-codebase-question',
+])
+export type BenchmarkWorkload = typeof BenchmarkWorkload.Type
+
+// Streaming vs batch transport (book Ch.7 / the P0-3 split). Determines which
+// metrics are even MEASURABLE (TTFT exists only on the streaming path; batch
+// optimizes throughput/cost over a detached job).
+export const BenchmarkTransport = S.Literals(['streaming', 'batch'])
+export type BenchmarkTransport = typeof BenchmarkTransport.Type
+
+// The expected verification OUTCOME the cell is judged on (book P1-5: "verification
+// outcome, not just raw token speed"). This is the EXPECTED class for the fixture
+// scenario — the runner records the ACTUAL executed verdict and the report compares.
+export const BenchmarkVerificationExpectation = S.Literals([
+  'none',
+  'seeded',
+  'test_passed',
+  'exact_trace_replay',
+])
+export type BenchmarkVerificationExpectation =
+  typeof BenchmarkVerificationExpectation.Type
+
+// ---------------------------------------------------------------------------
+// Lane availability (HONEST: which lanes are real Khala serving paths today).
+// ---------------------------------------------------------------------------
+
+// Whether a lane is a real serving path the benchmark can actually hit with a
+// real-lane adapter today, vs a named-but-unbuilt future lane.
+export const LaneAvailability = S.Literals([
+  'available',
+  'not_yet_available',
+])
+export type LaneAvailability = typeof LaneAvailability.Type
+
+// The availability table. `available` lanes have a real provider adapter behind
+// the (owner-gated) real-lane seam; `not_yet_available` lanes can still be put in
+// the matrix (so the comparison shape is complete) but are labeled and never
+// measured against a real path. This is the single source of truth the runner +
+// report read; it never invents an "available" claim for an unbuilt lane.
+export const LANE_AVAILABILITY: Readonly<Record<BenchmarkLane, LaneAvailability>> =
+  {
+    'vertex-anthropic': 'available',
+    'vertex-gemini': 'available',
+    fireworks: 'available',
+    'partner-passthrough': 'available',
+    // Pylon whole-small serving and Psionic shard-WAN are named in the notes as
+    // FUTURE lanes (§6, decentralized-serving-shard-wan). They are matrix axes so
+    // the decision suite is shaped for them, but they are not real serving paths
+    // yet — honestly labeled, never measured.
+    'pylon-whole-small': 'not_yet_available',
+    'psionic-shard-wan': 'not_yet_available',
+  }
+
+export const laneAvailability = (lane: BenchmarkLane): LaneAvailability =>
+  LANE_AVAILABILITY[lane]
+
+// ---------------------------------------------------------------------------
+// Sequence shape (book §4.5: ISL / OSL / cacheable prefix — must match prod).
+// ---------------------------------------------------------------------------
+
+// A sequence shape: input length (ISL), output length (OSL), and the cacheable
+// prefix length within the input. The book is emphatic that these must match the
+// production workload — a benchmark over the wrong shapes measures nothing useful
+// (§4.5: "If you're maximizing benchmark performance against bad inputs,
+// performance in production won't match expectations"). The report labels whether
+// a shape was sourced from real traffic or is synthetic.
+export const SequenceShape = S.Struct({
+  // A short stable id for the shape (e.g. "short-chat", "long-codebase-32k").
+  id: S.String,
+  // Input sequence length in tokens (the prompt).
+  inputTokens: S.Number,
+  // Output sequence length in tokens (the generation).
+  outputTokens: S.Number,
+  // Cacheable prefix length in tokens (the shared stable-prefix portion of the
+  // input that a prompt cache can reuse — book P0-2). 0 when no shared prefix.
+  cacheablePrefixTokens: S.Number,
+  // Concurrency: number of simultaneous in-flight requests this shape models
+  // (book §4.5 "volume and pattern of traffic"). 1 = a single serial request.
+  concurrency: S.Number,
+  // Whether this shape's lengths/contents came from REAL observed Khala traffic
+  // (`realistic`) or were invented (`synthetic`). The report surfaces this
+  // prominently: synthetic-only numbers are illustrative, not decision-grade.
+  provenance: S.Literals(['realistic', 'synthetic']),
+})
+export type SequenceShape = typeof SequenceShape.Type
+
+// ---------------------------------------------------------------------------
+// Sampling settings (book §4.5: temperature/reasoning at production values).
+// ---------------------------------------------------------------------------
+
+export const SamplingSettings = S.Struct({
+  // Sampling temperature (production value, not a benchmark-flattering 0).
+  temperature: S.Number,
+  // Reasoning/thinking effort where the model exposes it (off | low | medium |
+  // high). `off` for a non-reasoning lane. Reasoning inflates billed tokens
+  // (the `unaccountedTokens` dimension) and changes latency, so it is an axis.
+  reasoningEffort: S.Literals(['off', 'low', 'medium', 'high']),
+})
+export type SamplingSettings = typeof SamplingSettings.Type
+
+// ---------------------------------------------------------------------------
+// The matrix config (declarative cross-product spec) + a single expanded cell.
+// ---------------------------------------------------------------------------
+
+// One (lane, engine) supply target. Engines are paired with lanes explicitly
+// (rather than a blind cross-product) because not every engine runs on every
+// lane — a managed provider is always `provider-native`; only self-hosted lanes
+// pick vLLM/SGLang/TensorRT-LLM. Pairing avoids fabricating impossible cells.
+export const BenchmarkTarget = S.Struct({
+  lane: BenchmarkLane,
+  engine: BenchmarkEngine,
+})
+export type BenchmarkTarget = typeof BenchmarkTarget.Type
+
+// The declarative matrix config. The runner expands the cross-product of
+// targets × workloads × shapes × transports × sampling into ordered cells. A
+// benchmark RUN is "execute every cell of one config against one seam".
+export const BenchmarkMatrixConfig = S.Struct({
+  // Stable id for this matrix config (e.g. "fireworks-vs-vertex-chat-code-v1").
+  id: S.String,
+  // Human-readable purpose, public-safe (no accounts/prompts).
+  description: S.String,
+  targets: S.Array(BenchmarkTarget),
+  workloads: S.Array(BenchmarkWorkload),
+  shapes: S.Array(SequenceShape),
+  transports: S.Array(BenchmarkTransport),
+  sampling: S.Array(SamplingSettings),
+  // How many repeated samples per cell (book §4.5.2: "send enough traffic ...
+  // run a benchmark multiple times and average"). >= 1.
+  samplesPerCell: S.Number,
+})
+export type BenchmarkMatrixConfig = typeof BenchmarkMatrixConfig.Type
+
+// A single fully-resolved benchmark cell: one point in the cross-product. The
+// `verificationExpectation` is DERIVED from the workload (chat expects `none`;
+// artifact-gen/verifier-run expect an executed `test_passed`), so the matrix is
+// scored on outcome without the config author having to repeat it per cell.
+export const BenchmarkCell = S.Struct({
+  // Deterministic stable id: encodes every axis value so the same cell always
+  // gets the same id (auditable, reproducible).
+  cellId: S.String,
+  lane: BenchmarkLane,
+  engine: BenchmarkEngine,
+  laneAvailability: LaneAvailability,
+  workload: BenchmarkWorkload,
+  shape: SequenceShape,
+  transport: BenchmarkTransport,
+  sampling: SamplingSettings,
+  verificationExpectation: BenchmarkVerificationExpectation,
+  samplesPerCell: S.Number,
+})
+export type BenchmarkCell = typeof BenchmarkCell.Type
+
+// Derive the expected verification class from the workload. A chat turn is not
+// verified work; an artifact-gen / verifier-run cell expects an EXECUTED
+// `test_passed`; a long-context codebase question is `seeded` (a reference
+// answer exists but it is not an executed acceptance suite).
+export const verificationExpectationForWorkload = (
+  workload: BenchmarkWorkload,
+): BenchmarkVerificationExpectation => {
+  switch (workload) {
+    case 'chat':
+      return 'none'
+    case 'long-context-codebase-question':
+      return 'seeded'
+    case 'khala-code-artifact-gen':
+    case 'verifier-run':
+      return 'test_passed'
+  }
+}
+
+// Build the deterministic stable cell id. Pure string assembly over the axis
+// values — no randomness, no clock — so the same axes always yield the same id.
+export const buildCellId = (input: {
+  lane: BenchmarkLane
+  engine: BenchmarkEngine
+  workload: BenchmarkWorkload
+  shapeId: string
+  transport: BenchmarkTransport
+  sampling: SamplingSettings
+}): string =>
+  [
+    input.lane,
+    input.engine,
+    input.workload,
+    input.shapeId,
+    input.transport,
+    `t${input.sampling.temperature}`,
+    `r${input.sampling.reasoningEffort}`,
+  ].join('|')
+
+// Expand a matrix config into its ordered list of concrete cells. PURE and
+// DETERMINISTIC: the cross-product is generated in a fixed nested order
+// (targets → workloads → shapes → transports → sampling) so the expanded list is
+// byte-stable for a given config. This is the contract the runner + report rely
+// on for reproducibility.
+export const expandMatrix = (
+  config: BenchmarkMatrixConfig,
+): ReadonlyArray<BenchmarkCell> => {
+  const cells: Array<BenchmarkCell> = []
+  for (const target of config.targets) {
+    for (const workload of config.workloads) {
+      for (const shape of config.shapes) {
+        for (const transport of config.transports) {
+          for (const sampling of config.sampling) {
+            cells.push({
+              cellId: buildCellId({
+                lane: target.lane,
+                engine: target.engine,
+                workload,
+                shapeId: shape.id,
+                transport,
+                sampling,
+              }),
+              lane: target.lane,
+              engine: target.engine,
+              laneAvailability: laneAvailability(target.lane),
+              workload,
+              shape,
+              transport,
+              sampling,
+              verificationExpectation:
+                verificationExpectationForWorkload(workload),
+              samplesPerCell: config.samplesPerCell,
+            })
+          }
+        }
+      }
+    }
+  }
+  return cells
+}
+
+// The expected cell count for a config (the cross-product cardinality). Used by
+// tests to assert the matrix expanded to exactly the right number of cells, and
+// by the report header to disclose coverage.
+export const expectedCellCount = (config: BenchmarkMatrixConfig): number =>
+  config.targets.length *
+  config.workloads.length *
+  config.shapes.length *
+  config.transports.length *
+  config.sampling.length
+
+// ---------------------------------------------------------------------------
+// Decoders + a documented minimum decision suite (notes Q5).
+// ---------------------------------------------------------------------------
+
+export const decodeBenchmarkMatrixConfig = S.decodeUnknownSync(
+  BenchmarkMatrixConfig,
+)
+export const decodeBenchmarkCell = S.decodeUnknownSync(BenchmarkCell)

--- a/apps/openagents.com/workers/api/src/inference/benchmark/report.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/report.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from 'vitest'
+
+import { SAMPLE_DECISION_SUITE_CONFIG, TINY_TEST_CONFIG } from './fixtures'
+import { makeFixtureLaneSeam, makeRealLaneSeam } from './lane-seam'
+import {
+  buildBenchmarkReport,
+  checkReportPublicSafety,
+  mean,
+  percentile,
+} from './report'
+import { runBenchmark } from './runner'
+
+describe('percentile + mean helpers (book Ch.1 §1.4.1)', () => {
+  test('nearest-rank percentiles over a known distribution', () => {
+    const values = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+    expect(percentile(values, 50)).toBe(50)
+    expect(percentile(values, 90)).toBe(90)
+    expect(percentile(values, 99)).toBe(100)
+  })
+
+  test('empty input is honest null, never a fabricated 0', () => {
+    expect(percentile([], 50)).toBeNull()
+    expect(mean([])).toBeNull()
+  })
+
+  test('single sample returns itself', () => {
+    expect(percentile([42], 50)).toBe(42)
+    expect(percentile([42], 99)).toBe(42)
+  })
+
+  test('mean is the arithmetic average', () => {
+    expect(mean([10, 20, 30])).toBe(20)
+  })
+})
+
+describe('benchmark report — aggregation', () => {
+  test('groups are per (lane × workload), executed-only metrics, future lanes skipped', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam()),
+    )
+    // Two lanes × one workload, but pylon (future) is skipped → 2 groups exist
+    // (the future-lane group has only skipped samples).
+    const fireworks = report.groups.find(g => g.lane === 'fireworks')!
+    const pylon = report.groups.find(g => g.lane === 'pylon-whole-small')!
+    expect(fireworks.executedSamples).toBe(4)
+    expect(fireworks.skippedSamples).toBe(0)
+    expect(pylon.executedSamples).toBe(0)
+    expect(pylon.skippedSamples).toBe(1)
+    expect(pylon.laneAvailability).toBe('not_yet_available')
+  })
+
+  test('verification rate = accepted / attempted (all artifact-gen samples pass in fixture)', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam()),
+    )
+    const fireworks = report.groups.find(g => g.lane === 'fireworks')!
+    expect(fireworks.attemptedVerifications).toBe(4)
+    expect(fireworks.acceptedOutcomes).toBe(4)
+    expect(fireworks.verificationRate).toBe(1)
+  })
+
+  test('cost-per-accepted-outcome = total cost basis / accepted outcomes', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam()),
+    )
+    const fireworks = report.groups.find(g => g.lane === 'fireworks')!
+    // Verify the relationship directly (the value is fixture-derived).
+    expect(fireworks.costPerAcceptedOutcomeMsat).not.toBeNull()
+    expect(fireworks.costPerAcceptedOutcomeMsat).toBeCloseTo(
+      fireworks.totalCostBasisMsat / fireworks.acceptedOutcomes,
+      6,
+    )
+  })
+
+  test('a group with no accepted outcome has null cost-per-outcome, not a fake 0', () => {
+    // Build a config whose only executable workload is chat (never accepted).
+    const chatOnly = {
+      ...TINY_TEST_CONFIG,
+      id: 'chat-only-v1',
+      workloads: ['chat'] as const,
+      targets: [{ lane: 'fireworks', engine: 'provider-native' } as const],
+    }
+    const report = buildBenchmarkReport(
+      runBenchmark(chatOnly, makeFixtureLaneSeam()),
+    )
+    const fireworks = report.groups.find(g => g.lane === 'fireworks')!
+    expect(fireworks.acceptedOutcomes).toBe(0)
+    expect(fireworks.verificationRate).toBeNull()
+    expect(fireworks.costPerAcceptedOutcomeMsat).toBeNull()
+    // Cost basis is still measured even with no accepted outcome (the finding:
+    // money spent, nothing accepted).
+    expect(fireworks.totalCostBasisMsat).toBeGreaterThan(0)
+  })
+
+  test('cache hit rate reflects cached input tokens / prompt tokens', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam()),
+    )
+    const fireworks = report.groups.find(g => g.lane === 'fireworks')!
+    // 500 cacheable prefix × 0.8 hit = 400 cached, over a 1000-token prompt = 0.4.
+    expect(fireworks.cacheHitRate).toBeCloseTo(0.4, 6)
+  })
+
+  test('latency percentiles populate for streaming, sample count matches', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam()),
+    )
+    const fireworks = report.groups.find(g => g.lane === 'fireworks')!
+    expect(fireworks.ttftMs.sampleCount).toBe(4)
+    expect(fireworks.ttftMs.p50).not.toBeNull()
+    expect(fireworks.ttftMs.p99).not.toBeNull()
+    expect(fireworks.perceivedTps.p50).not.toBeNull()
+  })
+
+  test('report ordering is deterministic and byte-stable', () => {
+    const a = buildBenchmarkReport(
+      runBenchmark(SAMPLE_DECISION_SUITE_CONFIG, makeFixtureLaneSeam()),
+    )
+    const b = buildBenchmarkReport(
+      runBenchmark(SAMPLE_DECISION_SUITE_CONFIG, makeFixtureLaneSeam()),
+    )
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+  })
+})
+
+describe('benchmark report — honesty + public-safety', () => {
+  test('a fixture-lane report is NOT decision-grade and carries the illustrative notice', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(SAMPLE_DECISION_SUITE_CONFIG, makeFixtureLaneSeam()),
+    )
+    expect(report.seamId).toBe('fixture')
+    expect(report.decisionGrade).toBe(false)
+    expect(report.illustrativeNotice).toContain('ILLUSTRATIVE ONLY')
+    expect(report.illustrativeNotice).toContain('REALISTIC')
+  })
+
+  test('synthetic-only groups are flagged', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(SAMPLE_DECISION_SUITE_CONFIG, makeFixtureLaneSeam()),
+    )
+    expect(report.groups.every(g => g.syntheticOnly)).toBe(true)
+  })
+
+  test('even an owner-armed real seam over SYNTHETIC shapes is not decision-grade', () => {
+    // A real (canSpend) seam, but the shapes are still synthetic → the synthetic
+    // guard keeps the report out of decision-grade. Real numbers need real traffic.
+    const armedRealSeam = makeRealLaneSeam({
+      armRealSweep: true,
+      executor: (cell, sampleIndex) => ({
+        promptTokens: cell.shape.inputTokens,
+        completionTokens: cell.shape.outputTokens,
+        totalTokens: cell.shape.inputTokens + cell.shape.outputTokens,
+        cachedInputTokens: 0,
+        ttftMs: 100 + sampleIndex,
+        totalWallClockMs: 500,
+        generationWallClockMs: 400,
+        providerTimeMs: 480,
+        gatewayOverheadMs: 20,
+        verificationClass: 'test_passed',
+        executedVerdict: 'passed',
+        scalarReward: 1,
+        verifierTimeMs: 100,
+        costBasisMsat: 100,
+        region: cell.lane,
+      }),
+    })
+    const report = buildBenchmarkReport(
+      runBenchmark(TINY_TEST_CONFIG, armedRealSeam),
+    )
+    expect(report.seamId).toBe('real')
+    // Synthetic shapes → never decision-grade, even with a real seam.
+    expect(report.decisionGrade).toBe(false)
+  })
+
+  test('the report is public-safe — no raw prompt/account/price/secret keys', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(SAMPLE_DECISION_SUITE_CONFIG, makeFixtureLaneSeam()),
+    )
+    const safety = checkReportPublicSafety(report)
+    expect(safety.violations).toEqual([])
+    expect(safety.safe).toBe(true)
+  })
+
+  test('the public-safety check actually trips on a forbidden key (guard is real)', () => {
+    const report = buildBenchmarkReport(
+      runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam()),
+    )
+    // Inject a forbidden field to prove the tripwire fires.
+    const tampered = { ...report, leakedPrompt: 'do the thing' } as never
+    const safety = checkReportPublicSafety(tampered)
+    expect(safety.safe).toBe(false)
+    expect(safety.violations).toContain('prompt')
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/benchmark/report.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/report.ts
@@ -1,0 +1,349 @@
+// The dereferenceable benchmark REPORT (book P1-5 / #6088).
+//
+// Aggregates a `BenchmarkRunSet` into per-lane / per-workload metrics — the
+// book's "best is product-specific, MEASURED" framing turned into a typed
+// artifact. The report answers "faster/cheaper/better at WHAT" with:
+//   - latency PERCENTILES (P50/P90/P99 — book Ch.1 §1.4.1: a right-skewed
+//     distribution where the mean lies; outliers are the product risk);
+//   - perceived TPS (completion tokens / generation wall-clock);
+//   - COST-PER-ACCEPTED-OUTCOME (msat cost / accepted outcomes — the only cost
+//     metric that respects verification: a cheap lane that fails verification is
+//     not cheap);
+//   - VERIFICATION RATE (executed-passed / executed-attempted — P1-5's headline:
+//     score on outcome, not raw token speed);
+//   - cache hit rate (book P0-2).
+//
+// PUBLIC-SAFE (INVARIANTS: no raw prompt/account/secret in any projection). The
+// report carries ONLY token COUNTS, durations, neutral lane/engine/workload
+// classifiers, the coarse region, and the aggregate metrics. It NEVER carries a
+// prompt, completion, account ref, raw cache key, price, or margin. A
+// `publicSafety` self-check (below) asserts this structurally.
+//
+// HONESTY: the report header records the seam that produced it. When the seam is
+// the fixture lane (`seamCanSpend: false`), every number is labeled ILLUSTRATIVE
+// and `decisionGrade: false` — they prove the harness, not the lanes. Only an
+// owner-armed real sweep over REALISTIC traffic yields `decisionGrade: true`. A
+// group whose shapes are all synthetic is flagged `syntheticOnly: true`
+// regardless of seam.
+//
+// PURE: no clock, no randomness, no IO. Same run set → same report.
+import { type MeasuredNumber, isMeasured } from '../khala-telemetry'
+import type { BenchmarkRun, BenchmarkRunSet } from './runner'
+import type { BenchmarkLane, BenchmarkWorkload } from './matrix'
+
+// ---------------------------------------------------------------------------
+// Percentile helper (book Ch.1 §1.4.1).
+// ---------------------------------------------------------------------------
+
+// Nearest-rank percentile over a sample array. Returns null for an empty input
+// (honest absence, never a fabricated 0). `p` is in [0,100]. PURE: sorts a copy.
+export const percentile = (
+  values: ReadonlyArray<number>,
+  p: number,
+): number | null => {
+  if (values.length === 0) {
+    return null
+  }
+  const sorted = [...values].sort((a, b) => a - b)
+  if (sorted.length === 1) {
+    return sorted[0] ?? null
+  }
+  // Nearest-rank: rank = ceil(p/100 * N), clamped to [1, N].
+  const rank = Math.min(
+    sorted.length,
+    Math.max(1, Math.ceil((p / 100) * sorted.length)),
+  )
+  return sorted[rank - 1] ?? null
+}
+
+// Arithmetic mean, null for empty. PURE.
+export const mean = (values: ReadonlyArray<number>): number | null => {
+  if (values.length === 0) {
+    return null
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+// Collect the measured numeric values of one telemetry field across runs,
+// dropping the honest `not_measured` sentinel (so percentiles are over MEASURED
+// samples only — never polluted by a sentinel coerced to a number).
+const measuredValues = (
+  runs: ReadonlyArray<BenchmarkRun>,
+  pick: (record: NonNullable<BenchmarkRun['record']>) => MeasuredNumber,
+): ReadonlyArray<number> => {
+  const out: Array<number> = []
+  for (const run of runs) {
+    if (run.record === null) {
+      continue
+    }
+    const value = pick(run.record)
+    if (isMeasured(value)) {
+      out.push(value)
+    }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Per-group aggregate metrics.
+// ---------------------------------------------------------------------------
+
+// The latency distribution summary for one field (ms). Each percentile is null
+// when no sample measured the field (e.g. TTFT on a pure batch group).
+export type LatencySummary = Readonly<{
+  p50: number | null
+  p90: number | null
+  p99: number | null
+  mean: number | null
+  // Number of MEASURED samples behind this summary (the read confidence).
+  sampleCount: number
+}>
+
+const summarize = (values: ReadonlyArray<number>): LatencySummary => ({
+  p50: percentile(values, 50),
+  p90: percentile(values, 90),
+  p99: percentile(values, 99),
+  mean: mean(values),
+  sampleCount: values.length,
+})
+
+// The aggregate metrics for one (lane × workload) group.
+export type BenchmarkGroupMetrics = Readonly<{
+  lane: BenchmarkLane
+  workload: BenchmarkWorkload
+  laneAvailability: 'available' | 'not_yet_available'
+  // True when EVERY shape in this group is synthetic (numbers are not
+  // production-representative — book §4.5). Labeled prominently.
+  syntheticOnly: boolean
+  // How many samples were EXECUTED (telemetry record produced) vs SKIPPED (a
+  // not-yet-available lane). Skipped samples carry no metrics.
+  executedSamples: number
+  skippedSamples: number
+  // Latency distributions (book Ch.1 percentiles).
+  ttftMs: LatencySummary
+  totalWallClockMs: LatencySummary
+  perceivedTps: LatencySummary
+  interTokenLatencyMs: LatencySummary
+  // Cache hit rate: cached input tokens / prompt tokens, averaged over executed
+  // samples that measured both. null when unmeasured.
+  cacheHitRate: number | null
+  // VERIFICATION RATE: executed-passed / executed-attempted (a verdict that is
+  // not `not_executed`). null when the group has no verification (e.g. chat).
+  verificationRate: number | null
+  acceptedOutcomes: number
+  attemptedVerifications: number
+  // COST-PER-ACCEPTED-OUTCOME in msat: total cost basis / accepted outcomes.
+  // null when there were zero accepted outcomes (dividing would fabricate a
+  // number — a lane with no accepted outcome has UNDEFINED cost-per-outcome,
+  // which is itself a finding, not a 0).
+  costPerAcceptedOutcomeMsat: number | null
+  totalCostBasisMsat: number
+}>
+
+// Aggregate one group's runs into metrics. PURE.
+const aggregateGroup = (
+  lane: BenchmarkLane,
+  workload: BenchmarkWorkload,
+  runs: ReadonlyArray<BenchmarkRun>,
+): BenchmarkGroupMetrics => {
+  const executed = runs.filter(run => run.record !== null)
+  const skipped = runs.filter(run => run.record === null)
+  const laneAvailability =
+    runs[0]?.cell.laneAvailability ?? 'available'
+  const syntheticOnly =
+    runs.length > 0 &&
+    runs.every(run => run.cell.shape.provenance === 'synthetic')
+
+  // Verification: count attempted (an executed verdict) and accepted (passed).
+  let attemptedVerifications = 0
+  let acceptedOutcomes = 0
+  let totalCostBasisMsat = 0
+  const cacheRates: Array<number> = []
+
+  for (const run of executed) {
+    const record = run.record
+    if (record === null) {
+      continue
+    }
+    if (record.executedVerdict !== 'not_executed') {
+      attemptedVerifications += 1
+      if (record.executedVerdict === 'passed') {
+        acceptedOutcomes += 1
+      }
+    }
+    if (isMeasured(record.costBasisMsat)) {
+      totalCostBasisMsat += record.costBasisMsat
+    }
+    if (
+      isMeasured(record.cachedInputTokens) &&
+      isMeasured(record.promptTokens) &&
+      record.promptTokens > 0
+    ) {
+      cacheRates.push(record.cachedInputTokens / record.promptTokens)
+    }
+  }
+
+  return {
+    lane,
+    workload,
+    laneAvailability,
+    syntheticOnly,
+    executedSamples: executed.length,
+    skippedSamples: skipped.length,
+    ttftMs: summarize(measuredValues(executed, r => r.ttftMs)),
+    totalWallClockMs: summarize(
+      measuredValues(executed, r => r.totalWallClockMs),
+    ),
+    perceivedTps: summarize(measuredValues(executed, r => r.perceivedTps)),
+    interTokenLatencyMs: summarize(
+      measuredValues(executed, r => r.interTokenLatencyMs),
+    ),
+    cacheHitRate: mean(cacheRates),
+    verificationRate:
+      attemptedVerifications === 0
+        ? null
+        : acceptedOutcomes / attemptedVerifications,
+    acceptedOutcomes,
+    attemptedVerifications,
+    costPerAcceptedOutcomeMsat:
+      acceptedOutcomes === 0
+        ? null
+        : totalCostBasisMsat / acceptedOutcomes,
+    totalCostBasisMsat,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The full report artifact.
+// ---------------------------------------------------------------------------
+
+export type BenchmarkReport = Readonly<{
+  schemaVersion: 'openagents.khala.benchmark-report.v1'
+  configId: string
+  seamId: string
+  // True only when an owner-armed REAL sweep over REALISTIC traffic produced
+  // this report. Fixture-lane reports are NOT decision-grade.
+  decisionGrade: boolean
+  // The honest illustrative banner the report carries when not decision-grade.
+  // Empty string when decision-grade.
+  illustrativeNotice: string
+  cellsExpanded: number
+  cellsExecuted: number
+  cellsSkipped: number
+  // Per (lane × workload) metrics, in deterministic (lane, workload) order.
+  groups: ReadonlyArray<BenchmarkGroupMetrics>
+}>
+
+const ILLUSTRATIVE_NOTICE =
+  'ILLUSTRATIVE ONLY: produced by the deterministic FIXTURE lane (no network, ' +
+  'no spend). These numbers exercise the harness and report math; they are NOT ' +
+  'measurements of any real lane. Decision-grade numbers require an owner-armed ' +
+  'real sweep over REALISTIC Khala traffic (real input/output lengths, real ' +
+  'cacheable prefixes, real concurrency). Synthetic-only traffic is labeled as ' +
+  'such per group and is never a basis for a product claim.'
+
+// Stable ordering of lanes + workloads so the report group list is byte-stable.
+const LANE_ORDER: ReadonlyArray<BenchmarkLane> = [
+  'vertex-anthropic',
+  'vertex-gemini',
+  'fireworks',
+  'partner-passthrough',
+  'pylon-whole-small',
+  'psionic-shard-wan',
+]
+const WORKLOAD_ORDER: ReadonlyArray<BenchmarkWorkload> = [
+  'chat',
+  'khala-code-artifact-gen',
+  'verifier-run',
+  'long-context-codebase-question',
+]
+
+// Build the report from a run set. A report is decision-grade ONLY when the seam
+// can spend (a real sweep) AND no group is synthetic-only. PURE.
+export const buildBenchmarkReport = (
+  runSet: BenchmarkRunSet,
+): BenchmarkReport => {
+  // Bucket runs by (lane, workload).
+  const buckets = new Map<string, Array<BenchmarkRun>>()
+  for (const run of runSet.runs) {
+    const key = `${run.cell.lane}::${run.cell.workload}`
+    const existing = buckets.get(key)
+    if (existing === undefined) {
+      buckets.set(key, [run])
+    } else {
+      existing.push(run)
+    }
+  }
+
+  const groups: Array<BenchmarkGroupMetrics> = []
+  for (const lane of LANE_ORDER) {
+    for (const workload of WORKLOAD_ORDER) {
+      const runs = buckets.get(`${lane}::${workload}`)
+      if (runs === undefined || runs.length === 0) {
+        continue
+      }
+      groups.push(aggregateGroup(lane, workload, runs))
+    }
+  }
+
+  const anySynthetic = groups.some(group => group.syntheticOnly)
+  const decisionGrade = runSet.seamCanSpend && !anySynthetic
+
+  return {
+    schemaVersion: 'openagents.khala.benchmark-report.v1',
+    configId: runSet.configId,
+    seamId: runSet.seamId,
+    decisionGrade,
+    illustrativeNotice: decisionGrade ? '' : ILLUSTRATIVE_NOTICE,
+    cellsExpanded: runSet.cellsExpanded,
+    cellsExecuted: runSet.cellsExecuted,
+    cellsSkipped: runSet.cellsSkipped,
+    groups,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public-safety self-check (INVARIANTS: no raw prompt/account/secret leakage).
+// ---------------------------------------------------------------------------
+
+// The forbidden substrings a public benchmark report must NEVER contain. This is
+// a STRUCTURAL guard, not intent routing: it scans the serialized report for
+// field names / values that would indicate a prompt, account, raw cache key,
+// price, or margin leaked in. The report is built only from counts/durations/
+// classifiers, so this should always pass — it is a regression tripwire.
+const FORBIDDEN_REPORT_KEYS: ReadonlyArray<string> = [
+  'prompt',
+  'completion',
+  'message',
+  'content',
+  'account',
+  'apikey',
+  'api_key',
+  'token:', // a raw token value, not the "...Tokens" count fields
+  'cacheaffinitykey', // the raw key (the hash never appears in the report)
+  'pricemsat',
+  'margin',
+  'mnemonic',
+  'secret',
+]
+
+export type ReportPublicSafety = Readonly<{
+  safe: boolean
+  violations: ReadonlyArray<string>
+}>
+
+// Assert a report is public-safe. Serializes it and checks no forbidden key
+// appears. Returns the violations rather than throwing so a test can assert the
+// empty list and a caller can decide. PURE.
+export const checkReportPublicSafety = (
+  report: BenchmarkReport,
+): ReportPublicSafety => {
+  const serialized = JSON.stringify(report).toLowerCase()
+  const violations: Array<string> = []
+  for (const key of FORBIDDEN_REPORT_KEYS) {
+    if (serialized.includes(key)) {
+      violations.push(key)
+    }
+  }
+  return { safe: violations.length === 0, violations }
+}

--- a/apps/openagents.com/workers/api/src/inference/benchmark/runner.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/runner.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest'
+
+import { isMeasured } from '../khala-telemetry'
+import { SAMPLE_DECISION_SUITE_CONFIG, TINY_TEST_CONFIG } from './fixtures'
+import { makeFixtureLaneSeam } from './lane-seam'
+import { runBenchmark } from './runner'
+
+describe('benchmark runner — fixture lane', () => {
+  test('produces samplesPerCell runs per executable cell, one skipped run per future lane', () => {
+    const runSet = runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam())
+    // 2 cells expanded (fireworks available, pylon not-yet-available).
+    expect(runSet.cellsExpanded).toBe(2)
+    expect(runSet.cellsExecuted).toBe(1)
+    expect(runSet.cellsSkipped).toBe(1)
+    // fireworks: 4 samples; pylon: 1 skipped run.
+    expect(runSet.runs.length).toBe(5)
+    const executed = runSet.runs.filter(r => r.record !== null)
+    const skipped = runSet.runs.filter(r => r.record === null)
+    expect(executed.length).toBe(4)
+    expect(skipped.length).toBe(1)
+    expect(skipped[0]?.skippedReason).toBe(
+      'lane_not_yet_available:pylon-whole-small',
+    )
+  })
+
+  test('the run is deterministic (same config + seam → identical run set)', () => {
+    const seam = makeFixtureLaneSeam()
+    const a = runBenchmark(TINY_TEST_CONFIG, seam)
+    const b = runBenchmark(TINY_TEST_CONFIG, seam)
+    expect(a).toEqual(b)
+  })
+
+  test('each executed run carries a canonical telemetry record with the P0-1 fields', () => {
+    const runSet = runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam())
+    const run = runSet.runs.find(r => r.record !== null)
+    expect(run).toBeDefined()
+    const record = run!.record!
+    expect(record.schemaVersion).toBe('openagents.khala.telemetry.v1')
+    // Token, latency, verification, and cost fields are all MEASURED.
+    expect(isMeasured(record.promptTokens)).toBe(true)
+    expect(isMeasured(record.completionTokens)).toBe(true)
+    expect(isMeasured(record.ttftMs)).toBe(true)
+    expect(isMeasured(record.totalWallClockMs)).toBe(true)
+    expect(isMeasured(record.perceivedTps)).toBe(true)
+    expect(isMeasured(record.costBasisMsat)).toBe(true)
+    expect(record.executedVerdict).toBe('passed')
+    expect(record.provider).toBe('fireworks')
+    expect(record.route).toBe('khala-code-artifact-gen')
+    // Reproducible, non-random request id.
+    expect(record.requestId).toBe(
+      'bench:tiny-test-v1:fireworks|provider-native|khala-code-artifact-gen|tiny-shape|streaming|t0|roff:s0',
+    )
+  })
+
+  test('a verifier-run cell is classed as verifier_run; chat as interactive_stream; batch as batch', () => {
+    const runSet = runBenchmark(SAMPLE_DECISION_SUITE_CONFIG, makeFixtureLaneSeam())
+    const executed = runSet.runs.filter(r => r.record !== null)
+    const verifier = executed.find(
+      r => r.cell.workload === 'verifier-run' && r.cell.transport === 'streaming',
+    )
+    const chat = executed.find(
+      r => r.cell.workload === 'chat' && r.cell.transport === 'streaming',
+    )
+    const batch = executed.find(r => r.cell.transport === 'batch')
+    expect(verifier!.record!.requestClass).toBe('verifier_run')
+    expect(chat!.record!.requestClass).toBe('interactive_stream')
+    expect(batch!.record!.requestClass).toBe('batch')
+  })
+
+  test('future lanes are NEVER executed against the seam (no fabricated numbers)', () => {
+    // A recording seam: the inner fixture runs available lanes, but it records
+    // every lane it was asked to sample, so we can assert it was NEVER called for
+    // a not-yet-available lane.
+    const inner = makeFixtureLaneSeam()
+    const sampledLanes = new Set<string>()
+    const recordingSeam = {
+      id: 'recording',
+      canSpend: false,
+      sample: (cell: Parameters<typeof inner.sample>[0], index: number) => {
+        sampledLanes.add(cell.lane)
+        return inner.sample(cell, index)
+      },
+    }
+    const runSet = runBenchmark(SAMPLE_DECISION_SUITE_CONFIG, recordingSeam)
+    const futureRuns = runSet.runs.filter(
+      r => r.cell.laneAvailability === 'not_yet_available',
+    )
+    expect(futureRuns.length).toBeGreaterThan(0)
+    expect(futureRuns.every(r => r.record === null)).toBe(true)
+    // The seam was asked to sample the available lanes, but NEVER a future lane.
+    expect(sampledLanes.has('fireworks')).toBe(true)
+    expect(sampledLanes.has('pylon-whole-small')).toBe(false)
+    expect(sampledLanes.has('psionic-shard-wan')).toBe(false)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/benchmark/runner.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/runner.ts
@@ -1,0 +1,161 @@
+// The benchmark RUNNER (book P1-5 / #6088).
+//
+// Executes a matrix config cell-by-cell against a pluggable `BenchmarkLaneSeam`,
+// and records the P0-1 telemetry RECORD per sample by feeding the seam's measured
+// sample straight into the canonical `buildKhalaTelemetryRecord`. The runner
+// REUSES the telemetry schema — it never forks a parallel metric vocabulary — so
+// a benchmark sample and a production request are described by the exact same
+// `openagents.khala.telemetry.v1` record. That is the whole point: the benchmark
+// measures the SAME lifecycle fields the gateway records in production.
+//
+// PURE/DETERMINISTIC with the fixture seam: same config + same seam → same runs.
+// No clock, no randomness, no network. The runner itself issues no IO; it only
+// drives the seam and assembles telemetry records. (A real, billable sweep is
+// achieved by passing the owner-armed real seam — gated in `lane-seam.ts`.)
+import {
+  type KhalaTelemetryRecord,
+  buildKhalaTelemetryRecord,
+} from '../khala-telemetry'
+import type { BenchmarkCell, BenchmarkMatrixConfig } from './matrix'
+import { expandMatrix } from './matrix'
+import type { BenchmarkLaneSeam } from './lane-seam'
+
+// One executed sample of one cell: the cell context + the canonical telemetry
+// record. A not-yet-available lane produces NO telemetry record (it was never
+// executed) — `record` is null and `skippedReason` says why.
+export type BenchmarkRun = Readonly<{
+  cellId: string
+  cell: BenchmarkCell
+  sampleIndex: number
+  // The canonical lifecycle record, or null when the cell was skipped (a
+  // not-yet-available lane is never executed — honest, not a fabricated zero).
+  record: KhalaTelemetryRecord | null
+  // Why a run was skipped; null when it executed.
+  skippedReason: string | null
+}>
+
+// The full result of running a matrix config against a seam.
+export type BenchmarkRunSet = Readonly<{
+  configId: string
+  // The seam that produced these runs ("fixture" | "real").
+  seamId: string
+  // Whether the seam that ran these was capable of real spend. The report
+  // surfaces this so a reader knows whether numbers are illustrative or real.
+  seamCanSpend: boolean
+  // Every (cell × sample) run, in deterministic matrix order.
+  runs: ReadonlyArray<BenchmarkRun>
+  // Cell-level coverage: how many cells expanded, executed, and were skipped.
+  cellsExpanded: number
+  cellsExecuted: number
+  cellsSkipped: number
+}>
+
+// Build a stable request id for a benchmark run. PURE (no UUID/clock): it encodes
+// the config, cell, and sample index so the same run always gets the same id —
+// reproducible and auditable, never a random handle.
+const buildRunRequestId = (
+  configId: string,
+  cellId: string,
+  sampleIndex: number,
+): string => `bench:${configId}:${cellId}:s${sampleIndex}`
+
+// Run a single sample of a cell against the seam and assemble its telemetry
+// record. A not-yet-available lane is NEVER executed against any seam — it yields
+// a skipped run (honest absence), because there is no real path to measure and we
+// refuse to fabricate one.
+const runSample = (
+  config: BenchmarkMatrixConfig,
+  cell: BenchmarkCell,
+  sampleIndex: number,
+  seam: BenchmarkLaneSeam,
+): BenchmarkRun => {
+  if (cell.laneAvailability === 'not_yet_available') {
+    return {
+      cellId: cell.cellId,
+      cell,
+      sampleIndex,
+      record: null,
+      skippedReason: `lane_not_yet_available:${cell.lane}`,
+    }
+  }
+
+  const sample = seam.sample(cell, sampleIndex)
+  const requestClass =
+    cell.transport === 'batch'
+      ? 'batch'
+      : cell.workload === 'verifier-run'
+        ? 'verifier_run'
+        : 'interactive_stream'
+
+  const record = buildKhalaTelemetryRecord({
+    requestId: buildRunRequestId(config.id, cell.cellId, sampleIndex),
+    requestedModel: `${cell.lane}/${cell.engine}`,
+    servedModel: `${cell.lane}/${cell.engine}`,
+    route: cell.workload,
+    provider: cell.lane,
+    requestClass,
+    promptTokens: sample.promptTokens,
+    completionTokens: sample.completionTokens,
+    totalTokens: sample.totalTokens,
+    cachedInputTokens: sample.cachedInputTokens,
+    ttftMs: cell.transport === 'streaming' ? sample.ttftMs : undefined,
+    totalWallClockMs: sample.totalWallClockMs,
+    generationWallClockMs: sample.generationWallClockMs,
+    providerTimeMs: sample.providerTimeMs,
+    gatewayOverheadMs: sample.gatewayOverheadMs,
+    verifierTimeMs:
+      sample.verifierTimeMs > 0 ? sample.verifierTimeMs : undefined,
+    region: sample.region,
+    verificationClass: sample.verificationClass,
+    executedVerdict: sample.executedVerdict,
+    scalarReward: sample.scalarReward,
+    costBasisMsat: sample.costBasisMsat,
+    // The benchmark measures COST basis; it does not set a price (pricing is a
+    // separate product concern). Margin bucket therefore stays `not_measured`.
+    settlementState: 'not_applicable',
+  })
+
+  return {
+    cellId: cell.cellId,
+    cell,
+    sampleIndex,
+    record,
+    skippedReason: null,
+  }
+}
+
+// Run an entire matrix config against a seam. Expands the matrix deterministically,
+// then runs `samplesPerCell` samples of each executable cell (one skipped run for
+// each not-yet-available cell). PURE with the fixture seam.
+export const runBenchmark = (
+  config: BenchmarkMatrixConfig,
+  seam: BenchmarkLaneSeam,
+): BenchmarkRunSet => {
+  const cells = expandMatrix(config)
+  const runs: Array<BenchmarkRun> = []
+  let cellsExecuted = 0
+  let cellsSkipped = 0
+
+  for (const cell of cells) {
+    if (cell.laneAvailability === 'not_yet_available') {
+      cellsSkipped += 1
+      runs.push(runSample(config, cell, 0, seam))
+      continue
+    }
+    cellsExecuted += 1
+    const samples = Math.max(1, Math.floor(cell.samplesPerCell))
+    for (let sampleIndex = 0; sampleIndex < samples; sampleIndex += 1) {
+      runs.push(runSample(config, cell, sampleIndex, seam))
+    }
+  }
+
+  return {
+    configId: config.id,
+    seamId: seam.id,
+    seamCanSpend: seam.canSpend,
+    runs,
+    cellsExpanded: cells.length,
+    cellsExecuted,
+    cellsSkipped,
+  }
+}

--- a/docs/inference/2026-06-23-khala-benchmark-harness-book-p1-5.md
+++ b/docs/inference/2026-06-23-khala-benchmark-harness-book-p1-5.md
@@ -1,0 +1,166 @@
+# Khala provider/engine benchmark harness — book P1-5 / #6088
+
+*2026-06-23. This note ties the new typed Khala benchmark harness to the
+inference-engineering book's P1-5 ("build a provider and engine benchmark
+matrix") and Open Question #5 (the minimum lane decision suite). It is the
+fixture-driven, no-spend foundation for an eventual owner-armed real sweep.*
+
+## What the book asked for (P1-5)
+
+The book's Ch.4 §4.5 lesson is that **"faster" is meaningless until you say
+faster at *what*** — TTFT vs inter-token latency / perceived TPS vs throughput vs
+cost vs verification rate — on **which lane**, under **which traffic shape**,
+judged on **which outcome**. A benchmark is therefore not an ad-hoc script with
+hard-coded numbers; it is a **matrix** that varies the dimensions production
+actually exhibits, and the **best benchmark shadows real production traffic**.
+Synthetic traffic is useful only insofar as it matches the real input/output
+lengths, prompt contents, cache behaviour, and concurrency the system sees
+(§4.5: "if you're maximizing benchmark performance against bad inputs,
+performance in production won't match expectations"). Latency must be read in
+**percentiles** (Ch.1 §1.4.1) because the inference time distribution is
+right-skewed — the mean hides the P90/P99 outliers that erode user trust.
+
+P1-5 also folds in the notes' Open Question #5: *what is the minimum benchmark
+suite for deciding between Fireworks, Vertex, Pylon whole-small, and later
+shard-WAN lanes?*
+
+## What shipped
+
+A typed benchmark harness under
+`apps/openagents.com/workers/api/src/inference/benchmark/`. It is pure,
+framework-agnostic, deterministic, and reuses the merged P0-1 telemetry schema
+(`openagents.khala.telemetry.v1`) rather than forking a parallel metric
+vocabulary.
+
+### 1. The matrix (`matrix.ts`)
+
+A declarative, typed cross-product spec that varies exactly the book's
+dimensions:
+
+- **lane** — `vertex-anthropic`, `vertex-gemini`, `fireworks`,
+  `partner-passthrough` (real today), plus `pylon-whole-small` and
+  `psionic-shard-wan` (named but **not-yet-available** future lanes). A single
+  `LANE_AVAILABILITY` table is the source of truth for which lanes are real;
+  unbuilt lanes are still first-class matrix axes so the decision suite is shaped
+  for them, but they are never measured.
+- **engine** — `provider-native`, `vllm`, `sglang`, `tensorrt-llm`. Engines are
+  *paired* with lanes (not blindly crossed) so impossible cells (e.g. a managed
+  provider on our own vLLM) are never fabricated.
+- **workload** — `chat`, `khala-code-artifact-gen`, `verifier-run`,
+  `long-context-codebase-question`.
+- **sequence shape** — input length (ISL), output length (OSL), cacheable prefix
+  length, and concurrency — each shape tagged `realistic` or `synthetic`.
+- **streaming vs batch** transport, and **temperature / reasoning effort**.
+- **verification outcome** — the expected verification class is *derived from the
+  workload* (chat → `none`; artifact-gen/verifier → executed `test_passed`;
+  long-context → `seeded`), so every cell is scored on outcome, not just token
+  speed.
+
+`expandMatrix` deterministically expands a config into ordered cells with a
+stable, axis-encoded `cellId`; `expectedCellCount` is the cross-product
+cardinality used to assert coverage.
+
+### 2. The runner + pluggable lane seam (`runner.ts`, `lane-seam.ts`)
+
+The runner executes each cell against a pluggable **`BenchmarkLaneSeam`** and
+records a canonical `KhalaTelemetryRecord` per sample (TTFT, tokens, wall-clock,
+cached tokens, perceived TPS / ITL, verification class + executed verdict +
+reward, cost basis). Two seams exist:
+
+- **`makeFixtureLaneSeam` (default)** — fully deterministic, network-free,
+  spend-free. It derives every sample arithmetically from the cell + a per-lane
+  fixture profile (no clock, no randomness), so the same config always produces
+  the same runs. A small index-keyed jitter spreads repeated samples so
+  percentiles are non-degenerate. `canSpend: false` always.
+- **`makeRealLaneSeam` (flag/owner-gated, default OFF)** — the seam that *would*
+  hit a live provider adapter and measure a real, billable request. It is armed
+  only by an explicit `armRealSweep: true` **and** an injected live executor;
+  absent that it throws `RealLaneNotArmedError` and reports `canSpend: false`, so
+  a test or an un-armed environment can **never** issue a billable request. This
+  module implements the **gate**, not the live calls — the live provider sweep is
+  the owner-armed work.
+
+A **not-yet-available** lane is never executed against any seam: the runner emits
+a skipped run with a `lane_not_yet_available:<lane>` reason and a null telemetry
+record (honest absence, never a fabricated zero).
+
+### 3. The dereferenceable report (`report.ts`)
+
+`buildBenchmarkReport` aggregates a run set into per-`(lane × workload)` metrics —
+the book's "best is product-specific, *measured*" framing as a typed artifact:
+
+- **latency percentiles** (P50 / P90 / P99 + mean) for TTFT, total wall-clock,
+  perceived TPS, and inter-token latency, over *measured* samples only (the
+  `not_measured` sentinel is dropped, never coerced to a number);
+- **cost-per-accepted-outcome** (msat) = total cost basis / accepted outcomes —
+  the only cost metric that respects verification: a cheap lane that fails
+  verification is not cheap. A group with **zero** accepted outcomes has a
+  **null** cost-per-outcome (a finding — money spent, nothing accepted — not a
+  fake 0);
+- **verification rate** = executed-passed / executed-attempted (null when the
+  group has no verification, e.g. chat);
+- **cache hit rate** = cached input tokens / prompt tokens (book P0-2).
+
+The report is **public-safe**: it carries only token counts, durations, neutral
+lane/engine/workload classifiers, the coarse region, and the aggregates — never a
+prompt, completion, account ref, raw cache key, price, or margin. A structural
+`checkReportPublicSafety` tripwire serializes the report and asserts no forbidden
+key (`prompt`, `account`, `pricemsat`, `margin`, `secret`, …) ever appears.
+
+### 4. Honesty — realistic traffic is required for the numbers to mean anything
+
+The report header records the seam that produced it. A fixture-lane report is
+`decisionGrade: false` and carries an `illustrativeNotice`: the numbers exercise
+the harness and report math; they are **not** measurements of any real lane. A
+report is decision-grade **only** when an owner-armed real seam ran over
+**realistic** traffic (real input/output lengths, real cacheable prefixes, real
+concurrency) **and** no group is synthetic-only. Even an owner-armed real seam
+run over synthetic shapes stays out of decision-grade — real numbers need real
+traffic. Each group is independently flagged `syntheticOnly`.
+
+### Minimum decision suite (Open Question #5)
+
+`fixtures.ts` ships `SAMPLE_DECISION_SUITE_CONFIG` — the minimum lane decision
+suite shape: Fireworks vs Vertex-Anthropic on chat / khala-code / verifier /
+long-context, with Pylon whole-small and Psionic shard-WAN as labeled future
+lanes, over three synthetic shapes (short chat, large-prefix code artifact,
+32k-context codebase question), both transports, two sampling settings, 5 samples
+per cell (book §4.5.2: enough traffic to read percentiles, not be swayed by one
+outlier). Running it through the fixture lane produces the first dereferenceable
+report comparing Fireworks vs Vertex on chat + khala-code — **illustrative**
+until real traffic and an owner-armed sweep replace the synthetic shapes.
+
+## What is fixture-proven vs owner-gated
+
+- **Fixture-proven (no spend, in CI):** the matrix expands to the expected cells;
+  the fixture runner is deterministic and records canonical telemetry records;
+  the report aggregation (percentiles, cost-per-accepted-outcome, verification
+  rate, cache hit rate) is correct on a hand-checkable fixture set; the real-lane
+  seam is flag-gated OFF by default and refuses to sample unarmed; the report is
+  public-safe and labeled non-decision-grade for fixture/synthetic runs.
+- **Owner-gated (real spend, NOT in this change):** arming `makeRealLaneSeam`
+  with a live provider executor, sourcing **realistic** Khala traffic shapes from
+  observed production traffic, and running the suite for real, billable numbers
+  that earn `decisionGrade: true`.
+
+## Owner step for a real sweep
+
+1. Replace the synthetic `SequenceShape`s with shapes sourced from **real
+   observed Khala traffic** (provenance `realistic`).
+2. Provide a live `RealLaneExecutor` that drives the production provider adapters
+   and measures real samples.
+3. Construct `makeRealLaneSeam({ armRealSweep: true, executor })` with explicit
+   owner confirmation (this is the only path that can spend), run the suite, and
+   publish the now-`decisionGrade` report.
+
+## Verification bar (green)
+
+The inference test suites (742 tests, 39 new under `benchmark/`), `typecheck`,
+`check:architecture`, `check:effect-topology`, and
+`check:public-projection-freshness`.
+
+## Scope / boundaries
+
+New module under `workers/api/src/inference/benchmark/` only. No proof /
+claim-upgrade, settlement, Psionic, Pylon-runtime, or autopilot-desktop changes;
+no new routes; the telemetry schema is reused, never forked.

--- a/docs/inference/inference-engineering-book/IMPLEMENTATION_LOG.md
+++ b/docs/inference/inference-engineering-book/IMPLEMENTATION_LOG.md
@@ -167,3 +167,64 @@ Conventions:
   follow-on, unchanged here).
 - **Status:** PR open against `main` (#6086); orchestrator reviews / merges /
   deploys / smokes. NOT deployed by this entry.
+
+---
+
+## P1-5 — Build a provider/engine benchmark matrix — DONE (PR open, #6088)
+
+- **Notes ref:** `khala-investigation-notes.md` §P1 item 5 ("Build A Provider
+  And Engine Benchmark Matrix") + Open Question #5 (minimum lane decision suite);
+  book Ch.4 §4.5 (software benchmarking — "faster at *what*", shadow real
+  traffic, match production sequence shapes/contents/concurrency, change one
+  variable at a time) and Ch.1 §1.4.1 (latency percentiles over a right-skewed
+  distribution). Consumes the P0-1 telemetry schema (#6085) and the P0-2 prefix
+  cache (#6084).
+- **What shipped (the four deliverables):**
+  1. **Typed matrix** (`benchmark/matrix.ts`) varying lane (Vertex-Anthropic /
+     Vertex-Gemini / Fireworks / partner-passthrough real; Pylon whole-small /
+     Psionic shard-WAN labeled `not_yet_available`), engine (provider-native /
+     vLLM / SGLang / TensorRT-LLM, paired to lanes), workload (chat /
+     khala-code-artifact-gen / verifier-run / long-context-codebase-question),
+     sequence shape (ISL / OSL / cacheable-prefix / concurrency, tagged
+     realistic|synthetic), streaming-vs-batch, temperature/reasoning, and the
+     verification expectation *derived from the workload*. `expandMatrix` is
+     deterministic with a stable axis-encoded `cellId`.
+  2. **Runner + pluggable seam** (`benchmark/runner.ts`, `lane-seam.ts`): records
+     a canonical `openagents.khala.telemetry.v1` record per sample (reuses the
+     schema, never forks). Default = a deterministic, network-free, spend-free
+     FIXTURE lane; a real-lane adapter (`makeRealLaneSeam`) is flag/owner-gated —
+     unarmed it throws `RealLaneNotArmedError` and `canSpend:false`, so no test or
+     un-armed env can ever issue a billable request. Not-yet-available lanes are
+     never executed (skipped run, null record, honest reason).
+  3. **Dereferenceable report** (`benchmark/report.ts`): per-(lane × workload)
+     latency percentiles (P50/P90/P99 + mean over *measured* samples only),
+     perceived TPS, cost-per-accepted-outcome (null when zero accepted — never a
+     fake 0), verification rate, cache hit rate. Public-safe (only counts /
+     durations / neutral classifiers / coarse region) with a structural
+     `checkReportPublicSafety` tripwire.
+  4. **Realistic-traffic honesty:** a fixture/synthetic report is
+     `decisionGrade:false` + carries an `illustrativeNotice`; decision-grade
+     requires an owner-armed REAL seam over REALISTIC traffic with no
+     synthetic-only group. Each group independently flagged `syntheticOnly`.
+- **Where:** `apps/openagents.com/workers/api/src/inference/benchmark/`
+  (`matrix.ts`, `lane-seam.ts`, `runner.ts`, `report.ts`, `fixtures.ts`,
+  `index.ts` + `*.test.ts`). `fixtures.ts` ships `SAMPLE_DECISION_SUITE_CONFIG`
+  (the Q5 minimum decision suite: Fireworks vs Vertex on chat/code/verifier/
+  long-context + the two future lanes). Doc:
+  `docs/inference/2026-06-23-khala-benchmark-harness-book-p1-5.md`.
+- **Verification bar (green):** the inference test suites (742 tests, 39 new),
+  `typecheck`, `check:architecture`, `check:effect-topology`,
+  `check:public-projection-freshness`. Tests cover: the matrix expands to the
+  expected cells (192 for the decision suite); the fixture runner is deterministic
+  and produces telemetry records with the P0-1 fields; the report aggregation
+  (percentiles, cost-per-accepted-outcome, verification rate, cache hit rate) is
+  correct on a hand-checkable fixture set; the real-lane seam is flag-gated OFF by
+  default (no network); and the report is public-safe (the tripwire trips on a
+  forbidden key).
+- **Honest scope — fixture vs owner-gated:** every number is ILLUSTRATIVE today —
+  produced by the deterministic fixture lane over SYNTHETIC shapes. A real,
+  decision-grade sweep requires the owner to (1) source realistic Khala traffic
+  shapes, (2) provide a live `RealLaneExecutor`, (3) arm `makeRealLaneSeam` with
+  explicit confirmation and run it (the only path that can spend). NOT run here.
+- **Status:** PR open against `main` (#6088); orchestrator reviews / merges /
+  deploys / smokes. NOT deployed, NO spend by this entry.


### PR DESCRIPTION
Implements book **P1-5** — "Build a provider and engine benchmark matrix" (#6088). The book's Ch.4 §4.5 lesson — *"faster" is meaningless until you say faster at **what**, on **which lane**, under **which traffic shape**, judged on **which outcome*** — turned into a typed, deterministic, spend-free Khala benchmark harness under `apps/openagents.com/workers/api/src/inference/benchmark/`.

## Matrix dimensions (`matrix.ts`)

A declarative typed cross-product that varies exactly the book's dimensions:

- **lane** — `vertex-anthropic`, `vertex-gemini`, `fireworks`, `partner-passthrough` (real today) + `pylon-whole-small`, `psionic-shard-wan` (named but **`not_yet_available`**; first-class axes, never measured). One `LANE_AVAILABILITY` table is the source of truth.
- **engine** — `provider-native` / `vllm` / `sglang` / `tensorrt-llm`, *paired* to lanes so impossible cells are never fabricated.
- **workload** — chat / khala-code-artifact-gen / verifier-run / long-context-codebase-question.
- **sequence shape** — input len / output len / cacheable-prefix len / concurrency, each tagged `realistic` or `synthetic`.
- **streaming vs batch**, **temperature/reasoning**, and **verification outcome** (derived from the workload — scored on outcome, not just token speed).

`expandMatrix` is deterministic with a stable axis-encoded `cellId`.

## Fixture-vs-real seam (`lane-seam.ts`, `runner.ts`)

The runner records a canonical `openagents.khala.telemetry.v1` record per sample (**reuses** the P0-1 schema, never forks). Two seams:

- **Fixture lane (default)** — deterministic, network-free, **spend-free**; numbers derived arithmetically from cell + profile (no clock/randomness).
- **Real lane (flag/owner-gated, default OFF)** — `makeRealLaneSeam`; unarmed it throws `RealLaneNotArmedError` and `canSpend:false`, so no test or un-armed env can ever issue a billable request. This change implements the **gate**, not the live provider calls.

Not-yet-available lanes are never executed (skipped run, null record, honest reason).

## Report metrics (`report.ts`)

Per-`(lane × workload)`: latency **percentiles** (P50/P90/P99 + mean, over *measured* samples only — book Ch.1 §1.4.1), **perceived TPS**, **cost-per-accepted-outcome** (null when zero accepted — a finding, never a fake 0), **verification rate**, **cache hit rate** (P0-2). **Public-safe** (only counts/durations/neutral classifiers/coarse region) with a structural `checkReportPublicSafety` tripwire. A fixture/synthetic report is `decisionGrade:false` + carries an `illustrativeNotice`; **decision-grade requires an owner-armed real seam over realistic traffic** with no synthetic-only group.

`fixtures.ts` ships `SAMPLE_DECISION_SUITE_CONFIG` (Open Question #5 minimum suite: Fireworks vs Vertex on chat/code/verifier/long-context + the two future lanes).

## Tests (39 new; full inference suite 742 green)

- matrix expands to the expected cells (192 for the decision suite);
- the fixture runner is deterministic and produces telemetry records with the P0-1 fields;
- report aggregation (percentiles, cost-per-accepted-outcome, verification rate, cache hit rate) is correct on a hand-checkable fixture set;
- the real-lane seam is flag-gated OFF by default (no network in tests);
- the report is public-safe (the tripwire trips on a forbidden key).

Also green: `typecheck`, `check:architecture`, `check:effect-topology`, `check:public-projection-freshness`.

## What's fixture-proven vs owner-gated

- **Fixture-proven (no spend, in CI):** the full harness, telemetry plumbing, and report math — all numbers ILLUSTRATIVE.
- **Owner step for a real sweep:** (1) source realistic Khala traffic shapes (provenance `realistic`); (2) provide a live `RealLaneExecutor`; (3) construct `makeRealLaneSeam({ armRealSweep: true, executor })` with explicit owner confirmation and run it — the only path that can spend — to earn a `decisionGrade:true` report.

## Scope

New module + docs only (`docs/inference/2026-06-23-khala-benchmark-harness-book-p1-5.md` + the P1-5 IMPLEMENTATION_LOG entry). No proof/claim-upgrade, settlement, Psionic, Pylon-runtime, or autopilot-desktop changes; no new routes; telemetry schema reused, not forked. **No spend, no deploy** by this PR.

Closes #6088. **DO NOT auto-merge — orchestrator reviews/merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)