### PR TITLE
pylon: Implement public issue #6381 and run the named verification. (#6381)

### DIFF
--- a/clients/khala-cli/src/changelog.ts
+++ b/clients/khala-cli/src/changelog.ts
@@ -23,6 +23,7 @@ export const KHALA_CHANGELOG: ReadonlyArray<KhalaChangelogEntry> = [
     version: "0.1.20",
     releasedAt: "2026-06-27T15:43:41.000Z",
     bullets: [
+      "Adds `khala fleet link` - link this local Pylon fleet to your OpenAgents account with the browser + short-code flow and no manual token copying.",
       "Adds `khala fleet connect` — connect your own Codex account to Khala with one short command and a paste-free device login (browser + short code, no long auth strings).",
       "Adds `khala fleet status` — see your connected Codex fleet and readiness; run `khala fleet connect` again to add more accounts (auto-assigned codex, codex-2, …) for more throughput.",
       "Accounts use isolated per-account homes and are registered into your Pylon config; the flow never touches `~/.codex` and never prints tokens.",

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -14,8 +14,10 @@ import {
 import {
   CodexCliMissingError,
   connectFleetAccount,
+  linkFleetToKhala,
   listFleetAccounts,
   type KhalaFleetConnectResult,
+  type KhalaFleetLinkResult,
   type KhalaFleetStatus,
 } from "./fleet.js"
 import { appendPromptHistory, readPromptFromTerminal } from "./input.js"
@@ -65,6 +67,7 @@ type ParsedCommand =
   | { readonly kind: "changelog" }
   | { readonly kind: "feedback"; readonly text: string | undefined }
   | { readonly kind: "fleetConnect"; readonly accountRef: string | undefined; readonly force: boolean }
+  | { readonly kind: "fleetLink" }
   | { readonly kind: "fleetStatus" }
   | { readonly kind: "help" }
   | { readonly kind: "info" }
@@ -179,6 +182,27 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
           process.stderr.write(`${terminalStyle.meta(error.message)}\n`)
           return 1
         }
+        throw error
+      }
+    }
+    if (args.command.kind === "fleetLink") {
+      let waitingDots: { readonly stop: () => void } | undefined
+      try {
+        const result = await linkFleetToKhala({
+          baseUrl: args.baseUrl,
+          env,
+          explicitToken: args.token,
+          openBrowser: openVerificationUrl,
+          onPrompt: prompt => {
+            process.stdout.write(`${formatFleetLinkPrompt(prompt)}\n`)
+            waitingDots = startWaitingDots()
+          },
+        })
+        waitingDots?.stop()
+        process.stdout.write(args.json ? `${JSON.stringify(result)}\n` : `${formatFleetLink(result)}\n`)
+        return 0
+      } catch (error) {
+        waitingDots?.stop()
         throw error
       }
     }
@@ -473,7 +497,9 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     const sub = positional[1]?.trim().toLowerCase()
     if (sub === "status" || sub === "list" || sub === "ls") {
       command = { kind: "fleetStatus" }
-    } else if (sub === undefined || sub === "connect" || sub === "add" || sub === "link") {
+    } else if (sub === "link") {
+      command = { kind: "fleetLink" }
+    } else if (sub === undefined || sub === "connect" || sub === "add") {
       // `khala fleet`, `khala fleet connect`, `khala fleet add` all connect.
       // Optional positional ref: `khala fleet connect codex-2` (or --account).
       command = {
@@ -482,7 +508,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
         force: fleetForce,
       }
     } else {
-      throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet connect\` or \`khala fleet status\`.`)
+      throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet link\`, \`khala fleet connect\`, or \`khala fleet status\`.`)
     }
   } else if (maybeCommand === "codex") {
     command = positional[1] === "status"
@@ -1625,11 +1651,46 @@ function formatFleetConnect(result: KhalaFleetConnectResult): string {
   ].join("\n"))
 }
 
