### PR TITLE
fix(inference): publish Khala free-tier catalog status

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -11014,8 +11014,8 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     // Public model catalog (OpenAI-compatible GET /v1/models) for the inference
     // gateway. INERT by default: gated behind the SAME INFERENCE_GATEWAY_ENABLED
     // flag as /v1/chat/completions, so it 404s when the gateway is off. Public,
-    // unauthenticated, public-safe (published sell prices + free-tier flag only,
-    // no prompts/credentials/balances) — the pre-purchase discovery surface a
+    // unauthenticated, public-safe (published sell prices + free-key tier policy
+    // only, no prompts/credentials/balances) — the pre-purchase discovery surface a
     // credits customer reads to learn what each model costs before funding a
     // balance. Derived from the SAME pricing table the metering hook charges
     // against, so the published price cannot drift from the billed price. No
@@ -11024,6 +11024,7 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     handler: (request, env) =>
       handleModelsList(request, {
         enabled: isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED),
+        freeTierEnabled: isFreeTierEnabled(env.INFERENCE_FREE_TIER_ENABLED),
         laneArming: resolveSupplyLaneArming(env),
       }),
   },
@@ -11265,12 +11266,13 @@ const routeRequest = makeWorkerRouteRequest({
   // OpenAI-compatible GET /v1/models/{model} retrieve. Gated by the SAME
   // INFERENCE_GATEWAY_ENABLED flag as the list and chat-completions routes, so
   // it 404s when the gateway is off. Public + unauthenticated (published price
-  // and policy only — public-safe pre-purchase discovery), serving prices
-  // derived from the same pricing table the metering hook charges against. No
-  // promise state changes; the paid loop is still secrets-gated.
+  // and free-key tier policy only — public-safe pre-purchase discovery), serving
+  // prices derived from the same pricing table the metering hook charges
+  // against. No promise state changes; the paid loop is still secrets-gated.
   routeModelRetrieveRequest: (request, env) =>
     routeModelRetrieveRequest(request, {
       enabled: isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED),
+      freeTierEnabled: isFreeTierEnabled(env.INFERENCE_FREE_TIER_ENABLED),
       laneArming: resolveSupplyLaneArming(env),
     }),
   // Durable inference resume read GET /v1/chat/completions/durable/{requestId}

--- a/apps/openagents.com/workers/api/src/inference/gateway-readiness-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gateway-readiness-routes.test.ts
@@ -19,6 +19,13 @@ const ALL_ARMED: SupplyLaneArming = {
 
 const entry = (id: string, lane: SupplyLane): ModelCatalogEntry => ({
   costBasis: 'verified',
+  freeTier: {
+    eligible: false,
+    maxRequestsPerDay: null,
+    maxTokensPerDay: null,
+    reasonRef: 'reason.inference_free_tier.disabled',
+    window: null,
+  },
   freeTierEligible: false,
   id,
   lane,

--- a/apps/openagents.com/workers/api/src/inference/gateway-readiness.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gateway-readiness.test.ts
@@ -35,6 +35,13 @@ const HYDRALISK_ARMED_ENV = {
 // readiness projection counts only the public Khala row.
 const entry = (id: string, lane: SupplyLane): ModelCatalogEntry => ({
   costBasis: 'verified',
+  freeTier: {
+    eligible: false,
+    maxRequestsPerDay: null,
+    maxTokensPerDay: null,
+    reasonRef: 'reason.inference_free_tier.disabled',
+    window: null,
+  },
   freeTierEligible: false,
   id,
   lane,

--- a/apps/openagents.com/workers/api/src/inference/model-catalog.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-catalog.test.ts
@@ -7,9 +7,14 @@ import {
   toOpenAiModelsResponse,
 } from './model-catalog'
 import {
+  DEFAULT_FREE_TIER_QUOTA,
+  FREE_TIER_REASON_ELIGIBLE,
+} from './inference-free-tier-key'
+import {
   DEFAULT_MARGIN,
   HYDRALISK_GPT_OSS_120B_MODEL_ID,
   HYDRALISK_GPT_OSS_20B_MODEL_ID,
+  KHALA_MODEL_ID,
   MODEL_PRICING_TABLE,
   sellPricePerMtok,
 } from './pricing'
@@ -55,9 +60,32 @@ describe('buildModelCatalog', () => {
     }
   })
 
-  it('marks only the Gemini free-tier lane as free-tier eligible', () => {
+  it('keeps the public free API tier disabled by default', () => {
     const free = buildModelCatalog().filter(m => m.freeTierEligible)
-    expect(free.map(m => m.id)).toEqual(['gemini-3.5-flash'])
+    expect(free.map(m => m.id)).toEqual([])
+    expect(buildModelCatalog().find(m => m.id === KHALA_MODEL_ID)?.freeTier)
+      .toEqual({
+        eligible: false,
+        maxRequestsPerDay: null,
+        maxTokensPerDay: null,
+        reasonRef: 'reason.inference_free_tier.disabled',
+        window: null,
+      })
+  })
+
+  it('marks only public Khala as free-key eligible when free API mode is armed', () => {
+    const catalog = buildModelCatalog(DEFAULT_MARGIN, {
+      freeTierEnabled: true,
+    })
+    const free = catalog.filter(m => m.freeTierEligible)
+    expect(free.map(m => m.id)).toEqual([KHALA_MODEL_ID])
+    expect(catalog.find(m => m.id === KHALA_MODEL_ID)?.freeTier).toEqual({
+      eligible: true,
+      maxRequestsPerDay: DEFAULT_FREE_TIER_QUOTA.maxRequestsPerDay,
+      maxTokensPerDay: DEFAULT_FREE_TIER_QUOTA.maxTokensPerDay,
+      reasonRef: FREE_TIER_REASON_ELIGIBLE,
+      window: 'utc_day',
+    })
   })
 
   it('marks Fireworks open models as verified cost basis and Vertex as list placeholder', () => {
@@ -115,12 +143,34 @@ describe('toOpenAiModelsResponse', () => {
     expect(first.oa_price.inputUsdPerMtok).toBeGreaterThanOrEqual(0)
   })
 
-  it('carries the OpenAgents price/policy extension fields', () => {
+  it('carries the OpenAgents price/policy extension fields when free API mode is disabled', () => {
     const response = toOpenAiModelsResponse(buildModelCatalog(), 1)
-    const gemini = response.data.find(m => m.id === 'gemini-3.5-flash')!
-    expect(gemini.oa_free_tier_eligible).toBe(true)
-    expect(gemini.oa_lane).toBe('vertex-gemini')
-    expect(gemini.oa_cost_basis).toBe('list_placeholder')
+    const khala = response.data.find(m => m.id === KHALA_MODEL_ID)!
+    expect(khala.oa_free_tier_eligible).toBe(false)
+    expect(khala.oa_free_tier).toEqual({
+      eligible: false,
+      maxRequestsPerDay: null,
+      maxTokensPerDay: null,
+      reasonRef: 'reason.inference_free_tier.disabled',
+      window: null,
+    })
+    expect(khala.oa_price.inputUsdPerMtok).toBeGreaterThanOrEqual(0)
+  })
+
+  it('projects Khala as free-key eligible with quota when free API mode is armed', () => {
+    const response = toOpenAiModelsResponse(
+      buildModelCatalog(DEFAULT_MARGIN, { freeTierEnabled: true }),
+      1,
+    )
+    const khala = response.data.find(m => m.id === KHALA_MODEL_ID)!
+    expect(khala.oa_free_tier_eligible).toBe(true)
+    expect(khala.oa_free_tier).toEqual({
+      eligible: true,
+      maxRequestsPerDay: DEFAULT_FREE_TIER_QUOTA.maxRequestsPerDay,
+      maxTokensPerDay: DEFAULT_FREE_TIER_QUOTA.maxTokensPerDay,
+      reasonRef: FREE_TIER_REASON_ELIGIBLE,
+      window: 'utc_day',
+    })
   })
 
   it('publishes sell price >= the underlying cost basis (margin is non-negative)', () => {
@@ -170,12 +220,12 @@ describe('findModelCatalogEntry', () => {
 
 describe('toOpenAiModelObject', () => {
   it('projects a single model object matching the list projection', () => {
-    const entry = findModelCatalogEntry('gemini-3.5-flash')!
+    const entry = findModelCatalogEntry(KHALA_MODEL_ID)!
     const single = toOpenAiModelObject(entry, 1_700_000_000)
     const fromList = toOpenAiModelsResponse(
       buildModelCatalog(),
       1_700_000_000,
-    ).data.find(m => m.id === 'gemini-3.5-flash')!
+    ).data.find(m => m.id === KHALA_MODEL_ID)!
     expect(single).toEqual(fromList)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/model-catalog.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-catalog.ts
@@ -13,10 +13,10 @@
 //
 // PURE: no D1, no clock, no network, no secrets. It exposes ONLY public-safe
 // facts already implied by the pricing table (model id, supply lane, published
-// sell price per 1M tokens, free-tier eligibility, cost-basis provenance). It
-// moves no money and reveals no prompts, completions, or credentials. The route
-// handler (`handleModelsList`, models-routes.ts) injects the `created` timestamp
-// and serves this as the OpenAI `/v1/models` payload.
+// sell price per 1M tokens, current free-key catalog policy, cost-basis
+// provenance). It moves no money and reveals no prompts, completions, or
+// credentials. The route handler (`handleModelsList`, models-routes.ts) injects
+// the `created` timestamp and serves this as the OpenAI `/v1/models` payload.
 
 import {
   BASE_CREDIT_USD,
@@ -25,7 +25,10 @@ import {
   MODEL_PRICING_TABLE,
   type SupplyLane,
 } from './pricing'
-import { isFreeEligibleModel } from './inference-free-allowance'
+import {
+  DEFAULT_FREE_TIER_QUOTA,
+  decideFreeTierLane,
+} from './inference-free-tier-key'
 
 // Human-legible provider label for each supply lane (the OpenAI `owned_by`
 // field). All lanes are served THROUGH OpenAgents, so the label names the
@@ -59,6 +62,22 @@ export type PublishedModelPrice = Readonly<{
   outputCreditsPerMtok: number
 }>
 
+// Public free-key policy for one model. This is the self-serve per-key free
+// tier from `inference-free-tier-key.ts`, not the older owner-keyed Gemini
+// allowance. The `eligible` boolean is false unless the Worker has explicitly
+// armed INFERENCE_FREE_TIER_ENABLED.
+export type PublishedModelFreeTier = Readonly<{
+  eligible: boolean
+  maxRequestsPerDay: number | null
+  maxTokensPerDay: number | null
+  window: 'utc_day' | null
+  reasonRef: string
+}>
+
+export type ModelCatalogPolicy = Readonly<{
+  freeTierEnabled?: boolean
+}>
+
 // One public catalog entry for a model the gateway serves.
 export type ModelCatalogEntry = Readonly<{
   // Canonical model id (the `model` a client sends to /v1/chat/completions).
@@ -67,10 +86,11 @@ export type ModelCatalogEntry = Readonly<{
   lane: SupplyLane
   // Legible provider label (OpenAI `owned_by`).
   ownedBy: string
-  // True when this model class is free-tier eligible (Gemini Flash today): under
-  // the owner's Sybil-resistant free pool such requests cost no credits. Every
-  // other model is PAID from the first token.
+  // True when the public self-serve free-key tier is live for this model.
+  // Backward-compatible shorthand for `freeTier.eligible`.
   freeTierEligible: boolean
+  // Public self-serve free-key policy for this model.
+  freeTier: PublishedModelFreeTier
   // Published per-model multiplier relative to the Sonnet baseline (1.0x).
   multiplier: number
   // Cost-basis provenance of the published price.
@@ -86,12 +106,42 @@ const round = (value: number, decimals: number): number => {
   return Math.round(value * factor) / factor
 }
 
-// Is this model class free-tier eligible? Single source of truth is the
-// free-allowance policy (`FREE_ELIGIBLE_MODEL_CLASSES`); the catalog reuses it
-// so the published free-tier flag can never disagree with what actually gets
-// eaten under allowance.
-const isFreeTierEligible = (model: string): boolean =>
-  isFreeEligibleModel(model)
+const FREE_TIER_DISABLED_REASON =
+  'reason.inference_free_tier.disabled' as const
+
+const disabledFreeTier = (): PublishedModelFreeTier => ({
+  eligible: false,
+  maxRequestsPerDay: null,
+  maxTokensPerDay: null,
+  reasonRef: FREE_TIER_DISABLED_REASON,
+  window: null,
+})
+
+const freeTierForModel = (
+  model: string,
+  policy: ModelCatalogPolicy,
+): PublishedModelFreeTier => {
+  if (policy.freeTierEnabled !== true) {
+    return disabledFreeTier()
+  }
+  const lane = decideFreeTierLane(model)
+  if (!lane.freeLane) {
+    return {
+      eligible: false,
+      maxRequestsPerDay: null,
+      maxTokensPerDay: null,
+      reasonRef: lane.reasonRef,
+      window: null,
+    }
+  }
+  return {
+    eligible: true,
+    maxRequestsPerDay: DEFAULT_FREE_TIER_QUOTA.maxRequestsPerDay,
+    maxTokensPerDay: DEFAULT_FREE_TIER_QUOTA.maxTokensPerDay,
+    reasonRef: lane.reasonRef,
+    window: 'utc_day',
+  }
+}
 
 // Build the public model catalog from the pricing table at `margin`
 // (defaults to the launch margin). Deterministic + pure: the same table in
@@ -99,6 +149,7 @@ const isFreeTierEligible = (model: string): boolean =>
 // when the cost table is tuned.
 export const buildModelCatalog = (
   margin: number = DEFAULT_MARGIN,
+  policy: ModelCatalogPolicy = {},
 ): ReadonlyArray<ModelCatalogEntry> =>
   MODEL_PRICING_TABLE.map(entry => {
     const { cost } = entry
@@ -110,12 +161,14 @@ export const buildModelCatalog = (
     const inputUsd = sell(cost.inputUsdPerMtok)
     const cachedUsd = sell(cachedCostUsdPerMtok)
     const outputUsd = sell(cost.outputUsdPerMtok)
+    const freeTier = freeTierForModel(entry.model, policy)
 
     return {
       costBasis: entry.costIsListPlaceholder
         ? ('list_placeholder' as const)
         : ('verified' as const),
-      freeTierEligible: isFreeTierEligible(entry.model),
+      freeTier,
+      freeTierEligible: freeTier.eligible,
       id: entry.model,
       lane: entry.lane,
       multiplier: entry.multiplier,
@@ -146,6 +199,7 @@ export type OpenAiModelObject = Readonly<{
   owned_by: string
   oa_lane: SupplyLane
   oa_free_tier_eligible: boolean
+  oa_free_tier: PublishedModelFreeTier
   oa_multiplier: number
   oa_cost_basis: ModelCostBasis
   oa_price: PublishedModelPrice
@@ -168,6 +222,7 @@ export const toOpenAiModelObject = (
   created: createdEpochSeconds,
   id: model.id,
   oa_cost_basis: model.costBasis,
+  oa_free_tier: model.freeTier,
   oa_free_tier_eligible: model.freeTierEligible,
   oa_lane: model.lane,
   oa_multiplier: model.multiplier,
@@ -197,9 +252,10 @@ export const toOpenAiModelsResponse = (
 export const findModelCatalogEntry = (
   modelId: string,
   margin: number = DEFAULT_MARGIN,
+  policy: ModelCatalogPolicy = {},
 ): ModelCatalogEntry | undefined => {
   if (modelId.trim() === '') {
     return undefined
   }
-  return buildModelCatalog(margin).find(entry => entry.id === modelId)
+  return buildModelCatalog(margin, policy).find(entry => entry.id === modelId)
 }

--- a/apps/openagents.com/workers/api/src/inference/model-serving-policy.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-serving-policy.ts
@@ -407,7 +407,6 @@ export const projectKhalaCatalogForArming = (
       ? {
           ...entry,
           costBasis: backing.costBasis,
-          freeTierEligible: backing.freeTierEligible,
           lane: backing.lane,
           multiplier: backing.multiplier,
           ownedBy: backing.ownedBy,

--- a/apps/openagents.com/workers/api/src/inference/models-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/models-routes.test.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import { buildModelCatalog } from './model-catalog'
+import { DEFAULT_FREE_TIER_QUOTA } from './inference-free-tier-key'
 import { resolveSupplyLaneArming } from './model-serving-policy'
 import {
   handleModelRetrieve,
@@ -54,13 +55,59 @@ describe('handleModelsList', () => {
     expect(response.headers.get('cache-control')).toBe('no-store')
     const body = (await response.json()) as {
       object: string
-      data: ReadonlyArray<{ id: string; created: number; object: string }>
+      data: ReadonlyArray<{
+        id: string
+        created: number
+        object: string
+        oa_free_tier_eligible: boolean
+        oa_free_tier: { eligible: boolean; maxRequestsPerDay: number | null }
+      }>
     }
     expect(body.object).toBe('list')
     expect(body.data.length).toBe(1)
     expect(body.data.every(m => m.object === 'model')).toBe(true)
     expect(body.data.every(m => m.created === 1_700_000_000)).toBe(true)
     expect(body.data.map(m => m.id)).toEqual([KHALA_MODEL_ID])
+    expect(body.data[0]!.oa_free_tier_eligible).toBe(false)
+    expect(body.data[0]!.oa_free_tier.eligible).toBe(false)
+    expect(body.data[0]!.oa_free_tier.maxRequestsPerDay).toBeNull()
+  })
+
+  it('advertises the Khala free-key quota when free API mode is armed', async () => {
+    const response = await run(
+      new Request('https://x/v1/models', { method: 'GET' }),
+      {
+        enabled: true,
+        freeTierEnabled: true,
+        nowEpochSeconds: () => 1_700_000_000,
+      },
+    )
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      data: ReadonlyArray<{
+        id: string
+        oa_free_tier_eligible: boolean
+        oa_free_tier: {
+          eligible: boolean
+          maxRequestsPerDay: number
+          maxTokensPerDay: number
+          window: string
+        }
+      }>
+    }
+    expect(body.data).toEqual([
+      expect.objectContaining({
+        id: KHALA_MODEL_ID,
+        oa_free_tier_eligible: true,
+        oa_free_tier: {
+          eligible: true,
+          maxRequestsPerDay: DEFAULT_FREE_TIER_QUOTA.maxRequestsPerDay,
+          maxTokensPerDay: DEFAULT_FREE_TIER_QUOTA.maxTokensPerDay,
+          reasonRef: 'reason.inference_free_tier.eligible',
+          window: 'utc_day',
+        },
+      }),
+    ])
   })
 })
 
@@ -100,12 +147,48 @@ describe('handleModelRetrieve', () => {
       id: string
       object: string
       created: number
+      oa_free_tier_eligible: boolean
+      oa_free_tier: { eligible: boolean }
       oa_price: { inputUsdPerMtok: number }
     }
     expect(body.id).toBe(servedModelId)
     expect(body.object).toBe('model')
     expect(body.created).toBe(1_700_000_000)
+    expect(body.oa_free_tier_eligible).toBe(false)
+    expect(body.oa_free_tier.eligible).toBe(false)
     expect(typeof body.oa_price.inputUsdPerMtok).toBe('number')
+  })
+
+  it('retrieves Khala with free-key quota when free API mode is armed', async () => {
+    const response = await runRetrieve(
+      new Request(`https://x/v1/models/${servedModelId}`, { method: 'GET' }),
+      servedModelId,
+      {
+        enabled: true,
+        freeTierEnabled: true,
+        nowEpochSeconds: () => 1_700_000_000,
+      },
+    )
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      id: string
+      oa_free_tier_eligible: boolean
+      oa_free_tier: {
+        eligible: boolean
+        maxRequestsPerDay: number
+        maxTokensPerDay: number
+        window: string
+      }
+    }
+    expect(body.id).toBe(servedModelId)
+    expect(body.oa_free_tier_eligible).toBe(true)
+    expect(body.oa_free_tier).toEqual({
+      eligible: true,
+      maxRequestsPerDay: DEFAULT_FREE_TIER_QUOTA.maxRequestsPerDay,
+      maxTokensPerDay: DEFAULT_FREE_TIER_QUOTA.maxTokensPerDay,
+      reasonRef: 'reason.inference_free_tier.eligible',
+      window: 'utc_day',
+    })
   })
 
   it('404s with the OpenAI model_not_found shape for an unknown model', async () => {
@@ -327,13 +410,15 @@ describe('provider serving policy (laneArming)', () => {
     })
     const list = await run(
       new Request('https://x/v1/models', { method: 'GET' }),
-      { enabled: true, laneArming },
+      { enabled: true, freeTierEnabled: true, laneArming },
     )
     expect(list.status).toBe(200)
     const listBody = (await list.json()) as {
       data: ReadonlyArray<{
         id: string
         oa_lane: string
+        oa_free_tier_eligible: boolean
+        oa_free_tier: { eligible: boolean; maxRequestsPerDay: number }
         owned_by: string
         oa_price: { inputUsdPerMtok: number }
       }>
@@ -342,6 +427,11 @@ describe('provider serving policy (laneArming)', () => {
       expect.objectContaining({
         id: KHALA_MODEL_ID,
         oa_lane: 'fireworks',
+        oa_free_tier_eligible: true,
+        oa_free_tier: expect.objectContaining({
+          eligible: true,
+          maxRequestsPerDay: DEFAULT_FREE_TIER_QUOTA.maxRequestsPerDay,
+        }),
         owned_by: 'openagents/fireworks',
       }),
     ])
@@ -352,17 +442,23 @@ describe('provider serving policy (laneArming)', () => {
     const retrieved = await runRetrieve(
       new Request(`https://x/v1/models/${KHALA_MODEL_ID}`, { method: 'GET' }),
       KHALA_MODEL_ID,
-      { enabled: true, laneArming },
+      { enabled: true, freeTierEnabled: true, laneArming },
     )
     expect(retrieved.status).toBe(200)
     const body = (await retrieved.json()) as {
       id: string
       oa_lane: string
+      oa_free_tier_eligible: boolean
+      oa_free_tier: { eligible: boolean; maxRequestsPerDay: number }
       owned_by: string
       oa_price: { inputUsdPerMtok: number }
     }
     expect(body.id).toBe(KHALA_MODEL_ID)
     expect(body.oa_lane).toBe('fireworks')
+    expect(body.oa_free_tier_eligible).toBe(true)
+    expect(body.oa_free_tier.maxRequestsPerDay).toBe(
+      DEFAULT_FREE_TIER_QUOTA.maxRequestsPerDay,
+    )
     expect(body.owned_by).toBe('openagents/fireworks')
     expect(body.oa_price.inputUsdPerMtok).toBe(0.196)
   })

--- a/apps/openagents.com/workers/api/src/inference/models-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/models-routes.ts
@@ -21,6 +21,7 @@ import { currentEpochSeconds } from '../runtime-primitives'
 import {
   buildModelCatalog,
   findModelCatalogEntry,
+  type ModelCatalogPolicy,
   toOpenAiModelObject,
   toOpenAiModelsResponse,
 } from './model-catalog'
@@ -42,6 +43,9 @@ export type ModelsListDeps = Readonly<{
   nowEpochSeconds?: () => number
   // Catalog margin override (defaults to the launch margin inside the catalog).
   margin?: number
+  // Whether the self-serve free API mode is armed. This drives only the public
+  // catalog projection (`oa_free_tier*`), not the quota/key/balance gates.
+  freeTierEnabled?: boolean
   // Provider serving policy: which supply lanes are armed (credential present).
   // When supplied, the catalog is narrowed to ONLY models the gateway can
   // actually serve, so a paid gateway never advertises an unservable model
@@ -49,6 +53,10 @@ export type ModelsListDeps = Readonly<{
   // (the prior behaviour — preserved for callers that do not gate on arming).
   laneArming?: SupplyLaneArming
 }>
+
+const catalogPolicy = (deps: ModelsListDeps): ModelCatalogPolicy => ({
+  freeTierEnabled: deps.freeTierEnabled === true,
+})
 
 // Serve the OpenAI-compatible `/v1/models` listing for the gateway.
 export const handleModelsList = (request: Request, deps: ModelsListDeps) =>
@@ -70,7 +78,7 @@ export const handleModelsList = (request: Request, deps: ModelsListDeps) =>
     }
 
     const now = (deps.nowEpochSeconds ?? currentEpochSeconds)()
-    const fullCatalog = buildModelCatalog(deps.margin)
+    const fullCatalog = buildModelCatalog(deps.margin, catalogPolicy(deps))
     // PROVIDER POLICY: when the worker supplies lane arming, advertise only the
     // models whose supply lane is actually servable right now; otherwise list
     // the full catalog (prior behaviour).
@@ -111,14 +119,14 @@ export const handleModelRetrieve = (
 
     const catalog =
       deps.laneArming === undefined
-        ? buildModelCatalog(deps.margin)
+        ? buildModelCatalog(deps.margin, catalogPolicy(deps))
         : projectKhalaCatalogForArming(
-            buildModelCatalog(deps.margin),
+            buildModelCatalog(deps.margin, catalogPolicy(deps)),
             deps.laneArming,
           )
     const entry =
       deps.laneArming === undefined
-        ? findModelCatalogEntry(modelId, deps.margin)
+        ? findModelCatalogEntry(modelId, deps.margin, catalogPolicy(deps))
         : catalog.find(model => model.id === modelId)
     // PROVIDER POLICY: when lane arming is supplied, a model whose lane is not
     // servable right now is reported `model_not_found` (same as an unknown id),

--- a/apps/openagents.com/workers/api/src/openagents-capability-manifest-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-capability-manifest-routes.test.ts
@@ -127,6 +127,12 @@ describe('OpenAgents capability manifest route', () => {
         }),
         expect.objectContaining({
           auth: 'public',
+          href: 'https://openagents.com/api/v1/models',
+          id: 'inference_models_catalog',
+          description: expect.stringContaining('oa_free_tier_eligible'),
+        }),
+        expect.objectContaining({
+          auth: 'public',
           href: 'https://openagents.com/AGENTS.md',
           id: 'agent_full_reference',
         }),

--- a/apps/openagents.com/workers/api/src/openagents-capability-manifest.ts
+++ b/apps/openagents.com/workers/api/src/openagents-capability-manifest.ts
@@ -244,7 +244,7 @@ export const openAgentsCapabilityManifest = (): Effect.Effect<
         method: 'GET',
         auth: 'public',
         description:
-          'OpenAI-compatible model catalog for the Khala inference gateway, with published per-1M-token price and policy. Public pre-purchase discovery exposes one model: openagents/khala. Inside OpenAgents-owned callers the slug is khala; raw GPT-OSS ids and old split names are internal/legacy implementation details, not public products.',
+          'OpenAI-compatible model catalog for the Khala inference gateway, with published per-1M-token price and policy. Public pre-purchase discovery exposes one model: openagents/khala. The oa_free_tier_eligible boolean and oa_free_tier quota object reflect the same INFERENCE_FREE_TIER_ENABLED arming and free-key lane policy as POST /api/keys/free. Inside OpenAgents-owned callers the slug is khala; raw GPT-OSS ids and old split names are internal/legacy implementation details, not public products.',
       },
       {
         id: 'agent_full_reference',

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -378,6 +378,22 @@ describe('OpenAgents OpenAPI route', () => {
     expect(operationAt(body, '/api/omni/sdk-seed', 'get').operationId).toBe(
       'getOmniApiSdkSeed',
     )
+    const inferenceModelsOperation = operationAt(body, '/api/v1/models', 'get')
+    expect(inferenceModelsOperation.operationId).toBe('listInferenceModels')
+    expect(inferenceModelsOperation.description).toEqual(
+      expect.stringContaining('oa_free_tier_eligible'),
+    )
+    const khalaTokensServedOperation = operationAt(
+      body,
+      '/api/public/khala-tokens-served',
+      'get',
+    )
+    expect(khalaTokensServedOperation.operationId).toBe(
+      'getPublicKhalaTokensServed',
+    )
+    expect(khalaTokensServedOperation.description).toEqual(
+      expect.stringContaining('tokensServed'),
+    )
     expect(operationAt(body, '/api/agents/me', 'get').operationId).toBe(
       'getProgrammaticAgentMe',
     )

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1706,6 +1706,9 @@ const schemaComponents = (): JsonSchema => ({
   PublicPylonStats: objectSummary(
     'Public-safe OpenAgents Pylon API aggregate for v0.2.5+ registration, heartbeat, and receipt-backed accepted-work settlement stats. Canonical fields include minimumClientVersion, pylonsRegisteredTotal, pylonsWalletReadyNow, pylonsAssignmentReadyNow, earningLaunchGate, nexusAcceptedWorkSettlementGate, nexusAcceptedWorkPayoutReceiptRefs, pylonsByResourceMode, pylonsByClientVersion, caveatRefs, and sourceRefs. Accepted-work sats are populated only from public settlement receipts that prove real bitcoin movement; unavailable receipt storage remains distinct from zero settled receipts. Online, wallet-ready, assignment-ready, and earningLaunchGate-ready states are not accepted-work, payout, or settlement evidence.',
   ),
+  PublicKhalaTokensServed: objectSummary(
+    'Public-safe Khala usage aggregate with schemaVersion, tokensServed, generatedAt, and the live_at_read public-projection staleness contract. It is computed from the token usage ledger as one network-wide scalar and excludes per-user, per-team, provider, prompt, completion, API key, wallet, payment, and secret material. Read-only; grants no billing, quota, payout, settlement, or model-performance claim authority.',
+  ),
   TrainingRunEnvelope: objectSummary(
     'Public-safe training-run projection with trainingRunRef, promiseRef, state, sourceRefs, receiptRefs, display timestamps, and optional summary metrics. Public summary metrics include provenance labels for windows, contributors, verification, receipt refs, provider-confirmed settled payout sats, and the CS336 A1 real-gradient status/loss/leaderboard projection. Pending, offered, claimed, and wallet-side records are not counted as paid. The real-gradient status remains blocked unless Psionic evidence includes two real contributor devices, Freivalds commitments, merge/eval refs, verified closeouts, and loss under budget. It grants no assignment, payout, model-publication, or spend authority.',
   ),
@@ -4552,19 +4555,19 @@ const paths = (): JsonSchema => ({
       operationId: 'listInferenceModels',
       summary: 'List inference gateway models',
       description:
-        'OpenAI-compatible model catalog for the Khala inference gateway. Public, pre-purchase discovery (published per-1M-token price + policy only; no prompts, balances, or credentials). The public catalog intentionally exposes one model: openagents/khala. Inside the OpenAgents ecosystem the slug is khala; external clients use openagents/khala. Raw GPT-OSS ids and old Khala split names are internal/legacy implementation details and are not public or MPP-payable. Canonical under the /api base; the legacy bare /v1/models path remains a non-breaking alias.',
+        'OpenAI-compatible model catalog for the Khala inference gateway. Public, pre-purchase discovery (published per-1M-token price + policy only; no prompts, balances, or credentials). The public catalog intentionally exposes one model: openagents/khala. Its oa_free_tier_eligible boolean and oa_free_tier quota object reflect the same INFERENCE_FREE_TIER_ENABLED arming and free-key lane policy as POST /api/keys/free. Inside the OpenAgents ecosystem the slug is khala; external clients use openagents/khala. Raw GPT-OSS ids and old Khala split names are internal/legacy implementation details and are not public or MPP-payable. Canonical under the /api base; the legacy bare /v1/models path remains a non-breaking alias.',
       tags: ['Inference'],
       security: publicRead,
       responses: {
         '200': {
           description:
-            'OpenAI-compatible { object: "list", data: [...] } model catalog. Each entry carries id, owned_by, and oa_* price/policy fields.',
+            'OpenAI-compatible { object: "list", data: [...] } model catalog. Each entry carries id, owned_by, and oa_* price/policy fields including oa_free_tier_eligible and oa_free_tier.',
           content: {
             'application/json': {
               schema: {
                 type: 'object',
                 description:
-                  'OpenAI /v1/models list response; data entries include only the public Khala model openagents/khala when its backing supply lane is armed.',
+                  'OpenAI /v1/models list response; data entries include only the public Khala model openagents/khala when its backing supply lane is armed. When free API mode is armed, openagents/khala carries oa_free_tier_eligible=true and an oa_free_tier quota object; otherwise it reports false.',
               },
             },
           },
@@ -4634,6 +4637,23 @@ const paths = (): JsonSchema => ({
       security: publicRead,
       responses: {
         '200': okJson('Pylon stats.', '#/components/schemas/PublicPylonStats'),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/public/khala-tokens-served': {
+    get: operation({
+      operationId: 'getPublicKhalaTokensServed',
+      summary: 'Read public Khala tokens-served aggregate',
+      description:
+        'Returns the public-safe network-wide Khala tokens-served aggregate from the token usage ledger. The response contains schemaVersion, tokensServed, generatedAt, and the live_at_read staleness contract only; it excludes per-user, per-team, provider, prompt, completion, API key, wallet, payment, and secret material.',
+      tags: ['Public Proof', 'Inference'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Khala tokens-served aggregate.',
+          '#/components/schemas/PublicKhalaTokensServed',
+        ),
         ...errorResponses(),
       },
     }),

--- a/docs/faq/khala-inference-quickstart.md
+++ b/docs/faq/khala-inference-quickstart.md
@@ -115,7 +115,7 @@ OpenAI SDKs: pass `stream=True` / `{ stream: true }` as usual.
 | Method & path | What it does | Auth |
 |---|---|---|
 | `POST /api/keys/free` | Mint a free-tier API key | none |
-| `GET  /api/v1/models` | List models (one: `openagents/khala`) + pricing | Bearer |
+| `GET  /api/v1/models` | List models (one: `openagents/khala`) + pricing/free-tier policy | none |
 | `POST /api/v1/chat/completions` | Chat completion (streaming + non-streaming) | Bearer |
 
 (`https://openagents.com/v1/...` is a non-breaking alias for `https://openagents.com/api/v1/...`.)
@@ -134,7 +134,8 @@ OpenAI SDKs: pass `stream=True` / `{ stream: true }` as usual.
 - **Free** within the quota above — real inference, no payment, on `openagents/khala`.
 - **Beyond the free quota** (or for higher throughput), it's the same key + credits/budget
   on your account; per-token pricing is published in `GET /api/v1/models`
-  (`oa_price`, in both USD and credits per million tokens).
+  (`oa_price`, in both USD and credits per million tokens; `oa_free_tier_eligible`
+  and `oa_free_tier` publish the current free-tier status and quota).
 - **One public model** — `openagents/khala`. The orchestrator picks the backing lane; you
   buy the outcome. (There is no `khala-mini`/`khala-pro`/`khala-code` — just `openagents/khala`.)
 


### PR DESCRIPTION
## Problem

Closes #6229.

`GET /api/v1/models` exposed the single public `openagents/khala` model, but its `oa_free_tier_eligible` flag still came from the older owner-keyed Gemini allowance logic. That made the catalog disagree with the #6228 self-serve free API mode when `INFERENCE_FREE_TIER_ENABLED` is armed.

Public claim: https://openagents.com/forum/t/9e615a3b-4379-4897-a463-62ca0a5257b3#post-b8216de0-1690-4e25-9021-600be7d04edd

## What Changed

- Drives the public model catalog's free-key projection from the same free-tier lane decider used by the gateway (`decideFreeTierLane`) and the same env arming read used by chat completions (`isFreeTierEnabled(env.INFERENCE_FREE_TIER_ENABLED)`).
- Keeps `oa_free_tier_eligible` as the compatibility boolean and adds `oa_free_tier` with `eligible`, quota limits, `window`, and `reasonRef`.
- Threads the free-tier catalog policy through `/v1/models` list and retrieve so both surfaces agree.
- Preserves provider/backing projection behavior: Hydralisk/Fireworks can change Khala price/lane, but they do not overwrite Khala's free-key policy.
- Updates focused tests, capability manifest/OpenAPI wording, and the Khala quickstart.
- Adds the missing OpenAPI entry for `/api/public/khala-tokens-served`, which the OpenAPI route-coverage test exposed while validating this PR.

## Validation

- `bun install --frozen-lockfile`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/model-catalog.test.ts src/inference/models-routes.test.ts src/inference/model-serving-policy.test.ts src/inference/gateway-readiness.test.ts src/inference/gateway-readiness-routes.test.ts src/openagents-capability-manifest-routes.test.ts src/openagents-openapi-routes.test.ts src/public-khala-tokens-served-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/inference-free-tier-key.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`

Typecheck exited 0. It still prints existing TS47 informational messages in `src/trace-store-routes.ts`; this PR does not touch that file.

## Intentionally Not Changed

- No billing, quota counter, key mint, provider routing, paid rail, MPP, or settlement behavior changes.
- No product-promise green claim.
- No changes to raw provider model IDs or Khala split-name public policy.
