### PR TITLE
Fix onboarding persistence/resume not firing for logged-in users (refresh lost the conversation)

### DIFF
--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/persistence.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/persistence.test.ts
@@ -9,7 +9,9 @@ import {
   clearStoredSession,
   decodeStoredSession,
   encodeStoredSession,
+  makeMemoryOnboardingStoragePort,
   readStoredSession,
+  setOnboardingStoragePort,
   storedSessionFromParts,
   writeStoredSession,
 } from './persistence'
@@ -170,5 +172,66 @@ describe('autopilot onboarding persistence — localStorage wrapper', () => {
     // The first setItem call is the probe in maybeLocalStorage; it throws, so
     // the wrapper degrades to a no-op store. No exception escapes.
     expect(() => writeStoredSession(sampleSession())).not.toThrow()
+  })
+})
+
+describe('autopilot onboarding persistence — injectable storage port', () => {
+  let restore: (() => void) | undefined
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+  })
+
+  test('an installed in-memory port backs read/write/clear with no DOM', () => {
+    const backing = new Map<string, string>()
+    restore = setOnboardingStoragePort(makeMemoryOnboardingStoragePort(backing))
+
+    // Nothing stored yet.
+    expect(Option.isNone(readStoredSession())).toBe(true)
+
+    // Write goes to the in-memory port (no window.localStorage touched).
+    writeStoredSession(sampleSession())
+    expect(backing.get(ONBOARDING_STORAGE_KEY)).toBeTruthy()
+    const read = readStoredSession()
+    expect(Option.isSome(read)).toBe(true)
+    expect(Option.getOrThrow(read).sessionId).toBe('ob_abc123')
+
+    // Clear removes it from the same port.
+    clearStoredSession()
+    expect(backing.has(ONBOARDING_STORAGE_KEY)).toBe(false)
+    expect(Option.isNone(readStoredSession())).toBe(true)
+  })
+
+  test('the explicit port argument overrides the active port (no global swap needed)', () => {
+    const portA = makeMemoryOnboardingStoragePort()
+    writeStoredSession(sampleSession(), portA)
+    expect(Option.isSome(readStoredSession(portA))).toBe(true)
+    // A fresh, unrelated port sees nothing.
+    expect(Option.isNone(readStoredSession(makeMemoryOnboardingStoragePort()))).toBe(
+      true,
+    )
+  })
+
+  test('setOnboardingStoragePort returns a restore that reinstates the previous port', () => {
+    const first = makeMemoryOnboardingStoragePort()
+    const restoreFirst = setOnboardingStoragePort(first)
+    writeStoredSession(sampleSession())
+    const second = makeMemoryOnboardingStoragePort()
+    const restoreSecond = setOnboardingStoragePort(second)
+    // The active port is now `second`, which is empty.
+    expect(Option.isNone(readStoredSession())).toBe(true)
+    restoreSecond()
+    // Back to `first`, which still holds the record.
+    expect(Option.isSome(readStoredSession())).toBe(true)
+    restoreFirst()
+  })
+
+  test('a corrupt blob in the port reads as none AND is purged from the port', () => {
+    const backing = new Map<string, string>([
+      [ONBOARDING_STORAGE_KEY, '{"broken": true'],
+    ])
+    restore = setOnboardingStoragePort(makeMemoryOnboardingStoragePort(backing))
+    expect(Option.isNone(readStoredSession())).toBe(true)
+    expect(backing.has(ONBOARDING_STORAGE_KEY)).toBe(false)
   })
 })

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/persistence.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/persistence.ts
@@ -103,7 +103,23 @@ export const decodeStoredSession = (
 ): Option.Option<StoredOnboardingSession> =>
   S.decodeUnknownOption(StoredOnboardingSessionFromJson)(raw)
 
-// SAFE LOCALSTORAGE WRAPPER ----------------------------------------------
+// STORAGE PORT ------------------------------------------------------------
+
+// A narrow key/value port over the durable browser store. Injectable so the
+// full client↔server resume handshake is exercisable headlessly (an in-memory
+// port stands in for `window.localStorage` in tests), and so the production
+// store can be swapped without rewriting the read/write/clear logic. Every
+// method is total: an implementation MUST swallow its own quota/private-mode/
+// SSR failures and degrade to "absent" rather than throw, so the callers below
+// stay branch-free and a storage fault can never crash the page.
+export type OnboardingStoragePort = Readonly<{
+  // The raw stored string for the key, or `null` when absent/unavailable.
+  get: (key: string) => string | null
+  // Persist the value (best effort).
+  set: (key: string, value: string) => void
+  // Remove the value (best effort).
+  remove: (key: string) => void
+}>
 
 // Feature-detect a usable `localStorage`. Returns the store or `undefined` in
 // SSR/headless/private-mode contexts where access throws or is absent. Probing
@@ -128,65 +144,121 @@ const maybeLocalStorage = (): Storage | undefined => {
   }
 }
 
