### PR TITLE
pylon: Implement public issue #6394 and run the named verification. (#6394)

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
@@ -1094,6 +1094,127 @@ describe('POST /api/operator/artanis/chat — update_unsupported_request accepta
   })
 })
 
+describe('POST /api/operator/artanis/chat — open_issue_for_unsupported_request acceptance', () => {
+  test('opens a GitHub issue for a needs_issue row and links it through the loop', async () => {
+    const KNOWN_REF = 'khala_unsupported:ur_issue_1'
+    const requests: Array<InferenceRequest> = []
+    let round = 0
+    const client = (request: InferenceRequest) => {
+      requests.push(request)
+      round += 1
+      if (round === 1) {
+        return Effect.succeed(
+          toolCallResult(
+            'open_issue_for_unsupported_request',
+            JSON.stringify({ ref: KNOWN_REF }),
+          ),
+        )
+      }
+      const toolResult = lastToolResultContent(request) ?? ''
+      return Effect.succeed({
+        content: `Filed and linked it. ${toolResult}`,
+        finishReason: 'stop' as const,
+        servedModel: 'gpt-oss-120b',
+        usage: { completionTokens: 20, promptTokens: 300, totalTokens: 320 },
+      } satisfies InferenceResult)
+    }
+
+    const sourceRow = {
+      evidenceRefs: ['trace_review.bucket.local_git_diff'],
+      githubIssueRef: null,
+      nextAction: 'open_github_issue',
+      requestRef: KNOWN_REF,
+      sourceKind: 'trace_review',
+      status: 'needs_issue',
+      suggestedIssueTitle:
+        '[Khala unsupported] Khala cannot read the local git diff',
+      summary: 'Users ask Khala to read their local git diff before answering.',
+      title: 'Khala cannot read the local git diff',
+      triageKind: 'missing_capability',
+      updatedAt: '2026-06-27T11:00:00.000Z',
+    } as const
+    let createdIssue: unknown
+    let receivedUpdate: unknown
+    const { deps } = baseDeps({
+      makeKhalaClient: () => client,
+      makeOperatorTools: () =>
+        makeArtanisOperatorTools({
+          unsupportedRequestIssueCreator: async input => {
+            createdIssue = input
+            return {
+              kind: 'created',
+              number: 6401,
+              url: 'https://github.com/OpenAgentsInc/openagents/issues/6401',
+            }
+          },
+          unsupportedRequestWriter: async update => {
+            receivedUpdate = update
+            return {
+              ...sourceRow,
+              githubIssueRef: update.githubIssueRef ?? null,
+              nextAction: 'none',
+              status: update.status ?? sourceRow.status,
+              updatedAt: '2026-06-27T12:00:00.000Z',
+            }
+          },
+          unsupportedRequests: {
+            reader: async input => {
+              expect(input).toEqual({ limit: 100, status: 'needs_issue' })
+              return [sourceRow]
+            },
+          },
+        }),
+    })
+
+    const response = await runRoute(
+      deps,
+      post({
+        messages: [
+          {
+            content:
+              'Open the GitHub issue for unsupported request khala_unsupported:ur_issue_1',
+            role: 'user',
+          },
+        ],
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as Record<string, unknown>
+    const invocations = json.toolInvocations as ReadonlyArray<{
+      name: string
+      executed: boolean
+      deferredToApprovalGate: boolean
+      riskyActionKind: string | null
+    }>
+    const invocation = invocations.find(
+      item => item.name === 'open_issue_for_unsupported_request',
+    )
+    expect(invocation).toEqual({
+      deferredToApprovalGate: false,
+      executed: true,
+      executedRef: null,
+      name: 'open_issue_for_unsupported_request',
+      riskyActionKind: null,
+    })
+    expect(createdIssue).toEqual({
+      body: expect.stringContaining('trace_review.bucket.local_git_diff'),
+      labels: ['khala', 'unsupported-request'],
+      title: '[Khala unsupported] Khala cannot read the local git diff',
+    })
+    expect(receivedUpdate).toEqual({
+      githubIssueRef: 'OpenAgentsInc/openagents#6401',
+      ref: KNOWN_REF,
+      status: 'issue_opened',
+      triageKind: undefined,
+    })
+    expect(json.reply as string).toContain('Opened GitHub issue #6401')
+    expect(json.reply as string).toContain('status: issue_opened')
+    expect(json.deferredToApprovalGate).toBe(false)
+    expect(requests.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // get_trace_review acceptance — Artanis's iteration-11 self-improvement
 // capability drives the REAL bounded tool-calling loop through the chat

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -27,6 +27,7 @@ import {
   makeArtanisListGithubIssuesTool,
   makeArtanisListPylonAssignmentsTool,
   makeArtanisListRepoDirTool,
+  makeArtanisOpenUnsupportedRequestIssueTool,
   makeArtanisOperatorTools,
   makeArtanisReadGithubIssueTool,
   makeArtanisReadRepoFileTool,
@@ -2216,6 +2217,125 @@ describe('get_trace_review (live Khala trace-review report) - iteration 11', () 
   })
 })
 
+describe('open_issue_for_unsupported_request (GitHub issue create + ledger link) — #6394', () => {
+  const baseRow: ArtanisUnsupportedRequestRecord = {
+    evidenceRefs: [
+      'trace_review.bucket.local_git_diff',
+      'khala_feedback:fb_public_1',
+    ],
+    githubIssueRef: null,
+    nextAction: 'open_github_issue',
+    requestRef: 'khala_unsupported:ur_issue_1',
+    sourceKind: 'trace_review',
+    status: 'needs_issue',
+    suggestedIssueTitle:
+      '[Khala unsupported] Khala cannot read the local git diff',
+    summary: 'Users ask Khala to read their local git diff before answering.',
+    title: 'Khala cannot read the local git diff',
+    triageKind: 'missing_capability',
+    updatedAt: '2026-06-27T11:00:00.000Z',
+  }
+
+  test('creates a public GitHub issue for a needs_issue row, then links issue_opened', async () => {
+    const createdIssues: Array<unknown> = []
+    const updates: Array<unknown> = []
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      issueCreator: async input => {
+        createdIssues.push(input)
+        return {
+          kind: 'created',
+          number: 6399,
+          url: 'https://github.com/OpenAgentsInc/openagents/issues/6399',
+        }
+      },
+      reader: async input => {
+        expect(input).toEqual({ limit: 100, status: 'needs_issue' })
+        return [baseRow]
+      },
+      writer: async update => {
+        updates.push(update)
+        return {
+          ...baseRow,
+          githubIssueRef: update.githubIssueRef ?? null,
+          nextAction: 'none',
+          status: update.status ?? baseRow.status,
+          updatedAt: '2026-06-27T12:00:00.000Z',
+        }
+      },
+    })
+
+    expect(tool.kind).toBe('write')
+    expect(tool.definition.name).toBe('open_issue_for_unsupported_request')
+
+    const result = await Effect.runPromise(
+      tool.execute({ ref: 'khala_unsupported:ur_issue_1' }),
+    )
+
+    expect(createdIssues).toEqual([
+      {
+        body: expect.stringContaining('trace_review.bucket.local_git_diff'),
+        labels: ['khala', 'unsupported-request'],
+        title: '[Khala unsupported] Khala cannot read the local git diff',
+      },
+    ])
+    expect(JSON.stringify(createdIssues)).not.toMatch(
+      /bearer|secret|\/Users\/|wallet|raw[_-]?prompt/i,
+    )
+    expect(updates).toEqual([
+      {
+        githubIssueRef: 'OpenAgentsInc/openagents#6399',
+        ref: 'khala_unsupported:ur_issue_1',
+        status: 'issue_opened',
+        triageKind: undefined,
+      },
+    ])
+    expect(result).toContain('Opened GitHub issue #6399')
+    expect(result).toContain('status: issue_opened')
+    expect(result).toContain('linked issue: OpenAgentsInc/openagents#6399')
+  })
+
+  test('does not write the ledger when GitHub issue creation is rejected', async () => {
+    const updates: Array<unknown> = []
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      issueCreator: async () => ({
+        kind: 'rejected',
+        reason: 'github_issue_token_missing',
+      }),
+      reader: async () => [baseRow],
+      writer: async update => {
+        updates.push(update)
+        return baseRow
+      },
+    })
+
+    const result = await Effect.runPromise(
+      tool.execute({ ref: 'khala_unsupported:ur_issue_1' }),
+    )
+
+    expect(result).toContain('github_issue_token_missing')
+    expect(updates).toEqual([])
+  })
+
+  test('refuses a non-needs_issue row before creating an issue', async () => {
+    const createdIssues: Array<unknown> = []
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      issueCreator: async input => {
+        createdIssues.push(input)
+        return { kind: 'created', number: 6400, url: 'issue-url' }
+      },
+      reader: async () => [{ ...baseRow, status: 'open' }],
+      writer: async () => baseRow,
+    })
+
+    const result = await Effect.runPromise(
+      tool.execute({ ref: 'khala_unsupported:ur_issue_1' }),
+    )
+
+    expect(result).toContain('not needs_issue')
+    expect(createdIssues).toEqual([])
+  })
+})
+
 describe('makeArtanisOperatorTools default table', () => {
   test('includes the repo-read tools, the issue-read tool, the network-stats tool, the job-status tool, and the dispatch tool', () => {
     const tools = makeArtanisOperatorTools()
@@ -2232,6 +2352,7 @@ describe('makeArtanisOperatorTools default table', () => {
       'list_github_issues',
       'list_pylon_assignments',
       'list_repo_dir',
+      'open_issue_for_unsupported_request',
       'read_github_issue',
       'read_repo_file',
       'trigger_synthetic_load',

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -1511,6 +1511,10 @@ export type ArtanisUnsupportedRequestRecord = Readonly<{
   githubIssueRef: string | null
   // The next action the ledger derived, e.g. 'open_github_issue' | 'triage'.
   nextAction: string
+  // Public-safe evidence refs that may be copied into a GitHub issue body.
+  evidenceRefs?: ReadonlyArray<string> | undefined
+  // Optional public-safe issue title suggested by the ledger.
+  suggestedIssueTitle?: string | undefined
   // Public-safe "last updated" display string.
   updatedAt: string
 }>
@@ -1603,6 +1607,13 @@ const unsupportedRequestRecordIsSafe = (
   dispatchFieldIsSafe(record.status) &&
   dispatchFieldIsSafe(record.sourceKind) &&
   dispatchFieldIsSafe(record.nextAction) &&
+  (record.suggestedIssueTitle === undefined ||
+    (record.suggestedIssueTitle.trim() !== '' &&
+      dispatchFieldIsSafe(record.suggestedIssueTitle))) &&
+  (record.evidenceRefs === undefined ||
+    record.evidenceRefs.every(
+      ref => dispatchFieldIsSafe(ref) && isSafeArtanisAssignmentRef(ref),
+    )) &&
   (record.githubIssueRef === null ||
     dispatchFieldIsSafe(record.githubIssueRef))
 
@@ -2019,6 +2030,254 @@ export const makeArtanisUpdateUnsupportedRequestTool = (
           return `(not found: no unsupported request matches ref "${ref.value}")`
         }
         return formatUpdatedUnsupportedRequest(updated)
+      }),
+    kind: 'write',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// open_issue_for_unsupported_request — CREATE + LINK a GitHub issue for one
+// needs_issue ledger row (#6394).
+//
+// This is the outward half of the unsupported-request lifecycle. It is a WRITE
+// tool (not spend/destructive/risky): owner-scoped, fixed public repo only, and
+// public-safe text/refs only. It does exactly one external mutation, creating a
+// GitHub issue from an existing `needs_issue` row, then updates that same row to
+// `issue_opened` ONLY after GitHub returns the issue number. If any precondition
+// fails, no ledger write is attempted.
+// ---------------------------------------------------------------------------
+
+export type ArtanisGithubIssueCreateInput = Readonly<{
+  title: string
+  body: string
+  labels: ReadonlyArray<string>
+}>
+
+export type ArtanisGithubIssueCreateResult =
+  | Readonly<{ kind: 'created'; number: number; url: string }>
+  | Readonly<{ kind: 'rejected'; reason: string }>
+
+export type ArtanisGithubIssueCreator = (
+  input: ArtanisGithubIssueCreateInput,
+) => Promise<ArtanisGithubIssueCreateResult>
+
+export type ArtanisOpenUnsupportedRequestIssueConfig = Readonly<{
+  reader?: ArtanisUnsupportedRequestsReader | undefined
+  writer?: ArtanisUnsupportedRequestWriter | undefined
+  issueCreator?: ArtanisGithubIssueCreator | undefined
+  maxScan?: number | undefined
+}>
+
+const ARTANIS_UNSUPPORTED_REQUEST_ISSUE_LABELS = [
+  'khala',
+  'unsupported-request',
+] as const
+
+const issueTitleForUnsupportedRequest = (
+  record: ArtanisUnsupportedRequestRecord,
+): string => {
+  const suggested = record.suggestedIssueTitle?.trim()
+  const title =
+    suggested !== undefined && suggested !== '' ? suggested : record.title
+  return boundText(title.replace(/\s+/g, ' ').trim(), 180)
+}
+
+const issueBodyForUnsupportedRequest = (
+  record: ArtanisUnsupportedRequestRecord,
+): string => {
+  const evidenceRefs = (record.evidenceRefs ?? []).filter(
+    ref => dispatchFieldIsSafe(ref) && isSafeArtanisAssignmentRef(ref),
+  )
+  const evidence =
+    evidenceRefs.length === 0
+      ? '- (none supplied)'
+      : evidenceRefs.map(ref => `- ${ref}`).join('\n')
+  const summary =
+    record.summary.trim() === '' ? record.title : record.summary.trim()
+  return [
+    '## Unsupported Request',
+    '',
+    boundText(summary, 1_200),
+    '',
+    '## Ledger',
+    '',
+    `- Ref: ${record.requestRef}`,
+    `- Status: ${record.status}`,
+    `- Triage kind: ${record.triageKind}`,
+    `- Source kind: ${record.sourceKind}`,
+    `- Opened from: open_issue_for_unsupported_request`,
+    '',
+    '## Public Evidence Refs',
+    '',
+    evidence,
+  ].join('\n')
+}
+
+export const makeGitHubIssueCreator = (
+  config: Readonly<{
+    token?: string | undefined
+    owner?: string | undefined
+    repo?: string | undefined
+    fetchImpl?: typeof fetch | undefined
+  }> = {},
+): ArtanisGithubIssueCreator => {
+  const token = config.token?.trim()
+  const owner = config.owner ?? ARTANIS_REPO_READ_OWNER
+  const repo = config.repo ?? ARTANIS_REPO_READ_REPO
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch
+
+  return async input => {
+    if (token === undefined || token === '') {
+      return { kind: 'rejected', reason: 'github_issue_token_missing' }
+    }
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${owner}/${repo}/issues`,
+      {
+        body: JSON.stringify({
+          body: input.body,
+          labels: input.labels,
+          title: input.title,
+        }),
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'artanis-operator',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        method: 'POST',
+      },
+    )
+    if (!response.ok) {
+      return { kind: 'rejected', reason: `github_issue_create_${response.status}` }
+    }
+    const body = (await response.json().catch(() => undefined)) as
+      | Readonly<{ number?: unknown; html_url?: unknown }>
+      | undefined
+    const number =
+      typeof body?.number === 'number' && Number.isInteger(body.number)
+        ? body.number
+        : null
+    if (number === null) {
+      return { kind: 'rejected', reason: 'github_issue_response_invalid' }
+    }
+    const url =
+      typeof body?.html_url === 'string' && body.html_url.trim() !== ''
+        ? body.html_url
+        : `https://github.com/${owner}/${repo}/issues/${number}`
+    return { kind: 'created', number, url }
+  }
+}
+
+export const makeArtanisOpenUnsupportedRequestIssueTool = (
+  config: ArtanisOpenUnsupportedRequestIssueConfig = {},
+): ArtanisOperatorWriteTool => {
+  const reader = config.reader
+  const writer = config.writer
+  const issueCreator = config.issueCreator
+  const maxScan = config.maxScan ?? ARTANIS_UNSUPPORTED_REQUESTS_MAX_LIMIT
+
+  return {
+    definition: {
+      description: `Open a GitHub issue in ${ARTANIS_UNSUPPORTED_REQUEST_ISSUE_REPO} for ONE unsupported-request ledger row currently marked needs_issue, then link the returned issue number by updating the row to issue_opened. Pass the ledger "ref". The issue body contains public-safe title/summary/evidence refs only. Fixed public repo only; no secrets, private prompts, wallet material, local paths, spend, deploy, or payout authority.`,
+      name: 'open_issue_for_unsupported_request',
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          ref: {
+            description:
+              'The unsupported-request ledger entry ref to file, e.g. "khala_unsupported:ur_…". It must currently have status needs_issue and no linked issue.',
+            type: 'string',
+          },
+        },
+        required: ['ref'],
+        type: 'object',
+      },
+    },
+    execute: (args: unknown) =>
+      Effect.gen(function* () {
+        const record =
+          typeof args === 'object' && args !== null
+            ? (args as Record<string, unknown>)
+            : {}
+        const ref = parseUpdateRef(record)
+        if (ref.kind === 'absent') {
+          return '(invalid arguments: a string "ref" is required)'
+        }
+        if (ref.kind === 'invalid') {
+          return `(blocked: "${ref.raw}" is not an allowed public-safe ledger ref)`
+        }
+        if (reader === undefined) {
+          return `(could not open issue for "${ref.value}": no ledger reader is wired)`
+        }
+        if (writer === undefined) {
+          return `(could not open issue for "${ref.value}": no ledger writer is wired)`
+        }
+        if (issueCreator === undefined) {
+          return `(could not open issue for "${ref.value}": no GitHub issue creator is wired)`
+        }
+
+        const readExit = yield* Effect.exit(
+          Effect.tryPromise(() =>
+            reader({ limit: maxScan, status: 'needs_issue' }),
+          ),
+        )
+        if (readExit._tag === 'Failure') {
+          return `(could not read unsupported request "${ref.value}")`
+        }
+        const target = readExit.value.find(
+          request => request.requestRef === ref.value,
+        )
+        if (target === undefined) {
+          return `(not found: no needs_issue unsupported request matches ref "${ref.value}")`
+        }
+        if (!unsupportedRequestRecordIsSafe(target)) {
+          return `(blocked: unsupported request "${ref.value}" contains non-public-safe structured fields)`
+        }
+        if (target.status !== 'needs_issue') {
+          return `(blocked: unsupported request "${ref.value}" is ${target.status}, not needs_issue)`
+        }
+        if (target.githubIssueRef !== null) {
+          return `(blocked: unsupported request "${ref.value}" already links ${target.githubIssueRef})`
+        }
+
+        const createInput: ArtanisGithubIssueCreateInput = {
+          body: issueBodyForUnsupportedRequest(target),
+          labels: ARTANIS_UNSUPPORTED_REQUEST_ISSUE_LABELS,
+          title: issueTitleForUnsupportedRequest(target),
+        }
+        const createExit = yield* Effect.exit(
+          Effect.tryPromise(() => issueCreator(createInput)),
+        )
+        if (createExit._tag === 'Failure') {
+          return `(could not open GitHub issue for "${ref.value}")`
+        }
+        if (createExit.value.kind === 'rejected') {
+          return `(could not open GitHub issue for "${ref.value}": ${createExit.value.reason})`
+        }
+
+        const created = createExit.value
+        const updateExit = yield* Effect.exit(
+          Effect.tryPromise(() =>
+            writer({
+              githubIssueRef: `${ARTANIS_UNSUPPORTED_REQUEST_ISSUE_REPO}#${created.number}`,
+              ref: ref.value,
+              status: 'issue_opened',
+              triageKind: undefined,
+            }),
+          ),
+        )
+        if (updateExit._tag === 'Failure') {
+          return `(opened GitHub issue #${created.number} but could not update unsupported request "${ref.value}")`
+        }
+        if (updateExit.value === null) {
+          return `(opened GitHub issue #${created.number} but unsupported request "${ref.value}" was not found during link update)`
+        }
+        return [
+          `Opened GitHub issue #${created.number} for unsupported request ${ref.value}.`,
+          `URL: ${created.url}`,
+          formatUpdatedUnsupportedRequest(updateExit.value),
+        ].join('\n')
       }),
     kind: 'write',
   }
@@ -3329,6 +3588,9 @@ export const makeArtanisGetSyntheticLoadStatusTool = (
 // is honest ("(could not update …: no ledger writer is wired)") rather than
 // inventive. It is a WRITE tool, not risky/gated: owner-scoped, internal-ledger-
 // only, with no spend/payout/deploy/delete/outward authority.
+// `unsupportedRequestIssueCreator` is the owner-scoped outward issue CREATE seam
+// behind `open_issue_for_unsupported_request`: fixed public repo, public-safe
+// title/body/refs only, then the same ledger writer links the returned issue.
 export const makeArtanisOperatorTools = (
   config: Readonly<{
     repoRead?: ArtanisRepoReadConfig | undefined
@@ -3339,6 +3601,9 @@ export const makeArtanisOperatorTools = (
     traceReview?: ArtanisTraceReviewConfig | undefined
     unsupportedRequests?: ArtanisUnsupportedRequestsConfig | undefined
     unsupportedRequestWriter?: ArtanisUnsupportedRequestWriter | undefined
+    unsupportedRequestIssueCreator?:
+      | ArtanisGithubIssueCreator
+      | undefined
     defaultBranch?: string | undefined
     networkStats?: ArtanisGetNetworkStatsConfig | undefined
     glmFleetStatus?: ArtanisGlmFleetStatusConfig | undefined
@@ -3375,6 +3640,11 @@ export const makeArtanisOperatorTools = (
     makeArtanisGetTraceReviewTool(config.traceReview),
     makeArtanisGetUnsupportedRequestsTool(config.unsupportedRequests),
     makeArtanisUpdateUnsupportedRequestTool({
+      writer: config.unsupportedRequestWriter,
+    }),
+    makeArtanisOpenUnsupportedRequestIssueTool({
+      issueCreator: config.unsupportedRequestIssueCreator,
+      reader: config.unsupportedRequests?.reader,
       writer: config.unsupportedRequestWriter,
     }),
     makeArtanisDispatchCodexTaskTool({

--- a/apps/openagents.com/workers/api/src/artanis-operator-unsupported-requests.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-unsupported-requests.ts
@@ -65,12 +65,14 @@ export const makeArtanisUnsupportedRequestsReader = (
 const projectUnsupportedRequestRecord = (
   record: KhalaUnsupportedRequestRecord,
 ): ArtanisUnsupportedRequestRecord => ({
+  evidenceRefs: record.evidenceRefs,
   githubIssueRef: record.githubIssueRef,
   nextAction: record.nextAction,
   requestRef: record.requestRef,
   sourceKind: record.sourceKind,
   status: record.status,
   summary: record.summary,
+  suggestedIssueTitle: record.suggestedIssueTitle,
   title: record.title,
   triageKind: record.triageKind,
   updatedAt: record.updatedAt,

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -2,6 +2,7 @@ import { Effect, Layer, Redacted, Schema as S } from 'effect'
 import * as Context from 'effect/Context'
 
 export type OpenAgentsWorkerConfigEnv = Readonly<{
+  GITHUB_TOKEN?: string | undefined
   ARTANIS_SCHEDULED_RUNNER_ENABLED?: string | undefined
   // Compose-and-list marketplace MVP flag (EPIC #5510, #5515). Default OFF: the
   // `/api/public/marketplace/composed-products` listing surface is INERT (empty

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -113,7 +113,10 @@ import {
 import { makeArtanisGlmFleetStatusLoader } from './artanis-operator-glm-fleet-status'
 import { makeArtanisKhalaFeedbackReader } from './artanis-operator-khala-feedback'
 import { makeArtanisTraceReviewLoader } from './artanis-operator-trace-review'
-import { makeArtanisOperatorTools } from './artanis-operator-tools'
+import {
+  makeArtanisOperatorTools,
+  makeGitHubIssueCreator,
+} from './artanis-operator-tools'
 import {
   makeArtanisUnsupportedRequestsReader,
   makeArtanisUnsupportedRequestWriter,
@@ -8673,6 +8676,9 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
       unsupportedRequestWriter: makeArtanisUnsupportedRequestWriter({
         nowIso: currentIsoTimestamp,
         store: makeD1KhalaUnsupportedRequestStore(openAgentsDatabase(env)),
+      }),
+      unsupportedRequestIssueCreator: makeGitHubIssueCreator({
+        token: env.GITHUB_TOKEN,
       }),
       dispatchExecution: makeArtanisDispatchExecution({
         listLinkedAgentUserIds,


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6394

Assignment: assignment.public.khala_coding.chatcmpl_dd9a57f18fc6473ca69c3de3569c2cd8
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 6

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.