### PR TITLE
feat(khala): add GLM stress supervisor ticks

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/benchmark/live-adaptive-stress-runner.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/live-adaptive-stress-runner.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from 'vitest'
 
 import {
   GLM_LIVE_ADAPTIVE_STRESS_ARTIFACT_SCHEMA,
+  GLM_LIVE_ADAPTIVE_STRESS_SUPERVISOR_SCHEMA,
   GLM_REAP_SERVED_MODEL,
   buildGlmLiveAdaptiveStressArtifact,
+  buildGlmLiveAdaptiveStressSupervisorTick,
   classifyGlmLiveAdaptiveStressFailure,
   decideGlmLiveAdaptiveStressConcurrency,
   decideGlmLiveAdaptiveStressWindowBreaker,
@@ -318,5 +320,131 @@ describe('GLM live adaptive stress runner utilities (#6317)', () => {
     )
     expect(classifyGlmLiveAdaptiveStressFailure(429, 0)).toBe('rate_limited')
     expect(classifyGlmLiveAdaptiveStressFailure(null, 28)).toBe('timeout')
+  })
+
+  test('supervisor dispatches the next continuous window with public telemetry only', () => {
+    const previousArtifact = buildGlmLiveAdaptiveStressArtifact({
+      demandClient: 'issue6317-continuous',
+      durationMs: 60_000,
+      finalConcurrency: 3,
+      generatedAt: '2026-06-27T15:00:00.000Z',
+      initialConcurrency: 2,
+      maxConcurrency: 6,
+      maxTokens: 512,
+      minConcurrency: 2,
+      model: 'openagents/khala',
+      observations: [okObservation('glm-clean-1', 1200)],
+      runId: 'issue6317-continuous-0001',
+      windowMs: 60_000,
+      windows: [],
+    })
+
+    const tick = buildGlmLiveAdaptiveStressSupervisorTick({
+      cadenceMs: 60_000,
+      externalDemandActive: false,
+      generatedAt: '2026-06-27T15:01:00.000Z',
+      initialConcurrency: 2,
+      maxConcurrency: 6,
+      maxTicks: 10,
+      minConcurrency: 2,
+      model: 'openagents/khala',
+      previousArtifact,
+      runIdPrefix: 'issue6317-continuous',
+      tickIndex: 1,
+    })
+
+    expect(tick).toMatchObject({
+      action: 'dispatch_next_window',
+      demandKind: GLM_STRESS_DEMAND_KIND,
+      demandSource: GLM_STRESS_DEMAND_SOURCE,
+      nextEarliestStartAt: '2026-06-27T15:02:00.000Z',
+      nextRunId: 'issue6317-continuous-0002',
+      previousFinalConcurrency: 3,
+      previousRunId: 'issue6317-continuous-0001',
+      publicSafe: true,
+      recommendedInitialConcurrency: 3,
+      schema: GLM_LIVE_ADAPTIVE_STRESS_SUPERVISOR_SCHEMA,
+      telemetrySchema: GLM_CONTINUOUS_STRESS_TELEMETRY_SCHEMA,
+    })
+    expect(tick.previousSummary).toMatchObject({
+      failedCount: 0,
+      okCount: 1,
+      totalTokens: 1200,
+    })
+    expect(tick.reasonRefs).toEqual([
+      'supervisor.glm_live_adaptive_stress.continuous_window_ready',
+      'supervisor.glm_live_adaptive_stress.previous_window_clean',
+    ])
+    expect(JSON.stringify(tick)).not.toMatch(
+      /prompt|completion|bearer|secret|https?:\/\//i,
+    )
+  })
+
+  test('supervisor yields instantly to external demand and keeps stress at the floor', () => {
+    const previousArtifact = buildGlmLiveAdaptiveStressArtifact({
+      demandClient: 'issue6317-continuous',
+      durationMs: 60_000,
+      finalConcurrency: 5,
+      generatedAt: '2026-06-27T15:00:00.000Z',
+      initialConcurrency: 5,
+      maxConcurrency: 6,
+      maxTokens: 512,
+      minConcurrency: 2,
+      model: 'openagents/khala',
+      observations: [overloadObservation('failed-before-yield')],
+      runId: 'issue6317-continuous-0003',
+      windowMs: 60_000,
+      windows: [],
+    })
+
+    const tick = buildGlmLiveAdaptiveStressSupervisorTick({
+      cadenceMs: 60_000,
+      externalDemandActive: true,
+      generatedAt: '2026-06-27T15:04:00.000Z',
+      initialConcurrency: 5,
+      maxConcurrency: 6,
+      maxTicks: 10,
+      minConcurrency: 2,
+      model: 'openagents/khala',
+      previousArtifact,
+      runIdPrefix: 'issue6317-continuous',
+      tickIndex: 4,
+    })
+
+    expect(tick).toMatchObject({
+      action: 'yield_to_external',
+      nextRunId: null,
+      recommendedInitialConcurrency: 2,
+    })
+    expect(tick.reasonRefs).toEqual([
+      'supervisor.glm_live_adaptive_stress.external_demand_active',
+      'supervisor.glm_live_adaptive_stress.previous_backoff_carried_forward',
+    ])
+  })
+
+  test('supervisor completes after the configured bounded tick budget', () => {
+    const tick = buildGlmLiveAdaptiveStressSupervisorTick({
+      cadenceMs: 60_000,
+      externalDemandActive: false,
+      generatedAt: '2026-06-27T15:10:00.000Z',
+      initialConcurrency: 2,
+      maxConcurrency: 6,
+      maxTicks: 10,
+      minConcurrency: 2,
+      model: 'openagents/khala',
+      runIdPrefix: 'issue6317-continuous',
+      tickIndex: 10,
+    })
+
+    expect(tick).toMatchObject({
+      action: 'complete',
+      nextEarliestStartAt: null,
+      nextRunId: null,
+      previousRunId: null,
+      recommendedInitialConcurrency: 2,
+    })
+    expect(tick.reasonRefs).toEqual([
+      'supervisor.glm_live_adaptive_stress.max_ticks_completed',
+    ])
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/benchmark/live-adaptive-stress-runner.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/live-adaptive-stress-runner.ts
@@ -14,6 +14,9 @@ export const GLM_LIVE_ADAPTIVE_STRESS_RUNNER_SCHEMA =
 export const GLM_LIVE_ADAPTIVE_STRESS_ARTIFACT_SCHEMA =
   'openagents.khala.glm_live_adaptive_stress_artifact.v0_1' as const
 
+export const GLM_LIVE_ADAPTIVE_STRESS_SUPERVISOR_SCHEMA =
+  'openagents.khala.glm_live_adaptive_stress_supervisor_tick.v0_1' as const
+
 export const GLM_REAP_SERVED_MODEL = 'openagents/glm-5.2-reap-504b' as const
 
 export const GLM_LIVE_ADAPTIVE_STRESS_WINDOW_BREAKER_MAX_OBSERVATIONS = 3
@@ -36,6 +39,18 @@ export type GlmLiveAdaptiveStressDecisionReason =
   | 'error_rate_over_budget'
   | 'external_preemption_observed'
   | 'overload_failures_observed'
+
+export type GlmLiveAdaptiveStressSupervisorAction =
+  | 'dispatch_next_window'
+  | 'yield_to_external'
+  | 'complete'
+
+export type GlmLiveAdaptiveStressSupervisorReason =
+  | 'continuous_window_ready'
+  | 'external_demand_active'
+  | 'max_ticks_completed'
+  | 'previous_backoff_carried_forward'
+  | 'previous_window_clean'
 
 export type GlmLiveAdaptiveStressObservation = Readonly<{
   requestRef: string
@@ -132,6 +147,31 @@ export type GlmLiveAdaptiveStressArtifact = Readonly<{
   observations: ReadonlyArray<GlmLiveAdaptiveStressObservation>
 }>
 
+export type GlmLiveAdaptiveStressSupervisorTick = Readonly<{
+  schema: typeof GLM_LIVE_ADAPTIVE_STRESS_SUPERVISOR_SCHEMA
+  telemetrySchema: typeof GLM_CONTINUOUS_STRESS_TELEMETRY_SCHEMA
+  publicSafe: true
+  generatedAt: string
+  runIdPrefix: string
+  tickIndex: number
+  maxTicks: number
+  cadenceMs: number
+  action: GlmLiveAdaptiveStressSupervisorAction
+  nextRunId: string | null
+  nextEarliestStartAt: string | null
+  demandKind: typeof GLM_STRESS_DEMAND_KIND
+  demandSource: typeof GLM_STRESS_DEMAND_SOURCE
+  demandClient: string
+  model: string
+  minConcurrency: number
+  maxConcurrency: number
+  recommendedInitialConcurrency: number
+  previousRunId: string | null
+  previousFinalConcurrency: number | null
+  previousSummary: GlmLiveAdaptiveStressSummary | null
+  reasonRefs: ReadonlyArray<string>
+}>
+
 const positiveIntegerOr = (value: number, fallback: number): number =>
   Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback
 
@@ -149,6 +189,11 @@ const reasonRefs = (
   reasons: ReadonlyArray<GlmLiveAdaptiveStressDecisionReason>,
 ): ReadonlyArray<string> =>
   reasons.map(reason => `runner.glm_live_adaptive_stress.${reason}`)
+
+const supervisorReasonRefs = (
+  reasons: ReadonlyArray<GlmLiveAdaptiveStressSupervisorReason>,
+): ReadonlyArray<string> =>
+  reasons.map(reason => `supervisor.glm_live_adaptive_stress.${reason}`)
 
 const nextLowerConcurrency = (
   currentConcurrency: number,
@@ -496,3 +541,102 @@ export const buildGlmLiveAdaptiveStressArtifact = (input: {
   windows: input.windows,
   observations: input.observations,
 })
+
+export const buildGlmLiveAdaptiveStressSupervisorTick = (input: {
+  readonly generatedAt: string
+  readonly runIdPrefix: string
+  readonly tickIndex: number
+  readonly maxTicks: number
+  readonly cadenceMs: number
+  readonly model: string
+  readonly initialConcurrency: number
+  readonly minConcurrency: number
+  readonly maxConcurrency: number
+  readonly externalDemandActive: boolean
+  readonly previousArtifact?: GlmLiveAdaptiveStressArtifact | undefined
+}): GlmLiveAdaptiveStressSupervisorTick => {
+  const tickIndex = Math.max(0, Math.floor(input.tickIndex))
+  const maxTicks = Math.max(0, Math.floor(input.maxTicks))
+  const cadenceMs = positiveIntegerOr(input.cadenceMs, 60_000)
+  const minConcurrency = positiveIntegerOr(input.minConcurrency, 1)
+  const maxConcurrency = Math.max(
+    minConcurrency,
+    positiveIntegerOr(input.maxConcurrency, minConcurrency),
+  )
+  const previousFinalConcurrency =
+    input.previousArtifact === undefined
+      ? null
+      : boundedConcurrency(
+          input.previousArtifact.finalConcurrency,
+          minConcurrency,
+          maxConcurrency,
+        )
+  const carriedConcurrency =
+    previousFinalConcurrency ??
+    boundedConcurrency(input.initialConcurrency, minConcurrency, maxConcurrency)
+  const previousSummary =
+    input.previousArtifact === undefined ? null : input.previousArtifact.summary
+  const previousHadBackoff =
+    previousSummary !== null &&
+    (previousSummary.failedCount > 0 || previousSummary.preemptedCount > 0)
+  const previousWasClean =
+    previousSummary !== null &&
+    previousSummary.failedCount === 0 &&
+    previousSummary.preemptedCount === 0 &&
+    previousSummary.okCount > 0
+  const action: GlmLiveAdaptiveStressSupervisorAction =
+    tickIndex >= maxTicks
+      ? 'complete'
+      : input.externalDemandActive
+        ? 'yield_to_external'
+        : 'dispatch_next_window'
+  const recommendedInitialConcurrency =
+    action === 'yield_to_external' || action === 'complete'
+      ? minConcurrency
+      : carriedConcurrency
+  const nextEarliestStartAt =
+    action === 'complete'
+      ? null
+      : new Date(Date.parse(input.generatedAt) + cadenceMs).toISOString()
+  const reasons: Array<GlmLiveAdaptiveStressSupervisorReason> = [
+    ...(action === 'complete' ? (['max_ticks_completed'] as const) : []),
+    ...(action === 'yield_to_external'
+      ? (['external_demand_active'] as const)
+      : []),
+    ...(action === 'dispatch_next_window'
+      ? (['continuous_window_ready'] as const)
+      : []),
+    ...(previousHadBackoff
+      ? (['previous_backoff_carried_forward'] as const)
+      : []),
+    ...(previousWasClean ? (['previous_window_clean'] as const) : []),
+  ]
+
+  return {
+    schema: GLM_LIVE_ADAPTIVE_STRESS_SUPERVISOR_SCHEMA,
+    telemetrySchema: GLM_CONTINUOUS_STRESS_TELEMETRY_SCHEMA,
+    publicSafe: true,
+    generatedAt: input.generatedAt,
+    runIdPrefix: input.runIdPrefix,
+    tickIndex,
+    maxTicks,
+    cadenceMs,
+    action,
+    nextRunId:
+      action === 'dispatch_next_window'
+        ? `${input.runIdPrefix}-${String(tickIndex + 1).padStart(4, '0')}`
+        : null,
+    nextEarliestStartAt,
+    demandKind: GLM_STRESS_DEMAND_KIND,
+    demandSource: GLM_STRESS_DEMAND_SOURCE,
+    demandClient: input.runIdPrefix,
+    model: input.model,
+    minConcurrency,
+    maxConcurrency,
+    recommendedInitialConcurrency,
+    previousRunId: input.previousArtifact?.runId ?? null,
+    previousFinalConcurrency,
+    previousSummary,
+    reasonRefs: supervisorReasonRefs([...new Set(reasons)]),
+  }
+}

--- a/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md
+++ b/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md
@@ -265,7 +265,12 @@ operator view of what remains, not a public product claim.
   tokens and `178691` non-GLM/fallback tokens from earlier fallback/probe
   behavior, so the GLM stress ledger is now over the owner-requested
   `5,000,000` token threshold.
-  #6317 remains open for continuous scheduling/public telemetry and a
+  A 2026-06-28 prep slice added a bounded public-safe continuous supervisor tick
+  artifact around the adaptive runner. It carries the next run id, cadence,
+  carried-forward concurrency, previous public summary, and yield/complete
+  reason refs through `openagents.khala.telemetry.v1`, and it drops stress to
+  the floor instead of dispatching when external demand is active. #6317 remains
+  open for wiring that supervisor into the live durable loop and proving a
   controlled external-demand spike with zero external failure.
 - 2026-06-27T11:03Z #6323 isolated live-host attempt: `us-central1` could not
   allocate another 8x RTX PRO 6000 Spot host because regional preemptible quota

--- a/docs/stress-testing/2026-06-26-glm-counter-backed-stress-test.md
+++ b/docs/stress-testing/2026-06-26-glm-counter-backed-stress-test.md
@@ -1327,3 +1327,26 @@ Counter/page proof after the clean breaker run:
   `2026-06-27T14:51:45.307Z`
 - `/khala`: HTTP `200`
 - `/stats`: HTTP `200`
+
+## 2026-06-28 Continuous Supervisor Prep
+
+The adaptive runner now has a bounded public-safe supervisor tick artifact in
+`live-adaptive-stress-runner`. The tick records the continuous cadence, next run
+id, carried-forward concurrency, previous public summary, and reason refs using
+the same `openagents.khala.telemetry.v1` telemetry schema. It dispatches the
+next window only when external demand is clear, yields immediately to external
+demand by dropping the recommended initial concurrency to the configured floor,
+and completes once the bounded tick budget is exhausted.
+
+This is scheduler/publication prep, not live stress completion. The artifact is
+intended to be the durable control row the always-on loop publishes between
+adaptive windows, without raw prompts, completions, URLs, bearer material, or
+private runner output. #6317 still needs the controlled external-demand spike
+proof with zero external failure before the continuous lane should be treated as
+accepted live infrastructure.
+
+Verification for this prep:
+
+- `bun run --cwd apps/openagents.com/workers/api test --
+  src/inference/benchmark/live-adaptive-stress-runner.test.ts`: `11` tests
+  passed.


### PR DESCRIPTION
Addresses #6317.

### Changes
- Added a public-safe GLM live adaptive stress supervisor tick schema and builder for continuous max-capacity stress windows.
- Added supervisor behavior for dispatching the next window, yielding to external demand, carrying backoff to the floor, and completing after the bounded tick budget.
- Added tests covering supervisor telemetry, public-safety constraints, external-demand yield behavior, and completion.
- Updated the Khala roadmap and GLM counter-backed stress test docs with the continuous supervisor coverage.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).