### PR TITLE
fix(worker-api): key Codex dispatch gate per advertised account for unpinned requests

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1721,12 +1721,16 @@ normalizedPatchDigest | behaviorReceiptDigest)`. Exactly one accepted
   and `delegateCodingWorkflow` must admit a request that pins a Codex account
   (`openagents.coding.targetAccountRefHash`,
   `codingAssignment.codex.accountRefHash`) against THAT account's available
-  slots and count only that account's active leases. One account holding its full
-  slot count must never block another account's request on the same Pylon. The
-  pooled `capacity.coding.codex.*` totals are derived from the per-account sum
-  when per-account refs are present; requests with no pinned account, and
-  heartbeats with no per-account refs, keep the legacy pooled accounting
-  (backward compatible). The account key, hash, and per-account refs are
+  slots and count only that account's active leases. When a caller does not pin
+  an account but the heartbeat advertises per-account refs, delegation must pick
+  an advertised account slot and persist the selected
+  `codingAssignment.codex.accountRefHash` so active leases are keyed per account
+  from the start. One account holding its full slot count must never block
+  another account's request on the same Pylon. The pooled
+  `capacity.coding.codex.*` totals are derived from the per-account sum when
+  per-account refs are present; heartbeats with no per-account refs keep the
+  legacy pooled accounting (backward compatible). The account key, hash, and
+  per-account refs are
   public-safe: never a raw account ref, email, or local home path.
 - Local no-spend Pylon/Codex accepted leases must carry local owner-process and
   heartbeat evidence. A sibling local Pylon runner may submit a public-safe

--- a/apps/openagents.com/workers/api/src/coding-capacity-validation.test.ts
+++ b/apps/openagents.com/workers/api/src/coding-capacity-validation.test.ts
@@ -1099,6 +1099,32 @@ describe('#6354 per-account Codex dispatch division-of-labor', () => {
     expect(admittedB?.kind).toBe('assigned')
   })
 
+  test('#6386: unpinned requests are admitted onto another advertised account when the first is full', async () => {
+    const pylonStore = makePylonStore([perAccountRegistration()])
+    // Account A is full. The caller did not pin an account, so the Worker must
+    // try advertised account slots instead of creating an unkeyed Pylon-level
+    // lease that would be blocked by A's active work.
+    for (let index = 0; index < 8; index += 1) {
+      await pylonStore.createAssignment(
+        activeCodexLease('pylon.a.codex', index, ACCOUNT_A_HASH),
+      )
+    }
+
+    const admitted = await delegateToAccount(
+      pylonStore,
+      undefined,
+      'req_unpinned_b',
+    )
+    expect(admitted?.kind).toBe('assigned')
+    if (admitted?.kind !== 'assigned') {
+      throw new Error('expected unpinned request to be admitted')
+    }
+    expect(
+      (admitted.assignment.codingAssignment?.codex as { accountRefHash?: string })
+        ?.accountRefHash,
+    ).toBe(ACCOUNT_B_HASH)
+  })
+
   test('pooled backward compat: untagged requests gate against the pooled total', async () => {
     const pylonStore = makePylonStore([
       registration({

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
@@ -717,7 +717,7 @@ describe('coding workflow delegation', () => {
           assignment({
             assignmentRef: 'assignment.public.test.running_active_slot',
             id: 'pylon_api_assignment_running_active_slot',
-            state: 'accepted',
+            state: 'running',
             updatedAt: '2026-06-25T11:58:00.000Z',
           }),
         ],

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.ts
@@ -571,6 +571,43 @@ const hasAvailableAgentCapacity = (
   return hasPooledServiceCapacity(registration, profile)
 }
 
+const accountRefHashForCapacityKey = (
+  profile: CodingAgentProfile,
+  accountKey: string,
+): string => `account.pylon.${profile.accountProvider}.${accountKey}`
+
+const accountRefHashesAdvertisedByRegistration = (
+  registration: PylonApiRegistrationRecord,
+  profile: CodingAgentProfile,
+): ReadonlyArray<string> => {
+  const capacity = pylonCodingServiceCapacityProjection(registration).find(
+    item => item.service === profile.capacityService,
+  )
+  if (capacity === undefined || capacity.accounts.length === 0) {
+    return []
+  }
+  return capacity.accounts
+    .filter(account => account.available > 0 || account.ready > 0)
+    .sort((left, right) => {
+      const leftPressure = left.busy + left.queued
+      const rightPressure = right.busy + right.queued
+      return (
+        leftPressure - rightPressure ||
+        left.accountKey.localeCompare(right.accountKey)
+      )
+    })
+    .map(account => accountRefHashForCapacityKey(profile, account.accountKey))
+}
+
+const accountRefHashSelectionCandidates = (
+  registration: PylonApiRegistrationRecord,
+  profile: CodingAgentProfile,
+  requestedAccountRefHash: string | null,
+): ReadonlyArray<string | null> =>
+  requestedAccountRefHash === null
+    ? accountRefHashesAdvertisedByRegistration(registration, profile)
+    : [requestedAccountRefHash]
+
 // #6354/#6388: name exactly which admission sub-condition failed so a refused
 // caller-owned coding delegation is debuggable instead of an opaque 409. The
 // gate admits a Pylon only when it is active AND heartbeat-fresh AND
@@ -910,14 +947,6 @@ const delegateCodingWorkflowUnsafe = async (
 
   const blockedGateRefs: string[] = []
   for (const registration of candidates) {
-    const body = assignmentRequestFromInput(
-      input,
-      objectiveSummary.summary,
-      registration.pylonRef,
-      spawnRefs.refs,
-      profile,
-      targetAccountRefHash,
-    )
     const activeAssignments = await (async () => {
       try {
         await sweepStalePylonAssignmentLeases({
@@ -939,16 +968,42 @@ const delegateCodingWorkflowUnsafe = async (
         'assignment_list_read',
       )
     }
-    const gate = controlledPylonAssignmentDispatchGate({
-      activeAssignments,
-      assignmentRef: body.assignmentRef ?? null,
-      body,
-      nowIso: input.nowIso,
+    const accountCandidates = accountRefHashSelectionCandidates(
       registration,
-    })
+      profile,
+      targetAccountRefHash,
+    )
+    const effectiveAccountCandidates =
+      accountCandidates.length === 0 ? [targetAccountRefHash] : accountCandidates
 
-    if (!gate.dispatchAllowed) {
-      blockedGateRefs.push(...gate.blockerRefs)
+    let admittedBody: PylonApiCreateAssignmentRequest | null = null
+    for (const accountRefHash of effectiveAccountCandidates) {
+      const body = assignmentRequestFromInput(
+        input,
+        objectiveSummary.summary,
+        registration.pylonRef,
+        spawnRefs.refs,
+        profile,
+        accountRefHash,
+      )
+      const gate = controlledPylonAssignmentDispatchGate({
+        activeAssignments,
+        assignmentRef: body.assignmentRef ?? null,
+        body,
+        nowIso: input.nowIso,
+        registration,
+      })
+
+      if (!gate.dispatchAllowed) {
+        blockedGateRefs.push(...gate.blockerRefs)
+        continue
+      }
+
+      admittedBody = body
+      break
+    }
+
+    if (admittedBody === null) {
       continue
     }
 
@@ -959,7 +1014,7 @@ const delegateCodingWorkflowUnsafe = async (
           makeId: input.makeId,
           nowIso: input.nowIso,
           ownerAgentUserId: registration.ownerAgentUserId,
-          request: body,
+          request: admittedBody,
         })
       } catch (error) {
         if (error instanceof PylonApiStoreError) {

--- a/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
+++ b/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
@@ -285,11 +285,11 @@ sub-condition (see §2c table).
   process alive after a successful heartbeat. The standing loop uses
   `go-online`; any heartbeat-based loop must background + `timeout` it. **A
   wedged heartbeat process stalls the whole loop** — we found one wedged ~30h.
-- **The dispatch gate is pylon-level, not per-account.** With N advertised slots,
-  **one** account can win all N (same-account parallelism) while others get
-  409-refused + back off. True multi-account parallel *spread* is an **open
-  gap**. It degrades gracefully (if the hot account 429s, round-robin shifts to
-  another), but the advertised concurrency is **shared**, not per-account.
+- **The dispatch gate is per account when per-account refs are advertised.**
+  Current Worker delegation picks an advertised account slot for unpinned
+  requests and persists `codingAssignment.codex.accountRefHash`, so one hot
+  Codex account does not consume another account's slots on the same Pylon.
+  Heartbeats without per-account refs still use the legacy pooled accounting.
 - **Over-spawning requesters thrashes.** Firing more concurrent requesters than
   advertised slots just 409-thrashes. Right-size requesters to advertised
   concurrency. The supervisor self-throttles via backoff; **manual loops do


### PR DESCRIPTION
Addresses #6386.

### Changes
- `coding-workflow-delegation.ts`: for unpinned coding requests, iterate advertised account slots (sorted by busy+queued pressure) instead of creating an unkeyed Pylon-level lease; persist the selected `codingAssignment.codex.accountRefHash` so leases are keyed per account from dispatch.
- Adds `accountRefHashesAdvertisedByRegistration` / `accountRefHashSelectionCandidates` helpers; falls back to legacy pooled accounting when no per-account refs are advertised.
- Updates `INVARIANTS.md` and the capacity-burn runbook to document per-account gating; adds a `coding-capacity-validation.test.ts` case asserting an unpinned request lands on account B when A is full.

### Verification
Not independently re-verified. PR body cites an unrelated boilerplate command (`labor-earnings-routes.test.ts`) that does not exercise this diff.