### PR TITLE
Fix durable stream DO read/write: graceful missing-stream 404, persistence, and a real-DO test

### DIFF
--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-routes.ts
@@ -469,11 +469,24 @@ export const makeAutopilotOnboardingRoutes = <Env extends OnboardingRouteEnv>(
       )
     }
     return Effect.promise(async () => {
-      const replay = await replayFromOffsetDO({
-        namespace,
-        offset,
-        requestId: onboardingDurableStreamId(sessionId, turnIndex),
-      })
+      // A missing/empty durable log resolves to `undefined` (→ 404), NOT a throw
+      // (the DO SQL adapter reads its single metadata row tolerantly). A throw
+      // here is therefore a genuine DO transport fault; map it to a clean 502
+      // rather than an unhandled 500 defect. Onboarding is free, so this read
+      // never meters regardless.
+      let replay: Awaited<ReturnType<typeof replayFromOffsetDO>>
+      try {
+        replay = await replayFromOffsetDO({
+          namespace,
+          offset,
+          requestId: onboardingDurableStreamId(sessionId, turnIndex),
+        })
+      } catch {
+        return noStoreJsonResponse(
+          { error: 'durable_stream_unavailable' },
+          { status: 502 },
+        )
+      }
       if (replay === undefined) {
         return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
       }

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.test.ts
@@ -287,4 +287,19 @@ describe('routeDurableInferenceReadRequestDO (production DO-backed resume)', () 
     )
     expect(result?.status).toBe(400)
   })
+
+  test('502 (not an unhandled 500 defect) when the DO transport genuinely faults', async () => {
+    // A missing stream is a graceful 404 (the fixed prod crash); a TRUE transport
+    // fault (binding unreachable) must be a clean 502, never a thrown defect.
+    const faulting: DurableStreamNamespace = {
+      getByName: () => ({
+        fetch: () => Promise.reject(new Error('DO unreachable')),
+      }),
+    }
+    const result = await routeDurableInferenceReadRequestDO(
+      req(`${durableInferenceReadUrl('req-fault')}?offset=0`),
+      { enabled: true, namespace: faulting },
+    )
+    expect(result?.status).toBe(502)
+  })
 })

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-read-routes.ts
@@ -167,11 +167,24 @@ export const routeDurableInferenceReadRequestDO = async (
     return jsonError('method_not_allowed', 405)
   }
 
-  const replay = await replayFromOffsetDO({
-    namespace: deps.namespace,
-    offset: matched.offset,
-    requestId: matched.requestId,
-  })
+  // A missing/empty stream is a graceful `undefined` (→ 404) from
+  // `replayFromOffsetDO`, NOT a throw — the package's `SqliteStreamStore` reads
+  // its single-row metadata tolerantly (a missing stream is zero rows, not an
+  // "expected exactly one result" SQL error). A throw here can therefore only be
+  // a genuine DO transport fault (binding unreachable, runtime error); map it to
+  // a clean 502 instead of letting it surface as an unhandled 500 defect. This is
+  // read-side fail-safe ONLY — it never masks a systematic write failure, which
+  // is fixed at the source in the durable producer / DO SQL adapter.
+  let replay: DurableReplay | undefined
+  try {
+    replay = await replayFromOffsetDO({
+      namespace: deps.namespace,
+      offset: matched.offset,
+      requestId: matched.requestId,
+    })
+  } catch {
+    return jsonError('durable_stream_unavailable', 502)
+  }
 
   return replayToResponse(replay)
 }

