### PR TITLE
feat(artanis-web): /artanis activity ticker + autonomous decision log

### DIFF
--- a/apps/openagents.com/apps/web/src/docs-blog-route.test.ts
+++ b/apps/openagents.com/apps/web/src/docs-blog-route.test.ts
@@ -529,6 +529,77 @@ describe('docs and blog routes', () => {
               state: 'planned',
             },
           ],
+          decisionLog: {
+            authorityBoundary:
+              'Read-only public-safe decision summary. Grants no dispatch, spend, assignment, settlement, or issue-write authority.',
+            countsByState: {
+              blocked: 1,
+              dispatch_failed: 1,
+              dispatched: 1,
+              no_action: 0,
+            },
+            failureModes: [
+              {
+                count: 1,
+                failureModeRef: 'failure.public.artanis.decision.blocked',
+                label: 'Blocked decisions',
+                latestDecisionRef: 'tick_decision.public_blocked',
+                resultingPublicIssueNumber: null,
+                sourceRefs: [
+                  'route:/api/public/artanis/admin-ticks',
+                  'tick_decision.public_blocked',
+                ],
+                state: 'blocked',
+              },
+              {
+                count: 1,
+                failureModeRef:
+                  'failure.public.artanis.decision.dispatch_failed',
+                label: 'Dispatch failures',
+                latestDecisionRef: 'tick_decision.public_failed',
+                resultingPublicIssueNumber: 6415,
+                sourceRefs: [
+                  'route:/api/public/artanis/admin-ticks',
+                  'tick_decision.public_failed',
+                  'issue.github.6415',
+                ],
+                state: 'dispatch_failed',
+              },
+            ],
+            generatedAtDisplay: 'Just now',
+            sourceRefs: ['route:/api/public/artanis/admin-ticks'],
+            ticker: [
+              {
+                activityRef: 'tick_decision.public_dispatched',
+                assignmentRef: 'assignment.artanis_admin.20260611011429',
+                createdAtDisplay: 'Just now',
+                detail: 'Public-safe assignment decision recorded',
+                issueNumber: 6358,
+                label: 'Executor dispatched',
+                sourceRefs: [
+                  'route:/api/public/artanis/admin-ticks',
+                  'tick_decision.public_dispatched',
+                  'assignment.artanis_admin.20260611011429',
+                  'issue.github.6358',
+                ],
+                state: 'dispatched',
+              },
+              {
+                activityRef: 'tick_decision.public_failed',
+                assignmentRef: null,
+                createdAtDisplay: '2 minutes ago',
+                detail: 'Public-safe decision recorded',
+                issueNumber: 6415,
+                label: 'Dispatch failed',
+                sourceRefs: [
+                  'route:/api/public/artanis/admin-ticks',
+                  'tick_decision.public_failed',
+                  'issue.github.6415',
+                ],
+                state: 'dispatch_failed',
+              },
+            ],
+          },
           displayName: 'Artanis',
           forumLinks: [
             {
@@ -1060,6 +1131,13 @@ describe('docs and blog routes', () => {
       Scene.expect(Scene.text('1 signal needs attention')).toExist(),
       Scene.expect(Scene.text('Accepted-work bitcoin')).toExist(),
       Scene.expect(Scene.text('0.00001000 bitcoin')).toExist(),
+      Scene.expect(Scene.text('The Log')).toExist(),
+      Scene.expect(Scene.text('Live Artanis decisions')).toExist(),
+      Scene.expect(Scene.text('Executor dispatched')).toExist(),
+      Scene.expect(Scene.text('Issue #6358')).toExist(),
+      Scene.expect(Scene.text('The Brain')).toExist(),
+      Scene.expect(Scene.text('Dispatch failures')).toExist(),
+      Scene.expect(Scene.text('Issue #6415')).toExist(),
       Scene.expect(Scene.text('Omega release gate')).toExist(),
       Scene.expect(
         Scene.text('Pylon v0.2 Omega/Nexus release gate is blocked'),

--- a/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
@@ -859,6 +859,42 @@ export const PublicArtanisReportClaimSummary = S.Struct({
 export type PublicArtanisReportClaimSummary =
   typeof PublicArtanisReportClaimSummary.Type
 
+export const PublicArtanisReportActivityTickerEntry = S.Struct({
+  activityRef: S.String,
+  assignmentRef: S.NullOr(S.String),
+  createdAtDisplay: S.String,
+  detail: S.String,
+  issueNumber: S.NullOr(S.Number),
+  label: S.String,
+  sourceRefs: S.Array(S.String),
+  state: S.String,
+})
+export type PublicArtanisReportActivityTickerEntry =
+  typeof PublicArtanisReportActivityTickerEntry.Type
+
+export const PublicArtanisReportDecisionFailureMode = S.Struct({
+  count: S.Number,
+  failureModeRef: S.String,
+  label: S.String,
+  latestDecisionRef: S.NullOr(S.String),
+  resultingPublicIssueNumber: S.NullOr(S.Number),
+  sourceRefs: S.Array(S.String),
+  state: S.String,
+})
+export type PublicArtanisReportDecisionFailureMode =
+  typeof PublicArtanisReportDecisionFailureMode.Type
+
+export const PublicArtanisReportDecisionLog = S.Struct({
+  authorityBoundary: S.String,
+  countsByState: S.Record(S.String, S.Number),
+  failureModes: S.Array(PublicArtanisReportDecisionFailureMode),
+  generatedAtDisplay: S.String,
+  sourceRefs: S.Array(S.String),
+  ticker: S.Array(PublicArtanisReportActivityTickerEntry),
+})
+export type PublicArtanisReportDecisionLog =
+  typeof PublicArtanisReportDecisionLog.Type
+
 export const PublicArtanisReportStateCaveat = S.Struct({
   caveats: S.Array(S.String),
   description: S.String,
@@ -875,6 +911,7 @@ export const PublicArtanisReport = S.Struct({
   autonomousLoop: PublicArtanisReportLoopSummary,
   campaignRef: S.String,
   claimStateCaveats: S.Array(PublicArtanisReportStateCaveat),
+  decisionLog: S.optionalKey(PublicArtanisReportDecisionLog),
   displayName: S.String,
   forumLinks: S.Array(PublicArtanisReportForumLink),
   forumRewardSmoke: PublicArtanisForumRewardSmoke,

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
@@ -15,7 +15,9 @@ import type {
   PublicAgentGoalEvent,
   PublicArtanisForumRewardSmoke,
   PublicArtanisForumRewardVisibility,
+  PublicArtanisReportActivityTickerEntry,
   PublicArtanisProductionLaunchGate,
+  PublicArtanisReportDecisionFailureMode,
   PublicArtanisPylonLaunchCommunication,
   PublicArtanisReport,
   PublicArtanisReportClaimSummary,
@@ -526,6 +528,187 @@ const compactRefs = (
   refs: ReadonlyArray<string>,
   fallback = 'No public refs',
 ): string => (refs.length === 0 ? fallback : refs.slice(0, 3).join(', '))
+
+const tickerIssueLabel = (issueNumber: number | null): string =>
+  issueNumber === null ? 'No linked issue' : `Issue #${issueNumber}`
+
+const artanisTickerRow = (
+  entry: PublicArtanisReportActivityTickerEntry,
+): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    [
+      Ui.className<Message>(
+        'grid min-w-[16rem] gap-2 border border-[#222] bg-[#010102] p-3 sm:min-w-[20rem]',
+      ),
+    ],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex items-center justify-between gap-3 text-[0.6875rem] text-white/35',
+          ),
+        ],
+        [
+          h.span([Ui.className<Message>('uppercase')], [entry.state]),
+          h.span([Ui.className<Message>('tabular-nums')], [
+            entry.createdAtDisplay,
+          ]),
+        ],
+      ),
+      h.div(
+        [Ui.className<Message>('text-[0.8125rem] text-[#f1efe8]')],
+        [entry.label],
+      ),
+      h.div([Ui.className<Message>('text-[0.75rem] text-white/45')], [
+        entry.assignmentRef ?? entry.activityRef,
+      ]),
+      h.div([Ui.className<Message>('text-[0.75rem] text-white/35')], [
+        tickerIssueLabel(entry.issueNumber),
+      ]),
+    ],
+  )
+}
+
+const artanisFailureModeRow = (
+  mode: PublicArtanisReportDecisionFailureMode,
+): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    [
+      Ui.className<Message>(
+        'grid gap-2 border-b border-[#1b1b1b] py-3 last:border-b-0',
+      ),
+    ],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex flex-wrap items-center justify-between gap-3',
+          ),
+        ],
+        [
+          h.span(
+            [Ui.className<Message>('text-[0.8125rem] text-[#f1efe8]')],
+            [mode.label],
+          ),
+          h.span(
+            [Ui.className<Message>('tabular-nums text-[0.75rem] text-white/45')],
+            [formatNumber(mode.count)],
+          ),
+        ],
+      ),
+      h.div([Ui.className<Message>('text-[0.75rem] text-white/35')], [
+        `${tickerIssueLabel(mode.resultingPublicIssueNumber)} / ${
+          mode.latestDecisionRef ?? mode.failureModeRef
+        }`,
+      ]),
+    ],
+  )
+}
+
+const artanisDecisionLogView = (
+  report: PublicArtanisReport,
+): Html | null => {
+  const h = html<Message>()
+  const decisionLog = report.decisionLog
+
+  if (decisionLog === undefined) {
+    return null
+  }
+
+  return h.div(
+    [
+      Ui.className<Message>(
+        'grid gap-3 border border-[#222] bg-[#010102] p-3',
+      ),
+    ],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex flex-wrap items-end justify-between gap-3',
+          ),
+        ],
+        [
+          h.div(
+            [Ui.className<Message>('grid gap-1')],
+            [
+              h.div([Ui.className<Message>(Ui.eyebrowClass)], ['The Log']),
+              h.h3(
+                [
+                  Ui.className<Message>(
+                    'text-lg font-semibold tracking-normal text-[#f1efe8]',
+                  ),
+                ],
+                ['Live Artanis decisions'],
+              ),
+            ],
+          ),
+          h.div(
+            [Ui.className<Message>('text-[0.75rem] text-white/45')],
+            [`Generated ${decisionLog.generatedAtDisplay}`],
+          ),
+        ],
+      ),
+      Array.match(decisionLog.ticker, {
+        onEmpty: () =>
+          h.p(
+            [Ui.className<Message>('text-[0.75rem] text-white/35')],
+            ['No public Artanis decisions are published yet.'],
+          ),
+        onNonEmpty: entries =>
+          h.ol(
+            [
+              Ui.className<Message>(
+                'flex gap-2 overflow-x-auto pb-1 [scrollbar-width:thin]',
+              ),
+            ],
+            entries.map(artanisTickerRow),
+          ),
+      }),
+      h.div(
+        [
+          Ui.className<Message>(
+            'grid gap-3 border-t border-[#222] pt-3 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]',
+          ),
+        ],
+        [
+          h.div(
+            [Ui.className<Message>('grid gap-2')],
+            [
+              h.div([Ui.className<Message>(Ui.eyebrowClass)], ['The Brain']),
+              h.div(
+                [Ui.className<Message>('text-[0.8125rem] text-[#f1efe8]')],
+                ['Autonomous triage summary'],
+              ),
+              h.div(
+                [Ui.className<Message>('text-[0.75rem] text-white/35')],
+                [
+                  `Dispatches ${formatNumber(decisionLog.countsByState.dispatched ?? 0)} / blocked ${formatNumber(decisionLog.countsByState.blocked ?? 0)} / failed ${formatNumber(decisionLog.countsByState.dispatch_failed ?? 0)}`,
+                ],
+              ),
+            ],
+          ),
+          Array.match(decisionLog.failureModes, {
+            onEmpty: () =>
+              h.p(
+                [Ui.className<Message>('text-[0.75rem] text-white/35')],
+                ['No triaged failure modes in the public decision window.'],
+              ),
+            onNonEmpty: modes =>
+              h.ol([Ui.className<Message>('grid')], modes.map(artanisFailureModeRow)),
+          }),
+        ],
+      ),
+      h.div([Ui.className<Message>('text-[0.75rem] text-white/35')], [
+        decisionLog.authorityBoundary,
+      ]),
+    ],
+  )
+}
 
 const bitcoinPrimary = (value: string): string => value.replace(/ \(.+\)$/, '')
 
