### PR TITLE
feat(khala-cli): add turnkey `khala fleet run` backlog supervisor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -332,7 +332,7 @@
     },
     "clients/khala-cli": {
       "name": "@openagentsinc/khala",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "bin": {
         "khala": "dist/index.js",
       },

--- a/clients/khala-cli/README.md
+++ b/clients/khala-cli/README.md
@@ -26,6 +26,7 @@ khala logout
 khala fleet connect           # connect your own Codex account (paste-free device login)
 khala fleet connect --account codex-2   # add another distinct account for more throughput
 khala fleet status            # list your connected Codex fleet + readiness
+khala fleet run --repo owner/repo --issues 123,124 --verify "bun test" --dry-run
 khala auth codex
 khala codex "read README.md"
 khala spawn --count 5 --objective "audit this workspace" --strategy local
@@ -150,6 +151,12 @@ no long-string pasting:
   added throughput.
 - `khala fleet status` (alias `khala fleet list`) prints a table of connected
   accounts with readiness and email.
+- `khala fleet run --repo owner/repo --issues 123,124 --verify "bun test"`
+  starts the turnkey Pylon/Codex supervisor against your public repo backlog.
+  It auto-resolves your local Pylon ref, computes slots as ready accounts times
+  `--per-account` capped by `--max-parallel`, advertises that capacity, and
+  routes issue work through your local no-spend Pylon. Use `--dry-run` to inspect
+  the resolved plan first, or `--once` to run one refill round and exit.
 
 Each account uses an isolated home under `<pylon home>/accounts/codex/<ref>`; the
 flow never touches the default `~/.codex` home, credentials stay on your machine,
@@ -165,6 +172,8 @@ local Pylon and the dispatch gate can see the fleet.
 - `khala logout` clears the local OpenAgents token.
 - `khala fleet connect` connects a Codex account to your fleet (paste-free).
 - `khala fleet status` lists your connected Codex fleet and readiness.
+- `khala fleet run --repo owner/repo --issues 123,124 --verify "bun test"`
+  starts or plans the backlog supervisor for your connected fleet.
 - `khala auth codex` connects a Codex account for local workspace delegation.
 - `khala codex status` shows the active local Codex credential source.
 - `khala codex "task"` delegates directly to local Codex.

--- a/clients/khala-cli/package.json
+++ b/clients/khala-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagentsinc/khala",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Khala terminal client with interactive and headless CLI modes",
   "private": false,
   "type": "module",

--- a/clients/khala-cli/src/changelog.ts
+++ b/clients/khala-cli/src/changelog.ts
@@ -20,6 +20,13 @@ export const KHALA_CLI_VERSION = packageJson.version
 
 export const KHALA_CHANGELOG: ReadonlyArray<KhalaChangelogEntry> = [
   {
+    version: "0.1.21",
+    releasedAt: "2026-06-27T16:52:00.000Z",
+    bullets: [
+      "Adds `khala fleet run` — a turnkey Pylon/Codex backlog supervisor for your own repo and issues, with auto-resolved Pylon targeting, account-scaled slots, `--dry-run`, and one-round `--once` mode.",
+    ],
+  },
+  {
     version: "0.1.20",
     releasedAt: "2026-06-27T15:43:41.000Z",
     bullets: [

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -18,6 +18,11 @@ import {
   type KhalaFleetConnectResult,
   type KhalaFleetStatus,
 } from "./fleet.js"
+import {
+  parseFleetIssueList,
+  runKhalaFleetSupervisor,
+  type KhalaFleetRunResult,
+} from "./fleet-run.js"
 import { appendPromptHistory, readPromptFromTerminal } from "./input.js"
 import { readStdinText } from "./proc.js"
 import { openVerificationUrl, runKhalaLogin, type KhalaLoginResult } from "./login.js"
@@ -65,6 +70,7 @@ type ParsedCommand =
   | { readonly kind: "changelog" }
   | { readonly kind: "feedback"; readonly text: string | undefined }
   | { readonly kind: "fleetConnect"; readonly accountRef: string | undefined; readonly force: boolean }
+  | { readonly kind: "fleetRun" }
   | { readonly kind: "fleetStatus" }
   | { readonly kind: "help" }
   | { readonly kind: "info" }
@@ -97,6 +103,10 @@ interface ParsedArgs {
   readonly json: boolean
   readonly models: boolean
   readonly mintFreeKey: boolean
+  readonly fleetDryRun: boolean
+  readonly fleetIssues: readonly number[] | undefined
+  readonly fleetOnce: boolean
+  readonly fleetPerAccount: number | undefined
   readonly spawnCount: number | undefined
   readonly spawnBranch: string | undefined
   readonly spawnCommit: string | undefined
@@ -185,6 +195,11 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
     if (args.command.kind === "fleetStatus") {
       const status = await listFleetAccounts({ env })
       process.stdout.write(args.json ? `${JSON.stringify(status)}\n` : `${formatFleetStatus(status)}\n`)
+      return 0
+    }
+    if (args.command.kind === "fleetRun") {
+      const result = await runFleetRunCommand(args, env)
+      process.stdout.write(args.json ? `${JSON.stringify(result, null, 2)}\n` : `${formatFleetRunResult(result)}\n`)
       return 0
     }
     if (args.command.kind === "codex") {
@@ -340,6 +355,10 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
   let json = false
   let models = false
   let mintFreeKey = false
+  let fleetDryRun = false
+  let fleetIssues: readonly number[] | undefined
+  let fleetOnce = false
+  let fleetPerAccount: number | undefined
   let spawnBranch: string | undefined
   let spawnCommit: string | undefined
   let spawnCount: number | undefined
@@ -369,6 +388,19 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     else if (arg === "--json" || arg === "--no-stream") json = true
     else if (arg === "--models") models = true
     else if (arg === "--mint-free-key") mintFreeKey = true
+    else if (arg === "--dry-run") fleetDryRun = true
+    else if (arg === "--once") fleetOnce = true
+    else if (arg === "--issues") {
+      fleetIssues = parseFleetIssueList(requireValue(argv, index, arg))
+      index += 1
+    } else if (arg.startsWith("--issues=")) {
+      fleetIssues = parseFleetIssueList(arg.slice("--issues=".length))
+    } else if (arg === "--per-account") {
+      fleetPerAccount = parsePositiveInteger(requireValue(argv, index, arg), arg)
+      index += 1
+    } else if (arg.startsWith("--per-account=")) {
+      fleetPerAccount = parsePositiveInteger(arg.slice("--per-account=".length), "--per-account")
+    }
     else if (arg === "--fixture") spawnFixture = true
     else if (arg === "--count") {
       spawnCount = parsePositiveInteger(requireValue(argv, index, arg), arg)
@@ -473,6 +505,8 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     const sub = positional[1]?.trim().toLowerCase()
     if (sub === "status" || sub === "list" || sub === "ls") {
       command = { kind: "fleetStatus" }
+    } else if (sub === "run") {
+      command = { kind: "fleetRun" }
     } else if (sub === undefined || sub === "connect" || sub === "add" || sub === "link") {
       // `khala fleet`, `khala fleet connect`, `khala fleet add` all connect.
       // Optional positional ref: `khala fleet connect codex-2` (or --account).
@@ -482,7 +516,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
         force: fleetForce,
       }
     } else {
-      throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet connect\` or \`khala fleet status\`.`)
+      throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet connect\`, \`khala fleet status\`, or \`khala fleet run\`.`)
     }
   } else if (maybeCommand === "codex") {
     command = positional[1] === "status"
@@ -540,6 +574,10 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     json,
     models,
     mintFreeKey,
+    fleetDryRun,
+    fleetIssues,
+    fleetOnce,
+    fleetPerAccount,
     spawnCount,
     spawnBranch,
     spawnCommit,
@@ -1170,6 +1208,37 @@ async function runSpawnCommand(
   })
 }
 
+async function runFleetRunCommand(
+  args: ParsedArgs,
+  env: Record<string, string | undefined>,
+): Promise<KhalaFleetRunResult> {
+  if (args.spawnRepo === undefined || args.spawnRepo.trim().length === 0) {
+    throw new Error("khala fleet run requires --repo <owner/repo>")
+  }
+  if (args.fleetIssues === undefined || args.fleetIssues.length === 0) {
+    throw new Error("khala fleet run requires --issues <numbers>")
+  }
+  if (args.spawnVerify === undefined || args.spawnVerify.trim().length === 0) {
+    throw new Error("khala fleet run requires --verify <command>")
+  }
+  const token = await resolveConfiguredAgentToken(args.token, env)
+  return await runKhalaFleetSupervisor({
+    baseUrl: args.baseUrl,
+    ...(args.spawnBranch === undefined ? {} : { branch: args.spawnBranch }),
+    ...(args.spawnCommit === undefined ? {} : { commit: args.spawnCommit }),
+    dryRun: args.fleetDryRun,
+    env,
+    issues: args.fleetIssues,
+    ...(args.spawnMaxParallel === undefined ? {} : { maxSlots: args.spawnMaxParallel }),
+    once: args.fleetOnce,
+    ...(args.fleetPerAccount === undefined ? {} : { perAccount: args.fleetPerAccount }),
+    ...(args.spawnPylonRef === undefined ? {} : { pylonRef: args.spawnPylonRef }),
+    repo: args.spawnRepo,
+    ...(token === undefined ? {} : { token }),
+    verify: args.spawnVerify,
+  })
+}
+
 async function readSpawnRunCommand(
   args: ParsedArgs,
   env: Record<string, string | undefined>,
@@ -1648,6 +1717,30 @@ function formatFleetStatus(status: KhalaFleetStatus): string {
   ].join("\n"))
 }
 
+function formatFleetRunResult(result: KhalaFleetRunResult): string {
+  const plan = result.plan
+  const pylon = plan.pylonRef ?? "(auto-resolve when run starts)"
+  const lines = [
+    `${terminalStyle.assistant("Khala fleet run:")} ${result.status}`,
+    `  repo: ${plan.repo}`,
+    `  issues: ${plan.issues.map(issue => `#${issue}`).join(", ")}`,
+    `  pylon: ${pylon}`,
+    `  ready accounts: ${plan.readyAccounts.join(", ")}`,
+    `  target slots: ${plan.targetSlots} (min(${plan.maxSlots}, ${plan.readyAccounts.length} accounts * ${plan.perAccount}))`,
+    `  verify: ${plan.verify}`,
+  ]
+  if (result.rounds.length > 0) {
+    lines.push("", "Planned/last round:")
+    for (const round of result.rounds) {
+      lines.push(`  slot ${round.slot}: ${round.accountRef} -> #${round.issue} (${round.status})`)
+    }
+  }
+  if (result.mode === "supervise") {
+    lines.push("", "Supervisor mode keeps refilling slots until stopped.")
+  }
+  return terminalStyle.meta(lines.join("\n"))
+}
+
 function formatCodexCredentialSource(source: Extract<KhalaCodexStatus, { readonly ready: true }>["credentialSource"]): string {
   if (source === "khala_codex_home") return "Khala Codex account"
   if (source === "codex_home_env") return "CODEX_HOME"
@@ -1852,6 +1945,7 @@ Usage:
   khala fleet connect
   khala fleet connect --account codex-2
   khala fleet status
+  khala fleet run --repo owner/repo --issues 123,124 --verify "bun test" --dry-run
   khala auth codex
   khala codex status
   khala codex "read README.md"
@@ -1916,6 +2010,10 @@ Flags:
   --timeout <seconds>  Per-worker timeout for khala spawn
   --account <ref>      Codex account ref for khala fleet connect (auto-assigned if omitted)
   --force              Re-run device login for khala fleet connect even if already linked
+  --issues <list>      Public issue numbers for khala fleet run, comma or space separated
+  --per-account <n>    Fleet run slots per ready Codex account (default: 1)
+  --once               Fleet run one refill round, then exit
+  --dry-run            Fleet run prints the resolved plan without dispatching
   --help, -h           Show this help
 `
 }

--- a/clients/khala-cli/src/fleet-run.test.ts
+++ b/clients/khala-cli/src/fleet-run.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildFleetRunPlan,
+  parseFleetIssueList,
+  runKhalaFleetSupervisor,
+  validateFleetRunVerify,
+} from "./fleet-run.js"
+import type { KhalaFleetStatus } from "./fleet.js"
+
+const commit = "0123456789abcdef0123456789abcdef01234567"
+
+function status(accountRefs: readonly string[]): KhalaFleetStatus {
+  return {
+    accounts: accountRefs.map(accountRef => ({
+      accountRef,
+      email: null,
+      home: `/tmp/${accountRef}`,
+      lastLinkedAt: null,
+      readiness: "ready",
+    })),
+    configPath: "/tmp/pylon/config.json",
+    pylonHome: "/tmp/pylon",
+    readyCount: accountRefs.length,
+  }
+}
+
+describe("fleet run planning", () => {
+  test("parses issue lists with hashes, commas, and whitespace", () => {
+    expect(parseFleetIssueList("#6384, 6408 6410")).toEqual([6384, 6408, 6410])
+  })
+
+  test("scales slots to ready accounts times per-account, capped by max slots", () => {
+    const plan = buildFleetRunPlan({
+      commit,
+      issues: [6384, 6408, 6410],
+      maxSlots: 5,
+      mode: "dry_run",
+      perAccount: 2,
+      pylonRef: "pylon.local",
+      readyAccounts: ["codex", "codex-2", "codex-3"],
+      repo: "Example/repo",
+      verify: "bun test",
+    })
+    expect(plan.targetSlots).toBe(5)
+    expect(plan.readyAccounts).toEqual(["codex", "codex-2", "codex-3"])
+  })
+
+  test("rejects local/private-looking verify commands", () => {
+    expect(() => validateFleetRunVerify("OPENAGENTS_AGENT_TOKEN=x bun test")).toThrow(/public-safe/)
+    expect(() => validateFleetRunVerify("bun test /Users/example/private.test.ts")).toThrow(/public-safe/)
+  })
+})
+
+describe("fleet run dry-run", () => {
+  test("returns planned account and issue routing without dispatching", async () => {
+    const result = await runKhalaFleetSupervisor({
+      commit,
+      dryRun: true,
+      issues: [6384, 6408, 6410],
+      maxSlots: 4,
+      perAccount: 2,
+      pylonRef: "pylon.local",
+      repo: "Example/repo",
+      status: status(["codex", "codex-2"]),
+      verify: "bun test",
+    })
+    expect(result.status).toBe("planned")
+    expect(result.plan.targetSlots).toBe(4)
+    expect(result.rounds.map(round => `${round.accountRef}:#${round.issue}`)).toEqual([
+      "codex:#6384",
+      "codex-2:#6408",
+      "codex:#6410",
+      "codex-2:#6384",
+    ])
+  })
+})

