### PR TITLE
feat(khala): triage trace review into unsupported ledger

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.test.ts
@@ -11,6 +11,19 @@ import {
   ArtanisPersistenceTestStore,
   artanisPersistenceTestDb,
 } from './test/artanis-persistence-fixture'
+import type {
+  KhalaFeedbackRecord,
+  KhalaFeedbackStore,
+} from './khala-feedback-routes'
+import type {
+  KhalaTraceReviewFacts,
+  KhalaTraceReviewStore,
+} from './khala-trace-review-routes'
+import type {
+  KhalaUnsupportedRequestCreateInput,
+  KhalaUnsupportedRequestRecord,
+  KhalaUnsupportedRequestStore,
+} from './khala-unsupported-request-routes'
 
 const nowIso = '2026-06-07T05:20:00.000Z'
 const scheduledTime = Date.parse(nowIso)
@@ -31,6 +44,69 @@ const persistedKhalaReadinessSignal = (
 
   return signal
 }
+
+const emptyTraceReviewFacts = (): KhalaTraceReviewFacts => ({
+  modelMix: [],
+  notableTraces: [],
+  outcomes: [],
+  rawEventHighlights: [],
+  rawEventSummary: {
+    assignmentCount: 0,
+    byteLength: 0,
+    eventCount: 0,
+    rowCount: 0,
+  },
+  tokenByDemandSource: [],
+  tokenSummary: {
+    estimatedUsageCount: 0,
+    eventCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 0,
+    zeroOutputCount: 0,
+  },
+  traceByDemandSource: [],
+  traceSummary: {
+    ownerOnlyCount: 0,
+    publicCount: 0,
+    traceCount: 0,
+    trainingConsentCount: 0,
+    unlistedCount: 0,
+    zeroStepCount: 0,
+  },
+})
+
+const captureUnsupportedRequestStore = (
+  writes: Array<KhalaUnsupportedRequestCreateInput>,
+): KhalaUnsupportedRequestStore => ({
+  listRecent: async () => [],
+  upsert: async input => {
+    writes.push(input)
+    const record: KhalaUnsupportedRequestRecord = {
+      createdAt: input.createdAt,
+      evidenceRefs: input.evidenceRefs,
+      forumTopicRef: input.forumTopicRef,
+      githubIssueRef: input.githubIssueRef,
+      issueRequired:
+        (input.triageKind === 'bug' ||
+          input.triageKind === 'missing_capability') &&
+        input.githubIssueRef === null,
+      nextAction: 'open_github_issue',
+      requestRef: input.requestRef,
+      sourceKind: input.sourceKind,
+      sourceRef: input.sourceRef,
+      status: input.status,
+      suggestedIssueTitle: input.suggestedIssueTitle,
+      summary: input.summary,
+      title: input.title,
+      triageKind: input.triageKind,
+      updatedAt: input.updatedAt,
+    }
+
+    return record
+  },
+})
 
 describe('Artanis scheduled runner', () => {
   test('stays disabled by default and records no rows', async () => {
@@ -280,6 +356,115 @@ describe('Artanis scheduled runner', () => {
       ]),
       state: 'available',
     })
+  })
+
+  test('upserts trace-review triage items into the unsupported-request ledger', async () => {
+    const store = new ArtanisPersistenceTestStore()
+    const db = artanisPersistenceTestDb(store)
+    const writes: Array<KhalaUnsupportedRequestCreateInput> = []
+    const traceReviewStore: KhalaTraceReviewStore = {
+      readFacts: async () => ({
+        ...emptyTraceReviewFacts(),
+        tokenSummary: {
+          ...emptyTraceReviewFacts().tokenSummary,
+          eventCount: 3,
+          totalTokens: 120,
+          zeroOutputCount: 2,
+        },
+      }),
+    }
+
+    const result = await Effect.runPromise(
+      runArtanisScheduledTick({
+        db,
+        enabled: true,
+        khalaTraceReviewStore: traceReviewStore,
+        khalaUnsupportedRequestStore: captureUnsupportedRequestStore(writes),
+        nowIso,
+        scheduleRef: 'cron.public.artanis.trace-review-ledger',
+      }),
+    )
+
+    expect(result.state).toBe('completed')
+    expect(result.unsupportedRequestRefs).toEqual([
+      'khala_unsupported:triage.khala_trace_review.empty_response',
+    ])
+    expect(writes).toEqual([
+      expect.objectContaining({
+        evidenceRefs: [
+          'table.token_usage_events.output_tokens_zero',
+          'triage.khala_trace_review.empty_response',
+        ],
+        sourceKind: 'trace_review',
+        sourceRef: 'triage.khala_trace_review.empty_response',
+        status: 'needs_issue',
+        title: 'Token rows with zero completion/output tokens',
+        triageKind: 'bug',
+      }),
+    ])
+  })
+
+  test('groups recent Khala feedback into a public-safe unsupported-request row', async () => {
+    const store = new ArtanisPersistenceTestStore()
+    const db = artanisPersistenceTestDb(store)
+    const writes: Array<KhalaUnsupportedRequestCreateInput> = []
+    const feedbackRecords: ReadonlyArray<KhalaFeedbackRecord> = [
+      {
+        clientVersion: '0.1.0',
+        createdAt: '2026-06-07T04:20:00.000Z',
+        feedback:
+          'Please read my local /Users/example/private repo diff before answering.',
+        feedbackRef: 'khala_feedback:fb_public_1',
+        source: 'khala-cli',
+        traceRef: null,
+        userAgent: 'khala-cli',
+      },
+      {
+        clientVersion: '0.1.0',
+        createdAt: '2026-06-07T05:00:00.000Z',
+        feedback: 'The answer was too wordy.',
+        feedbackRef: 'khala_feedback:fb_public_2',
+        source: 'khala-cli',
+        traceRef: 'trace.public.feedback_2',
+        userAgent: 'khala-cli',
+      },
+    ]
+    const feedbackStore: KhalaFeedbackStore = {
+      create: async () => feedbackRecords[0]!,
+      listRecent: async () => feedbackRecords,
+    }
+
+    const result = await Effect.runPromise(
+      runArtanisScheduledTick({
+        db,
+        enabled: true,
+        khalaFeedbackStore: feedbackStore,
+        khalaUnsupportedRequestStore: captureUnsupportedRequestStore(writes),
+        nowIso,
+        scheduleRef: 'cron.public.artanis.feedback-ledger',
+      }),
+    )
+
+    expect(result.state).toBe('completed')
+    expect(result.unsupportedRequestRefs).toEqual([
+      'khala_unsupported:khala_feedback_recent_triage',
+    ])
+    expect(writes).toEqual([
+      expect.objectContaining({
+        evidenceRefs: [
+          'khala_feedback:fb_public_1',
+          'khala_feedback:fb_public_2',
+        ],
+        sourceKind: 'khala_feedback',
+        sourceRef: 'khala_feedback.recent_triage',
+        status: 'needs_issue',
+        title: 'Recent Khala feedback needs backlog triage',
+        triageKind: 'missing_capability',
+      }),
+    ])
+    expect(writes[0]!.summary).toContain('2 recent notes')
+    expect(writes[0]!.summary).not.toContain('/Users/example')
+    expect(writes[0]!.summary).not.toContain('too wordy')
   })
 
   test('blocks Khala readiness on leaked public model ids without projecting them', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
@@ -39,6 +39,21 @@ import { exampleArtanisRuntime } from './artanis-runtime'
 import {
   ArtanisWorkRoutingProposalRecord,
 } from './artanis-work-routing'
+import type {
+  KhalaFeedbackRecord,
+  KhalaFeedbackStore,
+} from './khala-feedback-routes'
+import {
+  buildKhalaTraceReviewReport,
+  type KhalaTraceReviewReport,
+  type KhalaTraceReviewTriageItem,
+  type KhalaTraceReviewStore,
+} from './khala-trace-review-routes'
+import type {
+  KhalaUnsupportedRequestCreateInput,
+  KhalaUnsupportedRequestStore,
+  KhalaUnsupportedRequestTriageKind,
+} from './khala-unsupported-request-routes'
 import {
   epochMillisToIsoTimestamp,
   isoTimestampAfterIso,
@@ -70,7 +85,10 @@ export type ArtanisScheduledRunnerInput = Readonly<{
   context?: Partial<ArtanisScheduledRunnerContext> | undefined
   db: D1Database
   enabled: boolean
+  khalaFeedbackStore?: KhalaFeedbackStore | undefined
   khalaReadinessObservation?: ArtanisKhalaReadinessObservation | undefined
+  khalaTraceReviewStore?: KhalaTraceReviewStore | undefined
+  khalaUnsupportedRequestStore?: KhalaUnsupportedRequestStore | undefined
   nowIso: string
   scheduleRef: string
   scopeRef?: string | undefined
@@ -105,6 +123,7 @@ export type ArtanisScheduledRunnerResult = Readonly<{
   state: ArtanisScheduledRunnerState
   storageReceipts: ReadonlyArray<ArtanisPersistenceWriteReceipt>
   tickRef: string | null
+  unsupportedRequestRefs: ReadonlyArray<string>
   workProposalRefs: ReadonlyArray<string>
 }>
 
@@ -416,6 +435,7 @@ const disabledResult = (
   state: 'disabled',
   storageReceipts: [],
   tickRef: null,
+  unsupportedRequestRefs: [],
   workProposalRefs: [],
 })
 
@@ -906,6 +926,161 @@ const scheduledHealthSnapshot = (
   })
 }
 
