### PR TITLE
fix(pylon): scope codex_agent_task rg/find to the active workspace and prune cache

### DIFF
--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -11,6 +11,7 @@ import {
 import {
   gitCheckoutWorkspaceFrom,
   materializeGitCheckoutWorkspaceWithLease,
+  pruneWorkspaceCacheDirectories,
   workspaceCheckoutFailureReasonRef,
   type GitCheckoutWorkspace,
   type WorkspaceCheckoutRunner,
@@ -32,6 +33,7 @@ import {
   type CodexTurnUsage,
 } from "./codex-turn-reporter.js"
 import type { PylonLocalState } from "./state.js"
+import { installCodexRipgrepGuard } from "./codex-rg-guard.js"
 
 /**
  * The local Codex executor gate (issue #4789, epic #4793, promise
@@ -147,6 +149,7 @@ type CodexAgentFixture = {
 
 const DEFAULT_TIMEOUT_SECONDS = 300
 const MAX_TIMEOUT_SECONDS = 1200
+const CODEX_AGENT_WORKSPACE_CACHE_MAX_ENTRIES = 200
 
 const CODEX_AGENT_FIXTURES: Record<string, CodexAgentFixture> = {
   [CODEX_AGENT_SUM_REPAIR_FIXTURE_REF]: {
@@ -803,9 +806,14 @@ async function materializeCodexAgentWorkspace(input: {
   state: PylonLocalState
   task: CodexAgentTaskPayload
 }) {
+  const cacheRoot = join(input.state.paths.cache, "codex-agent-tasks")
+  await pruneWorkspaceCacheDirectories({
+    cacheRoot,
+    maxEntries: CODEX_AGENT_WORKSPACE_CACHE_MAX_ENTRIES,
+  })
   if (input.task.workspace !== undefined) {
     const materialized = await materializeGitCheckoutWorkspaceWithLease({
-      cacheRoot: join(input.state.paths.cache, "codex-agent-tasks"),
+      cacheRoot,
       checkout: input.task.workspace,
       ...(input.checkoutRunner === undefined ? {} : { checkoutRunner: input.checkoutRunner }),
       leaseRef: input.leaseRef,
@@ -829,7 +837,7 @@ async function materializeCodexAgentWorkspace(input: {
   }
 
   const workspaceRef = stableRef("workspace.pylon.codex_agent_task", input.leaseRef)
-  const workspace = join(input.state.paths.cache, "codex-agent-tasks", workspaceRef)
+  const workspace = join(cacheRoot, workspaceRef)
   const fixtureRef = input.task.fixtureRef ?? CODEX_AGENT_SUM_REPAIR_FIXTURE_REF
   const fixture = CODEX_AGENT_FIXTURES[fixtureRef] ?? CODEX_AGENT_FIXTURES[CODEX_AGENT_SUM_REPAIR_FIXTURE_REF]
   await mkdir(workspace, { recursive: true })
@@ -1007,11 +1015,15 @@ export async function executeCodexAgentAssignment(
         DEFAULT_TIMEOUT_SECONDS,
         MAX_TIMEOUT_SECONDS,
       ) * 1000
+    const guardedEnv = installCodexRipgrepGuard({
+      env,
+      workspaceRoot: materialized.workspace,
+    }).env
     run = await runCodexAgentWithOuterDeadline(runner, {
       assignmentRef: lease.assignmentRef,
       cwd: materialized.workspace,
       account: options.account,
-      env,
+      env: guardedEnv,
       ...(eventChunkReporter === undefined ? {} : { eventChunkReporter }),
       ...(eventReporter === undefined ? {} : { eventReporter }),
       instructions: materialized.instructions,

--- a/apps/pylon/src/codex-rg-guard.test.ts
+++ b/apps/pylon/src/codex-rg-guard.test.ts
@@ -7,9 +7,12 @@ import { tmpdir } from "node:os"
 import {
   CODEX_RG_GUARD_ENV,
   CODEX_RG_GUARD_EXCLUDE_GLOBS,
+  CODEX_WORKSPACE_ROOT_ENV,
   guardedCodexRipgrepArgs,
   installCodexRipgrepGuard,
   sanitizeCodexRipgrepArgs,
+  scopeCodexFindArgsToWorkspace,
+  scopeCodexRipgrepArgsToWorkspace,
 } from "./codex-rg-guard.js"
 
 describe("Codex ripgrep guard", () => {
@@ -31,6 +34,32 @@ describe("Codex ripgrep guard", () => {
       expect(index).toBeLessThan(endOfOptions)
     }
     expect(args.slice(endOfOptions)).toEqual(["--", "--hidden"])
+  })
+
+  test("relativizes rg path args that escape the active workspace", () => {
+    const workspace = "/Users/example/.pylon-fable/cache/codex-agent-tasks/workspace.active"
+    expect(
+      scopeCodexRipgrepArgsToWorkspace(
+        ["-n", "marker", "/Users/example/.pylon-fable", "--glob", "*.ts"],
+        workspace,
+      ),
+    ).toEqual(["-n", "marker", ".", "--glob", "*.ts"])
+    expect(
+      scopeCodexRipgrepArgsToWorkspace(["-n", "marker", `${workspace}/src`], workspace),
+    ).toEqual(["-n", "marker", `${workspace}/src`])
+    expect(
+      scopeCodexRipgrepArgsToWorkspace(["-n", "-e", "marker", "/Users/example/.pylon-fable"], workspace),
+    ).toEqual(["-n", "-e", "marker", "."])
+  })
+
+  test("relativizes find roots that escape the active workspace", () => {
+    const workspace = "/Users/example/.pylon-fable/cache/codex-agent-tasks/workspace.active"
+    expect(
+      scopeCodexFindArgsToWorkspace(["/Users/example/.pylon-fable", "-name", "*.ts"], workspace),
+    ).toEqual([".", "-name", "*.ts"])
+    expect(
+      scopeCodexFindArgsToWorkspace([`${workspace}/src`, "-name", "*.ts"], workspace),
+    ).toEqual([`${workspace}/src`, "-name", "*.ts"])
   })
 
   test("installed wrapper delegates sanitized args to the real rg", async () => {
@@ -57,16 +86,59 @@ done
 
       expect(installed.installed).toBe(true)
       expect(installed.env[CODEX_RG_GUARD_ENV]).toBe("1")
-      const result = spawnSync("rg", ["-uu", "--no-ignore", "needle", ".", "--", "--hidden"], {
-        env: { ...process.env, ...installed.env, OUT: out },
+      const result = spawnSync("rg", ["-uu", "--no-ignore", "needle", join(root, ".."), "--", "--hidden"], {
+        env: { ...process.env, ...installed.env, [CODEX_WORKSPACE_ROOT_ENV]: root, OUT: out },
         encoding: "utf8",
       })
       expect(result.status).toBe(0)
       const delegated = (await readFile(out, "utf8")).trim().split("\n")
       expect(delegated).not.toContain("-uu")
       expect(delegated).not.toContain("--no-ignore")
+      expect(delegated).not.toContain(join(root, ".."))
+      expect(delegated).toContain(".")
       for (const glob of CODEX_RG_GUARD_EXCLUDE_GLOBS) expect(delegated).toContain(glob)
       expect(delegated.slice(-2)).toEqual(["--", "--hidden"])
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  test("installed wrapper scopes find roots to the workspace", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-find-guard-"))
+    try {
+      const realRg = join(root, "real-rg")
+      await writeFile(realRg, "#!/usr/bin/env bash\nexit 0\n")
+      await chmod(realRg, 0o755)
+      const realFind = join(root, "real-find")
+      const out = join(root, "find-args.json")
+      await writeFile(
+        realFind,
+        `#!/usr/bin/env bash
+: > "$OUT"
+printf '%s\\n' "$PWD" >> "$OUT"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$OUT"
+done
+`,
+      )
+      await chmod(realFind, 0o755)
+      const binDir = join(root, "bin")
+      const installed = installCodexRipgrepGuard({
+        env: { PATH: "/usr/bin:/bin" },
+        binDir,
+        realFindPath: realFind,
+        realRipgrepPath: realRg,
+        workspaceRoot: root,
+      })
+
+      const result = spawnSync("find", [join(root, ".."), "-name", "*.ts"], {
+        env: { ...process.env, ...installed.env, OUT: out },
+        encoding: "utf8",
+      })
+      expect(result.status).toBe(0)
+      const delegated = (await readFile(out, "utf8")).trim().split("\n")
+      expect(delegated[0]).toBe(root)
+      expect(delegated.slice(1)).toEqual([".", "-name", "*.ts"])
     } finally {
       await rm(root, { force: true, recursive: true })
     }

--- a/apps/pylon/src/codex-rg-guard.ts
+++ b/apps/pylon/src/codex-rg-guard.ts
@@ -1,11 +1,13 @@
 import { accessSync, chmodSync, constants, mkdirSync, writeFileSync } from "node:fs"
-import { delimiter, join } from "node:path"
+import { delimiter, isAbsolute, join, resolve } from "node:path"
 import { tmpdir } from "node:os"
 
 export const CODEX_RG_GUARD_ENV = "OPENAGENTS_CODEX_RG_GUARD"
 export const CODEX_RG_GUARD_DISABLED_ENV = "OPENAGENTS_CODEX_RG_GUARD_DISABLED"
 export const CODEX_RG_GUARD_BIN_DIR_ENV = "OPENAGENTS_CODEX_RG_GUARD_BIN_DIR"
 export const CODEX_REAL_RG_ENV = "OPENAGENTS_CODEX_REAL_RG"
+export const CODEX_REAL_FIND_ENV = "OPENAGENTS_CODEX_REAL_FIND"
+export const CODEX_WORKSPACE_ROOT_ENV = "OPENAGENTS_CODEX_WORKSPACE_ROOT"
 
 export const CODEX_RG_GUARD_EXCLUDE_GLOBS = [
   "!node_modules/**",
@@ -68,6 +70,92 @@ export function guardedCodexRipgrepArgs(args: ReadonlyArray<string>): string[] {
   ]
 }
 
+function isWithinWorkspace(path: string, workspaceRoot: string): boolean {
+  const root = resolve(workspaceRoot)
+  const resolved = isAbsolute(path) ? resolve(path) : resolve(root, path)
+  return resolved === root || resolved.startsWith(`${root}/`)
+}
+
+function isPathLikeArg(arg: string): boolean {
+  return arg === "." ||
+    arg === ".." ||
+    arg.startsWith("./") ||
+    arg.startsWith("../") ||
+    arg.startsWith("/") ||
+    arg.startsWith("~/")
+}
+
+function workspaceRelativePathArg(arg: string, workspaceRoot: string): string {
+  if (arg === ".") return "."
+  if (isWithinWorkspace(arg, workspaceRoot)) return arg
+  return "."
+}
+
+export function scopeCodexRipgrepArgsToWorkspace(
+  args: ReadonlyArray<string>,
+  workspaceRoot: string,
+): string[] {
+  const scoped: string[] = []
+  let endOfOptions = false
+  let sawPattern = false
+  let optionValuePending: "pattern" | "other" | null = null
+  for (const arg of args) {
+    if (endOfOptions) {
+      scoped.push(arg)
+      continue
+    }
+    if (optionValuePending) {
+      scoped.push(arg)
+      if (optionValuePending === "pattern") sawPattern = true
+      optionValuePending = null
+      continue
+    }
+    if (arg === "--") {
+      scoped.push(arg)
+      endOfOptions = true
+      continue
+    }
+    if (!sawPattern && arg.startsWith("-")) {
+      scoped.push(arg)
+      if (
+        !arg.includes("=") &&
+        ["-e", "-f", "-g", "--regexp", "--file", "--glob", "--type", "-t", "--type-not", "-T"].includes(arg)
+      ) {
+        optionValuePending = ["-e", "-f", "--regexp", "--file"].includes(arg) ? "pattern" : "other"
+      }
+      continue
+    }
+    if (!sawPattern) {
+      sawPattern = true
+      scoped.push(arg)
+      continue
+    }
+    scoped.push(isPathLikeArg(arg) ? workspaceRelativePathArg(arg, workspaceRoot) : arg)
+  }
+  return scoped
+}
+
+export function scopeCodexFindArgsToWorkspace(
+  args: ReadonlyArray<string>,
+  workspaceRoot: string,
+): string[] {
+  const scoped: string[] = []
+  let sawExpression = false
+  for (const arg of args) {
+    if (sawExpression) {
+      scoped.push(arg)
+      continue
+    }
+    if (arg.startsWith("-") || arg === "(" || arg === "!" || arg === "\\(") {
+      sawExpression = true
+      scoped.push(arg)
+      continue
+    }
+    scoped.push(isPathLikeArg(arg) ? workspaceRelativePathArg(arg, workspaceRoot) : arg)
+  }
+  return scoped.length === 0 ? ["."] : scoped
+}
+
 function singleQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`
 }
@@ -77,13 +165,43 @@ export function codexRipgrepGuardShell(realRipgrepPath: string): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
 REAL_RG=${singleQuote(realRipgrepPath)}
+workspace_root="\${${CODEX_WORKSPACE_ROOT_ENV}:-}"
 guard_globs=(${guardGlobs})
 before=()
 after=()
 seen_end=0
+saw_pattern=0
+option_value_pending=none
+is_within_workspace() {
+  local candidate="$1"
+  [[ -z "$workspace_root" ]] && return 0
+  python3 - "$workspace_root" "$candidate" <<'PY'
+import os, sys
+root = os.path.abspath(sys.argv[1])
+candidate = sys.argv[2]
+path = os.path.abspath(candidate if os.path.isabs(candidate) else os.path.join(root, candidate))
+sys.exit(0 if path == root or path.startswith(root + os.sep) else 1)
+PY
+}
+root_scoped_arg() {
+  local candidate="$1"
+  if [[ "$candidate" == "." ]] || is_within_workspace "$candidate"; then
+    printf '%s\\n' "$candidate"
+  else
+    printf '.\\n'
+  fi
+}
 for arg in "$@"; do
   if [[ "$seen_end" == "1" ]]; then
     after+=("$arg")
+    continue
+  fi
+  if [[ "$option_value_pending" != "none" ]]; then
+    before+=("$arg")
+    if [[ "$option_value_pending" == "pattern" ]]; then
+      saw_pattern=1
+    fi
+    option_value_pending=none
     continue
   fi
   if [[ "$arg" == "--" ]]; then
@@ -91,8 +209,33 @@ for arg in "$@"; do
     after+=("$arg")
     continue
   fi
+  if [[ "$saw_pattern" == "0" ]]; then
+    case "$arg" in
+      -u|-uu|-uuu|--unrestricted|--hidden|--follow|--no-ignore|--no-ignore-*)
+        continue
+        ;;
+      -e|-f|--regexp|--file)
+        before+=("$arg")
+        option_value_pending=pattern
+        continue
+        ;;
+      -g|--glob|--type|-t|--type-not|-T)
+        before+=("$arg")
+        option_value_pending=other
+        continue
+        ;;
+      -*)
+        before+=("$arg")
+        continue
+        ;;
+    esac
+    saw_pattern=1
+    before+=("$arg")
+    continue
+  fi
   case "$arg" in
-    -u|-uu|-uuu|--unrestricted|--hidden|--follow|--no-ignore|--no-ignore-*)
+    /*|~/*|../*|..|./*|.)
+      before+=("$(root_scoped_arg "$arg")")
       continue
       ;;
   esac
@@ -102,7 +245,60 @@ guard_args=()
 for glob in "\${guard_globs[@]}"; do
   guard_args+=(--glob "$glob")
 done
+cd "\${workspace_root:-.}"
 exec "$REAL_RG" "\${before[@]}" "\${guard_args[@]}" "\${after[@]}"
+`
+}
+
+export function codexFindGuardShell(realFindPath: string): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+REAL_FIND=${singleQuote(realFindPath)}
+workspace_root="\${${CODEX_WORKSPACE_ROOT_ENV}:-}"
+args=()
+saw_expression=0
+is_within_workspace() {
+  local candidate="$1"
+  [[ -z "$workspace_root" ]] && return 0
+  python3 - "$workspace_root" "$candidate" <<'PY'
+import os, sys
+root = os.path.abspath(sys.argv[1])
+candidate = sys.argv[2]
+path = os.path.abspath(candidate if os.path.isabs(candidate) else os.path.join(root, candidate))
+sys.exit(0 if path == root or path.startswith(root + os.sep) else 1)
+PY
+}
+root_scoped_arg() {
+  local candidate="$1"
+  if [[ "$candidate" == "." ]] || is_within_workspace "$candidate"; then
+    printf '%s\\n' "$candidate"
+  else
+    printf '.\\n'
+  fi
+}
+for arg in "$@"; do
+  if [[ "$saw_expression" == "1" ]]; then
+    args+=("$arg")
+    continue
+  fi
+  case "$arg" in
+    -\\(*|-*|\\(|!)
+      saw_expression=1
+      args+=("$arg")
+      continue
+      ;;
+    /*|~/*|../*|..|./*|.)
+      args+=("$(root_scoped_arg "$arg")")
+      continue
+      ;;
+  esac
+  args+=("$arg")
+done
+if [[ "\${#args[@]}" == "0" ]]; then
+  args=(.)
+fi
+cd "\${workspace_root:-.}"
+exec "$REAL_FIND" "\${args[@]}"
 `
 }
 
@@ -137,6 +333,8 @@ function prependPathOnce(pathValue: string | undefined, binDir: string): string 
 export function installCodexRipgrepGuard(input: {
   env: Record<string, string | undefined>
   binDir?: string
+  workspaceRoot?: string
+  realFindPath?: string
   realRipgrepPath?: string
 }): CodexRipgrepGuardInstall {
   const env = normalizedEnv(input.env)
@@ -157,11 +355,19 @@ export function installCodexRipgrepGuard(input: {
   const wrapperPath = join(binDir, "rg")
   writeFileSync(wrapperPath, codexRipgrepGuardShell(realRipgrepPath), { mode: 0o755 })
   chmodSync(wrapperPath, 0o755)
+  const realFindPath = input.realFindPath ?? env[CODEX_REAL_FIND_ENV] ?? findExecutableOnPath("find", env.PATH ?? process.env.PATH)
+  if (realFindPath !== null) {
+    const findWrapperPath = join(binDir, "find")
+    writeFileSync(findWrapperPath, codexFindGuardShell(realFindPath), { mode: 0o755 })
+    chmodSync(findWrapperPath, 0o755)
+  }
 
   const next = {
     ...env,
     [CODEX_RG_GUARD_ENV]: "1",
     [CODEX_REAL_RG_ENV]: realRipgrepPath,
+    ...(realFindPath === null ? {} : { [CODEX_REAL_FIND_ENV]: realFindPath }),
+    ...(input.workspaceRoot === undefined ? {} : { [CODEX_WORKSPACE_ROOT_ENV]: resolve(input.workspaceRoot) }),
     PATH: prependPathOnce(env.PATH ?? process.env.PATH, binDir),
   }
   return { env: next, installed: true, binDir, wrapperPath, realRipgrepPath }

--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -523,6 +523,53 @@ export async function removeMaterializedWorkspace(input: {
   await rm(target, { recursive: true, force: true })
 }
 
+export async function pruneWorkspaceCacheDirectories(input: {
+  cacheRoot: string
+  maxEntries: number
+  protectedWorkspaceRefs?: ReadonlyArray<string>
+}): Promise<{ removedWorkspaceRefs: string[] }> {
+  if (!Number.isFinite(input.maxEntries) || input.maxEntries < 1) {
+    return { removedWorkspaceRefs: [] }
+  }
+  let entries: string[]
+  try {
+    entries = await readdir(input.cacheRoot)
+  } catch {
+    return { removedWorkspaceRefs: [] }
+  }
+  const protectedRefs = new Set(input.protectedWorkspaceRefs ?? [])
+  const candidates: Array<{ workspaceRef: string; mtimeMs: number }> = []
+  for (const entry of entries) {
+    if (!entry.startsWith("workspace.pylon.") || protectedRefs.has(entry)) continue
+    const workingDirectory = join(input.cacheRoot, entry)
+    try {
+      assertPylonOwnedWorkspaceTarget({ cacheRoot: input.cacheRoot, workingDirectory })
+      const info = await stat(workingDirectory)
+      if (!info.isDirectory()) continue
+      candidates.push({ workspaceRef: entry, mtimeMs: info.mtimeMs })
+    } catch {
+      // Ignore malformed or concurrently removed entries.
+    }
+  }
+  if (candidates.length <= input.maxEntries) return { removedWorkspaceRefs: [] }
+  const stale = candidates
+    .sort((left, right) => left.mtimeMs - right.mtimeMs)
+    .slice(0, candidates.length - input.maxEntries)
+  const removedWorkspaceRefs: string[] = []
+  for (const candidate of stale) {
+    try {
+      await removeMaterializedWorkspace({
+        cacheRoot: input.cacheRoot,
+        workingDirectory: join(input.cacheRoot, candidate.workspaceRef),
+      })
+      removedWorkspaceRefs.push(candidate.workspaceRef)
+    } catch {
+      // Best-effort cache pressure relief; materialization correctness does not depend on it.
+    }
+  }
+  return { removedWorkspaceRefs }
+}
+
 /**
  * Native git worktree support behind the materializer (issue #4799).
  *

--- a/apps/pylon/tests/workspace-worktree.test.ts
+++ b/apps/pylon/tests/workspace-worktree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { existsSync } from "node:fs"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
@@ -10,6 +10,7 @@ import {
   createGitWorktreeCheckoutRunner,
   detectWorkspaceChangeConflicts,
   materializeGitCheckoutWorkspaceWithLease,
+  pruneWorkspaceCacheDirectories,
   publicWorkspaceChangeCaptureProjection,
   publicWorkspaceLeaseProjection,
   releaseWorkspace,
@@ -407,6 +408,35 @@ describe("createGitWorktreeCheckoutRunner", () => {
 })
 
 describe("materializeGitCheckoutWorkspaceWithLease", () => {
+  test("prunes oldest workspace cache directories while preserving protected refs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-workspace-cache-prune-"))
+    try {
+      const cacheRoot = join(root, "adapter-tasks")
+      const oldRef = "workspace.pylon.codex_agent_task.old"
+      const protectedRef = "workspace.pylon.codex_agent_task.protected"
+      const freshRef = "workspace.pylon.codex_agent_task.fresh"
+      await mkdir(join(cacheRoot, oldRef), { recursive: true })
+      await mkdir(join(cacheRoot, protectedRef), { recursive: true })
+      await mkdir(join(cacheRoot, freshRef), { recursive: true })
+      await utimes(join(cacheRoot, oldRef), new Date("2026-06-11T00:00:00.000Z"), new Date("2026-06-11T00:00:00.000Z"))
+      await utimes(join(cacheRoot, protectedRef), new Date("2026-06-11T01:00:00.000Z"), new Date("2026-06-11T01:00:00.000Z"))
+      await utimes(join(cacheRoot, freshRef), new Date("2026-06-11T02:00:00.000Z"), new Date("2026-06-11T02:00:00.000Z"))
+
+      const pruned = await pruneWorkspaceCacheDirectories({
+        cacheRoot,
+        maxEntries: 1,
+        protectedWorkspaceRefs: [protectedRef],
+      })
+
+      expect(pruned.removedWorkspaceRefs).toEqual([oldRef])
+      expect(existsSync(join(cacheRoot, oldRef))).toBe(false)
+      expect(existsSync(join(cacheRoot, protectedRef))).toBe(true)
+      expect(existsSync(join(cacheRoot, freshRef))).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("records a workspace lease with state, TTL, retention, and refs", async () => {
     const root = await mkdtemp(join(tmpdir(), "pylon-worktree-lease-"))
     try {


### PR DESCRIPTION
Addresses #6441.

### Changes
- `codex-rg-guard.ts`: adds `scopeCodexRipgrepArgsToWorkspace`/`scopeCodexFindArgsToWorkspace`, a `find` guard wrapper (`codexFindGuardShell`), and `OPENAGENTS_CODEX_WORKSPACE_ROOT`/`OPENAGENTS_CODEX_REAL_FIND` so escaping rg/find roots are relativized to the assignment workspace and the wrapper `cd`s into it.
- `codex-agent-executor.ts`: installs the guard with `workspaceRoot` set to the materialized workspace and prunes the codex-agent-tasks cache to 200 entries before materialization.
- `workspace-materializer.ts`: adds `pruneWorkspaceCacheDirectories` (mtime-ordered, protects refs, Pylon-owned target assertion).
- Adds guard and cache-prune unit tests.

### Verification
Not independently re-verified. PR body cites an unrelated boilerplate command (`labor-earnings-routes.test.ts`).