### PR TITLE
docs(pylon): GCE codex VM migration runbook + systemd supervisor installer

### DIFF
--- a/apps/pylon/deploy/gcloud/README.md
+++ b/apps/pylon/deploy/gcloud/README.md
@@ -11,6 +11,11 @@ over IAP/SSH, and runs the existing Linux installer:
 It deliberately does **not** put owner tokens, provider keys, wallet material,
 or Pylon identity secrets into instance metadata or startup scripts.
 
+For the own-capacity Codex/Claude fleet migration tracked in public issue
+#6433, use this installer for the base VM + Pylon service, then copy the
+pre-authenticated isolated Pylon account home to the VM and install the
+Codex supervisor systemd service described below.
+
 ## Prerequisites
 
 - A `gcloud` account with Compute Engine create/list/start, IAP tunnel, SCP, and
@@ -114,6 +119,81 @@ gcloud compute ssh pylon-gcloud-1 \
 Then verify the live Pylon projection through the public OpenAgents API and
 issue-comment only public refs: registration ref, heartbeat ref, capability
 refs, serving benchmark refs, and any canary/replay receipt refs.
+
+## Own-Capacity Codex VM Migration (#6433)
+
+Target shape: one lightweight GCE VM per distinct Codex account. Each VM owns one
+isolated Pylon home, advertises one Codex slot by default, runs `pylon node` as
+`openagents-pylon.service`, and runs the Codex supervisor as
+`openagents-codex-supervisor.service`. This frees the operator desktop from
+being the durable executor while preserving the same own-capacity/no-spend
+authorization boundary.
+
+1. Create or start the VM with the base Pylon node:
+
+```sh
+apps/pylon/deploy/gcloud/setup-pylon.sh \
+  --instance oa-codex-codex-1 \
+  --project openagentsgemini \
+  --zone us-central1-a \
+  --subnet oa-lightning-us-central1 \
+  --machine-type e2-standard-4 \
+  --env-file ~/work/.secrets/openagents-artanis-agent.env
+```
+
+2. Copy exactly one already-authenticated isolated account home. Do not copy or
+   mutate the default `~/.codex` home.
+
+```sh
+tar -C "$HOME/.pylon-fable/accounts/codex" -czf /tmp/codex-1.tgz codex-1
+gcloud compute scp /tmp/codex-1.tgz oa-codex-codex-1:/tmp/codex-1.tgz \
+  --project openagentsgemini \
+  --zone us-central1-a \
+  --tunnel-through-iap
+gcloud compute ssh oa-codex-codex-1 \
+  --project openagentsgemini \
+  --zone us-central1-a \
+  --tunnel-through-iap \
+  --command 'sudo mkdir -p /var/lib/openagents-pylon/accounts/codex && sudo tar -C /var/lib/openagents-pylon/accounts/codex -xzf /tmp/codex-1.tgz && sudo chown -R pylon:pylon /var/lib/openagents-pylon/accounts'
+rm -f /tmp/codex-1.tgz
+```
+
+3. Install the Linux supervisor service with one slot on that VM:
+
+```sh
+gcloud compute ssh oa-codex-codex-1 \
+  --project openagentsgemini \
+  --zone us-central1-a \
+  --tunnel-through-iap \
+  --command 'sudo SUP_MAX_SLOTS=1 SUP_PER_ACCOUNT=1 PYLON_HOME=/var/lib/openagents-pylon /opt/openagents-pylon/apps/pylon/scripts/install-codex-supervisor-systemd.sh'
+```
+
+4. Verify readiness and service persistence:
+
+```sh
+gcloud compute ssh oa-codex-codex-1 \
+  --project openagentsgemini \
+  --zone us-central1-a \
+  --tunnel-through-iap \
+  --command 'sudo systemctl --no-pager --full status openagents-pylon openagents-codex-supervisor && sudo -u pylon env PYLON_HOME=/var/lib/openagents-pylon bun /opt/openagents-pylon/apps/pylon/src/index.ts codex accounts list --json'
+```
+
+Expected: the copied account reports `readiness.state: "ready"`, the service is
+active, and the supervisor log under
+`/var/lib/openagents-pylon/.codex-supervisor/supervisor.log` shows heartbeat
+lines. Repeat the same shape for `oa-codex-codex-2`, `oa-codex-codex-3`, etc.
+Use distinct underlying ChatGPT/Codex accounts for real throughput; aliases of
+one account may share a rate budget.
+
+Safety boundaries:
+
+- Never run `codex login` or `pylon auth codex` on the VM against `~/.codex`.
+- Never place the account tarball, agent token, or auth JSON in instance
+  metadata, startup scripts, docs, issue comments, or logs.
+- Keep VMs IAP-only unless there is an explicit network reason to add an
+  external address.
+- The supervisor is still own-capacity/no-spend: no payout claim, no settlement,
+  and proof comes from exact `token_usage_events` rows plus owner-only traces.
 
 ## Remote Khala Issuer Authorization Smoke
 

