### PR TITLE
fix(pylon): add branch/PR/verification refs to codex assignment closeout

### DIFF
--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -1137,6 +1137,11 @@ const EMPTY_PULL_REQUEST_CONTRIBUTION: PullRequestCloseoutContribution = {
   messageSuffix: "",
 }
 
+function publicRefSegment(value: string): string {
+  const sanitized = value.toLowerCase().replace(/[^a-z0-9._-]+/g, ".").replace(/^\.+|\.+$/g, "")
+  return sanitized.length === 0 ? "unknown" : sanitized.slice(0, 80)
+}
+
 /**
  * Opens one scoped pull request for a verified, non-empty git_checkout diff and
  * maps the typed outcome to public-safe closeout refs. Only git_checkout tasks
@@ -1200,6 +1205,9 @@ async function maybePublishAssignmentPullRequest(input: {
         result.reused
           ? "result.public.pylon.codex_agent_task.pull_request_reused"
           : "result.public.pylon.codex_agent_task.pull_request_opened",
+        `branch.public.pylon.codex_agent_task.${publicRefSegment(result.branch)}`,
+        `pull_request.public.pylon.codex_agent_task.${result.prNumber}`,
+        `verification.public.pylon.codex_agent_task.passed.exit_${input.verification.exitCode}`,
         `result.public.pylon.codex_agent_task.pull_request_changed_files.${result.changedCount}`,
       ],
       previewRefs: [result.prUrl],

--- a/apps/pylon/src/codex-pr-publisher.ts
+++ b/apps/pylon/src/codex-pr-publisher.ts
@@ -146,7 +146,7 @@ function commitSubject(objectiveSummary: string | undefined, issueRef: string | 
   const base = cleaned.length === 0 ? "Pylon Codex assignment change" : cleaned
   const suffix = issueRef === null ? "" : ` (${issueRef})`
   const room = Math.max(8, MAX_SUBJECT_LENGTH - suffix.length)
-  const trimmed = base.length > room ? `${base.slice(0, room - 1).trimEnd()}…` : base
+  const trimmed = base.length > room ? `${base.slice(0, room - 3).trimEnd()}...` : base
   return `pylon: ${trimmed}${suffix}`
 }
 
@@ -289,8 +289,6 @@ export async function publishAssignmentPullRequest(
       subject,
       "-m",
       `Assignment: ${input.assignmentRef}`,
-      "-m",
-      "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>",
     ],
     cwd: workingDirectory,
     timeoutMs: GIT_TIMEOUT_MS,

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -731,6 +731,15 @@ describe("codex git_checkout workspace (shared B2 contract)", () => {
       expect(record?.resultRefs).toContain(
         "result.public.pylon.codex_agent_task.pull_request_changed_files.1",
       )
+      expect(record?.resultRefs).toContain(
+        "branch.public.pylon.codex_agent_task.pylon.assignment-deadbeefdeadbeef",
+      )
+      expect(record?.resultRefs).toContain(
+        "pull_request.public.pylon.codex_agent_task.99001",
+      )
+      expect(record?.resultRefs).toContain(
+        "verification.public.pylon.codex_agent_task.passed.exit_0",
+      )
       expect(record?.previewRefs).toContain(
         "https://github.com/OpenAgentsInc/openagents/pull/99001",
       )

--- a/apps/pylon/tests/codex-pr-publisher.test.ts
+++ b/apps/pylon/tests/codex-pr-publisher.test.ts
@@ -11,13 +11,22 @@ import {
 
 async function git(args: string[], cwd: string): Promise<void> {
   const proc = Bun.spawn(["git", ...args], { cwd, stderr: "pipe", stdout: "pipe" })
-  const code = await proc.exited
-  if (code !== 0) throw new Error(`git ${args.join(" ")} failed (${code})`)
+  const [, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (code !== 0) throw new Error(`git ${args.join(" ")} failed (${code}): ${err}`)
 }
 
 async function headSha(cwd: string): Promise<string> {
   const proc = Bun.spawn(["git", "rev-parse", "HEAD"], { cwd, stderr: "pipe", stdout: "pipe" })
-  const [out] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+  const [out, , code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (code !== 0) throw new Error(`git rev-parse HEAD failed (${code})`)
   return out.trim()
 }
 


### PR DESCRIPTION
Does not substantially resolve the P0. The headline ask — make each `codex_agent_task` actually open a PR (branch+commit+push+`gh pr create`) — is already implemented on main (`maybePublishAssignmentPullRequest`, `codex-pr-publisher.ts` pre-exist; the diff only edits them). This diff adds three closeout resultRefs (branch/PR number/verification exit), drops the Co-Authored-By commit trailer, swaps an ellipsis char, and improves git test error reporting. The visibility ask is only partially met (closeout refs only; no `/artanis` page or fleet-status surfacing).