### PR TITLE
feat(pylon): add operator account status endpoint

### DIFF
--- a/apps/pylon/src/account-registry.ts
+++ b/apps/pylon/src/account-registry.ts
@@ -11,6 +11,9 @@ export type PylonAccountRegistryEntry = {
   ref: string
   provider: PylonAccountProvider
   home: string
+  hourlyCap: number | null
+  weeklyCap: number | null
+  manualResetsRemaining: number | null
 }
 
 export type PylonAccountSelectionInput = {
@@ -53,6 +56,15 @@ function providerFrom(value: unknown): PylonAccountProvider | null {
   return value === "codex" || value === "claude_agent" ? value : null
 }
 
+function nonNegativeNumberOrNull(value: unknown): number | null {
+  const parsed = typeof value === "number"
+    ? value
+    : typeof value === "string" && value.trim().length > 0
+      ? Number(value)
+      : Number.NaN
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
+}
+
 export function normalizeAccountHome(value: string): string {
   const trimmed = value.trim()
   if (trimmed === "~") return homedir()
@@ -85,6 +97,11 @@ export async function loadPylonAccountRegistry(
         provider,
         ref: record.ref,
         home: normalizeAccountHome(home),
+        hourlyCap: nonNegativeNumberOrNull(record.hourlyCap ?? record.hourly_cap),
+        weeklyCap: nonNegativeNumberOrNull(record.weeklyCap ?? record.weekly_cap),
+        manualResetsRemaining: nonNegativeNumberOrNull(
+          record.manualResetsRemaining ?? record.manual_resets_remaining,
+        ),
       })
     }
     return entries

