### PR TITLE
feat(artanis): generalize Pylon dispatch admission + standing pylon_job_dispatch approval to any authenticated tenant

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1779,17 +1779,13 @@ normalizedPatchDigest | behaviorReceiptDigest)`. Exactly one accepted
   (#6366 follow-up), but only through this same own-capacity coding-delegation
   seam and only behind an effective owner approval. The gated tool executes ONLY
   when (a) the caller is the authenticated owner (the `/api/operator/artanis/chat`
-  route admits only the admin API token, an owner-linked admin agent bearer, or
-  an admin browser session), (b) a wired execution seam is present, AND (c) an
-  effective `pylon_job_dispatch` Artanis approval gate exists (an approved,
-  non-expired, non-superseded gate carrying `operator_approval` authority plus an
-  authority receipt ref, per `artanisApprovalGateEffective`). As of the owner
-  promotion (see "Artanis Owner Promotion" below), precondition (c) is ALSO
-  satisfied for the owner-promoted operator agent (Artanis) by a STANDING owner
-  approval scoped to `pylon_job_dispatch` ONLY, resolved by
-  `readEffectiveArtanisPylonDispatchApprovalForOwner`; every other owner still
-  needs an explicit armed gate, and every money-movement / payout-bearing kind
-  stays gated for everyone. If any precondition
+  route admits authenticated browser sessions, owner-linked agent bearers, or the
+  admin API token, always resolving to one owner scope), (b) a wired execution
+  seam is present, AND (c) a standing tenant approval for `pylon_job_dispatch`
+  exists. That standing approval is scoped to the tenant's own linked Pylons,
+  own-capacity, and no-spend dispatch only, and is resolved by
+  `readEffectiveArtanisPylonDispatchApprovalForOwner`. Every money-movement /
+  payout-bearing kind stays gated for everyone. If any precondition
   is missing — no seam, no effective approval, no eligible linked Pylon — it
   returns the public-safe plan and defers (`deferredToApprovalGate`); it never
   fires and never fabricates an `assignmentRef`. The dispatch carries no spend

--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
@@ -269,7 +269,7 @@ describe('readEffectiveArtanisPylonDispatchApprovalForOwner (owner promotion)', 
     expect(queried).toBe(false)
   })
 
-  test('a non-promoted owner falls back to the armed D1 gate (none -> false)', async () => {
+  test('a non-promoted owner carries standing approval for own-capacity dispatch', async () => {
     let queried = false
     const approved = await readEffectiveArtanisPylonDispatchApprovalForOwner(
       emptyGatesDb(() => {
@@ -278,8 +278,21 @@ describe('readEffectiveArtanisPylonDispatchApprovalForOwner (owner promotion)', 
       nowIso,
       'user_some_other_owner',
     )
+    expect(approved).toBe(true)
+    // The per-tenant standing approval short-circuits before the D1 gate query.
+    expect(queried).toBe(false)
+  })
+
+  test('an empty owner scope still fails closed through the armed D1 gate', async () => {
+    let queried = false
+    const approved = await readEffectiveArtanisPylonDispatchApprovalForOwner(
+      emptyGatesDb(() => {
+        queried = true
+      }),
+      nowIso,
+      '   ',
+    )
     expect(approved).toBe(false)
-    // The armed-gate path WAS consulted for a non-promoted owner.
     expect(queried).toBe(true)
   })
 })

--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
@@ -38,7 +38,6 @@ import {
   type ArtanisRiskyActionKind,
   artanisApprovalGateEffective,
 } from './artanis-approval-gates'
-import { isOpenAgentsOwnerAgentOpenAuthUserId } from './artanis-owner-authority'
 import type {
   ArtanisDispatchCreateResult,
   ArtanisDispatchExecution,
@@ -267,35 +266,32 @@ export const readEffectiveArtanisApproval = async (
 }
 
 
-// Owner-promotion-aware effective-approval read (owner-directed 2026-06-27,
-// epic #6359). This is the seam the LIVE route now uses. It flips the gated
-// `dispatch_codex_task` tool from "deferred" to "live" when EITHER:
+// Owner-aware effective-approval read (owner-directed 2026-06-27, epic #6359;
+// generalized for #6382). This is the seam the LIVE route now uses. It flips
+// the gated `dispatch_codex_task` tool from "deferred" to "live" when EITHER:
 //
-//   (a) the authenticated owner is an OWNER-PROMOTED operator agent (Artanis)
-//       — he carries a STANDING owner approval for his own `pylon_job_dispatch`
-//       actions, recorded under
-//       `ARTANIS_OWNER_PROMOTION_AUTHORITY_RECEIPT_REF`
-//       ("owner promotion by Chris, 2026-06-27"), so his own-capacity, no-spend
-//       Codex dispatch EXECUTES without a separately-armed `artanis_approval_gates`
-//       row; OR
+//   (a) the authenticated owner has a non-empty owner scope. Every tenant has a
+//       STANDING approval for their own `pylon_job_dispatch` actions, so their
+//       own-capacity, no-spend Codex dispatch EXECUTES without a separately
+//       armed `artanis_approval_gates` row; OR
 //   (b) an effective `pylon_job_dispatch` gate exists in `artanis_approval_gates`
-//       for any other owner (the original armed-gate path, unchanged).
+//       (legacy armed-gate compatibility).
 //
-// NEVER-WAIVABLE BOUNDS: the standing promotion approves `pylon_job_dispatch`
-// ONLY. It does not touch `wallet_spend`, `settlement`, `l402_redemption`, or any
-// money-movement/payout-bearing kind — those stay gated and still require an
-// explicit effective approval. The dispatch path itself remains own-capacity +
-// `unpaid_smoke` no-spend by construction (`createAssignmentPromise` above), so
-// the promotion grants no payout authority and invents no custody path.
+// NEVER-WAIVABLE BOUNDS: the standing tenant approval approves
+// `pylon_job_dispatch` ONLY. It does not touch `wallet_spend`, `settlement`,
+// `l402_redemption`, or any money-movement/payout-bearing kind — those stay
+// gated and still require an explicit effective approval. The dispatch path
+// itself remains own-capacity + `unpaid_smoke` no-spend by construction
+// (`createAssignmentPromise` above), so the tenant approval grants no payout
+// authority and invents no custody path.
 export const readEffectiveArtanisPylonDispatchApprovalForOwner = async (
   db: D1Database,
   nowIso: string,
   ownerOpenAuthUserId: string,
 ): Promise<boolean> => {
-  // (a) Standing owner-promotion approval — scoped to pylon_job_dispatch only.
-  // Recorded under ARTANIS_OWNER_PROMOTION_AUTHORITY_RECEIPT_REF (see
-  // artanis-owner-authority.ts).
-  if (isOpenAgentsOwnerAgentOpenAuthUserId(ownerOpenAuthUserId)) {
+  // (a) Standing per-tenant approval — scoped to pylon_job_dispatch only. The
+  // owner-promoted Artanis identity is included by this tenant-wide rule.
+  if (ownerOpenAuthUserId.trim() !== '') {
     return true
   }
   // (b) Otherwise fall back to the armed D1 approval-gate path.


### PR DESCRIPTION
Addresses #6382.

### Changes
- Removes the owner/admin-email gate in `artanis-operator-chat-routes.ts`: an authenticated browser session (or linked owner agent bearer) now reaches the per-tenant Artanis channel.
- `readEffectiveArtanisPylonDispatchApprovalForOwner` now grants a STANDING `pylon_job_dispatch` approval to any non-empty owner scope (own-capacity, no-spend), falling back to the armed D1 gate only for an empty scope; money-movement kinds stay gated for everyone.
- `resolveOwnerAgentBearer` in `index.ts` admits any linked OpenAuth account (not just admin email), scoping dispatch to that tenant's own linked Pylons.
- Updates INVARIANTS.md and tests (non-admin session → 200; non-promoted owner → standing approval; empty scope → fail closed).

### Verification
Not independently re-verified. (PR updates chat-routes + dispatch-execution tests.)