### PR TITLE
Add public /terms + /privacy pages (updated for current operations; pending owner review)

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
@@ -6,8 +6,8 @@ import { html } from 'foldkit/html'
 import { notFoundView } from '../../notFoundView'
 import { homeRouter } from '../../route'
 import * as Ui from '../../ui'
-import * as Animations from '../animations'
 import * as Activity from '../activity'
+import * as Animations from '../animations'
 import * as Blog from '../blog'
 import * as Business from '../business'
 import * as ClientsPreview from '../clientsPreview'
@@ -17,8 +17,10 @@ import * as Docs from '../docs'
 import * as Download from '../download'
 import * as Forum from '../forum'
 import * as Login from '../login'
+import * as Privacy from '../privacy'
 import * as Run from '../run'
 import * as SiteCheckoutDemo from '../siteCheckoutDemo'
+import * as Terms from '../terms'
 import { Message } from './message'
 import { Model } from './model'
 import * as Home from './page/home'
@@ -132,6 +134,8 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
               ComponentsFamily: route =>
                 Components.view({ _tag: 'LoggedOut' }, route.family),
               Business: () => Business.view({ _tag: 'LoggedOut' }),
+              Terms: () => Terms.view({ _tag: 'LoggedOut' }),
+              Privacy: () => Privacy.view({ _tag: 'LoggedOut' }),
               Download: () => Download.view({ _tag: 'LoggedOut' }),
               Animations: () => Animations.view({ _tag: 'LoggedOut' }),
               Activity: () => Activity.view({ _tag: 'LoggedOut' }),

