### PR TITLE
feat(pylon): detect virtual branch conflicts

### DIFF
--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -84,6 +84,31 @@ export type WorkspaceChangeConflictScan = {
   conflicts: WorkspaceChangeConflict[]
 }
 
+export type InFlightVirtualBranchChange = {
+  virtualBranchRef: string
+  target: {
+    repositoryFullName: string
+    branch: string
+  }
+  capture: WorkspaceChangeCapture
+}
+
+export type VirtualBranchChangeConflict = {
+  conflictRef: string
+  fileRef: string
+  repositoryFullName: string
+  targetBranch: string
+  sourceRefs: string[]
+  virtualBranchRefs: string[]
+  workspaceRefs: string[]
+}
+
+export type VirtualBranchChangeConflictScan = {
+  state: "clear" | "conflicted"
+  conflictRefs: string[]
+  conflicts: VirtualBranchChangeConflict[]
+}
+
 export type WorkspaceCommitResult =
   | {
       state: "clean"
@@ -293,6 +318,24 @@ export function workspaceChangeFileRef(sourceRef: string, relativePath: string):
   return stableRef("file.pylon.workspace", `${sourceRef}:${relativePath}`)
 }
 
+export function virtualBranchChangeFileRef(input: {
+  repositoryFullName: string
+  targetBranch: string
+  relativePath: string
+}): string {
+  if (!githubFullNamePattern.test(input.repositoryFullName)) {
+    throw new Error("virtual branch conflict scan refused: invalid repository name")
+  }
+  if (!gitBranchNamePattern.test(input.targetBranch)) {
+    throw new Error("virtual branch conflict scan refused: invalid target branch")
+  }
+  assertSafeWorkspaceRelativePath(input.relativePath)
+  return stableRef(
+    "file.pylon.virtual_branch",
+    `${input.repositoryFullName}:${input.targetBranch}:${input.relativePath}`,
+  )
+}
+
 export async function captureWorkspaceChanges(input: {
   cacheRoot: string
   workingDirectory: string
@@ -428,6 +471,68 @@ export function detectWorkspaceChangeConflicts(
       workspaceRefs: [...value.workspaceRefs].sort(),
     }))
     .filter((conflict) => conflict.workspaceRefs.length > 1)
