### PR TITLE
Autopilot onboarding: reuse the shared persistent 3D scene with an /autopilot camera pose

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/persistentScene.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/persistentScene.test.ts
@@ -9,6 +9,7 @@ import {
   PERSISTENT_SCENE_KEY,
   PERSISTENT_SCENE_OVERLAY_PREFIX,
   PERSISTENT_SCENE_SHELL_KEY,
+  poseForRoute,
   view as persistentSceneView,
 } from './persistentScene'
 import { view as khalaView } from './khala'
@@ -118,6 +119,69 @@ describe('persistent landing and Khala scene', () => {
     expect(landingCanvas?.key).toBe(tassadarCanvas?.key)
     expect(
       hasSelector(tassadarCanvas as SnabbVNode, 'oa-landing-squares'),
+    ).toBe(true)
+  })
+
+  test('maps each route to its distinct, non-blank camera pose', () => {
+    expect(poseForRoute('Landing')).toBe('landing')
+    expect(poseForRoute('Khala')).toBe('khala')
+    expect(poseForRoute('Tassadar')).toBe('tassadar')
+    // The /autopilot onboarding route reuses the SAME persistent scene with
+    // its own camera pose (#6125).
+    expect(poseForRoute('Autopilot')).toBe('autopilot')
+
+    const poses = (
+      ['Landing', 'Khala', 'Tassadar', 'Autopilot'] as const
+    ).map(poseForRoute)
+    expect(new Set(poses).size).toBe(poses.length)
+    for (const pose of poses) {
+      expect(pose.trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  test('hosts the Autopilot pose on the same persistent canvas (no second scene)', () => {
+    const landing = persistentSceneView('Landing') as SnabbVNode
+    const autopilot = persistentSceneView('Autopilot') as SnabbVNode
+
+    const landingCanvas = findByKey(landing, PERSISTENT_SCENE_KEY)
+    const autopilotCanvas = findByKey(autopilot, PERSISTENT_SCENE_KEY)
+
+    expect(landingCanvas).toBeDefined()
+    expect(autopilotCanvas).toBeDefined()
+    // Same keyed canvas wrapper => one persistent scene instance, not two.
+    expect(landingCanvas?.sel).toBe(autopilotCanvas?.sel)
+    expect(landingCanvas?.key).toBe(autopilotCanvas?.key)
+    expect(
+      hasSelector(autopilotCanvas as SnabbVNode, 'oa-landing-squares'),
+    ).toBe(true)
+
+    // Only the overlay key differs between routes; every other key is stable.
+    const stableKeys = (keys: ReadonlyArray<string>): ReadonlyArray<string> =>
+      keys.filter(k => !k.startsWith(PERSISTENT_SCENE_OVERLAY_PREFIX))
+    expect(stableKeys(allKeys(landing))).toEqual(stableKeys(allKeys(autopilot)))
+  })
+
+  test('passes the autopilot pose + overlay through the shared shell', () => {
+    // The /autopilot route wiring lands in #6124/#6129; here we verify the
+    // persistentScene mapping SUPPORTS the Autopilot pose directly off the view.
+    const autopilot = persistentSceneView('Autopilot') as SnabbVNode
+
+    const hasAttr = (root: SnabbVNode, attr: string, value: string): boolean => {
+      let present = false
+      walk(root, n => {
+        const data = (n as { data?: { attrs?: Record<string, unknown> } }).data
+        if (data?.attrs?.[attr] === value) {
+          present = true
+        }
+      })
+      return present
+    }
+
+    expect(hasSelector(autopilot, 'oa-landing-squares')).toBe(true)
+    expect(hasAttr(autopilot, 'data-pose', 'autopilot')).toBe(true)
+    expect(hasAttr(autopilot, 'data-route', 'autopilot')).toBe(true)
+    expect(
+      hasAttr(autopilot, 'data-persistent-scene-overlay', 'autopilot'),
     ).toBe(true)
   })
 

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/persistentScene.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/persistentScene.ts
@@ -12,13 +12,25 @@ export const PERSISTENT_SCENE_KEY = 'persistent-landing-scene'
 export const PERSISTENT_SCENE_SHELL_KEY = 'persistent-scene-shell'
 export const PERSISTENT_SCENE_OVERLAY_PREFIX = 'persistent-scene-overlay:'
 
-export type PersistentSceneRoute = 'Landing' | 'Khala' | 'Tassadar'
+export type PersistentSceneRoute =
+  | 'Landing'
+  | 'Khala'
+  | 'Tassadar'
+  | 'Autopilot'
 
 // Active route -> camera pose. The canvas node is keyed the same across
-// /landing <-> /khala <-> /tassadar so it persists; only this attribute
-// changes, and the element eases the camera to the new pose (continuous flight).
-const poseForRoute = (route: PersistentSceneRoute): string =>
-  route === 'Khala' ? 'khala' : route === 'Tassadar' ? 'tassadar' : 'landing'
+// /landing <-> /khala <-> /tassadar <-> /autopilot so the ONE scene instance
+// persists; only this attribute changes, and the element eases the camera to
+// the new pose (continuous flight). /autopilot reuses the same keyed canvas
+// with its own onboarding `autopilot` vantage — no second scene is created.
+export const poseForRoute = (route: PersistentSceneRoute): string =>
+  route === 'Khala'
+    ? 'khala'
+    : route === 'Tassadar'
+      ? 'tassadar'
+      : route === 'Autopilot'
+        ? 'autopilot'
+        : 'landing'
 
 const persistentCanvasLayer = (
   h: ReturnType<typeof html<Message>>,
@@ -119,6 +131,32 @@ const tassadarOverlay = (
     [tassadarView(copiedAgentInstructions)],
   )
 
+// Minimal onboarding overlay for the shared persistent scene at the `autopilot`
+// pose. The full /autopilot onboarding UI + route wiring lands in #6124/#6129;
+// this placeholder only proves the SAME keyed canvas hosts an `Autopilot` pose
+// (no second scene instance). It reuses the shared khala-* glow utilities (see
+// styles.css) so any CTA energy matches the rest of the scene.
+const autopilotOverlay = (h: ReturnType<typeof html<Message>>): Html =>
+  h.div(
+    [
+      h.DataAttribute('persistent-scene-overlay', 'autopilot'),
+      Ui.className<Message>(
+        'pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-6 px-6',
+      ),
+    ],
+    [
+      h.div(
+        [
+          h.DataAttribute('autopilot-glow', 'energy'),
+          Ui.className<Message>(
+            'khala-glow select-none text-center font-semibold text-white text-4xl sm:text-6xl',
+          ),
+        ],
+        ['Autopilot'],
+      ),
+    ],
+  )
+
 const overlayForRoute = (
   h: ReturnType<typeof html<Message>>,
   route: PersistentSceneRoute,
@@ -128,7 +166,9 @@ const overlayForRoute = (
     ? landingOverlay(h)
     : route === 'Tassadar'
       ? tassadarOverlay(h, copiedAgentInstructions)
-      : khalaOverlay(h)
+      : route === 'Autopilot'
+        ? autopilotOverlay(h)
+        : khalaOverlay(h)
 
 export const view = (
   route: PersistentSceneRoute,

--- a/apps/openagents.com/apps/web/src/scene/landingSquares.pose.test.ts
+++ b/apps/openagents.com/apps/web/src/scene/landingSquares.pose.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest'
+
+import type { LandingPose } from './landingSquares'
+import { POSES } from './landingSquares'
+
+// The persistent landing-squares scene is ONE instance with named camera poses;
+// navigating between routes only eases the camera to a new pose. This guards the
+// pose table: every route's pose must be defined, non-degenerate, and distinct,
+// including the /autopilot onboarding vantage added in #6125.
+describe('landing squares camera poses', () => {
+  const allPoses: ReadonlyArray<LandingPose> = [
+    'landing',
+    'khala',
+    'tassadar',
+    'autopilot',
+  ]
+
+  test('defines a distinct, non-blank pose for every route', () => {
+    for (const name of allPoses) {
+      const pose = POSES[name]
+      expect(pose).toBeDefined()
+      // Position and target must not be the zero/zero degenerate (a "blank" pose
+      // would put the camera at the origin looking at the origin).
+      expect(pose.pos.lengthSq() + pose.target.lengthSq()).toBeGreaterThan(0)
+    }
+
+    // No two routes may share the same camera position (each is its own vantage).
+    const positions = allPoses.map(name => {
+      const p = POSES[name].pos
+      return `${p.x},${p.y},${p.z}`
+    })
+    expect(new Set(positions).size).toBe(positions.length)
+  })
+
+  test('autopilot is a fresh vantage, not an alias of an existing pose', () => {
+    const autopilot = POSES.autopilot
+    expect(autopilot).toBeDefined()
+    expect(autopilot.pos.lengthSq()).toBeGreaterThan(0)
+
+    for (const other of ['landing', 'khala', 'tassadar'] as const) {
+      expect(autopilot.pos.equals(POSES[other].pos)).toBe(false)
+    }
+  })
+})

--- a/apps/openagents.com/apps/web/src/scene/landingSquares.ts
+++ b/apps/openagents.com/apps/web/src/scene/landingSquares.ts
@@ -20,7 +20,7 @@ import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPa
 // (three-effect #16 / openagents #6068) without pulling the full Foldkit/three
 // scene host for this raw background.
 
-export type LandingPose = 'landing' | 'khala' | 'tassadar'
+export type LandingPose = 'landing' | 'khala' | 'tassadar' | 'autopilot'
 
 const BACKGROUND_COLOR = 0x000000
 // A tasteful cool blue, driven above 1.0 (HDR) so the cores survive the bloom
@@ -37,21 +37,32 @@ const NEIGHBORS = 2 // connections per pylon
 // `tassadar` flies the camera up and across to a third, distinct vantage —
 // looking down the network from above-left — so entering /tassadar is another
 // continuous move through the same space, not a cut.
-const POSES: Record<LandingPose, { pos: Three.Vector3; target: Three.Vector3 }> =
-  {
-    landing: {
-      pos: new Three.Vector3(0, 1.2, 19),
-      target: new Three.Vector3(0, 0, 0),
-    },
-    khala: {
-      pos: new Three.Vector3(9.5, -2.6, 8.5),
-      target: new Three.Vector3(2.6, -0.6, -2.2),
-    },
-    tassadar: {
-      pos: new Three.Vector3(-8.5, 6.2, 11),
-      target: new Three.Vector3(-1.4, 1.1, -2),
-    },
-  }
+// `autopilot` is the onboarding vantage: the camera drops low and pushes in
+// close from below-right, banking up into the heart of the constellation so
+// the pylons loom overhead. It reads as arriving inside the network (you are
+// now flying it), distinct from every other pose — closer and more immersive
+// than `landing`, and on the opposite side from `tassadar`'s above-left view.
+export const POSES: Record<
+  LandingPose,
+  { pos: Three.Vector3; target: Three.Vector3 }
+> = {
+  landing: {
+    pos: new Three.Vector3(0, 1.2, 19),
+    target: new Three.Vector3(0, 0, 0),
+  },
+  khala: {
+    pos: new Three.Vector3(9.5, -2.6, 8.5),
+    target: new Three.Vector3(2.6, -0.6, -2.2),
+  },
+  tassadar: {
+    pos: new Three.Vector3(-8.5, 6.2, 11),
+    target: new Three.Vector3(-1.4, 1.1, -2),
+  },
+  autopilot: {
+    pos: new Three.Vector3(5.5, -4.5, 6.0),
+    target: new Three.Vector3(0.4, 1.6, -3.2),
+  },
+}
 
 // Deterministic hash in [0, 1) so pylon placement + the glow subset stay stable
 // across reloads (no Math.random flicker).

--- a/apps/openagents.com/apps/web/src/scene/landingSquaresElement.ts
+++ b/apps/openagents.com/apps/web/src/scene/landingSquaresElement.ts
@@ -22,7 +22,13 @@ export const landingSquaresTagName = 'oa-landing-squares'
 const POSE_ATTRIBUTE = 'data-pose'
 
 const parsePose = (value: string | null): LandingPose =>
-  value === 'khala' ? 'khala' : value === 'tassadar' ? 'tassadar' : 'landing'
+  value === 'khala'
+    ? 'khala'
+    : value === 'tassadar'
+      ? 'tassadar'
+      : value === 'autopilot'
+        ? 'autopilot'
+        : 'landing'
 
 const landingSquaresElement = defineCustomElement({
   events: {},


### PR DESCRIPTION
Closes #6125. Part of #6123.

Adds a fourth named camera pose (`autopilot`) to the ONE persistent landing-squares pylon scene instead of creating a second scene instance. The single keyed canvas already persists across /landing <-> /khala <-> /tassadar; only the camera pose changes per route, easing between poses for continuous flight. This makes the scene + persistentScene mapping SUPPORT an `Autopilot` pose, testable in isolation. The actual /autopilot route wiring + onboarding UI land in #6124/#6129.

## Changes
- `scene/landingSquares.ts`: add the `autopilot` `LandingPose` and a distinct onboarding vantage (camera low, pushed in from below-right, banking up into the network so the pylons loom overhead — reads as arriving *inside* the network). Export the `POSES` table for testing. Choice documented in a comment.
- `scene/landingSquaresElement.ts`: parse the `autopilot` `data-pose` value.
- `page/loggedOut/page/persistentScene.ts`: add `'Autopilot'` to `PersistentSceneRoute`, export + extend `poseForRoute`, and route it to a minimal onboarding overlay (reusing the shared `khala-*` glow utilities) hosted on the SAME keyed canvas — no second scene.

## Verification
- `bun run typecheck:web` — pass
- Scene tests (persistentScene, landing.scene, new landingSquares.pose) — 14 passed
- `bun run check:deploy` — exit 0 (the contract-drift-guard stderr lines are intentional seeded fixtures the guard test detects; that test passes and is unrelated to this scene change)

## Acceptance
- `poseForRoute('Autopilot')` yields `'autopilot'` (distinct, non-blank).
- The persistent canvas hosts the autopilot route on the same keyed node (asserted: same canvas sel/key, stable keys except the overlay key) — no second scene instance.
- New/extended scene tests assert a non-blank, distinct `autopilot` pose consistent with the existing landing/khala/tassadar scene tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)