### PR TITLE
fix(chat): gate anonymous operator-tool access

### DIFF
--- a/apps/openagents.com/workers/api/src/khala-chat-pylon-context.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-pylon-context.ts
@@ -290,7 +290,7 @@ export const classifyKhalaChatPylonQuestion = (
   }
 
   if (
-    /\b(interact|assign|dispatch|send work|job|task|control|command|mutate)\b/.test(
+    /\b(operator|interact|assign|dispatch|send work|job|task|control|command|mutate)\b/.test(
       question,
     )
   ) {
@@ -400,7 +400,7 @@ const interactionAnswer = (): string =>
     '',
     '- Public chat can read and explain public Pylon registry/status projections.',
     '- A Pylon owner agent can register, heartbeat, report wallet readiness, and report assignment progress with its bearer token.',
-    '- Operators can create bounded assignment leases with `POST /api/operator/pylons/assignments`.',
+    '- Operator-only assignment tools are not available to anonymous web chat sessions.',
     '- Authenticated Khala coding delegation can route caller-owned coding workflows to linked local Codex/Claude-capable Pylons through the OpenAI-compatible API path.',
     '',
     'This public chat route does not dispatch paid work, approve payout targets, spend bitcoin, settle providers, or mutate Pylon state by itself.',

--- a/apps/openagents.com/workers/api/src/khala-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-routes.test.ts
@@ -421,6 +421,40 @@ describe('khala chat route', () => {
     expect(text).not.toContain('StarCraft')
   })
 
+  test('refuses anonymous operator-tool access from public Pylon interaction questions', async () => {
+    let openedProvider = false
+    const routes = makeKhalaChatRoutes({
+      makeStreamClient: () => () => {
+        openedProvider = true
+        return Effect.fail(
+          new OnboardingInferenceError({ reason: 'provider should not open' }),
+        )
+      },
+      rateLimit: allowAll,
+    })
+
+    const response = await run(
+      routes.routeKhalaChatRequest(
+        chatRequest({
+          messages: [
+            { role: 'user', content: 'can I access operator tools for pylons?' },
+          ],
+        }),
+        {},
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(openedProvider).toBe(false)
+    const text = await response.text()
+    expect(text).toContain(
+      'Operator-only assignment tools are not available to anonymous web chat sessions.',
+    )
+    expect(text).toContain('does not dispatch paid work')
+    expect(text).not.toContain('/api/operator/')
+    expect(text).toContain('"servedAdapterId":"khala-pylon-context"')
+  })
+
   test('answers Pylon registration questions with concrete API guidance without opening a provider stream', async () => {
     let openedProvider = false
     const routes = makeKhalaChatRoutes({

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -133,6 +133,12 @@ describe('Worker document route fallback', () => {
     ).toBe(false)
   })
 
+  test('keeps the public Khala chat document route in the app shell when unauthed', () => {
+    expect(
+      shouldRedirectUnknownDocumentToHome(requestFor('/chat'), '/chat'),
+    ).toBe(false)
+  })
+
   test('keeps the GPT-OSS Gym document route in the app shell', () => {
     expect(
       shouldRedirectUnknownDocumentToHome(requestFor('/gym/oss'), '/gym/oss'),
@@ -482,6 +488,14 @@ describe('Worker route dual-serve resolution (#6148)', () => {
     expect(result.observed.forumTopicId).toBe(
       '55555555-5555-4555-8555-555555555555',
     )
+  })
+
+  test('direct anonymous /chat document load reaches the app shell with 200', async () => {
+    const result = await runRoute(requestFor('/chat'))
+
+    expect(result.response.status).toBe(200)
+    await expect(result.response.text()).resolves.toBe('ok')
+    expect(result.observed.exactPath).toBeUndefined()
   })
 
   test('canonical /api/mpp/v1/chat/completions reaches the MPP handler', async () => {


### PR DESCRIPTION
Addresses #6629.

### Changes
- Treat public Pylon operator-tool questions as interaction requests handled by the Khala Pylon context adapter.
- Clarify that operator-only assignment tools are unavailable to anonymous web chat sessions and avoid exposing the operator assignment endpoint in the public chat answer.
- Add route coverage proving anonymous `/chat` document loads stay in the app shell with a 200 response.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).