### PR TITLE
feat(gym): agentcl_eval.v0 schema + PG/SG/GG claim discipline

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl-eval.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl-eval.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  AgentClEvalSchemaVersion,
+  AgentClEvalUnsafe,
+  buildAgentClEval,
+  evaluateContinualLearningClaim,
+  type AgentClEval,
+} from './agentcl-eval'
+
+const validAgentClEval = (): AgentClEval => ({
+  schemaVersion: AgentClEvalSchemaVersion,
+  evalRef: 'eval.gym.agentcl.router_memory.v0',
+  streamRef: 'stream.gym.agentcl.compositional_repo_tasks.v0',
+  candidateRef: 'candidate.gym.khala.router_memory.v0',
+  memorySystemRef: 'memory_system.gym.khala.repo_memory.v0',
+  baseline: {
+    phase: 'baseline',
+    scoreBps: 4_000,
+    taskCount: 20,
+    reportRef: 'report.gym.agentcl.baseline',
+    receiptRef: 'receipt.gym.agentcl.baseline',
+  },
+  firstPass: {
+    phase: 'first_pass',
+    scoreBps: 5_700,
+    taskCount: 20,
+    reportRef: 'report.gym.agentcl.first_pass',
+    receiptRef: 'receipt.gym.agentcl.first_pass',
+  },
+  frozenSecondPass: {
+    phase: 'frozen_second_pass',
+    scoreBps: 5_300,
+    taskCount: 20,
+    reportRef: 'report.gym.agentcl.frozen_second_pass',
+    receiptRef: 'receipt.gym.agentcl.frozen_second_pass',
+  },
+  heldOut: {
+    phase: 'held_out',
+    scoreBps: 3_900,
+    taskCount: 20,
+    reportRef: 'report.gym.agentcl.held_out',
+    receiptRef: 'receipt.gym.agentcl.held_out',
+  },
+  gains: {
+    plasticity: {
+      kind: 'plasticity',
+      gainBps: 1_700,
+      evidenceRefs: ['evidence.gym.agentcl.pg'],
+    },
+    stability: {
+      kind: 'stability',
+      gainBps: -400,
+      evidenceRefs: ['evidence.gym.agentcl.sg'],
+    },
+    generalization: {
+      kind: 'generalization',
+      gainBps: -100,
+      evidenceRefs: ['evidence.gym.agentcl.gg'],
+    },
+  },
+  caveatRefs: ['caveat.public.gym.agentcl.test'],
+})
+
+describe('AgentCL eval contract', () => {
+  test('accepts baseline, first-pass, frozen second-pass, held-out, and separate gains', () => {
+    const evalRecord = buildAgentClEval(validAgentClEval())
+
+    expect(evalRecord.schemaVersion).toBe('openagents.gym.agentcl_eval.v0')
+    expect(evalRecord.gains.plasticity.gainBps).toBe(1_700)
+    expect(evalRecord.gains.stability.gainBps).toBe(-400)
+    expect(evalRecord.gains.generalization.gainBps).toBe(-100)
+    expect(evalRecord.caveatRefs).toContain(
+      'caveat.public.gym.agentcl_eval.pg_sg_gg_reported_separately',
+    )
+  })
+
+  test('rejects a gain that does not match its measured phase delta', () => {
+    const evalRecord = validAgentClEval()
+
+    expect(() =>
+      buildAgentClEval({
+        ...evalRecord,
+        gains: {
+          ...evalRecord.gains,
+          plasticity: {
+            ...evalRecord.gains.plasticity,
+            gainBps: 900,
+          },
+        },
+      }),
+    ).toThrow(AgentClEvalUnsafe)
+  })
+
+  test('rejects gain records without separate evidence refs', () => {
+    const evalRecord = validAgentClEval()
+
+    expect(() =>
+      buildAgentClEval({
+        ...evalRecord,
+        gains: {
+          ...evalRecord.gains,
+          generalization: {
+            ...evalRecord.gains.generalization,
+            evidenceRefs: [],
+          },
+        },
+      }),
+    ).toThrow(AgentClEvalUnsafe)
+  })
+})
+
+describe('continual-learning claim discipline', () => {
+  test('blocks a single memory-improved metric without AgentCL evidence', () => {
+    const discipline = evaluateContinualLearningClaim({
+      claimRef: 'claim.gym.khala.continually_learns',
+      copy: 'Khala memory improves accuracy over time.',
+      legacySingleMetricBps: 1_200,
+      evidenceRefs: ['evidence.gym.memory_improved_accuracy'],
+    })
+
+    expect(discipline.ok).toBe(false)
+    expect(discipline.evalRef).toBe(null)
+    expect(discipline.blockerRefs).toEqual([
+      'blocker.gym.agentcl_claim.agentcl_eval_v0_missing',
+      'blocker.gym.agentcl_claim.single_memory_improved_metric_refused',
+    ])
+  })
+
+  test('accepts a continual-learning claim only with AgentCL PG, SG, and GG evidence', () => {
+    const discipline = evaluateContinualLearningClaim({
+      claimRef: 'claim.gym.khala.continually_learns',
+      copy: 'Khala memory reports Plasticity, Stability, and Generalization separately.',
+      agentClEval: validAgentClEval(),
+      evidenceRefs: ['evidence.gym.agentcl.claim'],
+    })
+
+    expect(discipline.ok).toBe(true)
+    expect(discipline.evalRef).toBe('eval.gym.agentcl.router_memory.v0')
+    expect(discipline.blockerRefs).toEqual([])
+    expect(discipline.caveatRefs).toContain(
+      'caveat.public.gym.continual_learning_claim.no_single_memory_improved_metric',
+    )
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl-eval.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl-eval.ts
@@ -1,0 +1,270 @@
+import { Schema as S } from 'effect'
+
+import { assertPylonGepaMetricCallPublicRefs } from '../../pylon-gepa-metric-call-assignments'
+import { publicRefSegment, uniqueRefs } from '../../public-ref-format'
+
+export const AgentClEvalSchemaVersion = 'openagents.gym.agentcl_eval.v0'
+
+export const AgentClPhase = S.Literals([
+  'baseline',
+  'first_pass',
+  'frozen_second_pass',
+  'held_out',
+])
+export type AgentClPhase = typeof AgentClPhase.Type
+
+export const AgentClGainKind = S.Literals([
+  'plasticity',
+  'stability',
+  'generalization',
+])
+export type AgentClGainKind = typeof AgentClGainKind.Type
+
+export const AgentClEvalPhaseScore = S.Struct({
+  phase: AgentClPhase,
+  scoreBps: S.Number,
+  taskCount: S.Number,
+  reportRef: S.String,
+  receiptRef: S.String,
+})
+export type AgentClEvalPhaseScore = typeof AgentClEvalPhaseScore.Type
+
+export const AgentClEvalGain = S.Struct({
+  kind: AgentClGainKind,
+  gainBps: S.Number,
+  evidenceRefs: S.Array(S.String),
+})
+export type AgentClEvalGain = typeof AgentClEvalGain.Type
+
+export const AgentClEval = S.Struct({
+  schemaVersion: S.Literal(AgentClEvalSchemaVersion),
+  evalRef: S.String,
+  streamRef: S.String,
+  candidateRef: S.String,
+  memorySystemRef: S.String,
+  baseline: AgentClEvalPhaseScore,
+  firstPass: AgentClEvalPhaseScore,
+  frozenSecondPass: AgentClEvalPhaseScore,
+  heldOut: AgentClEvalPhaseScore,
+  gains: S.Struct({
+    plasticity: AgentClEvalGain,
+    stability: AgentClEvalGain,
+    generalization: AgentClEvalGain,
+  }),
+  caveatRefs: S.Array(S.String),
+})
+export type AgentClEval = typeof AgentClEval.Type
+
+export const ContinualLearningClaim = S.Struct({
+  claimRef: S.String,
+  copy: S.String,
+  agentClEval: S.optional(AgentClEval),
+  legacySingleMetricBps: S.optional(S.Number),
+  evidenceRefs: S.optional(S.Array(S.String)),
+})
+export type ContinualLearningClaim = typeof ContinualLearningClaim.Type
+
+export type AgentClClaimDiscipline = Readonly<{
+  ok: boolean
+  evalRef: string | null
+  blockerRefs: ReadonlyArray<string>
+  caveatRefs: ReadonlyArray<string>
+}>
+
+export class AgentClEvalUnsafe extends S.TaggedErrorClass<AgentClEvalUnsafe>()(
+  'AgentClEvalUnsafe',
+  {
+    reason: S.String,
+  },
+) {}
+
+const AGENTCL_EVAL_CAVEATS = [
+  'caveat.public.gym.agentcl_eval.non_parametric_memory_only',
+  'caveat.public.gym.agentcl_eval.pg_sg_gg_reported_separately',
+  'caveat.public.gym.agentcl_eval.held_out_not_memory_context',
+] as const
+
+const AGENTCL_CLAIM_CAVEATS = [
+  'caveat.public.gym.continual_learning_claim.requires_agentcl_eval_v0',
+  'caveat.public.gym.continual_learning_claim.no_single_memory_improved_metric',
+] as const
+
+const assertPublicRefs = (
+  label: string,
+  refs: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+  const normalized = uniqueRefs(refs)
+  try {
+    assertPylonGepaMetricCallPublicRefs(label, normalized)
+  } catch (error) {
+    throw new AgentClEvalUnsafe({
+      reason:
+        error instanceof Error
+          ? error.message
+          : `${label} contains unsafe refs.`,
+    })
+  }
+  return normalized
+}
+
+const assertFiniteBps = (label: string, value: number): void => {
+  if (!Number.isFinite(value)) {
+    throw new AgentClEvalUnsafe({ reason: `${label} must be finite.` })
+  }
+}
+
+const assertPhase = (
+  expected: AgentClPhase,
+  phaseScore: AgentClEvalPhaseScore,
+): void => {
+  if (phaseScore.phase !== expected) {
+    throw new AgentClEvalUnsafe({
+      reason: `${expected} phase evidence was provided as ${phaseScore.phase}.`,
+    })
+  }
+  assertFiniteBps(`${expected}.scoreBps`, phaseScore.scoreBps)
+  if (!Number.isInteger(phaseScore.taskCount) || phaseScore.taskCount <= 0) {
+    throw new AgentClEvalUnsafe({
+      reason: `${expected}.taskCount must be a positive integer.`,
+    })
+  }
+}
+
+const assertGain = (
+  expected: AgentClGainKind,
+  gain: AgentClEvalGain,
+  expectedGainBps: number,
+): void => {
+  if (gain.kind !== expected) {
+    throw new AgentClEvalUnsafe({
+      reason: `${expected} gain evidence was provided as ${gain.kind}.`,
+    })
+  }
+  assertFiniteBps(`${expected}.gainBps`, gain.gainBps)
+  if (gain.gainBps !== expectedGainBps) {
+    throw new AgentClEvalUnsafe({
+      reason: `${expected} gain must equal the measured phase delta.`,
+    })
+  }
+  if (gain.evidenceRefs.length === 0) {
+    throw new AgentClEvalUnsafe({
+      reason: `${expected} gain requires separate evidence refs.`,
+    })
+  }
+}
+
+export const buildAgentClEval = (raw: unknown): AgentClEval => {
+  let input: AgentClEval
+  try {
+    input = S.decodeUnknownSync(AgentClEval)(raw)
+  } catch (error) {
+    throw new AgentClEvalUnsafe({
+      reason: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  assertPhase('baseline', input.baseline)
+  assertPhase('first_pass', input.firstPass)
+  assertPhase('frozen_second_pass', input.frozenSecondPass)
+  assertPhase('held_out', input.heldOut)
+  assertGain(
+    'plasticity',
+    input.gains.plasticity,
+    input.firstPass.scoreBps - input.baseline.scoreBps,
+  )
+  assertGain(
+    'stability',
+    input.gains.stability,
+    input.frozenSecondPass.scoreBps - input.firstPass.scoreBps,
+  )
+  assertGain(
+    'generalization',
+    input.gains.generalization,
+    input.heldOut.scoreBps - input.baseline.scoreBps,
+  )
+
+  const evalRef =
+    input.evalRef === ''
+      ? `eval.gym.agentcl.${publicRefSegment(
+          [input.streamRef, input.candidateRef, input.memorySystemRef].join(
+            '.',
+          ),
+          'unnamed',
+        )}`
+      : input.evalRef
+
+  assertPublicRefs('AgentCL eval public refs', [
+    evalRef,
+    input.streamRef,
+    input.candidateRef,
+    input.memorySystemRef,
+    input.baseline.reportRef,
+    input.baseline.receiptRef,
+    input.firstPass.reportRef,
+    input.firstPass.receiptRef,
+    input.frozenSecondPass.reportRef,
+    input.frozenSecondPass.receiptRef,
+    input.heldOut.reportRef,
+    input.heldOut.receiptRef,
+    ...input.gains.plasticity.evidenceRefs,
+    ...input.gains.stability.evidenceRefs,
+    ...input.gains.generalization.evidenceRefs,
+    ...input.caveatRefs,
+  ])
+
+  return {
+    ...input,
+    evalRef,
+    caveatRefs: uniqueRefs([...AGENTCL_EVAL_CAVEATS, ...input.caveatRefs]),
+    gains: {
+      plasticity: {
+        ...input.gains.plasticity,
+        evidenceRefs: uniqueRefs(input.gains.plasticity.evidenceRefs),
+      },
+      stability: {
+        ...input.gains.stability,
+        evidenceRefs: uniqueRefs(input.gains.stability.evidenceRefs),
+      },
+      generalization: {
+        ...input.gains.generalization,
+        evidenceRefs: uniqueRefs(input.gains.generalization.evidenceRefs),
+      },
+    },
+  }
+}
+
+export const evaluateContinualLearningClaim = (
+  claim: ContinualLearningClaim,
+): AgentClClaimDiscipline => {
+  const blockerRefs = uniqueRefs([
+    ...(claim.agentClEval === undefined
+      ? ['blocker.gym.agentcl_claim.agentcl_eval_v0_missing']
+      : []),
+    ...(claim.legacySingleMetricBps !== undefined
+      ? ['blocker.gym.agentcl_claim.single_memory_improved_metric_refused']
+      : []),
+  ])
+
+  if (claim.agentClEval === undefined) {
+    return {
+      ok: false,
+      evalRef: null,
+      blockerRefs,
+      caveatRefs: [...AGENTCL_CLAIM_CAVEATS],
+    }
+  }
+
+  const agentClEval = buildAgentClEval(claim.agentClEval)
+  assertPublicRefs('AgentCL continual-learning claim refs', [
+    claim.claimRef,
+    ...(claim.evidenceRefs ?? []),
+    agentClEval.evalRef,
+  ])
+
+  return {
+    ok: blockerRefs.length === 0,
+    evalRef: agentClEval.evalRef,
+    blockerRefs,
+    caveatRefs: uniqueRefs([...AGENTCL_CLAIM_CAVEATS, ...agentClEval.caveatRefs]),
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/gym/index.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/index.ts
@@ -1,4 +1,5 @@
 export * from './agentcl'
+export * from './agentcl-eval'
 export * from './experiment'
 export * from './flywheel'
 export * from './harbor-dispatch'

--- a/apps/openagents.com/workers/api/src/inference/gym/leaderboard.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/leaderboard.test.ts
@@ -15,6 +15,9 @@ import {
   type GymExperiment,
 } from './experiment'
 import {
+  AgentClEvalSchemaVersion,
+} from './agentcl-eval'
+import {
   buildGymLeaderboardProjection,
   GymLeaderboardUnsafe,
   modelGymModuleAuthorSplit,
@@ -151,6 +154,110 @@ describe('Gym public leaderboard projection', () => {
         },
       ]),
     ).toThrow(GymLeaderboardUnsafe)
+  })
+
+  test('excludes decision-grade reports that make continual-learning claims without separate PG SG GG evidence', () => {
+    const report = decisionGradeReport(400)
+
+    const projection = buildGymLeaderboardProjection([
+      {
+        ...report,
+        reportRef: 'report.gym.leaderboard.memory_claim',
+        receiptRef: 'receipt.gym.leaderboard.memory_claim',
+        candidateRef: 'candidate.gym.leaderboard.memory_claim',
+        continualLearningClaim: {
+          claimRef: 'claim.gym.khala.continually_learns',
+          copy: 'Khala memory improved accuracy by 12%.',
+          legacySingleMetricBps: 1_200,
+          evidenceRefs: ['evidence.gym.memory_improved_accuracy'],
+        },
+      },
+    ])
+
+    expect(projection.rowCount).toBe(0)
+    expect(projection.excludedReports).toEqual([
+      {
+        reportRef: 'report.gym.leaderboard.memory_claim',
+        reason: 'continual_learning_claim_evidence_missing',
+      },
+    ])
+  })
+
+  test('allows decision-grade continual-learning claims backed by AgentCL eval evidence', () => {
+    const report = decisionGradeReport(400)
+
+    const projection = buildGymLeaderboardProjection([
+      {
+        ...report,
+        reportRef: 'report.gym.leaderboard.agentcl_claim',
+        receiptRef: 'receipt.gym.leaderboard.agentcl_claim',
+        candidateRef: 'candidate.gym.leaderboard.agentcl_claim',
+        continualLearningClaim: {
+          claimRef: 'claim.gym.khala.continually_learns',
+          copy: 'Khala memory reports Plasticity, Stability, and Generalization separately.',
+          evidenceRefs: ['evidence.gym.agentcl.claim'],
+          agentClEval: {
+            schemaVersion: AgentClEvalSchemaVersion,
+            evalRef: 'eval.gym.agentcl.leaderboard',
+            streamRef: 'stream.gym.agentcl.leaderboard',
+            candidateRef: 'candidate.gym.agentcl.leaderboard',
+            memorySystemRef: 'memory_system.gym.agentcl.repo_memory',
+            baseline: {
+              phase: 'baseline',
+              scoreBps: 4_000,
+              taskCount: 20,
+              reportRef: 'report.gym.agentcl.baseline',
+              receiptRef: 'receipt.gym.agentcl.baseline',
+            },
+            firstPass: {
+              phase: 'first_pass',
+              scoreBps: 5_000,
+              taskCount: 20,
+              reportRef: 'report.gym.agentcl.first_pass',
+              receiptRef: 'receipt.gym.agentcl.first_pass',
+            },
+            frozenSecondPass: {
+              phase: 'frozen_second_pass',
+              scoreBps: 4_900,
+              taskCount: 20,
+              reportRef: 'report.gym.agentcl.frozen_second_pass',
+              receiptRef: 'receipt.gym.agentcl.frozen_second_pass',
+            },
+            heldOut: {
+              phase: 'held_out',
+              scoreBps: 4_100,
+              taskCount: 20,
+              reportRef: 'report.gym.agentcl.held_out',
+              receiptRef: 'receipt.gym.agentcl.held_out',
+            },
+            gains: {
+              plasticity: {
+                kind: 'plasticity',
+                gainBps: 1_000,
+                evidenceRefs: ['evidence.gym.agentcl.pg'],
+              },
+              stability: {
+                kind: 'stability',
+                gainBps: -100,
+                evidenceRefs: ['evidence.gym.agentcl.sg'],
+              },
+              generalization: {
+                kind: 'generalization',
+                gainBps: 100,
+                evidenceRefs: ['evidence.gym.agentcl.gg'],
+              },
+            },
+            caveatRefs: [],
+          },
+        },
+      },
+    ])
+
+    expect(projection.rowCount).toBe(1)
+    expect(projection.excludedReports).toEqual([])
+    expect(projection.caveatRefs).toContain(
+      'caveat.public.gym.leaderboard.continual_learning_claims_require_pg_sg_gg',
+    )
   })
 })
 

--- a/apps/openagents.com/workers/api/src/inference/gym/leaderboard.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/leaderboard.ts
@@ -9,6 +9,10 @@ import {
 } from '../../pylon-gepa-metric-call-assignments'
 import { publicRefSegment, uniqueRefs } from '../../public-ref-format'
 import type { CompiledGymExperiment } from './experiment'
+import {
+  evaluateContinualLearningClaim,
+  type ContinualLearningClaim,
+} from './agentcl-eval'
 import { summarizeGymCostPerAcceptedOutcome } from './flywheel'
 
 export const GymLeaderboardProjectionSchemaVersion =
@@ -26,6 +30,7 @@ export type GymLeaderboardReportInput = Readonly<{
   reportRef: string
   receiptRef: string
   candidateRef: string
+  continualLearningClaim?: ContinualLearningClaim
 }>
 
 export type GymLeaderboardRow = Readonly<{
@@ -50,6 +55,7 @@ export type GymLeaderboardExcludedReport = Readonly<{
     | 'not_decision_grade'
     | 'no_accepted_outcomes'
     | 'public_safety_violation'
+    | 'continual_learning_claim_evidence_missing'
 }>
 
 export type GymLeaderboardProjection = Readonly<{
@@ -103,6 +109,7 @@ const LEADERBOARD_CAVEATS = [
   'caveat.public.gym.leaderboard.decision_grade_only',
   'caveat.public.gym.leaderboard.public_safe_fields_only',
   'caveat.public.gym.leaderboard.no_fixture_or_synthetic_ranking',
+  'caveat.public.gym.leaderboard.continual_learning_claims_require_pg_sg_gg',
 ] as const
 
 const MODULE_SPLIT_CAVEATS = [
@@ -159,6 +166,18 @@ const leaderboardCandidateRow = (
     return {
       reportRef: input.reportRef,
       reason: 'not_decision_grade',
+    }
+  }
+
+  if (input.continualLearningClaim !== undefined) {
+    const claimDiscipline = evaluateContinualLearningClaim(
+      input.continualLearningClaim,
+    )
+    if (!claimDiscipline.ok) {
+      return {
+        reportRef: input.reportRef,
+        reason: 'continual_learning_claim_evidence_missing',
+      }
     }
   }
 


### PR DESCRIPTION
Addresses #6418.

### Changes
- Adds `agentcl-eval.ts` (~270 lines): typed `openagents.gym.agentcl_eval.v0` schema with baseline / first_pass / frozen_second_pass / held_out phase scores and separate plasticity/stability/generalization gains; `buildAgentClEval` validates phases, finite/positive task counts, that each gain matches its measured phase delta, and requires separate evidence refs (throws `AgentClEvalUnsafe`).
- Adds `evaluateContinualLearningClaim`: blocks any single 'memory improved accuracy' metric without full AgentCL PG/SG/GG evidence (emits agentcl_eval_v0_missing + single_memory_improved_metric_refused blockers) and only passes with complete evidence.
- Wires the contract into gym `leaderboard.ts` and exports it via gym index.ts.
- Adds tests for schema acceptance, gain/evidence rejection, and claim discipline.

### Verification
Not independently re-verified. (Vitest covers schema validation, gain-mismatch rejection, and the single-metric claim refusal vs PG/SG/GG acceptance.)