### PR TITLE
feat(worker-api,khala-ios): stream owner Artanis operator channel over SSE + capture owner traces

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
@@ -88,6 +88,16 @@ const post = (body: unknown): Request =>
     method: 'POST',
   })
 
+const postSse = (body: unknown): Request =>
+  new Request('https://openagents.com/api/operator/artanis/chat', {
+    body: JSON.stringify(body),
+    headers: {
+      accept: 'text/event-stream',
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+  })
+
 const runRoute = async (
   deps: ReturnType<typeof baseDeps>['deps'],
   request: Request,
@@ -234,6 +244,69 @@ describe('POST /api/operator/artanis/chat — grounded Khala-powered reply', () 
     )
     // Owner-scoped.
     expect(owner?.ownerId).toBe('owner:github:14167547')
+  })
+
+  test('streams an owner-authenticated Artanis reply as OpenAI-style SSE', async () => {
+    const { deps } = baseDeps()
+    const response = await runRoute(
+      deps,
+      postSse({ messages: [{ content: 'status please', role: 'user' }] }),
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+    const text = await response.text()
+    expect(text).toContain('data: {"choices":[{"delta":{"role":"assistant"}')
+    expect(text).toContain(
+      'data: {"choices":[{"delta":{"content":"I dispatched two Codex assignments this morning."}',
+    )
+    expect(text).toContain('"channelRef":"operator.artanis.chat"')
+    expect(text.trim().endsWith('data: [DONE]')).toBe(true)
+  })
+
+  test('records the owner operator turn as a private trace hook without blocking the reply', async () => {
+    const traceInputs: Array<{
+      ownerUserId: string
+      requestMessages: ReadonlyArray<{ role: string; content: string }>
+      result: { content: string; servedModel: string }
+    }> = []
+    const { deps } = baseDeps({
+      emitOwnerTrace: async input => {
+        traceInputs.push({
+          ownerUserId: input.ownerUserId,
+          requestMessages: input.requestMessages,
+          result: {
+            content: input.result.content,
+            servedModel: input.result.servedModel,
+          },
+        })
+      },
+    })
+    const response = await runRoute(
+      deps,
+      post({ messages: [{ content: 'status please', role: 'user' }] }),
+    )
+    expect(response.status).toBe(200)
+    expect(traceInputs).toEqual([
+      {
+        ownerUserId: 'github:14167547',
+        requestMessages: [{ content: 'status please', role: 'user' }],
+        result: {
+          content: 'I dispatched two Codex assignments this morning.',
+          servedModel: 'gpt-oss-120b',
+        },
+      },
+    ])
+
+    const failingTrace = baseDeps({
+      emitOwnerTrace: async () => {
+        throw new Error('trace store unavailable')
+      },
+    })
+    const stillOk = await runRoute(
+      failingTrace.deps,
+      post({ messages: [{ content: 'status please', role: 'user' }] }),
+    )
+    expect(stillOk.status).toBe(200)
   })
 
   test('a spend ask surfaces the approval-gate hint', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
@@ -51,6 +51,7 @@ import {
   buildArtanisSituationalAwareness,
 } from './artanis-situational-awareness'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import type { InferenceMessage, InferenceResult } from './inference/provider-adapter'
 import { openAgentsDatabase } from './runtime'
 
 type OperatorArtanisChatEnv = Readonly<{
@@ -63,6 +64,13 @@ type OperatorArtanisChatSession = Readonly<{
     email: string
     userId: string
   }>
+}>
+
+type OperatorArtanisTraceInput = Readonly<{
+  ownerUserId: string
+  requestMessages: ReadonlyArray<InferenceMessage>
+  responseId: string
+  result: InferenceResult
 }>
 
 export type OperatorArtanisChatDependencies<
@@ -108,6 +116,10 @@ export type OperatorArtanisChatDependencies<
     env: Bindings,
     session: Session,
   ) => ReadonlyArray<ArtanisOperatorTool>
+  emitOwnerTrace?: (
+    input: OperatorArtanisTraceInput,
+    env: Bindings,
+  ) => Promise<unknown>
 }>
 
 class OperatorArtanisChatUnauthorized extends S.TaggedErrorClass<OperatorArtanisChatUnauthorized>()(
@@ -262,6 +274,73 @@ const parseBody = (request: Request) =>
     return decoded
   })
 
