### PR TITLE
fix(pylon): scope Codex supervisor accounts for offload

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -81,6 +81,9 @@ SUP_MAX_SLOTS="${SUP_MAX_SLOTS:-8}"
 SUP_REPO="${SUP_REPO:-OpenAgentsInc/openagents}"
 # Lightweight, sanctioned-shape verification run inside each throwaway workspace.
 SUP_VERIFY="${SUP_VERIFY:-bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts}"
+# Optional comma/space separated allowlist for multi-host fleet offload. When
+# set, a host only schedules the copied Codex profile refs assigned to it.
+SUP_ACCOUNT_REFS="${SUP_ACCOUNT_REFS:-}"
 # Presence heartbeat cadence (s) — keeps presence fresh + capacity advertised.
 SUP_HEARTBEAT_SECS="${SUP_HEARTBEAT_SECS:-45}"
 # Backoff bounds for refused/rate-limited dispatch.
@@ -128,12 +131,16 @@ counter_now() {
 # Print ready Codex account refs, one per line. Default-home account (accountRef
 # null) is printed as the literal token "default".
 ready_codex_account_refs() {
-  "${PYLON[@]}" codex accounts list --json 2>/dev/null | python3 -c "import sys,json
+  "${PYLON[@]}" codex accounts list --json 2>/dev/null | python3 -c "import os,sys,json
+allow_raw=os.environ.get('SUP_ACCOUNT_REFS','').replace(',', ' ').split()
+allow=set(allow_raw)
 try: d=json.load(sys.stdin)
 except Exception: sys.exit(0)
 for a in d.get('accounts',[]):
     if a.get('provider')=='codex' and a.get('readiness',{}).get('state')=='ready':
-        print(a.get('accountRef') or 'default')" 2>/dev/null
+        ref=a.get('accountRef') or 'default'
+        if not allow or ref in allow:
+            print(ref)" 2>/dev/null
 }
 
 owner_session_broken() {
@@ -280,7 +287,7 @@ if [ -z "${OPENAGENTS_AGENT_TOKEN:-}" ]; then
 fi
 
 echo $$ > "$SUP_STATE_DIR/supervisor.pid"
-log "=== codex-supervisor START pid=$$ repo=$REPO_ROOT pylon=$SUP_PYLON_REF per_account=$SUP_PER_ACCOUNT max_slots=$SUP_MAX_SLOTS ==="
+log "=== codex-supervisor START pid=$$ repo=$REPO_ROOT pylon=$SUP_PYLON_REF per_account=$SUP_PER_ACCOUNT max_slots=$SUP_MAX_SLOTS account_refs=${SUP_ACCOUNT_REFS:-all} ==="
 
 "${PYLON[@]}" provider go-online >> "$SUP_LOG" 2>&1 || log "provider go-online nonzero (continuing)"
 

--- a/apps/pylon/scripts/codex-supervisor/fleet-offload.sh
+++ b/apps/pylon/scripts/codex-supervisor/fleet-offload.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# fleet-offload.sh — move already-authenticated Pylon Codex profiles to
+# secondary Tailnet Macs and print/launch the matching standing supervisors.
+#
+# This script never runs `codex login` or `pylon auth codex`. It copies existing
+# isolated Pylon account homes from:
+#   $PYLON_HOME/accounts/codex/<ref>
+# to the remote:
+#   $REMOTE_PYLON_HOME/accounts/codex/<ref>
+#
+# Default mode is dry-run. Pass --execute to run tar/scp/ssh.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+PYLON_HOME="${PYLON_HOME:-$HOME/.pylon-fable}"
+REMOTE_PYLON_HOME="${REMOTE_PYLON_HOME:-~/.pylon-fable}"
+REMOTE_REPO="${REMOTE_REPO:-~/work/openagents}"
+SUP_STATE_BASE="${SUP_STATE_BASE:-~/.codex-supervisor}"
+SUP_PER_ACCOUNT="${SUP_PER_ACCOUNT:-2}"
+SUP_MAX_SLOTS_PER_HOST="${SUP_MAX_SLOTS_PER_HOST:-4}"
+SUP_REPO="${SUP_REPO:-OpenAgentsInc/openagents}"
+SUP_VERIFY="${SUP_VERIFY:-bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts}"
+REMOTE_AGENT_ENV="${REMOTE_AGENT_ENV:-~/.pylon-fable/openagents-agent.env}"
+SSH_BIN="${SSH_BIN:-ssh}"
+SCP_BIN="${SCP_BIN:-scp}"
+TAR_BIN="${TAR_BIN:-tar}"
+MKDIR_BIN="${MKDIR_BIN:-mkdir}"
+DATE_BIN="${DATE_BIN:-date}"
+
+DRY_RUN=1
+HOSTS=()
+ACCOUNTS=()
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  fleet-offload.sh --hosts imac-pro-bertha,macbook-pro-m2 --accounts codex-4,codex-5,codex-6,codex-7 [--execute]
+
+Options:
+  --hosts       Comma or space separated Tailnet hosts.
+  --accounts    Comma or space separated Codex account refs to move.
+  --execute     Actually run tar/scp/ssh. Default is dry-run.
+  --help        Show this help.
+
+Environment:
+  PYLON_HOME                 Local Pylon home. Default: ~/.pylon-fable
+  REMOTE_PYLON_HOME          Remote Pylon home. Default: ~/.pylon-fable
+  REMOTE_REPO                Remote clean openagents checkout. Default: ~/work/openagents
+  REMOTE_AGENT_ENV           Remote env file exporting OPENAGENTS_AGENT_TOKEN.
+                             Default: ~/.pylon-fable/openagents-agent.env
+  SUP_PER_ACCOUNT            Supervisor parallelism per account. Default: 2
+  SUP_MAX_SLOTS_PER_HOST     Host slot cap. Default: 4
+  SUP_PYLON_REF              Required for --execute launch commands.
+  OPENAGENTS_AGENT_TOKEN     Required on the remote for launched supervisors.
+USAGE
+}
+
+die() {
+  printf 'FATAL: %s\n' "$*" >&2
+  exit 1
+}
+
+split_words() {
+  printf '%s\n' "$1" | tr ',' ' ' | tr -s ' ' '\n' | sed '/^$/d'
+}
+
+shell_quote() {
+  # Single-quote a shell word.
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+remote_path_expr() {
+  case "$1" in
+    "~") printf '~' ;;
+    "~/"*) printf '~/%s' "$(printf '%s' "${1#~/}" | sed "s/'/'\\\\''/g")" ;;
+    "\$HOME") printf '$HOME' ;;
+    "\$HOME/"*) printf '$HOME/%s' "$(printf '%s' "${1#\$HOME/}" | sed "s/'/'\\\\''/g")" ;;
+    *) shell_quote "$1" ;;
+  esac
+}
+
+run_cmd() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf 'DRY-RUN:'
+    local arg
+    for arg in "$@"; do printf ' %s' "$(shell_quote "$arg")"; done
+    printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+remote_sh() {
+  local host="$1"
+  shift
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf 'DRY-RUN: %s %s %s\n' "$(shell_quote "$SSH_BIN")" "$(shell_quote "$host")" "$(shell_quote "$*")"
+    return 0
+  fi
+  "$SSH_BIN" "$host" "$*"
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --hosts)
+        shift; [ "$#" -gt 0 ] || die "--hosts requires a value"
+        while IFS= read -r item; do HOSTS+=("$item"); done < <(split_words "$1")
+        ;;
+      --accounts)
+        shift; [ "$#" -gt 0 ] || die "--accounts requires a value"
+        while IFS= read -r item; do ACCOUNTS+=("$item"); done < <(split_words "$1")
+        ;;
+      --execute) DRY_RUN=0 ;;
+      --help|-h) usage; exit 0 ;;
+      *) die "unknown argument: $1" ;;
+    esac
+    shift
+  done
+}
+
+validate() {
+  [ "${#HOSTS[@]}" -gt 0 ] || die "provide at least one --hosts entry"
+  [ "${#ACCOUNTS[@]}" -gt 0 ] || die "provide at least one --accounts entry"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    [ -n "${SUP_PYLON_REF:-}" ] || die "SUP_PYLON_REF is required with --execute"
+  fi
+
+  local account
+  for account in "${ACCOUNTS[@]}"; do
+    case "$account" in
+      default|codex|codex-[A-Za-z0-9._-]*) ;;
+      *) die "unsafe account ref '$account'; expected codex or codex-N" ;;
+    esac
+    [ -d "$PYLON_HOME/accounts/codex/$account" ] || die "missing local account profile: $PYLON_HOME/accounts/codex/$account"
+  done
+}
+
+accounts_for_host() {
+  local host_index="$1"
+  local host_count="$2"
+  local i
+  for i in "${!ACCOUNTS[@]}"; do
+    if [ $(( i % host_count )) -eq "$host_index" ]; then
+      printf '%s\n' "${ACCOUNTS[$i]}"
+    fi
+  done
+}
+
+host_account_csv() {
+  paste -sd, -
+}
+
+copy_account() {
+  local host="$1"
+  local account="$2"
+  local parent="$PYLON_HOME/accounts/codex"
+  local stamp
+  stamp="$("$DATE_BIN" -u +%Y%m%dT%H%M%SZ)"
+  local archive="/tmp/openagents-${account}-${stamp}.tgz"
+  local remote_archive="/tmp/openagents-${account}-${stamp}.tgz"
+  local remote_dir="$REMOTE_PYLON_HOME/accounts/codex"
+
+  run_cmd "$TAR_BIN" -C "$parent" -czf "$archive" "$account"
+  remote_sh "$host" "$MKDIR_BIN -p $(remote_path_expr "$remote_dir")"
+  run_cmd "$SCP_BIN" "$archive" "$host:$remote_archive"
+  remote_sh "$host" "$TAR_BIN -xzf $(shell_quote "$remote_archive") -C $(remote_path_expr "$remote_dir")"
+  remote_sh "$host" "rm -f $(shell_quote "$remote_archive")"
+  run_cmd rm -f "$archive"
+}
+
+launch_host() {
+  local host="$1"
+  local accounts_csv="$2"
+  local state_dir="$SUP_STATE_BASE/$host"
+  local max_slots="$SUP_MAX_SLOTS_PER_HOST"
+  local launch
+  launch="set -a; [ -f $(remote_path_expr "$REMOTE_AGENT_ENV") ] && . $(remote_path_expr "$REMOTE_AGENT_ENV"); set +a; cd $(remote_path_expr "$REMOTE_REPO") && PYLON_HOME=$(remote_path_expr "$REMOTE_PYLON_HOME") SUP_STATE_DIR=$(remote_path_expr "$state_dir") SUP_PYLON_REF=$(shell_quote "${SUP_PYLON_REF:-<live-pylon-ref>}") SUP_MAX_SLOTS=$(shell_quote "$max_slots") SUP_PER_ACCOUNT=$(shell_quote "$SUP_PER_ACCOUNT") SUP_ACCOUNT_REFS=$(shell_quote "$accounts_csv") SUP_REPO=$(shell_quote "$SUP_REPO") SUP_VERIFY=$(shell_quote "$SUP_VERIFY") bash apps/pylon/scripts/codex-supervisor/launch.sh start"
+  remote_sh "$host" "$launch"
+}
+
+main() {
+  parse_args "$@"
+  validate
+
+  printf 'mode=%s local_home=%s remote_home=%s remote_repo=%s\n' \
+    "$([ "$DRY_RUN" -eq 1 ] && echo dry-run || echo execute)" \
+    "$PYLON_HOME" "$REMOTE_PYLON_HOME" "$REMOTE_REPO"
+
+  local host_count="${#HOSTS[@]}"
+  local host_index
+  for host_index in "${!HOSTS[@]}"; do
+    local host="${HOSTS[$host_index]}"
+    local assigned=()
+    while IFS= read -r account; do assigned+=("$account"); done < <(accounts_for_host "$host_index" "$host_count")
+    [ "${#assigned[@]}" -gt 0 ] || continue
+
+    printf 'host=%s accounts=%s\n' "$host" "$(printf '%s\n' "${assigned[@]}" | host_account_csv)"
+    local account
+    for account in "${assigned[@]}"; do
+      copy_account "$host" "$account"
+    done
+    launch_host "$host" "$(printf '%s\n' "${assigned[@]}" | host_account_csv)"
+  done
+}
+
+main "$@"

