### PR TITLE
fix(khala): tighten CLI spacing, continue on length-finish, add read-only Artanis signature

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/khala-identity.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-identity.ts
@@ -79,6 +79,7 @@ export const KhalaSignatureId = S.Literals([
   'identity',
   'refusal_posture',
   'response_discipline',
+  'artanis_interaction',
 ])
 export type KhalaSignatureId = typeof KhalaSignatureId.Type
 
@@ -311,6 +312,23 @@ export const KHALA_IDENTITY_STATEMENT =
 
 export const KHALA_STANDARD_GREETING =
   'We are Khala. How can we help?'
+
+export const KHALA_ARTANIS_PUBLIC_READ_ONLY_ANSWER = [
+  'Artanis is the OpenAgents operator agent, not the StarCraft character.',
+  'You can observe public-safe Artanis state and activity at https://openagents.com/agents/artanis, the public report endpoint /api/public/artanis/report, and the launch dashboard /api/public/launch-dashboard.',
+  'This public Khala lane is read-only: we can summarize where to look and explain public decisions or fleet status, but we cannot command Artanis, dispatch work, spend funds, or use owner-only operator tools from here.',
+].join(' ')
+
+export const KHALA_ARTANIS_INTERACTION_SYSTEM_PROMPT = [
+  'Artanis interaction signature: when a user asks about Artanis, interpret Artanis as the OpenAgents operator agent, not a game/lore character.',
+  'The public Khala lane may answer read-only questions about Artanis using public-safe surfaces such as /agents/artanis, /api/public/artanis/report, /api/public/launch-dashboard, public activity, and fleet-status summaries.',
+  'Never roleplay StarCraft lore for Artanis unless the user explicitly asks for the game character. Never claim this public lane can command Artanis, dispatch work, spend funds, or access owner-only operator state.',
+].join(' ')
+
+export const isKhalaArtanisPublicReadOnlyPrompt = (input: string): boolean => {
+  const normalized = input.trim().toLowerCase()
+  return /\bartanis\b/u.test(normalized) && !/\bstarcraft\b|\bprotoss\b|\bdaelaam\b|\bhierarch\b/u.test(normalized)
+}
 
 // The reinforcement instruction the route prepends on a re-ask when identity is
 // violated (the LLM-side correction — the preferred correction path).
