### PR TITLE
feat(web): add rate limit countdowns for accounts

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/settings.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/settings.ts
@@ -496,7 +496,7 @@ const settingsGitHubRepositoryPanel = (model: Model): Html => {
   )
 }
 
-const poolValueRow = (label: string, value: string): Html => {
+const poolNodeRow = (label: string, value: Html): Html => {
   const h = html<Message>()
 
   return h.div(
@@ -519,12 +519,56 @@ const poolValueRow = (label: string, value: string): Html => {
   )
 }
 
-const poolCooldownLabel = (account: ProviderAccountPoolAccount): string =>
-  account.cooldownUntil === null
-    ? 'none'
-    : account.cooldownRemainingSeconds === null
-      ? `ended ${formatIsoDateTime(account.cooldownUntil)}`
-      : `until ${formatIsoDateTime(account.cooldownUntil)} (~${Math.max(1, Math.ceil(account.cooldownRemainingSeconds / 60))}m)`
+const poolValueRow = (label: string, value: string): Html => {
+  const h = html<Message>()
+
+  return poolNodeRow(label, h.span([], [value]))
+}
+
+const formatCountdownSeconds = (seconds: number): string => {
+  if (seconds <= 0) return 'now'
+
+  const totalMinutes = Math.max(1, Math.ceil(seconds / 60))
+  const days = Math.floor(totalMinutes / 1_440)
+  const hours = Math.floor((totalMinutes % 1_440) / 60)
+  const minutes = totalMinutes % 60
+
+  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  return `${minutes}m`
+}
+
+const poolCooldownLabel = (account: ProviderAccountPoolAccount): string => {
+  if (account.cooldownUntil === null) return 'none'
+  if (account.cooldownRemainingSeconds === null) {
+    return `ended ${formatIsoDateTime(account.cooldownUntil)}`
+  }
+
+  const prefix =
+    account.recentFailureClass === 'rate_limited'
+      ? 'rate limit resets'
+      : 'cooldown clears'
+  return `${prefix} in ${formatCountdownSeconds(account.cooldownRemainingSeconds)} (${formatIsoDateTime(account.cooldownUntil)})`
+}
+
+const poolCooldownRow = (account: ProviderAccountPoolAccount): Html => {
+  const h = html<Message>()
+  const label = poolCooldownLabel(account)
+
+  return poolNodeRow(
+    'Cooldown',
+    account.cooldownUntil === null
+      ? h.span([], [label])
+      : h.time(
+          [
+            h.Attribute('datetime', account.cooldownUntil),
+            h.DataAttribute('provider-account-cooldown-countdown', label),
+            h.DataAttribute('provider-account-cooldown-until', account.cooldownUntil),
+          ],
+          [label],
+        ),
+  )
+}
 
 const poolAccountTone = (account: ProviderAccountPoolAccount): string =>
   account.reconnect.needed
@@ -610,7 +654,7 @@ const poolAccountView = (account: ProviderAccountPoolAccount): Html => {
             `${account.activeLeaseCount}/${account.leaseLimit} active`,
           ),
           poolValueRow('Status', `${account.status} / ${account.health}`),
-          poolValueRow('Cooldown', poolCooldownLabel(account)),
+          poolCooldownRow(account),
           ...(account.lowCredit ? [poolValueRow('Credits', 'low')] : []),
           ...(account.recentFailureClass === null
             ? []

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
@@ -3825,4 +3825,82 @@ describe('logged-in workroom sidebar', () => {
       ).toExist(),
     )
   })
+
+  test('renders provider account cooldown countdown in settings connections', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with({
+        ...LoggedIn.init(
+          SettingsSectionRoute({ section: 'connections' }),
+          authWithHealthyProviderAccount,
+        ),
+        providerAccountPool: ProviderAccountPoolLoaded({
+          response: {
+            accounts: [
+              {
+                accountLabel: 'limited@openagents.com',
+                activeLeaseCount: 0,
+                connectedAt: '2026-06-10T00:00:00.000Z',
+                cooldownRemainingSeconds: 300,
+                cooldownUntil: '2026-06-11T12:05:00.000Z',
+                eligibility: 'ineligible',
+                eligibilityReasons: ['cooldown'],
+                health: 'healthy',
+                lastFailedLaunchAt: '2026-06-11T11:50:00.000Z',
+                lastParallelProbeAt: null,
+                lastParallelProbeResult: null,
+                lastSanityCheckAt: null,
+                lastSanityCheckResult: null,
+                lastSelectedAt: null,
+                lastSuccessfulLaunchAt: null,
+                leaseLimit: 2,
+                lowCredit: false,
+                operatorPriority: 100,
+                provider: 'chatgpt_codex',
+                providerAccountRef: 'provider-account_limited',
+                recentFailureClass: 'rate_limited',
+                reconnect: { needed: false, reason: null },
+                status: 'connected',
+              },
+            ],
+            activeLeases: [],
+            generatedAt: '2026-06-11T12:00:00.000Z',
+            nextSelection: {
+              accountLabel: null,
+              activeLeaseCount: null,
+              leaseLimit: null,
+              provider: null,
+              providerAccountRef: null,
+              selectionReason: 'No account selected while all accounts cool down.',
+              status: 'none',
+            },
+            policyVersion: 'provider-account-lease-policy:v2',
+            provider: 'all_connected_provider_accounts',
+            summary: {
+              activeLeaseCount: 0,
+              cooldown: 1,
+              eligible: 0,
+              lowCredit: 0,
+              requiresReauth: 0,
+              total: 1,
+              unhealthy: 0,
+            },
+          },
+        }),
+      }),
+      Scene.expect(Scene.text('limited@openagents.com')).toExist(),
+      Scene.expect(
+        Scene.selector('[data-provider-account-cooldown-countdown]'),
+      ).toHaveAttr(
+        'data-provider-account-cooldown-countdown',
+        'rate limit resets in 5m (6/11/2026, 7:05:00 AM)',
+      ),
+      Scene.expect(
+        Scene.selector('[data-provider-account-cooldown-countdown]'),
+      ).toHaveAttr(
+        'data-provider-account-cooldown-until',
+        '2026-06-11T12:05:00.000Z',
+      ),
+    )
+  })
 })

