### PR TITLE
feat(artanis): hourly trace-review + feedback triage into unsupported-requests ledger

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.test.ts
@@ -3,9 +3,21 @@ import { describe, expect, test } from 'vitest'
 
 import {
   ARTANIS_TASSADAR_EXECUTOR_SAFE_COPY,
+  type ArtanisKhalaUnsupportedTriageDependencies,
   runArtanisScheduledTick,
   runArtanisScheduledTickForWorker,
+  runArtanisKhalaUnsupportedRequestTriage,
 } from './artanis-scheduled-runner'
+import type {
+  KhalaFeedbackRecord,
+} from './khala-feedback-routes'
+import type {
+  KhalaTraceReviewFacts,
+} from './khala-trace-review-routes'
+import type {
+  KhalaUnsupportedRequestCreateInput,
+  KhalaUnsupportedRequestRecord,
+} from './khala-unsupported-request-routes'
 import { publicProductPromisesDocument } from './product-promises'
 import {
   ArtanisPersistenceTestStore,
@@ -13,7 +25,97 @@ import {
 } from './test/artanis-persistence-fixture'
 
 const nowIso = '2026-06-07T05:20:00.000Z'
+const hourlyNowIso = '2026-06-07T06:00:00.000Z'
 const scheduledTime = Date.parse(nowIso)
+
+const emptyTraceReviewFacts = (): KhalaTraceReviewFacts => ({
+  modelMix: [],
+  notableTraces: [],
+  outcomes: [],
+  rawEventHighlights: [],
+  rawEventSummary: {
+    assignmentCount: 0,
+    byteLength: 0,
+    eventCount: 0,
+    rowCount: 0,
+  },
+  tokenByDemandSource: [],
+  tokenSummary: {
+    estimatedUsageCount: 0,
+    eventCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 0,
+    zeroOutputCount: 0,
+  },
+  traceByDemandSource: [],
+  traceSummary: {
+    ownerOnlyCount: 0,
+    publicCount: 0,
+    traceCount: 0,
+    trainingConsentCount: 0,
+    unlistedCount: 0,
+    zeroStepCount: 0,
+  },
+})
+
+const khalaFeedbackRecord = (
+  feedbackRef: string,
+  feedback: string,
+): KhalaFeedbackRecord => ({
+  clientVersion: null,
+  createdAt: hourlyNowIso,
+  feedback,
+  feedbackRef,
+  source: 'khala-cli',
+  traceRef: null,
+  userAgent: null,
+})
+
+const recordFromUnsupportedInput = (
+  input: KhalaUnsupportedRequestCreateInput,
+): KhalaUnsupportedRequestRecord => ({
+  createdAt: input.createdAt,
+  evidenceRefs: input.evidenceRefs,
+  forumTopicRef: input.forumTopicRef,
+  githubIssueRef: input.githubIssueRef,
+  issueRequired: true,
+  nextAction: 'open_github_issue',
+  requestRef: input.requestRef,
+  sourceKind: input.sourceKind,
+  sourceRef: input.sourceRef,
+  status: input.status,
+  suggestedIssueTitle: input.suggestedIssueTitle,
+  summary: input.summary,
+  title: input.title,
+  triageKind: input.triageKind,
+  updatedAt: input.updatedAt,
+})
+
+const makeKhalaUnsupportedTriageDependencies = (
+  facts: KhalaTraceReviewFacts,
+  feedback: ReadonlyArray<KhalaFeedbackRecord>,
+): ArtanisKhalaUnsupportedTriageDependencies & {
+  readonly upserts: Array<KhalaUnsupportedRequestCreateInput>
+} => {
+  const upserts: Array<KhalaUnsupportedRequestCreateInput> = []
+  return {
+    feedbackStore: {
+      listRecent: async () => feedback,
+    },
+    traceReviewStore: {
+      readFacts: async () => facts,
+    },
+    unsupportedRequestStore: {
+      upsert: async input => {
+        upserts.push(input)
+        return recordFromUnsupportedInput(input)
+      },
+    },
+    upserts,
+  }
+}
 
 const persistedKhalaReadinessSignal = (
   store: ArtanisPersistenceTestStore,
@@ -215,6 +317,144 @@ describe('Artanis scheduled runner', () => {
       ]),
       state: 'available',
     })
