### PR TITLE
Add Khala GLM REAP smoke verifier

### DIFF
--- a/apps/openagents.com/package.json
+++ b/apps/openagents.com/package.json
@@ -47,6 +47,7 @@
     "smoke:khala:billing-mpp-proof": "node scripts/khala-billing-mpp-proof-smoke.mjs",
     "smoke:khala:mpp-payloop": "node scripts/khala-mpp-payloop-smoke.mjs",
     "smoke:khala:gateway-readiness": "node scripts/khala-gateway-readiness-smoke.mjs",
+    "smoke:khala:glm-reap": "node scripts/khala-glm-reap-smoke.mjs",
     "monitor:khala:production-readiness": "node scripts/khala-production-readiness-monitor.mjs",
     "smoke:khala:production": "node scripts/khala-production-smoke.mjs",
     "smoke:gpt-oss20b-production": "node scripts/gpt-oss20b-production-smoke.mjs",

--- a/apps/openagents.com/scripts/khala-glm-reap-smoke.mjs
+++ b/apps/openagents.com/scripts/khala-glm-reap-smoke.mjs
@@ -1,0 +1,422 @@
+#!/usr/bin/env node
+
+import { setTimeout as sleep } from 'node:timers/promises'
+
+import { runKhalaProductionSmoke } from './khala-production-smoke.mjs'
+
+const defaultBaseUrl = 'https://openagents.com'
+const defaultApiPrefix = '/api/v1'
+const defaultModel = 'openagents/khala'
+const defaultPrompt =
+  'OpenAgents Khala GLM REAP smoke: answer with exactly READY and no other words.'
+const expectedSupplyLane = 'hydralisk'
+const expectedWorker = 'hydralisk-vllm-glm-5p2-reap-504b'
+const expectedServedModelContains = 'glm-5.2-reap-504b'
+const rawGlmModelId = 'openagents/glm-5.2-reap-504b'
+const defaultForbiddenPublicModelIds = [
+  rawGlmModelId,
+  'glm-5.2-reap-504b',
+  'openagents/khala-code',
+  'openagents/khala-mini',
+  'openai/gpt-oss-120b',
+  'openai/gpt-oss-20b',
+]
+const defaultServingProfileRefs = [
+  'glm-reap-504b-g4-tp4-minp-rp105',
+  'glm-reap-504b-g4-tp4-mtp2-rp105',
+  'glm-reap-504b-g4-dual-tp4-minp-rp105',
+]
+const publicSafeRefPattern = /^[a-z0-9][a-z0-9._:-]{1,199}$/iu
+
+const trimBaseUrl = baseUrl =>
+  String(baseUrl || defaultBaseUrl).replace(/\/+$/, '')
+
+const absoluteUrl = (baseUrl, pathOrUrl) =>
+  new URL(String(pathOrUrl || ''), baseUrl).toString()
+
+const truthy = value =>
+  ['1', 'true', 'yes', 'on'].includes(
+    String(value || '')
+      .trim()
+      .toLowerCase(),
+  )
+
+const csv = value =>
+  String(value || '')
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+
+const isPresent = value => typeof value === 'string' && value.trim() !== ''
+
+const isPublicSafeRef = value => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return false
+  }
+  const trimmed = value.trim()
+  return (
+    trimmed === value &&
+    publicSafeRefPattern.test(trimmed) &&
+    !trimmed.includes('://') &&
+    !trimmed.toLowerCase().startsWith('sk-')
+  )
+}
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+const okStatus = response => response.status >= 200 && response.status < 300
+
+const redact = value => {
+  if (typeof value !== 'string') {
+    return value
+  }
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gu, 'Bearer <redacted>')
+    .replace(/oa_agent_[A-Za-z0-9._~+/=-]+/gu, 'oa_agent_<redacted>')
+    .replace(/sk-[A-Za-z0-9]{8,}/gu, 'sk-<redacted>')
+}
+
+const readJson = async response => {
+  const text = await response.text()
+  try {
+    return text.length === 0 ? null : JSON.parse(text)
+  } catch {
+    return { rawText: text }
+  }
+}
+
+const requestJson = async (fetchImpl, baseUrl, path, init = {}) => {
+  const response = await fetchImpl(absoluteUrl(baseUrl, path), {
+    ...init,
+    headers: {
+      accept: 'application/json',
+      ...(init.headers || {}),
+    },
+  })
+  return { body: await readJson(response), response }
+}
+
+const numberFrom = value => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const publicTokensServedFrom = body =>
+  numberFrom(body?.tokensServed ?? body?.tokens_served)
+
+const receiptTokensFrom = receiptSummary =>
+  numberFrom(
+    receiptSummary?.modelEvidence?.total_tokens ??
+      receiptSummary?.modelEvidence?.totalTokens,
+  )
+
+export const resolveGlmReapArming = (env = process.env) => {
+  const blockerRefs = []
+  const evidenceRefs = []
+  const evidence = [
+    [
+      'blocker.hydralisk_glm_52_reap_504b.preflight_ref_missing',
+      env.HYDRALISK_GLM_52_REAP_504B_PREFLIGHT_REF,
+    ],
+    [
+      'blocker.hydralisk_glm_52_reap_504b.receipt_ref_missing',
+      env.HYDRALISK_GLM_52_REAP_504B_RECEIPT_REF,
+    ],
+  ]
+
+  if (env.HYDRALISK_GLM_52_REAP_504B_ENABLED?.trim() !== 'ready') {
+    blockerRefs.push('blocker.hydralisk_glm_52_reap_504b.route_not_ready')
+  }
+  if (!isPresent(env.HYDRALISK_GLM_52_REAP_504B_BASE_URL)) {
+    blockerRefs.push('blocker.hydralisk_glm_52_reap_504b.base_url_missing')
+  }
+  if (!isPresent(env.HYDRALISK_GLM_52_REAP_504B_BEARER_TOKEN)) {
+    blockerRefs.push('blocker.hydralisk_glm_52_reap_504b.bearer_missing')
+  }
+
+  for (const [blockerRef, value] of evidence) {
+    if (isPublicSafeRef(value)) {
+      evidenceRefs.push(value)
+    } else {
+      blockerRefs.push(blockerRef)
+    }
+  }
+
+  return {
+    armed: blockerRefs.length === 0,
+    blockerRefs,
+    evidenceRefs,
+  }
+}
+
+export const parseArgs = (argv, env = process.env) => {
+  const options = {
+    apiPrefix: env.OPENAGENTS_KHALA_GLM_REAP_API_PREFIX || defaultApiPrefix,
+    approveLiveSpend: truthy(
+      env.OPENAGENTS_KHALA_GLM_REAP_SMOKE_APPROVE_LIVE_SPEND,
+    ),
+    baseUrl: env.OPENAGENTS_BASE_URL || defaultBaseUrl,
+    counterSettleMs: Number(
+      env.OPENAGENTS_KHALA_GLM_REAP_COUNTER_SETTLE_MS || 3000,
+    ),
+    counterToleranceTokens: Number(
+      env.OPENAGENTS_KHALA_GLM_REAP_COUNTER_TOLERANCE_TOKENS || 0,
+    ),
+    forbiddenPublicModelIds: [
+      ...defaultForbiddenPublicModelIds,
+      ...csv(env.OPENAGENTS_KHALA_GLM_REAP_FORBIDDEN_PUBLIC_MODEL_IDS),
+    ],
+    model: env.OPENAGENTS_KHALA_GLM_REAP_SMOKE_MODEL || defaultModel,
+    prompt: env.OPENAGENTS_KHALA_GLM_REAP_SMOKE_PROMPT || defaultPrompt,
+    servingProfileRefs: [
+      ...defaultServingProfileRefs,
+      ...csv(env.OPENAGENTS_KHALA_GLM_REAP_SERVING_PROFILE_REFS),
+    ],
+    token:
+      env.OPENAGENTS_KHALA_GLM_REAP_SMOKE_TOKEN ||
+      env.OPENAGENTS_AGENT_TOKEN ||
+      '',
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--api-prefix') {
+      options.apiPrefix = argv[++index] || options.apiPrefix
+    } else if (value === '--base-url' || value === '--baseUrl') {
+      options.baseUrl = argv[++index] || options.baseUrl
+    } else if (value === '--counter-settle-ms') {
+      options.counterSettleMs = Number(argv[++index] || options.counterSettleMs)
+    } else if (value === '--counter-tolerance-tokens') {
+      options.counterToleranceTokens = Number(
+        argv[++index] || options.counterToleranceTokens,
+      )
+    } else if (value === '--forbid-public-model') {
+      const forbidden = argv[++index]
+      if (forbidden) {
+        options.forbiddenPublicModelIds.push(forbidden)
+      }
+    } else if (value === '--model') {
+      options.model = argv[++index] || options.model
+    } else if (value === '--prompt') {
+      options.prompt = argv[++index] || options.prompt
+    } else if (value === '--serving-profile-ref') {
+      const profileRef = argv[++index]
+      if (profileRef) {
+        options.servingProfileRefs.push(profileRef)
+      }
+    } else if (value === '--token') {
+      options.token = argv[++index] || options.token
+    } else if (value === '--approve-live-spend') {
+      options.approveLiveSpend = true
+    } else if (value === '--help' || value === '-h') {
+      options.help = true
+    } else {
+      throw new Error(`Unknown argument: ${value}`)
+    }
+  }
+
+  return options
+}
+
+export const usage = () => `Usage:
+  OPENAGENTS_AGENT_TOKEN=oa_agent_... \\
+    node scripts/khala-glm-reap-smoke.mjs --approve-live-spend
+
+Required arming env for a live run:
+  HYDRALISK_GLM_52_REAP_504B_ENABLED=ready
+  HYDRALISK_GLM_52_REAP_504B_BASE_URL=<secret endpoint, never printed>
+  HYDRALISK_GLM_52_REAP_504B_BEARER_TOKEN=<secret bearer, never printed>
+  HYDRALISK_GLM_52_REAP_504B_PREFLIGHT_REF=<public-safe ref>
+  HYDRALISK_GLM_52_REAP_504B_RECEIPT_REF=<public-safe ref>
+
+Options:
+  --api-prefix <path>              Gateway prefix. Defaults to /api/v1.
+  --base-url <url>                 OpenAgents origin. Defaults to https://openagents.com.
+  --counter-settle-ms <ms>         Wait before reading the public counter after the smoke.
+  --counter-tolerance-tokens <n>   Allowed shortfall against receipt token sum. Defaults to 0.
+  --forbid-public-model <model>    Add a model id that must not appear in /api/v1/models.
+  --model <model>                  Defaults to openagents/khala.
+  --prompt <text>                  Prompt used for both completion calls.
+  --serving-profile-ref <ref>      Public-safe serving profile ref to include in proof output.
+  --token <token>                  Agent bearer token. Defaults to OPENAGENTS_AGENT_TOKEN.
+  --approve-live-spend             Required before authenticated completion calls.
+
+When the GLM REAP arming env is absent or unsafe, this exits 0 with state=skipped.
+It never prints bearer tokens, raw endpoint URLs, prompts, or completion text.
+`
+
+export const runKhalaGlmReapSmoke = async ({
+  apiPrefix = defaultApiPrefix,
+  approveLiveSpend = false,
+  baseUrl = defaultBaseUrl,
+  counterSettleMs = 3000,
+  counterToleranceTokens = 0,
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  forbiddenPublicModelIds = defaultForbiddenPublicModelIds,
+  model = defaultModel,
+  prompt = defaultPrompt,
+  servingProfileRefs = defaultServingProfileRefs,
+  token = '',
+} = {}) => {
+  assert(typeof fetchImpl === 'function', 'A fetch implementation is required.')
+
+  const arming = resolveGlmReapArming(env)
+  const safeServingProfileRefs = servingProfileRefs.filter(isPublicSafeRef)
+  if (!arming.armed) {
+    return {
+      arming: {
+        armed: false,
+        blockerRefs: arming.blockerRefs,
+        evidenceRefs: arming.evidenceRefs,
+        servingProfileRefs: safeServingProfileRefs,
+      },
+      ok: true,
+      state: 'skipped',
+    }
+  }
+
+  assert(
+    safeServingProfileRefs.length > 0,
+    'At least one public-safe GLM serving profile ref is required.',
+  )
+
+  const origin = trimBaseUrl(baseUrl)
+  const checks = []
+  const check = (name, passed, details = {}) => {
+    checks.push({ details, name, passed: Boolean(passed) })
+    assert(passed, `${name} failed`)
+  }
+
+  check('arming_ready', arming.armed, {
+    evidenceRefs: arming.evidenceRefs,
+    servingProfileRefs: safeServingProfileRefs,
+  })
+
+  const before = await requestJson(
+    fetchImpl,
+    origin,
+    '/api/public/khala-tokens-served',
+  )
+  const beforeTokens = publicTokensServedFrom(before.body)
+  check('public_tokens_counter_before', okStatus(before.response), {
+    status: before.response.status,
+  })
+  check('public_tokens_counter_before_value', beforeTokens !== null, {
+    tokensServed: beforeTokens,
+  })
+
+  const smoke = await runKhalaProductionSmoke({
+    apiPrefix,
+    approveLiveSpend,
+    baseUrl: origin,
+    expectedServedModelContains,
+    expectedSupplyLane,
+    expectedWorker,
+    fetchImpl,
+    forbiddenPublicModelIds,
+    model,
+    prompt,
+    token,
+  })
+  check('khala_glm_backing_smoke', smoke.ok === true, {
+    nonstreamWorker: smoke.nonstream?.openagents?.worker,
+    streamWorker: smoke.stream?.openagents?.worker,
+  })
+
+  if (Number(counterSettleMs) > 0) {
+    await sleep(Number(counterSettleMs))
+  }
+
+  const after = await requestJson(
+    fetchImpl,
+    origin,
+    '/api/public/khala-tokens-served',
+  )
+  const afterTokens = publicTokensServedFrom(after.body)
+  check('public_tokens_counter_after', okStatus(after.response), {
+    status: after.response.status,
+  })
+  check('public_tokens_counter_after_value', afterTokens !== null, {
+    tokensServed: afterTokens,
+  })
+
+  const nonstreamReceiptTokens = receiptTokensFrom(smoke.nonstream?.receipt) ?? 0
+  const streamReceiptTokens = receiptTokensFrom(smoke.stream?.receipt) ?? 0
+  const expectedCounterDelta = Math.max(
+    1,
+    nonstreamReceiptTokens + streamReceiptTokens - Number(counterToleranceTokens),
+  )
+  const counterDelta = afterTokens - beforeTokens
+  check('public_tokens_counter_delta', counterDelta >= expectedCounterDelta, {
+    afterTokens,
+    beforeTokens,
+    counterDelta,
+    expectedCounterDelta,
+    nonstreamReceiptTokens,
+    streamReceiptTokens,
+  })
+
+  return {
+    apiPrefix: smoke.apiPrefix,
+    arming: {
+      armed: true,
+      evidenceRefs: arming.evidenceRefs,
+      servingProfileRefs: safeServingProfileRefs,
+    },
+    checks: [...checks, ...smoke.checks],
+    expected: {
+      forbiddenPublicModelIds,
+      servedModelContains: expectedServedModelContains,
+      supplyLane: expectedSupplyLane,
+      worker: expectedWorker,
+    },
+    model,
+    nonstream: smoke.nonstream,
+    ok: true,
+    publicTokensServed: {
+      afterTokens,
+      beforeTokens,
+      counterDelta,
+      expectedCounterDelta,
+    },
+    state: 'ok',
+    stream: smoke.stream,
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    console.log(usage())
+  } else {
+    runKhalaGlmReapSmoke(options)
+      .then(output => {
+        console.log(
+          JSON.stringify(
+            output,
+            (key, value) => {
+              if (key.toLowerCase().includes('token')) {
+                return '<redacted>'
+              }
+              if (key.toLowerCase().includes('baseurl')) {
+                return '<redacted>'
+              }
+              return redact(value)
+            },
+            2,
+          ),
+        )
+      })
+      .catch(error => {
+        console.error(
+          redact(error instanceof Error ? error.message : String(error)),
+        )
+        process.exitCode = 1
+      })
+  }
+}

