### PR TITLE
Autopilot onboarding: /autopilot/legal industry overlay (legal-only config)

### DIFF
--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.test.ts
@@ -27,9 +27,17 @@ import {
 import {
   HUD_COMPONENT_ITEM_ATTR,
   HUD_COMPOSER_ATTR,
+  HUD_LEGAL_OVERLAY_ATTR,
+  HUD_LEGAL_STAT_STRIP_ATTR,
+  HUD_LEGAL_VSL_ATTR,
   HUD_ROOT_ATTR,
+  LEGAL_VERIFIED_STATS,
   overlayView,
 } from './page'
+import {
+  LEGAL_VERTICAL_OVERLAY,
+  verticalOverlayForSegment,
+} from './vertical-overlay'
 
 // A minimal Snabbdom-style vnode walker so the test can assert rendered markup
 // without a DOM. Mirrors the existing scene/route tests.
@@ -339,9 +347,21 @@ describe('autopilot onboarding — turn loop (via the loggedOut update)', () => 
       base,
       UpdatedAutopilotOnboardingComposer({ value: 'Help with an NDA' }),
     )
-    const [submitted] = update(typed, SubmittedAutopilotOnboardingTurn())
+    const [submitted, commands] = update(
+      typed,
+      SubmittedAutopilotOnboardingTurn(),
+    )
     // The verticalOverlay is threaded to the program command on the first turn.
     expect(flowOf(submitted).vertical).toBe('legal')
+    // The command carries the legal SYSTEM-PROMPT OVERLAY text (not the raw
+    // `legal` segment) so the program's vertical-overlay slot gets real guidance.
+    const turnCommand = commands.find(
+      command => command.name === 'SubmitAutopilotOnboardingTurn',
+    )
+    expect(turnCommand).toBeDefined()
+    expect(turnCommand?.args).toMatchObject({
+      verticalOverlay: LEGAL_VERTICAL_OVERLAY,
+    })
 
     // Simulate the command's failure terminal.
     const [failed] = update(
@@ -356,5 +376,69 @@ describe('autopilot onboarding — turn loop (via the loggedOut update)', () => 
     expect(flow.transcript).toEqual([
       { role: 'user', content: 'Help with an NDA' },
     ])
+  })
+})
+
+describe('autopilot onboarding — legal vertical overlay (#6130)', () => {
+  test('maps the legal segment to the legal system-prompt overlay; everything else to null', () => {
+    expect(verticalOverlayForSegment('legal')).toBe(LEGAL_VERTICAL_OVERLAY)
+    expect(verticalOverlayForSegment(null)).toBeNull()
+    expect(verticalOverlayForSegment('health')).toBeNull()
+    expect(verticalOverlayForSegment('LEGAL')).toBeNull()
+  })
+
+  test('the legal overlay leads with control + provability and bars "AI lawyer" / case-law framing', () => {
+    // Lead with control + provability, attorney-in-the-loop, source-linked.
+    expect(LEGAL_VERTICAL_OVERLAY).toContain('CONTROL and PROVABILITY')
+    expect(LEGAL_VERTICAL_OVERLAY).toContain('Attorney-in-the-loop')
+    expect(LEGAL_VERTICAL_OVERLAY).toContain('human-review gate')
+    // Explicitly NOT an AI lawyer and NOT case-law research.
+    expect(LEGAL_VERTICAL_OVERLAY).toContain('NOT an "AI lawyer"')
+    expect(LEGAL_VERTICAL_OVERLAY).toContain('NOT do case-law research')
+    // Carries no client/brand/scarcity/projection material.
+    expect(LEGAL_VERTICAL_OVERLAY).not.toMatch(/\$\d|slots?|3×|80%|N of/i)
+  })
+
+  test('legal vertical renders the legal overlay: VSL slot, intro, and verified stat strip', () => {
+    const markup = renderHtml(
+      overlayView(initFlowModel(Option.some('legal')), stubActions),
+    )
+    expect(markup).toContain(`data-${HUD_LEGAL_OVERLAY_ATTR}`)
+    expect(markup).toContain(`data-${HUD_LEGAL_VSL_ATTR}`)
+    expect(markup).toContain(`data-${HUD_LEGAL_STAT_STRIP_ATTR}`)
+    // Legal intro framing: control, review gate, no AI-lawyer/case-law claim.
+    expect(markup).toContain('Stay in expert review mode')
+    expect(markup).toContain('Not an AI lawyer, not case-law research.')
+    // Every stat figure carries its primary-source citation label (the openable
+    // link href is a DOM prop; the lightweight walker serializes the citation
+    // text, which is what proves the figure traces to a primary source).
+    expect(markup).toContain('69%')
+    expect(markup).toContain('8am 2026 Legal Industry Report (n=1,395)')
+    expect(markup).toContain('ABA Formal Opinion 512 (July 29, 2024)')
+    // No scarcity, projection, or unproven outcome numbers on this page.
+    expect(markup).not.toMatch(/N of \d|\b3×\b|\$\d+k|80% faster/i)
+  })
+
+  test('every legal stat carries a non-empty figure, label, and a primary-source citation with a real URL', () => {
+    expect(LEGAL_VERIFIED_STATS.length).toBeGreaterThan(0)
+    LEGAL_VERIFIED_STATS.forEach(stat => {
+      expect(stat.value.trim()).not.toBe('')
+      expect(stat.label.trim()).not.toBe('')
+      expect(stat.source.trim()).not.toBe('')
+      // The citation must be an openable primary source (8am report or ABA PDF).
+      expect(stat.sourceUrl).toMatch(/^https:\/\//)
+      expect(stat.sourceUrl).toMatch(/8am\.com|americanbar\.org/)
+    })
+  })
+
+  test('the generic /autopilot path shows NO legal-only content', () => {
+    const markup = renderHtml(
+      overlayView(initFlowModel(Option.none()), stubActions),
+    )
+    expect(markup).not.toContain(`data-${HUD_LEGAL_OVERLAY_ATTR}`)
+    expect(markup).not.toContain(`data-${HUD_LEGAL_VSL_ATTR}`)
+    expect(markup).not.toContain(`data-${HUD_LEGAL_STAT_STRIP_ATTR}`)
+    expect(markup).not.toContain('ABA Formal Opinion 512')
+    expect(markup).not.toContain('Stay in expert review mode')
   })
 })

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/page.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/page.ts
@@ -41,6 +41,11 @@ export const HUD_TRANSCRIPT_ATTR = 'autopilot-onboarding-transcript'
 export const HUD_COMPONENTS_ATTR = 'autopilot-onboarding-components'
 export const HUD_COMPOSER_ATTR = 'autopilot-onboarding-composer'
 export const HUD_COMPONENT_ITEM_ATTR = 'autopilot-onboarding-component'
+// The legal vertical overlay surfaces (VSL slot + verified stat strip). Present
+// only on `/autopilot/legal`; absent on the generic `/autopilot` flow.
+export const HUD_LEGAL_OVERLAY_ATTR = 'autopilot-onboarding-legal-overlay'
+export const HUD_LEGAL_VSL_ATTR = 'autopilot-onboarding-legal-vsl'
+export const HUD_LEGAL_STAT_STRIP_ATTR = 'autopilot-onboarding-legal-stats'
 
 // The message hooks the page needs. Threading these in (rather than importing a
 // concrete page `Message`) keeps this view decoupled and unit-testable: the
@@ -57,6 +62,185 @@ const introForVertical = (vertical: string | null): string =>
   vertical === 'legal'
     ? 'Describe your legal work. Autopilot scopes it, shows you a quick win, and keeps a review gate before anything is sent — no client-identifying detail leaves without your consent.'
     : 'Describe what you want done. Autopilot scopes the work, shows you a quick win, and keeps a human-review gate before anything ships.'
+
+// LEGAL VERTICAL OVERLAY ---------------------------------------------------
+
+// A single VERIFIED stat for the legal stat strip. Every figure here traces to a
+// primary source the reader can open and check; the citation travels with the
+// figure (issue #6130 hard constraint). Figures are drawn ONLY from the
+// re-authenticated legal data sheet's "verified-to-primary-source" set
+// (docs/blitz/lawpilot/source/DATA_SHEET.md + VERIFICATION_LEDGER.md). Removed or
+// unverified figures are intentionally excluded; nothing here is a scarcity claim
+// or an outcome projection.
+export type LegalVerifiedStat = Readonly<{
+  value: string
+  label: string
+  source: string
+  sourceUrl: string
+}>
+
+export const LEGAL_VERIFIED_STATS: ReadonlyArray<LegalVerifiedStat> = [
+  {
+    value: '69%',
+    label:
+      'of legal professionals now use generative AI for work — more than double a year earlier.',
+    source: '8am 2026 Legal Industry Report (n=1,395)',
+    sourceUrl: 'https://www.8am.com/reports/legal-industry-report-2026/',
+  },
+  {
+    value: '9%',
+    label:
+      'of firms have an actively enforced written AI policy; 43% have none and no plans to create one.',
+    source: '8am 2026 Legal Industry Report',
+    sourceUrl: 'https://www.8am.com/reports/legal-industry-report-2026/',
+  },
+  {
+    value: 'ABA Op. 512',
+    label:
+      'requires understanding an AI tool and obtaining informed client consent before inputting client information.',
+    source: 'ABA Formal Opinion 512 (July 29, 2024)',
+    sourceUrl:
+      'https://www.americanbar.org/content/dam/aba/administrative/professional_responsibility/ethics-opinions/aba-formal-opinion-512.pdf',
+  },
+]
+
+// Legal-flavored starter prompts kept generic (no client/brand/person material):
+// bounded, template-driven, verifiable first moments per the legal MVP shape.
+const LEGAL_STARTER_PROMPTS: ReadonlyArray<string> = [
+  'Prepare a draft NDA prep packet for a routine vendor conversation.',
+  'Find a fitting formation/intake template and list the missing facts.',
+  'Build a lawyer-review checklist for a routine document.',
+]
+
+// The legal-only overlay: the VSL slot (a placeholder embed region — no real
+// video asset is required for v1), a legal-specific framing line, a bounded set
+// of starter prompts, and the verified stat strip. Rendered ONLY for the `legal`
+// vertical; the generic `/autopilot` flow never sees it.
+const legalOverlaySection = <Message>(model: FlowModel): Html => {
+  const h = html<Message>()
+
+  if (model.vertical !== 'legal') {
+    return h.empty
+  }
+
+  return h.div(
+    [
+      h.DataAttribute(HUD_LEGAL_OVERLAY_ATTR, ''),
+      Ui.className<Message>(
+        'grid gap-4 border border-[#3a7bff]/20 bg-black/40 p-4',
+      ),
+    ],
+    [
+      h.div(
+        [Ui.className<Message>('grid gap-1.5')],
+        [
+          h.span([Ui.className<Message>(eyebrowClass)], ['For legal teams']),
+          h.p(
+            [
+              Ui.className<Message>(
+                'm-0 max-w-[60ch] text-[0.8125rem] leading-[1.5] text-white/65',
+              ),
+            ],
+            [
+              'Stay in expert review mode. You share only the source material you choose; Autopilot prepares a bounded, template-driven, source-linked work surface — a draft prep packet, intake questions, and a lawyer-review checklist — with an attorney-review gate before anything is sent. Not an AI lawyer, not case-law research.',
+            ],
+          ),
+        ],
+      ),
+      // VSL slot — a placeholder embed region. No real video asset is required
+      // for v1; the region reserves the space and is labelled so the asset can
+      // drop in later without a layout change.
+      h.div(
+        [
+          h.DataAttribute(HUD_LEGAL_VSL_ATTR, ''),
+          h.AriaLabel('Legal overview video'),
+          Ui.className<Message>(
+            'grid aspect-video place-items-center border border-[#222] bg-[#010102] text-center',
+          ),
+        ],
+        [
+          h.span(
+            [Ui.className<Message>('text-[0.75rem] text-white/45')],
+            ['Overview video — coming soon'],
+          ),
+        ],
+      ),
+      h.div(
+        [Ui.className<Message>('grid gap-2')],
+        [
+          h.span(
+            [Ui.className<Message>(eyebrowClass)],
+            ['Bounded first moves'],
+          ),
+          h.ul(
+            [Ui.className<Message>('m-0 grid list-none gap-1.5 p-0')],
+            LEGAL_STARTER_PROMPTS.map(prompt =>
+              h.li(
+                [
+                  Ui.className<Message>(
+                    'text-[0.8125rem] leading-[1.4] text-white/60',
+                  ),
+                ],
+                [prompt],
+              ),
+            ),
+          ),
+        ],
+      ),
+      legalStatStripView<Message>(),
+    ],
+  )
+}
+
+// The verified stat strip. A single strip of primary-sourced figures, each with
+// its citation as an openable link. No scarcity, no projections, no unproven
+// numbers — only figures the legal data sheet marks verified-to-primary-source.
+const legalStatStripView = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      h.DataAttribute(HUD_LEGAL_STAT_STRIP_ATTR, ''),
+      Ui.className<Message>(
+        'grid gap-3 border-t border-[#222] pt-3 sm:grid-cols-3',
+      ),
+    ],
+    LEGAL_VERIFIED_STATS.map(stat =>
+      h.div(
+        [Ui.className<Message>('grid gap-1')],
+        [
+          h.span(
+            [
+              Ui.className<Message>(
+                'font-medium text-[#f1efe8] text-lg tabular-nums',
+              ),
+            ],
+            [stat.value],
+          ),
+          h.span(
+            [
+              Ui.className<Message>(
+                'text-[0.75rem] leading-[1.4] text-white/55',
+              ),
+            ],
+            [stat.label],
+          ),
+          h.a(
+            [
+              h.Href(stat.sourceUrl),
+              h.Target('_blank'),
+              h.Rel('noopener noreferrer'),
+              Ui.className<Message>(
+                'text-[0.6875rem] text-[#7aa2ff] underline decoration-[#3a7bff]/40 underline-offset-2 hover:text-[#a8c2ff]',
+              ),
+            ],
+            [stat.source],
+          ),
+        ],
+      ),
+    ),
+  )
+}
 
 // One transcript turn rendered as an AI Elements `message`. The agent surface is
 // the assistant role; the visitor is the user role.
