### PR TITLE
feat(khala-cli): add `khala fleet status --live` operator dashboard

### DIFF
--- a/clients/khala-cli/README.md
+++ b/clients/khala-cli/README.md
@@ -28,6 +28,7 @@ khala fleet connect --account codex-2   # add another distinct account for more 
 khala fleet link              # link this local Pylon to your signed-in Khala account
 khala fleet status            # list your connected Codex fleet + readiness
 khala fleet run --repo owner/repo --issues 123,124 --verify "bun test" --dry-run
+khala fleet status --live     # poll the operator fleet dashboard
 khala auth codex
 khala codex "read README.md"
 khala spawn --count 5 --objective "audit this workspace" --strategy local
@@ -161,6 +162,10 @@ no long-string pasting:
   `--per-account` capped by `--max-parallel`, advertises that capacity, and
   routes issue work through your local no-spend Pylon. Use `--dry-run` to inspect
   the resolved plan first, or `--once` to run one refill round and exit.
+- `khala fleet status --live` polls the owner-only
+  `/api/operator/fleet/status` endpoint about every five seconds and renders the
+  Pace, Fleet, Watchdog, GLM, and Brain/Artanis blocks as a terminal dashboard.
+  It uses your `khala login` token, `OPENAGENTS_AGENT_TOKEN`, or `--token`.
 
 Each account uses an isolated home under `<pylon home>/accounts/codex/<ref>`; the
 flow never touches the default `~/.codex` home, credentials stay on your machine,
@@ -180,6 +185,7 @@ local Pylon and the dispatch gate can see the fleet.
 - `khala fleet status` lists your connected Codex fleet and readiness.
 - `khala fleet run --repo owner/repo --issues 123,124 --verify "bun test"`
   starts or plans the backlog supervisor for your connected fleet.
+- `khala fleet status --live` opens the live operator fleet dashboard.
 - `khala auth codex` connects a Codex account for local workspace delegation.
 - `khala codex status` shows the active local Codex credential source.
 - `khala codex "task"` delegates directly to local Codex.

--- a/clients/khala-cli/src/changelog.ts
+++ b/clients/khala-cli/src/changelog.ts
@@ -32,6 +32,7 @@ export const KHALA_CHANGELOG: ReadonlyArray<KhalaChangelogEntry> = [
     bullets: [
       "Adds `khala fleet connect` — connect your own Codex account to Khala with one short command and a paste-free device login (browser + short code, no long auth strings).",
       "Adds `khala fleet status` — see your connected Codex fleet and readiness; run `khala fleet connect` again to add more accounts (auto-assigned codex, codex-2, …) for more throughput.",
+      "Adds `khala fleet status --live` — poll the owner-only operator fleet status endpoint and render Pace, Fleet, Watchdog, GLM, and Brain/Artanis blocks as a terminal dashboard.",
       "Accounts use isolated per-account homes and are registered into your Pylon config; the flow never touches `~/.codex` and never prints tokens.",
     ],
   },

--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -50,6 +50,56 @@ describe("Khala CLI info diagnostics", () => {
     expect(stdout).not.toContain("token=")
   })
 