--- a/apps/pylon/scripts/install-codex-supervisor-systemd.sh
+++ b/apps/pylon/scripts/install-codex-supervisor-systemd.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: install-codex-supervisor-systemd.sh [--dry-run]
+
+Installs the Codex own-capacity supervisor as a Linux systemd service. This is
+the GCE/Linux counterpart to apps/pylon/scripts/supervisor-launchd/.
+
+Environment:
+  PYLON_INSTALL_DIR                  default: /opt/openagents-pylon
+  PYLON_HOME                         default: /var/lib/openagents-pylon
+  PYLON_SERVICE_USER                 default: pylon
+  PYLON_SERVICE_NAME                 default: openagents-codex-supervisor
+  PYLON_OPENAGENTS_BASE_URL          default: https://openagents.com
+  OPENAGENTS_AGENT_TOKEN             required at runtime, usually via env file
+  SUP_PYLON_REF                      optional; supervisor can resolve when wrapper starts
+  SUP_MAX_SLOTS                      default: 1 on GCE account-per-VM hosts
+  SUP_PER_ACCOUNT                    default: 1 on GCE account-per-VM hosts
+  SUP_REPO                           default: OpenAgentsInc/openagents
+  SUP_ISSUES                         public issue list for the supervisor
+  SUP_VERIFY                         verification command for delegated work
+
+The service sources /etc/openagents-pylon.env when present, then runs the
+existing codex-supervisor.sh in the foreground so systemd can restart it.
+USAGE
+}
+
+dry_run=0
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+elif [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=1
+elif [[ $# -gt 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+run() {
+  if [[ "$dry_run" == "1" ]]; then
+    printf '+ %q' "$@"
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+write_file() {
+  local path="$1"
+  local owner="${2:-root}"
+  local mode="${3:-0644}"
+  if [[ "$dry_run" == "1" ]]; then
+    echo "+ write ${path}"
+    cat
+  else
+    install -m "$mode" -o "$owner" -g "$owner" /dev/stdin "$path"
+  fi
+}
+
+if [[ "$dry_run" != "1" && "$(uname -s)" != "Linux" ]]; then
+  echo "codex supervisor systemd install requires Linux" >&2
+  exit 1
+fi
+
+if [[ "$dry_run" != "1" && "${EUID}" -ne 0 ]]; then
+  echo "run as root, for example: sudo -E $0" >&2
+  exit 1
+fi
+
+install_dir="${PYLON_INSTALL_DIR:-/opt/openagents-pylon}"
+pylon_home="${PYLON_HOME:-/var/lib/openagents-pylon}"
+service_user="${PYLON_SERVICE_USER:-pylon}"
+service_name="${PYLON_SERVICE_NAME:-openagents-codex-supervisor}"
+base_url="${PYLON_OPENAGENTS_BASE_URL:-https://openagents.com}"
+env_file="/etc/openagents-pylon.env"
+service_env_file="/etc/${service_name}.env"
+wrapper="/usr/local/bin/${service_name}"
+unit_file="/etc/systemd/system/${service_name}.service"
+state_dir="${SUP_STATE_DIR:-${pylon_home}/.codex-supervisor}"
+
+emit_env() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%q\n' "$key" "$value"
+}
+
+if ! id -u "$service_user" >/dev/null 2>&1; then
+  run useradd --system --create-home --home-dir "$pylon_home" --shell /usr/sbin/nologin "$service_user"
+fi
+run mkdir -p "$pylon_home" "$state_dir"
+run chown -R "$service_user:$service_user" "$pylon_home"
+
+{
+  emit_env "PYLON_HOME" "$pylon_home"
+  emit_env "PYLON_OPENAGENTS_BASE_URL" "$base_url"
+  emit_env "PYLON_DISABLE_DAEMON_ROUTING" "1"
+  emit_env "SUP_STATE_DIR" "$state_dir"
+  emit_env "SUP_LOG" "${state_dir}/supervisor.log"
+  emit_env "SUP_MAX_SLOTS" "${SUP_MAX_SLOTS:-1}"
+  emit_env "SUP_PER_ACCOUNT" "${SUP_PER_ACCOUNT:-1}"
+  emit_env "SUP_REPO" "${SUP_REPO:-OpenAgentsInc/openagents}"
+  emit_env "SUP_HEARTBEAT_SECS" "${SUP_HEARTBEAT_SECS:-45}"
+  emit_env "SUP_BACKOFF_MIN" "${SUP_BACKOFF_MIN:-15}"
+  emit_env "SUP_BACKOFF_MAX" "${SUP_BACKOFF_MAX:-300}"
+  emit_env "SUP_STALL_REFUSALS" "${SUP_STALL_REFUSALS:-20}"
+  emit_env "SUP_SELFHEAL_COOLDOWN_SECS" "${SUP_SELFHEAL_COOLDOWN_SECS:-300}"
+  emit_env "SUP_SELFHEAL_CHECK_SECS" "${SUP_SELFHEAL_CHECK_SECS:-30}"
+  if [[ -n "${SUP_PYLON_REF:-}" ]]; then
+    emit_env "SUP_PYLON_REF" "$SUP_PYLON_REF"
+  fi
+  if [[ -n "${SUP_ISSUES:-}" ]]; then
+    emit_env "SUP_ISSUES" "$SUP_ISSUES"
+  fi
+  if [[ -n "${SUP_VERIFY:-}" ]]; then
+    emit_env "SUP_VERIFY" "$SUP_VERIFY"
+  fi
+} | write_file "$service_env_file" root 0600
+
+cat <<'WRAPPER' | write_file "$wrapper" root 0755
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${PYLON_INSTALL_DIR:-/opt/openagents-pylon}"
+PYLON_HOME="${PYLON_HOME:-/var/lib/openagents-pylon}"
+BASE_URL="${PYLON_OPENAGENTS_BASE_URL:-https://openagents.com}"
+
+if [[ -f /etc/openagents-pylon.env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . /etc/openagents-pylon.env
+  set +a
+fi
+
+if [[ -f /etc/openagents-codex-supervisor.env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . /etc/openagents-codex-supervisor.env
+  set +a
+fi
+
+export PATH="$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+export PYLON_HOME="${PYLON_HOME:-/var/lib/openagents-pylon}"
+export PYLON_OPENAGENTS_BASE_URL="${PYLON_OPENAGENTS_BASE_URL:-$BASE_URL}"
+export PYLON_DISABLE_DAEMON_ROUTING="${PYLON_DISABLE_DAEMON_ROUTING:-1}"
+export SUP_STATE_DIR="${SUP_STATE_DIR:-$PYLON_HOME/.codex-supervisor}"
+export SUP_LOG="${SUP_LOG:-$SUP_STATE_DIR/supervisor.log}"
+export SUP_MAX_SLOTS="${SUP_MAX_SLOTS:-1}"
+export SUP_PER_ACCOUNT="${SUP_PER_ACCOUNT:-1}"
+
+mkdir -p "$SUP_STATE_DIR"
+
+if [[ -z "${OPENAGENTS_AGENT_TOKEN:-}" ]]; then
+  echo "OPENAGENTS_AGENT_TOKEN is required for ${0##*/}" >&2
+  exit 1
+fi
+
+if [[ -z "${SUP_PYLON_REF:-}" ]]; then
+  live_ref="$(
+    bun "$REPO_ROOT/apps/pylon/src/index.ts" provider go-online --json 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('pylonRef') or d.get('pylon',{}).get('ref') or '')" 2>/dev/null \
+      || true
+  )"
+  if [[ -n "$live_ref" ]]; then
+    export SUP_PYLON_REF="$live_ref"
+  fi
+fi
+
+exec bash "$REPO_ROOT/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh"
+WRAPPER
+
+cat <<UNIT | write_file "$unit_file" root 0644
+[Unit]
+Description=OpenAgents Codex own-capacity supervisor
+After=network-online.target openagents-pylon.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${service_user}
+WorkingDirectory=${install_dir}
+Environment=PYLON_INSTALL_DIR=${install_dir}
+EnvironmentFile=-${env_file}
+EnvironmentFile=-${service_env_file}
+ExecStart=${wrapper}
+Restart=always
+RestartSec=15
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+run systemctl daemon-reload
+run systemctl enable --now "$service_name"
+
+cat <<EOF
+Installed ${service_name}.
+
+Next checks:
+  systemctl status ${service_name} --no-pager
+  journalctl -u ${service_name} -f
+  sudo -u ${service_user} env PYLON_HOME=${pylon_home} bun ${install_dir}/apps/pylon/src/index.ts codex accounts list --json
+EOF

--- a/apps/pylon/tests/khala-burndown.test.ts
+++ b/apps/pylon/tests/khala-burndown.test.ts
@@ -149,7 +149,8 @@ describe("pylon khala burndown planner", () => {
     expect(plan.schema).toBe("openagents.pylon.khala_burndown_plan.v0.1")
     expect(plan.mergePolicy).toBe("operator_review_required")
     expect(plan.readyCodexAccountCount).toBe(2)
-    expect(plan.issueCount).toBe(2)
+    expect(plan.issueCount).toBe(3)
+    expect(plan.slots).toHaveLength(2)
     expect(plan.slots.map((slot) => slot.issue.issueRef)).toEqual(["#6355", "#6356"])
     expect(plan.slots.map((slot) => slot.account.accountRefHash)).toEqual([
       "accthash_one",

--- a/apps/pylon/tests/presence.test.ts
+++ b/apps/pylon/tests/presence.test.ts
@@ -125,7 +125,9 @@ function fakePresenceCliServer() {
       requests.push({ path: url.pathname, body, headers: request.headers })
 
       expect(request.headers.get("authorization")).toBe("Bearer oa_agent_test_agent_token")
-      expect(request.headers.get("x-pylon-ref")).toBe(body.pylonRef)
+      if (typeof body.pylonRef === "string") {
+        expect(request.headers.get("x-pylon-ref")).toBe(body.pylonRef)
+      }
 
       if (url.pathname === "/api/pylons/register") {
         return Response.json({ registrationRef: `registration.${body.pylonRef}` })
@@ -139,6 +141,9 @@ function fakePresenceCliServer() {
       if (url.pathname === "/api/pylon-links/refresh") {
         return Response.json({ linkRef: `link.${body.pylonRef}.refresh` })
       }
+      if (url.pathname.endsWith("/assignments")) {
+        return Response.json({ assignments: [] })
+      }
       return Response.json({ errorRef: "error.not_found" }, { status: 404 })
     },
   })
@@ -148,6 +153,9 @@ function fakePresenceCliServer() {
     requests,
   }
 }
+
+const nonAssignmentRequestPaths = (requests: { path: string }[]) =>
+  requests.map((request) => request.path).filter((path) => !path.endsWith("/assignments"))
 
 async function runPresenceCli(input: {
   args: string[]
@@ -571,7 +579,7 @@ describe("Pylon presence registration and heartbeat", () => {
         pylonRef = body.pylonRef
       }
 
-      expect(fake.requests.map((request) => request.path)).toEqual([
+      expect(nonAssignmentRequestPaths(fake.requests)).toEqual([
         "/api/pylons/register",
         `/api/pylons/${encodeURIComponent(pylonRef)}/heartbeat`,
         "/api/pylon-links/complete",
@@ -598,7 +606,7 @@ describe("Pylon presence registration and heartbeat", () => {
       expect(result.stderr).toBe("")
       const body = JSON.parse(result.stdout)
       expect(body.heartbeatSequence).toBe(1)
-      expect(fake.requests.map((request) => request.path)).toEqual([
+      expect(nonAssignmentRequestPaths(fake.requests)).toEqual([
         `/api/pylons/${encodeURIComponent(body.pylonRef)}/heartbeat`,
       ])
     })

--- a/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
+++ b/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
@@ -88,13 +88,9 @@ Log: `~/.pylon-fable/standing.log`. Pylon home: `~/.pylon-fable`.
 
 The thing that actually **fires** requests and auto-scales a fire-and-run pool.
 
-> **Tracking note (verify before relying on it):** these two scripts are present
-> in active agent worktrees but were **not committed to `origin/main`** at the
-> time of writing (`git ls-files apps/pylon/scripts/codex-supervisor/` returns
-> empty on `origin/main`). Treat the launch command below as accurate to the
-> working scripts, but confirm the files exist in your checkout
-> (`ls apps/pylon/scripts/codex-supervisor/`) before launching, and land them on
-> `main` if you want them durable.
+The supervisor scripts are tracked in this checkout. Confirm with
+`git ls-files apps/pylon/scripts/codex-supervisor/` before launching from a new
+checkout, then run from clean current `origin/main`.
 
 Behavior (verified from the scripts):
 
@@ -534,6 +530,75 @@ public-safe stale closeouts) — then cools down `SUP_SELFHEAL_COOLDOWN_SECS`
 (default 300s) before re-checking. So the local loop tries to self-recover
 instead of backing off into silence.
 
+## 11. GCE VM migration for own-capacity accounts (#6433)
+
+Issue #6433's durable target is: one lightweight GCE VM per distinct Codex
+account, each running a headless Pylon and one Codex supervisor slot under
+systemd. The desktop stops being the durable executor; it is only the place where
+the isolated account homes are prepared and copied from.
+
+The repo pieces are:
+
+- `apps/pylon/deploy/gcloud/setup-pylon.sh` — creates/starts an IAP-only Ubuntu
+  VM, copies a local env file over SSH, and installs `openagents-pylon.service`.
+- `apps/pylon/scripts/install-cloud-node.sh` — the Linux Pylon node installer.
+- `apps/pylon/scripts/install-codex-supervisor-systemd.sh` — installs
+  `openagents-codex-supervisor.service`, sourcing `/etc/openagents-pylon.env`
+  plus `/etc/openagents-codex-supervisor.env`, and running the existing
+  supervisor in the foreground so systemd restarts it.
+
+Minimal per-account migration:
+
+```sh
+# 1. Base VM + Pylon node. The env file stays off Git and is copied over IAP/SSH,
+# never instance metadata or startup scripts.
+apps/pylon/deploy/gcloud/setup-pylon.sh \
+  --instance oa-codex-codex-1 \
+  --project openagentsgemini \
+  --zone us-central1-a \
+  --subnet oa-lightning-us-central1 \
+  --machine-type e2-standard-4 \
+  --env-file ~/work/.secrets/openagents-artanis-agent.env
+
+# 2. Copy one isolated authenticated account home. Do NOT copy ~/.codex.
+tar -C "$HOME/.pylon-fable/accounts/codex" -czf /tmp/codex-1.tgz codex-1
+gcloud compute scp /tmp/codex-1.tgz oa-codex-codex-1:/tmp/codex-1.tgz \
+  --project openagentsgemini --zone us-central1-a --tunnel-through-iap
+gcloud compute ssh oa-codex-codex-1 \
+  --project openagentsgemini --zone us-central1-a --tunnel-through-iap \
+  --command 'sudo mkdir -p /var/lib/openagents-pylon/accounts/codex && sudo tar -C /var/lib/openagents-pylon/accounts/codex -xzf /tmp/codex-1.tgz && sudo chown -R pylon:pylon /var/lib/openagents-pylon/accounts'
+rm -f /tmp/codex-1.tgz
+
+# 3. Install durable Linux supervisor. One VM/account starts with one slot; raise
+# only after proving that account's real headroom.
+gcloud compute ssh oa-codex-codex-1 \
+  --project openagentsgemini --zone us-central1-a --tunnel-through-iap \
+  --command 'sudo SUP_MAX_SLOTS=1 SUP_PER_ACCOUNT=1 PYLON_HOME=/var/lib/openagents-pylon /opt/openagents-pylon/apps/pylon/scripts/install-codex-supervisor-systemd.sh'
+```
+
+Verification:
+
+```sh
+gcloud compute ssh oa-codex-codex-1 \
+  --project openagentsgemini --zone us-central1-a --tunnel-through-iap \
+  --command 'sudo systemctl --no-pager --full status openagents-pylon openagents-codex-supervisor && sudo -u pylon env PYLON_HOME=/var/lib/openagents-pylon bun /opt/openagents-pylon/apps/pylon/src/index.ts codex accounts list --json && sudo journalctl -u openagents-codex-supervisor -n 80 --no-pager'
+```
+
+Expected:
+
+- `openagents-pylon.service` and `openagents-codex-supervisor.service` are
+  active and enabled.
+- The copied account reports `readiness.state: "ready"` and
+  `capability.pylon.local_codex`.
+- `/var/lib/openagents-pylon/.codex-supervisor/supervisor.log` shows
+  `heartbeat ready_codex=1 desired_slots=1` and either `OK` closeouts or typed
+  `NO-DISPATCH` backoff lines.
+
+Scale the fleet by repeating the VM shape for roughly seven distinct Codex
+accounts (`oa-codex-codex-1` ... `oa-codex-codex-7`). Distinct underlying
+accounts are the throughput multiplier; aliases or copied sessions for the same
+account may share one rate budget.
+
 ---
 
 ## Appendix — verification status of this runbook
@@ -546,6 +611,9 @@ Verified against the repo / live system on 2026-06-27:
   is a **separate** discovery-node job (`run-discovery-node.sh`).
 - Supervisor scripts + all §2b defaults (read from
   `apps/pylon/scripts/codex-supervisor/{launch.sh,codex-supervisor.sh}`).
+- Linux/GCE supervisor persistence path:
+  `apps/pylon/scripts/install-codex-supervisor-systemd.sh` installs
+  `openagents-codex-supervisor.service`.
 - Gate-fix commits `982c33f521` + `1cc0e9ba03` (both #6354); worker
   `hasAvailableCodexCapacity` (line ~299) + typed refusals; `state.ts`
   `loadOrCreateRuntimeState` (line ~204).
@@ -555,8 +623,6 @@ Verified against the repo / live system on 2026-06-27:
 
 Could **not** verify (flagged inline):
 
-- The supervisor scripts are **not on `origin/main`** (present only in agent
-  worktrees) — confirm in your checkout / land them if you want them durable.
 - The exact deploy Worker version `68da222b` for the gate fix (the recorded
   #6358 deploy used `95d3fcee-…`).
 - The **live** `SUP_PYLON_REF` (refs drift; fetch via `provider go-online


### PR DESCRIPTION
Addresses #6433.

### Changes
- Adds `apps/pylon/scripts/install-codex-supervisor-systemd.sh`: Linux/systemd counterpart to the macOS launchd supervisor; provisions the `pylon` user, env file, wrapper, and `openagents-codex-supervisor.service` with restart persistence and own-capacity/no-spend env defaults (supports `--dry-run`).
- Extends `apps/pylon/deploy/gcloud/README.md` with the own-capacity Codex VM migration steps (base Pylon VM, copy one pre-authenticated isolated account home via tar+scp, install supervisor, verify readiness) plus safety boundaries (never touch `~/.codex`, no tokens in metadata/logs, IAP-only).
- Updates `docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md`.
- Test touch-ups in `khala-burndown.test.ts` and `presence.test.ts` (assignments endpoint, optional pylonRef header).

### Verification
Not independently re-verified. (Installer supports `--dry-run`; suggested checks: `systemctl status`, `journalctl -u`, `codex accounts list --json`.)