### PR TITLE
feat(artanis-web): /artanis Fleet Map grid + Active Task Board

### DIFF
--- a/apps/openagents.com/apps/web/src/docs-blog-route.test.ts
+++ b/apps/openagents.com/apps/web/src/docs-blog-route.test.ts
@@ -688,6 +688,42 @@ describe('docs and blog routes', () => {
             usedLiveBitcoin: false,
             walletAuthorityRefs: [],
           },
+          fleetActivity: {
+            activeIssueCount: 1,
+            activeIssues: [
+              {
+                activeAssignmentRefs: [
+                  'assignment.public.khala_coding.issue_6414',
+                ],
+                issueNumber: 6414,
+                issueTitle:
+                  'Web: /artanis Fleet Map grid + Active Task Board',
+                repositoryRef: 'OpenAgentsInc/openagents',
+                serviceLabels: ['Codex'],
+                state: 'running',
+              },
+            ],
+            caveatRefs: [
+              'caveat.public.artanis.fleet_activity_public_projection_only',
+            ],
+            generatedFromRefs: [
+              'table.public.pylon_api_registrations',
+              'table.public.pylon_api_assignments',
+            ],
+            slots: [
+              {
+                activeAssignmentRef: 'assignment.public.khala_coding.issue_6414',
+                issueNumber: 6414,
+                issueTitle:
+                  'Web: /artanis Fleet Map grid + Active Task Board',
+                label: 'Codex-1',
+                pylonRef: 'pylon.public.codex_one',
+                service: 'codex',
+                state: 'busy',
+                updatedAtDisplay: 'just now',
+              },
+            ],
+          },
           healthSummary: {
             attentionLabels: ['Model Lab report is stale'],
             blockerRefs: ['blocker.public.artanis.model_lab_report_stale'],

--- a/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
@@ -845,6 +845,40 @@ export const PublicArtanisReportHealthSummary = S.Struct({
 export type PublicArtanisReportHealthSummary =
   typeof PublicArtanisReportHealthSummary.Type
 
+export const PublicArtanisFleetMapSlot = S.Struct({
+  activeAssignmentRef: S.NullOr(S.String),
+  issueNumber: S.NullOr(S.Number),
+  issueTitle: S.NullOr(S.String),
+  label: S.String,
+  pylonRef: S.String,
+  service: S.Literals(['claude', 'codex']),
+  state: S.Literals(['available', 'busy', 'queued', 'stale']),
+  updatedAtDisplay: S.String,
+})
+export type PublicArtanisFleetMapSlot =
+  typeof PublicArtanisFleetMapSlot.Type
+
+export const PublicArtanisActiveIssueBoardItem = S.Struct({
+  activeAssignmentRefs: S.Array(S.String),
+  issueNumber: S.Number,
+  issueTitle: S.String,
+  repositoryRef: S.NullOr(S.String),
+  serviceLabels: S.Array(S.String),
+  state: S.String,
+})
+export type PublicArtanisActiveIssueBoardItem =
+  typeof PublicArtanisActiveIssueBoardItem.Type
+
+export const PublicArtanisFleetActivitySummary = S.Struct({
+  activeIssueCount: S.Number,
+  activeIssues: S.Array(PublicArtanisActiveIssueBoardItem),
+  caveatRefs: S.Array(S.String),
+  generatedFromRefs: S.Array(S.String),
+  slots: S.Array(PublicArtanisFleetMapSlot),
+})
+export type PublicArtanisFleetActivitySummary =
+  typeof PublicArtanisFleetActivitySummary.Type
+
 export const PublicArtanisReportClaimSummary = S.Struct({
   area: S.String,
   blockedByRefs: S.Array(S.String),
@@ -879,6 +913,7 @@ export const PublicArtanisReport = S.Struct({
   forumLinks: S.Array(PublicArtanisReportForumLink),
   forumRewardSmoke: PublicArtanisForumRewardSmoke,
   forumRewardVisibility: PublicArtanisForumRewardVisibility,
+  fleetActivity: PublicArtanisFleetActivitySummary,
   healthSummary: PublicArtanisReportHealthSummary,
   modelLabSummary: PublicArtanisReportModelLabSummary,
   nexusPublicRefs: S.Array(S.String),

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
@@ -13,6 +13,9 @@ import type {
   PublicAdjutantDeployedSite,
   PublicAgentGoal,
   PublicAgentGoalEvent,
+  PublicArtanisActiveIssueBoardItem,
+  PublicArtanisFleetActivitySummary,
+  PublicArtanisFleetMapSlot,
   PublicArtanisForumRewardSmoke,
   PublicArtanisForumRewardVisibility,
   PublicArtanisProductionLaunchGate,
@@ -532,6 +535,202 @@ const bitcoinPrimary = (value: string): string => value.replace(/ \(.+\)$/, '')
 const bitcoinDenomination = (value: string): string | null =>
   value.match(/\((.+)\)$/)?.[1] ?? null
 
+const fleetSlotStateClass = (slot: PublicArtanisFleetMapSlot): string =>
+  slot.state === 'available'
+    ? 'border-[#164729] bg-[#041108] text-[#b9f6ca]'
+    : slot.state === 'stale'
+      ? 'border-[#4a2a00] bg-[#130b00] text-[#ffcc80]'
+      : 'border-[#4b3a00] bg-[#120e00] text-[#ffe08a]'
+
+const artanisFleetSlotView = (slot: PublicArtanisFleetMapSlot): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    [
+      Ui.className<Message>(
+        `grid min-h-24 content-between gap-2 border p-3 ${fleetSlotStateClass(slot)}`,
+      ),
+    ],
+    [
+      h.div(
+        [Ui.className<Message>('flex items-center justify-between gap-2')],
+        [
+          h.span(
+            [Ui.className<Message>('text-[0.8125rem] font-semibold')],
+            [slot.label],
+          ),
+          h.span(
+            [
+              Ui.className<Message>(
+                'text-[0.6875rem] uppercase text-white/45',
+              ),
+            ],
+            [slot.state],
+          ),
+        ],
+      ),
+      h.div(
+        [Ui.className<Message>('min-w-0 text-[0.75rem] text-white/55')],
+        [
+          slot.issueNumber === null
+            ? slot.pylonRef
+            : `#${slot.issueNumber} ${slot.issueTitle ?? 'public issue'}`,
+        ],
+      ),
+      h.div(
+        [Ui.className<Message>('truncate text-[0.6875rem] text-white/35')],
+        [slot.activeAssignmentRef ?? slot.updatedAtDisplay],
+      ),
+    ],
+  )
+}
+
+const artanisActiveIssueRow = (
+  issue: PublicArtanisActiveIssueBoardItem,
+): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    [
+      Ui.className<Message>(
+        'grid gap-2 border-b border-[#1b1b1b] py-3 last:border-b-0 sm:grid-cols-[auto_minmax(0,1fr)_auto]',
+      ),
+    ],
+    [
+      h.a(
+        [
+          h.Href(
+            `https://github.com/OpenAgentsInc/openagents/issues/${issue.issueNumber}`,
+          ),
+          h.Target('_blank'),
+          h.Rel('noreferrer'),
+          Ui.className<Message>(
+            'tabular-nums text-[0.8125rem] text-[#ffb400] underline-offset-4 hover:underline',
+          ),
+        ],
+        [`#${issue.issueNumber}`],
+      ),
+      h.div(
+        [Ui.className<Message>('min-w-0')],
+        [
+          h.div(
+            [Ui.className<Message>('truncate text-[0.8125rem] text-[#f1efe8]')],
+            [issue.issueTitle],
+          ),
+          h.div(
+            [Ui.className<Message>('truncate text-[0.75rem] text-white/35')],
+            [
+              `${issue.repositoryRef ?? 'public repo'} / ${compactRefs(issue.activeAssignmentRefs)}`,
+            ],
+          ),
+        ],
+      ),
+      h.div(
+        [
+          Ui.className<Message>(
+            'text-[0.75rem] text-white/45 sm:text-right',
+          ),
+        ],
+        [`${issue.serviceLabels.join('+')} / ${issue.state}`],
+      ),
+    ],
+  )
+}
+
+const artanisFleetActivityView = (
+  activity: PublicArtanisFleetActivitySummary,
+): Html => {
+  const h = html<Message>()
+  const slots = activity.slots.slice(0, 24)
+
+  return h.div(
+    [
+      Ui.className<Message>(
+        'grid gap-3 border border-[#222] bg-[#010102] p-3',
+      ),
+    ],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex flex-wrap items-end justify-between gap-3',
+          ),
+        ],
+        [
+          h.div(
+            [Ui.className<Message>('grid gap-1')],
+            [
+              h.div(
+                [Ui.className<Message>('text-[0.75rem] text-white/45')],
+                ['The Grid'],
+              ),
+              h.h3(
+                [
+                  Ui.className<Message>(
+                    'text-base font-semibold text-[#f1efe8]',
+                  ),
+                ],
+                ['Fleet slots and backlog in flight'],
+              ),
+            ],
+          ),
+          h.div(
+            [Ui.className<Message>('text-[0.75rem] text-white/45')],
+            [`${formatNumber(activity.activeIssueCount)} active issues`],
+          ),
+        ],
+      ),
+      Array.match(slots, {
+        onEmpty: () =>
+          h.p(
+            [Ui.className<Message>('text-[0.75rem] text-white/35')],
+            ['No public coding slots are active right now.'],
+          ),
+        onNonEmpty: rows =>
+          h.ol(
+            [
+              Ui.className<Message>(
+                'grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4',
+              ),
+            ],
+            rows.map(artanisFleetSlotView),
+          ),
+      }),
+      h.div(
+        [
+          Ui.className<Message>(
+            'grid gap-2 border-t border-[#1b1b1b] pt-3',
+          ),
+        ],
+        [
+          h.div(
+            [Ui.className<Message>('text-[0.75rem] text-white/45')],
+            ['Active issues'],
+          ),
+          Array.match(activity.activeIssues.slice(0, 8), {
+            onEmpty: () =>
+              h.p(
+                [Ui.className<Message>('text-[0.75rem] text-white/35')],
+                ['No public issue-backed coding assignments are in flight.'],
+              ),
+            onNonEmpty: issues =>
+              h.ol(
+                [Ui.className<Message>('grid')],
+                issues.map(artanisActiveIssueRow),
+              ),
+          }),
+        ],
+      ),
+      h.div(
+        [Ui.className<Message>('text-[0.6875rem] text-white/35')],
+        [
+          `Public-safe only / ${compactRefs(activity.caveatRefs, compactRefs(activity.generatedFromRefs))}`,
+        ],
+      ),
+    ],
+  )
+}
+
 const artanisClaimRow = (claim: PublicArtanisReportClaimSummary): Html => {
   const h = html<Message>()
 
@@ -988,6 +1187,7 @@ const artanisReportLoadedView = (report: PublicArtanisReport): Html => {
           ),
         ],
       ),
