### PR TITLE
feat(openagents.com): add trace-economic underwriting

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/trace-economic-underwriting.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/trace-economic-underwriting.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  priceOutcomeWarrantyQuote,
+  type OutcomeWarrantyQuoteInput,
+} from './trace-economic-underwriting'
+
+const baseInput = (
+  overrides: Partial<OutcomeWarrantyQuoteInput> = {},
+): OutcomeWarrantyQuoteInput => ({
+  acceptedOutcomeRef: 'accepted_outcome.khala_coding.6426.001',
+  assignmentRef: 'assignment.public.khala_coding.issue_6426',
+  customerAccountRef: 'agent:customer-001',
+  evidence: {
+    meteringReceiptRefs: ['receipt.inference.charge.req_6426'],
+    settlementReceiptRefs: ['receipt.serving.payout.accepted_outcome.req_6426'],
+    tokenUsageEventRefs: ['token_usage_event.khala_coding.req_6426.turn_1'],
+    traceRef: 'trace.public.issue_6426.accepted',
+    usageTruth: 'exact',
+    verdictRef: 'verdict.khala_coding.accepted.req_6426',
+    verdictState: 'accepted',
+  },
+  premiumMarginBps: 2_500,
+  rejectionRiskBps: 400,
+  sla: {
+    coverageKind: 'refund_on_rejection',
+    refundCapMsat: 100_000,
+    responseWindowSeconds: 3_600,
+    verificationWindowSeconds: 86_400,
+  },
+  ...overrides,
+})
+
+describe('trace-economic underwriting warranty quote', () => {
+  test('prices an inert refund-on-rejection warranty from public-safe proof refs', () => {
+    const quote = priceOutcomeWarrantyQuote(baseInput())
+
+    expect(quote.schemaVersion).toBe(
+      'openagents.trace_economic_underwriting.quote.v1',
+    )
+    expect(quote.state).toBe('offered')
+    expect(quote.expectedLossMsat).toBe(4_000)
+    expect(quote.premiumMsat).toBe(5_000)
+    expect(quote.refundCapMsat).toBe(100_000)
+    expect(quote.coverageKind).toBe('refund_on_rejection')
+    expect(quote.blockerRefs).toEqual([])
+    expect(quote.evidenceRefs).toEqual([
+      'receipt.inference.charge.req_6426',
+      'receipt.serving.payout.accepted_outcome.req_6426',
+      'token_usage_event.khala_coding.req_6426.turn_1',
+      'trace.public.issue_6426.accepted',
+      'verdict.khala_coding.accepted.req_6426',
+    ])
+    expect(quote.refundExecutionAuthority).toBe(false)
+    expect(quote.settlementMutationAllowed).toBe(false)
+    expect(quote.publicClaimEligible).toBe(false)
+  })
+
+  test('blocks warranties without accepted verdict and exact metering proof', () => {
+    const quote = priceOutcomeWarrantyQuote(
+      baseInput({
+        evidence: {
+          meteringReceiptRefs: [],
+          settlementReceiptRefs: [],
+          tokenUsageEventRefs: [],
+          traceRef: null,
+          usageTruth: 'estimated',
+          verdictRef: 'verdict.khala_coding.rejected.req_6426',
+          verdictState: 'rejected',
+        },
+      }),
+    )
+
+    expect(quote.state).toBe('blocked')
+    expect(quote.premiumMsat).toBe(0)
+    expect(quote.expectedLossMsat).toBe(0)
+    expect(quote.blockerRefs).toEqual([
+      'blocker.trace_underwriting.accepted_verdict_missing',
+      'blocker.trace_underwriting.exact_usage_missing',
+      'blocker.trace_underwriting.metering_receipt_missing',
+      'blocker.trace_underwriting.public_safe_trace_missing',
+      'blocker.trace_underwriting.token_usage_event_missing',
+    ])
+    expect(quote.caveatRefs).toContain(
+      'caveat.trace_underwriting.settlement_receipt_not_attached',
+    )
+  })
+
+  test('produces a stable quote ref for the same risk terms and proof anchors', () => {
+    const first = priceOutcomeWarrantyQuote(baseInput())
+    const second = priceOutcomeWarrantyQuote(
+      baseInput({
+        evidence: {
+          ...baseInput().evidence,
+          settlementReceiptRefs: [
+            'receipt.serving.payout.accepted_outcome.req_6426',
+          ],
+        },
+      }),
+    )
+
+    expect(second.quoteRef).toBe(first.quoteRef)
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/trace-economic-underwriting.ts
+++ b/apps/openagents.com/workers/api/src/inference/trace-economic-underwriting.ts
@@ -1,0 +1,209 @@
+import { Schema as S } from 'effect'
+
+export const TRACE_ECONOMIC_UNDERWRITING_QUOTE_SCHEMA =
+  'openagents.trace_economic_underwriting.quote.v1'
+
+export const OutcomeWarrantyCoverageKind = S.Literals([
+  'refund_on_rejection',
+  'verified_outcome_sla',
+])
+export type OutcomeWarrantyCoverageKind =
+  typeof OutcomeWarrantyCoverageKind.Type
+
+export const OutcomeWarrantyEvidence = S.Struct({
+  traceRef: S.NullOr(S.String),
+  verdictRef: S.String,
+  verdictState: S.Literals(['accepted', 'rejected', 'pending']),
+  tokenUsageEventRefs: S.Array(S.String),
+  meteringReceiptRefs: S.Array(S.String),
+  settlementReceiptRefs: S.Array(S.String),
+  usageTruth: S.Literals(['exact', 'estimated', 'missing']),
+})
+export type OutcomeWarrantyEvidence = typeof OutcomeWarrantyEvidence.Type
+
+export const OutcomeWarrantySla = S.Struct({
+  coverageKind: OutcomeWarrantyCoverageKind,
+  responseWindowSeconds: S.Number,
+  verificationWindowSeconds: S.Number,
+  refundCapMsat: S.Number,
+})
+export type OutcomeWarrantySla = typeof OutcomeWarrantySla.Type
+
+export const OutcomeWarrantyQuoteInput = S.Struct({
+  assignmentRef: S.String,
+  acceptedOutcomeRef: S.String,
+  customerAccountRef: S.String,
+  evidence: OutcomeWarrantyEvidence,
+  sla: OutcomeWarrantySla,
+  premiumMarginBps: S.Number,
+  rejectionRiskBps: S.Number,
+})
+export type OutcomeWarrantyQuoteInput =
+  typeof OutcomeWarrantyQuoteInput.Type
+
+export const OutcomeWarrantyQuote = S.Struct({
+  schemaVersion: S.Literal(TRACE_ECONOMIC_UNDERWRITING_QUOTE_SCHEMA),
+  quoteRef: S.String,
+  assignmentRef: S.String,
+  acceptedOutcomeRef: S.String,
+  customerAccountRef: S.String,
+  coverageKind: OutcomeWarrantyCoverageKind,
+  state: S.Literals(['offered', 'blocked']),
+  premiumMsat: S.Number,
+  expectedLossMsat: S.Number,
+  refundCapMsat: S.Number,
+  rejectionRiskBps: S.Number,
+  premiumMarginBps: S.Number,
+  evidenceRefs: S.Array(S.String),
+  blockerRefs: S.Array(S.String),
+  caveatRefs: S.Array(S.String),
+  refundExecutionAuthority: S.Literal(false),
+  settlementMutationAllowed: S.Literal(false),
+  publicClaimEligible: S.Literal(false),
+})
+export type OutcomeWarrantyQuote = typeof OutcomeWarrantyQuote.Type
+
+const decodeInput = S.decodeUnknownSync(OutcomeWarrantyQuoteInput)
+const decodeQuote = S.decodeUnknownSync(OutcomeWarrantyQuote)
+
+const safeRefSegment = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+const fnv1a32 = (value: string): string => {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash.toString(16).padStart(8, '0')
+}
+
+const stableJson = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null'
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`
+  }
+  const entries = Object.entries(value as Record<string, unknown>).sort(
+    ([a], [b]) => a.localeCompare(b),
+  )
+  return `{${entries
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+    .join(',')}}`
+}
+
+const quoteRefForInput = (input: OutcomeWarrantyQuoteInput): string =>
+  `quote.trace_underwriting.${safeRefSegment(
+    input.acceptedOutcomeRef,
+  )}.${fnv1a32(
+    stableJson({
+      assignmentRef: input.assignmentRef,
+      coverageKind: input.sla.coverageKind,
+      premiumMarginBps: input.premiumMarginBps,
+      refundCapMsat: input.sla.refundCapMsat,
+      rejectionRiskBps: input.rejectionRiskBps,
+      verdictRef: input.evidence.verdictRef,
+    }),
+  )}`
+
+const uniqueSorted = (
+  values: ReadonlyArray<string | null>,
+): ReadonlyArray<string> =>
+  Array.from(
+    new Set(
+      values
+        .filter((value): value is string => value !== null)
+        .map(value => value.trim())
+        .filter(value => value !== ''),
+    ),
+  ).sort()
+
+const warrantyBlockers = (
+  input: OutcomeWarrantyQuoteInput,
+): ReadonlyArray<string> => {
+  const blockers: Array<string> = []
+  if (
+    input.evidence.traceRef === null ||
+    input.evidence.traceRef.trim() === ''
+  ) {
+    blockers.push('blocker.trace_underwriting.public_safe_trace_missing')
+  }
+  if (input.evidence.verdictState !== 'accepted') {
+    blockers.push('blocker.trace_underwriting.accepted_verdict_missing')
+  }
+  if (input.evidence.usageTruth !== 'exact') {
+    blockers.push('blocker.trace_underwriting.exact_usage_missing')
+  }
+  if (input.evidence.tokenUsageEventRefs.length === 0) {
+    blockers.push('blocker.trace_underwriting.token_usage_event_missing')
+  }
+  if (input.evidence.meteringReceiptRefs.length === 0) {
+    blockers.push('blocker.trace_underwriting.metering_receipt_missing')
+  }
+  if (input.sla.refundCapMsat <= 0) {
+    blockers.push('blocker.trace_underwriting.refund_cap_missing')
+  }
+  if (input.rejectionRiskBps < 0 || input.rejectionRiskBps > 10_000) {
+    blockers.push('blocker.trace_underwriting.risk_out_of_range')
+  }
+  if (input.premiumMarginBps < 0) {
+    blockers.push('blocker.trace_underwriting.margin_out_of_range')
+  }
+  return uniqueSorted(blockers)
+}
+
+const warrantyCaveats = (
+  input: OutcomeWarrantyQuoteInput,
+): ReadonlyArray<string> =>
+  uniqueSorted([
+    'caveat.trace_underwriting.inert_quote_only',
+    'caveat.trace_underwriting.refund_execution_requires_separate_authority',
+    input.evidence.settlementReceiptRefs.length === 0
+      ? 'caveat.trace_underwriting.settlement_receipt_not_attached'
+      : null,
+  ])
+
+export const priceOutcomeWarrantyQuote = (
+  unknownInput: OutcomeWarrantyQuoteInput,
+): OutcomeWarrantyQuote => {
+  const input = decodeInput(unknownInput)
+  const blockers = warrantyBlockers(input)
+  const expectedLossMsat = Math.ceil(
+    (input.sla.refundCapMsat * input.rejectionRiskBps) / 10_000,
+  )
+  const premiumMsat =
+    blockers.length > 0
+      ? 0
+      : Math.ceil(expectedLossMsat * (1 + input.premiumMarginBps / 10_000))
+
+  return decodeQuote({
+    acceptedOutcomeRef: input.acceptedOutcomeRef,
+    assignmentRef: input.assignmentRef,
+    caveatRefs: warrantyCaveats(input),
+    coverageKind: input.sla.coverageKind,
+    customerAccountRef: input.customerAccountRef,
+    evidenceRefs: uniqueSorted([
+      input.evidence.traceRef,
+      input.evidence.verdictRef,
+      ...input.evidence.tokenUsageEventRefs,
+      ...input.evidence.meteringReceiptRefs,
+      ...input.evidence.settlementReceiptRefs,
+    ]),
+    expectedLossMsat: blockers.length > 0 ? 0 : expectedLossMsat,
+    premiumMarginBps: input.premiumMarginBps,
+    premiumMsat,
+    publicClaimEligible: false,
+    quoteRef: quoteRefForInput(input),
+    refundCapMsat: input.sla.refundCapMsat,
+    refundExecutionAuthority: false,
+    rejectionRiskBps: input.rejectionRiskBps,
+    schemaVersion: TRACE_ECONOMIC_UNDERWRITING_QUOTE_SCHEMA,
+    settlementMutationAllowed: false,
+    state: blockers.length === 0 ? 'offered' : 'blocked',
+    blockerRefs: blockers,
+  })
+}


### PR DESCRIPTION
Addresses #6426.

### Changes
- Updated the trace-economic underwriting implementation.
- Added/updated coverage for trace-economic underwriting behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` - passed (exit 0)