### PR TITLE
feat(artanis): plan autonomous Khala improvement ticks

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1829,6 +1829,38 @@ normalizedPatchDigest | behaviorReceiptDigest)`. Exactly one accepted
   `workers/api/src/artanis-owner-authority.test.ts` and the owner-promotion
   cases in `workers/api/src/artanis-operator-dispatch-execution.test.ts`.
 
+## Artanis Autonomous Khala Improvement Tick
+
+- The scheduled Artanis tick is the bounded owner loop for #6359. On every
+  enabled tick it must persist a public-safe plan covering the Khala burndown
+  loop (#6355), trace review (#6356), unsupported requests (#6357), counter
+  health (#6358), Khala CLI feedback (#6360), and the serving umbrella (#6316).
+  Its recurring source refs include the master roadmap
+  `docs/khala/2026-06-26-khala-open-issues-master-roadmap.md`,
+  `api.operator.khala.trace_review`,
+  `api.operator.khala.unsupported_requests`, `api.operator.khala.feedback`,
+  `api.public.khala_tokens_served`, and
+  `docs/inference/inference-engineering-book/` as the "what next" source after
+  the current issue set drains.
+- Autonomous actions are limited to read/triage, own-capacity no-spend
+  Khala -> Pylon -> Codex dispatch planning/execution through the existing
+  `dispatch_codex_task`/`pylon khala burndown` seam, safe stale no-spend lease
+  recovery, closeout verification, exact-token/trace reconciliation, and opening
+  or updating public-safe issue/ledger refs. Counter movement alone is never
+  completion proof; exact `token_usage_events` and owner-only trace rows remain
+  the proof source.
+- The tick does not gain deployment, provider mutation, wallet spend,
+  settlement, payout, L402 redemption, runtime promotion, or third-party/pooled
+  capacity authority. Those actions must stay represented as blocked or
+  approval-required refs and must pass the explicit `artanis-approval-gates`
+  path before any executor treats them as authorized. Owner-Artanis's standing
+  approval remains scoped only to `pylon_job_dispatch` over the owner's own
+  linked capacity and no-spend coding delegation.
+- Regression coverage lives in
+  `workers/api/src/artanis-scheduled-runner.test.ts` for persisted tick source
+  refs, Khala burndown work-routing proposal refs, and owner-promotion dispatch
+  caveats, plus the dispatch execution tests named above.
+
 ## Spark Address Payout Target Registration
 
 - A Pylon may register its OWN Spark address as a payout target so the platform

--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.test.ts
@@ -93,6 +93,7 @@ describe('Artanis scheduled runner', () => {
     )
     expect(result.workProposalRefs).toEqual([
       'work.public.artanis.tassadar_executor_trace.cron_public_artanis_20260607T0520',
+      'work.public.artanis.khala_burndown.cron_public_artanis_20260607T0520',
     ])
     expect(result.forumIntentRefs).toEqual([
       'forum.public.artanis.tassadar_executor_trace_intent.cron_public_artanis_20260607T0520',
@@ -129,6 +130,38 @@ describe('Artanis scheduled runner', () => {
           risk: 'safe',
         }),
         expect.objectContaining({
+          actionRef:
+            'action.public.artanis.khala_burndown_tick.cron_public_artanis_20260607T0520',
+          authorityReceiptRefs: expect.arrayContaining([
+            'authority.public.artanis.owner_promotion.2026-06-27',
+            'authority.public.artanis.standing_pylon_job_dispatch',
+          ]),
+          kind: 'pylon_triage',
+          risk: 'safe',
+        }),
+        expect.objectContaining({
+          actionRef:
+            'action.public.artanis.khala_feedback_and_issue_triage.cron_public_artanis_20260607T0520',
+          evidenceRefs: expect.arrayContaining([
+            'api.operator.khala.feedback',
+            'api.operator.khala.trace_review',
+            'api.operator.khala.unsupported_requests',
+            'github.public.issue.6360',
+          ]),
+          kind: 'status_projection',
+          risk: 'safe',
+        }),
+        expect.objectContaining({
+          actionRef:
+            'action.public.artanis.inference_book_next_source.cron_public_artanis_20260607T0520',
+          evidenceRefs: expect.arrayContaining([
+            'docs/inference/inference-engineering-book/',
+            'github.public.issue.6316',
+          ]),
+          kind: 'status_projection',
+          risk: 'safe',
+        }),
+        expect.objectContaining({
           kind: 'executor_trace_replay',
           risk: 'safe',
         }),
@@ -144,8 +177,17 @@ describe('Artanis scheduled runner', () => {
         }),
       ],
       receiptRefs: expect.arrayContaining([
+        'receipt.public.artanis.khala_burndown_tick_plan.cron_public_artanis_20260607T0520',
+        'receipt.public.artanis.khala_stale_lease_recovery_plan.cron_public_artanis_20260607T0520',
         'receipt.public.artanis.tassadar_executor_dispatch.cron_public_artanis_20260607T0520',
         'receipt.public.artanis.tassadar_executor_replay_verified.cron_public_artanis_20260607T0520',
+      ]),
+      selectedContextRefs: expect.arrayContaining([
+        'api.operator.khala.feedback',
+        'api.operator.khala.trace_review',
+        'api.operator.khala.unsupported_requests',
+        'docs/inference/inference-engineering-book/',
+        'github.public.issue.6359',
       ]),
     })
     expect(store.rows('artanis_forum_publication_intents')).toHaveLength(1)
@@ -175,7 +217,30 @@ describe('Artanis scheduled runner', () => {
       ],
       deliveryState: 'ready',
     })
-    expect(store.rows('artanis_work_routing_proposals')).toHaveLength(1)
+    expect(store.rows('artanis_work_routing_proposals')).toHaveLength(2)
+    const workProposalProjections = store
+      .rows('artanis_work_routing_proposals')
+      .map(row => JSON.parse(row.public_projection_json))
+    const khalaBurndownProposal = workProposalProjections
+      .flatMap(projection => projection.proposals)
+      .find(proposal =>
+        proposal.proposalRef ===
+          'work.public.artanis.khala_burndown.cron_public_artanis_20260607T0520'
+      )
+    expect(khalaBurndownProposal).toMatchObject({
+      capability: 'coding_runtime_probe',
+      sourceEvidenceRefs: expect.arrayContaining([
+        'api.public.khala_served_count',
+        'docs/inference/inference-engineering-book/',
+        'github.public.issue.6355',
+        'github.public.issue.6359',
+      ]),
+      targetCapabilityRefs: expect.arrayContaining([
+        'capability.public.artanis.dispatch_codex_task',
+        'capability.public.pylon.codex_agent_task',
+      ]),
+      workClass: 'validation',
+    })
     expect(store.rows('artanis_approval_gates')).toHaveLength(1)
     expect(
       store.rows('artanis_forum_publication_intents')[0]!.public_projection_json,
@@ -291,7 +356,7 @@ describe('Artanis scheduled runner', () => {
     expect(store.rows('artanis_loop_ticks')).toHaveLength(1)
     expect(store.rows('artanis_approval_gates')).toHaveLength(1)
     expect(store.rows('artanis_health_snapshots')).toHaveLength(1)
-    expect(store.rows('artanis_work_routing_proposals')).toHaveLength(1)
+    expect(store.rows('artanis_work_routing_proposals')).toHaveLength(2)
     expect(store.rows('artanis_forum_publication_intents')).toHaveLength(1)
   })
 

--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
@@ -108,6 +108,13 @@ export type ArtanisScheduledRunnerResult = Readonly<{
   workProposalRefs: ReadonlyArray<string>
 }>
 
+export type ArtanisAutonomousKhalaLoopPlan = Readonly<{
+  allowedAutonomousActionRefs: ReadonlyArray<string>
+  blockedAutonomousActionRefs: ReadonlyArray<string>
+  escalationRefs: ReadonlyArray<string>
+  recurringSourceRefs: ReadonlyArray<string>
+}>
+
 const noRiskyExecutionAuthority: ArtanisScheduledRunnerForbiddenAuthority = {
   adapterInstallAllowed: false,
   deploymentAllowed: false,
@@ -122,6 +129,48 @@ const noRiskyExecutionAuthority: ArtanisScheduledRunnerForbiddenAuthority = {
   trainingLaunchAllowed: false,
   walletSpendAllowed: false,
 }
+
+const AUTONOMOUS_KHALA_LOOP_SOURCE_REFS = [
+  'github.public.issue.6355',
+  'github.public.issue.6356',
+  'github.public.issue.6357',
+  'github.public.issue.6358',
+  'github.public.issue.6359',
+  'github.public.issue.6360',
+  'github.public.issue.6316',
+  'docs/khala/2026-06-26-khala-open-issues-master-roadmap.md',
+  'docs/inference/inference-engineering-book/',
+  'api.operator.khala.trace_review',
+  'api.operator.khala.unsupported_requests',
+  'api.operator.khala.feedback',
+  'api.public.khala_served_count',
+]
+
+const autonomousKhalaLoopPlan = (
+  scheduleSuffix: string,
+): ArtanisAutonomousKhalaLoopPlan => ({
+  allowedAutonomousActionRefs: [
+    `action.public.artanis.khala_burndown_select.${scheduleSuffix}`,
+    `action.public.artanis.khala_burndown_dispatch_own_capacity.${scheduleSuffix}`,
+    `action.public.artanis.khala_burndown_verify_closeout.${scheduleSuffix}`,
+    `action.public.artanis.khala_stale_no_spend_recovery.${scheduleSuffix}`,
+    `action.public.artanis.khala_feedback_triage.${scheduleSuffix}`,
+    `action.public.artanis.khala_counter_health_read.${scheduleSuffix}`,
+  ],
+  blockedAutonomousActionRefs: [
+    `action.public.artanis.wallet_spend.${scheduleSuffix}`,
+    `action.public.artanis.settlement_mutation.${scheduleSuffix}`,
+    `action.public.artanis.provider_mutation.${scheduleSuffix}`,
+    `action.public.artanis.deployment.${scheduleSuffix}`,
+  ],
+  escalationRefs: [
+    'gate.public.artanis.wallet_spend.required',
+    'gate.public.artanis.settlement.required',
+    'gate.public.artanis.provider_mutation.required',
+    'gate.public.artanis.deployment.required',
+  ],
+  recurringSourceRefs: AUTONOMOUS_KHALA_LOOP_SOURCE_REFS,
+})
 
 export const ARTANIS_TASSADAR_EXECUTOR_SAFE_COPY =
   'The proof of concept ran on 2026-06-10: a real registered Pylon executed a digest-pinned exact-program workload dispatched through the operator assignment route, the closeout carried the trace digest byte-identical to the psionic Rust executor fixture, the production worker re-executed the workload as a separate validator device with a Verified exact_trace_replay challenge receipt (and a Rejected receipt on a tampered digest), and one operator-funded paid closeout settled over real Lightning to the Pylon payout target with balance receipts on both sides. Bounded to one workload family and one Pylon; broad executor earning remains gated separately.'
@@ -398,6 +447,10 @@ const scheduledLoop = (
     `receipt.public.artanis.tassadar_executor_replay_verified.${scheduleSuffix}`
   const acceptanceReceiptRef =
     `receipt.public.artanis.tassadar_executor_acceptance.${scheduleSuffix}`
+  const khalaBurndownReceiptRef =
+    `receipt.public.artanis.khala_burndown_tick_plan.${scheduleSuffix}`
+  const staleLeaseRecoveryReceiptRef =
+    `receipt.public.artanis.khala_stale_lease_recovery_plan.${scheduleSuffix}`
   const forumIntentQueuedReceiptRef =
     `receipt.public.artanis.tassadar_executor_forum_intent.${scheduleSuffix}`
   const tickCloseoutReceiptRef =
@@ -411,8 +464,10 @@ const scheduledLoop = (
   const approvalRef =
     `approval.public.artanis.tassadar_executor_paid_sample.${scheduleSuffix}`
   const authorityRef = 'authority.public.artanis.operator_spend_enable'
+  const khalaLoopPlan = autonomousKhalaLoopPlan(scheduleSuffix)
   const publicEvidenceRefs = uniqueRefs([
     ...selectedContextRefs,
+    ...khalaLoopPlan.recurringSourceRefs,
     assignmentRef,
     TASSADAR_EXECUTOR_CAPABILITY_REF,
     `job.public.${TassadarExecutorTraceJobKind}`,
@@ -431,6 +486,67 @@ const scheduledLoop = (
         ],
         evidenceRefs: publicEvidenceRefs,
         kind: 'pylon_triage',
+        risk: 'safe',
+      }),
+      new ArtanisActionProposalRecord({
+        actionRef:
+          `action.public.artanis.khala_burndown_tick.${scheduleSuffix}`,
+        approvalRequirementRefs: [],
+        artifactRefs: [],
+        authorityReceiptRefs: [
+          'authority.public.artanis.owner_promotion.2026-06-27',
+          'authority.public.artanis.standing_pylon_job_dispatch',
+        ],
+        caveatRefs: [
+          'caveat.public.khala_burndown.own_capacity_only',
+          'caveat.public.khala_burndown.no_spend_no_payout',
+          'caveat.public.khala_burndown.counter_movement_not_proof',
+        ],
+        evidenceRefs: [
+          'github.public.issue.6355',
+          'github.public.issue.6359',
+          'apps/pylon/docs/khala-burndown-runbook.md',
+          'api.public.khala_served_count',
+        ],
+        kind: 'pylon_triage',
+        risk: 'safe',
+      }),
+      new ArtanisActionProposalRecord({
+        actionRef:
+          `action.public.artanis.khala_feedback_and_issue_triage.${scheduleSuffix}`,
+        approvalRequirementRefs: [],
+        artifactRefs: [],
+        authorityReceiptRefs: [],
+        caveatRefs: [
+          'caveat.public.artanis.triage_reads_only_until_issue_or_code_patch',
+          'caveat.public.artanis.forum_first_product_promise_reports',
+        ],
+        evidenceRefs: [
+          'github.public.issue.6356',
+          'github.public.issue.6357',
+          'github.public.issue.6360',
+          'api.operator.khala.trace_review',
+          'api.operator.khala.unsupported_requests',
+          'api.operator.khala.feedback',
+        ],
+        kind: 'status_projection',
+        risk: 'safe',
+      }),
+      new ArtanisActionProposalRecord({
+        actionRef:
+          `action.public.artanis.inference_book_next_source.${scheduleSuffix}`,
+        approvalRequirementRefs: [],
+        artifactRefs: [],
+        authorityReceiptRefs: [],
+        caveatRefs: [
+          'caveat.public.artanis.consult_after_current_issue_set_drains',
+          'caveat.public.artanis.open_new_issues_before_broadening_claims',
+        ],
+        evidenceRefs: [
+          'github.public.issue.6316',
+          'docs/inference/inference-engineering-book/',
+        ],
+        kind: 'status_projection',
         risk: 'safe',
       }),
       new ArtanisActionProposalRecord({
@@ -484,7 +600,8 @@ const scheduledLoop = (
     blockerRefs: [],
     caveatRefs: [
       'caveat.public.tick_evidence_only',
-      'caveat.public.runner_no_direct_dispatch_or_spend_authority',
+      'caveat.public.runner_no_spend_or_destructive_authority',
+      'caveat.public.artanis_owner_dispatch_is_own_capacity_only',
       'caveat.public.tassadar_executor_trace.copy_limited_to_safeCopy',
     ],
     closeoutReceiptRefs: [tickCloseoutReceiptRef, closeoutReceiptRef],
@@ -497,6 +614,8 @@ const scheduledLoop = (
     receiptRefs: [
       `receipt.public.artanis.context_loaded.${scheduleSuffix}`,
       dispatchReceiptRef,
+      khalaBurndownReceiptRef,
+      staleLeaseRecoveryReceiptRef,
       closeoutReceiptRef,
       replayReceiptRef,
       acceptanceReceiptRef,
@@ -528,6 +647,61 @@ const scheduledLoop = (
     }),
     tick,
   }
+}
+
+const scheduledKhalaBurndownWorkProposal = (
+  input: ArtanisScheduledRunnerInput,
+  tick: ArtanisLoopTickRecord,
+): ArtanisWorkRoutingProposalRecord => {
+  const scheduleSuffix = refSuffix(input.scheduleRef)
+
+  return new ArtanisWorkRoutingProposalRecord({
+    acceptanceCriteriaRefs: [
+      'criteria.public.khala_burndown.exact_usage_rows',
+      'criteria.public.khala_burndown.owner_only_traces',
+      'criteria.public.khala_burndown.closeout_verified',
+      'criteria.public.khala_burndown.counter_reconciled',
+    ],
+    approvalRequirementRefs: [],
+    blockerRefs: [],
+    capability: 'coding_runtime_probe',
+    costCaveatRefs: ['cost.public.khala_burndown.no_spend_own_capacity'],
+    createdAtIso: input.nowIso,
+    decidedAtIso: input.nowIso,
+    operatorDetailRefs: [
+      'operator.artanis.route.khala_burndown',
+      'operator.artanis.route.khala_feedback_triage',
+      'operator.artanis.route.khala_unsupported_requests',
+    ],
+    proposalRef: `work.public.artanis.khala_burndown.${scheduleSuffix}`,
+    publicCaveatRefs: [
+      'caveat.public.khala_burndown.own_capacity_only',
+      'caveat.public.khala_burndown.no_spend_no_payout',
+      'caveat.public.khala_burndown.no_pooled_capacity',
+      'caveat.public.khala_burndown.safe_stale_lease_recovery_only',
+    ],
+    receiptRefs: tick.receiptRefs,
+    resourceMode: 'background',
+    risk: 'safe_read_only',
+    sourceEvidenceRefs: [
+      ...AUTONOMOUS_KHALA_LOOP_SOURCE_REFS,
+      'apps/pylon/docs/khala-burndown-runbook.md',
+      'apps/openagents.com/INVARIANTS.md',
+    ],
+    spendLimitRefs: ['spend_limit.public.khala_burndown.zero_sats'],
+    state: 'dispatched',
+    target: 'pylon',
+    targetCapabilityRefs: [
+      'capability.public.pylon.codex_agent_task',
+      'capability.public.artanis.dispatch_codex_task',
+    ],
+    traceableWorkRefs: [
+      `assignment.public.artanis.khala_burndown.${scheduleSuffix}`,
+      'assignment.public.khala_coding.own_capacity',
+    ],
+    updatedAtIso: input.nowIso,
+    workClass: 'validation',
+  })
 }
 
 const scheduledExecutorTraceWorkProposal = (
@@ -753,6 +927,7 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       ...context.persistedStateRefs,
       ...context.operatorSteeringRefs,
       ...context.runnerBackendRefs,
+      ...AUTONOMOUS_KHALA_LOOP_SOURCE_REFS,
     ])
     const { assignmentRef, loop, tick } = scheduledLoop(
       input,
@@ -773,6 +948,10 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       input,
       tick,
       assignmentRef,
+    )
+    const khalaBurndownWorkProposal = scheduledKhalaBurndownWorkProposal(
+      input,
+      tick,
     )
     const approvalGate = scheduledSpendApprovalGate(input, tick)
     const forumIntent = scheduledForumIntent(input, tick, publicLoadedContextRefs)
@@ -811,6 +990,12 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       workProposal,
       input.nowIso,
     )
+    const khalaBurndownWorkProposalReceipt =
+      yield* saveArtanisWorkRoutingProposal(
+        input.db,
+        khalaBurndownWorkProposal,
+        input.nowIso,
+      )
     const approvalGateReceipt = yield* saveArtanisApprovalGate(
       input.db,
       approvalGate,
@@ -837,6 +1022,7 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       tickReceipt,
       healthReceipt,
       workProposalReceipt,
+      khalaBurndownWorkProposalReceipt,
       approvalGateReceipt,
       forumIntentReceipt,
       closeoutReceipt,
@@ -863,7 +1049,10 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       state: 'completed',
       storageReceipts,
       tickRef: tick.tickRef,
-      workProposalRefs: [workProposal.proposalRef],
+      workProposalRefs: [
+        workProposal.proposalRef,
+        khalaBurndownWorkProposal.proposalRef,
+      ],
     }
 
     return result


### PR DESCRIPTION
Addresses #6359.

### Changes
- Adds the Artanis Autonomous Khala Improvement Tick invariant, including allowed actions, proof requirements, and authority limits.
- Extends the scheduled Artanis runner to persist Khala burndown planning, feedback and issue triage context, stale lease recovery planning, and inference-book next-source refs.
- Updates scheduled runner coverage for the new Khala work-routing proposal refs, selected context refs, receipts, and persisted proposal count.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)