### PR TITLE
feat(pro): add operator agent dashboard

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/pro.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/pro.ts
@@ -16,10 +16,9 @@ import { SAMPLE_TRACE_UUID } from '../../trace/sample'
 // /pro — operator / power-user console SHELL (issue 6179)
 // ---------------------------------------------------------------------------
 //
-// This module ships the FRAME + the teaching Overview empty state only. The real
-// operator features (run/session inspector, operator actions, the
-// hosted-executor view, real usage metering, connect-a-coding-agent) are
-// explicit follow-ups per docs/pro/2026-06-24-pro-operator-ui-revival-audit.md.
+// This module ships the FRAME + a bounded operator dashboard model. The live
+// ingest/send endpoints remain explicit follow-ups; this page only renders
+// public-safe sample state that matches the production contract shape.
 //
 // All class-bearing markup lives in the shared `@openagentsinc/ui` Pro console
 // primitives (proConsoleShell / proTopStrip / proRegister / ...). This page only
@@ -36,31 +35,139 @@ const tracesHref = traceRouter({ uuid: SAMPLE_TRACE_UUID })
 const compareHref = traceCompareRouter({ ids: SAMPLE_COMPARE_PATH_IDS })
 
 const SECTIONS: ReadonlyArray<Ui.ProConsoleSection> = [
-  { label: 'Overview', active: true, href: proRouter() },
+  { label: 'Agents', active: true, href: proRouter() },
   { label: 'Traces', href: tracesHref },
   { label: 'Compare', href: compareHref },
   { label: 'Sessions', disabled: true },
   { label: 'Settings', disabled: true },
 ]
 
-const overviewEmptyState = (): Html =>
-  Ui.proTeachingEmptyState<Message>({
-    title: 'Pro is a power-user operator console',
-    body: 'Run, inspect, and review machine work in one place. Sharing lives at /trace — every run renders as a public, shareable trace, and several runs compare side by side.',
-    footnote:
-      'Open a shared trace to see the full step timeline; open a comparison to see how config or MCP changes move verdict, latency, steps, and cost.',
-    affordances: [
-      Ui.proLinkAffordance<Message>({
-        label: 'View a shared trace',
-        href: tracesHref,
-      }),
-      Ui.proLinkAffordance<Message>({ label: 'Compare traces', href: compareHref }),
-      Ui.proComingAffordance<Message>({
-        label: 'Connect a coding agent',
-        hint: 'Connecting a coding agent is coming — not active yet.',
-      }),
-    ],
-  })
+const agentDashboardSnapshot: Ui.ProAgentDashboardSnapshot = {
+  generatedAt: '2026-06-27T18:44:00Z',
+  liveEntries: [
+    {
+      id: 'pane.codex-1',
+      agentLabel: 'Codex lane 1',
+      worktreeLabel: 'issue-6406-agent-dashboard',
+      state: 'working',
+      prompt: 'Build the operator dashboard status model and review queue.',
+      updatedAt: '18:43:58Z',
+      stateStartedAt: '18:36:14Z',
+      acknowledgedAt: '18:31:09Z',
+      unread: true,
+      toolName: 'bun test',
+      lastAssistantMessage:
+        'Status model is shaped; wiring the Pro surface and scene coverage now.',
+      stateHistory: [
+        {
+          state: 'waiting',
+          label: 'Workspace materialized',
+          at: '18:31Z',
+        },
+        {
+          state: 'working',
+          label: 'Dashboard implementation started',
+          at: '18:36Z',
+        },
+      ],
+    },
+    {
+      id: 'pane.claude-1',
+      agentLabel: 'Claude lane 1',
+      worktreeLabel: 'status-ingest-runbook',
+      state: 'blocked',
+      prompt: 'Verify owner-scoped status ingest prerequisites.',
+      updatedAt: '18:42:10Z',
+      stateStartedAt: '18:39:02Z',
+      acknowledgedAt: '18:39:02Z',
+      unread: false,
+      toolName: 'owner gate',
+      lastAssistantMessage:
+        'NEEDS-OWNER: confirm the live relay endpoint before enabling send.',
+      stateHistory: [
+        {
+          state: 'working',
+          label: 'Read relay docs',
+          at: '18:33Z',
+        },
+        {
+          state: 'blocked',
+          label: 'Owner endpoint confirmation needed',
+          at: '18:39Z',
+        },
+      ],
+    },
+    {
+      id: 'pane.opencode-1',
+      agentLabel: 'OpenCode lane',
+      worktreeLabel: 'future-runner-fixture',
+      state: 'waiting',
+      prompt: 'Hold for runner registry integration.',
+      updatedAt: '18:40:25Z',
+      stateStartedAt: '18:40:25Z',
+      acknowledgedAt: '18:40:25Z',
+      unread: false,
+      toolName: 'queue',
+      lastAssistantMessage:
+        'Waiting for a registry-backed runner before assignment.',
+      stateHistory: [
+        {
+          state: 'waiting',
+          label: 'Queued behind available Codex capacity',
+          at: '18:40Z',
+        },
+      ],
+    },
+  ],
+  retainedEntries: [
+    {
+      id: 'pane.codex-0',
+      agentLabel: 'Codex lane 0',
+      worktreeLabel: 'trace-compare-polish',
+      state: 'done',
+      prompt: 'Retain the completed run until the operator dismisses it.',
+      updatedAt: '18:22:31Z',
+      stateStartedAt: '18:22:31Z',
+      acknowledgedAt: '18:25:00Z',
+      unread: false,
+      toolName: 'verify',
+      lastAssistantMessage:
+        'Proof-ready with public trace refs; retained for review.',
+      stateHistory: [
+        {
+          state: 'working',
+          label: 'Compared trace variants',
+          at: '18:07Z',
+        },
+        {
+          state: 'done',
+          label: 'Verification completed',
+          at: '18:22Z',
+        },
+      ],
+    },
+  ],
+  diffComments: [
+    {
+      id: 'diff-comment-1',
+      filePath: 'apps/openagents.com/apps/web/src/page/loggedIn/page/pro.ts',
+      lineLabel: 'agent dashboard',
+      body: 'Keep stateStartedAt distinct from updatedAt so tool pings do not clear unread state.',
+      selectedText: 'stateStartedAt drives unread; updatedAt only shows freshness.',
+      targetAgentLabel: 'Codex lane 1',
+      sentAt: 'staged',
+    },
+    {
+      id: 'diff-comment-2',
+      filePath: 'packages/ui/src/pro.ts',
+      lineLabel: 'diff queue',
+      body: 'Group queued review comments by target agent before enabling the send endpoint.',
+      selectedText: 'diffComments are retained as operator review intent.',
+      targetAgentLabel: 'Claude lane 1',
+      sentAt: 'staged',
+    },
+  ],
+}
 
 // LOADING STATE: skeleton rows (not a center spinner). Exported so the shell can
 // render it while the future run/session index is fetching.
