### PR TITLE
Raise MPP Lightning budgets further for real warm Spark mint (~3.9s)

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
@@ -1206,23 +1206,26 @@ describe('MPP endpoint — Lightning rail (Bitcoin-first)', () => {
 
   // ---- BUDGET RAISE (#6049): cover REAL warm Spark mint latency ----
   //
-  // The real Spark `/spark/funding-invoice` mint takes ~1.5–3.1s even warm, so
-  // the old 1.2s issuer cap + 2.5s leg guard always tripped and the honesty gate
-  // dropped Lightning from every prod 402. The budgets are now
-  // `SPARK_LIGHTNING_MINT_TIMEOUT_MS = 4000` and `LIGHTNING_LEG_GUARD_MS = 4500`.
+  // The real warm Spark `/spark/funding-invoice` mint subrequest returns 200 in
+  // ~3.76–3.95s (observed in prod `wrangler tail`), and the worker-side
+  // round-trip lands at/just over 4s — so the old 1.2s issuer cap + 2.5s leg
+  // guard (and even a first-raise 4s/4.5s) tripped and the honesty gate dropped
+  // Lightning from every prod 402. The budgets are now
+  // `SPARK_LIGHTNING_MINT_TIMEOUT_MS = 6000` and `LIGHTNING_LEG_GUARD_MS = 6500`.
   // These two tests pin the new semantics: a mint that completes within the
   // budget SUCCEEDS and surfaces Lightning FIRST; a mint that exceeds the outer
   // guard still DROPS only Lightning (crypto + card stay fast, no hang).
 
-  test('SLOW-BUT-IN-BUDGET MINT (~3.5s, real warm Spark): lightning SURFACES first, crypto + card present', async () => {
+  test('SLOW-BUT-IN-BUDGET MINT (~4s, real warm Spark): lightning SURFACES first, crypto + card present', async () => {
     const db = makeDb()
     let mintStarted = false
-    // Models a real warm Spark mint: resolves after ~3.5s, under the 4.5s outer
-    // leg guard. The honesty gate must now ACCEPT it (old 1.2s cap would drop).
+    // Models a real warm Spark mint: resolves after ~4s, under the 6.5s outer
+    // leg guard. The honesty gate must now ACCEPT it (old 1.2s/4s caps would
+    // drop this real-world latency).
     const slowMint: MintLightningInvoice = () =>
       Effect.gen(function* () {
         mintStarted = true
-        yield* Effect.sleep(Duration.millis(3_500))
+        yield* Effect.sleep(Duration.millis(4_000))
         const paymentHash = yield* Effect.promise(lightningPaymentHash)
         return {
           bolt11: LIGHTNING_INVOICE,
@@ -1246,8 +1249,8 @@ describe('MPP endpoint — Lightning rail (Bitcoin-first)', () => {
             stripeSecretKey: 'sk_test_x',
           }),
         )
-        // Advance past the ~3.5s mint but still under the 4.5s guard.
-        yield* TestClock.adjust(4_000)
+        // Advance past the ~4s mint but still under the 6.5s guard.
+        yield* TestClock.adjust(5_000)
         return yield* Fiber.join(fiber)
       }).pipe(Effect.provide(TestClock.layer())),
     )
@@ -1267,16 +1270,16 @@ describe('MPP endpoint — Lightning rail (Bitcoin-first)', () => {
     expect(problem.challenges.some(c => c.method === 'stripe')).toBe(true)
   })
 
-  test('OVER-GUARD MINT (~6s, exceeds 4.5s guard): lightning DROPPED, crypto + card still present, no hang', async () => {
+  test('OVER-GUARD MINT (~8s, exceeds 6.5s guard): lightning DROPPED, crypto + card still present, no hang', async () => {
     const db = makeDb()
     let mintStarted = false
-    // Models a mint that exceeds even the raised 4.5s outer leg guard. Per-rail
+    // Models a mint that exceeds even the raised 6.5s outer leg guard. Per-rail
     // isolation (#6149) must still hold: the leg is interrupted and ONLY Lightning
     // is dropped — crypto + card are unaffected and the 402 never hangs.
     const tooSlowMint: MintLightningInvoice = () =>
       Effect.gen(function* () {
         mintStarted = true
-        yield* Effect.sleep(Duration.millis(6_000))
+        yield* Effect.sleep(Duration.millis(8_000))
         const paymentHash = yield* Effect.promise(lightningPaymentHash)
         return {
           bolt11: LIGHTNING_INVOICE,
@@ -1300,7 +1303,7 @@ describe('MPP endpoint — Lightning rail (Bitcoin-first)', () => {
             stripeSecretKey: 'sk_test_x',
           }),
         )
-        // Advance well past the 4.5s guard AND the 6s mint.
+        // Advance well past the 6.5s guard AND the 8s mint.
         yield* TestClock.adjust(10_000)
         return yield* Fiber.join(fiber)
       }).pipe(Effect.provide(TestClock.layer())),

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
@@ -100,15 +100,17 @@ const CHALLENGE_TTL_MS = 5 * 60 * 1000
 // at the full budget it never DELAYS the other rails — a slow/failed Lightning
 // rail can only ever drop ITSELF.
 //
-// BUDGET (#6049): raised to 4.5s so it stays ABOVE the Spark primary mint budget
-// (`SPARK_LIGHTNING_MINT_TIMEOUT_MS = 4000`). A real warm Spark mint takes
-// ~1.5–3.1s, so the outer guard must not cut it off before it can surface the
-// Lightning rail. The guard still BOUNDS the whole leg: a mint that exceeds 4.5s
+// BUDGET (#6049): raised to 6.5s so it stays ABOVE the Spark primary mint budget
+// (`SPARK_LIGHTNING_MINT_TIMEOUT_MS = 6000`). PROD `wrangler tail` showed the
+// real warm `MdkTreasuryContainer` mint subrequest returning 200 in ~3.76–3.95s,
+// and the worker-side round-trip lands at/just over 4s — so the outer guard must
+// sit well above that to not cut a real mint off before it can surface the
+// Lightning rail. The guard still BOUNDS the whole leg: a mint that exceeds 6.5s
 // is interrupted and the Lightning rail is dropped (honesty gate, #6149), so the
-// 402 can never hang and crypto + card stay fast. This trades ~1s of 402 latency
-// for Lightning visibility; the zero-latency fix is a pre-minted Spark invoice
-// pool (future optimization, tracked on #6049).
-const LIGHTNING_LEG_GUARD_MS = 4_500
+// 402 can never hang and crypto + card stay fast. This trades ~4–5s of 402
+// latency (when Lightning mints) for Lightning visibility; the zero-latency fix
+// is a pre-minted Spark invoice pool (future optimization, tracked on #6049).
+const LIGHTNING_LEG_GUARD_MS = 6_500
 
 // Parse the KHALA_MPP_ENABLED flag. Default OFF.
 export const isKhalaMppEnabled = (value: string | undefined): boolean => {

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.ts
@@ -41,14 +41,18 @@ import {
 //
 // BUDGET (#6049): the real Spark `/spark/funding-invoice` mint takes ~1.5–3.1s
 // even WARM, so the old 1.2s cap always tripped and the honesty gate dropped
-// Lightning from every 402. This budget is raised to 4s so a real warm Spark
-// mint actually completes and surfaces the Lightning rail. The tradeoff is ~1s
-// more 402 latency in exchange for Lightning visibility; the zero-latency fix is
-// a pre-minted Spark invoice pool (future optimization, tracked on #6049). The
-// per-rail isolation (#6149) is preserved: a mint that exceeds this budget (or
-// the outer `LIGHTNING_LEG_GUARD_MS`) still only DROPS the Lightning rail — it
-// can never hang the endpoint, which always returns crypto + card fast.
-export const SPARK_LIGHTNING_MINT_TIMEOUT_MS = 4_000
+// Lightning from every 402. PROD `wrangler tail` after the first raise showed the
+// `MdkTreasuryContainer` mint subrequest itself returning 200 in ~3.76–3.95s
+// warm — and the worker-side round-trip (DO dispatch + queue overhead on top of
+// the container time) lands right AT/just over a 4s cap, so a 4s budget still
+// tripped. This budget is raised to 6s to give the real warm mint genuine
+// headroom and reliably surface the Lightning rail. The tradeoff is the 402 now
+// takes ~4–5s when Lightning mints; the zero-latency fix is a pre-minted Spark
+// invoice pool (future optimization, tracked on #6049). The per-rail isolation
+// (#6149) is preserved: a mint that exceeds this budget (or the outer
+// `LIGHTNING_LEG_GUARD_MS`) still only DROPS the Lightning rail — it can never
+// hang the endpoint, which always returns crypto + card fast.
+export const SPARK_LIGHTNING_MINT_TIMEOUT_MS = 6_000
 
 // A POST transport to the Spark treasury route. Returns the HTTP ok flag +
 // status + parsed JSON payload (no throwing — the issuer maps a non-ok status to


### PR DESCRIPTION
Follow-up to #6153.

## What prod showed
After #6153 (4000ms issuer / 4500ms guard) deployed, `wrangler tail` on prod showed the real warm `MdkTreasuryContainer` `/spark/funding-invoice` mint subrequest itself returning **200 in ~3.76–3.95s**. The worker-side round-trip (DO dispatch + queue overhead on top of the container time) lands **at/just over a 4s cap**, so the 4s issuer budget still tripped and the honesty gate kept dropping Lightning from the prod 402 (`[base, stripe]`, ~3.7–4s latency = the leg genuinely waiting then timing out).

## Change
- `SPARK_LIGHTNING_MINT_TIMEOUT_MS` 4000 → **6000** (primary mint)
- `LIGHTNING_LEG_GUARD_MS` 4500 → **6500** (outer guard, > primary mint budget)
- `MDK_LIGHTNING_FALLBACK_MINT_TIMEOUT_MS` stays **3000** (fallback only runs if Spark fails fast)

Tradeoff: the 402 now takes ~4–5s when Lightning mints; the zero-latency fix remains a pre-minted Spark invoice pool (#6049). Per-rail isolation (#6149) preserved — a mint over the 6.5s guard still drops only Lightning and never hangs the endpoint.

Route regression tests updated: a ~4s in-budget mint SUCCEEDS and surfaces Lightning first; a ~8s over-guard mint still DROPS only Lightning with crypto + card present and no hang. `typecheck:api` green, mpp tests green.

Refs #6049, #6149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)