### PR TITLE
routing: move the landing scene to / (homepage), old Pylon root to /pylons

### DIFF
--- a/apps/openagents.com/apps/web/src/main.test.ts
+++ b/apps/openagents.com/apps/web/src/main.test.ts
@@ -77,7 +77,7 @@ describe('auth bootstrap flags', () => {
     window.history.replaceState({}, '', '/')
   })
 
-  test('does not request the auth session on the root Pylon route', async () => {
+  test('does not request the auth session on the root Landing route', async () => {
     window.history.replaceState({}, '', '/')
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
@@ -149,7 +149,7 @@ describe('auth bootstrap flags', () => {
   })
 
   test('does not request the auth session on the Pylon route', async () => {
-    window.history.replaceState({}, '', '/pylon')
+    window.history.replaceState({}, '', '/pylons')
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
     const loadedFlags = await Effect.runPromise(flags)
@@ -332,10 +332,10 @@ describe('authenticated startup routing', () => {
     )
   })
 
-  test('opens Pylon without an auth session', () => {
+  test('opens Pylon at /pylons without an auth session', () => {
     const [model, commands] = init(
       Flags.make({ maybeAuth: Option.none() }),
-      appUrl('/pylon'),
+      appUrl('/pylons'),
     )
 
     expect(model).toMatchObject({
@@ -494,7 +494,7 @@ describe('authenticated startup routing', () => {
   test('renders the Pylon route through the top-level view', () => {
     const [model] = init(
       Flags.make({ maybeAuth: Option.none() }),
-      appUrl('/pylon'),
+      appUrl('/pylons'),
     )
 
     Scene.scene(
@@ -556,7 +556,7 @@ describe('authenticated startup routing', () => {
     ])
   })
 
-  test('keeps incomplete authenticated root visits on the public Pylon scene', () => {
+  test('keeps incomplete authenticated root visits on the public Landing scene', () => {
     const [model, commands] = init(
       Flags.make({ maybeAuth: Option.some(authWithIncompleteOnboarding) }),
       appUrl('/'),
@@ -564,12 +564,12 @@ describe('authenticated startup routing', () => {
 
     expect(model).toMatchObject({
       _tag: 'LoggedOut',
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
     expect(commands).toHaveLength(0)
   })
 
-  test('keeps authenticated root visits on the public Pylon scene', () => {
+  test('keeps authenticated root visits on the public Landing scene', () => {
     const [model, commands] = init(
       Flags.make({ maybeAuth: Option.some(authWithoutCoreTeam) }),
       appUrl('/'),
@@ -577,7 +577,7 @@ describe('authenticated startup routing', () => {
 
     expect(model).toMatchObject({
       _tag: 'LoggedOut',
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
     expect(commands).toHaveLength(0)
   })
@@ -599,7 +599,7 @@ describe('authenticated startup routing', () => {
     ])
   })
 
-  test('keeps logged-out root visitors on the public Pylon scene', () => {
+  test('keeps logged-out root visitors on the public Landing scene', () => {
     const [model, commands] = init(
       Flags.make({ maybeAuth: Option.none() }),
       appUrl('/'),
@@ -607,7 +607,7 @@ describe('authenticated startup routing', () => {
 
     expect(model).toMatchObject({
       _tag: 'LoggedOut',
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
     expect(commands).toHaveLength(0)
   })
@@ -687,7 +687,7 @@ describe('authenticated startup routing', () => {
 
     expect(model).toMatchObject({
       _tag: 'LoggedOut',
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
     expect(commands.map(command => command.name)).toEqual(['RedirectToHome'])
   })
@@ -775,7 +775,7 @@ describe('authenticated startup routing', () => {
     ])
   })
 
-  test('keeps authenticated root visits on the public Pylon scene', () => {
+  test('keeps Core Team authenticated root visits on the public Landing scene', () => {
     const [model, commands] = init(
       Flags.make({ maybeAuth: Option.some(authWithTeam) }),
       appUrl('/'),
@@ -783,7 +783,7 @@ describe('authenticated startup routing', () => {
 
     expect(model).toMatchObject({
       _tag: 'LoggedOut',
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
     expect(commands).toHaveLength(0)
   })

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.test.ts
@@ -27,7 +27,7 @@ describe('logged-out nav + copy update', () => {
     expect(commandNames(commands)).toEqual(['NavigateToTassadar'])
   })
 
-  test('ClickedExitKhala returns to /landing (shared by both info pages)', () => {
+  test('ClickedExitKhala returns home to / (shared by both info pages)', () => {
     const [, commands] = update(model, ClickedExitKhala())
     expect(commandNames(commands)).toEqual(['NavigateToLanding'])
   })

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
@@ -67,7 +67,7 @@ import {
   PublicTrainingRunsResponse,
   ShareProjectionResponse,
 } from './model'
-import { khalaRouter, landingRouter, tassadarRouter } from '../../route'
+import { homeRouter, khalaRouter, tassadarRouter } from '../../route'
 import {
   SETTLED_FEED_SCOPE,
   applySettledFeedPatch,
@@ -723,7 +723,9 @@ export const NavigateToTassadar = Command.define(
 export const NavigateToLanding = Command.define(
   'NavigateToLanding',
   CompletedNavigateToLanding,
-)(pushUrl(landingRouter()).pipe(Effect.as(CompletedNavigateToLanding())))
+  // Landing IS home now (root `/`), so the back button on /khala and
+  // /tassadar pushes the root and flies the camera home.
+)(pushUrl(homeRouter()).pipe(Effect.as(CompletedNavigateToLanding())))
 
 const publicAgentIdForRef = (agentRef: string): string => {
   const knownAgentIds: Readonly<Record<string, string>> = {

--- a/apps/openagents.com/apps/web/src/route.test.ts
+++ b/apps/openagents.com/apps/web/src/route.test.ts
@@ -136,7 +136,11 @@ describe('app route parser', () => {
     expect(urlToAppRoute(appUrl('/moksha2'))).toEqual(Moksha2Route())
   })
 
-  test('accepts the standalone landing route', () => {
+  test('uses the Landing persistent scene as the root route', () => {
+    expect(urlToAppRoute(appUrl('/'))).toEqual(LandingRoute())
+  })
+
+  test('keeps the legacy /landing path as an inbound alias to Landing', () => {
     expect(urlToAppRoute(appUrl('/landing'))).toEqual(LandingRoute())
   })
 
@@ -157,12 +161,14 @@ describe('app route parser', () => {
     ).toEqual(TassadarReplayRoute({ replaySlug: 'first-real-settlement' }))
   })
 
-  test('uses the Pylon scene as the root route', () => {
-    expect(urlToAppRoute(appUrl('/'))).toEqual(PylonRoute())
+  test('serves the Pylon scene at /pylons', () => {
+    expect(urlToAppRoute(appUrl('/pylons'))).toEqual(PylonRoute())
   })
 
-  test('keeps the explicit Pylon scene route alias', () => {
-    expect(urlToAppRoute(appUrl('/pylon'))).toEqual(PylonRoute())
+  test('no longer resolves the old /pylon root alias', () => {
+    expect(urlToAppRoute(appUrl('/pylon'))).toEqual(
+      NotFoundRoute({ path: '/pylon' }),
+    )
   })
 
   test('does not keep the retired live Pylon launch preview route', () => {

--- a/apps/openagents.com/apps/web/src/route.ts
+++ b/apps/openagents.com/apps/web/src/route.ts
@@ -369,7 +369,10 @@ export type LoggedOutRoute = typeof LoggedOutRoute.Type
 export type LoggedInRoute = typeof LoggedInRoute.Type
 export type AppRoute = typeof AppRoute.Type
 
-export const homeRouter = pipe(Route.root, Route.mapTo(PylonRoute))
+// The root path `/` is now the Landing persistent scene (the homepage).
+// `homeRouter()` is the canonical "Go Home" URL builder app-wide and resolves
+// to `/`, which renders the Landing scene.
+export const homeRouter = pipe(Route.root, Route.mapTo(LandingRoute))
 export const chatRouter = pipe(literal('autopilot'), Route.mapTo(ChatRoute))
 export const inviteRouter = pipe(literal('invite'), Route.mapTo(InviteRoute))
 export const onboardingRouter = pipe(
@@ -557,11 +560,20 @@ export const shareRouter = pipe(
 )
 export const mokshaRouter = pipe(literal('moksha'), Route.mapTo(MokshaRoute))
 export const moksha2Router = pipe(literal('moksha2'), Route.mapTo(Moksha2Route))
-export const landingRouter = pipe(literal('landing'), Route.mapTo(LandingRoute))
+// Landing IS the homepage at `/`. `landingRouter()` builds the root path so
+// any "navigate to landing / go home" flow lands on `/`. The `/landing` path
+// is kept as an inbound-only alias (see `landingAliasRouter`) so old links and
+// bookmarks still resolve to the same Landing scene.
+export const landingRouter = pipe(Route.root, Route.mapTo(LandingRoute))
+export const landingAliasRouter = pipe(
+  literal('landing'),
+  Route.mapTo(LandingRoute),
+)
 export const termsRouter = pipe(literal('terms'), Route.mapTo(TermsRoute))
 export const privacyRouter = pipe(literal('privacy'), Route.mapTo(PrivacyRoute))
 export const khalaRouter = pipe(literal('khala'), Route.mapTo(KhalaRoute))
-export const pylonRouter = pipe(literal('pylon'), Route.mapTo(PylonRoute))
+// The Pylon scene moved off the root to `/pylons`.
+export const pylonsRouter = pipe(literal('pylons'), Route.mapTo(PylonRoute))
 export const downloadRouter = pipe(
   literal('download'),
   Route.mapTo(DownloadRoute),
@@ -700,11 +712,11 @@ const routeParser = Route.oneOf(
   shareRouter,
   moksha2Router,
   mokshaRouter,
-  landingRouter,
+  landingAliasRouter,
   termsRouter,
   privacyRouter,
   khalaRouter,
-  pylonRouter,
+  pylonsRouter,
   downloadRouter,
   inviteRouter,
   onboardingRouter,

--- a/apps/openagents.com/apps/web/src/routing/startup.test.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.test.ts
@@ -99,7 +99,7 @@ const incompleteAuth = {
 }
 
 describe('startup route policy', () => {
-  test('keeps logged-out root visitors on the public Pylon scene', () => {
+  test('keeps logged-out visitors on the public Pylon scene (now at /pylons)', () => {
     expect(startupRouteForLoggedOut(PylonRoute())).toEqual({
       _tag: 'LoggedOutStartupRoute',
       redirect: Option.none(),
@@ -434,7 +434,7 @@ describe('startup route policy', () => {
         _tag: 'Some',
         value: { _tag: 'StartupRedirectToHome', href: '/' },
       },
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
   })
 
@@ -509,7 +509,7 @@ describe('startup route policy', () => {
         _tag: 'Some',
         value: { _tag: 'StartupRedirectToHome', href: '/' },
       },
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
   })
 
@@ -522,7 +522,7 @@ describe('startup route policy', () => {
         _tag: 'Some',
         value: { _tag: 'StartupRedirectToHome', href: '/' },
       },
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
   })
 
@@ -535,7 +535,7 @@ describe('startup route policy', () => {
         _tag: 'Some',
         value: { _tag: 'StartupRedirectToHome', href: '/' },
       },
-      route: { _tag: 'Pylon' },
+      route: { _tag: 'Landing' },
     })
   })
 

--- a/apps/openagents.com/apps/web/src/routing/startup.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.ts
@@ -12,10 +12,10 @@ import {
 import {
   type AppRoute,
   InviteRoute,
+  LandingRoute,
   LoggedInRoute,
   LoggedOutRoute,
   OnboardingRoute,
-  PylonRoute,
   homeRouter,
   inviteRouter,
   onboardingRouter,
@@ -121,13 +121,13 @@ export const startupRouteForLoggedOut = (
     ),
     M.tag('NotFound', () =>
       LoggedOutStartupRoute({
-        route: PylonRoute(),
+        route: LandingRoute(),
         redirect: Option.some(StartupRedirectToHome({ href: homeRouter() })),
       }),
     ),
     M.orElse(() =>
       LoggedOutStartupRoute({
-        route: PylonRoute(),
+        route: LandingRoute(),
         redirect: Option.some(StartupRedirectToHome({ href: homeRouter() })),
       }),
     ),

--- a/apps/openagents.com/apps/web/src/scene/pylonCountdownElement.ts
+++ b/apps/openagents.com/apps/web/src/scene/pylonCountdownElement.ts
@@ -6,7 +6,7 @@ import {
   type PylonCountdownHandle,
 } from './pylonCountdown'
 
-// Centered 12-hour countdown overlay for the /pylon page. Lives in its own
+// Centered 12-hour countdown overlay for the /pylons page. Lives in its own
 // shadow root so the slot-text roll CSS is scoped here and does not leak into
 // the rest of the app.
 

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -91,7 +91,7 @@ describe('Worker document route fallback', () => {
 
   test('keeps the Pylon document route in the app shell', () => {
     expect(
-      shouldRedirectUnknownDocumentToHome(requestFor('/pylon'), '/pylon'),
+      shouldRedirectUnknownDocumentToHome(requestFor('/pylons'), '/pylons'),
     ).toBe(false)
   })
 

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -125,7 +125,7 @@ const knownDocumentPathPatterns: ReadonlyArray<RegExp> = [
   /^\/moksha$/,
   /^\/moksha2$/,
   /^\/mullet$/,
-  /^\/pylon$/,
+  /^\/pylons$/,
   /^\/onboarding$/,
   /^\/order$/,
   /^\/orders\/[^/]+$/,


### PR DESCRIPTION
## What

Make the Landing persistent 3D scene the homepage at `/`, and move the former root (the Pylon scene) to `/pylons`.

## Route remap (`apps/openagents.com/apps/web/src/route.ts`)

- `homeRouter` now maps `Route.root -> LandingRoute` (was `PylonRoute`). It is the canonical "Go Home" URL builder app-wide; it parses `/` to Landing and builds `/`.
- `landingRouter` now maps `Route.root -> LandingRoute` too (builds `/`). Added `landingAliasRouter = literal('landing') -> LandingRoute` as an **inbound-only alias** so `/landing` still resolves to the same Landing scene (no server redirect).
- Renamed `pylonRouter` (`/pylon`) to `pylonsRouter` (`/pylons`). The Pylon scene now lives at `/pylons`; the old `/pylon` no longer resolves.
- `routeParser` updated to include `landingAliasRouter` + `pylonsRouter`; `homeRouter` (root) is the last fallthrough and renders Landing.

## Back-nav repoint (`update.ts`)

`NavigateToLanding` (fired by `ClickedExitKhala`, the back button on `/khala` + `/tassadar`) now pushes `homeRouter()` = `/`. Landing is home, so the back button flies the camera home to `/`. Camera-flight behavior is preserved (same command, same persistent-scene reaction).

## What `/landing` now does

`/landing` stays a working inbound alias to the same Landing scene (`landingAliasRouter`), so old links/bookmarks don't break. Canonical home is `/`.

## product-policy / no-bootstrap (`startup.ts`)

- `/` (Landing) stays **public, no-auth-bootstrap, no redirect** for logged-out, incomplete-onboarding, and authenticated visitors — same classification the Pylon root had (both `Landing` and `Pylon` are in the public/no-bootstrap tag lists; classification is per route-tag, unaffected by path moves).
- Logged-out NotFound/fallback now renders `LandingRoute()` (still redirecting to home `/`) instead of `PylonRoute()`.
- `/pylons` keeps the Pylon route's public classification. `/khala` + `/tassadar` unchanged.

## Worker routes (`workers/api/src/worker-routes.ts`)

`knownDocumentPathPatterns`: added `/^\/pylons$/` (replacing `/^\/pylon$/`). Root `/`, `/landing`, `/khala`, `/tassadar` were and remain served.

## Test changes

- `route.test.ts`: `/` -> LandingRoute; `/landing` -> LandingRoute (alias); `/pylons` -> PylonRoute; old `/pylon` -> NotFound.
- `main.test.ts`: root `/` visits (logged-out, incomplete-onboarding, authed, Core Team) render `Landing`; unknown-path redirect-to-home renders `Landing`; Pylon open/render tests use `/pylons`.
- `startup.test.ts`: NotFound/orElse fallbacks render `Landing`; Pylon-route policy assertions retained (Pylon still public).
- `worker-routes.test.ts`: Pylon document-route test uses `/pylons`.

## How each path resolves now

| Path | Resolves to |
|------|-------------|
| `/` | `LandingRoute` (Landing persistent scene + the two CTAs) |
| `/pylons` | `PylonRoute` (former root Pylon scene) |
| `/pylon` | `NotFound` (old alias removed) |
| `/landing` | `LandingRoute` (inbound alias) |
| `/khala` | `KhalaRoute` (unchanged) |
| `/tassadar` | `TassadarRoute` (unchanged) |
| `/run` | `RunRoute` (unchanged) |

## Verification

- `typecheck:web` + `typecheck:api`: pass.
- `vitest run` (web): `route.test.ts`, `main.test.ts`, `navigation-policy.test.ts`, `routing/startup.test.ts`, `page/loggedOut/update.test.ts`, persistentScene + landing.scene tests = 129 passed; full `src/page/loggedOut` = 37 passed.
- `vitest run` (api): `worker-routes.test.ts` + `worker-exact-routes.test.ts` = 17 passed.

**DO NOT auto-merge — orchestrator reviews/merges + deploys.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)