### PR TITLE
feat(pylon): support virtual branch checkout bases

### DIFF
--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -29,6 +29,12 @@ export type GitCheckoutWorkspace = {
     provider: "github"
     visibility: "public"
   }
+  virtualBranch?: {
+    kind: "pylon_virtual_merge_queue"
+    branchName: string
+    baseCommitSha: string
+    queueRef: string
+  }
   verificationCommand: {
     args: string[]
     commandRef: string
@@ -137,6 +143,7 @@ const githubFullNamePattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
 const gitBranchNamePattern =
   /^(?!-)(?!refs\/)(?!.*(?:^|\/)\.)(?!.*(?:^|\/)$)(?!.*\.\.)(?!.*@{)(?!.*\/\/)(?!.*\.lock(?:\/|$))(?!.*\.$)[A-Za-z0-9][A-Za-z0-9._/-]{0,119}$/i
 const gitCommitShaPattern = /^[a-f0-9]{40}$/i
+const publicRefPattern = /^[A-Za-z0-9_.:/=@+-]{1,160}$/
 const verificationCommandArgPattern = /^[A-Za-z0-9_./:=@+-]{1,120}$/
 
 /**
@@ -155,6 +162,7 @@ export function gitCheckoutWorkspaceFrom(codingAssignment: unknown): GitCheckout
   if (!githubFullNamePattern.test(payload.repository.fullName)) return null
   if (!gitCommitShaPattern.test(payload.repository.commitSha)) return null
   if (typeof payload.repository.branch !== "string" || !gitBranchNamePattern.test(payload.repository.branch)) return null
+  if (!virtualBranchIsValid(payload.virtualBranch)) return null
   if (!Array.isArray(payload.verificationCommand?.args) || payload.verificationCommand.args.length === 0) return null
   if (typeof payload.verificationCommand.commandRef !== "string") return null
   const safeArgs = payload.verificationCommand.args.every((arg) =>
@@ -164,6 +172,29 @@ export function gitCheckoutWorkspaceFrom(codingAssignment: unknown): GitCheckout
     !arg.startsWith("/")
   )
   return safeArgs ? payload : null
+}
+
+function virtualBranchIsValid(virtualBranch: GitCheckoutWorkspace["virtualBranch"] | undefined): boolean {
+  if (virtualBranch === undefined) return true
+  if (virtualBranch === null || typeof virtualBranch !== "object") return false
+  return (
+    virtualBranch.kind === "pylon_virtual_merge_queue" &&
+    typeof virtualBranch.branchName === "string" &&
+    gitBranchNamePattern.test(virtualBranch.branchName) &&
+    virtualBranch.branchName.startsWith("pylon/virtual-") &&
+    typeof virtualBranch.baseCommitSha === "string" &&
+    gitCommitShaPattern.test(virtualBranch.baseCommitSha) &&
+    typeof virtualBranch.queueRef === "string" &&
+    publicRefPattern.test(virtualBranch.queueRef)
+  )
+}
+
+export function checkoutBaseCommitSha(checkout: GitCheckoutWorkspace): string {
+  return checkout.virtualBranch?.baseCommitSha ?? checkout.repository.commitSha
+}
+
+export function checkoutSourceRef(checkout: GitCheckoutWorkspace): string {
+  return `${checkout.repository.fullName}:${checkoutBaseCommitSha(checkout)}`
 }
 
 // Concurrent assignments materialize against a shared bare object store, so
@@ -549,6 +580,7 @@ export const defaultGitCheckoutRunner: WorkspaceCheckoutRunner = async (
   workingDirectory,
   checkout,
 ) => {
+  const baseCommitSha = checkoutBaseCommitSha(checkout)
   await rm(workingDirectory, { recursive: true, force: true })
   await mkdir(workingDirectory, { recursive: true })
   await runCheckedCommand(["git", "init"], workingDirectory, "reason.workspace_checkout.init_failed")
@@ -567,12 +599,12 @@ export const defaultGitCheckoutRunner: WorkspaceCheckoutRunner = async (
     "reason.workspace_checkout.remote_add_failed",
   )
   await runCheckedCommand(
-    ["git", "fetch", "--depth", "1", "origin", checkout.repository.commitSha],
+    ["git", "fetch", "--depth", "1", "origin", baseCommitSha],
     workingDirectory,
     "reason.workspace_checkout.fetch_failed",
   )
   await runCheckedCommand(
-    ["git", "checkout", "--detach", checkout.repository.commitSha],
+    ["git", "checkout", "--detach", baseCommitSha],
     workingDirectory,
     "reason.workspace_checkout.checkout_failed",
   )
@@ -609,7 +641,7 @@ export async function materializeGitCheckoutWorkspace(input: {
   await (input.checkoutRunner ?? defaultGitCheckoutRunner)(workingDirectory, input.checkout)
   return {
     cleanupRef: stableRef("cleanup.pylon.workspace", workspaceRef),
-    sourceRef: `${input.checkout.repository.fullName}:${input.checkout.repository.commitSha}`,
+    sourceRef: checkoutSourceRef(input.checkout),
     workingDirectory,
     workspaceRef,
   }
@@ -872,6 +904,7 @@ export function createGitWorktreeCheckoutRunner(
 ): WorkspaceCheckoutRunner {
   return async (workingDirectory, checkout) => {
     const repository = checkout.repository
+    const baseCommitSha = checkoutBaseCommitSha(checkout)
     const bareDirectory = join(
       options.repositoryCacheRoot,
       `${repositoryCacheKeyFor(repository.fullName)}.git`,
@@ -891,7 +924,7 @@ export function createGitWorktreeCheckoutRunner(
       // runs. Disable it on every materialization so pre-existing caches that
       // were created before this fix are also covered.
       await disableGitAutoMaintenance(bareDirectory)
-      const commitArg = `${repository.commitSha}^{commit}`
+      const commitArg = `${baseCommitSha}^{commit}`
       const cached = (await runQuietCommand(["git", "cat-file", "-e", commitArg], bareDirectory)) === 0
       if (!cached) {
         const remoteUrl =
@@ -913,7 +946,7 @@ export function createGitWorktreeCheckoutRunner(
           (await runQuietCommand(["git", "cat-file", "-e", commitArg], bareDirectory)) === 0
         if (!deepenedCached) {
           await runQuietCommand(
-            ["git", "fetch", "--depth", "1", remoteUrl, repository.commitSha],
+            ["git", "fetch", "--depth", "1", remoteUrl, baseCommitSha],
             bareDirectory,
           )
         }
@@ -925,15 +958,21 @@ export function createGitWorktreeCheckoutRunner(
       }
       // best-effort gc pin; materialization correctness never depends on it
       await runQuietCommand(
-        ["git", "update-ref", `refs/pinned/${repository.commitSha}`, repository.commitSha],
+        ["git", "update-ref", `refs/pinned/${baseCommitSha}`, baseCommitSha],
         bareDirectory,
       )
+      if (checkout.virtualBranch !== undefined) {
+        await runQuietCommand(
+          ["git", "update-ref", `refs/virtual/${checkout.virtualBranch.branchName}`, baseCommitSha],
+          bareDirectory,
+        )
+      }
       await rm(workingDirectory, { recursive: true, force: true })
       // a previously removed worktree leaves admin metadata that would block
       // re-adding the same path
       await runQuietCommand(["git", "worktree", "prune"], bareDirectory)
       await runCheckedCommand(
-        ["git", "worktree", "add", "--detach", workingDirectory, repository.commitSha],
+        ["git", "worktree", "add", "--detach", workingDirectory, baseCommitSha],
         bareDirectory,
         "reason.workspace_checkout.worktree_add_failed",
       )

--- a/apps/pylon/tests/workspace-materializer.test.ts
+++ b/apps/pylon/tests/workspace-materializer.test.ts
@@ -4,6 +4,8 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
+  checkoutBaseCommitSha,
+  checkoutSourceRef,
   cleanupOldestMaterializedWorkspaces,
   gitCheckoutWorkspaceFrom,
   materializeGitCheckoutWorkspace,
@@ -52,6 +54,26 @@ describe("gitCheckoutWorkspaceFrom", () => {
     expect(decoded).not.toBeNull()
     expect(decoded?.repository.commitSha).toBe(validCheckout.repository.commitSha)
     expect(decoded?.verificationCommand.args).toEqual(["bun", "test", "sum.test.ts"])
+  })
+
+  test("accepts virtual merge queue metadata and uses it as the effective base", () => {
+    const checkout = checkoutWith({
+      repository: { commitSha: "1".repeat(40) },
+    }) as GitCheckoutWorkspace
+    checkout.virtualBranch = {
+      kind: "pylon_virtual_merge_queue",
+      baseCommitSha: "2".repeat(40),
+      branchName: "pylon/virtual-issue-6690",
+      queueRef: "virtual_merge_queue.openagents.main",
+    }
+
+    const decoded = gitCheckoutWorkspaceFrom(assignmentWith(checkout))
+    expect(decoded).not.toBeNull()
+    expect(decoded?.repository.commitSha).toBe("1".repeat(40))
+    expect(decoded === null ? null : checkoutBaseCommitSha(decoded)).toBe("2".repeat(40))
+    expect(decoded === null ? null : checkoutSourceRef(decoded)).toBe(
+      `OpenAgentsInc/public-sum-fixture:${"2".repeat(40)}`,
+    )
   })
 
   test("rejects assignments without a workspace payload", () => {
@@ -107,6 +129,21 @@ describe("gitCheckoutWorkspaceFrom", () => {
       expect(
         gitCheckoutWorkspaceFrom(assignmentWith(checkoutWith({ repository: { branch } }))),
         branch,
+      ).toBeNull()
+    }
+  })
+
+  test("rejects unsafe virtual merge queue metadata", () => {
+    const base = checkoutWith({}) as GitCheckoutWorkspace
+    for (const virtualBranch of [
+      { kind: "pylon_virtual_merge_queue", baseCommitSha: "2".repeat(40), branchName: "feature/nope", queueRef: "queue.ok" },
+      { kind: "pylon_virtual_merge_queue", baseCommitSha: "main", branchName: "pylon/virtual-ok", queueRef: "queue.ok" },
+      { kind: "pylon_virtual_merge_queue", baseCommitSha: "2".repeat(40), branchName: "pylon/virtual-../bad", queueRef: "queue.ok" },
+      { kind: "pylon_virtual_merge_queue", baseCommitSha: "2".repeat(40), branchName: "pylon/virtual-ok", queueRef: "queue bad" },
+    ]) {
+      expect(
+        gitCheckoutWorkspaceFrom(assignmentWith({ ...base, virtualBranch })),
+        JSON.stringify(virtualBranch),
       ).toBeNull()
     }
   })

--- a/apps/pylon/tests/workspace-worktree.test.ts
+++ b/apps/pylon/tests/workspace-worktree.test.ts
@@ -191,6 +191,40 @@ describe("createGitWorktreeCheckoutRunner", () => {
     }
   })
 
+  test("materializes from the virtual merge queue base when one is supplied", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-worktree-"))
+    try {
+      const originRoot = join(root, "origin")
+      const origin = await createOriginRepo(originRoot)
+      const virtualBase = await commitOriginChange(
+        originRoot,
+        "virtual-head.ts",
+        "export const projectedHead = true\n",
+      )
+      const runner = createGitWorktreeCheckoutRunner({
+        repositoryCacheRoot: join(root, "git-cache"),
+        remoteUrlFor: () => origin.url,
+      })
+      const checkout = {
+        ...checkoutFor(origin.commitSha),
+        virtualBranch: {
+          kind: "pylon_virtual_merge_queue" as const,
+          baseCommitSha: virtualBase,
+          branchName: "pylon/virtual-issue-6690",
+          queueRef: "virtual_merge_queue.openagents.main",
+        },
+      }
+      const workingDirectory = join(root, "worktrees", "virtual-base")
+
+      await runner(workingDirectory, checkout)
+
+      expect(existsSync(join(workingDirectory, "virtual-head.ts"))).toBe(true)
+      expect((await run(["git", "rev-parse", "HEAD"], workingDirectory)).trim()).toBe(virtualBase)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("materializes a pinned commit when the requested branch is absent", async () => {
     const root = await mkdtemp(join(tmpdir(), "pylon-worktree-"))
     try {


### PR DESCRIPTION
Addresses #6690.

### Changes
- Added validation for Pylon virtual merge queue metadata on dispatched Git checkout workspaces.
- Introduced checkout helpers so materialization reports and fetches the effective base commit from virtual branch metadata when present.
- Updated direct checkout and shared worktree materialization to fetch, pin, and detach at the virtual branch base commit, including a cached virtual ref.
- Added tests for virtual branch acceptance, rejection, source refs, and worktree checkout behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).