--- a/packages/autopilot-ui/src/accounts.ts
+++ b/packages/autopilot-ui/src/accounts.ts
@@ -11,6 +11,7 @@ export type AccountSummary = Readonly<{
     used: number
     limit: number
   }
+  rateLimitResetAt?: string | null
 }>
 
 const h = html<AutopilotUiMessage>()
@@ -39,11 +40,105 @@ const quotaTone = (account: AccountSummary): ChipTone => {
 const quotaLabel = (usage: AccountSummary["usage"]): string =>
   usage === undefined ? "quota: unknown" : `quota: ${usage.used}/${usage.limit}`
 
-export const AccountRow = (account: AccountSummary): Html =>
+type CountdownProjection = Readonly<{
+  label: string
+  tone: ChipTone
+  resetAt: string | null
+  remainingMs: number | null
+}>
+
+const parseEpochMs = (value: string | number | Date | undefined): number => {
+  if (value instanceof Date) return value.getTime()
+  if (typeof value === "number") return value
+  if (typeof value === "string") return Date.parse(value)
+  return Date.now()
+}
+
+const countdownLabel = (remainingMs: number): string => {
+  if (remainingMs <= 0) return "reset due"
+
+  const totalMinutes = Math.max(1, Math.ceil(remainingMs / 60_000))
+  const days = Math.floor(totalMinutes / 1_440)
+  const hours = Math.floor((totalMinutes % 1_440) / 60)
+  const minutes = totalMinutes % 60
+
+  if (days > 0) {
+    return hours > 0 ? `resets in ${days}d ${hours}h` : `resets in ${days}d`
+  }
+  if (hours > 0) {
+    return minutes > 0 ? `resets in ${hours}h ${minutes}m` : `resets in ${hours}h`
+  }
+  return `resets in ${minutes}m`
+}
+
+export const rateLimitCountdownProjection = (input: {
+  resetAt?: string | null
+  now?: string | number | Date
+}): CountdownProjection => {
+  const resetAt = input.resetAt?.trim() ?? null
+  if (resetAt === null || resetAt === "") {
+    return { label: "reset: unknown", tone: "neutral", resetAt: null, remainingMs: null }
+  }
+
+  const resetEpochMs = Date.parse(resetAt)
+  const nowEpochMs = parseEpochMs(input.now)
+  if (!Number.isFinite(resetEpochMs) || !Number.isFinite(nowEpochMs)) {
+    return { label: "reset: invalid", tone: "danger", resetAt, remainingMs: null }
+  }
+
+  const remainingMs = resetEpochMs - nowEpochMs
+  return {
+    label: countdownLabel(remainingMs),
+    tone: remainingMs <= 0 ? "info" : "warning",
+    resetAt,
+    remainingMs,
+  }
+}
+
+export const RateLimitCountdown = (input: {
+  resetAt?: string | null
+  now?: string | number | Date
+  attrs?: ReadonlyArray<Attribute<AutopilotUiMessage>>
+}): Html => {
+  const countdown = rateLimitCountdownProjection(input)
+  const attrs = [
+    h.DataAttribute("autopilot-rate-limit-countdown", countdown.label),
+    ...(countdown.resetAt === null
+      ? []
+      : [
+          h.Attribute("datetime", countdown.resetAt),
+          h.DataAttribute("autopilot-rate-limit-reset-at", countdown.resetAt),
+        ]),
+    ...(input.attrs ?? []),
+  ]
+
+  return h.time(attrs, [
+    statusChip({
+      label: countdown.label,
+      tone: countdown.tone,
+    }),
+  ])
+}
+
+const accountCountdown = (
+  account: AccountSummary,
+  options?: { now?: string | number | Date },
+): Html =>
+  account.state === "quota_blocked" || account.rateLimitResetAt != null
+    ? RateLimitCountdown({
+        ...(account.rateLimitResetAt === undefined ? {} : { resetAt: account.rateLimitResetAt }),
+        ...(options?.now === undefined ? {} : { now: options.now }),
+      })
+    : h.empty
+
+export const AccountRow = (
+  account: AccountSummary,
+  options?: { now?: string | number | Date },
+): Html =>
   h.article(
     [
       className(
-        "account-row grid gap-2 border border-[var(--outline,#525458)] bg-[var(--bg-secondary,#151515)] p-3 text-[var(--text,#d7d8e5)] sm:grid-cols-[minmax(0,1.7fr)_7rem_8rem_8rem] sm:items-center",
+        "account-row grid gap-2 border border-[var(--outline,#525458)] bg-[var(--bg-secondary,#151515)] p-3 text-[var(--text,#d7d8e5)] sm:grid-cols-[minmax(0,1.7fr)_7rem_8rem_8rem_minmax(8rem,10rem)] sm:items-center",
       ),
       h.DataAttribute("autopilot-account-ref", account.accountRefHash),
     ],
@@ -64,12 +159,14 @@ export const AccountRow = (account: AccountSummary): Html =>
         tone: quotaTone(account),
         attrs: [h.DataAttribute("autopilot-account-quota", account.accountRefHash)],
       }),
