### PR TITLE
Autopilot Concierge: Khala-backed agent on the /api/v1 model API

### DIFF
--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-program.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-program.test.ts
@@ -206,6 +206,38 @@ describe('onboarding turn driver', () => {
     expect(persisted?.transcript).toHaveLength(2)
   })
 
+  test('accumulates the structured Output Spec from fenced replies across turns', async () => {
+    const store = makeD1OnboardingSessionStore(makeD1())
+    const first = recordingInferenceClient(
+      'Got it.\n```oa-output-spec\n{"business":"Acme bakery"}\n```',
+    )
+    const r1 = await run(
+      runOnboardingTurn(
+        { sessionId: 'sess-spec', userText: 'We run a bakery.', vertical: 'general' },
+        { infer: first.client, nowIso: () => '2026-06-23T00:00:00.000Z', store },
+      ),
+    )
+    expect(r1.outputSpec.business).toBe('Acme bakery')
+
+    const second = recordingInferenceClient(
+      'Thanks.\n```oa-output-spec\n{"goal":"more walk-ins","quickWin":"fix the site"}\n```',
+    )
+    const r2 = await run(
+      runOnboardingTurn(
+        { sessionId: 'sess-spec', userText: 'More foot traffic.', vertical: 'general' },
+        { infer: second.client, nowIso: () => '2026-06-23T00:01:00.000Z', store },
+      ),
+    )
+    // Prior field is preserved; new fields are added (the spec only grows).
+    expect(r2.outputSpec.business).toBe('Acme bakery')
+    expect(r2.outputSpec.goal).toBe('more walk-ins')
+    expect(r2.outputSpec.quickWin).toBe('fix the site')
+
+    const persisted = await run(store.read('sess-spec'))
+    expect(persisted?.outputSpec.business).toBe('Acme bakery')
+    expect(persisted?.outputSpec.goal).toBe('more walk-ins')
+  })
+
   test('a multi-turn session advances and replays prior transcript', async () => {
     const store = makeD1OnboardingSessionStore(makeD1())
     const first = recordingInferenceClient('Got it. Who are your customers?')

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-program.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-program.ts
@@ -26,8 +26,12 @@ import {
   onboardingVerticalStorageValue,
   resolveOnboardingPromptVertical,
 } from './autopilot-onboarding-system-prompt'
-import { type AutopilotConciergeVertical } from './inference/autopilot-concierge-model'
-import { parseJsonWithSchema } from './json-boundary'
+import {
+  type AutopilotConciergeVertical,
+  OA_OUTPUT_SPEC_FENCE_TAG as CONCIERGE_OUTPUT_SPEC_FENCE_TAG,
+  OUTPUT_SPEC_FIELDS as CONCIERGE_OUTPUT_SPEC_FIELDS,
+} from './inference/autopilot-concierge-model'
+import { parseJsonUnknown, parseJsonWithSchema } from './json-boundary'
 
 export const KHALA_ONBOARDING_MODEL = 'openagents/khala-mini'
 
@@ -57,6 +61,158 @@ export const OnboardingOutputSpec = S.Struct({
   openQuestions: S.optionalKey(S.String),
 })
 export type OnboardingOutputSpec = typeof OnboardingOutputSpec.Type
+
+// OUTPUT SPEC EXTRACTION (issue #6148) --------------------------------------
+//
+// The model surfaces the current Output Spec as a structured artifact via a
+// fenced `oa-output-spec` JSON block (every field optional; a partial spec is
+// valid mid-interview). The program OWNS the schema, so the extractor lives here
+// (the inference surface re-exports it) — keeping ONE source of truth and no
+// circular dependency. The fenced JSON block is the reliable primary; a markdown
+// `Output Spec` section is a bounded best-effort fallback. Pure; never throws.
+
+// The fenced-block language tag the model uses to surface the structured spec
+// + the 10 canonical spec field keys. Re-exported from the concierge model
+// module (the shared, cycle-free home), so the schema, the parser, and the
+// system prompt all derive from ONE field list.
+export const OA_OUTPUT_SPEC_FENCE_TAG = CONCIERGE_OUTPUT_SPEC_FENCE_TAG
+export const ONBOARDING_OUTPUT_SPEC_FIELDS = CONCIERGE_OUTPUT_SPEC_FIELDS
+
+const OUTPUT_SPEC_FENCE_RE = new RegExp(
+  '```' + OA_OUTPUT_SPEC_FENCE_TAG + '\\s*\\n([\\s\\S]*?)\\n?```',
+  'g',
+)
+
+// The LAST fenced `oa-output-spec` block's raw JSON body (the freshest snapshot),
+// or undefined when none is present.
+const lastFencedOutputSpecJson = (completion: string): string | undefined => {
+  OUTPUT_SPEC_FENCE_RE.lastIndex = 0
+  let match: RegExpExecArray | null
+  let last: string | undefined
+  while ((match = OUTPUT_SPEC_FENCE_RE.exec(completion)) !== null) {
+    last = match[1] ?? ''
+  }
+  return last
+}
+
+// Narrow an arbitrary record to the closed set of known string fields, then
+// validate against the schema. Returns undefined on parse/validation failure or
+// when no known field survives. Never throws.
+const decodeOutputSpecObject = (
+  value: unknown,
+): OnboardingOutputSpec | undefined => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  const record = value as Record<string, unknown>
+  const narrowed: Record<string, string> = {}
+  for (const field of ONBOARDING_OUTPUT_SPEC_FIELDS) {
+    const fieldValue = record[field]
+    if (typeof fieldValue === 'string' && fieldValue.trim() !== '') {
+      narrowed[field] = fieldValue.trim()
+    }
+  }
+  if (Object.keys(narrowed).length === 0) {
+    return undefined
+  }
+  try {
+    return S.decodeUnknownSync(OnboardingOutputSpec)(narrowed)
+  } catch {
+    return undefined
+  }
+}
+
+const MARKDOWN_OUTPUT_SPEC_LABELS: ReadonlyArray<
+  Readonly<{ field: keyof OnboardingOutputSpec; labels: ReadonlyArray<string> }>
+> = [
+  { field: 'business', labels: ['business'] },
+  { field: 'goal', labels: ['goal'] },
+  { field: 'chosenOfferings', labels: ['chosen offerings', 'offerings'] },
+  { field: 'quickWin', labels: ['quick win'] },
+  { field: 'successMetric', labels: ['success metric'] },
+  { field: 'scope', labels: ['scope'] },
+  { field: 'constraints', labels: ['constraints'] },
+  { field: 'timeline', labels: ['timeline'] },
+  { field: 'payment', labels: ['payment'] },
+  { field: 'openQuestions', labels: ['open questions'] },
+]
+
+// Text AFTER the last `Output Spec` heading, or undefined when absent.
+const outputSpecMarkdownSection = (completion: string): string | undefined => {
+  const headingRe = /(?:^|\n)[#*\s]*output spec[#*:\s]*\n/gi
+  let match: RegExpExecArray | null
+  let lastEnd: number | undefined
+  while ((match = headingRe.exec(completion)) !== null) {
+    lastEnd = match.index + match[0].length
+  }
+  return lastEnd === undefined ? undefined : completion.slice(lastEnd)
+}
+
+const parseMarkdownOutputSpec = (
+  section: string,
+): OnboardingOutputSpec | undefined => {
+  const collected: Record<string, string> = {}
+  for (const rawLine of section.split('\n')) {
+    const line = rawLine
+      .replace(/^[\s>]*[-*]?\s*/, '')
+      .replace(/^\d+[.)]\s*/, '')
+      .replace(/\*\*/g, '')
+      .trim()
+    if (line === '') continue
+    const sep = line.search(/\s—\s|\s–\s|:\s/u)
+    if (sep === -1) continue
+    const label = line
+      .slice(0, sep)
+      .trim()
+      .toLowerCase()
+      .replace(/^\d+[.)]?\s*/, '')
+      .trim()
+    const value = line.slice(sep).replace(/^\s*[—–:]\s*/u, '').trim()
+    if (value === '') continue
+    if (/^\(?(none|n\/a|na|tbd|unknown|—|-)\)?$/i.test(value)) continue
+    const binding = MARKDOWN_OUTPUT_SPEC_LABELS.find(b =>
+      b.labels.some(l => label === l || label.startsWith(l)),
+    )
+    if (binding === undefined) continue
+    if (collected[binding.field] === undefined) {
+      collected[binding.field] = value
+    }
+  }
+  return decodeOutputSpecObject(collected)
+}
+
+// Extract the structured Output Spec from a completion: the LAST fenced
+// `oa-output-spec` JSON block first (reliable), then a markdown `Output Spec`
+// section (best-effort). Returns undefined when neither yields a known field.
+export const extractOnboardingOutputSpec = (
+  completion: string,
+): OnboardingOutputSpec | undefined => {
+  const fenced = lastFencedOutputSpecJson(completion)
+  if (fenced !== undefined) {
+    let parsed: unknown
+    try {
+      // Parse at the named JSON boundary helper (zero-debt: raw JSON.parse stays
+      // inside json-boundary.ts).
+      parsed = parseJsonUnknown(fenced)
+    } catch {
+      parsed = undefined
+    }
+    const spec = decodeOutputSpecObject(parsed)
+    if (spec !== undefined) {
+      return spec
+    }
+  }
+  const section = outputSpecMarkdownSection(completion)
+  return section === undefined ? undefined : parseMarkdownOutputSpec(section)
+}
+
+// Merge a freshly-extracted spec over a prior accumulated spec so a session's
+// spec only GROWS across turns (a later non-empty field overrides; an omitted
+// field does not erase the earlier value). Pure.
+export const mergeOnboardingOutputSpec = (
+  prior: OnboardingOutputSpec,
+  next: OnboardingOutputSpec | undefined,
+): OnboardingOutputSpec => (next === undefined ? prior : { ...prior, ...next })
 
 export const OnboardingSessionStatus = S.Literals(['interviewing', 'complete'])
 export type OnboardingSessionStatus = typeof OnboardingSessionStatus.Type
