### PR TITLE
Khala speculation acceptance telemetry + dynamic-disablement policy + receipt disclosure (book P1-8, #6091)

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/benchmark/index.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/index.ts
@@ -8,6 +8,7 @@
 // honesty/public-safety discipline.
 export * from './matrix'
 export * from './lane-seam'
+export * from './speculation-lane'
 export * from './runner'
 export * from './report'
 export * from './fixtures'

--- a/apps/openagents.com/workers/api/src/inference/benchmark/lane-seam.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/lane-seam.ts
@@ -28,7 +28,9 @@ import type {
   KhalaExecutedVerdict,
   KhalaVerificationClass,
 } from '../khala-telemetry'
+import type { KhalaSpeculationInput } from '../khala-speculation'
 import type { BenchmarkCell } from './matrix'
+import { fixtureSpeculationForCell } from './speculation-lane'
 
 // ---------------------------------------------------------------------------
 // The measured sample a seam returns for one execution of one cell.
@@ -64,6 +66,14 @@ export type BenchmarkLaneSample = Readonly<{
   costBasisMsat: number
   // The serving region the lane reports (public-safe coarse region string).
   region: string
+  // The SPECULATIVE-DECODING signals this sample observed (book P1-8 / #6091).
+  // The fixture lane derives these from the cell's batch/pressure via the
+  // dynamic-disablement policy; a real lane would carry the engine's actual
+  // draft/verify counts. Optional: absent => the telemetry builder records the
+  // honest-unknown speculation shape (`not_measured`). It is honestly `none`
+  // (no speculation ran) on a disabled/high-batch cell, and a real drafting mode
+  // with acceptance counts on a low-batch code cell.
+  speculation?: KhalaSpeculationInput | undefined
 }>
 
 // The pluggable seam. Given a cell, return a measured sample. PURE for the
@@ -289,6 +299,9 @@ export const makeFixtureLaneSeam = (
       gatewayOverheadMs: profile.gatewayOverheadMs,
       costBasisMsat,
       region: profile.region,
+      // Fixture speculation: the policy decides on/off from the cell's batch
+      // (concurrency) + derived pressure; counts only when enabled (book P1-8).
+      speculation: fixtureSpeculationForCell(cell),
       ...fixtureVerification(cell),
     }
   },

--- a/apps/openagents.com/workers/api/src/inference/benchmark/report.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/report.ts
@@ -28,6 +28,7 @@
 //
 // PURE: no clock, no randomness, no IO. Same run set → same report.
 import { type MeasuredNumber, isMeasured } from '../khala-telemetry'
+import type { KhalaSpeculationMode } from '../khala-speculation'
 import type { BenchmarkRun, BenchmarkRunSet } from './runner'
 import type { BenchmarkLane, BenchmarkWorkload } from './matrix'
 
@@ -214,6 +215,113 @@ const aggregateGroup = (
 }
 
 // ---------------------------------------------------------------------------
+// Speculation acceptance-rate aggregate (book P1-8 / #6091).
+// ---------------------------------------------------------------------------
+//
+// The issue's done-when: record draft acceptance rate PER (workload × model ×
+// temperature × route). This is a SEPARATE aggregate from the (lane × workload)
+// group metrics so the four keying axes the book/issue ask for are explicit and
+// the acceptance rate is never averaged across different temperatures/models.
+
+// One acceptance-rate cell: the four keying axes + the aggregate acceptance over
+// the runs that ACTUALLY ran speculation. `acceptanceRate` is null (honest
+// absence, never a fabricated 0) when no run in the cell had a measured
+// acceptance rate — e.g. speculation was disabled (high batch) or not requested
+// (chat). The dominant `mode` is recorded so a reader sees which drafting mode
+// produced the rate (or `none` when none ran).
+export type SpeculationAcceptanceCell = Readonly<{
+  // The four keying axes the issue requires.
+  workload: BenchmarkWorkload
+  // The served model identity (`lane/engine`), the same id the telemetry record
+  // carries in `servedModel`.
+  model: string
+  temperature: number
+  // The route lane (the telemetry `route` — derived from the workload).
+  route: BenchmarkWorkload
+  // The speculation mode observed across the cell's runs (the mode every active
+  // run shared; `none` when speculation never ran in the cell).
+  mode: KhalaSpeculationMode
+  // Mean draft acceptance rate over runs that measured one; null when none did.
+  acceptanceRate: number | null
+  // How many runs in the cell ran speculation with a MEASURED acceptance rate
+  // (the read confidence behind the rate).
+  measuredRuns: number
+  // Total executed runs in the cell (measured + non-speculating).
+  executedRuns: number
+}>
+
+// Aggregate the per-cell speculation acceptance rate keyed by (workload × model ×
+// temperature × route). PURE: same runs → same cells, in deterministic order.
+const aggregateSpeculationAcceptance = (
+  runs: ReadonlyArray<BenchmarkRun>,
+): ReadonlyArray<SpeculationAcceptanceCell> => {
+  type Acc = {
+    workload: BenchmarkWorkload
+    model: string
+    temperature: number
+    rates: Array<number>
+    activeMode: KhalaSpeculationMode
+    executedRuns: number
+  }
+  const buckets = new Map<string, Acc>()
+  // Preserve first-seen order so the output is deterministic w.r.t. the runner's
+  // deterministic matrix order.
+  const order: Array<string> = []
+
+  for (const run of runs) {
+    if (run.record === null) {
+      continue
+    }
+    const workload = run.cell.workload
+    const model = run.record.servedModel
+    const temperature = run.cell.sampling.temperature
+    const key = `${workload}::${model}::${temperature}`
+    let acc = buckets.get(key)
+    if (acc === undefined) {
+      acc = {
+        workload,
+        model,
+        temperature,
+        rates: [],
+        activeMode: 'none',
+        executedRuns: 0,
+      }
+      buckets.set(key, acc)
+      order.push(key)
+    }
+    acc.executedRuns += 1
+    const spec = run.record.speculation
+    if (spec.active && spec.mode !== 'none' && spec.mode !== 'not_measured') {
+      acc.activeMode = spec.mode
+    }
+    if (isMeasured(spec.acceptanceRate)) {
+      acc.rates.push(spec.acceptanceRate)
+    }
+  }
+
+  const cells: Array<SpeculationAcceptanceCell> = []
+  for (const key of order) {
+    const acc = buckets.get(key)
+    if (acc === undefined) {
+      continue
+    }
+    cells.push({
+      workload: acc.workload,
+      model: acc.model,
+      temperature: acc.temperature,
+      // The route IS the workload lane in the benchmark (the runner sets
+      // `route: cell.workload`); kept as an explicit axis for the issue's tuple.
+      route: acc.workload,
+      mode: acc.activeMode,
+      acceptanceRate: mean(acc.rates),
+      measuredRuns: acc.rates.length,
+      executedRuns: acc.executedRuns,
+    })
+  }
+  return cells
+}
+
+// ---------------------------------------------------------------------------
 // The full report artifact.
 // ---------------------------------------------------------------------------
 
@@ -232,6 +340,12 @@ export type BenchmarkReport = Readonly<{
   cellsSkipped: number
   // Per (lane × workload) metrics, in deterministic (lane, workload) order.
   groups: ReadonlyArray<BenchmarkGroupMetrics>
+  // Draft acceptance rate per (workload × model × temperature × route) — book
+  // P1-8 / #6091. Separate from `groups` so the acceptance rate is never averaged
+  // across different temperatures/models. A cell with no speculation has a null
+  // rate (honest absence), which is itself the finding that speculation did not
+  // run (e.g. disabled at high batch, or not a code workload).
+  speculationAcceptance: ReadonlyArray<SpeculationAcceptanceCell>
 }>
 
 const ILLUSTRATIVE_NOTICE =
@@ -299,6 +413,7 @@ export const buildBenchmarkReport = (
     cellsExecuted: runSet.cellsExecuted,
     cellsSkipped: runSet.cellsSkipped,
     groups,
+    speculationAcceptance: aggregateSpeculationAcceptance(runSet.runs),
   }
 }
 