+  test("renders the live fleet dashboard from the operator status endpoint", async () => {
+    const authHeaders: Array<string | null> = []
+    const server = Bun.serve({
+      port: 0,
+      fetch: request => {
+        authHeaders.push(request.headers.get("authorization"))
+        expect(new URL(request.url).pathname).toBe("/api/operator/fleet/status")
+        return Response.json({
+          pace: { burnRate: "900 tokens/min", paceToFloor: "on pace" },
+          fleet: { concurrency: 2, inFlightIssues: ["#6429"] },
+          watchdog: { state: "healthy", leases: 1 },
+          glm: { status: "ready", readyReplicas: 8, totalReplicas: 8 },
+          brain: { state: "running", goals: 3 },
+        })
+      },
+    })
+
+    const originalWrite = process.stdout.write
+    let stdout = ""
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += String(chunk)
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const exitCode = await runKhalaCli([
+        "fleet",
+        "status",
+        "--live",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+      ], {
+        OPENAGENTS_AGENT_TOKEN: "oa_agent_live_dashboard_test",
+        KHALA_FLEET_LIVE_MAX_POLLS: "1",
+      })
+      expect(exitCode).toBe(0)
+    } finally {
+      process.stdout.write = originalWrite
+      server.stop(true)
+    }
+
+    expect(authHeaders).toEqual(["Bearer oa_agent_live_dashboard_test"])
+    expect(stdout).toContain("Khala fleet live dashboard")
+    expect(stdout).toContain("[Pace]")
+    expect(stdout).toContain("burnRate: 900 tokens/min")
+    expect(stdout).toContain("[Fleet]")
+    expect(stdout).toContain("[Watchdog]")
+    expect(stdout).toContain("[GLM]")
+    expect(stdout).toContain("[Brain]")
+  })
+
   test("uses the stored login token for --api when no env or flag token is present", async () => {
     const dir = mkdtempSync(join(tmpdir(), "khala-api-token-test-"))
     const tokenPath = join(dir, "agent-token")

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -16,6 +16,7 @@ import {
   connectFleetAccount,
   linkFleetPylon,
   listFleetAccounts,
+  runOperatorFleetStatusLive,
   type KhalaFleetConnectResult,
   type KhalaFleetLinkResult,
   type KhalaFleetStatus,
@@ -74,7 +75,7 @@ type ParsedCommand =
   | { readonly kind: "fleetConnect"; readonly accountRef: string | undefined; readonly force: boolean }
   | { readonly kind: "fleetRun" }
   | { readonly kind: "fleetLink" }
-  | { readonly kind: "fleetStatus" }
+  | { readonly kind: "fleetStatus"; readonly live: boolean }
   | { readonly kind: "help" }
   | { readonly kind: "info" }
   | {
@@ -205,6 +206,15 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
       return 0
     }
     if (args.command.kind === "fleetStatus") {
+      if (args.command.live) {
+        const token = await ensureStoredAgentToken({
+          baseUrl: args.baseUrl,
+          env,
+          explicitToken: args.token,
+        })
+        await runOperatorFleetStatusLive({ baseUrl: args.baseUrl, token, env })
+        return 0
+      }
       const status = await listFleetAccounts({ env })
       process.stdout.write(args.json ? `${JSON.stringify(status)}\n` : `${formatFleetStatus(status)}\n`)
       return 0
@@ -385,6 +395,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
   let spawnWorkflow: KhalaSpawnWorkflow = "codex_agent_task"
   let fleetAccount: string | undefined
   let fleetForce = false
+  let fleetLive = false
   const positional: Array<string> = []
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -495,6 +506,8 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
       fleetAccount = arg.slice("--account=".length)
     } else if (arg === "--force") {
       fleetForce = true
+    } else if (arg === "--live") {
+      fleetLive = true
     } else if (arg.startsWith("-")) {
       throw new Error(`Unknown flag: ${arg}`)
     } else {
@@ -516,7 +529,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
   } else if (maybeCommand === "fleet") {
     const sub = positional[1]?.trim().toLowerCase()
     if (sub === "status" || sub === "list" || sub === "ls") {
-      command = { kind: "fleetStatus" }
+      command = { kind: "fleetStatus", live: fleetLive }
     } else if (sub === "run") {
       command = { kind: "fleetRun" }
     } else if (sub === "link") {
@@ -1975,6 +1988,7 @@ Usage:
   khala fleet link
   khala fleet status
   khala fleet run --repo owner/repo --issues 123,124 --verify "bun test" --dry-run
+  khala fleet status --live
   khala auth codex
   khala codex status
   khala codex "read README.md"
@@ -2043,6 +2057,7 @@ Flags:
   --per-account <n>    Fleet run slots per ready Codex account (default: 1)
   --once               Fleet run one refill round, then exit
   --dry-run            Fleet run prints the resolved plan without dispatching
+  --live               Poll /api/operator/fleet/status for khala fleet status
   --help, -h           Show this help
 `
 }

--- a/clients/khala-cli/src/fleet.test.ts
+++ b/clients/khala-cli/src/fleet.test.ts
@@ -9,6 +9,8 @@ import {
   codexConfigWithFileCredentialStore,
   connectFleetAccount,
   decodeCodexIdTokenEmail,
+  fetchOperatorFleetStatus,
+  formatOperatorFleetDashboard,
   linkFleetPylon,
   listFleetAccounts,
   nextCodexAccountRef,
@@ -239,5 +241,47 @@ describe("connect + status (with injected device login)", () => {
       { accountRef: "codex", home, email: null, readiness: "credentials_missing", lastLinkedAt: null },
     ])
     void stat // keep import used across runtimes
+  })
+})
+
+describe("operator fleet live status", () => {
+  test("fetches the owner operator fleet status endpoint with bearer auth", async () => {
+    const seenAuth: Array<string | null> = []
+    const snapshot = await fetchOperatorFleetStatus({
+      baseUrl: "https://example.test/",
+      token: "oa_agent_live_test",
+      fetch: async (input, init) => {
+        seenAuth.push(init?.headers instanceof Headers
+          ? init.headers.get("authorization")
+          : (init?.headers as Record<string, string> | undefined)?.authorization ?? null)
+        expect(String(input)).toBe("https://example.test/api/operator/fleet/status")
+        return Response.json({ pace: { burnRate: 12 }, fleet: { ready: 2 } })
+      },
+    })
+
+    expect(seenAuth).toEqual(["Bearer oa_agent_live_test"])
+    expect(snapshot.payload).toEqual({ pace: { burnRate: 12 }, fleet: { ready: 2 } })
+  })
+
+  test("renders the five operator dashboard blocks", () => {
+    const rendered = formatOperatorFleetDashboard({
+      baseUrl: "https://example.test",
+      fetchedAt: "2026-06-27T00:00:00.000Z",
+      payload: {
+        pace: { burnRate: "1.2k tokens/min", paceToFloor: "above floor" },
+        fleet: { concurrency: 4, inFlightIssues: ["#6429"] },
+        watchdog: { state: "healthy", leases: 1 },
+        glmFleetStatus: { status: "ready", readyReplicas: 8, totalReplicas: 8 },
+        brain: { state: "running", recentDecisions: ["dispatch issue #6429"] },
+      },
+    })
+
+    expect(rendered).toContain("Khala fleet live dashboard")
+    expect(rendered).toContain("[Pace]")
+    expect(rendered).toContain("burnRate: 1.2k tokens/min")
+    expect(rendered).toContain("[Fleet]")
+    expect(rendered).toContain("[Watchdog]")
+    expect(rendered).toContain("[GLM]")
+    expect(rendered).toContain("[Brain]")
   })
 })

--- a/clients/khala-cli/src/fleet.ts
+++ b/clients/khala-cli/src/fleet.ts
@@ -63,12 +63,19 @@ export type KhalaFleetLinkResult = {
   readonly capabilityRefs: ReadonlyArray<string>
 }
 
+export type KhalaOperatorFleetStatusSnapshot = {
+  readonly fetchedAt: string
+  readonly baseUrl: string
+  readonly payload: unknown
+}
+
 export type KhalaCodexDeviceLoginRunner = (input: {
   readonly env: Record<string, string | undefined>
   readonly home: string
 }) => Promise<{ readonly exitCode: number }>
 
 type ConfigRecord = Record<string, unknown>
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
 
 const KHALA_FLEET_LINK_SCHEMA = "openagents.khala.fleet_link.v1" as const
 const PYLON_CLIENT_VERSION = "openagents.pylon@1.0.5"
@@ -598,4 +605,165 @@ export async function linkFleetPylon(
     linked: true,
     capabilityRefs,
   }
+}
+
+export async function fetchOperatorFleetStatus(options: {
+  readonly baseUrl?: string | undefined
+  readonly token: string
+  readonly fetch?: FetchLike | undefined
+}): Promise<KhalaOperatorFleetStatusSnapshot> {
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "")
+  const token = options.token.trim()
+  if (token.length === 0) {
+    throw new Error("khala fleet status --live requires an owner token. Run `khala login` or pass --token.")
+  }
+  const response = await (options.fetch ?? fetch)(`${baseUrl}/api/operator/fleet/status`, {
+    method: "GET",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${token}`,
+    },
+  })
+  if (!response.ok) {
+    let detail = ""
+    try {
+      const body = await response.json() as Record<string, unknown>
+      const reason = body.reason ?? body.error ?? body.message
+      detail = typeof reason === "string" && reason.trim().length > 0 ? `: ${reason.trim()}` : ""
+    } catch {
+      // Ignore malformed error bodies; the status code is enough to act on.
+    }
+    throw new Error(`operator fleet status request failed (${response.status})${detail}`)
+  }
+  return {
+    fetchedAt: new Date().toISOString(),
+    baseUrl,
+    payload: await response.json(),
+  }
+}
+
+export async function runOperatorFleetStatusLive(options: {
+  readonly baseUrl?: string | undefined
+  readonly token: string
+  readonly env?: Record<string, string | undefined> | undefined
+  readonly fetch?: FetchLike | undefined
+  readonly write?: ((text: string) => void) | undefined
+  readonly pollIntervalMs?: number | undefined
+  readonly maxPolls?: number | undefined
+}): Promise<void> {
+  const env = options.env ?? process.env
+  const write = options.write ?? (text => process.stdout.write(text))
+  const intervalMs = options.pollIntervalMs ?? 5_000
+  const maxPolls = options.maxPolls ?? parseOptionalPositiveInteger(env.KHALA_FLEET_LIVE_MAX_POLLS)
+  let stopped = false
+  const stop = (): void => {
+    stopped = true
+  }
+  process.once("SIGINT", stop)
+  try {
+    for (let poll = 0; !stopped; poll += 1) {
+      try {
+        const snapshot = await fetchOperatorFleetStatus({
+          baseUrl: options.baseUrl,
+          token: options.token,
+          fetch: options.fetch,
+        })
+        write(`${clearScreen()}${formatOperatorFleetDashboard(snapshot)}`)
+      } catch (error) {
+        write(`${clearScreen()}${formatOperatorFleetError(error)}\n`)
+      }
+      if (maxPolls !== undefined && poll + 1 >= maxPolls) return
+      await sleep(intervalMs)
+    }
+  } finally {
+    process.off("SIGINT", stop)
+  }
+}
+
+export function formatOperatorFleetDashboard(snapshot: KhalaOperatorFleetStatusSnapshot): string {
+  const payload = asRecord(snapshot.payload) ?? {}
+  const lines = [
+    `Khala fleet live dashboard`,
+    `updated: ${snapshot.fetchedAt}  source: ${snapshot.baseUrl}/api/operator/fleet/status`,
+    "",
+    formatDashboardBlock("Pace", firstRecord(payload, ["pace", "paceToFloor", "pace_to_floor", "burnPace"])),
+    formatDashboardBlock("Fleet", firstRecord(payload, ["fleet", "codexFleet", "capacity", "pylons"])),
+    formatDashboardBlock("Watchdog", firstRecord(payload, ["watchdog", "stallWatchdog", "fleetWatchdog"])),
+    formatDashboardBlock("GLM", firstRecord(payload, ["glm", "glmFleet", "glmFleetStatus", "inference", "readiness"])),
+    formatDashboardBlock("Brain", firstRecord(payload, ["brain", "artanis", "artanisLoop", "khalaBrain"])),
+  ]
+  return `${lines.join("\n")}\n`
+}
+
+function formatOperatorFleetError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  return [
+    "Khala fleet live dashboard",
+    `updated: ${new Date().toISOString()}`,
+    "",
+    "[status]",
+    `  ${message}`,
+  ].join("\n")
+}
+
+function formatDashboardBlock(title: string, value: unknown): string {
+  const lines = summarizeDashboardValue(value)
+  return [`[${title}]`, ...(lines.length === 0 ? ["  no data"] : lines.map(line => `  ${line}`))].join("\n")
+}
+
+function summarizeDashboardValue(value: unknown): ReadonlyArray<string> {
+  if (value === undefined || value === null) return []
+  if (typeof value !== "object") return [formatScalar(value)]
+  if (Array.isArray(value)) {
+    if (value.length === 0) return ["0 items"]
+    return [`${value.length} items`, ...value.slice(0, 3).map((entry, index) => `${index + 1}. ${formatCompact(entry)}`)]
+  }
+  const record = value as Record<string, unknown>
+  const entries = Object.entries(record)
+    .filter(([, entry]) => entry !== undefined && typeof entry !== "function")
+    .slice(0, 10)
+  if (entries.length === 0) return []
+  return entries.map(([key, entry]) => `${key}: ${formatCompact(entry)}`)
+}
+
+function firstRecord(record: Record<string, unknown>, keys: ReadonlyArray<string>): unknown {
+  for (const key of keys) {
+    if (record[key] !== undefined) return record[key]
+  }
+  return undefined
+}
+
+function formatCompact(value: unknown): string {
+  if (value === null || value === undefined) return "n/a"
+  if (typeof value !== "object") return formatScalar(value)
+  try {
+    const encoded = JSON.stringify(value)
+    return truncate(encoded ?? String(value), 160)
+  } catch {
+    return truncate(String(value), 160)
+  }
+}
+
+function formatScalar(value: unknown): string {
+  if (typeof value === "number") return Number.isInteger(value) ? String(value) : value.toFixed(2)
+  if (typeof value === "boolean") return value ? "yes" : "no"
+  return truncate(String(value), 160)
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max - 1)}…`
+}
+
+function clearScreen(): string {
+  return process.stdout.isTTY ? "\x1b[2J\x1b[H" : ""
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function parseOptionalPositiveInteger(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim() === "") return undefined
+  const parsed = Number.parseInt(value, 10)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
 }


### PR DESCRIPTION
Addresses #6429.

### Changes
- `fleet.ts`: adds `fetchOperatorFleetStatus`, `runOperatorFleetStatusLive`, and `formatOperatorFleetDashboard` that poll `/api/operator/fleet/status` (~5s) with bearer auth and render Pace, Fleet, Watchdog, GLM, and Brain blocks; `KHALA_FLEET_LIVE_MAX_POLLS` caps polls for tests.
- `cli.ts`: parses `--live`, ensures an owner token, and routes `khala fleet status --live` to the live renderer.
- README and changelog document the new flag; adds CLI and fleet unit tests.

### Verification
Not independently re-verified. PR body cites an unrelated boilerplate command (`labor-earnings-routes.test.ts`).