### PR TITLE
Onboarding: browser-side session persistence + durable stream resume on reload (unauthenticated)

### DIFF
--- a/apps/openagents.com/apps/web/src/autopilot-route.test.ts
+++ b/apps/openagents.com/apps/web/src/autopilot-route.test.ts
@@ -19,6 +19,7 @@ const onboardingActions = {
   updatedComposer: (value: string) => ({ _tag: 'stub-composer', value }),
   submittedTurn: () => ({ _tag: 'stub-submit' }),
   clickedCreditKickoff: () => ({ _tag: 'stub-kickoff' }),
+  clickedStartOver: () => ({ _tag: 'stub-start-over' }),
 }
 
 const appUrl = (pathname: string) => ({
@@ -192,9 +193,11 @@ describe('autopilot onboarding route', () => {
     expect(bare).toContain(`data-${AutopilotOnboardingPage.HUD_ROOT_ATTR}`)
     // The command composer is present (text now, voice deferred).
     expect(bare).toContain(`data-${AutopilotOnboardingPage.HUD_COMPOSER_ATTR}`)
-    // The intake_progress register surfaces from the first render (a complete,
-    // readable surface, not a class-gated blank).
-    expect(bare).toContain('Onboarding progress')
+    // The intake register surfaces from the first render (a compact sidebar
+    // register, not a class-gated blank). It was renamed from the old
+    // "Onboarding progress" box to the slim "Intake" register.
+    expect(bare).toContain(`data-${AutopilotOnboardingPage.HUD_REGISTER_ATTR}`)
+    expect(bare).toContain('Intake')
     // No credit_kickoff before the flow is quote-ready.
     expect(bare).not.toContain('Kick off the work')
   })

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.test.ts
@@ -33,6 +33,7 @@ import {
   HUD_LEGAL_VSL_ATTR,
   HUD_REGISTER_ATTR,
   HUD_ROOT_ATTR,
+  HUD_START_OVER_ATTR,
   HUD_THREAD_END_ATTR,
   LEGAL_VERIFIED_STATS,
   overlayView,
@@ -100,6 +101,7 @@ const stubActions = {
   updatedComposer: (value: string) => ({ _tag: 'stub', value }),
   submittedTurn: () => ({ _tag: 'stub' }),
   clickedCreditKickoff: () => ({ _tag: 'stub' }),
+  clickedStartOver: () => ({ _tag: 'stub' }),
 }
 
 // A stubbed program turn response (the Khala program is not invoked in the unit
@@ -204,6 +206,19 @@ describe('autopilot onboarding — page overlay rendering', () => {
     expect(markup).toContain(`data-${HUD_THREAD_END_ATTR}="true"`)
     // No credit kickoff before quote-ready.
     expect(markup).not.toContain('Kick off the work')
+    // No "Start over" affordance on a clean first paint (no conversation yet).
+    expect(markup).not.toContain(`data-${HUD_START_OVER_ATTR}`)
+  })
+
+  test('renders the "Start over" affordance once a conversation exists', () => {
+    const model: FlowModel = {
+      ...initFlowModel(Option.none()),
+      sessionId: 'ob_started',
+      transcript: [{ role: 'user', content: 'I run a bakery' }],
+    }
+    const markup = renderHtml(overlayView(model, stubActions))
+    expect(markup).toContain(`data-${HUD_START_OVER_ATTR}`)
+    expect(markup).toContain('Start over')
   })
 
   test('renders a clickable credit_kickoff once quote-ready', () => {
@@ -285,6 +300,9 @@ describe('autopilot onboarding — turn loop (via the loggedOut update)', () => 
     expect(pending?.userText).toBe('I run a bakery')
     expect(commands.map(command => command.name)).toEqual([
       'ScrollAutopilotOnboardingThreadToEnd',
+      // The user turn is also persisted to localStorage so a reload before the
+      // reply lands still shows it (#6154 tier 4 browser resume).
+      'PersistAutopilotOnboarding',
     ])
   })
 

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/flow.ts
@@ -84,6 +84,22 @@ export const FlowPendingTurn = S.Struct({
 })
 export type FlowPendingTurn = typeof FlowPendingTurn.Type
 
+// The durable cursor for the in-flight streaming turn (resume on reload). Set
+// from the server `event: stream` handshake frame (`streamId` + `turnIndex`),
+// then advanced as deltas land / resume reads report `stream-next-offset`. Held
+// in the model so a reload can persist it and reopen the resume read from the
+// last byte offset. `resuming` is true while a restored turn is being replayed
+// from the durable log (vs. a live turn driven by `pendingTurn`); the resume
+// subscription keys off `inFlight` when `resuming` is set. `null` when no stream
+// is in flight.
+export const FlowInFlight = S.Struct({
+  streamId: S.String,
+  turnIndex: S.Int,
+  lastOffset: S.NullOr(S.String),
+  resuming: S.Boolean,
+})
+export type FlowInFlight = typeof FlowInFlight.Type
+
 export const FlowModel = ts('AutopilotOnboardingFlow', {
   vertical: S.NullOr(S.String),
   sessionId: S.NullOr(S.String),
@@ -99,6 +115,12 @@ export const FlowModel = ts('AutopilotOnboardingFlow', {
   // The turn the streaming subscription should drive, or null when none is in
   // flight. Carries the per-turn id so the SSE stream opens exactly once.
   pendingTurn: S.NullOr(FlowPendingTurn),
+  // The durable cursor for the in-flight streaming turn, so a reload can persist
+  // it and resume from the durable log. Set from the `event: stream` handshake;
+  // cleared on `done`/failure. When `resuming` is set on it, the resume
+  // subscription reopens the durable read for that turn/offset. `null` when no
+  // stream is in flight.
+  inFlight: S.NullOr(FlowInFlight),
   outputSpec: FlowOutputSpec,
   turnCount: S.Int,
 })
@@ -128,11 +150,25 @@ export type OnboardingTurnResponse = typeof OnboardingTurnResponse.Type
 // One parsed SSE event from the stream, normalized for the subscription. The
 // subscription maps these to the streaming messages.
 export type OnboardingStreamEvent =
+  | Readonly<{
+      kind: 'stream'
+      streamId: string
+      sessionId: string
+      turnIndex: number
+    }>
   | Readonly<{ kind: 'delta'; text: string }>
   | Readonly<{ kind: 'done'; response: OnboardingTurnResponse }>
   | Readonly<{ kind: 'error'; reason: string }>
 
 const DeltaPayload = S.Struct({ text: S.String })
+
+// The `event: stream` handshake payload, emitted FIRST (before any delta) so the
+// browser can persist the durable cursor and resume the turn on reload.
+const StreamHandshakePayload = S.Struct({
+  streamId: S.String,
+  sessionId: S.String,
+  turnIndex: S.Int,
+})
 
 // Parse one decoded SSE block (its `event` name + JSON `data` payload) into a
 // typed stream event. Unknown events / malformed payloads yield `undefined` so
@@ -141,6 +177,19 @@ export const parseOnboardingStreamEvent = (
   event: string,
   data: unknown,
 ): OnboardingStreamEvent | undefined => {
+  if (event === 'stream') {
+    return S.decodeUnknownOption(StreamHandshakePayload)(data).pipe(
+      Option.match({
+        onNone: () => undefined,
+        onSome: ({ streamId, sessionId, turnIndex }) => ({
+          kind: 'stream' as const,
+          streamId,
+          sessionId,
+          turnIndex,
+        }),
+      }),
+    )
+  }
   if (event === 'delta') {
     return S.decodeUnknownOption(DeltaPayload)(data).pipe(
       Option.match({
@@ -173,6 +222,7 @@ export const initFlowModel = (vertical: Option.Option<string>): FlowModel =>
     transcript: [],
     streamingReply: null,
     pendingTurn: null,
+    inFlight: null,
     outputSpec: {},
     turnCount: 0,
   })

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/page.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/page.ts
@@ -73,9 +73,13 @@ export type OnboardingViewActions<Message> = Readonly<{
   updatedComposer: (value: string) => Message
   submittedTurn: () => Message
   clickedCreditKickoff: () => Message
+  clickedStartOver: () => Message
 }>
 
 const HUD_HEADING = 'Autopilot'
+
+// The "start over" affordance: data attribute so tests/captures can locate it.
+export const HUD_START_OVER_ATTR = 'autopilot-onboarding-start-over'
 
 const introForVertical = (vertical: string | null): string =>
   vertical === 'legal'
@@ -507,6 +511,39 @@ const composerView = <Message>(
   )
 }
 
+// START OVER --------------------------------------------------------------
+
+// A quiet "Start over" control. Present only once a conversation exists (a
+// session, transcript, or in-flight stream), so the first paint stays clean. It
+// drops the persisted/restored session and begins fresh.
+const startOverControl = <Message>(
+  model: FlowModel,
+  actions: OnboardingViewActions<Message>,
+): Html => {
+  const h = html<Message>()
+
+  const hasConversation =
+    model.sessionId !== null ||
+    model.transcript.length > 0 ||
+    model.streamingReply !== null
+
+  if (!hasConversation) {
+    return h.empty
+  }
+
+  return h.button(
+    [
+      h.Type('button'),
+      h.DataAttribute(HUD_START_OVER_ATTR, ''),
+      h.OnClick(actions.clickedStartOver()),
+      Ui.className<Message>(
+        'shrink-0 border border-[#222] px-2.5 py-1 text-[0.6875rem] text-white/55 transition-colors hover:border-[#3a7bff]/40 hover:text-white/80',
+      ),
+    ],
+    ['Start over'],
+  )
+}
+
 // OVERLAY -----------------------------------------------------------------
 
 // The HUD overlay: an operational command pane floating over the dimmed scene.
@@ -555,26 +592,38 @@ export const overlayView = <Message>(
         [
           // ONE intro treatment (problem #5): the HUD header. The first-message
           // duplicate is gone; the thread starts empty with a calm starter line.
+          // A quiet "Start over" control appears once a conversation exists so a
+          // visitor can drop the restored/persisted session and begin fresh.
           h.div(
-            [Ui.className<Message>('grid gap-1.5')],
             [
-              h.span([Ui.className<Message>(eyebrowClass)], [HUD_HEADING]),
-              h.h1(
+              Ui.className<Message>(
+                'flex items-start justify-between gap-3',
+              ),
+            ],
+            [
+              h.div(
+                [Ui.className<Message>('grid gap-1.5')],
                 [
-                  Ui.className<Message>(
-                    'm-0 text-balance font-medium text-[#f1efe8] text-2xl sm:text-3xl',
+                  h.span([Ui.className<Message>(eyebrowClass)], [HUD_HEADING]),
+                  h.h1(
+                    [
+                      Ui.className<Message>(
+                        'm-0 text-balance font-medium text-[#f1efe8] text-2xl sm:text-3xl',
+                      ),
+                    ],
+                    ['Put an AI workforce to work'],
+                  ),
+                  h.p(
+                    [
+                      Ui.className<Message>(
+                        'm-0 max-w-[60ch] text-[0.8125rem] leading-[1.5] text-white/60',
+                      ),
+                    ],
+                    [introForVertical(model.vertical)],
                   ),
                 ],
-                ['Put an AI workforce to work'],
               ),
-              h.p(
-                [
-                  Ui.className<Message>(
-                    'm-0 max-w-[60ch] text-[0.8125rem] leading-[1.5] text-white/60',
-                  ),
-                ],
-                [introForVertical(model.vertical)],
-              ),
+              startOverControl<Message>(model, actions),
             ],
           ),
           legalOverlaySection<Message>(model),

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/persistence.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/persistence.test.ts
@@ -1,0 +1,174 @@
+import { Option } from 'effect'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  MAX_STORED_TRANSCRIPT_TURNS,
+  ONBOARDING_STORAGE_KEY,
+  type StoredOnboardingSession,
+  capTranscript,
+  clearStoredSession,
+  decodeStoredSession,
+  encodeStoredSession,
+  readStoredSession,
+  storedSessionFromParts,
+  writeStoredSession,
+} from './persistence'
+
+const sampleSession = (
+  overrides: Partial<StoredOnboardingSession> = {},
+): StoredOnboardingSession =>
+  storedSessionFromParts({
+    sessionId: 'ob_abc123',
+    vertical: null,
+    status: 'interviewing',
+    transcript: [
+      { role: 'user', content: 'I run a bakery' },
+      { role: 'assistant', content: 'Great — what do you want done?' },
+    ],
+    outputSpec: { business: 'Acme Bakery' },
+    inFlight: null,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  })
+
+describe('autopilot onboarding persistence — pure transforms', () => {
+  test('encode then decode round-trips a stored session', () => {
+    const session = sampleSession()
+    const encoded = encodeStoredSession(session)
+    const decoded = decodeStoredSession(encoded)
+
+    expect(Option.isSome(decoded)).toBe(true)
+    expect(Option.getOrThrow(decoded)).toEqual(session)
+  })
+
+  test('decode of a corrupt or drifted blob yields none (never throws)', () => {
+    expect(Option.isNone(decodeStoredSession('not json at all'))).toBe(true)
+    expect(Option.isNone(decodeStoredSession('{"sessionId": 42}'))).toBe(true)
+    expect(Option.isNone(decodeStoredSession('{}'))).toBe(true)
+  })
+
+  test('round-trips an in-flight cursor for stream resume', () => {
+    const session = sampleSession({
+      inFlight: {
+        streamId: 'onboarding:ob_abc123:1',
+        turnIndex: 1,
+        replySoFar: 'Sure, here is the plan so',
+        lastOffset: '128',
+      },
+    })
+    const decoded = decodeStoredSession(encodeStoredSession(session))
+    expect(Option.getOrThrow(decoded).inFlight).toEqual(session.inFlight)
+  })
+
+  test('caps the transcript to the most recent turns', () => {
+    const longTranscript = Array.from(
+      { length: MAX_STORED_TRANSCRIPT_TURNS + 10 },
+      (_, index) => ({ role: 'user' as const, content: `turn ${index}` }),
+    )
+    const capped = capTranscript(longTranscript)
+    expect(capped.length).toBe(MAX_STORED_TRANSCRIPT_TURNS)
+    // Keeps the TAIL (most recent), not the head.
+    expect(capped[capped.length - 1]?.content).toBe(
+      `turn ${MAX_STORED_TRANSCRIPT_TURNS + 9}`,
+    )
+    expect(capped[0]?.content).toBe('turn 10')
+  })
+
+  test('encode applies the transcript cap defensively', () => {
+    const session = sampleSession({
+      transcript: Array.from(
+        { length: MAX_STORED_TRANSCRIPT_TURNS + 5 },
+        (_, index) => ({ role: 'assistant' as const, content: `r${index}` }),
+      ),
+    })
+    const decoded = Option.getOrThrow(
+      decodeStoredSession(encodeStoredSession(session)),
+    )
+    expect(decoded.transcript.length).toBe(MAX_STORED_TRANSCRIPT_TURNS)
+  })
+})
+
+// A minimal in-memory localStorage shim. The headless test environment's
+// `localStorage` is not a fully functional Storage, so the wrapper tests install
+// their own; the production code reaches `globalThis.localStorage` exactly as it
+// would in a browser.
+class MemoryStorage {
+  private store = new Map<string, string>()
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value)
+  }
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+  clear(): void {
+    this.store.clear()
+  }
+}
+
+let originalLocalStorage: PropertyDescriptor | undefined
+
+const installMemoryStorage = (storage: unknown): void => {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  })
+}
+
+describe('autopilot onboarding persistence — localStorage wrapper', () => {
+  beforeEach(() => {
+    originalLocalStorage = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'localStorage',
+    )
+    installMemoryStorage(new MemoryStorage())
+  })
+
+  afterEach(() => {
+    if (originalLocalStorage !== undefined) {
+      Object.defineProperty(globalThis, 'localStorage', originalLocalStorage)
+    }
+    vi.restoreAllMocks()
+  })
+
+  test('write then read returns the same session', () => {
+    const session = sampleSession()
+    writeStoredSession(session)
+
+    const read = readStoredSession()
+    expect(Option.isSome(read)).toBe(true)
+    expect(Option.getOrThrow(read)).toEqual(session)
+  })
+
+  test('read of an absent record returns none', () => {
+    expect(Option.isNone(readStoredSession())).toBe(true)
+  })
+
+  test('clear removes the stored record', () => {
+    writeStoredSession(sampleSession())
+    expect(Option.isSome(readStoredSession())).toBe(true)
+
+    clearStoredSession()
+    expect(Option.isNone(readStoredSession())).toBe(true)
+  })
+
+  test('a corrupt stored blob reads as none AND is cleared', () => {
+    localStorage.setItem(ONBOARDING_STORAGE_KEY, '{"broken": true')
+    expect(Option.isNone(readStoredSession())).toBe(true)
+    // The corrupt value is purged so it cannot wedge the next load.
+    expect(localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBeNull()
+  })
+
+  test('a write failure (quota) is swallowed, not thrown', () => {
+    const throwingStorage = new MemoryStorage()
+    throwingStorage.setItem = () => {
+      throw new Error('QuotaExceededError')
+    }
+    installMemoryStorage(throwingStorage)
+    // The first setItem call is the probe in maybeLocalStorage; it throws, so
+    // the wrapper degrades to a no-op store. No exception escapes.
+    expect(() => writeStoredSession(sampleSession())).not.toThrow()
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/persistence.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/persistence.ts
@@ -1,0 +1,224 @@
+// Autopilot onboarding — browser-side session persistence + resume cursor
+// (unauthenticated). An onboarding visitor has no account; the only identity is
+// the client-minted `sessionId`. To survive a reload or a navigate-away, the
+// conversation (transcript + accumulated Output Spec) and an in-flight stream
+// cursor are persisted in `localStorage`, keyed by `sessionId`. On the next
+// load the page rehydrates the transcript immediately, reconciles with the
+// server (GET session), and — if a turn was mid-stream — resumes that turn from
+// the durable log (the resume read).
+//
+// This module is SSR/headless-safe: every `localStorage` touch is guarded
+// (`typeof window`/feature-detect) and wrapped so a private-mode/quota/corrupt
+// failure degrades to "no stored session" rather than throwing. The stored
+// record shape is an Effect Schema, decoded defensively on read — a malformed
+// or schema-drifted blob is treated as absent (clean fresh start), never a
+// crash.
+//
+// Privacy: we persist ONLY the conversation/spec the visitor themselves
+// entered (transcript text + the derived Output Spec) plus the minimal cursor
+// needed to resume a stream. No secrets, tokens, or payment material. The
+// transcript is capped so a long conversation cannot grow the blob unbounded.
+
+import { Option, Schema as S } from 'effect'
+
+import {
+  FlowOutputSpec,
+  FlowTurn,
+  type FlowOutputSpec as FlowOutputSpecType,
+  type FlowTurn as FlowTurnType,
+} from './flow'
+
+// STORAGE KEY -------------------------------------------------------------
+
+// One record per browser, holding the single most-recent onboarding session.
+// The unauthenticated flow is single-session by design (one `/autopilot`
+// conversation at a time); a "start over" affordance clears it.
+export const ONBOARDING_STORAGE_KEY = 'oa.autopilot.onboarding.v1'
+
+// Cap the persisted transcript so the blob stays bounded even for a very long
+// conversation. We keep the most recent turns (the tail), which is what a
+// resuming reader needs; the server's GET session remains the authority for the
+// full transcript and reconciles on mount.
+export const MAX_STORED_TRANSCRIPT_TURNS = 80
+
+// STORED RECORD SCHEMA ----------------------------------------------------
+
+// The in-flight cursor for a turn that was mid-stream when the tab went away.
+// `streamId` / `turnIndex` come from the server `event: stream` handshake frame;
+// `replySoFar` is the partial assistant text already rendered; `lastOffset` is
+// the durable-log byte offset to resume from when one was observed (the LIVE
+// pass-through may not expose per-delta offsets — then it stays absent and the
+// resume read starts from offset 0, which replays the whole in-flight turn).
+export const StoredInFlight = S.Struct({
+  streamId: S.String,
+  turnIndex: S.Int,
+  replySoFar: S.String,
+  lastOffset: S.optionalKey(S.NullOr(S.String)),
+})
+export type StoredInFlight = typeof StoredInFlight.Type
+
+// The session status mirrored from the server (`interviewing | complete`).
+// Persisted so a returning tab can render the completed state without waiting
+// for the reconcile fetch.
+export const StoredOnboardingStatus = S.Literals(['interviewing', 'complete'])
+export type StoredOnboardingStatus = typeof StoredOnboardingStatus.Type
+
+export const StoredOnboardingSession = S.Struct({
+  sessionId: S.String,
+  vertical: S.optionalKey(S.NullOr(S.String)),
+  status: S.optionalKey(S.NullOr(StoredOnboardingStatus)),
+  transcript: S.Array(FlowTurn),
+  outputSpec: S.optionalKey(FlowOutputSpec),
+  inFlight: S.optionalKey(S.NullOr(StoredInFlight)),
+  updatedAt: S.Int,
+})
+export type StoredOnboardingSession = typeof StoredOnboardingSession.Type
+
+const StoredOnboardingSessionFromJson = S.fromJsonString(StoredOnboardingSession)
+
+// PURE TRANSFORMS ---------------------------------------------------------
+
+// Keep only the most recent `MAX_STORED_TRANSCRIPT_TURNS` turns. Pure; the
+// caller decides when to apply it (every persist).
+export const capTranscript = (
+  transcript: ReadonlyArray<FlowTurnType>,
+): ReadonlyArray<FlowTurnType> =>
+  transcript.length <= MAX_STORED_TRANSCRIPT_TURNS
+    ? transcript
+    : transcript.slice(transcript.length - MAX_STORED_TRANSCRIPT_TURNS)
+
+// Encode a stored record to its JSON string. Pure + total (the schema encode
+// never fails for in-domain data). Caps the transcript defensively so a caller
+// that forgot cannot persist an unbounded blob.
+export const encodeStoredSession = (session: StoredOnboardingSession): string =>
+  S.encodeSync(StoredOnboardingSessionFromJson)({
+    ...session,
+    transcript: capTranscript(session.transcript),
+  })
+
+// Decode a stored JSON string into a record, defensively. A malformed or
+// schema-drifted blob yields `none` (treated as absent — a clean fresh start).
+export const decodeStoredSession = (
+  raw: string,
+): Option.Option<StoredOnboardingSession> =>
+  S.decodeUnknownOption(StoredOnboardingSessionFromJson)(raw)
+
+// SAFE LOCALSTORAGE WRAPPER ----------------------------------------------
+
+// Feature-detect a usable `localStorage`. Returns the store or `undefined` in
+// SSR/headless/private-mode contexts where access throws or is absent. Probing
+// access (not just `typeof`) catches Safari private mode, where the API exists
+// but every call throws.
+const maybeLocalStorage = (): Storage | undefined => {
+  try {
+    if (typeof globalThis === 'undefined') {
+      return undefined
+    }
+    const store = (globalThis as { localStorage?: Storage }).localStorage
+    if (store === undefined || store === null) {
+      return undefined
+    }
+    // Touch the API so private-mode/disabled storage surfaces here, not later.
+    const probe = '__oa_probe__'
+    store.setItem(probe, probe)
+    store.removeItem(probe)
+    return store
+  } catch {
+    return undefined
+  }
+}
+
+// READ/WRITE/CLEAR --------------------------------------------------------
+
+// Read + decode the stored session, defensively. Absent storage, a missing
+// record, or a corrupt/drifted blob all yield `none` (clean fresh start). On a
+// corrupt blob the bad value is cleared so it cannot wedge future loads.
+export const readStoredSession = (): Option.Option<StoredOnboardingSession> => {
+  const store = maybeLocalStorage()
+  if (store === undefined) {
+    return Option.none()
+  }
+  try {
+    const raw = store.getItem(ONBOARDING_STORAGE_KEY)
+    if (raw === null) {
+      return Option.none()
+    }
+    return decodeStoredSession(raw).pipe(
+      Option.match({
+        onNone: () => {
+          // Corrupt/drifted: clear it so it does not wedge the next load.
+          try {
+            store.removeItem(ONBOARDING_STORAGE_KEY)
+          } catch {
+            // ignore — best effort
+          }
+          return Option.none<StoredOnboardingSession>()
+        },
+        onSome: session => Option.some(session),
+      }),
+    )
+  } catch {
+    return Option.none()
+  }
+}
+
+// Persist a stored session, defensively. A quota/disabled-storage failure is
+// swallowed (persistence is best-effort; the server remains the authority).
+export const writeStoredSession = (session: StoredOnboardingSession): void => {
+  const store = maybeLocalStorage()
+  if (store === undefined) {
+    return
+  }
+  try {
+    store.setItem(ONBOARDING_STORAGE_KEY, encodeStoredSession(session))
+  } catch {
+    // ignore — best effort
+  }
+}
+
+// Clear the stored session (start over / expired / unknown). Defensive.
+export const clearStoredSession = (): void => {
+  const store = maybeLocalStorage()
+  if (store === undefined) {
+    return
+  }
+  try {
+    store.removeItem(ONBOARDING_STORAGE_KEY)
+  } catch {
+    // ignore — best effort
+  }
+}
+
+// GET-SESSION DECODE ------------------------------------------------------
+
+// The server's GET /api/autopilot/onboarding/{sessionId} response: the
+// authoritative transcript + status + outputSpec + turnCount. Decoded at the
+// client boundary; a drift fails loudly (caught by the caller's catch).
+export const OnboardingSessionResponse = S.Struct({
+  sessionId: S.String,
+  status: StoredOnboardingStatus,
+  turnCount: S.Int,
+  transcript: S.Array(FlowTurn),
+  outputSpec: FlowOutputSpec,
+})
+export type OnboardingSessionResponse = typeof OnboardingSessionResponse.Type
+
+// Build a stored record from the live flow model fields. Centralizes the shape
+// so the update sites stay declarative.
+export const storedSessionFromParts = (parts: {
+  sessionId: string
+  vertical: string | null
+  status: StoredOnboardingStatus | null
+  transcript: ReadonlyArray<FlowTurnType>
+  outputSpec: FlowOutputSpecType
+  inFlight: StoredInFlight | null
+  updatedAt: number
+}): StoredOnboardingSession => ({
+  sessionId: parts.sessionId,
+  vertical: parts.vertical,
+  status: parts.status,
+  transcript: capTranscript(parts.transcript),
+  outputSpec: parts.outputSpec,
+  inFlight: parts.inFlight,
+  updatedAt: parts.updatedAt,
+})

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/resume.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/resume.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  ClickedAutopilotOnboardingStartOver,
+  ClosedAutopilotOnboardingResumeStream,
+  FailedAutopilotOnboardingResume,
+  FailedReconcileAutopilotOnboardingSession,
+  LoadedStoredAutopilotOnboarding,
+  ReceivedAutopilotOnboardingResumeReply,
+  ReceivedAutopilotOnboardingStreamHandshake,
+  SubmittedAutopilotOnboardingTurn,
+  SucceededReconcileAutopilotOnboardingSession,
+  SucceededResumeAutopilotOnboardingTurn,
+  UpdatedAutopilotOnboardingComposer,
+} from '../loggedOut/message'
+import { type Model, init } from '../loggedOut/model'
+import { initialCommands, update } from '../loggedOut/update'
+import { AutopilotRoute } from '../../route'
+import type { StoredOnboardingSession } from './persistence'
+import type { OnboardingSessionResponse } from './persistence'
+
+const flowOf = (model: Model) => model.autopilotOnboarding
+
+const commandNames = (commands: ReadonlyArray<{ name: string }>) =>
+  commands.map(command => command.name)
+
+const storedSession = (
+  overrides: Partial<StoredOnboardingSession> = {},
+): StoredOnboardingSession => ({
+  sessionId: 'ob_resume_1',
+  vertical: null,
+  status: 'interviewing',
+  transcript: [
+    { role: 'user', content: 'I run a law office' },
+    { role: 'assistant', content: 'Got it — what do you need first?' },
+  ],
+  outputSpec: { business: 'Law office' },
+  inFlight: null,
+  updatedAt: 1_700_000_000_000,
+  ...overrides,
+})
+
+const sessionResponse = (
+  overrides: Partial<OnboardingSessionResponse> = {},
+): OnboardingSessionResponse => ({
+  sessionId: 'ob_resume_1',
+  status: 'interviewing',
+  turnCount: 2,
+  transcript: [
+    { role: 'user', content: 'I run a law office' },
+    { role: 'assistant', content: 'Got it — what do you need first?' },
+  ],
+  outputSpec: { business: 'Law office' },
+  ...overrides,
+})
+
+describe('autopilot onboarding — mount rehydration', () => {
+  test('initialCommands rehydrates on the /autopilot route', () => {
+    const model = init(AutopilotRoute())
+    expect(commandNames(initialCommands(model))).toEqual([
+      'RehydrateAutopilotOnboarding',
+    ])
+  })
+
+  test('restoring a saved session shows the transcript immediately and reconciles', () => {
+    const base = init(AutopilotRoute())
+    const [restored, commands] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({ session: storedSession() }),
+    )
+
+    const flow = flowOf(restored)
+    expect(flow.sessionId).toBe('ob_resume_1')
+    expect(flow.transcript).toEqual([
+      { role: 'user', content: 'I run a law office' },
+      { role: 'assistant', content: 'Got it — what do you need first?' },
+    ])
+    expect(flow.outputSpec).toEqual({ business: 'Law office' })
+    expect(flow.status).toBe('idle')
+    // No resume when nothing was mid-stream.
+    expect(flow.inFlight).toBeNull()
+    expect(commandNames(commands)).toContain(
+      'ReconcileAutopilotOnboardingSession',
+    )
+  })
+
+  test('restoring an in-flight session primes the resume bubble + cursor', () => {
+    const base = init(AutopilotRoute())
+    const [restored] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({
+        session: storedSession({
+          inFlight: {
+            streamId: 'onboarding:ob_resume_1:2',
+            turnIndex: 2,
+            replySoFar: 'Here is the plan so far',
+            lastOffset: '64',
+          },
+        }),
+      }),
+    )
+
+    const flow = flowOf(restored)
+    expect(flow.status).toBe('streaming')
+    expect(flow.streamingReply).toBe('Here is the plan so far')
+    // The restored cursor carries `resuming: true` so the resume subscription
+    // reopens the durable read for this turn at the saved offset.
+    expect(flow.inFlight).toEqual({
+      streamId: 'onboarding:ob_resume_1:2',
+      turnIndex: 2,
+      lastOffset: '64',
+      resuming: true,
+    })
+  })
+})
+
+describe('autopilot onboarding — reconcile with the server', () => {
+  test('a 200 reconcile adopts the authoritative server transcript', () => {
+    const base = init(AutopilotRoute())
+    const [restored] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({
+        session: storedSession({
+          transcript: [{ role: 'user', content: 'I run a law office' }],
+        }),
+      }),
+    )
+
+    const [reconciled, commands] = update(
+      restored,
+      SucceededReconcileAutopilotOnboardingSession({
+        response: sessionResponse({
+          // The server has the completed assistant reply the tab missed.
+          transcript: [
+            { role: 'user', content: 'I run a law office' },
+            { role: 'assistant', content: 'Welcome back — here is the plan.' },
+          ],
+          turnCount: 2,
+        }),
+      }),
+    )
+
+    const flow = flowOf(reconciled)
+    expect(flow.transcript).toEqual([
+      { role: 'user', content: 'I run a law office' },
+      { role: 'assistant', content: 'Welcome back — here is the plan.' },
+    ])
+    expect(flow.turnCount).toBe(2)
+    expect(commandNames(commands)).toContain('PersistAutopilotOnboarding')
+  })
+
+  test('a 404 reconcile clears storage and starts fresh', () => {
+    const base = init(AutopilotRoute())
+    const [restored] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({ session: storedSession() }),
+    )
+
+    const [cleared, commands] = update(
+      restored,
+      FailedReconcileAutopilotOnboardingSession({ status: 404 }),
+    )
+
+    const flow = flowOf(cleared)
+    expect(flow.sessionId).toBeNull()
+    expect(flow.transcript).toEqual([])
+    expect(flow.outputSpec).toEqual({})
+    expect(commandNames(commands)).toEqual(['ClearAutopilotOnboardingStorage'])
+  })
+
+  test('a transient (status 0) reconcile keeps the local transcript', () => {
+    const base = init(AutopilotRoute())
+    const [restored] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({ session: storedSession() }),
+    )
+
+    const [kept, commands] = update(
+      restored,
+      FailedReconcileAutopilotOnboardingSession({ status: 0 }),
+    )
+
+    expect(flowOf(kept).transcript.length).toBe(2)
+    expect(commandNames(commands)).toEqual([])
+  })
+
+  test('a reconcile during an active resume does not clobber the streaming bubble', () => {
+    const base = init(AutopilotRoute())
+    const [restored] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({
+        session: storedSession({
+          inFlight: {
+            streamId: 'onboarding:ob_resume_1:2',
+            turnIndex: 2,
+            replySoFar: 'partial',
+            lastOffset: null,
+          },
+        }),
+      }),
+    )
+
+    const [reconciled] = update(
+      restored,
+      SucceededReconcileAutopilotOnboardingSession({
+        response: sessionResponse(),
+      }),
+    )
+
+    const flow = flowOf(reconciled)
+    // The resume cursor + streaming bubble survive the reconcile.
+    expect(flow.inFlight).toMatchObject({ turnIndex: 2, resuming: true })
+    expect(flow.status).toBe('streaming')
+    expect(flow.streamingReply).toBe('partial')
+  })
+})
+
+describe('autopilot onboarding — durable stream resume', () => {
+  const restoredInFlight = (): Model => {
+    const base = init(AutopilotRoute())
+    const [restored] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({
+        session: storedSession({
+          transcript: [{ role: 'user', content: 'I run a law office' }],
+          inFlight: {
+            streamId: 'onboarding:ob_resume_1:1',
+            turnIndex: 1,
+            replySoFar: '',
+            lastOffset: null,
+          },
+        }),
+      }),
+    )
+    return restored
+  }
+
+  test('the resume subscription is active for a restored in-flight turn', () => {
+    // The dependency selector drives the resume read; assert it activates.
+    const restored = restoredInFlight()
+    const flow = flowOf(restored)
+    expect(flow.inFlight).toMatchObject({ turnIndex: 1, resuming: true })
+    expect(flow.sessionId).toBe('ob_resume_1')
+  })
+
+  test('resume deltas REPLACE the bubble and advance the persisted offset', () => {
+    const restored = restoredInFlight()
+    const [step1] = update(
+      restored,
+      ReceivedAutopilotOnboardingResumeReply({
+        turnIndex: 1,
+        reply: 'Here is',
+        nextOffset: '32',
+      }),
+    )
+    const [step2, commands] = update(
+      step1,
+      ReceivedAutopilotOnboardingResumeReply({
+        turnIndex: 1,
+        reply: 'Here is the full plan',
+        nextOffset: '96',
+      }),
+    )
+
+    const flow = flowOf(step2)
+    // REPLACE, not append — the re-replayed prefix never doubles up.
+    expect(flow.streamingReply).toBe('Here is the full plan')
+    // The advanced offset lives on the single in-flight cursor.
+    expect(flow.inFlight).toMatchObject({
+      turnIndex: 1,
+      lastOffset: '96',
+      resuming: true,
+    })
+    expect(commandNames(commands)).toContain('PersistAutopilotOnboarding')
+  })
+
+  test('resume completion commits the assistant reply and clears resume state', () => {
+    const restored = restoredInFlight()
+    const [streamed] = update(
+      restored,
+      ReceivedAutopilotOnboardingResumeReply({
+        turnIndex: 1,
+        reply: 'Here is the full plan',
+        nextOffset: '96',
+      }),
+    )
+    const [done, commands] = update(
+      streamed,
+      SucceededResumeAutopilotOnboardingTurn({
+        response: {
+          sessionId: 'ob_resume_1',
+          reply: 'Here is the full plan',
+          status: 'interviewing',
+          turnCount: 1,
+          outputSpec: { business: 'Law office' },
+        },
+      }),
+    )
+
+    const flow = flowOf(done)
+    expect(flow.status).toBe('idle')
+    expect(flow.streamingReply).toBeNull()
+    expect(flow.inFlight).toBeNull()
+    expect(flow.transcript).toEqual([
+      { role: 'user', content: 'I run a law office' },
+      { role: 'assistant', content: 'Here is the full plan' },
+    ])
+    expect(commandNames(commands)).toContain('PersistAutopilotOnboarding')
+  })
+
+  test('a 404 resume read falls back without a stuck half-bubble', () => {
+    const restored = restoredInFlight()
+    const [failed] = update(
+      restored,
+      FailedAutopilotOnboardingResume({ turnIndex: 1 }),
+    )
+
+    const flow = flowOf(failed)
+    expect(flow.status).toBe('idle')
+    expect(flow.streamingReply).toBeNull()
+    expect(flow.inFlight).toBeNull()
+  })
+
+  test('a resume stream that ends without done falls back cleanly', () => {
+    const restored = restoredInFlight()
+    const [closed] = update(
+      restored,
+      ClosedAutopilotOnboardingResumeStream({ turnIndex: 1 }),
+    )
+
+    const flow = flowOf(closed)
+    expect(flow.status).toBe('idle')
+    expect(flow.streamingReply).toBeNull()
+    expect(flow.inFlight).toBeNull()
+  })
+})
+
+describe('autopilot onboarding — handshake + start over', () => {
+  test('the live handshake sets the in-flight cursor and persists', () => {
+    const base = init(AutopilotRoute())
+    const [typed] = update(
+      base,
+      UpdatedAutopilotOnboardingComposer({ value: 'Help me draft an NDA' }),
+    )
+    const [submitted] = update(typed, SubmittedAutopilotOnboardingTurn())
+    const pendingId = flowOf(submitted).pendingTurn?.id ?? ''
+
+    const [handshook, commands] = update(
+      submitted,
+      ReceivedAutopilotOnboardingStreamHandshake({
+        turnId: pendingId,
+        streamId: 'onboarding:ob_minted:0',
+        sessionId: 'ob_minted',
+        turnIndex: 0,
+      }),
+    )
+
+    const flow = flowOf(handshook)
+    // The handshake adopts the server-minted session id so a first-turn
+    // mid-stream reload can resume.
+    expect(flow.sessionId).toBe('ob_minted')
+    // A live (non-resume) handshake sets the cursor with `resuming: false`.
+    expect(flow.inFlight).toEqual({
+      streamId: 'onboarding:ob_minted:0',
+      turnIndex: 0,
+      lastOffset: null,
+      resuming: false,
+    })
+    expect(commandNames(commands)).toContain('PersistAutopilotOnboarding')
+  })
+
+  test('start over resets the flow and clears storage', () => {
+    const base = init(AutopilotRoute())
+    const [restored] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({ session: storedSession() }),
+    )
+
+    const [fresh, commands] = update(
+      restored,
+      ClickedAutopilotOnboardingStartOver(),
+    )
+
+    const flow = flowOf(fresh)
+    expect(flow.sessionId).toBeNull()
+    expect(flow.transcript).toEqual([])
+    expect(flow.composerDraft).toBe('')
+    expect(commandNames(commands)).toEqual(['ClearAutopilotOnboardingStorage'])
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/loggedOut/message.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/message.ts
@@ -4,6 +4,10 @@ import { m } from 'foldkit/message'
 
 import { OnboardingTurnResponse } from '../autopilot-onboarding/flow'
 import {
+  OnboardingSessionResponse,
+  StoredOnboardingSession,
+} from '../autopilot-onboarding/persistence'
+import {
   OnboardingStep,
   PublicAdjutantActivity,
   PublicAgentGoalResponse,
@@ -226,6 +230,64 @@ export const CompletedScrollAutopilotOnboardingThread = m(
   'CompletedScrollAutopilotOnboardingThread',
 )
 
+// /autopilot onboarding — browser persistence + durable resume (#6154 tier 4).
+// The live-stream handshake frame (`event: stream`) carries the durable cursor
+// so a reload can resume the in-flight turn from the durable log.
+export const ReceivedAutopilotOnboardingStreamHandshake = m(
+  'ReceivedAutopilotOnboardingStreamHandshake',
+  {
+    turnId: S.String,
+    streamId: S.String,
+    sessionId: S.String,
+    turnIndex: S.Int,
+  },
+)
+// Rehydrate from localStorage on mount: restore the saved transcript/spec/cursor
+// immediately (no blank flash) before reconciling with the server.
+export const LoadedStoredAutopilotOnboarding = m(
+  'LoadedStoredAutopilotOnboarding',
+  { session: StoredOnboardingSession },
+)
+// Reconcile with the authoritative server session (covers a turn that completed
+// while the tab was gone). 404 => expired/unknown => clear + fresh start.
+export const SucceededReconcileAutopilotOnboardingSession = m(
+  'SucceededReconcileAutopilotOnboardingSession',
+  { response: OnboardingSessionResponse },
+)
+export const FailedReconcileAutopilotOnboardingSession = m(
+  'FailedReconcileAutopilotOnboardingSession',
+  { status: S.Int },
+)
+// Resume read (durable replay) of an in-flight turn on reload. Deltas REPLACE
+// the bubble (the replay re-streams the whole turn from the offset), advancing
+// the persisted offset from the `stream-next-offset` header.
+export const ReceivedAutopilotOnboardingResumeReply = m(
+  'ReceivedAutopilotOnboardingResumeReply',
+  { turnIndex: S.Int, reply: S.String, nextOffset: S.NullOr(S.String) },
+)
+export const SucceededResumeAutopilotOnboardingTurn = m(
+  'SucceededResumeAutopilotOnboardingTurn',
+  { response: OnboardingTurnResponse },
+)
+export const ClosedAutopilotOnboardingResumeStream = m(
+  'ClosedAutopilotOnboardingResumeStream',
+  { turnIndex: S.Int },
+)
+// The resume read is unavailable (durable log gone / TTL expired / 404): fall
+// back to the reconciled transcript without leaving a stuck half-bubble.
+export const FailedAutopilotOnboardingResume = m(
+  'FailedAutopilotOnboardingResume',
+  { turnIndex: S.Int },
+)
+// The "start over" affordance: drop the in-memory flow + the stored session.
+export const ClickedAutopilotOnboardingStartOver = m(
+  'ClickedAutopilotOnboardingStartOver',
+)
+// Fire-and-forget completion of a localStorage persist/clear side effect.
+export const CompletedPersistAutopilotOnboarding = m(
+  'CompletedPersistAutopilotOnboarding',
+)
+
 export const Message = S.Union([
   ClickedCopyShareLink,
   ClickedEnterKhala,
@@ -279,5 +341,15 @@ export const Message = S.Union([
   ClickedAutopilotOnboardingCreditKickoff,
   CompletedAutopilotOnboardingCreditKickoff,
   CompletedScrollAutopilotOnboardingThread,
+  ReceivedAutopilotOnboardingStreamHandshake,
+  LoadedStoredAutopilotOnboarding,
+  SucceededReconcileAutopilotOnboardingSession,
+  FailedReconcileAutopilotOnboardingSession,
+  ReceivedAutopilotOnboardingResumeReply,
+  SucceededResumeAutopilotOnboardingTurn,
+  ClosedAutopilotOnboardingResumeStream,
+  FailedAutopilotOnboardingResume,
+  ClickedAutopilotOnboardingStartOver,
+  CompletedPersistAutopilotOnboarding,
 ])
 export type Message = typeof Message.Type

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
@@ -1,4 +1,4 @@
-import { Effect, Match as M, Schema as S } from 'effect'
+import { Clock, Effect, Match as M, Option, Schema as S } from 'effect'
 import { Command, Dom } from 'foldkit'
 import { load, pushUrl } from 'foldkit/navigation'
 import { evo } from 'foldkit/struct'
@@ -10,7 +10,11 @@ import {
   CompletedNavigateToLanding,
   CompletedNavigateToTassadar,
   CompletedAutopilotOnboardingCreditKickoff,
+  CompletedPersistAutopilotOnboarding,
   CompletedScrollAutopilotOnboardingThread,
+  FailedReconcileAutopilotOnboardingSession,
+  LoadedStoredAutopilotOnboarding,
+  SucceededReconcileAutopilotOnboardingSession,
   FailedLoadPublicAdjutantActivity,
   FailedLoadPublicAgentGoal,
   FailedLoadPublicArtanisReport,
@@ -71,6 +75,16 @@ import {
 } from './model'
 import { HUD_THREAD_END_SELECTOR } from '../autopilot-onboarding/page'
 import { onboardingVerticalForSegment } from '../autopilot-onboarding/vertical-overlay'
+import {
+  OnboardingSessionResponse,
+  type StoredInFlight,
+  type StoredOnboardingSession,
+  clearStoredSession,
+  readStoredSession,
+  storedSessionFromParts,
+  writeStoredSession,
+} from '../autopilot-onboarding/persistence'
+import { FlowModel } from '../autopilot-onboarding/flow'
 import { recordFromUnknown } from '../../json-boundary'
 import { homeRouter, khalaRouter, tassadarRouter } from '../../route'
 import {
@@ -792,6 +806,182 @@ export const OpenAutopilotCreditKickoff = Command.define(
   ),
 )
 
+// BROWSER PERSISTENCE + DURABLE RESUME (#6154 tier 4) --------------------------
+
+// Derive the stored localStorage record from the live flow model. Only the
+// conversation/spec the user entered plus the resume cursor is persisted; the
+// transcript is capped inside the persistence helper. Returns `null` when there
+// is nothing worth persisting yet (no session id minted).
+const storedSessionFromFlow = (
+  flow: FlowModel,
+  updatedAt: number,
+): StoredOnboardingSession | null => {
+  if (flow.sessionId === null) {
+    return null
+  }
+
+  const inFlight: StoredInFlight | null =
+    flow.inFlight === null
+      ? null
+      : {
+          streamId: flow.inFlight.streamId,
+          turnIndex: flow.inFlight.turnIndex,
+          replySoFar: flow.streamingReply ?? '',
+          lastOffset: flow.inFlight.lastOffset,
+        }
+
+  const status =
+    flow.status === 'idle' && flow.turnCount > 0
+      ? ('interviewing' as const)
+      : null
+
+  return storedSessionFromParts({
+    sessionId: flow.sessionId,
+    vertical: flow.vertical,
+    status,
+    transcript: flow.transcript,
+    outputSpec: flow.outputSpec,
+    inFlight,
+    updatedAt,
+  })
+}
+
+// Stop resuming an in-flight turn and fall back to the reconciled transcript
+// (no stuck half-bubble), persisting the cleared cursor. Shared by the resume
+// stream's terminal-without-done (closed) and 404 (failed) outcomes — both end
+// the resume the same way. Ignores a turn that is no longer the resuming one.
+const endResume = (
+  model: Model,
+  turnIndex: number,
+): UpdateReturn => {
+  const flow = model.autopilotOnboarding
+  if (
+    flow.inFlight === null ||
+    !flow.inFlight.resuming ||
+    flow.inFlight.turnIndex !== turnIndex
+  ) {
+    return [model, []]
+  }
+  const nextModel = evo(model, {
+    autopilotOnboarding: current =>
+      evo(current, {
+        status: () => 'idle',
+        streamingReply: () => null,
+        inFlight: () => null,
+      }),
+  })
+  return [
+    nextModel,
+    [PersistAutopilotOnboarding({ flow: nextModel.autopilotOnboarding })],
+  ]
+}
+
+// Persist the current flow to localStorage (fire-and-forget). Reads the clock
+// through Effect's `Clock` (no `Date.now`) for the `updatedAt` stamp; the write
+// itself is the safe, guarded helper.
+export const PersistAutopilotOnboarding = Command.define(
+  'PersistAutopilotOnboarding',
+  { flow: FlowModel },
+  CompletedPersistAutopilotOnboarding,
+)(({ flow }) =>
+  Clock.currentTimeMillis.pipe(
+    Effect.map(now => storedSessionFromFlow(flow, now)),
+    Effect.tap(session =>
+      Effect.sync(() => {
+        if (session !== null) {
+          writeStoredSession(session)
+        }
+      }),
+    ),
+    Effect.as(CompletedPersistAutopilotOnboarding()),
+  ),
+)
+
+// Clear the stored onboarding session (start over / expired / 404).
+export const ClearAutopilotOnboardingStorage = Command.define(
+  'ClearAutopilotOnboardingStorage',
+  CompletedPersistAutopilotOnboarding,
+)(
+  Effect.sync(() => {
+    clearStoredSession()
+  }).pipe(Effect.as(CompletedPersistAutopilotOnboarding())),
+)
+
+// On mount of `/autopilot` (and `/autopilot/{vertical}`), read the stored
+// session. If present, dispatch it so the page restores the transcript
+// immediately (no blank flash) and then reconciles with the server. Absent =>
+// a benign completion (clean fresh start). The localStorage read is the safe,
+// guarded helper; a corrupt blob is treated as absent.
+export const RehydrateAutopilotOnboarding = Command.define(
+  'RehydrateAutopilotOnboarding',
+  LoadedStoredAutopilotOnboarding,
+  CompletedPersistAutopilotOnboarding,
+)(
+  Effect.sync(() => readStoredSession()).pipe(
+    Effect.map(maybeSession =>
+      Option.match(maybeSession, {
+        onNone: () => CompletedPersistAutopilotOnboarding(),
+        onSome: session => LoadedStoredAutopilotOnboarding({ session }),
+      }),
+    ),
+  ),
+)
+
+class OnboardingSessionReconcileError extends S.TaggedErrorClass<OnboardingSessionReconcileError>()(
+  'OnboardingSessionReconcileError',
+  { error: S.Defect, status: S.Int },
+) {}
+
+// Reconcile the rehydrated session with the authoritative server record. A 200
+// adopts the server transcript/status/outputSpec (covers a turn that completed
+// while the tab was gone); a 404 clears localStorage and starts fresh. A
+// transient network error reports status 0 (the page keeps the local transcript
+// and does not clear).
+export const ReconcileAutopilotOnboardingSession = Command.define(
+  'ReconcileAutopilotOnboardingSession',
+  { sessionId: S.String },
+  SucceededReconcileAutopilotOnboardingSession,
+  FailedReconcileAutopilotOnboardingSession,
+)(({ sessionId }) =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`/api/autopilot/onboarding/${encodeURIComponent(sessionId)}`, {
+          cache: 'no-store',
+          headers: { accept: 'application/json' },
+        }),
+      catch: error => new OnboardingSessionReconcileError({ error, status: 0 }),
+    })
+
+    if (!response.ok) {
+      return yield* new OnboardingSessionReconcileError({
+        error: `Onboarding session returned HTTP ${response.status}.`,
+        status: response.status,
+      })
+    }
+
+    const payload = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: error => new OnboardingSessionReconcileError({ error, status: 0 }),
+    })
+    const decoded =
+      yield* S.decodeUnknownEffect(OnboardingSessionResponse)(payload)
+
+    return SucceededReconcileAutopilotOnboardingSession({ response: decoded })
+  }).pipe(
+    Effect.catch(error =>
+      Effect.succeed(
+        FailedReconcileAutopilotOnboardingSession({
+          status:
+            error instanceof OnboardingSessionReconcileError
+              ? error.status
+              : 0,
+        }),
+      ),
+    ),
+  ),
+)
+
 const publicAgentIdForRef = (agentRef: string): string => {
   const knownAgentIds: Readonly<Record<string, string>> = {
     adjutant: 'agent_adjutant',
@@ -804,7 +994,9 @@ const publicAgentIdForRef = (agentRef: string): string => {
 export const initialCommands = (
   model: Model,
 ): ReadonlyArray<Command.Command<Message>> =>
-  model.route._tag === 'Share'
+  model.route._tag === 'Autopilot' || model.route._tag === 'AutopilotVertical'
+    ? [RehydrateAutopilotOnboarding()]
+    : model.route._tag === 'Share'
     ? [LoadShareProjection({ shareId: model.route.shareId })]
     : model.route._tag === 'Home' ||
         model.route._tag === 'Stats' ||
@@ -1124,31 +1316,41 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         // Math.random; deterministic for captures/tests).
         const turnId = `${flow.sessionId ?? 'new'}:${flow.transcript.length + 1}`
 
-        return [
-          evo(model, {
-            autopilotOnboarding: current =>
-              evo(current, {
-                status: () => 'submitting',
-                errorReason: () => null,
-                composerDraft: () => '',
-                streamingReply: () => null,
-                transcript: transcript => [
-                  ...transcript,
-                  { role: 'user', content: userText },
-                ],
-                // Thread only the bounded vertical selector; the server owns
-                // all prompt guidance for the selected vertical.
-                pendingTurn: () => ({
-                  id: turnId,
-                  sessionId: current.sessionId,
-                  userText,
-                  vertical: onboardingVerticalForSegment(current.vertical),
-                }),
+        // The user's session id may still be null (minted at the stream
+        // boundary for the first turn); persist on the handshake once it lands.
+        const nextModel = evo(model, {
+          autopilotOnboarding: current =>
+            evo(current, {
+              status: () => 'submitting',
+              errorReason: () => null,
+              composerDraft: () => '',
+              streamingReply: () => null,
+              transcript: transcript => [
+                ...transcript,
+                { role: 'user', content: userText },
+              ],
+              // Thread only the bounded vertical selector; the server owns
+              // all prompt guidance for the selected vertical.
+              pendingTurn: () => ({
+                id: turnId,
+                sessionId: current.sessionId,
+                userText,
+                vertical: onboardingVerticalForSegment(current.vertical),
               }),
-          }),
+            }),
+        })
+
+        return [
+          nextModel,
           // Jump the thread to the just-sent message; the subscription opens the
-          // stream and deltas land into the streaming bubble.
-          [ScrollAutopilotOnboardingThreadToEnd()],
+          // stream and deltas land into the streaming bubble. Persist the user
+          // turn so a reload before the reply lands still shows it.
+          [
+            ScrollAutopilotOnboardingThreadToEnd(),
+            PersistAutopilotOnboarding({
+              flow: nextModel.autopilotOnboarding,
+            }),
+          ],
         ]
       },
       OpenedAutopilotOnboardingStream: ({ turnId }) => {
@@ -1169,27 +1371,66 @@ export const update = (model: Model, message: Message): UpdateReturn =>
           [],
         ]
       },
+      ReceivedAutopilotOnboardingStreamHandshake: ({
+        turnId,
+        streamId,
+        sessionId,
+        turnIndex,
+      }) => {
+        const flow = model.autopilotOnboarding
+        if (flow.pendingTurn === null || flow.pendingTurn.id !== turnId) {
+          return [model, []]
+        }
+        // The first turn mints its session id at the stream boundary; adopt the
+        // handshake's session id so persistence keys the right session and a
+        // mid-stream reload can resume even on the very first turn. The handshake
+        // also fixes the durable cursor.
+        const nextModel = evo(model, {
+          autopilotOnboarding: current =>
+            evo(current, {
+              sessionId: () => sessionId,
+              status: () => 'streaming',
+              inFlight: () => ({
+                streamId,
+                turnIndex,
+                lastOffset: null,
+                resuming: false,
+              }),
+            }),
+        })
+        return [
+          nextModel,
+          [PersistAutopilotOnboarding({ flow: nextModel.autopilotOnboarding })],
+        ]
+      },
       ReceivedAutopilotOnboardingDelta: ({ turnId, text }) => {
         const flow = model.autopilotOnboarding
         if (flow.pendingTurn === null || flow.pendingTurn.id !== turnId) {
           return [model, []]
         }
+        const nextModel = evo(model, {
+          autopilotOnboarding: current =>
+            evo(current, {
+              status: () => 'streaming',
+              streamingReply: reply => (reply ?? '') + text,
+            }),
+        })
         return [
-          evo(model, {
-            autopilotOnboarding: current =>
-              evo(current, {
-                status: () => 'streaming',
-                streamingReply: reply => (reply ?? '') + text,
-              }),
-          }),
+          nextModel,
           // Keep the newest tokens in view as they land (native scroll anchoring
           // only pins when already at the bottom, so this never fights a user who
-          // scrolled up).
-          [ScrollAutopilotOnboardingThreadToEnd()],
+          // scrolled up). Persist the partial reply so a mid-stream reload
+          // resumes from where it left off.
+          [
+            ScrollAutopilotOnboardingThreadToEnd(),
+            PersistAutopilotOnboarding({
+              flow: nextModel.autopilotOnboarding,
+            }),
+          ],
         ]
       },
-      SucceededAutopilotOnboardingTurn: ({ response }) => [
-        evo(model, {
+      SucceededAutopilotOnboardingTurn: ({ response }) => {
+        const nextModel = evo(model, {
           autopilotOnboarding: flow =>
             evo(flow, {
               sessionId: () => response.sessionId,
@@ -1199,26 +1440,244 @@ export const update = (model: Model, message: Message): UpdateReturn =>
               outputSpec: () => response.outputSpec,
               streamingReply: () => null,
               pendingTurn: () => null,
+              inFlight: () => null,
               transcript: transcript => [
                 ...transcript,
                 { role: 'assistant', content: response.reply },
               ],
             }),
-        }),
-        [ScrollAutopilotOnboardingThreadToEnd()],
-      ],
-      FailedAutopilotOnboardingTurn: ({ reason }) => [
-        evo(model, {
+        })
+        return [
+          nextModel,
+          [
+            ScrollAutopilotOnboardingThreadToEnd(),
+            PersistAutopilotOnboarding({
+              flow: nextModel.autopilotOnboarding,
+            }),
+          ],
+        ]
+      },
+      FailedAutopilotOnboardingTurn: ({ reason }) => {
+        const nextModel = evo(model, {
           autopilotOnboarding: flow =>
             evo(flow, {
               status: () => 'error',
               errorReason: () => (reason === '' ? null : reason),
               streamingReply: () => null,
               pendingTurn: () => null,
+              inFlight: () => null,
             }),
-        }),
-        [],
-      ],
+        })
+        // Persist with the cleared inFlight so a reload does not phantom-resume a
+        // turn that already failed.
+        return [
+          nextModel,
+          [PersistAutopilotOnboarding({ flow: nextModel.autopilotOnboarding })],
+        ]
+      },
+      LoadedStoredAutopilotOnboarding: ({ session }) => {
+        // Restore the saved transcript/spec/cursor IMMEDIATELY (no blank flash),
+        // then reconcile with the server. If a turn was mid-stream, prime the
+        // resume bubble + cursor (with `resuming` set) so the resume subscription
+        // reopens the durable read.
+        const wasInFlight = session.inFlight ?? null
+        const nextModel = evo(model, {
+          autopilotOnboarding: flow =>
+            evo(flow, {
+              sessionId: () => session.sessionId,
+              vertical: () => session.vertical ?? flow.vertical,
+              status: () => (wasInFlight === null ? 'idle' : 'streaming'),
+              errorReason: () => null,
+              transcript: () => session.transcript,
+              outputSpec: () => session.outputSpec ?? {},
+              streamingReply: () =>
+                wasInFlight === null ? null : wasInFlight.replySoFar,
+              pendingTurn: () => null,
+              inFlight: () =>
+                wasInFlight === null
+                  ? null
+                  : {
+                      streamId: wasInFlight.streamId,
+                      turnIndex: wasInFlight.turnIndex,
+                      lastOffset: wasInFlight.lastOffset ?? null,
+                      resuming: true,
+                    },
+            }),
+        })
+        return [
+          nextModel,
+          [
+            ReconcileAutopilotOnboardingSession({
+              sessionId: session.sessionId,
+            }),
+            ScrollAutopilotOnboardingThreadToEnd(),
+          ],
+        ]
+      },
+      SucceededReconcileAutopilotOnboardingSession: ({ response }) => {
+        const flow = model.autopilotOnboarding
+        // Only adopt the reconcile for the session we are showing.
+        if (flow.sessionId !== response.sessionId) {
+          return [model, []]
+        }
+        // Adopt the authoritative transcript/status/outputSpec/turnCount. If a
+        // resume is in flight, keep the streaming bubble + resume cursor intact
+        // (the resume read owns the in-flight tail); otherwise the server
+        // transcript is the full truth.
+        const resuming = flow.inFlight !== null && flow.inFlight.resuming
+        const nextModel = evo(model, {
+          autopilotOnboarding: current =>
+            evo(current, {
+              transcript: () => response.transcript,
+              outputSpec: () => response.outputSpec,
+              turnCount: () => response.turnCount,
+              status: existing =>
+                resuming ? existing : existing === 'error' ? existing : 'idle',
+            }),
+        })
+        return [
+          nextModel,
+          resuming
+            ? []
+            : [
+                PersistAutopilotOnboarding({
+                  flow: nextModel.autopilotOnboarding,
+                }),
+              ],
+        ]
+      },
+      FailedReconcileAutopilotOnboardingSession: ({ status }) => {
+        // 404 => the session expired or is unknown server-side: clear the stored
+        // record and start fresh (preserve the route's vertical). A transient
+        // network error (status 0) keeps the locally restored transcript.
+        if (status !== 404) {
+          return [model, []]
+        }
+        const nextModel = evo(model, {
+          autopilotOnboarding: flow =>
+            evo(flow, {
+              sessionId: () => null,
+              status: () => 'idle',
+              errorReason: () => null,
+              transcript: () => [],
+              outputSpec: () => ({}),
+              streamingReply: () => null,
+              pendingTurn: () => null,
+              inFlight: () => null,
+              turnCount: () => 0,
+            }),
+        })
+        return [nextModel, [ClearAutopilotOnboardingStorage()]]
+      },
+      ReceivedAutopilotOnboardingResumeReply: ({
+        turnIndex,
+        reply,
+        nextOffset,
+      }) => {
+        const flow = model.autopilotOnboarding
+        if (
+          flow.inFlight === null ||
+          !flow.inFlight.resuming ||
+          flow.inFlight.turnIndex !== turnIndex
+        ) {
+          return [model, []]
+        }
+        // REPLACE the bubble with the accumulated reply (the replay re-streams
+        // the whole turn from the offset; never append-duplicate). Advance the
+        // persisted offset from the `stream-next-offset` header so a second
+        // reload resumes further along.
+        const nextModel = evo(model, {
+          autopilotOnboarding: current =>
+            evo(current, {
+              status: () => 'streaming',
+              streamingReply: () => reply,
+              inFlight: held =>
+                held === null ? held : { ...held, lastOffset: nextOffset },
+            }),
+        })
+        return [
+          nextModel,
+          [
+            ScrollAutopilotOnboardingThreadToEnd(),
+            PersistAutopilotOnboarding({
+              flow: nextModel.autopilotOnboarding,
+            }),
+          ],
+        ]
+      },
+      SucceededResumeAutopilotOnboardingTurn: ({ response }) => {
+        const flow = model.autopilotOnboarding
+        if (flow.sessionId !== response.sessionId) {
+          return [model, []]
+        }
+        // The resumed turn completed: commit the final assistant message and
+        // clear the resume/in-flight state. The transcript already holds the
+        // user turn (from the reconcile / restore); append the assistant reply
+        // only if the last turn is not already this assistant reply (the
+        // reconcile may have adopted a completed transcript).
+        const lastTurn = flow.transcript[flow.transcript.length - 1]
+        const alreadyCommitted =
+          lastTurn !== undefined &&
+          lastTurn.role === 'assistant' &&
+          lastTurn.content === response.reply
+        const nextModel = evo(model, {
+          autopilotOnboarding: current =>
+            evo(current, {
+              status: () => 'idle',
+              errorReason: () => null,
+              turnCount: () => response.turnCount,
+              outputSpec: () => response.outputSpec,
+              streamingReply: () => null,
+              inFlight: () => null,
+              transcript: transcript =>
+                alreadyCommitted
+                  ? transcript
+                  : [
+                      ...transcript,
+                      { role: 'assistant', content: response.reply },
+                    ],
+            }),
+        })
+        return [
+          nextModel,
+          [
+            ScrollAutopilotOnboardingThreadToEnd(),
+            PersistAutopilotOnboarding({
+              flow: nextModel.autopilotOnboarding,
+            }),
+          ],
+        ]
+      },
+      ClosedAutopilotOnboardingResumeStream: ({ turnIndex }) =>
+        // The durable log ended without a `done` frame. Stop resuming and fall
+        // back to the reconciled transcript (which the reconcile already
+        // adopted) so no stuck half-bubble remains.
+        endResume(model, turnIndex),
+      FailedAutopilotOnboardingResume: ({ turnIndex }) =>
+        // The resume read 404'd (durable log gone / TTL expired): fall back to
+        // the reconciled transcript without leaving a stuck half-bubble.
+        endResume(model, turnIndex),
+      ClickedAutopilotOnboardingStartOver: () => {
+        // Drop the in-memory flow + the stored session (preserve the route's
+        // vertical so the page stays on the same onboarding lane).
+        const nextModel = evo(model, {
+          autopilotOnboarding: flow =>
+            evo(flow, {
+              sessionId: () => null,
+              composerDraft: () => '',
+              status: () => 'idle',
+              errorReason: () => null,
+              transcript: () => [],
+              outputSpec: () => ({}),
+              streamingReply: () => null,
+              pendingTurn: () => null,
+              inFlight: () => null,
+              turnCount: () => 0,
+            }),
+        })
+        return [nextModel, [ClearAutopilotOnboardingStorage()]]
+      },
+      CompletedPersistAutopilotOnboarding: () => [model, []],
       ClickedAutopilotOnboardingCreditKickoff: () => [
         model,
         [OpenAutopilotCreditKickoff()],

--- a/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
@@ -24,6 +24,7 @@ import * as SiteCheckoutDemo from '../siteCheckoutDemo'
 import * as Terms from '../terms'
 import {
   ClickedAutopilotOnboardingCreditKickoff,
+  ClickedAutopilotOnboardingStartOver,
   Message,
   SubmittedAutopilotOnboardingTurn,
   UpdatedAutopilotOnboardingComposer,
@@ -91,6 +92,7 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
           submittedTurn: () => SubmittedAutopilotOnboardingTurn(),
           clickedCreditKickoff: () =>
             ClickedAutopilotOnboardingCreditKickoff(),
+          clickedStartOver: () => ClickedAutopilotOnboardingStartOver(),
         }),
       ),
     ])

--- a/apps/openagents.com/apps/web/src/subscriptions.test.ts
+++ b/apps/openagents.com/apps/web/src/subscriptions.test.ts
@@ -6,6 +6,7 @@ import {
 } from './domain/session'
 import { Demo, LoggedIn, LoggedOut } from './model'
 import {
+  LoadedStoredAutopilotOnboarding,
   SubmittedAutopilotOnboardingTurn,
   UpdatedAutopilotOnboardingComposer,
 } from './page/loggedOut/message'
@@ -31,6 +32,7 @@ import {
   demoClockDependenciesForModel,
   demoKeyboardDependenciesForModel,
   demoPlaybackDependenciesForModel,
+  onboardingResumeDependenciesForModel,
   onboardingStreamDependenciesForModel,
   syncMessageFromPayload,
   syncStreamDependenciesForModel,
@@ -538,5 +540,74 @@ describe('autopilot onboarding stream subscription', () => {
     const deps = onboardingStreamDependenciesForModel(submitted)
     expect(deps.isActive).toBe(true)
     expect(deps.vertical).toBe('legal')
+  })
+})
+
+describe('autopilot onboarding resume subscription', () => {
+  const loggedOutBase = () => LoggedOut.init(AutopilotRoute())
+
+  test('is inactive when no in-flight turn was restored', () => {
+    expect(onboardingResumeDependenciesForModel(loggedOutBase())).toEqual({
+      isActive: false,
+      sessionId: '',
+      turnIndex: 0,
+      offset: '',
+    })
+  })
+
+  test('activates for a restored in-flight turn, defaulting the offset to 0', () => {
+    const [restored] = loggedOutUpdate(
+      loggedOutBase(),
+      LoadedStoredAutopilotOnboarding({
+        session: {
+          sessionId: 'ob_resume_sub',
+          vertical: null,
+          status: 'interviewing',
+          transcript: [{ role: 'user', content: 'hi' }],
+          outputSpec: {},
+          inFlight: {
+            streamId: 'onboarding:ob_resume_sub:0',
+            turnIndex: 0,
+            replySoFar: '',
+            lastOffset: null,
+          },
+          updatedAt: 1_700_000_000_000,
+        },
+      }),
+    )
+
+    const deps = onboardingResumeDependenciesForModel(restored)
+    expect(deps).toEqual({
+      isActive: true,
+      sessionId: 'ob_resume_sub',
+      turnIndex: 0,
+      // No tracked offset => resume from 0 (the durable replay re-streams the
+      // whole in-flight turn from the start and continues to EOF).
+      offset: '0',
+    })
+  })
+
+  test('carries a tracked offset so a second reload resumes further along', () => {
+    const [restored] = loggedOutUpdate(
+      loggedOutBase(),
+      LoadedStoredAutopilotOnboarding({
+        session: {
+          sessionId: 'ob_resume_sub',
+          vertical: null,
+          status: 'interviewing',
+          transcript: [{ role: 'user', content: 'hi' }],
+          outputSpec: {},
+          inFlight: {
+            streamId: 'onboarding:ob_resume_sub:0',
+            turnIndex: 0,
+            replySoFar: 'partial',
+            lastOffset: '128',
+          },
+          updatedAt: 1_700_000_000_000,
+        },
+      }),
+    )
+
+    expect(onboardingResumeDependenciesForModel(restored).offset).toBe('128')
   })
 })

--- a/apps/openagents.com/apps/web/src/subscriptions.ts
+++ b/apps/openagents.com/apps/web/src/subscriptions.ts
@@ -21,18 +21,26 @@ import {
   RequestedPollAutopilotRun,
 } from './page/loggedIn/message'
 import {
+  ClosedAutopilotOnboardingResumeStream,
   ClosedSettledFeedStream,
+  FailedAutopilotOnboardingResume,
   FailedAutopilotOnboardingTurn,
   FailedSettledFeedStream,
   OpenedAutopilotOnboardingStream,
   OpenedSettledFeedStream,
   ReceivedAutopilotOnboardingDelta,
+  ReceivedAutopilotOnboardingResumeReply,
+  ReceivedAutopilotOnboardingStreamHandshake,
   ReceivedSettledFeedCursorGap,
   ReceivedSettledFeedPatch,
   SucceededAutopilotOnboardingTurn,
+  SucceededResumeAutopilotOnboardingTurn,
 } from './page/loggedOut/message'
 import type { Message as LoggedOutMessage } from './page/loggedOut/message'
-import { parseOnboardingStreamEvent } from './page/autopilot-onboarding/flow'
+import {
+  type OnboardingStreamEvent,
+  parseOnboardingStreamEvent,
+} from './page/autopilot-onboarding/flow'
 import { newOnboardingSessionId } from './page/loggedOut/update'
 import { SETTLED_FEED_SCOPE } from './page/loggedOut/settled-feed'
 import {
@@ -481,11 +489,68 @@ export const onboardingStreamDependenciesForModel = (
   }
 }
 
-// Read a fetch SSE body to completion, parsing `event:`/`data:` blocks and
-// offering one message per parsed event into the subscription queue. The wire is
-// the narrow onboarding stream (`event: delta|done|error`). Mirrors the
-// settled-feed `Stream.callback` + acquireRelease lifecycle so an unmount aborts
-// the in-flight request cleanly.
+// Read a fetch SSE body to completion, parsing each `event:`/`data:` block into
+// a typed `OnboardingStreamEvent` and invoking `onEvent` for each. Shared by the
+// live turn stream and the durable resume read, which differ only in how they
+// map parsed events to messages (the live stream also emits a handshake +
+// failure; the resume read accumulates + closes). The block-splitting +
+// trailing-flush wire is identical, so it lives here once.
+const readOnboardingSseEvents = async (
+  body: NonNullable<Response['body']>,
+  onEvent: (event: OnboardingStreamEvent) => void,
+): Promise<void> => {
+  const reader = body.pipeThrough(new TextDecoderStream()).getReader()
+  let buffer = ''
+
+  const drainBlock = (block: string): void => {
+    const lines = block.split(/\r?\n/)
+    const eventLine = lines.find(line => line.startsWith('event:'))
+    const dataLines = lines
+      .filter(line => line.startsWith('data:'))
+      .map(line => line.slice('data:'.length).replace(/^ /, ''))
+
+    if (dataLines.length === 0) {
+      return
+    }
+
+    const eventName =
+      eventLine === undefined
+        ? 'message'
+        : eventLine.slice('event:'.length).replace(/^ /, '').trim()
+    const parsed = parseOnboardingStreamEvent(
+      eventName,
+      parseJsonRecord(dataLines.join('\n')),
+    )
+
+    if (parsed !== undefined) {
+      onEvent(parsed)
+    }
+  }
+
+  // Read frames; SSE events are separated by a blank line.
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+    buffer += value
+    let separator = buffer.search(/\r?\n\r?\n/)
+    while (separator !== -1) {
+      const block = buffer.slice(0, separator)
+      buffer = buffer.slice(separator).replace(/^\r?\n\r?\n/, '')
+      drainBlock(block)
+      separator = buffer.search(/\r?\n\r?\n/)
+    }
+  }
+  // Flush any trailing block without a terminating blank line.
+  if (buffer.trim() !== '') {
+    drainBlock(buffer)
+  }
+}
+
+// Live `/autopilot` onboarding turn stream. Opens the SSE POST and maps each
+// parsed event to a message. Mirrors the settled-feed `Stream.callback` +
+// acquireRelease lifecycle so an unmount aborts the in-flight request cleanly.
 const onboardingStream = (
   dependencies: OnboardingStreamDependencies,
 ): Stream.Stream<Message> => {
@@ -540,72 +605,170 @@ const onboardingStream = (
 
           offer(OpenedAutopilotOnboardingStream({ turnId }))
 
-          const reader = response.body
-            .pipeThrough(new TextDecoderStream())
-            .getReader()
-          let buffer = ''
-
-          const drainBlock = (block: string): void => {
-            const lines = block.split(/\r?\n/)
-            const eventLine = lines.find(line => line.startsWith('event:'))
-            const dataLines = lines
-              .filter(line => line.startsWith('data:'))
-              .map(line => line.slice('data:'.length).replace(/^ /, ''))
-
-            if (dataLines.length === 0) {
-              return
-            }
-
-            const eventName =
-              eventLine === undefined
-                ? 'message'
-                : eventLine.slice('event:'.length).replace(/^ /, '').trim()
-            const data = parseJsonRecord(dataLines.join('\n'))
-            const parsed = parseOnboardingStreamEvent(eventName, data)
-
-            if (parsed === undefined) {
-              return
-            }
-
-            if (parsed.kind === 'delta') {
+          await readOnboardingSseEvents(response.body, event => {
+            if (event.kind === 'stream') {
+              // The handshake frame carries the durable cursor; persist it so a
+              // reload can resume this turn from the durable log.
               offer(
-                ReceivedAutopilotOnboardingDelta({
+                ReceivedAutopilotOnboardingStreamHandshake({
                   turnId,
-                  text: parsed.text,
+                  streamId: event.streamId,
+                  sessionId: event.sessionId,
+                  turnIndex: event.turnIndex,
                 }),
               )
-            } else if (parsed.kind === 'done') {
-              offer(SucceededAutopilotOnboardingTurn({ response: parsed.response }))
+            } else if (event.kind === 'delta') {
+              offer(ReceivedAutopilotOnboardingDelta({ turnId, text: event.text }))
+            } else if (event.kind === 'done') {
+              offer(SucceededAutopilotOnboardingTurn({ response: event.response }))
             } else {
               fail()
             }
-          }
-
-          // Read frames; SSE events are separated by a blank line.
-          for (;;) {
-            const { done, value } = await reader.read()
-            if (done) {
-              break
-            }
-            buffer += value
-            let separator = buffer.search(/\r?\n\r?\n/)
-            while (separator !== -1) {
-              const block = buffer.slice(0, separator)
-              buffer = buffer.slice(separator).replace(/^\r?\n\r?\n/, '')
-              drainBlock(block)
-              separator = buffer.search(/\r?\n\r?\n/)
-            }
-          }
-          // Flush any trailing block without a terminating blank line.
-          if (buffer.trim() !== '') {
-            drainBlock(buffer)
-          }
+          })
         }
 
         run().catch(() => {
           if (!resource.aborted) {
             fail()
           }
+        })
+
+        return resource
+      }),
+      resource =>
+        Effect.sync(() => {
+          resource.aborted = true
+          resource.controller.abort()
+        }),
+    ).pipe(Effect.flatMap(() => Effect.never)),
+  )
+}
+
+// Resume read of an in-flight onboarding turn after reload (#6154 tier 4). When
+// the rehydrated model carries a `resumeTurn` (a turn was mid-stream when the
+// tab went away), open the durable resume read
+// (`GET /api/autopilot/onboarding/{sessionId}/turn/{turnIndex}/stream?offset=`),
+// which replays the SAME `delta`/`done` wire from the durable log starting at
+// `offset`. The replay re-streams the WHOLE in-flight turn from that offset, so
+// deltas accumulate into a fresh reply (the update REPLACES the bubble, never
+// double-appends a re-replayed prefix). The `stream-next-offset` header advances
+// the persisted offset so a second reload resumes further along. A 404 (durable
+// log gone / TTL expired) yields a typed failure so the page falls back to the
+// reconciled transcript without a stuck half-bubble.
+const inactiveOnboardingResume: {
+  readonly isActive: boolean
+  readonly sessionId: string
+  readonly turnIndex: number
+  readonly offset: string
+} = {
+  isActive: false,
+  sessionId: '',
+  turnIndex: 0,
+  offset: '',
+}
+
+type OnboardingResumeDependencies = typeof inactiveOnboardingResume
+
+export const onboardingResumeDependenciesForModel = (
+  model: Model,
+): OnboardingResumeDependencies => {
+  if (model._tag !== 'LoggedOut') {
+    return inactiveOnboardingResume
+  }
+
+  const flow = model.autopilotOnboarding
+  const inFlight = flow.inFlight
+  if (inFlight === null || !inFlight.resuming || flow.sessionId === null) {
+    return inactiveOnboardingResume
+  }
+
+  return {
+    isActive: true,
+    sessionId: flow.sessionId,
+    turnIndex: inFlight.turnIndex,
+    offset: inFlight.lastOffset ?? '0',
+  }
+}
+
+const onboardingResumeStream = (
+  dependencies: OnboardingResumeDependencies,
+): Stream.Stream<Message> => {
+  if (!dependencies.isActive) {
+    return Stream.empty
+  }
+
+  const { sessionId, turnIndex, offset } = dependencies
+
+  return Stream.callback<Message>(queue =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        const controller = new AbortController()
+        const resource = { aborted: false, controller }
+
+        const offer = (message: LoggedOutMessage): void => {
+          if (!resource.aborted) {
+            Queue.offerUnsafe(queue, GotLoggedOutMessage({ message }))
+          }
+        }
+
+        const run = async (): Promise<void> => {
+          const response = await fetch(
+            `/api/autopilot/onboarding/${encodeURIComponent(sessionId)}/turn/${turnIndex}/stream?offset=${encodeURIComponent(offset)}`,
+            {
+              method: 'GET',
+              cache: 'no-store',
+              signal: controller.signal,
+              headers: { accept: 'text/event-stream' },
+            },
+          )
+
+          // 404 / non-OK => durable log gone or unwired: fall back to the
+          // reconciled transcript (the completed reply may already be there).
+          if (!response.ok || response.body === null) {
+            offer(FailedAutopilotOnboardingResume({ turnIndex }))
+            return
+          }
+
+          const nextOffset = response.headers.get('stream-next-offset')
+
+          // The replay re-streams the whole turn from `offset`; accumulate fresh
+          // and REPLACE the bubble so a re-replayed prefix never double-counts.
+          let accumulated = ''
+          let sawDone = false
+
+          await readOnboardingSseEvents(response.body, event => {
+            if (event.kind === 'delta') {
+              accumulated += event.text
+              offer(
+                ReceivedAutopilotOnboardingResumeReply({
+                  turnIndex,
+                  reply: accumulated,
+                  nextOffset,
+                }),
+              )
+            } else if (event.kind === 'done') {
+              sawDone = true
+              offer(
+                SucceededResumeAutopilotOnboardingTurn({
+                  response: event.response,
+                }),
+              )
+            }
+            // A `stream` handshake or `error` frame in the replay is ignored:
+            // the close handler below resolves the terminal state.
+          })
+
+          // EOF without a `done` frame: the durable log ended mid-turn (the live
+          // producer is still writing, or the turn was abandoned). Mark the
+          // resume stream closed so the page stops resuming without losing what
+          // streamed; a later load re-checks via reconcile/resume.
+          if (!sawDone) {
+            offer(ClosedAutopilotOnboardingResumeStream({ turnIndex }))
+          }
+        }
+
+        run().catch(() => {
+          offer(FailedAutopilotOnboardingResume({ turnIndex }))
         })
 
         return resource
@@ -753,6 +916,25 @@ export const subscriptions = Subscription.make<Model, Message>()(entry => ({
       keepAliveEquivalence: (left, right) =>
         left.isActive === right.isActive && left.turnId === right.turnId,
       dependenciesToStream: onboardingStream,
+    },
+  ),
+  autopilotOnboardingResumeStream: entry(
+    {
+      isActive: S.Boolean,
+      sessionId: S.String,
+      turnIndex: S.Int,
+      offset: S.String,
+    },
+    {
+      modelToDependencies: onboardingResumeDependenciesForModel,
+      // Hold the resume read stable for one (turnIndex, offset) attempt; a new
+      // offset (a second reload resuming further along) reopens the read.
+      keepAliveEquivalence: (left, right) =>
+        left.isActive === right.isActive &&
+        left.sessionId === right.sessionId &&
+        left.turnIndex === right.turnIndex &&
+        left.offset === right.offset,
+      dependenciesToStream: onboardingResumeStream,
     },
   ),
   demoPlayback: entry(


### PR DESCRIPTION
Persists the unauthenticated onboarding session (sessionId + transcript + in-flight cursor) in localStorage and rehydrates on load: restores messages and resumes an in-flight streaming turn from the durable log. Builds on the durable-stream server contract (#6154 tier 4).