### PR TITLE
Wire approved Stripe Directory profile id into MPP Worker config (#6049)

### DIFF
--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -129,10 +129,13 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // (`/llms.txt`, `/agents.md`, `/ai.md`, `/skill.md`) are unconditional and do
   // NOT depend on this flag.
   KHALA_MPP_ENABLED?: string | undefined
-  // The Stripe network profile id (`profile_…`) enabling the card/SPT machine-
-  // payment rail for the MPP endpoint. Absent => the MPP endpoint is crypto-only
-  // (USDC via x402/MPP); the crypto rail does not need it. Worker secret; never
-  // committed/logged.
+  // The Stripe Directory network profile id (`profile_…`) enabling the card/SPT
+  // machine-payment rail for the MPP endpoint. Absent => the MPP endpoint is
+  // crypto-only (USDC via x402/MPP); the crypto rail does not need it. This is a
+  // PUBLIC directory identifier (how the public Stripe Directory references the
+  // business), so it ships as a committed Worker `var` in wrangler.jsonc — NOT a
+  // secret. It only NAMES the card rail; it never arms charges on its own (the
+  // endpoint stays inert until KHALA_MPP_ENABLED + a STRIPE_API_KEY secret).
   STRIPE_MPP_NETWORK_PROFILE_ID?: string | undefined
   // The Stripe SECRET API key (also used by the card-billing surface in
   // stripe-billing.ts via the structurally-compatible StripeBillingEnv). The MPP

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
@@ -263,6 +263,86 @@ describe('MPP endpoint — 402 challenge (no payment credential)', () => {
     )
     expect(problem.challenges[0]?.paymentIntentId).toBe('pi_quote_1')
   })
+
+  test('NO network profile id => crypto-only (no card/SPT challenge)', async () => {
+    const db = makeDb()
+    const fakeFetch: StripeFetch = async () =>
+      new Response(
+        JSON.stringify({
+          amount: 1,
+          currency: 'usd',
+          id: 'pi_quote_2',
+          next_action: {
+            crypto_display_details: {
+              addresses: [{ address: '0xabc', network: 'base' }],
+            },
+          },
+          status: 'requires_payment',
+        }),
+        { status: 200 },
+      )
+
+    const response = await run(
+      handleMppChatCompletions(mppRequest(), {
+        completionDeps: completionDeps(db),
+        db,
+        enabled: true,
+        fetch: fakeFetch,
+        newId: () => 'fixed',
+        // No stripeNetworkProfileId => card rail disabled.
+        stripeSecretKey: 'sk_test_x',
+      }),
+    )
+
+    expect(response.status).toBe(402)
+    const problem = (await response.json()) as {
+      challenges: Array<{ method: string }>
+    }
+    // Only the crypto challenge; no `method="stripe"` card challenge.
+    expect(problem.challenges.every(c => c.method !== 'stripe')).toBe(true)
+  })
+
+  test('WITH network profile id => adds the card/SPT (stripe) challenge', async () => {
+    const db = makeDb()
+    const fakeFetch: StripeFetch = async () =>
+      new Response(
+        JSON.stringify({
+          amount: 1,
+          currency: 'usd',
+          id: 'pi_quote_3',
+          next_action: {
+            crypto_display_details: {
+              addresses: [{ address: '0xabc', network: 'base' }],
+            },
+          },
+          status: 'requires_payment',
+        }),
+        { status: 200 },
+      )
+
+    const response = await run(
+      handleMppChatCompletions(mppRequest(), {
+        completionDeps: completionDeps(db),
+        db,
+        enabled: true,
+        fetch: fakeFetch,
+        newId: () => 'fixed',
+        stripeNetworkProfileId:
+          'profile_61Uug9ZHyJKTH8vxOA6Uug9Z3HSQjWfjZIUGSnTl27Xk',
+        stripeSecretKey: 'sk_test_x',
+      }),
+    )
+
+    expect(response.status).toBe(402)
+    const wwwAuth = response.headers.get('www-authenticate')
+    expect(wwwAuth).toContain('method="stripe"')
+    const problem = (await response.json()) as {
+      challenges: Array<{ method: string }>
+    }
+    // Both the crypto rail and the card/SPT (stripe) rail are advertised.
+    expect(problem.challenges.some(c => c.method === 'base')).toBe(true)
+    expect(problem.challenges.some(c => c.method === 'stripe')).toBe(true)
+  })
 })
 
 describe('MPP endpoint — valid credential serves + meters', () => {

--- a/apps/openagents.com/workers/api/wrangler.jsonc
+++ b/apps/openagents.com/workers/api/wrangler.jsonc
@@ -53,6 +53,15 @@
     "MDK_CHECKOUT_WEBHOOK_SOURCE": "sdk_node_control",
     "SHC_CONTROL_API_URL": "http://23.182.128.195.sslip.io/v1/codex-runs",
     "SHC_DISPATCH_MODE": "live",
+    // Approved Stripe Directory network profile id for the machine-payable Khala
+    // endpoint's card/SPT rail (EPIC #6049). This is a PUBLIC identifier — it is
+    // how the public Stripe Directory references "OpenAgents, Inc." — so it ships
+    // as a committed var, NOT a Worker secret. Staging it here ONLY references
+    // the profile; it does NOT arm the endpoint: the MPP route stays fail-safe
+    // inert until KHALA_MPP_ENABLED is on AND a STRIPE_API_KEY secret is present
+    // (neither is set here). A missing profile id would only disable the card
+    // rail; setting it does not enable charges on its own.
+    "STRIPE_MPP_NETWORK_PROFILE_ID": "profile_61Uug9ZHyJKTH8vxOA6Uug9Z3HSQjWfjZIUGSnTl27Xk",
   },
   "containers": [
     {


### PR DESCRIPTION
## What

Stages the **approved Stripe Directory network profile id** into the Worker config so the machine-payable Khala MPP endpoint (`/mpp/v1/chat/completions`, EPIC #6049) can reference it for the card / Shared Payment Token (SPT) rail. The OpenAgents profile was approved on the LIVE Stripe account ("OpenAgents, Inc.").

## How

- The route reads `env.STRIPE_MPP_NETWORK_PROFILE_ID` directly off the raw Worker env (the existing wiring at `workers/api/src/index.ts`), matching the sibling `STRIPE_API_KEY` convention — it is **not** routed through the decoded `OpenAgentsWorkerConfig` schema layer (neither Stripe field is).
- A directory `profile_…` id is a **PUBLIC** identifier (it is how the public Stripe Directory references the business), so it ships as a committed Worker `var` in `wrangler.jsonc` (production `vars`), **not** a secret. Also corrected the `config.ts` comment that previously mislabeled it as a Worker secret.
- Added unit tests: the card/SPT (`method="stripe"`) 402 challenge appears **only** when the profile id is configured; without it the endpoint stays crypto-only.

## Guardrails (held)

- `KHALA_MPP_ENABLED` stays **OFF** (unset everywhere) — endpoint not armed.
- **No** Stripe API key committed.
- **No** deploy.
- The endpoint remains **fail-safe inert**: with the flag off OR no `STRIPE_API_KEY`, it returns a clean "not configured" 503 and never constructs a charge. This only stages the public profile id for a later owner-gated flip.

## Verification

From a clean (non-`.worktrees`) checkout with this change applied: `bun run typecheck:api` and `bun run check:deploy` both green (contract-drift guard 5/5, web 205/205, api 69/69). The MPP route test suite passes 8/8 including the 2 new card-rail tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)