### PR TITLE
pylon: Implement public issue #6435 and run the named verification. (#6435)

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
@@ -106,6 +106,7 @@ export type OperatorArtanisChatDependencies<
   makeOperatorTools?: (
     env: Bindings,
     session: Session,
+    request: Request,
   ) => ReadonlyArray<ArtanisOperatorTool>
 }>
 
@@ -333,7 +334,7 @@ export const makeOperatorArtanisChatRoutes = <
       })
 
       const tools =
-        dependencies.makeOperatorTools?.(env, session) ??
+        dependencies.makeOperatorTools?.(env, session, request) ??
         makeArtanisOperatorTools()
 
       const turn = yield* artanisOperatorTurn({

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -28,6 +28,7 @@ import {
   makeArtanisListPylonAssignmentsTool,
   makeArtanisListRepoDirTool,
   makeArtanisOperatorTools,
+  makeArtanisPostForumUpdateTool,
   makeArtanisReadGithubIssueTool,
   makeArtanisReadRepoFileTool,
   makeArtanisTriggerSyntheticLoadTool,
@@ -353,6 +354,141 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
     // Neither the approval gate nor the create seam is consulted for bad input.
     expect(approvalCalls).toHaveLength(0)
     expect(createCalls).toHaveLength(0)
+  })
+})
+
+describe('#6435 post_forum_update (gated; public Forum publication)', () => {
+  test('with NO execution seam it DEFERS and returns the exact Forum API plan', async () => {
+    const tool = makeArtanisPostForumUpdateTool()
+
+    const result = await Effect.runPromise(
+      tool.run({
+        action: 'create_topic',
+        bodyText:
+          'Fleet update: Codex burndown is running against public issues only.',
+        forumSlug: 'product-promises',
+        title: 'Artanis fleet update',
+      }),
+    )
+
+    expect(tool.kind).toBe('gated')
+    expect(tool.riskyActionKind).toBe('public_claim_upgrade')
+    expect(result.outcome).toBe('deferred')
+    if (result.outcome !== 'deferred') return
+    expect(result.reason).toBe('execution_not_wired')
+    expect(result.plan).toContain(
+      'POST /api/forum/forums/product-promises/topics',
+    )
+    expect(result.plan).toContain('Idempotency-Key: artanis-forum-update-')
+    expect(result.plan).toContain('"title":"Artanis fleet update"')
+  })
+
+  test('owner-approved execution creates a topic under the forum identity seam', async () => {
+    const posted: Array<unknown> = []
+    const tool = makeArtanisPostForumUpdateTool({
+      execution: {
+        isOwnerApproved: () => Effect.succeed(true),
+        postForumUpdate: plan => {
+          posted.push(plan)
+          return Effect.succeed({
+            action: 'create_topic',
+            forumSlug: plan.forumSlug ?? null,
+            kind: 'created',
+            postId: 'post_123',
+            topicId: 'topic_123',
+            url: 'https://openagents.com/forum/t/topic_123',
+          } as const)
+        },
+      },
+    })
+
+    const result = await Effect.runPromise(
+      tool.run({
+        bodyText:
+          'Fleet update: public issue #6435 is now wired for gated Forum posts.',
+        forumSlug: 'product-promises',
+        title: 'Artanis forum-post tool update',
+      }),
+    )
+
+    expect(result.outcome).toBe('executed')
+    if (result.outcome !== 'executed') return
+    expect(posted).toHaveLength(1)
+    expect(result.assignmentRef).toBe('forum.post.post_123')
+    expect(result.summary).toContain('topicId: topic_123')
+    expect(result.summary).toContain('author: Artanis forum agent identity')
+  })
+
+  test('NO owner approval defers without calling the posting seam', async () => {
+    const posted: Array<unknown> = []
+    const tool = makeArtanisPostForumUpdateTool({
+      execution: {
+        isOwnerApproved: () => Effect.succeed(false),
+        postForumUpdate: plan => {
+          posted.push(plan)
+          return Effect.succeed({
+            action: 'reply',
+            forumSlug: null,
+            kind: 'created',
+            postId: 'post_should_not_happen',
+            topicId: 'topic_123',
+            url: 'https://openagents.com/forum/t/topic_123#post-post_should_not_happen',
+          } as const)
+        },
+      },
+    })
+
+    const result = await Effect.runPromise(
+      tool.run({
+        action: 'reply',
+        bodyText: 'Fleet update reply.',
+        topicId: 'topic_123',
+      }),
+    )
+
+    expect(result.outcome).toBe('deferred')
+    if (result.outcome !== 'deferred') return
+    expect(result.reason).toBe('no_effective_owner_approval')
+    expect(posted).toHaveLength(0)
+    expect(result.plan).toContain('POST /api/forum/topics/topic_123/posts')
+  })
+
+  test('blocks private material and never consults approval or posting seams', async () => {
+    const approvalCalls: Array<unknown> = []
+    const posted: Array<unknown> = []
+    const tool = makeArtanisPostForumUpdateTool({
+      execution: {
+        isOwnerApproved: () => {
+          approvalCalls.push(true)
+          return Effect.succeed(true)
+        },
+        postForumUpdate: plan => {
+          posted.push(plan)
+          return Effect.succeed({
+            action: 'create_topic',
+            forumSlug: 'product-promises',
+            kind: 'created',
+            postId: null,
+            topicId: 'topic_should_not_happen',
+            url: 'https://openagents.com/forum/t/topic_should_not_happen',
+          } as const)
+        },
+      },
+    })
+
+    const result = await Effect.runPromise(
+      tool.run({
+        bodyText: 'Use bearer sk-abc123 from /Users/local/auth.json',
+        title: 'Unsafe update',
+      }),
+    )
+
+    expect(result.outcome).toBe('deferred')
+    if (result.outcome !== 'deferred') return
+    expect(result.reason).toBe('invalid_arguments')
+    expect(result.plan).toContain('blocked')
+    expect(approvalCalls).toHaveLength(0)
+    expect(posted).toHaveLength(0)
   })
 })
 
