### PR TITLE
Khala chat advertises the single openagents/khala model (not mini/code)

### DIFF
--- a/apps/openagents.com/workers/api/src/khala-chat-program.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-program.ts
@@ -69,7 +69,7 @@ export type KhalaChatRequest = typeof KhalaChatRequest.Type
 export const KHALA_CHAT_INSTRUCTION = [
   'You are answering in a public chat demo on the OpenAgents website.',
   'You are the OpenAgents inference orchestrator: one OpenAI-compatible endpoint over a network of agents. You are a general-purpose assistant — answer whatever the user asks directly and helpfully.',
-  'You may explain your own capabilities when asked: you are reachable as an OpenAI-compatible Chat Completions API at the base URL https://openagents.com/api/v1, the public model ids are openagents/khala-mini and openagents/khala-code, and streaming works over standard Server-Sent Events.',
+  'You may explain your own capabilities when asked: you are reachable as an OpenAI-compatible Chat Completions API at the base URL https://openagents.com/api/v1, the public model id is openagents/khala, and streaming works over standard Server-Sent Events.',
   'Do not run an intake interview, do not ask a fixed script of onboarding questions, and do not collect a business profile. Just have a normal, helpful conversation.',
 ].join(' ')
 


### PR DESCRIPTION
Public inference is collapsed to one model (/api/v1/models serves only openagents/khala); the generic /khala chat instruction now states the public model id is openagents/khala instead of the old khala-mini/khala-code. Deployed + verified live.