+      accountCountdown(account, options),
     ],
   )
 
 export const AccountList = (input: {
   accounts: ReadonlyArray<AccountSummary>
   emptyLabel?: string
+  now?: string | number | Date
 }): Html =>
   h.section(
     [className("grid gap-2"), h.DataAttribute("autopilot-account-list", "")],
@@ -79,5 +176,7 @@ export const AccountList = (input: {
             input.emptyLabel ?? "No accounts",
           ]),
         ]
-      : input.accounts.map(AccountRow),
+      : input.accounts.map((account) =>
+          AccountRow(account, input.now === undefined ? undefined : { now: input.now }),
+        ),
   )

--- a/packages/autopilot-ui/test/accounts.test.ts
+++ b/packages/autopilot-ui/test/accounts.test.ts
@@ -11,7 +11,7 @@ Object.assign(globalThis, {
   },
 })
 
-const { AccountList } = await import("../src/accounts")
+const { AccountList, rateLimitCountdownProjection } = await import("../src/accounts")
 
 type VNodeLike = Readonly<{
   sel?: string
@@ -72,10 +72,13 @@ describe("Autopilot account components", () => {
         provider: "claude",
         state: "quota_blocked",
         usage: { used: 10, limit: 10 },
+        rateLimitResetAt: "2026-06-28T16:45:00Z",
       },
     ] satisfies ReadonlyArray<AccountSummary>
 
-    const rendered = renderHtml(AccountList({ accounts }))
+    const rendered = renderHtml(
+      AccountList({ accounts, now: "2026-06-28T15:00:00Z" }),
+    )
 
     expect(rendered).toContain('data-autopilot-account-list=""')
     expect(rendered).toContain("acct.hash.ready0001")
@@ -84,5 +87,52 @@ describe("Autopilot account components", () => {
     expect(rendered).toContain('data-autopilot-account-state="quota_blocked"')
     expect(rendered).toContain("quota: 4/10")
     expect(rendered).toContain("quota: 10/10")
+    expect(rendered).toContain('datetime="2026-06-28T16:45:00Z"')
+    expect(rendered).toContain('data-autopilot-rate-limit-reset-at="2026-06-28T16:45:00Z"')
+    expect(rendered).toContain("resets in 1h 45m")
+  })
+
+  test("renders an honest unknown countdown for blocked accounts without reset evidence", () => {
+    const accounts = [
+      {
+        accountRefHash: "acct.hash.blocked0003",
+        provider: "codex",
+        state: "quota_blocked",
+      },
+    ] satisfies ReadonlyArray<AccountSummary>
+
+    const rendered = renderHtml(AccountList({ accounts, now: "2026-06-28T15:00:00Z" }))
+
+    expect(rendered).toContain('data-autopilot-rate-limit-countdown="reset: unknown"')
+    expect(rendered).toContain("reset: unknown")
+  })
+
+  test("projects rate-limit countdown labels without wall-clock dependency", () => {
+    expect(rateLimitCountdownProjection({
+      resetAt: "2026-06-28T17:00:00Z",
+      now: "2026-06-28T15:00:00Z",
+    })).toMatchObject({
+      label: "resets in 2h",
+      tone: "warning",
+      resetAt: "2026-06-28T17:00:00Z",
+      remainingMs: 7_200_000,
+    })
+
+    expect(rateLimitCountdownProjection({
+      resetAt: "2026-06-28T14:59:00Z",
+      now: "2026-06-28T15:00:00Z",
+    })).toMatchObject({
+      label: "reset due",
+      tone: "info",
+    })
+
+    expect(rateLimitCountdownProjection({
+      resetAt: "not-a-date",
+      now: "2026-06-28T15:00:00Z",
+    })).toMatchObject({
+      label: "reset: invalid",
+      tone: "danger",
+      remainingMs: null,
+    })
   })
 })


### PR DESCRIPTION
Addresses #6665.

### Changes
- Added provider account cooldown countdown rendering in settings connections, including rate-limit-specific reset copy and countdown metadata attributes.
- Added `rateLimitResetAt` support to autopilot account summaries and account row countdown display logic.
- Added scene and package tests covering rate-limited account countdown rendering.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).