### PR TITLE
Allow owner-token Pylon assignment dispatch

### DIFF
--- a/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
@@ -745,6 +745,7 @@ const createAssignment = async (
     campaignPolicyRefs?: ReadonlyArray<string>
     forumAutoPublishAllowed?: boolean
     idempotencyKey?: string
+    jobKind?: string
     leaseSeconds?: number
     noDuplicateAssignmentRefs?: ReadonlyArray<string>
     nowIso?: string
@@ -752,10 +753,10 @@ const createAssignment = async (
     pylonRef?: string
     requiredCapabilityRefs?: ReadonlyArray<string>
     spendCapRefs?: ReadonlyArray<string>
+    tokenUserId?: string
   }> = {},
 ) =>
   route(store, '/api/operator/pylons/assignments', {
-    adminToken: true,
     body: {
       acceptanceCriteriaRefs: ['acceptance.public.echo_result'],
       assignmentRef: input.assignmentRef ?? 'assignment.public.issue502.echo',
@@ -767,7 +768,7 @@ const createAssignment = async (
       closeoutPathRefs: ['closeout.public.operator_review_required'],
       forumAutoPublishAllowed: input.forumAutoPublishAllowed ?? false,
       idempotencyRefs: ['idempotency.public.pylon_assignment.request_key'],
-      jobKind: 'healthcheck_echo',
+      jobKind: input.jobKind ?? 'healthcheck_echo',
       leaseSeconds: input.leaseSeconds ?? 600,
       noDuplicateAssignmentRefs: input.noDuplicateAssignmentRefs ?? [
         'dedupe.public.pylon_assignment.active_lease',
@@ -788,6 +789,9 @@ const createAssignment = async (
     idempotencyKey: input.idempotencyKey ?? 'assignment-create-echo',
     method: 'POST',
     ...(input.nowIso === undefined ? {} : { nowIso: input.nowIso }),
+    ...(input.tokenUserId === undefined
+      ? { adminToken: true }
+      : { tokenUserId: input.tokenUserId }),
   })
 
 describe('Pylon API routes', () => {
@@ -2482,6 +2486,75 @@ describe('Pylon API routes', () => {
     expect(paidWithoutSpendCapBody.dispatchGate?.blockerRefs).toContain(
       'blocker.public.pylon_dispatch.paid_mode_missing_spend_cap',
     )
+  })
+
+  test('allows non-admin agents to dispatch no-spend Codex assignments only to their own Pylon (#6382)', async () => {
+    const store = new MemoryPylonApiStore()
+    const pylonRef = 'pylon.owner.codex'
+    const requiredCapabilityRefs = ['capability.public.codex_agent_task']
+    await registerPylon(store, {
+      capabilityRefs: requiredCapabilityRefs,
+      idempotencyKey: 'register-owner-codex-pylon',
+      pylonRef,
+      tokenUserId: 'agent-owner',
+    })
+    await markOnline(store, {
+      pylonRef,
+      tokenUserId: 'agent-owner',
+    })
+    await markWalletReady(store, pylonRef, 'agent-owner')
+
+    const ownerDispatch = await createAssignment(store, {
+      assignmentRef: 'assignment.public.codex_owner',
+      idempotencyKey: 'assignment-owner-codex',
+      jobKind: 'codex_agent_task',
+      pylonRef,
+      requiredCapabilityRefs,
+      tokenUserId: 'agent-owner',
+    })
+    const ownerReplay = await createAssignment(store, {
+      assignmentRef: 'assignment.public.codex_owner',
+      idempotencyKey: 'assignment-owner-codex',
+      jobKind: 'codex_agent_task',
+      pylonRef,
+      requiredCapabilityRefs,
+      tokenUserId: 'agent-owner',
+    })
+    const crossTenantDispatch = await createAssignment(store, {
+      assignmentRef: 'assignment.public.codex_cross_tenant',
+      idempotencyKey: 'assignment-cross-tenant-codex',
+      jobKind: 'codex_agent_task',
+      pylonRef,
+      requiredCapabilityRefs,
+      tokenUserId: 'agent-other',
+    })
+    const crossTenantList = await route(
+      store,
+      `/api/pylons/${pylonRef}/assignments`,
+      {
+        tokenUserId: 'agent-other',
+      },
+    )
+    const ownerBody = await responseJson<PylonRouteJson>(ownerDispatch)
+    const replayBody = await responseJson<PylonRouteJson>(ownerReplay)
+    const crossTenantDispatchBody =
+      await responseJson<PylonRouteJson>(crossTenantDispatch)
+    const crossTenantListBody =
+      await responseJson<PylonRouteJson>(crossTenantList)
+
+    expect(ownerDispatch.status).toBe(201)
+    expect(ownerBody.assignment?.state).toBe('offered')
+    expect(ownerBody.dispatchGate?.dispatchAllowed).toBe(true)
+    expect(ownerBody.dispatchGate?.noSpendDispatch).toBe(true)
+    expect(ownerBody.dispatchGate?.walletSpendAllowed).toBe(false)
+    expect(ownerBody.dispatchGate?.settlementMutationAllowed).toBe(false)
+    expect(ownerBody.dispatchGate?.forumAutoPublishAllowed).toBe(false)
+    expect(ownerReplay.status).toBe(200)
+    expect(replayBody.idempotent).toBe(true)
+    expect(crossTenantDispatch.status).toBe(403)
+    expect(crossTenantDispatchBody.error).toBe('pylon_api_forbidden')
+    expect(crossTenantList.status).toBe(403)
+    expect(crossTenantListBody.error).toBe('pylon_api_forbidden')
   })
 
   test('does not let expired active leases consume future dispatch capacity', async () => {

--- a/apps/openagents.com/workers/api/src/pylon-api-routes.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.ts
@@ -819,6 +819,45 @@ const requireAdmin = <Bindings extends PylonApiRouteEnv>(
   )
 }
 
+type PylonAssignmentDispatcher =
+  | Readonly<{ kind: 'admin' }>
+  | Readonly<{ kind: 'agent'; session: ProgrammaticAgentSession }>
+
+const requireAssignmentDispatcher = <Bindings extends PylonApiRouteEnv>(
+  dependencies: PylonApiRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+): Effect.Effect<PylonAssignmentDispatcher, PylonApiUnauthorized> => {
+  const requireAdminApiToken = dependencies.requireAdminApiToken
+
+  if (requireAdminApiToken === undefined) {
+    return Effect.map(
+      requireAgent(dependencies, request, env),
+      (session): PylonAssignmentDispatcher => ({
+        kind: 'agent',
+        session,
+      }),
+    )
+  }
+
+  return Effect.flatMap(
+    Effect.tryPromise({
+      catch: () => new PylonApiUnauthorized({}),
+      try: () => requireAdminApiToken(request, env),
+    }),
+    (allowed): Effect.Effect<PylonAssignmentDispatcher, PylonApiUnauthorized> =>
+      allowed
+        ? Effect.succeed({ kind: 'admin' })
+        : Effect.map(
+            requireAgent(dependencies, request, env),
+            (session): PylonAssignmentDispatcher => ({
+              kind: 'agent',
+              session,
+            }),
+          ),
+  )
+}
+
 const sameOpenAuthOwnerAgentUserIds = <Bindings extends PylonApiRouteEnv>(
   dependencies: PylonApiRouteDependencies<Bindings>,
   env: Bindings,
@@ -1160,7 +1199,11 @@ const routeCreateAssignment = <Bindings extends PylonApiRouteEnv>(
   env: Bindings,
 ) =>
   Effect.gen(function* () {
-    yield* requireAdmin(dependencies, request, env)
+    const dispatcher = yield* requireAssignmentDispatcher(
+      dependencies,
+      request,
+      env,
+    )
     const idempotencyKeyHash = yield* requireIdempotencyHash(request)
     const body = yield* decodeBody(request, PylonApiCreateAssignmentRequest)
     const nowIso = routeNowIso(dependencies)
@@ -1171,6 +1214,23 @@ const routeCreateAssignment = <Bindings extends PylonApiRouteEnv>(
     })
 
     if (existing !== undefined) {
+      if (
+        dispatcher.kind === 'agent' &&
+        !(yield* sessionOwnsAgentUserId(
+          dependencies,
+          env,
+          dispatcher.session,
+          existing.ownerAgentUserId,
+        ))
+      ) {
+        return routeErrorResponse(
+          new PylonApiStoreError({
+            kind: 'forbidden',
+            reason: 'Assignment idempotency key belongs to another agent.',
+          }),
+        )
+      }
+
       if (
         existing.pylonRef !== body.pylonRef ||
         (body.assignmentRef !== undefined &&
@@ -1216,6 +1276,24 @@ const routeCreateAssignment = <Bindings extends PylonApiRouteEnv>(
       catch: pylonApiStoreErrorFromUnknown,
       try: () => store.readRegistration(body.pylonRef),
     })
+
+    if (
+      dispatcher.kind === 'agent' &&
+      registration !== undefined &&
+      !(yield* sessionOwnsAgentUserId(
+        dependencies,
+        env,
+        dispatcher.session,
+        registration.ownerAgentUserId,
+      ))
+    ) {
+      return routeErrorResponse(
+        new PylonApiStoreError({
+          kind: 'forbidden',
+          reason: 'Pylon registration belongs to another agent.',
+        }),
+      )
+    }
 
     const activeAssignments =
       registration === undefined


### PR DESCRIPTION
## Problem

Refs #6382.

Pylon assignment creation was still admin-token-only, which blocked the invite-only AaaS owner path where a registered Pylon owner should be able to dispatch a no-spend assignment to their own capacity without giving the caller admin privileges.

## Change

- Add a Pylon assignment dispatcher auth path that accepts either the existing admin token or an authenticated agent token.
- For agent-token dispatch, require the token owner to own the target Pylon registration using the existing linked-owner helper.
- Deny cross-tenant assignment idempotency replay when an agent token reuses a key owned by another agent.
- Preserve the existing admin behavior for assignment creation.

## Files touched

- `apps/openagents.com/workers/api/src/pylon-api-routes.ts`
- `apps/openagents.com/workers/api/src/pylon-api-routes.test.ts`

## Validation

- `git diff --check origin/main`
- `node_modules/.bin/vitest run workers/api/src/pylon-api-routes.test.ts` -> 68 tests passed after rebasing onto current `origin/main`
- `bun run typecheck` from `apps/openagents.com/workers/api` still fails on current unrelated baseline issues such as missing `@openagentsinc/sync-schema` / `effect` package types, `GLM_STRESS_SCHEDULER` Env typing, and sync-schema export mismatches. The earlier branch-owned `pylon-api-routes.ts` dispatcher typing error was fixed and is no longer present in the final typecheck output.

## Maintenance / Revenue Value

This unblocks the narrow owner-operated Pylon dispatch path needed for AaaS-style Codex capacity while keeping non-owner agents isolated and preserving no-spend dispatch semantics.

## Intentionally Not Changed

- Admin/operator closeout semantics.
- Wallet spend, settlement mutation, or forum auto-publish gates.
- `/api/operator/artanis/chat`, Artanis memory, `khala fleet run`, public `/artanis`, billing, or Codex resale surfaces.
