### PR TITLE
fix(gym): gate AgentCL learning claims

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
@@ -4,6 +4,7 @@ import {
   AGENTCL_EVAL_SCHEMA,
   AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
   AGENTCL_REPO_REUSE_PLAN_SCHEMA,
+  assessAgentClLearningClaimGate,
   buildAgentClRepoReusePlan,
   runAgentClRepoReuseFixtureEval,
 } from './agentcl'
@@ -82,5 +83,40 @@ describe('AgentCL repo-reuse gym environment', () => {
     for (const pass of memoryWritePasses) {
       expect(pass.taskRefs.some(ref => heldOutRefs.has(ref))).toBe(false)
     }
+  })
+
+  test('requires separate PG, SG, and GG before memory-learning claims', () => {
+    const result = runAgentClRepoReuseFixtureEval()
+    const gate = assessAgentClLearningClaimGate({
+      claimKind: 'continual_learning',
+      eval: result.eval,
+    })
+
+    expect(gate.requiresSeparatePgSgGg).toBe(true)
+    expect(gate.hasSeparatePlasticityGain).toBe(true)
+    expect(gate.hasSeparateStabilityGain).toBe(true)
+    expect(gate.hasSeparateGeneralizationGain).toBe(true)
+    expect(gate.decisionGradeClaimAllowed).toBe(false)
+    expect(gate.publicClaimAllowed).toBe(false)
+    expect(gate.blockerRefs).toContain('blocker.gym.agentcl.not_decision_grade')
+    expect(gate.blockerRefs).toContain(
+      'blocker.gym.agentcl.public_claim_not_eligible',
+    )
+  })
+
+  test('rejects a collapsed memory-improved metric as AgentCL evidence', () => {
+    const result = runAgentClRepoReuseFixtureEval()
+    const gate = assessAgentClLearningClaimGate({
+      claimKind: 'memory_improvement',
+      eval: result.eval,
+      collapsedMemoryImprovementMetric: 0.12,
+    })
+
+    expect(gate.collapsedMemoryImprovementMetricAccepted).toBe(false)
+    expect(gate.decisionGradeClaimAllowed).toBe(false)
+    expect(gate.publicClaimAllowed).toBe(false)
+    expect(gate.blockerRefs).toContain(
+      'blocker.gym.agentcl.collapsed_memory_improvement_metric',
+    )
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
@@ -83,7 +83,7 @@ export const AgentClPassScore = S.Struct({
 })
 export type AgentClPassScore = typeof AgentClPassScore.Type
 
-export const AgentClEval = S.Struct({
+export const AgentClEvalV0 = S.Struct({
   schemaVersion: S.Literal(AGENTCL_EVAL_SCHEMA),
   environmentRef: S.Literal('agentcl-repo-reuse'),
   experimentId: S.String,
@@ -105,10 +105,43 @@ export const AgentClEval = S.Struct({
   }),
   proofRefs: S.Array(S.String),
 })
-export type AgentClEval = typeof AgentClEval.Type
+export type AgentClEvalV0 = typeof AgentClEvalV0.Type
+
+export const AgentClLearningClaimKind = S.Literals([
+  'continual_learning',
+  'memory_improvement',
+])
+export type AgentClLearningClaimKind = typeof AgentClLearningClaimKind.Type
+
+export const AgentClLearningClaimGate = S.Struct({
+  schemaVersion: S.Literal('openagents.gym.agentcl_learning_claim_gate.v0'),
+  claimKind: AgentClLearningClaimKind,
+  evidenceSchemaVersion: S.Literal(AGENTCL_EVAL_SCHEMA),
+  requiresSeparatePgSgGg: S.Literal(true),
+  hasSeparatePlasticityGain: S.Boolean,
+  hasSeparateStabilityGain: S.Boolean,
+  hasSeparateGeneralizationGain: S.Boolean,
+  collapsedMemoryImprovementMetricAccepted: S.Literal(false),
+  decisionGradeClaimAllowed: S.Boolean,
+  publicClaimAllowed: S.Boolean,
+  blockerRefs: S.Array(S.String),
+})
+export type AgentClLearningClaimGate =
+  typeof AgentClLearningClaimGate.Type
+
+export type AgentClLearningClaimEvidence = Readonly<{
+  plasticityGain?: number
+  stabilityGain?: number
+  generalizationGain?: number
+  claimDiscipline?: Readonly<{
+    decisionGrade?: boolean
+    publicClaimEligible?: boolean
+  }>
+}>
 
 const decodePlan = S.decodeUnknownSync(AgentClRepoReusePlan)
-const decodeEval = S.decodeUnknownSync(AgentClEval)
+const decodeEval = S.decodeUnknownSync(AgentClEvalV0)
+const decodeLearningClaimGate = S.decodeUnknownSync(AgentClLearningClaimGate)
 
 const roundGain = (value: number): number => Math.round(value * 1000) / 1000
 
@@ -255,7 +288,7 @@ export const runAgentClRepoReuseFixtureEval = (
 ): Readonly<{
   compiled: CompiledGymExperiment
   plan: AgentClRepoReusePlan
-  eval: AgentClEval
+  eval: AgentClEvalV0
 }> => {
   const { compiled, plan } = buildAgentClRepoReusePlan(experiment)
   const baseline: AgentClPassScore = {
@@ -337,4 +370,66 @@ export const runAgentClRepoReuseFixtureEval = (
       ],
     }),
   }
+}
+
+export const assessAgentClLearningClaimGate = (
+  input: Readonly<{
+    claimKind: AgentClLearningClaimKind
+    eval?: AgentClLearningClaimEvidence
+    collapsedMemoryImprovementMetric?: number
+  }>,
+): AgentClLearningClaimGate => {
+  const hasSeparatePlasticityGain = input.eval?.plasticityGain !== undefined
+  const hasSeparateStabilityGain = input.eval?.stabilityGain !== undefined
+  const hasSeparateGeneralizationGain =
+    input.eval?.generalizationGain !== undefined
+  const hasAllSeparateGains =
+    hasSeparatePlasticityGain &&
+    hasSeparateStabilityGain &&
+    hasSeparateGeneralizationGain
+  const decisionGradeEvidence =
+    input.eval?.claimDiscipline?.decisionGrade === true
+  const publicClaimEvidence =
+    input.eval?.claimDiscipline?.publicClaimEligible === true
+  const blockerRefs = [
+    ...(hasSeparatePlasticityGain
+      ? []
+      : ['blocker.gym.agentcl.missing_plasticity_gain']),
+    ...(hasSeparateStabilityGain
+      ? []
+      : ['blocker.gym.agentcl.missing_stability_gain']),
+    ...(hasSeparateGeneralizationGain
+      ? []
+      : ['blocker.gym.agentcl.missing_generalization_gain']),
+    ...(input.collapsedMemoryImprovementMetric === undefined
+      ? []
+      : ['blocker.gym.agentcl.collapsed_memory_improvement_metric']),
+    ...(decisionGradeEvidence
+      ? []
+      : ['blocker.gym.agentcl.not_decision_grade']),
+    ...(publicClaimEvidence
+      ? []
+      : ['blocker.gym.agentcl.public_claim_not_eligible']),
+  ]
+
+  return decodeLearningClaimGate({
+    schemaVersion: 'openagents.gym.agentcl_learning_claim_gate.v0',
+    claimKind: input.claimKind,
+    evidenceSchemaVersion: AGENTCL_EVAL_SCHEMA,
+    requiresSeparatePgSgGg: true,
+    hasSeparatePlasticityGain,
+    hasSeparateStabilityGain,
+    hasSeparateGeneralizationGain,
+    collapsedMemoryImprovementMetricAccepted: false,
+    decisionGradeClaimAllowed:
+      hasAllSeparateGains &&
+      input.collapsedMemoryImprovementMetric === undefined &&
+      decisionGradeEvidence,
+    publicClaimAllowed:
+      hasAllSeparateGains &&
+      input.collapsedMemoryImprovementMetric === undefined &&
+      decisionGradeEvidence &&
+      publicClaimEvidence,
+    blockerRefs,
+  })
 }


### PR DESCRIPTION
Addresses #6418.

### Changes

- Renames the AgentCL eval schema export to `AgentClEvalV0` while preserving the existing `agentcl_eval.v0` schema version.
- Adds an AgentCL learning claim gate schema for continual-learning and memory-improvement claims.
- Requires separate plasticity, stability, and generalization gains before allowing decision-grade or public claims.
- Rejects collapsed memory-improvement metrics as AgentCL evidence and adds tests for the claim gate behavior.

### Verification

`bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`

Passed with exit 0.