@@ -241,6 +425,7 @@ export const overlayView = <Message>(
               ),
             ],
           ),
+          legalOverlaySection<Message>(model),
           transcriptView<Message>(model),
           componentsView<Message>(model, actions),
           composerView<Message>(model, actions),

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/vertical-overlay.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/vertical-overlay.ts
@@ -1,0 +1,44 @@
+// Autopilot onboarding — vertical overlay CONTENT (issue #6130).
+//
+// The shared onboarding flow threads the optional `/autopilot/{vertical}` segment
+// to the Khala program's vertical-overlay slot (the system prompt's VERTICAL
+// OVERLAY block, see workers/api `autopilot-onboarding-system-prompt.ts`). That
+// slot expects the actual overlay GUIDANCE TEXT, not the raw route segment.
+//
+// This module is the single client-side place that maps a vertical segment to
+// the overlay text the program receives. It is a pure config map, not new
+// plumbing: `/autopilot/legal` resolves to the legal overlay; every other (or
+// absent) segment resolves to `null` so the program runs the generic intake with
+// no overlay. The legal variant is the only in-scope vertical; other verticals
+// are postponed.
+//
+// The legal overlay leads with CONTROL + PROVABILITY: review-gated,
+// attorney-in-the-loop, source-linked, bounded and template-driven — explicitly
+// NOT an "AI lawyer" and NOT case-law research. It refines tone and which
+// offerings to lead with; it never relaxes the program's honesty contract, which
+// the server enforces (registry state still governs what may be sold).
+
+// The legal vertical's system-prompt overlay. Kept as an exported constant so it
+// is auditable and unit-testable in lockstep with the flow that threads it.
+export const LEGAL_VERTICAL_OVERLAY = `LEGAL VERTICAL. The human is a legal professional (a lawyer, small firm, or in-house counsel). Lead with CONTROL and PROVABILITY, not automation hype.
+
+Frame OpenAgents for legal work as a way to stay in expert review mode: the human gives only the limited source material they choose, and Autopilot prepares a bounded, template-driven, verifiable work surface — the right template, a draft prep packet, intake questions, and a lawyer-review checklist — while the human keeps strategic counsel.
+
+NON-NEGOTIABLE framing for this vertical:
+  - This is NOT an "AI lawyer" and NOT legal advice. It does NOT do case-law research and does NOT cite case law. Never imply it practices law or replaces the attorney's judgment.
+  - Attorney-in-the-loop is mandatory. A human-review gate precedes anything that is sent, filed, published, deployed, or spent. Treat the review gate as required (default yes) for ALL legal work, and say so plainly.
+  - Source-linked and conservative. Surfaces should be source-grounded, mark drafts as drafts, and produce a receipt of what the system did and did NOT do. Flag any drafted clause language for attorney review.
+  - Consent before client-identifying data. Before the human shares anything client-identifying, confirm consent and that no client-identifying detail is published (this reflects each lawyer's own professional duties around AI tools, e.g. ABA Formal Opinion 512). Do NOT solicit privileged or sensitive client detail you do not need.
+
+GOOD first quick wins to steer toward (bounded, template-driven, verifiable): a template/form finder with fit rationale; a draft prep packet for a routine document (e.g. a generic NDA or formation/intake checklist) with assumptions, missing-fact questions, and a lawyer-review checklist; a selected-source consult-prep or matter brief. Keep the first win small enough to see in days, and keep the original source one click away.
+
+Map these onto the live offerings honestly (the honesty contract governs availability): coding/agent work and Autopilot business automation for the document/workspace preparation, sites for any client-facing intake form. Do not promise filing authority, legal outcomes, or any capability the registry does not support as live; capture anything beyond the menu as an open question.`
+
+// Resolve the program's vertical-overlay slot text from the route segment. Pure:
+// the only recognized vertical is `legal`; everything else (including `null`)
+// yields `null`, so the generic `/autopilot` flow carries no overlay. This is the
+// seam that turns the bare segment into the actual overlay guidance the program
+// consumes — `flow.vertical` stays the raw segment for client-side UI branching.
+export const verticalOverlayForSegment = (
+  vertical: string | null,
+): string | null => (vertical === 'legal' ? LEGAL_VERTICAL_OVERLAY : null)

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
@@ -71,6 +71,7 @@ import {
   ShareProjectionResponse,
 } from './model'
 import { OnboardingTurnResponse } from '../autopilot-onboarding/flow'
