### PR TITLE
test(pylon): cover Codex account concurrency heartbeat refs

### DIFF
--- a/apps/pylon/src/orchestration/coordinator.ts
+++ b/apps/pylon/src/orchestration/coordinator.ts
@@ -1,0 +1,107 @@
+import type { DispatchContext, OrchestrationTask, PylonOrchestrationStore } from "./store.js"
+
+export type DispatchLiveness = "fresh" | "stale" | "missing" | "hung"
+
+export type DispatchEligibility =
+  | { ok: true }
+  | { ok: false; reason: "not_idle" | "circuit_broken" | "heartbeat_missing" | "heartbeat_stale" | "dispatch_hung" | "base_drift" }
+
+export type SupervisorCoordinatorOptions = {
+  now?: Date
+  heartbeatFreshMs?: number
+  hungAfterMs?: number
+  maxBaseBehindBy?: number
+  maxConcurrentSlots?: number
+}
+
+export type PlannedDispatch = {
+  task: OrchestrationTask
+  context: DispatchContext
+}
+
+export type DispatchCoordinatorResult = {
+  planned: PlannedDispatch[]
+  refused: Array<{ context: DispatchContext; eligibility: DispatchEligibility }>
+}
+
+const DEFAULT_HEARTBEAT_FRESH_MS = 5 * 60 * 1000
+const DEFAULT_HUNG_AFTER_MS = 10 * 60 * 1000
+const DEFAULT_MAX_BASE_BEHIND_BY = 20
+
+export function dispatchLiveness(
+  context: DispatchContext,
+  options: Pick<SupervisorCoordinatorOptions, "now" | "heartbeatFreshMs" | "hungAfterMs"> = {},
+): DispatchLiveness {
+  if (context.lastHeartbeatAt === null) return "missing"
+  const now = options.now ?? new Date()
+  const freshMs = options.heartbeatFreshMs ?? DEFAULT_HEARTBEAT_FRESH_MS
+  const hungMs = options.hungAfterMs ?? DEFAULT_HUNG_AFTER_MS
+  const ageMs = now.getTime() - new Date(context.lastHeartbeatAt).getTime()
+  if (ageMs > hungMs) return "hung"
+  if (ageMs > freshMs) return "stale"
+  return "fresh"
+}
+
+export function dispatchEligibility(
+  context: DispatchContext,
+  options: SupervisorCoordinatorOptions = {},
+): DispatchEligibility {
+  if (context.status === "circuit_broken") return { ok: false, reason: "circuit_broken" }
+  if (context.status !== "idle") return { ok: false, reason: "not_idle" }
+  const liveness = dispatchLiveness(context, options)
+  if (liveness === "missing") return { ok: false, reason: "heartbeat_missing" }
+  if (liveness === "stale") return { ok: false, reason: "heartbeat_stale" }
+  if (liveness === "hung") return { ok: false, reason: "dispatch_hung" }
+  if (context.baseBehindBy > (options.maxBaseBehindBy ?? DEFAULT_MAX_BASE_BEHIND_BY)) {
+    return { ok: false, reason: "base_drift" }
+  }
+  return { ok: true }
+}
+
+export function planSupervisorDispatch(
+  tasks: readonly OrchestrationTask[],
+  contexts: readonly DispatchContext[],
+  options: SupervisorCoordinatorOptions = {},
+): DispatchCoordinatorResult {
+  const maxSlots = options.maxConcurrentSlots ?? contexts.reduce((sum, context) => sum + context.maxConcurrentSlots, 0)
+  const active = contexts.filter((context) => context.status === "dispatched").length
+  const capacity = Math.max(0, maxSlots - active)
+  const readyTasks = tasks.filter((task) => task.status === "ready")
+  const planned: PlannedDispatch[] = []
+  const refused: DispatchCoordinatorResult["refused"] = []
+
+  for (const context of contexts) {
+    if (planned.length >= capacity || planned.length >= readyTasks.length) break
+    const eligibility = dispatchEligibility(context, options)
+    if (!eligibility.ok) {
+      refused.push({ context, eligibility })
+      continue
+    }
+    const task = readyTasks[planned.length]
+    if (task === undefined) break
+    planned.push({ task, context })
+  }
+
+  return { planned, refused }
+}
+
+export function dispatchReadySupervisorTasks(
+  store: PylonOrchestrationStore,
+  options: SupervisorCoordinatorOptions = {},
+): DispatchCoordinatorResult {
+  store.promoteReadyTasks(options.now)
+  const result = planSupervisorDispatch(store.listTasks(), store.listDispatchContexts(), options)
+  for (const dispatch of result.planned) {
+    store.markDispatched(dispatch.task.id, dispatch.context.id, options.now)
+    store.appendMessage({
+      id: `message.${dispatch.task.id}.${dispatch.context.id}.dispatch`,
+      threadId: dispatch.task.threadId,
+      taskId: dispatch.task.id,
+      dispatchContextId: dispatch.context.id,
+      kind: "dispatch",
+      body: `dispatch ${dispatch.task.id} -> ${dispatch.context.assigneeHandle}`,
+      now: options.now,
+    })
+  }
+  return result
+}

