### PR TITLE
fix(artanis): require verified codex task workspaces

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
@@ -87,13 +87,28 @@ const makeStore = (input: {
   return { created, store }
 }
 
+const workspaceVerificationCommand = (
+  assignment: PylonApiAssignmentRecord | undefined,
+): unknown => {
+  const codingAssignment = assignment?.codingAssignment
+  if (codingAssignment === null || typeof codingAssignment !== 'object') {
+    return undefined
+  }
+  const workspace = (codingAssignment as Record<string, unknown>).workspace
+  if (workspace === null || typeof workspace !== 'object') {
+    return undefined
+  }
+  return (workspace as Record<string, unknown>).verificationCommand
+}
+
 const plan: ArtanisDispatchPlanInput = {
   branch: 'main',
   filePaths: [],
   issue: 6320,
   objective: 'Burn down public issue work per the roadmap.',
   prompt: 'Implement public issue #6320. Burn down public issue work.',
-  verify: undefined,
+  verify:
+    'bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator-dispatch-execution.test.ts',
 }
 
 let idCounter = 0
@@ -116,6 +131,8 @@ const makeDeps = (overrides: {
       pylonStore: store,
       readEffectivePylonDispatchApproval: async () =>
         overrides.approved ?? false,
+      resolveCommitSha: async () =>
+        '0123456789abcdef0123456789abcdef01234567',
     },
   }
 }
