### PR TITLE
pylon: Implement public issue #6398 and run the named verification. (#6398)

### DIFF
--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -283,6 +283,7 @@ import {
   readPylonKhalaAssignmentTraceStatus,
   readPylonKhalaCloseout,
   readPylonKhalaProof,
+  readPylonKhalaReproductionFixture,
   readPylonKhalaStatus,
   resumePylonKhalaRequest,
   type PylonKhalaWorkflow,
@@ -4203,7 +4204,20 @@ async function main() {
         return
       }
 
-      throw new Error("usage: pylon khala request|resume|status|proof|closeout|spawn|burndown ...")
+      if (command === "fixture") {
+        const assignmentRef =
+          args[2] !== undefined && !args[2].startsWith("--")
+            ? args[2]
+            : optionString(options, "assignment-ref")
+        if (!assignmentRef) {
+          throw new Error("usage: pylon khala fixture <assignmentRef> [--json]")
+        }
+        const result = await readPylonKhalaReproductionFixture(networkOptions, assignmentRef)
+        emit(result)
+        return
+      }
+
+      throw new Error("usage: pylon khala request|resume|status|proof|closeout|fixture|spawn|burndown ...")
     } catch (error) {
       process.stdout.write(`${JSON.stringify({ error: error instanceof Error ? error.message : String(error), ok: false }, null, 2)}\n`)
       process.exitCode = 1

--- a/apps/pylon/src/khala-requester.ts
+++ b/apps/pylon/src/khala-requester.ts
@@ -234,6 +234,50 @@ export type PylonKhalaCloseoutResult = {
   status: PylonKhalaAssignmentTraceStatusResult
 }
 
+export type PylonKhalaReproductionFixtureChecklist = {
+  blockerRefs: string[]
+  items: PylonKhalaProofChecklistItem[]
+  ok: boolean
+  schema: "openagents.pylon.khala_reproduction_fixture_checklist.v0.1"
+}
+
+export type PylonKhalaReproductionFixture = {
+  assignmentRef: string
+  evidenceRefs: {
+    acceptedWorkRefs: string[]
+    artifactRefs: string[]
+    closeoutRefs: string[]
+    proofRefs: string[]
+    rawEventRefs: string[]
+    traceRefs: string[]
+  }
+  expectedOutput: {
+    closeoutReady: boolean
+    lifecycleState: string
+    tokenUsage: Pick<
+      PylonKhalaAssignmentTraceStatusResult["tokenUsage"],
+      | "demandKind"
+      | "demandSource"
+      | "model"
+      | "provider"
+      | "rowCount"
+      | "status"
+      | "totalTokens"
+      | "usageTruth"
+    >
+  }
+  generatedAt: string
+  input: {
+    owner: PylonKhalaAssignmentTraceStatusResult["owner"]
+    progressState: PylonKhalaAssignmentTraceStatusResult["progress"]["state"]
+    pylonRef: string
+    sourceTraceRefs: string[]
+  }
+  ok: true
+  reproductionChecklist: PylonKhalaReproductionFixtureChecklist
+  schema: "openagents.pylon.khala_reproduction_fixture.v0.1"
+}
+
 const durablePrefix = "/v1/chat/completions/durable/"
 const codexAssignmentProofPath = "/api/pylon/codex/proof"
 const codexAssignmentTraceStatusPath = "/api/pylon/codex/trace-status"
@@ -608,6 +652,93 @@ export function evaluatePylonKhalaCloseoutChecklist(
   }
 }
 
