### PR TITLE
fix(gym): require GLM throughput proof measurements

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/throughput.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/throughput.test.ts
@@ -215,6 +215,15 @@ const measuredRolloutEvidence = (
       chunkedPrefillMatches: true,
       speculativeDecodingMatches: true,
     },
+    prefixCache: {
+      coldRepeatedPrefixTtftP90Ms: 930,
+      warmRepeatedPrefixTtftP90Ms: 440,
+      cacheHitRate: 0.82,
+    },
+    chunkedPrefill: {
+      unchunkedLongPrefillDecodeStallP90Ms: 310,
+      chunkedLongPrefillDecodeStallP90Ms: 95,
+    },
     publicEvidenceRefs: [
       'report.gym.throughput.glm_52.vllm.issue_6320.measurement.001',
       'receipt.gym.throughput.glm_52.vllm.issue_6320.before_after.001',
@@ -577,7 +586,10 @@ describe('Gym throughput/concurrency report (#6244)', () => {
       'live_max_num_seqs',
       'live_vllm_flags',
       'prefix_cache',
+      'prefix_cache_repeated_ttft_p90',
+      'prefix_cache_hit_rate',
       'chunked_prefill',
+      'chunked_prefill_decode_stall_p90',
       'speculative_decode',
       'before_tokens_per_second',
       'after_tokens_per_second',
@@ -593,7 +605,7 @@ describe('Gym throughput/concurrency report (#6244)', () => {
       'public_evidence_refs',
     ])
     expect(readout.evidenceChecklist.map(item => item.status)).toEqual(
-      Array.from({ length: 18 }, () => 'satisfied'),
+      Array.from({ length: 21 }, () => 'satisfied'),
     )
     expect(
       readout.evidenceChecklist.find(item => item.check === 'live_max_num_seqs'),
@@ -612,9 +624,27 @@ describe('Gym throughput/concurrency report (#6244)', () => {
     ).toMatchObject({ expected: true, actual: true })
     expect(
       readout.evidenceChecklist.find(
+        item => item.check === 'prefix_cache_repeated_ttft_p90',
+      ),
+    ).toMatchObject({ expected: 930, actual: 440 })
+    expect(
+      readout.evidenceChecklist.find(
+        item => item.check === 'prefix_cache_hit_rate',
+      ),
+    ).toMatchObject({
+      expected: 'measured_positive_cache_hit_rate',
+      actual: 0.82,
+    })
+    expect(
+      readout.evidenceChecklist.find(
         item => item.check === 'chunked_prefill',
       ),
     ).toMatchObject({ expected: true, actual: true })
+    expect(
+      readout.evidenceChecklist.find(
+        item => item.check === 'chunked_prefill_decode_stall_p90',
+      ),
+    ).toMatchObject({ expected: 310, actual: 95 })
     expect(
       readout.evidenceChecklist.find(
         item => item.check === 'speculative_decode',
@@ -693,6 +723,72 @@ describe('Gym throughput/concurrency report (#6244)', () => {
       canStartIssue6317Stress: true,
       canStartIssue6312Benchmark: true,
       remainingChecks: [],
+    })
+  })
+
+  test('blocks #6320 acceptance when prefix-cache or chunked-prefill measurement proof is missing', () => {
+    const recommendation = measuredGlmRolloutRecommendation()
+    const rolloutRun = buildGymThroughputOwnerArmedRolloutRunArtifact({
+      generatedAt: '2026-06-26T13:00:00.000Z',
+      recommendation,
+      ownerArmRef: 'owner_arm.gym.glm_52.vllm_rollout.issue_6320.v1',
+    })
+    const {
+      prefixCache: _prefixCache,
+      chunkedPrefill: _chunkedPrefill,
+      ...measurementEvidence
+    } = measuredRolloutEvidence(recommendation)
+
+    const readout = buildGymThroughputRolloutReadout({
+      generatedAt: '2026-06-26T13:05:00.000Z',
+      rolloutRun,
+      progressEvidence: {
+        schemaVersion: 'openagents.gym.throughput_rollout_progress_evidence.v1',
+        rolloutRef: 'rollout.gym.glm_52.vllm.issue_6320.measurement.006',
+        observedAt: '2026-06-26T13:04:00.000Z',
+        status: 'measured_lift',
+        ownerArmRef: 'owner_arm.gym.glm_52.vllm_rollout.issue_6320.v1',
+        progressPercent: 100,
+        publicEvidenceRefs: [
+          'report.gym.throughput.glm_52.vllm.issue_6320.measurement.006',
+        ],
+        baselineAggregateTps: recommendation.selection!.baselineAggregateTps,
+        measuredAggregateTps: recommendation.selection!.aggregateTps,
+        measuredThroughputLiftPercent:
+          recommendation.selection!.aggregateTpsLiftPercent,
+        rolloutMeasurementEvidence: measurementEvidence,
+      },
+    })
+
+    expect(readout.status).toBe('blocked')
+    expect(readout.blockers).toEqual([
+      'prefix_cache_measurement_missing',
+      'chunked_prefill_measurement_missing',
+    ])
+    expect(
+      readout.evidenceChecklist.find(
+        item => item.check === 'prefix_cache_repeated_ttft_p90',
+      ),
+    ).toMatchObject({ status: 'mismatch', expected: null, actual: null })
+    expect(
+      readout.evidenceChecklist.find(
+        item => item.check === 'prefix_cache_hit_rate',
+      ),
+    ).toMatchObject({ status: 'mismatch', actual: null })
+    expect(
+      readout.evidenceChecklist.find(
+        item => item.check === 'chunked_prefill_decode_stall_p90',
+      ),
+    ).toMatchObject({ status: 'mismatch', expected: null, actual: null })
+    expect(readout.operatorAcceptance).toMatchObject({
+      status: 'blocked_before_stress_and_benchmark',
+      canStartIssue6317Stress: false,
+      canStartIssue6312Benchmark: false,
+      remainingChecks: [
+        'prefix_cache_repeated_ttft_p90',
+        'prefix_cache_hit_rate',
+        'chunked_prefill_decode_stall_p90',
+      ],
     })
   })
 

--- a/apps/openagents.com/workers/api/src/inference/gym/throughput.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/throughput.ts
@@ -375,6 +375,19 @@ export const GymThroughputRolloutMeasurementEvidence = S.Struct({
   before: GymThroughputRolloutMeasuredPoint,
   after: GymThroughputRolloutMeasuredPoint,
   expectedVsActual: GymThroughputRolloutExpectedVsActualEvidence,
+  prefixCache: S.optional(
+    S.Struct({
+      coldRepeatedPrefixTtftP90Ms: ThroughputMeasuredNumber,
+      warmRepeatedPrefixTtftP90Ms: ThroughputMeasuredNumber,
+      cacheHitRate: ThroughputMeasuredNumber,
+    }),
+  ),
+  chunkedPrefill: S.optional(
+    S.Struct({
+      unchunkedLongPrefillDecodeStallP90Ms: ThroughputMeasuredNumber,
+      chunkedLongPrefillDecodeStallP90Ms: ThroughputMeasuredNumber,
+    }),
+  ),
   publicEvidenceRefs: S.Array(S.String),
 })
 export type GymThroughputRolloutMeasurementEvidence =
@@ -413,6 +426,12 @@ export const GymThroughputRolloutReadoutBlocker = S.Literals([
   'progress_measurement_mismatch',
   'measured_lift_missing',
   'measured_lift_not_positive',
+  'prefix_cache_measurement_missing',
+  'prefix_cache_ttft_not_improved',
+  'prefix_cache_hit_rate_missing',
+  'prefix_cache_hit_rate_zero',
+  'chunked_prefill_measurement_missing',
+  'chunked_prefill_decode_stall_not_improved',
   'glm_fleet_serving_not_ready',
   'glm_fleet_durability_acceptance_not_complete',
 ])
@@ -464,7 +483,10 @@ export const GymThroughputRolloutEvidenceChecklistCheck = S.Literals([
   'live_max_num_seqs',
   'live_vllm_flags',
   'prefix_cache',
+  'prefix_cache_repeated_ttft_p90',
+  'prefix_cache_hit_rate',
   'chunked_prefill',
+  'chunked_prefill_decode_stall_p90',
   'speculative_decode',
   'before_tokens_per_second',
   'after_tokens_per_second',
@@ -1064,6 +1086,31 @@ const rolloutExpectedActualMatches = (
     evidence.after.configuration,
   )
 
+const prefixCacheTtftImproved = (
+  evidence: GymThroughputRolloutMeasurementEvidence,
+): boolean =>
+  evidence.prefixCache !== undefined &&
+  isMeasured(evidence.prefixCache.coldRepeatedPrefixTtftP90Ms) &&
+  isMeasured(evidence.prefixCache.warmRepeatedPrefixTtftP90Ms) &&
+  evidence.prefixCache.warmRepeatedPrefixTtftP90Ms <
+    evidence.prefixCache.coldRepeatedPrefixTtftP90Ms
+
+const prefixCacheHitRateMeasuredPositive = (
+  evidence: GymThroughputRolloutMeasurementEvidence,
+): boolean =>
+  evidence.prefixCache !== undefined &&
+  isMeasured(evidence.prefixCache.cacheHitRate) &&
+  evidence.prefixCache.cacheHitRate > 0
+
+const chunkedPrefillDecodeStallImproved = (
+  evidence: GymThroughputRolloutMeasurementEvidence,
+): boolean =>
+  evidence.chunkedPrefill !== undefined &&
+  isMeasured(evidence.chunkedPrefill.unchunkedLongPrefillDecodeStallP90Ms) &&
+  isMeasured(evidence.chunkedPrefill.chunkedLongPrefillDecodeStallP90Ms) &&
+  evidence.chunkedPrefill.chunkedLongPrefillDecodeStallP90Ms <
+    evidence.chunkedPrefill.unchunkedLongPrefillDecodeStallP90Ms
+
 const sameVllmFlags = (
   left: ReadonlyArray<GymThroughputRolloutVllmFlag>,
   right: ReadonlyArray<GymThroughputRolloutVllmFlag>,
@@ -1235,6 +1282,26 @@ const rolloutEvidenceChecklist = (input: {
       publicEvidenceRefs,
     }),
     checklistItem({
+      check: 'prefix_cache_repeated_ttft_p90',
+      status: matchedChecklistStatus(
+        evidence !== null && expectedConfiguration?.prefixCachingEnabled === true,
+        evidence === null ? false : prefixCacheTtftImproved(evidence),
+      ),
+      expected: evidence?.prefixCache?.coldRepeatedPrefixTtftP90Ms ?? null,
+      actual: evidence?.prefixCache?.warmRepeatedPrefixTtftP90Ms ?? null,
+      publicEvidenceRefs,
+    }),
+    checklistItem({
+      check: 'prefix_cache_hit_rate',
+      status: matchedChecklistStatus(
+        evidence !== null && expectedConfiguration?.prefixCachingEnabled === true,
+        evidence === null ? false : prefixCacheHitRateMeasuredPositive(evidence),
+      ),
+      expected: 'measured_positive_cache_hit_rate',
+      actual: evidence?.prefixCache?.cacheHitRate ?? null,
+      publicEvidenceRefs,
+    }),
+    checklistItem({
       check: 'chunked_prefill',
       status: matchedChecklistStatus(
         evidence !== null,
@@ -1242,6 +1309,18 @@ const rolloutEvidenceChecklist = (input: {
       ),
       expected: expectedConfiguration?.chunkedPrefillEnabled ?? null,
       actual: actualConfiguration?.chunkedPrefillEnabled ?? null,
+      publicEvidenceRefs,
+    }),
+    checklistItem({
+      check: 'chunked_prefill_decode_stall_p90',
+      status: matchedChecklistStatus(
+        evidence !== null && expectedConfiguration?.chunkedPrefillEnabled === true,
+        evidence === null ? false : chunkedPrefillDecodeStallImproved(evidence),
+      ),
+      expected:
+        evidence?.chunkedPrefill?.unchunkedLongPrefillDecodeStallP90Ms ?? null,
+      actual:
+        evidence?.chunkedPrefill?.chunkedLongPrefillDecodeStallP90Ms ?? null,
       publicEvidenceRefs,
     }),
     checklistItem({
@@ -1475,6 +1554,53 @@ export const buildGymThroughputRolloutReadout = (input: {
       }
       if (!rolloutExpectedActualMatches(rolloutMeasurementEvidence)) {
         blockers.push('expected_actual_evidence_mismatch')
+      }
+      if (
+        input.rolloutRun.recommendation.selection?.prefixCachingEnabled ===
+          true &&
+        rolloutMeasurementEvidence.prefixCache === undefined
+      ) {
+        blockers.push('prefix_cache_measurement_missing')
+      }
+      if (
+        input.rolloutRun.recommendation.selection?.prefixCachingEnabled ===
+          true &&
+        rolloutMeasurementEvidence.prefixCache !== undefined &&
+        !prefixCacheTtftImproved(rolloutMeasurementEvidence)
+      ) {
+        blockers.push('prefix_cache_ttft_not_improved')
+      }
+      if (
+        input.rolloutRun.recommendation.selection?.prefixCachingEnabled ===
+          true &&
+        rolloutMeasurementEvidence.prefixCache !== undefined &&
+        !isMeasured(rolloutMeasurementEvidence.prefixCache.cacheHitRate)
+      ) {
+        blockers.push('prefix_cache_hit_rate_missing')
+      }
+      if (
+        input.rolloutRun.recommendation.selection?.prefixCachingEnabled ===
+          true &&
+        rolloutMeasurementEvidence.prefixCache !== undefined &&
+        isMeasured(rolloutMeasurementEvidence.prefixCache.cacheHitRate) &&
+        rolloutMeasurementEvidence.prefixCache.cacheHitRate <= 0
+      ) {
+        blockers.push('prefix_cache_hit_rate_zero')
+      }
+      if (
+        input.rolloutRun.recommendation.selection?.chunkedPrefillEnabled ===
+          true &&
+        rolloutMeasurementEvidence.chunkedPrefill === undefined
+      ) {
+        blockers.push('chunked_prefill_measurement_missing')
+      }
+      if (
+        input.rolloutRun.recommendation.selection?.chunkedPrefillEnabled ===
+          true &&
+        rolloutMeasurementEvidence.chunkedPrefill !== undefined &&
+        !chunkedPrefillDecodeStallImproved(rolloutMeasurementEvidence)
+      ) {
+        blockers.push('chunked_prefill_decode_stall_not_improved')
       }
       if (
         progressEvidence !== null &&


### PR DESCRIPTION
Addresses #6320.

### Changes
- Adds prefix-cache and chunked-prefill measurement evidence fields to the GLM throughput rollout schema.
- Extends rollout acceptance blockers and checklist items so #6320 remains blocked unless repeated-prefix TTFT, cache-hit rate, and long-prefill decode-stall proof are present and improved.
- Adds tests for satisfied measurement proof and missing-proof rejection.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).