### PR TITLE
feat(mirrorcode): default Phase-0 smoke to a real S-target and capture end-to-end result

### DIFF
--- a/apps/openagents.com/scripts/mirrorcode/README.md
+++ b/apps/openagents.com/scripts/mirrorcode/README.md
@@ -53,7 +53,7 @@ preemptible behind real external demand (#6318).
 ## Usage
 
 ```sh
-# Cheapest smoke (false_c): mints a free Khala key, builds images, runs end-to-end.
+# Phase-0 S-target smoke (cal_python): mints a free Khala key, builds images, runs end-to-end.
 ./run.sh
 
 # Pick a different public task (sample id = "<target>_<language>"):
@@ -65,12 +65,13 @@ OPENAI_API_KEY=oa_agent_xxx ./run.sh --task numfmt_python
 
 `<target>_<language>` where language ∈ `python,c,go,rust,ocaml,ada`.
 
-- **Smoke / endpoint validation:** `false_c` — the lightest target (reimplement
-  `/usr/bin/false`). It is a *trivial, benchmark-excluded* target chosen
-  deliberately to exercise the full loop (Docker build → agent tool loop →
-  four-container scoring) with minimal tokens and wall-clock.
-- **Smallest *real* S-bucket targets** (for the first measured runs):
-  `uuidparse_python`, `numfmt_python`, `cal_python`.
+- **Phase-0 issue proof:** `cal_python` — a small public S-bucket target, used
+  as the default because #6377 requires a real S-target smoke.
+- **Endpoint-only validation:** `false_c` — the lightest target (reimplement
+  `/usr/bin/false`). It is a *trivial, benchmark-excluded* target and requires
+  `--allow-trivial-smoke`; do not use it as the #6377 proof.
+- **Other small real S-bucket targets:** `uuidparse_python`, `numfmt_python`,
+  `choose_python`.
 - S bucket: `qsv_select, jq_simple, gron, bitwise, hexyl, uuidparse, numfmt,
   cal, choose`. M bucket: `giac, tex, gotree, mailauth, brotli, wren_cli,
   nonogrid, sed, tssql, bib2json`. **L bucket is off-limits in this runner.**
@@ -81,13 +82,14 @@ OPENAI_API_KEY=oa_agent_xxx ./run.sh --task numfmt_python
 |---|---|---|
 | `MC_CLONE` | `~/work/projects/repos/MirrorCode` | Read-only MirrorCode clone |
 | `OPENAI_API_KEY` | minted free key | Khala key (bearer) |
-| `MC_TASK_ID` | `false_c` | Sample id `<target>_<language>` |
-| `MC_TOKEN_LIMIT` | `250000` | Hard per-sample token cap |
-| `MC_TIME_LIMIT` | `1800` | Hard per-sample wall-clock cap (s) |
-| `MC_MESSAGE_LIMIT` | `120` | Hard per-sample message cap |
+| `MC_TASK_ID` | `cal_python` | Sample id `<target>_<language>` |
+| `MC_TOKEN_LIMIT` | `20000000` | Hard per-sample token cap |
+| `MC_TIME_LIMIT` | `7200` | Hard per-sample wall-clock cap (s) |
+| `MC_MESSAGE_LIMIT` | `250` | Hard per-sample message cap |
 | `MC_OUT` | `./mirrorcode-phase0-result.json` | Result JSON path |
 | `MC_LOG_DIR` | Inspect default (`./logs`) | Inspect eval log dir |
 | `MC_VENV` / `MC_KEEP_VENV` | fresh mktemp / removed | Reuse/keep the throwaway venv |
+| `MC_ALLOW_TRIVIAL_SMOKE` | `0` | Set to `1` only for benchmark-excluded endpoint checks such as `false_c` |
 
 The venv is **throwaway** (a `mktemp` dir, auto-removed) and is never committed.
 
@@ -97,15 +99,18 @@ The venv is **throwaway** (a `mktemp` dir, auto-removed) and is never committed.
 {
   "runId": "mc-phase0-<utc>-<rand>",
   "model": "openagents/khala",
-  "taskId": "false_c",
-  "bucket": "S | M | L | trivial_excluded",
+  "taskId": "cal_python",
+  "bucket": "S | M",
+  "language": "python",
   "status": "passed | failed | error",
   "passRate": 0.0,
   "tokens": { "total": 0, "input": 0, "output": 0, "reasoning": 0,
               "cacheRead": 0, "cacheWrite": 0 },
   "startedAt": "<iso8601>",
   "finishedAt": "<iso8601>",
-  "summary": "..."
+  "summary": "...",
+  "grade": "smoke",
+  "decisionGrade": false
 }
 ```
 

--- a/apps/openagents.com/scripts/mirrorcode/phase0-result.json
+++ b/apps/openagents.com/scripts/mirrorcode/phase0-result.json
@@ -1,14 +1,40 @@
 {
-  "runId": "mc-phase0-cal-py-0001",
+  "runId": "mc-phase0-20260627T105718Z-bb38b2df",
   "model": "openagents/khala",
-  "taskId": "cal",
+  "taskId": "cal_python",
   "bucket": "S",
   "language": "python",
-  "status": "queued",
-  "passRate": null,
-  "tokens": { "total": 0 },
-  "startedAt": "2026-06-27T00:00:00.000Z",
-  "finishedAt": null,
-  "summary": "Phase-0 smoke: a single S-bucket target (cal) launched against openagents/khala to validate endpoint compatibility before any spendful bucket run. Public tasks only; never published as a frontier measurement.",
-  "grade": "smoke"
+  "status": "failed",
+  "passRate": 0.4559068219633943,
+  "tokens": {
+    "input": 5169703,
+    "output": 114403,
+    "total": 5284106,
+    "reasoning": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0
+  },
+  "startedAt": "2026-06-27T10:58:01+00:00",
+  "finishedAt": "2026-06-27T11:21:09+00:00",
+  "summary": "Khala completed the MirrorCode agent loop; implementation did not fully reproduce the target behavior.",
+  "grade": "smoke",
+  "decisionGrade": false,
+  "benchmark": "Epoch Research MirrorCode (public tasks only; private set excluded)",
+  "scoreGroups": {
+    "all": 0.49157509157509155,
+    "visible": 0.5196335078534031,
+    "ablated": null,
+    "hidden": 0.4559068219633943,
+    "withheld": 0.4559068219633943
+  },
+  "caps": {
+    "tokenLimit": 20000000,
+    "timeLimitSeconds": 7200,
+    "messageLimit": 250
+  },
+  "demand": {
+    "kind": "internal",
+    "source": "gym_mirrorcode",
+    "client": "mirrorcode-phase0"
+  }
 }

--- a/apps/openagents.com/scripts/mirrorcode/run.sh
+++ b/apps/openagents.com/scripts/mirrorcode/run.sh
@@ -14,17 +14,17 @@
 # Requirements: Docker (running), uv, python3.13, jq, curl.
 #
 # Usage:
-#   ./run.sh                         # smoke false_c (cheapest), mints a free Khala key
+#   ./run.sh                         # smoke cal_python (S target), mints a free Khala key
 #   MC_TASK_ID=uuidparse_python ./run.sh
 #   OPENAI_API_KEY=oa_agent_xxx ./run.sh --task numfmt_python
 #
 # Env knobs (all optional):
 #   MC_CLONE        path to the MirrorCode clone (default: projects/repos/MirrorCode)
 #   OPENAI_API_KEY  a Khala key; if unset a free one is minted
-#   MC_TASK_ID      sample id '<target>_<language>' (default: false_c)
-#   MC_TOKEN_LIMIT  hard token cap (default 250000)
-#   MC_TIME_LIMIT   hard wall-clock cap seconds (default 1800)
-#   MC_MESSAGE_LIMIT hard message cap (default 120)
+#   MC_TASK_ID      sample id '<target>_<language>' (default: cal_python)
+#   MC_TOKEN_LIMIT  hard token cap (default 20000000)
+#   MC_TIME_LIMIT   hard wall-clock cap seconds (default 7200)
+#   MC_MESSAGE_LIMIT hard message cap (default 250)
 #   MC_OUT          result JSON path (default: ./mirrorcode-phase0-result.json)
 #   MC_VENV         venv dir (default: a fresh mktemp dir; auto-removed)
 #   MC_KEEP_VENV    set to 1 to keep the venv after the run
@@ -88,10 +88,10 @@ if [[ ! -x "${VENV_DIR}/bin/python" ]]; then
 fi
 
 # --- run -----------------------------------------------------------------------
-export MC_TASK_ID="${MC_TASK_ID:-false_c}"
-export MC_TOKEN_LIMIT="${MC_TOKEN_LIMIT:-250000}"
-export MC_TIME_LIMIT="${MC_TIME_LIMIT:-1800}"
-export MC_MESSAGE_LIMIT="${MC_MESSAGE_LIMIT:-120}"
+export MC_TASK_ID="${MC_TASK_ID:-cal_python}"
+export MC_TOKEN_LIMIT="${MC_TOKEN_LIMIT:-20000000}"
+export MC_TIME_LIMIT="${MC_TIME_LIMIT:-7200}"
+export MC_MESSAGE_LIMIT="${MC_MESSAGE_LIMIT:-250}"
 export MC_OUT="${MC_OUT:-${PWD}/mirrorcode-phase0-result.json}"
 
 echo "Launching MirrorCode x Khala smoke (task ${MC_TASK_ID})..."

--- a/apps/openagents.com/scripts/mirrorcode/run_smoke.py
+++ b/apps/openagents.com/scripts/mirrorcode/run_smoke.py
@@ -14,8 +14,8 @@ model id `openai/openagents/khala`), runs ONE chosen public task with hard
 token + wall-clock caps far below the paper's 1B/10B limits, and writes a
 public-safe result JSON in the shared gym contract:
 
