### PR TITLE
fix(pylon): load supervisor tasks from linked ledger issues

### DIFF
--- a/apps/pylon/scripts/claude-supervisor/claude-supervisor.sh
+++ b/apps/pylon/scripts/claude-supervisor/claude-supervisor.sh
@@ -64,6 +64,9 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 
+# shellcheck source=../supervisor-task-pool.sh
+source "$SCRIPT_DIR/../supervisor-task-pool.sh"
+
 # --- Config (all overridable via env) ---
 export PYLON_OPENAGENTS_BASE_URL="${PYLON_OPENAGENTS_BASE_URL:-https://openagents.com}"
 # Default pylon home is the registered owner home (~/.pylon). A fresh/unknown
@@ -106,11 +109,9 @@ SUP_STALL_REFUSALS="${SUP_STALL_REFUSALS:-20}"
 SUP_SELFHEAL_COOLDOWN_SECS="${SUP_SELFHEAL_COOLDOWN_SECS:-300}"
 SUP_SELFHEAL_CHECK_SECS="${SUP_SELFHEAL_CHECK_SECS:-30}"
 
-# Rotated real backlog (public-safe issue numbers). Claude does real work against
-# the pinned origin/main commit in a bounded throwaway workspace.
-#   #6310 GLM tool-calling (also wins MirrorCode + GLM) | #6311 / #6320 follow-ups
-#   #6354 presence_stale | #6355 burndown | #6358 counter-health
-SUP_ISSUES="${SUP_ISSUES:-6310 6311 6320 6354 6355 6358}"
+# Fallback only. The active task pool is resolved dynamically from the
+# unsupported-request ledger and linked open GitHub issues.
+SUP_TASK_POOL_FALLBACK_ISSUES="${SUP_TASK_POOL_FALLBACK_ISSUES:-${SUP_ISSUES:-6310 6311 6320 6354 6355 6358}}"
 
 PYLON=(bun "$REPO_ROOT/apps/pylon/src/index.ts")
 mkdir -p "$SUP_STATE_DIR"