--- a/apps/openagents.com/scripts/khala-glm-reap-smoke.test.ts
+++ b/apps/openagents.com/scripts/khala-glm-reap-smoke.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, test, vi } from 'vitest'
+
+const smoke = await import('./khala-glm-reap-smoke.mjs')
+
+const json = (body: unknown, init?: ResponseInit) => Response.json(body, init)
+
+const sse = (frames: ReadonlyArray<string>) =>
+  new Response(
+    `${frames.map(frame => `data: ${frame}\n\n`).join('')}data: [DONE]\n\n`,
+    {
+      headers: { 'content-type': 'text/event-stream' },
+    },
+  )
+
+const armedEnv = {
+  HYDRALISK_GLM_52_REAP_504B_BASE_URL:
+    'https://hydralisk-glm-52-reap-504b.example.test',
+  HYDRALISK_GLM_52_REAP_504B_BEARER_TOKEN: 'secret-route-token',
+  HYDRALISK_GLM_52_REAP_504B_ENABLED: 'ready',
+  HYDRALISK_GLM_52_REAP_504B_PREFLIGHT_REF:
+    'preflight.hydralisk.glm_52_reap_504b.g4.mtp2.v1',
+  HYDRALISK_GLM_52_REAP_504B_RECEIPT_REF:
+    'receipt.hydralisk.glm_52_reap_504b.g4.mtp2_smoke.v1',
+}
+
+describe('Khala GLM REAP smoke', () => {
+  test('skips cleanly when the GLM REAP arming env is absent', async () => {
+    const fetchImpl = vi.fn()
+
+    const output = await smoke.runKhalaGlmReapSmoke({
+      env: {},
+      fetchImpl,
+    })
+
+    expect(output).toMatchObject({
+      arming: {
+        armed: false,
+        blockerRefs: [
+          'blocker.hydralisk_glm_52_reap_504b.route_not_ready',
+          'blocker.hydralisk_glm_52_reap_504b.base_url_missing',
+          'blocker.hydralisk_glm_52_reap_504b.bearer_missing',
+          'blocker.hydralisk_glm_52_reap_504b.preflight_ref_missing',
+          'blocker.hydralisk_glm_52_reap_504b.receipt_ref_missing',
+        ],
+      },
+      ok: true,
+      state: 'skipped',
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  test('checks canonical API calls, GLM receipts, model catalog closure, and token counter movement', async () => {
+    let counterReads = 0
+    const fetchImpl = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(
+          input instanceof Request ? input.url : String(input),
+        )
+
+        if (url.pathname === '/api/public/khala-tokens-served') {
+          counterReads += 1
+          return json({
+            schemaVersion: 'openagents.public_khala_tokens_served.v1',
+            tokensServed: counterReads === 1 ? 100 : 120,
+          })
+        }
+
+        if (url.pathname === '/api/v1/gateway/readiness') {
+          return json({
+            servableModelCount: 1,
+            status: 'ready',
+          })
+        }
+
+        if (url.pathname === '/api/v1/models') {
+          return json({
+            data: [{ id: 'openagents/khala' }],
+            object: 'list',
+          })
+        }
+
+        if (url.pathname === '/api/v1/chat/completions') {
+          const headers = new Headers(init?.headers)
+          expect(headers.get('authorization')).toBe('Bearer oa_agent_test')
+          const body = JSON.parse(String(init?.body || '{}')) as {
+            stream?: boolean
+          }
+
+          if (body.stream) {
+            return sse([
+              '{"choices":[{"delta":{"content":"RE"},"finish_reason":null}]}',
+              '{"choices":[{"delta":{"content":"ADY"},"finish_reason":null}],"openagents":{"lane":"open","receipt_url":"https://openagents.com/receipts/stream","requested_model":"openagents/khala","served_model":"openagents/glm-5.2-reap-504b","supply_lane":"hydralisk","worker":"hydralisk-vllm-glm-5p2-reap-504b"}}',
+            ])
+          }
+
+          return json({
+            choices: [
+              {
+                message: {
+                  content: 'READY',
+                  role: 'assistant',
+                },
+              },
+            ],
+            id: 'chatcmpl_glm_test',
+            model: 'openagents/khala',
+            openagents: {
+              receipt_url: 'https://openagents.com/receipts/nonstream',
+              requested_model: 'openagents/khala',
+              served_model: 'openagents/glm-5.2-reap-504b',
+              supply_lane: 'hydralisk',
+              worker: 'hydralisk-vllm-glm-5p2-reap-504b',
+            },
+            usage: {
+              completion_tokens: 2,
+              prompt_tokens: 7,
+              total_tokens: 9,
+            },
+          })
+        }
+
+        if (url.pathname === '/receipts/nonstream') {
+          return json({
+            receipt: {
+              kind: 'charge',
+              ledgerState: 'paid',
+              modelEvidence: {
+                requested_model: 'openagents/khala',
+                served_model: 'openagents/glm-5.2-reap-504b',
+                supply_lane: 'hydralisk',
+                total_tokens: 9,
+                worker: 'hydralisk-vllm-glm-5p2-reap-504b',
+              },
+              receiptRef: 'inference.receipt.glm.nonstream',
+              schemaVersion: 'openagents.inference.receipt.v1',
+            },
+          })
+        }
+
+        if (url.pathname === '/receipts/stream') {
+          return json({
+            receipt: {
+              kind: 'charge',
+              ledgerState: 'paid',
+              modelEvidence: {
+                requested_model: 'openagents/khala',
+                served_model: 'openagents/glm-5.2-reap-504b',
+                supply_lane: 'hydralisk',
+                total_tokens: 11,
+                worker: 'hydralisk-vllm-glm-5p2-reap-504b',
+              },
+              receiptRef: 'inference.receipt.glm.stream',
+              schemaVersion: 'openagents.inference.receipt.v1',
+            },
+          })
+        }
+
+        return json({ error: 'not found', path: url.pathname }, { status: 404 })
+      },
+    )
+
+    const output = await smoke.runKhalaGlmReapSmoke({
+      approveLiveSpend: true,
+      counterSettleMs: 0,
+      env: armedEnv,
+      fetchImpl,
+      token: 'oa_agent_test',
+    })
+
+    expect(output).toMatchObject({
+      arming: {
+        armed: true,
+        evidenceRefs: [
+          'preflight.hydralisk.glm_52_reap_504b.g4.mtp2.v1',
+          'receipt.hydralisk.glm_52_reap_504b.g4.mtp2_smoke.v1',
+        ],
+      },
+      nonstream: {
+        openagents: {
+          served_model: 'openagents/glm-5.2-reap-504b',
+          supply_lane: 'hydralisk',
+          worker: 'hydralisk-vllm-glm-5p2-reap-504b',
+        },
+      },
+      ok: true,
+      publicTokensServed: {
+        afterTokens: 120,
+        beforeTokens: 100,
+        counterDelta: 20,
+        expectedCounterDelta: 20,
+      },
+      state: 'ok',
+    })
+    expect(output.checks.map((check: { name: string }) => check.name)).toContain(
+      'public_tokens_counter_delta',
+    )
+  })
+
+  test('fails when the public counter does not move by the receipt token sum', async () => {
+    const fetchImpl = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(
+          input instanceof Request ? input.url : String(input),
+        )
+
+        if (url.pathname === '/api/public/khala-tokens-served') {
+          return json({ tokensServed: 100 })
+        }
+
+        if (url.pathname === '/api/v1/gateway/readiness') {
+          return json({ servableModelCount: 1, status: 'ready' })
+        }
+
+        if (url.pathname === '/api/v1/models') {
+          return json({ data: [{ id: 'openagents/khala' }] })
+        }
+
+        if (url.pathname === '/api/v1/chat/completions') {
+          const body = JSON.parse(String(init?.body || '{}')) as {
+            stream?: boolean
+          }
+          if (body.stream) {
+            return sse([
+              '{"choices":[{"delta":{"content":"READY"},"finish_reason":"stop"}],"openagents":{"receipt_url":"https://openagents.com/receipts/stream","requested_model":"openagents/khala","served_model":"openagents/glm-5.2-reap-504b","supply_lane":"hydralisk","worker":"hydralisk-vllm-glm-5p2-reap-504b"}}',
+            ])
+          }
+          return json({
+            choices: [{ message: { content: 'READY', role: 'assistant' } }],
+            model: 'openagents/khala',
+            openagents: {
+              receipt_url: 'https://openagents.com/receipts/nonstream',
+              requested_model: 'openagents/khala',
+              served_model: 'openagents/glm-5.2-reap-504b',
+              supply_lane: 'hydralisk',
+              worker: 'hydralisk-vllm-glm-5p2-reap-504b',
+            },
+            usage: { total_tokens: 9 },
+          })
+        }
+
+        if (
+          url.pathname === '/receipts/nonstream' ||
+          url.pathname === '/receipts/stream'
+        ) {
+          return json({
+            receipt: {
+              kind: 'charge',
+              ledgerState: 'paid',
+              modelEvidence: {
+                requested_model: 'openagents/khala',
+                served_model: 'openagents/glm-5.2-reap-504b',
+                supply_lane: 'hydralisk',
+                total_tokens: 9,
+                worker: 'hydralisk-vllm-glm-5p2-reap-504b',
+              },
+              receiptRef: 'inference.receipt.glm',
+              schemaVersion: 'openagents.inference.receipt.v1',
+            },
+          })
+        }
+
+        return json({ error: 'not found' }, { status: 404 })
+      },
+    )
+
+    await expect(
+      smoke.runKhalaGlmReapSmoke({
+        approveLiveSpend: true,
+        counterSettleMs: 0,
+        env: armedEnv,
+        fetchImpl,
+        token: 'oa_agent_test',
+      }),
+    ).rejects.toThrow('public_tokens_counter_delta failed')
+  })
+})

