### PR TITLE
feat(ops): gate Artanis diagnosis grounding

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-diagnosis-grounding-gate.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-diagnosis-grounding-gate.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  artanisDiagnosisGroundingPolicy,
+  evaluateArtanisDiagnosisGroundingGate,
+  type ArtanisDiagnosisEvidence,
+} from './artanis-diagnosis-grounding-gate'
+
+const dispatchLog = {
+  lastEntriesExamined: 20,
+  outcomes: ['accepted', 'rate_limited'],
+  ref: 'supervisor-dispatch-log.20260628.last20',
+}
+
+const providerHeaders = {
+  ref: 'provider-rate-limit-headers.20260628.openai.429',
+  retryAfterSeconds: 60,
+}
+
+const gate = (evidence: ArtanisDiagnosisEvidence) =>
+  evaluateArtanisDiagnosisGroundingGate({
+    claimKind: 'rate_limited',
+    evidence,
+  })
+
+describe('Artanis diagnosis grounding gate (#6647)', () => {
+  test('advances only through the required evidence states before remediation unlocks', () => {
+    expect(gate({}).state).toBe('UNGROUNDED')
+    expect(gate({}).canProposeRemediation).toBe(false)
+
+    expect(gate({ quotaLedgerReadRef: 'quota-ledger-read.20260628' }).state).toBe(
+      'LEDGER_READ',
+    )
+
+    expect(
+      gate({
+        quotaLedgerReadRef: 'quota-ledger-read.20260628',
+        supervisorDispatchLog: dispatchLog,
+      }).state,
+    ).toBe('DISPATCH_LOG_EXAMINED')
+
+    const grounded = gate({
+      providerRateLimitHeaders: providerHeaders,
+      quotaLedgerReadRef: 'quota-ledger-read.20260628',
+      supervisorDispatchLog: dispatchLog,
+    })
+    expect(grounded.state).toBe('GROUNDED')
+    expect(grounded.canProposeRemediation).toBe(true)
+    expect(grounded.missingRefs).toEqual([])
+  })
+
+  test('rejects shallow dispatch logs and rate-limit claims without real reset evidence', () => {
+    const shallowDispatch = gate({
+      providerRateLimitHeaders: providerHeaders,
+      quotaLedgerReadRef: 'quota-ledger-read.20260628',
+      supervisorDispatchLog: {
+        ...dispatchLog,
+        lastEntriesExamined: 19,
+      },
+    })
+    expect(shallowDispatch.state).toBe('LEDGER_READ')
+    expect(shallowDispatch.missingRefs).toContain('supervisor-dispatch-log')
+    expect(shallowDispatch.canProposeRemediation).toBe(false)
+
+    const unverifiedProvider = gate({
+      providerRateLimitHeaders: {
+        ref: 'provider-rate-limit-headers.20260628.openai.429',
+      },
+      quotaLedgerReadRef: 'quota-ledger-read.20260628',
+      supervisorDispatchLog: dispatchLog,
+    })
+    expect(unverifiedProvider.state).toBe('PROVIDER_VERIFIED')
+    expect(unverifiedProvider.blockerRefs).toContain(
+      'blocker.artanis.diagnosis.provider_headers_do_not_match_claim',
+    )
+    expect(unverifiedProvider.canProposeRemediation).toBe(false)
+  })
+
+  test('publishes the autonomous-ops-v1 signature policy refs for the composer', () => {
+    const policy = artanisDiagnosisGroundingPolicy()
+    expect(policy.signature).toBe(
+      'autonomous-ops-v1.signature-2.diagnosis-grounding',
+    )
+    expect(policy.requiredRefs).toEqual([
+      'quota-ledger-read',
+      'supervisor-dispatch-log',
+      'provider-rate-limit-headers',
+    ])
+    expect(policy.stateOrder).toEqual([
+      'UNGROUNDED',
+      'LEDGER_READ',
+      'DISPATCH_LOG_EXAMINED',
+      'PROVIDER_VERIFIED',
+      'GROUNDED',
+    ])
+  })
+})

