### PR TITLE
feat(traces): tag captured traces by demand origin

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0236_agent_trace_demand_attribution.sql
+++ b/apps/openagents.com/workers/api/migrations/0236_agent_trace_demand_attribution.sql
@@ -1,0 +1,12 @@
+-- #6298: public-safe demand-origin segmentation for captured traces.
+-- Nullable so existing traces remain readable and uploads without demand
+-- metadata keep their historical behaviour.
+ALTER TABLE agent_traces
+  ADD COLUMN demand_kind TEXT
+  CHECK (demand_kind IN ('external', 'internal', 'own_capacity', 'unlabeled'));
+
+ALTER TABLE agent_traces
+  ADD COLUMN demand_source TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_agent_traces_owner_demand_created
+  ON agent_traces (owner_user_id, demand_kind, created_at DESC);

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -11281,6 +11281,7 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
                   agentRef: input.accountRef,
                   uploadSource: 'agent',
                 },
+                requestAttribution: input.requestAttribution,
               },
             )
           },

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -1011,6 +1011,64 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
+  test('passes public-safe demand attribution into trace emission', async () => {
+    const emitted: Array<{ requestAttribution?: unknown }> = []
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(
+          { ...helloBody, oa_emit_trace: true },
+          {
+            headers: {
+              [INFERENCE_CLIENT_HEADER]: 'qa-runner',
+              [INFERENCE_DEMAND_KIND_HEADER]: 'internal',
+              [INFERENCE_DEMAND_SOURCE_HEADER]: 'qa-dogfood',
+            },
+          },
+        ),
+        baseDeps({
+          traceEmit: {
+            enabled: true,
+            emit: async input => {
+              emitted.push({ requestAttribution: input.requestAttribution })
+            },
+          },
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]?.requestAttribution).toEqual({
+      demandClient: 'qa-runner',
+      demandKind: 'internal',
+      demandSource: 'qa-dogfood',
+    })
+  })
+
+  test('labels captured traces with external/unlabeled when demand headers are absent', async () => {
+    const emitted: Array<{ requestAttribution?: unknown }> = []
+    const response = await run(
+      handleChatCompletions(
+        chatRequest({ ...helloBody, oa_emit_trace: true }),
+        baseDeps({
+          traceEmit: {
+            enabled: true,
+            emit: async input => {
+              emitted.push({ requestAttribution: input.requestAttribution })
+            },
+          },
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]?.requestAttribution).toEqual({
+      demandKind: 'external',
+      demandSource: 'unlabeled',
+    })
+  })
+
   test('records served tokens for a completed streaming completion (issue #6227)', async () => {
     const recorded: Array<{ streamed: boolean; usage: InferenceUsage }> = []
     const response = await run(

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -243,6 +243,16 @@ const requestAttributionFromHeaders = (
   }
 }
 
+const requestAttributionForCapturedTrace = (
+  requestAttribution: ServedTokensRequestAttribution | undefined,
+): ServedTokensRequestAttribution => ({
+  demandKind: requestAttribution?.demandKind ?? 'external',
+  demandSource: requestAttribution?.demandSource ?? 'unlabeled',
+  ...(requestAttribution?.demandClient === undefined
+    ? {}
+    : { demandClient: requestAttribution.demandClient }),
+})
+
 const booleanBodyFlag = (body: Record<string, unknown>, key: string): boolean =>
   body[key] === true || body[key] === 'true' || body[key] === 1
 
@@ -659,6 +669,7 @@ export type ChatCompletionsDeps = Readonly<{
         // DEFAULT-ON CAPTURE: persist even without an explicit opt-in. Stored
         // owner_only (private-by-default). Resolved at the call site.
         captureDefault: boolean
+        requestAttribution?: ServedTokensRequestAttribution | undefined
       }>,
     ) => Promise<void>
   }>
@@ -3015,6 +3026,8 @@ export const handleChatCompletions = (
             requestedModel,
             responseId,
             result: guardedResult,
+            requestAttribution:
+              requestAttributionForCapturedTrace(requestAttribution),
           }),
         )
       }