@@ -1065,6 +1248,7 @@ const artanisReportLoadedView = (report: PublicArtanisReport): Html => {
           ),
         ],
       ),
+      artanisDecisionLogView(report),
       artanisPylonLaunchView(report.pylonLaunchCommunication),
       artanisOmegaReleaseGateView(report.pylonOmegaReleaseGate),
       artanisProductionLaunchGateView(report.productionLaunchGate),

--- a/apps/openagents.com/workers/api/src/artanis-public-report-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-public-report-routes.ts
@@ -17,6 +17,10 @@ import {
   readLatestArtanisPersistedRows,
 } from './artanis-persistence'
 import {
+  type ArtanisTickMonitor,
+  readArtanisTickMonitor,
+} from './artanis-tick-monitor'
+import {
   type PublicPylonStatsStore,
   publicPylonStatsSnapshot,
 } from './public-pylon-stats'
@@ -34,6 +38,7 @@ const routeErrorResponse = (error: ArtanisPublicReportUnsafe) =>
 type PublicArtanisReportRouteInput = Readonly<{
   OPENAGENTS_DB?: D1Database
   loopTicks?: ReadonlyArray<ArtanisLoopTickRecord>
+  tickMonitor?: ArtanisTickMonitor
   store?: PublicPylonStatsStore
 }>
 
