### PR TITLE
MPP Lightning: Spark primary issuer, MDK fallback (#6049)

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -10,17 +10,29 @@ This is the invariant ledger for `openagents`.
   agent payment issuance / receipt / settlement. Spark is required because it
   supports **offline receives**, which agent payments need.
 - **MDK (MoneyDevKit, `@moneydevkit/*`, the `MDK_SIDECAR` / `mdkd` container) is
-  SECONDARY and for CHECKOUTS ONLY** (the `/api/mdk` `self_hosted_mdkd_sidecar`
-  flow, Forum tips/checkouts). MDK **must not** be used for agent payments or
-  MPP — it does not support offline receives.
+  for CHECKOUTS ONLY** (the `/api/mdk` `self_hosted_mdkd_sidecar` flow, Forum
+  tips/checkouts) and is permitted as an agent/MPP rail **ONLY as an explicit
+  FALLBACK Lightning issuer (never primary)**. MDK must never be re-asserted as
+  the primary or default agent/MPP rail — it does not support offline receives,
+  so it is used only when Spark is unavailable/unconfigured.
 - History (do not regress): Spark was stripped for MDK previously, then **re-added
   as the primary rail**, demoting MDK to secondary; Pylon was moved to Spark
   (2026-06). Never re-assert "MDK is the agent/MPP rail."
-- **Open violation:** the current MPP Lightning issuer
-  (`workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts`) mints via the MDK
-  sidecar and therefore breaks this invariant. It is **disarmed**
-  (`KHALA_MPP_LIGHTNING_ENABLED` unset on prod) and must be **rebuilt on Spark**
-  before the Lightning MPP rail is armed. See `docs/mpp/`.
+- **MPP Lightning issuer (Spark primary, MDK fallback):** the Lightning MPP rail
+  issuer selector (`workers/api/src/index.ts` `lightningInvoiceIssuerForEnv`)
+  tries the **Spark issuer first**
+  (`workers/api/src/inference/mpp/mpp-lightning-invoice-spark.ts`, minting a Spark
+  BOLT11 via the `MDK_TREASURY` container's `POST /spark/funding-invoice`), and
+  falls back to the MDK issuer
+  (`workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts`) **only when Spark
+  is unavailable/unconfigured**. Both legs stay behind the
+  `KHALA_MPP_LIGHTNING_ENABLED` gate, each keeps its bounded mint timeout, and the
+  combined attempt stays under the route's per-rail guard (#6149) so a slow/failed
+  issuer can only ever drop the Lightning rail, never hang the endpoint. The
+  preimage is verified LOCALLY (`sha256(preimage) === paymentHash`); offline
+  receipt is confirmable via the container's `GET /spark/received/:paymentHash`.
+  Disarmed by default (`KHALA_MPP_LIGHTNING_ENABLED` unset on prod). See
+  `docs/mpp/`.
 - Owner directive, 2026-06-23.
 
 ## Login Surface
@@ -868,8 +880,9 @@ This is the invariant ledger for `openagents`.
   boundary violation. The preimage is a bearer secret: never logged, persisted,
   or returned; the receipt/replay key is the paymentHash. The Lightning rail is
   fail-closed inert unless `KHALA_MPP_LIGHTNING_ENABLED` + `KHALA_MPP_ENABLED` +
-  a working MDK BOLT11 invoice issuer are all present (honesty gate: never
-  advertise a rail we cannot fulfill), and consume-once is enforced atomically
+  a working BOLT11 invoice issuer (Spark primary, MDK fallback) are all present
+  (honesty gate: never advertise a rail we cannot fulfill), and consume-once is
+  enforced atomically
   via `mpp_lightning_replay`. Regression coverage:
   `workers/api/src/inference/mpp/mpp-lightning-verify.test.ts`,
   `workers/api/src/inference/mpp/mpp-lightning-replay.test.ts`,

--- a/apps/openagents.com/services/mdk-treasury/src/server.mjs
+++ b/apps/openagents.com/services/mdk-treasury/src/server.mjs
@@ -11,6 +11,7 @@ import {
   sparkTreasuryFundingInvoicePayload,
   sparkTreasuryFundingPayload,
   sparkTreasuryPayPayload,
+  sparkTreasuryReceivedPayload,
   sparkTreasuryUnavailableReason,
 } from './spark-treasury.mjs'
 
@@ -458,6 +459,22 @@ const handleRequest = async request => {
     const result = await sparkTreasuryPayPayload(
       await request.json().catch(() => null),
     )
+    const status = typeof result.status === 'number' ? result.status : 200
+
+    return json(status, result)
+  }
+
+  const sparkReceivedMatch = /^\/spark\/received\/([a-f0-9]{64})$/i.exec(
+    url.pathname,
+  )
+
+  if (request.method === 'GET' && sparkReceivedMatch !== null) {
+    const sparkUnavailable = sparkTreasuryUnavailableReason()
+    if (sparkUnavailable !== null) {
+      return json(503, { error: sparkUnavailable })
+    }
+
+    const result = await sparkTreasuryReceivedPayload(sparkReceivedMatch[1])
     const status = typeof result.status === 'number' ? result.status : 200
 
     return json(status, result)

--- a/apps/openagents.com/services/mdk-treasury/src/spark-treasury-bolt11.test.mjs
+++ b/apps/openagents.com/services/mdk-treasury/src/spark-treasury-bolt11.test.mjs
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+
+import { bolt11PaymentHashHex } from './spark-treasury.mjs'
+
+describe('bolt11PaymentHashHex (Spark MPP Lightning rail, EPIC #6049)', () => {
+  // BOLT11 spec test vector: the `p` payment-hash field is
+  // 0001020304050607080900010203040506070809000102030405060708090102. The Spark
+  // `receivePayment` response returns only the bolt11; the MPP 402 challenge
+  // needs this hash, so the container decodes it from the minted invoice.
+  test('decodes the payment hash from a spec BOLT11 invoice', () => {
+    const invoice =
+      'lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp'
+    expect(bolt11PaymentHashHex(invoice)).toBe(
+      '0001020304050607080900010203040506070809000102030405060708090102',
+    )
+  })
+
+  test('returns null for non-string / malformed input (fail-closed)', () => {
+    expect(bolt11PaymentHashHex(undefined)).toBeNull()
+    expect(bolt11PaymentHashHex('')).toBeNull()
+    expect(bolt11PaymentHashHex('not-an-invoice')).toBeNull()
+    expect(bolt11PaymentHashHex('lnbc1notbech32!!!')).toBeNull()
+  })
+})

--- a/apps/openagents.com/services/mdk-treasury/src/spark-treasury.mjs
+++ b/apps/openagents.com/services/mdk-treasury/src/spark-treasury.mjs
@@ -333,12 +333,95 @@ export const sparkTreasuryFundingPayload = async () => {
   }
 }
 
+// ---- BOLT11 payment-hash decode (dependency-free) ----
+//
+// The Spark `receivePayment` response returns only the bolt11 `paymentRequest`
+// (and a fee) — NOT the payment hash. The OpenAgents MPP Lightning rail needs the
+// raw payment hash for the 402 challenge (the bearer preimage is verified
+// LOCALLY in the Worker as sha256(preimage) === paymentHash; the container never
+// sees the preimage). The payment hash IS carried inside the bolt11 itself: the
+// BOLT11 `p` tagged field is the 32-byte payment hash. We decode it here from the
+// invoice the SDK just minted — deterministic, no extra SDK round-trip, no new
+// dependency. Failure to decode is non-fatal: we still return the invoice and the
+// Worker fail-closes (drops the Lightning rail) on a missing/invalid hash.
+const BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+
+export const bolt11PaymentHashHex = bolt11 => {
+  try {
+    if (typeof bolt11 !== 'string') {
+      return null
+    }
+    const lower = bolt11.trim().toLowerCase()
+    const sep = lower.lastIndexOf('1')
+    if (sep < 1) {
+      return null
+    }
+    const data = lower.slice(sep + 1)
+    // The trailing 6 5-bit groups are the bech32 checksum (not signature). The
+    // signature is 104 5-bit groups before that. Decode every data char to a
+    // 5-bit value first; we then walk the tagged fields from the front.
+    const values = []
+    for (const ch of data) {
+      const v = BECH32_CHARSET.indexOf(ch)
+      if (v === -1) {
+        return null
+      }
+      values.push(v)
+    }
+    // Strip the 6-group checksum.
+    const body = values.slice(0, Math.max(0, values.length - 6))
+    // Timestamp is the first 7 groups (35 bits); tagged fields follow.
+    let i = 7
+    while (i + 3 <= body.length) {
+      const tag = body[i]
+      const len = body[i + 1] * 32 + body[i + 2]
+      const dataStart = i + 3
+      const dataEnd = dataStart + len
+      if (dataEnd > body.length) {
+        return null
+      }
+      // Tag 1 ('p') is the payment hash: 52 groups = 260 bits, first 256 = hash.
+      if (tag === 1 && len === 52) {
+        const fieldGroups = body.slice(dataStart, dataEnd)
+        // Convert 5-bit groups to bytes (big-endian), take the first 32 bytes.
+        let acc = 0
+        let bits = 0
+        const bytes = []
+        for (const g of fieldGroups) {
+          acc = (acc << 5) | g
+          bits += 5
+          while (bits >= 8) {
+            bits -= 8
+            bytes.push((acc >> bits) & 0xff)
+          }
+        }
+        if (bytes.length < 32) {
+          return null
+        }
+        return bytes
+          .slice(0, 32)
+          .map(b => b.toString(16).padStart(2, '0'))
+          .join('')
+      }
+      i = dataEnd
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
 export const sparkTreasuryFundingInvoicePayload = async input => {
   const amountSat = Number(input?.amountSat)
 
   if (!Number.isInteger(amountSat) || amountSat <= 0) {
     return { error: 'amount_sat_must_be_positive_integer', status: 400 }
   }
+
+  const description =
+    typeof input?.description === 'string' && input.description.trim() !== ''
+      ? input.description.trim().slice(0, 120)
+      : 'OpenAgents Spark treasury funding'
 
   const sdk = await buildSparkSdk()
   await syncWallet(sdk)
@@ -349,7 +432,7 @@ export const sparkTreasuryFundingInvoicePayload = async input => {
       sdk.receivePayment({
         paymentMethod: {
           amountSats: amountSat,
-          description: 'OpenAgents Spark treasury funding',
+          description,
           expirySecs: 3600,
           type: 'bolt11Invoice',
         },
@@ -376,19 +459,95 @@ export const sparkTreasuryFundingInvoicePayload = async input => {
     }
   }
 
-  return typeof response?.paymentRequest === 'string' &&
-    response.paymentRequest.trim() !== ''
-    ? {
-        amountSat,
-        bolt11Invoice: response.paymentRequest,
-        expiresInSeconds: 3600,
-        rail: 'spark',
-      }
-    : {
-        error: 'spark_treasury_funding_invoice_unavailable',
-        failureStage: 'spark_receive_payment_bolt11_invoice_empty_response',
-        status: 502,
-      }
+  if (
+    typeof response?.paymentRequest !== 'string' ||
+    response.paymentRequest.trim() === ''
+  ) {
+    return {
+      error: 'spark_treasury_funding_invoice_unavailable',
+      failureStage: 'spark_receive_payment_bolt11_invoice_empty_response',
+      status: 502,
+    }
+  }
+
+  const bolt11Invoice = response.paymentRequest.trim()
+  // Prefer the SDK-reported payment hash when present; otherwise decode it from
+  // the bolt11 we just minted (the `p` tagged field). Either way the hash is
+  // PUBLIC (it goes into the 402 challenge); only the preimage is secret.
+  const sdkPaymentHash =
+    typeof response?.payment?.details?.htlcDetails?.paymentHash === 'string'
+      ? response.payment.details.htlcDetails.paymentHash.toLowerCase()
+      : null
+  const paymentHash =
+    sdkPaymentHash !== null && /^[0-9a-f]{64}$/.test(sdkPaymentHash)
+      ? sdkPaymentHash
+      : bolt11PaymentHashHex(bolt11Invoice)
+
+  return {
+    amountSat,
+    bolt11Invoice,
+    expiresInSeconds: 3600,
+    ...(paymentHash === null ? {} : { paymentHash }),
+    rail: 'spark',
+  }
+}
+
+// Offline-receive confirmation for a Spark BOLT11 invoice. Spark supports
+// receiving while the recipient is offline; once the wallet next syncs, the
+// settled payment appears in `listPayments` (receive type) with status
+// Completed and its htlcDetails.paymentHash matching the minted invoice. This is
+// how the Worker confirms an MPP Lightning charge was paid. We return only the
+// minimal public-safe receipt fields; no preimage or raw payment material.
+export const sparkTreasuryReceivedPayload = async paymentHash => {
+  const normalized =
+    typeof paymentHash === 'string' ? paymentHash.trim().toLowerCase() : ''
+
+  if (!/^[0-9a-f]{64}$/.test(normalized)) {
+    return { error: 'payment_hash_must_be_hex_32_bytes', status: 400 }
+  }
+
+  const sdk = await buildSparkSdk()
+  await syncWallet(sdk)
+
+  let payments
+  try {
+    const response = await withTimeout(
+      sdk.listPayments({
+        limit: 200,
+        offset: 0,
+        typeFilter: ['receive'],
+      }),
+      timeoutMs(),
+      'spark listPayments',
+    )
+    payments = Array.isArray(response?.payments)
+      ? response.payments
+      : Array.isArray(response)
+        ? response
+        : []
+  } catch {
+    return { received: false, settled: false, status: 200 }
+  }
+
+  const match = payments.find(payment => {
+    const hash = payment?.details?.htlcDetails?.paymentHash
+    return typeof hash === 'string' && hash.toLowerCase() === normalized
+  })
+
+  if (match === undefined) {
+    return { received: false, settled: false, status: 200 }
+  }
+
+  const status = publicStatus(match.status)
+  const settled =
+    status !== null && /^(completed|complete|succeeded|success)$/i.test(status)
+
+  return {
+    amountSat: toSatNumber(match.amount) ?? null,
+    received: true,
+    settled,
+    status: 200,
+  }
 }
 
 export const sparkTreasuryPayPayload = async input => {

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -339,7 +339,12 @@ import {
   isKhalaMppEnabled,
   isKhalaMppLightningEnabled,
 } from './inference/mpp/mpp-chat-completions-routes'
-import { makeMdkLightningInvoiceIssuer } from './inference/mpp/mpp-lightning-invoice-mdk'
+import { makeFallbackLightningInvoiceIssuer } from './inference/mpp/mpp-lightning-invoice'
+import {
+  makeMdkLightningInvoiceIssuer,
+  MDK_LIGHTNING_FALLBACK_MINT_TIMEOUT_MS,
+} from './inference/mpp/mpp-lightning-invoice-mdk'
+import { makeSparkLightningInvoiceIssuer } from './inference/mpp/mpp-lightning-invoice-spark'
 import {
   isAcceptanceDispatchEnabled,
   makeD1KhalaVerificationStore,
@@ -6646,14 +6651,46 @@ const hostedMdkClientForEnv = (
   )
 }
 
-// The MDK-backed BOLT11 invoice issuer for the Lightning MPP rail (EPIC #6049).
-// Returns undefined when no MDK route is configured (route URL + secret), so the
-// Lightning rail is never offered without a working invoice issuer (honesty
-// gate). POSTs `create_checkout` to the SAME route/sidecar the Forum L402 flow
-// uses (the `self_hosted_mdkd_sidecar` route kind goes through the MDK_SIDECAR
-// container) and reads the RAW bolt11 + paymentHash. The invoice + paymentHash
-// are public (they go into the 402 challenge); the preimage is never seen here.
-const lightningInvoiceIssuerForEnv = (
+// The PRIMARY Spark-backed BOLT11 invoice issuer for the Lightning MPP rail
+// (EPIC #6049). Owner directive: Spark is the primary rail for all agent/MPP
+// payments (it supports OFFLINE RECEIVES). Returns undefined when the Spark
+// treasury container is not reachable (the `MDK_TREASURY` binding is absent), so
+// the selector can fall back to MDK. POSTs `/spark/funding-invoice` to the SAME
+// `MDK_TREASURY` container the Spark payout/balance paths already reach
+// (`fetchMdkTreasuryPath` → the `@breeztech/breez-sdk-spark` SDK) and reads the
+// RAW bolt11 + decoded paymentHash. Both are public (they go into the 402
+// challenge); the preimage is never seen here (verified LOCALLY in the Worker).
+const sparkLightningInvoiceIssuerForEnv = (
+  env: WorkerBindings & OpenAgentsWorkerConfigEnv,
+) => {
+  const fetchTreasury = fetchMdkTreasuryPath(env)
+  if (fetchTreasury === undefined) {
+    return undefined
+  }
+
+  const post = async (
+    body: Readonly<Record<string, unknown>>,
+  ): Promise<Readonly<{ ok: boolean; status: number; payload: unknown }>> => {
+    const response = await fetchTreasury('/spark/funding-invoice', {
+      body: JSON.stringify(body),
+      method: 'POST',
+    })
+    const payload = await response.json().catch(() => ({}))
+    return { ok: response.ok, payload, status: response.status }
+  }
+
+  return makeSparkLightningInvoiceIssuer(post)
+}
+
+// The FALLBACK MDK-backed BOLT11 invoice issuer for the Lightning MPP rail
+// (EPIC #6049). MDK is permitted ONLY as an explicit fallback Lightning issuer
+// (never primary) and remains checkouts-only otherwise. Returns undefined when
+// no MDK route is configured (route URL + secret). POSTs `create_checkout` to the
+// SAME route/sidecar the Forum L402 flow uses (the `self_hosted_mdkd_sidecar`
+// route kind goes through the MDK_SIDECAR container) and reads the RAW bolt11 +
+// paymentHash. Uses the tighter FALLBACK mint timeout so a Spark primary timeout
+// plus this MDK attempt together stay under the route's per-rail guard (#6149).
+const mdkLightningInvoiceIssuerForEnv = (
   env: WorkerBindings & OpenAgentsWorkerConfigEnv,
 ) => {
   const checkout = getOpenAgentsWorkerConfig(env).mdk.checkout
@@ -6688,8 +6725,26 @@ const lightningInvoiceIssuerForEnv = (
     return { ok: response.ok, payload, status: response.status }
   }
 
-  return makeMdkLightningInvoiceIssuer(post)
+  return makeMdkLightningInvoiceIssuer(
+    post,
+    MDK_LIGHTNING_FALLBACK_MINT_TIMEOUT_MS,
+  )
 }
+
+// The Lightning MPP invoice issuer for this env: SPARK PRIMARY, MDK FALLBACK
+// (EPIC #6049, owner directive). Tries Spark first; if Spark is
+// unavailable/unconfigured/slow, falls back to the MDK Lightning issuer. Returns
+// undefined only when NEITHER is reachable, so the Lightning rail is never
+// offered without a working invoice issuer (honesty gate). The combined issuer
+// keeps each leg's bounded mint timeout and stays under the route's per-rail
+// guard (#6149) so a slow/failed issuer can only ever drop the Lightning rail.
+const lightningInvoiceIssuerForEnv = (
+  env: WorkerBindings & OpenAgentsWorkerConfigEnv,
+) =>
+  makeFallbackLightningInvoiceIssuer(
+    sparkLightningInvoiceIssuerForEnv(env),
+    mdkLightningInvoiceIssuerForEnv(env),
+  )
 
 const forumL402SigningBoundaryForEnv = async (
   env: WorkerBindings & OpenAgentsWorkerConfigEnv,
@@ -9945,9 +10000,10 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         cardRailEnabled:
           env.STRIPE_MPP_NETWORK_PROFILE_ID !== undefined &&
           env.STRIPE_MPP_NETWORK_PROFILE_ID.trim() !== '',
-        // Bitcoin-first Lightning offer: armed flag AND a working MDK invoice
-        // issuer present (the SAME condition that arms the rail in the route).
-        // Honesty gate: omitted when we cannot actually mint an invoice.
+        // Bitcoin-first Lightning offer: armed flag AND a working Lightning
+        // invoice issuer present (Spark primary, MDK fallback — the SAME
+        // condition that arms the rail in the route). Honesty gate: omitted when
+        // we cannot actually mint an invoice.
         lightningRailEnabled:
           isKhalaMppLightningEnabled(env.KHALA_MPP_LIGHTNING_ENABLED) &&
           lightningInvoiceIssuerForEnv(env) !== undefined,
@@ -10307,8 +10363,9 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         ownerClaimStore.readVerifiedPublicIdentityForAgentUserId,
       )
       // Bitcoin-first Lightning rail (EPIC #6049). Offered FIRST when armed:
-      // KHALA_MPP_LIGHTNING_ENABLED on AND an MDK invoice issuer is configured
-      // (the MDK route/sidecar wallet binding). With either absent the issuer is
+      // KHALA_MPP_LIGHTNING_ENABLED on AND a Lightning invoice issuer is
+      // configured (Spark primary via the MDK_TREASURY container, MDK fallback
+      // via the route/sidecar wallet binding). With either absent the issuer is
       // undefined and the rail is never advertised (honesty gate).
       const lightningEnabled = isKhalaMppLightningEnabled(
         env.KHALA_MPP_LIGHTNING_ENABLED,

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
@@ -93,8 +93,16 @@ const rawInvoiceExpiry = (
 // checkout is created in `amount` mode with `currency: 'SAT'` for the requested
 // sats; the issuer reads the RAW bolt11 + paymentHash and surface-validates them
 // (fail-closed). The preimage is NEVER touched here.
+// Tighter mint timeout for when MDK runs as the FALLBACK leg behind the Spark
+// primary (EPIC #6049). Spark gets its own bounded primary attempt; if Spark
+// times out, the MDK fallback must still finish under the route's outer per-rail
+// guard (#6149), so the chained worst case (Spark + MDK) cannot hang the
+// endpoint. Used by the selector when both issuers are present.
+export const MDK_LIGHTNING_FALLBACK_MINT_TIMEOUT_MS = 1_200
+
 export const makeMdkLightningInvoiceIssuer = (
   post: MdkRoutePost,
+  timeoutMs: number = MDK_LIGHTNING_MINT_TIMEOUT_MS,
 ): MintLightningInvoice => input =>
   Effect.gen(function* () {
     const amountSats = Math.max(1, Math.trunc(input.amountSats))
@@ -118,7 +126,7 @@ export const makeMdkLightningInvoiceIssuer = (
       // SAME typed `provider_unavailable` reason a transport error produces, so
       // the caller drops the Lightning rail and serves the others promptly.
       Effect.timeoutOrElse({
-        duration: Duration.millis(MDK_LIGHTNING_MINT_TIMEOUT_MS),
+        duration: Duration.millis(timeoutMs),
         orElse: () =>
           Effect.fail(new LightningInvoiceError('provider_unavailable')),
       }),

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.test.ts
@@ -1,0 +1,214 @@
+import { Effect, Fiber } from 'effect'
+import { TestClock } from 'effect/testing'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type MintLightningInvoice,
+  LightningInvoiceError,
+  makeFallbackLightningInvoiceIssuer,
+} from './mpp-lightning-invoice'
+import {
+  type SparkTreasuryFundingInvoicePost,
+  SPARK_LIGHTNING_MINT_TIMEOUT_MS,
+  makeSparkLightningInvoiceIssuer,
+} from './mpp-lightning-invoice-spark'
+
+const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
+  Effect.runPromise(effect as Effect.Effect<A, never>)
+
+const reasonOf = <A>(
+  effect: Effect.Effect<A, LightningInvoiceError>,
+): Promise<string> =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.map(() => 'ok' as const),
+      Effect.catch((e: LightningInvoiceError) => Effect.succeed(e.reason)),
+    ),
+  )
+
+const HASH =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff'
+const HASH2 =
+  'aabbccddeeff00112233445566778899aabbccddeeff001122334455667788ff'
+const INVOICE = `lnbc100n1p${'a'.repeat(40)}`
+const MDK_INVOICE = `lnbc200n1p${'b'.repeat(40)}`
+
+describe('makeSparkLightningInvoiceIssuer', () => {
+  test('posts a Spark funding-invoice and reads bolt11 + decoded paymentHash', async () => {
+    let seen: Record<string, unknown> | undefined
+    const post: SparkTreasuryFundingInvoicePost = async body => {
+      seen = body
+      return {
+        ok: true,
+        payload: {
+          amountSat: 7,
+          bolt11Invoice: INVOICE,
+          paymentHash: HASH,
+          rail: 'spark',
+        },
+        status: 200,
+      }
+    }
+    const issuer = makeSparkLightningInvoiceIssuer(post)
+    const invoice = await run(
+      issuer({ amountSats: 7, correlationRef: 'ref', description: 'desc' }),
+    )
+    expect(invoice.bolt11).toBe(INVOICE)
+    expect(invoice.paymentHash).toBe(HASH)
+    expect(invoice.network).toBe('mainnet')
+    // The funding-invoice body carries amountSat + description (no secrets).
+    expect(seen?.amountSat).toBe(7)
+    expect(seen?.description).toBe('desc')
+  })
+
+  test('maps a 5xx route status to provider_unavailable', async () => {
+    const post: SparkTreasuryFundingInvoicePost = async () => ({
+      ok: false,
+      payload: { error: 'spark_treasury_funding_invoice_failed' },
+      status: 502,
+    })
+    const reason = await reasonOf(
+      makeSparkLightningInvoiceIssuer(post)({
+        amountSats: 1,
+        correlationRef: 'r',
+        description: 'd',
+      }),
+    )
+    expect(reason).toBe('provider_unavailable')
+  })
+
+  test('maps a 4xx route status to provider_rejected', async () => {
+    const post: SparkTreasuryFundingInvoicePost = async () => ({
+      ok: false,
+      payload: { error: 'amount_sat_must_be_positive_integer' },
+      status: 400,
+    })
+    const reason = await reasonOf(
+      makeSparkLightningInvoiceIssuer(post)({
+        amountSats: 1,
+        correlationRef: 'r',
+        description: 'd',
+      }),
+    )
+    expect(reason).toBe('provider_rejected')
+  })
+
+  test('a payload missing the paymentHash => malformed_invoice', async () => {
+    const post: SparkTreasuryFundingInvoicePost = async () => ({
+      ok: true,
+      payload: { bolt11Invoice: INVOICE, rail: 'spark' },
+      status: 200,
+    })
+    const reason = await reasonOf(
+      makeSparkLightningInvoiceIssuer(post)({
+        amountSats: 1,
+        correlationRef: 'r',
+        description: 'd',
+      }),
+    )
+    expect(reason).toBe('malformed_invoice')
+  })
+
+  // ROOT-CAUSE REGRESSION: the Spark treasury is a Cloudflare Container and a
+  // cold container / cold breez-sdk-spark build can block for SECONDS.
+  // `Effect.tryPromise` catches throws, NOT a hang. The bounded mint must
+  // interrupt a hung post and fail typed (`provider_unavailable`).
+  test('a HUNG post is bounded by the mint timeout => provider_unavailable (no hang)', async () => {
+    let postStarted = false
+    const post: SparkTreasuryFundingInvoicePost = () => {
+      postStarted = true
+      return new Promise(() => {})
+    }
+    const issuer = makeSparkLightningInvoiceIssuer(post)
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          issuer({ amountSats: 1, correlationRef: 'r', description: 'd' }).pipe(
+            Effect.map(() => 'ok' as const),
+            Effect.catch((e: LightningInvoiceError) =>
+              Effect.succeed(e.reason),
+            ),
+          ),
+        )
+        yield* TestClock.adjust(SPARK_LIGHTNING_MINT_TIMEOUT_MS + 1)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(postStarted).toBe(true)
+    expect(result).toBe('provider_unavailable')
+  })
+})
+
+describe('makeFallbackLightningInvoiceIssuer (Spark primary, MDK fallback)', () => {
+  const sparkIssuer = (invoice: string, hash: string): MintLightningInvoice =>
+    makeSparkLightningInvoiceIssuer(async () => ({
+      ok: true,
+      payload: { bolt11Invoice: invoice, paymentHash: hash, rail: 'spark' },
+      status: 200,
+    }))
+
+  const failingIssuer = (
+    reason: LightningInvoiceError['reason'],
+  ): MintLightningInvoice => makeSparkLightningInvoiceIssuer(async () => ({
+    ok: false,
+    payload: {},
+    status: reason === 'provider_rejected' ? 400 : 502,
+  }))
+
+  const mdkLike = (invoice: string, hash: string): MintLightningInvoice =>
+    makeSparkLightningInvoiceIssuer(async () => ({
+      ok: true,
+      payload: { bolt11Invoice: invoice, paymentHash: hash, rail: 'spark' },
+      status: 200,
+    }))
+
+  test('Spark available => Spark invoice is used (MDK fallback never called)', async () => {
+    let mdkCalled = false
+    const mdk: MintLightningInvoice = input => {
+      mdkCalled = true
+      return mdkLike(MDK_INVOICE, HASH2)(input)
+    }
+    const issuer = makeFallbackLightningInvoiceIssuer(
+      sparkIssuer(INVOICE, HASH),
+      mdk,
+    )
+    const invoice = await run(
+      issuer!({ amountSats: 5, correlationRef: 'r', description: 'd' }),
+    )
+    expect(invoice.bolt11).toBe(INVOICE)
+    expect(invoice.paymentHash).toBe(HASH)
+    expect(mdkCalled).toBe(false)
+  })
+
+  test('Spark unavailable => MDK fallback is used', async () => {
+    const issuer = makeFallbackLightningInvoiceIssuer(
+      failingIssuer('provider_unavailable'),
+      mdkLike(MDK_INVOICE, HASH2),
+    )
+    const invoice = await run(
+      issuer!({ amountSats: 5, correlationRef: 'r', description: 'd' }),
+    )
+    expect(invoice.bolt11).toBe(MDK_INVOICE)
+    expect(invoice.paymentHash).toBe(HASH2)
+  })
+
+  test('both unavailable => fails typed (route drops only the Lightning rail)', async () => {
+    const issuer = makeFallbackLightningInvoiceIssuer(
+      failingIssuer('provider_unavailable'),
+      failingIssuer('provider_unavailable'),
+    )
+    const reason = await reasonOf(
+      issuer!({ amountSats: 5, correlationRef: 'r', description: 'd' }),
+    )
+    expect(reason).toBe('provider_unavailable')
+  })
+
+  test('only one issuer present => returned as-is', () => {
+    const only = sparkIssuer(INVOICE, HASH)
+    expect(makeFallbackLightningInvoiceIssuer(only, undefined)).toBe(only)
+    expect(makeFallbackLightningInvoiceIssuer(undefined, only)).toBe(only)
+    expect(
+      makeFallbackLightningInvoiceIssuer(undefined, undefined),
+    ).toBeUndefined()
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.ts
@@ -1,0 +1,115 @@
+// Spark-backed BOLT11 invoice issuer for the Lightning MPP rail (EPIC #6049).
+//
+// PRIMARY RAIL. Owner directive: Spark is the primary rail for all agent/MPP
+// payments — it supports OFFLINE RECEIVES, so the payer can settle the 402
+// Lightning charge even when our receiving wallet is not actively listening.
+// MDK remains an explicit FALLBACK Lightning issuer only (see
+// `mpp-lightning-invoice-mdk.ts` + `lightningInvoiceIssuerForEnv`).
+//
+// Mints a fresh BOLT11 invoice for N sats by POSTing `/spark/funding-invoice`
+// to the SAME `MDK_TREASURY` container the Spark payout/balance paths already
+// reach (`fetchMdkTreasuryPath` → the `@breeztech/breez-sdk-spark` SDK). The
+// container returns the RAW `bolt11Invoice` + (decoded) `paymentHash`; both are
+// PUBLIC (they go into the 402 challenge the client pays). The PREIMAGE is never
+// touched here — settlement is verified LOCALLY in the Worker as
+// sha256(preimage) === paymentHash (draft-lightning-charge-00), and offline
+// receipt is confirmable via the container's `GET /spark/received/:paymentHash`.
+//
+// INERT NOTE: this issuer is constructed ONLY when a Spark treasury route is
+// reachable (the `MDK_TREASURY` container binding present) AND the Lightning flag
+// is on. With no route the selector falls back to MDK; with neither the rail is
+// never offered (honesty gate).
+
+import { Duration, Effect } from 'effect'
+
+import { isRecord, optionalString } from '../../json-boundary'
+import {
+  type LightningInvoice,
+  type MintLightningInvoice,
+  LightningInvoiceError,
+  validateLightningInvoice,
+} from './mpp-lightning-invoice'
+
+// Hard upper bound on the Spark `/spark/funding-invoice` mint round-trip. The
+// Spark treasury is the `MDK_TREASURY` Cloudflare Container; a cold container
+// boot OR a cold breez-sdk-spark build/sync can block for seconds — and
+// `Effect.tryPromise` only catches THROWS, never a hang. Without this bound a
+// cold/slow mint would block the Lightning leg. With it, a slow mint resolves to
+// a typed `provider_unavailable` failure so the SELECTOR can fall back to MDK and
+// still finish under the route's outer per-rail guard (#6149,
+// `LIGHTNING_LEG_GUARD_MS`). Kept tight (1.2s) so a Spark timeout + an MDK
+// fallback attempt together stay under that guard; the route guard is the final
+// safety net either way.
+export const SPARK_LIGHTNING_MINT_TIMEOUT_MS = 1_200
+
+// A POST transport to the Spark treasury route. Returns the HTTP ok flag +
+// status + parsed JSON payload (no throwing — the issuer maps a non-ok status to
+// a typed failure). In production this is `fetchMdkTreasuryPath(env)` pointed at
+// `/spark/funding-invoice` on the `MDK_TREASURY` container.
+export type SparkTreasuryFundingInvoicePost = (
+  body: Readonly<Record<string, unknown>>,
+) => Promise<Readonly<{ ok: boolean; status: number; payload: unknown }>>
+
+// Read the raw BOLT11 invoice string from the Spark funding-invoice payload.
+const rawBolt11 = (payload: Record<string, unknown>): unknown =>
+  payload.bolt11Invoice ?? payload.bolt11 ?? payload.invoice
+
+// Read the raw payment hash (lowercase hex) from the Spark funding-invoice
+// payload. The container decodes it from the minted bolt11 `p` field.
+const rawPaymentHash = (payload: Record<string, unknown>): unknown =>
+  payload.paymentHash ?? payload.payment_hash
+
+// Build a `MintLightningInvoice` from a `/spark/funding-invoice` POST transport.
+// The invoice is minted for the requested sats; the issuer reads the RAW bolt11 +
+// paymentHash and surface-validates them (fail-closed). The preimage is NEVER
+// touched here.
+export const makeSparkLightningInvoiceIssuer = (
+  post: SparkTreasuryFundingInvoicePost,
+  timeoutMs: number = SPARK_LIGHTNING_MINT_TIMEOUT_MS,
+): MintLightningInvoice => input =>
+  Effect.gen(function* () {
+    const amountSat = Math.max(1, Math.trunc(input.amountSats))
+    const result = yield* Effect.tryPromise({
+      catch: () => new LightningInvoiceError('provider_unavailable'),
+      try: () =>
+        post({
+          amountSat,
+          description: input.description,
+        }),
+    }).pipe(
+      // Bounded mint: a cold container / cold Spark SDK build can block for
+      // seconds. `Effect.tryPromise` catches throws, NOT a hang — so cap the
+      // wall-clock here. On timeout we fail with the SAME typed
+      // `provider_unavailable` reason a transport error produces, so the selector
+      // falls back to MDK (or, if MDK is also unavailable, drops the rail).
+      Effect.timeoutOrElse({
+        duration: Duration.millis(timeoutMs),
+        orElse: () =>
+          Effect.fail(new LightningInvoiceError('provider_unavailable')),
+      }),
+    )
+    if (!result.ok) {
+      return yield* Effect.fail(
+        new LightningInvoiceError(
+          result.status >= 500 ? 'provider_unavailable' : 'provider_rejected',
+        ),
+      )
+    }
+
+    if (!isRecord(result.payload)) {
+      return yield* Effect.fail(new LightningInvoiceError('provider_rejected'))
+    }
+    const payload = result.payload
+
+    const invoice: LightningInvoice | undefined = validateLightningInvoice({
+      bolt11: rawBolt11(payload),
+      ...(optionalString(payload.expiresAt) === undefined
+        ? {}
+        : { invoiceExpiresAt: optionalString(payload.expiresAt) }),
+      paymentHash: rawPaymentHash(payload),
+    })
+    if (invoice === undefined) {
+      return yield* Effect.fail(new LightningInvoiceError('malformed_invoice'))
+    }
+    return invoice
+  })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice.ts
@@ -135,3 +135,27 @@ export const validateLightningInvoice = (
     ...(invoiceExpiresAt === undefined ? {} : { invoiceExpiresAt }),
   }
 }
+
+// Compose a PRIMARY issuer with a FALLBACK issuer (EPIC #6049, owner directive:
+// Spark primary, MDK fallback). Tries `primary` first; on ANY typed
+// `LightningInvoiceError` (including its bounded mint timeout, which surfaces as
+// `provider_unavailable`), tries `fallback`. The combined issuer is itself the
+// SAME `MintLightningInvoice` seam the route already drops on failure — so if
+// BOTH fail it fails with the fallback's error and the route drops only the
+// Lightning rail (per-rail isolation, #6149). Each leg keeps its OWN bounded mint
+// timeout, and both legs are tuned (Spark + MDK) to fit under the route's outer
+// per-rail guard so a primary timeout plus a fallback attempt can never hang the
+// endpoint. When only one issuer is present it is returned as-is; when neither is
+// present `undefined` is returned (the rail is never offered — honesty gate).
+export const makeFallbackLightningInvoiceIssuer = (
+  primary: MintLightningInvoice | undefined,
+  fallback: MintLightningInvoice | undefined,
+): MintLightningInvoice | undefined => {
+  if (primary === undefined) {
+    return fallback
+  }
+  if (fallback === undefined) {
+    return primary
+  }
+  return input => primary(input).pipe(Effect.catch(() => fallback(input)))
+}


### PR DESCRIPTION
Rebuilds the MPP Lightning rail to issue/receive on **Spark** (`@breeztech/breez-sdk-spark`) as the **PRIMARY** invoice issuer, keeping the existing MDK issuer as an explicit **FALLBACK** only. Per owner directive, Spark is the primary rail for all agent/MPP payments (it supports offline receives); MDK is checkouts-only normally and is kept here solely as a fallback Lightning issuer.

## Worker→Spark issuance + receive (the gap, closed)
The Worker reaches the Spark wallet through the `MDK_TREASURY` container (`fetchMdkTreasuryPath`). That container already exposed `POST /spark/funding-invoice` (mints a Spark BOLT11 via `sdk.receivePayment`), but it returned **no `paymentHash`** and had **no receive-confirmation endpoint** — both required by the MPP 402 challenge. Closed:

- **`services/mdk-treasury`**: `/spark/funding-invoice` now also returns `paymentHash` (decoded dependency-free from the minted bolt11 `p` field; prefers an SDK-reported hash when present) and accepts a `description`. Added `GET /spark/received/:paymentHash` for offline-receive confirmation via `listPayments` (receive type, Completed status). The bolt11 decoder is verified against the BOLT11 spec test vector.

## Worker issuer (Spark primary, MDK fallback)
- New `mpp-lightning-invoice-spark.ts` issuer: POSTs `/spark/funding-invoice`, bounded mint timeout, surface-validates bolt11 + paymentHash, preimage never touched (settlement verified LOCALLY as `sha256(preimage)===paymentHash`).
- `lightningInvoiceIssuerForEnv` now tries **Spark first**, falls back to **MDK** only when Spark is unavailable/unconfigured, via `makeFallbackLightningInvoiceIssuer`. Each leg keeps its own bounded mint timeout (Spark 1.2s, MDK fallback 1.2s) so a primary timeout + a fallback attempt stays under the route's per-rail guard (#6149): a slow/failed issuer can only ever drop the Lightning rail, never hang the endpoint.
- Lightning stays **FIRST** in the 402 + `/openapi.json` offers regardless of which issuer minted it. Bitcoin-origin credit semantics unchanged. Honesty gate preserved.

## Invariant
`INVARIANTS.md` "Payment Rail Separation" no longer says the MPP issuer is an open violation "to be rebuilt on Spark." Spark is now the primary MPP Lightning path; MDK is permitted **ONLY as an explicit fallback Lightning issuer (never primary)** and remains checkouts-only otherwise.

## Inert / safety
Flag-gated behind `KHALA_MPP_LIGHTNING_ENABLED` (unset on prod). **No prod arming, no secrets, no deploy.**

## Tests
Spark issuer mint → Lightning challenge present + FIRST; Spark unavailable → MDK fallback used; both unavailable/slow → Lightning dropped while crypto+card return fast (no hang, #6149 isolation); inert when flag off; bolt11 paymentHash decode vs the BOLT11 spec vector. `bun run typecheck:api` + `bun run check:deploy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)