--- a/apps/openagents.com/workers/api/src/inference/durable-inference-real-do.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/durable-inference-real-do.test.ts
@@ -1,0 +1,233 @@
+// REAL Durable Object end-to-end test for the durable inference stream
+// (#6154 tier 4 follow-up; reproduces + fixes the prod 500).
+//
+// THE GAP THIS CLOSES: `durable-inference-do-transport.test.ts` drives the
+// production transport (`teeUpstreamToDurableDO` / `replayFromOffsetDO`) against
+// a `MemoryStreamStore`-backed registry. `MemoryStreamStore.getMeta()` returns
+// `null` for a missing stream, so the in-memory path can never hit Cloudflare's
+// real `SqlStorageCursor.one()` THROW on zero rows — the exact crash that
+// 500'd in prod ("Expected exactly one result from SQL query, but got no
+// results") on a missing-stream read AND silently broke writes (PUT-create reads
+// `getMeta()` on the not-yet-created stream first).
+//
+// This test drives the SAME production transport through a `DurableStreamNamespace`
+// whose `getByName(name).fetch()` delegates to the REAL package DO handler
+// (`handleDurableStreamFetch`) over a REAL `node:sqlite` database whose cursor
+// reproduces Cloudflare's `.one()` throw-on-zero/multiple-rows semantics EXACTLY,
+// keyed by name (so write and read hit the SAME DO instance — the prod key path).
+// Pre-fix this suite fails with the prod error; post-fix it is green.
+
+import {
+  handleDurableStreamFetch,
+  type DurableObjectStateLike,
+  type SqlStorageLike,
+} from '@openagentsinc/durable-stream'
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type DurableStreamNamespace,
+  replayFromOffsetDO,
+  teeUpstreamToDurableDO,
+} from './durable-inference-do-transport'
+import {
+  type InferenceStreamEvent,
+  type InferenceStreamSource,
+  type InferenceUsage,
+} from './provider-adapter'
+
+// A `SqlStorageLike` over `node:sqlite` that reproduces Cloudflare's
+// `SqlStorageCursor` semantics — crucially `.one()` THROWS on zero rows, exactly
+// like a live Durable Object's `state.storage.sql`.
+const cloudflareSql = (db: DatabaseSync): SqlStorageLike => ({
+  exec<T = Record<string, unknown>>(query: string, ...bindings: Array<unknown>) {
+    const stmt = db.prepare(query)
+    const rows = stmt.all(...(bindings as Array<never>)) as Array<T>
+    // node:sqlite returns BLOB columns as Uint8Array; the package's `readFrom`
+    // already tolerates both Uint8Array and ArrayBuffer, so no extra coercion.
+    return {
+      toArray: () => rows,
+      one: (): T | undefined => {
+        if (rows.length === 0) {
+          throw new Error(
+            'Expected exactly one result from SQL query, but got no results.',
+          )
+        }
+        if (rows.length > 1) {
+          throw new Error(
+            'Expected exactly one result from SQL query, but got multiple results.',
+          )
+        }
+        return rows[0]
+      },
+    }
+  },
+})
+
+const fakeDoState = (db: DatabaseSync): DurableObjectStateLike => ({
+  storage: {
+    sql: cloudflareSql(db),
+    setAlarm: () => {},
+    deleteAlarm: () => {},
+  },
+  blockConcurrencyWhile: <T>(fn: () => Promise<T>): Promise<T> => fn(),
+})
+
+// A `DurableStreamNamespace` backed by real per-name SQLite DOs. One
+// `DatabaseSync` per DO name == one DO instance, so a write and a later read of
+// the SAME name share storage — the production `getByName(requestId)` key path.
+const realSqliteNamespace = (): DurableStreamNamespace => {
+  const dbs = new Map<string, DatabaseSync>()
+  const stateFor = (name: string): DurableObjectStateLike => {
+    let db = dbs.get(name)
+    if (db === undefined) {
+      db = new DatabaseSync(':memory:')
+      dbs.set(name, db)
+    }
+    return fakeDoState(db)
+  }
+  return {
+    getByName: (name: string) => ({
+      fetch: (request: Request) =>
+        handleDurableStreamFetch(stateFor(name), request),
+    }),
+  }
+}
+
+const usage: InferenceUsage = {
+  completionTokens: 5,
+  promptTokens: 9,
+  totalTokens: 14,
+}
+
+const source = (
+  script: ReadonlyArray<InferenceStreamEvent>,
+  options: { readonly fault?: boolean } = {},
+): InferenceStreamSource => ({
+  frames: (async function* () {
+    for (const event of script) {
+      yield event
+    }
+    if (options.fault === true) {
+      throw new Error('upstream faulted')
+    }
+  })(),
+  terminal: () => ({
+    finishReason: 'stop' as string | undefined,
+    servedModel: 'served/m' as string | undefined,
+    usage: usage as InferenceUsage | undefined,
+  }),
+})
+
+const drive = async (input: {
+  namespace: DurableStreamNamespace
+  requestId: string
+  src: InferenceStreamSource
+}) => {
+  const emitted: Array<string> = []
+  let meterCount = 0
+  const outcome = await teeUpstreamToDurableDO({
+    emit: frame => emitted.push(frame),
+    frameForDelta: delta => `data: {"delta":${JSON.stringify(delta)}}\n\n`,
+    namespace: input.namespace,
+    onEof: async (terminal, content) => {
+      if (terminal.usage !== undefined) {
+        meterCount += 1
+      }
+      return `data: {"done":true,"content":${JSON.stringify(content)}}\n\n`
+    },
+    requestId: input.requestId,
+    source: input.src,
+  })
+  return { emitted, meterCount, outcome }
+}
+
+describe('REAL Durable Object (node:sqlite) — durable inference write + resume', () => {
+  test('a completed turn PERSISTS to the real SQLite DO and a separate read resumes the FULL completion (the prod write-persistence regression)', async () => {
+    const namespace = realSqliteNamespace()
+    const requestId = 'onboarding:sess-abc:0'
+
+    const { meterCount, outcome } = await drive({
+      namespace,
+      requestId,
+      src: source([{ contentDelta: 'Hel' }, { contentDelta: 'lo' }]),
+    })
+
+    // The producer drain completed cleanly and metered exactly once.
+    expect(outcome.faulted).toBe(false)
+    expect(outcome.content).toBe('Hello')
+    expect(meterCount).toBe(1)
+
+    // A SEPARATE read (a later Worker invocation) by the SAME key reconstructs
+    // the FULL log — proving the write actually persisted to the real DO and is
+    // resumable by the key the reader uses. Pre-fix this 500'd / returned 404
+    // because PUT-create threw on `.one()` and no frame ever persisted.
+    const full = await replayFromOffsetDO({ namespace, offset: '0', requestId })
+    expect(full).toBeDefined()
+    expect(full!.body).toContain('"Hel"')
+    expect(full!.body).toContain('"lo"')
+    expect(full!.body).toContain('"done":true')
+    expect(full!.streamClosed).toBe(true)
+  })
+
+  test('mid-offset resume returns only the suffix (streaming-equivalence) against the real DO', async () => {
+    const namespace = realSqliteNamespace()
+    const requestId = 'req-resume-real'
+
+    const { emitted } = await drive({
+      namespace,
+      requestId,
+      src: source([
+        { contentDelta: 'AAA' },
+        { contentDelta: 'BBB' },
+        { contentDelta: 'CCC' },
+      ]),
+    })
+
+    const firstReadBytes = new TextEncoder().encode(emitted[0]!).length
+    const resume = await replayFromOffsetDO({
+      namespace,
+      offset: String(firstReadBytes),
+      requestId,
+    })
+    expect(resume).toBeDefined()
+    expect(resume!.body).not.toContain('"AAA"')
+    expect(resume!.body).toContain('"BBB"')
+    expect(resume!.body).toContain('"CCC"')
+    expect(resume!.body).toContain('"done":true')
+    expect(resume!.streamClosed).toBe(true)
+  })
+
+  test('metering NEVER fires on a resume read against the real DO', async () => {
+    const namespace = realSqliteNamespace()
+    const requestId = 'req-no-rebill-real'
+    const first = await drive({
+      namespace,
+      requestId,
+      src: source([{ contentDelta: 'x' }, { contentDelta: 'y' }]),
+    })
+    expect(first.meterCount).toBe(1)
+
+    for (let i = 0; i < 4; i++) {
+      const replay = await replayFromOffsetDO({ namespace, offset: '0', requestId })
+      expect(replay).toBeDefined()
+    }
+    // Still exactly one settlement — the resume path has no metering hook.
+    expect(first.meterCount).toBe(1)
+  })
+})
+
+describe('REAL Durable Object (node:sqlite) — missing stream is a graceful 404 (the literal prod crash)', () => {
+  test('replayFromOffsetDO on a NEVER-created stream returns undefined (→ 404), not a thrown "Expected exactly one result" 500', async () => {
+    const namespace = realSqliteNamespace()
+    // EXACT prod reproduction #1: GET .../durable/<random>?offset=0 on a stream
+    // that was never created. Pre-fix the real DO threw the "no results" error
+    // (→ 500); post-fix the read is a clean not-found (undefined → 404).
+    const replay = await replayFromOffsetDO({
+      namespace,
+      offset: '0',
+      requestId: 'never-created-real',
+    })
+    expect(replay).toBeUndefined()
+  })
+})