@@ -633,6 +651,41 @@ export const KHALA_RESPONSE_DISCIPLINE_SIGNATURE: KhalaSignature = {
 // The signature registry (extensible set; identity is #1).
 // ---------------------------------------------------------------------------
 
+export const KHALA_ARTANIS_INTERACTION_SIGNATURE: KhalaSignature = {
+  correctText: (completion: string): string => completion,
+  description:
+    'Khala recognizes Artanis as the OpenAgents operator agent for Artanis-related public questions, keeps the answer read-only, and does not fall through to game lore unless explicitly requested.',
+  id: 'artanis_interaction',
+  reinforcementPrompt: KHALA_ARTANIS_INTERACTION_SYSTEM_PROMPT,
+  verify: (completion: string): KhalaSignatureVerdict => {
+    const lower = completion.toLowerCase()
+    const mentionsArtanis = lower.includes('artanis')
+    if (!mentionsArtanis) {
+      return {
+        reason: '',
+        satisfied: true,
+        signature: 'artanis_interaction',
+        violations: [],
+      }
+    }
+    const loreOnly =
+      /\bstarcraft\b|\bprotoss\b|\bdaelaam\b|\bhierarch\b|\bnerve cords\b/u.test(lower) &&
+      !/\bopenagents\b|\boperator agent\b|\bread-only\b/u.test(lower)
+    const unsafeCommandClaim =
+      /\b(?:i|we) (?:can|will) (?:command|dispatch|spend|approve|pay|execute)\b/u.test(lower)
+    const violations = [
+      ...(loreOnly ? [{ text: 'artanis_lore_fallback' }] : []),
+      ...(unsafeCommandClaim ? [{ text: 'artanis_public_command_claim' }] : []),
+    ]
+    return {
+      reason: violations.length === 0 ? '' : 'artanis_interaction_contract',
+      satisfied: violations.length === 0,
+      signature: 'artanis_interaction',
+      violations,
+    }
+  },
+}
+
 // Ordered registry of Khala signatures. Identity is first, refusal posture is
 // second, response discipline is third. New signatures append here and are
 // picked up by `verifyKhalaSignatures` / the route guard without further wiring.
@@ -641,6 +694,7 @@ export const KHALA_SIGNATURES: ReadonlyArray<KhalaSignature> = [
   KHALA_IDENTITY_SIGNATURE,
   KHALA_REFUSAL_POSTURE_SIGNATURE,
   KHALA_RESPONSE_DISCIPLINE_SIGNATURE,
+  KHALA_ARTANIS_INTERACTION_SIGNATURE,
 ]
 
 export const getKhalaSignature = (

--- a/apps/openagents.com/workers/api/src/khala-chat-program.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-program.ts
@@ -27,11 +27,14 @@ import { Effect, Schema as S } from 'effect'
 import type { OnboardingStreamSource } from './autopilot-onboarding-program'
 import { OnboardingInferenceError } from './autopilot-onboarding-program'
 import {
+  KHALA_ARTANIS_INTERACTION_SYSTEM_PROMPT,
+  KHALA_ARTANIS_PUBLIC_READ_ONLY_ANSWER,
   KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT,
   KHALA_IDENTITY_SYSTEM_PROMPT,
   KHALA_REFUSAL_POSTURE_SYSTEM_PROMPT,
   KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT,
   KHALA_STANDARD_GREETING,
+  isKhalaArtanisPublicReadOnlyPrompt,
 } from './inference/khala-identity'
 import {
   type InferenceMessage,
@@ -203,7 +206,7 @@ export const buildKhalaChatMessages = (
 ): ReadonlyArray<InferenceMessage> => [
   {
     role: 'system',
-    content: `${KHALA_IDENTITY_SYSTEM_PROMPT} ${KHALA_REFUSAL_POSTURE_SYSTEM_PROMPT} ${KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT} ${KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT} ${KHALA_CHAT_INSTRUCTION}${khalaChatContextInstruction(context)}`,
+    content: `${KHALA_IDENTITY_SYSTEM_PROMPT} ${KHALA_REFUSAL_POSTURE_SYSTEM_PROMPT} ${KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT} ${KHALA_CAPABILITY_TRUTH_SYSTEM_PROMPT} ${KHALA_ARTANIS_INTERACTION_SYSTEM_PROMPT} ${KHALA_CHAT_INSTRUCTION}${khalaChatContextInstruction(context)}`,
   },
   ...messages.map(message => ({
     role: message.role,
@@ -254,3 +257,14 @@ export const isKhalaFastGreetingTurn = (
     normalizeKhalaFastPrompt(message.content),
   )
 }
+
+export const isKhalaArtanisPublicReadOnlyTurn = (
+  messages: ReadonlyArray<KhalaChatMessage>,
+): boolean => {
+  const message = messages[messages.length - 1]
+  return message !== undefined &&
+    message.role === 'user' &&
+    isKhalaArtanisPublicReadOnlyPrompt(message.content)
+}
+
+export { KHALA_ARTANIS_PUBLIC_READ_ONLY_ANSWER }

--- a/apps/openagents.com/workers/api/src/khala-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-routes.test.ts
@@ -281,6 +281,34 @@ describe('khala chat route', () => {
     )
   })
 
+  test('answers Artanis questions through the public read-only operator-agent signature', async () => {
+    let openedProvider = false
+    const routes = makeKhalaChatRoutes({
+      makeStreamClient: () => () => {
+        openedProvider = true
+        return Effect.fail(new OnboardingInferenceError({ reason: 'provider should not open' }))
+      },
+      rateLimit: allowAll,
+      recordServedTokens: () => Effect.void,
+    })
+
+    const response = await run(
+      routes.routeKhalaChatRequest(
+        chatRequest({ messages: [{ role: 'user', content: 'How can I talk to Artanis?' }] }),
+        {},
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(openedProvider).toBe(false)
+    const text = await response.text()
+    expect(text).toContain('Artanis is the OpenAgents operator agent')
+    expect(text).toContain('read-only')
+    expect(text).toContain('/api/public/artanis/report')
+    expect(text).not.toContain('Protoss')
+    expect(text).toContain('"servedAdapterId":"khala-artanis-read-only-signature"')
+  })
+
   test('emits provider-labeled reasoning on a separate SSE event', async () => {
     const routes = routesWith(
       chunkStream([

--- a/apps/openagents.com/workers/api/src/khala-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-routes.ts
@@ -30,7 +30,9 @@ import {
   KHALA_CHAT_MODEL,
   KhalaChatRequest,
   KhalaChatValidationError,
+  KHALA_ARTANIS_PUBLIC_READ_ONLY_ANSWER,
   buildKhalaChatRequest,
+  isKhalaArtanisPublicReadOnlyTurn,
   isKhalaFastGreetingTurn,
   validateKhalaChatRequest,
 } from './khala-chat-program'
@@ -231,6 +233,24 @@ const staticTextSource = (
   }),
 })
 
+const artanisPublicReadOnlySource = (): KhalaChatStreamSource => ({
+  deltas: (async function* () {
+    yield KHALA_ARTANIS_PUBLIC_READ_ONLY_ANSWER
+  })(),
+  final: () => KHALA_ARTANIS_PUBLIC_READ_ONLY_ANSWER,
+  metadata: () => ({
+    finishReason: 'artanis_public_read_only',
+    requestedModel: KHALA_CHAT_MODEL,
+    servedAdapterId: 'khala-artanis-read-only-signature',
+    servedModel: 'khala-artanis-public-signature',
+    usage: {
+      completionTokens: Math.ceil(KHALA_ARTANIS_PUBLIC_READ_ONLY_ANSWER.length / 4),
+      promptTokens: 0,
+      totalTokens: Math.ceil(KHALA_ARTANIS_PUBLIC_READ_ONLY_ANSWER.length / 4),
+    },
+  }),
+})
+
 const latestUserContent = (messages: ReadonlyArray<KhalaChatMessage>): string =>
   messages[messages.length - 1]?.content ?? ''
 
@@ -397,6 +417,8 @@ export const makeKhalaChatRoutes = (
       Effect.flatMap(messages =>
         isKhalaFastGreetingTurn(messages)
           ? Effect.succeed(fastGreetingSource())
+          : isKhalaArtanisPublicReadOnlyTurn(messages)
+            ? Effect.succeed(artanisPublicReadOnlySource())
           : loadPylonContext(dependencies, env, requestTraceRef).pipe(
               Effect.flatMap(pylonContext => {
                 const pylonAnswer = answerKhalaChatPylonQuestion(

--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 
 import { formatKhalaSpawnCapabilityAnswer, runKhalaCli } from "./cli.js"
+import { normalizeTerminalMarkdownSpacing } from "./terminal.js"
 
 describe("Khala CLI spawn capability answer", () => {
   test("answers the original subprocess capability question with the reviewed CLI path", () => {
@@ -18,6 +19,12 @@ describe("Khala CLI spawn capability answer", () => {
     expect(lower).toContain("cannot execute local workers on your machine")
     expect(lower).not.toContain("capability we don't yet expose")
     expect(lower).not.toContain("we do not yet expose")
+  })
+})
+
+describe("Khala CLI terminal rendering", () => {
+  test("collapses excessive blank lines in streamed answers", () => {
+    expect(normalizeTerminalMarkdownSpacing("A\n\n\n\nB\r\n\r\n\r\nC")).toBe("A\n\nB\n\nC")
   })
 })
 

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -1684,7 +1684,10 @@ function renderStreamingMarkdownDelta(
   previousBuffer: string,
   delta: string,
 ): { readonly buffer: string; readonly text: string } {
-  const combined = `${previousBuffer}${delta}`.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+  const combined = `${previousBuffer}${delta}`
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
   const lastNewline = combined.lastIndexOf("\n")
   if (lastNewline < 0) {
     return { buffer: combined, text: "" }

--- a/clients/khala-cli/src/client.test.ts
+++ b/clients/khala-cli/src/client.test.ts
@@ -66,6 +66,42 @@ describe("Khala client", () => {
     expect(retryEvents).toEqual([{ maxRetries: 5, retry: 1 }])
   })
 
+  test("continues generation when the stream finishes because of length", async () => {
+    const bodies: Array<unknown> = []
+    let calls = 0
+    const fakeFetch = (async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      bodies.push(JSON.parse(typeof init?.body === "string" ? init.body : "{}"))
+      calls += 1
+      if (calls === 1) {
+        return sseResponse([
+          'event: delta\ndata: {"text":"Which of these paths were"}',
+          'event: meta\ndata: {"finishReason":"length","usage":{"promptTokens":3,"completionTokens":5,"totalTokens":8}}',
+          'event: done\ndata: {"done":true}',
+          "",
+        ].join("\n\n"))
+      }
+      return sseResponse([
+        'event: delta\ndata: {"text":" blocked by owner approval."}',
+        'event: meta\ndata: {"finishReason":"stop","usage":{"promptTokens":7,"completionTokens":4,"totalTokens":11}}',
+        'event: done\ndata: {"done":true}',
+        "",
+      ].join("\n\n"))
+    }) as unknown as typeof fetch
+
+    const result = await Effect.runPromise(runChatTurn({
+      baseUrl: "https://example.test",
+      fetch: fakeFetch,
+      messages: [{ role: "user", content: "audit" }],
+      mode: "public",
+    }))
+
+    expect(result.text).toBe("Which of these paths were blocked by owner approval.")
+    expect(result.metadata.finishReason).toBe("stop")
+    expect(result.metadata.usage.totalTokens).toBe(19)
+    expect(calls).toBe(2)
+    expect(JSON.stringify(bodies[1])).toContain("Continue the previous answer")
+  })
+
   test("reports first-byte, first-token, stream, and total timing metadata", async () => {
     const fakeFetch = (async () =>
       new Response(new ReadableStream<Uint8Array>({

--- a/clients/khala-cli/src/client.ts
+++ b/clients/khala-cli/src/client.ts
@@ -35,37 +35,70 @@ import { artanisApprovalGateDecisionPath } from "./types.js"
 
 const MAX_REQUEST_RETRIES = 5
 const RETRY_DELAYS_MS = [400, 1_000, 2_000, 4_000, 8_000] as const
+const MAX_LENGTH_CONTINUATIONS = 2
+const KHALA_CLI_COMPLETION_MAX_TOKENS = 8_192
 
 export function runChatTurn(options: ChatTurnOptions): Effect.Effect<ChatTurnResult, KhalaCliError> {
   return Effect.gen(function* () {
     const startedAt = Date.now()
-    const response = yield* postChat(options)
-    const responseAt = Date.now()
-    const traceRef = readTraceRef(response)
-    const byokAck = response.headers.get(BYOK_ACK_HEADER)?.trim() || undefined
-    const stream = yield* consumeStream(
-      response,
-      options.mode,
-      startedAt,
-      responseAt,
-      options.onDelta,
-      options.onReasoning,
-    )
+    let messages = [...options.messages]
+    let text = ""
+    let reasoningText = ""
+    let streamMetadata: StreamFrameMetadata = {}
+    let firstTokenAt: number | undefined
+    let responseAt = startedAt
+    let traceRef: string | undefined
+    let byokAck: string | undefined
+
+    for (let turn = 0; turn <= MAX_LENGTH_CONTINUATIONS; turn += 1) {
+      const response = yield* postChat({ ...options, messages })
+      if (turn === 0) responseAt = Date.now()
+      traceRef = traceRef ?? readTraceRef(response)
+      byokAck = byokAck ?? (response.headers.get(BYOK_ACK_HEADER)?.trim() || undefined)
+      const stream = yield* consumeStream(
+        response,
+        options.mode,
+        startedAt,
+        responseAt,
+        options.onDelta,
+        options.onReasoning,
+      )
+      text += stream.text
+      reasoningText += stream.reasoningText
+      firstTokenAt = firstTokenAt ?? stream.timings.firstTokenAt
+      streamMetadata = mergeMetadata(streamMetadata, stream.metadata)
+
+      if (!isLengthFinish(stream.metadata.finishReason) || stream.text.trim() === "") {
+        break
+      }
+      messages = [
+        ...messages,
+        { role: "assistant" as const, content: text },
+        {
+          role: "user" as const,
+          content: "Continue the previous answer from exactly where it stopped. Finish the sentence and complete the answer without restarting.",
+        },
+      ]
+    }
     const durationMs = Math.max(0, Date.now() - startedAt)
     const metadata = buildTurnMetadata({
       durationMs,
       mode: options.mode,
       streamMetadata: {
-        ...stream.metadata,
-        traceRef: stream.metadata.traceRef ?? traceRef,
+        ...streamMetadata,
+        traceRef: streamMetadata.traceRef ?? traceRef,
       },
-      timings: stream.timings,
-      text: stream.text,
+      timings: {
+        firstTokenAt,
+        responseAt,
+        startedAt,
+      },
+      text,
     })
     return {
-      text: stream.text,
-      reasoningText: stream.reasoningText,
-      assistantMessage: { role: "assistant" as const, content: stream.text },
+      text,
+      reasoningText,
+      assistantMessage: { role: "assistant" as const, content: text },
       metadata,
       traceRef: metadata.traceRef,
       ...(byokAck === undefined ? {} : { byokAck }),
@@ -350,6 +383,7 @@ function postChat(options: ChatTurnOptions): Effect.Effect<Response, KhalaCliErr
         body: JSON.stringify({
           model: KHALA_MODEL_ID,
           messages: options.messages,
+          max_tokens: KHALA_CLI_COMPLETION_MAX_TOKENS,
           stream: true,
           stream_options: { include_usage: true },
         }),
@@ -552,8 +586,28 @@ function mergeMetadata(
   return {
     ...previous,
     ...withoutUndefined(next),
-    usage: next.usage ?? previous.usage,
+    usage: mergeUsage(previous.usage, next.usage),
   }
+}
+
+function mergeUsage(
+  previous: KhalaStreamUsage | undefined,
+  next: KhalaStreamUsage | undefined,
+): KhalaStreamUsage | undefined {
+  if (previous === undefined) return next
+  if (next === undefined) return previous
+  return {
+    cachedPromptTokens: (previous.cachedPromptTokens ?? 0) + (next.cachedPromptTokens ?? 0),
+    completionTokens: previous.completionTokens + next.completionTokens,
+    promptTokens: previous.promptTokens + next.promptTokens,
+    totalTokens: previous.totalTokens + next.totalTokens,
+  }
+}
+
+function isLengthFinish(reason: string | undefined): boolean {
+  if (reason === undefined) return false
+  const normalized = reason.trim().toLowerCase()
+  return normalized === "length" || normalized === "max_tokens" || normalized === "max_output_tokens"
 }
 
 function withoutUndefined(record: StreamFrameMetadata): Partial<StreamFrameMetadata> {

--- a/clients/khala-cli/src/sse.test.ts
+++ b/clients/khala-cli/src/sse.test.ts
@@ -105,6 +105,37 @@ describe("SSE parsing", () => {
     expect(result.metadata.servedModel).toBe("openagents/khala")
   })
 
+  test("extracts OpenAI-compatible finish_reason from terminal chunks", async () => {
+    let calls = 0
+    const fakeFetch = (async () => {
+      calls += 1
+      return sseResponse(calls === 1
+        ? [
+            'data: {"id":"chat_1","model":"openagents/khala","choices":[{"delta":{"content":"Half"}}]}',
+            'data: {"id":"chat_1","model":"openagents/khala","choices":[{"delta":{},"finish_reason":"length"}],"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}}',
+            "data: [DONE]",
+            "",
+          ].join("\n\n")
+        : [
+            'data: {"id":"chat_1","model":"openagents/khala","choices":[{"delta":{"content":" done"}}]}',
+            'data: {"id":"chat_1","model":"openagents/khala","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}}',
+            "data: [DONE]",
+            "",
+          ].join("\n\n"))
+    }) as unknown as typeof fetch
+
+    const result = await Effect.runPromise(runChatTurn({
+      mode: "api",
+      baseUrl: "https://example.test",
+      token: "oa_agent_test",
+      fetch: fakeFetch,
+      messages: [{ role: "user", content: "Hello" }],
+    }))
+
+    expect(result.text).toBe("Half done")
+    expect(result.metadata.finishReason).toBe("stop")
+  })
+
   test("extracts Khala orchestration metadata from OpenAI-compatible openagents receipt", async () => {
     const fakeFetch = (async () => sseResponse([
       'data: {"id":"chat_1","model":"openagents/khala","choices":[{"delta":{"content":"Hi"}}]}',

--- a/clients/khala-cli/src/sse.ts
+++ b/clients/khala-cli/src/sse.ts
@@ -113,12 +113,16 @@ export function decodeOpenAiFrame(frame: SseFrame): DecodedStreamFrame {
   const reasoningText = payload.choices
     .map((choice) => choice.delta.reasoning_content ?? choice.delta.reasoning ?? "")
     .join("")
+  const finishReason = payload.choices.find(choice =>
+    choice.finish_reason !== undefined && choice.finish_reason !== null
+  )?.finish_reason ?? undefined
   const openagents = extractOpenAgentsReceipt(payload.openagents)
   return {
     kind: "delta",
     metadata: {
       adapterRouteMetadata: openagents?.routing,
       fallbackReason: openagents?.fallbackReason,
+      finishReason,
       id: payload.id,
       primaryAdapterId: openagents?.primaryAdapterId,
       requestedModel: payload.model,

--- a/clients/khala-cli/src/terminal.ts
+++ b/clients/khala-cli/src/terminal.ts
@@ -37,7 +37,7 @@ export const terminalStyle = {
 }
 
 export function renderMarkdownForTerminal(markdown: string): string {
-  const lines = markdown.replace(/\r\n?/g, "\n").split("\n")
+  const lines = normalizeTerminalMarkdownSpacing(markdown).split("\n")
   const rendered: Array<string> = []
   let inFence = false
 
@@ -96,6 +96,12 @@ export function renderMarkdownDeltaForTerminal(markdownDelta: string): string {
 
 export function renderReasoningMarkdownDeltaForTerminal(markdownDelta: string): string {
   return terminalStyle.reasoning(renderInlineMarkdown(markdownDelta))
+}
+
+export function normalizeTerminalMarkdownSpacing(markdown: string): string {
+  return markdown
+    .replace(/\r\n?/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
 }
 
 function renderInlineMarkdown(input: string): string {

--- a/clients/khala-cli/src/types.ts
+++ b/clients/khala-cli/src/types.ts
@@ -84,6 +84,7 @@ export const OpenAiStreamPayload = S.Struct({
         reasoning: S.optional(S.String),
         reasoning_content: S.optional(S.String),
       }),
+      finish_reason: S.optional(S.NullOr(S.String)),
     }),
   ),
   usage: S.optional(S.Struct({


### PR DESCRIPTION
Addresses #6437.

### Changes
- CLI spacing: `renderStreamingMarkdownDelta` collapses 3+ newlines to a single blank line; `normalizeTerminalMarkdownSpacing` added in terminal.ts with a test.
- Truncation: `runChatTurn` (client.ts) now loops up to `MAX_LENGTH_CONTINUATIONS` (2), re-asking 'Continue the previous answer...' when `finish_reason=length`, merging text/usage/metadata; sets `KHALA_CLI_COMPLETION_MAX_TOKENS=8192`. Test covers length->continue->stop.
- Artanis signature: adds `artanis_interaction` to `KhalaSignatureId` and `KHALA_ARTANIS_INTERACTION_SIGNATURE` (verify rejects lore-only fallback and public command claims); new system prompt injected into chat messages; route serves a deterministic read-only answer via `artanisPublicReadOnlySource` (adapter id `khala-artanis-read-only-signature`) pointing at /agents/artanis and /api/public/artanis/report.

### Verification
Not independently re-verified. (PR adds route + client + sse + cli tests asserting all three behaviors.)