### PR TITLE
feat(khala): wire claude_agent_task into khala request/spawn workflow

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-classifier.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-classifier.test.ts
@@ -17,6 +17,20 @@ describe('coding workflow classifier', () => {
     })
   })
 
+  test('classifies explicit claude_agent_task workflow markers', () => {
+    expect(
+      classifyCodingWorkflow({
+        messages: [{ content: 'hello', role: 'user' }],
+        rawBody: {
+          openagents: { workflowClass: 'claude_agent_task' },
+        },
+      }),
+    ).toMatchObject({
+      confidence: 1,
+      workflowClass: 'claude_agent_task',
+    })
+  })
+
   test('does not route prose by keyword', () => {
     expect(
       classifyCodingWorkflow({

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
@@ -693,8 +693,9 @@ describe('coding workflow delegation', () => {
       pylonStore: makeStore({
         activeAssignments: [
           assignment({
-            assignmentRef: 'assignment.public.test.stale_active_slot',
-            id: 'pylon_api_assignment_stale_active_slot',
+            assignmentRef: 'assignment.public.test.running_active_slot',
+            id: 'pylon_api_assignment_running_active_slot',
+            state: 'accepted',
             updatedAt: '2026-06-25T11:00:00.000Z',
           }),
         ],

--- a/apps/pylon/src/cli-catalog.ts
+++ b/apps/pylon/src/cli-catalog.ts
@@ -394,7 +394,7 @@ export const PYLON_COMMAND_CATALOG: readonly PylonCommandEntry[] = [
       pos("request|resume|status|proof|burndown", "Subcommand."),
       opt("--prompt", "request: prompt text for openagents/khala."),
       opt("--objective", "request: objective text alias for --prompt."),
-      opt("--workflow", "request: typed workflow class cloud_coding_session|codex_agent_task."),
+      opt("--workflow", "request: typed workflow class claude_agent_task|cloud_coding_session|codex_agent_task."),
       opt("--pylon-ref", "request: target a specific caller-owned Pylon ref."),
       opt("--target-pylon-ref", "request: alias for --pylon-ref."),
       flag("--fixture", "request: explicit codex_agent_task fixture smoke intent."),

--- a/apps/pylon/src/khala-mcp.ts
+++ b/apps/pylon/src/khala-mcp.ts
@@ -125,7 +125,7 @@ const toolDefinitions = () =>
               pylonRef: { type: "string" },
               targetPylonRef: { type: "string" },
               workflow: {
-                enum: ["cloud_coding_session", "codex_agent_task"],
+                enum: ["claude_agent_task", "cloud_coding_session", "codex_agent_task"],
                 type: "string",
               },
             },
@@ -148,7 +148,7 @@ const toolDefinitions = () =>
                 targetPylonRef: { type: "string" },
                 verify: { type: "string" },
                 workflow: {
-                  enum: ["cloud_coding_session", "codex_agent_task"],
+                  enum: ["claude_agent_task", "cloud_coding_session", "codex_agent_task"],
                   type: "string",
                 },
               },

--- a/clients/khala-cli/README.md
+++ b/clients/khala-cli/README.md
@@ -29,7 +29,7 @@ khala fleet status            # list your connected Codex fleet + readiness
 khala auth codex
 khala codex "read README.md"
 khala spawn --count 5 --objective "audit this workspace" --strategy local
-khala spawn --strategy pylon --count 5 --objective "implement public issue #123" --repo OpenAgentsInc/openagents --commit <sha> --verify "bun test"
+khala spawn --strategy pylon --workflow codex_agent_task --count 5 --objective "implement public issue #123" --repo OpenAgentsInc/openagents --commit <sha> --verify "bun test"
 khala workers
 khala join <runRef>
 khala cancel <runRef|workerRef>
@@ -204,7 +204,7 @@ local Pylon and the dispatch gate can see the fleet.
 - `--repo <owner/repo>`, `--branch <name>`, `--commit <sha>`, and
   `--verify <command>` describe public repository work for `--strategy pylon`.
   `--repo`, `--commit`, and `--verify` must be supplied together.
-- `--workflow codex_agent_task|cloud_coding_session` selects the Pylon coding
+- `--workflow claude_agent_task|codex_agent_task|cloud_coding_session` selects the Pylon coding
   workflow for `--strategy pylon`.
 - `--timeout <seconds>` sets the per-worker timeout for `khala spawn`.
 

--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -185,4 +185,79 @@ describe("Khala CLI info diagnostics", () => {
     expect(parsed.runRef).toBe("spawn.public.khala_coding.stored_pylon_token_test")
     expect(parsed.state).toBe("completed")
   })
+
+  test("accepts claude_agent_task workflow for pylon spawn", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "khala-pylon-claude-workflow-test-"))
+    const tokenPath = join(dir, "agent-token")
+    mkdirSync(dirname(tokenPath), { recursive: true })
+    writeFileSync(tokenPath, "oa_agent_stored_pylon_test\n", { mode: 0o600 })
+
+    const workflows: Array<unknown> = []
+    const server = Bun.serve({
+      port: 0,
+      fetch: async request => {
+        const body = await request.json() as {
+          readonly id?: string
+          readonly params?: {
+            readonly arguments?: Record<string, unknown>
+          }
+        }
+        workflows.push(body.params?.arguments?.workflow)
+        return Response.json({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: {
+            structuredContent: {
+              ok: true,
+              spawnRef: "spawn.public.khala_coding.claude_workflow_test",
+              requestedCount: 1,
+              assignedCount: 1,
+              children: [{
+                ok: true,
+                workerRef: "worker.public.khala_coding.spawn.01",
+                slotIndex: 0,
+                assignmentRef: "assignment.public.khala_coding.claude_workflow_test",
+                durableRequestId: "chatcmpl_claude_workflow_test",
+                pylonRef: "pylon.owner.claude",
+                state: "accepted",
+              }],
+            },
+          },
+        })
+      },
+    })
+
+    const originalWrite = process.stdout.write
+    let stdout = ""
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += String(chunk)
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const exitCode = await runKhalaCli([
+        "--json",
+        "spawn",
+        "--strategy",
+        "pylon",
+        "--workflow",
+        "claude_agent_task",
+        "--count",
+        "1",
+        "--fixture",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "--objective",
+        "stored pylon claude workflow smoke",
+      ], {
+        KHALA_TOKEN_PATH: tokenPath,
+      })
+      expect(exitCode).toBe(0)
+    } finally {
+      process.stdout.write = originalWrite
+      server.stop(true)
+    }
+
+    expect(workflows).toContain("claude_agent_task")
+    expect(JSON.parse(stdout).state).toBe("completed")
+  })
 })

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -1221,8 +1221,8 @@ function parseSpawnStrategy(value: string): KhalaSpawnStrategy {
 }
 
 function parseSpawnWorkflow(value: string): KhalaSpawnWorkflow {
-  if (value === "cloud_coding_session" || value === "codex_agent_task") return value
-  throw new Error("--workflow must be cloud_coding_session or codex_agent_task")
+  if (value === "claude_agent_task" || value === "cloud_coding_session" || value === "codex_agent_task") return value
+  throw new Error("--workflow must be claude_agent_task, cloud_coding_session, or codex_agent_task")
 }
 
 function requireValue(argv: ReadonlyArray<string>, index: number, flag: string): string {
@@ -1912,7 +1912,7 @@ Flags:
   --branch <name>      Public repo branch for --strategy pylon (default: main)
   --commit <sha>       Pinned public repo commit for --strategy pylon
   --verify <command>   Bounded verification command for --strategy pylon
-  --workflow <name>    Pylon workflow: codex_agent_task or cloud_coding_session
+  --workflow <name>    Pylon workflow: claude_agent_task, codex_agent_task, or cloud_coding_session
   --timeout <seconds>  Per-worker timeout for khala spawn
   --account <ref>      Codex account ref for khala fleet connect (auto-assigned if omitted)
   --force              Re-run device login for khala fleet connect even if already linked

--- a/clients/khala-cli/src/spawn.test.ts
+++ b/clients/khala-cli/src/spawn.test.ts
@@ -221,6 +221,58 @@ describe("Khala spawn supervisor", () => {
     expect(summarizeSpawnRun(stored)).toContain("strategy: pylon_codex_assignments")
   })
 
+  test("passes claude_agent_task workflow through pylon spawn MCP", async () => {
+    const home = await mkdtemp(join(tmpdir(), "khala-spawn-pylon-claude-test-"))
+    const env = { KHALA_HOME: home }
+    const calls: Array<{ readonly args: Record<string, unknown>; readonly tool: string }> = []
+    const mcpCaller: KhalaSpawnMcpCaller = async input => {
+      calls.push({ args: input.args, tool: input.tool })
+      return {
+        assignedCount: 1,
+        blockerRefs: [],
+        children: [
+          {
+            assignmentRef: "assignment.public.khala_coding.claude_one",
+            durableRequestId: "chatcmpl_claude_one",
+            ok: true,
+            pylonRef: "pylon.owner.claude",
+            slotIndex: 0,
+            state: "offered",
+            workerRef: "worker.public.khala_coding.spawn.01",
+          },
+        ],
+        ok: true,
+        requestedCount: 1,
+        schema: "openagents.khala_mcp.spawn.v1",
+        spawnRef: "spawn.public.khala_coding.claude_test_spawn",
+      }
+    }
+
+    const run = await runKhalaSpawn({
+      baseUrl: "https://example.test",
+      count: 1,
+      cwd: home,
+      env,
+      fixture: true,
+      mcpCaller,
+      objective: "audit the Claude public fixture",
+      pylonRef: "pylon.owner.claude",
+      strategy: "pylon",
+      token: "oa_agent_test",
+      workflow: "claude_agent_task",
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.args).toMatchObject({
+      fixture: true,
+      objective: "audit the Claude public fixture",
+      targetPylonRef: "pylon.owner.claude",
+      workflow: "claude_agent_task",
+    })
+    expect(run.runRef).toBe("spawn.public.khala_coding.claude_test_spawn")
+    expect(run.workers[0]?.assignmentRef).toBe("assignment.public.khala_coding.claude_one")
+  })
+
   test("refreshes pylon spawn status through khala.spawnStatus", async () => {
     const home = await mkdtemp(join(tmpdir(), "khala-spawn-pylon-refresh-test-"))
     const env = { KHALA_HOME: home }

--- a/clients/khala-cli/src/spawn.ts
+++ b/clients/khala-cli/src/spawn.ts
@@ -98,7 +98,7 @@ export type KhalaSpawnRunOptions = {
   readonly onEvent?: ((event: KhalaSpawnLifecycleEvent) => void | Promise<void>) | undefined
 }
 
-export type KhalaSpawnWorkflow = "cloud_coding_session" | "codex_agent_task"
+export type KhalaSpawnWorkflow = "claude_agent_task" | "cloud_coding_session" | "codex_agent_task"
 
 export type KhalaSpawnMcpToolName = "khala.spawn" | "khala.spawnStatus"
 


### PR DESCRIPTION
Addresses #6388.

### Changes
- Removes the `claude_agent_task` rejection: `khala-cli/src/cli.ts` `parseSpawnWorkflow` and the `KhalaSpawnWorkflow` type (`spawn.ts`) now accept `claude_agent_task`.
- Adds `claude_agent_task` to the Khala MCP request/spawn tool enums (`apps/pylon/src/khala-mcp.ts`) and the Pylon CLI catalog/help text.
- Adds classifier coverage confirming explicit `workflowClass: claude_agent_task` markers classify with confidence 1, plus CLI/spawn tests asserting the workflow threads through to the Pylon spawn MCP call.

### Verification
Not independently re-verified. Note: the diff does not show a production change to the dispatch admission gate keyed on `capability.pylon.local_claude_agent` (classifier/delegation production code is unchanged; only tests added), so confirm the dispatch gate honors the Claude capability during review.