### PR TITLE
pylon: Implement public issue #6432 and run the named verification. (#6432)

### DIFF
--- a/apps/pylon/scripts/codex-fleet-offload/offload-codex-accounts.sh
+++ b/apps/pylon/scripts/codex-fleet-offload/offload-codex-accounts.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# Copy selected isolated Codex account homes to a Tailnet Mac and optionally
+# launch the Codex supervisor there. This is intentionally account-ref scoped:
+# it never reads or copies ~/.codex, and it never runs a device login.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+LOCAL_PYLON_HOME="${PYLON_HOME:-$HOME/.pylon-fable}"
+REMOTE_PYLON_HOME='~/.pylon-fable'
+REMOTE_REPO='~/work/openagents'
+REMOTE_TOKEN_ENV='~/work/.secrets/openagents-artanis-agent.env'
+SUP_MAX_SLOTS=4
+SUP_PER_ACCOUNT=2
+EXECUTE=0
+START_SUPERVISOR=0
+HOST=""
+ACCOUNTS=()
+
+usage() {
+  cat <<'USAGE'
+usage:
+  offload-codex-accounts.sh --host <tailnet-host> --accounts <ref,ref...> [options] --execute
+
+options:
+  --local-pylon-home <path>    Source Pylon home. Default: $PYLON_HOME or ~/.pylon-fable.
+  --remote-pylon-home <path>   Destination Pylon home. Default: ~/.pylon-fable.
+  --remote-repo <path>         Remote openagents checkout. Default: ~/work/openagents.
+  --remote-token-env <path>    Remote env file that exports OPENAGENTS_AGENT_TOKEN.
+                               Default: ~/work/.secrets/openagents-artanis-agent.env.
+  --sup-max-slots <n>          Remote SUP_MAX_SLOTS when launching. Default: 4.
+  --sup-per-account <n>        Remote SUP_PER_ACCOUNT when launching. Default: 2.
+  --start-supervisor           Start remote codex supervisor after import.
+  --execute                    Required to copy credentials or launch anything.
+  --dry-run                    Print the plan only.
+
+example:
+  PYLON_HOME=$HOME/.pylon-fable \
+    apps/pylon/scripts/codex-fleet-offload/offload-codex-accounts.sh \
+      --host imac-pro-bertha \
+      --accounts codex-4,codex-5 \
+      --start-supervisor \
+      --execute
+
+safety:
+  Only <pylon home>/accounts/codex/<ref> is copied. The default ~/.codex home is
+  never read, copied, or logged into. Agent tokens are not copied; the remote
+  supervisor must source its own token env file.
+USAGE
+}
+
+fail() {
+  printf 'FATAL: %s\n' "$*" >&2
+  exit 1
+}
+
+shell_quote() {
+  printf "%q" "$1"
+}
+
+parse_accounts() {
+  local raw="$1"
+  IFS=',' read -r -a ACCOUNTS <<< "$raw"
+  local account
+  for account in "${ACCOUNTS[@]}"; do
+    [[ "$account" =~ ^[A-Za-z0-9._-]+$ ]] || fail "invalid account ref: $account"
+  done
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --host) HOST="${2:-}"; shift 2 ;;
+    --accounts) parse_accounts "${2:-}"; shift 2 ;;
+    --local-pylon-home) LOCAL_PYLON_HOME="${2:-}"; shift 2 ;;
+    --remote-pylon-home) REMOTE_PYLON_HOME="${2:-}"; shift 2 ;;
+    --remote-repo) REMOTE_REPO="${2:-}"; shift 2 ;;
+    --remote-token-env) REMOTE_TOKEN_ENV="${2:-}"; shift 2 ;;
+    --sup-max-slots) SUP_MAX_SLOTS="${2:-}"; shift 2 ;;
+    --sup-per-account) SUP_PER_ACCOUNT="${2:-}"; shift 2 ;;
+    --start-supervisor) START_SUPERVISOR=1; shift ;;
+    --execute) EXECUTE=1; shift ;;
+    --dry-run) EXECUTE=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown option: $1" ;;
+  esac
+done
+
+[ -n "$HOST" ] || fail "--host is required"
+[ "${#ACCOUNTS[@]}" -gt 0 ] || fail "--accounts is required"
+[[ "$SUP_MAX_SLOTS" =~ ^[0-9]+$ ]] || fail "--sup-max-slots must be an integer"
+[[ "$SUP_PER_ACCOUNT" =~ ^[0-9]+$ ]] || fail "--sup-per-account must be an integer"
+
+LOCAL_PYLON_HOME="${LOCAL_PYLON_HOME/#\~/$HOME}"
+LOCAL_CODEX_ROOT="$LOCAL_PYLON_HOME/accounts/codex"
+
+[ "$LOCAL_CODEX_ROOT" != "$HOME/.codex" ] || fail "refusing to use ~/.codex"
+[ -d "$LOCAL_CODEX_ROOT" ] || fail "missing local Codex account root: $LOCAL_CODEX_ROOT"
+
+for account in "${ACCOUNTS[@]}"; do
+  account_home="$LOCAL_CODEX_ROOT/$account"
+  [ -d "$account_home" ] || fail "missing local account home: $account_home"
+  [ "$account_home" != "$HOME/.codex" ] || fail "refusing to copy ~/.codex"
+  [ -f "$account_home/auth.json" ] || fail "missing auth.json for $account"
+done
+
+printf 'Codex account offload plan\n'
+printf '  host: %s\n' "$HOST"
+printf '  local pylon home: %s\n' "$LOCAL_PYLON_HOME"
+printf '  remote pylon home: %s\n' "$REMOTE_PYLON_HOME"
+printf '  remote repo: %s\n' "$REMOTE_REPO"
+printf '  accounts: %s\n' "${ACCOUNTS[*]}"
+printf '  start supervisor: %s\n' "$START_SUPERVISOR"
+
+if [ "$EXECUTE" -ne 1 ]; then
+  printf '\nDry run only. Re-run with --execute to copy account homes.\n'
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+archive="$tmpdir/codex-account-offload.tgz"
+remote_archive="/tmp/openagents-codex-account-offload-$(date +%s)-$$.tgz"
+cleanup() { rm -rf "$tmpdir"; }
+trap cleanup EXIT
+
+tar_args=()
+for account in "${ACCOUNTS[@]}"; do
+  tar_args+=("$account")
+done
+
+printf '\nCreating local archive with selected isolated account homes...\n'
+tar -C "$LOCAL_CODEX_ROOT" -czf "$archive" "${tar_args[@]}"
+chmod 600 "$archive"
+
+printf 'Copying archive to %s:%s ...\n' "$HOST" "$remote_archive"
+scp -q "$archive" "$HOST:$remote_archive"
+
+remote_account_args=""
+for account in "${ACCOUNTS[@]}"; do
+  remote_account_args+=" $(shell_quote "$account")"
+done
+
+remote_script=$(cat <<REMOTE
+set -euo pipefail
+REMOTE_PYLON_HOME=$REMOTE_PYLON_HOME
+REMOTE_REPO=$REMOTE_REPO
+REMOTE_ARCHIVE=$(shell_quote "$remote_archive")
+mkdir -p "\$REMOTE_PYLON_HOME/accounts/codex"
+tar -C "\$REMOTE_PYLON_HOME/accounts/codex" -xzf "\$REMOTE_ARCHIVE"
+chmod -R go-rwx "\$REMOTE_PYLON_HOME/accounts/codex"
+rm -f "\$REMOTE_ARCHIVE"
+cd "\$REMOTE_REPO"
+for account in$remote_account_args; do
+  home="\$REMOTE_PYLON_HOME/accounts/codex/\$account"
+  PYLON_HOME="\$REMOTE_PYLON_HOME" bun apps/pylon/src/index.ts accounts connect codex \
+    --account "\$account" \
+    --home "\$home" \
+    --skip-device-login \
+    --json >/dev/null
+done
+PYLON_HOME="\$REMOTE_PYLON_HOME" bun apps/pylon/src/index.ts codex accounts list --json
+REMOTE
+)
+
+if [ "$START_SUPERVISOR" -eq 1 ]; then
+  remote_script+=$(cat <<REMOTE
+
+set -a
+[ -f $REMOTE_TOKEN_ENV ] || { echo "missing remote token env: $REMOTE_TOKEN_ENV" >&2; exit 1; }
+. $REMOTE_TOKEN_ENV
+set +a
+live_ref=\$(PYLON_HOME="\$REMOTE_PYLON_HOME" bun apps/pylon/src/index.ts provider go-online --json \
+  | node -e 'let s="";process.stdin.on("data",c=>s+=c);process.stdin.on("end",()=>{const j=JSON.parse(s); console.log(j.pylonRef || "")})')
+[ -n "\$live_ref" ] || { echo "could not resolve live pylon ref" >&2; exit 1; }
+PYLON_HOME="\$REMOTE_PYLON_HOME" \
+SUP_PYLON_REF="\$live_ref" \
+SUP_MAX_SLOTS=$SUP_MAX_SLOTS \
+SUP_PER_ACCOUNT=$SUP_PER_ACCOUNT \
+bash apps/pylon/scripts/codex-supervisor/launch.sh start
+REMOTE
+)
+fi
+
+printf 'Importing on remote host...\n'
+ssh "$HOST" "bash -s" <<< "$remote_script"
+
+printf '\nOffload complete for %s: %s\n' "$HOST" "${ACCOUNTS[*]}"

