### PR TITLE
feat(worker-api): add unified GET /api/operator/fleet/status aggregator route

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -717,6 +717,7 @@ import {
 import { makeOperatorBillingHandlers } from './operator-billing-routes'
 import { makeOperatorBuyModeRoutes } from './operator-buy-mode-routes'
 import { makeOperatorEmailInspectionRoutes } from './operator-email-inspection-routes'
+import { makeOperatorFleetStatusRoutes } from './operator-fleet-status-routes'
 import { makeOperatorOrderTriageRoutes } from './operator-order-triage-routes'
 import { makeOperatorProviderAccountRoutes } from './operator-provider-account-routes'
 import { makeOperatorPylonMarketplaceRoutes } from './operator-pylon-marketplace-routes'
@@ -8888,6 +8889,10 @@ const operatorPylonMarketplaceRoutes = makeOperatorPylonMarketplaceRoutes({
   requireBrowserSession,
 })
 
+const operatorFleetStatusRoutes = makeOperatorFleetStatusRoutes({
+  requireAdminApiToken,
+})
+
 const nexusPylonVisibilityRoutes = makeNexusPylonVisibilityRoutes({
   appendRefreshedSessionCookies,
   currentIsoTimestamp,
@@ -11096,6 +11101,13 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     path: '/api/admin/inference-analytics',
     handler: (request, env, ctx) =>
       tokenUsageLedgerRoutes.handleInferenceAnalyticsApi(request, env, ctx),
+  },
+  {
+    path: '/api/operator/fleet/status',
+    handler: (request, env) =>
+      Effect.promise(() =>
+        operatorFleetStatusRoutes.handleOperatorFleetStatusApi(request, env),
+      ),
   },
   {
     path: '/api/stats/token-usage/leaderboards',

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -1216,6 +1216,10 @@ const intentionallyUndocumentedApiRoutes: ReadonlyArray<string> = [
   // Owner-gated inference cost / provider-lane analytics (#6232): internal cost
   // + provider data, owner session only, not part of the public OpenAPI surface.
   '/api/admin/inference-analytics',
+  // Operator fleet status aggregator (#6427): admin/operator snapshot for
+  // internal Artanis and fleet surfaces; public pages consume a later
+  // public-safe projection, not this operator route directly.
+  '/api/operator/fleet/status',
   '/api/admin/provider-accounts/usage',
   '/api/admin/sync/notify',
   // Self-hosted trace media blob serving (#6223): serves the public-safe R2 blob

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  clearOperatorFleetStatusCacheForTests,
+  makeOperatorFleetStatusRoutes,
+} from './operator-fleet-status-routes'
+
+type QueryLog = Array<string>
+
+class FakeStatement {
+  constructor(
+    private readonly sql: string,
+    private readonly log: QueryLog,
+  ) {}
+
+  bind(): FakeStatement {
+    return this
+  }
+
+  async all<T>(): Promise<{ results: ReadonlyArray<T> }> {
+    this.log.push(this.sql)
+    return { results: rowsForSql(this.sql) as ReadonlyArray<T> }
+  }
+
+  async first<T>(): Promise<T | null> {
+    this.log.push(this.sql)
+    const rows = rowsForSql(this.sql)
+    return (rows[0] ?? null) as T | null
+  }
+}
+
+const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
+  if (sql.includes('FROM pylon_api_registrations')) {
+    return [
+      {
+        capability_refs_json: JSON.stringify(['capability.pylon.local_codex']),
+        latest_capacity_refs_json: JSON.stringify([
+          'capacity.coding.codex.available=3',
+          'capacity.coding.codex.ready=2',
+        ]),
+        latest_heartbeat_at: '2026-06-27T18:40:55.000Z',
+        latest_load_refs_json: JSON.stringify([
+          'load.coding.codex.busy=1',
+          'load.coding.codex.queued=0',
+        ]),
+        owner_agent_user_id: 'agent_owner_public',
+        pylon_ref: 'pylon.public.codex_one',
+        status: 'active',
+      },
+    ]
+  }
+
+  if (sql.includes('FROM pylon_api_assignments')) {
+    return [
+      {
+        assignment_ref: 'assignment.public.issue_6427',
+        created_at: '2026-06-27T18:30:00.000Z',
+        job_kind: 'codex_agent_task',
+        lease_expires_at: '2026-06-27T19:30:00.000Z',
+        pylon_ref: 'pylon.public.codex_one',
+        state: 'running',
+        updated_at: '2026-06-27T18:39:00.000Z',
+      },
+    ]
+  }
+
+  if (sql.includes('FROM fleet_alerts')) {
+    return [
+      {
+        active_assignments: 1,
+        alert_ref: 'alert.public.fleet.stalled',
+        classification: 'stalled',
+        detected_at: '2026-06-27T18:39:30.000Z',
+        queued_assignments: 0,
+        reason_ref: 'reason.public.fleet.no_token_burn',
+      },
+    ]
+  }
+
+  if (sql.includes('tokens_today')) {
+    return [{ tokens_today: 1200 }]
+  }
+
+  if (sql.includes('tokens_yesterday')) {
+    return [{ tokens_yesterday: 250 }]
+  }
+
+  if (sql.includes('tokens_window')) {
+    return [{ tokens_window: 600 }]
+  }
+
+  if (sql.includes('FROM artanis_owner_memory')) {
+    return [
+      {
+        body: 'Fan out bounded public issue work through caller-owned Codex capacity.',
+        created_at: '2026-06-27T18:38:00.000Z',
+        memory_ref: 'decision.public.artanis.codex_burndown',
+        note_category: 'decision',
+      },
+    ]
+  }
+
+  if (sql.includes('FROM glm_fleet_readiness_heartbeats')) {
+    return [
+      { health_status: 'ok', replica_id: 'glm-1' },
+      { health_status: 'degraded', replica_id: 'glm-2' },
+    ]
+  }
+
+  return []
+}
+
+const fakeDb = (log: QueryLog): D1Database =>
+  ({
+    prepare: (sql: string) => new FakeStatement(sql, log),
+  }) as unknown as D1Database
+
+const request = (method = 'GET'): Request =>
+  new Request('https://openagents.com/api/operator/fleet/status', { method })
+
+describe('operator fleet status route', () => {
+  test('requires GET', async () => {
+    clearOperatorFleetStatusCacheForTests()
+    const routes = makeOperatorFleetStatusRoutes({
+      requireAdminApiToken: async () => true,
+    })
+    const response = await routes.handleOperatorFleetStatusApi(
+      request('POST'),
+      { OPENAGENTS_DB: fakeDb([]) },
+    )
+
+    expect(response.status).toBe(405)
+  })
+
+  test('requires operator auth', async () => {
+    clearOperatorFleetStatusCacheForTests()
+    const routes = makeOperatorFleetStatusRoutes({
+      requireAdminApiToken: async () => false,
+    })
+    const response = await routes.handleOperatorFleetStatusApi(
+      request(),
+      { OPENAGENTS_DB: fakeDb([]) },
+    )
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+  })
+
+  test('returns one cached public-safe fleet snapshot', async () => {
+    clearOperatorFleetStatusCacheForTests()
+    const log: QueryLog = []
+    const routes = makeOperatorFleetStatusRoutes({
+      currentIsoTimestamp: () => '2026-06-27T18:41:00.000Z',
+      requireAdminApiToken: async () => true,
+    })
+    const env = { OPENAGENTS_DB: fakeDb(log) }
+    const first = await routes.handleOperatorFleetStatusApi(request(), env)
+    const second = await routes.handleOperatorFleetStatusApi(request(), env)
+    const body = await first.json() as Record<string, any>
+    const cachedBody = await second.json() as Record<string, any>
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(first.headers.get('x-openagents-cache')).toBe('miss')
+    expect(second.headers.get('x-openagents-cache')).toBe('hit')
+    expect(log.length).toBeGreaterThan(0)
+    expect(log.length).toBe(8)
+    expect(cachedBody).toEqual(body)
+    expect(body).toMatchObject({
+      authority: {
+        buyerChargeMutationAllowed: false,
+        dispatchMutationAllowed: false,
+        payoutMutationAllowed: false,
+        settlementMutationAllowed: false,
+      },
+      brain: {
+        loopHealth: 'stalled',
+      },
+      fleet: {
+        activeAssignmentCount: 1,
+        activeSlots: 3,
+        busySlots: 1,
+        queuedSlots: 0,
+        readySlots: 2,
+      },
+      generatedAt: '2026-06-27T18:41:00.000Z',
+      glm: {
+        readyReplicas: 1,
+        status: 'degraded',
+        totalReplicas: 2,
+      },
+      pace: {
+        liveBurnRateTokensPerMinute: 60,
+        paceToFloor: 'ahead',
+        targetFloorTokens: 1000,
+        todayTokens: 1200,
+        yesterdayTokens: 250,
+      },
+      schemaVersion: 'operator.fleet_status.v1',
+      watchdog: {
+        activeLeases: 1,
+        state: 'STALLED',
+      },
+    })
+    expect(JSON.stringify(body)).not.toContain('/Users/')
+    expect(JSON.stringify(body)).not.toContain('auth.json')
+    expect(JSON.stringify(body)).not.toContain('Fan out bounded')
+  })
+})

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -1,0 +1,391 @@
+import { jsonResponse } from '@openagentsinc/sync-worker'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import { parseJsonStringArray } from './json-boundary'
+import { openAgentsDatabase } from './runtime'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const OPERATOR_FLEET_STATUS_PATH = '/api/operator/fleet/status'
+const CACHE_TTL_MILLIS = 10_000
+
+type OperatorFleetStatusEnv = Readonly<{
+  OPENAGENTS_DB: D1Database
+}>
+
+type OperatorFleetStatusDependencies<Bindings extends OperatorFleetStatusEnv> =
+  Readonly<{
+    currentIsoTimestamp?: () => string
+    requireAdminApiToken: (request: Request, env: Bindings) => Promise<boolean>
+  }>
+
+type D1Rows<T> = Readonly<{ results?: ReadonlyArray<T> }>
+
+type PylonRegistrationRow = Readonly<{
+  pylon_ref: string
+  owner_agent_user_id: string
+  latest_heartbeat_at: string | null
+  latest_capacity_refs_json: string | null
+  latest_load_refs_json: string | null
+  capability_refs_json: string | null
+  status: string | null
+}>
+
+type AssignmentRow = Readonly<{
+  assignment_ref: string
+  pylon_ref: string
+  job_kind: string
+  state: string
+  created_at: string
+  updated_at: string
+  lease_expires_at: string
+}>
+
+type AlertRow = Readonly<{
+  alert_ref: string
+  classification: string
+  detected_at: string
+  reason_ref: string
+  active_assignments: number
+  queued_assignments: number
+}>
+
+type TokenTodayRow = Readonly<{ tokens_today: number | null }>
+type TokenYesterdayRow = Readonly<{ tokens_yesterday: number | null }>
+type TokenWindowRow = Readonly<{ tokens_window: number | null }>
+type BrainRow = Readonly<{
+  memory_ref: string
+  created_at: string
+  note_category: string | null
+}>
+
+type GlmHeartbeatRow = Readonly<{
+  replica_id: string
+  health_status: string | null
+}>
+
+type CacheEntry = Readonly<{
+  expiresAt: number
+  generatedAt: string
+  response: unknown
+}>
+
+const snapshotCache = new Map<string, CacheEntry>()
+
+export const clearOperatorFleetStatusCacheForTests = (): void => {
+  snapshotCache.clear()
+}
+
+const metricFromRefs = (
+  refs: ReadonlyArray<string>,
+  prefix: string,
+): number => {
+  const ref = refs.find(item => item.startsWith(prefix))
+  const raw = ref?.slice(prefix.length)
+  const value = raw === undefined ? Number.NaN : Number.parseInt(raw, 10)
+  return Number.isFinite(value) ? Math.max(0, value) : 0
+}
+
+const millisBetween = (startIso: string, endIso: string): number => {
+  const start = Date.parse(startIso)
+  const end = Date.parse(endIso)
+  return Number.isFinite(start) && Number.isFinite(end)
+    ? Math.max(0, end - start)
+    : 0
+}
+
+const safeAll = async <T>(
+  db: D1Database,
+  sql: string,
+  ...bindings: ReadonlyArray<unknown>
+): Promise<ReadonlyArray<T>> => {
+  try {
+    const statement = db.prepare(sql)
+    const query =
+      bindings.length === 0 ? statement : statement.bind(...bindings)
+    const result = await query.all<T>() as D1Rows<T>
+    return result.results ?? []
+  } catch {
+    return []
+  }
+}
+
+const safeFirst = async <T>(
+  db: D1Database,
+  sql: string,
+  ...bindings: ReadonlyArray<unknown>
+): Promise<T | null> => {
+  try {
+    const statement = db.prepare(sql)
+    const query =
+      bindings.length === 0 ? statement : statement.bind(...bindings)
+    return await query.first<T>()
+  } catch {
+    return null
+  }
+}
+
+const buildFleetStatusSnapshot = async (
+  db: D1Database,
+  nowIso: string,
+): Promise<unknown> => {
+  const [
+    registrations,
+    assignments,
+    latestAlert,
+    today,
+    yesterday,
+    window,
+    brainRows,
+    glmRows,
+  ] = await Promise.all([
+    safeAll<PylonRegistrationRow>(
+      db,
+      `SELECT pylon_ref, owner_agent_user_id, latest_heartbeat_at,
+              latest_capacity_refs_json, latest_load_refs_json,
+              capability_refs_json, status
+         FROM pylon_api_registrations
+        WHERE archived_at IS NULL
+        ORDER BY updated_at DESC
+        LIMIT 100`,
+    ),
+    safeAll<AssignmentRow>(
+      db,
+      `SELECT assignment_ref, pylon_ref, job_kind, state, created_at, updated_at,
+              lease_expires_at
+         FROM pylon_api_assignments
+        WHERE archived_at IS NULL
+          AND state IN ('offered','accepted','running','proof_submitted')
+        ORDER BY updated_at DESC
+        LIMIT 50`,
+    ),
+    safeFirst<AlertRow>(
+      db,
+      `SELECT alert_ref, classification, detected_at, reason_ref,
+              active_assignments, queued_assignments
+         FROM fleet_alerts
+        ORDER BY detected_at DESC
+        LIMIT 1`,
+    ),
+    safeFirst<TokenTodayRow>(
+      db,
+      `SELECT COALESCE(SUM(total_tokens), 0) AS tokens_today
+         FROM token_usage_events
+        WHERE observed_at >= datetime('now', 'start of day')`,
+    ),
+    safeFirst<TokenYesterdayRow>(
+      db,
+      `SELECT COALESCE(SUM(total_tokens), 0) AS tokens_yesterday
+         FROM token_usage_events
+        WHERE observed_at >= datetime('now', 'start of day', '-1 day')
+          AND observed_at < datetime('now', 'start of day')`,
+    ),
+    safeFirst<TokenWindowRow>(
+      db,
+      `SELECT COALESCE(SUM(total_tokens), 0) AS tokens_window
+         FROM token_usage_events
+        WHERE observed_at >= datetime('now', '-10 minutes')`,
+    ),
+    safeAll<BrainRow>(
+      db,
+      `SELECT memory_ref, created_at, note_category
+         FROM artanis_owner_memory
+        WHERE kind = 'note'
+          AND note_category = 'decision'
+        ORDER BY created_at DESC
+        LIMIT 3`,
+    ),
+    safeAll<GlmHeartbeatRow>(
+      db,
+      `SELECT replica_id, health_status
+         FROM glm_fleet_readiness_heartbeats
+        ORDER BY observed_at DESC
+        LIMIT 50`,
+    ),
+  ])
+
+  const nowMs = Date.parse(nowIso)
+  const activeFreshCutoffMs = nowMs - 90_000
+  const fleetAccounts = registrations.map(row => {
+    const capacityRefs = parseJsonStringArray(row.latest_capacity_refs_json)
+    const loadRefs = parseJsonStringArray(row.latest_load_refs_json)
+    const capabilityRefs = parseJsonStringArray(row.capability_refs_json)
+    const latestHeartbeatMs =
+      row.latest_heartbeat_at === null ? Number.NaN : Date.parse(row.latest_heartbeat_at)
+    const heartbeatFresh =
+      Number.isFinite(latestHeartbeatMs) && latestHeartbeatMs >= activeFreshCutoffMs
+    return {
+      pylonRef: row.pylon_ref,
+      status: row.status ?? 'unknown',
+      heartbeatFresh,
+      latestHeartbeatAt: row.latest_heartbeat_at,
+      activeSlots: metricFromRefs(capacityRefs, 'capacity.coding.codex.available='),
+      readySlots: metricFromRefs(capacityRefs, 'capacity.coding.codex.ready='),
+      busySlots: metricFromRefs(loadRefs, 'load.coding.codex.busy='),
+      queuedSlots: metricFromRefs(loadRefs, 'load.coding.codex.queued='),
+      codexCapable: capabilityRefs.some(ref => ref.includes('codex')),
+    }
+  })
+
+  const activeSlots = fleetAccounts.reduce((sum, account) => sum + account.activeSlots, 0)
+  const readySlots = fleetAccounts.reduce((sum, account) => sum + account.readySlots, 0)
+  const busySlots = fleetAccounts.reduce((sum, account) => sum + account.busySlots, 0)
+  const queuedSlots = fleetAccounts.reduce((sum, account) => sum + account.queuedSlots, 0)
+  const activeAssignments = assignments.filter(row =>
+    row.state === 'accepted' || row.state === 'running' || row.state === 'proof_submitted',
+  )
+
+  const todayTokens = Math.max(0, Math.trunc(today?.tokens_today ?? 0))
+  const yesterdayTokens = Math.max(0, Math.trunc(yesterday?.tokens_yesterday ?? 0))
+  const windowTokens = Math.max(0, Math.trunc(window?.tokens_window ?? 0))
+  const burnRateTokensPerMinute = Math.round(windowTokens / 10)
+  const targetFloor = yesterdayTokens * 4
+  const paceToFloor =
+    targetFloor === 0 ? 'no_floor' : todayTokens >= targetFloor ? 'ahead' : 'behind'
+
+  const latestAlertAgeMs =
+    latestAlert === null ? Number.POSITIVE_INFINITY : millisBetween(latestAlert.detected_at, nowIso)
+  const watchdogState =
+    latestAlert === null || latestAlertAgeMs > 5 * 60_000
+      ? 'HEALTHY'
+      : latestAlert.classification === 'stalled'
+        ? 'STALLED'
+        : 'RECOVERING'
+
+  const uniqueGlmReplicas = new Map<string, string | null>()
+  for (const row of glmRows) {
+    if (!uniqueGlmReplicas.has(row.replica_id)) {
+      uniqueGlmReplicas.set(row.replica_id, row.health_status)
+    }
+  }
+  const glmReady = [...uniqueGlmReplicas.values()].filter(status =>
+    status === 'ok' || status === 'ready' || status === 'healthy',
+  ).length
+  const glmTotal = uniqueGlmReplicas.size
+
+  return {
+    schemaVersion: 'operator.fleet_status.v1',
+    generatedAt: nowIso,
+    cache: {
+      maxAgeSeconds: 10,
+      source: 'worker_memory_ttl',
+    },
+    authority: {
+      buyerChargeMutationAllowed: false,
+      dispatchMutationAllowed: false,
+      payoutMutationAllowed: false,
+      settlementMutationAllowed: false,
+    },
+    pace: {
+      liveBurnRateTokensPerMinute: burnRateTokensPerMinute,
+      paceToFloor,
+      todayTokens,
+      yesterdayTokens,
+      targetFloorTokens: targetFloor,
+      sourceRefs: ['d1:token_usage_events'],
+    },
+    fleet: {
+      activeSlots,
+      readySlots,
+      busySlots,
+      queuedSlots,
+      spread: fleetAccounts,
+      inFlightAssignments: assignments.map(row => ({
+        assignmentRef: row.assignment_ref,
+        pylonRef: row.pylon_ref,
+        jobKind: row.job_kind,
+        state: row.state,
+        elapsedMs: millisBetween(row.created_at, nowIso),
+        updatedAt: row.updated_at,
+        leaseExpiresAt: row.lease_expires_at,
+      })),
+      activeAssignmentCount: activeAssignments.length,
+      sourceRefs: ['d1:pylon_api_registrations', 'd1:pylon_api_assignments'],
+    },
+    watchdog: {
+      state: watchdogState,
+      lastCronHeartbeatAt: latestAlert?.detected_at ?? null,
+      activeLeases: activeAssignments.length,
+      activeAlerts: latestAlert === null || latestAlertAgeMs > 5 * 60_000 ? [] : [{
+        alertRef: latestAlert.alert_ref,
+        classification: latestAlert.classification,
+        reasonRef: latestAlert.reason_ref,
+        detectedAt: latestAlert.detected_at,
+      }],
+      sourceRefs: ['d1:fleet_alerts', 'd1:pylon_api_assignments'],
+    },
+    glm: {
+      status: glmTotal === 0 ? 'unknown' : glmReady === glmTotal ? 'ready' : 'degraded',
+      readyReplicas: glmReady,
+      totalReplicas: glmTotal,
+      sourceRefs: ['d1:glm_fleet_readiness_heartbeats'],
+      caveatRefs: glmTotal === 0 ? ['caveat.public.operator_fleet_status.glm_heartbeat_rows_missing'] : [],
+    },
+    brain: {
+      loopHealth: watchdogState === 'STALLED' ? 'stalled' : 'healthy',
+      currentGoals: [
+        {
+          goalRef: 'goal.public.artanis.serve_token_pace',
+          state: paceToFloor,
+        },
+      ],
+      recentDecisions: brainRows.map(row => ({
+        decisionRef: row.memory_ref,
+        createdAt: row.created_at,
+        summaryRef: `summary.public.artanis_decision.${row.memory_ref}`,
+      })),
+      sourceRefs: ['d1:artanis_owner_memory'],
+    },
+  }
+}
+
+export const makeOperatorFleetStatusRoutes = <
+  Bindings extends OperatorFleetStatusEnv,
+>(
+  dependencies: OperatorFleetStatusDependencies<Bindings>,
+) => ({
+  handleOperatorFleetStatusApi: async (
+    request: Request,
+    env: Bindings,
+  ) => {
+    if (request.method !== 'GET') {
+      return methodNotAllowed(['GET'])
+    }
+
+    if (!(await dependencies.requireAdminApiToken(request, env))) {
+      return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
+    }
+
+    const nowIso = (dependencies.currentIsoTimestamp ?? currentIsoTimestamp)()
+    const cacheKey = 'operator:fleet:status:v1'
+    const cached = snapshotCache.get(cacheKey)
+    const nowMs = Date.parse(nowIso)
+    if (
+      cached !== undefined &&
+      Number.isFinite(nowMs) &&
+      cached.expiresAt > nowMs
+    ) {
+      return jsonResponse(cached.response, {
+        headers: {
+          'cache-control': 'private, max-age=10',
+          'x-openagents-cache': 'hit',
+        },
+      })
+    }
+
+    const response = await buildFleetStatusSnapshot(openAgentsDatabase(env), nowIso)
+    if (Number.isFinite(nowMs)) {
+      snapshotCache.set(cacheKey, {
+        expiresAt: nowMs + CACHE_TTL_MILLIS,
+        generatedAt: nowIso,
+        response,
+      })
+    }
+
+    return jsonResponse(response, {
+      headers: {
+        'cache-control': 'private, max-age=10',
+        'x-openagents-cache': 'miss',
+      },
+    })
+  },
+})

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -87,6 +87,7 @@ const approvedExactRoutePaths = [
   '/api/stats/token-usage/events',
   '/api/stats/token-usage/aggregate',
   '/api/admin/inference-analytics',
+  '/api/operator/fleet/status',
   '/api/stats/token-usage/leaderboards',
   '/api/stats/token-usage/leaderboard-preference',
   '/api/auth/teams',


### PR DESCRIPTION
Addresses #6427.

### Changes
- Adds `operator-fleet-status-routes.ts` (399 lines) implementing a single admin-gated aggregator that composes Pace, Fleet, Watchdog, GLM, and Brain into one JSON snapshot (cached projection to protect D1/DO/Analytics Engine).
- Wires the route into `index.ts` and updates the OpenAPI and worker-exact-route allowlists.
- Adds `operator-fleet-status-routes.test.ts` (209 lines) covering the aggregated snapshot shape.

### Verification
Not independently re-verified. PR body cites an unrelated boilerplate command (`labor-earnings-routes.test.ts`).