### PR TITLE
pylon: Implement public issue #6385 and run the named verification. (#6385)

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
@@ -102,7 +102,7 @@ const runRoute = async (
   return Effect.runPromise(effect!)
 }
 
-describe('POST /api/operator/artanis/chat — owner auth', () => {
+describe('POST /api/operator/artanis/chat — per-user auth', () => {
   test('only matches the chat path', () => {
     const { deps } = baseDeps()
     const routes = makeOperatorArtanisChatRoutes(deps)
@@ -135,8 +135,8 @@ describe('POST /api/operator/artanis/chat — owner auth', () => {
     expect(response.status).toBe(401)
   })
 
-  test('403 when the session email is not an admin', async () => {
-    const { deps } = baseDeps({
+  test('200 when the browser session email is not an admin', async () => {
+    const { deps, fake } = baseDeps({
       requireBrowserSession: async () => ({
         user: { email: 'someone@example.com', userId: 'github:9' },
       }),
@@ -145,14 +145,19 @@ describe('POST /api/operator/artanis/chat — owner auth', () => {
       deps,
       post({ messages: [{ content: 'hi', role: 'user' }] }),
     )
-    expect(response.status).toBe(403)
+    expect(response.status).toBe(200)
+    expect(
+      fake.entries.every(entry => entry.ownerId === 'owner:github:9'),
+    ).toBe(true)
   })
 
-  test('200 when an owner-linked agent bearer resolves (no browser session needed)', async () => {
+  test('does not consult the admin email gate for authenticated browser sessions', async () => {
     const { deps } = baseDeps({
-      requireBrowserSession: async () => undefined,
-      resolveOwnerAgentBearer: async () => ({
-        user: { email: 'chris@openagents.com', userId: 'github:14167547' },
+      isOpenAgentsAdminEmail: () => {
+        throw new Error('admin gate should not run for Artanis chat')
+      },
+      requireBrowserSession: async () => ({
+        user: { email: 'someone@example.com', userId: 'github:9' },
       }),
     })
     const response = await runRoute(
@@ -162,7 +167,21 @@ describe('POST /api/operator/artanis/chat — owner auth', () => {
     expect(response.status).toBe(200)
   })
 
-  test('401 when the agent bearer is not owner-linked and there is no session', async () => {
+  test('200 when a linked agent bearer resolves (no browser session needed)', async () => {
+    const { deps } = baseDeps({
+      requireBrowserSession: async () => undefined,
+      resolveOwnerAgentBearer: async () => ({
+        user: { email: 'someone@example.com', userId: 'github:9' },
+      }),
+    })
+    const response = await runRoute(
+      deps,
+      post({ messages: [{ content: 'hi', role: 'user' }] }),
+    )
+    expect(response.status).toBe(200)
+  })
+
+  test('401 when the agent bearer is not linked and there is no session', async () => {
     const { deps } = baseDeps({
       requireBrowserSession: async () => undefined,
       resolveOwnerAgentBearer: async () => undefined,

--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
@@ -1,12 +1,14 @@
-// Owner-auth endpoint for the Artanis operator chat channel (issue #6363).
+// Authenticated endpoint for the per-user Artanis operator chat channel
+// (issue #6363, generalized for #6385).
 //
 //   POST /api/operator/artanis/chat   body { messages: [{role,content}] }
 //                                      -> { reply, servedVia, servedModel, ... }
 //
-// This is the OWNER-ONLY, PRIVATE channel to the REAL Artanis operator agent. It
-// is gated exactly like the other `/api/operator/*` routes (admin API token OR a
-// browser session whose email is an OpenAgents admin), and it routes the
-// conversation through the Artanis operator CORE (`artanis-operator.ts`), which:
+// This is the PRIVATE channel to the REAL Artanis operator agent. It accepts an
+// authenticated browser session or linked agent bearer, then scopes memory,
+// awareness, and tools to that authenticated user. The legacy admin API token
+// path remains for internal owner automation. The route sends the conversation
+// through the Artanis operator CORE (`artanis-operator.ts`), which:
 //   - uses the Artanis OPERATOR persona (NOT the public Khala collective
 //     identity — no roleplay),
 //   - is powered ONLY by the Khala API (the injected `khalaClient` dogfoods
@@ -79,11 +81,10 @@ export type OperatorArtanisChatDependencies<
   // route returns a typed unavailability instead of falling back to a provider.
   makeKhalaClient: (env: Bindings) => ArtanisOperatorKhalaClient | undefined
   requireAdminApiToken?: (request: Request, env: Bindings) => Promise<boolean>
-  // Resolves an agent bearer token to an owner session when the token's linked
-  // OpenAuth account email is an OpenAgents admin. Lets the Khala CLI (which
-  // authenticates with an `oa_agent_` bearer linked via `khala login`) reach the
-  // owner-only Artanis channel, alongside the admin API token and an admin
-  // browser session. Returns undefined for non-owner or unlinked tokens.
+  // Resolves an agent bearer token to the linked OpenAuth owner session. Lets
+  // the Khala CLI (which authenticates with an `oa_agent_` bearer linked via
+  // `khala login`) reach that user's Artanis channel. Returns undefined for
+  // unlinked tokens unless an internal owner-promoted agent path applies.
   resolveOwnerAgentBearer?: (
     request: Request,
     env: Bindings,
@@ -114,11 +115,6 @@ class OperatorArtanisChatUnauthorized extends S.TaggedErrorClass<OperatorArtanis
   {},
 ) {}
 
-class OperatorArtanisChatForbidden extends S.TaggedErrorClass<OperatorArtanisChatForbidden>()(
-  'OperatorArtanisChatForbidden',
-  {},
-) {}
-
 class OperatorArtanisChatBadRequest extends S.TaggedErrorClass<OperatorArtanisChatBadRequest>()(
   'OperatorArtanisChatBadRequest',
   { reason: S.String },
@@ -141,7 +137,6 @@ class OperatorArtanisChatStorageError extends S.TaggedErrorClass<OperatorArtanis
 
 type OperatorArtanisChatError =
   | OperatorArtanisChatBadRequest
-  | OperatorArtanisChatForbidden
   | OperatorArtanisChatSessionError
   | OperatorArtanisChatStorageError
   | OperatorArtanisChatUnauthorized
@@ -155,8 +150,6 @@ const routeErrorResponse = (error: OperatorArtanisChatError) =>
           { error: 'bad_request', reason: badRequest.reason },
           { status: 400 },
         ),
-      OperatorArtanisChatForbidden: () =>
-        noStoreJsonResponse({ error: 'forbidden' }, { status: 403 }),
       OperatorArtanisChatSessionError: () =>
         noStoreJsonResponse({ error: 'session_error' }, { status: 500 }),
       OperatorArtanisChatStorageError: () =>
@@ -175,7 +168,7 @@ const routeErrorResponse = (error: OperatorArtanisChatError) =>
     M.exhaustive,
   )
 
-const requireAdminSession = <
+const requireAuthenticatedSession = <
   Session extends OperatorArtanisChatSession,
   Bindings extends OperatorArtanisChatEnv,
 >(
@@ -222,10 +215,6 @@ const requireAdminSession = <
 
     if (session === undefined) {
       return yield* new OperatorArtanisChatUnauthorized({})
-    }
-
-    if (!dependencies.isOpenAgentsAdminEmail(session.user.email)) {
-      return yield* new OperatorArtanisChatForbidden({})
     }
 
     return session
@@ -301,7 +290,7 @@ export const makeOperatorArtanisChatRoutes = <
     const awarenessReaders = dependencies.awarenessReaders?.(env) ?? {}
 
     return Effect.gen(function* () {
-      const session = yield* requireAdminSession(
+      const session = yield* requireAuthenticatedSession(
         dependencies,
         request,
         env,

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -8720,8 +8720,10 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
   requireAdminApiToken,
   requireBrowserSession,
   // Accept an `oa_agent_` bearer (the Khala CLI's token from `khala login`) when
-  // its linked OpenAuth account email is an OpenAgents admin. Resolves the agent
-  // credential -> its linked owner user id -> that user's email -> admin check.
+  // it is linked to an OpenAuth account. Resolves the agent credential -> linked
+  // owner user id -> that user's email so Artanis can scope memory/awareness to
+  // the authenticated user. The owner-promoted internal Artanis agent remains
+  // admitted by its own agent identity for standing owner automation.
   resolveOwnerAgentBearer: async (request, env) => {
     const bearer = readBearerToken(request)
     if (bearer === undefined) {
@@ -8734,9 +8736,8 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
     // The owner-promoted operator agent (Artanis, owner-directed 2026-06-27) is
     // admitted by his OWN agent identity (his agent user id forms his actorRef
     // `agent:<userId>`), independent of any linked OpenAuth account — his
-    // credential carries no OpenAuth link. Every other owner uses the original
-    // Khala-CLI owner path: a linked OpenAuth account whose email is an
-    // OpenAgents admin.
+    // credential carries no OpenAuth link. Every other user enters through a
+    // linked OpenAuth account.
     const agentOwnUserId = agent?.user.id
     if (agentOwnUserId === undefined) {
       return undefined
@@ -8747,28 +8748,29 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
       isOpenAgentsOwnerAgentOpenAuthUserId(agentOwnUserId) ||
       isOpenAgentsOwnerAgentOpenAuthUserId(linkedOpenAuthUserId)
 
-    // Original admin-email path: only consulted when there is a linked OpenAuth
-    // account to resolve an email for.
-    let adminEmail: string | undefined
+    // Linked-user path: only consulted when there is a linked OpenAuth account
+    // to resolve an email for. This is no longer admin-email gated; the owner
+    // scope is the linked user id.
+    let linkedEmail: string | undefined
     if (linkedOpenAuthUserId !== null) {
       const row = await openAgentsDatabase(env)
         .prepare(`SELECT primary_email FROM users WHERE id = ?`)
         .bind(linkedOpenAuthUserId)
         .first<Readonly<{ primary_email: string | null }>>()
       const email = row?.primary_email?.trim().toLowerCase()
-      if (email !== undefined && email !== '' && isOpenAgentsAdminEmail(email)) {
-        adminEmail = email
+      if (email !== undefined && email !== '') {
+        linkedEmail = email
       }
     }
 
-    if (!isOwnerAgent && adminEmail === undefined) {
+    if (!isOwnerAgent && linkedOpenAuthUserId === null) {
       return undefined
     }
 
     // Owner-scope user id: for the owner-promoted agent key on his OWN
     // owner-promoted user id (so the standing pylon_job_dispatch approval and his
     // own-capacity resolution key consistently on his agent user id); for the
-    // admin-email path preserve the original linked-OpenAuth owner id.
+    // linked-user path preserve the original linked-OpenAuth owner id.
     const ownerScopeUserId = isOwnerAgent
       ? agentOwnUserId
       : (linkedOpenAuthUserId ?? agentOwnUserId)
@@ -8777,7 +8779,7 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
     // Session is the full human-session shape; fill the unused fields so the
     // owner-agent-bearer return type matches the browser-session return type.
     const sessionEmail =
-      adminEmail ??
+      linkedEmail ??
       agent?.user.primaryEmail?.trim().toLowerCase() ??
       'artanis@agents.openagents.com'
     return {


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6385

Assignment: assignment.public.khala_coding.chatcmpl_aae1e2cf96324e69a7e1104696518f04
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 3

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.