@@ -213,8 +214,6 @@ worker_loop() {
   local slot="$1"
   local backoff="$SUP_BACKOFF_MIN"
   local iter=0
-  # spread issue rotation per slot
-  local issues=($SUP_ISSUES)
   while true; do
     if [ -f "$PAUSE_FILE" ]; then sleep 30; continue; fi
     local desired; desired=$(cat "$DESIRED_FILE" 2>/dev/null || echo 0)
@@ -225,6 +224,17 @@ worker_loop() {
     [ "${#refs[@]}" -eq 0 ] && { sleep 20; continue; }
     local acc="${refs[$(( slot % ${#refs[@]} ))]}"
     local acc_args=(); [ "$acc" != "default" ] && acc_args=(--account-ref "$acc")
+
+    # Refresh the active pool from the unsupported-request ledger, with a short
+    # cache and a bounded fallback so transient route/GitHub failures do not idle
+    # the fleet.
+    local issues=(); while IFS= read -r i; do issues+=("$i"); done < <(supervisor_task_pool_issues)
+    if [ "${#issues[@]}" -eq 0 ]; then
+      log "slot=$slot TASK-POOL empty; backing off ${backoff}s"
+      sleep "$backoff"
+      backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
+      continue
+    fi
 
     local issue="${issues[$(( (slot + iter) % ${#issues[@]} ))]}"
     iter=$(( iter + 1 ))

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -58,6 +58,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 # open PR so the fleet never re-solves an already-PR'd issue and spawns dupes.
 # shellcheck source=lockout.sh
 source "$SCRIPT_DIR/lockout.sh"
+# shellcheck source=../supervisor-task-pool.sh
+source "$SCRIPT_DIR/../supervisor-task-pool.sh"
 
 # --- Config (all overridable via env) ---
 export PYLON_OPENAGENTS_BASE_URL="${PYLON_OPENAGENTS_BASE_URL:-https://openagents.com}"
@@ -99,11 +101,9 @@ SUP_STALL_REFUSALS="${SUP_STALL_REFUSALS:-20}"
 SUP_SELFHEAL_COOLDOWN_SECS="${SUP_SELFHEAL_COOLDOWN_SECS:-300}"
 SUP_SELFHEAL_CHECK_SECS="${SUP_SELFHEAL_CHECK_SECS:-30}"
 
-# Rotated real backlog (public-safe issue numbers). Codex does real work against
-# the pinned origin/main commit in a bounded throwaway workspace.
-#   #6310 GLM tool-calling (also wins MirrorCode + GLM) | #6311 / #6320 follow-ups
-#   #6354 presence_stale | #6355 burndown | #6358 counter-health
-SUP_ISSUES="${SUP_ISSUES:-6310 6311 6320 6354 6355 6358}"
+# Fallback only. The active task pool is resolved dynamically from the
+# unsupported-request ledger and linked open GitHub issues.
+SUP_TASK_POOL_FALLBACK_ISSUES="${SUP_TASK_POOL_FALLBACK_ISSUES:-${SUP_ISSUES:-6310 6311 6320 6354 6355 6358}}"
 
 PYLON=(bun "$REPO_ROOT/apps/pylon/src/index.ts")
 mkdir -p "$SUP_STATE_DIR"
@@ -206,8 +206,6 @@ worker_loop() {
   local slot="$1"
   local backoff="$SUP_BACKOFF_MIN"
   local iter=0
-  # spread issue rotation per slot
-  local issues=($SUP_ISSUES)
   while true; do
     if [ -f "$PAUSE_FILE" ]; then sleep 30; continue; fi
     local desired; desired=$(cat "$DESIRED_FILE" 2>/dev/null || echo 0)
@@ -218,6 +216,17 @@ worker_loop() {
     [ "${#refs[@]}" -eq 0 ] && { sleep 20; continue; }
     local acc="${refs[$(( slot % ${#refs[@]} ))]}"
     local acc_args=(); [ "$acc" != "default" ] && acc_args=(--account-ref "$acc")
+
+    # Refresh the active pool from the unsupported-request ledger, with a short
+    # cache and a bounded fallback so transient route/GitHub failures do not idle
+    # the fleet.
+    local issues=(); while IFS= read -r i; do issues+=("$i"); done < <(supervisor_task_pool_issues)
+    if [ "${#issues[@]}" -eq 0 ]; then
+      log "slot=$slot TASK-POOL empty; backing off ${backoff}s"
+      sleep "$backoff"
+      backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
+      continue
+    fi
 
     # Dispatch lockout: skip any issue that already has an open PR; only pick an
     # untouched one. If every backlog issue already has a PR, back off instead of

--- a/apps/pylon/scripts/supervisor-task-pool.sh
+++ b/apps/pylon/scripts/supervisor-task-pool.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# supervisor-task-pool.sh — dynamic public issue pool for owner-local supervisors.
+#
+# The Codex and Claude supervisors should burn down real user/agent pain first,
+# not a stale hard-coded issue list. This helper reads the unsupported-requests
+# ledger, extracts linked GitHub issues, filters to issues that are still open,
+# and prints a deduped issue-number list for worker rotation.
+#
+# This file performs no work at source time; it only defines functions.
+
+: "${PYLON_OPENAGENTS_BASE_URL:=https://openagents.com}"
+: "${SUP_REPO:=OpenAgentsInc/openagents}"
+: "${SUP_GH_BIN:=gh}"
+: "${SUP_TASK_POOL_LIMIT:=100}"
+: "${SUP_TASK_POOL_CACHE_TTL_SECS:=120}"
+
+if ! command -v sup_file_mtime >/dev/null 2>&1; then
+  sup_file_mtime() {
+    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+  }
+fi
+
+supervisor_task_pool_cache_file() {
+  local cache_dir="${SUP_TASK_POOL_CACHE_DIR:-${SUP_STATE_DIR:-$HOME/.pylon-supervisor}/task-pool-cache}"
+  mkdir -p "$cache_dir" 2>/dev/null || true
+  printf '%s/task-pool.issues' "$cache_dir"
+}
+
+supervisor_task_pool_auth_header() {
+  local token="${SUP_UNSUPPORTED_REQUESTS_TOKEN:-${OPENAGENTS_ADMIN_API_TOKEN:-${OPENAGENTS_AGENT_TOKEN:-}}}"
+  [ -n "$token" ] || return 1
+  printf 'Authorization: Bearer %s' "$token"
+}
+
+supervisor_issue_numbers_from_json() {
+  python3 -c "import json,re,sys
+try:
+    data=json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+rows=data.get('unsupportedRequests', []) if isinstance(data, dict) else []
+seen=set()
+for row in rows:
+    if not isinstance(row, dict):
+        continue
+    ref=str(row.get('githubIssueRef') or '')
+    if not ref:
+        continue
+    match=re.search(r'(?:^|[#/])([1-9][0-9]{0,8})(?:$|[^0-9])', ref)
+    if not match:
+        continue
+    issue=match.group(1)
+    if issue in seen:
+        continue
+    seen.add(issue)
+    print(issue)" 2>/dev/null
+}
+
+supervisor_issue_is_open() {
+  local issue="$1"
+  [ -n "$issue" ] || return 1
+  command -v "$SUP_GH_BIN" >/dev/null 2>&1 || return 0
+
+  local state
+  state=$("$SUP_GH_BIN" issue view "$issue" --repo "$SUP_REPO" --json state \
+    --jq .state 2>/dev/null | tr '[:upper:]' '[:lower:]')
+  [ -z "$state" ] && return 0
+  [ "$state" = "open" ]
+}
+
+supervisor_filter_open_issues() {
+  local issue
+  while IFS= read -r issue; do
+    [ -n "$issue" ] || continue
+    if supervisor_issue_is_open "$issue"; then
+      printf '%s\n' "$issue"
+    fi
+  done
+}
+
+supervisor_dedupe_issues() {
+  awk 'NF && !seen[$1]++ { print $1 }'
+}
+
+supervisor_fetch_unsupported_request_issues() {
+  local auth_header
+  auth_header="$(supervisor_task_pool_auth_header)" || return 1
+
+  local url base="${PYLON_OPENAGENTS_BASE_URL%/}"
+  for status in issue_opened open; do
+    url="$base/api/operator/khala/unsupported-requests?status=$status&limit=$SUP_TASK_POOL_LIMIT"
+    curl -fsS "$url" -H "$auth_header" 2>/dev/null | supervisor_issue_numbers_from_json
+  done | supervisor_dedupe_issues | supervisor_filter_open_issues | supervisor_dedupe_issues
+}
+
+supervisor_fallback_issues() {
+  local fallback="${SUP_TASK_POOL_FALLBACK_ISSUES:-6310 6311 6320 6354 6355 6358}"
+  printf '%s\n' $fallback | supervisor_dedupe_issues
+}
+
+supervisor_task_pool_issues() {
+  local cache
+  cache="$(supervisor_task_pool_cache_file)"
+  if [ -f "$cache" ]; then
+    local now age
+    now=$(date +%s)
+    age=$(( now - $(sup_file_mtime "$cache") ))
+    if [ "$age" -ge 0 ] && [ "$age" -lt "$SUP_TASK_POOL_CACHE_TTL_SECS" ] && [ -s "$cache" ]; then
+      cat "$cache"
+      return 0
+    fi
+  fi
+
+  local fetched
+  fetched="$(supervisor_fetch_unsupported_request_issues)"
+  if [ -n "$fetched" ]; then
+    printf '%s\n' "$fetched" > "$cache" 2>/dev/null || true
+    printf '%s\n' "$fetched"
+    return 0
+  fi
+
+  supervisor_fallback_issues | tee "$cache" 2>/dev/null
+}

--- a/apps/pylon/scripts/supervisor-task-pool.test.sh
+++ b/apps/pylon/scripts/supervisor-task-pool.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# supervisor-task-pool.test.sh — focused tests for dynamic supervisor issue pool.
+#
+# Stubs curl and gh (no network) and asserts that:
+#   * linked unsupported-request rows become issue numbers,
+#   * duplicate refs are deduped in ledger order,
+#   * closed GitHub issues are filtered out,
+#   * route/auth failures fall back to the bounded fallback issue list.
+#
+# Run: bash apps/pylon/scripts/supervisor-task-pool.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+cat > "$WORK/curl" <<'STUB'
+#!/usr/bin/env bash
+if [ "${SUP_TEST_CURL_FAIL:-0}" = "1" ]; then exit 22; fi
+url=""
+for arg in "$@"; do
+  case "$arg" in
+    http*) url="$arg" ;;
+  esac
+done
+case "$url" in
+  *status=issue_opened*)
+    cat "$SUP_TEST_FIXTURES/issue_opened.json"
+    ;;
+  *status=open*)
+    cat "$SUP_TEST_FIXTURES/open.json"
+    ;;
+  *)
+    echo '{"unsupportedRequests":[]}'
+    ;;
+esac
+STUB
+chmod +x "$WORK/curl"
+
+cat > "$WORK/gh" <<'STUB'
+#!/usr/bin/env bash
+issue="$3"
+case "$issue" in
+  7001|7002|7004) echo "OPEN" ;;
+  7003) echo "CLOSED" ;;
+  *) echo "OPEN" ;;
+esac
+STUB
+chmod +x "$WORK/gh"
+
+FIXTURES="$WORK/fixtures"
+mkdir -p "$FIXTURES"
+cat > "$FIXTURES/issue_opened.json" <<'JSON'
+{
+  "unsupportedRequests": [
+    { "githubIssueRef": "OpenAgentsInc/openagents#7001" },
+    { "githubIssueRef": "https://github.com/OpenAgentsInc/openagents/issues/7002" },
+    { "githubIssueRef": "#7001" },
+    { "githubIssueRef": "OpenAgentsInc/openagents#7003" }
+  ]
+}
+JSON
+cat > "$FIXTURES/open.json" <<'JSON'
+{
+  "unsupportedRequests": [
+    { "githubIssueRef": "OpenAgentsInc/openagents#7004" }
+  ]
+}
+JSON
+
+export PATH="$WORK:$PATH"
+export SUP_TEST_FIXTURES="$FIXTURES"
+export OPENAGENTS_AGENT_TOKEN="test-token"
+export SUP_GH_BIN="$WORK/gh"
+export SUP_REPO="OpenAgentsInc/openagents"
+export SUP_STATE_DIR="$WORK/state"
+export SUP_TASK_POOL_CACHE_DIR="$WORK/cache"
+export SUP_TASK_POOL_CACHE_TTL_SECS=0
+export SUP_TASK_POOL_FALLBACK_ISSUES="8001 8002 8001"
+
+# shellcheck source=supervisor-task-pool.sh
+source "$SCRIPT_DIR/supervisor-task-pool.sh"
+
+got="$(supervisor_task_pool_issues | paste -sd ' ' -)"
+if [ "$got" = "7001 7002 7004" ]; then
+  ok "dynamic pool extracts linked open issues, dedupes, and filters closed issues"
+else
+  bad "dynamic pool returned '$got' (want '7001 7002 7004')"
+fi
+
+export SUP_TEST_CURL_FAIL=1
+got="$(supervisor_task_pool_issues | paste -sd ' ' -)"
+if [ "$got" = "8001 8002" ]; then
+  ok "route failure falls back to bounded fallback issues"
+else
+  bad "fallback returned '$got' (want '8001 8002')"
+fi
+
+unset OPENAGENTS_AGENT_TOKEN
+unset OPENAGENTS_ADMIN_API_TOKEN
+unset SUP_UNSUPPORTED_REQUESTS_TOKEN
+export SUP_TEST_CURL_FAIL=0
+got="$(supervisor_task_pool_issues | paste -sd ' ' -)"
+if [ "$got" = "8001 8002" ]; then
+  ok "missing auth token falls back to bounded fallback issues"
+else
+  bad "missing-auth fallback returned '$got' (want '8001 8002')"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Addresses #6395.

### Changes
- Sources the shared supervisor task-pool helper in both Claude and Codex supervisors.
- Replaces the fixed supervisor issue rotation with a dynamically refreshed task pool from the unsupported-request ledger and linked open GitHub issues.
- Keeps the previous issue list as a bounded fallback via `SUP_TASK_POOL_FALLBACK_ISSUES`.
- Adds empty-pool backoff handling so workers do not dispatch without an available task.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).