### PR TITLE
feat(khala-cli): gate Artanis orchestration commands

### DIFF
--- a/apps/pylon/src/agent-status-reporter.ts
+++ b/apps/pylon/src/agent-status-reporter.ts
@@ -1,0 +1,144 @@
+export const PYLON_AGENT_STATUS_SCHEMA_VERSION =
+  "openagents.pylon.agent_status.v1"
+
+export type AgentStatusRunnerKind = "codex_sdk" | "claude_agent" | "local_command"
+
+export type AgentStatusUsage = {
+  inputTokens?: number
+  cachedInputTokens?: number
+  outputTokens?: number
+  reasoningOutputTokens?: number
+}
+
+export type AgentStatusItem = {
+  ordinal: number
+  itemType:
+    | "agent_message"
+    | "command_execution"
+    | "error"
+    | "file_change"
+    | "mcp_tool_call"
+    | "reasoning"
+    | "unknown"
+    | "web_search"
+  status?: string
+  message?: string
+  reasoningSummary?: string
+  commandLabel?: string
+  exitCode?: number
+  outputBytes?: number
+  changeCount?: number
+  toolName?: string
+}
+
+export type AgentStatusReport = {
+  assignmentRef: string
+  leaseRef: string
+  pylonRef: string
+  runnerKind: AgentStatusRunnerKind
+  runRef?: string
+  sessionRef?: string
+  workspaceRef?: string
+  turnIndex: number
+  observedAt?: string
+  usage?: AgentStatusUsage
+  items: ReadonlyArray<AgentStatusItem>
+  rawEvents?: ReadonlyArray<Record<string, unknown>>
+}
+
+export type AgentStatusReporter = (report: AgentStatusReport) => Promise<void>
+
+export const normalizeAgentStatusBaseUrl = (
+  value: string | undefined,
+): string | undefined => {
+  const trimmed = value?.trim()
+  if (trimmed === undefined || trimmed === "") return undefined
+  return trimmed.replace(/\/$/, "")
+}
+
+export const nonNegativeInteger = (value: number | undefined): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0
+  return Math.max(0, Math.trunc(value))
+}
+
+export const positiveInteger = (value: number): number =>
+  Math.max(1, nonNegativeInteger(value))
+
+export const boundedString = (
+  value: string | undefined,
+  max: number,
+): string | undefined => {
+  const trimmed = value?.trim()
+  if (trimmed === undefined || trimmed === "") return undefined
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed
+}
+
+export const encodeAgentStatusItems = (
+  items: ReadonlyArray<AgentStatusItem>,
+): ReadonlyArray<Record<string, unknown>> =>
+  items.map(item => ({
+    ordinal: positiveInteger(item.ordinal),
+    itemType: item.itemType,
+    ...(boundedString(item.status, 80) === undefined
+      ? {}
+      : { status: boundedString(item.status, 80) }),
+    ...(boundedString(item.message, 64 * 1024) === undefined
+      ? {}
+      : { message: boundedString(item.message, 64 * 1024) }),
+    ...(boundedString(item.reasoningSummary, 64 * 1024) === undefined
+      ? {}
+      : { reasoningSummary: boundedString(item.reasoningSummary, 64 * 1024) }),
+    ...(boundedString(item.commandLabel, 120) === undefined
+      ? {}
+      : { commandLabel: boundedString(item.commandLabel, 120) }),
+    ...(typeof item.exitCode === "number" ? { exitCode: item.exitCode } : {}),
+    ...(typeof item.outputBytes === "number"
+      ? { outputBytes: nonNegativeInteger(item.outputBytes) }
+      : {}),
+    ...(typeof item.changeCount === "number"
+      ? { changeCount: nonNegativeInteger(item.changeCount) }
+      : {}),
+    ...(boundedString(item.toolName, 120) === undefined
+      ? {}
+      : { toolName: boundedString(item.toolName, 120) }),
+  }))
+
+export const encodeAgentStatusUsage = (
+  usage: AgentStatusUsage | undefined,
+): Record<string, number> | undefined => {
+  if (usage === undefined) return undefined
+  return {
+    ...(usage.cachedInputTokens === undefined
+      ? {}
+      : { cachedInputTokens: nonNegativeInteger(usage.cachedInputTokens) }),
+    ...(usage.inputTokens === undefined
+      ? {}
+      : { inputTokens: nonNegativeInteger(usage.inputTokens) }),
+    ...(usage.outputTokens === undefined
+      ? {}
+      : { outputTokens: nonNegativeInteger(usage.outputTokens) }),
+    ...(usage.reasoningOutputTokens === undefined
+      ? {}
+      : { reasoningOutputTokens: nonNegativeInteger(usage.reasoningOutputTokens) }),
+  }
+}
+
+export const encodeAgentStatusReport = (
+  report: AgentStatusReport,
+): Record<string, unknown> => ({
+  schemaVersion: PYLON_AGENT_STATUS_SCHEMA_VERSION,
+  assignmentRef: report.assignmentRef,
+  leaseRef: report.leaseRef,
+  pylonRef: report.pylonRef,
+  runnerKind: report.runnerKind,
+  ...(report.runRef === undefined ? {} : { runRef: report.runRef }),
+  ...(report.sessionRef === undefined ? {} : { sessionRef: report.sessionRef }),
+  ...(report.workspaceRef === undefined ? {} : { workspaceRef: report.workspaceRef }),
+  turnIndex: positiveInteger(report.turnIndex),
+  ...(report.observedAt === undefined ? {} : { observedAt: report.observedAt }),
+  ...(encodeAgentStatusUsage(report.usage) === undefined
+    ? {}
+    : { usage: encodeAgentStatusUsage(report.usage) }),
+  items: encodeAgentStatusItems(report.items),
+  ...(report.rawEvents === undefined ? {} : { rawEvents: report.rawEvents }),
+})