+  })
+
+  test('triages trace-review and recurring Khala feedback into needs-issue unsupported ledger rows', async () => {
+    const facts: KhalaTraceReviewFacts = {
+      ...emptyTraceReviewFacts(),
+      tokenSummary: {
+        ...emptyTraceReviewFacts().tokenSummary,
+        eventCount: 3,
+        outputTokens: 10,
+        totalTokens: 20,
+        zeroOutputCount: 2,
+      },
+      traceByDemandSource: [
+        {
+          count: 3,
+          label: 'khala_cli_local_git_diff',
+          totalTokens: 0,
+        },
+      ],
+      traceSummary: {
+        ...emptyTraceReviewFacts().traceSummary,
+        traceCount: 3,
+      },
+    }
+    const dependencies = makeKhalaUnsupportedTriageDependencies(facts, [
+      khalaFeedbackRecord(
+        'khala_feedback:fb_1',
+        'Khala cannot read my local git diff before answering',
+      ),
+      khalaFeedbackRecord(
+        'khala_feedback:fb_2',
+        'Khala cannot read my local git diff before answering',
+      ),
+      khalaFeedbackRecord(
+        'khala_feedback:fb_noise',
+        'too wordy, prefer more conversational',
+      ),
+      khalaFeedbackRecord(
+        'khala_feedback:fb_one_off',
+        'Khala is broken on this one rare workflow',
+      ),
+    ])
+
+    const result = await Effect.runPromise(
+      runArtanisKhalaUnsupportedRequestTriage({
+        dependencies,
+        nowIso: hourlyNowIso,
+      }),
+    )
+
+    expect(result.reportRef).toBe('khala_trace_review.2026_06_07T06_00_00_000Z')
+    expect(result.skippedNoiseCount).toBe(1)
+    expect(result.unsupportedRequests.map(request => request.sourceKind)).toEqual(
+      expect.arrayContaining(['trace_review', 'khala_feedback']),
+    )
+    expect(dependencies.upserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceKind: 'trace_review',
+          sourceRef: 'triage.khala_trace_review.empty_response',
+          status: 'needs_issue',
+          triageKind: 'bug',
+        }),
+        expect.objectContaining({
+          sourceKind: 'trace_review',
+          sourceRef: 'triage.intent.khala_trace_review.khala_cli_local_git_diff',
+          status: 'needs_issue',
+          triageKind: 'missing_capability',
+        }),
+        expect.objectContaining({
+          evidenceRefs: ['khala_feedback:fb_1', 'khala_feedback:fb_2'],
+          sourceKind: 'khala_feedback',
+          status: 'needs_issue',
+          triageKind: 'missing_capability',
+        }),
+      ]),
+    )
+    expect(
+      dependencies.upserts.some(upsert =>
+        upsert.evidenceRefs.includes('khala_feedback:fb_noise')
+      ),
+    ).toBe(false)
+    expect(
+      dependencies.upserts.some(upsert =>
+        upsert.evidenceRefs.includes('khala_feedback:fb_one_off')
+      ),
+    ).toBe(false)
+  })
+
+  test('scheduled runner pulls Khala triage only on the hourly cron boundary', async () => {
+    const offHourDependencies = makeKhalaUnsupportedTriageDependencies(
+      {
+        ...emptyTraceReviewFacts(),
+        tokenSummary: {
+          ...emptyTraceReviewFacts().tokenSummary,
+          zeroOutputCount: 1,
+        },
+      },
+      [],
+    )
+    const offHourStore = new ArtanisPersistenceTestStore()
+    const offHourResult = await Effect.runPromise(
+      runArtanisScheduledTick({
+        db: artanisPersistenceTestDb(offHourStore),
+        enabled: true,
+        khalaUnsupportedTriage: offHourDependencies,
+        nowIso,
+        scheduleRef: 'cron.public.artanis.off-hour',
+      }),
+    )
+
+    const hourlyDependencies = makeKhalaUnsupportedTriageDependencies(
+      {
+        ...emptyTraceReviewFacts(),
+        tokenSummary: {
+          ...emptyTraceReviewFacts().tokenSummary,
+          zeroOutputCount: 1,
+        },
+      },
+      [],
+    )
+    const hourlyStore = new ArtanisPersistenceTestStore()
+    const hourlyResult = await Effect.runPromise(
+      runArtanisScheduledTick({
+        db: artanisPersistenceTestDb(hourlyStore),
+        enabled: true,
+        khalaUnsupportedTriage: hourlyDependencies,
+        nowIso: hourlyNowIso,
+        scheduleRef: 'cron.public.artanis.hourly',
+      }),
+    )
+
+    expect(offHourResult.khalaUnsupportedRequestRefs).toEqual([])
+    expect(offHourDependencies.upserts).toEqual([])
+    expect(hourlyResult.khalaUnsupportedRequestRefs).toEqual([
+      'khala_unsupported:artanis_trace_review:triage_khala_trace_review_empty_response',
+    ])
+    expect(hourlyDependencies.upserts).toHaveLength(1)
   })
 
   test('blocks Khala readiness on leaked public model ids without projecting them', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
@@ -35,6 +35,21 @@ import {
   ArtanisHealthSnapshotRecord,
   exampleArtanisHealthSnapshot,
 } from './artanis-health'
+import {
+  type KhalaFeedbackRecord,
+  type KhalaFeedbackStore,
+} from './khala-feedback-routes'
+import {
+  buildKhalaTraceReviewReport,
+  type KhalaTraceReviewReport,
+  type KhalaTraceReviewStore,
+  type KhalaTraceReviewTriageItem,
+} from './khala-trace-review-routes'
+import {
+  type KhalaUnsupportedRequestRecord,
+  type KhalaUnsupportedRequestStore,
+  type KhalaUnsupportedRequestTriageKind,
+} from './khala-unsupported-request-routes'
 import { exampleArtanisRuntime } from './artanis-runtime'
 import {
   ArtanisWorkRoutingProposalRecord,
@@ -70,6 +85,7 @@ export type ArtanisScheduledRunnerInput = Readonly<{
   context?: Partial<ArtanisScheduledRunnerContext> | undefined
   db: D1Database
   enabled: boolean
+  khalaUnsupportedTriage?: ArtanisKhalaUnsupportedTriageDependencies | undefined
   khalaReadinessObservation?: ArtanisKhalaReadinessObservation | undefined
   nowIso: string
   scheduleRef: string
@@ -98,6 +114,7 @@ export type ArtanisScheduledRunnerResult = Readonly<{
   forbiddenAuthority: ArtanisScheduledRunnerForbiddenAuthority
   forumIntentRefs: ReadonlyArray<string>
   healthSnapshotRef: string | null
+  khalaUnsupportedRequestRefs: ReadonlyArray<string>
   loadedContextRefs: ReadonlyArray<string>
   loopRef: string | null
   persistedRefs: ReadonlyArray<string>
@@ -106,6 +123,21 @@ export type ArtanisScheduledRunnerResult = Readonly<{
   storageReceipts: ReadonlyArray<ArtanisPersistenceWriteReceipt>
   tickRef: string | null
   workProposalRefs: ReadonlyArray<string>
+}>
+
+export type ArtanisKhalaUnsupportedTriageDependencies = Readonly<{
+  feedbackStore: Pick<KhalaFeedbackStore, 'listRecent'>
+  feedbackLimit?: number | undefined
+  traceLimit?: number | undefined
+  traceReviewStore: KhalaTraceReviewStore
+  unsupportedRequestStore: Pick<KhalaUnsupportedRequestStore, 'upsert'>
+}>
+
+export type ArtanisKhalaUnsupportedTriageResult = Readonly<{
+  feedbackGroupsConsidered: number
+  reportRef: string
+  skippedNoiseCount: number
+  unsupportedRequests: ReadonlyArray<KhalaUnsupportedRequestRecord>
 }>
 
 const noRiskyExecutionAuthority: ArtanisScheduledRunnerForbiddenAuthority = {
@@ -351,6 +383,251 @@ const forumPublicationSourceRef = (ref: string): boolean =>
     'report.public.',
   ].some(prefix => ref.startsWith(prefix))
 
+const refSegment = (value: string): string =>
+  refSuffix(value.toLowerCase()).slice(0, 80) || 'unknown'
+
+const feedbackNoisePattern =
+  /\b(thanks?|thank you|looks good|works great|nice|cool|wordy|verbose|tone|style|conversational|shorter|longer|friendly)\b/i
+const feedbackBugPattern =
+  /\b(500|bug|broken|crash(?:es|ed|ing)?|error|fail(?:s|ed|ing)?|hang(?:s|ing)?|stuck|timeout|wrong|regression|exception)\b/i
+const feedbackCapabilityPattern =
+  /\b(can't|cannot|could not|couldn't|does not support|unsupported|wish|need(?:s)?|local git|git diff|file|upload|repo|repository|browser|shell|terminal|integrat(?:e|ion)|connect)\b/i
+
+const feedbackFingerprint = (feedback: string): string =>
+  feedback
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(word => word.length > 2)
+    .slice(0, 8)
+    .join('_') || 'unknown'
+
+const feedbackTriageKind = (
+  record: KhalaFeedbackRecord,
+): KhalaUnsupportedRequestTriageKind | null => {
+  const feedback = record.feedback.trim()
+  if (feedback.length < 12 || feedbackNoisePattern.test(feedback)) {
+    return null
+  }
+  if (feedbackBugPattern.test(feedback)) {
+    return 'bug'
+  }
+  if (feedbackCapabilityPattern.test(feedback)) {
+    return 'missing_capability'
+  }
+  return null
+}
+
+const summarizeFeedbackGroup = (
+  records: ReadonlyArray<KhalaFeedbackRecord>,
+): string =>
+  records
+    .map(record => record.feedback.trim().replace(/\s+/g, ' '))
+    .filter(Boolean)
+    .slice(0, 3)
+    .join(' / ')
+    .slice(0, 1_000)
+
+const traceTriageKind = (
+  item: KhalaTraceReviewTriageItem,
+): KhalaUnsupportedRequestTriageKind | null =>
+  item.kind === 'bug' || item.kind === 'missing_capability' ? item.kind : null
+
+const traceReviewWindowFor = (nowIso: string) => ({
+  hours: 24,
+  since: isoTimestampAfterIso(nowIso, -24 * 60 * 60 * 1000),
+  until: nowIso,
+})
+
+const shouldRunHourlyKhalaUnsupportedTriage = (nowIso: string): boolean => {
+  const parsed = new Date(nowIso)
+  return Number.isFinite(parsed.getTime()) && parsed.getUTCMinutes() === 0
+}
+
+const uniqueUnsupportedRequests = (
+  requests: ReadonlyArray<KhalaUnsupportedRequestRecord | null>,
+): ReadonlyArray<KhalaUnsupportedRequestRecord> => {
+  const byRef = requests.reduce(
+    (acc, request) =>
+      request === null ? acc : new Map(acc).set(request.requestRef, request),
+    new Map<string, KhalaUnsupportedRequestRecord>(),
+  )
+  return [...byRef.values()].sort((a, b) =>
+    a.requestRef.localeCompare(b.requestRef)
+  )
+}
+
+const upsertTraceReviewUnsupportedRequest = (
+  input: Readonly<{
+    dependencies: ArtanisKhalaUnsupportedTriageDependencies
+    nowIso: string
+  }>,
+  report: KhalaTraceReviewReport,
+  item: KhalaTraceReviewTriageItem,
+) =>
+  Effect.gen(function* () {
+    const triageKind = traceTriageKind(item)
+    if (triageKind === null) {
+      return null
+    }
+    const sourceRef = item.triageRef
+    return yield* Effect.tryPromise({
+      try: () =>
+        input.dependencies.unsupportedRequestStore.upsert({
+          createdAt: input.nowIso,
+          evidenceRefs: uniqueRefs([
+            sourceRef,
+            report.reportRef,
+            ...item.evidenceRefs,
+          ]),
+          forumTopicRef: null,
+          githubIssueRef: null,
+          requestRef:
+            `khala_unsupported:artanis_trace_review:${refSegment(sourceRef)}`,
+          sourceKind: 'trace_review',
+          sourceRef,
+          status: 'needs_issue',
+          suggestedIssueTitle: item.suggestedIssueTitle,
+          summary:
+            `Recurring trace-review finding over ${report.window.hours}h: ${item.title}.`,
+          title: item.title,
+          triageKind,
+          updatedAt: input.nowIso,
+        }),
+      catch: error => error,
+    })
+  })
+
+const upsertFeedbackUnsupportedRequest = (
+  input: Readonly<{
+    dependencies: ArtanisKhalaUnsupportedTriageDependencies
+    nowIso: string
+  }>,
+  key: string,
+  triageKind: KhalaUnsupportedRequestTriageKind,
+  records: ReadonlyArray<KhalaFeedbackRecord>,
+) => {
+  const sourceRef = `triage.khala_feedback.${refSegment(key)}`
+  const title =
+    triageKind === 'bug'
+      ? 'Recurring Khala feedback reports a bug'
+      : 'Recurring Khala feedback requests an unsupported capability'
+
+  return Effect.tryPromise({
+    try: () =>
+      input.dependencies.unsupportedRequestStore.upsert({
+        createdAt: input.nowIso,
+        evidenceRefs: uniqueRefs(records.map(record => record.feedbackRef)),
+        forumTopicRef: null,
+        githubIssueRef: null,
+        requestRef: `khala_unsupported:artanis_feedback:${refSegment(key)}`,
+        sourceKind: 'khala_feedback',
+        sourceRef,
+        status: 'needs_issue',
+        suggestedIssueTitle: `[Khala feedback] ${title}`,
+        summary: summarizeFeedbackGroup(records),
+        title,
+        triageKind,
+        updatedAt: input.nowIso,
+      }),
+    catch: error => error,
+  })
+}
+
+export const runArtanisKhalaUnsupportedRequestTriage = Effect.fn(
+  'runArtanisKhalaUnsupportedRequestTriage',
+)(function* (
+  input: Readonly<{
+    dependencies: ArtanisKhalaUnsupportedTriageDependencies
+    nowIso: string
+  }>,
+) {
+  const traceLimit = Math.min(
+    Math.max(Math.trunc(input.dependencies.traceLimit ?? 10), 1),
+    50,
+  )
+  const feedbackLimit = Math.min(
+    Math.max(Math.trunc(input.dependencies.feedbackLimit ?? 50), 1),
+    100,
+  )
+  const window = traceReviewWindowFor(input.nowIso)
+  const facts = yield* Effect.tryPromise({
+    try: () =>
+      input.dependencies.traceReviewStore.readFacts({
+        limit: traceLimit,
+        window,
+      }),
+    catch: error => error,
+  })
+  const report = yield* Effect.try({
+    try: () =>
+      buildKhalaTraceReviewReport({
+        facts,
+        generatedAt: input.nowIso,
+        window,
+      }),
+    catch: error => error,
+  })
+  const traceRequests = yield* Effect.forEach(
+    report.triageItems,
+    item => upsertTraceReviewUnsupportedRequest(input, report, item),
+    { concurrency: 1 },
+  )
+  const feedback = yield* Effect.tryPromise({
+    try: () =>
+      input.dependencies.feedbackStore.listRecent({
+        limit: feedbackLimit,
+      }),
+    catch: error => error,
+  })
+  const classifiedFeedback = feedback
+    .map(record => ({ kind: feedbackTriageKind(record), record }))
+    .filter(
+      (
+        entry,
+      ): entry is Readonly<{
+        kind: KhalaUnsupportedRequestTriageKind
+        record: KhalaFeedbackRecord
+      }> => entry.kind !== null,
+    )
+  const groups = classifiedFeedback.reduce((acc, entry) => {
+    const key = `${entry.kind}:${feedbackFingerprint(entry.record.feedback)}`
+    const existing = acc.get(key)
+    return new Map(acc).set(key, {
+      kind: entry.kind,
+      records:
+        existing === undefined
+          ? [entry.record]
+          : [...existing.records, entry.record],
+    })
+  }, new Map<string, Readonly<{
+    kind: KhalaUnsupportedRequestTriageKind
+    records: ReadonlyArray<KhalaFeedbackRecord>
+  }>>())
+  const recurringFeedbackGroups = [...groups.entries()].filter(
+    ([, group]) => group.records.length >= 2,
+  )
+  const feedbackRequests = yield* Effect.forEach(
+    recurringFeedbackGroups,
+    ([key, group]) =>
+      upsertFeedbackUnsupportedRequest(input, key, group.kind, group.records),
+    { concurrency: 1 },
+  )
+
+  const result: ArtanisKhalaUnsupportedTriageResult = {
+    feedbackGroupsConsidered: groups.size,
+    reportRef: report.reportRef,
+    skippedNoiseCount: feedback.length - classifiedFeedback.length,
+    unsupportedRequests: uniqueUnsupportedRequests([
+      ...traceRequests,
+      ...feedbackRequests,
+    ]),
+  }
+  return result
+})
+
 const disabledResult = (
   scheduleRef: string,
 ): ArtanisScheduledRunnerResult => ({
@@ -360,6 +637,7 @@ const disabledResult = (
   forbiddenAuthority: noRiskyExecutionAuthority,
   forumIntentRefs: [],
   healthSnapshotRef: null,
+  khalaUnsupportedRequestRefs: [],
   loadedContextRefs: [],
   loopRef: null,
   persistedRefs: [],
@@ -841,6 +1119,23 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       forumIntentReceipt,
       closeoutReceipt,
     ]
+    const khalaUnsupportedTriage =
+      input.khalaUnsupportedTriage !== undefined &&
+      shouldRunHourlyKhalaUnsupportedTriage(input.nowIso)
+        ? yield* runArtanisKhalaUnsupportedRequestTriage({
+            dependencies: input.khalaUnsupportedTriage,
+            nowIso: input.nowIso,
+          }).pipe(
+            Effect.catch(() =>
+              Effect.succeed<ArtanisKhalaUnsupportedTriageResult>({
+                feedbackGroupsConsidered: 0,
+                reportRef: `khala_trace_review.${refSegment(input.nowIso)}`,
+                skippedNoiseCount: 0,
+                unsupportedRequests: [],
+              })
+            ),
+          )
+        : null
 
     const result: ArtanisScheduledRunnerResult = {
       approvalRequirementRefs: uniqueRefs([
@@ -853,8 +1148,19 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       forbiddenAuthority: noRiskyExecutionAuthority,
       forumIntentRefs: tick.forumPublicationIntentRefs,
       healthSnapshotRef: healthSnapshot.snapshotRef,
+      khalaUnsupportedRequestRefs:
+        khalaUnsupportedTriage?.unsupportedRequests.map(
+          request => request.requestRef,
+        ) ?? [],
       loadedContextRefs: uniqueRefs([
         ...loadedContextRefs,
+        ...(input.khalaUnsupportedTriage === undefined
+          ? []
+          : [
+              'operator.khala.trace_review',
+              'operator.khala.feedback',
+              'operator.khala.unsupported_requests',
+            ]),
         ...(priorLoop === null ? [] : [priorLoop.recordRef]),
       ]),
       loopRef: loop.loopRef,
@@ -873,6 +1179,7 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
 export const runArtanisScheduledTickForWorker = (
   input: Readonly<{
     db: D1Database
+    khalaUnsupportedTriage?: ArtanisKhalaUnsupportedTriageDependencies | undefined
     khalaReadinessObservation?: ArtanisKhalaReadinessObservation | undefined
     scheduledRunnerEnabled: boolean
     scheduledTime: number
@@ -883,6 +1190,7 @@ export const runArtanisScheduledTickForWorker = (
   return runArtanisScheduledTick({
     db: input.db,
     enabled: input.scheduledRunnerEnabled,
+    khalaUnsupportedTriage: input.khalaUnsupportedTriage,
     khalaReadinessObservation: input.khalaReadinessObservation,
     nowIso,
     scheduleRef: `cron.public.artanis.${refSuffix(nowIso)}`,

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -6213,6 +6213,11 @@ const runArtanisScheduledTickScheduled = (
 ): Effect.Effect<void, never> =>
   runArtanisScheduledTickForWorker({
     db,
+    khalaUnsupportedTriage: {
+      feedbackStore: makeD1KhalaFeedbackStore(db),
+      traceReviewStore: makeD1KhalaTraceReviewStore(db),
+      unsupportedRequestStore: makeD1KhalaUnsupportedRequestStore(db),
+    },
     scheduledRunnerEnabled,
     scheduledTime,
   }).pipe(


### PR DESCRIPTION
Addresses #6393.

### Changes
- Adds `runArtanisKhalaUnsupportedRequestTriage` in `artanis-scheduled-runner.ts`: reads a 24h trace-review window and recent Khala feedback, classifies into bug/missing_capability, filters noise (tone/thanks/etc.), groups recurring feedback (>=2) by fingerprint, and upserts `needs_issue` rows to the unsupported-requests ledger with evidence refs.
- Gates the triage to the hourly cron boundary (`getUTCMinutes()===0`) and threads `khalaUnsupportedTriage` deps through `runArtanisScheduledTick`/`runArtanisScheduledTickForWorker`, exposing `khalaUnsupportedRequestRefs` in the result with error-catch fallback.
- Wires D1 feedback/trace-review/unsupported-request stores into the production scheduled cron in `index.ts`.
- Adds runner tests for triage grouping/noise-filtering and the hourly-boundary gating.

### Verification
Not independently re-verified.