### PR TITLE
feat(worker-api): add get_fleet_status Artanis tool with unified fleet-status loader

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -8,6 +8,7 @@ import {
   ARTANIS_SYNTHETIC_LOAD_RISKY_ACTION_KIND,
   ARTANIS_SYNTHETIC_LOAD_RUN_TYPES,
   type ArtanisGlmFleetStatus,
+  type ArtanisFleetStatusPayload,
   type ArtanisKhalaFeedbackRecord,
   type ArtanisPylonAssignmentSummary,
   type ArtanisPylonJobStatus,
@@ -17,6 +18,7 @@ import {
   isSafeArtanisAssignmentRef,
   isSafeArtanisRepoPath,
   makeArtanisDispatchCodexTaskTool,
+  makeArtanisGetFleetStatusTool,
   makeArtanisGetGlmFleetStatusTool,
   makeArtanisGetSyntheticLoadStatusTool,
   makeArtanisGetKhalaFeedbackTool,
@@ -33,6 +35,7 @@ import {
   makeArtanisTriggerSyntheticLoadTool,
   makeArtanisUpdateUnsupportedRequestTool,
   normalizeArtanisGlmFleetStatus,
+  normalizeArtanisFleetStatus,
   normalizeArtanisTraceReview,
   parseArtanisAssignmentRef,
   parseArtanisIssueNumber,
@@ -1878,6 +1881,117 @@ describe('get_glm_fleet_status (live GLM inference-fleet readiness) - iteration 
   })
 })
 
