### PR TITLE
feat(pylon): add supervisor PR fast-forward merge API

### DIFF
--- a/apps/pylon/src/codex-pr-merge-queue.test.ts
+++ b/apps/pylon/src/codex-pr-merge-queue.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  fastForwardMergePullRequest,
+  type SupervisorPrMergeCommandRunner,
+} from "./codex-pr-merge-queue.js"
+
+const ok = (stdout = "") => ({ exitCode: 0, stdout, stderr: "", timedOut: false })
+
+describe("supervisor PR fast-forward merge queue", () => {
+  test("projects the PR onto base, verifies it, then merges the exact head through GitHub", async () => {
+    const calls: string[][] = []
+    const runner: SupervisorPrMergeCommandRunner = async (input) => {
+      calls.push(input.args)
+      if (input.args[0] === "gh" && input.args[1] === "pr" && input.args[2] === "view") {
+        return ok(
+          JSON.stringify({
+            number: 6695,
+            state: "OPEN",
+            isDraft: false,
+            url: "https://github.com/OpenAgentsInc/openagents/pull/7001",
+            baseRefName: "main",
+            headRefOid: "a".repeat(40),
+          }),
+        )
+      }
+      return ok()
+    }
+
+    const result = await fastForwardMergePullRequest({
+      repository: { fullName: "OpenAgentsInc/openagents", baseBranch: "main" },
+      prNumber: 6695,
+      workingDirectory: "/tmp/pylon-merge-queue-test",
+      verifyCommand: ["bun", "test", "apps/pylon/src/codex-pr-merge-queue.test.ts"],
+      runner,
+    })
+
+    expect(result).toEqual({
+      state: "merged",
+      prNumber: 6695,
+      prUrl: "https://github.com/OpenAgentsInc/openagents/pull/7001",
+      headSha: "a".repeat(40),
+      verifyExitCode: 0,
+    })
+    expect(calls).toEqual([
+      [
+        "gh",
+        "pr",
+        "view",
+        "6695",
+        "--repo",
+        "OpenAgentsInc/openagents",
+        "--json",
+        "number,state,isDraft,url,baseRefName,headRefOid",
+      ],
+      [
+        "git",
+        "fetch",
+        "--no-tags",
+        "https://github.com/OpenAgentsInc/openagents.git",
+        "refs/heads/main:refs/remotes/pylon-merge/main",
+        "refs/pull/6695/head:refs/remotes/pylon-merge/pr-6695",
+      ],
+      ["git", "checkout", "-B", "pylon/virtual-merge/pr-6695", "refs/remotes/pylon-merge/main"],
+      ["git", "merge", "--ff-only", "refs/remotes/pylon-merge/pr-6695"],
+      ["bun", "test", "apps/pylon/src/codex-pr-merge-queue.test.ts"],
+      [
+        "gh",
+        "pr",
+        "merge",
+        "6695",
+        "--repo",
+        "OpenAgentsInc/openagents",
+        "--rebase",
+        "--delete-branch",
+        "--match-head-commit",
+        "a".repeat(40),
+      ],
+    ])
+  })
+
+  test("does not ask GitHub to merge when the local fast-forward projection fails", async () => {
+    const calls: string[][] = []
+    const runner: SupervisorPrMergeCommandRunner = async (input) => {
+      calls.push(input.args)
+      if (input.args[0] === "gh" && input.args[1] === "pr" && input.args[2] === "view") {
+        return ok(
+          JSON.stringify({
+            number: 6695,
+            state: "OPEN",
+            isDraft: false,
+            url: "https://github.com/OpenAgentsInc/openagents/pull/7001",
+            baseRefName: "main",
+            headRefOid: "b".repeat(40),
+          }),
+        )
+      }
+      if (input.args[0] === "git" && input.args[1] === "merge") {
+        return { exitCode: 1, stdout: "", stderr: "Not possible to fast-forward", timedOut: false }
+      }
+      return ok()
+    }
+
+    const result = await fastForwardMergePullRequest({
+      repository: { fullName: "OpenAgentsInc/openagents", baseBranch: "main" },
+      prNumber: 6695,
+      workingDirectory: "/tmp/pylon-merge-queue-test",
+      runner,
+    })
+
+    expect(result).toEqual({
+      state: "skipped",
+      reasonRef: "merge_queue.skipped_not_fast_forward",
+      prNumber: 6695,
+      prUrl: "https://github.com/OpenAgentsInc/openagents/pull/7001",
+    })
+    expect(calls.some((args) => args[0] === "gh" && args[1] === "pr" && args[2] === "merge")).toBe(false)
+  })
+
+  test("guards stale GitHub merges by matching the viewed head commit", async () => {
+    const mergeCalls: string[][] = []
+    const runner: SupervisorPrMergeCommandRunner = async (input) => {
+      if (input.args[0] === "gh" && input.args[1] === "pr" && input.args[2] === "view") {
+        return ok(
+          JSON.stringify({
+            number: 42,
+            state: "OPEN",
+            isDraft: false,
+            url: "https://github.com/OpenAgentsInc/openagents/pull/42",
+            baseRefName: "main",
+            headRefOid: "c".repeat(40),
+          }),
+        )
+      }
+      if (input.args[0] === "gh" && input.args[1] === "pr" && input.args[2] === "merge") {
+        mergeCalls.push(input.args)
+      }
+      return ok()
+    }
+
+    await fastForwardMergePullRequest({
+      repository: { fullName: "OpenAgentsInc/openagents", baseBranch: "main" },
+      prNumber: 42,
+      workingDirectory: "/tmp/pylon-merge-queue-test",
+      runner,
+    })
+
+    expect(mergeCalls).toHaveLength(1)
+    expect(mergeCalls[0]).toContain("--match-head-commit")
+    expect(mergeCalls[0]).toContain("c".repeat(40))
+  })
+})

