### PR TITLE
fix(training): enforce verifier independence in replay checks

### DIFF
--- a/apps/openagents.com/workers/api/src/training-verification-integrity.test.ts
+++ b/apps/openagents.com/workers/api/src/training-verification-integrity.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assessVerificationIntegrity,
+  normalizeVerificationModelFamily,
+} from './training-verification-integrity'
+import { runTrainingVerificationClass } from './training-verification'
+import { buildTrainingVerificationChallengeRecord } from './training-verification'
+
+const exactTraceChallenge = (payload: Record<string, unknown>) =>
+  buildTrainingVerificationChallengeRecord({
+    makeId: () => 'integrity',
+    nowIso: '2026-06-28T12:00:00.000Z',
+    request: {
+      homeworkKind: 'admin_dispatched_homework',
+      payload: {
+        contributionRefs: ['contribution.training.integrity'],
+        replayDigestRef: 'digest.trace.same',
+        sampledWindow: { endStep: 10, startStep: 0 },
+        traceCommitmentDigestRef: 'digest.trace.same',
+        ...payload,
+      },
+      trainingRunRef: 'training.run.integrity',
+      verificationClass: 'exact_trace_replay',
+    },
+  }).challenge
+
+describe('training verification integrity policy', () => {
+  it('normalizes public provider and model ids into enforcement families', () => {
+    expect(normalizeVerificationModelFamily('openagents/pylon-codex')).toBe(
+      'pylon_codex',
+    )
+    expect(normalizeVerificationModelFamily('claude-sonnet-4')).toBe(
+      'anthropic_claude',
+    )
+    expect(normalizeVerificationModelFamily('0xSero/GLM-5.2-504B')).toBe('glm')
+    expect(normalizeVerificationModelFamily('gpt-oss-120b')).toBe('gpt_oss')
+  })
+
+  it('rejects same-family verifier panels and missing agent-channel defenses', () => {
+    const assessment = assessVerificationIntegrity({
+      channelDefense: { agentChannel: true },
+      verifierPanel: [
+        { family: 'pylon_codex', ref: 'judge.1' },
+        { model: 'openagents/pylon-codex', ref: 'judge.2' },
+      ],
+      workerFamily: 'pylon_codex',
+    })
+
+    expect(assessment.ok).toBe(false)
+    expect(assessment.blockers).toEqual([
+      'blocker.verification_integrity.agent_channel_cross_model_review_missing',
+      'blocker.verification_integrity.agent_channel_paraphrasing_missing',
+      'blocker.verification_integrity.effective_independence_below_floor',
+      'blocker.verification_integrity.same_family_worker_verifier',
+      'blocker.verification_integrity.verifier_panel_family_diversity_low',
+    ])
+  })
+
+  it('measures nominal nine-judge panels as two effective votes when families collapse', () => {
+    const assessment = assessVerificationIntegrity({
+      channelDefense: {
+        agentChannel: true,
+        crossModelReview: true,
+        paraphrasing: true,
+        steganalysis: true,
+      },
+      minimumEffectiveVotes: 3,
+      verifierPanel: [
+        { family: 'anthropic_claude', ref: 'judge.1' },
+        { family: 'anthropic_claude', ref: 'judge.2' },
+        { family: 'anthropic_claude', ref: 'judge.3' },
+        { family: 'anthropic_claude', ref: 'judge.4' },
+        { family: 'anthropic_claude', ref: 'judge.5' },
+        { family: 'gemini', ref: 'judge.6' },
+        { family: 'gemini', ref: 'judge.7' },
+        { family: 'gemini', ref: 'judge.8' },
+        { family: 'gemini', ref: 'judge.9' },
+      ],
+      workerFamily: 'pylon_codex',
+    })
+
+    expect(assessment.panelSize).toBe(9)
+    expect(assessment.effectiveIndependenceVotes).toBe(1.98)
+    expect(assessment.blockers).toEqual([
+      'blocker.verification_integrity.effective_independence_below_floor',
+    ])
+  })
+
+  it('passes independent cross-model panels with paraphrasing defenses', () => {
+    const assessment = assessVerificationIntegrity({
+      channelDefense: {
+        agentChannel: true,
+        crossModelReview: true,
+        paraphrasing: true,
+      },
+      verifierPanel: [
+        { family: 'anthropic_claude', ref: 'judge.1' },
+        { family: 'gemini', ref: 'judge.2' },
+        { family: 'glm', ref: 'judge.3' },
+      ],
+      workerFamily: 'pylon_codex',
+    })
+
+    expect(assessment.ok).toBe(true)
+    expect(assessment.effectiveIndependenceVotes).toBe(3)
+    expect(assessment.blockers).toEqual([])
+  })
+
+  it('allows a single verifier when its model family differs from the worker', () => {
+    const assessment = assessVerificationIntegrity({
+      verifierModel: 'claude-sonnet-4',
+      workerModel: 'openagents/pylon-codex',
+    })
+
+    expect(assessment.ok).toBe(true)
+    expect(assessment.effectiveIndependenceVotes).toBe(1)
+    expect(assessment.minimumEffectiveVotes).toBe(1)
+    expect(assessment.blockers).toEqual([])
+  })
+
+  it('fails exact-trace replay when worker and verifier share a model family', async () => {
+    await expect(
+      runTrainingVerificationClass({
+        challenge: exactTraceChallenge({
+          channelDefense: {
+            agentChannel: true,
+            crossModelReview: true,
+            paraphrasing: true,
+          },
+          verifierPanel: [
+            { family: 'pylon_codex', ref: 'validator.codex.1' },
+            { family: 'pylon_codex', ref: 'validator.codex.2' },
+          ],
+          workerModelFamily: 'pylon_codex',
+        }),
+      }),
+    ).resolves.toMatchObject({
+      failureCodes: ['VerifierIndependenceFailed'],
+      publicDetails: {
+        effectiveIndependenceVotes: 1,
+        integrityBlockers: [
+          'blocker.verification_integrity.effective_independence_below_floor',
+          'blocker.verification_integrity.same_family_worker_verifier',
+          'blocker.verification_integrity.verifier_panel_family_diversity_low',
+        ],
+        verifierFamilies: ['pylon_codex'],
+        workerFamily: 'pylon_codex',
+      },
+      state: 'Rejected',
+    })
+  })
+})

