### PR TITLE
pylon: Implement public issue #6442 and run the named verification. (#6442)

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
@@ -88,6 +88,16 @@ const post = (body: unknown): Request =>
     method: 'POST',
   })
 
+const postStream = (body: unknown): Request =>
+  new Request('https://openagents.com/api/operator/artanis/chat', {
+    body: JSON.stringify(body),
+    headers: {
+      accept: 'text/event-stream',
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  })
+
 const runRoute = async (
   deps: ReturnType<typeof baseDeps>['deps'],
   request: Request,
@@ -218,6 +228,33 @@ describe('POST /api/operator/artanis/chat — grounded Khala-powered reply', () 
     )
     // Owner-scoped.
     expect(owner?.ownerId).toBe('owner:github:14167547')
+  })
+
+  test('streams signed Artanis operator frames when SSE is requested', async () => {
+    const { deps, fake } = baseDeps()
+    const response = await runRoute(
+      deps,
+      postStream({ messages: [{ content: 'stream status', role: 'user' }] }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+
+    const body = await response.text()
+    expect(body).toContain('signature.operator.artanis.interaction.v1')
+    expect(body).toContain('"channelRef":"operator.artanis.chat"')
+    expect(body).toContain('"servedVia":"openagents_khala"')
+    expect(body).toContain(
+      '"content":"I dispatched two Codex assignments this morning.',
+    )
+    expect(body).toContain('data: [DONE]')
+
+    const owner = fake.entries.find(entry => entry.role === 'owner')
+    const artanis = fake.entries.find(entry => entry.role === 'artanis')
+    expect(owner?.body).toBe('stream status')
+    expect(artanis?.body).toBe(
+      'I dispatched two Codex assignments this morning.',
+    )
   })
 
   test('a spend ask surfaces the approval-gate hint', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
@@ -35,6 +35,7 @@ import {
   ARTANIS_OPERATOR_MEMORY_TURN_LIMIT,
   type ArtanisOperatorKhalaClient,
   ArtanisOperatorMessage,
+  type ArtanisOperatorTurnResult,
   type ArtanisOperatorTool,
   artanisOperatorTurn,
 } from './artanis-operator'
@@ -241,6 +242,83 @@ const ChatRequestBody = S.Struct({
   messages: S.Array(ArtanisOperatorMessage),
 })
 
+const wantsEventStream = (request: Request): boolean =>
+  request.headers.get('accept')?.toLowerCase().includes('text/event-stream') ===
+  true
+
+const sseData = (value: unknown): string =>
+  `data: ${JSON.stringify(value)}\n\n`
+
+const chunkReply = (reply: string): ReadonlyArray<string> => {
+  const chunks: Array<string> = []
+  let remaining = reply
+  while (remaining.length > 0) {
+    const candidate = remaining.slice(0, 240)
+    const splitAt = candidate.length === remaining.length
+      ? candidate.length
+      : Math.max(
+          candidate.lastIndexOf(' '),
+          candidate.lastIndexOf('\n'),
+          candidate.lastIndexOf('. '),
+        )
+    const take = splitAt > 48 ? splitAt + 1 : candidate.length
+    chunks.push(remaining.slice(0, take))
+    remaining = remaining.slice(take)
+  }
+  return chunks
+}
+
+const operatorArtanisSseResponse = (
+  turn: ArtanisOperatorTurnResult,
+): Response => {
+  const signatureRef = 'signature.operator.artanis.interaction.v1'
+  const lines: Array<string> = [
+    sseData({
+      channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
+      servedModel: turn.servedModel,
+      servedVia: turn.servedVia,
+      signatureRef,
+      type: 'signature',
+    }),
+  ]
+
+  for (const chunk of chunkReply(turn.reply)) {
+    lines.push(
+      sseData({
+        choices: [{ delta: { content: chunk } }],
+        channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
+        signatureRef,
+        type: 'delta',
+      }),
+    )
+  }
+
+  lines.push(
+    sseData({
+      approvalGateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
+      channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
+      deferredToApprovalGate: turn.deferredToApprovalGate,
+      iterations: turn.iterations,
+      persona: turn.persona,
+      requestedModel: turn.requestedModel,
+      servedModel: turn.servedModel,
+      servedVia: turn.servedVia,
+      signatureRef,
+      toolInvocations: turn.toolInvocations,
+      type: 'done',
+    }),
+  )
+  lines.push('data: [DONE]\n\n')
+
+  return new Response(lines.join(''), {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}
+
 const parseBody = (request: Request) =>
   Effect.gen(function* () {
     const raw = yield* Effect.tryPromise({
@@ -372,21 +450,22 @@ export const makeOperatorArtanisChatRoutes = <
         }),
       ).pipe(Effect.catch(() => Effect.void))
 
-      return dependencies.appendRefreshedSessionCookies(
-        noStoreJsonResponse({
-          approvalGateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
-          channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
-          deferredToApprovalGate: turn.deferredToApprovalGate,
-          iterations: turn.iterations,
-          persona: turn.persona,
-          reply: turn.reply,
-          requestedModel: turn.requestedModel,
-          servedModel: turn.servedModel,
-          servedVia: turn.servedVia,
-          toolInvocations: turn.toolInvocations,
-        }),
-        session,
-      )
+      const response = wantsEventStream(request)
+        ? operatorArtanisSseResponse(turn)
+        : noStoreJsonResponse({
+            approvalGateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
+            channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
+            deferredToApprovalGate: turn.deferredToApprovalGate,
+            iterations: turn.iterations,
+            persona: turn.persona,
+            reply: turn.reply,
+            requestedModel: turn.requestedModel,
+            servedModel: turn.servedModel,
+            servedVia: turn.servedVia,
+            toolInvocations: turn.toolInvocations,
+          })
+
+      return dependencies.appendRefreshedSessionCookies(response, session)
     }).pipe(Effect.catch(error => Effect.succeed(routeErrorResponse(error))))
   },
 })

--- a/clients/mobile/Khala/Khala/Net/KhalaArtanis.swift
+++ b/clients/mobile/Khala/Khala/Net/KhalaArtanis.swift
@@ -13,7 +13,9 @@ import Foundation
 /// - Endpoint:  POST https://openagents.com/api/operator/artanis/chat
 /// - Auth:      Authorization: Bearer <owner oa_agent_… key / session>
 /// - Body:      { "messages": [ { "role", "content" }, … ] }
-/// - Response:  { "reply": "…" }   (non-streaming)
+/// - Response:  JSON by default, or SSE frames when `Accept:
+///              text/event-stream` is sent. SSE frames carry the Artanis
+///              operator signature/provenance ref and OpenAI-style deltas.
 ///
 /// Unlike the public Khala paths, a non-owner caller is expected to receive
 /// 401/403 here. The app surfaces that as the existing `.unauthorized` error so
@@ -63,10 +65,11 @@ extension KhalaClient {
         }
     }
 
