### PR TITLE
fix(gym): expand benchmark ladder opponents

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/ladder.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/ladder.test.ts
@@ -110,7 +110,17 @@ describe('Gym ladder recurring config', () => {
       'rung3',
     ])
     expect(GYM_LADDER_RUNGS[0]?.opponentLanes).toContain('bigpickle')
-    expect(GYM_LADDER_RUNGS[2]?.opponentLanes).toEqual(['openai-gpt', 'claude'])
+    expect(GYM_LADDER_RUNGS[1]?.opponentLanes).toEqual([
+      'gemini-free',
+      'gpt-oss-20b',
+      'gpt-oss-120b',
+      'glm-52',
+    ])
+    expect(GYM_LADDER_RUNGS[2]?.opponentLanes).toEqual([
+      'openai-gpt',
+      'claude',
+      'vertex-gemini',
+    ])
     for (const rung of GYM_LADDER_RUNGS) {
       expect(rung.ownerGateRef).toMatch(/^gate\.owner\.gym\.ladder\./)
     }

--- a/apps/openagents.com/workers/api/src/inference/gym/ladder.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/ladder.ts
@@ -92,7 +92,12 @@ export const GYM_LADDER_RUNGS: ReadonlyArray<GymLadderRungDefinition> = [
   {
     rung: 'rung2',
     title: 'Rung 2 — Khala vs free / open models',
-    opponentLanes: ['gemini-free'],
+    opponentLanes: [
+      'gemini-free',
+      'gpt-oss-20b',
+      'gpt-oss-120b',
+      'glm-52',
+    ],
     barToClear:
       'Match or beat the free field on verified-rate at equal-or-lower cost; win on tool-call completion.',
     ownerGateRef: 'gate.owner.gym.ladder.rung2.free_tier_real_seam',
@@ -100,7 +105,7 @@ export const GYM_LADDER_RUNGS: ReadonlyArray<GymLadderRungDefinition> = [
   {
     rung: 'rung3',
     title: 'Rung 3 — Khala vs paid frontier',
-    opponentLanes: ['openai-gpt', 'claude'],
+    opponentLanes: ['openai-gpt', 'claude', 'vertex-gemini'],
     barToClear:
       'Honestly measure the gap to paid frontier models and track it shrinking over successive runs. No requirement to beat today.',
     ownerGateRef: 'gate.owner.gym.ladder.rung3.paid_api_keys_and_spend_approval',


### PR DESCRIPTION
Addresses #6309.

### Changes
- Adds the open/free model lanes `gpt-oss-20b`, `gpt-oss-120b`, and `glm-52` to rung 2 of the gym ladder.
- Adds `vertex-gemini` to the paid frontier rung.
- Updates the ladder config test expectations for the expanded opponent lanes.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0)