+// The production port: `window.localStorage`, with every touch guarded so a
+// quota/disabled/SSR failure degrades to "absent" instead of throwing.
+export const localStorageOnboardingStoragePort: OnboardingStoragePort = {
+  get: key => {
+    const store = maybeLocalStorage()
+    if (store === undefined) {
+      return null
+    }
+    try {
+      return store.getItem(key)
+    } catch {
+      return null
+    }
+  },
+  set: (key, value) => {
+    const store = maybeLocalStorage()
+    if (store === undefined) {
+      return
+    }
+    try {
+      store.setItem(key, value)
+    } catch {
+      // ignore — best effort
+    }
+  },
+  remove: key => {
+    const store = maybeLocalStorage()
+    if (store === undefined) {
+      return
+    }
+    try {
+      store.removeItem(key)
+    } catch {
+      // ignore — best effort
+    }
+  },
+}
+
+// A simple in-memory port over a `Map`, for headless tests (and any non-browser
+// caller). Lets the full resume handshake — persist on stream, reload, restore,
+// reconcile, resume — run with no DOM. Construct one per simulated browser.
+export const makeMemoryOnboardingStoragePort = (
+  backing: Map<string, string> = new Map(),
+): OnboardingStoragePort => ({
+  get: key => backing.get(key) ?? null,
+  set: (key, value) => {
+    backing.set(key, value)
+  },
+  remove: key => {
+    backing.delete(key)
+  },
+})
+
+// The active port. Defaults to `window.localStorage`; a test (or a future
+// non-browser host) swaps it via `setOnboardingStoragePort`. The read/write/
+// clear helpers below resolve the port lazily on each call, so a swap installed
+// before the Foldkit command runs takes effect (the commands are plain
+// `Effect.sync` over these helpers — they do not capture the port at define
+// time).
+let activeOnboardingStoragePort: OnboardingStoragePort =
+  localStorageOnboardingStoragePort
+
+// Install the active storage port. Returns a restore function that reinstates
+// the previous port, so a test can scope the swap and leave the global clean.
+export const setOnboardingStoragePort = (
+  port: OnboardingStoragePort,
+): (() => void) => {
+  const previous = activeOnboardingStoragePort
+  activeOnboardingStoragePort = port
+  return () => {
+    activeOnboardingStoragePort = previous
+  }
+}
+
 // READ/WRITE/CLEAR --------------------------------------------------------
 
 // Read + decode the stored session, defensively. Absent storage, a missing
 // record, or a corrupt/drifted blob all yield `none` (clean fresh start). On a
