### PR TITLE
Add Bitcoin-first Lightning rail to the MPP endpoint (EPIC #6049)

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -833,6 +833,28 @@ This is the invariant ledger for `openagents`.
   bounded by the available USD balance; the conversion is the single-source rate
   in `workers/api/src/inference/usd-msat-conversion.ts`. Regression coverage:
   `workers/api/src/inference/usd-credit-bridge.test.ts`.
+- MPP rail asset origin (EPIC #6049): a settled machine-payment that funds a
+  Khala completion mints inference credit, and the asset TAG must match the
+  inbound rail. The USDC/card MPP rails (`mintMppCredits`) are USD/Stripe
+  liabilities and are tagged USD-origin (`usd_credit_msat`,
+  NOT Bitcoin-withdrawable), exactly as the card->credit bridge above. The
+  Lightning MPP rail (`mintLightningCredits`, draft-lightning-charge-00) settles
+  REAL Bitcoin (a paid BOLT11 invoice verified LOCALLY by
+  `sha256(preimage)==paymentHash`), so it must NOT be tagged `usd_credit_msat`:
+  it mints a Bitcoin-origin `lightning_charge` pay-in that credits `balance_msat`
+  ONLY (Bitcoin-withdrawable, like a tip), keyed/idempotent per paymentHash.
+  Tagging real Bitcoin as USD-origin (or USD/card as Bitcoin-origin) is a
+  boundary violation. The preimage is a bearer secret: never logged, persisted,
+  or returned; the receipt/replay key is the paymentHash. The Lightning rail is
+  fail-closed inert unless `KHALA_MPP_LIGHTNING_ENABLED` + `KHALA_MPP_ENABLED` +
+  a working MDK BOLT11 invoice issuer are all present (honesty gate: never
+  advertise a rail we cannot fulfill), and consume-once is enforced atomically
+  via `mpp_lightning_replay`. Regression coverage:
+  `workers/api/src/inference/mpp/mpp-lightning-verify.test.ts`,
+  `workers/api/src/inference/mpp/mpp-lightning-replay.test.ts`,
+  `workers/api/src/inference/mpp/mpp-credit-grant.test.ts`, and the Lightning
+  rail cases in
+  `workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts`.
 
 ## Provider Capacity Marketplace Gate
 

--- a/apps/openagents.com/workers/api/migrations/0225_mpp_lightning_replay_cache.sql
+++ b/apps/openagents.com/workers/api/migrations/0225_mpp_lightning_replay_cache.sql
@@ -1,0 +1,27 @@
+-- MPP Lightning charge consume-once cache (EPIC #6049, draft-lightning-charge-00).
+--
+-- The Lightning charge intent requires ATOMIC consume-once settlement
+-- (§"Settlement Procedure" + §"Preimage Confidentiality"): a challenge marked
+-- consumed MUST NOT be accepted again, and concurrent requests presenting the
+-- same valid preimage MUST yield exactly one success. We claim the paymentHash
+-- BEFORE serving; a replay collides on the PRIMARY KEY and is rejected before a
+-- second free completion is served.
+--
+-- We key on the PAYMENT HASH (the public payment identifier), never the
+-- preimage. The preimage is a bearer secret and MUST NOT be logged, persisted,
+-- or returned (spec §"Preimage Confidentiality"); only its sha256 (the payment
+-- hash) is recorded here. This mirrors the SPT replay cache (0224).
+--
+-- INERT NOTE: this table is only written on the Lightning rail, which itself is
+-- inert until KHALA_MPP_LIGHTNING_ENABLED + KHALA_MPP_ENABLED + the MDK wallet
+-- binding are all configured. No other rail touches it.
+
+CREATE TABLE IF NOT EXISTS mpp_lightning_replay (
+  -- The BOLT11 payment hash (sha256 of the preimage), lowercase hex. PRIMARY KEY
+  -- so a second use of the same paid invoice collides and is refused.
+  payment_hash TEXT PRIMARY KEY,
+  -- The challenge id the payment was consumed under (binds the proof to the
+  -- exact quote, for audit).
+  challenge_id TEXT NOT NULL,
+  consumed_at TEXT NOT NULL
+);

--- a/apps/openagents.com/workers/api/migrations/0226_pay_in_lightning_charge_type.sql
+++ b/apps/openagents.com/workers/api/migrations/0226_pay_in_lightning_charge_type.sql
@@ -1,0 +1,94 @@
+-- Add the `lightning_charge` pay-in type (EPIC #6049, draft-lightning-charge-00).
+--
+-- WHY a new pay-in type: a settled MPP Lightning charge mints inference credit
+-- from REAL Bitcoin inbound (a paid BOLT11 invoice), unlike the USDC/card MPP
+-- rails which settle a USD/Stripe liability. The Bitcoin-origin credit must land
+-- in `balance_msat` WITHOUT bumping `usd_credit_msat` (so it stays
+-- Bitcoin-withdrawable per the RL-3 asset boundary — INVARIANTS
+-- "Credit<->Bitcoin Asset Boundary"), and it must NOT pollute the forum `tip`
+-- queries (tip-earnings, tip-ladder, sweep tip attribution). A dedicated
+-- `lightning_charge` type keeps the accounting honest and queryable.
+--
+-- This rebuilds `pay_ins` (and the leaf `pay_in_legs`) to extend the
+-- `pay_in_type` CHECK, copying the exact 0211 rebuild discipline so the FK and
+-- every index are preserved verbatim. No data is transformed; only the CHECK
+-- gains one allowed value.
+--
+-- INERT NOTE: nothing writes `lightning_charge` rows until the Lightning MPP
+-- rail is armed (KHALA_MPP_LIGHTNING_ENABLED + KHALA_MPP_ENABLED + the MDK
+-- wallet binding); this migration is data-model only.
+
+ALTER TABLE pay_ins RENAME TO pay_ins_old;
+
+CREATE TABLE pay_ins (
+  id TEXT PRIMARY KEY,
+  pay_in_type TEXT NOT NULL CHECK (
+    pay_in_type IN (
+      'tip', 'sweep', 'buffer_funding', 'reward', 'adjustment',
+      'usd_credit_grant', 'lightning_charge'
+    )
+  ),
+  payer_ref TEXT NOT NULL,
+  cost_msat INTEGER NOT NULL CHECK (cost_msat > 0),
+  state TEXT NOT NULL CHECK (
+    state IN ('pending', 'forwarding', 'paid', 'failed')
+  ),
+  failure_reason TEXT,
+  rung TEXT CHECK (rung IN ('credited', 'direct_bolt12') OR rung IS NULL),
+  context_ref TEXT,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  genesis_id TEXT,
+  successor_id TEXT,
+  created_at TEXT NOT NULL,
+  state_changed_at TEXT NOT NULL,
+  public_receipt_ref TEXT
+);
+
+INSERT INTO pay_ins (
+  id, pay_in_type, payer_ref, cost_msat, state, failure_reason, rung,
+  context_ref, idempotency_key, genesis_id, successor_id, created_at,
+  state_changed_at, public_receipt_ref
+)
+SELECT
+  id, pay_in_type, payer_ref, cost_msat, state, failure_reason, rung,
+  context_ref, idempotency_key, genesis_id, successor_id, created_at,
+  state_changed_at, public_receipt_ref
+FROM pay_ins_old;
+
+-- Rebuild pay_in_legs so its FK targets the new pay_ins (the parent rename
+-- rewrote it to point at pay_ins_old). pay_in_legs is a leaf table.
+ALTER TABLE pay_in_legs RENAME TO pay_in_legs_old;
+
+CREATE TABLE pay_in_legs (
+  id TEXT PRIMARY KEY,
+  pay_in_id TEXT NOT NULL REFERENCES pay_ins (id),
+  direction TEXT NOT NULL CHECK (direction IN ('in', 'out')),
+  kind TEXT NOT NULL CHECK (kind IN ('balance', 'lightning')),
+  party_ref TEXT NOT NULL,
+  amount_msat INTEGER NOT NULL CHECK (amount_msat > 0),
+  resulting_balance_msat INTEGER,
+  external_ref TEXT,
+  refund_of_leg_id TEXT,
+  created_at TEXT NOT NULL
+);
+
+INSERT INTO pay_in_legs (
+  id, pay_in_id, direction, kind, party_ref, amount_msat,
+  resulting_balance_msat, external_ref, refund_of_leg_id, created_at
+)
+SELECT
+  id, pay_in_id, direction, kind, party_ref, amount_msat,
+  resulting_balance_msat, external_ref, refund_of_leg_id, created_at
+FROM pay_in_legs_old;
+
+DROP TABLE pay_in_legs_old;
+DROP TABLE pay_ins_old;
+
+-- Recreate every index that lived on the rebuilt tables (0160 + 0169 + 0211).
+CREATE INDEX IF NOT EXISTS idx_pay_ins_state ON pay_ins (state);
+CREATE INDEX IF NOT EXISTS idx_pay_ins_payer ON pay_ins (payer_ref);
+CREATE INDEX IF NOT EXISTS idx_pay_ins_public_receipt_ref
+  ON pay_ins (public_receipt_ref)
+  WHERE public_receipt_ref IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_pay_in_legs_pay_in ON pay_in_legs (pay_in_id);
+CREATE INDEX IF NOT EXISTS idx_pay_in_legs_party ON pay_in_legs (party_ref);

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -162,6 +162,16 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // Absent => the MPP endpoint is fail-safe inert and never issues a challenge or
   // verifies a credential (alongside KHALA_MPP_ENABLED + STRIPE_API_KEY).
   KHALA_MPP_SIGNING_SECRET?: string | undefined
+  // The Lightning rail feature flag for the MPP endpoint (EPIC #6049,
+  // draft-lightning-charge-00). Default OFF: the `/mpp/v1/chat/completions` 402
+  // does NOT offer a Lightning charge until this is armed. Bitcoin-first: when
+  // armed AND a working BOLT11 invoice issuer is present (the MDK wallet binding
+  // — MDK_CHECKOUT_ROUTE_URL + MDK_CHECKOUT_ROUTE_SECRET/MDK_ACCESS_TOKEN, or the
+  // self-hosted MDK_SIDECAR), the Lightning offer is surfaced FIRST in the 402
+  // and the discovery doc. HONESTY GATE: with the flag off OR no invoice issuer,
+  // the Lightning rail is not advertised (we never offer a rail we cannot
+  // fulfill). The crypto/card rails are unaffected. Set "1"/"true"/"yes"/"on".
+  KHALA_MPP_LIGHTNING_ENABLED?: string | undefined
   // Cloud primitive scaffold feature flags (EPIC #5510, #5516/#5517). Default
   // OFF: the `/v1/fine_tuning/jobs` and `/v1/sandboxes` routes are inert on the
   // live Worker until those builds land. Set "true"/"1"/"on" to enable. The

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -337,7 +337,9 @@ import { renderMppDiscoveryDocument } from './inference/mpp-discovery-document'
 import {
   handleMppChatCompletions,
   isKhalaMppEnabled,
+  isKhalaMppLightningEnabled,
 } from './inference/mpp/mpp-chat-completions-routes'
+import { makeMdkLightningInvoiceIssuer } from './inference/mpp/mpp-lightning-invoice-mdk'
 import {
   isAcceptanceDispatchEnabled,
   makeD1KhalaVerificationStore,
@@ -6638,6 +6640,51 @@ const hostedMdkClientForEnv = (
   )
 }
 
+// The MDK-backed BOLT11 invoice issuer for the Lightning MPP rail (EPIC #6049).
+// Returns undefined when no MDK route is configured (route URL + secret), so the
+// Lightning rail is never offered without a working invoice issuer (honesty
+// gate). POSTs `create_checkout` to the SAME route/sidecar the Forum L402 flow
+// uses (the `self_hosted_mdkd_sidecar` route kind goes through the MDK_SIDECAR
+// container) and reads the RAW bolt11 + paymentHash. The invoice + paymentHash
+// are public (they go into the 402 challenge); the preimage is never seen here.
+const lightningInvoiceIssuerForEnv = (
+  env: WorkerBindings & OpenAgentsWorkerConfigEnv,
+) => {
+  const checkout = getOpenAgentsWorkerConfig(env).mdk.checkout
+  const routeSecret = redactedValue(checkout.routeSecret)
+
+  if (
+    !checkout.configured ||
+    checkout.routeUrl === undefined ||
+    routeSecret === undefined
+  ) {
+    return undefined
+  }
+
+  const routeUrl = checkout.routeUrl
+  const isSidecar = checkout.routeKind === 'self_hosted_mdkd_sidecar'
+
+  const post = async (
+    body: Readonly<Record<string, unknown>>,
+  ): Promise<Readonly<{ ok: boolean; status: number; payload: unknown }>> => {
+    const request = new Request(routeUrl, {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+        'x-moneydevkit-webhook-secret': routeSecret,
+      },
+      method: 'POST',
+    })
+    const response = isSidecar
+      ? await fetchMdkSidecarRequest(request, env)
+      : await fetch(request)
+    const payload = await response.json().catch(() => ({}))
+    return { ok: response.ok, payload, status: response.status }
+  }
+
+  return makeMdkLightningInvoiceIssuer(post)
+}
+
 const forumL402SigningBoundaryForEnv = async (
   env: WorkerBindings & OpenAgentsWorkerConfigEnv,
 ) => {
@@ -9885,6 +9932,12 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         cardRailEnabled:
           env.STRIPE_MPP_NETWORK_PROFILE_ID !== undefined &&
           env.STRIPE_MPP_NETWORK_PROFILE_ID.trim() !== '',
+        // Bitcoin-first Lightning offer: armed flag AND a working MDK invoice
+        // issuer present (the SAME condition that arms the rail in the route).
+        // Honesty gate: omitted when we cannot actually mint an invoice.
+        lightningRailEnabled:
+          isKhalaMppLightningEnabled(env.KHALA_MPP_LIGHTNING_ENABLED) &&
+          lightningInvoiceIssuerForEnv(env) !== undefined,
         mppEnabled: isKhalaMppEnabled(env.KHALA_MPP_ENABLED),
       })
     },
@@ -10240,9 +10293,23 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
       const resolveOwnerIdentity = makeVerifiedOwnerIdentityResolver(
         ownerClaimStore.readVerifiedPublicIdentityForAgentUserId,
       )
+      // Bitcoin-first Lightning rail (EPIC #6049). Offered FIRST when armed:
+      // KHALA_MPP_LIGHTNING_ENABLED on AND an MDK invoice issuer is configured
+      // (the MDK route/sidecar wallet binding). With either absent the issuer is
+      // undefined and the rail is never advertised (honesty gate).
+      const lightningEnabled = isKhalaMppLightningEnabled(
+        env.KHALA_MPP_LIGHTNING_ENABLED,
+      )
+      const mintLightningInvoice = lightningEnabled
+        ? lightningInvoiceIssuerForEnv(env)
+        : undefined
       return handleMppChatCompletions(request, {
         db: openAgentsDatabase(env),
         enabled: isKhalaMppEnabled(env.KHALA_MPP_ENABLED),
+        lightningEnabled,
+        ...(mintLightningInvoice === undefined
+          ? {}
+          : { mintLightningInvoice }),
         signingSecret: env.KHALA_MPP_SIGNING_SECRET,
         stripeNetworkProfileId: env.STRIPE_MPP_NETWORK_PROFILE_ID,
         stripeSecretKey: env.STRIPE_API_KEY,

--- a/apps/openagents.com/workers/api/src/inference/mpp-discovery-document.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp-discovery-document.test.ts
@@ -74,14 +74,34 @@ const isValidPaymentInfo = (value: unknown): boolean => {
   return isValidOffer(value)
 }
 
-const ARMED: MppDiscoveryFlags = { cardRailEnabled: true, mppEnabled: true }
-const ARMED_CRYPTO_ONLY: MppDiscoveryFlags = {
-  cardRailEnabled: false,
+const ARMED: MppDiscoveryFlags = {
+  cardRailEnabled: true,
+  lightningRailEnabled: false,
   mppEnabled: true,
 }
-const INERT: MppDiscoveryFlags = { cardRailEnabled: false, mppEnabled: false }
+const ARMED_CRYPTO_ONLY: MppDiscoveryFlags = {
+  cardRailEnabled: false,
+  lightningRailEnabled: false,
+  mppEnabled: true,
+}
+const ARMED_LIGHTNING: MppDiscoveryFlags = {
+  cardRailEnabled: true,
+  lightningRailEnabled: true,
+  mppEnabled: true,
+}
+const INERT: MppDiscoveryFlags = {
+  cardRailEnabled: false,
+  lightningRailEnabled: false,
+  mppEnabled: false,
+}
 const INERT_WITH_PROFILE: MppDiscoveryFlags = {
   cardRailEnabled: true,
+  lightningRailEnabled: false,
+  mppEnabled: false,
+}
+const INERT_WITH_LIGHTNING_FLAG: MppDiscoveryFlags = {
+  cardRailEnabled: false,
+  lightningRailEnabled: true,
   mppEnabled: false,
 }
 
@@ -218,5 +238,44 @@ describe('MPP discovery document (EPIC #6049 — /openapi.json)', () => {
     const paths = doc.paths as Record<string, Record<string, unknown>>
     const op = paths['/mpp/v1/chat/completions']?.post as Record<string, unknown>
     expect(isValidPaymentInfo(op['x-payment-info'])).toBe(true)
+  })
+
+  test('BITCOIN-FIRST: armed Lightning => Lightning (sat) offer is listed FIRST', () => {
+    const doc = buildMppDiscoveryDocument(ARMED_LIGHTNING)
+    const paths = doc.paths as Record<string, Record<string, unknown>>
+    const op = paths['/mpp/v1/chat/completions']?.post as Record<string, unknown>
+    const offers = (
+      op['x-payment-info'] as { offers: ReadonlyArray<Record<string, unknown>> }
+    ).offers
+    // The FIRST offer is the Lightning charge (Bitcoin-first / preferred).
+    expect(offers[0]?.method).toBe('lightning')
+    expect(offers[0]?.currency).toBe('sat')
+    expect(offers[0]?.intent).toBe('charge')
+    // sat amount is a positive-integer string.
+    expect(/^[1-9][0-9]*$/.test(offers[0]?.amount as string)).toBe(true)
+    // Crypto + card offers still follow.
+    const methods = offers.map(o => o.method)
+    expect(methods).toContain('tempo')
+    expect(methods).toContain('stripe')
+    // Every offer still validates against the draft schema.
+    expect(isValidPaymentInfo(op['x-payment-info'])).toBe(true)
+  })
+
+  test('HONESTY GATE: Lightning flag on but MPP inert => no paid path at all', () => {
+    const doc = buildMppDiscoveryDocument(INERT_WITH_LIGHTNING_FLAG)
+    const paths = doc.paths as Record<string, unknown>
+    expect(paths['/mpp/v1/chat/completions']).toBeUndefined()
+    expect(JSON.stringify(doc)).not.toContain('x-payment-info')
+    expect(JSON.stringify(doc)).not.toContain('lightning')
+  })
+
+  test('HONESTY GATE: Lightning rail OFF => no lightning offer advertised', () => {
+    const doc = buildMppDiscoveryDocument(ARMED)
+    const paths = doc.paths as Record<string, Record<string, unknown>>
+    const op = paths['/mpp/v1/chat/completions']?.post as Record<string, unknown>
+    const offers = (
+      op['x-payment-info'] as { offers: ReadonlyArray<Record<string, unknown>> }
+    ).offers
+    expect(offers.some(o => o.method === 'lightning')).toBe(false)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp-discovery-document.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp-discovery-document.ts
@@ -26,7 +26,11 @@
 import { Effect } from 'effect'
 
 import { isKhalaModel } from './pricing'
-import { type MppRail, quoteMppCall } from './mpp/mpp-pricing'
+import {
+  type MppRail,
+  quoteMppCall,
+  quoteMppLightningCall,
+} from './mpp/mpp-pricing'
 
 // The canonical public origin.
 const ORIGIN = 'https://openagents.com'
@@ -71,6 +75,11 @@ export type MppDiscoveryFlags = Readonly<{
   // STRIPE_MPP_NETWORK_PROFILE_ID presence (the same condition that arms the
   // card rail in the route). When absent the document omits the card offer.
   cardRailEnabled: boolean
+  // KHALA_MPP_LIGHTNING_ENABLED + a working invoice issuer (the SAME condition
+  // that arms the Lightning rail in the route). When present the Lightning offer
+  // is listed FIRST (Bitcoin-first / preferred). HONESTY GATE: omitted when the
+  // rail is not actually armed — never advertise a rail we cannot fulfill.
+  lightningRailEnabled: boolean
 }>
 
 // Build the offer set for the paid MPP path. Always includes one USDC `charge`
@@ -87,6 +96,21 @@ const buildOffers = (
   const cryptoQuote = quoteMppCall({ model, rail: 'crypto' as MppRail })
   const cryptoAmount = usdcBaseUnits(cryptoQuote.priceUsd)
 
+  // Bitcoin-first: the Lightning offer (sats, real Bitcoin) is listed FIRST when
+  // the rail is armed. amount is in SATS (the smallest denomination of the "sat"
+  // currency per draft-lightning-charge-00).
+  const lightningOffers: ReadonlyArray<PaymentOffer> = flags.lightningRailEnabled
+    ? [
+        {
+          amount: String(quoteMppLightningCall({ model }).amountSats),
+          currency: 'sat',
+          description: `Pay-per-call Khala chat completion over Lightning (BOLT11; real Bitcoin). Advisory quote for ${model}; the runtime 402 challenge re-quotes the requested model and is authoritative.`,
+          intent: 'charge' as const,
+          method: 'lightning',
+        },
+      ]
+    : []
+
   const cryptoOffers: ReadonlyArray<PaymentOffer> = CRYPTO_NETWORKS.map(
     network => ({
       amount: cryptoAmount,
@@ -98,7 +122,7 @@ const buildOffers = (
   )
 
   if (!flags.cardRailEnabled) {
-    return cryptoOffers
+    return [...lightningOffers, ...cryptoOffers]
   }
 
   const cardQuote = quoteMppCall({ model, rail: 'card' as MppRail })
@@ -111,7 +135,7 @@ const buildOffers = (
     method: 'stripe',
   }
 
-  return [...cryptoOffers, cardOffer]
+  return [...lightningOffers, ...cryptoOffers, cardOffer]
 }
 
 // The OpenAI chat-completions request-body schema (model + messages), per the

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
@@ -17,7 +17,14 @@ import {
   type MppChatCompletionsDeps,
   handleMppChatCompletions,
   isKhalaMppEnabled,
+  isKhalaMppLightningEnabled,
 } from './mpp-chat-completions-routes'
+import {
+  type LightningInvoice,
+  type MintLightningInvoice,
+  LightningInvoiceError,
+} from './mpp-lightning-invoice'
+import { sha256Hex } from './mpp-lightning-verify'
 import { buildChallenge, type MppChallenge } from './mpp-protocol'
 import { type StripeFetch } from './stripe-mpp-client'
 
@@ -94,7 +101,7 @@ CREATE TABLE agent_balances (
 CREATE TABLE pay_ins (
   id TEXT PRIMARY KEY,
   pay_in_type TEXT NOT NULL CHECK (
-    pay_in_type IN ('tip','sweep','buffer_funding','reward','adjustment','usd_credit_grant')
+    pay_in_type IN ('tip','sweep','buffer_funding','reward','adjustment','usd_credit_grant','lightning_charge')
   ),
   payer_ref TEXT NOT NULL,
   cost_msat INTEGER NOT NULL CHECK (cost_msat > 0),
@@ -125,6 +132,11 @@ CREATE TABLE mpp_spt_replay (
   spt TEXT PRIMARY KEY,
   challenge_id TEXT NOT NULL,
   payment_intent_id TEXT,
+  consumed_at TEXT NOT NULL
+);
+CREATE TABLE mpp_lightning_replay (
+  payment_hash TEXT PRIMARY KEY,
+  challenge_id TEXT NOT NULL,
   consumed_at TEXT NOT NULL
 );
 `
@@ -726,5 +738,359 @@ describe('MPP endpoint — card/SPT settlement + replay', () => {
     )
     // Only the FIRST attempt hit Stripe with a charge.
     expect(chargeCount).toBe(1)
+  })
+})
+
+// ---- Lightning rail (draft-lightning-charge-00) ----
+
+// A known preimage and the deterministic invoice/paymentHash it pays. The fake
+// issuer returns this invoice; the test pays with this preimage.
+const LIGHTNING_PREIMAGE =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff'
+const LIGHTNING_INVOICE = `lnbc100n1p${'a'.repeat(48)}`
+
+const lightningPaymentHash = (): Promise<string> =>
+  sha256Hex(
+    Uint8Array.from(
+      (LIGHTNING_PREIMAGE.match(/.{2}/g) ?? []).map(b => Number.parseInt(b, 16)),
+    ),
+  )
+
+// A fake invoice issuer returning a fixed invoice whose paymentHash is the
+// sha256 of LIGHTNING_PREIMAGE. `invoiceExpiresAt` is overridable for the
+// expiry test; `fail` makes the issuer fail (honesty-gate test).
+const fakeLightningIssuer = (
+  opts: { invoiceExpiresAt?: string; fail?: boolean } = {},
+): { mint: MintLightningInvoice; calls: () => number } => {
+  let calls = 0
+  return {
+    calls: () => calls,
+    mint: () =>
+      Effect.gen(function* () {
+        calls += 1
+        if (opts.fail === true) {
+          return yield* Effect.fail(
+            new LightningInvoiceError('provider_unavailable'),
+          )
+        }
+        const paymentHash = yield* Effect.promise(lightningPaymentHash)
+        const invoice: LightningInvoice = {
+          bolt11: LIGHTNING_INVOICE,
+          network: 'mainnet',
+          paymentHash,
+          ...(opts.invoiceExpiresAt === undefined
+            ? {}
+            : { invoiceExpiresAt: opts.invoiceExpiresAt }),
+        }
+        return invoice
+      }),
+  }
+}
+
+// Parse one `WWW-Authenticate: Payment ...` header for `method` from a 402 and
+// reconstruct the issued challenge shape so a retry can echo it.
+const lightningChallengeFrom402 = (response: Response): MppChallenge | undefined => {
+  const headers = response.headers.get('www-authenticate') ?? ''
+  // getSetCookie-style: multiple headers are comma-joined; split on the scheme.
+  const parts = headers.split(/,\s*(?=Payment\s)/i).map(h => h.trim())
+  for (const part of parts) {
+    const params: Record<string, string> = {}
+    for (const m of part.matchAll(/(\w+)="((?:[^"\\]|\\.)*)"/g)) {
+      params[m[1]!] = m[2]!.replace(/\\"/g, '"')
+    }
+    if (params.method === 'lightning') {
+      return {
+        amountCents: 0,
+        currency: 'sat',
+        expires: params.expires ?? '',
+        id: params.id!,
+        intent: 'charge',
+        method: 'lightning',
+        opaque: params.opaque,
+        realm: params.realm!,
+        request: params.request!,
+      }
+    }
+  }
+  return undefined
+}
+
+const lightningQuoteFetch = (id = 'pi_quote_ln'): StripeFetch => async () =>
+  new Response(
+    JSON.stringify({
+      amount: 1,
+      currency: 'usd',
+      id,
+      next_action: {
+        crypto_display_details: {
+          deposit_addresses: { base: { address: '0xabc', supported_tokens: [] } },
+        },
+      },
+      status: 'requires_payment',
+    }),
+    { status: 200 },
+  )
+
+describe('isKhalaMppLightningEnabled flag', () => {
+  test('default OFF; on for explicit truthy tokens', () => {
+    expect(isKhalaMppLightningEnabled(undefined)).toBe(false)
+    expect(isKhalaMppLightningEnabled('false')).toBe(false)
+    expect(isKhalaMppLightningEnabled('1')).toBe(true)
+    expect(isKhalaMppLightningEnabled('on')).toBe(true)
+  })
+})
+
+describe('MPP endpoint — Lightning rail (Bitcoin-first)', () => {
+  test('OFFER ORDERING: armed Lightning challenge is emitted FIRST', async () => {
+    const db = makeDb()
+    const issuer = fakeLightningIssuer()
+    const response = await run(
+      handleMppChatCompletions(mppRequest(), {
+        completionDeps: completionDeps(db),
+        db,
+        enabled: true,
+        fetch: lightningQuoteFetch(),
+        lightningEnabled: true,
+        mintLightningInvoice: issuer.mint,
+        newId: () => 'fixed',
+        signingSecret: SIGNING_SECRET,
+        stripeSecretKey: 'sk_test_x',
+      }),
+    )
+    expect(response.status).toBe(402)
+    // The FIRST www-authenticate header is the lightning challenge.
+    const wwwAuth = response.headers.get('www-authenticate') ?? ''
+    const firstChallenge = wwwAuth.split(/,\s*(?=Payment\s)/i)[0] ?? ''
+    expect(firstChallenge).toContain('method="lightning"')
+    // The problem body lists lightning FIRST too.
+    const problem = (await response.json()) as {
+      challenges: Array<{ method: string }>
+    }
+    expect(problem.challenges[0]?.method).toBe('lightning')
+    expect(issuer.calls()).toBe(1)
+  })
+
+  test('INERT: flag OFF => no lightning challenge even with an issuer present', async () => {
+    const db = makeDb()
+    const issuer = fakeLightningIssuer()
+    const response = await run(
+      handleMppChatCompletions(mppRequest(), {
+        completionDeps: completionDeps(db),
+        db,
+        enabled: true,
+        fetch: lightningQuoteFetch(),
+        lightningEnabled: false,
+        mintLightningInvoice: issuer.mint,
+        signingSecret: SIGNING_SECRET,
+        stripeSecretKey: 'sk_test_x',
+      }),
+    )
+    expect(response.status).toBe(402)
+    expect(response.headers.get('www-authenticate') ?? '').not.toContain(
+      'method="lightning"',
+    )
+    expect(issuer.calls()).toBe(0)
+  })
+
+  test('HONESTY GATE: flag ON but no issuer => no lightning challenge', async () => {
+    const db = makeDb()
+    const response = await run(
+      handleMppChatCompletions(mppRequest(), {
+        completionDeps: completionDeps(db),
+        db,
+        enabled: true,
+        fetch: lightningQuoteFetch(),
+        lightningEnabled: true,
+        // mintLightningInvoice omitted => rail not advertised
+        signingSecret: SIGNING_SECRET,
+        stripeSecretKey: 'sk_test_x',
+      }),
+    )
+    expect(response.status).toBe(402)
+    expect(response.headers.get('www-authenticate') ?? '').not.toContain(
+      'method="lightning"',
+    )
+  })
+
+  test('PAY LOOP: a valid preimage settles, mints Bitcoin-origin credit, serves 200 + receipt', async () => {
+    const db = makeDb()
+    const issuer = fakeLightningIssuer()
+    const deps: MppChatCompletionsDeps = {
+      completionDeps: completionDeps(db),
+      db,
+      enabled: true,
+      fetch: lightningQuoteFetch(),
+      lightningEnabled: true,
+      mintLightningInvoice: issuer.mint,
+      signingSecret: SIGNING_SECRET,
+      stripeSecretKey: 'sk_test_x',
+    }
+    // 1) Drive a 402 and grab the issued lightning challenge.
+    const challengeResp = await run(handleMppChatCompletions(mppRequest(), deps))
+    const challenge = lightningChallengeFrom402(challengeResp)!
+    expect(challenge).toBeDefined()
+    // 2) Retry with the preimage credential.
+    const header = credentialHeader(challenge, { preimage: LIGHTNING_PREIMAGE })
+    const served = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(served.status).toBe(200)
+    // Receipt: method lightning, reference = paymentHash (NEVER the preimage).
+    const receipt = served.headers.get('payment-receipt')
+    expect(receipt).toBeTruthy()
+    const decoded = JSON.parse(
+      Buffer.from(receipt!.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString(),
+    ) as { method: string; reference: string }
+    expect(decoded.method).toBe('lightning')
+    const paymentHash = await lightningPaymentHash()
+    expect(decoded.reference).toBe(paymentHash)
+    expect(decoded.reference).not.toBe(LIGHTNING_PREIMAGE)
+    // Bitcoin-origin credit: balance_msat credited, usd_credit_msat NOT bumped.
+    const row = (await (
+      db.prepare(
+        'SELECT balance_msat, usd_credit_msat FROM agent_balances WHERE actor_ref = ?',
+      ).bind(`agent:mpp-lightning:${paymentHash}`) as unknown as {
+        first: () => Promise<{ balance_msat: number; usd_credit_msat: number } | null>
+      }
+    ).first())
+    expect(row).not.toBeNull()
+    expect(Number(row?.usd_credit_msat)).toBe(0)
+    expect(Number(row?.balance_msat)).toBeGreaterThanOrEqual(0)
+    // The pay-in was recorded as lightning_charge (Bitcoin-origin), not usd_credit_grant.
+    const payIn = (await (
+      db.prepare(
+        'SELECT pay_in_type FROM pay_ins WHERE payer_ref = ?',
+      ).bind(`agent:mpp-lightning:${paymentHash}`) as unknown as {
+        first: () => Promise<{ pay_in_type: string } | null>
+      }
+    ).first())
+    expect(payIn?.pay_in_type).toBe('lightning_charge')
+  })
+
+  test('REPLAY: a second use of the same preimage is refused (consume-once)', async () => {
+    const db = makeDb()
+    const issuer = fakeLightningIssuer()
+    const deps: MppChatCompletionsDeps = {
+      completionDeps: completionDeps(db),
+      db,
+      enabled: true,
+      fetch: lightningQuoteFetch(),
+      lightningEnabled: true,
+      mintLightningInvoice: issuer.mint,
+      signingSecret: SIGNING_SECRET,
+      stripeSecretKey: 'sk_test_x',
+    }
+    const challengeResp = await run(handleMppChatCompletions(mppRequest(), deps))
+    const challenge = lightningChallengeFrom402(challengeResp)!
+    const header = credentialHeader(challenge, { preimage: LIGHTNING_PREIMAGE })
+    const first = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(first.status).toBe(200)
+    const second = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(second.status).toBe(402)
+    expect(((await second.json()) as { reason?: string }).reason).toBe(
+      'preimage_replayed',
+    )
+  })
+
+  test('INVALID PREIMAGE: a wrong preimage is rejected with invalid_preimage', async () => {
+    const db = makeDb()
+    const issuer = fakeLightningIssuer()
+    const deps: MppChatCompletionsDeps = {
+      completionDeps: completionDeps(db),
+      db,
+      enabled: true,
+      fetch: lightningQuoteFetch(),
+      lightningEnabled: true,
+      mintLightningInvoice: issuer.mint,
+      signingSecret: SIGNING_SECRET,
+      stripeSecretKey: 'sk_test_x',
+    }
+    const challengeResp = await run(handleMppChatCompletions(mppRequest(), deps))
+    const challenge = lightningChallengeFrom402(challengeResp)!
+    const wrong =
+      'ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100'
+    const header = credentialHeader(challenge, { preimage: wrong })
+    const served = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(served.status).toBe(402)
+    expect(((await served.json()) as { reason?: string }).reason).toBe(
+      'invalid_preimage',
+    )
+  })
+
+  test('TAMPERED CHALLENGE: a forged HMAC id is rejected (re-issues 402, no serve)', async () => {
+    const db = makeDb()
+    const issuer = fakeLightningIssuer()
+    const deps: MppChatCompletionsDeps = {
+      completionDeps: completionDeps(db),
+      db,
+      enabled: true,
+      fetch: lightningQuoteFetch(),
+      lightningEnabled: true,
+      mintLightningInvoice: issuer.mint,
+      signingSecret: SIGNING_SECRET,
+      stripeSecretKey: 'sk_test_x',
+    }
+    const challengeResp = await run(handleMppChatCompletions(mppRequest(), deps))
+    const challenge = lightningChallengeFrom402(challengeResp)!
+    const tampered: MppChallenge = { ...challenge, id: 'forged-id' }
+    const header = credentialHeader(tampered, { preimage: LIGHTNING_PREIMAGE })
+    const served = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    // Verification fails => fresh 402 (never served).
+    expect(served.status).toBe(402)
+  })
+
+  test('EXPIRED INVOICE: a past invoice expiry is rejected (earlier-of expiry)', async () => {
+    const db = makeDb()
+    // Issue an invoice that has ALREADY expired per its BOLT11 expiry.
+    const issuer = fakeLightningIssuer({
+      invoiceExpiresAt: '2000-01-01T00:00:00.000Z',
+    })
+    const deps: MppChatCompletionsDeps = {
+      completionDeps: completionDeps(db),
+      db,
+      enabled: true,
+      fetch: lightningQuoteFetch(),
+      lightningEnabled: true,
+      mintLightningInvoice: issuer.mint,
+      // now is well past the invoice expiry but the challenge TTL would be future
+      nowMs: () => Date.parse('2026-06-22T12:00:00.000Z'),
+      signingSecret: SIGNING_SECRET,
+      stripeSecretKey: 'sk_test_x',
+    }
+    const challengeResp = await run(handleMppChatCompletions(mppRequest(), deps))
+    const challenge = lightningChallengeFrom402(challengeResp)!
+    // The challenge `expires` is clamped to the (past) invoice expiry, so the
+    // generic verify already rejects on challenge expiry => fresh 402.
+    const header = credentialHeader(challenge, { preimage: LIGHTNING_PREIMAGE })
+    const served = await run(
+      handleMppChatCompletions(
+        mppRequest({ headers: { authorization: header } }),
+        deps,
+      ),
+    )
+    expect(served.status).toBe(402)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
@@ -46,9 +46,17 @@ import {
 import { isKhalaModel } from '../pricing'
 import {
   type MppCreditGrantOutcome,
+  mintLightningCredits,
   mintMppCredits,
+  mppLightningPayerAccountRef,
   mppPayerAccountRef,
 } from './mpp-credit-grant'
+import {
+  type MintLightningInvoice,
+  LightningInvoiceError,
+} from './mpp-lightning-invoice'
+import { claimLightningPaymentHash } from './mpp-lightning-replay'
+import { readPreimage, verifyLightningPreimage } from './mpp-lightning-verify'
 import {
   type MppChallenge,
   type MppOpaque,
@@ -60,7 +68,7 @@ import {
   parsePaymentCredential,
   verifyCredential,
 } from './mpp-protocol'
-import { type MppRail, quoteMppCall } from './mpp-pricing'
+import { type MppRail, quoteMppCall, quoteMppLightningCall } from './mpp-pricing'
 import { claimSpt, recordSptPaymentIntent } from './mpp-spt-replay'
 import {
   type StripeFetch,
@@ -75,6 +83,9 @@ const DEFAULT_MPP_MODEL = 'openagents/khala-mini'
 // x402 (Base) + MPP (Solana, Tempo) — all USDC. We advertise all three crypto
 // networks; the agent picks one.
 const CRYPTO_NETWORKS: ReadonlyArray<string> = ['base', 'solana', 'tempo']
+// The Lightning rail method name (draft-lightning-charge-00). Bitcoin-first: this
+// is the PREFERRED rail and is surfaced FIRST in the multi-method 402.
+const LIGHTNING_METHOD = 'lightning'
 // The protection-space realm for our challenges (core spec §5.1.1).
 const MPP_REALM = 'openagents.com'
 // Challenge validity window.
@@ -82,6 +93,18 @@ const CHALLENGE_TTL_MS = 5 * 60 * 1000
 
 // Parse the KHALA_MPP_ENABLED flag. Default OFF.
 export const isKhalaMppEnabled = (value: string | undefined): boolean => {
+  if (value === undefined) {
+    return false
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+// Parse the KHALA_MPP_LIGHTNING_ENABLED flag. Default OFF. The Lightning rail is
+// additionally gated on a configured invoice issuer being present (the MDK
+// wallet binding) — see the deps below.
+export const isKhalaMppLightningEnabled = (
+  value: string | undefined,
+): boolean => {
   if (value === undefined) {
     return false
   }
@@ -98,6 +121,15 @@ export type MppChatCompletionsDeps = Readonly<{
   signingSecret: string | undefined
   // The network profile id (`profile_…`) for SPT/card. Absent => crypto-only.
   stripeNetworkProfileId?: string | undefined
+  // The KHALA_MPP_LIGHTNING_ENABLED flag, parsed. Default OFF => no Lightning
+  // rail offered. HONESTY GATE: the Lightning rail is offered ONLY when this is
+  // on AND `mintLightningInvoice` is present (a working invoice issuer) — we
+  // never advertise a rail we cannot fulfill.
+  lightningEnabled?: boolean | undefined
+  // The injectable BOLT11 invoice issuer (the MDK sidecar/route-backed minter in
+  // production; a fake in tests). Absent => no Lightning rail, even if the flag
+  // is on. Real Bitcoin inbound: the verify path is LOCAL (sha256(preimage)).
+  mintLightningInvoice?: MintLightningInvoice | undefined
   // The deps for the underlying Khala completion path (registry, metering hook,
   // etc). The MPP endpoint reuses these so a paid call runs the SAME completion,
   // metering, receipt, and Bitcoin-payout loop as the keyed `/v1/chat/completions`
@@ -137,11 +169,63 @@ const resolveMppModel = (rawBody: Record<string, unknown> | undefined): string =
   return isKhalaModel(requested) ? requested : DEFAULT_MPP_MODEL
 }
 
-// Build the spec-shaped challenge set for a quote. Always includes the crypto
-// rail (one challenge per supported network, all bound to the SAME crypto
-// deposit PaymentIntent recovered from `opaque`); adds the card/SPT rail only
-// when a network profile id is configured. Each challenge's `id` is the HMAC
-// binding computed inside `buildChallenge`.
+// Build a Lightning charge challenge (draft-lightning-charge-00). amount is in
+// SATS, currency "sat"; methodDetails carries the BOLT11 invoice + paymentHash +
+// network (all PUBLIC). The opaque carries the paymentHash (`ph`) and the
+// invoice expiry (`invExp`) so the retry recovers the settlement target + the
+// invoice-expiry signal STATELESSLY. The HMAC `id` is computed inside
+// `buildChallenge`. The preimage NEVER appears here.
+const buildLightningChallenge = (
+  signingSecret: string,
+  input: Readonly<{
+    model: string
+    expires: string
+    amountSats: number
+    bolt11: string
+    paymentHash: string
+    network: string
+    invoiceExpiresAt: string | undefined
+  }>,
+) =>
+  Effect.promise(() =>
+    buildChallenge(signingSecret, {
+      // amountCents is the decoded mirror field; for Lightning it carries the
+      // SAT amount (sat-native, not cents). Documented at the type.
+      amountCents: input.amountSats,
+      currency: 'sat',
+      expires: input.expires,
+      method: LIGHTNING_METHOD,
+      network: input.network,
+      opaque: {
+        amount: String(input.amountSats),
+        ...(input.invoiceExpiresAt === undefined
+          ? {}
+          : { invExp: input.invoiceExpiresAt }),
+        model: input.model,
+        network: input.network,
+        ph: input.paymentHash,
+      },
+      realm: MPP_REALM,
+      request: {
+        amount: String(input.amountSats),
+        currency: 'sat',
+        description: `OpenAgents Khala ${input.model} pay-per-call`,
+        methodDetails: {
+          invoice: input.bolt11,
+          network: input.network,
+          paymentHash: input.paymentHash,
+        },
+        network: input.network,
+      },
+    }),
+  )
+
+// Build the spec-shaped challenge set for a quote. When a pre-built Lightning
+// challenge is supplied it is FIRST (Bitcoin-first / preferred rail). Always
+// includes the crypto rail (one challenge per supported network, all bound to
+// the SAME crypto deposit PaymentIntent recovered from `opaque`); adds the
+// card/SPT rail only when a network profile id is configured. Each challenge's
+// `id` is the HMAC binding computed inside `buildChallenge`.
 const buildChallenges = (
   signingSecret: string,
   input: Readonly<{
@@ -153,10 +237,16 @@ const buildChallenges = (
     cardEnabled: boolean
     cardAmountCents: number
     cardNetworkProfileId: string | undefined
+    // Pre-built Lightning challenge, prepended FIRST when present.
+    lightningChallenge: MppChallenge | undefined
   }>,
 ) =>
   Effect.gen(function* () {
     const challenges: Array<MppChallenge> = []
+    // Bitcoin-first: the Lightning challenge is offered FIRST when armed.
+    if (input.lightningChallenge !== undefined) {
+      challenges.push(input.lightningChallenge)
+    }
     // The opaque correlation data carries the crypto deposit PaymentIntent id
     // so the retry recovers it statelessly. One opaque per crypto rail (all
     // networks share the same deposit-mode PaymentIntent).
@@ -215,10 +305,66 @@ const buildChallenges = (
     return challenges as ReadonlyArray<MppChallenge>
   })
 
+// The Lightning rail is active only when the flag is on AND an invoice issuer is
+// wired (HONESTY GATE: never advertise a rail we cannot fulfill).
+const lightningRailActive = (
+  deps: MppChatCompletionsDeps,
+): MintLightningInvoice | undefined =>
+  deps.lightningEnabled === true && deps.mintLightningInvoice !== undefined
+    ? deps.mintLightningInvoice
+    : undefined
+
+// Mint a Lightning invoice + build the (Bitcoin-first) Lightning challenge for
+// this quote. Best-effort: if the invoice issuer fails we return undefined and
+// the 402 still carries the other rails — we just do not advertise a Lightning
+// rail we could not actually mint an invoice for (honesty gate). The effective
+// challenge expiry is the EARLIER of the challenge TTL and the invoice expiry.
+const buildLightningChallengeForQuote = (
+  deps: MppChatCompletionsDeps,
+  signingSecret: string,
+  mint: MintLightningInvoice,
+  input: Readonly<{ model: string; newId: () => string; challengeExpiresAt: string }>,
+) =>
+  Effect.gen(function* () {
+    const lightningQuote = quoteMppLightningCall({ model: input.model })
+    const minted = yield* mint({
+      amountSats: lightningQuote.amountSats,
+      correlationRef: `mpp:lightning:${input.model}:${input.newId()}`,
+      description: `OpenAgents Khala ${input.model} pay-per-call`,
+    }).pipe(
+      Effect.map(invoice => ({ ok: true as const, invoice })),
+      Effect.catch((error: LightningInvoiceError) =>
+        Effect.succeed({ ok: false as const, reason: error.reason }),
+      ),
+    )
+    if (!minted.ok) {
+      return undefined
+    }
+    // Effective expiry = earlier of challenge TTL and invoice BOLT11 expiry
+    // (spec §"Challenge Expiry and Invoice Expiry"). The challenge `expires`
+    // auth-param MUST NOT be later than the invoice expiry.
+    const challengeExpires =
+      minted.invoice.invoiceExpiresAt !== undefined &&
+      Date.parse(minted.invoice.invoiceExpiresAt) <
+        Date.parse(input.challengeExpiresAt)
+        ? minted.invoice.invoiceExpiresAt
+        : input.challengeExpiresAt
+    return yield* buildLightningChallenge(signingSecret, {
+      amountSats: lightningQuote.amountSats,
+      bolt11: minted.invoice.bolt11,
+      expires: challengeExpires,
+      invoiceExpiresAt: minted.invoice.invoiceExpiresAt,
+      model: input.model,
+      network: minted.invoice.network,
+      paymentHash: minted.invoice.paymentHash,
+    })
+  })
+
 // Issue a fresh 402 (no credential, or a credential we refused). Creates a
 // crypto deposit PaymentIntent for the quote (the address the crypto challenge
-// points at) and builds the bound challenge set. If Stripe cannot quote, returns
-// a clean 503 (never a broken 402).
+// points at) and builds the bound challenge set. When the Lightning rail is
+// armed the Lightning challenge is offered FIRST (Bitcoin-first). If Stripe
+// cannot quote, returns a clean 503 (never a broken 402).
 const issueChallenge = (
   deps: MppChatCompletionsDeps,
   signingSecret: string,
@@ -233,6 +379,18 @@ const issueChallenge = (
     const model = resolveMppModel(rawBody)
     const cryptoQuote = quoteMppCall({ model, rail: 'crypto' as MppRail })
     const cardQuote = quoteMppCall({ model, rail: 'card' as MppRail })
+    const challengeExpiresAt = epochMillisToIsoTimestamp(nowMs + CHALLENGE_TTL_MS)
+
+    // Bitcoin-first: mint the Lightning challenge first (when the rail is armed).
+    const mint = lightningRailActive(deps)
+    const lightningChallenge =
+      mint === undefined
+        ? undefined
+        : yield* buildLightningChallengeForQuote(deps, signingSecret, mint, {
+            challengeExpiresAt,
+            model,
+            newId,
+          })
 
     const created = yield* createCryptoDepositPaymentIntent(stripeDeps, {
       amountCents: cryptoQuote.amountCents,
@@ -256,7 +414,8 @@ const issueChallenge = (
       cryptoAmountCents: cryptoQuote.amountCents,
       cryptoDeposit: created.intent.deposits[0],
       cryptoPaymentIntentId: created.intent.id,
-      expires: epochMillisToIsoTimestamp(nowMs + CHALLENGE_TTL_MS),
+      expires: challengeExpiresAt,
+      lightningChallenge,
       model,
     })
 
@@ -306,6 +465,125 @@ const runPaidCompletion = (
       headers,
       status: response.status,
       statusText: response.statusText,
+    })
+  })
+
+// Settle + serve the LIGHTNING rail once a credential passed the generic HMAC
+// verification. Lightning settlement is LOCAL (draft-lightning-charge-00
+// §Verification): no node call. We:
+//   1. recover the bound paymentHash from the verified `opaque` (`ph`);
+//   2. enforce the invoice-expiry signal (`invExp`) — the EARLIER-of expiry —
+//      on top of the challenge expiry the generic verify already checked;
+//   3. verify sha256(payload.preimage) == paymentHash, fail-closed;
+//   4. atomically CONSUME-ONCE on the paymentHash (claim before serve);
+//   5. mint BITCOIN-ORIGIN credit (idempotent per paymentHash, NOT usd_credit),
+//      run the SAME Khala completion, attach a Payment-Receipt whose `reference`
+//      is the paymentHash (NEVER the preimage — bearer secret).
+// Any failure => fresh 402 (never serves unpaid). The preimage is never logged,
+// persisted, or returned.
+const settleAndServeLightning = (
+  request: Request,
+  deps: MppChatCompletionsDeps,
+  verified: Extract<Awaited<ReturnType<typeof verifyCredential>>, { ok: true }>,
+  credential: ParsedPaymentCredential,
+) =>
+  Effect.gen(function* () {
+    const nowMs = (deps.nowMs ?? currentEpochMillis)()
+    const paymentHash = verified.opaque?.ph
+    if (paymentHash === undefined || paymentHash.trim() === '') {
+      return noStoreJsonResponse(
+        { error: 'payment_verification_failed', reason: 'missing_correlation' },
+        { status: 402 },
+      )
+    }
+
+    // (2) Invoice expiry: the EARLIER-of expiry. The generic verify already
+    // rejected a past challenge `expires`; this additionally rejects a past
+    // invoice expiry (spec §"Challenge Expiry and Invoice Expiry").
+    const invExp = verified.opaque?.invExp
+    if (invExp !== undefined && invExp !== '') {
+      const invExpMs = Date.parse(invExp)
+      if (Number.isNaN(invExpMs) || invExpMs <= nowMs) {
+        return noStoreJsonResponse(
+          { error: 'payment_verification_failed', reason: 'expired_invoice' },
+          { status: 402 },
+        )
+      }
+    }
+
+    // (3) Local preimage verification — sha256(preimage) == paymentHash.
+    const preimage = readPreimage(credential.payload)
+    const preimageResult = yield* Effect.promise(() =>
+      verifyLightningPreimage(preimage, paymentHash),
+    )
+    if (!preimageResult.ok) {
+      // malformed-credential vs invalid-preimage (spec problem types). Either
+      // way => fresh 402 (never serve). The preimage value is never echoed.
+      return noStoreJsonResponse(
+        {
+          error: 'payment_verification_failed',
+          reason:
+            preimageResult.reason === 'malformed'
+              ? 'malformed_preimage'
+              : 'invalid_preimage',
+        },
+        { status: 402 },
+      )
+    }
+
+    // (4) Atomic consume-once on the paymentHash (claim BEFORE serve). A replay
+    // collides on the PRIMARY KEY and is refused before a second free serve.
+    const claimed = yield* claimLightningPaymentHash(deps.db, {
+      challengeId: credential.challenge.id,
+      paymentHash,
+    }).pipe(
+      Effect.map(ok => ({ ok: true as const, claimed: ok })),
+      Effect.catch(() => Effect.succeed({ ok: false as const })),
+    )
+    if (!claimed.ok) {
+      return noStoreJsonResponse(
+        { error: 'payment_verification_failed', reason: 'replay_store' },
+        { status: 502 },
+      )
+    }
+    if (!claimed.claimed) {
+      return noStoreJsonResponse(
+        { error: 'payment_verification_failed', reason: 'preimage_replayed' },
+        { status: 402 },
+      )
+    }
+
+    // (5) SETTLED (real Bitcoin). Mint BITCOIN-ORIGIN credit (NOT usd_credit),
+    // idempotent per paymentHash, then run the SAME Khala completion.
+    const amountSats = Number(verified.request.amount)
+    if (!Number.isFinite(amountSats) || amountSats <= 0) {
+      return noStoreJsonResponse(
+        { error: 'payment_verification_failed', reason: 'amount_invalid' },
+        { status: 402 },
+      )
+    }
+    const accountRef = mppLightningPayerAccountRef(paymentHash)
+    const grant = yield* mintLightningCredits(
+      {
+        db: deps.db,
+        ...(deps.nowIso === undefined ? {} : { nowIso: deps.nowIso }),
+      },
+      { accountRef, amountSats, paymentHash },
+    ).pipe(
+      Effect.map(outcome => ({ ok: true as const, outcome })),
+      Effect.catch(() => Effect.succeed({ ok: false as const } as const)),
+    )
+    if (!grant.ok) {
+      return noStoreJsonResponse(
+        { error: 'credit_grant_failed', reference: paymentHash },
+        { status: 500 },
+      )
+    }
+
+    // Receipt `reference` = the paymentHash (public), NEVER the preimage.
+    return yield* runPaidCompletion(request, deps, grant.outcome, {
+      method: LIGHTNING_METHOD,
+      reference: paymentHash,
     })
   })
 
@@ -547,22 +825,34 @@ export const handleMppChatCompletions = (
     const model = resolveMppModel(rawBody)
     const cryptoQuote = quoteMppCall({ model, rail: 'crypto' as MppRail })
     const cardQuote = quoteMppCall({ model, rail: 'card' as MppRail })
-    const allowedMethods = cardEnabled
-      ? [...CRYPTO_NETWORKS, 'stripe']
-      : [...CRYPTO_NETWORKS]
+    const lightningActive = lightningRailActive(deps) !== undefined
+    const lightningQuote = quoteMppLightningCall({ model })
+    // Lightning is offered FIRST when armed (Bitcoin-first). Verification only
+    // ACCEPTS a method we actually offered, so a `lightning` credential is
+    // refused unless the rail is armed.
+    const allowedMethods = [
+      ...(lightningActive ? [LIGHTNING_METHOD] : []),
+      ...CRYPTO_NETWORKS,
+      ...(cardEnabled ? ['stripe'] : []),
+    ]
 
     const verified = yield* Effect.promise(() =>
       verifyCredential(signingSecret, credential, {
         allowedMethods,
         expectedCurrencyForMethod: method =>
-          method === 'stripe' ? 'usd' : 'usdc',
-        // The card rail floor is the card quote; crypto uses the crypto quote.
-        // Use the lower of the two so neither rail under-floors; verification
-        // separately binds the exact amount via the HMAC over `request`.
-        expectedMinAmountCents: Math.min(
-          cryptoQuote.amountCents,
-          cardQuote.amountCents,
-        ),
+          method === LIGHTNING_METHOD
+            ? 'sat'
+            : method === 'stripe'
+              ? 'usd'
+              : 'usdc',
+        // Per-method floor: Lightning is sat-native (sats floor), the USDC/card
+        // rails are cent-native (cents floor). Verification separately binds the
+        // exact amount via the HMAC over `request`; this just floors a downward
+        // tamper in the method's native unit.
+        expectedMinAmountCents: method =>
+          method === LIGHTNING_METHOD
+            ? lightningQuote.amountSats
+            : Math.min(cryptoQuote.amountCents, cardQuote.amountCents),
         ...(deps.nowMs === undefined ? {} : { nowMs: deps.nowMs() }),
         realm: MPP_REALM,
       }),
@@ -583,6 +873,11 @@ export const handleMppChatCompletions = (
     }
 
     // ---- VERIFIED: settle for the rail, then serve ----
+    // Lightning settles LOCALLY (no Stripe); the USDC/card rails settle via
+    // Stripe. Dispatch on the verified method.
+    if (verified.method === LIGHTNING_METHOD) {
+      return yield* settleAndServeLightning(request, deps, verified, credential)
+    }
     return yield* settleAndServe(
       request,
       deps,

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-credit-grant.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-credit-grant.test.ts
@@ -5,9 +5,13 @@ import { describe, expect, test } from 'vitest'
 
 import { readAgentBalance } from '../../payments-ledger'
 import {
+  mintLightningCredits,
   mintMppCredits,
   mppCreditGrantContextRef,
   mppGrantRef,
+  mppLightningCreditGrantContextRef,
+  mppLightningGrantRef,
+  mppLightningPayerAccountRef,
   mppPayerAccountRef,
 } from './mpp-credit-grant'
 
@@ -78,7 +82,7 @@ CREATE TABLE agent_balances (
 CREATE TABLE pay_ins (
   id TEXT PRIMARY KEY,
   pay_in_type TEXT NOT NULL CHECK (
-    pay_in_type IN ('tip','sweep','buffer_funding','reward','adjustment','usd_credit_grant')
+    pay_in_type IN ('tip','sweep','buffer_funding','reward','adjustment','usd_credit_grant','lightning_charge')
   ),
   payer_ref TEXT NOT NULL,
   cost_msat INTEGER NOT NULL CHECK (cost_msat > 0),
@@ -163,6 +167,57 @@ describe('mpp credit grant (Phase 3 — settled payment -> Khala credits)', () =
     )
     const balance = await readAgentBalance(db, accountRef)
     // Balance reflects ONE grant, not two.
+    expect(balance?.balanceMsat).toBe(first.grantedMsat)
+  })
+})
+
+describe('lightning credit grant (BITCOIN-ORIGIN, not usd_credit_msat)', () => {
+  const HASH =
+    '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff'
+
+  test('mints Bitcoin-origin credit: balance_msat only, usd_credit_msat untouched', async () => {
+    const db = makeDb()
+    const accountRef = mppLightningPayerAccountRef(HASH)
+    const outcome = await run(
+      mintLightningCredits(
+        { db, nowIso: () => NOW },
+        { accountRef, amountSats: 100, paymentHash: HASH },
+      ),
+    )
+    // 100 sats = 100_000 msat.
+    expect(outcome.grantedMsat).toBe(100_000)
+    expect(outcome.grantRef).toBe(mppLightningGrantRef(HASH))
+
+    const balance = await readAgentBalance(db, accountRef)
+    expect(balance?.balanceMsat).toBe(100_000)
+    // RL-3 (the OPPOSITE of the USDC/card rails): real Bitcoin is NOT tagged
+    // usd_credit_msat, so it stays Bitcoin-withdrawable.
+    expect(balance?.usdCreditMsat).toBe(0)
+
+    const payIn = (await db
+      .prepare(`SELECT context_ref, pay_in_type FROM pay_ins WHERE payer_ref = ?`)
+      .bind(accountRef)
+      .first()) as { context_ref?: string; pay_in_type?: string } | null
+    expect(payIn?.pay_in_type).toBe('lightning_charge')
+    expect(payIn?.context_ref).toBe(mppLightningCreditGrantContextRef(HASH))
+  })
+
+  test('is idempotent per paymentHash (a replayed settlement never double-credits)', async () => {
+    const db = makeDb()
+    const accountRef = mppLightningPayerAccountRef(HASH)
+    const first = await run(
+      mintLightningCredits(
+        { db, nowIso: () => NOW },
+        { accountRef, amountSats: 100, paymentHash: HASH },
+      ),
+    )
+    await run(
+      mintLightningCredits(
+        { db, nowIso: () => NOW },
+        { accountRef, amountSats: 100, paymentHash: HASH },
+      ),
+    )
+    const balance = await readAgentBalance(db, accountRef)
     expect(balance?.balanceMsat).toBe(first.grantedMsat)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-credit-grant.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-credit-grant.ts
@@ -23,7 +23,7 @@
 import { Effect } from 'effect'
 
 import { currentIsoTimestamp } from '../../runtime-primitives'
-import { runLedgerStatements } from '../../payments-ledger'
+import { type LedgerStatement, runLedgerStatements } from '../../payments-ledger'
 import { usdCentsToMsatFloor } from '../usd-msat-conversion'
 import {
   agentRefForUser,
@@ -119,3 +119,163 @@ export const mintMppCredits = (
 // real agent account.
 export const mppPayerAccountRef = (paymentIntentId: string): string =>
   agentRefForUser(`mpp:${paymentIntentId}`)
+
+// ---- Lightning rail (REAL Bitcoin inbound) ----
+//
+// RL-3 ASSET BOUNDARY (load-bearing, the OPPOSITE of the USDC/card rails): a
+// settled Lightning charge is REAL Bitcoin (a paid BOLT11 invoice), NOT a USD/
+// Stripe liability. So the minted credit MUST NOT be tagged `usd_credit_msat`
+// (the USD-origin, NON-Bitcoin-withdrawable bucket the Lightning sweep subtracts
+// in `tips-sweep.ts`). Tagging real Bitcoin as USD-origin would mislabel a real
+// sat as non-withdrawable. The Lightning credit lands in `balance_msat` ONLY,
+// as a Bitcoin-origin `lightning_charge` pay-in — Bitcoin-withdrawable, exactly
+// like a forum tip, distinct from the USD-origin MPP credit minted for the
+// USDC/card rails.
+//
+// In practice the credit lands in the per-payment ephemeral payer account
+// (`mppPayerAccountRef`, keyed by the paymentHash) and is spent immediately by
+// the SAME paid completion, so it never sits as a withdrawable balance for a
+// real agent — but the asset TAG is still kept honest (Bitcoin-origin) so the
+// accounting can never misclassify the inbound asset.
+
+// Context-ref prefix binding a minted Lightning credit back to its settling
+// BOLT11 paymentHash, so the grant row is dereferenceable to the paid invoice.
+// Keyed on the PAYMENT HASH (public), NEVER the preimage (bearer secret).
+export const MPP_LIGHTNING_CREDIT_GRANT_CONTEXT_PREFIX =
+  'inference:mpp-lightning-credit:'
+
+export const mppLightningCreditGrantContextRef = (paymentHash: string): string =>
+  `${MPP_LIGHTNING_CREDIT_GRANT_CONTEXT_PREFIX}${paymentHash}`
+
+// A stable grant ref derived from the paymentHash, so a replayed settlement
+// (same paid invoice) is idempotent (one invoice = one grant) via the UNIQUE
+// pay_ins idempotency key.
+export const mppLightningGrantRef = (paymentHash: string): string =>
+  `mpp-lightning:${paymentHash}`
+
+export const mppLightningGrantReceiptRef = (grantRef: string): string =>
+  `receipt.inference.lightning_charge.${grantRef}`
+
+// The agent-balance ref for a Lightning MPP payer. Bound to the paymentHash so
+// the minted Bitcoin-origin credit and the immediately-following Khala spend
+// stay in one balance.
+export const mppLightningPayerAccountRef = (paymentHash: string): string =>
+  agentRefForUser(`mpp-lightning:${paymentHash}`)
+
+// Build the atomic ledger statements for a BITCOIN-ORIGIN msat credit grant from
+// a settled Lightning charge. Mirrors `usdCreditGrantStatements` but as a
+// `lightning_charge` pay-in that credits `balance_msat` ONLY (it does NOT bump
+// `usd_credit_msat`), so the credit is Bitcoin-withdrawable — the correct asset
+// classification for real Bitcoin inbound. Idempotent per grant ref via the
+// UNIQUE pay_ins idempotency key.
+export const lightningCreditGrantStatements = (
+  input: Readonly<{
+    grantRef: string
+    accountRef: string
+    grantMsat: number
+    contextRef: string
+  }>,
+  nowIso: string,
+): ReadonlyArray<LedgerStatement> => {
+  const grantMsat = Math.max(1, Math.trunc(input.grantMsat))
+  const payInId = `inference:lightning-charge:${input.grantRef}`
+  const legId = `${input.grantRef}:grant`
+  const idempotencyKey = `inference:lightning-credit-grant:${input.grantRef}`
+  const receiptRef = mppLightningGrantReceiptRef(input.grantRef)
+
+  return [
+    {
+      params: [
+        payInId,
+        input.accountRef,
+        grantMsat,
+        input.contextRef,
+        idempotencyKey,
+        receiptRef,
+        nowIso,
+        nowIso,
+      ],
+      sql: `INSERT OR IGNORE INTO pay_ins
+            (id, pay_in_type, payer_ref, cost_msat, state, rung, context_ref,
+             idempotency_key, public_receipt_ref, genesis_id, created_at,
+             state_changed_at)
+            VALUES (?, 'lightning_charge', ?, ?, 'paid', NULL, ?, ?, ?, NULL, ?, ?)`,
+    },
+    {
+      params: [input.accountRef, nowIso, nowIso],
+      sql: `INSERT INTO agent_balances (actor_ref, balance_msat, created_at, updated_at)
+            VALUES (?, 0, ?, ?)
+            ON CONFLICT (actor_ref) DO NOTHING`,
+    },
+    {
+      // Bitcoin-origin: credit balance_msat ONLY (NO usd_credit_msat bump).
+      // GUARDED on the leg not already existing so a replay is a no-op.
+      params: [grantMsat, nowIso, input.accountRef, legId],
+      sql: `UPDATE agent_balances
+            SET balance_msat = balance_msat + ?,
+                updated_at = ?
+            WHERE actor_ref = ?
+              AND NOT EXISTS (SELECT 1 FROM pay_in_legs WHERE id = ?)`,
+    },
+    {
+      params: [
+        legId,
+        payInId,
+        grantMsat,
+        input.accountRef,
+        input.accountRef,
+        nowIso,
+      ],
+      sql: `INSERT OR IGNORE INTO pay_in_legs
+            (id, pay_in_id, direction, kind, party_ref, amount_msat,
+             resulting_balance_msat, external_ref, refund_of_leg_id, created_at)
+            VALUES (?, ?, 'in', 'lightning', ?, ?,
+                    (SELECT balance_msat FROM agent_balances WHERE actor_ref = ?),
+                    'lightning_charge', NULL, ?)`,
+    },
+  ]
+}
+
+// Mint Bitcoin-origin Khala credits for a settled Lightning charge. Atomic,
+// idempotent per paymentHash, Bitcoin-origin (NOT tagged usd_credit_msat). The
+// amount is the settled sats converted to msat (1 sat = 1000 msat).
+export const mintLightningCredits = (
+  deps: Readonly<{
+    db: D1Database
+    nowIso?: () => string
+  }>,
+  input: Readonly<{
+    accountRef: string
+    paymentHash: string
+    amountSats: number
+  }>,
+): Effect.Effect<MppCreditGrantOutcome, MppCreditGrantError> =>
+  Effect.gen(function* () {
+    const nowIso = deps.nowIso ?? currentIsoTimestamp
+    const grantMsat = Math.max(1, Math.trunc(input.amountSats) * 1000)
+    const grantRef = mppLightningGrantRef(input.paymentHash)
+
+    yield* Effect.tryPromise({
+      catch: (cause: unknown) => new MppCreditGrantError(cause),
+      try: () =>
+        runLedgerStatements(
+          deps.db,
+          lightningCreditGrantStatements(
+            {
+              accountRef: input.accountRef,
+              contextRef: mppLightningCreditGrantContextRef(input.paymentHash),
+              grantMsat,
+              grantRef,
+            },
+            nowIso(),
+          ),
+        ),
+    })
+
+    return {
+      accountRef: input.accountRef,
+      grantedMsat: grantMsat,
+      grantRef,
+      receiptRef: mppLightningGrantReceiptRef(grantRef),
+    }
+  })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.test.ts
@@ -1,0 +1,102 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { LightningInvoiceError } from './mpp-lightning-invoice'
+import {
+  type MdkRoutePost,
+  makeMdkLightningInvoiceIssuer,
+} from './mpp-lightning-invoice-mdk'
+
+const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
+  Effect.runPromise(effect as Effect.Effect<A, never>)
+
+const HASH =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff'
+const INVOICE = `lnbc100n1p${'a'.repeat(40)}`
+
+describe('makeMdkLightningInvoiceIssuer', () => {
+  test('posts a SAT create_checkout and reads the raw bolt11 + paymentHash', async () => {
+    let seen: Record<string, unknown> | undefined
+    const post: MdkRoutePost = async body => {
+      seen = body
+      return {
+        ok: true,
+        payload: {
+          data: {
+            checkout: {
+              id: 'mdk_checkout_x',
+              invoice: {
+                invoice: INVOICE,
+                paymentHash: HASH,
+                expiresAt: '2099-01-15T12:05:00Z',
+              },
+            },
+          },
+        },
+        status: 200,
+      }
+    }
+    const issuer = makeMdkLightningInvoiceIssuer(post)
+    const invoice = await run(
+      issuer({ amountSats: 42, correlationRef: 'ref', description: 'd' }),
+    )
+    expect(invoice.bolt11).toBe(INVOICE)
+    expect(invoice.paymentHash).toBe(HASH)
+    expect(invoice.network).toBe('mainnet')
+    expect(invoice.invoiceExpiresAt).toBe('2099-01-15T12:05:00.000Z')
+    // The create_checkout body is amount-mode SAT.
+    const params = (seen as { params: Record<string, unknown> }).params
+    expect(seen?.handler).toBe('create_checkout')
+    expect(params.currency).toBe('SAT')
+    expect(params.amount).toBe(42)
+    expect(params.type).toBe('AMOUNT')
+  })
+
+  test('maps a 5xx route status to provider_unavailable', async () => {
+    const post: MdkRoutePost = async () => ({
+      ok: false,
+      payload: {},
+      status: 503,
+    })
+    const issuer = makeMdkLightningInvoiceIssuer(post)
+    const result = await Effect.runPromise(
+      issuer({ amountSats: 1, correlationRef: 'r', description: 'd' }).pipe(
+        Effect.map(() => 'ok' as const),
+        Effect.catch((e: LightningInvoiceError) => Effect.succeed(e.reason)),
+      ),
+    )
+    expect(result).toBe('provider_unavailable')
+  })
+
+  test('maps a 4xx route status to provider_rejected', async () => {
+    const post: MdkRoutePost = async () => ({
+      ok: false,
+      payload: {},
+      status: 400,
+    })
+    const issuer = makeMdkLightningInvoiceIssuer(post)
+    const result = await Effect.runPromise(
+      issuer({ amountSats: 1, correlationRef: 'r', description: 'd' }).pipe(
+        Effect.map(() => 'ok' as const),
+        Effect.catch((e: LightningInvoiceError) => Effect.succeed(e.reason)),
+      ),
+    )
+    expect(result).toBe('provider_rejected')
+  })
+
+  test('a payload with no usable invoice => malformed_invoice', async () => {
+    const post: MdkRoutePost = async () => ({
+      ok: true,
+      payload: { data: { checkout: { id: 'x' } } },
+      status: 200,
+    })
+    const issuer = makeMdkLightningInvoiceIssuer(post)
+    const result = await Effect.runPromise(
+      issuer({ amountSats: 1, correlationRef: 'r', description: 'd' }).pipe(
+        Effect.map(() => 'ok' as const),
+        Effect.catch((e: LightningInvoiceError) => Effect.succeed(e.reason)),
+      ),
+    )
+    expect(result).toBe('malformed_invoice')
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
@@ -1,0 +1,131 @@
+// MDK-backed BOLT11 invoice issuer for the Lightning MPP rail (EPIC #6049).
+//
+// Mints a fresh BOLT11 invoice for N sats by POSTing a `create_checkout`
+// (mode amount, currency SAT) to the SAME MDK route/sidecar the Forum L402 flow
+// uses, then reads the RAW `invoice.bolt11` + `invoice.paymentHash` from the
+// provider checkout. This is a server-internal issuer (the invoice + paymentHash
+// are PUBLIC — they go into the 402 challenge the client must pay); it does NOT
+// use the redacting public projection in `hosted-mdk-client.ts`.
+//
+// INERT NOTE: this issuer is constructed ONLY when an MDK route is configured
+// (route URL + secret) and the Lightning flag is on. With no route the route
+// wiring passes `mintLightningInvoice: undefined` and the rail is never offered.
+
+import { Effect } from 'effect'
+
+import { isRecord, nestedUnknown, optionalString } from '../../json-boundary'
+import {
+  type LightningInvoice,
+  type MintLightningInvoice,
+  LightningInvoiceError,
+  validateLightningInvoice,
+} from './mpp-lightning-invoice'
+
+// A POST transport to the MDK route/sidecar. Returns the HTTP ok flag + status +
+// parsed JSON payload (no throwing — the issuer maps a non-ok status to a typed
+// failure). In production this is the same `fetchMdkSidecarRequest` path the
+// hosted MDK route client uses for the `self_hosted_mdkd_sidecar` route kind.
+export type MdkRoutePost = (
+  body: Readonly<Record<string, unknown>>,
+) => Promise<Readonly<{ ok: boolean; status: number; payload: unknown }>>
+
+// Pull the provider checkout object out of the (possibly nested) route payload.
+// Mirrors `providerCheckoutFromPayload` in hosted-mdk-client.ts.
+const providerCheckout = (
+  payload: unknown,
+): Record<string, unknown> | undefined => {
+  if (!isRecord(payload)) {
+    return undefined
+  }
+  const nested = nestedUnknown(payload, ['data', 'checkout'])
+  if (isRecord(nested)) {
+    return nested
+  }
+  const data = nestedUnknown(payload, ['data'])
+  if (isRecord(data)) {
+    return data
+  }
+  const json = nestedUnknown(payload, ['json'])
+  if (isRecord(json)) {
+    return json
+  }
+  return payload
+}
+
+// Read the raw BOLT11 invoice string from the provider checkout.
+const rawBolt11 = (checkout: Record<string, unknown>): unknown =>
+  nestedUnknown(checkout, ['invoice', 'invoice']) ??
+  nestedUnknown(checkout, ['invoice', 'bolt11']) ??
+  nestedUnknown(checkout, ['invoice', 'paymentRequest']) ??
+  checkout.bolt11 ??
+  checkout.bolt11Invoice ??
+  checkout.invoice ??
+  checkout.paymentRequest
+
+// Read the raw payment hash (lowercase hex) from the provider checkout.
+const rawPaymentHash = (checkout: Record<string, unknown>): unknown =>
+  nestedUnknown(checkout, ['invoice', 'paymentHash']) ??
+  nestedUnknown(checkout, ['invoice', 'payment_hash']) ??
+  checkout.paymentHash ??
+  checkout.payment_hash
+
+// Read the raw invoice expiry (RFC 3339) from the provider checkout.
+const rawInvoiceExpiry = (
+  checkout: Record<string, unknown>,
+): string | undefined =>
+  optionalString(nestedUnknown(checkout, ['invoice', 'expiresAt'])) ??
+  optionalString(nestedUnknown(checkout, ['invoice', 'expiry'])) ??
+  optionalString(checkout.expiresAt)
+
+// Build a `MintLightningInvoice` from a `create_checkout` POST transport. The
+// checkout is created in `amount` mode with `currency: 'SAT'` for the requested
+// sats; the issuer reads the RAW bolt11 + paymentHash and surface-validates them
+// (fail-closed). The preimage is NEVER touched here.
+export const makeMdkLightningInvoiceIssuer = (
+  post: MdkRoutePost,
+): MintLightningInvoice => input =>
+  Effect.gen(function* () {
+    const amountSats = Math.max(1, Math.trunc(input.amountSats))
+    const result = yield* Effect.tryPromise({
+      catch: () => new LightningInvoiceError('provider_unavailable'),
+      try: () =>
+        post({
+          handler: 'create_checkout',
+          params: {
+            amount: amountSats,
+            currency: 'SAT',
+            metadata: { correlation_ref: input.correlationRef },
+            title: 'openagents_khala_mpp_lightning',
+            type: 'AMOUNT',
+          },
+        }),
+    })
+    if (!result.ok) {
+      return yield* Effect.fail(
+        new LightningInvoiceError(
+          result.status >= 500 ? 'provider_unavailable' : 'provider_rejected',
+        ),
+      )
+    }
+
+    const checkout = providerCheckout(result.payload)
+    if (checkout === undefined) {
+      return yield* Effect.fail(
+        new LightningInvoiceError('provider_rejected'),
+      )
+    }
+
+    const invoice: LightningInvoice | undefined = validateLightningInvoice({
+      bolt11: rawBolt11(checkout),
+      ...(rawInvoiceExpiry(checkout) === undefined
+        ? {}
+        : { invoiceExpiresAt: rawInvoiceExpiry(checkout) }),
+      paymentHash: rawPaymentHash(checkout),
+    })
+    if (invoice === undefined) {
+      return yield* Effect.fail(
+        new LightningInvoiceError('malformed_invoice'),
+      )
+    }
+    return invoice
+  })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  networkFromBolt11,
+  validateLightningInvoice,
+} from './mpp-lightning-invoice'
+
+const HASH =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff'
+const MAINNET_INVOICE = `lnbc100n1p${'a'.repeat(40)}`
+const REGTEST_INVOICE = `lnbcrt100n1p${'a'.repeat(40)}`
+const SIGNET_INVOICE = `lntbs100n1p${'a'.repeat(40)}`
+
+describe('networkFromBolt11', () => {
+  test('reads the network from the BOLT11 human-readable prefix', () => {
+    expect(networkFromBolt11(MAINNET_INVOICE)).toBe('mainnet')
+    expect(networkFromBolt11(REGTEST_INVOICE)).toBe('regtest')
+    expect(networkFromBolt11(SIGNET_INVOICE)).toBe('signet')
+    expect(networkFromBolt11('notaninvoice')).toBeUndefined()
+  })
+})
+
+describe('validateLightningInvoice (surface validation, fail-closed)', () => {
+  test('accepts a well-formed mainnet invoice + 64-hex paymentHash', () => {
+    const invoice = validateLightningInvoice({
+      bolt11: MAINNET_INVOICE,
+      paymentHash: HASH,
+    })
+    expect(invoice).toBeDefined()
+    expect(invoice?.network).toBe('mainnet')
+    expect(invoice?.paymentHash).toBe(HASH)
+    expect(invoice?.bolt11).toBe(MAINNET_INVOICE)
+  })
+
+  test('normalizes invoice expiry to ISO when present', () => {
+    const invoice = validateLightningInvoice({
+      bolt11: MAINNET_INVOICE,
+      invoiceExpiresAt: '2099-01-15T12:05:00Z',
+      paymentHash: HASH,
+    })
+    expect(invoice?.invoiceExpiresAt).toBe('2099-01-15T12:05:00.000Z')
+  })
+
+  test('rejects a non-bolt11 string', () => {
+    expect(
+      validateLightningInvoice({ bolt11: 'http://evil', paymentHash: HASH }),
+    ).toBeUndefined()
+    expect(
+      validateLightningInvoice({ bolt11: 123, paymentHash: HASH }),
+    ).toBeUndefined()
+  })
+
+  test('rejects a malformed / wrong-length paymentHash', () => {
+    expect(
+      validateLightningInvoice({ bolt11: MAINNET_INVOICE, paymentHash: 'short' }),
+    ).toBeUndefined()
+    expect(
+      validateLightningInvoice({ bolt11: MAINNET_INVOICE, paymentHash: 999 }),
+    ).toBeUndefined()
+  })
+
+  test('lowercases an uppercase paymentHash so it always stores lowercase hex', () => {
+    const invoice = validateLightningInvoice({
+      bolt11: MAINNET_INVOICE,
+      paymentHash: HASH.toUpperCase(),
+    })
+    expect(invoice?.paymentHash).toBe(HASH)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice.ts
@@ -1,0 +1,137 @@
+// Lightning rail BOLT11 invoice issuer for the MPP / Payment-Auth endpoint
+// (EPIC #6049, Lightning charge intent — draft-lightning-charge-00).
+//
+// THE FEASIBILITY: the Worker already mints BOLT11 invoices through the
+// self-hosted mdkd sidecar (the `MDK_SIDECAR` Durable Object container) — the
+// SAME path the Forum L402 flow uses (`fetchMdkSidecarRequest` +
+// `create_checkout`). The Lightning charge protocol needs the RAW bolt11
+// invoice string and RAW paymentHash to build the 402 challenge, and it
+// verifies the preimage LOCALLY with WebCrypto (sha256), so no node call is
+// needed at verification time. The public hosted-mdk client
+// (`hosted-mdk-client.ts`) deliberately REDACTS bolt11/paymentHash for public
+// projection surfaces; this module is a server-internal issuer that reads the
+// raw invoice fields, which is correct: the bolt11 invoice and its paymentHash
+// are PUBLIC (they go into the 402 challenge the client must pay); only the
+// PREIMAGE is the bearer secret, and the preimage never touches this module.
+//
+// INERT NOTE: the Lightning rail only calls this when KHALA_MPP_LIGHTNING_ENABLED
+// is on AND a working MDK sidecar/route is configured. With either absent the
+// rail is not advertised and never issues a challenge.
+
+import { Effect } from 'effect'
+
+import { normalizeIsoTimestamp } from '../../runtime-primitives'
+
+// A minted BOLT11 invoice for N sats. All fields are PUBLIC (the invoice + its
+// payment hash are what the client pays). The preimage is NEVER here.
+export type LightningInvoice = Readonly<{
+  // The full BOLT11-encoded payment request string (e.g. "lnbc100n1...").
+  bolt11: string
+  // The payment hash embedded in the invoice, lowercase hex (64 chars).
+  paymentHash: string
+  // The Lightning network the invoice is on, per the BOLT11 prefix.
+  network: 'mainnet' | 'regtest' | 'signet'
+  // RFC 3339 expiry derived from the invoice's BOLT11 expiry, when the provider
+  // reports it. The challenge expiry is the EARLIER of this and the challenge
+  // TTL (spec §"Challenge Expiry and Invoice Expiry").
+  invoiceExpiresAt?: string | undefined
+}>
+
+export type LightningInvoiceFailure =
+  | 'not_configured' // no sidecar/route wired (rail should not have been offered)
+  | 'provider_unavailable' // the sidecar/route call failed
+  | 'provider_rejected' // the provider returned a non-invoice / malformed payload
+  | 'malformed_invoice' // the returned bolt11/paymentHash did not validate
+
+export class LightningInvoiceError extends Error {
+  override readonly name = 'LightningInvoiceError'
+  readonly reason: LightningInvoiceFailure
+  constructor(reason: LightningInvoiceFailure) {
+    super(`lightning invoice issuance failed: ${reason}`)
+    this.reason = reason
+  }
+}
+
+// The injectable issuer seam. The pure MPP protocol + route code depends on
+// this function (mirrors the existing `fetch?: StripeFetch` seam); index.ts
+// wires the real sidecar-backed implementation; tests inject a fake.
+export type MintLightningInvoice = (
+  input: Readonly<{
+    amountSats: number
+    description: string
+    // A public-safe correlation ref (the model + a request nonce) for the
+    // provider's invoice memo/metadata. NEVER carries secret material.
+    correlationRef: string
+  }>,
+) => Effect.Effect<LightningInvoice, LightningInvoiceError>
+
+// ---- BOLT11 surface validation (no full decode; we trust the issuer) ----
+
+// Lowercase-hex 32-byte payment hash.
+const PAYMENT_HASH_PATTERN = /^[0-9a-f]{64}$/
+// BOLT11 human-readable prefix + bech32 body. We only need the prefix to read
+// the network and a sanity check on the body; we never decode the amount here
+// (the provider issued it for the amount we requested; the client decodes and
+// verifies the invoice independently before paying, per the spec).
+const BOLT11_PATTERN = /^(lnbc|lntb|lntbs|lnbcrt)[0-9a-z]+$/i
+
+// Read the Lightning network from the BOLT11 human-readable prefix.
+//   lnbc  -> mainnet
+//   lntb  -> signet (testnet HRP; treated as signet for our networks set)
+//   lntbs -> signet
+//   lnbcrt-> regtest
+export const networkFromBolt11 = (
+  bolt11: string,
+): LightningInvoice['network'] | undefined => {
+  const lower = bolt11.toLowerCase()
+  if (lower.startsWith('lnbcrt')) {
+    return 'regtest'
+  }
+  if (lower.startsWith('lntbs') || lower.startsWith('lntb')) {
+    return 'signet'
+  }
+  if (lower.startsWith('lnbc')) {
+    return 'mainnet'
+  }
+  return undefined
+}
+
+// Validate a freshly-issued invoice's surface (shape only). Returns the typed
+// invoice or undefined when malformed (the caller fails closed).
+export const validateLightningInvoice = (
+  input: Readonly<{
+    bolt11: unknown
+    paymentHash: unknown
+    invoiceExpiresAt?: unknown
+  }>,
+): LightningInvoice | undefined => {
+  if (
+    typeof input.bolt11 !== 'string' ||
+    !BOLT11_PATTERN.test(input.bolt11.trim())
+  ) {
+    return undefined
+  }
+  const bolt11 = input.bolt11.trim()
+  const paymentHash =
+    typeof input.paymentHash === 'string'
+      ? input.paymentHash.trim().toLowerCase()
+      : undefined
+  if (paymentHash === undefined || !PAYMENT_HASH_PATTERN.test(paymentHash)) {
+    return undefined
+  }
+  const network = networkFromBolt11(bolt11)
+  if (network === undefined) {
+    return undefined
+  }
+  const invoiceExpiresAt =
+    typeof input.invoiceExpiresAt === 'string' &&
+    !Number.isNaN(Date.parse(input.invoiceExpiresAt))
+      ? normalizeIsoTimestamp(input.invoiceExpiresAt)
+      : undefined
+  return {
+    bolt11,
+    network,
+    paymentHash,
+    ...(invoiceExpiresAt === undefined ? {} : { invoiceExpiresAt }),
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-replay.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-replay.test.ts
@@ -1,0 +1,90 @@
+import { DatabaseSync } from 'node:sqlite'
+
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { claimLightningPaymentHash } from './mpp-lightning-replay'
+
+const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
+  Effect.runPromise(effect as Effect.Effect<A, never>)
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+  async run(): Promise<{ meta: { changes: number } }> {
+    const info = this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { meta: { changes: Number(info.changes ?? 0) } }
+  }
+}
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+}
+
+const makeDb = (): D1Database => {
+  const raw = new DatabaseSync(':memory:')
+  raw.exec(`
+    CREATE TABLE mpp_lightning_replay (
+      payment_hash TEXT PRIMARY KEY,
+      challenge_id TEXT NOT NULL,
+      consumed_at TEXT NOT NULL
+    );
+  `)
+  return new SqliteD1(raw) as unknown as D1Database
+}
+
+const HASH =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff'
+
+describe('claimLightningPaymentHash (consume-once)', () => {
+  test('first claim succeeds (true); second claim is a replay (false)', async () => {
+    const db = makeDb()
+    const first = await run(
+      claimLightningPaymentHash(db, { challengeId: 'c1', paymentHash: HASH }),
+    )
+    expect(first).toBe(true)
+    const second = await run(
+      claimLightningPaymentHash(db, { challengeId: 'c1', paymentHash: HASH }),
+    )
+    expect(second).toBe(false)
+  })
+
+  test('a replay under a DIFFERENT challenge id is still refused (paymentHash keyed)', async () => {
+    const db = makeDb()
+    expect(
+      await run(
+        claimLightningPaymentHash(db, { challengeId: 'c1', paymentHash: HASH }),
+      ),
+    ).toBe(true)
+    expect(
+      await run(
+        claimLightningPaymentHash(db, { challengeId: 'c2', paymentHash: HASH }),
+      ),
+    ).toBe(false)
+  })
+
+  test('distinct paymentHashes each claim independently', async () => {
+    const db = makeDb()
+    const other =
+      'ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100'
+    expect(
+      await run(
+        claimLightningPaymentHash(db, { challengeId: 'c1', paymentHash: HASH }),
+      ),
+    ).toBe(true)
+    expect(
+      await run(
+        claimLightningPaymentHash(db, { challengeId: 'c1', paymentHash: other }),
+      ),
+    ).toBe(true)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-replay.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-replay.ts
@@ -1,0 +1,58 @@
+// Lightning charge consume-once guard (EPIC #6049,
+// draft-lightning-charge-00 §"Settlement Procedure" + §"Preimage
+// Confidentiality"). Mirrors the SPT replay guard (`mpp-spt-replay.ts`).
+//
+// The Lightning spec requires ATOMIC consume-once: a challenge marked consumed
+// MUST NOT be accepted again, and concurrent requests presenting the same valid
+// preimage MUST result in exactly ONE success. We claim the paymentHash BEFORE
+// serving: a second attempt collides on the PRIMARY KEY and is refused, so a
+// preimage that has already paid for one served completion cannot be replayed
+// for a second free completion.
+//
+// We key on the paymentHash (the public payment identifier), NOT the preimage
+// (a bearer secret which must never be persisted — spec §"Preimage
+// Confidentiality"). The challenge id is recorded alongside for audit binding.
+//
+// INERT NOTE: only the Lightning rail touches this table; it is never written
+// unless the Lightning rail is armed and a real preimage verified.
+
+import { Effect } from 'effect'
+
+import { currentIsoTimestamp } from '../../runtime-primitives'
+
+export class MppLightningReplayError extends Error {
+  override readonly name = 'MppLightningReplayError'
+  override readonly cause: unknown
+  constructor(cause: unknown) {
+    super('mpp lightning replay store failure')
+    this.cause = cause
+  }
+}
+
+// Atomically claim a paymentHash for one challenge. Returns true when this is
+// the FIRST use (the row was inserted) and false when the paymentHash was
+// already consumed (replay rejected). `INSERT ... ON CONFLICT DO NOTHING` + a
+// changes check makes the claim a single atomic D1 statement.
+export const claimLightningPaymentHash = (
+  db: D1Database,
+  input: Readonly<{ paymentHash: string; challengeId: string }>,
+  nowIso: () => string = currentIsoTimestamp,
+): Effect.Effect<boolean, MppLightningReplayError> =>
+  Effect.tryPromise({
+    catch: (cause: unknown) => new MppLightningReplayError(cause),
+    try: async () => {
+      const result = await db
+        .prepare(
+          `INSERT INTO mpp_lightning_replay (payment_hash, challenge_id, consumed_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT (payment_hash) DO NOTHING`,
+        )
+        .bind(input.paymentHash, input.challengeId, nowIso())
+        .run()
+      // D1 surfaces affected rows under meta.changes; 0 means the paymentHash
+      // was already present (replay).
+      const changes =
+        (result as unknown as { meta?: { changes?: number } }).meta?.changes
+      return changes === undefined ? true : changes > 0
+    },
+  })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-verify.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-verify.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  preimageHexToBytes,
+  readPreimage,
+  sha256Hex,
+  verifyLightningPreimage,
+} from './mpp-lightning-verify'
+
+// Build a (preimage, paymentHash) pair: paymentHash = sha256(preimage bytes).
+const pairFor = async (preimageHex: string): Promise<string> => {
+  const bytes = preimageHexToBytes(preimageHex)!
+  return sha256Hex(bytes)
+}
+
+const PREIMAGE_A =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff'
+const PREIMAGE_B =
+  'ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100'
+
+describe('verifyLightningPreimage (draft-lightning-charge-00 §Verification)', () => {
+  test('a correct preimage whose sha256 equals the paymentHash verifies', async () => {
+    const paymentHash = await pairFor(PREIMAGE_A)
+    expect(await verifyLightningPreimage(PREIMAGE_A, paymentHash)).toEqual({
+      ok: true,
+    })
+  })
+
+  test('a different (wrong) preimage is rejected as a mismatch', async () => {
+    const paymentHash = await pairFor(PREIMAGE_A)
+    const result = await verifyLightningPreimage(PREIMAGE_B, paymentHash)
+    expect(result).toEqual({ ok: false, reason: 'mismatch' })
+  })
+
+  test('a non-hex / wrong-length / non-string preimage is malformed', async () => {
+    const paymentHash = await pairFor(PREIMAGE_A)
+    expect(await verifyLightningPreimage('not-hex', paymentHash)).toEqual({
+      ok: false,
+      reason: 'malformed',
+    })
+    // too short (63 chars)
+    expect(
+      await verifyLightningPreimage('a'.repeat(63), paymentHash),
+    ).toEqual({ ok: false, reason: 'malformed' })
+    // uppercase hex is not accepted (spec: lowercase hex)
+    expect(
+      await verifyLightningPreimage(PREIMAGE_A.toUpperCase(), paymentHash),
+    ).toEqual({ ok: false, reason: 'malformed' })
+    expect(await verifyLightningPreimage(undefined, paymentHash)).toEqual({
+      ok: false,
+      reason: 'malformed',
+    })
+    expect(await verifyLightningPreimage(123, paymentHash)).toEqual({
+      ok: false,
+      reason: 'malformed',
+    })
+  })
+
+  test('a malformed expected paymentHash never verifies', async () => {
+    expect(await verifyLightningPreimage(PREIMAGE_A, 'short')).toEqual({
+      ok: false,
+      reason: 'malformed',
+    })
+  })
+
+  test('readPreimage returns the string field or undefined (fail-closed)', () => {
+    expect(readPreimage({ preimage: PREIMAGE_A })).toBe(PREIMAGE_A)
+    expect(readPreimage({ preimage: 123 })).toBeUndefined()
+    expect(readPreimage({})).toBeUndefined()
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-verify.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-verify.ts
@@ -1,0 +1,103 @@
+// Lightning charge LOCAL preimage verification (EPIC #6049,
+// draft-lightning-charge-00 §Verification). PURE crypto; no IO, no node call.
+//
+// The Lightning settlement proof is the payment PREIMAGE: a 32-byte secret
+// whose SHA-256 equals the invoice's paymentHash. The server verifies payment
+// WITHOUT contacting the Lightning node by computing
+// sha256(hex_to_bytes(preimage)) and comparing it to the stored paymentHash.
+//
+// SECURITY (spec §"Preimage Confidentiality"): the preimage is a BEARER SECRET.
+// This module accepts it, hashes it, and discards it. It MUST NEVER be logged,
+// persisted, returned, or placed in an error. The receipt `reference` is the
+// paymentHash (public), NEVER the preimage.
+
+// A 32-byte lowercase-hex preimage (64 hex chars).
+const PREIMAGE_PATTERN = /^[0-9a-f]{64}$/
+const PAYMENT_HASH_PATTERN = /^[0-9a-f]{64}$/
+
+// Decode a 64-char lowercase-hex string to its 32 raw bytes. Returns undefined
+// for any non-hex / wrong-length input (fail-closed).
+const hexToBytes = (hex: string): Uint8Array | undefined => {
+  if (hex.length % 2 !== 0) {
+    return undefined
+  }
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < bytes.length; i += 1) {
+    const byte = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+    if (Number.isNaN(byte)) {
+      return undefined
+    }
+    bytes[i] = byte
+  }
+  return bytes
+}
+
+const bytesToHex = (bytes: Uint8Array): string => {
+  let hex = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    hex += bytes[i]!.toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
+// Constant-time hex-string comparison (both are fixed 64-char lowercase hex).
+const constantTimeHexEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) {
+    return false
+  }
+  let diff = 0
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}
+
+export type LightningPreimageResult =
+  | Readonly<{ ok: true }>
+  // `malformed` = the preimage is absent/not a 64-hex string (spec
+  // malformed-credential); `mismatch` = sha256(preimage) != paymentHash (spec
+  // invalid-preimage).
+  | Readonly<{ ok: false; reason: 'malformed' | 'mismatch' }>
+
+// Verify a Lightning payment preimage against a stored paymentHash, FAIL-CLOSED.
+// Computes sha256(hex_to_bytes(preimage)) and constant-time compares to the
+// expected paymentHash. The preimage value is never returned or thrown.
+export const verifyLightningPreimage = async (
+  preimage: unknown,
+  expectedPaymentHash: string,
+): Promise<LightningPreimageResult> => {
+  if (
+    typeof preimage !== 'string' ||
+    !PREIMAGE_PATTERN.test(preimage) ||
+    !PAYMENT_HASH_PATTERN.test(expectedPaymentHash)
+  ) {
+    return { ok: false, reason: 'malformed' }
+  }
+  const bytes = hexToBytes(preimage)
+  if (bytes === undefined) {
+    return { ok: false, reason: 'malformed' }
+  }
+  const digest = await crypto.subtle.digest('SHA-256', bytes as BufferSource)
+  const computed = bytesToHex(new Uint8Array(digest))
+  return constantTimeHexEqual(computed, expectedPaymentHash)
+    ? { ok: true }
+    : { ok: false, reason: 'mismatch' }
+}
+
+// Read the `preimage` field from a credential payload as a typed string. Used so
+// the route never passes a non-string into the verifier. PURE.
+export const readPreimage = (
+  payload: Record<string, unknown>,
+): string | undefined => {
+  const value = payload.preimage
+  return typeof value === 'string' ? value : undefined
+}
+
+// SHA-256 of arbitrary bytes as lowercase hex — exported only for tests that
+// construct a (preimage, paymentHash) pair without re-implementing the hash.
+export const sha256Hex = async (bytes: Uint8Array): Promise<string> => {
+  const digest = await crypto.subtle.digest('SHA-256', bytes as BufferSource)
+  return bytesToHex(new Uint8Array(digest))
+}
+
+export const preimageHexToBytes = hexToBytes

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-pricing.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-pricing.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'vitest'
 
 import { KHALA_MINI_MODEL_ID } from '../pricing'
-import { MPP_MIN_USDC, SPT_MIN_USD, quoteMppCall } from './mpp-pricing'
+import {
+  LIGHTNING_MIN_SATS,
+  MPP_MIN_USDC,
+  SPT_MIN_USD,
+  quoteMppCall,
+  quoteMppLightningCall,
+} from './mpp-pricing'
 
 describe('mpp per-call pricing', () => {
   test('quotes a crypto call for khala-mini at or above the 0.01 USDC floor', () => {
@@ -49,5 +55,45 @@ describe('mpp per-call pricing', () => {
       rail: 'crypto',
     })
     expect(large.priceUsd).toBeGreaterThan(small.priceUsd)
+  })
+
+  test('the Lightning rail quotes a positive integer SAT amount at/above the floor', () => {
+    const quote = quoteMppLightningCall({ model: KHALA_MINI_MODEL_ID })
+    expect(quote.amountSats).toBeGreaterThanOrEqual(LIGHTNING_MIN_SATS)
+    expect(Number.isInteger(quote.amountSats)).toBe(true)
+    expect(quote.priceUsd).toBeGreaterThan(0)
+  })
+
+  test('the Lightning rail prices at the BITCOIN funding rate (cheaper than card)', () => {
+    // Lightning settles real Bitcoin, so it earns the Bitcoin funding discount
+    // and is the cheapest rail for the same representative call (owner
+    // Bitcoin-first). Compare the pre-conversion USD on a pricier model so the
+    // floors do not mask the discount.
+    const lightning = quoteMppLightningCall({
+      completionTokens: 5000,
+      model: 'openagents/khala-code',
+      promptTokens: 5000,
+    })
+    const card = quoteMppCall({
+      completionTokens: 5000,
+      model: 'openagents/khala-code',
+      promptTokens: 5000,
+      rail: 'card',
+    })
+    expect(lightning.priceUsd).toBeLessThan(card.priceUsd)
+  })
+
+  test('a pricier model quotes more sats than a cheap one (monotonic in usage)', () => {
+    const small = quoteMppLightningCall({
+      completionTokens: 100,
+      model: 'openagents/khala-code',
+      promptTokens: 100,
+    })
+    const large = quoteMppLightningCall({
+      completionTokens: 200_000,
+      model: 'openagents/khala-code',
+      promptTokens: 200_000,
+    })
+    expect(large.amountSats).toBeGreaterThan(small.amountSats)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-pricing.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-pricing.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_MARGIN,
   priceRequest,
 } from '../pricing'
+import { usdToSatsCeil } from '../usd-msat-conversion'
 
 // MPP / Stripe microtransaction floor: individual charges can be as low as
 // 0.01 USDC (Stripe machine-payments docs). We never quote below this.
@@ -28,6 +29,11 @@ export const MPP_MIN_USDC = 0.01
 // (Stripe MPP docs). Used for the card challenge floor only; crypto uses
 // MPP_MIN_USDC.
 export const SPT_MIN_USD = 0.5
+
+// Lightning microtransaction floor in SATS. Lightning settles real Bitcoin and
+// supports true micropayments, so the floor is 1 sat (an invoice must be a
+// positive integer number of sats). This is a sat-native floor, not a USD one.
+export const LIGHTNING_MIN_SATS = 1
 
 // Representative per-call token budget used to size the flat quote. A typical
 // single-turn Khala call is on the order of a few hundred prompt tokens and a
@@ -98,5 +104,56 @@ export const quoteMppCall = (
     model: priced.model,
     priceUsd,
     rail: input.rail,
+  }
+}
+
+export type MppLightningQuote = Readonly<{
+  // The model the quote was priced against (canonical).
+  model: string
+  // The per-call price in SATS for the BOLT11 invoice. Always >= the sat floor.
+  amountSats: number
+  // The pre-conversion per-call price in USD (Bitcoin funding rate), retained
+  // for parity reporting/logging. NOT what the invoice is denominated in.
+  priceUsd: number
+}>
+
+// Derive the flat per-call Lightning quote for a model, in SATS. PURE. Lightning
+// settles REAL Bitcoin, so unlike the USDC/card rails it is priced at the
+// BITCOIN funding rate (it earns the Bitcoin funding discount — owner
+// Bitcoin-first priority), then converted to sats at the SAME single-source
+// BTC/USD rate the metering hook uses (`usdToSatsCeil`), and clamped to the
+// 1-sat invoice floor. The runtime 402 challenge re-quotes the requested model
+// and remains authoritative.
+export const quoteMppLightningCall = (
+  input: Readonly<{
+    model: string
+    margin?: number
+    promptTokens?: number
+    completionTokens?: number
+  }>,
+): MppLightningQuote => {
+  const priced = priceRequest({
+    fundingKind: 'bitcoin' as FundingKind,
+    margin: input.margin ?? DEFAULT_MARGIN,
+    model: input.model,
+    usage: {
+      completionTokens:
+        input.completionTokens ?? REPRESENTATIVE_COMPLETION_TOKENS,
+      promptTokens: input.promptTokens ?? REPRESENTATIVE_PROMPT_TOKENS,
+      totalTokens:
+        (input.promptTokens ?? REPRESENTATIVE_PROMPT_TOKENS) +
+        (input.completionTokens ?? REPRESENTATIVE_COMPLETION_TOKENS),
+    },
+  })
+
+  const amountSats = Math.max(
+    LIGHTNING_MIN_SATS,
+    usdToSatsCeil(priced.chargeUsd),
+  )
+
+  return {
+    amountSats,
+    model: priced.model,
+    priceUsd: priced.chargeUsd,
   }
 }

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-protocol.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-protocol.ts
@@ -58,7 +58,15 @@ export type MppOpaque = Readonly<{
   amount?: string | undefined
   network?: string | undefined
   model?: string | undefined
-}>
+  // Lightning rail: the BOLT11 paymentHash (lowercase hex) we stash so the retry
+  // recovers the settlement target statelessly. PUBLIC (not the preimage). When
+  // present, the challenge is a Lightning charge.
+  ph?: string | undefined
+  // Lightning rail: the invoice's BOLT11 expiry (RFC 3339), so verification can
+  // enforce the EARLIER of challenge expiry and invoice expiry (spec
+  // §"Challenge Expiry and Invoice Expiry").
+  invExp?: string | undefined
+}>;
 
 // One accepted payment method on the 402 challenge (server-side shape before
 // HMAC id computation; the id is filled by buildChallengeHeader).
@@ -362,8 +370,11 @@ export const verifyCredential = async (
     allowedMethods: ReadonlyArray<string>
     // The currency we expect for the credential's method.
     expectedCurrencyForMethod: (method: string) => string
-    // The minimum amount in minor units we expect (>= floors a downward tamper).
-    expectedMinAmountCents: number
+    // The minimum amount in the METHOD'S native minor unit we expect (>= floors
+    // a downward tamper). A number applies to every method; a function lets a
+    // sat-native method (Lightning, currency "sat") floor in sats while the
+    // cent-native rails (USDC/card) floor in cents.
+    expectedMinAmountCents: number | ((method: string) => number)
     nowMs?: number | undefined
   }>,
 ): Promise<CredentialVerifyResult> => {
@@ -416,10 +427,11 @@ export const verifyCredential = async (
     return { ok: false, reason: 'request-mismatch' }
   }
   const amountCents = Number(amount)
-  if (
-    !Number.isFinite(amountCents) ||
-    amountCents < expectations.expectedMinAmountCents
-  ) {
+  const minAmount =
+    typeof expectations.expectedMinAmountCents === 'function'
+      ? expectations.expectedMinAmountCents(echoed.method)
+      : expectations.expectedMinAmountCents
+  if (!Number.isFinite(amountCents) || amountCents < minAmount) {
     return { ok: false, reason: 'request-mismatch' }
   }
   if (
@@ -477,8 +489,10 @@ const decodeOpaque = (opaqueB64: string): MppOpaque | undefined => {
   }
   return {
     amount: readString(record, 'amount'),
+    invExp: readString(record, 'invExp'),
     model: readString(record, 'model'),
     network: readString(record, 'network'),
+    ph: readString(record, 'ph'),
     pi: readString(record, 'pi'),
   }
 }

--- a/apps/openagents.com/workers/api/src/inference/usd-msat-conversion.ts
+++ b/apps/openagents.com/workers/api/src/inference/usd-msat-conversion.ts
@@ -40,6 +40,18 @@ export const usdToMsatCeil = (
   return Math.max(1, Math.ceil(msat - FLOAT_DUST))
 }
 
+// Convert a USD charge to integer SATOSHIS at a given BTC/USD rate, rounding UP
+// (1 sat = 1000 msat). Used by the Lightning MPP rail to size a BOLT11 invoice
+// in sats from the same per-call USD quote the other rails price against, at the
+// SAME single-source BTC/USD rate. A zero/negative/non-finite charge maps to 0.
+export const usdToSatsCeil = (
+  chargeUsd: number,
+  btcUsd: number = DEFAULT_BTC_USD,
+): number => {
+  const msat = usdToMsatCeil(chargeUsd, btcUsd)
+  return msat <= 0 ? 0 : Math.ceil(msat / 1000)
+}
+
 // Convert USD CENTS to integer msat, rounding DOWN so a credit grant never
 // over-credits the buyer beyond the dollars they actually paid (the grant must
 // be bounded by — and never exceed — the USD debited). A zero/negative/


### PR DESCRIPTION
Adds a **Lightning Network charge rail** (`draft-lightning-charge-00`) to the machine-payable Khala endpoint (`/mpp/v1/chat/completions`) and surfaces it **first / preferred** per owner Bitcoin-first priority. **Inert, fail-closed, flag-gated — nothing armed, no secrets, no deploy.**

## Feasibility (STEP 1)
The Worker can mint BOLT11 invoices via the existing **MDK sidecar** (`MDK_SIDECAR` Durable Object container, the `self_hosted_mdkd_sidecar` route). A `create_checkout` (amount mode, `SAT`) returns a checkout with a raw `invoice.bolt11` + `invoice.paymentHash` — the same path the Forum L402 flow already uses (`fetchMdkSidecarRequest`). Local preimage verification (`sha256(preimage)==paymentHash`, WebCrypto) needs **no node call**. The public `hosted-mdk-client.ts` *redacts* those fields for public projection; the new issuer is server-internal and reads them raw (invoice + paymentHash are public — they go in the 402; only the preimage is the bearer secret).

## What landed
- **`mpp-lightning-invoice.ts` / `-mdk.ts`** — BOLT11 issuer over the MDK route/sidecar; surface-validates the raw invoice + paymentHash; never touches the preimage.
- **`mpp-lightning-verify.ts`** — local fail-closed `sha256(preimage)==paymentHash`; preimage never logged/persisted/returned.
- **`mpp-lightning-replay.ts` + migration `0225`** — atomic per-paymentHash consume-once (mirrors the SPT guard).
- **Lightning-first ordering** — the `lightning` `WWW-Authenticate: Payment` challenge is emitted FIRST in the 402, then USDC (base/solana/tempo), then card; the discovery doc lists the Lightning offer FIRST in `x-payment-info.offers[]`. Gated on `KHALA_MPP_LIGHTNING_ENABLED` **and** a working MDK invoice issuer (honesty gate).
- **Pricing** — per-call sats via the single-source BTC/USD rate (`usdToSatsCeil`), priced at the **Bitcoin funding rate** (Lightning earns the Bitcoin discount → cheapest rail).
- **Settlement / RL-3** — real Bitcoin inbound mints a **Bitcoin-origin `lightning_charge`** pay-in into `balance_msat` only (NOT `usd_credit_msat`, unlike the USDC/card rails), idempotent per paymentHash; receipt `reference` = paymentHash. Migration `0226` adds the `lightning_charge` pay_in_type. Boundary documented in `INVARIANTS.md`.

## Arming (owner, later — NOT done here)
- `KHALA_MPP_LIGHTNING_ENABLED=1` (Worker var) **and** the existing `KHALA_MPP_ENABLED=1` + `KHALA_MPP_SIGNING_SECRET` + `STRIPE_API_KEY` (the endpoint's existing gates) **and** a configured MDK route (`MDK_CHECKOUT_ROUTE_URL` + `MDK_CHECKOUT_ROUTE_SECRET`/`MDK_ACCESS_TOKEN`, or the live `MDK_SIDECAR`). With any absent the Lightning rail is not advertised.

## Tests / checks
Thorough unit coverage: preimage→paymentHash verify, tampered/expired/replay/invalid-preimage rejection, Lightning-first offer ordering, inert when flag off / honesty gate when no issuer, Bitcoin-origin credit + idempotency, MDK issuer SAT create_checkout + failure mapping. `bun run typecheck:api` and `bun run check:deploy` are green (the `check-contract-drift.test.ts` `.worktrees/` stdout quirk is the known false-fail; the test file passes 5/5 and check:deploy exits 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)