@@ -2232,6 +2368,7 @@ describe('makeArtanisOperatorTools default table', () => {
       'list_github_issues',
       'list_pylon_assignments',
       'list_repo_dir',
+      'post_forum_update',
       'read_github_issue',
       'read_repo_file',
       'trigger_synthetic_load',
@@ -2303,6 +2440,16 @@ describe('makeArtanisOperatorTools default table', () => {
     )
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('risky')
+  })
+
+  test('the default table includes a gated post_forum_update tool', () => {
+    const tools = makeArtanisOperatorTools()
+    const tool = tools.find(t => t.definition.name === 'post_forum_update')
+    expect(tool).toBeDefined()
+    expect(tool?.kind).toBe('gated')
+    if (tool?.kind === 'gated') {
+      expect(tool.riskyActionKind).toBe('public_claim_upgrade')
+    }
   })
 
   test('a shared repoRead fetch stub also drives the issue-read tool', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -2315,6 +2315,343 @@ export const makeArtanisDispatchCodexTaskTool = (
 }
 
 // ---------------------------------------------------------------------------
+// #6435 — post_forum_update (GATED: public_claim_upgrade).
+// ---------------------------------------------------------------------------
+//
+// Artanis can compose public-safe update copy, but publishing to the Forum is an
+// outward public action. Keep it gated: with no execution seam or no effective
+// owner approval it returns the exact Forum API call it would make; only a wired,
+// approved seam may create the topic/reply under Artanis's forum identity.
+
+export const ARTANIS_FORUM_UPDATE_ACTIONS = ['create_topic', 'reply'] as const
+export type ArtanisForumUpdateAction =
+  (typeof ARTANIS_FORUM_UPDATE_ACTIONS)[number]
+
+export const ARTANIS_FORUM_UPDATE_DEFAULT_FORUM_SLUG = 'product-promises'
+export const ARTANIS_FORUM_UPDATE_BODY_MAX_CHARS = 8_000
+export const ARTANIS_FORUM_UPDATE_TITLE_MAX_CHARS = 160
+
+const FORUM_UPDATE_UNSAFE_PATTERN =
+  /(@|\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer|cookie|ghp_[A-Za-z0-9_]+|gho_[A-Za-z0-9_]+|lnbc|lntb|lnurl|macaroon|mnemonic|oauth|preimage|private[_-]?key|seed[_-]?phrase|sk-[a-z0-9])/i
+
+const forumUpdateFieldIsSafe = (value: string): boolean =>
+  !FORUM_UPDATE_UNSAFE_PATTERN.test(value)
+
+const isSafeForumSlug = (slug: string): boolean =>
+  slug.length > 0 &&
+  slug.length <= 80 &&
+  /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(slug) &&
+  forumUpdateFieldIsSafe(slug)
+
+const isSafeForumTopicId = (topicId: string): boolean =>
+  topicId.length > 0 &&
+  topicId.length <= 160 &&
+  /^[A-Za-z0-9][A-Za-z0-9_.:-]*$/.test(topicId) &&
+  forumUpdateFieldIsSafe(topicId)
+
+const stableForumUpdateSuffix = (value: string): string => {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export type ArtanisForumUpdatePlanInput = Readonly<{
+  action: ArtanisForumUpdateAction
+  bodyText: string
+  forumSlug: string | undefined
+  idempotencyKey: string
+  title: string | undefined
+  topicId: string | undefined
+}>
+
+export type ArtanisForumUpdateCreateResult =
+  | Readonly<{
+      kind: 'created'
+      action: ArtanisForumUpdateAction
+      forumSlug: string | null
+      topicId: string
+      postId: string | null
+      url: string
+    }>
+  | Readonly<{ kind: 'rejected'; reason: string }>
+
+export type ArtanisForumUpdateExecution = Readonly<{
+  isOwnerApproved: () => Effect.Effect<boolean>
+  postForumUpdate: (
+    plan: ArtanisForumUpdatePlanInput,
+  ) => Effect.Effect<ArtanisForumUpdateCreateResult>
+}>
+
+const parseForumUpdateAction = (
+  record: Record<string, unknown>,
+): ArtanisForumUpdateAction => {
+  const raw = asString(record.action ?? record.kind)
+  return raw === 'reply' || raw === 'create_topic' ? raw : 'create_topic'
+}
+
+const buildArtanisForumUpdatePlan = (
+  args: unknown,
+  defaultForumSlug: string,
+):
+  | Readonly<{ ok: true; input: ArtanisForumUpdatePlanInput; planText: string }>
+  | Readonly<{ ok: false; message: string }> => {
+  const record =
+    typeof args === 'object' && args !== null
+      ? (args as Record<string, unknown>)
+      : {}
+  const action = parseForumUpdateAction(record)
+  const bodyText = asString(record.bodyText ?? record.body ?? record.message)
+  if (bodyText === undefined) {
+    return {
+      message: '(invalid arguments: a public-safe "bodyText" string is required)',
+      ok: false,
+    }
+  }
+  if (bodyText.length > ARTANIS_FORUM_UPDATE_BODY_MAX_CHARS) {
+    return {
+      message: `(blocked: forum update body exceeds ${ARTANIS_FORUM_UPDATE_BODY_MAX_CHARS} characters)`,
+      ok: false,
+    }
+  }
+  if (!forumUpdateFieldIsSafe(bodyText)) {
+    return {
+      message:
+        '(blocked: forum update body contained non-public-safe material; remove secrets, tokens, local paths, payment material, or private credentials)',
+      ok: false,
+    }
+  }
+
+  const requestedForumSlug = asString(
+    record.forumSlug ?? record.forum_slug ?? record.forum,
+  )
+  const forumSlug =
+    action === 'create_topic'
+      ? (requestedForumSlug ?? defaultForumSlug)
+      : requestedForumSlug
+  if (forumSlug !== undefined && !isSafeForumSlug(forumSlug)) {
+    return {
+      message: `(blocked: "${forumSlug}" is not an allowed forum slug)`,
+      ok: false,
+    }
+  }
+
+  const topicId = asString(record.topicId ?? record.topic_id ?? record.topic)
+  if (action === 'reply' && topicId === undefined) {
+    return {
+      message: '(invalid arguments: "topicId" is required when action is "reply")',
+      ok: false,
+    }
+  }
+  if (topicId !== undefined && !isSafeForumTopicId(topicId)) {
+    return {
+      message: `(blocked: "${topicId}" is not an allowed forum topic id)`,
+      ok: false,
+    }
+  }
+
+  const title = asString(record.title)
+  if (action === 'create_topic' && title === undefined) {
+    return {
+      message: '(invalid arguments: "title" is required when action is "create_topic")',
+      ok: false,
+    }
+  }
+  if (title !== undefined) {
+    if (
+      title.length < 3 ||
+      title.length > ARTANIS_FORUM_UPDATE_TITLE_MAX_CHARS
+    ) {
+      return {
+        message: `(blocked: forum topic title must be 3-${ARTANIS_FORUM_UPDATE_TITLE_MAX_CHARS} characters)`,
+        ok: false,
+      }
+    }
+    if (!forumUpdateFieldIsSafe(title)) {
+      return {
+        message:
+          '(blocked: forum topic title contained non-public-safe material)',
+        ok: false,
+      }
+    }
+  }
+
+  const rawIdempotencyKey = asString(
+    record.idempotencyKey ?? record.idempotency_key,
+  )
+  const generatedIdempotencyKey = `artanis-forum-update-${stableForumUpdateSuffix(
+    [action, forumSlug ?? '', topicId ?? '', title ?? '', bodyText].join('\0'),
+  )}`
+  const idempotencyKey = rawIdempotencyKey ?? generatedIdempotencyKey
+  if (
+    idempotencyKey.length > 120 ||
+    !/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/.test(idempotencyKey) ||
+    !forumUpdateFieldIsSafe(idempotencyKey)
+  ) {
+    return {
+      message: `(blocked: "${idempotencyKey}" is not an allowed idempotency key)`,
+      ok: false,
+    }
+  }
+
+  const endpoint =
+    action === 'create_topic'
+      ? `/api/forum/forums/${encodeURIComponent(forumSlug ?? defaultForumSlug)}/topics`
+      : `/api/forum/topics/${encodeURIComponent(topicId ?? '')}/posts`
+  const payload =
+    action === 'create_topic'
+      ? { bodyText, title: title ?? '' }
+      : { bodyText }
+  const lines = [
+    'Planned Artanis Forum update (public post; owner-gated):',
+    '',
+    `  POST ${endpoint}`,
+    `  Idempotency-Key: ${idempotencyKey}`,
+    `  JSON: ${JSON.stringify(payload)}`,
+    '',
+    'Execution must use Artanis\'s own forum-active agent identity. Do not include raw tokens, private prompts, wallet material, or local paths in the post.',
+  ]
+
+  return {
+    input: {
+      action,
+      bodyText,
+      forumSlug: action === 'create_topic' ? (forumSlug ?? defaultForumSlug) : forumSlug,
+      idempotencyKey,
+      title,
+      topicId,
+    },
+    ok: true,
+    planText: lines.join('\n'),
+  }
+}
+
+export const makeArtanisPostForumUpdateTool = (
+  config: Readonly<{
+    defaultForumSlug?: string | undefined
+    execution?: ArtanisForumUpdateExecution | undefined
+  }> = {},
+): ArtanisOperatorGatedTool => {
+  const defaultForumSlug =
+    config.defaultForumSlug ?? ARTANIS_FORUM_UPDATE_DEFAULT_FORUM_SLUG
+  const execution = config.execution
+
+  return {
+    definition: {
+      description:
+        'Post a public-safe Artanis update to the OpenAgents Forum by creating a topic or replying to a topic. This is a gated public action: it executes ONLY behind an effective owner approval and a wired Artanis forum identity; otherwise it returns the exact Forum API call it would make. Inputs must be public-safe: no raw tokens, private prompts, wallet material, credentials, or local paths.',
+      name: 'post_forum_update',
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          action: {
+            description:
+              'Forum write kind: "create_topic" (default) or "reply".',
+            enum: [...ARTANIS_FORUM_UPDATE_ACTIONS],
+            type: 'string',
+          },
+          bodyText: {
+            description:
+              'Public-safe Forum post body. No secrets, raw prompts, credentials, wallet/payment material, or local paths.',
+            type: 'string',
+          },
+          forumSlug: {
+            description: `Forum slug for create_topic, default "${defaultForumSlug}".`,
+            type: 'string',
+          },
+          idempotencyKey: {
+            description:
+              'Optional public-safe idempotency key. If omitted, one is derived from the post fields.',
+            type: 'string',
+          },
+          title: {
+            description:
+              'Topic title. Required for create_topic, ignored for reply.',
+            type: 'string',
+          },
+          topicId: {
+            description: 'Existing topic id. Required for reply.',
+            type: 'string',
+          },
+        },
+        required: ['bodyText'],
+        type: 'object',
+      },
+    },
+    kind: 'gated',
+    riskyActionKind: 'public_claim_upgrade',
+    run: (args: unknown): Effect.Effect<ArtanisOperatorGatedResult> =>
+      Effect.gen(function* () {
+        const built = buildArtanisForumUpdatePlan(args, defaultForumSlug)
+        if (!built.ok) {
+          return {
+            outcome: 'deferred',
+            plan: built.message,
+            reason: 'invalid_arguments',
+          }
+        }
+
+        if (execution === undefined) {
+          return {
+            outcome: 'deferred',
+            plan: built.planText,
+            reason: 'execution_not_wired',
+          }
+        }
+
+        const approved = yield* execution
+          .isOwnerApproved()
+          .pipe(Effect.orElseSucceed(() => false))
+        if (!approved) {
+          return {
+            outcome: 'deferred',
+            plan: built.planText,
+            reason: 'no_effective_owner_approval',
+          }
+        }
+
+        const created = yield* execution.postForumUpdate(built.input).pipe(
+          Effect.orElseSucceed(
+            () =>
+              ({
+                kind: 'rejected',
+                reason: 'forum_execution_failed',
+              }) as const,
+          ),
+        )
+        if (created.kind === 'rejected') {
+          return {
+            outcome: 'deferred',
+            plan: built.planText,
+            reason: created.reason,
+          }
+        }
+
+        const summary = [
+          `action: ${created.action}`,
+          `forumSlug: ${created.forumSlug ?? '(unknown)'}`,
+          `topicId: ${created.topicId}`,
+          `postId: ${created.postId ?? '(none)'}`,
+          `url: ${created.url}`,
+          `idempotencyKey: ${built.input.idempotencyKey}`,
+          'author: Artanis forum agent identity',
+        ].join('\n')
+        return {
+          assignmentRef:
+            created.postId === null
+              ? `forum.topic.${created.topicId}`
+              : `forum.post.${created.postId}`,
+          durableRequestId: null,
+          outcome: 'executed',
+          summary,
+        }
+      }),
+  }
+}
+
+// ---------------------------------------------------------------------------
 // get_network_stats — LIVE public stats + token pace (epic #6359).
 // ---------------------------------------------------------------------------
 //
@@ -3329,6 +3666,9 @@ export const makeArtanisGetSyntheticLoadStatusTool = (
 // is honest ("(could not update …: no ledger writer is wired)") rather than
 // inventive. It is a WRITE tool, not risky/gated: owner-scoped, internal-ledger-
 // only, with no spend/payout/deploy/delete/outward authority.
+// `forumUpdateExecution` is the gated public Forum publication seam behind
+// #6435 `post_forum_update`; with no seam or no effective approval it returns an
+// exact Forum API plan instead of posting.
 export const makeArtanisOperatorTools = (
   config: Readonly<{
     repoRead?: ArtanisRepoReadConfig | undefined
@@ -3344,6 +3684,7 @@ export const makeArtanisOperatorTools = (
     glmFleetStatus?: ArtanisGlmFleetStatusConfig | undefined
     syntheticLoadStatus?: ArtanisSyntheticLoadStatusConfig | undefined
     dispatchExecution?: ArtanisDispatchExecution | undefined
+    forumUpdateExecution?: ArtanisForumUpdateExecution | undefined
     syntheticLoad?:
       | Readonly<{
           minTargetTokens?: number | undefined
@@ -3380,6 +3721,9 @@ export const makeArtanisOperatorTools = (
     makeArtanisDispatchCodexTaskTool({
       defaultBranch: config.defaultBranch,
       execution: config.dispatchExecution,
+    }),
+    makeArtanisPostForumUpdateTool({
+      execution: config.forumUpdateExecution,
     }),
     makeArtanisTriggerSyntheticLoadTool(config.syntheticLoad),
   ]

--- a/apps/openagents.com/workers/api/src/artanis-operator.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.ts
@@ -803,7 +803,7 @@ const runToolCall = (
       if (outcome.outcome === 'executed') {
         const content = [
           `EXECUTED — own-capacity, no spend.`,
-          `I created the Khala -> Pylon -> Codex assignment (${tool.definition.name}) on your linked Pylon. It runs at no spend and grants no payout.`,
+          `I completed the gated action (${tool.definition.name}) with no spend and no payout authority.`,
           '',
           outcome.summary,
         ].join('\n')

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -79,6 +79,10 @@ import {
   runArtanisCloseoutVerifierScheduled,
 } from './artanis-administrator-tick'
 import {
+  ArtanisApprovalGateRecord,
+  artanisApprovalGateEffective,
+} from './artanis-approval-gates'
+import {
   boundedDistillationDatasetLimit,
   readArtanisDistillationDatasetReceipt,
 } from './artanis-distillation-dataset-receipt'
@@ -594,6 +598,7 @@ import {
   optionalInteger,
   optionalNestedString,
   optionalString,
+  parseJsonUnknown,
   readJsonObject,
   safeJsonRecord,
   stringArrayFromUnknown,
@@ -8521,6 +8526,48 @@ const operatorArtanisConsoleRoutes = makeOperatorArtanisConsoleRoutes({
 // `openagents/khala` pool and meters the call as Khala usage, so this channel
 // never calls a provider directly. `makeKhalaClient` is invoked at request time,
 // so referencing the (later-declared) builder here is safe.
+const readEffectiveArtanisPublicClaimApprovalForOwner = async (
+  db: D1Database,
+  nowIso: string,
+  ownerOpenAuthUserId: string,
+): Promise<boolean> => {
+  if (isOpenAgentsOwnerAgentOpenAuthUserId(ownerOpenAuthUserId)) {
+    return true
+  }
+  const result = await db
+    .prepare(
+      `SELECT record_json
+         FROM artanis_approval_gates
+        ORDER BY updated_at DESC
+        LIMIT 50`,
+    )
+    .all<{ record_json: string }>()
+    .catch(() => ({ results: [] as ReadonlyArray<{ record_json: string }> }))
+
+  for (const row of result.results ?? []) {
+    try {
+      const parsed = parseJsonUnknown(row.record_json)
+      const record = S.decodeUnknownSync(ArtanisApprovalGateRecord)(parsed)
+      if (
+        record.kind === 'public_claim_upgrade' &&
+        artanisApprovalGateEffective(record, nowIso)
+      ) {
+        return true
+      }
+    } catch {
+      // Undecodable legacy row: skip it, never treat it as approval.
+    }
+  }
+  return false
+}
+
+const forumUrlForTopic = (topicId: string, postId: string | null): string =>
+  postId === null
+    ? `https://openagents.com/forum/t/${encodeURIComponent(topicId)}`
+    : `https://openagents.com/forum/t/${encodeURIComponent(
+        topicId,
+      )}#post-${encodeURIComponent(postId)}`
+
 const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
   appendRefreshedSessionCookies,
   // Inject the LIVE daily token-pace block into EVERY Artanis turn (epic #6359)
@@ -8544,7 +8591,7 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
   // no-spend (`unpaid_smoke`), and gated behind an effective `pylon_job_dispatch`
   // owner approval. With no effective approval (the default today), the tool
   // returns the plan and defers — it never fires.
-  makeOperatorTools: (env, session) => {
+  makeOperatorTools: (env, session, request) => {
     // Owner-scope resolver shared by the gated dispatch seam and the
     // owner-scoped Pylon job-status reader: resolve the owner's linked agent
     // user ids (their Pylon-owning credentials) so both stay strictly
@@ -8715,6 +8762,96 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
           }
         },
       }),
+      forumUpdateExecution: {
+        isOwnerApproved: () =>
+          Effect.tryPromise({
+            catch: () => false,
+            try: () =>
+              readEffectiveArtanisPublicClaimApprovalForOwner(
+                openAgentsDatabase(env),
+                currentIsoTimestamp(),
+                session.user.userId,
+              ),
+          }).pipe(Effect.orElseSucceed(() => false)),
+        postForumUpdate: plan =>
+          Effect.tryPromise(async () => {
+            const bearer = readBearerToken(request)
+            if (bearer === undefined) {
+              return {
+                kind: 'rejected',
+                reason: 'forum_agent_bearer_missing',
+              } as const
+            }
+            const path =
+              plan.action === 'create_topic'
+                ? `/api/forum/forums/${encodeURIComponent(
+                    plan.forumSlug ?? 'product-promises',
+                  )}/topics`
+                : `/api/forum/topics/${encodeURIComponent(
+                    plan.topicId ?? '',
+                  )}/posts`
+            const body =
+              plan.action === 'create_topic'
+                ? { bodyText: plan.bodyText, title: plan.title ?? '' }
+                : { bodyText: plan.bodyText }
+            const response = await fetch(`https://openagents.com${path}`, {
+              body: JSON.stringify(body),
+              headers: {
+                Authorization: `Bearer ${bearer}`,
+                'Content-Type': 'application/json',
+                'Idempotency-Key': plan.idempotencyKey,
+                'User-Agent': 'artanis-operator',
+              },
+              method: 'POST',
+            })
+            if (!response.ok) {
+              return {
+                kind: 'rejected',
+                reason: `forum_status_${response.status}`,
+              } as const
+            }
+            const parsed = (await response.json().catch(() => null)) as
+              | {
+                  firstPost?: { id?: unknown }
+                  post?: { id?: unknown }
+                  topic?: { id?: unknown; forumId?: unknown }
+                }
+              | null
+            const topicId =
+              typeof parsed?.topic?.id === 'string'
+                ? parsed.topic.id
+                : (plan.topicId ?? '')
+            if (topicId === '') {
+              return {
+                kind: 'rejected',
+                reason: 'forum_response_missing_topic_id',
+              } as const
+            }
+            const postId =
+              typeof parsed?.post?.id === 'string'
+                ? parsed.post.id
+                : typeof parsed?.firstPost?.id === 'string'
+                  ? parsed.firstPost.id
+                  : null
+            const forumSlug =
+              plan.forumSlug ??
+              (typeof parsed?.topic?.forumId === 'string'
+                ? parsed.topic.forumId
+                : null)
+            return {
+              action: plan.action,
+              forumSlug,
+              kind: 'created',
+              postId,
+              topicId,
+              url: forumUrlForTopic(topicId, postId),
+            } as const
+          }).pipe(
+            Effect.orElseSucceed(
+              () => ({ kind: 'rejected', reason: 'forum_execution_failed' }) as const,
+            ),
+          ),
+      },
     })
   },
   requireAdminApiToken,


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6435

Assignment: assignment.public.khala_coding.chatcmpl_43d33abf55754d4da37b662dac895555
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 5

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.