### PR TITLE
feat(khala): route BYOK OpenRouter requests server-side

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -35,6 +35,21 @@ This is the invariant ledger for `openagents`.
   `docs/mpp/`.
 - Owner directive, 2026-06-23.
 
+## Khala BYOK Caller-Paid Inference
+
+- Khala gateway BYOK (`x-openagents-provider: openrouter` plus
+  `x-openagents-provider-key`) is caller-paid upstream capacity. The gateway may
+  route the request with the caller's redacted provider key and count exact
+  served tokens in `token_usage_events`, but it must not debit OpenAgents
+  credits or treat the request as OpenAgents-funded resale capacity.
+- BYOK keys are per-request secret material: validate only shape bounds, carry
+  as redacted values, never log or persist the raw key, and never expose it in
+  receipts, traces, token rows, public counters, or error bodies.
+- BYOK does not widen subscription-account resale or provider-peer authority.
+  It is distinct from stored Autopilot provider-peer keys and from MPP or
+  settlement-bearing capacity. Unsupported providers and malformed key shapes
+  fail before provider dispatch.
+
 ## Login Surface
 
 - The `/login` SPA page (`LoginRoute` / `loginRouter`, `apps/web/src/page/login.ts`)

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -1,5 +1,5 @@
 import { MemoryStreamStore } from '@openagentsinc/durable-stream'
-import { Effect, Option } from 'effect'
+import { Effect, Option, Redacted } from 'effect'
 import { describe, expect, test } from 'vitest'
 
 import type { AgentRegistrationStore } from '../agent-registration'
