### PR TITLE
feat(pylon): dispatch from virtual merge queue head

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -59,6 +59,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 # (e.g. a PR against an already-closed issue) and never spawns dupes.
 # shellcheck source=lockout.sh
 source "$SCRIPT_DIR/lockout.sh"
+# shellcheck source=virtual-merge-queue.sh
+source "$SCRIPT_DIR/virtual-merge-queue.sh"
 # shellcheck source=../supervisor-task-pool.sh
 source "$SCRIPT_DIR/../supervisor-task-pool.sh"
 
@@ -312,7 +314,10 @@ worker_loop() {
       backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
       continue
     fi
-    local commit; commit=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)
+    local commit real_commit
+    real_commit=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)
+    commit=$(sup_vmq_project_head "$REPO_ROOT" "${real_commit:-HEAD}" 2>/dev/null)
+    [ -z "$commit" ] && commit="$real_commit"
     [ -z "$commit" ] && { sleep 15; continue; }
 
     # Record the dispatch ATTEMPT timestamp (#6646) right before firing the

--- a/apps/pylon/scripts/codex-supervisor/virtual-merge-queue.sh
+++ b/apps/pylon/scripts/codex-supervisor/virtual-merge-queue.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# virtual-merge-queue.sh — local projected-base helper for codex-supervisor.
+#
+# The supervisor still opens normal GitHub PRs, but it can stop creating work
+# from a stale base by maintaining a local "virtual HEAD": real main plus the
+# pylon/assignment-* branches that are already in flight and can be replayed
+# cleanly. New assignments are pinned to that projected commit, so the actual PR
+# merge path stays closer to trivial after main advances.
+#
+# This file is sourceable and test-friendly. It performs no work at source time.
+
+: "${SUP_VMQ_ENABLED:=1}"
+: "${SUP_VMQ_DIR:=${SUP_STATE_DIR:-$HOME/.codex-supervisor}/virtual-merge-queue}"
+: "${SUP_VMQ_BRANCH_PREFIX:=pylon/assignment-}"
+: "${SUP_VMQ_REMOTE:=origin}"
+: "${SUP_VMQ_BASE_BRANCH:=main}"
+: "${SUP_VMQ_MAX_BRANCHES:=24}"
+: "${SUP_GH_BIN:=gh}"
+
+sup_vmq_log() {
+  if declare -F log >/dev/null 2>&1; then
+    log "$*"
+  else
+    printf '%s\n' "$*" >&2
+  fi
+}
+
+sup_vmq_git() {
+  git -C "$SUP_VMQ_DIR" "$@"
+}
+
+sup_vmq_sha() {
+  git -C "$1" rev-parse "$2" 2>/dev/null
+}
+
+sup_vmq_sync_repo() {
+  local source_repo="$1"
+  [ -d "$source_repo/.git" ] || return 1
+  mkdir -p "$(dirname "$SUP_VMQ_DIR")" 2>/dev/null || true
+
+  local remote_url
+  remote_url="$(git -C "$source_repo" remote get-url "$SUP_VMQ_REMOTE" 2>/dev/null || true)"
+  [ -n "$remote_url" ] || remote_url="$source_repo"
+
+  if [ ! -d "$SUP_VMQ_DIR/.git" ]; then
+    rm -rf "$SUP_VMQ_DIR"
+    git clone --quiet "$remote_url" "$SUP_VMQ_DIR" >/dev/null 2>&1 || return 1
+  fi
+
+  sup_vmq_git remote set-url "$SUP_VMQ_REMOTE" "$remote_url" >/dev/null 2>&1 || true
+  sup_vmq_git fetch --quiet "$SUP_VMQ_REMOTE" \
+    "+refs/heads/*:refs/remotes/$SUP_VMQ_REMOTE/*" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+sup_vmq_candidate_branches() {
+  if command -v "$SUP_GH_BIN" >/dev/null 2>&1 && [ -n "${SUP_REPO:-}" ]; then
+    local json branches
+    if declare -F sup_run_timeout >/dev/null 2>&1; then
+      json=$(sup_run_timeout "${SUP_GH_TIMEOUT_SECS:-15}" "$SUP_GH_BIN" pr list \
+        --repo "$SUP_REPO" --state open --json headRefName \
+        --limit "$SUP_VMQ_MAX_BRANCHES" 2>/dev/null)
+    else
+      json=$("$SUP_GH_BIN" pr list --repo "$SUP_REPO" --state open --json headRefName \
+        --limit "$SUP_VMQ_MAX_BRANCHES" 2>/dev/null)
+    fi
+    branches=$(printf '%s' "$json" | python3 -c "import json,os,sys
+prefix=os.environ.get('SUP_VMQ_BRANCH_PREFIX','pylon/assignment-')
+try:
+    rows=json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if not isinstance(rows,list):
+    sys.exit(0)
+for row in rows:
+    head=row.get('headRefName') if isinstance(row,dict) else None
+    if isinstance(head,str) and head.startswith(prefix):
+        print(head)" 2>/dev/null)
+    if [ -n "$branches" ]; then
+      printf '%s\n' "$branches"
+      return 0
+    fi
+  fi
+
+  sup_vmq_git for-each-ref \
+    --format='%(refname:short)' \
+    --sort=committerdate \
+    "refs/remotes/$SUP_VMQ_REMOTE/$SUP_VMQ_BRANCH_PREFIX*" 2>/dev/null \
+    | sed "s#^$SUP_VMQ_REMOTE/##" \
+    | tail -n "$SUP_VMQ_MAX_BRANCHES"
+}
+
+sup_vmq_project_head() {
+  local source_repo="$1"
+  local source_base="${2:-HEAD}"
+  [ "${SUP_VMQ_ENABLED:-1}" = "1" ] || return 1
+
+  local real_base
+  real_base="$(sup_vmq_sha "$source_repo" "$source_base")" || return 1
+  [ -n "$real_base" ] || return 1
+
+  if ! sup_vmq_sync_repo "$source_repo"; then
+    sup_vmq_log "VMQ unavailable: sync failed; using real base $real_base"
+    return 1
+  fi
+
+  local work_branch="pylon/virtual-merge-queue"
+  sup_vmq_git checkout --quiet -B "$work_branch" "$real_base" >/dev/null 2>&1 || return 1
+
+  local applied=0 skipped=0 branch
+  while IFS= read -r branch; do
+    [ -n "$branch" ] || continue
+    # Skip branches already contained by the real base.
+    if sup_vmq_git merge-base --is-ancestor "$SUP_VMQ_REMOTE/$branch" HEAD >/dev/null 2>&1; then
+      continue
+    fi
+    if sup_vmq_git merge --quiet --no-ff --no-edit "$SUP_VMQ_REMOTE/$branch" >/dev/null 2>&1; then
+      applied=$((applied + 1))
+    else
+      sup_vmq_git merge --abort >/dev/null 2>&1 || true
+      skipped=$((skipped + 1))
+    fi
+  done < <(sup_vmq_candidate_branches)
+
+  local projected
+  projected="$(sup_vmq_git rev-parse HEAD 2>/dev/null)" || return 1
+  [ -n "$projected" ] || return 1
+  sup_vmq_log "VMQ projected_head=$projected real_base=$real_base applied=$applied skipped=$skipped"
+  printf '%s' "$projected"
+  return 0
+}

--- a/apps/pylon/scripts/codex-supervisor/virtual-merge-queue.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/virtual-merge-queue.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# virtual-merge-queue.test.sh — focused tests for supervisor virtual HEAD.
+#
+# Run: bash apps/pylon/scripts/codex-supervisor/virtual-merge-queue.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+export SUP_STATE_DIR="$WORK/state"
+export SUP_VMQ_DIR="$WORK/vmq"
+export SUP_VMQ_MAX_BRANCHES=24
+
+# shellcheck source=virtual-merge-queue.sh
+source "$SCRIPT_DIR/virtual-merge-queue.sh"
+
+git_init_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -b main >/dev/null 2>&1 || return 1
+  git -C "$repo" config user.email "pylon-test@example.invalid"
+  git -C "$repo" config user.name "Pylon Test"
+}
+
+git_commit_file() {
+  local repo="$1" file="$2" body="$3" msg="$4"
+  printf '%s\n' "$body" > "$repo/$file"
+  git -C "$repo" add "$file" >/dev/null 2>&1 || return 1
+  git -C "$repo" commit -m "$msg" >/dev/null 2>&1
+}
+
+repo="$WORK/repo"
+git_init_repo "$repo" || { echo "git init failed" >&2; exit 1; }
+git_commit_file "$repo" README.md "base" "base" || exit 1
+base1="$(git -C "$repo" rev-parse HEAD)"
+
+git -C "$repo" checkout -b pylon/assignment-issue-100 >/dev/null 2>&1
+git_commit_file "$repo" feature-a.txt "feature a" "feature a" || exit 1
+git -C "$repo" checkout main >/dev/null 2>&1
+
+projected1="$(sup_vmq_project_head "$repo" "$base1")"
+if git -C "$SUP_VMQ_DIR" show "$projected1:feature-a.txt" >/dev/null 2>&1; then
+  ok "projects a clean assignment branch onto main"
+else
+  bad "projected head is missing clean assignment branch content"
+fi
+
+git -C "$repo" checkout -b pylon/assignment-issue-101 main >/dev/null 2>&1
+git_commit_file "$repo" conflict.txt "from branch" "conflicting branch" || exit 1
+git -C "$repo" checkout main >/dev/null 2>&1
+git_commit_file "$repo" conflict.txt "from main" "main advanced" || exit 1
+base2="$(git -C "$repo" rev-parse HEAD)"
+
+projected2="$(sup_vmq_project_head "$repo" "$base2")"
+if [ -n "$projected2" ] && git -C "$SUP_VMQ_DIR" show "$projected2:feature-a.txt" >/dev/null 2>&1; then
+  ok "skips a conflicting assignment branch and keeps projecting clean branches"
+else
+  bad "conflicting assignment branch stopped virtual-head projection"
+fi
+
+if [ "$(git -C "$SUP_VMQ_DIR" show "$projected2:conflict.txt" 2>/dev/null)" = "from main" ]; then
+  ok "conflicting branch does not overwrite advanced main content"
+else
+  bad "conflicting branch changed advanced main content"
+fi
+
+git -C "$repo" checkout main >/dev/null 2>&1
+git_commit_file "$repo" main-advance.txt "new main" "main advances again" || exit 1
+base3="$(git -C "$repo" rev-parse HEAD)"
+projected3="$(sup_vmq_project_head "$repo" "$base3")"
+if [ "$projected3" != "$projected2" ] && git -C "$SUP_VMQ_DIR" show "$projected3:main-advance.txt" >/dev/null 2>&1; then
+  ok "recomputes projected head after main updates"
+else
+  bad "projected head did not refresh after main update"
+fi
+
+git -C "$repo" checkout -b pylon/assignment-issue-102 main >/dev/null 2>&1
+git_commit_file "$repo" stale-pr.txt "stale branch" "stale closed branch" || exit 1
+git -C "$repo" checkout main >/dev/null 2>&1
+
+cat > "$WORK/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' '[{"headRefName":"pylon/assignment-issue-100"}]'
+STUB
+chmod +x "$WORK/gh"
+SUP_GH_BIN="$WORK/gh" SUP_REPO="OpenAgentsInc/openagents" projected_open_only="$(sup_vmq_project_head "$repo" "$base3")"
+if git -C "$SUP_VMQ_DIR" show "$projected_open_only:stale-pr.txt" >/dev/null 2>&1; then
+  bad "virtual queue replayed a branch absent from the open PR list"
+else
+  ok "open-PR candidate list excludes stale assignment branches"
+fi
+
+disabled="$(SUP_VMQ_ENABLED=0 sup_vmq_project_head "$repo" "$base3" 2>/dev/null)"
+if [ -z "$disabled" ]; then
+  ok "SUP_VMQ_ENABLED=0 disables projection"
+else
+  bad "disabled virtual merge queue still returned '$disabled'"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Addresses #6694.

### Changes
- Loads the virtual merge queue helper in the Codex supervisor.
- Resolves worker dispatch commits through `sup_vmq_project_head`, falling back to the real repository HEAD when no projected head is available.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` - passed (exit 0)