### PR TITLE
fix(deploy): gate deploys on staging parallel dispatch

### DIFF
--- a/apps/openagents.com/AGENTS.md
+++ b/apps/openagents.com/AGENTS.md
@@ -67,9 +67,12 @@ If `foldkit-skills` is installed as a Claude Code plugin, the `generate-program`
   `bun run --cwd workers/api deploy:safe` (see the Worker deploy safety gate in
   `docs/DEPLOYMENT.md`). It always, in order: checks local==origin/main, runs
   `check:deploy` (typecheck:web/api + the real web/worker test suites + guards,
-  with NO dependency on the flaky `verse-launch-smoke`), applies remote D1
+  with NO dependency on the flaky `verse-launch-smoke`), applies staging D1
+  migrations, builds web assets, uploads the staging Worker with
+  `--containers-rollout=none`, runs the five-way Pylon/Codex
+  `smoke:khala:staging-parallel-dispatch` gate, applies production D1
   migrations, runs `check:pending-migrations` (fails if ANY migration is still
-  pending), builds web assets, then uploads the worker LAST with
+  pending), then uploads the production worker LAST with
   `--containers-rollout=none` so Wrangler does not probe local Docker/container
   rollout state. **Raw
   `bunx wrangler deploy` / `npx wrangler deploy` is FORBIDDEN as a deploy path:**

--- a/apps/openagents.com/package.json
+++ b/apps/openagents.com/package.json
@@ -33,7 +33,7 @@
     "test:contract-drift-guard": "vitest run scripts/check-contract-drift.test.ts",
     "check:conflict-markers": "bun scripts/check-conflict-markers.mjs",
     "test:conflict-markers-guard": "vitest run scripts/check-conflict-markers.test.ts",
-    "check:deploy": "bun run check:conflict-markers && bun run check:no-github-actions && bun run check:effect-topology && bun run check:agent-doc-links && bun run check:architecture && bun run check:contract-drift && bun run check:public-projection-freshness && bun run --cwd ../../packages/autopilot-control-protocol typecheck && bun run --cwd ../../apps/pylon typecheck && bun run typecheck:web && bun run typecheck:api && bun run test:conflict-markers-guard && bun run test:contract-drift-guard && bun run test:pending-migrations-guard && bun run --cwd apps/web test -- src/route.test.ts src/route-coverage.test.ts src/navigation-policy.test.ts src/icon.test.ts src/icon-policy.test.ts src/routing/startup.test.ts src/client-server-route-agreement.test.ts src/subscriptions.test.ts src/main.test.ts src/update.test.ts src/page/demo/update.test.ts src/page/demo/playback.test.ts src/page/loggedOut/gym/terminalBenchReplay.test.ts src/page/loggedOut/page/gym.test.ts src/page/loggedOut/page/login.scene.test.ts src/page/loggedOut/page/onboarding.story.test.ts src/page/loggedIn/view.scene.test.ts src/scene/tassadarProofReplayElement.test.ts src/scene/gymOssSceneElement.test.ts src/page/loggedIn/gymOss/gymOss.test.ts src/page/loggedIn/gymOss/stream.test.ts src/page/loggedOut/khala-tokens-served-countup.test.ts src/page/loggedOut/khala-tokens-served-countup-controller.test.ts && bun run --cwd workers/api test -- src/worker-routes.test.ts src/redirect-policy.test.ts src/client-server-route-agreement.test.ts src/mullet/routes.test.ts src/public-proof-replay-routes.test.ts src/product-promises.test.ts src/qualified-contributor-methodology.test.ts src/public-forum-activity-routes.test.ts src/inference/gym/terminal-bench-khala-orchestration.test.ts src/sync-broadcast-throttle.test.ts",
+    "check:deploy": "bun run check:conflict-markers && bun run check:no-github-actions && bun run check:effect-topology && bun run check:agent-doc-links && bun run check:architecture && bun run check:contract-drift && bun run check:public-projection-freshness && bun run --cwd ../../packages/autopilot-control-protocol typecheck && bun run --cwd ../../apps/pylon typecheck && bun run typecheck:web && bun run typecheck:api && bun run test:conflict-markers-guard && bun run test:contract-drift-guard && bun run test:pending-migrations-guard && bun run test:staging-parallel-dispatch-guard && bun run --cwd apps/web test -- src/route.test.ts src/route-coverage.test.ts src/navigation-policy.test.ts src/icon.test.ts src/icon-policy.test.ts src/routing/startup.test.ts src/client-server-route-agreement.test.ts src/subscriptions.test.ts src/main.test.ts src/update.test.ts src/page/demo/update.test.ts src/page/demo/playback.test.ts src/page/loggedOut/gym/terminalBenchReplay.test.ts src/page/loggedOut/page/gym.test.ts src/page/loggedOut/page/login.scene.test.ts src/page/loggedOut/page/onboarding.story.test.ts src/page/loggedIn/view.scene.test.ts src/scene/tassadarProofReplayElement.test.ts src/scene/gymOssSceneElement.test.ts src/page/loggedIn/gymOss/gymOss.test.ts src/page/loggedIn/gymOss/stream.test.ts src/page/loggedOut/khala-tokens-served-countup.test.ts src/page/loggedOut/khala-tokens-served-countup-controller.test.ts && bun run --cwd workers/api test -- src/worker-routes.test.ts src/redirect-policy.test.ts src/client-server-route-agreement.test.ts src/mullet/routes.test.ts src/public-proof-replay-routes.test.ts src/product-promises.test.ts src/qualified-contributor-methodology.test.ts src/public-forum-activity-routes.test.ts src/inference/gym/terminal-bench-khala-orchestration.test.ts src/sync-broadcast-throttle.test.ts",
     "private-workspace:setup-check": "node scripts/private-workspace-setup-check.mjs",
     "artanis:readiness": "node scripts/artanis-production-readiness.mjs",
     "forum": "node scripts/forum.mjs",