+      artanisFleetActivityView(report.fleetActivity),
       h.div(
         [
           Ui.className<Message>(

--- a/apps/openagents.com/workers/api/src/artanis-public-report-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-public-report-routes.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect'
 
 import {
   ArtanisPublicReportUnsafe,
+  artanisFleetActivitySummary,
   artanisPublicReportSnapshot,
 } from './artanis-public-report'
 import { ArtanisLoopTickRecord, type ArtanisLoopState } from './artanis-loop'
@@ -20,7 +21,8 @@ import {
   type PublicPylonStatsStore,
   publicPylonStatsSnapshot,
 } from './public-pylon-stats'
-import { makeD1PylonApiStore } from './pylon-api'
+import { makeD1PylonApiStore, type PylonApiStore } from './pylon-api'
+import { currentIsoTimestamp } from './runtime-primitives'
 
 const routeErrorResponse = (error: ArtanisPublicReportUnsafe) =>
   noStoreJsonResponse(
@@ -34,6 +36,7 @@ const routeErrorResponse = (error: ArtanisPublicReportUnsafe) =>
 type PublicArtanisReportRouteInput = Readonly<{
   OPENAGENTS_DB?: D1Database
   loopTicks?: ReadonlyArray<ArtanisLoopTickRecord>
+  pylonApiStore?: PylonApiStore
   store?: PublicPylonStatsStore
 }>
 
@@ -124,6 +127,39 @@ const loopTicksForRoute = (
           ),
         )
 
+const fleetActivityForRoute = async (
+  input: PublicArtanisReportRouteInput,
+) => {
+  const store =
+    input.pylonApiStore ??
+    (input.OPENAGENTS_DB === undefined
+      ? undefined
+      : makeD1PylonApiStore(input.OPENAGENTS_DB))
+
+  if (store === undefined) {
+    return undefined
+  }
+
+  const registrations = await store.listRegistrations(100)
+  const pylonRefs = registrations.map(registration => registration.pylonRef)
+  const assignments =
+    store.listAssignmentsForPylons === undefined
+      ? (
+          await Promise.all(
+            pylonRefs.map(pylonRef =>
+              store.listAssignmentsForPylon(pylonRef, 25),
+            ),
+          )
+        ).flat()
+      : await store.listAssignmentsForPylons(pylonRefs, 250)
+
+  return artanisFleetActivitySummary({
+    assignments,
+    nowIso: currentIsoTimestamp(),
+    registrations,
+  })
+}
+
 export const handlePublicArtanisReportApi = (
   request: Request,
   input: PublicArtanisReportRouteInput,
@@ -131,17 +167,28 @@ export const handlePublicArtanisReportApi = (
   request.method !== 'GET'
     ? Effect.succeed(methodNotAllowed(['GET']))
     : Effect.all({
+        fleetActivity: Effect.tryPromise({
+          catch: error =>
+            new ArtanisPublicReportUnsafe({
+              reason:
+                error instanceof Error
+                  ? `Artanis fleet activity unavailable: ${error.message}`
+                  : 'Artanis fleet activity unavailable.',
+            }),
+          try: () => fleetActivityForRoute(input),
+        }).pipe(Effect.catch(() => Effect.succeed(undefined))),
         loopTicks: loopTicksForRoute(input),
         pylonStats: publicPylonStatsSnapshot({
           store:
             input.store ?? makeD1PylonApiStore(input.OPENAGENTS_DB as D1Database),
         }),
       }).pipe(
-        Effect.flatMap(({ loopTicks, pylonStats }) =>
+        Effect.flatMap(({ fleetActivity, loopTicks, pylonStats }) =>
           Effect.try({
             try: () =>
               noStoreJsonResponse(
                 artanisPublicReportSnapshot({
+                  fleetActivity,
                   loopTicks,
                   pylonStats,
                 }),

--- a/apps/openagents.com/workers/api/src/artanis-public-report.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-public-report.test.ts
@@ -7,6 +7,7 @@ import {
 } from './artanis-forum-publication'
 import { ArtanisLoopTickRecord } from './artanis-loop'
 import {
+  artanisFleetActivitySummary,
   artanisPublicReportHasPrivateMaterial,
   artanisPublicReportSnapshot,
   publicNexusPylonReceiptRouteRefsFromRefs,
@@ -14,6 +15,10 @@ import {
 import { handlePublicArtanisReportApi } from './artanis-public-report-routes'
 import { publicPylonStatsFromNexusPayload } from './public-pylon-stats'
 import { publicScannerSafeRef } from './public-ref-scanner-safety'
+import type {
+  PylonApiAssignmentRecord,
+  PylonApiRegistrationRecord,
+} from './pylon-api'
 
 const nowIso = '2026-06-07T02:00:00.000Z'
 const scannerShapedBridgeRef = 'artanis-mdk-bridge-8b378373002501f3e896dcd3'
@@ -38,6 +43,75 @@ const deliveredForumQueue = (): ArtanisForumPublicationQueueRecord => {
     updatedAtIso: '2026-06-07T01:24:00.000Z',
   }
 }
+
+const fleetRegistration = (
+  overrides: Partial<PylonApiRegistrationRecord> = {},
+): PylonApiRegistrationRecord => ({
+  capabilityRefs: ['capability.pylon.local_codex'],
+  clientProtocolVersion: '0.2.5',
+  clientVersion: 'openagents.pylon@0.2.5',
+  createdAt: '2026-06-07T01:00:00.000Z',
+  displayName: 'Owner Pylon',
+  id: 'pylon_api_registration_test',
+  latestHeartbeatAt: '2026-06-07T01:59:00.000Z',
+  latestHeartbeatStatus: 'online',
+  latestCapacityRefs: ['capacity.coding.codex.available=1'],
+  latestHealthRefs: ['health.public.ready'],
+  latestLoadRefs: ['load.coding.codex.busy=1'],
+  latestResourceMode: 'background_20',
+  ownerAgentCredentialId: 'credential_test',
+  ownerAgentTokenPrefix: 'oa_agent_test',
+  ownerAgentUserId: 'agent_user_test',
+  providerMarketRelayRefs: [],
+  providerNip90LaneRefs: [],
+  providerNostrNpub: null,
+  providerNostrPubkey: null,
+  publicProjectionJson: '{}',
+  pylonRef: 'pylon.public.codex_one',
+  resourceMode: 'background_20',
+  status: 'active',
+  updatedAt: '2026-06-07T01:59:00.000Z',
+  walletReady: false,
+  walletRef: null,
+  ...overrides,
+})
+
+const fleetAssignment = (
+  overrides: Partial<PylonApiAssignmentRecord> = {},
+): PylonApiAssignmentRecord => ({
+  acceptanceCriteriaRefs: ['acceptance.public.issue_6414'],
+  acceptedWorkRefs: [],
+  artifactRefs: [],
+  assignmentRef: 'assignment.public.khala_coding.issue_6414',
+  closeoutRefs: [],
+  codingAssignment: {
+    objective: {
+      publicSummary: 'Web: /artanis Fleet Map grid + Active Task Board (#6414)',
+    },
+    workspace: {
+      repository: {
+        fullName: 'OpenAgentsInc/openagents',
+        provider: 'github',
+        visibility: 'public',
+      },
+    },
+  },
+  createdAt: '2026-06-07T01:40:00.000Z',
+  id: 'pylon_api_assignment_test',
+  idempotencyKeyHash: 'khala-coding:test',
+  jobKind: 'codex_agent_task',
+  leaseExpiresAt: '2026-06-07T02:40:00.000Z',
+  ownerAgentUserId: 'agent_user_test',
+  proofRefs: [],
+  publicProjectionJson: '{}',
+  pylonRef: 'pylon.public.codex_one',
+  rejectionRefs: [],
+  resultExpectationRefs: ['result.public.khala_coding.worker_closeout'],
+  state: 'running',
+  taskRefs: ['task.public.issue_6414'],
+  updatedAt: '2026-06-07T01:50:00.000Z',
+  ...overrides,
+})
 
 describe('Artanis public report', () => {
   afterEach(() => {
@@ -458,6 +532,46 @@ describe('Artanis public report', () => {
     expect(serialized).not.toContain('Pylon v0.2 is shipped')
     expect(serialized).not.toContain('Pylon v0.2 is ready for everyone')
     expect(serialized).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+
+  test('projects generic fleet slots and active public issue board without private assignment fields', () => {
+    const fleetActivity = artanisFleetActivitySummary({
+      assignments: [fleetAssignment()],
+      nowIso,
+      registrations: [fleetRegistration()],
+    })
+    const serialized = JSON.stringify(fleetActivity)
+
+    expect(fleetActivity.slots).toContainEqual(
+      expect.objectContaining({
+        activeAssignmentRef: 'assignment.public.khala_coding.issue_6414',
+        issueNumber: 6414,
+        label: 'Codex-1',
+        service: 'codex',
+        state: 'busy',
+      }),
+    )
+    expect(fleetActivity.slots).toContainEqual(
+      expect.objectContaining({
+        activeAssignmentRef: null,
+        label: 'Codex-2',
+        service: 'codex',
+        state: 'available',
+      }),
+    )
+    expect(fleetActivity.activeIssues).toEqual([
+      expect.objectContaining({
+        activeAssignmentRefs: ['assignment.public.khala_coding.issue_6414'],
+        issueNumber: 6414,
+        repositoryRef: 'OpenAgentsInc/openagents',
+        serviceLabels: ['Codex'],
+      }),
+    ])
+    expect(serialized).not.toContain('agent_user_test')
+    expect(serialized).not.toContain('credential_test')
+    expect(serialized).not.toContain('oa_agent_test')
+    expect(serialized).not.toContain('provider')
+    expect(serialized).not.toContain('visibility')
   })
 
   test('serves the same public-safe projection to anonymous and authenticated visitors', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-public-report.ts
+++ b/apps/openagents.com/workers/api/src/artanis-public-report.ts
@@ -91,6 +91,12 @@ import {
   PublicPylonEarningLaunchGate,
   PublicPylonStats,
 } from './public-pylon-stats'
+import {
+  publicPylonApiAssignmentProjection,
+  pylonCodingServiceCapacityProjection,
+  type PylonApiAssignmentRecord,
+  type PylonApiRegistrationRecord,
+} from './pylon-api'
 import { publicRefTriggersAgentSecretScanner } from './public-ref-scanner-safety'
 import {
   PylonV02OmegaReleaseGateProjection,
@@ -241,6 +247,40 @@ export class ArtanisPublicReportHealthSummary extends S.Class<ArtanisPublicRepor
   updatedAtDisplay: S.String,
 }) {}
 
+export class ArtanisFleetMapSlot extends S.Class<ArtanisFleetMapSlot>(
+  'ArtanisFleetMapSlot',
+)({
+  activeAssignmentRef: S.NullOr(S.String),
+  issueNumber: S.NullOr(S.Number),
+  issueTitle: S.NullOr(S.String),
+  label: S.String,
+  pylonRef: S.String,
+  service: S.Literals(['claude', 'codex']),
+  state: S.Literals(['available', 'busy', 'queued', 'stale']),
+  updatedAtDisplay: S.String,
+}) {}
+
+export class ArtanisActiveIssueBoardItem extends S.Class<ArtanisActiveIssueBoardItem>(
+  'ArtanisActiveIssueBoardItem',
+)({
+  activeAssignmentRefs: S.Array(S.String),
+  issueNumber: S.Number,
+  issueTitle: S.String,
+  repositoryRef: S.NullOr(S.String),
+  serviceLabels: S.Array(S.String),
+  state: S.String,
+}) {}
+
+export class ArtanisFleetActivitySummary extends S.Class<ArtanisFleetActivitySummary>(
+  'ArtanisFleetActivitySummary',
+)({
+  activeIssueCount: S.Number,
+  activeIssues: S.Array(ArtanisActiveIssueBoardItem),
+  caveatRefs: S.Array(S.String),
+  generatedFromRefs: S.Array(S.String),
+  slots: S.Array(ArtanisFleetMapSlot),
+}) {}
+
 export class ArtanisPublicReportAuthoritySummary extends S.Class<ArtanisPublicReportAuthoritySummary>(
   'ArtanisPublicReportAuthoritySummary',
 )({
@@ -301,6 +341,7 @@ export class ArtanisPublicReport extends S.Class<ArtanisPublicReport>(
    * in string fields; epoch milliseconds carry the same fact safely.
    */
   generatedAtUnixMs: S.Number,
+  fleetActivity: ArtanisFleetActivitySummary,
   healthSummary: ArtanisPublicReportHealthSummary,
   modelLabSummary: ArtanisPublicReportModelLabSummary,
   nexusPublicRefs: S.Array(S.String),
@@ -335,6 +376,15 @@ export class ArtanisPublicReportUnsafe extends S.TaggedErrorClass<ArtanisPublicR
 const unsafePublicReportPattern =
   /(@|\/Users\/|(^|https:\/\/openagents\.com)\/autopilot($|[/?#])|\/home\/|access[_-]?token|auth\.json|authGrantRef|bearer|callback[_-]?token|cookie|customer[_-]?(email|name|phone|prompt|record|value)|dataset\.raw|email[_-]?(address|body|html|raw|text)|full[_-]?(prompt|source|trace)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|hiddenSteering|invoice[_-]?(id|raw)|lnbc|lntb|lnbcrt|lno1|lnurl|macaroon|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|model[_-]?(weights|raw|secret)|oauth|opencode_auth_content|payloadJson|payment[_-]?(hash|id|invoice|preimage|proof|secret)|payout[_-]?(address|destination|private|raw)|payout[_-]?target[_-]?raw|preimage|private[_-]?(archive|customer|dataset|key|prompt|source|trace|wallet)|provider[_-]?(account|credential|grant|payload|secret|token)|raw[_-]?(artifact|auth|customer|dataset|email|invoice|log|model|payment|payload|payout|prompt|provider|record|repo|runner|run[_-]?log|source|state|target|telemetry|text|trace|training|weights|webhook)|raw[_-]?payout[_-]?target|recovery[_-]?phrase|runner[_-]?(payload|secret|token)|secret|seed[_-]?phrase|sk-[a-z0-9]|source[_-]?(archive|raw)|token|wallet[._-]?(key|material|mnemonic|payment|preimage|secret|seed|spend)|weights\.(bin|gguf|safetensors|pt|pth))/i
 const rawTimestampPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+const activeCodingAssignmentStates = new Set([
+  'accepted',
+  'offered',
+  'proof_submitted',
+  'running',
+])
+const issueNumberPattern =
+  /(?:github\.issue\.OpenAgentsInc\.openagents\.|issue\.github\.openagents\.|issue[ #:]+|#)(\d{1,7})/i
+const githubRepoPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
 
 const unique = <A>(values: ReadonlyArray<A>): ReadonlyArray<A> => [
   ...new Set(values),
@@ -348,6 +398,228 @@ const safeRefSuffix = (value: string): string =>
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '') || 'unknown'
+
+const serviceLabel = (service: 'claude' | 'codex', index: number): string =>
+  `${service === 'codex' ? 'Codex' : 'Claude'}-${index}`
+
+const publicSummarySafe = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim().replace(/\s+/g, ' ')
+
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > 180 ||
+    containsProviderSecretMaterial(trimmed) ||
+    publicRefTriggersAgentSecretScanner(trimmed) ||
+    unsafePublicReportPattern.test(trimmed) ||
+    rawTimestampPattern.test(trimmed)
+  ) {
+    return null
+  }
+
+  return trimmed
+}
+
+const recordFromUnknown = (value: unknown): Record<string, unknown> | null =>
+  typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : null
+
+const codingObjectiveSummary = (
+  assignment: PylonApiAssignmentRecord,
+): string | null => {
+  const coding = recordFromUnknown(assignment.codingAssignment)
+  const objective = recordFromUnknown(coding?.objective)
+
+  return publicSummarySafe(objective?.publicSummary)
+}
+
+const codingRepositoryRef = (
+  assignment: PylonApiAssignmentRecord,
+): string | null => {
+  const coding = recordFromUnknown(assignment.codingAssignment)
+  const workspace = recordFromUnknown(coding?.workspace)
+  const repository = recordFromUnknown(workspace?.repository)
+  const fullName = repository?.fullName
+
+  return typeof fullName === 'string' && githubRepoPattern.test(fullName)
+    ? fullName
+    : null
+}
+
+const assignmentIssueNumber = (
+  assignment: PylonApiAssignmentRecord,
+): number | null => {
+  const candidates = [
+    codingObjectiveSummary(assignment),
+    ...assignment.taskRefs,
+    ...assignment.acceptanceCriteriaRefs,
+  ].filter((value): value is string => value !== null)
+
+  for (const candidate of candidates) {
+    const match = issueNumberPattern.exec(candidate)
+
+    if (match !== null) {
+      const parsed = Number.parseInt(match[1]!, 10)
+
+      return Number.isSafeInteger(parsed) ? parsed : null
+    }
+  }
+
+  return null
+}
+
+const assignmentIssueTitle = (
+  assignment: PylonApiAssignmentRecord,
+  issueNumber: number,
+): string => {
+  const summary = codingObjectiveSummary(assignment)
+
+  if (summary !== null) {
+    return summary
+  }
+
+  return `Public issue #${issueNumber}`
+}
+
+const serviceForAssignment = (
+  assignment: PylonApiAssignmentRecord,
+): 'claude' | 'codex' | null =>
+  assignment.jobKind === 'codex_agent_task'
+    ? 'codex'
+    : assignment.jobKind === 'claude_agent_task'
+      ? 'claude'
+      : null
+
+export const artanisFleetActivitySummary = (input: {
+  assignments: ReadonlyArray<PylonApiAssignmentRecord>
+  nowIso: string
+  registrations: ReadonlyArray<PylonApiRegistrationRecord>
+}): ArtanisFleetActivitySummary => {
+  const activeAssignments = input.assignments
+    .filter(assignment => activeCodingAssignmentStates.has(assignment.state))
+    .filter(assignment => Date.parse(assignment.leaseExpiresAt) > Date.parse(input.nowIso))
+    .filter(assignment => serviceForAssignment(assignment) !== null)
+  const assignmentsByPylon = new Map<string, ReadonlyArray<PylonApiAssignmentRecord>>()
+
+  for (const registration of input.registrations) {
+    assignmentsByPylon.set(
+      registration.pylonRef,
+      activeAssignments.filter(
+        assignment => assignment.pylonRef === registration.pylonRef,
+      ),
+    )
+  }
+
+  const serviceCounts = new Map<'claude' | 'codex', number>()
+  const slots = input.registrations.flatMap(registration =>
+    pylonCodingServiceCapacityProjection(registration).flatMap(capacity => {
+      const service = capacity.service
+      const activeForService = (
+        assignmentsByPylon.get(registration.pylonRef) ?? []
+      ).filter(assignment => serviceForAssignment(assignment) === service)
+      const activeSlots = activeForService.map(assignment => {
+        const nextIndex = (serviceCounts.get(service) ?? 0) + 1
+        serviceCounts.set(service, nextIndex)
+        const issueNumber = assignmentIssueNumber(assignment)
+        const projection = publicPylonApiAssignmentProjection(
+          assignment,
+          input.nowIso,
+        )
+
+        return new ArtanisFleetMapSlot({
+          activeAssignmentRef: assignment.assignmentRef,
+          issueNumber,
+          issueTitle:
+            issueNumber === null
+              ? null
+              : assignmentIssueTitle(assignment, issueNumber),
+          label: serviceLabel(service, nextIndex),
+          pylonRef: registration.pylonRef,
+          service,
+          state: projection.state === 'stale' ? 'stale' : 'busy',
+          updatedAtDisplay: projection.updatedAtDisplay,
+        })
+      })
+      const availableCount = Math.max(0, capacity.available)
+
+      return [
+        ...activeSlots,
+        ...Array.from({ length: Math.min(availableCount, 12) }, () => {
+          const nextIndex = (serviceCounts.get(service) ?? 0) + 1
+          serviceCounts.set(service, nextIndex)
+
+          return new ArtanisFleetMapSlot({
+            activeAssignmentRef: null,
+            issueNumber: null,
+            issueTitle: null,
+            label: serviceLabel(service, nextIndex),
+            pylonRef: registration.pylonRef,
+            service,
+            state: 'available' as const,
+            updatedAtDisplay:
+              registration.latestHeartbeatAt === null
+                ? 'not seen'
+                : friendlyBlueprintMissionBriefingTime(
+                    registration.latestHeartbeatAt,
+                    input.nowIso,
+                  ),
+          })
+        }),
+      ]
+    }),
+  )
+  const issuesByNumber = new Map<number, ArtanisActiveIssueBoardItem>()
+
+  for (const assignment of activeAssignments) {
+    const issueNumber = assignmentIssueNumber(assignment)
+    const service = serviceForAssignment(assignment)
+
+    if (issueNumber === null || service === null) {
+      continue
+    }
+
+    const existing = issuesByNumber.get(issueNumber)
+    const label = service === 'codex' ? 'Codex' : 'Claude'
+
+    issuesByNumber.set(
+      issueNumber,
+      new ArtanisActiveIssueBoardItem({
+        activeAssignmentRefs: uniqueRefs([
+          ...(existing?.activeAssignmentRefs ?? []),
+          assignment.assignmentRef,
+        ]),
+        issueNumber,
+        issueTitle: existing?.issueTitle ?? assignmentIssueTitle(assignment, issueNumber),
+        repositoryRef: existing?.repositoryRef ?? codingRepositoryRef(assignment),
+        serviceLabels: uniqueRefs([...(existing?.serviceLabels ?? []), label]),
+        state: existing?.state ?? assignment.state,
+      }),
+    )
+  }
+
+  const activeIssues = [...issuesByNumber.values()].sort(
+    (left, right) => left.issueNumber - right.issueNumber,
+  )
+
+  return new ArtanisFleetActivitySummary({
+    activeIssueCount: activeIssues.length,
+    activeIssues,
+    caveatRefs: [
+      'caveat.public.artanis.fleet_activity_public_projection_only',
+      'caveat.public.artanis.fleet_activity_generic_slot_ids',
+      'caveat.public.artanis.fleet_activity_no_raw_prompts_or_diffs',
+    ],
+    generatedFromRefs: [
+      'table.public.pylon_api_registrations',
+      'table.public.pylon_api_assignments',
+      'issue.github.openagents.6414',
+    ],
+    slots: slots.slice(0, 48),
+  })
+}
 
 const publicReportStrings = (value: unknown): ReadonlyArray<string> => {
   if (typeof value === 'string') {
@@ -984,6 +1256,7 @@ const exampleProbeGepaOutcomeMetricsProjection =
     })
 
 export const artanisPublicReportSnapshot = (input: {
+  fleetActivity?: ArtanisFleetActivitySummary | undefined
   forumPublicationQueue?: ArtanisForumPublicationQueueRecord | undefined
   loopTicks?: ReadonlyArray<ArtanisLoopTickRecord> | undefined
   nowIso?: string | undefined
@@ -1357,6 +1630,17 @@ export const artanisPublicReportSnapshot = (input: {
     forumRewardSmoke,
     forumRewardVisibility,
     generatedAtUnixMs: Date.parse(nowIso),
+    fleetActivity:
+      input.fleetActivity ??
+      new ArtanisFleetActivitySummary({
+        activeIssueCount: 0,
+        activeIssues: [],
+        caveatRefs: [
+          'caveat.public.artanis.fleet_activity_no_live_store_attached',
+        ],
+        generatedFromRefs: ['issue.github.openagents.6414'],
+        slots: [],
+      }),
     healthSummary: {
       attentionLabels: uniqueRefs(healthAttentionLabels),
       blockerRefs: uniqueRefs([


### PR DESCRIPTION
Addresses #6414.

### Changes
- Adds `fleetActivity` (slots + active-issue board) to the public Artanis report in `workers/api/src/artanis-public-report.ts` and exposes it through `artanis-public-report-routes.ts`, generated from public Pylon registration/assignment tables with redaction caveats.
- Adds `PublicArtanisFleetMapSlot`, `PublicArtanisActiveIssueBoardItem`, and `PublicArtanisFleetActivitySummary` schemas to `apps/web/src/page/loggedOut/model.ts`.
- Renders The Grid (generic Codex-N/Claude-N slot cards with state) and Backlog-in-Flight active-issue rows (repo + public issue number/title, linking to GitHub) in `apps/web/src/page/loggedOut/page/publicAgent.ts`.

### Verification
Not independently re-verified. PR adds report fixture assertions in `artanis-public-report.test.ts` and rendered-scene assertions in `docs-blog-route.test.ts`.