### PR TITLE
landing: What is Khala? + Join Tassadar buttons; /tassadar info page (3rd scene pose) with Copy Agent Instructions

### DIFF
--- a/apps/openagents.com/apps/web/src/main.test.ts
+++ b/apps/openagents.com/apps/web/src/main.test.ts
@@ -399,23 +399,54 @@ describe('authenticated startup routing', () => {
     })
   })
 
-  test('renders the retired Tassadar web scene notice through the top-level view', () => {
+  test('keeps serving the live Tassadar run board at /run', () => {
+    const [model] = init(
+      Flags.make({ maybeAuth: Option.none() }),
+      appUrl('/run'),
+    )
+
+    // /run is unchanged: it still serves the existing Run.view board, separate
+    // from the new /tassadar info page.
+    Scene.scene(
+      { update, view },
+      Scene.with(model),
+      Scene.expect(Scene.selector('[data-route="tassadar"]')).toExist(),
+      Scene.expect(
+        Scene.selector('[data-persistent-scene-overlay="tassadar"]'),
+      ).not.toExist(),
+      Scene.expect(Scene.selector('oa-landing-squares')).not.toExist(),
+    )
+  })
+
+  test('renders the public Tassadar info page over the persistent scene', () => {
     const [model] = init(
       Flags.make({ maybeAuth: Option.none() }),
       appUrl('/tassadar'),
     )
 
+    // /tassadar is now a third persistent-scene pose (like /landing and /khala):
+    // the 3D pylon scene stays mounted and the camera flies to the tassadar
+    // vantage, with the public info page + Copy Agent Instructions over it.
     Scene.scene(
       { update, view },
       Scene.with(model),
-      Scene.expect(Scene.selector('oa-tassadar-run')).not.toExist(),
-      Scene.expect(Scene.selector('[data-tassadar-scene="retired"]')).toExist(),
-      Scene.expect(Scene.role('heading', { name: 'Tassadar lives in the Verse' })).toExist(),
-      Scene.expect(Scene.role('link', { name: 'Public summary API' })).toExist(),
-      Scene.expect(Scene.role('link', { name: 'Proof replay' })).toExist(),
+      Scene.expect(Scene.selector('oa-landing-squares')).toExist(),
+      Scene.expect(Scene.selector('[data-pose="tassadar"]')).toExist(),
+      Scene.expect(
+        Scene.selector('[data-persistent-scene-overlay="tassadar"]'),
+      ).toExist(),
       Scene.expect(Scene.selector('[data-route="tassadar"]')).toExist(),
+      Scene.expect(Scene.role('heading', { name: 'Tassadar' })).toExist(),
+      Scene.expect(
+        Scene.selector('[data-tassadar-copy="agent-instructions"]'),
+      ).toExist(),
+      Scene.expect(Scene.text('Copy Agent Instructions')).toExist(),
+      // The retired Run.view notice is no longer the logged-out /tassadar surface.
+      Scene.expect(
+        Scene.selector('[data-tassadar-scene="retired"]'),
+      ).not.toExist(),
+      // No public-header chrome on the persistent scene.
       Scene.expect(Scene.role('link', { name: 'Docs' })).not.toExist(),
-      Scene.expect(Scene.role('link', { name: 'Blog' })).not.toExist(),
       Scene.expect(Scene.role('link', { name: 'Log in' })).not.toExist(),
     )
   })

--- a/apps/openagents.com/apps/web/src/page/loggedOut/message.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/message.ts
@@ -24,6 +24,14 @@ export const ClickedCopyShareLink = m('ClickedCopyShareLink', {
 export const ClickedEnterKhala = m('ClickedEnterKhala')
 export const CompletedNavigateToKhala = m('CompletedNavigateToKhala')
 export const ClickedExitKhala = m('ClickedExitKhala')
+export const ClickedEnterTassadar = m('ClickedEnterTassadar')
+export const CompletedNavigateToTassadar = m('CompletedNavigateToTassadar')
+export const ClickedCopyAgentInstructions = m('ClickedCopyAgentInstructions', {
+  text: S.String,
+})
+export const CompletedCopyAgentInstructions = m(
+  'CompletedCopyAgentInstructions',
+)
 export const CompletedNavigateToLanding = m('CompletedNavigateToLanding')
 export const ClickedOnboardingStep = m('ClickedOnboardingStep', {
   step: OnboardingStep,
@@ -187,6 +195,10 @@ export const Message = S.Union([
   ClickedEnterKhala,
   CompletedNavigateToKhala,
   ClickedExitKhala,
+  ClickedEnterTassadar,
+  CompletedNavigateToTassadar,
+  ClickedCopyAgentInstructions,
+  CompletedCopyAgentInstructions,
   CompletedNavigateToLanding,
   ClickedOnboardingStep,
   SelectedOnboardingRepository,

--- a/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
@@ -1210,6 +1210,9 @@ export const Model = ts('LoggedOut', {
   publicTrainingRuns: PublicTrainingRunsModel,
   settledFeed: SettledFeedModel,
   shareProjection: ShareProjectionModel,
+  // True once the Tassadar "Copy Agent Instructions" button has written to the
+  // clipboard, so the button can show a "Copied" affirmation.
+  copiedAgentInstructions: S.Boolean,
 })
 
 export type Model = typeof Model.Type
@@ -1270,6 +1273,7 @@ export const init = (route: LoggedOutRoute): Model =>
       route._tag === 'Share'
         ? LoadingShareProjection({ shareId: route.shareId })
         : IdleShareProjection(),
+    copiedAgentInstructions: false,
   })
 
 export const initOnboardingModel = (): OnboardingModel =>

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/persistentScene.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/persistentScene.test.ts
@@ -2,7 +2,7 @@ import { Scene } from 'foldkit'
 import { describe, expect, test } from 'vitest'
 
 import { LoggedOut } from '../../../model'
-import { KhalaRoute, LandingRoute } from '../../../route'
+import { KhalaRoute, LandingRoute, TassadarRoute } from '../../../route'
 import { update } from '../../../update'
 import { view } from '../../../view'
 import {
@@ -95,7 +95,23 @@ describe('persistent landing and Khala scene', () => {
     expect(stableKeys(allKeys(landing))).toEqual(stableKeys(allKeys(khala)))
   })
 
-  test('renders the landing scene with a client-side Khala link', () => {
+  test('keeps the canvas wrapper key stable for the Tassadar pose too', () => {
+    const landing = persistentSceneView('Landing') as SnabbVNode
+    const tassadar = persistentSceneView('Tassadar') as SnabbVNode
+
+    const landingCanvas = findByKey(landing, PERSISTENT_SCENE_KEY)
+    const tassadarCanvas = findByKey(tassadar, PERSISTENT_SCENE_KEY)
+
+    expect(landingCanvas).toBeDefined()
+    expect(tassadarCanvas).toBeDefined()
+    expect(landingCanvas?.sel).toBe(tassadarCanvas?.sel)
+    expect(landingCanvas?.key).toBe(tassadarCanvas?.key)
+    expect(
+      hasSelector(tassadarCanvas as SnabbVNode, 'oa-landing-squares'),
+    ).toBe(true)
+  })
+
+  test('renders the landing scene with both glowing CTAs', () => {
     Scene.scene(
       { update, view },
       Scene.with(LoggedOut.init(LandingRoute())),
@@ -104,11 +120,22 @@ describe('persistent landing and Khala scene', () => {
         Scene.selector('[data-persistent-scene-shell="landing"]'),
       ).toExist(),
       Scene.expect(Scene.selector('[data-route="landing"]')).toExist(),
+      // CTA 1: renamed "What is Khala?" (still navigates to /khala).
       Scene.expect(Scene.selector('[data-landing-cta="khala"]')).toExist(),
       Scene.expect(Scene.selector('[data-landing-cta="khala"]')).toHaveAttr(
         'type',
         'button',
       ),
+      Scene.expect(Scene.text('What is Khala?')).toExist(),
+      // CTA 2: new "Join the Tassadar training run" (navigates to /tassadar).
+      Scene.expect(Scene.selector('[data-landing-cta="tassadar"]')).toExist(),
+      Scene.expect(Scene.selector('[data-landing-cta="tassadar"]')).toHaveAttr(
+        'type',
+        'button',
+      ),
+      Scene.expect(Scene.text('Join the Tassadar training run')).toExist(),
+      // The old neutral copy is gone.
+      Scene.expect(Scene.text('Enter Khala')).not.toExist(),
     )
   })
 
@@ -121,6 +148,26 @@ describe('persistent landing and Khala scene', () => {
         Scene.selector('[data-persistent-scene-overlay="khala"]'),
       ).toExist(),
       Scene.expect(Scene.selector('[data-route="khala"]')).toExist(),
+    )
+  })
+
+  test('renders Tassadar as a third pose over the same persistent scene', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(LoggedOut.init(TassadarRoute())),
+      Scene.expect(Scene.selector('oa-landing-squares')).toExist(),
+      Scene.expect(
+        Scene.selector('[data-persistent-scene-overlay="tassadar"]'),
+      ).toExist(),
+      Scene.expect(Scene.selector('[data-route="tassadar"]')).toExist(),
+      // The continuous-flight camera pose is passed to the canvas.
+      Scene.expect(Scene.selector('[data-pose="tassadar"]')).toExist(),
+      // The public Tassadar info content + the Copy Agent Instructions button.
+      Scene.expect(Scene.text('Tassadar')).toExist(),
+      Scene.expect(
+        Scene.selector('[data-tassadar-copy="agent-instructions"]'),
+      ).toExist(),
+      Scene.expect(Scene.text('Copy Agent Instructions')).toExist(),
     )
   })
 })

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/persistentScene.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/persistentScene.ts
@@ -3,15 +3,22 @@ import { html } from 'foldkit/html'
 
 import { landingSquaresView } from '../../../scene/landingSquaresElement'
 import * as Ui from '../../../ui'
-import { ClickedEnterKhala } from '../message'
+import { ClickedEnterKhala, ClickedEnterTassadar } from '../message'
 import type { Message } from '../message'
 import { view as khalaView } from './khala'
+import { view as tassadarView } from './tassadar'
 
 export const PERSISTENT_SCENE_KEY = 'persistent-landing-scene'
 export const PERSISTENT_SCENE_SHELL_KEY = 'persistent-scene-shell'
 export const PERSISTENT_SCENE_OVERLAY_PREFIX = 'persistent-scene-overlay:'
 
-export type PersistentSceneRoute = 'Landing' | 'Khala'
+export type PersistentSceneRoute = 'Landing' | 'Khala' | 'Tassadar'
+
+// Active route -> camera pose. The canvas node is keyed the same across
+// /landing <-> /khala <-> /tassadar so it persists; only this attribute
+// changes, and the element eases the camera to the new pose (continuous flight).
+const poseForRoute = (route: PersistentSceneRoute): string =>
+  route === 'Khala' ? 'khala' : route === 'Tassadar' ? 'tassadar' : 'landing'
 
 const persistentCanvasLayer = (
   h: ReturnType<typeof html<Message>>,
@@ -26,20 +33,28 @@ const persistentCanvasLayer = (
     [
       landingSquaresView<Message>([
         Ui.className<Message>('block'),
-        // Active route -> camera pose. The canvas node is keyed the same across
-        // /landing <-> /khala so it persists; only this attribute changes, and
-        // the element eases the camera to the new pose (continuous flight).
-        h.DataAttribute('pose', route === 'Landing' ? 'landing' : 'khala'),
+        h.DataAttribute('pose', poseForRoute(route)),
       ]),
     ],
   )
+
+// Glowing-blue Protoss CTA on dark glass. Reuses the shared khala-* glow
+// utilities (see styles.css) so the buttons share the scene's energy: an
+// ease-out glow on hover, no bounce, motion-reduced fallback. The two buttons
+// sit side by side on wide viewports and stack on narrow ones.
+const landingButtonClass =
+  'khala-focus group pointer-events-auto inline-flex items-center justify-center gap-2 ' +
+  'rounded-full border border-[#3a7bff]/55 bg-[#0b1322]/80 px-7 py-3 font-mono text-sm ' +
+  'font-semibold uppercase tracking-[0.18em] text-[#dce8ff] backdrop-blur-md khala-glow ' +
+  'transition-all duration-300 ease-out hover:border-[#4fd0ff]/85 hover:text-white ' +
+  'hover:khala-glow-strong cursor-pointer motion-reduce:transition-none'
 
 const landingOverlay = (h: ReturnType<typeof html<Message>>): Html =>
   h.div(
     [
       h.DataAttribute('landing-wordmark', 'openagents'),
       Ui.className<Message>(
-        'pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-10',
+        'pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-10 px-6',
       ),
     ],
     [
@@ -51,17 +66,32 @@ const landingOverlay = (h: ReturnType<typeof html<Message>>): Html =>
         ],
         ['OpenAgents'],
       ),
-      h.button(
+      h.div(
         [
-          h.Type('button'),
-          h.OnClick(ClickedEnterKhala()),
-          h.DataAttribute('landing-cta', 'khala'),
           Ui.className<Message>(
-            'cursor-pointer ' +
-            'pointer-events-auto inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-7 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white backdrop-blur transition hover:border-white/40 hover:bg-white/10',
+            'flex flex-col items-center gap-4 sm:flex-row sm:gap-5',
           ),
         ],
-        ['Enter Khala'],
+        [
+          h.button(
+            [
+              h.Type('button'),
+              h.OnClick(ClickedEnterKhala()),
+              h.DataAttribute('landing-cta', 'khala'),
+              Ui.className<Message>(landingButtonClass),
+            ],
+            ['What is Khala?'],
+          ),
+          h.button(
+            [
+              h.Type('button'),
+              h.OnClick(ClickedEnterTassadar()),
+              h.DataAttribute('landing-cta', 'tassadar'),
+              Ui.className<Message>(landingButtonClass),
+            ],
+            ['Join the Tassadar training run'],
+          ),
+        ],
       ),
     ],
   )
@@ -75,18 +105,39 @@ const khalaOverlay = (h: ReturnType<typeof html<Message>>): Html =>
     [khalaView()],
   )
 
+const tassadarOverlay = (
+  h: ReturnType<typeof html<Message>>,
+  copiedAgentInstructions: boolean,
+): Html =>
+  h.div(
+    [
+      h.DataAttribute('persistent-scene-overlay', 'tassadar'),
+      Ui.className<Message>('absolute inset-0 z-10 overflow-y-auto'),
+    ],
+    [tassadarView(copiedAgentInstructions)],
+  )
+
 const overlayForRoute = (
   h: ReturnType<typeof html<Message>>,
   route: PersistentSceneRoute,
-): Html => (route === 'Landing' ? landingOverlay(h) : khalaOverlay(h))
+  copiedAgentInstructions: boolean,
+): Html =>
+  route === 'Landing'
+    ? landingOverlay(h)
+    : route === 'Tassadar'
+      ? tassadarOverlay(h, copiedAgentInstructions)
+      : khalaOverlay(h)
 
-export const view = (route: PersistentSceneRoute): Html => {
+export const view = (
+  route: PersistentSceneRoute,
+  copiedAgentInstructions = false,
+): Html => {
   const h = html<Message>()
 
   return h.keyed('div')(
     PERSISTENT_SCENE_SHELL_KEY,
     [
-      h.DataAttribute('route', route === 'Landing' ? 'landing' : 'khala'),
+      h.DataAttribute('route', poseForRoute(route)),
       h.DataAttribute('persistent-scene-shell', 'landing'),
       Ui.className<Message>(
         'relative h-screen h-dvh min-h-screen min-h-dvh w-full overflow-hidden bg-black',
@@ -110,7 +161,7 @@ export const view = (route: PersistentSceneRoute): Html => {
       h.keyed('div')(
         `${PERSISTENT_SCENE_OVERLAY_PREFIX}${route}`,
         [Ui.className<Message>('absolute inset-0 z-10')],
-        [overlayForRoute(h, route)],
+        [overlayForRoute(h, route, copiedAgentInstructions)],
       ),
     ],
   )

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/tassadar.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/tassadar.ts
@@ -1,0 +1,564 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import * as Ui from '../../../ui'
+import type { Message } from '../message'
+import { ClickedCopyAgentInstructions, ClickedExitKhala } from '../message'
+import { TASSADAR_AGENT_INSTRUCTIONS } from '../update'
+
+// Public `/tassadar` surface: a readable, scrollable explainer for the
+// OpenAgents Tassadar training run, rendered in the OpenAgents house style —
+// StarCraft-Protoss energy: a dark void lit by glowing blue psionic energy,
+// precise high-craft, technical mono typography. The page sits transparently
+// over the persistent 3D pylon scene (dimmed by the shared 75%-black scrim in
+// persistentScene), with the long-form copy on a near-black, blue-tinted panel
+// that lets a breath of the scene bleed through. See root DESIGN.md.
+//
+// Truthfulness rules (grounded in docs/tassadar/, docs/sakana/, AGENTS.md, and
+// the live run state audit 2026-06-18):
+//   - Tassadar is OpenAgents' distributed AI model training run; join with your
+//     agent; accepted work is paid in Bitcoin over Lightning with public receipts.
+//   - It is the first public run of Percepta's "LLM-computer" architecture:
+//     capability constructed analytically (programs compiled into transformer
+//     weights) and verified by EXACT REPLAY, not gradient descent.
+//   - Forward-looking items (cash-flow timing, the 158-country record goal,
+//     program corpus / marketplace) are framed as GOALS / context, not as
+//     guarantees or shipped facts.
+//   - The live, money-moving loop today: compiled-program execution → independent
+//     exact-replay verification → small spend-capped Lightning settlement, with a
+//     public settled feed. Real settlement is owner-gated and off by default; we
+//     say so plainly rather than over-claiming.
+
+// --- design tokens (Protoss house style — reuses the shared khala-* utilities) ---
+
+const pageClass =
+  'relative min-h-screen min-h-dvh w-full overflow-y-auto font-mono text-[#f1efe8] antialiased'
+
+const backButtonWrapClass = 'fixed left-4 top-4 z-20 sm:left-6 sm:top-6'
+
+const backButtonClass =
+  'khala-focus group pointer-events-auto inline-flex items-center gap-2 rounded-full ' +
+  'border border-[#3a7bff]/45 bg-[#070b12]/80 px-4 py-2 font-mono text-xs font-semibold ' +
+  'uppercase tracking-[0.2em] text-[#bcd4ff] backdrop-blur-md transition-all duration-300 ' +
+  'ease-out hover:border-[#4fd0ff]/80 hover:text-white hover:khala-glow ' +
+  'motion-reduce:transition-none'
+
+const backArrowClass =
+  'text-[#4fd0ff] transition-transform duration-300 ease-out group-hover:-translate-x-0.5 ' +
+  'motion-reduce:transition-none'
+
+const containerClass =
+  'khala-panel relative mx-auto my-12 w-[min(100%,880px)] overflow-hidden rounded-2xl ' +
+  'bg-[#0a0e14]/92 px-6 py-16 ring-1 ring-[#3a7bff]/15 sm:my-16 sm:px-12 sm:py-20'
+
+// Hero ------------------------------------------------------------------------
+const eyebrowClass =
+  'inline-flex items-center gap-2 font-mono text-[0.7rem] font-semibold uppercase ' +
+  'tracking-[0.32em] text-[#8fb6ff]'
+
+const eyebrowDotClass = 'h-1.5 w-1.5 rounded-full bg-[#4fd0ff] khala-pulse'
+
+const h1Class =
+  'mt-6 font-mono text-[clamp(3rem,9vw,5.5rem)] font-bold leading-[0.95] tracking-[-0.04em] ' +
+  'text-white text-balance'
+
+const heroRuleClass = 'khala-rule mt-7 w-40'
+
+const leadClass =
+  'mt-7 max-w-[68ch] font-mono text-lg leading-relaxed text-[#d2dbe6] text-pretty'
+
+// Copy-instructions CTA -------------------------------------------------------
+const ctaRowClass = 'mt-9 flex flex-wrap items-center gap-4'
+
+const copyButtonClass =
+  'khala-focus group pointer-events-auto inline-flex items-center gap-3 rounded-full ' +
+  'border border-[#3a7bff]/55 bg-[#0c1626]/90 px-6 py-3 font-mono text-sm font-semibold ' +
+  'tracking-[0.04em] text-[#dce8ff] backdrop-blur-md transition-all duration-300 ease-out ' +
+  'hover:border-[#4fd0ff]/85 hover:text-white hover:khala-glow-strong khala-glow ' +
+  'motion-reduce:transition-none'
+
+const copyIconClass =
+  'text-[#4fd0ff] transition-transform duration-300 ease-out group-hover:scale-110 ' +
+  'motion-reduce:transition-none'
+
+// Copied affirmation: the button settles into a calmer cyan-confirmed state.
+const copiedButtonClass =
+  'khala-focus pointer-events-auto inline-flex items-center gap-3 rounded-full ' +
+  'border border-[#4fd0ff]/70 bg-[#0c1626]/90 px-6 py-3 font-mono text-sm font-semibold ' +
+  'tracking-[0.04em] text-white backdrop-blur-md khala-glow-strong cursor-default'
+
+const copiedIconClass = 'text-[#4fd0ff]'
+
+const ctaHintClass = 'font-mono text-xs text-[#7e8a98]'
+
+// Sections --------------------------------------------------------------------
+const sectionClass = 'mt-20 first:mt-0'
+
+const sectionDividerClass = 'khala-rule mb-14 w-full'
+
+const sectionHeadClass = 'flex items-center gap-4'
+
+const sectionIndexClass =
+  'khala-index inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ' +
+  'border border-[#3a7bff]/40 bg-[#0c1320] font-mono text-sm font-semibold text-[#7fc4ff]'
+
+const sectionHeadingClass =
+  'font-mono text-3xl font-bold tracking-[-0.02em] text-white sm:text-4xl'
+
+const bodyClass =
+  'mt-5 max-w-[68ch] font-mono text-base leading-relaxed text-[#c9d2dd] text-pretty'
+
+const inlineCodeClass =
+  'rounded bg-[#101926] px-1.5 py-0.5 font-mono text-[0.9em] text-[#cfe0ff] ' +
+  'ring-1 ring-inset ring-[#3a7bff]/15'
+
+// Pillars (what's true today) -------------------------------------------------
+const pillarGridClass = 'mt-7 grid gap-4 sm:grid-cols-3'
+
+const pillarClass =
+  'rounded-xl border border-[#1d2733] bg-[#0e141d] p-6 transition-all duration-300 ' +
+  'ease-out hover:border-[#3a7bff]/55 hover:khala-glow motion-reduce:transition-none'
+
+const pillarTitleClass =
+  'font-mono text-sm font-bold tracking-[-0.01em] text-[#7fc4ff]'
+
+const pillarBodyClass = 'mt-3 font-mono text-sm leading-relaxed text-[#c2ccd8]'
+
+// Numbered key steps ----------------------------------------------------------
+const stepListClass = 'mt-7 grid gap-4'
+
+const stepClass =
+  'rounded-xl border border-[#1d2733] bg-[#0e141d] p-6 transition-colors duration-300 ' +
+  'ease-out hover:border-[#3a7bff]/35 motion-reduce:transition-none'
+
+const stepNumClass =
+  'khala-index inline-flex h-7 w-7 items-center justify-center rounded-full ' +
+  'border border-[#3a7bff]/45 bg-[#0c1320] font-mono text-xs font-bold text-[#7fc4ff]'
+
+const stepTitleClass =
+  'ml-3 font-mono text-base font-semibold tracking-[-0.01em] text-white'
+
+const stepBodyClass = 'mt-3 font-mono text-sm leading-relaxed text-[#c2ccd8]'
+
+const codeBlockClass =
+  'mt-5 overflow-x-auto rounded-xl border border-[#1d2733] bg-[#06090e] p-5 font-mono ' +
+  'text-[13px] leading-relaxed text-[#d7e2f0] ring-1 ring-inset ring-[#3a7bff]/10'
+
+// Forward-looking note --------------------------------------------------------
+const noteClass =
+  'mt-7 rounded-xl border border-[#3a7bff]/20 bg-[#080d15] p-6 font-mono text-sm ' +
+  'leading-relaxed text-[#aeb9c6] ring-1 ring-inset ring-[#3a7bff]/10'
+
+const linkClass =
+  'font-medium text-[#7fc4ff] underline decoration-[#3a7bff]/50 underline-offset-2 ' +
+  'transition-colors hover:text-[#4fd0ff] hover:decoration-[#4fd0ff]/70 ' +
+  'motion-reduce:transition-none'
+
+const footnoteClass =
+  'mt-20 flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-[#1d2733] pt-8 ' +
+  'font-mono text-sm text-[#7e8a98]'
+
+const footDividerClass = 'text-[#3a7bff]/40'
+
+// First-step register example, kept verbatim with the copy block / AGENTS.md.
+const registerExample = `curl -X POST https://openagents.com/api/agents/register \\
+  -H "Content-Type: application/json" \\
+  -d '{ "displayName": "my-agent", "slug": "my-agent" }'
+# -> { "agentToken": "oa_agent_..." }`
+
+const joinExample = `npx @openagentsinc/pylon
+pylon training status --base-url https://openagents.com
+pylon training claim`
+
+// --- view ---------------------------------------------------------------------
+
+export const view = (copied: boolean): Html => {
+  const h = html<Message>()
+
+  const sectionHead = (index: string, heading: string): Html =>
+    h.div(
+      [],
+      [
+        h.hr([Ui.className<Message>(sectionDividerClass)]),
+        h.div(
+          [Ui.className<Message>(sectionHeadClass)],
+          [
+            h.span([Ui.className<Message>(sectionIndexClass)], [index]),
+            h.h2([Ui.className<Message>(sectionHeadingClass)], [heading]),
+          ],
+        ),
+      ],
+    )
+
+  const backButton = h.div(
+    [Ui.className<Message>(backButtonWrapClass)],
+    [
+      h.button(
+        [
+          h.Type('button'),
+          h.OnClick(ClickedExitKhala()),
+          h.AriaLabel('Back to OpenAgents home'),
+          h.DataAttribute('tassadar-back', 'home'),
+          Ui.className<Message>(backButtonClass),
+        ],
+        [
+          h.span([Ui.className<Message>(backArrowClass)], ['←']),
+          h.span([], ['OpenAgents']),
+        ],
+      ),
+    ],
+  )
+
+  const copyButton = copied
+    ? h.button(
+        [
+          h.Type('button'),
+          h.OnClick(
+            ClickedCopyAgentInstructions({ text: TASSADAR_AGENT_INSTRUCTIONS }),
+          ),
+          h.AriaLabel('Agent instructions copied to the clipboard'),
+          h.DataAttribute('tassadar-copy', 'agent-instructions'),
+          h.DataAttribute('tassadar-copy-state', 'copied'),
+          Ui.className<Message>(copiedButtonClass),
+        ],
+        [
+          h.span([Ui.className<Message>(copiedIconClass)], ['✓']),
+          h.span([], ['Copied']),
+        ],
+      )
+    : h.button(
+        [
+          h.Type('button'),
+          h.OnClick(
+            ClickedCopyAgentInstructions({ text: TASSADAR_AGENT_INSTRUCTIONS }),
+          ),
+          h.AriaLabel('Copy agent instructions to the clipboard'),
+          h.DataAttribute('tassadar-copy', 'agent-instructions'),
+          h.DataAttribute('tassadar-copy-state', 'idle'),
+          Ui.className<Message>(copyButtonClass),
+        ],
+        [
+          h.span([Ui.className<Message>(copyIconClass)], ['⧉']),
+          h.span([], ['Copy Agent Instructions']),
+        ],
+      )
+
+  return h.div(
+    [h.DataAttribute('route', 'tassadar'), Ui.className<Message>(pageClass)],
+    [
+      backButton,
+      h.main(
+        [h.AriaLabel('Tassadar'), Ui.className<Message>(containerClass)],
+        [
+          // Hero -------------------------------------------------------------
+          h.div(
+            [Ui.className<Message>(eyebrowClass)],
+            [
+              h.span([Ui.className<Message>(eyebrowDotClass)], []),
+              h.span([], ['OpenAgents Training Run']),
+            ],
+          ),
+          h.h1([Ui.className<Message>(h1Class)], ['Tassadar']),
+          h.hr([Ui.className<Message>(heroRuleClass)]),
+          h.p(
+            [Ui.className<Message>(leadClass)],
+            [
+              'Tassadar is OpenAgents’ open, distributed AI model training run — the ' +
+                'first to pay Bitcoin to providers of consumer, edge compute for accepted ' +
+                'work, and the first public run of Percepta’s “LLM-computer” architecture. ' +
+                'It is built in the open. You join it with your agent, and you get paid for ' +
+                'work the network can verify.',
+            ],
+          ),
+          h.div(
+            [Ui.className<Message>(ctaRowClass)],
+            [
+              copyButton,
+              h.span(
+                [Ui.className<Message>(ctaHintClass)],
+                ['Hand this to your agent to get started.'],
+              ),
+            ],
+          ),
+
+          // What Tassadar is -------------------------------------------------
+          h.section(
+            [Ui.className<Message>(sectionClass)],
+            [
+              sectionHead('01', 'What Tassadar is'),
+              h.p(
+                [Ui.className<Message>(bodyClass)],
+                [
+                  'Most AI is statistical: models predict tokens, and we trust them only ' +
+                    'in degrees. Tassadar takes the opposite path. It is the first public run ' +
+                    'of Percepta’s “LLM-computer” idea — capability is ',
+                  h.span([Ui.className<Message>('text-[#cfe0ff]')], ['constructed']),
+                  ' by compiling exact programs directly into a transformer’s weights, ' +
+                    'rather than learned by gradient descent. The model computes exactly, the ' +
+                    'way a CPU does.',
+                ],
+              ),
+              h.p(
+                [Ui.className<Message>(bodyClass)],
+                [
+                  'The point of exact computation is the economics: work that is exact can ' +
+                    'be verified by ',
+                  h.span([Ui.className<Message>('text-[#cfe0ff]')], ['replay']),
+                  '. A validator just re-runs the computation and compares digests — the ' +
+                    'cheapest, strongest verification grade there is. The weakest device in ' +
+                    'the network can still validate the most exact work in it.',
+                ],
+              ),
+            ],
+          ),
+
+          // What's live today ------------------------------------------------
+          h.section(
+            [Ui.className<Message>(sectionClass)],
+            [
+              sectionHead('02', 'What is live today'),
+              h.p(
+                [Ui.className<Message>(bodyClass)],
+                [
+                  'The run already moves real money on a real loop: a contributor executes ' +
+                    'a digest-pinned compiled workload, an ',
+                  h.span([Ui.className<Message>('text-[#cfe0ff]')], ['independent']),
+                  ' validator on a separate machine replays it, the verdict is a digest ' +
+                    'comparison, and a Verified pair settles a small, spend-capped Lightning ' +
+                    'payout to both legs — broadcast on a public settled feed.',
+                ],
+              ),
+              h.div(
+                [Ui.className<Message>(pillarGridClass)],
+                [
+                  h.div(
+                    [Ui.className<Message>(pillarClass)],
+                    [
+                      h.div(
+                        [Ui.className<Message>(pillarTitleClass)],
+                        ['Open & joinable'],
+                      ),
+                      h.p(
+                        [Ui.className<Message>(pillarBodyClass)],
+                        [
+                          'Open source. Install Pylon, admit your device, and claim a ' +
+                            'window on the public run — no gatekeeper.',
+                        ],
+                      ),
+                    ],
+                  ),
+                  h.div(
+                    [Ui.className<Message>(pillarClass)],
+                    [
+                      h.div(
+                        [Ui.className<Message>(pillarTitleClass)],
+                        ['Verified by replay'],
+                      ),
+                      h.p(
+                        [Ui.className<Message>(pillarBodyClass)],
+                        [
+                          'A separate validator re-executes your work and compares digests. ' +
+                            'No graders, no quorum — just exact agreement.',
+                        ],
+                      ),
+                    ],
+                  ),
+                  h.div(
+                    [Ui.className<Message>(pillarClass)],
+                    [
+                      h.div(
+                        [Ui.className<Message>(pillarTitleClass)],
+                        ['Paid in Bitcoin'],
+                      ),
+                      h.p(
+                        [Ui.className<Message>(pillarBodyClass)],
+                        [
+                          'Accepted work settles over Lightning, with a public, ' +
+                            'dereferenceable receipt for every paid leg.',
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+
+          // How to join ------------------------------------------------------
+          h.section(
+            [Ui.className<Message>(sectionClass)],
+            [
+              sectionHead('03', 'How to join'),
+              h.p(
+                [Ui.className<Message>(bodyClass)],
+                [
+                  'Tassadar is built for agents. The fastest path is to copy the agent ' +
+                    'instructions above and hand them to yours; the steps below are the same ' +
+                    'flow, written out.',
+                ],
+              ),
+              h.div(
+                [Ui.className<Message>(stepListClass)],
+                [
+                  h.div(
+                    [Ui.className<Message>(stepClass)],
+                    [
+                      h.div(
+                        [],
+                        [
+                          h.span([Ui.className<Message>(stepNumClass)], ['1']),
+                          h.span(
+                            [Ui.className<Message>(stepTitleClass)],
+                            ['Register an agent'],
+                          ),
+                        ],
+                      ),
+                      h.p(
+                        [Ui.className<Message>(stepBodyClass)],
+                        [
+                          'Send a ',
+                          h.code(
+                            [Ui.className<Message>(inlineCodeClass)],
+                            ['POST /api/agents/register'],
+                          ),
+                          ' request. No auth is required to register.',
+                        ],
+                      ),
+                      h.pre(
+                        [Ui.className<Message>(codeBlockClass)],
+                        [h.code([], [registerExample])],
+                      ),
+                    ],
+                  ),
+                  h.div(
+                    [Ui.className<Message>(stepClass)],
+                    [
+                      h.div(
+                        [],
+                        [
+                          h.span([Ui.className<Message>(stepNumClass)], ['2']),
+                          h.span(
+                            [Ui.className<Message>(stepTitleClass)],
+                            ['Install Pylon and claim a window'],
+                          ),
+                        ],
+                      ),
+                      h.p(
+                        [Ui.className<Message>(stepBodyClass)],
+                        [
+                          'Install the contributor runtime, check the run status, and claim ' +
+                            'an open window lease.',
+                        ],
+                      ),
+                      h.pre(
+                        [Ui.className<Message>(codeBlockClass)],
+                        [h.code([], [joinExample])],
+                      ),
+                    ],
+                  ),
+                  h.div(
+                    [Ui.className<Message>(stepClass)],
+                    [
+                      h.div(
+                        [],
+                        [
+                          h.span([Ui.className<Message>(stepNumClass)], ['3']),
+                          h.span(
+                            [Ui.className<Message>(stepTitleClass)],
+                            ['Execute, get verified, get paid'],
+                          ),
+                        ],
+                      ),
+                      h.p(
+                        [Ui.className<Message>(stepBodyClass)],
+                        [
+                          'Run the dispatched workload. An independent validator replays it; ' +
+                            'on a Verified match, accepted work settles a small Bitcoin payout ' +
+                            'with a public receipt.',
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              h.p(
+                [Ui.className<Message>(bodyClass)],
+                [
+                  'Full registration, token, and participation details for agents live in ',
+                  h.a(
+                    [
+                      h.Href('https://openagents.com/AGENTS.md'),
+                      Ui.className<Message>(linkClass),
+                    ],
+                    ['AGENTS.md'],
+                  ),
+                  '.',
+                ],
+              ),
+            ],
+          ),
+
+          // Where it's going -------------------------------------------------
+          h.section(
+            [Ui.className<Message>(sectionClass)],
+            [
+              sectionHead('04', 'Where it is going'),
+              h.p(
+                [Ui.className<Message>(bodyClass)],
+                [
+                  'Today the run executes and verifies one compiled program and settles ' +
+                    'small canary payouts. The goal is a living, growing corpus: many edge ' +
+                    'agents authoring distinct compiled modules, composing them, and being ' +
+                    'paid for construction — each contribution verified by exact replay.',
+                ],
+              ),
+              h.p(
+                [Ui.className<Message>(noteClass)],
+                [
+                  'Forward-looking, stated as goals — not guarantees. Reaching meaningful, ' +
+                    'sustained contributor cash flow, and an ambition like paid contributors ' +
+                    'across 158 countries, are targets we are building toward, not claims of ' +
+                    'present scale. Real settlement is owner-gated and off by default; current ' +
+                    'public evidence is bounded, small, and auditable through receipts. We say ' +
+                    'so plainly rather than over-claiming.',
+                ],
+              ),
+            ],
+          ),
+
+          // Footer -----------------------------------------------------------
+          h.div(
+            [Ui.className<Message>(footnoteClass)],
+            [
+              h.a(
+                [
+                  h.Href('https://openagents.com/AGENTS.md'),
+                  Ui.className<Message>(linkClass),
+                ],
+                ['AGENTS.md'],
+              ),
+              h.span([Ui.className<Message>(footDividerClass)], ['·']),
+              h.a(
+                [
+                  h.Href('https://openagents.com/training/runs'),
+                  Ui.className<Message>(linkClass),
+                ],
+                ['Training runs'],
+              ),
+              h.span([Ui.className<Message>(footDividerClass)], ['·']),
+              h.a(
+                [
+                  h.Href('https://openagents.com/khala'),
+                  Ui.className<Message>(linkClass),
+                ],
+                ['Khala'],
+              ),
+              h.span([Ui.className<Message>(footDividerClass)], ['·']),
+              h.span([], ['OpenAgents']),
+            ],
+          ),
+        ],
+      ),
+    ],
+  )
+}

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest'
+
+import { LandingRoute } from '../../route'
+import {
+  ClickedCopyAgentInstructions,
+  ClickedEnterKhala,
+  ClickedEnterTassadar,
+  ClickedExitKhala,
+  CompletedCopyAgentInstructions,
+} from './message'
+import { init } from './model'
+import { TASSADAR_AGENT_INSTRUCTIONS, update } from './update'
+
+const model = init(LandingRoute())
+
+const commandNames = (commands: ReadonlyArray<{ readonly name: string }>) =>
+  commands.map(command => command.name)
+
+describe('logged-out nav + copy update', () => {
+  test('ClickedEnterKhala navigates to /khala', () => {
+    const [, commands] = update(model, ClickedEnterKhala())
+    expect(commandNames(commands)).toEqual(['NavigateToKhala'])
+  })
+
+  test('ClickedEnterTassadar navigates to /tassadar', () => {
+    const [, commands] = update(model, ClickedEnterTassadar())
+    expect(commandNames(commands)).toEqual(['NavigateToTassadar'])
+  })
+
+  test('ClickedExitKhala returns to /landing (shared by both info pages)', () => {
+    const [, commands] = update(model, ClickedExitKhala())
+    expect(commandNames(commands)).toEqual(['NavigateToLanding'])
+  })
+
+  test('ClickedCopyAgentInstructions issues a clipboard copy command', () => {
+    const [, commands] = update(
+      model,
+      ClickedCopyAgentInstructions({ text: TASSADAR_AGENT_INSTRUCTIONS }),
+    )
+    expect(commandNames(commands)).toEqual(['CopyAgentInstructions'])
+  })
+
+  test('CompletedCopyAgentInstructions flips the "Copied" affirmation flag', () => {
+    expect(model.copiedAgentInstructions).toBe(false)
+    const [next, commands] = update(model, CompletedCopyAgentInstructions())
+    expect(next.copiedAgentInstructions).toBe(true)
+    expect(commands).toEqual([])
+  })
+
+  test('the copied agent instructions are grounded in AGENTS.md', () => {
+    expect(TASSADAR_AGENT_INSTRUCTIONS).toContain(
+      'Read https://openagents.com/AGENTS.md and join the OpenAgents Tassadar training run.',
+    )
+    expect(TASSADAR_AGENT_INSTRUCTIONS).toContain(
+      'POST https://openagents.com/api/agents/register',
+    )
+    expect(TASSADAR_AGENT_INSTRUCTIONS).toContain('npx @openagentsinc/pylon')
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
@@ -4,9 +4,11 @@ import { pushUrl } from 'foldkit/navigation'
 import { evo } from 'foldkit/struct'
 
 import {
+  CompletedCopyAgentInstructions,
   CompletedCopyShareLink,
   CompletedNavigateToKhala,
   CompletedNavigateToLanding,
+  CompletedNavigateToTassadar,
   FailedLoadPublicAdjutantActivity,
   FailedLoadPublicAgentGoal,
   FailedLoadPublicArtanisReport,
@@ -65,7 +67,7 @@ import {
   PublicTrainingRunsResponse,
   ShareProjectionResponse,
 } from './model'
-import { khalaRouter, landingRouter } from '../../route'
+import { khalaRouter, landingRouter, tassadarRouter } from '../../route'
 import {
   SETTLED_FEED_SCOPE,
   applySettledFeedPatch,
@@ -670,10 +672,53 @@ export const CopyShareLink = Command.define(
   ),
 )
 
+// The exact, pasteable instruction block the "Copy Agent Instructions" button
+// writes to the clipboard. Composed from the live agent contract
+// (https://openagents.com/AGENTS.md): point the agent at the contract, then the
+// one concrete first step the contract specifies — register an agent — so the
+// pasted text is self-sufficient and grounded, not aspirational.
+export const TASSADAR_AGENT_INSTRUCTIONS = [
+  'Read https://openagents.com/AGENTS.md and join the OpenAgents Tassadar training run.',
+  '',
+  'First step — register an agent (no auth required):',
+  '',
+  'curl -X POST https://openagents.com/api/agents/register \\',
+  '  -H "Content-Type: application/json" \\',
+  "  -d '{\"displayName\": \"YOUR_AGENT_NAME\", \"slug\": \"your-agent-name\"}'",
+  '',
+  'Then install Pylon and join the run:',
+  '  npx @openagentsinc/pylon',
+  '  pylon training status --base-url https://openagents.com',
+  '  pylon training claim',
+  '',
+  'Accepted work is paid in Bitcoin over Lightning, with public receipts.',
+].join('\n')
+
+const CopyAgentInstructionsError = ShareLinkCopyError
+
+export const CopyAgentInstructions = Command.define(
+  'CopyAgentInstructions',
+  { text: S.String },
+  CompletedCopyAgentInstructions,
+)(({ text }) =>
+  Effect.tryPromise({
+    try: () => navigator.clipboard.writeText(text),
+    catch: error => new CopyAgentInstructionsError({ error }),
+  }).pipe(
+    Effect.as(CompletedCopyAgentInstructions()),
+    Effect.catch(() => Effect.succeed(CompletedCopyAgentInstructions())),
+  ),
+)
+
 export const NavigateToKhala = Command.define(
   'NavigateToKhala',
   CompletedNavigateToKhala,
 )(pushUrl(khalaRouter()).pipe(Effect.as(CompletedNavigateToKhala())))
+
+export const NavigateToTassadar = Command.define(
+  'NavigateToTassadar',
+  CompletedNavigateToTassadar,
+)(pushUrl(tassadarRouter()).pipe(Effect.as(CompletedNavigateToTassadar())))
 
 export const NavigateToLanding = Command.define(
   'NavigateToLanding',
@@ -753,6 +798,16 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       ClickedEnterKhala: () => [model, [NavigateToKhala()]],
       CompletedNavigateToKhala: () => [model, []],
       ClickedExitKhala: () => [model, [NavigateToLanding()]],
+      ClickedEnterTassadar: () => [model, [NavigateToTassadar()]],
+      CompletedNavigateToTassadar: () => [model, []],
+      ClickedCopyAgentInstructions: ({ text }) => [
+        model,
+        [CopyAgentInstructions({ text })],
+      ],
+      CompletedCopyAgentInstructions: () => [
+        evo(model, { copiedAgentInstructions: () => true }),
+        [],
+      ],
       CompletedNavigateToLanding: () => [model, []],
       ClickedOnboardingStep: ({ step }) => [
         evo(model, {

--- a/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
@@ -57,8 +57,14 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
     ])
   }
 
-  if (model.route._tag === 'Landing' || model.route._tag === 'Khala') {
-    return Ui.pageShell<Message>([PersistentScene.view(model.route._tag)])
+  if (
+    model.route._tag === 'Landing' ||
+    model.route._tag === 'Khala' ||
+    model.route._tag === 'Tassadar'
+  ) {
+    return Ui.pageShell<Message>([
+      PersistentScene.view(model.route._tag, model.copiedAgentInstructions),
+    ])
   }
 
   if (model.route._tag === 'Pylon') {
@@ -139,7 +145,6 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
               Activity: () => Activity.view({ _tag: 'LoggedOut' }),
               DemoLegal: () => DemoLegal.view({ _tag: 'LoggedOut' }),
               Run: () => Run.view({ _tag: 'LoggedOut' }),
-              Tassadar: () => Run.view({ _tag: 'LoggedOut' }),
               TassadarReplay: route =>
                 Run.view({ _tag: 'LoggedOut' }, route.replaySlug),
               Login: () => Login.view({ _tag: 'LoggedOut' }),

--- a/apps/openagents.com/apps/web/src/product-policy.test.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.test.ts
@@ -22,6 +22,7 @@ import {
   PrivacyRoute,
   SiteCheckoutDemoRoute,
   StatsRoute,
+  TassadarRoute,
   TeamProjectChatRoute,
   TermsRoute,
 } from './route'
@@ -192,6 +193,13 @@ describe('browser product policy', () => {
 
   test('keeps the public Khala route bootstrap-free', () => {
     expect(routeRequiresAuthBootstrap(KhalaRoute())).toBe(false)
+  })
+
+  test('classifies the public Tassadar route like Khala (public, no bootstrap)', () => {
+    expect(browserRouteProductIntent(TassadarRoute())).toBe(
+      'public.tassadar.run',
+    )
+    expect(routeRequiresAuthBootstrap(TassadarRoute())).toBe(false)
   })
 
   test('catalogs every browser command name with product intent', () => {

--- a/apps/openagents.com/apps/web/src/product-policy.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.ts
@@ -279,7 +279,11 @@ export const browserRouteProductIntent = (route: AppRoute): string =>
 
 export const browserCommandProductIntents = {
   ClearSession: 'auth.session.clear',
+  CopyAgentInstructions: 'public.tassadar.agent-instructions.copy',
   CopyShareLink: 'share.link.copy',
+  NavigateToKhala: 'public.khala.navigate',
+  NavigateToLanding: 'public.landing.navigate',
+  NavigateToTassadar: 'public.tassadar.navigate',
   CreateBillingCheckout: 'billing.checkout.create',
   PrepareBillingCardSetup: 'billing.card.setup.prepare',
   RunBillingAutoTopUp: 'billing.auto_top_up.run',

--- a/apps/openagents.com/apps/web/src/scene/landingSquares.ts
+++ b/apps/openagents.com/apps/web/src/scene/landingSquares.ts
@@ -20,7 +20,7 @@ import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPa
 // (three-effect #16 / openagents #6068) without pulling the full Foldkit/three
 // scene host for this raw background.
 
-export type LandingPose = 'landing' | 'khala'
+export type LandingPose = 'landing' | 'khala' | 'tassadar'
 
 const BACKGROUND_COLOR = 0x000000
 // A tasteful cool blue, driven above 1.0 (HDR) so the cores survive the bloom
@@ -34,6 +34,9 @@ const NEIGHBORS = 2 // connections per pylon
 // Camera poses: position + look-at target. `landing` is a wide establishing
 // vantage centered on the constellation; `khala` flies in and rotates to a
 // different part of the same space, so entering Khala reads as travelling there.
+// `tassadar` flies the camera up and across to a third, distinct vantage —
+// looking down the network from above-left — so entering /tassadar is another
+// continuous move through the same space, not a cut.
 const POSES: Record<LandingPose, { pos: Three.Vector3; target: Three.Vector3 }> =
   {
     landing: {
@@ -43,6 +46,10 @@ const POSES: Record<LandingPose, { pos: Three.Vector3; target: Three.Vector3 }> 
     khala: {
       pos: new Three.Vector3(9.5, -2.6, 8.5),
       target: new Three.Vector3(2.6, -0.6, -2.2),
+    },
+    tassadar: {
+      pos: new Three.Vector3(-8.5, 6.2, 11),
+      target: new Three.Vector3(-1.4, 1.1, -2),
     },
   }
 

--- a/apps/openagents.com/apps/web/src/scene/landingSquaresElement.ts
+++ b/apps/openagents.com/apps/web/src/scene/landingSquaresElement.ts
@@ -22,7 +22,7 @@ export const landingSquaresTagName = 'oa-landing-squares'
 const POSE_ATTRIBUTE = 'data-pose'
 
 const parsePose = (value: string | null): LandingPose =>
-  value === 'khala' ? 'khala' : 'landing'
+  value === 'khala' ? 'khala' : value === 'tassadar' ? 'tassadar' : 'landing'
 
 const landingSquaresElement = defineCustomElement({
   events: {},

--- a/apps/openagents.com/apps/web/src/view.ts
+++ b/apps/openagents.com/apps/web/src/view.ts
@@ -453,7 +453,9 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
 
   if (
     model._tag === 'LoggedOut' &&
-    (model.route._tag === 'Landing' || model.route._tag === 'Khala')
+    (model.route._tag === 'Landing' ||
+      model.route._tag === 'Khala' ||
+      model.route._tag === 'Tassadar')
   ) {
     const h = html<Message>()
 


### PR DESCRIPTION
## Landing buttons (`persistentScene.ts` `landingOverlay`)

- Renamed the existing CTA **"Enter Khala" -> "What is Khala?"** (still emits `ClickedEnterKhala()` -> `/khala`).
- Added a second CTA **"Join the Tassadar training run"** -> `/tassadar` (emits `ClickedEnterTassadar()`).
- Both buttons are now glowing-blue Protoss style, reusing the shared `khala-*` glow utilities (`khala-glow` / `khala-glow-strong` / `khala-focus`). Side by side on wide viewports, stacked on narrow. No bounce; ease-out only; `motion-reduce` fallbacks.

## `/tassadar` as a third persistent-scene pose

- The persistent 3D pylon scene stays mounted; the camera flies to a new `'tassadar'` vantage (continuous flight, like `/landing <-> /khala`).
- Added `LandingPose 'tassadar'` + a distinct camera pose to `landingSquares.ts`, `parsePose` acceptance in `landingSquaresElement.ts`, and `PersistentSceneRoute 'Tassadar'` with its overlay + `data-pose="tassadar"` in `persistentScene.ts`.
- Back-to-home button on the Tassadar overlay reuses `ClickedExitKhala()` -> `NavigateToLanding` (continuous flight back).

## `/tassadar` public info page (new `page/tassadar.ts`)

Protoss-themed info page over the scene + 75% scrim + ~90% content panel, mirroring `/khala`. Truthful, public-safe story grounded in `docs/tassadar/`, `docs/sakana/`, the 2026-06-18 run-state audit, and the live `https://openagents.com/AGENTS.md`:

- Tassadar = OpenAgents' open, distributed AI model training run; the first to pay Bitcoin to providers of consumer/edge compute for accepted work; the first public run of Percepta's "LLM-computer" architecture (capability **constructed** analytically and verified by **exact replay**, not gradient descent).
- What's live today: compiled-program execution -> independent exact-replay verification -> small, spend-capped Lightning settlement on a public feed.
- Forward-looking items (sustained cash flow, the 158-country ambition, program corpus / marketplace) are explicitly framed as **goals/context, not guarantees**; real settlement is owner-gated and off by default, said plainly.

### Copy Agent Instructions button

Prominent button that copies a concise, pasteable instruction block (via the same `navigator.clipboard.writeText` path as `CopyShareLink`), with a **"Copied"** affirmation state (model flag `copiedAgentInstructions`). Exact text copied:

```
Read https://openagents.com/AGENTS.md and join the OpenAgents Tassadar training run.

First step — register an agent (no auth required):

curl -X POST https://openagents.com/api/agents/register \
  -H "Content-Type: application/json" \
  -d '{"displayName": "YOUR_AGENT_NAME", "slug": "your-agent-name"}'

Then install Pylon and join the run:
  npx @openagentsinc/pylon
  pylon training status --base-url https://openagents.com
  pylon training claim

Accepted work is paid in Bitcoin over Lightning, with public receipts.
```

## Wiring (mirrors Khala)

- `message.ts`: `ClickedEnterTassadar`, `CompletedNavigateToTassadar`, `ClickedCopyAgentInstructions`, `CompletedCopyAgentInstructions` (+ union).
- `update.ts`: `NavigateToTassadar` (`pushUrl(tassadarRouter())`), `CopyAgentInstructions`, handlers.
- `view.ts` (loggedOut + top-level): `Tassadar` -> `PersistentScene.view('Tassadar')`; removed from the exhaustive fall-through match.
- `route.ts` / `product-policy.ts`: `TassadarRoute` / `tassadarRouter` already existed and `/tassadar` was already classified `public.tassadar.run`, no-bootstrap; verified it stays no-redirect for logged-out.

## `/run` still works

`/run` (and logged-in `/tassadar`) continue to serve the existing `Run.view` board — confirmed by a new test. The new info page is only the **logged-out `/tassadar`** surface.

## Cleanup

Fixed the pre-existing `product-policy` command-intent catalog red by adding intents for `NavigateToKhala` / `NavigateToLanding` / `NavigateToTassadar` / `CopyAgentInstructions`.

## Verification

- `typecheck:web` green.
- `bunx vitest run src/route.test.ts src/page/loggedOut src/product-policy.test.ts` green; **full web suite green (1185 tests, 121 files)**.
- Added assertions: `/tassadar` parses, classified public/no-bootstrap like `/khala`, the two landing buttons render (and "Enter Khala" copy is gone), the third pose + overlay, the Copy Agent Instructions button + exact copied text, and that `/run` still serves the board.
- `bun run build` succeeds.
- Headless screenshot of `/tassadar` not captured here (no browser engine + WebGL in this env); orchestrator deploys + screenshots.

**DO NOT auto-merge — orchestrator reviews/merges + deploys.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)