### PR TITLE
feat(qa-runner): trace-evidence reproduction fixture generator

### DIFF
--- a/apps/qa-runner/package.json
+++ b/apps/qa-runner/package.json
@@ -52,6 +52,7 @@
     "./atif-html": "./src/atif-html.ts",
     "./atif-emit": "./src/atif-emit.ts",
     "./publish-trace": "./src/publish-trace.ts",
+    "./trace-fixture": "./src/trace-fixture.ts",
 
     "./codex-to-atif": "./src/codex-to-atif.ts"
   },
@@ -82,7 +83,8 @@
     "compose": "bun run src/compose/cli.ts",
     "evals": "bun run src/evals-run.ts",
     "pr-comment": "bun run src/pr-comment-run.ts",
-    "test": "bun test src/byo-model.test.ts src/byo.test.ts src/runner.test.ts src/runner-hardening.test.ts src/timeouts.test.ts src/shard.test.ts src/public-safety.test.ts src/brain.test.ts src/backend.test.ts src/terminal-backend.test.ts src/container-backend.test.ts src/native-desktop-backend.test.ts src/khala-action.test.ts src/khala-driver.test.ts src/khala-config.test.ts src/khala-openrouter.test.ts src/session-trace.test.ts src/distiller.test.ts src/skill-candidate.test.ts src/receipt.test.ts src/run-settlement.test.ts src/khala-session.test.ts src/compose/build-plan.test.ts src/compose/ffmpeg.test.ts src/evals.test.ts src/pr-comment.test.ts src/control-auth.test.ts src/artifacts.test.ts src/control.test.ts src/api-server.test.ts src/failure-learning.test.ts src/failure-learning-gepa.test.ts src/target-registry.test.ts src/target-registry-run.test.ts src/cf-browser-backend.test.ts src/cf-browser-video.test.ts src/cf-sandbox-backend.test.ts src/atif.test.ts src/atif-html.test.ts src/codex-to-atif.test.ts src/redaction.test.ts src/claude-code-to-atif.test.ts src/publish-trace.test.ts src/publish-trace-e2e.verify.test.ts",
+    "trace:fixture": "bun run src/trace-fixture.ts",
+    "test": "bun test src/byo-model.test.ts src/byo.test.ts src/runner.test.ts src/runner-hardening.test.ts src/timeouts.test.ts src/shard.test.ts src/public-safety.test.ts src/brain.test.ts src/backend.test.ts src/terminal-backend.test.ts src/container-backend.test.ts src/native-desktop-backend.test.ts src/khala-action.test.ts src/khala-driver.test.ts src/khala-config.test.ts src/khala-openrouter.test.ts src/session-trace.test.ts src/distiller.test.ts src/skill-candidate.test.ts src/receipt.test.ts src/run-settlement.test.ts src/khala-session.test.ts src/compose/build-plan.test.ts src/compose/ffmpeg.test.ts src/evals.test.ts src/pr-comment.test.ts src/control-auth.test.ts src/artifacts.test.ts src/control.test.ts src/api-server.test.ts src/failure-learning.test.ts src/failure-learning-gepa.test.ts src/target-registry.test.ts src/target-registry-run.test.ts src/cf-browser-backend.test.ts src/cf-browser-video.test.ts src/cf-sandbox-backend.test.ts src/atif.test.ts src/atif-html.test.ts src/codex-to-atif.test.ts src/redaction.test.ts src/claude-code-to-atif.test.ts src/publish-trace.test.ts src/trace-fixture.test.ts src/publish-trace-e2e.verify.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "playwright:install": "playwright install --with-deps chromium",
     "atif:emit": "bun run src/atif-emit.ts",

