### PR TITLE
DE-6: advance markets.open_protocol_markets.v1 — NIP-90 labor-market closeout machinery + receipt, owner-flip-ready (#5529)

### DIFF
--- a/docs/promises/2026-06-23-de6-lbr-labor-closeout-dereferenceable-receipt.md
+++ b/docs/promises/2026-06-23-de6-lbr-labor-closeout-dereferenceable-receipt.md
@@ -1,0 +1,140 @@
+# DE-6: NIP-LBR Labor-Market Closeout Dereferenceable Receipt
+
+Date: 2026-06-23
+
+Part of EPIC **#5529** (DE-6 Open markets + marketplace), under the Weekend
+Promise Assault master EPIC **#5523**.
+
+## Promise advanced
+
+`markets.open_protocol_markets.v1` (DE-6) — specifically the **labor** market's
+dippable + dereferenceable-receipt rung.
+
+This is receipt machinery on the `packages/nip90` protocol surface. It flips
+**no** promise state and changes **no** green count. The promise STAYS `planned`;
+its named blockers (`liquidity_market_unbuilt`, `risk_market_unbuilt`,
+`compute_data_markets_not_broadly_live`) are untouched — none of them is what
+this change addresses, and none can be cleared without real liquidity/risk
+implementations and broad live compute/data markets.
+
+## Why this promise was the most-ready buildable now
+
+DE-6's receipt acceptance for `markets.open_protocol_markets.v1` is "all six
+markets dippable + unified surface receipt." Of the six markets:
+
+- **Data (NIP-DS)** already had a *dippable end-to-end producer with a
+  verifiable receipt*: `apps/openagents.com/scripts/nip-ds.ts` signs a
+  listing/offer/access-request/access-result, publishes them to a scoped relay,
+  reads them back, and verifies the delivered-bundle digest
+  (`verifyDatasetDeliveryDescriptorDigest`).
+- **Labor (NIP-LBR)** had the full ref-only lifecycle protocol in
+  `packages/nip90/src/lbr.ts` — request `5934`, quote/acceptance `7000`, result
+  `6934` — but **no composed closeout object and no dereferenceable receipt**.
+  There was no labor-market analogue of NIP-DS's digest verification: nothing
+  bound one complete lifecycle into a single content-addressed receipt a reader
+  could independently re-verify.
+
+That was the exact missing "dippable + receipt" rung for the labor market, and
+it is buildable purely on the `packages/nip90` surface with no money, no live
+market, and no other lane. The remaining DE-6 promises are either money/owner
+gated (the capstone `monetize_any_layer_with_referral`, signature settlement) or
+need runtime work outside this scope (compose-and-list runtime, agentic-npm /
+WASM registries).
+
+## What was built
+
+All on the in-scope `packages/nip90` surface:
+
+- **`packages/nip90/src/lbr-closeout.ts`** — `makeLbrLaborCloseout(...)` composes
+  the four accepted LBR lifecycle events into one public-safe, content-addressed
+  `LbrLaborCloseout` receipt. It:
+  - re-decodes every event through the existing `./lbr` ref/payment-material
+    guards (raw prompts, private paths, credentials, invoices, preimages, etc.
+    are rejected here too);
+  - checks the four events describe **one** job — every lifecycle event's
+    `requestId` equals the request event id, the requester is the request
+    author across quote/result, and the provider is the quote author across
+    acceptance/result;
+  - enforces the **quote ≤ request budget** bound;
+  - hashes a deterministic canonical projection of the public-safe refs
+    (`canonicalLbrLaborCloseout`) into a SHA-256 `digest`, and binds a stable
+    ref-only `receiptRef` of `lbr-closeout:<requestId>:<digest>`.
+  - `verifyLbrLaborCloseoutDigest(...)` re-derives the digest and `receiptRef`
+    from the receipt's own fields — the **dereference check** that lets any
+    reader confirm the receipt binds the exact lifecycle that produced it, and
+    fails closed on any tamper.
+- **`packages/nip90/src/lbr-closeout.test.ts`** — 9 tests covering composition,
+  determinism, canonical-order independence, tamper detection (ref + amount +
+  receiptRef), over-budget rejection, one-job consistency, party mismatch,
+  wrong-kind rejection, and the inherited ref-only safety guard.
+- **`packages/nip90/scripts/lbr-closeout-proof.ts`** — the labor-market analogue
+  of `nip-ds.ts`. Offline by default: it **signs** a real LBR lifecycle with
+  deterministic keys, composes the closeout, and prints the receipt with
+  `closeoutDereferenced: true`. With `--relay <url>` it additionally publishes
+  the four events to a scoped market relay and reads them back, proving the
+  lifecycle is dippable on the relay before the closeout binds it.
+- **`packages/nip90/src/index.ts`** — exports the new closeout surface.
+- **`packages/nip90/README.md`** — documents the closeout contract and proof.
+- **`packages/nip90/tsconfig.json`** — typecheck now covers `scripts/**`.
+
+It is protocol-only and ref-only throughout: it moves no sats, opens no escrow,
+creates no invoice, publishes nothing private, and grants no settlement
+authority. Settlement authority stays in the platform receipt systems, per
+`docs/nips/LBR.md`.
+
+## The dereferenceable receipt (the proof)
+
+`bun packages/nip90/scripts/lbr-closeout-proof.ts` (offline) produces a real
+signed lifecycle and a content-addressed closeout, e.g.:
+
+- four real signed Nostr events, kinds `[5934, 7000, 7000, 6934]`, each with a
+  real 32-byte hex event id;
+- `receiptRef: lbr-closeout:<requestId>:<digest>` where `<requestId>` is the
+  signed request event id and `<digest>` is the SHA-256 over the canonical
+  ref-only projection;
+- `closeoutDereferenced: true` — `verifyLbrLaborCloseoutDigest` re-derived the
+  digest and receiptRef from the receipt's own public-safe fields and they
+  match.
+
+This is the labor-market shape of DE-6's "dippable market + dereferenceable
+receipt" rung, at the protocol/receipt layer. The relay accepts kinds
+5934/7000/6934 under `apps/nostr-relay/src/market-policy.ts`
+(`marketKindBucket`), so `--relay` makes the same lifecycle dippable on a live
+scoped relay.
+
+## State after this change
+
+- `markets.open_protocol_markets.v1` — **STAYS `planned`.** The labor market now
+  has a composed, content-addressed, dereferenceable closeout receipt and a
+  signed proof, matching the receipt shape the data (NIP-DS) market already has.
+  No blocker is cleared: liquidity and risk remain skeleton-only, and
+  compute/data are not broadly live paid markets. Green still requires real
+  participant transactions plus settlement receipts across all six markets.
+- No other promise changes state. Zero green flips.
+
+## What remains for the green flip (owner-gated / out of this scope)
+
+The single remaining step this scope can flag, not perform:
+
+1. **Owner**: run a real labor job through a live scoped relay with a real
+   requester and a real independent provider, escrow real budget through the
+   platform ledger, and record the green-flip transition receipt with **owner
+   sign-off** per `proof.claim_upgrade_receipts.v1`. Building out the liquidity
+   and risk markets and broad live compute/data markets is the larger remaining
+   DE-6 work for the *unified six-market* green, tracked by the promise's own
+   blockers.
+
+## Verification
+
+From the repo root:
+
+- `bun run --cwd packages/nip90 test` — 17 pass (incl. the 9 new closeout
+  tests).
+- `bun run --cwd packages/nip90 typecheck` — clean (now incl. `scripts/**`).
+- `bun run --cwd apps/nostr-relay test` — 28 pass.
+- `bun test apps/pylon/tests/nip90-import.test.ts` — 1 pass (export surface
+  intact).
+- `bun packages/nip90/scripts/lbr-closeout-proof.ts` — prints a signed
+  lifecycle and a closeout with `closeoutDereferenced: true`.
+
+No deploy, no money movement, no registry state flip.

--- a/packages/nip90/README.md
+++ b/packages/nip90/README.md
@@ -43,6 +43,17 @@ This package covers protocol-only behavior:
   `partial`
 - Effect Schema-backed event validation, typed malformed-event errors, and
   SHA-256 digest verification for delivered bundles
+- NIP-LBR labor-market **closeout receipt** (`./lbr-closeout`): composes one
+  complete labor lifecycle (request `5934`, quote `7000`, acceptance `7000`,
+  result `6934`) into a single content-addressed, public-safe
+  `LbrLaborCloseout`. It re-decodes each event through the `./lbr` ref/payment
+  guards, checks the four events describe one job (consistent `requestId`,
+  consistent requester/provider parties, quote within budget), and hashes a
+  canonical projection of the public-safe refs. `verifyLbrLaborCloseoutDigest`
+  re-derives the digest and `receiptRef` so any reader can confirm the receipt
+  dereferences the exact lifecycle that produced it. This is the labor market's
+  dereferenceable-receipt rung; it moves no sats and grants no settlement
+  authority.
 
 Historical contract reference:
 
@@ -72,6 +83,27 @@ bun apps/openagents.com/scripts/nip-ds.ts smoke \
 The script signs and publishes a `30404` listing, `30406` offer, `5960` access
 request, and `6960` access result, then reads them back and verifies the
 delivered bundle digest. It does not move sats or publish private datasets.
+
+## NIP-LBR closeout proof
+
+The labor-market equivalent of the NIP-DS proof. It signs a complete LBR
+lifecycle, composes the four accepted events into one content-addressed
+closeout receipt, and re-derives the digest to prove the receipt dereferences:
+
+```bash
+# Offline (default): build + sign + bind + dereference, no network.
+bun packages/nip90/scripts/lbr-closeout-proof.ts
+
+# Relay smoke (optional): also publish the four events to a scoped market relay
+# and read them back, proving the lifecycle is dippable before the closeout
+# binds it.
+bun packages/nip90/scripts/lbr-closeout-proof.ts --relay https://relay.openagents.com
+```
+
+It signs a `5934` request, two `7000` feedback events (quote + acceptance), and
+a `6934` result, then prints the closeout receipt with `closeoutDereferenced:
+true`. It moves no sats, opens no escrow, and grants no settlement authority — a
+live paid labor run is the owner gate.
 
 ## Verification
 

--- a/packages/nip90/scripts/lbr-closeout-proof.ts
+++ b/packages/nip90/scripts/lbr-closeout-proof.ts
@@ -1,0 +1,315 @@
+#!/usr/bin/env bun
+
+/**
+ * NIP-LBR labor-market closeout proof.
+ *
+ * Produces a real, dereferenceable labor-market closeout receipt for the
+ * agentic-coding labor lane (DE-6 "open protocol markets" — the labor market's
+ * dippable + receipt rung). It signs a complete LBR lifecycle (request `5934`,
+ * quote `7000`, acceptance `7000`, result `6934`) with deterministic keys,
+ * composes the four accepted events into one content-addressed
+ * `LbrLaborCloseout`, and re-derives the digest to prove the receipt
+ * dereferences the exact lifecycle that produced it.
+ *
+ * This is protocol-only and offline by default. It does NOT move sats, create
+ * invoices, escrow funds, publish private material, or grant settlement
+ * authority — the relay/transport is reference-only here, and a live paid labor
+ * run remains the owner gate. The structure mirrors the NIP-DS
+ * `apps/openagents.com/scripts/nip-ds.ts` proof: build → sign → bind → verify.
+ *
+ * Offline (default) — composes and dereferences the receipt with no network:
+ *
+ *   bun packages/nip90/scripts/lbr-closeout-proof.ts
+ *
+ * Relay smoke (optional) — also publishes the four events to a scoped market
+ * relay and reads them back, proving the lifecycle is dippable on the relay
+ * before the closeout binds it:
+ *
+ *   bun packages/nip90/scripts/lbr-closeout-proof.ts --relay https://relay.openagents.com
+ */
+
+import {
+  LBR_AGENTIC_CODING_REQUEST_KIND,
+  LBR_AGENTIC_CODING_RESULT_KIND,
+  LBR_FEEDBACK_KIND,
+  lbrAcceptanceToDraft,
+  lbrAgenticCodingRequestToDraft,
+  lbrQuoteToDraft,
+  lbrResultToDraft,
+  makeLbrAcceptance,
+  makeLbrAgenticCodingRequest,
+  makeLbrLaborCloseout,
+  makeLbrQuote,
+  makeLbrResult,
+  verifyLbrLaborCloseoutDigest,
+  type LbrLifecycleEvent,
+} from "../src/index.js"
+import {
+  finalizeEvent,
+  getPublicKey,
+  type EventTemplate,
+} from "nostr-effect/pure"
+
+const requesterSecretKey = new Uint8Array(32).fill(7)
+const providerSecretKey = new Uint8Array(32).fill(9)
+const requesterPubkey = getPublicKey(requesterSecretKey)
+const providerPubkey = getPublicKey(providerSecretKey)
+const createdAt = 1_781_107_200
+
+type SignedEvent = LbrLifecycleEvent & { tags: ReadonlyArray<ReadonlyArray<string>> }
+type RelayMessage = ReadonlyArray<unknown>
+
+const sign = (template: EventTemplate, secretKey: Uint8Array): SignedEvent => {
+  const event = finalizeEvent(template, secretKey)
+  return {
+    id: event.id,
+    pubkey: event.pubkey,
+    kind: event.kind,
+    created_at: event.created_at,
+    tags: event.tags,
+    content: event.content,
+    sig: event.sig,
+  }
+}
+
+const relayWebSocketUrl = (input: string): string => {
+  const url = new URL(/^[a-z]+:\/\//i.test(input) ? input : `wss://${input}`)
+  if (url.protocol === "http:") url.protocol = "ws:"
+  if (url.protocol === "https:") url.protocol = "wss:"
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error(`Expected ws/wss/http/https relay URL, got ${input}`)
+  }
+  return url.toString()
+}
+
+const waitForOpen = (socket: WebSocket): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("WebSocket open timed out")),
+      10_000,
+    )
+    socket.addEventListener("open", () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout)
+      reject(new Error("WebSocket open failed"))
+    })
+  })
+
+const waitForMessage = (
+  socket: WebSocket,
+  label: string,
+  predicate: (message: RelayMessage) => boolean,
+): Promise<RelayMessage> =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out waiting for ${label}`)),
+      15_000,
+    )
+    socket.addEventListener("message", (event) => {
+      const parsed = JSON.parse(String(event.data)) as RelayMessage
+      if (predicate(parsed)) {
+        clearTimeout(timeout)
+        resolve(parsed)
+      }
+    })
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout)
+      reject(new Error(`WebSocket error while waiting for ${label}`))
+    })
+  })
+
+const publishAndReadBack = async (
+  relayUrl: string,
+  events: ReadonlyArray<SignedEvent>,
+): Promise<ReadonlyArray<string>> => {
+  for (const event of events) {
+    const socket = new WebSocket(relayUrl)
+    await waitForOpen(socket)
+    socket.send(JSON.stringify(["EVENT", event]))
+    const ok = await waitForMessage(
+      socket,
+      `OK for ${event.id}`,
+      (message) => message[0] === "OK" && message[1] === event.id,
+    )
+    socket.close(1000, "publish complete")
+    if (ok[2] !== true) {
+      throw new Error(`Relay rejected kind ${event.kind}: ${JSON.stringify(ok)}`)
+    }
+  }
+
+  const readIds: Array<string> = []
+  for (const event of events) {
+    const socket = new WebSocket(relayUrl)
+    await waitForOpen(socket)
+    const subId = `lbr-closeout-${event.kind}-${Date.now()}`
+    socket.send(
+      JSON.stringify(["REQ", subId, { ids: [event.id], kinds: [event.kind], limit: 1 }]),
+    )
+    const message = await waitForMessage(
+      socket,
+      `EVENT ${event.id}`,
+      (candidate) =>
+        candidate[0] === "EVENT" &&
+        candidate[1] === subId &&
+        typeof candidate[2] === "object" &&
+        candidate[2] !== null &&
+        (candidate[2] as { id?: unknown }).id === event.id,
+    )
+    socket.send(JSON.stringify(["CLOSE", subId]))
+    socket.close(1000, "read complete")
+    readIds.push((message[2] as { id: string }).id)
+  }
+  return readIds
+}
+
+const parseRelayFlag = (argv: ReadonlyArray<string>): string | undefined => {
+  const index = argv.indexOf("--relay")
+  if (index === -1) return undefined
+  const value = argv[index + 1]
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error("--relay requires a URL")
+  }
+  return value
+}
+
+const main = async () => {
+  const relayInput = parseRelayFlag(process.argv.slice(2))
+  // 1. Requester publishes a budgeted, output-only agentic-coding request.
+  const request = makeLbrAgenticCodingRequest({
+    objectiveRef: "objective.public.lbr.de6_proof",
+    repositoryRefs: ["repo.public.openagents"],
+    verificationCommandRef: "command.public.bun_test",
+    requiredCapabilityRefs: ["capability.pylon.local_claude_agent"],
+    bidMsats: 2_000_000,
+    deadline: "deadline.public.lbr.20260630",
+    forumTopicRef: "topic.public.forum.labor_de6_proof",
+    relays: ["wss://relay.openagents.com"],
+  })
+  const requestDraft = lbrAgenticCodingRequestToDraft(request)
+  const requestEvent = sign(
+    { kind: requestDraft.kind, created_at: createdAt, tags: requestDraft.tags.map((t) => [...t]), content: requestDraft.content },
+    requesterSecretKey,
+  )
+  if (requestEvent.kind !== LBR_AGENTIC_CODING_REQUEST_KIND) {
+    throw new Error("request kind drift")
+  }
+
+  // 2. Provider quotes within budget (feedback 7000), referencing the request id.
+  const quote = makeLbrQuote({
+    requestId: requestEvent.id,
+    requesterPubkey,
+    amountMsats: 1_500_000,
+    providerRef: "provider.public.pylon.local_claude",
+    capabilityRefs: ["capability.pylon.local_claude_agent"],
+    quoteRef: "quote.public.lbr.de6_proof",
+    expiresAt: "expiry.public.lbr.20260630",
+    requestRelay: "wss://relay.openagents.com",
+  })
+  const quoteDraft = lbrQuoteToDraft(quote)
+  const quoteEvent = sign(
+    { kind: quoteDraft.kind, created_at: createdAt, tags: quoteDraft.tags.map((t) => [...t]), content: quoteDraft.content },
+    providerSecretKey,
+  )
+  if (quoteEvent.kind !== LBR_FEEDBACK_KIND) throw new Error("quote kind drift")
+
+  // 3. Requester accepts and references a platform escrow receipt ref.
+  const acceptance = makeLbrAcceptance({
+    requestId: requestEvent.id,
+    providerPubkey,
+    escrowReceiptRef: "receipt.public.escrow.de6_proof",
+    acceptanceRef: "acceptance.public.lbr.de6_proof",
+    requestRelay: "wss://relay.openagents.com",
+  })
+  const acceptanceDraft = lbrAcceptanceToDraft(acceptance)
+  const acceptanceEvent = sign(
+    { kind: acceptanceDraft.kind, created_at: createdAt, tags: acceptanceDraft.tags.map((t) => [...t]), content: acceptanceDraft.content },
+    requesterSecretKey,
+  )
+
+  // 4. Provider publishes an output-only result (6934) with artifact + receipt refs.
+  const result = makeLbrResult({
+    requestId: requestEvent.id,
+    requesterPubkey,
+    artifactRefs: ["artifact.public.lbr.patch_de6_proof"],
+    platformCloseoutRef: "closeout.public.lbr.de6_proof",
+    summaryRef: "summary.public.lbr.de6_proof",
+    testRef: "test.public.lbr.bun",
+    buildRef: "build.public.lbr.de6_proof",
+    requestRelay: "wss://relay.openagents.com",
+  })
+  const resultDraft = lbrResultToDraft(result)
+  const resultEvent = sign(
+    { kind: resultDraft.kind, created_at: createdAt, tags: resultDraft.tags.map((t) => [...t]), content: resultDraft.content },
+    providerSecretKey,
+  )
+  if (resultEvent.kind !== LBR_AGENTIC_CODING_RESULT_KIND) {
+    throw new Error("result kind drift")
+  }
+
+  // Compose the four accepted events into one content-addressed closeout.
+  const closeout = makeLbrLaborCloseout({
+    requestEvent,
+    quoteEvent,
+    acceptanceEvent,
+    resultEvent,
+  })
+
+  // Dereference: re-derive the digest/receiptRef from the receipt's own fields.
+  const dereferenced = verifyLbrLaborCloseoutDigest(closeout)
+  if (!dereferenced) {
+    throw new Error("closeout receipt failed to dereference")
+  }
+
+  const orderedEvents = [requestEvent, quoteEvent, acceptanceEvent, resultEvent]
+
+  let relayProof:
+    | { relay: string; publishedReadBackIds: ReadonlyArray<string>; allReadBack: boolean }
+    | undefined
+  if (relayInput !== undefined) {
+    const relayUrl = relayWebSocketUrl(relayInput)
+    const readIds = await publishAndReadBack(relayUrl, orderedEvents)
+    const allReadBack =
+      readIds.length === orderedEvents.length &&
+      orderedEvents.every((event, index) => readIds[index] === event.id)
+    if (!allReadBack) {
+      throw new Error("relay read-back did not return the published events")
+    }
+    relayProof = { relay: relayUrl, publishedReadBackIds: readIds, allReadBack }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        note:
+          "Protocol-only NIP-LBR labor-market closeout. No sats moved; no escrow; " +
+          "settlement authority stays in the platform receipt systems. A live paid " +
+          "labor run is the owner gate.",
+        requesterPubkey,
+        providerPubkey,
+        signedEventIds: {
+          request: requestEvent.id,
+          quote: quoteEvent.id,
+          acceptance: acceptanceEvent.id,
+          result: resultEvent.id,
+        },
+        eventKinds: orderedEvents.map((event) => event.kind),
+        receiptRef: closeout.receiptRef,
+        digest: closeout.digest,
+        closeoutDereferenced: dereferenced,
+        ...(relayProof === undefined ? {} : { relayProof }),
+        closeout,
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/packages/nip90/src/index.ts
+++ b/packages/nip90/src/index.ts
@@ -1,2 +1,3 @@
 export * from "nostr-effect/nip90"
 export * from "./lbr.js"
+export * from "./lbr-closeout.js"

--- a/packages/nip90/src/lbr-closeout.test.ts
+++ b/packages/nip90/src/lbr-closeout.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  LBR_CLOSEOUT_RECEIPT_VERSION,
+  LbrProtocolError,
+  canonicalLbrLaborCloseout,
+  lbrAcceptanceToDraft,
+  lbrAgenticCodingRequestToDraft,
+  lbrQuoteToDraft,
+  lbrResultToDraft,
+  makeLbrAcceptance,
+  makeLbrAgenticCodingRequest,
+  makeLbrLaborCloseout,
+  makeLbrQuote,
+  makeLbrResult,
+  verifyLbrLaborCloseoutDigest,
+  type LbrLifecycleEvent,
+} from "./index.js"
+
+const requesterPubkey = "11".repeat(32)
+const providerPubkey = "22".repeat(32)
+const requestEventId = "aa".repeat(32)
+const quoteEventId = "bb".repeat(32)
+const acceptanceEventId = "cc".repeat(32)
+const resultEventId = "dd".repeat(32)
+const sig = "33".repeat(64)
+
+type Draft = Readonly<{
+  kind: number
+  tags: ReadonlyArray<readonly string[]>
+  content: string
+}>
+
+const eventFrom = (
+  draft: Draft,
+  overrides: { id: string; pubkey: string },
+): LbrLifecycleEvent => ({
+  id: overrides.id,
+  pubkey: overrides.pubkey,
+  kind: draft.kind,
+  created_at: 1_781_107_200,
+  tags: draft.tags,
+  content: draft.content,
+  sig,
+})
+
+/**
+ * Build one complete, internally consistent LBR labor lifecycle (request,
+ * quote, acceptance, result) as relay-shaped events. The `requestId` that the
+ * quote/acceptance/result reference is the request event id, exactly as a live
+ * relay flow would bind them.
+ */
+const buildLifecycle = () => {
+  const request = makeLbrAgenticCodingRequest({
+    objectiveRef: "objective.public.lbr.fix_flaky_test",
+    repositoryRefs: ["repo.public.openagents"],
+    verificationCommandRef: "command.public.bun_test",
+    requiredCapabilityRefs: ["capability.pylon.local_claude_agent"],
+    bidMsats: 2_000_000,
+    deadline: "deadline.public.lbr.20260630",
+    forumTopicRef: "topic.public.forum.labor_de6",
+    relays: ["wss://relay.openagents.com"],
+  })
+  const requestEvent = eventFrom(lbrAgenticCodingRequestToDraft(request), {
+    id: requestEventId,
+    pubkey: requesterPubkey,
+  })
+
+  const quote = makeLbrQuote({
+    requestId: requestEventId,
+    requesterPubkey,
+    amountMsats: 1_500_000,
+    providerRef: "provider.public.pylon.local_claude",
+    capabilityRefs: ["capability.pylon.local_claude_agent"],
+    quoteRef: "quote.public.lbr.de6_1",
+    expiresAt: "expiry.public.lbr.20260630",
+    requestRelay: "wss://relay.openagents.com",
+  })
+  const quoteEvent = eventFrom(lbrQuoteToDraft(quote), {
+    id: quoteEventId,
+    pubkey: providerPubkey,
+  })
+
+  const acceptance = makeLbrAcceptance({
+    requestId: requestEventId,
+    providerPubkey,
+    escrowReceiptRef: "receipt.public.escrow.de6_1",
+    acceptanceRef: "acceptance.public.lbr.de6_1",
+    requestRelay: "wss://relay.openagents.com",
+  })
+  const acceptanceEvent = eventFrom(lbrAcceptanceToDraft(acceptance), {
+    id: acceptanceEventId,
+    pubkey: requesterPubkey,
+  })
+
+  const result = makeLbrResult({
+    requestId: requestEventId,
+    requesterPubkey,
+    artifactRefs: ["artifact.public.lbr.patch_de6_1"],
+    platformCloseoutRef: "closeout.public.lbr.de6_1",
+    summaryRef: "summary.public.lbr.de6_1",
+    testRef: "test.public.lbr.bun",
+    buildRef: "build.public.lbr.de6_1",
+    requestRelay: "wss://relay.openagents.com",
+  })
+  const resultEvent = eventFrom(lbrResultToDraft(result), {
+    id: resultEventId,
+    pubkey: providerPubkey,
+  })
+
+  return { requestEvent, quoteEvent, acceptanceEvent, resultEvent }
+}
+
+describe("NIP-LBR labor-market closeout receipt", () => {
+  test("composes a content-addressed, dereferenceable closeout receipt", () => {
+    const lifecycle = buildLifecycle()
+    const closeout = makeLbrLaborCloseout(lifecycle)
+
+    expect(closeout.version).toBe(LBR_CLOSEOUT_RECEIPT_VERSION)
+    expect(closeout.requestId).toBe(requestEventId)
+    expect(closeout.requesterPubkey).toBe(requesterPubkey)
+    expect(closeout.providerPubkey).toBe(providerPubkey)
+    expect(closeout.bidMsats).toBe(2_000_000)
+    expect(closeout.quotedAmountMsats).toBe(1_500_000)
+    expect(closeout.objectiveRef).toBe("objective.public.lbr.fix_flaky_test")
+    expect(closeout.repositoryRefs).toEqual(["repo.public.openagents"])
+    expect(closeout.verificationCommandRef).toBe("command.public.bun_test")
+    expect(closeout.providerRef).toBe("provider.public.pylon.local_claude")
+    expect(closeout.quoteRef).toBe("quote.public.lbr.de6_1")
+    expect(closeout.acceptanceRef).toBe("acceptance.public.lbr.de6_1")
+    expect(closeout.escrowReceiptRef).toBe("receipt.public.escrow.de6_1")
+    expect(closeout.artifactRefs).toEqual(["artifact.public.lbr.patch_de6_1"])
+    expect(closeout.platformCloseoutRef).toBe("closeout.public.lbr.de6_1")
+    expect(closeout.summaryRef).toBe("summary.public.lbr.de6_1")
+    expect(closeout.testRef).toBe("test.public.lbr.bun")
+    expect(closeout.buildRef).toBe("build.public.lbr.de6_1")
+    expect(closeout.forumTopicRef).toBe("topic.public.forum.labor_de6")
+    expect(closeout.deadline).toBe("deadline.public.lbr.20260630")
+    expect(closeout.eventIds).toEqual({
+      request: requestEventId,
+      quote: quoteEventId,
+      acceptance: acceptanceEventId,
+      result: resultEventId,
+    })
+
+    // The receipt is a 64-hex content address bound to the request id.
+    expect(closeout.digest).toMatch(/^[a-f0-9]{64}$/)
+    expect(closeout.receiptRef).toBe(
+      `lbr-closeout:${requestEventId}:${closeout.digest}`,
+    )
+
+    // The dereference check: a reader holding only the receipt re-derives the
+    // digest from its public-safe fields and confirms it binds this lifecycle.
+    expect(verifyLbrLaborCloseoutDigest(closeout)).toBe(true)
+  })
+
+  test("is deterministic: the same lifecycle yields the same receipt", () => {
+    const a = makeLbrLaborCloseout(buildLifecycle())
+    const b = makeLbrLaborCloseout(buildLifecycle())
+    expect(b.digest).toBe(a.digest)
+    expect(b.receiptRef).toBe(a.receiptRef)
+  })
+
+  test("digest does not depend on canonical field order", () => {
+    const closeout = makeLbrLaborCloseout(buildLifecycle())
+    const { digest: _digest, receiptRef: _receiptRef, ...fields } = closeout
+    // Rebuild the canonical projection from a reordered object; the JSON the
+    // digest is taken over must be identical.
+    const reordered = {
+      eventIds: fields.eventIds,
+      deadline: fields.deadline,
+      digest: "ignored",
+      testRef: fields.testRef,
+      version: fields.version,
+      requestId: fields.requestId,
+      requesterPubkey: fields.requesterPubkey,
+      providerPubkey: fields.providerPubkey,
+      bidMsats: fields.bidMsats,
+      quotedAmountMsats: fields.quotedAmountMsats,
+      objectiveRef: fields.objectiveRef,
+      repositoryRefs: fields.repositoryRefs,
+      verificationCommandRef: fields.verificationCommandRef,
+      requiredCapabilityRefs: fields.requiredCapabilityRefs,
+      providerRef: fields.providerRef,
+      quoteRef: fields.quoteRef,
+      acceptanceRef: fields.acceptanceRef,
+      escrowReceiptRef: fields.escrowReceiptRef,
+      artifactRefs: fields.artifactRefs,
+      platformCloseoutRef: fields.platformCloseoutRef,
+      summaryRef: fields.summaryRef,
+      buildRef: fields.buildRef,
+      forumTopicRef: fields.forumTopicRef,
+    } as typeof fields
+    expect(canonicalLbrLaborCloseout(reordered)).toBe(
+      canonicalLbrLaborCloseout(fields),
+    )
+  })
+
+  test("tampering with any public-safe ref breaks the dereference", () => {
+    const closeout = makeLbrLaborCloseout(buildLifecycle())
+    const tampered = { ...closeout, summaryRef: "summary.public.lbr.swapped" }
+    expect(verifyLbrLaborCloseoutDigest(tampered)).toBe(false)
+
+    const tamperedAmount = { ...closeout, quotedAmountMsats: 1 }
+    expect(verifyLbrLaborCloseoutDigest(tamperedAmount)).toBe(false)
+
+    const tamperedReceiptRef = {
+      ...closeout,
+      receiptRef: `lbr-closeout:${requestEventId}:${"00".repeat(32)}`,
+    }
+    expect(verifyLbrLaborCloseoutDigest(tamperedReceiptRef)).toBe(false)
+  })
+
+  test("rejects a quote that exceeds the request max budget", () => {
+    const lifecycle = buildLifecycle()
+    const overBudgetQuote = makeLbrQuote({
+      requestId: requestEventId,
+      requesterPubkey,
+      amountMsats: 3_000_000, // request bid is 2_000_000
+      providerRef: "provider.public.pylon.local_claude",
+      capabilityRefs: ["capability.pylon.local_claude_agent"],
+      quoteRef: "quote.public.lbr.de6_over",
+    })
+    const overBudgetEvent = eventFrom(lbrQuoteToDraft(overBudgetQuote), {
+      id: quoteEventId,
+      pubkey: providerPubkey,
+    })
+    expect(() =>
+      makeLbrLaborCloseout({ ...lifecycle, quoteEvent: overBudgetEvent }),
+    ).toThrow(LbrProtocolError)
+  })
+
+  test("rejects a lifecycle whose events do not describe one job", () => {
+    const lifecycle = buildLifecycle()
+    // Quote for a different request id.
+    const foreignQuote = makeLbrQuote({
+      requestId: "ee".repeat(32),
+      requesterPubkey,
+      amountMsats: 1_000_000,
+      providerRef: "provider.public.pylon.local_claude",
+      capabilityRefs: ["capability.pylon.local_claude_agent"],
+      quoteRef: "quote.public.lbr.de6_foreign",
+    })
+    const foreignQuoteEvent = eventFrom(lbrQuoteToDraft(foreignQuote), {
+      id: quoteEventId,
+      pubkey: providerPubkey,
+    })
+    expect(() =>
+      makeLbrLaborCloseout({ ...lifecycle, quoteEvent: foreignQuoteEvent }),
+    ).toThrow(LbrProtocolError)
+  })
+
+  test("rejects mismatched parties (result author is not the quoting provider)", () => {
+    const lifecycle = buildLifecycle()
+    const impostorResult = {
+      ...lifecycle.resultEvent,
+      pubkey: "99".repeat(32),
+    }
+    expect(() =>
+      makeLbrLaborCloseout({ ...lifecycle, resultEvent: impostorResult }),
+    ).toThrow(LbrProtocolError)
+  })
+
+  test("rejects wrong-kind events", () => {
+    const lifecycle = buildLifecycle()
+    const wrongKindResult = { ...lifecycle.resultEvent, kind: 6930 }
+    expect(() =>
+      makeLbrLaborCloseout({ ...lifecycle, resultEvent: wrongKindResult }),
+    ).toThrow(LbrProtocolError)
+  })
+
+  test("inherits the ref-only safety guard (payment material is rejected)", () => {
+    const lifecycle = buildLifecycle()
+    const unsafeResult = {
+      ...lifecycle.resultEvent,
+      content: "payment_preimage=deadbeef",
+    }
+    expect(() =>
+      makeLbrLaborCloseout({ ...lifecycle, resultEvent: unsafeResult }),
+    ).toThrow(LbrProtocolError)
+  })
+})

--- a/packages/nip90/src/lbr-closeout.ts
+++ b/packages/nip90/src/lbr-closeout.ts
@@ -1,0 +1,334 @@
+/**
+ * NIP-LBR labor-market closeout receipt.
+ *
+ * The four LBR lifecycle helpers in `./lbr` produce the individual relay events
+ * for an agentic-coding labor job: request (`5934`), quote (`7000`), acceptance
+ * (`7000`), and result (`6934`). What was missing was a single composed object
+ * that binds one complete lifecycle into a content-addressed, public-safe
+ * receipt the labor market can dereference and re-verify — the same shape the
+ * NIP-DS data market already has via `verifyDatasetDeliveryDescriptorDigest`.
+ *
+ * This module adds exactly that, and nothing more. It is protocol-only and
+ * ref-only:
+ *
+ * - It does NOT create invoices, move sats, open wallets, escrow funds, or
+ *   grant settlement authority. The relay is transport; settlement authority
+ *   stays in the platform receipt systems, per `docs/nips/LBR.md`.
+ * - The receipt carries only the public-safe refs that already passed the
+ *   ref/payment-material guards in `./lbr`, plus a SHA-256 digest over a
+ *   canonical projection of those refs.
+ * - `verifyLbrLaborCloseoutDigest` lets any reader independently re-derive the
+ *   digest and confirm the receipt dereferences the exact lifecycle that
+ *   produced it.
+ */
+
+import { sha256Hex } from "nostr-effect/nip90"
+
+import {
+  LBR_AGENTIC_CODING_REQUEST_KIND,
+  LBR_AGENTIC_CODING_RESULT_KIND,
+  LBR_FEEDBACK_KIND,
+  LbrProtocolError,
+  decodeLbrAcceptanceEvent,
+  decodeLbrAgenticCodingRequestEvent,
+  decodeLbrQuoteEvent,
+  decodeLbrResultEvent,
+  type LbrAcceptance,
+  type LbrAgenticCodingRequest,
+  type LbrQuote,
+  type LbrResult,
+} from "./lbr.js"
+
+export const LBR_CLOSEOUT_RECEIPT_VERSION = "nip-lbr-closeout.v1"
+
+/**
+ * The signed relay-event shape the closeout receipt binds to. This is the same
+ * shape the NIP-DS smoke flow signs and reads back from the relay (a Nostr
+ * event with `id`, author `pubkey`, `kind`, `created_at`, `tags`, `content`,
+ * and `sig`), so callers can pass either a freshly signed event or one read
+ * back from a relay without coupling this package to a signer. The signature is
+ * not re-verified here — the relay does that on accept; the closeout binds the
+ * accepted event ids and re-decodes the ref-only payloads through `./lbr`.
+ */
+export type LbrLifecycleEvent = Readonly<{
+  id: string
+  pubkey: string
+  kind: number
+  created_at: number
+  tags: ReadonlyArray<readonly string[]>
+  content: string
+  sig: string
+}>
+
+export type LbrLaborCloseoutInput = Readonly<{
+  requestEvent: LbrLifecycleEvent
+  quoteEvent: LbrLifecycleEvent
+  acceptanceEvent: LbrLifecycleEvent
+  resultEvent: LbrLifecycleEvent
+}>
+
+/**
+ * The public-safe, content-addressed labor-market closeout receipt. Every field
+ * is a ref or hex id that already cleared the `./lbr` ref/payment guards; the
+ * `digest` is a SHA-256 over the canonical projection below, so the receipt is
+ * dereferenceable: a reader re-derives the digest from the refs and confirms it
+ * matches.
+ */
+export type LbrLaborCloseout = Readonly<{
+  version: typeof LBR_CLOSEOUT_RECEIPT_VERSION
+  /** `lbr-closeout:<requestId>:<digest>` — a stable, ref-only receipt ref. */
+  receiptRef: string
+  requestId: string
+  requesterPubkey: string
+  providerPubkey: string
+  bidMsats: number
+  quotedAmountMsats: number
+  objectiveRef: string
+  repositoryRefs: ReadonlyArray<string>
+  verificationCommandRef: string
+  requiredCapabilityRefs: ReadonlyArray<string>
+  providerRef: string
+  quoteRef: string
+  acceptanceRef: string
+  escrowReceiptRef: string
+  artifactRefs: ReadonlyArray<string>
+  platformCloseoutRef: string
+  summaryRef: string
+  testRef: string
+  buildRef?: string
+  forumTopicRef?: string
+  deadline?: string
+  eventIds: Readonly<{
+    request: string
+    quote: string
+    acceptance: string
+    result: string
+  }>
+  /** SHA-256 hex over `canonicalLbrLaborCloseout(...)`. */
+  digest: string
+}>
+
+const eventIdPattern = /^[a-f0-9]{64}$/i
+
+const fail = (code: string, message: string): never => {
+  throw new LbrProtocolError(code, message)
+}
+
+const ensureEventId = (value: unknown, field: string): string => {
+  if (typeof value !== "string" || !eventIdPattern.test(value)) {
+    return fail("invalid_event_id", `${field} must be a 32-byte hex event id`)
+  }
+  return value.toLowerCase()
+}
+
+const ensureKind = (value: number, expected: number, field: string): void => {
+  if (value !== expected) {
+    fail("invalid_kind", `${field} must use kind ${expected}`)
+  }
+}
+
+/**
+ * Canonical, deterministic projection of the closeout's public-safe content.
+ * The digest is taken over this string, so it is independent of object key
+ * order and of any non-content fields (the `digest`/`receiptRef` themselves are
+ * excluded to avoid a self-referential hash).
+ */
+export const canonicalLbrLaborCloseout = (
+  fields: Omit<LbrLaborCloseout, "digest" | "receiptRef">,
+): string =>
+  JSON.stringify({
+    version: fields.version,
+    requestId: fields.requestId,
+    requesterPubkey: fields.requesterPubkey,
+    providerPubkey: fields.providerPubkey,
+    bidMsats: fields.bidMsats,
+    quotedAmountMsats: fields.quotedAmountMsats,
+    objectiveRef: fields.objectiveRef,
+    repositoryRefs: [...fields.repositoryRefs],
+    verificationCommandRef: fields.verificationCommandRef,
+    requiredCapabilityRefs: [...fields.requiredCapabilityRefs],
+    providerRef: fields.providerRef,
+    quoteRef: fields.quoteRef,
+    acceptanceRef: fields.acceptanceRef,
+    escrowReceiptRef: fields.escrowReceiptRef,
+    artifactRefs: [...fields.artifactRefs],
+    platformCloseoutRef: fields.platformCloseoutRef,
+    summaryRef: fields.summaryRef,
+    testRef: fields.testRef,
+    buildRef: fields.buildRef ?? null,
+    forumTopicRef: fields.forumTopicRef ?? null,
+    deadline: fields.deadline ?? null,
+    eventIds: {
+      request: fields.eventIds.request,
+      quote: fields.eventIds.quote,
+      acceptance: fields.eventIds.acceptance,
+      result: fields.eventIds.result,
+    },
+  })
+
+const buildCloseoutFields = (
+  events: {
+    requestEvent: LbrLifecycleEvent
+    quoteEvent: LbrLifecycleEvent
+    acceptanceEvent: LbrLifecycleEvent
+    resultEvent: LbrLifecycleEvent
+  },
+  decoded: {
+    request: LbrAgenticCodingRequest
+    quote: LbrQuote
+    acceptance: LbrAcceptance
+    result: LbrResult
+  },
+): Omit<LbrLaborCloseout, "digest" | "receiptRef"> => {
+  const requestId = decoded.quote.requestId
+
+  // The four events must describe ONE job: every lifecycle event's requestId
+  // must equal the request event id, and the parties must be consistent.
+  const requestEventId = ensureEventId(events.requestEvent.id, "request event id")
+  if (decoded.quote.requestId !== requestEventId) {
+    fail("mismatched_request", "quote requestId must equal the request event id")
+  }
+  if (decoded.acceptance.requestId !== requestEventId) {
+    fail(
+      "mismatched_request",
+      "acceptance requestId must equal the request event id",
+    )
+  }
+  if (decoded.result.labor.result.requestId !== requestEventId) {
+    fail("mismatched_request", "result requestId must equal the request event id")
+  }
+
+  const requesterPubkey = ensureEventId(
+    events.requestEvent.pubkey,
+    "requester pubkey",
+  )
+  if (decoded.quote.requesterPubkey !== requesterPubkey) {
+    fail("mismatched_party", "quote requester must equal the request author")
+  }
+  if (decoded.result.labor.result.customerPubkey !== requesterPubkey) {
+    fail("mismatched_party", "result customer must equal the request author")
+  }
+
+  const providerPubkey = ensureEventId(
+    events.quoteEvent.pubkey,
+    "provider pubkey",
+  )
+  if (decoded.acceptance.providerPubkey !== providerPubkey) {
+    fail(
+      "mismatched_party",
+      "acceptance provider must equal the quote author",
+    )
+  }
+  if (ensureEventId(events.resultEvent.pubkey, "result author") !== providerPubkey) {
+    fail("mismatched_party", "result author must equal the quote author")
+  }
+
+  if (decoded.quote.amountMsats > decoded.request.bidMsats) {
+    fail(
+      "quote_over_budget",
+      "quoted amount must not exceed the request max budget bid",
+    )
+  }
+
+  return {
+    version: LBR_CLOSEOUT_RECEIPT_VERSION,
+    requestId,
+    requesterPubkey,
+    providerPubkey,
+    bidMsats: decoded.request.bidMsats,
+    quotedAmountMsats: decoded.quote.amountMsats,
+    objectiveRef: decoded.request.objectiveRef,
+    repositoryRefs: decoded.request.repositoryRefs,
+    verificationCommandRef: decoded.request.verificationCommandRef,
+    requiredCapabilityRefs: decoded.request.requiredCapabilityRefs,
+    providerRef: decoded.quote.providerRef,
+    quoteRef: decoded.quote.quoteRef,
+    acceptanceRef: decoded.acceptance.acceptanceRef,
+    escrowReceiptRef: decoded.acceptance.escrowReceiptRef,
+    artifactRefs: decoded.result.artifactRefs,
+    platformCloseoutRef: decoded.result.platformCloseoutRef,
+    summaryRef: decoded.result.summaryRef,
+    testRef: decoded.result.testRef,
+    ...(decoded.result.buildRef === undefined
+      ? {}
+      : { buildRef: decoded.result.buildRef }),
+    ...(decoded.request.forumTopicRef === undefined
+      ? {}
+      : { forumTopicRef: decoded.request.forumTopicRef }),
+    ...(decoded.request.deadline === undefined
+      ? {}
+      : { deadline: decoded.request.deadline }),
+    eventIds: {
+      request: requestEventId,
+      quote: ensureEventId(events.quoteEvent.id, "quote event id"),
+      acceptance: ensureEventId(events.acceptanceEvent.id, "acceptance event id"),
+      result: ensureEventId(events.resultEvent.id, "result event id"),
+    },
+  }
+}
+
+/**
+ * Compose one complete LBR labor lifecycle into a content-addressed,
+ * public-safe closeout receipt. Each input event is re-decoded through the
+ * existing `./lbr` guards (so raw prompts, private paths, credentials, and
+ * payment material are rejected here too), the four events are checked for
+ * consistency (one job, consistent parties, quote within budget), and the
+ * canonical projection is hashed.
+ */
+export const makeLbrLaborCloseout = (
+  input: LbrLaborCloseoutInput,
+): LbrLaborCloseout => {
+  ensureKind(
+    input.requestEvent.kind,
+    LBR_AGENTIC_CODING_REQUEST_KIND,
+    "request event",
+  )
+  ensureKind(input.quoteEvent.kind, LBR_FEEDBACK_KIND, "quote event")
+  ensureKind(input.acceptanceEvent.kind, LBR_FEEDBACK_KIND, "acceptance event")
+  ensureKind(input.resultEvent.kind, LBR_AGENTIC_CODING_RESULT_KIND, "result event")
+
+  const decoded = {
+    request: decodeLbrAgenticCodingRequestEvent(input.requestEvent),
+    quote: decodeLbrQuoteEvent(input.quoteEvent),
+    acceptance: decodeLbrAcceptanceEvent(input.acceptanceEvent),
+    result: decodeLbrResultEvent(input.resultEvent),
+  }
+
+  const fields = buildCloseoutFields(
+    {
+      requestEvent: input.requestEvent,
+      quoteEvent: input.quoteEvent,
+      acceptanceEvent: input.acceptanceEvent,
+      resultEvent: input.resultEvent,
+    },
+    decoded,
+  )
+
+  const digest = sha256Hex(canonicalLbrLaborCloseout(fields))
+
+  return {
+    ...fields,
+    receiptRef: `lbr-closeout:${fields.requestId}:${digest}`,
+    digest,
+  }
+}
+
+/**
+ * Re-derive the closeout digest from the receipt's own public-safe fields and
+ * confirm it matches the recorded `digest`. This is the dereference check: a
+ * reader who holds only the receipt can independently prove it binds the exact
+ * lifecycle that produced it, and that the `receiptRef` is consistent with the
+ * content. Returns `true` only when both the digest and the derived
+ * `receiptRef` match.
+ */
+export const verifyLbrLaborCloseoutDigest = (
+  closeout: LbrLaborCloseout,
+): boolean => {
+  const { digest: _digest, receiptRef: _receiptRef, ...fields } = closeout
+  const derivedDigest = sha256Hex(canonicalLbrLaborCloseout(fields))
+  const derivedReceiptRef = `lbr-closeout:${closeout.requestId}:${derivedDigest}`
+  return (
+    derivedDigest === closeout.digest &&
+    derivedReceiptRef === closeout.receiptRef
+  )
+}

--- a/packages/nip90/tsconfig.json
+++ b/packages/nip90/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "types": ["bun-types"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "scripts/**/*"]
 }


### PR DESCRIPTION
## Promise + why most-ready

**`markets.open_protocol_markets.v1`** (DE-6), specifically the **labor**
market's dippable + dereferenceable-receipt rung.

DE-6's receipt acceptance is "all six markets dippable + unified surface
receipt." The **data** market (NIP-DS) already had a dippable end-to-end
producer with a verifiable receipt (`apps/openagents.com/scripts/nip-ds.ts` +
`verifyDatasetDeliveryDescriptorDigest`). The **labor** market (NIP-LBR) had the
full ref-only lifecycle protocol in `packages/nip90/src/lbr.ts` (request `5934`,
quote/acceptance `7000`, result `6934`) but **no composed closeout object and no
dereferenceable receipt** — no labor analogue of NIP-DS's digest verification.
That was the exact missing "dippable + receipt" rung, buildable purely on the
in-scope `packages/nip90` surface with no money, no live market, no other lane.
The rest of DE-6 is money/owner-gated (the capstone, signature settlement) or
needs runtime work outside this scope.

## What I built (all on `packages/nip90` + `docs/promises/`)

- **`packages/nip90/src/lbr-closeout.ts`** — `makeLbrLaborCloseout(...)` composes
  the four accepted LBR events into one public-safe, content-addressed
  `LbrLaborCloseout`. It re-decodes each event through the existing `./lbr`
  ref/payment-material guards, checks the four describe **one** job (consistent
  `requestId`; requester = request author across quote/result; provider = quote
  author across acceptance/result), enforces **quote ≤ request budget**, and
  hashes a deterministic canonical projection into a SHA-256 `digest` +
  `receiptRef` of `lbr-closeout:<requestId>:<digest>`.
  `verifyLbrLaborCloseoutDigest(...)` re-derives both and fails closed on tamper.
- **`packages/nip90/scripts/lbr-closeout-proof.ts`** — labor analogue of
  `nip-ds.ts`. Offline by default: signs a real lifecycle, composes the
  closeout, prints `closeoutDereferenced: true`. `--relay <url>` also publishes
  the four events to a scoped relay and reads them back (the relay accepts
  5934/7000/6934 under `market-policy.ts`).
- 9 new tests, index export, README contract, tsconfig covers `scripts/**`.
- `docs/promises/2026-06-23-de6-lbr-labor-closeout-dereferenceable-receipt.md`.

Protocol-only and ref-only throughout: **moves no sats, opens no escrow, creates
no invoice, publishes nothing private, grants no settlement authority.**

## The dereferenceable receipt (proof)

`bun packages/nip90/scripts/lbr-closeout-proof.ts` (offline) emits four real
signed Nostr events (kinds `[5934, 7000, 7000, 6934]`, real 32-byte hex ids), a
`receiptRef = lbr-closeout:<requestId>:<digest>` (digest = SHA-256 over the
canonical ref-only projection), and **`closeoutDereferenced: true`** —
`verifyLbrLaborCloseoutDigest` re-derived the digest + receiptRef from the
receipt's own public-safe fields and they match. This is the labor-market shape
of DE-6's "dippable market + dereferenceable receipt" rung at the
protocol/receipt layer.

## State / green count

**No promise state flips. Green count unchanged.** `markets.open_protocol_markets.v1`
**stays `planned`**; its blockers (liquidity/risk unbuilt, compute/data not
broadly live) are untouched — this strengthens the labor receipt machinery, not
those markets.

## EXACT remaining owner step (the single flip, flagged)

Run a real labor job through a live scoped relay with a real requester and a
real independent provider, escrow real budget through the platform ledger, then
record the owner-signed green-flip `promise_transition` per
`proof.claim_upgrade_receipts.v1`. (Liquidity/risk + broad live compute/data
markets are the larger remaining work for the unified six-market green, tracked
by the promise's own blockers.)

## Tests

- `bun run --cwd packages/nip90 test` — 17 pass (9 new closeout tests)
- `bun run --cwd packages/nip90 typecheck` — clean (incl. `scripts/**`)
- `bun run --cwd apps/nostr-relay test` — 28 pass
- `bun test apps/pylon/tests/nip90-import.test.ts` — 1 pass (export surface intact)

No deploy, no money movement.

Part of EPIC #5529. DO NOT auto-merge — orchestrator reviews/merges.