### PR TITLE
Add Autopilot onboarding route shape

### DIFF
--- a/apps/openagents.com/apps/web/src/main.test.ts
+++ b/apps/openagents.com/apps/web/src/main.test.ts
@@ -523,6 +523,19 @@ describe('authenticated startup routing', () => {
     expect(commands).toHaveLength(0)
   })
 
+  test('keeps logged-out Autopilot vertical visits on onboarding', () => {
+    const [model, commands] = init(
+      Flags.make({ maybeAuth: Option.none() }),
+      appUrl('/autopilot/legal'),
+    )
+
+    expect(model).toMatchObject({
+      _tag: 'LoggedOut',
+      route: { _tag: 'AutopilotOnboarding', vertical: 'legal' },
+    })
+    expect(commands).toHaveLength(0)
+  })
+
   test('redirects complete authenticated onboarding visits to order status', () => {
     const [model, commands] = init(
       Flags.make({ maybeAuth: Option.some(authWithTeam) }),
@@ -863,6 +876,19 @@ describe('authenticated startup routing', () => {
       href: '/api/sync/workspace/github%3A14167547/snapshot',
       scope: 'workspace:github:14167547',
     })
+  })
+
+  test('keeps signed-in visitors without a workspace on Autopilot onboarding', () => {
+    const [model, commands] = init(
+      Flags.make({ maybeAuth: Option.some(authWithoutCoreTeam) }),
+      appUrl('/autopilot/legal'),
+    )
+
+    expect(model).toMatchObject({
+      _tag: 'LoggedOut',
+      route: { _tag: 'AutopilotOnboarding', vertical: 'legal' },
+    })
+    expect(commands).toHaveLength(0)
   })
 
   test('does not expose the deprecated dashboard route', () => {

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding.ts
@@ -1,0 +1,107 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import type { AutopilotOnboardingRoute } from '../route'
+import * as Ui from '../ui'
+import type { PublicHeaderAuthState } from './publicHeader'
+import * as PublicHeader from './publicHeader'
+
+const pageShellClass = 'min-h-dvh overflow-auto bg-[#000] text-[#f1efe8]'
+
+const verticalLabel = (vertical: string | null): string =>
+  vertical === null
+    ? 'General workspace'
+    : vertical
+        .split('-')
+        .filter(part => part.length > 0)
+        .map(part => part[0]!.toUpperCase() + part.slice(1))
+        .join(' ')
+
+export const view = <Message>(
+  route: AutopilotOnboardingRoute,
+  authState: PublicHeaderAuthState<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      h.DataAttribute('route', 'autopilot-onboarding'),
+      h.DataAttribute('autopilot-vertical', route.vertical ?? 'general'),
+      Ui.className<Message>(pageShellClass),
+    ],
+    [
+      PublicHeader.view(authState),
+      h.main(
+        [
+          Ui.className<Message>(
+            'mx-auto grid min-h-[calc(100dvh-4rem)] w-[min(100%,72rem)] content-center gap-8 px-4 py-14 sm:px-6 lg:px-8',
+          ),
+        ],
+        [
+          h.section(
+            [Ui.className<Message>('max-w-3xl')],
+            [
+              h.p(
+                [
+                  Ui.className<Message>(
+                    'm-0 text-xs font-semibold uppercase tracking-[0.08em] text-white/45',
+                  ),
+                ],
+                ['OpenAgents Autopilot'],
+              ),
+              h.h1(
+                [
+                  Ui.className<Message>(
+                    'm-0 mt-7 max-w-[13ch] text-balance text-5xl font-semibold leading-none text-white/90 sm:text-6xl lg:text-7xl',
+                  ),
+                ],
+                ['Put Your Work On Autopilot'],
+              ),
+              h.p(
+                [
+                  Ui.className<Message>(
+                    'm-0 mt-7 max-w-[48ch] text-base leading-7 text-white/60 sm:text-lg sm:leading-8',
+                  ),
+                ],
+                [
+                  'Start with a narrow workspace, a real task, and reviewable evidence before anything expands.',
+                ],
+              ),
+              h.div(
+                [
+                  Ui.className<Message>(
+                    'mt-8 inline-flex border border-white/15 bg-white/[0.04] px-3 py-2 text-sm text-white/70',
+                  ),
+                ],
+                [verticalLabel(route.vertical)],
+              ),
+              h.div(
+                [Ui.className<Message>('mt-9 flex flex-wrap gap-3')],
+                [
+                  h.a(
+                    [
+                      h.Href('/login/github'),
+                      Ui.className<Message>(
+                        'inline-grid min-h-11 place-items-center border border-[#f1efe8] bg-[#f1efe8] px-4 text-sm font-medium text-black no-underline hover:border-[#ffb400]',
+                      ),
+                    ],
+                    ['Log in with GitHub'],
+                  ),
+                  h.a(
+                    [
+                      h.Href('/business'),
+                      Ui.className<Message>(
+                        'inline-grid min-h-11 place-items-center border border-white/20 px-4 text-sm font-medium text-white/75 no-underline hover:border-[#ffb400] hover:text-white',
+                      ),
+                    ],
+                    ['See business options'],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  )
+}

--- a/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
@@ -8,6 +8,7 @@ import { homeRouter } from '../../route'
 import * as Ui from '../../ui'
 import * as Activity from '../activity'
 import * as Animations from '../animations'
+import * as AutopilotOnboarding from '../autopilot-onboarding'
 import * as Blog from '../blog'
 import * as Business from '../business'
 import * as ClientsPreview from '../clientsPreview'
@@ -113,6 +114,8 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
                   settledFeed: model.settledFeed,
                 }),
               Invite: () => notFoundView('/invite', homeRouter(), 'Go Home'),
+              AutopilotOnboarding: route =>
+                AutopilotOnboarding.view(route, { _tag: 'LoggedOut' }),
               Onboarding: () => Onboarding.view(model.onboarding),
               Docs: route => Docs.view(route, { _tag: 'LoggedOut' }),
               DocsPage: route => Docs.view(route, { _tag: 'LoggedOut' }),

--- a/apps/openagents.com/apps/web/src/product-policy.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.ts
@@ -195,6 +195,7 @@ export const routeRequiresAuthBootstrap = (route: AppRoute): boolean =>
 
 export const browserRouteProductIntents = {
   Admin: 'admin.overview',
+  AutopilotOnboarding: 'autopilot.onboarding',
   AutopilotWork: 'autopilot.work.index',
   AutopilotWorkDetail: 'autopilot.work.detail',
   Billing: 'billing.credits',

--- a/apps/openagents.com/apps/web/src/route.test.ts
+++ b/apps/openagents.com/apps/web/src/route.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, test } from 'vitest'
 
 import {
   AdminRoute,
+  AutopilotOnboardingRoute,
   AutopilotWorkDetailRoute,
   AutopilotWorkRoute,
-  ChatRoute,
   Demo2OrderRoute,
   Demo2Route,
   Demo2TeamFileRoute,
@@ -65,8 +65,16 @@ describe('app route parser', () => {
     )
   })
 
-  test('accepts the operator Autopilot shell route', () => {
-    expect(urlToAppRoute(appUrl('/autopilot'))).toEqual(ChatRoute())
+  test('accepts Autopilot onboarding routes with an optional vertical segment', () => {
+    expect(urlToAppRoute(appUrl('/autopilot'))).toEqual(
+      AutopilotOnboardingRoute({ vertical: null }),
+    )
+    expect(urlToAppRoute(appUrl('/autopilot/legal'))).toEqual(
+      AutopilotOnboardingRoute({ vertical: 'legal' }),
+    )
+    expect(urlToAppRoute(appUrl('/autopilot/Legal'))).toEqual(
+      NotFoundRoute({ path: '/autopilot/Legal' }),
+    )
   })
 
   test('accepts Autopilot work visibility routes', () => {

--- a/apps/openagents.com/apps/web/src/route.ts
+++ b/apps/openagents.com/apps/web/src/route.ts
@@ -1,4 +1,4 @@
-import { Schema as S, pipe } from 'effect'
+import { Effect, Schema as S, pipe } from 'effect'
 import { Route } from 'foldkit'
 import { literal, r, slash, string } from 'foldkit/route'
 import type { Url } from 'foldkit/url'
@@ -8,6 +8,9 @@ export const InviteRoute = r('Invite')
 export const OnboardingRoute = r('Onboarding')
 export const OrderRoute = r('Order')
 export const OrderDetailRoute = r('OrderDetail', { orderId: S.String })
+export const AutopilotOnboardingRoute = r('AutopilotOnboarding', {
+  vertical: S.NullOr(S.String),
+})
 export const AutopilotWorkRoute = r('AutopilotWork')
 export const AutopilotWorkDetailRoute = r('AutopilotWorkDetail', {
   workOrderRef: S.String,
@@ -116,6 +119,7 @@ export type InviteRoute = typeof InviteRoute.Type
 export type OnboardingRoute = typeof OnboardingRoute.Type
 export type OrderRoute = typeof OrderRoute.Type
 export type OrderDetailRoute = typeof OrderDetailRoute.Type
+export type AutopilotOnboardingRoute = typeof AutopilotOnboardingRoute.Type
 export type AutopilotWorkRoute = typeof AutopilotWorkRoute.Type
 export type AutopilotWorkDetailRoute = typeof AutopilotWorkDetailRoute.Type
 export type ForgeRoute = typeof ForgeRoute.Type
@@ -195,6 +199,7 @@ export const LoggedOutRoute = S.Union([
   PublicStatsArchiveRoute,
   InviteRoute,
   OnboardingRoute,
+  AutopilotOnboardingRoute,
   DocsRoute,
   DocsPageRoute,
   ProductPromisesRoute,
@@ -292,6 +297,7 @@ export const AppRoute = S.Union([
   OnboardingRoute,
   OrderRoute,
   OrderDetailRoute,
+  AutopilotOnboardingRoute,
   AutopilotWorkRoute,
   AutopilotWorkDetailRoute,
   ForgeRoute,
@@ -384,6 +390,60 @@ export const orderDetailRouter = pipe(
   literal('orders'),
   slash(string('orderId')),
   Route.mapTo(OrderDetailRoute),
+)
+const autopilotVerticalPattern = /^[a-z0-9-]+$/
+const autopilotOnboardingHref = (
+  value: Omit<AutopilotOnboardingRoute, '_tag'>,
+): string =>
+  value.vertical === null ? '/autopilot' : `/autopilot/${value.vertical}`
+export const autopilotOnboardingRouter = Object.assign(
+  (value: Omit<AutopilotOnboardingRoute, '_tag'>): string =>
+    autopilotOnboardingHref(value),
+  {
+    build: (value: Omit<AutopilotOnboardingRoute, '_tag'>): string =>
+      autopilotOnboardingHref(value),
+    parse: (
+      segments: ReadonlyArray<string>,
+    ): Effect.Effect<
+      Route.ParseResult<AutopilotOnboardingRoute>,
+      Route.ParseError
+    > => {
+      if (segments[0] !== 'autopilot') {
+        return Effect.fail(
+          new Route.ParseError({
+            actual: segments[0] ?? 'end of path',
+            expected: 'autopilot',
+            message: "Expected 'autopilot'",
+            position: 0,
+          }),
+        )
+      }
+
+      const vertical = segments[1]
+      if (vertical === undefined) {
+        return Effect.succeed([
+          AutopilotOnboardingRoute({ vertical: null }),
+          [],
+        ])
+      }
+
+      if (!autopilotVerticalPattern.test(vertical)) {
+        return Effect.fail(
+          new Route.ParseError({
+            actual: vertical,
+            expected: 'lowercase autopilot vertical segment',
+            message: 'Expected lowercase autopilot vertical segment',
+            position: 1,
+          }),
+        )
+      }
+
+      return Effect.succeed([
+        AutopilotOnboardingRoute({ vertical }),
+        segments.slice(2),
+      ])
+    },
+  },
 )
 export const autopilotWorkRouter = pipe(
   literal('autopilot'),
@@ -722,6 +782,7 @@ const routeParser = Route.oneOf(
   onboardingRouter,
   autopilotWorkDetailRouter,
   autopilotWorkRouter,
+  autopilotOnboardingRouter,
   forgeRouter,
   decisionsRouter,
   workspaceRouter,

--- a/apps/openagents.com/apps/web/src/routing/startup.test.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.test.ts
@@ -7,6 +7,7 @@ import {
   incompleteOnboardingStatus,
 } from '../domain/session'
 import {
+  AutopilotOnboardingRoute,
   AutopilotWorkRoute,
   ChatRoute,
   Demo2OrderRoute,
@@ -370,6 +371,26 @@ describe('startup route policy', () => {
     })
   })
 
+  test('routes Autopilot onboarding by workspace access', () => {
+    const route = AutopilotOnboardingRoute({ vertical: 'legal' })
+
+    expect(startupRouteForLoggedOut(route)).toEqual({
+      _tag: 'LoggedOutStartupRoute',
+      redirect: Option.none(),
+      route,
+    })
+    expect(startupRouteForLoggedIn(route, completeAuth)).toEqual({
+      _tag: 'LoggedInStartupRoute',
+      redirect: Option.none(),
+      route: { _tag: 'Chat' },
+    })
+    expect(startupRouteForLoggedIn(route, auth)).toEqual({
+      _tag: 'LoggedOutStartupRoute',
+      redirect: Option.none(),
+      route,
+    })
+  })
+
   test('routes authenticated visitors without Core Team access to order status', () => {
     expect(startupRouteForLoggedIn(HomeRoute(), auth)).toEqual({
       _tag: 'LoggedInStartupRoute',
@@ -576,6 +597,11 @@ describe('startup route policy', () => {
     expect(routeRequiresAuthBootstrap(InviteRoute())).toBe(true)
     expect(routeRequiresAuthBootstrap(OnboardingRoute())).toBe(true)
     expect(routeRequiresAuthBootstrap(OrderRoute())).toBe(true)
+    expect(
+      routeRequiresAuthBootstrap(
+        AutopilotOnboardingRoute({ vertical: 'legal' }),
+      ),
+    ).toBe(true)
     expect(routeRequiresAuthBootstrap(AutopilotWorkRoute())).toBe(true)
     expect(routeRequiresAuthBootstrap(MulletRoute())).toBe(true)
     expect(

--- a/apps/openagents.com/apps/web/src/routing/startup.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.ts
@@ -6,11 +6,13 @@ import {
   browserRouteGate,
   defaultLoggedInHrefForAuth,
   defaultLoggedInRouteForAuth,
+  loggedInWorkroomAllowed,
   loggedInPermissionGate,
   routeAllowedForLoggedInAuth,
 } from '../product-policy'
 import {
   type AppRoute,
+  ChatRoute,
   InviteRoute,
   LandingRoute,
   LoggedInRoute,
@@ -78,6 +80,7 @@ export const startupRouteForLoggedOut = (
     M.tag(
       'Docs',
       'DocsPage',
+      'AutopilotOnboarding',
       'ProductPromises',
       'PublicTrainingRuns',
       'PublicTrainingRun',
@@ -152,6 +155,7 @@ const startupRouteForIncompleteOnboarding = (route: AppRoute): StartupRoute =>
     M.tag(
       'PublicAgent',
       'ProductPromises',
+      'AutopilotOnboarding',
       'PublicStatsArchive',
       'Share',
       'Moksha',
@@ -244,6 +248,17 @@ const startupRouteForCompleteOnboarding = (
           }),
         ),
       }),
+    ),
+    M.tag('AutopilotOnboarding', route =>
+      loggedInWorkroomAllowed(auth)
+        ? LoggedInStartupRoute({
+            route: ChatRoute(),
+            redirect: Option.none(),
+          })
+        : LoggedOutStartupRoute({
+            route,
+            redirect: Option.none(),
+          }),
     ),
     M.tag(
       'PublicAgent',

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -65,6 +65,27 @@ describe('Worker document route fallback', () => {
     ).toBe(false)
   })
 
+  test('keeps Autopilot onboarding document routes in the app shell', () => {
+    expect(
+      shouldRedirectUnknownDocumentToHome(
+        requestFor('/autopilot'),
+        '/autopilot',
+      ),
+    ).toBe(false)
+    expect(
+      shouldRedirectUnknownDocumentToHome(
+        requestFor('/autopilot/legal'),
+        '/autopilot/legal',
+      ),
+    ).toBe(false)
+    expect(
+      shouldRedirectUnknownDocumentToHome(
+        requestFor('/autopilot/legal/intake'),
+        '/autopilot/legal/intake',
+      ),
+    ).toBe(true)
+  })
+
   test('keeps the Moksha document route in the app shell', () => {
     expect(
       shouldRedirectUnknownDocumentToHome(requestFor('/moksha'), '/moksha'),

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -105,7 +105,7 @@ const knownDocumentPathPatterns: ReadonlyArray<RegExp> = [
   /^\/admin$/,
   /^\/agents\/[^/]+$/,
   /^\/artanis$/,
-  /^\/autopilot$/,
+  /^\/autopilot(?:\/[a-z0-9-]+)?$/,
   /^\/billing$/,
   /^\/blog(?:\/[^/]+)?$/,
   /^\/business$/,


### PR DESCRIPTION
Refs #6124.

Problem:
- /autopilot was parsed directly as the operator cockpit, and the Worker document allowlist only served the bare /autopilot path.
- /autopilot/<vertical> direct loads were treated as unknown document paths instead of reaching the SPA shell.

What changed:
- Added an AutopilotOnboarding route with a nullable vertical segment and parser support for /autopilot and one lowercase /autopilot/<vertical> segment.
- Added startup policy so logged-out users and signed-in users without workspace/core-team access stay on onboarding, while signed-in workspace users continue into the existing Chat cockpit.
- Added a minimal public onboarding surface at page/autopilot-onboarding.ts so the route renders until the richer page assembly lands.
- Extended the Worker document route allowlist to /^/autopilot(?:/[a-z0-9-]+)?$/ and covered it with fallback tests.

Files touched:
- apps/openagents.com/apps/web/src/route.ts
- apps/openagents.com/apps/web/src/routing/startup.ts
- apps/openagents.com/apps/web/src/page/autopilot-onboarding.ts
- apps/openagents.com/apps/web/src/page/loggedOut/view.ts
- apps/openagents.com/apps/web/src/product-policy.ts
- focused route/startup/main and worker route tests

Validation:
- bun run --cwd apps/openagents.com/apps/web test src/route.test.ts src/routing/startup.test.ts src/main.test.ts
- bun run --cwd apps/openagents.com test:api src/worker-routes.test.ts
- bun run --cwd apps/openagents.com typecheck:web

Revenue / proof value:
- Clears the first Autopilot onboarding URL gate so paid vertical funnels like /autopilot/legal can be linked, refreshed, and reviewed without server-side redirects.

Intentionally not changed:
- No component streaming, backend work-order behavior, 3D/renderer code, payment rails, or full onboarding page assembly beyond the minimal route render stub.