### PR TITLE
Autopilot onboarding: Foldkit closed-catalog component renderer (client)

### DIFF
--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/component-catalog.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/component-catalog.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  COMPONENT_FRAME_VERSION,
+  COMPONENT_SSE_EVENT,
+  componentNames,
+  isUnknownComponentFrame,
+  parseComponentFrames,
+  validateComponentFrame,
+  type RenderableFrame,
+} from './component-catalog'
+
+const at = (
+  frames: ReadonlyArray<RenderableFrame>,
+  index: number,
+): RenderableFrame => {
+  const frame = frames[index]
+  if (frame === undefined) {
+    throw new Error(`expected a frame at index ${index}`)
+  }
+  return frame
+}
+
+const frame = (component: string, props: unknown, id = 'cmp_01') => ({
+  v: COMPONENT_FRAME_VERSION,
+  component,
+  props,
+  id,
+})
+
+const sseFrame = (component: string, props: unknown, id = 'cmp_01') =>
+  `event: ${COMPONENT_SSE_EVENT}\ndata: ${JSON.stringify(frame(component, props, id))}\n\n`
+
+describe('component catalog — closed v1 set', () => {
+  test('exposes exactly the six v1 component names', () => {
+    expect(componentNames).toEqual([
+      'credit_kickoff',
+      'intake_progress',
+      'quick_win_card',
+      'dashboard_preview',
+      'human_handoff',
+      'consent_gate',
+    ])
+  })
+})
+
+describe('validateComponentFrame — per-component valid props', () => {
+  test('credit_kickoff', () => {
+    const result = validateComponentFrame(
+      frame('credit_kickoff', {
+        amountCents: 50000,
+        label: 'Kick off with $500 in credits',
+      }),
+    )
+
+    expect(result._tag).toBe('CatalogComponentFrame')
+    if (result._tag === 'CatalogComponentFrame') {
+      expect(result.frame.component).toBe('credit_kickoff')
+    }
+  })
+
+  test('intake_progress', () => {
+    const result = validateComponentFrame(
+      frame('intake_progress', {
+        steps: [
+          { id: 's1', label: 'Your business' },
+          { id: 's2', label: 'Painful work' },
+        ],
+        current: 1,
+      }),
+    )
+
+    expect(result._tag).toBe('CatalogComponentFrame')
+  })
+
+  test('quick_win_card', () => {
+    const result = validateComponentFrame(
+      frame('quick_win_card', {
+        title: 'Automate intake',
+        scope: 'Replace the 60-minute intake with a guided form',
+        etaDays: 5,
+      }),
+    )
+
+    expect(result._tag).toBe('CatalogComponentFrame')
+  })
+
+  test('dashboard_preview', () => {
+    const result = validateComponentFrame(
+      frame('dashboard_preview', {
+        workspaceRef: 'ws_demo_01',
+        seededFacts: ['15 LLCs per year', '~1 hour each'],
+      }),
+    )
+
+    expect(result._tag).toBe('CatalogComponentFrame')
+  })
+
+  test('human_handoff', () => {
+    const result = validateComponentFrame(
+      frame('human_handoff', {
+        reason: 'This needs a person to review.',
+        contact: 'team@openagents.com',
+      }),
+    )
+
+    expect(result._tag).toBe('CatalogComponentFrame')
+  })
+
+  test('consent_gate', () => {
+    const result = validateComponentFrame(
+      frame('consent_gate', {
+        scope: 'Process your client documents',
+        dataPractices: ['Redacted before inference', 'Never used for training'],
+        required: true,
+      }),
+    )
+
+    expect(result._tag).toBe('CatalogComponentFrame')
+  })
+})
+
+describe('validateComponentFrame — registry fallback (the real guarantee)', () => {
+  test('unknown component name falls back to typed-unknown, never crashes', () => {
+    const result = validateComponentFrame(
+      frame('inject_arbitrary_markup', { html: '<script>alert(1)</script>' }),
+    )
+
+    expect(isUnknownComponentFrame(result)).toBe(true)
+    if (isUnknownComponentFrame(result)) {
+      expect(result.component).toBe('inject_arbitrary_markup')
+      expect(result.reason).toBe('component_not_in_closed_catalog')
+    }
+  })
+
+  test('catalog component with invalid props falls back to typed-unknown', () => {
+    const result = validateComponentFrame(
+      // amountCents must be a positive integer
+      frame('credit_kickoff', { amountCents: -5, label: 'bad' }),
+    )
+
+    expect(isUnknownComponentFrame(result)).toBe(true)
+    if (isUnknownComponentFrame(result)) {
+      expect(result.component).toBe('credit_kickoff')
+      expect(result.reason).toBe('component_props_failed_schema_validation')
+    }
+  })
+
+  test('catalog component missing required props falls back', () => {
+    const result = validateComponentFrame(
+      frame('quick_win_card', { title: 'Only a title' }),
+    )
+
+    expect(isUnknownComponentFrame(result)).toBe(true)
+  })
+
+  test('wrong version falls back rather than rendering', () => {
+    const result = validateComponentFrame({
+      v: 999,
+      component: 'credit_kickoff',
+      props: { amountCents: 50000, label: 'x' },
+      id: 'cmp_01',
+    })
+
+    expect(isUnknownComponentFrame(result)).toBe(true)
+  })
+
+  test('non-object / garbage input does not crash', () => {
+    expect(isUnknownComponentFrame(validateComponentFrame(null))).toBe(true)
+    expect(isUnknownComponentFrame(validateComponentFrame('nope'))).toBe(true)
+    expect(isUnknownComponentFrame(validateComponentFrame(42))).toBe(true)
+    expect(isUnknownComponentFrame(validateComponentFrame([1, 2, 3]))).toBe(true)
+  })
+})
+
+describe('parseComponentFrames — SSE consumption', () => {
+  test('parses a single oa.component frame', () => {
+    const frames = parseComponentFrames(
+      sseFrame('credit_kickoff', {
+        amountCents: 50000,
+        label: 'Kick off with $500 in credits',
+      }),
+    )
+
+    expect(frames).toHaveLength(1)
+    expect(at(frames, 0)._tag).toBe('CatalogComponentFrame')
+  })
+
+  test('ignores non-component events (prose / OpenAI chunks) and interleaves correctly', () => {
+    const stream = [
+      'event: message\ndata: {"choices":[{"delta":{"content":"Hello, "}}]}\n\n',
+      sseFrame('intake_progress', {
+        steps: [{ id: 's1', label: 'Your business' }],
+        current: 0,
+      }),
+      'event: message\ndata: {"choices":[{"delta":{"content":"let me show you."}}]}\n\n',
+      sseFrame('credit_kickoff', { amountCents: 50000, label: 'Kick off' }, 'cmp_02'),
+    ].join('')
+
+    const frames = parseComponentFrames(stream)
+
+    // Only the two oa.component frames are surfaced, in document order.
+    expect(frames).toHaveLength(2)
+    const first = at(frames, 0)
+    const second = at(frames, 1)
+    expect(first._tag).toBe('CatalogComponentFrame')
+    expect(second._tag).toBe('CatalogComponentFrame')
+    if (
+      first._tag === 'CatalogComponentFrame' &&
+      second._tag === 'CatalogComponentFrame'
+    ) {
+      expect(first.frame.component).toBe('intake_progress')
+      expect(second.frame.component).toBe('credit_kickoff')
+    }
+  })
+
+  test('an invalid oa.component frame becomes a typed-unknown fallback, not dropped', () => {
+    const frames = parseComponentFrames(
+      sseFrame('made_up_component', { anything: true }),
+    )
+
+    expect(frames).toHaveLength(1)
+    expect(isUnknownComponentFrame(at(frames, 0))).toBe(true)
+  })
+
+  test('handles an empty / prose-only stream', () => {
+    expect(parseComponentFrames('')).toHaveLength(0)
+    expect(
+      parseComponentFrames(
+        'event: message\ndata: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+      ),
+    ).toHaveLength(0)
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/component-catalog.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/component-catalog.ts
@@ -1,0 +1,270 @@
+// Autopilot onboarding — the CLOSED component catalog (client side).
+//
+// This is the v1 closed catalog of onboarding component frames the Khala
+// gateway streams over `event: oa.component` SSE frames (see the audit doc
+// `docs/blitz/2026-06-23-autopilot-onboarding-intake-and-khala-audit.md`
+// §4.3.1). The gateway validates these props server-side before a frame leaves
+// Khala; this module re-validates them with Effect Schema at the client
+// boundary (defense in depth) and is the source of truth for which components
+// the Foldkit renderer will ever render.
+//
+// The decisive guarantee lives here and in `component-renderer.ts`: the catalog
+// is a *closed* tagged union keyed by `component`, and the renderer does
+// `registry[component] ?? fallback`. An unrecognized component renders a SAFE
+// fallback (or the `human_handoff` view), never arbitrary model-authored
+// markup — even if the gateway is bypassed.
+//
+// Issue #6127 owns the matching SERVER catalog independently; both mirror
+// §4.3.1 exactly so the wire format lines up. Integration (#6129) reconciles
+// them later.
+import { Result, Schema as S } from 'effect'
+
+import { parseJsonRecord } from '../../json-boundary'
+
+// The wire envelope version. json-render lacks a version field; §4.3.1 adds
+// one as the single thing not to copy.
+export const COMPONENT_FRAME_VERSION = 1
+
+// CLOSED catalog (v1). Adding a 7th component is a deliberate, reviewed bump,
+// never an ad-hoc model invention. Keep this list in lockstep with the
+// per-component prop schemas below and the renderer registry.
+export const ComponentName = S.Literals([
+  'credit_kickoff',
+  'intake_progress',
+  'quick_win_card',
+  'dashboard_preview',
+  'human_handoff',
+  'consent_gate',
+])
+export type ComponentName = typeof ComponentName.Type
+
+export const componentNames: ReadonlyArray<ComponentName> = ComponentName.literals
+
+// PROP SCHEMAS — exact shapes from §4.3.1. Each is an Effect Schema struct.
+
+// `credit_kickoff {amountCents, label}`
+export const CreditKickoffProps = S.Struct({
+  amountCents: S.Int.check(S.isGreaterThan(0)),
+  label: S.NonEmptyString,
+})
+export type CreditKickoffProps = typeof CreditKickoffProps.Type
+
+// `intake_progress {steps[], current}`
+export const IntakeProgressStep = S.Struct({
+  id: S.NonEmptyString,
+  label: S.NonEmptyString,
+})
+export type IntakeProgressStep = typeof IntakeProgressStep.Type
+
+export const IntakeProgressProps = S.Struct({
+  steps: S.NonEmptyArray(IntakeProgressStep),
+  current: S.Int.check(S.isGreaterThanOrEqualTo(0)),
+})
+export type IntakeProgressProps = typeof IntakeProgressProps.Type
+
+// `quick_win_card {title, scope, etaDays}`
+export const QuickWinCardProps = S.Struct({
+  title: S.NonEmptyString,
+  scope: S.NonEmptyString,
+  etaDays: S.Int.check(S.isGreaterThan(0)),
+})
+export type QuickWinCardProps = typeof QuickWinCardProps.Type
+
+// `dashboard_preview {workspaceRef, seededFacts[]}`
+export const DashboardPreviewProps = S.Struct({
+  workspaceRef: S.NonEmptyString,
+  seededFacts: S.Array(S.NonEmptyString),
+})
+export type DashboardPreviewProps = typeof DashboardPreviewProps.Type
+
+// `human_handoff {reason, contact}`
+export const HumanHandoffProps = S.Struct({
+  reason: S.NonEmptyString,
+  contact: S.NonEmptyString,
+})
+export type HumanHandoffProps = typeof HumanHandoffProps.Type
+
+// `consent_gate {scope, dataPractices, required}`
+export const ConsentGateProps = S.Struct({
+  scope: S.NonEmptyString,
+  dataPractices: S.NonEmptyArray(S.NonEmptyString),
+  required: S.Boolean,
+})
+export type ConsentGateProps = typeof ConsentGateProps.Type
+
+// The validated frame as a tagged union over `component`. `props` is validated
+// against the matching prop schema as a whole object (self-contained card; no
+// per-field patch reassembly — §4.3.1 rejects json-render's element graph and
+// JSON-Patch streaming).
+const FrameStruct = <Name extends ComponentName, Props extends S.Struct.Fields>(
+  component: Name,
+  props: S.Struct<Props>,
+) =>
+  S.Struct({
+    v: S.Literal(COMPONENT_FRAME_VERSION),
+    component: S.Literal(component),
+    props,
+    id: S.NonEmptyString,
+  })
+
+export const CreditKickoffFrame = FrameStruct('credit_kickoff', CreditKickoffProps)
+export const IntakeProgressFrame = FrameStruct('intake_progress', IntakeProgressProps)
+export const QuickWinCardFrame = FrameStruct('quick_win_card', QuickWinCardProps)
+export const DashboardPreviewFrame = FrameStruct(
+  'dashboard_preview',
+  DashboardPreviewProps,
+)
+export const HumanHandoffFrame = FrameStruct('human_handoff', HumanHandoffProps)
+export const ConsentGateFrame = FrameStruct('consent_gate', ConsentGateProps)
+
+// The closed component frame: a tagged union of the six catalog frames. Schema
+// decode rejects any `component` not in the catalog and any frame whose props
+// fail the matching schema.
+export const ComponentFrame = S.Union([
+  CreditKickoffFrame,
+  IntakeProgressFrame,
+  QuickWinCardFrame,
+  DashboardPreviewFrame,
+  HumanHandoffFrame,
+  ConsentGateFrame,
+])
+export type ComponentFrame = typeof ComponentFrame.Type
+
+// A frame that decoded but is NOT in the closed catalog (or failed prop
+// validation). Carried so the renderer can render the SAFE fallback view and
+// the page can surface a typed reason. Raw model material is never rendered.
+export type UnknownComponentFrame = Readonly<{
+  _tag: 'UnknownComponentFrame'
+  // `component` may be any string the model emitted; it is shown as a label
+  // only, never used to select markup.
+  component: string
+  id?: string
+  reason: string
+}>
+
+export const UnknownComponentFrameValue = (input: {
+  component: string
+  id?: string
+  reason: string
+}): UnknownComponentFrame => ({
+  _tag: 'UnknownComponentFrame',
+  component: input.component,
+  ...(input.id === undefined ? {} : { id: input.id }),
+  reason: input.reason,
+})
+
+// A validated catalog frame, tagged so the renderer can switch over the
+// renderable union without colliding with the unknown-fallback marker.
+export type CatalogComponentFrame = Readonly<{
+  _tag: 'CatalogComponentFrame'
+  frame: ComponentFrame
+}>
+
+export const CatalogComponentFrameValue = (
+  frame: ComponentFrame,
+): CatalogComponentFrame => ({ _tag: 'CatalogComponentFrame', frame })
+
+// The renderer input: either a validated catalog frame or the typed-unknown
+// fallback marker. The renderer switches on this; it can never receive raw,
+// unvalidated model output.
+export type RenderableFrame = CatalogComponentFrame | UnknownComponentFrame
+
+const decodeFrame = S.decodeUnknownResult(ComponentFrame)
+
+const looksLikeFrameRecord = (
+  value: unknown,
+): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const componentLabel = (value: unknown): string => {
+  if (looksLikeFrameRecord(value) && typeof value.component === 'string') {
+    return value.component
+  }
+
+  return 'unknown'
+}
+
+const idLabel = (value: unknown): string | undefined => {
+  if (looksLikeFrameRecord(value) && typeof value.id === 'string') {
+    return value.id
+  }
+
+  return undefined
+}
+
+// Re-validate a single frame payload with Effect Schema (defense in depth,
+// mirroring the gateway). Returns either a typed catalog frame or the
+// typed-unknown fallback marker — never throws, so a misbehaving model can
+// never crash the renderer.
+export const validateComponentFrame = (value: unknown): RenderableFrame =>
+  Result.match(decodeFrame(value), {
+    onFailure: () => {
+      const id = idLabel(value)
+      const component = componentLabel(value)
+      const reason = componentNames.includes(component as ComponentName)
+        ? 'component_props_failed_schema_validation'
+        : 'component_not_in_closed_catalog'
+
+      return UnknownComponentFrameValue({
+        component,
+        ...(id === undefined ? {} : { id }),
+        reason,
+      })
+    },
+    onSuccess: frame => CatalogComponentFrameValue(frame),
+  })
+
+export const isUnknownComponentFrame = (
+  frame: RenderableFrame,
+): frame is UnknownComponentFrame => frame._tag === 'UnknownComponentFrame'
+
+// SSE PARSE — reuse the existing client SSE-parse pattern from
+// `page/loggedIn/customer-order/transitions.ts`: split on newlines, read
+// `event:`/`data:` lines, JSON-parse the `data:` payload. We only surface
+// `event: oa.component` frames here; prose `content` deltas are handled by the
+// chat/onboarding stream separately. Standard OpenAI clients ignore the
+// unknown `oa.component` event type, which is the additive-frame contract from
+// §4.3.1.
+export const COMPONENT_SSE_EVENT = 'oa.component'
+
+type SseEvent = Readonly<{ event: string; data: string }>
+
+// Split a raw SSE text body into discrete events. SSE events are separated by a
+// blank line; each event accumulates `event:` and `data:` field lines.
+const splitSseEvents = (text: string): ReadonlyArray<SseEvent> => {
+  const blocks = text.split(/\r?\n\r?\n/)
+
+  return blocks.flatMap(block => {
+    const lines = block.split(/\r?\n/)
+    const eventLine = lines.find(line => line.startsWith('event:'))
+    const dataLines = lines
+      .filter(line => line.startsWith('data:'))
+      .map(line => line.slice('data:'.length).replace(/^ /, ''))
+
+    if (dataLines.length === 0) {
+      return []
+    }
+
+    return [
+      {
+        event:
+          eventLine === undefined
+            ? 'message'
+            : eventLine.slice('event:'.length).replace(/^ /, '').trim(),
+        data: dataLines.join('\n'),
+      },
+    ]
+  })
+}
+
+// Parse a raw SSE body, validate every `oa.component` frame through the closed
+// catalog, and return the renderable frames in order. Non-component events
+// (prose `content` deltas, OpenAI chunks) are ignored here. Invalid component
+// frames become typed-unknown fallback markers rather than being dropped, so
+// the page can render the safe fallback and surface a reason.
+export const parseComponentFrames = (
+  text: string,
+): ReadonlyArray<RenderableFrame> =>
+  splitSseEvents(text)
+    .filter(event => event.event === COMPONENT_SSE_EVENT)
+    .map(event => validateComponentFrame(parseJsonRecord(event.data)))

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/component-renderer.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/component-renderer.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  COMPONENT_FRAME_VERSION,
+  validateComponentFrame,
+} from './component-catalog'
+import { renderComponentFrame } from './component-renderer'
+
+// A snabbdom VNode is `{ sel, data: { attrs }, children, text }`. These walkers
+// collect every `data-ui-base` AI-Elements tag and all rendered text so we can
+// assert a frame produced trusted AI-Elements markup and the expected content.
+type VNodeLike = {
+  sel?: string
+  text?: string
+  data?: { attrs?: Record<string, unknown> }
+  children?: ReadonlyArray<VNodeLike | string>
+}
+
+const walk = (node: unknown, visit: (n: VNodeLike) => void): void => {
+  if (node === null || node === undefined || typeof node === 'string') {
+    return
+  }
+
+  const n = node as VNodeLike
+  visit(n)
+  for (const child of n.children ?? []) {
+    walk(child, visit)
+  }
+}
+
+const uiBaseTags = (node: unknown): ReadonlyArray<string> => {
+  const tags: Array<string> = []
+  walk(node, n => {
+    const base = n.data?.attrs?.['data-ui-base']
+    if (typeof base === 'string') {
+      tags.push(base)
+    }
+  })
+  return tags
+}
+
+const allText = (node: unknown): string => {
+  const parts: Array<string> = []
+  walk(node, n => {
+    if (typeof n.text === 'string') {
+      parts.push(n.text)
+    }
+  })
+  return parts.join(' ')
+}
+
+const catalogFrame = (component: string, props: unknown) =>
+  validateComponentFrame({
+    v: COMPONENT_FRAME_VERSION,
+    component,
+    props,
+    id: 'cmp_01',
+  })
+
+describe('renderComponentFrame — per-component render', () => {
+  test('credit_kickoff renders an AI-Elements confirmation with the amount', () => {
+    const node = renderComponentFrame(
+      catalogFrame('credit_kickoff', {
+        amountCents: 50000,
+        label: 'Kick off with $500 in credits',
+      }),
+    )
+
+    expect(node).not.toBeNull()
+    expect(uiBaseTags(node)).toContain('ai-elements:confirmation/Confirmation')
+    expect(allText(node)).toContain('$500')
+  })
+
+  test('intake_progress renders an AI-Elements task with each step', () => {
+    const node = renderComponentFrame(
+      catalogFrame('intake_progress', {
+        steps: [
+          { id: 's1', label: 'Your business' },
+          { id: 's2', label: 'Painful work' },
+        ],
+        current: 1,
+      }),
+    )
+
+    expect(uiBaseTags(node)).toContain('ai-elements:task/Task')
+    const text = allText(node)
+    expect(text).toContain('Your business')
+    expect(text).toContain('Painful work')
+  })
+
+  test('quick_win_card renders the title, scope and ETA', () => {
+    const node = renderComponentFrame(
+      catalogFrame('quick_win_card', {
+        title: 'Automate intake',
+        scope: 'Replace the 60-minute intake',
+        etaDays: 5,
+      }),
+    )
+
+    const text = allText(node)
+    expect(text).toContain('Automate intake')
+    expect(text).toContain('Replace the 60-minute intake')
+    expect(text).toContain('5 days')
+  })
+
+  test('dashboard_preview renders the workspace ref and seeded facts', () => {
+    const node = renderComponentFrame(
+      catalogFrame('dashboard_preview', {
+        workspaceRef: 'ws_demo_01',
+        seededFacts: ['15 LLCs per year', '~1 hour each'],
+      }),
+    )
+
+    const text = allText(node)
+    expect(text).toContain('ws_demo_01')
+    expect(text).toContain('15 LLCs per year')
+    expect(text).toContain('~1 hour each')
+  })
+
+  test('human_handoff renders the reason and contact', () => {
+    const node = renderComponentFrame(
+      catalogFrame('human_handoff', {
+        reason: 'This needs a person to review.',
+        contact: 'team@openagents.com',
+      }),
+    )
+
+    const text = allText(node)
+    expect(text).toContain('This needs a person to review.')
+    expect(text).toContain('team@openagents.com')
+  })
+
+  test('consent_gate renders the data practices and a confirmation', () => {
+    const node = renderComponentFrame(
+      catalogFrame('consent_gate', {
+        scope: 'Process your client documents',
+        dataPractices: ['Redacted before inference', 'Never used for training'],
+        required: true,
+      }),
+    )
+
+    expect(uiBaseTags(node)).toContain('ai-elements:confirmation/Confirmation')
+    const text = allText(node)
+    expect(text).toContain('Process your client documents')
+    expect(text).toContain('Redacted before inference')
+  })
+})
+
+describe('renderComponentFrame — registry fallback (never arbitrary markup)', () => {
+  test('an unknown component renders the safe fallback, not a crash', () => {
+    const node = renderComponentFrame(
+      validateComponentFrame({
+        v: COMPONENT_FRAME_VERSION,
+        component: 'inject_arbitrary_markup',
+        props: { html: '<script>alert(1)</script>' },
+        id: 'cmp_evil',
+      }),
+    )
+
+    expect(node).not.toBeNull()
+    const text = allText(node)
+    // The fallback is the human_handoff view; the model-authored component name
+    // and props are NEVER rendered.
+    expect(text).not.toContain('inject_arbitrary_markup')
+    expect(text).not.toContain('<script>')
+    expect(text).not.toContain('alert(1)')
+    expect(text.toLowerCase()).toContain('teammate')
+  })
+
+  test('a catalog component with invalid props also renders the safe fallback', () => {
+    const node = renderComponentFrame(
+      validateComponentFrame({
+        v: COMPONENT_FRAME_VERSION,
+        component: 'credit_kickoff',
+        props: { amountCents: -1, label: '' },
+        id: 'cmp_bad',
+      }),
+    )
+
+    expect(node).not.toBeNull()
+    expect(allText(node).toLowerCase()).toContain('teammate')
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/component-renderer.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/component-renderer.ts
@@ -1,0 +1,255 @@
+// Autopilot onboarding — the CLOSED component renderer (client side).
+//
+// Renders the validated v1 catalog frames (see `./component-catalog.ts` and the
+// audit doc §4.3.1) as Foldkit views built from the centralized
+// `@openagentsinc/ui` AI Elements + primitives. No hand-rolled styling and no
+// duplicated tokens: cards reuse the shared message/task/confirmation elements
+// and the kit class constants.
+//
+// THE GUARANTEE: a closed registry keyed by `component` name, looked up as
+// `registry[component] ?? fallback`. A frame that is not in the closed catalog
+// (or whose props failed Effect Schema validation) renders the SAFE fallback —
+// the `human_handoff` view — never arbitrary model-authored markup. This holds
+// even if the gateway is bypassed, because `validateComponentFrame` only ever
+// hands the renderer a typed `RenderableFrame`.
+import { Match as M } from 'effect'
+import type { Attribute, Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  AiElements,
+  eyebrowClass,
+  metaClass,
+  surfaceClass,
+  titleClass,
+} from '@openagentsinc/ui'
+
+import {
+  type ComponentFrame,
+  type ComponentName,
+  type ConsentGateProps,
+  type CreditKickoffProps,
+  type DashboardPreviewProps,
+  type HumanHandoffProps,
+  type IntakeProgressProps,
+  type QuickWinCardProps,
+  type RenderableFrame,
+} from './component-catalog'
+
+const cardClass = `grid gap-2 ${surfaceClass} p-3`
+
+// Optional action attributes (e.g. an `OnClick`) the page may supply per
+// component id so interactive cards can dispatch. The renderer never invents
+// messages itself (Elm discipline); page assembly (#6129) wires these.
+export type ComponentActionAttrs<Message> = Partial<
+  Record<ComponentName, ReadonlyArray<Attribute<Message>>>
+>
+
+const formatCents = (amountCents: number): string =>
+  `$${(amountCents / 100).toLocaleString('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}`
+
+// `credit_kickoff` — "Kick off with $500 in credits". A confirmation gate with
+// the credit amount and a primary action; the action click is wired by the page.
+const creditKickoffView = <Message>(
+  props: CreditKickoffProps,
+  actionAttrs: ReadonlyArray<Attribute<Message>>,
+): Html =>
+  AiElements.confirmation<Message>({
+    props: {
+      title: props.label,
+      state: 'requested',
+      detail: `${formatCents(props.amountCents)} in credits to start the work.`,
+      approveLabel: `Add ${formatCents(props.amountCents)} in credits`,
+    },
+    actions: [
+      AiElements.confirmationAction<Message>({
+        label: `Add ${formatCents(props.amountCents)} in credits`,
+        variant: 'primary',
+        attrs: actionAttrs,
+      }),
+    ],
+  })
+
+// `intake_progress` — the onboarding interview progress, as a task list with one
+// item per step; the current step is `active`, prior steps `done`, later ones
+// `queued`.
+const intakeProgressView = <Message>(props: IntakeProgressProps): Html =>
+  AiElements.task<Message>({
+    props: {
+      title: 'Onboarding progress',
+      open: true,
+      items: props.steps.map((step, index) => ({
+        label: step.label,
+        status:
+          index < props.current
+            ? ('done' as const)
+            : index === props.current
+              ? ('active' as const)
+              : ('queued' as const),
+      })),
+    },
+  })
+
+// `quick_win_card` — the scoped first deliverable with an ETA.
+const quickWinCardView = <Message>(props: QuickWinCardProps): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class(cardClass)],
+    [
+      h.span([h.Class(eyebrowClass)], ['Quick win']),
+      h.span([h.Class(titleClass)], [props.title]),
+      h.p([h.Class(metaClass)], [props.scope]),
+      h.p(
+        [h.Class(metaClass)],
+        [`Estimated ${props.etaDays} day${props.etaDays === 1 ? '' : 's'}`],
+      ),
+    ],
+  )
+}
+
+// `dashboard_preview` — "here's your dashboard with your info in it": the seeded
+// workspace ref and the public-safe facts already loaded.
+const dashboardPreviewView = <Message>(props: DashboardPreviewProps): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class(cardClass)],
+    [
+      h.span([h.Class(eyebrowClass)], ['Your dashboard']),
+      h.span([h.Class(titleClass)], [props.workspaceRef]),
+      props.seededFacts.length === 0
+        ? h.p([h.Class(metaClass)], ['No facts seeded yet'])
+        : h.ul(
+            [h.Class('grid gap-1')],
+            props.seededFacts.map(fact =>
+              h.li([h.Class(metaClass)], [fact]),
+            ),
+          ),
+    ],
+  )
+}
+
+// `human_handoff` — escalate to a person. This is also the SAFE FALLBACK view
+// for any unknown / invalid frame.
+const humanHandoffView = <Message>(props: HumanHandoffProps): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class(cardClass)],
+    [
+      h.span([h.Class(eyebrowClass)], ['Handoff to a person']),
+      h.p([h.Class(metaClass)], [props.reason]),
+      h.p([h.Class(titleClass)], [props.contact]),
+    ],
+  )
+}
+
+// `consent_gate` — explicit consent before sensitive data / inference, with the
+// data practices listed. A confirmation gate; the action click is wired by the
+// page.
+const consentGateView = <Message>(
+  props: ConsentGateProps,
+  actionAttrs: ReadonlyArray<Attribute<Message>>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class('grid gap-2')],
+    [
+      h.div(
+        [h.Class(cardClass)],
+        [
+          h.span([h.Class(eyebrowClass)], ['Data practices']),
+          h.ul(
+            [h.Class('grid gap-1')],
+            props.dataPractices.map(practice =>
+              h.li([h.Class(metaClass)], [practice]),
+            ),
+          ),
+        ],
+      ),
+      AiElements.confirmation<Message>({
+        props: {
+          title: props.scope,
+          state: 'requested',
+          detail: props.required
+            ? 'Your consent is required to continue.'
+            : 'You can decline and continue with limited scope.',
+          approveLabel: 'I consent',
+        },
+        actions: [
+          AiElements.confirmationAction<Message>({
+            label: 'I consent',
+            variant: 'primary',
+            attrs: actionAttrs,
+          }),
+        ],
+      }),
+    ],
+  )
+}
+
+// THE CLOSED REGISTRY: catalog component name -> view. Because the input is a
+// validated `ComponentFrame` tagged union, this match is exhaustive over the
+// closed set. There is no string-keyed dynamic dispatch into arbitrary markup.
+const renderCatalogFrame = <Message>(
+  frame: ComponentFrame,
+  actions: ComponentActionAttrs<Message>,
+): Html =>
+  M.value(frame).pipe(
+    M.when({ component: 'credit_kickoff' }, ({ props }) =>
+      creditKickoffView<Message>(props, actions.credit_kickoff ?? []),
+    ),
+    M.when({ component: 'intake_progress' }, ({ props }) =>
+      intakeProgressView<Message>(props),
+    ),
+    M.when({ component: 'quick_win_card' }, ({ props }) =>
+      quickWinCardView<Message>(props),
+    ),
+    M.when({ component: 'dashboard_preview' }, ({ props }) =>
+      dashboardPreviewView<Message>(props),
+    ),
+    M.when({ component: 'human_handoff' }, ({ props }) =>
+      humanHandoffView<Message>(props),
+    ),
+    M.when({ component: 'consent_gate' }, ({ props }) =>
+      consentGateView<Message>(props, actions.consent_gate ?? []),
+    ),
+    M.exhaustive,
+  )
+
+// The SAFE FALLBACK for any frame outside the closed catalog (unknown component
+// name, or props that failed schema validation). Renders the `human_handoff`
+// view rather than anything model-authored, so the user is never shown broken
+// or untrusted UI. The model-supplied component name and reason are
+// deliberately NOT rendered here — they are operator/debug evidence on the
+// `UnknownComponentFrame`, never user-facing markup.
+const fallbackView = <Message>(): Html =>
+  humanHandoffView<Message>({
+    reason: 'We hit something we could not safely render automatically.',
+    contact: 'A teammate will follow up with you directly.',
+  })
+
+// Render a single validated frame. `registry[component] ?? fallback` is realized
+// here: a `CatalogComponentFrame` hits the closed registry; an
+// `UnknownComponentFrame` hits the safe fallback.
+export const renderComponentFrame = <Message>(
+  frame: RenderableFrame,
+  actions: ComponentActionAttrs<Message> = {},
+): Html =>
+  frame._tag === 'CatalogComponentFrame'
+    ? renderCatalogFrame<Message>(frame.frame, actions)
+    : fallbackView<Message>()
+
+// Render an ordered list of frames (e.g. the components surfaced so far in an
+// onboarding session). Prose deltas are rendered separately by the page; this
+// only renders component frames so the two interleave by document order.
+export const renderComponentFrames = <Message>(
+  frames: ReadonlyArray<RenderableFrame>,
+  actions: ComponentActionAttrs<Message> = {},
+): ReadonlyArray<Html> =>
+  frames.map(frame => renderComponentFrame<Message>(frame, actions))


