### PR TITLE
Improve homepage search metadata

### DIFF
--- a/apps/openagents.com/apps/web/index.html
+++ b/apps/openagents.com/apps/web/index.html
@@ -3,6 +3,44 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenAgents - Paid AI agent work with public proof</title>
+    <meta
+      name="description"
+      content="OpenAgents is the agent network for paid AI work, public proof, product promises, and verifiable receipts."
+    />
+    <link rel="canonical" href="https://openagents.com/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta property="og:site_name" content="OpenAgents" />
+    <meta
+      property="og:title"
+      content="OpenAgents - Paid AI agent work with public proof"
+    />
+    <meta
+      property="og:description"
+      content="OpenAgents is the agent network for paid AI work, public proof, product promises, and verifiable receipts."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://openagents.com/" />
+    <meta name="twitter:card" content="summary" />
+    <meta
+      name="twitter:title"
+      content="OpenAgents - Paid AI agent work with public proof"
+    />
+    <meta
+      name="twitter:description"
+      content="OpenAgents is the agent network for paid AI work, public proof, product promises, and verifiable receipts."
+    />
+    <meta name="theme-color" content="#05070a" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "OpenAgents",
+        "alternateName": "OpenAgents.com",
+        "url": "https://openagents.com/",
+        "description": "OpenAgents is the agent network for paid AI work, public proof, product promises, and verifiable receipts."
+      }
+    </script>
     <meta
       name="openagents:homepage-json"
       content="https://openagents.com/api/public/home"
@@ -31,7 +69,6 @@
       data-site="IVAXCCIT"
       defer
     ></script>
-    <title>OpenAgents</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/openagents.com/apps/web/public/favicon.svg
+++ b/apps/openagents.com/apps/web/public/favicon.svg
@@ -1,0 +1,31 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 64 64"
+  role="img"
+  aria-label="OpenAgents"
+>
+  <rect width="64" height="64" rx="14" fill="#05070a" />
+  <circle
+    cx="25"
+    cy="32"
+    r="14"
+    fill="none"
+    stroke="#f8fafc"
+    stroke-width="6"
+  />
+  <path
+    d="M39 48L49 16L59 48"
+    fill="none"
+    stroke="#60a5fa"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M43.5 36H54.5"
+    fill="none"
+    stroke="#60a5fa"
+    stroke-width="6"
+    stroke-linecap="round"
+  />
+</svg>

--- a/apps/openagents.com/apps/web/src/index-html.test.ts
+++ b/apps/openagents.com/apps/web/src/index-html.test.ts
@@ -7,7 +7,65 @@ const indexHtml = import.meta.glob<string>('../index.html', {
   query: '?raw',
 })
 
+const faviconSvg = import.meta.glob<string>('../public/favicon.svg', {
+  eager: true,
+  import: 'default',
+  query: '?raw',
+})
+
+const expectedTitle = 'OpenAgents - Paid AI agent work with public proof'
+const expectedDescription =
+  'OpenAgents is the agent network for paid AI work, public proof, product promises, and verifiable receipts.'
+
 describe('index html', () => {
+  test('declares homepage search result metadata', () => {
+    const html = indexHtml['../index.html'] ?? ''
+
+    expect(html).toContain(`<title>${expectedTitle}</title>`)
+    expect(html).toContain(`name="description"`)
+    expect(html).toContain(`content="${expectedDescription}"`)
+    expect(html).toContain(
+      '<link rel="canonical" href="https://openagents.com/" />',
+    )
+    expect(html).toContain(
+      '<link rel="icon" type="image/svg+xml" href="/favicon.svg" />',
+    )
+    expect(html).toContain(`property="og:site_name" content="OpenAgents"`)
+    expect(html).toContain(`property="og:title"`)
+    expect(html).toContain(`property="og:description"`)
+    expect(html).toContain(
+      `property="og:url" content="https://openagents.com/"`,
+    )
+    expect(html).toContain(`name="twitter:card" content="summary"`)
+    expect(html).toContain(`name="twitter:title"`)
+    expect(html).toContain(`name="twitter:description"`)
+  })
+
+  test('declares WebSite structured data for the homepage', () => {
+    const html = indexHtml['../index.html'] ?? ''
+    const match = html.match(
+      /<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/,
+    )
+
+    expect(match).not.toBeNull()
+    expect(JSON.parse(match?.[1] ?? '{}')).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: 'OpenAgents',
+      alternateName: 'OpenAgents.com',
+      url: 'https://openagents.com/',
+      description: expectedDescription,
+    })
+  })
+
+  test('ships a crawlable favicon asset', () => {
+    const svg = faviconSvg['../public/favicon.svg'] ?? ''
+
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('viewBox="0 0 64 64"')
+    expect(svg).toContain('aria-label="OpenAgents"')
+  })
+
   test('loads the Fathom analytics script on the app shell', () => {
     const html = indexHtml['../index.html'] ?? ''
 


### PR DESCRIPTION
Closes #6337

## Problem
Google currently has very little useful homepage metadata to display for OpenAgents: the deployed app shell exposes a bare `OpenAgents` title, no meta description, no canonical URL, no social summary metadata, no WebSite structured data, and favicon paths fall through to SPA HTML.

## Change
- Add a descriptive homepage title and meta description to the app shell.
- Add canonical, Open Graph, Twitter summary, theme color, and WebSite JSON-LD metadata.
- Add a real square SVG favicon at `/favicon.svg` and link it from the app shell.
- Extend the existing index HTML test to cover search metadata, structured data, and the favicon asset.

## Validation
- `../../node_modules/.bin/vitest run src/index-html.test.ts` passed with the worktree using temporary symlinks to the already-installed workspace dependencies.
- `../../node_modules/.bin/prettier --write index.html src/index-html.test.ts`
- `../../node_modules/.bin/prettier --parser html --write public/favicon.svg`

## Build note
- Attempted `./node_modules/.bin/vite build` in the temporary worktree. It reached app bundling and failed on an unrelated dependency resolution mismatch from the temporary symlinked dependency tree: `InferenceAnalyticsResponse` was missing from `@openagentsinc/sync-schema` as resolved from the main checkout package path. This PR only changes static app-shell metadata and a public favicon asset.

## Not changed
- No runtime route/title behavior.
- No Google Search Console recrawl request; that should happen after deployment if a verified Search Console property is available.
