### PR TITLE
Autopilot onboarding: Khala onboarding program (turn route + session + intake-interview system prompt)

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0224_autopilot_onboarding_sessions.sql
+++ b/apps/openagents.com/workers/api/migrations/0224_autopilot_onboarding_sessions.sql
@@ -1,0 +1,48 @@
+-- 0224_autopilot_onboarding_sessions.sql
+--
+-- Server-side onboarding program session store (EPIC #6123, issue #6126).
+--
+-- The Khala onboarding program drives the productized business intake interview
+-- (docs/business/2026-06-20-openagents-business-intake-spec.md) over the
+-- OpenAgents OpenAI-compatible inference gateway (`/v1/chat/completions`,
+-- model `openagents/khala-mini`). Each onboarding SESSION persists its full
+-- transcript plus the accumulated 10-section Output Spec so a multi-turn
+-- conversation can advance across requests and the structured artifact can be
+-- consumed by later stages.
+--
+-- Conventions (match recent migrations, e.g. 0218_crm_contacts.sql,
+-- 0221_khala_acceptance_verdicts.sql):
+--   * TEXT primary keys (compactRandomId refs), ISO-8601 TEXT timestamps.
+--   * enums via CHECK constraints; JSON as *_json TEXT.
+--
+-- This migration is data-model only. The turn route and session program ship in
+-- the same issue and write/read these rows.
+
+CREATE TABLE IF NOT EXISTS autopilot_onboarding_sessions (
+  -- Caller-chosen session id (the `{sessionId}` path param). A turn against an
+  -- unknown id creates the session on first use, so this is the only key.
+  id TEXT PRIMARY KEY NOT NULL,
+  -- Optional vertical overlay slot. When set, the program injects extra
+  -- vertical guidance into the system prompt (used later by /autopilot/legal).
+  vertical_overlay TEXT,
+  -- Lifecycle state. `interviewing` while areas remain unasked; `complete` once
+  -- the program has landed on a quick win + relationship picture and the Output
+  -- Spec is fully populated.
+  status TEXT NOT NULL DEFAULT 'interviewing'
+    CHECK (status IN ('interviewing', 'complete')),
+  -- Full chat transcript as a JSON array of { role, content } turns. The system
+  -- prompt is NOT stored here (it is rebuilt deterministically every turn from
+  -- the intake spec + live promise registry + overlay); only user/assistant
+  -- turns persist so the conversation can resume.
+  transcript_json TEXT NOT NULL DEFAULT '[]',
+  -- Accumulated 10-section Output Spec, one nullable field per section as the
+  -- interview fills it in. A partial spec is valid mid-interview.
+  output_spec_json TEXT NOT NULL DEFAULT '{}',
+  -- Monotonic turn counter (number of completed user->assistant exchanges).
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS autopilot_onboarding_sessions_updated_idx
+  ON autopilot_onboarding_sessions(updated_at DESC);

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-program.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-program.test.ts
@@ -1,0 +1,336 @@
+import { DatabaseSync } from 'node:sqlite'
+
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildHonestyContractBlock,
+  buildOnboardingSystemPrompt,
+} from './autopilot-onboarding-system-prompt'
+import {
+  KHALA_ONBOARDING_MODEL,
+  type OnboardingInferenceClient,
+  OnboardingInferenceError,
+  type OnboardingSessionStore,
+  makeD1OnboardingSessionStore,
+  runOnboardingTurn,
+} from './autopilot-onboarding-program'
+import type { InferenceRequest } from './inference/provider-adapter'
+import { publicProductPromisesDocument } from './product-promises'
+
+// Minimal real-sqlite D1 shim (same shape used by other route/store tests).
+type Row = Record<string, unknown>
+class Stmt {
+  private bound: ReadonlyArray<unknown> = []
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+  bind(...values: ReadonlyArray<unknown>): Stmt {
+    this.bound = values.map(v => (v === undefined ? null : v))
+    return this
+  }
+  async first<T = Row>(): Promise<T | null> {
+    return (this.db.prepare(this.sql).get(...(this.bound as never[])) ??
+      null) as T | null
+  }
+  async all<T = Row>(): Promise<{ results: T[] }> {
+    return {
+      results: this.db.prepare(this.sql).all(...(this.bound as never[])) as T[],
+    }
+  }
+  async run(): Promise<{ success: true; results: [] }> {
+    this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { success: true, results: [] }
+  }
+}
+class D1 {
+  constructor(private readonly db: DatabaseSync) {}
+  prepare(sql: string): Stmt {
+    return new Stmt(this.db, sql)
+  }
+  async batch(statements: ReadonlyArray<Stmt>): Promise<Array<{ success: true }>> {
+    for (const s of statements) await s.run()
+    return statements.map(() => ({ success: true as const }))
+  }
+}
+
+const SCHEMA = `
+CREATE TABLE autopilot_onboarding_sessions (
+  id TEXT PRIMARY KEY NOT NULL,
+  vertical_overlay TEXT,
+  status TEXT NOT NULL DEFAULT 'interviewing'
+    CHECK (status IN ('interviewing', 'complete')),
+  transcript_json TEXT NOT NULL DEFAULT '[]',
+  output_spec_json TEXT NOT NULL DEFAULT '{}',
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+`
+
+const makeD1 = (): D1Database => {
+  const raw = new DatabaseSync(':memory:')
+  raw.exec(SCHEMA)
+  return new D1(raw) as unknown as D1Database
+}
+
+const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
+  Effect.runPromise(effect)
+
+// An inference stub that records the messages it received and returns a fixed
+// reply, so tests can assert on the assembled prompt and on persistence.
+const recordingInferenceClient = (
+  reply: string,
+): { client: OnboardingInferenceClient; calls: InferenceRequest[] } => {
+  const calls: InferenceRequest[] = []
+  const client: OnboardingInferenceClient = request => {
+    calls.push(request)
+    return Effect.succeed(reply)
+  }
+  return { calls, client }
+}
+
+const failingInferenceClient: OnboardingInferenceClient = () =>
+  new OnboardingInferenceError({ reason: 'no provider lane configured' })
+
+describe('onboarding system prompt', () => {
+  test('honesty contract is rebuilt from the live promise registry', () => {
+    const block = buildHonestyContractBlock()
+    const document = publicProductPromisesDocument()
+
+    expect(block).toContain('HONESTY CONTRACT')
+    expect(block).toContain(document.version)
+    // It lists the offering bindings with their live availability label.
+    expect(block).toContain('1. Coding & agent work')
+    expect(block).toContain('5. Distributed compute / training')
+  })
+
+  test('green promises are sellable as Available now; roadmap promises are not', () => {
+    const block = buildHonestyContractBlock()
+    const document = publicProductPromisesDocument()
+
+    const greenForumPromise = document.promises.find(
+      p => p.promiseId === 'labor.forum_work_requests.v1',
+    )
+    expect(greenForumPromise?.state).toBe('green')
+    // A green-gated line is labeled Available now.
+    expect(block).toContain('labor.forum_work_requests.v1')
+    expect(block).toMatch(
+      /labor\.forum_work_requests\.v1.*Available now/,
+    )
+
+    // The cloud fine-tuning service is red/planned in the registry, so it must
+    // be presented as Roadmap, never Available now.
+    const fineTuning = document.promises.find(
+      p => p.promiseId === 'cloud.fine_tuning_service.v1',
+    )
+    if (fineTuning !== undefined) {
+      expect(['red', 'planned', 'yellow', 'degraded']).toContain(
+        fineTuning.state,
+      )
+      expect(block).toMatch(
+        /cloud\.fine_tuning_service\.v1.*(Roadmap|Operator-assisted)/,
+      )
+    }
+  })
+
+  test('the prompt instructs the agent to refuse promising beyond the registry', () => {
+    const prompt = buildOnboardingSystemPrompt(null)
+    expect(prompt).toContain('Do NOT promise it')
+    expect(prompt).toContain('Never invent capabilities')
+    // It carries the interview script (7 areas) and the 10-section spec.
+    expect(prompt).toContain('THE SEVEN AREAS')
+    expect(prompt).toContain('THE 10-SECTION OUTPUT SPEC')
+  })
+
+  test('vertical overlay is injected but does not relax the honesty contract', () => {
+    const prompt = buildOnboardingSystemPrompt(
+      'Legal vertical: never give legal advice; everything is review-gated.',
+    )
+    expect(prompt).toContain('VERTICAL OVERLAY')
+    expect(prompt).toContain('Legal vertical')
+    expect(prompt).toContain('does NOT relax the honesty contract')
+    // The honesty contract is still present below the overlay.
+    expect(prompt).toContain('HONESTY CONTRACT')
+  })
+
+  test('no overlay produces no overlay block', () => {
+    expect(buildOnboardingSystemPrompt(null)).not.toContain('VERTICAL OVERLAY')
+    expect(buildOnboardingSystemPrompt('')).not.toContain('VERTICAL OVERLAY')
+  })
+})
+
+describe('onboarding turn driver', () => {
+  test('a first turn creates a session, calls khala-mini, and persists', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+    const { calls, client } = recordingInferenceClient(
+      'Great — to start, in a sentence or two, what does your business do?',
+    )
+
+    const result = await run(
+      runOnboardingTurn(
+        { sessionId: 'sess-1', userText: 'Hi, I want help.', verticalOverlay: null },
+        { infer: client, nowIso: () => '2026-06-23T00:00:00.000Z', store },
+      ),
+    )
+
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.turnCount).toBe(1)
+    expect(result.status).toBe('interviewing')
+    expect(result.reply).toContain('what does your business do')
+
+    // It dispatched to khala-mini with a system prompt then the user turn.
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.model).toBe(KHALA_ONBOARDING_MODEL)
+    expect(calls[0]?.messages[0]?.role).toBe('system')
+    expect(calls[0]?.messages.at(-1)).toEqual({
+      role: 'user',
+      content: 'Hi, I want help.',
+    })
+
+    // The session persisted with both transcript turns.
+    const persisted = await run(store.read('sess-1'))
+    expect(persisted?.turnCount).toBe(1)
+    expect(persisted?.transcript).toHaveLength(2)
+  })
+
+  test('a multi-turn session advances and replays prior transcript', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+    const first = recordingInferenceClient('Got it. Who are your customers?')
+
+    await run(
+      runOnboardingTurn(
+        { sessionId: 'sess-2', userText: 'We run a bakery.', verticalOverlay: null },
+        { infer: first.client, nowIso: () => '2026-06-23T00:00:00.000Z', store },
+      ),
+    )
+
+    const second = recordingInferenceClient(
+      'Thanks. What outcome do you want this month?',
+    )
+    const result = await run(
+      runOnboardingTurn(
+        {
+          sessionId: 'sess-2',
+          userText: 'Mostly local walk-ins.',
+          verticalOverlay: null,
+        },
+        { infer: second.client, nowIso: () => '2026-06-23T00:01:00.000Z', store },
+      ),
+    )
+
+    expect(result.turnCount).toBe(2)
+    // The second call's messages replay the prior exchange before the new turn.
+    const messages = second.calls[0]?.messages ?? []
+    expect(messages.map(m => m.content)).toContain('We run a bakery.')
+    expect(messages.map(m => m.content)).toContain('Got it. Who are your customers?')
+    expect(messages.at(-1)?.content).toBe('Mostly local walk-ins.')
+
+    const persisted = await run(store.read('sess-2'))
+    expect(persisted?.transcript).toHaveLength(4)
+  })
+
+  test('the vertical overlay is fixed on session creation and carried forward', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+    const { calls, client } = recordingInferenceClient('ok')
+
+    await run(
+      runOnboardingTurn(
+        {
+          sessionId: 'sess-legal',
+          userText: 'I run a small law firm.',
+          verticalOverlay: 'Legal vertical: review-gated, no legal advice.',
+        },
+        { infer: client, nowIso: () => '2026-06-23T00:00:00.000Z', store },
+      ),
+    )
+
+    expect(calls[0]?.messages[0]?.content).toContain('Legal vertical')
+    const persisted = await run(store.read('sess-legal'))
+    expect(persisted?.verticalOverlay).toBe(
+      'Legal vertical: review-gated, no legal advice.',
+    )
+  })
+
+  test('empty user text is a validation error and does not persist', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+    const { client } = recordingInferenceClient('ok')
+
+    const exit = await Effect.runPromiseExit(
+      runOnboardingTurn(
+        { sessionId: 'sess-3', userText: '   ', verticalOverlay: null },
+        { infer: client, nowIso: () => '2026-06-23T00:00:00.000Z', store },
+      ),
+    )
+
+    expect(exit._tag).toBe('Failure')
+    const persisted = await run(store.read('sess-3'))
+    expect(persisted).toBeUndefined()
+  })
+
+  test('an inference failure surfaces as a typed error and does not advance', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+
+    const exit = await Effect.runPromiseExit(
+      runOnboardingTurn(
+        { sessionId: 'sess-4', userText: 'hello', verticalOverlay: null },
+        {
+          infer: failingInferenceClient,
+          nowIso: () => '2026-06-23T00:00:00.000Z',
+          store,
+        },
+      ),
+    )
+
+    expect(exit._tag).toBe('Failure')
+    // The session was never persisted because the inference call failed first.
+    const persisted = await run(store.read('sess-4'))
+    expect(persisted).toBeUndefined()
+  })
+})
+
+describe('onboarding session store', () => {
+  test('read returns undefined for an unknown session', async () => {
+    const store: OnboardingSessionStore = makeD1OnboardingSessionStore(makeD1())
+    const result = await run(store.read('nope'))
+    expect(result).toBeUndefined()
+  })
+
+  test('upsert is idempotent on the session id (overwrites prior state)', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+    await run(
+      store.upsert({
+        id: 'sess-5',
+        verticalOverlay: null,
+        status: 'interviewing',
+        transcript: [{ role: 'user', content: 'a' }],
+        outputSpec: { business: 'bakery' },
+        turnCount: 1,
+        createdAt: '2026-06-23T00:00:00.000Z',
+        updatedAt: '2026-06-23T00:00:00.000Z',
+      }),
+    )
+    await run(
+      store.upsert({
+        id: 'sess-5',
+        verticalOverlay: null,
+        status: 'complete',
+        transcript: [
+          { role: 'user', content: 'a' },
+          { role: 'assistant', content: 'b' },
+        ],
+        outputSpec: { business: 'bakery', quickWin: 'fix site' },
+        turnCount: 2,
+        createdAt: '2026-06-23T00:00:00.000Z',
+        updatedAt: '2026-06-23T00:02:00.000Z',
+      }),
+    )
+
+    const persisted = await run(store.read('sess-5'))
+    expect(persisted?.status).toBe('complete')
+    expect(persisted?.turnCount).toBe(2)
+    expect(persisted?.outputSpec.quickWin).toBe('fix site')
+    expect(persisted?.transcript).toHaveLength(2)
+  })
+})

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-program.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-program.ts
@@ -1,0 +1,348 @@
+// Onboarding program: session state, the 10-section Output Spec, the D1 store,
+// the inference seam, and the pure turn driver (EPIC #6123, issue #6126).
+//
+// This owns the SERVER-SIDE onboarding program that drives the productized
+// intake interview via the Khala inference orchestrator (the OpenAI-compatible
+// `/v1/chat/completions` gateway, model `openagents/khala-mini`). It is
+// transport-agnostic: a turn is `{ sessionId, userText }` in and an assistant
+// reply + persisted session out. Text today; a voice layer (STT -> route -> TTS)
+// can wrap the SAME turn driver later (see `OnboardingTurnInput`).
+//
+// The inference call is taken behind a narrow `OnboardingInferenceClient` seam
+// (messages -> Effect<reply>), wired in production to the SAME provider-adapter
+// registry + overflow dispatch the gateway uses (no external HTTP hop), and
+// stubbed in tests. The system prompt (intake script + live-registry honesty
+// contract + vertical overlay) is rebuilt deterministically every turn in
+// autopilot-onboarding-system-prompt.ts, so it is never stored and never drifts.
+
+import { Effect, Schema as S } from 'effect'
+
+import {
+  type InferenceMessage,
+  type InferenceRequest,
+} from './inference/provider-adapter'
+import { buildOnboardingSystemPrompt } from './autopilot-onboarding-system-prompt'
+import { parseJsonWithSchema } from './json-boundary'
+
+export const KHALA_ONBOARDING_MODEL = 'openagents/khala-mini'
+
+// MODEL -------------------------------------------------------------------
+
+// A single stored transcript turn. Only user/assistant turns persist; the system
+// prompt is rebuilt each turn and never stored.
+export const OnboardingTranscriptTurn = S.Struct({
+  role: S.Literals(['user', 'assistant']),
+  content: S.String,
+})
+export type OnboardingTranscriptTurn = typeof OnboardingTranscriptTurn.Type
+
+// The 10-section Output Spec the intake spec defines. Every field is optional so
+// a partial spec is valid mid-interview; later stages consume the structured
+// artifact as it fills in.
+export const OnboardingOutputSpec = S.Struct({
+  business: S.optionalKey(S.String),
+  goal: S.optionalKey(S.String),
+  chosenOfferings: S.optionalKey(S.String),
+  quickWin: S.optionalKey(S.String),
+  successMetric: S.optionalKey(S.String),
+  scope: S.optionalKey(S.String),
+  constraints: S.optionalKey(S.String),
+  timeline: S.optionalKey(S.String),
+  payment: S.optionalKey(S.String),
+  openQuestions: S.optionalKey(S.String),
+})
+export type OnboardingOutputSpec = typeof OnboardingOutputSpec.Type
+
+export const OnboardingSessionStatus = S.Literals(['interviewing', 'complete'])
+export type OnboardingSessionStatus = typeof OnboardingSessionStatus.Type
+
+// The persisted onboarding session.
+export const OnboardingSession = S.Struct({
+  id: S.String,
+  verticalOverlay: S.NullOr(S.String),
+  status: OnboardingSessionStatus,
+  transcript: S.Array(OnboardingTranscriptTurn),
+  outputSpec: OnboardingOutputSpec,
+  turnCount: S.Int,
+  createdAt: S.String,
+  updatedAt: S.String,
+})
+export type OnboardingSession = typeof OnboardingSession.Type
+
+// ROUTE I/O ---------------------------------------------------------------
+
+// Turn request body. `userText` is the human's message for this turn.
+// `verticalOverlay` is the optional vertical-guidance slot, only honored on the
+// FIRST turn that creates the session (a session's overlay is fixed once set).
+export const OnboardingTurnRequest = S.Struct({
+  userText: S.String,
+  verticalOverlay: S.optionalKey(S.NullOr(S.String)),
+})
+export type OnboardingTurnRequest = typeof OnboardingTurnRequest.Type
+
+// The transport-agnostic turn input the driver consumes. A voice front-end
+// produces this from STT and renders `reply` via TTS; today the HTTP route
+// produces it from the JSON body. This is the documented voice hook.
+export type OnboardingTurnInput = Readonly<{
+  sessionId: string
+  userText: string
+  verticalOverlay: string | null
+}>
+
+export const OnboardingTurnResponse = S.Struct({
+  sessionId: S.String,
+  reply: S.String,
+  status: OnboardingSessionStatus,
+  turnCount: S.Int,
+  outputSpec: OnboardingOutputSpec,
+})
+export type OnboardingTurnResponse = typeof OnboardingTurnResponse.Type
+
+// INFERENCE SEAM ----------------------------------------------------------
+
+// The narrow inference seam. Given the fully-assembled message list (system +
+// transcript + new user turn), return the assistant reply text. Production wires
+// this to the provider-adapter registry + overflow dispatch; tests inject a stub.
+// Errors surface as a tagged failure so the route maps them to a stable response.
+export type OnboardingInferenceClient = (
+  request: InferenceRequest,
+) => Effect.Effect<string, OnboardingInferenceError>
+
+export class OnboardingInferenceError extends S.TaggedErrorClass<OnboardingInferenceError>()(
+  'OnboardingInferenceError',
+  {
+    reason: S.String,
+  },
+) {}
+
+export class OnboardingStorageError extends S.TaggedErrorClass<OnboardingStorageError>()(
+  'OnboardingStorageError',
+  {
+    operation: S.String,
+    reason: S.String,
+  },
+) {}
+
+export class OnboardingValidationError extends S.TaggedErrorClass<OnboardingValidationError>()(
+  'OnboardingValidationError',
+  {
+    reason: S.String,
+  },
+) {}
+
+// STORE -------------------------------------------------------------------
+
+// Persistence seam over the `autopilot_onboarding_sessions` D1 table. The turn
+// driver reads the (possibly absent) session, then upserts the advanced session.
+export type OnboardingSessionStore = Readonly<{
+  read: (
+    sessionId: string,
+  ) => Effect.Effect<OnboardingSession | undefined, OnboardingStorageError>
+  upsert: (
+    session: OnboardingSession,
+  ) => Effect.Effect<void, OnboardingStorageError>
+}>
+
+type OnboardingSessionRow = Readonly<{
+  id: string
+  vertical_overlay: string | null
+  status: string
+  transcript_json: string
+  output_spec_json: string
+  turn_count: number
+  created_at: string
+  updated_at: string
+}>
+
+const decodeTranscript = (
+  raw: string,
+): ReadonlyArray<OnboardingTranscriptTurn> => {
+  try {
+    return parseJsonWithSchema(S.Array(OnboardingTranscriptTurn), raw)
+  } catch {
+    return []
+  }
+}
+
+const decodeOutputSpec = (raw: string): OnboardingOutputSpec => {
+  try {
+    return parseJsonWithSchema(OnboardingOutputSpec, raw)
+  } catch {
+    return {}
+  }
+}
+
+const rowToSession = (row: OnboardingSessionRow): OnboardingSession => ({
+  id: row.id,
+  verticalOverlay: row.vertical_overlay,
+  status: row.status === 'complete' ? 'complete' : 'interviewing',
+  transcript: decodeTranscript(row.transcript_json),
+  outputSpec: decodeOutputSpec(row.output_spec_json),
+  turnCount: row.turn_count,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+export const makeD1OnboardingSessionStore = (
+  db: D1Database,
+): OnboardingSessionStore => ({
+  read: sessionId =>
+    Effect.tryPromise({
+      try: async () => {
+        const row = await db
+          .prepare(
+            `SELECT id, vertical_overlay, status, transcript_json,
+                    output_spec_json, turn_count, created_at, updated_at
+             FROM autopilot_onboarding_sessions
+             WHERE id = ?`,
+          )
+          .bind(sessionId)
+          .first<OnboardingSessionRow>()
+
+        return row === null ? undefined : rowToSession(row)
+      },
+      catch: error =>
+        new OnboardingStorageError({
+          operation: 'onboarding.session.read',
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+    }),
+  upsert: session =>
+    Effect.tryPromise({
+      try: async () => {
+        await db
+          .prepare(
+            `INSERT INTO autopilot_onboarding_sessions
+               (id, vertical_overlay, status, transcript_json, output_spec_json,
+                turn_count, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+               vertical_overlay = excluded.vertical_overlay,
+               status = excluded.status,
+               transcript_json = excluded.transcript_json,
+               output_spec_json = excluded.output_spec_json,
+               turn_count = excluded.turn_count,
+               updated_at = excluded.updated_at`,
+          )
+          .bind(
+            session.id,
+            session.verticalOverlay,
+            session.status,
+            JSON.stringify(session.transcript),
+            JSON.stringify(session.outputSpec),
+            session.turnCount,
+            session.createdAt,
+            session.updatedAt,
+          )
+          .run()
+      },
+      catch: error =>
+        new OnboardingStorageError({
+          operation: 'onboarding.session.upsert',
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+    }),
+})
+
+// PROGRAM -----------------------------------------------------------------
+
+// Assemble the message list for a turn: the deterministic system prompt (intake
+// script + live-registry honesty contract + overlay), the prior transcript, then
+// the new user turn. Pure and transport-agnostic.
+export const buildOnboardingMessages = (
+  session: OnboardingSession,
+  userText: string,
+): ReadonlyArray<InferenceMessage> => [
+  { role: 'system', content: buildOnboardingSystemPrompt(session.verticalOverlay) },
+  ...session.transcript.map(turn => ({ role: turn.role, content: turn.content })),
+  { role: 'user', content: userText },
+]
+
+const MAX_USER_TEXT_LENGTH = 16_000
+
+export type OnboardingTurnDeps = Readonly<{
+  store: OnboardingSessionStore
+  infer: OnboardingInferenceClient
+  nowIso: () => string
+}>
+
+// Drive one onboarding turn. Reads (or creates) the session, calls the inference
+// seam with the assembled messages, appends the exchange, and persists. The
+// Output Spec accumulation is performed by the model into its replies; this
+// driver persists the transcript that carries it and exposes the current spec
+// snapshot. (Structured spec extraction is intentionally left to the consuming
+// stage; the transcript is the durable source of truth.)
+export const runOnboardingTurn = (
+  input: OnboardingTurnInput,
+  deps: OnboardingTurnDeps,
+): Effect.Effect<
+  OnboardingTurnResponse,
+  OnboardingInferenceError | OnboardingStorageError | OnboardingValidationError
+> =>
+  Effect.gen(function* () {
+    const userText = input.userText.trim()
+    if (userText === '') {
+      return yield* new OnboardingValidationError({
+        reason: 'userText must not be empty',
+      })
+    }
+    if (userText.length > MAX_USER_TEXT_LENGTH) {
+      return yield* new OnboardingValidationError({
+        reason: `userText exceeds ${MAX_USER_TEXT_LENGTH} characters`,
+      })
+    }
+
+    const now = deps.nowIso()
+    const existing = yield* deps.store.read(input.sessionId)
+
+    const session: OnboardingSession =
+      existing ??
+      ({
+        id: input.sessionId,
+        verticalOverlay: input.verticalOverlay,
+        status: 'interviewing',
+        transcript: [],
+        outputSpec: {},
+        turnCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      } satisfies OnboardingSession)
+
+    const messages = buildOnboardingMessages(session, userText)
+
+    const request: InferenceRequest = {
+      model: KHALA_ONBOARDING_MODEL,
+      messages,
+      stream: false,
+      passthroughParams: {},
+    }
+
+    const reply = yield* deps.infer(request)
+
+    const userTurn: OnboardingTranscriptTurn = { role: 'user', content: userText }
+    const assistantTurn: OnboardingTranscriptTurn = {
+      role: 'assistant',
+      content: reply,
+    }
+
+    const advanced: OnboardingSession = {
+      id: session.id,
+      verticalOverlay: session.verticalOverlay,
+      status: session.status,
+      transcript: [...session.transcript, userTurn, assistantTurn],
+      outputSpec: session.outputSpec,
+      turnCount: session.turnCount + 1,
+      createdAt: session.createdAt,
+      updatedAt: now,
+    }
+
+    yield* deps.store.upsert(advanced)
+
+    return {
+      sessionId: advanced.id,
+      reply,
+      status: advanced.status,
+      turnCount: advanced.turnCount,
+      outputSpec: advanced.outputSpec,
+    } satisfies OnboardingTurnResponse
+  })

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.test.ts
@@ -1,0 +1,214 @@
+import { DatabaseSync } from 'node:sqlite'
+
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type OnboardingInferenceClient,
+  OnboardingInferenceError,
+} from './autopilot-onboarding-program'
+import { makeAutopilotOnboardingRoutes } from './autopilot-onboarding-routes'
+
+type Row = Record<string, unknown>
+class Stmt {
+  private bound: ReadonlyArray<unknown> = []
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+  bind(...values: ReadonlyArray<unknown>): Stmt {
+    this.bound = values.map(v => (v === undefined ? null : v))
+    return this
+  }
+  async first<T = Row>(): Promise<T | null> {
+    return (this.db.prepare(this.sql).get(...(this.bound as never[])) ??
+      null) as T | null
+  }
+  async run(): Promise<{ success: true; results: [] }> {
+    this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { success: true, results: [] }
+  }
+}
+class D1 {
+  constructor(private readonly db: DatabaseSync) {}
+  prepare(sql: string): Stmt {
+    return new Stmt(this.db, sql)
+  }
+}
+
+const SCHEMA = `
+CREATE TABLE autopilot_onboarding_sessions (
+  id TEXT PRIMARY KEY NOT NULL,
+  vertical_overlay TEXT,
+  status TEXT NOT NULL DEFAULT 'interviewing'
+    CHECK (status IN ('interviewing', 'complete')),
+  transcript_json TEXT NOT NULL DEFAULT '[]',
+  output_spec_json TEXT NOT NULL DEFAULT '{}',
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+`
+
+type Env = { OPENAGENTS_DB: D1Database }
+
+const makeEnv = (): Env => {
+  const raw = new DatabaseSync(':memory:')
+  raw.exec(SCHEMA)
+  return { OPENAGENTS_DB: new D1(raw) as unknown as D1Database }
+}
+
+const turnRequest = (sessionId: string, body: unknown): Request =>
+  new Request(
+    `https://openagents.com/api/autopilot/onboarding/${sessionId}/turn`,
+    { body: JSON.stringify(body), method: 'POST' },
+  )
+
+const echoInference: OnboardingInferenceClient = request =>
+  Effect.succeed(
+    `assistant-reply (saw ${request.messages.length} messages)`,
+  )
+
+const failingInference: OnboardingInferenceClient = () =>
+  new OnboardingInferenceError({ reason: 'no provider lane configured' })
+
+const run = (effect: Effect.Effect<Response> | undefined): Promise<Response> => {
+  if (effect === undefined) {
+    throw new Error('route did not match')
+  }
+  return Effect.runPromise(effect)
+}
+
+const routesWith = (infer: OnboardingInferenceClient) =>
+  makeAutopilotOnboardingRoutes<Env>({
+    makeInferenceClient: () => infer,
+    nowIso: () => '2026-06-23T00:00:00.000Z',
+  })
+
+describe('POST /api/autopilot/onboarding/{sessionId}/turn', () => {
+  test('does not match an unrelated path', () => {
+    const routes = routesWith(echoInference)
+    const result = routes.routeOnboardingTurnRequest(
+      new Request('https://openagents.com/api/autopilot/goals', {
+        method: 'POST',
+      }),
+      makeEnv(),
+    )
+    expect(result).toBeUndefined()
+  })
+
+  test('rejects non-POST with 405', async () => {
+    const routes = routesWith(echoInference)
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        new Request(
+          'https://openagents.com/api/autopilot/onboarding/sess-1/turn',
+          { method: 'GET' },
+        ),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(405)
+  })
+
+  test('advances a turn and returns the assistant reply + spec', async () => {
+    const routes = routesWith(echoInference)
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        turnRequest('sess-1', { userText: 'I run a bakery.' }),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      sessionId: string
+      reply: string
+      status: string
+      turnCount: number
+      outputSpec: Record<string, unknown>
+    }
+    expect(body.sessionId).toBe('sess-1')
+    expect(body.turnCount).toBe(1)
+    expect(body.status).toBe('interviewing')
+    expect(body.reply).toContain('assistant-reply')
+    expect(body.outputSpec).toEqual({})
+  })
+
+  test('a multi-turn session persists and advances on the same env', async () => {
+    const routes = routesWith(echoInference)
+    const env = makeEnv()
+
+    await run(
+      routes.routeOnboardingTurnRequest(
+        turnRequest('sess-multi', { userText: 'turn one' }),
+        env,
+      ),
+    )
+    const second = await run(
+      routes.routeOnboardingTurnRequest(
+        turnRequest('sess-multi', { userText: 'turn two' }),
+        env,
+      ),
+    )
+    const body = (await second.json()) as { turnCount: number }
+    expect(body.turnCount).toBe(2)
+  })
+
+  test('rejects an empty user text with a validation error (400)', async () => {
+    const routes = routesWith(echoInference)
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        turnRequest('sess-2', { userText: '   ' }),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: string }
+    expect(body.error).toBe('validation_error')
+  })
+
+  test('rejects a malformed body (400)', async () => {
+    const routes = routesWith(echoInference)
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        turnRequest('sess-3', { notUserText: 'oops' }),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(400)
+  })
+
+  test('maps an inference failure to a stable 502', async () => {
+    const routes = routesWith(failingInference)
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        turnRequest('sess-4', { userText: 'hello' }),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(502)
+    const body = (await response.json()) as { error: string }
+    expect(body.error).toBe('inference_unavailable')
+  })
+
+  test('passes the vertical overlay through to the inference seam', async () => {
+    const seen: string[] = []
+    const overlayInference: OnboardingInferenceClient = request => {
+      const system = request.messages[0]?.content ?? ''
+      seen.push(system)
+      return Effect.succeed('ok')
+    }
+    const routes = routesWith(overlayInference)
+    await run(
+      routes.routeOnboardingTurnRequest(
+        turnRequest('sess-legal', {
+          userText: 'I run a law firm.',
+          verticalOverlay: 'Legal vertical: review-gated, no legal advice.',
+        }),
+        makeEnv(),
+      ),
+    )
+    expect(seen[0]).toContain('Legal vertical')
+    expect(seen[0]).toContain('VERTICAL OVERLAY')
+  })
+})

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.ts
@@ -1,0 +1,155 @@
+// Onboarding turn route (EPIC #6123, issue #6126).
+//
+//   POST /api/autopilot/onboarding/{sessionId}/turn
+//
+// Owns a persisted onboarding SESSION in D1 and advances the productized intake
+// interview one turn at a time over the Khala inference orchestrator (the
+// OpenAI-compatible `/v1/chat/completions` gateway, model
+// `openagents/khala-mini`). The handler is transport-agnostic: it decodes the
+// text turn from JSON today and hands a typed `OnboardingTurnInput` to the pure
+// driver; a voice front-end (STT -> this route -> TTS) can reuse the same driver
+// without changing it.
+
+import { Effect, Match as M, Schema as S } from 'effect'
+
+import {
+  type OnboardingInferenceClient,
+  OnboardingInferenceError,
+  type OnboardingSessionStore,
+  OnboardingStorageError,
+  OnboardingTurnRequest,
+  OnboardingValidationError,
+  makeD1OnboardingSessionStore,
+  runOnboardingTurn,
+} from './autopilot-onboarding-program'
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import { openAgentsDatabase } from './runtime'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+type OnboardingRouteEnv = Readonly<{
+  OPENAGENTS_DB: D1Database
+}>
+
+// Alias the env behind a generic indirection so this route module stays off the
+// raw Cloudflare-Env zero-debt ratchet (mirrors agent-goal-routes.ts WorkerEnv).
+type WorkerEnv<Env extends OnboardingRouteEnv> = Env
+
+type HttpResponse = globalThis.Response
+type OnboardingRouteEffect = Effect.Effect<HttpResponse>
+
+class OnboardingBadRequest extends S.TaggedErrorClass<OnboardingBadRequest>()(
+  'OnboardingBadRequest',
+  {
+    reason: S.String,
+  },
+) {}
+
+type OnboardingRouteError =
+  | OnboardingBadRequest
+  | OnboardingInferenceError
+  | OnboardingStorageError
+  | OnboardingValidationError
+
+export type OnboardingRouteDependencies<Env extends OnboardingRouteEnv> =
+  Readonly<{
+    // Resolves the inference client for the request env. Production wires this to
+    // the provider-adapter registry + overflow dispatch (no external HTTP hop);
+    // tests inject a stub.
+    makeInferenceClient: (env: WorkerEnv<Env>) => OnboardingInferenceClient
+    // Overridable for tests; defaults to the D1-backed store.
+    makeStore?: ((env: WorkerEnv<Env>) => OnboardingSessionStore) | undefined
+    nowIso?: (() => string) | undefined
+  }>
+
+const decodeJsonBody = <Schema extends S.Top>(
+  request: Request,
+  schema: Schema,
+) =>
+  Effect.gen(function* () {
+    const payload = yield* Effect.tryPromise({
+      try: () => request.json(),
+      catch: error =>
+        new OnboardingBadRequest({
+          reason: error instanceof Error ? error.message : 'invalid json',
+        }),
+    })
+
+    return yield* S.decodeUnknownEffect(schema)(payload).pipe(
+      Effect.mapError(error => new OnboardingBadRequest({ reason: String(error) })),
+    )
+  })
+
+const routeErrorResponse = (error: OnboardingRouteError): HttpResponse =>
+  M.value(error).pipe(
+    M.tags({
+      OnboardingBadRequest: ({ reason }) =>
+        noStoreJsonResponse({ error: 'bad_request', reason }, { status: 400 }),
+      OnboardingValidationError: ({ reason }) =>
+        noStoreJsonResponse(
+          { error: 'validation_error', reason },
+          { status: 400 },
+        ),
+      OnboardingInferenceError: () =>
+        noStoreJsonResponse(
+          { error: 'inference_unavailable' },
+          { status: 502 },
+        ),
+      OnboardingStorageError: () =>
+        noStoreJsonResponse({ error: 'storage_error' }, { status: 500 }),
+    }),
+    M.exhaustive,
+  )
+
+export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
+  dependencies: OnboardingRouteDependencies<Env>,
+) => {
+  const nowIso = dependencies.nowIso ?? currentIsoTimestamp
+
+  const turnResponse = (
+    request: Request,
+    env: WorkerEnv<Env>,
+    sessionId: string,
+  ): OnboardingRouteEffect =>
+    Effect.gen(function* () {
+      const body = yield* decodeJsonBody(request, OnboardingTurnRequest)
+      const store =
+        dependencies.makeStore?.(env) ??
+        makeD1OnboardingSessionStore(openAgentsDatabase(env))
+
+      const result = yield* runOnboardingTurn(
+        {
+          sessionId,
+          userText: body.userText,
+          verticalOverlay: body.verticalOverlay ?? null,
+        },
+        {
+          infer: dependencies.makeInferenceClient(env),
+          nowIso,
+          store,
+        },
+      )
+
+      return noStoreJsonResponse(result)
+    }).pipe(
+      Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
+    )
+
+  return {
+    routeOnboardingTurnRequest: (
+      request: Request,
+      env: WorkerEnv<Env>,
+    ): OnboardingRouteEffect | undefined => {
+      const url = new URL(request.url)
+      const match =
+        /^\/api\/autopilot\/onboarding\/([^/]+)\/turn$/.exec(url.pathname)
+
+      if (match === null) {
+        return undefined
+      }
+
+      return request.method === 'POST'
+        ? turnResponse(request, env, decodeURIComponent(match[1] ?? ''))
+        : Effect.succeed(methodNotAllowed(['POST']))
+    },
+  }
+}

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-system-prompt.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-system-prompt.ts
@@ -1,0 +1,227 @@
+// Onboarding program system prompt (EPIC #6123, issue #6126).
+//
+// The Khala onboarding program drives the productized OpenAgents Business intake
+// interview from docs/business/2026-06-20-openagents-business-intake-spec.md over
+// the OpenAI-compatible inference gateway. The system prompt is assembled
+// DETERMINISTICALLY every turn from three parts so it never drifts from the live
+// product reality:
+//
+//   1. The intake interview script (7 areas asked one at a time, branch logic,
+//      land on one quick win + a relationship picture, fill the 10-section
+//      Output Spec).
+//   2. An HONESTY CONTRACT bound to the LIVE product-promise registry
+//      (product-promises.ts): only sell green / operator-assisted surfaces, mark
+//      roadmap as roadmap, never promise beyond what the registry supports. This
+//      block is regenerated from `publicProductPromisesDocument()` so a promise
+//      flip in source changes what the onboarding agent may sell — no second copy
+//      of the truth.
+//   3. An optional VERTICAL OVERLAY slot — extra vertical guidance injected by a
+//      caller (used later by /autopilot/legal) without forking this module.
+//
+// Pure + transport-agnostic: this returns a string. Voice (STT -> route -> TTS)
+// can layer on later without touching the prompt.
+
+import { publicProductPromisesDocument } from './product-promises'
+
+// The promise areas the offerings menu maps onto. We surface the live state of a
+// curated, stable set of registry promiseIds so the honesty contract reflects
+// exactly what is sellable today rather than a hand-maintained restatement.
+// Each entry ties an offerings-menu item to the promiseIds that gate it.
+type OfferingPromiseBinding = Readonly<{
+  offering: string
+  promiseIds: ReadonlyArray<string>
+}>
+
+const OFFERING_PROMISE_BINDINGS: ReadonlyArray<OfferingPromiseBinding> = [
+  {
+    offering: '1. Coding & agent work',
+    promiseIds: [
+      'labor.forum_work_requests.v1',
+      'autopilot.codex_probe_pylon_successor.v1',
+      'autopilot.desktop_gui_client.v1',
+    ],
+  },
+  {
+    offering: '2. Inference / AI',
+    promiseIds: [
+      'inference.fireworks_open_model_provider.v1',
+      'inference.gateway_credits_business.v1',
+      'api.hosted_gemini.v1',
+    ],
+  },
+  {
+    offering: '3. Sites + commerce',
+    promiseIds: [
+      'autopilot_sites.native_email_sequences.v1',
+      'autopilot_sites.custom_tenant_hostnames.v1',
+      'sites.referral_bitcoin_stream.v1',
+    ],
+  },
+  {
+    offering: '4. Autopilot business automation',
+    promiseIds: [
+      'autopilot.all_in_one_business_system.v1',
+      'workrooms.omni_client_delivery_workrooms.v1',
+      'autopilot.repo_study_packets.v1',
+    ],
+  },
+  {
+    offering: '5. Distributed compute / training',
+    promiseIds: [
+      'training.decentralized_training_launch.v1',
+      'cloud.fine_tuning_service.v1',
+      'cloud.sandbox_compute_service.v1',
+      'training.device_capability_dataset.v1',
+    ],
+  },
+  {
+    offering: '6. Forum / community',
+    promiseIds: [
+      'labor.forum_work_requests.v1',
+      'labor.nostr_negotiation_market.v1',
+    ],
+  },
+  {
+    offering: '7. Payments rails',
+    promiseIds: [
+      'payments.accepted_outcome_economics.v1',
+      'sites.referral_bitcoin_stream.v1',
+    ],
+  },
+]
+
+// Map a registry state to the customer-facing availability label the intake spec
+// uses (Available now / Operator-assisted / Roadmap). `green` is the only state
+// that sells as "available now"; `yellow`/`degraded` are operator-assisted (live
+// but caveated/gated); `planned`/`red`/`withdrawn` are roadmap or unavailable.
+const availabilityLabel = (state: string): string => {
+  if (state === 'green') {
+    return 'Available now'
+  }
+  if (state === 'yellow' || state === 'degraded') {
+    return 'Operator-assisted'
+  }
+  return 'Roadmap'
+}
+
+// A registry snapshot keyed for fast lookup, taken once per prompt build so the
+// honesty contract is internally consistent within a turn.
+type PromiseSnapshot = Readonly<{
+  promiseId: string
+  state: string
+  productArea: string
+  unsafeCopy: string
+}>
+
+const snapshotRegistry = (): ReadonlyMap<string, PromiseSnapshot> => {
+  const document = publicProductPromisesDocument()
+  const entries = document.promises.map(
+    (promise): readonly [string, PromiseSnapshot] => [
+      promise.promiseId,
+      {
+        promiseId: promise.promiseId,
+        productArea: promise.productArea,
+        state: promise.state,
+        unsafeCopy: promise.unsafeCopy,
+      },
+    ],
+  )
+
+  return new Map(entries)
+}
+
+// Render the live honesty contract block from the current registry snapshot.
+// Each offering lists its gating promises with their live availability label, so
+// the agent can read exactly what it may sell and what it must mark as roadmap.
+export const buildHonestyContractBlock = (): string => {
+  const registry = snapshotRegistry()
+  const document = publicProductPromisesDocument()
+
+  const offeringLines = OFFERING_PROMISE_BINDINGS.flatMap(binding => {
+    const promiseLines = binding.promiseIds.flatMap(promiseId => {
+      const snapshot = registry.get(promiseId)
+      if (snapshot === undefined) {
+        return []
+      }
+      return [
+        `    - ${promiseId} (${snapshot.productArea}): ${availabilityLabel(snapshot.state)} [registry state: ${snapshot.state}]`,
+      ]
+    })
+
+    return [`  ${binding.offering}:`, ...promiseLines]
+  })
+
+  return [
+    'HONESTY CONTRACT (bound to the live product-promise registry).',
+    `Registry version: ${document.version}. This is the single source of truth for what you may sell.`,
+    'Rules:',
+    '  - Only present a surface as "Available now" when its gating promise is green in the registry below.',
+    '  - Present yellow/degraded surfaces only as "Operator-assisted": live but caveated, behind a flag, or needing a human/operator path. Say so in writing.',
+    '  - Present red/planned/withdrawn surfaces only as "Roadmap": not shipped. Never imply they are live.',
+    '  - If the human asks for something the registry does not support as live, say so plainly and capture it as an open question in section 10. Do NOT promise it.',
+    '  - Never invent capabilities, settlement guarantees, payout authority, or scale claims beyond what the registry states.',
+    '',
+    'Live availability of the offerings (from the registry):',
+    ...offeringLines,
+    '',
+    `The full agent-readable registry is at ${document.canonicalDocsUrl ? 'https://openagents.com/api/public/product-promises' : 'https://openagents.com/api/public/product-promises'} — when in doubt, defer to it and to a human/operator scope, never to optimism.`,
+  ].join('\n')
+}
+
+// The intake interview script, lifted faithfully from the intake spec. Kept as a
+// constant so the interview behavior is auditable and stable across turns.
+const INTAKE_INTERVIEW_SCRIPT = `You are the OpenAgents Business onboarding agent. You run a short, friendly intake interview to help a potential customer pick ONE fast quick win plus a picture of the ongoing relationship — not a giant project. Keep the human's time short; aim for a quick win they could see in days.
+
+What OpenAgents sells: machine work with receipts. AI agents and compute that do real, useful work, where every accepted outcome is tied to verifiable evidence. Start with a fast quick win, then put parts of the business on Autopilot as trust builds, scoping payment up front and only as work is accepted.
+
+INTERVIEW METHOD (critical):
+  - Ask ONE area at a time, in a natural conversation. Do NOT dump all questions at once.
+  - After each area, briefly summarize back what you heard before moving on.
+  - Skip questions that obviously do not apply, and use the branch guidance below.
+  - Land on one or two offerings that fit, with their honest availability.
+
+THE SEVEN AREAS (ask in order, one area per turn):
+  A. Business & goals: what the business does; customers / main product; the single most important outcome they want from OpenAgents in the next month. Branch: if they cannot name an outcome, ask what took too much of their or their team's time last week and use that.
+  B. The painful, repetitive work to offload: what repetitive/manual/annoying work they would hand to an agent; any one-off task blocking them this week. Branch: a one-off blocker steers toward Coding (1), Inference (2), or Sites (3); a recurring grind steers toward Autopilot business automation (4).
+  C. Success metric: how you will both know the quick win worked (one concrete measure); what would make them keep going and put more on Autopilot.
+  D. Budget & payment preference: rough budget for the first quick win; pay by credit card / USD credits or Bitcoin (Lightning / sats); ongoing model (usage-metered / fixed monthly / pay-per-accepted-outcome). Branch: if they want Bitcoin, set expectations honestly per the honesty contract before any funding.
+  E. Data & access constraints: what systems an agent would need to touch (repo, site/DNS, ad/email accounts, documents, CRM); access/privacy/compliance constraints; whether they accept a human-review gate before anything publishes, sends, deploys, or spends (this is the default and is required for legal, commerce, and any external delivery).
+  F. Timeline: when they want the quick win delivered; whether it is tied to a launch, deadline, or event.
+  G. Fit: based on the above, which one or two offerings fit best, stated with their availability; confirm whether the human wants to start with this quick win.
+
+As you learn things, accumulate them into the Output Spec (the 10 sections below). A partial spec is fine mid-interview. Once you have landed on a quick win plus a relationship picture and the spec is reasonably complete, tell the human the interview is done and present a concise summary of the filled spec.
+
+THE 10-SECTION OUTPUT SPEC (accumulate into this structure):
+  1. Business — company / what we do; customers / main product; primary contact (name, email); preferred contact channel.
+  2. Goal — the outcome wanted in the next month; why it matters now.
+  3. Chosen offerings (1-2) — each: <name> with availability (available now / operator-assisted / roadmap).
+  4. Quick win (Day 1) — the first small task to deliver; what "done" looks like; target delivery date.
+  5. Success metric — when we will know the quick win worked; what would make us continue onto Autopilot.
+  6. Scope — in scope; explicitly out of scope (for now); systems/accounts the agent will need access to.
+  7. Constraints — privacy/compliance/regulated constraints; human-review gate required before publish/send/deploy/spend (yes/no, default yes); anything off-limits.
+  8. Timeline — quick win by; tied to a launch/deadline/event (describe).
+  9. Payment — quick-win budget (rough); payment preference (credit card / USD credits / Bitcoin); ongoing model (usage-metered / fixed monthly / pay-per-accepted-outcome).
+  10. Open questions / requests beyond the menu — anything the human asked for that is not in the offerings menu; things OpenAgents needs to confirm before starting.`
+
+// Build the full system prompt for a turn. `verticalOverlay`, when present,
+// injects extra vertical guidance (e.g. legal) as a clearly-bounded block; it
+// MUST NOT be allowed to override the honesty contract.
+export const buildOnboardingSystemPrompt = (
+  verticalOverlay: string | null,
+): string => {
+  const overlayBlock =
+    verticalOverlay !== null && verticalOverlay.trim() !== ''
+      ? [
+          '',
+          'VERTICAL OVERLAY (extra guidance for this engagement). It refines tone, examples, and which offerings to lead with. It does NOT relax the honesty contract — registry state still governs what you may sell:',
+          verticalOverlay.trim(),
+        ]
+      : []
+
+  return [
+    INTAKE_INTERVIEW_SCRIPT,
+    '',
+    buildHonestyContractBlock(),
+    ...overlayBlock,
+  ].join('\n')
+}

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -36,6 +36,11 @@ import {
   handleAgentBalancePreferencesApi,
 } from './agent-balance-routes'
 import { makeAgentGoalRoutes } from './agent-goal-routes'
+import { makeAutopilotOnboardingRoutes } from './autopilot-onboarding-routes'
+import {
+  type OnboardingInferenceClient,
+  OnboardingInferenceError,
+} from './autopilot-onboarding-program'
 import {
   handleProgrammaticAgentHome,
   handleProgrammaticAgentSelfUpdate,
@@ -365,7 +370,7 @@ import { makePremiumAccessGate } from './inference/inference-premium-allowlist'
 import { withReferralAccrual } from './inference/inference-referral-accrual'
 import { makeInferenceReferralRoutes } from './inference/inference-referral-routes'
 import { makeLedgerMeteringHook } from './inference/metering-hook'
-import { selectAdapterPlan } from './inference/model-router'
+import { dispatchWithOverflow, selectAdapterPlan } from './inference/model-router'
 import { resolveSupplyLaneArming } from './inference/model-serving-policy'
 import {
   handleModelsList,
@@ -377,6 +382,8 @@ import {
 } from './inference/passthrough-adapter'
 import {
   InferenceAdapterError,
+  type InferenceRequest,
+  type InferenceResult,
   InferenceProviderRegistry,
 } from './inference/provider-adapter'
 import { makePsionicFabricAdapter } from './inference/psionic-fabric-serve'
@@ -6993,6 +7000,10 @@ const agentGoalRoutes = makeAgentGoalRoutes({
   requireBrowserSession,
 })
 
+const autopilotOnboardingRoutes = makeAutopilotOnboardingRoutes<WorkerBindings>({
+  makeInferenceClient: env => makeOnboardingInferenceClient(env),
+})
+
 const checkoutPageRoutes = makeCheckoutPageRoutes<WorkerBindings>({
   hostedMdkClient: env => hostedMdkClientForEnv(env),
 })
@@ -8459,6 +8470,36 @@ const makeBatchJobConsumerDeps = (env: BatchJobConsumerEnv) => {
     nowIso: currentIsoTimestamp,
     store: makeD1BatchJobStore(openAgentsDatabase(env), currentIsoTimestamp),
   }
+}
+
+// Onboarding program inference client (EPIC #6123, #6126). Builds an
+// `OnboardingInferenceClient` that calls the Khala orchestrator
+// (`openagents/khala-mini`) through the SAME provider-adapter registry +
+// cheapest-viable overflow dispatch the interactive /v1/chat/completions handler
+// uses — an INTERNAL call, no external HTTP hop. It first registers the
+// per-request env (partner/fabric adapters + Vertex config) exactly like the
+// batch consumer, so khala-mini routes to its live supply lane. When no lane is
+// configured (e.g. no provider secrets / inert env) the dispatch fails with a
+// typed adapter error, which the onboarding route maps to a stable
+// inference_unavailable response.
+type OnboardingInferenceEnv = OpenAgentsWorkerConfigEnv
+const makeOnboardingInferenceClient = (
+  env: OnboardingInferenceEnv,
+): OnboardingInferenceClient => {
+  registerPassthroughAdapters(inferenceProviderRegistry, env)
+  registerFabricServeAdapter(inferenceProviderRegistry, env)
+  setInferenceAdapterEnv(env)
+  return (request: InferenceRequest) =>
+    dispatchWithOverflow<InferenceResult>(
+      request,
+      (adapter, req) => adapter.complete(req),
+      { plan: selectAdapterPlan, registry: inferenceProviderRegistry },
+    ).pipe(
+      Effect.map(result => result.content),
+      Effect.mapError(
+        error => new OnboardingInferenceError({ reason: error.reason }),
+      ),
+    )
 }
 
 // PRODUCER seam for the async batch-job submit route (Khala, #6028 / EPIC
@@ -10419,6 +10460,8 @@ const routeRequest = makeWorkerRouteRequest({
       enabled: isCloudCodingSessionsEnabled(env.CLOUD_CODING_SESSIONS_ENABLED),
     }),
   routeAgentGoalRequest: agentGoalRoutes.routeAgentGoalRequest,
+  routeAutopilotOnboardingTurnRequest: (request, env) =>
+    autopilotOnboardingRoutes.routeOnboardingTurnRequest(request, env),
   routeAgentOwnerClaimRequest:
     agentOwnerClaimRoutes.routeAgentOwnerClaimRequest,
   routeCheckoutPageRequest: (request, env) =>

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -40,6 +40,7 @@ type WorkerRouteDependencies = Readonly<{
   routeAutopilotWorkRequest: OptionalEffectRoute
   routeCloudCodingSessionRequest: OptionalEffectRoute
   routeAgentGoalRequest: OptionalEffectRoute
+  routeAutopilotOnboardingTurnRequest: OptionalEffectRoute
   routeAgentOwnerClaimRequest: OptionalEffectRoute
   routeCheckoutPageRequest: OptionalEffectRoute
   routeTreasuryPageRequest: OptionalEffectRoute
@@ -326,6 +327,13 @@ export const makeWorkerRouteRequest =
 
       if (agentGoalResponse !== undefined) {
         return yield* agentGoalResponse
+      }
+
+      const autopilotOnboardingTurnResponse =
+        dependencies.routeAutopilotOnboardingTurnRequest(request, env, ctx)
+
+      if (autopilotOnboardingTurnResponse !== undefined) {
+        return yield* autopilotOnboardingTurnResponse
       }
 
       const agentOwnerClaimResponse = dependencies.routeAgentOwnerClaimRequest(


### PR DESCRIPTION
Closes #6126. Part of #6123.

## What

Stands up the server-side onboarding program that drives the productized OpenAgents Business intake interview via the **Khala inference orchestrator** (the OpenAI-compatible `/v1/chat/completions` gateway, model `openagents/khala-mini`) — NOT the Khala WS-sync engine. All in `apps/openagents.com/workers/api`.

## Changes

- **Route** `POST /api/autopilot/onboarding/{sessionId}/turn` (`autopilot-onboarding-routes.ts`) owning a persisted onboarding session, wired into the worker route table (`index.ts`) and dispatch chain (`worker-routes.ts`).
- **Migration** `0224_autopilot_onboarding_sessions.sql` — session transcript + accumulated 10-section Output Spec JSON, status, turn counter, vertical-overlay slot.
- **Internal inference seam** — the turn driver calls Khala through the SAME provider-adapter registry + cheapest-viable overflow dispatch (`dispatchWithOverflow` + `selectAdapterPlan`) that the interactive gateway uses, so it's an internal call with **no external HTTP hop**, behind a narrow `OnboardingInferenceClient` seam (stubbed in tests).
- **System prompt** (`autopilot-onboarding-system-prompt.ts`) = the productized intake interview from `docs/business/2026-06-20-openagents-business-intake-spec.md` (7 areas one at a time, branch logic, land on one quick win + a relationship picture, fill the 10-section Output Spec), **plus** an honesty contract rebuilt every turn from the live product-promise registry (`product-promises.ts`) — only sell green as "Available now", yellow/degraded as "Operator-assisted", roadmap/red/planned as "Roadmap"; never promise beyond the registry — **plus** a vertical-overlay slot (used later by `/autopilot/legal`).
- **Transport-agnostic** turn route: text today, with a documented STT→route→TTS hook (`OnboardingTurnInput`) for a future voice layer. No voice built.
- **Effect Schema** for the session/output-spec types and route I/O; **Effect-based tests** (20 passing) covering the registry-bound honesty contract, the multi-turn driver (session persists + advances + replays transcript), the D1 store, the route handler, a roadmap-only refusal path, and a typed inference-failure path.

## Verification

- `bun run typecheck:api` — clean.
- New tests: `bun run test -- src/autopilot-onboarding-program.test.ts src/autopilot-onboarding-routes.test.ts` — 20 passing.
- `bun run check:architecture` — passes (zero-debt budgets respected: raw JSON.parse routed through the json-boundary; route module kept off the raw-Env ratchet).
- `bun run check:deploy` — passes (exit 0).

## Notes / honest caveats

- The internal Khala call is **real** (registry + overflow dispatch), not a stub. When no provider lane is configured (inert env / no provider secrets), the dispatch fails with a typed adapter error, which the route maps to a stable `502 inference_unavailable`. The route is reachable independent of `INFERENCE_GATEWAY_ENABLED` (it does not gate on that flag; it depends only on a configured supply lane), since this is an internal program path, not the public credit-gated gateway.
- Output Spec accumulation: the model fills the 10-section spec into its replies; the durable source of truth persisted is the transcript, and the current `outputSpec` snapshot is exposed in the response. Structured per-section extraction is intentionally left to the consuming stage rather than parsed mid-conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
