### PR TITLE
fix(khala): add capability-truth system prompt for accurate capability summaries

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -44,6 +44,7 @@ import {
   OA_COMPONENT_SSE_EVENT,
 } from './khala-component-channel'
 import {
+  KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT,
   KHALA_IDENTITY_STATEMENT,
   KHALA_IDENTITY_SYSTEM_PROMPT,
   KHALA_STANDARD_GREETING,
@@ -5348,6 +5349,9 @@ describe('Khala identity guard', () => {
     // The gateway identity prompt is the FIRST message the adapter sees.
     expect(messages[0]?.role).toBe('system')
     expect(messages[0]?.content).toBe(KHALA_IDENTITY_SYSTEM_PROMPT)
+    expect(messages.map(m => m.content)).toContain(
+      KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT,
+    )
     // The original user message is preserved after it.
     expect(messages.some(m => m.role === 'user' && m.content === 'hi')).toBe(
       true,
@@ -6076,6 +6080,7 @@ describe('Khala-code acceptance-contract injection', () => {
     // The public Khala model still gets identity, but NOT the code acceptance
     // contract (that block is scoped to the khala-code coding lane).
     expect(systemContents).toContain(KHALA_IDENTITY_SYSTEM_PROMPT)
+    expect(systemContents).toContain(KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT)
     expect(
       systemContents.some(c => c.includes('__openagentsCrossyRoadState')),
     ).toBe(false)
@@ -6201,6 +6206,7 @@ describe('Khala prefix caching (book P0-2 / #6084)', () => {
       .map(m => m.content)
     const identityIndex = systemContents.indexOf(KHALA_IDENTITY_SYSTEM_PROMPT)
     expect(identityIndex).toBeGreaterThanOrEqual(0)
+    expect(systemContents).toContain(KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT)
   })
 
   test('1. the stable prefix is identical across two turns of one session; only the user turn varies', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -110,6 +110,7 @@ import {
   serializeComponentFrame,
 } from './khala-component-channel'
 import {
+  KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT,
   KHALA_IDENTITY_REINFORCEMENT_PROMPT,
   KHALA_IDENTITY_SYSTEM_PROMPT,
   KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT,
@@ -972,6 +973,13 @@ const buildTaggedKhalaMessages = (
     tagged.push({
       message: {
         content: KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT,
+        role: 'system',
+      },
+      stableKind: 'stablePolicy' satisfies StableBlockKind,
+    })
+    tagged.push({
+      message: {
+        content: KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT,
         role: 'system',
       },
       stableKind: 'stablePolicy' satisfies StableBlockKind,

--- a/apps/openagents.com/workers/api/src/inference/khala-identity.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-identity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT,
   KHALA_IDENTITY_SIGNATURE,
   KHALA_IDENTITY_STATEMENT,
   KHALA_IDENTITY_SYSTEM_PROMPT,
@@ -117,6 +118,26 @@ describe('Khala response discipline signature', () => {
     const answer =
       'C’est parti. Qu’est-ce qu’on construit, casse ou clarifie aujourd’hui ? Balancez-nous ça.'
     expect(KHALA_RESPONSE_DISCIPLINE_SIGNATURE.verify(answer).satisfied).toBe(true)
+  })
+})
+
+describe('Khala capability-truth system prompt (#6399)', () => {
+  test('keeps capability summaries accurate about shipped surfaces and blueprint contracts', () => {
+    const prompt = KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT.toLowerCase()
+
+    expect(prompt).toContain('capability-truth contract')
+    expect(prompt).toContain('shipped user-visible capabilities')
+    expect(prompt).toContain('openai-compatible chat completions')
+    expect(prompt).toContain('linked local pylon')
+    expect(prompt).toContain('blueprint system')
+    expect(prompt).toContain('typed signature and response contracts')
+    expect(prompt).toContain('identity')
+    expect(prompt).toContain('refusal posture')
+    expect(prompt).toContain('final-answer discipline')
+    expect(prompt).toContain('do not claim')
+    expect(prompt).toContain('automatically design, install, train, deploy, or run')
+    expect(prompt).toContain('capability gap')
+    expect(prompt).toContain('never summarize planned, internal, operator-only, or gated work as already available')
   })
 })
 

--- a/apps/openagents.com/workers/api/src/inference/khala-identity.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-identity.ts
@@ -544,6 +544,14 @@ export const KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT = [
   'If the task is ambiguous, ask one concise clarifying question or state the assumption once, then answer. Do not spiral through alternatives unless the user asks for alternatives.',
 ].join(' ')
 
+export const KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT = [
+  'Capability-truth contract: when asked what Khala can do, describe shipped user-visible capabilities, not internal aspirations.',
+  'The current shipped surface can answer chat requests, write and explain code or documents in the reply, expose OpenAI-compatible chat completions for openagents/khala, and explain the reviewed CLI paths for spawning supervised workers or routing coding work through a linked local Pylon.',
+  'For the blueprint system, be precise: Khala uses typed signature and response contracts in the gateway to enforce identity, refusal posture, final-answer discipline, and public-safe structured outputs. Do not claim that public chat can automatically design, install, train, deploy, or run arbitrary new blueprint skills by itself.',
+  'If a requested capability is not on an active reviewed surface, say what exists today, name the missing part as a capability gap, and offer to guide the user through the manual or CLI path when one exists.',
+  'Never summarize planned, internal, operator-only, or gated work as already available to the public.',
+].join(' ')
+
 export const KHALA_RESPONSE_DISCIPLINE_REINFORCEMENT_PROMPT = [
   'Your previous answer exposed visible deliberation or a self-correction loop. That violates the Blueprint response contract.',
   'Answer again with one coherent final answer only. Do not include scratchpad, chain-of-thought, self-critique, repeated revisions, apology loops, headings like "final answer", or meta-commentary about malformed output.',

--- a/apps/openagents.com/workers/api/src/inference/khala-refusal-posture.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-refusal-posture.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, test } from 'vitest'
 
 import { buildAutopilotConciergeSystemPrompt } from './autopilot-concierge-model'
 import {
+  KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT,
   KHALA_REFUSAL_NON_PROMISE_RULE,
   KHALA_REFUSAL_POSTURE_REINFORCEMENT_PROMPT,
   KHALA_REFUSAL_POSTURE_SIGNATURE,
@@ -153,7 +154,7 @@ describe('Concierge non-promise rule adopted VERBATIM (#6178)', () => {
 })
 
 describe('buildKhalaChatMessages injects the refusal-posture clause (#6178)', () => {
-  test('the leading system message contains identity AND refusal posture AND the non-promise rule', () => {
+  test('the leading system message contains identity, refusal posture, capability truth, and the non-promise rule', () => {
     const assembled = buildKhalaChatMessages([
       { role: 'user', content: DECLINE_FIXTURES[0]!.prompt },
     ])
@@ -164,6 +165,8 @@ describe('buildKhalaChatMessages injects the refusal-posture clause (#6178)', ()
     expect(content.toLowerCase()).toContain('we are khala')
     // Refusal posture present.
     expect(content).toContain(KHALA_REFUSAL_POSTURE_SYSTEM_PROMPT)
+    // Capability truth present (#6399).
+    expect(content).toContain(KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT)
     // Concierge non-promise rule present.
     expect(content).toContain(KHALA_REFUSAL_NON_PROMISE_RULE)
   })

--- a/apps/openagents.com/workers/api/src/khala-chat-program.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-program.ts
@@ -11,7 +11,8 @@
 //   - System prompt = the Khala identity contract (`KHALA_IDENTITY_SYSTEM_PROMPT`
 //     from `inference/khala-identity.ts`, first-person plural "we are Khala",
 //     NEVER naming an underlying provider) + the refusal posture + Blueprint
-//     response discipline contracts + a light generic chat instruction. API
+//     response discipline + capability-truth contracts + a light generic chat
+//     instruction. API
 //     mechanics are only volunteered when explicitly asked — this is NOT the
 //     onboarding/concierge intake program.
 //   - Stateless: the client sends the running message list each turn. There is
@@ -31,6 +32,7 @@ import {
   type InferenceRequest,
 } from './inference/provider-adapter'
 import {
+  KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT,
   KHALA_IDENTITY_SYSTEM_PROMPT,
   KHALA_REFUSAL_POSTURE_SYSTEM_PROMPT,
   KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT,
@@ -183,7 +185,7 @@ export const buildKhalaChatMessages = (
 ): ReadonlyArray<InferenceMessage> => [
   {
     role: 'system',
-    content: `${KHALA_IDENTITY_SYSTEM_PROMPT} ${KHALA_REFUSAL_POSTURE_SYSTEM_PROMPT} ${KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT} ${KHALA_CHAT_INSTRUCTION}`,
+    content: `${KHALA_IDENTITY_SYSTEM_PROMPT} ${KHALA_REFUSAL_POSTURE_SYSTEM_PROMPT} ${KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT} ${KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT} ${KHALA_CHAT_INSTRUCTION}`,
   },
   ...messages.map(message => ({ role: message.role, content: message.content })),
 ]


### PR DESCRIPTION
Addresses #6399.

### Changes
- Adds `KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT` in `khala-identity.ts`: describe only shipped user-visible capabilities, be precise about the blueprint system (typed signature/response contracts enforcing identity, refusal posture, final-answer discipline), don't claim public chat can auto design/install/train/deploy skills, name capability gaps, and never present planned/internal/gated work as available.
- Injects the new prompt into the gateway message build in `chat-completions-routes.ts` and into `buildKhalaChatMessages` (`khala-chat-program.ts`).
- Adds/updates identity, refusal-posture, and chat-completions tests asserting the capability-truth block is present.

### Verification
Not independently re-verified.