--- a/apps/openagents.com/scripts/khala-production-smoke.mjs
+++ b/apps/openagents.com/scripts/khala-production-smoke.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const defaultBaseUrl = 'https://openagents.com'
+const defaultApiPrefix = '/v1'
 const defaultModel = 'openagents/khala'
 const defaultPrompt =
   'OpenAgents Khala production smoke: answer with exactly READY and no other words.'
@@ -31,6 +32,17 @@ const defaultForbiddenPublicModelIds = [
 
 const trimBaseUrl = baseUrl =>
   String(baseUrl || defaultBaseUrl).replace(/\/+$/, '')
+
+const normalizedApiPrefix = apiPrefix => {
+  const prefix = String(apiPrefix || defaultApiPrefix).trim()
+  if (prefix === '') {
+    return defaultApiPrefix
+  }
+  return `/${prefix.replace(/^\/+|\/+$/gu, '')}`
+}
+
+const apiPath = (apiPrefix, path) =>
+  `${normalizedApiPrefix(apiPrefix)}${path.startsWith('/') ? path : `/${path}`}`
 
 const absoluteUrl = (baseUrl, pathOrUrl) =>
   new URL(String(pathOrUrl || ''), baseUrl).toString()
@@ -294,6 +306,7 @@ const backingMatches = (
 
 export const parseArgs = (argv, env = process.env) => {
   const options = {
+    apiPrefix: env.OPENAGENTS_KHALA_API_PREFIX || defaultApiPrefix,
     approveLiveSpend:
       truthy(env.OPENAGENTS_KHALA_SMOKE_APPROVE_LIVE_SPEND) ||
       truthy(env.KHALA_SMOKE_APPROVE_LIVE_SPEND),
@@ -316,7 +329,9 @@ export const parseArgs = (argv, env = process.env) => {
 
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index]
-    if (value === '--base-url' || value === '--baseUrl') {
+    if (value === '--api-prefix') {
+      options.apiPrefix = argv[++index] || options.apiPrefix
+    } else if (value === '--base-url' || value === '--baseUrl') {
       options.baseUrl = argv[++index] || options.baseUrl
     } else if (value === '--model') {
       options.model = argv[++index] || options.model
@@ -355,6 +370,7 @@ export const usage = () => `Usage:
     node scripts/khala-production-smoke.mjs --approve-live-spend
 
 Options:
+  --api-prefix <path>                    Gateway prefix. Defaults to /v1.
   --base-url <url>                         OpenAgents origin. Defaults to https://openagents.com.
   --model <model>                          Defaults to openagents/khala.
   --prompt <text>                          Prompt used for both nonstreaming and streaming calls.
@@ -373,6 +389,7 @@ completion text.
 `
 
 export const runKhalaProductionSmoke = async ({
+  apiPrefix = defaultApiPrefix,
   approveLiveSpend = false,
   baseUrl = defaultBaseUrl,
   expectedServedModelContains = defaultExpectedServedModelContains,
@@ -388,6 +405,7 @@ export const runKhalaProductionSmoke = async ({
   assert(typeof fetchImpl === 'function', 'A fetch implementation is required.')
 
   const origin = trimBaseUrl(baseUrl)
+  const gatewayPrefix = normalizedApiPrefix(apiPrefix)
   const checks = []
   const check = (name, passed, details = {}) => {
     checks.push({ details, name, passed: Boolean(passed) })
@@ -397,7 +415,7 @@ export const runKhalaProductionSmoke = async ({
   const readiness = await requestJson(
     fetchImpl,
     origin,
-    '/v1/gateway/readiness',
+    apiPath(gatewayPrefix, '/gateway/readiness'),
   )
   check('readiness_endpoint_200', okStatus(readiness.response), {
     status: readiness.response.status,
@@ -411,7 +429,11 @@ export const runKhalaProductionSmoke = async ({
     },
   )
 
-  const models = await requestJson(fetchImpl, origin, '/v1/models')
+  const models = await requestJson(
+    fetchImpl,
+    origin,
+    apiPath(gatewayPrefix, '/models'),
+  )
   const modelIds = modelIdsFrom(models.body)
   const forbiddenPublicIds = forbiddenCatalogIdsFrom(
     modelIds,
@@ -430,6 +452,7 @@ export const runKhalaProductionSmoke = async ({
 
   if (readinessOnly) {
     return {
+      apiPrefix: gatewayPrefix,
       checks,
       model,
       ok: true,
@@ -467,7 +490,7 @@ export const runKhalaProductionSmoke = async ({
   const completion = await requestJson(
     fetchImpl,
     origin,
-    '/v1/chat/completions',
+    apiPath(gatewayPrefix, '/chat/completions'),
     {
       body: JSON.stringify({ ...chatBody, stream: false }),
       headers: authHeaders,
@@ -507,7 +530,7 @@ export const runKhalaProductionSmoke = async ({
   })
 
   const streamResponse = await fetchImpl(
-    absoluteUrl(origin, '/v1/chat/completions'),
+    absoluteUrl(origin, apiPath(gatewayPrefix, '/chat/completions')),
     {
       body: JSON.stringify({ ...chatBody, stream: true }),
       headers: {
@@ -550,6 +573,7 @@ export const runKhalaProductionSmoke = async ({
   })
 
   return {
+    apiPrefix: gatewayPrefix,
     checks,
     model,
     nonstream: {

--- a/docs/inference/2026-06-25-khala-glm-reap-smoke-runbook.md
+++ b/docs/inference/2026-06-25-khala-glm-reap-smoke-runbook.md
@@ -1,0 +1,57 @@
+# Khala GLM REAP Smoke Runbook
+
+This runbook covers the CI-safe smoke for GitHub #6259. It verifies that the
+public `openagents/khala` gateway is served by the GLM-5.2 REAP Hydralisk lane
+when that lane is armed, without printing raw endpoint URLs, bearer tokens,
+prompts, completions, or private Harbor logs.
+
+## Command
+
+From `apps/openagents.com`:
+
+```bash
+OPENAGENTS_AGENT_TOKEN=oa_agent_... \
+HYDRALISK_GLM_52_REAP_504B_ENABLED=ready \
+HYDRALISK_GLM_52_REAP_504B_BASE_URL=<secret endpoint> \
+HYDRALISK_GLM_52_REAP_504B_BEARER_TOKEN=<secret bearer> \
+HYDRALISK_GLM_52_REAP_504B_PREFLIGHT_REF=<public-safe preflight ref> \
+HYDRALISK_GLM_52_REAP_504B_RECEIPT_REF=<public-safe receipt ref> \
+bun run smoke:khala:glm-reap -- --approve-live-spend
+```
+
+If the GLM arming env is absent or unsafe, the script exits `0` with
+`state: "skipped"` and lists only public-safe blocker ref names. That keeps CI
+green until an owner intentionally arms the lane.
+
+## Checks
+
+- `POST /api/v1/chat/completions` with `model: openagents/khala`
+  non-streaming and streaming.
+- `openagents` disclosure and dereferenced usage receipt both report
+  `supply_lane: hydralisk`, worker `hydralisk-vllm-glm-5p2-reap-504b`, and a
+  served model containing `glm-5.2-reap-504b`.
+- `GET /api/v1/models` lists only the public Khala model and does not expose the
+  raw `openagents/glm-5.2-reap-504b` id.
+- `GET /api/public/khala-tokens-served` increases by at least the summed
+  non-streaming plus streaming receipt token total, subject to the optional
+  `--counter-tolerance-tokens` value.
+
+The script includes public-safe serving profile refs in its output for the GLM
+REAP G4 profiles:
+
+- `glm-reap-504b-g4-tp4-minp-rp105`
+- `glm-reap-504b-g4-tp4-mtp2-rp105`
+- `glm-reap-504b-g4-dual-tp4-minp-rp105`
+
+Add another public-safe profile ref with `--serving-profile-ref <ref>` if the
+operator rotates the serving profile.
+
+## Validation
+
+```bash
+cd apps/openagents.com
+bunx vitest run scripts/khala-glm-reap-smoke.test.ts scripts/khala-production-smoke.test.ts
+```
+
+The unit tests cover the unarmed skip, canonical `/api/v1` path use, GLM receipt
+classification, raw-model catalog closure, and counter-increment failure mode.


### PR DESCRIPTION
Addresses #6259.

Claim: https://openagents.com/forum/t/9e615a3b-4379-4897-a463-62ca0a5257b3#post-2d22dff8-e5cd-40b5-8d15-fc587d9319c6

## Problem

The GLM-5.2 REAP lane is wired and fail-closed, but reviewers need a repeatable smoke that proves `openagents/khala` reaches the GLM Hydralisk worker when owner arming is present, records public token-counter movement, and keeps raw GLM ids out of model discovery.

## Change

- Adds `scripts/khala-glm-reap-smoke.mjs`, a CI-safe smoke that:
  - exits `0` with `state: "skipped"` when the same GLM arming env used by the router is absent or unsafe;
  - calls canonical `/api/v1/chat/completions` non-streaming and streaming when armed;
  - asserts `openagents` disclosure plus dereferenced receipts show `supply_lane: hydralisk`, worker `hydralisk-vllm-glm-5p2-reap-504b`, and served model evidence containing `glm-5.2-reap-504b`;
  - asserts `/api/v1/models` does not expose `openagents/glm-5.2-reap-504b`;
  - checks `/api/public/khala-tokens-served` increases by the summed receipt token total.
- Adds a `smoke:khala:glm-reap` package script and a runbook.
- Extends the existing Khala production smoke with an `apiPrefix` option so this verifier can use canonical `/api/v1` without changing the default legacy `/v1` smoke behavior.

## Validation

- `node scripts/khala-glm-reap-smoke.mjs` -> `state: "skipped"` with arming blockers, exit 0.
- `env TMPDIR=/private/tmp bun run smoke:khala:glm-reap` -> `state: "skipped"` with arming blockers, exit 0.
- `env TMPDIR=/private/tmp bunx vitest run scripts/khala-glm-reap-smoke.test.ts scripts/khala-production-smoke.test.ts` -> 2 files passed, 10 tests passed.
- `git diff --check`

## Value

This gives the Khala launch lane a small reviewer-run verifier for the owner-armed GLM path: public model stays stable, receipts prove the worker class, and public token-counter movement proves served-token projection.

## Not Changed

- No router ordering or supply-lane semantics.
- No secrets, raw endpoint URLs, bearer tokens, prompts, completions, or Harbor logs.
- No owner arming, quota, billing, paid-loop, or Terminal-Bench evidence changes.