+function uniquePublicSafeRefs(refs: readonly string[]): string[] {
+  const cleanRefs = refs
+    .map((ref) => ref.trim())
+    .filter((ref) => ref !== "" && publicSafeDiagnosticRefPattern.test(ref))
+  return [...new Set(cleanRefs)].sort()
+}
+
+export function buildPylonKhalaReproductionFixture(
+  status: PylonKhalaAssignmentTraceStatusResult,
+): PylonKhalaReproductionFixture {
+  const evidenceRefs = {
+    acceptedWorkRefs: uniquePublicSafeRefs(status.lifecycle.acceptedWorkRefs),
+    artifactRefs: uniquePublicSafeRefs(status.lifecycle.artifactRefs),
+    closeoutRefs: uniquePublicSafeRefs(status.lifecycle.closeoutRefs),
+    proofRefs: uniquePublicSafeRefs(status.lifecycle.proofRefs),
+    rawEventRefs: uniquePublicSafeRefs(status.rawEvents.refs),
+    traceRefs: uniquePublicSafeRefs(status.traces.refs),
+  }
+  const items = [
+    checklistItem(
+      "check.khala_reproduction_fixture.schema.codex_assignment_trace_status_v1",
+      status.schemaVersion === "openagents.pylon.codex_assignment_trace_status.v1",
+    ),
+    checklistItem(
+      "check.khala_reproduction_fixture.assignment_ref_present",
+      status.assignmentRef.trim() !== "",
+    ),
+    checklistItem(
+      "check.khala_reproduction_fixture.trace_evidence_refs_present",
+      evidenceRefs.traceRefs.length > 0,
+    ),
+    checklistItem(
+      "check.khala_reproduction_fixture.raw_event_refs_present",
+      evidenceRefs.rawEventRefs.length > 0,
+    ),
+    checklistItem(
+      "check.khala_reproduction_fixture.expected_output_recorded",
+      status.progress.closeoutReady &&
+        status.tokenUsage.status === "recorded" &&
+        status.tokenUsage.rowCount > 0,
+    ),
+    checklistItem(
+      "check.khala_reproduction_fixture.owner_scoped_evidence",
+      status.traces.visibility === "owner_only" &&
+        status.rawEvents.visibility === "owner_only",
+    ),
+  ]
+  const blockerRefs = items
+    .filter((item) => !item.ok)
+    .map((item) => item.ref.replace(/^check\./, "blocker."))
+  const fixture: PylonKhalaReproductionFixture = {
+    assignmentRef: status.assignmentRef,
+    evidenceRefs,
+    expectedOutput: {
+      closeoutReady: status.progress.closeoutReady,
+      lifecycleState: status.lifecycle.state,
+      tokenUsage: {
+        demandKind: status.tokenUsage.demandKind,
+        demandSource: status.tokenUsage.demandSource,
+        model: status.tokenUsage.model,
+        provider: status.tokenUsage.provider,
+        rowCount: status.tokenUsage.rowCount,
+        status: status.tokenUsage.status,
+        totalTokens: status.tokenUsage.totalTokens,
+        usageTruth: status.tokenUsage.usageTruth,
+      },
+    },
+    generatedAt: status.generatedAt,
+    input: {
+      owner: status.owner,
+      progressState: status.progress.state,
+      pylonRef: status.pylonRef,
+      sourceTraceRefs: evidenceRefs.traceRefs,
+    },
+    ok: true,
+    reproductionChecklist: {
+      blockerRefs,
+      items,
+      ok: blockerRefs.length === 0,
+      schema: "openagents.pylon.khala_reproduction_fixture_checklist.v0.1",
+    },
+    schema: "openagents.pylon.khala_reproduction_fixture.v0.1",
+  }
+  assertPublicSafe(fixture, "khala reproduction fixture")
+  return fixture
+}
+
 export function buildPylonKhalaChatRequestBody(
   input: PylonKhalaRequestInput,
 ): Record<string, unknown> {
@@ -905,4 +1036,12 @@ export async function readPylonKhalaCloseout(
   }
   assertPublicSafe(result, "khala closeout response")
   return result
+}
+
+export async function readPylonKhalaReproductionFixture(
+  options: TipsNetworkOptions,
+  assignmentRefInput: string,
+): Promise<PylonKhalaReproductionFixture> {
+  const status = await readPylonKhalaAssignmentTraceStatus(options, assignmentRefInput)
+  return buildPylonKhalaReproductionFixture(status)
 }

--- a/apps/pylon/tests/khala-requester.test.ts
+++ b/apps/pylon/tests/khala-requester.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import {
+  buildPylonKhalaReproductionFixture,
   buildPylonKhalaGitCheckoutWorkspace,
   buildPylonKhalaChatRequestBody,
   durableRequestIdFromUrl,
@@ -1026,6 +1027,68 @@ describe("pylon khala requester API", () => {
     ])
   })
 