+import { verticalOverlayForSegment } from '../autopilot-onboarding/vertical-overlay'
 import { homeRouter, khalaRouter, tassadarRouter } from '../../route'
 import {
   SETTLED_FEED_SCOPE,
@@ -1175,10 +1176,15 @@ export const update = (model: Model, message: Message): UpdateReturn =>
               }),
           }),
           [
+            // Thread the legal SYSTEM-PROMPT OVERLAY (not the raw `legal`
+            // segment) to the program's vertical-overlay slot. The server only
+            // honors it on the first turn that creates the session; non-legal /
+            // absent verticals resolve to null so the generic intake carries no
+            // overlay (#6130).
             SubmitAutopilotOnboardingTurn({
               sessionId: flow.sessionId,
               userText,
-              verticalOverlay: flow.vertical,
+              verticalOverlay: verticalOverlayForSegment(flow.vertical),
             }),
           ],
         ]


### PR DESCRIPTION
Closes #6130. Part of #6123.

The single in-scope industry variant, implemented as a config overlay on the shared onboarding flow (NOT a fork). `/autopilot/legal` already resolves to the merged onboarding page and threads the optional vertical segment to the Khala onboarding program's vertical-overlay slot; this PR supplies the legal **content/overlay**.

## What this does
- **Legal system-prompt overlay (the core gap).** Adds a client-side vertical-overlay map (`vertical-overlay.ts`): the `legal` segment resolves to the legal **system-prompt overlay text**; every other or absent segment resolves to `null`. The onboarding turn command now threads this overlay text — not the raw `legal` segment — into the program's vertical-overlay slot. The overlay leads with **control + provability**: review-gated, attorney-in-the-loop, source-linked, bounded and template-driven — explicitly **not an "AI lawyer"** and **not case-law research** — and it never relaxes the program's honesty contract (registry state still governs what may be sold).
- **Legal overlay surfaces on the page**, rendered only for the `legal` vertical: a legal-specific intro, a **VSL placeholder embed region** (no real video asset required for v1), a bounded set of generic legal starter prompts, and a single **verified stat strip**. The existing `consent_gate` (ABA Op. 512 framing) continues to lead for the legal vertical.
- **Verified stats only.** Every figure traces to a primary source and carries its citation as an openable link. No scarcity, no outcome projections, no unproven numbers.