--- a/apps/pylon/scripts/codex-supervisor/fleet-offload.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/fleet-offload.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# fleet-offload.test.sh — no-network tests for the multi-host Codex profile
+# offload planner.
+#
+# Run: bash apps/pylon/scripts/codex-supervisor/fleet-offload.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+PYLON_HOME="$WORK/pylon"
+mkdir -p \
+  "$PYLON_HOME/accounts/codex/codex-4" \
+  "$PYLON_HOME/accounts/codex/codex-5" \
+  "$PYLON_HOME/accounts/codex/codex-6" \
+  "$PYLON_HOME/accounts/codex/codex-7"
+
+OUT="$WORK/out.txt"
+PYLON_HOME="$PYLON_HOME" \
+REMOTE_PYLON_HOME="/Users/operator/.pylon-fable" \
+REMOTE_REPO="/Users/operator/work/openagents" \
+SUP_PYLON_REF="pylon.live" \
+SUP_MAX_SLOTS_PER_HOST=4 \
+SUP_PER_ACCOUNT=2 \
+DATE_BIN=/bin/date \
+  bash "$SCRIPT_DIR/fleet-offload.sh" \
+    --hosts imac-pro-bertha,macbook-pro-m2 \
+    --accounts codex-4,codex-5,codex-6,codex-7 \
+    > "$OUT"
+rc=$?
+
+if [ "$rc" -eq 0 ]; then ok "dry-run exits zero"; else bad "dry-run rc=$rc"; fi
+
+if grep -q 'host=imac-pro-bertha accounts=codex-4,codex-6' "$OUT"; then
+  ok "bertha receives alternating account refs"
+else
+  bad "bertha assignment missing"
+fi
+
+if grep -q 'host=macbook-pro-m2 accounts=codex-5,codex-7' "$OUT"; then
+  ok "m2 receives alternating account refs"
+else
+  bad "m2 assignment missing"
+fi
+
+if grep -E -q "'tar' '-C' '.*/accounts/codex' '-czf' '/tmp/openagents-codex-4-" "$OUT"; then
+  ok "archives isolated codex profile directory"
+else
+  bad "codex-4 tar command missing"
+fi
+
+if grep -q "SUP_ACCOUNT_REFS=.*codex-4,codex-6" "$OUT" &&
+   grep -q "SUP_ACCOUNT_REFS=.*codex-5,codex-7" "$OUT"; then
+  ok "remote launches constrain supervisor account refs"
+else
+  bad "SUP_ACCOUNT_REFS launch constraints missing"
+fi
+
+if grep -q 'codex login\|pylon auth codex' "$OUT"; then
+  bad "offload dry-run must not include login commands"
+else
+  ok "offload plan never invokes login"
+fi
+
+BAD_OUT="$WORK/bad.txt"
+PYLON_HOME="$PYLON_HOME" bash "$SCRIPT_DIR/fleet-offload.sh" \
+  --hosts imac-pro-bertha \
+  --accounts codex-4,../../unsafe \
+  > "$BAD_OUT" 2>&1
+bad_rc=$?
+if [ "$bad_rc" -ne 0 ] && grep -q 'unsafe account ref' "$BAD_OUT"; then
+  ok "unsafe account refs are rejected"
+else
+  bad "unsafe account ref was not rejected"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
+++ b/docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
@@ -329,6 +329,62 @@ bash apps/pylon/scripts/codex-supervisor/launch.sh status
 bash apps/pylon/scripts/codex-supervisor/launch.sh stop
 ```
 
+### Offload Codex profiles to Tailnet machines (#6432)
+
+Use this when the owner's desktop is CPU-oversubscribed but the Codex profiles
+are already authenticated under `~/.pylon-fable/accounts/codex/<ref>`. The
+offload path **copies serialized isolated Pylon account homes only**; it never
+runs `codex login`, never runs `pylon auth codex`, and never touches the default
+`~/.codex`.
+
+Dry-run first from a clean checkout:
+
+```sh
+PYLON_HOME=$HOME/.pylon-fable \
+SUP_PYLON_REF=<live-ref> \
+  bash apps/pylon/scripts/codex-supervisor/fleet-offload.sh \
+    --hosts imac-pro-bertha,macbook-pro-m2 \
+    --accounts codex-4,codex-5,codex-6,codex-7
+```
+
+Expected dry-run shape:
+
+- `imac-pro-bertha` receives `codex-4,codex-6`.
+- `macbook-pro-m2` receives `codex-5,codex-7`.
+- Each profile is archived from
+  `$PYLON_HOME/accounts/codex/<ref>`, copied with `scp`, expanded under the
+  remote `~/.pylon-fable/accounts/codex/<ref>`, and the remote supervisor launch
+  includes `SUP_ACCOUNT_REFS=<only-that-hosts-refs>`.
+
+Execute only after the dry-run command is sane and both Tailnet hosts have a
+clean current checkout, Bun dependencies, and a remote env file exporting
+`OPENAGENTS_AGENT_TOKEN` at `~/.pylon-fable/openagents-agent.env` (override with
+`REMOTE_AGENT_ENV`). Do not put the token into the dry-run output, issue
+comments, or shell history.
+
+```sh
+PYLON_HOME=$HOME/.pylon-fable \
+SUP_PYLON_REF=<live-ref> \
+  bash apps/pylon/scripts/codex-supervisor/fleet-offload.sh \
+    --hosts imac-pro-bertha,macbook-pro-m2 \
+    --accounts codex-4,codex-5,codex-6,codex-7 \
+    --execute
+```
+
+The launched remote supervisors use:
+
+- `REMOTE_PYLON_HOME=~/.pylon-fable` by default.
+- `REMOTE_REPO=~/work/openagents` by default.
+- `REMOTE_AGENT_ENV=~/.pylon-fable/openagents-agent.env` by default.
+- `SUP_MAX_SLOTS_PER_HOST=4` and `SUP_PER_ACCOUNT=2` by default.
+- `SUP_ACCOUNT_REFS` so bertha and m2 do not both schedule the same copied
+  profiles.
+
+After offload, reduce the desktop supervisor/standing-pylon advertised slots by
+the moved accounts before declaring a 12-turn split across three machines. The
+gate admits by pylon-advertised capacity, so the sum of desktop + bertha + m2
+advertisements must match real CPU/account headroom.
+
 ### Restart the standing pylon
 ```sh
 launchctl kickstart -k gui/$(id -u)/com.openagents.pylon.fable   # graceful kick


### PR DESCRIPTION
Addresses #6432.

### Changes
- Added `SUP_ACCOUNT_REFS` filtering to the Codex supervisor so a host only schedules its assigned ready Codex account refs.
- Included the selected account refs in supervisor startup logging.
- Documented the Tailnet offload runbook for copying isolated Pylon Codex account homes to bertha/m2 and launching remote supervisors with scoped account refs.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).