-// corrupt blob the bad value is cleared so it cannot wedge future loads.
-export const readStoredSession = (): Option.Option<StoredOnboardingSession> => {
-  const store = maybeLocalStorage()
-  if (store === undefined) {
+// corrupt blob the bad value is cleared so it cannot wedge future loads. Reads
+// through the active port (overridable for headless tests).
+export const readStoredSession = (
+  port: OnboardingStoragePort = activeOnboardingStoragePort,
+): Option.Option<StoredOnboardingSession> => {
+  const raw = port.get(ONBOARDING_STORAGE_KEY)
+  if (raw === null) {
     return Option.none()
   }
-  try {
-    const raw = store.getItem(ONBOARDING_STORAGE_KEY)
-    if (raw === null) {
-      return Option.none()
-    }
-    return decodeStoredSession(raw).pipe(
-      Option.match({
-        onNone: () => {
-          // Corrupt/drifted: clear it so it does not wedge the next load.
-          try {
-            store.removeItem(ONBOARDING_STORAGE_KEY)
-          } catch {
-            // ignore — best effort
-          }
-          return Option.none<StoredOnboardingSession>()
-        },
-        onSome: session => Option.some(session),
-      }),
-    )
-  } catch {
-    return Option.none()
-  }
+  return decodeStoredSession(raw).pipe(
+    Option.match({
+      onNone: () => {
+        // Corrupt/drifted: clear it so it does not wedge the next load.
+        port.remove(ONBOARDING_STORAGE_KEY)
+        return Option.none<StoredOnboardingSession>()
+      },
+      onSome: session => Option.some(session),
+    }),
+  )
 }
 
 // Persist a stored session, defensively. A quota/disabled-storage failure is
-// swallowed (persistence is best-effort; the server remains the authority).
-export const writeStoredSession = (session: StoredOnboardingSession): void => {
-  const store = maybeLocalStorage()
-  if (store === undefined) {
-    return
-  }
-  try {
-    store.setItem(ONBOARDING_STORAGE_KEY, encodeStoredSession(session))
-  } catch {
-    // ignore — best effort
-  }
+// swallowed by the port (persistence is best-effort; the server remains the
+// authority). Writes through the active port (overridable for headless tests).
+export const writeStoredSession = (
+  session: StoredOnboardingSession,
+  port: OnboardingStoragePort = activeOnboardingStoragePort,
+): void => {
+  port.set(ONBOARDING_STORAGE_KEY, encodeStoredSession(session))
 }
 
-// Clear the stored session (start over / expired / unknown). Defensive.
-export const clearStoredSession = (): void => {
-  const store = maybeLocalStorage()
-  if (store === undefined) {
-    return
-  }
-  try {
-    store.removeItem(ONBOARDING_STORAGE_KEY)
-  } catch {
-    // ignore — best effort
-  }
+// Clear the stored session (start over / expired / unknown). Defensive. Clears
+// through the active port (overridable for headless tests).
+export const clearStoredSession = (
+  port: OnboardingStoragePort = activeOnboardingStoragePort,
+): void => {
+  port.remove(ONBOARDING_STORAGE_KEY)
 }
 
 // GET-SESSION DECODE ------------------------------------------------------

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/resume-handshake.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/resume-handshake.test.ts
@@ -1,0 +1,376 @@
+// Full client-side onboarding reload-resume handshake — the CLIENT half of the
+// client↔server contract, driven through the REAL Foldkit pieces:
+//   - the REAL persistence port (an in-memory `OnboardingStoragePort` standing
+//     in for `window.localStorage`, so the handshake runs headlessly),
+//   - the REAL `loggedOut` `update` reducer + `initialCommands`,
+//   - the REAL top-level routing `init` (`main.ts`), to prove which submodel a
+//     logged-in vs logged-out onboarding user actually mounts.
+//
+// What it proves (the regression that would have caught the live bug):
+//   1. A streaming turn persists the transcript + the in-flight stream cursor
+//      (handshake streamId/turnIndex) to the storage port.
+//   2. A PAGE RELOAD — a fresh client model running `initialCommands` again —
+//      rehydrates from the persisted port: `RehydrateAutopilotOnboarding` fires,
+//      `LoadedStoredAutopilotOnboarding` restores the transcript, and the
+//      reconcile + resume run.
+//   3. The mid-first-turn 404 reconcile (server row not written yet — see the
+//      api `autopilot-onboarding-resume-handshake.test.ts`) NO LONGER wipes the
+//      conversation. The durable resume read replays the in-flight turn and the
+//      bubble completes.
+//   4. This holds for BOTH auth states: a logged-OUT visitor AND a logged-in
+//      no-workspace user BOTH mount the rehydrating LoggedOut submodel on
+//      `/autopilot`, so `initialCommands` rehydrates either way.
+
+import { Option } from 'effect'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import {
+  authBootstrapFromSession,
+  incompleteOnboardingStatus,
+} from '../../domain/session'
+import { Flags, init } from '../../main'
+import {
+  FailedReconcileAutopilotOnboardingSession,
+  LoadedStoredAutopilotOnboarding,
+  ReceivedAutopilotOnboardingDelta,
+  ReceivedAutopilotOnboardingResumeReply,
+  ReceivedAutopilotOnboardingStreamHandshake,
+  SubmittedAutopilotOnboardingTurn,
+  SucceededResumeAutopilotOnboardingTurn,
+  UpdatedAutopilotOnboardingComposer,
+} from '../loggedOut/message'
+import { type Model, init as initLoggedOut } from '../loggedOut/model'
+import { initialCommands, update } from '../loggedOut/update'
+import { AutopilotRoute } from '../../route'
+import {
+  type OnboardingStoragePort,
+  makeMemoryOnboardingStoragePort,
+  readStoredSession,
+  setOnboardingStoragePort,
+  writeStoredSession,
+} from './persistence'
+
+// HELPERS -----------------------------------------------------------------
+
+const flowOf = (model: Model) => model.autopilotOnboarding
+const names = (commands: ReadonlyArray<{ name: string }>) =>
+  commands.map(c => c.name)
+
+// Run the `PersistAutopilotOnboarding` command's effect against the active
+// storage port by replaying what the command does: build the stored record from
+// the flow and write it. We instead exercise the real path by driving the same
+// `writeStoredSession` the command calls, sourced from the flow the reducer
+// produced — so the persisted blob is exactly what the app would store.
+//
+// The reducer returns `PersistAutopilotOnboarding({ flow })` commands; rather
+// than spin Foldkit's runtime, we mirror the command's documented behaviour
+// (storedSessionFromFlow -> writeStoredSession) by persisting the flow fields
+// the command would. To keep this honest we go through the SAME public
+// `writeStoredSession`/`readStoredSession` the production command uses.
+const persistFlow = (model: Model): void => {
+  const flow = flowOf(model)
+  if (flow.sessionId === null) {
+    return
+  }
+  const inFlight =
+    flow.inFlight === null
+      ? null
+      : {
+          streamId: flow.inFlight.streamId,
+          turnIndex: flow.inFlight.turnIndex,
+          replySoFar: flow.streamingReply ?? '',
+          lastOffset: flow.inFlight.lastOffset,
+        }
+  writeStoredSession({
+    sessionId: flow.sessionId,
+    vertical: flow.vertical,
+    status:
+      flow.status === 'idle' && flow.turnCount > 0 ? 'interviewing' : null,
+    transcript: flow.transcript,
+    outputSpec: flow.outputSpec,
+    inFlight,
+    updatedAt: 1_700_000_000_000,
+  })
+}
+
+// A simulated browser tab: a model plus the storage port that backs it. A
+// "reload" constructs a fresh model + runs `initialCommands` against the SAME
+// persisted port.
+const coreTeam = [
+  {
+    id: 'team_openagents_core',
+    name: 'OpenAgents Core Team',
+    slug: 'openagents-core-team',
+    role: 'owner',
+    members: [],
+  },
+]
+const baseAuth = authBootstrapFromSession({
+  email: 'visitor@example.com',
+  name: 'Visitor',
+  userId: 'gh:visitor',
+})
+const autopilotUrl = {
+  protocol: 'https:',
+  host: 'openagents.com',
+  port: Option.none(),
+  pathname: '/autopilot',
+  search: Option.none(),
+  hash: Option.none(),
+}
+
+describe('autopilot onboarding — full client reload-resume handshake', () => {
+  let restorePort: (() => void) | undefined
+
+  const install = (): OnboardingStoragePort => {
+    const port = makeMemoryOnboardingStoragePort()
+    restorePort = setOnboardingStoragePort(port)
+    return port
+  }
+
+  afterEach(() => {
+    restorePort?.()
+    restorePort = undefined
+  })
+
+  test('a streaming first turn persists transcript + in-flight cursor through the storage port', () => {
+    install()
+    let model = initLoggedOut(AutopilotRoute())
+
+    // The visitor types and submits the first turn.
+    ;[model] = update(
+      model,
+      UpdatedAutopilotOnboardingComposer({ value: 'I run a bakery' }),
+    )
+    ;[model] = update(model, SubmittedAutopilotOnboardingTurn())
+    const pendingId = flowOf(model).pendingTurn?.id ?? ''
+    persistFlow(model)
+
+    // The server handshake mints the session id + durable cursor.
+    ;[model] = update(
+      model,
+      ReceivedAutopilotOnboardingStreamHandshake({
+        turnId: pendingId,
+        streamId: 'onboarding:ob_bakery:0',
+        sessionId: 'ob_bakery',
+        turnIndex: 0,
+      }),
+    )
+    persistFlow(model)
+
+    // A delta lands mid-stream.
+    ;[model] = update(
+      model,
+      ReceivedAutopilotOnboardingDelta({ turnId: pendingId, text: 'Welcome' }),
+    )
+    persistFlow(model)
+
+    // The storage port now holds the in-flight turn the durable log can resume.
+    const stored = readStoredSession()
+    expect(Option.isSome(stored)).toBe(true)
+    const session = Option.getOrThrow(stored)
+    expect(session.sessionId).toBe('ob_bakery')
+    expect(session.transcript).toEqual([{ role: 'user', content: 'I run a bakery' }])
+    expect(session.inFlight).toMatchObject({
+      streamId: 'onboarding:ob_bakery:0',
+      turnIndex: 0,
+      replySoFar: 'Welcome',
+    })
+  })
+
+  test('RELOAD mid-first-turn: a 404 reconcile NO LONGER wipes the conversation; the resume replays and completes', () => {
+    const port = install()
+
+    // --- TAB 1: stream a first turn, persist mid-stream, then the tab goes away.
+    let tab1 = initLoggedOut(AutopilotRoute())
+    ;[tab1] = update(
+      tab1,
+      UpdatedAutopilotOnboardingComposer({ value: 'I run a bakery' }),
+    )
+    ;[tab1] = update(tab1, SubmittedAutopilotOnboardingTurn())
+    const pendingId = flowOf(tab1).pendingTurn?.id ?? ''
+    ;[tab1] = update(
+      tab1,
+      ReceivedAutopilotOnboardingStreamHandshake({
+        turnId: pendingId,
+        streamId: 'onboarding:ob_bakery:0',
+        sessionId: 'ob_bakery',
+        turnIndex: 0,
+      }),
+    )
+    ;[tab1] = update(
+      tab1,
+      ReceivedAutopilotOnboardingDelta({ turnId: pendingId, text: 'Welcome' }),
+    )
+    persistFlow(tab1)
+    expect(port.get('oa.autopilot.onboarding.v1')).not.toBeNull()
+
+    // --- TAB 2 (RELOAD): fresh model + initialCommands rehydrate from the port.
+    let tab2 = initLoggedOut(AutopilotRoute())
+    expect(names(initialCommands(tab2))).toEqual([
+      'RehydrateAutopilotOnboarding',
+    ])
+    // RehydrateAutopilotOnboarding reads the port and dispatches the restore.
+    const restored = readStoredSession()
+    expect(Option.isSome(restored)).toBe(true)
+    ;[tab2] = update(
+      tab2,
+      LoadedStoredAutopilotOnboarding({ session: Option.getOrThrow(restored) }),
+    )
+
+    // The transcript is restored and the in-flight turn is primed for resume.
+    expect(flowOf(tab2).transcript).toEqual([
+      { role: 'user', content: 'I run a bakery' },
+    ])
+    expect(flowOf(tab2).status).toBe('streaming')
+    expect(flowOf(tab2).inFlight).toMatchObject({ turnIndex: 0, resuming: true })
+
+    // The reconcile GET hits the server. MID-FIRST-TURN the session row is not
+    // written yet, so the server replies 404 (proved in the api handshake test).
+    // THE FIX: this 404 must NOT clear the conversation, because a resume is in
+    // flight and a transcript exists.
+    let after404: Model
+    let cmds404: ReadonlyArray<{ name: string }>
+    ;[after404, cmds404] = update(
+      tab2,
+      FailedReconcileAutopilotOnboardingSession({ status: 404 }),
+    )
+    // No ClearAutopilotOnboardingStorage — the transcript + resume survive.
+    expect(names(cmds404)).not.toContain('ClearAutopilotOnboardingStorage')
+    expect(flowOf(after404).transcript).toEqual([
+      { role: 'user', content: 'I run a bakery' },
+    ])
+    expect(flowOf(after404).inFlight).toMatchObject({ resuming: true })
+    // The persisted blob is still intact (not wiped).
+    expect(port.get('oa.autopilot.onboarding.v1')).not.toBeNull()
+
+    // The durable resume read replays the in-flight turn; deltas REPLACE the
+    // bubble, then completion commits the assistant reply.
+    let resumed: Model
+    ;[resumed] = update(
+      after404,
+      ReceivedAutopilotOnboardingResumeReply({
+        turnIndex: 0,
+        reply: 'Welcome to Autopilot',
+        nextOffset: '64',
+      }),
+    )
+    expect(flowOf(resumed).streamingReply).toBe('Welcome to Autopilot')
+    ;[resumed] = update(
+      resumed,
+      SucceededResumeAutopilotOnboardingTurn({
+        response: {
+          sessionId: 'ob_bakery',
+          reply: 'Welcome to Autopilot',
+          status: 'interviewing',
+          turnCount: 1,
+          outputSpec: {},
+        },
+      }),
+    )
+
+    // The conversation is fully restored + resumed — never lost.
+    expect(flowOf(resumed).status).toBe('idle')
+    expect(flowOf(resumed).inFlight).toBeNull()
+    expect(flowOf(resumed).transcript).toEqual([
+      { role: 'user', content: 'I run a bakery' },
+      { role: 'assistant', content: 'Welcome to Autopilot' },
+    ])
+  })
+
+  test('an in-flight turn that lands a real 404 is NOT a transcript wipe (resume still owns the tail)', () => {
+    install()
+    let model = initLoggedOut(AutopilotRoute())
+    ;[model] = update(
+      model,
+      LoadedStoredAutopilotOnboarding({
+        session: {
+          sessionId: 'ob_x',
+          vertical: null,
+          status: 'interviewing',
+          transcript: [{ role: 'user', content: 'hi' }],
+          outputSpec: {},
+          inFlight: {
+            streamId: 'onboarding:ob_x:0',
+            turnIndex: 0,
+            replySoFar: 'par',
+            lastOffset: null,
+          },
+          updatedAt: 1,
+        },
+      }),
+    )
+    const [after, cmds] = update(
+      model,
+      FailedReconcileAutopilotOnboardingSession({ status: 404 }),
+    )
+    expect(names(cmds)).not.toContain('ClearAutopilotOnboardingStorage')
+    expect(flowOf(after).transcript.length).toBe(1)
+  })
+
+  test('a 404 with an EMPTY transcript and NO in-flight turn still clears (genuinely dead pointer)', () => {
+    install()
+    let model = initLoggedOut(AutopilotRoute())
+    // Restore a session whose local transcript is empty and nothing in flight,
+    // then a 404 reconcile — this is the only case that should clear.
+    ;[model] = update(
+      model,
+      LoadedStoredAutopilotOnboarding({
+        session: {
+          sessionId: 'ob_dead',
+          vertical: null,
+          status: 'interviewing',
+          transcript: [],
+          outputSpec: {},
+          inFlight: null,
+          updatedAt: 1,
+        },
+      }),
+    )
+    const [after, cmds] = update(
+      model,
+      FailedReconcileAutopilotOnboardingSession({ status: 404 }),
+    )
+    expect(names(cmds)).toEqual(['ClearAutopilotOnboardingStorage'])
+    expect(flowOf(after).sessionId).toBeNull()
+    expect(flowOf(after).transcript).toEqual([])
+  })
+})
+
+describe('autopilot onboarding — rehydration fires for BOTH auth states', () => {
+  // The live bug report was from a LOGGED-IN owner. This pins which top-level
+  // submodel a /autopilot onboarding user mounts, and that `initialCommands`
+  // rehydrates in every case where the onboarding PAGE is actually shown.
+
+  test('a logged-OUT visitor on /autopilot mounts LoggedOut and rehydrates', () => {
+    const [model, commands] = init(
+      Flags.make({ maybeAuth: Option.none() }),
+      autopilotUrl as never,
+    )
+    expect((model as { _tag: string })._tag).toBe('LoggedOut')
+    expect(names(commands)).toContain('RehydrateAutopilotOnboarding')
+  })
+
+  test('a logged-in NO-WORKSPACE user (no core team) on /autopilot mounts LoggedOut and rehydrates', () => {
+    const [model, commands] = init(
+      Flags.make({ maybeAuth: Option.some(baseAuth) }),
+      autopilotUrl as never,
+    )
+    expect((model as { _tag: string })._tag).toBe('LoggedOut')
+    expect(names(commands)).toContain('RehydrateAutopilotOnboarding')
+  })
+
+  test('a logged-in core-team user with INCOMPLETE onboarding on /autopilot mounts LoggedOut and rehydrates', () => {
+    const auth = {
+      ...baseAuth,
+      teams: coreTeam,
+      onboarding: incompleteOnboardingStatus(),
+    }
+    const [model, commands] = init(
+      Flags.make({ maybeAuth: Option.some(auth) }),
+      autopilotUrl as never,
+    )
+    expect((model as { _tag: string })._tag).toBe('LoggedOut')
+    expect(names(commands)).toContain('RehydrateAutopilotOnboarding')
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/autopilot-onboarding/resume.test.ts
+++ b/apps/openagents.com/apps/web/src/page/autopilot-onboarding/resume.test.ts
@@ -149,11 +149,42 @@ describe('autopilot onboarding — reconcile with the server', () => {
     expect(commandNames(commands)).toContain('PersistAutopilotOnboarding')
   })
 
-  test('a 404 reconcile clears storage and starts fresh', () => {
+  test('a 404 reconcile KEEPS a restored transcript (does not wipe the conversation)', () => {
+    // A 404 means the server has no PERSISTED row yet — which happens MID-FIRST-
+    // TURN, before the turn finalizes. Clearing here used to silently destroy
+    // the user's real, resumable conversation on reload (the live bug). A 404
+    // with a non-empty restored transcript must KEEP it; the durable resume
+    // read / a later reconcile is the authority for the in-flight tail.
     const base = init(AutopilotRoute())
     const [restored] = update(
       base,
       LoadedStoredAutopilotOnboarding({ session: storedSession() }),
+    )
+
+    const [kept, commands] = update(
+      restored,
+      FailedReconcileAutopilotOnboardingSession({ status: 404 }),
+    )
+
+    const flow = flowOf(kept)
+    expect(flow.sessionId).toBe('ob_resume_1')
+    expect(flow.transcript).toEqual([
+      { role: 'user', content: 'I run a law office' },
+      { role: 'assistant', content: 'Got it — what do you need first?' },
+    ])
+    // No clear — the conversation survives.
+    expect(commandNames(commands)).not.toContain('ClearAutopilotOnboardingStorage')
+  })
+
+  test('a 404 reconcile clears ONLY a genuinely empty/no-in-flight session', () => {
+    // The only safe clear: a 404 with NOTHING in flight and an EMPTY transcript
+    // (a truly dead/expired pointer).
+    const base = init(AutopilotRoute())
+    const [restored] = update(
+      base,
+      LoadedStoredAutopilotOnboarding({
+        session: storedSession({ transcript: [], inFlight: null }),
+      }),
     )
 
     const [cleared, commands] = update(

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
@@ -1547,15 +1547,33 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         ]
       },
       FailedReconcileAutopilotOnboardingSession: ({ status }) => {
-        // 404 => the session expired or is unknown server-side: clear the stored
-        // record and start fresh (preserve the route's vertical). A transient
-        // network error (status 0) keeps the locally restored transcript.
+        // A transient network error (status 0) keeps the locally restored
+        // transcript untouched.
         if (status !== 404) {
           return [model, []]
         }
+        const flow = model.autopilotOnboarding
+        // A 404 means the server has no PERSISTED session row for this id. That
+        // is NOT always "stale/expired" — the FIRST turn's row is only written
+        // when that turn FINALIZES (after the stream drains). A refresh that
+        // lands mid-first-turn (or before the durable/D1 write is visible) sees
+        // a 404 even though the conversation is real and resumable from the
+        // durable log. Clearing here is what silently wiped the whole
+        // conversation on reload (the live bug). So: if a turn was mid-stream
+        // (a resuming in-flight cursor) OR we have a locally restored
+        // transcript, KEEP it — the durable resume read owns the in-flight tail
+        // and the local transcript is the user's real conversation; a later
+        // reconcile (after the turn finalizes server-side) will adopt the
+        // authoritative row. Only a 404 with NOTHING in flight and an EMPTY
+        // transcript is a genuinely dead pointer worth clearing.
+        const hasInFlight = flow.inFlight !== null
+        const hasTranscript = flow.transcript.length > 0
+        if (hasInFlight || hasTranscript) {
+          return [model, []]
+        }
         const nextModel = evo(model, {
-          autopilotOnboarding: flow =>
-            evo(flow, {
+          autopilotOnboarding: current =>
+            evo(current, {
               sessionId: () => null,
               status: () => 'idle',
               errorReason: () => null,

--- a/apps/openagents.com/apps/web/src/routing/startup.test.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.test.ts
@@ -7,6 +7,7 @@ import {
   incompleteOnboardingStatus,
 } from '../domain/session'
 import {
+  AutopilotRoute,
   AutopilotWorkRoute,
   ChatRoute,
   Demo2OrderRoute,
@@ -648,5 +649,52 @@ describe('startup route policy', () => {
         }),
       ),
     ).toBe(false)
+  })
+
+  // The /autopilot onboarding PAGE is served by the LoggedOut submodel for
+  // EVERY auth state that actually shows it — that is what makes the LoggedOut
+  // `initialCommands` (which fires `RehydrateAutopilotOnboarding`) the single
+  // rehydration owner regardless of login. Pin it so a future routing change
+  // cannot silently move a logged-in onboarding user onto a non-rehydrating
+  // path and reintroduce the "refresh loses the conversation" bug.
+  test('a logged-in user with INCOMPLETE onboarding gets /autopilot via the LoggedOut submodel', () => {
+    expect(startupRouteForLoggedIn(AutopilotRoute(), incompleteAuth)).toEqual({
+      _tag: 'LoggedOutStartupRoute',
+      route: AutopilotRoute(),
+      redirect: Option.none(),
+    })
+  })
+
+  test('a logged-in user WITHOUT the core team (no workspace) gets /autopilot via the LoggedOut submodel', () => {
+    // Onboarding complete, but no operator workspace -> the public onboarding
+    // page (same as logged-out), not the cockpit.
+    expect(
+      startupRouteForLoggedIn(AutopilotRoute(), {
+        ...auth,
+        onboarding: completedOnboardingStatus(),
+      }),
+    ).toEqual({
+      _tag: 'LoggedOutStartupRoute',
+      route: AutopilotRoute(),
+      redirect: Option.none(),
+    })
+  })
+
+  test('a logged-out visitor gets /autopilot via the LoggedOut submodel', () => {
+    expect(startupRouteForLoggedOut(AutopilotRoute())).toEqual({
+      _tag: 'LoggedOutStartupRoute',
+      route: AutopilotRoute(),
+      redirect: Option.none(),
+    })
+  })
+
+  test('a logged-in core-team user with a workspace lands on the cockpit, not the onboarding page', () => {
+    // The only logged-in case that does NOT show the onboarding page: it routes
+    // to the chat cockpit (LoggedIn), so no onboarding rehydration is needed.
+    expect(startupRouteForLoggedIn(AutopilotRoute(), completeAuth)).toEqual({
+      _tag: 'LoggedInStartupRoute',
+      route: ChatRoute(),
+      redirect: Option.none(),
+    })
   })
 })

--- a/apps/openagents.com/workers/api/src/autopilot-onboarding-resume-handshake.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-onboarding-resume-handshake.test.ts
@@ -1,0 +1,282 @@
+// Full server-side onboarding resume handshake — the SERVER half of the
+// client↔server reload-resume contract, wired through the REAL routes, a REAL
+// in-process durable substrate (the `@openagentsinc/durable-stream`
+// `MemoryStreamStore` behind `handleRequest`), a SQLite-backed D1 session
+// store, and a SCRIPTED multi-delta inference source.
+//
+// This regression-covers the live "refresh loses the whole conversation" bug.
+// The root cause is a server-side TIMING fact the client must tolerate: the
+// session ROW is only written when a turn FINALIZES (after the stream drains).
+// So a refresh that lands MID-FIRST-TURN sees:
+//   - GET /api/autopilot/onboarding/{sessionId}  => 404 (row not written yet)
+//   - GET .../turn/{turnIndex}/stream?offset=... => 200 (durable log replays)
+// The client previously treated that 404 as "stale, clear everything" and wiped
+// the user's real, resumable conversation. This test pins the server behaviour
+// (404-before-finalize, durable-replay-while-in-flight, 200-after-finalize) so
+// the client contract it feeds (see the web `resume-handshake.test.ts`) stays
+// honest.
+
+import { DatabaseSync } from 'node:sqlite'
+
+import {
+  MemoryStreamStore,
+  type StreamStore,
+  handleRequest,
+  streamIdFromUrl,
+} from '@openagentsinc/durable-stream'
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type OnboardingInferenceClient,
+  type OnboardingStreamClient,
+  type OnboardingStreamSource,
+} from './autopilot-onboarding-program'
+import { makeAutopilotOnboardingRoutes } from './autopilot-onboarding-routes'
+import { type DurableStreamNamespace } from './inference/durable-inference-do-transport'
+
+// MINIMAL D1 OVER node:sqlite (mirrors the routes test harness) --------------
+
+type Row = Record<string, unknown>
+class Stmt {
+  private bound: ReadonlyArray<unknown> = []
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+  bind(...values: ReadonlyArray<unknown>): Stmt {
+    this.bound = values.map(v => (v === undefined ? null : v))
+    return this
+  }
+  async first<T = Row>(): Promise<T | null> {
+    return (this.db.prepare(this.sql).get(...(this.bound as never[])) ??
+      null) as T | null
+  }
+  async run(): Promise<{ success: true; results: [] }> {
+    this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { success: true, results: [] }
+  }
+}
+class D1 {
+  constructor(private readonly db: DatabaseSync) {}
+  prepare(sql: string): Stmt {
+    return new Stmt(this.db, sql)
+  }
+}
+
+const SCHEMA = `
+CREATE TABLE autopilot_onboarding_sessions (
+  id TEXT PRIMARY KEY NOT NULL,
+  vertical_overlay TEXT,
+  status TEXT NOT NULL DEFAULT 'interviewing'
+    CHECK (status IN ('interviewing', 'complete')),
+  transcript_json TEXT NOT NULL DEFAULT '[]',
+  output_spec_json TEXT NOT NULL DEFAULT '{}',
+  turn_count INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+`
+
+type Env = { OPENAGENTS_DB: D1Database }
+
+const makeEnv = (): Env => {
+  const raw = new DatabaseSync(':memory:')
+  raw.exec(SCHEMA)
+  return { OPENAGENTS_DB: new D1(raw) as unknown as D1Database }
+}
+
+const run = (effect: Effect.Effect<Response> | undefined): Promise<Response> => {
+  if (effect === undefined) {
+    throw new Error('route did not match')
+  }
+  return Effect.runPromise(effect)
+}
+
+const echoInference: OnboardingInferenceClient = request =>
+  Effect.succeed(`assistant-reply (saw ${request.messages.length} messages)`)
+
+// REAL in-process DO backend: one MemoryStreamStore per stream id.
+class StreamRegistry {
+  private readonly stores = new Map<string, StreamStore>()
+  private storeFor(streamId: string): StreamStore {
+    let s = this.stores.get(streamId)
+    if (s === undefined) {
+      s = new MemoryStreamStore()
+      this.stores.set(streamId, s)
+    }
+    return s
+  }
+  fetch(request: Request): Promise<Response> {
+    const streamId = streamIdFromUrl(request.url)
+    if (streamId === null) {
+      return Promise.resolve(new Response('nope', { status: 404 }))
+    }
+    return handleRequest(this.storeFor(streamId), request, { streamId })
+  }
+}
+
+const durableNamespace = (registry: StreamRegistry): DurableStreamNamespace => ({
+  getByName: () => ({ fetch: (r: Request) => registry.fetch(r) }),
+})
+
+// A SCRIPTED stream source that emits MULTIPLE deltas and a controllable
+// completion gate. The producer drain runs after the request Effect resolves;
+// `release()` lets the test hold the turn "mid-stream" so it can probe the
+// not-yet-finalized server state before the durable tee + finalize complete.
+const gatedStream = (
+  chunks: ReadonlyArray<string>,
+): { client: OnboardingStreamClient; release: () => void; done: Promise<void> } => {
+  let releaseGate: () => void = () => {}
+  const gate = new Promise<void>(resolve => {
+    releaseGate = resolve
+  })
+  let resolveDone: () => void = () => {}
+  const done = new Promise<void>(resolve => {
+    resolveDone = resolve
+  })
+  const client: OnboardingStreamClient = () =>
+    Effect.succeed<OnboardingStreamSource>({
+      deltas: (async function* () {
+        for (let i = 0; i < chunks.length; i += 1) {
+          // Hold AFTER the first delta until the test releases, so the turn is
+          // genuinely mid-stream (durable log has bytes, session row absent).
+          if (i === 1) {
+            await gate
+          }
+          yield chunks[i]!
+        }
+        resolveDone()
+      })(),
+      final: () => chunks.join(''),
+    })
+  return { client, release: () => releaseGate(), done }
+}
+
+const streamRequest = (sessionId: string, body: unknown): Request =>
+  new Request(
+    `https://openagents.com/api/autopilot/onboarding/${sessionId}/turn`,
+    {
+      body: JSON.stringify(body),
+      method: 'POST',
+      headers: { accept: 'text/event-stream' },
+    },
+  )
+
+const getSession = (
+  routes: ReturnType<typeof makeAutopilotOnboardingRoutes<Env>>,
+  env: Env,
+  sessionId: string,
+) =>
+  run(
+    routes.routeOnboardingTurnRequest(
+      new Request(`https://openagents.com/api/autopilot/onboarding/${sessionId}`, {
+        method: 'GET',
+      }),
+      env,
+    ),
+  )
+
+const resumeRead = (
+  routes: ReturnType<typeof makeAutopilotOnboardingRoutes<Env>>,
+  env: Env,
+  sessionId: string,
+  turnIndex: number,
+  offset: string,
+) =>
+  run(
+    routes.routeOnboardingTurnRequest(
+      new Request(
+        `https://openagents.com/api/autopilot/onboarding/${sessionId}/turn/${turnIndex}/stream?offset=${offset}`,
+        { method: 'GET' },
+      ),
+      env,
+    ),
+  )
+
+describe('onboarding resume handshake — server contract for reload-resume', () => {
+  test('GET session is 404 MID-FIRST-TURN, but the durable read replays the in-flight turn (the bug condition)', async () => {
+    const registry = new StreamRegistry()
+    const env = makeEnv()
+    const gated = gatedStream(['AAA', 'BBB', 'CCC'])
+    const routes = makeAutopilotOnboardingRoutes<Env>({
+      makeInferenceClient: () => echoInference,
+      makeStreamClient: () => gated.client,
+      resolveDurableStream: () => durableNamespace(registry),
+      nowIso: () => '2026-06-23T00:00:00.000Z',
+    })
+
+    // Open the first turn's stream. The handshake + first delta flush; the
+    // source then holds (mid-stream) until we release.
+    const stream = await run(
+      routes.routeOnboardingTurnRequest(
+        streamRequest('sess-mid', { userText: 'I run a bakery.' }),
+        env,
+      ),
+    )
+    expect(stream.status).toBe(200)
+    // The durable stream id + resume url the client persists from the handshake.
+    expect(stream.headers.get('openagents-onboarding-stream-id')).toBe(
+      'onboarding:sess-mid:0',
+    )
+
+    // Begin draining so the producer tee writes the handshake + first delta into
+    // the durable log, then pauses at the gate.
+    const body = stream.body
+    if (body === null) throw new Error('no stream body')
+    const reader = body.getReader()
+    // Pull enough to ensure the handshake + first delta have been teed.
+    await reader.read()
+    await reader.read()
+    // Give the async tee a tick to flush the held bytes to the durable store.
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    // MID-FIRST-TURN REFRESH: the session ROW is not written yet (finalize has
+    // not run), so GET session is a 404 — exactly what made the client wipe the
+    // conversation.
+    const midSession = await getSession(routes, env, 'sess-mid')
+    expect(midSession.status).toBe(404)
+
+    // ...yet the durable log already holds the in-flight turn and replays it,
+    // so the conversation is genuinely RESUMABLE despite the 404. (The client
+    // must therefore NOT clear on this 404.)
+    const midResume = await resumeRead(routes, env, 'sess-mid', 0, '0')
+    expect(midResume.status).toBe(200)
+    const midResumeBody = await midResume.text()
+    expect(midResumeBody).toContain('event: delta\ndata: {"text":"AAA"}')
+
+    // Release the held stream and drain to completion (finalize runs: append +
+    // persist the session row).
+    gated.release()
+    for (;;) {
+      const { done } = await reader.read()
+      if (done) break
+    }
+    await gated.done
+    // Let the post-drain finalize (Effect.runPromise) settle.
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    // AFTER FINALIZE: the session row exists; the reconcile GET now returns the
+    // authoritative transcript.
+    const doneSession = await getSession(routes, env, 'sess-mid')
+    expect(doneSession.status).toBe(200)
+    const json = (await doneSession.json()) as {
+      sessionId: string
+      turnCount: number
+      transcript: ReadonlyArray<{ role: string; content: string }>
+    }
+    expect(json.sessionId).toBe('sess-mid')
+    expect(json.turnCount).toBe(1)
+    expect(json.transcript.some(t => t.role === 'user')).toBe(true)
+    expect(json.transcript.some(t => t.role === 'assistant')).toBe(true)
+
+    // The completed durable log replays the full turn (delta..done) on resume.
+    const finalResume = await resumeRead(routes, env, 'sess-mid', 0, '0')
+    expect(finalResume.status).toBe(200)
+    expect(finalResume.headers.get('stream-closed')).toBe('true')
+    const finalBody = await finalResume.text()
+    expect(finalBody).toContain('event: delta\ndata: {"text":"AAA"}')
+    expect(finalBody).toContain('event: delta\ndata: {"text":"CCC"}')
+    expect(finalBody).toContain('event: done')
+  })
+})


### PR DESCRIPTION
Follow-up to #6168.

## Symptom
On the deployed `/autopilot` onboarding flow, streaming worked but **refreshing the page lost the entire conversation** — the browser-side persistence/rehydration shipped in #6168 did not restore the messages in the live app. Reported by a logged-in user.

## Actual root cause (confirmed, not assumed)
The reported diagnosis was that rehydration never fires for logged-in users. I verified empirically that this is **not** the gap: routing already mounts the `/autopilot` onboarding PAGE through the **LoggedOut submodel** for every auth state that actually shows it (logged-out, and logged-in users without a workspace / with incomplete onboarding), so `LoggedOut.initialCommands` — which fires `RehydrateAutopilotOnboarding` — is the single rehydration owner regardless of login. The only logged-in case that skips onboarding routes to the chat cockpit.

The real bug is a server-timing fact the client mishandled: the onboarding session **row is only written when a turn FINALIZES** (after the stream drains). A refresh that lands **mid-first-turn** therefore gets a **404** from the reconcile `GET /api/autopilot/onboarding/{sessionId}` even though the conversation is real and still resumable from the durable log. The reconcile handler treated **any** 404 as "stale/expired" and called `ClearAutopilotOnboardingStorage()` — silently wiping the whole conversation on reload.

Persistence itself was **not** missing for the logged-in path; rehydration **was** wired; the defect was the 404-clears-everything reconcile branch destroying a valid, resumable transcript.

## The fix
On a 404 reconcile, **keep** the conversation when a turn is mid-stream (a resuming in-flight cursor) **or** a local transcript exists. Only a 404 with an **empty** transcript and **nothing** in flight (a genuinely dead pointer) clears. The durable resume read remains the authority for the in-flight tail; a later reconcile adopts the authoritative row once the turn finalizes.

Also refactored `persistence.ts` onto an injectable `OnboardingStoragePort` (`window.localStorage`-backed in production, in-memory in tests) so the full client↔server reload-resume handshake is exercisable headlessly.

## Verification
- **Headless Effect-wired handshake (primary proof):**
  - `workers/api`: real routes + real `MemoryStreamStore` durable + scripted multi-delta inference — asserts GET session is **404 mid-first-turn** while the durable read **replays the in-flight turn**, then **200 + transcript after finalize**.
  - `apps/web`: real `update`/`initialCommands` loop driven through the in-memory storage port — stream → persist → reload → rehydrate → **404 reconcile keeps the conversation** → resume completes; covered for **both auth states**. Fails without the fix, passes with it.
  - Startup routing-invariant tests pin that logged-in onboarding users mount the rehydrating LoggedOut path; persistence-port unit coverage added.
- **Real browser (chromium against local dev server):** before the fix the reload **loses** the transcript and wipes `localStorage`; after the fix the reload **restores** the transcript and keeps storage. Verified logged-out path live; the logged-in gap is regression-covered by the routing + handshake tests.
- `typecheck:web`, `typecheck:api`, full onboarding/loggedOut/startup suites, and `check:deploy` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)