@@ -359,7 +515,13 @@ export const runOnboardingTurn = (
       ),
       status: session.status,
       transcript: [...session.transcript, userTurn, assistantTurn],
-      outputSpec: session.outputSpec,
+      // Accumulate the structured Output Spec from this reply over the prior
+      // session spec (issue #6148), so the persisted spec grows across turns and
+      // the page + programmatic consumers read the same structured artifact.
+      outputSpec: mergeOnboardingOutputSpec(
+        session.outputSpec,
+        extractOnboardingOutputSpec(reply),
+      ),
       turnCount: session.turnCount + 1,
       createdAt: session.createdAt,
       updatedAt: now,
@@ -475,7 +637,12 @@ export const finalizeOnboardingStreamTurn = (
       ),
       status: session.status,
       transcript: [...session.transcript, userTurn, assistantTurn],
-      outputSpec: session.outputSpec,
+      // Accumulate the structured Output Spec from this reply over the prior
+      // session spec (issue #6148) — same as the buffered driver.
+      outputSpec: mergeOnboardingOutputSpec(
+        session.outputSpec,
+        extractOnboardingOutputSpec(reply),
+      ),
       turnCount: session.turnCount + 1,
       createdAt: session.createdAt,
       updatedAt: now,

--- a/apps/openagents.com/workers/api/src/inference/autopilot-concierge-model.ts
+++ b/apps/openagents.com/workers/api/src/inference/autopilot-concierge-model.ts
@@ -7,6 +7,7 @@
 // `/v1` auth, rate/fair-share, balance, metering, receipt, and component-channel
 // boundaries.
 import { KHALA_COMPONENT_NAMES } from './khala-component-channel'
+import { AUTOPILOT_CONCIERGE_TOOLS_PROMPT } from './autopilot-concierge-tools'
 
 export const AUTOPILOT_CONCIERGE_MODEL_ID =
   'openagents/autopilot-concierge' as const
@@ -15,7 +16,12 @@ export const AUTOPILOT_CONCIERGE_VERTICALS = ['general', 'legal'] as const
 export type AutopilotConciergeVertical =
   (typeof AUTOPILOT_CONCIERGE_VERTICALS)[number]
 