-    { runId, model, taskId, bucket, status, passRate, tokens, startedAt,
-      finishedAt, summary }
+    { runId, model, taskId, bucket, language, status, passRate, tokens,
+      startedAt, finishedAt, summary, grade, decisionGrade }
 
 Requests are tagged `internal` / `gym_mirrorcode` via the Khala demand-attribution
 headers (#6298) so the load is auditably an eval and stays preemptible (#6318).
@@ -37,7 +37,8 @@ from typing import Any
 
 # Buckets per the paper (Table 3), mirrored from scripts/run_mirrorcode.py in the
 # clone. Trivial targets (false, dirname, cal_simple, rev) are excluded from the
-# benchmark proper; we allow them ONLY as the cheapest possible smoke target.
+# benchmark proper; keep them behind an explicit opt-in so the default Phase-0
+# path remains a real public S-target as required by #6377.
 S_TARGETS = {
     "qsv_select", "jq_simple", "gron", "bitwise", "hexyl",
     "uuidparse", "numfmt", "cal", "choose",
@@ -48,6 +49,7 @@ M_TARGETS = {
 }
 L_TARGETS = {"ruff", "pkl", "cprepro"}
 TRIVIAL_EXCLUDED = {"false", "dirname", "cal_simple", "rev"}
+LANGUAGES = {"python", "c", "go", "rust", "ocaml", "ada"}
 
 
 def bucket_for_target(target: str) -> str:
@@ -60,6 +62,34 @@ def bucket_for_target(target: str) -> str:
     if target in TRIVIAL_EXCLUDED:
         return "trivial_excluded"
     return "unknown"
+
+
+def split_sample_id(sample_id: str) -> tuple[str, str | None]:
+    """Split '<target>_<language>' without breaking targets like qsv_select."""
+    for suffix in sorted(LANGUAGES, key=len, reverse=True):
+        language_suffix = "_" + suffix
+        if sample_id.endswith(language_suffix):
+            return sample_id[: -len(language_suffix)], suffix
+    return sample_id, None
+
+
+def validate_sample_id(sample_id: str, allow_trivial_smoke: bool) -> tuple[str, str | None, str]:
+    target, language = split_sample_id(sample_id)
+    bucket = bucket_for_target(target)
+    if language is None:
+        raise ValueError(
+            f"task '{sample_id}' must use '<target>_<language>' with language in {sorted(LANGUAGES)}"
+        )
+    if bucket == "unknown":
+        raise ValueError(f"task '{sample_id}' is not a known MirrorCode target")
+    if bucket == "L":
+        raise ValueError("L-bucket targets are off-limits for this bounded Phase-0 runner")
+    if bucket == "trivial_excluded" and not allow_trivial_smoke:
+        raise ValueError(
+            "trivial excluded targets require --allow-trivial-smoke; use an S-target "
+            "such as cal_python for issue #6377"
+        )
+    return target, language, bucket
 
 
 def _iso(value: Any) -> str | None:
@@ -106,12 +136,20 @@ def _score_value(sample: Any) -> dict[str, Any]:
     return {"scorer": None, "groups": {}}
 
 
+def _load_fixture_result(path: str) -> dict[str, Any]:
+    with open(path) as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError("fixture result must be a JSON object")
+    return payload
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description="MirrorCode x Khala Phase-0 smoke runner")
     p.add_argument(
         "--task",
-        default=os.environ.get("MC_TASK_ID", "false_c"),
-        help="Inspect sample id '<target>_<language>' (default: false_c).",
+        default=os.environ.get("MC_TASK_ID", "cal_python"),
+        help="Inspect sample id '<target>_<language>' (default: cal_python).",
     )
     p.add_argument(
         "--model",
@@ -121,25 +159,36 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument(
         "--token-limit",
         type=int,
-        default=int(os.environ.get("MC_TOKEN_LIMIT", "250000")),
-        help="Hard per-sample token cap (default 250000; far below paper 1B).",
+        default=int(os.environ.get("MC_TOKEN_LIMIT", "20000000")),
+        help="Hard per-sample token cap (default 20000000; far below paper 1B).",
     )
     p.add_argument(
         "--time-limit",
         type=int,
-        default=int(os.environ.get("MC_TIME_LIMIT", "1800")),
-        help="Hard per-sample wall-clock cap in seconds (default 1800).",
+        default=int(os.environ.get("MC_TIME_LIMIT", "7200")),
+        help="Hard per-sample wall-clock cap in seconds (default 7200).",
     )
     p.add_argument(
         "--message-limit",
         type=int,
-        default=int(os.environ.get("MC_MESSAGE_LIMIT", "120")),
-        help="Hard per-sample message cap (default 120).",
+        default=int(os.environ.get("MC_MESSAGE_LIMIT", "250")),
+        help="Hard per-sample message cap (default 250).",
     )
     p.add_argument(
         "--out",
         default=os.environ.get("MC_OUT", "mirrorcode-phase0-result.json"),
         help="Path to write the public-safe result JSON.",
+    )
+    p.add_argument(
+        "--allow-trivial-smoke",
+        action="store_true",
+        default=os.environ.get("MC_ALLOW_TRIVIAL_SMOKE", "0") == "1",
+        help="Allow benchmark-excluded trivial targets such as false_c.",
+    )
+    p.add_argument(
+        "--fixture-result",
+        default=os.environ.get("MC_FIXTURE_RESULT", None),
+        help="Use an existing public-safe result JSON instead of running Inspect.",
     )
     p.add_argument(
         "--log-dir",
@@ -156,16 +205,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = p.parse_args(argv)
 
-    if not os.environ.get("OPENAI_API_KEY"):
+    if not args.fixture_result and not os.environ.get("OPENAI_API_KEY"):
         print("ERROR: OPENAI_API_KEY (a Khala key) is not set.", file=sys.stderr)
         return 2
     os.environ.setdefault("OPENAI_BASE_URL", "https://openagents.com/api/v1")
 
-    import inspect_ai
-    from mc.task import mirrorcode
+    try:
+        target, language, bucket = validate_sample_id(
+            args.task,
+            allow_trivial_smoke=args.allow_trivial_smoke,
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
-    target = args.task.rsplit("_", 1)[0]
-    bucket = bucket_for_target(target)
     run_id = (
         "mc-phase0-"
         + _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -180,16 +233,12 @@ def main(argv: list[str] | None = None) -> int:
         "x-openagents-client": args.demand_client,
     }
 
-    # gated_submit=None so `submit` is always available (keeps the bounded smoke
-    # short); the rest of the task config matches the paper defaults.
-    task = mirrorcode(gated_submit=None)
-
     print("=" * 64)
     print(" MirrorCode x Khala Phase-0 smoke")
     print("=" * 64)
     print(f" runId        : {run_id}")
     print(f" model        : {args.model}")
-    print(f" task         : {args.task} (bucket {bucket})")
+    print(f" task         : {args.task} (target {target}, language {language}, bucket {bucket})")
     print(f" token_limit  : {args.token_limit:,}")
     print(f" time_limit   : {args.time_limit}s")
     print(f" message_limit: {args.message_limit}")
@@ -204,68 +253,91 @@ def main(argv: list[str] | None = None) -> int:
     started_at = _iso(_dt.datetime.now(_dt.timezone.utc))
     finished_at = started_at
     score_groups: dict[str, Any] = {}
+    caps = {
+        "tokenLimit": args.token_limit,
+        "timeLimitSeconds": args.time_limit,
+        "messageLimit": args.message_limit,
+    }
 
     try:
-        logs = inspect_ai.eval(
-            task,
-            model=args.model,
-            model_args={"default_headers": default_headers},
-            sample_id=[args.task],
-            token_limit=args.token_limit,
-            time_limit=args.time_limit,
-            message_limit=args.message_limit,
-            log_dir=args.log_dir,
-            display="plain",
-            fail_on_error=False,
-        )
-        log = logs[0]
-        stats = getattr(log, "stats", None)
-        if stats is not None:
-            tokens = _aggregate_tokens(getattr(stats, "model_usage", None))
-            started_at = _iso(getattr(stats, "started_at", None)) or started_at
-            finished_at = _iso(getattr(stats, "completed_at", None)) or finished_at
-
-        log_status = getattr(log, "status", "unknown")
-        samples = getattr(log, "samples", None) or []
-        if log_status == "error" and not samples:
-            err = getattr(log, "error", None)
-            status = "error"
-            summary = f"eval errored: {getattr(err, 'message', err)}"
-        elif samples:
-            sample = samples[0]
-            sv = _score_value(sample)
-            score_groups = sv["groups"]
-            # Headline pass rate: the held-out (hidden+ablated) reproduction rate
-            # if present, else "all", else "visible". This is the anti-contamination
-            # number that matters for the gym rung.
-            for key in ("withheld", "all", "visible"):
-                if key in score_groups and score_groups[key] is not None:
-                    try:
-                        candidate = float(score_groups[key])
-                    except (TypeError, ValueError):
-                        continue
-                    if candidate == candidate:  # not NaN
-                        pass_rate = candidate
-                        break
-            sample_err = getattr(sample, "error", None)
-            if sample_err is not None:
-                status = "error"
-                summary = f"sample errored: {getattr(sample_err, 'message', sample_err)}"
-            elif pass_rate is not None and pass_rate >= 0.999:
-                status = "passed"
-                summary = "Khala completed the MirrorCode agent loop and solved the target."
-            elif pass_rate is not None:
-                status = "failed"
-                summary = (
-                    "Khala completed the MirrorCode agent loop; implementation did not "
-                    "fully reproduce the target behavior."
-                )
-            else:
-                status = "failed"
-                summary = "Khala ran the agent loop; no usable pass rate was produced."
+        if args.fixture_result:
+            fixture = _load_fixture_result(args.fixture_result)
+            status = str(fixture.get("status", "error"))
+            pass_rate = fixture.get("passRate")
+            tokens = fixture.get("tokens") or tokens
+            started_at = _iso(fixture.get("startedAt")) or started_at
+            finished_at = _iso(fixture.get("finishedAt")) or finished_at
+            summary = str(fixture.get("summary", "Loaded public-safe fixture result."))
+            score_groups = fixture.get("scoreGroups") or {}
+            run_id = str(fixture.get("runId") or run_id)
+            caps = fixture.get("caps") or caps
         else:
-            status = "error"
-            summary = f"no samples produced (log status={log_status})."
+            import inspect_ai
+            from mc.task import mirrorcode
+
+            # gated_submit=None so `submit` is always available (keeps the bounded
+            # smoke short); the rest of the task config matches the paper defaults.
+            task = mirrorcode(gated_submit=None)
+            logs = inspect_ai.eval(
+                task,
+                model=args.model,
+                model_args={"default_headers": default_headers},
+                sample_id=[args.task],
+                token_limit=args.token_limit,
+                time_limit=args.time_limit,
+                message_limit=args.message_limit,
+                log_dir=args.log_dir,
+                display="plain",
+                fail_on_error=False,
+            )
+            log = logs[0]
+            stats = getattr(log, "stats", None)
+            if stats is not None:
+                tokens = _aggregate_tokens(getattr(stats, "model_usage", None))
+                started_at = _iso(getattr(stats, "started_at", None)) or started_at
+                finished_at = _iso(getattr(stats, "completed_at", None)) or finished_at
+
+            log_status = getattr(log, "status", "unknown")
+            samples = getattr(log, "samples", None) or []
+            if log_status == "error" and not samples:
+                err = getattr(log, "error", None)
+                status = "error"
+                summary = f"eval errored: {getattr(err, 'message', err)}"
+            elif samples:
+                sample = samples[0]
+                sv = _score_value(sample)
+                score_groups = sv["groups"]
+                # Headline pass rate: the held-out (hidden+ablated) reproduction rate
+                # if present, else "all", else "visible". This is the anti-contamination
+                # number that matters for the gym rung.
+                for key in ("withheld", "all", "visible"):
+                    if key in score_groups and score_groups[key] is not None:
+                        try:
+                            candidate = float(score_groups[key])
+                        except (TypeError, ValueError):
+                            continue
+                        if candidate == candidate:  # not NaN
+                            pass_rate = candidate
+                            break
+                sample_err = getattr(sample, "error", None)
+                if sample_err is not None:
+                    status = "error"
+                    summary = f"sample errored: {getattr(sample_err, 'message', sample_err)}"
+                elif pass_rate is not None and pass_rate >= 0.999:
+                    status = "passed"
+                    summary = "Khala completed the MirrorCode agent loop and solved the target."
+                elif pass_rate is not None:
+                    status = "failed"
+                    summary = (
+                        "Khala completed the MirrorCode agent loop; implementation did not "
+                        "fully reproduce the target behavior."
+                    )
+                else:
+                    status = "failed"
+                    summary = "Khala ran the agent loop; no usable pass rate was produced."
+            else:
+                status = "error"
+                summary = f"no samples produced (log status={log_status})."
     except Exception as exc:  # noqa: BLE001 - smoke must always emit a result
         status = "error"
         summary = f"runner exception: {type(exc).__name__}: {exc}"
@@ -278,21 +350,20 @@ def main(argv: list[str] | None = None) -> int:
         "model": "openagents/khala",
         "taskId": args.task,
         "bucket": bucket,
+        "language": language,
         "status": status,
         "passRate": pass_rate,
         "tokens": tokens,
         "startedAt": started_at,
         "finishedAt": finished_at,
         "summary": summary,
+        "grade": "smoke",
+        "decisionGrade": False,
         # Public-safe extras (not part of the minimal contract, but useful for the
         # service lane and honest reporting). Public-task only.
         "benchmark": "Epoch Research MirrorCode (public tasks only; private set excluded)",
         "scoreGroups": score_groups,
-        "caps": {
-            "tokenLimit": args.token_limit,
-            "timeLimitSeconds": args.time_limit,
-            "messageLimit": args.message_limit,
-        },
+        "caps": caps,
         "demand": {
             "kind": "internal",
             "source": args.demand_source,


### PR DESCRIPTION
Addresses #6377.

### Changes
- Switches the MirrorCode Phase-0 runner defaults from trivial `false_c` to the real S-bucket `cal_python` across `run.sh`, `run_smoke.py`, and `README.md`; trivial/excluded targets now require `--allow-trivial-smoke`.
- Adds `split_sample_id`/`validate_sample_id` to parse `<target>_<language>` correctly (no longer breaking targets like `qsv_select`), reject L-bucket and unknown targets, and emit `language` in the result.
- Raises bounded caps (token 20M, time 7200s, message 250) and adds a `--fixture-result` path to load a public-safe result JSON.
- Updates `phase0-result.json` with a captured real run: status `failed`, passRate 0.4559, token rows (input 5169703 / output 114403 / total 5284106), start/finish times, and `scoreGroups`, proving Khala completed the agent loop end-to-end.

### Verification
Captured run in `phase0-result.json` (runId mc-phase0-20260627T105718Z-bb38b2df): Khala completed the MirrorCode agent loop on cal_python with exact token rows recorded; not independently re-run.