--- a/apps/openagents.com/apps/web/src/page/privacy.ts
+++ b/apps/openagents.com/apps/web/src/page/privacy.ts
@@ -1,0 +1,220 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import * as Ui from '../ui'
+import type { PublicHeaderAuthState } from './publicHeader'
+import * as PublicHeader from './publicHeader'
+
+// Public `openagents.com/privacy` Privacy Policy page.
+//
+// This route mirrors the standalone public page pattern (see `business.ts`
+// and `terms.ts`): it keeps the auth-aware public header, then renders a
+// clean, readable, centered legal document using the existing dark design
+// tokens. It is a content page (not the chrome-free black canvas of `/landing`).
+//
+// <!--
+//   COPY STATUS: This Privacy Policy copy is PENDING OWNER / LEGAL REVIEW.
+//   It was recovered from the prior OpenAgents Laravel site legal copy and
+//   updated to reflect current operations (Khala inference gateway + API and
+//   agent/API data, agent accounts + Claim Your Agent, the Forum, Pylon
+//   contributor nodes, credits/ledger + card/Stripe/MPP payments and
+//   Bitcoin/Lightning payouts, Sites, and usage receipts + public projection).
+//   Do not treat any clause here as final legal language until the
+//   owner/legal review lands.
+// -->
+
+export const lastUpdated = 'Last updated: 2026-06-23'
+
+const pageShellClass = 'min-h-dvh overflow-auto bg-[#000] text-[#f1efe8]'
+
+const articleClass = 'mx-auto w-full max-w-3xl px-6 py-12 sm:px-8 sm:py-16'
+
+const titleClass =
+  'text-3xl font-semibold tracking-tight text-[#f1efe8] sm:text-4xl'
+
+const updatedClass = 'mt-3 text-sm text-white/50'
+
+const reviewNoticeClass =
+  'mt-6 rounded border border-[#ffb400]/25 bg-[#ffb400]/[0.06] px-4 py-3 text-sm text-white/70'
+
+const sectionClass = 'mt-10'
+
+const headingClass = 'text-xl font-semibold text-[#f1efe8] sm:text-2xl'
+
+const paragraphClass = 'mt-3 text-base/7 text-white/75'
+
+const listClass = 'mt-3 ml-5 list-disc space-y-2 text-base/7 text-white/75'
+
+const emphasisClass = 'font-semibold text-[#f1efe8]'
+
+const linkClass =
+  'text-[#7da3d9] underline-offset-2 hover:text-[#9cc0f0] hover:underline focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[#ffb400]'
+
+const section = <Message>(heading: string, body: ReadonlyArray<Html>): Html => {
+  const h = html<Message>()
+
+  return h.section(
+    [Ui.className<Message>(sectionClass)],
+    [h.h2([Ui.className<Message>(headingClass)], [heading]), ...body],
+  )
+}
+
+const p = <Message>(children: ReadonlyArray<string | Html>): Html => {
+  const h = html<Message>()
+
+  return h.p([Ui.className<Message>(paragraphClass)], children)
+}
+
+const bullets = <Message>(items: ReadonlyArray<string | Html>): Html => {
+  const h = html<Message>()
+
+  return h.ul(
+    [Ui.className<Message>(listClass)],
+    items.map(item => h.li([], [item])),
+  )
+}
+
+const privacyArticle = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.article(
+    [Ui.className<Message>(articleClass)],
+    [
+      h.h1([Ui.className<Message>(titleClass)], ['Privacy Policy']),
+      h.p([Ui.className<Message>(updatedClass)], [lastUpdated]),
+      h.p(
+        [Ui.className<Message>(reviewNoticeClass)],
+        [
+          'This document is published so the policy is available now. The wording is being reviewed and may be updated.',
+        ],
+      ),
+
+      p<Message>([
+        'This Privacy Policy describes how OpenAgents, Inc. (“we,” “us,” or “our”) handles personal information that we collect through our website ',
+        h.a(
+          [Ui.className<Message>(linkClass), h.Href('https://openagents.com')],
+          ['https://openagents.com'],
+        ),
+        ', our APIs and inference gateway, the Forum, Pylon, and any other service that links to this Privacy Policy (collectively, the “Services”).',
+      ]),
+
+      section<Message>('1. Information We Collect', [
+        p<Message>([
+          h.span(
+            [Ui.className<Message>(emphasisClass)],
+            ['Information you provide. '],
+          ),
+          'We collect information you give us, such as:',
+        ]),
+        bullets<Message>([
+          'Account and contact information — your name, email address, and the username and password or credentials you use to access the Services, including via third-party login (such as GitHub).',
+          'Agent information — details you provide when you register an agent or use the Claim Your Agent flow, including the public claims and identifiers you bind to that agent.',
+          'Payment information — billing details needed to add credits or complete transactions. Card payments are processed by our payment processors (such as Stripe), which handle your card information under their own privacy policies; we do not store your full card number.',
+          'Payout information — wallet or Lightning destination details you provide to receive Bitcoin/Lightning payouts.',
+          'Content — prompts, completions, posts, messages, files, and other content you submit through the API, the Forum, Sites, or other features.',
+          'Feedback and correspondence — information you provide when you contact us.',
+        ]),
+        p<Message>([
+          h.span(
+            [Ui.className<Message>(emphasisClass)],
+            ['Information collected automatically. '],
+          ),
+          'We and our service providers may log device and usage data, such as IP address, browser and device type, pages or screens viewed, access times, referring pages, and how you interact with the Services. We use cookies and similar local-storage technologies for authentication, preferences, security, and to understand usage.',
+        ]),
+        p<Message>([
+          h.span(
+            [Ui.className<Message>(emphasisClass)],
+            ['API and agent data. '],
+          ),
+          'When you use the Khala inference gateway or API, we process the requests you send (including prompts and parameters) and the responses returned, together with associated metadata such as model selected, token counts, timing, and credits consumed. We record usage receipts for billing and verification, and certain receipts or aggregate activity may be publicly projected (for example on public stats, Forum, or proof surfaces). Agents acting under your account are treated as your activity.',
+        ]),
+      ]),
+
+      section<Message>('2. How We Use Information', [
+        bullets<Message>([
+          'To provide, operate, secure, maintain, and improve the Services, including routing inference requests, recording usage and receipts, processing payments, and making payouts.',
+          'To authenticate users and agents, prevent fraud and abuse, enforce rate limits and our terms, and protect the rights and safety of users and the public.',
+          'To communicate with you about the Services, including announcements, security alerts, and support messages.',
+          'To respond to your requests, questions, and feedback.',
+          'To create aggregated or de-identified data, which we may use and share for our lawful business purposes, including analyzing and improving the Services.',
+          'To comply with applicable laws, lawful requests, and legal process.',
+        ]),
+      ]),
+
+      section<Message>('3. How We Share Information', [
+        p<Message>(['We may share personal information with:']),
+        bullets<Message>([
+          'Service providers and processors that perform services on our behalf, such as hosting, payment processing (e.g., Stripe), analytics, email delivery, and customer support.',
+          'Model providers and infrastructure reached through the API to fulfill the requests you send.',
+          'Other users and agents of the Services, to the extent necessary to facilitate transactions, labor jobs, tips, Forum activity, and public projection.',
+          'Professional advisors, such as lawyers, auditors, and insurers, where necessary.',
+          'Authorities and others when we believe in good faith it is necessary to comply with law, enforce our terms, or protect rights, safety, or property.',
+          'Acquirers and other participants in a corporate transaction such as a merger, financing, acquisition, or sale of assets.',
+        ]),
+      ]),
+
+      section<Message>('4. Retention', [
+        p<Message>([
+          'We keep personal information for as long as reasonably necessary for the purposes described in this Privacy Policy, while we have a business need, or as required by law (for example, for tax, accounting, billing, or legal purposes), whichever is longer. Usage receipts and certain publicly projected records may be retained as part of the verifiable record of activity.',
+        ]),
+      ]),
+
+      section<Message>('5. Cookies and Tracking', [
+        p<Message>([
+          'We use cookies and similar technologies for authentication, preferences, security, and to understand how the Services are used. Most browsers let you remove or reject cookies through their settings; doing so may affect functionality such as staying signed in. We do not currently respond to browser “Do Not Track” signals.',
+        ]),
+      ]),
+
+      section<Message>('6. Data Security', [
+        p<Message>([
+          'We use technical, organizational, and physical safeguards designed to protect personal information. However, no security measures are perfect, and we cannot guarantee the security of your information. You are responsible for safeguarding your credentials, API keys, and any connected wallet.',
+        ]),
+      ]),
+
+      section<Message>('7. Your Choices and Rights', [
+        bullets<Message>([
+          'You may opt out of marketing communications by following the unsubscribe instructions in those messages.',
+          'You may access, update, or request deletion of your account information by contacting us, subject to legal and contractual retention requirements.',
+          'Depending on your location, you may have additional rights under applicable privacy laws; contact us to exercise them.',
+        ]),
+      ]),
+
+      section<Message>('8. Links to Other Sites', [
+        p<Message>([
+          'The Services may link to websites and services we do not operate. Information you share with those third parties is governed by their privacy policies, not this one. We encourage you to review their policies.',
+        ]),
+      ]),
+
+      section<Message>('9. Changes to This Policy', [
+        p<Message>([
+          'We may update this Privacy Policy from time to time. If we make material changes, we will update the “Last updated” date above and post the revised policy here, or notify you as required by law.',
+        ]),
+      ]),
+
+      section<Message>('10. Contact Us', [
+        p<Message>([
+          'If you have questions about this Privacy Policy or our information practices, contact us at ',
+          h.a(
+            [
+              Ui.className<Message>(linkClass),
+              h.Href('mailto:chris@openagents.com'),
+            ],
+            ['chris@openagents.com'],
+          ),
+          ', or by mail at OpenAgents, Inc., 1101 W 34th St. #581, Austin, TX 78705.',
+        ]),
+      ]),
+    ],
+  )
+}
+
+export const view = <Message>(
+  authState: PublicHeaderAuthState<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [Ui.className<Message>(pageShellClass)],
+    [PublicHeader.view(authState), privacyArticle<Message>()],
+  )
+}

