### PR TITLE
feat(artanis): add FRLM conductor linear fallback

### DIFF
--- a/apps/pylon/src/frlm-conductor-execution.ts
+++ b/apps/pylon/src/frlm-conductor-execution.ts
@@ -1,0 +1,214 @@
+import { createHash } from "node:crypto"
+import { assertPublicProjectionSafe } from "./state.js"
+
+export const FRLM_CONDUCTOR_EXECUTION_SCHEMA =
+  "openagents.artanis.frlm_conductor_execution.v0.1"
+
+export type FrlmConductorSubQueryState =
+  | "planned"
+  | "running"
+  | "completed"
+  | "failed"
+  | "timed_out"
+  | "rejected"
+
+export type FrlmConductorExecutionMode =
+  | "recursive_parallel"
+  | "fallback_linear"
+  | "blocked"
+
+export type FrlmConductorExecutionBlockerRef =
+  | "blocker.artanis.frlm_conductor.execution_ref_missing"
+  | "blocker.artanis.frlm_conductor.root_task_ref_missing"
+  | "blocker.artanis.frlm_conductor.blueprint_signature_ref_missing"
+  | "blocker.artanis.frlm_conductor.sub_query_plan_missing"
+  | "blocker.artanis.frlm_conductor.sub_query_failure_without_linear_fallback"
+  | "blocker.artanis.frlm_conductor.linear_executor_ref_missing"
+  | "blocker.artanis.frlm_conductor.unsafe_ref"
+
+export type FrlmConductorSubQuery = {
+  subQueryRef: string
+  parentRef?: string | null
+  state: FrlmConductorSubQueryState
+  resultRef?: string | null
+  failureRef?: string | null
+  blueprintSignatureRef?: string | null
+}
+
+export type FrlmConductorExecutionProjection = {
+  schema: typeof FRLM_CONDUCTOR_EXECUTION_SCHEMA
+  observedAt: string
+  executionRef: string | null
+  rootTaskRef: string | null
+  blueprintSignatureRef: string | null
+  executionMode: FrlmConductorExecutionMode
+  canExecute: boolean
+  recursiveSubQueryRefs: string[]
+  failedSubQueryRefs: string[]
+  linearFallbackStepRefs: string[]
+  linearExecutorRef: string | null
+  fallbackReasonRef: string | null
+  executionPlanRef: string | null
+  evidenceRefs: string[]
+  blockerRefs: FrlmConductorExecutionBlockerRef[]
+  authorityBoundary: string
+  contentRedacted: true
+}
+
+const publicRefPattern = /^[a-z][a-z0-9._:/-]{1,220}$/i
+const unsafeRefPattern =
+  /(\/Users\/|\/home\/|api[_-]?key|bearer|checkpoint[-_]?path|invoice|lnbc|lno1|mnemonic|payment[_-]?(hash|preimage)|preimage|private|prompt|secret|token|wallet|weights\.(bin|gguf|safetensors|pt|pth))/i
+
+const failedStates = new Set<FrlmConductorSubQueryState>([
+  "failed",
+  "timed_out",
+  "rejected",
+])
+
+export function planFrlmConductorExecution(input: {
+  observedAt: string
+  executionRef?: string | null
+  rootTaskRef?: string | null
+  blueprintSignatureRef?: string | null
+  subQueries?: FrlmConductorSubQuery[]
+  linearFallbackEnabled?: boolean
+  linearExecutorRef?: string | null
+}): FrlmConductorExecutionProjection {
+  const blockerRefs = new Set<FrlmConductorExecutionBlockerRef>()
+  const subQueries = input.subQueries ?? []
+  const rawRefs = [
+    normalizedRef(input.executionRef),
+    normalizedRef(input.rootTaskRef),
+    normalizedRef(input.blueprintSignatureRef),
+    normalizedRef(input.linearExecutorRef),
+    ...subQueries.flatMap((subQuery) => [
+      normalizedRef(subQuery.subQueryRef),
+      normalizedRef(subQuery.parentRef),
+      normalizedRef(subQuery.resultRef),
+      normalizedRef(subQuery.failureRef),
+      normalizedRef(subQuery.blueprintSignatureRef),
+    ]),
+  ]
+  const safeRefs = new Map<string, string | null>()
+  for (const ref of rawRefs) {
+    if (ref !== null && !safeRefs.has(ref)) {
+      safeRefs.set(ref, isSafeRef(ref) ? ref : null)
+    }
+  }
+  const safeRef = (value: string | null | undefined) => {
+    const ref = normalizedRef(value)
+    return ref === null ? null : safeRefs.get(ref) ?? null
+  }
+
+  const executionRef = safeRef(input.executionRef)
+  const rootTaskRef = safeRef(input.rootTaskRef)
+  const blueprintSignatureRef = safeRef(input.blueprintSignatureRef)
+  const linearExecutorRef = safeRef(input.linearExecutorRef)
+  const recursiveSubQueryRefs = uniqueRefs(subQueries.map((subQuery) => safeRef(subQuery.subQueryRef)))
+  const failedSubQueryRefs = uniqueRefs(
+    subQueries
+      .filter((subQuery) => failedStates.has(subQuery.state))
+      .map((subQuery) => safeRef(subQuery.subQueryRef)),
+  )
+  const linearFallbackStepRefs = failedSubQueryRefs.length === 0
+    ? []
+    : recursiveSubQueryRefs.map((subQueryRef, index) =>
+      `step.artanis.frlm.linear.${stableHash(`${rootTaskRef ?? "unknown"}:${index}:${subQueryRef}`)}`)
+
+  if (executionRef === null) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.execution_ref_missing")
+  }
+  if (rootTaskRef === null) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.root_task_ref_missing")
+  }
+  if (blueprintSignatureRef === null) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.blueprint_signature_ref_missing")
+  }
+  if (recursiveSubQueryRefs.length === 0) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.sub_query_plan_missing")
+  }
+  if (failedSubQueryRefs.length > 0 && input.linearFallbackEnabled !== true) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.sub_query_failure_without_linear_fallback")
+  }
+  if (failedSubQueryRefs.length > 0 && linearExecutorRef === null) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.linear_executor_ref_missing")
+  }
+  if (rawRefs.some((ref) => ref !== null && !isSafeRef(ref))) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.unsafe_ref")
+  }
+
+  const executionMode: FrlmConductorExecutionMode =
+    blockerRefs.size > 0
+      ? "blocked"
+      : failedSubQueryRefs.length > 0
+        ? "fallback_linear"
+        : "recursive_parallel"
+  const canExecute = blockerRefs.size === 0
+  const fallbackReasonRef = failedSubQueryRefs.length === 0
+    ? null
+    : `reason.artanis.frlm.sub_query_failure.${stableHash(failedSubQueryRefs.join(":"))}`
+  const executionPlanRef =
+    canExecute && executionRef !== null
+      ? `plan.artanis.frlm.${executionMode}.${stableHash(executionRef)}`
+      : null
+  const evidenceRefs = uniqueRefs([
+    executionPlanRef,
+    executionRef,
+    rootTaskRef,
+    blueprintSignatureRef,
+    linearExecutorRef,
+    fallbackReasonRef,
+    ...recursiveSubQueryRefs,
+    ...failedSubQueryRefs,
+    ...linearFallbackStepRefs,
+    ...subQueries.flatMap((subQuery) => [
+      safeRef(subQuery.parentRef),
+      safeRef(subQuery.resultRef),
+      safeRef(subQuery.failureRef),
+      safeRef(subQuery.blueprintSignatureRef),
+    ]),
+  ])
+
+  const projection: FrlmConductorExecutionProjection = {
+    schema: FRLM_CONDUCTOR_EXECUTION_SCHEMA,
+    observedAt: input.observedAt,
+    executionRef,
+    rootTaskRef,
+    blueprintSignatureRef,
+    executionMode,
+    canExecute,
+    recursiveSubQueryRefs,
+    failedSubQueryRefs,
+    linearFallbackStepRefs,
+    linearExecutorRef,
+    fallbackReasonRef,
+    executionPlanRef,
+    evidenceRefs,
+    blockerRefs: [...blockerRefs].sort(),
+    authorityBoundary:
+      "Read-only FRLM Conductor execution projection. It selects recursive or linear fallback planning from public evidence refs only; it does not dispatch workers, run Python, spend sats, publish claims, or move settlement authority.",
+    contentRedacted: true,
+  }
+  assertPublicProjectionSafe(projection)
+  return projection
+}
+
+function normalizedRef(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null
+  const trimmed = value.trim()
+  return trimmed === "" ? null : trimmed
+}
+
+function isSafeRef(value: string) {
+  return publicRefPattern.test(value) && !unsafeRefPattern.test(value)
+}
+
+function stableHash(input: string) {
+  return createHash("sha256").update(input).digest("hex").slice(0, 20)
+}
+
+function uniqueRefs(refs: (string | null)[]) {
+  return [...new Set(refs.filter((ref): ref is string => ref !== null && ref.trim().length > 0))]
+    .map((ref) => ref.trim())
+    .sort()
+}

