### PR TITLE
feat(khala): route chat completions with BYOK

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -834,6 +834,10 @@ This is the invariant ledger for `openagents`.
   API keys, bearer/callback/OAuth material, tool args, raw source, private repo
   paths, local filesystem paths, or customer/private material. Unsafe fields
   must be rejected before persistence, not hidden after schema decode.
+- Caller-paid Khala BYOK completions still record exact served tokens in
+  `token_usage_events` as Khala-served usage, but the caller-supplied provider
+  API key is request-local secret material only. It must never be stored in token
+  rows, traces, public receipts, counters, logs, or replay artifacts.
 - Leaderboard privacy flags are accounting policy. Opted-out events remain in
   global aggregate totals but must be excluded or anonymized by leaderboard
   projections.
@@ -1233,6 +1237,11 @@ This is the invariant ledger for `openagents`.
   gateway resale. Converting a consumer subscription login into resale remains
   blocked; API-inference gateway resale is allowed only through an explicit
   policy path such as this gate, with tests.
+- Caller-paid Khala BYOK is not OpenAgents resale and not subscription-capacity
+  resale: the caller supplies their own upstream API key for that request,
+  OpenAgents must not debit credits or bill upstream cost for it, and the request
+  must not authorize use of any consumer subscription account or pooled provider
+  quota.
 - The authorizing policy required by the previous clause is
   `workers/api/src/inference-resale-authorization.ts`
   (`authorizeInferenceMonetization`, tests in

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -18,6 +18,9 @@ import {
 import {
   type ChatCompletionsDeps,
   INFERENCE_CLIENT_HEADER,
+  INFERENCE_BYOK_ACK_HEADER,
+  INFERENCE_BYOK_PROVIDER_HEADER,
+  INFERENCE_BYOK_PROVIDER_KEY_HEADER,
   INFERENCE_DEMAND_KIND_HEADER,
   INFERENCE_DEMAND_SOURCE_HEADER,
   type InferenceAuth,
@@ -61,6 +64,7 @@ import {
   HYDRALISK_ADAPTER_ID,
   HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
   HYDRALISK_GPT_OSS_120B_ADAPTER_ID,
+  OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
   VERTEX_GEMINI_ADAPTER_ID,
   selectAdapterPlan,
 } from './model-router'
@@ -878,6 +882,95 @@ describe('POST /v1/chat/completions', () => {
     expect(response.status).toBe(402)
     const body = (await response.json()) as { error: string }
     expect(body.error).toBe('insufficient_credits')
+  })
+
+  test('rejects malformed BYOK provider keys with a typed 400 and invalid ack', async () => {
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(helloBody, {
+          headers: {
+            [INFERENCE_BYOK_PROVIDER_HEADER]: 'openrouter',
+            [INFERENCE_BYOK_PROVIDER_KEY_HEADER]: 'bad key with spaces',
+          },
+        }),
+        baseDeps(),
+      ),
+    )
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get(INFERENCE_BYOK_ACK_HEADER)).toBe('invalid')
+    const body = (await response.json()) as { code: string; error: string }
+    expect(body.error).toBe('invalid_byok_provider_key')
+    expect(body.code).toBe('invalid_provider_key')
+  })
+
+  test('valid OpenRouter BYOK bypasses OpenAgents billing and still records served tokens', async () => {
+    const metered: Array<MeteringContext> = []
+    const recorded: Array<{ adapterId: string; usage: InferenceUsage }> = []
+    const seenRequests: Array<InferenceRequest> = []
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      complete: request =>
+        Effect.sync(() => {
+          seenRequests.push(request)
+          return {
+            content: 'BYOK answer',
+            finishReason: 'stop',
+            servedModel: 'openrouter/free',
+            usage: {
+              completionTokens: 3,
+              promptTokens: 2,
+              totalTokens: 5,
+            },
+          }
+        }),
+      id: OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(helloBody, {
+          headers: {
+            [INFERENCE_BYOK_PROVIDER_HEADER]: 'openrouter',
+            [INFERENCE_BYOK_PROVIDER_KEY_HEADER]: 'sk-or-test-caller-key',
+          },
+        }),
+        baseDeps({
+          laneArming: ALL_LANES_UNARMED,
+          meteringHook: context =>
+            Effect.sync(() => {
+              metered.push(context)
+              return { metered: true, receiptRef: 'receipt.should_not_write' }
+            }),
+          readAvailableMsat: emptyBalance,
+          recordTokensServed: input =>
+            Effect.sync(() => {
+              recorded.push({
+                adapterId: input.adapterId,
+                usage: input.usage,
+              })
+            }),
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(INFERENCE_BYOK_ACK_HEADER)).toBe('routed')
+    expect(metered).toHaveLength(0)
+    expect(recorded).toEqual([
+      {
+        adapterId: OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+        usage: {
+          completionTokens: 3,
+          promptTokens: 2,
+          totalTokens: 5,
+        },
+      },
+    ])
+    expect(seenRequests[0]?.callerProvider).toBe('openrouter')
+    expect(seenRequests[0]?.callerProviderKey).toBeDefined()
   })
 
   test('funded balance never calls the free-allowance pre-flight', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -16,11 +16,12 @@
 // only base URL + key. Anthropic Messages compatibility is a parallel surface;
 // a clean spot is left for it (see ANTHROPIC SEAM below) but is out of scope for
 // #5476.
-import { Effect } from 'effect'
+import { Effect, Redacted } from 'effect'
 
 import type { AgentRegistrationStore } from '../agent-registration'
 import { noStoreJsonResponse } from '../http/responses'
 import { recordFromUnknown } from '../json-boundary'
+import { requireProviderApiKeyShape } from '../provider-account-api-key'
 import type { PylonApiStore } from '../pylon-api'
 import {
   compactRandomId,
@@ -206,6 +207,100 @@ export const DEFAULT_CHAT_MODEL = KHALA_MODEL_ID
 export const INFERENCE_DEMAND_KIND_HEADER = 'x-openagents-demand-kind'
 export const INFERENCE_DEMAND_SOURCE_HEADER = 'x-openagents-demand-source'
 export const INFERENCE_CLIENT_HEADER = 'x-openagents-client'
+export const INFERENCE_BYOK_PROVIDER_HEADER = 'x-openagents-provider'
+export const INFERENCE_BYOK_PROVIDER_KEY_HEADER = 'x-openagents-provider-key'
+export const INFERENCE_BYOK_ACK_HEADER = 'x-openagents-byok'
+
+type CallerByok =
+  | Readonly<{ _tag: 'absent' }>
+  | Readonly<{
+      _tag: 'invalid'
+      code:
+        | 'missing_provider'
+        | 'missing_provider_key'
+        | 'unsupported_provider'
+        | 'invalid_provider_key'
+      reason: string
+    }>
+  | Readonly<{
+      _tag: 'valid'
+      provider: 'openrouter'
+      providerKey: Redacted.Redacted<string>
+    }>
+
+const callerByokFromHeaders = (headers: Headers): CallerByok => {
+  const rawProvider = headers.get(INFERENCE_BYOK_PROVIDER_HEADER)
+  const rawKey = headers.get(INFERENCE_BYOK_PROVIDER_KEY_HEADER)
+  const hasProvider = rawProvider !== null && rawProvider.trim() !== ''
+  const hasKey = rawKey !== null && rawKey.trim() !== ''
+
+  if (!hasProvider && !hasKey) {
+    return { _tag: 'absent' }
+  }
+  if (!hasProvider) {
+    return {
+      _tag: 'invalid',
+      code: 'missing_provider',
+      reason:
+        'x-openagents-provider is required when sending a caller provider key.',
+    }
+  }
+  if (!hasKey) {
+    return {
+      _tag: 'invalid',
+      code: 'missing_provider_key',
+      reason:
+        'x-openagents-provider-key is required when sending a caller provider.',
+    }
+  }
+
+  const provider = rawProvider.trim().toLowerCase()
+  if (provider !== 'openrouter') {
+    return {
+      _tag: 'invalid',
+      code: 'unsupported_provider',
+      reason:
+        'Only x-openagents-provider: openrouter is supported for Khala BYOK routing.',
+    }
+  }
+
+  try {
+    return {
+      _tag: 'valid',
+      provider: 'openrouter',
+      providerKey: Redacted.make(requireProviderApiKeyShape(rawKey)),
+    }
+  } catch {
+    return {
+      _tag: 'invalid',
+      code: 'invalid_provider_key',
+      reason: 'x-openagents-provider-key must be a single bounded API key value.',
+    }
+  }
+}
+
+const withByokAck = (
+  response: Response,
+  status: 'accepted' | 'invalid' | 'routed',
+): Response => {
+  response.headers.set(INFERENCE_BYOK_ACK_HEADER, status)
+  return response
+}
+
+const byokInvalidResponse = (
+  byok: Extract<CallerByok, { _tag: 'invalid' }>,
+): Response =>
+  withByokAck(
+    noStoreJsonResponse(
+      {
+        error: 'invalid_byok_provider_key',
+        code: byok.code,
+        reason: byok.reason,
+      },
+      { status: 400 },
+    ),
+    'invalid',
+  )
 
 const safeAttributionToken = (value: string | null): string | undefined => {
   const trimmed = value?.trim()
@@ -1025,6 +1120,7 @@ const toInferenceRequest = (
   // is injected as a stable prefix block. Default false => no injection.
   componentChannelActive?: boolean,
   autopilotConcierge?: AutopilotConciergeRequestConfig | undefined,
+  callerByok?: Extract<CallerByok, { _tag: 'valid' }> | undefined,
   scheduler?: Readonly<{
     abortSignal?: AbortSignal | undefined
     priority: InferenceRequest['priority']
@@ -1065,6 +1161,12 @@ const toInferenceRequest = (
       : { abortSignal: scheduler.abortSignal }),
     messages,
     model: requestedModel,
+    ...(callerByok === undefined
+      ? {}
+      : {
+          callerProvider: callerByok.provider,
+          callerProviderKey: callerByok.providerKey,
+        }),
     // Gateway-derived session affinity wins over any stray client copy.
     passthroughParams: { ...rest, ...affinityParams },
     ...(scheduler?.priority === undefined
@@ -2388,6 +2490,12 @@ export const handleChatCompletions = (
         { headers, status: 401 },
       )
     }
+    const callerByok = callerByokFromHeaders(request.headers)
+    if (callerByok._tag === 'invalid') {
+      return byokInvalidResponse(callerByok)
+    }
+    const validCallerByok =
+      callerByok._tag === 'valid' ? callerByok : undefined
 
     // INTERNAL/OPS ACCOUNT DEMAND RULE (#6298 follow-up). Refine the single
     // header-derived attribution with the env-configured internal-account
@@ -2682,6 +2790,7 @@ export const handleChatCompletions = (
     // `laneArming` is omitted, after the public-model gate above has already
     // rejected raw GPT-OSS and old split ids.
     if (
+      validCallerByok === undefined &&
       deps.laneArming !== undefined &&
       resolveNamedModelServability(requestedModel, deps.laneArming) === false
     ) {
@@ -2715,10 +2824,11 @@ export const handleChatCompletions = (
 
     // BALANCE GATE (read-only). #5477 owns the real per-model decrement.
     const minimum = deps.minimumAvailableMsat ?? 1
-    const availableMsat = yield* Effect.promise(() =>
-      deps.readAvailableMsat(session.accountRef),
-    )
-    if (availableMsat < minimum) {
+    const availableMsat =
+      validCallerByok === undefined
+        ? yield* Effect.promise(() => deps.readAvailableMsat(session.accountRef))
+        : minimum
+    if (validCallerByok === undefined && availableMsat < minimum) {
       // FREE-ALLOWANCE BYPASS (EPIC #5474 §1). A zero/insufficient-balance
       // account is NOT rejected when the request is free-eligible AND the
       // resolving owner still has remaining free allowance — that request would
@@ -2775,7 +2885,7 @@ export const handleChatCompletions = (
     // can be flush with credits yet still be capped at a configurable per-window
     // spend ceiling so a compromised key cannot drain the whole balance. Open
     // (no-op) when unwired or when no cap is configured for the account.
-    if (deps.checkSpendCap !== undefined) {
+    if (validCallerByok === undefined && deps.checkSpendCap !== undefined) {
       const spendCap = yield* Effect.promise(() =>
         deps.checkSpendCap!(session.accountRef),
       )
@@ -2793,7 +2903,10 @@ export const handleChatCompletions = (
       }
     }
 
-    const meteringHook = deps.meteringHook ?? stubMeteringHook
+    const meteringHook =
+      validCallerByok === undefined
+        ? (deps.meteringHook ?? stubMeteringHook)
+        : stubMeteringHook
     const resolveFundingKind =
       deps.resolveFundingKind ?? defaultCardFundingResolver
     const fundingKind = yield* Effect.promise(() =>
@@ -2877,18 +2990,25 @@ export const handleChatCompletions = (
         : { pinPolicy: deps.cachePinPolicy }),
     })
     const plannedIds = routingDecision.lanes
+    const routedPlannedIds =
+      validCallerByok === undefined
+        ? plannedIds
+        : [OPENROUTER_KHALA_FALLBACK_ADAPTER_ID]
 
     // model_unavailable when no lane is configured OR none of the planned lanes
     // is actually registered (e.g. an absent partner secret leaves the plan but
     // no resolvable adapter).
-    const hasViableLane = plannedIds.some(
+    const hasViableLane = routedPlannedIds.some(
       id => deps.registry.resolve(id) !== undefined,
     )
     if (!hasViableLane) {
-      return noStoreJsonResponse(
+      const response = noStoreJsonResponse(
         { error: 'model_unavailable', model: requestedModel },
         { status: 400 },
       )
+      return validCallerByok === undefined
+        ? response
+        : withByokAck(response, 'accepted')
     }
 
     // COMPONENT-CHANNEL ACTIVATION (issue #6127). AND-gated: gateway flag on +
@@ -2955,6 +3075,7 @@ export const handleChatCompletions = (
       affinity.params,
       componentChannelActive,
       autopilotConcierge?.ok === true ? autopilotConcierge.config : undefined,
+      validCallerByok,
       {
         ...(preemptionAbortController === undefined
           ? {}
@@ -3017,7 +3138,7 @@ export const handleChatCompletions = (
           })
     const dispatchDeps: DispatchDeps = {
       registry: deps.registry,
-      plan: () => plannedIds,
+      plan: () => routedPlannedIds,
       requestForAdapter: mirrorcodeStrongCodingKhalaRequest
         ? khalaStrongCodingRequestForAdapter
         : khalaRequestForAdapter,
@@ -3191,7 +3312,7 @@ export const handleChatCompletions = (
           source: sourceWithPreemptionRelease,
           routeMetadata: sseDispatch.served.route,
         })
-        return new Response(responseStream, {
+        const response = new Response(responseStream, {
           headers: {
             'cache-control': 'no-store',
             'content-type': 'text/event-stream; charset=utf-8',
@@ -3207,6 +3328,9 @@ export const handleChatCompletions = (
           },
           status: 200,
         })
+        return validCallerByok === undefined
+          ? response
+          : withByokAck(response, 'routed')
       }
 
       // Only fall back to the buffered path when the served lane genuinely could
@@ -3215,7 +3339,10 @@ export const handleChatCompletions = (
       // path (which would double-dispatch and could 524 again).
       if (sseDispatch.error.kind !== 'stream_not_supported') {
         yield* Effect.promise(() => releasePreemptionSlot())
-        return providerErrorResponse(sseDispatch.error)
+        const response = providerErrorResponse(sseDispatch.error)
+        return validCallerByok === undefined
+          ? response
+          : withByokAck(response, 'accepted')
       }
 
       // Run the stream op across the lane plan; the served adapter id rides
@@ -3233,7 +3360,10 @@ export const handleChatCompletions = (
         Effect.ensuring(Effect.promise(() => releasePreemptionSlot())),
       )
       if (!chunks.ok) {
-        return providerErrorResponse(chunks.error)
+        const response = providerErrorResponse(chunks.error)
+        return validCallerByok === undefined
+          ? response
+          : withByokAck(response, 'accepted')
       }
       const servedChunks = chunks.served.value.value
       // Settle metering from the terminal usage frame (receipt-first).
@@ -3447,13 +3577,16 @@ export const handleChatCompletions = (
       const body_sse = frameStrings.join('')
       const stream = `${body_sse}data: [DONE]\n\n`
 
-      return new Response(stream, {
+      const response = new Response(stream, {
         headers: {
           'cache-control': 'no-store',
           'content-type': 'text/event-stream; charset=utf-8',
         },
         status: 200,
       })
+      return validCallerByok === undefined
+        ? response
+        : withByokAck(response, 'routed')
     }
 
     const result = yield* dispatchWithOverflowWithMetadata(
@@ -3470,7 +3603,10 @@ export const handleChatCompletions = (
       Effect.ensuring(Effect.promise(() => releasePreemptionSlot())),
     )
     if (!result.ok) {
-      return providerErrorResponse(result.error)
+      const response = providerErrorResponse(result.error)
+      return validCallerByok === undefined
+        ? response
+        : withByokAck(response, 'accepted')
     }
 
     // KHALA IDENTITY GUARD (STEP 2). Run the typed identity signature over the
@@ -3665,7 +3801,7 @@ export const handleChatCompletions = (
       }
     }
 
-    return noStoreJsonResponse(
+    const response = noStoreJsonResponse(
       openAiResponse({
         created,
         id: responseId,
@@ -3690,4 +3826,7 @@ export const handleChatCompletions = (
         result: guardedResult,
       }),
     )
+    return validCallerByok === undefined
+      ? response
+      : withByokAck(response, 'routed')
   })

--- a/apps/openagents.com/workers/api/src/inference/openrouter-adapter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/openrouter-adapter.test.ts
@@ -144,4 +144,22 @@ describe('OpenRouter Khala fallback adapter', () => {
     expect(result._tag).toBe('Success')
     expect(capturedBody?.model).toBe(OPENROUTER_KHALA_FALLBACK_MODEL_ID)
   })
+
+  it('uses a caller-supplied provider key when present', async () => {
+    let authorization: string | undefined
+    const fetchImpl: OpenRouterFetch = async (_input, init) => {
+      authorization = init.headers.authorization
+      return jsonResponse(completionBody())
+    }
+    const adapter = makeOpenRouterAdapter(adapterConfig(fetchImpl))
+
+    const result = await runResult(
+      adapter.complete(
+        request({ callerProviderKey: Redacted.make('sk-or-caller-key') }),
+      ),
+    )
+
+    expect(result._tag).toBe('Success')
+    expect(authorization).toBe('Bearer sk-or-caller-key')
+  })
 })

--- a/apps/openagents.com/workers/api/src/inference/openrouter-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/openrouter-adapter.ts
@@ -151,6 +151,7 @@ const postChatCompletions = (
       }),
     try: () => {
       const fetcher = config.fetchImpl ?? (globalThis.fetch as OpenRouterFetch)
+      const apiKey = request.callerProviderKey ?? config.apiKey
       const signal = safeSignal(
         config.timeoutMs ?? OPENROUTER_DEFAULT_TIMEOUT_MS,
       )
@@ -158,7 +159,7 @@ const postChatCompletions = (
         body: JSON.stringify(requestBody(config, request)),
         headers: {
           accept: 'application/json',
-          authorization: `Bearer ${Redacted.value(config.apiKey)}`,
+          authorization: `Bearer ${Redacted.value(apiKey)}`,
           'content-type': 'application/json',
         },
         method: 'POST',

--- a/apps/openagents.com/workers/api/src/inference/provider-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/provider-adapter.ts
@@ -14,7 +14,7 @@
 // so a real client works by changing only base URL + key. Anthropic Messages is
 // a parallel surface (#5476 leaves a clean spot); both normalize into the same
 // adapter request/result here.
-import { Effect } from 'effect'
+import { Effect, Redacted } from 'effect'
 
 // A single chat message in the normalized request. `role`/`content` mirror the
 // OpenAI Chat Completions shape so adapters can pass through with minimal
@@ -38,6 +38,8 @@ export type InferenceMessage = Readonly<{
 // forwards verbatim; adapters apply only the ones their provider supports.
 export type InferenceRequest = Readonly<{
   abortSignal?: AbortSignal | undefined
+  callerProvider?: 'openrouter' | undefined
+  callerProviderKey?: Redacted.Redacted<string> | undefined
   model: string
   messages: ReadonlyArray<InferenceMessage>
   priority?: InferenceRequestPriority | undefined


### PR DESCRIPTION
Addresses #6380.

### Changes
- Added server-side Khala BYOK header handling for OpenRouter chat completions, including typed validation errors and a BYOK acknowledgement response header.
- Routed valid caller-supplied OpenRouter keys through the provider adapter without OpenAgents billing or credit debits, while still recording exact served-token usage.
- Added request-local caller provider key plumbing through inference provider adapters without persisting the supplied key.
- Documented BYOK privacy, accounting, and resale invariants.
- Added tests for malformed BYOK keys, successful BYOK routing, token recording, and OpenRouter adapter key selection.

### Verification
`bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`

Result: passed (exit 0)