### PR TITLE
Autopilot onboarding UI: markdown, streaming, scroll, sidebar progress

### DIFF
--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.test.ts
@@ -21,6 +21,7 @@ import {
   capturedSectionCount,
   currentSectionIndex,
   deriveComponentFrames,
+  deriveIntakeRegister,
   initFlowModel,
   isQuoteReady,
 } from './flow'
@@ -30,10 +31,16 @@ import {
   HUD_LEGAL_OVERLAY_ATTR,
   HUD_LEGAL_STAT_STRIP_ATTR,
   HUD_LEGAL_VSL_ATTR,
+  HUD_REGISTER_ATTR,
   HUD_ROOT_ATTR,
+  HUD_THREAD_END_ATTR,
   LEGAL_VERIFIED_STATS,
   overlayView,
 } from './page'
+import {
+  OpenedAutopilotOnboardingStream,
+  ReceivedAutopilotOnboardingDelta,
+} from '../loggedOut/message'
 import {
   LEGAL_VERTICAL_OVERLAY,
   verticalOverlayForSegment,
@@ -130,13 +137,11 @@ describe('autopilot onboarding — output spec progress', () => {
 })
 
 describe('autopilot onboarding — derived component frames', () => {
-  test('surfaces intake_progress from the first render, nothing else yet', () => {
+  test('surfaces nothing inline on the first render (intake is the sidebar register)', () => {
+    // intake_progress moved to the sidebar register (problem #3); the inline
+    // component column starts empty until facts are captured.
     const frames = deriveComponentFrames(initFlowModel(Option.none()))
-    expect(frames).toHaveLength(1)
-    expect(frames[0]).toMatchObject({
-      _tag: 'CatalogComponentFrame',
-      frame: { component: 'intake_progress' },
-    })
+    expect(frames).toHaveLength(0)
   })
 
   test('legal vertical adds a consent_gate', () => {
@@ -144,7 +149,7 @@ describe('autopilot onboarding — derived component frames', () => {
     const components = frames.map(frame =>
       frame._tag === 'CatalogComponentFrame' ? frame.frame.component : 'unknown',
     )
-    expect(components).toEqual(['intake_progress', 'consent_gate'])
+    expect(components).toEqual(['consent_gate'])
   })
 
   test('quote-ready state surfaces quick_win, dashboard_preview, credit_kickoff', () => {
@@ -161,7 +166,6 @@ describe('autopilot onboarding — derived component frames', () => {
       frame._tag === 'CatalogComponentFrame' ? frame.frame.component : 'unknown',
     )
     expect(components).toEqual([
-      'intake_progress',
       'quick_win_card',
       'dashboard_preview',
       'credit_kickoff',
@@ -169,14 +173,38 @@ describe('autopilot onboarding — derived component frames', () => {
   })
 })
 
+describe('autopilot onboarding — intake register (sidebar)', () => {
+  test('lights up captured sections and marks the current step active', () => {
+    const model: FlowModel = {
+      ...initFlowModel(Option.none()),
+      outputSpec: { business: 'Acme', goal: 'Launch a site' },
+    }
+    const register = deriveIntakeRegister(model)
+    expect(register).toHaveLength(10)
+    expect(register[0]).toMatchObject({ id: 'business', status: 'done' })
+    expect(register[1]).toMatchObject({ id: 'goal', status: 'done' })
+    // chosenOfferings is the first open section -> active.
+    expect(register[2]).toMatchObject({ id: 'chosenOfferings', status: 'active' })
+    expect(register[3]).toMatchObject({ status: 'queued' })
+  })
+})
+
 describe('autopilot onboarding — page overlay rendering', () => {
-  test('renders the HUD shell, composer, and intake register on first paint', () => {
+  test('renders the HUD shell, composer, scrollable thread, and sidebar register on first paint', () => {
     const markup = renderHtml(
       overlayView(initFlowModel(Option.none()), stubActions),
     )
     expect(markup).toContain(`data-${HUD_ROOT_ATTR}`)
     expect(markup).toContain(`data-${HUD_COMPOSER_ATTR}`)
-    expect(markup).toContain('Onboarding progress')
+    // The intake progress is now a compact sidebar register (problem #3), not a
+    // giant "Onboarding progress" box in the main column.
+    expect(markup).toContain(`data-${HUD_REGISTER_ATTR}`)
+    expect(markup).toContain('Intake')
+    expect(markup).toContain('0/10')
+    expect(markup).not.toContain('Onboarding progress')
+    // The thread is an internal scroll region with a bottom sentinel (problem #2).
+    expect(markup).toContain('oa-thread-scroll')
+    expect(markup).toContain(`data-${HUD_THREAD_END_ATTR}="true"`)
     // No credit kickoff before quote-ready.
     expect(markup).not.toContain('Kick off the work')
   })
@@ -235,7 +263,7 @@ describe('autopilot onboarding — turn loop (via the loggedOut update)', () => 
   const flowOf = (model: { autopilotOnboarding: FlowModel }): FlowModel =>
     model.autopilotOnboarding
 
-  test('submitting a turn appends the user turn, clears the draft, and fires the program command', () => {
+  test('submitting a turn appends the user turn, clears the draft, sets a pending turn, and scrolls', () => {
     const base = init(AutopilotRoute())
     const [typed] = update(
       base,
@@ -252,8 +280,87 @@ describe('autopilot onboarding — turn loop (via the loggedOut update)', () => 
     expect(flowOf(submitted).transcript).toEqual([
       { role: 'user', content: 'I run a bakery' },
     ])
+    // The turn is now driven by the streaming subscription: submit sets a
+    // pendingTurn (the subscription opens the SSE stream) and scrolls to the
+    // just-sent message. No fetch command fires on the pure path.
+    const pending = flowOf(submitted).pendingTurn
+    expect(pending).not.toBeNull()
+    expect(pending?.userText).toBe('I run a bakery')
     expect(commands.map(command => command.name)).toEqual([
-      'SubmitAutopilotOnboardingTurn',
+      'ScrollAutopilotOnboardingThreadToEnd',
+    ])
+  })
+
+  test('the streaming lifecycle: open -> deltas accumulate -> done commits and resets', () => {
+    const base = init(AutopilotRoute())
+    const [typed] = update(
+      base,
+      UpdatedAutopilotOnboardingComposer({ value: 'I run a bakery' }),
+    )
+    const [submitted] = update(typed, SubmittedAutopilotOnboardingTurn())
+    const turnId = flowOf(submitted).pendingTurn?.id ?? ''
+    expect(turnId).not.toBe('')
+
+    const [opened] = update(
+      submitted,
+      OpenedAutopilotOnboardingStream({ turnId }),
+    )
+    expect(flowOf(opened).status).toBe('streaming')
+    expect(flowOf(opened).streamingReply).toBe('')
+
+    const [d1] = update(
+      opened,
+      ReceivedAutopilotOnboardingDelta({ turnId, text: 'Great' }),
+    )
+    const [d2] = update(
+      d1,
+      ReceivedAutopilotOnboardingDelta({ turnId, text: ' — what next?' }),
+    )
+    expect(flowOf(d2).streamingReply).toBe('Great — what next?')
+    expect(flowOf(d2).status).toBe('streaming')
+
+    const [done] = update(
+      d2,
+      SucceededAutopilotOnboardingTurn({
+        response: turnResponse({
+          reply: 'Great — what next?',
+          outputSpec: { business: 'A neighborhood bakery' },
+          turnCount: 1,
+        }),
+      }),
+    )
+    const flow = flowOf(done)
+    expect(flow.status).toBe('idle')
+    expect(flow.streamingReply).toBeNull()
+    expect(flow.pendingTurn).toBeNull()
+    expect(flow.transcript).toEqual([
+      { role: 'user', content: 'I run a bakery' },
+      { role: 'assistant', content: 'Great — what next?' },
+    ])
+  })
+
+  test('a stale delta for a resolved turn is ignored', () => {
+    const base = init(AutopilotRoute())
+    const [typed] = update(
+      base,
+      UpdatedAutopilotOnboardingComposer({ value: 'hi' }),
+    )
+    const [submitted] = update(typed, SubmittedAutopilotOnboardingTurn())
+    const [done] = update(
+      submitted,
+      SucceededAutopilotOnboardingTurn({
+        response: turnResponse({ reply: 'ok', turnCount: 1 }),
+      }),
+    )
+    // A late delta for the now-cleared turn must not mutate the committed state.
+    const [after] = update(
+      done,
+      ReceivedAutopilotOnboardingDelta({ turnId: 'new:1', text: 'late' }),
+    )
+    expect(flowOf(after).streamingReply).toBeNull()
+    expect(flowOf(after).transcript).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'ok' },
     ])
   })
 
@@ -347,23 +454,17 @@ describe('autopilot onboarding — turn loop (via the loggedOut update)', () => 
       base,
       UpdatedAutopilotOnboardingComposer({ value: 'Help with an NDA' }),
     )
-    const [submitted, commands] = update(
-      typed,
-      SubmittedAutopilotOnboardingTurn(),
-    )
-    // The verticalOverlay is threaded to the program command on the first turn.
+    const [submitted] = update(typed, SubmittedAutopilotOnboardingTurn())
+    // The verticalOverlay is threaded to the pending turn on the first turn (the
+    // streaming subscription posts it to the program's vertical-overlay slot).
     expect(flowOf(submitted).vertical).toBe('legal')
-    // The command carries the legal SYSTEM-PROMPT OVERLAY text (not the raw
+    // The pending turn carries the legal SYSTEM-PROMPT OVERLAY text (not the raw
     // `legal` segment) so the program's vertical-overlay slot gets real guidance.
-    const turnCommand = commands.find(
-      command => command.name === 'SubmitAutopilotOnboardingTurn',
+    expect(flowOf(submitted).pendingTurn?.verticalOverlay).toBe(
+      LEGAL_VERTICAL_OVERLAY,
     )
-    expect(turnCommand).toBeDefined()
-    expect(turnCommand?.args).toMatchObject({
-      verticalOverlay: LEGAL_VERTICAL_OVERLAY,
-    })
 
-    // Simulate the command's failure terminal.
+    // Simulate the stream's failure terminal.
     const [failed] = update(
       submitted,
       FailedAutopilotOnboardingTurn({

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.ts
@@ -53,9 +53,15 @@ export const FlowOutputSpec = S.Struct({
 })
 export type FlowOutputSpec = typeof FlowOutputSpec.Type
 
-// The request lifecycle for a turn. `error` carries an operator-readable reason
-// the composer surfaces; the user can retry.
-export const FlowStatus = S.Literals(['idle', 'submitting', 'error'])
+// The request lifecycle for a turn:
+//   - `idle`        — no request in flight.
+//   - `submitting`  — a turn is posted; the SSE stream may not have opened yet.
+//   - `streaming`   — the assistant reply is landing token-by-token (deltas are
+//                     accumulating in `streamingReply`).
+//   - `error`       — the last turn failed; `errorReason` carries the message.
+// `error` carries an operator-readable reason the composer surfaces; the user
+// can retry.
+export const FlowStatus = S.Literals(['idle', 'submitting', 'streaming', 'error'])
 export type FlowStatus = typeof FlowStatus.Type
 
 // The onboarding flow model. `sessionId` is generated once the first turn is
@@ -63,6 +69,19 @@ export type FlowStatus = typeof FlowStatus.Type
 // optional `/autopilot/{vertical}` segment, threaded to the program's
 // vertical-overlay slot but never interpreted here (#6130 owns the legal
 // overlay content).
+// A turn waiting for (or receiving) its streamed reply. The subscription
+// (`subscriptions.ts`) reads this to open the SSE stream and dispatch deltas;
+// `id` is the stable per-turn key so the subscription opens the stream exactly
+// once per turn (never re-fires while it is in flight). `null` when no turn is
+// pending.
+export const FlowPendingTurn = S.Struct({
+  id: S.String,
+  sessionId: S.NullOr(S.String),
+  userText: S.String,
+  verticalOverlay: S.NullOr(S.String),
+})
+export type FlowPendingTurn = typeof FlowPendingTurn.Type
+
 export const FlowModel = ts('AutopilotOnboardingFlow', {
   vertical: S.NullOr(S.String),
   sessionId: S.NullOr(S.String),
@@ -70,6 +89,14 @@ export const FlowModel = ts('AutopilotOnboardingFlow', {
   status: FlowStatus,
   errorReason: S.NullOr(S.String),
   transcript: S.Array(FlowTurn),
+  // The in-flight assistant reply, accumulating as SSE deltas arrive. `null`
+  // when no reply is streaming. On stream completion it is committed to the
+  // transcript and reset to null. Held separately so the streaming turn renders
+  // a live, markdown-progressive bubble without mutating the durable transcript.
+  streamingReply: S.NullOr(S.String),
+  // The turn the streaming subscription should drive, or null when none is in
+  // flight. Carries the per-turn id so the SSE stream opens exactly once.
+  pendingTurn: S.NullOr(FlowPendingTurn),
   outputSpec: FlowOutputSpec,
   turnCount: S.Int,
 })
@@ -89,6 +116,51 @@ export const OnboardingTurnResponse = S.Struct({
 })
 export type OnboardingTurnResponse = typeof OnboardingTurnResponse.Type
 
+// STREAM WIRE -------------------------------------------------------------
+
+// The narrow SSE wire the streaming turn route emits (see
+// `workers/api/src/autopilot-onboarding-routes.ts`):
+//   event: delta  data: { "text": "…" }
+//   event: done   data: <OnboardingTurnResponse>
+//   event: error  data: { "error": "…" }
+// One parsed SSE event from the stream, normalized for the subscription. The
+// subscription maps these to the streaming messages.
+export type OnboardingStreamEvent =
+  | Readonly<{ kind: 'delta'; text: string }>
+  | Readonly<{ kind: 'done'; response: OnboardingTurnResponse }>
+  | Readonly<{ kind: 'error'; reason: string }>
+
+const DeltaPayload = S.Struct({ text: S.String })
+
+// Parse one decoded SSE block (its `event` name + JSON `data` payload) into a
+// typed stream event. Unknown events / malformed payloads yield `undefined` so
+// the consumer simply skips them (forward-compatible, never throws).
+export const parseOnboardingStreamEvent = (
+  event: string,
+  data: unknown,
+): OnboardingStreamEvent | undefined => {
+  if (event === 'delta') {
+    return S.decodeUnknownOption(DeltaPayload)(data).pipe(
+      Option.match({
+        onNone: () => undefined,
+        onSome: ({ text }) => ({ kind: 'delta' as const, text }),
+      }),
+    )
+  }
+  if (event === 'done') {
+    return S.decodeUnknownOption(OnboardingTurnResponse)(data).pipe(
+      Option.match({
+        onNone: () => undefined,
+        onSome: response => ({ kind: 'done' as const, response }),
+      }),
+    )
+  }
+  if (event === 'error') {
+    return { kind: 'error', reason: 'stream_failed' }
+  }
+  return undefined
+}
+
 export const initFlowModel = (vertical: Option.Option<string>): FlowModel =>
   FlowModel({
     vertical: Option.getOrNull(vertical),
@@ -97,6 +169,8 @@ export const initFlowModel = (vertical: Option.Option<string>): FlowModel =>
     status: 'idle',
     errorReason: null,
     transcript: [],
+    streamingReply: null,
+    pendingTurn: null,
     outputSpec: {},
     turnCount: 0,
   })
@@ -145,6 +219,38 @@ export const currentSectionIndex = (spec: FlowOutputSpec): number => {
   return firstOpen === -1 ? OUTPUT_SPEC_SECTIONS.length - 1 : firstOpen
 }
 
+// INTAKE REGISTER ---------------------------------------------------------
+
+// One row of the sidebar intake register (problem #3). The 10 Output-Spec
+// sections render as a slim vertical register that lights up / checks off as
+// each is captured — glanceable, not a giant box. `done` = captured, `active` =
+// the current (first open) step, `queued` = not yet reached.
+export type IntakeRegisterStatus = 'done' | 'active' | 'queued'
+
+export type IntakeRegisterStep = Readonly<{
+  id: keyof FlowOutputSpec
+  label: string
+  status: IntakeRegisterStatus
+}>
+
+// Derive the register rows for the current spec. Pure + deterministic.
+export const deriveIntakeRegister = (
+  model: FlowModel,
+): ReadonlyArray<IntakeRegisterStep> => {
+  const spec = model.outputSpec
+  const current = currentSectionIndex(spec)
+
+  return OUTPUT_SPEC_SECTIONS.map((section, index) => ({
+    id: section.id,
+    label: section.label,
+    status: isCaptured(spec, section.id)
+      ? ('done' as const)
+      : index === current
+        ? ('active' as const)
+        : ('queued' as const),
+  }))
+}
+
 // The flow is "quote-ready" once the credit-kickoff-relevant facts are captured:
 // the business, the goal, the quick win, and the payment intent. This is the
 // honest v1 gate for surfacing the `credit_kickoff` card — it does not pretend
@@ -166,12 +272,16 @@ export const CREDIT_KICKOFF_AMOUNT_CENTS = 500
 // difference today is that the page produces them from session state rather than
 // reading them off the `oa.component` SSE channel (which is inert in v1).
 //
+// The `intake_progress` register is NOT in this list any more (problem #3): the
+// 10-section interhview progress is now a compact sidebar register (see
+// `deriveIntakeRegister`), so it stays glanceable and never dominates the main
+// column. The components below are the inline, in-thread surfaces only.
+//
 // Ordering follows document order so the renderer interleaves them naturally:
-//   1. intake_progress   — always, as the assembling work surface
-//   2. consent_gate      — when a regulated vertical is active and consent is due
-//   3. quick_win_card    — once a quick win is captured
-//   4. dashboard_preview — once enough is captured to seed a workspace preview
-//   5. credit_kickoff    — once quote-ready (rendered + clickable; backend deferred)
+//   1. consent_gate      — when a regulated vertical is active and consent is due
+//   2. quick_win_card    — once a quick win is captured
+//   3. dashboard_preview — once enough is captured to seed a workspace preview
+//   4. credit_kickoff    — once quote-ready (rendered + clickable; backend deferred)
 export const deriveComponentFrames = (
   model: FlowModel,
 ): ReadonlyArray<RenderableFrame> => {
@@ -183,22 +293,6 @@ export const deriveComponentFrames = (
   // `RenderableFrame`; a record that somehow failed would degrade to the safe
   // fallback rather than crash — exactly the gateway contract.
   const records: Array<Record<string, unknown>> = []
-
-  // intake_progress — the interview assembling. Always present (even before the
-  // first turn) so the work surface is visible on a headless render, not gated
-  // behind a class-triggered reveal.
-  records.push({
-    v: 1,
-    component: 'intake_progress',
-    id: 'intake-progress',
-    props: {
-      steps: OUTPUT_SPEC_SECTIONS.map(section => ({
-        id: section.id,
-        label: section.label,
-      })),
-      current: currentSectionIndex(spec),
-    },
-  })
 
   // consent_gate — for regulated verticals (legal/health), surface an explicit
   // consent gate before anything client-identifying. v1 only knows `legal`; the

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/page.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/page.ts
@@ -1,10 +1,11 @@
-// Autopilot onboarding — the page view (issue #6129).
+// Autopilot onboarding — the page view (issue #6129, UI follow-up #6123).
 //
 // Assembles the `/autopilot` onboarding HUD that mounts as the overlay of the
 // SHARED persistent 3D scene at the `autopilot` pose (see
 // `page/loggedOut/page/persistentScene.ts`). This module renders ONLY the
-// command-canvas overlay — the conversation transcript, the streamed/surfaced
-// typed components (via the #6128 renderer), and the command composer. The
+// command-canvas overlay — the conversation thread (with progressive Markdown +
+// token streaming), the surfaced typed components (via the #6128 renderer), a
+// compact sidebar intake register, and the pinned command composer. The
 // persistent canvas, scrim, and camera pose are owned by `persistentScene.ts`
 // and are NOT respawned here (one keyed canvas, design doc §1).
 //
@@ -14,16 +15,25 @@
 // build on `@openagentsinc/ui` AI Elements + the kit tokens — no hand-rolled
 // styling, no duplicated tokens.
 //
-// Spatial behavior landed in v1: components flutter in deterministically
-// (`oa-flutter-in`, staggered by document order, with a `prefers-reduced-motion`
-// fallback). The full 3D-anchored `htmlOverlayPrimitives` choreography (cards
-// tracking scene anchors as the camera drifts) is a documented follow-up — see
-// the report and the design doc §12; v1 ships the clean, working, on-brand flow.
+// UI follow-up (this change) fixes five real-user problems on the live page:
+//   1. Markdown rendering — assistant prose renders through the centralized
+//      `response` AI element (bold/headings/lists/code/links), streaming-tolerant.
+//   2. Scroll — the thread is a FIXED-HEIGHT internal scroll region with the
+//      composer pinned below; native scroll anchoring (a bottom sentinel) keeps
+//      the newest message in view without fighting a user who has scrolled up,
+//      and an explicit scroll-to-end command fires when the user sends a turn.
+//   3. Intake progress — moved OUT of the main column into a slim sidebar
+//      register (a lit checklist, not a giant box); on narrow viewports it
+//      collapses to a thin progress strip above the thread.
+//   4. Streaming — the assistant reply lands token-by-token into a live bubble
+//      with a typing cursor; markdown renders progressively as deltas arrive.
+//   5. Clutter — ONE intro treatment (the HUD header), no duplicated hero/first
+//      message, and tightened speaker labels.
 
 import type { Attribute, Html } from 'foldkit/html'
 import { html } from 'foldkit/html'
 
-import { AiElements, eyebrowClass } from '@openagentsinc/ui'
+import { AiElements, eyebrowClass, statusDotClass } from '@openagentsinc/ui'
 
 import * as Ui from '../../ui'
 import {
@@ -32,15 +42,24 @@ import {
 } from './component-renderer'
 import {
   type FlowModel,
+  type IntakeRegisterStep,
+  capturedSectionCount,
   deriveComponentFrames,
+  deriveIntakeRegister,
+  OUTPUT_SPEC_SECTIONS,
 } from './flow'
 
-// Public data attributes so tests / captures can locate the HUD surfaces.
+// Public data attributes so tests / captures / the scroll command can locate the
+// HUD surfaces.
 export const HUD_ROOT_ATTR = 'autopilot-onboarding-hud'
 export const HUD_TRANSCRIPT_ATTR = 'autopilot-onboarding-transcript'
 export const HUD_COMPONENTS_ATTR = 'autopilot-onboarding-components'
 export const HUD_COMPOSER_ATTR = 'autopilot-onboarding-composer'
 export const HUD_COMPONENT_ITEM_ATTR = 'autopilot-onboarding-component'
+export const HUD_REGISTER_ATTR = 'autopilot-onboarding-register'
+export const HUD_THREAD_END_ATTR = 'autopilot-onboarding-thread-end'
+// The selector the scroll-to-end command targets (problem #2).
+export const HUD_THREAD_END_SELECTOR = `[data-${HUD_THREAD_END_ATTR}="true"]`
 // The legal vertical overlay surfaces (VSL slot + verified stat strip). Present
 // only on `/autopilot/legal`; absent on the generic `/autopilot` flow.
 export const HUD_LEGAL_OVERLAY_ATTR = 'autopilot-onboarding-legal-overlay'
@@ -242,25 +261,43 @@ const legalStatStripView = <Message>(): Html => {
   )
 }
 
-// One transcript turn rendered as an AI Elements `message`. The agent surface is
-// the assistant role; the visitor is the user role.
+// TRANSCRIPT --------------------------------------------------------------
+
+// One transcript turn. The assistant body renders as Markdown through the
+// centralized `response` element (problem #1); the user body is plain text.
 const transcriptTurnView = <Message>(turn: {
   role: 'user' | 'assistant'
   content: string
 }): Html =>
+  turn.role === 'assistant'
+    ? AiElements.message<Message>({
+        props: { role: 'assistant', author: HUD_HEADING },
+        markdown: turn.content,
+      })
+    : AiElements.message<Message>({
+        props: { role: 'user', body: turn.content, author: 'You' },
+      })
+
+// The in-flight streaming assistant bubble (problem #4): renders the partial
+// reply as progressive Markdown with a live typing cursor. Only present while a
+// reply is streaming.
+const streamingTurnView = <Message>(partial: string): Html =>
   AiElements.message<Message>({
-    props: {
-      role: turn.role,
-      body: turn.content,
-      author: turn.role === 'assistant' ? 'Autopilot' : 'You',
-    },
+    props: { role: 'assistant', author: HUD_HEADING },
+    markdown: partial,
+    streaming: true,
   })
 
-// The conversation register: the agent's opening line plus the running
-// transcript. Renders the opening even before the first turn so a headless
-// render shows a complete, readable surface (no class-gated blank).
+// The conversation thread: the running transcript plus the in-flight streaming
+// bubble, and a bottom sentinel the scroll-to-end command and native scroll
+// anchoring both target. The intro is NOT duplicated here (problem #5) — it lives
+// once in the HUD header. An empty thread shows a calm starter line so the
+// surface reads complete on first paint (no class-gated blank).
 const transcriptView = <Message>(model: FlowModel): Html => {
   const h = html<Message>()
+
+  const isEmpty =
+    model.transcript.length === 0 && model.streamingReply === null
 
   return h.div(
     [
@@ -268,17 +305,107 @@ const transcriptView = <Message>(model: FlowModel): Html => {
       Ui.className<Message>('grid gap-3'),
     ],
     [
-      AiElements.message<Message>({
-        props: {
-          role: 'assistant',
-          body: introForVertical(model.vertical),
-          author: 'Autopilot',
-        },
-      }),
+      isEmpty
+        ? h.p(
+            [
+              Ui.className<Message>(
+                'm-0 text-[0.8125rem] leading-[1.5] text-white/45',
+              ),
+            ],
+            ['Send a message to start. Autopilot will scope the work with you.'],
+          )
+        : h.empty,
       ...model.transcript.map(turn => transcriptTurnView<Message>(turn)),
+      model.streamingReply === null
+        ? h.empty
+        : streamingTurnView<Message>(model.streamingReply),
+      // Bottom sentinel: the scroll-to-end target (problem #2). `overflow-anchor`
+      // lets the browser keep this in view as content grows ONLY when the user is
+      // already at the bottom — native "don't fight the user" behavior.
+      h.div(
+        [
+          h.DataAttribute(HUD_THREAD_END_ATTR, 'true'),
+          Ui.className<Message>('h-px w-full [overflow-anchor:auto]'),
+        ],
+        [],
+      ),
     ],
   )
 }
+
+// INTAKE REGISTER (SIDEBAR) -----------------------------------------------
+
+const registerRowTone = (status: IntakeRegisterStep['status']) =>
+  status === 'done'
+    ? ('positive' as const)
+    : status === 'active'
+      ? ('info' as const)
+      : ('neutral' as const)
+
+const registerRowView = <Message>(step: IntakeRegisterStep): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    [
+      Ui.className<Message>(
+        `flex items-center gap-2 text-[0.75rem] leading-[1.3] ${
+          step.status === 'done'
+            ? 'text-white/55'
+            : step.status === 'active'
+              ? 'text-[#f1efe8]'
+              : 'text-white/35'
+        }`,
+      ),
+    ],
+    [
+      h.span([Ui.className<Message>(statusDotClass(registerRowTone(step.status)))], []),
+      h.span([Ui.className<Message>('min-w-0 truncate')], [step.label]),
+    ],
+  )
+}
+
+// The compact sidebar intake register (problem #3): the 10 Output-Spec sections
+// as a slim vertical register that lights up / checks off as each is captured —
+// glanceable, never dominating the column. A small captured/total count anchors
+// it. On narrow viewports the parent grid stacks it above the thread as a thin
+// strip.
+const intakeRegisterView = <Message>(model: FlowModel): Html => {
+  const h = html<Message>()
+  const steps = deriveIntakeRegister(model)
+  const captured = capturedSectionCount(model.outputSpec)
+
+  return h.aside(
+    [
+      h.DataAttribute(HUD_REGISTER_ATTR, ''),
+      h.AriaLabel('Intake progress'),
+      Ui.className<Message>(
+        'grid content-start gap-2 border border-[#222] bg-black/40 p-3',
+      ),
+    ],
+    [
+      h.div(
+        [Ui.className<Message>('flex items-center justify-between gap-2')],
+        [
+          h.span([Ui.className<Message>(eyebrowClass)], ['Intake']),
+          h.span(
+            [
+              Ui.className<Message>(
+                'text-[0.6875rem] tabular-nums text-white/45',
+              ),
+            ],
+            [`${captured}/${OUTPUT_SPEC_SECTIONS.length}`],
+          ),
+        ],
+      ),
+      h.ul(
+        [Ui.className<Message>('m-0 grid list-none gap-1.5 p-0')],
+        steps.map(step => registerRowView<Message>(step)),
+      ),
+    ],
+  )
+}
+
+// INLINE COMPONENTS -------------------------------------------------------
 
 // The surfaced typed components, each wrapped in a flutter-in surface whose
 // stagger index is its document order. `credit_kickoff` is wired clickable to
@@ -289,6 +416,10 @@ const componentsView = <Message>(
 ): Html => {
   const h = html<Message>()
   const frames = deriveComponentFrames(model)
+
+  if (frames.length === 0) {
+    return h.empty
+  }
 
   const componentActions: ComponentActionAttrs<Message> = {
     credit_kickoff: [h.OnClick(actions.clickedCreditKickoff())],
@@ -315,6 +446,8 @@ const componentsView = <Message>(
   )
 }
 
+// COMPOSER ----------------------------------------------------------------
+
 // The command composer: transport-agnostic text input (voice deferred — the
 // composer states leave room for `listening`/`speaking` later). Maps the prompt
 // status from the flow status so the submit control tracks the request.
@@ -324,17 +457,20 @@ const composerView = <Message>(
 ): Html => {
   const h = html<Message>()
 
+  const inFlight =
+    model.status === 'submitting' || model.status === 'streaming'
+
   const status =
-    model.status === 'submitting'
-      ? ('submitted' as const)
-      : model.status === 'error'
-        ? ('error' as const)
-        : ('ready' as const)
+    model.status === 'streaming'
+      ? ('streaming' as const)
+      : model.status === 'submitting'
+        ? ('submitted' as const)
+        : model.status === 'error'
+          ? ('error' as const)
+          : ('ready' as const)
 
   const submitAttrs: ReadonlyArray<Attribute<Message>> =
-    model.status === 'submitting' || model.composerDraft.trim() === ''
-      ? [h.Disabled(true)]
-      : []
+    inFlight || model.composerDraft.trim() === '' ? [h.Disabled(true)] : []
 
   return h.div(
     [
@@ -371,42 +507,58 @@ const composerView = <Message>(
   )
 }
 
+// OVERLAY -----------------------------------------------------------------
+
 // The HUD overlay: an operational command pane floating over the dimmed scene.
 // One sanctioned glass surface (design doc §9) — a breath of the scene bleeding
-// through the panel — because it ties the DOM HUD to the 3D backdrop. The pane
-// is a single bordered surface, never nested cards.
+// through the panel — because it ties the DOM HUD to the 3D backdrop. The pane is
+// a single bordered surface (never nested cards) laid out as a two-column grid on
+// wide viewports: a slim intake register rail + the main thread column. The
+// composer is pinned BELOW the scroll region so it never scrolls away; only the
+// thread + inline components scroll internally (problem #2).
 export const overlayView = <Message>(
   model: FlowModel,
   actions: OnboardingViewActions<Message>,
 ): Html => {
   const h = html<Message>()
 
+  // The scrollable region: the thread + inline components. Fixed max height with
+  // internal overflow so the page itself does not scroll; native scroll anchoring
+  // (the bottom sentinel) keeps the newest content in view.
+  const scrollRegion = h.div(
+    [
+      Ui.className<Message>(
+        'oa-thread-scroll grid min-h-0 content-start gap-3 overflow-y-auto pr-1',
+      ),
+    ],
+    [
+      transcriptView<Message>(model),
+      componentsView<Message>(model, actions),
+    ],
+  )
+
   return h.div(
     [
       h.DataAttribute(HUD_ROOT_ATTR, ''),
       h.AriaLabel('Autopilot onboarding'),
       Ui.className<Message>(
-        'pointer-events-none absolute inset-0 z-10 flex items-stretch justify-center overflow-y-auto px-4 py-6 sm:py-10',
+        'pointer-events-none absolute inset-0 z-10 flex items-stretch justify-center px-4 py-6 sm:py-10',
       ),
     ],
     [
       h.div(
         [
           Ui.className<Message>(
-            'pointer-events-auto m-auto grid w-[min(100%,46rem)] content-start gap-5 border border-[#3a7bff]/25 bg-black/55 p-4 backdrop-blur-md khala-glow sm:p-6',
+            'pointer-events-auto m-auto grid max-h-full w-[min(100%,60rem)] content-start gap-5 border border-[#3a7bff]/25 bg-black/55 p-4 backdrop-blur-md khala-glow sm:p-6',
           ),
         ],
         [
+          // ONE intro treatment (problem #5): the HUD header. The first-message
+          // duplicate is gone; the thread starts empty with a calm starter line.
           h.div(
             [Ui.className<Message>('grid gap-1.5')],
             [
-              h.span(
-                [Ui.className<Message>(eyebrowClass)],
-                [HUD_HEADING],
-              ),
-              // The HUD heading + intro are prose, not strip rows, so they use
-              // explicit on-brand classes (mono off-white, balanced) rather than
-              // the single-line-truncating `titleClass`/`metaClass` strip tokens.
+              h.span([Ui.className<Message>(eyebrowClass)], [HUD_HEADING]),
               h.h1(
                 [
                   Ui.className<Message>(
@@ -426,9 +578,34 @@ export const overlayView = <Message>(
             ],
           ),
           legalOverlaySection<Message>(model),
-          transcriptView<Message>(model),
-          componentsView<Message>(model, actions),
-          composerView<Message>(model, actions),
+          // Two-column work area: the intake register rail + the thread column.
+          // `min-h-0` on the grid + the scroll region is what lets the inner
+          // overflow actually scroll inside the capped pane. On narrow viewports
+          // the rail stacks above the thread (a thin progress strip).
+          h.div(
+            [
+              Ui.className<Message>(
+                'grid min-h-0 gap-4 sm:grid-cols-[minmax(0,1fr)_13rem] sm:gap-5',
+              ),
+            ],
+            [
+              // Thread column first in source order so it leads the document /
+              // a11y order; the rail is pulled to the right on wide via grid
+              // column placement.
+              h.div(
+                [
+                  Ui.className<Message>(
+                    'grid min-h-0 content-start gap-4 sm:col-start-1 sm:row-start-1',
+                  ),
+                ],
+                [scrollRegion, composerView<Message>(model, actions)],
+              ),
+              h.div(
+                [Ui.className<Message>('sm:col-start-2 sm:row-start-1')],
+                [intakeRegisterView<Message>(model)],
+              ),
+            ],
+          ),
         ],
       ),
     ],

--- a/apps/openagents.com/apps/web/src/page/loggedOut/message.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/message.ts
@@ -200,6 +200,14 @@ export const UpdatedAutopilotOnboardingComposer = m(
 export const SubmittedAutopilotOnboardingTurn = m(
   'SubmittedAutopilotOnboardingTurn',
 )
+export const OpenedAutopilotOnboardingStream = m(
+  'OpenedAutopilotOnboardingStream',
+  { turnId: S.String },
+)
+export const ReceivedAutopilotOnboardingDelta = m(
+  'ReceivedAutopilotOnboardingDelta',
+  { turnId: S.String, text: S.String },
+)
 export const SucceededAutopilotOnboardingTurn = m(
   'SucceededAutopilotOnboardingTurn',
   { response: OnboardingTurnResponse },
@@ -213,6 +221,9 @@ export const ClickedAutopilotOnboardingCreditKickoff = m(
 )
 export const CompletedAutopilotOnboardingCreditKickoff = m(
   'CompletedAutopilotOnboardingCreditKickoff',
+)
+export const CompletedScrollAutopilotOnboardingThread = m(
+  'CompletedScrollAutopilotOnboardingThread',
 )
 
 export const Message = S.Union([
@@ -261,9 +272,12 @@ export const Message = S.Union([
   ReceivedSettledFeedCursorGap,
   UpdatedAutopilotOnboardingComposer,
   SubmittedAutopilotOnboardingTurn,
+  OpenedAutopilotOnboardingStream,
+  ReceivedAutopilotOnboardingDelta,
   SucceededAutopilotOnboardingTurn,
   FailedAutopilotOnboardingTurn,
   ClickedAutopilotOnboardingCreditKickoff,
   CompletedAutopilotOnboardingCreditKickoff,
+  CompletedScrollAutopilotOnboardingThread,
 ])
 export type Message = typeof Message.Type

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
@@ -1,5 +1,5 @@
 import { Effect, Match as M, Schema as S } from 'effect'
-import { Command } from 'foldkit'
+import { Command, Dom } from 'foldkit'
 import { load, pushUrl } from 'foldkit/navigation'
 import { evo } from 'foldkit/struct'
 
@@ -10,8 +10,7 @@ import {
   CompletedNavigateToLanding,
   CompletedNavigateToTassadar,
   CompletedAutopilotOnboardingCreditKickoff,
-  FailedAutopilotOnboardingTurn,
-  SucceededAutopilotOnboardingTurn,
+  CompletedScrollAutopilotOnboardingThread,
   FailedLoadPublicAdjutantActivity,
   FailedLoadPublicAgentGoal,
   FailedLoadPublicArtanisReport,
@@ -70,8 +69,9 @@ import {
   PublicTrainingRunsResponse,
   ShareProjectionResponse,
 } from './model'
-import { OnboardingTurnResponse } from '../autopilot-onboarding/flow'
+import { HUD_THREAD_END_SELECTOR } from '../autopilot-onboarding/page'
 import { verticalOverlayForSegment } from '../autopilot-onboarding/vertical-overlay'
+import { recordFromUnknown } from '../../json-boundary'
 import { homeRouter, khalaRouter, tassadarRouter } from '../../route'
 import {
   SETTLED_FEED_SCOPE,
@@ -141,13 +141,6 @@ class ShareProjectionLoadError extends S.TaggedErrorClass<ShareProjectionLoadErr
 
 class ShareLinkCopyError extends S.TaggedErrorClass<ShareLinkCopyError>()(
   'ShareLinkCopyError',
-  {
-    error: S.Defect,
-  },
-) {}
-
-class AutopilotOnboardingTurnError extends S.TaggedErrorClass<AutopilotOnboardingTurnError>()(
-  'AutopilotOnboardingTurnError',
   {
     error: S.Defect,
   },
@@ -628,10 +621,7 @@ export const LoadShareProjection = Command.define(
         try: () => response.json(),
         catch: () => ({ error: 'share_unavailable' }),
       })
-      const record =
-        typeof payload === 'object' && payload !== null
-          ? (payload as Record<string, unknown>)
-          : {}
+      const record = recordFromUnknown(payload) ?? {}
       const error =
         typeof record.error === 'string'
           ? record.error
@@ -742,9 +732,9 @@ export const NavigateToLanding = Command.define(
 
 // Generate a session id for a new onboarding conversation. Uses secure browser
 // randomness (the same primitive the checkout idempotency key uses); no
-// Math.random. Lives in the command (effect side) so the pure update path stays
-// deterministic.
-const newOnboardingSessionId = (): string => {
+// Math.random. Exported so the streaming subscription mints the first-turn
+// session id at the stream boundary (off the pure update path).
+export const newOnboardingSessionId = (): string => {
   const bytes = new Uint8Array(12)
   if (
     globalThis.crypto !== undefined &&
@@ -760,65 +750,27 @@ const newOnboardingSessionId = (): string => {
   throw new Error('Secure browser randomness is required to start onboarding.')
 }
 
-// Drive one /autopilot onboarding turn against the merged Khala program
-// (`POST /api/autopilot/onboarding/{sessionId}/turn`, #6126). `sessionId` is the
-// existing session or null (a fresh one is minted here). `verticalOverlay` is
-// only honored by the server on the first turn that creates the session.
-export const SubmitAutopilotOnboardingTurn = Command.define(
-  'SubmitAutopilotOnboardingTurn',
-  {
-    sessionId: S.NullOr(S.String),
-    userText: S.String,
-    verticalOverlay: S.NullOr(S.String),
-  },
-  SucceededAutopilotOnboardingTurn,
-  FailedAutopilotOnboardingTurn,
-)(({ sessionId, userText, verticalOverlay }) =>
-  Effect.gen(function* () {
-    const resolvedSessionId =
-      sessionId ?? (yield* Effect.sync(() => newOnboardingSessionId()))
+// The /autopilot onboarding turn now STREAMS (issue #6123 UI follow-up): a
+// `pendingTurn` set on submit is picked up by the `autopilotOnboardingStream`
+// subscription (`subscriptions.ts`), which opens the SSE stream
+// (`POST /api/autopilot/onboarding/{sessionId}/turn` with
+// `Accept: text/event-stream`) and dispatches `Opened…` / `Received…Delta` /
+// `Succeeded…` / `Failed…` messages as deltas land. The submit handler stays a
+// pure model transition (no fetch on the command path).
 
-    const response = yield* Effect.tryPromise({
-      try: () =>
-        fetch(
-          `/api/autopilot/onboarding/${encodeURIComponent(resolvedSessionId)}/turn`,
-          {
-            method: 'POST',
-            cache: 'no-store',
-            headers: {
-              accept: 'application/json',
-              'content-type': 'application/json',
-            },
-            body: JSON.stringify({
-              userText,
-              ...(verticalOverlay === null ? {} : { verticalOverlay }),
-            }),
-          },
-        ),
-      catch: error => new AutopilotOnboardingTurnError({ error }),
-    })
-
-    if (!response.ok) {
-      return yield* new AutopilotOnboardingTurnError({
-        error: `Onboarding turn returned HTTP ${response.status}.`,
-      })
-    }
-
-    const payload = yield* Effect.tryPromise({
-      try: () => response.json(),
-      catch: error => new AutopilotOnboardingTurnError({ error }),
-    })
-    const decoded = yield* S.decodeUnknownEffect(OnboardingTurnResponse)(payload)
-
-    return SucceededAutopilotOnboardingTurn({ response: decoded })
+// Scroll the onboarding thread's bottom sentinel into view after a turn is sent
+// or finishes. Fire-and-forget; the native scroll anchoring keeps it pinned
+// while content grows, and this jumps to the bottom when the user sends.
+export const ScrollAutopilotOnboardingThreadToEnd = Command.define(
+  'ScrollAutopilotOnboardingThreadToEnd',
+  CompletedScrollAutopilotOnboardingThread,
+)(
+  Dom.scrollIntoViewAfterPaint(HUD_THREAD_END_SELECTOR, {
+    block: 'end',
   }).pipe(
+    Effect.as(CompletedScrollAutopilotOnboardingThread()),
     Effect.catch(() =>
-      Effect.succeed(
-        FailedAutopilotOnboardingTurn({
-          reason:
-            'Autopilot could not respond just now. Try sending that again.',
-        }),
-      ),
+      Effect.succeed(CompletedScrollAutopilotOnboardingThread()),
     ),
   ),
 )
@@ -1158,9 +1110,19 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         // Guard the empty/in-flight submit on the pure path so a double-enter or
         // an empty composer never fires a turn (the composer also disables the
         // control, but the model stays authoritative).
-        if (userText === '' || flow.status === 'submitting') {
+        if (
+          userText === '' ||
+          flow.status === 'submitting' ||
+          flow.status === 'streaming'
+        ) {
           return [model, []]
         }
+
+        // A deterministic per-turn id: the transcript length AFTER appending this
+        // user turn is unique and monotonic within the session, so the streaming
+        // subscription opens the SSE stream exactly once for this turn (no
+        // Math.random; deterministic for captures/tests).
+        const turnId = `${flow.sessionId ?? 'new'}:${flow.transcript.length + 1}`
 
         return [
           evo(model, {
@@ -1169,24 +1131,63 @@ export const update = (model: Model, message: Message): UpdateReturn =>
                 status: () => 'submitting',
                 errorReason: () => null,
                 composerDraft: () => '',
+                streamingReply: () => null,
                 transcript: transcript => [
                   ...transcript,
                   { role: 'user', content: userText },
                 ],
+                // Thread the legal SYSTEM-PROMPT OVERLAY (not the raw `legal`
+                // segment) to the program's vertical-overlay slot. The server
+                // only honors it on the first turn that creates the session;
+                // non-legal / absent verticals resolve to null (#6130).
+                pendingTurn: () => ({
+                  id: turnId,
+                  sessionId: current.sessionId,
+                  userText,
+                  verticalOverlay: verticalOverlayForSegment(current.vertical),
+                }),
               }),
           }),
-          [
-            // Thread the legal SYSTEM-PROMPT OVERLAY (not the raw `legal`
-            // segment) to the program's vertical-overlay slot. The server only
-            // honors it on the first turn that creates the session; non-legal /
-            // absent verticals resolve to null so the generic intake carries no
-            // overlay (#6130).
-            SubmitAutopilotOnboardingTurn({
-              sessionId: flow.sessionId,
-              userText,
-              verticalOverlay: verticalOverlayForSegment(flow.vertical),
-            }),
-          ],
+          // Jump the thread to the just-sent message; the subscription opens the
+          // stream and deltas land into the streaming bubble.
+          [ScrollAutopilotOnboardingThreadToEnd()],
+        ]
+      },
+      OpenedAutopilotOnboardingStream: ({ turnId }) => {
+        const flow = model.autopilotOnboarding
+        // Ignore a stream-open for a turn that is no longer pending (a stale
+        // subscription tail after the turn already resolved).
+        if (flow.pendingTurn === null || flow.pendingTurn.id !== turnId) {
+          return [model, []]
+        }
+        return [
+          evo(model, {
+            autopilotOnboarding: current =>
+              evo(current, {
+                status: () => 'streaming',
+                streamingReply: () => '',
+              }),
+          }),
+          [],
+        ]
+      },
+      ReceivedAutopilotOnboardingDelta: ({ turnId, text }) => {
+        const flow = model.autopilotOnboarding
+        if (flow.pendingTurn === null || flow.pendingTurn.id !== turnId) {
+          return [model, []]
+        }
+        return [
+          evo(model, {
+            autopilotOnboarding: current =>
+              evo(current, {
+                status: () => 'streaming',
+                streamingReply: reply => (reply ?? '') + text,
+              }),
+          }),
+          // Keep the newest tokens in view as they land (native scroll anchoring
+          // only pins when already at the bottom, so this never fights a user who
+          // scrolled up).
+          [ScrollAutopilotOnboardingThreadToEnd()],
         ]
       },
       SucceededAutopilotOnboardingTurn: ({ response }) => [
@@ -1198,13 +1199,15 @@ export const update = (model: Model, message: Message): UpdateReturn =>
               errorReason: () => null,
               turnCount: () => response.turnCount,
               outputSpec: () => response.outputSpec,
+              streamingReply: () => null,
+              pendingTurn: () => null,
               transcript: transcript => [
                 ...transcript,
                 { role: 'assistant', content: response.reply },
               ],
             }),
         }),
-        [],
+        [ScrollAutopilotOnboardingThreadToEnd()],
       ],
       FailedAutopilotOnboardingTurn: ({ reason }) => [
         evo(model, {
@@ -1212,6 +1215,8 @@ export const update = (model: Model, message: Message): UpdateReturn =>
             evo(flow, {
               status: () => 'error',
               errorReason: () => (reason === '' ? null : reason),
+              streamingReply: () => null,
+              pendingTurn: () => null,
             }),
         }),
         [],
@@ -1221,5 +1226,6 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         [OpenAutopilotCreditKickoff()],
       ],
       CompletedAutopilotOnboardingCreditKickoff: () => [model, []],
+      CompletedScrollAutopilotOnboardingThread: () => [model, []],
     }),
   )

--- a/apps/openagents.com/apps/web/src/styles.css
+++ b/apps/openagents.com/apps/web/src/styles.css
@@ -498,3 +498,63 @@
     transform: none;
   }
 }
+
+/*
+ * Streaming type cursor for the assistant reply (the `response` AI element).
+ * A Khala-cyan caret that blinks while a reply lands token-by-token. Honesty +
+ * accessibility rule: reduced-motion holds it static (no blink) but visible, so
+ * the "live" affordance still reads without motion.
+ */
+@keyframes oa-stream-cursor {
+  0%,
+  45% {
+    opacity: 1;
+  }
+  50%,
+  95% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@layer components {
+  .oa-stream-cursor {
+    animation: oa-stream-cursor 1.1s steps(2, jump-none) infinite;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .oa-stream-cursor {
+    animation: none;
+    opacity: 0.85;
+  }
+}
+
+/*
+ * Autopilot onboarding thread scroll region (problem #2). The thread is a
+ * fixed-height internal scroll area with the composer pinned below; only this
+ * region scrolls, not the whole page. `overscroll-contain` stops scroll-chaining
+ * to the page/scene; a thin dark scrollbar keeps it on-brand.
+ */
+@layer components {
+  .oa-thread-scroll {
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: #333 transparent;
+  }
+
+  .oa-thread-scroll::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .oa-thread-scroll::-webkit-scrollbar-thumb {
+    background-color: #2a2a2a;
+    border-radius: 0;
+  }
+
+  .oa-thread-scroll::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+}

--- a/apps/openagents.com/apps/web/src/subscriptions.test.ts
+++ b/apps/openagents.com/apps/web/src/subscriptions.test.ts
@@ -4,7 +4,13 @@ import {
   authBootstrapFromSession,
   incompleteOnboardingStatus,
 } from './domain/session'
-import { Demo, LoggedIn } from './model'
+import { Demo, LoggedIn, LoggedOut } from './model'
+import {
+  SubmittedAutopilotOnboardingTurn,
+  UpdatedAutopilotOnboardingComposer,
+} from './page/loggedOut/message'
+import { update as loggedOutUpdate } from './page/loggedOut/update'
+import { AutopilotRoute } from './route'
 import {
   ActiveChatRun,
   agentRunExternalRefFromNullable,
@@ -25,6 +31,7 @@ import {
   demoClockDependenciesForModel,
   demoKeyboardDependenciesForModel,
   demoPlaybackDependenciesForModel,
+  onboardingStreamDependenciesForModel,
   syncMessageFromPayload,
   syncStreamDependenciesForModel,
   workspaceSyncDependenciesForModel,
@@ -483,5 +490,37 @@ describe('demo clock subscriptions', () => {
       isActive: false,
       key: '',
     })
+  })
+})
+
+describe('autopilot onboarding stream subscription', () => {
+  const loggedOutBase = () => LoggedOut.init(AutopilotRoute())
+
+  test('is inactive with no pending turn', () => {
+    expect(onboardingStreamDependenciesForModel(loggedOutBase())).toEqual({
+      isActive: false,
+      turnId: '',
+      sessionId: '',
+      userText: '',
+      verticalOverlay: null,
+    })
+  })
+
+  test('activates and carries the pending turn once a turn is submitted', () => {
+    const [typed] = loggedOutUpdate(
+      loggedOutBase(),
+      UpdatedAutopilotOnboardingComposer({ value: 'I run a bakery' }),
+    )
+    const [submitted] = loggedOutUpdate(
+      typed,
+      SubmittedAutopilotOnboardingTurn(),
+    )
+
+    const deps = onboardingStreamDependenciesForModel(submitted)
+    expect(deps.isActive).toBe(true)
+    expect(deps.userText).toBe('I run a bakery')
+    // A first turn mints a fresh session id at the stream boundary.
+    expect(deps.sessionId).toMatch(/^ob_/)
+    expect(deps.turnId).not.toBe('')
   })
 })

--- a/apps/openagents.com/apps/web/src/subscriptions.ts
+++ b/apps/openagents.com/apps/web/src/subscriptions.ts
@@ -2,6 +2,8 @@ import { ServerMessage, SyncPatch } from '@openagentsinc/sync-schema'
 import { Duration, Effect, Exit, Queue, Schema as S, Stream } from 'effect'
 import { Subscription } from 'foldkit'
 
+import { parseJsonRecord } from './json-boundary'
+
 import {
   GotDemoMessage,
   GotLoggedInMessage,
@@ -20,11 +22,18 @@ import {
 } from './page/loggedIn/message'
 import {
   ClosedSettledFeedStream,
+  FailedAutopilotOnboardingTurn,
   FailedSettledFeedStream,
+  OpenedAutopilotOnboardingStream,
   OpenedSettledFeedStream,
+  ReceivedAutopilotOnboardingDelta,
   ReceivedSettledFeedCursorGap,
   ReceivedSettledFeedPatch,
+  SucceededAutopilotOnboardingTurn,
 } from './page/loggedOut/message'
+import type { Message as LoggedOutMessage } from './page/loggedOut/message'
+import { parseOnboardingStreamEvent } from './page/autopilot-onboarding/flow'
+import { newOnboardingSessionId } from './page/loggedOut/update'
 import { SETTLED_FEED_SCOPE } from './page/loggedOut/settled-feed'
 import {
   syncAgentRunScope,
@@ -427,6 +436,189 @@ const syncStreams = (
   )
 }
 
+// Live /autopilot onboarding turn stream (issue #6123 UI follow-up). When a turn
+// is pending (set on submit), open the SSE stream and dispatch prose deltas as
+// they arrive, then the terminal success/failure. Keyed by the turn id so the
+// stream opens EXACTLY ONCE per turn (the keepAliveEquivalence below holds the
+// open stream stable while a turn is in flight, and tears it down when the turn
+// resolves and `pendingTurn` clears).
+const inactiveOnboardingStream: {
+  readonly isActive: boolean
+  readonly turnId: string
+  readonly sessionId: string
+  readonly userText: string
+  readonly verticalOverlay: string | null
+} = {
+  isActive: false,
+  turnId: '',
+  sessionId: '',
+  userText: '',
+  verticalOverlay: null,
+}
+
+type OnboardingStreamDependencies = typeof inactiveOnboardingStream
+
+export const onboardingStreamDependenciesForModel = (
+  model: Model,
+): OnboardingStreamDependencies => {
+  if (model._tag !== 'LoggedOut') {
+    return inactiveOnboardingStream
+  }
+
+  const pending = model.autopilotOnboarding.pendingTurn
+  if (pending === null) {
+    return inactiveOnboardingStream
+  }
+
+  return {
+    isActive: true,
+    turnId: pending.id,
+    // Mint a session id at the stream boundary for the first turn (the server
+    // creates the session on first contact; later turns reuse it).
+    sessionId: pending.sessionId ?? newOnboardingSessionId(),
+    userText: pending.userText,
+    verticalOverlay: pending.verticalOverlay,
+  }
+}
+
+// Read a fetch SSE body to completion, parsing `event:`/`data:` blocks and
+// offering one message per parsed event into the subscription queue. The wire is
+// the narrow onboarding stream (`event: delta|done|error`). Mirrors the
+// settled-feed `Stream.callback` + acquireRelease lifecycle so an unmount aborts
+// the in-flight request cleanly.
+const onboardingStream = (
+  dependencies: OnboardingStreamDependencies,
+): Stream.Stream<Message> => {
+  if (!dependencies.isActive) {
+    return Stream.empty
+  }
+
+  const { turnId, sessionId, userText, verticalOverlay } = dependencies
+
+  return Stream.callback<Message>(queue =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        const controller = new AbortController()
+        const resource = { aborted: false, controller }
+
+        const offer = (message: LoggedOutMessage): void => {
+          if (!resource.aborted) {
+            Queue.offerUnsafe(queue, GotLoggedOutMessage({ message }))
+          }
+        }
+
+        const fail = (): void =>
+          offer(
+            FailedAutopilotOnboardingTurn({
+              reason:
+                'Autopilot could not respond just now. Try sending that again.',
+            }),
+          )
+
+        const run = async (): Promise<void> => {
+          const response = await fetch(
+            `/api/autopilot/onboarding/${encodeURIComponent(sessionId)}/turn`,
+            {
+              method: 'POST',
+              cache: 'no-store',
+              signal: controller.signal,
+              headers: {
+                accept: 'text/event-stream',
+                'content-type': 'application/json',
+              },
+              body: JSON.stringify({
+                userText,
+                ...(verticalOverlay === null ? {} : { verticalOverlay }),
+              }),
+            },
+          )
+
+          if (!response.ok || response.body === null) {
+            fail()
+            return
+          }
+
+          offer(OpenedAutopilotOnboardingStream({ turnId }))
+
+          const reader = response.body
+            .pipeThrough(new TextDecoderStream())
+            .getReader()
+          let buffer = ''
+
+          const drainBlock = (block: string): void => {
+            const lines = block.split(/\r?\n/)
+            const eventLine = lines.find(line => line.startsWith('event:'))
+            const dataLines = lines
+              .filter(line => line.startsWith('data:'))
+              .map(line => line.slice('data:'.length).replace(/^ /, ''))
+
+            if (dataLines.length === 0) {
+              return
+            }
+
+            const eventName =
+              eventLine === undefined
+                ? 'message'
+                : eventLine.slice('event:'.length).replace(/^ /, '').trim()
+            const data = parseJsonRecord(dataLines.join('\n'))
+            const parsed = parseOnboardingStreamEvent(eventName, data)
+
+            if (parsed === undefined) {
+              return
+            }
+
+            if (parsed.kind === 'delta') {
+              offer(
+                ReceivedAutopilotOnboardingDelta({
+                  turnId,
+                  text: parsed.text,
+                }),
+              )
+            } else if (parsed.kind === 'done') {
+              offer(SucceededAutopilotOnboardingTurn({ response: parsed.response }))
+            } else {
+              fail()
+            }
+          }
+
+          // Read frames; SSE events are separated by a blank line.
+          for (;;) {
+            const { done, value } = await reader.read()
+            if (done) {
+              break
+            }
+            buffer += value
+            let separator = buffer.search(/\r?\n\r?\n/)
+            while (separator !== -1) {
+              const block = buffer.slice(0, separator)
+              buffer = buffer.slice(separator).replace(/^\r?\n\r?\n/, '')
+              drainBlock(block)
+              separator = buffer.search(/\r?\n\r?\n/)
+            }
+          }
+          // Flush any trailing block without a terminating blank line.
+          if (buffer.trim() !== '') {
+            drainBlock(buffer)
+          }
+        }
+
+        run().catch(() => {
+          if (!resource.aborted) {
+            fail()
+          }
+        })
+
+        return resource
+      }),
+      resource =>
+        Effect.sync(() => {
+          resource.aborted = true
+          resource.controller.abort()
+        }),
+    ).pipe(Effect.flatMap(() => Effect.never)),
+  )
+}
+
 export const demoKeyboardDependenciesForModel = (model: Model) =>
   model._tag === 'Demo' && model.playback !== 'complete'
     ? { isActive: true, key: model.routeKey }
@@ -544,6 +736,23 @@ export const subscriptions = Subscription.make<Model, Message>()(entry => ({
       keepAliveEquivalence: (left, right) =>
         left.isActive === right.isActive && left.scope === right.scope,
       dependenciesToStream: settledFeedStream,
+    },
+  ),
+  autopilotOnboardingStream: entry(
+    {
+      isActive: S.Boolean,
+      turnId: S.String,
+      sessionId: S.String,
+      userText: S.String,
+      verticalOverlay: S.NullOr(S.String),
+    },
+    {
+      modelToDependencies: onboardingStreamDependenciesForModel,
+      // Hold the open stream stable for the duration of a single turn; a change
+      // of `turnId` (a new turn) tears down the old stream and opens a new one.
+      keepAliveEquivalence: (left, right) =>
+        left.isActive === right.isActive && left.turnId === right.turnId,
+      dependenciesToStream: onboardingStream,
     },
   ),
   demoPlayback: entry(

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -496,6 +496,14 @@ const runPromiseAllowlist = new Map([
   // run at that boundary. Named bridge; ratchet down if the streaming response is
   // expressed as an Effect Stream program end-to-end.
   ['workers/api/src/inference/chat-completions-routes.ts', 1],
+  // Added 2026-06-23 (#6123 UI follow-up): the /autopilot onboarding streaming
+  // turn route bridges the Effect-returning finalize step (append + persist) into
+  // the Web Streams `ReadableStream.start` controller callback ONCE, after the
+  // prose deltas drain, to commit the turn receipt-first. Same boundary as the
+  // chat-completions SSE bridge above (the controller API is not Effect-native and
+  // streaming must flow incrementally). Named bridge; ratchet down if the
+  // onboarding stream is expressed as an Effect Stream program end-to-end.
+  ['workers/api/src/autopilot-onboarding-routes.ts', 1],
 ])
 
 const runPromiseDetails = countByFile(sourceFiles, /Effect\.runPromise\(/g)

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-program.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-program.test.ts
@@ -12,7 +12,11 @@ import {
   type OnboardingInferenceClient,
   OnboardingInferenceError,
   type OnboardingSessionStore,
+  type OnboardingStreamClient,
+  type OnboardingStreamSource,
+  finalizeOnboardingStreamTurn,
   makeD1OnboardingSessionStore,
+  prepareOnboardingStreamTurn,
   runOnboardingTurn,
 } from './autopilot-onboarding-program'
 import type { InferenceRequest } from './inference/provider-adapter'
@@ -332,5 +336,82 @@ describe('onboarding session store', () => {
     expect(persisted?.turnCount).toBe(2)
     expect(persisted?.outputSpec.quickWin).toBe('fix site')
     expect(persisted?.transcript).toHaveLength(2)
+  })
+})
+
+// STREAMING TURN DRIVER ---------------------------------------------------
+
+const chunkStreamClient =
+  (chunks: ReadonlyArray<string>): OnboardingStreamClient =>
+  () =>
+    Effect.succeed<OnboardingStreamSource>({
+      deltas: (async function* () {
+        for (const chunk of chunks) {
+          yield chunk
+        }
+      })(),
+      final: () => chunks.join(''),
+    })
+
+const drain = async (source: OnboardingStreamSource): Promise<string> => {
+  let text = ''
+  for await (const delta of source.deltas) {
+    text += delta
+  }
+  const final = source.final()
+  return final === '' ? text : final
+}
+
+describe('streaming onboarding turn driver', () => {
+  test('prepare reads/creates the session and opens the stream; finalize appends + persists', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+    const deps = {
+      store,
+      stream: chunkStreamClient(['Hel', 'lo!']),
+      nowIso: () => '2026-06-23T00:00:00.000Z',
+    }
+
+    const turn = await run(
+      prepareOnboardingStreamTurn(
+        { sessionId: 'sess-stream', userText: 'hi there', verticalOverlay: null },
+        deps,
+      ),
+    )
+    expect(turn.userText).toBe('hi there')
+    expect(turn.session.id).toBe('sess-stream')
+    // The streaming request flag is set on the assembled inference request.
+    const reply = await drain(turn.source)
+    expect(reply).toBe('Hello!')
+
+    const result = await run(
+      finalizeOnboardingStreamTurn(turn, reply, {
+        store,
+        nowIso: () => '2026-06-23T00:01:00.000Z',
+      }),
+    )
+    expect(result.turnCount).toBe(1)
+    expect(result.reply).toBe('Hello!')
+
+    const persisted = await run(store.read('sess-stream'))
+    expect(persisted?.turnCount).toBe(1)
+    expect(persisted?.transcript).toEqual([
+      { role: 'user', content: 'hi there' },
+      { role: 'assistant', content: 'Hello!' },
+    ])
+  })
+
+  test('prepare rejects an empty user text before opening any stream', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+    const result = await Effect.runPromiseExit(
+      prepareOnboardingStreamTurn(
+        { sessionId: 'sess-empty', userText: '   ', verticalOverlay: null },
+        {
+          store,
+          stream: chunkStreamClient(['unused']),
+          nowIso: () => '2026-06-23T00:00:00.000Z',
+        },
+      ),
+    )
+    expect(result._tag).toBe('Failure')
   })
 })

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-program.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-program.ts
@@ -115,6 +115,25 @@ export class OnboardingInferenceError extends S.TaggedErrorClass<OnboardingInfer
   },
 ) {}
 
+// STREAMING INFERENCE SEAM ------------------------------------------------
+
+// The streaming inference seam. Given the assembled message list, return a
+// source whose `deltas` async-iterable yields assistant TEXT increments as the
+// upstream produces them, and whose `final()` resolves the full reply once the
+// stream is drained. Production wires this to the provider-adapter `streamSse`
+// (or buffered `stream`) path; tests inject a deterministic stub. This is the
+// streaming complement to `OnboardingInferenceClient` — same input, incremental
+// output. Errors surface as the same tagged failure the route already maps.
+export type OnboardingStreamSource = Readonly<{
+  deltas: AsyncIterable<string>
+  // Resolves AFTER `deltas` is exhausted, with the full accumulated reply.
+  final: () => string
+}>
+
+export type OnboardingStreamClient = (
+  request: InferenceRequest,
+) => Effect.Effect<OnboardingStreamSource, OnboardingInferenceError>
+
 export class OnboardingStorageError extends S.TaggedErrorClass<OnboardingStorageError>()(
   'OnboardingStorageError',
   {
@@ -318,6 +337,120 @@ export const runOnboardingTurn = (
     }
 
     const reply = yield* deps.infer(request)
+
+    const userTurn: OnboardingTranscriptTurn = { role: 'user', content: userText }
+    const assistantTurn: OnboardingTranscriptTurn = {
+      role: 'assistant',
+      content: reply,
+    }
+
+    const advanced: OnboardingSession = {
+      id: session.id,
+      verticalOverlay: session.verticalOverlay,
+      status: session.status,
+      transcript: [...session.transcript, userTurn, assistantTurn],
+      outputSpec: session.outputSpec,
+      turnCount: session.turnCount + 1,
+      createdAt: session.createdAt,
+      updatedAt: now,
+    }
+
+    yield* deps.store.upsert(advanced)
+
+    return {
+      sessionId: advanced.id,
+      reply,
+      status: advanced.status,
+      turnCount: advanced.turnCount,
+      outputSpec: advanced.outputSpec,
+    } satisfies OnboardingTurnResponse
+  })
+
+// STREAMING TURN DRIVER ---------------------------------------------------
+
+// The validated, in-flight state of a streaming turn: the session it advances,
+// the user text for this turn, and the live stream source. The route pumps the
+// source's `deltas` to the client, then calls `finalizeOnboardingStreamTurn`
+// with the same session + the full reply to append + persist + build the final
+// response. Splitting prepare/finalize lets the route own the SSE pump while the
+// program keeps the read/build/persist logic and the single validation point.
+export type OnboardingStreamTurn = Readonly<{
+  session: OnboardingSession
+  userText: string
+  source: OnboardingStreamSource
+}>
+
+export type OnboardingStreamTurnDeps = Readonly<{
+  store: OnboardingSessionStore
+  stream: OnboardingStreamClient
+  nowIso: () => string
+}>
+
+// Prepare a streaming turn: validate the user text, read (or create) the
+// session, and open the stream. Mirrors the non-streaming driver's validation +
+// session-resolution, so the streaming and buffered paths cannot diverge.
+export const prepareOnboardingStreamTurn = (
+  input: OnboardingTurnInput,
+  deps: OnboardingStreamTurnDeps,
+): Effect.Effect<
+  OnboardingStreamTurn,
+  OnboardingInferenceError | OnboardingStorageError | OnboardingValidationError
+> =>
+  Effect.gen(function* () {
+    const userText = input.userText.trim()
+    if (userText === '') {
+      return yield* new OnboardingValidationError({
+        reason: 'userText must not be empty',
+      })
+    }
+    if (userText.length > MAX_USER_TEXT_LENGTH) {
+      return yield* new OnboardingValidationError({
+        reason: `userText exceeds ${MAX_USER_TEXT_LENGTH} characters`,
+      })
+    }
+
+    const now = deps.nowIso()
+    const existing = yield* deps.store.read(input.sessionId)
+
+    const session: OnboardingSession =
+      existing ??
+      ({
+        id: input.sessionId,
+        verticalOverlay: input.verticalOverlay,
+        status: 'interviewing',
+        transcript: [],
+        outputSpec: {},
+        turnCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      } satisfies OnboardingSession)
+
+    const messages = buildOnboardingMessages(session, userText)
+
+    const request: InferenceRequest = {
+      model: KHALA_ONBOARDING_MODEL,
+      messages,
+      stream: true,
+      passthroughParams: {},
+    }
+
+    const source = yield* deps.stream(request)
+
+    return { session, userText, source }
+  })
+
+// Finalize a streaming turn once the deltas are drained: append the exchange,
+// persist, and build the same `OnboardingTurnResponse` the buffered path returns.
+// Only needs the store + clock (the stream is already drained), so it takes the
+// narrower deps shape — the route drives it at the streaming boundary.
+export const finalizeOnboardingStreamTurn = (
+  turn: OnboardingStreamTurn,
+  reply: string,
+  deps: Readonly<{ store: OnboardingSessionStore; nowIso: () => string }>,
+): Effect.Effect<OnboardingTurnResponse, OnboardingStorageError> =>
+  Effect.gen(function* () {
+    const { session, userText } = turn
+    const now = deps.nowIso()
 
     const userTurn: OnboardingTranscriptTurn = { role: 'user', content: userText }
     const assistantTurn: OnboardingTranscriptTurn = {

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from 'vitest'
 import {
   type OnboardingInferenceClient,
   OnboardingInferenceError,
+  type OnboardingStreamClient,
+  type OnboardingStreamSource,
 } from './autopilot-onboarding-program'
 import { makeAutopilotOnboardingRoutes } from './autopilot-onboarding-routes'
 
@@ -189,6 +191,124 @@ describe('POST /api/autopilot/onboarding/{sessionId}/turn', () => {
     expect(response.status).toBe(502)
     const body = (await response.json()) as { error: string }
     expect(body.error).toBe('inference_unavailable')
+  })
+
+  // STREAMING (SSE) PATH ---------------------------------------------------
+
+  const streamRequest = (sessionId: string, body: unknown): Request =>
+    new Request(
+      `https://openagents.com/api/autopilot/onboarding/${sessionId}/turn`,
+      {
+        body: JSON.stringify(body),
+        method: 'POST',
+        headers: { accept: 'text/event-stream' },
+      },
+    )
+
+  // A stub stream client that yields the given chunks as deltas.
+  const chunkStream =
+    (chunks: ReadonlyArray<string>): OnboardingStreamClient =>
+    () =>
+      Effect.succeed<OnboardingStreamSource>({
+        deltas: (async function* () {
+          for (const chunk of chunks) {
+            yield chunk
+          }
+        })(),
+        final: () => chunks.join(''),
+      })
+
+  const failingStream: OnboardingStreamClient = () =>
+    new OnboardingInferenceError({ reason: 'no provider lane configured' })
+
+  const streamRoutesWith = (stream: OnboardingStreamClient) =>
+    makeAutopilotOnboardingRoutes<Env>({
+      makeInferenceClient: () => echoInference,
+      makeStreamClient: () => stream,
+      nowIso: () => '2026-06-23T00:00:00.000Z',
+    })
+
+  test('streams prose deltas then a terminal done payload (SSE)', async () => {
+    const routes = streamRoutesWith(chunkStream(['Great', ' — ', 'what next?']))
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        streamRequest('sess-stream', { userText: 'I run a bakery.' }),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+
+    const text = await response.text()
+    // Three delta frames, in order, then one done frame.
+    expect(text).toContain('event: delta\ndata: {"text":"Great"}')
+    expect(text).toContain('event: delta\ndata: {"text":" — "}')
+    expect(text).toContain('event: delta\ndata: {"text":"what next?"}')
+    expect(text).toContain('event: done')
+
+    // The done frame carries the full reply + advanced turn count.
+    const doneLine = text
+      .split('\n')
+      .find(line => line.startsWith('data: {"sessionId"'))
+    const done = JSON.parse((doneLine ?? '').slice('data: '.length)) as {
+      reply: string
+      turnCount: number
+      sessionId: string
+    }
+    expect(done.reply).toBe('Great — what next?')
+    expect(done.turnCount).toBe(1)
+    expect(done.sessionId).toBe('sess-stream')
+  })
+
+  test('the streamed turn persists (a follow-up turn advances the count)', async () => {
+    const routes = streamRoutesWith(chunkStream(['ok']))
+    const env = makeEnv()
+    await run(
+      routes.routeOnboardingTurnRequest(
+        streamRequest('sess-stream-2', { userText: 'first' }),
+        env,
+      ),
+    )
+    const second = await run(
+      routes.routeOnboardingTurnRequest(
+        streamRequest('sess-stream-2', { userText: 'second' }),
+        env,
+      ),
+    )
+    const text = await second.text()
+    const doneLine = text
+      .split('\n')
+      .find(line => line.startsWith('data: {"sessionId"'))
+    const done = JSON.parse((doneLine ?? '').slice('data: '.length)) as {
+      turnCount: number
+    }
+    expect(done.turnCount).toBe(2)
+  })
+
+  test('a stream-open failure maps to a clean 502 before any byte is sent', async () => {
+    const routes = streamRoutesWith(failingStream)
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        streamRequest('sess-stream-3', { userText: 'hello' }),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(502)
+    const body = (await response.json()) as { error: string }
+    expect(body.error).toBe('inference_unavailable')
+  })
+
+  test('an SSE request with no stream client wired falls back to the buffered JSON path', async () => {
+    // No makeStreamClient -> content negotiation degrades to JSON (fail-safe).
+    const routes = routesWith(echoInference)
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        streamRequest('sess-fallback', { userText: 'hello' }),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/json')
   })
 
   test('passes the vertical overlay through to the inference seam', async () => {

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.ts
@@ -16,10 +16,15 @@ import {
   type OnboardingInferenceClient,
   OnboardingInferenceError,
   type OnboardingSessionStore,
+  type OnboardingStreamClient,
+  type OnboardingStreamTurn,
   OnboardingStorageError,
   OnboardingTurnRequest,
+  type OnboardingTurnResponse,
   OnboardingValidationError,
+  finalizeOnboardingStreamTurn,
   makeD1OnboardingSessionStore,
+  prepareOnboardingStreamTurn,
   runOnboardingTurn,
 } from './autopilot-onboarding-program'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
@@ -56,6 +61,12 @@ export type OnboardingRouteDependencies<Env extends OnboardingRouteEnv> =
     // the provider-adapter registry + overflow dispatch (no external HTTP hop);
     // tests inject a stub.
     makeInferenceClient: (env: WorkerEnv<Env>) => OnboardingInferenceClient
+    // Resolves the STREAMING inference client for the request env (the SSE path).
+    // Optional: when absent, the route serves the buffered JSON path even for an
+    // `Accept: text/event-stream` request (fail-safe — no behaviour regression).
+    makeStreamClient?:
+      | ((env: WorkerEnv<Env>) => OnboardingStreamClient)
+      | undefined
     // Overridable for tests; defaults to the D1-backed store.
     makeStore?: ((env: WorkerEnv<Env>) => OnboardingSessionStore) | undefined
     nowIso?: (() => string) | undefined
@@ -100,10 +111,99 @@ const routeErrorResponse = (error: OnboardingRouteError): HttpResponse =>
     M.exhaustive,
   )
 
+// A narrow SSE frame for the onboarding stream. We do NOT reuse the
+// OpenAI-compatible chat-completions wire here: the onboarding client only needs
+// prose deltas + a terminal payload, so the wire is intentionally minimal and
+// self-describing (the client's `parseComponentFrames`-style splitter reads it):
+//   event: delta   data: { "text": "…" }     (one per content increment)
+//   event: done    data: <OnboardingTurnResponse JSON>   (terminal, once)
+//   event: error   data: { "error": "…" }     (terminal, on failure)
+const sseFrame = (event: string, payload: unknown): string =>
+  `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`
+
+const STREAM_HEADERS: Readonly<Record<string, string>> = {
+  'content-type': 'text/event-stream; charset=utf-8',
+  'cache-control': 'no-store',
+  connection: 'keep-alive',
+  'x-accel-buffering': 'no',
+}
+
+const wantsEventStream = (request: Request): boolean => {
+  const accept = request.headers.get('accept') ?? ''
+  return accept.toLowerCase().includes('text/event-stream')
+}
+
+// Build the SSE response body for a prepared streaming turn. Pumps prose deltas,
+// then calls `finalize` (a plain Promise so the effect boundary stays OUT of the
+// Effect.gen request pipeline) to append + persist and resolve the terminal
+// payload, then emits the `done` frame. A failure at any point emits a terminal
+// `error` frame and closes — the client never hangs.
+const makeOnboardingStreamBody = (
+  turn: OnboardingStreamTurn,
+  finalize: (reply: string) => Promise<OnboardingTurnResponse>,
+): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let accumulated = ''
+      try {
+        for await (const delta of turn.source.deltas) {
+          if (delta !== '') {
+            accumulated += delta
+            controller.enqueue(encoder.encode(sseFrame('delta', { text: delta })))
+          }
+        }
+        const final = turn.source.final()
+        const reply = final === '' ? accumulated : final
+        const result = await finalize(reply)
+        controller.enqueue(encoder.encode(sseFrame('done', result)))
+      } catch {
+        controller.enqueue(
+          encoder.encode(sseFrame('error', { error: 'stream_failed' })),
+        )
+      } finally {
+        controller.close()
+      }
+    },
+  })
+}
+
+// Construct the streaming `Response` for a prepared turn. The finalize step
+// (append + persist) is a plain Promise driven by `Effect.runPromise` HERE — at
+// the streaming boundary, outside any request Effect pipeline — so the SSE pump
+// owns its own effect run.
+const buildStreamResponse = (
+  turn: OnboardingStreamTurn,
+  store: OnboardingSessionStore,
+  nowIso: () => string,
+): globalThis.Response => {
+  const finalize = (reply: string): Promise<OnboardingTurnResponse> =>
+    Effect.runPromise(finalizeOnboardingStreamTurn(turn, reply, { store, nowIso }))
+
+  return new Response(makeOnboardingStreamBody(turn, finalize), {
+    headers: STREAM_HEADERS,
+  })
+}
+
+const errorReason = (error: OnboardingRouteError): string =>
+  M.value(error).pipe(
+    M.tags({
+      OnboardingBadRequest: () => 'bad_request',
+      OnboardingValidationError: () => 'validation_error',
+      OnboardingInferenceError: () => 'inference_unavailable',
+      OnboardingStorageError: () => 'storage_error',
+    }),
+    M.exhaustive,
+  )
+
 export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
   dependencies: OnboardingRouteDependencies<Env>,
 ) => {
   const nowIso = dependencies.nowIso ?? currentIsoTimestamp
+
+  const resolveStore = (env: WorkerEnv<Env>): OnboardingSessionStore =>
+    dependencies.makeStore?.(env) ??
+    makeD1OnboardingSessionStore(openAgentsDatabase(env))
 
   const turnResponse = (
     request: Request,
@@ -112,9 +212,6 @@ export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
   ): OnboardingRouteEffect =>
     Effect.gen(function* () {
       const body = yield* decodeJsonBody(request, OnboardingTurnRequest)
-      const store =
-        dependencies.makeStore?.(env) ??
-        makeD1OnboardingSessionStore(openAgentsDatabase(env))
 
       const result = yield* runOnboardingTurn(
         {
@@ -125,7 +222,7 @@ export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
         {
           infer: dependencies.makeInferenceClient(env),
           nowIso,
-          store,
+          store: resolveStore(env),
         },
       )
 
@@ -133,6 +230,43 @@ export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
     }).pipe(
       Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
     )
+
+  // The SSE streaming path. Prepares the turn (validate + read/create session +
+  // open the stream) on the request path so validation/storage failures map to a
+  // clean error BEFORE any stream byte is committed; then returns a ReadableStream
+  // that pumps prose deltas, finalizes (append + persist), and emits the terminal
+  // `done` payload. A failure mid-prepare returns a normal JSON error response; a
+  // failure mid-stream emits a terminal `error` SSE frame and closes.
+  const streamResponse = (
+    request: Request,
+    env: WorkerEnv<Env>,
+    sessionId: string,
+    makeStreamClient: (env: WorkerEnv<Env>) => OnboardingStreamClient,
+  ): OnboardingRouteEffect => {
+    const store = resolveStore(env)
+    const streamClient = makeStreamClient(env)
+
+    return decodeJsonBody(request, OnboardingTurnRequest).pipe(
+      Effect.flatMap(body =>
+        prepareOnboardingStreamTurn(
+          {
+            sessionId,
+            userText: body.userText,
+            verticalOverlay: body.verticalOverlay ?? null,
+          },
+          { nowIso, store, stream: streamClient },
+        ),
+      ),
+      // The Response construction is a PURE transform of the prepared turn; the
+      // SSE pump + finalize (a plain Promise via `Effect.runPromise`) run AFTER
+      // this request Effect resolves, so the effect boundary stays out of the
+      // request pipeline.
+      Effect.map(turn => buildStreamResponse(turn, store, nowIso)),
+      // A prepare-time failure (validation / storage / inference open) becomes a
+      // clean JSON error — the stream was never started.
+      Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
+    )
+  }
 
   return {
     routeOnboardingTurnRequest: (
@@ -147,9 +281,23 @@ export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
         return undefined
       }
 
-      return request.method === 'POST'
-        ? turnResponse(request, env, decodeURIComponent(match[1] ?? ''))
-        : Effect.succeed(methodNotAllowed(['POST']))
+      if (request.method !== 'POST') {
+        return Effect.succeed(methodNotAllowed(['POST']))
+      }
+
+      const sessionId = decodeURIComponent(match[1] ?? '')
+      const makeStreamClient = dependencies.makeStreamClient
+
+      // Content-negotiated: an `Accept: text/event-stream` request streams when a
+      // stream client is wired; otherwise the buffered JSON path serves (and is
+      // the fail-safe default whenever streaming is unavailable).
+      return wantsEventStream(request) && makeStreamClient !== undefined
+        ? streamResponse(request, env, sessionId, makeStreamClient)
+        : turnResponse(request, env, sessionId)
     },
   }
 }
+
+// Re-exported for tests that assert the SSE wire shape directly.
+export const onboardingSseFrame = sseFrame
+export const onboardingStreamError = errorReason

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -40,6 +40,8 @@ import { makeAutopilotOnboardingRoutes } from './autopilot-onboarding-routes'
 import {
   type OnboardingInferenceClient,
   OnboardingInferenceError,
+  type OnboardingStreamClient,
+  type OnboardingStreamSource,
 } from './autopilot-onboarding-program'
 import {
   handleProgrammaticAgentHome,
@@ -388,6 +390,7 @@ import {
   InferenceAdapterError,
   type InferenceRequest,
   type InferenceResult,
+  type InferenceStreamChunk,
   InferenceProviderRegistry,
 } from './inference/provider-adapter'
 import { makeAdmittedOpenAgentsNetworkAdapter } from './inference/openagents-network-adapter'
@@ -7057,6 +7060,7 @@ const agentGoalRoutes = makeAgentGoalRoutes({
 
 const autopilotOnboardingRoutes = makeAutopilotOnboardingRoutes<WorkerBindings>({
   makeInferenceClient: env => makeOnboardingInferenceClient(env),
+  makeStreamClient: env => makeOnboardingStreamClient(env),
 })
 
 const checkoutPageRoutes = makeCheckoutPageRoutes<WorkerBindings>({
@@ -8553,6 +8557,44 @@ const makeOnboardingInferenceClient = (
       { plan: selectAdapterPlan, registry: inferenceProviderRegistry },
     ).pipe(
       Effect.map(result => result.content),
+      Effect.mapError(
+        error => new OnboardingInferenceError({ reason: error.reason }),
+      ),
+    )
+}
+
+// STREAMING onboarding client (issue #6123 UI follow-up). The same provider-
+// adapter registry + overflow dispatch as the buffered client, but it dispatches
+// the adapter's chunked `stream` and exposes the chunks as an
+// `OnboardingStreamSource` (a deltas async-iterable + a `final()` accumulation).
+// The interview reply is short, so the buffered-chunk path is the right reuse:
+// every adapter implements `stream` (the optional `streamSse` is for the long-
+// generation hot path), and the route pumps the chunks to the client as SSE.
+const makeOnboardingStreamClient = (
+  env: OnboardingInferenceEnv,
+): OnboardingStreamClient => {
+  registerPassthroughAdapters(inferenceProviderRegistry, env)
+  registerFabricServeAdapter(inferenceProviderRegistry, env)
+  setInferenceAdapterEnv(env)
+  return (request: InferenceRequest) =>
+    dispatchWithOverflow<ReadonlyArray<InferenceStreamChunk>>(
+      request,
+      (adapter, req) => adapter.stream(req),
+      { plan: selectAdapterPlan, registry: inferenceProviderRegistry },
+    ).pipe(
+      Effect.map((chunks): OnboardingStreamSource => {
+        const reply = chunks.map(chunk => chunk.contentDelta).join('')
+        return {
+          deltas: (async function* () {
+            for (const chunk of chunks) {
+              if (chunk.contentDelta !== '') {
+                yield chunk.contentDelta
+              }
+            }
+          })(),
+          final: () => reply,
+        }
+      }),
       Effect.mapError(
         error => new OnboardingInferenceError({ reason: error.reason }),
       ),

--- a/packages/ui/src/ai-elements/base.ts
+++ b/packages/ui/src/ai-elements/base.ts
@@ -70,6 +70,14 @@ export const aiElementPorts: ReadonlyArray<AiElementPort> = [
     primitives: ['Message', 'MessageContent', 'MessageActions', 'MessageMeta'],
   },
   {
+    moduleId: 'response',
+    label: 'Response',
+    category: 'chat',
+    purpose:
+      'Render assistant Markdown prose (bold, italics, headings, lists, inline/fenced code, links, blockquotes, rules) as typed Foldkit nodes, tolerating incomplete/streaming markdown, with a streaming cursor affordance.',
+    primitives: ['Response', 'ResponseCode', 'ResponseCursor'],
+  },
+  {
     moduleId: 'code-block',
     label: 'Code Block',
     category: 'code',

--- a/packages/ui/src/ai-elements/index.ts
+++ b/packages/ui/src/ai-elements/index.ts
@@ -6,6 +6,7 @@
 export * from './base'
 export * from './prompt-input'
 export * from './message'
+export * from './response'
 export * from './code-block'
 export * from './task'
 export * from './sources'

--- a/packages/ui/src/ai-elements/message.ts
+++ b/packages/ui/src/ai-elements/message.ts
@@ -5,6 +5,7 @@ import { html } from 'foldkit/html'
 
 import { eyebrowClass, metaClass } from '../primitives'
 import { aiElementBase } from './base'
+import { response } from './response'
 
 const MODULE_ID = 'message'
 
@@ -81,15 +82,35 @@ export const messageContent = <Message>(input: {
   )
 }
 
-// A single chat turn. `body` is the simple text path; pass `extra` (e.g. a code
-// block, sources, or an actions row) for richer assistant turns.
+// A single chat turn. Body paths, in precedence order:
+//   - `markdown`: render the body through the centralized `response` Markdown
+//     element (bold/italics/headings/lists/code/links), streaming-tolerant.
+//     Pass `streaming: true` to append a live typing cursor while a reply lands.
+//   - `props.body`: the plain-text path (no markdown parsing).
+// `extra` (e.g. a code block, sources, or an actions row) appends after the body.
 export const message = <Message>(input: {
   props: MessageProps
+  markdown?: string
+  streaming?: boolean
   extra?: ReadonlyArray<Html>
   attrs?: ReadonlyArray<Attribute<Message>>
 }): Html => {
   const h = html<Message>()
   const props = Schema.decodeUnknownSync(MessageProps)(input.props)
+
+  const bodyChildren: ReadonlyArray<Html | string> =
+    input.markdown !== undefined
+      ? [
+          response<Message>({
+            markdown: input.markdown,
+            ...(input.streaming === undefined
+              ? {}
+              : { streaming: input.streaming }),
+          }),
+        ]
+      : props.body === undefined
+        ? []
+        : [props.body]
 
   return h.div(
     [
@@ -111,10 +132,7 @@ export const message = <Message>(input: {
           }),
       messageContent<Message>({
         role: props.role,
-        children: [
-          ...(props.body === undefined ? [] : [props.body]),
-          ...(input.extra ?? []),
-        ],
+        children: [...bodyChildren, ...(input.extra ?? [])],
       }),
     ],
   )

--- a/packages/ui/src/ai-elements/response.ts
+++ b/packages/ui/src/ai-elements/response.ts
@@ -1,0 +1,480 @@
+import { clsx } from 'clsx'
+import type { Attribute, Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import { aiElementBase } from './base'
+
+const MODULE_ID = 'response'
+
+// A streaming-tolerant Markdown renderer, the centralized AI Element every chat
+// surface uses to render assistant prose. There is no raw-HTML escape hatch in
+// Foldkit's virtual DOM (text nodes auto-escape), so this parses Markdown into a
+// tree of typed Foldkit `Html` nodes — never an HTML string. That is the safe,
+// auditable path (AGENTS.md bans innerHTML); a malformed model reply can only
+// ever produce text nodes, never injected markup.
+//
+// STREAMING DISCIPLINE (the Vercel "streamdown" pattern): the input may be an
+// INCOMPLETE markdown fragment mid-stream — a half-open `**`, a dangling `` ` ``,
+// an unterminated ```fence```, a list item still being typed. The parser must
+// never throw and must never flash broken syntax: dangling inline markers render
+// as plain text up to the cursor, and an unterminated fenced block renders the
+// lines captured so far as a code block. Each delta re-parses the whole
+// accumulated text (cheap for chat-length replies), so the tree is always a
+// correct render of "the markdown so far".
+//
+// Scope is deliberately the common chat subset — bold, italic, inline code,
+// links, headings, unordered/ordered lists, blockquotes, fenced + indented code,
+// horizontal rules, paragraphs. Not a full CommonMark engine (no tables, nested
+// blockquotes, reference links, HTML passthrough); those degrade to readable
+// plain text rather than rendering wrong.
+
+// CLASSES — dark-only, mono-first, matching DESIGN.md tokens. Headings are mono
+// off-white; links are Khala-blue; code is framed in the panel surface; list
+// markers are subtle. No light theme, no decorative gradients.
+export const responseClass =
+  'grid gap-2 text-[0.8125rem] leading-[1.5] text-[#f1efe8] [overflow-wrap:anywhere]'
+export const responseHeadingClass = 'm-0 font-medium text-[#f1efe8] leading-[1.3]'
+export const responseH1Class = clsx(responseHeadingClass, 'text-[1.05rem]')
+export const responseH2Class = clsx(responseHeadingClass, 'text-[0.95rem]')
+export const responseH3Class = clsx(
+  responseHeadingClass,
+  'text-[0.875rem] uppercase tracking-[0.04em] text-white/80',
+)
+export const responseParagraphClass = 'm-0 text-[0.8125rem] leading-[1.5]'
+export const responseListClass = 'm-0 grid gap-1 pl-4'
+export const responseOrderedListClass = clsx(responseListClass, 'list-decimal')
+export const responseUnorderedListClass = clsx(responseListClass, 'list-disc')
+export const responseListItemClass =
+  'text-[0.8125rem] leading-[1.45] marker:text-white/35'
+export const responseInlineCodeClass =
+  'border border-[#222] bg-[#0a0a0a] px-1 py-px font-mono text-[0.75rem] text-[#f1efe8]'
+export const responseCodeBlockClass =
+  'm-0 overflow-x-auto border border-[#222] bg-[#010102] px-3 py-2.5 font-mono text-[0.75rem] leading-[1.45] text-[#f1efe8]'
+export const responseLinkClass =
+  'text-[#7aa2ff] underline decoration-[#3a7bff]/40 underline-offset-2 hover:text-[#a8c2ff]'
+export const responseBlockquoteClass =
+  'm-0 border-l border-[#3a7bff]/30 pl-3 text-white/70 italic'
+export const responseRuleClass = 'm-0 h-px w-full border-0 bg-[#222]'
+export const responseStrongClass = 'font-semibold text-white/90'
+export const responseEmphasisClass = 'italic'
+
+// INLINE PARSING ----------------------------------------------------------
+
+// A bounded inline tokenizer over a single line of text. Handles, in priority
+// order, inline code (`` `code` ``), links (`[text](url)`), bold (`**` / `__`),
+// and italic (`*` / `_`). A dangling/unterminated marker renders as the literal
+// text from the marker to the end — the streaming-tolerant contract.
+//
+// Returns a list of Foldkit inline nodes (text + element nodes). Links are
+// rendered with an explicit safe-href guard so a model-supplied `javascript:`
+// URL degrades to plain text.
+const isSafeHref = (href: string): boolean => {
+  const trimmed = href.trim()
+  if (trimmed === '') {
+    return false
+  }
+  // Allow relative, anchor, and the http(s)/mailto schemes only. Everything else
+  // (javascript:, data:, vbscript:, …) renders as plain text, never a link.
+  return (
+    /^https?:\/\//i.test(trimmed) ||
+    /^mailto:/i.test(trimmed) ||
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('#')
+  )
+}
+
+const renderInline = <Message>(text: string): ReadonlyArray<Html | string> => {
+  const h = html<Message>()
+  const nodes: Array<Html | string> = []
+  let buffer = ''
+  let index = 0
+
+  const flush = (): void => {
+    if (buffer !== '') {
+      nodes.push(buffer)
+      buffer = ''
+    }
+  }
+
+  while (index < text.length) {
+    const rest = text.slice(index)
+
+    // Inline code: `…`. Highest priority — its content is never further parsed.
+    if (rest.startsWith('`')) {
+      const end = rest.indexOf('`', 1)
+      if (end > 0) {
+        flush()
+        nodes.push(
+          h.code([h.Class(responseInlineCodeClass)], [rest.slice(1, end)]),
+        )
+        index += end + 1
+        continue
+      }
+      // Dangling backtick mid-stream: emit the literal char, keep scanning.
+      buffer += '`'
+      index += 1
+      continue
+    }
+
+    // Link: [text](href).
+    if (rest.startsWith('[')) {
+      const labelEnd = rest.indexOf(']')
+      if (labelEnd > 0 && rest[labelEnd + 1] === '(') {
+        const hrefEnd = rest.indexOf(')', labelEnd + 2)
+        if (hrefEnd > labelEnd + 1) {
+          const label = rest.slice(1, labelEnd)
+          const href = rest.slice(labelEnd + 2, hrefEnd)
+          flush()
+          if (isSafeHref(href)) {
+            nodes.push(
+              h.a(
+                [
+                  h.Href(href),
+                  h.Target('_blank'),
+                  h.Rel('noopener noreferrer'),
+                  h.Class(responseLinkClass),
+                ],
+                renderInline<Message>(label),
+              ),
+            )
+          } else {
+            // Unsafe scheme: render the visible label as plain inline text.
+            nodes.push(...renderInline<Message>(label))
+          }
+          index += hrefEnd + 1
+          continue
+        }
+      }
+      // Incomplete link mid-stream: literal `[`, keep scanning.
+      buffer += '['
+      index += 1
+      continue
+    }
+
+    // Bold: ** … ** or __ … __.
+    const boldMarker = rest.startsWith('**') ? '**' : rest.startsWith('__') ? '__' : ''
+    if (boldMarker !== '') {
+      const end = rest.indexOf(boldMarker, boldMarker.length)
+      if (end > 0) {
+        flush()
+        nodes.push(
+          h.strong(
+            [h.Class(responseStrongClass)],
+            renderInline<Message>(rest.slice(boldMarker.length, end)),
+          ),
+        )
+        index += end + boldMarker.length
+        continue
+      }
+      // Dangling bold marker mid-stream: literal text, keep scanning.
+      buffer += boldMarker
+      index += boldMarker.length
+      continue
+    }
+
+    // Italic: * … * or _ … _ (single marker, not part of a bold pair).
+    const italicMarker =
+      rest.startsWith('*') ? '*' : rest.startsWith('_') ? '_' : ''
+    if (italicMarker !== '') {
+      const end = rest.indexOf(italicMarker, 1)
+      if (end > 0) {
+        flush()
+        nodes.push(
+          h.em(
+            [h.Class(responseEmphasisClass)],
+            renderInline<Message>(rest.slice(1, end)),
+          ),
+        )
+        index += end + 1
+        continue
+      }
+      buffer += italicMarker
+      index += 1
+      continue
+    }
+
+    buffer += text[index]
+    index += 1
+  }
+
+  flush()
+  return nodes
+}
+
+// BLOCK PARSING -----------------------------------------------------------
+
+type Block =
+  | Readonly<{ kind: 'heading'; level: 1 | 2 | 3; text: string }>
+  | Readonly<{ kind: 'paragraph'; text: string }>
+  | Readonly<{ kind: 'unordered-list'; items: ReadonlyArray<string> }>
+  | Readonly<{ kind: 'ordered-list'; items: ReadonlyArray<string> }>
+  | Readonly<{ kind: 'blockquote'; text: string }>
+  | Readonly<{ kind: 'code'; language: string | undefined; code: string }>
+  | Readonly<{ kind: 'rule' }>
+
+const headingMatch = (line: string): { level: 1 | 2 | 3; text: string } | undefined => {
+  const match = /^(#{1,6})\s+(.*)$/.exec(line)
+  if (match === null) {
+    return undefined
+  }
+  const hashes = match[1] ?? ''
+  const level = (hashes.length >= 3 ? 3 : hashes.length) as 1 | 2 | 3
+  return { level, text: (match[2] ?? '').trim() }
+}
+
+const unorderedItemMatch = (line: string): string | undefined => {
+  const match = /^\s*[-*+]\s+(.*)$/.exec(line)
+  return match === null ? undefined : (match[1] ?? '')
+}
+
+const orderedItemMatch = (line: string): string | undefined => {
+  const match = /^\s*\d+[.)]\s+(.*)$/.exec(line)
+  return match === null ? undefined : (match[1] ?? '')
+}
+
+const isRule = (line: string): boolean => /^\s*([-*_])(\s*\1){2,}\s*$/.test(line)
+
+const isBlank = (line: string): boolean => line.trim() === ''
+
+// Parse the accumulated markdown text into a list of blocks. Streaming-tolerant:
+// an unterminated ``` fence captures every line seen so far as a code block; a
+// list still being typed is a valid list; trailing blank lines are dropped.
+export const parseMarkdownBlocks = (text: string): ReadonlyArray<Block> => {
+  const lines = text.replace(/\r\n/g, '\n').split('\n')
+  const blocks: Array<Block> = []
+  let lineIndex = 0
+
+  while (lineIndex < lines.length) {
+    const line = lines[lineIndex] ?? ''
+
+    if (isBlank(line)) {
+      lineIndex += 1
+      continue
+    }
+
+    // Fenced code block: ```lang … ``` . An unterminated fence (mid-stream)
+    // captures the rest of the input as code rather than flashing the raw fence.
+    const fenceMatch = /^\s*```(.*)$/.exec(line)
+    if (fenceMatch !== null) {
+      const language = (fenceMatch[1] ?? '').trim()
+      const codeLines: Array<string> = []
+      lineIndex += 1
+      let closed = false
+      while (lineIndex < lines.length) {
+        const codeLine = lines[lineIndex] ?? ''
+        if (/^\s*```\s*$/.test(codeLine)) {
+          closed = true
+          lineIndex += 1
+          break
+        }
+        codeLines.push(codeLine)
+        lineIndex += 1
+      }
+      // `closed` is informational; whether or not the fence closed, the captured
+      // lines render as a code block (the streaming-tolerant contract).
+      void closed
+      blocks.push({
+        kind: 'code',
+        language: language === '' ? undefined : language,
+        code: codeLines.join('\n'),
+      })
+      continue
+    }
+
+    // Indented code block (4+ leading spaces), collected greedily.
+    if (/^ {4}\S/.test(line)) {
+      const codeLines: Array<string> = []
+      while (lineIndex < lines.length && /^ {4}/.test(lines[lineIndex] ?? '')) {
+        codeLines.push((lines[lineIndex] ?? '').slice(4))
+        lineIndex += 1
+      }
+      blocks.push({ kind: 'code', language: undefined, code: codeLines.join('\n') })
+      continue
+    }
+
+    if (isRule(line)) {
+      blocks.push({ kind: 'rule' })
+      lineIndex += 1
+      continue
+    }
+
+    const heading = headingMatch(line)
+    if (heading !== undefined) {
+      blocks.push({ kind: 'heading', level: heading.level, text: heading.text })
+      lineIndex += 1
+      continue
+    }
+
+    // Unordered list: consecutive `- ` / `* ` / `+ ` lines.
+    if (unorderedItemMatch(line) !== undefined) {
+      const items: Array<string> = []
+      while (lineIndex < lines.length) {
+        const item = unorderedItemMatch(lines[lineIndex] ?? '')
+        if (item === undefined) {
+          break
+        }
+        items.push(item)
+        lineIndex += 1
+      }
+      blocks.push({ kind: 'unordered-list', items })
+      continue
+    }
+
+    // Ordered list: consecutive `1. ` / `2) ` lines.
+    if (orderedItemMatch(line) !== undefined) {
+      const items: Array<string> = []
+      while (lineIndex < lines.length) {
+        const item = orderedItemMatch(lines[lineIndex] ?? '')
+        if (item === undefined) {
+          break
+        }
+        items.push(item)
+        lineIndex += 1
+      }
+      blocks.push({ kind: 'ordered-list', items })
+      continue
+    }
+
+    // Blockquote: consecutive `> ` lines, joined into one quote.
+    if (/^\s*>\s?/.test(line)) {
+      const quoteLines: Array<string> = []
+      while (lineIndex < lines.length && /^\s*>\s?/.test(lines[lineIndex] ?? '')) {
+        quoteLines.push((lines[lineIndex] ?? '').replace(/^\s*>\s?/, ''))
+        lineIndex += 1
+      }
+      blocks.push({ kind: 'blockquote', text: quoteLines.join('\n') })
+      continue
+    }
+
+    // Paragraph: consecutive non-blank lines that don't start a new block, soft
+    // wrapped into one paragraph.
+    const paragraphLines: Array<string> = []
+    while (lineIndex < lines.length) {
+      const candidate = lines[lineIndex] ?? ''
+      if (
+        isBlank(candidate) ||
+        /^\s*```/.test(candidate) ||
+        headingMatch(candidate) !== undefined ||
+        unorderedItemMatch(candidate) !== undefined ||
+        orderedItemMatch(candidate) !== undefined ||
+        /^\s*>\s?/.test(candidate) ||
+        isRule(candidate)
+      ) {
+        break
+      }
+      paragraphLines.push(candidate.trim())
+      lineIndex += 1
+    }
+    if (paragraphLines.length > 0) {
+      blocks.push({ kind: 'paragraph', text: paragraphLines.join(' ') })
+    }
+  }
+
+  return blocks
+}
+
+const headingClassFor = (level: 1 | 2 | 3): string =>
+  level === 1 ? responseH1Class : level === 2 ? responseH2Class : responseH3Class
+
+const headingTagFor = (level: 1 | 2 | 3): 'h3' | 'h4' | 'h5' =>
+  // Keep heading levels demoted relative to the page h1 so the assistant prose
+  // never out-ranks the HUD heading in the document outline.
+  level === 1 ? 'h3' : level === 2 ? 'h4' : 'h5'
+
+const renderBlock = <Message>(block: Block): Html => {
+  const h = html<Message>()
+
+  switch (block.kind) {
+    case 'heading':
+      return h[headingTagFor(block.level)](
+        [h.Class(headingClassFor(block.level))],
+        renderInline<Message>(block.text),
+      )
+    case 'paragraph':
+      return h.p(
+        [h.Class(responseParagraphClass)],
+        renderInline<Message>(block.text),
+      )
+    case 'unordered-list':
+      return h.ul(
+        [h.Class(responseUnorderedListClass)],
+        block.items.map(item =>
+          h.li([h.Class(responseListItemClass)], renderInline<Message>(item)),
+        ),
+      )
+    case 'ordered-list':
+      return h.ol(
+        [h.Class(responseOrderedListClass)],
+        block.items.map(item =>
+          h.li([h.Class(responseListItemClass)], renderInline<Message>(item)),
+        ),
+      )
+    case 'blockquote':
+      return h.blockquote(
+        [h.Class(responseBlockquoteClass)],
+        renderInline<Message>(block.text),
+      )
+    case 'code':
+      return h.pre(
+        [
+          aiElementBase<Message>(MODULE_ID, 'ResponseCode'),
+          h.Class(responseCodeBlockClass),
+          ...(block.language === undefined
+            ? []
+            : [h.DataAttribute('language', block.language)]),
+        ],
+        [h.code([], [block.code])],
+      )
+    case 'rule':
+      return h.hr([h.Class(responseRuleClass)])
+  }
+}
+
+// Render a complete markdown body (or the markdown-so-far during streaming) into
+// a single dark-only, mono response surface. `streaming` appends a blinking
+// cursor affordance to the last block so the live reply visibly "types".
+export const response = <Message>(input: {
+  markdown: string
+  streaming?: boolean
+  attrs?: ReadonlyArray<Attribute<Message>>
+}): Html => {
+  const h = html<Message>()
+  const blocks = parseMarkdownBlocks(input.markdown)
+  const rendered = blocks.map(block => renderBlock<Message>(block))
+  const children =
+    input.streaming === true
+      ? [...rendered, streamingCursor<Message>()]
+      : rendered
+
+  return h.div(
+    [
+      ...(input.attrs ?? []),
+      aiElementBase<Message>(MODULE_ID, 'Response'),
+      h.Class(responseClass),
+    ],
+    children.length === 0
+      ? // An empty streaming reply (no content yet) shows the cursor alone so the
+        // turn reads as "starting", never blank.
+        input.streaming === true
+        ? [streamingCursor<Message>()]
+        : []
+      : children,
+  )
+}
+
+// The blinking type cursor. Honors reduced-motion (the CSS holds it static).
+export const responseStreamingCursorClass =
+  'oa-stream-cursor inline-block h-[1em] w-[0.5ch] translate-y-[0.1em] bg-[#4fd0ff] align-baseline'
+
+export const streamingCursor = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.span(
+    [
+      aiElementBase<Message>(MODULE_ID, 'ResponseCursor'),
+      h.AriaHidden(true),
+      h.Class(responseStreamingCursorClass),
+    ],
+    [],
+  )
+}

--- a/packages/ui/test/ai-elements.coverage.test.ts
+++ b/packages/ui/test/ai-elements.coverage.test.ts
@@ -16,6 +16,7 @@ import {
 const expectedCatalog = [
   { moduleId: 'prompt-input', primitives: 7 },
   { moduleId: 'message', primitives: 4 },
+  { moduleId: 'response', primitives: 3 },
   { moduleId: 'code-block', primitives: 4 },
   { moduleId: 'task', primitives: 5 },
   { moduleId: 'sources', primitives: 4 },
@@ -72,6 +73,7 @@ describe('AI Elements catalog coverage', () => {
   it('exposes the family through the package barrel namespace', () => {
     expect(typeof AiElements.promptInput).toBe('function')
     expect(typeof AiElements.message).toBe('function')
+    expect(typeof AiElements.response).toBe('function')
     expect(typeof AiElements.codeBlock).toBe('function')
     expect(typeof AiElements.task).toBe('function')
     expect(typeof AiElements.sources).toBe('function')

--- a/packages/ui/test/response.test.ts
+++ b/packages/ui/test/response.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from 'bun:test'
+import type { Html } from 'foldkit/html'
+
+import { AiElements } from '../src'
+import { parseMarkdownBlocks, response } from '../src/ai-elements/response'
+
+// A lightweight Snabbdom-style vnode walker (mirrors business.test.ts) so the
+// markdown renderer can be asserted as serialized markup without a DOM.
+type VNodeLike = Readonly<{
+  sel?: string
+  text?: string
+  children?: ReadonlyArray<VNodeLike | string | null>
+  data?: {
+    attrs?: Record<string, unknown>
+    props?: Record<string, unknown>
+    class?: Record<string, boolean>
+  }
+}>
+
+const isVNodeLike = (value: unknown): value is VNodeLike =>
+  typeof value === 'object' && value !== null
+
+const renderHtml = (html: Html): string => {
+  if (html === null || !isVNodeLike(html)) {
+    return ''
+  }
+
+  const tag = html.sel ?? 'node'
+  const attrs = html.data?.attrs ?? {}
+  const classes = Object.entries(html.data?.class ?? {})
+    .filter(([, on]) => on)
+    .map(([name]) => name)
+    .join(' ')
+  const attrString = [
+    ...Object.entries(attrs),
+    ...(classes.length === 0 ? [] : [['class', classes] as const]),
+  ]
+    .filter(([, v]) => v !== false && v !== undefined && v !== null)
+    .map(([k, v]) => (v === true ? ` ${k}` : ` ${k}="${String(v)}"`))
+    .join('')
+  const children = (html.children ?? [])
+    .map(child =>
+      typeof child === 'string' ? child : child === null ? '' : renderHtml(child),
+    )
+    .join('')
+
+  return `<${tag}${attrString}>${html.text ?? ''}${children}</${tag}>`
+}
+
+const render = (markdown: string, streaming?: boolean): string =>
+  renderHtml(
+    response({ markdown, ...(streaming === undefined ? {} : { streaming }) }),
+  )
+
+describe('response markdown — block structure', () => {
+  test('renders headings as demoted heading tags', () => {
+    const markup = render('# Title\n\n## Section\n\n### Sub')
+    expect(markup).toContain('<h3')
+    expect(markup).toContain('Title')
+    expect(markup).toContain('<h4')
+    expect(markup).toContain('Section')
+    expect(markup).toContain('<h5')
+    expect(markup).toContain('Sub')
+  })
+
+  test('renders unordered and ordered lists', () => {
+    const ul = render('- one\n- two\n- three')
+    expect(ul).toContain('<ul')
+    expect((ul.match(/<li/g) ?? []).length).toBe(3)
+
+    const ol = render('1. first\n2. second')
+    expect(ol).toContain('<ol')
+    expect((ol.match(/<li/g) ?? []).length).toBe(2)
+  })
+
+  test('renders fenced code blocks with language metadata', () => {
+    const markup = render('```ts\nconst x = 1\n```')
+    expect(markup).toContain('<pre')
+    expect(markup).toContain('data-language="ts"')
+    expect(markup).toContain('const x = 1')
+  })
+
+  test('renders blockquotes and horizontal rules', () => {
+    expect(render('> quoted line')).toContain('<blockquote')
+    expect(render('---')).toContain('<hr')
+  })
+
+  test('paragraphs soft-wrap consecutive lines', () => {
+    const blocks = parseMarkdownBlocks('line one\nline two')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ kind: 'paragraph', text: 'line one line two' })
+  })
+})
+
+describe('response markdown — inline structure', () => {
+  test('renders bold, italic, and inline code', () => {
+    const markup = render('A **bold** and *italic* and `code` line.')
+    expect(markup).toContain('<strong')
+    expect(markup).toContain('bold')
+    expect(markup).toContain('<em')
+    expect(markup).toContain('italic')
+    expect(markup).toContain('<code')
+    expect(markup).toContain('code')
+  })
+
+  test('renders safe links and degrades unsafe schemes to text', () => {
+    // The href is a DOM prop on the vnode (not a serialized attr in the
+    // lightweight walker); asserting the anchor element + visible label proves
+    // the safe link renders as a link.
+    const safe = render('See [docs](https://openagents.com/docs).')
+    expect(safe).toContain('<a')
+    expect(safe).toContain('docs')
+    expect(safe).toContain('text-[#7aa2ff]')
+
+    const unsafe = render('Click [here](javascript:alert(1)).')
+    expect(unsafe).not.toContain('<a')
+    expect(unsafe).not.toContain('javascript:')
+    expect(unsafe).toContain('here')
+  })
+})
+
+describe('response markdown — streaming tolerance (streamdown pattern)', () => {
+  test('a half-open bold marker never throws and renders as text', () => {
+    expect(() => render('A reply with **bold stil')).not.toThrow()
+    const markup = render('A reply with **bold stil')
+    // No <strong> for the dangling marker; the literal text is preserved.
+    expect(markup).toContain('bold stil')
+  })
+
+  test('a dangling inline code backtick renders literally', () => {
+    expect(() => render('partial `cod')).not.toThrow()
+    expect(render('partial `cod')).toContain('cod')
+  })
+
+  test('an unterminated fenced block renders the captured lines as code', () => {
+    const markup = render('```ts\nconst y = 2\nconst z = 3')
+    expect(markup).toContain('<pre')
+    expect(markup).toContain('const y = 2')
+    expect(markup).toContain('const z = 3')
+  })
+
+  test('an incomplete link renders the literal characters', () => {
+    expect(() => render('start [partial link')).not.toThrow()
+    expect(render('start [partial link')).toContain('partial link')
+  })
+
+  test('streaming appends a cursor; empty streaming shows only the cursor', () => {
+    const withContent = render('Hello', true)
+    expect(withContent).toContain('oa-stream-cursor')
+    expect(withContent).toContain('Hello')
+
+    const empty = render('', true)
+    expect(empty).toContain('oa-stream-cursor')
+
+    // Non-streaming never adds a cursor.
+    expect(render('Hello')).not.toContain('oa-stream-cursor')
+  })
+})
+
+describe('response markdown — package barrel', () => {
+  test('is exposed through the AiElements namespace', () => {
+    expect(typeof AiElements.response).toBe('function')
+  })
+})


### PR DESCRIPTION
Adds markdown rendering, token streaming, a scrollable thread, and a compact sidebar progress register to the /autopilot onboarding page. Part of #6123 follow-up.