+function formatFleetLinkPrompt(prompt: {
+  readonly userCode: string
+  readonly verificationUrl: string
+  readonly expiresAt: string | undefined
+}): string {
+  const lines = [
+    "To link this local Pylon fleet to your OpenAgents account, open this URL:",
+    `  ${terminalStyle.assistant(prompt.verificationUrl)}`,
+    `Then confirm this code: ${terminalStyle.assistant(prompt.userCode)}`,
+  ]
+  const expiry = formatLoginExpiry(prompt.expiresAt)
+  if (expiry !== undefined) {
+    lines.push(terminalStyle.meta(`The code expires ${expiry}.`))
+  }
+  lines.push(terminalStyle.meta("Waiting for you to finish linking in the browser..."))
+  return lines.join("\n")
+}
+
+function formatFleetLink(result: KhalaFleetLinkResult): string {
+  const who = result.email ?? result.displayName
+  const linkedAs = who === undefined ? "" : ` as ${who}`
+  const status = result.alreadyLinked ? "Already linked" : "Linked"
+  return terminalStyle.meta([
+    `${terminalStyle.assistant("Khala fleet:")} ${status} this local Pylon fleet to OpenAgents${linkedAs}.`,
+    `Pylon home: ${result.pylonHome}`,
+    result.tokenPrefix === undefined ? "Agent token: stored locally" : `Agent token: ${result.tokenPrefix}... stored locally`,
+    "",
+    "Next:",
+    "  khala fleet connect       Connect a Codex account",
+    "  khala fleet status        See your Codex fleet",
+    "  pylon provider go-online  Advertise this Pylon's capacity",
+  ].join("\n"))
+}
+
 function formatFleetStatus(status: KhalaFleetStatus): string {
   if (status.accounts.length === 0) {
     return terminalStyle.meta([
       `${terminalStyle.assistant("Khala fleet:")} No Codex accounts connected yet.`,
-      "Connect one (paste-free device login):",
+      "Link this Pylon to OpenAgents, then connect a Codex account:",
+      "  khala fleet link",
       "  khala fleet connect",
     ].join("\n"))
   }
@@ -1849,6 +1910,7 @@ Usage:
   khala version
   khala changelog
   khala tokens
+  khala fleet link
   khala fleet connect
   khala fleet connect --account codex-2
   khala fleet status

--- a/clients/khala-cli/src/fleet.test.ts
+++ b/clients/khala-cli/src/fleet.test.ts
@@ -9,6 +9,7 @@ import {
   codexConfigWithFileCredentialStore,
   connectFleetAccount,
   decodeCodexIdTokenEmail,
+  linkFleetToKhala,
   listFleetAccounts,
   nextCodexAccountRef,
   parseCodexAccounts,
@@ -16,11 +17,26 @@ import {
   resolvePylonHome,
   upsertCodexAccount,
 } from "./fleet.js"
+import { readStoredAgentToken } from "./token-store.js"
 
 function idTokenFor(email: string): string {
   const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")
   const payload = Buffer.from(JSON.stringify({ email })).toString("base64url")
   return `${header}.${payload}.`
+}
+
+const noSleep = async (): Promise<void> => {}
+
+const PENDING_LINK_BODY = {
+  schema: "openagents.pylon.auth.openagents.v1",
+  status: "pending",
+  attemptId: "pylon_openauth_fleet_link",
+  expiresAt: "2026-06-27T04:12:19.889Z",
+  intervalSeconds: 2,
+  userCode: "LINK-CODE",
+  verificationUrl:
+    "https://example.test/api/pylon/auth/openagents/device/verify?attempt=pylon_openauth_fleet_link&code=LINK-CODE",
+  linkedAgent: { tokenPrefix: "oa_agent_link" },
 }
 
 describe("fleet ref assignment", () => {
@@ -177,5 +193,117 @@ describe("connect + status (with injected device login)", () => {
       { accountRef: "codex", home, email: null, readiness: "credentials_missing", lastLinkedAt: null },
     ])
     void stat // keep import used across runtimes
+  })
+})
+
+describe("fleet OpenAgents link", () => {
+  test("links with the existing device-auth flow and stores the owner-linked token", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-link-"))
+    const env = {
+      KHALA_TOKEN_PATH: join(base, "khala-token"),
+      PYLON_HOME: join(base, ".openagents", "pylon"),
+    }
+    const prompts: Array<{ expiresAt: string | undefined; userCode: string; verificationUrl: string }> = []
+    const urls: Array<string> = []
+    const authHeaders: Array<string | null> = []
+
+    const fakeFetch = (async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const target = String(url)
+      authHeaders.push((init?.headers as Record<string, string> | undefined)?.authorization ?? null)
+      urls.push(target)
+      if (target.endsWith("/api/pylon/auth/openagents/device/start")) {
+        return Response.json(PENDING_LINK_BODY, { status: 201 })
+      }
+      if (target.includes("/api/pylon/auth/openagents/device/pylon_openauth_fleet_link")) {
+        return Response.json(
+          {
+            schema: "openagents.pylon.auth.openagents.v1",
+            status: "linked",
+            linkedAgent: { tokenPrefix: "oa_agent_link" },
+          },
+          { status: 200 },
+        )
+      }
+      if (target.endsWith("/api/agents/me")) {
+        return Response.json(
+          { authenticated: true, agent: { user: { displayName: "Fleet Owner", primaryEmail: "owner@example.com" } } },
+          { status: 200 },
+        )
+      }
+      throw new Error(`unexpected fetch: ${target}`)
+    }) as unknown as typeof fetch
+
+    const result = await linkFleetToKhala({
+      baseUrl: "https://example.test",
+      env,
+      explicitToken: "oa_agent_link_token",
+      fetch: fakeFetch,
+      onPrompt: prompt => prompts.push(prompt),
+      openBrowser: () => {},
+      sleep: noSleep,
+    })
+
+    expect(prompts).toEqual([
+      {
+        expiresAt: PENDING_LINK_BODY.expiresAt,
+        userCode: "LINK-CODE",
+        verificationUrl: PENDING_LINK_BODY.verificationUrl,
+      },
+    ])
+    expect(urls).toContain("https://example.test/api/pylon/auth/openagents/device/start")
+    expect(authHeaders).toContain("Bearer oa_agent_link_token")
+    expect(result).toEqual({
+      alreadyLinked: false,
+      displayName: "Fleet Owner",
+      email: "owner@example.com",
+      pylonHome: env.PYLON_HOME,
+      tokenPrefix: "oa_agent_link",
+    })
+    expect(await readStoredAgentToken(env)).toBe("oa_agent_link_token")
+  })
+
+  test("reports an already-linked fleet without prompting", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-link-"))
+    const env = {
+      KHALA_TOKEN_PATH: join(base, "khala-token"),
+      PYLON_HOME: join(base, ".openagents", "pylon"),
+    }
+    const prompts: Array<unknown> = []
+
+    const fakeFetch = (async (url: Parameters<typeof fetch>[0]) => {
+      const target = String(url)
+      if (target.endsWith("/api/pylon/auth/openagents/device/start")) {
+        return Response.json(
+          {
+            schema: "openagents.pylon.auth.openagents.v1",
+            status: "linked",
+            linkedAgent: { tokenPrefix: "oa_agent_owner" },
+          },
+          { status: 200 },
+        )
+      }
+      if (target.endsWith("/api/agents/me")) {
+        return Response.json(
+          { authenticated: true, agent: { user: { displayName: "Fleet Owner" } } },
+          { status: 200 },
+        )
+      }
+      throw new Error(`unexpected fetch: ${target}`)
+    }) as unknown as typeof fetch
+
+    const result = await linkFleetToKhala({
+      baseUrl: "https://example.test",
+      env,
+      explicitToken: "oa_agent_owner_token",
+      fetch: fakeFetch,
+      onPrompt: prompt => prompts.push(prompt),
+      openBrowser: () => {},
+      sleep: noSleep,
+    })
+
+    expect(prompts).toHaveLength(0)
+    expect(result.alreadyLinked).toBe(true)
+    expect(result.displayName).toBe("Fleet Owner")
+    expect(result.tokenPrefix).toBe("oa_agent_owner")
   })
 })

