### PR TITLE
feat(api): Cloudflare-native backend incident sink → trace-review triage pipeline

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0248_backend_incident_events.sql
+++ b/apps/openagents.com/workers/api/migrations/0248_backend_incident_events.sql
@@ -1,0 +1,49 @@
+-- 0248_backend_incident_events.sql (#6396)
+--
+-- Cloudflare-native backend incident sink for the trace-review triage loop.
+-- Rows are public-safe summaries of failures observed by Worker catch paths,
+-- Tail Worker / Logpush-style ingestion, queue consumers, Durable Objects, or
+-- local Pylon crash reporters. Do not store raw stack traces, request bodies,
+-- query strings, headers, prompts, provider payloads, credentials, or local
+-- paths here.
+
+CREATE TABLE IF NOT EXISTS backend_incident_events (
+  id TEXT PRIMARY KEY,
+  incident_ref TEXT NOT NULL UNIQUE,
+  observed_at TEXT NOT NULL,
+  source TEXT NOT NULL
+    CHECK (source IN (
+      'worker_fetch',
+      'tail_worker',
+      'workers_logs',
+      'logpush',
+      'queue_consumer',
+      'durable_object',
+      'pylon_local_runner'
+    )),
+  kind TEXT NOT NULL
+    CHECK (kind IN (
+      'unhandled_exception',
+      'gateway_timeout',
+      'silent_agent_crash'
+    )),
+  severity TEXT NOT NULL
+    CHECK (severity IN ('warning', 'critical')),
+  route_pattern TEXT NOT NULL DEFAULT 'unknown',
+  method TEXT NOT NULL DEFAULT 'UNKNOWN',
+  status_code INTEGER,
+  error_name TEXT NOT NULL DEFAULT 'unknown',
+  runtime_name TEXT NOT NULL DEFAULT 'cloudflare_workers',
+  occurrence_count INTEGER NOT NULL DEFAULT 1,
+  safe_metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_backend_incident_events_observed
+  ON backend_incident_events(observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_backend_incident_events_kind_observed
+  ON backend_incident_events(kind, observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_backend_incident_events_source_observed
+  ON backend_incident_events(source, observed_at DESC);

--- a/apps/openagents.com/workers/api/migrations/0249_backend_incident_events.sql
+++ b/apps/openagents.com/workers/api/migrations/0249_backend_incident_events.sql
@@ -1,4 +1,4 @@
--- 0248_backend_incident_events.sql (#6396)
+-- 0249_backend_incident_events.sql (#6396)
 --
 -- Cloudflare-native backend incident sink for the trace-review triage loop.
 -- Rows are public-safe summaries of failures observed by Worker catch paths,

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -1990,6 +1990,13 @@ describe('get_synthetic_load_status (active synthetic-load runs) - iteration 12'
 // outcomes + failureModes. Used to drive the get_trace_review read tool.
 const TRACE_REVIEW_REPORT_FIXTURE = {
   aggregates: {
+    backendIncidents: {
+      criticalCount: 2,
+      gatewayTimeoutCount: 0,
+      rowCount: 2,
+      silentAgentCrashCount: 0,
+      unhandledExceptionCount: 2,
+    },
     rawCodexEvents: { byteLength: 4096, eventCount: 9, rowCount: 3 },
     tokens: {
       eventCount: 42,
@@ -2060,6 +2067,7 @@ describe('get_trace_review (live Khala trace-review report) - iteration 11', () 
     expect(result).toContain('12,000 tokens')
     expect(result).toContain('17 traces')
     expect(result).toContain('3 raw Codex event rows')
+    expect(result).toContain('2 backend incident rows (2 critical)')
     // Model mix.
     expect(result).toContain('Model mix (2):')
     expect(result).toContain('openagents/khala: 30 calls, 9,000 tokens')
@@ -2084,6 +2092,7 @@ describe('get_trace_review (live Khala trace-review report) - iteration 11', () 
       new Response(
         JSON.stringify({
           aggregates: {
+            backendIncidents: { criticalCount: 0, rowCount: 0 },
             rawCodexEvents: { rowCount: 0 },
             tokens: { eventCount: 0, totalTokens: 0 },
             traces: { traceCount: 0 },
@@ -2101,6 +2110,7 @@ describe('get_trace_review (live Khala trace-review report) - iteration 11', () 
     expect(result).toContain('Outcomes: (none)')
     expect(result).toContain('Failure modes: (none)')
     expect(result).toContain('0 token rows')
+    expect(result).toContain('0 backend incident rows')
   })
 
   test('a failing/unreachable fetch returns an honest "(could not fetch trace review ...)" string, never fabricated numbers', async () => {
@@ -2212,6 +2222,7 @@ describe('get_trace_review (live Khala trace-review report) - iteration 11', () 
     expect(empty).not.toBeNull()
     expect(empty?.modelMix).toEqual([])
     expect(empty?.totalTokens).toBe(0)
+    expect(empty?.backendIncidentCount).toBe(0)
     expect(empty?.windowHours).toBeNull()
   })
 })

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -2629,6 +2629,8 @@ export type ArtanisTraceReviewSummary = Readonly<{
   tokenEventCount: number
   totalTokens: number
   traceCount: number
+  backendIncidentCount: number
+  backendIncidentCriticalCount: number
   rawEventRowCount: number
   modelMix: ReadonlyArray<ArtanisTraceReviewModelBucket>
   outcomes: ReadonlyArray<ArtanisTraceReviewOutcomeBucket>
@@ -2686,9 +2688,9 @@ const traceReviewRecord = (value: unknown): Record<string, unknown> =>
 
 // Normalize an unknown trace-review payload into the bounded, public-safe
 // summary, or null when the body is not an object at all. It is tolerant of the
-// live route shape (`{ window, aggregates: { tokens, traces, rawCodexEvents },
-// modelMix, outcomes, failureModes }`): a missing section degrades to empty / 0
-// (honest absence over invention), never a throw.
+// live route shape (`{ window, aggregates: { tokens, traces, rawCodexEvents,
+// backendIncidents }, modelMix, outcomes, failureModes }`): a missing section
+// degrades to empty / 0 (honest absence over invention), never a throw.
 export const normalizeArtanisTraceReview = (
   body: unknown,
   maxBuckets: number = ARTANIS_TRACE_REVIEW_MAX_BUCKETS,
@@ -2701,6 +2703,7 @@ export const normalizeArtanisTraceReview = (
   const tokens = traceReviewRecord(aggregates.tokens)
   const traces = traceReviewRecord(aggregates.traces)
   const rawEvents = traceReviewRecord(aggregates.rawCodexEvents)
+  const backendIncidents = traceReviewRecord(aggregates.backendIncidents)
 
   const windowHours =
     typeof window.hours === 'number' && Number.isFinite(window.hours)
@@ -2747,6 +2750,10 @@ export const normalizeArtanisTraceReview = (
     })
 
   return {
+    backendIncidentCount: traceReviewCount(backendIncidents.rowCount),
+    backendIncidentCriticalCount: traceReviewCount(
+      backendIncidents.criticalCount,
+    ),
     failureModes,
     modelMix,
     outcomes,
@@ -2783,7 +2790,11 @@ const formatTraceReviewSummary = (
     'en-US',
   )} traces; ${summary.rawEventRowCount.toLocaleString(
     'en-US',
-  )} raw Codex event rows.`
+  )} raw Codex event rows; ${summary.backendIncidentCount.toLocaleString(
+    'en-US',
+  )} backend incident rows (${summary.backendIncidentCriticalCount.toLocaleString(
+    'en-US',
+  )} critical).`
 
   const modelMixBlock =
     summary.modelMix.length === 0

--- a/apps/openagents.com/workers/api/src/backend-incident-events.ts
+++ b/apps/openagents.com/workers/api/src/backend-incident-events.ts
@@ -1,0 +1,151 @@
+import { createHash } from 'node:crypto'
+
+import { redactProviderAccountLogValue } from '@openagentsinc/provider-account-schema'
+
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export type BackendIncidentKind =
+  | 'unhandled_exception'
+  | 'gateway_timeout'
+  | 'silent_agent_crash'
+
+export type BackendIncidentSource =
+  | 'worker_fetch'
+  | 'tail_worker'
+  | 'workers_logs'
+  | 'logpush'
+  | 'queue_consumer'
+  | 'durable_object'
+  | 'pylon_local_runner'
+
+export type BackendIncidentSeverity = 'warning' | 'critical'
+
+export type BackendIncidentEventInput = Readonly<{
+  errorName?: string | undefined
+  kind: BackendIncidentKind
+  method?: string | undefined
+  observedAt?: string | undefined
+  routePattern?: string | undefined
+  safeMetadata?: Readonly<Record<string, unknown>> | undefined
+  severity?: BackendIncidentSeverity | undefined
+  source: BackendIncidentSource
+  statusCode?: number | undefined
+}>
+
+const routeSegmentPatterns: ReadonlyArray<RegExp> = [
+  /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi,
+  /\b(?:chatcmpl|run|assignment|request|trace|pylon|agent|user|team)_[A-Za-z0-9_-]{8,}\b/g,
+  /\b[0-9a-f]{24,64}\b/gi,
+]
+
+const stableRefSuffix = (value: string): string =>
+  createHash('sha256').update(value).digest('hex').slice(0, 24)
+
+const bounded = (value: string, fallback: string, maxLength: number): string => {
+  const text = value.trim()
+  if (text.length === 0) {
+    return fallback
+  }
+  return text.slice(0, maxLength)
+}
+
+export const routePatternFromRequest = (request: Request): string => {
+  const url = new URL(request.url)
+  const normalizedPath = routeSegmentPatterns.reduce(
+    (path, pattern) => path.replace(pattern, ':ref'),
+    url.pathname,
+  )
+  return bounded(normalizedPath, 'unknown', 240)
+}
+
+const safeMethod = (method: string | undefined): string =>
+  bounded((method ?? 'UNKNOWN').toUpperCase().replace(/[^A-Z]/g, ''), 'UNKNOWN', 12)
+
+const safeStatusCode = (statusCode: number | undefined): number | null => {
+  if (statusCode === undefined || !Number.isFinite(statusCode)) {
+    return null
+  }
+  return Math.trunc(statusCode)
+}
+
+const safeMetadataJson = (
+  metadata: Readonly<Record<string, unknown>> | undefined,
+): string => {
+  const safeMetadata = Object.fromEntries(
+    Object.entries(metadata ?? {})
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [
+        bounded(key.replace(/[^A-Za-z0-9_.:-]/g, '_'), 'field', 80),
+        redactProviderAccountLogValue(value).slice(0, 240),
+      ]),
+  )
+  return JSON.stringify(safeMetadata)
+}
+
+export const recordBackendIncidentEvent = async (
+  db: D1Database,
+  input: BackendIncidentEventInput,
+  nowIso: () => string = currentIsoTimestamp,
+): Promise<void> => {
+  const observedAt = input.observedAt ?? nowIso()
+  const routePattern = bounded(input.routePattern ?? 'unknown', 'unknown', 240)
+  const method = safeMethod(input.method)
+  const statusCode = safeStatusCode(input.statusCode)
+  const errorName = bounded(
+    (input.errorName ?? 'unknown').replace(/[^A-Za-z0-9_.:-]/g, '_'),
+    'unknown',
+    120,
+  )
+  const severity = input.severity ?? 'critical'
+  const idempotencySeed = [
+    observedAt,
+    input.source,
+    input.kind,
+    routePattern,
+    method,
+    statusCode ?? 'none',
+    errorName,
+    safeMetadataJson(input.safeMetadata),
+  ].join('\0')
+  const suffix = stableRefSuffix(idempotencySeed)
+  const id = `backend_incident_event_${suffix}`
+  const incidentRef = `backend_incident.${input.kind}.${suffix}`
+  const createdAt = nowIso()
+
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO backend_incident_events (
+         id,
+         incident_ref,
+         observed_at,
+         source,
+         kind,
+         severity,
+         route_pattern,
+         method,
+         status_code,
+         error_name,
+         runtime_name,
+         occurrence_count,
+         safe_metadata_json,
+         created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      id,
+      incidentRef,
+      observedAt,
+      input.source,
+      input.kind,
+      severity,
+      routePattern,
+      method,
+      statusCode,
+      errorName,
+      'cloudflare_workers',
+      1,
+      safeMetadataJson(input.safeMetadata),
+      createdAt,
+    )
+    .run()
+}

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -203,6 +203,10 @@ import {
   withBillingCreditPackages,
 } from './billing'
 import { makeBillingApiHandlers } from './billing-routes'
+import {
+  recordBackendIncidentEvent,
+  routePatternFromRequest,
+} from './backend-incident-events'
 import { OpenAgentsDatabase, ThreadFileArtifacts } from './bindings'
 import { makeBlueprintProbeContributionRoutes } from './blueprint-probe-contribution-routes'
 import { makeBlueprintRoutes } from './blueprint-routes'
@@ -13310,7 +13314,24 @@ const workerFetchProgram = Effect.gen(function* () {
   }).pipe(
     Effect.catchCause(cause =>
       Effect.sync(() => {
-        logWorkerRouteError('worker_unhandled_exception', Cause.pretty(cause))
+        const prettyCause = Cause.pretty(cause)
+        logWorkerRouteError('worker_unhandled_exception', prettyCause)
+        ctx.waitUntil(
+          recordBackendIncidentEvent(openAgentsDatabase(env), {
+            errorName: 'EffectCause',
+            kind: 'unhandled_exception',
+            method: request.method,
+            routePattern: routePatternFromRequest(request),
+            safeMetadata: {
+              host: url.hostname,
+            },
+            severity: 'critical',
+            source: 'worker_fetch',
+            statusCode: 500,
+          }).catch(error =>
+            logWorkerRouteError('backend_incident_record_failed', error),
+          ),
+        )
 
         if (url.hostname === 'auth.openagents.com') {
           return redirectResponse(getAppOrigin(env))

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -13316,7 +13316,8 @@ const workerFetchProgram = Effect.gen(function* () {
       Effect.sync(() => {
         const prettyCause = Cause.pretty(cause)
         logWorkerRouteError('worker_unhandled_exception', prettyCause)
-        ctx.waitUntil(
+        scheduleBackgroundWork(
+          ctx,
           recordBackendIncidentEvent(openAgentsDatabase(env), {
             errorName: 'EffectCause',
             kind: 'unhandled_exception',

--- a/apps/openagents.com/workers/api/src/khala-trace-review-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/khala-trace-review-routes.test.ts
@@ -11,6 +11,15 @@ const run = (effect: Effect.Effect<Response>): Promise<Response> =>
   Effect.runPromise(effect)
 
 const facts: KhalaTraceReviewFacts = {
+  backendIncidentBuckets: [],
+  backendIncidentHighlights: [],
+  backendIncidentSummary: {
+    criticalCount: 0,
+    gatewayTimeoutCount: 0,
+    rowCount: 0,
+    silentAgentCrashCount: 0,
+    unhandledExceptionCount: 0,
+  },
   modelMix: [
     {
       count: 3,
@@ -113,6 +122,68 @@ describe('Khala trace review report', () => {
     expect(report.triageItems.length).toBeGreaterThan(0)
     expect(JSON.stringify(report)).not.toContain('trajectory_json')
     expect(JSON.stringify(report)).not.toContain('raw_payload')
+  })
+
+  test('promotes backend incident rows into failure modes and triage without raw errors', () => {
+    const incidentFacts: KhalaTraceReviewFacts = {
+      ...facts,
+      backendIncidentBuckets: [
+        {
+          count: 2,
+          criticalCount: 2,
+          kind: 'unhandled_exception',
+          source: 'worker_fetch',
+        },
+      ],
+      backendIncidentHighlights: [
+        {
+          errorName: 'RuntimeError',
+          incidentRef: 'backend_incident.unhandled_exception.abc123',
+          kind: 'unhandled_exception',
+          method: 'POST',
+          observedAt: '2026-06-26T20:10:00.000Z',
+          routePattern: '/api/v1/chat/completions',
+          source: 'worker_fetch',
+          statusCode: 500,
+        },
+      ],
+      backendIncidentSummary: {
+        criticalCount: 2,
+        gatewayTimeoutCount: 0,
+        rowCount: 2,
+        silentAgentCrashCount: 0,
+        unhandledExceptionCount: 2,
+      },
+    }
+
+    const report = buildKhalaTraceReviewReport({
+      facts: incidentFacts,
+      generatedAt: '2026-06-26T21:00:00.000Z',
+      window: {
+        hours: 24,
+        since: '2026-06-25T21:00:00.000Z',
+        until: '2026-06-26T21:00:00.000Z',
+      },
+    })
+
+    expect(report.aggregates.backendIncidents).toMatchObject({
+      rowCount: 2,
+      unhandledExceptionCount: 2,
+    })
+    expect(report.sourceTables).toContain('backend_incident_events')
+    expect(report.failureModes.map(mode => mode.failureRef)).toContain(
+      'failure.khala_trace_review.backend_unhandled_exception',
+    )
+    expect(report.triageItems.map(item => item.triageRef)).toContain(
+      'triage.khala_trace_review.backend_unhandled_exception',
+    )
+    expect(report.backendIncidentHighlights[0]).toMatchObject({
+      incidentRef: 'backend_incident.unhandled_exception.abc123',
+      routePattern: '/api/v1/chat/completions',
+    })
+    expect(JSON.stringify(report)).not.toContain('stack')
+    expect(JSON.stringify(report)).not.toContain('raw_error')
+    expect(JSON.stringify(report)).not.toContain('raw_stack')
   })
 
   test('a legitimate serving provider id with an sk-shaped substring does not trip the secret-material backstop', async () => {

--- a/apps/openagents.com/workers/api/src/khala-trace-review-routes.ts
+++ b/apps/openagents.com/workers/api/src/khala-trace-review-routes.ts
@@ -70,6 +70,24 @@ export type KhalaTraceReviewRawEventHighlight = Readonly<{
   rawEventRef: string
 }>
 
+export type KhalaTraceReviewBackendIncidentBucket = Readonly<{
+  kind: 'unhandled_exception' | 'gateway_timeout' | 'silent_agent_crash'
+  source: string
+  count: number
+  criticalCount: number
+}>
+
+export type KhalaTraceReviewBackendIncidentHighlight = Readonly<{
+  errorName: string
+  incidentRef: string
+  kind: 'unhandled_exception' | 'gateway_timeout' | 'silent_agent_crash'
+  method: string
+  observedAt: string
+  routePattern: string
+  source: string
+  statusCode: number | null
+}>
+
 export type KhalaTraceReviewFailureMode = Readonly<{
   failureRef: string
   label: string
@@ -124,6 +142,15 @@ export type KhalaTraceReviewFacts = Readonly<{
     byteLength: number
   }
   rawEventHighlights: ReadonlyArray<KhalaTraceReviewRawEventHighlight>
+  backendIncidentSummary: {
+    rowCount: number
+    criticalCount: number
+    unhandledExceptionCount: number
+    gatewayTimeoutCount: number
+    silentAgentCrashCount: number
+  }
+  backendIncidentBuckets: ReadonlyArray<KhalaTraceReviewBackendIncidentBucket>
+  backendIncidentHighlights: ReadonlyArray<KhalaTraceReviewBackendIncidentHighlight>
 }>
 
 export type KhalaTraceReviewReport = Readonly<{
@@ -132,16 +159,22 @@ export type KhalaTraceReviewReport = Readonly<{
   generatedAt: string
   window: KhalaTraceReviewWindow
   sourceTables: ReadonlyArray<
-    'agent_traces' | 'token_usage_events' | 'pylon_codex_raw_events'
+    | 'agent_traces'
+    | 'token_usage_events'
+    | 'pylon_codex_raw_events'
+    | 'backend_incident_events'
   >
   aggregates: {
     tokens: KhalaTraceReviewFacts['tokenSummary']
     traces: KhalaTraceReviewFacts['traceSummary']
     rawCodexEvents: KhalaTraceReviewFacts['rawEventSummary']
+    backendIncidents: KhalaTraceReviewFacts['backendIncidentSummary']
   }
   modelMix: ReadonlyArray<KhalaTraceReviewModelBucket>
   demandSources: ReadonlyArray<KhalaTraceReviewBucket>
   outcomes: ReadonlyArray<KhalaTraceReviewOutcomeBucket>
+  backendIncidentBuckets: ReadonlyArray<KhalaTraceReviewBackendIncidentBucket>
+  backendIncidentHighlights: ReadonlyArray<KhalaTraceReviewBackendIncidentHighlight>
   notableTraces: ReadonlyArray<KhalaTraceReviewNotableTrace>
   userIntents: ReadonlyArray<KhalaTraceReviewUserIntent>
   failureModes: ReadonlyArray<KhalaTraceReviewFailureMode>
@@ -269,7 +302,20 @@ export const makeD1KhalaTraceReviewStore = (
   db: D1Database,
 ): KhalaTraceReviewStore => ({
   readFacts: async input => {
-    const [tokenSummary, demandRows, modelRows, outcomeRows, traceSummary, traceDemandRows, notableRows, rawSummary, rawRows] = await Promise.all([
+    const [
+      tokenSummary,
+      demandRows,
+      modelRows,
+      outcomeRows,
+      traceSummary,
+      traceDemandRows,
+      notableRows,
+      rawSummary,
+      rawRows,
+      backendIncidentSummary,
+      backendIncidentBucketRows,
+      backendIncidentRows,
+    ] = await Promise.all([
       db
         .prepare(
           `SELECT COUNT(*) AS event_count,
@@ -397,9 +443,80 @@ export const makeD1KhalaTraceReviewStore = (
         )
         .bind(input.window.since, input.window.until, input.limit)
         .all<Record<string, unknown>>(),
+      db
+        .prepare(
+          `SELECT COUNT(*) AS row_count,
+                  COALESCE(SUM(CASE WHEN severity = 'critical' THEN occurrence_count ELSE 0 END), 0) AS critical_count,
+                  COALESCE(SUM(CASE WHEN kind = 'unhandled_exception' THEN occurrence_count ELSE 0 END), 0) AS unhandled_exception_count,
+                  COALESCE(SUM(CASE WHEN kind = 'gateway_timeout' THEN occurrence_count ELSE 0 END), 0) AS gateway_timeout_count,
+                  COALESCE(SUM(CASE WHEN kind = 'silent_agent_crash' THEN occurrence_count ELSE 0 END), 0) AS silent_agent_crash_count
+             FROM backend_incident_events
+            WHERE observed_at >= ? AND observed_at < ?`,
+        )
+        .bind(input.window.since, input.window.until)
+        .first<Record<string, unknown>>(),
+      db
+        .prepare(
+          `SELECT kind,
+                  source,
+                  COALESCE(SUM(occurrence_count), 0) AS count,
+                  COALESCE(SUM(CASE WHEN severity = 'critical' THEN occurrence_count ELSE 0 END), 0) AS critical_count
+             FROM backend_incident_events
+            WHERE observed_at >= ? AND observed_at < ?
+            GROUP BY kind, source
+            ORDER BY critical_count DESC, count DESC
+            LIMIT ?`,
+        )
+        .bind(input.window.since, input.window.until, input.limit)
+        .all<Record<string, unknown>>(),
+      db
+        .prepare(
+          `SELECT incident_ref,
+                  kind,
+                  source,
+                  route_pattern,
+                  method,
+                  status_code,
+                  error_name,
+                  observed_at
+             FROM backend_incident_events
+            WHERE observed_at >= ? AND observed_at < ?
+            ORDER BY observed_at DESC
+            LIMIT ?`,
+        )
+        .bind(input.window.since, input.window.until, input.limit)
+        .all<Record<string, unknown>>(),
     ])
 
     return {
+      backendIncidentBuckets: (backendIncidentBucketRows.results ?? []).map(row => ({
+        count: n(row.count),
+        criticalCount: n(row.critical_count),
+        kind: s(row.kind) as KhalaTraceReviewBackendIncidentBucket['kind'],
+        source: s(row.source),
+      })),
+      backendIncidentHighlights: (backendIncidentRows.results ?? []).map(row => ({
+        errorName: s(row.error_name),
+        incidentRef: s(row.incident_ref),
+        kind: s(row.kind) as KhalaTraceReviewBackendIncidentHighlight['kind'],
+        method: s(row.method, 'UNKNOWN'),
+        observedAt: s(row.observed_at),
+        routePattern: s(row.route_pattern),
+        source: s(row.source),
+        statusCode:
+          row.status_code === null || row.status_code === undefined
+            ? null
+            : n(row.status_code),
+      })),
+      backendIncidentSummary: {
+        criticalCount: n(backendIncidentSummary?.critical_count),
+        gatewayTimeoutCount: n(backendIncidentSummary?.gateway_timeout_count),
+        rowCount: n(backendIncidentSummary?.row_count),
+        silentAgentCrashCount: n(backendIncidentSummary?.silent_agent_crash_count),
+        unhandledExceptionCount: n(
+          backendIncidentSummary?.unhandled_exception_count,
+        ),
+      },
       modelMix: (modelRows.results ?? []).map(row => ({
         count: n(row.count),
         model: s(row.model),
@@ -523,6 +640,36 @@ export const buildKhalaTraceReviewReport = (input: {
     })
   }
 
+  if (input.facts.backendIncidentSummary.unhandledExceptionCount > 0) {
+    failureModes.push({
+      count: input.facts.backendIncidentSummary.unhandledExceptionCount,
+      evidenceRefs: ['table.backend_incident_events.kind.unhandled_exception'],
+      failureRef: 'failure.khala_trace_review.backend_unhandled_exception',
+      label: 'Unhandled backend exceptions captured by Cloudflare incident sink',
+      severity: 'critical',
+    })
+  }
+
+  if (input.facts.backendIncidentSummary.gatewayTimeoutCount > 0) {
+    failureModes.push({
+      count: input.facts.backendIncidentSummary.gatewayTimeoutCount,
+      evidenceRefs: ['table.backend_incident_events.kind.gateway_timeout'],
+      failureRef: 'failure.khala_trace_review.backend_gateway_timeout',
+      label: 'Gateway timeout incidents captured by Cloudflare incident sink',
+      severity: 'critical',
+    })
+  }
+
+  if (input.facts.backendIncidentSummary.silentAgentCrashCount > 0) {
+    failureModes.push({
+      count: input.facts.backendIncidentSummary.silentAgentCrashCount,
+      evidenceRefs: ['table.backend_incident_events.kind.silent_agent_crash'],
+      failureRef: 'failure.khala_trace_review.silent_agent_crash',
+      label: 'Silent agent crash incidents captured by Cloudflare incident sink',
+      severity: 'critical',
+    })
+  }
+
   const userIntents = input.facts.traceByDemandSource.map(bucket => ({
     count: bucket.count,
     evidenceRefs: [`demand_source.${bucket.label}`],
@@ -564,6 +711,7 @@ export const buildKhalaTraceReviewReport = (input: {
 
   return publicSafeReport({
     aggregates: {
+      backendIncidents: input.facts.backendIncidentSummary,
       rawCodexEvents: input.facts.rawEventSummary,
       tokens: input.facts.tokenSummary,
       traces: input.facts.traceSummary,
@@ -572,6 +720,8 @@ export const buildKhalaTraceReviewReport = (input: {
       itemRefs: triageItems.map(item => item.triageRef),
       producedItemCount: triageItems.length,
     },
+    backendIncidentBuckets: input.facts.backendIncidentBuckets,
+    backendIncidentHighlights: input.facts.backendIncidentHighlights,
     demandSources,
     failureModes,
     generatedAt: input.generatedAt,
@@ -588,6 +738,7 @@ export const buildKhalaTraceReviewReport = (input: {
     schemaVersion: 'openagents.khala.trace_review.v1',
     sourceTables: [
       'agent_traces',
+      'backend_incident_events',
       'token_usage_events',
       'pylon_codex_raw_events',
     ],


### PR DESCRIPTION
Addresses #6396.

### Changes
- New migration `0248_backend_incident_events.sql`: public-safe incident table (source/kind/severity/route_pattern/method/status/error_name, occurrence_count, indexes) explicitly excluding raw stacks/bodies/prompts/credentials.
- New `backend-incident-events.ts`: `recordBackendIncidentEvent` with route-pattern ref redaction, metadata redaction (`redactProviderAccountLogValue`), and idempotency-hashed ids.
- Wires the worker top-level `catchCause` path to record an `unhandled_exception` incident via `ctx.waitUntil` (no third-party observability deps — Cloudflare primitives only).
- Trace-review store reads incident summary/buckets/highlights and promotes unhandled-exception / gateway-timeout / silent-crash counts into failure modes + triage items; Artanis `get_trace_review` reports backend incident rows.
- Tests across trace-review routes + operator tools.

### Verification
Not independently re-verified. (PR adds khala-trace-review-routes.test.ts and operator-tools tests.)