### PR TITLE
Guard Codex ripgrep searches

### DIFF
--- a/apps/pylon/src/codex-composer.ts
+++ b/apps/pylon/src/codex-composer.ts
@@ -20,6 +20,7 @@ import {
   providerRateLimitSnapshotsFromEvent,
   recordPylonAccountUsageObservation,
 } from "./account-usage.js"
+import { installCodexRipgrepGuard } from "./codex-rg-guard.js"
 
 export type CodexComposerSandboxMode = CodexAgentSandboxMode | "danger-full-access"
 export type CodexComposerExecutionMode = "local_bounded" | "local_supervised_danger"
@@ -613,10 +614,11 @@ export async function runCodexComposerStream(
           home: options.accountHome,
         }
       : null)
-  const env = pylonAccountEnvironment(
+  const accountEnv = pylonAccountEnvironment(
     options.env ?? (Bun.env as Record<string, string | undefined>),
     account,
   )
+  const env = installCodexRipgrepGuard({ env: accountEnv }).env
   const executionMode = options.executionMode ?? "local_bounded"
   const sandboxMode = options.sandboxMode ?? sandboxModeForCodexComposerExecutionMode(executionMode, config.sandboxMode)
   if (sandboxMode === "danger-full-access" && executionMode !== "local_supervised_danger") {

--- a/apps/pylon/src/codex-rg-guard.test.ts
+++ b/apps/pylon/src/codex-rg-guard.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test"
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { spawnSync } from "node:child_process"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import {
+  CODEX_RG_GUARD_ENV,
+  CODEX_RG_GUARD_EXCLUDE_GLOBS,
+  guardedCodexRipgrepArgs,
+  installCodexRipgrepGuard,
+  sanitizeCodexRipgrepArgs,
+} from "./codex-rg-guard.js"
+
+describe("Codex ripgrep guard", () => {
+  test("strips unrestricted traversal flags before end-of-options", () => {
+    expect(sanitizeCodexRipgrepArgs(["-uu", "--no-ignore", "--hidden", "needle", "--", "--no-ignore"])).toEqual([
+      "needle",
+      "--",
+      "--no-ignore",
+    ])
+  })
+
+  test("appends hard exclude globs before end-of-options", () => {
+    const args = guardedCodexRipgrepArgs(["needle", ".", "--", "--hidden"])
+    const endOfOptions = args.indexOf("--")
+    expect(endOfOptions).toBeGreaterThan(0)
+    for (const glob of CODEX_RG_GUARD_EXCLUDE_GLOBS) {
+      const index = args.indexOf(glob)
+      expect(index).toBeGreaterThan(0)
+      expect(index).toBeLessThan(endOfOptions)
+    }
+    expect(args.slice(endOfOptions)).toEqual(["--", "--hidden"])
+  })
+
+  test("installed wrapper delegates sanitized args to the real rg", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-rg-guard-"))
+    try {
+      const realRg = join(root, "real-rg")
+      const out = join(root, "args.json")
+      await writeFile(
+        realRg,
+        `#!/usr/bin/env bash
+: > "$OUT"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$OUT"
+done
+`,
+      )
+      await chmod(realRg, 0o755)
+      const binDir = join(root, "bin")
+      const installed = installCodexRipgrepGuard({
+        env: { PATH: "/usr/bin:/bin" },
+        binDir,
+        realRipgrepPath: realRg,
+      })
+
+      expect(installed.installed).toBe(true)
+      expect(installed.env[CODEX_RG_GUARD_ENV]).toBe("1")
+      const result = spawnSync("rg", ["-uu", "--no-ignore", "needle", ".", "--", "--hidden"], {
+        env: { ...process.env, ...installed.env, OUT: out },
+        encoding: "utf8",
+      })
+      expect(result.status).toBe(0)
+      const delegated = (await readFile(out, "utf8")).trim().split("\n")
+      expect(delegated).not.toContain("-uu")
+      expect(delegated).not.toContain("--no-ignore")
+      for (const glob of CODEX_RG_GUARD_EXCLUDE_GLOBS) expect(delegated).toContain(glob)
+      expect(delegated.slice(-2)).toEqual(["--", "--hidden"])
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/apps/pylon/src/codex-rg-guard.ts
+++ b/apps/pylon/src/codex-rg-guard.ts
@@ -1,0 +1,168 @@
+import { accessSync, chmodSync, constants, mkdirSync, writeFileSync } from "node:fs"
+import { delimiter, join } from "node:path"
+import { tmpdir } from "node:os"
+
+export const CODEX_RG_GUARD_ENV = "OPENAGENTS_CODEX_RG_GUARD"
+export const CODEX_RG_GUARD_DISABLED_ENV = "OPENAGENTS_CODEX_RG_GUARD_DISABLED"
+export const CODEX_RG_GUARD_BIN_DIR_ENV = "OPENAGENTS_CODEX_RG_GUARD_BIN_DIR"
+export const CODEX_REAL_RG_ENV = "OPENAGENTS_CODEX_REAL_RG"
+
+export const CODEX_RG_GUARD_EXCLUDE_GLOBS = [
+  "!node_modules/**",
+  "!**/node_modules/**",
+  "!.git/**",
+  "!**/.git/**",
+  "!dist/**",
+  "!**/dist/**",
+  "!build/**",
+  "!**/build/**",
+] as const
+
+export interface CodexRipgrepGuardInstall {
+  env: Record<string, string>
+  installed: boolean
+  binDir: string | null
+  wrapperPath: string | null
+  realRipgrepPath: string | null
+}
+
+export function isCodexRipgrepUnsafeArg(arg: string): boolean {
+  return (
+    /^-u+$/.test(arg) ||
+    arg === "--unrestricted" ||
+    arg === "--hidden" ||
+    arg === "--follow" ||
+    arg === "--no-ignore" ||
+    arg.startsWith("--no-ignore-")
+  )
+}
+
+export function sanitizeCodexRipgrepArgs(args: ReadonlyArray<string>): string[] {
+  const sanitized: string[] = []
+  let endOfOptions = false
+  for (const arg of args) {
+    if (endOfOptions) {
+      sanitized.push(arg)
+      continue
+    }
+    if (arg === "--") {
+      sanitized.push(arg)
+      endOfOptions = true
+      continue
+    }
+    if (isCodexRipgrepUnsafeArg(arg)) continue
+    sanitized.push(arg)
+  }
+  return sanitized
+}
+
+export function guardedCodexRipgrepArgs(args: ReadonlyArray<string>): string[] {
+  const sanitized = sanitizeCodexRipgrepArgs(args)
+  const endOfOptionsIndex = sanitized.indexOf("--")
+  const guardArgs = CODEX_RG_GUARD_EXCLUDE_GLOBS.flatMap((glob) => ["--glob", glob])
+  if (endOfOptionsIndex === -1) return [...sanitized, ...guardArgs]
+  return [
+    ...sanitized.slice(0, endOfOptionsIndex),
+    ...guardArgs,
+    ...sanitized.slice(endOfOptionsIndex),
+  ]
+}
+
+function singleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+export function codexRipgrepGuardShell(realRipgrepPath: string): string {
+  const guardGlobs = CODEX_RG_GUARD_EXCLUDE_GLOBS.map((glob) => singleQuote(glob)).join(" ")
+  return `#!/usr/bin/env bash
+set -euo pipefail
+REAL_RG=${singleQuote(realRipgrepPath)}
+guard_globs=(${guardGlobs})
+before=()
+after=()
+seen_end=0
+for arg in "$@"; do
+  if [[ "$seen_end" == "1" ]]; then
+    after+=("$arg")
+    continue
+  fi
+  if [[ "$arg" == "--" ]]; then
+    seen_end=1
+    after+=("$arg")
+    continue
+  fi
+  case "$arg" in
+    -u|-uu|-uuu|--unrestricted|--hidden|--follow|--no-ignore|--no-ignore-*)
+      continue
+      ;;
+  esac
+  before+=("$arg")
+done
+guard_args=()
+for glob in "\${guard_globs[@]}"; do
+  guard_args+=(--glob "$glob")
+done
+exec "$REAL_RG" "\${before[@]}" "\${guard_args[@]}" "\${after[@]}"
+`
+}
+
+function normalizedEnv(env: Record<string, string | undefined>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) out[key] = value
+  }
+  return out
+}
+
+function findExecutableOnPath(name: string, pathValue: string | undefined): string | null {
+  const entries = (pathValue ?? "").split(delimiter).filter((entry) => entry.length > 0)
+  for (const entry of entries) {
+    const candidate = join(entry, name)
+    try {
+      accessSync(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      // Continue scanning PATH.
+    }
+  }
+  return null
+}
+
+function prependPathOnce(pathValue: string | undefined, binDir: string): string {
+  const entries = (pathValue ?? "").split(delimiter).filter((entry) => entry.length > 0)
+  if (entries.includes(binDir)) return pathValue ?? binDir
+  return entries.length === 0 ? binDir : `${binDir}${delimiter}${entries.join(delimiter)}`
+}
+
+export function installCodexRipgrepGuard(input: {
+  env: Record<string, string | undefined>
+  binDir?: string
+  realRipgrepPath?: string
+}): CodexRipgrepGuardInstall {
+  const env = normalizedEnv(input.env)
+  if (env[CODEX_RG_GUARD_DISABLED_ENV] === "1" || process.platform === "win32") {
+    return { env, installed: false, binDir: null, wrapperPath: null, realRipgrepPath: null }
+  }
+
+  const realRipgrepPath =
+    input.realRipgrepPath ??
+    env[CODEX_REAL_RG_ENV] ??
+    findExecutableOnPath("rg", env.PATH ?? process.env.PATH)
+  if (realRipgrepPath === null) {
+    return { env, installed: false, binDir: null, wrapperPath: null, realRipgrepPath: null }
+  }
+
+  const binDir = input.binDir ?? env[CODEX_RG_GUARD_BIN_DIR_ENV] ?? join(tmpdir(), "openagents-codex-rg-guard", "bin")
+  mkdirSync(binDir, { recursive: true })
+  const wrapperPath = join(binDir, "rg")
+  writeFileSync(wrapperPath, codexRipgrepGuardShell(realRipgrepPath), { mode: 0o755 })
+  chmodSync(wrapperPath, 0o755)
+
+  const next = {
+    ...env,
+    [CODEX_RG_GUARD_ENV]: "1",
+    [CODEX_REAL_RG_ENV]: realRipgrepPath,
+    PATH: prependPathOnce(env.PATH ?? process.env.PATH, binDir),
+  }
+  return { env: next, installed: true, binDir, wrapperPath, realRipgrepPath }
+}

--- a/apps/pylon/tests/codex-composer.test.ts
+++ b/apps/pylon/tests/codex-composer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -317,6 +318,52 @@ describe("Codex composer SDK stream", () => {
     expect(result.threadId).toBe("thread.test.codex")
     expect(clientEnv).toMatchObject({ PATH: "/bin", CODEX_HOME: "/tmp/codex-home-a" })
     expect(Bun.env.CODEX_HOME).toBe(original)
+  })
+
+  test("injects the ripgrep guard into the Codex environment", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-codex-composer-rg-"))
+    try {
+      const realRg = join(root, "real-rg")
+      const guardBin = join(root, "guard-bin")
+      await writeFile(realRg, "#!/usr/bin/env bash\nexit 0\n")
+      await chmod(realRg, 0o755)
+
+      let clientEnv: Record<string, string | undefined> | null = null
+      const importer = async (specifier: string) => {
+        if (specifier !== CODEX_AGENT_SDK_PACKAGE) throw new Error(`unexpected import: ${specifier}`)
+        return {
+          Codex: class {
+            constructor(options?: { env?: Record<string, string | undefined> }) {
+              clientEnv = options?.env ?? null
+            }
+            startThread() {
+              return {
+                runStreamed: async () => ({ events: fakeCodexEvents() }),
+              }
+            }
+          },
+        }
+      }
+
+      await runCodexComposerStream("fix", {
+        codexCliLoginPresent: true,
+        cwd: "/tmp/current-repo",
+        env: {
+          OPENAGENTS_CODEX_REAL_RG: realRg,
+          OPENAGENTS_CODEX_RG_GUARD_BIN_DIR: guardBin,
+          PATH: "/bin",
+        },
+        importer,
+        platform: "darwin",
+      })
+
+      expect(clientEnv?.OPENAGENTS_CODEX_RG_GUARD).toBe("1")
+      expect(clientEnv?.OPENAGENTS_CODEX_REAL_RG).toBe(realRg)
+      expect(clientEnv?.PATH?.startsWith(`${guardBin}:`)).toBe(true)
+      expect(existsSync(join(guardBin, "rg"))).toBe(true)
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
   test("persists streamed usage snapshots when a Pylon home is provided", async () => {

--- a/scripts/codex-fleet/README.md
+++ b/scripts/codex-fleet/README.md
@@ -29,6 +29,10 @@ just subscription quota.
 - **Per-promise isolation.** Each worker gets its own `CODEX_HOME` and leases one
   subscription account, released after the run, so concurrent workers never
   share or overwrite auth material.
+- **Bounded ripgrep searches.** Workers install an `rg` wrapper on the Codex
+  process `PATH` that strips unrestricted traversal flags (`-u`, `--no-ignore`,
+  `--hidden`, `--follow`) and always excludes `node_modules`, `.git`, `dist`,
+  and `build`.
 
 ## Components
 
@@ -36,6 +40,7 @@ just subscription quota.
 |------|--------------|
 | `assign.mjs` | Fetches the public product-promise registry (`https://openagents.com/api/public/product-promises`, browser UA), selects N non-green promises with **buildable, non-owner-gated** blockers, and emits one task brief each. `--priority business` front-loads business-fulfillment promises. Open-PR dedup matches the `codex-fleet/<promise>` branch prefix. |
 | `fetch-codex-auth.mjs` | **The auth crux.** Pulls a Codex OAuth blob from the central device-flow provider-account store and materializes a codex-native `auth.json` under an isolated `CODEX_HOME`. Subcommands: `lease`, `release`, `sanity-all`. |
+| `install-rg-guard.mjs` | Installs the per-run `rg` wrapper used by `worker.sh` so agent searches respect ignore files and cannot traverse heavy generated directories. |
 | `worker.sh` | Given one assignment: `git worktree add` from `origin/main`, `bun install`, fetch central Codex auth into a per-promise `CODEX_HOME`, run `codex exec "<brief>" -m gpt-5.5 -c model_reasoning_effort=xhigh --dangerously-bypass-approvals-and-sandbox --json`, release the lease, run `check:deploy`, commit to branch `codex-fleet/<promise>`, push, open a PR. Emits a one-line JSON result (incl. token usage). |
 | `run.sh` | Orchestrator. Runs a few workers (sequential by default; `--parallel` opt-in), then prints PR URLs + per-worker `check:deploy` status + total tokens. |
 

--- a/scripts/codex-fleet/install-rg-guard.mjs
+++ b/scripts/codex-fleet/install-rg-guard.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export const CODEX_RG_GUARD_EXCLUDE_GLOBS = [
+  "!node_modules/**",
+  "!**/node_modules/**",
+  "!.git/**",
+  "!**/.git/**",
+  "!dist/**",
+  "!**/dist/**",
+  "!build/**",
+  "!**/build/**",
+]
+
+export function isUnsafeRipgrepArg(arg) {
+  return (
+    /^-u+$/.test(arg) ||
+    arg === "--unrestricted" ||
+    arg === "--hidden" ||
+    arg === "--follow" ||
+    arg === "--no-ignore" ||
+    arg.startsWith("--no-ignore-")
+  )
+}
+
+export function sanitizeRipgrepArgs(args) {
+  const sanitized = []
+  let endOfOptions = false
+  for (const arg of args) {
+    if (endOfOptions) {
+      sanitized.push(arg)
+      continue
+    }
+    if (arg === "--") {
+      sanitized.push(arg)
+      endOfOptions = true
+      continue
+    }
+    if (isUnsafeRipgrepArg(arg)) continue
+    sanitized.push(arg)
+  }
+  return sanitized
+}
+
+export function guardedRipgrepArgs(args) {
+  const sanitized = sanitizeRipgrepArgs(args)
+  const endOfOptionsIndex = sanitized.indexOf("--")
+  const guardArgs = CODEX_RG_GUARD_EXCLUDE_GLOBS.flatMap((glob) => ["--glob", glob])
+  if (endOfOptionsIndex === -1) return [...sanitized, ...guardArgs]
+  return [
+    ...sanitized.slice(0, endOfOptionsIndex),
+    ...guardArgs,
+    ...sanitized.slice(endOfOptionsIndex),
+  ]
+}
+
+function singleQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`
+}
+
+export function rgGuardShell(realRg) {
+  const guardGlobs = CODEX_RG_GUARD_EXCLUDE_GLOBS.map((glob) => singleQuote(glob)).join(" ")
+  return `#!/usr/bin/env bash
+set -euo pipefail
+REAL_RG=${singleQuote(realRg)}
+guard_globs=(${guardGlobs})
+before=()
+after=()
+seen_end=0
+for arg in "$@"; do
+  if [[ "$seen_end" == "1" ]]; then
+    after+=("$arg")
+    continue
+  fi
+  if [[ "$arg" == "--" ]]; then
+    seen_end=1
+    after+=("$arg")
+    continue
+  fi
+  case "$arg" in
+    -u|-uu|-uuu|--unrestricted|--hidden|--follow|--no-ignore|--no-ignore-*)
+      continue
+      ;;
+  esac
+  before+=("$arg")
+done
+guard_args=()
+for glob in "\${guard_globs[@]}"; do
+  guard_args+=(--glob "$glob")
+done
+exec "$REAL_RG" "\${before[@]}" "\${guard_args[@]}" "\${after[@]}"
+`
+}
+
+export function installRipgrepGuard({ binDir, realRg }) {
+  if (!binDir) throw new Error("missing binDir")
+  if (!realRg) throw new Error("missing realRg")
+  mkdirSync(binDir, { recursive: true })
+  const wrapperPath = join(binDir, "rg")
+  writeFileSync(wrapperPath, rgGuardShell(realRg), { mode: 0o755 })
+  chmodSync(wrapperPath, 0o755)
+  return wrapperPath
+}
+
+function usage() {
+  return "usage: install-rg-guard.mjs --bin-dir <dir> --real-rg <path>"
+}
+
+function parseArgs(argv) {
+  const out = { binDir: "", realRg: "" }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === "--bin-dir" && argv[i + 1]) {
+      out.binDir = argv[i + 1]
+      i += 1
+    } else if (arg === "--real-rg" && argv[i + 1]) {
+      out.realRg = argv[i + 1]
+      i += 1
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(usage())
+      process.exit(0)
+    } else {
+      throw new Error(`unknown arg: ${arg}`)
+    }
+  }
+  return out
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const parsed = parseArgs(process.argv.slice(2))
+    const wrapperPath = installRipgrepGuard(parsed)
+    console.log(JSON.stringify({ ok: true, wrapperPath }))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    console.error(usage())
+    process.exit(2)
+  }
+}

--- a/scripts/codex-fleet/rg-guard.test.mjs
+++ b/scripts/codex-fleet/rg-guard.test.mjs
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  CODEX_RG_GUARD_EXCLUDE_GLOBS,
+  guardedRipgrepArgs,
+  installRipgrepGuard,
+  sanitizeRipgrepArgs,
+} from "./install-rg-guard.mjs"
+
+describe("codex-fleet rg guard", () => {
+  test("sanitizes unrestricted flags before end-of-options", () => {
+    assert.deepEqual(sanitizeRipgrepArgs(["-uu", "--no-ignore", "--hidden", "needle", "--", "--hidden"]), [
+      "needle",
+      "--",
+      "--hidden",
+    ])
+  })
+
+  test("adds guard globs before end-of-options", () => {
+    const args = guardedRipgrepArgs(["needle", ".", "--", "--no-ignore"])
+    const endOfOptions = args.indexOf("--")
+    assert.ok(endOfOptions > 0)
+    for (const glob of CODEX_RG_GUARD_EXCLUDE_GLOBS) {
+      const index = args.indexOf(glob)
+      assert.ok(index > 0, `missing ${glob}`)
+      assert.ok(index < endOfOptions, `${glob} must precede --`)
+    }
+    assert.deepEqual(args.slice(endOfOptions), ["--", "--no-ignore"])
+  })
+
+  test("installed wrapper delegates sanitized args to the real rg", () => {
+    const root = mkdtempSync(join(tmpdir(), "codex-fleet-rg-guard-"))
+    try {
+      const realRg = join(root, "real-rg")
+      const out = join(root, "args.json")
+      writeFileSync(
+        realRg,
+        `#!/usr/bin/env bash
+: > "$OUT"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$OUT"
+done
+`,
+      )
+      chmodSync(realRg, 0o755)
+      const binDir = join(root, "bin")
+      installRipgrepGuard({ binDir, realRg })
+      const result = spawnSync("rg", ["-uu", "--no-ignore-vcs", "needle", ".", "--", "--hidden"], {
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}`, OUT: out },
+        encoding: "utf8",
+      })
+      assert.equal(result.status, 0)
+      const delegated = readFileSync(out, "utf8").trim().split("\n")
+      assert.equal(delegated.includes("-uu"), false)
+      assert.equal(delegated.includes("--no-ignore-vcs"), false)
+      for (const glob of CODEX_RG_GUARD_EXCLUDE_GLOBS) assert.ok(delegated.includes(glob))
+      assert.deepEqual(delegated.slice(-2), ["--", "--hidden"])
+    } finally {
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/scripts/codex-fleet/worker.sh
+++ b/scripts/codex-fleet/worker.sh
@@ -78,6 +78,7 @@ TRACE="${TRACE_DIR}/${SAFE}.${RUN_ID}.trace.jsonl"
 TRACE_INDEX="${CF_TRACE_ROOT}/index.jsonl"
 
 FETCH_AUTH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fetch-codex-auth.mjs"
+RG_GUARD_INSTALLER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/install-rg-guard.mjs"
 LEASE_REF=""
 
 log() { echo "[worker:${PROMISE}] $*" >&2; }
@@ -172,6 +173,23 @@ LEASE_REF="$(printf '%s' "$LEASE_OUT" | node -e 'let s="";process.stdin.on("data
 if [[ ! -s "$CODEX_HOME/auth.json" ]]; then
   log "FATAL: auth.json was not materialized under CODEX_HOME"
   emit "$(result_json auth_failed "" skipped null "auth_json_missing")"; exit 0
+fi
+REAL_RG="$(command -v rg 2>/dev/null || true)"
+if [[ -n "$REAL_RG" && -x "$REAL_RG" ]]; then
+  RG_GUARD_BIN="${CODEX_HOME_DIR}/rg-guard-bin"
+  if node "$RG_GUARD_INSTALLER" --bin-dir "$RG_GUARD_BIN" --real-rg "$REAL_RG" >>"$AGENT_LOG" 2>&1; then
+    export OPENAGENTS_CODEX_REAL_RG="$REAL_RG"
+    export OPENAGENTS_CODEX_RG_GUARD=1
+    case ":${PATH:-}:" in
+      *":${RG_GUARD_BIN}:"*) ;;
+      *) export PATH="${RG_GUARD_BIN}${PATH:+:${PATH}}" ;;
+    esac
+    log "ripgrep guard installed for Codex agent"
+  else
+    log "WARN: ripgrep guard install failed; continuing without rg guard"
+  fi
+else
+  log "ripgrep guard skipped: rg not on PATH"
 fi
 log "Codex auth materialized (lease acquired); running agent..."
 


### PR DESCRIPTION
## Problem

Fixes #6431. Codex-driven Pylon/fleet work can invoke `rg -uu` or equivalent no-ignore searches, causing recursive traversal through heavy directories such as `node_modules`, `.git`, `dist`, and `build`.

## Changes

- Adds a Pylon Codex ripgrep guard that installs an `rg` wrapper into the Codex SDK/CLI environment.
- Wires the same kind of guard into `scripts/codex-fleet/worker.sh` before `codex exec`.
- The wrapper strips unrestricted traversal flags (`-u`, `--unrestricted`, `--no-ignore*`, `--hidden`, `--follow`) before `--`, while preserving literal args after `--`.
- It appends hard exclude globs for `node_modules`, `.git`, `dist`, and `build`.
- Documents the fleet guard and adds focused tests for argument sanitization and wrapper delegation.

## Validation

- `bun install --frozen-lockfile`
- `bun test apps/pylon/src/codex-rg-guard.test.ts apps/pylon/tests/codex-composer.test.ts`
- `bun run --cwd apps/pylon typecheck`
- `node --test scripts/codex-fleet/rg-guard.test.mjs`
- `bash -n scripts/codex-fleet/worker.sh`
- `git diff --check`
- `bun run check:deploy` (rerun with network access for live doc-link checks)

## Value

This should reduce local owner desktop CPU spikes from unrestricted agent searches and keep the Pylon/Codex own-capacity loop usable for Artanis/Khala dispatch work without changing model, scheduler, or spend behavior.

## Intentionally Not Changed

- No scheduler/concurrency changes.
- No vendored Codex CLI changes.
- No global user-shell `rg` replacement; the guard only applies to Codex processes launched by Pylon and the codex-fleet worker.
