### PR TITLE
feat(pylon-gate): self-expiring 5min lease TTLs + self-healing stale-lease sweep

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
@@ -92,6 +92,28 @@ const makeStore = (input: {
     },
     listAssignmentsForPylon: async pylonRef =>
       assignments.filter(item => item.pylonRef === pylonRef),
+    sweepStaleAssignmentLeases: async (pylonRef, nowIso, staleBeforeIso) => {
+      const refs: string[] = []
+      for (const [index, item] of assignments.entries()) {
+        if (
+          item.pylonRef === pylonRef &&
+          ['accepted', 'blocked', 'offered', 'proof_submitted', 'running'].includes(
+            item.state,
+          ) &&
+          item.leaseExpiresAt > nowIso &&
+          item.updatedAt < staleBeforeIso
+        ) {
+          refs.push(item.assignmentRef)
+          assignments[index] = {
+            ...item,
+            leaseExpiresAt: nowIso,
+            state: 'stale',
+            updatedAt: nowIso,
+          }
+        }
+      }
+      return refs
+    },
     listEventsForAssignment: async () => [],
     listEventsForPylon: async () => [],
     listProviderJobLifecycleForPylons: async () => [],
@@ -696,7 +718,7 @@ describe('coding workflow delegation', () => {
             assignmentRef: 'assignment.public.test.running_active_slot',
             id: 'pylon_api_assignment_running_active_slot',
             state: 'accepted',
-            updatedAt: '2026-06-25T11:00:00.000Z',
+            updatedAt: '2026-06-25T11:58:00.000Z',
           }),
         ],
         registrations: [registration()],
@@ -721,6 +743,40 @@ describe('coding workflow delegation', () => {
       requestedPylonRef: 'pylon.owner.codex',
       statusCode: 409,
     })
