### PR TITLE
feat(pylon): add account quota status controls

### DIFF
--- a/apps/pylon/src/account-quota-ledger.ts
+++ b/apps/pylon/src/account-quota-ledger.ts
@@ -1,7 +1,9 @@
-import { readFile, mkdir, writeFile } from "node:fs/promises"
+import { readFile, mkdir, unlink, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import type { BootstrapSummary } from "./bootstrap.js"
+
+type QuotaSummary = Pick<BootstrapSummary, "paths">
 
 export type QuotaRecord = {
   accountRefHash: string
@@ -11,18 +13,37 @@ export type QuotaRecord = {
   sourceDigestRef: string
 }
 
+export type ManualQuotaResetRecord = {
+  accountRefHash: string
+  provider: string
+  manualResetsRemaining: number
+  updatedAt: string
+  resetEvents: Array<{
+    observedAt: string
+    quotaDeleted: boolean
+  }>
+}
+
+export const DEFAULT_MANUAL_QUOTA_RESETS = 3
 const defaultQuotaCooldownMs = 3600_000
 const safePathSegmentPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
 
-function quotaDirectory(summary: BootstrapSummary) {
+function quotaDirectory(summary: QuotaSummary) {
   return join(summary.paths.home, "account-quota")
 }
 
-function quotaRecordPath(summary: BootstrapSummary, accountRefHash: string) {
+function quotaRecordPath(summary: QuotaSummary, accountRefHash: string) {
   const safeRef = safePathSegmentPattern.test(accountRefHash)
     ? accountRefHash
     : encodeURIComponent(accountRefHash)
   return join(quotaDirectory(summary), `${safeRef}.json`)
+}
+
+function manualResetRecordPath(summary: QuotaSummary, accountRefHash: string) {
+  const safeRef = safePathSegmentPattern.test(accountRefHash)
+    ? accountRefHash
+    : encodeURIComponent(accountRefHash)
+  return join(quotaDirectory(summary), `${safeRef}.manual-reset.json`)
 }
 
 function publicProviderRef(provider: string) {
@@ -49,8 +70,38 @@ function quotaRecordFrom(value: unknown): QuotaRecord | null {
   }
 }
 
+function nonNegativeInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null
+  return Math.max(0, Math.floor(value))
+}
+
+function manualResetRecordFrom(value: unknown): ManualQuotaResetRecord | null {
+  if (value === null || typeof value !== "object") return null
+  const record = value as Record<string, unknown>
+  if (typeof record.accountRefHash !== "string") return null
+  if (typeof record.provider !== "string") return null
+  if (typeof record.updatedAt !== "string") return null
+  const manualResetsRemaining = nonNegativeInteger(record.manualResetsRemaining)
+  if (manualResetsRemaining === null) return null
+  const resetEvents = Array.isArray(record.resetEvents)
+    ? record.resetEvents.flatMap((event): ManualQuotaResetRecord["resetEvents"] => {
+        if (event === null || typeof event !== "object") return []
+        const source = event as Record<string, unknown>
+        if (typeof source.observedAt !== "string" || typeof source.quotaDeleted !== "boolean") return []
+        return [{ observedAt: source.observedAt, quotaDeleted: source.quotaDeleted }]
+      })
+    : []
+  return {
+    accountRefHash: record.accountRefHash,
+    provider: publicProviderRef(record.provider),
+    manualResetsRemaining,
+    updatedAt: record.updatedAt,
+    resetEvents,
+  }
+}
+
 export async function recordQuotaBlock(
-  summary: BootstrapSummary,
+  summary: QuotaSummary,
   input: {
     accountRefHash: string
     provider: string
@@ -74,7 +125,7 @@ export async function recordQuotaBlock(
 }
 
 export async function loadQuotaRecord(
-  summary: BootstrapSummary,
+  summary: QuotaSummary,
   accountRefHash: string,
 ): Promise<QuotaRecord | null> {
   try {
@@ -83,6 +134,64 @@ export async function loadQuotaRecord(
   } catch {
     return null
   }
+}
+
+export async function loadManualQuotaResetRecord(
+  summary: QuotaSummary,
+  input: { accountRefHash: string; provider: string },
+): Promise<ManualQuotaResetRecord> {
+  try {
+    const raw = await readFile(manualResetRecordPath(summary, input.accountRefHash), "utf8")
+    const parsed = manualResetRecordFrom(JSON.parse(raw))
+    if (parsed) return parsed
+  } catch {
+    // Missing or malformed local manual-reset state starts from the default allowance.
+  }
+  const now = new Date(0).toISOString()
+  return {
+    accountRefHash: input.accountRefHash,
+    provider: publicProviderRef(input.provider),
+    manualResetsRemaining: DEFAULT_MANUAL_QUOTA_RESETS,
+    updatedAt: now,
+    resetEvents: [],
+  }
+}
+
+export async function consumeManualQuotaReset(
+  summary: QuotaSummary,
+  input: { accountRefHash: string; provider: string; now?: Date },
+): Promise<ManualQuotaResetRecord> {
+  const existing = await loadManualQuotaResetRecord(summary, input)
+  if (existing.manualResetsRemaining <= 0) {
+    throw new Error("no manual quota resets remaining for this account")
+  }
+  let quotaDeleted = false
+  try {
+    await unlink(quotaRecordPath(summary, input.accountRefHash))
+    quotaDeleted = true
+  } catch {
+    quotaDeleted = false
+  }
+  const observedAt = (input.now ?? new Date()).toISOString()
+  const updated: ManualQuotaResetRecord = {
+    accountRefHash: input.accountRefHash,
+    provider: publicProviderRef(input.provider),
+    manualResetsRemaining: existing.manualResetsRemaining - 1,
+    updatedAt: observedAt,
+    resetEvents: [
+      ...existing.resetEvents,
+      {
+        observedAt,
+        quotaDeleted,
+      },
+    ].slice(-20),
+  }
+  await mkdir(quotaDirectory(summary), { recursive: true })
+  await writeFile(
+    manualResetRecordPath(summary, input.accountRefHash),
+    `${JSON.stringify(updated, null, 2)}\n`,
+  )
+  return updated
 }
 
 export function isAccountAvailable(record: QuotaRecord | null, now: Date): boolean {

--- a/apps/pylon/src/account-status.test.ts
+++ b/apps/pylon/src/account-status.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { classifyQuotaSignal } from "./account-quota.js"
+import {
+  consumeManualQuotaReset,
+  loadQuotaRecord,
+  recordQuotaBlock,
+} from "./account-quota-ledger.js"
+import {
+  collectPylonAccountsStatus,
+  parsePylonAccountsStatusArgs,
+  recordPylonAccountUsageObservation,
+} from "./account-usage.js"
+import { createBootstrapSummary, parseBootstrapArgs } from "./bootstrap.js"
+import { hashPylonAccountRef } from "./account-registry.js"
+
+async function withTempHome<T>(fn: (input: { home: string; summary: ReturnType<typeof createBootstrapSummary> }) => Promise<T>) {
+  const home = await mkdtemp(join(tmpdir(), "pylon-account-status-"))
+  try {
+    const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+    return await fn({ home, summary })
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+}
+
+describe("#6637 account status observability", () => {
+  test("parses a concrete provider retry time from quota output", () => {
+    const signal = classifyQuotaSignal(
+      "Hit your usage limit. Please try again at 2026-06-28T21:41:00Z.",
+      "codex",
+    )
+
+    expect(signal.exhausted).toBe(true)
+    expect(signal.retryAtIso).toBe("2026-06-28T21:41:00.000Z")
+  })
+
+  test("projects quota, provider windows, usage, and manual reset state per account", async () => {
+    await withTempHome(async ({ home, summary }) => {
+      const accountHome = join(home, "accounts", "codex", "codex")
+      await mkdir(accountHome, { recursive: true })
+      await writeFile(summary.paths.config, JSON.stringify({
+        dev: {
+          accounts: [
+            {
+              provider: "codex",
+              ref: "codex",
+              home: accountHome,
+            },
+          ],
+        },
+      }))
+      const accountRefHash = hashPylonAccountRef("codex", "codex")
+      await recordQuotaBlock(summary, {
+        accountRefHash,
+        provider: "codex",
+        retryAtIso: "2026-06-28T22:00:00.000Z",
+        sourceDigestRef: "digest.pylon.account_quota.test",
+        now: new Date("2026-06-28T21:30:00.000Z"),
+      })
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        account: {
+          provider: "codex",
+          selector: "registry_ref",
+          accountRef: "codex",
+          accountRefHash,
+          home: accountHome,
+        },
+        providerSnapshots: [
+          {
+            provider: "codex",
+            limitId: "codex",
+            limitName: "Codex",
+            primary: {
+              usedPercent: 25,
+              remainingPercent: 75,
+              windowMinutes: 60,
+              resetsAt: 1_782_682_200,
+              label: "hourly",
+            },
+            secondary: {
+              usedPercent: 50,
+              remainingPercent: 50,
+              windowMinutes: 7 * 24 * 60,
+              resetsAt: 1_783_286_400_000,
+              label: "weekly",
+            },
+            credits: null,
+            planType: "pro",
+            rateLimitReachedType: null,
+          },
+        ],
+        localSessionUsage: {
+          provider: "codex",
+          sessionRef: "session.test",
+          inputTokens: 100,
+          outputTokens: 40,
+          totalTokens: 140,
+        },
+        observedAt: new Date("2026-06-28T21:31:00.000Z"),
+      })
+
+      const status = await collectPylonAccountsStatus(
+        summary,
+        parsePylonAccountsStatusArgs(["--account", "codex", "--json"]),
+        {
+          env: { PYLON_HOME: home, CODEX_HOME: accountHome, PYLON_ACCOUNT_HOME_ROOT: join(home, "empty-siblings") },
+          now: new Date("2026-06-28T21:45:00.000Z"),
+        },
+      )
+
+      expect(status.schema).toBe("openagents.pylon.accounts_status.v0.1")
+      expect(status.accounts).toHaveLength(1)
+      expect(status.accounts[0]?.quota).toMatchObject({
+        state: "limited",
+        cooldownExpiresAt: "2026-06-28T22:00:00.000Z",
+        cooldownSecondsRemaining: 900,
+      })
+      expect(status.accounts[0]?.capacity.hourly?.remainingPercent).toBe(75)
+      expect(status.accounts[0]?.capacity.weekly?.remainingPercent).toBe(50)
+      expect(status.accounts[0]?.usage.totalTokens).toBe(140)
+      expect(status.accounts[0]?.manualReset.manualResetsRemaining).toBe(3)
+    })
+  })
+
+  test("manual reset deletes the quota block and decrements the account allowance", async () => {
+    await withTempHome(async ({ summary }) => {
+      const accountRefHash = hashPylonAccountRef("codex", "codex")
+      await recordQuotaBlock(summary, {
+        accountRefHash,
+        provider: "codex",
+        retryAtIso: "2026-06-28T22:00:00.000Z",
+        sourceDigestRef: "digest.pylon.account_quota.test",
+        now: new Date("2026-06-28T21:30:00.000Z"),
+      })
+
+      const reset = await consumeManualQuotaReset(summary, {
+        accountRefHash,
+        provider: "codex",
+        now: new Date("2026-06-28T21:35:00.000Z"),
+      })
+
+      expect(reset.manualResetsRemaining).toBe(2)
+      expect(reset.resetEvents.at(-1)).toEqual({
+        observedAt: "2026-06-28T21:35:00.000Z",
+        quotaDeleted: true,
+      })
+      expect(await loadQuotaRecord(summary, accountRefHash)).toBeNull()
+    })
+  })
+})

--- a/apps/pylon/src/account-usage.ts
+++ b/apps/pylon/src/account-usage.ts
@@ -24,11 +24,19 @@ import {
 } from "./codex-agent.js"
 import type { BootstrapSummary } from "./bootstrap.js"
 import { assertPublicProjectionSafe } from "./state.js"
+import {
+  consumeManualQuotaReset,
+  isAccountAvailable,
+  loadManualQuotaResetRecord,
+  loadQuotaRecord,
+  type QuotaRecord,
+} from "./account-quota-ledger.js"
 
 export const PYLON_ACCOUNT_USAGE_STORE_SCHEMA = "openagents.pylon.account_usage_store.v0.3"
 export const PYLON_ACCOUNTS_LIST_SCHEMA = "openagents.pylon.accounts_list.v0.3"
 export const PYLON_ACCOUNTS_USAGE_SCHEMA = "openagents.pylon.accounts_usage.v0.3"
 export const PYLON_ACCOUNT_USAGE_SUMMARY_SCHEMA = "openagents.pylon.account_usage_summary.v0.3"
+export const PYLON_ACCOUNTS_STATUS_SCHEMA = "openagents.pylon.accounts_status.v0.1"
 
 export type PylonRateLimitWindowSnapshot = {
   usedPercent: number
@@ -113,6 +121,57 @@ export type PylonAccountsUsageArgs = {
   all: boolean
   refresh: boolean
   json: boolean
+}
+
+export type PylonAccountsStatusArgs = Pick<PylonAccountsUsageArgs, "accountRef" | "provider" | "all" | "json"> & {
+  reset: boolean
+}
+
+export type PylonAccountWindowStatus = {
+  usedPercent: number
+  remainingPercent: number
+  windowMinutes: number | null
+  resetsAtIso: string | null
+  label: string
+}
+
+export type PylonAccountsStatusProjection = {
+  schema: typeof PYLON_ACCOUNTS_STATUS_SCHEMA
+  observedAt: string
+  accounts: Array<{
+    provider: PylonAccountProvider
+    selector: "registry_ref" | "default_home"
+    accountRef: string | null
+    accountRefHash: string
+    readiness: PylonAccountReadiness["readiness"]
+    quota: {
+      state: "available" | "limited"
+      observedAt: string | null
+      cooldownExpiresAt: string | null
+      cooldownSecondsRemaining: number | null
+      sourceDigestRef: string | null
+    }
+    capacity: {
+      hourly: PylonAccountWindowStatus | null
+      weekly: PylonAccountWindowStatus | null
+      windows: PylonAccountWindowStatus[]
+    }
+    usage: {
+      observedAt: string | null
+      inputTokens: number | null
+      outputTokens: number | null
+      totalTokens: number | null
+      totalCostUsd?: number
+    }
+    manualReset: {
+      performed: boolean
+      manualResetsRemaining: number
+      updatedAt: string
+      blockerRefs: string[]
+    }
+    blockerRefs: string[]
+  }>
+  blockerRefs: string[]
 }
 
 export type PylonAccountsUsageProjection = {
@@ -318,6 +377,7 @@ function isApproximateWindow(minutes: number, expectedMinutes: number) {
 export function rateLimitLabelForWindow(windowMinutes: number | null): string {
   if (windowMinutes === null) return "usage"
   const minutes = Math.max(0, windowMinutes)
+  if (isApproximateWindow(minutes, 60)) return "hourly"
   if (isApproximateWindow(minutes, 5 * 60)) return "5h"
   if (isApproximateWindow(minutes, 24 * 60)) return "daily"
   if (isApproximateWindow(minutes, 7 * 24 * 60)) return "weekly"
@@ -528,6 +588,44 @@ export function parsePylonAccountsUsageArgs(args: string[]): PylonAccountsUsageA
   }
   const selectorCount = [parsed.accountRef, parsed.provider, parsed.all ? "all" : null].filter(Boolean).length
   if (selectorCount > 1) throw new Error("Use only one of --account, --provider, or --all")
+  return parsed
+}
+
+export function parsePylonAccountsStatusArgs(args: string[]): PylonAccountsStatusArgs {
+  const parsed: PylonAccountsStatusArgs = {
+    accountRef: null,
+    provider: null,
+    all: false,
+    json: false,
+    reset: false,
+  }
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === "--json") {
+      parsed.json = true
+    } else if (arg === "--reset") {
+      parsed.reset = true
+    } else if (arg === "--all") {
+      parsed.all = true
+    } else if (arg === "--account") {
+      const value = args[index + 1]
+      if (!value || value.startsWith("--")) throw new Error("--account requires an account ref or provider selector")
+      parsed.accountRef = value
+      index += 1
+    } else if (arg === "--provider") {
+      const value = args[index + 1]
+      if (!value || value.startsWith("--")) throw new Error("--provider requires codex or claude_agent")
+      const provider = providerSelectorFrom(value)
+      if (!provider) throw new Error("--provider must be codex or claude_agent")
+      parsed.provider = provider
+      index += 1
+    } else {
+      throw new Error(`Unknown accounts status option: ${arg}`)
+    }
+  }
+  const selectorCount = [parsed.accountRef, parsed.provider, parsed.all ? "all" : null].filter(Boolean).length
+  if (selectorCount > 1) throw new Error("Use only one of --account, --provider, or --all")
+  if (parsed.reset && !parsed.accountRef) throw new Error("accounts status --reset requires --account <ref>")
   return parsed
 }
 
@@ -920,6 +1018,148 @@ function clonePlatformTruth(value: PlatformTruthProjection): PlatformTruthProjec
       : null,
     blockerRefs: [...value.blockerRefs],
   }
+}
+
+function isoFromResetEpoch(value: number | null): string | null {
+  if (value === null || !Number.isFinite(value) || value <= 0) return null
+  const millis = value < 10_000_000_000 ? value * 1000 : value
+  const date = new Date(millis)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function windowStatusFrom(snapshot: PylonRateLimitWindowSnapshot): PylonAccountWindowStatus {
+  return {
+    usedPercent: snapshot.usedPercent,
+    remainingPercent: snapshot.remainingPercent,
+    windowMinutes: snapshot.windowMinutes,
+    resetsAtIso: isoFromResetEpoch(snapshot.resetsAt),
+    label: snapshot.label,
+  }
+}
+
+function capacityWindowsFrom(entry: PylonAccountUsageStoreEntry | undefined): PylonAccountWindowStatus[] {
+  if (!entry?.providerTruth) return []
+  const windows: PylonAccountWindowStatus[] = []
+  for (const snapshot of entry.providerTruth.snapshots) {
+    if (snapshot.primary) windows.push(windowStatusFrom(snapshot.primary))
+    if (snapshot.secondary) windows.push(windowStatusFrom(snapshot.secondary))
+  }
+  const seen = new Set<string>()
+  return windows.filter((window) => {
+    const key = `${window.label}:${window.windowMinutes ?? "unknown"}:${window.usedPercent}:${window.resetsAtIso ?? "none"}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function quotaCooldownExpiresAt(record: QuotaRecord | null): string | null {
+  if (record === null) return null
+  if (record.retryAtIso !== null) return record.retryAtIso
+  const observed = Date.parse(record.observedAt)
+  if (!Number.isFinite(observed)) return null
+  return new Date(observed + 3600_000).toISOString()
+}
+
+function quotaCooldownSecondsRemaining(record: QuotaRecord | null, now: Date): number | null {
+  const expiresAt = quotaCooldownExpiresAt(record)
+  if (expiresAt === null) return null
+  const parsed = Date.parse(expiresAt)
+  if (!Number.isFinite(parsed)) return null
+  return Math.max(0, Math.ceil((parsed - now.getTime()) / 1000))
+}
+
+function firstWindowByLabel(windows: PylonAccountWindowStatus[], label: string): PylonAccountWindowStatus | null {
+  return windows.find((window) => window.label === label) ?? null
+}
+
+export async function collectPylonAccountsStatus(
+  summary: Pick<BootstrapSummary, "paths">,
+  args: PylonAccountsStatusArgs,
+  options: { env?: Record<string, string | undefined>; now?: Date } = {},
+): Promise<PylonAccountsStatusProjection> {
+  const env = options.env ?? (Bun.env as Record<string, string | undefined>)
+  const now = options.now ?? new Date()
+  const observedAt = now.toISOString()
+  const targets = await selectAccountUsageTargets(summary, args, env)
+  const store = await loadAccountUsageStore(summary)
+  const accounts: PylonAccountsStatusProjection["accounts"] = []
+
+  for (const target of targets) {
+    const readiness = (await readinessForTarget(summary, target, env)).readiness
+    let resetPerformed = false
+    let resetBlockerRefs: string[] = []
+    if (args.reset && args.accountRef === target.accountRef) {
+      try {
+        await consumeManualQuotaReset(summary, {
+          accountRefHash: target.accountRefHash,
+          provider: target.provider,
+          now,
+        })
+        resetPerformed = true
+      } catch {
+        resetBlockerRefs = ["blocker.pylon.accounts_status.manual_resets_exhausted"]
+      }
+    }
+
+    const quotaRecord = await loadQuotaRecord(summary, target.accountRefHash)
+    const resetRecord = await loadManualQuotaResetRecord(summary, {
+      accountRefHash: target.accountRefHash,
+      provider: target.provider,
+    })
+    const entry = store.accounts[target.accountRefHash]
+    const windows = capacityWindowsFrom(entry)
+    const localUsage = entry?.localSessionTruth?.usage ?? null
+    const quotaLimited = !isAccountAvailable(quotaRecord, now)
+    const quota = {
+      state: quotaLimited ? "limited" as const : "available" as const,
+      observedAt: quotaRecord?.observedAt ?? null,
+      cooldownExpiresAt: quotaCooldownExpiresAt(quotaRecord),
+      cooldownSecondsRemaining: quotaCooldownSecondsRemaining(quotaRecord, now),
+      sourceDigestRef: quotaRecord?.sourceDigestRef ?? null,
+    }
+    const manualReset = {
+      performed: resetPerformed,
+      manualResetsRemaining: resetRecord.manualResetsRemaining,
+      updatedAt: resetRecord.updatedAt,
+      blockerRefs: resetBlockerRefs,
+    }
+    accounts.push({
+      provider: target.provider,
+      selector: target.selector,
+      accountRef: target.accountRef,
+      accountRefHash: target.accountRefHash,
+      readiness,
+      quota,
+      capacity: {
+        hourly: firstWindowByLabel(windows, "hourly"),
+        weekly: firstWindowByLabel(windows, "weekly"),
+        windows,
+      },
+      usage: {
+        observedAt: entry?.localSessionTruth?.observedAt ?? null,
+        inputTokens: localUsage?.inputTokens ?? null,
+        outputTokens: localUsage?.outputTokens ?? null,
+        totalTokens: localUsage?.totalTokens ?? null,
+        ...(localUsage?.totalCostUsd === undefined ? {} : { totalCostUsd: localUsage.totalCostUsd }),
+      },
+      manualReset,
+      blockerRefs: [
+        ...readiness.blockerRefs,
+        ...(quotaLimited ? ["blocker.pylon.accounts_status.quota_limited"] : []),
+        ...manualReset.blockerRefs,
+      ],
+    })
+  }
+
+  const projection = {
+    schema: PYLON_ACCOUNTS_STATUS_SCHEMA,
+    observedAt,
+    accounts,
+    blockerRefs: accounts.flatMap((account) => account.blockerRefs),
+  } satisfies PylonAccountsStatusProjection
+  assertPublicProjectionSafe(projection)
+  return projection
 }
 
 export async function collectPylonAccountsUsage(

--- a/apps/pylon/src/cli-catalog.ts
+++ b/apps/pylon/src/cli-catalog.ts
@@ -119,9 +119,9 @@ export const PYLON_COMMAND_CATALOG: readonly PylonCommandEntry[] = [
     spends: false,
     json: true,
     args: [
-      pos("connect|list|usage", "Subcommand."),
+      pos("connect|list|usage|status", "Subcommand."),
       pos("codex", "connect: provider to connect.", false),
-      opt("--account", "connect/usage: stable local account ref."),
+      opt("--account", "connect/usage/status: stable local account ref."),
       opt("--account-label", "connect --openagents-link: provider-account label."),
       opt("--agent-token", "connect --openagents-link: OpenAgents agent token (or OPENAGENTS_AGENT_TOKEN)."),
       opt("--base-url", "connect --openagents-link: OpenAgents base URL."),
@@ -133,6 +133,7 @@ export const PYLON_COMMAND_CATALOG: readonly PylonCommandEntry[] = [
       flag("--skip-device-login", "connect: only register the home; do not run Codex device auth."),
       flag("--json", "Emit JSON (required)."),
       flag("--refresh", "usage: refresh provider snapshots."),
+      flag("--reset", "status: consume one manual quota reset for the selected account."),
     ],
   },
   {
@@ -143,8 +144,8 @@ export const PYLON_COMMAND_CATALOG: readonly PylonCommandEntry[] = [
     json: true,
     args: [
       pos("accounts", "Codex account sub-namespace; `fleet offload-plan` is also supported."),
-      pos("list|usage|connect|offload-plan", "Account command or fleet offload planner."),
-      opt("--account", "connect/usage: stable local Codex account ref."),
+      pos("list|usage|status|connect|offload-plan", "Account command or fleet offload planner."),
+      opt("--account", "connect/usage/status: stable local Codex account ref."),
       opt("--accounts", "fleet offload-plan: comma-separated Codex account refs to move."),
       opt("--base-url", "connect --openagents-link: OpenAgents base URL."),
       opt("--bundle-dir", "fleet offload-plan: local directory for tar bundles."),
@@ -154,6 +155,7 @@ export const PYLON_COMMAND_CATALOG: readonly PylonCommandEntry[] = [
       opt("--target", "fleet offload-plan: Tailnet host capacity, e.g. imac-pro-bertha:2."),
       flag("--json", "Emit JSON."),
       flag("--refresh", "usage: refresh provider snapshots."),
+      flag("--reset", "status: consume one manual quota reset for the selected account."),
       flag("--include-private-paths", "fleet offload-plan: include local tar/scp/launch commands with private paths."),
     ],
   },

--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -103,7 +103,9 @@ import {
 import {
   collectPylonAccountsList,
   collectPylonCodexAccountsLocal,
+  collectPylonAccountsStatus,
   collectPylonAccountsUsage,
+  parsePylonAccountsStatusArgs,
   parsePylonAccountsUsageArgs,
   resolvePylonAccountUsageRefreshTargets,
   type PylonAccountsUsageArgs,
@@ -3248,6 +3250,16 @@ async function main() {
         }, null, 2)}\n`)
         return
       }
+      if (command === "status") {
+        const options = parsePylonAccountsStatusArgs(accountCommandArgs.slice(1))
+        if (!options.json) {
+          throw new Error("usage: pylon accounts status [--account <ref-or-provider>|--provider <codex|claude_agent>|--all] [--reset] --json")
+        }
+        const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), Bun.env)
+        const projection = await collectPylonAccountsStatus(summary, options, { env: Bun.env })
+        process.stdout.write(`${JSON.stringify(projection, null, 2)}\n`)
+        return
+      }
       if (command === "connect") {
         const options = parsePylonAccountsConnectArgs(accountCommandArgs.slice(1))
         if (!options.json) {
@@ -3258,7 +3270,7 @@ async function main() {
         process.stdout.write(`${JSON.stringify(projection, null, 2)}\n`)
         return
       }
-      throw new Error("usage: pylon accounts list|usage|connect ...")
+      throw new Error("usage: pylon accounts list|usage|status|connect ...")
     } catch (error) {
       process.stderr.write(`Pylon accounts failed: ${error instanceof Error ? error.message : String(error)}\n`)
       process.exitCode = 1


### PR DESCRIPTION
Addresses #6637.

### Changes
- Added local quota status projection support for Pylon accounts, including limited/available state, cooldown timing, readiness, and usage window details.
- Added manual quota reset tracking with a default reset allowance, reset history, and quota record deletion when a reset is consumed.
- Exposed account status and reset handling through the Pylon CLI catalog and command entrypoint.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)