--- a/apps/openagents.com/workers/api/src/inference/benchmark/runner.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/runner.ts
@@ -106,6 +106,13 @@ const runSample = (
     verifierTimeMs:
       sample.verifierTimeMs > 0 ? sample.verifierTimeMs : undefined,
     region: sample.region,
+    // Speculation disclosure (book P1-8 / #6091): the seam's per-sample
+    // speculation outcome (mode + draft counts) flows into the canonical record
+    // so a benchmark sample discloses speculation the same way a production
+    // request will. Absent => the builder records the honest-unknown shape.
+    ...(sample.speculation === undefined
+      ? {}
+      : { speculation: sample.speculation }),
     verificationClass: sample.verificationClass,
     executedVerdict: sample.executedVerdict,
     scalarReward: sample.scalarReward,

--- a/apps/openagents.com/workers/api/src/inference/benchmark/speculation-lane.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/speculation-lane.ts
@@ -1,0 +1,118 @@
+// Fixture speculation derivation for the benchmark lane (book P1-8 / #6091).
+//
+// The benchmark fixture lane is the natural home for a DETERMINISTIC "decode
+// trace" the speculation telemetry can populate from — there is no real draft
+// model in the Worker, so the live serving path discloses `not_measured`/`none`,
+// and the only place we can EXERCISE the acceptance-rate plumbing + the
+// dynamic-disablement policy end-to-end (without spend) is the fixture lane.
+//
+// This module turns a benchmark CELL into a fixture speculation outcome:
+//
+//   1. A CODE workload (artifact-gen / verifier-run / long-context codebase
+//      question) is a speculation FIT — generated code repeats syntax + reuses
+//      prompt context — so it REQUESTS a draft-free mode (`n_gram`). A plain chat
+//      workload does not request speculation (`none`).
+//   2. The cell's CONCURRENCY is the batch signal and a derived saturation scalar
+//      is the compute-pressure signal. `decideSpeculation` (the bounded policy)
+//      then ENABLES speculation at low batch/pressure and DISABLES it otherwise.
+//   3. When enabled, the fixture derives plausible draft-token counts (a high
+//      acceptance rate for code, lower for a long-context question) so the
+//      acceptance-rate telemetry populates from a real count pair — never a bare
+//      fabricated rate. When disabled, the outcome is honest mode `none` (we know
+//      no speculation ran because the policy turned it off).
+//
+// PURE/DETERMINISTIC: same cell → same outcome. No clock, no randomness, no spend.
+import {
+  type KhalaSpeculationInput,
+  type KhalaSpeculationMode,
+  decideSpeculation,
+} from '../khala-speculation'
+import type { BenchmarkCell } from './matrix'
+
+// Whether a workload is a code workload that fits draft-free speculation (book
+// Ch.5: code repeats syntax + reuses prompt context). A bounded classification of
+// the typed workload enum — NOT request-content string matching.
+const isCodeWorkload = (cell: BenchmarkCell): boolean => {
+  switch (cell.workload) {
+    case 'khala-code-artifact-gen':
+    case 'verifier-run':
+    case 'long-context-codebase-question':
+      return true
+    case 'chat':
+      return false
+  }
+}
+
+// The drafting mode a code workload requests. n-gram drafting (no draft model) is
+// the Worker-runnable, code-fitting default; a long-context codebase question
+// uses lookahead (KV-cache n-gram table) since it has a large context to mine.
+const requestedModeForCell = (cell: BenchmarkCell): KhalaSpeculationMode => {
+  if (!isCodeWorkload(cell)) {
+    return 'none'
+  }
+  return cell.workload === 'long-context-codebase-question'
+    ? 'lookahead'
+    : 'n_gram'
+}
+
+// Derive a normalized compute-pressure scalar in [0, 1] from the cell's
+// concurrency. A single serial request is near-idle (lots of spare compute to
+// verify drafts); pressure climbs with concurrency and saturates by ~16
+// concurrent sequences. PURE arithmetic — illustrative, not a real utilization
+// measurement (the fixture lane labels its numbers illustrative).
+const fixtureComputePressure = (concurrency: number): number => {
+  const safe = Number.isFinite(concurrency) && concurrency > 0 ? concurrency : 1
+  return Math.min(1, (safe - 1) / 15)
+}
+
+// Derive the proposed/accepted draft-token counts for an ENABLED code cell. The
+// acceptance rate is illustrative-but-plausible: high for tight code artifact
+// generation (lots of syntax repetition), a bit lower for a long-context
+// question (more novel content). Counts scale with output length so the rate is
+// backed by a real count pair, not a bare number. PURE.
+const fixtureDraftCounts = (
+  cell: BenchmarkCell,
+): Readonly<{ proposed: number; accepted: number }> => {
+  // Propose a draft block per ~K output tokens (K=4, the book's typical draft
+  // length). Total proposed ≈ outputTokens (every position had a draft attempt).
+  const proposed = Math.max(4, cell.shape.outputTokens)
+  // Illustrative acceptance: 0.78 for n-gram code gen, 0.62 for lookahead on a
+  // long-context question (more novel tokens → fewer repeated n-grams).
+  const targetRate =
+    cell.workload === 'long-context-codebase-question' ? 0.62 : 0.78
+  const accepted = Math.round(proposed * targetRate)
+  return { proposed, accepted }
+}
+
+// Derive the fixture speculation outcome for a cell: request a mode for code
+// workloads, run the dynamic-disablement policy against the cell's batch
+// (concurrency) + derived pressure, and produce honest counts only when the
+// policy ENABLED speculation. Returns the `KhalaSpeculationInput` the runner
+// threads into the telemetry builder. PURE/deterministic.
+export const fixtureSpeculationForCell = (
+  cell: BenchmarkCell,
+): KhalaSpeculationInput => {
+  const requestedMode = requestedModeForCell(cell)
+  const decision = decideSpeculation({
+    requestedMode,
+    signal: {
+      batchSize: cell.shape.concurrency,
+      computePressure: fixtureComputePressure(cell.shape.concurrency),
+    },
+  })
+
+  if (!decision.enabled) {
+    // The policy turned speculation OFF (chat, or high batch/pressure). We KNOW
+    // no speculation ran → honest `none` (not the unknown sentinel, and not a
+    // fabricated 0 acceptance).
+    return { mode: 'none', active: false }
+  }
+
+  const { proposed, accepted } = fixtureDraftCounts(cell)
+  return {
+    mode: decision.selectedMode,
+    active: true,
+    draftTokensProposed: proposed,
+    draftTokensAccepted: accepted,
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/khala-speculation-telemetry.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-speculation-telemetry.test.ts
@@ -1,0 +1,215 @@
+// Integration tests for book P1-8 (#6091): speculation acceptance-rate telemetry
+// populates from a fixture decode trace, the dynamic-disablement policy turns
+// speculation on at low batch and off at high batch through the fixture lane, the
+// speculation mode is disclosed in the telemetry record (the receipt-mode
+// disclosure), and the real speculative-decoding engine stays flag-gated off (no
+// real engine in tests).
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildKhalaTelemetryRecord,
+  isMeasured,
+} from './khala-telemetry'
+import {
+  RealLaneNotArmedError,
+  makeFixtureLaneSeam,
+  makeRealLaneSeam,
+} from './benchmark/lane-seam'
+import { fixtureSpeculationForCell } from './benchmark/speculation-lane'
+import { runBenchmark } from './benchmark/runner'
+import { buildBenchmarkReport } from './benchmark/report'
+import { expandMatrix } from './benchmark/matrix'
+import type { BenchmarkMatrixConfig } from './benchmark/matrix'
+import { TINY_TEST_CONFIG } from './benchmark/fixtures'
+
+// A high-concurrency code config: concurrency 32 is well above the policy's
+// profitable batch threshold, so the fixture lane must DISABLE speculation.
+const HIGH_BATCH_CODE_CONFIG: BenchmarkMatrixConfig = {
+  id: 'high-batch-code-v1',
+  description: 'High-concurrency code workload — speculation must be disabled.',
+  targets: [{ lane: 'fireworks', engine: 'provider-native' }],
+  workloads: ['khala-code-artifact-gen'],
+  shapes: [
+    {
+      id: 'high-batch-shape',
+      inputTokens: 1000,
+      outputTokens: 200,
+      cacheablePrefixTokens: 400,
+      concurrency: 32,
+      provenance: 'synthetic',
+    },
+  ],
+  transports: ['streaming'],
+  sampling: [{ temperature: 0, reasoningEffort: 'off' }],
+  samplesPerCell: 3,
+}
+
+describe('telemetry record carries the speculation disclosure', () => {
+  test('absent speculation input => honest-unknown shape (not_measured), never fabricated', () => {
+    const record = buildKhalaTelemetryRecord({
+      requestId: 'r1',
+      requestedModel: 'openagents/khala-code',
+      servedModel: 'fireworks/x',
+      route: 'coding',
+      provider: 'fireworks',
+      requestClass: 'interactive_stream',
+      verificationClass: 'none',
+      executedVerdict: 'not_executed',
+      settlementState: 'not_applicable',
+    })
+    expect(record.speculation.mode).toBe('not_measured')
+    expect(record.speculation.active).toBe(false)
+    expect(record.speculation.acceptanceRate).toBe('not_measured')
+  })
+
+  test('a disclosed drafting pass populates the acceptance rate on the record', () => {
+    const record = buildKhalaTelemetryRecord({
+      requestId: 'r2',
+      requestedModel: 'openagents/khala-code',
+      servedModel: 'fireworks/x',
+      route: 'coding',
+      provider: 'fireworks',
+      requestClass: 'interactive_stream',
+      verificationClass: 'none',
+      executedVerdict: 'not_executed',
+      settlementState: 'not_applicable',
+      speculation: {
+        mode: 'n_gram',
+        draftTokensProposed: 200,
+        draftTokensAccepted: 150,
+      },
+    })
+    expect(record.speculation.mode).toBe('n_gram')
+    expect(record.speculation.active).toBe(true)
+    expect(record.speculation.acceptanceRate).toBe(0.75)
+  })
+})
+
+describe('fixture decode trace: acceptance-rate telemetry populates honestly', () => {
+  test('a low-batch code cell ENABLES speculation and records a measured acceptance rate', () => {
+    const seam = makeFixtureLaneSeam()
+    const runSet = runBenchmark(TINY_TEST_CONFIG, seam)
+    // TINY_TEST_CONFIG is concurrency 1, khala-code-artifact-gen => enabled.
+    const executed = runSet.runs.filter(
+      run => run.record !== null && run.cell.laneAvailability === 'available',
+    )
+    expect(executed.length).toBeGreaterThan(0)
+    for (const run of executed) {
+      const spec = run.record?.speculation
+      expect(spec?.mode).toBe('n_gram')
+      expect(spec?.active).toBe(true)
+      // A real count pair backs the rate (never a bare fabricated number).
+      expect(isMeasured(spec?.acceptanceRate ?? 'not_measured')).toBe(true)
+      expect(isMeasured(spec?.draftTokensProposed ?? 'not_measured')).toBe(true)
+      expect(isMeasured(spec?.draftTokensAccepted ?? 'not_measured')).toBe(true)
+    }
+  })
+
+  test('a chat cell does NOT request speculation => honest mode `none`, no fabricated rate', () => {
+    const seam = makeFixtureLaneSeam()
+    // The sample decision suite has a chat workload at concurrency 1.
+    const chatCells = expandMatrix({
+      id: 'chat-only',
+      description: 'chat only',
+      targets: [{ lane: 'fireworks', engine: 'provider-native' }],
+      workloads: ['chat'],
+      shapes: [
+        {
+          id: 's',
+          inputTokens: 200,
+          outputTokens: 100,
+          cacheablePrefixTokens: 0,
+          concurrency: 1,
+          provenance: 'synthetic',
+        },
+      ],
+      transports: ['streaming'],
+      sampling: [{ temperature: 0.2, reasoningEffort: 'off' }],
+      samplesPerCell: 1,
+    })
+    const sample = seam.sample(chatCells[0]!, 0)
+    expect(sample.speculation?.mode).toBe('none')
+    expect(sample.speculation?.active).toBe(false)
+  })
+})
+
+describe('fixture lane applies the dynamic-disablement policy end-to-end', () => {
+  test('HIGH batch code cell => speculation disabled, honest mode `none`', () => {
+    const cells = expandMatrix(HIGH_BATCH_CODE_CONFIG)
+    const codeCell = cells.find(c => c.workload === 'khala-code-artifact-gen')
+    expect(codeCell).toBeDefined()
+    const outcome = fixtureSpeculationForCell(codeCell!)
+    expect(outcome.mode).toBe('none')
+    expect(outcome.active).toBe(false)
+
+    // And through the full runner + telemetry: no measured acceptance rate.
+    const runSet = runBenchmark(HIGH_BATCH_CODE_CONFIG, makeFixtureLaneSeam())
+    for (const run of runSet.runs) {
+      if (run.record === null) continue
+      expect(run.record.speculation.mode).toBe('none')
+      expect(run.record.speculation.acceptanceRate).toBe('not_measured')
+    }
+  })
+
+  test('LOW batch code cell => speculation enabled with a measured rate (the contrast)', () => {
+    const cells = expandMatrix(TINY_TEST_CONFIG)
+    const codeCell = cells.find(
+      c =>
+        c.workload === 'khala-code-artifact-gen' &&
+        c.laneAvailability === 'available',
+    )
+    expect(codeCell).toBeDefined()
+    const outcome = fixtureSpeculationForCell(codeCell!)
+    expect(outcome.active).toBe(true)
+    expect(outcome.mode).toBe('n_gram')
+    expect(typeof outcome.draftTokensProposed).toBe('number')
+    expect(typeof outcome.draftTokensAccepted).toBe('number')
+  })
+})
+
+describe('report discloses acceptance per (workload x model x temperature x route)', () => {
+  test('the report carries a speculation-acceptance aggregate with the four keying axes', () => {
+    const runSet = runBenchmark(TINY_TEST_CONFIG, makeFixtureLaneSeam())
+    const report = buildBenchmarkReport(runSet)
+    expect(report.speculationAcceptance.length).toBeGreaterThan(0)
+    const cell = report.speculationAcceptance.find(
+      c => c.workload === 'khala-code-artifact-gen',
+    )
+    expect(cell).toBeDefined()
+    // The four axes are present.
+    expect(cell?.workload).toBe('khala-code-artifact-gen')
+    expect(typeof cell?.model).toBe('string')
+    expect(typeof cell?.temperature).toBe('number')
+    expect(cell?.route).toBe('khala-code-artifact-gen')
+    // A low-batch code cell ran speculation => a measured aggregate rate + mode.
+    expect(cell?.mode).toBe('n_gram')
+    expect(cell?.acceptanceRate).not.toBeNull()
+    expect(cell?.measuredRuns).toBeGreaterThan(0)
+  })
+
+  test('a high-batch report records a null acceptance rate (honest absence, not 0)', () => {
+    const runSet = runBenchmark(HIGH_BATCH_CODE_CONFIG, makeFixtureLaneSeam())
+    const report = buildBenchmarkReport(runSet)
+    const cell = report.speculationAcceptance.find(
+      c => c.workload === 'khala-code-artifact-gen',
+    )
+    expect(cell).toBeDefined()
+    expect(cell?.mode).toBe('none')
+    expect(cell?.acceptanceRate).toBeNull()
+    expect(cell?.measuredRuns).toBe(0)
+  })
+})
+
+describe('real speculative-decoding engine stays flag-gated OFF (no real engine in tests)', () => {
+  test('the fixture seam never spends and never runs a real draft model', () => {
+    const seam = makeFixtureLaneSeam()
+    expect(seam.canSpend).toBe(false)
+  })
+
+  test('an un-armed real lane refuses to run (no real engine reachable from a test)', () => {
+    const realSeam = makeRealLaneSeam({ armRealSweep: false })
+    expect(realSeam.canSpend).toBe(false)
+    const cells = expandMatrix(TINY_TEST_CONFIG)
+    expect(() => realSeam.sample(cells[0]!, 0)).toThrow(RealLaneNotArmedError)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-speculation.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-speculation.test.ts
@@ -1,0 +1,206 @@
+import { Option } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  DEFAULT_SPECULATION_POLICY,
+  NOT_MEASURED,
+  NO_SPECULATION,
+  UNKNOWN_SPECULATION,
+  buildKhalaSpeculationMetadata,
+  decideSpeculation,
+  decodeKhalaSpeculationMetadata,
+  isDraftFreeMode,
+  isLearnedMode,
+} from './khala-speculation'
+
+describe('khala speculation — mode classifiers', () => {
+  test('draft-free modes are exactly n-gram + lookahead (Worker-runnable today)', () => {
+    expect(isDraftFreeMode('n_gram')).toBe(true)
+    expect(isDraftFreeMode('lookahead')).toBe(true)
+    expect(isDraftFreeMode('eagle')).toBe(false)
+    expect(isDraftFreeMode('none')).toBe(false)
+    expect(isDraftFreeMode('not_measured')).toBe(false)
+  })
+
+  test('eagle is the only learned mode (the later Psionic / hidden-state lane)', () => {
+    expect(isLearnedMode('eagle')).toBe(true)
+    expect(isLearnedMode('n_gram')).toBe(false)
+    expect(isLearnedMode('lookahead')).toBe(false)
+    expect(isLearnedMode('none')).toBe(false)
+  })
+})
+
+describe('khala speculation — honest builder (no fabricated acceptance)', () => {
+  test('absent mode yields the honest-unknown shape, never a fabricated rate', () => {
+    const meta = buildKhalaSpeculationMetadata({})
+    expect(meta).toEqual(UNKNOWN_SPECULATION)
+    expect(meta.mode).toBe('not_measured')
+    expect(meta.active).toBe(false)
+    expect(meta.acceptanceRate).toBe(NOT_MEASURED)
+    expect(meta.draftTokensProposed).toBe(NOT_MEASURED)
+    expect(meta.draftTokensAccepted).toBe(NOT_MEASURED)
+  })
+
+  test('explicit mode `none` is the KNOWN no-speculation shape (not the unknown one)', () => {
+    const meta = buildKhalaSpeculationMetadata({ mode: 'none' })
+    expect(meta).toEqual(NO_SPECULATION)
+    expect(meta.mode).toBe('none')
+    expect(meta.active).toBe(false)
+    // No drafts ran => acceptance is the sentinel, NOT a measured 0 (which would
+    // falsely imply a drafter ran and accepted nothing).
+    expect(meta.acceptanceRate).toBe(NOT_MEASURED)
+  })
+
+  test('a real drafting pass records counts + a derived acceptance rate', () => {
+    const meta = buildKhalaSpeculationMetadata({
+      mode: 'n_gram',
+      draftTokensProposed: 100,
+      draftTokensAccepted: 78,
+    })
+    expect(meta.mode).toBe('n_gram')
+    expect(meta.active).toBe(true)
+    expect(meta.acceptanceRate).toBe(0.78)
+    expect(meta.draftTokensProposed).toBe(100)
+    expect(meta.draftTokensAccepted).toBe(78)
+  })
+
+  test('acceptance rate is the sentinel when counts are missing (never a bare number)', () => {
+    const meta = buildKhalaSpeculationMetadata({
+      mode: 'lookahead',
+      draftTokensProposed: 50,
+      // accepted omitted
+    })
+    expect(meta.acceptanceRate).toBe(NOT_MEASURED)
+    expect(meta.draftTokensProposed).toBe(50)
+    expect(meta.draftTokensAccepted).toBe(NOT_MEASURED)
+  })
+
+  test('zero proposals => rate is the sentinel (a rate over zero proposals is undefined, not 0)', () => {
+    const meta = buildKhalaSpeculationMetadata({
+      mode: 'n_gram',
+      draftTokensProposed: 0,
+      draftTokensAccepted: 0,
+    })
+    expect(meta.acceptanceRate).toBe(NOT_MEASURED)
+  })
+
+  test('accepted is clamped to <= proposed so a malformed disclosure never exceeds rate 1', () => {
+    const meta = buildKhalaSpeculationMetadata({
+      mode: 'n_gram',
+      draftTokensProposed: 10,
+      draftTokensAccepted: 99,
+    })
+    expect(meta.acceptanceRate).toBe(1)
+    expect(meta.draftTokensAccepted).toBe(10)
+  })
+
+  test('the built metadata round-trips through the decoder', () => {
+    const meta = buildKhalaSpeculationMetadata({
+      mode: 'n_gram',
+      draftTokensProposed: 100,
+      draftTokensAccepted: 70,
+    })
+    const decoded = decodeKhalaSpeculationMetadata(meta)
+    expect(Option.isSome(decoded)).toBe(true)
+  })
+})
+
+describe('decideSpeculation — dynamic disablement (the book operating rule)', () => {
+  test('ENABLES a draft-free mode at low batch + low pressure', () => {
+    const decision = decideSpeculation({
+      requestedMode: 'n_gram',
+      signal: { batchSize: 1, computePressure: 0.1 },
+    })
+    expect(decision.enabled).toBe(true)
+    expect(decision.selectedMode).toBe('n_gram')
+    expect(decision.reason).toBe('enabled_low_batch')
+  })
+
+  test('lookahead enables at the batch boundary (batch == maxProfitableBatchSize)', () => {
+    const decision = decideSpeculation({
+      requestedMode: 'lookahead',
+      signal: {
+        batchSize: DEFAULT_SPECULATION_POLICY.maxProfitableBatchSize,
+        computePressure: 0,
+      },
+    })
+    expect(decision.enabled).toBe(true)
+    expect(decision.selectedMode).toBe('lookahead')
+  })
+
+  test('DISABLES above the batch threshold (high concurrency => verification hurts throughput)', () => {
+    const decision = decideSpeculation({
+      requestedMode: 'n_gram',
+      signal: {
+        batchSize: DEFAULT_SPECULATION_POLICY.maxProfitableBatchSize + 1,
+        computePressure: 0.1,
+      },
+    })
+    expect(decision.enabled).toBe(false)
+    expect(decision.selectedMode).toBe('none')
+    expect(decision.reason).toBe('disabled_high_batch')
+  })
+
+  test('DISABLES above the compute-pressure threshold (no spare compute to verify drafts)', () => {
+    const decision = decideSpeculation({
+      requestedMode: 'n_gram',
+      signal: {
+        batchSize: 1,
+        computePressure:
+          DEFAULT_SPECULATION_POLICY.maxProfitableComputePressure + 0.01,
+      },
+    })
+    expect(decision.enabled).toBe(false)
+    expect(decision.reason).toBe('disabled_high_pressure')
+  })
+
+  test('DISABLES conservatively when the pressure signal is unknown', () => {
+    expect(
+      decideSpeculation({
+        requestedMode: 'n_gram',
+        signal: { batchSize: NOT_MEASURED, computePressure: 0.1 },
+      }).reason,
+    ).toBe('disabled_pressure_unknown')
+    expect(
+      decideSpeculation({
+        requestedMode: 'n_gram',
+        signal: { batchSize: 1, computePressure: NOT_MEASURED },
+      }).reason,
+    ).toBe('disabled_pressure_unknown')
+  })
+
+  test('DISABLES a learned/unavailable mode (eagle is the Psionic lane, not Worker-runnable)', () => {
+    const decision = decideSpeculation({
+      requestedMode: 'eagle',
+      signal: { batchSize: 1, computePressure: 0 },
+    })
+    expect(decision.enabled).toBe(false)
+    expect(decision.reason).toBe('disabled_mode_unavailable')
+  })
+
+  test('DISABLES when speculation was not requested (chat / none)', () => {
+    expect(
+      decideSpeculation({
+        requestedMode: 'none',
+        signal: { batchSize: 1, computePressure: 0 },
+      }).reason,
+    ).toBe('disabled_not_requested')
+  })
+
+  test('a custom policy widens/narrows the profitable window deterministically', () => {
+    const decision = decideSpeculation({
+      requestedMode: 'n_gram',
+      signal: { batchSize: 8, computePressure: 0.5 },
+      policy: { maxProfitableBatchSize: 16, maxProfitableComputePressure: 0.9 },
+    })
+    expect(decision.enabled).toBe(true)
+  })
+
+  test('PURE: same inputs => same decision', () => {
+    const input = {
+      requestedMode: 'n_gram' as const,
+      signal: { batchSize: 2, computePressure: 0.2 },
+    }
+    expect(decideSpeculation(input)).toEqual(decideSpeculation(input))
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/khala-speculation.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-speculation.ts
@@ -1,0 +1,418 @@
+// Khala speculative-decoding telemetry + dynamic-disablement policy
+// (book P1-8 / #6091).
+//
+// THE PRINCIPLE (book Ch.5 "Speculative Decoding", in our own words)
+// ------------------------------------------------------------------
+// Speculative decoding speeds up DECODE by letting a cheap drafter guess the
+// next few tokens and letting the expensive target model VERIFY them in a single
+// parallel forward pass. Accepted drafts give several tokens for the cost of one
+// verification step; a rejection still makes forward progress of one true token.
+//
+// It is NOT a universal win. The verification pass costs spare compute, so the
+// trick only pays off when there IS spare compute to spend — i.e. at LOW batch,
+// where decode is the bottleneck and the machine is not already saturated. At
+// HIGH batch (or under compute pressure) the extra verification work competes
+// with real throughput and speculation becomes a LOSS. So speculation must be
+// MEASURED (acceptance rate) and DYNAMICALLY DISABLED when the batch/pressure
+// signal says it will not profit — and the mode must be DISCLOSED in the receipt,
+// because a request served with speculation is a different serving product than
+// one served by plain autoregressive decode.
+//
+// Code generation is a strong FIT: generated code repeats syntax and reuses
+// prompt context, so cheap n-gram / lookahead drafting (no separate draft model)
+// hits a high acceptance rate. EAGLE (learned hidden-state drafting) is flagged
+// as a LATER Psionic / learned-serving lane: it needs target-model hidden-state
+// data + training, so it is named here but never claimed as a built mode.
+//
+// THIS MODULE owns ONLY the typed speculation telemetry metadata, the canonical
+// honest shapes, the builder, and the bounded `decideSpeculation` policy. It does
+// NOT run a draft model (there is no draft model / real engine in the Worker);
+// the REAL speculative decode is compute/owner-gated and lives behind a future
+// serving engine. This module is the typed, public-safe, receipt-bearing record
+// of "which speculation mode (if any) was active, how well it accepted, and why
+// the policy enabled or disabled it" — pure, framework-agnostic, no Worker/D1.
+//
+// HONESTY CONTRACT (mirrors the telemetry schema's `not_measured` discipline):
+//   - `none` means we KNOW no speculation ran (plain autoregressive decode).
+//   - `not_measured` means we do NOT know whether speculation ran / how well it
+//     accepted (e.g. a managed provider that speculates behind its API without
+//     disclosing acceptance). A typed, first-class sentinel — never a fabricated
+//     acceptance number and never a missing field. "We did not measure the
+//     acceptance rate" is a real value, distinct from "the acceptance rate was 0".
+//   - An acceptance rate is ONLY a real number when an actual draft/verify pass
+//     produced accepted + proposed counts. Absent counts => the sentinel.
+//
+// PUBLIC-SAFE (INVARIANTS: no secret/private leakage): the metadata carries only
+// neutral classifiers (the speculation mode, whether it was active, a coarse
+// acceptance rate + draft-token counts, the decision + reason, and the workload/
+// temperature CONTEXT that keyed the decision). No prompt, draft text, account,
+// key, price, or weights material. The acceptance rate is an aggregate ratio, not
+// any token content.
+import { Schema as S } from 'effect'
+
+// The honest "no measurement exists" sentinel. Defined LOCALLY (equal to the
+// telemetry module's `NOT_MEASURED`) so this module — which the telemetry schema
+// imports — carries no back-import to telemetry and there is no import cycle.
+export const NOT_MEASURED = 'not_measured' as const
+
+// A scalar that is EITHER a finite number OR the honest sentinel.
+const MeasuredNumber = S.Union([S.Number, S.Literal(NOT_MEASURED)])
+export type MeasuredNumber = typeof MeasuredNumber.Type
+
+const isFiniteNonNegative = (value: number): boolean =>
+  Number.isFinite(value) && value >= 0
+
+// ---------------------------------------------------------------------------
+// Speculation mode (book Ch.5: the drafting strategy).
+// ---------------------------------------------------------------------------
+
+// The drafting strategy that proposed tokens for the target model to verify.
+//
+//   - `none`        — no speculation ran; plain autoregressive decode (a real,
+//                     known value, NOT the unknown sentinel).
+//   - `n_gram`      — n-gram speculation: reuse repeated n-grams already seen in
+//                     the current generation/context as the draft. No draft model.
+//                     Strong fit for code (syntax + prompt-context repetition).
+//   - `lookahead`   — lookahead decoding: maintain an n-gram table over the KV
+//                     cache and propose matching continuations. No draft model.
+//                     Same code-repetition fit, slightly different machinery.
+//   - `eagle`       — EAGLE-style learned hidden-state drafting. FLAGGED AS A
+//                     LATER Psionic / learned-serving lane: it requires target-
+//                     model hidden-state data + a trained draft head, so it is a
+//                     named-but-unbuilt mode here. The policy never SELECTS it (it
+//                     is not a built mode); it exists so a future learned lane has
+//                     a stable receipt vocabulary.
+//   - `not_measured`— the honest sentinel: a managed lane may speculate behind its
+//                     API without telling us the mode.
+//
+// A closed union so a new mode is added deliberately (and the policy stays
+// exhaustive).
+export const KhalaSpeculationMode = S.Literals([
+  'none',
+  'n_gram',
+  'lookahead',
+  'eagle',
+  'not_measured',
+])
+export type KhalaSpeculationMode = typeof KhalaSpeculationMode.Type
+
+// Whether a mode is a DRAFT-FREE mode (no separate draft model / no training).
+// These are the two modes the Worker-side policy can profitably select TODAY for
+// code workloads; `eagle` is learned (Psionic lane), `none`/`not_measured` are
+// not drafting modes.
+export const isDraftFreeMode = (mode: KhalaSpeculationMode): boolean =>
+  mode === 'n_gram' || mode === 'lookahead'
+
+// Whether a mode is a LEARNED mode that needs target hidden-state data + training
+// (the EAGLE / Psionic lane). The policy never selects a learned mode; this flags
+// it for the doc + receipt.
+export const isLearnedMode = (mode: KhalaSpeculationMode): boolean =>
+  mode === 'eagle'
+
+// ---------------------------------------------------------------------------
+// The speculation telemetry metadata (the typed receipt/telemetry fields).
+// ---------------------------------------------------------------------------
+
+// The speculation metadata recorded on the telemetry record / receipt. Every
+// field is a concrete value or the honest sentinel. This is the typed answer to
+// "was speculation active for this request, in which mode, how well did the
+// drafter's proposals get accepted, and what acceptance/draft counts back that
+// up?"
+export const KhalaSpeculationMetadata = S.Struct({
+  schemaVersion: S.Literal('openagents.khala.speculation.v1'),
+  // The drafting mode (or `none` / `not_measured`).
+  mode: KhalaSpeculationMode,
+  // Whether speculation was ACTIVE for this request. `false` for `none`/`eagle`
+  // (eagle is unbuilt) and for any request the policy disabled. A request can be
+  // in mode `n_gram` with `active:false` if it was disabled by pressure — but the
+  // builder keeps these consistent (an inactive request reports mode `none` unless
+  // a managed lane disclosed an active mode we did not select).
+  active: S.Boolean,
+  // The acceptance RATE in [0, 1]: accepted draft tokens / proposed draft tokens
+  // over the request. `not_measured` when no draft/verify pass produced counts
+  // (the honest sentinel — never a fabricated rate, never defaulted to 0).
+  acceptanceRate: MeasuredNumber,
+  // The raw counts behind the rate (book Ch.5: proposed K, accepted ≤ K). Each is
+  // a measured count or the sentinel. The rate is DERIVED from these; they are
+  // recorded so the rate is auditable and never a bare unverifiable number.
+  draftTokensProposed: MeasuredNumber,
+  draftTokensAccepted: MeasuredNumber,
+})
+export type KhalaSpeculationMetadata = typeof KhalaSpeculationMetadata.Type
+
+// The canonical "no speculation" metadata: we KNOW plain autoregressive decode
+// ran. Distinct from `UNKNOWN_SPECULATION` (we do not know). Acceptance is
+// `not_measured` because there were no drafts to accept (NOT a measured 0 — a 0
+// would falsely imply a drafter ran and accepted nothing).
+export const NO_SPECULATION: KhalaSpeculationMetadata = {
+  schemaVersion: 'openagents.khala.speculation.v1',
+  mode: 'none',
+  active: false,
+  acceptanceRate: NOT_MEASURED,
+  draftTokensProposed: NOT_MEASURED,
+  draftTokensAccepted: NOT_MEASURED,
+}
+
+// The canonical honest-unknown metadata: we do NOT know whether/how this lane
+// speculated (a managed provider that does not disclose). Distinct from
+// `NO_SPECULATION` (we know none ran).
+export const UNKNOWN_SPECULATION: KhalaSpeculationMetadata = {
+  schemaVersion: 'openagents.khala.speculation.v1',
+  mode: 'not_measured',
+  active: false,
+  acceptanceRate: NOT_MEASURED,
+  draftTokensProposed: NOT_MEASURED,
+  draftTokensAccepted: NOT_MEASURED,
+}
+
+// ---------------------------------------------------------------------------
+// Decoders.
+// ---------------------------------------------------------------------------
+
+export const decodeKhalaSpeculationMetadata = S.decodeUnknownOption(
+  KhalaSpeculationMetadata,
+)
+
+// ---------------------------------------------------------------------------
+// Builder — assemble metadata honestly from a draft/verify pass (or none).
+// ---------------------------------------------------------------------------
+
+// The raw, possibly-partial signals a serving lane CAN disclose about its
+// speculation. Everything optional; absence collapses to the honest sentinel —
+// never a guess.
+export type KhalaSpeculationInput = Readonly<{
+  // The mode the lane ran (or `none`). Absent => `not_measured`.
+  mode?: KhalaSpeculationMode | undefined
+  // Whether speculation was active for this request. Absent => derived from mode
+  // (a real drafting mode with counts => active; otherwise false).
+  active?: boolean | undefined
+  // The raw draft-token counts from the draft/verify pass. Both required for a
+  // measured acceptance rate; either absent => the rate is the sentinel.
+  draftTokensProposed?: number | undefined
+  draftTokensAccepted?: number | undefined
+}>
+
+// Derive the acceptance rate from accepted / proposed. `not_measured` unless BOTH
+// counts are finite + non-negative AND proposed > 0 (a rate over zero proposals
+// is undefined, NOT 0). Accepted is clamped to ≤ proposed so a malformed input
+// never yields a rate above 1. PURE.
+const deriveAcceptanceRate = (
+  proposed: number | undefined,
+  accepted: number | undefined,
+): MeasuredNumber => {
+  if (
+    proposed === undefined ||
+    accepted === undefined ||
+    !isFiniteNonNegative(proposed) ||
+    !isFiniteNonNegative(accepted) ||
+    proposed === 0
+  ) {
+    return NOT_MEASURED
+  }
+  const clampedAccepted = Math.min(accepted, proposed)
+  return clampedAccepted / proposed
+}
+
+// Build the speculation metadata from raw lane signals. PURE: same input => same
+// metadata. Absent mode yields the honest-unknown shape; an explicit `none`
+// yields the no-speculation shape; a real drafting mode records the disclosed
+// counts + the derived acceptance rate.
+export const buildKhalaSpeculationMetadata = (
+  input: KhalaSpeculationInput,
+): KhalaSpeculationMetadata => {
+  const mode: KhalaSpeculationMode = input.mode ?? 'not_measured'
+
+  if (mode === 'none') {
+    return NO_SPECULATION
+  }
+  if (mode === 'not_measured') {
+    // Honest unknown: a managed lane that may speculate but disclosed no mode. We
+    // never invent counts/rate for it.
+    return UNKNOWN_SPECULATION
+  }
+
+  const acceptanceRate = deriveAcceptanceRate(
+    input.draftTokensProposed,
+    input.draftTokensAccepted,
+  )
+  const proposed =
+    input.draftTokensProposed !== undefined &&
+    isFiniteNonNegative(input.draftTokensProposed)
+      ? input.draftTokensProposed
+      : NOT_MEASURED
+  const acceptedRaw =
+    input.draftTokensAccepted !== undefined &&
+    isFiniteNonNegative(input.draftTokensAccepted)
+      ? input.draftTokensAccepted
+      : NOT_MEASURED
+  // Keep accepted ≤ proposed in the recorded counts too (consistency with the
+  // clamped rate) so a malformed disclosure never records accepted > proposed.
+  const accepted =
+    typeof acceptedRaw === 'number' && typeof proposed === 'number'
+      ? Math.min(acceptedRaw, proposed)
+      : acceptedRaw
+
+  // `active` defaults from the mode: a real drafting mode is active unless the
+  // caller said otherwise. (A disabled drafting lane should record mode `none`;
+  // a disclosed-but-inactive managed mode can set `active:false` explicitly.)
+  const active = input.active ?? true
+
+  return {
+    schemaVersion: 'openagents.khala.speculation.v1',
+    mode,
+    active,
+    acceptanceRate,
+    draftTokensProposed: proposed,
+    draftTokensAccepted: accepted,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The dynamic-disablement POLICY (`decideSpeculation`).
+// ---------------------------------------------------------------------------
+//
+// The book's core operating rule: speculation profits ONLY when there is spare
+// compute to spend on verification — i.e. at LOW batch / LOW compute pressure.
+// As the batch grows (or the machine is otherwise saturated), the verification
+// pass competes with real throughput and speculation becomes a loss, so it must
+// be DISABLED. This is a bounded, typed decision over an explicit pressure
+// signal — NOT ad-hoc per-request string matching.
+
+// The compute-pressure signal the policy decides over. These are the only inputs
+// the decision reads; they come from the (fixture/observed) serving state, not
+// from request content. All numeric inputs are honest: an unknown signal is
+// `not_measured` and the policy treats unknown pressure conservatively.
+export type KhalaSpeculationPressureSignal = Readonly<{
+  // The current decode BATCH size (concurrent sequences sharing the decode step).
+  // The headline signal: speculation helps at LOW batch. `not_measured` => the
+  // policy cannot confirm low batch and conservatively does NOT enable.
+  batchSize: MeasuredNumber
+  // A normalized compute-pressure scalar in [0, 1] (e.g. GPU/decode-step
+  // utilization): 0 = idle (lots of spare compute to verify drafts), 1 = fully
+  // saturated (no spare compute). `not_measured` => treated conservatively.
+  computePressure: MeasuredNumber
+}>
+
+// The policy CONFIG — the bounded thresholds. Documented + tunable, never
+// hand-coded at the call site.
+export type KhalaSpeculationPolicyConfig = Readonly<{
+  // The maximum batch size at/below which speculation is allowed to profit. Above
+  // this, the verification work competes with throughput => disable. (Book: a
+  // small batch — single/low concurrency — is the sweet spot.)
+  maxProfitableBatchSize: number
+  // The maximum normalized compute pressure at/below which speculation may profit.
+  // Above this, there is no spare compute to spend verifying drafts => disable.
+  maxProfitableComputePressure: number
+}>
+
+// The default policy config. Conservative + documented: speculation is enabled
+// only at genuinely low concurrency (batch ≤ 4) and well below saturation
+// (pressure ≤ 0.6). These are the book's "low-batch sweet spot" turned into
+// bounded numbers; tune from observed acceptance/throughput telemetry.
+export const DEFAULT_SPECULATION_POLICY: KhalaSpeculationPolicyConfig = {
+  maxProfitableBatchSize: 4,
+  maxProfitableComputePressure: 0.6,
+}
+
+// The reason the policy reached its decision — a closed, public-safe vocabulary
+// (never free-form intent text). Each value names a concrete cause so a receipt
+// reader knows WHY speculation was on or off.
+export const KhalaSpeculationDecisionReason = S.Literals([
+  // Enabled: batch + pressure are both in the profitable low range AND the
+  // workload is a fit (a drafting mode was requested).
+  'enabled_low_batch',
+  // Disabled: batch size is above the profitable threshold (high concurrency).
+  'disabled_high_batch',
+  // Disabled: compute pressure is above the profitable threshold (saturated).
+  'disabled_high_pressure',
+  // Disabled: the pressure signal is unknown (`not_measured`), so the policy
+  // cannot confirm a low-batch sweet spot and conservatively declines.
+  'disabled_pressure_unknown',
+  // Disabled: the requested mode is not a draft-free mode the Worker can run
+  // today (e.g. `eagle`/learned, or `none`/`not_measured`).
+  'disabled_mode_unavailable',
+  // Disabled: speculation was not requested for this lane at all.
+  'disabled_not_requested',
+])
+export type KhalaSpeculationDecisionReason =
+  typeof KhalaSpeculationDecisionReason.Type
+
+// The policy DECISION: enable or not, the selected mode (the requested drafting
+// mode when enabled, else `none`), and the typed reason.
+export const KhalaSpeculationDecision = S.Struct({
+  schemaVersion: S.Literal('openagents.khala.speculation-decision.v1'),
+  enabled: S.Boolean,
+  // The mode the policy SELECTED. When enabled, the requested drafting mode; when
+  // disabled, `none` (we know speculation did not run because we turned it off).
+  selectedMode: KhalaSpeculationMode,
+  reason: KhalaSpeculationDecisionReason,
+})
+export type KhalaSpeculationDecision = typeof KhalaSpeculationDecision.Type
+
+// The inputs to the decision. `requestedMode` is the mode the lane WOULD run if
+// the policy allows it (a drafting mode for a code workload, or `none`).
+export type KhalaSpeculationDecisionInput = Readonly<{
+  requestedMode: KhalaSpeculationMode
+  signal: KhalaSpeculationPressureSignal
+  // Optional override of the bounded thresholds; defaults to
+  // `DEFAULT_SPECULATION_POLICY`.
+  policy?: KhalaSpeculationPolicyConfig | undefined
+}>
+
+const disabled = (
+  reason: KhalaSpeculationDecisionReason,
+): KhalaSpeculationDecision => ({
+  schemaVersion: 'openagents.khala.speculation-decision.v1',
+  enabled: false,
+  selectedMode: 'none',
+  reason,
+})
+
+// Decide whether speculation should run for a request, given the requested mode
+// and the (fixture/observed) compute-pressure signal. PURE + bounded:
+//
+//   1. If no drafting mode was requested (`none`/`not_measured`)         => off.
+//   2. If a learned/unavailable mode was requested (`eagle`)             => off
+//      (the Worker has no draft model / learned head — that is the Psionic lane).
+//   3. If the pressure signal is unknown                                 => off
+//      (cannot confirm the low-batch sweet spot — be conservative).
+//   4. If batch size is above the profitable threshold                   => off.
+//   5. If compute pressure is above the profitable threshold             => off.
+//   6. Otherwise (a draft-free mode at low batch + low pressure)         => ON.
+//
+// This is the book's "disable speculation when large batches make verification
+// hurt throughput" turned into a typed, auditable decision.
+export const decideSpeculation = (
+  input: KhalaSpeculationDecisionInput,
+): KhalaSpeculationDecision => {
+  const policy = input.policy ?? DEFAULT_SPECULATION_POLICY
+  const { requestedMode, signal } = input
+
+  // (1) No drafting requested.
+  if (requestedMode === 'none' || requestedMode === 'not_measured') {
+    return disabled('disabled_not_requested')
+  }
+  // (2) Learned/unavailable mode — the Worker cannot run it (Psionic lane).
+  if (!isDraftFreeMode(requestedMode)) {
+    return disabled('disabled_mode_unavailable')
+  }
+  // (3) Unknown pressure => conservative decline.
+  if (signal.batchSize === NOT_MEASURED || signal.computePressure === NOT_MEASURED) {
+    return disabled('disabled_pressure_unknown')
+  }
+  // (4) High batch => the verification work competes with throughput.
+  if (signal.batchSize > policy.maxProfitableBatchSize) {
+    return disabled('disabled_high_batch')
+  }
+  // (5) High compute pressure => no spare compute to verify drafts.
+  if (signal.computePressure > policy.maxProfitableComputePressure) {
+    return disabled('disabled_high_pressure')
+  }
+  // (6) Low batch + low pressure + draft-free mode => enable.
+  return {
+    schemaVersion: 'openagents.khala.speculation-decision.v1',
+    enabled: true,
+    selectedMode: requestedMode,
+    reason: 'enabled_low_batch',
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/khala-telemetry.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-telemetry.ts
@@ -54,6 +54,12 @@ import {
   UNKNOWN_QUANTIZATION,
   buildKhalaQuantizationMetadata,
 } from './khala-quantization'
+import {
+  type KhalaSpeculationInput,
+  KhalaSpeculationMetadata,
+  UNKNOWN_SPECULATION,
+  buildKhalaSpeculationMetadata,
+} from './khala-speculation'
 
 // ---------------------------------------------------------------------------
 // The honest sentinel.
@@ -218,6 +224,18 @@ export const KhalaTelemetryRecord = S.Struct({
   // precision. The same-model-claim guard reads this to reject an undisclosed
   // quantized variant fronting an unqualified public alias.
   quantization: KhalaQuantizationMetadata,
+  // The SPECULATIVE-DECODING disclosure (book P1-8 / #6091): which drafting mode
+  // (n-gram / lookahead / EAGLE / none) was active, whether it ran, and the draft
+  // acceptance rate + counts. A request served WITH speculation is a different
+  // serving product than plain autoregressive decode (it ties to the shard-WAN
+  // speculative/direct-return receipt-mode disclosure), so the mode is a
+  // first-class receipt field — honest `none` (we know no speculation ran) or
+  // `not_measured` (a managed lane that speculates without disclosing), never a
+  // fabricated acceptance number. The acceptance rate is `not_measured` whenever no
+  // draft/verify pass produced counts. The dynamic-disablement policy
+  // (`decideSpeculation`) lives in `khala-speculation.ts`; this records the
+  // OUTCOME, not the decision inputs.
+  speculation: KhalaSpeculationMetadata,
   // The coordinator route lane (coding | cheap | long_context | default | ...).
   route: S.String,
   // The provider/adapter id that actually served (provider-capacity attribution).
@@ -381,6 +399,15 @@ export type KhalaTelemetryInput = Readonly<{
   // the same-model guard + eval gate read.
   quantization?: KhalaQuantizationInput | undefined
 
+  // The speculative-decoding signals the lane disclosed (book P1-8 / #6091): the
+  // mode, whether it was active, and the draft-token counts behind the acceptance
+  // rate. Absent => the honest-unknown shape (`UNKNOWN_SPECULATION`); an explicit
+  // `none` mode => the known no-speculation shape. Never a fabricated acceptance
+  // rate. There is no real draft model in the Worker, so on the live hot path this
+  // is `not_measured`/`none`; a future compute/owner-gated serving engine threads
+  // real counts here.
+  speculation?: KhalaSpeculationInput | undefined
+
   // Tokens (receipt-first from provider usage).
   promptTokens?: number | undefined
   completionTokens?: number | undefined
@@ -502,6 +529,12 @@ export const buildKhalaTelemetryRecord = (
       input.quantization === undefined
         ? UNKNOWN_QUANTIZATION
         : buildKhalaQuantizationMetadata(input.quantization),
+    // Honest speculation disclosure: built from disclosed lane signals, or the
+    // honest-unknown shape when the lane disclosed nothing (book P1-8 / #6091).
+    speculation:
+      input.speculation === undefined
+        ? UNKNOWN_SPECULATION
+        : buildKhalaSpeculationMetadata(input.speculation),
     route: input.route,
     provider: input.provider,
     region:

--- a/docs/inference/2026-06-23-khala-speculation-telemetry-book-p1-8.md
+++ b/docs/inference/2026-06-23-khala-speculation-telemetry-book-p1-8.md
@@ -1,0 +1,164 @@
+# Khala speculation acceptance telemetry + dynamic-disablement policy (book P1-8, #6091)
+
+Status: buildable-now telemetry + decision-policy + receipt-disclosure machinery
+merged; the REAL speculative decode (a draft model / a real serving engine) is
+compute/owner-gated and stays inert. Not deployed by this change.
+
+## The principle (book Ch.5 "Speculative Decoding", in our own words)
+
+Speculative decoding speeds up DECODE by letting a cheap drafter guess the next
+few tokens and letting the expensive target model VERIFY all the guesses in a
+single parallel forward pass. Accepted drafts give several tokens for the cost of
+one verification step; a rejection still makes forward progress of one true token
+(the target's own prediction at the rejection point). Verifying K tokens costs
+roughly one forward pass because transformers process all positions in parallel,
+which is exactly what they are good at.
+
+The catch is the load-bearing one for Khala:
+
+- **Speculation is NOT a universal win.** The verification pass spends spare
+  compute. It only pays off when there IS spare compute to spend — i.e. at LOW
+  batch, where decode is the bottleneck and the machine is not already saturated.
+- **At HIGH batch (or under compute pressure) speculation is a LOSS.** The extra
+  verification work competes with real throughput. So it must be MEASURED
+  (acceptance rate) and DYNAMICALLY DISABLED when the batch/pressure signal says
+  it will not profit.
+- **It is a serving-product fact, not an invisible trick.** A request served WITH
+  speculation is a different serving product than plain autoregressive decode, so
+  the mode is DISCLOSED in the receipt — tying to the shard-WAN
+  speculative/direct-return/async receipt-mode disclosure
+  (`2026-06-19-decentralized-serving-shard-wan.md`): for shard-WAN, speculation
+  is a WAN latency-hiding strategy recorded in the Psionic receipt mode, not just
+  a local speed trick.
+
+Code generation is a strong FIT: generated code repeats syntax and reuses prompt
+context, so cheap **n-gram / lookahead** drafting (no separate draft model) hits a
+high acceptance rate. This is why the Worker-side policy only ever selects
+draft-free modes.
+
+## Drafting modes (and the EAGLE/Psionic boundary)
+
+The typed `KhalaSpeculationMode` union:
+
+- `n_gram` — reuse repeated n-grams already seen in the current generation/context
+  as the draft. No draft model. **Fit for code repetition.**
+- `lookahead` — maintain an n-gram table over the KV cache and propose matching
+  continuations. No draft model. Same code-repetition fit; used for long-context
+  codebase questions (a large context to mine).
+- `eagle` — **EAGLE-style learned hidden-state drafting. FLAGGED AS A LATER
+  Psionic / learned-serving lane.** EAGLE predicts the target model's next hidden
+  state (richer than predicting tokens directly) using a trained draft head, so it
+  needs target-model hidden-state DATA + TRAINING. It is a named-but-unbuilt mode
+  here: the policy never SELECTS it (the Worker has no draft model / learned head),
+  and `decideSpeculation` returns `disabled_mode_unavailable` for it. It exists in
+  the vocabulary so a future Psionic learned-serving lane has a stable receipt
+  mode to disclose.
+- `none` — we KNOW no speculation ran (plain autoregressive decode).
+- `not_measured` — the honest sentinel: a managed lane may speculate behind its
+  API without disclosing the mode/acceptance.
+
+n-gram and lookahead are the two Worker-runnable draft-free modes today
+(`isDraftFreeMode`); `eagle` is the only learned mode (`isLearnedMode`).
+
+## Honesty contract (mirrors the telemetry `not_measured` discipline)
+
+- The acceptance rate is a real number ONLY when an actual draft/verify pass
+  produced an accepted + proposed count pair; the rate is DERIVED from those
+  counts and clamped to `[0, 1]`. Absent counts (or zero proposals) =>
+  `not_measured`, never a fabricated rate and never a defaulted `0`.
+- `none` (we know no speculation ran) is distinct from `not_measured` (we do not
+  know whether/how a managed lane speculated). A `none` cell's acceptance rate is
+  the sentinel, NOT a measured 0 — a 0 would falsely imply a drafter ran and
+  accepted nothing.
+- The recorded `draftTokensAccepted` is clamped `<= draftTokensProposed`, so a
+  malformed disclosure can never record a rate above 1.
+
+## The dynamic-disablement policy (`decideSpeculation`)
+
+A bounded, typed decision over an explicit compute-pressure signal — NOT ad-hoc
+per-request string matching. Inputs: the requested mode, a
+`KhalaSpeculationPressureSignal { batchSize, computePressure }`, and an optional
+threshold config (`KhalaSpeculationPolicyConfig`). Decision order:
+
+1. No drafting requested (`none`/`not_measured`) => off (`disabled_not_requested`).
+2. A learned/unavailable mode (`eagle`) => off (`disabled_mode_unavailable`) — the
+   Worker has no draft model; that is the Psionic lane.
+3. The pressure signal is unknown (`not_measured` batch or pressure) => off
+   (`disabled_pressure_unknown`) — we cannot confirm the low-batch sweet spot, so
+   be conservative.
+4. Batch above `maxProfitableBatchSize` => off (`disabled_high_batch`) — the
+   verification work competes with throughput.
+5. Compute pressure above `maxProfitableComputePressure` => off
+   (`disabled_high_pressure`) — no spare compute to verify drafts.
+6. Otherwise (a draft-free mode at low batch + low pressure) => ON
+   (`enabled_low_batch`).
+
+The default policy (`DEFAULT_SPECULATION_POLICY`) is conservative and documented:
+`maxProfitableBatchSize: 4`, `maxProfitableComputePressure: 0.6` — the book's
+"low-batch sweet spot" turned into bounded numbers, tunable from observed
+acceptance/throughput telemetry. The decision records a typed
+`KhalaSpeculationDecisionReason` so a receipt reader knows WHY speculation was on
+or off.
+
+## Receipt-mode disclosure
+
+The speculation metadata is a first-class field on the canonical
+`openagents.khala.telemetry.v1` record (`KhalaTelemetryRecord.speculation`),
+alongside the P1-7 quantization disclosure. It records the mode, whether it was
+active, the acceptance rate, and the draft-token counts behind the rate. The live
+hot path has no draft model, so it discloses `not_measured` (a managed provider
+may speculate without telling us) — honest, never a fabricated active mode.
+
+## What is buildable-now vs gated
+
+**Buildable now (merged, exercised by tests):**
+
+- The typed speculation telemetry metadata + honest builder
+  (`khala-speculation.ts`), wired onto the telemetry record.
+- The bounded `decideSpeculation` dynamic-disablement policy + thresholds.
+- The fixture decode-trace lane (`benchmark/speculation-lane.ts`): a deterministic
+  per-cell speculation outcome that REQUESTS a draft-free mode for code workloads,
+  runs the policy against the cell's batch (concurrency) + derived pressure, and
+  produces honest draft counts only when ENABLED. This is the only place the
+  acceptance-rate plumbing is exercised end-to-end without spend.
+- The report's draft-acceptance aggregate per (workload × model × temperature ×
+  route) (`benchmark/report.ts`), with a null rate (honest absence) where
+  speculation did not run.
+
+**Compute / owner / flag-gated (built shape, inert — NOT armed here):**
+
+- The REAL speculative decode (an actual n-gram/lookahead drafter or a learned
+  draft head) needs a real serving engine; there is none in the Worker, so the
+  live path discloses `not_measured`/`none`. A future serving engine threads real
+  draft counts into the same metadata fields.
+- EAGLE / learned hidden-state drafting is a Psionic learned-serving lane that
+  needs target-model hidden-state data + training. Named, never selected.
+- A real, billable benchmark sweep stays behind the owner-armed real lane seam
+  (`makeRealLaneSeam`, default off — refuses to run unarmed).
+
+## Where
+
+- `apps/openagents.com/workers/api/src/inference/khala-speculation.ts` — the typed
+  metadata, canonical shapes, builder, and the `decideSpeculation` policy.
+- `apps/openagents.com/workers/api/src/inference/khala-telemetry.ts` — the
+  `speculation` field on the record + input, built honestly.
+- `apps/openagents.com/workers/api/src/inference/benchmark/speculation-lane.ts` —
+  the fixture decode-trace derivation.
+- `apps/openagents.com/workers/api/src/inference/benchmark/lane-seam.ts` /
+  `runner.ts` / `report.ts` — the fixture sample field, the runner thread, and the
+  per-(workload × model × temperature × route) acceptance aggregate.
+- Tests: `khala-speculation.test.ts` (policy + builder),
+  `khala-speculation-telemetry.test.ts` (telemetry/fixture/report integration +
+  the flag-gated-off discipline).
+
+## Verification bar (green)
+
+The inference test suites (807 tests, incl. the new speculation suites),
+`typecheck`, `check:architecture`, `check:effect-topology`, and
+`check:public-projection-freshness`. Tests cover: acceptance-rate telemetry
+populating from a fixture decode trace (honest sentinel when no speculation ran);
+`decideSpeculation` enabling at low batch and disabling at high batch / pressure /
+unknown-signal / learned-mode / not-requested; the speculation mode disclosed in
+the record; the report acceptance aggregate keyed by the four axes; and the real
+speculative-decoding engine staying flag-gated off (the fixture seam never spends,
+the un-armed real seam refuses to run).

--- a/docs/inference/inference-engineering-book/IMPLEMENTATION_LOG.md
+++ b/docs/inference/inference-engineering-book/IMPLEMENTATION_LOG.md
@@ -290,3 +290,69 @@ Conventions:
   lane requires that armed sweep over realistic traffic. NOT run here.
 - **Status:** PR open against `main` (#6090); orchestrator reviews / merges /
   deploys / smokes. NOT deployed, NO spend by this entry.
+
+---
+
+## P1-8 — Test speculation where Khala is actually low-batch — in progress (PR open, #6091)
+
+- **Notes ref:** `khala-investigation-notes.md` §P1 item 8 ("Test Speculation
+  Where Khala Is Actually Low-Batch"); book Ch.5 (Speculative Decoding);
+  `docs/inference/speculative-decoding-article.md`;
+  `2026-06-19-decentralized-serving-shard-wan.md` (receipt-mode disclosure).
+- **The principle (book, our words):** speculative decoding speeds up DECODE by
+  letting a cheap drafter guess tokens and the target model verify them in one
+  parallel pass. It profits ONLY when there is spare compute to spend on
+  verification — at LOW batch. At HIGH batch / under compute pressure the
+  verification work competes with throughput and it is a LOSS. So it must be
+  MEASURED (acceptance rate), DYNAMICALLY DISABLED, and DISCLOSED in the receipt.
+  Code is a fit (syntax + prompt-context repetition) for draft-free n-gram /
+  lookahead modes; EAGLE is a later learned Psionic lane (needs target
+  hidden-state data + training).
+- **What shipped (the four deliverables):**
+  1. **Acceptance-rate telemetry** (`khala-speculation.ts` + the `speculation`
+     field on `khala-telemetry.ts`): typed mode (n-gram / lookahead / EAGLE /
+     none / not_measured), `active`, the acceptance rate, and the draft-token
+     count pair behind it. Honest `not_measured` when no draft/verify pass
+     produced counts; `none` (known no speculation) distinct from `not_measured`
+     (unknown managed lane); rate clamped to `[0,1]`, never fabricated.
+  2. **Dynamic-disablement policy** (`decideSpeculation`): a bounded, typed
+     decision over `{batchSize, computePressure}` with documented thresholds
+     (default batch ≤ 4, pressure ≤ 0.6). Enables a draft-free mode at low
+     batch/pressure; disables on high batch / high pressure / unknown signal /
+     learned-or-unavailable mode / not-requested — each with a typed reason.
+  3. **Receipt-mode disclosure:** the speculation mode is a first-class field on
+     the canonical `openagents.khala.telemetry.v1` record (ties to the shard-WAN
+     speculative/direct-return/async receipt-mode idea).
+  4. **Policy doc** (`docs/inference/2026-06-23-khala-speculation-telemetry-book-p1-8.md`):
+     n-gram/lookahead fit for code repetition; EAGLE flagged as a later
+     learned/Psionic lane needing target hidden-state data + training.
+- **Fixture decode trace:** `benchmark/speculation-lane.ts` derives a
+  deterministic per-cell speculation outcome — code workloads request a draft-free
+  mode, the policy decides on/off from the cell's batch (concurrency) + derived
+  pressure, and honest draft counts populate only when ENABLED. Threaded through
+  the fixture seam + runner so a benchmark sample discloses speculation the same
+  way production will; the report adds a draft-acceptance aggregate per
+  (workload × model × temperature × route), with a null rate (honest absence)
+  where speculation did not run.
+- **Where:** `apps/openagents.com/workers/api/src/inference/`
+  (`khala-speculation.ts` + `khala-speculation.test.ts`,
+  `khala-speculation-telemetry.test.ts`; `speculation` field on
+  `khala-telemetry.ts`; `benchmark/speculation-lane.ts`, and the
+  `lane-seam.ts` / `runner.ts` / `report.ts` / `index.ts` threads).
+- **Verification bar (green):** inference suites (807 tests, 28 new),
+  `typecheck`, `check:architecture`, `check:effect-topology`,
+  `check:public-projection-freshness`. Tests: acceptance-rate telemetry populates
+  from a fixture decode trace (honest sentinel when no speculation ran);
+  `decideSpeculation` enables at low batch + disables at high batch / pressure /
+  unknown / learned-mode / not-requested; speculation mode disclosed in the
+  record + the per-axis report aggregate; the real speculative-decoding engine is
+  flag-gated OFF (fixture seam never spends; un-armed real seam refuses to run).
+- **Honest scope — fixture vs owner/compute-gated:** the telemetry, the policy,
+  and the fixture decode trace run deterministically with no real draft model and
+  no spend. The REAL speculative decode (an actual n-gram/lookahead drafter or a
+  learned EAGLE head) needs a real serving engine that does not exist in the
+  Worker, so the live hot path discloses `not_measured`/`none`; a future
+  compute/owner-gated serving engine threads real counts into the same fields.
+  EAGLE is a named-but-unbuilt Psionic learned-serving lane. NOT run/armed here.
+- **Status:** PR open against `main` (#6091); orchestrator reviews / merges /
+  deploys / smokes. NOT deployed, NO spend by this entry.


### PR DESCRIPTION
Implements book **P1-8** ("Test speculation where Khala is actually low-batch", #6091) into the Khala gateway: typed speculation acceptance-rate telemetry, a bounded dynamic-disablement policy, and receipt-mode disclosure.

## The principle (book Ch.5, our words)
Speculative decoding speeds up DECODE by letting a cheap drafter guess tokens and the target model verify them in one parallel pass. It profits ONLY when there is spare compute to verify drafts — at LOW batch. At HIGH batch / under compute pressure the verification work competes with throughput and it is a LOSS. So it must be MEASURED, DYNAMICALLY DISABLED, and DISCLOSED in the receipt. Code is a fit for draft-free n-gram / lookahead drafting; EAGLE is a later learned Psionic lane.

## Deliverables
1. **Acceptance-rate telemetry** (`khala-speculation.ts` + `speculation` field on `khala-telemetry.ts`): typed mode (n-gram / lookahead / EAGLE / none / not_measured), `active`, acceptance rate, and the draft-token count pair behind it — by workload / model / temperature / route via the report aggregate. Honest `not_measured` when no speculation ran; `none` (known no speculation) distinct from `not_measured` (unknown managed lane); rate clamped to `[0,1]`, never fabricated.
2. **Dynamic-disablement policy** (`decideSpeculation`): bounded, typed decision over `{batchSize, computePressure}` with documented thresholds (default batch ≤ 4, pressure ≤ 0.6). Enables a draft-free mode at low batch/pressure; disables on high batch / high pressure / unknown signal / learned-or-unavailable mode / not-requested, each with a typed reason.
3. **Receipt-mode disclosure**: speculation mode is a first-class field on the canonical `openagents.khala.telemetry.v1` record (ties to the shard-WAN speculative/direct-return/async receipt-mode idea).
4. **Docs**: n-gram/lookahead fit for code repetition; EAGLE flagged as a later learned/Psionic lane needing target hidden-state data + training.

Plus `docs/inference/2026-06-23-khala-speculation-telemetry-book-p1-8.md` and the P1-8 `IMPLEMENTATION_LOG.md` entry.

## Buildable-now vs fixture/owner/compute-gated split
- **Buildable now (merged, tested):** the telemetry metadata + honest builder, the `decideSpeculation` policy, the deterministic fixture decode-trace lane (`benchmark/speculation-lane.ts`) that exercises acceptance-rate plumbing end-to-end without spend, and the per-(workload × model × temperature × route) report aggregate.
- **Gated / inert:** the REAL speculative decode (an actual n-gram/lookahead drafter or a learned EAGLE head) needs a real serving engine that does not exist in the Worker, so the live hot path discloses `not_measured`/`none`; a future compute/owner-gated engine threads real counts into the same fields. EAGLE is named-but-unbuilt (Psionic learned-serving lane). The real benchmark sweep stays behind the owner-armed real lane seam (default off).

## Tests (28 new)
- acceptance-rate telemetry populates from a fixture decode trace (honest sentinel when no speculation ran);
- `decideSpeculation` enables at low batch + disables at high batch / pressure / unknown / learned-mode / not-requested;
- speculation mode disclosed in the record + the per-axis report aggregate (null rate = honest absence at high batch);
- the real speculative-decoding engine is flag-gated OFF (fixture seam never spends; un-armed real seam refuses to run).

## Verification (green)
Inference suites (807 tests, 28 new), `typecheck`, `check:architecture`, `check:effect-topology`, `check:public-projection-freshness`. Scope: `apps/openagents.com/workers/api/src/inference/` + the two docs only. No proof/claim-upgrade, settlement, pylon, web, or Psionic changes. INVARIANTS honored (public-safe: only neutral classifiers, durations, counts, and a coarse acceptance ratio — no prompt/account/key/price material).

Closes #6091. DO NOT auto-merge — orchestrator reviews/merges + deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)