### PR TITLE
feat(db): D1 migration for Artanis operator threads + messages

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0248_artanis_operator_threads.sql
+++ b/apps/openagents.com/workers/api/migrations/0248_artanis_operator_threads.sql
@@ -1,0 +1,60 @@
+-- Artanis operator chat thread/message ledger (#6401).
+--
+-- This is the dedicated D1 home for multi-turn, multi-agent operator chats:
+-- owner-started Artanis chats plus agent-started operator chats from Codex,
+-- Claude, and future local/remote agents. Long-term preferences and durable
+-- memory stay in artanis_owner_memory; conversational logs live here.
+--
+-- Private/operator scoped. Rows may contain bounded chat text and local agent
+-- refs, so they must not feed public projections, counters, Forum posts, or
+-- product-promise copy.
+
+CREATE TABLE IF NOT EXISTS artanis_threads (
+  thread_ref TEXT PRIMARY KEY,
+  caller_id TEXT NOT NULL,
+  caller_kind TEXT NOT NULL CHECK (
+    caller_kind IN ('owner', 'agent', 'operator', 'system')
+  ),
+  subject_agent_ref TEXT NOT NULL,
+  subject_agent_kind TEXT NOT NULL CHECK (
+    subject_agent_kind IN ('artanis', 'claude', 'codex', 'other')
+  ),
+  title TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'open' CHECK (
+    status IN ('open', 'archived')
+  ),
+  source_ref TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  last_message_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS artanis_messages (
+  message_ref TEXT PRIMARY KEY,
+  thread_ref TEXT NOT NULL REFERENCES artanis_threads(thread_ref) ON DELETE CASCADE,
+  caller_id TEXT NOT NULL,
+  author_id TEXT NOT NULL,
+  author_kind TEXT NOT NULL CHECK (
+    author_kind IN ('owner', 'agent', 'operator', 'system', 'tool')
+  ),
+  body TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL
+);
+
+-- Primary thread list path: one caller's threads, newest activity first.
+CREATE INDEX IF NOT EXISTS idx_artanis_threads_caller_last_message
+  ON artanis_threads(caller_id, last_message_at DESC);
+
+-- Secondary thread audit path: one caller's threads by creation time.
+CREATE INDEX IF NOT EXISTS idx_artanis_threads_caller_created
+  ON artanis_threads(caller_id, created_at DESC);
+
+-- Primary transcript path: one thread in chronological order.
+CREATE INDEX IF NOT EXISTS idx_artanis_messages_thread_created
+  ON artanis_messages(thread_ref, created_at ASC);
+
+-- Cross-thread caller audit path requested by #6401.
+CREATE INDEX IF NOT EXISTS idx_artanis_messages_caller_created
+  ON artanis_messages(caller_id, created_at DESC);

--- a/apps/openagents.com/workers/api/src/artanis-operator-threads-migration.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-threads-migration.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { describe, expect, test } from 'vitest'
+
+const migrationSql = readFileSync(
+  join(__dirname, '..', 'migrations', '0248_artanis_operator_threads.sql'),
+  'utf8',
+)
+
+const rows = <T extends Record<string, unknown>>(
+  db: DatabaseSync,
+  query: string,
+): ReadonlyArray<T> =>
+  db
+    .prepare(query)
+    .all()
+    .map(row => row as T)
+
+describe('0248_artanis_operator_threads migration', () => {
+  test('creates dedicated Artanis thread/message tables and caller timestamp indexes', () => {
+    const db = new DatabaseSync(':memory:')
+    db.exec('PRAGMA foreign_keys = ON')
+    db.exec(migrationSql)
+
+    const tables = rows<{ name: string }>(
+      db,
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'artanis_%' ORDER BY name",
+    ).map(row => row.name)
+    expect(tables).toContain('artanis_threads')
+    expect(tables).toContain('artanis_messages')
+
+    const indexes = rows<{ name: string }>(
+      db,
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_artanis_%' ORDER BY name",
+    ).map(row => row.name)
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        'idx_artanis_threads_caller_last_message',
+        'idx_artanis_threads_caller_created',
+        'idx_artanis_messages_thread_created',
+        'idx_artanis_messages_caller_created',
+      ]),
+    )
+
+    db.prepare(
+      `INSERT INTO artanis_threads (
+        thread_ref,
+        caller_id,
+        caller_kind,
+        subject_agent_ref,
+        subject_agent_kind,
+        title,
+        last_message_at,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'artanis_thread_owner_codex_1',
+      'github:14167547',
+      'owner',
+      'codex-4',
+      'codex',
+      'Codex burn review',
+      '2026-06-27T16:10:00.000Z',
+      '2026-06-27T16:00:00.000Z',
+      '2026-06-27T16:10:00.000Z',
+    )
+
+    db.prepare(
+      `INSERT INTO artanis_messages (
+        message_ref,
+        thread_ref,
+        caller_id,
+        author_id,
+        author_kind,
+        body,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'artanis_message_owner_codex_1',
+      'artanis_thread_owner_codex_1',
+      'github:14167547',
+      'codex-4',
+      'agent',
+      'Public-safe status update.',
+      '2026-06-27T16:10:00.000Z',
+    )
+
+    const messages = rows<{ message_ref: string }>(
+      db,
+      "SELECT message_ref FROM artanis_messages WHERE caller_id = 'github:14167547' ORDER BY created_at DESC",
+    )
+    expect(messages).toEqual([
+      { message_ref: 'artanis_message_owner_codex_1' },
+    ])
+
+    db.prepare(
+      "DELETE FROM artanis_threads WHERE thread_ref = 'artanis_thread_owner_codex_1'",
+    ).run()
+    expect(
+      rows<{ count: number }>(
+        db,
+        'SELECT COUNT(*) AS count FROM artanis_messages',
+      )[0]?.count,
+    ).toBe(0)
+  })
+})


### PR DESCRIPTION
Addresses #6401.

### Changes
- Adds migration `workers/api/migrations/0248_artanis_operator_threads.sql` creating `artanis_threads` (caller_id, caller_kind, subject_agent_ref/kind, status, source_ref, metadata, timestamps) and `artanis_messages` (thread_ref FK with ON DELETE CASCADE, author_id/kind, body, metadata, created_at).
- Adds the requested indexes: `idx_artanis_threads_caller_last_message`, `idx_artanis_threads_caller_created`, `idx_artanis_messages_thread_created`, and `idx_artanis_messages_caller_created` (caller_id + timestamp).
- Documents private/operator scoping (must not feed public projections).

### Verification
Not independently re-verified. PR adds `artanis-operator-threads-migration.test.ts` exercising the migration against an in-memory SQLite DB (table/index creation, insert, cascade delete).