### PR TITLE
Isolate MPP Lightning rail so a slow/cold MDK mint can never hang the 402

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from 'node:sqlite'
 
-import { Effect } from 'effect'
+import { Effect, Fiber } from 'effect'
+import { TestClock } from 'effect/testing'
 import { describe, expect, test } from 'vitest'
 
 import { readAgentBalance } from '../../payments-ledger'
@@ -1092,5 +1093,114 @@ describe('MPP endpoint — Lightning rail (Bitcoin-first)', () => {
       ),
     )
     expect(served.status).toBe(402)
+  })
+
+  // ---- PER-RAIL ISOLATION / NO-HANG (root-cause regression) ----
+  //
+  // The observed prod hang: arming KHALA_MPP_LIGHTNING_ENABLED made a slow/cold
+  // MDK-sidecar mint block the ENTIRE 402 handler (crypto + card timed out too)
+  // because the Lightning leg ran first and synchronously. These tests prove the
+  // Lightning leg is now fully isolated: a hung/slow mint is bounded and dropped,
+  // and the endpoint still returns a 402 carrying the crypto (+ card) challenges.
+
+  test('HANGING MINT: a never-resolving mint is bounded => 402 still carries crypto + card, lightning DROPPED', async () => {
+    const db = makeDb()
+    let mintStarted = false
+    // A mint that NEVER resolves — models a cold/blocked MDK sidecar container.
+    const hangingMint: MintLightningInvoice = () =>
+      Effect.callback<LightningInvoice, LightningInvoiceError>(() => {
+        mintStarted = true
+        // never resume => the effect hangs until interrupted by the timeout.
+      })
+    const response = await run(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          handleMppChatCompletions(mppRequest(), {
+            completionDeps: completionDeps(db),
+            db,
+            enabled: true,
+            fetch: lightningQuoteFetch(),
+            lightningEnabled: true,
+            mintLightningInvoice: hangingMint,
+            newId: () => 'fixed',
+            signingSecret: SIGNING_SECRET,
+            // card rail armed too, to prove BOTH non-lightning rails survive.
+            stripeNetworkProfileId: 'profile_test',
+            stripeSecretKey: 'sk_test_x',
+          }),
+        )
+        // Advance well past BOTH the inner mint timeout and the outer leg guard.
+        yield* TestClock.adjust(10_000)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(mintStarted).toBe(true)
+    // The endpoint still returns a 402 (NOT a hang, NOT a 503).
+    expect(response.status).toBe(402)
+    const wwwAuth = response.headers.get('www-authenticate') ?? ''
+    // Lightning is DROPPED (honesty gate) but the other rails are present.
+    expect(wwwAuth).not.toContain('method="lightning"')
+    expect(wwwAuth).toContain('method="base"')
+    expect(wwwAuth).toContain('method="stripe"')
+    const problem = (await response.json()) as {
+      challenges: Array<{ method: string }>
+    }
+    expect(problem.challenges.some(c => c.method === 'lightning')).toBe(false)
+    expect(problem.challenges.some(c => c.method === 'base')).toBe(true)
+    expect(problem.challenges.some(c => c.method === 'stripe')).toBe(true)
+  })
+
+  test('FAILING MINT: a fast typed failure drops ONLY lightning; crypto still present', async () => {
+    const db = makeDb()
+    const issuer = fakeLightningIssuer({ fail: true })
+    const response = await run(
+      handleMppChatCompletions(mppRequest(), {
+        completionDeps: completionDeps(db),
+        db,
+        enabled: true,
+        fetch: lightningQuoteFetch(),
+        lightningEnabled: true,
+        mintLightningInvoice: issuer.mint,
+        newId: () => 'fixed',
+        signingSecret: SIGNING_SECRET,
+        stripeSecretKey: 'sk_test_x',
+      }),
+    )
+    expect(response.status).toBe(402)
+    expect(issuer.calls()).toBe(1)
+    const wwwAuth = response.headers.get('www-authenticate') ?? ''
+    expect(wwwAuth).not.toContain('method="lightning"')
+    expect(wwwAuth).toContain('method="base"')
+  })
+
+  test('FAST SUCCESS: a fast mint => lightning challenge present and FIRST, crypto still present', async () => {
+    const db = makeDb()
+    const issuer = fakeLightningIssuer()
+    const response = await run(
+      handleMppChatCompletions(mppRequest(), {
+        completionDeps: completionDeps(db),
+        db,
+        enabled: true,
+        fetch: lightningQuoteFetch(),
+        lightningEnabled: true,
+        mintLightningInvoice: issuer.mint,
+        newId: () => 'fixed',
+        signingSecret: SIGNING_SECRET,
+        stripeSecretKey: 'sk_test_x',
+      }),
+    )
+    expect(response.status).toBe(402)
+    expect(issuer.calls()).toBe(1)
+    const wwwAuth = response.headers.get('www-authenticate') ?? ''
+    // Lightning is the FIRST presented challenge (Bitcoin-first).
+    const firstChallenge = wwwAuth.split(/,\s*(?=Payment\s)/i)[0] ?? ''
+    expect(firstChallenge).toContain('method="lightning"')
+    // ...and the crypto rail is still present.
+    expect(wwwAuth).toContain('method="base"')
+    const problem = (await response.json()) as {
+      challenges: Array<{ method: string }>
+    }
+    expect(problem.challenges[0]?.method).toBe('lightning')
+    expect(problem.challenges.some(c => c.method === 'base')).toBe(true)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
@@ -29,7 +29,7 @@
 // 503 and NEVER constructs a charge or issues a challenge. A missing `profile_`
 // id only disables the CARD rail; the crypto rail still works.
 
-import { Effect } from 'effect'
+import { Duration, Effect } from 'effect'
 
 import { noStoreJsonResponse } from '../../http/responses'
 import {
@@ -51,10 +51,7 @@ import {
   mppLightningPayerAccountRef,
   mppPayerAccountRef,
 } from './mpp-credit-grant'
-import {
-  type MintLightningInvoice,
-  LightningInvoiceError,
-} from './mpp-lightning-invoice'
+import { type MintLightningInvoice } from './mpp-lightning-invoice'
 import { claimLightningPaymentHash } from './mpp-lightning-replay'
 import { readPreimage, verifyLightningPreimage } from './mpp-lightning-verify'
 import {
@@ -90,6 +87,19 @@ const LIGHTNING_METHOD = 'lightning'
 const MPP_REALM = 'openagents.com'
 // Challenge validity window.
 const CHALLENGE_TTL_MS = 5 * 60 * 1000
+// PER-RAIL ISOLATION GUARD for the Lightning leg of challenge issuance. The
+// MDK-backed invoice issuer already caps its own mint round-trip
+// (`MDK_LIGHTNING_MINT_TIMEOUT_MS`, ~2s), but the route MUST NOT trust any single
+// issuer to be well-behaved: a buggy, mis-wired, or non-MDK issuer could hang,
+// reject in an unmapped way, or die with a defect. So the route wraps the WHOLE
+// Lightning leg in its own bounded, defect-swallowing guard (`Effect.timeout` +
+// `Effect.catchAllCause`) that resolves to "no Lightning challenge" on ANY
+// failure. Slightly LARGER than the issuer's internal mint timeout so the inner,
+// more specific bound normally wins; this is the outer safety net. The Lightning
+// leg runs CONCURRENTLY with the crypto deposit (see `issueChallenge`), so even
+// at the full budget it never DELAYS the other rails — a slow/failed Lightning
+// rail can only ever drop ITSELF.
+const LIGHTNING_LEG_GUARD_MS = 2_500
 
 // Parse the KHALA_MPP_ENABLED flag. Default OFF.
 export const isKhalaMppEnabled = (value: string | undefined): boolean => {
@@ -315,50 +325,58 @@ const lightningRailActive = (
     : undefined
 
 // Mint a Lightning invoice + build the (Bitcoin-first) Lightning challenge for
-// this quote. Best-effort: if the invoice issuer fails we return undefined and
-// the 402 still carries the other rails — we just do not advertise a Lightning
-// rail we could not actually mint an invoice for (honesty gate). The effective
-// challenge expiry is the EARLIER of the challenge TTL and the invoice expiry.
+// this quote. Best-effort and FULLY ISOLATED: if the invoice issuer fails,
+// times out, or dies with a defect we return undefined and the 402 still carries
+// the other rails — we just do not advertise a Lightning rail we could not
+// actually mint an invoice for (honesty gate). The effective challenge expiry is
+// the EARLIER of the challenge TTL and the invoice expiry.
+//
+// SAFETY (the central fix): this leg can NEVER hang or break the 402. The whole
+// computation is bounded by `LIGHTNING_LEG_GUARD_MS` and ANY failure cause —
+// typed `LightningInvoiceError`, a hang/timeout, OR an unexpected defect from a
+// mis-wired issuer — is swallowed back to `undefined` (drop the rail). The
+// observed prod hang was a cold MDK-sidecar container blocking the entire
+// (sequential) issuance Effect; here a hung mint is interrupted and dropped.
 const buildLightningChallengeForQuote = (
   deps: MppChatCompletionsDeps,
   signingSecret: string,
   mint: MintLightningInvoice,
   input: Readonly<{ model: string; newId: () => string; challengeExpiresAt: string }>,
-) =>
+): Effect.Effect<MppChallenge | undefined, never> =>
   Effect.gen(function* () {
     const lightningQuote = quoteMppLightningCall({ model: input.model })
-    const minted = yield* mint({
+    const invoice = yield* mint({
       amountSats: lightningQuote.amountSats,
       correlationRef: `mpp:lightning:${input.model}:${input.newId()}`,
       description: `OpenAgents Khala ${input.model} pay-per-call`,
-    }).pipe(
-      Effect.map(invoice => ({ ok: true as const, invoice })),
-      Effect.catch((error: LightningInvoiceError) =>
-        Effect.succeed({ ok: false as const, reason: error.reason }),
-      ),
-    )
-    if (!minted.ok) {
-      return undefined
-    }
+    })
     // Effective expiry = earlier of challenge TTL and invoice BOLT11 expiry
     // (spec §"Challenge Expiry and Invoice Expiry"). The challenge `expires`
     // auth-param MUST NOT be later than the invoice expiry.
     const challengeExpires =
-      minted.invoice.invoiceExpiresAt !== undefined &&
-      Date.parse(minted.invoice.invoiceExpiresAt) <
+      invoice.invoiceExpiresAt !== undefined &&
+      Date.parse(invoice.invoiceExpiresAt) <
         Date.parse(input.challengeExpiresAt)
-        ? minted.invoice.invoiceExpiresAt
+        ? invoice.invoiceExpiresAt
         : input.challengeExpiresAt
     return yield* buildLightningChallenge(signingSecret, {
       amountSats: lightningQuote.amountSats,
-      bolt11: minted.invoice.bolt11,
+      bolt11: invoice.bolt11,
       expires: challengeExpires,
-      invoiceExpiresAt: minted.invoice.invoiceExpiresAt,
+      invoiceExpiresAt: invoice.invoiceExpiresAt,
       model: input.model,
-      network: minted.invoice.network,
-      paymentHash: minted.invoice.paymentHash,
+      network: invoice.network,
+      paymentHash: invoice.paymentHash,
     })
-  })
+  }).pipe(
+    // Outer per-rail safety net: bound the WHOLE leg, then swallow ANY cause
+    // (typed error, the timeout's `TimeoutException`, or an interrupt/defect)
+    // back to "no Lightning challenge". This is what makes a Lightning failure
+    // ALWAYS safe regardless of issuer behavior. `catchCause` (not `catch`)
+    // recovers from BOTH recoverable errors and unrecoverable defects.
+    Effect.timeout(Duration.millis(LIGHTNING_LEG_GUARD_MS)),
+    Effect.catchCause(() => Effect.succeed(undefined)),
+  )
 
 // Issue a fresh 402 (no credential, or a credential we refused). Creates a
 // crypto deposit PaymentIntent for the quote (the address the crypto challenge
@@ -381,27 +399,36 @@ const issueChallenge = (
     const cardQuote = quoteMppCall({ model, rail: 'card' as MppRail })
     const challengeExpiresAt = epochMillisToIsoTimestamp(nowMs + CHALLENGE_TTL_MS)
 
-    // Bitcoin-first: mint the Lightning challenge first (when the rail is armed).
+    // PER-RAIL ISOLATION: the Lightning leg ("Bitcoin-first" in PRESENTATION
+    // order) and the crypto deposit creation run CONCURRENTLY, so a slow/cold
+    // Lightning mint can never delay the crypto/card rails beyond its own bounded
+    // guard. The Lightning leg is fully self-contained — it resolves to
+    // `undefined` (drop the rail) on ANY failure/timeout/defect and never fails
+    // this Effect (`Effect.Effect<…, never>`). Presentation order still puts
+    // Lightning FIRST, but only when it actually minted (see `buildChallenges`).
     const mint = lightningRailActive(deps)
-    const lightningChallenge =
-      mint === undefined
-        ? undefined
-        : yield* buildLightningChallengeForQuote(deps, signingSecret, mint, {
-            challengeExpiresAt,
-            model,
-            newId,
-          })
-
-    const created = yield* createCryptoDepositPaymentIntent(stripeDeps, {
-      amountCents: cryptoQuote.amountCents,
-      idempotencyKey: `mpp:quote:${newId()}`,
-      metadata: { model, product: 'openagents_khala_mpp' },
-      networks: CRYPTO_NETWORKS,
-    }).pipe(
-      Effect.map(intent => ({ ok: true as const, intent })),
-      Effect.catch(error =>
-        Effect.succeed({ ok: false as const, reason: error.detail }),
-      ),
+    const [lightningChallenge, created] = yield* Effect.all(
+      [
+        mint === undefined
+          ? Effect.succeed(undefined)
+          : buildLightningChallengeForQuote(deps, signingSecret, mint, {
+              challengeExpiresAt,
+              model,
+              newId,
+            }),
+        createCryptoDepositPaymentIntent(stripeDeps, {
+          amountCents: cryptoQuote.amountCents,
+          idempotencyKey: `mpp:quote:${newId()}`,
+          metadata: { model, product: 'openagents_khala_mpp' },
+          networks: CRYPTO_NETWORKS,
+        }).pipe(
+          Effect.map(intent => ({ ok: true as const, intent })),
+          Effect.catch(error =>
+            Effect.succeed({ ok: false as const, reason: error.detail }),
+          ),
+        ),
+      ] as const,
+      { concurrency: 'unbounded' },
     )
     if (!created.ok) {
       return notConfigured(`stripe quote failed: ${created.reason}`)

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.test.ts
@@ -1,9 +1,11 @@
-import { Effect } from 'effect'
+import { Effect, Fiber } from 'effect'
+import { TestClock } from 'effect/testing'
 import { describe, expect, test } from 'vitest'
 
 import { LightningInvoiceError } from './mpp-lightning-invoice'
 import {
   type MdkRoutePost,
+  MDK_LIGHTNING_MINT_TIMEOUT_MS,
   makeMdkLightningInvoiceIssuer,
 } from './mpp-lightning-invoice-mdk'
 
@@ -98,5 +100,38 @@ describe('makeMdkLightningInvoiceIssuer', () => {
       ),
     )
     expect(result).toBe('malformed_invoice')
+  })
+
+  // ROOT-CAUSE REGRESSION: the MDK sidecar is a Cloudflare Container that sleeps
+  // after 30m and a cold boot can block `getContainer(...).fetch()` for SECONDS.
+  // `Effect.tryPromise` catches throws, NOT a hang. The bounded mint must
+  // interrupt a hung post and fail typed (`provider_unavailable`) so the rail is
+  // dropped — never propagate the hang. Deterministic via TestClock: the post
+  // NEVER resolves; advancing past the timeout must produce the typed failure.
+  test('a HUNG post is bounded by the mint timeout => provider_unavailable (no hang)', async () => {
+    let postStarted = false
+    const post: MdkRoutePost = () => {
+      postStarted = true
+      // Never resolves — models a cold/blocked container boot.
+      return new Promise(() => {})
+    }
+    const issuer = makeMdkLightningInvoiceIssuer(post)
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          issuer({ amountSats: 1, correlationRef: 'r', description: 'd' }).pipe(
+            Effect.map(() => 'ok' as const),
+            Effect.catch((e: LightningInvoiceError) =>
+              Effect.succeed(e.reason),
+            ),
+          ),
+        )
+        // Advance virtual time just past the bounded mint window.
+        yield* TestClock.adjust(MDK_LIGHTNING_MINT_TIMEOUT_MS + 1)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(postStarted).toBe(true)
+    expect(result).toBe('provider_unavailable')
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
@@ -11,7 +11,7 @@
 // (route URL + secret) and the Lightning flag is on. With no route the route
 // wiring passes `mintLightningInvoice: undefined` and the rail is never offered.
 
-import { Effect } from 'effect'
+import { Duration, Effect } from 'effect'
 
 import { isRecord, nestedUnknown, optionalString } from '../../json-boundary'
 import {
@@ -20,6 +20,18 @@ import {
   LightningInvoiceError,
   validateLightningInvoice,
 } from './mpp-lightning-invoice'
+
+// Hard upper bound on the MDK sidecar `create_checkout` mint round-trip. The MDK
+// route is the `self_hosted_mdkd_sidecar` Cloudflare Container, which sleeps
+// after 30m of inactivity (`MdkSidecarContainer.sleepAfter = '30m'`). A cold
+// container boot blocks `getContainer(...).fetch()` for SECONDS — and
+// `Effect.tryPromise` only catches THROWS, never a hang. Without this bound a
+// cold/slow mint would block the whole 402 handler (the observed prod hang:
+// arming the rail timed out crypto+card too because the Lightning leg runs in
+// the same Effect). With it, a slow mint resolves to a typed `provider_unavailable`
+// failure and the Lightning rail is silently dropped (honesty gate), while the
+// other rails return promptly. 2s is well under any client/edge timeout budget.
+export const MDK_LIGHTNING_MINT_TIMEOUT_MS = 2_000
 
 // A POST transport to the MDK route/sidecar. Returns the HTTP ok flag + status +
 // parsed JSON payload (no throwing — the issuer maps a non-ok status to a typed
@@ -99,7 +111,18 @@ export const makeMdkLightningInvoiceIssuer = (
             type: 'AMOUNT',
           },
         }),
-    })
+    }).pipe(
+      // Bounded mint: a cold/slow MDK sidecar container can block for seconds.
+      // `Effect.tryPromise` catches throws, NOT a hang — so we cap the wall-clock
+      // here. On timeout the in-flight effect is interrupted and we fail with the
+      // SAME typed `provider_unavailable` reason a transport error produces, so
+      // the caller drops the Lightning rail and serves the others promptly.
+      Effect.timeoutOrElse({
+        duration: Duration.millis(MDK_LIGHTNING_MINT_TIMEOUT_MS),
+        orElse: () =>
+          Effect.fail(new LightningInvoiceError('provider_unavailable')),
+      }),
+    )
     if (!result.ok) {
       return yield* Effect.fail(
         new LightningInvoiceError(


### PR DESCRIPTION
## Problem (observed on prod)

Arming `KHALA_MPP_LIGHTNING_ENABLED` **hung the entire `/mpp/v1/chat/completions` 402 handler** (timeouts, 0 bytes — crypto + card too).

Root cause: the Lightning leg mints a BOLT11 synchronously via the MDK sidecar `create_checkout` with **no client-side timeout** (`Effect.tryPromise` catches throws, not a hang), and it ran **first** in `issueChallenge`. The MDK sidecar is a Cloudflare Container that **sleeps after 30m** (`MdkSidecarContainer.sleepAfter = '30m'`), so a cold-boot `getContainer(...).fetch()` blocks for seconds and stalls the whole handler.

## Fix — make a Lightning failure ALWAYS safe

1. **Bounded mint** (`mpp-lightning-invoice-mdk.ts`): cap the `create_checkout` round-trip with `Effect.timeoutOrElse`, `MDK_LIGHTNING_MINT_TIMEOUT_MS = 2000ms`. On timeout the in-flight effect is interrupted and fails typed (`provider_unavailable`).
2. **Per-rail isolation** (`mpp-chat-completions-routes.ts`): the Lightning leg now runs **concurrently** with the crypto deposit (`Effect.all`, unbounded) and is wrapped in its own outer guard (`Effect.timeout` `LIGHTNING_LEG_GUARD_MS = 2500ms` + `Effect.catchCause`) that swallows **any** cause — typed error, timeout, or defect — back to "no Lightning challenge". A slow/failed/mis-wired issuer can only ever drop itself; the crypto/card rails always return promptly. Lightning stays FIRST only when it actually minted.
3. **Honesty gate preserved**: a dropped Lightning rail is absent from that 402's `WWW-Authenticate` + problem body; `/openapi.json` stays gated on configured-issuer presence.

## Mint feasibility finding

The MDK sidecar `create_checkout(SAT, AMOUNT)` path **is wired** (`mpp-lightning-invoice-mdk.ts`) and the `MdkSidecarContainer` is deployed and proven for amount-mode SAT checkout. **But it is a sleep-after-30m Cloudflare Container**, so a cold mint is exactly the multi-second hang this PR isolates. The Forum L402 flow uses local HMAC signing (`forumL402SigningBoundaryForEnv`), NOT this mint — so Forum L402 working does not prove this path. With the rail unconfigured or slow, it stays correctly suppressed by the honesty gate.

## Tests (deterministic via `TestClock` — no real waits, no network)

- `mdk`: a never-resolving post is bounded => `provider_unavailable`.
- `routes`: a hanging mint => 402 still carries crypto + card, lightning dropped; a fast typed failure drops only lightning; a fast success => lightning present and FIRST with crypto still present.

`bun run typecheck:api` green (0 errors); `bun run check:deploy` exits 0 (the `check-contract-drift.test.ts` console "FAILED" lines are the known fixture quirk — the file passes 5/5).

Refs #6049

🤖 Generated with [Claude Code](https://claude.com/claude-code)