+  })
+
+  test('sweeps stale active coding leases before targeted dispatch (#6410)', async () => {
+    const result = await delegateCodingWorkflow({
+      classification,
+      linkedAgents: [linkedOwner],
+      makeId: () => 'id1',
+      nowIso,
+      pylonStore: makeStore({
+        activeAssignments: [
+          assignment({
+            assignmentRef: 'assignment.public.test.silent_running_slot',
+            id: 'pylon_api_assignment_silent_running_slot',
+            state: 'running',
+            updatedAt: '2026-06-25T11:54:59.000Z',
+          }),
+        ],
+        registrations: [registration()],
+      }),
+      rawBody: {
+        openagents: {
+          coding: {
+            targetPylonRef: 'pylon.owner.codex',
+          },
+        },
+      },
+      requestId: 'chatcmpl_coding_target_sweeps_stale_slot',
+    })
+
+    expect(result?.kind).toBe('assigned')
+    if (result?.kind !== 'assigned') throw new Error('expected assignment')
+    expect(result.assignment.assignmentRef).toBe(
+      'assignment.public.khala_coding.id1',
+    )
   })
 
   test('diagnoses a stale-capability target as not Codex-capable (#6354)', async () => {

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.ts
@@ -11,7 +11,10 @@ import {
   pylonCodingServiceAccountCapacity,
   pylonCodingServiceCapacityProjection,
 } from '../pylon-api'
-import { controlledPylonAssignmentDispatchGate } from '../pylon-api-routes'
+import {
+  controlledPylonAssignmentDispatchGate,
+  sweepStalePylonAssignmentLeases,
+} from '../pylon-api-routes'
 import type { CodingWorkflowClassification } from './coding-workflow-classifier'
 
 const CODEX_AGENT_CAPABILITY_REF = 'capability.pylon.local_codex'
@@ -917,6 +920,11 @@ const delegateCodingWorkflowUnsafe = async (
     )
     const activeAssignments = await (async () => {
       try {
+        await sweepStalePylonAssignmentLeases({
+          nowIso: input.nowIso,
+          pylonRef: registration.pylonRef,
+          store: input.pylonStore,
+        })
         return await input.pylonStore.listAssignmentsForPylon(
           registration.pylonRef,
           100,

--- a/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
@@ -160,6 +160,39 @@ class MemoryPylonApiStore implements PylonApiStore {
       .filter(assignment => assignment.pylonRef === pylonRef)
       .slice(0, limit)
 
+  sweepStaleAssignmentLeases = async (
+    pylonRef: string,
+    nowIso: string,
+    staleBeforeIso: string,
+  ) => {
+    const refs: string[] = []
+    for (const assignment of this.assignments.values()) {
+      if (
+        assignment.pylonRef === pylonRef &&
+        ['accepted', 'blocked', 'offered', 'proof_submitted', 'running'].includes(
+          assignment.state,
+        ) &&
+        assignment.leaseExpiresAt > nowIso &&
+        assignment.updatedAt < staleBeforeIso
+      ) {
+        const next = {
+          ...assignment,
+          leaseExpiresAt: nowIso,
+          state: 'stale' as const,
+          updatedAt: nowIso,
+        }
+        refs.push(assignment.assignmentRef)
+        this.assignments.set(assignment.assignmentRef, next)
+        this.assignmentsByIdempotency.set(next.idempotencyKeyHash, next)
+        this.providerJobLifecycle.set(
+          next.assignmentRef,
+          providerJobLifecycleRecordFromAssignment(next),
+        )
+      }
+    }
+    return refs
+  }
+
   listRegistrations = async (limit: number) =>
     Array.from(this.registrations.values()).slice(0, limit)
 
@@ -2581,6 +2614,53 @@ describe('Pylon API routes', () => {
     expect(freshBody.dispatchGate?.blockerRefs).not.toContain(
       'blocker.public.pylon_dispatch.duplicate_active_assignment',
     )
+  })
+
+  test('sweeps silent active leases before dispatch capacity accounting (#6410)', async () => {
+    const store = new MemoryPylonApiStore()
+    await registerPylon(store)
+    await markOnline(store)
+    await markWalletReady(store)
+    const staleRunning = await createAssignment(store, {
+      assignmentRef: 'assignment.public.silent_running_one',
+      idempotencyKey: 'assignment-silent-running-one',
+      nowIso: '2026-06-07T00:10:00.000Z',
+    })
+    expect(staleRunning.status).toBe(201)
+    const staleRecord = store.assignments.get(
+      'assignment.public.silent_running_one',
+    )
+    expect(staleRecord).toBeDefined()
+    if (staleRecord === undefined) {
+      throw new Error('expected seeded assignment')
+    }
+    const runningRecord = {
+      ...staleRecord,
+      leaseExpiresAt: '2026-06-07T01:10:00.000Z',
+      state: 'running' as const,
+      updatedAt: '2026-06-07T00:09:59.000Z',
+    }
+    store.assignments.set(runningRecord.assignmentRef, runningRecord)
+    store.assignmentsByIdempotency.set(
+      runningRecord.idempotencyKeyHash,
+      runningRecord,
+    )
+
+    const next = await createAssignment(store, {
+      assignmentRef: 'assignment.public.after_silent_running_two',
+      idempotencyKey: 'assignment-after-silent-running-two',
+      nowIso: '2026-06-07T00:15:00.000Z',
+    })
+    const nextBody = await responseJson<PylonRouteJson>(next)
+
+    expect(next.status).toBe(201)
+    expect(nextBody.dispatchGate?.dispatchAllowed).toBe(true)
+    expect(nextBody.dispatchGate?.blockerRefs).not.toContain(
+      'blocker.public.pylon_dispatch.duplicate_active_assignment',
+    )
+    expect(
+      store.assignments.get('assignment.public.silent_running_one')?.state,
+    ).toBe('stale')
   })
 
   test('allows unpaid smoke dispatch without wallet readiness', async () => {

--- a/apps/openagents.com/workers/api/src/pylon-api-routes.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.ts
@@ -56,7 +56,11 @@ import {
   pylonClientVersionMeetsMinimum,
   resolveSparkPayoutTargetReadiness,
 } from './pylon-api'
-import { currentIsoTimestamp, randomUuid } from './runtime-primitives'
+import {
+  currentIsoTimestamp,
+  isoTimestampAfterIso,
+  randomUuid,
+} from './runtime-primitives'
 import {
   TASSADAR_DISPATCH_CAPABILITY_UNRECEIPTED_BLOCKER_REF,
   admitTassadarExecutorCapabilityClaim,
@@ -345,23 +349,32 @@ const paidAssignmentPaymentModes = new Set([
   'settled_bitcoin',
 ])
 
-// #6386: an `offered` assignment is a dispatched-but-unclaimed lease. A live
-// Pylon claims it within seconds (offered -> running via the first reported
-// event), so a FRESH `offered` rightly holds a dispatch slot and throttles
-// within-heartbeat over-admission. But an `offered` lease that has not progressed
-// for well beyond that claim window is an over-admitted / abandoned dispatch:
-// e.g. a concurrent burst (~40 parallel khala requests across one Pylon) that
-// all raced past the per-account ceiling before any of their leases committed,
-// then was never executed. Those rows then hold their full (1-hour) lease while
-// the heartbeat still advertises free `available` slots (heartbeat `busy` counts
-// only RUNNING work, not the orphaned `offered` backlog). Counting them for the
-// whole lease deadlocks every account at its ceiling for an hour even though
-// real capacity is free. After the claim window a stale `offered` stops counting,
-// mirroring the closeout slot-release fix (299bc363ec) that dropped
-// `closeout_submitted` from the blocking set. Real held work
-// (running/accepted/proof_submitted/blocked) and the live heartbeat `available`
-// remain the capacity authority, so admission still tops out at advertised slots.
-const OFFERED_DISPATCH_SLOT_CLAIM_WINDOW_MS = 2 * 60 * 1000
+// #6410: dispatch slots use a short sliding lease TTL. Any slot-holding
+// assignment must keep touching updatedAt via acceptance/progress/proof/closeout
+// events; if it goes silent for more than this window it no longer consumes
+// future capacity. The store path proactively marks these rows stale before gate
+// accounting, while this pure gate check keeps tests/fallback stores correct.
+export const PYLON_ASSIGNMENT_ACTIVE_LEASE_TTL_MS = 5 * 60 * 1000
+
+export const staleAssignmentLeaseCutoffIso = (nowIso: string): string =>
+  isoTimestampAfterIso(nowIso, -PYLON_ASSIGNMENT_ACTIVE_LEASE_TTL_MS)
+
+export const sweepStalePylonAssignmentLeases = async (
+  input: Readonly<{
+    nowIso: string
+    pylonRef: string
+    store: PylonApiStore
+  }>,
+): Promise<ReadonlyArray<string>> => {
+  if (input.store.sweepStaleAssignmentLeases === undefined) {
+    return []
+  }
+  return input.store.sweepStaleAssignmentLeases(
+    input.pylonRef,
+    input.nowIso,
+    staleAssignmentLeaseCutoffIso(input.nowIso),
+  )
+}
 
 const pylonAssignmentHasActiveLease = (
   assignment: PylonApiAssignmentRecord,
@@ -374,14 +387,12 @@ const pylonAssignmentHasActiveLease = (
   if (!(Date.parse(assignment.leaseExpiresAt) > now)) {
     return false
   }
-  if (assignment.state === 'offered') {
-    const lastTouch = Date.parse(assignment.updatedAt ?? assignment.createdAt)
-    if (
-      Number.isFinite(lastTouch) &&
-      now - lastTouch > OFFERED_DISPATCH_SLOT_CLAIM_WINDOW_MS
-    ) {
-      return false
-    }
+  const lastTouch = Date.parse(assignment.updatedAt ?? assignment.createdAt)
+  if (
+    Number.isFinite(lastTouch) &&
+    now - lastTouch > PYLON_ASSIGNMENT_ACTIVE_LEASE_TTL_MS
+  ) {
+    return false
   }
   return true
 }
@@ -1300,8 +1311,20 @@ const routeCreateAssignment = <Bindings extends PylonApiRouteEnv>(
         ? []
         : yield* Effect.tryPromise({
             catch: pylonApiStoreErrorFromUnknown,
-            try: () => store.listAssignmentsForPylon(body.pylonRef, 100),
-          })
+            try: () =>
+              sweepStalePylonAssignmentLeases({
+                nowIso,
+                pylonRef: body.pylonRef,
+                store,
+              }),
+          }).pipe(
+            Effect.flatMap(() =>
+              Effect.tryPromise({
+                catch: pylonApiStoreErrorFromUnknown,
+                try: () => store.listAssignmentsForPylon(body.pylonRef, 100),
+              }),
+            ),
+          )
     const dispatchGate = controlledPylonAssignmentDispatchGate({
       activeAssignments,
       assignmentRef: requestedAssignmentRef ?? null,

--- a/apps/openagents.com/workers/api/src/pylon-api.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api.ts
@@ -800,6 +800,11 @@ export type PylonApiStore = Readonly<{
     pylonRef: string,
     limit: number,
   ) => Promise<ReadonlyArray<PylonApiAssignmentRecord>>
+  sweepStaleAssignmentLeases?: (
+    pylonRef: string,
+    nowIso: string,
+    staleBeforeIso: string,
+  ) => Promise<ReadonlyArray<string>>
   listAssignmentsForPylons?: (
     pylonRefs: ReadonlyArray<string>,
     limit: number,
@@ -2112,6 +2117,42 @@ export const makeD1PylonApiStore = (db: D1Database): PylonApiStore => ({
       .all<PylonApiAssignmentRow>()
 
     return (result.results ?? []).map(rowToAssignment)
+  },
+
+  sweepStaleAssignmentLeases: async (pylonRef, nowIso, staleBeforeIso) => {
+    const staleRows = await db
+      .prepare(
+        `SELECT assignment_ref
+           FROM pylon_api_assignments
+          WHERE pylon_ref = ?
+            AND state IN ('accepted', 'blocked', 'offered', 'proof_submitted', 'running')
+            AND lease_expires_at > ?
+            AND updated_at < ?
+            AND archived_at IS NULL`,
+      )
+      .bind(pylonRef, nowIso, staleBeforeIso)
+      .all<{ assignment_ref: string }>()
+    const refs = (staleRows.results ?? []).map(row => row.assignment_ref)
+    if (refs.length === 0) {
+      return []
+    }
+
+    await db
+      .prepare(
+        `UPDATE pylon_api_assignments
+            SET state = 'stale',
+                lease_expires_at = ?,
+                updated_at = ?
+          WHERE pylon_ref = ?
+            AND state IN ('accepted', 'blocked', 'offered', 'proof_submitted', 'running')
+            AND lease_expires_at > ?
+            AND updated_at < ?
+            AND archived_at IS NULL`,
+      )
+      .bind(nowIso, nowIso, pylonRef, nowIso, staleBeforeIso)
+      .run()
+
+    return refs
   },
 
   listAssignmentsForPylons: async (pylonRefs, limit) => {


### PR DESCRIPTION
Addresses #6410.

### Changes
- Replaces the offered-only claim-window with a uniform `PYLON_ASSIGNMENT_ACTIVE_LEASE_TTL_MS` (5min) sliding TTL in `pylon-api-routes.ts`, so any slot-holding lease that goes silent past the window stops consuming dispatch capacity.
- Adds `sweepStalePylonAssignmentLeases` + `staleAssignmentLeaseCutoffIso` and runs the sweep before capacity accounting in both `routeCreateAssignment` and `delegateCodingWorkflowUnsafe`, marking stale rows `stale`.
- Adds an optional `sweepStaleAssignmentLeases` to the `PylonApiStore` interface with a D1 implementation (SELECT + UPDATE of accepted/blocked/offered/proof_submitted/running rows past TTL).
- Adds tests covering stale-lease sweep before targeted dispatch and before capacity accounting (no `duplicate_active_assignment`).

### Verification
Not independently re-verified.