### PR TITLE
fix(gym): restrict MirrorCode public targets

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
@@ -30,6 +30,33 @@ export const KHALA_MODEL_ID = 'openagents/khala'
 export const MirrorCodeBucket = S.Literals(['S', 'M', 'L'])
 export type MirrorCodeBucket = typeof MirrorCodeBucket.Type
 
+export const MIRRORCODE_PUBLIC_TARGETS_BY_BUCKET = {
+  S: [
+    'qsv_select',
+    'jq_simple',
+    'gron',
+    'bitwise',
+    'hexyl',
+    'uuidparse',
+    'numfmt',
+    'cal',
+    'choose',
+  ],
+  M: [
+    'giac',
+    'tex',
+    'gotree',
+    'mailauth',
+    'brotli',
+    'wren_cli',
+    'nonogrid',
+    'sed',
+    'tssql',
+    'bib2json',
+  ],
+  L: ['ruff', 'pkl', 'cprepro'],
+} as const
+
 // Run lifecycle status. `queued`/`running` are in-progress; `passed`/`failed`
 // are scored terminal states; `error` is an execution/harness failure.
 export const MirrorCodeRunStatus = S.Literals([
@@ -182,6 +209,25 @@ const assertBounds = (input: MirrorCodeRunInput): void => {
   }
 }
 
+export const isMirrorCodePublicTargetForBucket = (
+  bucket: MirrorCodeBucket,
+  taskId: string,
+): boolean =>
+  (MIRRORCODE_PUBLIC_TARGETS_BY_BUCKET[bucket] as ReadonlyArray<string>).includes(
+    taskId,
+  )
+
+const assertPublicTarget = (input: {
+  readonly bucket: MirrorCodeBucket
+  readonly taskId: string
+}): void => {
+  if (!isMirrorCodePublicTargetForBucket(input.bucket, input.taskId)) {
+    throw new MirrorCodeRunError(
+      'taskId must be a public MirrorCode target for the selected bucket.',
+    )
+  }
+}
+
 const assertPublicSafe = (input: MirrorCodeRunInput): void => {
   // No code fences anywhere — task source/tests would arrive that way.
   const serialized = JSON.stringify(input)
@@ -218,6 +264,7 @@ export const buildMirrorCodeRun = (raw: unknown): MirrorCodeRun => {
     )
   }
   assertBounds(input)
+  assertPublicTarget(input)
   assertPublicSafe(input)
 
   const grade = input.grade ?? 'smoke'
@@ -275,6 +322,7 @@ export const buildMirrorCodeLaunchRun = (
   if (taskPart.length < 1) {
     throw new MirrorCodeRunError('taskId must contain a public-safe id.')
   }
+  assertPublicTarget(launch)
 
   return buildMirrorCodeRun({
     runId: `mc-${launch.bucket.toLowerCase()}-${taskPart}-${languagePart}-${timestampPart}`,

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
@@ -69,6 +69,12 @@ describe('buildMirrorCodeRun', () => {
     ).toThrow(MirrorCodeRunError)
   })
 
+  test('rejects task ids outside the selected public bucket', () => {
+    expect(() =>
+      buildMirrorCodeRun({ ...validInput, taskId: 'ruff', bucket: 'S' }),
+    ).toThrow(MirrorCodeRunError)
+  })
+
   test('rejects a malformed body', () => {
     expect(() => buildMirrorCodeRun({ runId: 'x' })).toThrow(MirrorCodeRunError)
   })
@@ -89,6 +95,20 @@ describe('buildMirrorCodeRun', () => {
     expect(built.passRate).toBeNull()
     expect(built.decisionGrade).toBe(false)
     expect(built.summary).toContain('Owner-gated MirrorCode launch queued')
+  })
+
+  test('rejects an owner-gated launch for an unknown public target', () => {
+    expect(() =>
+      buildMirrorCodeLaunchRun(
+        {
+          kind: 'launch',
+          taskId: 'private_eval_target',
+          bucket: 'S',
+          language: 'python',
+        },
+        '2026-06-27T02:03:04.000Z',
+      ),
+    ).toThrow(MirrorCodeRunError)
   })
 })
 
@@ -116,7 +136,11 @@ describe('handleMirrorCodeRunsApi GET', () => {
     expect(body.model).toBe('openagents/khala')
     expect(body.runs[0]?.runId).toBe('mc-phase0-cal-py-0001')
     expect(body.comparators.length).toBeGreaterThan(0)
-    expect(body.comparators.every(c => c.source === 'paper_reference_illustrative')).toBe(true)
+    expect(
+      body.comparators.every(
+        c => c.source === 'paper_reference_illustrative',
+      ),
+    ).toBe(true)
     expect(body.staleness.composition).toBe('live_at_read')
   })
 })
@@ -217,9 +241,9 @@ describe('handleMirrorCodeRunsApi POST', () => {
             listRuns: () => Effect.succeed([]),
             getRun: () => Effect.succeed(undefined),
             upsertRun: () => {
-            stored += 1
-            return Effect.void
-          },
+              stored += 1
+              return Effect.void
+            },
           },
         },
       ),
@@ -267,6 +291,21 @@ describe('matchMirrorCodeRunByIdRequest', () => {
     expect(
       matchMirrorCodeRunByIdRequest(
         new Request('https://openagents.com/api/gym/mirrorcode/runs'),
+      ),
+    ).toBeUndefined()
+  })
+
+  test('rejects unsafe or oversized run id path segments', () => {
+    expect(
+      matchMirrorCodeRunByIdRequest(
+        new Request('https://openagents.com/api/gym/mirrorcode/runs/abc%2F123'),
+      ),
+    ).toBeUndefined()
+    expect(
+      matchMirrorCodeRunByIdRequest(
+        new Request(
+          `https://openagents.com/api/gym/mirrorcode/runs/${'x'.repeat(129)}`,
+        ),
       ),
     ).toBeUndefined()
   })

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.ts
@@ -43,6 +43,9 @@ const mirrorCodeStaleness = () =>
     'gym.mirrorcode.run_updated',
   ])
 
+const MAX_ROUTE_RUN_ID_LENGTH = 128
+const routeRunIdPattern = /^[a-zA-Z0-9._:-]+$/
+
 export type MirrorCodeRunsRouteInput = Readonly<{
   // Production D1 source. Tests may pass `listRuns`/`getRun` overrides instead.
   store?: MirrorCodeRunSourceStore
@@ -251,7 +254,11 @@ export const matchMirrorCodeRunByIdRequest = (
   }
   try {
     const decoded = decodeURIComponent(match[1]!)
-    return decoded.length > 0 ? decoded : undefined
+    return decoded.length > 0 &&
+      decoded.length <= MAX_ROUTE_RUN_ID_LENGTH &&
+      routeRunIdPattern.test(decoded)
+      ? decoded
+      : undefined
   } catch {
     return undefined
   }


### PR DESCRIPTION
Addresses #6376.

### Changes
- Added public MirrorCode target allowlists by bucket and validation for run creation and owner-gated launch runs.
- Rejected mismatched or unknown task IDs outside the selected public bucket.
- Hardened MirrorCode run ID route matching with length and character checks.
- Added tests for public target validation and unsafe run ID path segments.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).