--- a/packages/durable-stream/src/durable-object.ts
+++ b/packages/durable-stream/src/durable-object.ts
@@ -18,6 +18,16 @@ import type { AppendResult, ProducerState, StreamMeta, StreamStore } from "./sto
 // Minimal structural typings for the DO SQLite surface (mirrors the world DO's
 // approach of typing `ctx.storage.sql` locally rather than depending on
 // @cloudflare/workers-types at the package level).
+//
+// IMPORTANT — `one()` THROWS on zero rows: Cloudflare's real `SqlStorageCursor`
+// `.one()` returns the single row but raises "Expected exactly one result from
+// SQL query, but got no results." for zero rows (and an analogous error for >1).
+// `getMeta()`/`getProducer()` must read a row that MAY NOT EXIST yet (a missing
+// or not-yet-created stream), so this adapter reads the first row of `toArray()`
+// — which tolerates zero rows — and NEVER calls `.one()` on those queries. (The
+// in-memory `MemoryStreamStore` returns null/undefined for the same case, so the
+// in-memory conformance tests never exercised `.one()`'s throw; a real-SQLite
+// test in `sqlite-do.test.ts` now does.)
 interface SqlCursor<T> {
   toArray(): Array<T>
   one(): T | undefined
@@ -34,6 +44,10 @@ interface DurableObjectStateLike {
   readonly storage: DurableObjectStorageLike
   blockConcurrencyWhile<T>(fn: () => Promise<T>): Promise<T>
 }
+
+// Read the first row of a single-row query without `.one()`'s throw-on-zero-rows
+// behaviour. Returns `undefined` when the query matched no rows.
+const firstRow = <T>(cursor: SqlCursor<T>): T | undefined => cursor.toArray()[0]
 
 const MIGRATIONS: ReadonlyArray<string> = [
   `CREATE TABLE IF NOT EXISTS ds_meta (
@@ -66,8 +80,10 @@ export class SqliteStreamStore implements StreamStore {
   }
 
   getMeta(): StreamMeta | null {
-    const row = this.sql
-      .exec<{
+    // A not-yet-created / missing stream has zero `ds_meta` rows. Use `firstRow`
+    // (not `.one()`) so that returns null instead of throwing on the real DO.
+    const row = firstRow(
+      this.sql.exec<{
         stream_id: string
         content_type: string
         ttl_seconds: number | null
@@ -75,8 +91,8 @@ export class SqliteStreamStore implements StreamStore {
         closed: number
         created_at_ms: number
         last_stream_seq: string | null
-      }>(`SELECT * FROM ds_meta WHERE id = 1`)
-      .one()
+      }>(`SELECT * FROM ds_meta WHERE id = 1`),
+    )
     if (row === undefined) return null
     return {
       streamId: row.stream_id,
@@ -118,9 +134,13 @@ export class SqliteStreamStore implements StreamStore {
   }
 
   byteLength(): number {
-    const row = this.sql
-      .exec<{ n: number | null }>(`SELECT MAX(pos + LENGTH(byte)) AS n FROM ds_log`)
-      .one()
+    // `MAX(...)` over an aggregate always yields exactly one row (n=null when
+    // empty), but read via `firstRow` for uniformity / defence-in-depth.
+    const row = firstRow(
+      this.sql.exec<{ n: number | null }>(
+        `SELECT MAX(pos + LENGTH(byte)) AS n FROM ds_log`,
+      ),
+    )
     return row?.n ?? 0
   }
 
@@ -186,12 +206,19 @@ export class SqliteStreamStore implements StreamStore {
   }
 
   getProducer(producerId: string): ProducerState | null {
-    const row = this.sql
-      .exec<{ epoch: number; last_seq: number; closing_epoch: number | null; closing_seq: number | null }>(
+    // An unknown producer has zero `ds_producer` rows. Use `firstRow` (not
+    // `.one()`) so the brand-new-producer path returns null instead of throwing.
+    const row = firstRow(
+      this.sql.exec<{
+        epoch: number
+        last_seq: number
+        closing_epoch: number | null
+        closing_seq: number | null
+      }>(
         `SELECT epoch, last_seq, closing_epoch, closing_seq FROM ds_producer WHERE producer_id = ?`,
         producerId,
-      )
-      .one()
+      ),
+    )
     if (row === undefined) return null
     return {
       epoch: row.epoch,

--- a/packages/durable-stream/src/sqlite-do.test.ts
+++ b/packages/durable-stream/src/sqlite-do.test.ts
@@ -1,0 +1,251 @@
+// REAL SQLite Durable-Object adapter tests (#6154 tier 4 follow-up).
+//
+// WHY THIS FILE EXISTS — THE PROD GAP IT CLOSES:
+// The conformance + idempotent + live suites all drive `MemoryStreamStore`,
+// whose `getMeta()`/`getProducer()` return `null`/`undefined` for a row that
+// does not exist. The REAL Cloudflare `SqliteStreamStore` instead reads those
+// rows through `SqlStorageCursor.one()`, and Cloudflare's `.one()` THROWS
+// ("Expected exactly one result from SQL query, but got no results") when the
+// query returns zero rows. So the in-memory tests can never observe the prod
+// failure: a missing-stream read 500'd in production while every unit test was
+// green, and PUT-create itself 500'd (it calls `getMeta()` on the not-yet-
+// existing stream first), so durable writes never persisted at all.
+//
+// This suite backs the REAL `SqliteStreamStore` with a real `bun:sqlite`
+// database wrapped in a `SqlStorageLike` whose `.one()` reproduces Cloudflare's
+// throw-on-zero/multiple-rows semantics EXACTLY. It then drives the REAL
+// `handleDurableStreamFetch` (the DO `fetch` body) end-to-end, so the prod
+// failure is reproducible here and the fix is proven against real SQLite — not
+// a re-implementation.
+
+import { Database } from 'bun:sqlite'
+import { describe, expect, test } from 'bun:test'
+
+import {
+  handleDurableStreamFetch,
+  SqliteStreamStore,
+  type DurableObjectStateLike,
+  type SqlStorageLike,
+} from './durable-object.ts'
+
+// A `SqlStorageLike` over `bun:sqlite` that faithfully reproduces Cloudflare's
+// `SqlStorageCursor` semantics — most importantly `.one()` THROWS on zero rows
+// (and on >1 row), exactly like `state.storage.sql` in a live Durable Object.
+const FAITHFUL_ONE_ERROR =
+  'Expected exactly one result from SQL query, but got no results.'
+
+const cloudflareSql = (db: Database): SqlStorageLike => ({
+  exec<T = Record<string, unknown>>(query: string, ...bindings: Array<unknown>) {
+    const stmt = db.query(query)
+    const rows = stmt.all(...(bindings as Array<never>)) as Array<T>
+    return {
+      toArray: () => rows,
+      // Cloudflare's `.one()`: returns the single row, THROWS otherwise.
+      one: (): T | undefined => {
+        if (rows.length === 0) {
+          throw new Error(FAITHFUL_ONE_ERROR)
+        }
+        if (rows.length > 1) {
+          throw new Error(
+            'Expected exactly one result from SQL query, but got multiple results.',
+          )
+        }
+        return rows[0]
+      },
+    }
+  },
+})
+
+// A minimal `DurableObjectStateLike` over the faithful SQL surface. Alarms are
+// captured (not scheduled) so the TTL-refresh path is exercised without a real
+// timer.
+const fakeDoState = (db: Database): DurableObjectStateLike => {
+  const sql = cloudflareSql(db)
+  return {
+    storage: {
+      sql,
+      setAlarm: () => {},
+      deleteAlarm: () => {},
+    },
+    blockConcurrencyWhile: <T>(fn: () => Promise<T>): Promise<T> => fn(),
+  }
+}
+
+const streamUrl = (id: string): string =>
+  `https://do-internal/v1/stream/${encodeURIComponent(id)}`
+
+describe('real SQLite Durable Object — missing-stream reads are graceful (not a thrown SQL error)', () => {
+  test('GET a never-created stream returns 404, never throwing "Expected exactly one result"', async () => {
+    const db = new Database(':memory:')
+    const state = fakeDoState(db)
+
+    // This is the EXACT prod reproduction: a durable read of a stream that was
+    // never created. Pre-fix, `SqliteStreamStore.getMeta()` calls `.one()` on
+    // zero `ds_meta` rows and THROWS, surfacing as the 500 the gateway mapped to
+    // `internal_server_error`. Post-fix it must be a clean 404.
+    const res = await handleDurableStreamFetch(
+      state,
+      new Request(`${streamUrl('never-created')}?offset=0`, { method: 'GET' }),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  test('HEAD / POST / DELETE on a missing stream are all 404 (no thrown SQL error)', async () => {
+    const db = new Database(':memory:')
+    const state = fakeDoState(db)
+
+    const head = await handleDurableStreamFetch(
+      state,
+      new Request(streamUrl('absent'), { method: 'HEAD' }),
+    )
+    expect(head.status).toBe(404)
+
+    const post = await handleDurableStreamFetch(
+      state,
+      new Request(streamUrl('absent'), {
+        method: 'POST',
+        headers: {
+          'content-type': 'text/event-stream',
+          'producer-id': 'p',
+          'producer-epoch': '0',
+          'producer-seq': '0',
+        },
+        body: new TextEncoder().encode('data: x\n\n'),
+      }),
+    )
+    expect(post.status).toBe(404)
+
+    const del = await handleDurableStreamFetch(
+      state,
+      new Request(streamUrl('absent'), { method: 'DELETE' }),
+    )
+    expect(del.status).toBe(404)
+  })
+})
+
+describe('real SQLite Durable Object — create + append + resume round-trip', () => {
+  test('PUT-create succeeds against real SQLite (regression: create reads getMeta on the empty stream first)', async () => {
+    const db = new Database(':memory:')
+    const state = fakeDoState(db)
+
+    // Pre-fix this 500'd: `handlePut` calls `store.getMeta()` BEFORE creating,
+    // and on the not-yet-existing stream `.one()` threw — so `ensureStreamDO`
+    // saw a non-2xx and degraded `durable=false`, and NO frames ever persisted.
+    const put = await handleDurableStreamFetch(
+      state,
+      new Request(streamUrl('s1'), {
+        method: 'PUT',
+        headers: { 'content-type': 'text/event-stream', 'stream-ttl': '3600' },
+      }),
+    )
+    expect(put.status).toBe(201)
+  })
+
+  test('write deltas + terminal frame, then a separate GET resumes the FULL log (streaming-equivalent) and a mid-offset resume returns only the suffix', async () => {
+    const db = new Database(':memory:')
+    const state = fakeDoState(db)
+    const id = 'completion-1'
+
+    // 1) PUT-create.
+    expect(
+      (
+        await handleDurableStreamFetch(
+          state,
+          new Request(streamUrl(id), {
+            method: 'PUT',
+            headers: {
+              'content-type': 'text/event-stream',
+              'stream-ttl': '3600',
+            },
+          }),
+        )
+      ).status,
+    ).toBe(201)
+
+    // 2) Append two delta frames as the producer (seq 0, 1).
+    const frames = ['data: {"delta":"Hel"}\n\n', 'data: {"delta":"lo"}\n\n']
+    const offsets: Array<string> = []
+    for (let seq = 0; seq < frames.length; seq++) {
+      const res = await handleDurableStreamFetch(
+        state,
+        new Request(streamUrl(id), {
+          method: 'POST',
+          headers: {
+            'content-type': 'text/event-stream',
+            'producer-id': 'khala-gateway',
+            'producer-epoch': '0',
+            'producer-seq': String(seq),
+          },
+          body: new TextEncoder().encode(frames[seq]!),
+        }),
+      )
+      expect(res.status).toBe(200)
+      offsets.push(res.headers.get('stream-next-offset')!)
+    }
+
+    // 3) Append the terminal frame + close (seq 2, stream-closed).
+    const terminal = 'data: {"done":true}\n\n'
+    const closeRes = await handleDurableStreamFetch(
+      state,
+      new Request(streamUrl(id), {
+        method: 'POST',
+        headers: {
+          'content-type': 'text/event-stream',
+          'producer-id': 'khala-gateway',
+          'producer-epoch': '0',
+          'producer-seq': '2',
+          'stream-closed': 'true',
+        },
+        body: new TextEncoder().encode(terminal),
+      }),
+    )
+    expect(closeRes.status).toBe(200)
+    expect(closeRes.headers.get('stream-closed')).toBe('true')
+
+    // 4) FULL resume from offset 0 (a fresh Worker invocation / new DO read):
+    //    reconstructs the entire completion.
+    const full = await handleDurableStreamFetch(
+      state,
+      new Request(`${streamUrl(id)}?offset=0`, { method: 'GET' }),
+    )
+    expect(full.status).toBe(200)
+    const fullBody = await full.text()
+    expect(fullBody).toContain('"Hel"')
+    expect(fullBody).toContain('"lo"')
+    expect(fullBody).toContain('"done":true')
+    expect(full.headers.get('stream-closed')).toBe('true')
+
+    // 5) MID-OFFSET resume (client kept the first frame, dropped after): the
+    //    suffix carries "lo" + terminal but NOT "Hel" — streaming-equivalence.
+    const resume = await handleDurableStreamFetch(
+      state,
+      new Request(`${streamUrl(id)}?offset=${offsets[0]}`, { method: 'GET' }),
+    )
+    expect(resume.status).toBe(200)
+    const resumeBody = await resume.text()
+    expect(resumeBody).not.toContain('"Hel"')
+    expect(resumeBody).toContain('"lo"')
+    expect(resumeBody).toContain('"done":true')
+    expect(resume.headers.get('stream-closed')).toBe('true')
+  })
+})
+
+describe('real SQLite SqliteStreamStore — getMeta / getProducer tolerate zero rows', () => {
+  test('getMeta() returns null (not a throw) on an empty store', () => {
+    const db = new Database(':memory:')
+    const store = new SqliteStreamStore(cloudflareSql(db))
+    expect(store.getMeta()).toBeNull()
+  })
+
+  test('getProducer() returns null (not a throw) for an unknown producer', () => {
+    const db = new Database(':memory:')
+    const store = new SqliteStreamStore(cloudflareSql(db))
+    expect(store.getProducer('unknown')).toBeNull()
+  })
+
+  test('byteLength() is 0 (not a throw) on an empty store', () => {
+    const db = new Database(':memory:')
+    const store = new SqliteStreamStore(cloudflareSql(db))
+    expect(store.byteLength()).toBe(0)
+  })
+})


### PR DESCRIPTION
Fixes the prod 500 (Expected exactly one result from SQL query) on durable resume reads: missing/empty stream now returns not-found instead of throwing, and durable writes persist/resume by a consistent key. Adds a real Durable Object test (the gap that let the MemoryStreamStore tests pass while prod failed). Follow-up to #6154 tier 4.

## Root cause (one bug, two symptoms)
The real Cloudflare `SqlStorageCursor.one()` **throws** on zero rows (`Expected exactly one result from SQL query, but got no results.`), but `SqliteStreamStore.getMeta()`/`getProducer()` used it to read single-row metadata that may not exist yet. The in-memory `MemoryStreamStore` the conformance/transport suites drive returns `null` for that case, so the throw was never exercised — green tests, red prod.

- **(A) missing-stream read** — `handleGet` -> `getMeta()` -> `.one()` threw on the absent `ds_meta` row -> mapped to HTTP 500. Now a clean **404**.
- **(B) write persistence** — PUT-create (`handlePut`) reads `getMeta()` on the not-yet-created stream **first**; the same throw made `ensureStreamDO` see a non-2xx and degrade `durable=false`, so **no frame ever persisted** (the producer fail-safe silently masked it). It was the **same `.one()` bug**, not a key mismatch — write and read both key by `getByName(requestId)` with the same id. Fixing the read fixes create, so a completed turn now persists and resumes by the same key the reader uses.

## Fix
- Read single-row metadata via a `firstRow` helper (`toArray()[0]`) that tolerates zero rows; never call `.one()` on may-not-exist queries (`packages/durable-stream/src/durable-object.ts`).
- Harden the two DO-backed resume routes (gateway + onboarding) so a **genuine** transport fault is a clean **502** instead of an unhandled 500 defect — without masking the (now source-fixed) systematic write failure.
- Exactly-once metering on EOF preserved; resume/replay never meters.

## Test gap closed (reproduce-first)
Added a **real Durable Object** test exercising `handleDurableStreamFetch` + the package SQL adapter against real SQLite, with a cursor that reproduces Cloudflare's `.one()` throw-on-zero/multiple-rows semantics **exactly**:
- `packages/durable-stream/src/sqlite-do.test.ts` (bun:sqlite)
- `apps/openagents.com/workers/api/src/inference/durable-inference-real-do.test.ts` (node:sqlite, driving the production `teeUpstreamToDurableDO`/`replayFromOffsetDO` transport)

Pre-fix both suites fail with the exact prod error at `SqliteStreamStore.getMeta` via **both** create and read; post-fix green.

## Verification
- `bun run --cwd packages/durable-stream test` — 61 pass; `typecheck` clean
- `workers/api` inference + onboarding scope — 1070 pass
- `typecheck:api` + `typecheck:web` clean
- `check:deploy` green (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)