### PR TITLE
fix(codex-supervisor): timeout guards + last_dispatch_time liveness + wedge auto-restart (#6646)

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -93,6 +93,19 @@ SUP_HEARTBEAT_SECS="${SUP_HEARTBEAT_SECS:-45}"
 SUP_BACKOFF_MIN="${SUP_BACKOFF_MIN:-15}"
 SUP_BACKOFF_MAX="${SUP_BACKOFF_MAX:-300}"
 
+# --- Timeout guards (#6646 wedge fix). ---
+# The #1 token-burn failure mode: an external `gh`/network call in the dispatch
+# loop hangs with NO timeout and silently stalls async dispatch (alive +
+# heartbeating, but never dispatching) while the independent heartbeat keeps
+# firing. EVERY external call is now bounded. `gh`/`curl` timeouts live in
+# lockout.sh + supervisor-task-pool.sh (SUP_GH_TIMEOUT_SECS / SUP_CURL_TIMEOUT_SECS,
+# via sup_run_timeout). Quick local Pylon control calls (heartbeat, go-online,
+# accounts list) get a short bound; the actual labor dispatch (`khala request` /
+# stale-closeout sweep) gets a generous-but-finite bound so it can never hang
+# forever yet normal multi-minute Codex work is not interrupted.
+SUP_PYLON_TIMEOUT_SECS="${SUP_PYLON_TIMEOUT_SECS:-60}"
+SUP_DISPATCH_TIMEOUT_SECS="${SUP_DISPATCH_TIMEOUT_SECS:-1800}"
+
 # --- Self-heal watchdog (#6408): "fleet never silently stalls". ---
 # If the pool sees this many consecutive NO-DISPATCH lines with ZERO OK in
 # between, the loop has stalled (e.g. the dispatch gate is poisoned into
@@ -113,10 +126,31 @@ PYLON=(bun "$REPO_ROOT/apps/pylon/src/index.ts")
 mkdir -p "$SUP_STATE_DIR"
 DESIRED_FILE="$SUP_STATE_DIR/desired-slots"
 PAUSE_FILE="$SUP_STATE_DIR/paused"
+# Wedge telemetry (#6646): epoch-ms timestamp of the most recent dispatch
+# ATTEMPT (pick+dispatch cycle). The liveness check + watcher read this to tell
+# "alive but stalled" (wedged) from "alive and dispatching" (healthy).
+LAST_DISPATCH_FILE="$SUP_STATE_DIR/last_dispatch_time"
 echo 0 > "$DESIRED_FILE"
 rm -f "$PAUSE_FILE"
 
 log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$SUP_LOG"; }
+
+# Epoch milliseconds (portable: python3 is already a dependency here; `date`
+# fallback for environments without it). BSD `date` has no %N, so do not use it.
+now_epoch_ms() {
+  python3 -c 'import time;print(int(time.time()*1000))' 2>/dev/null \
+    || echo $(( $(date +%s) * 1000 ))
+}
+
+# Record one dispatch ATTEMPT (called each pick+dispatch cycle, before spawning
+# the slot's khala request). Powers last_dispatch_time telemetry + wedge detect.
+record_dispatch_attempt() {
+  now_epoch_ms > "$LAST_DISPATCH_FILE" 2>/dev/null || true
+}
+
+read_last_dispatch_time() {
+  cat "$LAST_DISPATCH_FILE" 2>/dev/null || echo ""
+}
 
 bound_log() {
   if [ -f "$SUP_LOG" ] && [ "$(wc -c < "$SUP_LOG" 2>/dev/null || echo 0)" -gt 4194304 ]; then
@@ -125,14 +159,15 @@ bound_log() {
 }
 
 counter_now() {
-  curl -fsS "$PYLON_OPENAGENTS_BASE_URL/api/public/khala-tokens-served" 2>/dev/null \
+  curl -fsS --max-time "${SUP_CURL_TIMEOUT_SECS:-15}" --connect-timeout 10 \
+    "$PYLON_OPENAGENTS_BASE_URL/api/public/khala-tokens-served" 2>/dev/null \
     | sed -n 's/.*"tokensServed":\([0-9]*\).*/\1/p' | head -1
 }
 
 # Print ready Codex account refs, one per line. Default-home account (accountRef
 # null) is printed as the literal token "default".
 ready_codex_account_refs() {
-  "${PYLON[@]}" codex accounts list --json 2>/dev/null | python3 -c "import os,sys,json
+  sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" codex accounts list --json 2>/dev/null | python3 -c "import os,sys,json
 allow_raw=os.environ.get('SUP_ACCOUNT_REFS','').replace(',', ' ').split()
 allow=set(allow_raw)
 try: d=json.load(sys.stdin)
@@ -179,11 +214,11 @@ selfheal_watchdog_loop() {
     if [ "${n:-0}" -ge "$SUP_STALL_REFUSALS" ]; then
       log "!!!!!! FLEET-STALL: $n consecutive NO-DISPATCH with 0 OK -> self-healing (re-advertise + stale-closeout sweep)"
       # (a) re-assert advertisement so a dropped/ignored heartbeat is refreshed.
-      "${PYLON[@]}" provider go-online >> "$SUP_LOG" 2>&1 || true
+      sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" provider go-online >> "$SUP_LOG" 2>&1 || true
       # (b) clear our OWN abandoned/interrupted local leases so they stop
       #     poisoning the dispatch gate into duplicate_active_assignment. The
       #     no-spend runner submits public-safe stale closeouts at load.
-      "${PYLON[@]}" assignment run-no-spend --json >> "$SUP_LOG" 2>&1 || true
+      sup_run_timeout "$SUP_DISPATCH_TIMEOUT_SECS" "${PYLON[@]}" assignment run-no-spend --json >> "$SUP_LOG" 2>&1 || true
       log "FLEET-STALL: self-heal complete (re-advertised + swept stale closeouts); cooldown ${SUP_SELFHEAL_COOLDOWN_SECS}s"
       sleep "$SUP_SELFHEAL_COOLDOWN_SECS"
     fi
@@ -202,8 +237,11 @@ heartbeater_loop() {
     OPENAGENTS_PYLON_CODEX_CONCURRENCY="$desired" \
     OPENAGENTS_PYLON_CODEX_BUSY=0 \
     OPENAGENTS_PYLON_CODEX_QUEUED=0 \
-      "${PYLON[@]}" presence heartbeat --json >> "$SUP_LOG" 2>&1 || true
-    log "heartbeat ready_codex=$ready desired_slots=$desired"
+      sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" presence heartbeat --json >> "$SUP_LOG" 2>&1 || true
+    # last_dispatch_time telemetry (#6646): emitted on the heartbeat line so a
+    # wedged loop (heartbeat firing, dispatch stalled) is visible in the log and
+    # the watcher's liveness check has a fresh value to read.
+    log "heartbeat ready_codex=$ready desired_slots=$desired last_dispatch_time=$(read_last_dispatch_time)"
     bound_log
     sleep "$SUP_HEARTBEAT_SECS"
   done
@@ -277,8 +315,17 @@ worker_loop() {
     local commit; commit=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)
     [ -z "$commit" ] && { sleep 15; continue; }
 
+    # Record the dispatch ATTEMPT timestamp (#6646) right before firing the
+    # request, so last_dispatch_time advances every pick+dispatch cycle and a
+    # wedged loop is detectable as "alive but last_dispatch_time stale".
+    record_dispatch_attempt
+
     local out="$SUP_STATE_DIR/slot.$slot.json"
-    "${PYLON[@]}" khala request \
+    # Bound the labor dispatch so a hung request can never stall this slot
+    # forever (#6646). The bound is generous (SUP_DISPATCH_TIMEOUT_SECS) so
+    # normal multi-minute Codex work completes; on timeout (rc 124) the slot
+    # treats it as a failed dispatch and continues with backoff below.
+    sup_run_timeout "$SUP_DISPATCH_TIMEOUT_SECS" "${PYLON[@]}" khala request \
       --prompt "Implement public issue #$issue and run the named verification." \
       --workflow codex_agent_task \
       --pylon-ref "$SUP_PYLON_REF" \
@@ -322,9 +369,12 @@ if [ -z "${OPENAGENTS_AGENT_TOKEN:-}" ]; then
 fi
 
 echo $$ > "$SUP_STATE_DIR/supervisor.pid"
+# Seed last_dispatch_time at startup so the liveness check has a baseline and the
+# fresh process is not flagged wedged before its first dispatch (#6646).
+record_dispatch_attempt
 log "=== codex-supervisor START pid=$$ repo=$REPO_ROOT pylon=$SUP_PYLON_REF per_account=$SUP_PER_ACCOUNT max_slots=$SUP_MAX_SLOTS account_refs=${SUP_ACCOUNT_REFS:-all} ==="
 
-"${PYLON[@]}" provider go-online >> "$SUP_LOG" 2>&1 || log "provider go-online nonzero (continuing)"
+sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" provider go-online >> "$SUP_LOG" 2>&1 || log "provider go-online nonzero (continuing)"
 
 heartbeater_loop &
 log "heartbeater pid=$! cadence=${SUP_HEARTBEAT_SECS}s"
@@ -343,6 +393,6 @@ done
 # Periodic public-counter progress line for observability.
 while true; do
   bound_log
-  log "counter tokensServed=$(counter_now) desired_slots=$(cat "$DESIRED_FILE" 2>/dev/null)"
+  log "counter tokensServed=$(counter_now) desired_slots=$(cat "$DESIRED_FILE" 2>/dev/null) last_dispatch_time=$(read_last_dispatch_time)"
   sleep 120
 done

--- a/apps/pylon/scripts/codex-supervisor/launch.sh
+++ b/apps/pylon/scripts/codex-supervisor/launch.sh
@@ -10,19 +10,41 @@
 #   OPENAGENTS_AGENT_TOKEN=... ./launch.sh            # start
 #   ./launch.sh status                                # show pid + tail log
 #   ./launch.sh stop                                  # stop the supervisor
+#   ./launch.sh wedge-check                           # liveness verdict (#6646)
+#   OPENAGENTS_AGENT_TOKEN=... ./launch.sh wedge-watch  # restart IF wedged (#6646)
 #
 # Run this from a CLEAN worktree at current origin/main (deps installed via
 # `bun install --frozen-lockfile`). See the Khala -> Pylon -> Codex runbook.
 #
+# Wedge auto-restart (#6646): the supervisor's #1 token-burn failure mode is a
+# WEDGE — alive + heartbeating but no longer dispatching (an external call hung
+# the dispatch loop). `wedge-check` runs the tested liveness check in
+# `apps/pylon/src/blueprint-gates/fleet-liveness.ts` against the supervisor pid +
+# `$SUP_STATE_DIR/last_dispatch_time`; `wedge-watch` additionally force-kills and
+# restarts the supervisor when that check reports `wedged`. Run `wedge-watch` on
+# an interval from an external watcher (cron / standing loop) with
+# OPENAGENTS_AGENT_TOKEN in the environment.
+#
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 SUP_STATE_DIR="${SUP_STATE_DIR:-$HOME/.codex-supervisor}"
 SUP_LOG="${SUP_LOG:-$SUP_STATE_DIR/supervisor.log}"
 PIDFILE="$SUP_STATE_DIR/supervisor.pid"
+FLEET_LIVENESS_TS="$REPO_ROOT/apps/pylon/src/blueprint-gates/fleet-liveness.ts"
 mkdir -p "$SUP_STATE_DIR"
 
+# bun must be on PATH for the liveness CLI and the detached supervisor.
+export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
 alive() { [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; }
+
+# Run the tested liveness check; returns its exit code (0 healthy, 3 wedged,
+# 4 unknown) and prints the JSON verdict.
+wedge_check() {
+  SUP_STATE_DIR="$SUP_STATE_DIR" bun "$FLEET_LIVENESS_TS" --check
+}
 
 case "${1:-start}" in
   status)
@@ -45,8 +67,35 @@ case "${1:-start}" in
     fi
     exit 0
     ;;
+  wedge-check)
+    # One-shot liveness verdict; exit code mirrors the check (0/3/4).
+    wedge_check
+    exit $?
+    ;;
+  wedge-watch|restart-if-wedged)
+    # Force-restart the supervisor ONLY when the liveness check says wedged.
+    wedge_check
+    code=$?
+    if [ "$code" -eq 3 ]; then
+      echo "WEDGE DETECTED (#6646): supervisor alive but last_dispatch_time stale > threshold -> force-restarting"
+      if [ -f "$PIDFILE" ]; then
+        PID="$(cat "$PIDFILE" 2>/dev/null)"
+        if [ -n "$PID" ]; then
+          kill -TERM "$PID" 2>/dev/null
+          for _ in 1 2 3 4 5; do kill -0 "$PID" 2>/dev/null || break; sleep 1; done
+          kill -KILL "$PID" 2>/dev/null
+          echo "killed wedged supervisor pid=$PID"
+        fi
+      fi
+      rm -f "$PIDFILE"
+      # Re-enter via the normal start path (requires OPENAGENTS_AGENT_TOKEN).
+      exec bash "$0" start
+    fi
+    echo "supervisor not wedged (liveness exit=$code); no restart"
+    exit 0
+    ;;
   start) ;;
-  *) echo "usage: launch.sh [start|status|stop]" >&2; exit 2 ;;
+  *) echo "usage: launch.sh [start|status|stop|wedge-check|wedge-watch]" >&2; exit 2 ;;
 esac
 
 if alive; then
