### PR TITLE
fix(mirrorcode-backstop): authenticate Khala /api/v1 + fail-loud + burn smoke (#6735)

### DIFF
--- a/apps/openagents.com/scripts/mirrorcode/.gitignore
+++ b/apps/openagents.com/scripts/mirrorcode/.gitignore
@@ -1,0 +1,2 @@
+# Generated backstop burn output (issue #6735) — runtime artifacts, never committed.
+results/backstop/

--- a/apps/openagents.com/scripts/mirrorcode/README.md
+++ b/apps/openagents.com/scripts/mirrorcode/README.md
@@ -27,8 +27,22 @@ What it does, per problem:
 ```sh
 ./backstop-run.sh                 # mint a free Khala key, run the bounded batch
 OPENAI_API_KEY=oa_agent_xxx ./backstop-run.sh --limit 8
+MC_BACKSTOP_SMOKE=1 ./backstop-run.sh     # burn smoke: one live call, nonzero on 0-burn
 MC_BACKSTOP_DRY_RUN=1 ./backstop-run.sh   # diagnostic: no model call, no spend
 ```
+
+**Auth & burn correctness (issue #6735).** Own-capacity inference authenticates
+to the Khala OpenAI-compatible endpoint (`POST /api/v1/chat/completions`) with a
+Bearer `oa_agent_` token -- either one you pass in `OPENAI_API_KEY` or a free key
+the runner mints at `POST /api/keys/free`. The Khala endpoint is behind
+Cloudflare, which **403s the default `Python-urllib` User-Agent** (`error code:
+1010`) before the request reaches the Worker; the runner now always sends an
+explicit `User-Agent`, so the call returns 200 and burns real tokens. The runner
+**fails loud** (nonzero exit + the exact status on stderr) when the model call is
+unauthorized (401), WAF-blocked (403), payment-gated (402), or returns zero usage
+-- it never silently produces an all-failed / 0-burn run. Every live run first
+does a one-call **burn preflight** that asserts real usage tokens before spending
+the batch; `MC_BACKSTOP_SMOKE=1` runs that preflight standalone.
 
 Problem source: the built-in **public-domain fixture set** (classic toy
 functions — sum, reverse, palindrome, factorial, gcd, FizzBuzz, …). These are

--- a/apps/openagents.com/scripts/mirrorcode/backstop-run.sh
+++ b/apps/openagents.com/scripts/mirrorcode/backstop-run.sh
@@ -27,6 +27,7 @@
 #   MC_BACKSTOP_OUT       results dir (default ./results/backstop)
 #   MC_BACKSTOP_MODEL     model id (default openagents/khala)
 #   MC_BACKSTOP_DRY_RUN   set to 1 to skip the live model (diagnostic; no spend)
+#   MC_BACKSTOP_SMOKE     set to 1 for a burn smoke only (one live call; nonzero on 0-burn)
 
 set -euo pipefail
 
@@ -50,7 +51,7 @@ if [[ -z "${OPENAI_API_KEY:-}" ]]; then
   command -v curl >/dev/null 2>&1 || { echo "ERROR: 'curl' needed to mint a free Khala key" >&2; exit 2; }
   echo "Minting a free Khala key (own-capacity, \$0)..."
   base="${OPENAI_BASE_URL%/api/v1}"
-  OPENAI_API_KEY="$(curl -fsS -X POST "${base}/api/keys/free" 2>/dev/null | "$PYTHON_BIN" -c 'import sys,json;
+  OPENAI_API_KEY="$(curl -fsS -A "openagents-mirrorcode-backstop/1.0" -X POST "${base}/api/keys/free" 2>/dev/null | "$PYTHON_BIN" -c 'import sys,json;
 try:
     print(json.load(sys.stdin).get("credential",{}).get("token",""))
 except Exception:
@@ -62,7 +63,19 @@ except Exception:
 fi
 export OPENAI_API_KEY
 echo "Khala endpoint   : ${OPENAI_BASE_URL} (key ${OPENAI_API_KEY:0:12}...)"
+# BURN SMOKE (issue #6735): one live own-capacity call that FAILS LOUD (nonzero)
+# if it does not actually burn tokens. Use before trusting the backstop for burn.
+if [[ "${MC_BACKSTOP_SMOKE:-0}" == "1" ]]; then
+  echo "Running backstop burn smoke (one live own-capacity call)..."
+  exec "$PYTHON_BIN" "${SCRIPT_DIR}/backstop_eval.py" --smoke \
+    --model "${MC_BACKSTOP_MODEL:-openagents/khala}" "$@"
+fi
+
 echo "Launching gym backstop (own-capacity \$0 high-density fixture eval)..."
 
+# The Python runner runs a burn PREFLIGHT before the batch and exits nonzero
+# (fail loud) if the own-capacity path is unauthorized / WAF-blocked / 0-burn;
+# `exec` propagates that exit code so this script never silently reports a
+# successful 0-burn run.
 exec "$PYTHON_BIN" "${SCRIPT_DIR}/backstop_eval.py" --live \
   --limit "${MC_BACKSTOP_LIMIT:-8}" --out "$OUT" --model "${MC_BACKSTOP_MODEL:-openagents/khala}" "$@"

--- a/apps/openagents.com/scripts/mirrorcode/backstop_eval.py
+++ b/apps/openagents.com/scripts/mirrorcode/backstop_eval.py
@@ -285,6 +285,7 @@ def evaluate_batch(
     finished = _now_iso()
     agg_pass_rate = (total_passed / total_cases) if total_cases else 0.0
     fully_solved = sum(1 for p in per_problem if p["status"] == "passed")
+    model_error_count = sum(1 for p in per_problem if p.get("modelError"))
     summary = {
         "runId": run_id,
         "model": model_name,
@@ -302,6 +303,7 @@ def evaluate_batch(
         "demand": DEMAND,
         "grade": "backstop",
         "decisionGrade": False,
+        "modelErrorCount": model_error_count,
         "perProblem": [
             {"problemId": p["problemId"], "passed": p["passed"], "total": p["total"], "passRate": p["passRate"], "status": p["status"]}
             for p in per_problem
@@ -313,6 +315,110 @@ def evaluate_batch(
 
 
 # --- Live Khala model function -------------------------------------------------
+# IMPORTANT (issue #6735): the Khala endpoint sits behind Cloudflare, which
+# blocks the default stdlib `Python-urllib/<ver>` User-Agent with HTTP 403
+# (`error code: 1010`) BEFORE the request ever reaches the Worker. That 403 was
+# being swallowed per-problem as a fail-soft `model_call_failed`, so the whole
+# backstop produced all-failed / 0-burn runs while exiting 0 -- looking like an
+# auth failure ("unauthorized") when it was really a WAF block. We MUST send an
+# explicit, non-default User-Agent on every request (mint + chat + counter).
+USER_AGENT = "openagents-mirrorcode-backstop/1.0 (+https://openagents.com; issue-6735)"
+
+
+class KhalaCallError(RuntimeError):
+    """A loud, attributable failure of a live Khala call (auth/HTTP/transport).
+
+    Carries the HTTP status (when known) and a short public-safe body snippet so
+    the runner can FAIL LOUD with the exact reason instead of silently producing
+    a 0-burn run.
+    """
+
+    def __init__(self, message: str, status: Optional[int] = None, body: str = "") -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def _public_base(base_url: str) -> str:
+    """Strip the `/api/v1` OpenAI-compat suffix to get the site origin."""
+    b = base_url.rstrip("/")
+    for suffix in ("/api/v1", "/v1"):
+        if b.endswith(suffix):
+            return b[: -len(suffix)]
+    return b
+
+
+def _khala_chat_raw(
+    url: str,
+    api_key: str,
+    model: str,
+    prompt: str,
+    timeout: float,
+) -> Dict[str, Any]:
+    """POST one chat completion and return the parsed body.
+
+    Raises KhalaCallError (loud) on any HTTP / transport failure, reading the
+    error body so the caller can report the exact status (401 unauthorized, 403
+    WAF block, 402 payment required, etc.).
+    """
+    import urllib.error
+    import urllib.request
+
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": "You are a precise Python coding assistant. Respond with only the requested function in a single python code block."},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": 0,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(url, data=payload, method="POST")
+    req.add_header("Content-Type", "application/json")
+    # Non-default UA is REQUIRED: see the Cloudflare note above.
+    req.add_header("User-Agent", USER_AGENT)
+    if api_key:
+        req.add_header("Authorization", "Bearer " + api_key)
+    req.add_header("x-openagents-demand-kind", DEMAND["kind"])
+    req.add_header("x-openagents-demand-source", DEMAND["source"])
+    req.add_header("x-openagents-client", DEMAND["client"])
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        try:
+            body = exc.read().decode("utf-8", "replace")[:500]
+        except Exception:
+            body = ""
+        raise KhalaCallError(
+            "khala_http_error status=%s" % exc.code, status=exc.code, body=body
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise KhalaCallError("khala_transport_error: %r" % exc.reason) from exc
+
+
+def fetch_tokens_served(base_url: str, timeout: float = 30.0) -> Optional[int]:
+    """Read the public `khala-tokens-served` counter; None if unavailable.
+
+    Best-effort supporting evidence for the burn smoke. Never raises (the strong
+    burn signal is our own call's reported usage, not this shared counter).
+    """
+    import urllib.error
+    import urllib.request
+
+    url = _public_base(base_url) + "/api/public/khala-tokens-served"
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("User-Agent", USER_AGENT)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+        val = body.get("tokensServed")
+        return int(val) if val is not None else None
+    except (urllib.error.HTTPError, urllib.error.URLError, ValueError, TypeError, KeyError):
+        return None
+
+
 def khala_model_fn(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
@@ -323,38 +429,76 @@ def khala_model_fn(
 
     Own-capacity ($0) path. Uses only stdlib urllib so the backstop has no
     third-party dependency. Tags the request with the gym-backstop demand
-    attribution headers so the load is auditably an internal eval.
+    attribution headers so the load is auditably an internal eval, and sends a
+    non-default User-Agent so Cloudflare does not 403 the call (issue #6735).
     """
-    import urllib.request
-
     base_url = (base_url or os.environ.get("OPENAI_BASE_URL") or "https://openagents.com/api/v1").rstrip("/")
     api_key = api_key or os.environ.get("OPENAI_API_KEY") or ""
     url = base_url + "/chat/completions"
 
     def _call(prompt: str) -> str:
-        payload = json.dumps(
-            {
-                "model": model,
-                "messages": [
-                    {"role": "system", "content": "You are a precise Python coding assistant. Respond with only the requested function in a single python code block."},
-                    {"role": "user", "content": prompt},
-                ],
-                "temperature": 0,
-            }
-        ).encode("utf-8")
-        req = urllib.request.Request(url, data=payload, method="POST")
-        req.add_header("Content-Type", "application/json")
-        if api_key:
-            req.add_header("Authorization", "Bearer " + api_key)
-        req.add_header("x-openagents-demand-kind", DEMAND["kind"])
-        req.add_header("x-openagents-demand-source", DEMAND["source"])
-        req.add_header("x-openagents-client", DEMAND["client"])
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            body = json.loads(resp.read().decode("utf-8"))
+        body = _khala_chat_raw(url, api_key, model, prompt, timeout)
         return body["choices"][0]["message"]["content"] or ""
 
     return _call
 
+
+def live_preflight(
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    model: str = "openagents/khala",
+    timeout: float = 120.0,
+) -> Dict[str, Any]:
+    """Do ONE real own-capacity call and PROVE it burned tokens.
+
+    Returns a dict with the served-token usage of our own call plus the public
+    counter before/after (supporting evidence). Raises KhalaCallError (loud) if
+    the call is unauthorized / WAF-blocked / empty, or if it reports ZERO usage
+    tokens -- so the runner can fail loud BEFORE wasting a batch on a dead auth
+    path. The strong burn signal is our own response usage; the shared counter
+    delta is informational (other agents burn concurrently).
+    """
+    base_url = (base_url or os.environ.get("OPENAI_BASE_URL") or "https://openagents.com/api/v1").rstrip("/")
+    api_key = api_key or os.environ.get("OPENAI_API_KEY") or ""
+    url = base_url + "/chat/completions"
+
+    counter_before = fetch_tokens_served(base_url, timeout=30.0)
+    body = _khala_chat_raw(
+        url,
+        api_key,
+        model,
+        "Write a Python function `ping()` that returns the string 'pong'. Return only the function in a single ```python code block.",
+        timeout,
+    )
+    usage = body.get("usage") or {}
+    total_tokens = int(usage.get("total_tokens") or 0)
+    content = ""
+    try:
+        content = body["choices"][0]["message"]["content"] or ""
+    except (KeyError, IndexError, TypeError):
+        content = ""
+    counter_after = fetch_tokens_served(base_url, timeout=30.0)
+    counter_delta = (
+        counter_after - counter_before
+        if (counter_before is not None and counter_after is not None)
+        else None
+    )
+    if total_tokens <= 0:
+        raise KhalaCallError(
+            "khala_preflight_zero_usage: model returned no usage tokens "
+            "(content_chars=%d); refusing to run a 0-burn batch" % len(content)
+        )
+    return {
+        "ok": True,
+        "model": model,
+        "usageTotalTokens": total_tokens,
+        "promptTokens": int(usage.get("prompt_tokens") or 0),
+        "completionTokens": int(usage.get("completion_tokens") or 0),
+        "contentChars": len(content),
+        "counterBefore": counter_before,
+        "counterAfter": counter_after,
+        "counterDelta": counter_delta,
+    }
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="MirrorCode gym backstop runner (#6710)")
@@ -363,7 +507,54 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--live", action="store_true", help="Use the live Khala model (needs OPENAI_API_KEY / OPENAI_BASE_URL).")
     parser.add_argument("--case-timeout", type=float, default=float(os.environ.get("MC_BACKSTOP_CASE_TIMEOUT", "8")), help="Per-problem execution timeout (s).")
     parser.add_argument("--model", default=os.environ.get("MC_BACKSTOP_MODEL", "openagents/khala"))
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Burn smoke only: do ONE live own-capacity call and assert it burned tokens (no batch). Exits nonzero if the call is unauthorized / WAF-blocked / 0-burn. Implies --live.",
+    )
     args = parser.parse_args(argv)
+
+    # BURN PREFLIGHT / SMOKE (issue #6735). For any live run, prove the
+    # own-capacity auth path actually burns BEFORE spending a batch on a dead
+    # endpoint, and FAIL LOUD (nonzero exit + exact reason on stderr) if it does
+    # not -- instead of the old silent all-failed / 0-burn run that exited 0.
+    if args.live or args.smoke:
+        try:
+            pf = live_preflight(model=args.model)
+        except KhalaCallError as exc:
+            print(
+                "FATAL backstop burn preflight failed: %s" % exc,
+                file=sys.stderr,
+            )
+            if getattr(exc, "status", None) is not None:
+                print("  http_status: %s" % exc.status, file=sys.stderr)
+            if getattr(exc, "body", ""):
+                print("  body: %s" % exc.body, file=sys.stderr)
+            print(
+                "  hint: own-capacity inference needs a valid oa_agent_ Bearer key "
+                "(OPENAI_API_KEY) OR a mint at POST <base>/api/keys/free, AND a "
+                "non-default User-Agent (Cloudflare 403s Python-urllib). "
+                "401=bad/missing token; 403=WAF/UA block; 402=needs credits or "
+                "free-tier not enabled.",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            "Burn preflight OK: own call burned %d tokens (prompt=%d, completion=%d); "
+            "public counter %s -> %s (delta %s)."
+            % (
+                pf["usageTotalTokens"],
+                pf["promptTokens"],
+                pf["completionTokens"],
+                pf["counterBefore"],
+                pf["counterAfter"],
+                pf["counterDelta"],
+            ),
+            file=sys.stderr,
+        )
+        if args.smoke:
+            print(json.dumps({"smoke": pf}, indent=2))
+            return 0
 
     problems = select_problems(args.limit)
     if args.live:
@@ -377,6 +568,18 @@ def main(argv: Optional[List[str]] = None) -> int:
     os.makedirs(args.out, exist_ok=True)
     summary = evaluate_batch(problems, model_fn, args.out, case_timeout=args.case_timeout, model_name=args.model)
     print(json.dumps(summary, indent=2))
+
+    # FAIL LOUD (issue #6735): a live batch where EVERY model call failed is a
+    # broken auth/transport path, not a legitimate 0% pass rate. Never let it
+    # masquerade as a successful 0-burn run.
+    if args.live and problems and summary.get("modelErrorCount", 0) == len(problems):
+        print(
+            "FATAL backstop: all %d live model calls failed (modelErrorCount=%d); "
+            "0 tokens burned. Treating as a broken own-capacity path."
+            % (len(problems), summary.get("modelErrorCount", 0)),
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py
+++ b/apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py
@@ -143,6 +143,89 @@ class EvaluateBatchTests(unittest.TestCase):
             self.assertTrue(str(tr["modelError"]).startswith("model_call_failed"))
 
 
+class Issue6735BurnGuardTests(unittest.TestCase):
+    """Issue #6735: own-capacity auth + fail-loud + burn smoke."""
+
+    def test_public_base_strips_v1_suffix(self):
+        self.assertEqual(be._public_base("https://openagents.com/api/v1"), "https://openagents.com")
+        self.assertEqual(be._public_base("https://openagents.com/api/v1/"), "https://openagents.com")
+        self.assertEqual(be._public_base("https://x.test/v1"), "https://x.test")
+        self.assertEqual(be._public_base("https://x.test"), "https://x.test")
+
+    def test_summary_reports_model_error_count(self):
+        problems = [{"id": "a", "entrypoint": "a", "prompt": "a", "tests": [[[1], 1]]}]
+
+        def model_fn(_prompt):
+            raise RuntimeError("network down")
+
+        with tempfile.TemporaryDirectory() as d:
+            summary = be.evaluate_batch(problems, model_fn, d, run_id="t-errcount")
+            self.assertEqual(summary["modelErrorCount"], 1)
+
+    def test_preflight_raises_loud_on_http_error(self):
+        def fake_chat(url, api_key, model, prompt, timeout):
+            raise be.KhalaCallError("khala_http_error status=403", status=403, body="error code: 1010")
+
+        orig = be._khala_chat_raw
+        be._khala_chat_raw = fake_chat
+        try:
+            with self.assertRaises(be.KhalaCallError) as ctx:
+                be.live_preflight(base_url="https://x.test/api/v1", api_key="oa_agent_x", model="openagents/khala")
+            self.assertEqual(ctx.exception.status, 403)
+        finally:
+            be._khala_chat_raw = orig
+
+    def test_preflight_raises_loud_on_zero_usage(self):
+        def fake_chat(url, api_key, model, prompt, timeout):
+            return {"choices": [{"message": {"content": "ok"}}], "usage": {"total_tokens": 0}}
+
+        orig_chat, orig_counter = be._khala_chat_raw, be.fetch_tokens_served
+        be._khala_chat_raw = fake_chat
+        be.fetch_tokens_served = lambda *a, **k: 100
+        try:
+            with self.assertRaises(be.KhalaCallError):
+                be.live_preflight(base_url="https://x.test/api/v1", api_key="oa_agent_x")
+        finally:
+            be._khala_chat_raw, be.fetch_tokens_served = orig_chat, orig_counter
+
+    def test_preflight_ok_reports_usage_and_counter_delta(self):
+        def fake_chat(url, api_key, model, prompt, timeout):
+            return {"choices": [{"message": {"content": "```python\ndef ping():\n    return 'pong'\n```"}}], "usage": {"total_tokens": 42, "prompt_tokens": 30, "completion_tokens": 12}}
+
+        counters = iter([1000, 1042])
+        orig_chat, orig_counter = be._khala_chat_raw, be.fetch_tokens_served
+        be._khala_chat_raw = fake_chat
+        be.fetch_tokens_served = lambda *a, **k: next(counters)
+        try:
+            pf = be.live_preflight(base_url="https://x.test/api/v1", api_key="oa_agent_x")
+            self.assertTrue(pf["ok"])
+            self.assertEqual(pf["usageTotalTokens"], 42)
+            self.assertEqual(pf["counterDelta"], 42)
+        finally:
+            be._khala_chat_raw, be.fetch_tokens_served = orig_chat, orig_counter
+
+    def test_main_live_fails_loud_when_preflight_unauthorized(self):
+        def boom(*a, **k):
+            raise be.KhalaCallError("khala_http_error status=401", status=401, body='{"error":"unauthorized"}')
+
+        orig = be.live_preflight
+        be.live_preflight = boom
+        try:
+            rc = be.main(["--live", "--limit", "1"])
+            self.assertEqual(rc, 1)
+        finally:
+            be.live_preflight = orig
+
+    def test_main_smoke_returns_zero_on_real_burn(self):
+        orig = be.live_preflight
+        be.live_preflight = lambda **k: {"ok": True, "usageTotalTokens": 7, "promptTokens": 4, "completionTokens": 3, "contentChars": 5, "counterBefore": 1, "counterAfter": 8, "counterDelta": 7}
+        try:
+            rc = be.main(["--smoke"])
+            self.assertEqual(rc, 0)
+        finally:
+            be.live_preflight = orig
+
+
 class SelectionTests(unittest.TestCase):
     def test_limit_bounds_batch(self):
         self.assertEqual(len(be.select_problems(3)), 3)


### PR DESCRIPTION
Closes #6735.