+  return {
+    state: conflicts.length === 0 ? "clear" : "conflicted",
+    conflictRefs: conflicts.map((conflict) => conflict.conflictRef),
+    conflicts,
+  }
+}
+
+export function detectInFlightVirtualBranchConflicts(
+  changes: ReadonlyArray<InFlightVirtualBranchChange>,
+): VirtualBranchChangeConflictScan {
+  type ConflictBucket = {
+    repositoryFullName: string
+    targetBranch: string
+    sourceRefs: Set<string>
+    virtualBranchRefs: Set<string>
+    workspaceRefs: Set<string>
+  }
+  const byFileRef = new Map<string, ConflictBucket>()
+
+  for (const change of changes) {
+    if (change.capture.state === "clean") continue
+    if (!githubFullNamePattern.test(change.target.repositoryFullName)) {
+      throw new Error("virtual branch conflict scan refused: invalid repository name")
+    }
+    if (!gitBranchNamePattern.test(change.target.branch)) {
+      throw new Error("virtual branch conflict scan refused: invalid target branch")
+    }
+    for (const path of change.capture.local.changedPaths) {
+      const fileRef = virtualBranchChangeFileRef({
+        repositoryFullName: change.target.repositoryFullName,
+        targetBranch: change.target.branch,
+        relativePath: path,
+      })
+      const existing = byFileRef.get(fileRef) ?? {
+        repositoryFullName: change.target.repositoryFullName,
+        targetBranch: change.target.branch,
+        sourceRefs: new Set<string>(),
+        virtualBranchRefs: new Set<string>(),
+        workspaceRefs: new Set<string>(),
+      }
+      existing.sourceRefs.add(change.capture.sourceRef)
+      existing.virtualBranchRefs.add(change.virtualBranchRef)
+      existing.workspaceRefs.add(change.capture.workspaceRef)
+      byFileRef.set(fileRef, existing)
+    }
+  }
+
+  const conflicts = [...byFileRef.entries()]
+    .map(([fileRef, value]) => ({
+      conflictRef: stableRef(
+        "conflict.pylon.virtual_branch",
+        `${fileRef}:${[...value.virtualBranchRefs].sort().join(":")}`,
+      ),
+      fileRef,
+      repositoryFullName: value.repositoryFullName,
+      targetBranch: value.targetBranch,
+      sourceRefs: [...value.sourceRefs].sort(),
+      virtualBranchRefs: [...value.virtualBranchRefs].sort(),
+      workspaceRefs: [...value.workspaceRefs].sort(),
+    }))
+    .filter((conflict) => conflict.virtualBranchRefs.length > 1)
+
   return {
     state: conflicts.length === 0 ? "clear" : "conflicted",
     conflictRefs: conflicts.map((conflict) => conflict.conflictRef),

--- a/apps/pylon/tests/workspace-worktree.test.ts
+++ b/apps/pylon/tests/workspace-worktree.test.ts
@@ -8,6 +8,7 @@ import {
   cleanupExpiredWorkspaces,
   commitWorkspaceChanges,
   createGitWorktreeCheckoutRunner,
+  detectInFlightVirtualBranchConflicts,
   detectWorkspaceChangeConflicts,
   materializeGitCheckoutWorkspaceWithLease,
   pruneWorkspaceCacheDirectories,
@@ -18,6 +19,7 @@ import {
   repositoryCacheKeyFor,
   stageWorkspacePaths,
   withWorkspaceMaterializerCapability,
+  virtualBranchChangeFileRef,
   workspaceChangeFileRef,
   workspaceLeaseRecordFor,
   WORKSPACE_CLEANUP_RECEIPTS_CAPABILITY_REF,
@@ -374,6 +376,62 @@ describe("createGitWorktreeCheckoutRunner", () => {
           workspaceRefs: [first.workspaceRef, second.workspaceRef].sort(),
         },
       ])
+
+      const virtualBranchConflicts = detectInFlightVirtualBranchConflicts([
+        {
+          virtualBranchRef: "virtual_branch.pylon.issue_1",
+          target: { repositoryFullName: "OpenAgentsInc/worktree-fixture", branch: "main" },
+          capture: firstCapture,
+        },
+        {
+          virtualBranchRef: "virtual_branch.pylon.issue_2",
+          target: { repositoryFullName: "OpenAgentsInc/worktree-fixture", branch: "main" },
+          capture: {
+            ...secondCapture,
+            sourceRef: `${checkout.repository.fullName}:4444444444444444444444444444444444444444`,
+            fileRefs: secondCapture.local.changedPaths.map((path) =>
+              workspaceChangeFileRef(
+                `${checkout.repository.fullName}:4444444444444444444444444444444444444444`,
+                path,
+              ),
+            ),
+          },
+        },
+      ])
+      expect(virtualBranchConflicts.state).toBe("conflicted")
+      expect(virtualBranchConflicts.conflicts).toEqual([
+        {
+          conflictRef: virtualBranchConflicts.conflictRefs[0],
+          fileRef: virtualBranchChangeFileRef({
+            repositoryFullName: "OpenAgentsInc/worktree-fixture",
+            targetBranch: "main",
+            relativePath: "sum.ts",
+          }),
+          repositoryFullName: "OpenAgentsInc/worktree-fixture",
+          targetBranch: "main",
+          sourceRefs: [
+            `${checkout.repository.fullName}:4444444444444444444444444444444444444444`,
+            first.sourceRef,
+          ].sort(),
+          virtualBranchRefs: ["virtual_branch.pylon.issue_1", "virtual_branch.pylon.issue_2"],
+          workspaceRefs: [first.workspaceRef, second.workspaceRef].sort(),
+        },
+      ])
+      assertPublicProjectionSafe(virtualBranchConflicts)
+
+      const independentVirtualBranches = detectInFlightVirtualBranchConflicts([
+        {
+          virtualBranchRef: "virtual_branch.pylon.issue_1",
+          target: { repositoryFullName: "OpenAgentsInc/worktree-fixture", branch: "main" },
+          capture: firstCapture,
+        },
+        {
+          virtualBranchRef: "virtual_branch.pylon.issue_3",
+          target: { repositoryFullName: "OpenAgentsInc/worktree-fixture", branch: "release" },
+          capture: secondCapture,
+        },
+      ])
+      expect(independentVirtualBranches).toEqual({ state: "clear", conflictRefs: [], conflicts: [] })
 
       const firstCommit = await commitWorkspaceChanges({
         cacheRoot,


### PR DESCRIPTION
Addresses #6692.

### Changes
- Added public-safe types and helpers for in-flight virtual branch conflict scans.
- Added conflict detection that groups changed files by repository, target branch, and relative path, then reports conflicts when multiple virtual branches touch the same target file.
- Added worktree tests covering conflicted virtual branches and independent target branches.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).