### PR TITLE
feat(pylon): unify Claude/Codex executors behind an AgentRunner registry

### DIFF
--- a/apps/pylon/src/agent-runner-registry.ts
+++ b/apps/pylon/src/agent-runner-registry.ts
@@ -1,0 +1,154 @@
+import type { AgentRuntimeAdapterKind } from "@openagentsinc/agent-runtime-schema"
+
+import type { ResolvedPylonAccountSelection } from "./account-registry.js"
+import {
+  CLAUDE_AGENT_CAPABILITY_REF,
+  type ClaudeAgentProbeOptions,
+} from "./claude-agent.js"
+import {
+  claudeAgentTaskFrom,
+  executeClaudeAgentAssignment,
+  type ClaudeAgentCheckoutRunner,
+  type ClaudeAgentExecutionOptions,
+  type ClaudeAgentRunner,
+} from "./claude-agent-executor.js"
+import {
+  CODEX_AGENT_CAPABILITY_REF,
+  type CodexAgentProbeOptions,
+} from "./codex-agent.js"
+import {
+  codexAgentTaskFrom,
+  executeCodexAgentAssignment,
+  type CodexAgentExecutionOptions,
+  type CodexAgentRunner,
+} from "./codex-agent-executor.js"
+import type { PylonAssignmentLease } from "./assignment.js"
+import type { PylonLocalState } from "./state.js"
+
+export type AgentRunnerKind = "claude_agent" | "codex"
+export type AgentRunnerServiceRef = "claude" | "codex"
+export type AgentRunnerAccountProvider = "claude_agent" | "codex"
+
+export type AgentRunnerCloseoutRecord = {
+  artifactRefs: string[]
+  blockerRefs: string[]
+  buildRefs: string[]
+  message: string
+  previewRefs: string[]
+  proofRefs: string[]
+  resultRefs: string[]
+  runRefs: string[]
+  status: "accepted" | "rejected"
+  summaryRefs: string[]
+  testRefs: string[]
+}
+
+export type AgentRunnerExecutionOptions = {
+  account?: ResolvedPylonAccountSelection | null
+  agentToken?: string
+  baseUrl?: string
+  claudeAgentCheckoutRunner?: ClaudeAgentCheckoutRunner
+  claudeAgentProbe?: ClaudeAgentProbeOptions
+  claudeAgentRunner?: ClaudeAgentRunner
+  codexAgentProbe?: CodexAgentProbeOptions
+  codexAgentRunner?: CodexAgentRunner
+  fetch?: typeof fetch
+}
+
+export type AgentRunnerDescriptor = {
+  kind: AgentRunnerKind
+  adapterKind: AgentRuntimeAdapterKind
+  accountProvider: AgentRunnerAccountProvider
+  serviceRef: AgentRunnerServiceRef
+  capabilityRef: string
+  canRunAssignment: (codingAssignment: unknown) => boolean
+  execute: (
+    state: PylonLocalState,
+    lease: PylonAssignmentLease,
+    now: Date,
+    options: AgentRunnerExecutionOptions,
+  ) => Promise<AgentRunnerCloseoutRecord | null>
+}
+
+function hasObjectField(value: unknown, key: string): boolean {
+  const field = (value as Record<string, unknown> | undefined)?.[key]
+  return field !== null && typeof field === "object"
+}
+
+function commonExecutionOptions(options: AgentRunnerExecutionOptions) {
+  return {
+    ...(options.account === undefined ? {} : { account: options.account }),
+    ...(options.agentToken === undefined ? {} : { agentToken: options.agentToken }),
+    ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
+    ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+  }
+}
+
+export const AGENT_RUNNER_REGISTRY: ReadonlyArray<AgentRunnerDescriptor> = [
+  {
+    kind: "claude_agent",
+    adapterKind: "claude_code",
+    accountProvider: "claude_agent",
+    serviceRef: "claude",
+    capabilityRef: CLAUDE_AGENT_CAPABILITY_REF,
+    canRunAssignment: (codingAssignment) => claudeAgentTaskFrom(codingAssignment) !== null,
+    execute: (state, lease, now, options) =>
+      executeClaudeAgentAssignment(state, lease, now, {
+        ...commonExecutionOptions(options),
+        ...(options.claudeAgentCheckoutRunner === undefined
+          ? {}
+          : { checkoutRunner: options.claudeAgentCheckoutRunner }),
+        ...(options.claudeAgentProbe === undefined ? {} : { claudeAgentProbe: options.claudeAgentProbe }),
+        ...(options.claudeAgentRunner === undefined ? {} : { claudeAgentRunner: options.claudeAgentRunner }),
+      } satisfies ClaudeAgentExecutionOptions),
+  },
+  {
+    kind: "codex",
+    adapterKind: "codex",
+    accountProvider: "codex",
+    serviceRef: "codex",
+    capabilityRef: CODEX_AGENT_CAPABILITY_REF,
+    canRunAssignment: (codingAssignment) => codexAgentTaskFrom(codingAssignment) !== null,
+    execute: (state, lease, now, options) =>
+      executeCodexAgentAssignment(state, lease, now, {
+        ...commonExecutionOptions(options),
+        ...(options.codexAgentProbe === undefined ? {} : { codexAgentProbe: options.codexAgentProbe }),
+        ...(options.codexAgentRunner === undefined ? {} : { codexAgentRunner: options.codexAgentRunner }),
+      } satisfies CodexAgentExecutionOptions),
+  },
+]
+
+export function agentRunnerForAdapterKind(
+  adapterKind: AgentRuntimeAdapterKind,
+): AgentRunnerDescriptor | null {
+  return AGENT_RUNNER_REGISTRY.find((runner) => runner.adapterKind === adapterKind) ?? null
+}
+
+export function agentRunnerForLease(lease: PylonAssignmentLease): AgentRunnerDescriptor | null {
+  return AGENT_RUNNER_REGISTRY.find((runner) => runner.canRunAssignment(lease.codingAssignment)) ?? null
+}
+
+export function agentRunnerServiceForLease(lease: PylonAssignmentLease): AgentRunnerServiceRef | null {
+  const runner = agentRunnerForLease(lease)
+  if (runner !== null) return runner.serviceRef
+
+  const codingAssignment = lease.codingAssignment
+  const legacyRunner = AGENT_RUNNER_REGISTRY.find((candidate) => {
+    if (lease.capabilityRefs.includes(candidate.capabilityRef)) return true
+    if (candidate.kind === "codex") return hasObjectField(codingAssignment, "codex")
+    if (candidate.kind === "claude_agent") return hasObjectField(codingAssignment, "claudeAgent")
+    return false
+  })
+  return legacyRunner?.serviceRef ?? null
+}
+
+export async function executeRegisteredAgentRunner(
+  state: PylonLocalState,
+  lease: PylonAssignmentLease,
+  now: Date,
+  options: AgentRunnerExecutionOptions,
+): Promise<AgentRunnerCloseoutRecord | null> {
+  const runner = agentRunnerForLease(lease)
+  if (runner === null) return null
+  return runner.execute(state, lease, now, options)
+}

