### PR TITLE
test(inference): derive external-wins proof from response

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/benchmark/stress-saturation-plan.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/stress-saturation-plan.test.ts
@@ -14,6 +14,7 @@ import {
   buildGlmContinuousStressPlan,
   buildGlmContinuousStressRunnerPlan,
   evaluateGlmExternalWinsProbe,
+  evaluateGlmExternalWinsOpenAgentsResponse,
 } from './stress-saturation-plan'
 
 const stressShape = (id: string, concurrency: number): SequenceShape => ({
@@ -629,5 +630,71 @@ describe('GLM continuous stress saturation plan (#6317 prep slice)', () => {
     expect(proof.status).toBe('blocked')
     expect(proof.reasons).toEqual(['missing_scheduler_preemption'])
     expect(proof.schedulerPreemptionTargetOutcome).toBe('missing')
+  })
+
+  test('derives accepted #6318 proof from the public OpenAgents response block', () => {
+    const proof = evaluateGlmExternalWinsOpenAgentsResponse({
+      externalHttpStatus: 200,
+      body: {
+        openagents: {
+          served_model: 'openagents/glm-5.2-reap-504b',
+          supply_lane: 'hydralisk',
+          worker: 'hydralisk-vllm-glm-5p2-reap-504b',
+          routing: {
+            fallback_reason: null,
+            scheduler_preemption: {
+              evidence_ref:
+                'scheduler.preemption.internal_stress.request_live',
+              reason: 'external_preemption',
+              target_demand_class: 'internal_stress',
+              target_outcome: 'preempted_yielded',
+            },
+          },
+        },
+        usage: {
+          total_tokens: 614,
+        },
+      },
+    })
+
+    expect(proof.status).toBe('accepted')
+    expect(proof.servedLane).toBe('glm_primary')
+    expect(proof.fallbackReason).toBeNull()
+    expect(proof.schedulerPreemptionTargetOutcome).toBe('preempted_yielded')
+    expect(proof.usageTotalTokens).toBe(614)
+  })
+
+  test('derives blocked #6318 proof when public response overflowed to a weaker lane', () => {
+    const proof = evaluateGlmExternalWinsOpenAgentsResponse({
+      externalHttpStatus: 200,
+      body: {
+        openagents: {
+          served_model: 'accounts/fireworks/models/glm-4.5',
+          supply_lane: 'fireworks',
+          worker: 'fireworks',
+          routing: {
+            fallback_reason: 'empty_assistant_content',
+            scheduler_preemption: {
+              evidence_ref:
+                'scheduler.preemption.internal_stress.request_fallback',
+              reason: 'external_preemption',
+              target_demand_class: 'internal_stress',
+              target_outcome: 'preempted_yielded',
+            },
+          },
+        },
+        usage: {
+          total_tokens: 614,
+        },
+      },
+    })
+
+    expect(proof.status).toBe('blocked')
+    expect(proof.servedLane).toBe('weaker_fallback')
+    expect(proof.reasons).toEqual([
+      'fallback_after_preemption',
+      'served_lane_not_glm_primary',
+      'empty_glm_content_after_preemption',
+    ])
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/benchmark/stress-saturation-plan.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/stress-saturation-plan.ts
@@ -37,6 +37,9 @@ export const GLM_STRESS_DEMAND_CLIENT = 'stress-harness' as const
 export const GLM_STRESS_EXTERNAL_WINS_POLICY =
   'external_wins_reserved_headroom_and_preemption_required' as const
 
+export const GLM_EXTERNAL_WINS_PRIMARY_SERVED_MODEL =
+  'openagents/glm-5.2-reap-504b' as const
+
 export const GLM_STRESS_ERROR_RATE_BACKOFF_THRESHOLD = 0.02
 
 export const GLM_STRESS_BACKOFF_STEP_FRACTION = 0.25
@@ -298,6 +301,11 @@ export type GlmExternalWinsProofReadout = Readonly<{
   fallbackReason: string | null
   schedulerPreemptionTargetOutcome: 'preempted_yielded' | 'missing'
   usageTotalTokens: number | null
+}>
+
+export type GlmExternalWinsOpenAgentsResponseInput = Readonly<{
+  body: unknown
+  externalHttpStatus: number
 }>
 
 const safePositiveInteger = (value: number): number =>
@@ -825,4 +833,76 @@ export const evaluateGlmExternalWinsProbe = (
         ? null
         : input.usageTotalTokens,
   }
+}
+
+const recordFromUnknown = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {}
+
+const nonEmptyStringFromUnknown = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+
+const nullableStringFromUnknown = (value: unknown): string | null =>
+  value === null ? null : nonEmptyStringFromUnknown(value) ?? null
+
+const finiteNumberFromUnknown = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined
+
+const schedulerPreemptionOutcomeFromUnknown = (
+  value: unknown,
+): 'preempted_yielded' | undefined =>
+  value === 'preempted_yielded' ? 'preempted_yielded' : undefined
+
+const servedLaneFromOpenAgentsResponse = (
+  openagents: Record<string, unknown>,
+): GlmExternalWinsServedLane => {
+  const servedModel = nonEmptyStringFromUnknown(openagents.served_model)
+  const supplyLane = nonEmptyStringFromUnknown(openagents.supply_lane)
+  const worker = nonEmptyStringFromUnknown(openagents.worker)
+
+  if (
+    supplyLane === 'hydralisk' &&
+    servedModel === GLM_EXTERNAL_WINS_PRIMARY_SERVED_MODEL
+  ) {
+    return 'glm_primary'
+  }
+  if (
+    supplyLane === 'fireworks' ||
+    supplyLane === 'openrouter' ||
+    supplyLane === 'vertex-anthropic' ||
+    supplyLane === 'vertex-gemini'
+  ) {
+    return 'weaker_fallback'
+  }
+  if (
+    worker === 'hydralisk-vllm-glm-5p2-reap-504b' &&
+    servedModel === GLM_EXTERNAL_WINS_PRIMARY_SERVED_MODEL
+  ) {
+    return 'glm_primary'
+  }
+  return 'unknown'
+}
+
+export const evaluateGlmExternalWinsOpenAgentsResponse = (
+  input: GlmExternalWinsOpenAgentsResponseInput,
+): GlmExternalWinsProofReadout => {
+  const body = recordFromUnknown(input.body)
+  const openagents = recordFromUnknown(body.openagents)
+  const routing = recordFromUnknown(openagents.routing)
+  const schedulerPreemption = recordFromUnknown(routing.scheduler_preemption)
+  const usage = recordFromUnknown(body.usage)
+
+  return evaluateGlmExternalWinsProbe({
+    externalHttpStatus: input.externalHttpStatus,
+    fallbackReason: nullableStringFromUnknown(routing.fallback_reason),
+    schedulerPreemptionEvidenceRef: nonEmptyStringFromUnknown(
+      schedulerPreemption.evidence_ref,
+    ),
+    schedulerPreemptionTargetOutcome: schedulerPreemptionOutcomeFromUnknown(
+      schedulerPreemption.target_outcome,
+    ),
+    servedLane: servedLaneFromOpenAgentsResponse(openagents),
+    usageTotalTokens: finiteNumberFromUnknown(usage.total_tokens),
+  })
 }


### PR DESCRIPTION
Addresses #6318.

### Changes
- Added parsing for public OpenAgents response metadata into the GLM external-wins proof evaluator.
- Classified primary GLM service versus weaker fallback lanes from response fields.
- Added tests for accepted proof when internal stress is preempted and blocked proof when preemption still falls back to a weaker lane.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).