### PR TITLE
fix(inference): summarize GLM NVFP4 serving stack findings

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/glm-nvfp4-pilot-operator.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/glm-nvfp4-pilot-operator.test.ts
@@ -165,4 +165,68 @@ describe('GLM NVFP4 pilot operator path (#6323)', () => {
     expect(retained).not.toContain('prompt.private.quality')
     expect(retained).not.toContain('wallet.private.boot.load')
   })
+
+  test('summarizes public serving-stack no-go findings for operator handoff', () => {
+    const localConfig = config({
+      ownerArmed: true,
+      ownerApprovalRef: 'approval.public.khala.glm_nvfp4.owner_armed.001',
+      endpointUrl: 'https://pilot.internal.example.invalid/v1',
+      endpointRef: 'endpoint.public.khala.glm_nvfp4.single_host_8x.001',
+      decisionRef:
+        'decision.public.khala.glm_nvfp4.issue_6323.no_go_generation_001',
+      bootLoadStatus: 'passed',
+      bootLoadEvidenceRef:
+        'evidence.public.khala.glm_nvfp4.boot_load.model_list_001',
+      measuredMaxModelLen: 65536,
+      measuredMaxModelLenEvidenceRef:
+        'evidence.public.khala.glm_nvfp4.max_model_len.65536.001',
+      servingStackFindings: [
+        {
+          engine: 'sglang',
+          status: 'failed_during_generation',
+          failureCode: 'sglang_trtllm_sm120_unsupported',
+          evidenceRef:
+            'evidence.public.khala.glm_nvfp4.sglang_trtllm_sm120.001',
+        },
+        {
+          engine: 'sglang',
+          status: 'failed_during_generation',
+          failureCode: 'sglang_tilelang_sm120_compile_failure',
+          evidenceRef:
+            'evidence.public.khala.glm_nvfp4.sglang_tilelang_sm120.001',
+        },
+      ],
+    })
+    const result = buildGlmNvfp4PilotResult({ config: localConfig })
+    const bundle = buildGlmNvfp4PilotOperatorBundle({
+      config: localConfig,
+      result,
+      outputDir: '.pilot-evidence/glm-nvfp4-6323-sm120-generation-no-go',
+    })
+    const readme = formatGlmNvfp4PilotOperatorReadme(bundle)
+
+    expect(bundle.servingStackSummary).toEqual({
+      findingCount: 2,
+      failedBeforeEndpointCount: 0,
+      failedDuringGenerationCount: 2,
+      endpointHealthyCount: 0,
+      failureCodes: [
+        'sglang_tilelang_sm120_compile_failure',
+        'sglang_trtllm_sm120_unsupported',
+      ],
+      evidenceRefs: [
+        'evidence.public.khala.glm_nvfp4.sglang_tilelang_sm120.001',
+        'evidence.public.khala.glm_nvfp4.sglang_trtllm_sm120.001',
+      ],
+      nextAction: 'fix_generation_backend',
+    })
+    expect(readme).toContain('## Serving Stack Findings')
+    expect(readme).toContain('Next action: fix_generation_backend')
+    expect(readme).toContain(
+      '- sglang failed_during_generation sglang_trtllm_sm120_unsupported evidence.public.khala.glm_nvfp4.sglang_trtllm_sm120.001',
+    )
+    expect(JSON.stringify(bundle) + readme).not.toContain(
+      'pilot.internal.example.invalid',
+    )
+  })
 })

--- a/apps/openagents.com/workers/api/src/inference/glm-nvfp4-pilot-operator.ts
+++ b/apps/openagents.com/workers/api/src/inference/glm-nvfp4-pilot-operator.ts
@@ -6,6 +6,7 @@ import {
   type GlmNvfp4PilotEvidenceRefField,
   type GlmNvfp4PilotPublicSummary,
   type GlmNvfp4PilotResult,
+  type GlmNvfp4ServingStackFailureCode,
 } from './glm-nvfp4-pilot'
 
 export const GLM_NVFP4_PILOT_OPERATOR_BUNDLE_SCHEMA =
@@ -24,6 +25,22 @@ export type GlmNvfp4PilotOwnerArmedCommandInput = Readonly<{
   measuredMaxModelLen?: number | undefined
 }>
 
