### PR TITLE
feat(web): add Artanis pulse token panel

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
@@ -2,11 +2,14 @@ import { ShareProjectionV1 } from '@openagentsinc/sync-schema'
 import { Option, Schema as S } from 'effect'
 import { ts } from 'foldkit/schema'
 
-import { LoggedOutRoute } from '../../route'
 import { Session } from '../../domain/session'
+import { LoggedOutRoute } from '../../route'
 import { FlowModel, initFlowModel } from '../autopilot-onboarding/flow'
 import { KhalaChatModel, initKhalaChatModel } from '../khala-chat/flow'
-import { BlobRef as AtifBlobRef, Trajectory as AtifTrajectory } from '../trace/atif'
+import {
+  BlobRef as AtifBlobRef,
+  Trajectory as AtifTrajectory,
+} from '../trace/atif'
 import { SAMPLE_TRACE_UUID } from '../trace/sample'
 import { GymModel, initGymModel } from './gym/flow'
 import { GymRunProgressPublicProjection } from './gym/runProgress'
@@ -945,10 +948,7 @@ export const PublicKhalaTokensServed = S.Struct({
 })
 export type PublicKhalaTokensServed = typeof PublicKhalaTokensServed.Type
 
-export const IdlePublicKhalaTokensServed = ts(
-  'PublicKhalaTokensServedIdle',
-  {},
-)
+export const IdlePublicKhalaTokensServed = ts('PublicKhalaTokensServedIdle', {})
 export const LoadingPublicKhalaTokensServed = ts(
   'PublicKhalaTokensServedLoading',
   {},
@@ -1410,31 +1410,35 @@ export const initSettledFeedModel = (): SettledFeedModel =>
 // socket-down fallback seed (monotone: it only ever raises the displayed total).
 // This slice is purely live transport state; the total lives on
 // `publicKhalaTokensServed`.
-export const KhalaTokensServedStreamModel = ts('LoggedOutKhalaTokensServedStream', {
-  connection: SettledFeedConnection,
-  cursor: S.Number,
-  appliedEventRefs: S.Array(S.String),
-  // The WebSocket must open at the SEEDED cursor, never at 0 (openagents #6324).
-  // The stream subscription opened at the init cursor 0 before the snapshot load
-  // resolved (and its keep-alive equivalence intentionally ignores the live
-  // cursor), so it replayed the ENTIRE per-completion delta history from seq 1 on
-  // every load — a flood that, combined with old-format pre-authoritative-total
-  // rows, the client could not apply past the seed (the frozen counter). We gate
-  // socket activation on this flag: the snapshot load (or its failure fallback)
-  // flips it true AFTER it has seeded `cursor`, so the socket opens once at the
-  // seeded cursor and delivers ONLY new deltas. Bounded replay; live increments.
-  snapshotLoaded: S.Boolean,
-})
+export const KhalaTokensServedStreamModel = ts(
+  'LoggedOutKhalaTokensServedStream',
+  {
+    connection: SettledFeedConnection,
+    cursor: S.Number,
+    appliedEventRefs: S.Array(S.String),
+    // The WebSocket must open at the SEEDED cursor, never at 0 (openagents #6324).
+    // The stream subscription opened at the init cursor 0 before the snapshot load
+    // resolved (and its keep-alive equivalence intentionally ignores the live
+    // cursor), so it replayed the ENTIRE per-completion delta history from seq 1 on
+    // every load — a flood that, combined with old-format pre-authoritative-total
+    // rows, the client could not apply past the seed (the frozen counter). We gate
+    // socket activation on this flag: the snapshot load (or its failure fallback)
+    // flips it true AFTER it has seeded `cursor`, so the socket opens once at the
+    // seeded cursor and delivers ONLY new deltas. Bounded replay; live increments.
+    snapshotLoaded: S.Boolean,
+  },
+)
 export type KhalaTokensServedStreamModel =
   typeof KhalaTokensServedStreamModel.Type
 
-export const initKhalaTokensServedStreamModel = (): KhalaTokensServedStreamModel =>
-  KhalaTokensServedStreamModel({
-    connection: 'idle',
-    cursor: 0,
-    appliedEventRefs: [],
-    snapshotLoaded: false,
-  })
+export const initKhalaTokensServedStreamModel =
+  (): KhalaTokensServedStreamModel =>
+    KhalaTokensServedStreamModel({
+      connection: 'idle',
+      cursor: 0,
+      appliedEventRefs: [],
+      snapshotLoaded: false,
+    })
 
 // Live Gym / Harbor run-progress follow-along (#6261). The `/gym` route polls
 // `GET /api/public/gym/run-progress` and renders EVERY returned run live
@@ -1473,8 +1477,7 @@ export const GymRunProgressStreamModel = ts('LoggedOutGymRunProgressStream', {
   cursor: S.Number,
   appliedEventRefs: S.Array(S.String),
 })
-export type GymRunProgressStreamModel =
-  typeof GymRunProgressStreamModel.Type
+export type GymRunProgressStreamModel = typeof GymRunProgressStreamModel.Type
 
 export const initGymRunProgressStreamModel = (): GymRunProgressStreamModel =>
   GymRunProgressStreamModel({
@@ -1592,13 +1595,15 @@ export const init = (
     publicKhalaTokensServed:
       route._tag === 'Home' ||
       route._tag === 'Stats' ||
-      route._tag === 'PublicStatsArchive'
+      route._tag === 'PublicStatsArchive' ||
+      (route._tag === 'PublicAgent' && route.agentRef === 'artanis')
         ? LoadingPublicKhalaTokensServed()
         : IdlePublicKhalaTokensServed(),
     publicKhalaTokensServedHistory:
       route._tag === 'Home' ||
       route._tag === 'Stats' ||
-      route._tag === 'PublicStatsArchive'
+      route._tag === 'PublicStatsArchive' ||
+      (route._tag === 'PublicAgent' && route.agentRef === 'artanis')
         ? LoadingPublicKhalaTokensServedHistory()
         : IdlePublicKhalaTokensServedHistory(),
     publicKhalaTokensServedModelMix:

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
@@ -20,6 +20,9 @@ import type {
   PublicArtanisReport,
   PublicArtanisReportClaimSummary,
   PublicArtanisReportModel,
+  PublicKhalaTokensServedHistoryModel,
+  PublicKhalaTokensServedHistoryPoint,
+  PublicKhalaTokensServedModel,
   PublicPylonStats,
   PublicPylonStatsModel,
   PublicPylonV02OmegaReleaseGate,
@@ -57,6 +60,21 @@ const usageText = (goal: PublicAgentGoal): string =>
     : `${goal.tokensUsed} / ${goal.tokenBudget ?? 0} tokens`
 
 const formatNumber = (value: number): string => numberFormatter.format(value)
+
+const compactNumberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+  notation: 'compact',
+})
+
+const formatCompactNumber = (value: number): string =>
+  compactNumberFormatter.format(value)
+
+const percentFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
+})
+
+const formatPercent = (value: number): string =>
+  `${percentFormatter.format(Math.max(0, value))}%`
 
 const publicRefsLabel = (
   label: string,
@@ -900,7 +918,303 @@ const artanisOmegaReleaseGateView = (
   )
 }
 
-const artanisReportLoadedView = (report: PublicArtanisReport): Html => {
+const pulseSeries = (
+  history: PublicKhalaTokensServedHistoryModel,
+): ReadonlyArray<PublicKhalaTokensServedHistoryPoint> =>
+  history._tag === 'PublicKhalaTokensServedHistoryLoaded'
+    ? history.history.series.slice(-14)
+    : []
+
+const pulseCurrentTotal = (
+  counter: PublicKhalaTokensServedModel,
+): number | null =>
+  counter._tag === 'PublicKhalaTokensServedLoaded'
+    ? counter.served.tokensServed
+    : null
+
+const pulseAveragePriorActiveDay = (
+  series: ReadonlyArray<PublicKhalaTokensServedHistoryPoint>,
+): number => {
+  const priorActiveDays = series
+    .slice(0, -1)
+    .map(point => Math.max(0, point.tokensServed))
+    .filter(value => value > 0)
+
+  return priorActiveDays.length === 0
+    ? 0
+    : Math.round(
+        priorActiveDays.reduce((total, value) => total + value, 0) /
+          priorActiveDays.length,
+      )
+}
+
+const pulseSparklinePoints = (
+  series: ReadonlyArray<PublicKhalaTokensServedHistoryPoint>,
+): string => {
+  const width = 192
+  const height = 56
+  const values =
+    series.length < 2
+      ? [0, ...(series[0] === undefined ? [] : [series[0].tokensServed]), 0]
+      : series.map(point => point.tokensServed)
+  const max = values.reduce((largest, value) => Math.max(largest, value), 0)
+  const span = max || 1
+  const step = values.length <= 1 ? width : width / (values.length - 1)
+
+  return values
+    .map((value, index) => {
+      const x = (index * step).toFixed(1)
+      const y = (height - (value / span) * height).toFixed(1)
+
+      return `${x},${y}`
+    })
+    .join(' ')
+}
+
+const pulseSparkline = (
+  series: ReadonlyArray<PublicKhalaTokensServedHistoryPoint>,
+): Html => {
+  const h = html<Message>()
+  const points = pulseSparklinePoints(series)
+  const latest = series[series.length - 1]
+  const maxTokens = series.reduce(
+    (largest, point) => Math.max(largest, point.tokensServed),
+    0,
+  )
+
+  return h.div(
+    [
+      h.Role('img'),
+      h.AriaLabel(
+        latest === undefined
+          ? 'No token burn history is available yet.'
+          : `Token burn sparkline across ${formatNumber(
+              series.length,
+            )} days. Latest ${formatNumber(
+              latest.tokensServed,
+            )} tokens. Peak ${formatNumber(maxTokens)} tokens.`,
+      ),
+      Ui.className<Message>('grid gap-2'),
+    ],
+    [
+      h.svg(
+        [
+          h.ViewBox('0 0 192 56'),
+          h.Attribute('preserveAspectRatio', 'none'),
+          Ui.className<Message>('h-14 w-full overflow-visible'),
+        ],
+        [
+          h.polyline(
+            [
+              h.Attribute('points', '0,56 192,56'),
+              h.Attribute('fill', 'none'),
+              h.Attribute('stroke', '#222222'),
+              h.Attribute('stroke-width', '1'),
+            ],
+            [],
+          ),
+          h.polyline(
+            [
+              h.Attribute('points', points),
+              h.Attribute('fill', 'none'),
+              h.Attribute('stroke', '#00c853'),
+              h.Attribute('stroke-linecap', 'round'),
+              h.Attribute('stroke-linejoin', 'round'),
+              h.Attribute('stroke-width', '2'),
+            ],
+            [],
+          ),
+        ],
+      ),
+      h.ul(
+        [Ui.className<Message>('sr-only')],
+        series.map(point =>
+          h.li(
+            [],
+            [`${point.day}: ${formatNumber(point.tokensServed)} tokens`],
+          ),
+        ),
+      ),
+    ],
+  )
+}
+
+const pulseProgressStyle = (progress: number): string =>
+  `width: ${Math.min(100, Math.max(0, progress)).toFixed(2)}%;`
+
+const artanisPulseView = (
+  counter: PublicKhalaTokensServedModel,
+  history: PublicKhalaTokensServedHistoryModel,
+): Html => {
+  const h = html<Message>()
+
+  if (
+    counter._tag === 'PublicKhalaTokensServedFailed' ||
+    history._tag === 'PublicKhalaTokensServedHistoryFailed'
+  ) {
+    return h.div(
+      [
+        Ui.className<Message>(
+          'grid gap-3 border border-[#222] bg-[#010102] p-3',
+        ),
+      ],
+      [
+        h.div(
+          [Ui.className<Message>('text-[0.75rem] text-white/45')],
+          ['The Pulse'],
+        ),
+        h.p(
+          [Ui.className<Message>('text-[0.75rem] text-[#ff6f00]')],
+          ['Live token-burn analytics are temporarily unavailable.'],
+        ),
+      ],
+    )
+  }
+
+  const series = pulseSeries(history)
+  const latest = series[series.length - 1]
+  const target = pulseAveragePriorActiveDay(series)
+  const progress =
+    latest === undefined || target <= 0
+      ? 0
+      : (latest.tokensServed / target) * 100
+  const currentTotal = pulseCurrentTotal(counter)
+
+  return h.div(
+    [
+      h.DataAttribute('component', 'artanis-pulse'),
+      Ui.className<Message>('grid gap-4 border border-[#222] bg-[#010102] p-3'),
+    ],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex flex-wrap items-end justify-between gap-3',
+          ),
+        ],
+        [
+          h.div(
+            [Ui.className<Message>('grid gap-1')],
+            [
+              h.div(
+                [Ui.className<Message>('text-[0.75rem] text-white/45')],
+                ['The Pulse'],
+              ),
+              h.h3(
+                [
+                  Ui.className<Message>(
+                    'text-base font-semibold tracking-normal text-[#f1efe8]',
+                  ),
+                ],
+                ['Live token burn'],
+              ),
+            ],
+          ),
+          h.div(
+            [Ui.className<Message>('text-right text-[0.75rem]')],
+            [
+              h.div(
+                [Ui.className<Message>('tabular-nums text-[#f1efe8]')],
+                [
+                  currentTotal === null
+                    ? 'syncing'
+                    : `${formatCompactNumber(currentTotal)} total`,
+                ],
+              ),
+              h.div(
+                [Ui.className<Message>('text-white/35')],
+                [
+                  history._tag === 'PublicKhalaTokensServedHistoryLoaded'
+                    ? history.history.generatedAt === undefined
+                      ? 'live public ledger'
+                      : `updated ${history.history.generatedAt}`
+                    : 'loading public ledger',
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+      series.length === 0
+        ? h.div(
+            [
+              h.Role('status'),
+              Ui.className<Message>(
+                'flex h-24 items-center justify-center border border-[#1b1b1b] text-[0.75rem] text-white/35',
+              ),
+            ],
+            ['Loading burn history.'],
+          )
+        : pulseSparkline(series),
+      h.div(
+        [Ui.className<Message>('grid gap-2')],
+        [
+          h.div(
+            [
+              Ui.className<Message>(
+                'flex flex-wrap justify-between gap-3 text-[0.75rem]',
+              ),
+            ],
+            [
+              h.span(
+                [Ui.className<Message>('text-white/55')],
+                [
+                  latest === undefined
+                    ? 'Latest day syncing'
+                    : `${latest.day} burn ${formatCompactNumber(latest.tokensServed)}`,
+                ],
+              ),
+              h.span(
+                [Ui.className<Message>('tabular-nums text-white/45')],
+                [
+                  target <= 0
+                    ? 'target pending'
+                    : `${formatPercent(progress)} of ${formatCompactNumber(
+                        target,
+                      )} daily target`,
+                ],
+              ),
+            ],
+          ),
+          h.div(
+            [
+              h.AriaLabel(
+                target <= 0
+                  ? 'Daily target progress is pending.'
+                  : `Daily target progress is ${formatPercent(progress)}.`,
+              ),
+              h.Role('meter'),
+              h.Attribute('aria-valuemin', '0'),
+              h.Attribute('aria-valuemax', '100'),
+              h.Attribute(
+                'aria-valuenow',
+                String(Math.round(Math.min(100, progress))),
+              ),
+              Ui.className<Message>(
+                'h-2 overflow-hidden border border-[#242424] bg-[#050505]',
+              ),
+            ],
+            [
+              h.div(
+                [
+                  h.Attribute('style', pulseProgressStyle(progress)),
+                  Ui.className<Message>('h-full bg-[#00c853]'),
+                ],
+                [],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+const artanisReportLoadedView = (
+  report: PublicArtanisReport,
+  counter: PublicKhalaTokensServedModel,
+  history: PublicKhalaTokensServedHistoryModel,
+): Html => {
   const h = html<Message>()
   const blockers = report.publicBlockerRefs.slice(0, 5)
   const claims = [...report.standaloneClaims, ...report.r10Claims].slice(0, 7)
@@ -1065,6 +1379,7 @@ const artanisReportLoadedView = (report: PublicArtanisReport): Html => {
           ),
         ],
       ),
+      artanisPulseView(counter, history),
       artanisPylonLaunchView(report.pylonLaunchCommunication),
       artanisOmegaReleaseGateView(report.pylonOmegaReleaseGate),
       artanisProductionLaunchGateView(report.productionLaunchGate),
@@ -1088,11 +1403,15 @@ const artanisReportLoadedView = (report: PublicArtanisReport): Html => {
   )
 }
 
-const artanisReportView = (model: PublicArtanisReportModel): Html => {
+const artanisReportView = (
+  model: PublicArtanisReportModel,
+  counter: PublicKhalaTokensServedModel,
+  history: PublicKhalaTokensServedHistoryModel,
+): Html => {
   const h = html<Message>()
 
   if (model._tag === 'PublicArtanisReportLoaded') {
-    return artanisReportLoadedView(model.report)
+    return artanisReportLoadedView(model.report, counter, history)
   }
 
   if (model._tag === 'PublicArtanisReportFailed') {
@@ -1171,6 +1490,8 @@ const loadedView = (
   events: ReadonlyArray<PublicAgentGoalEvent>,
   pylonStats: PublicPylonStatsModel,
   artanisReport: PublicArtanisReportModel,
+  khalaTokensServed: PublicKhalaTokensServedModel,
+  khalaTokensServedHistory: PublicKhalaTokensServedHistoryModel,
   adjutantActivity: PublicAdjutantActivityModel,
 ): Html => {
   const h = html<Message>()
@@ -1283,7 +1604,13 @@ const loadedView = (
           ),
         ],
       ),
-      isArtanis ? artanisReportView(artanisReport) : null,
+      isArtanis
+        ? artanisReportView(
+            artanisReport,
+            khalaTokensServed,
+            khalaTokensServedHistory,
+          )
+        : null,
       isArtanis ? pylonStatsView(pylonStats) : null,
       isAdjutant ? adjutantActivityView(adjutantActivity) : null,
       h.section(
@@ -1318,6 +1645,8 @@ export const view = (model: Model, agentRef: string): Html => {
       model.publicAgent.response.events,
       model.publicPylonStats,
       model.publicArtanisReport,
+      model.publicKhalaTokensServed,
+      model.publicKhalaTokensServedHistory,
       model.publicAdjutantActivity,
     )
   }
@@ -1347,6 +1676,8 @@ export const view = (model: Model, agentRef: string): Html => {
       ],
       model.publicPylonStats,
       model.publicArtanisReport,
+      model.publicKhalaTokensServed,
+      model.publicKhalaTokensServedHistory,
       model.publicAdjutantActivity,
     )
   }

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.test.ts
@@ -1,7 +1,13 @@
 import { Effect } from 'effect'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
-import { LandingRoute, StatsRoute, TraceRoute } from '../../route'
+import {
+  LandingRoute,
+  PublicAgentRoute,
+  StatsRoute,
+  TraceRoute,
+} from '../../route'
+import { SAMPLE_TRACE_UUID, sampleTrajectory } from '../trace/sample'
 import {
   ClickedCopyAgentInstructions,
   ClickedEnterKhala,
@@ -27,7 +33,6 @@ import {
   initialCommands,
   update,
 } from './update'
-import { sampleTrajectory, SAMPLE_TRACE_UUID } from '../trace/sample'
 
 const model = init(LandingRoute())
 
@@ -187,6 +192,25 @@ describe('logged-out nav + copy update', () => {
     ])
   })
 
+  test('Artanis public route loads the pulse counter and history', () => {
+    const artanisModel = init(PublicAgentRoute({ agentRef: 'artanis' }))
+
+    expect(artanisModel.publicKhalaTokensServed._tag).toBe(
+      'PublicKhalaTokensServedLoading',
+    )
+    expect(artanisModel.publicKhalaTokensServedHistory._tag).toBe(
+      'PublicKhalaTokensServedHistoryLoading',
+    )
+    expect(commandNames(initialCommands(artanisModel))).toEqual([
+      'LoadPublicAgentGoal',
+      'LoadPublicArtanisReport',
+      'LoadPublicPylonStats',
+      'LoadKhalaTokensServedSnapshot',
+      'LoadPublicKhalaTokensServed',
+      'LoadPublicKhalaTokensServedHistory',
+    ])
+  })
+
   test('LoadPublicKhalaTokensServedModelMix reads canonical aggregate family mix', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(
@@ -298,7 +322,9 @@ describe('logged-out nav + copy update', () => {
       RequestedPollKhalaTokensServedModelMix(),
     )
 
-    expect(commandNames(commands)).toEqual(['LoadPublicKhalaTokensServedModelMix'])
+    expect(commandNames(commands)).toEqual([
+      'LoadPublicKhalaTokensServedModelMix',
+    ])
     // The previously loaded mix is held while the next aggregate is in flight.
     expect(next.publicKhalaTokensServedModelMix._tag).toBe(
       'PublicKhalaTokensServedModelMixLoaded',
@@ -410,7 +436,9 @@ describe('trace route load wiring', () => {
     )
     if (message._tag === 'SucceededLoadTrace') {
       expect(message.uuid).toBe(REAL_TRACE_UUID)
-      expect(message.trajectory.steps.length).toBe(sampleTrajectory.steps.length)
+      expect(message.trajectory.steps.length).toBe(
+        sampleTrajectory.steps.length,
+      )
     }
   })
 

--- a/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/update.ts
@@ -11,111 +11,13 @@ import { load, pushUrl } from 'foldkit/navigation'
 import { evo } from 'foldkit/struct'
 
 import {
-  CompletedCopyAgentInstructions,
-  CompletedCopyShareLink,
-  CompletedLandingLogout,
-  CompletedNavigateToKhala,
-  CompletedNavigateToLanding,
-  CompletedNavigateToTassadar,
-  CompletedAutopilotOnboardingCreditKickoff,
-  CompletedPersistAutopilotOnboarding,
-  CompletedScrollAutopilotOnboardingThread,
-  CompletedScrollKhalaChatThread,
-  FailedReconcileAutopilotOnboardingSession,
-  LoadedStoredAutopilotOnboarding,
-  SucceededReconcileAutopilotOnboardingSession,
-  FailedLoadPublicAdjutantActivity,
-  FailedLoadPublicAgentGoal,
-  FailedLoadPublicArtanisReport,
-  FailedLoadPublicForumLaunchStatus,
-  FailedLoadPublicForumTipLeaderboards,
-  FailedLoadKhalaTokensServedSnapshot,
-  FailedLoadPublicKhalaTokensServed,
-  FailedLoadPublicKhalaTokensServedHistory,
-  FailedLoadPublicKhalaTokensServedModelMix,
-  FailedLoadPublicGymRunProgress,
-  FailedLoadGymRunProgressSnapshot,
-  FailedLoadMirrorCodeRuns,
-  FailedLoadPublicProductPromises,
-  FailedLoadPublicPromiseTransitions,
-  FailedLoadPublicPylonStats,
-  FailedLoadPublicTrainingRuns,
-  FailedLoadSettledFeedSnapshot,
-  FailedLoadShareProjection,
-  FailedLoadTrace,
-  Message,
-  SucceededLoadPublicAdjutantActivity,
-  SucceededLoadPublicAgentGoal,
-  SucceededLoadPublicArtanisReport,
-  SucceededLoadPublicForumLaunchStatus,
-  SucceededLoadPublicForumTipLeaderboards,
-  SucceededLoadKhalaTokensServedSnapshot,
-  SucceededLoadPublicKhalaTokensServed,
-  SucceededLoadPublicKhalaTokensServedHistory,
-  SucceededLoadPublicKhalaTokensServedModelMix,
-  SucceededLoadPublicGymRunProgress,
-  SucceededLoadGymRunProgressSnapshot,
-  SucceededLoadMirrorCodeRuns,
-  SucceededLoadPublicProductPromises,
-  SucceededLoadPublicPromiseTransitions,
-  SucceededLoadPublicPylonStats,
-  SucceededLoadPublicTrainingRuns,
-  SucceededLoadSettledFeedSnapshot,
-  SucceededLoadShareProjection,
-  SucceededLoadTrace,
-} from './message'
-import {
-  FailedPublicAdjutantActivity,
-  FailedPublicAgent,
-  FailedPublicArtanisReport,
-  FailedPublicForumLaunchStatus,
-  FailedPublicForumTipLeaderboards,
-  FailedPublicKhalaTokensServed,
-  FailedPublicKhalaTokensServedHistory,
-  FailedPublicKhalaTokensServedModelMix,
-  FailedPublicGymRunProgress,
-  FailedMirrorCodeRuns,
-  FailedPublicProductPromises,
-  FailedPublicPromiseTransitions,
-  FailedPublicPylonStats,
-  FailedPublicTrainingRuns,
-  FailedShareProjection,
-  LoadedPublicAdjutantActivity,
-  LoadedPublicAgent,
-  LoadedPublicArtanisReport,
-  LoadedPublicForumLaunchStatus,
-  LoadedPublicForumTipLeaderboards,
-  LoadedPublicKhalaTokensServedHistory,
-  LoadedPublicKhalaTokensServedModelMix,
-  LoadedPublicGymRunProgress,
-  LoadedMirrorCodeRuns,
-  LoadedPublicProductPromises,
-  LoadedPublicPromiseTransitions,
-  LoadedPublicPylonStats,
-  LoadedPublicTrainingRuns,
-  LoadedShareProjection,
-  LoadedTrace,
-  Model,
-  NotFoundTrace,
-  FailedTrace,
-  PublicAdjutantActivity,
-  PublicAgentGoalResponse,
-  PublicArtanisReport,
-  PublicForumLaunchStatus,
-  PublicForumTipLeaderboards,
-  PublicKhalaTokensServed,
-  PublicKhalaTokensServedHistory,
-  PublicKhalaTokensServedModelMix,
-  PublicProductPromises,
-  PublicPromiseTransitions,
-  PublicPylonStats,
-  PublicTrainingRunResponse,
-  PublicTrainingRunsResponse,
-  ShareProjectionResponse,
-} from './model'
+  clearSessionFromStore,
+  sessionStoreLayer,
+} from '../../commands/session-store'
+import { recordFromUnknown } from '../../json-boundary'
+import { homeRouter, khalaRouter, tassadarRouter } from '../../route'
+import { FlowModel } from '../autopilot-onboarding/flow'
 import { HUD_THREAD_END_SELECTOR } from '../autopilot-onboarding/page'
-import { KHALA_CHAT_THREAD_END_SELECTOR } from '../khala-chat/page'
-import { onboardingVerticalForSegment } from '../autopilot-onboarding/vertical-overlay'
 import {
   OnboardingSessionResponse,
   type StoredInFlight,
@@ -125,7 +27,13 @@ import {
   storedSessionFromParts,
   writeStoredSession,
 } from '../autopilot-onboarding/persistence'
-import { FlowModel } from '../autopilot-onboarding/flow'
+import { onboardingVerticalForSegment } from '../autopilot-onboarding/vertical-overlay'
+import { KHALA_CHAT_THREAD_END_SELECTOR } from '../khala-chat/page'
+import {
+  BlobRef as AtifBlobRef,
+  Trajectory as AtifTrajectory,
+} from '../trace/atif'
+import { SAMPLE_TRACE_UUID } from '../trace/sample'
 import {
   setGymConcurrency,
   setGymFanoutMode,
@@ -144,24 +52,15 @@ import {
   GymRunProgressPublicProjection,
   GymRunProgressResponse,
 } from './gym/runProgress'
-import { MirrorCodeRunsResponse } from './mirrorcode/runs'
-import { BlobRef as AtifBlobRef, Trajectory as AtifTrajectory } from '../trace/atif'
-import { SAMPLE_TRACE_UUID } from '../trace/sample'
-import { recordFromUnknown } from '../../json-boundary'
 import {
-  clearSessionFromStore,
-  sessionStoreLayer,
-} from '../../commands/session-store'
-import { homeRouter, khalaRouter, tassadarRouter } from '../../route'
-import {
-  SETTLED_FEED_SCOPE,
-  applySettledFeedPatch,
-  settledFeedAfterCursorGap,
-  settledFeedAfterSnapshot,
-  settledFeedClosed,
-  settledFeedFailed,
-  settledFeedOpen,
-} from './settled-feed'
+  GYM_RUN_PROGRESS_SCOPE,
+  applyGymRunProgressPatch,
+  gymRunProgressAfterSnapshot,
+  gymRunProgressStreamAfterCursorGap,
+  gymRunProgressStreamClosed,
+  gymRunProgressStreamFailed,
+  gymRunProgressStreamOpen,
+} from './gym/runProgressFeed'
 import {
   KHALA_TOKENS_SERVED_SCOPE,
   applyKhalaTokensServedPatch,
@@ -174,14 +73,118 @@ import {
   khalaTokensServedStreamSnapshotSettled,
 } from './khala-tokens-served-feed'
 import {
-  GYM_RUN_PROGRESS_SCOPE,
-  applyGymRunProgressPatch,
-  gymRunProgressAfterSnapshot,
-  gymRunProgressStreamAfterCursorGap,
-  gymRunProgressStreamClosed,
-  gymRunProgressStreamFailed,
-  gymRunProgressStreamOpen,
-} from './gym/runProgressFeed'
+  CompletedAutopilotOnboardingCreditKickoff,
+  CompletedCopyAgentInstructions,
+  CompletedCopyShareLink,
+  CompletedLandingLogout,
+  CompletedNavigateToKhala,
+  CompletedNavigateToLanding,
+  CompletedNavigateToTassadar,
+  CompletedPersistAutopilotOnboarding,
+  CompletedScrollAutopilotOnboardingThread,
+  CompletedScrollKhalaChatThread,
+  FailedLoadGymRunProgressSnapshot,
+  FailedLoadKhalaTokensServedSnapshot,
+  FailedLoadMirrorCodeRuns,
+  FailedLoadPublicAdjutantActivity,
+  FailedLoadPublicAgentGoal,
+  FailedLoadPublicArtanisReport,
+  FailedLoadPublicForumLaunchStatus,
+  FailedLoadPublicForumTipLeaderboards,
+  FailedLoadPublicGymRunProgress,
+  FailedLoadPublicKhalaTokensServed,
+  FailedLoadPublicKhalaTokensServedHistory,
+  FailedLoadPublicKhalaTokensServedModelMix,
+  FailedLoadPublicProductPromises,
+  FailedLoadPublicPromiseTransitions,
+  FailedLoadPublicPylonStats,
+  FailedLoadPublicTrainingRuns,
+  FailedLoadSettledFeedSnapshot,
+  FailedLoadShareProjection,
+  FailedLoadTrace,
+  FailedReconcileAutopilotOnboardingSession,
+  LoadedStoredAutopilotOnboarding,
+  Message,
+  SucceededLoadGymRunProgressSnapshot,
+  SucceededLoadKhalaTokensServedSnapshot,
+  SucceededLoadMirrorCodeRuns,
+  SucceededLoadPublicAdjutantActivity,
+  SucceededLoadPublicAgentGoal,
+  SucceededLoadPublicArtanisReport,
+  SucceededLoadPublicForumLaunchStatus,
+  SucceededLoadPublicForumTipLeaderboards,
+  SucceededLoadPublicGymRunProgress,
+  SucceededLoadPublicKhalaTokensServed,
+  SucceededLoadPublicKhalaTokensServedHistory,
+  SucceededLoadPublicKhalaTokensServedModelMix,
+  SucceededLoadPublicProductPromises,
+  SucceededLoadPublicPromiseTransitions,
+  SucceededLoadPublicPylonStats,
+  SucceededLoadPublicTrainingRuns,
+  SucceededLoadSettledFeedSnapshot,
+  SucceededLoadShareProjection,
+  SucceededLoadTrace,
+  SucceededReconcileAutopilotOnboardingSession,
+} from './message'
+import { MirrorCodeRunsResponse } from './mirrorcode/runs'
+import {
+  FailedMirrorCodeRuns,
+  FailedPublicAdjutantActivity,
+  FailedPublicAgent,
+  FailedPublicArtanisReport,
+  FailedPublicForumLaunchStatus,
+  FailedPublicForumTipLeaderboards,
+  FailedPublicGymRunProgress,
+  FailedPublicKhalaTokensServed,
+  FailedPublicKhalaTokensServedHistory,
+  FailedPublicKhalaTokensServedModelMix,
+  FailedPublicProductPromises,
+  FailedPublicPromiseTransitions,
+  FailedPublicPylonStats,
+  FailedPublicTrainingRuns,
+  FailedShareProjection,
+  FailedTrace,
+  LoadedMirrorCodeRuns,
+  LoadedPublicAdjutantActivity,
+  LoadedPublicAgent,
+  LoadedPublicArtanisReport,
+  LoadedPublicForumLaunchStatus,
+  LoadedPublicForumTipLeaderboards,
+  LoadedPublicGymRunProgress,
+  LoadedPublicKhalaTokensServedHistory,
+  LoadedPublicKhalaTokensServedModelMix,
+  LoadedPublicProductPromises,
+  LoadedPublicPromiseTransitions,
+  LoadedPublicPylonStats,
+  LoadedPublicTrainingRuns,
+  LoadedShareProjection,
+  LoadedTrace,
+  Model,
+  NotFoundTrace,
+  PublicAdjutantActivity,
+  PublicAgentGoalResponse,
+  PublicArtanisReport,
+  PublicForumLaunchStatus,
+  PublicForumTipLeaderboards,
+  PublicKhalaTokensServed,
+  PublicKhalaTokensServedHistory,
+  PublicKhalaTokensServedModelMix,
+  PublicProductPromises,
+  PublicPromiseTransitions,
+  PublicPylonStats,
+  PublicTrainingRunResponse,
+  PublicTrainingRunsResponse,
+  ShareProjectionResponse,
+} from './model'
+import {
+  SETTLED_FEED_SCOPE,
+  applySettledFeedPatch,
+  settledFeedAfterCursorGap,
+  settledFeedAfterSnapshot,
+  settledFeedClosed,
+  settledFeedFailed,
+  settledFeedOpen,
+} from './settled-feed'
 
 type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>]
 const withUpdateReturn = M.withReturnType<UpdateReturn>()
@@ -468,8 +471,9 @@ export const LoadPublicKhalaTokensServed = Command.define(
       try: () => response.json(),
       catch: error => new PublicKhalaTokensServedLoadError({ error }),
     })
-    const decoded =
-      yield* S.decodeUnknownEffect(PublicKhalaTokensServed)(payload)
+    const decoded = yield* S.decodeUnknownEffect(PublicKhalaTokensServed)(
+      payload,
+    )
 
     return SucceededLoadPublicKhalaTokensServed({ served: decoded })
   }).pipe(
@@ -535,15 +539,16 @@ export const LoadKhalaTokensServedSnapshot = Command.define(
       try: () => response.json(),
       catch: error => new KhalaTokensServedSnapshotLoadError({ error }),
     })
-    const decoded =
-      yield* S.decodeUnknownEffect(KhalaTokensServedSnapshotPayload)(payload)
-    const rawSummary =
-      decoded.collections['tokens_served_summary']?.['summary']
-    const summary = rawSummary === undefined
-      ? null
-      : yield* S.decodeUnknownEffect(KhalaTokensServedSnapshotSummary)(
-          rawSummary,
-        ).pipe(Effect.orElseSucceed(() => null))
+    const decoded = yield* S.decodeUnknownEffect(
+      KhalaTokensServedSnapshotPayload,
+    )(payload)
+    const rawSummary = decoded.collections['tokens_served_summary']?.['summary']
+    const summary =
+      rawSummary === undefined
+        ? null
+        : yield* S.decodeUnknownEffect(KhalaTokensServedSnapshotSummary)(
+            rawSummary,
+          ).pipe(Effect.orElseSucceed(() => null))
 
     return SucceededLoadKhalaTokensServedSnapshot({
       cursor: decoded.cursor,
@@ -594,8 +599,9 @@ export const LoadPublicKhalaTokensServedHistory = Command.define(
       try: () => response.json(),
       catch: error => new PublicKhalaTokensServedHistoryLoadError({ error }),
     })
-    const decoded =
-      yield* S.decodeUnknownEffect(PublicKhalaTokensServedHistory)(payload)
+    const decoded = yield* S.decodeUnknownEffect(
+      PublicKhalaTokensServedHistory,
+    )(payload)
 
     return SucceededLoadPublicKhalaTokensServedHistory({ history: decoded })
   }).pipe(
@@ -638,8 +644,9 @@ export const LoadPublicKhalaTokensServedModelMix = Command.define(
       try: () => response.json(),
       catch: error => new PublicKhalaTokensServedModelMixLoadError({ error }),
     })
-    const decoded =
-      yield* S.decodeUnknownEffect(PublicKhalaTokensServedModelMix)(payload)
+    const decoded = yield* S.decodeUnknownEffect(
+      PublicKhalaTokensServedModelMix,
+    )(payload)
 
     return SucceededLoadPublicKhalaTokensServedModelMix({ mix: decoded })
   }).pipe(
@@ -684,7 +691,9 @@ export const LoadPublicGymRunProgress = Command.define(
       try: () => response.json(),
       catch: error => new PublicGymRunProgressLoadError({ error }),
     })
-    const decoded = yield* S.decodeUnknownEffect(GymRunProgressResponse)(payload)
+    const decoded = yield* S.decodeUnknownEffect(GymRunProgressResponse)(
+      payload,
+    )
 
     return SucceededLoadPublicGymRunProgress({ runs: decoded.runs })
   }).pipe(
@@ -734,7 +743,9 @@ export const LoadMirrorCodeRuns = Command.define(
       try: () => response.json(),
       catch: error => new MirrorCodeRunsLoadError({ error }),
     })
-    const decoded = yield* S.decodeUnknownEffect(MirrorCodeRunsResponse)(payload)
+    const decoded = yield* S.decodeUnknownEffect(MirrorCodeRunsResponse)(
+      payload,
+    )
 
     return SucceededLoadMirrorCodeRuns({ response: decoded })
   }).pipe(
@@ -774,10 +785,13 @@ export const LoadGymRunProgressSnapshot = Command.define(
   Effect.gen(function* () {
     const response = yield* Effect.tryPromise({
       try: () =>
-        fetch(`/api/sync/${GYM_RUN_PROGRESS_SCOPE.replace(':', '/')}/snapshot`, {
-          cache: 'no-store',
-          headers: { accept: 'application/json' },
-        }),
+        fetch(
+          `/api/sync/${GYM_RUN_PROGRESS_SCOPE.replace(':', '/')}/snapshot`,
+          {
+            cache: 'no-store',
+            headers: { accept: 'application/json' },
+          },
+        ),
       catch: error => new GymRunProgressSnapshotLoadError({ error }),
     })
 
@@ -791,20 +805,17 @@ export const LoadGymRunProgressSnapshot = Command.define(
       try: () => response.json(),
       catch: error => new GymRunProgressSnapshotLoadError({ error }),
     })
-    const decoded =
-      yield* S.decodeUnknownEffect(GymRunProgressSnapshotPayload)(payload)
+    const decoded = yield* S.decodeUnknownEffect(GymRunProgressSnapshotPayload)(
+      payload,
+    )
     const collection = decoded.collections['gym_run_progress'] ?? {}
-    const maybeRuns = yield* Effect.forEach(
-      Object.values(collection),
-      value =>
-        S.decodeUnknownEffect(GymRunProgressPublicProjection)(value).pipe(
-          Effect.map(run =>
-            Option.some<GymRunProgressPublicProjection>(run),
-          ),
-          Effect.orElseSucceed(() =>
-            Option.none<GymRunProgressPublicProjection>(),
-          ),
+    const maybeRuns = yield* Effect.forEach(Object.values(collection), value =>
+      S.decodeUnknownEffect(GymRunProgressPublicProjection)(value).pipe(
+        Effect.map(run => Option.some<GymRunProgressPublicProjection>(run)),
+        Effect.orElseSucceed(() =>
+          Option.none<GymRunProgressPublicProjection>(),
         ),
+      ),
     )
     const runs = Arr.getSomes(maybeRuns)
 
@@ -868,14 +879,16 @@ export const LoadSettledFeedSnapshot = Command.define(
       try: () => response.json(),
       catch: error => new SettledFeedSnapshotLoadError({ error }),
     })
-    const decoded =
-      yield* S.decodeUnknownEffect(SettledFeedSnapshotPayload)(payload)
+    const decoded = yield* S.decodeUnknownEffect(SettledFeedSnapshotPayload)(
+      payload,
+    )
     const rawSummary = decoded.collections['settled_summary']?.['summary']
-    const summary = rawSummary === undefined
-      ? null
-      : yield* S.decodeUnknownEffect(SettledFeedSnapshotSummary)(
-          rawSummary,
-        ).pipe(Effect.orElseSucceed(() => null))
+    const summary =
+      rawSummary === undefined
+        ? null
+        : yield* S.decodeUnknownEffect(SettledFeedSnapshotSummary)(
+            rawSummary,
+          ).pipe(Effect.orElseSucceed(() => null))
 
     return SucceededLoadSettledFeedSnapshot({
       cursor: decoded.cursor,
@@ -1040,8 +1053,9 @@ export const LoadPublicPromiseTransitions = Command.define(
       try: () => response.json(),
       catch: error => new PublicPromiseTransitionsLoadError({ error }),
     })
-    const decoded =
-      yield* S.decodeUnknownEffect(PublicPromiseTransitions)(payload)
+    const decoded = yield* S.decodeUnknownEffect(PublicPromiseTransitions)(
+      payload,
+    )
 
     return SucceededLoadPublicPromiseTransitions({ transitions: decoded })
   }).pipe(
@@ -1291,7 +1305,7 @@ export const TASSADAR_AGENT_INSTRUCTIONS = [
   '',
   'curl -X POST https://openagents.com/api/agents/register \\',
   '  -H "Content-Type: application/json" \\',
-  "  -d '{\"displayName\": \"YOUR_AGENT_NAME\", \"slug\": \"your-agent-name\"}'",
+  '  -d \'{"displayName": "YOUR_AGENT_NAME", "slug": "your-agent-name"}\'',
   '',
   'Then install Pylon and join the run:',
   '  npx @openagentsinc/pylon',
@@ -1476,10 +1490,7 @@ const storedSessionFromFlow = (
 // (no stuck half-bubble), persisting the cleared cursor. Shared by the resume
 // stream's terminal-without-done (closed) and 404 (failed) outcomes — both end
 // the resume the same way. Ignores a turn that is no longer the resuming one.
-const endResume = (
-  model: Model,
-  turnIndex: number,
-): UpdateReturn => {
+const endResume = (model: Model, turnIndex: number): UpdateReturn => {
   const flow = model.autopilotOnboarding
   if (
     flow.inFlight === null ||
@@ -1590,8 +1601,9 @@ export const ReconcileAutopilotOnboardingSession = Command.define(
       try: () => response.json(),
       catch: error => new OnboardingSessionReconcileError({ error, status: 0 }),
     })
-    const decoded =
-      yield* S.decodeUnknownEffect(OnboardingSessionResponse)(payload)
+    const decoded = yield* S.decodeUnknownEffect(OnboardingSessionResponse)(
+      payload,
+    )
 
     return SucceededReconcileAutopilotOnboardingSession({ response: decoded })
   }).pipe(
@@ -1599,9 +1611,7 @@ export const ReconcileAutopilotOnboardingSession = Command.define(
       Effect.succeed(
         FailedReconcileAutopilotOnboardingSession({
           status:
-            error instanceof OnboardingSessionReconcileError
-              ? error.status
-              : 0,
+            error instanceof OnboardingSessionReconcileError ? error.status : 0,
         }),
       ),
     ),
@@ -1623,73 +1633,84 @@ export const initialCommands = (
   model.route._tag === 'Autopilot' || model.route._tag === 'AutopilotVertical'
     ? [RehydrateAutopilotOnboarding()]
     : model.route._tag === 'Share'
-    ? [LoadShareProjection({ shareId: model.route.shareId })]
-    : model.route._tag === 'Trace' &&
-        model.route.uuid !== SAMPLE_TRACE_UUID
-      ? [LoadTrace({ uuid: model.route.uuid })]
-    : model.route._tag === 'Home'
-      ? [
-          LoadPublicPylonStats(),
-          LoadKhalaTokensServedSnapshot(),
-          LoadPublicKhalaTokensServed(),
-          LoadPublicKhalaTokensServedHistory(),
-          LoadPublicForumLaunchStatus(),
-          LoadPublicForumTipLeaderboards(),
-          LoadSettledFeedSnapshot(),
-        ]
-      : model.route._tag === 'Stats' ||
-        model.route._tag === 'PublicStatsArchive'
-      ? [
-          LoadPublicPylonStats(),
-          LoadKhalaTokensServedSnapshot(),
-          LoadPublicKhalaTokensServed(),
-          LoadPublicKhalaTokensServedHistory(),
-          LoadPublicKhalaTokensServedModelMix(),
-          LoadPublicForumLaunchStatus(),
-          LoadPublicForumTipLeaderboards(),
-          LoadSettledFeedSnapshot(),
-        ]
-      : model.route._tag === 'Khala' || model.route._tag === 'Landing'
-        ? // /khala AND the / landing hero both show the live "Khala Tokens
-          // Served" total (the landing top-left pill mirrors the /khala
-          // counter), so both seed from the SAME snapshot + scalar endpoints and
-          // subscribe to the SAME live stream below — no parallel data source.
-          [LoadKhalaTokensServedSnapshot(), LoadPublicKhalaTokensServed()]
-      : model.route._tag === 'Gym'
-        ? [LoadGymRunProgressSnapshot(), LoadPublicGymRunProgress()]
-      : model.route._tag === 'MirrorCode'
-        ? [LoadMirrorCodeRuns()]
-      : model.route._tag === 'ProductPromises'
-        ? [LoadPublicProductPromises(), LoadPublicPromiseTransitions()]
-        : model.route._tag === 'PublicTrainingRuns'
-          ? [LoadPublicTrainingRuns({ runId: null })]
-          : model.route._tag === 'PublicTrainingRun'
-            ? [LoadPublicTrainingRuns({ runId: model.route.runId })]
-            : model.route._tag === 'PublicAgent'
-              ? model.route.agentRef === 'artanis'
-                ? [
-                    LoadPublicAgentGoal({
-                      agentId: publicAgentIdForRef(model.route.agentRef),
-                      agentRef: model.route.agentRef,
-                    }),
-                    LoadPublicArtanisReport(),
-                    LoadPublicPylonStats(),
-                  ]
-                : model.route.agentRef === 'adjutant'
-                  ? [
-                      LoadPublicAgentGoal({
-                        agentId: publicAgentIdForRef(model.route.agentRef),
-                        agentRef: model.route.agentRef,
-                      }),
-                      LoadPublicAdjutantActivity(),
-                    ]
-                  : [
-                      LoadPublicAgentGoal({
-                        agentId: publicAgentIdForRef(model.route.agentRef),
-                        agentRef: model.route.agentRef,
-                      }),
-                    ]
-              : []
+      ? [LoadShareProjection({ shareId: model.route.shareId })]
+      : model.route._tag === 'Trace' && model.route.uuid !== SAMPLE_TRACE_UUID
+        ? [LoadTrace({ uuid: model.route.uuid })]
+        : model.route._tag === 'Home'
+          ? [
+              LoadPublicPylonStats(),
+              LoadKhalaTokensServedSnapshot(),
+              LoadPublicKhalaTokensServed(),
+              LoadPublicKhalaTokensServedHistory(),
+              LoadPublicForumLaunchStatus(),
+              LoadPublicForumTipLeaderboards(),
+              LoadSettledFeedSnapshot(),
+            ]
+          : model.route._tag === 'Stats' ||
+              model.route._tag === 'PublicStatsArchive'
+            ? [
+                LoadPublicPylonStats(),
+                LoadKhalaTokensServedSnapshot(),
+                LoadPublicKhalaTokensServed(),
+                LoadPublicKhalaTokensServedHistory(),
+                LoadPublicKhalaTokensServedModelMix(),
+                LoadPublicForumLaunchStatus(),
+                LoadPublicForumTipLeaderboards(),
+                LoadSettledFeedSnapshot(),
+              ]
+            : model.route._tag === 'Khala' || model.route._tag === 'Landing'
+              ? // /khala AND the / landing hero both show the live "Khala Tokens
+                // Served" total (the landing top-left pill mirrors the /khala
+                // counter), so both seed from the SAME snapshot + scalar endpoints and
+                // subscribe to the SAME live stream below — no parallel data source.
+                [LoadKhalaTokensServedSnapshot(), LoadPublicKhalaTokensServed()]
+              : model.route._tag === 'Gym'
+                ? [LoadGymRunProgressSnapshot(), LoadPublicGymRunProgress()]
+                : model.route._tag === 'MirrorCode'
+                  ? [LoadMirrorCodeRuns()]
+                  : model.route._tag === 'ProductPromises'
+                    ? [
+                        LoadPublicProductPromises(),
+                        LoadPublicPromiseTransitions(),
+                      ]
+                    : model.route._tag === 'PublicTrainingRuns'
+                      ? [LoadPublicTrainingRuns({ runId: null })]
+                      : model.route._tag === 'PublicTrainingRun'
+                        ? [LoadPublicTrainingRuns({ runId: model.route.runId })]
+                        : model.route._tag === 'PublicAgent'
+                          ? model.route.agentRef === 'artanis'
+                            ? [
+                                LoadPublicAgentGoal({
+                                  agentId: publicAgentIdForRef(
+                                    model.route.agentRef,
+                                  ),
+                                  agentRef: model.route.agentRef,
+                                }),
+                                LoadPublicArtanisReport(),
+                                LoadPublicPylonStats(),
+                                LoadKhalaTokensServedSnapshot(),
+                                LoadPublicKhalaTokensServed(),
+                                LoadPublicKhalaTokensServedHistory(),
+                              ]
+                            : model.route.agentRef === 'adjutant'
+                              ? [
+                                  LoadPublicAgentGoal({
+                                    agentId: publicAgentIdForRef(
+                                      model.route.agentRef,
+                                    ),
+                                    agentRef: model.route.agentRef,
+                                  }),
+                                  LoadPublicAdjutantActivity(),
+                                ]
+                              : [
+                                  LoadPublicAgentGoal({
+                                    agentId: publicAgentIdForRef(
+                                      model.route.agentRef,
+                                    ),
+                                    agentRef: model.route.agentRef,
+                                  }),
+                                ]
+                          : []
 
 const fundingAmountFromInput = (value: string): number => {
   const parsed = Number.parseInt(value, 10)
@@ -2208,7 +2229,8 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       CompletedCopyShareLink: () => [model, []],
       SucceededLoadSettledFeedSnapshot: ({ cursor, summary }) => [
         evo(model, {
-          settledFeed: feed => settledFeedAfterSnapshot(feed, { cursor, summary }),
+          settledFeed: feed =>
+            settledFeedAfterSnapshot(feed, { cursor, summary }),
         }),
         [],
       ],

--- a/apps/openagents.com/apps/web/src/subscriptions.ts
+++ b/apps/openagents.com/apps/web/src/subscriptions.ts
@@ -3,7 +3,6 @@ import { Duration, Effect, Exit, Queue, Schema as S, Stream } from 'effect'
 import { Subscription } from 'foldkit'
 
 import { parseJsonRecord } from './json-boundary'
-
 import {
   GotDemoMessage,
   GotLoggedInMessage,
@@ -13,49 +12,6 @@ import {
 import type { Model } from './model'
 import { Demo } from './model'
 import {
-  ClosedSyncStream,
-  FailedSyncStream,
-  OpenedSyncStream,
-  ReceivedSyncCursorGap,
-  ReceivedSyncPatch,
-  RequestedPollAutopilotRun,
-} from './page/loggedIn/message'
-import {
-  ClosedAutopilotOnboardingResumeStream,
-  ClosedSettledFeedStream,
-  FailedAutopilotOnboardingResume,
-  FailedAutopilotOnboardingTurn,
-  FailedSettledFeedStream,
-  OpenedAutopilotOnboardingStream,
-  OpenedSettledFeedStream,
-  ReceivedAutopilotOnboardingDelta,
-  ReceivedAutopilotOnboardingResumeReply,
-  ReceivedAutopilotOnboardingStreamHandshake,
-  ReceivedSettledFeedCursorGap,
-  ReceivedSettledFeedPatch,
-  ClosedKhalaTokensServedStream,
-  FailedKhalaTokensServedStream,
-  OpenedKhalaTokensServedStream,
-  ReceivedKhalaTokensServedCursorGap,
-  ReceivedKhalaTokensServedPatch,
-  RequestedPollKhalaTokensServed,
-  RequestedPollKhalaTokensServedHistory,
-  RequestedPollKhalaTokensServedModelMix,
-  RequestedPollGymRunProgress,
-  ClosedGymRunProgressStream,
-  FailedGymRunProgressStream,
-  OpenedGymRunProgressStream,
-  ReceivedGymRunProgressCursorGap,
-  ReceivedGymRunProgressPatch,
-  SucceededAutopilotOnboardingTurn,
-  SucceededResumeAutopilotOnboardingTurn,
-  FailedKhalaChatTurn,
-  OpenedKhalaChatStream,
-  ReceivedKhalaChatDelta,
-  SucceededKhalaChatTurn,
-} from './page/loggedOut/message'
-import type { Message as LoggedOutMessage } from './page/loggedOut/message'
-import {
   type OnboardingStreamEvent,
   parseOnboardingStreamEvent,
 } from './page/autopilot-onboarding/flow'
@@ -64,10 +20,14 @@ import {
   KhalaChatTurn,
   parseKhalaChatStreamEvent,
 } from './page/khala-chat/flow'
-import { newOnboardingSessionId } from './page/loggedOut/update'
-import { SETTLED_FEED_SCOPE } from './page/loggedOut/settled-feed'
-import { KHALA_TOKENS_SERVED_SCOPE } from './page/loggedOut/khala-tokens-served-feed'
-import { GYM_RUN_PROGRESS_SCOPE } from './page/loggedOut/gym/runProgressFeed'
+import {
+  ClosedSyncStream,
+  FailedSyncStream,
+  OpenedSyncStream,
+  ReceivedSyncCursorGap,
+  ReceivedSyncPatch,
+  RequestedPollAutopilotRun,
+} from './page/loggedIn/message'
 import {
   syncAgentRunScope,
   syncTeamScope,
@@ -75,6 +35,45 @@ import {
 } from './page/loggedIn/model'
 import { authorizedThreadRouteScope } from './page/loggedIn/thread-route'
 import { chatRunIsBusy } from './page/loggedIn/update'
+import { GYM_RUN_PROGRESS_SCOPE } from './page/loggedOut/gym/runProgressFeed'
+import { KHALA_TOKENS_SERVED_SCOPE } from './page/loggedOut/khala-tokens-served-feed'
+import {
+  ClosedAutopilotOnboardingResumeStream,
+  ClosedGymRunProgressStream,
+  ClosedKhalaTokensServedStream,
+  ClosedSettledFeedStream,
+  FailedAutopilotOnboardingResume,
+  FailedAutopilotOnboardingTurn,
+  FailedGymRunProgressStream,
+  FailedKhalaChatTurn,
+  FailedKhalaTokensServedStream,
+  FailedSettledFeedStream,
+  OpenedAutopilotOnboardingStream,
+  OpenedGymRunProgressStream,
+  OpenedKhalaChatStream,
+  OpenedKhalaTokensServedStream,
+  OpenedSettledFeedStream,
+  ReceivedAutopilotOnboardingDelta,
+  ReceivedAutopilotOnboardingResumeReply,
+  ReceivedAutopilotOnboardingStreamHandshake,
+  ReceivedGymRunProgressCursorGap,
+  ReceivedGymRunProgressPatch,
+  ReceivedKhalaChatDelta,
+  ReceivedKhalaTokensServedCursorGap,
+  ReceivedKhalaTokensServedPatch,
+  ReceivedSettledFeedCursorGap,
+  ReceivedSettledFeedPatch,
+  RequestedPollGymRunProgress,
+  RequestedPollKhalaTokensServed,
+  RequestedPollKhalaTokensServedHistory,
+  RequestedPollKhalaTokensServedModelMix,
+  SucceededAutopilotOnboardingTurn,
+  SucceededKhalaChatTurn,
+  SucceededResumeAutopilotOnboardingTurn,
+} from './page/loggedOut/message'
+import type { Message as LoggedOutMessage } from './page/loggedOut/message'
+import { SETTLED_FEED_SCOPE } from './page/loggedOut/settled-feed'
+import { newOnboardingSessionId } from './page/loggedOut/update'
 import { loggedInWorkroomAllowed } from './product-policy'
 import type { LoggedInRoute } from './route'
 
@@ -276,7 +275,8 @@ const khalaTokensServedSurfaceIsLive = (
 ): boolean =>
   settledFeedRouteIsLive(model) ||
   model.route._tag === 'Khala' ||
-  model.route._tag === 'Landing'
+  model.route._tag === 'Landing' ||
+  (model.route._tag === 'PublicAgent' && model.route.agentRef === 'artanis')
 
 export const settledFeedDependenciesForModel = (
   model: Model,
@@ -323,7 +323,8 @@ const inactiveKhalaTokensServedStream: {
   streamHref: '',
 }
 
-type KhalaTokensServedStreamDependencies = typeof inactiveKhalaTokensServedStream
+type KhalaTokensServedStreamDependencies =
+  typeof inactiveKhalaTokensServedStream
 
 export const khalaTokensServedStreamDependenciesForModel = (
   model: Model,
@@ -538,8 +539,7 @@ export const khalaTokensServedPollDependenciesForModel = (
 // GROUP BY aggregate against).
 const khalaTokensServedModelMixRouteIsLive = (model: Model): boolean =>
   model._tag === 'LoggedOut' &&
-  (model.route._tag === 'Stats' ||
-    model.route._tag === 'PublicStatsArchive')
+  (model.route._tag === 'Stats' || model.route._tag === 'PublicStatsArchive')
 
 export const khalaTokensServedModelMixPollDependenciesForModel = (
   model: Model,
@@ -988,9 +988,13 @@ const onboardingStream = (
                 }),
               )
             } else if (event.kind === 'delta') {
-              offer(ReceivedAutopilotOnboardingDelta({ turnId, text: event.text }))
+              offer(
+                ReceivedAutopilotOnboardingDelta({ turnId, text: event.text }),
+              )
             } else if (event.kind === 'done') {
-              offer(SucceededAutopilotOnboardingTurn({ response: event.response }))
+              offer(
+                SucceededAutopilotOnboardingTurn({ response: event.response }),
+              )
             } else {
               fail()
             }
@@ -1130,7 +1134,8 @@ const khalaChatStream = (
         const fail = (): void =>
           offer(
             FailedKhalaChatTurn({
-              reason: 'Khala could not respond just now. Try sending that again.',
+              reason:
+                'Khala could not respond just now. Try sending that again.',
             }),
           )
 


### PR DESCRIPTION
Addresses #6413.

### Changes
- Loads Khala tokens-served totals and history for the `/artanis` public agent route.
- Adds The Pulse UI on the Artanis public page with recent token-burn history, sparkline data, compact totals, and daily pace calculations.
- Updates logged-out route update/subscription handling and tests so Artanis receives the live counter/history data used by the panel.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).