@@ -50,6 +50,7 @@
     "smoke:khala:glm-reap": "node scripts/khala-glm-reap-production-smoke.mjs",
     "monitor:khala:production-readiness": "node scripts/khala-production-readiness-monitor.mjs",
     "smoke:khala:production": "node scripts/khala-production-smoke.mjs",
+    "smoke:khala:staging-parallel-dispatch": "bun scripts/staging-parallel-dispatch-smoke.mjs",
     "smoke:gpt-oss20b-production": "node scripts/gpt-oss20b-production-smoke.mjs",
     "smoke:visibility:browser": "node scripts/visibility-browser-smoke.mjs",
     "lint": "eslint .",
@@ -62,7 +63,8 @@
     "check:no-github-actions": "bun run scripts/check-no-github-actions.mjs",
     "check:deploy-from-main": "bun run scripts/check-deploy-from-main.mjs",
     "check:pending-migrations": "bun run scripts/check-pending-migrations.mjs",
-    "test:pending-migrations-guard": "vitest run scripts/check-pending-migrations.test.ts"
+    "test:pending-migrations-guard": "vitest run scripts/check-pending-migrations.test.ts",
+    "test:staging-parallel-dispatch-guard": "vitest run scripts/staging-parallel-dispatch-smoke.test.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250601.0",

