### PR TITLE
feat(codex-supervisor): label-priority dispatch + standing-task auto-recreate (#6711)

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -61,6 +61,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 source "$SCRIPT_DIR/lockout.sh"
 # shellcheck source=../supervisor-task-pool.sh
 source "$SCRIPT_DIR/../supervisor-task-pool.sh"
+# Fleet-saturation engine (#6711): label-priority dispatch ordering so slots
+# always burn the highest tier first and FALL THROUGH locked/empty tiers, plus
+# standing-task auto-recreate so the priority queue is self-sustaining.
+# shellcheck source=priority-dispatch.sh
+source "$SCRIPT_DIR/priority-dispatch.sh"
+# shellcheck source=standing-tasks.sh
+source "$SCRIPT_DIR/standing-tasks.sh"
 
 # --- Config (all overridable via env) ---
 export PYLON_OPENAGENTS_BASE_URL="${PYLON_OPENAGENTS_BASE_URL:-https://openagents.com}"
@@ -117,6 +124,13 @@ SUP_DISPATCH_TIMEOUT_SECS="${SUP_DISPATCH_TIMEOUT_SECS:-1800}"
 SUP_STALL_REFUSALS="${SUP_STALL_REFUSALS:-20}"
 SUP_SELFHEAL_COOLDOWN_SECS="${SUP_SELFHEAL_COOLDOWN_SECS:-300}"
 SUP_SELFHEAL_CHECK_SECS="${SUP_SELFHEAL_CHECK_SECS:-30}"
+
+# --- Standing-task keeper (#6711): self-sustaining priority queue. ---
+# Cadence (s) at which the supervisor re-grows any CLOSED `standing-task` issue
+# (the four prio task(ops) issues) so the queue never runs dry. Recreation is
+# idempotent by title, so a title that already has an open standing issue is
+# never duplicated.
+SUP_STANDING_TASK_CHECK_SECS="${SUP_STANDING_TASK_CHECK_SECS:-300}"
 
 # Fallback only. The active task pool is resolved dynamically from the
 # unsupported-request ledger and linked open GitHub issues.
@@ -225,6 +239,23 @@ selfheal_watchdog_loop() {
   done
 }
 
+# --- Standing-task keeper (#6711): keep the priority queue self-sustaining. ---
+# On a timer, re-grow any CLOSED `standing-task` issue (the four prio task(ops)
+# issues) that has no open sibling, so a finished standing cycle immediately
+# reopens fresh work and no slot ever idles for lack of a queue. Idempotent by
+# title: a title that already has an open standing issue is never duplicated.
+standing_task_keeper_loop() {
+  while true; do
+    if [ -f "$PAUSE_FILE" ]; then sleep "$SUP_STANDING_TASK_CHECK_SECS"; continue; fi
+    local made
+    made=$(sup_recreate_closed_standing_tasks 2>>"$SUP_LOG")
+    if [ -n "$made" ] && [ "$made" -gt 0 ] 2>/dev/null; then
+      log "standing-task keeper recreated $made closed standing task(s)"
+    fi
+    sleep "$SUP_STANDING_TASK_CHECK_SECS"
+  done
+}
+
 # --- Heartbeater: recompute desired slots + advertise capacity on a timer. ---
 heartbeater_loop() {
   while true; do
@@ -304,8 +335,21 @@ worker_loop() {
     # cause).
     local start_idx=$(( (slot + iter) % ${#issues[@]} ))
     iter=$(( iter + 1 ))
+
+    # Label-priority dispatch (#6711): refresh the open-issue label map (cached,
+    # TTL) and reorder the pool by priority tier (prio:0-pr-burndown first ...
+    # prio:4-backstop-burn last, then unlabelled), keeping intra-tier round-robin
+    # spread via start_idx. pick_unlocked_issue then scans from the TOP so slots
+    # prefer the highest tier and FALL THROUGH locked/lower tiers — never idling.
+    sup_fetch_issue_label_map >/dev/null 2>&1 || true
+    local ordered=()
+    while IFS= read -r oissue; do
+      [ -n "$oissue" ] && ordered+=("$oissue")
+    done < <(sup_order_pool_by_priority "$start_idx" "${issues[@]}")
+    [ "${#ordered[@]}" -gt 0 ] || ordered=("${issues[@]}")
+
     local issue
-    issue=$(pick_unlocked_issue "$start_idx" "${issues[@]}")
+    issue=$(pick_unlocked_issue 0 "${ordered[@]}")
     if [ -z "$issue" ]; then
       log "slot=$slot LOCKOUT all backlog issues are closed or already have open PRs; backing off ${backoff}s"
       sleep "$backoff"
@@ -381,6 +425,9 @@ log "heartbeater pid=$! cadence=${SUP_HEARTBEAT_SECS}s"
 
 selfheal_watchdog_loop &
 log "selfheal-watchdog pid=$! stall_refusals=$SUP_STALL_REFUSALS cooldown=${SUP_SELFHEAL_COOLDOWN_SECS}s"
+
+standing_task_keeper_loop &
+log "standing-task-keeper pid=$! cadence=${SUP_STANDING_TASK_CHECK_SECS}s label=${SUP_STANDING_TASK_LABEL:-standing-task}"
 
 # Give the first heartbeat a moment to publish desired slots.
 sleep 5

--- a/apps/pylon/scripts/codex-supervisor/priority-dispatch.sh
+++ b/apps/pylon/scripts/codex-supervisor/priority-dispatch.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# priority-dispatch.sh — label-priority dispatch ordering for codex-supervisor (#6711)
+#
+# Fleet-saturation engine, part 1: the supervisor should never let a slot idle
+# while higher-leverage work exists, and it should always burn the highest-value
+# tier first. This helper reorders the dispatchable open-issue pool by the
+# fleet-saturation priority labels:
+#
+#   prio:0-pr-burndown        (rank 0, highest)
+#   prio:1-continual-learning (rank 1)
+#   prio:2-issue-triage       (rank 2)
+#   prio:3-product-promises   (rank 3)
+#   prio:4-backstop-burn      (rank 4, lowest — the infinite own-capacity floor)
+#   (no prio:* label)         (rank 99 — dispatched only after every tier above)
+#
+# The supervisor then scans the reordered pool from the top with the existing
+# `pick_unlocked_issue` lockout (skip CLOSED issues and issues that already have
+# an open PR), so it prefers the highest tier and FALLS THROUGH locked/empty
+# tiers automatically — slots never idle while any dispatchable issue exists.
+#
+# Design:
+#   * Sourceable + test-friendly: `gh` is indirected via $SUP_GH_BIN, and the
+#     per-issue label lookup (`sup_labels_for_issue`) can be overridden in tests
+#     so the ranking + ordering logic is verifiable with no network.
+#   * Intra-tier round-robin spread is preserved: the input pool is rotated by
+#     the caller's start index BEFORE the stable bucket-by-rank, so two slots do
+#     not always collide on the same top-of-tier issue.
+#   * Fails soft: when gh is missing/errors the label map is empty, every issue
+#     ranks 99, and the pool order degrades to the caller's rotation — dispatch
+#     still proceeds, it just loses tier preference until gh recovers.
+#
+# This file performs no work at source time; it only defines functions.
+
+: "${SUP_GH_BIN:=gh}"
+: "${SUP_REPO:=OpenAgentsInc/openagents}"
+: "${SUP_STATE_DIR:=$HOME/.codex-supervisor}"
+: "${SUP_GH_TIMEOUT_SECS:=15}"
+# TTL (s) for the cached open-issue label map.
+: "${SUP_PRIORITY_MAP_TTL_SECS:=${SUP_LOCKOUT_TTL_SECS:-90}}"
+# Max open issues to pull labels for.
+: "${SUP_PRIORITY_MAP_LIMIT:=${SUP_OPEN_SET_LIMIT:-300}}"
+
+# Defensive fallbacks: codex-supervisor.sh sources lockout.sh (which defines
+# sup_file_mtime + sup_run_timeout) BEFORE this file, so the canonical helpers
+# are normally present. Define equivalents here for standalone use.
+if ! command -v sup_file_mtime >/dev/null 2>&1; then
+  sup_file_mtime() {
+    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+  }
+fi
+if ! command -v sup_run_timeout >/dev/null 2>&1; then
+  sup_run_timeout() {
+    local secs="$1"; shift
+    [ "$#" -gt 0 ] || return 0
+    local rc
+    if command -v timeout >/dev/null 2>&1; then
+      timeout "$secs" "$@"; rc=$?
+    elif command -v gtimeout >/dev/null 2>&1; then
+      gtimeout "$secs" "$@"; rc=$?
+    else
+      "$@" &
+      local cmd_pid=$!
+      ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null; sleep 2; kill -KILL "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 &
+      local watch_pid=$!
+      wait "$cmd_pid" 2>/dev/null; rc=$?
+      kill -TERM "$watch_pid" 2>/dev/null; wait "$watch_pid" 2>/dev/null
+      [ "$rc" -ge 128 ] && rc=124
+    fi
+    return "$rc"
+  }
+fi
+
+# The five fleet-saturation tiers, highest priority first.
+SUP_PRIORITY_LABELS=(
+  "prio:0-pr-burndown"
+  "prio:1-continual-learning"
+  "prio:2-issue-triage"
+  "prio:3-product-promises"
+  "prio:4-backstop-burn"
+)
+
+# sup_priority_rank_for_labels <comma-separated-labels>
+#   Prints the numeric priority rank for an issue's label set: the rank of the
+#   highest (lowest-numbered) prio:* label present, or 99 when none is present.
+#   Pure: no external calls.
+sup_priority_rank_for_labels() {
+  local labels=",${1:-},"
+  local i
+  for i in 0 1 2 3 4; do
+    case "$labels" in
+      *",${SUP_PRIORITY_LABELS[$i]},"*) printf '%s' "$i"; return 0 ;;
+    esac
+  done
+  printf '99'
+}
+
+sup_issue_label_map_file() {
+  local cache_dir="${SUP_LOCKOUT_CACHE_DIR:-$SUP_STATE_DIR}"
+  mkdir -p "$cache_dir" 2>/dev/null || true
+  printf '%s/issue-label-map.tsv' "$cache_dir"
+}
+
+# sup_fetch_issue_label_map
+#   Refreshes (TTL-cached) a TSV map of the repo's OPEN issues to their labels:
+#   one line per issue, "<number>\t<label1,label2,...>". rc 0 when the map is
+#   fresh/written, rc 1 when gh is missing/errors (callers fail soft).
+sup_fetch_issue_label_map() {
+  command -v "$SUP_GH_BIN" >/dev/null 2>&1 || return 1
+  local map; map="$(sup_issue_label_map_file)"
+  if [ -f "$map" ] && [ -s "$map" ]; then
+    local now age
+    now=$(date +%s)
+    age=$(( now - $(sup_file_mtime "$map") ))
+    if [ "$age" -ge 0 ] && [ "$age" -lt "$SUP_PRIORITY_MAP_TTL_SECS" ]; then
+      return 0
+    fi
+  fi
+  local json
+  json=$(sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" issue list --repo "$SUP_REPO" --state open \
+    --limit "$SUP_PRIORITY_MAP_LIMIT" --json number,labels 2>/dev/null) || return 1
+  [ -n "$json" ] || return 1
+  local tsv
+  tsv=$(printf '%s' "$json" | python3 -c "import sys,json
+try:
+    rows=json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+if not isinstance(rows,list):
+    sys.exit(1)
+for r in rows:
+    n=r.get('number')
+    if not isinstance(n,int):
+        continue
+    labels=[(l.get('name') or '') for l in (r.get('labels') or []) if isinstance(l,dict)]
+    print(str(n)+chr(9)+','.join([x for x in labels if x]))" 2>/dev/null) || return 1
+  [ -n "$tsv" ] || return 1
+  printf '%s\n' "$tsv" > "$map" 2>/dev/null || true
+  return 0
+}
+
+# sup_labels_for_issue <issue>
+#   Prints the comma-separated label set for an issue from the cached map (built
+#   by sup_fetch_issue_label_map). Prints nothing when unknown. Tests override
+#   this function directly to inject labels with no gh.
+sup_labels_for_issue() {
+  local issue="$1"
+  [ -n "$issue" ] || return 0
+  local map; map="$(sup_issue_label_map_file)"
+  [ -f "$map" ] || return 0
+  awk -F'\t' -v n="$issue" '$1==n {print $2; exit}' "$map" 2>/dev/null
+}
+
+# sup_order_pool_by_priority <start_index> <issue...>
+#   Prints the issue pool reordered by priority tier (rank 0 first, 99 last),
+#   stable WITHIN each tier after a round-robin rotation by <start_index> so
+#   intra-tier load is spread across slots. Issue ranks come from
+#   sup_labels_for_issue. Empty pool prints nothing.
+sup_order_pool_by_priority() {
+  local start="$1"; shift
+  local arr=("$@")
+  local n="${#arr[@]}"
+  [ "$n" -gt 0 ] || return 0
+  [ "$start" -ge 0 ] 2>/dev/null || start=0
+
+  # Rotate the input by start to preserve intra-tier round-robin spread.
+  local rotated=()
+  local k i
+  for (( k=0; k<n; k++ )); do
+    i=$(( (start + k) % n ))
+    rotated+=("${arr[$i]}")
+  done
+
+  # Stable bucket by rank: 0,1,2,3,4 then 99 (unlabelled).
+  local out=()
+  local r issue rank
+  for r in 0 1 2 3 4 99; do
+    for issue in "${rotated[@]}"; do
+      rank=$(sup_priority_rank_for_labels "$(sup_labels_for_issue "$issue")")
+      if [ "$rank" = "$r" ]; then
+        out+=("$issue")
+      fi
+    done
+  done
+  printf '%s\n' "${out[@]}"
+}

--- a/apps/pylon/scripts/codex-supervisor/priority-dispatch.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/priority-dispatch.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# priority-dispatch.test.sh — tests for the codex-supervisor label-priority
+# dispatch ordering (#6711).
+#
+# Covers:
+#   * sup_priority_rank_for_labels maps each prio:* tier to its rank and
+#     unlabelled / unknown-only label sets to 99, taking the highest tier when
+#     several prio:* labels are present.
+#   * sup_order_pool_by_priority orders a mixed pool prio:0 -> ... -> prio:4 ->
+#     unlabelled, preserves intra-tier round-robin rotation, and never drops or
+#     duplicates a pool member.
+#   * sup_fetch_issue_label_map parses gh JSON into the cached TSV label map and
+#     sup_labels_for_issue reads it back (stub gh, no network).
+#
+# Run: bash apps/pylon/scripts/codex-supervisor/priority-dispatch.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+export SUP_STATE_DIR="$WORK/state"
+export SUP_LOCKOUT_CACHE_DIR="$WORK/cache"
+export SUP_REPO="OpenAgentsInc/openagents"
+
+# shellcheck source=priority-dispatch.sh
+source "$SCRIPT_DIR/priority-dispatch.sh"
+
+# --- sup_priority_rank_for_labels -----------------------------------------
+[ "$(sup_priority_rank_for_labels 'prio:0-pr-burndown')" = "0" ]        && ok "rank prio:0 -> 0"        || bad "rank prio:0"
+[ "$(sup_priority_rank_for_labels 'prio:1-continual-learning')" = "1" ] && ok "rank prio:1 -> 1"        || bad "rank prio:1"
+[ "$(sup_priority_rank_for_labels 'prio:2-issue-triage')" = "2" ]       && ok "rank prio:2 -> 2"        || bad "rank prio:2"
+[ "$(sup_priority_rank_for_labels 'prio:3-product-promises')" = "3" ]   && ok "rank prio:3 -> 3"        || bad "rank prio:3"
+[ "$(sup_priority_rank_for_labels 'prio:4-backstop-burn')" = "4" ]      && ok "rank prio:4 -> 4"        || bad "rank prio:4"
+[ "$(sup_priority_rank_for_labels '')" = "99" ]                         && ok "rank empty -> 99"        || bad "rank empty"
+[ "$(sup_priority_rank_for_labels 'bug,enhancement')" = "99" ]          && ok "rank no-prio -> 99"      || bad "rank no-prio"
+# Highest (lowest-numbered) prio wins when several are present.
+[ "$(sup_priority_rank_for_labels 'bug,prio:4-backstop-burn,prio:1-continual-learning')" = "1" ] \
+  && ok "rank takes highest tier (prio:1 over prio:4)" || bad "rank highest-tier"
+# A prio substring that is not a full label must NOT match.
+[ "$(sup_priority_rank_for_labels 'prio:0-pr-burndown-extra')" = "99" ] && ok "rank ignores non-exact prio label" || bad "rank non-exact"
+
+# --- sup_order_pool_by_priority -------------------------------------------
+# Inject labels directly (override the map lookup; no gh needed).
+declare -A LBL=(
+  [10]="prio:4-backstop-burn"
+  [11]="prio:0-pr-burndown"
+  [12]="bug"
+  [13]="prio:2-issue-triage"
+  [14]="prio:0-pr-burndown"
+)
+sup_labels_for_issue() { printf '%s' "${LBL[$1]:-}"; }
+
+# start=0: tiers ascending; within prio:0, input order (11 then 14) preserved.
+order="$(sup_order_pool_by_priority 0 10 11 12 13 14 | tr '\n' ' ')"
+[ "$order" = "11 14 13 10 12 " ] && ok "order prio:0(11,14) -> prio:2(13) -> prio:4(10) -> none(12)" \
+  || bad "order start=0 returned '$order' (want '11 14 13 10 12 ')"
+
+# Rotation spreads intra-tier order: start=2 rotates the input (12,13,14,10,11)
+# so within the prio:0 tier 14 now leads 11.
+order2="$(sup_order_pool_by_priority 2 10 11 12 13 14 | tr '\n' ' ')"
+[ "$order2" = "14 11 13 10 12 " ] && ok "order intra-tier rotation (start=2 -> 14 before 11)" \
+  || bad "order start=2 returned '$order2' (want '14 11 13 10 12 ')"
+
+# No member dropped or duplicated regardless of start.
+count="$(sup_order_pool_by_priority 3 10 11 12 13 14 | grep -c .)"
+[ "$count" = "5" ] && ok "order preserves pool size (5)" || bad "order pool size '$count'"
+
+# --- sup_fetch_issue_label_map + sup_labels_for_issue (stub gh) -----------
+# Restore the real map-backed lookup (the block above overrode it).
+# shellcheck source=priority-dispatch.sh
+source "$SCRIPT_DIR/priority-dispatch.sh"
+STUB_DIR="$WORK/fixtures"; mkdir -p "$STUB_DIR"
+cat > "$WORK/gh" <<'STUB'
+#!/usr/bin/env bash
+# Only supports: issue list --state open --json number,labels
+cat "$STUB_DIR/openlist.json"
+STUB
+chmod +x "$WORK/gh"
+export STUB_DIR
+export SUP_GH_BIN="$WORK/gh"
+printf '%s' '[{"number":11,"labels":[{"name":"prio:0-pr-burndown"},{"name":"bug"}]},{"number":13,"labels":[{"name":"prio:2-issue-triage"}]},{"number":12,"labels":[]}]' \
+  > "$STUB_DIR/openlist.json"
+
+if sup_fetch_issue_label_map; then ok "sup_fetch_issue_label_map built the map"; else bad "sup_fetch_issue_label_map failed"; fi
+[ "$(sup_labels_for_issue 11)" = "prio:0-pr-burndown,bug" ] && ok "labels for #11 read back from map" || bad "labels #11 '$(sup_labels_for_issue 11)'"
+[ "$(sup_labels_for_issue 13)" = "prio:2-issue-triage" ]    && ok "labels for #13 read back from map" || bad "labels #13"
+[ -z "$(sup_labels_for_issue 12)" ]                          && ok "labels for #12 empty (no labels)" || bad "labels #12 not empty"
+[ -z "$(sup_labels_for_issue 999)" ]                         && ok "labels for unknown #999 empty"    || bad "labels #999 not empty"
+
+# End-to-end: map-backed ordering ranks #11 (prio:0) ahead of #13 (prio:2) ahead of #12 (none).
+order3="$(sup_order_pool_by_priority 0 12 13 11 | tr '\n' ' ')"
+[ "$order3" = "11 13 12 " ] && ok "map-backed order prio:0 -> prio:2 -> none" || bad "map-backed order '$order3'"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/apps/pylon/scripts/codex-supervisor/standing-tasks.sh
+++ b/apps/pylon/scripts/codex-supervisor/standing-tasks.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# standing-tasks.sh — auto-recreate closed STANDING task(ops) issues (#6711)
+#
+# Fleet-saturation engine, part 2: the four standing task(ops) issues are the
+# self-sustaining floor of the priority queue (one per prio tier 1-4). If any is
+# closed (a slot finished its cycle of that standing work), the queue must
+# re-grow it so the fleet never runs dry. A standing task is identified by the
+# `standing-task` label; when a labelled issue is CLOSED and no OPEN issue with
+# the SAME title exists, the supervisor opens a fresh clone (same title, body,
+# and labels). The old closed issue stays closed as the audit trail.
+#
+# Idempotency (no duplicates): recreation is keyed on the issue TITLE. Once a
+# fresh clone is open, the next sweep sees an OPEN sibling for that title and
+# skips it. So running this repeatedly never produces duplicate standing tasks,
+# and a title that already has an open standing issue is never recreated.
+#
+# Design:
+#   * Sourceable + test-friendly: `gh` is indirected via $SUP_GH_BIN. The
+#     selection logic (`sup_standing_tasks_to_recreate`) is a pure parse over the
+#     gh JSON, so the no-dup behaviour is verifiable with a stubbed gh.
+#   * Fails soft: when gh is missing/errors, nothing is recreated (rc 1) — a
+#     transient GitHub problem never spams duplicate issues.
+#
+# This file performs no work at source time; it only defines functions.
+
+: "${SUP_GH_BIN:=gh}"
+: "${SUP_REPO:=OpenAgentsInc/openagents}"
+: "${SUP_STANDING_TASK_LABEL:=standing-task}"
+: "${SUP_STANDING_TASK_LIMIT:=200}"
+: "${SUP_GH_TIMEOUT_SECS:=15}"
+
+# Defensive fallback for standalone use; codex-supervisor.sh sources lockout.sh
+# (which defines sup_run_timeout) before this file.
+if ! command -v sup_run_timeout >/dev/null 2>&1; then
+  sup_run_timeout() {
+    local secs="$1"; shift
+    [ "$#" -gt 0 ] || return 0
+    local rc
+    if command -v timeout >/dev/null 2>&1; then
+      timeout "$secs" "$@"; rc=$?
+    elif command -v gtimeout >/dev/null 2>&1; then
+      gtimeout "$secs" "$@"; rc=$?
+    else
+      "$@" &
+      local cmd_pid=$!
+      ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null; sleep 2; kill -KILL "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 &
+      local watch_pid=$!
+      wait "$cmd_pid" 2>/dev/null; rc=$?
+      kill -TERM "$watch_pid" 2>/dev/null; wait "$watch_pid" 2>/dev/null
+      [ "$rc" -ge 128 ] && rc=124
+    fi
+    return "$rc"
+  }
+fi
+
+# Optional logger — used by the live supervisor; harmless no-op standalone.
+if ! command -v sup_standing_log >/dev/null 2>&1; then
+  sup_standing_log() {
+    if [ -n "${SUP_LOG:-}" ]; then
+      printf '%s standing-tasks %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$SUP_LOG" 2>/dev/null || true
+    fi
+  }
+fi
+
+# sup_standing_task_rows_json
+#   Prints the raw gh JSON array of ALL (open + closed) `standing-task` issues
+#   with number, title, and state. rc 1 when gh is missing/errors.
+sup_standing_task_rows_json() {
+  command -v "$SUP_GH_BIN" >/dev/null 2>&1 || return 1
+  local json
+  json=$(sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" issue list --repo "$SUP_REPO" \
+    --label "$SUP_STANDING_TASK_LABEL" --state all \
+    --limit "$SUP_STANDING_TASK_LIMIT" --json number,title,state 2>/dev/null) || return 1
+  [ -n "$json" ] || return 1
+  printf '%s' "$json"
+}
+
+# sup_standing_tasks_to_recreate
+#   Prints the source issue NUMBER (most-recent closed clone) for each standing
+#   task TITLE that is currently CLOSED with NO open sibling — i.e. the titles
+#   that need a fresh clone. The no-dup guard lives here: any title with an OPEN
+#   standing issue is omitted. rc 1 when gh is missing/errors (prints nothing).
+sup_standing_tasks_to_recreate() {
+  local json
+  json="$(sup_standing_task_rows_json)" || return 1
+  printf '%s' "$json" | python3 -c "import sys,json
+try:
+    rows=json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+if not isinstance(rows,list):
+    sys.exit(0)
+open_titles=set()
+closed={}  # title -> most-recent (highest) closed issue number
+for r in rows:
+    if not isinstance(r,dict):
+        continue
+    t=(r.get('title') or '').strip()
+    st=(r.get('state') or '').upper()
+    n=r.get('number')
+    if not t or not isinstance(n,int):
+        continue
+    if st=='OPEN':
+        open_titles.add(t)
+    elif st=='CLOSED':
+        if t not in closed or n>closed[t]:
+            closed[t]=n
+# Recreate only titles that are closed AND have no open sibling (idempotent).
+for t,n in sorted(closed.items(), key=lambda kv: kv[1]):
+    if t not in open_titles:
+        print(n)" 2>/dev/null
+}
+
+# sup_recreate_closed_standing_tasks
+#   For each closed-with-no-open-sibling standing task, opens a fresh clone with
+#   the same title, body, and labels. Prints the number of issues created.
+#   Idempotent across runs (keyed on title). rc 1 when gh is missing.
+sup_recreate_closed_standing_tasks() {
+  command -v "$SUP_GH_BIN" >/dev/null 2>&1 || return 1
+  local created=0 src
+  while IFS= read -r src; do
+    [ -n "$src" ] || continue
+    local meta
+    meta=$(sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" issue view "$src" --repo "$SUP_REPO" \
+      --json title,body,labels 2>/dev/null) || continue
+    [ -n "$meta" ] || continue
+    local title body labels
+    title=$(printf '%s' "$meta" | python3 -c "import sys,json
+try: print((json.load(sys.stdin).get('title') or ''))
+except Exception: pass" 2>/dev/null)
+    body=$(printf '%s' "$meta" | python3 -c "import sys,json
+try: print((json.load(sys.stdin).get('body') or ''))
+except Exception: pass" 2>/dev/null)
+    labels=$(printf '%s' "$meta" | python3 -c "import sys,json
+try:
+    d=json.load(sys.stdin)
+    print(','.join([(l.get('name') or '') for l in (d.get('labels') or []) if isinstance(l,dict) and l.get('name')]))
+except Exception: pass" 2>/dev/null)
+    [ -n "$title" ] || continue
+    local label_args=()
+    if [ -n "$labels" ]; then
+      local oldifs="$IFS"; IFS=','
+      local l
+      for l in $labels; do [ -n "$l" ] && label_args+=(--label "$l"); done
+      IFS="$oldifs"
+    fi
+    if sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" issue create --repo "$SUP_REPO" \
+        --title "$title" --body "$body" "${label_args[@]}" >/dev/null 2>&1; then
+      created=$(( created + 1 ))
+      sup_standing_log "recreated standing task from closed #$src: $title"
+    fi
+  done < <(sup_standing_tasks_to_recreate)
+  printf '%s' "$created"
+  return 0
+}

--- a/apps/pylon/scripts/codex-supervisor/standing-tasks.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/standing-tasks.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# standing-tasks.test.sh — tests for codex-supervisor standing-task auto-recreate
+# (#6711). Stubs the `gh` binary (no network) and asserts:
+#   * sup_standing_tasks_to_recreate selects a CLOSED standing task that has NO
+#     open sibling by title,
+#   * it does NOT select a closed task whose title already has an OPEN sibling
+#     (the no-duplicate guard),
+#   * when several closed clones share a title, only the title is recreated once
+#     (via the most-recent closed source), never one-per-closed-clone,
+#   * sup_recreate_closed_standing_tasks issues exactly one `gh issue create`
+#     per orphaned title, with the source title/body/labels,
+#   * after that fresh clone exists (open sibling present), a second sweep
+#     creates nothing (idempotent across runs),
+#   * a missing gh recreates nothing (fails soft).
+#
+# Run: bash apps/pylon/scripts/codex-supervisor/standing-tasks.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+STUB_DIR="$WORK/fixtures"; mkdir -p "$STUB_DIR"
+CREATE_LOG="$WORK/created.log"; : > "$CREATE_LOG"
+
+# --- stub gh ---------------------------------------------------------------
+#   issue list --label standing-task --state all --json ... -> $STUB_DIR/list.json
+#   issue view N --json title,body,labels                   -> $STUB_DIR/view.N.json
+#   issue create --title T ...                               -> append T to CREATE_LOG
+cat > "$WORK/gh" <<'STUB'
+#!/usr/bin/env bash
+sub="${1:-}"; shift || true
+[ "$sub" = "issue" ] || exit 0
+action="${1:-}"; shift || true
+case "$action" in
+  list) cat "$STUB_DIR/list.json" ;;
+  view)
+    n="${1:-}"
+    f="$STUB_DIR/view.$n.json"
+    [ -f "$f" ] && cat "$f"
+    ;;
+  create)
+    title=""
+    args=("$@"); i=0
+    while [ $i -lt ${#args[@]} ]; do
+      [ "${args[$i]}" = "--title" ] && title="${args[$((i+1))]}"
+      i=$((i+1))
+    done
+    printf '%s\n' "$title" >> "$CREATE_LOG"
+    echo "https://github.com/OpenAgentsInc/openagents/issues/9001"
+    ;;
+esac
+STUB
+chmod +x "$WORK/gh"
+export STUB_DIR CREATE_LOG
+export SUP_GH_BIN="$WORK/gh"
+export SUP_REPO="OpenAgentsInc/openagents"
+
+# shellcheck source=standing-tasks.sh
+source "$SCRIPT_DIR/standing-tasks.sh"
+
+# Fixture: standing-task issues.
+#  - "standing backstop burn"  : CLOSED #6710, no open sibling   -> recreate
+#  - "standing triage"         : OPEN #6708 + CLOSED #6700       -> SKIP (open sibling)
+#  - "standing promise sync"   : CLOSED #6709 + CLOSED #6690     -> recreate ONCE (from #6709)
+printf '%s' '[
+  {"number":6710,"title":"standing backstop burn","state":"CLOSED"},
+  {"number":6708,"title":"standing triage","state":"OPEN"},
+  {"number":6700,"title":"standing triage","state":"CLOSED"},
+  {"number":6709,"title":"standing promise sync","state":"CLOSED"},
+  {"number":6690,"title":"standing promise sync","state":"CLOSED"}
+]' > "$STUB_DIR/list.json"
+
+printf '%s' '{"title":"standing backstop burn","body":"Recurring backstop body","labels":[{"name":"standing-task"},{"name":"prio:4-backstop-burn"}]}' > "$STUB_DIR/view.6710.json"
+printf '%s' '{"title":"standing promise sync","body":"Recurring promise body","labels":[{"name":"standing-task"},{"name":"prio:3-product-promises"}]}' > "$STUB_DIR/view.6709.json"
+
+# --- sup_standing_tasks_to_recreate ---------------------------------------
+to_recreate="$(sup_standing_tasks_to_recreate | sort -n | tr '\n' ' ')"
+[ "$to_recreate" = "6709 6710 " ] \
+  && ok "to_recreate selects orphaned closed titles only (#6709,#6710), skips open-sibling title" \
+  || bad "to_recreate returned '$to_recreate' (want '6709 6710 ')"
+
+# The open-sibling title (#6708/#6700 "standing triage") must NOT appear.
+if printf '%s' "$to_recreate" | grep -qE '(^| )6700( |$)'; then
+  bad "to_recreate must not select #6700 (its title has an open sibling)"
+else
+  ok "no-dup guard: closed #6700 skipped (open sibling #6708 exists)"
+fi
+# The duplicate-closed-clone title must appear at most once (via newest #6709, not #6690).
+dup_count="$(printf '%s\n' $to_recreate | grep -cE '6690')"
+[ "$dup_count" = "0" ] && ok "duplicate closed clone #6690 not double-counted (newest #6709 used)" \
+  || bad "duplicate closed clone #6690 was selected"
+
+# --- sup_recreate_closed_standing_tasks -----------------------------------
+made="$(sup_recreate_closed_standing_tasks)"
+[ "$made" = "2" ] && ok "recreate created 2 issues (one per orphaned title)" || bad "recreate count '$made' (want 2)"
+created_titles="$(sort "$CREATE_LOG" | tr '\n' '|')"
+[ "$created_titles" = "standing backstop burn|standing promise sync|" ] \
+  && ok "recreate used the source titles" || bad "created titles '$created_titles'"
+
+# --- idempotent across runs -----------------------------------------------
+# Simulate the recreate: both titles now have an OPEN sibling.
+printf '%s' '[
+  {"number":6710,"title":"standing backstop burn","state":"CLOSED"},
+  {"number":9101,"title":"standing backstop burn","state":"OPEN"},
+  {"number":6708,"title":"standing triage","state":"OPEN"},
+  {"number":6709,"title":"standing promise sync","state":"CLOSED"},
+  {"number":9102,"title":"standing promise sync","state":"OPEN"}
+]' > "$STUB_DIR/list.json"
+: > "$CREATE_LOG"
+made2="$(sup_recreate_closed_standing_tasks)"
+[ "$made2" = "0" ] && ok "second sweep creates nothing (idempotent; open siblings now exist)" \
+  || bad "second sweep created '$made2' (want 0)"
+[ ! -s "$CREATE_LOG" ] && ok "no gh issue create calls on idempotent sweep" || bad "unexpected create calls: $(cat "$CREATE_LOG")"
+
+# --- fails soft when gh missing -------------------------------------------
+if SUP_GH_BIN="$WORK/does-not-exist" sup_recreate_closed_standing_tasks >/dev/null 2>&1; then
+  bad "missing gh should return nonzero (fail soft, no recreation)"
+else
+  ok "missing gh fails soft (no recreation)"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fleet-saturation engine, part 1 (#6711). Idle slots starve today because there
is no priority dispatch and no self-sustaining queue. This adds both.

## Label-priority dispatch (`priority-dispatch.sh`)
- Reorders the dispatchable open-issue pool by priority tier:
  `prio:0-pr-burndown` > `prio:1-continual-learning` > `prio:2-issue-triage` >
  `prio:3-product-promises` > `prio:4-backstop-burn`, then unlabelled.
- `pick_unlocked_issue` scans the reordered pool from the top, so slots prefer
  the highest tier and **fall through** locked/empty tiers — slots never idle
  while any dispatchable issue exists.
- The existing **lockout is preserved**: CLOSED issues and issues with an open
  PR are still skipped.
- Intra-tier round-robin spread is kept via start-index rotation before a stable
  bucket-by-rank. TTL-cached label map; fails soft to plain rotation when `gh`
  is unavailable.

## Standing-task auto-recreate (`standing-tasks.sh`)
- A timed keeper loop re-grows any CLOSED `standing-task` issue (the four prio
  task(ops) issues #6707/#6708/#6709/#6710) that has no open sibling, opening a
  fresh clone with the same title/body/labels.
- **Idempotent by title** — a title with an open standing issue is never
  duplicated, so repeated sweeps never create duplicates. Fails soft when `gh`
  is missing.

Both libs are sourced by `codex-supervisor.sh` and run as background loops.

## Tests
- `priority-dispatch.test.sh`: rank mapping per tier, ordering + rotation,
  label-map parse/readback (stubbed gh).
- `standing-tasks.test.sh`: orphaned-title selection, the no-dup guard
  (open-sibling skip), recreation, and idempotency across runs (stubbed gh).
- Existing `lockout.test.sh` still green.
- Repo `check:deploy` green.

Closes #6711

🤖 Generated with [Claude Code](https://claude.com/claude-code)