@@ -58,9 +107,6 @@ if [ -z "${OPENAGENTS_AGENT_TOKEN:-}" ]; then
   echo "FATAL: OPENAGENTS_AGENT_TOKEN must be set in the environment before launch" >&2
   exit 1
 fi
-
-# Ensure bun is on PATH for the detached process.
-export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
 echo "launching codex-supervisor (log: $SUP_LOG)"
 nohup caffeinate -i bash "$SCRIPT_DIR/codex-supervisor.sh" >> "$SUP_LOG" 2>&1 &

--- a/apps/pylon/scripts/codex-supervisor/lockout.sh
+++ b/apps/pylon/scripts/codex-supervisor/lockout.sh
@@ -31,10 +31,46 @@
 : "${SUP_REPO:=OpenAgentsInc/openagents}"
 : "${SUP_LOCKOUT_TTL_SECS:=90}"
 : "${SUP_STATE_DIR:=$HOME/.codex-supervisor}"
+# Strict timeout (s) for every external `gh` CLI call (issue #6646 wedge fix).
+: "${SUP_GH_TIMEOUT_SECS:=15}"
 
 # Portable file mtime (BSD/macOS `stat -f`, GNU/Linux `stat -c`).
 sup_file_mtime() {
   stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+}
+
+# sup_run_timeout <secs> <cmd...>
+#   #6646 wedge guard. The supervisor's #1 token-burn failure mode is a single
+#   external `gh`/network call in the dispatch loop hanging with NO timeout: the
+#   async dispatch loop silently stalls (alive + heartbeating, but never
+#   dispatching) while the independent heartbeat keeps firing. This wraps any
+#   external call with a hard wall-clock bound so it can NEVER hang unbounded.
+#   On timeout it returns 124 (mirroring coreutils `timeout`), emits a TIMEOUT
+#   line on stderr, and the caller treats it as a failed/empty result and
+#   CONTINUES the loop. Portable: prefers `timeout`/`gtimeout`, else a pure-bash
+#   background-watchdog fallback (stock macOS ships neither binary).
+sup_run_timeout() {
+  local secs="$1"; shift
+  [ "$#" -gt 0 ] || return 0
+  local rc
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"; rc=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"; rc=$?
+  else
+    "$@" &
+    local cmd_pid=$!
+    ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null; sleep 2; kill -KILL "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 &
+    local watch_pid=$!
+    wait "$cmd_pid" 2>/dev/null; rc=$?
+    kill -TERM "$watch_pid" 2>/dev/null; wait "$watch_pid" 2>/dev/null
+    # Normalize a watchdog-killed command to coreutils' 124 timeout code.
+    [ "$rc" -ge 128 ] && rc=124
+  fi
+  if [ "$rc" -eq 124 ]; then
+    printf 'sup_run_timeout: TIMEOUT after %ss: %s\n' "$secs" "$*" >&2
+  fi
+  return "$rc"
 }
 
 # issue_has_open_pr <issue>