@@ -151,6 +168,36 @@ describe('makeArtanisDispatchExecution (#6366 live seam)', () => {
     expect(created[0]?.jobKind).toBe('codex_agent_task')
     expect(created[0]?.ownerAgentUserId).toBe('agent_owner')
     expect(created[0]?.pylonRef).toBe('pylon.owner.codex')
+    expect(workspaceVerificationCommand(created[0])).toMatchObject({
+      commandRef: 'command.public.artanis_dispatch.verify',
+    })
+  })
+
+  test('rejects direct execution calls without a verification command', async () => {
+    const { created, deps } = makeDeps({ approved: true })
+    const execution = makeArtanisDispatchExecution(deps)
+    const result = await Effect.runPromise(
+      execution.createCodexAssignment({ ...plan, verify: undefined }),
+    )
+    expect(result).toEqual({
+      kind: 'rejected',
+      reason: 'verification_required',
+    })
+    expect(created).toHaveLength(0)
+  })
+
+  test('rejects when the verified workspace commit cannot be resolved', async () => {
+    const { created, deps } = makeDeps({ approved: true })
+    const execution = makeArtanisDispatchExecution({
+      ...deps,
+      resolveCommitSha: async () => undefined,
+    })
+    const result = await Effect.runPromise(execution.createCodexAssignment(plan))
+    expect(result).toEqual({
+      kind: 'rejected',
+      reason: 'verification_workspace_unavailable',
+    })
+    expect(created).toHaveLength(0)
   })
 
   test('rejects with no_linked_agents when the owner has no linked agents', async () => {
@@ -246,6 +293,8 @@ describe('owner-promoted Artanis dispatch EXECUTES end-to-end (gated tool)', () 
       nowIso: () => nowIso,
       ownerOpenAuthUserId: ARTANIS_OWNER_OPENAUTH_USER_ID,
       pylonStore: store,
+      resolveCommitSha: async () =>
+        '0123456789abcdef0123456789abcdef01234567',
       // Standing owner approval (what the live wiring resolves for owner-Artanis).
       readEffectivePylonDispatchApproval: () =>
         readEffectiveArtanisPylonDispatchApprovalForOwner(

--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
@@ -11,6 +11,9 @@
 //     only ever selects among the CALLER's own linked, heartbeat-fresh,
 //     Codex-capable Pylon registrations — never pooled, third-party, or
 //     marketplace capacity.
+//   - VERIFIED REPO WORK ONLY. Artanis dispatch must carry a bounded public
+//     verification command and a resolved commit SHA. If either is absent, this
+//     seam rejects instead of falling back to the fixture path.
 //   - NO SPEND. The coding-delegation path uses `paymentMode: 'unpaid_smoke'`,
 //     so no money moves, no payout is granted, and closeout settlement is
 //     `not_applicable`.
@@ -57,31 +60,29 @@ const ARTANIS_DISPATCH_EVIDENCE_REF =
 // No target Pylon ref is set: the server route auto-selects the owner's most
 // recent eligible linked Pylon (still strictly own-capacity). A workspace
 // (pinned git checkout + verification) is included only when a verify command
-// and a resolved commit SHA are both present; otherwise the route runs the
-// bounded public sum-repair fixture, which is a real own-capacity no-spend
-// `codex_agent_task` assignment.
+// and a resolved commit SHA are both present. The caller must enforce that
+// before invoking this helper; no Artanis live dispatch is allowed to fall back
+// to the fixture path.
 const buildDelegationBody = (
-  plan: ArtanisDispatchPlanInput,
-  commitSha: string | undefined,
+  plan: ArtanisDispatchPlanInput & Readonly<{ verify: string }>,
+  commitSha: string,
 ): Record<string, unknown> => {
   const coding: Record<string, unknown> = {
     objectiveSummary: plan.objective,
   }
-  if (plan.verify !== undefined && commitSha !== undefined) {
-    coding.workspace = {
-      kind: 'git_checkout',
-      repository: {
-        branch: plan.branch,
-        commitSha,
-        fullName: `${ARTANIS_REPO_READ_OWNER}/${ARTANIS_REPO_READ_REPO}`,
-        provider: 'github',
-        visibility: 'public',
-      },
-      verificationCommand: {
-        args: plan.verify.split(/\s+/).filter(arg => arg !== ''),
-        commandRef: 'command.public.artanis_dispatch.verify',
-      },
-    }
+  coding.workspace = {
+    kind: 'git_checkout',
+    repository: {
+      branch: plan.branch,
+      commitSha,
+      fullName: `${ARTANIS_REPO_READ_OWNER}/${ARTANIS_REPO_READ_REPO}`,
+      provider: 'github',
+      visibility: 'public',
+    },
+    verificationCommand: {
+      args: plan.verify.split(/\s+/).filter(arg => arg !== ''),
+      commandRef: 'command.public.artanis_dispatch.verify',
+    },
   }
   return {
     messages: [{ content: plan.prompt, role: 'user' }],
@@ -118,6 +119,10 @@ const createAssignmentPromise = async (
   plan: ArtanisDispatchPlanInput,
 ): Promise<ArtanisDispatchCreateResult> => {
   try {
+    if (plan.verify === undefined) {
+      return { kind: 'rejected', reason: 'verification_required' }
+    }
+    const verifiedPlan = { ...plan, verify: plan.verify }
     const ownerAgentUserIds = await deps.listLinkedAgentUserIds(
       deps.ownerOpenAuthUserId,
     )
@@ -129,9 +134,12 @@ const createAssignmentPromise = async (
     const requestId = deps.makeId()
     const nowIso = deps.nowIso()
     const commitSha =
-      plan.verify !== undefined && deps.resolveCommitSha !== undefined
-        ? await deps.resolveCommitSha(plan.branch).catch(() => undefined)
-        : undefined
+      deps.resolveCommitSha === undefined
+        ? undefined
+        : await deps.resolveCommitSha(verifiedPlan.branch).catch(() => undefined)
+    if (commitSha === undefined) {
+      return { kind: 'rejected', reason: 'verification_workspace_unavailable' }
+    }
 
     const result = await delegateCodingWorkflow({
       classification: {
@@ -143,7 +151,7 @@ const createAssignmentPromise = async (
       makeId: deps.makeId,
       nowIso,
       pylonStore: deps.pylonStore,
-      rawBody: buildDelegationBody(plan, commitSha),
+      rawBody: buildDelegationBody(verifiedPlan, commitSha),
       requestId,
     })
 

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -219,6 +219,19 @@ describe('#6366 dispatch_codex_task (gated; plan-only without a seam)', () => {
     expect(result.plan).toContain('src/foo.test.ts')
   })
 
+  test('requires a verification command before approval or execution', async () => {
+    const result = await Effect.runPromise(
+      tool.run({
+        objective: 'Burn down public issue work per the roadmap.',
+      }),
+    )
+    expect(result.outcome).toBe('deferred')
+    if (result.outcome !== 'deferred') return
+    expect(result.reason).toBe('invalid_arguments')
+    expect(result.plan).toContain('"verify" command is required')
+    expect(result.plan).toContain('codex_agent_task')
+  })
+
   test('blocks a dispatch field carrying non-public-safe material (deferred)', async () => {
     const result = await Effect.runPromise(
       tool.run({
@@ -259,7 +272,11 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
     })
 
     const result = await Effect.runPromise(
-      tool.run({ objective: 'Burn down public issue work per the roadmap.' }),
+      tool.run({
+        objective: 'Burn down public issue work per the roadmap.',
+        verify:
+          'bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator-tools.test.ts',
+      }),
     )
     expect(result.outcome).toBe('executed')
     if (result.outcome !== 'executed') return
@@ -291,7 +308,11 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
     })
 
     const result = await Effect.runPromise(
-      tool.run({ objective: 'Burn down public issue work per the roadmap.' }),
+      tool.run({
+        objective: 'Burn down public issue work per the roadmap.',
+        verify:
+          'bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator-tools.test.ts',
+      }),
     )
     expect(result.outcome).toBe('deferred')
     if (result.outcome !== 'deferred') return
@@ -314,7 +335,11 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
     })
 
     const result = await Effect.runPromise(
-      tool.run({ objective: 'Burn down public issue work per the roadmap.' }),
+      tool.run({
+        objective: 'Burn down public issue work per the roadmap.',
+        verify:
+          'bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator-tools.test.ts',
+      }),
     )
     expect(result.outcome).toBe('deferred')
     if (result.outcome !== 'deferred') return

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -2037,6 +2037,9 @@ export const makeArtanisUpdateUnsupportedRequestTool = (
 //   - own-capacity + no-spend ONLY (the seam targets the OWNER's linked Pylon
 //     and uses the `unpaid_smoke` coding-delegation path; it moves no money,
 //     grants no payout, and never touches pooled/third-party capacity);
+//   - required verification: Artanis-owned coding dispatch must name a bounded
+//     public verification command before it can execute. There is deliberately
+//     no arbitrary shell tool and no fixture-only escape hatch for real work.
 //   - default DEFER: with no execution seam wired, or no effective owner
 //     approval, or no eligible linked Pylon, it returns the public-safe plan
 //     plus a typed reason and never fires;
@@ -2134,6 +2137,13 @@ const buildArtanisDispatchPlan = (
       ok: false,
     }
   }
+  if (verify === undefined) {
+    return {
+      message:
+        '(invalid arguments: a public-safe "verify" command is required; Artanis coding dispatch must run through codex_agent_task with green verification before merge)',
+      ok: false,
+    }
+  }
   const badPath = filePaths.find(path => !isSafeArtanisRepoPath(path))
   if (badPath !== undefined) {
     return {
@@ -2149,9 +2159,7 @@ const buildArtanisDispatchPlan = (
   if (filePaths.length > 0) {
     promptParts.push(`Files: ${filePaths.join(', ')}.`)
   }
-  if (verify !== undefined) {
-    promptParts.push(`Run the named verification.`)
-  }
+  promptParts.push(`Run the named verification.`)
   const prompt = promptParts.join(' ')
 
   const lines: Array<string> = [
@@ -2165,9 +2173,7 @@ const buildArtanisDispatchPlan = (
     `    --branch ${branch} \\`,
     '    --commit "<current origin/main sha>" \\',
   ]
-  if (verify !== undefined) {
-    lines.push(`    --verify "${verify}" \\`)
-  }
+  lines.push(`    --verify "${verify}" \\`)
   lines.push('    --json')
   lines.push('')
   lines.push(
@@ -2188,7 +2194,9 @@ const buildArtanisDispatchPlan = (
   }
 }
 
-// dispatch_codex_task — a GATED (pylon_job_dispatch) tool. With no execution
+// dispatch_codex_task — a GATED (pylon_job_dispatch) tool. A bounded public
+// verification command is REQUIRED; Artanis does not get an arbitrary-shell
+// execution tool or a fixture-only bypass for code work. With no execution
 // seam wired (or no effective owner approval, or no eligible linked Pylon) it
 // DEFERS and returns the exact public-safe Khala -> Pylon -> Codex dispatch it
 // WOULD run. Behind an effective owner approval AND a wired execution seam it
@@ -2207,7 +2215,7 @@ export const makeArtanisDispatchCodexTaskTool = (
   return {
     definition: {
       description:
-        'Dispatch a Codex coding task through the Khala -> Pylon -> Codex burndown loop against the OWNER\'s own linked Pylon (own-capacity, NO spend, no payout). This is a gated (pylon_job_dispatch) action: it executes ONLY behind an effective owner approval; otherwise it returns the exact public-safe dispatch that would run, pending approval. Inputs MUST be public-safe (public issue numbers, public file paths, public verification commands) — no secrets, tokens, or private content.',
+        'Dispatch a Codex coding task through the Khala -> Pylon -> Codex burndown loop against the OWNER\'s own linked Pylon (own-capacity, NO spend, no payout). This is a gated (pylon_job_dispatch) action: it executes ONLY behind an effective owner approval; otherwise it returns the exact public-safe dispatch that would run, pending approval. A bounded public verify command is REQUIRED so non-spend code can merge only after green verification. Inputs MUST be public-safe (public issue numbers, public file paths, public verification commands) — no secrets, tokens, or private content.',
       name: 'dispatch_codex_task',
       parameters: {
         additionalProperties: false,
@@ -2236,7 +2244,7 @@ export const makeArtanisDispatchCodexTaskTool = (
             type: 'string',
           },
         },
-        required: ['objective'],
+        required: ['objective', 'verify'],
         type: 'object',
       },
     },

--- a/docs/artanis/2026-06-27-artanis-codex-agent-task-execution-policy.md
+++ b/docs/artanis/2026-06-27-artanis-codex-agent-task-execution-policy.md
@@ -1,0 +1,19 @@
+# Artanis Codex Agent Task Execution Policy
+
+- **Date:** 2026-06-27
+- **Scope:** Issue #6367, under epic #6359.
+
+Artanis does not get an arbitrary-shell execution tool. Owner-local coding work
+must flow through the typed Khala -> Pylon -> Codex `codex_agent_task` path so
+every action has an assignment closeout, exact downstream token rows, and an
+owner-private/public-safe trace split.
+
+The dispatch tool requires a public-safe verification command before it can
+create live work. The Worker execution seam also rejects direct calls that omit
+verification or cannot resolve the pinned commit for a verified workspace. That
+prevents fixture-only or unverifiable repository work from entering the Artanis
+burndown path.
+
+Non-spend code may be merged only after the assignment closeout reports green
+verification/proof. Spend, settlement, wallet, deployment, runtime promotion,
+and other risky actions remain behind the Artanis approval-gate ledger.


### PR DESCRIPTION
Addresses #6367.

### Changes
- Require Artanis `codex_agent_task` dispatches to include a verification command before creating an assignment.
- Resolve and require a commit SHA so live dispatch uses a pinned public git checkout workspace instead of falling back to the fixture path.
- Add coverage for accepted workspace verification metadata and rejection cases when verification or workspace resolution is missing.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).