### PR TITLE
fix(benchmark): pair real sweep workloads with observed shapes

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/benchmark/matrix.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/matrix.test.ts
@@ -14,6 +14,7 @@ import {
   laneAvailability,
   verificationExpectationForWorkload,
 } from './matrix'
+import type { BenchmarkMatrixConfig } from './matrix'
 
 describe('benchmark matrix — expansion', () => {
   test('expands to exactly the cross-product cardinality', () => {
@@ -27,6 +28,48 @@ describe('benchmark matrix — expansion', () => {
     // 2 targets × 1 workload × 1 shape × 1 transport × 1 sampling = 2.
     expect(expectedCellCount(TINY_TEST_CONFIG)).toBe(2)
     expect(expandMatrix(TINY_TEST_CONFIG).length).toBe(2)
+  })
+
+  test('workload-shape pairs restrict real suites without changing default cross-products', () => {
+    const config = {
+      ...TINY_TEST_CONFIG,
+      id: 'paired-workload-shape-test-v1',
+      workloads: ['chat', 'verifier-run'],
+      shapes: [
+        {
+          id: 'observed-chat',
+          inputTokens: 500,
+          outputTokens: 200,
+          cacheablePrefixTokens: 0,
+          concurrency: 1,
+          provenance: 'realistic',
+        },
+        {
+          id: 'observed-verifier',
+          inputTokens: 1800,
+          outputTokens: 700,
+          cacheablePrefixTokens: 900,
+          concurrency: 1,
+          provenance: 'realistic',
+        },
+      ],
+      workloadShapePairs: [
+        { workload: 'chat', shapeId: 'observed-chat' },
+        { workload: 'verifier-run', shapeId: 'observed-verifier' },
+      ],
+    } satisfies BenchmarkMatrixConfig
+
+    const cells = expandMatrix(config)
+    expect(expectedCellCount(config)).toBe(4)
+    expect(cells).toHaveLength(4)
+    expect(
+      cells.every(
+        cell =>
+          (cell.workload === 'chat' && cell.shape.id === 'observed-chat') ||
+          (cell.workload === 'verifier-run' &&
+            cell.shape.id === 'observed-verifier'),
+      ),
+    ).toBe(true)
   })
 
   test('expansion is deterministic — identical config yields identical ordered cell ids', () => {

--- a/apps/openagents.com/workers/api/src/inference/benchmark/matrix.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/matrix.ts
@@ -266,6 +266,17 @@ export const BenchmarkMatrixConfig = S.Struct({
   targets: S.Array(BenchmarkTarget),
   workloads: S.Array(BenchmarkWorkload),
   shapes: S.Array(SequenceShape),
+  // Optional workload -> shape filter for real traffic suites where each
+  // workload must run only against the observed traffic shape sourced for that
+  // workload. Omitted configs keep the historical full cross-product behavior.
+  workloadShapePairs: S.optional(
+    S.Array(
+      S.Struct({
+        workload: BenchmarkWorkload,
+        shapeId: S.String,
+      }),
+    ),
+  ),
   transports: S.Array(BenchmarkTransport),
   sampling: S.Array(SamplingSettings),
   // How many repeated samples per cell (book §4.5.2: "send enough traffic ...
@@ -352,9 +363,23 @@ export const expandMatrix = (
   config: BenchmarkMatrixConfig,
 ): ReadonlyArray<BenchmarkCell> => {
   const cells: Array<BenchmarkCell> = []
+  const allowedWorkloadShapePairs =
+    config.workloadShapePairs === undefined
+      ? null
+      : new Set(
+          config.workloadShapePairs.map(
+            pair => `${pair.workload}::${pair.shapeId}`,
+          ),
+        )
   for (const target of config.targets) {
     for (const workload of config.workloads) {
       for (const shape of config.shapes) {
+        if (
+          allowedWorkloadShapePairs !== null &&
+          !allowedWorkloadShapePairs.has(`${workload}::${shape.id}`)
+        ) {
+          continue
+        }
         for (const transport of config.transports) {
           for (const sampling of config.sampling) {
             cells.push({
@@ -391,15 +416,11 @@ export const expandMatrix = (
   return cells
 }
 
-// The expected cell count for a config (the cross-product cardinality). Used by
-// tests to assert the matrix expanded to exactly the right number of cells, and
-// by the report header to disclose coverage.
+// The expected cell count for a config. For the default matrix this is the raw
+// cross-product cardinality; configs with `workloadShapePairs` count only the
+// workload/shape pairs they explicitly allow.
 export const expectedCellCount = (config: BenchmarkMatrixConfig): number =>
-  config.targets.length *
-  config.workloads.length *
-  config.shapes.length *
-  config.transports.length *
-  config.sampling.length
+  expandMatrix(config).length
 
 // ---------------------------------------------------------------------------
 // Decoders + a documented minimum decision suite (notes Q5).

--- a/apps/openagents.com/workers/api/src/inference/benchmark/real-sweep-config.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/real-sweep-config.ts
@@ -121,16 +121,15 @@ const DEFAULT_SAMPLING: SamplingSettings = {
 }
 
 // The full decision-grade-eligible suite: Khala vs Fireworks vs Vertex
-// (Anthropic + Gemini) on all four decision workloads, over realistic shapes,
-// streaming transport (the path with measurable TTFT/ITL), one production sampling
-// setting, 5 samples per cell (book §4.5.2: enough traffic to read percentiles).
+// (Anthropic + Gemini) on all four decision workloads, over the realistic shape
+// observed for that workload, streaming transport (the path with measurable
+// TTFT/ITL), one production sampling setting, 5 samples per cell (book §4.5.2:
+// enough traffic to read percentiles).
 //
-// 4 targets × 4 workloads × 1 shape-per-workload-mapped-via-shapes-array... NOTE:
-// the matrix expands targets × workloads × shapes × transports × sampling, so to
-// keep each workload paired with ITS realistic shape we list all four shapes; the
-// report buckets by (lane × workload) and every group's shapes are realistic, so
-// no group is `syntheticOnly`. Total cells: 4 × 4 × 4 × 1 × 1 = 64 cells (with the
-// future-lane skip handled by the runner).
+// `workloadShapePairs` is intentionally set: the issue asks for realistic
+// traffic shapes, not a blind cross-product that runs a verifier over chat token
+// lengths or a chat turn over verifier token lengths. Total cells:
+// 4 targets × 4 workload/shape pairs × 1 transport × 1 sampling = 16.
 export const KHALA_VS_FIREWORKS_VERTEX_DECISION_SUITE: BenchmarkMatrixConfig = {
   id: 'khala-vs-fireworks-vertex-decision-suite-oq5-v1',
   description:
@@ -156,6 +155,18 @@ export const KHALA_VS_FIREWORKS_VERTEX_DECISION_SUITE: BenchmarkMatrixConfig = {
     OBSERVED_CODE_ARTIFACT_SHAPE,
     OBSERVED_VERIFIER_SHAPE,
     OBSERVED_LONG_CONTEXT_SHAPE,
+  ],
+  workloadShapePairs: [
+    { workload: 'chat', shapeId: OBSERVED_CHAT_SHAPE.id },
+    {
+      workload: 'khala-code-artifact-gen',
+      shapeId: OBSERVED_CODE_ARTIFACT_SHAPE.id,
+    },
+    { workload: 'verifier-run', shapeId: OBSERVED_VERIFIER_SHAPE.id },
+    {
+      workload: 'long-context-codebase-question',
+      shapeId: OBSERVED_LONG_CONTEXT_SHAPE.id,
+    },
   ],
   transports: ['streaming'],
   sampling: [DEFAULT_SAMPLING],

--- a/apps/openagents.com/workers/api/src/inference/benchmark/real-sweep-plan.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/real-sweep-plan.test.ts
@@ -150,9 +150,9 @@ describe('real benchmark sweep preflight', () => {
 
     expect(preflight.canArmRealSeam).toBe(true)
     expect(preflight.decisionGradeEligible).toBe(true)
-    expect(preflight.executableCells).toBe(64)
-    expect(preflight.executableSampleUpperBound).toBe(320)
-    expect(preflight.billableSampleUpperBound).toBe(240)
+    expect(preflight.executableCells).toBe(16)
+    expect(preflight.executableSampleUpperBound).toBe(80)
+    expect(preflight.billableSampleUpperBound).toBe(60)
     expect(preflight.billableLanes).toEqual([
       'fireworks',
       'vertex-anthropic',
@@ -173,8 +173,8 @@ describe('real benchmark sweep preflight', () => {
 
     expect(preflight.canArmRealSeam).toBe(true)
     expect(preflight.decisionGradeEligible).toBe(false)
-    expect(preflight.executableCells).toBe(16)
-    expect(preflight.executableSampleUpperBound).toBe(80)
+    expect(preflight.executableCells).toBe(4)
+    expect(preflight.executableSampleUpperBound).toBe(20)
     expect(preflight.billableSampleUpperBound).toBe(0)
     expect(preflight.billableLanes).toEqual([])
   })
@@ -192,8 +192,8 @@ describe('real benchmark sweep preflight', () => {
     )
 
     expect(preflight.canArmRealSeam).toBe(true)
-    expect(preflight.executableSampleUpperBound).toBe(320)
-    expect(preflight.billableSampleUpperBound).toBe(80)
+    expect(preflight.executableSampleUpperBound).toBe(80)
+    expect(preflight.billableSampleUpperBound).toBe(20)
     expect(preflight.billableLanes).toEqual(['fireworks'])
   })
 

--- a/apps/openagents.com/workers/api/src/inference/benchmark/real-sweep-runner.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/real-sweep-runner.test.ts
@@ -298,9 +298,10 @@ describe('runRealSweep gating + decision-grade rule', () => {
       preflight: armed,
       transports: [makeKhalaPublicTransport({ fetch, now: stepClock(80) })],
     })
-    // 3 un-armed lanes (fireworks + 2 vertex) × 4 workloads × 4 shapes = 48 cells
-    // skipped (no transport). The matrix expands targets × workloads × shapes.
-    expect(runSet.cellsSkipped).toBe(48)
+    // 3 un-armed lanes (fireworks + 2 vertex) × 4 workload/shape pairs = 12
+    // cells skipped (no transport). The OQ5 suite pairs each workload with its
+    // observed traffic shape instead of cross-producting mismatched shapes.
+    expect(runSet.cellsSkipped).toBe(12)
     const skipReasons = new Set(
       runSet.runs
         .filter(r => r.skippedReason !== null)


### PR DESCRIPTION
Addresses #6307.

### Changes
- Added optional `workloadShapePairs` support to benchmark matrix configs so real suites can restrict expansion to explicit workload/shape pairs while preserving default cross-product behavior.
- Updated the Khala vs Fireworks/Vertex decision suite to run each decision workload only against its observed realistic traffic shape, reducing the planned suite from the blind 64-cell cross-product to 16 intended cells.
- Added and adjusted tests covering paired workload/shape expansion and real sweep planning expectations.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).