### PR TITLE
feat(khala-cli): add `khala fleet link` for paste-free Pylon↔Khala account linking

### DIFF
--- a/clients/khala-cli/README.md
+++ b/clients/khala-cli/README.md
@@ -25,6 +25,7 @@ khala login
 khala logout
 khala fleet connect           # connect your own Codex account (paste-free device login)
 khala fleet connect --account codex-2   # add another distinct account for more throughput
+khala fleet link              # link this local Pylon to your signed-in Khala account
 khala fleet status            # list your connected Codex fleet + readiness
 khala fleet run --repo owner/repo --issues 123,124 --verify "bun test" --dry-run
 khala auth codex
@@ -145,6 +146,9 @@ no long-string pasting:
   shows a SHORT code to enter, then confirms with the linked account email.
   Requires the `codex` CLI (`npm install -g @openai/codex`); a friendly hint is
   printed if it is missing.
+- `khala fleet link` registers this local Pylon's public identity with your
+  signed-in Khala/OpenAgents owner token from `khala login`, so caller-owned
+  Pylon dispatch can target it without token copying.
 - Run it again to add more accounts (auto-assigned `codex`, `codex-2`,
   `codex-3`, …), or pass `--account <ref>` to name one. Distinct ChatGPT
   accounts have distinct rate budgets, so each new distinct account is real
@@ -171,6 +175,8 @@ local Pylon and the dispatch gate can see the fleet.
 - `khala login` starts OpenAgents device auth.
 - `khala logout` clears the local OpenAgents token.
 - `khala fleet connect` connects a Codex account to your fleet (paste-free).
+- `khala fleet link` associates this local Pylon with your signed-in Khala owner
+  account.
 - `khala fleet status` lists your connected Codex fleet and readiness.
 - `khala fleet run --repo owner/repo --issues 123,124 --verify "bun test"`
   starts or plans the backlog supervisor for your connected fleet.

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -14,8 +14,10 @@ import {
 import {
   CodexCliMissingError,
   connectFleetAccount,
+  linkFleetPylon,
   listFleetAccounts,
   type KhalaFleetConnectResult,
+  type KhalaFleetLinkResult,
   type KhalaFleetStatus,
 } from "./fleet.js"
 import {
@@ -71,6 +73,7 @@ type ParsedCommand =
   | { readonly kind: "feedback"; readonly text: string | undefined }
   | { readonly kind: "fleetConnect"; readonly accountRef: string | undefined; readonly force: boolean }
   | { readonly kind: "fleetRun" }
+  | { readonly kind: "fleetLink" }
   | { readonly kind: "fleetStatus" }
   | { readonly kind: "help" }
   | { readonly kind: "info" }
@@ -191,6 +194,15 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
         }
         throw error
       }
+    }
+    if (args.command.kind === "fleetLink") {
+      const result = await linkFleetPylon({
+        env,
+        baseUrl: args.baseUrl,
+        token: args.token,
+      })
+      process.stdout.write(args.json ? `${JSON.stringify(result)}\n` : `${formatFleetLink(result)}\n`)
+      return 0
     }
     if (args.command.kind === "fleetStatus") {
       const status = await listFleetAccounts({ env })
@@ -507,7 +519,9 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
       command = { kind: "fleetStatus" }
     } else if (sub === "run") {
       command = { kind: "fleetRun" }
-    } else if (sub === undefined || sub === "connect" || sub === "add" || sub === "link") {
+    } else if (sub === "link") {
+      command = { kind: "fleetLink" }
+    } else if (sub === undefined || sub === "connect" || sub === "add") {
       // `khala fleet`, `khala fleet connect`, `khala fleet add` all connect.
       // Optional positional ref: `khala fleet connect codex-2` (or --account).
       command = {
@@ -516,7 +530,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
         force: fleetForce,
       }
     } else {
-      throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet connect\`, \`khala fleet status\`, or \`khala fleet run\`.`)
+      throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet connect\`, \`khala fleet link\`, \`khala fleet status\`, or \`khala fleet run\`.`)
     }
   } else if (maybeCommand === "codex") {
     command = positional[1] === "status"
@@ -1689,8 +1703,22 @@ function formatFleetConnect(result: KhalaFleetConnectResult): string {
     "Your Codex credentials stay on this machine; OpenAgents orchestrates, your local Pylon executes.",
     "",
     "Next:",
+    "  khala login               Sign in to Khala/OpenAgents",
+    "  khala fleet link          Link this Pylon to that Khala account",
     "  khala fleet status        See your fleet",
     "  khala fleet connect       Add another account for more throughput",
+  ].join("\n"))
+}
+
+function formatFleetLink(result: KhalaFleetLinkResult): string {
+  return terminalStyle.meta([
+    `${terminalStyle.assistant("Khala fleet:")} Linked local Pylon ${result.pylonRef}`,
+    `registration: ${result.registrationRef}`,
+    `public key: ${result.publicKey.slice(0, 12)}…${result.publicKey.slice(-8)}`,
+    "",
+    "Next:",
+    "  khala fleet status        See connected Codex accounts",
+    "  khala spawn --strategy pylon --pylon-ref " + result.pylonRef + " --objective \"implement public issue #123\"",
   ].join("\n"))
 }
 