+export type GlmNvfp4PilotServingStackNextAction =
+  | 'fix_boot_load'
+  | 'fix_generation_backend'
+  | 'run_owner_armed_pilot'
+  | 'record_tool_quality_throughput_evidence'
+
+export type GlmNvfp4PilotServingStackSummary = Readonly<{
+  findingCount: number
+  failedBeforeEndpointCount: number
+  failedDuringGenerationCount: number
+  endpointHealthyCount: number
+  failureCodes: ReadonlyArray<GlmNvfp4ServingStackFailureCode>
+  evidenceRefs: ReadonlyArray<string>
+  nextAction: GlmNvfp4PilotServingStackNextAction
+}>
+
 export type GlmNvfp4PilotOperatorBundle = Readonly<{
   schemaVersion: typeof GLM_NVFP4_PILOT_OPERATOR_BUNDLE_SCHEMA
   generatedAt: string
@@ -31,6 +48,7 @@ export type GlmNvfp4PilotOperatorBundle = Readonly<{
   publicSafe: true
   result: GlmNvfp4PilotResult
   summary: GlmNvfp4PilotPublicSummary
+  servingStackSummary: GlmNvfp4PilotServingStackSummary
   missingOperatorInputs: ReadonlyArray<GlmNvfp4PilotOperatorInput>
   ownerArmedCommand: string
   retentionNotes: ReadonlyArray<string>
@@ -232,12 +250,58 @@ export const collectGlmNvfp4PilotMissingOperatorInputs = (input: {
   ]
 }
 
+export const summarizeGlmNvfp4PilotServingStack = (
+  result: GlmNvfp4PilotResult,
+): GlmNvfp4PilotServingStackSummary => {
+  const failedBeforeEndpoint = result.servingStackFindings.filter(
+    finding => finding.status === 'failed_before_endpoint',
+  )
+  const failedDuringGeneration = result.servingStackFindings.filter(
+    finding => finding.status === 'failed_during_generation',
+  )
+  const endpointHealthy = result.servingStackFindings.filter(
+    finding => finding.status === 'endpoint_healthy',
+  )
+  const failureCodes = [
+    ...new Set(
+      result.servingStackFindings.flatMap(finding =>
+        finding.failureCode === null ? [] : [finding.failureCode],
+      ),
+    ),
+  ].sort()
+  const evidenceRefs = [
+    ...new Set(
+      result.servingStackFindings.flatMap(finding =>
+        finding.evidenceRef === null ? [] : [finding.evidenceRef],
+      ),
+    ),
+  ].sort()
+
+  return {
+    findingCount: result.servingStackFindings.length,
+    failedBeforeEndpointCount: failedBeforeEndpoint.length,
+    failedDuringGenerationCount: failedDuringGeneration.length,
+    endpointHealthyCount: endpointHealthy.length,
+    failureCodes,
+    evidenceRefs,
+    nextAction:
+      failedBeforeEndpoint.length > 0
+        ? 'fix_boot_load'
+        : failedDuringGeneration.length > 0
+          ? 'fix_generation_backend'
+          : result.toolLoop.sampleCount === 0
+            ? 'run_owner_armed_pilot'
+            : 'record_tool_quality_throughput_evidence',
+  }
+}
+
 export const buildGlmNvfp4PilotOperatorBundle = (input: {
   config: GlmNvfp4PilotConfig
   result: GlmNvfp4PilotResult
   outputDir?: string | undefined
 }): GlmNvfp4PilotOperatorBundle => {
   const summary = summarizeGlmNvfp4PilotResult(input.result)
+  const servingStackSummary = summarizeGlmNvfp4PilotServingStack(input.result)
   return {
     schemaVersion: GLM_NVFP4_PILOT_OPERATOR_BUNDLE_SCHEMA,
     generatedAt: input.result.generatedAt,
@@ -245,6 +309,7 @@ export const buildGlmNvfp4PilotOperatorBundle = (input: {
     publicSafe: true,
     result: input.result,
     summary,
+    servingStackSummary,
     missingOperatorInputs: collectGlmNvfp4PilotMissingOperatorInputs(input),
     ownerArmedCommand: buildGlmNvfp4PilotOwnerArmedCommand({
       outputDir: input.outputDir,
@@ -274,6 +339,15 @@ export const formatGlmNvfp4PilotOperatorReadme = (
               `- ${input.env} (${input.flag}): ${input.status}; ${input.label}`,
           )
           .join('\n')
+  const servingStackFindings =
+    bundle.result.servingStackFindings.length === 0
+      ? '- none'
+      : bundle.result.servingStackFindings
+          .map(
+            finding =>
+              `- ${finding.engine} ${finding.status} ${finding.failureCode ?? 'none'} ${finding.evidenceRef ?? 'no_public_ref'}`,
+          )
+          .join('\n')
 
   return [
     '# GLM NVFP4 Pilot Evidence Bundle',
@@ -286,6 +360,12 @@ export const formatGlmNvfp4PilotOperatorReadme = (
     '## Missing Operator Inputs',
     '',
     missingInputs,
+    '',
+    '## Serving Stack Findings',
+    '',
+    `Next action: ${bundle.servingStackSummary.nextAction}`,
+    '',
+    servingStackFindings,
     '',
     '## Owner-Armed Command Template',
     '',


### PR DESCRIPTION
Addresses #6323.

### Changes
- Added a public-safe serving stack summary to the GLM NVFP4 pilot operator bundle, including finding counts, failure codes, evidence refs, and next action selection.
- Added README output for serving stack findings so operator handoff includes generation/backend no-go evidence without exposing private endpoint details.
- Added test coverage for SM120 generation no-go findings and public-safe bundle formatting.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).