--- a/apps/openagents.com/workers/api/src/training-verification-integrity.ts
+++ b/apps/openagents.com/workers/api/src/training-verification-integrity.ts
@@ -1,0 +1,272 @@
+export type VerificationModelFamily =
+  | 'anthropic_claude'
+  | 'deepseek'
+  | 'gemini'
+  | 'glm'
+  | 'gpt'
+  | 'gpt_oss'
+  | 'grok'
+  | 'llama'
+  | 'mistral'
+  | 'openagents_khala'
+  | 'pylon_codex'
+  | 'pylon_claude'
+  | 'qwen'
+  | 'unknown'
+
+export type VerificationPanelMember = Readonly<{
+  family?: string
+  model?: string
+  ref: string
+}>
+
+export type VerificationChannelDefense = Readonly<{
+  agentChannel?: boolean
+  crossModelReview?: boolean
+  paraphrasing?: boolean
+  steganalysis?: boolean
+}>
+
+export type VerificationIntegrityInput = Readonly<{
+  channelDefense?: VerificationChannelDefense
+  minimumEffectiveVotes?: number
+  verifierFamily?: string
+  verifierModel?: string
+  verifierPanel?: ReadonlyArray<VerificationPanelMember>
+  workerFamily?: string
+  workerModel?: string
+}>
+
+export type VerificationIntegrityAssessment = Readonly<{
+  blockers: ReadonlyArray<string>
+  crossModelDefenseRequired: boolean
+  effectiveIndependenceVotes: number
+  familyCounts: ReadonlyArray<Readonly<{ family: VerificationModelFamily; count: number }>>
+  minimumEffectiveVotes: number
+  ok: boolean
+  panelSize: number
+  paraphrasingDefenseRequired: boolean
+  verifierFamilies: ReadonlyArray<VerificationModelFamily>
+  workerFamily: VerificationModelFamily
+}>
+
+const familyPatterns: ReadonlyArray<
+  readonly [VerificationModelFamily, ReadonlyArray<RegExp>]
+> = [
+  ['pylon_codex', [/pylon[-_/ ]?codex/i, /openagents\/pylon-codex/i]],
+  ['pylon_claude', [/pylon[-_/ ]?claude/i, /openagents\/pylon-claude/i]],
+  ['openagents_khala', [/openagents\/khala/i, /\bkhala\b/i]],
+  ['gpt_oss', [/gpt[-_ ]?oss/i]],
+  ['gpt', [/\bgpt[-_ ]?4/i, /\bgpt[-_ ]?5/i, /openai/i, /\bo[1345]\b/i]],
+  ['anthropic_claude', [/claude/i, /anthropic/i]],
+  ['gemini', [/gemini/i, /vertex/i, /google/i]],
+  ['glm', [/\bglm\b/i, /z\.?ai/i]],
+  ['deepseek', [/deepseek/i]],
+  ['qwen', [/qwen/i, /dashscope/i]],
+  ['llama', [/llama/i, /meta[-_ ]?ai/i]],
+  ['mistral', [/mistral/i, /mixtral/i]],
+  ['grok', [/grok/i, /xai/i]],
+]
+
+export const normalizeVerificationModelFamily = (
+  familyOrModel: string | undefined,
+): VerificationModelFamily => {
+  const value = familyOrModel?.trim()
+
+  if (value === undefined || value === '') {
+    return 'unknown'
+  }
+
+  const exact = familyPatterns.find(([family]) => family === value)
+
+  if (exact !== undefined) {
+    return exact[0]
+  }
+
+  return familyPatterns.find(([, patterns]) =>
+    patterns.some(pattern => pattern.test(value)),
+  )?.[0] ?? 'unknown'
+}
+
+const uniqueSortedFamilies = (
+  families: ReadonlyArray<VerificationModelFamily>,
+): ReadonlyArray<VerificationModelFamily> => [...new Set(families)].sort()
+
+const roundedVotes = (votes: number): number => Math.round(votes * 100) / 100
+
+const effectiveIndependenceVotes = (
+  families: ReadonlyArray<VerificationModelFamily>,
+): number => {
+  if (families.length === 0) {
+    return 0
+  }
+
+  const counts = familyCounts(families)
+  const denominator = counts.reduce((sum, row) => {
+    const share = row.count / families.length
+
+    return sum + share * share
+  }, 0)
+
+  return denominator === 0 ? 0 : roundedVotes(1 / denominator)
+}
+
+const familyCounts = (
+  families: ReadonlyArray<VerificationModelFamily>,
+): ReadonlyArray<Readonly<{ family: VerificationModelFamily; count: number }>> =>
+  uniqueSortedFamilies(families)
+    .map(family => ({
+      family,
+      count: families.filter(candidate => candidate === family).length,
+    }))
+    .sort((left, right) => right.count - left.count || left.family.localeCompare(right.family))
+
+const verifierFamiliesFor = (
+  input: VerificationIntegrityInput,
+): ReadonlyArray<VerificationModelFamily> => {
+  const panel = input.verifierPanel ?? []
+
+  if (panel.length > 0) {
+    return panel.map(member =>
+      normalizeVerificationModelFamily(member.family ?? member.model),
+    )
+  }
+
+  return [
+    normalizeVerificationModelFamily(input.verifierFamily ?? input.verifierModel),
+  ]
+}
+
+export const assessVerificationIntegrity = (
+  input: VerificationIntegrityInput,
+): VerificationIntegrityAssessment => {
+  const panelSupplied = (input.verifierPanel?.length ?? 0) > 0
+  const workerFamily = normalizeVerificationModelFamily(
+    input.workerFamily ?? input.workerModel,
+  )
+  const verifierFamilies = verifierFamiliesFor(input)
+  const uniqueVerifierFamilies = uniqueSortedFamilies(verifierFamilies)
+  const effectiveVotes = effectiveIndependenceVotes(verifierFamilies)
+  const minimumEffectiveVotes = input.minimumEffectiveVotes ?? (panelSupplied ? 2 : 1)
+  const agentChannel = input.channelDefense?.agentChannel === true
+  const paraphrasingDefenseRequired =
+    agentChannel && input.channelDefense?.paraphrasing !== true
+  const crossModelDefenseRequired =
+    agentChannel && input.channelDefense?.crossModelReview !== true
+  const blockers = [
+    ...(workerFamily === 'unknown'
+      ? ['blocker.verification_integrity.worker_model_family_unknown']
+      : []),
+    ...(verifierFamilies.some(family => family === 'unknown')
+      ? ['blocker.verification_integrity.verifier_model_family_unknown']
+      : []),
+    ...(verifierFamilies.some(family => family === workerFamily)
+      ? ['blocker.verification_integrity.same_family_worker_verifier']
+      : []),
+    ...(panelSupplied && uniqueVerifierFamilies.length < 2
+      ? ['blocker.verification_integrity.verifier_panel_family_diversity_low']
+      : []),
+    ...(panelSupplied && effectiveVotes < minimumEffectiveVotes
+      ? ['blocker.verification_integrity.effective_independence_below_floor']
+      : []),
+    ...(paraphrasingDefenseRequired
+      ? ['blocker.verification_integrity.agent_channel_paraphrasing_missing']
+      : []),
+    ...(crossModelDefenseRequired
+      ? ['blocker.verification_integrity.agent_channel_cross_model_review_missing']
+      : []),
+  ].sort()
+
+  return {
+    blockers,
+    crossModelDefenseRequired,
+    effectiveIndependenceVotes: effectiveVotes,
+    familyCounts: familyCounts(verifierFamilies),
+    minimumEffectiveVotes,
+    ok: blockers.length === 0,
+    panelSize: verifierFamilies.length,
+    paraphrasingDefenseRequired,
+    verifierFamilies: uniqueVerifierFamilies,
+    workerFamily,
+  }
+}
+
+export const verificationIntegrityInputFromPayload = (
+  payload: Record<string, unknown>,
+): VerificationIntegrityInput | undefined => {
+  const workerFamily =
+    typeof payload.workerModelFamily === 'string'
+      ? payload.workerModelFamily
+      : undefined
+  const workerModel =
+    typeof payload.workerModel === 'string' ? payload.workerModel : undefined
+  const verifierFamily =
+    typeof payload.verifierModelFamily === 'string'
+      ? payload.verifierModelFamily
+      : undefined
+  const verifierModel =
+    typeof payload.verifierModel === 'string' ? payload.verifierModel : undefined
+  const rawPanel = Array.isArray(payload.verifierPanel)
+    ? payload.verifierPanel
+    : []
+  const verifierPanel = rawPanel
+    .map((item, index): VerificationPanelMember | undefined => {
+      if (typeof item !== 'object' || item === null) {
+        return undefined
+      }
+
+      const record = item as Record<string, unknown>
+      const family = typeof record.family === 'string' ? record.family : undefined
+      const model = typeof record.model === 'string' ? record.model : undefined
+      const ref =
+        typeof record.ref === 'string' && record.ref.trim() !== ''
+          ? record.ref
+          : `verifier.panel.${index}`
+
+      return {
+        ...(family === undefined ? {} : { family }),
+        ...(model === undefined ? {} : { model }),
+        ref,
+      }
+    })
+    .filter((item): item is VerificationPanelMember => item !== undefined)
+  const channelDefense =
+    typeof payload.channelDefense === 'object' && payload.channelDefense !== null
+      ? (payload.channelDefense as Record<string, unknown>)
+      : undefined
+  const minimumEffectiveVotes =
+    typeof payload.minimumEffectiveVotes === 'number' &&
+    Number.isFinite(payload.minimumEffectiveVotes)
+      ? payload.minimumEffectiveVotes
+      : undefined
+
+  if (
+    workerFamily === undefined &&
+    workerModel === undefined &&
+    verifierFamily === undefined &&
+    verifierModel === undefined &&
+    verifierPanel.length === 0 &&
+    channelDefense === undefined
+  ) {
+    return undefined
+  }
+
+  return {
+    ...(channelDefense === undefined
+      ? {}
+      : {
+          channelDefense: {
+            agentChannel: channelDefense.agentChannel === true,
+            crossModelReview: channelDefense.crossModelReview === true,
+            paraphrasing: channelDefense.paraphrasing === true,
+            steganalysis: channelDefense.steganalysis === true,
+          },
+        }),
+    ...(minimumEffectiveVotes === undefined ? {} : { minimumEffectiveVotes }),
+    ...(verifierFamily === undefined ? {} : { verifierFamily }),
+    ...(verifierModel === undefined ? {} : { verifierModel }),
+    verifierPanel,
+    ...(workerFamily === undefined ? {} : { workerFamily }),
+    ...(workerModel === undefined ? {} : { workerModel }),
+  }
+}