--- a/apps/openagents.com/scripts/check-pending-migrations.test.ts
+++ b/apps/openagents.com/scripts/check-pending-migrations.test.ts
@@ -77,9 +77,12 @@ describe('deploy:safe package command', () => {
     const expectedOrder = [
       'cd ../.. && bun run check:deploy-from-main',
       '&& bun run check:deploy &&',
+      '&& cd workers/api && wrangler d1 migrations apply openagents-autopilot-staging --env staging --remote',
+      '&& cd ../.. && bun run build:web',
+      '&& cd workers/api && wrangler deploy --env staging --containers-rollout=none --assets ../../apps/web/dist',
+      '&& cd ../.. && bun run smoke:khala:staging-parallel-dispatch',
       '&& cd workers/api && wrangler d1 migrations apply openagents-autopilot --remote',
       '&& cd ../.. && bun run check:pending-migrations',
-      '&& bun run build:web',
       '&& cd workers/api && wrangler deploy --containers-rollout=none --assets ../../apps/web/dist',
     ]
 
@@ -93,6 +96,12 @@ describe('deploy:safe package command', () => {
   test('disables Wrangler container rollout probing on the final upload', () => {
     expect(deploySafe).toContain(
       'wrangler deploy --containers-rollout=none --assets ../../apps/web/dist',
+    )
+  })
+
+  test('disables Wrangler container rollout probing on the staging upload', () => {
+    expect(deploySafe).toContain(
+      'wrangler deploy --env staging --containers-rollout=none --assets ../../apps/web/dist',
     )
   })
 })

--- a/apps/openagents.com/scripts/staging-parallel-dispatch-smoke.mjs
+++ b/apps/openagents.com/scripts/staging-parallel-dispatch-smoke.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+export const DEFAULT_STAGING_BASE_URL =
+  'https://openagents-staging.openagents.workers.dev'
+export const DEFAULT_COUNT = 5
+export const DUPLICATE_ACTIVE_ASSIGNMENT_REF =
+  'blocker.public.pylon_dispatch.duplicate_active_assignment'
+
+const truthy = value =>
+  ['1', 'true', 'yes', 'on'].includes(
+    String(value || '')
+      .trim()
+      .toLowerCase(),
+  )
+
+const redact = value =>
+  String(value || '')
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gu, 'Bearer <redacted>')
+    .replace(/oa_agent_[A-Za-z0-9._~+/=-]+/gu, 'oa_agent_<redacted>')
+    .replace(/sk-[A-Za-z0-9]{8,}/gu, 'sk-<redacted>')
+
+const parsePositiveInteger = (value, fallback, label) => {
+  if (value === undefined || value === null || value === '') return fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+  return parsed
+}
+
+export const assertStagingHost = baseUrl => {
+  const url = new URL(baseUrl)
+  if (url.hostname !== 'openagents-staging.openagents.workers.dev') {
+    throw new Error(
+      `staging parallel-dispatch smoke is staging-only; refused ${url.hostname}`,
+    )
+  }
+  return url.toString().replace(/\/+$/u, '')
+}
+
+export const parseArgs = (argv = process.argv.slice(2), env = process.env) => {
+  const options = {
+    baseUrl: env.OPENAGENTS_STAGING_BASE_URL || DEFAULT_STAGING_BASE_URL,
+    count: parsePositiveInteger(
+      env.OPENAGENTS_STAGING_PARALLEL_DISPATCH_COUNT,
+      DEFAULT_COUNT,
+      'OPENAGENTS_STAGING_PARALLEL_DISPATCH_COUNT',
+    ),
+    json: truthy(env.OPENAGENTS_STAGING_PARALLEL_DISPATCH_JSON),
+    pylonCommand: env.PYLON || 'bun ../pylon/src/index.ts',
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const readValue = () => {
+      const value = argv[index + 1]
+      if (value === undefined) throw new Error(`${arg} requires a value`)
+      index += 1
+      return value
+    }
+    if (arg === '--base-url') options.baseUrl = readValue()
+    else if (arg === '--count') {
+      options.count = parsePositiveInteger(readValue(), DEFAULT_COUNT, '--count')
+    } else if (arg === '--pylon') options.pylonCommand = readValue()
+    else if (arg === '--json') options.json = true
+    else if (arg === '--help' || arg === '-h') {
+      options.help = true
+    } else {
+      throw new Error(`unknown argument: ${arg}`)
+    }
+  }
+
+  return {
+    ...options,
+    baseUrl: assertStagingHost(options.baseUrl),
+  }
+}
+
+const flattenRefs = value => {
+  if (Array.isArray(value)) return value.flatMap(flattenRefs)
+  if (value && typeof value === 'object') {
+    return Object.values(value).flatMap(flattenRefs)
+  }
+  return typeof value === 'string' ? [value] : []
+}
+
+export const parseSpawnJson = stdout => {
+  const text = String(stdout || '').trim()
+  if (text === '') throw new Error('pylon khala spawn produced no JSON output')
+  try {
+    return JSON.parse(text)
+  } catch {
+    const start = text.indexOf('{')
+    const end = text.lastIndexOf('}')
+    if (start >= 0 && end > start) {
+      return JSON.parse(text.slice(start, end + 1))
+    }
+    throw new Error('pylon khala spawn output was not valid JSON')
+  }
+}
+
+export const validateSpawnResult = (result, expectedCount = DEFAULT_COUNT) => {
+  const refs = flattenRefs(result)
+  const blockers = Array.isArray(result?.blockerRefs) ? result.blockerRefs : []
+  const results = Array.isArray(result?.results) ? result.results : []
+  const distinctAccountHashes = new Set(
+    results
+      .map(slot => slot?.accountRefHash)
+      .filter(hash => typeof hash === 'string' && hash.length > 0),
+  ).size
+  const acceptedCount = Number(result?.aggregate?.acceptedCount ?? 0)
+  const readyAccounts = Number(result?.plan?.readyCodexAccountCount ?? 0)
+  const maxParallel = Number(result?.plan?.maxParallel ?? 0)
+  const duplicateRefSeen = refs.includes(DUPLICATE_ACTIVE_ASSIGNMENT_REF)
+  const failures = [
+    ...(duplicateRefSeen
+      ? [
+          `${DUPLICATE_ACTIVE_ASSIGNMENT_REF} observed; parallel dispatch regressed`,
+        ]
+      : []),
+    ...(result?.ok !== true ? ['spawn result ok=false'] : []),
+    ...(blockers.length > 0 ? [`spawn blockers present: ${blockers.join(', ')}`] : []),
+    ...(results.length !== expectedCount
+      ? [`expected ${expectedCount} assignment results, got ${results.length}`]
+      : []),
+    ...(acceptedCount !== expectedCount
+      ? [`expected ${expectedCount} accepted assignments, got ${acceptedCount}`]
+      : []),
+    ...(readyAccounts < expectedCount
+      ? [`expected at least ${expectedCount} ready Codex accounts, got ${readyAccounts}`]
+      : []),
+    ...(distinctAccountHashes < expectedCount
+      ? [
+          `expected ${expectedCount} distinct Codex account hashes, got ${distinctAccountHashes}`,
+        ]
+      : []),
+    ...(maxParallel < expectedCount
+      ? [`expected advertised parallel capacity ${expectedCount}, got ${maxParallel}`]
+      : []),
+  ]
+  return {
+    ok: failures.length === 0,
+    failures,
+    summary: {
+      acceptedCount,
+      assignmentRefs: result?.aggregate?.assignmentRefs ?? [],
+      distinctAccountHashes,
+      durableRequestIds: result?.aggregate?.durableRequestIds ?? [],
+      maxParallel,
+      readyCodexAccountCount: readyAccounts,
+      resultCount: results.length,
+      totalVerifiedTokens: result?.aggregate?.totalVerifiedTokens ?? 0,
+    },
+  }
+}
+
+const splitCommand = command =>
+  String(command || '')
+    .match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/gu)
+    ?.map(part => part.replace(/^(['"])(.*)\1$/u, '$2')) ?? []
+
+const runCommand = ({ args, command, cwd, env }) =>
+  new Promise(resolve => {
+    const [bin, ...prefixArgs] = splitCommand(command)
+    if (!bin) {
+      resolve({ code: 1, stderr: 'empty pylon command', stdout: '' })
+      return
+    }
+    const child = spawn(bin, [...prefixArgs, ...args], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', chunk => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', chunk => {
+      stderr += chunk.toString()
+    })
+    child.on('error', error => {
+      resolve({ code: 1, stderr: error.message, stdout })
+    })
+    child.on('close', code => {
+      resolve({ code: code ?? 1, stderr, stdout })
+    })
+  })
+
+export const buildSpawnArgs = options => [
+  'khala',
+  'spawn',
+  '--count',
+  String(options.count),
+  '--max-parallel',
+  String(options.count),
+  '--objective',
+  'Run the staging pre-deploy public-safe dummy Codex fixture task.',
+  '--fixture',
+  '--execute',
+  '--base-url',
+  options.baseUrl,
+  '--json',
+]
+
+export const runStagingParallelDispatchSmoke = async ({
+  cwd = fileURLToPath(new URL('..', import.meta.url)),
+  env = process.env,
+  options,
+  run = runCommand,
+} = {}) => {
+  const parsedOptions = options ?? parseArgs([], env)
+  const output = await run({
+    args: buildSpawnArgs(parsedOptions),
+    command: parsedOptions.pylonCommand,
+    cwd,
+    env: {
+      ...env,
+      PYLON_OPENAGENTS_BASE_URL: parsedOptions.baseUrl,
+    },
+  })
+  if (output.code !== 0) {
+    throw new Error(
+      `pylon khala spawn failed (${output.code}): ${redact(output.stderr || output.stdout)}`,
+    )
+  }
+  const result = parseSpawnJson(output.stdout)
+  const verdict = validateSpawnResult(result, parsedOptions.count)
+  if (!verdict.ok) {
+    throw new Error(
+      `staging parallel-dispatch smoke failed: ${verdict.failures.join('; ')}`,
+    )
+  }
+  return {
+    ok: true,
+    baseUrl: parsedOptions.baseUrl,
+    command: 'pylon khala spawn',
+    count: parsedOptions.count,
+    summary: verdict.summary,
+  }
+}
+
+const HELP = `Staging parallel-dispatch smoke gate
+
+Deploy gate for issue #6409. Runs five concurrent fixture-backed Khala coding
+delegations through caller-owned Pylon/Codex capacity against the isolated
+Cloudflare staging Worker, then fails closed on duplicate_active_assignment or
+any incomplete assignment.
+
+Usage:
+  bun scripts/staging-parallel-dispatch-smoke.mjs [--base-url <staging-url>] [--count 5] [--pylon <command>] [--json]
+
+Environment:
+  OPENAGENTS_AGENT_TOKEN                      required by pylon khala spawn
+  OPENAGENTS_STAGING_BASE_URL                 defaults to ${DEFAULT_STAGING_BASE_URL}
+  OPENAGENTS_STAGING_PARALLEL_DISPATCH_COUNT  defaults to ${DEFAULT_COUNT}
+  PYLON                                       defaults to "bun ../pylon/src/index.ts"
+`
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const options = parseArgs()
+    if (options.help) {
+      process.stdout.write(HELP)
+      process.exit(0)
+    }
+    const result = await runStagingParallelDispatchSmoke({ options })
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+    } else {
+      process.stdout.write(
+        [
+          'staging parallel-dispatch smoke: PASS',
+          `baseUrl=${result.baseUrl}`,
+          `accepted=${result.summary.acceptedCount}/${result.count}`,
+          `tokens=${result.summary.totalVerifiedTokens}`,
+        ].join('\n') + '\n',
+      )
+    }
+  } catch (error) {
+    process.stderr.write(
+      `staging parallel-dispatch smoke: FAIL: ${redact(error?.message ?? String(error))}\n`,
+    )
+    process.exit(1)
+  }
+}

--- a/apps/openagents.com/scripts/staging-parallel-dispatch-smoke.test.ts
+++ b/apps/openagents.com/scripts/staging-parallel-dispatch-smoke.test.ts
@@ -1,0 +1,206 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, test } from 'vitest'
+
+import {
+  DEFAULT_STAGING_BASE_URL,
+  DUPLICATE_ACTIVE_ASSIGNMENT_REF,
+  assertStagingHost,
+  buildSpawnArgs,
+  parseArgs,
+  parseSpawnJson,
+  runStagingParallelDispatchSmoke,
+  validateSpawnResult,
+} from './staging-parallel-dispatch-smoke.mjs'
+
+const spawnResult = (patch: Record<string, unknown> = {}) => ({
+  aggregate: {
+    acceptedCount: 5,
+    assignmentRefs: [
+      'assignment.public.staging.1',
+      'assignment.public.staging.2',
+      'assignment.public.staging.3',
+      'assignment.public.staging.4',
+      'assignment.public.staging.5',
+    ],
+    durableRequestIds: [
+      'chatcmpl_staging_1',
+      'chatcmpl_staging_2',
+      'chatcmpl_staging_3',
+      'chatcmpl_staging_4',
+      'chatcmpl_staging_5',
+    ],
+    totalVerifiedTokens: 5000,
+  },
+  blockerRefs: [],
+  ok: true,
+  plan: {
+    maxParallel: 5,
+    readyCodexAccountCount: 5,
+  },
+  results: Array.from({ length: 5 }, (_, index) => ({
+    accountRefHash: `accthash_${index + 1}`,
+    blockerRefs: [],
+    ok: true,
+    slotIndex: index,
+  })),
+  ...patch,
+})
+
+describe('staging parallel-dispatch smoke', () => {
+  test('is staging-only and refuses production hosts', () => {
+    expect(assertStagingHost(DEFAULT_STAGING_BASE_URL)).toBe(
+      DEFAULT_STAGING_BASE_URL,
+    )
+    expect(() => assertStagingHost('https://openagents.com')).toThrow(
+      /staging-only/,
+    )
+  })
+
+  test('builds the five-way fixture-backed pylon khala spawn command', () => {
+    const options = parseArgs(['--count', '5'], {})
+    expect(buildSpawnArgs(options)).toEqual([
+      'khala',
+      'spawn',
+      '--count',
+      '5',
+      '--max-parallel',
+      '5',
+      '--objective',
+      'Run the staging pre-deploy public-safe dummy Codex fixture task.',
+      '--fixture',
+      '--execute',
+      '--base-url',
+      DEFAULT_STAGING_BASE_URL,
+      '--json',
+    ])
+  })
+
+  test('validates a complete five-assignment run', () => {
+    const verdict = validateSpawnResult(spawnResult(), 5)
+    expect(verdict.ok).toBe(true)
+    expect(verdict.summary).toMatchObject({
+      acceptedCount: 5,
+      maxParallel: 5,
+      readyCodexAccountCount: 5,
+      distinctAccountHashes: 5,
+      resultCount: 5,
+    })
+  })
+
+  test('fails closed on duplicate_active_assignment evidence anywhere in the result', () => {
+    const verdict = validateSpawnResult(
+      spawnResult({
+        blockerRefs: [DUPLICATE_ACTIVE_ASSIGNMENT_REF],
+        ok: false,
+      }),
+      5,
+    )
+    expect(verdict.ok).toBe(false)
+    expect(verdict.failures.join('\n')).toContain(
+      DUPLICATE_ACTIVE_ASSIGNMENT_REF,
+    )
+  })
+
+  test('fails when the planner silently lowers concurrency below five accounts', () => {
+    const verdict = validateSpawnResult(
+      spawnResult({
+        aggregate: { acceptedCount: 4, totalVerifiedTokens: 4000 },
+        plan: { maxParallel: 4, readyCodexAccountCount: 4 },
+        results: Array.from({ length: 4 }, (_, index) => ({
+          accountRefHash: `accthash_${index + 1}`,
+          blockerRefs: [],
+          ok: true,
+          slotIndex: index,
+        })),
+      }),
+      5,
+    )
+    expect(verdict.ok).toBe(false)
+    expect(verdict.failures).toEqual(
+      expect.arrayContaining([
+        'expected 5 assignment results, got 4',
+        'expected 5 accepted assignments, got 4',
+        'expected at least 5 ready Codex accounts, got 4',
+        'expected 5 distinct Codex account hashes, got 4',
+        'expected advertised parallel capacity 5, got 4',
+      ]),
+    )
+  })
+
+  test('fails when five assignments recycle fewer than five accounts', () => {
+    const result = spawnResult({
+      results: Array.from({ length: 5 }, (_, index) => ({
+        accountRefHash: `accthash_${(index % 2) + 1}`,
+        blockerRefs: [],
+        ok: true,
+        slotIndex: index,
+      })),
+    })
+    const verdict = validateSpawnResult(result, 5)
+
+    expect(verdict.ok).toBe(false)
+    expect(verdict.failures).toContain(
+      'expected 5 distinct Codex account hashes, got 2',
+    )
+  })
+
+  test('parses JSON even when pylon emits lifecycle lines around the final object', () => {
+    expect(
+      parseSpawnJson(`ignored stderr mirror\n${JSON.stringify(spawnResult())}\n`),
+    ).toMatchObject({ ok: true })
+  })
+
+  test('runs pylon spawn and returns a public-safe summary', async () => {
+    const calls: unknown[] = []
+    const result = await runStagingParallelDispatchSmoke({
+      env: { OPENAGENTS_AGENT_TOKEN: 'oa_agent_secret_test' },
+      options: parseArgs(['--count', '5', '--pylon', 'pylon'], {}),
+      run: async input => {
+        calls.push(input)
+        return {
+          code: 0,
+          stderr: '',
+          stdout: JSON.stringify(spawnResult()),
+        }
+      },
+    })
+
+    expect(result).toMatchObject({
+      baseUrl: DEFAULT_STAGING_BASE_URL,
+      count: 5,
+      ok: true,
+      summary: {
+        acceptedCount: 5,
+        totalVerifiedTokens: 5000,
+      },
+    })
+    expect(calls).toHaveLength(1)
+  })
+})
+
+describe('deploy:safe package command', () => {
+  const apiPackage = JSON.parse(
+    readFileSync(new URL('../workers/api/package.json', import.meta.url), 'utf8'),
+  )
+  const deploySafe = apiPackage.scripts['deploy:safe']
+
+  test('deploys staging and passes parallel-dispatch smoke before production upload', () => {
+    const expectedOrder = [
+      'cd ../.. && bun run check:deploy-from-main',
+      '&& bun run check:deploy &&',
+      '&& cd workers/api && wrangler d1 migrations apply openagents-autopilot-staging --env staging --remote',
+      '&& cd ../.. && bun run build:web',
+      '&& cd workers/api && wrangler deploy --env staging --containers-rollout=none --assets ../../apps/web/dist',
+      '&& cd ../.. && bun run smoke:khala:staging-parallel-dispatch',
+      '&& cd workers/api && wrangler d1 migrations apply openagents-autopilot --remote',
+      '&& cd ../.. && bun run check:pending-migrations',
+      '&& cd workers/api && wrangler deploy --containers-rollout=none --assets ../../apps/web/dist',
+    ]
+
+    expectedOrder.reduce((previousIndex, step) => {
+      const index = deploySafe.indexOf(step)
+      expect(index).toBeGreaterThan(previousIndex)
+      return index
+    }, -1)
+  })
+})

