### PR TITLE
fix(mobile): accept JSON Artanis replies

### DIFF
--- a/clients/mobile/Khala/Khala/Net/KhalaArtanis.swift
+++ b/clients/mobile/Khala/Khala/Net/KhalaArtanis.swift
@@ -44,6 +44,19 @@ extension KhalaClient {
                         throw KhalaError.http(http.statusCode, body)
                     }
 
+                    let contentType = http.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
+                    if !contentType.contains("text/event-stream") {
+                        let body = await Self.collectArtanisBody(from: bytes)
+                        guard let reply = Self.artanisReply(from: body) else {
+                            throw KhalaError.decoding
+                        }
+                        if !reply.isEmpty {
+                            continuation.yield(reply)
+                        }
+                        continuation.finish()
+                        return
+                    }
+
                     for try await line in bytes.lines {
                         try Task.checkCancellation()
                         guard let delta = Self.delta(fromSSELine: line) else { continue }
@@ -99,5 +112,24 @@ extension KhalaClient {
             // Best-effort; return whatever was read.
         }
         return String(data: collected, encoding: .utf8) ?? ""
+    }
+
+    private static func collectArtanisBody(from bytes: URLSession.AsyncBytes) async -> Data {
+        var collected = Data()
+        do {
+            for try await byte in bytes {
+                collected.append(byte)
+            }
+        } catch {
+            // Best-effort; parser will fail closed if the response is incomplete.
+        }
+        return collected
+    }
+
+    private static func artanisReply(from data: Data) -> String? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let reply = obj["reply"] as? String
+        else { return nil }
+        return reply
     }
 }

--- a/clients/mobile/Khala/KhalaTests/KhalaStreamTests.swift
+++ b/clients/mobile/Khala/KhalaTests/KhalaStreamTests.swift
@@ -186,6 +186,37 @@ final class KhalaStreamTests: XCTestCase {
         XCTAssertEqual(deltas, ["Working"])
     }
 
+    func testArtanisStreamAcceptsSharedEndpointJSONReply() async throws {
+        let session = makeSession()
+        let apiKey = "oa_agent_owner_key"
+
+        StreamMockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://openagents.com/api/operator/artanis/chat")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(apiKey)")
+
+            return (
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                Data(#"{ "reply": "I am tracking current Khala operations." }"#.utf8)
+            )
+        }
+
+        var deltas: [String] = []
+        for try await delta in KhalaClient.streamArtanisCompletion(
+            messages: [.init(role: "user", content: "status")],
+            apiKey: apiKey,
+            session: session
+        ) {
+            deltas.append(delta)
+        }
+        XCTAssertEqual(deltas, ["I am tracking current Khala operations."])
+    }
+
     func testCancellationStopsStreamCleanly() async throws {
         let session = makeSession()
         StreamMockURLProtocol.requestHandler = { request in


### PR DESCRIPTION
Addresses #6363.

### Changes
- Added handling for non-SSE Artanis chat responses that return `application/json` with a `reply` field.
- Added a Khala stream test covering the shared operator Artanis endpoint JSON reply path.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).