### PR TITLE
Durable Streams: wire + enable resumable inference streaming (gateway + onboarding)

### DIFF
--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -377,7 +377,20 @@ const budgetChecks = [
     // crawlable discovery-surface renderer already counted here, is public +
     // cacheable, mints no authority, and never charges. Ratchet back down when
     // these discovery handlers are extracted behind shared route mappers.
-    budget: 107,
+    // +3 (107 -> 110) on 2026-06-23 (#6154 / EPIC #6056) for the durable
+    // resumable-inference wiring: (a) the DO-fetch transport stub type in
+    // inference/durable-inference-do-transport.ts (`DurableStreamStub.fetch():
+    // Promise<Response>`, a REQUIRED structural typing of the Cloudflare DO stub
+    // surface, mirroring the package's own local DO typing convention), and (b)
+    // two SHARED response builders extracted in
+    // inference/durable-inference-read-routes.ts (`jsonError`, `replayToResponse`)
+    // that DEDUPLICATE the resume-read response shaping across the synchronous and
+    // the new async DO-backed read dispatchers — a net reduction in inline
+    // Response construction, just hoisted into named `: Response` helpers the
+    // counter sees. Both read dispatchers read stored bytes only and NEVER meter.
+    // Ratchet back down when the durable read surfaces are extracted behind a
+    // shared prefix-route mapper.
+    budget: 110,
     description:
       'Worker domain and route modules may not grow Response-returning surfaces while route mappers are extracted.',
     details: countByFile(

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.test.ts
@@ -1,5 +1,11 @@
 import { DatabaseSync } from 'node:sqlite'
 
+import {
+  MemoryStreamStore,
+  type StreamStore,
+  handleRequest,
+  streamIdFromUrl,
+} from '@openagentsinc/durable-stream'
 import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
@@ -10,6 +16,7 @@ import {
   type OnboardingStreamSource,
 } from './autopilot-onboarding-program'
 import { makeAutopilotOnboardingRoutes } from './autopilot-onboarding-routes'
+import { type DurableStreamNamespace } from './inference/durable-inference-do-transport'
 
 type Row = Record<string, unknown>
 class Stmt {
@@ -390,5 +397,209 @@ describe('POST /api/autopilot/onboarding/{sessionId}/turn', () => {
     const body = (await response.json()) as { error: string; reason: string }
     expect(body.error).toBe('bad_request')
     expect(body.reason).toContain('invalid vertical')
+  })
+})
+
+// DURABLE ONBOARDING STREAM (#6154 item 4) — the resumable turn stream + the
+// session-rehydration GET, against an in-process DO backend (the package's real
+// handleRequest, one MemoryStreamStore per stream id).
+describe('durable onboarding stream + resume + GET session', () => {
+  class StreamRegistry {
+    private readonly stores = new Map<string, StreamStore>()
+    private storeFor(streamId: string): StreamStore {
+      let s = this.stores.get(streamId)
+      if (s === undefined) {
+        s = new MemoryStreamStore()
+        this.stores.set(streamId, s)
+      }
+      return s
+    }
+    fetch(request: Request): Promise<Response> {
+      const streamId = streamIdFromUrl(request.url)
+      if (streamId === null) {
+        return Promise.resolve(new Response('nope', { status: 404 }))
+      }
+      return handleRequest(this.storeFor(streamId), request, { streamId })
+    }
+  }
+
+  const durableNamespace = (
+    registry: StreamRegistry,
+  ): DurableStreamNamespace => ({
+    getByName: () => ({ fetch: (r: Request) => registry.fetch(r) }),
+  })
+
+  const chunkStream =
+    (chunks: ReadonlyArray<string>): OnboardingStreamClient =>
+    () =>
+      Effect.succeed<OnboardingStreamSource>({
+        deltas: (async function* () {
+          for (const chunk of chunks) {
+            yield chunk
+          }
+        })(),
+        final: () => chunks.join(''),
+      })
+
+  const streamRequest = (sessionId: string, body: unknown): Request =>
+    new Request(
+      `https://openagents.com/api/autopilot/onboarding/${sessionId}/turn`,
+      {
+        body: JSON.stringify(body),
+        method: 'POST',
+        headers: { accept: 'text/event-stream' },
+      },
+    )
+
+  const durableRoutes = (registry: StreamRegistry) =>
+    makeAutopilotOnboardingRoutes<Env>({
+      makeInferenceClient: () => echoInference,
+      makeStreamClient: () => chunkStream(['AAA', 'BBB', 'CCC']),
+      resolveDurableStream: () => durableNamespace(registry),
+      nowIso: () => '2026-06-23T00:00:00.000Z',
+    })
+
+  test('emits the stream handshake first, durable-tees the turn, and resumes by offset', async () => {
+    const registry = new StreamRegistry()
+    const routes = durableRoutes(registry)
+    const env = makeEnv()
+
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        streamRequest('sess-dur', { userText: 'I run a bakery.' }),
+        env,
+      ),
+    )
+    expect(response.status).toBe(200)
+    // Durable response advertises the stable stream id + resume URL.
+    expect(response.headers.get('openagents-onboarding-stream-id')).toBe(
+      'onboarding:sess-dur:0',
+    )
+    expect(response.headers.get('openagents-onboarding-resume-url')).toBe(
+      '/api/autopilot/onboarding/sess-dur/turn/0/stream',
+    )
+
+    const text = await response.text()
+    // HANDSHAKE first, before any delta.
+    const streamIdx = text.indexOf('event: stream')
+    const firstDeltaIdx = text.indexOf('event: delta')
+    expect(streamIdx).toBeGreaterThanOrEqual(0)
+    expect(streamIdx).toBeLessThan(firstDeltaIdx)
+    expect(text).toContain('"streamId":"onboarding:sess-dur:0"')
+    expect(text).toContain('"sessionId":"sess-dur"')
+    expect(text).toContain('"turnIndex":0')
+    // Deltas + terminal done.
+    expect(text).toContain('event: delta\ndata: {"text":"AAA"}')
+    expect(text).toContain('event: delta\ndata: {"text":"CCC"}')
+    expect(text).toContain('event: done')
+
+    // RESUME from offset 0: the durable log replays the SAME delta/done wire.
+    const resume = await run(
+      routes.routeOnboardingTurnRequest(
+        new Request(
+          'https://openagents.com/api/autopilot/onboarding/sess-dur/turn/0/stream?offset=0',
+          { method: 'GET' },
+        ),
+        env,
+      ),
+    )
+    expect(resume.status).toBe(200)
+    expect(resume.headers.get('stream-closed')).toBe('true')
+    const resumeBody = await resume.text()
+    expect(resumeBody).toContain('event: delta\ndata: {"text":"AAA"}')
+    expect(resumeBody).toContain('event: delta\ndata: {"text":"CCC"}')
+    expect(resumeBody).toContain('event: done')
+    // The handshake frame is NOT persisted (metadata the browser already holds).
+    expect(resumeBody).not.toContain('event: stream')
+
+    // Mid-stream resume: a non-zero offset replays only the missing suffix.
+    const firstFrameBytes = new TextEncoder().encode(
+      'event: delta\ndata: {"text":"AAA"}\n\n',
+    ).length
+    const suffix = await run(
+      routes.routeOnboardingTurnRequest(
+        new Request(
+          `https://openagents.com/api/autopilot/onboarding/sess-dur/turn/0/stream?offset=${firstFrameBytes}`,
+          { method: 'GET' },
+        ),
+        env,
+      ),
+    )
+    const suffixBody = await suffix.text()
+    expect(suffixBody).not.toContain('"text":"AAA"')
+    expect(suffixBody).toContain('"text":"BBB"')
+  })
+
+  test('resume read is 404 when the durable substrate is unwired (fail-safe)', async () => {
+    const routes = makeAutopilotOnboardingRoutes<Env>({
+      makeInferenceClient: () => echoInference,
+      makeStreamClient: () => chunkStream(['x']),
+      // No resolveDurableStream -> non-durable.
+      nowIso: () => '2026-06-23T00:00:00.000Z',
+    })
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        new Request(
+          'https://openagents.com/api/autopilot/onboarding/sess-x/turn/0/stream?offset=0',
+          { method: 'GET' },
+        ),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(404)
+  })
+
+  test('GET session returns the persisted transcript + status + outputSpec', async () => {
+    const registry = new StreamRegistry()
+    const routes = durableRoutes(registry)
+    const env = makeEnv()
+
+    // Run a turn so the session is persisted. The finalize (transcript append +
+    // persist) runs in the stream body, so the response must be drained first.
+    const turn = await run(
+      routes.routeOnboardingTurnRequest(
+        streamRequest('sess-get', { userText: 'I run a bakery.' }),
+        env,
+      ),
+    )
+    await turn.text()
+
+    const session = await run(
+      routes.routeOnboardingTurnRequest(
+        new Request(
+          'https://openagents.com/api/autopilot/onboarding/sess-get',
+          { method: 'GET' },
+        ),
+        env,
+      ),
+    )
+    expect(session.status).toBe(200)
+    const json = (await session.json()) as {
+      sessionId: string
+      status: string
+      turnCount: number
+      transcript: ReadonlyArray<{ role: string; content: string }>
+    }
+    expect(json.sessionId).toBe('sess-get')
+    expect(json.turnCount).toBe(1)
+    expect(json.status).toBe('interviewing')
+    // The user turn + assistant reply are both in the transcript.
+    expect(json.transcript.some(t => t.role === 'user')).toBe(true)
+    expect(json.transcript.some(t => t.role === 'assistant')).toBe(true)
+  })
+
+  test('GET session is 404 for an unknown session', async () => {
+    const registry = new StreamRegistry()
+    const routes = durableRoutes(registry)
+    const response = await run(
+      routes.routeOnboardingTurnRequest(
+        new Request(
+          'https://openagents.com/api/autopilot/onboarding/never-existed',
+          { method: 'GET' },
+        ),
+        makeEnv(),
+      ),
+    )
+    expect(response.status).toBe(404)
   })
 })

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.ts
@@ -16,6 +16,11 @@ import {
   AUTOPILOT_CONCIERGE_VERTICALS,
   type AutopilotConciergeVertical,
 } from './inference/autopilot-concierge-model'