+const wantsEventStream = (request: Request): boolean =>
+  request.headers
+    .get('accept')
+    ?.split(',')
+    .map(part => part.trim().toLowerCase())
+    .some(
+      part =>
+        part === 'text/event-stream' ||
+        part.startsWith('text/event-stream;'),
+    ) === true
+
+const sseData = (value: unknown): string =>
+  `data: ${JSON.stringify(value)}\n\n`
+
+const artanisSseResponse = (turn: Readonly<{
+  deferredToApprovalGate: boolean
+  iterations: number
+  persona: unknown
+  reply: string
+  requestedModel: string
+  servedModel: string
+  servedVia: string
+  toolInvocations: unknown
+}>) =>
+  new Response(
+    [
+      sseData({
+        choices: [
+          {
+            delta: { role: 'assistant' },
+            index: 0,
+          },
+        ],
+      }),
+      ...(turn.reply.length === 0
+        ? []
+        : [
+            sseData({
+              choices: [
+                {
+                  delta: { content: turn.reply },
+                  index: 0,
+                },
+              ],
+            }),
+          ]),
+      sseData({
+        approvalGateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
+        channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
+        deferredToApprovalGate: turn.deferredToApprovalGate,
+        iterations: turn.iterations,
+        persona: turn.persona,
+        requestedModel: turn.requestedModel,
+        servedModel: turn.servedModel,
+        servedVia: turn.servedVia,
+        toolInvocations: turn.toolInvocations,
+      }),
+      'data: [DONE]\n\n',
+    ].join(''),
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+        'Content-Type': 'text/event-stream; charset=utf-8',
+      },
+    },
+  )
+
 export const makeOperatorArtanisChatRoutes = <
   Session extends OperatorArtanisChatSession,
   Bindings extends OperatorArtanisChatEnv,
@@ -360,6 +439,39 @@ export const makeOperatorArtanisChatRoutes = <
           role: 'artanis',
         }),
       ).pipe(Effect.catch(() => Effect.void))
