### PR TITLE
Autopilot onboarding: route shape for /autopilot and /autopilot/legal

### DIFF
--- a/apps/openagents.com/apps/web/src/autopilot-route.test.ts
+++ b/apps/openagents.com/apps/web/src/autopilot-route.test.ts
@@ -1,0 +1,180 @@
+import { Option } from 'effect'
+import type { Html } from 'foldkit/html'
+import { describe, expect, test } from 'vitest'
+
+import { authBootstrapFromSession } from './domain/session'
+import { Flags, init } from './main'
+import * as AutopilotOnboarding from './page/autopilot-onboarding'
+import {
+  AutopilotRoute,
+  AutopilotVerticalRoute,
+  AutopilotWorkRoute,
+  urlToAppRoute,
+} from './route'
+
+const appUrl = (pathname: string) => ({
+  protocol: 'https:',
+  host: 'openagents.com',
+  port: Option.none(),
+  pathname,
+  search: Option.none(),
+  hash: Option.none(),
+})
+
+// A logged-in user whose team is the core team can see the cockpit; a
+// logged-in user with no such team has no workspace and sees onboarding.
+const authWithWorkspace = {
+  ...authBootstrapFromSession({
+    email: 'chris@openagents.com',
+    name: 'Christopher David',
+    userId: 'github:14167547',
+  }),
+  teams: [
+    {
+      id: 'team_openagents_core',
+      name: 'OpenAgents Core Team',
+      slug: 'openagents-core-team',
+      role: 'owner',
+      members: [],
+    },
+  ],
+}
+
+const authWithoutWorkspace = authBootstrapFromSession({
+  email: 'visitor@example.com',
+  name: 'Visitor',
+  userId: 'github:visitor',
+})
+
+type VNodeLike = Readonly<{
+  sel?: string
+  text?: string
+  children?: ReadonlyArray<VNodeLike | string | null>
+  data?: {
+    attrs?: Record<string, unknown>
+    props?: Record<string, unknown>
+    class?: Record<string, boolean>
+  }
+}>
+
+const isVNodeLike = (value: unknown): value is VNodeLike =>
+  typeof value === 'object' && value !== null
+
+const attrsToString = (node: VNodeLike): string => {
+  const attrs = node.data?.attrs ?? {}
+  const props = node.data?.props ?? {}
+  const classes = Object.entries(node.data?.class ?? {})
+    .filter(([, enabled]) => enabled)
+    .map(([className]) => className)
+    .join(' ')
+  const pairs = [
+    ...Object.entries(attrs),
+    ...Object.entries(props),
+    ...(classes.length === 0 ? [] : [['class', classes] as const]),
+  ]
+
+  return pairs
+    .filter(
+      ([, value]) => value !== false && value !== undefined && value !== null,
+    )
+    .map(([name, value]) =>
+      value === true ? ` ${name}` : ` ${name}="${String(value)}"`,
+    )
+    .join('')
+}
+
+const renderHtml = (html: Html): string => {
+  if (html === null || !isVNodeLike(html)) {
+    return ''
+  }
+
+  const tag = html.sel ?? 'node'
+  const children = (html.children ?? [])
+    .map(child =>
+      typeof child === 'string'
+        ? child
+        : child === null
+          ? ''
+          : renderHtml(child),
+    )
+    .join('')
+  const text = html.text ?? ''
+
+  return `<${tag}${attrsToString(html)}>${text}${children}</${tag}>`
+}
+
+describe('autopilot onboarding route', () => {
+  test('parses /autopilot and /autopilot/<vertical>, leaving /autopilot/work for the cockpit', () => {
+    expect(urlToAppRoute(appUrl('/autopilot'))).toEqual(AutopilotRoute())
+    expect(urlToAppRoute(appUrl('/autopilot/legal'))).toEqual(
+      AutopilotVerticalRoute({ vertical: 'legal' }),
+    )
+    // The cockpit sub-route still wins over the optional vertical segment.
+    expect(urlToAppRoute(appUrl('/autopilot/work'))).toEqual(
+      AutopilotWorkRoute(),
+    )
+  })
+
+  test('serves the onboarding SPA shell to logged-out users (no 302) for both paths', () => {
+    const [bareModel] = init(
+      Flags.make({ maybeAuth: Option.none() }),
+      appUrl('/autopilot'),
+    )
+
+    expect(bareModel).toMatchObject({
+      _tag: 'LoggedOut',
+      route: { _tag: 'Autopilot' },
+    })
+
+    const [verticalModel] = init(
+      Flags.make({ maybeAuth: Option.none() }),
+      appUrl('/autopilot/legal'),
+    )
+
+    expect(verticalModel).toMatchObject({
+      _tag: 'LoggedOut',
+      route: { _tag: 'AutopilotVertical', vertical: 'legal' },
+    })
+  })
+
+  test('serves onboarding to a logged-in user without a workspace', () => {
+    const [model] = init(
+      Flags.make({ maybeAuth: Option.some(authWithoutWorkspace) }),
+      appUrl('/autopilot'),
+    )
+
+    expect(model).toMatchObject({
+      _tag: 'LoggedOut',
+      route: { _tag: 'Autopilot' },
+    })
+  })
+
+  test('resolves a logged-in user with a workspace to the existing cockpit', () => {
+    const [model] = init(
+      Flags.make({ maybeAuth: Option.some(authWithWorkspace) }),
+      appUrl('/autopilot'),
+    )
+
+    expect(model).toMatchObject({
+      _tag: 'LoggedIn',
+      route: { _tag: 'Chat' },
+    })
+  })
+
+  test('renders the placeholder heading and intro, adapting the intro to the vertical', () => {
+    const bare = renderHtml(
+      AutopilotOnboarding.view({ _tag: 'LoggedOut' }, Option.none()),
+    )
+
+    expect(bare).toContain('Put an AI workforce to work')
+    expect(bare).toContain('Tell Autopilot what you want done.')
+    expect(bare).toContain('data-autopilot-onboarding-shell')
+
+    const legal = renderHtml(
+      AutopilotOnboarding.view({ _tag: 'LoggedOut' }, Option.some('legal')),
+    )
+
+    expect(legal).toContain('Put an AI workforce to work')
+    expect(legal).toContain('for your legal work')
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding.ts
@@ -1,0 +1,94 @@
+import { Option } from 'effect'
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import * as Ui from '../ui'
+import type { PublicHeaderAuthState } from './publicHeader'
+import * as PublicHeader from './publicHeader'
+
+// Public `openagents.com/autopilot` onboarding entry point.
+//
+// This is the route-shape placeholder. It serves the SPA shell for both
+// `/autopilot` and `/autopilot/<vertical>` (e.g. `/autopilot/legal`) for
+// logged-out users and for logged-in users without a workspace. Logged-in
+// users with a workspace resolve to the existing cockpit upstream in the
+// router, so they never reach this page.
+//
+// The rich onboarding flow (conversation + streamed components + 3D scene) is
+// a separate issue (#6129) that expands this page. Keep this minimal: a
+// heading + intro composed from the centralized `@openagentsinc/ui` theme so
+// #6129 has a clean, well-structured base to build on. Do NOT hand-roll
+// styling or duplicate tokens.
+
+const pageShellClass = 'h-dvh overflow-auto bg-[#000] text-[#f1efe8]'
+
+const verticalLabels: Readonly<Record<string, string>> = {
+  legal: 'legal',
+}
+
+const introForVertical = (maybeVertical: Option.Option<string>): string =>
+  Option.match(maybeVertical, {
+    onNone: () =>
+      'Tell Autopilot what you want done. We set up a workspace, then agents do the work with a human-review gate before anything ships.',
+    onSome: vertical => {
+      const label = verticalLabels[vertical] ?? vertical
+      return `Tell Autopilot what you want done for your ${label} work. We set up a workspace, then agents do the work with a human-review gate before anything ships.`
+    },
+  })
+
+export const onboardingShell = <Message>(
+  maybeVertical: Option.Option<string>,
+): Html => {
+  const h = html<Message>()
+
+  return Ui.publicLandingThemeShell<Message>({
+    preference: 'dark',
+    mode: 'dark',
+    className: 'min-h-[calc(100dvh-3.5rem)]',
+    attrs: [h.DataAttribute('autopilot-onboarding-shell', '')],
+    children: [
+      h.main(
+        [
+          h.AriaLabel('Autopilot onboarding'),
+          Ui.className<Message>(
+            'mx-auto grid w-[min(100%,720px)] content-start gap-4 px-4 py-16',
+          ),
+        ],
+        [
+          h.p(
+            [
+              Ui.className<Message>(
+                'm-0 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-white/40',
+              ),
+            ],
+            ['Autopilot'],
+          ),
+          h.h1(
+            [
+              Ui.className<Message>(
+                'm-0 text-balance text-3xl font-medium tracking-normal text-[#f1efe8] sm:text-4xl',
+              ),
+            ],
+            ['Put an AI workforce to work'],
+          ),
+          h.p(
+            [Ui.className<Message>('m-0 text-base text-white/70')],
+            [introForVertical(maybeVertical)],
+          ),
+        ],
+      ),
+    ],
+  })
+}
+
+export const view = <Message>(
+  authState: PublicHeaderAuthState<Message>,
+  maybeVertical: Option.Option<string> = Option.none(),
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [Ui.className<Message>(pageShellClass)],
+    [PublicHeader.view(authState), onboardingShell<Message>(maybeVertical)],
+  )
+}

--- a/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
@@ -1,4 +1,4 @@
-import { Match as M } from 'effect'
+import { Match as M, Option } from 'effect'
 import { Submodel } from 'foldkit'
 import type { Html } from 'foldkit/html'
 import { html } from 'foldkit/html'
@@ -8,6 +8,7 @@ import { homeRouter } from '../../route'
 import * as Ui from '../../ui'
 import * as Activity from '../activity'
 import * as Animations from '../animations'
+import * as AutopilotOnboarding from '../autopilot-onboarding'
 import * as Blog from '../blog'
 import * as Business from '../business'
 import * as ClientsPreview from '../clientsPreview'
@@ -138,6 +139,13 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
               ComponentsFamily: route =>
                 Components.view({ _tag: 'LoggedOut' }, route.family),
               Business: () => Business.view({ _tag: 'LoggedOut' }),
+              Autopilot: () =>
+                AutopilotOnboarding.view({ _tag: 'LoggedOut' }),
+              AutopilotVertical: route =>
+                AutopilotOnboarding.view(
+                  { _tag: 'LoggedOut' },
+                  Option.some(route.vertical),
+                ),
               Terms: () => Terms.view({ _tag: 'LoggedOut' }),
               Privacy: () => Privacy.view({ _tag: 'LoggedOut' }),
               Download: () => Download.view({ _tag: 'LoggedOut' }),

--- a/apps/openagents.com/apps/web/src/product-policy.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.ts
@@ -199,6 +199,8 @@ export const browserRouteProductIntents = {
   AutopilotWorkDetail: 'autopilot.work.detail',
   Billing: 'billing.credits',
   Business: 'public.business.landing',
+  Autopilot: 'public.autopilot.onboarding',
+  AutopilotVertical: 'public.autopilot.onboarding.vertical',
   Animations: 'internal.animations.playground',
   Activity: 'public.activity.timeline',
   Login: 'public.login',

--- a/apps/openagents.com/apps/web/src/route.ts
+++ b/apps/openagents.com/apps/web/src/route.ts
@@ -8,6 +8,10 @@ export const InviteRoute = r('Invite')
 export const OnboardingRoute = r('Onboarding')
 export const OrderRoute = r('Order')
 export const OrderDetailRoute = r('OrderDetail', { orderId: S.String })
+export const AutopilotRoute = r('Autopilot')
+export const AutopilotVerticalRoute = r('AutopilotVertical', {
+  vertical: S.String,
+})
 export const AutopilotWorkRoute = r('AutopilotWork')
 export const AutopilotWorkDetailRoute = r('AutopilotWorkDetail', {
   workOrderRef: S.String,
@@ -116,6 +120,8 @@ export type InviteRoute = typeof InviteRoute.Type
 export type OnboardingRoute = typeof OnboardingRoute.Type
 export type OrderRoute = typeof OrderRoute.Type
 export type OrderDetailRoute = typeof OrderDetailRoute.Type
+export type AutopilotRoute = typeof AutopilotRoute.Type
+export type AutopilotVerticalRoute = typeof AutopilotVerticalRoute.Type
 export type AutopilotWorkRoute = typeof AutopilotWorkRoute.Type
 export type AutopilotWorkDetailRoute = typeof AutopilotWorkDetailRoute.Type
 export type ForgeRoute = typeof ForgeRoute.Type
@@ -210,6 +216,8 @@ export const LoggedOutRoute = S.Union([
   ComponentsRoute,
   ComponentsFamilyRoute,
   BusinessRoute,
+  AutopilotRoute,
+  AutopilotVerticalRoute,
   AnimationsRoute,
   ActivityRoute,
   RunRoute,
@@ -292,6 +300,8 @@ export const AppRoute = S.Union([
   OnboardingRoute,
   OrderRoute,
   OrderDetailRoute,
+  AutopilotRoute,
+  AutopilotVerticalRoute,
   AutopilotWorkRoute,
   AutopilotWorkDetailRoute,
   ForgeRoute,
@@ -374,6 +384,15 @@ export type AppRoute = typeof AppRoute.Type
 // to `/`, which renders the Landing scene.
 export const homeRouter = pipe(Route.root, Route.mapTo(LandingRoute))
 export const chatRouter = pipe(literal('autopilot'), Route.mapTo(ChatRoute))
+export const autopilotRouter = pipe(
+  literal('autopilot'),
+  Route.mapTo(AutopilotRoute),
+)
+export const autopilotVerticalRouter = pipe(
+  literal('autopilot'),
+  slash(string('vertical')),
+  Route.mapTo(AutopilotVerticalRoute),
+)
 export const inviteRouter = pipe(literal('invite'), Route.mapTo(InviteRoute))
 export const onboardingRouter = pipe(
   literal('onboarding'),
@@ -722,6 +741,8 @@ const routeParser = Route.oneOf(
   onboardingRouter,
   autopilotWorkDetailRouter,
   autopilotWorkRouter,
+  autopilotVerticalRouter,
+  autopilotRouter,
   forgeRouter,
   decisionsRouter,
   workspaceRouter,
@@ -747,7 +768,6 @@ const routeParser = Route.oneOf(
   imagesRouter,
   settingsSectionRouter,
   settingsRouter,
-  chatRouter,
   homeRouter,
 )
 

--- a/apps/openagents.com/apps/web/src/routing/startup.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.ts
@@ -7,10 +7,12 @@ import {
   defaultLoggedInHrefForAuth,
   defaultLoggedInRouteForAuth,
   loggedInPermissionGate,
+  loggedInWorkroomAllowed,
   routeAllowedForLoggedInAuth,
 } from '../product-policy'
 import {
   type AppRoute,
+  ChatRoute,
   InviteRoute,
   LandingRoute,
   LoggedInRoute,
@@ -93,6 +95,8 @@ export const startupRouteForLoggedOut = (
       'Components',
       'ComponentsFamily',
       'Business',
+      'Autopilot',
+      'AutopilotVertical',
       'Animations',
       'Activity',
       'DemoLegal',
@@ -181,6 +185,15 @@ const startupRouteForIncompleteOnboarding = (route: AppRoute): StartupRoute =>
         redirect: Option.none(),
       }),
     ),
+    M.tag('Autopilot', 'AutopilotVertical', route =>
+      // Mid-onboarding users have no workspace yet, so the autopilot entry
+      // serves the public onboarding page rather than forcing the onboarding
+      // flow redirect.
+      LoggedOutStartupRoute({
+        route,
+        redirect: Option.none(),
+      }),
+    ),
     M.tag(
       'Docs',
       'DocsPage',
@@ -244,6 +257,20 @@ const startupRouteForCompleteOnboarding = (
           }),
         ),
       }),
+    ),
+    M.tag('Autopilot', 'AutopilotVertical', route =>
+      // A logged-in user with a workspace lands on the existing cockpit; a
+      // logged-in user without one sees the public onboarding page (same page
+      // logged-out users get). #6129 expands that page into the full flow.
+      loggedInWorkroomAllowed(auth)
+        ? LoggedInStartupRoute({
+            route: ChatRoute(),
+            redirect: Option.none(),
+          })
+        : LoggedOutStartupRoute({
+            route,
+            redirect: Option.none(),
+          }),
     ),
     M.tag(
       'PublicAgent',

--- a/apps/openagents.com/apps/web/src/view.ts
+++ b/apps/openagents.com/apps/web/src/view.ts
@@ -11,6 +11,7 @@ import type { Model } from './model'
 import { Demo, LoggedIn, LoggedOut } from './model'
 import * as Activity from './page/activity'
 import * as Animations from './page/animations'
+import * as AutopilotOnboarding from './page/autopilot-onboarding'
 import * as Blog from './page/blog'
 import * as Business from './page/business'
 import * as Components from './page/components'
@@ -375,6 +376,9 @@ const title = (model: Model): string => {
       return 'Components - OpenAgents'
     case 'Business':
       return 'For your business - OpenAgents'
+    case 'Autopilot':
+    case 'AutopilotVertical':
+      return 'Autopilot - OpenAgents'
     case 'Terms':
       return 'Terms of Service - OpenAgents'
     case 'Privacy':
@@ -522,6 +526,8 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
       model.route._tag !== 'Components' &&
       model.route._tag !== 'ComponentsFamily' &&
       model.route._tag !== 'Business' &&
+      model.route._tag !== 'Autopilot' &&
+      model.route._tag !== 'AutopilotVertical' &&
       model.route._tag !== 'Terms' &&
       model.route._tag !== 'Privacy' &&
       model.route._tag !== 'Animations' &&
@@ -549,6 +555,17 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
 
   if (model.route._tag === 'Business') {
     return Business.view<Message>(authState)
+  }
+
+  if (model.route._tag === 'Autopilot') {
+    return AutopilotOnboarding.view<Message>(authState)
+  }
+
+  if (model.route._tag === 'AutopilotVertical') {
+    return AutopilotOnboarding.view<Message>(
+      authState,
+      Option.some(model.route.vertical),
+    )
   }
 
   if (model.route._tag === 'Terms') {

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -65,6 +65,27 @@ describe('Worker document route fallback', () => {
     ).toBe(false)
   })
 
+  test('keeps autopilot onboarding and its optional vertical in the app shell', () => {
+    expect(
+      shouldRedirectUnknownDocumentToHome(
+        requestFor('/autopilot'),
+        '/autopilot',
+      ),
+    ).toBe(false)
+    expect(
+      shouldRedirectUnknownDocumentToHome(
+        requestFor('/autopilot/legal'),
+        '/autopilot/legal',
+      ),
+    ).toBe(false)
+    expect(
+      shouldRedirectUnknownDocumentToHome(
+        requestFor('/autopilot/work'),
+        '/autopilot/work',
+      ),
+    ).toBe(false)
+  })
+
   test('keeps the Moksha document route in the app shell', () => {
     expect(
       shouldRedirectUnknownDocumentToHome(requestFor('/moksha'), '/moksha'),

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -105,7 +105,7 @@ const knownDocumentPathPatterns: ReadonlyArray<RegExp> = [
   /^\/admin$/,
   /^\/agents\/[^/]+$/,
   /^\/artanis$/,
-  /^\/autopilot$/,
+  /^\/autopilot(?:\/[a-z0-9-]+)?$/,
   /^\/billing$/,
   /^\/blog(?:\/[^/]+)?$/,
   /^\/business$/,


### PR DESCRIPTION
Closes #6124. Part of #6123.

## What

Adds the route shape for the new Autopilot onboarding flow, keeping the two layers in sync:

1. **Worker document gate** (`workers/api/src/worker-routes.ts`): `knownDocumentPathPatterns` now admits an optional single vertical segment under `/autopilot` (`/^\/autopilot(?:\/[a-z0-9-]+)?$/`), so `/autopilot/legal` serves the SPA shell instead of 302-ing to `/`.
2. **Client router** (`apps/web/src/route.ts`): adds `AutopilotRoute` (bare) and `AutopilotVerticalRoute` (`{ vertical }`), parsed after the `/autopilot/work*` cockpit routers so those still win. Bare `/autopilot` no longer aliases to the chat route in the parser.
3. **Placeholder page** (`apps/web/src/page/autopilot-onboarding.ts`): a minimal, well-structured heading + intro built entirely from the centralized `@openagentsinc/ui` theme (`publicLandingThemeShell` + `PublicHeader`). The rich flow (conversation + streamed components + 3D scene) is #6129, which expands this page.

## Behavior (locked, mirrors the `/business` precedent)

- Logged-out → onboarding page.
- Logged-in **without** a workspace → onboarding page.
- Logged-in **with** a workspace → existing cockpit (resolved in startup routing to the current logged-in app home; `autopilot-work.ts` cockpit stays reachable as before).

Workspace presence reuses the existing `loggedInWorkroomAllowed` gate (the same gate that already controls who can see the cockpit), so no new authority is introduced.

## Tests

- `apps/web/src/autopilot-route.test.ts` (modeled on `demo-legal-route.test.ts`): URL parsing for both paths and `/autopilot/work`; logged-out, logged-in-without-workspace, and logged-in-with-workspace resolution; placeholder render.
- `workers/api/src/worker-routes.test.ts`: document gate keeps `/autopilot`, `/autopilot/legal`, and `/autopilot/work` in the app shell.

## Verification

- `bun run typecheck:web` and `bun run typecheck:api`: green.
- New web route tests + `routing/startup.test.ts`, `main.test.ts`, `update.test.ts`, `view.scene.test.ts`, `login.scene.test.ts`, `demo-legal-route.test.ts`: green.
- `bun run check:deploy`: exits 0 (green). The contract-drift-guard diagnostic lines are pre-existing fixture output unrelated to this change; the suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