--- a/apps/pylon/src/account-status.ts
+++ b/apps/pylon/src/account-status.ts
@@ -1,0 +1,123 @@
+import {
+  hashPylonAccountRef,
+  loadPylonAccountRegistry,
+  type PylonAccountProvider,
+} from "./account-registry.js"
+import {
+  isAccountAvailable,
+  loadQuotaRecord,
+  type QuotaRecord,
+} from "./account-quota-ledger.js"
+import {
+  loadAccountUsageStore,
+  type PylonAccountUsageStoreEntry,
+  type PylonProviderRateLimitSnapshot,
+} from "./account-usage.js"
+import type { BootstrapSummary } from "./bootstrap.js"
+import { assertPublicProjectionSafe } from "./state.js"
+
+export const PYLON_OPERATOR_ACCOUNT_STATUS_SCHEMA =
+  "openagents.pylon.operator_account_status.v0.1"
+
+export type PylonOperatorAccountStatusEntry = {
+  accountRefHash: string
+  provider: PylonAccountProvider
+  isRateLimited: boolean
+  cooldownExpiresAt: string | null
+  hourlyCap: number | null
+  hourlyUsage: number | null
+  weeklyCap: number | null
+  weeklyUsage: number | null
+  manualResetsRemaining: number | null
+}
+
+export type PylonOperatorAccountStatusProjection = {
+  schema: typeof PYLON_OPERATOR_ACCOUNT_STATUS_SCHEMA
+  observedAt: string
+  accounts: PylonOperatorAccountStatusEntry[]
+}
+
+const fallbackQuotaCooldownMs = 3600_000
+
+function fallbackCooldownExpiresAt(record: QuotaRecord): string | null {
+  if (record.retryAtIso !== null) return record.retryAtIso
+  const observedAt = Date.parse(record.observedAt)
+  if (!Number.isFinite(observedAt)) return null
+  return new Date(observedAt + fallbackQuotaCooldownMs).toISOString()
+}
+
+function cooldownExpiresAt(record: QuotaRecord | null, now: Date): string | null {
+  if (record === null || isAccountAvailable(record, now)) return null
+  return fallbackCooldownExpiresAt(record)
+}
+
+function usageFromPercent(cap: number | null, usedPercent: number): number {
+  return cap === null ? Math.round(usedPercent) : Math.round((cap * usedPercent) / 100)
+}
+
+function snapshotWindowUsage(
+  snapshots: PylonProviderRateLimitSnapshot[],
+  kind: "hourly" | "weekly",
+  cap: number | null,
+): number | null {
+  const targetMinutes = kind === "hourly" ? 60 : 7 * 24 * 60
+  for (const snapshot of snapshots) {
+    for (const window of [snapshot.primary, snapshot.secondary]) {
+      if (window === null) continue
+      const minutes = window.windowMinutes
+      const labelMatches = kind === "weekly"
+        ? window.label === "weekly"
+        : window.label === "hourly"
+      const minutesMatch = minutes !== null && Math.abs(minutes - targetMinutes) <= targetMinutes * 0.1
+      if (minutesMatch || labelMatches) return usageFromPercent(cap, window.usedPercent)
+    }
+  }
+  return null
+}
+
+function usageFor(
+  entry: PylonAccountUsageStoreEntry | undefined,
+  kind: "hourly" | "weekly",
+  cap: number | null,
+): number | null {
+  const snapshots = entry?.providerTruth?.snapshots ?? []
+  const fromProvider = snapshotWindowUsage(snapshots, kind, cap)
+  if (fromProvider !== null) return fromProvider
+  if (kind === "hourly") return entry?.localSessionTruth?.usage.totalTokens ?? null
+  return null
+}
+
+export async function collectPylonOperatorAccountStatus(
+  summary: Pick<BootstrapSummary, "paths">,
+  options: { now?: Date } = {},
+): Promise<PylonOperatorAccountStatusProjection> {
+  const now = options.now ?? new Date()
+  const registry = await loadPylonAccountRegistry(summary)
+  const usageStore = await loadAccountUsageStore(summary)
+  const accounts: PylonOperatorAccountStatusEntry[] = []
+
+  for (const account of registry) {
+    const accountRefHash = hashPylonAccountRef(account.provider, account.ref)
+    const quotaRecord = await loadQuotaRecord(summary as BootstrapSummary, accountRefHash)
+    const usageEntry = usageStore.accounts[accountRefHash]
+    accounts.push({
+      accountRefHash,
+      provider: account.provider,
+      isRateLimited: !isAccountAvailable(quotaRecord, now),
+      cooldownExpiresAt: cooldownExpiresAt(quotaRecord, now),
+      hourlyCap: account.hourlyCap,
+      hourlyUsage: usageFor(usageEntry, "hourly", account.hourlyCap),
+      weeklyCap: account.weeklyCap,
+      weeklyUsage: usageFor(usageEntry, "weekly", account.weeklyCap),
+      manualResetsRemaining: account.manualResetsRemaining,
+    })
+  }
+
+  const projection = {
+    schema: PYLON_OPERATOR_ACCOUNT_STATUS_SCHEMA,
+    observedAt: now.toISOString(),
+    accounts,
+  } satisfies PylonOperatorAccountStatusProjection
+  assertPublicProjectionSafe(projection)
+  return projection
+}

--- a/apps/pylon/src/account-usage.ts
+++ b/apps/pylon/src/account-usage.ts
@@ -257,7 +257,7 @@ async function pathIsDirectory(path: string): Promise<boolean> {
   }
 }
 