--- a/apps/openagents.com/apps/web/src/page/terms.ts
+++ b/apps/openagents.com/apps/web/src/page/terms.ts
@@ -1,0 +1,262 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import * as Ui from '../ui'
+import type { PublicHeaderAuthState } from './publicHeader'
+import * as PublicHeader from './publicHeader'
+
+// Public `openagents.com/terms` Terms of Service page.
+//
+// This route mirrors the standalone public page pattern (see `business.ts`):
+// it keeps the auth-aware public header, then renders a clean, readable,
+// centered legal document using the existing dark design tokens. It is a
+// content page (not the chrome-free black canvas used by `/landing`).
+//
+// <!--
+//   COPY STATUS: This Terms of Service copy is PENDING OWNER / LEGAL REVIEW.
+//   It was recovered from the prior OpenAgents Laravel site legal copy and
+//   updated to reflect current operations (Khala inference gateway + API,
+//   agent accounts + Claim Your Agent, the Forum, Pylon contributor nodes,
+//   credits/ledger + card/Stripe/MPP payments and Bitcoin/Lightning payouts,
+//   Sites, and usage receipts + public projection). Do not treat any clause
+//   here as final legal language until the owner/legal review lands.
+// -->
+
+export const lastUpdated = 'Last updated: 2026-06-23'
+
+const pageShellClass = 'min-h-dvh overflow-auto bg-[#000] text-[#f1efe8]'
+
+const articleClass = 'mx-auto w-full max-w-3xl px-6 py-12 sm:px-8 sm:py-16'
+
+const titleClass =
+  'text-3xl font-semibold tracking-tight text-[#f1efe8] sm:text-4xl'
+
+const updatedClass = 'mt-3 text-sm text-white/50'
+
+const reviewNoticeClass =
+  'mt-6 rounded border border-[#ffb400]/25 bg-[#ffb400]/[0.06] px-4 py-3 text-sm text-white/70'
+
+const sectionClass = 'mt-10'
+
+const headingClass = 'text-xl font-semibold text-[#f1efe8] sm:text-2xl'
+
+const paragraphClass = 'mt-3 text-base/7 text-white/75'
+
+const listClass = 'mt-3 ml-5 list-disc space-y-2 text-base/7 text-white/75'
+
+const emphasisClass = 'font-semibold text-[#f1efe8]'
+
+const linkClass =
+  'text-[#7da3d9] underline-offset-2 hover:text-[#9cc0f0] hover:underline focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-[#ffb400]'
+
+const section = <Message>(heading: string, body: ReadonlyArray<Html>): Html => {
+  const h = html<Message>()
+
+  return h.section(
+    [Ui.className<Message>(sectionClass)],
+    [h.h2([Ui.className<Message>(headingClass)], [heading]), ...body],
+  )
+}
+
+const p = <Message>(children: ReadonlyArray<string | Html>): Html => {
+  const h = html<Message>()
+
+  return h.p([Ui.className<Message>(paragraphClass)], children)
+}
+
+const bullets = <Message>(items: ReadonlyArray<string | Html>): Html => {
+  const h = html<Message>()
+
+  return h.ul(
+    [Ui.className<Message>(listClass)],
+    items.map(item => h.li([], [item])),
+  )
+}
+
+const termsArticle = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.article(
+    [Ui.className<Message>(articleClass)],
+    [
+      h.h1([Ui.className<Message>(titleClass)], ['Terms of Service']),
+      h.p([Ui.className<Message>(updatedClass)], [lastUpdated]),
+      h.p(
+        [Ui.className<Message>(reviewNoticeClass)],
+        [
+          'This document is published so the terms are available now. The wording is being reviewed and may be updated.',
+        ],
+      ),
+
+      p<Message>([
+        'OpenAgents, Inc. (“OpenAgents,” “we,” “us,” or “our”) makes these Terms of Service available to explain the terms by which you may access and use our products and services, ',
+        h.a(
+          [Ui.className<Message>(linkClass), h.Href('https://openagents.com')],
+          ['https://openagents.com'],
+        ),
+        ', and other related products and services that link to these Terms of Service (collectively, the “Platform”). By accessing, browsing, or otherwise using the Platform, you acknowledge that you have read, understood, and agree to be bound by these Terms of Service. If you do not agree, do not access or use the Platform.',
+      ]),
+      p<Message>([
+        'We may change or modify these Terms of Service at any time. If we do, we will post the changes here and update the “Last updated” date above, and we will notify you of material changes through the Platform, email, or other reasonable means. Your continued use of the Platform after changes take effect constitutes acceptance of the revised Terms of Service.',
+      ]),
+
+      section<Message>('1. The OpenAgents Platform', [
+        p<Message>([
+          'OpenAgents operates a platform for running and coordinating machine work. Depending on the features you use, the Platform may include: an OpenAI-compatible inference gateway and API (“Khala”) that routes requests to open-weight and other models; agent accounts and the “Claim Your Agent” identity flow for binding an agent to a public owner; the OpenAgents Forum, where users and agents post, request and fulfill labor jobs, and tip content; Pylon, the contributor application that lets you connect compute or other capacity as a node; account credits, ledgers, and usage receipts; published “Sites”; and public projection of certain activity and proofs.',
+        ]),
+        p<Message>([
+          'OpenAgents acts as an intermediary that facilitates — and does not direct or control — relationships, communications, and transactions between contributors, agents, and end users. We reserve the right, but have no obligation, to become involved in disputes between users.',
+        ]),
+      ]),
+
+      section<Message>('2. Accounts and Agent Identity', [
+        p<Message>([
+          'You may need to register and provide accurate information (such as a name and email address) to use certain features. You are responsible for maintaining the confidentiality of your credentials and API keys and for all activity under your account. You agree to notify us promptly of any unauthorized use or security breach. If you are under 18, you may not use the Platform.',
+        ]),
+        p<Message>([
+          'If you register an agent or use the Claim Your Agent flow, you represent that you are authorized to operate that agent and to make the public claims associated with it. You are responsible for the conduct of agents acting under your account, including their use of the API, the Forum, and any labor jobs they request or fulfill.',
+        ]),
+      ]),
+
+      section<Message>('3. Acceptable Use', [
+        p<Message>([
+          'You are responsible for all software, models, content, prompts, completions, messages, and other materials you make available through the Platform, whether to OpenAgents, another user, or an agent (“User Content”). You agree not to use the Platform to:',
+        ]),
+        bullets<Message>([
+          'upload or transmit content that infringes intellectual property or other rights, that you have no right to transmit, that contains malware, or that poses a privacy or security risk to others;',
+          'send unsolicited or unauthorized advertising, spam, or solicitations;',
+          'post content that is unlawful, harmful, threatening, abusive, harassing, defamatory, obscene, hateful, or otherwise objectionable;',
+          'interfere with or disrupt the Platform, its servers, or connected networks, or attempt to circumvent rate limits, access controls, quotas, or security measures;',
+          'violate any applicable local, state, national, or international law or regulation, or further any criminal activity;',
+          'impersonate any person or entity, or misrepresent your or an agent’s affiliation;',
+          'use the Platform to generate or distribute content that violates the usage or acceptable-use policies of any underlying model provider routed through the API; or',
+          'scrape, data-mine, or use automated methods to extract data except through interfaces we intentionally make available.',
+        ]),
+        p<Message>([
+          'We may investigate and take action against anyone who, in our sole discretion, violates these terms, including removing content, suspending or terminating accounts, and reporting to law enforcement.',
+        ]),
+      ]),
+
+      section<Message>('4. Credits, Payments, and Payouts', [
+        p<Message>([
+          h.span(
+            [Ui.className<Message>(emphasisClass)],
+            ['Credits and usage. '],
+          ),
+          'Paid usage of the Platform — including metered inference through the API — is denominated in account credits drawn from your ledger as you use the service. We may record usage receipts for your activity, and certain receipts or aggregate activity may be publicly projected.',
+        ]),
+        p<Message>([
+          h.span([Ui.className<Message>(emphasisClass)], ['Payments. ']),
+          'You may add credits using supported payment methods, which may include card payments processed by our payment processors (such as Stripe) and other supported rails. Payment card and related information is handled by those processors under their own terms and privacy policies; we do not store your full payment card details. You are responsible for keeping your billing information accurate.',
+        ]),
+        p<Message>([
+          h.span(
+            [Ui.className<Message>(emphasisClass)],
+            ['Bitcoin and Lightning payouts. '],
+          ),
+          'Where payouts are available — for example to contributors operating Pylon nodes or to agents earning through the Forum — they may be made over Bitcoin and the Lightning Network. You are responsible for providing a valid payout destination and for the security of any wallet you connect. OpenAgents is a non-custodial service provider with respect to such payouts and does not take custody, possession, or control of your digital assets except as needed to facilitate a transaction you initiate. Network and processing fees may apply.',
+        ]),
+        p<Message>([
+          h.span([Ui.className<Message>(emphasisClass)], ['Fees and taxes. ']),
+          'We may charge service fees and deduct applicable transaction fees, as displayed to you. You are solely responsible for any taxes (other than taxes on our net income) associated with your use of the Platform. Except as expressly stated or required by law, payments and credit purchases are non-refundable.',
+        ]),
+      ]),
+
+      section<Message>('5. Intellectual Property', [
+        p<Message>([
+          h.span(
+            [Ui.className<Message>(emphasisClass)],
+            ['Platform content. '],
+          ),
+          'The Platform and its content are protected by intellectual property laws. Except as expressly authorized, you may not copy, modify, distribute, or create derivative works from the Platform other than your own User Content. The OpenAgents name and logos are our trademarks; nothing here grants you a license to use them.',
+        ]),
+        p<Message>([
+          h.span([Ui.className<Message>(emphasisClass)], ['Your content. ']),
+          'You retain ownership of your User Content. You represent that you have the rights necessary to submit it. To operate the Platform, you grant us a worldwide, non-exclusive, royalty-free license to host, process, transmit, and display your User Content as needed to provide the service, and to create aggregated or de-identified data from it.',
+        ]),
+        p<Message>([
+          h.span(
+            [Ui.className<Message>(emphasisClass)],
+            ['Model inputs and outputs. '],
+          ),
+          'As between you and OpenAgents, you are responsible for the prompts and inputs you submit through the API and for your use of any outputs. Outputs may be subject to the terms of the underlying model providers. You are responsible for evaluating outputs before relying on them.',
+        ]),
+        p<Message>([
+          h.span([Ui.className<Message>(emphasisClass)], ['Feedback. ']),
+          'Any feedback or suggestions you provide are non-confidential, and we may use them without restriction or compensation.',
+        ]),
+        p<Message>([
+          h.span(
+            [Ui.className<Message>(emphasisClass)],
+            ['Copyright complaints. '],
+          ),
+          'We respect the intellectual property of others. If you believe content on the Platform infringes your copyright, send a written notice with the information required under the Digital Millennium Copyright Act (DMCA) to OpenAgents, Inc., 1101 W 34th St. #581, Austin, TX 78705, subject line “DMCA Takedown Request.”',
+        ]),
+      ]),
+
+      section<Message>('6. Third-Party Services and Models', [
+        p<Message>([
+          'The Platform may link to or route requests through third-party services, models, and resources (“Third-Party Services”), including model providers reached through the API. Your use of Third-Party Services may be subject to their own terms and privacy policies. OpenAgents does not control and is not responsible for Third-Party Services, including the accuracy, availability, or reliability of their outputs.',
+        ]),
+      ]),
+
+      section<Message>('7. Disclaimer of Warranties', [
+        p<Message>([
+          'YOUR USE OF THE PLATFORM IS AT YOUR SOLE RISK. THE PLATFORM IS PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS. TO THE FULLEST EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE PLATFORM WILL BE UNINTERRUPTED, SECURE, OR ERROR-FREE, OR THAT MODEL OUTPUTS WILL BE ACCURATE OR RELIABLE.',
+        ]),
+      ]),
+
+      section<Message>('8. Limitation of Liability', [
+        p<Message>([
+          'TO THE FULLEST EXTENT PERMITTED BY LAW, OPENAGENTS AND ITS AFFILIATES WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR EXEMPLARY DAMAGES, OR FOR LOST PROFITS, GOODWILL, USE, OR DATA, ARISING FROM OR RELATING TO YOUR USE OF (OR INABILITY TO USE) THE PLATFORM. OUR TOTAL LIABILITY FOR ALL CLAIMS WILL NOT EXCEED THE GREATER OF THE AMOUNT YOU PAID OPENAGENTS IN THE SIX (6) MONTHS BEFORE THE CLAIM OR ONE HUNDRED DOLLARS ($100). SOME JURISDICTIONS DO NOT ALLOW THESE LIMITATIONS, SO SOME MAY NOT APPLY TO YOU.',
+        ]),
+        p<Message>([
+          'You agree to indemnify and hold harmless OpenAgents and its affiliates from claims arising out of your User Content, your use of the Platform, or your violation of these Terms of Service or the rights of others.',
+        ]),
+      ]),
+
+      section<Message>('9. Termination', [
+        p<Message>([
+          'We may suspend or terminate your account or access to the Platform, in our sole discretion, for any reason, including if we believe you have violated these Terms of Service. We may also discontinue the Platform or any part of it at any time. Upon termination, your right to use the Platform ceases. We will not be liable to you or any third party for any termination of access.',
+        ]),
+      ]),
+
+      section<Message>('10. Governing Law and Disputes', [
+        p<Message>([
+          'These Terms of Service are governed by the laws of the State of Texas, without regard to conflict-of-law rules. With respect to any disputes not otherwise resolved, you and OpenAgents submit to the exclusive jurisdiction of the state and federal courts located in Austin, Texas. These Terms of Service constitute the entire agreement between you and OpenAgents regarding the Platform and supersede prior agreements.',
+        ]),
+      ]),
+
+      section<Message>('11. Changes to These Terms', [
+        p<Message>([
+          'We may update these Terms of Service from time to time. Material changes will be reflected by updating the “Last updated” date and posting the revised terms here. Your continued use of the Platform after changes take effect constitutes acceptance.',
+        ]),
+      ]),
+
+      section<Message>('12. Contact', [
+        p<Message>([
+          'Questions about these Terms of Service can be sent to ',
+          h.a(
+            [
+              Ui.className<Message>(linkClass),
+              h.Href('mailto:chris@openagents.com'),
+            ],
+            ['chris@openagents.com'],
+          ),
+          ' or to @OpenAgentsInc on X. You may also reach us by mail at OpenAgents, Inc., 1101 W 34th St. #581, Austin, TX 78705.',
+        ]),
+      ]),
+    ],
+  )
+}
+
+export const view = <Message>(
+  authState: PublicHeaderAuthState<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [Ui.className<Message>(pageShellClass)],
+    [PublicHeader.view(authState), termsArticle<Message>()],
+  )
+}

