### PR TITLE
pylon: Implement public issue #6394 and run the named verification. (#6394)

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -27,6 +27,7 @@ import {
   makeArtanisListGithubIssuesTool,
   makeArtanisListPylonAssignmentsTool,
   makeArtanisListRepoDirTool,
+  makeArtanisOpenUnsupportedRequestIssueTool,
   makeArtanisOperatorTools,
   makeArtanisReadGithubIssueTool,
   makeArtanisReadRepoFileTool,
@@ -1469,6 +1470,140 @@ describe('update_unsupported_request (owner-scoped ledger triage WRITE) — iter
   })
 })
 
+describe('open_unsupported_request_issue (#6394 create + link needs_issue rows)', () => {
+  const needsIssueRow: ArtanisUnsupportedRequestRecord = {
+    githubIssueRef: null,
+    nextAction: 'open_github_issue',
+    requestRef: 'khala_unsupported:ur_issue_001',
+    sourceKind: 'trace_review',
+    status: 'needs_issue',
+    summary:
+      'Users ask Khala to inspect a public-safe local git diff summary before answering.',
+    title: 'Khala cannot inspect local diff summaries',
+    triageKind: 'missing_capability',
+    updatedAt: '2026-06-27T13:00:00.000Z',
+  }
+
+  test('opens a public GitHub issue for one needs_issue row and marks the ledger issue_opened', async () => {
+    const openedDrafts: Array<unknown> = []
+    const updates: Array<unknown> = []
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      opener: async draft => {
+        openedDrafts.push(draft)
+        return {
+          issueNumber: 6395,
+          issueRef: 'OpenAgentsInc/openagents#6395',
+          issueUrl: 'https://github.com/OpenAgentsInc/openagents/issues/6395',
+        }
+      },
+      reader: async input => {
+        expect(input).toEqual({ limit: 100, status: 'needs_issue' })
+        return [needsIssueRow]
+      },
+      writer: async update => {
+        updates.push(update)
+        return {
+          ...needsIssueRow,
+          githubIssueRef: update.githubIssueRef ?? null,
+          nextAction: 'none',
+          status: update.status ?? needsIssueRow.status,
+          updatedAt: '2026-06-27T13:05:00.000Z',
+        }
+      },
+    })
+
+    expect(tool.kind).toBe('write')
+    expect(tool.definition.name).toBe('open_unsupported_request_issue')
+
+    const result = await Effect.runPromise(
+      tool.execute({ ref: 'khala_unsupported:ur_issue_001' }),
+    )
+
+    expect(openedDrafts).toEqual([
+      {
+        body: expect.stringContaining('khala_unsupported:ur_issue_001'),
+        labels: ['khala', 'unsupported-request'],
+        title: '[Khala unsupported] Khala cannot inspect local diff summaries',
+      },
+    ])
+    expect(updates).toEqual([
+      {
+        githubIssueRef: 'OpenAgentsInc/openagents#6395',
+        ref: 'khala_unsupported:ur_issue_001',
+        status: 'issue_opened',
+      },
+    ])
+    expect(result).toContain(
+      'Opened GitHub issue OpenAgentsInc/openagents#6395',
+    )
+    expect(result).toContain('status: issue_opened')
+    expect(result).toContain('next action: none')
+  })
+
+  test('fails closed when the GitHub opener is not wired', async () => {
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      reader: async () => [needsIssueRow],
+      writer: async () => needsIssueRow,
+    })
+    const result = await Effect.runPromise(
+      tool.execute({ ref: 'khala_unsupported:ur_issue_001' }),
+    )
+    expect(result).toContain('no GitHub issue opener is wired')
+  })
+
+  test('does not open issues for rows outside needs_issue', async () => {
+    const openedDrafts: Array<unknown> = []
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      opener: async draft => {
+        openedDrafts.push(draft)
+        return {
+          issueNumber: 6395,
+          issueRef: 'OpenAgentsInc/openagents#6395',
+          issueUrl: 'https://github.com/OpenAgentsInc/openagents/issues/6395',
+        }
+      },
+      reader: async () => [
+        {
+          ...needsIssueRow,
+          githubIssueRef: 'OpenAgentsInc/openagents#6310',
+          status: 'issue_opened',
+        },
+      ],
+      writer: async () => needsIssueRow,
+    })
+
+    const result = await Effect.runPromise(
+      tool.execute({ ref: 'khala_unsupported:ur_issue_001' }),
+    )
+
+    expect(result).toContain('not waiting for an issue')
+    expect(openedDrafts).toEqual([])
+  })
+
+  test('blocks unsafe refs before reading or opening', async () => {
+    const openedDrafts: Array<unknown> = []
+    const tool = makeArtanisOpenUnsupportedRequestIssueTool({
+      opener: async draft => {
+        openedDrafts.push(draft)
+        return {
+          issueNumber: 1,
+          issueRef: 'OpenAgentsInc/openagents#1',
+          issueUrl: 'https://github.com/OpenAgentsInc/openagents/issues/1',
+        }
+      },
+      reader: async () => [needsIssueRow],
+      writer: async () => needsIssueRow,
+    })
+
+    const result = await Effect.runPromise(
+      tool.execute({ ref: '../../etc/passwd' }),
+    )
+
+    expect(result).toContain('blocked')
+    expect(openedDrafts).toEqual([])
+  })
+})
+
 describe('parseArtanisAssignmentRef + isSafeArtanisAssignmentRef', () => {
   test('accepts a ref under several key aliases', () => {
     expect(parseArtanisAssignmentRef({ assignmentRef: 'a.b.c' })).toEqual({
@@ -2232,6 +2367,7 @@ describe('makeArtanisOperatorTools default table', () => {
       'list_github_issues',
       'list_pylon_assignments',
       'list_repo_dir',
+      'open_unsupported_request_issue',
       'read_github_issue',
       'read_repo_file',
       'trigger_synthetic_load',
@@ -2246,6 +2382,20 @@ describe('makeArtanisOperatorTools default table', () => {
     )
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('write')
+  })
+
+  test('the default table includes a fail-closed write-kind open_unsupported_request_issue tool', async () => {
+    const tools = makeArtanisOperatorTools()
+    const tool = tools.find(
+      t => t.definition.name === 'open_unsupported_request_issue',
+    )
+    expect(tool).toBeDefined()
+    expect(tool?.kind).toBe('write')
+    if (tool?.kind !== 'write') return
+    const result = await Effect.runPromise(
+      tool.execute({ ref: 'khala_unsupported:ur_issue_001' }),
+    )
+    expect(result).toContain('no ledger reader is wired')
   })
 
   test('the default table includes a read-kind get_unsupported_requests tool', () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -2025,6 +2025,210 @@ export const makeArtanisUpdateUnsupportedRequestTool = (
 }
 
 // ---------------------------------------------------------------------------
+// open_unsupported_request_issue — CREATE + LINK one needs_issue ledger row.
+// ---------------------------------------------------------------------------
+//
+// The update tool above can only record a GitHub issue after an issue already
+// exists. This tool is the bounded outward-action companion for #6394: it reads
+// one `needs_issue` row, builds a public-safe strict-issue draft from the row,
+// asks an injected GitHub opener to create the issue, then marks the same ledger
+// row `issue_opened` with the returned public issue ref. If any seam is missing
+// or any step fails, it returns an honest blocker and never fabricates a link.
+
+export type ArtanisUnsupportedRequestIssueDraft = Readonly<{
+  body: string
+  labels: ReadonlyArray<string>
+  title: string
+}>
+
+export type ArtanisUnsupportedRequestIssueReceipt = Readonly<{
+  issueNumber: number
+  issueRef: string
+  issueUrl: string
+}>
+
+export type ArtanisUnsupportedRequestIssueOpener = (
+  draft: ArtanisUnsupportedRequestIssueDraft,
+) => Promise<ArtanisUnsupportedRequestIssueReceipt>
+
+export type ArtanisOpenUnsupportedRequestIssueConfig = Readonly<{
+  reader?: ArtanisUnsupportedRequestsReader | undefined
+  opener?: ArtanisUnsupportedRequestIssueOpener | undefined
+  writer?: ArtanisUnsupportedRequestWriter | undefined
+}>
+
+const unsupportedRequestIssueTitle = (
+  record: ArtanisUnsupportedRequestRecord,
+): string => {
+  const prefix = '[Khala unsupported] '
+  const collapsed = record.title.replace(/\s+/g, ' ').trim()
+  return `${prefix}${collapsed}`.slice(0, 180)
+}
+
+const unsupportedRequestIssueBody = (
+  record: ArtanisUnsupportedRequestRecord,
+): string =>
+  [
+    '## Unsupported request',
+    '',
+    record.summary.trim() === ''
+      ? record.title.trim()
+      : record.summary.replace(/\s+/g, ' ').trim(),
+    '',
+    '## Ledger link',
+    '',
+    `- Unsupported request ref: \`${record.requestRef}\``,
+    `- Triage kind: \`${record.triageKind}\``,
+    `- Source kind: \`${record.sourceKind}\``,
+    `- Opened by: \`open_unsupported_request_issue\``,
+    '',
+    'This issue was opened from the unsupported-request ledger. Keep discussion public-safe and move loose product-promise commentary back to the Product Promises Forum.',
+  ].join('\n')
+
+const buildUnsupportedRequestIssueDraft = (
+  record: ArtanisUnsupportedRequestRecord,
+): ArtanisUnsupportedRequestIssueDraft | null => {
+  const title = unsupportedRequestIssueTitle(record)
+  const body = unsupportedRequestIssueBody(record)
+  const labels = ['khala', 'unsupported-request']
+  const unsafe = [title, body, ...labels].find(
+    field => !dispatchFieldIsSafe(field),
+  )
+  if (unsafe !== undefined) return null
+  return { body, labels, title }
+}
+
+const formatOpenedUnsupportedRequestIssue = (
+  input: Readonly<{
+    issue: ArtanisUnsupportedRequestIssueReceipt
+    record: ArtanisUnsupportedRequestRecord
+    updated: ArtanisUnsupportedRequestRecord
+  }>,
+): string =>
+  [
+    `Opened GitHub issue ${input.issue.issueRef} for unsupported request ${input.record.requestRef}.`,
+    `- issue URL: ${input.issue.issueUrl}`,
+    `- status: ${input.updated.status}`,
+    `- linked issue: ${input.updated.githubIssueRef ?? input.issue.issueRef}`,
+    `- next action: ${input.updated.nextAction}`,
+  ].join('\n')
+
+export const makeArtanisOpenUnsupportedRequestIssueTool = (
+  config: ArtanisOpenUnsupportedRequestIssueConfig = {},
+): ArtanisOperatorWriteTool => {
+  const reader = config.reader
+  const opener = config.opener
+  const writer = config.writer
+
+  return {
+    definition: {
+      description:
+        'Open a real public GitHub issue for ONE unsupported-request ledger row whose status is needs_issue, then mark that row issue_opened with the returned issue ref. This is an outward write to the fixed public OpenAgents issue tracker plus an internal ledger update: it only runs through wired seams, only for bug/missing_capability rows, and never spends, deploys, or writes private material.',
+      name: 'open_unsupported_request_issue',
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          ref: {
+            description:
+              'The unsupported-request ledger entry ref to open an issue for, e.g. "khala_unsupported:ur_...".',
+            type: 'string',
+          },
+        },
+        required: ['ref'],
+        type: 'object',
+      },
+    },
+    execute: (args: unknown) =>
+      Effect.gen(function* () {
+        const record =
+          typeof args === 'object' && args !== null
+            ? (args as Record<string, unknown>)
+            : {}
+        const ref = parseUpdateRef(record)
+        if (ref.kind === 'absent') {
+          return '(invalid arguments: a string "ref" is required)'
+        }
+        if (ref.kind === 'invalid') {
+          return `(blocked: "${ref.raw}" is not an allowed public-safe ledger ref)`
+        }
+        if (reader === undefined) {
+          return `(could not open issue for "${ref.value}": no ledger reader is wired)`
+        }
+        if (opener === undefined) {
+          return `(could not open issue for "${ref.value}": no GitHub issue opener is wired)`
+        }
+        if (writer === undefined) {
+          return `(could not open issue for "${ref.value}": no ledger writer is wired)`
+        }
+
+        const readExit = yield* Effect.exit(
+          Effect.tryPromise(() =>
+            reader({ limit: ARTANIS_UNSUPPORTED_REQUESTS_MAX_LIMIT, status: 'needs_issue' }),
+          ),
+        )
+        if (readExit._tag === 'Failure') {
+          return `(could not read unsupported-request ledger before opening issue for "${ref.value}")`
+        }
+        const existing = readExit.value.find(row => row.requestRef === ref.value)
+        if (existing === undefined) {
+          return `(not found: no needs_issue unsupported request matches ref "${ref.value}")`
+        }
+        if (existing.githubIssueRef !== null || existing.status !== 'needs_issue') {
+          return `(blocked: unsupported request "${ref.value}" is not waiting for an issue)`
+        }
+        if (
+          existing.triageKind !== 'bug' &&
+          existing.triageKind !== 'missing_capability'
+        ) {
+          return `(blocked: unsupported request "${ref.value}" must be triaged as bug or missing_capability before opening a GitHub issue)`
+        }
+        const draft = buildUnsupportedRequestIssueDraft(existing)
+        if (draft === null) {
+          return `(blocked: unsupported request "${ref.value}" cannot produce a public-safe GitHub issue draft)`
+        }
+
+        const issueExit = yield* Effect.exit(Effect.tryPromise(() => opener(draft)))
+        if (issueExit._tag === 'Failure') {
+          return `(could not open GitHub issue for "${ref.value}")`
+        }
+        const issue = issueExit.value
+        if (
+          !Number.isInteger(issue.issueNumber) ||
+          issue.issueNumber <= 0 ||
+          !dispatchFieldIsSafe(issue.issueRef) ||
+          !dispatchFieldIsSafe(issue.issueUrl)
+        ) {
+          return `(blocked: GitHub issue opener returned an invalid public issue receipt for "${ref.value}")`
+        }
+
+        const updateExit = yield* Effect.exit(
+          Effect.tryPromise(() =>
+            writer({
+              githubIssueRef: issue.issueRef,
+              ref: ref.value,
+              status: 'issue_opened',
+            }),
+          ),
+        )
+        if (updateExit._tag === 'Failure') {
+          return `(opened ${issue.issueRef}, but could not update unsupported-request ledger for "${ref.value}")`
+        }
+        const updated = updateExit.value
+        if (updated === null) {
+          return `(opened ${issue.issueRef}, but unsupported request "${ref.value}" was not found during ledger update)`
+        }
+
+        return formatOpenedUnsupportedRequestIssue({
+          issue,
+          record: existing,
+          updated,
+        })
+      }),
+    kind: 'write',
+  }
+}
+
+// ---------------------------------------------------------------------------
 // #6366 — dispatch_codex_task (GATED: pylon_job_dispatch).
 // ---------------------------------------------------------------------------
 //
@@ -3329,6 +3533,11 @@ export const makeArtanisGetSyntheticLoadStatusTool = (
 // is honest ("(could not update …: no ledger writer is wired)") rather than
 // inventive. It is a WRITE tool, not risky/gated: owner-scoped, internal-ledger-
 // only, with no spend/payout/deploy/delete/outward authority.
+// `unsupportedRequestIssueOpener` is the outward GitHub issue creation seam
+// behind `open_unsupported_request_issue` (#6394). With no opener wired the tool
+// is honest and does not mutate anything; when wired it opens a public issue only
+// after reading a needs_issue row and links the ledger row only after the opener
+// returns a concrete issue receipt.
 export const makeArtanisOperatorTools = (
   config: Readonly<{
     repoRead?: ArtanisRepoReadConfig | undefined
@@ -3339,6 +3548,9 @@ export const makeArtanisOperatorTools = (
     traceReview?: ArtanisTraceReviewConfig | undefined
     unsupportedRequests?: ArtanisUnsupportedRequestsConfig | undefined
     unsupportedRequestWriter?: ArtanisUnsupportedRequestWriter | undefined
+    unsupportedRequestIssueOpener?:
+      | ArtanisUnsupportedRequestIssueOpener
+      | undefined
     defaultBranch?: string | undefined
     networkStats?: ArtanisGetNetworkStatsConfig | undefined
     glmFleetStatus?: ArtanisGlmFleetStatusConfig | undefined
@@ -3375,6 +3587,11 @@ export const makeArtanisOperatorTools = (
     makeArtanisGetTraceReviewTool(config.traceReview),
     makeArtanisGetUnsupportedRequestsTool(config.unsupportedRequests),
     makeArtanisUpdateUnsupportedRequestTool({
+      writer: config.unsupportedRequestWriter,
+    }),
+    makeArtanisOpenUnsupportedRequestIssueTool({
+      opener: config.unsupportedRequestIssueOpener,
+      reader: config.unsupportedRequests?.reader,
       writer: config.unsupportedRequestWriter,
     }),
     makeArtanisDispatchCodexTaskTool({


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6394

Assignment: assignment.public.khala_coding.chatcmpl_f2ffa4c2856b41e2ac30bba42ecef851
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 2

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.