### PR TITLE
Tighten Autopilot legal route boundary

### DIFF
--- a/apps/openagents.com/apps/web/src/autopilot-route.test.ts
+++ b/apps/openagents.com/apps/web/src/autopilot-route.test.ts
@@ -10,6 +10,7 @@ import {
   AutopilotRoute,
   AutopilotVerticalRoute,
   AutopilotWorkRoute,
+  NotFoundRoute,
   urlToAppRoute,
 } from './route'
 
@@ -112,7 +113,7 @@ const renderHtml = (html: Html): string => {
 }
 
 describe('autopilot onboarding route', () => {
-  test('parses /autopilot and /autopilot/<vertical>, leaving /autopilot/work for the cockpit', () => {
+  test('parses /autopilot and /autopilot/legal, leaving /autopilot/work for the cockpit', () => {
     expect(urlToAppRoute(appUrl('/autopilot'))).toEqual(AutopilotRoute())
     expect(urlToAppRoute(appUrl('/autopilot/legal'))).toEqual(
       AutopilotVerticalRoute({ vertical: 'legal' }),
@@ -120,6 +121,15 @@ describe('autopilot onboarding route', () => {
     // The cockpit sub-route still wins over the optional vertical segment.
     expect(urlToAppRoute(appUrl('/autopilot/work'))).toEqual(
       AutopilotWorkRoute(),
+    )
+  })
+
+  test('does not claim arbitrary or deeper autopilot verticals as live onboarding pages', () => {
+    expect(urlToAppRoute(appUrl('/autopilot/foo'))).toEqual(
+      NotFoundRoute({ path: '/autopilot/foo' }),
+    )
+    expect(urlToAppRoute(appUrl('/autopilot/legal/foo'))).toEqual(
+      NotFoundRoute({ path: '/autopilot/legal/foo' }),
     )
   })
 

--- a/apps/openagents.com/apps/web/src/route.ts
+++ b/apps/openagents.com/apps/web/src/route.ts
@@ -1,6 +1,6 @@
-import { Schema as S, pipe } from 'effect'
+import { Effect, Schema as S, pipe } from 'effect'
 import { Route } from 'foldkit'
-import { literal, r, slash, string } from 'foldkit/route'
+import { ParseError, literal, param, r, slash, string } from 'foldkit/route'
 import type { Url } from 'foldkit/url'
 
 export const HomeRoute = r('Home')
@@ -10,7 +10,7 @@ export const OrderRoute = r('Order')
 export const OrderDetailRoute = r('OrderDetail', { orderId: S.String })
 export const AutopilotRoute = r('Autopilot')
 export const AutopilotVerticalRoute = r('AutopilotVertical', {
-  vertical: S.String,
+  vertical: S.Literal('legal'),
 })
 export const AutopilotWorkRoute = r('AutopilotWork')
 export const AutopilotWorkDetailRoute = r('AutopilotWorkDetail', {
@@ -388,9 +388,23 @@ export const autopilotRouter = pipe(
   literal('autopilot'),
   Route.mapTo(AutopilotRoute),
 )
+const legalVertical = param(
+  'legal autopilot vertical',
+  segment =>
+    segment === 'legal'
+      ? Effect.succeed({ vertical: 'legal' as const })
+      : Effect.fail(
+          new ParseError({
+            message: 'Expected legal autopilot vertical',
+            expected: 'legal',
+            actual: segment,
+          }),
+        ),
+  () => 'legal',
+)
 export const autopilotVerticalRouter = pipe(
   literal('autopilot'),
-  slash(string('vertical')),
+  slash(legalVertical),
   Route.mapTo(AutopilotVerticalRoute),
 )
 export const inviteRouter = pipe(literal('invite'), Route.mapTo(InviteRoute))

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -65,7 +65,7 @@ describe('Worker document route fallback', () => {
     ).toBe(false)
   })
 
-  test('keeps autopilot onboarding and its optional vertical in the app shell', () => {
+  test('keeps autopilot onboarding and its legal vertical in the app shell', () => {
     expect(
       shouldRedirectUnknownDocumentToHome(
         requestFor('/autopilot'),
@@ -84,6 +84,21 @@ describe('Worker document route fallback', () => {
         '/autopilot/work',
       ),
     ).toBe(false)
+  })
+
+  test('redirects unclaimed autopilot vertical and deeper onboarding documents', () => {
+    expect(
+      shouldRedirectUnknownDocumentToHome(
+        requestFor('/autopilot/foo'),
+        '/autopilot/foo',
+      ),
+    ).toBe(true)
+    expect(
+      shouldRedirectUnknownDocumentToHome(
+        requestFor('/autopilot/legal/foo'),
+        '/autopilot/legal/foo',
+      ),
+    ).toBe(true)
   })
 
   test('keeps the Moksha document route in the app shell', () => {

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -106,7 +106,7 @@ const knownDocumentPathPatterns: ReadonlyArray<RegExp> = [
   /^\/admin$/,
   /^\/agents\/[^/]+$/,
   /^\/artanis$/,
-  /^\/autopilot(?:\/[a-z0-9-]+)?$/,
+  /^\/autopilot(?:\/(?:legal|work))?$/,
   /^\/billing$/,
   /^\/blog(?:\/[^/]+)?$/,
   /^\/business$/,


### PR DESCRIPTION
## Problem

Orrery's closeout check on #6124 found that the worker document gate still admitted any single `/autopilot/<vertical>` segment, while #6130 keeps the public industry scope to `/autopilot/legal` only. There was also no regression pinning deeper paths such as `/autopilot/legal/foo` outside the onboarding document gate.

Forum claim: https://openagents.com/forum/t/7c4decf6-eb5d-4dc0-b69c-4d36cf502c26#post-980f9593-10bb-41f8-b03b-3695c7d51bdd

Refs #6130.

## Behavior

- Keeps `/autopilot` and `/autopilot/legal` as public onboarding routes.
- Keeps `/autopilot/work` in the existing cockpit/document shell.
- Stops claiming arbitrary one-segment verticals such as `/autopilot/foo` as live onboarding pages.
- Pins `/autopilot/legal/foo` as outside the onboarding document gate.
- Narrows the web route contract to the currently claimed `legal` vertical.
- Rebased over #6145 and keeps the assembled Autopilot onboarding flow/page work intact.

## Files Touched

- `apps/openagents.com/apps/web/src/route.ts`
- `apps/openagents.com/apps/web/src/autopilot-route.test.ts`
- `apps/openagents.com/workers/api/src/worker-routes.ts`
- `apps/openagents.com/workers/api/src/worker-routes.test.ts`

## Validation

- `bun run --cwd apps/openagents.com/apps/web test src/autopilot-route.test.ts src/route.test.ts src/routing/startup.test.ts src/main.test.ts`
- `bun run --cwd apps/openagents.com test:api src/worker-routes.test.ts`
- `bun run --cwd apps/openagents.com typecheck:web`
- `bun run --cwd apps/openagents.com typecheck:api`
- `git diff --check origin/main...HEAD`
- `CHROME_PATH='/Applications/Brave Browser.app/Contents/MacOS/Brave Browser' bun run --cwd apps/openagents.com check:deploy`

## Maintenance / Revenue Value

This keeps the public Autopilot promise surface tight before future verticals expand it, so reviewers can distinguish the claimed paid/legal path from postponed vertical pages.

## Intentionally Not Changed

- No new legal overlay copy/content beyond #6145's landed flow.
- No Autopilot 3D scene changes.
- No Khala flow work.
- No billing or product-promise state changes.
- No deploy.
