### PR TITLE
chore(pylon): advertise per-account supervisor concurrency in heartbeat

### DIFF
--- a/apps/pylon/scripts/claude-supervisor/claude-supervisor.sh
+++ b/apps/pylon/scripts/claude-supervisor/claude-supervisor.sh
@@ -199,6 +199,7 @@ heartbeater_loop() {
     [ "$desired" -gt "$SUP_MAX_SLOTS" ] && desired="$SUP_MAX_SLOTS"
     echo "$desired" > "$DESIRED_FILE"
     OPENAGENTS_PYLON_CLAUDE_CONCURRENCY="$desired" \
+    OPENAGENTS_PYLON_CLAUDE_ACCOUNT_CONCURRENCY="$SUP_PER_ACCOUNT" \
     OPENAGENTS_PYLON_CLAUDE_BUSY=0 \
     OPENAGENTS_PYLON_CLAUDE_QUEUED=0 \
       "${PYLON[@]}" presence heartbeat --json >> "$SUP_LOG" 2>&1 || true

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -187,6 +187,7 @@ heartbeater_loop() {
     [ "$desired" -gt "$SUP_MAX_SLOTS" ] && desired="$SUP_MAX_SLOTS"
     echo "$desired" > "$DESIRED_FILE"
     OPENAGENTS_PYLON_CODEX_CONCURRENCY="$desired" \
+    OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY="$SUP_PER_ACCOUNT" \
     OPENAGENTS_PYLON_CODEX_BUSY=0 \
     OPENAGENTS_PYLON_CODEX_QUEUED=0 \
       "${PYLON[@]}" presence heartbeat --json >> "$SUP_LOG" 2>&1 || true


### PR DESCRIPTION
Does not resolve #6421. The issue requires wiring per-account Claude credential routing in the executor (today `--account-ref claude-pylon-N` fails with 'Pylon account ref is not registered for this provider') plus a per-account capacity gate. This PR only adds a single `OPENAGENTS_PYLON_{CLAUDE,CODEX}_ACCOUNT_CONCURRENCY` env line to the two supervisor shell scripts' heartbeat call. It does not register account refs, does not route per-account Claude credentials in the executor, and does not add the dispatch-gate capacity logic — the actual blocker is untouched.