### PR TITLE
feat(khala-cli): turnkey `khala fleet run` supervisor with auto-resolved defaults

### DIFF
--- a/clients/khala-cli/README.md
+++ b/clients/khala-cli/README.md
@@ -26,6 +26,7 @@ khala logout
 khala fleet connect           # connect your own Codex account (paste-free device login)
 khala fleet connect --account codex-2   # add another distinct account for more throughput
 khala fleet status            # list your connected Codex fleet + readiness
+khala fleet run --repo OpenAgentsInc/openagents --commit <sha> --verify "bun test" --issue 6384
 khala auth codex
 khala codex "read README.md"
 khala spawn --count 5 --objective "audit this workspace" --strategy local
@@ -150,6 +151,13 @@ no long-string pasting:
   added throughput.
 - `khala fleet status` (alias `khala fleet list`) prints a table of connected
   accounts with readiness and email.
+- `khala fleet run --repo <owner/repo> --commit <sha> --verify "<command>"
+  --issue <n>` plans a caller-owned Pylon/Codex burndown cycle for your public
+  issue backlog. It auto-resolves your local Pylon ref with
+  `pylon provider go-online --json`, scales slots from ready account count
+  (`--per-account`, capped by `--max-slots`), publishes Codex capacity, and
+  round-robins assignments across your isolated account refs. Use `--dry-run` to
+  inspect the plan without creating assignments.
 
 Each account uses an isolated home under `<pylon home>/accounts/codex/<ref>`; the
 flow never touches the default `~/.codex` home, credentials stay on your machine,
@@ -206,6 +214,9 @@ local Pylon and the dispatch gate can see the fleet.
   `--repo`, `--commit`, and `--verify` must be supplied together.
 - `--workflow codex_agent_task|cloud_coding_session` selects the Pylon coding
   workflow for `--strategy pylon`.
+- `--issue <n>` / `--issues <list>` provide the public issue backlog for
+  `khala fleet run`; `--per-account`, `--max-slots`, `--dry-run`, and `--loop`
+  tune the supervisor cycle.
 - `--timeout <seconds>` sets the per-worker timeout for `khala spawn`.
 
 ## Changelog