--- a/apps/openagents.com/workers/api/src/artanis-diagnosis-grounding-gate.ts
+++ b/apps/openagents.com/workers/api/src/artanis-diagnosis-grounding-gate.ts
@@ -1,0 +1,135 @@
+export type ArtanisDiagnosisGateState =
+  | 'UNGROUNDED'
+  | 'LEDGER_READ'
+  | 'DISPATCH_LOG_EXAMINED'
+  | 'PROVIDER_VERIFIED'
+  | 'GROUNDED'
+
+export type ArtanisDiagnosisClaimKind =
+  | 'rate_limited'
+  | 'quota_exhausted'
+  | 'dispatch_stalled'
+  | 'unknown'
+
+export type ArtanisDiagnosisEvidence = Readonly<{
+  quotaLedgerReadRef?: string
+  supervisorDispatchLog?: Readonly<{
+    ref: string
+    lastEntriesExamined: number
+    outcomes: ReadonlyArray<string>
+  }>
+  providerRateLimitHeaders?: Readonly<{
+    ref: string
+    retryAfterSeconds?: number
+    xRateLimitReset?: string
+  }>
+}>
+
+export type ArtanisDiagnosisGateInput = Readonly<{
+  claimKind: ArtanisDiagnosisClaimKind
+  evidence: ArtanisDiagnosisEvidence
+}>
+
+export type ArtanisDiagnosisGate = Readonly<{
+  state: ArtanisDiagnosisGateState
+  canProposeRemediation: boolean
+  requiredRefs: ReadonlyArray<string>
+  missingRefs: ReadonlyArray<string>
+  blockerRefs: ReadonlyArray<string>
+}>
+
+const requiredRefs = [
+  'quota-ledger-read',
+  'supervisor-dispatch-log',
+  'provider-rate-limit-headers',
+] as const
+
+const hasText = (value: string | undefined): boolean =>
+  value !== undefined && value.trim() !== ''
+
+const providerHeadersVerifyClaim = (
+  claimKind: ArtanisDiagnosisClaimKind,
+  headers: ArtanisDiagnosisEvidence['providerRateLimitHeaders'],
+): boolean => {
+  if (claimKind !== 'rate_limited') {
+    return true
+  }
+  return (
+    headers !== undefined &&
+    hasText(headers.ref) &&
+    (typeof headers.retryAfterSeconds === 'number' || hasText(headers.xRateLimitReset))
+  )
+}
+
+export const evaluateArtanisDiagnosisGroundingGate = (
+  input: ArtanisDiagnosisGateInput,
+): ArtanisDiagnosisGate => {
+  const missingRefs: Array<string> = []
+  const blockerRefs: Array<string> = []
+
+  if (!hasText(input.evidence.quotaLedgerReadRef)) {
+    missingRefs.push('quota-ledger-read')
+  }
+
+  const dispatchLog = input.evidence.supervisorDispatchLog
+  if (
+    dispatchLog === undefined ||
+    !hasText(dispatchLog.ref) ||
+    dispatchLog.lastEntriesExamined < 20 ||
+    dispatchLog.outcomes.length === 0
+  ) {
+    missingRefs.push('supervisor-dispatch-log')
+  }
+
+  const providerHeaders = input.evidence.providerRateLimitHeaders
+  if (!hasText(providerHeaders?.ref)) {
+    missingRefs.push('provider-rate-limit-headers')
+  }
+
+  if (!providerHeadersVerifyClaim(input.claimKind, providerHeaders)) {
+    blockerRefs.push('blocker.artanis.diagnosis.provider_headers_do_not_match_claim')
+  }
+
+  const hasLedger = !missingRefs.includes('quota-ledger-read')
+  const hasDispatchLog = !missingRefs.includes('supervisor-dispatch-log')
+  const hasProviderHeaders = !missingRefs.includes('provider-rate-limit-headers')
+  const providerVerified =
+    hasProviderHeaders && providerHeadersVerifyClaim(input.claimKind, providerHeaders)
+
+  const state: ArtanisDiagnosisGateState = !hasLedger
+    ? 'UNGROUNDED'
+    : !hasDispatchLog
+      ? 'LEDGER_READ'
+      : !hasProviderHeaders
+        ? 'DISPATCH_LOG_EXAMINED'
+        : !providerVerified
+          ? 'PROVIDER_VERIFIED'
+          : 'GROUNDED'
+
+  return {
+    blockerRefs,
+    canProposeRemediation: state === 'GROUNDED',
+    missingRefs,
+    requiredRefs,
+    state,
+  }
+}
+
+export const artanisDiagnosisGroundingPolicy = (): Readonly<{
+  signature: 'autonomous-ops-v1.signature-2.diagnosis-grounding'
+  requiredRefs: ReadonlyArray<string>
+  stateOrder: ReadonlyArray<ArtanisDiagnosisGateState>
+  rule: string
+}> => ({
+  requiredRefs,
+  rule:
+    'No root-cause claim or remediation proposal is allowed until quota-ledger-read, supervisor-dispatch-log with the last 20 entries plus outcomes, and provider-rate-limit-headers are present; rate-limited claims must match real Retry-After or X-RateLimit-Reset evidence.',
+  signature: 'autonomous-ops-v1.signature-2.diagnosis-grounding',
+  stateOrder: [
+    'UNGROUNDED',
+    'LEDGER_READ',
+    'DISPATCH_LOG_EXAMINED',
+    'PROVIDER_VERIFIED',
+    'GROUNDED',
+  ],
+})

