### PR TITLE
Worker-native MPP credential verification + settlement (defect B)

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0224_mpp_spt_replay_cache.sql
+++ b/apps/openagents.com/workers/api/migrations/0224_mpp_spt_replay_cache.sql
@@ -1,0 +1,24 @@
+-- MPP Stripe SPT single-use replay cache (EPIC #6049, defect B).
+--
+-- The Payment Auth core spec requires single-use payment proofs, and the Stripe
+-- charge intent (draft-stripe-charge-00 §"Verification Procedure" step 4) makes
+-- the server enforce that an SPT (`spt_…`) is not used twice. Stripe also
+-- prevents SPT reuse at the API level, and the PaymentIntent idempotency key
+-- (`<challengeId>_<spt>`) prevents duplicate charges; this local cache is the
+-- defense-in-depth replay guard the spec says servers MAY/SHOULD additionally
+-- keep. We record the consumed SPT keyed on its id; a second attempt collides on
+-- the PRIMARY KEY and is rejected before any second Stripe charge.
+--
+-- INERT NOTE: this table is only written on the card/SPT rail, which itself is
+-- inert until STRIPE_MPP_NETWORK_PROFILE_ID + KHALA_MPP_ENABLED + STRIPE_API_KEY
+-- are all configured. The crypto rail does not touch it.
+
+CREATE TABLE IF NOT EXISTS mpp_spt_replay (
+  -- The Shared Payment Token id (starts with `spt_`).
+  spt TEXT PRIMARY KEY,
+  -- The challenge id the SPT was consumed under (binds the proof to the quote).
+  challenge_id TEXT NOT NULL,
+  -- The resulting Stripe PaymentIntent id, for dereference.
+  payment_intent_id TEXT,
+  consumed_at TEXT NOT NULL
+);

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -143,6 +143,14 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // Stripe REST API. Worker secret; never committed/logged. Absent => the MPP
   // endpoint is fail-safe inert and never constructs a charge.
   STRIPE_API_KEY?: string | undefined
+  // The MPP/Payment-Auth challenge-binding signing secret (EPIC #6049, defect B).
+  // The 402 challenge `id` is HMAC-SHA256(secret, canonical challenge fields), so
+  // the Worker verifies a retry credential STATELESSLY (draft-httpauth-payment-00
+  // §5.1.3). Worker SECRET; never committed/logged. Set via
+  //   wrangler secret put KHALA_MPP_SIGNING_SECRET
+  // Absent => the MPP endpoint is fail-safe inert and never issues a challenge or
+  // verifies a credential (alongside KHALA_MPP_ENABLED + STRIPE_API_KEY).
+  KHALA_MPP_SIGNING_SECRET?: string | undefined
   // Cloud primitive scaffold feature flags (EPIC #5510, #5516/#5517). Default
   // OFF: the `/v1/fine_tuning/jobs` and `/v1/sandboxes` routes are inert on the
   // live Worker until those builds land. Set "true"/"1"/"on" to enable. The

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -10154,6 +10154,7 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
       return handleMppChatCompletions(request, {
         db: openAgentsDatabase(env),
         enabled: isKhalaMppEnabled(env.KHALA_MPP_ENABLED),
+        signingSecret: env.KHALA_MPP_SIGNING_SECRET,
         stripeNetworkProfileId: env.STRIPE_MPP_NETWORK_PROFILE_ID,
         stripeSecretKey: env.STRIPE_API_KEY,
         // The underlying Khala completion reuses the SAME registry, metering

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-canonical.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-canonical.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  base64UrlDecode,
+  base64UrlEncode,
+  canonicalJson,
+  challengeBindingInput,
+  computeChallengeId,
+  constantTimeEqual,
+  decodeJcsBase64UrlRecord,
+  jcsBase64Url,
+} from './mpp-canonical'
+
+describe('mpp-canonical — base64url-nopad', () => {
+  test('round-trips a UTF-8 string with no padding', () => {
+    const value = '{"a":1,"b":"two"}'
+    const encoded = base64UrlEncode(value)
+    expect(encoded).not.toContain('=')
+    expect(encoded).not.toContain('+')
+    expect(encoded).not.toContain('/')
+    expect(base64UrlDecode(encoded)).toBe(value)
+  })
+
+  test('decode returns undefined for invalid input', () => {
+    // A character outside the base64url alphabet.
+    expect(base64UrlDecode('!!not-valid!!')).toBeUndefined()
+  })
+})
+
+describe('mpp-canonical — JCS (RFC 8785)', () => {
+  test('sorts object keys deterministically regardless of insertion order', () => {
+    const a = canonicalJson({ b: '2', a: '1', c: '3' })
+    const b = canonicalJson({ c: '3', a: '1', b: '2' })
+    expect(a).toBe(b)
+    expect(a).toBe('{"a":"1","b":"2","c":"3"}')
+  })
+
+  test('omits undefined members and serializes nested objects', () => {
+    expect(
+      canonicalJson({ z: undefined, a: { y: '2', x: '1' } }),
+    ).toBe('{"a":{"x":"1","y":"2"}}')
+  })
+
+  test('jcsBase64Url then decode is a stable round-trip', () => {
+    const opaque = { pi: 'pi_123', amount: '100', network: 'base' }
+    const encoded = jcsBase64Url(opaque)
+    const decoded = decodeJcsBase64UrlRecord(encoded)
+    expect(decoded).toEqual(opaque)
+    // Re-encoding the decoded record yields the SAME base64url (canonical).
+    expect(jcsBase64Url(decoded)).toBe(encoded)
+  })
+})
+
+describe('mpp-canonical — HMAC challenge binding', () => {
+  const slots = {
+    digest: '',
+    expires: '2026-06-23T12:05:00.000Z',
+    intent: 'charge',
+    method: 'base',
+    opaqueB64Url: jcsBase64Url({ pi: 'pi_1' }),
+    realm: 'openagents.com',
+    requestB64Url: jcsBase64Url({ amount: '100', currency: 'usdc' }),
+  }
+
+  test('builds the seven-slot pipe-joined input', () => {
+    const input = challengeBindingInput(slots)
+    expect(input.split('|')).toHaveLength(7)
+    expect(input.startsWith('openagents.com|base|charge|')).toBe(true)
+  })
+
+  test('id is deterministic for the same secret + slots', async () => {
+    const a = await computeChallengeId('secret-key', slots)
+    const b = await computeChallengeId('secret-key', slots)
+    expect(a).toBe(b)
+    expect(a).not.toContain('=')
+  })
+
+  test('id changes when the secret changes (binding is keyed)', async () => {
+    const a = await computeChallengeId('secret-A', slots)
+    const b = await computeChallengeId('secret-B', slots)
+    expect(a).not.toBe(b)
+  })
+
+  test('id changes when any slot is tampered', async () => {
+    const base = await computeChallengeId('k', slots)
+    const tampered = await computeChallengeId('k', {
+      ...slots,
+      requestB64Url: jcsBase64Url({ amount: '1', currency: 'usdc' }),
+    })
+    expect(base).not.toBe(tampered)
+  })
+})
+
+describe('mpp-canonical — constantTimeEqual', () => {
+  test('true for equal, false for unequal (incl. different lengths)', () => {
+    expect(constantTimeEqual('abc', 'abc')).toBe(true)
+    expect(constantTimeEqual('abc', 'abd')).toBe(false)
+    expect(constantTimeEqual('abc', 'abcd')).toBe(false)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-canonical.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-canonical.ts
@@ -1,0 +1,205 @@
+// MPP / Payment Auth canonicalization + HMAC primitives (EPIC #6049, defect B).
+// Worker-native (WebCrypto). PURE crypto/encoding; no IO, no Stripe, no env.
+//
+// The Payment Auth core spec (draft-httpauth-payment-00) makes STATELESS
+// challenge binding possible by deriving the challenge `id` as
+//
+//   id = base64url(HMAC-SHA256(server_secret, "|".join([
+//          realm, method, intent, request_b64url,
+//          expires||"", digest||"", opaque_b64url||"" ])))
+//
+// where `request` and `opaque` are JSON serialized with JSON Canonicalization
+// Scheme (JCS, RFC 8785) before base64url-nopad encoding. Because the HMAC input
+// uses the base64url-encoded request/opaque AS THEY APPEAR ON THE WIRE, the
+// server can recompute the `id` from the echoed challenge in the retry credential
+// and verify the binding without storing any per-challenge state (Section 5.1.3
+// "Recommended: HMAC-SHA256 Binding").
+//
+// This module owns: RFC 8785 JCS serialization, base64url-nopad encode/decode,
+// the WebCrypto HMAC-SHA256 over the canonical input, and a constant-time
+// comparison for the recomputed id.
+
+import { parseJsonUnknown } from '../../json-boundary'
+
+// Typed error for a programmer-misuse canonicalization input (a non-finite
+// number or unsupported value type). A typed error keeps the zero-debt
+// architecture boundary (no generic `throw new Error`) while still failing loud
+// on a true coding mistake rather than silently mis-canonicalizing an id.
+export class CanonicalJsonError extends Error {
+  override readonly name = 'CanonicalJsonError'
+}
+
+// ---- base64url (RFC 4648 §5, no padding) ----
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+// Encode raw bytes as base64url without padding.
+export const base64UrlEncodeBytes = (bytes: Uint8Array): string => {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]!)
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')
+}
+
+// Encode a UTF-8 string as base64url-nopad.
+export const base64UrlEncode = (value: string): string =>
+  base64UrlEncodeBytes(textEncoder.encode(value))
+
+// Decode a base64url-nopad string back to a UTF-8 string. Returns undefined for
+// invalid input (so callers fail-closed rather than throwing through verify).
+export const base64UrlDecode = (value: string): string | undefined => {
+  try {
+    const padded = value
+      .replaceAll('-', '+')
+      .replaceAll('_', '/')
+      .padEnd(Math.ceil(value.length / 4) * 4, '=')
+    const binary = atob(padded)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return textDecoder.decode(bytes)
+  } catch {
+    return undefined
+  }
+}
+
+// ---- JCS / RFC 8785 canonical JSON ----
+
+// Serialize a JSON value per the JSON Canonicalization Scheme (RFC 8785):
+//   - object members sorted by key (UTF-16 code-unit order, which matches
+//     JavaScript's default Array.prototype.sort on the ASCII key set we use);
+//   - no insignificant whitespace;
+//   - strings serialized with JSON.stringify (the JS string escaping matches
+//     the JCS rules for the ASCII payloads MPP uses: amounts, ids, networks).
+//   - numbers serialized via the ES Number-to-string algorithm (JSON.stringify),
+//     which RFC 8785 defers to for the integer/short-decimal range we emit.
+// We restrict inputs to JSON-safe values (no NaN/Infinity, no bigint); a
+// non-finite number throws so a programming error never produces a silently
+// mis-canonicalized id.
+export const canonicalJson = (value: unknown): string => {
+  if (value === null) {
+    return 'null'
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false'
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new CanonicalJsonError('canonicalJson: non-finite number')
+    }
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(item => canonicalJson(item)).join(',')}]`
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).filter(
+      ([, v]) => v !== undefined,
+    )
+    entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    const members = entries.map(
+      ([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`,
+    )
+    return `{${members.join(',')}}`
+  }
+  throw new CanonicalJsonError(
+    `canonicalJson: unsupported value type ${typeof value}`,
+  )
+}
+
+// Serialize a JSON value with JCS, then base64url-nopad encode it. This is the
+// exact transform the spec applies to the `request` and `opaque` challenge
+// parameters before they enter the HMAC input and the WWW-Authenticate header.
+export const jcsBase64Url = (value: unknown): string =>
+  base64UrlEncode(canonicalJson(value))
+
+// Decode a base64url-nopad JCS parameter back to a JSON record. Returns
+// undefined on any decode/parse failure (fail-closed).
+export const decodeJcsBase64UrlRecord = (
+  value: string,
+): Record<string, unknown> | undefined => {
+  const json = base64UrlDecode(value)
+  if (json === undefined) {
+    return undefined
+  }
+  try {
+    const parsed = parseJsonUnknown(json)
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+// ---- HMAC-SHA256 challenge id ----
+
+// The seven fixed positional HMAC slots (core spec §5.1.3). Required fields
+// supply their string value; optional fields are the empty string when absent.
+export type ChallengeBindingSlots = Readonly<{
+  realm: string
+  method: string
+  intent: string
+  // The base64url-nopad of the JCS-serialized `request` JSON.
+  requestB64Url: string
+  // RFC 3339 expiry; '' when absent.
+  expires: string
+  // RFC 9530 content digest; '' when absent.
+  digest: string
+  // The base64url-nopad of the JCS-serialized `opaque` JSON; '' when absent.
+  opaqueB64Url: string
+}>
+
+// Build the canonical HMAC input string: the seven slots joined with '|'. Every
+// slot is always present; absent optional fields appear as empty segments.
+export const challengeBindingInput = (slots: ChallengeBindingSlots): string =>
+  [
+    slots.realm,
+    slots.method,
+    slots.intent,
+    slots.requestB64Url,
+    slots.expires,
+    slots.digest,
+    slots.opaqueB64Url,
+  ].join('|')
+
+// Compute the challenge `id` = base64url(HMAC-SHA256(secret, input)). Worker
+// WebCrypto; the secret is the server-held signing secret (never logged).
+export const computeChallengeId = async (
+  serverSecret: string,
+  slots: ChallengeBindingSlots,
+): Promise<string> => {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    textEncoder.encode(serverSecret),
+    { hash: 'SHA-256', name: 'HMAC' },
+    false,
+    ['sign'],
+  )
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    textEncoder.encode(challengeBindingInput(slots)),
+  )
+  return base64UrlEncodeBytes(new Uint8Array(signature))
+}
+
+// Constant-time string comparison for the recomputed vs presented id. Compares
+// over the max length so the timing does not leak the length of the match.
+export const constantTimeEqual = (a: string, b: string): boolean => {
+  const aBytes = textEncoder.encode(a)
+  const bBytes = textEncoder.encode(b)
+  const length = Math.max(aBytes.length, bBytes.length)
+  let diff = aBytes.length ^ bBytes.length
+  for (let i = 0; i < length; i += 1) {
+    diff |= (aBytes[i] ?? 0) ^ (bBytes[i] ?? 0)
+  }
+  return diff === 0
+}

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
@@ -12,15 +12,20 @@ import {
   InferenceProviderRegistry,
 } from '../provider-adapter'
 import { stubEchoAdapter } from '../stub-echo-adapter'
+import { base64UrlEncode, jcsBase64Url } from './mpp-canonical'
 import {
   type MppChatCompletionsDeps,
   handleMppChatCompletions,
   isKhalaMppEnabled,
 } from './mpp-chat-completions-routes'
+import { buildChallenge, type MppChallenge } from './mpp-protocol'
 import { type StripeFetch } from './stripe-mpp-client'
 
 const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
   Effect.runPromise(effect as Effect.Effect<A, never>)
+
+const SIGNING_SECRET = 'test-signing-secret'
+const REALM = 'openagents.com'
 
 // In-memory D1 (same harness as usd-credit-bridge.test.ts).
 class SqliteD1Statement {
@@ -42,9 +47,13 @@ class SqliteD1Statement {
       results: this.db.prepare(this.sql).all(...(this.bound as never[])) as T[],
     }
   }