-    /// Streaming-shaped wrapper so the Artanis channel reuses the same chat UI as
-    /// public Khala. The contract is non-streaming, so this yields the whole
-    /// reply as a single delta and finishes. Errors map onto `KhalaError`, the
-    /// same surface the streaming Khala path uses.
+    /// Stream the owner-only Artanis operator channel. This is the real two-way
+    /// operator path: the app posts the full conversation to the authenticated
+    /// Worker route, receives SSE deltas signed/provenanced as the Artanis
+    /// interaction signature, and renders them into the same transcript UI as
+    /// public Khala.
     static func streamArtanisCompletion(
         messages: [OutgoingMessage],
         apiKey: String,
@@ -75,14 +78,23 @@ extension KhalaClient {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    let reply = try await artanisChat(
-                        messages: messages,
-                        apiKey: apiKey,
-                        session: session
-                    )
-                    try Task.checkCancellation()
-                    if !reply.isEmpty {
-                        continuation.yield(reply)
+                    let request = try makeArtanisStreamRequest(messages: messages, apiKey: apiKey)
+                    let (bytes, response) = try await session.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else { throw KhalaError.decoding }
+                    if http.statusCode == 401 || http.statusCode == 403 { throw KhalaError.unauthorized }
+                    if http.statusCode == 402 { throw KhalaError.quotaExceeded }
+                    guard (200..<300).contains(http.statusCode) else {
+                        let body = await Self.collectErrorBody(from: bytes)
+                        throw KhalaError.http(http.statusCode, body)
+                    }
+
+                    for try await line in bytes.lines {
+                        try Task.checkCancellation()
+                        guard let delta = Self.delta(fromSSELine: line) else { continue }
+                        if delta.isDone { break }
+                        if let content = delta.content, !content.isEmpty {
+                            continuation.yield(content)
+                        }
                     }
                     continuation.finish()
                 } catch is CancellationError {
@@ -95,5 +107,39 @@ extension KhalaClient {
             }
             continuation.onTermination = { _ in task.cancel() }
         }
+    }
+
+    private static func makeArtanisStreamRequest(
+        messages: [OutgoingMessage],
+        apiKey: String
+    ) throws -> URLRequest {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { throw KhalaError.missingKey }
+
+        var request = URLRequest(url: artanisChatURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: Any] = ["messages": messages.map(\.json)]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private static func collectErrorBody(
+        from bytes: URLSession.AsyncBytes,
+        limit: Int = 2_048
+    ) async -> String {
+        var collected = Data()
+        do {
+            for try await byte in bytes {
+                collected.append(byte)
+                if collected.count >= limit { break }
+            }
+        } catch {
+            // Best-effort; return whatever was read.
+        }
+        return String(data: collected, encoding: .utf8) ?? ""
     }
 }

--- a/clients/mobile/Khala/KhalaTests/KhalaStreamTests.swift
+++ b/clients/mobile/Khala/KhalaTests/KhalaStreamTests.swift
@@ -101,6 +101,51 @@ final class KhalaStreamTests: XCTestCase {
         XCTAssertEqual(result.role, "assistant")
     }
 
+    func testArtanisStreamUsesOwnerEndpointAndYieldsSignedDeltas() async throws {
+        let session = makeSession()
+        let apiKey = "oa_agent_owner_key"
+
+        StreamMockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://openagents.com/api/operator/artanis/chat")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(apiKey)")
+
+            let body = try XCTUnwrap(request.httpBodyStream.flatMap(Self.data(from:)))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let messages = try XCTUnwrap(json["messages"] as? [[String: String]])
+            XCTAssertEqual(messages.count, 2)
+            XCTAssertEqual(messages[0]["role"], "user")
+            XCTAssertEqual(messages[0]["content"], "status")
+            XCTAssertEqual(messages[1]["role"], "assistant")
+
+            return (
+                Self.ok(request),
+                Self.sse([
+                    #"data: {"type":"signature","signatureRef":"signature.operator.artanis.interaction.v1","channelRef":"operator.artanis.chat"}"#,
+                    #"data: {"type":"delta","signatureRef":"signature.operator.artanis.interaction.v1","choices":[{"delta":{"content":"Fleet "}}]}"#,
+                    #"data: {"type":"delta","signatureRef":"signature.operator.artanis.interaction.v1","choices":[{"delta":{"content":"online"}}]}"#,
+                    #"data: {"type":"done","signatureRef":"signature.operator.artanis.interaction.v1"}"#,
+                    "data: [DONE]",
+                ])
+            )
+        }
+
+        var deltas: [String] = []
+        for try await delta in KhalaClient.streamArtanisCompletion(
+            messages: [
+                .init(role: "user", content: "status"),
+                .init(role: "assistant", content: "previous"),
+            ],
+            apiKey: apiKey,
+            session: session
+        ) {
+            deltas.append(delta)
+        }
+
+        XCTAssertEqual(deltas, ["Fleet ", "online"])
+    }
+
     func testStreamMapsHTTP401ToUnauthorized() async throws {
         let session = makeSession()
         StreamMockURLProtocol.requestHandler = { request in


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6442

Assignment: assignment.public.khala_coding.chatcmpl_1aface9a4cd044d8850f9c0900ceaf06
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 4

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.