### PR TITLE
feat(api): expose trace underwriting projection

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -1000,6 +1000,10 @@ import {
   TrainingPublicGradientWindowsEndpoint,
   handleTrainingPublicGradientWindowsApi,
 } from './training-public-gradient-windows-routes'
+import {
+  TraceEconomicUnderwritingEndpoint,
+  handleTraceEconomicUnderwritingApi,
+} from './trace-economic-underwriting-routes'
 import { handleVerifiedOutcomeReputationApi } from './verified-outcome-reputation-routes'
 import {
   buildTrainingWindowRecord,
@@ -10327,6 +10331,15 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     // identity, or spend authority.
     path: '/api/public/reputation/verified-outcomes',
     handler: request => handleVerifiedOutcomeReputationApi(request),
+  },
+  {
+    // Public trace-economic underwriting readiness projection (#6426). Read-only
+    // evidence surface over trace/verdict/settlement/metering receipts; models
+    // refund-on-rejection and verified-outcome-SLA shapes without binding
+    // policies, quoting premiums, adjudicating claims, moving money, or granting
+    // public risk-market authority.
+    path: TraceEconomicUnderwritingEndpoint,
+    handler: request => handleTraceEconomicUnderwritingApi(request),
   },
   {
     // Public-safe live Gym / Harbor run progress (#6261). web_authorized runs

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -33,6 +33,7 @@ import { TrainingPostTrainingInstructSftEndpoint } from './training-post-trainin
 import { TrainingPostTrainingVibeTestRubricEndpoint } from './training-post-training-vibe-test-rubric'
 import { TrainingPublicDistributedRunScaleEndpoint } from './training-public-distributed-run-scale'
 import { TrainingPublicGradientWindowsEndpoint } from './training-public-gradient-windows'
+import { TraceEconomicUnderwritingEndpoint } from './trace-economic-underwriting'
 import { VerifiedOutcomeReputationEndpoint } from './verified-outcome-reputation'
 
 export const OpenAgentsOpenApiEndpoint = '/api/openapi.json'
@@ -1618,6 +1619,9 @@ const schemaComponents = (): JsonSchema => ({
   ),
   VerifiedOutcomeReputationProjection: objectSummary(
     'Public-safe verified-outcome reputation projection. Includes generatedAt, the declared live_at_read staleness contract, TraceRank/EigenTrust algorithm metadata, graph counts, ignored edge refs, score rows, and copy gates. Only replay-verified outcomes with public-safe Bitcoin settlement receipts affect scores; self-reported feedback, unpaid no-spend work, unverified reviews, and missing-receipt edges are ignored. The seed projection is read-only and grants no dispatch, marketplace ranking, assignment, payout, settlement, moderation, identity, ERC-8004 publication, or spend authority.',
+  ),
+  TraceEconomicUnderwritingProjection: objectSummary(
+    'Public-safe trace-economic underwriting readiness projection for #6426. Includes generatedAt, the declared live_at_read staleness contract, the trace/verdict/settlement/metering substrate, qualifying and incomplete outcome counts, modeled refund-on-rejection and verified-outcome-SLA warranty shapes, copy gates, and blocker refs. It is a seed readiness surface only and grants no policy binding, premium quote, underwriting, claims adjudication, refund, payout, settlement, custody, dispatch, public risk-market claim, or spend authority.',
   ),
   DemandProvenanceProjection: objectSummary(
     'Public-safe demand-provenance projection. Includes generatedAt and the projection_staleness.v1 live_at_read staleness contract with maxStalenessSeconds 0. Summarizes all revenue-bearing public surfaces that carry typed internal/external demand splits — AO/kWh, pylon-stats, training leaderboards, training run pages, and the model-ladder rung economics gates — each reporting internal/external/unlabeled accepted-outcome counts. Coverage is complete (coveredRevenueBearingSurfaceCount, no remaining surface gaps). It enforces the no_external_dollar_no_demand_claim copy gate and keeps externalDemandClaimAllowed false: every current surface is backed by internal first-party demand only. It grants no revenue, demand, payout, settlement, reporting, or public-claim upgrade authority.',
@@ -4856,6 +4860,23 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Verified-outcome reputation seed projection.',
           '#/components/schemas/VerifiedOutcomeReputationProjection',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  [TraceEconomicUnderwritingEndpoint]: {
+    get: operation({
+      operationId: 'getTraceEconomicUnderwriting',
+      summary: 'Read trace-economic underwriting readiness projection',
+      description:
+        'Returns the public trace-economic underwriting readiness projection for issue #6426. The projection prices work-risk only as a modeled seed over public-safe trace, replay-verdict, settlement, and metering evidence, and exposes inert refund-on-rejection / verified-outcome-SLA warranty shapes. It grants no policy binding, premium quote, underwriting, claims adjudication, refund, payout, settlement, custody, dispatch, public risk-market claim, or spend authority.',
+      tags: ['Public Proof'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Trace-economic underwriting readiness projection.',
+          '#/components/schemas/TraceEconomicUnderwritingProjection',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/trace-economic-underwriting-routes.ts
+++ b/apps/openagents.com/workers/api/src/trace-economic-underwriting-routes.ts
@@ -1,0 +1,14 @@
+import { Effect } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import {
+  TraceEconomicUnderwritingEndpoint,
+  projectTraceEconomicUnderwriting,
+} from './trace-economic-underwriting'
+
+export { TraceEconomicUnderwritingEndpoint }
+
+export const handleTraceEconomicUnderwritingApi = (request: Request) =>
+  request.method !== 'GET'
+    ? Effect.succeed(methodNotAllowed(['GET']))
+    : Effect.succeed(noStoreJsonResponse(projectTraceEconomicUnderwriting()))

--- a/apps/openagents.com/workers/api/src/trace-economic-underwriting.test.ts
+++ b/apps/openagents.com/workers/api/src/trace-economic-underwriting.test.ts
@@ -1,0 +1,150 @@
+import { Effect, Schema as S } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { openAgentsOpenApiDocument } from './openagents-openapi'
+import {
+  TraceEconomicUnderwritingEndpoint,
+  TraceEconomicUnderwritingMinimumReadyOutcomeCount,
+  TraceEconomicUnderwritingProjection,
+  TraceEconomicUnderwritingOutcome,
+  projectTraceEconomicUnderwriting,
+  seedTraceEconomicUnderwritingOutcomes,
+} from './trace-economic-underwriting'
+import { handleTraceEconomicUnderwritingApi } from './trace-economic-underwriting-routes'
+
+type TraceEconomicUnderwritingBody = Readonly<{
+  projectionId: string
+  gate: Readonly<{
+    state: string
+    warrantyOfferAllowed: boolean
+  }>
+}>
+
+const qualifyingOutcome = (
+  index: number,
+): TraceEconomicUnderwritingOutcome =>
+  new TraceEconomicUnderwritingOutcome({
+    accepted: true,
+    acceptedOutcomeRef: `accepted.outcome.${index}`,
+    claimableLossBps: 10000,
+    meterable: true,
+    meteringReceiptRef: `receipt.metering.${index}`,
+    observedAt: '2026-06-28T12:00:00.000Z',
+    outcomeRef: `outcome.${index}`,
+    replayVerified: true,
+    settlementReceiptRef: `receipt.settlement.${index}`,
+    settled: true,
+    sourceRefs: [`source.${index}`],
+    traceRef: `trace.${index}`,
+    verdictRef: `verdict.${index}`,
+    workClass: 'codex_agent_task',
+  })
+
+describe('Trace-economic underwriting projection', () => {
+  test('publishes a schema-valid seed readiness projection with inert warranty shapes', () => {
+    const projection = projectTraceEconomicUnderwriting({
+      generatedAt: '2026-06-28T12:00:00.000Z',
+    })
+
+    expect(
+      S.decodeUnknownSync(TraceEconomicUnderwritingProjection)(projection),
+    ).toEqual(projection)
+    expect(projection.projectionId).toBe('underwriting.trace_economic.v1')
+    expect(projection.issueRef).toBe('github:OpenAgentsInc/openagents#6426')
+    expect(projection.substrate.traceSurface).toBe('/trace/{uuid}')
+    expect(projection.observed.qualifyingOutcomeCount).toBe(1)
+    expect(projection.observed.incompleteOutcomeCount).toBe(1)
+    expect(projection.gate.state).toBe('yellow')
+    expect(projection.gate.warrantyOfferAllowed).toBe(false)
+    expect(projection.warrantyShapes).toHaveLength(2)
+    expect(projection.warrantyShapes.every(shape => shape.inert)).toBe(true)
+    expect(projection.warrantyShapes.every(shape => !shape.policyBound)).toBe(
+      true,
+    )
+    expect(projection.authorityBoundary).toContain('grants no policy binding')
+    expect(projection.unsafeCopy).toContain('Do not describe this projection as insurance')
+  })
+
+  test('requires accepted, replay-verified, settled, metered outcomes before risk is warranty-ready', () => {
+    const projection = projectTraceEconomicUnderwriting({
+      outcomes: [
+        qualifyingOutcome(1),
+        new TraceEconomicUnderwritingOutcome({
+          ...qualifyingOutcome(2),
+          meteringReceiptRef: '',
+          meterable: false,
+        }),
+        new TraceEconomicUnderwritingOutcome({
+          ...qualifyingOutcome(3),
+          replayVerified: false,
+        }),
+      ],
+    })
+
+    expect(projection.observed.inputOutcomeCount).toBe(3)
+    expect(projection.observed.qualifyingOutcomeCount).toBe(1)
+    expect(projection.observed.incompleteOutcomeCount).toBe(2)
+    expect(projection.observed.receiptCoverageBps).toBe(3333)
+    expect(projection.incompleteOutcomeRefs).toEqual(['outcome.2', 'outcome.3'])
+    expect(projection.gate.blockerRefs).toContain(
+      'blocker.underwriting.receipt_coverage_below_warranty_threshold',
+    )
+  })
+
+  test('opens warranty copy gates only after count and receipt coverage thresholds are met', () => {
+    const outcomes = Array.from(
+      { length: TraceEconomicUnderwritingMinimumReadyOutcomeCount },
+      (_, index) => qualifyingOutcome(index),
+    )
+    const projection = projectTraceEconomicUnderwriting({ outcomes })
+
+    expect(projection.gate.state).toBe('green')
+    expect(projection.gate.warrantyOfferAllowed).toBe(true)
+    expect(projection.gate.refundPromiseAllowed).toBe(true)
+    expect(projection.gate.slaPromiseAllowed).toBe(true)
+    expect(projection.gate.blockerRefs).toEqual([])
+  })
+
+  test('serves the public route as no-store JSON', async () => {
+    const response = await Effect.runPromise(
+      handleTraceEconomicUnderwritingApi(
+        new Request(`https://openagents.com${TraceEconomicUnderwritingEndpoint}`),
+      ),
+    )
+    const body = (await response.json()) as TraceEconomicUnderwritingBody
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body.projectionId).toBe('underwriting.trace_economic.v1')
+    expect(body.gate.state).toBe('yellow')
+    expect(body.gate.warrantyOfferAllowed).toBe(false)
+  })
+
+  test('documents the public underwriting endpoint in OpenAPI', async () => {
+    const document = await Effect.runPromise(openAgentsOpenApiDocument())
+
+    expect(
+      (
+        document.paths[TraceEconomicUnderwritingEndpoint] as
+          | { get?: unknown }
+          | undefined
+      )?.get,
+    ).toEqual(
+      expect.objectContaining({
+        operationId: 'getTraceEconomicUnderwriting',
+      }),
+    )
+    expect(
+      (document.components as { schemas: Record<string, unknown> }).schemas,
+    ).toHaveProperty('TraceEconomicUnderwritingProjection')
+  })
+
+  test('seed fixture has one qualifying outcome and one blocked counterexample', () => {
+    const projection = projectTraceEconomicUnderwriting({
+      outcomes: seedTraceEconomicUnderwritingOutcomes(),
+    })
+
+    expect(projection.qualifyingOutcomeRefs).toHaveLength(1)
+    expect(projection.incompleteOutcomeRefs).toHaveLength(1)
+  })
+})

--- a/apps/openagents.com/workers/api/src/trace-economic-underwriting.ts
+++ b/apps/openagents.com/workers/api/src/trace-economic-underwriting.ts
@@ -1,0 +1,310 @@
+import { Schema as S } from 'effect'
+
+import {
+  PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const TraceEconomicUnderwritingEndpoint =
+  '/api/public/underwriting/trace-economic'
+export const TraceEconomicUnderwritingSchemaVersion =
+  'openagents.underwriting.trace_economic.v1'
+export const TraceEconomicUnderwritingMinimumReadyOutcomeCount = 8
+export const TraceEconomicUnderwritingMinimumReadyCoverageBps = 9500
+export const TraceEconomicUnderwritingStaleness = liveAtReadStaleness([
+  'accepted_outcome_receipt_published',
+  'trace_replay_verdict_published',
+  'pylon_settlement_receipt_published',
+  'khala_metering_receipt_published',
+  'product_promise_registry_updated',
+])
+
+export const TraceEconomicUnderwritingWarrantyKind = S.Literals([
+  'refund_on_rejection',
+  'verified_outcome_sla',
+])
+export type TraceEconomicUnderwritingWarrantyKind = S.Schema.Type<
+  typeof TraceEconomicUnderwritingWarrantyKind
+>
+
+export class TraceEconomicUnderwritingOutcome extends S.Class<TraceEconomicUnderwritingOutcome>(
+  'TraceEconomicUnderwritingOutcome',
+)({
+  outcomeRef: S.String,
+  workClass: S.String,
+  acceptedOutcomeRef: S.String,
+  traceRef: S.String,
+  verdictRef: S.String,
+  settlementReceiptRef: S.String,
+  meteringReceiptRef: S.String,
+  replayVerified: S.Boolean,
+  accepted: S.Boolean,
+  settled: S.Boolean,
+  meterable: S.Boolean,
+  claimableLossBps: S.Int,
+  observedAt: S.String,
+  sourceRefs: S.Array(S.String),
+}) {}
+
+export class TraceEconomicUnderwritingWarrantyShape extends S.Class<TraceEconomicUnderwritingWarrantyShape>(
+  'TraceEconomicUnderwritingWarrantyShape',
+)({
+  kind: TraceEconomicUnderwritingWarrantyKind,
+  state: S.Literal('modeled_not_bound'),
+  trigger: S.String,
+  requiredEvidenceRefs: S.Array(S.String),
+  settlementMode: S.Literal('existing_metering_and_settlement_spine'),
+  premiumQuoted: S.Literal(false),
+  policyBound: S.Literal(false),
+  claimPayoutEnabled: S.Literal(false),
+  inert: S.Literal(true),
+}) {}
+
+export class TraceEconomicUnderwritingGate extends S.Class<TraceEconomicUnderwritingGate>(
+  'TraceEconomicUnderwritingGate',
+)({
+  state: S.Literals(['yellow', 'green']),
+  currentQualifyingOutcomeCount: S.Int,
+  requiredQualifyingOutcomeCount: S.Int,
+  currentReceiptCoverageBps: S.Int,
+  requiredReceiptCoverageBps: S.Int,
+  warrantyOfferAllowed: S.Boolean,
+  refundPromiseAllowed: S.Boolean,
+  slaPromiseAllowed: S.Boolean,
+  blockerRefs: S.Array(S.String),
+  caveatRefs: S.Array(S.String),
+}) {}
+
+export class TraceEconomicUnderwritingProjection extends S.Class<TraceEconomicUnderwritingProjection>(
+  'TraceEconomicUnderwritingProjection',
+)({
+  schemaVersion: S.String,
+  generatedAt: S.String,
+  projectionId: S.Literal('underwriting.trace_economic.v1'),
+  definitionRef: S.String,
+  issueRef: S.Literal('github:OpenAgentsInc/openagents#6426'),
+  promiseRef: S.Literal('promise:markets.risk_bonds_underwriting.v1'),
+  staleness: PublicProjectionStalenessContract,
+  status: S.Literal('instrumented_seed'),
+  statusLabel: S.String,
+  substrate: S.Struct({
+    traceSurface: S.Literal('/trace/{uuid}'),
+    verdictSource: S.Literal('replay_verdicts'),
+    settlementSource: S.Literal('public_safe_settlement_receipts'),
+    meteringSource: S.Literal('khala_metering_receipts'),
+    pricingBasis: S.Literal('claimable_loss_bps_over_qualifying_outcomes'),
+  }),
+  observed: S.Struct({
+    inputOutcomeCount: S.Int,
+    qualifyingOutcomeCount: S.Int,
+    incompleteOutcomeCount: S.Int,
+    receiptCoverageBps: S.Int,
+    averageClaimableLossBps: S.Int,
+  }),
+  gate: TraceEconomicUnderwritingGate,
+  warrantyShapes: S.Array(TraceEconomicUnderwritingWarrantyShape),
+  qualifyingOutcomeRefs: S.Array(S.String),
+  incompleteOutcomeRefs: S.Array(S.String),
+  authorityBoundary: S.String,
+  unsafeCopy: S.String,
+  sourceRefs: S.Array(S.String),
+}) {}
+
+export type ProjectTraceEconomicUnderwritingInput = Readonly<{
+  generatedAt?: string | undefined
+  outcomes?: ReadonlyArray<TraceEconomicUnderwritingOutcome> | undefined
+}>
+
+const isQualifyingOutcome = (
+  outcome: TraceEconomicUnderwritingOutcome,
+): boolean =>
+  outcome.accepted &&
+  outcome.replayVerified &&
+  outcome.settled &&
+  outcome.meterable &&
+  outcome.traceRef.length > 0 &&
+  outcome.verdictRef.length > 0 &&
+  outcome.settlementReceiptRef.length > 0 &&
+  outcome.meteringReceiptRef.length > 0
+
+const clampBps = (value: number): number =>
+  Math.min(10000, Math.max(0, Math.round(value)))
+
+const averageClaimableLossBps = (
+  outcomes: ReadonlyArray<TraceEconomicUnderwritingOutcome>,
+): number =>
+  outcomes.length === 0
+    ? 0
+    : clampBps(
+        outcomes.reduce((sum, outcome) => sum + outcome.claimableLossBps, 0) /
+          outcomes.length,
+      )
+
+export const seedTraceEconomicUnderwritingOutcomes =
+  (): ReadonlyArray<TraceEconomicUnderwritingOutcome> => [
+    new TraceEconomicUnderwritingOutcome({
+      accepted: true,
+      acceptedOutcomeRef:
+        'closeout.public.pylon.labor_market.fe1ee748e332a9b9ff7f1e0b',
+      claimableLossBps: 10000,
+      meterable: true,
+      meteringReceiptRef:
+        'receipt.metering.khala.accepted_outcome.labor_4777.public',
+      observedAt: '2026-06-14T03:06:15.399Z',
+      outcomeRef:
+        'work_result.public.788b59de-8ee9-4029-9f5b-c6cf23dc668d',
+      replayVerified: true,
+      settlementReceiptRef:
+        'receipt.labor_escrow.release.b74bb55c-849c-43a3-b8d9-9a741316b528.quote.public.pylon.labor_market.b97f312478504e9df212e333',
+      settled: true,
+      sourceRefs: [
+        'docs/labor/2026-06-14-first-negotiated-labor-job-evidence-bundle.md',
+        'docs/research/idai/roadmap-alignment.md#2-trace-economic-underwriting-safety-economics',
+      ],
+      traceRef: 'trace.public.labor_market.b74bb55c',
+      verdictRef: 'verdict.public.pylon.labor_market.b74bb55c.bun_test.pass',
+      workClass: 'labor_market_fixture',
+    }),
+    new TraceEconomicUnderwritingOutcome({
+      accepted: false,
+      acceptedOutcomeRef: '',
+      claimableLossBps: 0,
+      meterable: true,
+      meteringReceiptRef: 'receipt.metering.khala.rejected.synthetic',
+      observedAt: '2026-06-27T12:00:00.000Z',
+      outcomeRef: 'work_result.public.synthetic.rejected',
+      replayVerified: true,
+      settlementReceiptRef: '',
+      settled: false,
+      sourceRefs: [
+        'docs/research/idai/roadmap-alignment.md#2-trace-economic-underwriting-safety-economics',
+      ],
+      traceRef: 'trace.public.synthetic.rejected',
+      verdictRef: 'verdict.public.synthetic.rejected',
+      workClass: 'synthetic_counterexample',
+    }),
+  ]
+
+const warrantyShapes = (): ReadonlyArray<TraceEconomicUnderwritingWarrantyShape> => [
+  new TraceEconomicUnderwritingWarrantyShape({
+    claimPayoutEnabled: false,
+    inert: true,
+    kind: 'refund_on_rejection',
+    policyBound: false,
+    premiumQuoted: false,
+    requiredEvidenceRefs: [
+      'acceptedOutcomeRef',
+      'traceRef',
+      'verdictRef',
+      'settlementReceiptRef',
+      'meteringReceiptRef',
+    ],
+    settlementMode: 'existing_metering_and_settlement_spine',
+    state: 'modeled_not_bound',
+    trigger:
+      'A future bound warranty would refund an eligible rejected outcome only when the rejection verdict and metering receipt both identify the same work unit.',
+  }),
+  new TraceEconomicUnderwritingWarrantyShape({
+    claimPayoutEnabled: false,
+    inert: true,
+    kind: 'verified_outcome_sla',
+    policyBound: false,
+    premiumQuoted: false,
+    requiredEvidenceRefs: [
+      'acceptedOutcomeRef',
+      'traceRef',
+      'verdictRef',
+      'settlementReceiptRef',
+      'meteringReceiptRef',
+    ],
+    settlementMode: 'existing_metering_and_settlement_spine',
+    state: 'modeled_not_bound',
+    trigger:
+      'A future bound SLA would attach service terms to verified accepted outcomes only after the trace, verdict, settlement, and metering receipts agree.',
+  }),
+]
+
+export const projectTraceEconomicUnderwriting = (
+  input: ProjectTraceEconomicUnderwritingInput = {},
+): TraceEconomicUnderwritingProjection => {
+  const outcomes = input.outcomes ?? seedTraceEconomicUnderwritingOutcomes()
+  const qualifyingOutcomes = outcomes.filter(isQualifyingOutcome)
+  const incompleteOutcomes = outcomes.filter(outcome => !isQualifyingOutcome(outcome))
+  const receiptCoverageBps =
+    outcomes.length === 0
+      ? 0
+      : clampBps((qualifyingOutcomes.length / outcomes.length) * 10000)
+  const gateState =
+    qualifyingOutcomes.length >=
+      TraceEconomicUnderwritingMinimumReadyOutcomeCount &&
+    receiptCoverageBps >= TraceEconomicUnderwritingMinimumReadyCoverageBps
+      ? 'green'
+      : 'yellow'
+
+  return new TraceEconomicUnderwritingProjection({
+    authorityBoundary:
+      'Trace-economic underwriting is a public read-only readiness projection. It grants no policy binding, premium quote, underwriting, claims adjudication, refund, payout, settlement, custody, marketplace ranking, dispatch, public risk-market claim, or spend authority.',
+    definitionRef:
+      'docs/research/idai/roadmap-alignment.md#2-trace-economic-underwriting-safety-economics',
+    gate: new TraceEconomicUnderwritingGate({
+      blockerRefs:
+        gateState === 'green'
+          ? []
+          : [
+              'blocker.underwriting.needs_more_verified_settled_metered_outcomes',
+              'blocker.underwriting.receipt_coverage_below_warranty_threshold',
+              'blocker.underwriting.no_bound_policy_or_premium_authority',
+            ],
+      caveatRefs: [
+        'caveat.underwriting.seed_projection_not_insurance_product',
+        'caveat.underwriting.shapley_credit_assignment_deferred',
+      ],
+      currentQualifyingOutcomeCount: qualifyingOutcomes.length,
+      currentReceiptCoverageBps: receiptCoverageBps,
+      refundPromiseAllowed: gateState === 'green',
+      requiredQualifyingOutcomeCount:
+        TraceEconomicUnderwritingMinimumReadyOutcomeCount,
+      requiredReceiptCoverageBps:
+        TraceEconomicUnderwritingMinimumReadyCoverageBps,
+      slaPromiseAllowed: gateState === 'green',
+      state: gateState,
+      warrantyOfferAllowed: gateState === 'green',
+    }),
+    generatedAt: input.generatedAt ?? currentIsoTimestamp(),
+    incompleteOutcomeRefs: incompleteOutcomes.map(outcome => outcome.outcomeRef),
+    issueRef: 'github:OpenAgentsInc/openagents#6426',
+    observed: {
+      averageClaimableLossBps: averageClaimableLossBps(qualifyingOutcomes),
+      incompleteOutcomeCount: incompleteOutcomes.length,
+      inputOutcomeCount: outcomes.length,
+      qualifyingOutcomeCount: qualifyingOutcomes.length,
+      receiptCoverageBps,
+    },
+    projectionId: 'underwriting.trace_economic.v1',
+    promiseRef: 'promise:markets.risk_bonds_underwriting.v1',
+    qualifyingOutcomeRefs: qualifyingOutcomes.map(outcome => outcome.outcomeRef),
+    schemaVersion: TraceEconomicUnderwritingSchemaVersion,
+    sourceRefs: [
+      'docs/research/idai/roadmap-alignment.md',
+      'docs/research/idai/safety-economics.md',
+      'apps/openagents.com/workers/api/src/trace-economic-underwriting.ts',
+    ],
+    staleness: TraceEconomicUnderwritingStaleness,
+    status: 'instrumented_seed',
+    statusLabel:
+      gateState === 'green'
+        ? 'Trace-economic underwriting has enough verified, settled, metered outcomes for warranty offer copy gates.'
+        : `${qualifyingOutcomes.length} of ${TraceEconomicUnderwritingMinimumReadyOutcomeCount} qualifying verified, settled, metered outcomes are present; warranty and SLA offers remain blocked.`,
+    substrate: {
+      meteringSource: 'khala_metering_receipts',
+      pricingBasis: 'claimable_loss_bps_over_qualifying_outcomes',
+      settlementSource: 'public_safe_settlement_receipts',
+      traceSurface: '/trace/{uuid}',
+      verdictSource: 'replay_verdicts',
+    },
+    unsafeCopy:
+      'Do not describe this projection as insurance, a bound warranty, a premium quote, a refund entitlement, a claim payout, a live SLA offer, a green risk market, or underwriting authority. It only reports whether public-safe trace, verdict, settlement, and metering evidence is ready to support a future owner-approved warranty product.',
+    warrantyShapes: warrantyShapes(),
+  })
+}


### PR DESCRIPTION
Addresses #6426.

### Changes
- Registers the public trace-economic underwriting readiness endpoint in the API route registry.
- Adds the projection schema summary and GET operation to the OpenAPI document, including public-read security and authority disclaimers.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).