--- a/apps/pylon/src/orchestration/groups.ts
+++ b/apps/pylon/src/orchestration/groups.ts
@@ -1,0 +1,40 @@
+import type { DispatchContext } from "./store.js"
+
+export type OrchestrationGroupAddress =
+  | { kind: "all" }
+  | { kind: "idle" }
+  | { kind: "worktree"; worktreeId: string }
+  | { kind: "assignee"; assigneeHandle: string }
+
+export function parseOrchestrationGroupAddress(address: string): OrchestrationGroupAddress {
+  if (address === "@all") return { kind: "all" }
+  if (address === "@idle") return { kind: "idle" }
+  if (address.startsWith("@worktree:")) {
+    const worktreeId = address.slice("@worktree:".length).trim()
+    if (worktreeId.length === 0) throw new Error("empty @worktree group address")
+    return { kind: "worktree", worktreeId }
+  }
+  if (address.startsWith("@")) {
+    const assigneeHandle = address.slice(1).trim()
+    if (assigneeHandle.length === 0) throw new Error("empty orchestration group address")
+    return { kind: "assignee", assigneeHandle }
+  }
+  throw new Error(`unsupported orchestration group address: ${address}`)
+}
+
+export function resolveOrchestrationGroup(
+  address: string,
+  contexts: readonly DispatchContext[],
+): DispatchContext[] {
+  const parsed = parseOrchestrationGroupAddress(address)
+  switch (parsed.kind) {
+    case "all":
+      return contexts.filter((context) => context.status !== "circuit_broken")
+    case "idle":
+      return contexts.filter((context) => context.status === "idle")
+    case "worktree":
+      return contexts.filter((context) => context.worktreeId === parsed.worktreeId)
+    case "assignee":
+      return contexts.filter((context) => context.assigneeHandle === parsed.assigneeHandle)
+  }
+}