--- a/apps/pylon/tests/frlm-conductor-execution.test.ts
+++ b/apps/pylon/tests/frlm-conductor-execution.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test"
+import {
+  planFrlmConductorExecution,
+  type FrlmConductorSubQuery,
+} from "../src/frlm-conductor-execution"
+import { assertPublicProjectionSafe } from "../src/state"
+
+const observedAt = "2026-06-28T16:40:00.000Z"
+
+describe("FRLM Conductor execution planning", () => {
+  test("keeps the recursive plan when all sub-queries completed", () => {
+    const projection = planFrlmConductorExecution({
+      ...validInput(),
+      subQueries: completedSubQueries(),
+    })
+
+    expect(projection.canExecute).toBe(true)
+    expect(projection.executionMode).toBe("recursive_parallel")
+    expect(projection.blockerRefs).toEqual([])
+    expect(projection.failedSubQueryRefs).toEqual([])
+    expect(projection.linearFallbackStepRefs).toEqual([])
+    expect(projection.executionPlanRef).toMatch(/^plan\.artanis\.frlm\.recursive_parallel\.[a-f0-9]{20}$/)
+    assertPublicProjectionSafe(projection)
+  })
+
+  test("falls back to linear execution when any recursive sub-query fails", () => {
+    const projection = planFrlmConductorExecution({
+      ...validInput(),
+      subQueries: [
+        completedSubQueries()[0],
+        {
+          subQueryRef: "subquery.artanis.frlm.optimize_route.v1",
+          parentRef: "task.artanis.frlm.root.v1",
+          state: "failed",
+          failureRef: "failure.artanis.frlm.optimize_route.timeout.v1",
+          blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+        },
+        completedSubQueries()[2],
+      ],
+    })
+
+    expect(projection.canExecute).toBe(true)
+    expect(projection.executionMode).toBe("fallback_linear")
+    expect(projection.blockerRefs).toEqual([])
+    expect(projection.failedSubQueryRefs).toEqual(["subquery.artanis.frlm.optimize_route.v1"])
+    expect(projection.linearFallbackStepRefs).toHaveLength(3)
+    expect(projection.linearFallbackStepRefs.every((ref) => ref.startsWith("step.artanis.frlm.linear."))).toBe(true)
+    expect(projection.fallbackReasonRef).toMatch(/^reason\.artanis\.frlm\.sub_query_failure\.[a-f0-9]{20}$/)
+    expect(projection.evidenceRefs).toContain("failure.artanis.frlm.optimize_route.timeout.v1")
+    expect(projection.evidenceRefs).toContain("executor.artanis.frlm.linear_local.v1")
+    assertPublicProjectionSafe(projection)
+  })
+
+  test("blocks a failed sub-query when linear fallback is not enabled", () => {
+    const projection = planFrlmConductorExecution({
+      ...validInput(),
+      linearFallbackEnabled: false,
+      subQueries: [
+        {
+          subQueryRef: "subquery.artanis.frlm.collect_blueprint_signatures.v1",
+          parentRef: "task.artanis.frlm.root.v1",
+          state: "rejected",
+          failureRef: "failure.artanis.frlm.collect_blueprint_signatures.policy.v1",
+          blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+        },
+      ],
+    })
+
+    expect(projection.canExecute).toBe(false)
+    expect(projection.executionMode).toBe("blocked")
+    expect(projection.blockerRefs).toContain(
+      "blocker.artanis.frlm_conductor.sub_query_failure_without_linear_fallback",
+    )
+  })
+
+  test("blocks unsafe refs before they reach public projection fields", () => {
+    const projection = planFrlmConductorExecution({
+      ...validInput(),
+      subQueries: [
+        {
+          subQueryRef: "/Users/operator/private/subquery.json",
+          state: "completed",
+          resultRef: "result.artanis.frlm.collect_context.v1",
+        },
+      ],
+    })
+
+    expect(projection.canExecute).toBe(false)
+    expect(projection.recursiveSubQueryRefs).toEqual([])
+    expect(projection.blockerRefs).toContain("blocker.artanis.frlm_conductor.sub_query_plan_missing")
+    expect(projection.blockerRefs).toContain("blocker.artanis.frlm_conductor.unsafe_ref")
+    assertPublicProjectionSafe(projection)
+  })
+})
+
+function validInput() {
+  return {
+    observedAt,
+    executionRef: "execution.artanis.frlm.issue_6684.v1",
+    rootTaskRef: "task.artanis.frlm.root.v1",
+    blueprintSignatureRef: "signature.blueprint.frlm_conductor.v1",
+    linearFallbackEnabled: true,
+    linearExecutorRef: "executor.artanis.frlm.linear_local.v1",
+  }
+}
+
+function completedSubQueries(): FrlmConductorSubQuery[] {
+  return [
+    {
+      subQueryRef: "subquery.artanis.frlm.collect_context.v1",
+      parentRef: "task.artanis.frlm.root.v1",
+      state: "completed",
+      resultRef: "result.artanis.frlm.collect_context.v1",
+      blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+    },
+    {
+      subQueryRef: "subquery.artanis.frlm.optimize_route.v1",
+      parentRef: "task.artanis.frlm.root.v1",
+      state: "completed",
+      resultRef: "result.artanis.frlm.optimize_route.v1",
+      blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+    },
+    {
+      subQueryRef: "subquery.artanis.frlm.verify_blueprint_boundary.v1",
+      parentRef: "task.artanis.frlm.root.v1",
+      state: "completed",
+      resultRef: "result.artanis.frlm.verify_blueprint_boundary.v1",
+      blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+    },
+  ]
+}


### PR DESCRIPTION
Addresses #6684.

### Changes
- Added FRLM Conductor execution planning that selects recursive parallel execution when sub-queries complete successfully.
- Added fallback-to-linear planning when a recursive sub-query fails, including failed sub-query refs, fallback step refs, fallback reason refs, and public-safe evidence refs.
- Added blocker handling for missing required refs, disabled linear fallback, missing linear executor refs, missing sub-query plans, and unsafe public projection refs.
- Added tests for recursive execution, linear fallback on sub-query failure, disabled fallback blocking, and unsafe ref redaction/blocking.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).