### PR TITLE
feat(web): /artanis fleet recruitment CTA + connect-codex-fleet docs page

### DIFF
--- a/apps/openagents.com/apps/web/src/docs-blog-route.test.ts
+++ b/apps/openagents.com/apps/web/src/docs-blog-route.test.ts
@@ -1074,6 +1074,18 @@ describe('docs and blog routes', () => {
       Scene.expect(Scene.text('Omega Pylon stats')).toExist(),
       Scene.expect(Scene.text('Pylons online')).toExist(),
       Scene.expect(Scene.text('Earning gate')).toExist(),
+      Scene.expect(
+        Scene.role('heading', { name: 'Have Codex or Claude? Join the fleet.' }),
+      ).toExist(),
+      Scene.expect(Scene.text('khala fleet connect')).toExist(),
+      Scene.expect(Scene.text('khala fleet status')).toExist(),
+      Scene.expect(Scene.role('link', { name: 'Fleet docs' })).toHaveAttr(
+        'href',
+        '/docs/connect-codex-fleet',
+      ),
+      Scene.expect(
+        Scene.role('link', { name: 'Read the setup guide' }),
+      ).toHaveAttr('href', '/docs/connect-codex-fleet'),
       Scene.expect(Scene.role('link', { name: 'Artanis Forum' })).toHaveAttr(
         'href',
         '/forum/f/artanis',
@@ -1088,6 +1100,33 @@ describe('docs and blog routes', () => {
       Scene.expect(Scene.text('authGrantRef')).toBeAbsent(),
       Scene.expect(Scene.text('payloadJson')).toBeAbsent(),
       Scene.expect(Scene.text('hiddenSteering')).toBeAbsent(),
+    )
+  })
+
+  test('renders the Codex fleet connection docs page', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(LoggedOut.init(DocsPageRoute({ slug: 'connect-codex-fleet' }))),
+      Scene.expect(
+        Scene.role('heading', { name: 'Connect Your Codex Fleet' }),
+      ).toExist(),
+      Scene.expect(Scene.text('khala fleet connect')).toExist(),
+      Scene.expect(Scene.text('khala fleet status')).toExist(),
+      Scene.expect(
+        Scene.text('The own-capacity coding path routes only through capacity linked to the same owner scope. It is not third-party pooled labor and it is not a settlement-bearing marketplace path.'),
+      ).toExist(),
+      Scene.expect(
+        Scene.role('link', { name: 'Khala CLI fleet docs' }),
+      ).toHaveAttr(
+        'href',
+        'https://github.com/OpenAgentsInc/openagents/blob/main/clients/khala-cli/README.md#connect-your-codex-fleet',
+      ),
+      Scene.expect(
+        Scene.role('link', { name: 'Fleet contribution plan' }),
+      ).toHaveAttr(
+        'href',
+        'https://github.com/OpenAgentsInc/openagents/blob/main/docs/ops/2026-06-27-artanis-as-a-service-multi-tenant-codex-fleet-enablement.md',
+      ),
     )
   })
 