--- a/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
+++ b/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
@@ -323,6 +323,95 @@ PYLON_HOME=$HOME/.pylon-fable pylon codex accounts list --json
 # each codex account: readiness.state == "ready", capability.pylon.local_codex present
 ```
 
+### Offload Codex accounts to Tailnet Macs (#6432)
+
+Use this when the owner desktop is CPU-saturated but the Codex account homes are
+already authenticated under `~/.pylon-fable/accounts/codex/<ref>`. The goal is
+to split the 12-ish concurrent turns across multiple Macs without re-login:
+keep a subset on the desktop, ship selected serialized account homes to
+`imac-pro-bertha` and `macbook-pro-m2`, then launch one supervisor per machine.
+
+**Do not run any Codex login flow for this.** The helper copies only selected
+isolated homes from `<pylon home>/accounts/codex/<ref>`, refuses `~/.codex`, and
+registers the imported homes with `accounts connect codex --skip-device-login`.
+Agent tokens are not copied; the remote host must source its own
+`OPENAGENTS_AGENT_TOKEN` env file.
+
+Preflight on the desktop:
+
+```sh
+PYLON_HOME=$HOME/.pylon-fable bun apps/pylon/src/index.ts codex accounts list --json
+# choose only accounts with readiness.state == "ready"
+```
+
+Dry-run the split plan:
+
+```sh
+apps/pylon/scripts/codex-fleet-offload/offload-codex-accounts.sh \
+  --host imac-pro-bertha \
+  --accounts codex-4,codex-5 \
+  --start-supervisor \
+  --dry-run
+
+apps/pylon/scripts/codex-fleet-offload/offload-codex-accounts.sh \
+  --host macbook-pro-m2 \
+  --accounts codex-6,codex-7 \
+  --start-supervisor \
+  --dry-run
+```
+
+Execute only after the account refs and remote checkout paths are correct:
+
+```sh
+PYLON_HOME=$HOME/.pylon-fable \
+apps/pylon/scripts/codex-fleet-offload/offload-codex-accounts.sh \
+  --host imac-pro-bertha \
+  --accounts codex-4,codex-5 \
+  --remote-repo ~/work/openagents \
+  --remote-pylon-home ~/.pylon-fable \
+  --remote-token-env ~/work/.secrets/openagents-artanis-agent.env \
+  --sup-max-slots 4 \
+  --sup-per-account 2 \
+  --start-supervisor \
+  --execute
+
+PYLON_HOME=$HOME/.pylon-fable \
+apps/pylon/scripts/codex-fleet-offload/offload-codex-accounts.sh \
+  --host macbook-pro-m2 \
+  --accounts codex-6,codex-7 \
+  --remote-repo ~/work/openagents \
+  --remote-pylon-home ~/.pylon-fable \
+  --remote-token-env ~/work/.secrets/openagents-artanis-agent.env \
+  --sup-max-slots 4 \
+  --sup-per-account 2 \
+  --start-supervisor \
+  --execute
+```
+
+Remote proof after each import:
+
+```sh
+ssh imac-pro-bertha 'cd ~/work/openagents && PYLON_HOME=$HOME/.pylon-fable bun apps/pylon/src/index.ts codex accounts list --json'
+ssh imac-pro-bertha 'bash ~/work/openagents/apps/pylon/scripts/codex-supervisor/launch.sh status'
+
+ssh macbook-pro-m2 'cd ~/work/openagents && PYLON_HOME=$HOME/.pylon-fable bun apps/pylon/src/index.ts codex accounts list --json'
+ssh macbook-pro-m2 'bash ~/work/openagents/apps/pylon/scripts/codex-supervisor/launch.sh status'
+```
+
+If a remote host already has a supervisor running, stop it before changing its
+account set:
+
+```sh
+ssh imac-pro-bertha 'bash ~/work/openagents/apps/pylon/scripts/codex-supervisor/launch.sh stop'
+ssh macbook-pro-m2 'bash ~/work/openagents/apps/pylon/scripts/codex-supervisor/launch.sh stop'
+```
+
+Capacity guidance: with two ready Codex accounts per remote and
+`SUP_PER_ACCOUNT=2`, each remote should advertise up to four Codex slots. Keep
+the desktop at the remaining account count so the total advertised slots match
+the true machine capacity. Do not run two supervisors against the same copied
+account ref at the same time; that just contends for the same provider budget.
+
 ### Launch / stop / status the supervisor
 ```sh
 # (fetch live SUP_PYLON_REF first — see §2b)


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6432

Assignment: assignment.public.khala_coding.chatcmpl_0abf33068ab24b41afd9463430257338
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 2

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.