### PR TITLE
Restore inference: Khala degrades to Vertex Gemini on Hydralisk outage; /khala chat Enter-to-submit

### DIFF
--- a/apps/openagents.com/apps/web/src/page/khala-chat/page.ts
+++ b/apps/openagents.com/apps/web/src/page/khala-chat/page.ts
@@ -164,6 +164,15 @@ const composerView = <Message>(
           h.Value(model.composerDraft),
           h.OnInput(value => actions.updatedComposer(value)),
           h.AriaLabel('Message Khala'),
+          // Enter submits the turn; Shift+Enter inserts a newline.
+          h.OnKeyDownPreventDefault((key, modifiers) =>
+            key === 'Enter' &&
+            !modifiers.shiftKey &&
+            !inFlight &&
+            model.composerDraft.trim() !== ''
+              ? Option.some(actions.submittedTurn())
+              : Option.none(),
+          ),
         ],
         submitAttrs,
       }),

--- a/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.ts
@@ -50,6 +50,14 @@ const classifyStatus = (
   if (status >= 500) {
     return { kind: 'upstream_error', retryable: true }
   }
+  // Lane-level auth/routing failures (401 unauthorized, 403 forbidden, 404 not
+  // found) mean THIS serving lane is unavailable or misconfigured — not that the
+  // request itself is bad. Treat them as retryable so `dispatchWithOverflow`
+  // overflows to the next lane (e.g. the Khala Vertex Gemini fallback) instead of
+  // failing the whole request. Genuine client errors (400/422) stay non-retryable.
+  if (status === 401 || status === 403 || status === 404) {
+    return { kind: 'lane_unavailable', retryable: true }
+  }
   return { kind: 'request_rejected', retryable: false }
 }
 

--- a/apps/openagents.com/workers/api/src/inference/model-router.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.test.ts
@@ -141,12 +141,13 @@ describe('model classification', () => {
     }
   })
 
-  test('routes the single Khala model through Hydralisk, using either internal slug or external id', () => {
+  test('routes the single Khala model through Hydralisk, then degrades to Vertex Gemini on full outage', () => {
     for (const model of [KHALA_MODEL_SLUG, KHALA_MODEL_ID]) {
       expect(classifyModel(model)).toBe('open')
       expect(selectAdapterPlan(model)).toEqual([
         HYDRALISK_GPT_OSS_120B_ADAPTER_ID,
         HYDRALISK_ADAPTER_ID,
+        VERTEX_GEMINI_ADAPTER_ID,
       ])
     }
   })

--- a/apps/openagents.com/workers/api/src/inference/model-router.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.ts
@@ -248,7 +248,19 @@ const LANE_PLAN_BY_CLASS: Readonly<
 export const selectAdapterPlan = (model: string): ReadonlyArray<string> => {
   const normalizedModel = normalizeKhalaModelId(model)
   if (normalizedModel === KHALA_MODEL_ID) {
-    return [HYDRALISK_GPT_OSS_120B_ADAPTER_ID, HYDRALISK_ADAPTER_ID]
+    // Khala-first: the Hydralisk GPT-OSS lanes (120B, then 20B) serve the
+    // collapsed public Khala model. Vertex Gemini is the FINAL graceful-
+    // degradation overflow so a full Hydralisk outage degrades to Gemini
+    // instead of failing the whole product with `inference_unavailable`
+    // (the vertex-gemini adapter is registered at module load and reads
+    // VERTEX_SA_KEY via the shared adapter env). Explicit `hydralisk-gpt-oss-*`
+    // model ids below keep NO Gemini fallback — they are deliberate GPT-OSS
+    // requests, not the generic Khala lane.
+    return [
+      HYDRALISK_GPT_OSS_120B_ADAPTER_ID,
+      HYDRALISK_ADAPTER_ID,
+      VERTEX_GEMINI_ADAPTER_ID,
+    ]
   }
   if (normalizedModel === HYDRALISK_GPT_OSS_20B_MODEL_ID) {
     return [HYDRALISK_ADAPTER_ID]

--- a/apps/openagents.com/workers/api/src/khala-chat-program.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-program.ts
@@ -34,7 +34,7 @@ import { KHALA_IDENTITY_SYSTEM_PROMPT } from './inference/khala-identity'
 
 // The live public Khala model for the generic chat demo (same model id the
 // onboarding program uses; the cheapest-viable router lane).
-export const KHALA_CHAT_MODEL = 'openagents/khala-mini'
+export const KHALA_CHAT_MODEL = 'khala'
 
 // Bounds: a single message body and the whole running conversation are capped so
 // a public, unauthenticated demo cannot push an unbounded prompt through the


### PR DESCRIPTION
Production fix. The Hydralisk GPT-OSS serving endpoint (the collapsed Khala lane) returns 403, which was classified non-retryable -> dispatchWithOverflow surfaced it immediately and 502'd ALL internal inference (onboarding + /khala chat). Fixes: (1) treat serving-lane 401/403/404 as lane-unavailable (retryable -> overflow); (2) add Vertex Gemini as the final overflow on the Khala plan (Hydralisk-first, Gemini on outage); (3) /khala composer: Enter submits, Shift+Enter newlines; (4) use the internal 'khala' model slug. NOTE: the Hydralisk endpoint's 403 (auth) is a real infra issue to fix separately so the GPT-OSS lane actually serves.