### PR TITLE
fix(artanis): harden public repo read tool

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.test.ts
@@ -369,6 +369,21 @@ const roadmapContents = readFileSync(
   'utf8',
 )
 const roadmapFirstLine = roadmapContents.split('\n')[0] ?? ''
+const base64Utf8 = (content: string): string => {
+  const bytes = new TextEncoder().encode(content)
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+const githubFileJson = (content: string): string =>
+  JSON.stringify({
+    content: base64Utf8(content),
+    encoding: 'base64',
+    size: new TextEncoder().encode(content).byteLength,
+    type: 'file',
+  })
 
 // A fetch stub the REAL read_repo_file tool fetches through, so we can feed it
 // the real roadmap bytes (happy path) or a 404 (nonexistent path)
@@ -434,7 +449,7 @@ const makeReadThenEchoKhalaClient = (path: string) => {
 describe('POST /api/operator/artanis/chat — #6365 read_repo_file acceptance', () => {
   test('reads the roadmap through the loop and replies with its real first line', async () => {
     const { fetchImpl, urls } = stubRepoFetch(
-      () => new Response(roadmapContents, { status: 200 }),
+      () => new Response(githubFileJson(roadmapContents), { status: 200 }),
     )
     const { client, requests } = makeReadThenEchoKhalaClient(ROADMAP_PATH)
     const { deps } = baseDeps({
@@ -472,9 +487,10 @@ describe('POST /api/operator/artanis/chat — #6365 read_repo_file acceptance', 
     expect(readInvocation?.executed).toBe(true)
     expect(readInvocation?.deferredToApprovalGate).toBe(false)
 
-    // It was the REAL read tool: it fetched the roadmap from the public repo.
+    // It was the REAL read tool: it fetched the roadmap from the public repo
+    // through the GitHub contents API.
     expect(urls[0]).toBe(
-      `https://raw.githubusercontent.com/OpenAgentsInc/openagents/main/${ROADMAP_PATH}`,
+      `https://api.github.com/repos/OpenAgentsInc/openagents/contents/${ROADMAP_PATH}?ref=main`,
     )
 
     // The loop resolved the tool with the real file contents: at least two Khala

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -66,12 +66,29 @@ const stubFetch = (
   return { fetchImpl, urls }
 }
 
+const base64Utf8 = (content: string): string => {
+  const bytes = new TextEncoder().encode(content)
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+
+const githubFileJson = (content: string): string =>
+  JSON.stringify({
+    content: base64Utf8(content),
+    encoding: 'base64',
+    size: new TextEncoder().encode(content).byteLength,
+    type: 'file',
+  })
+
 describe('#6365 read_repo_file (public OpenAgentsInc/openagents only)', () => {
-  test('returns the real file contents from raw.githubusercontent', async () => {
+  test('returns decoded file contents from the GitHub contents API', async () => {
     const fileBody =
       '# Khala open issues master roadmap\nFirst priority: the #6316 serving track.'
     const { fetchImpl, urls } = stubFetch(
-      () => new Response(fileBody, { status: 200 }),
+      () => new Response(githubFileJson(fileBody), { status: 200 }),
     )
     const tool = makeArtanisReadRepoFileTool({ fetchImpl })
 
@@ -83,7 +100,7 @@ describe('#6365 read_repo_file (public OpenAgentsInc/openagents only)', () => {
 
     expect(result).toBe(fileBody)
     expect(urls[0]).toBe(
-      'https://raw.githubusercontent.com/OpenAgentsInc/openagents/main/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md',
+      'https://api.github.com/repos/OpenAgentsInc/openagents/contents/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md?ref=main',
     )
   })
 
@@ -115,15 +132,35 @@ describe('#6365 read_repo_file (public OpenAgentsInc/openagents only)', () => {
     expect(urls).toHaveLength(0)
   })
 
-  test('truncates an oversized file at the byte cap', async () => {
+  test('blocks an oversized file at the byte cap before decoding content', async () => {
     const big = 'a'.repeat(ARTANIS_REPO_READ_MAX_BYTES + 10)
-    const { fetchImpl } = stubFetch(() => new Response(big, { status: 200 }))
+    const { fetchImpl } = stubFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            content: base64Utf8('not fetched'),
+            encoding: 'base64',
+            size: new TextEncoder().encode(big).byteLength,
+            type: 'file',
+          }),
+          { status: 200 },
+        ),
+    )
     const tool = makeArtanisReadRepoFileTool({ fetchImpl })
     const result = await Effect.runPromise(
       tool.execute({ path: 'docs/big.md' }),
     )
-    expect(result).toContain('truncated')
-    expect(result.length).toBeLessThan(big.length + 200)
+    expect(result).toContain('file too large')
+    expect(result).toContain(String(ARTANIS_REPO_READ_MAX_BYTES))
+  })
+
+  test('reports a directory response as not a file', async () => {
+    const { fetchImpl } = stubFetch(
+      () => new Response(JSON.stringify([{ name: 'README.md', type: 'file' }])),
+    )
+    const tool = makeArtanisReadRepoFileTool({ fetchImpl })
+    const result = await Effect.runPromise(tool.execute({ path: 'docs' }))
+    expect(result).toContain('not a file')
   })
 
   test('invalid arguments return an honest message, not a throw', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -105,8 +105,38 @@ const resolveRepoReadConfig = (config: ArtanisRepoReadConfig) => ({
   repo: config.repo ?? ARTANIS_REPO_READ_REPO,
 })
 
-// read_repo_file(path) — reads a file from the public repo via
-// raw.githubusercontent.com. Bounded, public-only, secret-path-denied.
+type GitHubContentsFile = Readonly<{
+  content?: unknown
+  encoding?: unknown
+  size?: unknown
+  type?: unknown
+}>
+
+const repoContentsUrl = (
+  owner: string,
+  repo: string,
+  path: string,
+  ref: string,
+): string => {
+  const encodedPath = path
+    .split('/')
+    .map(part => encodeURIComponent(part))
+    .join('/')
+  return `https://api.github.com/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`
+}
+
+const decodeGitHubBase64Utf8 = (content: string): string | undefined => {
+  try {
+    const binary = atob(content.replace(/\s+/g, ''))
+    const bytes = Uint8Array.from(binary, character => character.charCodeAt(0))
+    return new TextDecoder().decode(bytes)
+  } catch {
+    return undefined
+  }
+}
+
+// read_repo_file(path) — reads a file from the public repo via the GitHub
+// contents API. Bounded, public-only, secret-path-denied.
 export const makeArtanisReadRepoFileTool = (
   config: ArtanisRepoReadConfig = {},
 ): ArtanisOperatorReadTool => {
@@ -115,7 +145,7 @@ export const makeArtanisReadRepoFileTool = (
 
   return {
     definition: {
-      description: `Read a UTF-8 text file from the PUBLIC ${owner}/${repo} repo (branch ${ref}). Use for docs and source, e.g. "docs/khala/2026-06-26-khala-open-issues-master-roadmap.md". Public repo only; bounded size; secret paths are blocked.`,
+      description: `Read a UTF-8 text file from the PUBLIC ${owner}/${repo} repo (branch ${ref}) via the GitHub contents API. Use for docs and source, e.g. "docs/khala/2026-06-26-khala-open-issues-master-roadmap.md". Public repo only; bounded size; secret paths are blocked.`,
       name: 'read_repo_file',
       parameters: {
         additionalProperties: false,
@@ -140,10 +170,13 @@ export const makeArtanisReadRepoFileTool = (
           return `(blocked: "${path}" is not an allowed public-repo path)`
         }
 
-        const url = `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`
+        const url = repoContentsUrl(owner, repo, path, ref)
         const response = yield* Effect.tryPromise(() =>
           fetchImpl(url, {
-            headers: { 'User-Agent': 'artanis-operator' },
+            headers: {
+              Accept: 'application/vnd.github+json',
+              'User-Agent': 'artanis-operator',
+            },
           }),
         ).pipe(Effect.orElseSucceed(() => undefined))
 
@@ -157,10 +190,29 @@ export const makeArtanisReadRepoFileTool = (
           return `(read failed for "${path}": status ${response.status})`
         }
 
-        const text = yield* Effect.tryPromise(() => response.text()).pipe(
-          Effect.orElseSucceed(() => ''),
-        )
-        if (text.length > maxBytes) {
+        const body = yield* Effect.tryPromise(
+          () => response.json() as Promise<unknown>,
+        ).pipe(Effect.orElseSucceed(() => undefined))
+        if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+          return `("${path}" is not a file)`
+        }
+
+        const file = body as GitHubContentsFile
+        if (file.type !== 'file') {
+          return `("${path}" is not a file)`
+        }
+        if (typeof file.size === 'number' && file.size > maxBytes) {
+          return `(file too large: "${path}" is ${file.size} bytes; max is ${maxBytes})`
+        }
+        if (file.encoding !== 'base64' || typeof file.content !== 'string') {
+          return `(read failed for "${path}": expected base64 file content from GitHub contents API)`
+        }
+
+        const text = decodeGitHubBase64Utf8(file.content)
+        if (text === undefined) {
+          return `(read failed for "${path}": invalid base64 file content)`
+        }
+        if (new TextEncoder().encode(text).byteLength > maxBytes) {
           return `${text.slice(0, maxBytes)}\n\n(…truncated at ${maxBytes} bytes; the file is longer)`
         }
         if (text === '') {
@@ -209,7 +261,7 @@ export const makeArtanisListRepoDirTool = (
           return `(blocked: "${path}" is not an allowed public-repo path)`
         }
 
-        const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${ref}`
+        const url = repoContentsUrl(owner, repo, path, ref)
         const response = yield* Effect.tryPromise(() =>
           fetchImpl(url, {
             headers: {
@@ -217,7 +269,8 @@ export const makeArtanisListRepoDirTool = (
               'User-Agent': 'artanis-operator',
             },
           }),
-        ).pipe(Effect.orElseSucceed(() => undefined))
+        )
+          .pipe(Effect.orElseSucceed(() => undefined))
 
         if (response === undefined) {
           return `(could not list "${path}")`


### PR DESCRIPTION
Addresses #6365.

### Changes
- Switched `read_repo_file` to the GitHub contents API for the public OpenAgentsInc/openagents repo.
- Decodes base64 UTF-8 file responses and validates GitHub contents metadata before returning content.
- Blocks oversized files before decoding and reports directory responses as not-a-file errors.
- Updated Artanis operator tool and chat-route acceptance tests for the contents API behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).