### PR TITLE
fix(pylon): hold repository cache lock when owner process is still live

### DIFF
--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -609,6 +609,38 @@ async function sleep(ms: number): Promise<void> {
 
 type RepositoryCacheProcessLock = { lockDirectory: string; heartbeat: ReturnType<typeof setInterval> }
 
+type RepositoryCacheProcessLockOwner = {
+  pid: number
+  acquiredAt?: string
+}
+
+function repositoryCacheLockOwnerFrom(value: unknown): RepositoryCacheProcessLockOwner | null {
+  if (value === null || typeof value !== "object") return null
+  const record = value as { pid?: unknown; acquiredAt?: unknown }
+  if (typeof record.pid !== "number" || !Number.isInteger(record.pid) || record.pid <= 0) return null
+  return {
+    pid: record.pid,
+    ...(typeof record.acquiredAt === "string" ? { acquiredAt: record.acquiredAt } : {}),
+  }
+}
+
+export async function repositoryCacheProcessLockOwnerIsLive(lockDirectory: string): Promise<boolean> {
+  let owner: RepositoryCacheProcessLockOwner | null = null
+  try {
+    owner = repositoryCacheLockOwnerFrom(JSON.parse(await readFile(join(lockDirectory, "owner.json"), "utf8")))
+  } catch {
+    return false
+  }
+  if (owner === null) return false
+  try {
+    process.kill(owner.pid, 0)
+    return true
+  } catch (error) {
+    const code = error instanceof Error && "code" in error ? (error as { code?: unknown }).code : undefined
+    return code === "EPERM"
+  }
+}
+
 async function acquireRepositoryCacheProcessLock(bareDirectory: string): Promise<RepositoryCacheProcessLock> {
   const lockDirectory = `${bareDirectory}.pylon-lock`
   const startedAt = Date.now()
@@ -641,6 +673,10 @@ async function acquireRepositoryCacheProcessLock(bareDirectory: string): Promise
 
     const now = Date.now()
     if (now - lockStat.mtimeMs > repositoryCacheProcessLockStaleMs) {
+      if (await repositoryCacheProcessLockOwnerIsLive(lockDirectory)) {
+        await sleep(repositoryCacheProcessLockPollMs)
+        continue
+      }
       await rm(lockDirectory, { recursive: true, force: true })
       continue
     }

--- a/apps/pylon/tests/workspace-worktree.test.ts
+++ b/apps/pylon/tests/workspace-worktree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { existsSync } from "node:fs"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
@@ -13,6 +13,7 @@ import {
   publicWorkspaceChangeCaptureProjection,
   publicWorkspaceLeaseProjection,
   releaseWorkspace,
+  repositoryCacheProcessLockOwnerIsLive,
   repositoryCacheKeyFor,
   stageWorkspacePaths,
   withWorkspaceMaterializerCapability,
@@ -549,6 +550,24 @@ describe("materializeGitCheckoutWorkspaceWithLease", () => {
       }
       // every assignment got its own isolated working tree
       expect(dirs.size).toBe(concurrency)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("does not treat a stale lock mtime as abandoned while the owner process is live", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-worktree-live-lock-"))
+    try {
+      const lockDirectory = join(root, "repo.git.pylon-lock")
+      await mkdir(lockDirectory, { recursive: true })
+      await writeFile(
+        join(lockDirectory, "owner.json"),
+        `${JSON.stringify({ pid: process.pid, acquiredAt: new Date(0).toISOString() }, null, 2)}\n`,
+      )
+      const old = new Date(Date.now() - 5 * 60 * 1000)
+      await utimes(lockDirectory, old, old)
+
+      await expect(repositoryCacheProcessLockOwnerIsLive(lockDirectory)).resolves.toBe(true)
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
Addresses #6434.

### Changes
- Adds `repositoryCacheProcessLockOwnerIsLive` in `apps/pylon/src/workspace-materializer.ts`: reads `owner.json` (pid/acquiredAt) from a lock directory and probes liveness via `process.kill(pid, 0)` (treats `EPERM` as live).
- In `acquireRepositoryCacheProcessLock`, before deleting a lock whose mtime looks stale, it now checks owner liveness; if the owner process is alive it polls and continues instead of tearing down a live lock, preventing concurrent-checkout collisions on the materialization source.
- Adds a test asserting a stale mtime is not treated as abandoned while the owner pid is live.

### Verification
Not independently re-verified. (New `bun:test` case `does not treat a stale lock mtime as abandoned while the owner process is live`.)