-  async run(): Promise<{ success: true; results: [] }> {
-    this.db.prepare(this.sql).run(...(this.bound as never[]))
-    return { results: [], success: true }
+  async run(): Promise<{ success: true; results: []; meta: { changes: number } }> {
+    const info = this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return {
+      meta: { changes: Number(info.changes ?? 0) },
+      results: [],
+      success: true,
+    }
   }
 }
 class SqliteD1 {
@@ -112,6 +121,12 @@ CREATE TABLE pay_in_legs (
   refund_of_leg_id TEXT,
   created_at TEXT NOT NULL
 );
+CREATE TABLE mpp_spt_replay (
+  spt TEXT PRIMARY KEY,
+  challenge_id TEXT NOT NULL,
+  payment_intent_id TEXT,
+  consumed_at TEXT NOT NULL
+);
 `
 
 const makeDb = (): D1Database => {
@@ -120,9 +135,6 @@ const makeDb = (): D1Database => {
   return new SqliteD1(raw) as unknown as D1Database
 }
 
-// The stub echo adapter registered under the Gemini lane id, so khala-mini
-// resolves via `selectAdapterPlan` (khala-mini classifies to the Gemini lane).
-// Reports receipt-first usage so the metering hook settles.
 const echoAdapter = (id: string): InferenceProviderAdapter => ({
   ...stubEchoAdapter,
   id,
@@ -134,9 +146,6 @@ const khalaRegistry = (): InferenceProviderRegistry => {
   return registry
 }
 
-// completionDeps mirroring the keyed route (minus auth/balance, which the MPP
-// handler replaces). enabled = inference-gateway flag (on so the completion can
-// run for a paid call).
 const completionDeps = (
   db: D1Database,
 ): MppChatCompletionsDeps['completionDeps'] => ({
@@ -158,6 +167,41 @@ const mppRequest = (init: RequestInit = {}): Request =>
     ...init,
   })
 
+// Compose a wire credential that echoes a challenge + carries a payload.
+const credentialHeader = (
+  challenge: MppChallenge,
+  payload: Record<string, unknown> = {},
+): string =>
+  `Payment ${base64UrlEncode(
+    JSON.stringify({
+      challenge: {
+        expires: challenge.expires,
+        id: challenge.id,
+        intent: challenge.intent,
+        method: challenge.method,
+        opaque: challenge.opaque,
+        realm: challenge.realm,
+        request: challenge.request,
+      },
+      payload,
+    }),
+  )}`
+
+// A valid crypto challenge whose opaque carries the deposit PaymentIntent id.
+const cryptoChallenge = (pi: string, amountCents = 100): Promise<MppChallenge> =>
+  buildChallenge(SIGNING_SECRET, {
+    amountCents,
+    currency: 'usdc',
+    expires: '2099-01-15T12:05:00.000Z',
+    method: 'base',
+    network: 'base',
+    opaque: { amount: String(amountCents), network: 'base', pi },
+    paymentIntentId: pi,
+    realm: REALM,
+    recipient: '0xabc',
+    request: { amount: String(amountCents), currency: 'usdc', network: 'base' },
+  })
+
 describe('isKhalaMppEnabled flag', () => {
   test('default OFF; on for explicit truthy tokens', () => {
     expect(isKhalaMppEnabled(undefined)).toBe(false)
@@ -170,89 +214,118 @@ describe('isKhalaMppEnabled flag', () => {
 })
 
 describe('MPP endpoint — FAIL-SAFE inert (never charges when unconfigured)', () => {
-  test('flag OFF => 503 not-configured, no Stripe call', async () => {
-    const db = makeDb()
-    let stripeCalled = false
-    const fakeFetch: StripeFetch = async () => {
-      stripeCalled = true
-      return new Response('{}', { status: 200 })
+  const noStripeCall = (): {
+    fetch: StripeFetch
+    called: () => boolean
+  } => {
+    let called = false
+    return {
+      called: () => called,
+      fetch: async () => {
+        called = true
+        return new Response('{}', { status: 200 })
+      },
     }
+  }
+
+  test('flag OFF => 503, no Stripe call', async () => {
+    const db = makeDb()
+    const spy = noStripeCall()
     const response = await run(
       handleMppChatCompletions(mppRequest(), {
         completionDeps: completionDeps(db),
         db,
         enabled: false,
-        fetch: fakeFetch,
+        fetch: spy.fetch,
+        signingSecret: SIGNING_SECRET,
         stripeSecretKey: 'sk_test_x',
       }),
     )
     expect(response.status).toBe(503)
-    const body = (await response.json()) as { error: string }
-    expect(body.error).toBe('mpp_not_configured')
-    expect(stripeCalled).toBe(false)
+    expect(((await response.json()) as { error: string }).error).toBe(
+      'mpp_not_configured',
+    )
+    expect(spy.called()).toBe(false)
   })
 
-  test('no Stripe key => 503 not-configured, no Stripe call', async () => {
+  test('no Stripe key => 503, no Stripe call', async () => {
     const db = makeDb()
-    let stripeCalled = false
-    const fakeFetch: StripeFetch = async () => {
-      stripeCalled = true
-      return new Response('{}', { status: 200 })
-    }
+    const spy = noStripeCall()
     const response = await run(
       handleMppChatCompletions(mppRequest(), {
         completionDeps: completionDeps(db),
         db,
         enabled: true,
-        fetch: fakeFetch,
+        fetch: spy.fetch,
+        signingSecret: SIGNING_SECRET,
         stripeSecretKey: undefined,
       }),
     )
     expect(response.status).toBe(503)
-    expect(stripeCalled).toBe(false)
+    expect(spy.called()).toBe(false)
   })
-})
 
-describe('MPP endpoint — 402 challenge (no payment credential)', () => {
-  test('returns 402 with a WWW-Authenticate Payment challenge + problem+json body', async () => {
+  test('no signing secret => 503, no Stripe call', async () => {
     const db = makeDb()
-    // Fake Stripe create-PaymentIntent (the 402 needs a deposit address).
-    const fakeFetch: StripeFetch = async () =>
-      new Response(
-        JSON.stringify({
-          amount: 1,
-          currency: 'usd',
-          id: 'pi_quote_1',
-          next_action: {
-            crypto_display_details: {
-              deposit_addresses: {
-                base: { address: '0xabc', supported_tokens: [] },
-              },
-            },
-          },
-          status: 'requires_payment',
-        }),
-        { status: 200 },
-      )
-
+    const spy = noStripeCall()
     const response = await run(
       handleMppChatCompletions(mppRequest(), {
         completionDeps: completionDeps(db),
         db,
         enabled: true,
-        fetch: fakeFetch,
-        newId: () => 'fixed',
+        fetch: spy.fetch,
+        signingSecret: undefined,
         stripeSecretKey: 'sk_test_x',
       }),
     )
+    expect(response.status).toBe(503)
+    expect(((await response.json()) as { reason: string }).reason).toContain(
+      'signing secret',
+    )
+    expect(spy.called()).toBe(false)
+  })
+})
 
+describe('MPP endpoint — 402 challenge (no payment credential)', () => {
+  const quoteFetch = (id: string): StripeFetch => async () =>
+    new Response(
+      JSON.stringify({
+        amount: 1,
+        currency: 'usd',
+        id,
+        next_action: {
+          crypto_display_details: {
+            deposit_addresses: { base: { address: '0xabc', supported_tokens: [] } },
+          },
+        },
+        status: 'requires_payment',
+      }),
+      { status: 200 },
+    )
+
+  test('returns 402 with an HMAC-bound WWW-Authenticate Payment challenge', async () => {
+    const db = makeDb()
+    const response = await run(
+      handleMppChatCompletions(mppRequest(), {
+        completionDeps: completionDeps(db),
+        db,
+        enabled: true,
+        fetch: quoteFetch('pi_quote_1'),
+        newId: () => 'fixed',
+        signingSecret: SIGNING_SECRET,
+        stripeSecretKey: 'sk_test_x',
+      }),
+    )
     expect(response.status).toBe(402)
     expect(response.headers.get('content-type')).toBe('application/problem+json')
-    const wwwAuth = response.headers.get('www-authenticate')
+    const wwwAuth = response.headers.get('www-authenticate')!
     expect(wwwAuth).toContain('Payment ')
     expect(wwwAuth).toContain('method="base"')
-    expect(wwwAuth).toContain('recipient="0xabc"')
-    expect(wwwAuth).toContain('payment_intent="pi_quote_1"')
+    expect(wwwAuth).toContain('realm="openagents.com"')
+    expect(wwwAuth).toContain('request=')
+    expect(wwwAuth).toContain('opaque=')
+    // The id is an HMAC, NOT a plaintext "pi_…:crypto".
+    expect(wwwAuth).not.toContain('pi_quote_1:crypto')
 
     const problem = (await response.json()) as {
       type: string
@@ -264,117 +337,95 @@ describe('MPP endpoint — 402 challenge (no payment credential)', () => {
       'https://paymentauth.org/problems/payment-required',
     )
     expect(problem.challenges[0]?.paymentIntentId).toBe('pi_quote_1')
+    expect(problem.challenges[0]?.recipient).toBe('0xabc')
   })
 
-  test('NO network profile id => crypto-only (no card/SPT challenge)', async () => {
+  test('NO network profile id => crypto-only (no stripe/card challenge)', async () => {
     const db = makeDb()
-    const fakeFetch: StripeFetch = async () =>
-      new Response(
-        JSON.stringify({
-          amount: 1,
-          currency: 'usd',
-          id: 'pi_quote_2',
-          next_action: {
-            crypto_display_details: {
-              deposit_addresses: {
-                base: { address: '0xabc', supported_tokens: [] },
-              },
-            },
-          },
-          status: 'requires_payment',
-        }),
-        { status: 200 },
-      )
-
     const response = await run(
       handleMppChatCompletions(mppRequest(), {
         completionDeps: completionDeps(db),
         db,
         enabled: true,
-        fetch: fakeFetch,
+        fetch: quoteFetch('pi_quote_2'),
         newId: () => 'fixed',
-        // No stripeNetworkProfileId => card rail disabled.
+        signingSecret: SIGNING_SECRET,
         stripeSecretKey: 'sk_test_x',
       }),
     )
-
     expect(response.status).toBe(402)
     const problem = (await response.json()) as {
       challenges: Array<{ method: string }>
     }
-    // Only the crypto challenge; no `method="stripe"` card challenge.
     expect(problem.challenges.every(c => c.method !== 'stripe')).toBe(true)
   })
 
   test('WITH network profile id => adds the card/SPT (stripe) challenge', async () => {
     const db = makeDb()
-    const fakeFetch: StripeFetch = async () =>
-      new Response(
-        JSON.stringify({
-          amount: 1,
-          currency: 'usd',
-          id: 'pi_quote_3',
-          next_action: {
-            crypto_display_details: {
-              deposit_addresses: {
-                base: { address: '0xabc', supported_tokens: [] },
-              },
-            },
-          },
-          status: 'requires_payment',
-        }),
-        { status: 200 },
-      )
-
     const response = await run(
       handleMppChatCompletions(mppRequest(), {
         completionDeps: completionDeps(db),
         db,
         enabled: true,
-        fetch: fakeFetch,
+        fetch: quoteFetch('pi_quote_3'),
         newId: () => 'fixed',
-        stripeNetworkProfileId:
-          'profile_61Uug9ZHyJKTH8vxOA6Uug9Z3HSQjWfjZIUGSnTl27Xk',
+        signingSecret: SIGNING_SECRET,
+        stripeNetworkProfileId: 'profile_test',
         stripeSecretKey: 'sk_test_x',
       }),
     )
-
     expect(response.status).toBe(402)
-    const wwwAuth = response.headers.get('www-authenticate')
+    const wwwAuth = response.headers.get('www-authenticate')!
     expect(wwwAuth).toContain('method="stripe"')
     const problem = (await response.json()) as {
       challenges: Array<{ method: string }>
     }
-    // Both the crypto rail and the card/SPT (stripe) rail are advertised.
     expect(problem.challenges.some(c => c.method === 'base')).toBe(true)
     expect(problem.challenges.some(c => c.method === 'stripe')).toBe(true)
   })
 })
 
-describe('MPP endpoint — valid credential serves + meters', () => {
-  test('verifies the settled payment, mints credit, runs Khala, meters, returns the completion', async () => {
+describe('MPP endpoint — credential verification + crypto settlement', () => {
+  // Stripe fetch that verifies a settled crypto deposit on GET and provides a
+  // quote on the re-challenge POST.
+  const settledCryptoFetch = (pi: string, amount = 100): StripeFetch => async (
+    url,
+    init,
+  ) => {
+    if ((init.method ?? 'GET') === 'GET' && url.includes('/payment_intents/')) {
+      return new Response(
+        JSON.stringify({
+          amount,
+          currency: 'usd',
+          id: pi,
+          metadata: { model: KHALA_MINI_MODEL_ID },
+          status: 'succeeded',
+        }),
+        { status: 200 },
+      )
+    }
+    // re-challenge quote
+    return new Response(
+      JSON.stringify({
+        amount: 1,
+        currency: 'usd',
+        id: 'pi_requote',
+        next_action: {
+          crypto_display_details: {
+            deposit_addresses: { base: { address: '0xabc' } },
+          },
+        },
+        status: 'requires_payment',
+      }),
+      { status: 200 },
+    )
+  }
+
+  test('verifies the bound credential, mints credit, runs Khala, meters, serves + Payment-Receipt', async () => {
     const db = makeDb()
     const metered: Array<MeteringContext> = []
+    const challenge = await cryptoChallenge('pi_paid_1', 100)
 
-    // Stripe fetch routes by method: GET /payment_intents/<id> = verify
-    // (settled); we should NOT need a create call on the paid path.
-    const fakeFetch: StripeFetch = async (url, init) => {
-      if ((init.method ?? 'GET') === 'GET' && url.includes('/payment_intents/')) {
-        return new Response(
-          JSON.stringify({
-            amount: 100,
-            currency: 'usd',
-            id: 'pi_paid_1',
-            metadata: { model: KHALA_MINI_MODEL_ID },
-            status: 'succeeded',
-          }),
-          { status: 200 },
-        )
-      }
-      return new Response('{}', { status: 200 })
-    }
-
-    // Spy metering hook wrapping the real ledger hook so we assert it fired.
     const ledger = makeLedgerMeteringHook({ db })
     const spyMetering = (context: MeteringContext) =>
       Effect.gen(function* () {
@@ -386,8 +437,9 @@ describe('MPP endpoint — valid credential serves + meters', () => {
       completionDeps: { ...completionDeps(db), meteringHook: spyMetering },
       db,
       enabled: true,
-      fetch: fakeFetch,
+      fetch: settledCryptoFetch('pi_paid_1', 100),
       nowIso: () => '2026-06-22T12:00:00.000Z',
+      signingSecret: SIGNING_SECRET,
       stripeSecretKey: 'sk_test_x',
     }
 
@@ -395,7 +447,7 @@ describe('MPP endpoint — valid credential serves + meters', () => {
       handleMppChatCompletions(
         mppRequest({
           headers: {
-            authorization: 'Payment id="c:crypto", payment_intent="pi_paid_1"',
+            authorization: credentialHeader(challenge),
             'content-type': 'application/json',
           },
         }),
@@ -403,33 +455,101 @@ describe('MPP endpoint — valid credential serves + meters', () => {
       ),
     )
 
-    // Served the completion (OpenAI shape).
     expect(response.status).toBe(200)
+    // Payment-Receipt header (standards-shaped, base64url JCS).
+    expect(response.headers.get('payment-receipt')).toBe(
+      jcsBase64Url({
+        method: 'base',
+        reference: 'pi_paid_1',
+        status: 'success',
+        timestamp: '2026-06-22T12:00:00.000Z',
+      }),
+    )
+    expect(response.headers.get('cache-control')).toBe('private')
+
     const completion = (await response.json()) as {
       object: string
       choices: Array<{ message: { content: string } }>
-      openagents?: { served_model?: string }
+      openagents?: unknown
     }
     expect(completion.object).toBe('chat.completion')
-    // The stub echoes the last user message back ('hello').
     expect(completion.choices[0]?.message.content).toBe('hello')
-    // Khala disclosure block present.
     expect(completion.openagents).toBeDefined()
 
-    // The metering hook fired (the SAME receipt-first metering as the keyed route).
     expect(metered.length).toBe(1)
     expect(metered[0]?.requestedModel).toBe(KHALA_MINI_MODEL_ID)
 
-    // Phase 3: credit was minted into the payer-bound balance (USD-origin).
     const balance = await readAgentBalance(db, 'agent:mpp:pi_paid_1')
     expect(balance).not.toBeNull()
     expect(balance!.usdCreditMsat).toBeGreaterThan(0)
   })
 
-  test('an unsettled payment returns 402 and serves nothing (never serves unpaid)', async () => {
+  test('credit mint is idempotent across two settled retries (one payment = one grant)', async () => {
+    const db = makeDb()
+    const challenge = await cryptoChallenge('pi_idem_1', 100)
+    const deps: MppChatCompletionsDeps = {
+      completionDeps: completionDeps(db),
+      db,
+      enabled: true,
+      fetch: settledCryptoFetch('pi_idem_1', 100),
+      nowIso: () => '2026-06-22T12:00:00.000Z',
+      signingSecret: SIGNING_SECRET,
+      stripeSecretKey: 'sk_test_x',
+    }
+    const header = credentialHeader(challenge)
+    const first = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(first.status).toBe(200)
+    const balance1 = await readAgentBalance(db, 'agent:mpp:pi_idem_1')
+    const second = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(second.status).toBe(200)
+    const balance2 = await readAgentBalance(db, 'agent:mpp:pi_idem_1')
+    // The second retry did not double-grant credit (idempotent by pi).
+    expect(balance2!.usdCreditMsat).toBe(balance1!.usdCreditMsat)
+  })
+
+  test('a tampered credential is rejected (fresh 402, never serves)', async () => {
     const db = makeDb()
     let completionRan = false
-    const fakeFetch: StripeFetch = async (url, init) => {
+    const challenge = await cryptoChallenge('pi_tamper_1', 100)
+    const tampered: MppChallenge = { ...challenge, id: `${challenge.id}x` }
+    const spyMetering = () =>
+      Effect.sync(() => {
+        completionRan = true
+        return { metered: false, receiptRef: null }
+      })
+    const response = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: credentialHeader(tampered) } }),
+        {
+          completionDeps: { ...completionDeps(db), meteringHook: spyMetering },
+          db,
+          enabled: true,
+          fetch: settledCryptoFetch('pi_tamper_1'),
+          signingSecret: SIGNING_SECRET,
+          stripeSecretKey: 'sk_test_x',
+        },
+      ),
+    )
+    expect(response.status).toBe(402)
+    expect(response.headers.get('payment-receipt')).toBeNull()
+    expect(completionRan).toBe(false)
+  })
+
+  test('an unsettled crypto payment returns 402 and serves nothing', async () => {
+    const db = makeDb()
+    let completionRan = false
+    const challenge = await cryptoChallenge('pi_pending', 100)
+    const fetch: StripeFetch = async (url, init) => {
       if ((init.method ?? 'GET') === 'GET' && url.includes('/payment_intents/')) {
         return new Response(
           JSON.stringify({ amount: 100, id: 'pi_pending', status: 'processing' }),
@@ -438,33 +558,173 @@ describe('MPP endpoint — valid credential serves + meters', () => {
       }
       return new Response('{}', { status: 200 })
     }
-    const spyMetering = (context: MeteringContext) =>
+    const spyMetering = () =>
       Effect.sync(() => {
         completionRan = true
         return { metered: false, receiptRef: null }
       })
-
     const response = await run(
       handleMppChatCompletions(
-        mppRequest({
-          headers: {
-            authorization: 'Payment payment_intent="pi_pending"',
-            'content-type': 'application/json',
-          },
-        }),
+        mppRequest({ headers: { authorization: credentialHeader(challenge) } }),
         {
           completionDeps: { ...completionDeps(db), meteringHook: spyMetering },
           db,
           enabled: true,
-          fetch: fakeFetch,
+          fetch,
+          signingSecret: SIGNING_SECRET,
           stripeSecretKey: 'sk_test_x',
         },
       ),
     )
-
     expect(response.status).toBe(402)
-    const body = (await response.json()) as { error: string }
-    expect(body.error).toBe('payment_not_settled')
+    expect(((await response.json()) as { error: string }).error).toBe(
+      'payment_not_settled',
+    )
     expect(completionRan).toBe(false)
+  })
+})
+
+describe('MPP endpoint — card/SPT settlement + replay', () => {
+  const PROFILE = 'profile_test'
+  // A stripe challenge (card rail). Currency usd, networkId in methodDetails.
+  const stripeChallenge = (): Promise<MppChallenge> =>
+    buildChallenge(SIGNING_SECRET, {
+      amountCents: 100,
+      currency: 'usd',
+      expires: '2099-01-15T12:05:00.000Z',
+      method: 'stripe',
+      realm: REALM,
+      request: {
+        amount: '100',
+        currency: 'usd',
+        methodDetails: { networkId: PROFILE, paymentMethodTypes: ['card'] },
+      },
+    })
+
+  // Stripe fetch: POST /payment_intents with an SPT body succeeds; re-challenge
+  // quote returns a deposit address.
+  const sptFetch = (pi: string): StripeFetch => async (url, init) => {
+    if ((init.method ?? 'GET') === 'POST' && url.endsWith('/payment_intents')) {
+      const body = String(init.body ?? '')
+      if (body.includes('shared_payment_granted_token')) {
+        return new Response(
+          JSON.stringify({ amount: 100, currency: 'usd', id: pi, status: 'succeeded' }),
+          { status: 200 },
+        )
+      }
+      // quote (deposit-mode crypto create)
+      return new Response(
+        JSON.stringify({
+          amount: 1,
+          id: 'pi_requote',
+          next_action: {
+            crypto_display_details: {
+              deposit_addresses: { base: { address: '0xabc' } },
+            },
+          },
+          status: 'requires_payment',
+        }),
+        { status: 200 },
+      )
+    }
+    return new Response('{}', { status: 200 })
+  }
+
+  test('settles a fresh SPT, mints credit, serves + Payment-Receipt method=stripe', async () => {
+    const db = makeDb()
+    const challenge = await stripeChallenge()
+    const response = await run(
+      handleMppChatCompletions(
+        mppRequest({
+          headers: {
+            authorization: credentialHeader(challenge, { spt: 'spt_abc123' }),
+          },
+        }),
+        {
+          completionDeps: completionDeps(db),
+          db,
+          enabled: true,
+          fetch: sptFetch('pi_card_1'),
+          nowIso: () => '2026-06-22T12:00:00.000Z',
+          signingSecret: SIGNING_SECRET,
+          stripeNetworkProfileId: PROFILE,
+          stripeSecretKey: 'sk_test_x',
+        },
+      ),
+    )
+    expect(response.status).toBe(200)
+    const receipt = response.headers.get('payment-receipt')!
+    expect(receipt).toBe(
+      jcsBase64Url({
+        method: 'stripe',
+        reference: 'pi_card_1',
+        status: 'success',
+        timestamp: '2026-06-22T12:00:00.000Z',
+      }),
+    )
+    const balance = await readAgentBalance(db, 'agent:mpp:pi_card_1')
+    expect(balance!.usdCreditMsat).toBeGreaterThan(0)
+  })
+
+  test('a replayed SPT is rejected (402), never double-charges', async () => {
+    const db = makeDb()
+    const challenge = await stripeChallenge()
+    let chargeCount = 0
+    const fetch: StripeFetch = async (url, init) => {
+      if (
+        (init.method ?? 'GET') === 'POST' &&
+        url.endsWith('/payment_intents') &&
+        String(init.body ?? '').includes('shared_payment_granted_token')
+      ) {
+        chargeCount += 1
+        return new Response(
+          JSON.stringify({ amount: 100, currency: 'usd', id: 'pi_card_2', status: 'succeeded' }),
+          { status: 200 },
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          amount: 1,
+          id: 'pi_requote',
+          next_action: {
+            crypto_display_details: {
+              deposit_addresses: { base: { address: '0xabc' } },
+            },
+          },
+          status: 'requires_payment',
+        }),
+        { status: 200 },
+      )
+    }
+    const deps: MppChatCompletionsDeps = {
+      completionDeps: completionDeps(db),
+      db,
+      enabled: true,
+      fetch,
+      nowIso: () => '2026-06-22T12:00:00.000Z',
+      signingSecret: SIGNING_SECRET,
+      stripeNetworkProfileId: PROFILE,
+      stripeSecretKey: 'sk_test_x',
+    }
+    const header = credentialHeader(challenge, { spt: 'spt_replay_me' })
+    const first = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(first.status).toBe(200)
+    const second = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(second.status).toBe(402)
+    expect(((await second.json()) as { reason?: string }).reason).toBe(
+      'spt_replayed',
+    )
+    // Only the FIRST attempt hit Stripe with a charge.
+    expect(chargeCount).toBe(1)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
@@ -1,26 +1,43 @@
-// The 402-gated, machine-payable Khala endpoint (EPIC #6049, Phase 2 + 3).
+// The 402-gated, machine-payable Khala endpoint (EPIC #6049, Phase 2/3 + defect
+// B Worker-native MPP verification + settlement).
 //
 // Flagged, default OFF. Wraps the EXISTING Khala completion path
-// (`handleChatCompletions`) behind an MPP/x402 paywall:
+// (`handleChatCompletions`) behind an MPP / Payment-Auth (HTTP 402) paywall,
+// implemented per the canonical spec mirrored at
+// docs/reference/mpp/paymentauth/specs/:
 //
-//   1. No payment credential  -> 402 Payment Required + WWW-Authenticate
-//      challenge(s) (USDC crypto, and card/SPT when a profile id is configured).
-//   2. Valid credential        -> verify settlement via the Stripe REST API
-//      (Worker-native, API version 2026-03-04.preview), mint Khala credits into
-//      a payer-bound balance (Phase 3, reuses the USD-origin credit-grant seam),
-//      then run the SAME Khala completion against that credit and return it with
-//      the `openagents` receipt.
+//   1. No payment credential  -> 402 Payment Required with one
+//      `WWW-Authenticate: Payment ...` per supported method. Each challenge `id`
+//      is HMAC-SHA256 over the canonical challenge fields with a server-held
+//      secret (draft-httpauth-payment-00 §5.1.3), and our crypto deposit
+//      PaymentIntent id rides in the `opaque` field so we recover it statelessly.
+//   2. `Authorization: Payment <base64url>` -> decode {challenge,payload}, verify
+//      the HMAC binding + expiry + request-amount/currency FAIL-CLOSED, then
+//      settle:
+//        - crypto: recover the deposit PaymentIntent id from `opaque`, retrieve
+//          it from Stripe, serve only when `succeeded`;
+//        - card/SPT: take `payload.spt`, enforce single-use (replay cache),
+//          create+confirm a PaymentIntent with the SPT, serve only when
+//          `succeeded`.
+//      On success: mint USD-origin Khala credits (idempotent `mpp:<pi>`), run the
+//      SAME Khala completion + metering + receipt, and return it with a
+//      standards-shaped `Payment-Receipt` header.
 //
 // FAIL-SAFE (the central safety property): the endpoint is INERT unless it is
-// fully configured. With no Stripe key, OR no flag (KHALA_MPP_ENABLED), the
-// endpoint returns a clean "not configured" 503 and NEVER constructs a charge.
-// A missing `profile_` id only disables the CARD rail; the crypto rail still
-// works. So a half-configured deploy can charge nothing it should not.
+// fully configured. With no flag (KHALA_MPP_ENABLED), no Stripe key, OR no
+// signing secret (KHALA_MPP_SIGNING_SECRET) it returns a clean "not configured"
+// 503 and NEVER constructs a charge or issues a challenge. A missing `profile_`
+// id only disables the CARD rail; the crypto rail still works.
 
 import { Effect } from 'effect'
 
 import { noStoreJsonResponse } from '../../http/responses'
-import { randomUuid } from '../../runtime-primitives'
+import {
+  currentEpochMillis,
+  currentIsoTimestamp,
+  epochMillisToIsoTimestamp,
+  randomUuid,
+} from '../../runtime-primitives'
 import {
   type ChatCompletionsDeps,
   handleChatCompletions,
@@ -34,14 +51,21 @@ import {
 } from './mpp-credit-grant'
 import {
   type MppChallenge,
+  type MppOpaque,
+  type ParsedPaymentCredential,
+  buildChallenge,
+  buildPaymentReceipt,
   buildPaymentRequiredHeaders,
   buildPaymentRequiredProblem,
   parsePaymentCredential,
+  verifyCredential,
 } from './mpp-protocol'
 import { type MppRail, quoteMppCall } from './mpp-pricing'
+import { claimSpt, recordSptPaymentIntent } from './mpp-spt-replay'
 import {
   type StripeFetch,
   createCryptoDepositPaymentIntent,
+  createSptChargePaymentIntent,
   retrievePaymentIntent,
 } from './stripe-mpp-client'
 
@@ -51,6 +75,10 @@ const DEFAULT_MPP_MODEL = 'openagents/khala-mini'
 // x402 (Base) + MPP (Solana, Tempo) — all USDC. We advertise all three crypto
 // networks; the agent picks one.
 const CRYPTO_NETWORKS: ReadonlyArray<string> = ['base', 'solana', 'tempo']
+// The protection-space realm for our challenges (core spec §5.1.1).
+const MPP_REALM = 'openagents.com'
+// Challenge validity window.
+const CHALLENGE_TTL_MS = 5 * 60 * 1000
 
 // Parse the KHALA_MPP_ENABLED flag. Default OFF.
 export const isKhalaMppEnabled = (value: string | undefined): boolean => {
@@ -65,6 +93,9 @@ export type MppChatCompletionsDeps = Readonly<{
   enabled: boolean
   // The Stripe secret key (live or test). Absent => inert (never charges).
   stripeSecretKey: string | undefined
+  // The challenge-binding signing secret (HMAC key). Absent => inert (never
+  // issues a challenge or verifies a credential).
+  signingSecret: string | undefined
   // The network profile id (`profile_…`) for SPT/card. Absent => crypto-only.
   stripeNetworkProfileId?: string | undefined
   // The deps for the underlying Khala completion path (registry, metering hook,
@@ -83,6 +114,7 @@ export type MppChatCompletionsDeps = Readonly<{
   // Injectable seams for tests.
   fetch?: StripeFetch
   nowIso?: () => string
+  nowMs?: () => number
   usdCentsToMsat?: (amountCents: number) => number
   newId?: () => string
 }>
@@ -95,43 +127,6 @@ const notConfigured = (reason: string): Response =>
     { status: 503 },
   )
 
-// Build the 402 challenge set for a quote. Always includes the crypto rail; adds
-// the card/SPT rail only when a network profile id is configured.
-const buildChallenges = (
-  input: Readonly<{
-    model: string
-    cryptoPaymentIntentId: string
-    cryptoAmountCents: number
-    cryptoDeposit: { network: string; address: string } | undefined
-    cardEnabled: boolean
-    cardAmountCents: number
-    challengeIdPrefix: string
-  }>,
-): ReadonlyArray<MppChallenge> => {
-  const challenges: Array<MppChallenge> = [
-    {
-      amountCents: input.cryptoAmountCents,
-      currency: 'usdc',
-      id: `${input.challengeIdPrefix}:crypto`,
-      intent: 'charge',
-      method: input.cryptoDeposit?.network ?? 'base',
-      network: input.cryptoDeposit?.network ?? 'base',
-      paymentIntentId: input.cryptoPaymentIntentId,
-      recipient: input.cryptoDeposit?.address,
-    },
-  ]
-  if (input.cardEnabled) {
-    challenges.push({
-      amountCents: input.cardAmountCents,
-      currency: 'usd',
-      id: `${input.challengeIdPrefix}:card`,
-      intent: 'charge',
-      method: 'stripe',
-    })
-  }
-  return challenges
-}
-
 // Resolve the requested model from the body, defaulting to khala-mini, and
 // constrained to Khala models (the MPP endpoint sells Khala). A non-Khala model
 // is coerced to the default so the paywall always quotes a Khala price.
@@ -142,22 +137,341 @@ const resolveMppModel = (rawBody: Record<string, unknown> | undefined): string =
   return isKhalaModel(requested) ? requested : DEFAULT_MPP_MODEL
 }
 
+// Build the spec-shaped challenge set for a quote. Always includes the crypto
+// rail (one challenge per supported network, all bound to the SAME crypto
+// deposit PaymentIntent recovered from `opaque`); adds the card/SPT rail only
+// when a network profile id is configured. Each challenge's `id` is the HMAC
+// binding computed inside `buildChallenge`.
+const buildChallenges = (
+  signingSecret: string,
+  input: Readonly<{
+    model: string
+    expires: string
+    cryptoPaymentIntentId: string
+    cryptoAmountCents: number
+    cryptoDeposit: { network: string; address: string } | undefined
+    cardEnabled: boolean
+    cardAmountCents: number
+    cardNetworkProfileId: string | undefined
+  }>,
+) =>
+  Effect.gen(function* () {
+    const challenges: Array<MppChallenge> = []
+    // The opaque correlation data carries the crypto deposit PaymentIntent id
+    // so the retry recovers it statelessly. One opaque per crypto rail (all
+    // networks share the same deposit-mode PaymentIntent).
+    const cryptoNetwork = input.cryptoDeposit?.network ?? CRYPTO_NETWORKS[0]!
+    const cryptoOpaque: MppOpaque = {
+      amount: String(input.cryptoAmountCents),
+      model: input.model,
+      network: cryptoNetwork,
+      pi: input.cryptoPaymentIntentId,
+    }
+    // Crypto challenge (single network = the deposit-mode network Stripe
+    // returned; the deposit-mode PaymentIntent backs the settlement).
+    const crypto = yield* Effect.promise(() =>
+      buildChallenge(signingSecret, {
+        amountCents: input.cryptoAmountCents,
+        currency: 'usdc',
+        expires: input.expires,
+        method: cryptoNetwork,
+        network: cryptoNetwork,
+        opaque: cryptoOpaque,
+        paymentIntentId: input.cryptoPaymentIntentId,
+        realm: MPP_REALM,
+        recipient: input.cryptoDeposit?.address,
+        request: {
+          amount: String(input.cryptoAmountCents),
+          currency: 'usdc',
+          description: `OpenAgents Khala ${input.model} pay-per-call`,
+          network: cryptoNetwork,
+          recipient: input.cryptoDeposit?.address,
+        },
+      }),
+    )
+    challenges.push(crypto)
+
+    if (input.cardEnabled && input.cardNetworkProfileId !== undefined) {
+      const card = yield* Effect.promise(() =>
+        buildChallenge(signingSecret, {
+          amountCents: input.cardAmountCents,
+          currency: 'usd',
+          expires: input.expires,
+          method: 'stripe',
+          realm: MPP_REALM,
+          request: {
+            amount: String(input.cardAmountCents),
+            currency: 'usd',
+            description: `OpenAgents Khala ${input.model} pay-per-call`,
+            methodDetails: {
+              networkId: input.cardNetworkProfileId,
+              paymentMethodTypes: ['card', 'link'],
+            },
+          },
+        }),
+      )
+      challenges.push(card)
+    }
+    return challenges as ReadonlyArray<MppChallenge>
+  })
+
+// Issue a fresh 402 (no credential, or a credential we refused). Creates a
+// crypto deposit PaymentIntent for the quote (the address the crypto challenge
+// points at) and builds the bound challenge set. If Stripe cannot quote, returns
+// a clean 503 (never a broken 402).
+const issueChallenge = (
+  deps: MppChatCompletionsDeps,
+  signingSecret: string,
+  stripeDeps: Parameters<typeof createCryptoDepositPaymentIntent>[0],
+  cardEnabled: boolean,
+  rawBody: Record<string, unknown> | undefined,
+  detail?: string,
+) =>
+  Effect.gen(function* () {
+    const newId = deps.newId ?? randomUuid
+    const nowMs = (deps.nowMs ?? currentEpochMillis)()
+    const model = resolveMppModel(rawBody)
+    const cryptoQuote = quoteMppCall({ model, rail: 'crypto' as MppRail })
+    const cardQuote = quoteMppCall({ model, rail: 'card' as MppRail })
+
+    const created = yield* createCryptoDepositPaymentIntent(stripeDeps, {
+      amountCents: cryptoQuote.amountCents,
+      idempotencyKey: `mpp:quote:${newId()}`,
+      metadata: { model, product: 'openagents_khala_mpp' },
+      networks: CRYPTO_NETWORKS,
+    }).pipe(
+      Effect.map(intent => ({ ok: true as const, intent })),
+      Effect.catch(error =>
+        Effect.succeed({ ok: false as const, reason: error.detail }),
+      ),
+    )
+    if (!created.ok) {
+      return notConfigured(`stripe quote failed: ${created.reason}`)
+    }
+
+    const challenges = yield* buildChallenges(signingSecret, {
+      cardAmountCents: cardQuote.amountCents,
+      cardEnabled,
+      cardNetworkProfileId: deps.stripeNetworkProfileId,
+      cryptoAmountCents: cryptoQuote.amountCents,
+      cryptoDeposit: created.intent.deposits[0],
+      cryptoPaymentIntentId: created.intent.id,
+      expires: epochMillisToIsoTimestamp(nowMs + CHALLENGE_TTL_MS),
+      model,
+    })
+
+    return new Response(
+      JSON.stringify(buildPaymentRequiredProblem(challenges, detail)),
+      {
+        headers: buildPaymentRequiredHeaders(challenges),
+        status: 402,
+      },
+    )
+  })
+
 // Run the underlying Khala completion as the payer-bound account (credit already
-// minted). Replaces auth + balance reader so the completion runs against the
-// minted credit; everything else (registry, metering hook, receipt, lane plan)
-// is the SAME as the keyed route.
+// minted), then attach the standards-shaped `Payment-Receipt` header on success.
 const runPaidCompletion = (
   request: Request,
   deps: MppChatCompletionsDeps,
   grant: MppCreditGrantOutcome,
-): Effect.Effect<Response> =>
-  handleChatCompletions(request, {
-    ...deps.completionDeps,
-    authenticate: async () => ({ accountRef: grant.accountRef }),
-    enabled: deps.completionDeps.enabled,
-    // The minted credit is the available balance; the metering hook decrements
-    // it receipt-first on the real completion.
-    readAvailableMsat: async () => grant.grantedMsat,
+  receipt: Readonly<{ method: string; reference: string }>,
+) =>
+  Effect.gen(function* () {
+    const nowIso = (deps.nowIso ?? currentIsoTimestamp)()
+    const response = yield* handleChatCompletions(request, {
+      ...deps.completionDeps,
+      authenticate: async () => ({ accountRef: grant.accountRef }),
+      enabled: deps.completionDeps.enabled,
+      // The minted credit is the available balance; the metering hook decrements
+      // it receipt-first on the real completion.
+      readAvailableMsat: async () => grant.grantedMsat,
+    })
+    // Attach the Payment-Receipt only on a 2xx (success). Core spec: receipts are
+    // issued only on success; error responses carry none.
+    if (response.status < 200 || response.status >= 300) {
+      return response
+    }
+    const headers = new Headers(response.headers)
+    headers.set(
+      'payment-receipt',
+      buildPaymentReceipt({
+        method: receipt.method,
+        reference: receipt.reference,
+        timestamp: nowIso,
+      }),
+    )
+    headers.set('cache-control', 'private')
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    })
+  })
+
+// Settle + serve once a credential has passed stateless verification. The method
+// chooses the settlement rail. On a settled payment: mint credit (idempotent),
+// run the completion, attach the receipt. Anything not settled => 402 (never
+// serves unpaid).
+const settleAndServe = (
+  request: Request,
+  deps: MppChatCompletionsDeps,
+  stripeDeps: Parameters<typeof retrievePaymentIntent>[0],
+  verified: Extract<
+    Awaited<ReturnType<typeof verifyCredential>>,
+    { ok: true }
+  >,
+  credential: ParsedPaymentCredential,
+) =>
+  Effect.gen(function* () {
+    // Resolve the settled PaymentIntent for the rail.
+    let settledPi:
+      | Readonly<{ id: string; amountCents: number }>
+      | undefined
+
+    if (verified.method === 'stripe') {
+      // ---- card/SPT rail ----
+      const spt = credential.payload.spt
+      if (typeof spt !== 'string' || !spt.startsWith('spt_')) {
+        return noStoreJsonResponse(
+          { error: 'payment_verification_failed', reason: 'missing_spt' },
+          { status: 402 },
+        )
+      }
+      const profileId = deps.stripeNetworkProfileId
+      if (profileId === undefined || profileId.trim() === '') {
+        // Card rail not configured — should not happen (we never offered it) but
+        // fail-closed.
+        return noStoreJsonResponse(
+          { error: 'payment_verification_failed', reason: 'card_rail_off' },
+          { status: 402 },
+        )
+      }
+      // Single-use SPT: claim BEFORE charging. A replay collides and is refused.
+      const claimed = yield* claimSpt(deps.db, {
+        challengeId: credential.challenge.id,
+        spt,
+      }).pipe(
+        Effect.map(ok => ({ ok: true as const, claimed: ok })),
+        Effect.catch(() => Effect.succeed({ ok: false as const })),
+      )
+      if (!claimed.ok) {
+        return noStoreJsonResponse(
+          { error: 'payment_verification_failed', reason: 'replay_store' },
+          { status: 502 },
+        )
+      }
+      if (!claimed.claimed) {
+        return noStoreJsonResponse(
+          { error: 'payment_verification_failed', reason: 'spt_replayed' },
+          { status: 402 },
+        )
+      }
+      const charged = yield* createSptChargePaymentIntent(stripeDeps, {
+        amountCents: Number(verified.request.amount),
+        challengeId: credential.challenge.id,
+        metadata: { model: verified.opaque?.model ?? '', product: 'openagents_khala_mpp' },
+        networkProfileId: profileId,
+        spt,
+      }).pipe(
+        Effect.map(intent => ({ ok: true as const, intent })),
+        Effect.catch(error =>
+          Effect.succeed({ ok: false as const, reason: error.detail }),
+        ),
+      )
+      if (!charged.ok) {
+        return noStoreJsonResponse(
+          { error: 'payment_verification_failed', reason: charged.reason },
+          { status: 502 },
+        )
+      }
+      if (!charged.intent.settled) {
+        return noStoreJsonResponse(
+          {
+            error: 'payment_not_settled',
+            payment_intent: charged.intent.id,
+            status: charged.intent.status,
+          },
+          { status: 402 },
+        )
+      }
+      yield* recordSptPaymentIntent(deps.db, {
+        paymentIntentId: charged.intent.id,
+        spt,
+      }).pipe(Effect.catch(() => Effect.void))
+      settledPi = { amountCents: charged.intent.amountCents, id: charged.intent.id }
+    } else {
+      // ---- crypto rail ----
+      // Recover our deposit PaymentIntent id from the bound `opaque`.
+      const paymentIntentId = verified.opaque?.pi
+      if (paymentIntentId === undefined || paymentIntentId.trim() === '') {
+        return noStoreJsonResponse(
+          { error: 'payment_verification_failed', reason: 'missing_correlation' },
+          { status: 402 },
+        )
+      }
+      const retrieved = yield* retrievePaymentIntent(
+        stripeDeps,
+        paymentIntentId,
+      ).pipe(
+        Effect.map(intent => ({ ok: true as const, intent })),
+        Effect.catch(error =>
+          Effect.succeed({ ok: false as const, reason: error.detail }),
+        ),
+      )
+      if (!retrieved.ok) {
+        return noStoreJsonResponse(
+          { error: 'payment_verification_failed', reason: retrieved.reason },
+          { status: 502 },
+        )
+      }
+      if (!retrieved.intent.settled) {
+        return noStoreJsonResponse(
+          {
+            error: 'payment_not_settled',
+            payment_intent: retrieved.intent.id,
+            status: retrieved.intent.status,
+          },
+          { status: 402 },
+        )
+      }
+      settledPi = {
+        amountCents: retrieved.intent.amountCents,
+        id: retrieved.intent.id,
+      }
+    }
+
+    // SETTLED. Mint Khala credits for the settled amount into a payer-bound
+    // balance (idempotent per payment id), then run the SAME Khala completion.
+    const accountRef = mppPayerAccountRef(settledPi.id)
+    const grant = yield* mintMppCredits(
+      {
+        db: deps.db,
+        ...(deps.nowIso === undefined ? {} : { nowIso: deps.nowIso }),
+        ...(deps.usdCentsToMsat === undefined
+          ? {}
+          : { usdCentsToMsat: deps.usdCentsToMsat }),
+      },
+      {
+        accountRef,
+        amountCents: settledPi.amountCents,
+        paymentIntentId: settledPi.id,
+      },
+    ).pipe(
+      Effect.map(outcome => ({ ok: true as const, outcome })),
+      Effect.catch(() => Effect.succeed({ ok: false as const } as const)),
+    )
+    if (!grant.ok) {
+      return noStoreJsonResponse(
+        { error: 'credit_grant_failed', payment_intent: settledPi.id },
+        { status: 500 },
+      )
+    }
+
+    return yield* runPaidCompletion(request, deps, grant.outcome, {
+      method: verified.method,
+      reference: settledPi.id,
+    })
   })
 
 export const handleMppChatCompletions = (
@@ -176,6 +490,15 @@ export const handleMppChatCompletions = (
     ) {
       return notConfigured('stripe key not configured')
     }
+    // FAIL-SAFE GATE 3: no signing secret => inert. Cannot bind/verify a
+    // challenge, so we never issue one or accept a credential.
+    if (
+      deps.signingSecret === undefined ||
+      deps.signingSecret.trim() === ''
+    ) {
+      return notConfigured('signing secret not configured')
+    }
+    const signingSecret = deps.signingSecret
 
     if (request.method !== 'POST') {
       return noStoreJsonResponse(
@@ -191,14 +514,12 @@ export const handleMppChatCompletions = (
         ? {}
         : { networkProfileId: deps.stripeNetworkProfileId }),
     }
-    const newId = deps.newId ?? randomUuid
     const cardEnabled =
       deps.stripeNetworkProfileId !== undefined &&
       deps.stripeNetworkProfileId.trim() !== ''
 
     // We need the body for BOTH the 402 quote (model) and the paid retry (the
-    // completion). Read it once; reconstruct a fresh Request for the underlying
-    // handler so its own `request.json()` works.
+    // completion). Read it once; the underlying handler reads its own clone.
     const rawBody = yield* Effect.promise(async () => {
       try {
         return (await request.clone().json()) as Record<string, unknown>
@@ -207,151 +528,66 @@ export const handleMppChatCompletions = (
       }
     })
 
-    const credential = parsePaymentCredential(request.headers.get('authorization'))
+    const credential = parsePaymentCredential(
+      request.headers.get('authorization'),
+    )
 
-    // ---- NO CREDENTIAL: return 402 + challenge(s) ----
+    // ---- NO CREDENTIAL (or malformed): return 402 + challenge(s) ----
     if (credential === undefined) {
-      const model = resolveMppModel(rawBody)
-      const cryptoQuote = quoteMppCall({ model, rail: 'crypto' as MppRail })
-      const cardQuote = quoteMppCall({ model, rail: 'card' as MppRail })
-
-      // Create a crypto deposit PaymentIntent to get a deposit address for the
-      // challenge. If Stripe fails here, the endpoint is effectively unable to
-      // quote — return a clean 503 (never a broken 402).
-      const created = yield* createCryptoDepositPaymentIntent(stripeDeps, {
-        amountCents: cryptoQuote.amountCents,
-        idempotencyKey: `mpp:quote:${newId()}`,
-        metadata: { model, product: 'openagents_khala_mpp' },
-        networks: CRYPTO_NETWORKS,
-      }).pipe(
-        Effect.map(intent => ({ ok: true as const, intent })),
-        Effect.catch(error =>
-          Effect.succeed({ ok: false as const, reason: error.detail }),
-        ),
-      )
-      if (!created.ok) {
-        return notConfigured(`stripe quote failed: ${created.reason}`)
-      }
-
-      const challenges = buildChallenges({
-        cardAmountCents: cardQuote.amountCents,
+      return yield* issueChallenge(
+        deps,
+        signingSecret,
+        stripeDeps,
         cardEnabled,
-        challengeIdPrefix: created.intent.id,
-        cryptoAmountCents: cryptoQuote.amountCents,
-        cryptoDeposit: created.intent.deposits[0],
-        cryptoPaymentIntentId: created.intent.id,
-        model,
-      })
-
-      return new Response(
-        JSON.stringify(buildPaymentRequiredProblem(challenges)),
-        {
-          headers: buildPaymentRequiredHeaders(challenges),
-          status: 402,
-        },
+        rawBody,
       )
     }
 
-    // ---- CREDENTIAL PRESENT: verify settlement, mint credits, serve ----
-    const paymentIntentId = credential.paymentIntentId
-    if (paymentIntentId === undefined || paymentIntentId.trim() === '') {
-      // A credential we cannot verify Worker-native (e.g. an SPT/card token that
-      // needs the Node MPP SDK to settle). We do NOT guess; return a fresh 402
-      // so the client retries with a verifiable crypto credential, and flag the
-      // sidecar requirement in the body.
-      const model = resolveMppModel(rawBody)
-      const cryptoQuote = quoteMppCall({ model, rail: 'crypto' as MppRail })
-      const created = yield* createCryptoDepositPaymentIntent(stripeDeps, {
-        amountCents: cryptoQuote.amountCents,
-        idempotencyKey: `mpp:quote:${newId()}`,
-        metadata: { model, product: 'openagents_khala_mpp' },
-        networks: CRYPTO_NETWORKS,
-      }).pipe(
-        Effect.map(intent => ({ ok: true as const, intent })),
-        Effect.catch(error =>
-          Effect.succeed({ ok: false as const, reason: error.detail }),
-        ),
-      )
-      if (!created.ok) {
-        return notConfigured(`stripe quote failed: ${created.reason}`)
-      }
-      const challenges = buildChallenges({
-        cardAmountCents: cryptoQuote.amountCents,
-        cardEnabled,
-        challengeIdPrefix: created.intent.id,
-        cryptoAmountCents: cryptoQuote.amountCents,
-        cryptoDeposit: created.intent.deposits[0],
-        cryptoPaymentIntentId: created.intent.id,
-        model,
-      })
-      const problem = {
-        ...buildPaymentRequiredProblem(challenges),
-        detail:
-          'Could not verify the supplied payment credential Worker-native. Retry with a crypto payment credential (Base/Solana/Tempo USDC). Card/SPT settlement may require the Node MPP sidecar.',
-      }
-      return new Response(JSON.stringify(problem), {
-        headers: buildPaymentRequiredHeaders(challenges),
-        status: 402,
-      })
-    }
+    // ---- CREDENTIAL PRESENT: verify the HMAC binding FAIL-CLOSED ----
+    const model = resolveMppModel(rawBody)
+    const cryptoQuote = quoteMppCall({ model, rail: 'crypto' as MppRail })
+    const cardQuote = quoteMppCall({ model, rail: 'card' as MppRail })
+    const allowedMethods = cardEnabled
+      ? [...CRYPTO_NETWORKS, 'stripe']
+      : [...CRYPTO_NETWORKS]
 
-    const verified = yield* retrievePaymentIntent(
-      stripeDeps,
-      paymentIntentId,
-    ).pipe(
-      Effect.map(intent => ({ ok: true as const, intent })),
-      Effect.catch(error =>
-        Effect.succeed({ ok: false as const, reason: error.detail }),
-      ),
+    const verified = yield* Effect.promise(() =>
+      verifyCredential(signingSecret, credential, {
+        allowedMethods,
+        expectedCurrencyForMethod: method =>
+          method === 'stripe' ? 'usd' : 'usdc',
+        // The card rail floor is the card quote; crypto uses the crypto quote.
+        // Use the lower of the two so neither rail under-floors; verification
+        // separately binds the exact amount via the HMAC over `request`.
+        expectedMinAmountCents: Math.min(
+          cryptoQuote.amountCents,
+          cardQuote.amountCents,
+        ),
+        ...(deps.nowMs === undefined ? {} : { nowMs: deps.nowMs() }),
+        realm: MPP_REALM,
+      }),
     )
+
     if (!verified.ok) {
-      return noStoreJsonResponse(
-        { error: 'payment_verification_failed', reason: verified.reason },
-        { status: 502 },
-      )
-    }
-    if (!verified.intent.settled) {
-      // Paid not yet settled — return 402 again so the client waits/retries. No
-      // completion runs; nothing is served unpaid.
-      return noStoreJsonResponse(
-        {
-          error: 'payment_not_settled',
-          payment_intent: verified.intent.id,
-          status: verified.intent.status,
-        },
-        { status: 402 },
+      // Verification failed => fresh 402 (never serve). Re-issue a challenge so a
+      // well-behaved client can retry with a correctly-bound credential.
+      const detail = `Payment credential rejected (${verified.reason}). Retry against a fresh challenge.`
+      return yield* issueChallenge(
+        deps,
+        signingSecret,
+        stripeDeps,
+        cardEnabled,
+        rawBody,
+        detail,
       )
     }
 
-    // SETTLED. Phase 3: mint Khala credits for the settled amount into a
-    // payer-bound balance (idempotent per payment id), then run the SAME Khala
-    // completion against that credit.
-    const accountRef = mppPayerAccountRef(verified.intent.id)
-    const grant = yield* mintMppCredits(
-      {
-        db: deps.db,
-        ...(deps.nowIso === undefined ? {} : { nowIso: deps.nowIso }),
-        ...(deps.usdCentsToMsat === undefined
-          ? {}
-          : { usdCentsToMsat: deps.usdCentsToMsat }),
-      },
-      {
-        accountRef,
-        amountCents: verified.intent.amountCents,
-        paymentIntentId: verified.intent.id,
-      },
-    ).pipe(
-      Effect.map(outcome => ({ ok: true as const, outcome })),
-      Effect.catch(() =>
-        Effect.succeed({ ok: false as const } as const),
-      ),
+    // ---- VERIFIED: settle for the rail, then serve ----
+    return yield* settleAndServe(
+      request,
+      deps,
+      stripeDeps,
+      verified,
+      credential,
     )
-    if (!grant.ok) {
-      return noStoreJsonResponse(
-        { error: 'credit_grant_failed', payment_intent: verified.intent.id },
-        { status: 500 },
-      )
-    }
-
-    return yield* runPaidCompletion(request, deps, grant.outcome)
   })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-protocol.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-protocol.test.ts
@@ -1,107 +1,259 @@
 import { describe, expect, test } from 'vitest'
 
+import { base64UrlEncode, jcsBase64Url } from './mpp-canonical'
 import {
   type MppChallenge,
+  type MppRequestParams,
+  buildChallenge,
+  buildPaymentReceipt,
   buildPaymentRequiredHeaders,
   buildPaymentRequiredProblem,
   parsePaymentCredential,
   renderChallengeHeader,
+  verifyCredential,
 } from './mpp-protocol'
 
-const cryptoChallenge: MppChallenge = {
-  amountCents: 1,
-  currency: 'usdc',
-  id: 'chal_abc:crypto',
-  intent: 'charge',
-  method: 'base',
-  network: 'base',
-  paymentIntentId: 'pi_123',
-  recipient: '0xdeadbeef',
-}
+const SECRET = 'test-signing-secret'
+const REALM = 'openagents.com'
+const FUTURE = '2099-01-15T12:05:00.000Z'
 
-describe('mpp protocol — 402 challenge wire shape', () => {
-  test('renders a WWW-Authenticate Payment header with the load-bearing params', () => {
-    const header = renderChallengeHeader(cryptoChallenge)
-    expect(header.startsWith('Payment ')).toBe(true)
-    expect(header).toContain('id="chal_abc:crypto"')
-    expect(header).toContain('method="base"')
-    expect(header).toContain('intent="charge"')
-    expect(header).toContain('amount="1"')
-    expect(header).toContain('currency="usdc"')
-    expect(header).toContain('network="base"')
-    expect(header).toContain('recipient="0xdeadbeef"')
-    expect(header).toContain('payment_intent="pi_123"')
+// Build a spec-shaped crypto challenge with a valid HMAC id.
+const cryptoChallenge = (
+  overrides: Partial<Parameters<typeof buildChallenge>[1]> = {},
+): Promise<MppChallenge> =>
+  buildChallenge(SECRET, {
+    amountCents: 100,
+    currency: 'usdc',
+    expires: FUTURE,
+    method: 'base',
+    network: 'base',
+    opaque: { amount: '100', network: 'base', pi: 'pi_dep_1' },
+    paymentIntentId: 'pi_dep_1',
+    realm: REALM,
+    recipient: '0xdeadbeef',
+    request: {
+      amount: '100',
+      currency: 'usdc',
+      network: 'base',
+      recipient: '0xdeadbeef',
+    },
+    ...overrides,
   })
 
-  test('builds one WWW-Authenticate header per challenge', () => {
-    const headers = buildPaymentRequiredHeaders([
-      cryptoChallenge,
-      {
-        amountCents: 50,
-        currency: 'usd',
-        id: 'chal_abc:card',
-        intent: 'charge',
-        method: 'stripe',
+// Compose a wire credential that echoes a challenge + carries a payload.
+const credentialFor = (
+  challenge: MppChallenge,
+  payload: Record<string, unknown>,
+): string =>
+  base64UrlEncode(
+    JSON.stringify({
+      challenge: {
+        expires: challenge.expires,
+        id: challenge.id,
+        intent: challenge.intent,
+        method: challenge.method,
+        opaque: challenge.opaque,
+        realm: challenge.realm,
+        request: challenge.request,
       },
-    ])
+      payload,
+    }),
+  )
+
+describe('mpp protocol — 402 challenge wire shape (HMAC-bound)', () => {
+  test('renders a WWW-Authenticate Payment header with the spec params', async () => {
+    const challenge = await cryptoChallenge()
+    const header = renderChallengeHeader(challenge)
+    expect(header.startsWith('Payment ')).toBe(true)
+    expect(header).toContain(`id="${challenge.id}"`)
+    expect(header).toContain('realm="openagents.com"')
+    expect(header).toContain('method="base"')
+    expect(header).toContain('intent="charge"')
+    expect(header).toContain(`request="${challenge.request}"`)
+    expect(header).toContain(`expires="${FUTURE}"`)
+    expect(header).toContain('opaque=')
+    // The id is an HMAC, not a plaintext quote id.
+    expect(challenge.id).not.toContain(':crypto')
+  })
+
+  test('builds one WWW-Authenticate per challenge + problem body', async () => {
+    const crypto = await cryptoChallenge()
+    const card = await buildChallenge(SECRET, {
+      amountCents: 50,
+      currency: 'usd',
+      expires: FUTURE,
+      method: 'stripe',
+      realm: REALM,
+      request: {
+        amount: '50',
+        currency: 'usd',
+        methodDetails: { networkId: 'profile_x', paymentMethodTypes: ['card'] },
+      },
+    })
+    const headers = buildPaymentRequiredHeaders([crypto, card])
     const all = headers.get('www-authenticate')
     expect(all).toContain('method="base"')
     expect(all).toContain('method="stripe"')
-    expect(headers.get('content-type')).toBe('application/problem+json')
     expect(headers.get('cache-control')).toBe('no-store')
-  })
 
-  test('builds the problem+json body with the paymentauth.org type', () => {
-    const problem = buildPaymentRequiredProblem([cryptoChallenge])
+    const problem = buildPaymentRequiredProblem([crypto, card])
     expect(problem.status).toBe(402)
     expect(problem.type).toBe(
       'https://paymentauth.org/problems/payment-required',
     )
-    expect(problem.title).toBe('Payment Required')
-    expect(problem.challengeId).toBe('chal_abc:crypto')
-    expect(problem.challenges).toHaveLength(1)
-    expect(problem.challenges[0]?.paymentIntentId).toBe('pi_123')
+    expect(problem.challenges).toHaveLength(2)
+    expect(problem.challenges[0]?.paymentIntentId).toBe('pi_dep_1')
+  })
+
+  test('Payment-Receipt is base64url JCS with status success', () => {
+    const receipt = buildPaymentReceipt({
+      method: 'base',
+      reference: 'pi_1',
+      timestamp: FUTURE,
+    })
+    expect(receipt).not.toContain('=')
+    expect(receipt).toBe(
+      jcsBase64Url({
+        method: 'base',
+        reference: 'pi_1',
+        status: 'success',
+        timestamp: FUTURE,
+      }),
+    )
   })
 })
 
 describe('mpp protocol — credential parsing', () => {
-  test('undefined for a missing Authorization header', () => {
+  test('undefined for missing / non-Payment scheme', () => {
     expect(parsePaymentCredential(null)).toBeUndefined()
-  })
-
-  test('undefined for a non-Payment scheme (so the endpoint re-challenges)', () => {
     expect(parsePaymentCredential('Bearer xyz')).toBeUndefined()
   })
 
-  test('parses the quoted-param Payment credential and extracts the payment intent', () => {
+  test('undefined for malformed (no challenge/payload)', () => {
+    expect(parsePaymentCredential('Payment not-base64')).toBeUndefined()
+    expect(
+      parsePaymentCredential(`Payment ${base64UrlEncode('{"x":1}')}`),
+    ).toBeUndefined()
+  })
+
+  test('parses an echoed-challenge + payload credential', async () => {
+    const challenge = await cryptoChallenge()
     const parsed = parsePaymentCredential(
-      'Payment id="chal_abc:crypto", method="base", payment_intent="pi_123"',
+      `Payment ${credentialFor(challenge, { ref: '0xpay' })}`,
     )
     expect(parsed?.scheme).toBe('Payment')
-    expect(parsed?.challengeId).toBe('chal_abc:crypto')
-    expect(parsed?.method).toBe('base')
-    expect(parsed?.paymentIntentId).toBe('pi_123')
+    expect(parsed?.challenge.id).toBe(challenge.id)
+    expect(parsed?.challenge.method).toBe('base')
+    expect(parsed?.payload.ref).toBe('0xpay')
+  })
+})
+
+describe('mpp protocol — stateless HMAC verification (FAIL-CLOSED)', () => {
+  const expectations = {
+    allowedMethods: ['base', 'solana', 'tempo', 'stripe'],
+    expectedCurrencyForMethod: (m: string) => (m === 'stripe' ? 'usd' : 'usdc'),
+    expectedMinAmountCents: 1,
+    nowMs: Date.parse('2026-06-23T12:00:00.000Z'),
+    realm: REALM,
+  }
+
+  test('accepts a correctly-bound credential and recovers opaque/request', async () => {
+    const challenge = await cryptoChallenge()
+    const parsed = parsePaymentCredential(
+      `Payment ${credentialFor(challenge, {})}`,
+    )!
+    const result = await verifyCredential(SECRET, parsed, expectations)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.method).toBe('base')
+      expect(result.opaque?.pi).toBe('pi_dep_1')
+      expect(result.request.amount).toBe('100')
+    }
   })
 
-  test('parses a base64url JSON Payment token and extracts the payment intent', () => {
-    const token = btoa(
-      JSON.stringify({
-        challengeId: 'chal_zzz',
-        method: 'tempo',
-        payload: { payment_intent: 'pi_999' },
-      }),
-    )
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-    const parsed = parsePaymentCredential(`Payment ${token}`)
-    expect(parsed?.paymentIntentId).toBe('pi_999')
-    expect(parsed?.challengeId).toBe('chal_zzz')
+  test('rejects a tampered challenge (forged id)', async () => {
+    const challenge = await cryptoChallenge()
+    const tampered: MppChallenge = { ...challenge, id: `${challenge.id}x` }
+    const parsed = parsePaymentCredential(
+      `Payment ${credentialFor(tampered, {})}`,
+    )!
+    const result = await verifyCredential(SECRET, parsed, expectations)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('invalid-challenge')
   })
 
-  test('retains the raw value when a token does not decode (sidecar verify path)', () => {
-    const parsed = parsePaymentCredential('Payment not-base64-or-params')
-    expect(parsed?.scheme).toBe('Payment')
-    expect(parsed?.paymentIntentId).toBeUndefined()
-    expect(parsed?.raw).toBe('not-base64-or-params')
+  test('rejects a credential whose request was swapped (binding catches it)', async () => {
+    const challenge = await cryptoChallenge()
+    // Swap the bound request for a cheaper one but keep the original id.
+    const cheaperRequest: MppRequestParams = {
+      amount: '1',
+      currency: 'usdc',
+      network: 'base',
+    }
+    const tampered: MppChallenge = {
+      ...challenge,
+      request: jcsBase64Url(cheaperRequest),
+    }
+    const parsed = parsePaymentCredential(
+      `Payment ${credentialFor(tampered, {})}`,
+    )!
+    const result = await verifyCredential(SECRET, parsed, expectations)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('invalid-challenge')
+  })
+
+  test('rejects an expired challenge', async () => {
+    const challenge = await cryptoChallenge({
+      expires: '2000-01-01T00:00:00.000Z',
+    })
+    const parsed = parsePaymentCredential(
+      `Payment ${credentialFor(challenge, {})}`,
+    )!
+    const result = await verifyCredential(SECRET, parsed, expectations)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('expired')
+  })
+
+  test('rejects a wrong-secret credential (different signer)', async () => {
+    const challenge = await buildChallenge('OTHER-secret', {
+      amountCents: 100,
+      currency: 'usdc',
+      expires: FUTURE,
+      method: 'base',
+      realm: REALM,
+      request: { amount: '100', currency: 'usdc' },
+    })
+    const parsed = parsePaymentCredential(
+      `Payment ${credentialFor(challenge, {})}`,
+    )!
+    const result = await verifyCredential(SECRET, parsed, expectations)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('invalid-challenge')
+  })
+
+  test('rejects a method we never offered', async () => {
+    const challenge = await cryptoChallenge()
+    const parsed = parsePaymentCredential(
+      `Payment ${credentialFor(challenge, {})}`,
+    )!
+    const result = await verifyCredential(SECRET, parsed, {
+      ...expectations,
+      allowedMethods: ['solana'], // base not offered
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('method-mismatch')
+  })
+
+  test('rejects a request whose currency does not match the method', async () => {
+    const challenge = await cryptoChallenge()
+    const parsed = parsePaymentCredential(
+      `Payment ${credentialFor(challenge, {})}`,
+    )!
+    const result = await verifyCredential(SECRET, parsed, {
+      ...expectations,
+      expectedCurrencyForMethod: () => 'eur',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('request-mismatch')
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-protocol.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-protocol.ts
@@ -1,39 +1,85 @@
-// MPP / x402 wire protocol — 402 challenge construction + credential parsing
-// (EPIC #6049, Phase 2). PURE (no IO, no Stripe, no env).
+// MPP / Payment Auth wire protocol — 402 challenge construction + credential
+// parsing + STATELESS HMAC verification (EPIC #6049, defect B).
 //
-// The mechanism (Stripe machine-payments docs, authoritative):
+// The mechanism (draft-httpauth-payment-00, the authoritative Payment Auth core
+// spec, mirrored at docs/reference/mpp/paymentauth/specs/core/):
 //   - A request with NO payment credential gets `402 Payment Required` with one
-//     `WWW-Authenticate: Payment ...` header per accepted method, and a
+//     `WWW-Authenticate: Payment ...` header per accepted method, and an
 //     `application/problem+json` body
 //     (`type: https://paymentauth.org/problems/payment-required`).
-//   - The client reads the challenges, picks a method, pays, and RETRIES with an
-//     `Authorization: Payment <token>` credential.
-//   - The server parses the credential, verifies it (Stripe REST, see
-//     stripe-mpp-client.ts), and serves.
+//   - Each challenge carries `id`, `realm`, `method`, `intent`, `request`
+//     (base64url JCS JSON of the method request), `expires`, and `opaque`
+//     (base64url JCS JSON of our server correlation data). The `id` is the
+//     HMAC-SHA256 binding over those fields (see mpp-canonical.ts §5.1.3), so the
+//     server verifies the retry statelessly — no per-challenge storage.
+//   - The client pays, then RETRIES with `Authorization: Payment <base64url>`
+//     where the decoded JSON is `{ challenge, payload, source? }`. `challenge`
+//     ECHOES the issued challenge; `payload` carries the method proof (the SPT
+//     for card; for our crypto rail the deposit reference lives in `opaque`).
+//   - The server: recomputes the HMAC id from the echoed challenge fields and
+//     constant-time compares; checks expiry; checks the request binds to what we
+//     serve (amount/currency); recovers correlation from `opaque`; settles.
 //
-// This module owns the wire shape only; verification + the Khala completion live
-// in the endpoint handler.
+// This module owns the wire shape + the stateless verification of the binding.
+// Settlement (Stripe REST) and the Khala completion live in the endpoint handler.
 
-import { parseBase64UrlJsonRecord } from '../../json-boundary'
+import { currentEpochMillis } from '../../runtime-primitives'
+import {
+  type ChallengeBindingSlots,
+  computeChallengeId,
+  constantTimeEqual,
+  decodeJcsBase64UrlRecord,
+  jcsBase64Url,
+} from './mpp-canonical'
 
-// One accepted payment method on the 402 challenge.
+// ---- Challenge model ----
+
+// The method `request` JSON (base64url JCS in the challenge). Mirrors the
+// charge-intent request schema: amount is a STRING in minor units per the
+// stripe/usdc charge specs; currency is the ISO/asset code. recipient + network
+// describe the crypto deposit target.
+export type MppRequestParams = Readonly<{
+  amount: string
+  currency: string
+  description?: string | undefined
+  recipient?: string | undefined
+  network?: string | undefined
+  // methodDetails.networkId carries our Stripe Business Network Profile id for
+  // the stripe/SPT method (the `profile_…`).
+  methodDetails?: Record<string, unknown> | undefined
+}>
+
+// Server correlation data carried in `opaque` (base64url JCS). Flat string map
+// per the core spec (§5.1.2). We stash the crypto deposit PaymentIntent id +
+// amount + network so we can recover settlement state statelessly on retry.
+export type MppOpaque = Readonly<{
+  // The Stripe crypto deposit PaymentIntent id backing a crypto challenge.
+  pi?: string | undefined
+  amount?: string | undefined
+  network?: string | undefined
+  model?: string | undefined
+}>
+
+// One accepted payment method on the 402 challenge (server-side shape before
+// HMAC id computation; the id is filled by buildChallengeHeader).
 export type MppChallenge = Readonly<{
-  // Challenge id (binds the retry to this quote).
   id: string
-  // Method name: 'tempo'/'solana'/'base' (crypto) or 'stripe' (card/SPT).
+  realm: string
+  // Method name: a crypto network ('base'/'solana'/'tempo') or 'stripe' (SPT).
   method: string
-  // 'charge' for a pay-per-call charge.
   intent: 'charge'
-  // Price in minor units (cents) for this method.
+  // Base64url JCS of MppRequestParams.
+  request: string
+  // RFC 3339 expiry.
+  expires: string
+  // Base64url JCS of MppOpaque.
+  opaque?: string | undefined
+  // Decoded convenience mirrors for the inline problem body (NOT in the HMAC).
   amountCents: number
   currency: string
-  // For crypto methods: the network the deposit address lives on.
   network?: string | undefined
-  // For crypto methods: the deposit address the agent pays to.
   recipient?: string | undefined
-  // The Stripe PaymentIntent id backing this challenge (crypto). The retry
-  // references it (or the agent's payment proof references the deposit address);
-  // the server verifies settlement of this PaymentIntent.
+  // The Stripe PaymentIntent id (crypto rail) recovered from opaque.
   paymentIntentId?: string | undefined
 }>
 
@@ -44,34 +90,86 @@ export type PaymentRequiredProblem = Readonly<{
   status: 402
   detail: string
   challengeId: string
-  // Non-standard but useful: a structured echo of the challenges so a simple
-  // client that does not parse WWW-Authenticate can still act on the price +
-  // deposit address. Mirrors the directory examples that surface this inline.
-  challenges: ReadonlyArray<MppChallenge>
+  // Structured echo so a simple client that does not parse WWW-Authenticate can
+  // still act on the price + deposit address.
+  challenges: ReadonlyArray<
+    Readonly<{
+      id: string
+      method: string
+      intent: 'charge'
+      amountCents: number
+      currency: string
+      network?: string | undefined
+      recipient?: string | undefined
+      paymentIntentId?: string | undefined
+    }>
+  >
 }>
 
 const PAYMENT_REQUIRED_TYPE =
   'https://paymentauth.org/problems/payment-required'
 
-// Render the `WWW-Authenticate: Payment ...` header value for one challenge. The
-// quoted-param shape matches the Stripe docs example:
-//   WWW-Authenticate: Payment id="chal_…", method="tempo", intent="charge", …
+// Build a challenge: encode the method request + opaque to base64url JCS, then
+// compute the HMAC id over the binding slots. Async because the HMAC uses
+// WebCrypto. Returns the fully-formed challenge with its `id` populated.
+export const buildChallenge = async (
+  serverSecret: string,
+  input: Readonly<{
+    realm: string
+    method: string
+    request: MppRequestParams
+    expires: string
+    opaque?: MppOpaque | undefined
+    // Decoded mirrors for the inline problem body.
+    amountCents: number
+    currency: string
+    network?: string | undefined
+    recipient?: string | undefined
+    paymentIntentId?: string | undefined
+  }>,
+): Promise<MppChallenge> => {
+  const requestB64 = jcsBase64Url(input.request)
+  const opaqueB64 =
+    input.opaque === undefined ? undefined : jcsBase64Url(input.opaque)
+  const slots: ChallengeBindingSlots = {
+    digest: '',
+    expires: input.expires,
+    intent: 'charge',
+    method: input.method,
+    opaqueB64Url: opaqueB64 ?? '',
+    realm: input.realm,
+    requestB64Url: requestB64,
+  }
+  const id = await computeChallengeId(serverSecret, slots)
+  return {
+    amountCents: input.amountCents,
+    currency: input.currency,
+    expires: input.expires,
+    id,
+    intent: 'charge',
+    method: input.method,
+    network: input.network,
+    opaque: opaqueB64,
+    paymentIntentId: input.paymentIntentId,
+    realm: input.realm,
+    recipient: input.recipient,
+    request: requestB64,
+  }
+}
+
+// Render the `WWW-Authenticate: Payment ...` header for one challenge. Emits the
+// spec parameters (id, realm, method, intent, request, expires, opaque).
 export const renderChallengeHeader = (challenge: MppChallenge): string => {
   const params: Array<[string, string]> = [
     ['id', challenge.id],
+    ['realm', challenge.realm],
     ['method', challenge.method],
     ['intent', challenge.intent],
-    ['amount', String(challenge.amountCents)],
-    ['currency', challenge.currency],
+    ['request', challenge.request],
+    ['expires', challenge.expires],
   ]
-  if (challenge.network !== undefined) {
-    params.push(['network', challenge.network])
-  }
-  if (challenge.recipient !== undefined) {
-    params.push(['recipient', challenge.recipient])
-  }
-  if (challenge.paymentIntentId !== undefined) {
-    params.push(['payment_intent', challenge.paymentIntentId])
+  if (challenge.opaque !== undefined) {
+    params.push(['opaque', challenge.opaque])
   }
   const rendered = params
     .map(([k, v]) => `${k}="${v.replace(/"/g, '\\"')}"`)
@@ -80,7 +178,7 @@ export const renderChallengeHeader = (challenge: MppChallenge): string => {
 }
 
 // Build the full set of 402 response headers (one WWW-Authenticate per method +
-// problem content type + no-store).
+// problem content type + no-store, per the core spec caching rules).
 export const buildPaymentRequiredHeaders = (
   challenges: ReadonlyArray<MppChallenge>,
 ): Headers => {
@@ -97,48 +195,62 @@ export const buildPaymentRequiredHeaders = (
 // Build the problem+json body for the 402.
 export const buildPaymentRequiredProblem = (
   challenges: ReadonlyArray<MppChallenge>,
+  detail = 'Payment is required to use this endpoint.',
 ): PaymentRequiredProblem => ({
   challengeId: challenges[0]?.id ?? '',
-  challenges,
-  detail: 'Payment is required to use this endpoint.',
+  challenges: challenges.map(c => ({
+    amountCents: c.amountCents,
+    currency: c.currency,
+    id: c.id,
+    intent: c.intent,
+    method: c.method,
+    network: c.network,
+    paymentIntentId: c.paymentIntentId,
+    recipient: c.recipient,
+  })),
+  detail,
   status: 402,
   title: 'Payment Required',
   type: PAYMENT_REQUIRED_TYPE,
 })
 
-// A parsed inbound payment credential from `Authorization: Payment …`. The
-// retry carries the challenge id it is answering and a reference the server uses
-// to verify settlement — for the crypto rail, the Stripe PaymentIntent id.
+// ---- Credential parsing + verification ----
+
+// The echoed challenge object inside a credential (core spec §6.2).
+export type CredentialChallenge = Readonly<{
+  id: string
+  realm: string
+  method: string
+  intent: string
+  request: string
+  expires?: string | undefined
+  opaque?: string | undefined
+  digest?: string | undefined
+}>
+
+// A decoded inbound payment credential from `Authorization: Payment <b64url>`.
 export type ParsedPaymentCredential = Readonly<{
   scheme: 'Payment'
-  // The challenge id this credential answers, when present.
-  challengeId?: string | undefined
-  method?: string | undefined
-  // The Stripe PaymentIntent id to verify (crypto rail).
-  paymentIntentId?: string | undefined
-  // The shared payment token (card/SPT rail), when present.
-  sharedPaymentToken?: string | undefined
-  // The raw credential value (for a Node-sidecar verify path if needed).
+  challenge: CredentialChallenge
+  payload: Record<string, unknown>
+  source?: string | undefined
   raw: string
 }>
 
-// Parse a quoted-param list like: id="chal_1", payment_intent="pi_123" → map.
-const parseQuotedParams = (value: string): Record<string, string> => {
-  const out: Record<string, string> = {}
-  // Match key="value" (value may contain escaped quotes).
-  const re = /(\w+)="((?:[^"\\]|\\.)*)"/g
-  let match: RegExpExecArray | null
-  while ((match = re.exec(value)) !== null) {
-    out[match[1]!] = match[2]!.replace(/\\"/g, '"')
-  }
-  return out
+const readString = (
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined => {
+  const value = record[key]
+  return typeof value === 'string' ? value : undefined
 }
 
-// Parse the `Authorization` header. Returns undefined for a missing or
-// non-Payment scheme (so the endpoint returns a fresh 402). The Payment value is
-// either quoted params (`Payment id="…", payment_intent="…"`) or a base64url
-// JSON token (the Mppx-signed shape). We extract the fields we need to verify;
-// the raw value is retained for a Node-sidecar verify path.
+// Parse the `Authorization` header. Returns undefined for a missing/non-Payment
+// scheme (the endpoint then issues a fresh 402). The Payment value is a
+// base64url-nopad JSON object `{ challenge, payload, source? }`. We require the
+// echoed `challenge` (with at least id/realm/method/intent/request) and a
+// `payload` object; anything malformed returns undefined (fail-closed →
+// malformed-credential 402).
 export const parsePaymentCredential = (
   authorization: string | null,
 ): ParsedPaymentCredential | undefined => {
@@ -149,45 +261,224 @@ export const parsePaymentCredential = (
   if (!/^Payment\s+/i.test(trimmed)) {
     return undefined
   }
-  const raw = trimmed.replace(/^Payment\s+/i, '')
+  const raw = trimmed.replace(/^Payment\s+/i, '').trim()
+  if (raw === '') {
+    return undefined
+  }
 
-  // Quoted-param form.
-  if (raw.includes('="')) {
-    const params = parseQuotedParams(raw)
-    return {
-      challengeId: params.id,
-      method: params.method,
-      paymentIntentId: params.payment_intent ?? params.paymentIntent,
-      raw,
-      scheme: 'Payment',
-      sharedPaymentToken: params.shared_payment_token ?? params.spt,
+  const decoded = base64UrlDecodeRecord(raw)
+  if (decoded === undefined) {
+    return undefined
+  }
+
+  const challengeRecord = decoded.challenge
+  if (
+    challengeRecord === null ||
+    typeof challengeRecord !== 'object' ||
+    Array.isArray(challengeRecord)
+  ) {
+    return undefined
+  }
+  const challenge = challengeRecord as Record<string, unknown>
+  const id = readString(challenge, 'id')
+  const realm = readString(challenge, 'realm')
+  const method = readString(challenge, 'method')
+  const intent = readString(challenge, 'intent')
+  const request = readString(challenge, 'request')
+  if (
+    id === undefined ||
+    realm === undefined ||
+    method === undefined ||
+    intent === undefined ||
+    request === undefined
+  ) {
+    return undefined
+  }
+
+  const payloadRecord = decoded.payload
+  const payload =
+    payloadRecord !== null &&
+    typeof payloadRecord === 'object' &&
+    !Array.isArray(payloadRecord)
+      ? (payloadRecord as Record<string, unknown>)
+      : undefined
+  if (payload === undefined) {
+    return undefined
+  }
+
+  return {
+    challenge: {
+      digest: readString(challenge, 'digest'),
+      expires: readString(challenge, 'expires'),
+      id,
+      intent,
+      method,
+      opaque: readString(challenge, 'opaque'),
+      realm,
+      request,
+    },
+    payload,
+    raw,
+    scheme: 'Payment',
+    source: readString(decoded, 'source'),
+  }
+}
+
+// Decode a base64url-nopad string to a JSON record (top-level credential).
+const base64UrlDecodeRecord = (
+  value: string,
+): Record<string, unknown> | undefined => decodeJcsBase64UrlRecord(value)
+
+// ---- Stateless verification result ----
+
+export type CredentialVerifyFailure =
+  | 'invalid-challenge' // HMAC id mismatch / unknown binding
+  | 'expired' // past `expires`
+  | 'request-mismatch' // amount/currency does not bind to what we serve
+  | 'method-mismatch' // method not one we offered
+
+export type CredentialVerifyResult =
+  | Readonly<{
+      ok: true
+      method: string
+      // Decoded method request params (amount/currency/etc).
+      request: MppRequestParams
+      // Decoded server correlation data (crypto: pi/amount/network).
+      opaque: MppOpaque | undefined
+    }>
+  | Readonly<{ ok: false; reason: CredentialVerifyFailure }>
+
+// Recompute the HMAC id over the echoed challenge fields and verify the binding
+// statelessly, FAIL-CLOSED. Then check expiry and that the request binds to what
+// we serve (currency + amount). This is the load-bearing verification: a tampered
+// challenge, a forged id, an expired challenge, or a request whose amount/currency
+// no longer matches our quote all reject here. Settlement happens AFTER this.
+export const verifyCredential = async (
+  serverSecret: string,
+  credential: ParsedPaymentCredential,
+  expectations: Readonly<{
+    realm: string
+    // The methods we offered (crypto networks + optionally 'stripe').
+    allowedMethods: ReadonlyArray<string>
+    // The currency we expect for the credential's method.
+    expectedCurrencyForMethod: (method: string) => string
+    // The minimum amount in minor units we expect (>= floors a downward tamper).
+    expectedMinAmountCents: number
+    nowMs?: number | undefined
+  }>,
+): Promise<CredentialVerifyResult> => {
+  const echoed = credential.challenge
+
+  // (d-pre) method must be one we offered.
+  if (!expectations.allowedMethods.includes(echoed.method)) {
+    return { ok: false, reason: 'method-mismatch' }
+  }
+
+  // (a) recompute the HMAC id from the echoed challenge fields + server secret
+  // and constant-time compare. The realm in the echo must also match ours.
+  if (echoed.realm !== expectations.realm) {
+    return { ok: false, reason: 'invalid-challenge' }
+  }
+  const slots: ChallengeBindingSlots = {
+    digest: echoed.digest ?? '',
+    expires: echoed.expires ?? '',
+    intent: echoed.intent,
+    method: echoed.method,
+    opaqueB64Url: echoed.opaque ?? '',
+    realm: echoed.realm,
+    requestB64Url: echoed.request,
+  }
+  const expectedId = await computeChallengeId(serverSecret, slots)
+  if (!constantTimeEqual(expectedId, echoed.id)) {
+    return { ok: false, reason: 'invalid-challenge' }
+  }
+
+  // (b) not expired.
+  if (echoed.expires !== undefined && echoed.expires !== '') {
+    const expiresMs = Date.parse(echoed.expires)
+    const nowMs = expectations.nowMs ?? currentEpochMillis()
+    if (Number.isNaN(expiresMs) || expiresMs <= nowMs) {
+      return { ok: false, reason: 'expired' }
     }
   }
 
-  // base64url JSON token form (Mppx-signed). Decode best-effort to extract the
-  // settlement reference; if it does not decode, the raw value still rides
-  // through for a sidecar verify.
-  try {
-    const parsed = parseBase64UrlJsonRecord(raw)
-    if (parsed === undefined) {
-      return { raw, scheme: 'Payment' }
-    }
-    const payload = (parsed.payload ?? parsed) as Record<string, unknown>
-    const pi =
-      payload.payment_intent ??
-      payload.paymentIntent ??
-      payload.payment_intent_id
-    const spt = payload.shared_payment_token ?? payload.spt
-    return {
-      challengeId:
-        typeof parsed.challengeId === 'string' ? parsed.challengeId : undefined,
-      method: typeof parsed.method === 'string' ? parsed.method : undefined,
-      paymentIntentId: typeof pi === 'string' ? pi : undefined,
-      raw,
-      scheme: 'Payment',
-      sharedPaymentToken: typeof spt === 'string' ? spt : undefined,
-    }
-  } catch {
-    return { raw, scheme: 'Payment' }
+  // (c) the request params bind to what we're serving (amount/currency). Decode
+  // the JCS request and check currency + a non-decreasing amount. Because the id
+  // already covered `request`, this is a defense-in-depth read; a mismatch means
+  // we would be serving for a different quote than the bound one.
+  const requestRecord = decodeJcsBase64UrlRecord(echoed.request)
+  if (requestRecord === undefined) {
+    return { ok: false, reason: 'invalid-challenge' }
+  }
+  const amount = readString(requestRecord, 'amount')
+  const currency = readString(requestRecord, 'currency')
+  if (amount === undefined || currency === undefined) {
+    return { ok: false, reason: 'request-mismatch' }
+  }
+  const amountCents = Number(amount)
+  if (
+    !Number.isFinite(amountCents) ||
+    amountCents < expectations.expectedMinAmountCents
+  ) {
+    return { ok: false, reason: 'request-mismatch' }
+  }
+  if (
+    currency.toLowerCase() !==
+    expectations.expectedCurrencyForMethod(echoed.method).toLowerCase()
+  ) {
+    return { ok: false, reason: 'request-mismatch' }
+  }
+
+  const request: MppRequestParams = {
+    amount,
+    currency,
+    description: readString(requestRecord, 'description'),
+    methodDetails:
+      requestRecord.methodDetails !== null &&
+      typeof requestRecord.methodDetails === 'object' &&
+      !Array.isArray(requestRecord.methodDetails)
+        ? (requestRecord.methodDetails as Record<string, unknown>)
+        : undefined,
+    network: readString(requestRecord, 'network'),
+    recipient: readString(requestRecord, 'recipient'),
+  }
+
+  const opaque =
+    echoed.opaque === undefined
+      ? undefined
+      : decodeOpaque(echoed.opaque)
+
+  return { method: echoed.method, ok: true, opaque, request }
+}
+
+// ---- Payment-Receipt (core spec §6.3) ----
+
+// Build the base64url-nopad `Payment-Receipt` header value for a settled
+// payment. Issued ONLY on success (2xx); never on error responses.
+export const buildPaymentReceipt = (
+  input: Readonly<{
+    method: string
+    reference: string
+    timestamp: string
+  }>,
+): string =>
+  jcsBase64Url({
+    method: input.method,
+    reference: input.reference,
+    status: 'success',
+    timestamp: input.timestamp,
+  })
+
+// Decode the `opaque` correlation record (base64url JCS) into MppOpaque.
+const decodeOpaque = (opaqueB64: string): MppOpaque | undefined => {
+  const record = decodeJcsBase64UrlRecord(opaqueB64)
+  if (record === undefined) {
+    return undefined
+  }
+  return {
+    amount: readString(record, 'amount'),
+    model: readString(record, 'model'),
+    network: readString(record, 'network'),
+    pi: readString(record, 'pi'),
   }
 }

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-spt-replay.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-spt-replay.ts
@@ -1,0 +1,70 @@
+// MPP Stripe SPT single-use replay guard (EPIC #6049, defect B).
+//
+// The Payment Auth core spec requires single-use payment proofs (§"Replay
+// Protection"), and the Stripe charge intent makes the SERVER reject a reused
+// SPT (draft-stripe-charge-00 §"Verification Procedure" step 4). This is the
+// local defense-in-depth replay cache the spec says servers SHOULD/MAY keep, on
+// top of Stripe's own SPT single-use enforcement and the PaymentIntent
+// idempotency key. We claim the SPT BEFORE creating the charge: a second attempt
+// collides on the PRIMARY KEY and is refused before any second charge.
+//
+// INERT NOTE: only the card/SPT rail touches this; the crypto rail never does.
+
+import { Effect } from 'effect'
+
+import { currentIsoTimestamp } from '../../runtime-primitives'
+
+export class MppSptReplayError extends Error {
+  override readonly name = 'MppSptReplayError'
+  override readonly cause: unknown
+  constructor(cause: unknown) {
+    super('mpp spt replay store failure')
+    this.cause = cause
+  }
+}
+
+// Atomically claim an SPT for one challenge. Returns true when this is the FIRST
+// use (the row was inserted) and false when the SPT was already consumed (replay
+// rejected). Uses `INSERT ... ON CONFLICT DO NOTHING` + a changes check so the
+// claim is a single atomic D1 statement.
+export const claimSpt = (
+  db: D1Database,
+  input: Readonly<{ spt: string; challengeId: string }>,
+  nowIso: () => string = currentIsoTimestamp,
+): Effect.Effect<boolean, MppSptReplayError> =>
+  Effect.tryPromise({
+    catch: (cause: unknown) => new MppSptReplayError(cause),
+    try: async () => {
+      const result = await db
+        .prepare(
+          `INSERT INTO mpp_spt_replay (spt, challenge_id, payment_intent_id, consumed_at)
+           VALUES (?, ?, NULL, ?)
+           ON CONFLICT (spt) DO NOTHING`,
+        )
+        .bind(input.spt, input.challengeId, nowIso())
+        .run()
+      // D1 surfaces affected rows under meta.changes; a 0 means the SPT was
+      // already present (replay).
+      const changes =
+        (result as unknown as { meta?: { changes?: number } }).meta?.changes
+      return changes === undefined ? true : changes > 0
+    },
+  })
+
+// Record the resulting PaymentIntent id against a consumed SPT (best-effort
+// dereference; not load-bearing for the replay guard itself).
+export const recordSptPaymentIntent = (
+  db: D1Database,
+  input: Readonly<{ spt: string; paymentIntentId: string }>,
+): Effect.Effect<void, MppSptReplayError> =>
+  Effect.tryPromise({
+    catch: (cause: unknown) => new MppSptReplayError(cause),
+    try: async () => {
+      await db
+        .prepare(
+          `UPDATE mpp_spt_replay SET payment_intent_id = ? WHERE spt = ?`,
+        )
+        .bind(input.paymentIntentId, input.spt)
+        .run()
+    },
+  })

--- a/apps/openagents.com/workers/api/src/inference/mpp/stripe-mpp-client.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/stripe-mpp-client.ts
@@ -242,6 +242,90 @@ export const createCryptoDepositPaymentIntent = (
     }
   })
 
+// Create + confirm a PaymentIntent from a Stripe Shared Payment Token (SPT),
+// the card/SPT charge settlement (draft-stripe-charge-00 §"Settlement
+// Procedure"). The SPT rides as `shared_payment_granted_token`, `confirm: true`,
+// with automatic payment methods (no explicit `payment_method_types`, per
+// OpenAgents Stripe best practice — the SPT itself carries the method). The
+// challenge id + SPT form the Stripe idempotency key so a client retry never
+// double-charges. We serve only when the returned status is `succeeded`.
+export const createSptChargePaymentIntent = (
+  deps: StripeMppClientDeps,
+  input: Readonly<{
+    amountCents: number
+    currency?: string
+    spt: string
+    challengeId: string
+    networkProfileId: string
+    metadata?: Record<string, string>
+  }>,
+): Effect.Effect<RetrievedPaymentIntent, StripeMppError> =>
+  Effect.gen(function* () {
+    const doFetch = deps.fetch ?? ((u, i) => fetch(u, i))
+    const currency = input.currency ?? 'usd'
+    const body = encodeStripeForm({
+      amount: input.amountCents,
+      automatic_payment_methods: { allow_redirects: 'never', enabled: true },
+      confirm: true,
+      currency,
+      metadata: {
+        ...(input.metadata ?? {}),
+        challenge_id: input.challengeId,
+        network_id: input.networkProfileId,
+      },
+      shared_payment_granted_token: input.spt,
+    })
+
+    const response = yield* Effect.tryPromise({
+      catch: (cause: unknown) =>
+        new StripeMppError('create_spt_payment_intent', String(cause)),
+      try: () =>
+        doFetch(`${STRIPE_API_BASE}/payment_intents`, {
+          body,
+          headers: {
+            ...authHeaders(deps.secretKey),
+            // Spec idempotency key: `${challenge.id}_${credential.spt}`.
+            'idempotency-key': `${input.challengeId}_${input.spt}`,
+          },
+          method: 'POST',
+        }),
+    })
+
+    const json = yield* Effect.tryPromise({
+      catch: (cause: unknown) =>
+        new StripeMppError('create_spt_payment_intent_parse', String(cause)),
+      try: () => response.json() as Promise<Record<string, unknown>>,
+    })
+
+    if (!response.ok) {
+      const err = (json.error ?? {}) as Record<string, unknown>
+      return yield* Effect.fail(
+        new StripeMppError(
+          'create_spt_payment_intent',
+          `${response.status} ${String(err.message ?? 'stripe error')}`,
+        ),
+      )
+    }
+
+    const status = typeof json.status === 'string' ? json.status : 'unknown'
+    const rawMeta = (json.metadata ?? {}) as Record<string, unknown>
+    const metadata: Record<string, string> = {}
+    for (const [k, v] of Object.entries(rawMeta)) {
+      if (typeof v === 'string') {
+        metadata[k] = v
+      }
+    }
+    return {
+      amountCents:
+        typeof json.amount === 'number' ? json.amount : input.amountCents,
+      currency: typeof json.currency === 'string' ? json.currency : currency,
+      id: typeof json.id === 'string' ? json.id : '',
+      metadata,
+      settled: status === 'succeeded',
+      status,
+    }
+  })
+
 export type RetrievedPaymentIntent = Readonly<{
   id: string
   status: string

--- a/docs/launch/2026-06-23-mpp-integration-audit.md
+++ b/docs/launch/2026-06-23-mpp-integration-audit.md
@@ -6,6 +6,79 @@ Scope: OpenAgentsInc/openagents#6049 plus the payment, credit, Stripe, and MPP
 issues that affect whether Khala can accept Machine Payments Protocol (MPP)
 payments before Stripe Directory profile approval.
 
+## Defect B Resolution (2026-06-23, Worker-native)
+
+Defect B — "the credential verify path expected a Stripe `payment_intent="…"`
+inside the returned credential, did not find one from a real `mppx` client, and
+fell into an infinite 402 loop and never served" — is RESOLVED Worker-native
+(WebCrypto, no Node sidecar). The verify path now implements the canonical
+Payment Auth protocol instead of a handwritten quoted-param guess:
+
+- **Stateless HMAC challenge binding** (`mpp-canonical.ts`,
+  `draft-httpauth-payment-00` §5.1.3). The 402 challenge `id` is
+  `base64url(HMAC-SHA256(server_secret, "|".join([realm, method, intent,
+  request_b64url, expires, digest, opaque_b64url])))` with JCS/RFC-8785
+  canonicalization of the `request` and `opaque` JSON. The server-held secret is
+  the new Worker SECRET `KHALA_MPP_SIGNING_SECRET`.
+- **Challenge issuance** carries our correlation data (crypto deposit
+  PaymentIntent id + amount + network + model) in the `opaque` field
+  (base64url JCS), so retry verification recovers it statelessly with no
+  per-challenge storage. One `WWW-Authenticate: Payment …` per supported method
+  (crypto networks always; `stripe`/SPT only when
+  `STRIPE_MPP_NETWORK_PROFILE_ID` is set).
+- **Credential verification** decodes `Authorization: Payment <base64url>` →
+  `{challenge, payload, source?}` and FAILS CLOSED (returns 402, never serves)
+  on any of: (a) recomputed HMAC `id` mismatch (constant-time compare),
+  (b) expired challenge, (c) `request` amount/currency not binding to the
+  served quote, (d) a method we did not offer. Only after that does it settle:
+  - **crypto:** recover the deposit PaymentIntent id from `opaque`, retrieve it
+    from Stripe, serve only when `status === 'succeeded'`.
+  - **card/SPT:** extract `payload.spt`, enforce single-use via a D1 replay
+    cache (`mpp_spt_replay`, migration `0224`), create+confirm a PaymentIntent
+    with `shared_payment_granted_token` + the `profile_…` networkId, serve only
+    when `succeeded`.
+- **Payment-Receipt** (`draft-httpauth-payment-00` §6.3) is now returned on a
+  settled paid completion (base64url JCS `{status:"success", method, timestamp,
+  reference}`) alongside the unchanged OpenAgents receipt block, with
+  `Cache-Control: private`. (Slice B.)
+- The settled-payment path still mints USD-origin Khala credits (idempotent
+  `mpp:<pi>`, RL-3: inference-spendable, not Bitcoin-withdrawable) and runs the
+  SAME completion + metering + receipt loop.
+
+There is NO infinite-402 loop on a real `mppx` credential anymore: a well-formed
+crypto or SPT credential that binds to a settled payment serves; a malformed,
+tampered, expired, mismatched, replayed, or unsettled credential returns a fresh
+402 (with a detail string) exactly as the spec prescribes.
+
+### Arming + secret steps (owner-gated; endpoint stays INERT until all done)
+
+The endpoint is triple-gated and fail-safe inert. To arm it on the live Worker:
+
+1. `wrangler secret put KHALA_MPP_SIGNING_SECRET` (a high-entropy random string;
+   the HMAC challenge-binding key — Worker SECRET, never committed/logged).
+2. `wrangler secret put STRIPE_API_KEY` (the Stripe secret key; absent ⇒ inert).
+3. Set `KHALA_MPP_ENABLED` to `true` (the var, currently OFF).
+4. The card/SPT rail additionally needs `STRIPE_MPP_NETWORK_PROFILE_ID` (already a
+   committed `var`); without it the endpoint is crypto-only.
+
+With any of `KHALA_MPP_ENABLED` off, no `STRIPE_API_KEY`, or no
+`KHALA_MPP_SIGNING_SECRET`, the endpoint returns `503 mpp_not_configured` and
+constructs no charge and issues no challenge. THIS DEFECT-B CHANGE DID NOT ARM
+THE ENDPOINT, set any live key, or deploy.
+
+### Smoke before arming
+
+Before flipping `KHALA_MPP_ENABLED`, prove the crypto rail end-to-end against
+staging with a real MPP/x402 client: issue a 402 with a `KHALA_MPP_SIGNING_SECRET`
+set, use Stripe's `simulate_crypto_deposit` (test mode) to settle the deposit
+PaymentIntent named in `opaque`, retry with the echoed-challenge credential, and
+assert a 200 + `Payment-Receipt` + a dereferenceable USD-credit grant + metered
+spend receipt. A real `mppx fetch <staging endpoint>` is now EXPECTED to complete
+the crypto flow once the signing secret + test Stripe key are present, because the
+challenge/credential wire format is now spec-canonical (HMAC-bound `id`, JCS
+`request`/`opaque`, echoed challenge). The card/SPT rail additionally needs the
+approved `profile_…` and an SPT-capable client.
+
 ## Verdict
 
 OpenAgents is not blocked on the Stripe Directory profile to keep adding MPP
@@ -146,15 +219,20 @@ handwritten quoted-param parser.
 
 - `mppx fetch <openagents endpoint>` can complete an end-to-end paid request
   against staging or production.
-- The Worker-native `WWW-Authenticate` challenge is bit-compatible with the
-  canonical MPP/mppx challenge format, including request/body digest, opaque
-  metadata, expiry, HMAC binding, and exact base64url/JCS payload expectations.
-- The card/SPT rail can settle without a Node sidecar.
 - The crypto rail can be paid and verified by a real MPP/x402 client on staging.
-- `Payment-Receipt` is returned on successful MPP completions. Today the route
-  returns the normal OpenAI-compatible completion with the `openagents` receipt
-  block, but the audit did not find a MPP `Payment-Receipt` header on the paid
-  route.
+  (The wire format is now spec-canonical per "Defect B Resolution" above; the
+  remaining gap is a live staging proof with a real `mppx` client + Stripe test
+  `simulate_crypto_deposit`, not the protocol shape.)
+
+Resolved 2026-06-23 by the Defect B change (see above):
+
+- The Worker-native challenge is now HMAC-bound with JCS `request`/`opaque`,
+  expiry, and a slot for body digest, matching `draft-httpauth-payment-00`
+  §5.1.3.
+- The card/SPT rail settles Worker-native (create+confirm PaymentIntent with
+  `shared_payment_granted_token` + replay cache) without a Node sidecar.
+- `Payment-Receipt` is now returned on successful MPP completions alongside the
+  unchanged `openagents` receipt block.
 
 ## Issue Read
 


### PR DESCRIPTION
Resolves defect B from the MPP integration audit: the credential verify path expected a Stripe `payment_intent="..."` inside the returned credential, did not find one from a real `mppx` client, and fell into an infinite 402 loop, never serving.

## What changed

Reimplements verification per the canonical Payment-Auth spec (`draft-httpauth-payment-00`, mirrored at `docs/reference/mpp/`), Worker-native with WebCrypto — **no Node sidecar**.

- **`mpp-canonical.ts`** — RFC-8785 JCS canonical JSON, base64url-nopad, WebCrypto HMAC-SHA256 over the seven-slot binding input, constant-time compare.
- **Challenge issuance** — the 402 challenge `id` is `base64url(HMAC-SHA256(secret, "|".join([realm, method, intent, request_b64url, expires, digest, opaque_b64url])))`. Our crypto deposit PaymentIntent id + amount + network ride in `opaque` (base64url JCS) so the retry recovers them statelessly. One `WWW-Authenticate: Payment …` per supported method (crypto always; `stripe`/SPT only when `STRIPE_MPP_NETWORK_PROFILE_ID` is set).
- **Credential verification** — decode `Authorization: Payment <b64url>` → `{challenge, payload}`; **FAIL-CLOSED** (402, never serves) on HMAC id mismatch, expiry, request amount/currency mismatch, or a method we did not offer. Then settle:
  - crypto: recover the PaymentIntent id from `opaque`, retrieve, serve only when `succeeded`;
  - card/SPT: take `payload.spt`, enforce single-use via a D1 replay cache (migration `0224`), create+confirm a PaymentIntent with `shared_payment_granted_token`, serve only when `succeeded`.
- **`Payment-Receipt`** header on settled completions (base64url JCS) + `Cache-Control: private`, alongside the unchanged OpenAgents receipt block.
- Preserves every invariant: idempotent USD-origin credit mint (`mpp:<pi>`, RL-3 — not Bitcoin-withdrawable), the same completion + metering + receipt loop.

## Secret

New Worker **SECRET** `KHALA_MPP_SIGNING_SECRET` (HMAC key), plumbed through `config.ts` like `STRIPE_API_KEY`. Owner arms with:

```
wrangler secret put KHALA_MPP_SIGNING_SECRET
```

## Fail-closed / inert

Triple-gated: with `KHALA_MPP_ENABLED` off, no `STRIPE_API_KEY`, OR no `KHALA_MPP_SIGNING_SECRET`, the endpoint returns `503 mpp_not_configured` and constructs no charge / issues no challenge. **This PR does NOT arm the endpoint, set any live key, or deploy.**

## Tests

49/49 MPP tests pass: HMAC round-trip, tampered/expired/request-mismatch/wrong-secret/method-mismatch rejection, SPT replay rejection, crypto-not-settled → 402, crypto + SPT settled → serve + idempotent credit mint + Payment-Receipt. `typecheck:api` and `check:architecture` (zero-debt) green. `check:deploy` green except the known `check-contract-drift.test.ts` false-fail inside `.worktrees/` (the guard's own file passes 5/5 from a non-worktree checkout — verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)