### PR TITLE
Raise MPP Lightning mint-timeout budgets to cover real Spark latency

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
@@ -1,6 +1,6 @@
 import { DatabaseSync } from 'node:sqlite'
 
-import { Effect, Fiber } from 'effect'
+import { Duration, Effect, Fiber } from 'effect'
 import { TestClock } from 'effect/testing'
 import { describe, expect, test } from 'vitest'
 
@@ -1202,5 +1202,120 @@ describe('MPP endpoint — Lightning rail (Bitcoin-first)', () => {
     }
     expect(problem.challenges[0]?.method).toBe('lightning')
     expect(problem.challenges.some(c => c.method === 'base')).toBe(true)
+  })
+
+  // ---- BUDGET RAISE (#6049): cover REAL warm Spark mint latency ----
+  //
+  // The real Spark `/spark/funding-invoice` mint takes ~1.5–3.1s even warm, so
+  // the old 1.2s issuer cap + 2.5s leg guard always tripped and the honesty gate
+  // dropped Lightning from every prod 402. The budgets are now
+  // `SPARK_LIGHTNING_MINT_TIMEOUT_MS = 4000` and `LIGHTNING_LEG_GUARD_MS = 4500`.
+  // These two tests pin the new semantics: a mint that completes within the
+  // budget SUCCEEDS and surfaces Lightning FIRST; a mint that exceeds the outer
+  // guard still DROPS only Lightning (crypto + card stay fast, no hang).
+
+  test('SLOW-BUT-IN-BUDGET MINT (~3.5s, real warm Spark): lightning SURFACES first, crypto + card present', async () => {
+    const db = makeDb()
+    let mintStarted = false
+    // Models a real warm Spark mint: resolves after ~3.5s, under the 4.5s outer
+    // leg guard. The honesty gate must now ACCEPT it (old 1.2s cap would drop).
+    const slowMint: MintLightningInvoice = () =>
+      Effect.gen(function* () {
+        mintStarted = true
+        yield* Effect.sleep(Duration.millis(3_500))
+        const paymentHash = yield* Effect.promise(lightningPaymentHash)
+        return {
+          bolt11: LIGHTNING_INVOICE,
+          network: 'mainnet' as const,
+          paymentHash,
+        }
+      })
+    const response = await run(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          handleMppChatCompletions(mppRequest(), {
+            completionDeps: completionDeps(db),
+            db,
+            enabled: true,
+            fetch: lightningQuoteFetch(),
+            lightningEnabled: true,
+            mintLightningInvoice: slowMint,
+            newId: () => 'fixed',
+            signingSecret: SIGNING_SECRET,
+            stripeNetworkProfileId: 'profile_test',
+            stripeSecretKey: 'sk_test_x',
+          }),
+        )
+        // Advance past the ~3.5s mint but still under the 4.5s guard.
+        yield* TestClock.adjust(4_000)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(mintStarted).toBe(true)
+    expect(response.status).toBe(402)
+    const wwwAuth = response.headers.get('www-authenticate') ?? ''
+    // Lightning is the FIRST presented challenge (Bitcoin-first) — it SURVIVED.
+    const firstChallenge = wwwAuth.split(/,\s*(?=Payment\s)/i)[0] ?? ''
+    expect(firstChallenge).toContain('method="lightning"')
+    expect(wwwAuth).toContain('method="base"')
+    expect(wwwAuth).toContain('method="stripe"')
+    const problem = (await response.json()) as {
+      challenges: Array<{ method: string }>
+    }
+    expect(problem.challenges[0]?.method).toBe('lightning')
+    expect(problem.challenges.some(c => c.method === 'base')).toBe(true)
+    expect(problem.challenges.some(c => c.method === 'stripe')).toBe(true)
+  })
+
+  test('OVER-GUARD MINT (~6s, exceeds 4.5s guard): lightning DROPPED, crypto + card still present, no hang', async () => {
+    const db = makeDb()
+    let mintStarted = false
+    // Models a mint that exceeds even the raised 4.5s outer leg guard. Per-rail
+    // isolation (#6149) must still hold: the leg is interrupted and ONLY Lightning
+    // is dropped — crypto + card are unaffected and the 402 never hangs.
+    const tooSlowMint: MintLightningInvoice = () =>
+      Effect.gen(function* () {
+        mintStarted = true
+        yield* Effect.sleep(Duration.millis(6_000))
+        const paymentHash = yield* Effect.promise(lightningPaymentHash)
+        return {
+          bolt11: LIGHTNING_INVOICE,
+          network: 'mainnet' as const,
+          paymentHash,
+        }
+      })
+    const response = await run(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          handleMppChatCompletions(mppRequest(), {
+            completionDeps: completionDeps(db),
+            db,
+            enabled: true,
+            fetch: lightningQuoteFetch(),
+            lightningEnabled: true,
+            mintLightningInvoice: tooSlowMint,
+            newId: () => 'fixed',
+            signingSecret: SIGNING_SECRET,
+            stripeNetworkProfileId: 'profile_test',
+            stripeSecretKey: 'sk_test_x',
+          }),
+        )
+        // Advance well past the 4.5s guard AND the 6s mint.
+        yield* TestClock.adjust(10_000)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(mintStarted).toBe(true)
+    expect(response.status).toBe(402)
+    const wwwAuth = response.headers.get('www-authenticate') ?? ''
+    expect(wwwAuth).not.toContain('method="lightning"')
+    expect(wwwAuth).toContain('method="base"')
+    expect(wwwAuth).toContain('method="stripe"')
+    const problem = (await response.json()) as {
+      challenges: Array<{ method: string }>
+    }
+    expect(problem.challenges.some(c => c.method === 'lightning')).toBe(false)
+    expect(problem.challenges.some(c => c.method === 'base')).toBe(true)
+    expect(problem.challenges.some(c => c.method === 'stripe')).toBe(true)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
@@ -99,7 +99,16 @@ const CHALLENGE_TTL_MS = 5 * 60 * 1000
 // leg runs CONCURRENTLY with the crypto deposit (see `issueChallenge`), so even
 // at the full budget it never DELAYS the other rails — a slow/failed Lightning
 // rail can only ever drop ITSELF.
-const LIGHTNING_LEG_GUARD_MS = 2_500
+//
+// BUDGET (#6049): raised to 4.5s so it stays ABOVE the Spark primary mint budget
+// (`SPARK_LIGHTNING_MINT_TIMEOUT_MS = 4000`). A real warm Spark mint takes
+// ~1.5–3.1s, so the outer guard must not cut it off before it can surface the
+// Lightning rail. The guard still BOUNDS the whole leg: a mint that exceeds 4.5s
+// is interrupted and the Lightning rail is dropped (honesty gate, #6149), so the
+// 402 can never hang and crypto + card stay fast. This trades ~1s of 402 latency
+// for Lightning visibility; the zero-latency fix is a pre-minted Spark invoice
+// pool (future optimization, tracked on #6049).
+const LIGHTNING_LEG_GUARD_MS = 4_500
 
 // Parse the KHALA_MPP_ENABLED flag. Default OFF.
 export const isKhalaMppEnabled = (value: string | undefined): boolean => {

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
@@ -93,12 +93,17 @@ const rawInvoiceExpiry = (
 // checkout is created in `amount` mode with `currency: 'SAT'` for the requested
 // sats; the issuer reads the RAW bolt11 + paymentHash and surface-validates them
 // (fail-closed). The preimage is NEVER touched here.
-// Tighter mint timeout for when MDK runs as the FALLBACK leg behind the Spark
-// primary (EPIC #6049). Spark gets its own bounded primary attempt; if Spark
-// times out, the MDK fallback must still finish under the route's outer per-rail
-// guard (#6149), so the chained worst case (Spark + MDK) cannot hang the
-// endpoint. Used by the selector when both issuers are present.
-export const MDK_LIGHTNING_FALLBACK_MINT_TIMEOUT_MS = 1_200
+// Mint timeout for when MDK runs as the FALLBACK leg behind the Spark primary
+// (EPIC #6049). The fallback only runs if Spark fails FAST (e.g. a non-ok status
+// or a thrown transport error), so it does not normally stack on top of the full
+// Spark budget. It is bounded so a slow/cold MDK sidecar still cannot hang the
+// endpoint: a fallback that exceeds this budget (or the route's outer per-rail
+// guard `LIGHTNING_LEG_GUARD_MS`, #6149) just DROPS the Lightning rail. Raised to
+// 3s alongside the Spark primary budget so a real warm MDK mint can also surface
+// Lightning; the zero-latency fix remains a pre-minted invoice pool (future
+// optimization, tracked on #6049). Used by the selector when both issuers are
+// present.
+export const MDK_LIGHTNING_FALLBACK_MINT_TIMEOUT_MS = 3_000
 
 export const makeMdkLightningInvoiceIssuer = (
   post: MdkRoutePost,

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.ts
@@ -37,10 +37,18 @@ import {
 // cold/slow mint would block the Lightning leg. With it, a slow mint resolves to
 // a typed `provider_unavailable` failure so the SELECTOR can fall back to MDK and
 // still finish under the route's outer per-rail guard (#6149,
-// `LIGHTNING_LEG_GUARD_MS`). Kept tight (1.2s) so a Spark timeout + an MDK
-// fallback attempt together stay under that guard; the route guard is the final
-// safety net either way.
-export const SPARK_LIGHTNING_MINT_TIMEOUT_MS = 1_200
+// `LIGHTNING_LEG_GUARD_MS`).
+//
+// BUDGET (#6049): the real Spark `/spark/funding-invoice` mint takes ~1.5–3.1s
+// even WARM, so the old 1.2s cap always tripped and the honesty gate dropped
+// Lightning from every 402. This budget is raised to 4s so a real warm Spark
+// mint actually completes and surfaces the Lightning rail. The tradeoff is ~1s
+// more 402 latency in exchange for Lightning visibility; the zero-latency fix is
+// a pre-minted Spark invoice pool (future optimization, tracked on #6049). The
+// per-rail isolation (#6149) is preserved: a mint that exceeds this budget (or
+// the outer `LIGHTNING_LEG_GUARD_MS`) still only DROPS the Lightning rail — it
+// can never hang the endpoint, which always returns crypto + card fast.
+export const SPARK_LIGHTNING_MINT_TIMEOUT_MS = 4_000
 
 // A POST transport to the Spark treasury route. Returns the HTTP ok flag +
 // status + parsed JSON payload (no throwing — the issuer maps a non-ok status to


### PR DESCRIPTION
## Problem
The MPP Lightning rail is armed on prod (`KHALA_MPP_LIGHTNING_ENABLED`) but never appears in the runtime 402. The real Spark mint (`MDK_TREASURY` `/spark/funding-invoice`) takes ~1.5–3.1s even warm, exceeding the hard-coded per-leg budgets, so it always times out → the honesty gate drops Lightning → the 402 stays `[base, stripe]`.

## Change
Raise the mint-timeout budgets to cover real Spark latency with margin (and document the tradeoff at each constant):

- `SPARK_LIGHTNING_MINT_TIMEOUT_MS` 1200 → **4000** (primary mint)
- `MDK_LIGHTNING_FALLBACK_MINT_TIMEOUT_MS` 1200 → **3000** (fallback; only runs if Spark fails fast)
- `LIGHTNING_LEG_GUARD_MS` 2500 → **4500** (outer per-rail guard; ≥ the primary mint budget so a real Spark mint isn't cut off, while still bounding the 402 so it can never hang)

This trades ~1s of 402 latency for Lightning visibility; the zero-latency fix is a pre-minted Spark invoice pool (future optimization, tracked on #6049). The per-rail isolation (#6149) is preserved — a failed/over-guard Lightning leg still only drops Lightning, never hangs the endpoint.

## Tests
Added two route regression tests:
- a ~3.5s in-budget mint (models a real warm Spark mint) now **SUCCEEDS** and surfaces Lightning **first**, with crypto + card present;
- a ~6s over-guard mint still **DROPS only Lightning** with crypto + card present and no hang.

`bun run typecheck:api` and `bun run check:deploy` are green (the `.worktrees/` contract-drift quirk is known/unrelated).

Refs #6049, #6149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)