### PR TITLE
feat(gym): add MirrorCode ladder rung publishing

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/ladder-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/ladder-routes.test.ts
@@ -22,6 +22,7 @@ import {
   type GymLadderLeaderboard,
 } from './ladder'
 import type { GymLadderStore } from './ladder-store'
+import { buildMirrorCodeRun } from './mirrorcode-contract'
 
 const makeMemoryStore = (): GymLadderStore & {
   snapshot: () => GymLadderLeaderboard | undefined
@@ -137,6 +138,7 @@ describe('GET /api/public/gym/leaderboard', () => {
       'awaiting_owner',
       'awaiting_owner',
       'awaiting_owner',
+      'awaiting_owner',
     ])
   })
 
@@ -219,6 +221,54 @@ describe('POST /api/operator/gym/leaderboard', () => {
         .find(r => r.rung === 'rung1')
         ?.entries.map(e => e.lane),
     ).toEqual(['khala', 'bigpickle'])
+  })
+
+  test('publishes a decision-grade MirrorCode rung from public-safe run rows', async () => {
+    const store = makeMemoryStore()
+    const mirrorCodeRun = buildMirrorCodeRun({
+      runId: 'mc-public-cal-python-route-0001',
+      model: 'openagents/khala',
+      taskId: 'cal_python',
+      bucket: 'S',
+      language: 'python',
+      status: 'passed',
+      passRate: 0.875,
+      tokens: { total: 1_500_000_000 },
+      startedAt: '2026-06-27T12:00:00.000Z',
+      finishedAt: '2026-06-27T18:00:00.000Z',
+      summary: 'Decision-grade public MirrorCode cal_python route run.',
+      grade: 'decision_grade',
+    })
+    const publishResponse = await Effect.runPromise(
+      handleOperatorGymLeaderboardApi(
+        new Request('https://x/', {
+          method: 'POST',
+          body: JSON.stringify({
+            reports: [],
+            mirrorCodeRuns: [mirrorCodeRun],
+          }),
+        }),
+        {
+          store,
+          requireAdminApiToken: adminAllowed,
+          nowIso: () => '2026-06-27T19:00:00.000Z',
+        },
+      ),
+    )
+    expect(publishResponse.status).toBe(201)
+    const published = (await publishResponse.json()) as {
+      ladder: GymLadderLeaderboard
+    }
+    const rung4 = published.ladder.rungs.find(r => r.rung === 'rung4')!
+    expect(rung4.state).toBe('published')
+    expect(rung4.mirrorCodeEntries[0]).toEqual(
+      expect.objectContaining({
+        runId: 'mc-public-cal-python-route-0001',
+        passRateBps: 8750,
+        tokensTotal: 1_500_000_000,
+        demandSource: 'gym_mirrorcode',
+      }),
+    )
   })
 
   test('flags an old published ladder as stale instead of making read time look fresh', async () => {

--- a/apps/openagents.com/workers/api/src/inference/gym/ladder-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/ladder-routes.ts
@@ -17,7 +17,7 @@
 // No dispatch, spend, settlement, payout, or public-claim authority beyond the
 // honest decision-grade ranking the shipped harness already produces. The ladder
 // is a recurring projection of owner-armed real benchmark reports.
-import { Effect } from 'effect'
+import { Effect, Schema as S } from 'effect'
 
 import { methodNotAllowed, noStoreJsonResponse } from '../../http/responses'
 import { currentIsoTimestamp } from '../../runtime-primitives'
@@ -34,6 +34,10 @@ import {
 } from './ladder'
 import type { GymLeaderboardReportInput } from './leaderboard'
 import { GymLeaderboardUnsafe } from './leaderboard'
+import {
+  MirrorCodeRun,
+  type MirrorCodeRun as MirrorCodeRunType,
+} from './mirrorcode-contract'
 import type {
   GymLadderSnapshot,
   GymLadderSourceStore,
@@ -157,13 +161,24 @@ const buildPublishedLadder = (
   | Readonly<{ reason: string; tag: 'reject' }>
 > => {
   const body = raw as
-    | { reports?: ReadonlyArray<GymLeaderboardReportInput> }
+    | {
+        reports?: ReadonlyArray<GymLeaderboardReportInput>
+        mirrorCodeRuns?: ReadonlyArray<unknown>
+      }
     | undefined
   const reports = body?.reports
   if (!Array.isArray(reports)) {
     return Effect.succeed({
       reason:
         'A ladder publish needs a `reports` array of decision-grade report inputs.',
+      tag: 'reject' as const,
+    })
+  }
+  const mirrorCodeRunsRaw = body?.mirrorCodeRuns ?? []
+  if (!Array.isArray(mirrorCodeRunsRaw)) {
+    return Effect.succeed({
+      reason:
+        'A ladder publish `mirrorCodeRuns`, when present, must be an array of public-safe MirrorCode run rows.',
       tag: 'reject' as const,
     })
   }
@@ -174,7 +189,12 @@ const buildPublishedLadder = (
         : error instanceof Error
           ? error.message
           : String(error),
-    try: () => buildGymLadderLeaderboard(reports, config),
+    try: () => {
+      const mirrorCodeRuns = mirrorCodeRunsRaw.map(run =>
+        S.decodeUnknownSync(MirrorCodeRun)(run),
+      ) as ReadonlyArray<MirrorCodeRunType>
+      return buildGymLadderLeaderboard(reports, config, mirrorCodeRuns)
+    },
   }).pipe(
     Effect.map(ladder => ({ ladder, tag: 'ok' as const })),
     Effect.catch(reason => Effect.succeed({ reason, tag: 'reject' as const })),

--- a/apps/openagents.com/workers/api/src/inference/gym/ladder-store.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/ladder-store.ts
@@ -32,13 +32,33 @@ const GymLadderOpponentEntrySchema = S.Struct({
   costPerAcceptedOutcomeMsat: S.Number,
 })
 
+const GymLadderMirrorCodeEntrySchema = S.Struct({
+  rank: S.Number,
+  runId: S.String,
+  model: S.String,
+  taskId: S.String,
+  bucket: S.Literals(['S', 'M', 'L']),
+  language: S.NullOr(S.String),
+  status: S.Literals(['queued', 'running', 'passed', 'failed', 'error']),
+  passRateBps: S.Number,
+  tokensTotal: S.Number,
+  startedAt: S.String,
+  finishedAt: S.NullOr(S.String),
+  decisionGrade: S.Literal(true),
+  demandKind: S.Literal('internal'),
+  demandSource: S.Literal('gym_mirrorcode'),
+  generalizationSet: S.String,
+  memoryPolicy: S.String,
+})
+
 const GymLadderRungSchema = S.Struct({
-  rung: S.Literals(['rung1', 'rung2', 'rung3']),
+  rung: S.Literals(['rung1', 'rung2', 'rung3', 'rung4']),
   title: S.String,
   state: S.Literals(['published', 'awaiting_owner']),
   barToClear: S.String,
   opponentLanes: S.Array(S.String),
   entries: S.Array(GymLadderOpponentEntrySchema),
+  mirrorCodeEntries: S.Array(GymLadderMirrorCodeEntrySchema),
   blockerRefs: S.Array(S.String),
 })
 
@@ -94,9 +114,23 @@ type GymLadderD1Row = Readonly<{
 
 const parseStoredLadder = (json: string): GymLadderLeaderboard | undefined => {
   try {
+    const raw = JSON.parse(json) as unknown
+    const normalized =
+      typeof raw === 'object' && raw !== null && Array.isArray((raw as { rungs?: unknown }).rungs)
+        ? {
+            ...raw,
+            rungs: (raw as { rungs: ReadonlyArray<unknown> }).rungs.map(rung =>
+              typeof rung === 'object' &&
+              rung !== null &&
+              !('mirrorCodeEntries' in rung)
+                ? { ...rung, mirrorCodeEntries: [] }
+                : rung,
+            ),
+          }
+        : raw
     return parseJsonWithSchema(
       GymLadderLeaderboardStored,
-      json,
+      JSON.stringify(normalized),
     ) as GymLadderLeaderboard
   } catch {
     return undefined

--- a/apps/openagents.com/workers/api/src/inference/gym/ladder.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/ladder.test.ts
@@ -22,6 +22,10 @@ import {
   gymLadderSnapshotRef,
 } from './ladder'
 import type { GymLeaderboardReportInput } from './leaderboard'
+import {
+  buildMirrorCodeRun,
+  type MirrorCodeRun,
+} from './mirrorcode-contract'
 
 const REALISTIC_SHAPE = {
   id: 'observed-opencode-ladder-run',
@@ -102,15 +106,36 @@ const khalaInput = (costBasisMsat: number): GymLeaderboardReportInput => {
   }
 }
 
+const mirrorCodeRun = (
+  overrides: Partial<Parameters<typeof buildMirrorCodeRun>[0]> = {},
+): MirrorCodeRun =>
+  buildMirrorCodeRun({
+    runId: 'mc-public-cal-python-0001',
+    model: 'openagents/khala',
+    taskId: 'cal_python',
+    bucket: 'S',
+    language: 'python',
+    status: 'passed',
+    passRate: 1,
+    tokens: { total: 1_250_000_000 },
+    startedAt: '2026-06-27T00:00:00.000Z',
+    finishedAt: '2026-06-27T04:00:00.000Z',
+    summary: 'Decision-grade public MirrorCode cal_python run.',
+    grade: 'decision_grade',
+    ...overrides,
+  })
+
 describe('Gym ladder recurring config', () => {
-  test('defines the three deliberate rungs with owner gates + internal demand tagging', () => {
+  test('defines the four deliberate rungs with owner gates + internal demand tagging', () => {
     expect(GYM_LADDER_RUNGS.map(r => r.rung)).toEqual([
       'rung1',
       'rung2',
       'rung3',
+      'rung4',
     ])
     expect(GYM_LADDER_RUNGS[0]?.opponentLanes).toContain('bigpickle')
     expect(GYM_LADDER_RUNGS[2]?.opponentLanes).toEqual(['openai-gpt', 'claude'])
+    expect(GYM_LADDER_RUNGS[3]?.opponentLanes).toEqual([])
     for (const rung of GYM_LADDER_RUNGS) {
       expect(rung.ownerGateRef).toMatch(/^gate\.owner\.gym\.ladder\./)
     }
@@ -141,6 +166,7 @@ describe('Gym ladder leaderboard projection', () => {
       'awaiting_owner',
       'awaiting_owner',
       'awaiting_owner',
+      'awaiting_owner',
     ])
     const rung1 = ladder.rungs[0]!
     expect(rung1.entries).toEqual([])
@@ -153,6 +179,11 @@ describe('Gym ladder leaderboard projection', () => {
     // bigpickle is a fixture_only lane today -> honest fixture-only blocker.
     expect(rung1.blockerRefs).toContain(
       'blocker.gym.ladder.opponent_lane_fixture_only.bigpickle',
+    )
+    const rung4 = ladder.rungs.find(r => r.rung === 'rung4')!
+    expect(rung4.mirrorCodeEntries).toEqual([])
+    expect(rung4.blockerRefs).toContain(
+      'blocker.gym.ladder.mirrorcode.no_decision_grade_public_task_run',
     )
   })
 
@@ -200,18 +231,47 @@ describe('Gym ladder leaderboard projection', () => {
     expect(ladder.rungs.find(r => r.rung === 'rung3')?.state).toBe(
       'awaiting_owner',
     )
+    expect(ladder.rungs.find(r => r.rung === 'rung4')?.state).toBe(
+      'awaiting_owner',
+    )
   })
 
-  test('never publishes fixture / non-decision-grade reports as a rung measurement', () => {
-    const fixture = runGymFixtureExperiment(BUNDLED_GYM_EXPERIMENT)
-    const ladder = buildGymLadderLeaderboard([
-      {
-        ...fixture,
-        reportRef: 'report.gym.ladder.fixture',
-        receiptRef: 'receipt.gym.ladder.fixture',
-        candidateRef: 'bigpickle.fixture.run',
-      },
+  test('publishes rung4 from decision-grade MirrorCode public-task rows', () => {
+    const ladder = buildGymLadderLeaderboard([], undefined, [mirrorCodeRun()])
+    const rung4 = ladder.rungs.find(r => r.rung === 'rung4')!
+    expect(rung4.state).toBe('published')
+    expect(rung4.entries).toEqual([])
+    expect(rung4.blockerRefs).toEqual([])
+    expect(rung4.mirrorCodeEntries).toEqual([
+      expect.objectContaining({
+        rank: 1,
+        runId: 'mc-public-cal-python-0001',
+        taskId: 'cal_python',
+        passRateBps: 10_000,
+        tokensTotal: 1_250_000_000,
+        decisionGrade: true,
+        demandKind: 'internal',
+        demandSource: 'gym_mirrorcode',
+        generalizationSet: 'mirrorcode_public_tasks_no_rag',
+        memoryPolicy: 'no_rag_public_tasks_only',
+      }),
     ])
+  })
+
+  test('never publishes fixture / non-decision-grade reports or MirrorCode smoke as a rung measurement', () => {
+    const fixture = runGymFixtureExperiment(BUNDLED_GYM_EXPERIMENT)
+    const ladder = buildGymLadderLeaderboard(
+      [
+        {
+          ...fixture,
+          reportRef: 'report.gym.ladder.fixture',
+          receiptRef: 'receipt.gym.ladder.fixture',
+          candidateRef: 'bigpickle.fixture.run',
+        },
+      ],
+      undefined,
+      [mirrorCodeRun({ grade: 'smoke' })],
+    )
     expect(ladder.decisionGradeRowCount).toBe(0)
     expect(ladder.excludedReports).toContainEqual({
       reportRef: 'report.gym.ladder.fixture',
@@ -220,6 +280,7 @@ describe('Gym ladder leaderboard projection', () => {
     for (const rung of ladder.rungs) {
       expect(rung.state).toBe('awaiting_owner')
     }
+    expect(ladder.rungs.find(r => r.rung === 'rung4')?.mirrorCodeEntries).toEqual([])
   })
 
   test('carries the honest ladder caveats and no illustrative leakage', () => {
@@ -229,6 +290,9 @@ describe('Gym ladder leaderboard projection', () => {
     )
     expect(ladder.caveatRefs).toContain(
       'caveat.public.gym.ladder.no_beats_frontier_claim_from_single_run',
+    )
+    expect(ladder.caveatRefs).toContain(
+      'caveat.public.gym.ladder.mirrorcode_smoke_runs_never_ranked',
     )
     expect(JSON.stringify(ladder)).not.toContain('illustrativeNotice')
   })

--- a/apps/openagents.com/workers/api/src/inference/gym/ladder.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/ladder.ts
@@ -9,6 +9,7 @@
 //   Rung 1 — Big Pickle (OpenCode's default free model): the baseline.
 //   Rung 2 — other free/open models: the field users reach for when not paying.
 //   Rung 3 — paid frontier (Claude / GPT / Gemini class): the upper bound.
+//   Rung 4 — MirrorCode frontier coding: sustained real-software reproduction.
 //
 // This module owns ONLY the PUBLISHING layer on top of the already-shipped
 // benchmark harness (matrix, runner, report) and the flat
@@ -37,12 +38,13 @@ import {
   type GymLeaderboardReportInput,
   type GymLeaderboardRow,
 } from './leaderboard'
+import type { MirrorCodeRun } from './mirrorcode-contract'
 
 export const GymLadderLeaderboardSchemaVersion =
   'openagents.gym.ladder_leaderboard.v1'
 
-// The three rungs of the ladder, in deliberate climbing order.
-export const GymLadderRungId = S.Literals(['rung1', 'rung2', 'rung3'])
+// The four rungs of the ladder, in deliberate climbing order.
+export const GymLadderRungId = S.Literals(['rung1', 'rung2', 'rung3', 'rung4'])
 export type GymLadderRungId = typeof GymLadderRungId.Type
 
 // How a rung was produced. Only `published` rungs carry decision-grade numbers.
@@ -77,7 +79,7 @@ export type GymLadderRungDefinition = Readonly<{
   ownerGateRef: string
 }>
 
-// The canonical three-rung ladder definition. Lane membership mirrors the matrix
+// The canonical four-rung ladder definition. Lane membership mirrors the matrix
 // availability table + the planning doc `opencode-gym-benchmark-ladder.md`.
 export const GYM_LADDER_RUNGS: ReadonlyArray<GymLadderRungDefinition> = [
   {
@@ -105,6 +107,15 @@ export const GYM_LADDER_RUNGS: ReadonlyArray<GymLadderRungDefinition> = [
       'Honestly measure the gap to paid frontier models and track it shrinking over successive runs. No requirement to beat today.',
     ownerGateRef: 'gate.owner.gym.ladder.rung3.paid_api_keys_and_spend_approval',
   },
+  {
+    rung: 'rung4',
+    title: 'Rung 4 — Khala on MirrorCode public tasks',
+    opponentLanes: [],
+    barToClear:
+      'Measure sustained real-software reimplementation on MirrorCode public tasks, with private tasks excluded and no task/source/test contents published.',
+    ownerGateRef:
+      'gate.owner.gym.ladder.rung4.mirrorcode_public_bucket_decision_grade',
+  },
 ]
 
 // The recurring config: WHICH ladder, at WHAT cadence, and the canonical
@@ -117,7 +128,8 @@ export type GymLadderRecurringConfig = Readonly<{
   // The well-known public dereference path for the latest published ladder.
   publishPath: string
   // The experiment config id the ladder re-runs each cadence (the OpenCode
-  // head-to-head matrix). The owner-armed real sweep arms this config.
+  // head-to-head matrix). The owner-armed real sweep arms this config; the
+  // MirrorCode rung ingests public-safe MirrorCode run rows separately.
   experimentConfigId: string
   // The demand attribution tags every Khala request the ladder drives MUST carry
   // (#6298) so gym traffic stays segmented from external traffic.
@@ -149,6 +161,25 @@ export type GymLadderOpponentEntry = Readonly<{
   costPerAcceptedOutcomeMsat: number
 }>
 
+export type GymLadderMirrorCodeEntry = Readonly<{
+  rank: number
+  runId: string
+  model: string
+  taskId: string
+  bucket: MirrorCodeRun['bucket']
+  language: string | null
+  status: MirrorCodeRun['status']
+  passRateBps: number
+  tokensTotal: number
+  startedAt: string
+  finishedAt: string | null
+  decisionGrade: true
+  demandKind: 'internal'
+  demandSource: 'gym_mirrorcode'
+  generalizationSet: string
+  memoryPolicy: string
+}>
+
 // One rung of the published ladder.
 export type GymLadderRung = Readonly<{
   rung: GymLadderRungId
@@ -159,6 +190,9 @@ export type GymLadderRung = Readonly<{
   // The decision-grade rows that landed on this rung (Khala + measured
   // opponents). Empty when the rung is `awaiting_owner`.
   entries: ReadonlyArray<GymLadderOpponentEntry>
+  // Decision-grade MirrorCode public-task rows for the frontier-coding rung.
+  // Empty on rungs 1-3 and whenever only smoke/in-progress rows exist.
+  mirrorCodeEntries: ReadonlyArray<GymLadderMirrorCodeEntry>
   // When `awaiting_owner`, the honest reasons the rung cannot publish yet.
   blockerRefs: ReadonlyArray<string>
 }>
@@ -186,6 +220,8 @@ const LADDER_CAVEATS = [
   'caveat.public.gym.ladder.awaiting_owner_rungs_show_gate_not_numbers',
   'caveat.public.gym.ladder.no_beats_frontier_claim_from_single_run',
   'caveat.public.gym.ladder.gym_traffic_tagged_internal_gym_ladder',
+  'caveat.public.gym.ladder.mirrorcode_public_tasks_private_set_excluded',
+  'caveat.public.gym.ladder.mirrorcode_smoke_runs_never_ranked',
 ] as const
 
 // Recover the lane from a candidateRef prefix for opponent classification. The
@@ -219,6 +255,49 @@ const toOpponentEntry = (row: GymLeaderboardRow): GymLadderOpponentEntry => ({
   verificationRateBps: row.verificationRateBps,
   costPerAcceptedOutcomeMsat: row.costPerAcceptedOutcomeMsat,
 })
+
+const isDecisionGradeMirrorCodeRun = (run: MirrorCodeRun): boolean =>
+  run.decisionGrade && (run.status === 'passed' || run.status === 'failed')
+
+const toMirrorCodeEntry = (
+  run: MirrorCodeRun,
+  index: number,
+): GymLadderMirrorCodeEntry => ({
+  rank: index + 1,
+  runId: run.runId,
+  model: run.model,
+  taskId: run.taskId,
+  bucket: run.bucket,
+  language: run.language,
+  status: run.status,
+  passRateBps: Math.round((run.passRate ?? 0) * 10_000),
+  tokensTotal: run.tokensTotal,
+  startedAt: run.startedAt,
+  finishedAt: run.finishedAt,
+  decisionGrade: true,
+  demandKind: run.demandKind,
+  demandSource: run.demandSource,
+  generalizationSet: run.generalizationSet,
+  memoryPolicy: run.memoryPolicy,
+})
+
+const mirrorCodeEntriesForLadder = (
+  runs: ReadonlyArray<MirrorCodeRun>,
+): ReadonlyArray<GymLadderMirrorCodeEntry> =>
+  runs
+    .filter(isDecisionGradeMirrorCodeRun)
+    .sort((left, right) => {
+      const passDelta = (right.passRate ?? 0) - (left.passRate ?? 0)
+      if (passDelta !== 0) {
+        return passDelta
+      }
+      const tokenDelta = left.tokensTotal - right.tokensTotal
+      if (tokenDelta !== 0) {
+        return tokenDelta
+      }
+      return left.runId.localeCompare(right.runId)
+    })
+    .map(toMirrorCodeEntry)
 
 // The honest blockers for a rung that has no published opponent measurement yet.
 // A `fixture_only` opponent lane needs a real executor wired + owner arming; a
@@ -258,14 +337,36 @@ const rungBlockers = (
 export const buildGymLadderLeaderboard = (
   inputs: ReadonlyArray<GymLeaderboardReportInput>,
   config: GymLadderRecurringConfig = GYM_LADDER_RECURRING_CONFIG,
+  mirrorCodeRuns: ReadonlyArray<MirrorCodeRun> = [],
 ): GymLadderLeaderboard => {
   const projection: GymLeaderboardProjection =
     buildGymLeaderboardProjection(inputs)
 
   const khalaRows = projection.rows.filter(isKhalaRow)
   const bestKhalaRow = khalaRows[0]
+  const mirrorCodeEntries = mirrorCodeEntriesForLadder(mirrorCodeRuns)
 
   const rungs: Array<GymLadderRung> = config.rungs.map(definition => {
+    if (definition.rung === 'rung4') {
+      const published = mirrorCodeEntries.length > 0
+      return {
+        rung: definition.rung,
+        title: definition.title,
+        state: published ? 'published' : 'awaiting_owner',
+        barToClear: definition.barToClear,
+        opponentLanes: definition.opponentLanes,
+        entries: [],
+        mirrorCodeEntries: published ? mirrorCodeEntries : [],
+        blockerRefs: published
+          ? []
+          : uniqueRefs([
+              'blocker.gym.ladder.mirrorcode.no_decision_grade_public_task_run',
+              'blocker.gym.ladder.mirrorcode.smoke_or_in_progress_runs_not_ranked',
+              definition.ownerGateRef,
+            ]),
+      }
+    }
+
     const opponentLaneSet = new Set(definition.opponentLanes)
     const measuredOpponentRows = projection.rows.filter(row => {
       const lane = laneFromCandidateRef(row.candidateRef)
@@ -301,6 +402,7 @@ export const buildGymLadderLeaderboard = (
       barToClear: definition.barToClear,
       opponentLanes: definition.opponentLanes,
       entries,
+      mirrorCodeEntries: [],
       blockerRefs: published
         ? []
         : rungBlockers(


### PR DESCRIPTION
Addresses #6376.

### Changes
- Adds MirrorCode run ingestion to the operator gym leaderboard publish path via `mirrorCodeRuns`.
- Extends the gym ladder with a published `rung4` populated from decision-grade public-safe MirrorCode runs.
- Stores MirrorCode ladder entries in the persisted leaderboard schema while preserving compatibility with older ladder snapshots.
- Adds route and ladder coverage for MirrorCode-powered rung publishing.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).