### PR TITLE
Khala quantization eval gate: quant metadata in receipts + same-model-claim guard + quality/cost eval gate (book P1-7, #6090)

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/khala-quantization-eval-gate.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-quantization-eval-gate.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+import type { AcceptanceVerdict } from './acceptance-runner/verdict'
+import {
+  DEFAULT_QUANT_GATE_POLICY,
+  RealQuantSweepNotArmedError,
+  collectRealQuantSweepSamples,
+  runQuantizationEvalGate,
+  type QuantizationComparisonSample,
+} from './khala-quantization-eval-gate'
+
+// Build a deterministic EXECUTED acceptance verdict fixture. `verified` is the
+// quality signal the gate counts; we vary it per-sample to set accepted rates.
+const verdict = (verified: boolean): AcceptanceVerdict => ({
+  kind: 'crossy_road_single_html',
+  executed: true,
+  rubricRef: 'rubric.khala_code.crossy_road.single_html.v1',
+  checks: [
+    {
+      id: 'loads_without_errors',
+      passed: verified,
+      detail: verified ? 'loaded clean' : 'console error on load',
+    },
+  ],
+  passedChecks: verified ? ['loads_without_errors'] : [],
+  failedChecks: verified ? [] : ['loads_without_errors'],
+  scalarReward: verified ? 1 : 0,
+  verified,
+  consoleErrors: verified ? [] : ['boom'],
+  pageErrors: [],
+})
+
+// Build a paired comparison sample: same task, original vs quantized verdict +
+// cost. The quantized cost is typically lower (the throughput win).
+const sample = (input: {
+  taskId: string
+  originalVerified: boolean
+  quantizedVerified: boolean
+  originalCostBasisMsat: number
+  quantizedCostBasisMsat: number
+}): QuantizationComparisonSample => ({
+  taskId: input.taskId,
+  originalVerdict: verdict(input.originalVerified),
+  quantizedVerdict: verdict(input.quantizedVerified),
+  originalCostBasisMsat: input.originalCostBasisMsat,
+  quantizedCostBasisMsat: input.quantizedCostBasisMsat,
+})
+
+// A 4-task baseline where the original precision passes 4/4 and is more expensive.
+const heldQualitySet: ReadonlyArray<QuantizationComparisonSample> = [
+  sample({ taskId: 't1', originalVerified: true, quantizedVerified: true, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 600 }),
+  sample({ taskId: 't2', originalVerified: true, quantizedVerified: true, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 600 }),
+  sample({ taskId: 't3', originalVerified: true, quantizedVerified: true, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 600 }),
+  sample({ taskId: 't4', originalVerified: true, quantizedVerified: true, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 600 }),
+]
+
+describe('quantization eval gate — quality holds (book P1-7 / #6090)', () => {
+  it('PASSES when the quantized lane holds the accepted-outcome rate', () => {
+    const result = runQuantizationEvalGate({
+      samples: heldQualitySet,
+      scope: 'weights_only',
+    })
+    expect(result.passed).toBe(true)
+    expect(result.reason).toBe('accepted_rate_held')
+    expect(result.originalAcceptedRate).toBe(1)
+    expect(result.quantizedAcceptedRate).toBe(1)
+    expect(result.acceptedRateDeltaAbs).toBe(0)
+    // Decision-grade defaults OFF — the fixture gate proves the LOGIC.
+    expect(result.decisionGrade).toBe(false)
+  })
+
+  it('PASSES when quality improves', () => {
+    const set = [
+      sample({ taskId: 't1', originalVerified: false, quantizedVerified: true, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 600 }),
+      sample({ taskId: 't2', originalVerified: true, quantizedVerified: true, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 600 }),
+    ]
+    const result = runQuantizationEvalGate({ samples: set, scope: 'weights_only' })
+    expect(result.passed).toBe(true)
+    expect(result.reason).toBe('accepted_rate_held')
+    expect(result.acceptedRateDeltaAbs).toBeGreaterThan(0)
+  })
+})
+
+describe('quantization eval gate — quality drops (the LOSS rule)', () => {
+  it('FAILS when the accepted-outcome rate drops beyond the bound, no matter the cost win', () => {
+    // Original 4/4 accepted; quantized 2/4 => a 0.5 absolute drop, way past the
+    // 0.02 bound. Even though quantized is far cheaper, this is a LOSS.
+    const set = [
+      sample({ taskId: 't1', originalVerified: true, quantizedVerified: true, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 100 }),
+      sample({ taskId: 't2', originalVerified: true, quantizedVerified: true, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 100 }),
+      sample({ taskId: 't3', originalVerified: true, quantizedVerified: false, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 100 }),
+      sample({ taskId: 't4', originalVerified: true, quantizedVerified: false, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 100 }),
+    ]
+    const result = runQuantizationEvalGate({ samples: set, scope: 'weights_only' })
+    expect(result.passed).toBe(false)
+    expect(result.reason).toBe('accepted_rate_dropped_beyond_bound')
+    expect(result.acceptedRateDeltaAbs).toBeLessThan(0)
+  })
+
+  it('FAILS a small drop with NO sufficient cost-per-accepted improvement', () => {
+    // Build a large set so a single-task drop is a SMALL absolute drop (1/100 =
+    // 0.01, within the 0.02 bound) but with NO cost win (costs are equal).
+    const set: Array<QuantizationComparisonSample> = []
+    for (let i = 0; i < 100; i += 1) {
+      const quantizedVerified = i !== 0 // task 0 fails on quantized only
+      set.push(
+        sample({
+          taskId: `t${i}`,
+          originalVerified: true,
+          quantizedVerified,
+          originalCostBasisMsat: 1000,
+          quantizedCostBasisMsat: 1000, // no cost win
+        }),
+      )
+    }
+    const result = runQuantizationEvalGate({ samples: set, scope: 'weights_only' })
+    expect(result.passed).toBe(false)
+    expect(result.reason).toBe('accepted_rate_dropped_without_cost_win')
+    // The drop is within the bound...
+    expect(-(result.acceptedRateDeltaAbs ?? 0)).toBeLessThanOrEqual(
+      DEFAULT_QUANT_GATE_POLICY.maxAcceptedRateDropAbs,
+    )
+  })
+
+  it('PASSES a small drop that IS bought back by a cost-per-accepted improvement', () => {
+    // Same small drop (1/100) but the quantized lane is much cheaper, so
+    // cost-per-accepted-outcome improves past the 0.15 fractional threshold.
+    const set: Array<QuantizationComparisonSample> = []
+    for (let i = 0; i < 100; i += 1) {
+      const quantizedVerified = i !== 0
+      set.push(
+        sample({
+          taskId: `t${i}`,
+          originalVerified: true,
+          quantizedVerified,
+          originalCostBasisMsat: 1000,
+          quantizedCostBasisMsat: 400, // big cost win
+        }),
+      )
+    }
+    const result = runQuantizationEvalGate({ samples: set, scope: 'weights_only' })
+    expect(result.passed).toBe(true)
+    expect(result.reason).toBe('cost_per_accepted_improved_offsets_drop')
+    expect(result.costPerAcceptedImprovementFrac).toBeGreaterThanOrEqual(
+      DEFAULT_QUANT_GATE_POLICY.minCostPerAcceptedImprovementFrac,
+    )
+  })
+})
+
+describe('quantization eval gate — policy and edge cases', () => {
+  it('FAILS an aggressive scope without the owner ack even when metrics hold', () => {
+    const result = runQuantizationEvalGate({
+      samples: heldQualitySet,
+      scope: 'kv_cache',
+    })
+    expect(result.passed).toBe(false)
+    expect(result.reason).toBe('aggressive_scope_requires_ack')
+    expect(result.aggressiveScope).toBe(true)
+  })
+
+  it('PASSES an aggressive scope WITH the owner ack when metrics hold', () => {
+    const result = runQuantizationEvalGate({
+      samples: heldQualitySet,
+      scope: 'kv_cache',
+      aggressiveScopeAck: true,
+    })
+    expect(result.passed).toBe(true)
+    expect(result.reason).toBe('accepted_rate_held')
+  })
+
+  it('FAILS with no comparison samples', () => {
+    const result = runQuantizationEvalGate({ samples: [], scope: 'weights_only' })
+    expect(result.passed).toBe(false)
+    expect(result.reason).toBe('no_comparison_samples')
+  })
+
+  it('FAILS when the original precision produced no accepted outcomes (no baseline)', () => {
+    const set = [
+      sample({ taskId: 't1', originalVerified: false, quantizedVerified: false, originalCostBasisMsat: 1000, quantizedCostBasisMsat: 600 }),
+    ]
+    const result = runQuantizationEvalGate({ samples: set, scope: 'weights_only' })
+    expect(result.passed).toBe(false)
+    expect(result.reason).toBe('no_baseline_accepted_outcomes')
+    // cost-per-accepted is null (zero accepted) — never a fabricated 0.
+    expect(result.originalCostPerAcceptedMsat).toBeNull()
+  })
+})
+
+describe('real quantized-vs-original sweep is FLAG/OWNER/COMPUTE-GATED off', () => {
+  it('throws RealQuantSweepNotArmedError when not armed', () => {
+    expect(() =>
+      collectRealQuantSweepSamples({ armRealQuantSweep: false }),
+    ).toThrow(RealQuantSweepNotArmedError)
+  })
+
+  it('throws even if armRealQuantSweep:true but no executor is provided', () => {
+    expect(() =>
+      collectRealQuantSweepSamples({ armRealQuantSweep: true }),
+    ).toThrow(RealQuantSweepNotArmedError)
+  })
+
+  it('delegates to the executor only when explicitly owner-armed', () => {
+    const samples = collectRealQuantSweepSamples({
+      armRealQuantSweep: true,
+      executor: () => heldQualitySet,
+    })
+    expect(samples).toHaveLength(heldQualitySet.length)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-quantization-eval-gate.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-quantization-eval-gate.ts
@@ -1,0 +1,431 @@
+// Khala QUANTIZATION EVAL GATE (book P1-7 / #6090).
+//
+// THE GATE (book Ch.5, in our own words):
+// ---------------------------------------
+// Quantization is only allowed to claim the public model if it is PROVEN against
+// product evals — never assumed safe from a throughput number. The gate scores a
+// quantized lane against the ORIGINAL precision on EXECUTED checks (reusing the
+// P0-4 executed Khala-code verifier — `AcceptanceVerdict` — not a regex over
+// source) and computes the cost-per-accepted-outcome delta. The verdict:
+//
+//   PASS the quantized lane ONLY when accepted-outcome quality HOLDS (within an
+//   agreed bound), OR — if quality drops slightly — when cost-per-accepted-outcome
+//   IMPROVES enough to be a net win. A throughput/cost win that lowers the
+//   accepted-outcome rate without improving cost-per-accepted-outcome is a LOSS.
+//
+// REUSE, DO NOT FORK:
+//   - the executed-acceptance verdict shape (`AcceptanceVerdict` from the P0-4
+//     verifier) is the per-sample quality signal — an EXECUTED pass/fail, never a
+//     source heuristic;
+//   - the benchmark report's cost-per-accepted-outcome math (P1-5) is the cost
+//     metric — we aggregate the same way (total cost basis / accepted outcomes,
+//     null when zero accepted, never a fake 0);
+//   - the benchmark runner could drive a real quantized vs original sweep; THAT
+//     real sweep is FLAG/OWNER/COMPUTE-GATED (see `RealQuantSweepNotArmedError`).
+//     By default the gate scores DETERMINISTIC fixture comparison sets — no real
+//     quantized serving, no spend.
+//
+// HONESTY: a fixture comparison is labeled `decisionGrade:false`. A real,
+// production-promoting gate decision requires the owner-armed real sweep over
+// realistic traffic. The default path proves the GATE LOGIC, not a real lane.
+//
+// PURE: no Worker, no clock, no randomness, no IO. Same inputs => same verdict.
+import type { AcceptanceVerdict } from './acceptance-runner/verdict'
+import type { KhalaQuantizationScope } from './khala-quantization'
+import { isAggressiveScope } from './khala-quantization'
+
+// ---------------------------------------------------------------------------
+// A single comparison sample: the SAME task scored on both precisions.
+// ---------------------------------------------------------------------------
+
+// One executed comparison: a single Khala-code task run on BOTH the original
+// precision and the candidate quantized precision, each producing an EXECUTED
+// acceptance verdict + a measured cost basis. Pairing per-task means the gate
+// compares like-for-like (same prompt, same acceptance suite) — the book's
+// "change one variable" discipline applied to precision.
+export type QuantizationComparisonSample = Readonly<{
+  // A stable id for the task being compared (e.g. an artifact-gen scenario id).
+  taskId: string
+  // The EXECUTED acceptance verdict on the ORIGINAL (full) precision. `executed`
+  // is always true on this shape — it is only produced after a real headless run
+  // (or a deterministic fixture verdict for the default gate path).
+  originalVerdict: AcceptanceVerdict
+  // The EXECUTED acceptance verdict on the CANDIDATE quantized precision.
+  quantizedVerdict: AcceptanceVerdict
+  // Cost basis in msat for the original-precision run (P1-5 cost metric).
+  originalCostBasisMsat: number
+  // Cost basis in msat for the quantized run (typically lower — the throughput
+  // win — which is exactly why quality must be proven to hold).
+  quantizedCostBasisMsat: number
+}>
+
+// ---------------------------------------------------------------------------
+// The gate policy (the agreed bounds).
+// ---------------------------------------------------------------------------
+
+// The thresholds the gate decision uses. Defaults are conservative: a quantized
+// lane must hold accepted-outcome rate within a small absolute drop, and any
+// allowed drop must be paid for by a cost-per-accepted-outcome improvement.
+export type QuantizationGatePolicy = Readonly<{
+  // The maximum ABSOLUTE accepted-outcome-rate drop tolerated when the rate drops
+  // (e.g. 0.02 = 2 percentage points). A drop strictly within this AND offset by
+  // a cost-per-accepted-outcome win can still pass; a larger drop never passes.
+  maxAcceptedRateDropAbs: number
+  // The minimum FRACTIONAL cost-per-accepted-outcome improvement required to
+  // "buy back" an accepted-rate drop (e.g. 0.15 = the quantized lane must be at
+  // least 15% cheaper per accepted outcome). Only consulted when the rate dropped.
+  minCostPerAcceptedImprovementFrac: number
+  // Whether an AGGRESSIVE quantization scope (KV-cache / attention) requires an
+  // explicit owner acknowledgement to pass even when the metrics hold (book
+  // policy: weights-only / FP8 before aggressive KV/attention quant). Default true.
+  requireAckForAggressiveScope: boolean
+}>
+
+export const DEFAULT_QUANT_GATE_POLICY: QuantizationGatePolicy = {
+  maxAcceptedRateDropAbs: 0.02,
+  minCostPerAcceptedImprovementFrac: 0.15,
+  requireAckForAggressiveScope: true,
+}
+
+// ---------------------------------------------------------------------------
+// The gate decision result.
+// ---------------------------------------------------------------------------
+
+// Why the gate reached its decision (stable, neutral refs).
+export type QuantizationGateReason =
+  // Accepted-outcome rate held within the agreed bound — clean pass.
+  | 'accepted_rate_held'
+  // Accepted rate dropped but cost-per-accepted-outcome improved enough — net win.
+  | 'cost_per_accepted_improved_offsets_drop'
+  // Accepted rate dropped beyond the bound — quality loss, FAIL.
+  | 'accepted_rate_dropped_beyond_bound'
+  // Accepted rate dropped within the bound but cost-per-accepted did not improve
+  // enough to pay for it — not a net win, FAIL.
+  | 'accepted_rate_dropped_without_cost_win'
+  // An aggressive scope (KV-cache / attention) lacked the required owner ack.
+  | 'aggressive_scope_requires_ack'
+  // No accepted outcomes on the ORIGINAL precision — there is nothing to hold; the
+  // comparison is undefined and cannot pass.
+  | 'no_baseline_accepted_outcomes'
+  // No comparison samples at all.
+  | 'no_comparison_samples'
+
+export type QuantizationGateResult = Readonly<{
+  schemaVersion: 'openagents.khala.quant-eval-gate.v1'
+  // The headline: may the quantized lane be promoted to claim the public model?
+  passed: boolean
+  reason: QuantizationGateReason
+  detail: string
+  // How many task comparisons fed the decision.
+  sampleCount: number
+  // Accepted-outcome rate on each precision (accepted / attempted EXECUTED
+  // checks). null when no executed attempts existed on that side.
+  originalAcceptedRate: number | null
+  quantizedAcceptedRate: number | null
+  // The ABSOLUTE accepted-rate delta (quantized − original). Negative = a drop.
+  // null when either rate is null.
+  acceptedRateDeltaAbs: number | null
+  // Cost-per-accepted-outcome (msat) on each precision (P1-5 metric). null when a
+  // side had zero accepted outcomes (dividing would fabricate a number).
+  originalCostPerAcceptedMsat: number | null
+  quantizedCostPerAcceptedMsat: number | null
+  // The FRACTIONAL cost-per-accepted improvement (positive = quantized cheaper
+  // per accepted outcome). null when either side is null.
+  costPerAcceptedImprovementFrac: number | null
+  // Whether the candidate scope is aggressive (KV-cache / attention).
+  aggressiveScope: boolean
+  // Whether this is a decision-grade gate (an owner-armed real sweep over real
+  // traffic) vs the default fixture gate (proves the gate logic only).
+  decisionGrade: boolean
+}>
+
+// ---------------------------------------------------------------------------
+// Aggregation helpers (reuse the P1-5 accepted-outcome + cost math shape).
+// ---------------------------------------------------------------------------
+
+// Count accepted outcomes (verified executed verdicts) and attempts across one
+// side of the comparison. An `AcceptanceVerdict` is EXECUTED by construction; we
+// count one ATTEMPT per verdict and one ACCEPTED per `verified` verdict.
+const tallySide = (
+  verdicts: ReadonlyArray<AcceptanceVerdict>,
+  costs: ReadonlyArray<number>,
+): {
+  attempted: number
+  accepted: number
+  totalCostMsat: number
+} => {
+  let attempted = 0
+  let accepted = 0
+  for (const verdict of verdicts) {
+    attempted += 1
+    if (verdict.verified) {
+      accepted += 1
+    }
+  }
+  const totalCostMsat = costs.reduce((sum, cost) => sum + cost, 0)
+  return { attempted, accepted, totalCostMsat }
+}
+
+// Accepted-outcome RATE: accepted / attempted. null when nothing was attempted
+// (the honest absence, never a fabricated 0).
+const acceptedRate = (accepted: number, attempted: number): number | null =>
+  attempted === 0 ? null : accepted / attempted
+
+// Cost-per-accepted-outcome (msat): total cost / accepted. null when zero
+// accepted — undefined cost-per-outcome is itself a finding, NOT a 0 (this is the
+// exact rule the P1-5 report follows).
+const costPerAccepted = (
+  totalCostMsat: number,
+  accepted: number,
+): number | null => (accepted === 0 ? null : totalCostMsat / accepted)
+
+// ---------------------------------------------------------------------------
+// The gate.
+// ---------------------------------------------------------------------------
+
+export type QuantizationGateInput = Readonly<{
+  // The per-task paired comparisons (original vs quantized, executed).
+  samples: ReadonlyArray<QuantizationComparisonSample>
+  // The candidate quantization scope (drives the aggressive-scope policy).
+  scope: KhalaQuantizationScope
+  // Owner acknowledgement of an aggressive scope (KV-cache / attention). Required
+  // to pass an aggressive-scope candidate when the policy demands it.
+  aggressiveScopeAck?: boolean | undefined
+  // Whether this result is decision-grade (an owner-armed real sweep). Default
+  // false — the fixture gate proves the LOGIC, not a real lane.
+  decisionGrade?: boolean | undefined
+  // The policy bounds; defaults to the conservative `DEFAULT_QUANT_GATE_POLICY`.
+  policy?: QuantizationGatePolicy | undefined
+}>
+
+// Run the quantization eval gate over a comparison set. PURE: same input =>
+// same result. The decision encodes the book's principle exactly: a quantized
+// lane passes only when accepted-outcome quality HOLDS, or a quality drop is
+// strictly bought back by a cost-per-accepted-outcome improvement.
+export const runQuantizationEvalGate = (
+  input: QuantizationGateInput,
+): QuantizationGateResult => {
+  const policy = input.policy ?? DEFAULT_QUANT_GATE_POLICY
+  const decisionGrade = input.decisionGrade ?? false
+  const aggressiveScope = isAggressiveScope(input.scope)
+
+  const base = {
+    schemaVersion: 'openagents.khala.quant-eval-gate.v1' as const,
+    sampleCount: input.samples.length,
+    aggressiveScope,
+    decisionGrade,
+  }
+
+  if (input.samples.length === 0) {
+    return {
+      ...base,
+      passed: false,
+      reason: 'no_comparison_samples',
+      detail:
+        'No quantized-vs-original comparison samples were provided; the gate cannot prove the quantized lane and fails closed.',
+      originalAcceptedRate: null,
+      quantizedAcceptedRate: null,
+      acceptedRateDeltaAbs: null,
+      originalCostPerAcceptedMsat: null,
+      quantizedCostPerAcceptedMsat: null,
+      costPerAcceptedImprovementFrac: null,
+    }
+  }
+
+  const originalSide = tallySide(
+    input.samples.map(s => s.originalVerdict),
+    input.samples.map(s => s.originalCostBasisMsat),
+  )
+  const quantizedSide = tallySide(
+    input.samples.map(s => s.quantizedVerdict),
+    input.samples.map(s => s.quantizedCostBasisMsat),
+  )
+
+  const originalAcceptedRate = acceptedRate(
+    originalSide.accepted,
+    originalSide.attempted,
+  )
+  const quantizedAcceptedRate = acceptedRate(
+    quantizedSide.accepted,
+    quantizedSide.attempted,
+  )
+  const originalCostPerAcceptedMsat = costPerAccepted(
+    originalSide.totalCostMsat,
+    originalSide.accepted,
+  )
+  const quantizedCostPerAcceptedMsat = costPerAccepted(
+    quantizedSide.totalCostMsat,
+    quantizedSide.accepted,
+  )
+
+  const acceptedRateDeltaAbs =
+    originalAcceptedRate === null || quantizedAcceptedRate === null
+      ? null
+      : quantizedAcceptedRate - originalAcceptedRate
+
+  // Fractional cost-per-accepted improvement: positive = quantized cheaper per
+  // accepted outcome. (original − quantized) / original. null when either is null.
+  const costPerAcceptedImprovementFrac =
+    originalCostPerAcceptedMsat === null ||
+    quantizedCostPerAcceptedMsat === null ||
+    originalCostPerAcceptedMsat === 0
+      ? null
+      : (originalCostPerAcceptedMsat - quantizedCostPerAcceptedMsat) /
+        originalCostPerAcceptedMsat
+
+  const metrics = {
+    originalAcceptedRate,
+    quantizedAcceptedRate,
+    acceptedRateDeltaAbs,
+    originalCostPerAcceptedMsat,
+    quantizedCostPerAcceptedMsat,
+    costPerAcceptedImprovementFrac,
+  }
+
+  // No baseline accepted outcomes: there is no quality bar to hold against, so
+  // the comparison is undefined and cannot pass.
+  if (originalAcceptedRate === null || originalSide.accepted === 0) {
+    return {
+      ...base,
+      ...metrics,
+      passed: false,
+      reason: 'no_baseline_accepted_outcomes',
+      detail:
+        'The original precision produced no accepted outcomes, so there is no quality baseline to hold against. The gate cannot prove the quantized lane and fails closed.',
+    }
+  }
+
+  // Aggressive scope without the required ack fails closed regardless of metrics
+  // (book policy: weights-only / FP8 before aggressive KV/attention quant).
+  if (
+    aggressiveScope &&
+    policy.requireAckForAggressiveScope &&
+    input.aggressiveScopeAck !== true
+  ) {
+    return {
+      ...base,
+      ...metrics,
+      passed: false,
+      reason: 'aggressive_scope_requires_ack',
+      detail:
+        'Candidate uses an aggressive quantization scope (KV-cache / attention). Policy requires explicit owner acknowledgement before such a lane may be promoted; absent the ack the gate fails closed. Prefer weights-only / FP8 first.',
+    }
+  }
+
+  // The quantized rate should never be null here (samples exist + attempts > 0),
+  // but guard defensively: a null quantized rate cannot demonstrate held quality.
+  if (quantizedAcceptedRate === null || acceptedRateDeltaAbs === null) {
+    return {
+      ...base,
+      ...metrics,
+      passed: false,
+      reason: 'accepted_rate_dropped_beyond_bound',
+      detail:
+        'The quantized lane produced no measurable accepted-outcome rate to compare against the baseline; it cannot demonstrate held quality and fails closed.',
+    }
+  }
+
+  // Quality HELD: the accepted-outcome rate did not drop (delta >= 0) or dropped
+  // by a negligible amount below the tolerance floor. Clean pass.
+  if (acceptedRateDeltaAbs >= 0) {
+    return {
+      ...base,
+      ...metrics,
+      passed: true,
+      reason: 'accepted_rate_held',
+      detail:
+        'The quantized lane held (or improved) the accepted-outcome rate vs the original precision; quality is preserved and the lane may be promoted.',
+    }
+  }
+
+  // From here the accepted-outcome rate DROPPED (delta < 0).
+  const dropAbs = -acceptedRateDeltaAbs
+
+  // A drop beyond the absolute bound is a quality LOSS no cost win can buy back.
+  if (dropAbs > policy.maxAcceptedRateDropAbs) {
+    return {
+      ...base,
+      ...metrics,
+      passed: false,
+      reason: 'accepted_rate_dropped_beyond_bound',
+      detail:
+        'The quantized lane dropped the accepted-outcome rate beyond the agreed bound. A throughput/cost win cannot offset a quality loss this large; the gate fails. This is the book’s rule: a faster lane that drops accepted outcomes is a loss.',
+    }
+  }
+
+  // A drop WITHIN the bound is allowed only if cost-per-accepted-outcome improved
+  // enough to be a net win (the book: a quality drop is acceptable only if
+  // cost-per-accepted-outcome improves).
+  if (
+    costPerAcceptedImprovementFrac !== null &&
+    costPerAcceptedImprovementFrac >= policy.minCostPerAcceptedImprovementFrac
+  ) {
+    return {
+      ...base,
+      ...metrics,
+      passed: true,
+      reason: 'cost_per_accepted_improved_offsets_drop',
+      detail:
+        'The quantized lane dropped the accepted-outcome rate slightly (within the agreed bound) but improved cost-per-accepted-outcome by enough to be a net win; the lane may be promoted.',
+    }
+  }
+
+  // A drop within the bound but no sufficient cost win is NOT a net win.
+  return {
+    ...base,
+    ...metrics,
+    passed: false,
+    reason: 'accepted_rate_dropped_without_cost_win',
+    detail:
+      'The quantized lane dropped the accepted-outcome rate without a sufficient cost-per-accepted-outcome improvement to offset it; it is not a net win and the gate fails.',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Real quantized-vs-original sweep — FLAG/OWNER/COMPUTE-GATED, default OFF.
+// ---------------------------------------------------------------------------
+
+// Raised when a real quantized-vs-original sweep is requested without owner
+// arming. A typed refusal (not a silent fallback) so a test or un-armed
+// environment can NEVER stand up real quantized serving or spend compute. The
+// gate LOGIC above runs on deterministic fixture comparison sets by default; the
+// real sweep that actually serves a quantized model and runs the executed
+// verifier on both precisions is owner/compute-gated.
+export class RealQuantSweepNotArmedError extends Error {
+  readonly _tag = 'RealQuantSweepNotArmedError'
+  constructor() {
+    super(
+      'Real quantized-vs-original eval sweep is owner/compute-gated and not armed. ' +
+        'It stands up real quantized serving and runs the executed verifier on both ' +
+        'precisions (spend + compute). Set armRealQuantSweep:true (owner-confirmed) to run it.',
+    )
+    this.name = 'RealQuantSweepNotArmedError'
+  }
+}
+
+// The injected executor a real sweep would call to produce the executed
+// comparison samples from REAL quantized + original serving. This module does NOT
+// implement it (the live serving + executed verifier runs live in the owner-armed
+// sweep + the out-of-Worker acceptance runner); it types the gate so the default
+// path is provably serving-free and spend-free.
+export type RealQuantSweepExecutor = () => ReadonlyArray<QuantizationComparisonSample>
+
+export type RealQuantSweepOptions = Readonly<{
+  // MUST be exactly true to run a real sweep. Anything else refuses.
+  armRealQuantSweep: boolean
+  executor?: RealQuantSweepExecutor | undefined
+}>
+
+// Produce the comparison samples for a real sweep, or throw the typed refusal.
+// When armed (and given an executor) it delegates; unarmed it throws so no real
+// quantized serving / spend can ever happen on the default path.
+export const collectRealQuantSweepSamples = (
+  options: RealQuantSweepOptions,
+): ReadonlyArray<QuantizationComparisonSample> => {
+  const armed =
+    options.armRealQuantSweep === true && options.executor !== undefined
+  if (!armed || options.executor === undefined) {
+    throw new RealQuantSweepNotArmedError()
+  }
+  return options.executor()
+}

--- a/apps/openagents.com/workers/api/src/inference/khala-quantization-guard.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-quantization-guard.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+import { buildKhalaServedModelDescriptor } from './khala-quantization'
+import {
+  KhalaSameModelClaimError,
+  assertSameModelClaim,
+  evaluateSameModelClaim,
+  isQuantizationDisclosed,
+} from './khala-quantization-guard'
+
+describe('same-model-claim guard (book P1-7 / #6090)', () => {
+  it('ALLOWS an unquantized lane under the bare public alias (same product)', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code',
+      servedModelId: 'accounts/fireworks/models/kimi-k2',
+      quantization: { precision: 'unquantized', backend: 'vllm' },
+    })
+    const verdict = evaluateSameModelClaim(descriptor)
+    expect(verdict.allowed).toBe(true)
+    expect(verdict.reason).toBeNull()
+    expect(verdict.isQuantizedLane).toBe(false)
+  })
+
+  it('REJECTS an undisclosed quantized lane fronting the unqualified alias (the headline leak)', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code',
+      servedModelId: 'accounts/fireworks/models/kimi-k2-fp8',
+      // Quantized precision but NO backend disclosed => undisclosed.
+      quantization: { precision: 'fp8' },
+    })
+    const verdict = evaluateSameModelClaim(descriptor)
+    expect(verdict.allowed).toBe(false)
+    expect(verdict.reason).toBe(
+      'undisclosed_quantization_under_unqualified_alias',
+    )
+    expect(verdict.isQuantizedLane).toBe(true)
+    expect(verdict.disclosed).toBe(false)
+  })
+
+  it('REJECTS an unknown-precision lane under the unqualified alias', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code',
+      servedModelId: 'partner/opaque-model',
+      // The managed provider does not disclose how it quantizes.
+      quantization: {},
+    })
+    const verdict = evaluateSameModelClaim(descriptor)
+    expect(verdict.allowed).toBe(false)
+    expect(verdict.reason).toBe('unknown_precision_under_unqualified_alias')
+  })
+
+  it('REJECTS a disclosed quantized lane under the unqualified alias when the eval gate has NOT passed', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code',
+      servedModelId: 'accounts/fireworks/models/kimi-k2-fp8',
+      // Disclosed (precision + backend) but not yet eval-gate qualified.
+      quantization: {
+        precision: 'fp8',
+        backend: 'sglang',
+        scope: 'weights_only',
+        evalGatePassed: false,
+      },
+    })
+    const verdict = evaluateSameModelClaim(descriptor)
+    expect(verdict.allowed).toBe(false)
+    expect(verdict.reason).toBe('quantized_lane_not_eval_gate_qualified')
+    expect(verdict.disclosed).toBe(true)
+  })
+
+  it('ALLOWS a disclosed, eval-gate-qualified quantized lane under the unqualified alias (proven claim)', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code',
+      servedModelId: 'accounts/fireworks/models/kimi-k2-fp8',
+      quantization: {
+        precision: 'fp8',
+        backend: 'sglang',
+        backendVersion: '0.4.1',
+        scope: 'weights_only',
+        evalGatePassed: true,
+        evalGateRef: 'gate:khala-code-fp8:v1',
+      },
+    })
+    const verdict = evaluateSameModelClaim(descriptor)
+    expect(verdict.allowed).toBe(true)
+    expect(verdict.reason).toBeNull()
+    expect(verdict.disclosed).toBe(true)
+  })
+
+  it('ALLOWS a quantized lane under a QUALIFIED alias regardless of receipt (the alias is the disclosure)', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code-fp8',
+      servedModelId: 'accounts/fireworks/models/kimi-k2-fp8',
+      // Even undisclosed/ungated: the customer addressed a precision-named product.
+      quantization: { precision: 'fp8' },
+    })
+    const verdict = evaluateSameModelClaim(descriptor)
+    expect(verdict.allowed).toBe(true)
+    expect(verdict.reason).toBeNull()
+  })
+
+  it('raises an aggressive-scope WARNING even when the claim is allowed', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code-int4',
+      servedModelId: 'self-hosted/khala-code-int4',
+      quantization: {
+        precision: 'int4',
+        backend: 'vllm',
+        scope: 'kv_cache',
+      },
+    })
+    const verdict = evaluateSameModelClaim(descriptor)
+    expect(verdict.allowed).toBe(true) // qualified alias
+    expect(verdict.aggressiveScopeWarning).toBe(true)
+  })
+})
+
+describe('isQuantizationDisclosed', () => {
+  it('is false for an unquantized lane (nothing to disclose) and an unknown lane', () => {
+    expect(
+      isQuantizationDisclosed(
+        buildKhalaServedModelDescriptor({
+          publicAlias: 'openagents/khala-code',
+          servedModelId: 'x',
+          quantization: { precision: 'unquantized', backend: 'vllm' },
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      isQuantizationDisclosed(
+        buildKhalaServedModelDescriptor({
+          publicAlias: 'openagents/khala-code',
+          servedModelId: 'x',
+          quantization: {},
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('is true only when a quantized precision AND a named backend are present', () => {
+    expect(
+      isQuantizationDisclosed(
+        buildKhalaServedModelDescriptor({
+          publicAlias: 'openagents/khala-code',
+          servedModelId: 'x',
+          quantization: { precision: 'fp8', backend: 'sglang' },
+        }),
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('assertSameModelClaim (fail-closed route entry point)', () => {
+  it('throws a typed error with the rejection reason on an undisclosed quantized variant', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code',
+      servedModelId: 'x-fp8',
+      quantization: { precision: 'fp8' },
+    })
+    try {
+      assertSameModelClaim(descriptor)
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(KhalaSameModelClaimError)
+      expect((error as KhalaSameModelClaimError).reason).toBe(
+        'undisclosed_quantization_under_unqualified_alias',
+      )
+    }
+  })
+
+  it('returns the verdict (no throw) when the claim is allowed', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code',
+      servedModelId: 'x',
+      quantization: { precision: 'unquantized', backend: 'vllm' },
+    })
+    expect(assertSameModelClaim(descriptor).allowed).toBe(true)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-quantization-guard.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-quantization-guard.ts
@@ -1,0 +1,223 @@
+// Khala SAME-MODEL-CLAIM guard (book P1-7 / #6090).
+//
+// THE RULE (book Ch.5 + khala.md §6/§7 disclosure):
+// -------------------------------------------------
+// A quantized lane is NOT the same product as the unqualified public model id.
+// So you may NOT silently serve a reduced-precision variant UNDER the bare public
+// alias (`openagents/khala-code`) and let the receipt imply the customer got the
+// unqualified model. A quantized lane may carry a public-facing identity ONLY if
+// EITHER:
+//   (a) the alias itself DISCLOSES the precision (a `qualified` alias, e.g.
+//       `openagents/khala-code-fp8`), OR
+//   (b) the unqualified alias is fronted by a quantized lane whose precision +
+//       backend are DISCLOSED IN THE RECEIPT and the lane has PASSED the
+//       quantization eval gate (so "same model" is a proven claim, not a guess).
+//
+// This is the receipt-disclosure sibling of the Khala IDENTITY guard
+// (`khala-identity.ts`): that guard stops Khala from naming the wrong model;
+// THIS guard stops Khala from claiming an unqualified model identity for a
+// reduced-precision product without disclosing what it actually served.
+//
+// It is a TYPED, FAIL-CLOSED check over the served-model descriptor — NOT intent
+// routing or string matching over user content. It inspects the structured
+// descriptor (alias qualification + quantization metadata), per the workspace
+// rule that bounded enum/field checks are fine once the structured object exists.
+//
+// PURE: no Worker, no Effect runtime, no IO. Same descriptor => same verdict.
+import {
+  type KhalaServedModelDescriptor,
+  isAggressiveScope,
+  isQuantizedPrecision,
+} from './khala-quantization'
+
+// ---------------------------------------------------------------------------
+// The verdict.
+// ---------------------------------------------------------------------------
+
+// Stable, neutral reason refs for a REJECTED same-model claim. Each names exactly
+// WHY the descriptor may not present under its (unqualified) public alias.
+export type KhalaSameModelRejectionReason =
+  // A quantized lane fronted an UNQUALIFIED alias without disclosing its
+  // precision in the receipt (the headline P1-7 leak: silent quantized variant).
+  | 'undisclosed_quantization_under_unqualified_alias'
+  // The precision is honestly UNKNOWN (`not_measured`) under an unqualified
+  // alias — we cannot claim "same model" when we cannot even say how it served.
+  | 'unknown_precision_under_unqualified_alias'
+  // The quantized lane is disclosed but has NOT passed the eval gate, so its
+  // accepted-outcome quality vs the original precision is unproven — it may not
+  // claim the unqualified alias (it MAY still serve under a qualified alias).
+  | 'quantized_lane_not_eval_gate_qualified'
+
+// The guard verdict over one served-model descriptor.
+export type KhalaSameModelVerdict = Readonly<{
+  // True when the descriptor may legitimately present under its public alias.
+  allowed: boolean
+  // The rejection reason when not allowed; null when allowed.
+  reason: KhalaSameModelRejectionReason | null
+  // A public-safe, human/agent-readable explanation. Never carries secrets.
+  detail: string
+  // Whether the served lane is a reduced-precision (quantized) lane at all (an
+  // unquantized lane is trivially allowed under any alias).
+  isQuantizedLane: boolean
+  // Whether the lane's quantization metadata is DISCLOSED in the receipt
+  // (precision + backend present and not the unknown sentinel). The disclosure
+  // half of the rule.
+  disclosed: boolean
+  // Whether the quantization SCOPE is aggressive (KV-cache / attention). Surfaced
+  // as a policy WARNING even when the claim is allowed, so an aggressive lane is
+  // never silently normalized.
+  aggressiveScopeWarning: boolean
+}>
+
+// ---------------------------------------------------------------------------
+// Disclosure check (is the quantization recorded in the receipt?).
+// ---------------------------------------------------------------------------
+
+// Whether a quantized lane's metadata is DISCLOSED: the precision is a concrete
+// reduced-precision value (not the `not_measured` sentinel) AND the backend is
+// named (not the `not_measured` sentinel). A reduced-precision lane that records
+// neither is NOT disclosed — that is the silent-variant case the guard rejects.
+export const isQuantizationDisclosed = (
+  descriptor: KhalaServedModelDescriptor,
+): boolean => {
+  const { precision, backend } = descriptor.quantization
+  if (!isQuantizedPrecision(precision)) {
+    // Either unquantized (nothing to disclose) or `not_measured` (unknown — that
+    // is handled as its own rejection, not "disclosed").
+    return false
+  }
+  return backend !== 'not_measured'
+}
+
+// ---------------------------------------------------------------------------
+// The guard.
+// ---------------------------------------------------------------------------
+
+// Evaluate the same-model claim for a served-model descriptor. FAIL-CLOSED: a
+// quantized lane is allowed under an UNQUALIFIED alias ONLY when its precision +
+// backend are disclosed AND it passed the eval gate. A `qualified` alias (the id
+// itself discloses precision) is always allowed for a quantized lane — the
+// customer was told. An unquantized lane is always allowed.
+//
+// PURE: same descriptor => same verdict.
+export const evaluateSameModelClaim = (
+  descriptor: KhalaServedModelDescriptor,
+): KhalaSameModelVerdict => {
+  const { precision, scope } = descriptor.quantization
+  const isQuantizedLane = isQuantizedPrecision(precision)
+  const disclosed = isQuantizationDisclosed(descriptor)
+  const aggressiveScopeWarning = isQuantizedLane && isAggressiveScope(scope)
+
+  // An unquantized lane is the same product as the unqualified alias — allowed.
+  // (Note: an `unquantized` precision is not quantized, so this branch covers it.
+  // A `not_measured` precision is NOT unquantized — it falls through below.)
+  if (precision === 'unquantized') {
+    return {
+      allowed: true,
+      reason: null,
+      detail:
+        'Lane served at full original precision (unquantized); it is the same product as the public alias.',
+      isQuantizedLane: false,
+      disclosed: false,
+      aggressiveScopeWarning: false,
+    }
+  }
+
+  // A QUALIFIED alias discloses the precision in the model id itself. The customer
+  // explicitly addressed a reduced-precision product, so presenting it is allowed
+  // regardless of the receipt (the alias is the disclosure). The eval gate still
+  // governs whether the lane is PRODUCTION-promoted, but the claim itself is honest.
+  if (descriptor.aliasQualification === 'qualified') {
+    return {
+      allowed: true,
+      reason: null,
+      detail:
+        'Public alias discloses its precision; the reduced-precision product is named in the model id the caller addressed.',
+      isQuantizedLane,
+      disclosed,
+      aggressiveScopeWarning,
+    }
+  }
+
+  // From here the alias is UNQUALIFIED (the bare public alias). The lane is either
+  // honestly-unknown precision or a disclosed/undisclosed quantized lane.
+
+  // Honestly-unknown precision under the bare alias: we cannot claim "same model"
+  // when we cannot even say how it was served. REJECT.
+  if (precision === 'not_measured') {
+    return {
+      allowed: false,
+      reason: 'unknown_precision_under_unqualified_alias',
+      detail:
+        'Served precision is not known (not_measured) under the unqualified public alias. The receipt cannot honestly claim this is the unqualified model; disclose the precision/backend or serve under a qualified alias.',
+      isQuantizedLane: false,
+      disclosed: false,
+      aggressiveScopeWarning: false,
+    }
+  }
+
+  // A quantized lane under the bare alias with NO disclosure: the silent-variant
+  // leak the issue calls out. REJECT.
+  if (!disclosed) {
+    return {
+      allowed: false,
+      reason: 'undisclosed_quantization_under_unqualified_alias',
+      detail:
+        'A reduced-precision (quantized) lane is fronting the unqualified public alias without disclosing its precision/backend in the receipt. A quantized variant cannot silently share an unqualified public model alias.',
+      isQuantizedLane,
+      disclosed,
+      aggressiveScopeWarning,
+    }
+  }
+
+  // A DISCLOSED quantized lane under the bare alias is allowed ONLY if it has
+  // passed the eval gate — otherwise its accepted-outcome quality vs the original
+  // precision is unproven and it may not claim to BE the unqualified model.
+  if (!descriptor.quantization.evalGatePassed) {
+    return {
+      allowed: false,
+      reason: 'quantized_lane_not_eval_gate_qualified',
+      detail:
+        'Quantization is disclosed in the receipt, but the quantized lane has not passed the Khala quantization eval gate, so its accepted-outcome quality vs the original precision is unproven. It may serve under a qualified alias but not claim the unqualified public alias.',
+      isQuantizedLane,
+      disclosed,
+      aggressiveScopeWarning,
+    }
+  }
+
+  // Disclosed AND eval-gate-qualified quantized lane under the bare alias: the
+  // claim is proven. Allowed (with an aggressive-scope warning if applicable).
+  return {
+    allowed: true,
+    reason: null,
+    detail:
+      'Quantization is disclosed in the receipt and the lane passed the Khala quantization eval gate; the claim to the public alias is proven.',
+    isQuantizedLane,
+    disclosed,
+    aggressiveScopeWarning,
+  }
+}
+
+// A thrown rejection for the route path that wants fail-closed enforcement rather
+// than a verdict to branch on. Carries the typed reason + public-safe detail.
+export class KhalaSameModelClaimError extends Error {
+  readonly _tag = 'KhalaSameModelClaimError'
+  readonly reason: KhalaSameModelRejectionReason
+  constructor(verdict: KhalaSameModelVerdict & { reason: KhalaSameModelRejectionReason }) {
+    super(verdict.detail)
+    this.name = 'KhalaSameModelClaimError'
+    this.reason = verdict.reason
+  }
+}
+
+// Assert a descriptor may present under its public alias, throwing the typed
+// error otherwise. The fail-closed route entry point.
+export const assertSameModelClaim = (
+  descriptor: KhalaServedModelDescriptor,
+): KhalaSameModelVerdict => {
+  const verdict = evaluateSameModelClaim(descriptor)
+  if (!verdict.allowed && verdict.reason !== null) {
+    throw new KhalaSameModelClaimError({ ...verdict, reason: verdict.reason })
+  }
+  return verdict
+}

--- a/apps/openagents.com/workers/api/src/inference/khala-quantization.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-quantization.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NOT_MEASURED,
+  UNKNOWN_QUANTIZATION,
+  UNQUANTIZED,
+  aliasQualification,
+  buildKhalaQuantizationMetadata,
+  buildKhalaServedModelDescriptor,
+  decodeKhalaQuantizationMetadata,
+  decodeKhalaServedModelDescriptor,
+  isAggressiveScope,
+  isQuantizedPrecision,
+} from './khala-quantization'
+import {
+  buildKhalaTelemetryRecord,
+  type KhalaTelemetryInput,
+} from './khala-telemetry'
+import { Option } from 'effect'
+
+const baseTelemetryInput: KhalaTelemetryInput = {
+  requestId: 'req-1',
+  requestedModel: 'openagents/khala-code',
+  servedModel: 'accounts/fireworks/models/kimi-k2',
+  route: 'coding',
+  provider: 'fireworks',
+  requestClass: 'interactive_stream',
+  verificationClass: 'none',
+  executedVerdict: 'not_executed',
+  settlementState: 'not_applicable',
+}
+
+describe('precision classification', () => {
+  it('classifies reduced-precision modes as quantized', () => {
+    for (const mode of ['fp8', 'mxfp8', 'nvfp4', 'int8', 'int4', 'awq', 'gptq'] as const) {
+      expect(isQuantizedPrecision(mode)).toBe(true)
+    }
+  })
+
+  it('treats unquantized and not_measured as NOT quantized', () => {
+    expect(isQuantizedPrecision('unquantized')).toBe(false)
+    // not_measured is honestly-unknown, NOT a quantized claim — the guard handles
+    // unknown precision as its own rejection, not as "quantized".
+    expect(isQuantizedPrecision('not_measured')).toBe(false)
+  })
+
+  it('flags only KV-cache and attention scopes as aggressive', () => {
+    expect(isAggressiveScope('kv_cache')).toBe(true)
+    expect(isAggressiveScope('attention')).toBe(true)
+    expect(isAggressiveScope('weights_only')).toBe(false)
+    expect(isAggressiveScope('weights_and_activations')).toBe(false)
+    expect(isAggressiveScope('none')).toBe(false)
+    expect(isAggressiveScope('not_measured')).toBe(false)
+  })
+})
+
+describe('buildKhalaQuantizationMetadata — honest sentinels', () => {
+  it('collapses an absent precision to the honest-unknown sentinel, never a fabricated full precision', () => {
+    const meta = buildKhalaQuantizationMetadata({})
+    expect(meta.precision).toBe('not_measured')
+    expect(meta.backend).toBe('not_measured')
+    expect(meta.backendVersion).toBe(NOT_MEASURED)
+    expect(meta.scope).toBe('not_measured')
+    expect(meta.evalGatePassed).toBe(false)
+    expect(meta.evalGateRef).toBeNull()
+  })
+
+  it('records a disclosed unquantized lane with scope none', () => {
+    const meta = buildKhalaQuantizationMetadata({
+      precision: 'unquantized',
+      backend: 'vllm',
+      backendVersion: '0.6.3',
+    })
+    expect(meta.precision).toBe('unquantized')
+    expect(meta.scope).toBe('none')
+    // An unquantized lane is never "eval-gate passed" (the gate is for proving a
+    // quantized lane holds quality).
+    expect(meta.evalGatePassed).toBe(false)
+  })
+
+  it('records a disclosed fp8 weights-only lane and preserves the eval-gate flag', () => {
+    const meta = buildKhalaQuantizationMetadata({
+      precision: 'fp8',
+      backend: 'sglang',
+      backendVersion: '0.4.1',
+      scope: 'weights_only',
+      evalGatePassed: true,
+      evalGateRef: 'gate:khala-code-fp8:v1',
+    })
+    expect(meta.precision).toBe('fp8')
+    expect(meta.backend).toBe('sglang')
+    expect(meta.scope).toBe('weights_only')
+    expect(meta.evalGatePassed).toBe(true)
+    expect(meta.evalGateRef).toBe('gate:khala-code-fp8:v1')
+  })
+
+  it('keeps scope as not_measured for a quantized lane that did not disclose scope (no fabricated weights_only)', () => {
+    const meta = buildKhalaQuantizationMetadata({
+      precision: 'int4',
+      backend: 'vllm',
+    })
+    expect(meta.scope).toBe('not_measured')
+  })
+
+  it('canonical UNQUANTIZED and UNKNOWN_QUANTIZATION decode cleanly', () => {
+    expect(Option.isSome(decodeKhalaQuantizationMetadata(UNQUANTIZED))).toBe(true)
+    expect(
+      Option.isSome(decodeKhalaQuantizationMetadata(UNKNOWN_QUANTIZATION)),
+    ).toBe(true)
+    expect(UNQUANTIZED.precision).toBe('unquantized')
+    expect(UNKNOWN_QUANTIZATION.precision).toBe('not_measured')
+  })
+})
+
+describe('aliasQualification — does the public alias disclose precision?', () => {
+  it('classifies a bare public alias as unqualified', () => {
+    expect(aliasQualification('openagents/khala-code')).toBe('unqualified')
+    expect(aliasQualification('openagents/khala-mini')).toBe('unqualified')
+  })
+
+  it('classifies a precision-suffixed alias as qualified', () => {
+    expect(aliasQualification('openagents/khala-code-fp8')).toBe('qualified')
+    expect(aliasQualification('openagents/khala-code-nvfp4')).toBe('qualified')
+    expect(aliasQualification('openagents/khala-mini-int4')).toBe('qualified')
+  })
+
+  it('is case-insensitive on the suffix', () => {
+    expect(aliasQualification('openagents/khala-code-FP8')).toBe('qualified')
+  })
+})
+
+describe('buildKhalaServedModelDescriptor', () => {
+  it('derives alias qualification from the alias so it is always consistent', () => {
+    const descriptor = buildKhalaServedModelDescriptor({
+      publicAlias: 'openagents/khala-code',
+      servedModelId: 'accounts/fireworks/models/kimi-k2',
+      quantization: { precision: 'fp8', backend: 'sglang' },
+    })
+    expect(descriptor.aliasQualification).toBe('unqualified')
+    expect(descriptor.quantization.precision).toBe('fp8')
+    expect(
+      Option.isSome(decodeKhalaServedModelDescriptor(descriptor)),
+    ).toBe(true)
+  })
+})
+
+describe('telemetry record carries quantization (book P1-7)', () => {
+  it('populates quant fields from a fixture served-model descriptor', () => {
+    const record = buildKhalaTelemetryRecord({
+      ...baseTelemetryInput,
+      quantization: {
+        precision: 'fp8',
+        backend: 'sglang',
+        backendVersion: '0.4.1',
+        scope: 'weights_only',
+        evalGatePassed: true,
+        evalGateRef: 'gate:khala-code-fp8:v1',
+      },
+    })
+    expect(record.quantization.precision).toBe('fp8')
+    expect(record.quantization.backend).toBe('sglang')
+    expect(record.quantization.scope).toBe('weights_only')
+    expect(record.quantization.evalGatePassed).toBe(true)
+  })
+
+  it('records the honest-unknown quant shape when the lane disclosed nothing', () => {
+    const record = buildKhalaTelemetryRecord(baseTelemetryInput)
+    // The HONESTY contract: an unmeasured precision is a typed sentinel, not a
+    // fabricated full-precision claim.
+    expect(record.quantization.precision).toBe('not_measured')
+    expect(record.quantization.backend).toBe('not_measured')
+    expect(record.quantization.scope).toBe('not_measured')
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-quantization.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-quantization.ts
@@ -1,0 +1,342 @@
+// Khala quantization metadata + served-model descriptor (book P1-7 / #6090).
+//
+// THE PRINCIPLE (book Ch.5, in our own words)
+// -------------------------------------------
+// A model served at a reduced numeric precision (FP8 / MXFP8 / NVFP4 / INT4 / …)
+// is NOT the same product as the unqualified model id. Quantization can win
+// prefill/decode throughput AND lower the accepted-outcome rate; a throughput
+// number is not a quality proof. So precision is a FIRST-CLASS, disclosed
+// property of the served-model descriptor — not an invisible serving detail.
+//
+// This module owns ONLY the typed quantization metadata and the served-model
+// DESCRIPTOR it hangs on. It is the single place that turns "how was this model
+// actually served at the bit level" into a typed, public-safe, receipt-bearing
+// fact. The same-model-claim GUARD lives in `khala-quantization-guard.ts`; the
+// quality/cost eval gate lives in `khala-quantization-eval-gate.ts`. Both read
+// this descriptor; neither re-invents the vocabulary.
+//
+// HONESTY CONTRACT (mirrors the telemetry schema's `not_measured` discipline):
+//   - `unquantized` means we KNOW the lane served at full original precision.
+//   - `not_measured` means we do NOT know the precision (e.g. a managed provider
+//     that does not disclose how it quantizes behind its API). It is a typed,
+//     first-class sentinel — never a fabricated "fp16" guess and never a missing
+//     field. "We do not know the precision" is a real value, distinct from "we
+//     know it is full precision".
+//   - A descriptor whose precision is `not_measured` is HONESTLY ambiguous; the
+//     guard treats that ambiguity as undisclosed for an UNQUALIFIED alias (you
+//     cannot claim "same model" when you cannot even say how it was served).
+//
+// PUBLIC-SAFE (INVARIANTS: no secret/private leakage): the descriptor carries
+// only neutral classifiers (precision mode, backend/engine id, a coarse method
+// label) and public refs. No prompt, account, key, price, or weights material.
+import { Schema as S } from 'effect'
+
+// The honest "no measurement exists" sentinel. Defined locally (equal to the
+// telemetry module's `NOT_MEASURED`) so this module — which the telemetry schema
+// imports — carries no back-import to telemetry and there is no import cycle.
+export const NOT_MEASURED = 'not_measured' as const
+
+// ---------------------------------------------------------------------------
+// Precision mode (book Ch.5: the numeric format the weights/activations use).
+// ---------------------------------------------------------------------------
+
+// The served numeric precision. `unquantized` is a real value (full original
+// precision — FP16/BF16/FP32, i.e. NOT quantized). `not_measured` is the honest
+// sentinel for an undisclosed managed lane. Every other value is a concrete
+// reduced-precision format the book discusses. A closed union so a new format is
+// added deliberately (and the guard/gate stay exhaustive).
+export const KhalaPrecisionMode = S.Literals([
+  // Full original precision — the lane is NOT quantized.
+  'unquantized',
+  // Weights-only / activation reduced-precision formats (book Ch.5 §5.x).
+  'fp8',
+  'mxfp8',
+  'nvfp4',
+  'int8',
+  'int4',
+  'awq',
+  'gptq',
+  // The honest "we do not know how this lane quantizes" sentinel.
+  'not_measured',
+])
+export type KhalaPrecisionMode = typeof KhalaPrecisionMode.Type
+
+// Whether a precision mode is a reduced-precision (quantized) format. Used by the
+// guard + gate to decide whether disclosure / an eval gate is even required.
+// `unquantized` and `not_measured` are NOT "quantized": the first is known-full,
+// the second is honestly unknown (the guard handles unknown separately).
+export const isQuantizedPrecision = (mode: KhalaPrecisionMode): boolean => {
+  switch (mode) {
+    case 'unquantized':
+    case 'not_measured':
+      return false
+    case 'fp8':
+    case 'mxfp8':
+    case 'nvfp4':
+    case 'int8':
+    case 'int4':
+    case 'awq':
+    case 'gptq':
+      return true
+  }
+}
+
+// ---------------------------------------------------------------------------
+// What was quantized (book Ch.5: weights-only is safest; KV-cache / attention
+// quantization is more aggressive and riskier — POLICY, see the doc).
+// ---------------------------------------------------------------------------
+
+// The SCOPE of the quantization — which tensors carry the reduced precision. The
+// book's policy ladder (and our adopted policy): weights-only / FP8 BEFORE
+// aggressive KV-cache or attention quantization. Recording the scope lets the
+// policy be enforced (the eval-gate flags an aggressive scope) instead of assumed.
+export const KhalaQuantizationScope = S.Literals([
+  // The lane is not quantized; scope is not applicable.
+  'none',
+  // Weights only (the safest first step the book recommends).
+  'weights_only',
+  // Weights + activations.
+  'weights_and_activations',
+  // Includes KV-cache quantization (more aggressive — book flags quality risk).
+  'kv_cache',
+  // Includes attention quantization (most aggressive — flagged).
+  'attention',
+  // The honest sentinel: we know it is quantized but not which tensors.
+  'not_measured',
+])
+export type KhalaQuantizationScope = typeof KhalaQuantizationScope.Type
+
+// Whether a scope is one the policy considers AGGRESSIVE (KV-cache / attention).
+// The eval-gate requires an explicit policy acknowledgement for these.
+export const isAggressiveScope = (scope: KhalaQuantizationScope): boolean =>
+  scope === 'kv_cache' || scope === 'attention'
+
+// ---------------------------------------------------------------------------
+// The serving backend / engine that produced the precision (book §6 notes:
+// receipt fields for engine + version + quantization).
+// ---------------------------------------------------------------------------
+
+// The serving backend behind the precision. Reuses the same engine vocabulary as
+// the benchmark matrix (provider-native for managed lanes; concrete open engines
+// for self-hosted) plus `not_measured`. We do NOT fork the benchmark's
+// `BenchmarkEngine` union here — we ADD the sentinel — because a served request
+// may have an unknown backend where a benchmark cell always names one.
+export const KhalaQuantizationBackend = S.Literals([
+  'provider-native',
+  'vllm',
+  'sglang',
+  'tensorrt-llm',
+  'not_measured',
+])
+export type KhalaQuantizationBackend = typeof KhalaQuantizationBackend.Type
+
+// ---------------------------------------------------------------------------
+// The quantization metadata struct (the typed receipt/telemetry fields).
+// ---------------------------------------------------------------------------
+
+// The quantization metadata recorded on the served-model descriptor / receipt.
+// Every field is a concrete value or the honest sentinel. This is the typed
+// answer to "at what precision, on what backend, over which tensors, was this
+// request actually served, and has the quantized lane been eval-gate qualified?"
+export const KhalaQuantizationMetadata = S.Struct({
+  schemaVersion: S.Literal('openagents.khala.quantization.v1'),
+  // The served numeric precision (or `unquantized` / `not_measured`).
+  precision: KhalaPrecisionMode,
+  // The serving backend/engine that applied the precision.
+  backend: KhalaQuantizationBackend,
+  // The serving engine VERSION when the lane exposes it (book §6: engine +
+  // version in receipts). `not_measured` sentinel string otherwise.
+  backendVersion: S.Union([S.String, S.Literal(NOT_MEASURED)]),
+  // Which tensors carry the reduced precision (the policy-relevant scope).
+  scope: KhalaQuantizationScope,
+  // Whether this quantized lane has PASSED a Khala quantization eval gate
+  // (`khala-quantization-eval-gate.ts`) against the original precision. `false`
+  // for an unquantized lane (not applicable) AND for a quantized lane that has
+  // not been gated. The guard reads this to decide if a quantized lane may carry
+  // a public alias.
+  evalGatePassed: S.Boolean,
+  // The dereferenceable ref to the eval-gate result, when one exists. Null when
+  // the lane has not been gated (unquantized or ungated quantized).
+  evalGateRef: S.NullOr(S.String),
+})
+export type KhalaQuantizationMetadata = typeof KhalaQuantizationMetadata.Type
+
+// The canonical UNQUANTIZED metadata: a lane we KNOW served at full original
+// precision. Distinct from `UNKNOWN_QUANTIZATION` (we do not know).
+export const UNQUANTIZED: KhalaQuantizationMetadata = {
+  schemaVersion: 'openagents.khala.quantization.v1',
+  precision: 'unquantized',
+  backend: 'not_measured',
+  backendVersion: NOT_MEASURED,
+  scope: 'none',
+  evalGatePassed: false,
+  evalGateRef: null,
+}
+
+// The canonical honest-unknown metadata: we do NOT know how this lane was served
+// at the bit level (a managed provider that does not disclose). The guard treats
+// this ambiguity as undisclosed for an UNQUALIFIED public alias.
+export const UNKNOWN_QUANTIZATION: KhalaQuantizationMetadata = {
+  schemaVersion: 'openagents.khala.quantization.v1',
+  precision: 'not_measured',
+  backend: 'not_measured',
+  backendVersion: NOT_MEASURED,
+  scope: 'not_measured',
+  evalGatePassed: false,
+  evalGateRef: null,
+}
+
+// ---------------------------------------------------------------------------
+// The served-model descriptor (the typed "what model, served how" record).
+// ---------------------------------------------------------------------------
+
+// Whether a public model alias is QUALIFIED — i.e. it discloses precision in the
+// alias itself (e.g. `openagents/khala-code-fp8`) — or UNQUALIFIED (the bare
+// public alias `openagents/khala-code`). The same-model guard uses this to
+// decide whether an alias may front a quantized lane silently.
+export const KhalaAliasQualification = S.Literals([
+  'qualified', // the alias discloses precision (e.g. ...-fp8)
+  'unqualified', // the bare public alias
+])
+export type KhalaAliasQualification = typeof KhalaAliasQualification.Type
+
+// The served-model descriptor: the public alias a request was served UNDER, the
+// concrete served-model id, and the quantization metadata of how it was served.
+// This is the object the guard inspects and the telemetry/receipt carries.
+export const KhalaServedModelDescriptor = S.Struct({
+  schemaVersion: S.Literal('openagents.khala.served-model.v1'),
+  // The PUBLIC alias the caller addressed (e.g. `openagents/khala-code`). This is
+  // the brand-promise identity — what the receipt claims the customer bought.
+  publicAlias: S.String,
+  // The concrete served-model id the lane actually ran (provider/engine-specific).
+  servedModelId: S.String,
+  // How the public alias qualifies (does it disclose precision?). DERIVED from
+  // the alias by `aliasQualification` so it is never hand-set inconsistently.
+  aliasQualification: KhalaAliasQualification,
+  // The quantization metadata of how this request was served.
+  quantization: KhalaQuantizationMetadata,
+})
+export type KhalaServedModelDescriptor =
+  typeof KhalaServedModelDescriptor.Type
+
+// ---------------------------------------------------------------------------
+// Decoders.
+// ---------------------------------------------------------------------------
+
+export const decodeKhalaQuantizationMetadata = S.decodeUnknownOption(
+  KhalaQuantizationMetadata,
+)
+export const decodeKhalaServedModelDescriptor = S.decodeUnknownOption(
+  KhalaServedModelDescriptor,
+)
+
+// ---------------------------------------------------------------------------
+// Builders — assemble metadata honestly from what the lane disclosed.
+// ---------------------------------------------------------------------------
+
+// The raw, possibly-partial signals a serving lane CAN disclose about precision.
+// Everything optional; absence collapses to the honest sentinel — never a guess.
+export type KhalaQuantizationInput = Readonly<{
+  precision?: KhalaPrecisionMode | undefined
+  backend?: KhalaQuantizationBackend | undefined
+  backendVersion?: string | undefined
+  scope?: KhalaQuantizationScope | undefined
+  evalGatePassed?: boolean | undefined
+  evalGateRef?: string | null | undefined
+}>
+
+// Normalize a possibly-absent precision into a concrete value or the sentinel.
+// Absence => `not_measured` (honest unknown), NEVER a fabricated full-precision.
+const normalizePrecision = (
+  precision: KhalaPrecisionMode | undefined,
+): KhalaPrecisionMode => precision ?? 'not_measured'
+
+// Derive the scope honestly. If the lane is unquantized, scope is `none`. If the
+// caller gave a scope, use it. Otherwise: an unknown precision => `not_measured`;
+// a known quantized precision with no scope => `not_measured` (we know it is
+// quantized but not which tensors — honest, not a fabricated `weights_only`).
+const deriveScope = (
+  precision: KhalaPrecisionMode,
+  scope: KhalaQuantizationScope | undefined,
+): KhalaQuantizationScope => {
+  if (precision === 'unquantized') {
+    return 'none'
+  }
+  if (scope !== undefined) {
+    return scope
+  }
+  return 'not_measured'
+}
+
+// Build the quantization metadata from raw lane signals. PURE: same input => same
+// metadata. Unknown precision yields the honest-unknown shape; an explicitly
+// unquantized lane yields the unquantized shape with any disclosed backend.
+export const buildKhalaQuantizationMetadata = (
+  input: KhalaQuantizationInput,
+): KhalaQuantizationMetadata => {
+  const precision = normalizePrecision(input.precision)
+  return {
+    schemaVersion: 'openagents.khala.quantization.v1',
+    precision,
+    backend: input.backend ?? 'not_measured',
+    backendVersion:
+      input.backendVersion === undefined || input.backendVersion.trim() === ''
+        ? NOT_MEASURED
+        : input.backendVersion,
+    scope: deriveScope(precision, input.scope),
+    // An unquantized lane is never "eval-gate passed" (the gate is for proving a
+    // quantized lane holds quality); default to the caller's flag only for a
+    // quantized lane.
+    evalGatePassed:
+      precision === 'unquantized' || precision === 'not_measured'
+        ? false
+        : (input.evalGatePassed ?? false),
+    evalGateRef: input.evalGateRef ?? null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Alias qualification (does the public alias disclose precision?).
+// ---------------------------------------------------------------------------
+
+// The disclosed-precision suffixes an alias may carry to QUALIFY itself. An alias
+// ending in one of these (case-insensitive, after the final `-`) is `qualified`:
+// it tells the caller, in the model id itself, that this is a reduced-precision
+// product. The bare alias is `unqualified`. This is a bounded, documented
+// classification of the alias STRING (not intent routing): it maps a precision
+// suffix to the qualification flag the guard reads.
+const QUALIFYING_PRECISION_SUFFIXES: ReadonlyArray<string> = [
+  'fp8',
+  'mxfp8',
+  'nvfp4',
+  'int8',
+  'int4',
+  'awq',
+  'gptq',
+]
+
+// Classify a public alias as qualified (discloses precision in the id) or
+// unqualified (the bare public alias). PURE string classification.
+export const aliasQualification = (
+  publicAlias: string,
+): KhalaAliasQualification => {
+  const lower = publicAlias.toLowerCase()
+  const tail = lower.slice(lower.lastIndexOf('-') + 1)
+  return QUALIFYING_PRECISION_SUFFIXES.includes(tail)
+    ? 'qualified'
+    : 'unqualified'
+}
+
+// Assemble the full served-model descriptor. The alias qualification is DERIVED
+// from the alias so it is always consistent with the public id. PURE.
+export const buildKhalaServedModelDescriptor = (input: {
+  readonly publicAlias: string
+  readonly servedModelId: string
+  readonly quantization: KhalaQuantizationInput
+}): KhalaServedModelDescriptor => ({
+  schemaVersion: 'openagents.khala.served-model.v1',
+  publicAlias: input.publicAlias,
+  servedModelId: input.servedModelId,
+  aliasQualification: aliasQualification(input.publicAlias),
+  quantization: buildKhalaQuantizationMetadata(input.quantization),
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-telemetry.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-telemetry.ts
@@ -48,6 +48,12 @@
 // `not_measured`. The schema is the same whether a field is measured today or
 // becomes measurable later, so adding a measurement never reshapes the contract.
 import { Schema as S } from 'effect'
+import {
+  type KhalaQuantizationInput,
+  KhalaQuantizationMetadata,
+  UNKNOWN_QUANTIZATION,
+  buildKhalaQuantizationMetadata,
+} from './khala-quantization'
 
 // ---------------------------------------------------------------------------
 // The honest sentinel.
@@ -204,6 +210,14 @@ export const KhalaTelemetryRecord = S.Struct({
   requestId: S.String,
   requestedModel: S.String,
   servedModel: S.String,
+  // How the served model was served at the BIT LEVEL (book P1-7 / #6090): the
+  // precision/quant mode, backend/engine, scope, and eval-gate status. A model
+  // served at a reduced precision is NOT the same product as the unqualified
+  // model id, so the precision is a first-class receipt field — honest
+  // `unquantized` / `not_measured` where unknown, never a fabricated full
+  // precision. The same-model-claim guard reads this to reject an undisclosed
+  // quantized variant fronting an unqualified public alias.
+  quantization: KhalaQuantizationMetadata,
   // The coordinator route lane (coding | cheap | long_context | default | ...).
   route: S.String,
   // The provider/adapter id that actually served (provider-capacity attribution).
@@ -360,6 +374,13 @@ export type KhalaTelemetryInput = Readonly<{
   provider: string
   requestClass: KhalaRequestClass
 
+  // How the served model was served at the bit level (book P1-7 / #6090). When
+  // the gateway/lane discloses precision/backend/scope it is recorded here;
+  // absence collapses to the honest-unknown shape (`UNKNOWN_QUANTIZATION`) —
+  // never a fabricated full-precision claim. This is the typed quant metadata
+  // the same-model guard + eval gate read.
+  quantization?: KhalaQuantizationInput | undefined
+
   // Tokens (receipt-first from provider usage).
   promptTokens?: number | undefined
   completionTokens?: number | undefined
@@ -475,6 +496,12 @@ export const buildKhalaTelemetryRecord = (
     requestId: input.requestId,
     requestedModel: input.requestedModel,
     servedModel: input.servedModel,
+    // Honest quant metadata: built from disclosed lane signals, or the
+    // honest-unknown shape when the lane disclosed nothing (book P1-7 / #6090).
+    quantization:
+      input.quantization === undefined
+        ? UNKNOWN_QUANTIZATION
+        : buildKhalaQuantizationMetadata(input.quantization),
     route: input.route,
     provider: input.provider,
     region:

--- a/docs/inference/2026-06-23-khala-quantization-eval-gate-book-p1-7.md
+++ b/docs/inference/2026-06-23-khala-quantization-eval-gate-book-p1-7.md
@@ -1,0 +1,124 @@
+# Khala quantization eval gate (book P1-7, #6090)
+
+Status: buildable-now metadata + guard + eval-gate machinery merged; the real
+quantized-model serving and the real quant-vs-original sweep are
+flag/owner/compute-gated (built but not armed). Not deployed by this change.
+
+## The principle (book Ch.5, in our own words)
+
+Quantization — serving a model at a reduced numeric precision (FP8 / MXFP8 /
+NVFP4 / INT4 / AWQ / GPTQ) — can win prefill and decode throughput. It can ALSO
+damage output quality. A throughput number is not a quality proof. So two rules:
+
+1. **A reduced-precision model is NOT the same product as the unqualified model
+   id.** Serving `openagents/khala-code` from an FP8 lane and letting the receipt
+   imply the customer got the unqualified model is a silent product
+   substitution. The precision/backend must be disclosed.
+2. **A throughput/cost win that lowers the accepted-outcome rate is a LOSS**
+   unless cost-per-accepted-outcome improves. Quality is measured on EXECUTED
+   product evals (the P0-4 Khala-code executed verifier), never assumed from a
+   tokens/second figure.
+
+This maps to `khala.md` §6/§7 (verification + receipt disclosure): the receipt
+must carry the engine, version, and quantization, and a "same model" claim is
+only honest if precision/backend are disclosed and the lane has passed a real
+eval comparison vs the original precision.
+
+## Adopted policy
+
+- **Weights-only / FP8 / MXFP8 BEFORE aggressive KV-cache or attention
+  quantization.** The quantization SCOPE is a first-class, recorded field
+  (`weights_only` / `weights_and_activations` / `kv_cache` / `attention`). KV-cache
+  and attention scopes are flagged `aggressive` and require an explicit owner
+  acknowledgement to pass the eval gate, even when the metrics hold.
+- **Disclosure is required.** A quantized lane may carry a public identity only if
+  EITHER (a) the public alias itself discloses the precision (a *qualified* alias
+  like `openagents/khala-code-fp8`), OR (b) the unqualified alias is fronted by a
+  quantized lane whose precision + backend are disclosed in the receipt AND the
+  lane has passed the quantization eval gate.
+- **Honest sentinels.** Precision is `unquantized` (known full precision),
+  `not_measured` (honestly unknown — e.g. a managed provider that does not
+  disclose how it quantizes), or a concrete reduced-precision value. Unknown is
+  never silently treated as full precision. An unqualified alias over an
+  `not_measured` lane is rejected: you cannot claim "same model" when you cannot
+  even say how it was served.
+
+### Alias-sharing policy (Open Question Q6 — resolved)
+
+Which quantization modes may share a public model alias?
+
+- **An unqualified public alias** (`openagents/khala-code`) may be served by:
+  - the unquantized lane (always — same product); or
+  - a quantized lane only when its precision + backend are disclosed in the
+    receipt AND it has passed the quantization eval gate. Until then the
+    quantized lane must use a qualified alias.
+- **A qualified alias** (`openagents/khala-code-fp8`) may always front the
+  matching reduced-precision lane — the precision is named in the id the caller
+  addressed, so the claim is honest by construction. The eval gate still governs
+  whether such a lane is *production-promoted*, but the identity claim itself is
+  not a leak.
+- **`not_measured` precision may NOT share an unqualified alias.** Honest
+  ambiguity is treated as undisclosed.
+
+## What shipped (buildable now)
+
+All in `apps/openagents.com/workers/api/src/inference/`:
+
+1. **Quantization metadata + served-model descriptor**
+   (`khala-quantization.ts`): the typed `KhalaQuantizationMetadata`
+   (precision / backend / backendVersion / scope / evalGatePassed / evalGateRef)
+   and `KhalaServedModelDescriptor` (publicAlias / servedModelId /
+   aliasQualification / quantization). Builders collapse absent signals to honest
+   sentinels (`UNKNOWN_QUANTIZATION`) — never a fabricated full precision. Added
+   as a first-class `quantization` field on `KhalaTelemetryRecord`
+   (`khala-telemetry.ts`); an unmeasured request records the honest-unknown shape.
+
+2. **Same-model-claim guard** (`khala-quantization-guard.ts`): a typed,
+   fail-closed check over the served-model descriptor. `evaluateSameModelClaim`
+   returns a verdict; `assertSameModelClaim` throws `KhalaSameModelClaimError`.
+   It REJECTS an undisclosed quantized lane under an unqualified alias, a
+   `not_measured` lane under an unqualified alias, and a disclosed-but-ungated
+   quantized lane under an unqualified alias; it PASSES an unquantized lane, a
+   qualified alias, and a disclosed + eval-gate-qualified quantized lane. It is a
+   bounded enum/field check over the STRUCTURED descriptor — not intent routing —
+   the receipt-disclosure sibling of the Khala identity guard.
+
+3. **Quantization eval gate** (`khala-quantization-eval-gate.ts`): a comparison
+   harness that scores a quantized lane vs the original precision on EXECUTED
+   acceptance verdicts (reuses the P0-4 verifier's `AcceptanceVerdict`, never a
+   regex) and computes the cost-per-accepted-outcome delta (reuses the P1-5
+   report's accepted-outcome + cost math shape). `runQuantizationEvalGate` PASSES
+   only when accepted-outcome quality HOLDS, or a small drop (within an agreed
+   bound) is bought back by a sufficient cost-per-accepted-outcome improvement.
+   Deterministic/fixture by default (`decisionGrade:false`).
+
+## Fixture vs owner/compute-gated split
+
+- **Buildable now (in this change):** the metadata schema + telemetry field, the
+  same-model-claim guard, and the eval-gate LOGIC scored on deterministic fixture
+  comparison sets. No real quantized serving, no network, no spend, no compute.
+- **Owner/compute-gated (built, flagged OFF):** the real quantized-vs-original
+  sweep that stands up a real reduced-precision serving lane and runs the executed
+  Khala verifier on BOTH precisions. `collectRealQuantSweepSamples` throws
+  `RealQuantSweepNotArmedError` unless `armRealQuantSweep:true` plus an injected
+  executor are owner-supplied. A decision-grade gate result (promoting a real lane
+  to a public alias) requires this armed sweep over realistic traffic; the default
+  fixture path proves the gate logic only.
+
+## Tests
+
+`khala-quantization.test.ts`, `khala-quantization-guard.test.ts`,
+`khala-quantization-eval-gate.test.ts` (37 new): quant metadata populates from a
+fixture served-model descriptor and records the honest sentinel when unknown; the
+same-model guard rejects an undisclosed/unknown/ungated quantized alias and passes
+a disclosed-gated one and a qualified alias; the eval gate passes when quality
+holds (or a small drop is offset by a cost-per-accepted win) and fails when the
+accepted-outcome rate drops beyond bound or without a cost win, fails an
+aggressive scope without ack, and the real sweep is flag-gated off (no real
+serving in tests).
+
+## Verification
+
+Inference suites green (779 tests, 37 new), `typecheck`, `check:architecture`,
+`check:effect-topology`, `check:public-projection-freshness` all green. Not
+deployed; no spend.

--- a/docs/inference/inference-engineering-book/IMPLEMENTATION_LOG.md
+++ b/docs/inference/inference-engineering-book/IMPLEMENTATION_LOG.md
@@ -228,3 +228,65 @@ Conventions:
   explicit confirmation and run it (the only path that can spend). NOT run here.
 - **Status:** PR open against `main` (#6088); orchestrator reviews / merges /
   deploys / smokes. NOT deployed, NO spend by this entry.
+
+---
+
+## P1-7 — Quantization needs a Khala eval gate — in progress (PR open, #6090)
+
+- **Notes ref:** `khala-investigation-notes.md` §P1 item 7 ("Quantization Needs
+  A Khala Eval Gate") + Open Question #6 (which quant modes may share a public
+  alias); book Ch.5 (Quantization). Consumes the P0-1 telemetry schema (#6085),
+  the P1-5 benchmark cost-per-accepted-outcome math (#6088), and the P0-4 executed
+  Khala-code verifier `AcceptanceVerdict` (#6087) as the eval gate.
+- **The principle encoded:** a model served at a reduced precision (FP8 / MXFP8 /
+  NVFP4 / INT4 / …) is NOT the same product as the unqualified model id, and a
+  throughput win that lowers the accepted-outcome rate is a LOSS unless
+  cost-per-accepted-outcome improves.
+- **What shipped (the four deliverables):**
+  1. **Quantization metadata** (`khala-quantization.ts`): typed
+     `KhalaQuantizationMetadata` (precision / backend / backendVersion / scope /
+     evalGatePassed / evalGateRef) + `KhalaServedModelDescriptor`. Added as a
+     first-class `quantization` field on `KhalaTelemetryRecord`
+     (`khala-telemetry.ts`). HONEST sentinels: `unquantized` (known full),
+     `not_measured` (honestly unknown), or a concrete reduced-precision value —
+     an unmeasured request records `UNKNOWN_QUANTIZATION`, never a fabricated
+     full precision.
+  2. **Same-model-claim guard** (`khala-quantization-guard.ts`): a typed,
+     fail-closed check over the descriptor (`evaluateSameModelClaim` /
+     `assertSameModelClaim` → `KhalaSameModelClaimError`). REJECTS an undisclosed
+     quantized lane, a `not_measured` lane, and a disclosed-but-ungated quantized
+     lane under an UNQUALIFIED public alias; PASSES an unquantized lane, a
+     qualified alias (precision named in the id), and a disclosed +
+     eval-gate-qualified quantized lane. A bounded enum/field check over the
+     structured descriptor — the receipt-disclosure sibling of the identity guard.
+  3. **Quantization eval gate** (`khala-quantization-eval-gate.ts`): scores a
+     quantized lane vs the original precision on EXECUTED `AcceptanceVerdict`s
+     (reuses P0-4, never a regex) and the cost-per-accepted-outcome delta (reuses
+     the P1-5 report math). PASSES only when accepted-outcome quality HOLDS, or a
+     small drop within the agreed bound is bought back by a sufficient
+     cost-per-accepted-outcome improvement; FAILS a drop beyond bound, a drop
+     without a cost win, an aggressive (KV-cache/attention) scope without owner
+     ack, no baseline accepted outcomes, or no samples.
+  4. **Policy doc** (`docs/inference/2026-06-23-khala-quantization-eval-gate-book-p1-7.md`):
+     weights-only / FP8 before aggressive KV/attention quant; disclosure required;
+     Open Question Q6 alias-sharing policy resolved.
+- **Where:** `apps/openagents.com/workers/api/src/inference/`
+  (`khala-quantization.ts`, `khala-quantization-guard.ts`,
+  `khala-quantization-eval-gate.ts` + `*.test.ts`; `quantization` field added to
+  `khala-telemetry.ts`).
+- **Verification bar (green):** inference suites (779 tests, 37 new),
+  `typecheck`, `check:architecture`, `check:effect-topology`,
+  `check:public-projection-freshness`. Tests: quant metadata populates from a
+  fixture descriptor (honest sentinel when unknown); the guard rejects an
+  undisclosed/unknown/ungated quantized alias and passes a disclosed-gated one +
+  a qualified alias; the eval gate passes when quality holds (or a small drop is
+  offset by a cost win) and fails when accepted-outcome drops without a cost win;
+  the real sweep is flag-gated OFF (no real serving in tests).
+- **Honest scope — fixture vs owner/compute-gated:** the metadata, guard, and the
+  eval-gate LOGIC run on deterministic fixture comparison sets — no real
+  quantized serving, no spend, no compute. The real quantized-vs-original sweep
+  (`collectRealQuantSweepSamples`) throws `RealQuantSweepNotArmedError` unless
+  owner-armed with an executor; a decision-grade gate decision promoting a real
+  lane requires that armed sweep over realistic traffic. NOT run here.
+- **Status:** PR open against `main` (#6090); orchestrator reviews / merges /
+  deploys / smokes. NOT deployed, NO spend by this entry.

--- a/docs/inference/khala.md
+++ b/docs/inference/khala.md
@@ -370,6 +370,20 @@ Receipts (the `openagents` block) carry the receipt id, route, workers,
 verification class, cost/price in msat, and settled state — enough for a stranger
 to re-check without exposing CoT.
 
+**Quantization disclosure (book P1-7 / #6090).** A model served at a reduced
+precision (FP8 / MXFP8 / NVFP4 / INT4 / …) is **not the same product** as the
+unqualified model id. Receipts therefore carry typed quantization metadata —
+precision, serving backend/engine + version, the quantized **scope** (which
+tensors), and whether the lane passed the quantization eval gate — with honest
+`unquantized` / `not_measured` sentinels where unknown (never a fabricated full
+precision). A quantized lane may carry an **unqualified** public alias only when
+its precision/backend are disclosed in the receipt **and** it has passed an
+executed eval comparison vs the original precision (accepted-outcome rate held,
+or cost-per-accepted-outcome improved). Otherwise it must use a **qualified**
+alias that names the precision (e.g. `openagents/khala-code-fp8`). Policy:
+weights-only / FP8 before aggressive KV-cache or attention quantization. See
+`docs/inference/2026-06-23-khala-quantization-eval-gate-book-p1-7.md`.
+
 ## 7. Metering, pricing, settlement
 
 - **Metering** (`MeteringHook`, #5477): per call record user/agent, model,
@@ -581,6 +595,12 @@ Requirements:
   `settled` field on a streaming response.
 - How `khala-code` defines "accepted outcome" for arbitrary repos (verification
   command discovery) — ties to the Tassadar coding-environment work.
+- ~~Which quantization modes may share a public model alias?~~ **Resolved (P1-7 /
+  #6090):** an unqualified public alias may be served by a quantized lane only
+  when its precision/backend are disclosed in the receipt **and** the lane passed
+  the quantization eval gate; otherwise the lane uses a qualified alias that names
+  the precision. Honestly-unknown precision (`not_measured`) may not share an
+  unqualified alias. See §6 + the eval-gate doc.
 
 ---
 


### PR DESCRIPTION
Implements book **P1-7 — "Quantization needs a Khala eval gate"** (#6090) into the Khala gateway.

**Principle encoded:** a model served at a reduced precision (FP8 / MXFP8 / NVFP4 / INT4 / …) is **not the same product** as the unqualified model id, and a throughput win that lowers the accepted-outcome rate is a **loss** unless cost-per-accepted-outcome improves.

## Deliverables (buildable now)

1. **Quantization metadata** (`khala-quantization.ts`) — typed `KhalaQuantizationMetadata` (precision / backend / backendVersion / scope / evalGatePassed / evalGateRef) + `KhalaServedModelDescriptor`. Added as a first-class `quantization` field on `KhalaTelemetryRecord` (`khala-telemetry.ts`). Honest `unquantized` / `not_measured` sentinels — an unmeasured request records `UNKNOWN_QUANTIZATION`, never a fabricated full precision.
2. **Same-model-claim guard** (`khala-quantization-guard.ts`) — typed, fail-closed check over the served-model descriptor (`evaluateSameModelClaim` / `assertSameModelClaim` → `KhalaSameModelClaimError`). REJECTS an undisclosed quantized lane, a `not_measured` lane, and a disclosed-but-ungated quantized lane under an **unqualified** public alias; PASSES an unquantized lane, a qualified alias (precision named in the id), and a disclosed + eval-gate-qualified quantized lane. The receipt-disclosure sibling of the Khala identity guard.
3. **Quantization eval gate** (`khala-quantization-eval-gate.ts`) — scores a quantized lane vs the original precision on **executed** `AcceptanceVerdict`s (reuses the P0-4 verifier, never a regex) and the cost-per-accepted-outcome delta (reuses the P1-5 report math). PASSES only when accepted-outcome quality holds, or a small drop within the agreed bound is bought back by a sufficient cost-per-accepted-outcome improvement.
4. **Policy doc** (`docs/inference/2026-06-23-khala-quantization-eval-gate-book-p1-7.md`) + `khala.md` §6 disclosure policy + Open Question Q6 resolved + IMPLEMENTATION_LOG P1-7 entry.

## Fixture vs owner/compute-gated split

- **Buildable now:** the metadata + telemetry field, the guard, and the eval-gate **logic** scored on deterministic fixture comparison sets — no real quantized serving, no network, no spend, no compute.
- **Owner/compute-gated (built, flagged OFF):** the real quantized-vs-original sweep stands up real reduced-precision serving and runs the executed verifier on both precisions. `collectRealQuantSweepSamples` throws `RealQuantSweepNotArmedError` unless owner-armed with an executor. A decision-grade gate decision (promoting a real lane to a public alias) requires that armed sweep over realistic traffic. NOT run here.

## Tests (37 new, 779 inference total)

- Quant metadata populates from a fixture served-model descriptor and records the honest sentinel when unknown.
- The same-model guard rejects an undisclosed/unknown/ungated quantized alias and passes a disclosed-gated one + a qualified alias.
- The eval gate passes when quality holds (or a small drop is offset by a cost-per-accepted win) and fails when accepted-outcome drops beyond bound / without a cost win / on an aggressive scope without owner ack.
- The real sweep is flag-gated off (no real serving in tests).

## Verification

Inference suites green (779 tests, 37 new), `typecheck`, `check:architecture`, `check:effect-topology`, `check:public-projection-freshness` all green. Not deployed; no spend.

Closes #6090. **DO NOT auto-merge — orchestrator reviews/merges + deploys.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)