--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -22,6 +22,60 @@ describe("Khala CLI spawn capability answer", () => {
 })
 
 describe("Khala CLI info diagnostics", () => {
+  test("plans khala fleet run with stored fleet accounts and JSON output", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "khala-fleet-run-cli-"))
+    const pylonHome = join(dir, "pylon")
+    const accountHome = join(pylonHome, "accounts", "codex", "codex")
+    mkdirSync(accountHome, { recursive: true })
+    const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")
+    const payload = Buffer.from(JSON.stringify({ email: "fleet-cli@example.com" })).toString("base64url")
+    writeFileSync(join(accountHome, "auth.json"), JSON.stringify({ tokens: { id_token: `${header}.${payload}.` } }))
+    writeFileSync(
+      join(pylonHome, "config.json"),
+      JSON.stringify({ dev: { accounts: [{ ref: "codex", provider: "codex", home: accountHome }] } }),
+    )
+    const pylonScript = join(dir, "fake-pylon.js")
+    writeFileSync(
+      pylonScript,
+      "if (process.argv.slice(2).join(' ') === 'provider go-online --json') console.log(JSON.stringify({pylonRef:'pylon.cli.test'})); else process.exit(2);\n",
+    )
+
+    const originalWrite = process.stdout.write
+    let stdout = ""
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += String(chunk)
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const exitCode = await runKhalaCli([
+        "--json",
+        "fleet",
+        "run",
+        "--dry-run",
+        "--repo",
+        "ExampleCo/example",
+        "--commit",
+        "0123456789abcdef0123456789abcdef01234567",
+        "--verify",
+        "bun test",
+        "--issue",
+        "6384",
+      ], {
+        KHALA_PYLON_COMMAND: `node ${pylonScript}`,
+        PYLON_HOME: pylonHome,
+      })
+      expect(exitCode).toBe(0)
+    } finally {
+      process.stdout.write = originalWrite
+    }
+
+    const parsed = JSON.parse(stdout)
+    expect(parsed.schema).toBe("openagents.khala.fleet_run.v0.1")
+    expect(parsed.dryRun).toBe(true)
+    expect(parsed.plan.pylonRef).toBe("pylon.cli.test")
+    expect(parsed.plan.issues).toEqual([6384])
+  })
+
   test("does not print raw agent tokens or token-bearing trace URLs", async () => {
     const dir = mkdtempSync(join(tmpdir(), "khala-info-test-"))
     const tokenPath = join(dir, "agent-token")

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -13,9 +13,12 @@ import {
 } from "./codex.js"
 import {
   CodexCliMissingError,
+  PylonCliMissingError,
   connectFleetAccount,
   listFleetAccounts,
+  runFleetSupervisor,
   type KhalaFleetConnectResult,
+  type KhalaFleetRunResult,
   type KhalaFleetStatus,
 } from "./fleet.js"
 import { appendPromptHistory, readPromptFromTerminal } from "./input.js"
@@ -65,6 +68,7 @@ type ParsedCommand =
   | { readonly kind: "changelog" }
   | { readonly kind: "feedback"; readonly text: string | undefined }
   | { readonly kind: "fleetConnect"; readonly accountRef: string | undefined; readonly force: boolean }
+  | { readonly kind: "fleetRun" }
   | { readonly kind: "fleetStatus" }
   | { readonly kind: "help" }
   | { readonly kind: "info" }
@@ -109,6 +113,11 @@ interface ParsedArgs {
   readonly spawnTimeoutMs: number | undefined
   readonly spawnVerify: string | undefined
   readonly spawnWorkflow: KhalaSpawnWorkflow
+  readonly fleetDryRun: boolean
+  readonly fleetIssues: ReadonlyArray<number>
+  readonly fleetLoop: boolean
+  readonly fleetMaxSlots: number | undefined
+  readonly fleetPerAccount: number | undefined
 }
 
 export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<string, string | undefined> = process.env): Promise<number> {
@@ -186,6 +195,32 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
       const status = await listFleetAccounts({ env })
       process.stdout.write(args.json ? `${JSON.stringify(status)}\n` : `${formatFleetStatus(status)}\n`)
       return 0
+    }
+    if (args.command.kind === "fleetRun") {
+      try {
+        const token = await resolveConfiguredAgentToken(args.token, env)
+        const result = await runFleetSupervisor({
+          branch: args.spawnBranch,
+          commit: args.spawnCommit,
+          dryRun: args.fleetDryRun,
+          env: token === undefined ? env : { ...env, OPENAGENTS_AGENT_TOKEN: token },
+          issues: args.fleetIssues,
+          loop: args.fleetLoop,
+          maxSlots: args.fleetMaxSlots,
+          perAccount: args.fleetPerAccount,
+          pylonRef: args.spawnPylonRef,
+          repo: args.spawnRepo,
+          verify: args.spawnVerify,
+        })
+        process.stdout.write(args.json ? `${JSON.stringify(result, null, 2)}\n` : `${formatFleetRun(result)}\n`)
+        return result.dispatched.some(issue => issue.state === "failed") ? 1 : 0
+      } catch (error) {
+        if (error instanceof PylonCliMissingError) {
+          process.stderr.write(`${terminalStyle.meta(error.message)}\n`)
+          return 1
+        }
+        throw error
+      }
     }
     if (args.command.kind === "codex") {
       const prompt = args.command.text?.trim()
@@ -353,7 +388,12 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
   let spawnVerify: string | undefined
   let spawnWorkflow: KhalaSpawnWorkflow = "codex_agent_task"
   let fleetAccount: string | undefined
+  let fleetDryRun = false
   let fleetForce = false
+  let fleetIssues: number[] = []
+  let fleetLoop = false
+  let fleetMaxSlots: number | undefined
+  let fleetPerAccount: number | undefined
   const positional: Array<string> = []
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -370,7 +410,29 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     else if (arg === "--models") models = true
     else if (arg === "--mint-free-key") mintFreeKey = true
     else if (arg === "--fixture") spawnFixture = true
-    else if (arg === "--count") {
+    else if (arg === "--dry-run") fleetDryRun = true
+    else if (arg === "--loop") fleetLoop = true
+    else if (arg === "--issue") {
+      fleetIssues.push(parsePositiveInteger(requireValue(argv, index, arg), arg))
+      index += 1
+    } else if (arg.startsWith("--issue=")) {
+      fleetIssues.push(parsePositiveInteger(arg.slice("--issue=".length), "--issue"))
+    } else if (arg === "--issues") {
+      fleetIssues = fleetIssues.concat(parseIssueList(requireValue(argv, index, arg), arg))
+      index += 1
+    } else if (arg.startsWith("--issues=")) {
+      fleetIssues = fleetIssues.concat(parseIssueList(arg.slice("--issues=".length), "--issues"))
+    } else if (arg === "--per-account") {
+      fleetPerAccount = parsePositiveInteger(requireValue(argv, index, arg), arg)
+      index += 1
+    } else if (arg.startsWith("--per-account=")) {
+      fleetPerAccount = parsePositiveInteger(arg.slice("--per-account=".length), "--per-account")
+    } else if (arg === "--max-slots") {
+      fleetMaxSlots = parsePositiveInteger(requireValue(argv, index, arg), arg)
+      index += 1
+    } else if (arg.startsWith("--max-slots=")) {
+      fleetMaxSlots = parsePositiveInteger(arg.slice("--max-slots=".length), "--max-slots")
+    } else if (arg === "--count") {
       spawnCount = parsePositiveInteger(requireValue(argv, index, arg), arg)
       index += 1
     } else if (arg.startsWith("--count=")) {
@@ -473,6 +535,12 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     const sub = positional[1]?.trim().toLowerCase()
     if (sub === "status" || sub === "list" || sub === "ls") {
       command = { kind: "fleetStatus" }
+    } else if (sub === "run" || sub === "start") {
+      const positionalIssues = positional.slice(2).flatMap(value =>
+        /^#?\d+$/.test(value.trim()) ? [parsePositiveInteger(value.trim().replace(/^#/, ""), "issue")] : [],
+      )
+      command = { kind: "fleetRun" }
+      fleetIssues = fleetIssues.concat(positionalIssues)
     } else if (sub === undefined || sub === "connect" || sub === "add" || sub === "link") {
       // `khala fleet`, `khala fleet connect`, `khala fleet add` all connect.
       // Optional positional ref: `khala fleet connect codex-2` (or --account).
@@ -482,7 +550,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
         force: fleetForce,
       }
     } else {
-      throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet connect\` or \`khala fleet status\`.`)
+      throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet connect\`, \`khala fleet status\`, or \`khala fleet run\`.`)
     }
   } else if (maybeCommand === "codex") {
     command = positional[1] === "status"
@@ -552,6 +620,11 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     spawnTimeoutMs,
     spawnVerify,
     spawnWorkflow,
+    fleetDryRun,
+    fleetIssues,
+    fleetLoop,
+    fleetMaxSlots,
+    fleetPerAccount,
   }
 }
 
