### PR TITLE
Abort timed-out MPP Lightning MDK mints

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -6732,6 +6732,7 @@ const mdkLightningInvoiceIssuerForEnv = (
 
   const post = async (
     body: Readonly<Record<string, unknown>>,
+    options?: Readonly<{ signal?: AbortSignal | undefined }>,
   ): Promise<Readonly<{ ok: boolean; status: number; payload: unknown }>> => {
     const request = new Request(routeUrl, {
       body: JSON.stringify(body),
@@ -6740,6 +6741,7 @@ const mdkLightningInvoiceIssuerForEnv = (
         'x-moneydevkit-webhook-secret': routeSecret,
       },
       method: 'POST',
+      ...(options?.signal === undefined ? {} : { signal: options.signal }),
     })
     const response = isSidecar
       ? await fetchMdkSidecarRequest(request, env)

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.test.ts
@@ -37,6 +37,7 @@ import {
   type LightningInvoice,
   type MintLightningInvoice,
   LightningInvoiceError,
+  makeFallbackLightningInvoiceIssuer,
 } from './mpp-lightning-invoice'
 import { sha256Hex } from './mpp-lightning-verify'
 import { buildChallenge, type MppChallenge } from './mpp-protocol'
@@ -1592,5 +1593,50 @@ describe('MPP endpoint — Lightning rail (Bitcoin-first)', () => {
     expect(problem.challenges.some(c => c.method === 'lightning')).toBe(false)
     expect(problem.challenges.some(c => c.method === 'base')).toBe(true)
     expect(problem.challenges.some(c => c.method === 'stripe')).toBe(true)
+  })
+
+  test('OUTER GUARD aborts the caller signal when MDK fallback starts after a slow primary', async () => {
+    const db = makeDb()
+    let fallbackSignal: AbortSignal | undefined
+    const primary: MintLightningInvoice = () =>
+      Effect.sleep(Duration.millis(6_000)).pipe(
+        Effect.andThen(
+          Effect.fail(new LightningInvoiceError('provider_unavailable')),
+        ),
+      )
+    const fallback: MintLightningInvoice = input => {
+      fallbackSignal = input.abortSignal
+      return Effect.never
+    }
+    const response = await run(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(
+          handleMppChatCompletions(mppRequest(), {
+            completionDeps: completionDeps(db),
+            db,
+            enabled: true,
+            fetch: lightningQuoteFetch(),
+            lightningEnabled: true,
+            mintLightningInvoice: makeFallbackLightningInvoiceIssuer(
+              primary,
+              fallback,
+            ),
+            newId: () => 'fixed',
+            signingSecret: SIGNING_SECRET,
+            stripeNetworkProfileId: 'profile_test',
+            stripeSecretKey: 'sk_test_x',
+          }),
+        )
+        yield* TestClock.adjust(7_000)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(response.status).toBe(402)
+    expect(fallbackSignal).toBeInstanceOf(AbortSignal)
+    expect(fallbackSignal?.aborted).toBe(true)
+    const wwwAuth = response.headers.get('www-authenticate') ?? ''
+    expect(wwwAuth).not.toContain('method="lightning"')
+    expect(wwwAuth).toContain('method="base"')
+    expect(wwwAuth).toContain('method="stripe"')
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts
@@ -462,51 +462,55 @@ const buildLightningChallengeForQuote = (
   input: Readonly<{ model: string; newId: () => string; challengeExpiresAt: string }>,
 ): Effect.Effect<MppChallenge | undefined, never> =>
   Effect.gen(function* () {
+    const abortController = new AbortController()
     const nowMs = deps.nowMs ?? currentEpochMillis
     const legStartMs = nowMs()
-    const lightningQuote = quoteMppLightningCall({ model: input.model })
-    const invoice = yield* mint({
-      amountSats: lightningQuote.amountSats,
-      correlationRef: `mpp:lightning:${input.model}:${input.newId()}`,
-      description: modelDescription(input.model),
-    }).pipe(
-      // DIAGNOSTIC (#6049): observe WHY a Lightning leg drops in prod tail. The
-      // mint cause is the actual drop reason (typed `provider_unavailable` /
-      // `provider_rejected` / `malformed_invoice`, an interrupt, or the inner
-      // mint timeout). Logged with elapsed ms; carries NO invoice/secret content.
-      Effect.tapCause((cause: Cause.Cause<unknown>) =>
-        Effect.logWarning('mpp_lightning_leg_dropped', {
-          elapsedMs: nowMs() - legStartMs,
-          model: input.model,
-          reason: Cause.pretty(cause).slice(0, 240),
-        }),
-      ),
-    )
-    // Effective expiry = earlier of challenge TTL and invoice BOLT11 expiry
-    // (spec §"Challenge Expiry and Invoice Expiry"). The challenge `expires`
-    // auth-param MUST NOT be later than the invoice expiry.
-    const challengeExpires =
-      invoice.invoiceExpiresAt !== undefined &&
-      Date.parse(invoice.invoiceExpiresAt) <
-        Date.parse(input.challengeExpiresAt)
-        ? invoice.invoiceExpiresAt
-        : input.challengeExpiresAt
-    const challenge = yield* buildLightningChallenge(signingSecret, {
-      amountSats: lightningQuote.amountSats,
-      bolt11: invoice.bolt11,
-      expires: challengeExpires,
-      invoiceExpiresAt: invoice.invoiceExpiresAt,
-      model: input.model,
-      network: invoice.network,
-      paymentHash: invoice.paymentHash,
-    })
-    // DIAGNOSTIC (#6049): a Lightning leg that actually minted + surfaced, with
-    // elapsed ms. NO invoice/secret content.
-    yield* Effect.logInfo('mpp_lightning_leg_surfaced', {
-      elapsedMs: nowMs() - legStartMs,
-      model: input.model,
-    })
-    return challenge
+    return yield* Effect.gen(function* () {
+      const lightningQuote = quoteMppLightningCall({ model: input.model })
+      const invoice = yield* mint({
+        abortSignal: abortController.signal,
+        amountSats: lightningQuote.amountSats,
+        correlationRef: `mpp:lightning:${input.model}:${input.newId()}`,
+        description: modelDescription(input.model),
+      }).pipe(
+        // DIAGNOSTIC (#6049): observe WHY a Lightning leg drops in prod tail. The
+        // mint cause is the actual drop reason (typed `provider_unavailable` /
+        // `provider_rejected` / `malformed_invoice`, an interrupt, or the inner
+        // mint timeout). Logged with elapsed ms; carries NO invoice/secret content.
+        Effect.tapCause((cause: Cause.Cause<unknown>) =>
+          Effect.logWarning('mpp_lightning_leg_dropped', {
+            elapsedMs: nowMs() - legStartMs,
+            model: input.model,
+            reason: Cause.pretty(cause).slice(0, 240),
+          }),
+        ),
+      )
+      // Effective expiry = earlier of challenge TTL and invoice BOLT11 expiry
+      // (spec §"Challenge Expiry and Invoice Expiry"). The challenge `expires`
+      // auth-param MUST NOT be later than the invoice expiry.
+      const challengeExpires =
+        invoice.invoiceExpiresAt !== undefined &&
+        Date.parse(invoice.invoiceExpiresAt) <
+          Date.parse(input.challengeExpiresAt)
+          ? invoice.invoiceExpiresAt
+          : input.challengeExpiresAt
+      const challenge = yield* buildLightningChallenge(signingSecret, {
+        amountSats: lightningQuote.amountSats,
+        bolt11: invoice.bolt11,
+        expires: challengeExpires,
+        invoiceExpiresAt: invoice.invoiceExpiresAt,
+        model: input.model,
+        network: invoice.network,
+        paymentHash: invoice.paymentHash,
+      })
+      // DIAGNOSTIC (#6049): a Lightning leg that actually minted + surfaced, with
+      // elapsed ms. NO invoice/secret content.
+      yield* Effect.logInfo('mpp_lightning_leg_surfaced', {
+        elapsedMs: nowMs() - legStartMs,
+        model: input.model,
+      })
+      return challenge
+    }).pipe(Effect.ensuring(Effect.sync(() => abortController.abort())))
   }).pipe(
     // Outer per-rail safety net: bound the WHOLE leg, then swallow ANY cause
     // (typed error, the timeout's `TimeoutException`, or an interrupt/defect)

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.test.ts
@@ -40,8 +40,10 @@ describe('normalizeMdkLightningRouteUrl', () => {
 describe('makeMdkLightningInvoiceIssuer', () => {
   test('posts a SAT create_checkout and reads the raw bolt11 + paymentHash', async () => {
     let seen: Record<string, unknown> | undefined
-    const post: MdkRoutePost = async body => {
+    let seenSignal: AbortSignal | undefined
+    const post: MdkRoutePost = async (body, options) => {
       seen = body
+      seenSignal = options?.signal
       return {
         ok: true,
         payload: {
@@ -73,6 +75,8 @@ describe('makeMdkLightningInvoiceIssuer', () => {
     expect(params.currency).toBe('SAT')
     expect(params.amount).toBe(42)
     expect(params.type).toBe('AMOUNT')
+    expect(seenSignal).toBeInstanceOf(AbortSignal)
+    expect(seenSignal?.aborted).toBe(false)
   })
 
   test('maps a 5xx route status to provider_unavailable', async () => {
@@ -131,8 +135,10 @@ describe('makeMdkLightningInvoiceIssuer', () => {
   // NEVER resolves; advancing past the timeout must produce the typed failure.
   test('a HUNG post is bounded by the mint timeout => provider_unavailable (no hang)', async () => {
     let postStarted = false
-    const post: MdkRoutePost = () => {
+    let seenSignal: AbortSignal | undefined
+    const post: MdkRoutePost = (_body, options) => {
       postStarted = true
+      seenSignal = options?.signal
       // Never resolves — models a cold/blocked container boot.
       return new Promise(() => {})
     }
@@ -153,6 +159,7 @@ describe('makeMdkLightningInvoiceIssuer', () => {
       }).pipe(Effect.provide(TestClock.layer())),
     )
     expect(postStarted).toBe(true)
+    expect(seenSignal?.aborted).toBe(true)
     expect(result).toBe('provider_unavailable')
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts
@@ -39,6 +39,7 @@ export const MDK_LIGHTNING_MINT_TIMEOUT_MS = 2_000
 // hosted MDK route client uses for the `self_hosted_mdkd_sidecar` route kind.
 export type MdkRoutePost = (
   body: Readonly<Record<string, unknown>>,
+  options?: Readonly<{ signal?: AbortSignal | undefined }>,
 ) => Promise<Readonly<{ ok: boolean; status: number; payload: unknown }>>
 
 // The self-hosted MDK sidecar exposes exactly `/api/mdk`; its internal bridge
@@ -135,19 +136,31 @@ export const makeMdkLightningInvoiceIssuer = (
 ): MintLightningInvoice => input =>
   Effect.gen(function* () {
     const amountSats = Math.max(1, Math.trunc(input.amountSats))
+    const abortController = new AbortController()
+    const relayInputAbort = () => abortController.abort()
+    if (input.abortSignal?.aborted === true) {
+      abortController.abort()
+    } else {
+      input.abortSignal?.addEventListener('abort', relayInputAbort, {
+        once: true,
+      })
+    }
     const result = yield* Effect.tryPromise({
       catch: () => new LightningInvoiceError('provider_unavailable'),
       try: () =>
-        post({
-          handler: 'create_checkout',
-          params: {
-            amount: amountSats,
-            currency: 'SAT',
-            metadata: { correlation_ref: input.correlationRef },
-            title: 'openagents_khala_mpp_lightning',
-            type: 'AMOUNT',
+        post(
+          {
+            handler: 'create_checkout',
+            params: {
+              amount: amountSats,
+              currency: 'SAT',
+              metadata: { correlation_ref: input.correlationRef },
+              title: 'openagents_khala_mpp_lightning',
+              type: 'AMOUNT',
+            },
           },
-        }),
+          { signal: abortController.signal },
+        ),
     }).pipe(
       // Bounded mint: a cold/slow MDK sidecar container can block for seconds.
       // `Effect.tryPromise` catches throws, NOT a hang — so we cap the wall-clock
@@ -157,8 +170,17 @@ export const makeMdkLightningInvoiceIssuer = (
       Effect.timeoutOrElse({
         duration: Duration.millis(timeoutMs),
         orElse: () =>
-          Effect.fail(new LightningInvoiceError('provider_unavailable')),
+          Effect.sync(() => abortController.abort()).pipe(
+            Effect.andThen(
+              Effect.fail(new LightningInvoiceError('provider_unavailable')),
+            ),
+          ),
       }),
+      Effect.ensuring(
+        Effect.sync(() =>
+          input.abortSignal?.removeEventListener('abort', relayInputAbort),
+        ),
+      ),
     )
     if (!result.ok) {
       return yield* Effect.fail(

--- a/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice.ts
+++ b/apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice.ts
@@ -57,6 +57,7 @@ export class LightningInvoiceError extends Error {
 // wires the real sidecar-backed implementation; tests inject a fake.
 export type MintLightningInvoice = (
   input: Readonly<{
+    abortSignal?: AbortSignal | undefined
     amountSats: number
     description: string
     // A public-safe correlation ref (the model + a request nonce) for the


### PR DESCRIPTION
## Problem

The current MPP Lightning isolation work bounds slow MDK minting so crypto/card 402s keep returning, but the MDK transport itself was not receiving an abort signal. A timed-out sidecar `create_checkout` could still keep the underlying request alive after the rail had already been dropped.

## Change

- Add an optional abort signal to the Lightning invoice issuer surface.
- Create an internal `AbortController` for MDK invoice minting, pass its signal into the Worker `Request`, and abort it when the MDK mint timeout fires.
- Relay any caller-provided abort signal into the internal controller.
- Extend MDK issuer tests to assert the transport receives a signal and that the hung-post timeout aborts it.

## Validation

- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/mpp/mpp-chat-completions-routes.test.ts src/inference/mpp/mpp-lightning-invoice-mdk.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/mpp`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:architecture`
- `bun run check:deploy` reached the desktop visual smoke path, then failed because this host has no Chrome/Chromium/Edge binary and `CHROME_PATH` is unset: `Chrome executable not found. Set CHROME_PATH to a Chrome, Chromium, or Edge binary before running smoke:training-scene.`

## Out of scope

- Prod arming/deploy verification.
- Stripe directory crawl/badge work.
- Real prod MDK/Spark verification.
- Settlement/payout changes.
- Crypto/card rail behavior changes.
- Promise green flip.
