### PR TITLE
feat(inference): verifier model-family independence + panel diversity gating

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -1312,6 +1312,9 @@ type OpenAgentsReceipt = Readonly<{
   workers?: ReadonlyArray<string> | undefined
   verification_receipt?: string | undefined
   verification_command?: string | undefined
+  verification_integrity?:
+    | KhalaCodeVerificationVerdict['integrity']
+    | undefined
   scalar_reward?: number | undefined
   reward_handoff?: string | undefined
   rubric?:
@@ -1881,6 +1884,7 @@ const openAgentsReceiptForResult = (
     telemetry,
     verification: verdict.verification,
     verification_command: verdict.command.commandRef,
+    verification_integrity: verdict.integrity,
     verification_receipt: verdict.receiptRef,
     verified: verdict.verified,
     workers: [input.adapterId, KHALA_CODE_VERIFIER_WORKER_ID],

--- a/apps/openagents.com/workers/api/src/inference/khala-code-verifier.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-code-verifier.test.ts
@@ -114,6 +114,8 @@ describe('Khala code verifier — honest downgrade (EPIC #6017)', () => {
     expect(verdict.reward.handoffRef).toContain(
       'accepted_outcome.khala_code.crossy_road.',
     )
+    expect(verdict.integrity.passed).toBe(true)
+    expect(verdict.integrity.effectiveIndependentVotes).toBe(1)
   })
 
   test('an executed acceptance suite that did not fully pass is failed with a dense reward', () => {
@@ -124,6 +126,34 @@ describe('Khala code verifier — honest downgrade (EPIC #6017)', () => {
     expect(verdict.scalarReward).toBeGreaterThan(0)
     expect(verdict.scalarReward).toBeLessThan(1)
     expect(verdict.failedChecks.length).toBeGreaterThan(0)
+  })
+
+  test('same-family model verifier panel blocks certification even when execution passed', () => {
+    const verdict = verifyKhalaCodeCompletion({
+      acceptance: executedVerdict(true),
+      content: GOOD_CROSSY_ROAD_HTML,
+      meteringReceiptRef: 'receipt.inference.charge.chatcmpl-fixture',
+      requestId: 'chatcmpl-fixture',
+      servedModel: 'openai/gpt-4.1-mini',
+      verifierPanel: [
+        {
+          model: 'openai/gpt-4.1',
+          verifierRef: 'verifier.public.same_family_gpt',
+        },
+      ],
+      worker: 'fireworks',
+    })
+
+    expect(verdict.executed).toBe(true)
+    expect(verdict.verification).toBe('failed')
+    expect(verdict.verified).toBe(false)
+    expect(verdict.scalarReward).toBe(0)
+    expect(verdict.failedChecks).toContain(
+      'blocker.public.verification_integrity.same_model_family_verifier',
+    )
+    expect(verdict.sourceRefs).toContain(
+      'blocker.public.verification_integrity.same_model_family_verifier',
+    )
   })
 })
 

--- a/apps/openagents.com/workers/api/src/inference/khala-code-verifier.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-code-verifier.ts
@@ -22,6 +22,12 @@
 // and accepts the runner's verdict.
 
 import type { AcceptanceVerdict } from './acceptance-runner/verdict'
+import {
+  assessVerificationIntegrity,
+  type VerificationChannelDefenses,
+  type VerificationIntegrityReport,
+  type VerificationPanelMember,
+} from './verification-integrity'
 
 export const KHALA_CODE_CROSSY_ROAD_RUBRIC_REF =
   'rubric.khala_code.crossy_road.single_html.v1'
@@ -94,6 +100,7 @@ export type KhalaCodeVerificationVerdict = Readonly<{
   passedChecks: ReadonlyArray<string>
   // Whether a real headless acceptance run produced this verdict.
   executed: boolean
+  integrity: VerificationIntegrityReport
   receiptRef: string
   reward: Readonly<{
     handoffRef: string
@@ -113,6 +120,9 @@ export type KhalaCodeVerifierInput = Readonly<{
   requestId: string
   servedModel: string
   worker: string
+  verifierPanel?: ReadonlyArray<VerificationPanelMember> | undefined
+  channelDefenses?: VerificationChannelDefenses | undefined
+  minimumEffectiveIndependentVotes?: number | undefined
   // The executed-acceptance verdict from the out-of-Worker headless runner, when
   // available. PRESENT => the verdict is derived from EXECUTION. ABSENT => honest
   // downgrade to `unverified` (we did not run it).
@@ -389,6 +399,12 @@ export const verifyKhalaCodeCompletion = (
   })
 
   const acceptance = input.acceptance
+  const integrity = assessVerificationIntegrity({
+    channelDefenses: input.channelDefenses,
+    minimumEffectiveIndependentVotes: input.minimumEffectiveIndependentVotes,
+    panel: input.verifierPanel,
+    workerModel: input.servedModel,
+  })
 
   // VERDICT DERIVATION.
   //   - Prescreen failed => `failed` (not even worth running). scalarReward 0.
@@ -415,6 +431,15 @@ export const verifyKhalaCodeCompletion = (
     rubricRef = KHALA_CODE_CROSSY_ROAD_RUBRIC_REF
     summary =
       'Artifact failed the cheap pre-screen (not a runnable single-file HTML game); not executed.'
+  } else if (!integrity.passed) {
+    verification = 'failed'
+    verified = false
+    scalarReward = 0
+    executed = acceptance?.executed === true
+    passedChecks = []
+    failedChecks = integrity.blockerRefs
+    rubricRef = KHALA_CODE_CROSSY_ROAD_RUBRIC_REF
+    summary = `Verification integrity failed: ${integrity.blockerRefs.join(', ')}.`
   } else if (acceptance !== undefined && acceptance.executed) {
     verified = acceptance.verified
     scalarReward = acceptance.scalarReward
@@ -448,6 +473,7 @@ export const verifyKhalaCodeCompletion = (
     command: discoverKhalaCodeVerificationCommand(),
     executed,
     failedChecks,
+    integrity,
     passedChecks,
     prescreen,
     receiptRef,
@@ -467,6 +493,8 @@ export const verifyKhalaCodeCompletion = (
         : [input.meteringReceiptRef]),
       `model:${input.servedModel}`,
       `worker:${input.worker}`,
+      `verifier_independence:${integrity.effectiveIndependentVotes}`,
+      ...integrity.blockerRefs,
     ],
     summary,
     verification,

--- a/apps/openagents.com/workers/api/src/inference/verification-integrity.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/verification-integrity.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  assessVerificationIntegrity,
+  inferVerificationModelFamily,
+} from './verification-integrity'
+
+describe('verification integrity — model-family independence (#6423)', () => {
+  test('normalizes served model ids into coarse model families', () => {
+    expect(inferVerificationModelFamily('accounts/fireworks/models/kimi-k2p7-code')).toBe(
+      'model_family.kimi',
+    )
+    expect(inferVerificationModelFamily('vertex/gemini-2.5-flash')).toBe(
+      'model_family.gemini',
+    )
+    expect(inferVerificationModelFamily('deterministic/browser-acceptance-runner')).toBe(
+      'model_family.deterministic_acceptance_runner',
+    )
+  })
+
+  test('blocks a verifier panel member from the worker model family', () => {
+    const report = assessVerificationIntegrity({
+      panel: [
+        { model: 'openai/gpt-4.1', verifierRef: 'verifier.public.gpt_4_1.a' },
+        { model: 'anthropic/claude-opus-4', verifierRef: 'verifier.public.claude.b' },
+      ],
+      workerModel: 'openai/gpt-4.1-mini',
+    })
+
+    expect(report.passed).toBe(false)
+    expect(report.workerModelFamily).toBe('model_family.openai')
+    expect(report.effectiveIndependentVotes).toBe(1)
+    expect(report.blockerRefs).toContain(
+      'blocker.public.verification_integrity.same_model_family_verifier',
+    )
+  })
+
+  test('measures nominal judges versus effective independent votes by family', () => {
+    const report = assessVerificationIntegrity({
+      minimumEffectiveIndependentVotes: 2,
+      panel: [
+        { model: 'google/gemini-2.5-pro', verifierRef: 'verifier.public.gemini.a' },
+        { model: 'vertex/gemini-2.5-flash', verifierRef: 'verifier.public.gemini.b' },
+        { model: 'anthropic/claude-opus-4', verifierRef: 'verifier.public.claude.c' },
+        { model: 'deepseek/deepseek-v4', verifierRef: 'verifier.public.deepseek.d' },
+      ],
+      workerModel: 'openai/gpt-oss-120b',
+    })
+
+    expect(report.passed).toBe(true)
+    expect(report.nominalVotes).toBe(4)
+    expect(report.effectiveIndependentVotes).toBe(3)
+    expect(report.panelDiversityLabel).toBe(
+      '4 nominal judge(s), 3 effective independent vote(s)',
+    )
+  })
+
+  test('requires paraphrase, cross-model, and steganography channel defenses', () => {
+    const report = assessVerificationIntegrity({
+      channelDefenses: {
+        crossModelReview: false,
+        paraphraseBeforeReview: false,
+        steganographyScan: false,
+      },
+      panel: [{ model: 'anthropic/claude-opus-4', verifierRef: 'verifier.public.claude' }],
+      workerModel: 'openai/gpt-4.1-mini',
+    })
+
+    expect(report.passed).toBe(false)
+    expect(report.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.public.verification_integrity.paraphrase_defense_missing',
+        'blocker.public.verification_integrity.cross_model_review_missing',
+        'blocker.public.verification_integrity.steganography_scan_missing',
+      ]),
+    )
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/verification-integrity.ts
+++ b/apps/openagents.com/workers/api/src/inference/verification-integrity.ts
@@ -1,0 +1,144 @@
+// Verification-panel integrity helpers (#6423).
+//
+// These checks protect the replay/acceptance floor from correlated model-family
+// failures. A verifier panel may have many nominal judges, but same-family judges
+// count as one effective vote, and any model verifier from the worker's own family
+// blocks certification.
+
+export type VerificationChannelDefenses = Readonly<{
+  paraphraseBeforeReview: boolean
+  crossModelReview: boolean
+  steganographyScan: boolean
+}>
+
+export type VerificationPanelMember = Readonly<{
+  verifierRef: string
+  model: string
+}>
+
+export type VerificationIntegrityInput = Readonly<{
+  workerModel: string
+  panel?: ReadonlyArray<VerificationPanelMember> | undefined
+  channelDefenses?: VerificationChannelDefenses | undefined
+  minimumEffectiveIndependentVotes?: number | undefined
+}>
+
+export type VerificationIntegrityReport = Readonly<{
+  workerModelFamily: string
+  verifierModelFamilies: ReadonlyArray<string>
+  nominalVotes: number
+  effectiveIndependentVotes: number
+  minimumEffectiveIndependentVotes: number
+  panelDiversityLabel: string
+  channelDefenses: VerificationChannelDefenses
+  blockerRefs: ReadonlyArray<string>
+  passed: boolean
+}>
+
+const DEFAULT_DETERMINISTIC_VERIFIER: VerificationPanelMember = {
+  model: 'deterministic/browser-acceptance-runner',
+  verifierRef: 'verifier.khala_code.executed_acceptance_suite.v1',
+}
+
+const DEFAULT_CHANNEL_DEFENSES: VerificationChannelDefenses = {
+  crossModelReview: true,
+  paraphraseBeforeReview: true,
+  steganographyScan: true,
+}
+
+const normalize = (value: string): string => value.trim().toLowerCase()
+
+export const inferVerificationModelFamily = (model: string): string => {
+  const value = normalize(model)
+  if (value === '') return 'model_family.unknown'
+  if (value.includes('deterministic') || value.includes('browser-acceptance')) {
+    return 'model_family.deterministic_acceptance_runner'
+  }
+  if (
+    value.includes('gpt') ||
+    value.includes('openai') ||
+    /\bo[134]\b/u.test(value)
+  ) {
+    return 'model_family.openai'
+  }
+  if (value.includes('claude') || value.includes('anthropic')) {
+    return 'model_family.anthropic'
+  }
+  if (value.includes('gemini') || value.includes('google')) {
+    return 'model_family.gemini'
+  }
+  if (value.includes('glm') || value.includes('z-ai') || value.includes('zai')) {
+    return 'model_family.glm'
+  }
+  if (value.includes('deepseek')) return 'model_family.deepseek'
+  if (value.includes('qwen')) return 'model_family.qwen'
+  if (value.includes('kimi') || value.includes('moonshot')) {
+    return 'model_family.kimi'
+  }
+  if (value.includes('llama') || value.includes('meta')) {
+    return 'model_family.llama'
+  }
+  if (value.includes('mistral') || value.includes('mixtral')) {
+    return 'model_family.mistral'
+  }
+  return `model_family.${value.replace(/[^a-z0-9]+/gu, '_').replace(/^_+|_+$/gu, '') || 'unknown'}`
+}
+
+export const assessVerificationIntegrity = (
+  input: VerificationIntegrityInput,
+): VerificationIntegrityReport => {
+  const panel =
+    input.panel === undefined || input.panel.length === 0
+      ? [DEFAULT_DETERMINISTIC_VERIFIER]
+      : input.panel
+  const channelDefenses = input.channelDefenses ?? DEFAULT_CHANNEL_DEFENSES
+  const minimumEffectiveIndependentVotes =
+    input.minimumEffectiveIndependentVotes ?? 1
+  const workerModelFamily = inferVerificationModelFamily(input.workerModel)
+  const verifierModelFamilies = panel.map(member =>
+    inferVerificationModelFamily(member.model),
+  )
+  const uniqueVerifierFamilies = new Set(verifierModelFamilies)
+  const effectiveIndependentVotes = Array.from(uniqueVerifierFamilies).filter(
+    family => family !== workerModelFamily,
+  ).length
+  const blockerRefs: string[] = []
+
+  if (verifierModelFamilies.includes(workerModelFamily)) {
+    blockerRefs.push(
+      'blocker.public.verification_integrity.same_model_family_verifier',
+    )
+  }
+  if (effectiveIndependentVotes < minimumEffectiveIndependentVotes) {
+    blockerRefs.push(
+      'blocker.public.verification_integrity.insufficient_effective_independent_votes',
+    )
+  }
+  if (!channelDefenses.paraphraseBeforeReview) {
+    blockerRefs.push(
+      'blocker.public.verification_integrity.paraphrase_defense_missing',
+    )
+  }
+  if (!channelDefenses.crossModelReview) {
+    blockerRefs.push(
+      'blocker.public.verification_integrity.cross_model_review_missing',
+    )
+  }
+  if (!channelDefenses.steganographyScan) {
+    blockerRefs.push(
+      'blocker.public.verification_integrity.steganography_scan_missing',
+    )
+  }
+
+  return {
+    blockerRefs,
+    channelDefenses,
+    effectiveIndependentVotes,
+    minimumEffectiveIndependentVotes,
+    nominalVotes: panel.length,
+    panelDiversityLabel: `${panel.length} nominal judge(s), ${effectiveIndependentVotes} effective independent vote(s)`,
+    passed: blockerRefs.length === 0,
+    verifierModelFamilies,
+    workerModelFamily,
+  }
+}


### PR DESCRIPTION
Addresses #6423 (Phase 1 hard prerequisite).

### Changes
- Adds `workers/api/src/inference/verification-integrity.ts` with `inferVerificationModelFamily` (coarse model-family normalization) and `assessVerificationIntegrity`, which blocks certification when a verifier shares the worker's model family, measures nominal judges vs effective independent votes ('Nine Judges, Two Effective Votes'), enforces a minimum effective-independent-vote threshold, and requires paraphrase / cross-model / steganography channel defenses.
- Wires the integrity report into `khala-code-verifier.ts`: new `verifierPanel`/`channelDefenses`/`minimumEffectiveIndependentVotes` inputs, a failing verdict (scalarReward 0, blocker refs) when integrity fails, and integrity metadata in source refs.
- Surfaces `verification_integrity` on the OpenAgents receipt in `chat-completions-routes.ts`.

### Verification
Not independently re-verified. PR adds `verification-integrity.test.ts` and extends `khala-code-verifier.test.ts` for same-family panel blocking.

Note: channel defenses are enforced as boolean gates rather than implemented paraphrasing/steganography scanners; remaining EPIC scope may continue beyond this PR.