### PR TITLE
feat(forum): ingest Product Promises posts into unsupported-request ledger

### DIFF
--- a/apps/openagents.com/workers/api/src/forum-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forum-routes.test.ts
@@ -4051,6 +4051,9 @@ const route = async (
     headers?: HeadersInit
     moderator?: 'admin' | 'non_admin'
     method?: string
+    productPromisesUnsupportedRequestIngest?: NonNullable<
+      Parameters<typeof makeForumRoutes>[0]
+    >['productPromisesUnsupportedRequestIngest']
     workRequestEscrowReserver?: NonNullable<
       Parameters<typeof makeForumRoutes>[0]
     >['forumWorkRequestEscrowReserver']
@@ -4094,6 +4097,12 @@ const route = async (
     },
     nowEpochMillis: () => 1_780_000_000_000,
     nowIso: () => '2026-06-05T20:00:00.000Z',
+    ...(options.productPromisesUnsupportedRequestIngest === undefined
+      ? {}
+      : {
+          productPromisesUnsupportedRequestIngest:
+            options.productPromisesUnsupportedRequestIngest,
+        }),
     publicIdentityClaimStore: {
       readVerifiedPublicIdentityForAgentUserId: () =>
         Promise.resolve(
@@ -4168,6 +4177,14 @@ describe('Forum routes', () => {
 
   test('discovers Product Promises as the public product report forum', async () => {
     const store = new ForumRouteStore()
+    const ingested: Array<{
+      bodyText: string
+      firstPostId: string
+      forumId: string
+      sourceRef: string
+      title: string
+      topicId: string
+    }> = []
     const forum = await route(store, '/api/forum/forums/product-promises')
     const topic = await route(
       store,
@@ -4183,6 +4200,10 @@ describe('Forum routes', () => {
           'idempotency-key': 'product-promises-agent-topic-create-1',
         },
         method: 'POST',
+        productPromisesUnsupportedRequestIngest: input => {
+          ingested.push(input)
+          return Promise.resolve()
+        },
       },
     )
 
@@ -4196,6 +4217,95 @@ describe('Forum routes', () => {
       topic: {
         slug: 'promise-report-example-mismatch',
         title: 'Promise report: example mismatch',
+      },
+    })
+    expect(ingested).toStrictEqual([
+      {
+        bodyText:
+          'This product promise report is public-safe and cites a visible claim mismatch.',
+        firstPostId: 'aaaaaaaa-1111-4111-8111-000000000002',
+        forumId: '99999999-3333-4333-8333-999999999999',
+        sourceRef: 'forum.topic:aaaaaaaa-1111-4111-8111-000000000001',
+        title: 'Promise report: example mismatch',
+        topicId: 'aaaaaaaa-1111-4111-8111-000000000001',
+      },
+    ])
+
+    const retry = await route(
+      store,
+      '/api/forum/forums/product-promises/topics',
+      {
+        body: {
+          bodyText:
+            'This product promise report is public-safe and cites a visible claim mismatch.',
+          title: 'Promise report: example mismatch',
+        },
+        headers: {
+          authorization: 'Bearer oa_agent_route_test',
+          'idempotency-key': 'product-promises-agent-topic-create-1',
+        },
+        method: 'POST',
+        productPromisesUnsupportedRequestIngest: input => {
+          ingested.push(input)
+          return Promise.resolve()
+        },
+      },
+    )
+
+    expect(retry.status).toBe(200)
+    await expect(retry.json()).resolves.toMatchObject({ idempotent: true })
+    expect(ingested).toHaveLength(2)
+
+    const otherForumTopic = await route(
+      store,
+      '/api/forum/forums/site-builder-help/topics',
+      {
+        body: {
+          bodyText: 'Question for the site builder forum.',
+          title: 'Site builder question',
+        },
+        headers: {
+          authorization: 'Bearer oa_agent_route_test',
+          'idempotency-key': 'site-builder-topic-create-1',
+        },
+        method: 'POST',
+        productPromisesUnsupportedRequestIngest: input => {
+          ingested.push(input)
+          return Promise.resolve()
+        },
+      },
+    )
+
+    expect(otherForumTopic.status).toBe(201)
+    expect(ingested).toHaveLength(2)
+  })
+
+  test('keeps Product Promises posting available if unsupported-request ingestion fails', async () => {
+    const store = new ForumRouteStore()
+    const topic = await route(
+      store,
+      '/api/forum/forums/product-promises/topics',
+      {
+        body: {
+          bodyText:
+            'This Product Promises post should still publish if the ledger is temporarily unavailable.',
+          title: 'Promise report: ledger outage',
+        },
+        headers: {
+          authorization: 'Bearer oa_agent_route_test',
+          'idempotency-key': 'product-promises-agent-topic-create-fail-soft',
+        },
+        method: 'POST',
+        productPromisesUnsupportedRequestIngest: () =>
+          Promise.reject(new Error('ledger unavailable')),
+      },
+    )
+
+    expect(topic.status).toBe(201)
+    await expect(topic.json()).resolves.toMatchObject({
+      topic: {
+        slug: 'promise-report-ledger-outage',
+        title: 'Promise report: ledger outage',
       },
     })
   })

--- a/apps/openagents.com/workers/api/src/forum-routes.ts
+++ b/apps/openagents.com/workers/api/src/forum-routes.ts
@@ -203,6 +203,10 @@ import type {
 } from './pylon-api'
 import { resolveSparkPayoutDestination } from './pylon-api'
 
+const ProductPromisesForumSlug = 'product-promises'
+const productPromisesUnsupportedRequestSourceRef = (topicId: string): string =>
+  `forum.topic:${topicId}`
+
 type ForumWorkRequestEscrowReserveResult =
   | Readonly<{ ok: true; escrow: LaborEscrowRecord; reserveReceiptRef: string }>
   | Readonly<{ ok: false; availableMsat?: number; reason: string }>
@@ -211,6 +215,9 @@ type ForumRouteDependencies = Readonly<{
   tipsBufferPay?: import('./tips-sweep').BufferPayFn | null
   agentStore?: AgentRegistrationStore
   hostedMdkClient?: OpenAgentsHostedMdkClient
+  productPromisesUnsupportedRequestIngest?: (
+    input: ForumProductPromisesUnsupportedRequestIngestInput,
+  ) => Promise<void>
   forumWorkRequestEscrowReserver?: (
     input: ReserveLaborEscrowInput,
     db: D1Database,
@@ -239,6 +246,15 @@ type ForumRouteDependencies = Readonly<{
   resolveHumanActor?: (
     request: Request,
   ) => Promise<ForumHumanSessionActor | undefined>
+}>
+
+export type ForumProductPromisesUnsupportedRequestIngestInput = Readonly<{
+  bodyText: string
+  firstPostId: string
+  forumId: string
+  sourceRef: string
+  title: string
+  topicId: string
 }>
 
 type ForumAgentWriterActor = Extract<
@@ -1593,6 +1609,38 @@ const paidActionFailureResponse = (error: unknown) => {
   return serverError()
 }
 
+const ingestProductPromisesUnsupportedRequest = (
+  dependencies: ForumRouteDependencies,
+  input: Readonly<{
+    bodyText: string
+    firstPostId: string
+    forumId: string
+    forumSlug: string
+    title: string
+    topicId: string
+  }>,
+) => {
+  if (
+    input.forumSlug !== ProductPromisesForumSlug ||
+    dependencies.productPromisesUnsupportedRequestIngest === undefined
+  ) {
+    return Effect.void
+  }
+
+  return Effect.tryPromise({
+    try: () =>
+      dependencies.productPromisesUnsupportedRequestIngest?.({
+        bodyText: input.bodyText,
+        firstPostId: input.firstPostId,
+        forumId: input.forumId,
+        sourceRef: productPromisesUnsupportedRequestSourceRef(input.topicId),
+        title: input.title,
+        topicId: input.topicId,
+      }) ?? Promise.resolve(),
+    catch: () => undefined,
+  }).pipe(Effect.catch(() => Effect.void), Effect.asVoid)
+}
+
 const createTopicResponse = (
   request: Request,
   db: D1Database,
@@ -1630,6 +1678,21 @@ const createTopicResponse = (
         (existingPost.bodyText ?? '') !== body.bodyText
       ) {
         return idempotencyConflictResponse()
+      }
+
+      const forum = yield* readForumSummaryByRef(db, forumRef, {
+        allowUnlisted: true,
+      })
+
+      if (forum !== null) {
+        yield* ingestProductPromisesUnsupportedRequest(dependencies, {
+          bodyText: existingPost.bodyText ?? '',
+          firstPostId: existingPost.postId,
+          forumId: forum.forumId,
+          forumSlug: forum.slug,
+          title: existingTopic.title,
+          topicId: existingTopic.topicId,
+        })
       }
 
       return noStoreJsonResponse({
@@ -1713,6 +1776,15 @@ const createTopicResponse = (
       slug,
       title: body.title,
       topicId,
+    })
+
+    yield* ingestProductPromisesUnsupportedRequest(dependencies, {
+      bodyText: created.firstPost.bodyText ?? '',
+      firstPostId: created.firstPost.postId,
+      forumId: forum.forumId,
+      forumSlug: forum.slug,
+      title: created.topic.title,
+      topicId: created.topic.topicId,
     })
 
     return noStoreJsonResponse(

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -1894,6 +1894,14 @@ const compactTeamContextText = (value: string, maxLength: number): string => {
     : `${compact.slice(0, Math.max(0, maxLength - 3))}...`
 }
 
+const compactForumLedgerText = (value: string, maxLength: number): string => {
+  const compact = value.replace(/\s+/g, ' ').trim()
+
+  return compact.length <= maxLength
+    ? compact
+    : `${compact.slice(0, Math.max(0, maxLength - 3))}...`
+}
+
 export const selectedTeamFileIdsForAutopilotPrompt = (
   input: Readonly<{
     files: ReadonlyArray<TeamAutopilotContextFile>
@@ -12731,6 +12739,32 @@ const routeRequest = makeWorkerRouteRequest({
       hostedMdkClient: hostedMdkClientForEnv(env),
       l402SigningBoundary: () => forumL402SigningBoundaryForEnv(env),
       mdkWebhookConfig: hostedMdkWebhookConfigForEnv(env),
+      productPromisesUnsupportedRequestIngest: async input => {
+        const db = openAgentsDatabase(env)
+        const now = currentIsoTimestamp()
+        await makeD1KhalaUnsupportedRequestStore(db).upsert({
+          createdAt: now,
+          evidenceRefs: [
+            input.sourceRef,
+            `forum.post:${input.firstPostId}`,
+            'https://openagents.com/forum/f/product-promises',
+          ],
+          forumTopicRef: input.sourceRef,
+          githubIssueRef: null,
+          requestRef: `khala_unsupported:forum_${input.topicId}`,
+          sourceKind: 'forum',
+          sourceRef: input.sourceRef,
+          status: 'open',
+          suggestedIssueTitle: compactForumLedgerText(
+            `[Product Promises] ${input.title}`,
+            180,
+          ),
+          summary: compactForumLedgerText(input.bodyText, 1_000),
+          title: compactForumLedgerText(input.title, 180),
+          triageKind: 'needs_triage',
+          updatedAt: now,
+        })
+      },
       publicIdentityClaimStore: makeD1AgentOwnerClaimStore(
         openAgentsDatabase(env),
       ),


### PR DESCRIPTION
Addresses #6397.

### Changes
- Adds an optional `productPromisesUnsupportedRequestIngest` dependency and `ingestProductPromisesUnsupportedRequest` helper to `workers/api/src/forum-routes.ts`, firing on `product-promises` topic creation (and idempotent retries) to feed new posts into the unsupported-requests ledger; failures are caught so Forum posting stays available.
- Wires the dependency in `workers/api/src/index.ts` to upsert into `makeD1KhalaUnsupportedRequestStore` with `sourceKind:'forum'`, evidence refs (topic/post/forum URL), compacted title/summary, and `needs_triage` status.

### Verification
Not independently re-verified. PR adds forum-route tests asserting ingestion on create, idempotent retry re-ingest, non-product-promises forums skipped, and fail-soft posting when the ledger throws.