--- a/apps/qa-runner/src/trace-fixture.test.ts
+++ b/apps/qa-runner/src/trace-fixture.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+
+import type { AtifTrajectory } from "./atif";
+import {
+  generateTraceFixture,
+  loadTraceFixtureFromFile,
+  TRACE_FIXTURE_SCHEMA_VERSION,
+} from "./trace-fixture";
+
+const trajectory = (overrides: Partial<AtifTrajectory> = {}): AtifTrajectory => ({
+  schema_version: "ATIF-v1.7",
+  trajectory_id: "trace-123",
+  session_id: "session-123",
+  agent: {
+    name: "openagents-qa-runner",
+    version: "0.1.0",
+    model_name: "openagents/khala",
+  },
+  steps: [
+    {
+      step_id: 1,
+      source: "user",
+      message: "Reproduce public issue #6398",
+    },
+    {
+      step_id: 2,
+      source: "agent",
+      model_name: "openagents/khala",
+      message: "open the failing page",
+      reasoning_content: "Chose action \"navigate\" against /login; outcome ok.",
+      tool_calls: [
+        {
+          tool_call_id: "call_2",
+          function_name: "navigate",
+          arguments: { target: "/login", action: "navigate" },
+        },
+      ],
+      observation: {
+        results: [
+          {
+            source_call_id: "call_2",
+            content: "ok: open the failing page",
+          },
+        ],
+      },
+    },
+  ],
+  final_metrics: { total_steps: 2 },
+  ...overrides,
+});
+
+describe("generateTraceFixture", () => {
+  test("extracts step input/output payloads from ATIF evidence", () => {
+    const fixture = generateTraceFixture({
+      evidenceRef: "https://openagents.com/trace/trace-123",
+      trajectory: trajectory(),
+    });
+
+    expect(fixture.schemaVersion).toBe(TRACE_FIXTURE_SCHEMA_VERSION);
+    expect(fixture.evidenceRef).toBe("https://openagents.com/trace/trace-123");
+    expect(fixture.trajectoryId).toBe("trace-123");
+    expect(fixture.cases).toHaveLength(2);
+
+    const agentCase = fixture.cases[1]!;
+    expect(agentCase.id).toBe("trace-123:step-2");
+    expect(agentCase.input.message).toBe("open the failing page");
+    expect(agentCase.input.toolCalls?.[0]).toEqual({
+      name: "navigate",
+      arguments: { target: "/login", action: "navigate" },
+    });
+    expect(agentCase.output).toEqual({
+      observations: ["ok: open the failing page"],
+      status: "ok",
+    });
+  });
+
+  test("marks failed observations as failed fixture cases", () => {
+    const fixture = generateTraceFixture({
+      evidenceRef: "trace://failed",
+      trajectory: trajectory({
+        steps: [
+          {
+            step_id: 1,
+            source: "agent",
+            message: "assert checkout works",
+            tool_calls: [
+              {
+                tool_call_id: "call_1",
+                function_name: "assert",
+                arguments: { target: "checkout completed" },
+              },
+            ],
+            observation: {
+              results: [
+                {
+                  source_call_id: "call_1",
+                  content: "FAILED: checkout button did not enable",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(fixture.cases[0]!.output.status).toBe("failed");
+  });
+
+  test("redacts unsafe values before returning a fixture", () => {
+    const fixture = generateTraceFixture({
+      evidenceRef: "trace://unsafe",
+      trajectory: trajectory({
+        steps: [
+          {
+            step_id: 1,
+            source: "user",
+            message:
+              "Failure happened at /Users/alice/work/app with token sk-test_secretvalue",
+          },
+        ],
+      }),
+    });
+
+    const serialized = JSON.stringify(fixture);
+    expect(serialized).not.toContain("/Users/alice");
+    expect(serialized).not.toContain("sk-test_secretvalue");
+    expect(serialized).toContain("[REDACTED:home_path]");
+    expect(serialized).toContain("[REDACTED:provider_key]");
+    expect(fixture.redaction.total).toBeGreaterThanOrEqual(2);
+  });
+
+  test("loads a fixture from an ATIF JSON file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "trace-fixture-"));
+    try {
+      const inputPath = join(dir, "trajectory.json");
+      writeFileSync(inputPath, JSON.stringify(trajectory()));
+
+      const fixture = loadTraceFixtureFromFile(inputPath, {
+        evidenceRef: "local-test-ref",
+      });
+
+      expect(fixture.evidenceRef).toBe("local-test-ref");
+      expect(fixture.cases[0]!.input.message).toBe("Reproduce public issue #6398");
+      expect(readFileSync(inputPath, "utf8")).toContain("trace-123");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/qa-runner/src/trace-fixture.ts
+++ b/apps/qa-runner/src/trace-fixture.ts
@@ -1,0 +1,189 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+import { redactValue, type RedactionReport } from "./redaction";
+import {
+  type AtifStep,
+  type AtifToolCall,
+  type AtifTrajectory,
+} from "./atif";
+import { assertValidAtif } from "./atif-validate";
+
+export const TRACE_FIXTURE_SCHEMA_VERSION =
+  "openagents.qa_runner.trace_fixture.v1" as const;
+
+export interface TraceFixtureToolCall {
+  readonly name: string;
+  readonly arguments: Record<string, unknown>;
+}
+
+export interface TraceFixtureCase {
+  readonly id: string;
+  readonly stepId: number;
+  readonly source: "user" | "agent" | "system";
+  readonly input: {
+    readonly message: string;
+    readonly reasoning?: string;
+    readonly toolCalls?: ReadonlyArray<TraceFixtureToolCall>;
+  };
+  readonly output: {
+    readonly observations: ReadonlyArray<string>;
+    readonly status: "ok" | "failed" | "unknown";
+  };
+}
+
+export interface TraceFixture {
+  readonly schemaVersion: typeof TRACE_FIXTURE_SCHEMA_VERSION;
+  readonly evidenceRef: string;
+  readonly trajectoryId: string;
+  readonly sessionId?: string;
+  readonly agent: {
+    readonly name: string;
+    readonly version: string;
+    readonly model?: string;
+  };
+  readonly cases: ReadonlyArray<TraceFixtureCase>;
+  readonly redaction: RedactionReport;
+}
+
+export interface GenerateTraceFixtureInput {
+  readonly evidenceRef: string;
+  readonly trajectory: AtifTrajectory;
+}
+
+const normalizeToolCall = (call: AtifToolCall): TraceFixtureToolCall => ({
+  name: call.function_name,
+  arguments: call.arguments,
+});
+
+const observationContents = (step: AtifStep): ReadonlyArray<string> =>
+  (step.observation?.results ?? [])
+    .map((result) => result.content)
+    .filter((content): content is string => typeof content === "string");
+
+const statusFromObservations = (
+  observations: ReadonlyArray<string>,
+): TraceFixtureCase["output"]["status"] => {
+  if (observations.length === 0) return "unknown";
+  return observations.some((content) => /^FAILED\b/i.test(content)) ? "failed" : "ok";
+};
+
+const caseForStep = (
+  trajectoryId: string,
+  step: AtifStep,
+): TraceFixtureCase | undefined => {
+  const observations = observationContents(step);
+  const toolCalls = (step.tool_calls ?? []).map(normalizeToolCall);
+
+  if (step.message === "" && toolCalls.length === 0 && observations.length === 0) {
+    return undefined;
+  }
+
+  const input: TraceFixtureCase["input"] = {
+    message: step.message,
+    ...(step.reasoning_content ? { reasoning: step.reasoning_content } : {}),
+    ...(toolCalls.length > 0 ? { toolCalls } : {}),
+  };
+
+  return {
+    id: `${trajectoryId}:step-${step.step_id}`,
+    stepId: step.step_id,
+    source: step.source,
+    input,
+    output: {
+      observations,
+      status: statusFromObservations(observations),
+    },
+  };
+};
+
+/**
+ * Extract a public-safe reproduction fixture from an ATIF trace evidence ref.
+ *
+ * The trace is first validated against the ATIF producer contract, then the
+ * generated fixture is passed through the shared trace redactor. This keeps the
+ * fixture usable for regression tests while preventing raw prompts, paths,
+ * tokens, credentials, emails, and wallet material from becoming committed test
+ * data.
+ */
+export const generateTraceFixture = (
+  input: GenerateTraceFixtureInput,
+): TraceFixture => {
+  assertValidAtif(input.trajectory);
+
+  const trajectoryId = input.trajectory.trajectory_id ?? input.trajectory.session_id ?? "trace";
+  const rawFixture: Omit<TraceFixture, "redaction"> = {
+    schemaVersion: TRACE_FIXTURE_SCHEMA_VERSION,
+    evidenceRef: input.evidenceRef,
+    trajectoryId,
+    ...(input.trajectory.session_id ? { sessionId: input.trajectory.session_id } : {}),
+    agent: {
+      name: input.trajectory.agent.name,
+      version: input.trajectory.agent.version,
+      ...(input.trajectory.agent.model_name
+        ? { model: input.trajectory.agent.model_name }
+        : {}),
+    },
+    cases: input.trajectory.steps
+      .map((step) => caseForStep(trajectoryId, step))
+      .filter((fixtureCase): fixtureCase is TraceFixtureCase => fixtureCase !== undefined),
+  };
+
+  const redacted = redactValue(rawFixture);
+  return {
+    ...redacted.value,
+    redaction: redacted.report,
+  };
+};
+
+export const loadTraceFixtureFromFile = (
+  path: string,
+  options: { readonly evidenceRef?: string } = {},
+): TraceFixture => {
+  const trajectory = JSON.parse(readFileSync(path, "utf8")) as AtifTrajectory;
+  return generateTraceFixture({
+    evidenceRef: options.evidenceRef ?? path,
+    trajectory,
+  });
+};
+
+const usage = (): string =>
+  [
+    "Usage: bun run src/trace-fixture.ts <atif-trajectory.json> [--out fixture.json] [--ref evidence-ref]",
+    "",
+    "Reads a public-safe ATIF trajectory and writes a redacted reproduction fixture.",
+  ].join("\n");
+
+const runCli = (): void => {
+  const args = process.argv.slice(2);
+  const inputPath = args[0];
+  if (!inputPath || inputPath === "--help" || inputPath === "-h") {
+    console.log(usage());
+    process.exit(inputPath ? 0 : 1);
+  }
+
+  const outIndex = args.indexOf("--out");
+  const refIndex = args.indexOf("--ref");
+  const outPath = outIndex >= 0 ? args[outIndex + 1] : undefined;
+  const evidenceRef = refIndex >= 0 ? args[refIndex + 1] : undefined;
+  if (outIndex >= 0 && !outPath) {
+    throw new Error("--out requires a file path");
+  }
+  if (refIndex >= 0 && !evidenceRef) {
+    throw new Error("--ref requires an evidence ref");
+  }
+
+  const fixture = loadTraceFixtureFromFile(
+    inputPath,
+    evidenceRef ? { evidenceRef } : {},
+  );
+  const body = `${JSON.stringify(fixture, null, 2)}\n`;
+  if (outPath) {
+    writeFileSync(outPath, body);
+    return;
+  }
+  process.stdout.write(body);
+};
+
+if (import.meta.main) {
+  runCli();
+}


### PR DESCRIPTION
Addresses #6398.

### Changes
- Adds `apps/qa-runner/src/trace-fixture.ts`: `generateTraceFixture` validates an ATIF trajectory, extracts per-step public-safe input (message/reasoning/tool calls) and output (observations + ok/failed/unknown status), then runs the shared redactor so paths/tokens/credentials never become committed fixtures.
- Adds `loadTraceFixtureFromFile` and a CLI (`bun run src/trace-fixture.ts <atif.json> [--out] [--ref]`) plus `trace:fixture` script and `./trace-fixture` export in `package.json`.
- Adds `trace-fixture.test.ts` (extraction, failed-status detection, redaction, file load) to the test script.

### Verification
Not independently re-verified. PR adds bun:test coverage including redaction assertions on home paths and provider keys.