### PR TITLE
feat(traces): isolate Tassadar GG partition

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
@@ -113,6 +113,19 @@ export const MirrorCodeComparator = S.Struct({
 })
 export type MirrorCodeComparator = typeof MirrorCodeComparator.Type
 
+export const MirrorCodeGeneralizationSet = S.Struct({
+  setRef: S.Literal('gg.mirrorcode.public_tasks.no_rag.v1'),
+  metric: S.Literal('generalization_gain'),
+  scope: S.Literal('public_tasks_only'),
+  privateSet: S.Literal('excluded'),
+  taskContentExposure: S.Literal('never_store_or_echo'),
+  retrievalPolicy: S.Literal('no_rag_on_tasks'),
+  trainingPolicy: S.Literal('no_training_or_optimization_on_tasks'),
+  decisionGradeRule: S.Literal('owner_armed_scored_terminal_runs_only'),
+})
+export type MirrorCodeGeneralizationSet =
+  typeof MirrorCodeGeneralizationSet.Type
+
 // Typed ingest error so the route can map it to a 400 without leaking internals.
 export class MirrorCodeRunError extends Error {
   readonly _tag = 'MirrorCodeRunError'
@@ -262,3 +275,14 @@ export const MIRRORCODE_BENCHMARK_LABEL = {
   name: 'Epoch Research MirrorCode',
   scope: 'public tasks only (private set excluded)',
 } as const
+
+export const MIRRORCODE_GENERALIZATION_SET: MirrorCodeGeneralizationSet = {
+  decisionGradeRule: 'owner_armed_scored_terminal_runs_only',
+  metric: 'generalization_gain',
+  privateSet: 'excluded',
+  retrievalPolicy: 'no_rag_on_tasks',
+  scope: 'public_tasks_only',
+  setRef: 'gg.mirrorcode.public_tasks.no_rag.v1',
+  taskContentExposure: 'never_store_or_echo',
+  trainingPolicy: 'no_training_or_optimization_on_tasks',
+}

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
@@ -3,6 +3,7 @@ import { Effect } from 'effect'
 
 import {
   buildMirrorCodeRun,
+  MIRRORCODE_GENERALIZATION_SET,
   MirrorCodeRunError,
 } from './mirrorcode-contract'
 import {
@@ -91,10 +92,16 @@ describe('handleMirrorCodeRunsApi GET', () => {
       model: string
       runs: ReadonlyArray<{ runId: string }>
       comparators: ReadonlyArray<{ source: string }>
+      generalizationSet: typeof MIRRORCODE_GENERALIZATION_SET
       staleness: { composition: string }
     }
     expect(body.schemaVersion).toBe('openagents.gym.mirrorcode_runs.v1')
     expect(body.model).toBe('openagents/khala')
+    expect(body.generalizationSet).toEqual(MIRRORCODE_GENERALIZATION_SET)
+    expect(body.generalizationSet.retrievalPolicy).toBe('no_rag_on_tasks')
+    expect(body.generalizationSet.trainingPolicy).toBe(
+      'no_training_or_optimization_on_tasks',
+    )
     expect(body.runs[0]?.runId).toBe('mc-phase0-cal-py-0001')
     expect(body.comparators.length).toBeGreaterThan(0)
     expect(body.comparators.every(c => c.source === 'paper_reference_illustrative')).toBe(true)

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.ts
@@ -26,6 +26,7 @@ import {
   buildMirrorCodeRun,
   KHALA_MODEL_ID,
   MIRRORCODE_BENCHMARK_LABEL,
+  MIRRORCODE_GENERALIZATION_SET,
   MIRRORCODE_PAPER_REFERENCE_COMPARATORS,
   MirrorCodeRunError,
   MirrorCodeRunsSchemaVersion,
@@ -125,6 +126,7 @@ const publicEnvelope = (
   staleness: mirrorCodeStaleness(),
   model: KHALA_MODEL_ID,
   benchmark: MIRRORCODE_BENCHMARK_LABEL,
+  generalizationSet: MIRRORCODE_GENERALIZATION_SET,
   runs,
   comparators: MIRRORCODE_PAPER_REFERENCE_COMPARATORS,
 })

--- a/apps/openagents.com/workers/api/src/tassadar-trace-factory/training-split-policy.test.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-trace-factory/training-split-policy.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, test } from 'vitest'
 import {
   splitAssignmentForRecord,
   splitPolicyViolations,
+  tassadarTraceCorpusUseDecision,
+  TASSADAR_HELD_OUT_PARTITION_MANIFEST_SHA256,
+  TASSADAR_HELD_OUT_PARTITION_REF,
   TASSADAR_TRAINING_SPLIT_POLICY_V0_1,
   type TassadarTrainingSplitPolicy,
 } from './training-split-policy'
@@ -40,6 +43,42 @@ describe('training split policy v0.1', () => {
     expect(TASSADAR_TRAINING_SPLIT_POLICY_V0_1.heldOutFamilies).toContain(
       TASSADAR_TRAINING_SPLIT_POLICY_V0_1.economicFamily,
     )
+  })
+
+  test('the GG partition is checksum-locked and exposed by ref only', () => {
+    expect(
+      TASSADAR_TRAINING_SPLIT_POLICY_V0_1.generalizationPartition,
+    ).toMatchObject({
+      exposure: 'checksum_only',
+      manifestDigest: {
+        algorithm: 'sha256',
+        hex: TASSADAR_HELD_OUT_PARTITION_MANIFEST_SHA256,
+      },
+      partitionRef: TASSADAR_HELD_OUT_PARTITION_REF,
+      purpose: 'generalization_gg_eval',
+      rotation: 'append_new_partition_ref_never_rewrite',
+    })
+  })
+
+  test('the GG partition is blocked from training, optimization, homework, and retrieval context', () => {
+    for (const use of [
+      'training',
+      'optimization',
+      'homework',
+      'retrieval_context',
+    ] as const) {
+      expect(tassadarTraceCorpusUseDecision(use)).toMatchObject({
+        allowed: false,
+        blockerRef: 'blocker.tassadar_trace.gg_partition_isolated',
+        partitionRef: TASSADAR_HELD_OUT_PARTITION_REF,
+        use,
+      })
+    }
+    expect(tassadarTraceCorpusUseDecision('generalization_eval')).toEqual({
+      allowed: true,
+      partitionRef: TASSADAR_HELD_OUT_PARTITION_REF,
+      use: 'generalization_eval',
+    })
   })
 
   test('adversarial near-miss records route to the adversarial eval', () => {
@@ -95,6 +134,34 @@ describe('training split policy v0.1', () => {
     expect(
       violations.some(
         violation => violation.kind === 'economic_family_not_held_out',
+      ),
+    ).toBe(true)
+  })
+
+  test('a policy that exposes a mutable or non-checksummed GG partition is rejected', () => {
+    const broken: TassadarTrainingSplitPolicy = {
+      ...TASSADAR_TRAINING_SPLIT_POLICY_V0_1,
+      generalizationPartition: {
+        ...TASSADAR_TRAINING_SPLIT_POLICY_V0_1.generalizationPartition,
+        blockedUses: ['homework'],
+        exposure: 'checksum_only',
+        manifestDigest: {
+          algorithm: 'sha256',
+          hex: 'not-a-digest',
+        },
+      },
+    }
+    const violations = splitPolicyViolations(broken)
+    expect(
+      violations.some(
+        violation =>
+          violation.kind === 'held_out_partition_not_checksum_locked',
+      ),
+    ).toBe(true)
+    expect(
+      violations.some(
+        violation =>
+          violation.kind === 'held_out_partition_training_use_allowed',
       ),
     ).toBe(true)
   })

--- a/apps/openagents.com/workers/api/src/tassadar-trace-factory/training-split-policy.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-trace-factory/training-split-policy.ts
@@ -15,9 +15,41 @@ import { TASSADAR_TRACE_FAMILY_IDS, type TassadarTraceFamilyId } from './workloa
 
 export const TASSADAR_TRAINING_SPLIT_POLICY_VERSION = 'training_split.v0.1'
 
+export const TASSADAR_HELD_OUT_PARTITION_REF =
+  'partition.tassadar_trace.generalization_gg.v1'
+
+export const TASSADAR_HELD_OUT_PARTITION_MANIFEST_SHA256 =
+  '7f7f37c1d3a7de89c4a2517cf4b2f21df7a2dbb68b746d353aa247348c8f9e9a'
+
+export type TassadarTraceCorpusUse =
+  | 'generalization_eval'
+  | 'training'
+  | 'optimization'
+  | 'homework'
+  | 'retrieval_context'
+
+export type TassadarGeneralizationPartitionLock = Readonly<{
+  partitionRef: typeof TASSADAR_HELD_OUT_PARTITION_REF
+  purpose: 'generalization_gg_eval'
+  manifestDigest: Readonly<{
+    algorithm: 'sha256'
+    hex: string
+  }>
+  blockedUses: ReadonlyArray<
+    Extract<
+      TassadarTraceCorpusUse,
+      'homework' | 'optimization' | 'retrieval_context' | 'training'
+    >
+  >
+  allowedUses: ReadonlyArray<Extract<TassadarTraceCorpusUse, 'generalization_eval'>>
+  exposure: 'checksum_only'
+  rotation: 'append_new_partition_ref_never_rewrite'
+}>
+
 export type TassadarTrainingSplitPolicy = Readonly<{
   policyVersion: typeof TASSADAR_TRAINING_SPLIT_POLICY_VERSION
   splitUnit: 'program_family'
+  generalizationPartition: TassadarGeneralizationPartitionLock
   trainFamilies: ReadonlyArray<TassadarTraceFamilyId>
   heldOutFamilies: ReadonlyArray<TassadarTraceFamilyId>
   adversarialFamilies: ReadonlyArray<TassadarTraceFamilyId>
@@ -35,6 +67,23 @@ export const TASSADAR_TRAINING_SPLIT_POLICY_V0_1: TassadarTrainingSplitPolicy =
     adversarialFamilies: ['family.near_miss_lookup.v1'],
     economicFamily: 'family.application_state_machine.v1',
     evalLengthFactors: [2, 4, 8],
+    generalizationPartition: {
+      allowedUses: ['generalization_eval'],
+      blockedUses: [
+        'homework',
+        'optimization',
+        'retrieval_context',
+        'training',
+      ],
+      exposure: 'checksum_only',
+      manifestDigest: {
+        algorithm: 'sha256',
+        hex: TASSADAR_HELD_OUT_PARTITION_MANIFEST_SHA256,
+      },
+      partitionRef: TASSADAR_HELD_OUT_PARTITION_REF,
+      purpose: 'generalization_gg_eval',
+      rotation: 'append_new_partition_ref_never_rewrite',
+    },
     heldOutFamilies: [
       'family.application_state_machine.v1',
       'family.stack_loop_sum.compiled.v1',
@@ -64,6 +113,8 @@ export type TassadarSplitPolicyViolation = Readonly<
   | { kind: 'family_unassigned'; familyId: string }
   | { kind: 'economic_family_not_held_out'; familyId: string }
   | { kind: 'eval_factors_not_ascending'; detail: string }
+  | { kind: 'held_out_partition_not_checksum_locked'; detail: string }
+  | { kind: 'held_out_partition_training_use_allowed'; detail: string }
 >
 
 /**
@@ -107,6 +158,34 @@ export const splitPolicyViolations = (
       kind: 'eval_factors_not_ascending',
     })
   }
+  if (
+    policy.generalizationPartition.exposure !== 'checksum_only' ||
+    policy.generalizationPartition.manifestDigest.algorithm !== 'sha256' ||
+    !/^[a-f0-9]{64}$/.test(policy.generalizationPartition.manifestDigest.hex)
+  ) {
+    violations.push({
+      detail:
+        'Generalization partition must expose only a checksum-locked sha256 manifest digest.',
+      kind: 'held_out_partition_not_checksum_locked',
+    })
+  }
+  const forbiddenUses: ReadonlyArray<
+    Extract<
+      TassadarTraceCorpusUse,
+      'homework' | 'optimization' | 'retrieval_context' | 'training'
+    >
+  > = ['homework', 'optimization', 'retrieval_context', 'training']
+  if (
+    forbiddenUses.some(
+      use => !policy.generalizationPartition.blockedUses.includes(use),
+    )
+  ) {
+    violations.push({
+      detail:
+        'Generalization partition must block training, optimization, homework, and retrieval-context use.',
+      kind: 'held_out_partition_training_use_allowed',
+    })
+  }
 
   return violations
 }
@@ -137,4 +216,33 @@ export const splitAssignmentForRecord = (
   }
 
   return 'train'
+}
+
+export type TassadarTraceCorpusUseDecision = Readonly<
+  | { allowed: true; partitionRef: string; use: TassadarTraceCorpusUse }
+  | {
+      allowed: false
+      blockerRef: 'blocker.tassadar_trace.gg_partition_isolated'
+      partitionRef: string
+      reason: string
+      use: TassadarTraceCorpusUse
+    }
+>
+
+export const tassadarTraceCorpusUseDecision = (
+  use: TassadarTraceCorpusUse,
+  partition: TassadarGeneralizationPartitionLock = TASSADAR_TRAINING_SPLIT_POLICY_V0_1.generalizationPartition,
+): TassadarTraceCorpusUseDecision => {
+  if (use === 'generalization_eval' && partition.allowedUses.includes(use)) {
+    return { allowed: true, partitionRef: partition.partitionRef, use }
+  }
+
+  return {
+    allowed: false,
+    blockerRef: 'blocker.tassadar_trace.gg_partition_isolated',
+    partitionRef: partition.partitionRef,
+    reason:
+      'The Tassadar GG held-out partition is checksum-only and may be used only for Generalization Gain evaluation.',
+    use,
+  }
 }


### PR DESCRIPTION
Addresses #6419.

### Changes
- Added a checksum-locked Tassadar held-out GG partition policy with a stable partition ref, SHA-256 manifest digest, append-only rotation rule, and blocked training/optimization/homework/retrieval uses.
- Added use-decision coverage so only generalization evaluation is allowed for the held-out partition.
- Exposed the MirrorCode generalization set metadata in the public runs envelope, including no-RAG and no-training policies.
- Added tests for the GG partition lock, blocked uses, policy violations, and MirrorCode response metadata.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).