### PR TITLE
feat(traces): checksum-locked GG held-out partition + generalization guard

### DIFF
--- a/apps/openagents.com/scripts/mirrorcode/README.md
+++ b/apps/openagents.com/scripts/mirrorcode/README.md
@@ -36,6 +36,12 @@ preemptible behind real external demand (#6318).
   both canary strings (MirrorCode + BIG-Bench).
 - We run **PUBLIC tasks only** (the paper's private set is not shipped). Always
   label results "public tasks only; private set excluded."
+- Treat the public-task lane as Khala's AgentCL Generalization Gain (GG) set:
+  `generalizationSet=mirrorcode_public_tasks_no_rag` and
+  `memoryPolicy=no_rag_public_tasks_only`. Khala memory, training, homework,
+  retrieval, prompt-optimization, and RAG loops must not ingest MirrorCode task
+  text, docs, tests, logs, or traces. The runner and ingest route may store only
+  the public-safe score envelope.
 - **Cost/wall-clock is the dominant risk.** A real sample burns ≥1B tokens
   (S/M) or 10B (L); the longest paper sample ran **19 days**. This runner sets
   hard token + wall-clock caps FAR below those limits — it is a **smoke**, not a
@@ -110,7 +116,9 @@ The venv is **throwaway** (a `mktemp` dir, auto-removed) and is never committed.
 ```
 
 Plus public-safe extras: `benchmark`, `scoreGroups` (MirrorCode per-group pass
-rates: `all/visible/ablated/hidden/withheld`), `caps`, `demand`.
+rates: `all/visible/ablated/hidden/withheld`), `caps`, `demand`, and the derived
+GG fields `generalizationSet=mirrorcode_public_tasks_no_rag` and
+`memoryPolicy=no_rag_public_tasks_only`.
 
 `passRate` is the **held-out** (`withheld` = hidden + ablated) reproduction rate
 when present (the anti-contamination number), else `all`, else `visible`.

--- a/apps/openagents.com/workers/api/corpus/tassadar-trace-corpus.v0_1.manifest.json
+++ b/apps/openagents.com/workers/api/corpus/tassadar-trace-corpus.v0_1.manifest.json
@@ -67,6 +67,59 @@
   "manifestVersion": "corpus_manifest.v0.1",
   "masterSeed": "4748c0de20260611",
   "profileVersion": "profile.tassadar_alm_numeric.v1",
+  "generalizationGuard": {
+    "allowedConsumers": [
+      "gg_eval",
+      "replay_verification",
+      "public_manifest_audit"
+    ],
+    "checksumAlgorithm": "sha256",
+    "forbiddenConsumers": [
+      "training",
+      "memory_context",
+      "trace_homework",
+      "rag",
+      "optimization",
+      "homework_loop"
+    ],
+    "guardDigest": "0b8d825543cb6ba2edb67b13721b7c5170e35c533a7ca408f272cf9adfee61fb",
+    "integrityMode": "checksum_only_no_payload",
+    "issueRef": "#6419",
+    "metric": "generalization_gain",
+    "partitions": [
+      {
+        "familyIds": [
+          "family.arithmetic_carry.v1",
+          "family.branch_gated_control.v1",
+          "family.memory_load_store.v1"
+        ],
+        "kind": "train_allowed",
+        "recordCount": 208,
+        "shardRefs": [
+          "shards/family_arithmetic_carry_v1.ttrc#9ca294f38cdc3cdd7f014ed99d82025b6f78daef17bec25d5fd0ff4b1355ddf1",
+          "shards/family_branch_gated_control_v1.ttrc#aee3d2bbd0381d268c52f55ae4a47d31eb2d629e693269c58a32e9c0083205b6",
+          "shards/family_memory_load_store_v1.ttrc#bfd80624224341989219c8c6c632f3b3d5de7999264f253da30a0d44e74e0b64"
+        ],
+        "split": "train",
+        "tokenCount": 1515520
+      },
+      {
+        "familyIds": [
+          "family.application_state_machine.v1",
+          "family.stack_loop_sum.compiled.v1"
+        ],
+        "kind": "gg_held_out",
+        "recordCount": 46,
+        "shardRefs": [
+          "shards/family_application_state_machine_v1.ttrc#c4c6eafdb9edf7b0703c1b3b968dc65dad5196aaf19de05a12ce6f59f27dae65",
+          "shards/family_stack_loop_sum_compiled_v1.ttrc#1a6048ed159f7e968a93b732cd3aceeb1edc8c7fdbd8f7ccf3fb02f0438f0a2b"
+        ],
+        "split": "eval_heldout_family",
+        "tokenCount": 456800
+      }
+    ],
+    "schemaVersion": "openagents.tassadar.generalization_guard.v0"
+  },
   "projectionAfterGeneration": {
     "contractVersion": "projection_rebuild.v0.1",
     "familyCoverage": [

--- a/apps/openagents.com/workers/api/corpus/tassadar-trace-corpus.v0_2.w3_100m.manifest.json
+++ b/apps/openagents.com/workers/api/corpus/tassadar-trace-corpus.v0_2.w3_100m.manifest.json
@@ -12,6 +12,60 @@
   "manifestVersion": "corpus_manifest.v0.1",
   "masterSeed": "4749facade202606",
   "profileVersion": "profile.tassadar_alm_numeric.v1",
+  "generalizationGuard": {
+    "allowedConsumers": [
+      "gg_eval",
+      "replay_verification",
+      "public_manifest_audit"
+    ],
+    "checksumAlgorithm": "sha256",
+    "forbiddenConsumers": [
+      "training",
+      "memory_context",
+      "trace_homework",
+      "rag",
+      "optimization",
+      "homework_loop"
+    ],
+    "guardDigest": "9d5c5b833ef6b8cac1c308eec77986824786a3118a72d1c93aa1f293479cfe8b",
+    "integrityMode": "checksum_only_no_payload",
+    "issueRef": "#6419",
+    "metric": "generalization_gain",
+    "partitions": [
+      {
+        "familyIds": [
+          "family.arithmetic_carry.v1",
+          "family.branch_gated_control.v1",
+          "family.memory_load_store.v1"
+        ],
+        "kind": "train_allowed",
+        "recordCount": 11800,
+        "shardRefs": [
+          "shards/family_arithmetic_carry_v1.train.ttrc#4a2768397e4dda896b07ab18850e8c098d3baa7ac697742c6fe5d8a3e69b5e5d",
+          "shards/family_branch_gated_control_v1.train.ttrc#89266594b15d9b63161075eb7fd1d9a60f12565664ce1b9577f7d1abe7bb5306",
+          "shards/family_memory_load_store_v1.train.ttrc#8914fd87e17401ac9814484bcab80306dc093a1316c5faa26ff85d5b307e28bb"
+        ],
+        "split": "train",
+        "tokenCount": 85504000
+      },
+      {
+        "familyIds": [
+          "family.application_state_machine.v1",
+          "family.stack_loop_sum.compiled.v1"
+        ],
+        "kind": "gg_held_out",
+        "recordCount": 328,
+        "shardRefs": [
+          "shards/family_application_state_machine_v1.long.ttrc#cbfd75c2a81c0a4f31021cb83b8b429d88d3c0b73a57e3480a195beda6c20692",
+          "shards/family_application_state_machine_v1.short.ttrc#2a3a24c7cdca6616f6413b931127f2c8cc0fc671500ffefa2b6bf6f21063cf3c",
+          "shards/family_stack_loop_sum_compiled_v1.anchor.ttrc#8b1604ac3aebd72128032cd98d4d259539bc31e253ab9d8e0fa2de1f0e24751a"
+        ],
+        "split": "eval_heldout_family",
+        "tokenCount": 4798560
+      }
+    ],
+    "schemaVersion": "openagents.tassadar.generalization_guard.v0"
+  },
   "records": {
     "jsonl": "records.jsonl",
     "recordCount": 12548,

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
@@ -50,6 +50,8 @@ export type MirrorCodeRunGrade = typeof MirrorCodeRunGrade.Type
 // must yield to real external demand (#6318).
 export const MIRRORCODE_DEMAND_KIND = 'internal'
 export const MIRRORCODE_DEMAND_SOURCE = 'gym_mirrorcode'
+export const MIRRORCODE_GENERALIZATION_SET = 'mirrorcode_public_tasks_no_rag'
+export const MIRRORCODE_MEMORY_POLICY = 'no_rag_public_tasks_only'
 
 // Field bounds enforced in `buildMirrorCodeRun` (the codebase avoids inline
 // Schema length/number refinements; the build boundary is the single place that
@@ -101,6 +103,8 @@ export const MirrorCodeRun = S.Struct({
   decisionGrade: S.Boolean,
   demandKind: S.Literal(MIRRORCODE_DEMAND_KIND),
   demandSource: S.Literal(MIRRORCODE_DEMAND_SOURCE),
+  generalizationSet: S.Literal(MIRRORCODE_GENERALIZATION_SET),
+  memoryPolicy: S.Literal(MIRRORCODE_MEMORY_POLICY),
 })
 export type MirrorCodeRun = typeof MirrorCodeRun.Type
 
@@ -228,6 +232,8 @@ export const buildMirrorCodeRun = (raw: unknown): MirrorCodeRun => {
     decisionGrade: decisionGradeFor(grade, status),
     demandKind: MIRRORCODE_DEMAND_KIND,
     demandSource: MIRRORCODE_DEMAND_SOURCE,
+    generalizationSet: MIRRORCODE_GENERALIZATION_SET,
+    memoryPolicy: MIRRORCODE_MEMORY_POLICY,
   }
 }
 

--- a/apps/openagents.com/workers/api/src/tassadar-trace-corpus-generalization-guard.test.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-trace-corpus-generalization-guard.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import {
+  tassadarGeneralizationGuardDigest,
+  validateTassadarGeneralizationGuard,
+  type TassadarGeneralizationGuardManifest,
+} from './tassadar-trace-factory/generalization-guard'
+import { buildMirrorCodeRun } from './inference/gym/mirrorcode-contract'
+
+const corpusDir = join(import.meta.dirname, '..', 'corpus')
+
+const readManifest = (fileName: string): TassadarGeneralizationGuardManifest =>
+  JSON.parse(readFileSync(join(corpusDir, fileName), 'utf8')) as TassadarGeneralizationGuardManifest
+
+describe('Tassadar trace corpus generalization guard', () => {
+  test.each([
+    [
+      'tassadar-trace-corpus.v0_1.manifest.json',
+      '0b8d825543cb6ba2edb67b13721b7c5170e35c533a7ca408f272cf9adfee61fb',
+      46,
+      456800,
+    ],
+    [
+      'tassadar-trace-corpus.v0_2.w3_100m.manifest.json',
+      '9d5c5b833ef6b8cac1c308eec77986824786a3118a72d1c93aa1f293479cfe8b',
+      328,
+      4798560,
+    ],
+  ])('%s declares a checksum-only GG held-out partition', async (
+    fileName,
+    expectedDigest,
+    expectedHeldOutRecords,
+    expectedHeldOutTokens,
+  ) => {
+    const manifest = readManifest(fileName)
+    const guard = manifest.generalizationGuard
+    expect(guard).toBeDefined()
+    expect(await validateTassadarGeneralizationGuard(manifest)).toEqual([])
+    expect(await tassadarGeneralizationGuardDigest(manifest, guard!)).toBe(expectedDigest)
+
+    const heldOut = guard!.partitions.find(
+      partition => partition.kind === 'gg_held_out',
+    )
+    const train = guard!.partitions.find(
+      partition => partition.kind === 'train_allowed',
+    )
+    expect(heldOut).toMatchObject({
+      recordCount: expectedHeldOutRecords,
+      split: 'eval_heldout_family',
+      tokenCount: expectedHeldOutTokens,
+    })
+    expect(heldOut?.shardRefs.every(ref => ref.includes('#'))).toBe(true)
+    expect(heldOut?.familyIds).toEqual([
+      'family.application_state_machine.v1',
+      'family.stack_loop_sum.compiled.v1',
+    ])
+    expect(
+      heldOut?.familyIds.some(familyId => train?.familyIds.includes(familyId)),
+    ).toBe(false)
+    expect(guard!.forbiddenConsumers).toEqual(
+      expect.arrayContaining([
+        'training',
+        'memory_context',
+        'trace_homework',
+        'rag',
+        'optimization',
+        'homework_loop',
+      ]),
+    )
+  })
+
+  test('detects guard weakening if a held-out family is admitted to training', async () => {
+    const manifest = readManifest('tassadar-trace-corpus.v0_2.w3_100m.manifest.json')
+    const guard = manifest.generalizationGuard!
+    const weakened: TassadarGeneralizationGuardManifest = {
+      ...manifest,
+      generalizationGuard: {
+        ...guard,
+        partitions: guard.partitions.map(partition =>
+          partition.kind === 'train_allowed'
+            ? {
+                ...partition,
+                familyIds: [
+                  ...partition.familyIds,
+                  'family.application_state_machine.v1',
+                ],
+              }
+            : partition,
+        ),
+      },
+    }
+
+    await expect(validateTassadarGeneralizationGuard(weakened)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'partition_overlap' }),
+        expect.objectContaining({ kind: 'guard_digest_mismatch' }),
+      ]),
+    )
+  })
+
+  test('MirrorCode public tasks are labeled as Khala GG evidence', () => {
+    const run = buildMirrorCodeRun({
+      runId: 'mc-decision-cal-py-gg-0001',
+      model: 'openagents/khala',
+      taskId: 'cal',
+      bucket: 'S',
+      language: 'python',
+      status: 'failed',
+      passRate: 0.5,
+      tokens: { total: 1 },
+      startedAt: '2026-06-27T00:00:00.000Z',
+      finishedAt: '2026-06-27T00:01:00.000Z',
+      summary: 'Public MirrorCode GG set run for cal.',
+      grade: 'decision_grade',
+    })
+
+    expect(run.generalizationSet).toBe('mirrorcode_public_tasks_no_rag')
+    expect(run.memoryPolicy).toBe('no_rag_public_tasks_only')
+    expect(run.decisionGrade).toBe(true)
+  })
+})

--- a/apps/openagents.com/workers/api/src/tassadar-trace-factory/generalization-guard.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-trace-factory/generalization-guard.ts
@@ -1,0 +1,182 @@
+export const TASSADAR_GENERALIZATION_GUARD_SCHEMA_VERSION =
+  'openagents.tassadar.generalization_guard.v0'
+
+export const TASSADAR_GENERALIZATION_GUARD_FORBIDDEN_CONSUMERS = [
+  'training',
+  'memory_context',
+  'trace_homework',
+  'rag',
+  'optimization',
+  'homework_loop',
+] as const
+
+export const TASSADAR_GENERALIZATION_GUARD_ALLOWED_CONSUMERS = [
+  'gg_eval',
+  'replay_verification',
+  'public_manifest_audit',
+] as const
+
+export type TassadarGeneralizationGuardPartition = Readonly<{
+  familyIds: ReadonlyArray<string>
+  kind: 'train_allowed' | 'gg_held_out'
+  recordCount: number
+  shardRefs: ReadonlyArray<string>
+  split: string
+  tokenCount: number
+}>
+
+export type TassadarGeneralizationGuard = Readonly<{
+  allowedConsumers: ReadonlyArray<string>
+  checksumAlgorithm: 'sha256'
+  forbiddenConsumers: ReadonlyArray<string>
+  guardDigest: string
+  integrityMode: 'checksum_only_no_payload'
+  issueRef: '#6419'
+  metric: 'generalization_gain'
+  partitions: ReadonlyArray<TassadarGeneralizationGuardPartition>
+  schemaVersion: typeof TASSADAR_GENERALIZATION_GUARD_SCHEMA_VERSION
+}>
+
+export type TassadarGeneralizationGuardManifest = Readonly<{
+  corpusId: string
+  generalizationGuard?: TassadarGeneralizationGuard
+  manifestVersion: string
+  records?: Readonly<{ sha256?: string }>
+  snapshotDigest?: string
+  splitPolicyVersion: string
+}>
+
+export type TassadarGeneralizationGuardViolation = Readonly<{
+  detail: string
+  kind:
+    | 'missing_guard'
+    | 'schema_version_mismatch'
+    | 'integrity_mode_mismatch'
+    | 'checksum_algorithm_mismatch'
+    | 'missing_forbidden_consumer'
+    | 'missing_allowed_consumer'
+    | 'partition_overlap'
+    | 'partition_missing'
+    | 'guard_digest_mismatch'
+}>
+
+const digestInputForGuard = (
+  manifest: TassadarGeneralizationGuardManifest,
+  guard: TassadarGeneralizationGuard,
+): string =>
+  JSON.stringify({
+    corpusId: manifest.corpusId,
+    manifestVersion: manifest.manifestVersion,
+    partitions: [...guard.partitions]
+      .map(partition => ({
+        familyIds: [...partition.familyIds].sort(),
+        kind: partition.kind,
+        recordCount: partition.recordCount,
+        shardRefs: [...partition.shardRefs].sort(),
+        split: partition.split,
+        tokenCount: partition.tokenCount,
+      }))
+      .sort((a, b) => `${a.kind}:${a.split}`.localeCompare(`${b.kind}:${b.split}`)),
+    recordsSha256: manifest.records?.sha256 ?? null,
+    schemaVersion: guard.schemaVersion,
+    snapshotDigest: manifest.snapshotDigest ?? null,
+    splitPolicyVersion: manifest.splitPolicyVersion,
+  })
+
+export const sha256HexOfGuardInput = async (input: string): Promise<string> => {
+  const bytes = new TextEncoder().encode(input)
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
+
+  return [...new Uint8Array(digest)]
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export const tassadarGeneralizationGuardDigest = async (
+  manifest: TassadarGeneralizationGuardManifest,
+  guard: TassadarGeneralizationGuard,
+): Promise<string> => sha256HexOfGuardInput(digestInputForGuard(manifest, guard))
+
+export const validateTassadarGeneralizationGuard = async (
+  manifest: TassadarGeneralizationGuardManifest,
+): Promise<ReadonlyArray<TassadarGeneralizationGuardViolation>> => {
+  const guard = manifest.generalizationGuard
+  if (guard === undefined) {
+    return [{ detail: 'Manifest has no generalizationGuard.', kind: 'missing_guard' }]
+  }
+
+  const violations: Array<TassadarGeneralizationGuardViolation> = []
+  if (guard.schemaVersion !== TASSADAR_GENERALIZATION_GUARD_SCHEMA_VERSION) {
+    violations.push({
+      detail: `Expected ${TASSADAR_GENERALIZATION_GUARD_SCHEMA_VERSION}, got ${guard.schemaVersion}.`,
+      kind: 'schema_version_mismatch',
+    })
+  }
+  if (guard.integrityMode !== 'checksum_only_no_payload') {
+    violations.push({
+      detail: `Expected checksum_only_no_payload, got ${guard.integrityMode}.`,
+      kind: 'integrity_mode_mismatch',
+    })
+  }
+  if (guard.checksumAlgorithm !== 'sha256') {
+    violations.push({
+      detail: `Expected sha256, got ${guard.checksumAlgorithm}.`,
+      kind: 'checksum_algorithm_mismatch',
+    })
+  }
+  for (const consumer of TASSADAR_GENERALIZATION_GUARD_FORBIDDEN_CONSUMERS) {
+    if (!guard.forbiddenConsumers.includes(consumer)) {
+      violations.push({
+        detail: `Missing forbidden consumer ${consumer}.`,
+        kind: 'missing_forbidden_consumer',
+      })
+    }
+  }
+  for (const consumer of TASSADAR_GENERALIZATION_GUARD_ALLOWED_CONSUMERS) {
+    if (!guard.allowedConsumers.includes(consumer)) {
+      violations.push({
+        detail: `Missing allowed consumer ${consumer}.`,
+        kind: 'missing_allowed_consumer',
+      })
+    }
+  }
+
+  const train = guard.partitions.filter(
+    partition => partition.kind === 'train_allowed',
+  )
+  const heldOut = guard.partitions.filter(
+    partition => partition.kind === 'gg_held_out',
+  )
+  if (train.length === 0) {
+    violations.push({
+      detail: 'No train_allowed partition is declared.',
+      kind: 'partition_missing',
+    })
+  }
+  if (heldOut.length === 0) {
+    violations.push({
+      detail: 'No gg_held_out partition is declared.',
+      kind: 'partition_missing',
+    })
+  }
+
+  const trainFamilies = new Set(train.flatMap(partition => partition.familyIds))
+  for (const familyId of heldOut.flatMap(partition => partition.familyIds)) {
+    if (trainFamilies.has(familyId)) {
+      violations.push({
+        detail: `Family ${familyId} appears in both train and GG held-out partitions.`,
+        kind: 'partition_overlap',
+      })
+    }
+  }
+
+  const expectedDigest = await tassadarGeneralizationGuardDigest(manifest, guard)
+  if (guard.guardDigest !== expectedDigest) {
+    violations.push({
+      detail: `Guard digest ${guard.guardDigest} does not match ${expectedDigest}.`,
+      kind: 'guard_digest_mismatch',
+    })
+  }
+
+  return violations
+}


### PR DESCRIPTION
Addresses #6419.

### Changes
- Adds `tassadar-trace-factory/generalization-guard.ts`: a SHA-256 guard-digest validator that declares train_allowed vs gg_held_out partitions, forbids consumers (`training`, `memory_context`, `trace_homework`, `rag`, `optimization`, `homework_loop`), allows only `gg_eval`/`replay_verification`/`public_manifest_audit`, and detects family overlap and digest mismatch (guard weakening).
- Adds `generalizationGuard` blocks (checksum_only_no_payload) to the v0_1 and v0_2 Tassadar corpus manifests.
- Formalizes MirrorCode's no-RAG / public-tasks-only rule as a GG set: `MIRRORCODE_GENERALIZATION_SET` / `MIRRORCODE_MEMORY_POLICY` in `mirrorcode-contract.ts` and the scripts README.
- Adds `tassadar-trace-corpus-generalization-guard.test.ts`.

### Verification
Not independently re-verified. PR adds vitest coverage for digest match, held-out isolation, forbidden consumers, and guard-weakening detection.