--- a/apps/openagents.com/workers/api/src/training-verification.ts
+++ b/apps/openagents.com/workers/api/src/training-verification.ts
@@ -8,6 +8,10 @@ import {
   stringArrayFromUnknown,
 } from './json-boundary'
 import { isoTimestampAfterIso } from './runtime-primitives'
+import {
+  assessVerificationIntegrity,
+  verificationIntegrityInputFromPayload,
+} from './training-verification-integrity'
 
 const TrimmedString = S.Trim
 const NonEmptyTrimmedString = TrimmedString.check(S.isNonEmpty())
@@ -59,6 +63,7 @@ export const TrainingVerificationFailureCode = S.Literals([
   'RowOpeningMissing',
   'SamplePolicyRejected',
   'StatisticalThresholdFailed',
+  'VerifierIndependenceFailed',
   'VerificationClassUnknown',
 ])
 export type TrainingVerificationFailureCode =
@@ -554,6 +559,11 @@ export const verifyExactTraceReplay = (
   input: TrainingVerificationVerifierInput,
 ): TrainingVerificationVerdict => {
   const payload = input.payload
+  const integrityInput = verificationIntegrityInputFromPayload(payload)
+  const integrityAssessment =
+    integrityInput === undefined
+      ? undefined
+      : assessVerificationIntegrity(integrityInput)
   const expected = typeof payload.traceCommitmentDigestRef === 'string'
     ? payload.traceCommitmentDigestRef
     : undefined
@@ -576,6 +586,10 @@ export const verifyExactTraceReplay = (
     failureCodes.push('ExecutorTraceMismatch')
   }
 
+  if (integrityAssessment !== undefined && !integrityAssessment.ok) {
+    failureCodes.push('VerifierIndependenceFailed')
+  }
+
   const sampledCodes = withSamplingPolicy(
     input.challenge,
     payload,
@@ -588,6 +602,15 @@ export const verifyExactTraceReplay = (
     sampledCodes,
     input.challenge.challengeRef,
     {
+      ...(integrityAssessment === undefined
+        ? {}
+        : {
+            effectiveIndependenceVotes:
+              integrityAssessment.effectiveIndependenceVotes,
+            integrityBlockers: integrityAssessment.blockers,
+            verifierFamilies: integrityAssessment.verifierFamilies,
+            workerFamily: integrityAssessment.workerFamily,
+          }),
       sampledWindowRef:
         typeof payload.sampledWindowRef === 'string'
           ? payload.sampledWindowRef
@@ -666,7 +689,11 @@ export const defaultTrainingVerificationRegistry = new Map<
     {
       className: 'exact_trace_replay',
       defaultSamplingPolicy: 'per_contribution',
-      failureCodes: ['ExecutorTraceMismatch', 'OutputDigestMissing'],
+      failureCodes: [
+        'ExecutorTraceMismatch',
+        'OutputDigestMissing',
+        'VerifierIndependenceFailed',
+      ],
       stalenessPolicy: { kind: 'inherit_run_default' },
       verify: verifyExactTraceReplay,
     },


### PR DESCRIPTION
Addresses #6423.

### Changes
- Runs verification integrity assessment during `exact_trace_replay` verification when the payload contains integrity input.
- Adds `VerifierIndependenceFailed` as a training verification failure code and registry failure condition.
- Includes integrity evidence in verdict details, including effective independence votes, blockers, verifier families, and worker family.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)