--- a/apps/openagents.com/workers/api/package.json
+++ b/apps/openagents.com/workers/api/package.json
@@ -7,7 +7,7 @@
     "dev": "wrangler dev",
     "build": "wrangler deploy --dry-run --containers-rollout=none --assets ../../apps/web/dist",
     "deploy": "bun run deploy:safe",
-    "deploy:safe": "cd ../.. && bun run check:deploy-from-main && bun run check:deploy && cd workers/api && wrangler d1 migrations apply openagents-autopilot --remote && cd ../.. && bun run check:pending-migrations && bun run build:web && cd workers/api && wrangler deploy --containers-rollout=none --assets ../../apps/web/dist",
+    "deploy:safe": "cd ../.. && bun run check:deploy-from-main && bun run check:deploy && cd workers/api && wrangler d1 migrations apply openagents-autopilot-staging --env staging --remote && cd ../.. && bun run build:web && cd workers/api && wrangler deploy --env staging --containers-rollout=none --assets ../../apps/web/dist && cd ../.. && bun run smoke:khala:staging-parallel-dispatch && cd workers/api && wrangler d1 migrations apply openagents-autopilot --remote && cd ../.. && bun run check:pending-migrations && cd workers/api && wrangler deploy --containers-rollout=none --assets ../../apps/web/dist",
     "migrate:staging": "wrangler d1 migrations apply openagents-autopilot-staging --env staging --remote",
     "deploy:staging": "cd ../.. && bun run check:deploy && cd workers/api && wrangler d1 migrations apply openagents-autopilot-staging --env staging --remote && cd ../.. && bun run build:web && cd workers/api && wrangler deploy --env staging --assets ../../apps/web/dist",
     "smoke:cs336-a2:device-capability": "vitest run src/training-device-capability.test.ts src/training-device-admission-gates.test.ts src/training-run-window-routes.test.ts",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -47,16 +47,27 @@ change, update its linked runbook **and** fix the pointer here.
 2. `check:deploy` — typecheck:web + typecheck:api + the real web/worker test
    suites + the contract-drift / architecture / effect-topology /
    public-projection guards + the deploy-guard self-tests