--- a/apps/pylon/src/agent-runtime-adapter.ts
+++ b/apps/pylon/src/agent-runtime-adapter.ts
@@ -10,15 +10,9 @@ import {
 import { Effect, Stream } from "effect"
 
 import {
-  claudeAgentTaskFrom,
-  executeClaudeAgentAssignment,
-  type ClaudeAgentExecutionOptions,
-} from "./claude-agent-executor.js"
-import {
-  codexAgentTaskFrom,
-  executeCodexAgentAssignment,
-  type CodexAgentExecutionOptions,
-} from "./codex-agent-executor.js"
+  agentRunnerForAdapterKind,
+  type AgentRunnerExecutionOptions,
+} from "./agent-runner-registry.js"
 import { runOpencodeStream, type OpencodeStreamCallbacks } from "./opencode-run.js"
 import type { PylonAssignmentLease } from "./assignment.js"
 import type { PylonLocalState } from "./state.js"
@@ -221,31 +215,37 @@ function makeAdapter(input: {
 }
 
 export function createClaudeCodeAgentRuntimeAdapter(
-  options: ClaudeAgentExecutionOptions = {},
+  options: AgentRunnerExecutionOptions = {},
 ): AgentRuntimeAdapter {
-  return makeAdapter({
-    kind: "claude_code",
-    canRun: (request) => claudeAgentTaskFrom(request.lease.codingAssignment) !== null,
-    start: async (request) =>
-      closeoutToEvents(
-        "claude_code",
-        request,
-        await executeClaudeAgentAssignment(request.state, request.lease, request.now, options),
-      ),
-  })
+  return createRegisteredAgentRuntimeAdapter("claude_code", options)
 }
 
 export function createCodexAgentRuntimeAdapter(
-  options: CodexAgentExecutionOptions = {},
+  options: AgentRunnerExecutionOptions = {},
 ): AgentRuntimeAdapter {
+  return createRegisteredAgentRuntimeAdapter("codex", options)
+}
+
+function createRegisteredAgentRuntimeAdapter(
+  adapterKind: AgentRuntimeAdapterKind,
+  options: AgentRunnerExecutionOptions,
+): AgentRuntimeAdapter {
+  const runner = agentRunnerForAdapterKind(adapterKind)
+  if (runner === null) {
+    throw new AgentRuntimeAdapterError(
+      `No registered agent runner for ${adapterKind}.`,
+      adapterKind,
+      [`blocker.agent_runtime.${adapterKind}.runner_unregistered`],
+    )
+  }
   return makeAdapter({
-    kind: "codex",
-    canRun: (request) => codexAgentTaskFrom(request.lease.codingAssignment) !== null,
+    kind: runner.adapterKind,
+    canRun: (request) => runner.canRunAssignment(request.lease.codingAssignment),
     start: async (request) =>
       closeoutToEvents(
-        "codex",
+        runner.adapterKind,
         request,
-        await executeCodexAgentAssignment(request.state, request.lease, request.now, options),
+        await runner.execute(request.state, request.lease, request.now, options),
       ),
   })
 }

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -11,23 +11,26 @@ import {
 } from "@openagentsinc/tassadar-executor"
 import type { BootstrapSummary } from "./bootstrap.js"
 import {
-  CLAUDE_AGENT_CAPABILITY_REF,
   loadClaudeAgentConfig,
   probeClaudeAgentReadiness,
   type ClaudeAgentProbeOptions,
 } from "./claude-agent.js"
 import {
-  executeClaudeAgentAssignment,
   type ClaudeAgentCheckoutRunner,
   type ClaudeAgentRunner,
 } from "./claude-agent-executor.js"
 import {
-  CODEX_AGENT_CAPABILITY_REF,
   loadCodexAgentConfig,
   probeCodexAgentReadiness,
   type CodexAgentProbeOptions,
 } from "./codex-agent.js"
-import { executeCodexAgentAssignment, type CodexAgentRunner } from "./codex-agent-executor.js"
+import type { CodexAgentRunner } from "./codex-agent-executor.js"
+import {
+  agentRunnerForLease,
+  agentRunnerServiceForLease,
+  executeRegisteredAgentRunner,
+  type AgentRunnerCloseoutRecord,
+} from "./agent-runner-registry.js"
 import { createSignedHeaders, sendHeartbeat } from "./presence.js"
 import { PresenceRequestError } from "./presence-error.js"
 import {
@@ -939,20 +942,7 @@ function localLeaseIsTerminal(store: AssignmentStore, leaseRef: string): boolean
 }
 
 function codingRunServiceForLease(lease: PylonAssignmentLease): PylonCodingServiceRef | null {
-  const codingAssignment = lease.codingAssignment as { claudeAgent?: unknown; codex?: unknown } | undefined
-  if (
-    lease.capabilityRefs.includes(CODEX_AGENT_CAPABILITY_REF) ||
-    (codingAssignment?.codex !== null && typeof codingAssignment?.codex === "object")
-  ) {
-    return "codex"
-  }
-  if (
-    lease.capabilityRefs.includes(CLAUDE_AGENT_CAPABILITY_REF) ||
-    (codingAssignment?.claudeAgent !== null && typeof codingAssignment?.claudeAgent === "object")
-  ) {
-    return "claude"
-  }
-  return null
+  return agentRunnerServiceForLease(lease)
 }
 
 function isLegacyLease(value: unknown): value is PylonAssignmentLease {
@@ -1479,7 +1469,8 @@ async function resolveAgentAccountForAssignment(
   now: Date,
 ): Promise<AssignmentCodexAccountSelection> {
   const provider: PylonAccountProvider =
-    codingRunServiceForLease(lease) === "claude" ? "claude_agent" : "codex"
+    agentRunnerForLease(lease)?.accountProvider ??
+    (codingRunServiceForLease(lease) === "claude" ? "claude_agent" : "codex")
 
   if (options.accountRef !== undefined || options.accountHome !== undefined) {
     const account = await resolvePylonAccountSelection(summary, {
@@ -1741,8 +1732,7 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
       }, runtimeHeartbeatIntervalMs)
   let runtimeGate:
     | Awaited<ReturnType<typeof executeTassadarAssignment>>
-    | Awaited<ReturnType<typeof executeClaudeAgentAssignment>>
-    | Awaited<ReturnType<typeof executeCodexAgentAssignment>>
+    | AgentRunnerCloseoutRecord
     | Awaited<ReturnType<typeof executeRuntimeGate>>
   try {
     runtimeGate = await withRuntimeProgress({
@@ -1752,26 +1742,17 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
       startedAtMs: runtimeStartedAtMs,
       run: async () =>
         (await executeTassadarAssignment(lease, observedAtDate)) ??
-        (await executeClaudeAgentAssignment(state, lease, observedAtDate, {
-          // agentToken + baseUrl + fetch let the executor post the exact
-          // own-capacity Claude turn token usage (#6391). #6421: pass the
-          // provider-resolved account so a claude_agent_task lease runs against
-          // the selected Claude account's isolated home + OAuth token. The
-          // account is null for codex leases or when none resolves, leaving the
-          // executor's default-resolution path; it is only ever a `claude_agent`
-          // account here, so Claude credentials are never crossed with Codex.
-          ...(agentAccount.account === null ? {} : { account: agentAccount.account }),
+        (await executeRegisteredAgentRunner(state, lease, observedAtDate, {
+          // agentToken + baseUrl + fetch let agent executors post exact
+          // own-capacity turn token usage. The provider-aware account is
+          // resolved from the selected registry entry so Claude credentials are
+          // never crossed with Codex credentials.
           ...(options.agentToken === undefined ? {} : { agentToken: options.agentToken }),
+          ...(agentAccount.account === null ? {} : { account: agentAccount.account }),
           baseUrl: options.baseUrl,
-          ...(options.claudeAgentCheckoutRunner === undefined ? {} : { checkoutRunner: options.claudeAgentCheckoutRunner }),
-          ...(options.claudeAgentRunner === undefined ? {} : { claudeAgentRunner: options.claudeAgentRunner }),
+          ...(options.claudeAgentCheckoutRunner === undefined ? {} : { claudeAgentCheckoutRunner: options.claudeAgentCheckoutRunner }),
           ...(options.claudeAgentProbe === undefined ? {} : { claudeAgentProbe: options.claudeAgentProbe }),
-          ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
-        })) ??
-        (await executeCodexAgentAssignment(state, lease, observedAtDate, {
-          ...(options.agentToken === undefined ? {} : { agentToken: options.agentToken }),
-          ...(agentAccount.account === null ? {} : { account: agentAccount.account }),
-          baseUrl: options.baseUrl,
+          ...(options.claudeAgentRunner === undefined ? {} : { claudeAgentRunner: options.claudeAgentRunner }),
           ...(options.codexAgentRunner === undefined ? {} : { codexAgentRunner: options.codexAgentRunner }),
           ...(options.codexAgentProbe === undefined ? {} : { codexAgentProbe: options.codexAgentProbe }),
           ...(options.fetch === undefined ? {} : { fetch: options.fetch }),

--- a/apps/pylon/tests/agent-runtime-adapter.test.ts
+++ b/apps/pylon/tests/agent-runtime-adapter.test.ts
@@ -19,6 +19,11 @@ import {
   replayAgentRuntimeEventLog,
   type AgentRuntimeRunRequest,
 } from "../src/agent-runtime-adapter"
+import {
+  AGENT_RUNNER_REGISTRY,
+  agentRunnerForLease,
+  agentRunnerServiceForLease,
+} from "../src/agent-runner-registry"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import { CLAUDE_AGENT_SDK_PACKAGE } from "../src/claude-agent"
 import {
@@ -105,6 +110,64 @@ async function withRequest<T>(
 }
 
 describe("AgentRuntimeAdapter", () => {
+  test("Claude and Codex runners are selected from the declarative registry", () => {
+    expect(
+      AGENT_RUNNER_REGISTRY.map((runner) => ({
+        adapterKind: runner.adapterKind,
+        accountProvider: runner.accountProvider,
+        kind: runner.kind,
+        serviceRef: runner.serviceRef,
+      })),
+    ).toEqual([
+      {
+        accountProvider: "claude_agent",
+        adapterKind: "claude_code",
+        kind: "claude_agent",
+        serviceRef: "claude",
+      },
+      {
+        accountProvider: "codex",
+        adapterKind: "codex",
+        kind: "codex",
+        serviceRef: "codex",
+      },
+    ])
+
+    const claudeLease = {
+      schema: "openagents.pylon.assignment_lease.v0.3",
+      assignmentRef: "assignment.public.registry.claude",
+      leaseRef: "lease.public.registry.claude",
+      goal: "goal.public.registry.claude",
+      paymentMode: "no-spend",
+      capabilityRefs: [],
+      codingAssignment: {
+        claudeAgent: {
+          schema: CLAUDE_AGENT_TASK_SCHEMA,
+          agentKind: "claude_agent_sdk",
+          fixtureRef: CLAUDE_AGENT_SUM_REPAIR_FIXTURE_REF,
+        },
+      },
+      expiresAt: now.toISOString(),
+    } as const
+    const codexLease = {
+      ...claudeLease,
+      assignmentRef: "assignment.public.registry.codex",
+      leaseRef: "lease.public.registry.codex",
+      codingAssignment: {
+        codex: {
+          schema: CODEX_AGENT_TASK_SCHEMA,
+          agentKind: "codex_sdk",
+          fixtureRef: CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
+        },
+      },
+    }
+
+    expect(agentRunnerForLease(claudeLease)?.adapterKind).toBe("claude_code")
+    expect(agentRunnerServiceForLease(claudeLease)).toBe("claude")
+    expect(agentRunnerForLease(codexLease)?.adapterKind).toBe("codex")
+    expect(agentRunnerServiceForLease(codexLease)).toBe("codex")
+  })
+
   test("fixture, Codex, and Claude wrappers emit the same kernel event contract", async () => {
     const fixtureAdapter = createTestFixtureAgentRuntimeAdapter()
     await withRequest({}, async (request) => {


### PR DESCRIPTION
Addresses #6404.

### Changes
- Adds `apps/pylon/src/agent-runner-registry.ts` with an `AgentRunnerDescriptor` interface and a declarative `AGENT_RUNNER_REGISTRY` array (Claude + Codex entries) plus lookup helpers (`agentRunnerForAdapterKind`, `agentRunnerForLease`, `agentRunnerServiceForLease`, `executeRegisteredAgentRunner`).
- Refactors `agent-runtime-adapter.ts` to build both Claude and Codex adapters from the registry via a shared `createRegisteredAgentRuntimeAdapter`, raising a typed error for unregistered kinds.
- Rewrites `assignment.ts` service/account resolution and the no-spend run path to dispatch through the registry instead of forked `executeClaudeAgentAssignment`/`executeCodexAgentAssignment` calls.
- Adds a registry-selection unit test in `tests/agent-runtime-adapter.test.ts`.

### Verification
Not independently re-verified.