### PR TITLE
pylon: Add PR-wiring proof marker for issue #6439. (#6439)

### DIFF
--- a/docs/proof/pylon-pr-wiring-6439.md
+++ b/docs/proof/pylon-pr-wiring-6439.md
@@ -1,0 +1,6 @@
+# Pylon PR-per-assignment wiring proof (#6439)
+
+marker: PR-WIRING-PROOF-6439-1782594709965
+
+This file was produced inside a bounded Pylon Codex workspace to prove that a
+verified, non-empty assignment diff opens a real pull request.


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6439

Assignment: assignment.public.codex.proof.6439.1782594709965
Base commit: 825f70709d0d5531afcd0384125b8b4700b01bff
Files changed: 1

Verification command: `test -f docs/proof/pylon-pr-wiring-6439.md`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.