@@ -124,6 +129,20 @@ const loopTicksForRoute = (
           ),
         )
 
+const tickMonitorForRoute = (
+  input: PublicArtanisReportRouteInput,
+): Effect.Effect<ArtanisTickMonitor | undefined> =>
+  input.tickMonitor !== undefined
+    ? Effect.succeed(input.tickMonitor)
+    : input.OPENAGENTS_DB === undefined
+      ? Effect.succeed(undefined)
+      : Effect.promise(() =>
+          readArtanisTickMonitor(input.OPENAGENTS_DB as D1Database, {
+            limit: 20,
+            nowIso: new Date().toISOString(),
+          }).catch(() => undefined),
+        )
+
 export const handlePublicArtanisReportApi = (
   request: Request,
   input: PublicArtanisReportRouteInput,
@@ -136,14 +155,16 @@ export const handlePublicArtanisReportApi = (
           store:
             input.store ?? makeD1PylonApiStore(input.OPENAGENTS_DB as D1Database),
         }),
+        tickMonitor: tickMonitorForRoute(input),
       }).pipe(
-        Effect.flatMap(({ loopTicks, pylonStats }) =>
+        Effect.flatMap(({ loopTicks, pylonStats, tickMonitor }) =>
           Effect.try({
             try: () =>
               noStoreJsonResponse(
                 artanisPublicReportSnapshot({
                   loopTicks,
                   pylonStats,
+                  tickMonitor,
                 }),
               ),
             catch: error =>

--- a/apps/openagents.com/workers/api/src/artanis-public-report.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-public-report.test.ts
@@ -12,6 +12,7 @@ import {
   publicNexusPylonReceiptRouteRefsFromRefs,
 } from './artanis-public-report'
 import { handlePublicArtanisReportApi } from './artanis-public-report-routes'
+import { projectArtanisTickMonitor } from './artanis-tick-monitor'
 import { publicPylonStatsFromNexusPayload } from './public-pylon-stats'
 import { publicScannerSafeRef } from './public-ref-scanner-safety'
 
@@ -521,6 +522,74 @@ describe('Artanis public report', () => {
       ]),
     )
     expect(artanisPublicReportHasPrivateMaterial(report)).toBe(false)
+  })
+
+  test('projects public-safe Log and Brain decision summaries from admin ticks', () => {
+    const tickMonitor = projectArtanisTickMonitor(
+      [
+        {
+          action_json: JSON.stringify({
+            rationale:
+              'Public issue #6358 identified the counter-health failure mode.',
+          }),
+          assignment_ref: 'assignment.artanis_admin.20260611011429',
+          created_at: '2026-06-11T01:14:29.000Z',
+          id: 'decision-1',
+          state: 'dispatched',
+        },
+        {
+          action_json: JSON.stringify({
+            reason:
+              'private token leak attempt should redact before the public report',
+          }),
+          assignment_ref: null,
+          created_at: '2026-06-11T01:10:00.000Z',
+          id: 'decision-2',
+          state: 'blocked',
+        },
+        {
+          action_json: JSON.stringify({
+            reason: 'Dispatch failed; triaged to OpenAgentsInc/openagents#6415.',
+          }),
+          assignment_ref: null,
+          created_at: '2026-06-11T01:08:00.000Z',
+          id: 'decision-3',
+          state: 'dispatch_failed',
+        },
+      ],
+      '2026-06-11T01:20:00.000Z',
+    )
+    const report = artanisPublicReportSnapshot({
+      nowIso: '2026-06-11T01:20:00.000Z',
+      pylonStats: publicPylonStatsFromNexusPayload({
+        as_of_unix_ms: Date.parse('2026-06-11T01:20:00.000Z'),
+      }),
+      tickMonitor,
+    })
+    const serialized = JSON.stringify(report)
+
+    expect(report.decisionLog.ticker).toHaveLength(3)
+    expect(report.decisionLog.ticker[0]).toMatchObject({
+      assignmentRef: 'assignment.artanis_admin.20260611011429',
+      issueNumber: 6358,
+      label: 'Executor dispatched',
+    })
+    expect(report.decisionLog.failureModes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          count: 1,
+          label: 'Blocked decisions',
+          resultingPublicIssueNumber: null,
+        }),
+        expect.objectContaining({
+          count: 1,
+          label: 'Dispatch failures',
+          resultingPublicIssueNumber: 6415,
+        }),
+      ]),
+    )
+    expect(artanisPublicReportHasPrivateMaterial(report)).toBe(false)
+    expect(serialized).not.toContain('private token leak')
   })
 
   // Epic #4751 (instance 6, #4745): the report declares its staleness