+const ARTANIS_UNSUPPORTED_TRIAGE_LIMIT = 10
+const ARTANIS_UNSUPPORTED_TRACE_REVIEW_HOURS = 24
+const ARTANIS_UNSUPPORTED_FEEDBACK_LIMIT = 20
+
+const publicSafeRef = (value: string): string =>
+  value
+    .trim()
+    .replace(/[^A-Za-z0-9_.:/#-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 160)
+
+const traceReviewWindowFor = (nowIso: string) => ({
+  hours: ARTANIS_UNSUPPORTED_TRACE_REVIEW_HOURS,
+  since: isoTimestampAfterIso(
+    nowIso,
+    -ARTANIS_UNSUPPORTED_TRACE_REVIEW_HOURS * 60 * 60 * 1000,
+  ),
+  until: nowIso,
+})
+
+const loadScheduledTraceReview = async (
+  store: KhalaTraceReviewStore,
+  nowIso: string,
+): Promise<KhalaTraceReviewReport> => {
+  const window = traceReviewWindowFor(nowIso)
+  const facts = await store.readFacts({
+    limit: ARTANIS_UNSUPPORTED_TRIAGE_LIMIT,
+    window,
+  })
+
+  return buildKhalaTraceReviewReport({
+    facts,
+    generatedAt: nowIso,
+    window,
+  })
+}
+
+const traceReviewTriageKind = (
+  item: KhalaTraceReviewTriageItem,
+): KhalaUnsupportedRequestTriageKind =>
+  item.kind === 'missing_capability' ? 'missing_capability' : 'bug'
+
+const unsupportedRequestFromTraceTriageItem = (
+  item: KhalaTraceReviewTriageItem,
+  nowIso: string,
+): KhalaUnsupportedRequestCreateInput => {
+  const triageKind = traceReviewTriageKind(item)
+
+  return {
+    createdAt: nowIso,
+    evidenceRefs: uniqueRefs([item.triageRef, ...item.evidenceRefs]).slice(
+      0,
+      20,
+    ),
+    forumTopicRef: null,
+    githubIssueRef: null,
+    requestRef: `khala_unsupported:${publicSafeRef(item.triageRef)}`,
+    sourceKind: 'trace_review',
+    sourceRef: item.triageRef,
+    status: 'needs_issue',
+    suggestedIssueTitle: item.suggestedIssueTitle,
+    summary:
+      `Trace review found a recurring ${item.priority}-priority ${item.kind} signal in the last ${ARTANIS_UNSUPPORTED_TRACE_REVIEW_HOURS}h window. Evidence refs are bounded to public-safe aggregate refs.`,
+    title: item.title,
+    triageKind,
+    updatedAt: nowIso,
+  }
+}
+
+const feedbackSummary = (
+  records: ReadonlyArray<KhalaFeedbackRecord>,
+): string => {
+  const sourceLabels = uniqueRefs(
+    records.map(record => publicSafeRef(record.source)).filter(Boolean),
+  ).slice(0, 5)
+  const firstCreatedAt = records
+    .map(record => record.createdAt)
+    .sort((left, right) => left.localeCompare(right))[0]
+  const latestCreatedAt = records
+    .map(record => record.createdAt)
+    .sort((left, right) => right.localeCompare(left))[0]
+
+  return `Khala feedback intake received ${records.length} recent note${records.length === 1 ? '' : 's'} requiring backlog triage. Source labels: ${sourceLabels.join(', ') || 'unknown'}. Window: ${firstCreatedAt ?? 'unknown'} to ${latestCreatedAt ?? 'unknown'}. Raw feedback text stays in the owner/admin feedback store.`
+}
+
+const unsupportedRequestFromFeedback = (
+  records: ReadonlyArray<KhalaFeedbackRecord>,
+  nowIso: string,
+): KhalaUnsupportedRequestCreateInput | null => {
+  if (records.length === 0) {
+    return null
+  }
+
+  const evidenceRefs = uniqueRefs(
+    records.map(record => record.feedbackRef),
+  ).slice(0, 20)
+
+  return {
+    createdAt: nowIso,
+    evidenceRefs,
+    forumTopicRef: null,
+    githubIssueRef: null,
+    requestRef: 'khala_unsupported:khala_feedback_recent_triage',
+    sourceKind: 'khala_feedback',
+    sourceRef: 'khala_feedback.recent_triage',
+    status: 'needs_issue',
+    suggestedIssueTitle: '[Khala feedback] Triage recent CLI feedback into fixes',
+    summary: feedbackSummary(records),
+    title: 'Recent Khala feedback needs backlog triage',
+    triageKind: 'missing_capability',
+    updatedAt: nowIso,
+  }
+}
+
+const scheduledUnsupportedRequestInputs = async (
+  input: ArtanisScheduledRunnerInput,
+): Promise<ReadonlyArray<KhalaUnsupportedRequestCreateInput>> => {
+  const traceReview = input.khalaTraceReviewStore === undefined
+    ? null
+    : await loadScheduledTraceReview(input.khalaTraceReviewStore, input.nowIso)
+  const traceInputs = (traceReview?.triageItems ?? [])
+    .filter(item => item.priority !== 'low' || item.kind === 'missing_capability')
+    .slice(0, ARTANIS_UNSUPPORTED_TRIAGE_LIMIT)
+    .map(item => unsupportedRequestFromTraceTriageItem(item, input.nowIso))
+  const feedback = input.khalaFeedbackStore === undefined
+    ? []
+    : await input.khalaFeedbackStore.listRecent({
+        limit: ARTANIS_UNSUPPORTED_FEEDBACK_LIMIT,
+      })
+  const feedbackInput = unsupportedRequestFromFeedback(feedback, input.nowIso)
+
+  return feedbackInput === null ? traceInputs : [...traceInputs, feedbackInput]
+}
+
+const runUnsupportedLedgerTriage = (
+  input: ArtanisScheduledRunnerInput,
+): Effect.Effect<ReadonlyArray<string>, never> => {
+  if (input.khalaUnsupportedRequestStore === undefined) {
+    return Effect.succeed([])
+  }
+  const store = input.khalaUnsupportedRequestStore
+
+  return Effect.tryPromise({
+    catch: () => 'khala_unsupported_triage_failed' as const,
+    try: async () => {
+      const requests = await scheduledUnsupportedRequestInputs(input)
+      const records = await Promise.all(
+        requests.map(request => store.upsert(request)),
+      )
+
+      return uniqueRefs(records.map(record => record.requestRef))
+    },
+  }).pipe(Effect.catch(() => Effect.succeed([])))
+}
+
 export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
   function* (input: ArtanisScheduledRunnerInput) {
     if (!input.enabled) {
@@ -960,6 +1135,7 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       loop.loopRef,
       tick.tickRef,
     )
+    const unsupportedRequestRefs = yield* runUnsupportedLedgerTriage(input)
 
     const runtimeReceipt = yield* saveArtanisRuntimeSnapshot(
       input.db,
@@ -1049,6 +1225,7 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       state: 'completed',
       storageReceipts,
       tickRef: tick.tickRef,
+      unsupportedRequestRefs,
       workProposalRefs: [
         workProposal.proposalRef,
         khalaBurndownWorkProposal.proposalRef,
@@ -1062,7 +1239,10 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
 export const runArtanisScheduledTickForWorker = (
   input: Readonly<{
     db: D1Database
+    khalaFeedbackStore?: KhalaFeedbackStore | undefined
     khalaReadinessObservation?: ArtanisKhalaReadinessObservation | undefined
+    khalaTraceReviewStore?: KhalaTraceReviewStore | undefined
+    khalaUnsupportedRequestStore?: KhalaUnsupportedRequestStore | undefined
     scheduledRunnerEnabled: boolean
     scheduledTime: number
   }>,
@@ -1072,7 +1252,10 @@ export const runArtanisScheduledTickForWorker = (
   return runArtanisScheduledTick({
     db: input.db,
     enabled: input.scheduledRunnerEnabled,
+    khalaFeedbackStore: input.khalaFeedbackStore,
     khalaReadinessObservation: input.khalaReadinessObservation,
+    khalaTraceReviewStore: input.khalaTraceReviewStore,
+    khalaUnsupportedRequestStore: input.khalaUnsupportedRequestStore,
     nowIso,
     scheduleRef: `cron.public.artanis.${refSuffix(nowIso)}`,
   })

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -6232,6 +6232,9 @@ const runArtanisScheduledTickScheduled = (
 ): Effect.Effect<void, never> =>
   runArtanisScheduledTickForWorker({
     db,
+    khalaFeedbackStore: makeD1KhalaFeedbackStore(db),
+    khalaTraceReviewStore: makeD1KhalaTraceReviewStore(db),
+    khalaUnsupportedRequestStore: makeD1KhalaUnsupportedRequestStore(db),
     scheduledRunnerEnabled,
     scheduledTime,
   }).pipe(


### PR DESCRIPTION
Addresses #6393.

### Changes
- Added Artanis scheduled-runner support for writing trace-review triage findings into the Khala unsupported-request ledger.
- Added scheduled grouping for recent Khala feedback into a public-safe unsupported-request row.
- Wired the scheduled runner through the Worker entry point and added coverage for trace-review and feedback ledger writes.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).