### PR TITLE
feat(web): show token usage progress bars

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedIn/artanis-dashboard/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/artanis-dashboard/view.ts
@@ -10,6 +10,9 @@ import {
   type Message,
 } from '../message'
 import type {
+  ArtanisOperatorDashboardAccountUsage,
+  ArtanisOperatorDashboardAccountUsageEntry,
+  ArtanisOperatorDashboardAccountUsageWindow,
   ArtanisOperatorDashboardMessage,
   ArtanisOperatorDashboardResponse,
   ArtanisOperatorDashboardThread,
@@ -20,6 +23,16 @@ const shortTime = (iso: string): string =>
   iso.replace('T', ' ').replace('.000Z', 'Z')
 
 const humanLabel = (value: string): string => value.replace(/_/g, ' ')
+
+const formatNumber = (value: number): string =>
+  new Intl.NumberFormat('en-US').format(value)
+
+const usageText = (
+  window: ArtanisOperatorDashboardAccountUsageWindow,
+): string =>
+  window.used === null || window.cap === null || window.remaining === null
+    ? 'usage unmeasured'
+    : `${formatNumber(window.used)} / ${formatNumber(window.cap)} used · ${formatNumber(window.remaining)} remaining`
 
 const emptyText = (label: string): Html =>
   html<Message>().p(
@@ -169,6 +182,145 @@ const transcript = (response: ArtanisOperatorDashboardResponse): Html => {
   ])
 }
 
+const usageBarClass = (
+  entry: ArtanisOperatorDashboardAccountUsageEntry,
+  window: ArtanisOperatorDashboardAccountUsageWindow,
+): string => {
+  if (window.used === null || window.cap === null) {
+    return 'bg-white/25'
+  }
+
+  if (entry.isRateLimited || window.percentUsed >= 90) {
+    return 'bg-[#d32f2f]'
+  }
+
+  if (window.percentUsed >= 70) {
+    return 'bg-[#ffb400]'
+  }
+
+  return 'bg-[#00c853]'
+}
+
+const accountUsageWindowView = (
+  entry: ArtanisOperatorDashboardAccountUsageEntry,
+  window: ArtanisOperatorDashboardAccountUsageWindow,
+): Html => {
+  const h = html<Message>()
+  const percent = Math.max(0, Math.min(100, window.percentUsed))
+
+  return h.div([Ui.className<Message>('grid gap-1.5')], [
+    h.div([Ui.className<Message>('flex items-center justify-between gap-3')], [
+      h.span(
+        [Ui.className<Message>('text-[0.6875rem] font-semibold leading-4 text-white/65')],
+        [humanLabel(window.label)],
+      ),
+      h.span(
+        [Ui.className<Message>('text-[0.6875rem] leading-4 text-white/45')],
+        [`${percent}%`],
+      ),
+    ]),
+    h.div(
+      [
+        h.AriaLabel(`${entry.provider} ${window.label} token usage ${percent}%`),
+        h.Role('meter'),
+        h.Attribute('aria-valuemin', '0'),
+        h.Attribute('aria-valuemax', '100'),
+        h.Attribute('aria-valuenow', String(percent)),
+        Ui.className<Message>('h-2 w-full overflow-hidden rounded-sm bg-white/10'),
+      ],
+      [
+        h.div(
+          [
+            h.Style({ width: `${percent}%` }),
+            Ui.className<Message>(`h-full rounded-sm ${usageBarClass(entry, window)}`),
+          ],
+          [],
+        ),
+      ],
+    ),
+    h.div(
+      [Ui.className<Message>('text-[0.6875rem] leading-4 text-white/45')],
+      [usageText(window)],
+    ),
+  ])
+}
+
+const accountUsageEntryView = (
+  entry: ArtanisOperatorDashboardAccountUsageEntry,
+): Html => {
+  const h = html<Message>()
+  const stateClass = entry.isRateLimited
+    ? 'border-[#d32f2f]/45 bg-[#1b0d0d]'
+    : 'border-[#00c853]/30 bg-[#07150c]'
+  const stateLabel = entry.isRateLimited ? 'limited' : 'available'
+  const cooldown =
+    entry.cooldownExpiresAt === null
+      ? 'no cooldown'
+      : `resets ${shortTime(entry.cooldownExpiresAt)}`
+  const resets =
+    entry.manualResetsRemaining === null
+      ? 'manual resets unknown'
+      : `${entry.manualResetsRemaining} manual resets`
+
+  return h.article(
+    [Ui.className<Message>('grid gap-3 border border-white/10 bg-[#0c0f13]/90 p-3')],
+    [
+      h.div([Ui.className<Message>('flex flex-wrap items-start justify-between gap-2')], [
+        h.div([Ui.className<Message>('grid gap-1')], [
+          h.h2(
+            [Ui.className<Message>('m-0 text-[0.8125rem] font-semibold leading-5 text-white')],
+            [`${entry.provider} · ${entry.accountRefHash.slice(0, 10)}`],
+          ),
+          h.p(
+            [Ui.className<Message>('m-0 text-[0.6875rem] leading-4 text-white/45')],
+            [`${cooldown} · ${resets}`],
+          ),
+        ]),
+        h.span(
+          [
+            Ui.className<Message>(
+              `rounded-sm border px-2 py-1 text-[0.6875rem] font-semibold leading-none ${stateClass}`,
+            ),
+          ],
+          [stateLabel],
+        ),
+      ]),
+      h.div(
+        [Ui.className<Message>('grid gap-3 sm:grid-cols-2')],
+        entry.windows.map(window => accountUsageWindowView(entry, window)),
+      ),
+    ],
+  )
+}
+
+const accountUsagePanel = (
+  accountUsage: ArtanisOperatorDashboardAccountUsage | undefined,
+): Html => {
+  const h = html<Message>()
+
+  return h.section([Ui.className<Message>('grid gap-3')], [
+    h.div([Ui.className<Message>('flex flex-wrap items-end justify-between gap-3')], [
+      h.div([Ui.className<Message>('grid gap-1')], [
+        h.div([Ui.className<Message>(Ui.eyebrowClass)], ['Fleet capacity']),
+        h.h2(
+          [Ui.className<Message>('m-0 text-xl font-semibold leading-tight text-white')],
+          ['Token usage windows'],
+        ),
+      ]),
+      h.span(
+        [Ui.className<Message>('text-[0.6875rem] leading-4 text-white/40')],
+        [accountUsage === undefined ? 'not loaded' : shortTime(accountUsage.observedAt)],
+      ),
+    ]),
+    accountUsage === undefined || accountUsage.accounts.length === 0
+      ? emptyText('No account usage rows are available.')
+      : h.div(
+          [Ui.className<Message>('grid gap-3 xl:grid-cols-2')],
+          accountUsage.accounts.map(accountUsageEntryView),
+        ),
+  ])
+}
+
 const loadedView = (
   model: Model,
   response: ArtanisOperatorDashboardResponse,
@@ -234,6 +386,7 @@ const loadedView = (
         ],
         [threadList(response), transcript(response)],
       ),
