### PR TITLE
feat(worker-api): admit any authenticated user to Artanis operator chat, owner-scoped

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
@@ -135,7 +135,7 @@ describe('POST /api/operator/artanis/chat — owner auth', () => {
     expect(response.status).toBe(401)
   })
 
-  test('403 when the session email is not an admin', async () => {
+  test('200 for any authenticated browser session, scoped to that user', async () => {
     const { deps } = baseDeps({
       requireBrowserSession: async () => ({
         user: { email: 'someone@example.com', userId: 'github:9' },
@@ -145,7 +145,23 @@ describe('POST /api/operator/artanis/chat — owner auth', () => {
       deps,
       post({ messages: [{ content: 'hi', role: 'user' }] }),
     )
-    expect(response.status).toBe(403)
+    expect(response.status).toBe(200)
+  })
+
+  test('non-admin browser sessions persist only to their own owner memory', async () => {
+    const { deps, fake } = baseDeps({
+      requireBrowserSession: async () => ({
+        user: { email: 'community@example.com', userId: 'github:community' },
+      }),
+    })
+    const response = await runRoute(
+      deps,
+      post({ messages: [{ content: 'tenant status', role: 'user' }] }),
+    )
+    expect(response.status).toBe(200)
+    const owner = fake.entries.find(entry => entry.role === 'owner')
+    expect(owner?.body).toBe('tenant status')
+    expect(owner?.ownerId).toBe('owner:github:community')
   })
 
   test('200 when an owner-linked agent bearer resolves (no browser session needed)', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
@@ -3,9 +3,10 @@
 //   POST /api/operator/artanis/chat   body { messages: [{role,content}] }
 //                                      -> { reply, servedVia, servedModel, ... }
 //
-// This is the OWNER-ONLY, PRIVATE channel to the REAL Artanis operator agent. It
-// is gated exactly like the other `/api/operator/*` routes (admin API token OR a
-// browser session whose email is an OpenAgents admin), and it routes the
+// This is the authenticated, owner-scoped private channel to the REAL Artanis
+// operator agent. It admits a signed-in browser session, an owner-linked agent
+// bearer, or the admin API token, then keys memory and awareness to that
+// authenticated owner user id. It routes the
 // conversation through the Artanis operator CORE (`artanis-operator.ts`), which:
 //   - uses the Artanis OPERATOR persona (NOT the public Khala collective
 //     identity — no roleplay),
@@ -79,11 +80,11 @@ export type OperatorArtanisChatDependencies<
   // route returns a typed unavailability instead of falling back to a provider.
   makeKhalaClient: (env: Bindings) => ArtanisOperatorKhalaClient | undefined
   requireAdminApiToken?: (request: Request, env: Bindings) => Promise<boolean>
-  // Resolves an agent bearer token to an owner session when the token's linked
-  // OpenAuth account email is an OpenAgents admin. Lets the Khala CLI (which
-  // authenticates with an `oa_agent_` bearer linked via `khala login`) reach the
-  // owner-only Artanis channel, alongside the admin API token and an admin
-  // browser session. Returns undefined for non-owner or unlinked tokens.
+  // Resolves an agent bearer token to an owner session when the token is linked
+  // to an authenticated OpenAuth user (or is the owner-promoted Artanis agent).
+  // Lets the Khala CLI (which authenticates with an `oa_agent_` bearer linked
+  // via `khala login`) reach the same per-user Artanis channel as a browser
+  // session. Returns undefined for unlinked/non-owner tokens.
   resolveOwnerAgentBearer?: (
     request: Request,
     env: Bindings,
@@ -114,11 +115,6 @@ class OperatorArtanisChatUnauthorized extends S.TaggedErrorClass<OperatorArtanis
   {},
 ) {}
 
-class OperatorArtanisChatForbidden extends S.TaggedErrorClass<OperatorArtanisChatForbidden>()(
-  'OperatorArtanisChatForbidden',
-  {},
-) {}
-
 class OperatorArtanisChatBadRequest extends S.TaggedErrorClass<OperatorArtanisChatBadRequest>()(
   'OperatorArtanisChatBadRequest',
   { reason: S.String },
@@ -141,7 +137,6 @@ class OperatorArtanisChatStorageError extends S.TaggedErrorClass<OperatorArtanis
 
 type OperatorArtanisChatError =
   | OperatorArtanisChatBadRequest
-  | OperatorArtanisChatForbidden
   | OperatorArtanisChatSessionError
   | OperatorArtanisChatStorageError
   | OperatorArtanisChatUnauthorized
@@ -155,8 +150,6 @@ const routeErrorResponse = (error: OperatorArtanisChatError) =>
           { error: 'bad_request', reason: badRequest.reason },
           { status: 400 },
         ),
-      OperatorArtanisChatForbidden: () =>
-        noStoreJsonResponse({ error: 'forbidden' }, { status: 403 }),
       OperatorArtanisChatSessionError: () =>
         noStoreJsonResponse({ error: 'session_error' }, { status: 500 }),
       OperatorArtanisChatStorageError: () =>
@@ -175,7 +168,7 @@ const routeErrorResponse = (error: OperatorArtanisChatError) =>
     M.exhaustive,
   )
 
-const requireAdminSession = <
+const requireAuthenticatedSession = <
   Session extends OperatorArtanisChatSession,
   Bindings extends OperatorArtanisChatEnv,
 >(
@@ -222,10 +215,6 @@ const requireAdminSession = <
 
     if (session === undefined) {
       return yield* new OperatorArtanisChatUnauthorized({})
-    }
-
-    if (!dependencies.isOpenAgentsAdminEmail(session.user.email)) {
-      return yield* new OperatorArtanisChatForbidden({})
     }
 
     return session
@@ -301,7 +290,7 @@ export const makeOperatorArtanisChatRoutes = <
     const awarenessReaders = dependencies.awarenessReaders?.(env) ?? {}
 
     return Effect.gen(function* () {
-      const session = yield* requireAdminSession(
+      const session = yield* requireAuthenticatedSession(
         dependencies,
         request,
         env,

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -8516,11 +8516,12 @@ const operatorArtanisConsoleRoutes = makeOperatorArtanisConsoleRoutes({
   requireBrowserSession,
 })
 
-// Owner-only Artanis operator chat channel (#6363). Artanis's reasoning is
-// powered ONLY by the Khala API — `makeArtanisResponderKhalaClient` dogfoods the
-// `openagents/khala` pool and meters the call as Khala usage, so this channel
-// never calls a provider directly. `makeKhalaClient` is invoked at request time,
-// so referencing the (later-declared) builder here is safe.
+// Authenticated, owner-scoped Artanis operator chat channel (#6363, #6385).
+// Artanis's reasoning is powered ONLY by the Khala API —
+// `makeArtanisResponderKhalaClient` dogfoods the `openagents/khala` pool and
+// meters the call as Khala usage, so this channel never calls a provider
+// directly. `makeKhalaClient` is invoked at request time, so referencing the
+// (later-declared) builder here is safe.
 const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
   appendRefreshedSessionCookies,
   // Inject the LIVE daily token-pace block into EVERY Artanis turn (epic #6359)
@@ -8545,6 +8546,9 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
   // owner approval. With no effective approval (the default today), the tool
   // returns the plan and defers — it never fires.
   makeOperatorTools: (env, session) => {
+    const hasOperatorLedgerAccess =
+      isOpenAgentsAdminEmail(session.user.email) ||
+      isOpenAgentsOwnerAgentOpenAuthUserId(session.user.userId)
     // Owner-scope resolver shared by the gated dispatch seam and the
     // owner-scoped Pylon job-status reader: resolve the owner's linked agent
     // user ids (their Pylon-owning credentials) so both stay strictly
@@ -8574,8 +8578,32 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
       }
       return ids
     }
-    return makeArtanisOperatorTools({
+    const ownerScopedTools = {
       defaultBranch: 'main',
+      pylonAssignments: {
+        lister: makeArtanisPylonAssignmentsLister({
+          listLinkedAgentUserIds,
+          nowIso: currentIsoTimestamp,
+          ownerOpenAuthUserId: session.user.userId,
+          pylonStore: makeD1PylonApiStore(openAgentsDatabase(env)),
+        }),
+      },
+      pylonJobStatus: {
+        reader: makeArtanisPylonJobStatusReader({
+          listLinkedAgentUserIds,
+          nowIso: currentIsoTimestamp,
+          ownerOpenAuthUserId: session.user.userId,
+          pylonStore: makeD1PylonApiStore(openAgentsDatabase(env)),
+        }),
+      },
+    } satisfies Parameters<typeof makeArtanisOperatorTools>[0]
+
+    if (!hasOperatorLedgerAccess) {
+      return makeArtanisOperatorTools(ownerScopedTools)
+    }
+
+    return makeArtanisOperatorTools({
+      ...ownerScopedTools,
       // get_network_stats reads the token-usage ledger directly (the worker
       // cannot reliably HTTP-fetch its own public /stats zone).
       networkStats: {
@@ -8604,29 +8632,6 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
       // reader: the tool reports an honest "(no active synthetic-load runs)"
       // rather than inventing one. When a real own-capacity synthetic-load run
       // registry lands, wire its owner-scoped reader here.
-      // iteration-3: the owner-scoped Pylon job-status read tool. Reads the
-      // public-safe closeout/proof status of ONE of the owner's own linked-Pylon
-      // assignments. Read-only, owner-scoped, no spend/authority.
-      pylonJobStatus: {
-        reader: makeArtanisPylonJobStatusReader({
-          listLinkedAgentUserIds,
-          nowIso: currentIsoTimestamp,
-          ownerOpenAuthUserId: session.user.userId,
-          pylonStore: makeD1PylonApiStore(openAgentsDatabase(env)),
-        }),
-      },
-      // iteration-5: the owner-scoped bulk Pylon assignments LIST tool. Reads the
-      // public-safe summaries of ALL of the owner's own linked-Pylon assignments
-      // in one call so Artanis can scan the burndown, spot failed/stalled runs,
-      // and queue parallel retries. Read-only, owner-scoped, no spend/authority.
-      pylonAssignments: {
-        lister: makeArtanisPylonAssignmentsLister({
-          listLinkedAgentUserIds,
-          nowIso: currentIsoTimestamp,
-          ownerOpenAuthUserId: session.user.userId,
-          pylonStore: makeD1PylonApiStore(openAgentsDatabase(env)),
-        }),
-      },
       // iteration-6: the owner-scoped Khala CLI feedback READ tool. Reads the most
       // recent user feedback submitted through the Khala CLI /feedback command
       // (the same admin-gated `khala_feedback` store the
@@ -8720,8 +8725,8 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
   requireAdminApiToken,
   requireBrowserSession,
   // Accept an `oa_agent_` bearer (the Khala CLI's token from `khala login`) when
-  // its linked OpenAuth account email is an OpenAgents admin. Resolves the agent
-  // credential -> its linked owner user id -> that user's email -> admin check.
+  // it is linked to an OpenAuth account. Resolves the agent credential -> its
+  // linked owner user id -> that user's email and scopes Artanis to that owner.
   resolveOwnerAgentBearer: async (request, env) => {
     const bearer = readBearerToken(request)
     if (bearer === undefined) {
@@ -8734,9 +8739,8 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
     // The owner-promoted operator agent (Artanis, owner-directed 2026-06-27) is
     // admitted by his OWN agent identity (his agent user id forms his actorRef
     // `agent:<userId>`), independent of any linked OpenAuth account — his
-    // credential carries no OpenAuth link. Every other owner uses the original
-    // Khala-CLI owner path: a linked OpenAuth account whose email is an
-    // OpenAgents admin.
+    // credential carries no OpenAuth link. Every other caller uses the Khala-CLI
+    // path: a token linked to an OpenAuth account.
     const agentOwnUserId = agent?.user.id
     if (agentOwnUserId === undefined) {
       return undefined
@@ -8747,28 +8751,26 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
       isOpenAgentsOwnerAgentOpenAuthUserId(agentOwnUserId) ||
       isOpenAgentsOwnerAgentOpenAuthUserId(linkedOpenAuthUserId)
 
-    // Original admin-email path: only consulted when there is a linked OpenAuth
-    // account to resolve an email for.
-    let adminEmail: string | undefined
+    let linkedEmail: string | undefined
     if (linkedOpenAuthUserId !== null) {
       const row = await openAgentsDatabase(env)
         .prepare(`SELECT primary_email FROM users WHERE id = ?`)
         .bind(linkedOpenAuthUserId)
         .first<Readonly<{ primary_email: string | null }>>()
       const email = row?.primary_email?.trim().toLowerCase()
-      if (email !== undefined && email !== '' && isOpenAgentsAdminEmail(email)) {
-        adminEmail = email
+      if (email !== undefined && email !== '') {
+        linkedEmail = email
       }
     }
 
-    if (!isOwnerAgent && adminEmail === undefined) {
+    if (!isOwnerAgent && linkedOpenAuthUserId === null) {
       return undefined
     }
 
     // Owner-scope user id: for the owner-promoted agent key on his OWN
     // owner-promoted user id (so the standing pylon_job_dispatch approval and his
-    // own-capacity resolution key consistently on his agent user id); for the
-    // admin-email path preserve the original linked-OpenAuth owner id.
+    // own-capacity resolution key consistently on his agent user id); for linked
+    // Khala CLI tokens preserve the original linked-OpenAuth owner id.
     const ownerScopeUserId = isOwnerAgent
       ? agentOwnUserId
       : (linkedOpenAuthUserId ?? agentOwnUserId)
@@ -8777,7 +8779,7 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
     // Session is the full human-session shape; fill the unused fields so the
     // owner-agent-bearer return type matches the browser-session return type.
     const sessionEmail =
-      adminEmail ??
+      linkedEmail ??
       agent?.user.primaryEmail?.trim().toLowerCase() ??
       'artanis@agents.openagents.com'
     return {


### PR DESCRIPTION
Addresses #6385.

### Changes
- Replaces `requireAdminSession`/`OperatorArtanisChatForbidden` (403) with `requireAuthenticatedSession` in `artanis-operator-chat-routes.ts`, so any signed-in browser session, owner-linked agent bearer, or admin token is admitted and keyed to that user's owner id.
- Updates `index.ts` to always wire the owner-scoped Pylon job-status/assignments tools per-user, and gates ledger/network-stats tools behind an admin/owner check (`hasOperatorLedgerAccess`).
- Loosens `resolveOwnerAgentBearer` so a Khala CLI token linked to any OpenAuth account (not only admin emails) resolves to its own owner scope.
- Updates route tests to expect 200 + own-owner memory persistence for non-admin sessions.

### Verification
Not independently re-verified.