### PR TITLE
pylon: Implement public issue #6394 and run the named verification. (#6394)

### DIFF
--- a/apps/openagents.com/packages/sync-worker/src/index.ts
+++ b/apps/openagents.com/packages/sync-worker/src/index.ts
@@ -42,6 +42,7 @@ export type WorkerBindings = Readonly<{
   AUTH_STORAGE: KVNamespace
   GITHUB_CLIENT_ID: string
   GITHUB_CLIENT_SECRET: string
+  ARTANIS_GITHUB_ISSUE_TOKEN?: string
   GEMINI_API_KEY?: string
   OPENAUTH_CLIENT_ID: string
   OPENAUTH_ISSUER_URL: string

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -27,6 +27,7 @@ import {
   makeArtanisListGithubIssuesTool,
   makeArtanisListPylonAssignmentsTool,
   makeArtanisListRepoDirTool,
+  makeArtanisOpenUnsupportedRequestIssueTool,
   makeArtanisOperatorTools,
   makeArtanisReadGithubIssueTool,
   makeArtanisReadRepoFileTool,
@@ -1469,6 +1470,83 @@ describe('update_unsupported_request (owner-scoped ledger triage WRITE) — iter
   })
 })
 
+describe('open_unsupported_request_issue (gated GitHub issue opener) — issue #6394', () => {
+  test('is a gated provider_call tool because it reaches GitHub', () => {
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({})
+    expect(tool.kind).toBe('gated')
+    expect(tool.riskyActionKind).toBe('provider_call')
+    expect(tool.definition.name).toBe('open_unsupported_request_issue')
+  })
+
+  test('opens and links one needs_issue ledger entry through the injected opener', async () => {
+    const updated: ArtanisUnsupportedRequestRecord = {
+      ...unsupportedRows[0]!,
+      githubIssueRef: 'OpenAgentsInc/openagents#6394',
+      nextAction: 'none',
+      status: 'issue_opened',
+    }
+    const calls: Array<unknown> = []
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      opener: input => {
+        calls.push(input)
+        return Effect.succeed({
+          issueNumber: 6394,
+          issueRef: 'OpenAgentsInc/openagents#6394',
+          issueUrl: 'https://github.com/OpenAgentsInc/openagents/issues/6394',
+          kind: 'opened',
+          updated,
+        })
+      },
+    })
+
+    const result = await Effect.runPromise(
+      tool.run({ ref: 'khala_unsupported:ur_aaa111' }),
+    )
+
+    expect(calls).toEqual([{ ref: 'khala_unsupported:ur_aaa111' }])
+    expect(result).toMatchObject({
+      assignmentRef: 'OpenAgentsInc/openagents#6394',
+      durableRequestId: null,
+      outcome: 'executed',
+    })
+    expect(result.outcome === 'executed' ? result.summary : '').toContain(
+      'ledgerStatus: issue_opened',
+    )
+  })
+
+  test('defers with a public-safe plan when no opener is wired', async () => {
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({})
+    const result = await Effect.runPromise(
+      tool.run({ ref: 'khala_unsupported:ur_aaa111' }),
+    )
+    expect(result).toMatchObject({
+      outcome: 'deferred',
+      reason: 'execution_not_wired',
+    })
+    expect(result.outcome === 'deferred' ? result.plan : '').toContain(
+      'Open a GitHub issue',
+    )
+  })
+
+  test('blocks unsafe refs before the opener seam is called', async () => {
+    const calls: Array<unknown> = []
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      opener: input => {
+        calls.push(input)
+        return Effect.succeed({ kind: 'rejected', reason: 'should_not_run' })
+      },
+    })
+    const result = await Effect.runPromise(
+      tool.run({ ref: '../../etc/passwd' }),
+    )
+    expect(result).toMatchObject({
+      outcome: 'deferred',
+      reason: 'invalid_arguments',
+    })
+    expect(calls).toEqual([])
+  })
+})
+
 describe('parseArtanisAssignmentRef + isSafeArtanisAssignmentRef', () => {
   test('accepts a ref under several key aliases', () => {
     expect(parseArtanisAssignmentRef({ assignmentRef: 'a.b.c' })).toEqual({
@@ -2232,6 +2310,7 @@ describe('makeArtanisOperatorTools default table', () => {
       'list_github_issues',
       'list_pylon_assignments',
       'list_repo_dir',
+      'open_unsupported_request_issue',
       'read_github_issue',
       'read_repo_file',
       'trigger_synthetic_load',
@@ -2255,6 +2334,15 @@ describe('makeArtanisOperatorTools default table', () => {
     )
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
+  })
+
+  test('the default table includes a gated open_unsupported_request_issue tool', () => {
+    const tools = makeArtanisOperatorTools()
+    const tool = tools.find(
+      t => t.definition.name === 'open_unsupported_request_issue',
+    )
+    expect(tool).toBeDefined()
+    expect(tool?.kind).toBe('gated')
   })
 
   test('the default table includes a read-kind list_pylon_assignments tool', () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -1785,6 +1785,28 @@ export type ArtanisUpdateUnsupportedRequestConfig = Readonly<{
   writer?: ArtanisUnsupportedRequestWriter | undefined
 }>
 
+export type ArtanisUnsupportedRequestIssueOpenInput = Readonly<{
+  ref: string
+}>
+
+export type ArtanisUnsupportedRequestIssueOpenResult =
+  | Readonly<{
+      kind: 'opened'
+      issueNumber: number
+      issueRef: string
+      issueUrl: string
+      updated: ArtanisUnsupportedRequestRecord
+    }>
+  | Readonly<{ kind: 'rejected'; reason: string }>
+
+export type ArtanisUnsupportedRequestIssueOpener = (
+  input: ArtanisUnsupportedRequestIssueOpenInput,
+) => Effect.Effect<ArtanisUnsupportedRequestIssueOpenResult>
+
+export type ArtanisOpenUnsupportedRequestIssueConfig = Readonly<{
+  opener?: ArtanisUnsupportedRequestIssueOpener | undefined
+}>
+
 // The parse outcome for the model-produced ref argument: ABSENT (no ref field ->
 // honest "invalid arguments"), INVALID (present but unsafe/empty -> honest
 // "(blocked …)"), or VALID.
@@ -2021,6 +2043,112 @@ export const makeArtanisUpdateUnsupportedRequestTool = (
         return formatUpdatedUnsupportedRequest(updated)
       }),
     kind: 'write',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// open_unsupported_request_issue — GATED outward GitHub issue creation (#6394).
+// ---------------------------------------------------------------------------
+//
+// This is separate from `update_unsupported_request` because opening a GitHub
+// issue is an outward third-party side effect. The model can request it for ONE
+// unsupported-request ledger entry, but execution only happens through the
+// injected opener seam. The opener owns the GitHub credential boundary and must
+// update the ledger row to `issue_opened` with the real issue ref after GitHub
+// returns a real issue number. With no opener wired, the tool returns the exact
+// public-safe plan and does not fabricate an issue.
+export const makeArtanisOpenUnsupportedRequestIssueTool = (
+  config: ArtanisOpenUnsupportedRequestIssueConfig = {},
+): ArtanisOperatorGatedTool => {
+  const opener = config.opener
+
+  return {
+    definition: {
+      description:
+        'Open a REAL public GitHub issue for one unsupported-request ledger entry that is already marked needs_issue, then link that real issue back to the ledger as issue_opened. This is an outward provider_call action and executes only through the wired GitHub issue opener; otherwise it returns the public-safe plan. Pass the ledger entry ref only.',
+      name: 'open_unsupported_request_issue',
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          ref: {
+            description:
+              'The unsupported-request ledger entry ref to open an issue for, e.g. "khala_unsupported:ur_...".',
+            type: 'string',
+          },
+        },
+        required: ['ref'],
+        type: 'object',
+      },
+    },
+    kind: 'gated',
+    riskyActionKind: 'provider_call',
+    run: (args: unknown): Effect.Effect<ArtanisOperatorGatedResult> =>
+      Effect.gen(function* () {
+        const record =
+          typeof args === 'object' && args !== null
+            ? (args as Record<string, unknown>)
+            : {}
+        const ref = parseUpdateRef(record)
+        if (ref.kind === 'absent') {
+          return {
+            outcome: 'deferred',
+            plan: '(invalid arguments: a string "ref" is required)',
+            reason: 'invalid_arguments',
+          }
+        }
+        if (ref.kind === 'invalid') {
+          return {
+            outcome: 'deferred',
+            plan: `(blocked: "${ref.raw}" is not an allowed public-safe ledger ref)`,
+            reason: 'invalid_arguments',
+          }
+        }
+
+        const plan = [
+          `Open a GitHub issue in ${ARTANIS_UNSUPPORTED_REQUEST_ISSUE_REPO} for unsupported-request ${ref.value}.`,
+          'Use only the ledger title, bounded summary, and public-safe evidence refs in the issue body.',
+          'After GitHub returns a real issue number, update the ledger row to status=issue_opened and githubIssueRef=<repo>#<number>.',
+        ].join('\n')
+
+        if (opener === undefined) {
+          return {
+            outcome: 'deferred',
+            plan,
+            reason: 'execution_not_wired',
+          }
+        }
+
+        const opened = yield* opener({ ref: ref.value }).pipe(
+          Effect.orElseSucceed(
+            () =>
+              ({
+                kind: 'rejected',
+                reason: 'github_issue_open_failed',
+              }) as const,
+          ),
+        )
+        if (opened.kind === 'rejected') {
+          return {
+            outcome: 'deferred',
+            plan: `${plan}\n\nBlocked/rejected: ${opened.reason}`,
+            reason: opened.reason,
+          }
+        }
+
+        const summary = [
+          `issueRef: ${opened.issueRef}`,
+          `issueUrl: ${opened.issueUrl}`,
+          `ledgerRef: ${opened.updated.requestRef}`,
+          `ledgerStatus: ${opened.updated.status}`,
+          `linkedIssue: ${opened.updated.githubIssueRef ?? '(none)'}`,
+        ].join('\n')
+        return {
+          assignmentRef: opened.issueRef,
+          durableRequestId: null,
+          outcome: 'executed',
+          summary,
+        }
+      }),
   }
 }
 
@@ -3329,6 +3457,9 @@ export const makeArtanisGetSyntheticLoadStatusTool = (
 // is honest ("(could not update …: no ledger writer is wired)") rather than
 // inventive. It is a WRITE tool, not risky/gated: owner-scoped, internal-ledger-
 // only, with no spend/payout/deploy/delete/outward authority.
+// `unsupportedRequestIssueOpener` is the outward GitHub issue opener behind
+// #6394. It is a gated provider_call tool: it creates a real public issue only
+// through the wired opener seam, then links the ledger row to the real issue.
 export const makeArtanisOperatorTools = (
   config: Readonly<{
     repoRead?: ArtanisRepoReadConfig | undefined
@@ -3339,6 +3470,9 @@ export const makeArtanisOperatorTools = (
     traceReview?: ArtanisTraceReviewConfig | undefined
     unsupportedRequests?: ArtanisUnsupportedRequestsConfig | undefined
     unsupportedRequestWriter?: ArtanisUnsupportedRequestWriter | undefined
+    unsupportedRequestIssueOpener?:
+      | ArtanisUnsupportedRequestIssueOpener
+      | undefined
     defaultBranch?: string | undefined
     networkStats?: ArtanisGetNetworkStatsConfig | undefined
     glmFleetStatus?: ArtanisGlmFleetStatusConfig | undefined
@@ -3376,6 +3510,9 @@ export const makeArtanisOperatorTools = (
     makeArtanisGetUnsupportedRequestsTool(config.unsupportedRequests),
     makeArtanisUpdateUnsupportedRequestTool({
       writer: config.unsupportedRequestWriter,
+    }),
+    makeArtanisOpenUnsupportedRequestIssueTool({
+      opener: config.unsupportedRequestIssueOpener,
     }),
     makeArtanisDispatchCodexTaskTool({
       defaultBranch: config.defaultBranch,

--- a/apps/openagents.com/workers/api/src/artanis-operator-unsupported-requests.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-unsupported-requests.ts
@@ -25,7 +25,10 @@
 //   - OWNER-SCOPED. It is only wired into the owner-authenticated operator chat
 //     (`makeArtanisOperatorTools`), the same admin path as the other read tools.
 
+import { Effect } from 'effect'
+
 import type {
+  ArtanisUnsupportedRequestIssueOpener,
   ArtanisUnsupportedRequestRecord,
   ArtanisUnsupportedRequestsReader,
   ArtanisUnsupportedRequestWriter,
@@ -131,4 +134,158 @@ export const makeArtanisUnsupportedRequestWriter = (
     })
     return projectUnsupportedRequestRecord(updated)
   }
+}
+
+export type ArtanisUnsupportedRequestIssueOpenerDeps = Readonly<{
+  store: KhalaUnsupportedRequestStore
+  githubToken: string | undefined
+  fetchImpl?: typeof fetch | undefined
+  nowIso?: (() => string) | undefined
+  maxScan?: number | undefined
+}>
+
+type GitHubCreatedIssueResponse = Readonly<{
+  html_url?: unknown
+  number?: unknown
+}>
+
+const OPENAGENTS_ISSUE_REPO = 'OpenAgentsInc/openagents'
+
+const githubIssueRef = (issueNumber: number): string =>
+  `${OPENAGENTS_ISSUE_REPO}#${issueNumber}`
+
+const githubIssueBodyFor = (
+  record: KhalaUnsupportedRequestRecord,
+): string => {
+  const evidence =
+    record.evidenceRefs.length === 0
+      ? '- (none)'
+      : record.evidenceRefs.map(ref => `- ${ref}`).join('\n')
+  return [
+    'Auto-created from the Khala unsupported-request ledger.',
+    '',
+    `Ledger ref: ${record.requestRef}`,
+    `Source: ${record.sourceKind} ${record.sourceRef}`,
+    `Triage kind: ${record.triageKind}`,
+    '',
+    'Summary:',
+    record.summary.trim() === '' ? '(none)' : record.summary,
+    '',
+    'Public-safe evidence refs:',
+    evidence,
+    '',
+    'Acceptance:',
+    '- Reproduce or validate the gap using public-safe refs only.',
+    '- Implement the fix without exposing raw prompts, private paths, provider payloads, credentials, or wallet material.',
+    '- Keep the unsupported-request ledger linked to this issue.',
+  ].join('\n')
+}
+
+export const makeArtanisUnsupportedRequestIssueOpener = (
+  deps: ArtanisUnsupportedRequestIssueOpenerDeps,
+): ArtanisUnsupportedRequestIssueOpener => {
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
+  const nowIso = deps.nowIso ?? currentIsoTimestamp
+  const maxScan = deps.maxScan ?? 100
+  const writer = makeArtanisUnsupportedRequestWriter({
+    maxScan,
+    nowIso,
+    store: deps.store,
+  })
+
+  return input =>
+    Effect.gen(function* () {
+      const token = deps.githubToken?.trim()
+      if (token === undefined || token === '') {
+        return { kind: 'rejected', reason: 'github_issue_token_not_configured' }
+      }
+
+      const records = yield* Effect.tryPromise(() =>
+        deps.store.listRecent({ limit: maxScan, status: 'needs_issue' }),
+      ).pipe(
+        Effect.orElseSucceed(
+          () => [] as ReadonlyArray<KhalaUnsupportedRequestRecord>,
+        ),
+      )
+      const record = records.find(row => row.requestRef === input.ref)
+      if (record === undefined) {
+        return { kind: 'rejected', reason: 'unsupported_request_not_found' }
+      }
+      if (record.githubIssueRef !== null) {
+        return { kind: 'rejected', reason: 'unsupported_request_already_linked' }
+      }
+
+      const response = yield* Effect.tryPromise(() =>
+        fetchImpl(
+          `https://api.github.com/repos/${OPENAGENTS_ISSUE_REPO}/issues`,
+          {
+            body: JSON.stringify({
+              body: githubIssueBodyFor(record),
+              title: record.suggestedIssueTitle,
+            }),
+            headers: {
+              Accept: 'application/vnd.github+json',
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+              'User-Agent': 'openagents-artanis-unsupported-request-issue-opener',
+              'X-GitHub-Api-Version': '2022-11-28',
+            },
+            method: 'POST',
+          },
+        ),
+      ).pipe(
+        Effect.orElseSucceed(
+          () => new Response('', { status: 599, statusText: 'fetch failed' }),
+        ),
+      )
+      if (!response.ok) {
+        return {
+          kind: 'rejected',
+          reason: `github_issue_http_${response.status}`,
+        }
+      }
+
+      const body = yield* Effect.tryPromise(
+        () => response.json() as Promise<GitHubCreatedIssueResponse>,
+      ).pipe(
+        Effect.orElseSucceed(
+          (): GitHubCreatedIssueResponse => ({
+            html_url: undefined,
+            number: undefined,
+          }),
+        ),
+      )
+      const issueNumber =
+        typeof body.number === 'number' && Number.isInteger(body.number)
+          ? body.number
+          : null
+      const issueUrl =
+        typeof body.html_url === 'string' &&
+        body.html_url.startsWith('https://github.com/')
+          ? body.html_url
+          : null
+      if (issueNumber === null || issueNumber <= 0 || issueUrl === null) {
+        return { kind: 'rejected', reason: 'github_issue_response_invalid' }
+      }
+
+      const issueRef = githubIssueRef(issueNumber)
+      const updated = yield* Effect.tryPromise(() =>
+        writer({
+          githubIssueRef: issueRef,
+          ref: record.requestRef,
+          status: 'issue_opened',
+        }),
+      ).pipe(Effect.orElseSucceed(() => null))
+      if (updated === null) {
+        return { kind: 'rejected', reason: 'ledger_link_failed' }
+      }
+
+      return {
+        issueNumber,
+        issueRef,
+        issueUrl,
+        kind: 'opened',
+        updated,
+      }
+    })
 }

--- a/apps/openagents.com/workers/api/src/artanis-operator.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.ts
@@ -497,7 +497,8 @@ export type ArtanisOperatorGatedExecuted = Readonly<{
   outcome: 'executed'
   // Public-safe summary of what was created (no secrets, prompts, or paths).
   summary: string
-  // The created assignment ref the loop reports back (public-safe).
+  // The public-safe ref the loop reports back. For Codex dispatch this is the
+  // assignment ref; other gated tools may use their own created public ref.
   assignmentRef: string
   // The durable resume id, when the seam returned one.
   durableRequestId: string | null
@@ -802,8 +803,8 @@ const runToolCall = (
       const outcome = ran.value
       if (outcome.outcome === 'executed') {
         const content = [
-          `EXECUTED — own-capacity, no spend.`,
-          `I created the Khala -> Pylon -> Codex assignment (${tool.definition.name}) on your linked Pylon. It runs at no spend and grants no payout.`,
+          `EXECUTED.`,
+          `I ran ${tool.definition.name} and recorded its public-safe result ref: ${outcome.assignmentRef}.`,
           '',
           outcome.summary,
         ].join('\n')

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -115,6 +115,7 @@ import { makeArtanisKhalaFeedbackReader } from './artanis-operator-khala-feedbac
 import { makeArtanisTraceReviewLoader } from './artanis-operator-trace-review'
 import { makeArtanisOperatorTools } from './artanis-operator-tools'
 import {
+  makeArtanisUnsupportedRequestIssueOpener,
   makeArtanisUnsupportedRequestsReader,
   makeArtanisUnsupportedRequestWriter,
 } from './artanis-operator-unsupported-requests'
@@ -8671,6 +8672,11 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
       // the gap (#6357). Owner-scoped, internal-ledger-only: no spend, payout,
       // deploy, delete, or outward action.
       unsupportedRequestWriter: makeArtanisUnsupportedRequestWriter({
+        nowIso: currentIsoTimestamp,
+        store: makeD1KhalaUnsupportedRequestStore(openAgentsDatabase(env)),
+      }),
+      unsupportedRequestIssueOpener: makeArtanisUnsupportedRequestIssueOpener({
+        githubToken: env.ARTANIS_GITHUB_ISSUE_TOKEN,
         nowIso: currentIsoTimestamp,
         store: makeD1KhalaUnsupportedRequestStore(openAgentsDatabase(env)),
       }),

--- a/apps/openagents.com/workers/api/src/khala-unsupported-request-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/khala-unsupported-request-routes.test.ts
@@ -2,6 +2,9 @@ import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
 import {
+  makeArtanisUnsupportedRequestIssueOpener,
+} from './artanis-operator-unsupported-requests'
+import {
   type KhalaUnsupportedRequestCreateInput,
   type KhalaUnsupportedRequestRecord,
   type KhalaUnsupportedRequestStore,
@@ -279,5 +282,86 @@ describe('khala unsupported-request operator routes', () => {
 
     expect(response.status).toBe(405)
     expect(response.headers.get('allow')).toBe('GET, POST')
+  })
+
+  test('GitHub issue opener creates an issue from a needs_issue row and links it', async () => {
+    const store = makeStore()
+    await store.upsert({
+      createdAt: '2026-06-27T10:00:00.000Z',
+      evidenceRefs: ['triage.intent.khala_trace_review.local_diff'],
+      forumTopicRef: null,
+      githubIssueRef: null,
+      requestRef: 'khala_unsupported:local_diff',
+      sourceKind: 'trace_review',
+      sourceRef: 'triage.intent.khala_trace_review.local_diff',
+      status: 'needs_issue',
+      suggestedIssueTitle: '[Khala unsupported] local diff reads',
+      summary: 'Users ask Khala to inspect a local git diff before answering.',
+      title: 'Khala cannot read local git diffs',
+      triageKind: 'missing_capability',
+      updatedAt: '2026-06-27T10:00:00.000Z',
+    })
+
+    const calls: Array<Readonly<{ body: unknown; url: string }>> = []
+    const opener = makeArtanisUnsupportedRequestIssueOpener({
+      fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({
+          body: JSON.parse(String(init?.body ?? '{}')) as unknown,
+          url: String(input),
+        })
+        return Response.json({
+          html_url:
+            'https://github.com/OpenAgentsInc/openagents/issues/7001',
+          number: 7001,
+        })
+      }) as typeof fetch,
+      githubToken: 'gho_test_token_never_logged',
+      nowIso: () => '2026-06-27T10:05:00.000Z',
+      store,
+    })
+
+    const result = await Effect.runPromise(
+      opener({ ref: 'khala_unsupported:local_diff' }),
+    )
+
+    expect(result).toMatchObject({
+      issueNumber: 7001,
+      issueRef: 'OpenAgentsInc/openagents#7001',
+      issueUrl: 'https://github.com/OpenAgentsInc/openagents/issues/7001',
+      kind: 'opened',
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe(
+      'https://api.github.com/repos/OpenAgentsInc/openagents/issues',
+    )
+    expect(calls[0]?.body).toMatchObject({
+      title: '[Khala unsupported] local diff reads',
+    })
+    expect(JSON.stringify(calls[0]?.body)).toContain(
+      'triage.intent.khala_trace_review.local_diff',
+    )
+    expect(JSON.stringify(calls[0]?.body)).not.toContain(
+      'gho_test_token_never_logged',
+    )
+    expect(store.records[0]).toMatchObject({
+      githubIssueRef: 'OpenAgentsInc/openagents#7001',
+      requestRef: 'khala_unsupported:local_diff',
+      status: 'issue_opened',
+      updatedAt: '2026-06-27T10:05:00.000Z',
+    })
+  })
+
+  test('GitHub issue opener is inert without a configured token', async () => {
+    const store = makeStore()
+    const opener = makeArtanisUnsupportedRequestIssueOpener({
+      githubToken: undefined,
+      store,
+    })
+    await expect(
+      Effect.runPromise(opener({ ref: 'khala_unsupported:missing' })),
+    ).resolves.toEqual({
+      kind: 'rejected',
+      reason: 'github_issue_token_not_configured',
+    })
   })
 })


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6394

Assignment: assignment.public.khala_coding.chatcmpl_2c41520e4ece447fbdc3e87a99a1b4b5
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 7

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.