### PR TITLE
pylon: Implement public issue #6436 and run the named verification. (#6436)

### DIFF
--- a/apps/openagents.com/apps/web/src/routing/startup.test.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.test.ts
@@ -108,6 +108,18 @@ const incompleteAuth = {
 }
 
 describe('startup route policy', () => {
+  test('keeps unknown Forum paths as public NotFound routes', () => {
+    const route = NotFoundRoute({
+      path: '/forum/f/product-promises/not-a-topic',
+    })
+
+    expect(startupRouteForLoggedOut(route)).toEqual({
+      _tag: 'LoggedOutStartupRoute',
+      redirect: Option.none(),
+      route,
+    })
+  })
+
   test('keeps logged-out visitors on the public Pylon scene (now at /pylons)', () => {
     expect(startupRouteForLoggedOut(PylonRoute())).toEqual({
       _tag: 'LoggedOutStartupRoute',

--- a/apps/openagents.com/apps/web/src/routing/startup.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.ts
@@ -17,6 +17,7 @@ import {
   LandingRoute,
   LoggedInRoute,
   LoggedOutRoute,
+  type NotFoundRoute,
   OnboardingRoute,
   homeRouter,
   inviteRouter,
@@ -67,6 +68,9 @@ export const StartupRoute = S.Union([
 export type StartupRoute = typeof StartupRoute.Type
 
 export { routeRequiresAuthBootstrap } from '../product-policy'
+
+const notFoundIsPublicForumRoute = (route: NotFoundRoute): boolean =>
+  route.path === '/forum' || route.path.startsWith('/forum/')
 
 export const startupRouteForLoggedOut = (
   route: AppRoute,
@@ -129,11 +133,18 @@ export const startupRouteForLoggedOut = (
           redirect: Option.none(),
         }),
     ),
-    M.tag('NotFound', () =>
-      LoggedOutStartupRoute({
-        route: LandingRoute(),
-        redirect: Option.some(StartupRedirectToHome({ href: homeRouter() })),
-      }),
+    M.tag('NotFound', route =>
+      notFoundIsPublicForumRoute(route)
+        ? LoggedOutStartupRoute({
+            route,
+            redirect: Option.none(),
+          })
+        : LoggedOutStartupRoute({
+            route: LandingRoute(),
+            redirect: Option.some(
+              StartupRedirectToHome({ href: homeRouter() }),
+            ),
+          }),
     ),
     M.orElse(() =>
       LoggedOutStartupRoute({

--- a/apps/openagents.com/apps/web/src/update.test.ts
+++ b/apps/openagents.com/apps/web/src/update.test.ts
@@ -31,6 +31,7 @@ import {
 import {
   ChatRoute,
   DocsRoute,
+  ForumForumRoute,
   HomeRoute,
   InviteRoute,
   LandingRoute,
@@ -178,6 +179,22 @@ describe('app link routing', () => {
       'LoadPublicKhalaTokensServed',
       'RedirectToHome',
     ])
+  })
+
+  test('keeps unknown Forum URL changes on the NotFound route while logged out', () => {
+    const [model, commands] = update(
+      LoggedOut.init(ForumForumRoute({ forumRef: 'product-promises' })),
+      ChangedUrl({ url: appUrl('/forum/f/product-promises/not-a-topic') }),
+    )
+
+    expect(model).toMatchObject({
+      _tag: 'LoggedOut',
+      route: {
+        _tag: 'NotFound',
+        path: '/forum/f/product-promises/not-a-topic',
+      },
+    })
+    expect(commands.map(command => command.name)).toEqual([])
   })
 
   test('keeps team room routes as internal navigation', () => {

--- a/apps/openagents.com/workers/api/src/forum-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forum-routes.test.ts
@@ -8110,7 +8110,9 @@ describe('Forum routes', () => {
       },
       method: 'POST',
     })
-    const body = await response.json()
+    const body = (await response.json()) as Readonly<{
+      topic: Readonly<{ topicId: string }>
+    }>
 
     expect(response.status).toBe(201)
     expect(body).toMatchObject({
@@ -8123,6 +8125,8 @@ describe('Forum routes', () => {
         postCount: 1,
         slug: 'void-test-thread',
         title: 'Void test thread',
+        topicHref: `/forum/t/${body.topic.topicId}`,
+        webUrl: `https://openagents.com/forum/t/${body.topic.topicId}`,
       },
     })
     expect(store.forums[1]?.topic_count).toBe(1)
@@ -8155,7 +8159,14 @@ describe('Forum routes', () => {
         postNumber: 1,
       },
       idempotent: false,
-      topic: { postCount: 1, title: 'Unclaimed listed thread' },
+      topic: {
+        postCount: 1,
+        title: 'Unclaimed listed thread',
+        topicHref: expect.stringMatching(/^\/forum\/t\/[0-9a-f-]+$/),
+        webUrl: expect.stringMatching(
+          /^https:\/\/openagents\.com\/forum\/t\/[0-9a-f-]+$/,
+        ),
+      },
     })
     expect(store.forums[0]?.topic_count).toBe(2)
   })

--- a/apps/openagents.com/workers/api/src/forum/repository.ts
+++ b/apps/openagents.com/workers/api/src/forum/repository.ts
@@ -1361,6 +1361,7 @@ const ensureReadablePost = (
     : Effect.succeed(post)
 
 const topicFromRow = (row: TopicRow): ForumTopicSummary => {
+  const topicHref = `/forum/t/${encodeURIComponent(row.id)}`
   const topic = {
     author: actorFromJson(row.actor_json),
     createdAt: row.created_at,
@@ -1375,10 +1376,12 @@ const topicFromRow = (row: TopicRow): ForumTopicSummary => {
     slug: row.slug,
     state: row.state,
     title: row.title,
+    topicHref,
     topicId: row.id,
     topicType: row.pin_state,
     updatedAt: row.updated_at,
     viewCount: 0,
+    webUrl: `https://openagents.com${topicHref}`,
   }
 
   return decodeForumTopicSummary({

--- a/apps/openagents.com/workers/api/src/forum/schemas.test.ts
+++ b/apps/openagents.com/workers/api/src/forum/schemas.test.ts
@@ -90,8 +90,10 @@ const topic = {
   slug: 'otc-floating-datacenter',
   state: 'open',
   title: 'OTEC Floating Datacenter',
+  topicHref: '/forum/t/44444444-4444-4444-8444-444444444444',
   topicId: '44444444-4444-4444-8444-444444444444',
   updatedAt: '2026-06-05T18:05:00.000Z',
+  webUrl: 'https://openagents.com/forum/t/44444444-4444-4444-8444-444444444444',
 }
 
 const firstPost = {

--- a/apps/openagents.com/workers/api/src/forum/schemas.ts
+++ b/apps/openagents.com/workers/api/src/forum/schemas.ts
@@ -551,10 +551,12 @@ export const ForumTopicSummary = S.Struct({
   slug: ForumSlug,
   state: ForumTopicState,
   title: S.String,
+  topicHref: S.String,
   topicId: ForumUuid,
   topicType: S.optionalKey(ForumTopicPinState),
   updatedAt: S.String,
   viewCount: S.optionalKey(S.Number),
+  webUrl: S.String,
 })
 export type ForumTopicSummary = typeof ForumTopicSummary.Type
 


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6436

Assignment: assignment.public.khala_coding.chatcmpl_afb4b245cb454e1db856b86cadd439f0
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 7

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.