### PR TITLE
docs(promises): sync registry narrative source version

### DIFF
--- a/docs/promises/registry.md
+++ b/docs/promises/registry.md
@@ -37,23 +37,32 @@
 > sharing is owner opt-in only; capture grants no payout. The disclosure remains
 > separate from capture behavior and paid privacy product proof.
 >
-> Latest reconciliation: live registry `2026-06-19.2` (see
-> [`product-promises.ts`](../../apps/openagents.com/workers/api/src/product-promises.ts)
-> and the June 18-19 launch/promise reconciliation notes). `2026-06-19.2` is a
-> copy/evidence destale pass with no state flips: `autopilot.desktop_gui_client.v1`
-> stays yellow but records the BUILT auto-onboarding EPIC #5441 (AO-1..AO-6) with
-> the final from-DMG clean-Mac proof owner-gated and pending; the Sites referral
-> payout ledger is WIRED in source (RL-1 #5458: eligibility feed +
-> readiness-gated idempotent approved->dispatched->settled dispatch via the
-> MDK/Spark adapter) but no real referral payout has settled, so
-> `sites.referral_bitcoin_stream.v1` stays yellow and
-> `autopilot_sites.partner_payout_ledger.v1` stays red, each with a
+> Current machine-readable source of truth: `/api/public/product-promises` is
+> generated from
+> [`product-promises.ts`](../../apps/openagents.com/workers/api/src/product-promises.ts),
+> which currently advertises registry `2026-06-27.2` with
+> `lastUpdated: "2026-06-27"`. This narrative document records the same
+> top-line 2026-06-27 promise decisions above, plus historical reconciliation
+> context below; when in doubt, agents and reviewers should defer to the
+> machine-readable registry and include its version in mismatch reports.
+>
+> `2026-06-28` standing sweep: recent mainline Khala, Artanis, Pylon, Gym, and
+> operator-safety merges were checked against the current `2026-06-27.2`
+> registry header. This pass records no promise state flips, no new green
+> claims, and no machine-registry changes; follow-on public claims from those
+> surfaces remain bound to their existing scoped/yellow/red records until their
+> own evidence and owner-signed transition receipts exist.
+>
+> Historical reconciliation `2026-06-19.2` was a copy/evidence destale pass with
+> no state flips: `autopilot.desktop_gui_client.v1` stays yellow but records the
+> BUILT auto-onboarding EPIC #5441 (AO-1..AO-6) with the final from-DMG clean-Mac
+> proof owner-gated and pending; the Sites referral payout ledger is WIRED in
+> source (RL-1 #5458: eligibility feed + readiness-gated idempotent
+> approved->dispatched->settled dispatch via the MDK/Spark adapter) but no real
+> referral payout has settled, so `sites.referral_bitcoin_stream.v1` stays
+> yellow and `autopilot_sites.partner_payout_ledger.v1` stays red, each with a
 > first-real-payout-pending blocker.
-> The machine-readable source of truth served at
-> `/api/public/product-promises` is
-> `apps/openagents.com/workers/api/src/product-promises.ts`; this narrative doc
-> documents the record contract and families and may trail the source registry
-> between full rewrites. As of `2026-06-19.1`: the agent labor market is green
+> As of `2026-06-19.1`: the agent labor market is green
 > (`labor.forum_work_requests.v1`, `labor.nostr_negotiation_market.v1`), with
 > `provider.compliant_usage_labor.v1` and
 > `autopilot.control_center_fanout_marketplace.v1` yellow; nine new wave-3 /


### PR DESCRIPTION
## Problem

#6709 asks for recurring product-promise registry sync against recent main merges. The narrative registry doc already had the 2026-06-27.2 top-line decision, and the machine-readable source advertises `PublicProductPromisesVersion = '2026-06-27.2'`, but the docs still called `2026-06-19.2` the "Latest reconciliation".

## Change

- Rewords the stale "latest" block to point reviewers and agents at the machine-readable `/api/public/product-promises` source of truth generated from `product-promises.ts`.
- Adds a compact 2026-06-28 standing sweep note for recent Khala, Artanis, Pylon, Gym, and operator-safety merges.
- Preserves `2026-06-19.2` as historical reconciliation context.

## Claim State

Docs-only sync. No product promise state flips, no new green claims, no machine-registry changes, and no authority boundary changes.

## Validation

- `git diff --check`
- `bun test apps/openagents.com/workers/api/src/product-promises.test.ts` did not reach assertions in the clean scratch worktree because dependencies are not installed there: `Cannot find package 'effect'`.

## Not Changed

- Did not edit `apps/openagents.com/workers/api/src/product-promises.ts`.
- Did not record or backfill transition receipts.
- Did not broaden any Khala, Artanis, Pylon, Gym, payout, privacy, or paid-work claim.

Refs #6709