--- a/apps/pylon/src/codex-pr-merge-queue.ts
+++ b/apps/pylon/src/codex-pr-merge-queue.ts
@@ -1,0 +1,239 @@
+export type SupervisorPrMergeCommandResult = {
+  exitCode: number
+  stdout: string
+  stderr: string
+  timedOut: boolean
+}
+
+export type SupervisorPrMergeCommandRunner = (input: {
+  args: string[]
+  cwd: string
+  timeoutMs?: number
+}) => Promise<SupervisorPrMergeCommandResult>
+
+export type SupervisorPrFastForwardMergeInput = {
+  repository: {
+    fullName: string
+    baseBranch: string
+  }
+  prNumber: number
+  workingDirectory: string
+  verifyCommand?: string[]
+  runner?: SupervisorPrMergeCommandRunner
+}
+
+export type SupervisorPrFastForwardMergeResult =
+  | {
+      state: "merged"
+      prNumber: number
+      prUrl: string | null
+      headSha: string
+      verifyExitCode: number | null
+    }
+  | { state: "skipped"; reasonRef: string; prNumber: number; prUrl?: string | null }
+  | { state: "failed"; reasonRef: string; prNumber: number; prUrl?: string | null }
+
+type PullRequestView = {
+  number?: unknown
+  state?: unknown
+  isDraft?: unknown
+  url?: unknown
+  baseRefName?: unknown
+  headRefOid?: unknown
+}
+
+const GIT_TIMEOUT_MS = 60 * 1000
+const GH_TIMEOUT_MS = 2 * 60 * 1000
+const VERIFY_TIMEOUT_MS = 10 * 60 * 1000
+
+const githubFullNamePattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
+const gitRefNamePattern = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/
+const gitCommitShaPattern = /^[a-f0-9]{40}$/i
+
+async function defaultRunner(input: {
+  args: string[]
+  cwd: string
+  timeoutMs?: number
+}): Promise<SupervisorPrMergeCommandResult> {
+  const proc = Bun.spawn(input.args, { cwd: input.cwd, stderr: "pipe", stdout: "pipe" })
+  let timedOut = false
+  const timer =
+    input.timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => {
+          timedOut = true
+          proc.kill()
+        }, input.timeoutMs)
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    return { exitCode, stdout, stderr, timedOut }
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+function githubRemoteUrl(fullName: string): string {
+  return `https://github.com/${fullName}.git`
+}
+
+function safeRefSegment(value: string): string | null {
+  if (!gitRefNamePattern.test(value) || value.includes("..") || value.endsWith(".lock")) {
+    return null
+  }
+  return value
+}
+
+function parsePullRequestView(stdout: string): PullRequestView | null {
+  try {
+    const parsed = JSON.parse(stdout) as PullRequestView
+    return parsed !== null && typeof parsed === "object" ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+async function runOk(
+  runner: SupervisorPrMergeCommandRunner,
+  input: { args: string[]; cwd: string; timeoutMs?: number },
+): Promise<boolean> {
+  const result = await runner(input)
+  return result.exitCode === 0 && !result.timedOut
+}
+
+/**
+ * Supervisor-side virtual merge queue primitive for Pylon/Codex PRs.
+ *
+ * The API never pushes directly to the protected base branch. It first builds
+ * the projected post-merge tree locally (`base` + PR head via `--ff-only`),
+ * optionally runs the supplied verifier there, then asks GitHub to merge that
+ * exact PR head with `--match-head-commit`. This gives the supervisor a
+ * deterministic fast-forward eligibility gate without turning GitHub's native
+ * merge queue into the fleet's hot coordination path.
+ */
+export async function fastForwardMergePullRequest(
+  input: SupervisorPrFastForwardMergeInput,
+): Promise<SupervisorPrFastForwardMergeResult> {
+  const runner = input.runner ?? defaultRunner
+  const prNumber = input.prNumber
+  const fullName = input.repository.fullName
+  const baseBranch = safeRefSegment(input.repository.baseBranch)
+
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    return { state: "skipped", reasonRef: "merge_queue.skipped_invalid_pr_number", prNumber }
+  }
+  if (!githubFullNamePattern.test(fullName) || baseBranch === null) {
+    return { state: "skipped", reasonRef: "merge_queue.skipped_unsupported_repository", prNumber }
+  }
+
+  const prView = await runner({
+    args: [
+      "gh",
+      "pr",
+      "view",
+      String(prNumber),
+      "--repo",
+      fullName,
+      "--json",
+      "number,state,isDraft,url,baseRefName,headRefOid",
+    ],
+    cwd: input.workingDirectory,
+    timeoutMs: GH_TIMEOUT_MS,
+  })
+  if (prView.exitCode !== 0 || prView.timedOut) {
+    return { state: "failed", reasonRef: "merge_queue.pr_view_failed", prNumber }
+  }
+
+  const pr = parsePullRequestView(prView.stdout)
+  const prUrl = typeof pr?.url === "string" ? pr.url : null
+  const headSha = typeof pr?.headRefOid === "string" ? pr.headRefOid : ""
+  if (pr === null || pr.number !== prNumber || !gitCommitShaPattern.test(headSha)) {
+    return { state: "failed", reasonRef: "merge_queue.pr_view_invalid", prNumber, prUrl }
+  }
+  if (pr.state !== "OPEN") {
+    return { state: "skipped", reasonRef: "merge_queue.skipped_pr_not_open", prNumber, prUrl }
+  }
+  if (pr.isDraft === true) {
+    return { state: "skipped", reasonRef: "merge_queue.skipped_pr_draft", prNumber, prUrl }
+  }
+  if (pr.baseRefName !== baseBranch) {
+    return { state: "skipped", reasonRef: "merge_queue.skipped_base_mismatch", prNumber, prUrl }
+  }
+
+  const remote = githubRemoteUrl(fullName)
+  const localBaseRef = `refs/remotes/pylon-merge/${baseBranch}`
+  const localPrRef = `refs/remotes/pylon-merge/pr-${prNumber}`
+  const virtualBranch = `pylon/virtual-merge/pr-${prNumber}`
+
+  const fetched = await runOk(runner, {
+    args: [
+      "git",
+      "fetch",
+      "--no-tags",
+      remote,
+      `refs/heads/${baseBranch}:${localBaseRef}`,
+      `refs/pull/${prNumber}/head:${localPrRef}`,
+    ],
+    cwd: input.workingDirectory,
+    timeoutMs: GIT_TIMEOUT_MS,
+  })
+  if (!fetched) {
+    return { state: "failed", reasonRef: "merge_queue.fetch_failed", prNumber, prUrl }
+  }
+
+  const checkedOut = await runOk(runner, {
+    args: ["git", "checkout", "-B", virtualBranch, localBaseRef],
+    cwd: input.workingDirectory,
+    timeoutMs: GIT_TIMEOUT_MS,
+  })
+  if (!checkedOut) {
+    return { state: "failed", reasonRef: "merge_queue.virtual_checkout_failed", prNumber, prUrl }
+  }
+
+  const mergedLocally = await runOk(runner, {
+    args: ["git", "merge", "--ff-only", localPrRef],
+    cwd: input.workingDirectory,
+    timeoutMs: GIT_TIMEOUT_MS,
+  })
+  if (!mergedLocally) {
+    return { state: "skipped", reasonRef: "merge_queue.skipped_not_fast_forward", prNumber, prUrl }
+  }
+
+  let verifyExitCode: number | null = null
+  if (input.verifyCommand !== undefined && input.verifyCommand.length > 0) {
+    const verify = await runner({
+      args: input.verifyCommand,
+      cwd: input.workingDirectory,
+      timeoutMs: VERIFY_TIMEOUT_MS,
+    })
+    verifyExitCode = verify.exitCode
+    if (verify.exitCode !== 0 || verify.timedOut) {
+      return { state: "skipped", reasonRef: "merge_queue.skipped_verification_failed", prNumber, prUrl }
+    }
+  }
+
+  const merged = await runOk(runner, {
+    args: [
+      "gh",
+      "pr",
+      "merge",
+      String(prNumber),
+      "--repo",
+      fullName,
+      "--rebase",
+      "--delete-branch",
+      "--match-head-commit",
+      headSha,
+    ],
+    cwd: input.workingDirectory,
+    timeoutMs: GH_TIMEOUT_MS,
+  })
+  if (!merged) {
+    return { state: "failed", reasonRef: "merge_queue.github_merge_failed", prNumber, prUrl }
+  }
+
+  return { state: "merged", prNumber, prUrl, headSha, verifyExitCode }
+}

--- a/apps/pylon/src/virtual-merge-queue.test.ts
+++ b/apps/pylon/src/virtual-merge-queue.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  simulateVirtualMergeQueue,
+  type VirtualMergeQueueItem,
+} from "./virtual-merge-queue.js"
+
+const item = (issueNumber: number, path: string): VirtualMergeQueueItem => ({
+  assignmentRef: `assignment.public.codex_agent_task.vmq_${issueNumber}`,
+  issueNumber,
+  changedPaths: [path],
+  verificationRef: `command.public.pylon_khala.verify.fixture_${issueNumber}`,
+})
+
+describe("simulateVirtualMergeQueue", () => {
+  test("projects 20+ parallel virtual merges through one advancing virtual head", () => {
+    const items = Array.from({ length: 24 }, (_, index) =>
+      item(6693 + index, `apps/pylon/tests/virtual-merge-${index.toString().padStart(2, "0")}.test.ts`),
+    )
+
+    const plan = simulateVirtualMergeQueue({
+      baseHead: "main.351276003542c4267665e60767d3e8feb5b97f64",
+      items,
+    })
+
+    expect(plan.schema).toBe("openagents.pylon.virtual_merge_queue.simulation.v1")
+    expect(plan.accepted).toHaveLength(24)
+    expect(plan.conflicts).toHaveLength(0)
+    expect(plan.accepted[0]?.branchPoint).toBe(plan.baseHead)
+
+    for (let index = 1; index < plan.accepted.length; index += 1) {
+      expect(plan.accepted[index]?.branchPoint).toBe(plan.accepted[index - 1]?.virtualHeadAfter)
+      expect(plan.accepted[index]?.virtualHeadBefore).toBe(plan.accepted[index - 1]?.virtualHeadAfter)
+      expect(plan.accepted[index]?.virtualHeadAfter).not.toBe(plan.accepted[index]?.virtualHeadBefore)
+    }
+
+    expect(new Set(plan.accepted.map((entry) => entry.virtualHeadAfter)).size).toBe(24)
+    expect(plan.finalVirtualHead).toBe(plan.accepted[23]?.virtualHeadAfter)
+    expect(plan.sourceRefs).toContain("issue.public.github.OpenAgentsInc.openagents.6693")
+  })
+
+  test("keeps the virtual head stable when a later item conflicts with an accepted path", () => {
+    const plan = simulateVirtualMergeQueue({
+      baseHead: "main.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      items: [
+        item(7001, "apps/pylon/src/codex-pr-publisher.ts"),
+        item(7002, "apps/pylon/src/codex-pr-publisher.ts"),
+        item(7003, "apps/pylon/src/virtual-merge-queue.ts"),
+      ],
+    })
+
+    expect(plan.accepted.map((entry) => entry.issueNumber)).toEqual([7001, 7003])
+    expect(plan.conflicts).toEqual([
+      {
+        assignmentRef: "assignment.public.codex_agent_task.vmq_7002",
+        issueNumber: 7002,
+        conflictingAssignmentRef: "assignment.public.codex_agent_task.vmq_7001",
+        conflictingIssueNumber: 7001,
+        conflictingPaths: ["apps/pylon/src/codex-pr-publisher.ts"],
+        reasonRef: "blocker.public.pylon_virtual_merge_queue.path_conflict",
+      },
+    ])
+    expect(plan.accepted[1]?.branchPoint).toBe(plan.accepted[0]?.virtualHeadAfter)
+    expect(plan.finalVirtualHead).toBe(plan.accepted[1]?.virtualHeadAfter)
+  })
+})

