### PR TITLE
feat(artanis): enforce FRLM conductor BudgetPolicy

### DIFF
--- a/apps/pylon/src/frlm-conductor-execution.ts
+++ b/apps/pylon/src/frlm-conductor-execution.ts
@@ -21,10 +21,20 @@ export type FrlmConductorExecutionBlockerRef =
   | "blocker.artanis.frlm_conductor.execution_ref_missing"
   | "blocker.artanis.frlm_conductor.root_task_ref_missing"
   | "blocker.artanis.frlm_conductor.blueprint_signature_ref_missing"
+  | "blocker.artanis.frlm_conductor.budget_policy_ref_missing"
+  | "blocker.artanis.frlm_conductor.budget_policy_invalid"
+  | "blocker.artanis.frlm_conductor.token_budget_exceeded"
+  | "blocker.artanis.frlm_conductor.depth_limit_exceeded"
   | "blocker.artanis.frlm_conductor.sub_query_plan_missing"
   | "blocker.artanis.frlm_conductor.sub_query_failure_without_linear_fallback"
   | "blocker.artanis.frlm_conductor.linear_executor_ref_missing"
   | "blocker.artanis.frlm_conductor.unsafe_ref"
+
+export type FrlmConductorBudgetPolicy = {
+  budgetPolicyRef: string
+  maxTokens: number
+  maxDepth: number
+}
 
 export type FrlmConductorSubQuery = {
   subQueryRef: string
@@ -33,6 +43,8 @@ export type FrlmConductorSubQuery = {
   resultRef?: string | null
   failureRef?: string | null
   blueprintSignatureRef?: string | null
+  depth?: number | null
+  tokenCount?: number | null
 }
 
 export type FrlmConductorExecutionProjection = {
@@ -41,6 +53,11 @@ export type FrlmConductorExecutionProjection = {
   executionRef: string | null
   rootTaskRef: string | null
   blueprintSignatureRef: string | null
+  budgetPolicyRef: string | null
+  tokenBudget: number | null
+  projectedTokenCount: number
+  depthLimit: number | null
+  projectedMaxDepth: number
   executionMode: FrlmConductorExecutionMode
   canExecute: boolean
   recursiveSubQueryRefs: string[]
@@ -70,6 +87,7 @@ export function planFrlmConductorExecution(input: {
   executionRef?: string | null
   rootTaskRef?: string | null
   blueprintSignatureRef?: string | null
+  budgetPolicy?: FrlmConductorBudgetPolicy | null
   subQueries?: FrlmConductorSubQuery[]
   linearFallbackEnabled?: boolean
   linearExecutorRef?: string | null
@@ -80,6 +98,7 @@ export function planFrlmConductorExecution(input: {
     normalizedRef(input.executionRef),
     normalizedRef(input.rootTaskRef),
     normalizedRef(input.blueprintSignatureRef),
+    normalizedRef(input.budgetPolicy?.budgetPolicyRef),
     normalizedRef(input.linearExecutorRef),
     ...subQueries.flatMap((subQuery) => [
       normalizedRef(subQuery.subQueryRef),
@@ -103,8 +122,16 @@ export function planFrlmConductorExecution(input: {
   const executionRef = safeRef(input.executionRef)
   const rootTaskRef = safeRef(input.rootTaskRef)
   const blueprintSignatureRef = safeRef(input.blueprintSignatureRef)
+  const budgetPolicyRef = safeRef(input.budgetPolicy?.budgetPolicyRef)
+  const tokenBudget = positiveInteger(input.budgetPolicy?.maxTokens)
+  const depthLimit = positiveInteger(input.budgetPolicy?.maxDepth)
   const linearExecutorRef = safeRef(input.linearExecutorRef)
   const recursiveSubQueryRefs = uniqueRefs(subQueries.map((subQuery) => safeRef(subQuery.subQueryRef)))
+  const projectedTokenCount = subQueries.reduce(
+    (total, subQuery) => total + nonNegativeInteger(subQuery.tokenCount),
+    0,
+  )
+  const projectedMaxDepth = maxProjectedDepth(rootTaskRef, subQueries)
   const failedSubQueryRefs = uniqueRefs(
     subQueries
       .filter((subQuery) => failedStates.has(subQuery.state))
@@ -123,6 +150,18 @@ export function planFrlmConductorExecution(input: {
   }
   if (blueprintSignatureRef === null) {
     blockerRefs.add("blocker.artanis.frlm_conductor.blueprint_signature_ref_missing")
+  }
+  if (budgetPolicyRef === null) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.budget_policy_ref_missing")
+  }
+  if (input.budgetPolicy === null || input.budgetPolicy === undefined || tokenBudget === null || depthLimit === null) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.budget_policy_invalid")
+  }
+  if (tokenBudget !== null && projectedTokenCount > tokenBudget) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.token_budget_exceeded")
+  }
+  if (depthLimit !== null && projectedMaxDepth > depthLimit) {
+    blockerRefs.add("blocker.artanis.frlm_conductor.depth_limit_exceeded")
   }
   if (recursiveSubQueryRefs.length === 0) {
     blockerRefs.add("blocker.artanis.frlm_conductor.sub_query_plan_missing")
@@ -156,6 +195,7 @@ export function planFrlmConductorExecution(input: {
     executionRef,
     rootTaskRef,
     blueprintSignatureRef,
+    budgetPolicyRef,
     linearExecutorRef,
     fallbackReasonRef,
     ...recursiveSubQueryRefs,
@@ -175,6 +215,11 @@ export function planFrlmConductorExecution(input: {
     executionRef,
     rootTaskRef,
     blueprintSignatureRef,
+    budgetPolicyRef,
+    tokenBudget,
+    projectedTokenCount,
+    depthLimit,
+    projectedMaxDepth,
     executionMode,
     canExecute,
     recursiveSubQueryRefs,
@@ -211,4 +256,55 @@ function uniqueRefs(refs: (string | null)[]) {
   return [...new Set(refs.filter((ref): ref is string => ref !== null && ref.trim().length > 0))]
     .map((ref) => ref.trim())
     .sort()
+}
+
+function positiveInteger(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null
+}
+
+function nonNegativeInteger(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : 0
+}
+
+function maxProjectedDepth(rootTaskRef: string | null, subQueries: FrlmConductorSubQuery[]) {
+  const parentByRef = new Map<string, string | null>()
+  for (const subQuery of subQueries) {
+    const subQueryRef = normalizedRef(subQuery.subQueryRef)
+    if (subQueryRef !== null) {
+      parentByRef.set(subQueryRef, normalizedRef(subQuery.parentRef))
+    }
+  }
+
+  let maxDepth = 0
+  for (const subQuery of subQueries) {
+    const explicitDepth = positiveInteger(subQuery.depth)
+    if (explicitDepth !== null) {
+      maxDepth = Math.max(maxDepth, explicitDepth)
+      continue
+    }
+
+    const subQueryRef = normalizedRef(subQuery.subQueryRef)
+    if (subQueryRef !== null) {
+      maxDepth = Math.max(maxDepth, inferredDepth(rootTaskRef, subQueryRef, parentByRef))
+    }
+  }
+  return maxDepth
+}
+
+function inferredDepth(rootTaskRef: string | null, subQueryRef: string, parentByRef: Map<string, string | null>) {
+  let depth = 1
+  let currentRef: string | null = subQueryRef
+  const seen = new Set<string>()
+
+  while (currentRef !== null && !seen.has(currentRef)) {
+    seen.add(currentRef)
+    const parentRef: string | null = parentByRef.get(currentRef) ?? null
+    if (parentRef === null || parentRef === rootTaskRef) {
+      return depth
+    }
+    depth += 1
+    currentRef = parentByRef.has(parentRef) ? parentRef : null
+  }
+
+  return depth
 }

--- a/apps/pylon/tests/frlm-conductor-execution.test.ts
+++ b/apps/pylon/tests/frlm-conductor-execution.test.ts
@@ -16,6 +16,11 @@ describe("FRLM Conductor execution planning", () => {
 
     expect(projection.canExecute).toBe(true)
     expect(projection.executionMode).toBe("recursive_parallel")
+    expect(projection.budgetPolicyRef).toBe("budget_policy.artanis.frlm_conductor.issue_6683.v1")
+    expect(projection.tokenBudget).toBe(12_000)
+    expect(projection.projectedTokenCount).toBe(4_800)
+    expect(projection.depthLimit).toBe(2)
+    expect(projection.projectedMaxDepth).toBe(1)
     expect(projection.blockerRefs).toEqual([])
     expect(projection.failedSubQueryRefs).toEqual([])
     expect(projection.linearFallbackStepRefs).toEqual([])
@@ -73,6 +78,76 @@ describe("FRLM Conductor execution planning", () => {
     )
   })
 
+  test("blocks execution when recursive sub-query tokens exceed the BudgetPolicy", () => {
+    const projection = planFrlmConductorExecution({
+      ...validInput(),
+      budgetPolicy: {
+        budgetPolicyRef: "budget_policy.artanis.frlm_conductor.tight_tokens.v1",
+        maxTokens: 4_000,
+        maxDepth: 3,
+      },
+      subQueries: completedSubQueries(),
+    })
+
+    expect(projection.canExecute).toBe(false)
+    expect(projection.executionMode).toBe("blocked")
+    expect(projection.tokenBudget).toBe(4_000)
+    expect(projection.projectedTokenCount).toBe(4_800)
+    expect(projection.blockerRefs).toContain("blocker.artanis.frlm_conductor.token_budget_exceeded")
+    expect(projection.executionPlanRef).toBeNull()
+    assertPublicProjectionSafe(projection)
+  })
+
+  test("blocks execution when recursive sub-query depth exceeds the BudgetPolicy", () => {
+    const projection = planFrlmConductorExecution({
+      ...validInput(),
+      subQueries: [
+        completedSubQueries()[0],
+        {
+          subQueryRef: "subquery.artanis.frlm.inspect_nested_context.v1",
+          parentRef: "subquery.artanis.frlm.collect_context.v1",
+          state: "completed",
+          resultRef: "result.artanis.frlm.inspect_nested_context.v1",
+          blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+          tokenCount: 1_200,
+        },
+        {
+          subQueryRef: "subquery.artanis.frlm.inspect_leaf_context.v1",
+          parentRef: "subquery.artanis.frlm.inspect_nested_context.v1",
+          state: "completed",
+          resultRef: "result.artanis.frlm.inspect_leaf_context.v1",
+          blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+          tokenCount: 900,
+        },
+      ],
+    })
+
+    expect(projection.canExecute).toBe(false)
+    expect(projection.executionMode).toBe("blocked")
+    expect(projection.depthLimit).toBe(2)
+    expect(projection.projectedMaxDepth).toBe(3)
+    expect(projection.blockerRefs).toContain("blocker.artanis.frlm_conductor.depth_limit_exceeded")
+    expect(projection.executionPlanRef).toBeNull()
+    assertPublicProjectionSafe(projection)
+  })
+
+  test("blocks execution when the BudgetPolicy is missing or invalid", () => {
+    const projection = planFrlmConductorExecution({
+      ...validInput(),
+      budgetPolicy: null,
+      subQueries: completedSubQueries(),
+    })
+
+    expect(projection.canExecute).toBe(false)
+    expect(projection.executionMode).toBe("blocked")
+    expect(projection.budgetPolicyRef).toBeNull()
+    expect(projection.tokenBudget).toBeNull()
+    expect(projection.depthLimit).toBeNull()
+    expect(projection.blockerRefs).toContain("blocker.artanis.frlm_conductor.budget_policy_ref_missing")
+    expect(projection.blockerRefs).toContain("blocker.artanis.frlm_conductor.budget_policy_invalid")
+    assertPublicProjectionSafe(projection)
+  })
+
   test("blocks unsafe refs before they reach public projection fields", () => {
     const projection = planFrlmConductorExecution({
       ...validInput(),
@@ -99,6 +174,11 @@ function validInput() {
     executionRef: "execution.artanis.frlm.issue_6684.v1",
     rootTaskRef: "task.artanis.frlm.root.v1",
     blueprintSignatureRef: "signature.blueprint.frlm_conductor.v1",
+    budgetPolicy: {
+      budgetPolicyRef: "budget_policy.artanis.frlm_conductor.issue_6683.v1",
+      maxTokens: 12_000,
+      maxDepth: 2,
+    },
     linearFallbackEnabled: true,
     linearExecutorRef: "executor.artanis.frlm.linear_local.v1",
   }
@@ -112,6 +192,7 @@ function completedSubQueries(): FrlmConductorSubQuery[] {
       state: "completed",
       resultRef: "result.artanis.frlm.collect_context.v1",
       blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+      tokenCount: 1_500,
     },
     {
       subQueryRef: "subquery.artanis.frlm.optimize_route.v1",
@@ -119,6 +200,7 @@ function completedSubQueries(): FrlmConductorSubQuery[] {
       state: "completed",
       resultRef: "result.artanis.frlm.optimize_route.v1",
       blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+      tokenCount: 1_800,
     },
     {
       subQueryRef: "subquery.artanis.frlm.verify_blueprint_boundary.v1",
@@ -126,6 +208,7 @@ function completedSubQueries(): FrlmConductorSubQuery[] {
       state: "completed",
       resultRef: "result.artanis.frlm.verify_blueprint_boundary.v1",
       blueprintSignatureRef: "signature.blueprint.rlm_subquery.v1",
+      tokenCount: 1_500,
     },
   ]
 }


### PR DESCRIPTION
Addresses #6683.

### Changes
- Added FRLM conductor BudgetPolicy projection fields for policy ref, token budget, projected token count, depth limit, and projected max depth.
- Added blockers for missing or invalid budget policies, token budget overruns, and depth limit overruns.
- Covered BudgetPolicy acceptance and rejection behavior in FRLM conductor execution tests.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).