### PR TITLE
feat(web): add rate limit countdown timer

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/settings.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/settings.ts
@@ -496,7 +496,33 @@ const settingsGitHubRepositoryPanel = (model: Model): Html => {
   )
 }
 
-const poolValueRow = (label: string, value: string): Html => {
+export const formatRateLimitCountdown = (
+  remainingSeconds: number | null,
+): string => {
+  if (remainingSeconds === null) {
+    return 'reset pending'
+  }
+
+  const bounded = Math.max(0, Math.floor(remainingSeconds))
+  const hours = Math.floor(bounded / 3600)
+  const minutes = Math.floor((bounded % 3600) / 60)
+  const seconds = bounded % 60
+  const parts =
+    hours > 0
+      ? [hours, minutes, seconds]
+      : [minutes, seconds]
+
+  return parts.map(part => String(part).padStart(2, '0')).join(':')
+}
+
+export const rateLimitCountdownTitle = (
+  cooldownUntil: string | null,
+): string =>
+  cooldownUntil === null
+    ? 'Rate limit reset time unavailable'
+    : `Rate limit resets at ${formatIsoDateTime(cooldownUntil)}`
+
+const poolValueContentRow = (label: string, content: Html): Html => {
   const h = html<Message>()
 
   return h.div(
@@ -507,15 +533,24 @@ const poolValueRow = (label: string, value: string): Html => {
     ],
     [
       h.span([Ui.className<Message>('min-w-0 text-white/35')], [label]),
-      h.span(
-        [
-          Ui.className<Message>(
-            'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-white/80',
-          ),
-        ],
-        [value],
-      ),
+      content,
     ],
+  )
+}
+
+const poolValueRow = (label: string, value: string): Html => {
+  const h = html<Message>()
+
+  return poolValueContentRow(
+    label,
+    h.span(
+      [
+        Ui.className<Message>(
+          'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-white/80',
+        ),
+      ],
+      [value],
+    ),
   )
 }
 
@@ -525,6 +560,32 @@ const poolCooldownLabel = (account: ProviderAccountPoolAccount): string =>
     : account.cooldownRemainingSeconds === null
       ? `ended ${formatIsoDateTime(account.cooldownUntil)}`
       : `until ${formatIsoDateTime(account.cooldownUntil)} (~${Math.max(1, Math.ceil(account.cooldownRemainingSeconds / 60))}m)`
+
+export const rateLimitCountdownView = (
+  account: Pick<
+    ProviderAccountPoolAccount,
+    'cooldownRemainingSeconds' | 'cooldownUntil'
+  >,
+): Html => {
+  const h = html<Message>()
+  const elapsed =
+    account.cooldownRemainingSeconds !== null &&
+    account.cooldownRemainingSeconds <= 0
+
+  return h.time(
+    [
+      h.Attribute('data-rate-limit-countdown', 'true'),
+      ...(account.cooldownUntil === null
+        ? []
+        : [h.Attribute('datetime', account.cooldownUntil)]),
+      h.Attribute('aria-label', rateLimitCountdownTitle(account.cooldownUntil)),
+      Ui.className<Message>(
+        `inline-flex h-6 min-w-[4.75rem] items-center justify-center border px-2 font-mono text-xs tabular-nums ${elapsed ? 'border-[#333] text-white/45' : 'border-[#ff6f00]/60 text-[#ffb400]'}`,
+      ),
+    ],
+    [formatRateLimitCountdown(account.cooldownRemainingSeconds)],
+  )
+}
 
 const poolAccountTone = (account: ProviderAccountPoolAccount): string =>
   account.reconnect.needed
@@ -611,6 +672,31 @@ const poolAccountView = (account: ProviderAccountPoolAccount): Html => {
           ),
           poolValueRow('Status', `${account.status} / ${account.health}`),
           poolValueRow('Cooldown', poolCooldownLabel(account)),
+          ...(account.cooldownUntil === null
+            ? []
+            : [
+                poolValueContentRow(
+                  'Rate limit',
+                  h.span(
+                    [
+                      Ui.className<Message>(
+                        'flex min-w-0 flex-wrap items-center gap-2 text-white/80',
+                      ),
+                    ],
+                    [
+                      rateLimitCountdownView(account),
+                      h.span(
+                        [
+                          Ui.className<Message>(
+                            'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-white/35',
+                          ),
+                        ],
+                        ['until reset'],
+                      ),
+                    ],
+                  ),
+                ),
+              ]),
           ...(account.lowCredit ? [poolValueRow('Credits', 'low')] : []),
           ...(account.recentFailureClass === null
             ? []

--- a/apps/openagents.com/apps/web/src/page/loggedIn/providers/pool.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/providers/pool.test.ts
@@ -4,6 +4,7 @@ import {
   ProviderConnectionAttemptId,
   IsoTimestamp as ProviderIsoTimestamp,
 } from '@openagentsinc/provider-account-schema'
+import type { Html } from 'foldkit/html'
 import { describe, expect, test } from 'vitest'
 
 import {
@@ -18,7 +19,69 @@ import {
   SucceededPollProviderDeviceLogin,
 } from '../message'
 import { type ProviderAccountPoolResponse, init } from '../model'
+import {
+  formatRateLimitCountdown,
+  rateLimitCountdownTitle,
+  rateLimitCountdownView,
+} from '../page/settings'
 import { initialCommands, update } from '../update'
+
+type VNodeLike = Readonly<{
+  children?: ReadonlyArray<VNodeLike | string | null>
+  data?: {
+    attrs?: Record<string, unknown>
+    class?: Record<string, boolean>
+    props?: Record<string, unknown>
+  }
+  sel?: string
+  text?: string
+}>
+
+const isVNodeLike = (value: unknown): value is VNodeLike =>
+  typeof value === 'object' && value !== null
+
+const attrsToString = (node: VNodeLike): string => {
+  const attrs = node.data?.attrs ?? {}
+  const props = node.data?.props ?? {}
+  const classes = Object.entries(node.data?.class ?? {})
+    .filter(([, enabled]) => enabled)
+    .map(([className]) => className)
+    .join(' ')
+  const pairs = [
+    ...Object.entries(attrs),
+    ...Object.entries(props),
+    ...(classes.length === 0 ? [] : [['class', classes] as const]),
+  ]
+
+  return pairs
+    .filter(
+      ([, value]) => value !== false && value !== undefined && value !== null,
+    )
+    .map(([name, value]) =>
+      value === true ? ` ${name}` : ` ${name}="${String(value)}"`,
+    )
+    .join('')
+}
+
+const renderHtml = (html: Html): string => {
+  if (html === null || !isVNodeLike(html)) {
+    return ''
+  }
+
+  const tag = html.sel ?? 'node'
+  const children = (html.children ?? [])
+    .map(child =>
+      typeof child === 'string'
+        ? child
+        : child === null
+          ? ''
+          : renderHtml(child),
+    )
+    .join('')
+  const text = html.text ?? ''
+
+  return `<${tag}${attrsToString(html)}>${text}${children}</${tag}>`
+}
 
 const auth = authBootstrapFromSession({
   email: 'chris@openagents.com',
@@ -150,6 +213,30 @@ const connectedDeviceLoginStatus = {
 } satisfies ProviderDeviceLoginStatusResponse
 
 describe('provider account pool', () => {
+  test('formats rate-limit countdowns as stable timer text', () => {
+    expect(formatRateLimitCountdown(300)).toBe('05:00')
+    expect(formatRateLimitCountdown(65)).toBe('01:05')
+    expect(formatRateLimitCountdown(3661)).toBe('01:01:01')
+    expect(formatRateLimitCountdown(-4)).toBe('00:00')
+    expect(formatRateLimitCountdown(null)).toBe('reset pending')
+  })
+
+  test('renders rate-limited accounts with a semantic countdown timer', () => {
+    const rendered = renderHtml(
+      rateLimitCountdownView({
+        cooldownRemainingSeconds: 300,
+        cooldownUntil: '2026-06-11T12:05:00.000Z',
+      }),
+    )
+
+    expect(rendered).toContain('data-rate-limit-countdown="true"')
+    expect(rendered).toContain('datetime="2026-06-11T12:05:00.000Z"')
+    expect(rendered).toContain('05:00')
+    expect(rateLimitCountdownTitle('2026-06-11T12:05:00.000Z')).toContain(
+      'Rate limit resets at ',
+    )
+  })
+
   test('settings connections route loads the account pool', () => {
     const model = init(SettingsSectionRoute({ section: 'connections' }), auth)
 


### PR DESCRIPTION
Addresses #6665.

### Changes
- Added rate limit countdown formatting and title helpers for provider account cooldowns.
- Rendered a semantic countdown timer for rate-limited provider accounts in settings.
- Added provider pool tests covering countdown formatting and timer markup.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)