### PR TITLE
fix(forum): purge 'AI Agents That Do Real Work' OG title and serve per-thread OG by canonical topic id

### DIFF
--- a/apps/openagents.com/apps/web/index.html
+++ b/apps/openagents.com/apps/web/index.html
@@ -10,10 +10,7 @@
     />
     <link rel="canonical" href="https://openagents.com/" />
     <meta property="og:site_name" content="OpenAgents" />
-    <meta
-      property="og:title"
-      content="OpenAgents - AI Agents That Do Real Work"
-    />
+    <meta property="og:title" content="OpenAgents" />
     <meta
       property="og:description"
       content="OpenAgents builds public, verifiable AI agents for coding, research, payments, and operational work."
@@ -21,10 +18,7 @@
     <meta property="og:url" content="https://openagents.com/" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary" />
-    <meta
-      name="twitter:title"
-      content="OpenAgents - AI Agents That Do Real Work"
-    />
+    <meta name="twitter:title" content="OpenAgents" />
     <meta
       name="twitter:description"
       content="OpenAgents builds public, verifiable AI agents for coding, research, payments, and operational work."

--- a/apps/openagents.com/apps/web/src/index-html.test.ts
+++ b/apps/openagents.com/apps/web/src/index-html.test.ts
@@ -16,7 +16,7 @@ const publicAssets = import.meta.glob<string>('../public/*.svg', {
 })
 
 const html = indexHtml['../index.html'] ?? ''
-const title = 'OpenAgents - AI Agents That Do Real Work'
+const title = 'OpenAgents'
 const description =
   'OpenAgents builds public, verifiable AI agents for coding, research, payments, and operational work.'
 const canonicalUrl = 'https://openagents.com/'

--- a/apps/openagents.com/workers/api/src/http/forum-social-preview.test.ts
+++ b/apps/openagents.com/workers/api/src/http/forum-social-preview.test.ts
@@ -11,7 +11,11 @@ import {
 } from './forum-social-preview'
 
 const detailWith = (
-  overrides: Partial<{ title: string; bodyText: string | null }> = {},
+  overrides: Partial<{
+    bodyText: string | null
+    title: string
+    topicId: string
+  }> = {},
 ): ForumThreadPreviewSource => ({
   posts: [
     {
@@ -21,7 +25,10 @@ const detailWith = (
           : overrides.bodyText,
     },
   ],
-  topic: { title: overrides.title ?? 'Hello Thread' },
+  topic: {
+    title: overrides.title ?? 'Hello Thread',
+    ...(overrides.topicId === undefined ? {} : { topicId: overrides.topicId }),
+  },
 })
 
 describe('buildSocialPreviewExcerpt', () => {
@@ -105,6 +112,20 @@ describe('forumThreadSocialPreviewFromDetail', () => {
     expect(preview.url).toBe('https://openagents.com/forum/t/a%20b%2Fc')
     expect(preview.imageUrl).toBe(
       'https://openagents.com/og/forum/a%20b%2Fc.svg',
+    )
+  })
+
+  test('uses the resolved topic id for the canonical thread URL', () => {
+    const preview = forumThreadSocialPreviewFromDetail(
+      'hello-thread',
+      detailWith({ topicId: '55555555-5555-4555-8555-555555555555' }),
+    )
+
+    expect(preview.url).toBe(
+      'https://openagents.com/forum/t/55555555-5555-4555-8555-555555555555',
+    )
+    expect(preview.imageUrl).toBe(
+      'https://openagents.com/og/forum/hello-thread.svg',
     )
   })
 })

--- a/apps/openagents.com/workers/api/src/http/forum-social-preview.ts
+++ b/apps/openagents.com/workers/api/src/http/forum-social-preview.ts
@@ -118,7 +118,7 @@ export type ForumThreadSocialPreview = Readonly<{
 // The full ForumTopicDetailResponse satisfies this, so callers pass it
 // directly; tests build a minimal object without type assertions.
 export type ForumThreadPreviewSource = Readonly<{
-  topic: Readonly<{ title: string }>
+  topic: Readonly<{ title: string; topicId?: string }>
   posts: ReadonlyArray<Readonly<{ bodyText?: string | null }>>
 }>
 
@@ -143,7 +143,7 @@ export const forumThreadSocialPreviewFromDetail = (
     description: excerpt.length > 0 ? excerpt : DEFAULT_DESCRIPTION,
     imageUrl: forumThreadOgImageUrl(topicId),
     title: title.length > 0 ? title : DEFAULT_TITLE,
-    url: forumThreadPublicUrl(topicId),
+    url: forumThreadPublicUrl(detail.topic.topicId ?? topicId),
   }
 }
 

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -294,6 +294,7 @@ describe('Worker route dual-serve resolution (#6148)', () => {
     const observed = {
       exactPath: undefined as string | undefined,
       dispatcherPathname: undefined as string | undefined,
+      forumTopicId: undefined as string | undefined,
     }
 
     const okResponse = new Response('ok', { status: 200 })
@@ -336,7 +337,17 @@ describe('Worker route dual-serve resolution (#6148)', () => {
       handleAssetRequest: () => Effect.succeed(okResponse),
       handleAppShellPage: () => Effect.succeed(okResponse),
       handleThreadPage: () => Effect.succeed(okResponse),
-      handleForumThreadPage: () => Effect.succeed(okResponse),
+      handleForumThreadPage: (_request, _env, _ctx, topicId) =>
+        Effect.sync(() => {
+          observed.forumTopicId = topicId
+          return new Response(
+            '<!doctype html><meta property="og:title" content="First Topic">',
+            {
+              headers: { 'content-type': 'text/html; charset=utf-8' },
+              status: 200,
+            },
+          )
+        }),
       optionalUuid: (value: string | undefined) => value,
       routeAutopilotWorkRequest: noRoute,
       routeCloudCodingSessionRequest: noRoute,
@@ -448,6 +459,22 @@ describe('Worker route dual-serve resolution (#6148)', () => {
     expect(canonical.response.status).toBe(200)
     expect(canonical.observed.exactPath).toBe(
       '/v1/gateway/glm-fleet/readiness',
+    )
+  })
+
+  test('forum topic document routes reach the social preview document handler', async () => {
+    const result = await runRoute(
+      requestFor('/forum/t/55555555-5555-4555-8555-555555555555', {
+        headers: { 'user-agent': 'Discordbot/2.0' },
+      }),
+    )
+
+    expect(result.response.status).toBe(200)
+    await expect(result.response.text()).resolves.toContain(
+      'property="og:title" content="First Topic"',
+    )
+    expect(result.observed.forumTopicId).toBe(
+      '55555555-5555-4555-8555-555555555555',
     )
   })
 


### PR DESCRIPTION
Addresses #6438.

### Changes
- Removes the `OpenAgents - AI Agents That Do Real Work` string from `apps/web/index.html` (og:title and twitter:title) and the asserting test; replaces with `OpenAgents`.
- `forum-social-preview.ts`: canonical thread `og:url` now uses the resolved `topic.topicId` (not the slug), with a new unit test.
- `worker-routes.test.ts`: adds a regression test that a Discordbot request to `/forum/t/<topicId>` reaches the social-preview document handler and returns the thread's og:title.

### Verification
Not independently re-verified.