### PR TITLE
Streaming: make onboarding genuinely incremental (Vertex Gemini streamSse + onboarding client swap)

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -395,9 +395,9 @@ import {
   InferenceAdapterError,
   type InferenceRequest,
   type InferenceResult,
-  type InferenceStreamChunk,
   InferenceProviderRegistry,
 } from './inference/provider-adapter'
+import { dispatchOnboardingStreamSource } from './inference/onboarding-stream-source'
 import { makeAdmittedOpenAgentsNetworkAdapter } from './inference/openagents-network-adapter'
 import {
   makePylonFabricHttpTransport,
@@ -8618,13 +8618,22 @@ const makeOnboardingInferenceClient = (
     )
 }
 
-// STREAMING onboarding client (issue #6123 UI follow-up). The same provider-
-// adapter registry + overflow dispatch as the buffered client, but it dispatches
-// the adapter's chunked `stream` and exposes the chunks as an
-// `OnboardingStreamSource` (a deltas async-iterable + a `final()` accumulation).
-// The interview reply is short, so the buffered-chunk path is the right reuse:
-// every adapter implements `stream` (the optional `streamSse` is for the long-
-// generation hot path), and the route pumps the chunks to the client as SSE.
+// STREAMING onboarding client (issue #6123 UI follow-up; #6154 incremental).
+// The same provider-adapter registry + overflow dispatch as the buffered client,
+// but it prefers the adapter's TRUE incremental `streamSse` so the onboarding
+// reply streams token-by-token — one `event: delta` per upstream Gemini fragment
+// — instead of one buffered reply materialized server-side. Adapters without a
+// `streamSse` (stub/echo, simple test adapters) fall back to the buffered chunk
+// `stream`. Overflow happens at source-open time exactly like the `/v1` gateway:
+// the dispatched Effect resolves once the upstream stream HEAD is accepted (a
+// non-2xx surfaces as a retryable adapter error BEFORE any frame is consumed), so
+// a failing lane overflows to the next without buffering the body.
+//
+// The source's `final()` returns '' (no content re-buffering): the route already
+// accumulates the deltas it emits and persists that accumulation, so the lazy
+// frames stay the single source of truth (receipt-first, matching the gateway).
+// The dispatch operation + source shaping live in `onboarding-stream-source.ts`
+// so the prefer-streamSse / fall-back-to-stream behavior is unit-testable.
 const makeOnboardingStreamClient = (
   env: OnboardingInferenceEnv,
 ): OnboardingStreamClient => {
@@ -8632,24 +8641,11 @@ const makeOnboardingStreamClient = (
   registerFabricServeAdapter(inferenceProviderRegistry, env)
   setInferenceAdapterEnv(env)
   return (request: InferenceRequest) =>
-    dispatchWithOverflow<ReadonlyArray<InferenceStreamChunk>>(
+    dispatchWithOverflow<OnboardingStreamSource>(
       request,
-      (adapter, req) => adapter.stream(req),
+      dispatchOnboardingStreamSource,
       { plan: selectAdapterPlan, registry: inferenceProviderRegistry },
     ).pipe(
-      Effect.map((chunks): OnboardingStreamSource => {
-        const reply = chunks.map(chunk => chunk.contentDelta).join('')
-        return {
-          deltas: (async function* () {
-            for (const chunk of chunks) {
-              if (chunk.contentDelta !== '') {
-                yield chunk.contentDelta
-              }
-            }
-          })(),
-          final: () => reply,
-        }
-      }),
       Effect.mapError(
         error => new OnboardingInferenceError({ reason: error.reason }),
       ),

--- a/apps/openagents.com/workers/api/src/inference/onboarding-stream-source.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/onboarding-stream-source.test.ts
@@ -1,0 +1,125 @@
+// Onboarding incremental-stream wiring (issue #6154).
+//
+// Proves the two properties the buffered fake-stream violated:
+//   1. PREFER streamSse. A mock adapter with `streamSse` yielding MANY frames
+//      produces MANY onboarding `deltas` (token-by-token), not one buffered
+//      reply. This is the fix: each upstream fragment becomes its own delta.
+//   2. FALLBACK to stream. A mock adapter with NO `streamSse` still works via
+//      the buffered chunk `stream` path (so existing adapters/tests don't
+//      regress).
+
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type InferenceAdapterError,
+  type InferenceProviderAdapter,
+  type InferenceRequest,
+  type InferenceStreamEvent,
+  type InferenceStreamSource,
+} from './provider-adapter'
+import { dispatchOnboardingStreamSource } from './onboarding-stream-source'
+
+const run = <A>(effect: Effect.Effect<A, InferenceAdapterError>): Promise<A> =>
+  Effect.runPromise(effect)
+
+const request: InferenceRequest = {
+  messages: [{ content: 'I run a bakery.', role: 'user' }],
+  model: 'openagents/khala-mini',
+  passthroughParams: {},
+  stream: true,
+}
+
+const drain = async (
+  deltas: AsyncIterable<string>,
+): Promise<Array<string>> => {
+  const collected: Array<string> = []
+  for await (const delta of deltas) {
+    collected.push(delta)
+  }
+  return collected
+}
+
+// A mock adapter whose `streamSse` yields the given content frames plus a
+// terminal usage frame, mirroring the real adapter contract.
+const streamSseAdapter = (
+  contents: ReadonlyArray<string>,
+): InferenceProviderAdapter => ({
+  complete: () => Effect.die('unused'),
+  id: 'mock-stream-sse',
+  stream: () => Effect.die('mock streamSse adapter should not use buffered stream'),
+  streamSse: () =>
+    Effect.sync((): InferenceStreamSource => {
+      const events: Array<InferenceStreamEvent> = [
+        ...contents.map(content => ({ contentDelta: content })),
+        {
+          contentDelta: '',
+          finishReason: 'stop',
+          servedModel: 'gemini-3.5-flash',
+          usage: { completionTokens: 3, promptTokens: 5, totalTokens: 8 },
+        },
+      ]
+      return {
+        frames: (async function* () {
+          for (const event of events) {
+            yield event
+          }
+        })(),
+        terminal: () => ({
+          finishReason: 'stop',
+          servedModel: 'gemini-3.5-flash',
+          usage: { completionTokens: 3, promptTokens: 5, totalTokens: 8 },
+        }),
+      }
+    }),
+})
+
+// A mock adapter with NO `streamSse` — only the buffered chunk `stream`.
+const bufferedOnlyAdapter = (
+  contents: ReadonlyArray<string>,
+): InferenceProviderAdapter => ({
+  complete: () => Effect.die('unused'),
+  id: 'mock-buffered',
+  stream: () =>
+    Effect.succeed([
+      ...contents.map(content => ({ contentDelta: content })),
+      {
+        contentDelta: '',
+        finishReason: 'stop',
+        usage: { completionTokens: 3, promptTokens: 5, totalTokens: 8 },
+      },
+    ]),
+})
+
+describe('dispatchOnboardingStreamSource', () => {
+  test('prefers streamSse: a multi-frame source yields MANY deltas (token-by-token)', async () => {
+    const adapter = streamSseAdapter(['Great', ' — ', 'what', ' next?'])
+    const source = await run(dispatchOnboardingStreamSource(adapter, request))
+
+    const deltas = await drain(source.deltas)
+    // One delta per upstream content frame; the empty terminal frame is skipped.
+    expect(deltas).toEqual(['Great', ' — ', 'what', ' next?'])
+    expect(deltas.length).toBeGreaterThan(1)
+    // final() returns '' on the streamSse path (no content re-buffering); the
+    // route falls back to its own accumulation.
+    expect(source.final()).toBe('')
+  })
+
+  test('falls back to buffered stream when the adapter has no streamSse', async () => {
+    const adapter = bufferedOnlyAdapter(['ok', ' done'])
+    expect(adapter.streamSse).toBeUndefined()
+    const source = await run(dispatchOnboardingStreamSource(adapter, request))
+
+    const deltas = await drain(source.deltas)
+    expect(deltas).toEqual(['ok', ' done'])
+    // The buffered path can cheaply rejoin (content already materialized).
+    expect(source.final()).toBe('ok done')
+  })
+
+  test('skips empty content deltas (terminal usage frame is not a delta)', async () => {
+    const adapter = streamSseAdapter(['only'])
+    const source = await run(dispatchOnboardingStreamSource(adapter, request))
+    const deltas = await drain(source.deltas)
+    expect(deltas).toEqual(['only'])
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/onboarding-stream-source.ts
+++ b/apps/openagents.com/workers/api/src/inference/onboarding-stream-source.ts
@@ -1,0 +1,71 @@
+// Onboarding stream-source shaping (issue #6154). Bridges the provider-adapter
+// streaming seam into the onboarding program's `OnboardingStreamSource`.
+//
+// The onboarding stream client PREFERS the adapter's TRUE incremental `streamSse`
+// so the interview reply streams token-by-token — one `event: delta` per upstream
+// fragment — instead of one buffered reply materialized server-side. Adapters
+// without a `streamSse` (stub/echo, simple test adapters) fall back to the
+// buffered chunk `stream`, which is byte-equivalent but materialized.
+//
+// This mirrors the `/v1` gateway boundary: the dispatched Effect resolves once the
+// upstream stream HEAD is accepted (a non-2xx surfaces as an adapter error BEFORE
+// any frame is consumed), so the overflow dispatcher can fail a lane over without
+// buffering the body. The lazy frames stay the single source of truth — `final()`
+// returns '' for the streamSse path so nothing re-buffers the content (the route
+// accumulates the deltas it emits and persists that accumulation, receipt-first).
+
+import { Effect } from 'effect'
+
+import type { OnboardingStreamSource } from '../autopilot-onboarding-program'
+import {
+  type InferenceAdapterError,
+  type InferenceProviderAdapter,
+  type InferenceRequest,
+  type InferenceStreamChunk,
+  type InferenceStreamSource,
+} from './provider-adapter'
+
+// Surface an adapter's incremental `InferenceStreamSource.frames` as the
+// onboarding `deltas` async-iterable. Empty content deltas (e.g. the terminal
+// usage frame) are skipped so the route only sees prose. `final()` returns ''
+// so the content is never re-buffered — the route accumulates as it pumps.
+export const onboardingSourceFromStreamSse = (
+  source: InferenceStreamSource,
+): OnboardingStreamSource => ({
+  deltas: (async function* () {
+    for await (const frame of source.frames) {
+      if (frame.contentDelta !== '') {
+        yield frame.contentDelta
+      }
+    }
+  })(),
+  final: () => '',
+})
+
+// Fallback: surface a buffered chunk array as onboarding deltas. Used only for
+// adapters that do not implement `streamSse`. The content IS already materialized
+// here, so `final()` can cheaply rejoin it (the route still prefers its own
+// accumulation when non-empty).
+export const onboardingSourceFromChunks = (
+  chunks: ReadonlyArray<InferenceStreamChunk>,
+): OnboardingStreamSource => ({
+  deltas: (async function* () {
+    for (const chunk of chunks) {
+      if (chunk.contentDelta !== '') {
+        yield chunk.contentDelta
+      }
+    }
+  })(),
+  final: () => chunks.map(chunk => chunk.contentDelta).join(''),
+})
+
+// The dispatch operation handed to `dispatchWithOverflow`: prefer the adapter's
+// incremental `streamSse`, fall back to the buffered `stream`. Returns an
+// `OnboardingStreamSource` either way so the onboarding client is uniform.
+export const dispatchOnboardingStreamSource = (
+  adapter: InferenceProviderAdapter,
+  request: InferenceRequest,
+): Effect.Effect<OnboardingStreamSource, InferenceAdapterError> =>
+  adapter.streamSse !== undefined
+    ? adapter.streamSse(request).pipe(Effect.map(onboardingSourceFromStreamSse))
+    : adapter.stream(request).pipe(Effect.map(onboardingSourceFromChunks))

--- a/apps/openagents.com/workers/api/src/inference/vertex-gemini-adapter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/vertex-gemini-adapter.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_GEMINI_MODEL_ID,
   makeVertexGeminiAdapter,
 } from './vertex-gemini-adapter'
+import type { InferenceStreamEvent } from './provider-adapter'
 
 const run = <A>(effect: Effect.Effect<A, InferenceAdapterError>): Promise<A> =>
   Effect.runPromise(effect)
@@ -104,5 +105,134 @@ describe('vertex gemini adapter request mapping', () => {
       'https://aiplatform.googleapis.com/v1/projects/openagentsgemini' +
         `/locations/global/publishers/google/models/${DEFAULT_GEMINI_MODEL_ID}:generateContent`,
     )
+  })
+})
+
+// Build a Vertex Gemini streamGenerateContent(?alt=sse)-shaped ReadableStream
+// from a list of GenerateContentResponse fragments, each on its own `data:`
+// line. Mirrors how Vertex emits SSE so the adapter's incremental reader sees
+// many fragments rather than one buffered body.
+const sseStreamResponse = (
+  fragments: ReadonlyArray<unknown>,
+): Response => {
+  const encoder = new TextEncoder()
+  let index = 0
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index >= fragments.length) {
+        controller.close()
+        return
+      }
+      const fragment = fragments[index]
+      index += 1
+      controller.enqueue(
+        encoder.encode(`data: ${JSON.stringify(fragment)}\n\n`),
+      )
+    },
+  })
+  return new Response(stream, {
+    headers: { 'content-type': 'text/event-stream' },
+    status: 200,
+  })
+}
+
+const drainFrames = async (
+  frames: AsyncIterable<InferenceStreamEvent>,
+): Promise<Array<InferenceStreamEvent>> => {
+  const collected: Array<InferenceStreamEvent> = []
+  for await (const frame of frames) {
+    collected.push(frame)
+  }
+  return collected
+}
+
+describe('vertex gemini adapter streamSse — incremental pass-through', () => {
+  test('parses a multi-fragment Gemini SSE body into multiple events (one per fragment)', async () => {
+    const { fetchImpl } = recordingFetch(
+      sseStreamResponse([
+        { candidates: [{ content: { parts: [{ text: 'Hello' }] } }] },
+        { candidates: [{ content: { parts: [{ text: ', ' }] } }] },
+        {
+          candidates: [
+            {
+              content: { parts: [{ text: 'world' }] },
+              finishReason: 'STOP',
+            },
+          ],
+          modelVersion: DEFAULT_GEMINI_MODEL_ID,
+          usageMetadata: {
+            candidatesTokenCount: 3,
+            promptTokenCount: 5,
+            totalTokenCount: 8,
+          },
+        },
+      ]),
+    )
+    const adapter = makeVertexGeminiAdapter({
+      fetchImpl,
+      project: 'openagentsgemini',
+      tokenProvider: fixedToken,
+    })
+
+    expect(adapter.streamSse).toBeDefined()
+    const source = await run(adapter.streamSse!(baseRequest({ stream: true })))
+    const frames = await drainFrames(source.frames)
+
+    // MANY events, not one buffered chunk: one per upstream Gemini fragment.
+    const contentFrames = frames.filter(frame => frame.contentDelta !== '')
+    expect(contentFrames.map(frame => frame.contentDelta)).toEqual([
+      'Hello',
+      ', ',
+      'world',
+    ])
+
+    // Receipt-first terminal state from the final fragment's cumulative usage.
+    const terminal = source.terminal()
+    expect(terminal.finishReason).toBe('STOP')
+    expect(terminal.servedModel).toBe(DEFAULT_GEMINI_MODEL_ID)
+    expect(terminal.usage?.promptTokens).toBe(5)
+    expect(terminal.usage?.completionTokens).toBe(3)
+    expect(terminal.usage?.totalTokens).toBe(8)
+  })
+
+  test('hits the streamGenerateContent?alt=sse endpoint', async () => {
+    const { calls, fetchImpl } = recordingFetch(
+      sseStreamResponse([
+        { candidates: [{ content: { parts: [{ text: 'hi' }] } }] },
+      ]),
+    )
+    const adapter = makeVertexGeminiAdapter({
+      fetchImpl,
+      project: 'openagentsgemini',
+      tokenProvider: fixedToken,
+    })
+
+    const source = await run(adapter.streamSse!(baseRequest({ stream: true })))
+    await drainFrames(source.frames)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toContain(':streamGenerateContent?alt=sse')
+  })
+
+  test('a non-2xx stream open surfaces a typed retryable adapter error before any frame', async () => {
+    const { fetchImpl } = recordingFetch(
+      new Response('quota exceeded', { status: 429 }),
+    )
+    const adapter = makeVertexGeminiAdapter({
+      fetchImpl,
+      project: 'openagentsgemini',
+      tokenProvider: fixedToken,
+    })
+
+    const result = await Effect.runPromise(
+      adapter.streamSse!(baseRequest({ stream: true })).pipe(
+        Effect.map(() => 'ok' as const),
+        Effect.catch(error =>
+          Effect.succeed({ reason: error.reason, retryable: error.retryable }),
+        ),
+      ),
+    )
+    expect(result).not.toBe('ok')
+    expect(result).toMatchObject({ retryable: true })
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/vertex-gemini-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/vertex-gemini-adapter.ts
@@ -55,6 +55,8 @@ import {
   type InferenceRequest,
   type InferenceResult,
   type InferenceStreamChunk,
+  type InferenceStreamEvent,
+  type InferenceStreamSource,
   type InferenceUsage,
 } from './provider-adapter'
 import {
@@ -333,9 +335,12 @@ export const makeVertexGeminiAdapter = (
         )
       : Effect.succeed(tokenProvider)
 
-  // Issue a Vertex request and return the raw response body text. Reading the
-  // body here keeps the Cloudflare Response type fully encapsulated.
-  const call = (
+  // Issue a Vertex request and return the raw Cloudflare `Response`. Callers that
+  // want a buffered body call `.text()`; the incremental `streamSse` path reads
+  // `response.body` as bytes arrive instead. Status validation that needs the
+  // body (the non-ok error slice) is left to the caller so the streaming path
+  // never drains a successful body up front.
+  const callResponse = (
     request: InferenceRequest,
     method: 'generateContent' | 'streamGenerateContent',
   ) =>
@@ -350,7 +355,7 @@ export const makeVertexGeminiAdapter = (
       )
       const body = buildGeminiBody(request)
 
-      const { ok, status, text } = yield* Effect.tryPromise({
+      return yield* Effect.tryPromise({
         catch: error =>
           adapterError(
             `Vertex Gemini request transport error: ${
@@ -358,21 +363,40 @@ export const makeVertexGeminiAdapter = (
             }`,
             true,
           ),
-        try: async () => {
-          const response = await fetchImpl(url, {
+        try: () =>
+          fetchImpl(url, {
             body: JSON.stringify(body),
             headers: {
               authorization: `Bearer ${token}`,
               'content-type': 'application/json',
             },
             method: 'POST',
-          })
-          return {
-            ok: response.ok,
-            status: response.status,
-            text: await response.text(),
-          }
-        },
+          }),
+      })
+    })
+
+  // Issue a Vertex request and return the raw response body text (buffered). Used
+  // by `complete` and the buffered `stream` path. Reading the body here keeps the
+  // Cloudflare Response type fully encapsulated.
+  const call = (
+    request: InferenceRequest,
+    method: 'generateContent' | 'streamGenerateContent',
+  ) =>
+    Effect.gen(function* () {
+      const response = yield* callResponse(request, method)
+      const { ok, status, text } = yield* Effect.tryPromise({
+        catch: error =>
+          adapterError(
+            `Vertex Gemini response read error: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            true,
+          ),
+        try: async () => ({
+          ok: response.ok,
+          status: response.status,
+          text: await response.text(),
+        }),
       })
 
       if (!ok) {
@@ -417,7 +441,127 @@ export const makeVertexGeminiAdapter = (
         const text = yield* call(request, 'streamGenerateContent')
         return parseGeminiSseChunks(text, request.model, resolveModelId)
       }),
+    // TRUE PASS-THROUGH STREAM (the long-generation 524 fix + onboarding
+    // token-by-token). Returns a lazily consumed SSE source over the upstream
+    // `response.body` so the caller can pump each Gemini SSE fragment as Google
+    // produces it — every fragment is a separate `event: delta`, so onboarding
+    // (khala-mini) streams incrementally instead of one buffered reply. The
+    // buffered `stream` above stays for tests/metering reconstruction/overflow.
+    streamSse: (request: InferenceRequest) =>
+      Effect.gen(function* () {
+        const response = yield* callResponse(request, 'streamGenerateContent')
+        if (!response.ok) {
+          const errorText = yield* Effect.tryPromise({
+            catch: () => adapterError('Vertex Gemini stream read error.', true),
+            try: () => response.text(),
+          })
+          return yield* Effect.fail(
+            adapterError(
+              `Vertex Gemini returned HTTP ${response.status}${
+                errorText === '' ? '' : `: ${errorText.slice(0, 500)}`
+              }`,
+              isRetryableStatus(response.status),
+            ),
+          )
+        }
+        const body = response.body
+        if (body === null) {
+          return yield* Effect.fail(
+            adapterError('Vertex Gemini stream had no response body.', false),
+          )
+        }
+        return makeGeminiSseSource(body, request.model, resolveModelId)
+      }),
   }
+}
+
+const num = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined
+
+// Pull the `usageMetadata` (if any) off a single Gemini SSE fragment, layered on
+// the running cumulative usage. Gemini reports usage CUMULATIVELY across the
+// stream — each later fragment supersedes the earlier one — so we carry the prior
+// values forward and only overwrite the fields this fragment actually reports.
+const foldGeminiUsage = (
+  fragment: Record<string, unknown>,
+  prior: InferenceUsage | undefined,
+): InferenceUsage | undefined => {
+  const usage = fragment['usageMetadata']
+  if (typeof usage !== 'object' || usage === null) {
+    return prior
+  }
+  const u = usage as Record<string, unknown>
+  const promptTokens =
+    num(u['promptTokenCount']) ?? prior?.promptTokens ?? 0
+  const completionTokens =
+    num(u['candidatesTokenCount']) ?? prior?.completionTokens ?? 0
+  const reportedTotal = num(u['totalTokenCount']) ?? prior?.totalTokens ?? 0
+  const cached =
+    num(u['cachedContentTokenCount']) ?? prior?.cachedPromptTokens
+  return {
+    completionTokens,
+    promptTokens,
+    totalTokens:
+      reportedTotal > 0 ? reportedTotal : promptTokens + completionTokens,
+    ...(cached === undefined || cached <= 0 ? {} : { cachedPromptTokens: cached }),
+  }
+}
+
+// Normalize one parsed Gemini SSE fragment into the route-facing event shape.
+// Shared by the buffered `stream` array path and the incremental `streamSse`
+// pass-through so both produce identical normalization. `usage` carries the
+// cumulative usage VISIBLE SO FAR (Gemini cumulates), folded over `priorUsage`.
+const eventForGeminiFragment = (
+  fragment: Record<string, unknown>,
+  priorUsage: InferenceUsage | undefined,
+): InferenceStreamEvent => {
+  const event: {
+    contentDelta: string
+    finishReason?: string
+    usage?: InferenceUsage
+    servedModel?: string
+  } = { contentDelta: '' }
+
+  const candidates = fragment['candidates']
+  if (Array.isArray(candidates) && candidates.length > 0) {
+    event.contentDelta = extractText(candidates)
+    // extractFinishReason defaults to 'stop'; only adopt a real terminal reason
+    // when the fragment actually carries one.
+    const first = candidates[0]
+    if (
+      typeof first === 'object' &&
+      first !== null &&
+      typeof (first as Record<string, unknown>)['finishReason'] === 'string'
+    ) {
+      event.finishReason = extractFinishReason(candidates)
+    }
+  }
+
+  if (typeof fragment['modelVersion'] === 'string') {
+    event.servedModel = fragment['modelVersion']
+  }
+
+  const usage = foldGeminiUsage(fragment, priorUsage)
+  if (usage !== undefined) {
+    event.usage = usage
+  }
+  return event
+}
+
+// Parse a single SSE `data:` line into a Gemini fragment record, or undefined for
+// blank/comment/`[DONE]` lines.
+const parseGeminiSseData = (
+  line: string,
+): Record<string, unknown> | undefined => {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith('data:')) {
+    return undefined
+  }
+  const payload = trimmed.slice('data:'.length).trim()
+  if (payload === '' || payload === '[DONE]') {
+    return undefined
+  }
+  return parseJsonRecord(payload)
 }
 
 // Parse a Vertex Gemini streamGenerateContent (?alt=sse) body into our
@@ -432,71 +576,35 @@ const parseGeminiSseChunks = (
   requestedModel: string,
   resolveModelId: (model: string) => string,
 ): ReadonlyArray<InferenceStreamChunk> => {
-  let promptTokens = 0
-  let completionTokens = 0
-  let totalTokens = 0
-  let cachedPromptTokens: number | undefined
   let finishReason: string | undefined
   let servedModel = resolveModelId(requestedModel)
+  let usage: InferenceUsage | undefined
   const contentDeltas: Array<string> = []
 
-  const num = (value: unknown): number | undefined =>
-    typeof value === 'number' && Number.isFinite(value) ? value : undefined
-
   for (const line of body.split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed.startsWith('data:')) {
+    const fragment = parseGeminiSseData(line)
+    if (fragment === undefined) {
       continue
     }
-    const payload = trimmed.slice('data:'.length).trim()
-    if (payload === '' || payload === '[DONE]') {
-      continue
+    const event = eventForGeminiFragment(fragment, usage)
+    if (event.contentDelta !== '') {
+      contentDeltas.push(event.contentDelta)
     }
-    const event = parseJsonRecord(payload)
-    if (event === undefined) {
-      continue
+    if (event.finishReason !== undefined) {
+      finishReason = event.finishReason
     }
-    if (typeof event['modelVersion'] === 'string') {
-      servedModel = event['modelVersion']
+    if (event.servedModel !== undefined) {
+      servedModel = event.servedModel
     }
-    // Incremental text + finishReason from this fragment's first candidate.
-    const candidates = event['candidates']
-    if (Array.isArray(candidates) && candidates.length > 0) {
-      const delta = extractText(candidates)
-      if (delta !== '') {
-        contentDeltas.push(delta)
-      }
-      // extractFinishReason defaults to 'stop'; only adopt a real terminal
-      // reason when the fragment actually carries one.
-      const first = candidates[0]
-      if (
-        typeof first === 'object' &&
-        first !== null &&
-        typeof (first as Record<string, unknown>)['finishReason'] === 'string'
-      ) {
-        finishReason = extractFinishReason(candidates)
-      }
-    }
-    // usageMetadata is cumulative across fragments; take the latest values.
-    const usage = event['usageMetadata']
-    if (typeof usage === 'object' && usage !== null) {
-      const u = usage as Record<string, unknown>
-      promptTokens = num(u['promptTokenCount']) ?? promptTokens
-      completionTokens = num(u['candidatesTokenCount']) ?? completionTokens
-      totalTokens = num(u['totalTokenCount']) ?? totalTokens
-      cachedPromptTokens =
-        num(u['cachedContentTokenCount']) ?? cachedPromptTokens
+    if (event.usage !== undefined) {
+      usage = event.usage
     }
   }
 
-  const usage: InferenceUsage = {
-    completionTokens,
-    promptTokens,
-    totalTokens:
-      totalTokens > 0 ? totalTokens : promptTokens + completionTokens,
-    ...(cachedPromptTokens === undefined || cachedPromptTokens <= 0
-      ? {}
-      : { cachedPromptTokens }),
+  const terminalUsage: InferenceUsage = usage ?? {
+    completionTokens: 0,
+    promptTokens: 0,
+    totalTokens: 0,
   }
 
   const chunks: Array<InferenceStreamChunk> = []
@@ -508,7 +616,79 @@ const parseGeminiSseChunks = (
     contentDelta: '',
     finishReason: finishReason ?? 'stop',
     servedModel,
-    usage,
+    usage: terminalUsage,
   })
   return chunks
+}
+
+// Build a true incremental SSE source over the upstream Gemini `ReadableStream`.
+// Fragments are decoded + parsed AS BYTES ARRIVE (partial lines buffered across
+// reads) and yielded one at a time, so the caller can pump each to the client and
+// reset the edge idle-timer — and onboarding emits one `event: delta` per Gemini
+// fragment instead of one buffered reply. The running terminal state
+// (finishReason / cumulative usage / servedModel) is captured during iteration
+// and exposed via `terminal()` once the stream is drained — receipt-first, no
+// re-buffering of content. Blank/comment/`[DONE]` lines are skipped.
+const makeGeminiSseSource = (
+  body: ReadableStream<Uint8Array>,
+  requestedModel: string,
+  resolveModelId: (model: string) => string,
+): InferenceStreamSource => {
+  let finishReason: string | undefined
+  let usage: InferenceUsage | undefined
+  let servedModel: string | undefined = resolveModelId(requestedModel)
+
+  const captureTerminalState = (event: InferenceStreamEvent): void => {
+    if (event.finishReason !== undefined) {
+      finishReason = event.finishReason
+    }
+    if (event.usage !== undefined) {
+      usage = event.usage
+    }
+    if (event.servedModel !== undefined) {
+      servedModel = event.servedModel
+    }
+  }
+
+  const frames = (async function* (): AsyncIterable<InferenceStreamEvent> {
+    const reader = body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    try {
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (value !== undefined) {
+          buffer += decoder.decode(value, { stream: true })
+        }
+        let newlineIndex = buffer.indexOf('\n')
+        while (newlineIndex !== -1) {
+          const line = buffer.slice(0, newlineIndex)
+          buffer = buffer.slice(newlineIndex + 1)
+          const fragment = parseGeminiSseData(line)
+          if (fragment !== undefined) {
+            const event = eventForGeminiFragment(fragment, usage)
+            captureTerminalState(event)
+            yield event
+          }
+          newlineIndex = buffer.indexOf('\n')
+        }
+        if (done) {
+          const tail = parseGeminiSseData(buffer)
+          if (tail !== undefined) {
+            const event = eventForGeminiFragment(tail, usage)
+            captureTerminalState(event)
+            yield event
+          }
+          break
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+  })()
+
+  return {
+    frames,
+    terminal: () => ({ finishReason, servedModel, usage }),
+  }
 }


### PR DESCRIPTION
Tiers 1-2 of #6154. Adds an incremental `streamSse` to the Vertex Gemini adapter and rewires `makeOnboardingStreamClient` to prefer `streamSse`, so onboarding streams token-by-token. Durable-streams routing (tier 4) is a follow-up.

## What changed

- **`vertex-gemini-adapter.ts` — real `streamSse`.** Calls `streamGenerateContent?alt=sse` and reads `response.body` incrementally (no more `await response.text()`/`.join('')` for the stream path), mirroring the Fireworks `makeSseSource` shape: decode bytes as they arrive, buffer partial lines across reads, yield one `InferenceStreamEvent` per upstream Gemini SSE fragment. The terminal state (`finishReason`/`usage`/`servedModel`) is captured from the cumulative `usageMetadata` and exposed via `terminal()`, receipt-first, no content re-buffering. The buffered `stream` path is refactored to share the same per-fragment normalization (`eventForGeminiFragment`) so it stays byte-equivalent.
- **`onboarding-stream-source.ts` (new) — dispatch seam.** `dispatchOnboardingStreamSource` prefers `adapter.streamSse` and falls back to `adapter.stream` when an adapter has no `streamSse`. The `streamSse` source's `final()` returns `''` so the route's own accumulation stays the single source of truth (metering/persist receipt-first).
- **`index.ts` — onboarding client swap.** `makeOnboardingStreamClient` now dispatches `dispatchOnboardingStreamSource` through the same overflow dispatcher; overflow happens at stream-open time exactly like the `/v1` gateway. No route changes — `autopilot-onboarding-routes.ts` already streams whatever it is handed.

## Constraints honored

- Additive: `/v1` gateway behavior, auth, and the component channel are unchanged; the buffered `adapter.stream` path is preserved for other callers/tests.
- Provider-identity redaction posture matches the gateway (the onboarding wire only carries prose deltas + a terminal payload).

## Proof the stream is now multi-frame

- `vertex-gemini-adapter.test.ts`: a multi-fragment Gemini SSE `ReadableStream` body parses into **multiple** events (`['Hello', ', ', 'world']`), the terminal frame carries the real cumulative usage, and the request hits `:streamGenerateContent?alt=sse`. A non-2xx open surfaces a typed retryable error before any frame.
- `onboarding-stream-source.test.ts`: a mock `streamSse` adapter yielding many frames produces **many** onboarding `deltas` (token-by-token), and a no-`streamSse` adapter still works via the buffered `stream` fallback.

## Verification

- `bun run typecheck:api` and `bun run typecheck:web`: clean (only two pre-existing `message TS47` notices in the untouched `mpp-chat-completions-routes.ts`).
- Inference + onboarding suites: `bun run test -- src/inference/ src/autopilot-onboarding-*` → **1007 passed**.
- `bun run check:deploy`: exit 0 (green).
- No new lint regressions: the gemini adapter/test files already carried `as Record<…>` casts on `main` (same count before/after); the two new files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
