### PR TITLE
docs(khala): Artanis-as-a-Service Phase-1 smoke harness, guide, and demo video script

### DIFF
--- a/docs/khala/2026-06-27-artanis-as-a-service-demo-video-script.md
+++ b/docs/khala/2026-06-27-artanis-as-a-service-demo-video-script.md
@@ -1,0 +1,132 @@
+# Artanis-as-a-Service Demo Video Script
+
+**Date:** 2026-06-27
+**Audience:** Internal reviewers and invited community Codex testers.
+**Goal:** Show the Phase-1 loop in one short recording: connect a Codex fleet,
+dispatch a bounded fixture task, verify the closeout, and explain the safety
+boundary.
+
+## Scene 1 - Install And Open The Fleet Door
+
+Narration:
+
+> Artanis-as-a-Service lets a Khala user bring their own Codex accounts. The
+> credentials stay on their machine; Khala orchestrates and the local Pylon
+> executes.
+
+Terminal:
+
+```sh
+npm install -g @openagentsinc/khala
+khala fleet connect
+khala fleet status
+```
+
+Callouts:
+
+- The device login shows a short browser code, not a long pasted auth string.
+- Each account lands under an isolated Pylon account home.
+- The default `~/.codex` session is never touched.
+
+## Scene 2 - Add Throughput
+
+Narration:
+
+> More distinct ChatGPT accounts give the tenant more independent Codex capacity.
+> Khala tracks them as a fleet.
+
+Terminal:
+
+```sh
+khala fleet connect --account codex-2
+khala fleet status
+```
+
+Callouts:
+
+- Account refs are stable (`codex`, `codex-2`, ...).
+- Readiness is visible without printing tokens.
+- Credential problems show as readiness, not as leaked secrets.
+
+## Scene 3 - Show The Bounded Fixture
+
+Narration:
+
+> For the first smoke we use a public fixture repo, not a private customer repo.
+> The task is tiny and deterministic: add risk classification to a fleet plan.
+
+Terminal:
+
+```sh
+sed -n '1,120p' docs/khala/fixtures/artanis-as-a-service-smoke-repo/README.md
+sed -n '1,120p' docs/khala/fixtures/artanis-as-a-service-smoke-repo/test/backlog.test.js
+```
+
+Callouts:
+
+- The failing test names the expected behavior.
+- The verification command is `bun test`.
+- The prompt and repo refs are public-safe.
+
+## Scene 4 - Dispatch To Caller-Owned Pylon Capacity
+
+Narration:
+
+> The coding request names the workflow, the caller-owned Pylon, a public repo,
+> a pinned commit, and a verification command. If delegation does not happen, we
+> stop instead of spending on a model fallback.
+
+Terminal:
+
+```sh
+khala spawn \
+  --strategy pylon \
+  --count 1 \
+  --objective "Implement the Artanis-as-a-Service smoke fixture riskLevel task." \
+  --repo OpenAgentsInc/openagents \
+  --branch main \
+  --commit "<current-origin-main-sha>" \
+  --verify "bun test docs/khala/fixtures/artanis-as-a-service-smoke-repo/test/backlog.test.js"
+```
+
+Callouts:
+
+- The request is owner/caller scoped.
+- The assignment runs no-spend own capacity.
+- The local Codex runner may use full local execution rights only on the
+  tenant's own linked Pylon.
+
+## Scene 5 - Verify Closeout
+
+Narration:
+
+> Completion is not a vague chat answer. We require the local verification
+> command, closeout, exact own-capacity token rows, and public counter
+> reconciliation.
+
+Terminal:
+
+```sh
+bun apps/pylon/src/index.ts khala closeout "<assignmentRef>" --json
+curl -fsS https://openagents.com/api/public/khala-tokens-served
+```
+
+Callouts:
+
+- Closeout should be accepted.
+- Settlement is `not_applicable`.
+- Payout claims are not allowed for own-capacity no-spend work.
+- Counter movement alone is not proof; exact rows are the source of truth.
+
+## Scene 6 - Safety Close
+
+Narration:
+
+> The tenant owns the accounts, the Pylon, the repo access, and the local
+> execution. OpenAgents provides orchestration and proof, not Codex resale.
+
+Show the report template from
+[`2026-06-27-artanis-as-a-service-phase-1-smoke-guide.md`](./2026-06-27-artanis-as-a-service-phase-1-smoke-guide.md).
+
+Do not show tokens, raw SDK events, raw terminal dumps, wallet material, private
+repo contents, or local credential paths on screen.