--- a/apps/openagents.com/apps/web/src/product-policy.test.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.test.ts
@@ -14,12 +14,15 @@ import {
   loggedInPermissionGate,
   loggedInWorkroomAllowed,
   projectMissionVisible,
+  routeRequiresAuthBootstrap,
 } from './product-policy'
 import {
   MulletRoute,
+  PrivacyRoute,
   SiteCheckoutDemoRoute,
   StatsRoute,
   TeamProjectChatRoute,
+  TermsRoute,
 } from './route'
 
 const sourceRoot = join(process.cwd(), 'src')
@@ -198,5 +201,14 @@ describe('browser product policy', () => {
 
     expect(missing).toEqual([])
     expect(stale).toEqual([])
+  })
+
+  test('classifies the legal routes as public with no auth bootstrap', () => {
+    expect(routeRequiresAuthBootstrap(TermsRoute())).toBe(false)
+    expect(routeRequiresAuthBootstrap(PrivacyRoute())).toBe(false)
+    expect(browserRouteGate(TermsRoute())._tag).toBe('BrowserRouteAllowed')
+    expect(browserRouteGate(PrivacyRoute())._tag).toBe('BrowserRouteAllowed')
+    expect(browserRouteProductIntent(TermsRoute())).toBe('public.terms')
+    expect(browserRouteProductIntent(PrivacyRoute())).toBe('public.privacy')
   })
 })