--- a/apps/openagents.com/workers/api/src/artanis-reply-composer.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-reply-composer.test.ts
@@ -421,6 +421,9 @@ describe('artanis reply composer - operational grounding (#5540 defect 2)', () =
     expect(capturedBody).toContain('request-payout-target-admission')
     expect(capturedBody).toContain('presence heartbeat')
     expect(capturedBody).toContain('send_readiness_unproven')
+    expect(capturedBody).toContain('diagnosisGrounding')
+    expect(capturedBody).toContain('autonomous-ops-v1.signature-2.diagnosis-grounding')
+    expect(capturedBody).toContain('quota-ledger-read')
     // And the registry grounding is still present.
     expect(capturedBody).toContain('promiseRegistry')
   })

--- a/apps/openagents.com/workers/api/src/artanis-reply-composer.ts
+++ b/apps/openagents.com/workers/api/src/artanis-reply-composer.ts
@@ -4,6 +4,7 @@ import {
   ArtanisMindEscalatedMaxOutputTokens,
   artanisMindComplete,
 } from './artanis-mind'
+import { artanisDiagnosisGroundingPolicy } from './artanis-diagnosis-grounding-gate'
 import { artanisOperationalGrounding } from './artanis-operational-grounding'
 import { publicProductPromisesDocument } from './product-promises'
 import {
@@ -192,6 +193,7 @@ export const runArtanisComposerTick = async (
       // concrete how-to question (e.g. making payout-target ready, keeping
       // executor-trace capability refs live through heartbeat) instead of
       // restating promise-registry copy (#5540 defect 2).
+      diagnosisGrounding: artanisDiagnosisGroundingPolicy(),
       operationalDocs: artanisOperationalGrounding(),
       promiseRegistry: groundingPromises(),
       question: {
@@ -212,7 +214,7 @@ export const runArtanisComposerTick = async (
       // defect 3).
       maxOutputTokens: ArtanisMindEscalatedMaxOutputTokens,
       prompt: [
-        'Compose a reply to this Pylon contributor question. GROUNDING RULES (absolute): every claim about the platform, promises, capabilities, dispatch, or payments must come from the grounding JSON below - if the grounding does not answer part of the question, say so plainly rather than inventing. When the question is a concrete operational how-to (e.g. making payout-target/send readiness true, keeping capability refs live through heartbeat, running a no-spend lane), answer it directly from operationalDocs with the specific commands, blocker names, and readiness states - do NOT just restate promiseRegistry status copy. Device facts come only from the question body (the Pylon embedded its own inventory there). Be specific, useful, and honest about what is yellow vs green. 150-350 words, plain text. End with: - Artanis (automated responder; the mind proposes, schemas validate, gates hold)',
+        'Compose a reply to this Pylon contributor question. GROUNDING RULES (absolute): every claim about the platform, promises, capabilities, dispatch, or payments must come from the grounding JSON below - if the grounding does not answer part of the question, say so plainly rather than inventing. When the question is a concrete operational how-to (e.g. making payout-target/send readiness true, keeping capability refs live through heartbeat, running a no-spend lane), answer it directly from operationalDocs with the specific commands, blocker names, and readiness states - do NOT just restate promiseRegistry status copy. Device facts come only from the question body (the Pylon embedded its own inventory there). Do not assert a root cause or propose a remediation for autonomous ops failures unless diagnosisGrounding is satisfied at GROUNDED with all required refs present and matching the claim. Be specific, useful, and honest about what is yellow vs green. 150-350 words, plain text. End with: - Artanis (automated responder; the mind proposes, schemas validate, gates hold)',
         `GROUNDING: ${JSON.stringify(grounding)}`,
       ].join('\n\n'),
       system:


### PR DESCRIPTION
Addresses #6647.

### Changes
- Added `diagnosisGrounding` policy data to the Artanis reply composer grounding payload.
- Updated the composer prompt to forbid autonomous-ops root-cause or remediation claims unless diagnosis grounding is satisfied at `GROUNDED` with required refs matching the claim.
- Extended the reply composer test to assert the diagnosis grounding signature and required ref are included.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).