### PR TITLE
fix(khala-cli): surface pylon spawn server errors

### DIFF
--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -380,6 +380,48 @@ describe("Khala CLI info diagnostics", () => {
     expect(parsed.state).toBe("completed")
   })
 
+  test("surfaces pylon spawn server validation errors instead of reporting network failure", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        Response.json({
+          error: "pylon_api_validation_error",
+          message: "Missing key [\"jobKind\"] after network reached server",
+        }, { status: 400 }),
+    })
+
+    const originalWrite = process.stderr.write
+    let stderr = ""
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderr += String(chunk)
+      return true
+    }) as typeof process.stderr.write
+    try {
+      const exitCode = await runKhalaCli([
+        "spawn",
+        "--strategy",
+        "pylon",
+        "--count",
+        "1",
+        "--fixture",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "--objective",
+        "validation smoke",
+      ], {
+        OPENAGENTS_AGENT_TOKEN: "oa_agent_pylon_validation_test",
+      })
+      expect(exitCode).toBe(1)
+    } finally {
+      process.stderr.write = originalWrite
+      server.stop(true)
+    }
+
+    expect(stderr).toContain("remote khala.spawn failed (400)")
+    expect(stderr).toContain("pylon_api_validation_error")
+    expect(stderr).not.toContain("Could not reach Khala")
+  })
+
   test("accepts claude_agent_task workflow for pylon spawn", async () => {
     const dir = mkdtempSync(join(tmpdir(), "khala-pylon-claude-workflow-test-"))
     const tokenPath = join(dir, "agent-token")

--- a/clients/khala-cli/src/spawn.ts
+++ b/clients/khala-cli/src/spawn.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from "node:path"
 
 import { khalaHome, runKhalaCodexTask, type KhalaCodexRunResult } from "./codex.js"
 import { spawnProcess } from "./proc.js"
-import { DEFAULT_BASE_URL } from "./types.js"
+import { DEFAULT_BASE_URL, KhalaCliError } from "./types.js"
 
 export const KHALA_SPAWN_RUN_SCHEMA = "openagents.khala.spawn_run.v0.1"
 export const KHALA_SPAWN_WORKER_SCHEMA = "openagents.khala.spawn_worker.v0.1"
@@ -446,12 +446,19 @@ const remoteKhalaSpawnMcpCaller: KhalaSpawnMcpCaller = async input => {
   })
   const text = await response.text()
   if (!response.ok) {
-    throw new Error(`remote ${input.tool} failed (${response.status}): ${text.trim() || response.statusText}`)
+    throw new KhalaCliError({
+      code: "remote_http_error",
+      reason: `remote ${input.tool} failed (${response.status}): ${text.trim() || response.statusText}`,
+      statusCode: response.status,
+    })
   }
   const envelope = parseJsonRecord(text, `remote ${input.tool} response`)
   const error = recordValue(envelope, "error")
   if (isRecord(error)) {
-    throw new Error(stringValue(error, "message") ?? `remote ${input.tool} returned an error`)
+    throw new KhalaCliError({
+      code: "remote_mcp_error",
+      reason: stringValue(error, "message") ?? `remote ${input.tool} returned an error`,
+    })
   }
   const result = recordValue(envelope, "result")
   if (!isRecord(result)) {


### PR DESCRIPTION
Addresses #6444.

### Changes
- Updated Khala spawn remote HTTP and MCP error handling to throw `KhalaCliError` with the server response instead of falling through to the generic network failure message.
- Added CLI coverage for pylon spawn validation errors to confirm server-side failures show the HTTP status and validation code, and do not print `Could not reach Khala`.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).