### PR TITLE
fix(khala): make intro responses more concise

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.test.ts
@@ -245,7 +245,7 @@ describe('artanis operator persona (NOT the public Khala identity)', () => {
 
   test('persona guard flags the Khala collective "we are Khala" voice', () => {
     const verdict = verifyArtanisOperatorPersona(
-      'We are Khala, a collective intelligence. How can we help you?',
+      'We are Khala, a collective intelligence built and operated by OpenAgents.',
     )
     expect(verdict.satisfied).toBe(false)
     expect(verdict.leaks).toContain('we are khala')

--- a/apps/openagents.com/workers/api/src/inference/khala-identity.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-identity.test.ts
@@ -52,9 +52,9 @@ describe('Khala identity system prompt (STEP 1)', () => {
     )
   })
 
-  test('includes the standard collective-intelligence greeting', () => {
+  test('includes the standard concise greeting', () => {
     expect(KHALA_IDENTITY_SYSTEM_PROMPT).toContain(
-      'We are Khala, a collective intelligence. How can we help you?',
+      'We are Khala. How can we help?',
     )
   })
 })
@@ -95,6 +95,14 @@ describe('Khala response discipline signature', () => {
     expect(prompt).toContain('blueprint response contract')
     expect(prompt).toContain('reasoning channel')
     expect(prompt).toContain('one coherent answer')
+  })
+
+  test('keeps first turns concise and conversational (#6400)', () => {
+    const prompt = KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT.toLowerCase()
+    expect(prompt).toContain('concise, warm, and conversational')
+    expect(prompt).toContain('not a technical preface')
+    expect(prompt).toContain('one or two short sentences')
+    expect(prompt).toContain('do not open with architecture')
   })
 
   test('flags visible self-correction loops and repeated final-answer rewrites', () => {

--- a/apps/openagents.com/workers/api/src/inference/khala-identity.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-identity.ts
@@ -63,7 +63,7 @@ export const KHALA_IDENTITY_SYSTEM_PROMPT = [
   'Never say "we are built on X", "we are powered by X", "we are a large language model by Y", "our underlying model is Z", or anything that discloses or hints at your provenance.',
   'If asked what model or provider you are, who made you, or what you are built on, answer only that we are Khala, a collective intelligence built and operated by OpenAgents, and do not name any underlying model or company.',
   'State your identity ONCE when it is relevant; do not repeat the identity sentence. Mention "OpenAgents" at most ONCE in any single reply — never write "OpenAgents" twice in one message.',
-  'For a simple greeting or intro, use exactly: "We are Khala, a collective intelligence. How can we help you?"',
+  'For a simple greeting or intro, use exactly: "We are Khala. How can we help?"',
   "Answer the user's actual request directly and helpfully. When asked to build something, return complete, runnable code.",
 ].join(' ')
 
@@ -310,7 +310,7 @@ export const KHALA_IDENTITY_STATEMENT =
   'We are Khala, a collective intelligence built and operated by OpenAgents.'
 
 export const KHALA_STANDARD_GREETING =
-  'We are Khala, a collective intelligence. How can we help you?'
+  'We are Khala. How can we help?'
 
 // The reinforcement instruction the route prepends on a re-ask when identity is
 // violated (the LLM-side correction — the preferred correction path).
@@ -538,6 +538,9 @@ export const KHALA_REFUSAL_POSTURE_SIGNATURE: KhalaSignature = {
 // not be copied into normal content.
 export const KHALA_RESPONSE_DISCIPLINE_SYSTEM_PROMPT = [
   'Blueprint response contract: answer in the final-answer channel, not as visible deliberation.',
+  'Tone: be concise, warm, and conversational. Lead with the answer in plain language, not a technical preface.',
+  'For greetings, intros, and first turns, keep the reply to one or two short sentences unless the user asks for depth.',
+  'Do not open with architecture, routing, model, API, provider, agent-network, or implementation details unless the user explicitly asks how Khala works or how to integrate it.',
   'Do not expose scratchpad, chain-of-thought, hidden reasoning, self-critique, or repeated revisions in the normal answer text. Provider-labeled reasoning belongs only in the separate reasoning channel when the provider supplies one.',
   'Produce one coherent answer. If you notice an error while composing, silently correct it and continue from the best answer; do not narrate "actually", "hmm", "final answer", "we apologize", or multiple replacement attempts.',
   'For transformation requests such as translation, rewriting, summarization, formatting, or extraction, return the transformed artifact cleanly with at most one short clarifying line when needed.',

--- a/apps/openagents.com/workers/api/src/khala-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-routes.test.ts
@@ -183,7 +183,7 @@ describe('khala chat route', () => {
     expect(openedProvider).toBe(false)
     const text = await response.text()
     expect(text).toContain('event: delta')
-    expect(text).toContain('We are Khala, a collective intelligence. How can we help you?')
+    expect(text).toContain('We are Khala. How can we help?')
     expect(text).toContain('"servedAdapterId":"khala-fast-path"')
     expect(text).toContain('"servedModel":"khala-fast-greeting"')
     expect(text.indexOf('event: meta')).toBeLessThan(text.indexOf('event: done'))
@@ -242,6 +242,8 @@ describe('khala chat route', () => {
     )
     // It is the GENERIC chat instruction, not the concierge intake interview.
     expect(messages[0]?.content).toContain('Do not run an intake interview')
+    expect(messages[0]?.content).toContain('not a technical preface')
+    expect(messages[0]?.content).toContain('one or two short sentences')
     // The running conversation follows the system prompt, in order.
     expect(messages.slice(1)).toEqual([
       { role: 'user', content: 'hi' },


### PR DESCRIPTION
Addresses #6400.

### Changes
- Shortened the standard Khala greeting to `We are Khala. How can we help?`.
- Added response discipline guidance for concise, warm first turns without technical prefaces.
- Updated identity, route, and persona tests to cover the shorter greeting and tone guidance.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).