### PR TITLE
feat(inference): add GLM max tokens benchmark readout

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/benchmark/stress-saturation-plan.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/stress-saturation-plan.test.ts
@@ -13,8 +13,10 @@ import {
   buildGlmContinuousStressReport,
   buildGlmContinuousStressPlan,
   buildGlmContinuousStressRunnerPlan,
+  buildGlmMaxToksBenchmarkReadout,
   evaluateGlmExternalWinsProbe,
   evaluateGlmExternalWinsOpenAgentsResponse,
+  type GlmStressReport,
 } from './stress-saturation-plan'
 
 const stressShape = (id: string, concurrency: number): SequenceShape => ({
@@ -27,6 +29,73 @@ const stressShape = (id: string, concurrency: number): SequenceShape => ({
   requestClass: 'interactive_stream',
   source: 'synthetic_fixture',
 })
+
+const readyRunnerPlan = () => {
+  const plan = buildGlmContinuousStressPlan({
+    matrixConfig: SAMPLE_DECISION_SUITE_CONFIG,
+    target: GLM_52_REAP_POOL_TARGET,
+    shapes: [stressShape('saturation-knee', 16)],
+    workloads: ['chat'],
+    headroom: {
+      healthyReplicaCount: 10,
+      aggregateAvailableSlots: 10,
+      reservedExternalSlots: 3,
+      externalDemandActive: false,
+    },
+    evidence: {
+      liveHeadroomEvidenceRef: 'evidence.glm.live_headroom.oracle.v1',
+      externalWinsPreemptionEvidenceRef:
+        'evidence.glm.external_wins.preemption.v1',
+      externalWinsProofStatus: 'accepted',
+      rolloutGuardEvidenceRef: 'evidence.glm.stress.rollout_guard.v1',
+      throughputRolloutCanStartIssue6317Stress: true,
+    },
+  })
+  return buildGlmContinuousStressRunnerPlan({
+    generatedAt: '2026-06-26T00:00:00.000Z',
+    tickRef: 'tick.glm.stress.report.max_toks.v1',
+    plan,
+  })
+}
+
+const measuredSaturationReport = (
+  outputTokens: number,
+  ttftMs: number,
+): GlmStressReport => {
+  const runnerPlan = readyRunnerPlan()
+  const firstCell = runnerPlan.dispatchCells[0]
+  if (firstCell === undefined) {
+    throw new Error('expected a dispatch cell for max-tok/s report test')
+  }
+  return buildGlmContinuousStressReport({
+    generatedAt: '2026-06-26T00:00:02.000Z',
+    runnerPlan,
+    throughputMeasurementWindowMs: 2000,
+    observations: [
+      {
+        cellId: firstCell.cellId,
+        replicaRef: 'replica.glm.us-central1-a.1',
+        status: 'ok',
+        outputTokens,
+        goodputTokens: outputTokens - 100,
+        wallClockMs: 2000,
+        ttftMs,
+        interTokenLatencyP50Ms: 6,
+        interTokenLatencyP90Ms: 18,
+        interTokenLatencyP99Ms: 32,
+      },
+      {
+        cellId: firstCell.cellId,
+        replicaRef: 'replica.glm.us-central1-a.2',
+        status: 'failed',
+        httpStatus: 429,
+        failureKind: 'rate_limited',
+        outputTokens: 0,
+        wallClockMs: 100,
+      },
+    ],
+  })
+}
 
 describe('GLM continuous stress saturation plan (#6317 prep slice)', () => {
   test('returns a typed blocker artifact until live scheduler evidence exists', () => {
@@ -572,6 +641,108 @@ describe('GLM continuous stress saturation plan (#6317 prep slice)', () => {
     expect(JSON.stringify(report)).not.toMatch(
       /prompt|completion|bearer|secret|https?:\/\//i,
     )
+  })
+
+  test('builds a decision-grade #6312 max-tok/s readout from in-cloud and WAN saturation reports', () => {
+    const inCloudReport = measuredSaturationReport(1400, 120)
+    const wanReport = measuredSaturationReport(1100, 180)
+
+    const readout = buildGlmMaxToksBenchmarkReadout({
+      generatedAt: '2026-06-26T00:00:03.000Z',
+      benchmarkRef: 'benchmark.glm.max_toks.2026_06_26',
+      recordedAt: '2026-06-26T00:00:02.000Z',
+      fleetSize: 10,
+      servingProfileRef:
+        'serving.glm_52_reap_504b.tp4.mtp2.no_min_p.context_250k',
+      sustainedOpenCodeSessionEstimate: 42,
+      reports: [
+        { surface: 'in_cloud', report: inCloudReport },
+        { surface: 'wan', report: wanReport },
+      ],
+    })
+
+    expect(readout.decisionGrade).toBe(true)
+    expect(readout.blockerRefs).toEqual([])
+    expect(readout.headlineMaxTokPerSecond).toBe(700)
+    expect(readout.saturationConcurrency).toBe(7)
+    expect(readout.sustainedOpenCodeSessionEstimate).toBe(42)
+    expect(readout.inCloud).toMatchObject({
+      surface: 'in_cloud',
+      aggregateTokPerSecond: 700,
+      goodputTokPerSecond: 650,
+      saturationConcurrency: 7,
+      singleflightOverflowRateAtSaturation: 0.5,
+      replicaCount: 2,
+      outputTokens: 1400,
+      goodputTokens: 1300,
+    })
+    expect(readout.wan).toMatchObject({
+      surface: 'wan',
+      aggregateTokPerSecond: 550,
+      goodputTokPerSecond: 500,
+      saturationConcurrency: 7,
+      singleflightOverflowRateAtSaturation: 0.5,
+      replicaCount: 2,
+      outputTokens: 1100,
+      goodputTokens: 1000,
+    })
+    expect(readout.wanDelta).toEqual({
+      aggregateTokPerSecond: -150,
+      ttftP90Ms: 60,
+    })
+    expect(JSON.stringify(readout)).not.toMatch(
+      /prompt|completion|bearer|secret|https?:\/\//i,
+    )
+  })
+
+  test('keeps #6312 max-tok/s readout blocked until WAN and saturation evidence exist', () => {
+    const runnerPlan = readyRunnerPlan()
+    const firstCell = runnerPlan.dispatchCells[0]
+    if (firstCell === undefined) {
+      throw new Error('expected a dispatch cell for blocked max-tok/s test')
+    }
+    const cleanUnsaturatedReport = buildGlmContinuousStressReport({
+      generatedAt: '2026-06-26T00:00:02.000Z',
+      runnerPlan,
+      throughputMeasurementWindowMs: 2000,
+      observations: [
+        {
+          cellId: firstCell.cellId,
+          replicaRef: 'replica.glm.us-central1-a.1',
+          status: 'ok',
+          outputTokens: 1200,
+          goodputTokens: 1100,
+          wallClockMs: 2000,
+          ttftMs: 120,
+          interTokenLatencyP50Ms: 6,
+          interTokenLatencyP90Ms: 18,
+          interTokenLatencyP99Ms: 32,
+        },
+      ],
+    })
+
+    const readout = buildGlmMaxToksBenchmarkReadout({
+      generatedAt: '2026-06-26T00:00:03.000Z',
+      benchmarkRef: 'benchmark.glm.max_toks.blocked',
+      recordedAt: '2026-06-26T00:00:02.000Z',
+      fleetSize: 10,
+      servingProfileRef:
+        'serving.glm_52_reap_504b.tp4.mtp2.no_min_p.context_250k',
+      reports: [{ surface: 'in_cloud', report: cleanUnsaturatedReport }],
+    })
+
+    expect(readout.decisionGrade).toBe(false)
+    expect(readout.headlineMaxTokPerSecond).toBeNull()
+    expect(readout.reasons).toEqual([
+      'missing_wan_report',
+      'saturation_point_not_observed',
+      'opencode_session_estimate_missing',
+    ])
+    expect(readout.blockerRefs).toEqual([
+      'blocker.glm_max_toks_benchmark.missing_wan_report',
+      'blocker.glm_max_toks_benchmark.saturation_point_not_observed',
+      'blocker.glm_max_toks_benchmark.opencode_session_estimate_missing',
+    ])
   })
 
   test('accepts external-wins proof only when preempted external demand stays on GLM primary', () => {

--- a/apps/openagents.com/workers/api/src/inference/benchmark/stress-saturation-plan.ts
+++ b/apps/openagents.com/workers/api/src/inference/benchmark/stress-saturation-plan.ts
@@ -25,6 +25,9 @@ export const GLM_CONTINUOUS_STRESS_REPORT_SCHEMA =
 export const GLM_EXTERNAL_WINS_PROOF_SCHEMA =
   'openagents.khala.glm_external_wins_proof.v0_1' as const
 
+export const GLM_MAX_TOKS_BENCHMARK_READOUT_SCHEMA =
+  'openagents.khala.glm_max_toks_benchmark_readout.v0_1' as const
+
 export const GLM_CONTINUOUS_STRESS_TELEMETRY_SCHEMA =
   'openagents.khala.telemetry.v1' as const
 
@@ -263,6 +266,71 @@ export type GlmStressReport = Readonly<{
   replicaRefs: ReadonlyArray<string>
   latencyMs: GlmStressLatencyRollup
   replicaRollups: ReadonlyArray<GlmStressReplicaRollup>
+}>
+
+export type GlmMaxToksBenchmarkSurface = 'in_cloud' | 'wan'
+
+export type GlmMaxToksBenchmarkBlockerReason =
+  | 'missing_in_cloud_report'
+  | 'missing_wan_report'
+  | 'report_not_ready'
+  | 'throughput_not_measured'
+  | 'latency_distribution_not_measured'
+  | 'saturation_point_not_observed'
+  | 'opencode_session_estimate_missing'
+
+export type GlmMaxToksBenchmarkReportInput = Readonly<{
+  surface: GlmMaxToksBenchmarkSurface
+  report: GlmStressReport
+}>
+
+export type GlmMaxToksBenchmarkReadoutInput = Readonly<{
+  generatedAt: string
+  benchmarkRef: string
+  recordedAt: string
+  fleetSize: number
+  servingProfileRef: string
+  sustainedOpenCodeSessionEstimate?: number | undefined
+  reports: ReadonlyArray<GlmMaxToksBenchmarkReportInput>
+}>
+
+export type GlmMaxToksBenchmarkSurfaceReadout = Readonly<{
+  surface: GlmMaxToksBenchmarkSurface
+  tickRef: string
+  aggregateTokPerSecond: number | null
+  goodputTokPerSecond: number | null
+  saturationConcurrency: number | null
+  singleflightOverflowRateAtSaturation: number | null
+  ttftMs: GlmStressLatencySummary
+  interTokenLatencyP50Ms: GlmStressLatencySummary
+  interTokenLatencyP90Ms: GlmStressLatencySummary
+  interTokenLatencyP99Ms: GlmStressLatencySummary
+  replicaCount: number
+  outputTokens: number
+  goodputTokens: number
+  blockerRefs: ReadonlyArray<string>
+}>
+
+export type GlmMaxToksBenchmarkReadout = Readonly<{
+  schema: typeof GLM_MAX_TOKS_BENCHMARK_READOUT_SCHEMA
+  generatedAt: string
+  benchmarkRef: string
+  recordedAt: string
+  publicSafe: true
+  decisionGrade: boolean
+  blockerRefs: ReadonlyArray<string>
+  reasons: ReadonlyArray<GlmMaxToksBenchmarkBlockerReason>
+  fleetSize: number
+  servingProfileRef: string
+  headlineMaxTokPerSecond: number | null
+  saturationConcurrency: number | null
+  sustainedOpenCodeSessionEstimate: number | null
+  inCloud: GlmMaxToksBenchmarkSurfaceReadout | null
+  wan: GlmMaxToksBenchmarkSurfaceReadout | null
+  wanDelta: Readonly<{
+    aggregateTokPerSecond: number | null
+    ttftP90Ms: number | null
+  }>
 }>
 
 export type GlmExternalWinsServedLane =
@@ -779,6 +847,150 @@ export const buildGlmContinuousStressReport = (
     replicaRollups: replicaRefs.map(replicaRef =>
       replicaRollup(replicaRef, input.observations, throughputMeasurementWindowMs),
     ),
+  }
+}
+
+const maxToksBlockerRefs = (
+  reasons: ReadonlyArray<GlmMaxToksBenchmarkBlockerReason>,
+): ReadonlyArray<string> =>
+  reasons.map(reason => `blocker.glm_max_toks_benchmark.${reason}`)
+
+const hasMeasuredLatencyDistribution = (report: GlmStressReport): boolean =>
+  report.latencyMs.ttftMs.sampleCount > 0 &&
+  report.latencyMs.interTokenLatencyP50Ms.sampleCount > 0 &&
+  report.latencyMs.interTokenLatencyP90Ms.sampleCount > 0 &&
+  report.latencyMs.interTokenLatencyP99Ms.sampleCount > 0
+
+const saturationObserved = (report: GlmStressReport): boolean =>
+  report.backoff.action === 'decrease' ||
+  report.backoff.action === 'pause' ||
+  report.overloadFailureCount > 0 ||
+  (report.errorRate !== null &&
+    report.errorRate > GLM_STRESS_ERROR_RATE_BACKOFF_THRESHOLD)
+
+const surfaceReadoutFor = (
+  surface: GlmMaxToksBenchmarkSurface,
+  report: GlmStressReport | undefined,
+): GlmMaxToksBenchmarkSurfaceReadout | null => {
+  if (report === undefined) {
+    return null
+  }
+  const outputTokens = report.replicaRollups.reduce(
+    (sum, replica) => sum + replica.outputTokens,
+    0,
+  )
+  const goodputTokens = report.replicaRollups.reduce(
+    (sum, replica) => sum + replica.goodputTokens,
+    0,
+  )
+  return {
+    surface,
+    tickRef: report.tickRef,
+    aggregateTokPerSecond: report.aggregateTokPerSecond,
+    goodputTokPerSecond: report.goodputTokPerSecond,
+    saturationConcurrency: saturationObserved(report)
+      ? report.backoff.currentConcurrency
+      : null,
+    singleflightOverflowRateAtSaturation: saturationObserved(report)
+      ? report.errorRate
+      : null,
+    ttftMs: report.latencyMs.ttftMs,
+    interTokenLatencyP50Ms: report.latencyMs.interTokenLatencyP50Ms,
+    interTokenLatencyP90Ms: report.latencyMs.interTokenLatencyP90Ms,
+    interTokenLatencyP99Ms: report.latencyMs.interTokenLatencyP99Ms,
+    replicaCount: report.replicaRefs.length,
+    outputTokens,
+    goodputTokens,
+    blockerRefs: report.blockerRefs,
+  }
+}
+
+const reportReasons = (
+  report: GlmStressReport | undefined,
+): ReadonlyArray<GlmMaxToksBenchmarkBlockerReason> => {
+  if (report === undefined) {
+    return []
+  }
+  return [
+    ...(report.runnerState !== 'ready' || report.blockerRefs.length > 0
+      ? (['report_not_ready'] as const)
+      : []),
+    ...(report.aggregateTokPerSecond === null ||
+    report.aggregateTokPerSecond <= 0
+      ? (['throughput_not_measured'] as const)
+      : []),
+    ...(!hasMeasuredLatencyDistribution(report)
+      ? (['latency_distribution_not_measured'] as const)
+      : []),
+    ...(!saturationObserved(report)
+      ? (['saturation_point_not_observed'] as const)
+      : []),
+  ]
+}
+
+const firstReportForSurface = (
+  reports: ReadonlyArray<GlmMaxToksBenchmarkReportInput>,
+  surface: GlmMaxToksBenchmarkSurface,
+): GlmStressReport | undefined =>
+  reports.find(candidate => candidate.surface === surface)?.report
+
+export const buildGlmMaxToksBenchmarkReadout = (
+  input: GlmMaxToksBenchmarkReadoutInput,
+): GlmMaxToksBenchmarkReadout => {
+  const inCloudReport = firstReportForSurface(input.reports, 'in_cloud')
+  const wanReport = firstReportForSurface(input.reports, 'wan')
+  const inCloud = surfaceReadoutFor('in_cloud', inCloudReport)
+  const wan = surfaceReadoutFor('wan', wanReport)
+  const opencodeEstimate =
+    input.sustainedOpenCodeSessionEstimate === undefined ||
+    !Number.isFinite(input.sustainedOpenCodeSessionEstimate) ||
+    input.sustainedOpenCodeSessionEstimate <= 0
+      ? null
+      : Math.floor(input.sustainedOpenCodeSessionEstimate)
+  const reasons = [
+    ...(inCloudReport === undefined
+      ? (['missing_in_cloud_report'] as const)
+      : []),
+    ...(wanReport === undefined ? (['missing_wan_report'] as const) : []),
+    ...reportReasons(inCloudReport),
+    ...reportReasons(wanReport),
+    ...(opencodeEstimate === null
+      ? (['opencode_session_estimate_missing'] as const)
+      : []),
+  ]
+  const uniqueReasons = [...new Set(reasons)]
+  const decisionGrade = uniqueReasons.length === 0
+  const inCloudTps = inCloud?.aggregateTokPerSecond ?? null
+  const wanTps = wan?.aggregateTokPerSecond ?? null
+  const inCloudTtftP90 = inCloud?.ttftMs.p90 ?? null
+  const wanTtftP90 = wan?.ttftMs.p90 ?? null
+
+  return {
+    schema: GLM_MAX_TOKS_BENCHMARK_READOUT_SCHEMA,
+    generatedAt: input.generatedAt,
+    benchmarkRef: input.benchmarkRef,
+    recordedAt: input.recordedAt,
+    publicSafe: true,
+    decisionGrade,
+    blockerRefs: maxToksBlockerRefs(uniqueReasons),
+    reasons: uniqueReasons,
+    fleetSize: safePositiveInteger(input.fleetSize),
+    servingProfileRef: input.servingProfileRef,
+    headlineMaxTokPerSecond: decisionGrade ? inCloudTps : null,
+    saturationConcurrency: decisionGrade
+      ? (inCloud?.saturationConcurrency ?? null)
+      : null,
+    sustainedOpenCodeSessionEstimate: decisionGrade ? opencodeEstimate : null,
+    inCloud,
+    wan,
+    wanDelta: {
+      aggregateTokPerSecond:
+        inCloudTps === null || wanTps === null ? null : wanTps - inCloudTps,
+      ttftP90Ms:
+        inCloudTtftP90 === null || wanTtftP90 === null
+          ? null
+          : wanTtftP90 - inCloudTtftP90,
+    },
   }
 }
 


### PR DESCRIPTION
Addresses #6312.

### Changes
- Adds a GLM-5.2-REAP max tokens-per-second benchmark readout schema and builder for aggregate fleet throughput, saturation concurrency, WAN delta, and decision-grade blockers.
- Adds coverage for accepted in-cloud/WAN saturation evidence and blocked readouts when WAN, saturation, or OpenCode session estimate evidence is missing.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).