### PR TITLE
fix(pylon): resolve and gate Claude accounts by authenticated sibling homes

### DIFF
--- a/apps/pylon/src/account-registry.ts
+++ b/apps/pylon/src/account-registry.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto"
 import { readFileSync } from "node:fs"
-import { readFile, stat } from "node:fs/promises"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import { join, resolve } from "node:path"
 
@@ -130,10 +130,23 @@ export async function resolvePylonAccountSelection(
       candidate => candidate.provider === input.provider && candidate.ref === accountRef,
     )
     if (!entry) {
-      throw new PylonAccountSelectionError(
-        "Pylon account ref is not registered for this provider",
-        "blocker.pylon.account_ref_unknown",
+      const sibling = (await discoverPylonSiblingAccountHomes()).find(
+        candidate => candidate.provider === input.provider && candidate.ref === accountRef,
       )
+      if (!sibling) {
+        throw new PylonAccountSelectionError(
+          "Pylon account ref is not registered for this provider",
+          "blocker.pylon.account_ref_unknown",
+        )
+      }
+      await assertAccountHomePresent(sibling.home)
+      return {
+        provider: input.provider,
+        selector: "registry_ref",
+        accountRef,
+        accountRefHash: hashPylonAccountRef(input.provider, sibling.home),
+        home: sibling.home,
+      }
     }
     await assertAccountHomePresent(entry.home)
     return {
@@ -174,6 +187,44 @@ function readClaudeOauthToken(home: string): string | null {
   } catch {
     return null
   }
+}
+
+export async function pylonClaudeAccountHomeHasAuth(home: string): Promise<boolean> {
+  try {
+    const info = await stat(join(home, PYLON_CLAUDE_OAUTH_TOKEN_FILE))
+    return info.isFile() && info.size > 0
+  } catch {
+    return false
+  }
+}
+
+export async function discoverPylonSiblingAccountHomes(
+  env: Record<string, string | undefined> = process.env,
+): Promise<{ provider: PylonAccountProvider; home: string; ref: string }[]> {
+  const root = (env.PYLON_ACCOUNT_HOME_ROOT ?? "").trim() || homedir()
+  let entries: string[]
+  try {
+    entries = await readdir(root)
+  } catch {
+    return []
+  }
+  const out: { provider: PylonAccountProvider; home: string; ref: string }[] = []
+  for (const name of entries) {
+    const provider: PylonAccountProvider | null = name.startsWith(".codex")
+      ? "codex"
+      : name.startsWith(".claude")
+        ? "claude_agent"
+        : null
+    if (provider === null) continue
+    const home = join(root, name)
+    try {
+      if (!(await stat(home)).isDirectory()) continue
+    } catch {
+      continue
+    }
+    out.push({ provider, home, ref: name.replace(/^\./, "") })
+  }
+  return out
 }
 
 export function pylonAccountEnvironment(

--- a/apps/pylon/src/account-usage.ts
+++ b/apps/pylon/src/account-usage.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto"
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises"
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import {
   hashPylonAccountRef,
+  discoverPylonSiblingAccountHomes,
   loadPylonAccountRegistry,
+  pylonClaudeAccountHomeHasAuth,
   pylonAccountEnvironment,
   type PylonAccountProvider,
   type ResolvedPylonAccountSelection,
@@ -229,41 +231,6 @@ function defaultHome(provider: PylonAccountProvider, env: Record<string, string 
   }
   const configured = (env.CLAUDE_CONFIG_DIR ?? "").trim()
   return configured.length > 0 ? configured : join(homedir(), ".claude")
-}
-
-// #4953: scan the home directory for sibling account homes so a multi-account
-// setup (e.g. ~/.codex, ~/.codex-pylon-b, ~/.claude-work) surfaces every account
-// instead of only the two default homes. Read-only; best-effort (returns [] on
-// any error). The directory name (sans leading dot) is the public account ref.
-async function discoverSiblingHomes(
-  env: Record<string, string | undefined>,
-): Promise<{ provider: PylonAccountProvider; home: string; ref: string }[]> {
-  // Scan root is overridable (PYLON_ACCOUNT_HOME_ROOT) so tests stay isolated
-  // from the real home directory; production defaults to homedir().
-  const root = (env.PYLON_ACCOUNT_HOME_ROOT ?? "").trim() || homedir()
-  let entries: string[]
-  try {
-    entries = await readdir(root)
-  } catch {
-    return []
-  }
-  const out: { provider: PylonAccountProvider; home: string; ref: string }[] = []
-  for (const name of entries) {
-    const provider: PylonAccountProvider | null = name.startsWith(".codex")
-      ? "codex"
-      : name.startsWith(".claude")
-        ? "claude_agent"
-        : null
-    if (provider === null) continue
-    const home = join(root, name)
-    try {
-      if (!(await stat(home)).isDirectory()) continue
-    } catch {
-      continue
-    }
-    out.push({ provider, home, ref: name.replace(/^\./, "") })
-  }
-  return out
 }
 
 function accountIdentity(
@@ -587,7 +554,9 @@ async function readinessForTarget(
     readiness: await probeClaudeAgentReadiness({
       config,
       env: effectiveEnv,
-      localSessionProbe: () => pathIsDirectory(target.home),
+      localSessionProbe: () => target.account
+        ? pylonClaudeAccountHomeHasAuth(target.home)
+        : pathIsDirectory(target.home),
     }),
   }
 }
@@ -640,7 +609,7 @@ async function discoverAccountTargets(
   // default homes. Scan the home dir for sibling account homes (e.g.
   // ~/.codex-pylon-b, ~/.claude-work) so multi-account setups show every
   // account without manual registry entries. Read-only; deduped by provider:home.
-  for (const sibling of await discoverSiblingHomes(env)) {
+  for (const sibling of await discoverPylonSiblingAccountHomes(env)) {
     addTarget({
       provider: sibling.provider,
       selector: "registry_ref",

--- a/apps/pylon/src/presence-claude-account-capacity.test.ts
+++ b/apps/pylon/src/presence-claude-account-capacity.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import {
   claudeAccountCapacityRefs,
@@ -6,8 +9,11 @@ import {
   claudePerAccountConcurrency,
   codexAccountCapacities,
   codexAccountCapacityKey,
+  localClaudeAccountReadiness,
 } from "./presence.js"
 import { UNKEYED_ACTIVE_RUN_ACCOUNT } from "./active-assignment-runs.js"
+import { createBootstrapSummary, parseBootstrapArgs } from "./bootstrap.js"
+import { hashPylonAccountRef } from "./account-registry.js"
 
 const HASH_A = "account.pylon.claude_agent.aaaaaaaaaaaa"
 const KEY_A = "aaaaaaaaaaaa"
@@ -15,6 +21,34 @@ const HASH_B = "account.pylon.claude_agent.bbbbbbbbbbbb"
 const KEY_B = "bbbbbbbbbbbb"
 
 describe("#6421 per-account Claude capacity (Pylon side)", () => {
+  test("discovers only authenticated Claude sibling homes for per-account readiness", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pylon-claude-capacity-"))
+    try {
+      const root = join(home, "scan-root")
+      const realHome = join(root, ".claude-pylon-2")
+      const supervisorHome = join(root, ".claude-supervisor")
+      await mkdir(realHome, { recursive: true })
+      await mkdir(supervisorHome, { recursive: true })
+      await writeFile(join(realHome, "claude-oauth-token"), "sk-ant-oat-real\n")
+      const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+
+      const readiness = await localClaudeAccountReadiness(summary, {
+        PYLON_ACCOUNT_HOME_ROOT: root,
+      } as NodeJS.ProcessEnv)
+
+      expect(readiness).toContainEqual({
+        accountRefHash: hashPylonAccountRef("claude_agent", realHome),
+        ready: true,
+      })
+      expect(readiness).toContainEqual({
+        accountRefHash: hashPylonAccountRef("claude_agent", supervisorHome),
+        ready: false,
+      })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   test("capacity key is the public-safe trailing hex of the claude account-ref hash", () => {
     expect(codexAccountCapacityKey(HASH_A)).toBe(KEY_A)
   })

--- a/apps/pylon/src/presence.ts
+++ b/apps/pylon/src/presence.ts
@@ -6,9 +6,10 @@ import { PYLON_CLIENT_VERSION, type PylonClientVersion } from "./version.js"
 import type { BootstrapSummary } from "./bootstrap.js"
 import {
   hashPylonAccountRef,
+  discoverPylonSiblingAccountHomes,
   loadPylonAccountRegistry,
   normalizeAccountHome,
-  PYLON_CLAUDE_OAUTH_TOKEN_FILE,
+  pylonClaudeAccountHomeHasAuth,
 } from "./account-registry.js"
 import {
   PYLON_NIP90_PROVIDER_CAPABILITY_REF,
@@ -437,15 +438,6 @@ export function codexBusyByAccount(
 // analogue of a Codex home's `auth.json`); a non-empty token file is the
 // public-safe readiness signal. The wire only carries the trailing hex of the
 // account-ref hash, never a raw ref, email, home path, or token.
-async function claudeHomeHasAuth(home: string): Promise<boolean> {
-  try {
-    const info = await stat(join(home, PYLON_CLAUDE_OAUTH_TOKEN_FILE))
-    return info.isFile() && info.size > 0
-  } catch {
-    return false
-  }
-}
-
 // Enumerate the linked Claude accounts and whether each one's isolated home
 // holds a usable per-account login. Registry accounts are keyed by their ref
 // (matching `resolvePylonAccountSelection`'s registry_ref hash and the
@@ -456,14 +448,31 @@ async function claudeHomeHasAuth(home: string): Promise<boolean> {
 // a token file advertise a per-account slot, so the gate never sees a phantom.
 export async function localClaudeAccountReadiness(
   summary: Pick<BootstrapSummary, "paths">,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<PylonCodexAccountReadiness[]> {
   const registry = await loadPylonAccountRegistry(summary)
   const readiness: PylonCodexAccountReadiness[] = []
+  const seen = new Set<string>()
+  const seenHomes = new Set<string>()
   for (const entry of registry) {
     if (entry.provider !== "claude_agent") continue
+    const accountRefHash = hashPylonAccountRef("claude_agent", entry.ref)
+    seen.add(accountRefHash)
+    seenHomes.add(entry.home)
     readiness.push({
-      accountRefHash: hashPylonAccountRef("claude_agent", entry.ref),
-      ready: await claudeHomeHasAuth(entry.home),
+      accountRefHash,
+      ready: await pylonClaudeAccountHomeHasAuth(entry.home),
+    })
+  }
+  for (const sibling of await discoverPylonSiblingAccountHomes(env)) {
+    if (sibling.provider !== "claude_agent") continue
+    if (seenHomes.has(sibling.home)) continue
+    const accountRefHash = hashPylonAccountRef("claude_agent", sibling.home)
+    if (seen.has(accountRefHash)) continue
+    seen.add(accountRefHash)
+    readiness.push({
+      accountRefHash,
+      ready: await pylonClaudeAccountHomeHasAuth(sibling.home),
     })
   }
   return readiness
@@ -511,7 +520,7 @@ export async function localClaudeAccountCapacities(
   return codexAccountCapacities({
     busyByAccount: accountBusyCounts,
     perAccountConcurrency: claudePerAccountConcurrency(env),
-    readiness: await localClaudeAccountReadiness(summary),
+    readiness: await localClaudeAccountReadiness(summary, env),
   })
 }
 

--- a/apps/pylon/tests/account-registry.test.ts
+++ b/apps/pylon/tests/account-registry.test.ts
@@ -122,6 +122,41 @@ describe("pylon account registry", () => {
     })
   })
 
+  test("resolves discovered Claude account refs against sibling account homes", async () => {
+    await withHome(async (home) => {
+      const root = join(home, "scan-root")
+      const claudeHome = join(root, ".claude-pylon-2")
+      await mkdir(claudeHome, { recursive: true })
+      await writeFile(join(claudeHome, "claude-oauth-token"), "sk-ant-oat-discovered\n")
+      const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+      const previousRoot = process.env.PYLON_ACCOUNT_HOME_ROOT
+      process.env.PYLON_ACCOUNT_HOME_ROOT = root
+      try {
+        const resolved = await resolvePylonAccountSelection(summary, {
+          provider: "claude_agent",
+          accountRef: "claude-pylon-2",
+        })
+        expect(resolved).toMatchObject({
+          provider: "claude_agent",
+          selector: "registry_ref",
+          accountRef: "claude-pylon-2",
+          accountRefHash: hashPylonAccountRef("claude_agent", claudeHome),
+          home: claudeHome,
+        })
+
+        const env = pylonAccountEnvironment({ PATH: "/bin" }, resolved)
+        expect(env.CLAUDE_CONFIG_DIR).toBe(claudeHome)
+        expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat-discovered")
+      } finally {
+        if (previousRoot === undefined) {
+          delete process.env.PYLON_ACCOUNT_HOME_ROOT
+        } else {
+          process.env.PYLON_ACCOUNT_HOME_ROOT = previousRoot
+        }
+      }
+    })
+  })
+
   test("refuses unknown refs, ambiguous selectors, and missing homes", async () => {
     await withHome(async (home) => {
       const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })

--- a/apps/pylon/tests/account-usage.test.ts
+++ b/apps/pylon/tests/account-usage.test.ts
@@ -275,8 +275,10 @@ describe("pylon account usage", () => {
       await mkdir(join(root, ".codex-pylon-b"), { recursive: true })
       await mkdir(join(root, ".claude"), { recursive: true })
       await mkdir(join(root, ".claude-work"), { recursive: true })
+      await mkdir(join(root, ".claude-supervisor"), { recursive: true })
       await mkdir(join(root, ".unrelated"), { recursive: true })
       await writeFile(join(root, ".codex-not-a-dir"), "x")
+      await writeFile(join(root, ".claude-work", "claude-oauth-token"), "sk-ant-oat-work\n")
 
       const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
       const projection = await collectPylonAccountsList(summary, {
@@ -296,6 +298,10 @@ describe("pylon account usage", () => {
       expect(claudeHomes).toBeGreaterThanOrEqual(2)
       // The non-account dir and the regular file are ignored.
       expect(projection.accounts.some((a) => String(a.accountRef ?? "").includes("unrelated"))).toBe(false)
+      const claudeWork = projection.accounts.find((a) => a.provider === "claude_agent" && a.accountRef === "claude-work")
+      const claudeSupervisor = projection.accounts.find((a) => a.provider === "claude_agent" && a.accountRef === "claude-supervisor")
+      expect(claudeWork?.readiness.state).toBe("ready")
+      expect(claudeSupervisor?.readiness.state).not.toBe("ready")
       assertPublicProjectionSafe(projection)
     })
   })


### PR DESCRIPTION
Addresses #6430.

### Changes
- `account-registry.ts`: exports `discoverPylonSiblingAccountHomes` and `pylonClaudeAccountHomeHasAuth`; `resolvePylonAccountSelection` now falls back to discovered sibling homes (keyed by real home hash) when a ref is absent from the registry instead of throwing `account_ref_unknown`.
- `account-usage.ts`: removes the duplicate `discoverSiblingHomes` in favor of the shared discovery; per-account Claude readiness now requires a non-empty `claude-oauth-token` rather than mere directory existence.
- `presence.ts`: `localClaudeAccountReadiness` takes env, dedupes registry + sibling homes, and only advertises authenticated Claude homes (so a bogus `claude-supervisor` reads not-ready).
- Adds registry, usage, and presence-capacity tests.

### Verification
Not independently re-verified. PR body cites an unrelated boilerplate command (`labor-earnings-routes.test.ts`).