### PR TITLE
Serve MPP /openapi.json discovery document for Khala

### DIFF
--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -366,7 +366,18 @@ const budgetChecks = [
     // the sibling `handlePublicArtanisLaborReceiptsApi` already counted here, is
     // no-store and mints no authority. Ratchet back down when these Artanis read
     // handlers are extracted behind shared route mappers.
-    budget: 106,
+    // +1 (106 -> 107) on 2026-06-23 (EPIC #6049) for the MPP service-discovery
+    // document renderer in inference/mpp-discovery-document.ts
+    // (`renderMppDiscoveryDocument` `Effect.Effect<Response>`, mounted from
+    // index.ts at `GET /openapi.json`). It serves the OpenAPI 3.1 discovery doc
+    // the MPP registries (MPPScan, mpp.dev/services) crawl to light the Machine
+    // Payments badge; the paid path's offers + 402 are gated behind the same
+    // KHALA_MPP_ENABLED flag the route reads, so an inert endpoint advertises
+    // nothing payable. It returns `Effect.Effect<Response>` like the sibling
+    // crawlable discovery-surface renderer already counted here, is public +
+    // cacheable, mints no authority, and never charges. Ratchet back down when
+    // these discovery handlers are extracted behind shared route mappers.
+    budget: 107,
     description:
       'Worker domain and route modules may not grow Response-returning surfaces while route mappers are extracted.',
     details: countByFile(

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -327,6 +327,7 @@ import {
   type DiscoverySurfacePath,
   renderDiscoverySurface,
 } from './inference/discovery-surfaces'
+import { renderMppDiscoveryDocument } from './inference/mpp-discovery-document'
 import {
   handleMppChatCompletions,
   isKhalaMppEnabled,
@@ -9815,6 +9816,37 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
       path: surfacePath,
     }),
   ),