-async function loadAccountUsageStore(summary: Pick<BootstrapSummary, "paths">): Promise<PylonAccountUsageStore> {
+export async function loadAccountUsageStore(summary: Pick<BootstrapSummary, "paths">): Promise<PylonAccountUsageStore> {
   try {
     const parsed = JSON.parse(await readFile(accountUsagePath(summary), "utf8")) as PylonAccountUsageStore
     if (parsed.schema === PYLON_ACCOUNT_USAGE_STORE_SCHEMA && parsed.accounts && typeof parsed.accounts === "object") {

--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -108,6 +108,7 @@ import {
   resolvePylonAccountUsageRefreshTargets,
   type PylonAccountsUsageArgs,
 } from "./account-usage.js"
+import { collectPylonOperatorAccountStatus } from "./account-status.js"
 import {
   createCodexFleetOffloadPlan,
   parseCodexFleetOffloadArgs,
@@ -1155,6 +1156,7 @@ const runHeadlessNode = Effect.gen(function* () {
       sessions: headlessSessionsWithExternal,
       intents: makeIntentActions(headlessIntentQueue),
       accountsList: () => collectPylonAccountsList(bootstrapSummary),
+      accountsStatus: () => collectPylonOperatorAccountStatus(bootstrapSummary),
       // The supervisor-status provider comes from the launch lifecycle owner
       // above (undefined unless PYLON_APPLE_FM_SUPERVISE=1 and a helper exists),
       // so by default this is the unsupervised projection unchanged.

--- a/apps/pylon/src/node/control-server.ts
+++ b/apps/pylon/src/node/control-server.ts
@@ -86,6 +86,7 @@ export type ControlCommand =
   | { type: "intent.submit"; title: string; body: string; scopeHint?: string; submittedByClientRef?: string }
   | { type: "intent.list"; sinceCursor?: string }
   | { type: "accounts.list" }
+  | { type: "accounts.status" }
   // CL-16 approvals: read-only pending list + exactly-once resolve.
   | { type: "approvals.list" }
   | { type: "approvals.resolve"; approvalRef: string; decision: "approve" | "deny" | "answer"; answer?: string }
@@ -132,6 +133,7 @@ export interface ControlCommandActions {
   }
   // CL-18: read-only accounts + readiness panel (public-projection-safe).
   accountsList?: () => Promise<unknown>
+  accountsStatus?: () => Promise<unknown>
   // CL-16: read-only pending approvals + exactly-once resolve (approve/deny/answer).
   approvals?: {
     list: () => Promise<unknown>
@@ -344,6 +346,9 @@ export const startControlServer = (
         case "accounts.list":
           if (!options.actions.accountsList) throw new Error("accounts unavailable on this node")
           return options.actions.accountsList()
+        case "accounts.status":
+          if (!options.actions.accountsStatus) throw new Error("account status unavailable on this node")
+          return options.actions.accountsStatus()
         case "bridge.issueBootstrap":
           // Returns { bootstrapId, secret } for the operator to hand to a client
           // (QR/connect payload). Single-use; the secret is exchanged at
@@ -687,6 +692,21 @@ export const startControlServer = (
                   { status: 404 },
                 )
               }
+            }
+
+            if (url.pathname === "/api/operator/accounts/status" && request.method === "GET") {
+              if (!authorized(request)) {
+                return Response.json(
+                  { error: "operator ledger access required" },
+                  { status: 403, headers: { "cache-control": "no-store" } },
+                )
+              }
+              if (!options.actions.accountsStatus) {
+                return Response.json({ error: "account status unavailable" }, { status: 404 })
+              }
+              return Response.json(await options.actions.accountsStatus(), {
+                headers: { "cache-control": "no-store" },
+              })
             }
 
             if (!authorized(request)) return unauthorized()

--- a/apps/pylon/tests/account-status.test.ts
+++ b/apps/pylon/tests/account-status.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { hashPylonAccountRef } from "../src/account-registry"
+import { recordQuotaBlock } from "../src/account-quota-ledger"
+import { collectPylonOperatorAccountStatus } from "../src/account-status"
+import { recordPylonAccountUsageObservation } from "../src/account-usage"
+import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
+import { assertPublicProjectionSafe } from "../src/state"
+
+async function withHome<T>(fn: (home: string) => Promise<T>) {
+  const home = await mkdtemp(join(tmpdir(), "pylon-account-status-"))
+  try {
+    return await fn(home)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+}
+
+describe("pylon operator account status", () => {
+  test("aggregates registered account quota, capacity, manual resets, and usage", async () => {
+    await withHome(async (home) => {
+      const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+      const codexHome = join(home, "codex-a")
+      await mkdir(codexHome, { recursive: true })
+      await writeFile(
+        summary.paths.config,
+        `${JSON.stringify(
+          {
+            dev: {
+              accounts: [
+                {
+                  ref: "codex-a",
+                  provider: "codex",
+                  home: codexHome,
+                  hourlyCap: 1_000,
+                  weeklyCap: 10_000,
+                  manualResetsRemaining: 2,
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      )
+
+      const accountRefHash = hashPylonAccountRef("codex", "codex-a")
+      await recordQuotaBlock(summary, {
+        accountRefHash,
+        provider: "codex",
+        retryAtIso: "2026-06-28T02:00:00.000Z",
+        sourceDigestRef: "digest.pylon.account_quota.test",
+        now: new Date("2026-06-28T01:00:00.000Z"),
+      })
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        account: {
+          provider: "codex",
+          selector: "registry_ref",
+          accountRef: "codex-a",
+          accountRefHash,
+          home: codexHome,
+        },
+        providerSnapshots: [
+          {
+            provider: "codex",
+            limitId: "codex",
+            limitName: null,
+            primary: {
+              usedPercent: 25,
+              remainingPercent: 75,
+              windowMinutes: 60,
+              resetsAt: null,
+              label: "usage",
+            },
+            secondary: {
+              usedPercent: 40,
+              remainingPercent: 60,
+              windowMinutes: 10_080,
+              resetsAt: null,
+              label: "weekly",
+            },
+            credits: null,
+            planType: null,
+            rateLimitReachedType: null,
+          },
+        ],
+        observedAt: new Date("2026-06-28T01:05:00.000Z"),
+      })
+
+      const projection = await collectPylonOperatorAccountStatus(summary, {
+        now: new Date("2026-06-28T01:10:00.000Z"),
+      })
+
+      expect(projection.accounts).toEqual([
+        {
+          accountRefHash,
+          provider: "codex",
+          isRateLimited: true,
+          cooldownExpiresAt: "2026-06-28T02:00:00.000Z",
+          hourlyCap: 1_000,
+          hourlyUsage: 250,
+          weeklyCap: 10_000,
+          weeklyUsage: 4_000,
+          manualResetsRemaining: 2,
+        },
+      ])
+      expect(JSON.stringify(projection)).not.toContain(codexHome)
+      assertPublicProjectionSafe(projection)
+    })
+  })
+})

--- a/apps/pylon/tests/control-protocol.test.ts
+++ b/apps/pylon/tests/control-protocol.test.ts
@@ -250,6 +250,62 @@ describe("control protocol", () => {
     )
   })
 
+  test("operator account status endpoint is bearer gated and no-store", async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const runtime = yield* makePylonNodeRuntime
+          const server = yield* startControlServer(runtime, {
+            token: "test-token-0123456789abcdef",
+            actions: {
+              ...stubActions([]),
+              accountsStatus: async () => ({
+                schema: "openagents.pylon.operator_account_status.v0.1",
+                observedAt: "2026-06-28T00:00:00.000Z",
+                accounts: [
+                  {
+                    accountRefHash: "account.pylon.codex.abc",
+                    provider: "codex",
+                    isRateLimited: false,
+                    cooldownExpiresAt: null,
+                    hourlyCap: null,
+                    hourlyUsage: null,
+                    weeklyCap: null,
+                    weeklyUsage: null,
+                    manualResetsRemaining: null,
+                  },
+                ],
+              }),
+            },
+            port: 0,
+          })
+
+          const denied = yield* Effect.promise(() =>
+            fetch(`${server.url}/api/operator/accounts/status`, {
+              headers: { authorization: "Bearer wrong" },
+            }),
+          )
+          expect(denied.status).toBe(403)
+          expect(denied.headers.get("cache-control")).toBe("no-store")
+          const deniedBody = yield* Effect.promise(() => denied.text())
+          expect(deniedBody).not.toContain("account.pylon.codex.abc")
+
+          const allowed = yield* Effect.promise(() =>
+            fetch(`${server.url}/api/operator/accounts/status`, {
+              headers: { authorization: "Bearer test-token-0123456789abcdef" },
+            }),
+          )
+          expect(allowed.status).toBe(200)
+          expect(allowed.headers.get("cache-control")).toBe("no-store")
+          const body = yield* Effect.promise(() =>
+            allowed.json() as Promise<{ accounts: Array<{ accountRefHash: string }> }>,
+          )
+          expect(body.accounts[0]?.accountRefHash).toBe("account.pylon.codex.abc")
+        }),
+      ),
+    )
+  })
+
   test("assignments commands round-trip and report unavailability", async () => {
     const calls: Array<Record<string, unknown>> = []
     await Effect.runPromise(


### PR DESCRIPTION
Addresses #6639.

### Changes
- Added account registry fields for hourly caps, weekly caps, and manual reset counts.
- Exposed account usage store loading for account status aggregation.
- Wired headless Pylon nodes to collect operator account status.
- Added `accounts.status` control command support and `GET /api/operator/accounts/status` with bearer gating and `no-store` responses.
- Added control protocol coverage for authorized and unauthorized account status requests.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).