### PR TITLE
feat(gym): add AgentCL repo-reuse evaluation

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/benchmark/matrix.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/matrix.ts
@@ -75,6 +75,9 @@ export const BenchmarkWorkload = S.Literals([
   'khala-code-artifact-gen',
   'verifier-run',
   'long-context-codebase-question',
+  'agentcl-source-task',
+  'agentcl-complex-task',
+  'agentcl-held-out-task',
 ])
 export type BenchmarkWorkload = typeof BenchmarkWorkload.Type
 
@@ -302,6 +305,10 @@ export const verificationExpectationForWorkload = (
 ): BenchmarkVerificationExpectation => {
   switch (workload) {
     case 'chat':
+      return 'none'
+    case 'agentcl-source-task':
+    case 'agentcl-complex-task':
+    case 'agentcl-held-out-task':
       return 'none'
     case 'long-context-codebase-question':
       return 'seeded'

--- a/apps/openagents.com/workers/api/src/inference/benchmark/speculation-lane.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/speculation-lane.ts
@@ -38,6 +38,9 @@ const isCodeWorkload = (cell: BenchmarkCell): boolean => {
     case 'khala-code-artifact-gen':
     case 'verifier-run':
     case 'long-context-codebase-question':
+    case 'agentcl-source-task':
+    case 'agentcl-complex-task':
+    case 'agentcl-held-out-task':
       return true
     case 'chat':
       return false

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  AGENTCL_EVAL_SCHEMA,
+  AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
+  AGENTCL_REPO_REUSE_PLAN_SCHEMA,
+  buildAgentClRepoReusePlan,
+  runAgentClRepoReuseFixtureEval,
+} from './agentcl'
+
+describe('AgentCL repo-reuse gym environment', () => {
+  test('builds a public-safe two-pass compositional stream plan', () => {
+    const { compiled, plan } = buildAgentClRepoReusePlan(
+      AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
+    )
+
+    expect(plan.schemaVersion).toBe(AGENTCL_REPO_REUSE_PLAN_SCHEMA)
+    expect(plan.environmentRef).toBe('agentcl-repo-reuse')
+    expect(plan.streamKind).toBe('compositional')
+    expect(plan.sourceTasks).toHaveLength(4)
+    expect(plan.complexTasks).toHaveLength(2)
+    expect(plan.heldOutTasks).toHaveLength(1)
+    expect(plan.passes.map(pass => pass.pass)).toEqual([
+      'baseline',
+      'first_pass',
+      'frozen_second_pass',
+      'held_out_pass',
+    ])
+    expect(plan.passes.map(pass => pass.memoryAccess)).toEqual([
+      'disabled',
+      'read_write',
+      'read_only_frozen',
+      'read_only_frozen',
+    ])
+    expect(plan.publicSafetyBoundary).toEqual({
+      publicTaskRefsOnly: true,
+      rawPromptsStayOwnerPrivate: true,
+      noTrainingOnHeldOut: true,
+      reportPgSgGgSeparately: true,
+      publicClaimEligible: false,
+    })
+    expect(compiled.policySelection.environment.acceptanceContractRef).toBe(
+      'acceptance.gym.agentcl.report_only_no_claim.v0',
+    )
+  })
+
+  test('emits agentcl_eval.v0 with separate plasticity, stability, and generalization gains', () => {
+    const result = runAgentClRepoReuseFixtureEval(
+      AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
+    )
+
+    expect(result.eval.schemaVersion).toBe(AGENTCL_EVAL_SCHEMA)
+    expect(result.eval.baseline.acceptedOutcomeRate).toBe(0.45)
+    expect(result.eval.firstPass.acceptedOutcomeRate).toBe(0.62)
+    expect(result.eval.frozenSecondPass.acceptedOutcomeRate).toBe(0.58)
+    expect(result.eval.heldOutBaseline.acceptedOutcomeRate).toBe(0.7)
+    expect(result.eval.heldOutPass.acceptedOutcomeRate).toBe(0.66)
+    expect(result.eval.plasticityGain).toBe(0.17)
+    expect(result.eval.stabilityGain).toBe(-0.04)
+    expect(result.eval.generalizationGain).toBe(-0.04)
+    expect(result.eval.claimDiscipline).toMatchObject({
+      decisionGrade: false,
+      publicClaimEligible: false,
+      collapseGainsIntoOneNumber: false,
+    })
+    expect(result.eval.claimDiscipline.notes).toContain(
+      'negative_stability_gain_requires_memory_review',
+    )
+    expect(result.eval.claimDiscipline.notes).toContain(
+      'negative_generalization_gain_blocks_generalizes_claim',
+    )
+  })
+
+  test('keeps held-out tasks out of read-write memory construction passes', () => {
+    const { plan } = buildAgentClRepoReusePlan()
+    const heldOutRefs = new Set(plan.heldOutTasks.map(task => task.taskRef))
+    const memoryWritePasses = plan.passes.filter(
+      pass => pass.memoryAccess === 'read_write',
+    )
+
+    expect(memoryWritePasses).toHaveLength(1)
+    for (const pass of memoryWritePasses) {
+      expect(pass.taskRefs.some(ref => heldOutRefs.has(ref))).toBe(false)
+    }
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
@@ -1,0 +1,340 @@
+import { Schema as S } from 'effect'
+
+import {
+  AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
+  GYM_ENVIRONMENT_REGISTRY,
+  compileGymExperiment,
+  type CompiledGymExperiment,
+  type GymExperiment,
+} from './experiment'
+
+export { AGENTCL_REPO_REUSE_GYM_EXPERIMENT } from './experiment'
+
+export const AGENTCL_EVAL_SCHEMA = 'openagents.gym.agentcl_eval.v0' as const
+export const AGENTCL_REPO_REUSE_PLAN_SCHEMA =
+  'openagents.gym.agentcl_repo_reuse_plan.v0' as const
+
+export const AgentClStreamKind = S.Literals(['naive', 'compositional'])
+export type AgentClStreamKind = typeof AgentClStreamKind.Type
+
+export const AgentClTaskRole = S.Literals(['source', 'complex', 'held_out'])
+export type AgentClTaskRole = typeof AgentClTaskRole.Type
+
+export const AgentClPassKind = S.Literals([
+  'baseline',
+  'first_pass',
+  'frozen_second_pass',
+  'held_out_pass',
+])
+export type AgentClPassKind = typeof AgentClPassKind.Type
+
+export const AgentClMemoryAccess = S.Literals([
+  'disabled',
+  'read_write',
+  'read_only_frozen',
+])
+export type AgentClMemoryAccess = typeof AgentClMemoryAccess.Type
+
+export const AgentClRepoReuseTask = S.Struct({
+  taskRef: S.String,
+  role: AgentClTaskRole,
+  packageRef: S.String,
+  publicObjectiveRef: S.String,
+  reusableSolutionRefs: S.Array(S.String),
+  expectedReuseFromTaskRefs: S.Array(S.String),
+})
+export type AgentClRepoReuseTask = typeof AgentClRepoReuseTask.Type
+
+export const AgentClRepoReusePassPlan = S.Struct({
+  pass: AgentClPassKind,
+  memoryAccess: AgentClMemoryAccess,
+  taskRefs: S.Array(S.String),
+  dispatchSurfaceRef: S.String,
+  harborDispatchProfileRef: S.String,
+})
+export type AgentClRepoReusePassPlan =
+  typeof AgentClRepoReusePassPlan.Type
+
+export const AgentClRepoReusePlan = S.Struct({
+  schemaVersion: S.Literal(AGENTCL_REPO_REUSE_PLAN_SCHEMA),
+  environmentRef: S.Literal('agentcl-repo-reuse'),
+  experimentId: S.String,
+  streamKind: AgentClStreamKind,
+  sourceTasks: S.Array(AgentClRepoReuseTask),
+  complexTasks: S.Array(AgentClRepoReuseTask),
+  heldOutTasks: S.Array(AgentClRepoReuseTask),
+  passes: S.Array(AgentClRepoReusePassPlan),
+  memorySystemsUnderTest: S.Array(S.String),
+  publicSafetyBoundary: S.Struct({
+    publicTaskRefsOnly: S.Literal(true),
+    rawPromptsStayOwnerPrivate: S.Literal(true),
+    noTrainingOnHeldOut: S.Literal(true),
+    reportPgSgGgSeparately: S.Literal(true),
+    publicClaimEligible: S.Literal(false),
+  }),
+})
+export type AgentClRepoReusePlan = typeof AgentClRepoReusePlan.Type
+
+export const AgentClPassScore = S.Struct({
+  pass: AgentClPassKind,
+  taskRole: AgentClTaskRole,
+  taskCount: S.Number,
+  acceptedOutcomeRate: S.Number.check(S.isBetween({ minimum: 0, maximum: 1 })),
+})
+export type AgentClPassScore = typeof AgentClPassScore.Type
+
+export const AgentClEval = S.Struct({
+  schemaVersion: S.Literal(AGENTCL_EVAL_SCHEMA),
+  environmentRef: S.Literal('agentcl-repo-reuse'),
+  experimentId: S.String,
+  streamKind: AgentClStreamKind,
+  memorySystemsUnderTest: S.Array(S.String),
+  baseline: AgentClPassScore,
+  firstPass: AgentClPassScore,
+  frozenSecondPass: AgentClPassScore,
+  heldOutBaseline: AgentClPassScore,
+  heldOutPass: AgentClPassScore,
+  plasticityGain: S.Number,
+  stabilityGain: S.Number,
+  generalizationGain: S.Number,
+  claimDiscipline: S.Struct({
+    decisionGrade: S.Literal(false),
+    publicClaimEligible: S.Literal(false),
+    collapseGainsIntoOneNumber: S.Literal(false),
+    notes: S.Array(S.String),
+  }),
+  proofRefs: S.Array(S.String),
+})
+export type AgentClEval = typeof AgentClEval.Type
+
+const decodePlan = S.decodeUnknownSync(AgentClRepoReusePlan)
+const decodeEval = S.decodeUnknownSync(AgentClEval)
+
+const roundGain = (value: number): number => Math.round(value * 1000) / 1000
+
+const agentClTaskRefs = (
+  tasks: ReadonlyArray<AgentClRepoReuseTask>,
+): ReadonlyArray<string> => tasks.map(task => task.taskRef)
+
+const SOURCE_TASKS: ReadonlyArray<AgentClRepoReuseTask> = [
+  {
+    taskRef: 'agentcl.repo_reuse.source.effect_schema_contract.v0',
+    role: 'source',
+    packageRef: 'apps/openagents.com/workers/api/src/inference/gym',
+    publicObjectiveRef: 'public.issue.6420.source.agentcl_eval_contract',
+    reusableSolutionRefs: ['solution.agentcl.effect_schema.pg_sg_gg.v0'],
+    expectedReuseFromTaskRefs: [],
+  },
+  {
+    taskRef: 'agentcl.repo_reuse.source.harbor_public_receipt.v0',
+    role: 'source',
+    packageRef: 'apps/openagents.com/workers/api/src/inference/gym',
+    publicObjectiveRef: 'public.issue.6420.source.harbor_dispatch_receipts',
+    reusableSolutionRefs: ['solution.agentcl.harbor_dispatch_profile.v0'],
+    expectedReuseFromTaskRefs: [],
+  },
+  {
+    taskRef: 'agentcl.repo_reuse.source.tas_memory_ref.v0',
+    role: 'source',
+    packageRef: 'apps/pylon/src/tas',
+    publicObjectiveRef: 'public.issue.6420.source.tas_memory_public_refs',
+    reusableSolutionRefs: ['solution.agentcl.memory_reference_only.v0'],
+    expectedReuseFromTaskRefs: [],
+  },
+  {
+    taskRef: 'agentcl.repo_reuse.source.omni_retrieval_ref.v0',
+    role: 'source',
+    packageRef: 'apps/openagents.com/workers/api/src/inference',
+    publicObjectiveRef: 'public.issue.6420.source.omni_retrieval_public_refs',
+    reusableSolutionRefs: ['solution.agentcl.retrieve_but_verify.v0'],
+    expectedReuseFromTaskRefs: [],
+  },
+]
+
+const COMPLEX_TASKS: ReadonlyArray<AgentClRepoReuseTask> = [
+  {
+    taskRef: 'agentcl.repo_reuse.complex.two_pass_runner.v0',
+    role: 'complex',
+    packageRef: 'apps/openagents.com/workers/api/src/inference/gym',
+    publicObjectiveRef: 'public.issue.6420.complex.two_pass_runner',
+    reusableSolutionRefs: ['solution.agentcl.pass_plan.composition.v0'],
+    expectedReuseFromTaskRefs: SOURCE_TASKS.map(task => task.taskRef),
+  },
+  {
+    taskRef: 'agentcl.repo_reuse.complex.pg_sg_gg_report.v0',
+    role: 'complex',
+    packageRef: 'apps/openagents.com/workers/api/src/inference/gym',
+    publicObjectiveRef: 'public.issue.6420.complex.pg_sg_gg_report',
+    reusableSolutionRefs: ['solution.agentcl.separate_gain_report.v0'],
+    expectedReuseFromTaskRefs: [
+      'agentcl.repo_reuse.source.effect_schema_contract.v0',
+      'agentcl.repo_reuse.source.harbor_public_receipt.v0',
+    ],
+  },
+]
+
+const HELD_OUT_TASKS: ReadonlyArray<AgentClRepoReuseTask> = [
+  {
+    taskRef: 'agentcl.repo_reuse.held_out.mirrorcode_no_rag.v0',
+    role: 'held_out',
+    packageRef: 'apps/openagents.com/scripts/mirrorcode',
+    publicObjectiveRef: 'public.issue.6420.held_out.mirrorcode_no_rag',
+    reusableSolutionRefs: [],
+    expectedReuseFromTaskRefs: [],
+  },
+]
+
+export const buildAgentClRepoReusePlan = (
+  experiment: GymExperiment = AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
+): Readonly<{
+  compiled: CompiledGymExperiment
+  plan: AgentClRepoReusePlan
+}> => {
+  const compiled = compileGymExperiment(experiment)
+  const definition = GYM_ENVIRONMENT_REGISTRY['agentcl-repo-reuse']
+  const passBase = {
+    dispatchSurfaceRef: 'gym.harbor_dispatch.public_safe_plan.v0',
+    harborDispatchProfileRef: 'harbor.dispatch.agentcl.repo_reuse.no_spend.v0',
+  }
+  return {
+    compiled,
+    plan: decodePlan({
+      schemaVersion: AGENTCL_REPO_REUSE_PLAN_SCHEMA,
+      environmentRef: 'agentcl-repo-reuse',
+      experimentId: experiment.id,
+      streamKind: 'compositional',
+      sourceTasks: SOURCE_TASKS,
+      complexTasks: COMPLEX_TASKS,
+      heldOutTasks: HELD_OUT_TASKS,
+      passes: [
+        {
+          ...passBase,
+          pass: 'baseline',
+          memoryAccess: 'disabled',
+          taskRefs: [
+            ...agentClTaskRefs(SOURCE_TASKS),
+            ...agentClTaskRefs(COMPLEX_TASKS),
+          ],
+        },
+        {
+          ...passBase,
+          pass: 'first_pass',
+          memoryAccess: 'read_write',
+          taskRefs: [
+            ...agentClTaskRefs(SOURCE_TASKS),
+            ...agentClTaskRefs(COMPLEX_TASKS),
+          ],
+        },
+        {
+          ...passBase,
+          pass: 'frozen_second_pass',
+          memoryAccess: 'read_only_frozen',
+          taskRefs: agentClTaskRefs(COMPLEX_TASKS),
+        },
+        {
+          ...passBase,
+          pass: 'held_out_pass',
+          memoryAccess: 'read_only_frozen',
+          taskRefs: agentClTaskRefs(HELD_OUT_TASKS),
+        },
+      ],
+      memorySystemsUnderTest: experiment.policy.modules.moduleRefs,
+      publicSafetyBoundary: {
+        publicTaskRefsOnly: true,
+        rawPromptsStayOwnerPrivate: true,
+        noTrainingOnHeldOut: true,
+        reportPgSgGgSeparately: true,
+        publicClaimEligible: definition.acceptance.publicClaimEligible,
+      },
+    }),
+  }
+}
+
+export const runAgentClRepoReuseFixtureEval = (
+  experiment: GymExperiment = AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
+): Readonly<{
+  compiled: CompiledGymExperiment
+  plan: AgentClRepoReusePlan
+  eval: AgentClEval
+}> => {
+  const { compiled, plan } = buildAgentClRepoReusePlan(experiment)
+  const baseline: AgentClPassScore = {
+    pass: 'baseline',
+    taskRole: 'complex',
+    taskCount: plan.complexTasks.length,
+    acceptedOutcomeRate: 0.45,
+  }
+  const firstPass: AgentClPassScore = {
+    pass: 'first_pass',
+    taskRole: 'complex',
+    taskCount: plan.complexTasks.length,
+    acceptedOutcomeRate: 0.62,
+  }
+  const frozenSecondPass: AgentClPassScore = {
+    pass: 'frozen_second_pass',
+    taskRole: 'complex',
+    taskCount: plan.complexTasks.length,
+    acceptedOutcomeRate: 0.58,
+  }
+  const heldOutBaseline: AgentClPassScore = {
+    pass: 'baseline',
+    taskRole: 'held_out',
+    taskCount: plan.heldOutTasks.length,
+    acceptedOutcomeRate: 0.7,
+  }
+  const heldOutPass: AgentClPassScore = {
+    pass: 'held_out_pass',
+    taskRole: 'held_out',
+    taskCount: plan.heldOutTasks.length,
+    acceptedOutcomeRate: 0.66,
+  }
+
+  const plasticityGain = roundGain(
+    firstPass.acceptedOutcomeRate - baseline.acceptedOutcomeRate,
+  )
+  const stabilityGain = roundGain(
+    frozenSecondPass.acceptedOutcomeRate - firstPass.acceptedOutcomeRate,
+  )
+  const generalizationGain = roundGain(
+    heldOutPass.acceptedOutcomeRate - heldOutBaseline.acceptedOutcomeRate,
+  )
+
+  return {
+    compiled,
+    plan,
+    eval: decodeEval({
+      schemaVersion: AGENTCL_EVAL_SCHEMA,
+      environmentRef: 'agentcl-repo-reuse',
+      experimentId: experiment.id,
+      streamKind: plan.streamKind,
+      memorySystemsUnderTest: plan.memorySystemsUnderTest,
+      baseline,
+      firstPass,
+      frozenSecondPass,
+      heldOutBaseline,
+      heldOutPass,
+      plasticityGain,
+      stabilityGain,
+      generalizationGain,
+      claimDiscipline: {
+        decisionGrade: false,
+        publicClaimEligible: false,
+        collapseGainsIntoOneNumber: false,
+        notes: [
+          'fixture_only_first_measurement_not_a_product_claim',
+          stabilityGain < 0
+            ? 'negative_stability_gain_requires_memory_review'
+            : 'non_negative_stability_gain',
+          generalizationGain < 0
+            ? 'negative_generalization_gain_blocks_generalizes_claim'
+            : 'non_negative_generalization_gain',
+        ],
+      },
+      proofRefs: [
+        compiled.policySelection.environment.taskSetRef,
+        compiled.policySelection.environment.verifierRef,
+        compiled.policySelection.environment.acceptanceContractRef,
+      ],
+    }),
+  }
+}

--- a/apps/openagents.com/workers/api/src/inference/gym/experiment.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/experiment.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
   BUNDLED_GYM_EXPERIMENT,
+  AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
   GYM_ENVIRONMENT_REGISTRY,
   KHALA_CODE_GYM_EXPERIMENT,
   LONG_CONTEXT_CODEBASE_QA_GYM_EXPERIMENT,
@@ -73,6 +74,7 @@ describe('Gym environment registry', () => {
       'long-context-codebase-qa',
       'm8-head-to-head',
       'throughput-concurrency',
+      'agentcl-repo-reuse',
     ])
 
     const terminalBench = getGymEnvironmentDefinition('terminal-bench')
@@ -207,6 +209,27 @@ describe('compileGymExperiment', () => {
       'vllm.max_num_seqs.8.prefix_cache.chunked_prefill.nvfp4',
       'vllm.max_num_seqs.16.prefix_cache.chunked_prefill.nvfp4',
     ])
+  })
+
+  test('expands the AgentCL repo-reuse environment as a compositional stream', () => {
+    const compiled = compileGymExperiment(AGENTCL_REPO_REUSE_GYM_EXPERIMENT)
+
+    expect(compiled.matrixConfig.workloads).toEqual([
+      'agentcl-source-task',
+      'agentcl-complex-task',
+      'agentcl-held-out-task',
+    ])
+    expect(compiled.policySelection.environment.surface).toBe(
+      'continual-learning',
+    )
+    expect(compiled.policySelection.environment.verifierRef).toBe(
+      'verifier.gym.agentcl.two_pass_pg_sg_gg.v0',
+    )
+    expect(compiled.policySelection.modules.moduleRefs).toEqual([
+      'memory.pylon.tas.repo.v0',
+      'retrieval.openagents.omni_trace_context.v0',
+    ])
+    expect(compiled.expectedCellCount).toBe(3)
   })
 
   test('compiles a real-seam experiment without spending', () => {

--- a/apps/openagents.com/workers/api/src/inference/gym/experiment.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/experiment.ts
@@ -35,6 +35,7 @@ export const GymEnvironmentRef = S.Literals([
   'long-context-codebase-qa',
   'm8-head-to-head',
   'throughput-concurrency',
+  'agentcl-repo-reuse',
 ])
 export type GymEnvironmentRef = typeof GymEnvironmentRef.Type
 
@@ -68,6 +69,7 @@ export const GymEnvironmentSurface = S.Literals([
   'retrieval-qa',
   'recorded-head-to-head',
   'throughput-concurrency',
+  'continual-learning',
 ])
 export type GymEnvironmentSurface = typeof GymEnvironmentSurface.Type
 
@@ -80,6 +82,7 @@ export const GymEnvironmentTaskSet = S.Struct({
     'retained-public-fixture',
     'recorded-manifest',
     'throughput-ramp',
+    'agentcl-public-repo-stream',
   ]),
   publicSafeTaskRefs: S.Array(S.String),
   harborDataset: S.optional(S.String),
@@ -93,6 +96,7 @@ export const GymVerifierMode = S.Literals([
   'executed-acceptance',
   'seeded-reference',
   'telemetry-reconciliation',
+  'agentcl-two-pass',
 ])
 export type GymVerifierMode = typeof GymVerifierMode.Type
 
@@ -308,6 +312,20 @@ const THROUGHPUT_CONCURRENCY_RAMP_SHAPES: ReadonlyArray<
   provenance: 'realistic',
 }))
 
+const AGENTCL_REPO_REUSE_SHAPE: typeof SequenceShape.Type = {
+  id: 'agentcl-repo-reuse-two-pass-public-fixture',
+  inputTokens: 7600,
+  outputTokens: 1800,
+  cacheablePrefixTokens: 4200,
+  concurrency: 2,
+  provenance: 'realistic',
+  requestClass: 'async_job',
+  source: 'operator_export',
+  observedTrafficEvidenceRef:
+    'docs/research/agentcl/incorporation-synthesis.md#roadmap-5-6',
+  observedRequestCount: 16,
+}
+
 export const GYM_ENVIRONMENT_REGISTRY: Readonly<
   Record<GymEnvironmentRef, GymEnvironmentDefinition>
 > = {
@@ -489,6 +507,42 @@ export const GYM_ENVIRONMENT_REGISTRY: Readonly<
     },
     defaultShapes: THROUGHPUT_CONCURRENCY_RAMP_SHAPES,
     defaultTools: 'no-tools',
+  },
+  'agentcl-repo-reuse': {
+    ref: 'agentcl-repo-reuse',
+    surface: 'continual-learning',
+    taskSet: {
+      ref: 'taskset.gym.agentcl.repo_reuse.public_stream.v0',
+      source: 'agentcl-public-repo-stream',
+      publicSafeTaskRefs: [
+        'agentcl.repo_reuse.source.effect_schema_contract.v0',
+        'agentcl.repo_reuse.source.harbor_public_receipt.v0',
+        'agentcl.repo_reuse.source.tas_memory_ref.v0',
+        'agentcl.repo_reuse.source.omni_retrieval_ref.v0',
+        'agentcl.repo_reuse.complex.two_pass_runner.v0',
+        'agentcl.repo_reuse.complex.pg_sg_gg_report.v0',
+        'agentcl.repo_reuse.held_out.mirrorcode_no_rag.v0',
+      ],
+    },
+    workloads: [
+      'agentcl-source-task',
+      'agentcl-complex-task',
+      'agentcl-held-out-task',
+    ],
+    verifier: {
+      ref: 'verifier.gym.agentcl.two_pass_pg_sg_gg.v0',
+      mode: 'agentcl-two-pass',
+      expectedOutcome: 'none',
+    },
+    acceptance: {
+      ref: 'acceptance.gym.agentcl.report_only_no_claim.v0',
+      verifierRef: 'verifier.gym.agentcl.two_pass_pg_sg_gg.v0',
+      scalarRewardPassThreshold: 0,
+      requiresExecutedVerifier: false,
+      publicClaimEligible: false,
+    },
+    defaultShapes: [AGENTCL_REPO_REUSE_SHAPE],
+    defaultTools: 'khala-code-tools',
   },
 }
 
@@ -751,12 +805,44 @@ export const THROUGHPUT_CONCURRENCY_GYM_EXPERIMENT: GymExperiment = {
   shapes: GYM_ENVIRONMENT_REGISTRY['throughput-concurrency'].defaultShapes,
 }
 
+export const AGENTCL_REPO_REUSE_GYM_EXPERIMENT: GymExperiment = {
+  ...TERMINAL_BENCH_GYM_EXPERIMENT,
+  id: 'gym-agentcl-repo-reuse-two-pass-fixture-v0',
+  environment: 'agentcl-repo-reuse',
+  policy: {
+    ...TERMINAL_BENCH_GYM_EXPERIMENT.policy,
+    coordinator: 'conductor-v2',
+    fanout: {
+      lanes: ['khala'],
+      mode: 'single',
+      concurrency: 2,
+    },
+    tools: GYM_ENVIRONMENT_REGISTRY['agentcl-repo-reuse'].defaultTools,
+    modules: {
+      mode: 'starter-catalog',
+      signatureRefs: ['program-signature:agentcl-two-pass-runner.v0'],
+      moduleRefs: [
+        'memory.pylon.tas.repo.v0',
+        'retrieval.openagents.omni_trace_context.v0',
+      ],
+    },
+    sampling: {
+      temperature: 0.2,
+      reasoningEffort: 'low',
+      maxTokens: 8192,
+      transport: 'streaming',
+    },
+  },
+  shapes: GYM_ENVIRONMENT_REGISTRY['agentcl-repo-reuse'].defaultShapes,
+}
+
 export const PHASE_1_GYM_ENVIRONMENT_FIXTURE_EXPERIMENTS: ReadonlyArray<GymExperiment> =
   [
     TERMINAL_BENCH_GYM_EXPERIMENT,
     KHALA_CODE_GYM_EXPERIMENT,
     LONG_CONTEXT_CODEBASE_QA_GYM_EXPERIMENT,
     M8_HEAD_TO_HEAD_GYM_EXPERIMENT,
+    AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
   ]
 
 const validateGymExperiment = (

--- a/apps/openagents.com/workers/api/src/inference/gym/index.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/index.ts
@@ -1,3 +1,4 @@
+export * from './agentcl'
 export * from './experiment'
 export * from './flywheel'
 export * from './harbor-dispatch'


### PR DESCRIPTION
Addresses #6420.

### Changes
- Added an AgentCL repo-reuse gym environment with compositional stream task roles, two-pass planning, frozen second-pass and held-out pass support, and public-safety boundaries.
- Added fixture evaluation output for separate plasticity, stability, and generalization gains instead of collapsing them into one score.
- Registered AgentCL source, complex, and held-out benchmark workloads and marked them as code workloads.
- Exported the new gym environment and added tests for plan construction, held-out isolation, and PG/SG/GG evaluation behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).