### PR TITLE
fix(pylon): prune codex task workspaces on closeout

### DIFF
--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -9,9 +9,11 @@ import {
   type CodexAgentSandboxMode,
 } from "./codex-agent.js"
 import {
+  cleanupOldestMaterializedWorkspaces,
   gitCheckoutWorkspaceFrom,
   materializeGitCheckoutWorkspaceWithLease,
   pruneWorkspaceCacheDirectories,
+  releaseWorkspace,
   workspaceCheckoutFailureReasonRef,
   type GitCheckoutWorkspace,
   type WorkspaceCheckoutRunner,
@@ -154,6 +156,8 @@ type CodexAgentFixture = {
 const DEFAULT_TIMEOUT_SECONDS = 300
 const MAX_TIMEOUT_SECONDS = 1200
 const CODEX_AGENT_WORKSPACE_CACHE_MAX_ENTRIES = 200
+const CODEX_AGENT_TASK_MAX_MATERIALIZED_WORKSPACES = 64
+const CODEX_AGENT_TASK_CACHE_PRUNE_MIN_AGE_SECONDS = MAX_TIMEOUT_SECONDS + 300
 
 const CODEX_AGENT_FIXTURES: Record<string, CodexAgentFixture> = {
   [CODEX_AGENT_SUM_REPAIR_FIXTURE_REF]: {
@@ -815,6 +819,7 @@ async function materializeCodexAgentWorkspace(input: {
     cacheRoot,
     maxEntries: CODEX_AGENT_WORKSPACE_CACHE_MAX_ENTRIES,
   })
+  const workspaceStateRoot = join(input.state.paths.cache, "workspace-leases")
   if (input.task.workspace !== undefined) {
     const materialized = await materializeGitCheckoutWorkspaceWithLease({
       cacheRoot,
@@ -823,7 +828,13 @@ async function materializeCodexAgentWorkspace(input: {
       leaseRef: input.leaseRef,
       refPrefix: "workspace.pylon.codex_agent_task",
       repositoryCacheRoot: join(input.state.paths.cache, "workspace-git-cache"),
-      workspaceStateRoot: join(input.state.paths.cache, "workspace-leases"),
+      retentionPolicy: "remove_on_closeout",
+      workspaceStateRoot,
+    })
+    await cleanupOldestMaterializedWorkspaces({
+      maxMaterializedWorkspaces: CODEX_AGENT_TASK_MAX_MATERIALIZED_WORKSPACES,
+      minimumAgeSeconds: CODEX_AGENT_TASK_CACHE_PRUNE_MIN_AGE_SECONDS,
+      workspaceStateRoot,
     })
     return {
       acceptanceResultRef: "git_checkout_verified",
@@ -837,6 +848,7 @@ async function materializeCodexAgentWorkspace(input: {
       verificationArgs: input.task.workspace.verificationCommand.args,
       workspace: materialized.workingDirectory,
       workspaceRef: materialized.workspaceRef,
+      workspaceStateRoot,
     }
   }
 
@@ -855,7 +867,37 @@ async function materializeCodexAgentWorkspace(input: {
     verificationArgs: fixture.verificationArgs,
     workspace,
     workspaceRef,
+    workspaceStateRoot: undefined,
   }
+}
+
+async function releaseCodexAgentWorkspace(input: {
+  materialized: Awaited<ReturnType<typeof materializeCodexAgentWorkspace>>
+  now: Date
+}): Promise<{ resultRefs: string[] }> {
+  if (input.materialized.workspaceStateRoot === undefined) return { resultRefs: [] }
+  const result = await releaseWorkspace({
+    now: input.now,
+    workspaceRef: input.materialized.workspaceRef,
+    workspaceStateRoot: input.materialized.workspaceStateRoot,
+  }).catch(() => null)
+  if (result?.cleanupReceiptRef !== undefined) {
+    return {
+      resultRefs: [
+        "result.public.pylon.codex_agent_task.workspace_cleaned_on_closeout",
+        result.cleanupReceiptRef,
+      ],
+    }
+  }
+  if (result?.retentionReasonRef !== undefined) {
+    return {
+      resultRefs: [
+        "result.public.pylon.codex_agent_task.workspace_retained_on_closeout",
+        result.retentionReasonRef,
+      ],
+    }
+  }
+  return { resultRefs: [] }
 }
 
 type CodexAgentLease = {
@@ -986,6 +1028,7 @@ export async function executeCodexAgentAssignment(
     workspace: materialized.workspace,
   })
   if (!dependencies.ok) {
+    await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
       lease,
       runRef,
@@ -1041,6 +1084,7 @@ export async function executeCodexAgentAssignment(
       workspaceRef: materialized.workspaceRef,
     })
   } catch {
+    await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
       lease,
       runRef,
@@ -1052,6 +1096,7 @@ export async function executeCodexAgentAssignment(
   }
 
   if (run.outcome === "workspace_escape_blocked") {
+    await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
       lease,
       runRef,
@@ -1072,6 +1117,7 @@ export async function executeCodexAgentAssignment(
     })
   }
   if (run.outcome === "refused") {
+    await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
       lease,
       runRef,
@@ -1116,6 +1162,7 @@ export async function executeCodexAgentAssignment(
     env,
     account: options.account,
   })
+  const workspaceCleanup = await releaseCodexAgentWorkspace({ materialized, now })
 
   return {
     artifactRefs: [artifactRef],
@@ -1132,6 +1179,7 @@ export async function executeCodexAgentAssignment(
         : `result.public.pylon.codex_agent_task.${materialized.acceptanceResultRef}_failed`,
       `result.public.pylon.codex_agent_task.edited_files.${run.editedFileCount}`,
       ...pullRequest.resultRefs,
+      ...workspaceCleanup.resultRefs,
     ],
     runRefs: [runRef, ...sessionRefs],
     status: passed ? ("accepted" as const) : ("rejected" as const),

--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -1023,6 +1023,67 @@ export async function cleanupExpiredWorkspaces(input: {
 }
 
 /**
+ * Count-bounded cleanup for hot assignment caches. Unlike the TTL sweep, this
+ * runs when a lane knows its cache root is high churn and must stay under a
+ * fixed number of materialized workspaces.
+ */
+export async function cleanupOldestMaterializedWorkspaces(input: {
+  workspaceStateRoot: string
+  maxMaterializedWorkspaces: number
+  minimumAgeSeconds?: number
+  now?: Date
+}): Promise<{ cleanupReceiptRefs: string[]; retainedWorkspaceRefs: string[] }> {
+  const maxMaterializedWorkspaces = Math.max(
+    0,
+    Math.floor(input.maxMaterializedWorkspaces),
+  )
+  let entries: string[]
+  try {
+    entries = await readdir(input.workspaceStateRoot)
+  } catch {
+    return { cleanupReceiptRefs: [], retainedWorkspaceRefs: [] }
+  }
+
+  const materializedRecords: WorkspaceLeaseRecord[] = []
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue
+    const record = await readLeaseRecord(join(input.workspaceStateRoot, entry))
+    if (record === null || record.state !== "materialized") continue
+    materializedRecords.push(record)
+  }
+  if (materializedRecords.length <= maxMaterializedWorkspaces) {
+    return { cleanupReceiptRefs: [], retainedWorkspaceRefs: [] }
+  }
+
+  const now = input.now ?? new Date()
+  const minimumAgeMs =
+    Math.max(0, Math.floor(input.minimumAgeSeconds ?? 0)) * 1000
+  const cleanupReceiptRefs: string[] = []
+  const retainedWorkspaceRefs: string[] = []
+  const eligibleOldestFirst = materializedRecords
+    .filter((record) => {
+      const materializedAtMs = Date.parse(record.materializedAt)
+      if (!Number.isFinite(materializedAtMs)) return true
+      return now.getTime() - materializedAtMs >= minimumAgeMs
+    })
+    .sort((left, right) => {
+      const leftMs = Date.parse(left.materializedAt)
+      const rightMs = Date.parse(right.materializedAt)
+      return (
+        (Number.isFinite(leftMs) ? leftMs : 0) -
+        (Number.isFinite(rightMs) ? rightMs : 0)
+      )
+    })
+  const cleanupCount = materializedRecords.length - maxMaterializedWorkspaces
+  for (const record of eligibleOldestFirst.slice(0, cleanupCount)) {
+    const result = await cleanLeaseRecord(input.workspaceStateRoot, record, now)
+    if (result?.state === "cleaned") cleanupReceiptRefs.push(result.cleanupReceiptRef)
+    if (result?.state === "retained") retainedWorkspaceRefs.push(result.workspaceRef)
+  }
+  return { cleanupReceiptRefs, retainedWorkspaceRefs }
+}
+
+/**
  * Explicit release for the remove_on_closeout retention policy: removes
  * one workspace by its internal ref and mints its cleanup receipt. Returns
  * null when the lease is unknown or already cleaned.

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test"
+import { existsSync } from "node:fs"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { tmpdir } from "node:os"
@@ -19,7 +20,10 @@ import type {
 } from "../src/codex-turn-reporter"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import { ensurePylonLocalState, assertPublicProjectionSafe } from "../src/state"
-import { WorkspaceCheckoutError } from "../src/workspace-materializer"
+import {
+  WorkspaceCheckoutError,
+  workspaceLeaseRecordFor,
+} from "../src/workspace-materializer"
 
 const now = new Date("2026-06-11T22:00:00.000Z")
 
@@ -734,6 +738,60 @@ describe("codex git_checkout workspace (shared B2 contract)", () => {
       expect(record?.previewRefs).toContain(
         "https://github.com/OpenAgentsInc/openagents/pull/99001",
       )
+      assertPublicProjectionSafe(record)
+    })
+  })
+
+  test("releases a clean git checkout workspace after closeout (#6524)", async () => {
+    await withState(async (state) => {
+      const checkoutRunner = async (workspace: string) => {
+        await mkdir(workspace, { recursive: true })
+        await writeFile(
+          join(workspace, "package.json"),
+          `${JSON.stringify({ private: true, type: "module" })}\n`,
+        )
+        await writeFile(
+          join(workspace, "sum.ts"),
+          "export const sum = (left: number, right: number) => left + right\n",
+        )
+        await writeFile(
+          join(workspace, "sum.test.ts"),
+          [
+            'import { describe, expect, test } from "bun:test"',
+            'import { sum } from "./sum"',
+            'describe("sum", () => { test("adds", () => { expect(sum(2, 3)).toBe(5) }) })',
+            "",
+          ].join("\n"),
+        )
+      }
+      let workspaceRef: string | null = null
+      const record = await executeCodexAgentAssignment(
+        state,
+        { ...lease, codingAssignment: checkoutAssignment },
+        now,
+        {
+          checkoutRunner,
+          codexAgentProbe: readyProbe,
+          codexAgentRunner: async (input) => {
+            workspaceRef = input.workspaceRef ?? null
+            return idleRunner(input)
+          },
+          pullRequestPublisher: async () => ({ state: "no_change" }),
+        },
+      )
+
+      expect(record?.status).toBe("accepted")
+      expect(record?.resultRefs).toContain(
+        "result.public.pylon.codex_agent_task.workspace_cleaned_on_closeout",
+      )
+      expect(workspaceRef).not.toBeNull()
+      const leaseRecord = await workspaceLeaseRecordFor({
+        workspaceRef: workspaceRef as string,
+        workspaceStateRoot: join(state.paths.cache, "workspace-leases"),
+      })
+      expect(leaseRecord?.state).toBe("cleaned")
+      expect(leaseRecord?.cleanupReceiptRef).toStartWith("receipt.pylon.workspace_cleanup.")
+      expect(existsSync(leaseRecord?.local.workingDirectory ?? "")).toBe(false)
       assertPublicProjectionSafe(record)
     })
   })

--- a/apps/pylon/tests/workspace-materializer.test.ts
+++ b/apps/pylon/tests/workspace-materializer.test.ts
@@ -4,11 +4,14 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
+  cleanupOldestMaterializedWorkspaces,
   gitCheckoutWorkspaceFrom,
   materializeGitCheckoutWorkspace,
+  materializeGitCheckoutWorkspaceWithLease,
   removeMaterializedWorkspace,
   type GitCheckoutWorkspace,
   type WorkspaceCheckoutRunner,
+  workspaceLeaseRecordFor,
 } from "../src/workspace-materializer"
 
 const validCheckout: GitCheckoutWorkspace = {
@@ -262,6 +265,128 @@ describe("removeMaterializedWorkspace", () => {
     } finally {
       await rm(cacheRoot, { recursive: true, force: true })
       await rm(outside, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("cleanupOldestMaterializedWorkspaces", () => {
+  test("removes oldest clean lease records until the cache is under the cap", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "pylon-workspace-cache-"))
+    const repositoryCacheRoot = await mkdtemp(join(tmpdir(), "pylon-repository-cache-"))
+    const workspaceStateRoot = await mkdtemp(join(tmpdir(), "pylon-workspace-state-"))
+    const checkoutRunner: WorkspaceCheckoutRunner = async (workingDirectory) => {
+      await mkdir(workingDirectory, { recursive: true })
+      await writeFile(join(workingDirectory, "checked-out"), "ok\n")
+    }
+
+    try {
+      const first = await materializeGitCheckoutWorkspaceWithLease({
+        cacheRoot,
+        checkout: validCheckout,
+        checkoutRunner,
+        leaseRef: "lease.public.workspace.cap.first",
+        refPrefix: "workspace.pylon.codex_agent_task",
+        repositoryCacheRoot,
+        workspaceStateRoot,
+        now: new Date("2026-06-11T00:00:00.000Z"),
+      })
+      const second = await materializeGitCheckoutWorkspaceWithLease({
+        cacheRoot,
+        checkout: validCheckout,
+        checkoutRunner,
+        leaseRef: "lease.public.workspace.cap.second",
+        refPrefix: "workspace.pylon.codex_agent_task",
+        repositoryCacheRoot,
+        workspaceStateRoot,
+        now: new Date("2026-06-11T00:01:00.000Z"),
+      })
+      const third = await materializeGitCheckoutWorkspaceWithLease({
+        cacheRoot,
+        checkout: validCheckout,
+        checkoutRunner,
+        leaseRef: "lease.public.workspace.cap.third",
+        refPrefix: "workspace.pylon.codex_agent_task",
+        repositoryCacheRoot,
+        workspaceStateRoot,
+        now: new Date("2026-06-11T00:02:00.000Z"),
+      })
+
+      const result = await cleanupOldestMaterializedWorkspaces({
+        maxMaterializedWorkspaces: 1,
+        now: new Date("2026-06-11T00:03:00.000Z"),
+        workspaceStateRoot,
+      })
+
+      expect(result.cleanupReceiptRefs).toHaveLength(2)
+      expect(result.retainedWorkspaceRefs).toEqual([])
+      expect(existsSync(first.workingDirectory)).toBe(false)
+      expect(existsSync(second.workingDirectory)).toBe(false)
+      expect(existsSync(third.workingDirectory)).toBe(true)
+      expect(
+        (await workspaceLeaseRecordFor({ workspaceStateRoot, workspaceRef: first.workspaceRef }))
+          ?.state,
+      ).toBe("cleaned")
+      expect(
+        (await workspaceLeaseRecordFor({ workspaceStateRoot, workspaceRef: second.workspaceRef }))
+          ?.state,
+      ).toBe("cleaned")
+      expect(
+        (await workspaceLeaseRecordFor({ workspaceStateRoot, workspaceRef: third.workspaceRef }))
+          ?.state,
+      ).toBe("materialized")
+    } finally {
+      await rm(cacheRoot, { recursive: true, force: true })
+      await rm(repositoryCacheRoot, { recursive: true, force: true })
+      await rm(workspaceStateRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("does not remove fresh materialized workspaces under the age guard", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "pylon-workspace-cache-"))
+    const repositoryCacheRoot = await mkdtemp(join(tmpdir(), "pylon-repository-cache-"))
+    const workspaceStateRoot = await mkdtemp(join(tmpdir(), "pylon-workspace-state-"))
+    const checkoutRunner: WorkspaceCheckoutRunner = async (workingDirectory) => {
+      await mkdir(workingDirectory, { recursive: true })
+      await writeFile(join(workingDirectory, "checked-out"), "ok\n")
+    }
+
+    try {
+      const first = await materializeGitCheckoutWorkspaceWithLease({
+        cacheRoot,
+        checkout: validCheckout,
+        checkoutRunner,
+        leaseRef: "lease.public.workspace.age.first",
+        refPrefix: "workspace.pylon.codex_agent_task",
+        repositoryCacheRoot,
+        workspaceStateRoot,
+        now: new Date("2026-06-11T00:00:00.000Z"),
+      })
+      const second = await materializeGitCheckoutWorkspaceWithLease({
+        cacheRoot,
+        checkout: validCheckout,
+        checkoutRunner,
+        leaseRef: "lease.public.workspace.age.second",
+        refPrefix: "workspace.pylon.codex_agent_task",
+        repositoryCacheRoot,
+        workspaceStateRoot,
+        now: new Date("2026-06-11T00:01:00.000Z"),
+      })
+
+      const result = await cleanupOldestMaterializedWorkspaces({
+        maxMaterializedWorkspaces: 1,
+        minimumAgeSeconds: 10 * 60,
+        now: new Date("2026-06-11T00:02:00.000Z"),
+        workspaceStateRoot,
+      })
+
+      expect(result.cleanupReceiptRefs).toEqual([])
+      expect(result.retainedWorkspaceRefs).toEqual([])
+      expect(existsSync(first.workingDirectory)).toBe(true)
+      expect(existsSync(second.workingDirectory)).toBe(true)
+    } finally {
+      await rm(cacheRoot, { recursive: true, force: true })
+      await rm(repositoryCacheRoot, { recursive: true, force: true })
+      await rm(workspaceStateRoot, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
Closes #6524

## Problem
`codex_agent_task` git checkout workspaces accumulate under the Pylon cache after assignment closeout. With one full repo plus dependencies per assignment, stale workspaces can fill disk and stall the fleet.

## Change
- Mark Codex git checkout workspaces with the existing `remove_on_closeout` lease policy.
- Release clean Codex git checkout workspaces after verification and PR/no-change handling. Dirty/unknown workspaces still use the existing retention guard so evidence is not deleted.
- Add a count-bounded cleanup helper for oldest materialized lease records, and wire Codex task materialization to keep at most 64 materialized workspaces after a 25-minute minimum-age guard.
- Record public-safe cleanup/retention refs in accepted closeouts.

## Files touched
- `apps/pylon/src/codex-agent-executor.ts`
- `apps/pylon/src/workspace-materializer.ts`
- `apps/pylon/tests/codex-agent-executor.test.ts`
- `apps/pylon/tests/workspace-materializer.test.ts`

## Validation
- `git diff --check`
- `bun --cwd apps/pylon test tests/workspace-materializer.test.ts tests/codex-agent-executor.test.ts --max-concurrency=1`
  - 41 pass / 0 fail
  - Used temporary symlinks to the already-installed local dependency directories in the scratch worktree, then removed them before commit.

## Known validation blocker
- `bun run --cwd apps/pylon typecheck` is blocked before this change by missing `@opentui/core` in `apps/pylon/packages/runtime`:
  - `packages/runtime/src/cli.ts(59,55): error TS2307: Cannot find module '@opentui/core'...`\n  - `packages/runtime/src/opentui-renderer.ts(31,8): error TS2307: Cannot find module '@opentui/core'...`\n\n## Maintenance / revenue value\nThis removes the disk-full failure mode that stalls own-capacity Codex labor, while preserving dirty-workspace evidence when cleanup is unsafe. It directly improves paid fleet throughput and reduces manual host pruning.\n\n## Not changed\n- No payout, wallet, payment, or auth logic.\n- No PR publisher behavior beyond releasing the workspace after PR/no-change handling.\n- No deletion of dirty/unknown workspaces.