+  test("reproduction fixture extracts public-safe trace evidence refs", () => {
+    const fixture = buildPylonKhalaReproductionFixture(
+      completeTraceStatus() as CloseoutTraceStatus,
+    )
+
+    expect(fixture).toMatchObject({
+      assignmentRef: "assignment-pylon-codex-1",
+      evidenceRefs: {
+        rawEventRefs: ["raw.pylon_codex.aaa", "raw.pylon_codex.bbb"],
+        traceRefs: ["trace-chunk-1", "trace-final-1"],
+      },
+      expectedOutput: {
+        closeoutReady: true,
+        lifecycleState: "closeout_submitted",
+        tokenUsage: {
+          provider: "pylon-codex-own-capacity",
+          rowCount: 1,
+          status: "recorded",
+          totalTokens: 140,
+          usageTruth: "exact",
+        },
+      },
+      input: {
+        progressState: "closed_out",
+        sourceTraceRefs: ["trace-chunk-1", "trace-final-1"],
+      },
+      ok: true,
+      reproductionChecklist: {
+        blockerRefs: [],
+        ok: true,
+        schema: "openagents.pylon.khala_reproduction_fixture_checklist.v0.1",
+      },
+      schema: "openagents.pylon.khala_reproduction_fixture.v0.1",
+    })
+    expect(JSON.stringify(fixture)).not.toMatch(
+      /rawEventsJson|trajectory_json|safe_metadata_json|r2_key|prompt|shell|\/Users|secret|access[_-]?token|bearer/i,
+    )
+  })
+
+  test("reproduction fixture fails closed when evidence refs are absent", () => {
+    const fixture = buildPylonKhalaReproductionFixture(
+      completeTraceStatus({
+        rawEvents: {
+          ...completeTraceStatus().rawEvents,
+          refs: [],
+        },
+        traces: {
+          ...completeTraceStatus().traces,
+          refs: [],
+        },
+      }) as CloseoutTraceStatus,
+    )
+
+    expect(fixture.reproductionChecklist.ok).toBe(false)
+    expect(fixture.reproductionChecklist.blockerRefs).toContain(
+      "blocker.khala_reproduction_fixture.trace_evidence_refs_present",
+    )
+    expect(fixture.reproductionChecklist.blockerRefs).toContain(
+      "blocker.khala_reproduction_fixture.raw_event_refs_present",
+    )
+  })
+
   test("closeout reads owner-scoped trace status and proof as one JSON projection", async () => {
     const calls: Array<{ init: RequestInit; url: string }> = []
     const result = await readPylonKhalaCloseout(
@@ -1424,6 +1487,53 @@ describe("pylon khala requester API", () => {
       rawEventChunks: {
         visibility: "owner_only",
       },
+    })
+    expect(JSON.stringify(body)).not.toMatch(
+      /rawEventsJson|trajectory_json|safe_metadata_json|r2_key|prompt|shell|\/Users|secret|access[_-]?token|bearer/i,
+    )
+  }, 15_000)
+
+  test("local CLI generates a public-safe Khala reproduction fixture", async () => {
+    const requests: Array<{ headers: Headers; path: string; search: string }> = []
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url)
+        requests.push({ headers: request.headers, path: url.pathname, search: url.search })
+        return new Response(JSON.stringify(completeTraceStatus()), {
+          headers: { "content-type": "application/json" },
+        })
+      },
+    })
+    servers.push(server)
+
+    const result = await runPylonCli(
+      ["khala", "fixture", "assignment-pylon-codex-1", "--agent-token", "oa_agent_cli_test", "--json"],
+      {
+        OPENAGENTS_AGENT_TOKEN: "oa_agent_cli_test",
+        PYLON_OPENAGENTS_BASE_URL: `http://127.0.0.1:${server.port}`,
+      },
+    )
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(0)
+    expect(requests).toHaveLength(1)
+    expect(requests[0]?.path).toBe("/api/pylon/codex/trace-status")
+    expect(requests[0]?.search).toBe("?assignmentRef=assignment-pylon-codex-1")
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer oa_agent_cli_test")
+    const body = JSON.parse(result.stdout) as Record<string, unknown>
+    expect(body).toMatchObject({
+      assignmentRef: "assignment-pylon-codex-1",
+      evidenceRefs: {
+        rawEventRefs: ["raw.pylon_codex.aaa", "raw.pylon_codex.bbb"],
+        traceRefs: ["trace-chunk-1", "trace-final-1"],
+      },
+      ok: true,
+      reproductionChecklist: {
+        ok: true,
+        schema: "openagents.pylon.khala_reproduction_fixture_checklist.v0.1",
+      },
+      schema: "openagents.pylon.khala_reproduction_fixture.v0.1",
     })
     expect(JSON.stringify(body)).not.toMatch(
       /rawEventsJson|trajectory_json|safe_metadata_json|r2_key|prompt|shell|\/Users|secret|access[_-]?token|bearer/i,


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6398

Assignment: assignment.public.khala_coding.chatcmpl_3ebc911b2ed9446ebb3fd31d38de390f
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 3

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.