+
+      if (dependencies.emitOwnerTrace !== undefined) {
+        yield* Effect.tryPromise(() =>
+          dependencies.emitOwnerTrace!(
+            {
+              ownerUserId: session.user.userId,
+              requestMessages: body.messages.map(message => ({
+                content: message.content,
+                role: message.role,
+              })),
+              responseId: `operator-artanis:${crypto.randomUUID()}`,
+              result: {
+                content: turn.reply,
+                finishReason: 'stop',
+                servedModel: turn.servedModel,
+                usage: {
+                  completionTokens: 0,
+                  promptTokens: 0,
+                  totalTokens: 0,
+                },
+              },
+            },
+            env,
+          ),
+        ).pipe(Effect.catch(() => Effect.void))
+      }
+
+      if (wantsEventStream(request)) {
+        return dependencies.appendRefreshedSessionCookies(
+          artanisSseResponse(turn),
+          session,
+        )
+      }
 
       return dependencies.appendRefreshedSessionCookies(
         noStoreJsonResponse({

--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
@@ -53,6 +53,7 @@ import {
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import type { InferenceMessage, InferenceResult } from './inference/provider-adapter'
 import { openAgentsDatabase } from './runtime'
+import { randomUuid } from './runtime-primitives'
 
 type OperatorArtanisChatEnv = Readonly<{
   OPENAGENTS_DB: D1Database
@@ -449,7 +450,7 @@ export const makeOperatorArtanisChatRoutes = <
                 content: message.content,
                 role: message.role,
               })),
-              responseId: `operator-artanis:${crypto.randomUUID()}`,
+              responseId: `operator-artanis:${randomUuid()}`,
               result: {
                 content: turn.reply,
                 finishReason: 'stop',

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -8733,6 +8733,31 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
   },
   requireAdminApiToken,
   requireBrowserSession,
+  emitOwnerTrace: async (input, env) => {
+    await emitKhalaChatTrace(
+      {
+        requestedModel: 'openagents/khala',
+        requestMessages: input.requestMessages,
+        responseId: input.responseId,
+        result: input.result,
+      },
+      {
+        enabled: isKhalaChatTraceEmitEnabled(env.KHALA_CHAT_TRACE_EMIT_ENABLED),
+        optedIn: false,
+        captureDefault: true,
+        store: makeD1TraceStore(openAgentsDatabase(env)),
+        owner: {
+          ownerUserId: input.ownerUserId,
+          agentRef: 'operator.artanis.chat',
+          uploadSource: 'user_session',
+        },
+        demandAttribution: {
+          demandKind: 'internal',
+          demandSource: 'artanis_operator_channel',
+        },
+      },
+    )
+  },
   // Accept an `oa_agent_` bearer (the Khala CLI's token from `khala login`) when
   // it is linked to an OpenAuth account. Resolves the agent credential -> its
   // linked owner user id -> that user's email and scopes Artanis to that owner.

--- a/clients/mobile/Khala/Khala/Net/KhalaArtanis.swift
+++ b/clients/mobile/Khala/Khala/Net/KhalaArtanis.swift
@@ -13,7 +13,7 @@ import Foundation
 /// - Endpoint:  POST https://openagents.com/api/operator/artanis/chat
 /// - Auth:      Authorization: Bearer <owner oa_agent_… key / session>
 /// - Body:      { "messages": [ { "role", "content" }, … ] }
-/// - Response:  { "reply": "…" }   (non-streaming)
+/// - Response:  OpenAI-style SSE frames when `Accept: text/event-stream`
 ///
 /// Unlike the public Khala paths, a non-owner caller is expected to receive
 /// 401/403 here. The app surfaces that as the existing `.unauthorized` error so
@@ -23,50 +23,9 @@ extension KhalaClient {
     /// public `/api/v1` OpenAI-compatible base.
     static let artanisChatURL = URL(string: "https://openagents.com/api/operator/artanis/chat")!
 
-    /// Send the full conversation to the owner-only Artanis operator channel and
-    /// return the operator's reply. Non-streaming, per the shared contract.
-    static func artanisChat(
-        messages: [OutgoingMessage],
-        apiKey: String,
-        session: URLSession = .shared
-    ) async throws -> String {
-        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedKey.isEmpty else { throw KhalaError.missingKey }
-
-        var request = URLRequest(url: artanisChatURL)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
-
-        let body: [String: Any] = ["messages": messages.map(\.json)]
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-
-        do {
-            let (data, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse else { throw KhalaError.decoding }
-            if http.statusCode == 401 || http.statusCode == 403 { throw KhalaError.unauthorized }
-            if http.statusCode == 402 { throw KhalaError.quotaExceeded }
-            guard (200..<300).contains(http.statusCode) else {
-                throw KhalaError.http(http.statusCode, String(data: data, encoding: .utf8) ?? "")
-            }
-            guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let reply = obj["reply"] as? String
-            else {
-                throw KhalaError.decoding
-            }
-            return reply
-        } catch let err as KhalaError {
-            throw err
-        } catch {
-            throw KhalaError.transport(error)
-        }
-    }
-
-    /// Streaming-shaped wrapper so the Artanis channel reuses the same chat UI as
-    /// public Khala. The contract is non-streaming, so this yields the whole
-    /// reply as a single delta and finishes. Errors map onto `KhalaError`, the
-    /// same surface the streaming Khala path uses.
+    /// Stream the owner-only Artanis operator channel. The endpoint returns
+    /// OpenAI-style SSE frames, so this parser reuses the public Khala delta
+    /// contract while keeping the owner-only URL/auth boundary separate.
     static func streamArtanisCompletion(
         messages: [OutgoingMessage],
         apiKey: String,
@@ -75,25 +34,70 @@ extension KhalaClient {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    let reply = try await artanisChat(
-                        messages: messages,
-                        apiKey: apiKey,
-                        session: session
-                    )
-                    try Task.checkCancellation()
-                    if !reply.isEmpty {
-                        continuation.yield(reply)
+                    let request = try makeArtanisStreamRequest(messages: messages, apiKey: apiKey)
+                    let (bytes, response) = try await session.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else { throw KhalaError.decoding }
+                    if http.statusCode == 401 || http.statusCode == 403 { throw KhalaError.unauthorized }
+                    if http.statusCode == 402 { throw KhalaError.quotaExceeded }
+                    guard (200..<300).contains(http.statusCode) else {
+                        let body = await Self.collectArtanisErrorBody(from: bytes)
+                        throw KhalaError.http(http.statusCode, body)
+                    }
+
+                    for try await line in bytes.lines {
+                        try Task.checkCancellation()
+                        guard let delta = Self.delta(fromSSELine: line) else { continue }
+                        if delta.isDone { break }
+                        if let content = delta.content, !content.isEmpty {
+                            continuation.yield(content)
+                        }
                     }
                     continuation.finish()
                 } catch is CancellationError {
                     continuation.finish(throwing: CancellationError())
                 } catch let err as KhalaError {
                     continuation.finish(throwing: err)
+                } catch let urlError as URLError where urlError.code == .cancelled {
+                    continuation.finish(throwing: CancellationError())
                 } catch {
                     continuation.finish(throwing: KhalaError.transport(error))
                 }
             }
             continuation.onTermination = { _ in task.cancel() }
         }
+    }
+
+    private static func makeArtanisStreamRequest(
+        messages: [OutgoingMessage],
+        apiKey: String
+    ) throws -> URLRequest {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { throw KhalaError.missingKey }
+
+        var request = URLRequest(url: artanisChatURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: Any] = ["messages": messages.map(\.json)]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private static func collectArtanisErrorBody(
+        from bytes: URLSession.AsyncBytes,
+        limit: Int = 2_048
+    ) async -> String {
+        var collected = Data()
+        do {
+            for try await byte in bytes {
+                collected.append(byte)
+                if collected.count >= limit { break }
+            }
+        } catch {
+            // Best-effort; return whatever was read.
+        }
+        return String(data: collected, encoding: .utf8) ?? ""
     }
 }

--- a/clients/mobile/Khala/KhalaTests/KhalaStreamTests.swift
+++ b/clients/mobile/Khala/KhalaTests/KhalaStreamTests.swift
@@ -150,6 +150,42 @@ final class KhalaStreamTests: XCTestCase {
         }
     }
 
+    func testArtanisStreamUsesOwnerEndpointAndYieldsSSEDeltas() async throws {
+        let session = makeSession()
+        let apiKey = "oa_agent_owner_key"
+
+        StreamMockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://openagents.com/api/operator/artanis/chat")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(apiKey)")
+
+            let body = try XCTUnwrap(request.httpBodyStream.flatMap(Self.data(from:)))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let messages = try XCTUnwrap(json["messages"] as? [[String: String]])
+            XCTAssertEqual(messages, [["role": "user", "content": "status"]])
+
+            return (
+                Self.ok(request),
+                Self.sse([
+                    #"data: {"choices":[{"delta":{"role":"assistant"}}]}"#,
+                    #"data: {"choices":[{"delta":{"content":"Working"}}]}"#,
+                    "data: [DONE]",
+                ])
+            )
+        }
+
+        var deltas: [String] = []
+        for try await delta in KhalaClient.streamArtanisCompletion(
+            messages: [.init(role: "user", content: "status")],
+            apiKey: apiKey,
+            session: session
+        ) {
+            deltas.append(delta)
+        }
+        XCTAssertEqual(deltas, ["Working"])
+    }
+
     func testCancellationStopsStreamCleanly() async throws {
         let session = makeSession()
         StreamMockURLProtocol.requestHandler = { request in


### PR DESCRIPTION
Addresses #6442.

### Changes
- `artanis-operator-chat-routes.ts`: returns OpenAI-style SSE frames when `Accept: text/event-stream` (role delta, content delta, metadata frame with channelRef/approvalGateRef, `[DONE]`); adds an optional `emitOwnerTrace` hook that records the owner turn without blocking the reply.
- `index.ts`: wires `emitOwnerTrace` to `emitKhalaChatTrace` with owner identity and internal demand attribution so owner operator messages reliably land in agent_traces.
- `KhalaArtanis.swift`: replaces the non-streaming `artanisChat` with an SSE streaming parser reusing the Khala delta contract on the owner-only URL/auth.
- Adds SSE route tests and a Swift stream test.

### Verification
Not independently re-verified. PR body cites an unrelated boilerplate command (`labor-earnings-routes.test.ts`).