### PR TITLE
feat(web): add provider pool manual reset flow

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedIn/message.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/message.ts
@@ -61,6 +61,7 @@ import {
   ImageGenerationModelId,
   ImageGenerationProvider,
   PrefilledWorkspaceResponse,
+  ProviderAccountPoolManualResetResponse,
   ProviderAccountPoolResponse,
   SubmitCustomerSiteFeedbackResponse,
   TeamChatMessagesResponse,
@@ -154,6 +155,25 @@ export const FailedLoadProviderAccountPool = m(
   'FailedLoadProviderAccountPool',
   {
     error: S.String,
+  },
+)
+export const ClickedResetProviderAccountPoolAccount = m(
+  'ClickedResetProviderAccountPoolAccount',
+  {
+    providerAccountRef: S.String,
+  },
+)
+export const SucceededResetProviderAccountPoolAccount = m(
+  'SucceededResetProviderAccountPoolAccount',
+  {
+    response: ProviderAccountPoolManualResetResponse,
+  },
+)
+export const FailedResetProviderAccountPoolAccount = m(
+  'FailedResetProviderAccountPoolAccount',
+  {
+    error: S.String,
+    providerAccountRef: S.String,
   },
 )
 export const ClickedBillingPackage = m('ClickedBillingPackage', {
@@ -1263,6 +1283,9 @@ export const Message = S.Union([
   RequestedLoadProviderAccountPool,
   SucceededLoadProviderAccountPool,
   FailedLoadProviderAccountPool,
+  ClickedResetProviderAccountPoolAccount,
+  SucceededResetProviderAccountPoolAccount,
+  FailedResetProviderAccountPoolAccount,
   ClickedBillingPackage,
   UpdatedBillingCouponCode,
   SubmittedBillingCoupon,

--- a/apps/openagents.com/apps/web/src/page/loggedIn/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/model.ts
@@ -1193,6 +1193,14 @@ export const ProviderAccountPoolResponse = S.Struct({
 export type ProviderAccountPoolResponse =
   typeof ProviderAccountPoolResponse.Type
 
+export const ProviderAccountPoolManualResetResponse = S.Struct({
+  ok: S.Literal(true),
+  providerAccountRef: S.String,
+  resetAt: S.String,
+})
+export type ProviderAccountPoolManualResetResponse =
+  typeof ProviderAccountPoolManualResetResponse.Type
+
 export const ProviderAccountPoolIdle = ts('ProviderAccountPoolIdle', {})
 export const ProviderAccountPoolLoading = ts('ProviderAccountPoolLoading', {})
 export const ProviderAccountPoolLoaded = ts('ProviderAccountPoolLoaded', {

--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/settings.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/settings.ts
@@ -12,6 +12,7 @@ import {
   ClickedNextOnboardingRepositoryPage,
   ClickedPollProviderDeviceLogin,
   ClickedPreviousOnboardingRepositoryPage,
+  ClickedResetProviderAccountPoolAccount,
   ClickedStartProviderDeviceLogin,
   type Message,
   RequestedLoadOnboardingRepositories,
@@ -540,6 +541,9 @@ const poolAccountHeadline = (account: ProviderAccountPoolAccount): string =>
       ? 'ready'
       : (account.eligibilityReasons[0] ?? 'unavailable')
 
+const poolAccountCanReset = (account: ProviderAccountPoolAccount): boolean =>
+  account.cooldownUntil !== null || account.recentFailureClass === 'rate_limited'
+
 const poolAccountView = (account: ProviderAccountPoolAccount): Html => {
   const h = html<Message>()
 
@@ -596,6 +600,19 @@ const poolAccountView = (account: ProviderAccountPoolAccount): Html => {
                   [Ui.className<Message>('text-xs text-[#d32f2f]')],
                   ['Reconnect required'],
                 )
+              : poolAccountCanReset(account)
+                ? Ui.button<Message>({
+                    label: 'Reset',
+                    size: 'sm',
+                    variant: 'secondary',
+                    attrs: [
+                      h.OnClick(
+                        ClickedResetProviderAccountPoolAccount({
+                          providerAccountRef: account.providerAccountRef,
+                        }),
+                      ),
+                    ],
+                  })
               : h.span(
                   [Ui.className<Message>('text-xs text-white/35')],
                   [`priority ${account.operatorPriority}`],

--- a/apps/openagents.com/apps/web/src/page/loggedIn/providers/commands.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/providers/commands.ts
@@ -9,12 +9,17 @@ import { errorMessageFromUnknown, requestJson } from '../commands/api'
 import {
   FailedLoadProviderAccountPool,
   FailedPollProviderDeviceLogin,
+  FailedResetProviderAccountPoolAccount,
   FailedStartProviderDeviceLogin,
   SucceededLoadProviderAccountPool,
   SucceededPollProviderDeviceLogin,
+  SucceededResetProviderAccountPoolAccount,
   SucceededStartProviderDeviceLogin,
 } from '../message'
-import { ProviderAccountPoolResponse } from '../model'
+import {
+  ProviderAccountPoolManualResetResponse,
+  ProviderAccountPoolResponse,
+} from '../model'
 
 export const StartProviderDeviceLogin = Command.define(
   'StartProviderDeviceLogin',
@@ -81,6 +86,42 @@ export const LoadProviderAccountPool = Command.define(
       Effect.succeed(
         FailedLoadProviderAccountPool({
           error: errorMessageFromUnknown(error),
+        }),
+      ),
+    ),
+  ),
+)
+
+export const ResetProviderAccountPoolAccount = Command.define(
+  'ResetProviderAccountPoolAccount',
+  { providerAccountRef: S.String },
+  SucceededResetProviderAccountPoolAccount,
+  FailedResetProviderAccountPoolAccount,
+)(({ providerAccountRef }) =>
+  Effect.gen(function* () {
+    const response = yield* requestJson({
+      init: {
+        body: JSON.stringify({ providerAccountRef }),
+        cache: 'no-store',
+        credentials: 'include',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      },
+      name: 'loggedIn.providerAccountPool.resetAccount',
+      request: '/api/provider-accounts/pool/reset',
+      schema: ProviderAccountPoolManualResetResponse,
+    })
+
+    return SucceededResetProviderAccountPoolAccount({ response })
+  }).pipe(
+    Effect.catch(error =>
+      Effect.succeed(
+        FailedResetProviderAccountPoolAccount({
+          error: errorMessageFromUnknown(error),
+          providerAccountRef,
         }),
       ),
     ),

--- a/apps/openagents.com/apps/web/src/page/loggedIn/providers/pool.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/providers/pool.test.ts
@@ -13,7 +13,9 @@ import {
 import { SettingsRoute, SettingsSectionRoute } from '../../../route'
 import {
   FailedLoadProviderAccountPool,
+  ClickedResetProviderAccountPoolAccount,
   RequestedLoadProviderAccountPool,
+  SucceededResetProviderAccountPoolAccount,
   SucceededLoadProviderAccountPool,
   SucceededPollProviderDeviceLogin,
 } from '../message'
@@ -229,6 +231,58 @@ describe('provider account pool', () => {
     )
 
     expect(commands.map(command => command.name)).toEqual([
+      'LoadProviderAccountPool',
+    ])
+  })
+
+  test('manual reset optimistically clears cooldown and refreshes after POST', () => {
+    const model = init(SettingsSectionRoute({ section: 'connections' }), auth)
+    const [loadedModel] = update(
+      model,
+      SucceededLoadProviderAccountPool({ response: poolResponse }),
+    )
+    const [optimisticModel, resetCommands] = update(
+      loadedModel,
+      ClickedResetProviderAccountPoolAccount({
+        providerAccountRef: 'provider-account_2',
+      }),
+    )
+
+    expect(resetCommands.map(command => command.name)).toEqual([
+      'ResetProviderAccountPoolAccount',
+    ])
+
+    if (
+      optimisticModel.providerAccountPool._tag !== 'ProviderAccountPoolLoaded'
+    ) {
+      throw new Error('expected loaded account pool')
+    }
+
+    expect(optimisticModel.providerAccountPool.response.summary.cooldown).toBe(
+      0,
+    )
+    expect(
+      optimisticModel.providerAccountPool.response.accounts[1],
+    ).toMatchObject({
+      cooldownRemainingSeconds: null,
+      cooldownUntil: null,
+      eligibility: 'eligible',
+      eligibilityReasons: [],
+      recentFailureClass: null,
+    })
+
+    const [, refreshCommands] = update(
+      optimisticModel,
+      SucceededResetProviderAccountPoolAccount({
+        response: {
+          ok: true,
+          providerAccountRef: 'provider-account_2',
+          resetAt: '2026-06-11T12:01:00.000Z',
+        },
+      }),
+    )
+
+    expect(refreshCommands.map(command => command.name)).toEqual([
       'LoadProviderAccountPool',
     ])
   })

--- a/apps/openagents.com/apps/web/src/page/loggedIn/providers/transitions.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/providers/transitions.ts
@@ -22,6 +22,7 @@ import { type UpdateReturn, noUpdate } from '../transition'
 import {
   LoadProviderAccountPool,
   PollProviderDeviceLogin,
+  ResetProviderAccountPoolAccount,
   StartProviderDeviceLogin,
 } from './commands'
 
@@ -48,6 +49,58 @@ const applyProviderConnection = (
       authWithProviderAccounts(model.auth, {
         accounts,
         attempts,
+      }),
+  })
+}
+
+const optimisticResetPoolAccount = (
+  model: Model,
+  providerAccountRef: string,
+): Model => {
+  if (model.providerAccountPool._tag !== 'ProviderAccountPoolLoaded') {
+    return model
+  }
+
+  const response = model.providerAccountPool.response
+  const accounts = response.accounts.map(account => {
+    if (account.providerAccountRef !== providerAccountRef) {
+      return account
+    }
+
+    const eligibilityReasons = account.eligibilityReasons.filter(
+      reason => reason !== 'cooldown',
+    )
+
+    return {
+      ...account,
+      cooldownRemainingSeconds: null,
+      cooldownUntil: null,
+      eligibility:
+        eligibilityReasons.length === 0 ? 'eligible' : account.eligibility,
+      eligibilityReasons,
+      recentFailureClass:
+        account.recentFailureClass === 'rate_limited'
+          ? null
+          : account.recentFailureClass,
+    }
+  })
+
+  return evo(model, {
+    providerAccountPool: () =>
+      ProviderAccountPoolLoaded({
+        response: {
+          ...response,
+          accounts,
+          summary: {
+            ...response.summary,
+            cooldown: accounts.filter(account =>
+              account.eligibilityReasons.includes('cooldown'),
+            ).length,
+            eligible: accounts.filter(
+              account => account.eligibility === 'eligible',
+            ).length,
+          },
+        },
       }),
   })
 }
@@ -95,6 +148,21 @@ export const updateProviders = (model: Model, message: Message): UpdateReturn =>
           providerAccountPool: () => ProviderAccountPoolFailed({ error }),
         }),
         [],
+        Option.none(),
+      ],
+      ClickedResetProviderAccountPoolAccount: ({ providerAccountRef }) => [
+        optimisticResetPoolAccount(model, providerAccountRef),
+        [ResetProviderAccountPoolAccount({ providerAccountRef })],
+        Option.none(),
+      ],
+      SucceededResetProviderAccountPoolAccount: () => [
+        model,
+        [LoadProviderAccountPool({})],
+        Option.none(),
+      ],
+      FailedResetProviderAccountPoolAccount: () => [
+        model,
+        [LoadProviderAccountPool({})],
         Option.none(),
       ],
       SucceededStartProviderDeviceLogin: ({ response }) => {

--- a/apps/openagents.com/apps/web/src/page/loggedIn/update-dispatch.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/update-dispatch.ts
@@ -114,6 +114,12 @@ export const update = (model: Model, message: Message): UpdateReturn => {
       RequestedLoadProviderAccountPool: () => updateProviders(model, message),
       SucceededLoadProviderAccountPool: () => updateProviders(model, message),
       FailedLoadProviderAccountPool: () => updateProviders(model, message),
+      ClickedResetProviderAccountPoolAccount: () =>
+        updateProviders(model, message),
+      SucceededResetProviderAccountPoolAccount: () =>
+        updateProviders(model, message),
+      FailedResetProviderAccountPoolAccount: () =>
+        updateProviders(model, message),
 
       RequestedLoadOnboardingRepositories: () =>
         updateOnboarding(model, message),

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1604,6 +1604,12 @@ const schemaComponents = (): JsonSchema => ({
   ProviderAccountPoolResponse: objectSummary(
     'Account-pool dashboard projection over the connected provider accounts owned by the signed-in user or the agent grant owner: provider-tagged per-account status/health, lease eligibility with typed reasons, active lease count vs lease limit, cooldown-until plus remaining seconds, low-credit flags, recent failure class, last-selected/sanity-check/probe/launch timestamps, and reconnect nudges for expired or reauth-required accounts; plus the active lease list, the next-selection explain row, summary counts, generatedAt, and the declared staleness contract (live_at_read, rebuilds on provider-account connect/disconnect/health/lease/failover transitions). Read-only projection: lease refs and typed state only. Provider tokens, secrets, grants, and raw provider payloads are never returned, and the projection grants no lease, spend, or provider-mutation authority.',
   ),
+  ProviderAccountPoolManualResetRequest: objectSummary(
+    'Signed-in owner request to manually clear a provider account cooldown/rate-limit marker by providerAccountRef. Browser session only; agent bearer grants remain read-only for this surface. The reset does not touch credentials, leases, spend, or other owners accounts.',
+  ),
+  ProviderAccountPoolManualResetResponse: objectSummary(
+    'Manual reset receipt with ok, providerAccountRef, and resetAt. It confirms only that the signed-in owners local cooldown/rate-limit marker was cleared; callers should re-read the pool projection for current eligibility.',
+  ),
   BuiltinComputeAgentGrantEnvelope: objectSummary(
     'Built-in hosted-Gemini grant result for the no-key built-in agent path. A granted response returns a short-lived redacted grant with provider secret refs, free-tier budget refs, expiry, and materialization instructions only; it never returns the hosted key, provider payloads, prompts, completions, or broad provider-account mutation authority. Not-configured and quota-exhausted states are explicit.',
   ),
@@ -11057,6 +11063,26 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Account-pool dashboard projection.',
           '#/components/schemas/ProviderAccountPoolResponse',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/provider-accounts/pool/reset': {
+    post: operation({
+      operationId: 'resetProviderAccountPoolAccount',
+      summary: 'Manually reset an owned provider account cooldown marker',
+      description:
+        'Signed-in owner action that clears the selected account-pool cooldown and recent rate-limit marker by providerAccountRef, then returns a reset receipt. The action is browser-session only; bearer-agent pool access remains read-only. It does not expose or mutate provider credentials, active leases, spend, or accounts outside the signed-in owner scope.',
+      tags: ['Provider Accounts'],
+      security: [{ browserSession: [] }],
+      requestBody: jsonContent(
+        '#/components/schemas/ProviderAccountPoolManualResetRequest',
+      ),
+      responses: {
+        '200': okJson(
+          'Provider account manual reset receipt.',
+          '#/components/schemas/ProviderAccountPoolManualResetResponse',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/provider-account-pool-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-pool-routes.test.ts
@@ -76,7 +76,7 @@ class FakeD1Statement {
       results: this.database.all(this.query, this.values) as Array<T>,
     })
 
-  run = () => Promise.resolve({ success: true })
+  run = () => Promise.resolve(this.database.run(this.query, this.values))
 }
 
 class FakePoolD1 {
@@ -149,6 +149,37 @@ class FakePoolD1 {
     }
 
     return null
+  }
+
+  run = (query: string, values: Array<unknown>) => {
+    if (
+      query.includes('UPDATE provider_accounts') &&
+      query.includes('cooldown_until = NULL')
+    ) {
+      const [updatedAt, userId, providerAccountRef] = values as [
+        string,
+        string,
+        string,
+      ]
+      const account = this.accounts.find(
+        candidate =>
+          candidate.user_id === userId &&
+          candidate.provider_account_ref === providerAccountRef &&
+          candidate.deleted_at === null,
+      )
+
+      if (account === undefined) {
+        return { success: true, meta: { changes: 0 } }
+      }
+
+      account.cooldown_until = null
+      account.recent_failure_class = null
+      account.last_failed_launch_at = updatedAt
+
+      return { success: true, meta: { changes: 1 } }
+    }
+
+    return { success: true, meta: { changes: 0 } }
   }
 
   all = (query: string, values: Array<unknown>): Array<unknown> => {
@@ -319,6 +350,16 @@ const poolRequest = (headers: Record<string, string> = {}): Request =>
   new Request('https://openagents.com/api/provider-accounts/pool', {
     headers,
     method: 'GET',
+  })
+
+const resetRequest = (
+  providerAccountRef: string,
+  headers: Record<string, string> = {},
+): Request =>
+  new Request('https://openagents.com/api/provider-accounts/pool/reset', {
+    body: JSON.stringify({ providerAccountRef }),
+    headers: { 'content-type': 'application/json', ...headers },
+    method: 'POST',
   })
 
 const seededDatabase = (): FakePoolD1 => {
@@ -546,6 +587,51 @@ describe('provider account pool projection route', () => {
     expect(response.status).toBe(401)
   })
 
+  test('browser session manually resets an owned cooldown account', async () => {
+    const database = seededDatabase()
+    const handler = makeHandler({
+      database,
+      session: { user: { userId: OWNER_USER_ID } },
+    })
+    const response = await handler(
+      resetRequest('provider-account_acct_cooling'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({
+      ok: true,
+      providerAccountRef: 'provider-account_acct_cooling',
+      resetAt: NOW,
+    })
+    expect(
+      database.accounts.find(
+        account =>
+          account.provider_account_ref === 'provider-account_acct_cooling',
+      ),
+    ).toMatchObject({
+      cooldown_until: null,
+      recent_failure_class: null,
+    })
+  })
+
+  test('manual reset refuses missing and cross-owner accounts', async () => {
+    const handler = makeHandler({
+      database: seededDatabase(),
+      session: { user: { userId: OWNER_USER_ID } },
+    })
+    const missingBody = await handler(
+      new Request('https://openagents.com/api/provider-accounts/pool/reset', {
+        body: '{}',
+        method: 'POST',
+      }),
+    )
+    const missingAccount = await handler(resetRequest('provider-account_other'))
+
+    expect(missingBody.status).toBe(400)
+    expect(missingAccount.status).toBe(404)
+  })
+
   test('non-GET methods are rejected', async () => {
     const handler = makeHandler({
       database: seededDatabase(),
@@ -554,6 +640,20 @@ describe('provider account pool projection route', () => {
     const response = await handler(
       new Request('https://openagents.com/api/provider-accounts/pool', {
         method: 'POST',
+      }),
+    )
+
+    expect(response.status).toBe(405)
+  })
+
+  test('non-POST reset methods are rejected', async () => {
+    const handler = makeHandler({
+      database: seededDatabase(),
+      session: { user: { userId: OWNER_USER_ID } },
+    })
+    const response = await handler(
+      new Request('https://openagents.com/api/provider-accounts/pool/reset', {
+        method: 'GET',
       }),
     )
 

--- a/apps/openagents.com/workers/api/src/provider-account-pool-routes.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-pool-routes.ts
@@ -8,6 +8,7 @@ import {
 } from './customer-order-agent-auth'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import type { RouteEffect } from './http/route-effects'
+import { optionalString, readJsonObject } from './json-boundary'
 import { logWorkerRouteError } from './observability'
 import { PROVIDER_ACCOUNT_LEASE_POLICY_VERSION } from './provider-account-lease-policy'
 import {
@@ -105,6 +106,12 @@ export type ProviderAccountPoolResponse = Readonly<{
   activeLeases: ReadonlyArray<ProviderAccountPoolLease>
   nextSelection: ProviderAccountPoolNextSelection
   summary: ProviderAccountPoolSummary
+}>
+
+export type ProviderAccountPoolManualResetResponse = Readonly<{
+  ok: true
+  providerAccountRef: string
+  resetAt: string
 }>
 
 type PoolAccountRow = Readonly<{
@@ -530,12 +537,53 @@ class ProviderAccountPoolProjectionError extends Error {
   override readonly name = 'ProviderAccountPoolProjectionError'
 }
 
+class ProviderAccountPoolBadRequest extends Error {
+  override readonly name = 'ProviderAccountPoolBadRequest'
+}
+
 const poolProjectionError = (
   error: unknown,
 ): ProviderAccountPoolProjectionError =>
   new ProviderAccountPoolProjectionError(
     error instanceof Error ? error.message : String(error),
   )
+
+const readManualResetProviderAccountRef = async (
+  request: Request,
+): Promise<string> => {
+  const body = await readJsonObject(request)
+  const providerAccountRef = optionalString(body.providerAccountRef)
+
+  if (providerAccountRef === undefined) {
+    throw new ProviderAccountPoolBadRequest()
+  }
+
+  return providerAccountRef
+}
+
+const resetProviderAccountPoolAccount = async (
+  db: D1Database,
+  input: Readonly<{
+    providerAccountRef: string
+    resetAt: string
+    userId: string
+  }>,
+): Promise<boolean> => {
+  const result = await db
+    .prepare(
+      `UPDATE provider_accounts
+          SET cooldown_until = NULL,
+              recent_failure_class = NULL,
+              updated_at = ?
+        WHERE user_id = ?
+          AND provider_account_ref = ?
+          AND deleted_at IS NULL`,
+    )
+    .bind(input.resetAt, input.userId, input.providerAccountRef)
+    .run()
+
+  return (result.meta?.changes ?? 0) > 0
+}
 
 const agentAuthFailureStatus = (
   failure: CustomerOrderAgentAuthFailure,
@@ -557,11 +605,71 @@ export const makeProviderAccountPoolRoutes = <
     ctx: ExecutionContext,
   ): RouteEffect =>
     Effect.gen(function* () {
-      if (request.method !== 'GET') {
+      const pathname = new URL(request.url).pathname
+      const isReset = pathname === '/api/provider-accounts/pool/reset'
+
+      if (!isReset && request.method !== 'GET') {
         return methodNotAllowed(['GET'])
       }
 
+      if (isReset && request.method !== 'POST') {
+        return methodNotAllowed(['POST'])
+      }
+
       const now = dependencies.nowIso?.() ?? currentIsoTimestamp()
+
+      if (isReset) {
+        if (hasBearerAuthorization(request)) {
+          return noStoreJsonResponse(
+            { error: 'browser_session_required' },
+            { status: 401 },
+          )
+        }
+
+        const session = yield* Effect.tryPromise({
+          catch: poolProjectionError,
+          try: () => dependencies.requireBrowserSession(request, env, ctx),
+        })
+
+        if (session === undefined) {
+          return yield* Effect.fail(new ProviderAccountPoolSessionMissing())
+        }
+
+        const providerAccountRef = yield* Effect.tryPromise({
+          catch: error =>
+            error instanceof ProviderAccountPoolBadRequest
+              ? error
+              : poolProjectionError(error),
+          try: () => readManualResetProviderAccountRef(request),
+        })
+        const reset = yield* Effect.tryPromise({
+          catch: poolProjectionError,
+          try: () =>
+            resetProviderAccountPoolAccount(openAgentsDatabase(env), {
+              providerAccountRef,
+              resetAt: now,
+              userId: session.user.userId,
+            }),
+        })
+
+        if (!reset) {
+          return noStoreJsonResponse(
+            { error: 'provider_account_not_found' },
+            { status: 404 },
+          )
+        }
+
+        const response: ProviderAccountPoolManualResetResponse = {
+          ok: true,
+          providerAccountRef,
+          resetAt: now,
+        }
+
+        return dependencies.appendRefreshedSessionCookies(
+          noStoreJsonResponse(response),
+          session,
+        )
+      }
 
       if (hasBearerAuthorization(request)) {
         const auth = yield* authenticateCustomerOrderAgentRequest(
@@ -621,6 +729,15 @@ export const makeProviderAccountPoolRoutes = <
         if (error instanceof ProviderAccountPoolSessionMissing) {
           return Effect.succeed(
             noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 }),
+          )
+        }
+
+        if (error instanceof ProviderAccountPoolBadRequest) {
+          return Effect.succeed(
+            noStoreJsonResponse(
+              { error: 'provider_account_ref_required' },
+              { status: 400 },
+            ),
           )
         }
 

--- a/apps/openagents.com/workers/api/src/provider-account-routes.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-routes.ts
@@ -134,7 +134,10 @@ export const makeProviderAccountRoutes = <Bindings = OpenAgentsEnv>(
       )
     }
 
-    if (url.pathname === '/api/provider-accounts/pool') {
+    if (
+      url.pathname === '/api/provider-accounts/pool' ||
+      url.pathname === '/api/provider-accounts/pool/reset'
+    ) {
       return routeEffectOrResponse(
         dependencies.handleProviderAccountPoolApi(request, env, ctx),
       )


### PR DESCRIPTION
Addresses #6666.

### Changes
- Added a provider account pool manual reset POST route and OpenAPI response schema.
- Wired the settings Reset button to dispatch the manual reset command, parse the API response, and surface success/failure messages.
- Added optimistic UI state handling so resettable pool accounts clear cooldown/failure state immediately and refresh after the POST succeeds.
- Added API and web tests covering manual reset authorization, cooldown clearing, optimistic updates, and refresh behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)