### PR TITLE
feat(inference): add GLM durability acceptance checklist

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/glm-fleet-durability-operator.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/glm-fleet-durability-operator.test.ts
@@ -70,6 +70,22 @@ describe('GLM fleet durability operator bundle', () => {
       totalReplicaCount: 1,
       warmReplicaCount: 1,
     })
+    expect(bundle.acceptanceChecklist.map(item => item.dimension)).toEqual([
+      'all_replica_keep_warm_watchdog',
+      'capacity_floor_owner_decision',
+      'multi_region_auto_replace',
+      'quota_request_tracking',
+    ])
+    expect(bundle.acceptanceChecklist[0]).toMatchObject({
+      complete: false,
+      dimension: 'all_replica_keep_warm_watchdog',
+      status: 'blocked',
+    })
+    expect(
+      bundle.acceptanceChecklist[0]?.missingOperatorInputs.map(
+        input => input.env,
+      ),
+    ).toEqual(['HYDRALISK_GLM_52_REAP_504B_FORCED_STOP_RECOVERY_REFS'])
     expect(bundle.missingOperatorInputs.map(input => input.env)).toEqual([
       'HYDRALISK_GLM_52_REAP_504B_CAPACITY_FLOOR_DECISION',
       'HYDRALISK_GLM_52_REAP_504B_FORCED_STOP_RECOVERY_REFS',
@@ -138,8 +154,15 @@ describe('GLM fleet durability operator bundle', () => {
     expect(bundle.readiness.acceptanceStatus).toBe('complete')
     expect(bundle.missingOperatorInputs).toEqual([])
     expect(bundle.readiness.operatorActionItems).toEqual([])
+    expect(bundle.acceptanceChecklist.every(item => item.complete)).toBe(true)
+    expect(
+      bundle.acceptanceChecklist.flatMap(item => item.missingOperatorInputs),
+    ).toEqual([])
     expect(readme).toContain('- total replicas: 2')
     expect(readme).toContain('- warm replicas: 1')
+    expect(readme).toContain(
+      '- all_replica_keep_warm_watchdog: complete; complete: true',
+    )
     expect(readme).toContain('- none')
     expect(JSON.stringify(bundle)).not.toContain('private.example.test')
     expect(JSON.stringify(bundle)).not.toContain('secret-')
@@ -222,6 +245,13 @@ describe('GLM fleet durability operator bundle', () => {
     expect(readme).toContain('Acceptance: blocked')
     expect(readme).toContain(
       'Serving ready but durability acceptance incomplete: true',
+    )
+    expect(readme).toContain('## Acceptance checklist')
+    expect(readme).toContain(
+      '- capacity_floor_owner_decision: blocked; complete: false',
+    )
+    expect(readme).toContain(
+      'HYDRALISK_GLM_52_REAP_504B_CAPACITY_FLOOR_DECISION [--capacity-floor-decision]',
     )
     expect(readme).toContain('- reclaimed replicas: 0')
     expect(readme).not.toContain('recover_reclaimed_replicas')

--- a/apps/openagents.com/workers/api/src/inference/glm-fleet-durability-operator.ts
+++ b/apps/openagents.com/workers/api/src/inference/glm-fleet-durability-operator.ts
@@ -1,5 +1,6 @@
 import type {
   GlmFleetAcceptanceDimensionStatus,
+  GlmFleetReadinessOperatorDimension,
   GlmFleetReadinessOperatorReadout,
   GlmFleetReadinessProjection,
 } from './glm-fleet-readiness'
@@ -25,6 +26,16 @@ export type GlmFleetDurabilityOwnerArmedCommandInput = Readonly<{
   readinessUrl?: string | undefined
 }>
 
+export type GlmFleetDurabilityAcceptanceChecklistItem = Readonly<{
+  blockerRefs: ReadonlyArray<string>
+  complete: boolean
+  dimension: GlmFleetReadinessOperatorDimension
+  evidenceRefs: ReadonlyArray<string>
+  missingOperatorInputs: ReadonlyArray<GlmFleetDurabilityOperatorInput>
+  missingReplicaRefs: ReadonlyArray<string>
+  status: GlmFleetAcceptanceDimensionStatus
+}>
+
 export type GlmFleetDurabilityOperatorBundle = Readonly<{
   schemaVersion: typeof GLM_FLEET_DURABILITY_OPERATOR_BUNDLE_SCHEMA
   generatedAt: string
@@ -32,6 +43,7 @@ export type GlmFleetDurabilityOperatorBundle = Readonly<{
   publicSafe: true
   readiness: GlmFleetReadinessOperatorReadout
   acceptance: GlmFleetReadinessProjection['acceptance']
+  acceptanceChecklist: ReadonlyArray<GlmFleetDurabilityAcceptanceChecklistItem>
   counts: GlmFleetReadinessProjection['counts']
   missingOperatorInputs: ReadonlyArray<GlmFleetDurabilityOperatorInput>
   ownerArmedCommand: string
@@ -207,6 +219,21 @@ export const collectGlmFleetDurabilityMissingOperatorInputs = (
 ): ReadonlyArray<GlmFleetDurabilityOperatorInput> =>
   uniqueInputs(readout.blockerRefs.flatMap(ref => input(ref) ?? []))
 
+export const buildGlmFleetDurabilityAcceptanceChecklist = (
+  readout: GlmFleetReadinessOperatorReadout,
+): ReadonlyArray<GlmFleetDurabilityAcceptanceChecklistItem> =>
+  readout.dimensions.map(dimension => ({
+    blockerRefs: dimension.blockerRefs,
+    complete: dimension.status === 'complete',
+    dimension: dimension.dimension,
+    evidenceRefs: dimension.evidenceRefs,
+    missingOperatorInputs: uniqueInputs(
+      dimension.blockerRefs.flatMap(ref => input(ref) ?? []),
+    ),
+    missingReplicaRefs: dimension.missingReplicaRefs,
+    status: dimension.status,
+  }))
+
 const ownerArmedCommandLines = (
   input: Required<GlmFleetDurabilityOwnerArmedCommandInput>,
 ): ReadonlyArray<string> => [
@@ -246,6 +273,7 @@ export const buildGlmFleetDurabilityOperatorBundle = (input: {
     publicSafe: true,
     readiness,
     acceptance: input.projection.acceptance,
+    acceptanceChecklist: buildGlmFleetDurabilityAcceptanceChecklist(readiness),
     counts: input.projection.counts,
     missingOperatorInputs:
       collectGlmFleetDurabilityMissingOperatorInputs(readiness),
@@ -269,6 +297,18 @@ const statusLine = (
 
 const listOrNone = (values: ReadonlyArray<string>): string =>
   values.length === 0 ? 'none' : values.join(', ')
+
+const checklistLine = (
+  item: GlmFleetDurabilityAcceptanceChecklistItem,
+): string => {
+  const missingInputs =
+    item.missingOperatorInputs.length === 0
+      ? 'none'
+      : item.missingOperatorInputs
+          .map(input => `${input.env} [${input.flag}]`)
+          .join(', ')
+  return `- ${item.dimension}: ${item.status}; complete: ${item.complete}; blockers: ${listOrNone(item.blockerRefs)}; evidence: ${listOrNone(item.evidenceRefs)}; missing replicas: ${listOrNone(item.missingReplicaRefs)}; missing inputs: ${missingInputs}`
+}
 
 export const formatGlmFleetDurabilityOperatorReadme = (
   bundle: GlmFleetDurabilityOperatorBundle,
@@ -325,6 +365,10 @@ export const formatGlmFleetDurabilityOperatorReadme = (
       'quota request tracking',
       bundle.acceptance.quotaRequestTracking.status,
     ),
+    '',
+    '## Acceptance checklist',
+    '',
+    ...bundle.acceptanceChecklist.map(checklistLine),
     '',
     '## Operator action items',
     '',


### PR DESCRIPTION
Addresses #6311.

### Changes
- Adds a public-safe GLM fleet durability acceptance checklist to the operator bundle.
- Includes per-dimension completion status, blockers, evidence refs, missing replicas, and missing operator inputs.
- Renders the acceptance checklist in the generated durability operator README.
- Extends tests to cover blocked and complete checklist output.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).