### PR TITLE
feat(artanis): expose pending approval gates

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-chat-routes.ts
@@ -292,6 +292,7 @@ const sseData = (value: unknown): string =>
 const artanisSseResponse = (turn: Readonly<{
   deferredToApprovalGate: boolean
   iterations: number
+  pendingApprovalGates: unknown
   persona: unknown
   reply: string
   requestedModel: string
@@ -326,6 +327,7 @@ const artanisSseResponse = (turn: Readonly<{
         channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
         deferredToApprovalGate: turn.deferredToApprovalGate,
         iterations: turn.iterations,
+        pendingApprovalGates: turn.pendingApprovalGates,
         persona: turn.persona,
         requestedModel: turn.requestedModel,
         servedModel: turn.servedModel,
@@ -480,6 +482,7 @@ export const makeOperatorArtanisChatRoutes = <
           channelRef: ARTANIS_OPERATOR_CHANNEL_REF,
           deferredToApprovalGate: turn.deferredToApprovalGate,
           iterations: turn.iterations,
+          pendingApprovalGates: turn.pendingApprovalGates,
           persona: turn.persona,
           reply: turn.reply,
           requestedModel: turn.requestedModel,

--- a/apps/openagents.com/workers/api/src/artanis-operator.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
   ARTANIS_OPERATOR_EMPTY_REPLY_FALLBACK,
+  ARTANIS_OPERATOR_APPROVAL_GATE_REF,
   ARTANIS_OPERATOR_KHALA_MODEL,
   ARTANIS_OPERATOR_MAX_TOOL_ITERATIONS,
   ARTANIS_OPERATOR_SYSTEM_PROMPT,
@@ -696,6 +697,15 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     // plan() ran (the public-safe plan was built) but nothing was executed.
     expect(planned).toEqual([{ objective: 'burn down #6320' }])
     expect(result.deferredToApprovalGate).toBe(true)
+    expect(result.pendingApprovalGates).toEqual([
+      {
+        gateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
+        gateSystem: 'artanis-approval-gates',
+        riskyActionKind: 'pylon_job_dispatch',
+        state: 'pending',
+        toolName: 'dispatch_codex_task',
+      },
+    ])
     expect(result.toolInvocations).toEqual([
       {
         deferredToApprovalGate: true,
@@ -786,6 +796,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     // The gated tool ran (it really fired), and reports the created ref.
     expect(ran).toEqual([{ objective: 'burn down #6320' }])
     expect(result.deferredToApprovalGate).toBe(false)
+    expect(result.pendingApprovalGates).toEqual([])
     expect(result.toolInvocations).toEqual([
       {
         deferredToApprovalGate: false,
@@ -823,6 +834,15 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     if ('error' in result) return
     expect(ran).toEqual([{ objective: 'burn down #6320' }])
     expect(result.deferredToApprovalGate).toBe(true)
+    expect(result.pendingApprovalGates).toEqual([
+      {
+        gateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
+        gateSystem: 'artanis-approval-gates',
+        riskyActionKind: 'pylon_job_dispatch',
+        state: 'pending',
+        toolName: 'dispatch_codex_task',
+      },
+    ])
     expect(result.toolInvocations).toEqual([
       {
         deferredToApprovalGate: true,

--- a/apps/openagents.com/workers/api/src/artanis-operator.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.ts
@@ -554,6 +554,19 @@ export type ArtanisOperatorToolInvocation = Readonly<{
   executedRef: string | null
 }>
 
+// Public-safe, typed pending approval gate emitted when a risky/gated tool does
+// not execute. This is the operator-turn's machine-readable handoff to the
+// `artanis-approval-gates` boundary: it records the exact risky action class and
+// tool that need owner review, without minting authority or pretending the
+// action already ran.
+export type ArtanisOperatorPendingApprovalGate = Readonly<{
+  gateRef: typeof ARTANIS_OPERATOR_APPROVAL_GATE_REF
+  gateSystem: 'artanis-approval-gates'
+  state: 'pending'
+  toolName: string
+  riskyActionKind: ArtanisRiskyActionKind
+}>
+
 // The base operator conversation as normalized inference messages: persona
 // system + grounded context system + the owner conversation. The tool-calling
 // loop appends assistant-tool-call and tool-result messages onto this base.
@@ -671,6 +684,9 @@ export type ArtanisOperatorTurnResult = Readonly<{
   // Public-safe summaries of the tools Artanis invoked during the loop (empty
   // when no tools were used or no tools were configured).
   toolInvocations: ReadonlyArray<ArtanisOperatorToolInvocation>
+  // Typed pending approval gates produced by risky/gated tool deferrals. This
+  // supersedes treating `deferredToApprovalGate` as the only machine signal.
+  pendingApprovalGates: ReadonlyArray<ArtanisOperatorPendingApprovalGate>
   // How many Khala completions the turn made (1 for a no-tool turn, more when
   // the loop executed tools and re-called Khala).
   iterations: number
@@ -900,6 +916,7 @@ export const artanisOperatorTurn = (input: {
     let conversation: ReadonlyArray<InferenceMessage> = baseMessages
 
     const toolInvocations: Array<ArtanisOperatorToolInvocation> = []
+    const pendingApprovalGates: Array<ArtanisOperatorPendingApprovalGate> = []
     // Bounded record of the tool results gathered this turn. Drives the compact
     // composition retry and the grounded synthesis fallback so a blown-up
     // conversation (or a failed late Khala call) never costs the owner a reply.
@@ -981,6 +998,15 @@ export const artanisOperatorTurn = (input: {
         toolInvocations.push(invocation)
         if (invocation.deferredToApprovalGate) {
           toolsDeferred = true
+          if (invocation.riskyActionKind !== null) {
+            pendingApprovalGates.push({
+              gateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
+              gateSystem: 'artanis-approval-gates',
+              riskyActionKind: invocation.riskyActionKind,
+              state: 'pending',
+              toolName: invocation.name,
+            })
+          }
         }
         // Bound the tool result fed back into the conversation. Large bodies
         // (e.g. a 256KB repo file) accumulated verbatim are what push a later
@@ -1079,6 +1105,7 @@ export const artanisOperatorTurn = (input: {
       deferredToApprovalGate:
         mentionsSpendOrDestructive(input.messages) || toolsDeferred,
       iterations,
+      pendingApprovalGates,
       persona: verifyArtanisOperatorPersona(replyText),
       reply: replyText,
       requestedModel: ARTANIS_OPERATOR_KHALA_MODEL,


### PR DESCRIPTION
Addresses #6364.

### Changes
- Added typed pending approval gate metadata to `artanisOperatorTurn` results when risky gated tools are deferred.
- Included pending approval gates in Artanis operator chat JSON and SSE responses.
- Covered deferred and approved gated tool behavior in Artanis operator tests.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).