### PR TITLE
pylon: Implement public issue #6441 and run the named verification. (#6441)

### DIFF
--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -11,6 +11,7 @@ import {
 import {
   gitCheckoutWorkspaceFrom,
   materializeGitCheckoutWorkspaceWithLease,
+  releaseWorkspace,
   workspaceCheckoutFailureReasonRef,
   type GitCheckoutWorkspace,
   type WorkspaceCheckoutRunner,
@@ -66,6 +67,12 @@ export type CodexAgentRuntimeSandboxMode = CodexAgentSandboxMode | "danger-full-
 
 export const CODEX_AGENT_OWNER_LOCAL_SANDBOX_MODE = "danger-full-access" as const
 export const CODEX_AGENT_OWNER_LOCAL_APPROVAL_POLICY = "never" as const
+export const CODEX_AGENT_BOUNDED_SEARCH_INSTRUCTION = [
+  "Workspace boundary: all file search, grep, find, list, and verification commands must run from the active checkout only.",
+  "Use the current working directory as the search root; prefer workspace-relative paths such as `.` or repo-relative subpaths.",
+  "Never search or traverse the Pylon home, parent directories, sibling cache workspaces, `$PYLON_HOME`, `~/.pylon-fable`, `/Users/*/.pylon-fable`, or `..`.",
+  "If a requested search path escapes this checkout, reject it or relativize it back inside the checkout before running the command.",
+].join(" ")
 
 export type CodexAgentTaskPayload = {
   schema: typeof CODEX_AGENT_TASK_SCHEMA
@@ -811,12 +818,14 @@ async function materializeCodexAgentWorkspace(input: {
       leaseRef: input.leaseRef,
       refPrefix: "workspace.pylon.codex_agent_task",
       repositoryCacheRoot: join(input.state.paths.cache, "workspace-git-cache"),
+      retentionPolicy: "remove_on_closeout",
       workspaceStateRoot: join(input.state.paths.cache, "workspace-leases"),
     })
     return {
       acceptanceResultRef: "git_checkout_verified",
       artifactSourceRef: materialized.sourceRef,
       instructions: [
+        CODEX_AGENT_BOUNDED_SEARCH_INSTRUCTION,
         "You are working in a bounded public repository checkout.",
         `Task objective: ${input.task.objectiveSummary ?? "complete the referenced Autopilot task"}.`,
         "Only modify files inside this checkout.",
@@ -1097,11 +1106,17 @@ export async function executeCodexAgentAssignment(
     now,
     publisher: options.pullRequestPublisher,
   })
+  const workspaceRelease = await maybeReleaseCodexAgentWorkspace({
+    materialized,
+    now,
+    state,
+    task,
+  })
 
   return {
     artifactRefs: [artifactRef],
     blockerRefs: passed ? [] : ["blocker.assignment.codex_agent_test_failed"],
-    buildRefs: [commandRef],
+    buildRefs: [commandRef, ...workspaceRelease.buildRefs],
     message: passed
       ? `Local Codex completed the bounded coding task: ${run.editedFileCount} file edit(s), ${run.commandCount} command(s), ${run.turnCount} turn(s), verification test passed on this device.${pullRequest.messageSuffix}`
       : "Local Codex thread completed but the verification test command failed; the change is not accepted.",
@@ -1113,6 +1128,7 @@ export async function executeCodexAgentAssignment(
         : `result.public.pylon.codex_agent_task.${materialized.acceptanceResultRef}_failed`,
       `result.public.pylon.codex_agent_task.edited_files.${run.editedFileCount}`,
       ...pullRequest.resultRefs,
+      ...workspaceRelease.resultRefs,
     ],
     runRefs: [runRef, ...sessionRefs],
     status: passed ? ("accepted" as const) : ("rejected" as const),
@@ -1123,6 +1139,50 @@ export async function executeCodexAgentAssignment(
     ],
     testRefs: [commandRef],
   }
+}
+
+type WorkspaceReleaseCloseoutContribution = {
+  buildRefs: string[]
+  resultRefs: string[]
+}
+
+const EMPTY_WORKSPACE_RELEASE_CONTRIBUTION: WorkspaceReleaseCloseoutContribution = {
+  buildRefs: [],
+  resultRefs: [],
+}
+
+async function maybeReleaseCodexAgentWorkspace(input: {
+  task: CodexAgentTaskPayload
+  materialized: Awaited<ReturnType<typeof materializeCodexAgentWorkspace>>
+  state: PylonLocalState
+  now: Date
+}): Promise<WorkspaceReleaseCloseoutContribution> {
+  if (input.task.workspace === undefined) return EMPTY_WORKSPACE_RELEASE_CONTRIBUTION
+  try {
+    const result = await releaseWorkspace({
+      workspaceRef: input.materialized.workspaceRef,
+      workspaceStateRoot: join(input.state.paths.cache, "workspace-leases"),
+      now: input.now,
+    })
+    if (result?.cleanupReceiptRef !== undefined) {
+      return {
+        buildRefs: [result.cleanupReceiptRef],
+        resultRefs: ["result.public.pylon.codex_agent_task.workspace_cleaned"],
+      }
+    }
+    if (result?.retentionReasonRef !== undefined) {
+      return {
+        buildRefs: [result.retentionReasonRef],
+        resultRefs: ["result.public.pylon.codex_agent_task.workspace_retained"],
+      }
+    }
+  } catch {
+    return {
+      buildRefs: [],
+      resultRefs: ["result.public.pylon.codex_agent_task.workspace_cleanup_failed"],
+    }
+  }
+  return EMPTY_WORKSPACE_RELEASE_CONTRIBUTION
 }
 
 type PullRequestCloseoutContribution = {

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, mock, test } from "bun:test"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { existsSync } from "node:fs"
 import { join, relative } from "node:path"
 import { tmpdir } from "node:os"
 import {
+  CODEX_AGENT_BOUNDED_SEARCH_INSTRUCTION,
   CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
   CODEX_AGENT_TASK_SCHEMA,
   codexAgentTaskFrom,
@@ -639,7 +641,9 @@ describe("codex git_checkout workspace (shared B2 contract)", () => {
 
   test("executes a checkout task end to end with an injected checkout runner", async () => {
     await withState(async (state) => {
+      let workspaceDir: string | null = null
       const checkoutRunner = async (workspace: string) => {
+        workspaceDir = workspace
         const { mkdir } = await import("node:fs/promises")
         await mkdir(workspace, { recursive: true })
         await writeFile(
@@ -660,16 +664,32 @@ describe("codex git_checkout workspace (shared B2 contract)", () => {
           ].join("\n"),
         )
       }
+      let runnerSawBoundedSearchInstruction = false
+      const observingRunner: CodexAgentRunner = async (input) => {
+        runnerSawBoundedSearchInstruction = input.instructions.includes(
+          CODEX_AGENT_BOUNDED_SEARCH_INSTRUCTION,
+        )
+        expect(input.instructions).toContain("Only modify files inside this checkout.")
+        expect(input.instructions).toContain("command.public.autopilot_coder.bun_test")
+        return fixingRunner(input)
+      }
       const record = await executeCodexAgentAssignment(
         state,
         { ...lease, codingAssignment: checkoutAssignment },
         now,
-        { checkoutRunner, codexAgentRunner: fixingRunner, codexAgentProbe: readyProbe },
+        { checkoutRunner, codexAgentRunner: observingRunner, codexAgentProbe: readyProbe },
       )
       expect(record?.status).toBe("accepted")
       expect(record?.resultRefs).toContain(
         "result.public.pylon.codex_agent_task.git_checkout_verified_passed",
       )
+      expect(record?.resultRefs).toContain(
+        "result.public.pylon.codex_agent_task.workspace_cleaned",
+      )
+      expect(record?.buildRefs.some(ref => ref.startsWith("receipt.pylon.workspace_cleanup."))).toBe(true)
+      expect(runnerSawBoundedSearchInstruction).toBe(true)
+      expect(workspaceDir).not.toBeNull()
+      expect(existsSync(workspaceDir as unknown as string)).toBe(false)
       assertPublicProjectionSafe(record)
       const projected = JSON.stringify(record)
       expect(projected).not.toContain(state.paths.cache)


### PR DESCRIPTION
Automated pull request opened by an OpenAgents Pylon Codex assignment.

Refs #6441

Assignment: assignment.public.khala_coding.chatcmpl_deeb7c090eeb4db99f76312b6d7bee91
Base commit: 6e69c8a2dfa2a7e98e5e09a72a3e3741a4ef1f5b
Files changed: 2

Verification command: `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
Verification result: passed (exit 0)

The diff was produced by Codex in a bounded local workspace, and the
verification command passed locally before this PR was opened.