@@ -58,7 +94,7 @@ issue_has_open_pr() {
   fi
 
   local json
-  json=$("$SUP_GH_BIN" pr list --repo "$SUP_REPO" --state open \
+  json=$(sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" pr list --repo "$SUP_REPO" --state open \
     --search "#$issue in:title in:body" \
     --json number,title,body --limit 50 2>/dev/null)
 
@@ -106,7 +142,7 @@ issue_is_open() {
   fi
 
   local state
-  state=$("$SUP_GH_BIN" issue view "$issue" --repo "$SUP_REPO" \
+  state=$(sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" issue view "$issue" --repo "$SUP_REPO" \
     --json state -q .state 2>/dev/null | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')
 
   case "$state" in
@@ -153,7 +189,7 @@ sup_open_issue_numbers() {
   fi
 
   local json
-  json=$("$SUP_GH_BIN" issue list --repo "$SUP_REPO" --state open \
+  json=$(sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" issue list --repo "$SUP_REPO" --state open \
     --limit "${SUP_OPEN_SET_LIMIT:-300}" --json number 2>/dev/null) || return 1
   [ -n "$json" ] || return 1
 

--- a/apps/pylon/scripts/codex-supervisor/timeout.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/timeout.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# timeout.test.sh — focused tests for sup_run_timeout, the #6646 wedge guard.
+#
+# The supervisor's #1 token-burn failure mode is an external gh/network call in
+# the dispatch loop hanging with no timeout. sup_run_timeout (defined in
+# lockout.sh) bounds every such call. This asserts:
+#   * a fast command passes through (rc + stdout preserved),
+#   * a nonzero exit code is preserved,
+#   * an overrunning command is killed and reports the timeout (rc 124),
+#   * the timeout fires promptly (it does not wait for the full command).
+#
+# These exercise the pure-bash watchdog fallback on hosts without coreutils
+# `timeout`/`gtimeout` (e.g. stock macOS), which is the real production path.
+#
+# Run: bash apps/pylon/scripts/codex-supervisor/timeout.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lockout.sh
+source "$SCRIPT_DIR/lockout.sh"
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# --- fast command passes through (rc 0, stdout preserved) ------------------
+out=$(sup_run_timeout 5 bash -c 'echo hello; exit 0'); rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "hello" ]; then
+  ok "fast command passes through (rc=0, stdout='hello')"
+else
+  bad "fast command rc=$rc out='$out' (want rc=0 out='hello')"
+fi
+
+# --- nonzero exit code is preserved ---------------------------------------
+sup_run_timeout 5 bash -c 'exit 7' >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 7 ]; then
+  ok "nonzero exit code preserved (7)"
+else
+  bad "expected rc 7, got $rc"
+fi
+
+# --- overrunning command is killed and reports timeout (rc 124) -----------
+start=$(date +%s)
+sup_run_timeout 1 bash -c 'sleep 30' >/dev/null 2>&1; rc=$?
+end=$(date +%s)
+if [ "$rc" -eq 124 ]; then
+  ok "overrunning command times out (rc=124)"
+else
+  bad "expected rc 124 (timeout), got $rc"
+fi
+if [ $(( end - start )) -lt 10 ]; then
+  ok "timeout fired promptly ($(( end - start ))s, not the full 30s)"
+else
+  bad "timeout took too long ($(( end - start ))s)"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/apps/pylon/scripts/supervisor-task-pool.sh
+++ b/apps/pylon/scripts/supervisor-task-pool.sh
@@ -14,10 +14,42 @@
 : "${SUP_GH_BIN:=gh}"
 : "${SUP_TASK_POOL_LIMIT:=100}"
 : "${SUP_TASK_POOL_CACHE_TTL_SECS:=120}"
+# Strict timeouts for external calls (#6646 wedge guard).
+: "${SUP_GH_TIMEOUT_SECS:=15}"
+: "${SUP_CURL_TIMEOUT_SECS:=15}"
 
 if ! command -v sup_file_mtime >/dev/null 2>&1; then
   sup_file_mtime() {
     stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+  }
+fi
+
+# Defensive fallback: codex-supervisor.sh sources lockout.sh (which defines
+# sup_run_timeout) BEFORE this file, so the canonical wrapper is normally
+# present. Define an equivalent here for any standalone use so an external call
+# can still never hang unbounded (#6646).
+if ! command -v sup_run_timeout >/dev/null 2>&1; then
+  sup_run_timeout() {
+    local secs="$1"; shift
+    [ "$#" -gt 0 ] || return 0
+    local rc
+    if command -v timeout >/dev/null 2>&1; then
+      timeout "$secs" "$@"; rc=$?
+    elif command -v gtimeout >/dev/null 2>&1; then
+      gtimeout "$secs" "$@"; rc=$?
+    else
+      "$@" &
+      local cmd_pid=$!
+      ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null; sleep 2; kill -KILL "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 &
+      local watch_pid=$!
+      wait "$cmd_pid" 2>/dev/null; rc=$?
+      kill -TERM "$watch_pid" 2>/dev/null; wait "$watch_pid" 2>/dev/null
+      [ "$rc" -ge 128 ] && rc=124
+    fi
+    if [ "$rc" -eq 124 ]; then
+      printf 'sup_run_timeout: TIMEOUT after %ss: %s\n' "$secs" "$*" >&2
+    fi
+    return "$rc"
   }
 fi
 
@@ -63,7 +95,7 @@ supervisor_issue_is_open() {
   command -v "$SUP_GH_BIN" >/dev/null 2>&1 || return 0
 
   local state
-  state=$("$SUP_GH_BIN" issue view "$issue" --repo "$SUP_REPO" --json state \
+  state=$(sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" issue view "$issue" --repo "$SUP_REPO" --json state \
     --jq .state 2>/dev/null | tr '[:upper:]' '[:lower:]')
   [ -z "$state" ] && return 0
   [ "$state" = "open" ]
@@ -90,7 +122,8 @@ supervisor_fetch_unsupported_request_issues() {
   local url base="${PYLON_OPENAGENTS_BASE_URL%/}"
   for status in issue_opened open; do
     url="$base/api/operator/khala/unsupported-requests?status=$status&limit=$SUP_TASK_POOL_LIMIT"
-    curl -fsS "$url" -H "$auth_header" 2>/dev/null | supervisor_issue_numbers_from_json
+    curl -fsS --max-time "$SUP_CURL_TIMEOUT_SECS" --connect-timeout 10 \
+      "$url" -H "$auth_header" 2>/dev/null | supervisor_issue_numbers_from_json
   done | supervisor_dedupe_issues | supervisor_filter_open_issues | supervisor_dedupe_issues
 }
 

--- a/apps/pylon/src/blueprint-gates/fleet-liveness.test.ts
+++ b/apps/pylon/src/blueprint-gates/fleet-liveness.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  DEFAULT_WEDGE_THRESHOLD_MS,
+  evaluateFleetLiveness,
+  FLEET_LIVENESS_EXIT,
+  parseLastDispatchTime,
+} from "./fleet-liveness.js"
+
+describe("evaluateFleetLiveness (#6646 wedge detection)", () => {
+  const now = 1_000_000_000_000
+
+  test("alive but last dispatch older than threshold is WEDGED", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: now - (DEFAULT_WEDGE_THRESHOLD_MS + 60_000),
+      now,
+    })
+    expect(r.status).toBe("wedged")
+    expect(r.wedged).toBe(true)
+    expect(r.healthy).toBe(false)
+    expect(FLEET_LIVENESS_EXIT[r.status]).toBe(3)
+  })
+
+  test("alive with a fresh dispatch is HEALTHY", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: now - 30_000,
+      now,
+    })
+    expect(r.status).toBe("healthy")
+    expect(r.healthy).toBe(true)
+    expect(r.wedged).toBe(false)
+    expect(FLEET_LIVENESS_EXIT[r.status]).toBe(0)
+  })
+
+  test("dispatch age exactly at threshold is HEALTHY (boundary)", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: now - DEFAULT_WEDGE_THRESHOLD_MS,
+      now,
+    })
+    expect(r.status).toBe("healthy")
+  })
+
+  test("just over threshold is WEDGED (boundary)", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: now - (DEFAULT_WEDGE_THRESHOLD_MS + 1),
+      now,
+    })
+    expect(r.status).toBe("wedged")
+  })
+
+  test("a dead/stopped process is UNKNOWN, not wedged", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: false,
+      lastDispatchTime: now - 10 * DEFAULT_WEDGE_THRESHOLD_MS,
+      now,
+    })
+    expect(r.status).toBe("unknown")
+    expect(r.wedged).toBe(false)
+    expect(FLEET_LIVENESS_EXIT[r.status]).toBe(4)
+  })
+
+  test("no dispatch recorded yet is UNKNOWN", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: null,
+      now,
+    })
+    expect(r.status).toBe("unknown")
+    expect(r.wedged).toBe(false)
+  })
+
+  test("a custom wedge threshold is honored", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: now - 5_000,
+      now,
+      wedgeThresholdMs: 1_000,
+    })
+    expect(r.status).toBe("wedged")
+    expect(r.wedgeThresholdMs).toBe(1_000)
+  })
+
+  test("a non-positive threshold override falls back to the default", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: now - 30_000,
+      now,
+      wedgeThresholdMs: 0,
+    })
+    expect(r.wedgeThresholdMs).toBe(DEFAULT_WEDGE_THRESHOLD_MS)
+    expect(r.status).toBe("healthy")
+  })
+})
+
+describe("parseLastDispatchTime", () => {
+  test("parses epoch ms", () => {
+    expect(parseLastDispatchTime("1719500000000")).toBe(1719500000000)
+  })
+
+  test("parses ISO-8601", () => {
+    const iso = "2026-06-27T00:00:00.000Z"
+    expect(parseLastDispatchTime(iso)).toBe(Date.parse(iso))
+  })
+
+  test("empty / whitespace / garbage / null -> null", () => {
+    expect(parseLastDispatchTime("")).toBeNull()
+    expect(parseLastDispatchTime("   ")).toBeNull()
+    expect(parseLastDispatchTime("not-a-time")).toBeNull()
+    expect(parseLastDispatchTime(null)).toBeNull()
+    expect(parseLastDispatchTime(undefined)).toBeNull()
+  })
+})