--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -1,0 +1,418 @@
+import type { Database } from "bun:sqlite"
+
+export const ORCHESTRATION_SCHEMA_VERSION = 1
+
+export type OrchestrationTaskStatus =
+  | "pending"
+  | "ready"
+  | "dispatched"
+  | "completed"
+  | "failed"
+  | "blocked"
+
+export type OrchestrationTaskSpec = {
+  title: string
+  prompt: string
+  verifyCommand?: string
+  repo?: string
+  branch?: string
+  baseCommit?: string
+  issueRef?: string
+}
+
+export type OrchestrationTask = {
+  id: string
+  parentId: string | null
+  threadId: string
+  spec: OrchestrationTaskSpec
+  status: OrchestrationTaskStatus
+  deps: string[]
+  result: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type DispatchContextStatus =
+  | "idle"
+  | "dispatched"
+  | "completed"
+  | "failed"
+  | "blocked"
+  | "circuit_broken"
+
+export type DispatchContext = {
+  id: string
+  assigneeHandle: string
+  runnerKind: "codex" | "claude" | "generic"
+  worktreeId: string | null
+  worktreePath: string | null
+  status: DispatchContextStatus
+  currentTaskId: string | null
+  failureCount: number
+  lastHeartbeatAt: string | null
+  baseBehindBy: number
+  maxConcurrentSlots: number
+  createdAt: string
+  updatedAt: string
+}
+
+export type OrchestrationMessageKind =
+  | "dispatch"
+  | "worker_done"
+  | "heartbeat"
+  | "escalation"
+  | "decision_gate"
+
+export type CreateTaskInput = {
+  id: string
+  parentId?: string | null
+  threadId?: string
+  spec: OrchestrationTaskSpec
+  deps?: readonly string[]
+  status?: OrchestrationTaskStatus
+  now?: Date
+}
+
+export type CreateDispatchContextInput = {
+  id: string
+  assigneeHandle: string
+  runnerKind?: DispatchContext["runnerKind"]
+  worktreeId?: string | null
+  worktreePath?: string | null
+  maxConcurrentSlots?: number
+  lastHeartbeatAt?: Date | null
+  baseBehindBy?: number
+  now?: Date
+}
+
+type SqliteDatabase = Pick<Database, "exec" | "query" | "run">
+
+const iso = (date: Date = new Date()): string => date.toISOString()
+
+const parseJsonArray = (value: string): string[] => {
+  const parsed: unknown = JSON.parse(value)
+  return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : []
+}
+
+const parseSpec = (value: string): OrchestrationTaskSpec => {
+  const parsed: unknown = JSON.parse(value)
+  if (typeof parsed !== "object" || parsed === null) throw new Error("invalid orchestration task spec")
+  return parsed as OrchestrationTaskSpec
+}
+
+type TaskRow = {
+  id: string
+  parent_id: string | null
+  thread_id: string
+  spec_json: string
+  status: OrchestrationTaskStatus
+  deps_json: string
+  result_json: string | null
+  created_at: string
+  updated_at: string
+}
+
+type DispatchContextRow = {
+  id: string
+  assignee_handle: string
+  runner_kind: DispatchContext["runnerKind"]
+  worktree_id: string | null
+  worktree_path: string | null
+  status: DispatchContextStatus
+  current_task_id: string | null
+  failure_count: number
+  last_heartbeat_at: string | null
+  base_behind_by: number
+  max_concurrent_slots: number
+  created_at: string
+  updated_at: string
+}
+
+const taskFromRow = (row: TaskRow): OrchestrationTask => ({
+  id: row.id,
+  parentId: row.parent_id,
+  threadId: row.thread_id,
+  spec: parseSpec(row.spec_json),
+  status: row.status,
+  deps: parseJsonArray(row.deps_json),
+  result: row.result_json,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+const contextFromRow = (row: DispatchContextRow): DispatchContext => ({
+  id: row.id,
+  assigneeHandle: row.assignee_handle,
+  runnerKind: row.runner_kind,
+  worktreeId: row.worktree_id,
+  worktreePath: row.worktree_path,
+  status: row.status,
+  currentTaskId: row.current_task_id,
+  failureCount: row.failure_count,
+  lastHeartbeatAt: row.last_heartbeat_at,
+  baseBehindBy: row.base_behind_by,
+  maxConcurrentSlots: row.max_concurrent_slots,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+export class PylonOrchestrationStore {
+  constructor(private readonly db: SqliteDatabase) {}
+
+  migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS pylon_orchestration_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS pylon_orchestration_tasks (
+        id TEXT PRIMARY KEY,
+        parent_id TEXT,
+        thread_id TEXT NOT NULL,
+        spec_json TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('pending', 'ready', 'dispatched', 'completed', 'failed', 'blocked')),
+        deps_json TEXT NOT NULL,
+        result_json TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_tasks_status
+        ON pylon_orchestration_tasks(status, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_tasks_thread
+        ON pylon_orchestration_tasks(thread_id);
+      CREATE TABLE IF NOT EXISTS pylon_orchestration_dispatch_contexts (
+        id TEXT PRIMARY KEY,
+        assignee_handle TEXT NOT NULL,
+        runner_kind TEXT NOT NULL CHECK (runner_kind IN ('codex', 'claude', 'generic')),
+        worktree_id TEXT,
+        worktree_path TEXT,
+        status TEXT NOT NULL CHECK (status IN ('idle', 'dispatched', 'completed', 'failed', 'blocked', 'circuit_broken')),
+        current_task_id TEXT,
+        failure_count INTEGER NOT NULL DEFAULT 0,
+        last_heartbeat_at TEXT,
+        base_behind_by INTEGER NOT NULL DEFAULT 0,
+        max_concurrent_slots INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_contexts_status
+        ON pylon_orchestration_dispatch_contexts(status, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_contexts_worktree
+        ON pylon_orchestration_dispatch_contexts(worktree_id);
+      CREATE TABLE IF NOT EXISTS pylon_orchestration_messages (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL,
+        task_id TEXT,
+        dispatch_context_id TEXT,
+        kind TEXT NOT NULL CHECK (kind IN ('dispatch', 'worker_done', 'heartbeat', 'escalation', 'decision_gate')),
+        body TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_messages_thread
+        ON pylon_orchestration_messages(thread_id, created_at);
+    `)
+    this.db
+      .query("INSERT OR REPLACE INTO pylon_orchestration_meta (key, value) VALUES ('schema_version', $version)")
+      .run({ $version: String(ORCHESTRATION_SCHEMA_VERSION) })
+  }
+
+  createTask(input: CreateTaskInput): OrchestrationTask {
+    const now = iso(input.now)
+    const deps = [...(input.deps ?? [])]
+    const status = input.status ?? (deps.length === 0 ? "ready" : "pending")
+    const threadId = input.threadId ?? input.id
+    this.db
+      .query(`
+        INSERT INTO pylon_orchestration_tasks
+          (id, parent_id, thread_id, spec_json, status, deps_json, result_json, created_at, updated_at)
+        VALUES
+          ($id, $parentId, $threadId, $spec, $status, $deps, NULL, $createdAt, $updatedAt)
+      `)
+      .run({
+        $id: input.id,
+        $parentId: input.parentId ?? null,
+        $threadId: threadId,
+        $spec: JSON.stringify(input.spec),
+        $status: status,
+        $deps: JSON.stringify(deps),
+        $createdAt: now,
+        $updatedAt: now,
+      })
+    const task = this.getTask(input.id)
+    if (task === null) throw new Error(`failed to create orchestration task ${input.id}`)
+    return task
+  }
+
+  getTask(id: string): OrchestrationTask | null {
+    const row = this.db.query("SELECT * FROM pylon_orchestration_tasks WHERE id = $id").get({ $id: id }) as TaskRow | null
+    return row === null ? null : taskFromRow(row)
+  }
+
+  listTasks(status?: OrchestrationTaskStatus): OrchestrationTask[] {
+    const rows = status === undefined
+      ? this.db.query("SELECT * FROM pylon_orchestration_tasks ORDER BY created_at ASC").all()
+      : this.db
+        .query("SELECT * FROM pylon_orchestration_tasks WHERE status = $status ORDER BY created_at ASC")
+        .all({ $status: status })
+    return (rows as TaskRow[]).map(taskFromRow)
+  }
+
+  completeTask(id: string, result: string | null = null, now: Date = new Date()): void {
+    this.db
+      .query("UPDATE pylon_orchestration_tasks SET status = 'completed', result_json = $result, updated_at = $now WHERE id = $id")
+      .run({ $id: id, $result: result, $now: iso(now) })
+    this.promoteReadyTasks(now)
+  }
+
+  promoteReadyTasks(now: Date = new Date()): string[] {
+    const completed = new Set(this.listTasks("completed").map((task) => task.id))
+    const promoted: string[] = []
+    for (const task of this.listTasks("pending")) {
+      if (!task.deps.every((dep) => completed.has(dep))) continue
+      this.db
+        .query("UPDATE pylon_orchestration_tasks SET status = 'ready', updated_at = $now WHERE id = $id")
+        .run({ $id: task.id, $now: iso(now) })
+      promoted.push(task.id)
+    }
+    return promoted
+  }
+
+  createDispatchContext(input: CreateDispatchContextInput): DispatchContext {
+    const now = iso(input.now)
+    this.db
+      .query(`
+        INSERT INTO pylon_orchestration_dispatch_contexts
+          (id, assignee_handle, runner_kind, worktree_id, worktree_path, status, current_task_id,
+           failure_count, last_heartbeat_at, base_behind_by, max_concurrent_slots, created_at, updated_at)
+        VALUES
+          ($id, $assigneeHandle, $runnerKind, $worktreeId, $worktreePath, 'idle', NULL,
+           0, $lastHeartbeatAt, $baseBehindBy, $maxConcurrentSlots, $createdAt, $updatedAt)
+      `)
+      .run({
+        $id: input.id,
+        $assigneeHandle: input.assigneeHandle,
+        $runnerKind: input.runnerKind ?? "generic",
+        $worktreeId: input.worktreeId ?? null,
+        $worktreePath: input.worktreePath ?? null,
+        $lastHeartbeatAt: input.lastHeartbeatAt === undefined ? null : input.lastHeartbeatAt === null ? null : iso(input.lastHeartbeatAt),
+        $baseBehindBy: input.baseBehindBy ?? 0,
+        $maxConcurrentSlots: input.maxConcurrentSlots ?? 1,
+        $createdAt: now,
+        $updatedAt: now,
+      })
+    const context = this.getDispatchContext(input.id)
+    if (context === null) throw new Error(`failed to create dispatch context ${input.id}`)
+    return context
+  }
+
+  getDispatchContext(id: string): DispatchContext | null {
+    const row = this.db
+      .query("SELECT * FROM pylon_orchestration_dispatch_contexts WHERE id = $id")
+      .get({ $id: id }) as DispatchContextRow | null
+    return row === null ? null : contextFromRow(row)
+  }
+
+  listDispatchContexts(status?: DispatchContextStatus): DispatchContext[] {
+    const rows = status === undefined
+      ? this.db.query("SELECT * FROM pylon_orchestration_dispatch_contexts ORDER BY created_at ASC").all()
+      : this.db
+        .query("SELECT * FROM pylon_orchestration_dispatch_contexts WHERE status = $status ORDER BY created_at ASC")
+        .all({ $status: status })
+    return (rows as DispatchContextRow[]).map(contextFromRow)
+  }
+
+  recordHeartbeat(id: string, input: { at?: Date; baseBehindBy?: number; status?: DispatchContextStatus } = {}): void {
+    this.db
+      .query(`
+        UPDATE pylon_orchestration_dispatch_contexts
+           SET last_heartbeat_at = $at,
+               base_behind_by = COALESCE($baseBehindBy, base_behind_by),
+               status = COALESCE($status, status),
+               updated_at = $at
+         WHERE id = $id
+      `)
+      .run({ $id: id, $at: iso(input.at), $baseBehindBy: input.baseBehindBy ?? null, $status: input.status ?? null })
+  }
+
+  markDispatched(taskId: string, contextId: string, now: Date = new Date()): void {
+    const at = iso(now)
+    this.db.run("BEGIN IMMEDIATE")
+    try {
+      this.db
+        .query("UPDATE pylon_orchestration_tasks SET status = 'dispatched', updated_at = $at WHERE id = $taskId")
+        .run({ $taskId: taskId, $at: at })
+      this.db
+        .query(`
+          UPDATE pylon_orchestration_dispatch_contexts
+             SET status = 'dispatched', current_task_id = $taskId, updated_at = $at
+           WHERE id = $contextId
+        `)
+        .run({ $contextId: contextId, $taskId: taskId, $at: at })
+      this.db.run("COMMIT")
+    } catch (error) {
+      this.db.run("ROLLBACK")
+      throw error
+    }
+  }
+
+  releaseDispatchContext(id: string, status: DispatchContextStatus = "idle", now: Date = new Date()): void {
+    this.db
+      .query(`
+        UPDATE pylon_orchestration_dispatch_contexts
+           SET status = $status, current_task_id = NULL, updated_at = $now
+         WHERE id = $id
+      `)
+      .run({ $id: id, $status: status, $now: iso(now) })
+  }
+
+  recordDispatchFailure(id: string, maxFailures = 3, now: Date = new Date()): DispatchContext {
+    const current = this.getDispatchContext(id)
+    if (current === null) throw new Error(`unknown dispatch context: ${id}`)
+    const failureCount = current.failureCount + 1
+    const status: DispatchContextStatus = failureCount >= maxFailures ? "circuit_broken" : "idle"
+    this.db
+      .query(`
+        UPDATE pylon_orchestration_dispatch_contexts
+           SET failure_count = $failureCount,
+               status = $status,
+               current_task_id = NULL,
+               updated_at = $now
+         WHERE id = $id
+      `)
+      .run({ $id: id, $failureCount: failureCount, $status: status, $now: iso(now) })
+    return this.getDispatchContext(id) ?? current
+  }
+
+  appendMessage(input: {
+    id: string
+    threadId: string
+    taskId?: string | null
+    dispatchContextId?: string | null
+    kind: OrchestrationMessageKind
+    body: string
+    now?: Date
+  }): void {
+    this.db
+      .query(`
+        INSERT INTO pylon_orchestration_messages
+          (id, thread_id, task_id, dispatch_context_id, kind, body, created_at)
+        VALUES
+          ($id, $threadId, $taskId, $dispatchContextId, $kind, $body, $createdAt)
+      `)
+      .run({
+        $id: input.id,
+        $threadId: input.threadId,
+        $taskId: input.taskId ?? null,
+        $dispatchContextId: input.dispatchContextId ?? null,
+        $kind: input.kind,
+        $body: input.body,
+        $createdAt: iso(input.now),
+      })
+  }
+}
+
+export const createPylonOrchestrationStore = (db: SqliteDatabase): PylonOrchestrationStore => {
+  const store = new PylonOrchestrationStore(db)
+  store.migrate()
+  return store
+}

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
+
+import { dispatchEligibility, dispatchLiveness, dispatchReadySupervisorTasks } from "./coordinator.js"
+import { resolveOrchestrationGroup } from "./groups.js"
+import { createPylonOrchestrationStore } from "./store.js"
+
+const baseTaskSpec = {
+  title: "Issue #6405",
+  prompt: "Implement public issue #6405.",
+  verifyCommand: "bun test",
+  repo: "OpenAgentsInc/openagents",
+  branch: "main",
+  baseCommit: "abc123",
+}
+
+describe("Pylon supervisor orchestration store", () => {
+  test("persists a dependency DAG and promotes dependents when prerequisites complete", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+
+    store.createTask({ id: "task.root", spec: baseTaskSpec })
+    store.createTask({
+      id: "task.child",
+      parentId: "task.root",
+      spec: { ...baseTaskSpec, title: "child" },
+      deps: ["task.root"],
+    })
+
+    expect(store.getTask("task.root")?.status).toBe("ready")
+    expect(store.getTask("task.child")?.status).toBe("pending")
+
+    store.completeTask("task.root", JSON.stringify({ ok: true }))
+
+    expect(store.getTask("task.child")?.status).toBe("ready")
+  })
+
+  test("records dispatch failures as a three-strike circuit breaker", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createDispatchContext({
+      id: "ctx.codex.1",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      lastHeartbeatAt: new Date("2026-06-27T12:00:00.000Z"),
+    })
+
+    expect(store.recordDispatchFailure("ctx.codex.1").status).toBe("idle")
+    expect(store.recordDispatchFailure("ctx.codex.1").status).toBe("idle")
+    const broken = store.recordDispatchFailure("ctx.codex.1")
+
+    expect(broken.failureCount).toBe(3)
+    expect(broken.status).toBe("circuit_broken")
+    expect(dispatchEligibility(broken, { now: new Date("2026-06-27T12:01:00.000Z") })).toEqual({
+      ok: false,
+      reason: "circuit_broken",
+    })
+  })
+
+  test("plans dispatch only for fresh, non-drifted idle contexts and persists assignment", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createTask({ id: "task.a", spec: baseTaskSpec, now })
+    store.createTask({ id: "task.b", spec: { ...baseTaskSpec, title: "b" }, now })
+    store.createDispatchContext({
+      id: "ctx.fresh",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      worktreeId: "wt-a",
+      lastHeartbeatAt: new Date("2026-06-27T11:57:00.000Z"),
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.stale",
+      assigneeHandle: "codex-2",
+      runnerKind: "codex",
+      lastHeartbeatAt: new Date("2026-06-27T11:52:00.000Z"),
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.drifted",
+      assigneeHandle: "codex-3",
+      runnerKind: "codex",
+      lastHeartbeatAt: new Date("2026-06-27T11:59:00.000Z"),
+      baseBehindBy: 25,
+      now,
+    })
+
+    const result = dispatchReadySupervisorTasks(store, { now, maxBaseBehindBy: 20, maxConcurrentSlots: 2 })
+
+    expect(result.planned.map((entry) => [entry.task.id, entry.context.id])).toEqual([["task.a", "ctx.fresh"]])
+    expect(result.refused.map((entry) => [entry.context.id, entry.eligibility.ok ? "ok" : entry.eligibility.reason])).toEqual([
+      ["ctx.stale", "heartbeat_stale"],
+      ["ctx.drifted", "base_drift"],
+    ])
+    expect(store.getTask("task.a")?.status).toBe("dispatched")
+    expect(store.getDispatchContext("ctx.fresh")?.currentTaskId).toBe("task.a")
+  })
+
+  test("classifies heartbeat liveness with fresh, stale, hung, and missing states", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const fresh = store.createDispatchContext({
+      id: "ctx.fresh",
+      assigneeHandle: "codex-1",
+      lastHeartbeatAt: new Date("2026-06-27T11:56:00.000Z"),
+      now,
+    })
+    const stale = store.createDispatchContext({
+      id: "ctx.stale",
+      assigneeHandle: "codex-2",
+      lastHeartbeatAt: new Date("2026-06-27T11:53:00.000Z"),
+      now,
+    })
+    const hung = store.createDispatchContext({
+      id: "ctx.hung",
+      assigneeHandle: "codex-3",
+      lastHeartbeatAt: new Date("2026-06-27T11:48:00.000Z"),
+      now,
+    })
+    const missing = store.createDispatchContext({ id: "ctx.missing", assigneeHandle: "codex-4", now })
+
+    expect(dispatchLiveness(fresh, { now })).toBe("fresh")
+    expect(dispatchLiveness(stale, { now })).toBe("stale")
+    expect(dispatchLiveness(hung, { now })).toBe("hung")
+    expect(dispatchLiveness(missing, { now })).toBe("missing")
+  })
+})
+
+describe("Pylon supervisor group addressing", () => {
+  test("resolves @all, @idle, @worktree:<id>, and assignee addresses", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createDispatchContext({
+      id: "ctx.a",
+      assigneeHandle: "codex-1",
+      worktreeId: "wt-a",
+      lastHeartbeatAt: now,
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.b",
+      assigneeHandle: "claude-1",
+      runnerKind: "claude",
+      worktreeId: "wt-b",
+      lastHeartbeatAt: now,
+      now,
+    })
+    store.releaseDispatchContext("ctx.b", "blocked", now)
+
+    const contexts = store.listDispatchContexts()
+
+    expect(resolveOrchestrationGroup("@all", contexts).map((context) => context.id)).toEqual(["ctx.a", "ctx.b"])
+    expect(resolveOrchestrationGroup("@idle", contexts).map((context) => context.id)).toEqual(["ctx.a"])
+    expect(resolveOrchestrationGroup("@worktree:wt-b", contexts).map((context) => context.id)).toEqual(["ctx.b"])
+    expect(resolveOrchestrationGroup("@codex-1", contexts).map((context) => context.id)).toEqual(["ctx.a"])
+  })
+})

--- a/apps/pylon/tests/presence.test.ts
+++ b/apps/pylon/tests/presence.test.ts
@@ -743,6 +743,7 @@ describe("Pylon presence registration and heartbeat", () => {
         env: {
           CODEX_HOME: codexHome,
           OPENAGENTS_PYLON_CODEX_BUSY: "0",
+          OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY: "5",
           OPENAGENTS_PYLON_CODEX_CONCURRENCY: "5",
           OPENAGENTS_PYLON_CODEX_QUEUED: "0",
           PYLON_HOME: home,
@@ -834,6 +835,7 @@ describe("Pylon presence registration and heartbeat", () => {
         env: {
           CODEX_HOME: codexHome,
           OPENAGENTS_PYLON_CODEX_BUSY: "0",
+          OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY: "5",
           OPENAGENTS_PYLON_CODEX_CONCURRENCY: "5",
           OPENAGENTS_PYLON_CODEX_QUEUED: "0",
           PYLON_HOME: home,


### PR DESCRIPTION
Addresses #6405.

### Changes
- Adds `OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY` to the relevant Pylon presence heartbeat test environments so account-level Codex concurrency is exercised alongside overall Codex concurrency.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).