--- a/apps/pylon/src/virtual-merge-queue.ts
+++ b/apps/pylon/src/virtual-merge-queue.ts
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto"
+
+export type VirtualMergeQueueItem = {
+  assignmentRef: string
+  issueNumber: number
+  changedPaths: string[]
+  verificationRef: string
+}
+
+export type VirtualMergeQueueAcceptedItem = {
+  assignmentRef: string
+  issueNumber: number
+  changedPaths: string[]
+  verificationRef: string
+  branchPoint: string
+  virtualHeadBefore: string
+  virtualHeadAfter: string
+}
+
+export type VirtualMergeQueueConflict = {
+  assignmentRef: string
+  issueNumber: number
+  conflictingAssignmentRef: string
+  conflictingIssueNumber: number
+  conflictingPaths: string[]
+  reasonRef: "blocker.public.pylon_virtual_merge_queue.path_conflict"
+}
+
+export type VirtualMergeQueueSimulation = {
+  schema: "openagents.pylon.virtual_merge_queue.simulation.v1"
+  baseHead: string
+  accepted: VirtualMergeQueueAcceptedItem[]
+  conflicts: VirtualMergeQueueConflict[]
+  finalVirtualHead: string
+  sourceRefs: string[]
+}
+
+const refPattern = /^[A-Za-z0-9][A-Za-z0-9_.:-]{2,180}$/
+const pathPattern = /^[A-Za-z0-9._/@+-][A-Za-z0-9._/@+ -]{0,240}$/
+
+function stableVirtualHead(input: {
+  previousHead: string
+  assignmentRef: string
+  issueNumber: number
+  changedPaths: string[]
+  verificationRef: string
+}): string {
+  const digest = createHash("sha256")
+    .update(
+      [
+        input.previousHead,
+        input.assignmentRef,
+        String(input.issueNumber),
+        input.verificationRef,
+        ...input.changedPaths,
+      ].join("\0"),
+    )
+    .digest("hex")
+    .slice(0, 40)
+  return `virtual-head.pylon.${digest}`
+}
+
+function cleanPaths(paths: string[]): string[] {
+  return [
+    ...new Set(
+      paths.map((path) => path.trim()).filter((path) => pathPattern.test(path)),
+    ),
+  ].sort()
+}
+
+function validItem(item: VirtualMergeQueueItem): boolean {
+  return (
+    Number.isInteger(item.issueNumber) &&
+    item.issueNumber > 0 &&
+    refPattern.test(item.assignmentRef) &&
+    refPattern.test(item.verificationRef)
+  )
+}
+
+export function simulateVirtualMergeQueue(input: {
+  baseHead: string
+  items: VirtualMergeQueueItem[]
+}): VirtualMergeQueueSimulation {
+  const accepted: VirtualMergeQueueAcceptedItem[] = []
+  const conflicts: VirtualMergeQueueConflict[] = []
+  const pathOwners = new Map<string, VirtualMergeQueueAcceptedItem>()
+  let virtualHead = input.baseHead
+
+  for (const item of input.items) {
+    if (!validItem(item)) continue
+    const changedPaths = cleanPaths(item.changedPaths)
+    const conflictingOwners = new Map<string, VirtualMergeQueueAcceptedItem>()
+    for (const path of changedPaths) {
+      const owner = pathOwners.get(path)
+      if (owner !== undefined) conflictingOwners.set(owner.assignmentRef, owner)
+    }
+
+    if (conflictingOwners.size > 0) {
+      const [conflicting] = [...conflictingOwners.values()].sort(
+        (a, b) => a.issueNumber - b.issueNumber,
+      )
+      if (conflicting !== undefined) {
+        conflicts.push({
+          assignmentRef: item.assignmentRef,
+          issueNumber: item.issueNumber,
+          conflictingAssignmentRef: conflicting.assignmentRef,
+          conflictingIssueNumber: conflicting.issueNumber,
+          conflictingPaths: changedPaths.filter(
+            (path) => pathOwners.get(path)?.assignmentRef === conflicting.assignmentRef,
+          ),
+          reasonRef: "blocker.public.pylon_virtual_merge_queue.path_conflict",
+        })
+      }
+      continue
+    }
+
+    const virtualHeadBefore = virtualHead
+    const virtualHeadAfter = stableVirtualHead({
+      previousHead: virtualHeadBefore,
+      assignmentRef: item.assignmentRef,
+      issueNumber: item.issueNumber,
+      changedPaths,
+      verificationRef: item.verificationRef,
+    })
+    const acceptedItem: VirtualMergeQueueAcceptedItem = {
+      assignmentRef: item.assignmentRef,
+      issueNumber: item.issueNumber,
+      changedPaths,
+      verificationRef: item.verificationRef,
+      branchPoint: virtualHeadBefore,
+      virtualHeadBefore,
+      virtualHeadAfter,
+    }
+    accepted.push(acceptedItem)
+    for (const path of changedPaths) pathOwners.set(path, acceptedItem)
+    virtualHead = virtualHeadAfter
+  }
+
+  return {
+    schema: "openagents.pylon.virtual_merge_queue.simulation.v1",
+    baseHead: input.baseHead,
+    accepted,
+    conflicts,
+    finalVirtualHead: virtualHead,
+    sourceRefs: accepted.map(
+      (item) => `issue.public.github.OpenAgentsInc.openagents.${item.issueNumber}`,
+    ),
+  }
+}


### PR DESCRIPTION
Addresses #6695.

### Changes
- Adds supervisor-level PR fast-forward merge support to the Pylon Codex PR merge queue.
- Extends virtual merge queue coverage for the new fast-forward merge behavior.
- Adds tests for the Codex PR merge queue and virtual merge queue changes.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0)