-const OUTPUT_SPEC_FIELDS = [
+// The 10-section Output Spec field keys, in section order. CANONICAL here (this
+// module has no dependency on the onboarding program, so it is a safe shared
+// home that the program + the inference extractor both import — avoiding an
+// import cycle). The fenced-block tag the model uses to surface the structured
+// spec (issue #6148).
+export const OUTPUT_SPEC_FIELDS = [
   'business',
   'goal',
   'chosenOfferings',
@@ -27,6 +33,19 @@ const OUTPUT_SPEC_FIELDS = [
   'payment',
   'openQuestions',
 ] as const
+
+export const OA_OUTPUT_SPEC_FENCE_TAG = 'oa-output-spec' as const
+
+// The system-prompt instruction telling the model to emit the structured Output
+// Spec block (issue #6148). Lives here (alongside the field list) so the prompt
+// and the parser derive from the same field constant, and so the concierge model
+// module does not import the program-coupled extractor module.
+export const AUTOPILOT_CONCIERGE_OUTPUT_SPEC_PROMPT = [
+  'STRUCTURED OUTPUT SPEC (for programmatic consumers).',
+  `When you have any Output Spec content, emit the current spec as a single fenced \`\`\`${OA_OUTPUT_SPEC_FENCE_TAG}\`\`\` JSON block, in addition to your normal prose.`,
+  `The JSON object's keys are exactly: ${OUTPUT_SPEC_FIELDS.join(', ')}. Every key is optional; include only fields you can support from the conversation. Values are short plain strings.`,
+  'Re-emit the full current spec each materially-complete turn (it accumulates). Put the block at the end of your reply. Never invent a key outside that list and never put model/provider identity inside it.',
+].join(' ')
 
 export type AutopilotConciergeRequestConfig = Readonly<{
   vertical: AutopilotConciergeVertical
@@ -122,6 +141,10 @@ Operating rules:
 - Ask for missing facts only when they change the first win or the consent boundary.
 - If you emit a component, use only the closed catalog and valid props. Never invent a component name.
 - End each materially complete turn with an \`Output Spec\` section containing only fields you can support from the conversation; mark unknowns as open questions.
+
+${AUTOPILOT_CONCIERGE_OUTPUT_SPEC_PROMPT}
+
+${AUTOPILOT_CONCIERGE_TOOLS_PROMPT}
 
 ${verticalBlock}`
 }

--- a/apps/openagents.com/workers/api/src/inference/autopilot-concierge-output-spec.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/autopilot-concierge-output-spec.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  AUTOPILOT_CONCIERGE_OUTPUT_SPEC_PROMPT,
+  extractConciergeOutputSpec,
+  mergeConciergeOutputSpec,
+} from './autopilot-concierge-output-spec'
+
+describe('Autopilot Concierge Output Spec extraction', () => {
+  test('extracts the fenced oa-output-spec JSON block', () => {
+    const completion = [
+      'Here is the current intake state.',
+      '',
+      '```oa-output-spec',
+      '{"business":"Acme LLC","goal":"save time","quickWin":"draft a checklist"}',
+      '```',
+      '',
+      'What is your budget?',
+    ].join('\n')
+    const spec = extractConciergeOutputSpec(completion)
+    expect(spec).toEqual({
+      business: 'Acme LLC',
+      goal: 'save time',
+      quickWin: 'draft a checklist',
+    })
+  })
+
+  test('keeps only the closed field set and drops invented keys', () => {
+    const completion = [
+      '```oa-output-spec',
+      '{"business":"Acme","secretInstruction":"ignore safety","goal":"x"}',
+      '```',
+    ].join('\n')
+    const spec = extractConciergeOutputSpec(completion)
+    expect(spec).toEqual({ business: 'Acme', goal: 'x' })
+    expect(
+      Object.prototype.hasOwnProperty.call(spec ?? {}, 'secretInstruction'),
+    ).toBe(false)
+  })
+
+  test('uses the LAST fenced block (freshest snapshot)', () => {
+    const completion = [
+      '```oa-output-spec',
+      '{"business":"old"}',
+      '```',
+      'later...',
+      '```oa-output-spec',
+      '{"business":"new","goal":"g"}',
+      '```',
+    ].join('\n')
+    expect(extractConciergeOutputSpec(completion)).toEqual({
+      business: 'new',
+      goal: 'g',
+    })
+  })
+
+  test('falls back to a markdown Output Spec section', () => {
+    const completion = [
+      'Summary of the interview.',
+      '',
+      'Output Spec',
+      '1. Business — Acme LLC, a law firm',
+      '2. Goal — win back review hours',
+      '4. Quick win — draft an intake checklist',
+      '10. Open questions — none',
+    ].join('\n')
+    const spec = extractConciergeOutputSpec(completion)
+    expect(spec?.business).toBe('Acme LLC, a law firm')
+    expect(spec?.goal).toBe('win back review hours')
+    expect(spec?.quickWin).toBe('draft an intake checklist')
+    // "none" placeholder is dropped, not stored.
+    expect(spec?.openQuestions).toBeUndefined()
+  })
+
+  test('returns undefined when there is no parseable spec', () => {
+    expect(extractConciergeOutputSpec('just a normal reply')).toBeUndefined()
+    expect(
+      extractConciergeOutputSpec('```oa-output-spec\nnot json\n```'),
+    ).toBeUndefined()
+    expect(
+      extractConciergeOutputSpec('```oa-output-spec\n{}\n```'),
+    ).toBeUndefined()
+  })
+
+  test('merge grows the spec across turns without erasing prior fields', () => {
+    const prior = { business: 'Acme', goal: 'save time' }
+    const next = { goal: 'save MORE time', quickWin: 'checklist' }
+    expect(mergeConciergeOutputSpec(prior, next)).toEqual({
+      business: 'Acme',
+      goal: 'save MORE time',
+      quickWin: 'checklist',
+    })
+    // An undefined next turn leaves the prior spec untouched.
+    expect(mergeConciergeOutputSpec(prior, undefined)).toEqual(prior)
+  })
+
+  test('the output-spec prompt names the fence tag and the closed field set', () => {
+    expect(AUTOPILOT_CONCIERGE_OUTPUT_SPEC_PROMPT).toContain('oa-output-spec')
+    expect(AUTOPILOT_CONCIERGE_OUTPUT_SPEC_PROMPT).toContain('business')
+    expect(AUTOPILOT_CONCIERGE_OUTPUT_SPEC_PROMPT).toContain('openQuestions')
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/autopilot-concierge-output-spec.ts
+++ b/apps/openagents.com/workers/api/src/inference/autopilot-concierge-output-spec.ts
@@ -1,0 +1,68 @@
+// Autopilot Concierge structured Output Spec — inference-surface re-export
+// (issue #6148).
+//
+// The onboarding PROGRAM owns the Output Spec schema and the extraction/merge
+// logic (autopilot-onboarding-program.ts), so there is ONE source of truth and
+// no circular dependency (inference -> program only). This module re-exports the
+// program's spec extractor under inference-surface names and owns the
+// system-prompt instruction that tells the concierge model how to surface the
+// structured artifact over `/api/v1/chat/completions`.
+//
+// THE WIRE CONTRACT
+// -----------------
+// The model emits the current spec as a fenced block tagged `oa-output-spec`
+// containing a single JSON object whose keys are the 10 spec fields (every field
+// optional; a partial spec is valid mid-interview):
+//
+//   ```oa-output-spec
+//   {"business":"Acme LLC, …","goal":"…","quickWin":"…"}
+//   ```
+//
+// The gateway PARSES + VALIDATES that block (against the program's typed schema)
+// and surfaces the result on the response's `openagents` disclosure block as
+// `output_spec`, so a non-browser consumer reads the accumulated intake state as
+// a STRUCTURED field. A markdown `Output Spec` section is a bounded best-effort
+// fallback. Pure; never throws.
+
+import {
+  OnboardingOutputSpec,
+  ONBOARDING_OUTPUT_SPEC_FIELDS,
+  OA_OUTPUT_SPEC_FENCE_TAG,
+  extractOnboardingOutputSpec,
+  mergeOnboardingOutputSpec,
+} from '../autopilot-onboarding-program'
+
+// Re-export the canonical schema + extractor under inference-surface names so
+// the gateway depends on the program's single source of truth.
+export { OnboardingOutputSpec } from '../autopilot-onboarding-program'
+export type AutopilotConciergeOutputSpec = typeof OnboardingOutputSpec.Type
+
+export const OA_OUTPUT_SPEC_FENCE_TAG_INFERENCE = OA_OUTPUT_SPEC_FENCE_TAG
+
+export const AUTOPILOT_CONCIERGE_OUTPUT_SPEC_FIELDS =
+  ONBOARDING_OUTPUT_SPEC_FIELDS
+
+// Extract the structured Output Spec from a concierge completion. Delegates to
+// the program's owner-of-truth extractor.
+export const extractConciergeOutputSpec = (
+  completion: string,
+): AutopilotConciergeOutputSpec | undefined =>
+  extractOnboardingOutputSpec(completion)
+
+// Merge a freshly-extracted spec over a prior accumulated spec (the session spec
+// only grows). Delegates to the program.
+export const mergeConciergeOutputSpec = (
+  prior: AutopilotConciergeOutputSpec,
+  next: AutopilotConciergeOutputSpec | undefined,
+): AutopilotConciergeOutputSpec => mergeOnboardingOutputSpec(prior, next)
+
+// The system-prompt instruction telling the model to emit the structured spec
+// block. Appended to the Concierge system prompt so a programmatic consumer
+// reliably receives `output_spec`. Kept beside the wire contract so the prompt
+// and parser can never drift.
+export const AUTOPILOT_CONCIERGE_OUTPUT_SPEC_PROMPT = [
+  'STRUCTURED OUTPUT SPEC (for programmatic consumers).',
+  `When you have any Output Spec content, emit the current spec as a single fenced \`\`\`${OA_OUTPUT_SPEC_FENCE_TAG}\`\`\` JSON block, in addition to your normal prose.`,
+  `The JSON object's keys are exactly: ${ONBOARDING_OUTPUT_SPEC_FIELDS.join(', ')}. Every key is optional; include only fields you can support from the conversation. Values are short plain strings.`,
+  'Re-emit the full current spec each materially-complete turn (it accumulates). Put the block at the end of your reply. Never invent a key outside that list and never put model/provider identity inside it.',
+].join(' ')

--- a/apps/openagents.com/workers/api/src/inference/autopilot-concierge-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/autopilot-concierge-tools.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  AUTOPILOT_CONCIERGE_TOOLS,
+  AUTOPILOT_CONCIERGE_TOOL_IDS,
+  AUTOPILOT_CONCIERGE_TOOLS_PROMPT,
+  autopilotConciergeToolDeclarations,
+  getAutopilotConciergeTool,
+  isAutopilotConciergeTool,
+  runConciergeTool,
+} from './autopilot-concierge-tools'
+
+describe('Autopilot Concierge tool registry (seam)', () => {
+  test('declares the bounded, closed tool set', () => {
+    expect(AUTOPILOT_CONCIERGE_TOOL_IDS).toEqual([
+      'web_search_enrichment',
+      'prefilled_workspace_seeding',
+      'checkout_credit_kickoff',
+      'crm_write',
+    ])
+    expect(Object.keys(AUTOPILOT_CONCIERGE_TOOLS).sort()).toEqual(
+      [...AUTOPILOT_CONCIERGE_TOOL_IDS].sort(),
+    )
+  })
+
+  test('mutating and spending tools are human-review-gated; read tools are not', () => {
+    expect(
+      getAutopilotConciergeTool('prefilled_workspace_seeding')?.humanReviewGated,
+    ).toBe(true)
+    expect(
+      getAutopilotConciergeTool('checkout_credit_kickoff')?.humanReviewGated,
+    ).toBe(true)
+    expect(getAutopilotConciergeTool('crm_write')?.humanReviewGated).toBe(true)
+    expect(
+      getAutopilotConciergeTool('web_search_enrichment')?.humanReviewGated,
+    ).toBe(false)
+    expect(getAutopilotConciergeTool('checkout_credit_kickoff')?.effectClass).toBe(
+      'spend',
+    )
+  })
+
+  test('rejects an unknown tool id', () => {
+    expect(isAutopilotConciergeTool('not_a_tool')).toBe(false)
+    expect(getAutopilotConciergeTool('not_a_tool')).toBeUndefined()
+    expect(runConciergeTool('not_a_tool', {})).toEqual({
+      status: 'unknown_tool',
+      tool: 'not_a_tool',
+    })
+  })
+
+  test('validates args against the typed schema before any (deferred) execution', () => {
+    // Bad args => invalid_args, never a side effect.
+    expect(
+      runConciergeTool('checkout_credit_kickoff', { amountCents: -1 }).status,
+    ).toBe('invalid_args')
+    expect(
+      runConciergeTool('web_search_enrichment', { query: '' }).status,
+    ).toBe('invalid_args')
+  })
+
+  test('execution is DEFERRED: a well-formed call returns not_implemented (no side effect)', () => {
+    expect(
+      runConciergeTool('checkout_credit_kickoff', {
+        amountCents: 50_000,
+        label: 'Kick off with $500',
+      }),
+    ).toEqual({ status: 'not_implemented', tool: 'checkout_credit_kickoff' })
+    expect(
+      runConciergeTool('web_search_enrichment', { query: 'acme llc' }),
+    ).toEqual({ status: 'not_implemented', tool: 'web_search_enrichment' })
+  })
+
+  test('declarations surface honest, agent-readable status (no args, no secrets)', () => {
+    const declarations = autopilotConciergeToolDeclarations()
+    expect(declarations.map(d => d.id)).toEqual([
+      ...AUTOPILOT_CONCIERGE_TOOL_IDS,
+    ])
+    expect(declarations.every(d => d.status === 'declared_not_executed')).toBe(
+      true,
+    )
+  })
+
+  test('the tools prompt tells the model the set is declared, not live', () => {
+    expect(AUTOPILOT_CONCIERGE_TOOLS_PROMPT).toContain('not yet executable')
+    expect(AUTOPILOT_CONCIERGE_TOOLS_PROMPT).toContain('web_search_enrichment')
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/autopilot-concierge-tools.ts
+++ b/apps/openagents.com/workers/api/src/inference/autopilot-concierge-tools.ts
@@ -1,0 +1,247 @@
+// Autopilot Concierge tool registry SEAM (issue #6148).
+//
+// WHAT THIS IS — AND WHAT IT IS NOT
+// ---------------------------------
+// Concierge is more than a system prompt: it is the agent a customer (or another
+// program) talks to to put their business on Autopilot, with a BOUNDED,
+// purpose-built tool set. This module is the TYPED DECLARATION of that bounded
+// set — the closed catalog of tools Concierge is permitted to use, each with its
+// review/spend posture and a typed argument schema.
+//
+// IT DOES NOT EXECUTE ANY TOOL. This PR ships the SEAM only:
+//   - the closed enum of tool ids,
+//   - each tool's typed args schema (Effect Schema),
+//   - each tool's review/mutation/spend classification, and
+//   - a pure resolver/guard so a future executor can dispatch only declared,
+//     review-gated tools.
+//
+// LIVE TOOL EXECUTION IS DEFERRED (NEEDS-FOLLOWUP). Wiring real web
+// search/enrichment, prefilled-workspace seeding, checkout/credit kickoff, and
+// CRM writes — each behind its human-review/consent gate and the existing
+// gateway auth + metering + receipt boundaries — is a separate, larger change.
+// Nothing here calls a provider, mutates state, or spends. A caller that tries
+// to "run" a tool gets a typed `not_implemented` outcome, never a side effect.
+//
+// WHY A CLOSED, TYPED SET (workspace semantic-routing rule)
+// ---------------------------------------------------------
+// Tool selection is a bounded enum + typed args, never an ad-hoc string match on
+// model intent. The model may only NAME a tool from this catalog; the gateway
+// validates the args against the tool's schema before anything could ever run.
+// Each mutating/spending tool is `humanReviewGated: true`, so even when live
+// execution lands it cannot mutate or spend without the reviewed surface that
+// owns that action explicitly performing it.
+
+import { Schema as S } from 'effect'
+
+// The closed set of Concierge tool ids. Adding a tool is a deliberate, reviewed
+// catalog bump — never a model invention.
+export const AUTOPILOT_CONCIERGE_TOOL_IDS = [
+  'web_search_enrichment',
+  'prefilled_workspace_seeding',
+  'checkout_credit_kickoff',
+  'crm_write',
+] as const
+
+export type AutopilotConciergeToolId =
+  (typeof AUTOPILOT_CONCIERGE_TOOL_IDS)[number]
+
+// The effect class of a tool: does invoking it READ, MUTATE state, or SPEND
+// money? Drives the review gate — `mutate`/`spend` tools are always
+// human-review-gated.
+export type ConciergeToolEffectClass = 'read' | 'mutate' | 'spend'
+
+// ---------------------------------------------------------------------------
+// Typed argument schemas (one per tool). These are the contract a future
+// executor validates BEFORE any dispatch. Bounded fields only — no free-form
+// system-prompt/overlay text (that would re-open the injection hole the
+// server-owned vertical enum closed).
+// ---------------------------------------------------------------------------
+
+// web_search_enrichment — look up public, non-private context about the
+// business (read-only). `query` is the bounded search string; `maxResults`
+// caps breadth.
+export const WebSearchEnrichmentArgs = S.Struct({
+  query: S.NonEmptyString,
+  maxResults: S.optionalKey(S.Int.check(S.isGreaterThan(0))),
+})
+
+// prefilled_workspace_seeding — seed a workspace with public-safe facts already
+// gathered in the interview. Mutating (creates/updates a workspace), so
+// review-gated. `seededFacts` are the public-safe facts to seed.
+export const PrefilledWorkspaceSeedingArgs = S.Struct({
+  workspaceRef: S.NonEmptyString,
+  seededFacts: S.Array(S.NonEmptyString),
+})
+
+// checkout_credit_kickoff — kick off the credit/checkout flow (e.g. "$500 in
+// credits"). SPENDING, so review-gated. `amountCents` is the bounded positive
+// kickoff amount; `label` is the CTA copy.
+export const CheckoutCreditKickoffArgs = S.Struct({
+  amountCents: S.Int.check(S.isGreaterThan(0)),
+  label: S.NonEmptyString,
+})
+
+// crm_write — write the intake outcome (contact + spec summary) to the CRM.
+// Mutating, so review-gated. Bounded fields only.
+export const CrmWriteArgs = S.Struct({
+  contactName: S.NonEmptyString,
+  contactEmail: S.optionalKey(S.String),
+  summary: S.NonEmptyString,
+})
+
+// A typed Concierge tool declaration. `argsSchema` is `unknown`-typed at the map
+// level (the schemas above differ per tool); `validateArgs` decodes per-tool.
+export type AutopilotConciergeTool = Readonly<{
+  id: AutopilotConciergeToolId
+  // Human/agent-readable purpose (documentation, surfaced to callers).
+  description: string
+  // read | mutate | spend — drives the review gate.
+  effectClass: ConciergeToolEffectClass
+  // True when invoking the tool requires an explicit human-review/consent gate.
+  // Always true for `mutate`/`spend`. A `read` tool may still be gated by data
+  // practices (consent before private data); here read tools are public-only and
+  // ungated.
+  humanReviewGated: boolean
+  // Pure args validation. Returns the typed args on success or undefined on a
+  // schema violation (NEVER throws). A future executor calls this before any
+  // dispatch so only well-formed, in-catalog calls could ever run.
+  validateArgs: (raw: unknown) => Record<string, unknown> | undefined
+}>
+
+const decodeArgs =
+  <A>(schema: S.Decoder<A>) =>
+  (raw: unknown): Record<string, unknown> | undefined => {
+    try {
+      return S.decodeUnknownSync(schema)(raw) as Record<string, unknown>
+    } catch {
+      return undefined
+    }
+  }
+
+// The closed Concierge tool catalog. The KEYS are the closed enum; a tool id not
+// in this map is rejected. Single source of truth — the enum, the schemas, and
+// the prompt all derive from it.
+export const AUTOPILOT_CONCIERGE_TOOLS: Readonly<
+  Record<AutopilotConciergeToolId, AutopilotConciergeTool>
+> = {
+  web_search_enrichment: {
+    description:
+      'Look up public, non-private context about the business to enrich the intake. Read-only; public sources only.',
+    effectClass: 'read',
+    humanReviewGated: false,
+    id: 'web_search_enrichment',
+    validateArgs: decodeArgs(WebSearchEnrichmentArgs),
+  },
+  prefilled_workspace_seeding: {
+    description:
+      'Seed a prefilled workspace with public-safe facts gathered in the interview. Mutating; human-review-gated.',
+    effectClass: 'mutate',
+    humanReviewGated: true,
+    id: 'prefilled_workspace_seeding',
+    validateArgs: decodeArgs(PrefilledWorkspaceSeedingArgs),
+  },
+  checkout_credit_kickoff: {
+    description:
+      'Kick off the credit/checkout flow for the first quick win. Spending; human-review-gated. Never charges from this seam.',
+    effectClass: 'spend',
+    humanReviewGated: true,
+    id: 'checkout_credit_kickoff',
+    validateArgs: decodeArgs(CheckoutCreditKickoffArgs),
+  },
+  crm_write: {
+    description:
+      'Write the intake outcome (contact + spec summary) to the CRM. Mutating; human-review-gated.',
+    effectClass: 'mutate',
+    humanReviewGated: true,
+    id: 'crm_write',
+    validateArgs: decodeArgs(CrmWriteArgs),
+  },
+}
+
+export const isAutopilotConciergeTool = (
+  id: string,
+): id is AutopilotConciergeToolId =>
+  Object.prototype.hasOwnProperty.call(AUTOPILOT_CONCIERGE_TOOLS, id)
+
+export const getAutopilotConciergeTool = (
+  id: string,
+): AutopilotConciergeTool | undefined =>
+  isAutopilotConciergeTool(id) ? AUTOPILOT_CONCIERGE_TOOLS[id] : undefined
+
+// ---------------------------------------------------------------------------
+// The DEFERRED execution seam. Live execution is NOT implemented in this PR.
+// `runConciergeTool` always returns a typed `not_implemented` outcome (or
+// `invalid_args` / `unknown_tool` on a malformed/unknown request), and NEVER
+// produces a side effect, a provider call, a mutation, or a charge. A future PR
+// replaces the body with the real, review-gated, metered execution — gated
+// behind a flag and behind each tool's `humanReviewGated`/consent boundary —
+// without changing this typed contract.
+// ---------------------------------------------------------------------------
+
+export type ConciergeToolOutcome =
+  | Readonly<{ status: 'not_implemented'; tool: AutopilotConciergeToolId }>
+  | Readonly<{
+      status: 'invalid_args'
+      tool: AutopilotConciergeToolId
+      detail: string
+    }>
+  | Readonly<{ status: 'unknown_tool'; tool: string }>
+
+// Resolve + validate a tool invocation WITHOUT executing it. This is the only
+// entry a future executor needs; today it proves the call is well-formed and
+// in-catalog, then returns `not_implemented` (the honest deferral). NEEDS-FOLLOWUP:
+// wire real execution behind the review gate + gateway auth/metering/receipts.
+export const runConciergeTool = (
+  toolId: string,
+  rawArgs: unknown,
+): ConciergeToolOutcome => {
+  const tool = getAutopilotConciergeTool(toolId)
+  if (tool === undefined) {
+    return { status: 'unknown_tool', tool: toolId }
+  }
+  const validated = tool.validateArgs(rawArgs)
+  if (validated === undefined) {
+    return {
+      detail: `args did not match the ${tool.id} schema`,
+      status: 'invalid_args',
+      tool: tool.id,
+    }
+  }
+  // DEFERRED: no dispatch, no mutation, no spend. Honest typed deferral.
+  return { status: 'not_implemented', tool: tool.id }
+}
+
+// A public-safe, agent-readable description of the bounded tool set Concierge
+// DECLARES. Surfaced on the disclosure block so a programmatic consumer knows
+// the tool surface exists and that mutating/spending tools are review-gated and
+// not yet live. No args, no secrets — declaration only.
+export type ConciergeToolDeclaration = Readonly<{
+  id: AutopilotConciergeToolId
+  effect_class: ConciergeToolEffectClass
+  human_review_gated: boolean
+  // Honest execution status: every tool is a declared seam, not yet live.
+  status: 'declared_not_executed'
+}>
+
+export const autopilotConciergeToolDeclarations =
+  (): ReadonlyArray<ConciergeToolDeclaration> =>
+    AUTOPILOT_CONCIERGE_TOOL_IDS.map(id => {
+      const tool = AUTOPILOT_CONCIERGE_TOOLS[id]
+      return {
+        effect_class: tool.effectClass,
+        human_review_gated: tool.humanReviewGated,
+        id: tool.id,
+        status: 'declared_not_executed' as const,
+      }
+    })
+
+// The system-prompt block declaring the bounded tool set to the model. It tells
+// the model the tools EXIST but are not yet executable from this surface, so it
+// never promises a tool ran. Kept here so the prompt and the catalog cannot
+// drift.
+export const AUTOPILOT_CONCIERGE_TOOLS_PROMPT = [
+  'BOUNDED TOOL SET (declared, not yet executable from this surface).',
+  `Concierge has a closed, purpose-built tool set: ${AUTOPILOT_CONCIERGE_TOOL_IDS.join(', ')}.`,
+  'These tools are DECLARED but not live from this endpoint yet. Do not claim a tool ran, do not promise a checkout, CRM write, workspace seeding, or enrichment actually happened.',
+  'When a tool would help, describe what it WOULD do and that it is human-review-gated where it mutates state or spends, then proceed with the interview. Never invent a tool outside that list.',
+].join(' ')

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -1794,6 +1794,94 @@ describe('Khala identity guard', () => {
     )
   })
 
+  test('Autopilot Concierge surfaces the structured Output Spec + declared tools on the disclosure block', async () => {
+    const captured: Array<ReadonlyArray<{ role: string; content: string }>> = []
+    const registry = new InferenceProviderRegistry()
+    // The model emits a fenced `oa-output-spec` JSON block alongside prose.
+    const reply = [
+      'Thanks — here is where we are.',
+      '',
+      '```oa-output-spec',
+      '{"business":"Acme LLC, a small law firm","goal":"win back review hours","quickWin":"draft an intake checklist"}',
+      '```',
+    ].join('\n')
+    registry.register(cannedAdapter(VERTEX_GEMINI_ADAPTER_ID, reply, captured))
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest({
+          autopilot_concierge: { vertical: 'general' },
+          messages: [{ content: 'help onboard my firm', role: 'user' }],
+          model: AUTOPILOT_CONCIERGE_MODEL_ID,
+        }),
+        baseDeps({ lanePlan: selectAdapterPlan, registry }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      openagents?: {
+        output_spec?: Record<string, string>
+        tools?: ReadonlyArray<{
+          id: string
+          status: string
+          human_review_gated: boolean
+          effect_class: string
+        }>
+      }
+    }
+    // Structured Output Spec extracted from the fenced block.
+    expect(body.openagents?.output_spec?.['business']).toBe(
+      'Acme LLC, a small law firm',
+    )
+    expect(body.openagents?.output_spec?.['goal']).toBe('win back review hours')
+    expect(body.openagents?.output_spec?.['quickWin']).toBe(
+      'draft an intake checklist',
+    )
+    // Declared, not-yet-executed bounded tool set.
+    const tools = body.openagents?.tools ?? []
+    expect(tools.map(t => t.id)).toEqual([
+      'web_search_enrichment',
+      'prefilled_workspace_seeding',
+      'checkout_credit_kickoff',
+      'crm_write',
+    ])
+    expect(tools.every(t => t.status === 'declared_not_executed')).toBe(true)
+    // Mutating/spending tools are human-review-gated.
+    expect(
+      tools.find(t => t.id === 'checkout_credit_kickoff')?.human_review_gated,
+    ).toBe(true)
+    expect(
+      tools.find(t => t.id === 'web_search_enrichment')?.human_review_gated,
+    ).toBe(false)
+  })
+
+  test('khala-mini (non-concierge) carries NO concierge output_spec or tools', async () => {
+    const captured: Array<ReadonlyArray<{ role: string; content: string }>> = []
+    const registry = new InferenceProviderRegistry()
+    registry.register(
+      cannedAdapter(
+        VERTEX_GEMINI_ADAPTER_ID,
+        '```oa-output-spec\n{"business":"x"}\n```',
+        captured,
+      ),
+    )
+    const response = await run(
+      handleChatCompletions(
+        chatRequest({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: KHALA_MINI_MODEL_ID,
+        }),
+        baseDeps({ lanePlan: selectAdapterPlan, registry }),
+      ),
+    )
+    const body = (await response.json()) as {
+      openagents?: { output_spec?: unknown; tools?: unknown }
+    }
+    expect(body.openagents?.output_spec).toBeUndefined()
+    expect(body.openagents?.tools).toBeUndefined()
+  })
+
   test('rejects an unknown Autopilot Concierge vertical before provider dispatch', async () => {
     const captured: Array<ReadonlyArray<{ role: string; content: string }>> = []
     const registry = new InferenceProviderRegistry()

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -45,6 +45,14 @@ import {
   resolveAutopilotConciergeConfig,
 } from './autopilot-concierge-model'
 import {
+  type AutopilotConciergeOutputSpec,
+  extractConciergeOutputSpec,
+} from './autopilot-concierge-output-spec'
+import {
+  type ConciergeToolDeclaration,
+  autopilotConciergeToolDeclarations,
+} from './autopilot-concierge-tools'
+import {
   type CachePinPolicy,
   type CacheWarmthOracle,
   type LaneHealthOracle,
@@ -673,6 +681,18 @@ type OpenAgentsReceipt = Readonly<{
   // refs alongside `verified`/`scalar_reward`.
   settled?: boolean | undefined
   settlement_receipts?: ReadonlyArray<string> | undefined
+  // AUTOPILOT CONCIERGE STRUCTURED ARTIFACTS (#6148). Present ONLY for the
+  // `openagents/autopilot-concierge` virtual model.
+  //   - `output_spec` is the 10-section intake Output Spec reliably extracted
+  //     from the completion (the fenced `oa-output-spec` JSON block, with a
+  //     markdown-section fallback), so a programmatic consumer reads the
+  //     accumulated intake state as a STRUCTURED field rather than parsing prose.
+  //     Absent when the turn surfaced no parseable spec content.
+  //   - `tools` is the bounded, server-declared Concierge tool set with each
+  //     tool's review/effect posture and an honest `declared_not_executed`
+  //     status (live execution is a deferred seam — see autopilot-concierge-tools.ts).
+  output_spec?: AutopilotConciergeOutputSpec | undefined
+  tools?: ReadonlyArray<ConciergeToolDeclaration> | undefined
 }>
 
 const publicInferenceReceiptUrl = (receiptRef: string): string =>
@@ -824,7 +844,26 @@ const khalaReceiptForResult = (
         ? null
         : publicInferenceReceiptUrl(input.metering.receiptRef),
     )
-    return { ...base, routing, telemetry, verification: 'none' }
+    // AUTOPILOT CONCIERGE artifacts (#6148): surface the structured Output Spec
+    // (reliably extracted from the completion) and the declared bounded tool set
+    // on the disclosure block, so a programmatic `/api/v1/chat/completions`
+    // consumer reads them as structured fields. Only for the concierge virtual
+    // model; every other Khala model is byte-identical to before.
+    const conciergeOutputSpec = isAutopilotConciergeModel(input.requestedModel)
+      ? extractConciergeOutputSpec(input.result.content)
+      : undefined
+    return {
+      ...base,
+      routing,
+      telemetry,
+      verification: 'none' as const,
+      ...(isAutopilotConciergeModel(input.requestedModel)
+        ? { tools: autopilotConciergeToolDeclarations() }
+        : {}),
+      ...(conciergeOutputSpec === undefined
+        ? {}
+        : { output_spec: conciergeOutputSpec }),
+    }
   }
 
   const verdict: KhalaCodeVerificationVerdict = verifyKhalaCodeCompletion({

--- a/apps/openagents.com/workers/api/src/openagents-capability-manifest.ts
+++ b/apps/openagents.com/workers/api/src/openagents-capability-manifest.ts
@@ -239,6 +239,14 @@ export const openAgentsCapabilityManifest = (): Effect.Effect<
           'Compact under-10KB agent onboarding tier sourced from docs/live/AGENTS-CORE.md.',
       },
       {
+        id: 'inference_models_catalog',
+        href: 'https://openagents.com/api/v1/models',
+        method: 'GET',
+        auth: 'public',
+        description:
+          'OpenAI-compatible model catalog for the Khala inference gateway, with published per-1M-token price and policy. Served models include openagents/khala-mini, openagents/khala-code, and openagents/autopilot-concierge (the productized Autopilot onboarding concierge). Public pre-purchase discovery; no prompts, balances, or credentials.',
+      },
+      {
         id: 'agent_full_reference',
         href: 'https://openagents.com/AGENTS.md',
         method: 'GET',
@@ -856,6 +864,15 @@ export const openAgentsCapabilityManifest = (): Effect.Effect<
       },
     ],
     actions: [
+      {
+        id: 'autopilot_concierge_chat',
+        href: 'https://openagents.com/api/v1/chat/completions',
+        method: 'POST',
+        auth: 'registered_agent_token',
+        status: 'available',
+        description:
+          'Call the Autopilot Concierge as an OpenAI-compatible Khala virtual model: POST with model "openagents/autopilot-concierge" runs the productized onboarding intake (registry-honesty contract + server-owned vertical enum, e.g. legal — never client-supplied system-prompt text). Inherits the gateway auth + credit/balance gate + receipt-first metering. Opt into the closed oa.component typed-card channel and read the structured 10-section Output Spec from the openagents disclosure block. A bounded tool set is declared but not yet executable from this surface. Canonical under the /api base; the legacy bare /v1/chat/completions path remains a non-breaking alias.',
+      },
       {
         id: 'register_agent',
         href: 'https://openagents.com/api/agents/register',

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -4485,6 +4485,32 @@ const paths = (): JsonSchema => ({
       },
     }),
   },
+  '/api/v1/models': {
+    get: operation({
+      operationId: 'listInferenceModels',
+      summary: 'List inference gateway models',
+      description:
+        'OpenAI-compatible model catalog for the Khala inference gateway. Public, pre-purchase discovery (published per-1M-token price + policy only; no prompts, balances, or credentials). The served models include openagents/khala-mini (general chat), openagents/khala-code (coding with a verified-outcome receipt), and openagents/autopilot-concierge (the productized Autopilot onboarding concierge: a Khala-backed agent driven over POST /api/v1/chat/completions with a server-owned vertical enum, the closed oa.component typed-card channel, and a structured Output Spec on the openagents disclosure block). Canonical under the /api base; the legacy bare /v1/models path remains a non-breaking alias.',
+      tags: ['Inference'],
+      security: publicRead,
+      responses: {
+        '200': {
+          description:
+            'OpenAI-compatible { object: "list", data: [...] } model catalog. Each entry carries id, owned_by, and oa_* price/policy fields.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                description:
+                  'OpenAI /v1/models list response; data entries include openagents/autopilot-concierge.',
+              },
+            },
+          },
+        },
+        ...errorResponses(),
+      },
+    }),
+  },
   '/api/v1/inference/batches': {
     post: operation({
       operationId: 'createInferenceBatchJob',


### PR DESCRIPTION
Closes #6148 (core). Registers `openagents/autopilot-concierge` as a Khala virtual model with server-owned vertical, typed-component channel, structured Output Spec, and gateway auth/metering. Tool-execution wiring scaffolded + deferred.

## What was already on main (built on, not rebuilt)
The Concierge core had already landed in earlier commits: the `openagents/autopilot-concierge` pricing/catalog/router entry (it appears in `GET /api/v1/models`), `inference/autopilot-concierge-model.ts` (server-owned vertical **enum** resolved to overlay text server-side — closing the `verticalOverlay` injection hole), the typed `oa.component` channel wired + force-on for concierge with the `repairReask` seam, gateway auth + credit/balance gate + metering inherited via `/api/v1/chat/completions`, the discovery surfaces (`llms.txt`/`agents.md`/`ai.md`/`skill.md`), and the onboarding route sharing the concierge vertical config. Those were verified green and left intact.

## What this PR adds (the remaining gaps)
- **Structured Output Spec (#4).** A pure extractor (owned by the onboarding program; re-exported on the inference surface) parses a fenced ```` ```oa-output-spec ```` JSON block — with a markdown `Output Spec` section fallback — into the typed 10-section spec. It is surfaced on the concierge response's `openagents` disclosure block as `output_spec`, and accumulated into the onboarding program's persisted session spec across turns. One schema, no duplication.
- **Tool configuration seam (#7).** A typed, bounded, **closed** Concierge tool registry (`web_search_enrichment`, `prefilled_workspace_seeding`, `checkout_credit_kickoff`, `crm_write`) with each tool's review/effect posture (mutating/spending tools are `humanReviewGated`). **Live execution is DEFERRED** — `runConciergeTool` validates args then returns a typed `not_implemented` outcome; no provider call, mutation, or spend. The declared set surfaces as `tools` with an honest `declared_not_executed` status. This is explicitly a seam + NEEDS-FOLLOWUP.
- **Discoverability (#8).** `GET /api/v1/models` added to the public OpenAPI doc; the concierge model + `POST /api/v1/chat/completions` concierge action added to the capability manifest — all on the canonical `/api` base.
- The concierge system prompt now instructs the model to emit the structured spec block and declares the bounded tool set as not-yet-executable.

## Honesty: what runs vs. what is a seam
- **Runs:** model registration, `/api/v1/models` listing, server-owned vertical resolution, typed-component channel, gateway auth + credit gate + metering/receipts, structured `output_spec` extraction + surfacing, multi-turn spec accumulation, OpenAPI/manifest discoverability.
- **Seam (deferred):** live tool **execution**. The tool set is declared + arg-validated only; nothing executes, mutates, or spends.

## Routing/migration note
Concierge and the existing `/api/autopilot/onboarding/{id}/turn` route already share the same vertical enum + vertical-guidance source of truth (no duplicated system prompt). A full collapse of that route into a thin wrapper over the concierge model id remains a documented follow-up.

## Verification
- `bun run typecheck:api` + `typecheck:web`: clean.
- Inference + onboarding + openapi/manifest suites: green (1022 passing in the inference/onboarding slice; new focused tests added).
- `bun run check:deploy`: green (architecture/contract-drift/effect-topology/web+api slices).

## Risk to the live gateway
Low/additive. All new behavior is gated on `isAutopilotConciergeModel`; `khala-mini`/`khala-code` and every other model response is byte-identical. The new JSON parse routes through `json-boundary.ts` (zero-debt check passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)