### PR TITLE
Fix MPP crypto deposit-address parser to Stripe's real shape (#6049)

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
@@ -225,7 +225,9 @@ describe('MPP endpoint — 402 challenge (no payment credential)', () => {
           id: 'pi_quote_1',
           next_action: {
             crypto_display_details: {
-              addresses: [{ address: '0xabc', network: 'base' }],
+              deposit_addresses: {
+                base: { address: '0xabc', supported_tokens: [] },
+              },
             },
           },
           status: 'requires_payment',
@@ -274,7 +276,9 @@ describe('MPP endpoint — 402 challenge (no payment credential)', () => {
           id: 'pi_quote_2',
           next_action: {
             crypto_display_details: {
-              addresses: [{ address: '0xabc', network: 'base' }],
+              deposit_addresses: {
+                base: { address: '0xabc', supported_tokens: [] },
+              },
             },
           },
           status: 'requires_payment',
@@ -312,7 +316,9 @@ describe('MPP endpoint — 402 challenge (no payment credential)', () => {
           id: 'pi_quote_3',
           next_action: {
             crypto_display_details: {
-              addresses: [{ address: '0xabc', network: 'base' }],
+              deposit_addresses: {
+                base: { address: '0xabc', supported_tokens: [] },
+              },
             },
           },
           status: 'requires_payment',

--- a/apps/openagents.com/workers/api/src/inference/mpp/stripe-mpp-client.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/stripe-mpp-client.test.ts
@@ -37,7 +37,13 @@ describe('stripe mpp client — form encoding', () => {
     expect(encoded).toContain(
       encodeURIComponent('payment_method_data[type]') + '=crypto',
     )
-    expect(encoded).not.toContain('payment_method_types')
+  })
+
+  test('encodes payment_method_types as a crypto array', () => {
+    const encoded = encodeStripeForm({ payment_method_types: ['crypto'] })
+    expect(encoded).toContain(
+      encodeURIComponent('payment_method_types[0]') + '=crypto',
+    )
   })
 })
 
@@ -55,11 +61,26 @@ describe('stripe mpp client — create crypto deposit PaymentIntent', () => {
           currency: 'usd',
           id: 'pi_test_1',
           next_action: {
+            // REAL Stripe deposit-mode shape: deposit_addresses is an object
+            // KEYED BY NETWORK NAME; the address lives under `.address`.
             crypto_display_details: {
-              addresses: [{ address: '0xabc', network: 'base' }],
+              deposit_addresses: {
+                base: {
+                  address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+                  supported_tokens: [{ token: 'usdc' }],
+                },
+                solana: {
+                  address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                  supported_tokens: [{ token: 'usdc' }],
+                },
+                tempo: {
+                  address: '0x20c000000000000000000000b9537d11c60e8b50',
+                  supported_tokens: [{ token: 'usdc' }],
+                },
+              },
             },
           },
-          status: 'requires_payment',
+          status: 'requires_action',
         }),
         { headers: { 'content-type': 'application/json' }, status: 200 },
       )
@@ -77,18 +98,37 @@ describe('stripe mpp client — create crypto deposit PaymentIntent', () => {
     )
 
     expect(created.id).toBe('pi_test_1')
-    expect(created.deposits).toEqual([{ address: '0xabc', network: 'base' }])
+    // Parser reads the network-keyed object and returns one entry per network.
+    expect(created.deposits).toEqual([
+      { address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', network: 'base' },
+      {
+        address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        network: 'solana',
+      },
+      {
+        address: '0x20c000000000000000000000b9537d11c60e8b50',
+        network: 'tempo',
+      },
+    ])
+    // The first deposit yields a usable recipient address for the 402 challenge
+    // (the bug was that the old array-shape parser returned []).
+    expect(created.deposits[0]?.address).toBe(
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    )
     // API version pinned + auth header set + idempotency key forwarded.
     const headers = new Headers(seen[0]?.init.headers)
     expect(headers.get('stripe-version')).toBe(STRIPE_MPP_API_VERSION)
     expect(headers.get('authorization')).toBe('Bearer sk_test_x')
     expect(headers.get('idempotency-key')).toBe('mpp:quote:abc')
-    // Body requests crypto deposit mode on the requested networks.
+    // Body requests crypto deposit mode on the requested networks, and sets
+    // payment_method_types=['crypto'] to match Stripe's official SDK samples.
     const body = String(seen[0]?.init.body)
     expect(body).toContain(
       encodeURIComponent('payment_method_data[type]') + '=crypto',
     )
-    expect(body).not.toContain('payment_method_types')
+    expect(body).toContain(
+      encodeURIComponent('payment_method_types[0]') + '=crypto',
+    )
   })
 
   test('fails on a Stripe error response', async () => {
@@ -151,5 +191,21 @@ describe('stripe mpp client — retrieve / verify settlement', () => {
     )
     expect(verified.settled).toBe(false)
     expect(verified.status).toBe('requires_payment_method')
+  })
+
+  test('does NOT treat requires_capture as settled in deposit mode', async () => {
+    const fakeFetch = async (): Promise<Response> =>
+      new Response(
+        JSON.stringify({ amount: 5, id: 'pi_3', status: 'requires_capture' }),
+        { status: 200 },
+      )
+    const verified = await run(
+      retrievePaymentIntent(
+        { fetch: fakeFetch, secretKey: 'sk_test_x' },
+        'pi_3',
+      ),
+    )
+    expect(verified.settled).toBe(false)
+    expect(verified.status).toBe('requires_capture')
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/stripe-mpp-client.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/stripe-mpp-client.ts
@@ -117,9 +117,13 @@ export type CreatedCryptoPaymentIntent = Readonly<{
 }>
 
 // Extract deposit addresses from a PaymentIntent's next_action crypto display
-// details. Stripe's deposit-mode crypto response nests the addresses under
-// `next_action.crypto_display_details` (per the MPP/x402 quickstarts). Shape is
-// read defensively.
+// details. Stripe's deposit-mode crypto response exposes
+// `next_action.crypto_display_details.deposit_addresses` as an OBJECT keyed by
+// network name, where each value carries the on-chain `address` (and a
+// `supported_tokens` list). The network is the KEY; there is no `network` field
+// on the value. See the MPP/x402 quickstarts and the deposit-mode stablecoin
+// guide (e.g. `deposit_addresses["base"].address`). This is the authoritative
+// shape; we add a cheap tolerant fallback for a single top-level address only.
 const extractDeposits = (
   intent: Record<string, unknown>,
 ): ReadonlyArray<CryptoDepositAddress> => {
@@ -128,26 +132,31 @@ const extractDeposits = (
     string,
     unknown
   >
-  const addresses = display.addresses
-  if (!Array.isArray(addresses)) {
-    // Some shapes expose a single address + network at the top of display.
-    const network = display.network
-    const address = display.address ?? display.deposit_address
-    if (typeof network === 'string' && typeof address === 'string') {
-      return [{ address, network }]
+  const depositAddresses = display.deposit_addresses
+  if (
+    depositAddresses !== null &&
+    typeof depositAddresses === 'object' &&
+    !Array.isArray(depositAddresses)
+  ) {
+    const out: Array<CryptoDepositAddress> = []
+    for (const [network, value] of Object.entries(
+      depositAddresses as Record<string, unknown>,
+    )) {
+      const entry = (value ?? {}) as Record<string, unknown>
+      const address = entry.address
+      if (typeof network === 'string' && typeof address === 'string') {
+        out.push({ address, network })
+      }
     }
-    return []
+    return out
   }
-  return addresses
-    .map(entry => {
-      const e = entry as Record<string, unknown>
-      const network = e.network
-      const address = e.address ?? e.deposit_address
-      return typeof network === 'string' && typeof address === 'string'
-        ? ({ address, network } satisfies CryptoDepositAddress)
-        : undefined
-    })
-    .filter((v): v is CryptoDepositAddress => v !== undefined)
+  // Cheap tolerant fallback: a single address + network at the top of display.
+  const network = display.network
+  const address = display.address ?? display.deposit_address
+  if (typeof network === 'string' && typeof address === 'string') {
+    return [{ address, network }]
+  }
+  return []
 }
 
 // Create a crypto deposit-mode PaymentIntent for the given amount + networks and
@@ -172,6 +181,9 @@ export const createCryptoDepositPaymentIntent = (
       currency,
       ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
       payment_method_data: { type: 'crypto' },
+      // Stripe's official MPP/x402 SDK samples set this alongside
+      // payment_method_data[type]=crypto for deposit-mode crypto PaymentIntents.
+      payment_method_types: ['crypto'],
       payment_method_options: {
         crypto: {
           deposit_options: { networks: input.networks },
@@ -240,11 +252,11 @@ export type RetrievedPaymentIntent = Readonly<{
   metadata: Record<string, string>
 }>
 
-// Retrieve a PaymentIntent to check it has settled. A `succeeded` status (or
-// `requires_capture` after an authorize, which we treat as settled for the
-// deposit flow) means the agent has paid and we may serve. Anything else
-// (`requires_payment_method`, `processing`, `requires_action`) is NOT settled —
-// a domain outcome, not an error.
+// Retrieve a PaymentIntent to check it has settled. In deposit mode Stripe
+// auto-captures the PaymentIntent after the on-chain funds settle, so a
+// `succeeded` status is the only settled state — it means the agent has paid
+// and we may serve. Anything else (`requires_payment_method`, `processing`,
+// `requires_action`, etc.) is NOT settled — a domain outcome, not an error.
 export const retrievePaymentIntent = (
   deps: StripeMppClientDeps,
   paymentIntentId: string,
@@ -283,7 +295,7 @@ export const retrievePaymentIntent = (
     }
 
     const status = typeof json.status === 'string' ? json.status : 'unknown'
-    const settled = status === 'succeeded' || status === 'requires_capture'
+    const settled = status === 'succeeded'
     const rawMeta = (json.metadata ?? {}) as Record<string, unknown>
     const metadata: Record<string, string> = {}
     for (const [k, v] of Object.entries(rawMeta)) {


### PR DESCRIPTION
Fixes the safe, well-specified correctness defects in the MPP crypto client found in the read-only audit (issue #6049). Scoped to the MPP client + its tests (plus a test-data-only fixture correction in the route test so the suite lands green). The MPP endpoint stays INERT — no flag, key, arming, or deploy changes.

## Fixes
1. **Deposit-address parser (critical).** Stripe's deposit-mode crypto PaymentIntent returns `next_action.crypto_display_details.deposit_addresses` as an **object keyed by network name** (`deposit_addresses["base"].address`), not an `addresses` array. The old parser read the array form and returned `[]` against the real shape, so the 402 challenge had no recipient. `extractDeposits` now reads the network-keyed object and returns the same `{ network, address }[]` the route consumes; keeps a cheap tolerant single-address fallback.
2. **`requires_capture` (minor).** Deposit mode auto-captures after on-chain settlement, so settlement is judged by `status === 'succeeded'` only. Removed `requires_capture` from the settled condition.
3. **`payment_method_types` (minor).** Added `payment_method_types: ['crypto']` to the create body to match Stripe's official SDK samples.

## Verified shape (authoritative Stripe sources)
- MPP quickstart (Node): `depositDetails.deposit_addresses["tempo"].address`
- x402 quickstart (Python): `deposit_addresses.get("base", {}); base_address.get("address")`
- Deposit-mode stablecoin guide: `crypto_display_details` in `next_action` "contains deposit addresses and `supported_tokens` for each network."

## Out of scope (defect B, left open)
The mpp.dev signed-credential / settlement (verify) model remains open pending an architecture decision (a Node MPP sidecar for bit-compatible challenge signing). Not addressed here.

## Verify
- `bun run typecheck:api` green
- MPP suite: 29/29 pass
- `bun run check:deploy`: EXIT 0 (contract-drift test's "FAILED" lines are its own injected fixtures; the test file passes 5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)