## Stats used (all primary-sourced, from the re-authenticated legal data sheet/ledger)
- **69%** of legal professionals now use generative AI for work — [8am 2026 Legal Industry Report (n=1,395)](https://www.8am.com/reports/legal-industry-report-2026/)
- **9%** of firms have an actively enforced written AI policy (43% have none) — [8am 2026 Legal Industry Report](https://www.8am.com/reports/legal-industry-report-2026/)
- **ABA Formal Opinion 512** — informed client consent before inputting client information — [ABA Op. 512 (PDF)](https://www.americanbar.org/content/dam/aba/administrative/professional_responsibility/ethics-opinions/aba-formal-opinion-512.pdf)

Removed/unverified ledger figures (e.g. ILTA 68%, "+68% breach attempts") are intentionally excluded.

## Constraints honored
- No client/design-partner/person/brand material, no pricing, no private assets, no scarcity ("N of 5 slots"), no outcome projections ("$50k–$100k", "3×", "80%") anywhere in the change.
- Did NOT build the private legal delivery loop or seed any workspace (out of scope).
- Existing user-facing copy elsewhere preserved; only the legal overlay was added.

## Verification
- `bun run typecheck:web` and `bun run typecheck:api` — clean.
- `apps/web` tests `src/page/autopilot-onboarding` (43) + `src/ui-composition.test.ts` + `src/page/loggedOut` (42) — green.
- New tests assert: legal vertical renders the overlay (VSL slot + intro + stat strip) and threads the legal system-prompt overlay to the program command; each stat carries a primary-source citation/URL; and the generic `/autopilot` path shows no legal-only content.
- `bun run check:deploy` from `apps/openagents.com` — exit 0 (full clean run, including the hardened desktop WebGL smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