+import {
+  type DurableStreamNamespace,
+  replayFromOffsetDO,
+  teeUpstreamToDurableDO,
+} from './inference/durable-inference-do-transport'
 import { resolveOnboardingPromptVertical } from './autopilot-onboarding-system-prompt'
 import {
   type OnboardingInferenceClient,
@@ -74,6 +79,15 @@ export type OnboardingRouteDependencies<Env extends OnboardingRouteEnv> =
       | undefined
     // Overridable for tests; defaults to the D1-backed store.
     makeStore?: ((env: WorkerEnv<Env>) => OnboardingSessionStore) | undefined
+    // DURABLE ONBOARDING STREAM (#6154 item 4). Resolves the per-request Durable
+    // Object namespace when the durable-stream flag is on AND the binding is
+    // wired; absent => the onboarding stream is the non-durable SSE (fail-safe).
+    // When present, each onboarding turn stream is teed into a durable log keyed
+    // by the STABLE id `onboarding:{sessionId}:{turnIndex}`, so an unauthenticated
+    // browser holding only `sessionId` + last offset can resume a dropped turn.
+    resolveDurableStream?:
+      | ((env: WorkerEnv<Env>) => DurableStreamNamespace | undefined)
+      | undefined
     nowIso?: (() => string) | undefined
   }>
 
@@ -120,11 +134,30 @@ const routeErrorResponse = (error: OnboardingRouteError): HttpResponse =>
 // OpenAI-compatible chat-completions wire here: the onboarding client only needs
 // prose deltas + a terminal payload, so the wire is intentionally minimal and
 // self-describing (the client's `parseComponentFrames`-style splitter reads it):
+//   event: stream  data: { "streamId", "sessionId", "turnIndex" }  (handshake, first)
 //   event: delta   data: { "text": "…" }     (one per content increment)
 //   event: done    data: <OnboardingTurnResponse JSON>   (terminal, once)
 //   event: error   data: { "error": "…" }     (terminal, on failure)
 const sseFrame = (event: string, payload: unknown): string =>
   `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`