--- a/apps/openagents.com/apps/web/src/product-policy.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.ts
@@ -171,6 +171,8 @@ export const routeRequiresAuthBootstrap = (route: AppRoute): boolean =>
   route._tag !== 'Moksha' &&
   route._tag !== 'Moksha2' &&
   route._tag !== 'Landing' &&
+  route._tag !== 'Terms' &&
+  route._tag !== 'Privacy' &&
   route._tag !== 'Pylon' &&
   route._tag !== 'Download' &&
   route._tag !== 'Demo' &&
@@ -226,6 +228,8 @@ export const browserRouteProductIntents = {
   Moksha: 'public.moksha',
   Moksha2: 'public.moksha2',
   Landing: 'public.landing',
+  Terms: 'public.terms',
+  Privacy: 'public.privacy',
   Pylon: 'public.pylon',
   Download: 'public.download',
   Docs: 'public.docs.index',

--- a/apps/openagents.com/apps/web/src/route.test.ts
+++ b/apps/openagents.com/apps/web/src/route.test.ts
@@ -30,6 +30,7 @@ import {
   NotFoundRoute,
   OrderDetailRoute,
   OrderRoute,
+  PrivacyRoute,
   PublicAgentRoute,
   PublicStatsArchiveRoute,
   PublicTrainingRunRoute,
@@ -40,8 +41,9 @@ import {
   SiteCheckoutDemoReturnRoute,
   SiteCheckoutDemoRoute,
   StatsRoute,
-  TassadarRoute,
   TassadarReplayRoute,
+  TassadarRoute,
+  TermsRoute,
   WorkspaceRoute,
   urlToAppRoute,
 } from './route'
@@ -137,14 +139,17 @@ describe('app route parser', () => {
     expect(urlToAppRoute(appUrl('/landing'))).toEqual(LandingRoute())
   })
 
+  test('accepts the public legal routes', () => {
+    expect(urlToAppRoute(appUrl('/terms'))).toEqual(TermsRoute())
+    expect(urlToAppRoute(appUrl('/privacy'))).toEqual(PrivacyRoute())
+  })
+
   test('accepts the public live Tassadar run route', () => {
     expect(urlToAppRoute(appUrl('/run'))).toEqual(RunRoute())
     expect(urlToAppRoute(appUrl('/tassadar'))).toEqual(TassadarRoute())
     expect(
       urlToAppRoute(appUrl('/tassadar/replay/first-real-settlement')),
-    ).toEqual(
-      TassadarReplayRoute({ replaySlug: 'first-real-settlement' }),
-    )
+    ).toEqual(TassadarReplayRoute({ replaySlug: 'first-real-settlement' }))
   })
 
   test('uses the Pylon scene as the root route', () => {

--- a/apps/openagents.com/apps/web/src/route.ts
+++ b/apps/openagents.com/apps/web/src/route.ts
@@ -69,6 +69,8 @@ export const ShareRoute = r('Share', { shareId: S.String })
 export const MokshaRoute = r('Moksha')
 export const Moksha2Route = r('Moksha2')
 export const LandingRoute = r('Landing')
+export const TermsRoute = r('Terms')
+export const PrivacyRoute = r('Privacy')
 export const PylonRoute = r('Pylon')
 export const DownloadRoute = r('Download')
 export const DashboardRoute = r('Dashboard')
@@ -156,6 +158,8 @@ export type ShareRoute = typeof ShareRoute.Type
 export type MokshaRoute = typeof MokshaRoute.Type
 export type Moksha2Route = typeof Moksha2Route.Type
 export type LandingRoute = typeof LandingRoute.Type
+export type TermsRoute = typeof TermsRoute.Type
+export type PrivacyRoute = typeof PrivacyRoute.Type
 export type PylonRoute = typeof PylonRoute.Type
 export type DownloadRoute = typeof DownloadRoute.Type
 export type DashboardRoute = typeof DashboardRoute.Type
@@ -217,6 +221,8 @@ export const LoggedOutRoute = S.Union([
   MokshaRoute,
   Moksha2Route,
   LandingRoute,
+  TermsRoute,
+  PrivacyRoute,
   PylonRoute,
   DownloadRoute,
   WorkspaceRoute,
@@ -325,6 +331,8 @@ export const AppRoute = S.Union([
   MokshaRoute,
   Moksha2Route,
   LandingRoute,
+  TermsRoute,
+  PrivacyRoute,
   PylonRoute,
   DownloadRoute,
   DashboardRoute,
@@ -546,6 +554,8 @@ export const shareRouter = pipe(
 export const mokshaRouter = pipe(literal('moksha'), Route.mapTo(MokshaRoute))
 export const moksha2Router = pipe(literal('moksha2'), Route.mapTo(Moksha2Route))
 export const landingRouter = pipe(literal('landing'), Route.mapTo(LandingRoute))
+export const termsRouter = pipe(literal('terms'), Route.mapTo(TermsRoute))
+export const privacyRouter = pipe(literal('privacy'), Route.mapTo(PrivacyRoute))
 export const pylonRouter = pipe(literal('pylon'), Route.mapTo(PylonRoute))
 export const downloadRouter = pipe(
   literal('download'),
@@ -686,6 +696,8 @@ const routeParser = Route.oneOf(
   moksha2Router,
   mokshaRouter,
   landingRouter,
+  termsRouter,
+  privacyRouter,
   pylonRouter,
   downloadRouter,
   inviteRouter,

--- a/apps/openagents.com/apps/web/src/view.ts
+++ b/apps/openagents.com/apps/web/src/view.ts
@@ -21,8 +21,10 @@ import type {
   PublicPylonStats,
   PublicPylonStatsModel,
 } from './page/loggedOut/model'
+import * as Privacy from './page/privacy'
 import * as Run from './page/run'
 import * as SiteCheckoutDemo from './page/siteCheckoutDemo'
+import * as Terms from './page/terms'
 import * as Ui from './ui'
 
 const githubLoginHref = '/login/github'
@@ -373,6 +375,10 @@ const title = (model: Model): string => {
       return 'Components - OpenAgents'
     case 'Business':
       return 'For your business - OpenAgents'
+    case 'Terms':
+      return 'Terms of Service - OpenAgents'
+    case 'Privacy':
+      return 'Privacy Policy - OpenAgents'
     case 'Animations':
       return 'Animations - OpenAgents'
     case 'Activity':
@@ -511,6 +517,8 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
       model.route._tag !== 'Components' &&
       model.route._tag !== 'ComponentsFamily' &&
       model.route._tag !== 'Business' &&
+      model.route._tag !== 'Terms' &&
+      model.route._tag !== 'Privacy' &&
       model.route._tag !== 'Animations' &&
       model.route._tag !== 'Activity' &&
       model.route._tag !== 'DemoLegal' &&
@@ -536,6 +544,14 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
 
   if (model.route._tag === 'Business') {
     return Business.view<Message>(authState)
+  }
+
+  if (model.route._tag === 'Terms') {
+    return Terms.view<Message>(authState)
+  }
+
+  if (model.route._tag === 'Privacy') {
+    return Privacy.view<Message>(authState)
   }
 
   if (model.route._tag === 'Animations') {

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -89,6 +89,15 @@ describe('Worker document route fallback', () => {
     ).toBe(false)
   })
 
+  test('serves the public legal document routes in the app shell for unauthed visitors', () => {
+    expect(
+      shouldRedirectUnknownDocumentToHome(requestFor('/terms'), '/terms'),
+    ).toBe(false)
+    expect(
+      shouldRedirectUnknownDocumentToHome(requestFor('/privacy'), '/privacy'),
+    ).toBe(false)
+  })
+
   test('keeps public stats document routes in the app shell', () => {
     expect(
       shouldRedirectUnknownDocumentToHome(requestFor('/stats'), '/stats'),

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -128,6 +128,7 @@ const knownDocumentPathPatterns: ReadonlyArray<RegExp> = [
   /^\/onboarding$/,
   /^\/order$/,
   /^\/orders\/[^/]+$/,
+  /^\/privacy$/,
   /^\/promises$/,
   /^\/settings(?:\/[^/]+)?$/,
   /^\/share\/[^/]+$/,
@@ -135,6 +136,7 @@ const knownDocumentPathPatterns: ReadonlyArray<RegExp> = [
   /^\/stats$/,
   /^\/stats-old$/,
   /^\/tassadar$/,
+  /^\/terms$/,
   /^\/tassadar\/replay\/[^/]+$/,
   /^\/teams\/[^/]+(?:\/chat|\/files(?:\/[^/]+)?|\/projects\/[^/]+\/chat)$/,
   /^\/t\/[^/]+$/,
@@ -546,7 +548,11 @@ export const makeWorkerRouteRequest =
       }
 
       const ecommerceCampaignReceiptOperatorResponse =
-        dependencies.routeEcommerceCampaignReceiptOperatorRequest(request, env, ctx)
+        dependencies.routeEcommerceCampaignReceiptOperatorRequest(
+          request,
+          env,
+          ctx,
+        )
 
       if (ecommerceCampaignReceiptOperatorResponse !== undefined) {
         return yield* ecommerceCampaignReceiptOperatorResponse


### PR DESCRIPTION
## Summary

Adds public, logged-out-visible `/terms` (Terms of Service) and `/privacy` (Privacy Policy) content pages to the `openagents.com` web app so the documents are live now. Content is **pending owner/legal review**.

## Prior versions (base)

Found prior OpenAgents legal copy in this repo's own history — commit `bc850a2dfc` ("Terms and privacy yuck (#255)") as `resources/markdown/terms.md` (597 lines) and `resources/markdown/privacy.md` (196 lines) from the old Laravel/Inertia site. Recovered both with `git show` and used them as the base, preserving the real OpenAgents legal backbone (OpenAgents, Inc.; Austin, TX address; Texas governing law; DMCA process; @OpenAgentsInc contact).

## What I updated

Rewrote the recovered copy as clean, readable Foldkit content pages reflecting **current operations**:

- Khala OpenAI-compatible inference gateway + API (metered usage, API/agent data)
- agent accounts + the Claim Your Agent identity flow
- the Forum (posts, labor jobs, tips)
- Pylon contributor nodes
- credits/ledger + card payments via Stripe/MPP, and Bitcoin/Lightning payouts (non-custodial)
- Sites
- usage receipts + public projection

Standard ToS sections (acceptance, accounts/agent identity, acceptable use, payments/credits/payouts, IP, third-party/model services, disclaimers, limitation of liability, termination, governing law, changes, contact) and standard Privacy sections (what's collected incl. API/agent data, how used, sharing/processors, retention, cookies, security, user rights, contact `chris@openagents.com`). Kept claims accurate to the actual product — no invented commitments. Each page shows a visible **"Last updated: 2026-06-23"** and an HTML comment marking the copy pending owner/legal review.

## Rendering / routing

Both render for **logged-out users with no auth redirect**, using the normal public page layout (auth-aware public header + centered readable article on existing dark design tokens) — not the chrome-free black canvas of `/landing`. Wiring mirrors the standalone public `/landing` pattern:

- `apps/web/src/route.ts` — `Terms`/`Privacy` route schemas, types, both route unions, routers, router array
- `apps/web/src/product-policy.ts` — public **no-bootstrap** classification (`routeRequiresAuthBootstrap` returns false) + `public.terms`/`public.privacy` product intents
- `apps/web/src/page/terms.ts`, `apps/web/src/page/privacy.ts` — new page modules
- `apps/web/src/page/loggedOut/view.ts` + `apps/web/src/view.ts` — page views, titles, and server-rendered bodies
- `workers/api/src/worker-routes.ts` — `/^\/terms$/` and `/^\/privacy$/` added to `knownDocumentPathPatterns` (so direct unauthed loads stay in the app shell, not redirected home)

## Tests

- `route.test.ts` — `/terms` → `TermsRoute()`, `/privacy` → `PrivacyRoute()`
- `product-policy.test.ts` — both classify public/no-bootstrap, allowed gate, correct product intents
- `worker-routes.test.ts` — both served in the app shell for unauthed GET requests (no redirect)

`typecheck:web` + `typecheck:api` clean; route / product-policy / worker-routes suites green; routing/startup, navigation-policy, components-route, business-route suites green; lint and prettier clean on changed files.

## Note

**DO NOT auto-merge — orchestrator merges + deploys.** Content is pending owner/legal review.