@@ -1215,6 +1288,12 @@ function parsePositiveInteger(value: string, flag: string): number {
   return parsed
 }
 
+function parseIssueList(value: string, flag: string): ReadonlyArray<number> {
+  const parts = value.split(/[,\s]+/).map(part => part.trim()).filter(part => part.length > 0)
+  if (parts.length === 0) throw new Error(`${flag} requires at least one issue number`)
+  return parts.map(part => parsePositiveInteger(part.replace(/^#/, ""), flag))
+}
+
 function parseSpawnStrategy(value: string): KhalaSpawnStrategy {
   if (value === "auto" || value === "local" || value === "pylon") return value
   throw new Error("--strategy must be auto, local, or pylon")
@@ -1648,6 +1727,32 @@ function formatFleetStatus(status: KhalaFleetStatus): string {
   ].join("\n"))
 }
 
+function formatFleetRun(result: KhalaFleetRunResult): string {
+  const plan = result.plan
+  const lines = [
+    `${terminalStyle.assistant("Khala fleet:")} ${result.dryRun ? "Dry run planned" : "Run dispatched"}`,
+    `pylon: ${plan.pylonRef}`,
+    `repo: ${plan.repo} @ ${plan.commit.slice(0, 12)} (${plan.branch})`,
+    `verify: ${plan.verify}`,
+    `capacity: ${plan.readyAccounts.length} ready account(s) x ${plan.perAccount}, max ${plan.maxSlots} => ${plan.desiredSlots} slot(s)`,
+    `issues: ${plan.issues.map(issue => `#${issue}`).join(", ")}`,
+  ]
+  if (result.dryRun) {
+    lines.push("No assignments were created because --dry-run was set.")
+    return terminalStyle.meta(lines.join("\n"))
+  }
+  for (const entry of result.dispatched) {
+    const suffix = entry.state === "dispatched"
+      ? `assignment ${entry.assignmentRef ?? "not reported"}`
+      : `failed: ${entry.error ?? "unknown error"}`
+    lines.push(`#${entry.issue} via ${entry.accountRef}: ${suffix}`)
+  }
+  if (result.loop) {
+    lines.push("Loop mode requested; this CLI build runs one refill cycle per invocation.")
+  }
+  return terminalStyle.meta(lines.join("\n"))
+}
+
 function formatCodexCredentialSource(source: Extract<KhalaCodexStatus, { readonly ready: true }>["credentialSource"]): string {
   if (source === "khala_codex_home") return "Khala Codex account"
   if (source === "codex_home_env") return "CODEX_HOME"
@@ -1852,6 +1957,7 @@ Usage:
   khala fleet connect
   khala fleet connect --account codex-2
   khala fleet status
+  khala fleet run --repo <owner/repo> --commit <sha> --verify "bun test" --issue 123
   khala auth codex
   khala codex status
   khala codex "read README.md"
@@ -1916,6 +2022,12 @@ Flags:
   --timeout <seconds>  Per-worker timeout for khala spawn
   --account <ref>      Codex account ref for khala fleet connect (auto-assigned if omitted)
   --force              Re-run device login for khala fleet connect even if already linked
+  --issue <n>          Public issue for khala fleet run; repeat or use --issues
+  --issues <list>      Comma/space-separated public issues for khala fleet run
+  --per-account <n>    Fleet run slots per ready Codex account (default: 1)
+  --max-slots <n>      Fleet run total slot cap (default: 10)
+  --dry-run            Plan khala fleet run without creating assignments
+  --loop               Mark fleet run as a long-running supervisor request
   --help, -h           Show this help
 `
 }

--- a/clients/khala-cli/src/fleet.test.ts
+++ b/clients/khala-cli/src/fleet.test.ts
@@ -11,9 +11,11 @@ import {
   decodeCodexIdTokenEmail,
   listFleetAccounts,
   nextCodexAccountRef,
+  planFleetRun,
   parseCodexAccounts,
   pylonConfigPath,
   resolvePylonHome,
+  runFleetSupervisor,
   upsertCodexAccount,
 } from "./fleet.js"
 
@@ -29,6 +31,115 @@ describe("fleet ref assignment", () => {
     expect(nextCodexAccountRef(["codex"])).toBe("codex-2")
     expect(nextCodexAccountRef(["codex", "codex-2"])).toBe("codex-3")
     expect(nextCodexAccountRef(["codex", "codex-3"])).toBe("codex-2")
+  })
+})
+
+describe("fleet run planning and dispatch", () => {
+  async function writeReadyFleet(pylonHome: string, refs: ReadonlyArray<string>): Promise<void> {
+    const accounts = []
+    for (const ref of refs) {
+      const home = codexAccountHome(pylonHome, ref)
+      await mkdir(home, { recursive: true })
+      await writeFile(
+        join(home, "auth.json"),
+        JSON.stringify({ tokens: { id_token: idTokenFor(`${ref}@example.com`) } }),
+      )
+      accounts.push({ ref, provider: "codex", home })
+    }
+    await mkdir(pylonHome, { recursive: true })
+    await writeFile(pylonConfigPath(pylonHome), JSON.stringify({ dev: { accounts } }))
+  }
+
+  test("plans tenant fleet work from ready accounts and auto-resolved pylon ref", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-run-plan-"))
+    const pylonHome = join(base, ".openagents", "pylon")
+    await writeReadyFleet(pylonHome, ["codex", "codex-2"])
+    const commands: string[] = []
+
+    const plan = await planFleetRun({
+      commit: "0123456789abcdef0123456789abcdef01234567",
+      env: { PYLON_HOME: pylonHome },
+      issues: [6384, 6385],
+      maxSlots: 8,
+      perAccount: 2,
+      repo: "ExampleCo/example",
+      runner: async input => {
+        commands.push(input.command.join(" "))
+        return { exitCode: 0, stdout: JSON.stringify({ pylonRef: "pylon.tenant.local" }), stderr: "" }
+      },
+      verify: "bun test",
+    })
+
+    expect(plan.pylonRef).toBe("pylon.tenant.local")
+    expect(plan.desiredSlots).toBe(4)
+    expect(plan.readyAccounts.map(account => account.accountRef)).toEqual(["codex", "codex-2"])
+    expect(commands).toEqual(["pylon provider go-online --json"])
+  })
+
+  test("dry-run returns a plan without dispatching assignments", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-run-dry-"))
+    const pylonHome = join(base, ".openagents", "pylon")
+    await writeReadyFleet(pylonHome, ["codex"])
+    const commands: string[] = []
+
+    const result = await runFleetSupervisor({
+      commit: "0123456789abcdef0123456789abcdef01234567",
+      dryRun: true,
+      env: { PYLON_HOME: pylonHome },
+      issues: [6384],
+      repo: "ExampleCo/example",
+      runner: async input => {
+        commands.push(input.command.join(" "))
+        return { exitCode: 0, stdout: JSON.stringify({ pylonRef: "pylon.tenant.local" }), stderr: "" }
+      },
+      verify: "bun test",
+    })
+
+    expect(result.dryRun).toBe(true)
+    expect(result.dispatched).toEqual([])
+    expect(commands).toEqual(["pylon provider go-online --json"])
+  })
+
+  test("one refill cycle publishes capacity and round-robins account refs", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-run-dispatch-"))
+    const pylonHome = join(base, ".openagents", "pylon")
+    await writeReadyFleet(pylonHome, ["codex", "codex-2"])
+    const commands: string[] = []
+
+    const result = await runFleetSupervisor({
+      commit: "0123456789abcdef0123456789abcdef01234567",
+      env: { PYLON_HOME: pylonHome },
+      issues: [6384, 6385],
+      maxSlots: 2,
+      perAccount: 2,
+      pylonRef: "pylon.tenant.local",
+      repo: "ExampleCo/example",
+      runner: async input => {
+        commands.push(input.command.join(" "))
+        if (input.command.includes("heartbeat")) {
+          expect(input.env.OPENAGENTS_PYLON_CODEX_CONCURRENCY).toBe("2")
+          return { exitCode: 0, stdout: JSON.stringify({ ok: true }), stderr: "" }
+        }
+        const issue = input.command[input.command.indexOf("--prompt") + 1]?.match(/#(\d+)/)?.[1] ?? "unknown"
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            assignmentRef: `assignment.public.${issue}`,
+            durableRequestId: `chatcmpl_${issue}`,
+          }),
+          stderr: "",
+        }
+      },
+      verify: "bun test",
+    })
+
+    expect(result.dispatched.map(entry => [entry.issue, entry.accountRef, entry.assignmentRef])).toEqual([
+      [6384, "codex", "assignment.public.6384"],
+      [6385, "codex-2", "assignment.public.6385"],
+    ])
+    expect(commands[0]).toBe("pylon presence heartbeat --json")
+    expect(commands[1]).toContain("--account-ref codex")
+    expect(commands[2]).toContain("--account-ref codex-2")
   })
 })
 

--- a/clients/khala-cli/src/fleet.ts
+++ b/clients/khala-cli/src/fleet.ts
@@ -53,6 +53,44 @@ export type KhalaCodexDeviceLoginRunner = (input: {
   readonly home: string
 }) => Promise<{ readonly exitCode: number }>
 
+export type KhalaFleetRunIssue = {
+  readonly issue: number
+  readonly accountRef: string
+  readonly state: "planned" | "dispatched" | "failed" | "skipped"
+  readonly assignmentRef?: string | undefined
+  readonly durableRequestId?: string | undefined
+  readonly error?: string | undefined
+}
+
+export type KhalaFleetRunPlan = {
+  readonly schema: "openagents.khala.fleet_run_plan.v0.1"
+  readonly pylonHome: string
+  readonly configPath: string
+  readonly pylonRef: string
+  readonly repo: string
+  readonly branch: string
+  readonly commit: string
+  readonly verify: string
+  readonly readyAccounts: ReadonlyArray<KhalaFleetAccount>
+  readonly perAccount: number
+  readonly maxSlots: number
+  readonly desiredSlots: number
+  readonly issues: ReadonlyArray<number>
+}
+
+export type KhalaFleetRunResult = {
+  readonly schema: "openagents.khala.fleet_run.v0.1"
+  readonly plan: KhalaFleetRunPlan
+  readonly dryRun: boolean
+  readonly loop: boolean
+  readonly dispatched: ReadonlyArray<KhalaFleetRunIssue>
+}
+
+export type KhalaFleetRunCommandRunner = (input: {
+  readonly command: ReadonlyArray<string>
+  readonly env: Record<string, string | undefined>
+}) => Promise<{ readonly exitCode: number; readonly stdout: string; readonly stderr: string }>
+
 type ConfigRecord = Record<string, unknown>
 
 // Raised when the `codex` CLI is not installed. The CLI catches this and prints
@@ -67,6 +105,17 @@ export class CodexCliMissingError extends Error {
         "  (or see https://github.com/openai/codex)",
     )
     this.name = "CodexCliMissingError"
+  }
+}
+
+export class PylonCliMissingError extends Error {
+  readonly _tag = "PylonCliMissingError"
+  constructor() {
+    super(
+      "The `pylon` CLI is required to run your Khala fleet but was not found on your PATH.\n" +
+        "Install or expose Pylon, then re-run `khala fleet run`.",
+    )
+    this.name = "PylonCliMissingError"
   }
 }
 
@@ -107,6 +156,16 @@ export function pylonConfigPath(pylonHome: string): string {
 
 export function codexAccountHome(pylonHome: string, accountRef: string): string {
   return join(pylonHome, "accounts", "codex", accountRef)
+}
+
+function splitCommand(value: string | undefined, fallback: ReadonlyArray<string>): ReadonlyArray<string> {
+  const trimmed = value?.trim()
+  if (trimmed === undefined || trimmed.length === 0) return fallback
+  return trimmed.split(/\s+/).filter(part => part.length > 0)
+}
+
+function pylonCommand(env: Record<string, string | undefined>): ReadonlyArray<string> {
+  return splitCommand(env.KHALA_PYLON_COMMAND ?? env.PYLON_COMMAND, ["pylon"])
 }
 
 function asRecord(value: unknown): ConfigRecord | null {
@@ -271,6 +330,16 @@ const defaultCodexDeviceLoginRunner: KhalaCodexDeviceLoginRunner = async input =
   return { exitCode: await child.exited }
 }
 
+const defaultFleetRunCommandRunner: KhalaFleetRunCommandRunner = async input => {
+  const child = spawnProcess(input.command, {
+    env: { ...process.env, ...input.env },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([child.exited, child.stdout, child.stderr])
+  return { exitCode, stdout, stderr }
+}
+
 // List the connected Codex accounts in the user's fleet with readiness.
 export async function listFleetAccounts(
   options: { readonly env?: Record<string, string | undefined> } = {},
@@ -358,5 +427,274 @@ export async function connectFleetAccount(
     pylonHome,
     configPath,
     status,
+  }
+}
+
+function positiveInteger(value: number | undefined, fallback: number, label: string): number {
+  const next = value ?? fallback
+  if (!Number.isSafeInteger(next) || next <= 0) {
+    throw new Error(`khala fleet run ${label} must be a positive integer`)
+  }
+  return next
+}
+
+function cleanIssueList(issues: ReadonlyArray<number>): ReadonlyArray<number> {
+  const out: number[] = []
+  const seen = new Set<number>()
+  for (const issue of issues) {
+    if (!Number.isSafeInteger(issue) || issue <= 0) {
+      throw new Error("khala fleet run issue numbers must be positive integers")
+    }
+    if (!seen.has(issue)) {
+      seen.add(issue)
+      out.push(issue)
+    }
+  }
+  if (out.length === 0) {
+    throw new Error("khala fleet run requires at least one issue: pass --issue 123 or --issues 123,124")
+  }
+  return out
+}
+
+function cleanRepo(repo: string | undefined): string {
+  const value = repo?.trim()
+  if (value === undefined || value.length === 0) {
+    throw new Error("khala fleet run requires --repo <owner/repo>")
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+    throw new Error("khala fleet run --repo must look like owner/repo")
+  }
+  return value
+}
+
+function cleanBranch(branch: string | undefined): string {
+  const value = branch?.trim() || "main"
+  if (!/^[A-Za-z0-9._/-]{1,120}$/.test(value) || value.includes("..")) {
+    throw new Error("khala fleet run --branch must be a bounded public branch name")
+  }
+  return value
+}
+
+function cleanCommit(commit: string | undefined): string {
+  const value = commit?.trim()
+  if (value === undefined || value.length === 0) {
+    throw new Error("khala fleet run requires --commit <sha> for bounded public repo work")
+  }
+  if (!/^[a-f0-9]{40}$/i.test(value)) {
+    throw new Error("khala fleet run --commit must be a 40-character git SHA")
+  }
+  return value
+}
+
+function cleanVerify(verify: string | undefined): string {
+  const value = verify?.trim()
+  if (value === undefined || value.length === 0) {
+    throw new Error("khala fleet run requires --verify <command>")
+  }
+  return value
+}
+
+function parsePylonRef(stdout: string): string | null {
+  try {
+    const parsed = JSON.parse(stdout) as Record<string, unknown>
+    for (const key of ["pylonRef", "ref", "providerRef"]) {
+      const value = parsed[key]
+      if (typeof value === "string" && value.trim().length > 0) return value.trim()
+    }
+    const nested = parsed.provider
+    if (nested !== null && typeof nested === "object") {
+      const value = (nested as Record<string, unknown>).pylonRef
+      if (typeof value === "string" && value.trim().length > 0) return value.trim()
+    }
+  } catch {
+    const match = stdout.match(/pylon[.:][a-z0-9_.:-]+/i)
+    if (match !== null) return match[0]
+  }
+  return null
+}
+
+async function resolveFleetRunPylonRef(input: {
+  readonly env: Record<string, string | undefined>
+  readonly explicit: string | undefined
+  readonly runner: KhalaFleetRunCommandRunner
+}): Promise<string> {
+  const explicit = input.explicit?.trim()
+  if (explicit !== undefined && explicit.length > 0) return explicit
+  const command = [...pylonCommand(input.env), "provider", "go-online", "--json"]
+  const result = await input.runner({ command, env: input.env })
+  if (result.exitCode === 127) throw new PylonCliMissingError()
+  if (result.exitCode !== 0) {
+    throw new Error(`pylon provider go-online failed with status ${result.exitCode}: ${result.stderr.trim() || result.stdout.trim()}`)
+  }
+  const pylonRef = parsePylonRef(result.stdout)
+  if (pylonRef === null) {
+    throw new Error("pylon provider go-online did not report a pylonRef; pass --pylon-ref explicitly")
+  }
+  return pylonRef
+}
+
+export async function planFleetRun(options: {
+  readonly env?: Record<string, string | undefined> | undefined
+  readonly branch?: string | undefined
+  readonly commit?: string | undefined
+  readonly issues: ReadonlyArray<number>
+  readonly maxSlots?: number | undefined
+  readonly perAccount?: number | undefined
+  readonly pylonRef?: string | undefined
+  readonly repo?: string | undefined
+  readonly verify?: string | undefined
+  readonly runner?: KhalaFleetRunCommandRunner | undefined
+}): Promise<KhalaFleetRunPlan> {
+  const env = options.env ?? process.env
+  const status = await listFleetAccounts({ env })
+  const readyAccounts = status.accounts.filter(account => account.readiness === "ready")
+  if (readyAccounts.length === 0) {
+    throw new Error("khala fleet run needs at least one ready Codex account. Run `khala fleet connect` first.")
+  }
+  const perAccount = positiveInteger(options.perAccount, 1, "--per-account")
+  const maxSlots = positiveInteger(options.maxSlots, 10, "--max-slots")
+  const desiredSlots = Math.min(maxSlots, readyAccounts.length * perAccount)
+  return {
+    schema: "openagents.khala.fleet_run_plan.v0.1",
+    branch: cleanBranch(options.branch),
+    commit: cleanCommit(options.commit),
+    configPath: status.configPath,
+    desiredSlots,
+    issues: cleanIssueList(options.issues),
+    maxSlots,
+    perAccount,
+    pylonHome: status.pylonHome,
+    pylonRef: await resolveFleetRunPylonRef({
+      env,
+      explicit: options.pylonRef,
+      runner: options.runner ?? defaultFleetRunCommandRunner,
+    }),
+    readyAccounts,
+    repo: cleanRepo(options.repo),
+    verify: cleanVerify(options.verify),
+  }
+}
+
+async function publishFleetCapacity(input: {
+  readonly env: Record<string, string | undefined>
+  readonly plan: KhalaFleetRunPlan
+  readonly runner: KhalaFleetRunCommandRunner
+}): Promise<void> {
+  const command = [...pylonCommand(input.env), "presence", "heartbeat", "--json"]
+  const result = await input.runner({
+    command,
+    env: {
+      ...input.env,
+      OPENAGENTS_PYLON_CODEX_CONCURRENCY: String(input.plan.desiredSlots),
+      OPENAGENTS_PYLON_CODEX_BUSY: "0",
+      OPENAGENTS_PYLON_CODEX_QUEUED: "0",
+    },
+  })
+  if (result.exitCode === 127) throw new PylonCliMissingError()
+  if (result.exitCode !== 0) {
+    throw new Error(`pylon presence heartbeat failed with status ${result.exitCode}: ${result.stderr.trim() || result.stdout.trim()}`)
+  }
+}
+
+async function dispatchFleetIssue(input: {
+  readonly accountRef: string
+  readonly env: Record<string, string | undefined>
+  readonly issue: number
+  readonly plan: KhalaFleetRunPlan
+  readonly runner: KhalaFleetRunCommandRunner
+}): Promise<KhalaFleetRunIssue> {
+  const prompt = `Implement public issue #${input.issue} and run the named verification.`
+  const command = [
+    ...pylonCommand(input.env),
+    "khala",
+    "request",
+    "--prompt",
+    prompt,
+    "--workflow",
+    "codex_agent_task",
+    "--pylon-ref",
+    input.plan.pylonRef,
+    "--account-ref",
+    input.accountRef,
+    "--repo",
+    input.plan.repo,
+    "--branch",
+    input.plan.branch,
+    "--commit",
+    input.plan.commit,
+    "--verify",
+    input.plan.verify,
+    "--json",
+  ]
+  const result = await input.runner({ command, env: input.env })
+  if (result.exitCode === 127) throw new PylonCliMissingError()
+  if (result.exitCode !== 0) {
+    return {
+      accountRef: input.accountRef,
+      error: result.stderr.trim() || result.stdout.trim() || `pylon exited ${result.exitCode}`,
+      issue: input.issue,
+      state: "failed",
+    }
+  }
+  try {
+    const parsed = JSON.parse(result.stdout) as Record<string, unknown>
+    return {
+      accountRef: input.accountRef,
+      assignmentRef: typeof parsed.assignmentRef === "string" ? parsed.assignmentRef : undefined,
+      durableRequestId: typeof parsed.durableRequestId === "string" ? parsed.durableRequestId : undefined,
+      issue: input.issue,
+      state: "dispatched",
+    }
+  } catch {
+    return {
+      accountRef: input.accountRef,
+      error: "pylon returned non-JSON output for khala request",
+      issue: input.issue,
+      state: "failed",
+    }
+  }
+}
+
+export async function runFleetSupervisor(options: {
+  readonly env?: Record<string, string | undefined> | undefined
+  readonly branch?: string | undefined
+  readonly commit?: string | undefined
+  readonly dryRun?: boolean | undefined
+  readonly issues: ReadonlyArray<number>
+  readonly loop?: boolean | undefined
+  readonly maxSlots?: number | undefined
+  readonly perAccount?: number | undefined
+  readonly pylonRef?: string | undefined
+  readonly repo?: string | undefined
+  readonly runner?: KhalaFleetRunCommandRunner | undefined
+  readonly verify?: string | undefined
+}): Promise<KhalaFleetRunResult> {
+  const env = options.env ?? process.env
+  const runner = options.runner ?? defaultFleetRunCommandRunner
+  const plan = await planFleetRun({ ...options, env, runner })
+  if (options.dryRun === true) {
+    return { schema: "openagents.khala.fleet_run.v0.1", plan, dryRun: true, loop: options.loop === true, dispatched: [] }
+  }
+  await publishFleetCapacity({ env, plan, runner })
+  const slots = Math.min(plan.desiredSlots, plan.issues.length)
+  const dispatched: KhalaFleetRunIssue[] = []
+  for (let slot = 0; slot < slots; slot += 1) {
+    const account = plan.readyAccounts[slot % plan.readyAccounts.length]
+    const issue = plan.issues[slot]
+    if (account === undefined || issue === undefined) continue
+    dispatched.push(await dispatchFleetIssue({
+      accountRef: account.accountRef,
+      env,
+      issue,
+      plan,
+      runner,
+    }))
+  }
+  return {
+    schema: "openagents.khala.fleet_run.v0.1",
+    plan,
+    dryRun: false,
+    loop: options.loop === true,
+    dispatched,
   }
 }


### PR DESCRIPTION
Addresses #6384.

### Changes
- Adds `khala fleet run` (alias `start`) subcommand to `clients/khala-cli/src/cli.ts` with `--issue/--issues`, `--per-account`, `--max-slots`, `--dry-run`, and `--loop` flags plus help/usage entries.
- Implements `planFleetRun` and `runFleetSupervisor` in `clients/khala-cli/src/fleet.ts`: auto-resolves the caller's Pylon ref via `pylon provider go-online --json`, scales desired slots from ready Codex account count (`perAccount` capped by `maxSlots`), publishes Codex capacity via `pylon presence heartbeat`, and round-robins `pylon khala request` assignments across isolated account refs.
- Adds `PylonCliMissingError`, typed `KhalaFleetRunPlan`/`KhalaFleetRunResult` schemas, JSON + human output formatting, and `--dry-run` plan-only mode.
- Documents the command in `clients/khala-cli/README.md`.

### Verification
Not independently re-verified. PR adds unit tests in `cli.test.ts` and `fleet.test.ts` covering plan, dry-run, and one-cycle round-robin dispatch.