+const exampleFleetStatusPayload = (): ArtanisFleetStatusPayload => ({
+  brain: {
+    goalCount: 2,
+    loopState: 'running',
+    recentDecisionRefs: ['decision.public.artanis.tick_1'],
+  },
+  caveatRefs: ['caveat.operator.fleet_status.read_only_snapshot'],
+  fleet: {
+    activeAssignments: 3,
+    failCount: 1,
+    inFlightIssues: [6428, 6359],
+    inProgressCount: 2,
+    passCount: 4,
+    recentAssignments: 7,
+  },
+  generatedAt: '2026-06-27T12:00:00.000Z',
+  glm: {
+    readyReplicas: 5,
+    status: 'ready',
+    totalReplicas: 6,
+    warmReplicas: 1,
+  },
+  pace: {
+    behindPace: true,
+    floorTokens: 4000,
+    projectedTokens: 3000,
+    status: 'behind_pace',
+    stretchTokens: 10000,
+    todayTokens: 1200,
+    yesterdayTokens: 1000,
+  },
+  schemaVersion: 'openagents.operator.fleet_status.v1',
+  watchdog: {
+    activeLeaseCount: 3,
+    activeSyntheticRuns: 1,
+    alertRefs: ['alert.operator.fleet_burn.behind_floor'],
+    state: 'active',
+  },
+})
+
+describe('get_fleet_status (unified operator fleet-status) - issue #6428', () => {
+  test('returns one high-context read with Pace, Fleet, Watchdog, GLM, and Brain sections from the in-worker loader', async () => {
+    const tool = makeArtanisGetFleetStatusTool({
+      loadStatus: async () => exampleFleetStatusPayload(),
+    })
+    expect(tool.kind).toBe('read')
+    expect(tool.definition.name).toBe('get_fleet_status')
+
+    const result = await Effect.runPromise(tool.execute({}))
+    expect(result).toContain('Unified fleet status')
+    expect(result).toContain('- Pace: status=behind_pace')
+    expect(result).toContain('floor=4,000')
+    expect(result).toContain('- Fleet: active=3')
+    expect(result).toContain('inFlightIssues=#6428, #6359')
+    expect(result).toContain('- Watchdog: state=active')
+    expect(result).toContain('- GLM: status=ready; ready=5/6; warm=1')
+    expect(result).toContain('- Brain: loopState=running; goals=2')
+  })
+
+  test('normalizes the /api/operator/fleet/status payload shape on the HTTP fallback path', async () => {
+    const urls: Array<string> = []
+    const fetchImpl = (async (input: RequestInfo | URL) => {
+      urls.push(typeof input === 'string' ? input : input.toString())
+      return new Response(JSON.stringify(exampleFleetStatusPayload()), {
+        status: 200,
+      })
+    }) as typeof fetch
+    const tool = makeArtanisGetFleetStatusTool({ fetchImpl })
+
+    const result = await Effect.runPromise(tool.execute({}))
+    expect(urls[0]).toBe('https://openagents.com/api/operator/fleet/status')
+    expect(result).toContain('Unified fleet status')
+    expect(result).toContain('GLM: status=ready')
+  })
+
+  test('a loader failure reads as an honest soft failure, never scattered invented status', async () => {
+    const tool = makeArtanisGetFleetStatusTool({
+      loadStatus: async () => {
+        throw new Error('d1 down')
+      },
+    })
+    const result = await Effect.runPromise(tool.execute({}))
+    expect(result).toContain('could not fetch unified fleet status')
+    expect(result).not.toContain('Pace:')
+    expect(result).not.toContain('Error:')
+  })
+
+  test('normalization rejects missing required sections and redacts unsafe free-text fields', () => {
+    expect(normalizeArtanisFleetStatus(null)).toBeNull()
+    expect(normalizeArtanisFleetStatus({ generatedAt: 'x' })).toBeNull()
+    const normalized = normalizeArtanisFleetStatus({
+      ...exampleFleetStatusPayload(),
+      brain: {
+        goalCount: 1,
+        loopState: 'running bearer sk-abc123',
+        recentDecisionRefs: ['decision.public.ok', 'secret.sk-abc123'],
+      },
+      pace: {
+        ...exampleFleetStatusPayload().pace,
+        status: 'behind bearer sk-abc123',
+      },
+    })
+    expect(normalized).not.toBeNull()
+    expect(normalized?.brain.loopState).toBe('(redacted)')
+    expect(normalized?.pace.status).toBe('(redacted)')
+    expect(normalized?.brain.recentDecisionRefs).toEqual([
+      'decision.public.ok',
+    ])
+  })
+})
+
 describe('get_synthetic_load_status (active synthetic-load runs) - iteration 12', () => {
   test('with a stubbed source returning one active run, returns a public-safe summary with run ref, state, and token-burn progress', async () => {
     const tool = makeArtanisGetSyntheticLoadStatusTool({
@@ -2222,6 +2336,7 @@ describe('makeArtanisOperatorTools default table', () => {
     const names = tools.map(tool => tool.definition.name).sort()
     expect(names).toEqual([
       'dispatch_codex_task',
+      'get_fleet_status',
       'get_glm_fleet_status',
       'get_khala_feedback',
       'get_network_stats',
@@ -2269,6 +2384,13 @@ describe('makeArtanisOperatorTools default table', () => {
   test('the default table includes a read-kind get_glm_fleet_status tool', () => {
     const tools = makeArtanisOperatorTools()
     const tool = tools.find(t => t.definition.name === 'get_glm_fleet_status')
+    expect(tool).toBeDefined()
+    expect(tool?.kind).toBe('read')
+  })
+
+  test('the default table includes a read-kind get_fleet_status tool', () => {
+    const tools = makeArtanisOperatorTools()
+    const tool = tools.find(t => t.definition.name === 'get_fleet_status')
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
   })

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -2557,6 +2557,278 @@ export const makeArtanisGetGlmFleetStatusTool = (
 }
 
 // ---------------------------------------------------------------------------
+// get_fleet_status — unified Artanis fleet-status read (#6428).
+// ---------------------------------------------------------------------------
+//
+// This is the single high-context read Artanis should prefer over scattered
+// get_network_stats / get_glm_fleet_status / list_pylon_assignments /
+// get_synthetic_load_status calls when he needs a broad operating picture. It
+// mirrors the intended `/api/operator/fleet/status` payload shape: Pace, Fleet,
+// Watchdog, GLM, and Brain. The production route wires an in-worker loader so
+// the Worker does not need to HTTP-fetch its own operator endpoint.
+
+export const ARTANIS_FLEET_STATUS_URL =
+  'https://openagents.com/api/operator/fleet/status'
+
+export type ArtanisFleetStatusPace = Readonly<{
+  todayTokens: number
+  projectedTokens: number | null
+  yesterdayTokens: number | null
+  floorTokens: number | null
+  stretchTokens: number | null
+  behindPace: boolean | null
+  status: string
+}>
+
+export type ArtanisFleetStatusFleet = Readonly<{
+  activeAssignments: number
+  recentAssignments: number
+  passCount: number
+  failCount: number
+  inProgressCount: number
+  inFlightIssues: ReadonlyArray<number>
+}>
+
+export type ArtanisFleetStatusWatchdog = Readonly<{
+  state: string
+  activeSyntheticRuns: number
+  activeLeaseCount: number
+  alertRefs: ReadonlyArray<string>
+}>
+
+export type ArtanisFleetStatusBrain = Readonly<{
+  loopState: string
+  goalCount: number
+  recentDecisionRefs: ReadonlyArray<string>
+}>
+
+export type ArtanisFleetStatusPayload = Readonly<{
+  schemaVersion: 'openagents.operator.fleet_status.v1'
+  generatedAt: string
+  pace: ArtanisFleetStatusPace
+  fleet: ArtanisFleetStatusFleet
+  watchdog: ArtanisFleetStatusWatchdog
+  glm: ArtanisGlmFleetStatus
+  brain: ArtanisFleetStatusBrain
+  caveatRefs: ReadonlyArray<string>
+}>
+
+export type ArtanisFleetStatusConfig = Readonly<{
+  url?: string | undefined
+  fetchImpl?: typeof fetch | undefined
+  loadStatus?: (() => Promise<ArtanisFleetStatusPayload>) | undefined
+}>
+
+const coerceFiniteInteger = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value)
+    ? Math.trunc(value)
+    : null
+
+const coerceNullableInteger = (value: unknown): number | null =>
+  value === null || value === undefined ? null : coerceFiniteInteger(value)
+
+const coerceNullableBoolean = (value: unknown): boolean | null =>
+  typeof value === 'boolean' ? value : null
+
+const safeStatusField = (value: unknown, fallback: string): string => {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (text === '') return fallback
+  return dispatchFieldIsSafe(text) ? text : '(redacted)'
+}
+
+const safeRefsField = (
+  value: unknown,
+  maxRefs: number = 8,
+): ReadonlyArray<string> =>
+  Array.isArray(value)
+    ? value
+        .filter((item): item is string => typeof item === 'string')
+        .map(item => item.trim())
+        .filter(item => item !== '' && dispatchFieldIsSafe(item))
+        .slice(0, maxRefs)
+    : []
+
+const safeIssueNumbersField = (value: unknown): ReadonlyArray<number> =>
+  Array.isArray(value)
+    ? value
+        .map(item => coerceFiniteInteger(item))
+        .filter((item): item is number => item !== null && item > 0)
+        .slice(0, 20)
+    : []
+
+const statusRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : {}
+
+export const normalizeArtanisFleetStatus = (
+  body: unknown,
+): ArtanisFleetStatusPayload | null => {
+  if (typeof body !== 'object' || body === null) return null
+  const record = body as Record<string, unknown>
+  const generatedAt =
+    typeof record.generatedAt === 'string' && record.generatedAt.trim() !== ''
+      ? record.generatedAt.trim()
+      : null
+  if (generatedAt === null) return null
+
+  const pace = statusRecord(record.pace)
+  const fleet = statusRecord(record.fleet)
+  const watchdog = statusRecord(record.watchdog)
+  const brain = statusRecord(record.brain)
+  const glm = normalizeArtanisGlmFleetStatus(record.glm)
+  if (glm === null) return null
+
+  const todayTokens = coerceFiniteInteger(pace.todayTokens)
+  if (todayTokens === null || todayTokens < 0) return null
+
+  return {
+    brain: {
+      goalCount: Math.max(coerceFiniteInteger(brain.goalCount) ?? 0, 0),
+      loopState: safeStatusField(brain.loopState, 'unknown'),
+      recentDecisionRefs: safeRefsField(brain.recentDecisionRefs),
+    },
+    caveatRefs: safeRefsField(record.caveatRefs, 12),
+    fleet: {
+      activeAssignments: Math.max(
+        coerceFiniteInteger(fleet.activeAssignments) ?? 0,
+        0,
+      ),
+      failCount: Math.max(coerceFiniteInteger(fleet.failCount) ?? 0, 0),
+      inFlightIssues: safeIssueNumbersField(fleet.inFlightIssues),
+      inProgressCount: Math.max(
+        coerceFiniteInteger(fleet.inProgressCount) ?? 0,
+        0,
+      ),
+      passCount: Math.max(coerceFiniteInteger(fleet.passCount) ?? 0, 0),
+      recentAssignments: Math.max(
+        coerceFiniteInteger(fleet.recentAssignments) ?? 0,
+        0,
+      ),
+    },
+    generatedAt,
+    glm,
+    pace: {
+      behindPace: coerceNullableBoolean(pace.behindPace),
+      floorTokens: coerceNullableInteger(pace.floorTokens),
+      projectedTokens: coerceNullableInteger(pace.projectedTokens),
+      status: safeStatusField(pace.status, 'unknown'),
+      stretchTokens: coerceNullableInteger(pace.stretchTokens),
+      todayTokens,
+      yesterdayTokens: coerceNullableInteger(pace.yesterdayTokens),
+    },
+    schemaVersion: 'openagents.operator.fleet_status.v1',
+    watchdog: {
+      activeLeaseCount: Math.max(
+        coerceFiniteInteger(watchdog.activeLeaseCount) ?? 0,
+        0,
+      ),
+      activeSyntheticRuns: Math.max(
+        coerceFiniteInteger(watchdog.activeSyntheticRuns) ?? 0,
+        0,
+      ),
+      alertRefs: safeRefsField(watchdog.alertRefs),
+      state: safeStatusField(watchdog.state, 'unknown'),
+    },
+  }
+}
+
+const formatNullableCount = (value: number | null): string =>
+  value === null ? 'unknown' : value.toLocaleString('en-US')
+
+const formatFleetStatusPayload = (
+  status: ArtanisFleetStatusPayload,
+): string => {
+  const issueText =
+    status.fleet.inFlightIssues.length === 0
+      ? 'none'
+      : status.fleet.inFlightIssues.map(issue => `#${issue}`).join(', ')
+  const alertText =
+    status.watchdog.alertRefs.length === 0
+      ? 'none'
+      : status.watchdog.alertRefs.join(', ')
+  const decisionText =
+    status.brain.recentDecisionRefs.length === 0
+      ? 'none'
+      : status.brain.recentDecisionRefs.join(', ')
+  const caveatText =
+    status.caveatRefs.length === 0 ? 'none' : status.caveatRefs.join(', ')
+
+  return [
+    `Unified fleet status (${status.generatedAt}):`,
+    `- Pace: status=${status.pace.status}; today=${status.pace.todayTokens.toLocaleString(
+      'en-US',
+    )}; projected=${formatNullableCount(
+      status.pace.projectedTokens,
+    )}; floor=${formatNullableCount(
+      status.pace.floorTokens,
+    )}; stretch=${formatNullableCount(
+      status.pace.stretchTokens,
+    )}; behindPace=${
+      status.pace.behindPace === null ? 'unknown' : String(status.pace.behindPace)
+    }`,
+    `- Fleet: active=${status.fleet.activeAssignments}; recent=${status.fleet.recentAssignments}; pass=${status.fleet.passCount}; fail=${status.fleet.failCount}; inProgress=${status.fleet.inProgressCount}; inFlightIssues=${issueText}`,
+    `- Watchdog: state=${status.watchdog.state}; activeSyntheticRuns=${status.watchdog.activeSyntheticRuns}; activeLeases=${status.watchdog.activeLeaseCount}; alerts=${alertText}`,
+    `- GLM: status=${status.glm.status}; ready=${status.glm.readyReplicas}/${status.glm.totalReplicas}; warm=${
+      status.glm.warmReplicas === null ? 'unknown' : status.glm.warmReplicas
+    }`,
+    `- Brain: loopState=${status.brain.loopState}; goals=${status.brain.goalCount}; recentDecisions=${decisionText}`,
+    `- Caveats: ${caveatText}`,
+  ].join('\n')
+}
+
+export const makeArtanisGetFleetStatusTool = (
+  config: ArtanisFleetStatusConfig = {},
+): ArtanisOperatorReadTool => {
+  const url = config.url ?? ARTANIS_FLEET_STATUS_URL
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch
+  const loadStatus = config.loadStatus
+
+  return {
+    definition: {
+      description:
+        'Read the unified operator fleet-status snapshot in one call: Pace (token burn and pace-to-floor), Fleet (assignment concurrency, pass/fail/in-progress counts, in-flight issues), Watchdog (leases/runs/alerts), GLM readiness, and Brain loop health. Prefer this over scattered get_network_stats/get_glm_fleet_status/list_pylon_assignments/get_synthetic_load_status calls when you need a high-context operating picture. Read-only, side-effect-free, owner-scoped; takes no arguments.',
+      name: 'get_fleet_status',
+      parameters: {
+        additionalProperties: false,
+        properties: {},
+        type: 'object',
+      },
+    },
+    execute: (_args: unknown) =>
+      Effect.gen(function* () {
+        if (loadStatus !== undefined) {
+          const exit = yield* Effect.exit(Effect.tryPromise(() => loadStatus()))
+          if (exit._tag === 'Failure') {
+            return '(could not fetch unified fleet status)'
+          }
+          return formatFleetStatusPayload(exit.value)
+        }
+
+        const response = yield* Effect.tryPromise(() =>
+          fetchImpl(url, { headers: { 'User-Agent': 'artanis-operator' } }),
+        ).pipe(Effect.orElseSucceed(() => undefined))
+        if (response === undefined) {
+          return `(could not fetch unified fleet status from ${url})`
+        }
+        if (!response.ok) {
+          return `(could not fetch unified fleet status from ${url}: status ${response.status})`
+        }
+
+        const body = yield* Effect.tryPromise(
+          () => response.json() as Promise<unknown>,
+        ).pipe(Effect.orElseSucceed(() => undefined))
+        const normalized = normalizeArtanisFleetStatus(body)
+        if (normalized === null) {
+          return `(could not fetch unified fleet status from ${url}: unexpected response shape)`
+        }
+        return formatFleetStatusPayload(normalized)
+      }),
+    kind: 'read',
+  }
+}
+
+// ---------------------------------------------------------------------------
 // get_trace_review — read the LIVE Khala trace-review report (iteration-11).
 // ---------------------------------------------------------------------------
 //
@@ -3307,6 +3579,9 @@ export const makeArtanisGetSyntheticLoadStatusTool = (
 // to an HTTP fetch of the public-safe readiness route, and an unreachable source
 // reads as an honest "(could not fetch GLM fleet status …)" rather than
 // inventing replica numbers.
+// `fleetStatus.loadStatus` is the unified #6428 fleet-status loader behind
+// `get_fleet_status`; production wires it in-worker so Artanis can read Pace,
+// Fleet, Watchdog, GLM, and Brain in one turn without scattering tool calls.
 // `syntheticLoadStatus.reader` is the owner-scoped ACTIVE synthetic-load run
 // reader behind the iteration-12 `get_synthetic_load_status` read tool (the read
 // half of the plan-only `trigger_synthetic_load` pair); with no reader wired it
@@ -3342,6 +3617,7 @@ export const makeArtanisOperatorTools = (
     defaultBranch?: string | undefined
     networkStats?: ArtanisGetNetworkStatsConfig | undefined
     glmFleetStatus?: ArtanisGlmFleetStatusConfig | undefined
+    fleetStatus?: ArtanisFleetStatusConfig | undefined
     syntheticLoadStatus?: ArtanisSyntheticLoadStatusConfig | undefined
     dispatchExecution?: ArtanisDispatchExecution | undefined
     syntheticLoad?:
@@ -3366,6 +3642,7 @@ export const makeArtanisOperatorTools = (
       owner: issueRead.owner,
       repo: issueRead.repo,
     }),
+    makeArtanisGetFleetStatusTool(config.fleetStatus),
     makeArtanisGetNetworkStatsTool(config.networkStats),
     makeArtanisGetGlmFleetStatusTool(config.glmFleetStatus),
     makeArtanisGetSyntheticLoadStatusTool(config.syntheticLoadStatus),

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -113,7 +113,10 @@ import {
 import { makeArtanisGlmFleetStatusLoader } from './artanis-operator-glm-fleet-status'
 import { makeArtanisKhalaFeedbackReader } from './artanis-operator-khala-feedback'
 import { makeArtanisTraceReviewLoader } from './artanis-operator-trace-review'
-import { makeArtanisOperatorTools } from './artanis-operator-tools'
+import {
+  type ArtanisFleetStatusPayload,
+  makeArtanisOperatorTools,
+} from './artanis-operator-tools'
 import {
   makeArtanisUnsupportedRequestsReader,
   makeArtanisUnsupportedRequestWriter,
@@ -8576,6 +8579,10 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
     }
     return makeArtanisOperatorTools({
       defaultBranch: 'main',
+      fleetStatus: {
+        loadStatus: () =>
+          loadArtanisOperatorFleetStatusPayload(env, session.user.userId),
+      },
       // get_network_stats reads the token-usage ledger directly (the worker
       // cannot reliably HTTP-fetch its own public /stats zone).
       networkStats: {
@@ -10044,6 +10051,105 @@ const khalaChatRoutes = makeKhalaChatRoutes({
   recordServedTokens: recordPublicKhalaChatServedTokens,
 })
 
+const loadArtanisOperatorFleetStatusPayload = async (
+  env: Env,
+  ownerOpenAuthUserId: string,
+): Promise<ArtanisFleetStatusPayload> => {
+  const db = openAgentsDatabase(env)
+  const nowIso = currentIsoTimestamp()
+  const listLinkedAgentUserIds = async (ownerUserId: string) => {
+    const agentStore = makeD1AgentRegistrationStore(db)
+    if (agentStore.listLinkedAgentsForOpenAuthUser === undefined) {
+      return []
+    }
+    const linked = await agentStore.listLinkedAgentsForOpenAuthUser(
+      ownerUserId,
+      100,
+    )
+    const ids = linked.map(agent => agent.agentUserId)
+    if (
+      isOpenAgentsOwnerAgentOpenAuthUserId(ownerUserId) &&
+      !ids.includes(ownerUserId)
+    ) {
+      ids.push(ownerUserId)
+    }
+    return ids
+  }
+  const [networkStats, glm, assignments] = await Promise.all([
+    loadArtanisNetworkStatsFromLedger(makeD1TokenUsageLedger(db)).catch(
+      () => null,
+    ),
+    makeArtanisGlmFleetStatusLoader({ db, env })().catch(() => ({
+      readyReplicas: 0,
+      status: 'unknown',
+      totalReplicas: 0,
+      warmReplicas: null,
+    })),
+    makeArtanisPylonAssignmentsLister({
+      listLinkedAgentUserIds,
+      nowIso: () => nowIso,
+      ownerOpenAuthUserId,
+      pylonStore: makeD1PylonApiStore(db),
+    })(100).catch(() => []),
+  ])
+  const pace = networkStats?.pace ?? null
+  const activeAssignments = assignments.filter(
+    assignment =>
+      assignment.leaseState === 'active' ||
+      ['offered', 'accepted', 'running', 'proof_submitted'].includes(
+        assignment.state,
+      ),
+  ).length
+
+  return {
+    brain: {
+      goalCount: 0,
+      loopState: 'unknown',
+      recentDecisionRefs: [],
+    },
+    caveatRefs: [
+      'caveat.operator.fleet_status.read_only_snapshot',
+      'caveat.operator.fleet_status.brain_loop_health_not_wired',
+    ],
+    fleet: {
+      activeAssignments,
+      failCount: assignments.filter(
+        assignment => assignment.verifyResult === 'fail',
+      ).length,
+      inFlightIssues: [],
+      inProgressCount: assignments.filter(
+        assignment => assignment.verifyResult === 'unknown',
+      ).length,
+      passCount: assignments.filter(
+        assignment => assignment.verifyResult === 'pass',
+      ).length,
+      recentAssignments: assignments.length,
+    },
+    generatedAt: nowIso,
+    glm,
+    pace: {
+      behindPace: pace?.behindPace ?? null,
+      floorTokens: pace?.target4x ?? null,
+      projectedTokens: pace?.paceProjection ?? null,
+      status:
+        pace === null ? 'unknown' : pace.behindPace ? 'behind_pace' : 'on_pace',
+      stretchTokens: pace?.target10x ?? null,
+      todayTokens: networkStats?.todayTokens ?? pace?.todayTokens ?? 0,
+      yesterdayTokens: pace?.yesterdayTokens ?? null,
+    },
+    schemaVersion: 'openagents.operator.fleet_status.v1',
+    watchdog: {
+      activeLeaseCount: activeAssignments,
+      activeSyntheticRuns: 0,
+      alertRefs:
+        activeAssignments > 0
+          ? []
+          : ['alert.operator.fleet_status.no_active_assignments'],
+      state: activeAssignments > 0 ? 'active' : 'idle',
+    },
+  }
+}
+
 // PRODUCER seam for the async batch-job submit route (Khala, #6028 / EPIC
 // #6017). Returns an `enqueueBatchJob` that sends the executable
 // `BatchJobQueueMessage` onto the batch-job queue so the consumer (the `queue`
@@ -10192,6 +10298,26 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         requireAdminApiToken: adminRequest =>
           requireAdminApiToken(adminRequest, env),
         store: makeD1KhalaUnsupportedRequestStore(openAgentsDatabase(env)),
+      }),
+  },
+  {
+    path: '/api/operator/fleet/status',
+    handler: (request, env) =>
+      Effect.promise(async () => {
+        if (request.method !== 'GET') {
+          return methodNotAllowed(['GET'])
+        }
+        if (!(await requireAdminApiToken(request, env))) {
+          return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
+        }
+        const url = new URL(request.url)
+        const ownerUserId =
+          url.searchParams.get('ownerUserId') ?? 'github:14167547'
+        const payload = await loadArtanisOperatorFleetStatusPayload(
+          env,
+          ownerUserId,
+        )
+        return noStoreJsonResponse(payload)
       }),
   },
   {

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -1164,6 +1164,7 @@ const intentionallyUndocumentedApiRoutes: ReadonlyArray<string> = [
   // documented `/api/public/...` routes; feedback is app/operator-internal.
   '/api/khala/feedback',
   '/api/khala/tokens',
+  '/api/operator/fleet/status',
   '/api/operator/khala/feedback',
   '/api/operator/khala/trace-review',
   '/api/operator/khala/unsupported-requests',


### PR DESCRIPTION
Addresses #6428.

### Changes
- `artanis-operator-tools.ts`: adds `makeArtanisGetFleetStatusTool`, the `ArtanisFleetStatusPayload` types, `normalizeArtanisFleetStatus` (rejects missing sections, redacts unsafe free-text, caps refs/issues), and a formatter rendering Pace/Fleet/Watchdog/GLM/Brain in one read; registers it in the default tool table.
- `index.ts`: adds `loadArtanisOperatorFleetStatusPayload` (aggregates ledger pace + GLM loader + Pylon assignments), wires it as the in-worker `loadStatus`, and exposes `GET /api/operator/fleet/status` behind admin auth.
- Marks the route intentionally undocumented in the OpenAPI test allowlist; adds tool and normalization tests.

### Verification
Not independently re-verified. PR body cites an unrelated boilerplate command (`labor-earnings-routes.test.ts`).