--- a/clients/khala-cli/src/fleet-run.ts
+++ b/clients/khala-cli/src/fleet-run.ts
@@ -1,0 +1,384 @@
+import { spawnProcess } from "./proc.js"
+import { listFleetAccounts, type KhalaFleetAccount, type KhalaFleetStatus } from "./fleet.js"
+import { DEFAULT_BASE_URL } from "./types.js"
+
+export const KHALA_FLEET_RUN_SCHEMA = "openagents.khala.fleet_run.v0.1"
+
+export type KhalaFleetRunMode = "dry_run" | "once" | "supervise"
+
+export type KhalaFleetRunPlan = {
+  readonly schema: typeof KHALA_FLEET_RUN_SCHEMA
+  readonly mode: KhalaFleetRunMode
+  readonly baseUrl: string
+  readonly branch: string
+  readonly commit: string
+  readonly issues: readonly number[]
+  readonly maxSlots: number
+  readonly perAccount: number
+  readonly pylonRef: string | null
+  readonly readyAccounts: readonly string[]
+  readonly repo: string
+  readonly targetSlots: number
+  readonly verify: string
+}
+
+export type KhalaFleetRunResult = {
+  readonly schema: typeof KHALA_FLEET_RUN_SCHEMA
+  readonly mode: KhalaFleetRunMode
+  readonly plan: KhalaFleetRunPlan
+  readonly rounds: readonly KhalaFleetRunRound[]
+  readonly status: "planned" | "completed"
+}
+
+export type KhalaFleetRunRound = {
+  readonly accountRef: string
+  readonly assignmentRef?: string | undefined
+  readonly issue: number
+  readonly ok: boolean
+  readonly slot: number
+  readonly status: "dry_run" | "accepted" | "refused" | "failed"
+}
+
+export type KhalaFleetRunOptions = {
+  readonly baseUrl?: string | undefined
+  readonly branch?: string | undefined
+  readonly commit?: string | undefined
+  readonly dryRun?: boolean | undefined
+  readonly env?: Record<string, string | undefined> | undefined
+  readonly issues: readonly number[]
+  readonly maxSlots?: number | undefined
+  readonly once?: boolean | undefined
+  readonly perAccount?: number | undefined
+  readonly pylonCommand?: readonly string[] | undefined
+  readonly pylonRef?: string | undefined
+  readonly repo: string
+  readonly status?: KhalaFleetStatus | undefined
+  readonly token?: string | undefined
+  readonly verify: string
+}
+
+const DEFAULT_PER_ACCOUNT = 1
+const DEFAULT_MAX_SLOTS = 8
+const SUPERVISOR_IDLE_MS = 2_000
+const REFUSED_BACKOFF_MS = 15_000
+const MAX_REFUSED_BACKOFF_MS = 300_000
+
+export function parseFleetIssueList(raw: string): readonly number[] {
+  const issues = raw
+    .split(/[,\s]+/)
+    .map(part => part.trim())
+    .filter(part => part.length > 0)
+    .map(part => {
+      const normalized = part.startsWith("#") ? part.slice(1) : part
+      const parsed = Number.parseInt(normalized, 10)
+      if (!/^\d+$/.test(normalized) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+        throw new Error("khala fleet run --issues must contain public GitHub issue numbers")
+      }
+      return parsed
+    })
+  if (issues.length === 0) {
+    throw new Error("khala fleet run requires --issues <numbers>")
+  }
+  return [...new Set(issues)]
+}
+
+export function validateFleetRunRepo(repo: string): string {
+  const value = repo.trim()
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+    throw new Error("khala fleet run --repo must be owner/repo")
+  }
+  return value
+}
+
+export function validateFleetRunVerify(verify: string): string {
+  const value = verify.trim()
+  if (value.length < 3 || value.length > 500) {
+    throw new Error("khala fleet run --verify must be 3-500 characters")
+  }
+  if (/(\.\.|~\/|\/Users\/|\/home\/|auth\.json|OPENAGENTS_AGENT_TOKEN|API_KEY|SECRET|TOKEN=)/i.test(value)) {
+    throw new Error("khala fleet run --verify must be public-safe and must not include local paths or secrets")
+  }
+  return value
+}
+
+export function buildFleetRunPlan(input: {
+  readonly baseUrl?: string | undefined
+  readonly branch?: string | undefined
+  readonly commit: string
+  readonly issues: readonly number[]
+  readonly maxSlots?: number | undefined
+  readonly mode: KhalaFleetRunMode
+  readonly perAccount?: number | undefined
+  readonly pylonRef?: string | undefined
+  readonly readyAccounts: readonly string[]
+  readonly repo: string
+  readonly verify: string
+}): KhalaFleetRunPlan {
+  const perAccount = positiveBounded(input.perAccount ?? DEFAULT_PER_ACCOUNT, "--per-account", 16)
+  const maxSlots = positiveBounded(input.maxSlots ?? DEFAULT_MAX_SLOTS, "--max-slots", 64)
+  const readyAccounts = input.readyAccounts.filter(ref => ref.trim().length > 0)
+  const targetSlots = Math.min(maxSlots, readyAccounts.length * perAccount)
+  return {
+    schema: KHALA_FLEET_RUN_SCHEMA,
+    baseUrl: input.baseUrl ?? DEFAULT_BASE_URL,
+    branch: input.branch?.trim() || "main",
+    commit: validateCommit(input.commit),
+    issues: input.issues,
+    maxSlots,
+    mode: input.mode,
+    perAccount,
+    pylonRef: input.pylonRef?.trim() || null,
+    readyAccounts,
+    repo: validateFleetRunRepo(input.repo),
+    targetSlots,
+    verify: validateFleetRunVerify(input.verify),
+  }
+}
+
+export async function runKhalaFleetSupervisor(options: KhalaFleetRunOptions): Promise<KhalaFleetRunResult> {
+  const env = options.env ?? process.env
+  const commandEnv = {
+    ...env,
+    PYLON_OPENAGENTS_BASE_URL: options.baseUrl ?? env.PYLON_OPENAGENTS_BASE_URL ?? DEFAULT_BASE_URL,
+  }
+  const status = options.status ?? await listFleetAccounts({ env: commandEnv })
+  const readyAccounts = status.accounts
+    .filter(account => account.readiness === "ready")
+    .map(account => account.accountRef)
+  const mode: KhalaFleetRunMode = options.dryRun ? "dry_run" : options.once ? "once" : "supervise"
+  const pylonCommand = options.pylonCommand ?? pylonCommandFromEnv(env)
+  const pylonRef = options.pylonRef?.trim() || (options.dryRun ? undefined : await resolvePylonRef({ env: commandEnv, pylonCommand }))
+  const commit = options.commit?.trim() || (options.dryRun ? "0000000000000000000000000000000000000000" : await resolveGitHeadCommit())
+  const plan = buildFleetRunPlan({
+    baseUrl: options.baseUrl,
+    branch: options.branch,
+    commit,
+    issues: options.issues,
+    maxSlots: options.maxSlots,
+    mode,
+    perAccount: options.perAccount,
+    pylonRef,
+    readyAccounts,
+    repo: options.repo,
+    verify: options.verify,
+  })
+
+  if (plan.readyAccounts.length === 0) {
+    throw new Error("No ready Codex accounts. Run `khala fleet connect`, then `khala fleet status`.")
+  }
+  if (plan.targetSlots === 0) {
+    throw new Error("khala fleet run resolved zero target slots")
+  }
+  if (plan.pylonRef === null && !options.dryRun) {
+    throw new Error("Could not resolve a local Pylon ref. Run `pylon provider go-online --json` or pass --pylon-ref.")
+  }
+
+  if (options.dryRun) {
+    return {
+      schema: KHALA_FLEET_RUN_SCHEMA,
+      mode,
+      plan,
+      rounds: plannedRounds(plan).map(round => ({ ...round, ok: true, status: "dry_run" })),
+      status: "planned",
+    }
+  }
+
+  await runPylonCommand(pylonCommand, ["provider", "go-online", "--json"], envWithToken(commandEnv, options.token))
+  await publishHeartbeat({ env: commandEnv, plan, pylonCommand, token: options.token })
+  const rounds = options.once
+    ? await runOneRound({ env: commandEnv, plan, pylonCommand, token: options.token })
+    : await runSupervisorLoop({ env: commandEnv, plan, pylonCommand, token: options.token })
+  return { schema: KHALA_FLEET_RUN_SCHEMA, mode, plan, rounds, status: "completed" }
+}
+
+function plannedRounds(plan: KhalaFleetRunPlan): ReadonlyArray<Omit<KhalaFleetRunRound, "ok" | "status">> {
+  return Array.from({ length: plan.targetSlots }, (_, slot) => ({
+    accountRef: plan.readyAccounts[slot % plan.readyAccounts.length] ?? "codex",
+    issue: plan.issues[slot % plan.issues.length] ?? plan.issues[0]!,
+    slot,
+  }))
+}
+
+async function runSupervisorLoop(input: {
+  readonly env: Record<string, string | undefined>
+  readonly plan: KhalaFleetRunPlan
+  readonly pylonCommand: readonly string[]
+  readonly token?: string | undefined
+}): Promise<readonly KhalaFleetRunRound[]> {
+  const rounds: KhalaFleetRunRound[] = []
+  let issueOffset = 0
+  let refusedBackoffMs = REFUSED_BACKOFF_MS
+  for (;;) {
+    await publishHeartbeat(input)
+    const roundPlan = plannedRounds({
+      ...input.plan,
+      issues: rotateIssues(input.plan.issues, issueOffset),
+    })
+    const round = await Promise.all(roundPlan.map(slot => dispatchFleetSlot({ ...input, slot })))
+    rounds.push(...round)
+    issueOffset = (issueOffset + round.length) % input.plan.issues.length
+    if (round.some(item => item.status === "refused")) {
+      await delay(refusedBackoffMs)
+      refusedBackoffMs = Math.min(refusedBackoffMs * 2, MAX_REFUSED_BACKOFF_MS)
+    } else {
+      refusedBackoffMs = REFUSED_BACKOFF_MS
+      await delay(SUPERVISOR_IDLE_MS)
+    }
+  }
+}
+
+async function runOneRound(input: {
+  readonly env: Record<string, string | undefined>
+  readonly plan: KhalaFleetRunPlan
+  readonly pylonCommand: readonly string[]
+  readonly token?: string | undefined
+}): Promise<readonly KhalaFleetRunRound[]> {
+  return await Promise.all(plannedRounds(input.plan).map(slot => dispatchFleetSlot({ ...input, slot })))
+}
+
+async function dispatchFleetSlot(input: {
+  readonly env: Record<string, string | undefined>
+  readonly plan: KhalaFleetRunPlan
+  readonly pylonCommand: readonly string[]
+  readonly slot: Omit<KhalaFleetRunRound, "ok" | "status">
+  readonly token?: string | undefined
+}): Promise<KhalaFleetRunRound> {
+  const args = [
+    "khala",
+    "request",
+    "--prompt",
+    `Implement public issue #${input.slot.issue} and run the named verification.`,
+    "--workflow",
+    "codex_agent_task",
+    "--pylon-ref",
+    input.plan.pylonRef ?? "",
+    "--account-ref",
+    input.slot.accountRef,
+    "--repo",
+    input.plan.repo,
+    "--branch",
+    input.plan.branch,
+    "--commit",
+    input.plan.commit,
+    "--verify",
+    input.plan.verify,
+    "--json",
+  ]
+  const result = await runPylonCommand(input.pylonCommand, args, envWithToken(input.env, input.token))
+  const assignmentRef = readJsonStringField(result.stdout, "assignmentRef")
+  if (result.exitCode === 0 && assignmentRef !== undefined) {
+    return { ...input.slot, assignmentRef, ok: true, status: "accepted" }
+  }
+  const combined = `${result.stdout}\n${result.stderr}`
+  if (/access token could not be refreshed|please sign in again|reauthenticate/i.test(combined)) {
+    throw new Error("NEEDS-OWNER: Codex login needs reauthentication. `khala fleet run` will not run codex login or touch ~/.codex.")
+  }
+  if (/409|429|target_pylon_unavailable|rate.?limit|duplicate_active_assignment/i.test(combined)) {
+    return { ...input.slot, ok: false, status: "refused" }
+  }
+  return { ...input.slot, ok: false, status: "failed" }
+}
+
+async function publishHeartbeat(input: {
+  readonly env: Record<string, string | undefined>
+  readonly plan: KhalaFleetRunPlan
+  readonly pylonCommand: readonly string[]
+  readonly token?: string | undefined
+}): Promise<void> {
+  await runPylonCommand(input.pylonCommand, ["presence", "heartbeat", "--json"], {
+    ...envWithToken(input.env, input.token),
+    OPENAGENTS_PYLON_CODEX_CONCURRENCY: String(input.plan.targetSlots),
+    OPENAGENTS_PYLON_CODEX_BUSY: "0",
+    OPENAGENTS_PYLON_CODEX_QUEUED: "0",
+  })
+}
+
+async function resolvePylonRef(input: {
+  readonly env: Record<string, string | undefined>
+  readonly pylonCommand: readonly string[]
+}): Promise<string> {
+  const result = await runPylonCommand(input.pylonCommand, ["provider", "go-online", "--json"], input.env)
+  const ref = readJsonStringField(result.stdout, "pylonRef")
+  if (result.exitCode !== 0 || ref === undefined) {
+    throw new Error("Could not auto-resolve Pylon ref from `pylon provider go-online --json`; pass --pylon-ref or check Pylon auth.")
+  }
+  return ref
+}
+
+async function resolveGitHeadCommit(): Promise<string> {
+  const result = await runPylonCommand(["git"], ["rev-parse", "HEAD"], process.env)
+  if (result.exitCode !== 0) {
+    throw new Error("Could not resolve current git commit; pass --commit <40-char-sha>.")
+  }
+  return validateCommit(result.stdout.trim())
+}
+
+async function runPylonCommand(
+  command: readonly string[],
+  args: readonly string[],
+  env: Record<string, string | undefined>,
+): Promise<{ readonly exitCode: number; readonly stdout: string; readonly stderr: string }> {
+  const child = spawnProcess([...command, ...args], {
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([child.exited, child.stdout, child.stderr])
+  return { exitCode, stdout, stderr }
+}
+
+function pylonCommandFromEnv(env: Record<string, string | undefined>): readonly string[] {
+  const raw = env.KHALA_PYLON_COMMAND?.trim()
+  if (!raw) return ["pylon"]
+  return raw.split(/\s+/).filter(part => part.length > 0)
+}
+
+function envWithToken(env: Record<string, string | undefined>, token: string | undefined): Record<string, string | undefined> {
+  const clean = token?.trim()
+  return clean ? { ...env, OPENAGENTS_AGENT_TOKEN: clean } : env
+}
+
+function rotateIssues(issues: readonly number[], offset: number): readonly number[] {
+  if (issues.length === 0) return issues
+  const normalized = offset % issues.length
+  return [...issues.slice(normalized), ...issues.slice(0, normalized)]
+}
+
+function readJsonStringField(raw: string, field: string): string | undefined {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const value = parsed[field]
+    return typeof value === "string" && value.trim().length > 0 ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function validateCommit(commit: string): string {
+  if (!/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error("khala fleet run --commit must be a pinned 40-character git SHA")
+  }
+  return commit
+}
+
+function positiveBounded(value: number, label: string, max: number): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`khala fleet run ${label} must be a positive integer`)
+  }
+  if (value > max) {
+    throw new Error(`khala fleet run ${label} is capped at ${max}`)
+  }
+  return value
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export function readyFleetAccountRefs(status: KhalaFleetStatus): readonly string[] {
+  return status.accounts.filter(isReadyFleetAccount).map(account => account.accountRef)
+}
+
+function isReadyFleetAccount(account: KhalaFleetAccount): boolean {
+  return account.readiness === "ready"
+}


### PR DESCRIPTION
Addresses #6384.

### Changes
- Adds `khala fleet run` command: new `fleet-run.ts` with `buildFleetRunPlan`, `runKhalaFleetSupervisor`, `parseFleetIssueList`, repo/verify validation (rejects local paths/secrets), and dry-run/once/supervise modes.
- Auto-resolves the local Pylon ref and scales target slots as `min(maxSlots, readyAccounts * perAccount)`; routes issues round-robin across ready Codex accounts via the local no-spend Pylon.
- Wires `--issues`, `--per-account`, `--once`, `--dry-run` flag parsing and `fleet run` subcommand into `cli.ts`, with a formatted result printer.
- Bumps CLI to 0.1.21 (package.json, bun.lock, changelog) and documents the command in the README.
- Adds `fleet-run.test.ts` covering issue parsing, slot scaling, verify validation, and dry-run routing.

### Verification
Not independently re-verified.