--- a/apps/openagents.com/workers/api/src/inference/khala-chat-trace-emitter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-chat-trace-emitter.test.ts
@@ -69,6 +69,8 @@ const makeFakeStore = (): TraceStore & {
     rewardEligible: input.rewardEligible,
     rewardAmountSats: input.rewardAmountSats,
     uploadSource: input.uploadSource,
+    demandKind: input.demandKind ?? null,
+    demandSource: input.demandSource ?? null,
     createdAt: input.nowIso,
     updatedAt: input.nowIso,
   })
@@ -217,11 +219,31 @@ describe('emitKhalaChatTrace persistence (flag ON, opted in)', () => {
     expect(stored.trainingConsent).toBe(false)
     expect(stored.rewardEligible).toBe(false)
     expect(stored.rewardAmountSats).toBeNull()
+    expect(stored.demandKind).toBeNull()
+    expect(stored.demandSource).toBeNull()
     // Idempotency keyed by the chat response id.
     expect(stored.idempotencyKey).toBe('chatcmpl-abc123')
     // The stored trajectory is the gateway projection.
     const trajectory = stored.trajectory as { agent: { model_name: string } }
     expect(trajectory.agent.model_name).toBe('openagents/khala')
+  })
+
+  it('persists public-safe demand attribution when supplied by the route', async () => {
+    const store = makeFakeStore()
+    const result = await emitKhalaChatTrace(fakeSession(), {
+      enabled: true,
+      optedIn: true,
+      store,
+      owner: { ownerUserId: 'u1', agentRef: 'agent:u1', uploadSource: 'agent' },
+      requestAttribution: {
+        demandClient: 'khala-canary',
+        demandKind: 'internal',
+        demandSource: 'canary',
+      },
+    })
+    expect(result.emitted).toBe(true)
+    expect(store.created[0]?.demandKind).toBe('internal')
+    expect(store.created[0]?.demandSource).toBe('canary')
   })
 
   it('REDACTS (then stores) a session that would otherwise trip the tripwire', async () => {

--- a/apps/openagents.com/workers/api/src/inference/khala-chat-trace-emitter.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-chat-trace-emitter.ts
@@ -49,6 +49,7 @@ import { currentIsoTimestamp, randomUuid } from '../runtime-primitives'
 import type { TraceStore, TraceUploadSource } from '../trace-store-d1'
 import { isKhalaModel } from './pricing'
 import type { InferenceMessage, InferenceResult } from './provider-adapter'
+import type { ServedTokensRequestAttribution } from './served-tokens-recorder'
 import {
   redactTraceValue,
   type TraceRedactionReport,
@@ -274,6 +275,8 @@ export type EmitKhalaChatTraceDeps = Readonly<{
   // The resolved owner of the trace. Absent => no-op (we never store an
   // unowned/anonymous gateway trace).
   owner: KhalaChatTraceOwner | undefined
+  // Public-safe demand-origin attribution resolved at the request boundary.
+  requestAttribution?: ServedTokensRequestAttribution | undefined
   // Default visibility for an emitted trace. Defaults to `unlisted`.
   visibility?: TraceVisibility | undefined
   // Deterministic id/clock injection for tests.
@@ -423,6 +426,8 @@ export const emitKhalaChatTrace = async (
       rewardEligible: false,
       rewardAmountSats: null,
       uploadSource: deps.owner.uploadSource,
+      demandKind: deps.requestAttribution?.demandKind ?? null,
+      demandSource: deps.requestAttribution?.demandSource ?? null,
       nowIso,
     })
     return {

--- a/apps/openagents.com/workers/api/src/trace-store-d1.ts
+++ b/apps/openagents.com/workers/api/src/trace-store-d1.ts
@@ -40,6 +40,17 @@ export type TraceBlobRef = Readonly<{
 /** How an upload authenticated (#6221). */
 export type TraceUploadSource = 'agent' | 'user_session'
 
+/** Public-safe demand-origin segment attached to captured traces (#6298). */
+export type TraceDemandKind =
+  | 'external'
+  | 'internal'
+  | 'own_capacity'
+  | 'unlabeled'
+
+export type TraceListFilters = Readonly<{
+  demandKind?: TraceDemandKind | undefined
+}>
+
 export type TraceRecord = Readonly<{
   traceUuid: string
   ownerUserId: string
@@ -84,6 +95,13 @@ export type TraceRecord = Readonly<{
   rewardAmountSats: number | null
   /** Whether the upload arrived via agent bearer or a user web session. */
   uploadSource: TraceUploadSource
+  /**
+   * Public-safe demand-origin classification (#6298). Null means the trace was
+   * created before attribution existed, or via an upload path with no resolved
+   * demand metadata.
+   */
+  demandKind: TraceDemandKind | null
+  demandSource: string | null
   createdAt: string
   updatedAt: string
 }>
@@ -107,6 +125,8 @@ export type CreateTraceInput = Readonly<{
   rewardEligible: boolean
   rewardAmountSats: number | null
   uploadSource: TraceUploadSource
+  demandKind?: TraceDemandKind | null | undefined
+  demandSource?: string | null | undefined
   nowIso: string
 }>
 
@@ -127,6 +147,7 @@ export type TraceStore = Readonly<{
   listTracesForOwner: (
     ownerUserId: string,
     limit: number,
+    filters?: TraceListFilters | undefined,
   ) => Promise<ReadonlyArray<TraceRecord>>
   /**
    * Dedup lookup (#6221): the existing trace for `(ownerUserId, contentDigest)`,
@@ -159,6 +180,18 @@ const bool = (value: unknown): boolean =>
 
 const uploadSourceFromRow = (value: unknown): TraceUploadSource =>
   value === 'user_session' ? 'user_session' : 'agent'
+
+const demandKindFromRow = (value: unknown): TraceDemandKind | null => {
+  if (
+    value === 'external' ||
+    value === 'internal' ||
+    value === 'own_capacity' ||
+    value === 'unlabeled'
+  ) {
+    return value
+  }
+  return null
+}
 
 const visibilityFromRow = (value: unknown): TraceVisibility =>
   value === 'public' || value === 'owner_only' ? value : 'unlisted'
@@ -193,29 +226,64 @@ const recordFromRow = (row: Record<string, unknown>): TraceRecord => ({
   rewardEligible: bool(row.reward_eligible),
   rewardAmountSats: nullableNum(row.reward_amount_sats),
   uploadSource: uploadSourceFromRow(row.upload_source),
+  demandKind: demandKindFromRow(row.demand_kind),
+  demandSource: nullableStr(row.demand_source),
   createdAt: str(row.created_at),
   updatedAt: str(row.updated_at),
 })
 
 // Shared public-safe column projection. Extended by #6221 with the data-market
 // consent/license/digest/reward/upload-source columns (migration 0229) and the
-// large-trajectory R2 pointer (migration 0230).
-const TRACE_COLUMNS = `trace_uuid, owner_user_id, agent_ref, schema_version,
+// large-trajectory R2 pointer (migration 0230). Demand-origin columns (#6298)
+// are selected only after their migration is present so code-before-migration
+// deploys continue to read existing traces.
+const TRACE_BASE_COLUMNS = `trace_uuid, owner_user_id, agent_ref, schema_version,
                   trajectory_id, session_id, visibility, step_count,
                   trajectory_json, trajectory_r2_key, blob_refs_json,
                   idempotency_key,
                   training_consent, license, content_digest,
-                  reward_eligible, reward_amount_sats, upload_source,
+                  reward_eligible, reward_amount_sats, upload_source`
+
+const TRACE_COLUMNS_WITH_DEMAND = `${TRACE_BASE_COLUMNS},
+                  demand_kind, demand_source,
                   created_at, updated_at`
 
+const TRACE_COLUMNS_WITHOUT_DEMAND = `${TRACE_BASE_COLUMNS},
+                  NULL AS demand_kind, NULL AS demand_source,
+                  created_at, updated_at`
+
+const traceColumns = (includeDemandAttribution: boolean): string =>
+  includeDemandAttribution
+    ? TRACE_COLUMNS_WITH_DEMAND
+    : TRACE_COLUMNS_WITHOUT_DEMAND
+
 export const makeD1TraceStore = (db: D1Database): TraceStore => {
+  let demandAttributionColumnsAvailable: boolean | undefined
+
+  const hasDemandAttributionColumns = async (): Promise<boolean> => {
+    if (demandAttributionColumnsAvailable !== undefined) {
+      return demandAttributionColumnsAvailable
+    }
+    const result = await db
+      .prepare('PRAGMA table_info(agent_traces)')
+      .all<Record<string, unknown>>()
+    const names = new Set((result.results ?? []).map(row => str(row.name)))
+    demandAttributionColumnsAvailable =
+      names.has('demand_kind') && names.has('demand_source')
+    return demandAttributionColumnsAvailable
+  }
+
+  const selectTraceColumns = async (): Promise<string> =>
+    traceColumns(await hasDemandAttributionColumns())
+
   const readByUuid = async (
     traceUuid: string,
   ): Promise<TraceRecord | undefined> => {
     try {
+      const columns = await selectTraceColumns()
       const row = await db
         .prepare(
-          `SELECT ${TRACE_COLUMNS}
+          `SELECT ${columns}
              FROM agent_traces
             WHERE trace_uuid = ?1`,
         )
@@ -233,9 +301,10 @@ export const makeD1TraceStore = (db: D1Database): TraceStore => {
     idempotencyKey: string,
   ): Promise<TraceRecord | undefined> => {
     try {
+      const columns = await selectTraceColumns()
       const row = await db
         .prepare(
-          `SELECT ${TRACE_COLUMNS}
+          `SELECT ${columns}
              FROM agent_traces
             WHERE owner_user_id = ?1 AND idempotency_key = ?2`,
         )
@@ -261,42 +330,82 @@ export const makeD1TraceStore = (db: D1Database): TraceStore => {
       }
 
       try {
-        await db
-          .prepare(
-            `INSERT INTO agent_traces
-               (trace_uuid, owner_user_id, agent_ref, schema_version,
-                trajectory_id, session_id, visibility, step_count,
-                trajectory_json, trajectory_r2_key, blob_refs_json,
-                idempotency_key,
-                training_consent, license, content_digest,
-                reward_eligible, reward_amount_sats, upload_source,
-                created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                     ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)`,
-          )
-          .bind(
-            input.traceUuid,
-            input.ownerUserId,
-            input.agentRef,
-            input.schemaVersion,
-            input.trajectoryId,
-            input.sessionId,
-            input.visibility,
-            input.stepCount,
-            JSON.stringify(input.trajectory),
-            input.trajectoryR2Key,
-            JSON.stringify(input.blobRefs),
-            input.idempotencyKey,
-            input.trainingConsent ? 1 : 0,
-            input.license,
-            input.contentDigest,
-            input.rewardEligible ? 1 : 0,
-            input.rewardAmountSats,
-            input.uploadSource,
-            input.nowIso,
-            input.nowIso,
-          )
-          .run()
+        const demandColumnsAvailable = await hasDemandAttributionColumns()
+        const statement = demandColumnsAvailable
+          ? db
+              .prepare(
+                `INSERT INTO agent_traces
+                   (trace_uuid, owner_user_id, agent_ref, schema_version,
+                    trajectory_id, session_id, visibility, step_count,
+                    trajectory_json, trajectory_r2_key, blob_refs_json,
+                    idempotency_key,
+                    training_consent, license, content_digest,
+                    reward_eligible, reward_amount_sats, upload_source,
+                    demand_kind, demand_source,
+                    created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                         ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)`,
+              )
+              .bind(
+                input.traceUuid,
+                input.ownerUserId,
+                input.agentRef,
+                input.schemaVersion,
+                input.trajectoryId,
+                input.sessionId,
+                input.visibility,
+                input.stepCount,
+                JSON.stringify(input.trajectory),
+                input.trajectoryR2Key,
+                JSON.stringify(input.blobRefs),
+                input.idempotencyKey,
+                input.trainingConsent ? 1 : 0,
+                input.license,
+                input.contentDigest,
+                input.rewardEligible ? 1 : 0,
+                input.rewardAmountSats,
+                input.uploadSource,
+                input.demandKind ?? null,
+                input.demandSource ?? null,
+                input.nowIso,
+                input.nowIso,
+              )
+          : db
+              .prepare(
+                `INSERT INTO agent_traces
+                   (trace_uuid, owner_user_id, agent_ref, schema_version,
+                    trajectory_id, session_id, visibility, step_count,
+                    trajectory_json, trajectory_r2_key, blob_refs_json,
+                    idempotency_key,
+                    training_consent, license, content_digest,
+                    reward_eligible, reward_amount_sats, upload_source,
+                    created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                         ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)`,
+              )
+              .bind(
+                input.traceUuid,
+                input.ownerUserId,
+                input.agentRef,
+                input.schemaVersion,
+                input.trajectoryId,
+                input.sessionId,
+                input.visibility,
+                input.stepCount,
+                JSON.stringify(input.trajectory),
+                input.trajectoryR2Key,
+                JSON.stringify(input.blobRefs),
+                input.idempotencyKey,
+                input.trainingConsent ? 1 : 0,
+                input.license,
+                input.contentDigest,
+                input.rewardEligible ? 1 : 0,
+                input.rewardAmountSats,
+                input.uploadSource,
+                input.nowIso,
+                input.nowIso,
+              )
+        await statement.run()
       } catch (error) {
         // A racing idempotent insert can lose the unique-index race; surface the
         // already-stored record rather than a conflict.
@@ -322,18 +431,36 @@ export const makeD1TraceStore = (db: D1Database): TraceStore => {
       return { record: stored, created: true }
     },
     readTraceByUuid: readByUuid,
-    listTracesForOwner: async (ownerUserId, limit) => {
+    listTracesForOwner: async (ownerUserId, limit, filters) => {
       try {
-        const result = await db
-          .prepare(
-            `SELECT ${TRACE_COLUMNS}
-               FROM agent_traces
-              WHERE owner_user_id = ?1
-              ORDER BY created_at DESC
-              LIMIT ?2`,
-          )
-          .bind(ownerUserId, limit)
-          .all<Record<string, unknown>>()
+        const demandKind = filters?.demandKind
+        const demandColumnsAvailable = await hasDemandAttributionColumns()
+        if (demandKind !== undefined && !demandColumnsAvailable) {
+          return []
+        }
+        const columns = traceColumns(demandColumnsAvailable)
+        const result =
+          demandKind === undefined
+            ? await db
+                .prepare(
+                  `SELECT ${columns}
+                     FROM agent_traces
+                    WHERE owner_user_id = ?1
+                    ORDER BY created_at DESC
+                    LIMIT ?2`,
+                )
+                .bind(ownerUserId, limit)
+                .all<Record<string, unknown>>()
+            : await db
+                .prepare(
+                  `SELECT ${columns}
+                     FROM agent_traces
+                    WHERE owner_user_id = ?1 AND demand_kind = ?2
+                    ORDER BY created_at DESC
+                    LIMIT ?3`,
+                )
+                .bind(ownerUserId, demandKind, limit)
+                .all<Record<string, unknown>>()
 
         return (result.results ?? []).map(recordFromRow)
       } catch (error) {
@@ -342,9 +469,10 @@ export const makeD1TraceStore = (db: D1Database): TraceStore => {
     },
     findTraceByOwnerDigest: async (ownerUserId, contentDigest) => {
       try {
+        const columns = await selectTraceColumns()
         const row = await db
           .prepare(
-            `SELECT ${TRACE_COLUMNS}
+            `SELECT ${columns}
                FROM agent_traces
               WHERE owner_user_id = ?1 AND content_digest = ?2`,
           )

--- a/apps/openagents.com/workers/api/src/trace-store-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/trace-store-routes.test.ts
@@ -9,6 +9,7 @@ import { ATIF_PINNED_SCHEMA_VERSION } from './atif-trace-schema'
 import { makeTraceStoreRoutes } from './trace-store-routes'
 import type {
   CreateTraceInput,
+  TraceDemandKind,
   TraceMediaBlobObject,
   TraceMediaBlobStore,
   TraceRecord,
@@ -74,6 +75,8 @@ const makeMemoryStore = (): TraceStore & { rows: Map<string, TraceRecord> } => {
     rewardEligible: input.rewardEligible,
     rewardAmountSats: input.rewardAmountSats,
     uploadSource: input.uploadSource,
+    demandKind: input.demandKind ?? null,
+    demandSource: input.demandSource ?? null,
     createdAt: input.nowIso,
     updatedAt: input.nowIso,
   })
@@ -96,10 +99,15 @@ const makeMemoryStore = (): TraceStore & { rows: Map<string, TraceRecord> } => {
       return Promise.resolve({ record, created: true })
     },
     readTraceByUuid: uuid => Promise.resolve(rows.get(uuid)),
-    listTracesForOwner: (ownerUserId, limit) =>
+    listTracesForOwner: (ownerUserId, limit, filters) =>
       Promise.resolve(
         [...rows.values()]
           .filter(row => row.ownerUserId === ownerUserId)
+          .filter(row =>
+            filters?.demandKind === undefined
+              ? true
+              : row.demandKind === filters.demandKind,
+          )
           .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
           .slice(0, limit),
       ),
@@ -742,6 +750,10 @@ const seedTrace = async (
   store: TraceStore,
   visibility: 'public' | 'unlisted' | 'owner_only',
   ownerUserId = 'agent-1',
+  demand?: Readonly<{
+    kind: TraceDemandKind
+    source?: string | undefined
+  }>,
 ): Promise<string> => {
   const result = await store.createTrace({
     traceUuid: `uuid-${visibility}`,
@@ -762,6 +774,8 @@ const seedTrace = async (
     rewardEligible: false,
     rewardAmountSats: null,
     uploadSource: 'agent',
+    demandKind: demand?.kind ?? null,
+    demandSource: demand?.source ?? null,
     nowIso: NOW,
   })
   return result.record.traceUuid
@@ -773,7 +787,10 @@ const readRequest = (uuid: string): Request =>
 describe('GET /api/traces/{uuid} read', () => {
   it('returns the public-safe projection for a public trace (no auth)', async () => {
     const store = makeMemoryStore()
-    const uuid = await seedTrace(store, 'public')
+    const uuid = await seedTrace(store, 'public', 'agent-1', {
+      kind: 'external',
+      source: 'unlabeled',
+    })
     const routes = makeDeps({ store })
     const response = await run(
       routes.routeTraceRequest(readRequest(uuid), ENV, CTX),
@@ -783,6 +800,10 @@ describe('GET /api/traces/{uuid} read', () => {
     expect(json.trace.uuid).toBe(uuid)
     expect(json.trace.visibility).toBe('public')
     expect(json.trace.blobRefs).toHaveLength(1)
+    expect(json.trace.demand).toEqual({
+      kind: 'external',
+      source: 'unlabeled',
+    })
     expect((json.trace.authority as Record<string, unknown>).payoutAuthority).toBe(
       false,
     )
@@ -900,6 +921,39 @@ describe('GET /api/traces owner list', () => {
     expect(response.status).toBe(200)
     const json = (await response.json()) as { traces: ReadonlyArray<unknown> }
     expect(json.traces).toHaveLength(2)
+  })
+
+  it('filters the owner list by demand kind', async () => {
+    const store = makeMemoryStore()
+    await seedTrace(store, 'public', 'agent-1', {
+      kind: 'internal',
+      source: 'heartbeat',
+    })
+    await seedTrace(store, 'owner_only', 'agent-1', {
+      kind: 'external',
+      source: 'unlabeled',
+    })
+    const routes = makeDeps({
+      store,
+      browserSession: { user: { userId: 'agent-1' } },
+    })
+    const response = await run(
+      routes.routeTraceRequest(
+        new Request('https://openagents.com/api/traces?demandKind=internal'),
+        ENV,
+        CTX,
+      ),
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as {
+      traces: ReadonlyArray<{ demand: unknown; uuid: string }>
+    }
+    expect(json.traces).toHaveLength(1)
+    expect(json.traces[0]?.uuid).toBe('uuid-public')
+    expect(json.traces[0]?.demand).toEqual({
+      kind: 'internal',
+      source: 'heartbeat',
+    })
   })
 
   it('401s an anonymous owner list', async () => {

--- a/apps/openagents.com/workers/api/src/trace-store-routes.ts
+++ b/apps/openagents.com/workers/api/src/trace-store-routes.ts
@@ -28,6 +28,7 @@ import {
 } from './runtime-primitives'
 import {
   type TraceBlobRef,
+  type TraceDemandKind,
   type TraceMediaBlobStore,
   type TraceRecord,
   type TraceStore,
@@ -421,6 +422,10 @@ const publicTraceProjection = (record: TraceRecord) => ({
   trajectory: record.trajectory,
   blobRefs: record.blobRefs,
   createdAt: record.createdAt,
+  demand: {
+    kind: record.demandKind ?? 'unlabeled',
+    ...(record.demandSource === null ? {} : { source: record.demandSource }),
+  },
   // Data market (#6221), public-safe. The reward marker is INERT: eligibility
   // only, amount TBD; it moves no money and grants no payout authority.
   dataMarket: {
@@ -447,11 +452,30 @@ const ownerTraceSummary = (record: TraceRecord) => ({
   agentRef: record.agentRef,
   stepCount: record.stepCount,
   createdAt: record.createdAt,
+  demand: {
+    kind: record.demandKind ?? 'unlabeled',
+    ...(record.demandSource === null ? {} : { source: record.demandSource }),
+  },
   trainingConsent: record.trainingConsent,
   ...(record.license === null ? {} : { license: record.license }),
   uploadSource: record.uploadSource,
   rewardEligible: record.rewardEligible,
 })
+
+const traceDemandKindFromSearchParam = (
+  value: string | null,
+): TraceDemandKind | undefined => {
+  const normalized = value?.trim().toLowerCase()
+  if (
+    normalized === 'external' ||
+    normalized === 'internal' ||
+    normalized === 'own_capacity' ||
+    normalized === 'unlabeled'
+  ) {
+    return normalized
+  }
+  return undefined
+}
 
 // ---------------------------------------------------------------------------
 // POST /api/traces — ingest
@@ -1022,12 +1046,20 @@ const routeOwnerList = <Bindings, Session extends TraceBrowserSession>(
       return yield* new TraceUnauthorized({})
     }
 
+    const url = new URL(request.url)
+    const demandKind = traceDemandKindFromSearchParam(
+      url.searchParams.get('demandKind') ?? url.searchParams.get('demand_kind'),
+    )
     const traces = yield* Effect.tryPromise({
       catch: traceStoreErrorFromUnknown,
       try: () =>
         dependencies
           .makeStore(env)
-          .listTracesForOwner(session.user.userId, OWNER_LIST_LIMIT),
+          .listTracesForOwner(
+            session.user.userId,
+            OWNER_LIST_LIMIT,
+            demandKind === undefined ? undefined : { demandKind },
+          ),
     })
 
     return dependencies.appendRefreshedSessionCookies(

--- a/scripts/khala-canary.sh
+++ b/scripts/khala-canary.sh
@@ -94,7 +94,13 @@ IDX_STATE="$HOME_DIR/.canary-keystate"
 idx=0; [ -f "$IDX_STATE" ] && idx=$(cat "$IDX_STATE" 2>/dev/null || echo 0)
 KEY="${KEYS[$(( idx % ${#KEYS[@]} ))]}"
 echo $(( (idx + 1) % 1000000 )) > "$IDX_STATE"
-AUTH=(-H "Authorization: Bearer $KEY" -H "content-type: application/json")
+AUTH=(
+  -H "Authorization: Bearer $KEY"
+  -H "content-type: application/json"
+  -H "x-openagents-demand-kind: internal"
+  -H "x-openagents-demand-source: canary"
+  -H "x-openagents-client: khala-canary"
+)
 
 # --- one tick ----------------------------------------------------------------
 before=$(curl -s --max-time 10 "$PUBLIC_BASE/api/public/khala-tokens-served" | jq -r '.tokensServed // empty')

--- a/scripts/khala-heartbeat.sh
+++ b/scripts/khala-heartbeat.sh
@@ -39,7 +39,13 @@ idx=0; [ -f "$STATE" ] && idx=$(cat "$STATE" 2>/dev/null || echo 0)
 KEY="${KEYS[$(( idx % ${#KEYS[@]} ))]}"
 echo $(( (idx + 1) % 1000000 )) > "$STATE"
 
-AUTH=(-H "Authorization: Bearer $KEY" -H "content-type: application/json")
+AUTH=(
+  -H "Authorization: Bearer $KEY"
+  -H "content-type: application/json"
+  -H "x-openagents-demand-kind: internal"
+  -H "x-openagents-demand-source: heartbeat"
+  -H "x-openagents-client: khala-heartbeat"
+)
 ok=0; fail=0; q402=0; summed=0; details=""
 
 before=$(curl -s --max-time 15 "$PUBLIC_BASE/api/public/khala-tokens-served" | jq -r '.tokensServed // empty')


### PR DESCRIPTION
## Problem

Refs #6298. Captured Khala traces did not carry the existing demand-origin classification, so reviewers could not separate internal dogfood/canary traffic from genuine external demand in the trace corpus.

## What changed

- Added nullable `demand_kind` / `demand_source` columns to `agent_traces` via migration `0236`.
- Made the D1 trace store deployment-safe for code-before-migration reads/writes by feature-detecting the new columns and falling back to the old projection until the migration is present.
- Threaded the existing chat request attribution into `emitKhalaChatTrace`; no new classifier or private header surface was introduced.
- Defaulted captured trace attribution with no demand headers to `external` / `unlabeled`.
- Exposed demand attribution in public/owner trace projections and added owner-list filtering via `demandKind` / `demand_kind`.
- Tagged `scripts/khala-heartbeat.sh` and `scripts/khala-canary.sh` as internal demand sources.

## Validation

- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/khala-chat-trace-emitter.test.ts src/inference/chat-completions-routes.test.ts src/trace-store-routes.test.ts`
- `bun run --cwd apps/openagents.com typecheck:api` (exit 0; existing Effect language-service TS47 advisory messages in `trace-store-routes.ts`)
- `bun run --cwd apps/openagents.com test:pending-migrations-guard`
- `bash -n scripts/khala-heartbeat.sh && bash -n scripts/khala-canary.sh && git diff --check`
- Applied `0228`, `0229`, `0230`, and `0236` to an in-memory sqlite database and verified `demand_kind` / `demand_source` exist.

## Value

This gives the free-tier trace capture/data-sharing path a reviewable demand segmentation primitive, which protects product proof from being inflated by internal heartbeat/canary traffic while preserving fail-soft trace capture.

## Not changed

No backfill, no live deploy, no paid-privacy change, no trace visibility mutation route, no public promise green claim, and no real-spend smoke.