+
+// The STABLE durable log key for an onboarding turn (#6154 item 4). Derivable by
+// the browser from `sessionId` + the turn index (the session's `turnCount` BEFORE
+// this turn finalizes), so a returning unauthenticated browser only needs to
+// persist `sessionId` + last `offset` — it never has to invent a requestId.
+export const onboardingDurableStreamId = (
+  sessionId: string,
+  turnIndex: number,
+): string => `onboarding:${sessionId}:${turnIndex}`
+
+// The public resume read URL for an in-flight onboarding turn (#6154 item 4).
+// Keyed by (sessionId, turnIndex) — both of which the browser holds — plus the
+// last `offset`. No prompt/credential material is in the path.
+export const onboardingResumeUrl = (
+  sessionId: string,
+  turnIndex: number,
+): string =>
+  `/api/autopilot/onboarding/${encodeURIComponent(sessionId)}/turn/${turnIndex}/stream`
 
 const STREAM_HEADERS: Readonly<Record<string, string>> = {
   'content-type': 'text/event-stream; charset=utf-8',
@@ -138,34 +171,114 @@ const wantsEventStream = (request: Request): boolean => {
   return accept.toLowerCase().includes('text/event-stream')
 }
 
+// The durable substrate for one prepared onboarding turn: the per-request DO
+// namespace + the STABLE stream id derived from `sessionId` + turn index. Absent
+// => the stream is the non-durable SSE (today's behaviour, fail-safe).
+type OnboardingDurable = Readonly<{
+  namespace: DurableStreamNamespace
+  streamId: string
+  sessionId: string
+  turnIndex: number
+}>
+
 // Build the SSE response body for a prepared streaming turn. Pumps prose deltas,
 // then calls `finalize` (a plain Promise so the effect boundary stays OUT of the
 // Effect.gen request pipeline) to append + persist and resolve the terminal
 // payload, then emits the `done` frame. A failure at any point emits a terminal
 // `error` frame and closes — the client never hangs.
+//
+// DURABLE (#6154 item 4): when `durable` is present, the turn is teed into the
+// per-request Durable Object via the SAME `teeUpstreamToDurableDO` the gateway
+// uses, persisting the onboarding `delta`/`done` frames so a mid-turn disconnect
+// can resume by offset. An `event: stream` handshake frame is emitted FIRST (not
+// persisted — it is metadata the resuming browser already holds) carrying the
+// streamId + sessionId + turnIndex so the browser can persist them.
 const makeOnboardingStreamBody = (
   turn: OnboardingStreamTurn,
   finalize: (reply: string) => Promise<OnboardingTurnResponse>,
+  durable: OnboardingDurable | undefined,
 ): ReadableStream<Uint8Array> => {
   const encoder = new TextEncoder()
   return new ReadableStream<Uint8Array>({
     async start(controller) {
-      let accumulated = ''
-      try {
-        for await (const delta of turn.source.deltas) {
-          if (delta !== '') {
-            accumulated += delta
-            controller.enqueue(encoder.encode(sseFrame('delta', { text: delta })))
-          }
-        }
-        const final = turn.source.final()
-        const reply = final === '' ? accumulated : final
-        const result = await finalize(reply)
-        controller.enqueue(encoder.encode(sseFrame('done', result)))
-      } catch {
-        controller.enqueue(
-          encoder.encode(sseFrame('error', { error: 'stream_failed' })),
+      const emit = (frame: string): void =>
+        controller.enqueue(encoder.encode(frame))
+
+      // HANDSHAKE: tell the client the durable stream id + keys FIRST, before any
+      // delta, so a refresh/navigate-away can resume by (sessionId, turnIndex,
+      // offset). Emitted live only — not part of the durable log.
+      if (durable !== undefined) {
+        emit(
+          sseFrame('stream', {
+            streamId: durable.streamId,
+            sessionId: durable.sessionId,
+            turnIndex: durable.turnIndex,
+          }),
         )
+      }
+
+      // The non-durable path: pump deltas straight to the client (today's wire).
+      if (durable === undefined) {
+        let accumulated = ''
+        try {
+          for await (const delta of turn.source.deltas) {
+            if (delta !== '') {
+              accumulated += delta
+              emit(sseFrame('delta', { text: delta }))
+            }
+          }
+          const final = turn.source.final()
+          const reply = final === '' ? accumulated : final
+          const result = await finalize(reply)
+          emit(sseFrame('done', result))
+        } catch {
+          emit(sseFrame('error', { error: 'stream_failed' }))
+        } finally {
+          controller.close()
+        }
+        return
+      }
+
+      // The durable path: adapt the onboarding source into an `InferenceStreamSource`
+      // and tee through the DO transport. `frameForDelta` renders the onboarding
+      // `delta` wire; `onEof` finalizes (append + persist the session) and renders
+      // the terminal `done` wire. Both the delta frames and the `done` frame are
+      // persisted to the durable log, so a resume replays the byte-identical wire.
+      // The session transcript append happens ONCE here in `onEof` (the live
+      // producer drain), never on a resume read.
+      let accumulated = ''
+      const adapted = {
+        frames: (async function* () {
+          for await (const delta of turn.source.deltas) {
+            if (delta !== '') {
+              accumulated += delta
+              yield { contentDelta: delta }
+            }
+          }
+        })(),
+        terminal: () => ({
+          finishReason: 'stop' as string | undefined,
+          servedModel: undefined,
+          usage: undefined,
+        }),
+      }
+
+      try {
+        await teeUpstreamToDurableDO({
+          emit,
+          frameForDelta: delta => sseFrame('delta', { text: delta }),
+          namespace: durable.namespace,
+          onEof: async () => {
+            const final = turn.source.final()
+            const reply = final === '' ? accumulated : final
+            const result = await finalize(reply)
+            return sseFrame('done', result)
+          },
+          requestId: durable.streamId,
+          source: adapted,
+        })
+      } catch {
+        emit(sseFrame('error', { error: 'stream_failed' }))
       } finally {
         controller.close()
       }
@@ -181,12 +294,25 @@ const buildStreamResponse = (
   turn: OnboardingStreamTurn,
   store: OnboardingSessionStore,
   nowIso: () => string,
+  durable: OnboardingDurable | undefined,
 ): globalThis.Response => {
   const finalize = (reply: string): Promise<OnboardingTurnResponse> =>
     Effect.runPromise(finalizeOnboardingStreamTurn(turn, reply, { store, nowIso }))
 
-  return new Response(makeOnboardingStreamBody(turn, finalize), {
-    headers: STREAM_HEADERS,
+  return new Response(makeOnboardingStreamBody(turn, finalize, durable), {
+    headers:
+      durable === undefined
+        ? STREAM_HEADERS
+        : {
+            ...STREAM_HEADERS,
+            // Advertise the durable resume read URL + the stable stream id so the
+            // browser can resume even if it missed the `event: stream` frame.
+            'openagents-onboarding-stream-id': durable.streamId,
+            'openagents-onboarding-resume-url': onboardingResumeUrl(
+              durable.sessionId,
+              durable.turnIndex,
+            ),
+          },
   })
 }
 
@@ -275,6 +401,7 @@ export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
   ): OnboardingRouteEffect => {
     const store = resolveStore(env)
     const streamClient = makeStreamClient(env)
+    const namespace = dependencies.resolveDurableStream?.(env)
 
     return decodeJsonBody(request, OnboardingTurnRequest).pipe(
       Effect.flatMap(body =>
@@ -296,13 +423,105 @@ export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
       // The Response construction is a PURE transform of the prepared turn; the
       // SSE pump + finalize (a plain Promise via `Effect.runPromise`) run AFTER
       // this request Effect resolves, so the effect boundary stays out of the
-      // request pipeline.
-      Effect.map(turn => buildStreamResponse(turn, store, nowIso)),
+      // request pipeline. The durable substrate (when wired) keys the per-turn
+      // log by the STABLE id `onboarding:{sessionId}:{turnIndex}`, where the turn
+      // index is the session's PRE-turn `turnCount` (so a resume read can derive
+      // it from `sessionId` + the count it last saw).
+      Effect.map(turn =>
+        buildStreamResponse(
+          turn,
+          store,
+          nowIso,
+          namespace === undefined
+            ? undefined
+            : {
+                namespace,
+                sessionId,
+                streamId: onboardingDurableStreamId(
+                  sessionId,
+                  turn.session.turnCount,
+                ),
+                turnIndex: turn.session.turnCount,
+              },
+        ),
+      ),
       // A prepare-time failure (validation / storage / inference open) becomes a
       // clean JSON error — the stream was never started.
       Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
     )
   }
+
+  // RESUME READ (#6154 item 4): replay an in-flight (or completed) onboarding
+  // turn's durable log from `?offset=`, keyed by (sessionId, turnIndex). The
+  // browser calls this on reload with only `sessionId` + last `offset`. NEVER
+  // meters (onboarding is free; this only reads stored bytes). Returns 404 when
+  // the durable substrate is unwired or the turn has no durable log.
+  const resumeReadResponse = (
+    env: WorkerEnv<Env>,
+    sessionId: string,
+    turnIndex: number,
+    offset: string | undefined,
+  ): OnboardingRouteEffect => {
+    const namespace = dependencies.resolveDurableStream?.(env)
+    if (namespace === undefined) {
+      return Effect.succeed(
+        noStoreJsonResponse({ error: 'not_found' }, { status: 404 }),
+      )
+    }
+    return Effect.promise(async () => {
+      const replay = await replayFromOffsetDO({
+        namespace,
+        offset,
+        requestId: onboardingDurableStreamId(sessionId, turnIndex),
+      })
+      if (replay === undefined) {
+        return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
+      }
+      if (replay.status === 400) {
+        return noStoreJsonResponse(
+          { error: 'invalid_offset' },
+          { status: 400 },
+        )
+      }
+      const headers: Record<string, string> = {
+        'cache-control': 'no-store',
+        'content-type': replay.contentType,
+        'stream-next-offset': replay.nextOffset,
+      }
+      if (replay.upToDate) {
+        headers['stream-up-to-date'] = 'true'
+      }
+      if (replay.streamClosed) {
+        headers['stream-closed'] = 'true'
+      }
+      return new Response(replay.body, { headers, status: 200 })
+    })
+  }
+
+  // GET SESSION (#6154 item 4): the persisted transcript + status + outputSpec +
+  // turnCount for a `sessionId`, so a returning browser can rehydrate past
+  // messages (even if a turn completed server-side while the tab was gone). Read
+  // only — no mutation, no metering. 404 when the session does not exist.
+  const sessionResponse = (
+    env: WorkerEnv<Env>,
+    sessionId: string,
+  ): OnboardingRouteEffect =>
+    resolveStore(env)
+      .read(sessionId)
+      .pipe(
+        Effect.map(session =>
+          session === undefined
+            ? noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
+            : noStoreJsonResponse({
+                sessionId: session.id,
+                status: session.status,
+                turnCount: session.turnCount,
+                transcript: session.transcript,
+                outputSpec: session.outputSpec,
+              }),
+        ),
+        Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
+      )
 
   return {
     routeOnboardingTurnRequest: (
@@ -310,26 +529,55 @@ export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
       env: WorkerEnv<Env>,
     ): OnboardingRouteEffect | undefined => {
       const url = new URL(request.url)
+
+      // RESUME READ: GET /api/autopilot/onboarding/{sessionId}/turn/{turnIndex}/stream?offset=
+      const resumeMatch =
+        /^\/api\/autopilot\/onboarding\/([^/]+)\/turn\/(\d+)\/stream$/.exec(
+          url.pathname,
+        )
+      if (resumeMatch !== null) {
+        if (request.method !== 'GET') {
+          return Effect.succeed(methodNotAllowed(['GET']))
+        }
+        return resumeReadResponse(
+          env,
+          decodeURIComponent(resumeMatch[1] ?? ''),
+          Number(resumeMatch[2] ?? '0'),
+          url.searchParams.get('offset') ?? undefined,
+        )
+      }
+
+      // TURN: POST /api/autopilot/onboarding/{sessionId}/turn
       const match =
         /^\/api\/autopilot\/onboarding\/([^/]+)\/turn$/.exec(url.pathname)
 
-      if (match === null) {
-        return undefined
+      if (match !== null) {
+        if (request.method !== 'POST') {
+          return Effect.succeed(methodNotAllowed(['POST']))
+        }
+
+        const sessionId = decodeURIComponent(match[1] ?? '')
+        const makeStreamClient = dependencies.makeStreamClient
+
+        // Content-negotiated: an `Accept: text/event-stream` request streams when
+        // a stream client is wired; otherwise the buffered JSON path serves (and
+        // is the fail-safe default whenever streaming is unavailable).
+        return wantsEventStream(request) && makeStreamClient !== undefined
+          ? streamResponse(request, env, sessionId, makeStreamClient)
+          : turnResponse(request, env, sessionId)
       }
 
-      if (request.method !== 'POST') {
-        return Effect.succeed(methodNotAllowed(['POST']))
+      // GET SESSION: GET /api/autopilot/onboarding/{sessionId}
+      const sessionMatch =
+        /^\/api\/autopilot\/onboarding\/([^/]+)$/.exec(url.pathname)
+      if (sessionMatch !== null) {
+        if (request.method !== 'GET') {
+          return Effect.succeed(methodNotAllowed(['GET']))
+        }
+        return sessionResponse(env, decodeURIComponent(sessionMatch[1] ?? ''))
       }
 
-      const sessionId = decodeURIComponent(match[1] ?? '')
-      const makeStreamClient = dependencies.makeStreamClient
-
-      // Content-negotiated: an `Accept: text/event-stream` request streams when a
-      // stream client is wired; otherwise the buffered JSON path serves (and is
-      // the fail-safe default whenever streaming is unavailable).
-      return wantsEventStream(request) && makeStreamClient !== undefined
-        ? streamResponse(request, env, sessionId, makeStreamClient)
-        : turnResponse(request, env, sessionId)
+      return undefined
     },
   }
 }

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -330,7 +330,12 @@ import {
   isInferenceGatewayEnabled,
 } from './inference/chat-completions-routes'
 import { isComponentChannelEnabled } from './inference/khala-component-channel'
-import { routeDurableInferenceReadRequest } from './inference/durable-inference-read-routes'
+import { type DurableStreamNamespace } from './inference/durable-inference-do-transport'
+import {
+  matchDurableReadRequest,
+  routeDurableInferenceReadRequest,
+  routeDurableInferenceReadRequestDO,
+} from './inference/durable-inference-read-routes'
 import {
   type DiscoverySurfacePath,
   renderDiscoverySurface,
@@ -7121,6 +7126,21 @@ const agentGoalRoutes = makeAgentGoalRoutes({
 const autopilotOnboardingRoutes = makeAutopilotOnboardingRoutes<WorkerBindings>({
   makeInferenceClient: env => makeOnboardingInferenceClient(env),
   makeStreamClient: env => makeOnboardingStreamClient(env),
+  // DURABLE ONBOARDING STREAM (#6154 item 4). The per-request Durable Object
+  // namespace, resolved only when the durable-stream flag is on AND the binding
+  // is wired; absent => the onboarding stream stays the non-durable SSE
+  // (fail-safe). Keyed by the stable id `onboarding:{sessionId}:{turnIndex}` so
+  // an unauthenticated browser can resume a dropped turn by offset.
+  resolveDurableStream: env => {
+    // `env` is the full Worker `Env` at call time; the route's generic narrows it
+    // to `WorkerBindings`, so read the config flag through the broader Env shape.
+    const fullEnv = env as Env
+    return isInferenceDurableStreamEnabled(
+      fullEnv.INFERENCE_DURABLE_STREAM_ENABLED,
+    ) && fullEnv.INFERENCE_DURABLE_STREAM !== undefined
+      ? (fullEnv.INFERENCE_DURABLE_STREAM as unknown as DurableStreamNamespace)
+      : undefined
+  },
 })
 
 const checkoutPageRoutes = makeCheckoutPageRoutes<WorkerBindings>({
@@ -10388,19 +10408,25 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
           // here once a runner host exists. Until then the seam is inert.
           queue: undefined,
         },
-        // DURABLE-STREAM RANK-1 (#6058, EPIC #6056). Flag-gated INERT by default:
-        // with INFERENCE_DURABLE_STREAM_ENABLED off the streaming path is today's
-        // pure pass-through (no persistence/resume). The producer factory is left
-        // undefined here so the LIVE Worker stays inert even with the flag on —
-        // the DO class (`DurableInferenceStreamObject`) + binding
-        // (`INFERENCE_DURABLE_STREAM`) ship deployable, but the per-token producer
-        // write into the DO is wired in a follow-up. Metering still settles
-        // EXACTLY ONCE on the real upstream EOF and NEVER on a replay (proven by
-        // the in-memory durable-proxy tests, which use the SAME StreamStore port
-        // the DO implements).
-        // NEEDS-OWNER: wire the DO-fetch-backed producer factory + the read-route
-        // dispatcher's `durableStream` to `env.INFERENCE_DURABLE_STREAM` here.
+        // DURABLE-STREAM RANK-1 (#6058, EPIC #6056). LIVE when
+        // INFERENCE_DURABLE_STREAM_ENABLED is on AND the DO binding is wired:
+        // every streamed completion is teed into the per-request Durable Object
+        // (`DurableInferenceStreamObject`, keyed `getByName(responseId)`) over the
+        // `/v1/stream/{id}` HTTP contract, so a client disconnect mid-generation
+        // can be resumed by offset via the durable read route. The in-memory
+        // `durableStream` (synchronous `StreamStore`) factory stays undefined here
+        // — it is the test/contract substrate; production uses the DO namespace.
+        // Metering settles EXACTLY ONCE on the real upstream EOF and NEVER on a
+        // replay (the resume route has no metering hook). FAIL-SAFE: with the flag
+        // off OR the binding absent, `durableStreamNamespace` is undefined and the
+        // streaming path is byte-for-byte today's pure pass-through.
         durableStream: undefined,
+        durableStreamNamespace:
+          isInferenceDurableStreamEnabled(
+            env.INFERENCE_DURABLE_STREAM_ENABLED,
+          ) && env.INFERENCE_DURABLE_STREAM !== undefined
+            ? (env.INFERENCE_DURABLE_STREAM as unknown as DurableStreamNamespace)
+            : undefined,
         durableStreamEnabled: isInferenceDurableStreamEnabled(
           env.INFERENCE_DURABLE_STREAM_ENABLED,
         ),
@@ -10811,16 +10837,47 @@ const routeRequest = makeWorkerRouteRequest({
     }),
   // Durable inference resume read GET /v1/chat/completions/durable/{requestId}
   // (durable-stream Rank-1, #6058). Reads stored bytes only — NEVER meters.
-  // Shares the gateway flag AND the durable-stream flag; with the producer
-  // factory left undefined (see the chat route above) this returns 404, so the
-  // surface is honestly inert until the DO producer is wired. Synchronous
-  // Response wrapped into the Effect dispatcher shape.
+  // Shares the gateway flag AND the durable-stream flag. LIVE when both are on
+  // AND the DO binding is wired: resumes from the per-request Durable Object the
+  // chat route's producer teed into. FAIL-SAFE: with the flag off OR the binding
+  // absent, returns an honest 404 (the synchronous fallback path).
   routeDurableInferenceReadRequest: (request, env) => {
+    const enabled =
+      isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED) &&
+      isInferenceDurableStreamEnabled(env.INFERENCE_DURABLE_STREAM_ENABLED)
+    const namespace =
+      enabled && env.INFERENCE_DURABLE_STREAM !== undefined
+        ? (env.INFERENCE_DURABLE_STREAM as unknown as DurableStreamNamespace)
+        : undefined
+    // Production DO-backed resume (async): when the binding is wired, a durable
+    // read URL resolves to an Effect that reads the per-request DO; a non-durable
+    // URL falls through (undefined). The URL match is synchronous, so the
+    // dispatcher contract (`Effect<Response> | undefined`) is honored: undefined
+    // only for a non-match.
+    if (namespace !== undefined) {
+      if (matchDurableReadRequest(request) === undefined) {
+        return undefined
+      }
+      return Effect.promise(() =>
+        routeDurableInferenceReadRequestDO(request, { enabled, namespace }).then(
+          // A matched durable URL with the namespace present always yields a
+          // Response; the `?? notFound` is a defensive total fallback.
+          response =>
+            response ??
+            new Response(JSON.stringify({ error: 'not_found' }), {
+              headers: {
+                'cache-control': 'no-store',
+                'content-type': 'application/json',
+              },
+              status: 404,
+            }),
+        ),
+      )
+    }
+    // Fail-safe synchronous path (binding absent / flag off): honest 404.
     const response = routeDurableInferenceReadRequest(request, {
       durableStream: undefined,
-      enabled:
-        isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED) &&
-        isInferenceDurableStreamEnabled(env.INFERENCE_DURABLE_STREAM_ENABLED),
+      enabled,
       nowEpochMillis: currentEpochMillis,
     })
     return response === undefined ? undefined : Effect.succeed(response)

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -65,6 +65,10 @@ import {
   teeUpstreamToDurable,
 } from './durable-inference-proxy'
 import {
+  type DurableStreamNamespace,
+  teeUpstreamToDurableDO,
+} from './durable-inference-do-transport'
+import {
   type FairShareDecision,
   type SpendCapDecision,
 } from './inference-abuse-controls'
@@ -367,6 +371,15 @@ export type ChatCompletionsDeps = Readonly<{
   // resume/replay read (the resume route has no metering hook).
   durableStreamEnabled?: boolean | undefined
   durableStream?: DurableInferenceStreamStore | undefined
+  // PRODUCTION DURABLE SUBSTRATE (#6058). When present AND `durableStreamEnabled`
+  // is true, the streaming completion is teed into the per-request Durable Object
+  // (`DurableInferenceStreamObject`, keyed `getByName(responseId)`) over the
+  // `/v1/stream/{id}` HTTP contract — the DO is the single authoritative durable
+  // log a LATER GET resume reads. This is the live wiring; `durableStream` (the
+  // synchronous `StreamStore` factory) is the in-memory test/contract substrate.
+  // When both are present the DO namespace wins. Absent (e.g. the binding is
+  // unbound on an env) => fail-safe non-durable pass-through.
+  durableStreamNamespace?: DurableStreamNamespace | undefined
   // TYPED COMPONENT CHANNEL SEAM (EPIC #6123, issue #6127). The ADDITIVE,
   // OPT-IN `oa.component` SSE channel: a Khala turn may stream prose PLUS one or
   // more validated, versioned `oa.component` cards from the CLOSED v1 catalog
@@ -1130,6 +1143,12 @@ const makePassThroughResponseStream = (
     // `responseId` so a client disconnect mid-generation can be resumed by offset.
     // ABSENT => today's pure pass-through, byte-for-byte unchanged (fail-safe).
     durableStore?: StreamStore | undefined
+    // PRODUCTION DURABLE SUBSTRATE (#6058). When present, every upstream frame is
+    // teed into the per-request Durable Object (`getByName(responseId)`) over the
+    // `/v1/stream/{id}` HTTP contract — the authoritative durable log a later GET
+    // resume reads. Takes precedence over `durableStore` (the in-memory test
+    // substrate) when both are present. Absent => non-durable pass-through.
+    durableNamespace?: DurableStreamNamespace | undefined
     // Deterministic clock for the durable log (TTL/offset bookkeeping). Defaults
     // to a fixed epoch in tests; the route threads `currentEpochMillis`.
     durableNowMs?: number | undefined
@@ -1260,6 +1279,36 @@ const makePassThroughResponseStream = (
       // Telemetry: the first observed content delta (TTFT boundary). Captured on
       // BOTH the durable and non-durable drains so streaming TTFT is real.
       let firstTokenMs: number | undefined
+      // PRODUCTION DURABLE PATH (#6058). Tee each upstream frame into the
+      // per-request Durable Object over the `/v1/stream/{id}` HTTP contract AND
+      // to the client. The DO is the authoritative durable log a later GET
+      // resume reads. Metering settles EXACTLY ONCE in the `onEof` callback (the
+      // producer drain), never in the DO and never on replay. A DO-fetch fault
+      // degrades the durable mirror but never breaks the live completion.
+      if (input.durableNamespace !== undefined) {
+        await teeUpstreamToDurableDO({
+          emit: frame => {
+            if (firstTokenMs === undefined) {
+              firstTokenMs = telemetryNow()
+            }
+            controller.enqueue(encoder.encode(frame))
+          },
+          frameForDelta: delta => chunkFrame(delta, null),
+          namespace: input.durableNamespace,
+          onEof: (terminal, content) =>
+            buildTerminalFrame(terminal, content, {
+              eofMs: telemetryNow(),
+              firstTokenMs,
+            }),
+          requestId: input.responseId,
+          source: input.source,
+        })
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+        return
+      }
+      // IN-MEMORY DURABLE PATH (test/contract substrate). Same guarantees against
+      // the synchronous `StreamStore` port the DO implements.
       if (input.durableStore !== undefined) {
         await teeUpstreamToDurable({
           emit: frame => {
@@ -1702,6 +1751,18 @@ export const handleChatCompletions = (
           deps.durableStreamEnabled === true && deps.durableStream !== undefined
             ? resolveDurableStore(deps.durableStream, responseId)
             : undefined
+        // PRODUCTION DURABLE SUBSTRATE (#6058): the per-request Durable Object,
+        // resolved only when the flag is on AND the binding is wired. Takes
+        // precedence over the in-memory `durableStore` test substrate.
+        const durableNamespace: DurableStreamNamespace | undefined =
+          deps.durableStreamEnabled === true &&
+          deps.durableStreamNamespace !== undefined
+            ? deps.durableStreamNamespace
+            : undefined
+        // The completion is being persisted (and is resumable) when EITHER durable
+        // substrate is active.
+        const durablePersisting =
+          durableNamespace !== undefined || durableStore !== undefined
         const responseStream = makePassThroughResponseStream({
           accountRef: session.accountRef,
           adapterId,
@@ -1709,6 +1770,7 @@ export const handleChatCompletions = (
           created,
           durableNowMs: nowEpochMillis(),
           durableStore,
+          ...(durableNamespace === undefined ? {} : { durableNamespace }),
           fundingKind,
           meteringHook,
           // TELEMETRY CLOCK (book P0-1): the TRUE pass-through path is where TTFT
@@ -1727,7 +1789,7 @@ export const handleChatCompletions = (
             // Advertise the resumable read URL only when the completion is being
             // persisted. The opaque request id carries no prompt/credential
             // material, so this header is safe (INVARIANTS: no leakage).
-            ...(durableStore !== undefined
+            ...(durablePersisting
               ? {
                   'openagents-durable-stream-url':
                     durableInferenceReadUrl(responseId),

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-do-transport.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-do-transport.test.ts
@@ -1,0 +1,362 @@
+// DO-fetch transport tests (durable-stream Rank-1, #6058). These prove the
+// PRODUCTION wiring — the async `/v1/stream/{id}` HTTP transport to the per-request
+// Durable Object — against the package's REAL `core.ts` + `http.ts` code paths
+// (`TestStreamRegistry`, the same in-memory backend the conformance suite drives,
+// keying one `MemoryStreamStore` per stream id exactly as the DO keys one DO per
+// request id). This is the strongest oracle short of a live Workers runtime:
+//
+//   1. a streamed completion PERSISTS every frame to the DO log;
+//   2. a CROSS-INVOCATION resume (a separate `replayFromOffsetDO` call, as a later
+//      Worker invocation would do) replays the suffix from a mid-stream offset and
+//      reconstructs the FULL completion — streaming-equivalence;
+//   3. metering fires EXACTLY ONCE on the real upstream EOF and NEVER on a replay;
+//   4. an upstream fault closes the DO stream WITHOUT metering (receipt-first);
+//   5. a DO-fetch fault degrades the durable mirror but NEVER breaks the live
+//      client stream and still meters once on EOF (fail-safe).
+
+import {
+  MemoryStreamStore,
+  type StreamStore,
+  handleRequest,
+  streamIdFromUrl,
+} from '@openagentsinc/durable-stream'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type DurableStreamNamespace,
+  replayFromOffsetDO,
+  teeUpstreamToDurableDO,
+} from './durable-inference-do-transport'
+import {
+  type InferenceStreamEvent,
+  type InferenceStreamSource,
+  type InferenceUsage,
+} from './provider-adapter'
+
+// A minimal in-process Durable Streams backend: one `MemoryStreamStore` per
+// stream id, routed through the package's REAL `handleRequest` (`core.ts` +
+// `http.ts`) — the SAME code the Cloudflare DO runs internally
+// (`handleDurableStreamFetch`). So this fake exercises actual DO behavior, not a
+// re-implementation.
+class StreamRegistry {
+  private readonly stores = new Map<string, StreamStore>()
+
+  private storeFor(streamId: string): StreamStore {
+    let s = this.stores.get(streamId)
+    if (s === undefined) {
+      s = new MemoryStreamStore()
+      this.stores.set(streamId, s)
+    }
+    return s
+  }
+
+  fetch(request: Request): Promise<Response> {
+    const streamId = streamIdFromUrl(request.url)
+    if (streamId === null) {
+      return Promise.resolve(new Response('not a stream url', { status: 404 }))
+    }
+    return handleRequest(this.storeFor(streamId), request, { streamId })
+  }
+}
+
+// A `DurableStreamNamespace` whose `getByName(id).fetch(req)` delegates to a
+// shared `StreamRegistry`.
+const fakeNamespace = (
+  registry: StreamRegistry = new StreamRegistry(),
+): DurableStreamNamespace => ({
+  getByName: (_name: string) => ({
+    fetch: (request: Request) => registry.fetch(request),
+  }),
+})
+
+// A `DurableStreamNamespace` whose stub `.fetch` always rejects — models a DO
+// transport fault (binding present but the DO is unreachable).
+const faultingNamespace = (): DurableStreamNamespace => ({
+  getByName: () => ({
+    fetch: () => Promise.reject(new Error('DO unreachable')),
+  }),
+})
+
+const usage: InferenceUsage = {
+  completionTokens: 5,
+  promptTokens: 9,
+  totalTokens: 14,
+}
+
+const source = (
+  script: ReadonlyArray<InferenceStreamEvent>,
+  terminal: Readonly<{
+    finishReason: string | undefined
+    usage: InferenceUsage | undefined
+    servedModel: string | undefined
+  }>,
+  options: { readonly fault?: boolean } = {},
+): InferenceStreamSource => ({
+  frames: (async function* () {
+    for (const event of script) {
+      yield event
+    }
+    if (options.fault === true) {
+      throw new Error('upstream faulted')
+    }
+  })(),
+  terminal: () => terminal,
+})
+
+// Drive `teeUpstreamToDurableDO`, collecting emitted client frames + the metering
+// count (the `onEof` callback is where the route meters).
+const drive = async (input: {
+  namespace: DurableStreamNamespace
+  requestId: string
+  src: InferenceStreamSource
+}) => {
+  const emitted: Array<string> = []
+  let meterCount = 0
+  const outcome = await teeUpstreamToDurableDO({
+    emit: frame => emitted.push(frame),
+    frameForDelta: delta => `data: {"delta":${JSON.stringify(delta)}}\n\n`,
+    namespace: input.namespace,
+    onEof: async (terminal, content) => {
+      if (terminal.usage !== undefined) {
+        meterCount += 1
+      }
+      return `data: {"done":true,"content":${JSON.stringify(content)}}\n\n`
+    },
+    requestId: input.requestId,
+    source: input.src,
+  })
+  return { emitted, meterCount, outcome }
+}
+
+describe('durable inference DO transport — persistence + cross-invocation resume', () => {
+  test('a streamed completion persists every frame to the per-request DO log', async () => {
+    const namespace = fakeNamespace()
+    const { outcome } = await drive({
+      namespace,
+      requestId: 'req-persist',
+      src: source([{ contentDelta: 'Hel' }, { contentDelta: 'lo' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage,
+      }),
+    })
+
+    expect(outcome.faulted).toBe(false)
+    expect(outcome.content).toBe('Hello')
+
+    // A SEPARATE read (a later Worker invocation) reconstructs the full log from
+    // offset 0 — both deltas + the terminal frame.
+    const full = await replayFromOffsetDO({
+      namespace,
+      offset: '0',
+      requestId: 'req-persist',
+    })
+    expect(full).toBeDefined()
+    expect(full!.body).toContain('"Hel"')
+    expect(full!.body).toContain('"lo"')
+    expect(full!.body).toContain('"done":true')
+    expect(full!.streamClosed).toBe(true)
+  })
+
+  test('a mid-stream disconnect + cross-invocation resume replays the suffix and reconstructs the full completion (streaming-equivalence)', async () => {
+    const namespace = fakeNamespace()
+    const { emitted } = await drive({
+      namespace,
+      requestId: 'req-resume',
+      src: source(
+        [
+          { contentDelta: 'AAA' },
+          { contentDelta: 'BBB' },
+          { contentDelta: 'CCC' },
+        ],
+        { finishReason: 'stop', servedModel: 'served/m', usage },
+      ),
+    })
+
+    // SIMULATE A DISCONNECT: the client only received the first frame. Resume
+    // from the offset after that frame — as a fresh Worker invocation would, with
+    // only the client-held last offset.
+    const firstReadBytes = new TextEncoder().encode(emitted[0]!).length
+    const resume = await replayFromOffsetDO({
+      namespace,
+      offset: String(firstReadBytes),
+      requestId: 'req-resume',
+    })
+    expect(resume).toBeDefined()
+    // The resumed suffix carries BBB + CCC + the terminal frame, not AAA.
+    expect(resume!.body).not.toContain('"AAA"')
+    expect(resume!.body).toContain('"BBB"')
+    expect(resume!.body).toContain('"CCC"')
+    expect(resume!.body).toContain('"done":true')
+    expect(resume!.streamClosed).toBe(true)
+
+    // The full completion = the first frame the client kept + the resumed suffix.
+    const reconstructed = emitted[0]! + resume!.body
+    expect(reconstructed).toContain('"AAA"')
+    expect(reconstructed).toContain('"BBB"')
+    expect(reconstructed).toContain('"CCC"')
+  })
+
+  test('mid-stream resume works while the stream is still OPEN (before EOF)', async () => {
+    // Drive the producer manually so we can read the DO BEFORE the terminal frame
+    // is appended — the real "client dropped mid-generation" case.
+    const registry = new StreamRegistry()
+    const namespace = fakeNamespace(registry)
+    const requestId = 'req-open'
+
+    let resolveSecond: (() => void) | undefined
+    const secondGate = new Promise<void>(resolve => {
+      resolveSecond = resolve
+    })
+
+    const src: InferenceStreamSource = {
+      frames: (async function* () {
+        yield { contentDelta: 'one' }
+        // Pause after the first frame so a reader can observe an OPEN stream.
+        await secondGate
+        yield { contentDelta: 'two' }
+      })(),
+      terminal: () => ({
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage,
+      }),
+    }
+
+    let meterCount = 0
+    const producer = teeUpstreamToDurableDO({
+      emit: () => {},
+      frameForDelta: delta => `data: {"delta":${JSON.stringify(delta)}}\n\n`,
+      namespace,
+      onEof: async () => {
+        meterCount += 1
+        return `data: {"done":true}\n\n`
+      },
+      requestId,
+      source: src,
+    })
+
+    // Give the first frame time to persist, then read the OPEN stream.
+    await new Promise(resolve => setTimeout(resolve, 5))
+    const openRead = await replayFromOffsetDO({
+      namespace,
+      offset: '0',
+      requestId,
+    })
+    expect(openRead).toBeDefined()
+    expect(openRead!.body).toContain('"one"')
+    // The stream is NOT closed yet — generation is still in flight.
+    expect(openRead!.streamClosed).toBe(false)
+    expect(meterCount).toBe(0)
+
+    // Let the producer finish.
+    resolveSecond?.()
+    await producer
+    expect(meterCount).toBe(1)
+  })
+})
+
+describe('durable inference DO transport — METERING EXACTLY ONCE', () => {
+  test('metering fires exactly once on the real upstream EOF', async () => {
+    const namespace = fakeNamespace()
+    const { meterCount, outcome } = await drive({
+      namespace,
+      requestId: 'req-meter-once',
+      src: source([{ contentDelta: 'hi' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage,
+      }),
+    })
+    expect(outcome.faulted).toBe(false)
+    expect(meterCount).toBe(1)
+  })
+
+  test('metering does NOT fire on replay / resume reads', async () => {
+    const namespace = fakeNamespace()
+    const first = await drive({
+      namespace,
+      requestId: 'req-no-rebill',
+      src: source([{ contentDelta: 'x' }, { contentDelta: 'y' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage,
+      }),
+    })
+    expect(first.meterCount).toBe(1)
+
+    // Many reconnects / catch-up reads. `replayFromOffsetDO` has NO metering hook,
+    // so none can re-bill.
+    for (let i = 0; i < 5; i++) {
+      const replay = await replayFromOffsetDO({
+        namespace,
+        offset: '0',
+        requestId: 'req-no-rebill',
+      })
+      expect(replay).toBeDefined()
+    }
+    // Still exactly one settlement from the single producer drain.
+    expect(first.meterCount).toBe(1)
+  })
+
+  test('an upstream fault closes the DO stream WITHOUT metering (receipt-first)', async () => {
+    const namespace = fakeNamespace()
+    const { meterCount, outcome } = await drive({
+      namespace,
+      requestId: 'req-fault',
+      src: source(
+        [{ contentDelta: 'partial' }],
+        { finishReason: undefined, servedModel: undefined, usage: undefined },
+        { fault: true },
+      ),
+    })
+    // The upstream faulted: no terminal frame, no metering.
+    expect(outcome.faulted).toBe(true)
+    expect(meterCount).toBe(0)
+
+    // The partial content is still durable + the stream is closed (a reconnect
+    // sees the closed partial completion).
+    const replay = await replayFromOffsetDO({
+      namespace,
+      offset: '0',
+      requestId: 'req-fault',
+    })
+    expect(replay).toBeDefined()
+    expect(replay!.body).toContain('"partial"')
+    expect(replay!.streamClosed).toBe(true)
+  })
+})
+
+describe('durable inference DO transport — FAIL-SAFE', () => {
+  test('a DO-fetch fault degrades the durable mirror but never breaks the live stream and still meters once', async () => {
+    const namespace = faultingNamespace()
+    const { emitted, meterCount, outcome } = await drive({
+      namespace,
+      requestId: 'req-do-down',
+      src: source([{ contentDelta: 'aa' }, { contentDelta: 'bb' }], {
+        finishReason: 'stop',
+        servedModel: 'served/m',
+        usage,
+      }),
+    })
+
+    // The client STILL received every frame (deltas + terminal), and metering
+    // settled exactly once — the broken durable substrate did not break the
+    // completion. Resume is simply unavailable (the DO is down).
+    expect(outcome.faulted).toBe(false)
+    expect(emitted.some(f => f.includes('"aa"'))).toBe(true)
+    expect(emitted.some(f => f.includes('"bb"'))).toBe(true)
+    expect(emitted.some(f => f.includes('"done":true'))).toBe(true)
+    expect(meterCount).toBe(1)
+  })
+
+  test('replayFromOffsetDO returns undefined for an unknown request id (404)', async () => {
+    const namespace = fakeNamespace()
+    const replay = await replayFromOffsetDO({
+      namespace,
+      offset: '0',
+      requestId: 'never-created',
+    })
+    expect(replay).toBeUndefined()
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-do-transport.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-do-transport.ts
@@ -1,0 +1,256 @@
+// DO-fetch transport for the durable inference stream (durable-stream Rank-1,
+// #6058, EPIC #6056). This is the PRODUCTION wiring of the durable proxy: it
+// speaks the EXACT `/v1/stream/{id}` HTTP contract the
+// `@openagentsinc/durable-stream` Durable Object (`DurableInferenceStreamObject`)
+// serves (`handleDurableStreamFetch`), so the per-request DO is the single
+// authoritative durable log.
+//
+// WHY A SEPARATE ASYNC TRANSPORT (not the sync `StreamStore` proxy):
+// `durable-inference-proxy.ts` drives a SYNCHRONOUS `StreamStore` — which models
+// the inside of ONE stream's DO running its SQLite synchronously. A remote DO is
+// reached over an ASYNC `stub.fetch()`, so the sync port cannot back it. This
+// module rebuilds the SAME wire requests (PUT create, POST append with the
+// `(producer-id, epoch, seq)` idempotency tuple + optional `stream-closed`, GET
+// replay with `?offset=`) and sends them via `fetch()` to the DO stub. The DO
+// then runs the package's sync core internally, so the offset/idempotency/EOF
+// guarantees are byte-identical to the unit-tested in-memory path.
+//
+// ┌─────────────────── METERING EXACTLY-ONCE (the money path) ────────────────┐
+// │ Metering lives ENTIRELY in the route's `onEof` callback (the producer      │
+// │ drain), NOT in this transport and NOT in the DO. `teeUpstreamToDurableDO`  │
+// │ calls `onEof` EXACTLY ONCE on a clean upstream drain and NEVER on the fault │
+// │ path. `replayFromOffsetDO` reads stored bytes ONLY — it has no metering     │
+// │ hook. Replays + catch-up reads are therefore free, exactly as the          │
+// │ in-memory proxy guarantees.                                                 │
+// └────────────────────────────────────────────────────────────────────────────┘
+//
+// FAIL-SAFE: a DO-fetch failure in the producer must NOT break the live client
+// completion. Persist errors stop the durable mirror but the client keeps
+// receiving its tokens and metering still settles on EOF — a broken durable
+// substrate degrades to today's non-durable pass-through behaviour.
+
+import {
+  DURABLE_INFERENCE_CONTENT_TYPE,
+  DURABLE_INFERENCE_TTL_SECONDS,
+  type DurableProducerOutcome,
+  type DurableReplay,
+} from './durable-inference-proxy'
+import { type InferenceStreamSource } from './provider-adapter'
+
+// Structural typing for the DO namespace + stub surface, matching the package's
+// own convention of typing the Cloudflare runtime locally rather than depending
+// on `@cloudflare/workers-types` here. `getByName` is the repo's modern DO API
+// (runtime.ts), returning a stub whose `.fetch()` is the DO's `fetch()`.
+export interface DurableStreamStub {
+  fetch(request: Request): Promise<Response>
+}
+export interface DurableStreamNamespace {
+  getByName(name: string): DurableStreamStub
+}
+
+// The stable idempotent-producer id for a request's durable stream (must match
+// the sync proxy's `PRODUCER_ID` so the wire format is identical).
+const PRODUCER_ID = 'khala-gateway'
+
+// The DO addresses streams at `/v1/stream/{streamId}` (durable-stream `http.ts`
+// `STREAM_URL_PREFIX`). The host is arbitrary — the stub routes by name, not by
+// host — so we use an opaque internal origin.
+const streamUrl = (streamId: string): string =>
+  `https://durable-inference-stream/v1/stream/${encodeURIComponent(streamId)}`
+
+const encoder = new TextEncoder()
+
+// PUT-create the per-request durable stream (idempotent: re-create with the same
+// config returns 200; first create 201). Returns false when the DO rejects
+// creation (treated as "durable unavailable" → caller fails safe).
+const ensureStreamDO = async (
+  stub: DurableStreamStub,
+  streamId: string,
+): Promise<boolean> => {
+  const res = await stub.fetch(
+    new Request(streamUrl(streamId), {
+      method: 'PUT',
+      headers: {
+        'content-type': DURABLE_INFERENCE_CONTENT_TYPE,
+        'stream-ttl': String(DURABLE_INFERENCE_TTL_SECONDS),
+      },
+    }),
+  )
+  return res.status === 200 || res.status === 201
+}
+
+// POST one persisted frame as the producer's `seq`-th record (exactly-once via
+// the `(producer-id, epoch, seq)` tuple the DO dedups on). When `close` is set
+// the append also closes the stream (the completion EOF).
+const appendFrameDO = async (
+  stub: DurableStreamStub,
+  streamId: string,
+  seq: number,
+  frame: string,
+  close: boolean,
+): Promise<void> => {
+  const headers: Record<string, string> = {
+    'content-type': DURABLE_INFERENCE_CONTENT_TYPE,
+    'producer-epoch': '0',
+    'producer-id': PRODUCER_ID,
+    'producer-seq': String(seq),
+  }
+  if (close) {
+    headers['stream-closed'] = 'true'
+  }
+  await stub.fetch(
+    new Request(streamUrl(streamId), {
+      method: 'POST',
+      headers,
+      body: encoder.encode(frame),
+    }),
+  )
+}
+
+// Close the durable stream at the producer's `seq`-th record without bytes (the
+// EOF for an empty/terminal-only or faulted completion).
+const closeStreamDO = async (
+  stub: DurableStreamStub,
+  streamId: string,
+  seq: number,
+): Promise<void> => {
+  await stub.fetch(
+    new Request(streamUrl(streamId), {
+      method: 'POST',
+      headers: {
+        'producer-epoch': '0',
+        'producer-id': PRODUCER_ID,
+        'producer-seq': String(seq),
+        'stream-closed': 'true',
+      },
+    }),
+  )
+}
+
+// Tee the upstream `InferenceStreamSource` into the DO durable log AND to the
+// live client. The DO-fetch analogue of `teeUpstreamToDurable`: each upstream
+// content delta is (1) persisted to the DO as a durable frame and (2) emitted to
+// the client. On clean drain the terminal frame is persisted and the stream is
+// CLOSED (EOF) and metering fires ONCE via `onEof`. On an upstream fault the
+// partial content stays durable and the stream is closed WITHOUT a terminal
+// frame (no metering — receipt-first).
+//
+// PERSIST-BEFORE-EMIT: each frame is awaited into the DO before it is emitted to
+// the client, so the durable log is always ahead of (or equal to) what the
+// client saw — a resume can only ever replay MORE, never less.
+//
+// FAIL-SAFE: if a DO persist throws (transport fault), we STOP persisting but
+// keep draining + emitting to the client so the completion still lands and
+// metering still settles. The durable mirror is best-effort; the live stream is
+// authoritative for the client.
+export const teeUpstreamToDurableDO = async (input: {
+  readonly namespace: DurableStreamNamespace
+  readonly requestId: string
+  readonly frameForDelta: (delta: string) => string
+  readonly onEof: (
+    terminal: ReturnType<InferenceStreamSource['terminal']>,
+    content: string,
+  ) => Promise<string>
+  readonly emit: (frame: string) => void
+  readonly source: InferenceStreamSource
+}): Promise<DurableProducerOutcome> => {
+  const { emit, frameForDelta, namespace, onEof, requestId, source } = input
+
+  const stub = namespace.getByName(requestId)
+  let durable = await ensureStreamDO(stub, requestId).catch(() => false)
+
+  const contentParts: Array<string> = []
+  let seq = 0
+
+  // Persist a frame, degrading `durable` to false (and swallowing the error) on
+  // any DO transport fault so the live client stream is never broken.
+  const persist = async (frame: string, close: boolean): Promise<void> => {
+    if (!durable) {
+      return
+    }
+    try {
+      await appendFrameDO(stub, requestId, seq, frame, close)
+    } catch {
+      durable = false
+    }
+  }
+
+  try {
+    for await (const event of source.frames) {
+      if (event.contentDelta !== '') {
+        contentParts.push(event.contentDelta)
+        const frame = frameForDelta(event.contentDelta)
+        await persist(frame, false)
+        if (durable) {
+          seq += 1
+        }
+        emit(frame)
+      }
+    }
+  } catch {
+    // Upstream faulted mid-flight. Close the durable stream WITHOUT a terminal
+    // frame so metering does NOT settle (receipt-first). Best-effort: a close
+    // failure is swallowed.
+    if (durable) {
+      await closeStreamDO(stub, requestId, seq).catch(() => {})
+    }
+    return {
+      content: contentParts.join(''),
+      faulted: true,
+      terminal: undefined,
+    }
+  }
+
+  // Clean drain: the SINGLE real EOF. Run the route's metering-once + receipt
+  // builder, persist the terminal frame, close the stream (Stream-Closed), and
+  // emit the terminal frame to the live client. Metering happens inside `onEof`
+  // regardless of whether the durable mirror is still healthy.
+  const terminal = source.terminal()
+  const terminalFrame = await onEof(terminal, contentParts.join(''))
+  await persist(terminalFrame, true)
+  emit(terminalFrame)
+
+  return {
+    content: contentParts.join(''),
+    faulted: false,
+    terminal,
+  }
+}
+
+// Resume/replay read of a durable completion from `offset`, via the DO. The
+// DO-fetch analogue of `replayFromOffset`: returns the stored SSE byte suffix,
+// the next offset to resume from, and whether the stream is closed (EOF). THIS
+// PATH NEVER METERS — it issues a GET to the DO and reads stored bytes only.
+// Returns `undefined` when the DO reports the stream does not exist (404).
+export const replayFromOffsetDO = async (input: {
+  readonly namespace: DurableStreamNamespace
+  readonly requestId: string
+  readonly offset: string | undefined
+}): Promise<DurableReplay | undefined> => {
+  const { namespace, offset, requestId } = input
+
+  const stub = namespace.getByName(requestId)
+  const url = new URL(streamUrl(requestId))
+  if (offset !== undefined) {
+    url.searchParams.set('offset', offset)
+  }
+
+  const res = await stub.fetch(new Request(url.toString(), { method: 'GET' }))
+
+  // Unknown request id → no durable stream for it.
+  if (res.status === 404) {
+    return undefined
+  }
+
+  const bodyText = await res.text()
+  const headerOffset = res.headers.get('stream-next-offset')
+  return {
+    body: bodyText,
+    contentType:
+      res.headers.get('content-type') ?? DURABLE_INFERENCE_CONTENT_TYPE,
+    nextOffset: headerOffset ?? offset ?? '',
+    status: res.status,
+    streamClosed: res.headers.get('stream-closed') === 'true',
+    upToDate: res.headers.get('stream-up-to-date') === 'true',
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.test.ts
@@ -4,14 +4,26 @@
 // persisted suffix with the resume headers; and it NEVER meters (it has no
 // metering hook at all — it reads stored bytes only).
 
-import { MemoryStreamStore } from '@openagentsinc/durable-stream'
+import {
+  MemoryStreamStore,
+  type StreamStore,
+  handleRequest,
+  streamIdFromUrl,
+} from '@openagentsinc/durable-stream'
 import { describe, expect, test } from 'vitest'
 
+import {
+  type DurableStreamNamespace,
+  teeUpstreamToDurableDO,
+} from './durable-inference-do-transport'
 import {
   durableInferenceReadUrl,
   teeUpstreamToDurable,
 } from './durable-inference-proxy'
-import { routeDurableInferenceReadRequest } from './durable-inference-read-routes'
+import {
+  routeDurableInferenceReadRequest,
+  routeDurableInferenceReadRequestDO,
+} from './durable-inference-read-routes'
 import {
   type InferenceStreamSource,
   type InferenceUsage,
@@ -151,6 +163,127 @@ describe('routeDurableInferenceReadRequest', () => {
         enabled: true,
         nowEpochMillis: () => NOW,
       },
+    )
+    expect(result?.status).toBe(400)
+  })
+})
+
+// In-process DO backend (one MemoryStreamStore per stream id via the package's
+// real handleRequest) — the same backend the DO runs internally.
+class StreamRegistry {
+  private readonly stores = new Map<string, StreamStore>()
+  private storeFor(streamId: string): StreamStore {
+    let s = this.stores.get(streamId)
+    if (s === undefined) {
+      s = new MemoryStreamStore()
+      this.stores.set(streamId, s)
+    }
+    return s
+  }
+  fetch(request: Request): Promise<Response> {
+    const streamId = streamIdFromUrl(request.url)
+    if (streamId === null) {
+      return Promise.resolve(new Response('nope', { status: 404 }))
+    }
+    return handleRequest(this.storeFor(streamId), request, { streamId })
+  }
+}
+
+const doNamespace = (
+  registry: StreamRegistry = new StreamRegistry(),
+): DurableStreamNamespace => ({
+  getByName: () => ({ fetch: (r: Request) => registry.fetch(r) }),
+})
+
+const seedDO = async (namespace: DurableStreamNamespace, requestId: string) => {
+  const src: InferenceStreamSource = {
+    frames: (async function* () {
+      yield { contentDelta: 'AAA' }
+      yield { contentDelta: 'BBB' }
+    })(),
+    terminal: () => ({ finishReason: 'stop', servedModel: 'm', usage }),
+  }
+  await teeUpstreamToDurableDO({
+    emit: () => {},
+    frameForDelta: delta => `data: ${delta}\n\n`,
+    namespace,
+    onEof: async () => 'data: [done]\n\n',
+    requestId,
+    source: src,
+  })
+}
+
+describe('routeDurableInferenceReadRequestDO (production DO-backed resume)', () => {
+  test('returns undefined for a non-durable URL (router falls through)', async () => {
+    const result = await routeDurableInferenceReadRequestDO(
+      req('/v1/chat/completions'),
+      { enabled: true, namespace: doNamespace() },
+    )
+    expect(result).toBeUndefined()
+  })
+
+  test('404 when the flag is off or the binding is absent', async () => {
+    const offFlag = await routeDurableInferenceReadRequestDO(
+      req(durableInferenceReadUrl('req-1')),
+      { enabled: false, namespace: doNamespace() },
+    )
+    expect(offFlag?.status).toBe(404)
+
+    const noBinding = await routeDurableInferenceReadRequestDO(
+      req(durableInferenceReadUrl('req-1')),
+      { enabled: true, namespace: undefined },
+    )
+    expect(noBinding?.status).toBe(404)
+  })
+
+  test('405 on a non-GET method', async () => {
+    const result = await routeDurableInferenceReadRequestDO(
+      req(durableInferenceReadUrl('req-1'), 'POST'),
+      { enabled: true, namespace: doNamespace() },
+    )
+    expect(result?.status).toBe(405)
+  })
+
+  test('404 for an unknown request id', async () => {
+    const result = await routeDurableInferenceReadRequestDO(
+      req(durableInferenceReadUrl('never')),
+      { enabled: true, namespace: doNamespace() },
+    )
+    expect(result?.status).toBe(404)
+  })
+
+  test('replays the persisted suffix from the DO with resume headers and never meters', async () => {
+    const namespace = doNamespace()
+    await seedDO(namespace, 'req-read')
+
+    const full = await routeDurableInferenceReadRequestDO(
+      req(`${durableInferenceReadUrl('req-read')}?offset=0`),
+      { enabled: true, namespace },
+    )
+    expect(full?.status).toBe(200)
+    expect(full?.headers.get('stream-closed')).toBe('true')
+    expect(full?.headers.get('stream-next-offset')).not.toBeNull()
+    const fullBody = await full!.text()
+    expect(fullBody).toContain('AAA')
+    expect(fullBody).toContain('BBB')
+
+    const firstFrameBytes = new TextEncoder().encode('data: AAA\n\n').length
+    const suffix = await routeDurableInferenceReadRequestDO(
+      req(`${durableInferenceReadUrl('req-read')}?offset=${firstFrameBytes}`),
+      { enabled: true, namespace },
+    )
+    expect(suffix?.status).toBe(200)
+    const suffixBody = await suffix!.text()
+    expect(suffixBody).not.toContain('AAA')
+    expect(suffixBody).toContain('BBB')
+  })
+
+  test('400 on a malformed offset', async () => {
+    const namespace = doNamespace()
+    await seedDO(namespace, 'req-bad')
+    const result = await routeDurableInferenceReadRequestDO(
+      req(`${durableInferenceReadUrl('req-bad')}?offset=nope!`),
+      { enabled: true, namespace },
     )
     expect(result?.status).toBe(400)
   })

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.ts
@@ -20,8 +20,13 @@
 
 import {
   type DurableInferenceStreamStore,
+  type DurableReplay,
   replayFromOffset,
 } from './durable-inference-proxy'
+import {
+  type DurableStreamNamespace,
+  replayFromOffsetDO,
+} from './durable-inference-do-transport'
 
 const DURABLE_PREFIX = '/v1/chat/completions/durable/'
 
@@ -48,68 +53,24 @@ const requestIdFromPath = (pathname: string): string | undefined => {
   return decodeURIComponent(raw)
 }
 
-// Dispatch a durable inference read. Returns `undefined` when the request is not
-// a durable read URL (the worker router falls through). When it IS a durable read
-// URL but the gateway is off / unwired / the id is unknown, returns the matching
-// 404/400/200 Response so the surface is honest.
-export const routeDurableInferenceReadRequest = (
-  request: Request,
-  deps: DurableInferenceReadDeps,
-): Response | undefined => {
-  const url = new URL(request.url)
-  const requestId = requestIdFromPath(url.pathname)
-  if (requestId === undefined) {
-    return undefined
-  }
-
-  // Shares the gateway flag: inert/404 when the gateway is off.
-  if (!deps.enabled || deps.durableStream === undefined) {
-    return new Response(JSON.stringify({ error: 'not_found' }), {
-      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
-      status: 404,
-    })
-  }
-
-  if (request.method !== 'GET') {
-    return new Response(JSON.stringify({ error: 'method_not_allowed' }), {
-      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
-      status: 405,
-    })
-  }
-
-  const store = deps.durableStream(requestId)
-  if (store === undefined) {
-    return new Response(JSON.stringify({ error: 'not_found' }), {
-      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
-      status: 404,
-    })
-  }
-
-  const replay = replayFromOffset({
-    nowMs: deps.nowEpochMillis(),
-    offset: url.searchParams.get('offset') ?? undefined,
-    requestId,
-    store,
+const jsonError = (error: string, status: number): Response =>
+  new Response(JSON.stringify({ error }), {
+    headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
+    status,
   })
 
-  // Unknown request id (no durable stream) → 404.
+// Map a `DurableReplay` (from EITHER the sync store or the DO transport) to the
+// resume Response. `undefined` (unknown request id) → 404; status 400 (malformed
+// offset) → 400; otherwise the stored SSE suffix with the resume headers.
+const replayToResponse = (replay: DurableReplay | undefined): Response => {
   if (replay === undefined) {
-    return new Response(JSON.stringify({ error: 'not_found' }), {
-      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
-      status: 404,
-    })
+    return jsonError('not_found', 404)
   }
-
-  // Malformed offset → 400.
   if (replay.status === 400) {
-    return new Response(JSON.stringify({ error: 'invalid_offset' }), {
-      headers: { 'cache-control': 'no-store', 'content-type': 'application/json' },
-      status: 400,
-    })
+    return jsonError('invalid_offset', 400)
   }
-
-  // Replay the stored SSE suffix. `Stream-Next-Offset` lets the client resume
-  // from exactly where it left off; `Stream-Closed` signals the completion EOF.
+  // `Stream-Next-Offset` lets the client resume from exactly where it left off;
+  // `Stream-Closed` signals the completion EOF.
   const headers: Record<string, string> = {
     'cache-control': 'no-store',
     'content-type': replay.contentType,
@@ -122,4 +83,95 @@ export const routeDurableInferenceReadRequest = (
     headers['stream-closed'] = 'true'
   }
   return new Response(replay.body, { headers, status: 200 })
+}
+
+// Parse a durable read request into `{ requestId, offset }`, or `undefined` when
+// it is not a durable read URL. Shared by the sync and DO dispatchers.
+export interface DurableReadMatch {
+  readonly requestId: string
+  readonly offset: string | undefined
+}
+
+export const matchDurableReadRequest = (
+  request: Request,
+): DurableReadMatch | undefined => {
+  const url = new URL(request.url)
+  const requestId = requestIdFromPath(url.pathname)
+  if (requestId === undefined) {
+    return undefined
+  }
+  return { offset: url.searchParams.get('offset') ?? undefined, requestId }
+}
+
+// Dispatch a durable inference read. Returns `undefined` when the request is not
+// a durable read URL (the worker router falls through). When it IS a durable read
+// URL but the gateway is off / unwired / the id is unknown, returns the matching
+// 404/400/200 Response so the surface is honest.
+export const routeDurableInferenceReadRequest = (
+  request: Request,
+  deps: DurableInferenceReadDeps,
+): Response | undefined => {
+  const matched = matchDurableReadRequest(request)
+  if (matched === undefined) {
+    return undefined
+  }
+
+  // Shares the gateway flag: inert/404 when the gateway is off.
+  if (!deps.enabled || deps.durableStream === undefined) {
+    return jsonError('not_found', 404)
+  }
+
+  if (request.method !== 'GET') {
+    return jsonError('method_not_allowed', 405)
+  }
+
+  const store = deps.durableStream(matched.requestId)
+  if (store === undefined) {
+    return jsonError('not_found', 404)
+  }
+
+  const replay = replayFromOffset({
+    nowMs: deps.nowEpochMillis(),
+    offset: matched.offset,
+    requestId: matched.requestId,
+    store,
+  })
+
+  return replayToResponse(replay)
+}
+
+// PRODUCTION DURABLE READ DISPATCHER (#6058). The async DO-backed resume: reads
+// the per-request Durable Object (`getByName(requestId)`) over the
+// `/v1/stream/{id}` HTTP contract. Returns `undefined` when the request is not a
+// durable read URL (router falls through). NEVER METERS — it reads stored bytes
+// only, so a reconnect / multi-tab share / catch-up read is free. The chat
+// route's producer drain already settled metering exactly once on the upstream
+// EOF; it can never fire here.
+export const routeDurableInferenceReadRequestDO = async (
+  request: Request,
+  deps: Readonly<{
+    enabled: boolean
+    namespace: DurableStreamNamespace | undefined
+  }>,
+): Promise<Response | undefined> => {
+  const matched = matchDurableReadRequest(request)
+  if (matched === undefined) {
+    return undefined
+  }
+
+  if (!deps.enabled || deps.namespace === undefined) {
+    return jsonError('not_found', 404)
+  }
+
+  if (request.method !== 'GET') {
+    return jsonError('method_not_allowed', 405)
+  }
+
+  const replay = await replayFromOffsetDO({
+    namespace: deps.namespace,
+    offset: matched.offset,
+    requestId: matched.requestId,
+  })
+
+  return replayToResponse(replay)
 }

--- a/apps/openagents.com/workers/api/wrangler.jsonc
+++ b/apps/openagents.com/workers/api/wrangler.jsonc
@@ -38,6 +38,12 @@
   "vars": {
     "GITHUB_CLIENT_ID": "Ov23lirHI1DWTzZ1zT1u",
     "INFERENCE_GATEWAY_ENABLED": "true",
+    // Durable-stream Rank-1 resumable inference (#6058, EPIC #6056). LIVE: every
+    // streamed `/api/v1/chat/completions` completion is teed into the per-request
+    // `INFERENCE_DURABLE_STREAM` Durable Object so a client disconnect can resume
+    // by offset via `/v1/chat/completions/durable/{requestId}`. Metering still
+    // settles EXACTLY ONCE on the real upstream EOF and NEVER on a replay.
+    "INFERENCE_DURABLE_STREAM_ENABLED": "true",
     "OPENAUTH_CLIENT_ID": "openagents-web",
     "OPENAUTH_ISSUER_URL": "https://auth.openagents.com",
     "OPENAGENTS_APP_URL": "https://openagents.com",
@@ -237,6 +243,9 @@
       "vars": {
         "ARTANIS_SCHEDULED_RUNNER_ENABLED": "false",
         "INFERENCE_GATEWAY_ENABLED": "true",
+        // Durable-stream Rank-1 resumable inference (#6058) — LIVE on staging too
+        // (the DO binding + migration are added to this env below).
+        "INFERENCE_DURABLE_STREAM_ENABLED": "true",
         // Ep239 "Let's Make Money" loop surfaces — armed on STAGING ONLY so
         // external agent-testers can exercise the inert/scaffold endpoints.
         // Production (the top-level config above) leaves these unset, so the
@@ -331,12 +340,23 @@
             "name": "SYNC_ROOM",
             "class_name": "SyncRoomDurableObject",
           },
+          // Durable-stream Rank-1 resumable inference (#6058). One SQLite-class DO
+          // per request id holds that completion's durable offset log. LIVE on
+          // staging (INFERENCE_DURABLE_STREAM_ENABLED above).
+          {
+            "name": "INFERENCE_DURABLE_STREAM",
+            "class_name": "DurableInferenceStreamObject",
+          },
         ],
       },
       "migrations": [
         {
           "tag": "v1",
           "new_sqlite_classes": ["SyncRoomDurableObject"],
+        },
+        {
+          "tag": "v2",
+          "new_sqlite_classes": ["DurableInferenceStreamObject"],
         },
       ],
     },


### PR DESCRIPTION
Tier 4 of #6154 (EPIC #6056). Wires the DO-backed producer StreamStore factory, enables `INFERENCE_DURABLE_STREAM_ENABLED`, activates resumable durable streaming on `/api/v1/chat/completions`, and routes the onboarding turn stream through the durable layer. Exactly-once metering preserved.

## What's now live

### Gateway (`/api/v1/chat/completions`)
- **New DO-fetch transport** (`inference/durable-inference-do-transport.ts`): `teeUpstreamToDurableDO` + `replayFromOffsetDO` speak the per-request `DurableInferenceStreamObject`'s `/v1/stream/{id}` HTTP contract (`getByName(responseId)`). The synchronous `StreamStore` proxy stays as the in-memory test/contract substrate; production uses the DO namespace (DO wins when both present).
- **Producer factory wired** at `index.ts` (removed the `durableStream: undefined` NEEDS-OWNER seam) to `env.INFERENCE_DURABLE_STREAM`, gated on the flag.
- **Read route wired**: `routeDurableInferenceReadRequestDO` resumes `/v1/chat/completions/durable/{requestId}` (and the `/api/v1/...` alias) from the persisted DO log; the durable read URL is advertised via the `openagents-durable-stream-url` response header.
- **Flag enabled** `INFERENCE_DURABLE_STREAM_ENABLED: "true"` on **prod top-level AND staging**; added the DO binding + migration `v2` to the staging env (it previously had neither).
- **Metering settles EXACTLY ONCE** on the real upstream EOF (the producer `onEof`), never in the DO and never on a replay/catch-up read. This makes ALL gateway streaming durable, including the `openagents/autopilot-concierge` model.

### Onboarding turn stream (item 4)
- Routed the onboarding SSE through the durable layer keyed by the **stable id `onboarding:{sessionId}:{turnIndex}`** (derivable by the browser from `sessionId` + turn index).
- Emits an **early `event: stream` handshake** `{streamId, sessionId, turnIndex}` before the first delta, plus `openagents-onboarding-stream-id` / `openagents-onboarding-resume-url` headers.
- **Resume read**: `GET /api/autopilot/onboarding/{sessionId}/turn/{turnIndex}/stream?offset=` replays the in-flight turn from the last offset (streaming-equivalent), reusing `replayFromOffsetDO`. Never re-meters (onboarding is free; transcript append happens once in the live producer drain).
- **Session rehydration**: `GET /api/autopilot/onboarding/{sessionId}` returns transcript + status + outputSpec + turnCount.

## Fail-safe
With the flag off OR the binding absent, both paths degrade to today's non-durable pass-through (byte-for-byte unchanged). A DO-fetch fault degrades the durable mirror but never breaks the live completion and still meters once on EOF.

## Tests
- `durable-inference-do-transport.test.ts` (8): persistence, **cross-invocation** resume-by-offset, **mid-stream-open** resume (before EOF), exactly-once metering, replay-doesn't-meter, fault-no-meter, DO-down fail-safe, unknown-id 404 — all driven against the package's REAL `core.ts`/`http.ts` (one `MemoryStreamStore` per stream id, the same code the DO runs internally).
- `durable-inference-read-routes.test.ts`: added the DO-dispatcher suite (match/flag/method/404/replay/400).
- `autopilot-onboarding-routes.test.ts`: handshake-first, durable-tee + resume-by-offset + mid-stream suffix, resume fail-safe when unwired, GET-session rehydration + 404.
- Existing durable-proxy + package conformance (54) suites unchanged and green.

## Verification
`typecheck:api` + `typecheck:web` clean; `check:deploy` green (raised the Worker Response-surface budget +3 with justification for the DO stub type + two shared resume-read response builders; the pre-existing raw-primitive violation at my stale base is resolved by rebasing onto current main / #6049).

Refs #6123 (onboarding), #6056 (durable-stream epic), #6148 (Concierge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)