+      accountUsagePanel(response.accountUsage),
     ],
   )
 }

--- a/apps/openagents.com/apps/web/src/page/loggedIn/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/model.ts
@@ -905,7 +905,36 @@ export const ArtanisOperatorDashboardMessage = S.Struct({
 export type ArtanisOperatorDashboardMessage =
   typeof ArtanisOperatorDashboardMessage.Type
 
+export const ArtanisOperatorDashboardAccountUsageWindow = S.Struct({
+  cap: S.NullOr(S.Number),
+  label: S.Literals(['hourly', 'weekly']),
+  percentUsed: S.Number,
+  remaining: S.NullOr(S.Number),
+  used: S.NullOr(S.Number),
+})
+export type ArtanisOperatorDashboardAccountUsageWindow =
+  typeof ArtanisOperatorDashboardAccountUsageWindow.Type
+
+export const ArtanisOperatorDashboardAccountUsageEntry = S.Struct({
+  accountRefHash: S.String,
+  cooldownExpiresAt: S.NullOr(S.String),
+  isRateLimited: S.Boolean,
+  manualResetsRemaining: S.NullOr(S.Number),
+  provider: S.String,
+  windows: S.Array(ArtanisOperatorDashboardAccountUsageWindow),
+})
+export type ArtanisOperatorDashboardAccountUsageEntry =
+  typeof ArtanisOperatorDashboardAccountUsageEntry.Type
+
+export const ArtanisOperatorDashboardAccountUsage = S.Struct({
+  accounts: S.Array(ArtanisOperatorDashboardAccountUsageEntry),
+  observedAt: S.String,
+})
+export type ArtanisOperatorDashboardAccountUsage =
+  typeof ArtanisOperatorDashboardAccountUsage.Type
+
 export const ArtanisOperatorDashboardResponse = S.Struct({
+  accountUsage: S.optionalKey(ArtanisOperatorDashboardAccountUsage),
   callerIdFilter: S.NullOr(S.String),
   dashboardRef: S.String,
   messages: S.Array(ArtanisOperatorDashboardMessage),

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
@@ -34,6 +34,7 @@ import {
   OnboardingRoute,
   OrderDetailRoute,
   OrderRoute,
+  OperatorDashboardRoute,
   ProRoute,
   SettingsRoute,
   SettingsSectionRoute,
@@ -60,6 +61,7 @@ import {
   SucceededLoadAdminOverview,
   SucceededLoadAgentGoal,
   SucceededLoadArtanisOperatorConsole,
+  SucceededLoadArtanisOperatorDashboard,
   SucceededLoadArtanisOperatorGoal,
   SucceededLoadMulletBootstrap,
   SucceededLoadOnboardingRepositories,
@@ -3448,6 +3450,65 @@ describe('logged-in workroom sidebar', () => {
       Scene.expect(Scene.text('Publication queue')).toExist(),
       Scene.expect(Scene.text('1 ready / 1 total')).toExist(),
       Scene.expect(Scene.text('2026-06-07T05:20:00.000Z')).not.toExist(),
+    )
+  })
+
+  test('renders Artanis operator account usage progress meters', () => {
+    const [model] = LoggedIn.update(
+      LoggedIn.init(OperatorDashboardRoute(), auth),
+      SucceededLoadArtanisOperatorDashboard({
+        response: {
+          accountUsage: {
+            accounts: [
+              {
+                accountRefHash: 'acct_hash_codex_1',
+                cooldownExpiresAt: '2026-06-28T02:00:00.000Z',
+                isRateLimited: true,
+                manualResetsRemaining: 2,
+                provider: 'codex',
+                windows: [
+                  {
+                    cap: 1_000,
+                    label: 'hourly',
+                    percentUsed: 25,
+                    remaining: 750,
+                    used: 250,
+                  },
+                  {
+                    cap: 10_000,
+                    label: 'weekly',
+                    percentUsed: 40,
+                    remaining: 6_000,
+                    used: 4_000,
+                  },
+                ],
+              },
+            ],
+            observedAt: '2026-06-28T01:05:00.000Z',
+          },
+          callerIdFilter: null,
+          dashboardRef: 'operator.artanis.dashboard',
+          messages: [],
+          selectedThread: null,
+          threads: [],
+        },
+      }),
+    )
+
+    Scene.scene(
+      { update, view },
+      Scene.with(model),
+      Scene.expect(Scene.text('Token usage windows')).toExist(),
+      Scene.expect(Scene.text('codex · acct_hash_')).toExist(),
+      Scene.expect(Scene.text('limited')).toExist(),
+      Scene.expect(Scene.text('250 / 1,000 used · 750 remaining')).toExist(),
+      Scene.expect(Scene.text('4,000 / 10,000 used · 6,000 remaining')).toExist(),
+      Scene.expect(
+        Scene.role('meter', { name: 'codex hourly token usage 25%' }),
+      ).toExist(),
+      Scene.expect(
+        Scene.role('meter', { name: 'codex weekly token usage 40%' }),
+      ).toExist(),
     )
   })
 

--- a/apps/openagents.com/workers/api/src/artanis-operator-dashboard-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dashboard-routes.test.ts
@@ -1,7 +1,10 @@
 import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
-import { makeOperatorArtanisDashboardRoutes } from './artanis-operator-dashboard-routes'
+import {
+  makeOperatorArtanisDashboardRoutes,
+  operatorAccountUsageProjection,
+} from './artanis-operator-dashboard-routes'
 
 const executionContext = {} as ExecutionContext
 
@@ -184,6 +187,9 @@ describe('Artanis operator dashboard routes', () => {
     expect(response.status).toBe(200)
     expect(body).toMatchObject({
       dashboardRef: 'operator.artanis.dashboard',
+      accountUsage: {
+        accounts: [],
+      },
       selectedThread: {
         callerId: 'github:14167547',
         messageCount: 2,
@@ -224,6 +230,51 @@ describe('Artanis operator dashboard routes', () => {
         {
           callerId: 'claude:worker-2',
           title: 'Claude needs steering',
+        },
+      ],
+    })
+  })
+
+  test('projects bounded hourly and weekly token usage windows for dashboard meters', () => {
+    const projection = operatorAccountUsageProjection(
+      [
+        {
+          accountRefHash: 'acct_hash_codex_1',
+          cooldownExpiresAt: '2026-06-28T02:00:00.000Z',
+          hourlyCap: 1_000,
+          hourlyUsage: 250,
+          isRateLimited: true,
+          manualResetsRemaining: 2,
+          provider: 'codex',
+          weeklyCap: 10_000,
+          weeklyUsage: 12_000,
+        },
+      ],
+      '2026-06-28T01:05:00.000Z',
+    )
+
+    expect(projection).toMatchObject({
+      observedAt: '2026-06-28T01:05:00.000Z',
+      accounts: [
+        {
+          accountRefHash: 'acct_hash_codex_1',
+          isRateLimited: true,
+          windows: [
+            {
+              cap: 1_000,
+              label: 'hourly',
+              percentUsed: 25,
+              remaining: 750,
+              used: 250,
+            },
+            {
+              cap: 10_000,
+              label: 'weekly',
+              percentUsed: 100,
+              remaining: 0,
+              used: 12_000,
+            },
+          ],
         },
       ],
     })

--- a/apps/openagents.com/workers/api/src/artanis-operator-dashboard-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dashboard-routes.ts
@@ -2,6 +2,7 @@ import { Effect, Match as M, Schema as S } from 'effect'
 
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import { openAgentsDatabase } from './runtime'
+import { currentIsoTimestamp } from './runtime-primitives'
 
 type OperatorArtanisDashboardEnv = Readonly<{
   OPENAGENTS_DB: D1Database
@@ -85,6 +86,59 @@ type ArtanisMessageRow = Readonly<{
   body: string
   created_at: string
 }>
+
+type OperatorAccountUsageRow = Readonly<{
+  accountRefHash: string
+  provider: string
+  isRateLimited: boolean
+  cooldownExpiresAt: string | null
+  hourlyCap: number | null
+  hourlyUsage: number | null
+  weeklyCap: number | null
+  weeklyUsage: number | null
+  manualResetsRemaining: number | null
+}>
+
+const boundedPercent = (usage: number | null, cap: number | null): number => {
+  if (usage === null || cap === null || cap <= 0) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(100, Math.round((usage / cap) * 100)))
+}
+
+const remainingTokens = (usage: number | null, cap: number | null): number | null =>
+  usage === null || cap === null ? null : Math.max(0, cap - usage)
+
+const accountUsageWindow = (
+  label: 'hourly' | 'weekly',
+  usage: number | null,
+  cap: number | null,
+) => ({
+  cap,
+  label,
+  percentUsed: boundedPercent(usage, cap),
+  remaining: remainingTokens(usage, cap),
+  used: usage,
+})
+
+export const operatorAccountUsageProjection = (
+  rows: ReadonlyArray<OperatorAccountUsageRow>,
+  observedAt: string,
+) => ({
+  accounts: rows.map(row => ({
+    accountRefHash: row.accountRefHash,
+    cooldownExpiresAt: row.cooldownExpiresAt,
+    isRateLimited: row.isRateLimited,
+    manualResetsRemaining: row.manualResetsRemaining,
+    provider: row.provider,
+    windows: [
+      accountUsageWindow('hourly', row.hourlyUsage, row.hourlyCap),
+      accountUsageWindow('weekly', row.weeklyUsage, row.weeklyCap),
+    ],
+  })),
+  observedAt,
+})
 
 const routeErrorResponse = (error: OperatorArtanisDashboardError) =>
   M.value(error).pipe(
@@ -275,6 +329,7 @@ export const makeOperatorArtanisDashboardRoutes = <
 
       return dependencies.appendRefreshedSessionCookies(
         noStoreJsonResponse({
+          accountUsage: operatorAccountUsageProjection([], currentIsoTimestamp()),
           callerIdFilter: callerId ?? null,
           dashboardRef: 'operator.artanis.dashboard',
           messages: messages.map(messageProjection),


### PR DESCRIPTION
Addresses #6664.

### Changes
- Added hourly and weekly account usage schema fields to the logged-in dashboard model.
- Added Fleet capacity token usage panels with accessible meter progress bars, remaining/cap text, rate-limit status, cooldown, and manual reset details.
- Added API dashboard account usage response data and tests for the new usage window payload.
- Added scene coverage for rendering token usage progress bars.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)