@@ -89,7 +196,9 @@ export const view = (session: Session): Html =>
   Ui.proConsoleShell<Message>({
     topStrip: topStrip(session),
     register: Ui.proRegister<Message>(SECTIONS),
-    main: Ui.proMainPane<Message>([overviewEmptyState()]),
+    main: Ui.proMainPane<Message>([
+      Ui.proAgentDashboard<Message>(agentDashboardSnapshot),
+    ]),
   })
 
 // A safe forward path for any "go back" affordance the shell may need.

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
@@ -1782,9 +1782,9 @@ describe('logged-in workroom sidebar', () => {
     )
   })
 
-  test('renders the /pro operator console shell + teaching Overview for any signed-in user', () => {
+  test('renders the /pro operator dashboard for any signed-in user', () => {
     // Explicitly a NON-admin, NON-Core-Team user: /pro is open to any signed-in
-    // user, so the console shell + teaching empty state must render for them.
+    // user, so the console shell + operator dashboard must render for them.
     const plainUser: AuthBootstrap = { ...auth, isAdmin: false, teams: [] }
 
     Scene.scene(
@@ -1802,25 +1802,48 @@ describe('logged-in workroom sidebar', () => {
         Scene.selector('[data-component="pro-top-strip"]'),
       ).toExist(),
       Scene.expect(Scene.selector('[data-component="pro-register"]')).toExist(),
-      // The teaching Overview empty state with its honest forward affordances.
       Scene.expect(
-        Scene.selector('[data-component="pro-overview-empty"]'),
+        Scene.selector('[data-component="pro-agent-dashboard-summary"]'),
       ).toExist(),
       Scene.expect(
         Scene.role('heading', {
-          name: 'Pro is a power-user operator console',
+          name: 'Agent operations',
         }),
       ).toExist(),
-      // #6215: sharing lives at /trace, so the console links out to the public
-      // shareable trace surfaces as LIVE affordances.
+      Scene.expect(Scene.text('Live agents')).toExist(),
+      Scene.expect(Scene.text('Retained agents')).toExist(),
+      Scene.expect(Scene.text('Codex lane 1')).toExist(),
+      Scene.expect(Scene.text('Claude lane 1')).toExist(),
+      Scene.expect(Scene.text('OpenCode lane')).toExist(),
+      Scene.expect(Scene.text('Codex lane 0')).toExist(),
+      Scene.expect(Scene.text('working')).toExist(),
+      Scene.expect(Scene.text('blocked')).toExist(),
+      Scene.expect(Scene.text('waiting')).toExist(),
+      Scene.expect(Scene.text('done')).toExist(),
+      Scene.expect(Scene.text('unread')).toExist(),
+      Scene.expect(Scene.text('stateStartedAt')).toExist(),
+      Scene.expect(Scene.text('stateHistory')).toExist(),
       Scene.expect(
-        Scene.role('link', { name: 'View a shared trace' }),
+        Scene.text(
+          'Keep stateStartedAt distinct from updatedAt so tool pings do not clear unread state.',
+        ),
       ).toExist(),
-      Scene.expect(Scene.role('link', { name: 'Compare traces' })).toExist(),
-      // The remaining forward affordance stays an honest disabled placeholder.
+      Scene.expect(Scene.text('Annotate diff -> ship back')).toExist(),
       Scene.expect(
-        Scene.role('button', { name: 'Connect a coding agent' }),
+        Scene.selector('[data-component="pro-diff-comment-queue"]'),
+      ).toExist(),
+      Scene.expect(
+        Scene.role('button', { name: 'Send comments' }),
       ).toBeDisabled(),
+      // #6215: sharing lives at /trace, so the console links out to the public
+      // shareable trace surfaces from the section register.
+      Scene.expect(
+        Scene.role('link', { name: 'Traces' }),
+      ).toHaveAttr('href', '/trace/0e08d2db-2026-4624-9a39-f1efe8000001'),
+      Scene.expect(Scene.role('link', { name: 'Compare' })).toHaveAttr(
+        'href',
+        '/trace/compare/0e08d2db-2026-4624-9a39-f1efe8000001,0e08d2db-2026-4624-9a39-f1efe8000002,0e08d2db-2026-4624-9a39-f1efe8000003',
+      ),
     )
   })
 

--- a/packages/ui/src/pro.ts
+++ b/packages/ui/src/pro.ts
@@ -378,6 +378,413 @@ export const proMainPane = <Message>(children: ReadonlyArray<Html>): Html => {
   )
 }
 
+export type ProAgentState = 'working' | 'blocked' | 'waiting' | 'done'
+
+export type ProAgentStateHistoryEntry = Readonly<{
+  state: ProAgentState
+  label: string
+  at: string
+}>
+
+export type ProAgentStatusEntry = Readonly<{
+  id: string
+  agentLabel: string
+  worktreeLabel: string
+  state: ProAgentState
+  prompt: string
+  updatedAt: string
+  stateStartedAt: string
+  acknowledgedAt: string
+  unread: boolean
+  toolName: string
+  lastAssistantMessage: string
+  stateHistory: ReadonlyArray<ProAgentStateHistoryEntry>
+}>
+
+export type ProDiffComment = Readonly<{
+  id: string
+  filePath: string
+  lineLabel: string
+  body: string
+  selectedText: string
+  targetAgentLabel: string
+  sentAt: string
+}>
+
+export type ProAgentDashboardSnapshot = Readonly<{
+  generatedAt: string
+  liveEntries: ReadonlyArray<ProAgentStatusEntry>
+  retainedEntries: ReadonlyArray<ProAgentStatusEntry>
+  diffComments: ReadonlyArray<ProDiffComment>
+}>
+
+const proAgentStateLabel = (state: ProAgentState): string =>
+  state === 'working'
+    ? 'working'
+    : state === 'blocked'
+      ? 'blocked'
+      : state === 'waiting'
+        ? 'waiting'
+        : 'done'
+
+const proAgentStateClass = (state: ProAgentState): string =>
+  state === 'working'
+    ? 'border-[#2979ff]/45 text-[#8fb6ff]'
+    : state === 'blocked'
+      ? 'border-[#ff6f00]/55 text-[#ffb400]'
+      : state === 'waiting'
+        ? 'border-white/20 text-white/45'
+        : 'border-[#00c853]/45 text-[#00c853]'
+
+const proAgentStatePill = <Message>(state: ProAgentState): Html => {
+  const h = html<Message>()
+
+  return h.span(
+    [
+      h.DataAttribute('component', 'pro-agent-state-pill'),
+      h.DataAttribute('state', state),
+      h.Class(
+        clsx(
+          'inline-flex items-center border px-1.5 py-0.5 text-[0.625rem] font-semibold uppercase tracking-[0.1em]',
+          proAgentStateClass(state),
+        ),
+      ),
+    ],
+    [proAgentStateLabel(state)],
+  )
+}
+
+const proAgentStatusRow = <Message>(
+  entry: ProAgentStatusEntry,
+  retention: 'live' | 'retained',
+): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    [
+      h.DataAttribute('component', 'pro-agent-status-row'),
+      h.DataAttribute('agent-status-retention', retention),
+      h.DataAttribute('agent-state-started-at', entry.stateStartedAt),
+      h.DataAttribute('agent-updated-at', entry.updatedAt),
+      h.Class(
+        clsx(
+          'grid gap-3 border bg-[#010102] px-3 py-2.5',
+          entry.unread === true ? 'border-[#ffb400]/60' : 'border-[#222]',
+        ),
+      ),
+    ],
+    [
+      h.div(
+        [
+          h.Class(
+            'grid gap-2 md:grid-cols-[minmax(0,1fr)_auto] md:items-start',
+          ),
+        ],
+        [
+          h.div(
+            [h.Class('grid min-w-0 gap-1')],
+            [
+              h.div(
+                [h.Class('flex min-w-0 flex-wrap items-center gap-2')],
+                [
+                  h.h3(
+                    [h.Class('m-0 truncate text-sm font-semibold text-[#f1efe8]')],
+                    [entry.agentLabel],
+                  ),
+                  proAgentStatePill<Message>(entry.state),
+                  ...(entry.unread === true
+                    ? [
+                        h.span(
+                          [
+                            h.DataAttribute('component', 'pro-agent-unread'),
+                            h.Class(
+                              'border border-[#ffb400]/45 px-1.5 py-0.5 text-[0.625rem] uppercase tracking-[0.1em] text-[#ffb400]',
+                            ),
+                          ],
+                          ['unread'],
+                        ),
+                      ]
+                    : []),
+                ],
+              ),
+              h.p([h.Class('m-0 text-xs leading-[1.5] text-white/55')], [
+                entry.prompt,
+              ]),
+            ],
+          ),
+          h.dl(
+            [
+              h.Class(
+                'm-0 grid gap-1 text-[0.6875rem] text-white/45 sm:grid-cols-2 md:min-w-72',
+              ),
+            ],
+            [
+              h.div([h.Class('grid gap-0.5')], [
+                h.dt([h.Class('uppercase tracking-[0.08em] text-white/25')], [
+                  'worktree',
+                ]),
+                h.dd([h.Class('m-0 truncate text-white/60')], [
+                  entry.worktreeLabel,
+                ]),
+              ]),
+              h.div([h.Class('grid gap-0.5')], [
+                h.dt([h.Class('uppercase tracking-[0.08em] text-white/25')], [
+                  'stateStartedAt',
+                ]),
+                h.dd([h.Class('m-0 text-white/60')], [entry.stateStartedAt]),
+              ]),
+              h.div([h.Class('grid gap-0.5')], [
+                h.dt([h.Class('uppercase tracking-[0.08em] text-white/25')], [
+                  'updatedAt',
+                ]),
+                h.dd([h.Class('m-0 text-white/60')], [entry.updatedAt]),
+              ]),
+              h.div([h.Class('grid gap-0.5')], [
+                h.dt([h.Class('uppercase tracking-[0.08em] text-white/25')], [
+                  'ack',
+                ]),
+                h.dd([h.Class('m-0 text-white/60')], [entry.acknowledgedAt]),
+              ]),
+            ],
+          ),
+        ],
+      ),
+      h.div(
+        [
+          h.Class(
+            'grid gap-2 border-t border-[#222] pt-2 md:grid-cols-[minmax(0,1fr)_minmax(18rem,0.85fr)]',
+          ),
+        ],
+        [
+          h.div([h.Class('grid gap-1')], [
+            h.span(
+              [
+                h.Class(
+                  'text-[0.625rem] font-semibold uppercase tracking-[0.1em] text-white/25',
+                ),
+              ],
+              ['last assistant'],
+            ),
+            h.p([h.Class('m-0 text-xs leading-[1.5] text-white/55')], [
+              entry.lastAssistantMessage,
+            ]),
+          ]),
+          h.div([h.Class('grid gap-1')], [
+            h.span(
+              [
+                h.Class(
+                  'text-[0.625rem] font-semibold uppercase tracking-[0.1em] text-white/25',
+                ),
+              ],
+              ['stateHistory'],
+            ),
+            h.ol(
+              [h.Class('m-0 grid list-none gap-1 p-0')],
+              entry.stateHistory.map(history =>
+                h.li(
+                  [
+                    h.DataAttribute('component', 'pro-agent-history-entry'),
+                    h.Class(
+                      'grid grid-cols-[4.5rem_minmax(0,1fr)_5.5rem] gap-2 text-[0.6875rem]',
+                    ),
+                  ],
+                  [
+                    h.span([h.Class('text-white/35')], [history.at]),
+                    h.span([h.Class('truncate text-white/60')], [history.label]),
+                    h.span([h.Class('text-right text-white/35')], [
+                      proAgentStateLabel(history.state),
+                    ]),
+                  ],
+                ),
+              ),
+            ),
+          ]),
+        ],
+      ),
+    ],
+  )
+}
+
+const proAgentStatusList = <Message>(input: {
+  label: string
+  retention: 'live' | 'retained'
+  entries: ReadonlyArray<ProAgentStatusEntry>
+}): Html => {
+  const h = html<Message>()
+
+  return proConsoleSection2<Message>(input.label, [
+    h.ul(
+      [
+        h.DataAttribute('component', `pro-agent-status-${input.retention}`),
+        h.Class('m-0 grid list-none gap-2 p-0'),
+      ],
+      input.entries.map(entry =>
+        proAgentStatusRow<Message>(entry, input.retention),
+      ),
+    ),
+  ])
+}
+
+const proDiffCommentRow = <Message>(comment: ProDiffComment): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    [
+      h.DataAttribute('component', 'pro-diff-comment-row'),
+      h.Class(
+        'grid gap-2 border border-[#222] bg-[#010102] px-3 py-2.5 md:grid-cols-[minmax(0,1fr)_minmax(14rem,0.55fr)]',
+      ),
+    ],
+    [
+      h.div([h.Class('grid min-w-0 gap-1.5')], [
+        h.div([h.Class('flex min-w-0 flex-wrap items-center gap-2')], [
+          proCodeRef<Message>(`${comment.filePath}:${comment.lineLabel}`),
+          h.span([h.Class('text-xs text-white/35')], [
+            `target ${comment.targetAgentLabel}`,
+          ]),
+        ]),
+        h.p([h.Class('m-0 text-sm leading-[1.5] text-[#f1efe8]')], [
+          comment.body,
+        ]),
+        h.blockquote(
+          [
+            h.Class(
+              'm-0 border border-[#222] bg-[#080808] px-2 py-1.5 text-xs leading-[1.45] text-white/45',
+            ),
+          ],
+          [comment.selectedText],
+        ),
+      ]),
+      h.div([h.Class('grid content-between gap-3')], [
+        h.div([h.Class('grid gap-1 text-xs text-white/45')], [
+          h.span(
+            [
+              h.Class(
+                'text-[0.625rem] font-semibold uppercase tracking-[0.1em] text-white/25',
+              ),
+            ],
+            ['ship-back queue'],
+          ),
+          h.span([], [`sentAt ${comment.sentAt}`]),
+        ]),
+        button<Message>({
+          label: 'Send comments',
+          variant: 'secondary',
+          size: 'sm',
+          attrs: [
+            h.Disabled(true),
+            h.AriaDisabled(true),
+            h.Title('Staged until the live agent-send endpoint is connected.'),
+            h.DataAttribute('component', 'pro-diff-send-action'),
+            h.Class('justify-self-start cursor-not-allowed opacity-50'),
+          ],
+        }),
+      ]),
+    ],
+  )
+}
+
+const proDiffCommentQueue = <Message>(
+  comments: ReadonlyArray<ProDiffComment>,
+): Html => {
+  const h = html<Message>()
+
+  return proConsoleSection2<Message>('Annotate diff -> ship back', [
+    h.div(
+      [
+        h.DataAttribute('component', 'pro-diff-comment-queue'),
+        h.Class('grid gap-2'),
+      ],
+      [
+        h.p([h.Class('m-0 max-w-[72ch] text-xs leading-[1.55] text-white/45')], [
+          'Line comments are retained as review intent and grouped by target agent. Live sending stays disabled until the owner-scoped agent-send endpoint is wired.',
+        ]),
+        h.ul(
+          [h.Class('m-0 grid list-none gap-2 p-0')],
+          comments.map(proDiffCommentRow<Message>),
+        ),
+      ],
+    ),
+  ])
+}
+
+const proDashboardSummary = <Message>(
+  snapshot: ProAgentDashboardSnapshot,
+): Html => {
+  const h = html<Message>()
+  const activeCount = snapshot.liveEntries.length.toString()
+  const retainedCount = snapshot.retainedEntries.length.toString()
+  const commentCount = snapshot.diffComments.length.toString()
+
+  return h.div(
+    [
+      h.DataAttribute('component', 'pro-agent-dashboard-summary'),
+      h.Class(
+        'grid gap-2 border-b border-[#222] pb-4 md:grid-cols-[minmax(0,1fr)_auto]',
+      ),
+    ],
+    [
+      h.div([h.Class('grid gap-1')], [
+        h.h1(
+          [h.Class('m-0 text-base font-semibold tracking-[0.01em] text-[#f1efe8]')],
+          ['Agent operations'],
+        ),
+        h.p([h.Class('m-0 max-w-[72ch] text-sm leading-[1.55] text-white/55')], [
+          'Live and retained agent status entries use stateStartedAt for unread tracking, keep a bounded stateHistory, and stage diff annotations for operator review.',
+        ]),
+      ]),
+      h.dl(
+        [
+          h.Class(
+            'm-0 grid grid-cols-3 gap-2 text-center text-xs sm:min-w-[24rem]',
+          ),
+        ],
+        [
+          h.div([h.Class('border border-[#222] bg-[#010102] px-2 py-2')], [
+            h.dt([h.Class('text-white/30')], ['live']),
+            h.dd([h.Class('m-0 text-sm font-semibold text-[#f1efe8]')], [
+              activeCount,
+            ]),
+          ]),
+          h.div([h.Class('border border-[#222] bg-[#010102] px-2 py-2')], [
+            h.dt([h.Class('text-white/30')], ['retained']),
+            h.dd([h.Class('m-0 text-sm font-semibold text-[#f1efe8]')], [
+              retainedCount,
+            ]),
+          ]),
+          h.div([h.Class('border border-[#222] bg-[#010102] px-2 py-2')], [
+            h.dt([h.Class('text-white/30')], ['comments']),
+            h.dd([h.Class('m-0 text-sm font-semibold text-[#f1efe8]')], [
+              commentCount,
+            ]),
+          ]),
+        ],
+      ),
+      h.p([h.Class('m-0 text-xs text-white/35 md:col-span-2')], [
+        `Generated ${snapshot.generatedAt}. Public-safe sample data only; no private prompts, raw logs, wallet material, or provider payloads are rendered.`,
+      ]),
+    ],
+  )
+}
+
+export const proAgentDashboard = <Message>(
+  snapshot: ProAgentDashboardSnapshot,
+): Html =>
+  proConsoleStack<Message>([
+    proDashboardSummary<Message>(snapshot),
+    proAgentStatusList<Message>({
+      label: 'Live agents',
+      retention: 'live',
+      entries: snapshot.liveEntries,
+    }),
+    proAgentStatusList<Message>({
+      label: 'Retained agents',
+      retention: 'retained',
+      entries: snapshot.retainedEntries,
+    }),
+    proDiffCommentQueue<Message>(snapshot.diffComments),
+  ])
+
 // ---------------------------------------------------------------------------
 // Runs + evals surfaces (issue 6184)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses #6406.

### Changes
- Replaced the `/pro` teaching overview with a public-safe operator dashboard snapshot showing agent lanes, worktree state, unread status, state history, and retained completed work.
- Added shared Pro UI primitives for the agent status dashboard and diff comment review queue.
- Updated logged-in scene coverage to assert the new operator dashboard, agent status store shape, and annotate-diff review loop affordances.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).