--- a/clients/khala-cli/src/fleet.ts
+++ b/clients/khala-cli/src/fleet.ts
@@ -3,7 +3,9 @@ import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 
+import { runKhalaLogin, type KhalaLoginPrompt, type KhalaLoginResult } from "./login.js"
 import { spawnProcess } from "./proc.js"
+import { DEFAULT_BASE_URL } from "./types.js"
 
 // `khala fleet` is the dead-simple onboarding surface for connecting your own
 // Codex accounts to Khala so a per-user Artanis can burn down a backlog across
@@ -46,6 +48,14 @@ export type KhalaFleetConnectResult = {
   readonly pylonHome: string
   readonly configPath: string
   readonly status: "connected" | "already_connected"
+}
+
+export type KhalaFleetLinkResult = {
+  readonly alreadyLinked: boolean
+  readonly displayName: string | undefined
+  readonly email: string | undefined
+  readonly pylonHome: string
+  readonly tokenPrefix: string | undefined
 }
 
 export type KhalaCodexDeviceLoginRunner = (input: {
@@ -358,5 +368,44 @@ export async function connectFleetAccount(
     pylonHome,
     configPath,
     status,
+  }
+}
+
+// Link this local Khala/Pylon token to the signed-in OpenAgents account. This
+// is the paste-free Pylon<->Khala ownership step: browser + short code only,
+// no raw token copying. The same linked token is stored in the Khala token
+// store so `khala spawn --strategy pylon` and related calls resolve caller
+// ownership without asking the user to manage OPENAGENTS_AGENT_TOKEN manually.
+export async function linkFleetToKhala(
+  options: {
+    readonly baseUrl?: string | undefined
+    readonly env?: Record<string, string | undefined>
+    readonly explicitToken?: string | undefined
+    readonly fetch?: typeof fetch | undefined
+    readonly onPending?: (() => void) | undefined
+    readonly onPrompt: (prompt: KhalaLoginPrompt) => void
+    readonly openBrowser?: ((url: string) => void) | undefined
+    readonly sleep?: ((ms: number) => Promise<void>) | undefined
+    readonly timeoutSeconds?: number | undefined
+  },
+): Promise<KhalaFleetLinkResult> {
+  const env = options.env ?? process.env
+  const linked: KhalaLoginResult = await runKhalaLogin({
+    baseUrl: options.baseUrl ?? DEFAULT_BASE_URL,
+    env,
+    explicitToken: options.explicitToken,
+    fetch: options.fetch,
+    onPending: options.onPending,
+    onPrompt: options.onPrompt,
+    openBrowser: options.openBrowser,
+    sleep: options.sleep,
+    timeoutSeconds: options.timeoutSeconds,
+  })
+  return {
+    alreadyLinked: linked.alreadyLinked,
+    displayName: linked.displayName,
+    email: linked.email,
+    pylonHome: resolvePylonHome(env),
+    tokenPrefix: linked.tokenPrefix,
   }
 }


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6381

Assignment: assignment.public.khala_coding.chatcmpl_13de1a776289411ea6db3f102463f1be
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 4

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.