@@ -20,6 +20,9 @@ import {
   INFERENCE_CLIENT_HEADER,
   INFERENCE_DEMAND_KIND_HEADER,
   INFERENCE_DEMAND_SOURCE_HEADER,
+  KHALA_BYOK_ACK_HEADER,
+  KHALA_BYOK_PROVIDER_HEADER,
+  KHALA_BYOK_PROVIDER_KEY_HEADER,
   type InferenceAuth,
   type InferenceBalanceReader,
   codingDelegationDisabled,
@@ -62,6 +65,7 @@ import {
   HYDRALISK_ADAPTER_ID,
   HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
   HYDRALISK_GPT_OSS_120B_ADAPTER_ID,
+  OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
   VERTEX_GEMINI_ADAPTER_ID,
   selectAdapterPlan,
 } from './model-router'
@@ -1473,6 +1477,121 @@ describe('POST /v1/chat/completions', () => {
 
     expect(captured).toHaveLength(1)
     expect(captured[0]?.fundingKind).toBe('bitcoin')
+  })
+
+  test('routes accepted BYOK requests through OpenRouter without debiting credits and still records served tokens', async () => {
+    let capturedRequest: InferenceRequest | undefined
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      complete: request =>
+        Effect.sync(() => {
+          capturedRequest = request
+          return {
+            content: 'BYOK response',
+            finishReason: 'stop',
+            servedModel: 'openrouter/test-model',
+            usage: { completionTokens: 3, promptTokens: 5, totalTokens: 8 },
+          }
+        }),
+      id: OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+    const metered: Array<MeteringContext> = []
+    const recorded: Array<{
+      adapterId: string
+      requestId: string
+      usage: InferenceUsage
+    }> = []
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(helloBody, {
+          headers: {
+            [KHALA_BYOK_PROVIDER_HEADER]: 'openrouter',
+            [KHALA_BYOK_PROVIDER_KEY_HEADER]: 'sk-or-user-owned-key',
+          },
+        }),
+        baseDeps({
+          lanePlan: selectAdapterPlan,
+          meteringHook: context =>
+            Effect.sync(() => {
+              metered.push(context)
+              return { metered: true, receiptRef: 'must-not-run' }
+            }),
+          readAvailableMsat: async () => {
+            throw new Error('BYOK must not require OpenAgents credit balance')
+          },
+          recordTokensServed: input =>
+            Effect.sync(() => {
+              recorded.push({
+                adapterId: input.adapterId,
+                requestId: input.requestId,
+                usage: input.usage,
+              })
+            }),
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(KHALA_BYOK_ACK_HEADER)).toBe('routed')
+    expect(capturedRequest?.callerProviderKey?.provider).toBe('openrouter')
+    expect(
+      capturedRequest?.callerProviderKey === undefined
+        ? undefined
+        : Redacted.value(capturedRequest.callerProviderKey.apiKey),
+    ).toBe('sk-or-user-owned-key')
+    expect(metered).toEqual([])
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0]?.adapterId).toBe(OPENROUTER_KHALA_FALLBACK_ADAPTER_ID)
+    expect(recorded[0]?.usage.totalTokens).toBe(8)
+    const body = (await response.json()) as {
+      openagents?: { billing?: Record<string, unknown>; worker?: string }
+    }
+    expect(body.openagents?.worker).toBe(OPENROUTER_KHALA_FALLBACK_ADAPTER_ID)
+    expect(body.openagents?.billing).toEqual({
+      mode: 'no_debit',
+      reason: 'caller_provider_key',
+      receipt_required: false,
+    })
+  })
+
+  test('rejects malformed BYOK provider keys before dispatch', async () => {
+    let dispatched = false
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      complete: () =>
+        Effect.sync(() => {
+          dispatched = true
+          return {
+            content: 'should not dispatch',
+            finishReason: 'stop',
+            servedModel: 'openrouter/test-model',
+            usage: { completionTokens: 1, promptTokens: 1, totalTokens: 2 },
+          }
+        }),
+      id: OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(helloBody, {
+          headers: {
+            [KHALA_BYOK_PROVIDER_HEADER]: 'openrouter',
+            [KHALA_BYOK_PROVIDER_KEY_HEADER]: 'bad key with spaces',
+          },
+        }),
+        baseDeps({ lanePlan: selectAdapterPlan, registry }),
+      ),
+    )
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get(KHALA_BYOK_ACK_HEADER)).toBe('invalid')
+    expect(dispatched).toBe(false)
+    const body = (await response.json()) as { error: string }
+    expect(body.error).toBe('invalid_byok_provider_key')
   })
 
   test('records served tokens for a completed non-streaming completion (issue #6227)', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -16,12 +16,13 @@
 // only base URL + key. Anthropic Messages compatibility is a parallel surface;
 // a clean spot is left for it (see ANTHROPIC SEAM below) but is out of scope for
 // #5476.
-import { Effect } from 'effect'
+import { Effect, Redacted } from 'effect'
 
 import type { AgentRegistrationStore } from '../agent-registration'
 import { noStoreJsonResponse } from '../http/responses'
 import { recordFromUnknown } from '../json-boundary'
 import type { PylonApiStore } from '../pylon-api'
+import { requireProviderApiKeyShape } from '../provider-account-api-key'
 import {
   compactRandomId,
   currentEpochMillis,
@@ -207,6 +208,66 @@ export const DEFAULT_CHAT_MODEL = KHALA_MODEL_ID
 export const INFERENCE_DEMAND_KIND_HEADER = 'x-openagents-demand-kind'
 export const INFERENCE_DEMAND_SOURCE_HEADER = 'x-openagents-demand-source'
 export const INFERENCE_CLIENT_HEADER = 'x-openagents-client'
+export const KHALA_BYOK_PROVIDER_HEADER = 'x-openagents-provider'
+export const KHALA_BYOK_PROVIDER_KEY_HEADER = 'x-openagents-provider-key'
+export const KHALA_BYOK_ACK_HEADER = 'x-openagents-byok'
+
+type KhalaByokState =
+  | Readonly<{ _tag: 'absent' }>
+  | Readonly<{
+      _tag: 'accepted'
+      apiKey: Redacted.Redacted<string>
+      provider: 'openrouter'
+    }>
+  | Readonly<{ _tag: 'invalid'; reason: string }>
+
+const resolveKhalaByokState = (headers: Headers): KhalaByokState => {
+  const provider = headers.get(KHALA_BYOK_PROVIDER_HEADER)?.trim().toLowerCase()
+  const rawKey = headers.get(KHALA_BYOK_PROVIDER_KEY_HEADER)
+
+  if ((provider === undefined || provider === '') && rawKey === null) {
+    return { _tag: 'absent' }
+  }
+  if (provider !== 'openrouter') {
+    return {
+      _tag: 'invalid',
+      reason: 'Only x-openagents-provider: openrouter is supported for BYOK.',
+    }
+  }
+  try {
+    return {
+      _tag: 'accepted',
+      apiKey: Redacted.make(requireProviderApiKeyShape(rawKey)),
+      provider: 'openrouter',
+    }
+  } catch {
+    return {
+      _tag: 'invalid',
+      reason: 'x-openagents-provider-key must be a single valid API key value.',
+    }
+  }
+}
+
+const byokResponseHeaders = (
+  byok: KhalaByokState,
+  routed: boolean,
+): Record<string, string> =>
+  byok._tag === 'absent'
+    ? {}
+    : {
+        [KHALA_BYOK_ACK_HEADER]:
+          byok._tag === 'invalid' ? 'invalid' : routed ? 'routed' : 'accepted',
+      }
+
+const applyByokResponseHeader = (
+  response: Readonly<{ headers: Pick<Headers, 'set'> }>,
+  byok: KhalaByokState,
+  routed: boolean,
+): void => {
+  for (const [key, value] of Object.entries(byokResponseHeaders(byok, routed))) {
+    response.headers.set(key, value)
+  }
+}
 
 const safeAttributionToken = (value: string | null): string | undefined => {
   const trimmed = value?.trim()
@@ -1037,6 +1098,7 @@ const toInferenceRequest = (
     abortSignal?: AbortSignal | undefined
     priority: InferenceRequest['priority']
   }>,
+  callerProviderKey?: InferenceRequest['callerProviderKey'],
 ): InferenceRequest => {
   const clientMessages: ReadonlyArray<InferenceMessage> = body.messages
   // For a non-Khala model, leave the messages exactly as the client sent them
@@ -1071,6 +1133,7 @@ const toInferenceRequest = (
     ...(scheduler?.abortSignal === undefined
       ? {}
       : { abortSignal: scheduler.abortSignal }),
+    ...(callerProviderKey === undefined ? {} : { callerProviderKey }),
     messages,
     model: requestedModel,
     // Gateway-derived session affinity wins over any stray client copy.
@@ -1312,7 +1375,10 @@ type OpenAgentsReceipt = Readonly<{
   billing?:
     | Readonly<{
         mode: 'receipt_backed' | 'no_debit' | 'zero_charge'
-        reason?: 'operator_exempt_or_unmetered' | undefined
+        reason?:
+          | 'caller_provider_key'
+          | 'operator_exempt_or_unmetered'
+          | undefined
         receipt_required: boolean
       }>
     | undefined
@@ -1373,6 +1439,13 @@ const billingDisclosureFor = (
   }
   if (metering.receiptRef !== null) {
     return { mode: 'receipt_backed', receipt_required: true }
+  }
+  if (metering.byok === true) {
+    return {
+      mode: 'no_debit',
+      reason: 'caller_provider_key',
+      receipt_required: false,
+    }
   }
   return {
     mode: 'no_debit',
@@ -2484,6 +2557,16 @@ export const handleChatCompletions = (
         { status: 400 },
       )
     }
+    const byok = resolveKhalaByokState(request.headers)
+    if (byok._tag === 'invalid') {
+      return noStoreJsonResponse(
+        {
+          error: 'invalid_byok_provider_key',
+          reason: byok.reason,
+        },
+        { headers: byokResponseHeaders(byok, false), status: 400 },
+      )
+    }
 
     const nowEpochSeconds = deps.nowEpochSeconds ?? currentEpochSeconds
     const newId = deps.newId ?? defaultId
@@ -2726,11 +2809,12 @@ export const handleChatCompletions = (
     }
 
     // BALANCE GATE (read-only). #5477 owns the real per-model decrement.
+    const callerPaidByok = byok._tag === 'accepted'
     const minimum = deps.minimumAvailableMsat ?? 1
-    const availableMsat = yield* Effect.promise(() =>
-      deps.readAvailableMsat(session.accountRef),
-    )
-    if (availableMsat < minimum) {
+    const availableMsat = callerPaidByok
+      ? minimum
+      : yield* Effect.promise(() => deps.readAvailableMsat(session.accountRef))
+    if (!callerPaidByok && availableMsat < minimum) {
       // FREE-ALLOWANCE BYPASS (EPIC #5474 §1). A zero/insufficient-balance
       // account is NOT rejected when the request is free-eligible AND the
       // resolving owner still has remaining free allowance — that request would
@@ -2787,7 +2871,7 @@ export const handleChatCompletions = (
     // can be flush with credits yet still be capped at a configurable per-window
     // spend ceiling so a compromised key cannot drain the whole balance. Open
     // (no-op) when unwired or when no cap is configured for the account.
-    if (deps.checkSpendCap !== undefined) {
+    if (!callerPaidByok && deps.checkSpendCap !== undefined) {
       const spendCap = yield* Effect.promise(() =>
         deps.checkSpendCap!(session.accountRef),
       )
@@ -2805,7 +2889,15 @@ export const handleChatCompletions = (
       }
     }
 
-    const meteringHook = deps.meteringHook ?? stubMeteringHook
+    const baseMeteringHook = deps.meteringHook ?? stubMeteringHook
+    const meteringHook: MeteringHook = callerPaidByok
+      ? () =>
+          Effect.succeed({
+            byok: true,
+            metered: false,
+            receiptRef: null,
+          } satisfies MeteringOutcome)
+      : baseMeteringHook
     const resolveFundingKind =
       deps.resolveFundingKind ?? defaultCardFundingResolver
     const fundingKind = yield* Effect.promise(() =>
@@ -2845,20 +2937,22 @@ export const handleChatCompletions = (
       toolBearingKhalaRequest &&
       requestAttribution?.demandKind === 'internal' &&
       requestAttribution.demandSource === 'gym_mirrorcode'
-    const basePlannedIds = mirrorcodeStrongCodingKhalaRequest
-      ? selectAdapterPlanForKhalaStrongCodingRequest(
-          requestedModel,
-          plannedIdsForModel,
-        )
-      : glmSaturationStressKhalaRequest &&
-          plannedIdsForModel.includes(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID)
-        ? [HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID]
-        : toolBearingKhalaRequest || glmSaturationStressKhalaRequest
-          ? selectAdapterPlanForKhalaToolRequest(
-              requestedModel,
-              plannedIdsForModel,
-            )
-          : plannedIdsForModel
+    const basePlannedIds = callerPaidByok
+      ? [OPENROUTER_KHALA_FALLBACK_ADAPTER_ID]
+      : mirrorcodeStrongCodingKhalaRequest
+        ? selectAdapterPlanForKhalaStrongCodingRequest(
+            requestedModel,
+            plannedIdsForModel,
+          )
+        : glmSaturationStressKhalaRequest &&
+            plannedIdsForModel.includes(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID)
+          ? [HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID]
+          : toolBearingKhalaRequest || glmSaturationStressKhalaRequest
+            ? selectAdapterPlanForKhalaToolRequest(
+                requestedModel,
+                plannedIdsForModel,
+              )
+            : plannedIdsForModel
 
     // CACHE-AFFINITY RESOLUTION (book P0-2 deliverables 3+4). Compose the
     // account/session/codebase key, its public-safe hash (for the receipt), and
@@ -2899,7 +2993,7 @@ export const handleChatCompletions = (
     if (!hasViableLane) {
       return noStoreJsonResponse(
         { error: 'model_unavailable', model: requestedModel },
-        { status: 400 },
+        { headers: byokResponseHeaders(byok, false), status: 400 },
       )
     }
 
@@ -2973,6 +3067,9 @@ export const handleChatCompletions = (
           : { abortSignal: preemptionAbortController.signal }),
         priority: routeDemandClass,
       },
+      byok._tag === 'accepted'
+        ? { apiKey: byok.apiKey, provider: byok.provider }
+        : undefined,
     )
     // The raw cache-affinity key threaded into every telemetry build site so the
     // receipt records its public-safe HASH (never the raw key). Undefined for
@@ -3207,6 +3304,7 @@ export const handleChatCompletions = (
           headers: {
             'cache-control': 'no-store',
             'content-type': 'text/event-stream; charset=utf-8',
+            ...byokResponseHeaders(byok, true),
             // Advertise the resumable read URL only when the completion is being
             // persisted. The opaque request id carries no prompt/credential
             // material, so this header is safe (INVARIANTS: no leakage).
@@ -3227,7 +3325,9 @@ export const handleChatCompletions = (
       // path (which would double-dispatch and could 524 again).
       if (sseDispatch.error.kind !== 'stream_not_supported') {
         yield* Effect.promise(() => releasePreemptionSlot())
-        return providerErrorResponse(sseDispatch.error)
+        const response = providerErrorResponse(sseDispatch.error)
+        applyByokResponseHeader(response, byok, false)
+        return response
       }
 
       // Run the stream op across the lane plan; the served adapter id rides
@@ -3245,7 +3345,9 @@ export const handleChatCompletions = (
         Effect.ensuring(Effect.promise(() => releasePreemptionSlot())),
       )
       if (!chunks.ok) {
-        return providerErrorResponse(chunks.error)
+        const response = providerErrorResponse(chunks.error)
+        applyByokResponseHeader(response, byok, false)
+        return response
       }
       const servedChunks = chunks.served.value.value
       // Settle metering from the terminal usage frame (receipt-first).
@@ -3463,6 +3565,7 @@ export const handleChatCompletions = (
         headers: {
           'cache-control': 'no-store',
           'content-type': 'text/event-stream; charset=utf-8',
+          ...byokResponseHeaders(byok, true),
         },
         status: 200,
       })
@@ -3482,7 +3585,9 @@ export const handleChatCompletions = (
       Effect.ensuring(Effect.promise(() => releasePreemptionSlot())),
     )
     if (!result.ok) {
-      return providerErrorResponse(result.error)
+      const response = providerErrorResponse(result.error)
+      applyByokResponseHeader(response, byok, false)
+      return response
     }
 
     // KHALA IDENTITY GUARD (STEP 2). Run the typed identity signature over the
@@ -3701,5 +3806,6 @@ export const handleChatCompletions = (
         }),
         result: guardedResult,
       }),
+      { headers: byokResponseHeaders(byok, true) },
     )
   })

--- a/apps/openagents.com/workers/api/src/inference/metering-hook.ts
+++ b/apps/openagents.com/workers/api/src/inference/metering-hook.ts
@@ -101,6 +101,10 @@ export type MeteringContext = Readonly<{
 // credits are decremented (or `metered: true` + `zeroCharge` when usage rounded
 // to a zero charge, e.g. an empty/no-token completion).
 export type MeteringOutcome = Readonly<{
+  // True when the caller supplied their own upstream provider API key. The
+  // gateway still records served tokens, but it must not debit OpenAgents
+  // credits for upstream cost.
+  byok?: boolean | undefined
   metered: boolean
   // Public-safe ledger/usage receipt ref when metering is live; null for the
   // stub. Never a raw amount, destination, or payment material here.

--- a/apps/openagents.com/workers/api/src/inference/openrouter-adapter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/openrouter-adapter.test.ts
@@ -144,4 +144,27 @@ describe('OpenRouter Khala fallback adapter', () => {
     expect(result._tag).toBe('Success')
     expect(capturedBody?.model).toBe(OPENROUTER_KHALA_FALLBACK_MODEL_ID)
   })
+
+  it('uses a caller-supplied OpenRouter key instead of the configured fallback key', async () => {
+    let capturedAuthorization: string | undefined
+    const fetchImpl: OpenRouterFetch = async (_input, init) => {
+      capturedAuthorization = init.headers.authorization
+      return jsonResponse(completionBody())
+    }
+    const adapter = makeOpenRouterAdapter(adapterConfig(fetchImpl))
+
+    const result = await runResult(
+      adapter.complete(
+        request({
+          callerProviderKey: {
+            apiKey: Redacted.make('sk-or-caller-owned'),
+            provider: 'openrouter',
+          },
+        }),
+      ),
+    )
+
+    expect(result._tag).toBe('Success')
+    expect(capturedAuthorization).toBe('Bearer sk-or-caller-owned')
+  })
 })

--- a/apps/openagents.com/workers/api/src/inference/openrouter-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/openrouter-adapter.ts
@@ -154,11 +154,15 @@ const postChatCompletions = (
       const signal = safeSignal(
         config.timeoutMs ?? OPENROUTER_DEFAULT_TIMEOUT_MS,
       )
+      const apiKey =
+        request.callerProviderKey?.provider === 'openrouter'
+          ? request.callerProviderKey.apiKey
+          : config.apiKey
       return fetcher(endpointFor(config.baseUrl), {
         body: JSON.stringify(requestBody(config, request)),
         headers: {
           accept: 'application/json',
-          authorization: `Bearer ${Redacted.value(config.apiKey)}`,
+          authorization: `Bearer ${Redacted.value(apiKey)}`,
           'content-type': 'application/json',
         },
         method: 'POST',

--- a/apps/openagents.com/workers/api/src/inference/provider-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/provider-adapter.ts
@@ -14,7 +14,7 @@
 // so a real client works by changing only base URL + key. Anthropic Messages is
 // a parallel surface (#5476 leaves a clean spot); both normalize into the same
 // adapter request/result here.
-import { Effect } from 'effect'
+import { Effect, Redacted } from 'effect'
 
 // A single chat message in the normalized request. `role`/`content` mirror the
 // OpenAI Chat Completions shape so adapters can pass through with minimal
@@ -38,6 +38,12 @@ export type InferenceMessage = Readonly<{
 // forwards verbatim; adapters apply only the ones their provider supports.
 export type InferenceRequest = Readonly<{
   abortSignal?: AbortSignal | undefined
+  callerProviderKey?:
+    | Readonly<{
+        apiKey: Redacted.Redacted<string>
+        provider: 'openrouter'
+      }>
+    | undefined
   model: string
   messages: ReadonlyArray<InferenceMessage>
   priority?: InferenceRequestPriority | undefined


### PR DESCRIPTION
Addresses #6380.

### Changes
- Added Khala BYOK request handling for `openrouter` using `x-openagents-provider` and `x-openagents-provider-key` headers.
- Routes caller-supplied provider keys through OpenRouter without debiting OpenAgents credits, while still recording exact served-token usage.
- Validates malformed or unsupported BYOK inputs before provider dispatch and keeps provider keys redacted.
- Propagates caller provider key context through the provider adapter layer and documents the BYOK authority invariant.
- Added route and adapter tests for BYOK routing, invalid key rejection, and OpenRouter caller-key usage.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)