--- a/apps/openagents.com/workers/api/src/artanis-public-report.ts
+++ b/apps/openagents.com/workers/api/src/artanis-public-report.ts
@@ -42,6 +42,7 @@ import {
   exampleArtanisLoopLedger,
   projectArtanisLoopLedger,
 } from './artanis-loop'
+import type { ArtanisTickMonitor } from './artanis-tick-monitor'
 import {
   exampleArtanisModelLabContext,
   projectArtanisModelLabContext,
@@ -273,6 +274,42 @@ export class ArtanisPublicReportClaimSummary extends S.Class<ArtanisPublicReport
   stateLabel: S.String,
 }) {}
 
+export class ArtanisPublicReportActivityTickerEntry extends S.Class<ArtanisPublicReportActivityTickerEntry>(
+  'ArtanisPublicReportActivityTickerEntry',
+)({
+  activityRef: S.String,
+  assignmentRef: S.NullOr(S.String),
+  createdAtDisplay: S.String,
+  detail: S.String,
+  issueNumber: S.NullOr(S.Number),
+  label: S.String,
+  sourceRefs: S.Array(S.String),
+  state: S.String,
+}) {}
+
+export class ArtanisPublicReportDecisionFailureMode extends S.Class<ArtanisPublicReportDecisionFailureMode>(
+  'ArtanisPublicReportDecisionFailureMode',
+)({
+  count: S.Number,
+  failureModeRef: S.String,
+  label: S.String,
+  latestDecisionRef: S.NullOr(S.String),
+  resultingPublicIssueNumber: S.NullOr(S.Number),
+  sourceRefs: S.Array(S.String),
+  state: S.String,
+}) {}
+
+export class ArtanisPublicReportDecisionLog extends S.Class<ArtanisPublicReportDecisionLog>(
+  'ArtanisPublicReportDecisionLog',
+)({
+  authorityBoundary: S.String,
+  countsByState: S.Record(S.String, S.Number),
+  failureModes: S.Array(ArtanisPublicReportDecisionFailureMode),
+  generatedAtDisplay: S.String,
+  sourceRefs: S.Array(S.String),
+  ticker: S.Array(ArtanisPublicReportActivityTickerEntry),
+}) {}
+
 export class ArtanisPublicReportStateCaveat extends S.Class<ArtanisPublicReportStateCaveat>(
   'ArtanisPublicReportStateCaveat',
 )({
@@ -292,6 +329,7 @@ export class ArtanisPublicReport extends S.Class<ArtanisPublicReport>(
   autonomousLoop: ArtanisPublicReportLoopSummary,
   campaignRef: S.String,
   claimStateCaveats: S.Array(ArtanisPublicReportStateCaveat),
+  decisionLog: ArtanisPublicReportDecisionLog,
   displayName: S.String,
   forumLinks: S.Array(ArtanisPublicReportForumLink),
   forumRewardSmoke: ArtanisForumRewardSmokeProjection,
@@ -914,6 +952,127 @@ const artanisLoopLedgerForReport = (
   })
 }
 
+const publicIssueNumberPattern =
+  /(?:#|issue[:._ -]?|openagentsinc\/openagents#)(\d{2,7})/i
+
+const publicIssueNumberFromText = (value: string): number | null => {
+  const match = publicIssueNumberPattern.exec(value)
+  if (match === null) {
+    return null
+  }
+
+  const parsed = Number(match[1])
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+const decisionStateLabel = (state: string): string =>
+  state === 'dispatched'
+    ? 'Executor dispatched'
+    : state === 'no_action'
+      ? 'No action'
+      : state === 'blocked'
+        ? 'Blocked'
+        : state === 'dispatch_failed'
+          ? 'Dispatch failed'
+          : 'Decision recorded'
+
+const decisionFailureModeLabel = (state: string): string =>
+  state === 'no_action'
+    ? 'No-action decisions'
+    : state === 'blocked'
+      ? 'Blocked decisions'
+      : state === 'dispatch_failed'
+        ? 'Dispatch failures'
+        : 'Other non-dispatch decisions'
+
+const decisionLogFromTickMonitor = (
+  monitor: ArtanisTickMonitor | undefined,
+  nowIso: string,
+): ArtanisPublicReportDecisionLog => {
+  if (monitor === undefined) {
+    return new ArtanisPublicReportDecisionLog({
+      authorityBoundary:
+        'Read-only public-safe decision summary. Grants no dispatch, spend, assignment, settlement, or issue-write authority.',
+      countsByState: {},
+      failureModes: [],
+      generatedAtDisplay: friendlyBlueprintMissionBriefingTime(nowIso, nowIso),
+      sourceRefs: ['route:/api/public/artanis/admin-ticks'],
+      ticker: [],
+    })
+  }
+
+  const ticker = monitor.decisions.slice(0, 12).map(decision => {
+    const issueNumber = publicIssueNumberFromText(decision.reason)
+    return new ArtanisPublicReportActivityTickerEntry({
+      activityRef: decision.decisionRef,
+      assignmentRef: decision.assignmentRef,
+      createdAtDisplay: friendlyBlueprintMissionBriefingTime(
+        decision.createdAt,
+        nowIso,
+      ),
+      detail:
+        decision.assignmentRef === null
+          ? 'Public-safe decision recorded'
+          : 'Public-safe assignment decision recorded',
+      issueNumber,
+      label: decisionStateLabel(decision.state),
+      sourceRefs: uniqueRefs([
+        'route:/api/public/artanis/admin-ticks',
+        decision.decisionRef,
+        ...(decision.assignmentRef === null ? [] : [decision.assignmentRef]),
+        ...(issueNumber === null ? [] : [`issue.github.${issueNumber}`]),
+      ]),
+      state: decision.state,
+    })
+  })
+  const nonDispatchDecisions = monitor.decisions.filter(
+    decision => decision.state !== 'dispatched',
+  )
+  const grouped = nonDispatchDecisions.reduce((groups, decision) => {
+    const current = groups.get(decision.state) ?? []
+    groups.set(decision.state, [...current, decision])
+
+    return groups
+  }, new Map<string, typeof nonDispatchDecisions>())
+  const failureModes = [...grouped.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([state, decisions]) => {
+      const issueNumber =
+        decisions
+          .map(decision => publicIssueNumberFromText(decision.reason))
+          .find((issue): issue is number => issue !== null) ?? null
+      const latestDecision = decisions[0] ?? null
+
+      return new ArtanisPublicReportDecisionFailureMode({
+        count: decisions.length,
+        failureModeRef: `failure.public.artanis.decision.${safeRefSuffix(
+          state,
+        )}`,
+        label: decisionFailureModeLabel(state),
+        latestDecisionRef: latestDecision?.decisionRef ?? null,
+        resultingPublicIssueNumber: issueNumber,
+        sourceRefs: uniqueRefs([
+          'route:/api/public/artanis/admin-ticks',
+          ...(latestDecision === null ? [] : [latestDecision.decisionRef]),
+          ...(issueNumber === null ? [] : [`issue.github.${issueNumber}`]),
+        ]),
+        state,
+      })
+    })
+
+  return new ArtanisPublicReportDecisionLog({
+    authorityBoundary: monitor.authorityBoundary,
+    countsByState: monitor.countsByState,
+    failureModes,
+    generatedAtDisplay: friendlyBlueprintMissionBriefingTime(
+      monitor.generatedAt,
+      nowIso,
+    ),
+    sourceRefs: ['route:/api/public/artanis/admin-ticks'],
+    ticker,
+  })
+}
+
 const probeGepaOutcomeSnapshot = (
   overrides: Partial<ProbeGepaCodingOutcomeMetricSnapshot> = {},
 ): ProbeGepaCodingOutcomeMetricSnapshot =>
@@ -985,6 +1144,7 @@ const exampleProbeGepaOutcomeMetricsProjection =
 
 export const artanisPublicReportSnapshot = (input: {
   forumPublicationQueue?: ArtanisForumPublicationQueueRecord | undefined
+  tickMonitor?: ArtanisTickMonitor | undefined
   loopTicks?: ReadonlyArray<ArtanisLoopTickRecord> | undefined
   nowIso?: string | undefined
   pylonStats: PublicPylonStats
@@ -1051,6 +1211,7 @@ export const artanisPublicReportSnapshot = (input: {
     'public',
     nowIso,
   )
+  const decisionLog = decisionLogFromTickMonitor(input.tickMonitor, nowIso)
   const productionLaunchGate =
     exampleArtanisProductionLaunchGateProjection(nowIso)
   const health = projectArtanisHealthSnapshot(
@@ -1352,6 +1513,7 @@ export const artanisPublicReportSnapshot = (input: {
     },
     campaignRef: campaign.campaignRef,
     claimStateCaveats,
+    decisionLog,
     displayName: runtime.displayName,
     forumLinks,
     forumRewardSmoke,


### PR DESCRIPTION
Addresses #6415.

### Changes
- Adds a public-safe `decisionLog` (ticker entries, failure-mode aggregates with counts/resulting issue number, countsByState, authority-boundary note) to the Artanis report in `workers/api/src/artanis-public-report.ts`, exposed via `artanis-public-report-routes.ts`.
- Adds `PublicArtanisReportActivityTickerEntry`, `PublicArtanisReportDecisionFailureMode`, and `PublicArtanisReportDecisionLog` schemas (decisionLog optional) to `apps/web/src/page/loggedOut/model.ts`.
- Renders The Log (scrolling decision ticker) and The Brain (aggregated failure-mode/decision panel) in `apps/web/src/page/loggedOut/page/publicAgent.ts`, sourced from `/api/public/artanis/admin-ticks` with no raw feedback text.

### Verification
Not independently re-verified. PR adds report fixtures in `artanis-public-report.test.ts` and rendered-scene assertions (The Log/The Brain, issue numbers) in `docs-blog-route.test.ts`.