### PR TITLE
feat(operator): add threaded Artanis chat turns

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
@@ -23,6 +23,16 @@ type Session = Readonly<{ user: Readonly<{ email: string; userId: string }> }>
 
 const ctx = {} as ExecutionContext
 
+type ThreadEntry = Readonly<{
+  authorId: string
+  authorKind: 'owner' | 'agent' | 'operator' | 'system' | 'tool'
+  body: string
+  callerId: string
+  createdAt: string
+  messageRef: string
+  threadRef: string
+}>
+
 // An in-memory owner-memory store so the route test exercises persistence
 // without the D1/sqlite harness. Owner-scoped: load only returns the owner's
 // own entries.
@@ -55,12 +65,77 @@ const makeFakeStore = (): {
   return { entries, store }
 }
 
+const makeFakeThreadStore = (): {
+  appendInputs: Array<{
+    callerId: string
+    threadRef: string
+    messages: ReadonlyArray<{ authorKind: string; body: string }>
+  }>
+  entries: Array<ThreadEntry>
+  store: {
+    appendTurn: (input: {
+      callerId: string
+      messages: ReadonlyArray<{
+        authorId: string
+        authorKind: ThreadEntry['authorKind']
+        body: string
+      }>
+      nowIso: string
+      threadRef: string
+    }) => Promise<ReadonlyArray<ThreadEntry>>
+    loadThreadMessages: (threadRef: string) => Promise<ReadonlyArray<ThreadEntry>>
+  }
+} => {
+  const entries: Array<ThreadEntry> = []
+  const appendInputs: Array<{
+    callerId: string
+    threadRef: string
+    messages: ReadonlyArray<{ authorKind: string; body: string }>
+  }> = []
+  const store = {
+    appendTurn: async (input: {
+      callerId: string
+      messages: ReadonlyArray<{
+        authorId: string
+        authorKind: ThreadEntry['authorKind']
+        body: string
+      }>
+      nowIso: string
+      threadRef: string
+    }) => {
+      appendInputs.push({
+        callerId: input.callerId,
+        messages: input.messages.map(message => ({
+          authorKind: message.authorKind,
+          body: message.body,
+        })),
+        threadRef: input.threadRef,
+      })
+      const inserted = input.messages.map((message, index) => ({
+        authorId: message.authorId,
+        authorKind: message.authorKind,
+        body: message.body,
+        callerId: input.callerId,
+        createdAt: input.nowIso,
+        messageRef: `msg_${entries.length + index + 1}`,
+        threadRef: input.threadRef,
+      }))
+      entries.push(...inserted)
+      return inserted
+    },
+    loadThreadMessages: async (threadRef: string) =>
+      entries.filter(entry => entry.threadRef === threadRef),
+  }
+  return { appendInputs, entries, store }
+}
+
 const baseDeps = (
   overrides: Partial<
     Parameters<typeof makeOperatorArtanisChatRoutes<Session, { OPENAGENTS_DB: D1Database }>>[0]
   > = {},
 ) => {
   const fake = makeFakeStore()
+  const thread = makeFakeThreadStore()
   const deps = {
     appendRefreshedSessionCookies: (response: Response) => response,
     isOpenAgentsAdminEmail: (email: string) => email.endsWith('@openagents.com'),
@@ -73,12 +148,13 @@ const baseDeps = (
         usage: { completionTokens: 9, promptTokens: 100, totalTokens: 109 },
       }),
     makeMemoryStore: () => fake.store,
+    makeThreadStore: () => thread.store,
     requireBrowserSession: async (): Promise<Session | undefined> => ({
       user: { email: 'chris@openagents.com', userId: 'github:14167547' },
     }),
     ...overrides,
   }
-  return { deps, fake }
+  return { deps, fake, thread }
 }
 
 const post = (body: unknown): Request =>
@@ -246,6 +322,90 @@ describe('POST /api/operator/artanis/chat — grounded Khala-powered reply', () 
     expect(owner?.ownerId).toBe('owner:github:14167547')
   })
 