--- a/apps/openagents.com/apps/web/src/page/docs.ts
+++ b/apps/openagents.com/apps/web/src/page/docs.ts
@@ -15,6 +15,7 @@ export const DocSlug = S.Literals([
   'autopilot-sites',
   'software-handoff',
   'autonomous-qa',
+  'connect-codex-fleet',
   'product-promises',
   'forum',
   'api',
@@ -166,6 +167,58 @@ const docsPages: ReadonlyArray<DocPage> = [
       {
         href: 'https://github.com/OpenAgentsInc/openagents/blob/main/apps/qa-runner/LICENSE',
         label: 'MIT license',
+      },
+    ],
+  },
+  {
+    slug: 'connect-codex-fleet',
+    title: 'Connect Your Codex Fleet',
+    summary:
+      'Use Khala CLI to connect your own Codex accounts so Artanis can route bounded coding backlog work through your local capacity.',
+    description: [
+      'Install Khala CLI, connect a Codex account with the paste-free device-login flow, then check fleet readiness.',
+      'The public onboarding path is deliberately short: npm install -g @openagentsinc/khala, khala fleet connect, then khala fleet status.',
+      'Each connected account uses an isolated home under your Pylon home. The flow never touches the default ~/.codex home, credentials stay on your machine, and tokens are not printed.',
+      'Run khala fleet connect again to add another distinct account. More distinct accounts mean more usable throughput for your own Artanis-backed backlog work.',
+      'Claude capacity is exposed through the Pylon local-Claude lane and operator runbooks; the zero-paste public fleet command is Codex-first today.',
+    ],
+    sections: [
+      {
+        heading: 'Quick Start',
+        items: [
+          'npm install -g @openagentsinc/khala',
+          'khala fleet connect',
+          'khala fleet status',
+        ],
+      },
+      {
+        heading: 'What You Should See',
+        items: [
+          'khala fleet connect opens the standard Codex device-auth browser flow, shows a short code, and confirms the linked account email after success.',
+          'khala fleet status lists connected accounts with readiness such as ready or credentials-missing.',
+          'If the Codex CLI is missing, the command prints a friendly install hint for npm install -g @openai/codex.',
+        ],
+      },
+      {
+        heading: 'Public Safety Boundary',
+        items: [
+          'Public Artanis and Pylon projections use generic labels and refs. They must not expose emails, credentials, raw prompts, diffs, local paths, or private repository data.',
+          'The own-capacity coding path routes only through capacity linked to the same owner scope. It is not third-party pooled labor and it is not a settlement-bearing marketplace path.',
+        ],
+      },
+    ],
+    links: [
+      {
+        href: 'https://github.com/OpenAgentsInc/openagents/blob/main/clients/khala-cli/README.md#connect-your-codex-fleet',
+        label: 'Khala CLI fleet docs',
+      },
+      {
+        href: 'https://github.com/OpenAgentsInc/openagents/blob/main/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md',
+        label: 'Own-capacity runbook',
+      },
+      {
+        href: 'https://github.com/OpenAgentsInc/openagents/blob/main/docs/ops/2026-06-27-artanis-as-a-service-multi-tenant-codex-fleet-enablement.md',
+        label: 'Fleet contribution plan',
       },
     ],
   },

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
@@ -532,6 +532,143 @@ const bitcoinPrimary = (value: string): string => value.replace(/ \(.+\)$/, '')
 const bitcoinDenomination = (value: string): string | null =>
   value.match(/\((.+)\)$/)?.[1] ?? null
 
+const fleetOnboardingCommands = [
+  'npm install -g @openagentsinc/khala',
+  'khala fleet connect',
+  'khala fleet status',
+] as const
+
+const artanisFleetOnboardingView = (): Html => {
+  const h = html<Message>()
+
+  return h.section(
+    [Ui.className<Message>('grid gap-4 border-b border-[#222] pb-6')],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex flex-wrap items-end justify-between gap-3',
+          ),
+        ],
+        [
+          h.div(
+            [Ui.className<Message>('grid gap-2')],
+            [
+              h.div([Ui.className<Message>(Ui.eyebrowClass)], ['Join fleet']),
+              h.h2(
+                [
+                  Ui.className<Message>(
+                    'text-xl font-semibold tracking-normal text-[#f1efe8]',
+                  ),
+                ],
+                ['Have Codex or Claude? Join the fleet.'],
+              ),
+            ],
+          ),
+          h.a(
+            [
+              h.Href('/docs/connect-codex-fleet'),
+              Ui.className<Message>(
+                'border border-[#333] px-3 py-2 text-[0.75rem] text-white/70 underline-offset-4 hover:border-white/35 hover:text-[#f1efe8] hover:underline',
+              ),
+            ],
+            ['Fleet docs'],
+          ),
+        ],
+      ),
+      h.div(
+        [
+          Ui.className<Message>(
+            'grid gap-3 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]',
+          ),
+        ],
+        [
+          h.div(
+            [
+              Ui.className<Message>(
+                'grid gap-3 border border-[#222] bg-[#010102] p-3',
+              ),
+            ],
+            [
+              h.p(
+                [
+                  Ui.className<Message>(
+                    'max-w-3xl text-sm leading-6 text-[#f1efe8]',
+                  ),
+                ],
+                [
+                  'Connect your own coding-agent capacity so a per-user Artanis can burn down public issue backlogs through your local Pylon. Credentials stay on your machine; public projections use generic fleet labels and refs only.',
+                ],
+              ),
+              h.div(
+                [
+                  Ui.className<Message>(
+                    'grid gap-2 text-[0.75rem] text-white/45 sm:grid-cols-3',
+                  ),
+                ],
+                [
+                  h.div(
+                    [Ui.className<Message>('border border-[#1b1b1b] p-2')],
+                    ['Paste-free device login'],
+                  ),
+                  h.div(
+                    [Ui.className<Message>('border border-[#1b1b1b] p-2')],
+                    ['Isolated Codex account homes'],
+                  ),
+                  h.div(
+                    [Ui.className<Message>('border border-[#1b1b1b] p-2')],
+                    ['More accounts, more throughput'],
+                  ),
+                ],
+              ),
+            ],
+          ),
+          h.div(
+            [
+              Ui.className<Message>(
+                'grid gap-3 border border-[#222] bg-[#010102] p-3',
+              ),
+            ],
+            [
+              h.div(
+                [Ui.className<Message>('text-[0.75rem] text-white/45')],
+                ['Start here'],
+              ),
+              h.ol(
+                [Ui.className<Message>('grid gap-1')],
+                fleetOnboardingCommands.map(command =>
+                  h.li(
+                    [
+                      Ui.className<Message>(
+                        'overflow-x-auto border border-[#1b1b1b] bg-black px-3 py-2 text-[0.75rem] leading-6 text-[#f1efe8]',
+                      ),
+                    ],
+                    [h.code([], [command])],
+                  ),
+                ),
+              ),
+              h.div(
+                [Ui.className<Message>('flex flex-wrap gap-2')],
+                [
+                  h.a(
+                    [
+                      h.Href('/docs/connect-codex-fleet'),
+                      Ui.className<Message>(
+                        'border border-[#333] px-3 py-2 text-[0.75rem] text-white/70 underline-offset-4 hover:border-white/35 hover:text-[#f1efe8] hover:underline',
+                      ),
+                    ],
+                    ['Read the setup guide'],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
 const artanisClaimRow = (claim: PublicArtanisReportClaimSummary): Html => {
   const h = html<Message>()
 
@@ -1284,6 +1421,7 @@ const loadedView = (
         ],
       ),
       isArtanis ? artanisReportView(artanisReport) : null,
+      isArtanis ? artanisFleetOnboardingView() : null,
       isArtanis ? pylonStatsView(pylonStats) : null,
       isAdjutant ? adjutantActivityView(adjutantActivity) : null,
       h.section(


### PR DESCRIPTION
Addresses #6416.

### Changes
- Adds an `artanisFleetOnboardingView` recruitment section to the public Artanis page (`page/loggedOut/page/publicAgent.ts`): "Have Codex or Claude? Join the fleet." heading, `khala fleet connect`/`khala fleet status` quick-start, and a Fleet docs link.
- Adds a `connect-codex-fleet` docs page (`page/docs.ts`) with quick-start, expected output, public-safety boundary, and links to the Khala CLI fleet README and fleet-contribution plan.
- Public-safe wording only (generic labels, no emails/keys/diffs); states the own-capacity path is owner-scoped, not pooled labor or settlement-bearing.
- Adds route/render coverage in `docs-blog-route.test.ts`.

### Verification
Not independently re-verified. PR adds Scene render assertions for the CTA section and the new docs page.