--- a/docs/khala/2026-06-27-artanis-as-a-service-phase-1-smoke-guide.md
+++ b/docs/khala/2026-06-27-artanis-as-a-service-phase-1-smoke-guide.md
@@ -1,0 +1,175 @@
+# Artanis-as-a-Service Phase-1 Smoke Guide
+
+**Date:** 2026-06-27
+**Scope:** Step-by-step guide for invited community Codex testers to connect a
+local Codex fleet to Khala, run one bounded public smoke task, and record
+public-safe proof for the internal Artanis-as-a-Service demo.
+**Fixture:** [`fixtures/artanis-as-a-service-smoke-repo`](./fixtures/artanis-as-a-service-smoke-repo/)
+
+This guide complements the multi-tenant enablement plan in
+[`../ops/2026-06-27-artanis-as-a-service-multi-tenant-codex-fleet-enablement.md`](../ops/2026-06-27-artanis-as-a-service-multi-tenant-codex-fleet-enablement.md)
+and the own-capacity burn runbook in
+[`../ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md`](../ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md).
+
+## What This Smoke Proves
+
+- The tester can install Khala and connect one or more Codex accounts with the
+  paste-free device login flow.
+- Codex credentials stay in isolated Pylon account homes and never touch the
+  default `~/.codex` home.
+- Khala can route a bounded public coding task to the tester's caller-owned
+  local Pylon capacity.
+- The local runner can produce a closeout with a passing verification command.
+- The public token counter can be reconciled against exact own-capacity rows by
+  an operator without exposing raw private trace material.
+
+## Tester Prerequisites
+
+- Node 20+ or Bun.
+- The `codex` CLI on `PATH`; if missing, `khala fleet connect` prints the install
+  hint.
+- A logged-in OpenAgents/Khala token for the invited tester.
+- A public GitHub checkout or fork containing this repository and the fixture
+  path above.
+
+Do not run `codex login` against the default `~/.codex` home during this smoke.
+Use the Khala/Pylon fleet flow below so each account is isolated under
+`<pylon home>/accounts/codex/<ref>`.
+
+## 1. Install Khala And Connect The Fleet
+
+```sh
+npm install -g @openagentsinc/khala
+khala fleet connect
+khala fleet status
+```
+
+To add more throughput, run `khala fleet connect` again with a distinct ChatGPT
+account, or name the account explicitly:
+
+```sh
+khala fleet connect --account codex-2
+khala fleet status
+```
+
+Expected status evidence:
+
+- each connected account has a stable ref such as `codex` or `codex-2`,
+- ready accounts show `ready`,
+- credential-missing accounts are visible without printing tokens,
+- the tester can explain that more distinct accounts mean more independent rate
+  budget.
+
+## 2. Pick The Smoke Task
+
+Use the fixture task:
+
+```text
+Verify or re-implement the behavior in docs/khala/fixtures/artanis-as-a-service-smoke-repo/src/backlog.js.
+Each buildFleetPlan account row must include riskLevel: "low" when readiness is
+"ready", otherwise "needs-attention". Keep the summary counts unchanged.
+```
+
+Verification command:
+
+```sh
+bun test
+```
+
+When this fixture is dispatched through Pylon, pass the public repository,
+pinned branch/commit, and the fixture-relative verification command. Keep the
+prompt public and bounded; do not include private local paths, raw prompts,
+secrets, provider payloads, or wallet material.
+
+## 3. Run Through Caller-Owned Pylon Capacity
+
+Operators may use either the CLI spawn bridge or the lower-level Pylon request
+flow, depending on which tenant surface is being tested.
+
+CLI spawn shape:
+
+```sh
+khala spawn \
+  --strategy pylon \
+  --count 1 \
+  --objective "Implement the Artanis-as-a-Service smoke fixture riskLevel task." \
+  --repo OpenAgentsInc/openagents \
+  --branch main \
+  --commit "<current-origin-main-sha>" \
+  --verify "bun test docs/khala/fixtures/artanis-as-a-service-smoke-repo/test/backlog.test.js"
+```
+
+Lower-level Pylon request shape:
+
+```sh
+bun apps/pylon/src/index.ts khala request \
+  --workflow codex_agent_task \
+  --pylon-ref "<tester-owned-pylon-ref>" \
+  --repo OpenAgentsInc/openagents \
+  --branch main \
+  --commit "<current-origin-main-sha>" \
+  --verify "bun test docs/khala/fixtures/artanis-as-a-service-smoke-repo/test/backlog.test.js" \
+  --prompt "Implement the Artanis-as-a-Service smoke fixture riskLevel task." \
+  --json
+```
+
+Expected request evidence:
+
+- `ok: true`,
+- `workflow: "codex_agent_task"`,
+- a delegation frame naming the targeted Pylon,
+- an `assignmentRef`,
+- a `durableRequestId`,
+- an `assignmentRun` closeout when auto-run is enabled.
+
+If the request falls through to normal model routing, stop and fix the
+delegation preconditions before recording proof.
+
+## 4. Verify And Close Out
+
+The fixture is complete when the assigned workspace passes:
+
+```sh
+bun test docs/khala/fixtures/artanis-as-a-service-smoke-repo/test/backlog.test.js
+```
+
+Then record the owner-scoped closeout:
+
+```sh
+bun apps/pylon/src/index.ts khala closeout "<assignmentRef>" --json
+```
+
+Expected closeout evidence:
+
+- `closeoutChecklist.ok: true`,
+- status is accepted,
+- settlement is `not_applicable`,
+- payout claim is not allowed,
+- exact own-capacity token rows exist for the assignment,
+- owner-only traces exist without raw private material in public projections.
+
+## 5. Public Report Template
+
+Use this structure for the internal report or demo notes:
+
+```text
+Artanis-as-a-Service Phase-1 smoke
+Date:
+Tester:
+Khala CLI version:
+Fixture commit:
+Pylon ref:
+Codex account refs:
+Assignment ref:
+Durable request id:
+Verification:
+Closeout:
+Counter before:
+Counter after:
+Notes:
+```
+
+Public-safe reports may include command names, public refs, status values, and
+token totals. They must not include agent tokens, raw Codex events, raw shell
+output, credential paths, private repository content, private prompts, wallet
+material, or local workspace paths.