### PR DESCRIPTION
Closes #6128. Part of #6123.

Client-side renderer for the typed component frames the Khala gateway emits over `event: oa.component` SSE frames, per the audit doc `docs/blitz/2026-06-23-autopilot-onboarding-intake-and-khala-audit.md` §4.3.1. Foldkit/Effect MVU + `@openagentsinc/ui` AI Elements (not React).

Self-contained module in `apps/openagents.com/apps/web/src/page/autopilot-onboarding/` for the page-assembly issue (#6129) to import. Does NOT build the full onboarding page.

## What's here

- **`component-catalog.ts`** — the closed v1 catalog as an Effect Schema tagged union over `component`: `credit_kickoff {amountCents,label}`, `intake_progress {steps[],current}`, `quick_win_card {title,scope,etaDays}`, `dashboard_preview {workspaceRef,seededFacts[]}`, `human_handoff {reason,contact}`, `consent_gate {scope,dataPractices,required}` — exact §4.3.1 shapes, versioned (`v:1`). Re-validates each frame's props with Effect Schema at render (defense in depth, mirroring the gateway). SSE parse reuses the existing `customer-order/transitions.ts` `event:`/`data:` approach through the shared `json-boundary` helper, surfacing only `oa.component` frames (prose deltas pass through untouched). An unknown component name or schema-invalid props becomes a typed `UnknownComponentFrame` — never raw model output.
- **`component-renderer.ts`** — a **closed `registry[component] ?? fallback`** realized as an exhaustive `Match` over the validated union. Each card renders with the centralized AI Elements (`confirmation`, `task`) and kit class primitives — no hand-rolled styling, no duplicated tokens. Any unknown/invalid frame renders the safe `human_handoff` fallback, never arbitrary markup. This is the real guarantee even if the gateway is bypassed.

## Acceptance

- Each catalog component renders from a frame ✓
- Unknown component name renders the fallback, not a crash ✓ (and never echoes the model-authored component name/props)
- Prose deltas and component frames interleave correctly ✓ (SSE-interleave test)
- Unit tests for registry-fallback and per-component render ✓ (24 tests across the two files)

## Verification

- `bun run typecheck:web` — clean
- New tests: 24/24 pass; full `check:deploy` web test slice (179 tests) green
- `check:architecture`, `check:effect-topology`, `check:contract-drift` — pass
- `check:deploy` aborts earlier in `verify:autopilot-desktop:deploy` on a pre-existing, environmental Verse desktop WebGL/keybinding launch smoke (`verse.keybindings.reloadIDoesNotMove`, headless fps ≈ 2.5) that is entirely outside this change's scope (web-only; touches no `apps/autopilot-desktop` code). All web/api checks that this change could affect are green.

## Coordination

Issue #6127 (separate worktree) owns the matching server-side catalog; this client catalog is defined independently to match §4.3.1 exactly. Integration (#6129) reconciles them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
