### PR TITLE
feat(operator): add unified fleet status tool

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -17,6 +17,7 @@ import {
   isSafeArtanisAssignmentRef,
   isSafeArtanisRepoPath,
   makeArtanisDispatchCodexTaskTool,
+  makeArtanisGetFleetStatusTool,
   makeArtanisGetGlmFleetStatusTool,
   makeArtanisGetSyntheticLoadStatusTool,
   makeArtanisGetKhalaFeedbackTool,
@@ -1633,6 +1634,131 @@ describe('#6359 get_network_stats (live public stats + token pace)', () => {
   })
 })
 
+describe('get_fleet_status (unified operator fleet read)', () => {
+  test('composes pace, fleet, watchdog, GLM, and brain status in one read', async () => {
+    const tool = makeArtanisGetFleetStatusTool({
+      glmFleetStatus: {
+        loadFleetStatus: async (): Promise<ArtanisGlmFleetStatus> => ({
+          readyReplicas: 4,
+          status: 'ready',
+          totalReplicas: 5,
+          warmReplicas: 1,
+        }),
+      },
+      networkStats: {
+        loadStats: async () => ({
+          allTimeTokensServed: 9_000,
+          generatedAt: '2026-06-27T17:00:00.000Z',
+          history: [],
+          modelMix: [],
+          pace: {
+            behindPace: true,
+            day: '2026-06-27',
+            fractionOfCentralDayElapsed: 0.5,
+            gapToTarget4x: 300,
+            paceProjection: 100,
+            target10x: 1_000,
+            target4x: 400,
+            todayTokens: 50,
+            yesterdayTokens: 100,
+          },
+          timezone: 'America/Chicago',
+          todayTokens: 50,
+        }),
+      },
+      pylonAssignments: {
+        lister: async (): Promise<ReadonlyArray<ArtanisPylonAssignmentSummary>> => [
+          {
+            assignmentRef: 'assignment.public.pylon_api.pass',
+            jobKind: 'codex_agent_task',
+            leaseState: 'terminal',
+            phase: 'proof-ready',
+            state: 'closeout_submitted',
+            updatedAt: 'a minute ago',
+            verifyResult: 'pass',
+          },
+          {
+            assignmentRef: 'assignment.public.pylon_api.running',
+            jobKind: 'codex_agent_task',
+            leaseState: 'active',
+            phase: 'accepted',
+            state: 'accepted',
+            updatedAt: 'now',
+            verifyResult: 'unknown',
+          },
+        ],
+      },
+      syntheticLoadStatus: {
+        reader: async (): Promise<ReadonlyArray<ArtanisSyntheticLoadRun>> => [
+          {
+            runRef: 'synthetic_load.terminal_bench.public.one',
+            runType: 'terminal-bench',
+            state: 'running',
+            targetTokens: 10_000,
+            tokensBurned: 2_500,
+          },
+        ],
+      },
+      traceReview: {
+        loadReport: async () => ({
+          aggregates: {
+            rawCodexEvents: { rowCount: 1 },
+            tokens: { eventCount: 2, totalTokens: 345 },
+            traces: { traceCount: 3 },
+          },
+          outcomes: [{ count: 2, outcome: 'accepted', totalTokens: 345 }],
+          window: {
+            hours: 24,
+            since: '2026-06-26T17:00:00.000Z',
+            until: '2026-06-27T17:00:00.000Z',
+          },
+        }),
+      },
+    })
+
+    expect(tool.kind).toBe('read')
+    expect(tool.definition.name).toBe('get_fleet_status')
+
+    const result = await Effect.runPromise(tool.execute({}))
+    expect(result).toContain('Unified fleet status')
+    expect(result).toContain('Pace: Token pace for 2026-06-27')
+    expect(result).toContain('BEHIND PACE')
+    expect(result).toContain(
+      'Fleet: 2 recent Pylon/Codex assignments; active=1, pass=1, fail=0, in-progress=1.',
+    )
+    expect(result).toContain('assignment.public.pylon_api.running')
+    expect(result).toContain('Watchdog: 1 active synthetic-load run')
+    expect(result).toContain('2500/10000 tokens')
+    expect(result).toContain('GLM: status=ready, ready=4/5, warm=1.')
+    expect(result).toContain(
+      'Brain: trace-review 3 turns / 345 tokens over 24h; top outcome=accepted.',
+    )
+  })
+
+  test('degrades missing or failing readers to honest unavailable sections', async () => {
+    const tool = makeArtanisGetFleetStatusTool({
+      networkStats: {
+        loadStats: async () => {
+          throw new Error('stats down')
+        },
+      },
+      pylonAssignments: {
+        lister: async () => {
+          throw new Error('d1 down')
+        },
+      },
+    })
+
+    const result = await Effect.runPromise(tool.execute({}))
+    expect(result).toContain('Pace: unavailable')
+    expect(result).toContain('Fleet: unavailable')
+    expect(result).toContain('Watchdog: unavailable')
+    expect(result).toContain('GLM: unavailable')
+    expect(result).toContain('Brain: unavailable')
+    expect(result).not.toContain('Error:')
+  })
+})
+
 describe('trigger_synthetic_load (RISKY plan-only) — iteration 4', () => {
   const tool = makeArtanisTriggerSyntheticLoadTool()
 
@@ -2222,6 +2348,7 @@ describe('makeArtanisOperatorTools default table', () => {
     const names = tools.map(tool => tool.definition.name).sort()
     expect(names).toEqual([
       'dispatch_codex_task',
+      'get_fleet_status',
       'get_glm_fleet_status',
       'get_khala_feedback',
       'get_network_stats',
@@ -2269,6 +2396,13 @@ describe('makeArtanisOperatorTools default table', () => {
   test('the default table includes a read-kind get_glm_fleet_status tool', () => {
     const tools = makeArtanisOperatorTools()
     const tool = tools.find(t => t.definition.name === 'get_glm_fleet_status')
+    expect(tool).toBeDefined()
+    expect(tool?.kind).toBe('read')
+  })
+
+  test('the default table includes a read-kind get_fleet_status tool', () => {
+    const tools = makeArtanisOperatorTools()
+    const tool = tools.find(t => t.definition.name === 'get_fleet_status')
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
   })

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -42,6 +42,7 @@ import type {
 } from './artanis-operator'
 import {
   type ArtanisGetNetworkStatsConfig,
+  type ArtanisNetworkStats,
   fetchArtanisNetworkStats,
   formatArtanisTokenPaceLine,
 } from './artanis-token-pace'
@@ -2372,6 +2373,185 @@ export const makeArtanisGetNetworkStatsTool = (
 })
 
 // ---------------------------------------------------------------------------
+// get_fleet_status — unified operator fleet status for one-turn decisions.
+// ---------------------------------------------------------------------------
+//
+// Read-only composition of the status buckets Artanis otherwise has to gather
+// through several separate tools. It deliberately reuses the existing read
+// loaders: pace from get_network_stats, Pylon/Codex spread from
+// list_pylon_assignments, GLM readiness from get_glm_fleet_status, synthetic
+// load/watchdog state from get_synthetic_load_status, and trace-review/goal
+// health from get_trace_review. No dispatch, spend, scale-out, or quarantine
+// authority is added here; this is one bounded status read.
+
+export type ArtanisFleetStatusConfig = Readonly<{
+  networkStats?: ArtanisGetNetworkStatsConfig | undefined
+  pylonAssignments?: ArtanisPylonAssignmentsConfig | undefined
+  glmFleetStatus?: ArtanisGlmFleetStatusConfig | undefined
+  syntheticLoadStatus?: ArtanisSyntheticLoadStatusConfig | undefined
+  traceReview?: ArtanisTraceReviewConfig | undefined
+}>
+
+const fleetStatusUnavailableLine = (label: string): string =>
+  `${label}: unavailable (reader not wired or failed).`
+
+const loadFleetStatusNetworkStats = (
+  config: ArtanisGetNetworkStatsConfig | undefined,
+): Effect.Effect<ArtanisNetworkStats | null> =>
+  Effect.tryPromise(() =>
+    (config?.loadStats ?? (() => fetchArtanisNetworkStats(config ?? {})))(),
+  ).pipe(Effect.orElseSucceed(() => null))
+
+const loadFleetStatusAssignments = (
+  config: ArtanisPylonAssignmentsConfig | undefined,
+): Effect.Effect<ReadonlyArray<ArtanisPylonAssignmentSummary> | null> => {
+  if (config?.lister === undefined) {
+    return Effect.succeed(null)
+  }
+  const limit =
+    config.defaultLimit ?? ARTANIS_ASSIGNMENTS_LIST_DEFAULT_LIMIT
+  return Effect.tryPromise(() => config.lister!(limit)).pipe(
+    Effect.orElseSucceed(() => null),
+  )
+}
+
+const loadFleetStatusGlm = (
+  config: ArtanisGlmFleetStatusConfig | undefined,
+): Effect.Effect<ArtanisGlmFleetStatus | null> => {
+  if (config?.loadFleetStatus === undefined) {
+    return Effect.succeed(null)
+  }
+  return Effect.tryPromise(() => config.loadFleetStatus!()).pipe(
+    Effect.orElseSucceed(() => null),
+  )
+}
+
+const loadFleetStatusSyntheticRuns = (
+  config: ArtanisSyntheticLoadStatusConfig | undefined,
+): Effect.Effect<ReadonlyArray<ArtanisSyntheticLoadRun> | null> => {
+  if (config?.reader === undefined) {
+    return Effect.succeed(null)
+  }
+  return Effect.tryPromise(() => config.reader!()).pipe(
+    Effect.orElseSucceed(() => null),
+  )
+}
+
+const loadFleetStatusTraceReview = (
+  config: ArtanisTraceReviewConfig | undefined,
+): Effect.Effect<ArtanisTraceReviewSummary | null> => {
+  if (config?.loadReport === undefined) {
+    return Effect.succeed(null)
+  }
+  return Effect.tryPromise(() => config.loadReport!()).pipe(
+    Effect.map(normalizeArtanisTraceReview),
+    Effect.orElseSucceed(() => null),
+  )
+}
+
+const formatFleetAssignmentSpread = (
+  assignments: ReadonlyArray<ArtanisPylonAssignmentSummary> | null,
+): string => {
+  if (assignments === null) {
+    return fleetStatusUnavailableLine('Fleet')
+  }
+  if (assignments.length === 0) {
+    return 'Fleet: no recent Pylon/Codex assignments.'
+  }
+  const active = assignments.filter(summary =>
+    ['accepted', 'offered', 'running'].includes(summary.state),
+  ).length
+  const failed = assignments.filter(
+    summary => summary.verifyResult === 'fail',
+  ).length
+  const passed = assignments.filter(
+    summary => summary.verifyResult === 'pass',
+  ).length
+  const inProgress = assignments.length - failed - passed
+  return [
+    `Fleet: ${assignments.length} recent Pylon/Codex assignments; active=${active}, pass=${passed}, fail=${failed}, in-progress=${inProgress}.`,
+    ...assignments.slice(0, 8).map(formatAssignmentSummaryLine),
+  ].join('\n')
+}
+
+const formatFleetGlmLine = (status: ArtanisGlmFleetStatus | null): string =>
+  status === null
+    ? fleetStatusUnavailableLine('GLM')
+    : `GLM: status=${status.status}, ready=${status.readyReplicas}/${status.totalReplicas}, warm=${status.warmReplicas ?? 0}.`
+
+const formatFleetWatchdogLine = (
+  runs: ReadonlyArray<ArtanisSyntheticLoadRun> | null,
+): string => {
+  if (runs === null) {
+    return fleetStatusUnavailableLine('Watchdog')
+  }
+  if (runs.length === 0) {
+    return 'Watchdog: no active synthetic-load runs reported.'
+  }
+  return [
+    `Watchdog: ${runs.length} active synthetic-load run(s).`,
+    ...runs.slice(0, 5).map(run => {
+      const progress =
+        run.targetTokens === null || run.targetTokens <= 0
+          ? 'tokens unknown'
+          : `${run.tokensBurned}/${run.targetTokens} tokens`
+      return `- ${run.runRef} | ${run.runType} | state=${run.state} | ${progress}`
+    }),
+  ].join('\n')
+}
+
+const formatFleetBrainLine = (trace: ArtanisTraceReviewSummary | null): string =>
+  trace === null
+    ? fleetStatusUnavailableLine('Brain')
+    : `Brain: trace-review ${trace.traceCount} turns / ${trace.totalTokens} tokens over ${trace.windowHours ?? 'unknown'}h; top outcome=${trace.outcomes[0]?.outcome ?? 'none'}.`
+
+export const makeArtanisGetFleetStatusTool = (
+  config: ArtanisFleetStatusConfig = {},
+): ArtanisOperatorReadTool => ({
+  definition: {
+    description:
+      'Read the unified operator fleet status in one bounded call: Pace (token burn rate and gap to floor), Fleet (Pylon/Codex concurrency, recent assignment spread, pass/fail/in-flight), Watchdog (active synthetic-load/lease alerts when wired), GLM (serving readiness), and Brain (Artanis/Khala trace-review health). Read-only, side-effect-free, public-safe aggregates only; grants no dispatch, spend, scale-out, quarantine, payout, or deployment authority.',
+    name: 'get_fleet_status',
+    parameters: {
+      additionalProperties: false,
+      properties: {},
+      type: 'object',
+    },
+  },
+  execute: (_args: unknown) =>
+    Effect.gen(function* () {
+      const [networkStats, assignments, glm, syntheticRuns, traceReview] =
+        yield* Effect.all([
+          loadFleetStatusNetworkStats(config.networkStats),
+          loadFleetStatusAssignments(config.pylonAssignments),
+          loadFleetStatusGlm(config.glmFleetStatus),
+          loadFleetStatusSyntheticRuns(config.syntheticLoadStatus),
+          loadFleetStatusTraceReview(config.traceReview),
+        ])
+
+      const pace =
+        networkStats?.pace === undefined || networkStats.pace === null
+          ? 'unavailable (reader not wired or failed).'
+          : formatArtanisTokenPaceLine(networkStats.pace)
+
+      return [
+        'Unified fleet status:',
+        '',
+        `Pace: ${pace}`,
+        '',
+        formatFleetAssignmentSpread(assignments),
+        '',
+        formatFleetWatchdogLine(syntheticRuns),
+        '',
+        formatFleetGlmLine(glm),
+        '',
+        formatFleetBrainLine(traceReview),
+      ].join('\n')
+    }),
+  kind: 'read',
+})
+
+// ---------------------------------------------------------------------------
 // get_glm_fleet_status — LIVE GLM inference-fleet readiness (iteration 7).
 // ---------------------------------------------------------------------------
 //
@@ -3337,6 +3517,7 @@ export const makeArtanisOperatorTools = (
     pylonAssignments?: ArtanisPylonAssignmentsConfig | undefined
     khalaFeedback?: ArtanisKhalaFeedbackConfig | undefined
     traceReview?: ArtanisTraceReviewConfig | undefined
+    fleetStatus?: ArtanisFleetStatusConfig | undefined
     unsupportedRequests?: ArtanisUnsupportedRequestsConfig | undefined
     unsupportedRequestWriter?: ArtanisUnsupportedRequestWriter | undefined
     defaultBranch?: string | undefined
@@ -3367,6 +3548,16 @@ export const makeArtanisOperatorTools = (
       repo: issueRead.repo,
     }),
     makeArtanisGetNetworkStatsTool(config.networkStats),
+    makeArtanisGetFleetStatusTool({
+      glmFleetStatus: config.fleetStatus?.glmFleetStatus ?? config.glmFleetStatus,
+      networkStats: config.fleetStatus?.networkStats ?? config.networkStats,
+      pylonAssignments:
+        config.fleetStatus?.pylonAssignments ?? config.pylonAssignments,
+      syntheticLoadStatus:
+        config.fleetStatus?.syntheticLoadStatus ??
+        config.syntheticLoadStatus,
+      traceReview: config.fleetStatus?.traceReview ?? config.traceReview,
+    }),
     makeArtanisGetGlmFleetStatusTool(config.glmFleetStatus),
     makeArtanisGetSyntheticLoadStatusTool(config.syntheticLoadStatus),
     makeArtanisGetPylonJobStatusTool(config.pylonJobStatus),


### PR DESCRIPTION
Addresses #6428.

### Changes
- Added `get_fleet_status` as a read-only Artanis operator tool that composes token pace, recent Pylon/Codex assignments, synthetic load watchdog state, GLM readiness, and trace-review health into one status read.
- Added graceful unavailable output for missing or failing status readers without exposing raw errors.
- Registered the new tool in the default Artanis operator tool table.
- Added tests for the composed happy path, degraded-reader behavior, and default tool registration.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)