-   (`test:pending-migrations-guard`). It does **NOT** depend on the flaky
+   (`test:pending-migrations-guard` and the staging parallel-dispatch guard
+   tests). It does **NOT** depend on the flaky
    `verse-launch-smoke` (that desktop smoke was removed from `check:deploy`,
    #6234), so there is **no reason to ever bypass it** with a raw deploy.
-3. **`wrangler d1 migrations apply openagents-autopilot --remote`** — migrations
-   are applied to remote D1 **before** the worker is uploaded, always.
-4. **`check:pending-migrations`** — runs `wrangler d1 migrations list … --remote`
+3. **`wrangler d1 migrations apply openagents-autopilot-staging --env staging --remote`**
+   — staging schema is applied before staging upload.
+4. `build:web` → **`wrangler deploy --env staging --containers-rollout=none --assets …`**
+   — the candidate Worker is uploaded to the isolated Cloudflare staging env.
+5. **`smoke:khala:staging-parallel-dispatch`** — dispatches five concurrent
+   fixture-backed `codex_agent_task` requests through caller-owned Pylon/Codex
+   capacity against staging and fails the deploy on any
+   `duplicate_active_assignment` evidence, incomplete closeout, or less than five
+   ready/advertised Codex slots (#6409).
+6. **`wrangler d1 migrations apply openagents-autopilot --remote`** — production
+   migrations are applied to remote D1 **before** the production worker is
+   uploaded, always.
+7. **`check:pending-migrations`** — runs `wrangler d1 migrations list … --remote`
    and **fails the deploy if ANY migration is still pending**, naming the files.
    This is the guard that makes "code shipped ahead of its schema" impossible.
-5. `build:web` → `wrangler deploy --containers-rollout=none --assets …` — the
-   worker is uploaded last, without Wrangler container rollout probing.
+8. `wrangler deploy --containers-rollout=none --assets …` — the production worker
+   is uploaded last, without Wrangler container rollout probing.
 
 **Raw `bunx wrangler deploy` / `npx wrangler deploy` is FORBIDDEN as a deploy
 path** because it skips both `migrations apply` and `check:pending-migrations`.


### PR DESCRIPTION
Addresses #6409.

### Changes
- Adds the staging parallel-dispatch smoke command to the OpenAgents deploy checks.
- Updates the safe deploy sequence and docs so staging migrations, staging Worker upload, and the five-way Pylon/Codex parallel-dispatch smoke gate run before production migration/deploy.
- Extends deploy command guard coverage for the new staging smoke gate ordering.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0)