+  test('generates a thread_id when omitted and stores caller-tagged turn rows', async () => {
+    const { deps, thread } = baseDeps()
+    const response = await runRoute(
+      deps,
+      post({
+        caller_id: 'codex_supervisor',
+        messages: [{ content: 'agent-side status please', role: 'user' }],
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as Record<string, unknown>
+    expect(typeof json.thread_id).toBe('string')
+    expect(json.caller_id).toBe('codex_supervisor')
+    expect(json.historicalMessageCount).toBe(0)
+    expect(thread.appendInputs).toHaveLength(1)
+    expect(thread.appendInputs[0]?.callerId).toBe('codex_supervisor')
+    expect(thread.appendInputs[0]?.threadRef).toBe(json.thread_id)
+    expect(thread.appendInputs[0]?.messages).toEqual([
+      { authorKind: 'owner', body: 'agent-side status please' },
+      { authorKind: 'agent', body: 'I dispatched two Codex assignments this morning.' },
+    ])
+  })
+
+  test('reuses thread_id and sends stored thread history before the new turn', async () => {
+    const requests: Array<InferenceRequest> = []
+    const { deps } = baseDeps({
+      makeKhalaClient: () => request => {
+        requests.push(request)
+        return Effect.succeed({
+          content:
+            requests.length === 1
+              ? 'First answer stored in the thread.'
+              : 'Second answer saw the thread.',
+          finishReason: 'stop',
+          servedModel:
+            request.model === 'openagents/khala' ? 'gpt-oss-120b' : 'wrong',
+          usage: { completionTokens: 9, promptTokens: 100, totalTokens: 109 },
+        })
+      },
+    })
+
+    const first = await runRoute(
+      deps,
+      post({
+        caller_id: 'owner',
+        messages: [{ content: 'first question', role: 'user' }],
+        thread_id: 'artanis_thread_test_1',
+      }),
+    )
+    expect(first.status).toBe(200)
+    const firstJson = (await first.json()) as Record<string, unknown>
+    expect(firstJson.thread_id).toBe('artanis_thread_test_1')
+
+    const second = await runRoute(
+      deps,
+      post({
+        caller_id: 'owner',
+        messages: [{ content: 'second question', role: 'user' }],
+        thread_id: 'artanis_thread_test_1',
+      }),
+    )
+    expect(second.status).toBe(200)
+    const secondJson = (await second.json()) as Record<string, unknown>
+    expect(secondJson.historicalMessageCount).toBe(2)
+
+    const secondKhalaMessages = requests[1]?.messages ?? []
+    expect(
+      secondKhalaMessages.some(
+        message => message.role === 'user' && message.content === 'first question',
+      ),
+    ).toBe(true)
+    expect(
+      secondKhalaMessages.some(
+        message =>
+          message.role === 'assistant' &&
+          message.content === 'First answer stored in the thread.',
+      ),
+    ).toBe(true)
+    expect(
+      secondKhalaMessages.at(-1),
+    ).toMatchObject({ content: 'second question', role: 'user' })
+  })
+
   test('streams an owner-authenticated Artanis reply as OpenAI-style SSE', async () => {
     const { deps } = baseDeps()
     const response = await runRoute(
@@ -260,6 +420,7 @@ describe('POST /api/operator/artanis/chat — grounded Khala-powered reply', () 
       'data: {"choices":[{"delta":{"content":"I dispatched two Codex assignments this morning."}',
     )
     expect(text).toContain('"channelRef":"operator.artanis.chat"')
+    expect(text).toContain('"thread_id":"artanis_thread:')
     expect(text.trim().endsWith('data: [DONE]')).toBe(true)
   })
 

--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
@@ -53,7 +53,11 @@ import {
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import type { InferenceMessage, InferenceResult } from './inference/provider-adapter'
 import { openAgentsDatabase } from './runtime'
-import { randomUuid } from './runtime-primitives'
+import {
+  compactRandomId,
+  currentIsoTimestamp,
+  randomUuid,
+} from './runtime-primitives'
 
 type OperatorArtanisChatEnv = Readonly<{
   OPENAGENTS_DB: D1Database
@@ -72,6 +76,40 @@ type OperatorArtanisTraceInput = Readonly<{
   requestMessages: ReadonlyArray<InferenceMessage>
   responseId: string
   result: InferenceResult
+}>
+
+type ArtanisOperatorThreadMessage = Readonly<{
+  authorId: string
+  authorKind: 'owner' | 'agent' | 'operator' | 'system' | 'tool'
+  body: string
+  callerId: string
+  createdAt: string
+  messageRef: string
+  threadRef: string
+}>
+
+type ArtanisOperatorThreadInput = Readonly<{
+  callerId: string
+  messages: ReadonlyArray<
+    Readonly<{
+      authorId: string
+      authorKind: ArtanisOperatorThreadMessage['authorKind']
+      body: string
+      metadata?: Readonly<Record<string, unknown>>
+    }>
+  >
+  nowIso: string
+  threadRef: string
+  title: string
+}>
+
+type ArtanisOperatorThreadStore = Readonly<{
+  appendTurn: (
+    input: ArtanisOperatorThreadInput,
+  ) => Promise<ReadonlyArray<ArtanisOperatorThreadMessage>>
+  loadThreadMessages: (
+    threadRef: string,
+  ) => Promise<ReadonlyArray<ArtanisOperatorThreadMessage>>
 }>
 
 export type OperatorArtanisChatDependencies<
@@ -117,6 +155,7 @@ export type OperatorArtanisChatDependencies<
     env: Bindings,
     session: Session,
   ) => ReadonlyArray<ArtanisOperatorTool>
+  makeThreadStore?: (env: Bindings) => ArtanisOperatorThreadStore
   emitOwnerTrace?: (
     input: OperatorArtanisTraceInput,
     env: Bindings,
@@ -240,7 +279,191 @@ const ownerIdForSession = (session: OperatorArtanisChatSession): string =>
   `owner:${session.user.userId}`
 
 const ChatRequestBody = S.Struct({
+  caller_id: S.optionalKey(S.String),
   messages: S.Array(ArtanisOperatorMessage),
+  thread_id: S.optionalKey(S.String),
+})
+
+const normalizeOptionalText = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim()
+  return trimmed === undefined || trimmed.length === 0 ? undefined : trimmed
+}
+
+const requestedThreadRef = (value: string | undefined): string | undefined =>
+  normalizeOptionalText(value)
+
+const requestedCallerId = (
+  value: string | undefined,
+  session: OperatorArtanisChatSession,
+): string => normalizeOptionalText(value) ?? session.user.userId
+
+const callerKindForCallerId = (
+  callerId: string,
+): 'owner' | 'agent' | 'operator' | 'system' => {
+  const normalized = callerId.toLowerCase()
+  if (normalized === 'owner' || normalized.startsWith('github:')) return 'owner'
+  if (normalized.includes('codex') || normalized.includes('claude')) return 'agent'
+  if (normalized === 'system') return 'system'
+  return 'operator'
+}
+
+const authorKindForMessage = (
+  message: ArtanisOperatorMessage,
+): ArtanisOperatorThreadMessage['authorKind'] =>
+  message.role === 'assistant'
+    ? 'agent'
+    : message.role === 'system'
+      ? 'system'
+      : 'owner'
+
+const messageRoleForThreadMessage = (
+  message: ArtanisOperatorThreadMessage,
+): ArtanisOperatorMessage['role'] =>
+  message.authorKind === 'owner'
+    ? 'user'
+    : message.authorKind === 'system'
+      ? 'system'
+      : 'assistant'
+
+const threadMessageToOperatorMessage = (
+  message: ArtanisOperatorThreadMessage,
+): ArtanisOperatorMessage => ({
+  content: message.body,
+  role: messageRoleForThreadMessage(message),
+})
+
+const makeThreadRef = (): string =>
+  `artanis_thread:${compactRandomId('thread')}`
+
+const makeMessageRef = (): string =>
+  `artanis_message:${compactRandomId('msg')}`
+
+const threadTitleFromMessages = (
+  messages: ReadonlyArray<ArtanisOperatorMessage>,
+): string => {
+  const title = messages.find(message => message.role === 'user')?.content ?? ''
+  return title.trim().slice(0, 120)
+}
+
+const makeD1ArtanisOperatorThreadStore = (
+  db: D1Database,
+): ArtanisOperatorThreadStore => ({
+  appendTurn: async input => {
+    const callerKind = callerKindForCallerId(input.callerId)
+    await db
+      .prepare(
+        `INSERT INTO artanis_threads (
+            thread_ref,
+            caller_id,
+            caller_kind,
+            subject_agent_ref,
+            subject_agent_kind,
+            title,
+            last_message_at,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(thread_ref) DO UPDATE SET
+            caller_id = excluded.caller_id,
+            caller_kind = excluded.caller_kind,
+            title = CASE
+              WHEN artanis_threads.title = '' THEN excluded.title
+              ELSE artanis_threads.title
+            END,
+            last_message_at = excluded.last_message_at,
+            updated_at = excluded.updated_at`,
+      )
+      .bind(
+        input.threadRef,
+        input.callerId,
+        callerKind,
+        'artanis',
+        'artanis',
+        input.title,
+        input.nowIso,
+        input.nowIso,
+        input.nowIso,
+      )
+      .run()
+
+    const inserted: Array<ArtanisOperatorThreadMessage> = []
+    for (const message of input.messages) {
+      const messageRef = makeMessageRef()
+      await db
+        .prepare(
+          `INSERT INTO artanis_messages (
+              message_ref,
+              thread_ref,
+              caller_id,
+              author_id,
+              author_kind,
+              body,
+              metadata_json,
+              created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+          messageRef,
+          input.threadRef,
+          input.callerId,
+          message.authorId,
+          message.authorKind,
+          message.body,
+          JSON.stringify(message.metadata ?? {}),
+          input.nowIso,
+        )
+        .run()
+      inserted.push({
+        authorId: message.authorId,
+        authorKind: message.authorKind,
+        body: message.body,
+        callerId: input.callerId,
+        createdAt: input.nowIso,
+        messageRef,
+        threadRef: input.threadRef,
+      })
+    }
+    return inserted
+  },
+
+  loadThreadMessages: async threadRef => {
+    const rows = await db
+      .prepare(
+        `SELECT message_ref, thread_ref, caller_id, author_id, author_kind, body, created_at
+           FROM artanis_messages
+          WHERE thread_ref = ?
+          ORDER BY created_at ASC`,
+      )
+      .bind(threadRef)
+      .all<{
+        author_id: string
+        author_kind: string
+        body: string
+        caller_id: string
+        created_at: string
+        message_ref: string
+        thread_ref: string
+      }>()
+
+    return rows.results
+      .filter(
+        row =>
+          row.author_kind === 'owner' ||
+          row.author_kind === 'agent' ||
+          row.author_kind === 'operator' ||
+          row.author_kind === 'system' ||
+          row.author_kind === 'tool',
+      )
+      .map(row => ({
+        authorId: row.author_id,
+        authorKind: row.author_kind as ArtanisOperatorThreadMessage['authorKind'],
+        body: row.body,
+        callerId: row.caller_id,
+        createdAt: row.created_at,
+        messageRef: row.message_ref,
+        threadRef: row.thread_ref,
+      }))
+  },
 })
 
 const parseBody = (request: Request) =>
@@ -290,6 +513,7 @@ const sseData = (value: unknown): string =>
   `data: ${JSON.stringify(value)}\n\n`
 
 const artanisSseResponse = (turn: Readonly<{
+  callerId: string
   deferredToApprovalGate: boolean
   iterations: number
   persona: unknown
@@ -297,6 +521,7 @@ const artanisSseResponse = (turn: Readonly<{
   requestedModel: string
   servedModel: string
   servedVia: string
+  threadRef: string
   toolInvocations: unknown
 }>) =>
   new Response(
@@ -323,6 +548,7 @@ const artanisSseResponse = (turn: Readonly<{
           ]),
       sseData({
         approvalGateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
+        caller_id: turn.callerId,
         channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
         deferredToApprovalGate: turn.deferredToApprovalGate,
         iterations: turn.iterations,
@@ -330,6 +556,7 @@ const artanisSseResponse = (turn: Readonly<{
         requestedModel: turn.requestedModel,
         servedModel: turn.servedModel,
         servedVia: turn.servedVia,
+        thread_id: turn.threadRef,
         toolInvocations: turn.toolInvocations,
       }),
       'data: [DONE]\n\n',
@@ -367,6 +594,10 @@ export const makeOperatorArtanisChatRoutes = <
       dependencies.makeMemoryStore ??
       ((bindings: Bindings) =>
         makeD1ArtanisOwnerMemoryStore(openAgentsDatabase(bindings)))
+    const makeThreadStore =
+      dependencies.makeThreadStore ??
+      ((bindings: Bindings) =>
+        makeD1ArtanisOperatorThreadStore(openAgentsDatabase(bindings)))
     const awarenessReaders = dependencies.awarenessReaders?.(env) ?? {}
 
     return Effect.gen(function* () {
@@ -384,7 +615,19 @@ export const makeOperatorArtanisChatRoutes = <
 
       const body = yield* parseBody(request)
       const ownerId = ownerIdForSession(session)
+      const threadRef = requestedThreadRef(body.thread_id) ?? makeThreadRef()
+      const callerId = requestedCallerId(body.caller_id, session)
       const store = makeMemoryStore(env)
+      const threadStore = makeThreadStore(env)
+
+      const historicalMessages = yield* Effect.tryPromise({
+        catch: error => new OperatorArtanisChatStorageError({ error }),
+        try: () => threadStore.loadThreadMessages(threadRef),
+      })
+      const turnMessages = [
+        ...historicalMessages.map(threadMessageToOperatorMessage),
+        ...body.messages,
+      ]
 
       // Load grounded state: owner memory (owner-scoped) + live situational
       // awareness (bounded, owner-scoped). Both are best-effort: a storage
@@ -409,7 +652,7 @@ export const makeOperatorArtanisChatRoutes = <
         awareness,
         khalaClient,
         memory,
-        messages: body.messages,
+        messages: turnMessages,
         ownerId,
         tools,
       })
@@ -441,6 +684,38 @@ export const makeOperatorArtanisChatRoutes = <
         }),
       ).pipe(Effect.catch(() => Effect.void))
 
+      const nowIso = currentIsoTimestamp()
+      const inboundMessages = body.messages.map(message => ({
+        authorId:
+          message.role === 'user'
+            ? callerId
+            : message.role === 'assistant'
+              ? 'artanis'
+              : 'system',
+        authorKind: authorKindForMessage(message),
+        body: message.content,
+        metadata: { source: 'operator_artanis_chat_request' },
+      }))
+      yield* Effect.tryPromise({
+        catch: error => new OperatorArtanisChatStorageError({ error }),
+        try: () =>
+          threadStore.appendTurn({
+            callerId,
+            messages: [
+              ...inboundMessages,
+              {
+                authorId: 'artanis',
+                authorKind: 'agent',
+                body: turn.reply,
+                metadata: { source: 'operator_artanis_chat_reply' },
+              },
+            ],
+            nowIso,
+            threadRef,
+            title: threadTitleFromMessages(turnMessages),
+          }),
+      })
+
       if (dependencies.emitOwnerTrace !== undefined) {
         yield* Effect.tryPromise(() =>
           dependencies.emitOwnerTrace!(
@@ -469,7 +744,7 @@ export const makeOperatorArtanisChatRoutes = <
 
       if (wantsEventStream(request)) {
         return dependencies.appendRefreshedSessionCookies(
-          artanisSseResponse(turn),
+          artanisSseResponse({ ...turn, callerId, threadRef }),
           session,
         )
       }
@@ -478,13 +753,16 @@ export const makeOperatorArtanisChatRoutes = <
         noStoreJsonResponse({
           approvalGateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
           channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
+          caller_id: callerId,
           deferredToApprovalGate: turn.deferredToApprovalGate,
+          historicalMessageCount: historicalMessages.length,
           iterations: turn.iterations,
           persona: turn.persona,
           reply: turn.reply,
           requestedModel: turn.requestedModel,
           servedModel: turn.servedModel,
           servedVia: turn.servedVia,
+          thread_id: threadRef,
           toolInvocations: turn.toolInvocations,
         }),
         session,


### PR DESCRIPTION
Addresses #6402.

### Changes
- Adds thread-aware `/api/operator/artanis/chat` handling with generated or reused `thread_id` values.
- Persists caller-tagged owner and agent turn rows for operator chat requests.
- Loads stored thread history into follow-up Khala requests and returns thread metadata in responses and SSE output.
- Expands route tests for generated threads, reused thread history, caller tagging, and streamed thread metadata.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).