--- a/apps/pylon/src/blueprint-gates/fleet-liveness.ts
+++ b/apps/pylon/src/blueprint-gates/fleet-liveness.ts
@@ -1,0 +1,239 @@
+/**
+ * Blueprint Signature — `fleet-liveness` (#6646)
+ *
+ * Wedge detection for the codex-supervisor dispatch loop. The supervisor can be
+ * ALIVE and heartbeating yet WEDGED: an external `gh`/network call in the
+ * dispatch loop hung with no timeout and silently stalled async dispatch while
+ * the independent heartbeat kept firing. This is the #1 token-burn failure mode
+ * (it can cost ~all of a day's burn); see
+ * `docs/afteraction/2026-06-26-khala-pylon-codex-delegation-afteraction.md` and
+ * the burn runbook `docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md`.
+ *
+ * The timeout guards in the supervisor scripts (lockout.sh +
+ * supervisor-task-pool.sh + codex-supervisor.sh, via `sup_run_timeout`) make a
+ * single hung call no longer able to stall the loop. This module is the
+ * defense-in-depth layer on top: the tested source of truth for "is the
+ * supervisor wedged?". Given the supervisor pid liveness plus the most recent
+ * dispatch-ATTEMPT timestamp (written by the supervisor to
+ * `$SUP_STATE_DIR/last_dispatch_time`), it returns `wedged` when the process is
+ * alive but no dispatch has been attempted within the wedge threshold (default
+ * 10 min). `launch.sh wedge-watch` consumes the CLI entry below to force-kill +
+ * restart a wedged supervisor.
+ *
+ * Pure core (`evaluateFleetLiveness`) + a thin I/O CLI. Aligns with the other
+ * blueprint-gates. It is intentionally NOT run from inside the supervisor
+ * itself: a wedged process cannot reliably restart itself, so an external
+ * watcher owns the restart decision.
+ */
+
+export const FLEET_LIVENESS_STATES = ["healthy", "wedged", "unknown"] as const
+
+export type FleetLivenessStatus = (typeof FLEET_LIVENESS_STATES)[number]
+
+/** Default wedge threshold: alive but no dispatch attempt in 10 minutes. */
+export const DEFAULT_WEDGE_THRESHOLD_MS = 10 * 60 * 1000
+
+/** Process exit codes for the CLI: stable so a watcher can branch on them. */
+export const FLEET_LIVENESS_EXIT = {
+  healthy: 0,
+  wedged: 3,
+  unknown: 4,
+} as const
+
+export interface FleetLivenessInputs {
+  /** Is the supervisor process currently alive? */
+  readonly pidAlive: boolean
+  /** Epoch ms of the most recent dispatch ATTEMPT, or null if none recorded. */
+  readonly lastDispatchTime: number | null
+  /** Current time, epoch ms. */
+  readonly now: number
+  /** Override the wedge threshold (ms). Non-positive values are ignored. */
+  readonly wedgeThresholdMs?: number
+}
+
+export interface FleetLivenessResult {
+  readonly status: FleetLivenessStatus
+  /** True only when alive AND last dispatch attempt is older than threshold. */
+  readonly wedged: boolean
+  /** True only when alive AND last dispatch attempt is within threshold. */
+  readonly healthy: boolean
+  /** Age of the last dispatch attempt in ms (null when unknown). */
+  readonly ageMs: number | null
+  readonly wedgeThresholdMs: number
+  readonly reason: string
+}
+
+/**
+ * Evaluate supervisor liveness. Pure function.
+ *
+ * - not alive          -> `unknown` (a dead/stopped process is the watcher's
+ *                          ordinary start path, not a wedge)
+ * - no dispatch yet    -> `unknown`
+ * - alive, fresh       -> `healthy` (age <= threshold)
+ * - alive, stale       -> `wedged`  (age >  threshold)
+ */
+export function evaluateFleetLiveness(
+  inputs: FleetLivenessInputs,
+): FleetLivenessResult {
+  const threshold =
+    typeof inputs.wedgeThresholdMs === "number" && inputs.wedgeThresholdMs > 0
+      ? inputs.wedgeThresholdMs
+      : DEFAULT_WEDGE_THRESHOLD_MS
+
+  if (!inputs.pidAlive) {
+    return {
+      status: "unknown",
+      wedged: false,
+      healthy: false,
+      ageMs: null,
+      wedgeThresholdMs: threshold,
+      reason: "supervisor process is not alive",
+    }
+  }
+
+  if (
+    inputs.lastDispatchTime === null ||
+    !Number.isFinite(inputs.lastDispatchTime)
+  ) {
+    return {
+      status: "unknown",
+      wedged: false,
+      healthy: false,
+      ageMs: null,
+      wedgeThresholdMs: threshold,
+      reason: "no dispatch attempt recorded yet",
+    }
+  }
+
+  const ageMs = inputs.now - inputs.lastDispatchTime
+
+  if (ageMs > threshold) {
+    return {
+      status: "wedged",
+      wedged: true,
+      healthy: false,
+      ageMs,
+      wedgeThresholdMs: threshold,
+      reason: `alive but last dispatch attempt was ${ageMs}ms ago (> ${threshold}ms threshold)`,
+    }
+  }
+
+  return {
+    status: "healthy",
+    wedged: false,
+    healthy: true,
+    ageMs,
+    wedgeThresholdMs: threshold,
+    reason: `alive and last dispatch attempt was ${ageMs}ms ago (<= ${threshold}ms threshold)`,
+  }
+}
+
+/**
+ * Parse a `last_dispatch_time` file payload: epoch ms (digits) or an ISO-8601
+ * timestamp. Returns epoch ms, or null when empty/unparseable.
+ */
+export function parseLastDispatchTime(
+  raw: string | null | undefined,
+): number | null {
+  if (typeof raw !== "string") {
+    return null
+  }
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) {
+    return null
+  }
+  if (/^[0-9]+$/.test(trimmed)) {
+    const n = Number.parseInt(trimmed, 10)
+    return Number.isFinite(n) ? n : null
+  }
+  const parsed = Date.parse(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parsePositiveInt(raw: string | undefined): number | null {
+  if (typeof raw !== "string") {
+    return null
+  }
+  const n = Number.parseInt(raw.trim(), 10)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+async function readTextOrNull(path: string): Promise<string | null> {
+  try {
+    return await Bun.file(path).text()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * CLI: read the supervisor pid + last_dispatch_time from `$SUP_STATE_DIR`,
+ * evaluate liveness, print a JSON verdict, and exit with FLEET_LIVENESS_EXIT.
+ * Consumed by `launch.sh wedge-watch` / `wedge-check`.
+ */
+export async function runFleetLivenessCli(): Promise<number> {
+  const home = process.env.HOME ?? ""
+  const stateDir =
+    typeof process.env.SUP_STATE_DIR === "string" &&
+    process.env.SUP_STATE_DIR.length > 0
+      ? process.env.SUP_STATE_DIR
+      : `${home}/.codex-supervisor`
+  const pidPath = `${stateDir}/supervisor.pid`
+  const lastDispatchPath = `${stateDir}/last_dispatch_time`
+  const thresholdMs =
+    parsePositiveInt(process.env.SUP_WEDGE_THRESHOLD_MS) ??
+    DEFAULT_WEDGE_THRESHOLD_MS
+
+  let pid: number | null = null
+  let pidAlive = false
+  const pidRaw = await readTextOrNull(pidPath)
+  if (pidRaw !== null) {
+    const parsed = Number.parseInt(pidRaw.trim(), 10)
+    if (Number.isFinite(parsed) && parsed > 0) {
+      pid = parsed
+      try {
+        // Signal 0 = liveness probe (no signal delivered).
+        process.kill(parsed, 0)
+        pidAlive = true
+      } catch (err) {
+        // EPERM means the process exists but is owned by another user -> alive.
+        const code = (err as { code?: string } | null)?.code
+        pidAlive = code === "EPERM"
+      }
+    }
+  }
+
+  const lastDispatchTime = parseLastDispatchTime(
+    await readTextOrNull(lastDispatchPath),
+  )
+
+  const result = evaluateFleetLiveness({
+    pidAlive,
+    lastDispatchTime,
+    now: Date.now(),
+    wedgeThresholdMs: thresholdMs,
+  })
+
+  console.log(
+    JSON.stringify({
+      pid,
+      pidAlive,
+      lastDispatchTime,
+      stateDir,
+      ...result,
+    }),
+  )
+
+  return FLEET_LIVENESS_EXIT[result.status]
+}
+
+if (import.meta.main) {
+  runFleetLivenessCli()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(
+        `fleet-liveness CLI error: ${err instanceof Error ? err.message : String(err)}`,
+      )
+      process.exit(FLEET_LIVENESS_EXIT.unknown)
+    })
+}

--- a/apps/pylon/src/blueprint-gates/index.ts
+++ b/apps/pylon/src/blueprint-gates/index.ts
@@ -8,10 +8,14 @@
  * consequential action; a missing required evidence ref makes the action
  * structurally impossible.
  *
- * These are libraries (types + pure functions + Bun tests). They are not yet
- * wired into the live supervisor/watcher — wiring is a follow-up.
+ * These are libraries (types + pure functions + Bun tests). Most are not yet
+ * wired into the live supervisor/watcher — wiring is a follow-up. The exception
+ * is `fleet-liveness` (#6646), whose CLI entry IS consumed by
+ * `apps/pylon/scripts/codex-supervisor/launch.sh wedge-watch` to force-restart a
+ * wedged supervisor.
  */
 
 export * from "./issue-close-safe.js"
 export * from "./command-execution-source-verified.js"
 export * from "./merge-deploy-gate.js"
+export * from "./fleet-liveness.js"


### PR DESCRIPTION
Closes #6646.

P0 wedge-proofing for the codex-supervisor — the #1 token-burn protector. The supervisor's worst failure mode is a WEDGE: alive + heartbeating but no longer dispatching, because an external `gh`/network call in the dispatch loop hangs with no timeout and silently stalls the async dispatch loop while the independent heartbeat keeps firing.

Implements the after-action action items in `docs/afteraction/2026-06-26-khala-pylon-codex-delegation-afteraction.md` and the fleet-liveness signature (#6646). No change to dispatch policy, lockout semantics, or slot counts — only timeout guards, telemetry, and a liveness/restart hook.

## What changed
1. **Timeout guards** — `sup_run_timeout` (in `lockout.sh`; portable: prefers `timeout`/`gtimeout`, pure-bash watchdog fallback for stock macOS which ships neither) bounds every external call. All `gh` CLI calls bounded at `SUP_GH_TIMEOUT_SECS=15`; `curl` uses `--max-time`/`--connect-timeout`; local Pylon control calls (heartbeat, go-online, accounts list) at `SUP_PYLON_TIMEOUT_SECS=60`; labor dispatch (`khala request`) + stale-closeout sweep at a generous `SUP_DISPATCH_TIMEOUT_SECS=1800`. On timeout: logged, treated as failed/empty, loop CONTINUES.
2. **last_dispatch_time telemetry** — supervisor records an epoch-ms timestamp on every pick+dispatch cycle and emits `last_dispatch_time` on the heartbeat + counter log lines.
3. **Wedge auto-restart** — `apps/pylon/src/blueprint-gates/fleet-liveness.ts` returns `wedged` when the pid is alive but `last_dispatch_time` is older than 10 min. `launch.sh wedge-check` prints the verdict; `launch.sh wedge-watch` force-kills + restarts when wedged, runnable on an interval from an external watcher.
4. **Tests** — `fleet-liveness.test.ts` (alive+stale=wedged, alive+fresh=healthy, boundaries, dead/none=unknown, parser) and `timeout.test.sh` (passthrough / exit-code / kill / promptness).

## Verification
- `bun run check:deploy` green (exit 0)
- `bun test src/blueprint-gates/` → 42 pass
- `bash lockout.test.sh` → 12 pass; `timeout.test.sh` → 4 pass; `fleet-offload.test.sh` → 7 pass
- CLI smoke: wedged→exit 3, healthy→exit 0, dead→exit 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)