--- a/docs/khala/fixtures/artanis-as-a-service-smoke-repo/README.md
+++ b/docs/khala/fixtures/artanis-as-a-service-smoke-repo/README.md
@@ -1,0 +1,49 @@
+# Artanis-as-a-Service Phase-1 Smoke Repo
+
+This is a public, self-contained fixture repo for invited Codex fleet testers.
+It is intentionally small enough for a first Khala -> Pylon -> Codex assignment
+to finish quickly while still proving the full loop:
+
+- a human-readable backlog item,
+- a deterministic code change target,
+- a local verification command,
+- public-safe evidence to cite in a demo.
+
+The fixture never requires secrets, private repositories, wallet material, raw
+provider payloads, or the user's default `~/.codex` home.
+
+## Tester Task
+
+Ask the fleet to verify or re-implement the behavior in `src/backlog.js`:
+
+> Ensure each `buildFleetPlan()` account row includes `riskLevel`. Accounts with
+> `readiness: "ready"` are `"low"` risk, all other accounts are
+> `"needs-attention"`. Keep the summary counts unchanged.
+
+## Local Verification
+
+From the fixture root:
+
+```sh
+bun test
+```
+
+Expected result after the task is complete:
+
+```text
+2 pass
+```
+
+## Public Proof Checklist
+
+A completed tester run should record only public-safe refs:
+
+- the public repo and pinned commit used for the run,
+- the issue or task summary,
+- the verification command (`bun test`),
+- the assignment ref and durable request id,
+- the closeout status and public result refs,
+- the before/after public token-counter values.
+
+Do not paste agent tokens, Codex auth paths, raw SDK events, raw terminal output,
+private prompts, wallet material, or local workspace paths into public reports.