+  {
+    // MPP service-discovery document (EPIC #6049). The Machine Payments Protocol
+    // registries (MPPScan, mpp.dev/services) crawl `GET /openapi.json` to light
+    // the Machine Payments badge for Khala. OpenAPI 3.1 with `x-service-info`
+    // (root) + per-operation `x-payment-info` (canonical multi-offer form).
+    //
+    // HONESTY GATE: the paid `/mpp/v1/chat/completions` path's offers + 402 are
+    // emitted ONLY when the MPP endpoint is actually armed — the SAME
+    // KHALA_MPP_ENABLED flag the route reads from config.ts (and the card offer
+    // only when STRIPE_MPP_NETWORK_PROFILE_ID is set, the same condition that
+    // arms the card rail). Inert => the document omits the paid path and
+    // advertises nothing payable. The document itself is always served (free
+    // description + x-service-info) so registries can still discover the service.
+    path: '/openapi.json',
+    handler: (request, env, ctx) => {
+      recordPublicAgentFunnelRead(
+        request,
+        openAgentsDatabase(env),
+        ctx,
+        'openapi_read',
+        '/openapi.json',
+      )
+
+      return renderMppDiscoveryDocument(request, {
+        cardRailEnabled:
+          env.STRIPE_MPP_NETWORK_PROFILE_ID !== undefined &&
+          env.STRIPE_MPP_NETWORK_PROFILE_ID.trim() !== '',
+        mppEnabled: isKhalaMppEnabled(env.KHALA_MPP_ENABLED),
+      })
+    },
+  },
   {
     path: '/api/openapi.json',
     handler: (request, env, ctx) => {

--- a/apps/openagents.com/workers/api/src/inference/mpp-discovery-document.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp-discovery-document.test.ts
@@ -1,0 +1,222 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type MppDiscoveryFlags,
+  buildMppDiscoveryDocument,
+  renderMppDiscoveryDocument,
+} from './mpp-discovery-document'
+
+const run = <A>(effect: Effect.Effect<A>): Promise<A> => Effect.runPromise(effect)
+
+const get = (method = 'GET'): Request =>
+  new Request('https://openagents.com/openapi.json', { method })
+
+// Validate one offer object against the draft-payment-discovery-00 JSON Schema
+// for the `offer` def (section "JSON Schema for x-payment-info").
+const isValidOffer = (offer: unknown): boolean => {
+  if (typeof offer !== 'object' || offer === null) {
+    return false
+  }
+  const o = offer as Record<string, unknown>
+  // Required: intent (enum charge|session), method (string), amount (null or
+  // non-negative-integer string with no leading zeros). additionalProperties:
+  // false beyond intent/method/amount/currency/description.
+  const allowed = new Set([
+    'intent',
+    'method',
+    'amount',
+    'currency',
+    'description',
+  ])
+  for (const key of Object.keys(o)) {
+    if (!allowed.has(key)) {
+      return false
+    }
+  }
+  if (o.intent !== 'charge' && o.intent !== 'session') {
+    return false
+  }
+  if (typeof o.method !== 'string') {
+    return false
+  }
+  if (o.amount !== null) {
+    if (typeof o.amount !== 'string' || !/^(0|[1-9][0-9]*)$/.test(o.amount)) {
+      return false
+    }
+  }
+  if ('currency' in o && typeof o.currency !== 'string') {
+    return false
+  }
+  if ('description' in o && typeof o.description !== 'string') {
+    return false
+  }
+  return true
+}
+
+// Validate an `x-payment-info` value against the draft's `oneOf` (single-offer
+// shorthand OR { offers: Offer[] } with minItems 1).
+const isValidPaymentInfo = (value: unknown): boolean => {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const v = value as Record<string, unknown>
+  if ('offers' in v) {
+    if (!Array.isArray(v.offers) || v.offers.length < 1) {
+      return false
+    }
+    // additionalProperties: false on the multi-offer form (only `offers`).
+    if (Object.keys(v).some(k => k !== 'offers')) {
+      return false
+    }
+    return v.offers.every(isValidOffer)
+  }
+  return isValidOffer(value)
+}
+
+const ARMED: MppDiscoveryFlags = { cardRailEnabled: true, mppEnabled: true }
+const ARMED_CRYPTO_ONLY: MppDiscoveryFlags = {
+  cardRailEnabled: false,
+  mppEnabled: true,
+}
+const INERT: MppDiscoveryFlags = { cardRailEnabled: false, mppEnabled: false }
+const INERT_WITH_PROFILE: MppDiscoveryFlags = {
+  cardRailEnabled: true,
+  mppEnabled: false,
+}
+
+describe('MPP discovery document (EPIC #6049 — /openapi.json)', () => {
+  test('is a valid OpenAPI 3.1 doc with required top-level fields', () => {
+    const doc = buildMppDiscoveryDocument(ARMED)
+    expect(doc.openapi).toBe('3.1.0')
+    const info = doc.info as Record<string, unknown>
+    expect(typeof info.title).toBe('string')
+    expect((info.title as string).length).toBeGreaterThan(0)
+    expect(typeof info.version).toBe('string')
+    const paths = doc.paths as Record<string, unknown>
+    expect(Object.keys(paths).length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('carries x-service-info with categories ["ai"] and the docs links', () => {
+    const doc = buildMppDiscoveryDocument(INERT)
+    const svc = doc['x-service-info'] as Record<string, unknown>
+    expect(svc.categories).toEqual(['ai'])
+    const docs = svc.docs as Record<string, unknown>
+    expect(docs.homepage).toBe('https://openagents.com')
+    expect(docs.llms).toBe('https://openagents.com/llms.txt')
+    expect(typeof docs.apiReference).toBe('string')
+  })
+
+  test('HONESTY GATE: armed => advertises the paid MPP path with offers + 402', () => {
+    const doc = buildMppDiscoveryDocument(ARMED)
+    const paths = doc.paths as Record<string, Record<string, unknown>>
+    const op = paths['/mpp/v1/chat/completions']?.post as Record<string, unknown>
+    expect(op).toBeDefined()
+    // Valid x-payment-info per the draft JSON Schema.
+    const paymentInfo = op['x-payment-info']
+    expect(isValidPaymentInfo(paymentInfo)).toBe(true)
+    // 402 declared (mandatory for payable operations) + 200.
+    const responses = op.responses as Record<string, unknown>
+    expect(responses['402']).toBeDefined()
+    expect(responses['200']).toBeDefined()
+    // requestBody JSON schema for the OpenAI chat-completions shape.
+    const body = op.requestBody as {
+      content: { 'application/json': { schema: Record<string, unknown> } }
+    }
+    const schema = body.content['application/json'].schema
+    expect(schema.required).toEqual(['model', 'messages'])
+  })
+
+  test('HONESTY GATE: armed crypto-only => crypto offers present, NO card offer', () => {
+    const doc = buildMppDiscoveryDocument(ARMED_CRYPTO_ONLY)
+    const paths = doc.paths as Record<string, Record<string, unknown>>
+    const op = paths['/mpp/v1/chat/completions']?.post as Record<string, unknown>
+    const offers = (op['x-payment-info'] as { offers: ReadonlyArray<Record<string, unknown>> }).offers
+    expect(offers.length).toBeGreaterThanOrEqual(1)
+    expect(offers.every(o => o.currency === 'usdc')).toBe(true)
+    expect(offers.some(o => o.method === 'stripe')).toBe(false)
+    // crypto networks advertised
+    const methods = offers.map(o => o.method)
+    expect(methods).toContain('tempo')
+    expect(methods).toContain('base')
+    expect(methods).toContain('solana')
+  })
+
+  test('HONESTY GATE: armed with profile => card offer present alongside crypto', () => {
+    const doc = buildMppDiscoveryDocument(ARMED)
+    const paths = doc.paths as Record<string, Record<string, unknown>>
+    const op = paths['/mpp/v1/chat/completions']?.post as Record<string, unknown>
+    const offers = (op['x-payment-info'] as { offers: ReadonlyArray<Record<string, unknown>> }).offers
+    const card = offers.find(o => o.method === 'stripe')
+    expect(card).toBeDefined()
+    expect(card?.currency).toBe('usd')
+    expect(card?.intent).toBe('charge')
+    // USD cents amount is a non-negative-integer string >= the SPT floor (50c).
+    expect(typeof card?.amount).toBe('string')
+    expect(Number(card?.amount)).toBeGreaterThanOrEqual(50)
+  })
+
+  test('HONESTY GATE: inert (flag off) => NO paid path advertised at all', () => {
+    const doc = buildMppDiscoveryDocument(INERT)
+    const paths = doc.paths as Record<string, unknown>
+    expect(paths['/mpp/v1/chat/completions']).toBeUndefined()
+    // No operation anywhere advertises x-payment-info or a 402 when inert.
+    const json = JSON.stringify(doc)
+    expect(json).not.toContain('x-payment-info')
+    expect(json).not.toContain('"402"')
+  })
+
+  test('HONESTY GATE: inert even when a profile id is set => still no paid path', () => {
+    const doc = buildMppDiscoveryDocument(INERT_WITH_PROFILE)
+    const paths = doc.paths as Record<string, unknown>
+    expect(paths['/mpp/v1/chat/completions']).toBeUndefined()
+    expect(JSON.stringify(doc)).not.toContain('x-payment-info')
+  })
+
+  test('always describes the free keyed /v1/chat/completions surface (no payment offers)', () => {
+    const doc = buildMppDiscoveryDocument(INERT)
+    const paths = doc.paths as Record<string, Record<string, unknown>>
+    const op = paths['/v1/chat/completions']?.post as Record<string, unknown>
+    expect(op).toBeDefined()
+    expect(op['x-payment-info']).toBeUndefined()
+    const responses = op.responses as Record<string, unknown>
+    expect(responses['402']).toBeUndefined()
+  })
+
+  test('crypto offer amount is a USDC base-units integer string (6 decimals)', () => {
+    const doc = buildMppDiscoveryDocument(ARMED_CRYPTO_ONLY)
+    const paths = doc.paths as Record<string, Record<string, unknown>>
+    const op = paths['/mpp/v1/chat/completions']?.post as Record<string, unknown>
+    const offers = (op['x-payment-info'] as { offers: ReadonlyArray<Record<string, unknown>> }).offers
+    // 0.01 USDC floor => 10000 base units (6 decimals).
+    expect(offers[0]?.amount).toBe('10000')
+    expect(/^(0|[1-9][0-9]*)$/.test(offers[0]?.amount as string)).toBe(true)
+  })
+
+  test('serves GET with application/json + public, max-age=300 cache + CORS', async () => {
+    const response = await run(renderMppDiscoveryDocument(get('GET'), ARMED))
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(response.headers.get('cache-control')).toBe('public, max-age=300')
+    expect(response.headers.get('access-control-allow-origin')).toBe('*')
+    const parsed = (await response.json()) as Record<string, unknown>
+    expect(parsed.openapi).toBe('3.1.0')
+  })
+
+  test('HEAD returns no body, GET returns the doc; non-GET/HEAD is 405', async () => {
+    const head = await run(renderMppDiscoveryDocument(get('HEAD'), INERT))
+    expect(head.status).toBe(200)
+    expect(await head.text()).toBe('')
+
+    const post = await run(renderMppDiscoveryDocument(get('POST'), INERT))
+    expect(post.status).toBe(405)
+    expect(post.headers.get('allow')).toBe('GET, HEAD')
+  })
+
+  test('every offer in an armed doc validates against the draft JSON Schema', () => {
+    const doc = buildMppDiscoveryDocument(ARMED)
+    const paths = doc.paths as Record<string, Record<string, unknown>>
+    const op = paths['/mpp/v1/chat/completions']?.post as Record<string, unknown>
+    expect(isValidPaymentInfo(op['x-payment-info'])).toBe(true)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/mpp-discovery-document.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp-discovery-document.ts
@@ -1,0 +1,263 @@
+// MPP service-discovery document for Khala (EPIC #6049).
+//
+// Serves the OpenAPI 3.1 discovery document the Machine Payments Protocol
+// registries (MPPScan, mpp.dev/services) crawl at `GET /openapi.json` to light
+// the Machine Payments badge. The document follows the payment-discovery draft
+// (`draft-payment-discovery-00`): a standard OpenAPI 3.1 file with two
+// extensions — root-level `x-service-info` and per-operation `x-payment-info`
+// (canonical multi-offer form).
+//
+// HONESTY GATE (the central safety property): the document must reflect REALITY.
+// We must NEVER advertise a payable endpoint that does not actually serve — a
+// broken/inert paid endpoint gets us delisted and burns agents. So the paid MPP
+// path's `x-payment-info` offers + `402` are emitted ONLY when the MPP endpoint
+// is actually armed (the SAME `KHALA_MPP_ENABLED` flag the route reads via
+// `config.ts`). The card/`stripe` offer additionally requires the network
+// profile id (the same condition that arms the card rail in the route). When the
+// endpoint is inert, the document omits the paid path entirely, so nothing
+// payable is advertised. The document itself is always served (it still carries
+// `x-service-info` + the free description), so registries can discover the
+// service even before the paid rail is armed.
+//
+// This module is PURE of the MPP verify/settlement code: it only READS the
+// pricing model (`mpp-pricing.ts`) and is handed the parsed flags by the route
+// wiring (which reads them from the same `config.ts` seam as the MPP route).
+
+import { Effect } from 'effect'
+
+import { isKhalaModel } from './pricing'
+import { type MppRail, quoteMppCall } from './mpp/mpp-pricing'
+
+// The canonical public origin.
+const ORIGIN = 'https://openagents.com'
+
+// The paid MPP path (mirrors the route registered in index.ts).
+const MPP_PATH = '/mpp/v1/chat/completions'
+
+// The general pay-per-call tier the discovery offers quote against (same default
+// as the MPP route's DEFAULT_MPP_MODEL). The runtime 402 challenge re-quotes for
+// the requested model and remains authoritative; discovery is advisory.
+const DISCOVERY_MODEL = 'openagents/khala-mini'
+
+// The crypto networks the MPP route advertises (USDC on each). Mirrors
+// CRYPTO_NETWORKS in the route. Discovery emits one `charge` offer per network.
+const CRYPTO_NETWORKS: ReadonlyArray<string> = ['tempo', 'base', 'solana']
+
+// USDC has 6 decimals. Discovery `amount` is a base-units integer string (per
+// the draft: smallest denomination of the currency). 0.01 USDC => "10000".
+const USDC_DECIMALS = 6
+
+// Convert a USD/USDC price to a USDC base-units integer string (6 decimals).
+// Rounds up to whole base units, never under-quoting. The runtime 402 challenge
+// is authoritative; this is the advisory display amount.
+const usdcBaseUnits = (priceUsd: number): string =>
+  String(Math.max(1, Math.ceil(priceUsd * 10 ** USDC_DECIMALS - 1e-9)))
+
+// A single x-payment-info offer (canonical multi-offer entry; draft offer obj).
+export type PaymentOffer = Readonly<{
+  intent: 'charge'
+  method: string
+  // Base-units integer string, or null for dynamic pricing. Always a fixed
+  // advisory quote here (the runtime 402 re-quotes the real model).
+  amount: string
+  currency: string
+  description: string
+}>
+
+export type MppDiscoveryFlags = Readonly<{
+  // KHALA_MPP_ENABLED, parsed. When false the paid endpoint is inert; the
+  // document omits the paid path so it advertises nothing payable.
+  mppEnabled: boolean
+  // STRIPE_MPP_NETWORK_PROFILE_ID presence (the same condition that arms the
+  // card rail in the route). When absent the document omits the card offer.
+  cardRailEnabled: boolean
+}>
+
+// Build the offer set for the paid MPP path. Always includes one USDC `charge`
+// offer per crypto network (the crypto rail is the default-on MPP rail). Adds a
+// `stripe`/`usd` card offer ONLY when the network profile id is configured —
+// the SAME condition that makes the card rail actually serve.
+const buildOffers = (
+  flags: MppDiscoveryFlags,
+): ReadonlyArray<PaymentOffer> => {
+  // The discovery model is a known Khala tier; fall back to the default if not.
+  const model = isKhalaModel(DISCOVERY_MODEL)
+    ? DISCOVERY_MODEL
+    : 'openagents/khala-mini'
+  const cryptoQuote = quoteMppCall({ model, rail: 'crypto' as MppRail })
+  const cryptoAmount = usdcBaseUnits(cryptoQuote.priceUsd)
+
+  const cryptoOffers: ReadonlyArray<PaymentOffer> = CRYPTO_NETWORKS.map(
+    network => ({
+      amount: cryptoAmount,
+      currency: 'usdc',
+      description: `Pay-per-call Khala chat completion in USDC on ${network} (x402/MPP). Advisory quote for ${model}; the runtime 402 challenge re-quotes the requested model and is authoritative.`,
+      intent: 'charge' as const,
+      method: network,
+    }),
+  )
+
+  if (!flags.cardRailEnabled) {
+    return cryptoOffers
+  }
+
+  const cardQuote = quoteMppCall({ model, rail: 'card' as MppRail })
+  const cardOffer: PaymentOffer = {
+    // Card/SPT amount in USD cents (smallest denomination of USD).
+    amount: String(cardQuote.amountCents),
+    currency: 'usd',
+    description: `Pay-per-call Khala chat completion via card (Stripe Shared Payment Token). Advisory quote for ${model}; the runtime 402 challenge is authoritative.`,
+    intent: 'charge' as const,
+    method: 'stripe',
+  }
+
+  return [...cryptoOffers, cardOffer]
+}
+
+// The OpenAI chat-completions request-body schema (model + messages), per the
+// draft's Input Schema guidance so agents can construct a valid request.
+const CHAT_COMPLETIONS_REQUEST_SCHEMA = {
+  type: 'object',
+  properties: {
+    model: {
+      type: 'string',
+      description:
+        'A Khala model id, e.g. "openagents/khala-mini" or "openagents/khala-code".',
+    },
+    messages: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          role: { type: 'string' },
+          content: { type: 'string' },
+        },
+        required: ['role', 'content'],
+      },
+    },
+  },
+  required: ['model', 'messages'],
+} as const
+
+// The paid MPP path operation object. Carries `x-payment-info` (multi-offer) and
+// the mandatory `402` response. Only built when the endpoint is armed.
+const buildPaidPath = (flags: MppDiscoveryFlags) => ({
+  post: {
+    summary: 'Khala chat completions (pay-per-call via Machine Payments)',
+    description:
+      'OpenAI-compatible Chat Completions, paid per request via the Machine Payments Protocol (MPP) / x402. A request with no payment credential returns 402 with a payment challenge; a verified credential runs the completion and returns it with a usage receipt.',
+    operationId: 'mppChatCompletions',
+    'x-payment-info': {
+      offers: buildOffers(flags),
+    },
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: CHAT_COMPLETIONS_REQUEST_SCHEMA,
+        },
+      },
+    },
+    responses: {
+      '200': {
+        description:
+          'Successful chat completion (OpenAI Chat Completions shape plus an `openagents` disclosure block).',
+      },
+      '402': {
+        description: 'Payment Required',
+      },
+    },
+  },
+})
+
+// Build the OpenAPI 3.1 discovery document. PURE — given the parsed flags it is
+// fully deterministic. When the MPP endpoint is inert (flag off), the paid path
+// is OMITTED so the document advertises nothing payable; only the free
+// description + `x-service-info` remain.
+export const buildMppDiscoveryDocument = (
+  flags: MppDiscoveryFlags,
+): Record<string, unknown> => {
+  const paths: Record<string, unknown> = {
+    // The free, keyed Khala endpoint is always described (no payment offers, no
+    // 402 advertised — it is keyed/credit-metered, not MPP-payable). This lets a
+    // registry see the service surface even before the paid rail is armed.
+    '/v1/chat/completions': {
+      post: {
+        summary: 'Khala chat completions (keyed / credit-metered)',
+        description:
+          'OpenAI-compatible Chat Completions. Authenticated with an OpenAgents agent key and metered receipt-first against the account balance. For pay-per-call machine payments without a key, see the MPP endpoint when armed.',
+        operationId: 'chatCompletions',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: CHAT_COMPLETIONS_REQUEST_SCHEMA,
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description:
+              'Successful chat completion (OpenAI Chat Completions shape plus an `openagents` disclosure block).',
+          },
+        },
+      },
+    },
+  }
+
+  // HONESTY GATE: only advertise the payable MPP path when the endpoint is
+  // actually armed. Inert => omit it entirely (no offers, no 402).
+  if (flags.mppEnabled) {
+    paths[MPP_PATH] = buildPaidPath(flags)
+  }
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'OpenAgents Khala Inference API',
+      version: '1.0.0',
+      description:
+        'OpenAI-compatible LLM inference, pay-per-call. Machine-payable (MPP / x402) when the paid endpoint is armed.',
+    },
+    'x-service-info': {
+      categories: ['ai'],
+      docs: {
+        homepage: ORIGIN,
+        llms: `${ORIGIN}/llms.txt`,
+        apiReference: `${ORIGIN}/agents.md`,
+      },
+    },
+    paths,
+  }
+}
+
+// Render the discovery document as an HTTPS, cacheable JSON response per the
+// draft: `Content-Type: application/json`, `Cache-Control: public, max-age=300`.
+// GET (and HEAD) only; anything else is 405. CORS-open so browser-based clients
+// can read it cross-origin (the draft RECOMMENDS this for browser clients).
+export const renderMppDiscoveryDocument = (
+  request: Request,
+  flags: MppDiscoveryFlags,
+): Effect.Effect<Response> =>
+  Effect.sync(() => {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response(JSON.stringify({ error: 'method_not_allowed' }), {
+        headers: new Headers({
+          allow: 'GET, HEAD',
+          'cache-control': 'no-store',
+          'content-type': 'application/json',
+        }),
+        status: 405,
+      })
+    }
+    const body = JSON.stringify(buildMppDiscoveryDocument(flags))
+    const headers = new Headers({
+      'access-control-allow-origin': '*',
+      'cache-control': 'public, max-age=300',
+      'content-type': 'application/json',
+    })
+    return new Response(request.method === 'HEAD' ? null : body, {
+      headers,
+      status: 200,
+    })
+  })

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -120,6 +120,7 @@ const approvedExactRoutePaths = [
   '/agents.md',
   '/ai.md',
   '/skill.md',
+  '/openapi.json',
   '/api/openapi.json',
   '/api/omni/sdk-seed',
   '/api/developer/signature-packages/validate',


### PR DESCRIPTION
## What

Serves the Machine Payments Protocol service-discovery document at `GET /openapi.json` on the `openagents.com` Cloudflare Worker so MPP registries (MPPScan, mpp.dev/services) and the Stripe Directory crawler can discover Khala and light the **Machine Payments badge** (EPIC #6049).

`/openapi.json` did **not** previously exist. The worker already served a *different*, general OpenAgents OpenAPI doc at `/api/openapi.json` (`openagents-openapi.ts`) without any `x-payment-info`/`x-service-info`; that doc is unchanged. This adds the dedicated MPP discovery doc at the root path the spec/registries require.

OpenAPI 3.1, served HTTPS with `Content-Type: application/json`, `Cache-Control: public, max-age=300`, CORS-open. Carries:
- root `x-service-info`: `{ categories: ["ai"], docs: { homepage, llms: /llms.txt, apiReference } }`
- when armed, per-operation `x-payment-info` (canonical multi-offer form) on `/mpp/v1/chat/completions`: one USDC `charge` offer per crypto network (Tempo/Base/Solana) plus a `stripe`/`usd` card offer, a declared `402` + `200`, and the OpenAI chat-completions `requestBody` schema (model + messages). Amounts derive from `inference/mpp/mpp-pricing.ts` (crypto floor 0.01 USDC → `10000` base units; card floor $0.50 → `50` cents).

## Honesty gate

The paid path's offers + `402` are emitted **only when the endpoint actually serves** — gated behind the SAME `KHALA_MPP_ENABLED` flag the MPP route reads from `config.ts`. The `stripe`/`usd` card offer additionally requires `STRIPE_MPP_NETWORK_PROFILE_ID` (the same condition that arms the card rail). When inert, the document **omits the paid path entirely** and advertises nothing payable, so we never list a broken/inert paid endpoint. The document itself is always served (free `/v1/chat/completions` description + `x-service-info`) so the service stays discoverable before launch.

**Nothing is armed or deployed by this change.** With the flag off (current state) it advertises nothing payable.

## Scope

New route module lives in `inference/mpp-discovery-document.ts` (sibling to `discovery-surfaces.ts`), mounted via the worker exact-route registry next to `/llms.txt` and `/api/openapi.json`. The concurrently-edited `inference/mpp/` directory was only READ (`mpp-pricing.ts`), never modified.

## Verify

- New unit tests (`mpp-discovery-document.test.ts`, 12): doc validity; offers present only when armed; absent/inert when off (no `x-payment-info`, no `402`); card offer gated on the profile id; `x-payment-info` validated against the draft `draft-payment-discovery-00` JSON Schema; headers/cache/CORS; 405 on non-GET/HEAD.
- `worker-exact-routes.test.ts` manifest updated for the new `/openapi.json` route.
- `bun run typecheck:api` clean; `bun run check:deploy` green (exit 0). The contract-drift-guard "FAILED" message strings are the known asserted-failure quirk; the guard test passes 5/5 and the `check:contract-drift` step itself passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)