--- a/apps/pylon/src/codex-turn-reporter.ts
+++ b/apps/pylon/src/codex-turn-reporter.ts
@@ -1,3 +1,12 @@
+import {
+  encodeAgentStatusItems,
+  encodeAgentStatusReport,
+  nonNegativeInteger,
+  normalizeAgentStatusBaseUrl,
+  positiveInteger,
+  type AgentStatusItem,
+} from "./agent-status-reporter.js"
+
 export const PYLON_CODEX_TURN_INGEST_PATH = "/api/pylon/codex/turns"
 export const PYLON_CODEX_EVENT_CHUNK_INGEST_PATH = "/api/pylon/codex/event-chunks"
 export const PYLON_CODEX_TURN_SCHEMA_VERSION = "openagents.pylon.codex_turn.v1"
@@ -10,26 +19,7 @@ export type CodexTurnUsage = {
   reasoningOutputTokens?: number
 }
 
-export type CodexTurnReportItem = {
-  ordinal: number
-  itemType:
-    | "agent_message"
-    | "command_execution"
-    | "error"
-    | "file_change"
-    | "mcp_tool_call"
-    | "reasoning"
-    | "unknown"
-    | "web_search"
-  status?: string
-  message?: string
-  reasoningSummary?: string
-  commandLabel?: string
-  exitCode?: number
-  outputBytes?: number
-  changeCount?: number
-  toolName?: string
-}
+export type CodexTurnReportItem = AgentStatusItem
 
 export type CodexTurnReport = {
   assignmentRef: string
@@ -63,31 +53,12 @@ export type CodexEventChunkReport = {
 
 export type CodexEventChunkReporter = (report: CodexEventChunkReport) => Promise<void>
 
-const normalizeBaseUrl = (value: string | undefined): string | undefined => {
-  const trimmed = value?.trim()
-  if (trimmed === undefined || trimmed === "") return undefined
-  return trimmed.replace(/\/$/, "")
-}
-
-const nonNegativeInteger = (value: number): number => {
-  if (!Number.isFinite(value)) return 0
-  return Math.max(0, Math.trunc(value))
-}
-
-const positiveInteger = (value: number): number => Math.max(1, nonNegativeInteger(value))
-
-const boundedString = (value: string | undefined, max: number): string | undefined => {
-  const trimmed = value?.trim()
-  if (trimmed === undefined || trimmed === "") return undefined
-  return trimmed.length > max ? trimmed.slice(0, max) : trimmed
-}
-
 export function createPylonCodexTurnReporter(input: {
   agentToken?: string
   baseUrl?: string
   fetch?: typeof fetch
 }): CodexTurnReporter | undefined {
-  const baseUrl = normalizeBaseUrl(input.baseUrl)
+  const baseUrl = normalizeAgentStatusBaseUrl(input.baseUrl)
   const agentToken = input.agentToken?.trim()
   if (baseUrl === undefined || agentToken === undefined || agentToken === "") {
     return undefined
@@ -97,15 +68,12 @@ export function createPylonCodexTurnReporter(input: {
   return async report => {
     const turnIndex = positiveInteger(report.turnIndex)
     const body = {
+      ...encodeAgentStatusReport({
+        ...report,
+        runnerKind: "codex_sdk",
+        turnIndex,
+      }),
       schemaVersion: PYLON_CODEX_TURN_SCHEMA_VERSION,
-      assignmentRef: report.assignmentRef,
-      leaseRef: report.leaseRef,
-      pylonRef: report.pylonRef,
-      ...(report.runRef === undefined ? {} : { runRef: report.runRef }),
-      ...(report.sessionRef === undefined ? {} : { sessionRef: report.sessionRef }),
-      ...(report.workspaceRef === undefined ? {} : { workspaceRef: report.workspaceRef }),
-      turnIndex,
-      ...(report.observedAt === undefined ? {} : { observedAt: report.observedAt }),
       usage: {
         inputTokens: nonNegativeInteger(report.usage.inputTokens),
         ...(report.usage.cachedInputTokens === undefined
@@ -116,25 +84,6 @@ export function createPylonCodexTurnReporter(input: {
           ? {}
           : { reasoningOutputTokens: nonNegativeInteger(report.usage.reasoningOutputTokens) }),
       },
-      items: report.items.map(item => ({
-        ordinal: positiveInteger(item.ordinal),
-        itemType: item.itemType,
-        ...(boundedString(item.status, 80) === undefined ? {} : { status: boundedString(item.status, 80) }),
-        ...(boundedString(item.message, 64 * 1024) === undefined
-          ? {}
-          : { message: boundedString(item.message, 64 * 1024) }),
-        ...(boundedString(item.reasoningSummary, 64 * 1024) === undefined
-          ? {}
-          : { reasoningSummary: boundedString(item.reasoningSummary, 64 * 1024) }),
-        ...(boundedString(item.commandLabel, 120) === undefined
-          ? {}
-          : { commandLabel: boundedString(item.commandLabel, 120) }),
-        ...(typeof item.exitCode === "number" ? { exitCode: item.exitCode } : {}),
-        ...(typeof item.outputBytes === "number" ? { outputBytes: nonNegativeInteger(item.outputBytes) } : {}),
-        ...(typeof item.changeCount === "number" ? { changeCount: nonNegativeInteger(item.changeCount) } : {}),
-        ...(boundedString(item.toolName, 120) === undefined ? {} : { toolName: boundedString(item.toolName, 120) }),
-      })),
-      ...(report.rawEvents === undefined ? {} : { rawEvents: report.rawEvents }),
     }
     const response = await fetchImpl(new URL(PYLON_CODEX_TURN_INGEST_PATH, baseUrl), {
       method: "POST",
@@ -163,7 +112,7 @@ export function createPylonCodexEventChunkReporter(input: {
   baseUrl?: string
   fetch?: typeof fetch
 }): CodexEventChunkReporter | undefined {
-  const baseUrl = normalizeBaseUrl(input.baseUrl)
+  const baseUrl = normalizeAgentStatusBaseUrl(input.baseUrl)
   const agentToken = input.agentToken?.trim()
   if (baseUrl === undefined || agentToken === undefined || agentToken === "") {
     return undefined
@@ -189,28 +138,7 @@ export function createPylonCodexEventChunkReporter(input: {
       ...(report.items === undefined
         ? {}
         : {
-            items: report.items.map(item => ({
-              ordinal: positiveInteger(item.ordinal),
-              itemType: item.itemType,
-              ...(boundedString(item.status, 80) === undefined
-                ? {}
-                : { status: boundedString(item.status, 80) }),
-              ...(boundedString(item.message, 64 * 1024) === undefined
-                ? {}
-                : { message: boundedString(item.message, 64 * 1024) }),
-              ...(boundedString(item.reasoningSummary, 64 * 1024) === undefined
-                ? {}
-                : { reasoningSummary: boundedString(item.reasoningSummary, 64 * 1024) }),
-              ...(boundedString(item.commandLabel, 120) === undefined
-                ? {}
-                : { commandLabel: boundedString(item.commandLabel, 120) }),
-              ...(typeof item.exitCode === "number" ? { exitCode: item.exitCode } : {}),
-              ...(typeof item.outputBytes === "number" ? { outputBytes: nonNegativeInteger(item.outputBytes) } : {}),
-              ...(typeof item.changeCount === "number" ? { changeCount: nonNegativeInteger(item.changeCount) } : {}),
-              ...(boundedString(item.toolName, 120) === undefined
-                ? {}
-                : { toolName: boundedString(item.toolName, 120) }),
-            })),
+            items: encodeAgentStatusItems(report.items),
           }),
     }
     const response = await fetchImpl(new URL(PYLON_CODEX_EVENT_CHUNK_INGEST_PATH, baseUrl), {

--- a/apps/pylon/tests/codex-turn-reporter.test.ts
+++ b/apps/pylon/tests/codex-turn-reporter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  PYLON_AGENT_STATUS_SCHEMA_VERSION,
+  encodeAgentStatusReport,
+} from "../src/agent-status-reporter"
+import {
   PYLON_CODEX_EVENT_CHUNK_INGEST_PATH,
   PYLON_CODEX_EVENT_CHUNK_SCHEMA_VERSION,
   PYLON_CODEX_TURN_INGEST_PATH,
@@ -10,6 +14,43 @@ import {
 } from "../src/codex-turn-reporter"
 
 describe("Pylon Codex turn reporter", () => {
+  test("encodes a runner-neutral agent status envelope for non-Codex reporters", () => {
+    const body = encodeAgentStatusReport({
+      assignmentRef: "assignment.public.agent-status",
+      leaseRef: "lease.public.agent-status",
+      pylonRef: "pylon.public.agent-status",
+      runnerKind: "claude_agent",
+      turnIndex: 0,
+      usage: {
+        inputTokens: 2.9,
+        outputTokens: -1,
+      },
+      items: [
+        {
+          commandLabel: "very-long-label".repeat(20),
+          itemType: "command_execution",
+          ordinal: 0,
+          outputBytes: 12.8,
+          status: "completed",
+        },
+      ],
+    })
+
+    expect(body).toMatchObject({
+      assignmentRef: "assignment.public.agent-status",
+      leaseRef: "lease.public.agent-status",
+      pylonRef: "pylon.public.agent-status",
+      runnerKind: "claude_agent",
+      schemaVersion: PYLON_AGENT_STATUS_SCHEMA_VERSION,
+      turnIndex: 1,
+    })
+    expect(body.usage).toEqual({ inputTokens: 2, outputTokens: 0 })
+    expect(body.items).toMatchObject([
+      { itemType: "command_execution", ordinal: 1, outputBytes: 12 },
+    ])
+    expect(JSON.stringify(body)).not.toContain("/Users/")
+  })
+
   test("posts the exact turn envelope with bearer auth and stable idempotency", async () => {
     const calls: Array<{ init?: RequestInit; url: string }> = []
     const fetchImpl = async (

--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -22,6 +22,143 @@ describe("Khala CLI spawn capability answer", () => {
 })
 
 describe("Khala CLI info diagnostics", () => {
+  test("routes Artanis approval-gate status through the owner console endpoint", async () => {
+    const authHeaders: Array<string | null> = []
+    const server = Bun.serve({
+      port: 0,
+      fetch: request => {
+        authHeaders.push(request.headers.get("authorization"))
+        expect(new URL(request.url).pathname).toBe("/api/operator/artanis/console")
+        return Response.json({
+          ledgerRef: "ledger.public.artanis.approval_gates",
+          gateCount: 1,
+        })
+      },
+    })
+
+    const originalWrite = process.stdout.write
+    let stdout = ""
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += String(chunk)
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const exitCode = await runKhalaCli([
+        "--json",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "artanis",
+        "status",
+      ], {
+        OPENAGENTS_AGENT_TOKEN: "oa_agent_artanis_status_test",
+      })
+      expect(exitCode).toBe(0)
+    } finally {
+      process.stdout.write = originalWrite
+      server.stop(true)
+    }
+
+    expect(authHeaders).toEqual(["Bearer oa_agent_artanis_status_test"])
+    expect(JSON.parse(stdout).gateCount).toBe(1)
+  })
+
+  test("arms Artanis pylon dispatch through the approval-gate create endpoint", async () => {
+    const requests: Array<{ body: unknown; path: string }> = []
+    const server = Bun.serve({
+      port: 0,
+      fetch: async request => {
+        requests.push({
+          body: await request.json(),
+          path: new URL(request.url).pathname,
+        })
+        expect(request.headers.get("authorization")).toBe("Bearer oa_agent_artanis_arm_test")
+        return Response.json({
+          ok: true,
+          armedGate: {
+            expiresAtDisplay: "soon",
+            gateRef: "gate.public.artanis.arm_pylon_dispatch.test",
+            kind: "pylon_job_dispatch",
+            state: "approved",
+          },
+        })
+      },
+    })
+
+    const originalWrite = process.stdout.write
+    let stdout = ""
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += String(chunk)
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const exitCode = await runKhalaCli([
+        "--json",
+        "--expires-hours",
+        "12",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "artanis",
+        "arm-pylon-dispatch",
+      ], {
+        OPENAGENTS_AGENT_TOKEN: "oa_agent_artanis_arm_test",
+      })
+      expect(exitCode).toBe(0)
+    } finally {
+      process.stdout.write = originalWrite
+      server.stop(true)
+    }
+
+    expect(requests).toEqual([{
+      body: { expiresInHours: 12 },
+      path: "/api/operator/artanis/approval-gates",
+    }])
+    expect(JSON.parse(stdout).armedGate.gateRef).toBe("gate.public.artanis.arm_pylon_dispatch.test")
+  })
+
+  test("approves a pending Artanis gate through the gated decision endpoint", async () => {
+    const paths: Array<string> = []
+    const server = Bun.serve({
+      port: 0,
+      fetch: request => {
+        paths.push(new URL(request.url).pathname)
+        expect(request.method).toBe("POST")
+        expect(request.headers.get("authorization")).toBe("Bearer oa_agent_artanis_approve_test")
+        return Response.json({
+          ledgerRef: "ledger.public.artanis.approval_gates",
+          gateCount: 2,
+        })
+      },
+    })
+
+    const originalWrite = process.stdout.write
+    let stdout = ""
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += String(chunk)
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const exitCode = await runKhalaCli([
+        "--json",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "artanis",
+        "approve",
+        "gate.public.artanis.pending_test",
+      ], {
+        OPENAGENTS_AGENT_TOKEN: "oa_agent_artanis_approve_test",
+      })
+      expect(exitCode).toBe(0)
+    } finally {
+      process.stdout.write = originalWrite
+      server.stop(true)
+    }
+
+    expect(paths).toEqual([
+      "/api/operator/artanis/approval-gates/gate.public.artanis.pending_test/approve",
+    ])
+    expect(JSON.parse(stdout).gateCount).toBe(2)
+  })
+
   test("does not print raw agent tokens or token-bearing trace URLs", async () => {
     const dir = mkdtempSync(join(tmpdir(), "khala-info-test-"))
     const tokenPath = join(dir, "agent-token")

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -1,7 +1,18 @@
 import { Effect } from "effect"
 import { appendAssistantTurn, prepareUserTurn } from "./bounds.js"
 import { KHALA_CLI_VERSION, formatKhalaChangelog } from "./changelog.js"
-import { fetchModels, fetchTokensServed, mintFreeKey, runArtanisTurn, runChatTurn, submitFeedback, toKhalaCliError } from "./client.js"
+import {
+  armArtanisPylonDispatch,
+  decideArtanisApprovalGate,
+  fetchArtanisConsole,
+  fetchModels,
+  fetchTokensServed,
+  mintFreeKey,
+  runArtanisTurn,
+  runChatTurn,
+  submitFeedback,
+  toKhalaCliError,
+} from "./client.js"
 import {
   connectKhalaCodex,
   resolveKhalaCodexStatus,
@@ -67,6 +78,11 @@ type Channel = "khala" | "artanis"
 
 type ParsedCommand =
   | { readonly kind: "chat" }
+  | {
+      readonly kind: "artanisApprovalGate"
+      readonly action: "approve" | "reject" | "arm-pylon-dispatch" | "status"
+      readonly gateRef?: string | undefined
+    }
   | { readonly kind: "codex"; readonly text: string | undefined }
   | { readonly kind: "codexAuth" }
   | { readonly kind: "codexStatus" }
@@ -107,6 +123,7 @@ interface ParsedArgs {
   readonly json: boolean
   readonly models: boolean
   readonly mintFreeKey: boolean
+  readonly artanisExpiresInHours: number | undefined
   readonly fleetDryRun: boolean
   readonly fleetIssues: readonly number[] | undefined
   readonly fleetOnce: boolean
@@ -160,6 +177,11 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
     }
     if (args.command.kind === "help") {
       process.stdout.write(usage())
+      return 0
+    }
+    if (args.command.kind === "artanisApprovalGate") {
+      const result = await runArtanisApprovalGateCommand(args, env, args.command)
+      process.stdout.write(args.json ? `${JSON.stringify(result, null, 2)}\n` : `${formatArtanisApprovalGateResult(result)}\n`)
       return 0
     }
     if (args.command.kind === "codexAuth") {
@@ -377,6 +399,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
   let json = false
   let models = false
   let mintFreeKey = false
+  let artanisExpiresInHours: number | undefined
   let fleetDryRun = false
   let fleetIssues: readonly number[] | undefined
   let fleetOnce = false
@@ -411,6 +434,12 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     else if (arg === "--json" || arg === "--no-stream") json = true
     else if (arg === "--models") models = true
     else if (arg === "--mint-free-key") mintFreeKey = true
+    else if (arg === "--expires-hours") {
+      artanisExpiresInHours = parsePositiveInteger(requireValue(argv, index, arg), arg)
+      index += 1
+    } else if (arg.startsWith("--expires-hours=")) {
+      artanisExpiresInHours = parsePositiveInteger(arg.slice("--expires-hours=".length), "--expires-hours")
+    }
     else if (arg === "--dry-run") fleetDryRun = true
     else if (arg === "--once") fleetOnce = true
     else if (arg === "--issues") {
@@ -524,6 +553,21 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     }
   } else if (maybeCommand === "changelog") {
     command = { kind: "changelog" }
+  } else if (maybeCommand === "artanis") {
+    const sub = positional[1]?.trim().toLowerCase()
+    if (sub === "status" || sub === "approval-gates" || sub === "gates") {
+      command = { kind: "artanisApprovalGate", action: "status" }
+    } else if (sub === "arm-pylon-dispatch") {
+      command = { kind: "artanisApprovalGate", action: "arm-pylon-dispatch" }
+    } else if (sub === "approve" || sub === "reject") {
+      command = {
+        kind: "artanisApprovalGate",
+        action: sub,
+        gateRef: positional[2],
+      }
+    } else {
+      throw new Error("Unknown Artanis command. Use `khala artanis status`, `khala artanis arm-pylon-dispatch`, `khala artanis approve <gateRef>`, or `khala artanis reject <gateRef>`.")
+    }
   } else if (maybeCommand === "auth" && positional[1] === "codex") {
     command = { kind: "codexAuth" }
   } else if (maybeCommand === "fleet") {
@@ -601,6 +645,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     json,
     models,
     mintFreeKey,
+    artanisExpiresInHours,
     fleetDryRun,
     fleetIssues,
     fleetOnce,
@@ -1780,6 +1825,74 @@ function formatFleetRunResult(result: KhalaFleetRunResult): string {
     lines.push("", "Supervisor mode keeps refilling slots until stopped.")
   }
   return terminalStyle.meta(lines.join("\n"))
+}
+
+async function runArtanisApprovalGateCommand(
+  args: ParsedArgs,
+  env: Record<string, string | undefined>,
+  command: Extract<ParsedCommand, { readonly kind: "artanisApprovalGate" }>,
+): Promise<unknown> {
+  const token = await ensureStoredAgentToken({
+    baseUrl: args.baseUrl,
+    env,
+    explicitToken: args.token,
+  })
+  if (command.action === "status") {
+    return await Effect.runPromise(fetchArtanisConsole({
+      baseUrl: args.baseUrl,
+      token,
+    }))
+  }
+  if (command.action === "arm-pylon-dispatch") {
+    return await Effect.runPromise(armArtanisPylonDispatch({
+      baseUrl: args.baseUrl,
+      token,
+      expiresInHours: args.artanisExpiresInHours,
+    }))
+  }
+  const gateRef = command.gateRef?.trim()
+  if (gateRef === undefined || gateRef.length === 0) {
+    throw new Error(`khala artanis ${command.action} requires a gate ref`)
+  }
+  return await Effect.runPromise(decideArtanisApprovalGate({
+    action: command.action,
+    baseUrl: args.baseUrl,
+    gateRef,
+    token,
+  }))
+}
+
+function formatArtanisApprovalGateResult(result: unknown): string {
+  if (result !== null && typeof result === "object") {
+    const record = result as {
+      readonly armedGate?: {
+        readonly expiresAtDisplay?: unknown
+        readonly gateRef?: unknown
+        readonly kind?: unknown
+        readonly state?: unknown
+      }
+      readonly gateCount?: unknown
+      readonly ledgerRef?: unknown
+    }
+    if (record.armedGate !== undefined) {
+      const gate = record.armedGate
+      return terminalStyle.meta([
+        `${terminalStyle.assistant("Artanis:")} pylon dispatch gate armed`,
+        `  gate: ${String(gate.gateRef ?? "(unknown)")}`,
+        `  kind: ${String(gate.kind ?? "pylon_job_dispatch")}`,
+        `  state: ${String(gate.state ?? "approved")}`,
+        `  expires: ${String(gate.expiresAtDisplay ?? "(unknown)")}`,
+      ].join("\n"))
+    }
+    if (typeof record.ledgerRef === "string" || typeof record.gateCount === "number") {
+      return terminalStyle.meta([
+        `${terminalStyle.assistant("Artanis:")} approval gates`,
+        `  ledger: ${String(record.ledgerRef ?? "(unknown)")}`,
+        `  gates: ${String(record.gateCount ?? "(unknown)")}`,
+      ].join("\n"))
+    }
+  }
+  return terminalStyle.meta(JSON.stringify(result, null, 2))
 }
 
 function formatCodexCredentialSource(source: Extract<KhalaCodexStatus, { readonly ready: true }>["credentialSource"]): string {

--- a/clients/khala-cli/src/client.ts
+++ b/clients/khala-cli/src/client.ts
@@ -3,6 +3,8 @@ import { validatePublicConversation } from "./bounds.js"
 import { decodeOpenAiFrame, decodePublicFrame, readSseFrames, type StreamFrameMetadata } from "./sse.js"
 import {
   ARTANIS_CHAT_PATH,
+  ARTANIS_APPROVAL_GATES_PATH,
+  ARTANIS_CONSOLE_PATH,
   ArtanisChatRequest,
   ArtanisChatResponse,
   BYOK_ACK_HEADER,
@@ -18,6 +20,9 @@ import {
   OpenAiModelsResponse,
   type ArtanisTurnOptions,
   type ArtanisTurnResult,
+  type ArtanisApprovalGateArmOptions,
+  type ArtanisApprovalGateCommandOptions,
+  type ArtanisApprovalGateDecisionOptions,
   type ChatClientOptions,
   type ChatTurnOptions,
   type ChatTurnResult,
@@ -26,6 +31,7 @@ import {
   type KhalaFeedbackSubmitOptions,
   type KhalaStreamUsage,
 } from "./types.js"
+import { artanisApprovalGateDecisionPath } from "./types.js"
 
 const MAX_REQUEST_RETRIES = 5
 const RETRY_DELAYS_MS = [400, 1_000, 2_000, 4_000, 8_000] as const
@@ -116,6 +122,90 @@ export function runArtanisTurn(options: ArtanisTurnOptions): Effect.Effect<Artan
       traceRef: decoded.traceRef ?? readTraceRef(response),
     }
   })
+}
+
+export function fetchArtanisConsole(
+  options: ArtanisApprovalGateCommandOptions,
+): Effect.Effect<unknown, KhalaCliError> {
+  return Effect.gen(function* () {
+    const token = yield* requireOwnerToken(options.token)
+    const response = yield* request({
+      fetch: options.fetch,
+      url: urlFor(options.baseUrl, ARTANIS_CONSOLE_PATH),
+      init: {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${token}`,
+        },
+      },
+    })
+    return yield* readJsonResponse(response, "Artanis console response")
+  })
+}
+
+export function armArtanisPylonDispatch(
+  options: ArtanisApprovalGateArmOptions,
+): Effect.Effect<unknown, KhalaCliError> {
+  return Effect.gen(function* () {
+    const token = yield* requireOwnerToken(options.token)
+    const response = yield* request({
+      fetch: options.fetch,
+      url: urlFor(options.baseUrl, ARTANIS_APPROVAL_GATES_PATH),
+      init: {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          ...(options.expiresInHours === undefined
+            ? {}
+            : { expiresInHours: options.expiresInHours }),
+        }),
+      },
+    })
+    return yield* readJsonResponse(response, "Artanis approval-gate arm response")
+  })
+}
+
+export function decideArtanisApprovalGate(
+  options: ArtanisApprovalGateDecisionOptions,
+): Effect.Effect<unknown, KhalaCliError> {
+  return Effect.gen(function* () {
+    const token = yield* requireOwnerToken(options.token)
+    const gateRef = options.gateRef.trim()
+    if (gateRef.length === 0) {
+      return yield* new KhalaCliError({
+        reason: "Artanis approval-gate decision requires a gate ref.",
+        code: "missing_gate_ref",
+      })
+    }
+    const response = yield* request({
+      fetch: options.fetch,
+      url: urlFor(options.baseUrl, artanisApprovalGateDecisionPath(gateRef, options.action)),
+      init: {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${token}`,
+        },
+      },
+    })
+    return yield* readJsonResponse(response, "Artanis approval-gate decision response")
+  })
+}
+
+function requireOwnerToken(token: string | undefined): Effect.Effect<string, KhalaCliError> {
+  const trimmed = token?.trim()
+  if (trimmed === undefined || trimmed.length === 0) {
+    return new KhalaCliError({
+      reason: "Artanis orchestration commands require the owner agent token. Run `khala login` to sign in (or pass --token / set OPENAGENTS_AGENT_TOKEN).",
+      code: "missing_token",
+    })
+  }
+  return Effect.succeed(trimmed)
 }
 
 export function fetchModels(options: Pick<ChatClientOptions, "baseUrl" | "fetch">): Effect.Effect<unknown, KhalaCliError> {

--- a/clients/khala-cli/src/types.ts
+++ b/clients/khala-cli/src/types.ts
@@ -124,6 +124,14 @@ export type KhalaTokensResponse = typeof KhalaTokensResponse.Type
 //   body  { messages: [{ role, content }] }
 //   ->    { reply }   (owner-only operator persona, NOT public Khala roleplay)
 export const ARTANIS_CHAT_PATH = "/api/operator/artanis/chat"
+export const ARTANIS_CONSOLE_PATH = "/api/operator/artanis/console"
+export const ARTANIS_APPROVAL_GATES_PATH =
+  "/api/operator/artanis/approval-gates"
+export const artanisApprovalGateDecisionPath = (
+  gateRef: string,
+  action: "approve" | "reject",
+): string =>
+  `${ARTANIS_APPROVAL_GATES_PATH}/${encodeURIComponent(gateRef)}/${action}`
 
 export const ArtanisChatRequest = S.Struct({
   messages: S.Array(KhalaChatMessage),
@@ -135,6 +143,25 @@ export const ArtanisChatResponse = S.Struct({
   traceRef: S.optional(S.String),
 })
 export type ArtanisChatResponse = typeof ArtanisChatResponse.Type
+
+export type ArtanisApprovalGateAction = "approve" | "reject"
+
+export interface ArtanisApprovalGateCommandOptions {
+  readonly baseUrl: string
+  readonly token: string
+  readonly fetch?: typeof fetch | undefined
+}
+
+export interface ArtanisApprovalGateDecisionOptions
+  extends ArtanisApprovalGateCommandOptions {
+  readonly action: ArtanisApprovalGateAction
+  readonly gateRef: string
+}
+
+export interface ArtanisApprovalGateArmOptions
+  extends ArtanisApprovalGateCommandOptions {
+  readonly expiresInHours?: number | undefined
+}
 
 // OpenAgents device-auth (`khala login`, #6363, epic #6359).
 //


### PR DESCRIPTION
Addresses #6407.

### Changes
- Added shared agent-status encoding for Pylon Codex turn and event chunk reporters so status items use the same runner-neutral envelope.
- Updated Codex turn reporting tests to cover the common agent-status envelope and raw event preservation.
- Added Khala CLI/client support and types for gated Artanis orchestration verbs, with CLI tests covering unauthorized and enabled command flows.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).