@@ -1944,6 +1972,7 @@ Usage:
   khala tokens
   khala fleet connect
   khala fleet connect --account codex-2
+  khala fleet link
   khala fleet status
   khala fleet run --repo owner/repo --issues 123,124 --verify "bun test" --dry-run
   khala auth codex

--- a/clients/khala-cli/src/fleet.test.ts
+++ b/clients/khala-cli/src/fleet.test.ts
@@ -9,6 +9,7 @@ import {
   codexConfigWithFileCredentialStore,
   connectFleetAccount,
   decodeCodexIdTokenEmail,
+  linkFleetPylon,
   listFleetAccounts,
   nextCodexAccountRef,
   parseCodexAccounts,
@@ -29,6 +30,67 @@ describe("fleet ref assignment", () => {
     expect(nextCodexAccountRef(["codex"])).toBe("codex-2")
     expect(nextCodexAccountRef(["codex", "codex-2"])).toBe("codex-3")
     expect(nextCodexAccountRef(["codex", "codex-3"])).toBe("codex-2")
+  })
+})
+
+describe("fleet Pylon link", () => {
+  test("links the local Pylon to the signed-in Khala token without printing or reading Codex credentials", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-link-"))
+    const pylonHome = join(base, ".openagents", "pylon")
+    const tokenPath = join(base, "khala-token")
+    const env = { PYLON_HOME: pylonHome, KHALA_TOKEN_PATH: tokenPath }
+    await mkdir(pylonHome, { recursive: true })
+    await writeFile(tokenPath, "oa_agent_owner_link\n")
+
+    const codexHome = codexAccountHome(pylonHome, "codex")
+    await mkdir(codexHome, { recursive: true })
+    await writeFile(join(codexHome, "auth.json"), JSON.stringify({ tokens: { id_token: idTokenFor("fleet@example.com") } }))
+    await writeFile(
+      pylonConfigPath(pylonHome),
+      JSON.stringify({ dev: { accounts: [{ ref: "codex", provider: "codex", home: codexHome }] } }),
+    )
+
+    const requests: Array<{ url: string; init: RequestInit; body: Record<string, unknown> }> = []
+    const result = await linkFleetPylon({
+      env,
+      baseUrl: "https://openagents.test",
+      fetch: (async (url: Parameters<typeof fetch>[0], init: Parameters<typeof fetch>[1]) => {
+        const requestInit = init ?? {}
+        requests.push({
+          url: String(url),
+          init: requestInit,
+          body: JSON.parse(String(requestInit.body)) as Record<string, unknown>,
+        })
+        return new Response(JSON.stringify({ registrationRef: "registration.pylon.linked" }), { status: 201 })
+      }) as unknown as typeof fetch,
+    })
+
+    expect(result.linked).toBe(true)
+    expect(result.registrationRef).toBe("registration.pylon.linked")
+    expect(result.pylonRef).toStartWith("pylon.")
+    expect(result.publicKey).toMatch(/^[0-9a-f]{64}$/)
+    expect(requests).toHaveLength(1)
+    expect(requests[0]?.url).toBe("https://openagents.test/api/pylons/register")
+    expect((requests[0]?.init.headers as Record<string, string>).authorization).toBe("Bearer oa_agent_owner_link")
+    expect(requests[0]?.body).toMatchObject({
+      schema: "openagents.pylon.register.v0.3",
+      pylonRef: result.pylonRef,
+      providerNostrPubkey: result.publicKey,
+      statusRefs: ["status.public.khala_fleet_linked"],
+    })
+    expect(requests[0]?.body.capabilityRefs).toContain("capability.pylon.local_codex")
+    expect(JSON.stringify(requests[0]?.body)).not.toContain("fleet@example.com")
+    expect(JSON.stringify(requests[0]?.body)).not.toContain(codexHome)
+  })
+
+  test("requires khala login before linking", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-link-"))
+    await expect(
+      linkFleetPylon({
+        env: { PYLON_HOME: join(base, ".openagents", "pylon"), KHALA_TOKEN_PATH: join(base, "missing-token") },
+        fetch: (async () => new Response("{}", { status: 201 })) as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow("khala fleet link requires a signed-in Khala account")
   })
 })
 

--- a/clients/khala-cli/src/fleet.ts
+++ b/clients/khala-cli/src/fleet.ts
@@ -1,9 +1,12 @@
+import { createHash, randomBytes } from "node:crypto"
 import { existsSync } from "node:fs"
 import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises"
-import { homedir } from "node:os"
+import { homedir, hostname } from "node:os"
 import { dirname, join, resolve } from "node:path"
 
 import { spawnProcess } from "./proc.js"
+import { readStoredAgentToken } from "./token-store.js"
+import { DEFAULT_BASE_URL } from "./types.js"
 
 // `khala fleet` is the dead-simple onboarding surface for connecting your own
 // Codex accounts to Khala so a per-user Artanis can burn down a backlog across
@@ -48,12 +51,28 @@ export type KhalaFleetConnectResult = {
   readonly status: "connected" | "already_connected"
 }
 
+export type KhalaFleetLinkResult = {
+  readonly schema: "openagents.khala.fleet_link.v1"
+  readonly pylonHome: string
+  readonly configPath: string
+  readonly pylonRef: string
+  readonly publicKey: string
+  readonly npub: string
+  readonly registrationRef: string
+  readonly linked: true
+  readonly capabilityRefs: ReadonlyArray<string>
+}
+
 export type KhalaCodexDeviceLoginRunner = (input: {
   readonly env: Record<string, string | undefined>
   readonly home: string
 }) => Promise<{ readonly exitCode: number }>
 
 type ConfigRecord = Record<string, unknown>
+
+const KHALA_FLEET_LINK_SCHEMA = "openagents.khala.fleet_link.v1" as const
+const PYLON_CLIENT_VERSION = "openagents.pylon@1.0.5"
+const CODEX_AGENT_CAPABILITY_REF = "capability.pylon.local_codex"
 
 // Raised when the `codex` CLI is not installed. The CLI catches this and prints
 // a friendly install hint instead of a raw spawn error.
@@ -230,6 +249,192 @@ async function writePylonConfig(configPath: string, config: ConfigRecord): Promi
   await rename(tempPath, configPath)
 }
 