--- a/docs/khala/fixtures/artanis-as-a-service-smoke-repo/package.json
+++ b/docs/khala/fixtures/artanis-as-a-service-smoke-repo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "artanis-as-a-service-smoke-repo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/docs/khala/fixtures/artanis-as-a-service-smoke-repo/src/backlog.js
+++ b/docs/khala/fixtures/artanis-as-a-service-smoke-repo/src/backlog.js
@@ -1,0 +1,18 @@
+export function buildFleetPlan(accounts) {
+  const rows = accounts.map((account, index) => ({
+    ref: account.ref,
+    ordinal: index + 1,
+    readiness: account.readiness,
+    canRunCodex: account.readiness === "ready",
+    riskLevel: account.readiness === "ready" ? "low" : "needs-attention",
+  }))
+
+  return {
+    rows,
+    summary: {
+      total: rows.length,
+      ready: rows.filter((row) => row.canRunCodex).length,
+      needsAttention: rows.filter((row) => !row.canRunCodex).length,
+    },
+  }
+}

--- a/docs/khala/fixtures/artanis-as-a-service-smoke-repo/test/backlog.test.js
+++ b/docs/khala/fixtures/artanis-as-a-service-smoke-repo/test/backlog.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { buildFleetPlan } from "../src/backlog.js"
+
+describe("buildFleetPlan", () => {
+  test("preserves deterministic fleet summary counts", () => {
+    const plan = buildFleetPlan([
+      { ref: "codex", readiness: "ready" },
+      { ref: "codex-2", readiness: "credentials-missing" },
+      { ref: "codex-3", readiness: "ready" },
+    ])
+
+    expect(plan.summary).toEqual({
+      total: 3,
+      ready: 2,
+      needsAttention: 1,
+    })
+  })
+
+  test("classifies each account risk for the demo report", () => {
+    const plan = buildFleetPlan([
+      { ref: "codex", readiness: "ready" },
+      { ref: "codex-2", readiness: "credentials-missing" },
+    ])
+
+    expect(plan.rows).toEqual([
+      {
+        ref: "codex",
+        ordinal: 1,
+        readiness: "ready",
+        canRunCodex: true,
+        riskLevel: "low",
+      },
+      {
+        ref: "codex-2",
+        ordinal: 2,
+        readiness: "credentials-missing",
+        canRunCodex: false,
+        riskLevel: "needs-attention",
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Addresses #6387.

### Changes
- Adds `docs/khala/2026-06-27-artanis-as-a-service-phase-1-smoke-guide.md`: step-by-step tester flow (install, `khala fleet connect`/`status`, pick fixture task, dispatch via caller-owned Pylon, verify/closeout, public report template).
- Adds `docs/khala/2026-06-27-artanis-as-a-service-demo-video-script.md`: a 6-scene demo recording script with public-safety callouts.
- Adds a self-contained fixture repo under `docs/khala/fixtures/artanis-as-a-service-smoke-repo/` (README, package.json, `src/backlog.js` with a deterministic `buildFleetPlan` riskLevel target, and `test/backlog.test.js`).

### Verification
Fixture ships with `bun test` (test/backlog.test.js); not independently executed.