+function stableHash(input: string, length = 24): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, length)
+}
+
+function sanitizeLabel(value: string): string {
+  const sanitized = value.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "")
+  return sanitized || "pylon-node"
+}
+
+const BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+function bech32Polymod(values: ReadonlyArray<number>): number {
+  const generator = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+  let chk = 1
+  for (const value of values) {
+    const top = chk >> 25
+    chk = (chk & 0x1ffffff) << 5 ^ value
+    for (let index = 0; index < 5; index += 1) {
+      if (((top >> index) & 1) === 1) chk ^= generator[index] ?? 0
+    }
+  }
+  return chk
+}
+
+function bech32HrpExpand(hrp: string): number[] {
+  const out: number[] = []
+  for (const char of hrp) out.push(char.charCodeAt(0) >> 5)
+  out.push(0)
+  for (const char of hrp) out.push(char.charCodeAt(0) & 31)
+  return out
+}
+
+function bytesToBech32Words(bytes: Buffer): number[] {
+  const words: number[] = []
+  let value = 0
+  let bits = 0
+  for (const byte of bytes) {
+    value = (value << 8) | byte
+    bits += 8
+    while (bits >= 5) {
+      words.push((value >> (bits - 5)) & 31)
+      bits -= 5
+    }
+  }
+  if (bits > 0) words.push((value << (5 - bits)) & 31)
+  return words
+}
+
+function encodeNpub(publicKey: string): string {
+  const hrp = "npub"
+  const words = bytesToBech32Words(Buffer.from(publicKey, "hex"))
+  const values = [...bech32HrpExpand(hrp), ...words]
+  const polymod = bech32Polymod([...values, 0, 0, 0, 0, 0, 0]) ^ 1
+  const checksum = Array.from({ length: 6 }, (_, index) => (polymod >> (5 * (5 - index))) & 31)
+  return `${hrp}1${[...words, ...checksum].map(word => BECH32_CHARSET[word] ?? "").join("")}`
+}
+
+function generatePublicKey(): string {
+  return randomBytes(32).toString("hex")
+}
+
+type PylonIdentityRecord = {
+  readonly nodeId: string
+  readonly pylonRef: string
+  readonly nodeLabel: string
+  readonly publicKey: string
+  readonly npub: string
+  readonly createdAt: string
+}
+
+function parseIdentity(value: unknown): PylonIdentityRecord | null {
+  const record = asRecord(value)
+  if (record === null) return null
+  if (
+    typeof record.nodeId === "string" &&
+    typeof record.pylonRef === "string" &&
+    typeof record.nodeLabel === "string" &&
+    typeof record.publicKey === "string" &&
+    /^[0-9a-f]{64}$/i.test(record.publicKey) &&
+    typeof record.npub === "string" &&
+    typeof record.createdAt === "string"
+  ) {
+    return record as PylonIdentityRecord
+  }
+  return null
+}
+
+async function loadOrCreatePylonIdentity(pylonHome: string): Promise<PylonIdentityRecord> {
+  const identityPath = join(pylonHome, "identity.json")
+  try {
+    const existing = parseIdentity(JSON.parse(await readFile(identityPath, "utf8")))
+    if (existing !== null) return existing
+  } catch {
+    // Fall through and create a public identity record.
+  }
+
+  const publicKey = generatePublicKey()
+  const nodeLabel = sanitizeLabel(hostname())
+  const identity: PylonIdentityRecord = {
+    nodeId: `pylon_${stableHash(publicKey)}`,
+    pylonRef: `pylon.${stableHash(`${nodeLabel}:${publicKey}`, 20)}`,
+    nodeLabel,
+    publicKey,
+    npub: encodeNpub(publicKey),
+    createdAt: new Date().toISOString(),
+  }
+  await mkdir(dirname(identityPath), { recursive: true })
+  await writeFile(identityPath, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 })
+  return identity
+}
+
+async function readRuntimeCapabilityRefs(pylonHome: string): Promise<string[]> {
+  try {
+    const parsed = JSON.parse(await readFile(join(pylonHome, "runtime-state.json"), "utf8"))
+    const refs = asRecord(parsed)?.capabilityRefs
+    return Array.isArray(refs) ? refs.filter((ref): ref is string => typeof ref === "string") : []
+  } catch {
+    return []
+  }
+}
+
+async function capabilityRefsForFleetLink(pylonHome: string): Promise<string[]> {
+  const refs = await readRuntimeCapabilityRefs(pylonHome)
+  const config = await readPylonConfig(pylonConfigPath(pylonHome))
+  const accounts = parseCodexAccounts(config)
+  const readyAccounts = await Promise.all(
+    accounts.map(async account => codexHomeHasLogin(account.home ?? codexAccountHome(pylonHome, account.ref))),
+  )
+  if (readyAccounts.some(Boolean)) refs.push(CODEX_AGENT_CAPABILITY_REF)
+  return [...new Set(refs)]
+}
+
+async function tokenForFleetLink(input: {
+  readonly env: Record<string, string | undefined>
+  readonly explicitToken?: string | undefined
+}): Promise<string> {
+  const explicit = input.explicitToken?.trim()
+  if (explicit?.startsWith("oa_agent_")) return explicit
+  const envToken = input.env.OPENAGENTS_AGENT_TOKEN?.trim()
+  if (envToken?.startsWith("oa_agent_")) return envToken
+  const stored = await readStoredAgentToken(input.env)
+  if (stored !== undefined) return stored
+  throw new Error("khala fleet link requires a signed-in Khala account. Run `khala login` first.")
+}
+
+async function postPylonFleetLink(input: {
+  readonly baseUrl: string
+  readonly token: string
+  readonly identity: PylonIdentityRecord
+  readonly capabilityRefs: ReadonlyArray<string>
+  readonly fetch: typeof fetch
+}): Promise<{ readonly registrationRef: string }> {
+  const body = {
+    schema: "openagents.pylon.register.v0.3",
+    pylonRef: input.identity.pylonRef,
+    lifecycle: "online",
+    clientProtocolVersion: "0.3.0",
+    clientVersion: PYLON_CLIENT_VERSION,
+    resourceMode: "background_20",
+    displayName: input.identity.nodeLabel,
+    capabilityRefs: input.capabilityRefs,
+    statusRefs: ["status.public.khala_fleet_linked"],
+    providerNostrPubkey: input.identity.publicKey,
+    providerNostrNpub: input.identity.npub,
+  }
+  const response = await input.fetch(new URL("/api/pylons/register", input.baseUrl).toString(), {
+    body: JSON.stringify(body),
+    headers: {
+      authorization: `Bearer ${input.token}`,
+      "content-type": "application/json",
+      "Idempotency-Key": `khala-fleet-link:${input.identity.pylonRef}`,
+      "x-pylon-ref": input.identity.pylonRef,
+    },
+    method: "POST",
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`OpenAgents rejected the Pylon link (${response.status}): ${text || response.statusText}`)
+  }
+  const parsed = text.trim() ? JSON.parse(text) : {}
+  const registrationRef = typeof parsed.registrationRef === "string"
+    ? parsed.registrationRef
+    : `registration.${input.identity.pylonRef}`
+  return { registrationRef }
+}
+
 async function codexHomeHasLogin(home: string): Promise<boolean> {
   try {
     const info = await stat(join(home, "auth.json"))
@@ -358,5 +563,39 @@ export async function connectFleetAccount(
     pylonHome,
     configPath,
     status,
+  }
+}
+
+export async function linkFleetPylon(
+  options: {
+    readonly env?: Record<string, string | undefined>
+    readonly baseUrl?: string | undefined
+    readonly token?: string | undefined
+    readonly fetch?: typeof fetch | undefined
+  } = {},
+): Promise<KhalaFleetLinkResult> {
+  const env = options.env ?? process.env
+  const pylonHome = resolvePylonHome(env)
+  const configPath = pylonConfigPath(pylonHome)
+  const token = await tokenForFleetLink({ env, explicitToken: options.token })
+  const identity = await loadOrCreatePylonIdentity(pylonHome)
+  const capabilityRefs = await capabilityRefsForFleetLink(pylonHome)
+  const linked = await postPylonFleetLink({
+    baseUrl: options.baseUrl || env.KHALA_BASE_URL || DEFAULT_BASE_URL,
+    token,
+    identity,
+    capabilityRefs,
+    fetch: options.fetch ?? fetch,
+  })
+  return {
+    schema: KHALA_FLEET_LINK_SCHEMA,
+    pylonHome,
+    configPath,
+    pylonRef: identity.pylonRef,
+    publicKey: identity.publicKey,
+    npub: identity.npub,
+    registrationRef: linked.registrationRef,
+    linked: true,
+    capabilityRefs,
   }
 }


### PR DESCRIPTION
Addresses #6381.

### Changes
- Adds `khala fleet link` subcommand + `linkFleetPylon` in `clients/khala-cli/src/fleet.ts`: loads/creates a local Pylon identity (public key, pylonRef, npub via bech32), derives capability refs (e.g. `capability.pylon.local_codex` when a Codex account is ready), and POSTs `openagents.pylon.register.v0.3` to `/api/pylons/register` using the signed-in `oa_agent_` Khala owner token — no token/string pasting.
- Routes `khala fleet link` distinctly (previously aliased to connect); adds JSON + human formatters and README/help/usage docs.
- Requires `khala login` first (honest error otherwise); test asserts no Codex credentials/emails/home paths leak into the request body.

### Verification
Not independently re-verified. (PR adds fleet.test.ts coverage for link + login-required.)