### PR TITLE
feat(web): add Artanis trace tree route

### DIFF
--- a/apps/openagents.com/apps/web/src/page/artanisTraceTree.test.ts
+++ b/apps/openagents.com/apps/web/src/page/artanisTraceTree.test.ts
@@ -1,0 +1,87 @@
+import type { Html } from 'foldkit/html'
+import { describe, expect, test } from 'vitest'
+
+import * as ArtanisTraceTree from './artanisTraceTree'
+
+type VNodeLike = Readonly<{
+  children?: ReadonlyArray<string | VNodeLike | null>
+  data?: {
+    attrs?: Record<string, unknown>
+    class?: Record<string, boolean>
+    props?: Record<string, unknown>
+  }
+  sel?: string
+  text?: string
+}>
+
+const isVNodeLike = (value: unknown): value is VNodeLike =>
+  typeof value === 'object' && value !== null
+
+const attrsToString = (node: VNodeLike): string => {
+  const attrs = node.data?.attrs ?? {}
+  const props = node.data?.props ?? {}
+  const classes = Object.entries(node.data?.class ?? {})
+    .filter(([, enabled]) => enabled)
+    .map(([className]) => className)
+    .join(' ')
+  const pairs = [
+    ...Object.entries(attrs),
+    ...Object.entries(props),
+    ...(classes.length === 0 ? [] : [['class', classes] as const]),
+  ]
+  return pairs
+    .filter(
+      ([, value]) => value !== false && value !== undefined && value !== null,
+    )
+    .map(([name, value]) =>
+      value === true ? ` ${name}` : ` ${name}="${String(value)}"`,
+    )
+    .join('')
+}
+
+const renderHtml = (html: Html): string => {
+  if (html === null || !isVNodeLike(html)) return ''
+  const tag = html.sel ?? 'node'
+  const children = (html.children ?? [])
+    .map(child =>
+      typeof child === 'string'
+        ? child
+        : child === null
+          ? ''
+          : renderHtml(child),
+    )
+    .join('')
+  return `<${tag}${attrsToString(html)}>${html.text ?? ''}${children}</${tag}>`
+}
+
+describe('Artanis RLM trace tree page', () => {
+  test('renders the FRLM conductor tree with Blueprint governance refs', () => {
+    const rendered = renderHtml(
+      ArtanisTraceTree.view({ _tag: 'LoggedOut' }),
+    )
+
+    expect(rendered).toContain('Artanis execution tree')
+    expect(rendered).toContain('FrlmConductor')
+    expect(rendered).toContain('SubQuery.Submit')
+    expect(rendered).toContain('SubQuery.Return')
+    expect(rendered).toContain('Run.Done')
+    expect(rendered).toContain('program_signature.frlm_conductor.v1')
+    expect(rendered).toContain('program_signature.rlm_leaf_executor.v1')
+    expect(rendered).toContain('/api/operator/rlm/traces')
+    expect(rendered).toContain('No direct execution authority')
+  })
+
+  test('keeps private trace material out of the public visualizer', () => {
+    const rendered = renderHtml(
+      ArtanisTraceTree.view({ _tag: 'LoggedOut' }),
+    )
+
+    expect(rendered).not.toMatch(
+      /raw_prompt|raw_trace|rawEvents|trajectory_json|bearer|api[_-]?key|sk-[a-z0-9]/i,
+    )
+  })
+
+  test('uses a route-specific document title', () => {
+    expect(ArtanisTraceTree.title()).toBe('Artanis RLM traces - OpenAgents')
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/artanisTraceTree.ts
+++ b/apps/openagents.com/apps/web/src/page/artanisTraceTree.ts
@@ -1,0 +1,317 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import * as Ui from '../ui'
+import type { PublicHeaderAuthState } from './publicHeader'
+import * as PublicHeader from './publicHeader'
+
+const pageShellClass = 'min-h-screen bg-[#08090a] text-[#f4f1e8]'
+
+const shell =
+  'mx-auto grid min-h-screen w-full max-w-7xl gap-6 px-4 py-6 sm:px-6 lg:px-8'
+
+const panel = 'border border-white/10 bg-[#0d0f13] p-4 sm:p-5'
+
+const eyebrow =
+  'm-0 text-[0.68rem] font-semibold uppercase leading-none tracking-[0.14em] text-[#ffb400]/75'
+
+const titleClass =
+  'm-0 max-w-4xl text-3xl font-semibold leading-tight text-white sm:text-4xl'
+
+const bodyClass = 'm-0 max-w-4xl text-sm leading-6 text-white/62'
+
+const codeClass =
+  'break-all rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[0.85em] text-white/82'
+
+type TreeNode = Readonly<{
+  label: string
+  ref: string
+  state: 'ready' | 'running' | 'blocked'
+  detail: string
+  children: ReadonlyArray<TreeNode>
+}>
+
+const tree: TreeNode = {
+  label: 'FrlmConductor',
+  ref: 'program_signature.frlm_conductor.v1',
+  state: 'ready',
+  detail: 'Environment, scheduler, budget policy, trace emitter',
+  children: [
+    {
+      label: 'Run.Init',
+      ref: 'trace.rlm.run_init',
+      state: 'ready',
+      detail: 'Context fragments and root task refs are bounded before fanout',
+      children: [],
+    },
+    {
+      label: 'SubQuery.Submit',
+      ref: 'program_signature.rlm_leaf_executor.v1',
+      state: 'running',
+      detail: 'Typed leaf calls may target local, swarm, remote, or Codex lanes',
+      children: [
+        {
+          label: 'Local',
+          ref: 'executor.local.ref_only',
+          state: 'ready',
+          detail: 'Same-device deterministic work and public-safe adapters',
+          children: [],
+        },
+        {
+          label: 'Swarm',
+          ref: 'executor.nip90.ref_only',
+          state: 'running',
+          detail: 'Federated work is quorum-scored before composition',
+          children: [],
+        },
+        {
+          label: 'Codex',
+          ref: 'executor.pylon_codex.ref_only',
+          state: 'running',
+          detail: 'Owner-local coding turns stay private; token rows are exact',
+          children: [],
+        },
+      ],
+    },
+    {
+      label: 'SubQuery.Return',
+      ref: 'evidence.rlm_trace.redacted_operator_projection',
+      state: 'ready',
+      detail: 'Only refs, counts, states, and gate evidence reach this page',
+      children: [],
+    },
+    {
+      label: 'Run.Done',
+      ref: 'release_gate.rlm_trace.redacted_operator_projection',
+      state: 'blocked',
+      detail: 'Final composition stays blocked until every evidence ref exists',
+      children: [],
+    },
+  ],
+}
+
+const signatureRefs = [
+  'program_signature.frlm_conductor.v1',
+  'program_signature.rlm_leaf_executor.v1',
+  'program_signature.blueprint_action_submission.evidence_only.v1',
+  'autonomous-ops-v1.signature-4.command-execution-source-verified',
+]
+
+const authorityRows = [
+  ['Execution', 'No direct execution authority'],
+  ['Payment', 'No payout or settlement authority'],
+  ['Claims', 'No public-promise promotion authority'],
+  ['Training', 'No checkpoint or training-promotion authority'],
+] as const
+
+const codeInline = <Message>(text: string): Html => {
+  const h = html<Message>()
+  return h.code([Ui.className<Message>(codeClass)], [text])
+}
+
+const stateClass = (state: TreeNode['state']): string =>
+  state === 'ready'
+    ? 'border-emerald-300/25 bg-emerald-300/10 text-emerald-100'
+    : state === 'running'
+      ? 'border-sky-300/25 bg-sky-300/10 text-sky-100'
+      : 'border-[#ffb400]/25 bg-[#ffb400]/10 text-[#ffe0a3]'
+
+const stateLabel = (state: TreeNode['state']): string =>
+  state === 'ready' ? 'ready' : state === 'running' ? 'running' : 'blocked'
+
+const treeNode = <Message>(node: TreeNode, depth = 0): Html => {
+  const h = html<Message>()
+  const hasChildren = node.children.length > 0
+
+  return h.li(
+    [Ui.className<Message>('grid gap-3')],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            `grid gap-2 border border-white/10 bg-black/25 p-3 ${depth === 0 ? '' : 'ml-4 sm:ml-6'}`,
+          ),
+        ],
+        [
+          h.div(
+            [Ui.className<Message>('flex flex-wrap items-center gap-2')],
+            [
+              h.span(
+                [
+                  Ui.className<Message>(
+                    'text-sm font-semibold leading-5 text-white',
+                  ),
+                ],
+                [node.label],
+              ),
+              h.span(
+                [
+                  Ui.className<Message>(
+                    `rounded border px-2 py-0.5 text-[0.68rem] font-semibold uppercase leading-none tracking-[0.12em] ${stateClass(node.state)}`,
+                  ),
+                ],
+                [stateLabel(node.state)],
+              ),
+            ],
+          ),
+          codeInline<Message>(node.ref),
+          h.p([Ui.className<Message>('m-0 text-sm leading-5 text-white/58')], [
+            node.detail,
+          ]),
+        ],
+      ),
+      hasChildren
+        ? h.ol(
+            [
+              Ui.className<Message>(
+                'grid gap-3 border-l border-white/10 pl-3 sm:pl-4',
+              ),
+            ],
+            node.children.map(child => treeNode<Message>(child, depth + 1)),
+          )
+        : h.span([Ui.className<Message>('sr-only')], ['Leaf node']),
+    ],
+  )
+}
+
+const signatureList = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.ul(
+    [Ui.className<Message>('grid gap-2 p-0')],
+    signatureRefs.map(ref =>
+      h.li(
+        [
+          Ui.className<Message>(
+            'border border-white/10 bg-white/[0.035] p-3 text-sm leading-5 text-white/70',
+          ),
+        ],
+        [codeInline<Message>(ref)],
+      ),
+    ),
+  )
+}
+
+const authorityTable = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      Ui.className<Message>(
+        'grid overflow-hidden border border-white/10 text-sm leading-5',
+      ),
+    ],
+    authorityRows.map(([label, value]) =>
+      h.div(
+        [
+          Ui.className<Message>(
+            'grid gap-2 border-b border-white/10 p-3 last:border-b-0 sm:grid-cols-[8rem_1fr]',
+          ),
+        ],
+        [
+          h.span([Ui.className<Message>('font-semibold text-white/82')], [
+            label,
+          ]),
+          h.span([Ui.className<Message>('text-white/58')], [value]),
+        ],
+      ),
+    ),
+  )
+}
+
+export const view = <Message>(
+  authState: PublicHeaderAuthState<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      Ui.className<Message>(pageShellClass),
+      h.DataAttribute('route', 'artanis-traces'),
+    ],
+    [
+      PublicHeader.view(authState),
+      h.main(
+        [Ui.className<Message>(shell), h.AriaLabel('Artanis RLM traces')],
+        [
+          h.section(
+            [
+              Ui.className<Message>(
+                'grid gap-5 border border-white/10 bg-[#0d0f13] p-5 sm:p-6',
+              ),
+            ],
+            [
+              h.p([Ui.className<Message>(eyebrow)], ['RLM trace visualizer']),
+              h.h1([Ui.className<Message>(titleClass)], [
+                'Artanis execution tree',
+              ]),
+              h.p([Ui.className<Message>(bodyClass)], [
+                'A ref-only view of the Recursive Language Model shape behind Artanis: conductor, fanout, typed leaf executors, returned evidence, and composition gates.',
+              ]),
+              h.div(
+                [
+                  Ui.className<Message>(
+                    'grid gap-3 border border-white/10 bg-black/25 p-3 text-sm leading-5 text-white/60 sm:grid-cols-3',
+                  ),
+                ],
+                [
+                  h.div([], [
+                    h.span([Ui.className<Message>('block text-white/42')], [
+                      'Source',
+                    ]),
+                    codeInline<Message>('/api/operator/rlm/traces'),
+                  ]),
+                  h.div([], [
+                    h.span([Ui.className<Message>('block text-white/42')], [
+                      'Projection',
+                    ]),
+                    codeInline<Message>('openagents.operator.rlm_traces.v1'),
+                  ]),
+                  h.div([], [
+                    h.span([Ui.className<Message>('block text-white/42')], [
+                      'Privacy',
+                    ]),
+                    codeInline<Message>('operator_refs_only'),
+                  ]),
+                ],
+              ),
+            ],
+          ),
+          h.section(
+            [Ui.className<Message>('grid gap-6 lg:grid-cols-[1.45fr_0.9fr]')],
+            [
+              h.div([Ui.className<Message>(panel)], [
+                h.div([Ui.className<Message>('grid gap-4')], [
+                  h.p([Ui.className<Message>(eyebrow)], ['Execution tree']),
+                  h.ol([Ui.className<Message>('grid gap-3 p-0')], [
+                    treeNode<Message>(tree),
+                  ]),
+                ]),
+              ]),
+              h.aside([Ui.className<Message>('grid content-start gap-6')], [
+                h.section([Ui.className<Message>(panel)], [
+                  h.div([Ui.className<Message>('grid gap-4')], [
+                    h.p([Ui.className<Message>(eyebrow)], [
+                      'Blueprint signatures',
+                    ]),
+                    signatureList<Message>(),
+                  ]),
+                ]),
+                h.section([Ui.className<Message>(panel)], [
+                  h.div([Ui.className<Message>('grid gap-4')], [
+                    h.p([Ui.className<Message>(eyebrow)], [
+                      'Authority boundary',
+                    ]),
+                    authorityTable<Message>(),
+                  ]),
+                ]),
+              ]),
+            ],
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+export const title = (): string => 'Artanis RLM traces - OpenAgents'

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.ts
@@ -9,6 +9,7 @@ import {
   adminRouter,
   activityRouter,
   animationsRouter,
+  artanisTraceTreeRouter,
   autopilotWorkDetailRouter,
   autopilotWorkRouter,
   billingRouter,
@@ -141,6 +142,7 @@ const currentHref = (model: Model): string =>
       Blog: () => blogRouter(),
       BlogPost: ({ slug }) => blogPostRouter({ slug }),
       PublicAgent: ({ agentRef }) => publicAgentRouter({ agentRef }),
+      ArtanisTraceTree: () => artanisTraceTreeRouter(),
       Trace: ({ uuid }) => traceRouter({ uuid }),
       TraceCompare: ({ ids }) => traceCompareRouter({ ids }),
       PylonCodexAssignmentStatus: ({ assignmentRef }) =>
@@ -210,6 +212,7 @@ const routeKey = (model: Model): string =>
       Blog: () => 'Blog',
       BlogPost: ({ slug }) => `BlogPost:${slug}`,
       PublicAgent: ({ agentRef }) => `PublicAgent:${agentRef}`,
+      ArtanisTraceTree: () => 'ArtanisTraceTree',
       Trace: ({ uuid }) => `Trace:${uuid}`,
       TraceCompare: ({ ids }) => `TraceCompare:${ids}`,
       PylonCodexAssignmentStatus: ({ assignmentRef }) =>
@@ -611,6 +614,10 @@ const routeView = (model: Model): Html => {
                 chatRouter(),
                 'Go to Chat',
               ),
+            ]),
+          ArtanisTraceTree: () =>
+            Ui.workroomScrollableRoute<Message>([
+              notFoundView(artanisTraceTreeRouter(), chatRouter(), 'Go to Chat'),
             ]),
           // /trace/{uuid} is a public route resolved by the top-level
           // `publicRouteBody` in view.ts before the logged-in submodel; this

--- a/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
@@ -9,6 +9,7 @@ import { homeRouter } from '../../route'
 import * as Ui from '../../ui'
 import * as Activity from '../activity'
 import * as Animations from '../animations'
+import * as ArtanisTraceTree from '../artanisTraceTree'
 import * as AutopilotOnboardingPage from '../autopilot-onboarding/page'
 import * as Blog from '../blog'
 import * as Business from '../business'
@@ -334,6 +335,8 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
               // union here no longer includes it.
               Blog: route => Blog.view(route, { _tag: 'LoggedOut' }),
               BlogPost: route => Blog.view(route, { _tag: 'LoggedOut' }),
+              ArtanisTraceTree: () =>
+                ArtanisTraceTree.view({ _tag: 'LoggedOut' }),
               PublicAgent: route => PublicAgent.view(model, route.agentRef),
               NotFound: ({ path }) =>
                 notFoundView(path, homeRouter(), 'Go Home'),

--- a/apps/openagents.com/apps/web/src/product-policy.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.ts
@@ -194,6 +194,7 @@ export const browserRouteProductIntents = {
   OperatorDashboard: 'operator.artanis.dashboard',
   ProductPromises: 'public.product-promises',
   PublicAgent: 'public.agent.profile',
+  ArtanisTraceTree: 'public.artanis.rlm-traces',
   PublicStatsArchive: 'public.stats.archive',
   PublicTrainingRun: 'public.training.run',
   PublicTrainingRuns: 'public.training.runs',

--- a/apps/openagents.com/apps/web/src/route-table.ts
+++ b/apps/openagents.com/apps/web/src/route-table.ts
@@ -150,6 +150,7 @@ const TEAMS =
 const THREAD = /^\/t\/[^/]+$/
 const TRAINING_RUNS = /^\/training\/runs(?:\/[^/]+)?$/
 const AGENTS = /^\/agents\/[^/]+$/
+const ARTANIS_TRACES = /^\/artanis\/traces$/
 
 // The full table, keyed by `AppRoute['_tag']`. `route.ts` enforces, at compile
 // time, that these keys are EXACTLY the `AppRoute` tag union (no missing, no
@@ -662,6 +663,16 @@ export const routeTable = {
     inLoggedOutUnion: true,
     inLoggedInUnion: true,
     render: 'submodel',
+  },
+  ArtanisTraceTree: {
+    surface: 'spaDocument',
+    serverDocument: ARTANIS_TRACES,
+    examplePaths: ['/artanis/traces'],
+    requiresAuthBootstrap: false,
+    loggedInGate: 'open',
+    inLoggedOutUnion: true,
+    inLoggedInUnion: true,
+    render: 'statelessShell',
   },
   Share: {
     surface: 'spaDocument',

--- a/apps/openagents.com/apps/web/src/route.test.ts
+++ b/apps/openagents.com/apps/web/src/route.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
   AdminRoute,
+  ArtanisTraceTreeRoute,
   type AppRoute,
   AutopilotRoute,
   AutopilotWorkDetailRoute,
@@ -119,6 +120,12 @@ describe('app route parser', () => {
   test('accepts the short public Artanis campaign route', () => {
     expect(urlToAppRoute(appUrl('/artanis'))).toEqual(
       PublicAgentRoute({ agentRef: 'artanis' }),
+    )
+  })
+
+  test('accepts the Artanis RLM trace tree visualizer route', () => {
+    expect(urlToAppRoute(appUrl('/artanis/traces'))).toEqual(
+      ArtanisTraceTreeRoute(),
     )
   })
 

--- a/apps/openagents.com/apps/web/src/route.ts
+++ b/apps/openagents.com/apps/web/src/route.ts
@@ -84,6 +84,7 @@ export const LoginRoute = r('Login')
 export const BlogRoute = r('Blog')
 export const BlogPostRoute = r('BlogPost', { slug: S.String })
 export const PublicAgentRoute = r('PublicAgent', { agentRef: S.String })
+export const ArtanisTraceTreeRoute = r('ArtanisTraceTree')
 export const ShareRoute = r('Share', { shareId: S.String })
 // Public, shareable ATIF trace render at `/trace/{uuid}` (issue #6209). No auth
 // to view a shared trace; the uuid is the stable shareable id.
@@ -197,6 +198,7 @@ export type LoginRoute = typeof LoginRoute.Type
 export type BlogRoute = typeof BlogRoute.Type
 export type BlogPostRoute = typeof BlogPostRoute.Type
 export type PublicAgentRoute = typeof PublicAgentRoute.Type
+export type ArtanisTraceTreeRoute = typeof ArtanisTraceTreeRoute.Type
 export type ShareRoute = typeof ShareRoute.Type
 export type TraceRoute = typeof TraceRoute.Type
 export type TraceCompareRoute = typeof TraceCompareRoute.Type
@@ -272,6 +274,7 @@ export const LoggedOutRoute = S.Union([
   BlogRoute,
   BlogPostRoute,
   PublicAgentRoute,
+  ArtanisTraceTreeRoute,
   ShareRoute,
   TraceRoute,
   TraceCompareRoute,
@@ -332,6 +335,7 @@ export const LoggedInRoute = S.Union([
   BlogRoute,
   BlogPostRoute,
   PublicAgentRoute,
+  ArtanisTraceTreeRoute,
   TraceRoute,
   TraceCompareRoute,
   PylonCodexAssignmentStatusRoute,
@@ -398,6 +402,7 @@ export const AppRoute = S.Union([
   BlogRoute,
   BlogPostRoute,
   PublicAgentRoute,
+  ArtanisTraceTreeRoute,
   ShareRoute,
   TraceRoute,
   TraceCompareRoute,
@@ -659,6 +664,11 @@ export const publicAgentRouter = pipe(
   literal('agents'),
   slash(string('agentRef')),
   Route.mapTo(PublicAgentRoute),
+)
+export const artanisTraceTreeRouter = pipe(
+  literal('artanis'),
+  slash(literal('traces')),
+  Route.mapTo(ArtanisTraceTreeRoute),
 )
 export const shareRouter = pipe(
   literal('share'),
@@ -954,6 +964,7 @@ const orderedParserRouters = [
   forumTopicRouter,
   forumForumRouter,
   blogPostRouter,
+  artanisTraceTreeRouter,
   publicAgentRouter,
   shareRouter,
   // `/trace/compare/{ids}` is more specific than `/trace/{uuid}`; it must come

--- a/apps/openagents.com/apps/web/src/routing/startup.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.ts
@@ -115,6 +115,7 @@ export const startupRouteForLoggedOut = (
       'Blog',
       'BlogPost',
       'PublicAgent',
+      'ArtanisTraceTree',
       'Share',
       'Trace',
       'TraceCompare',
@@ -174,6 +175,7 @@ const startupRouteForIncompleteOnboarding = (route: AppRoute): StartupRoute =>
     ),
     M.tag(
       'PublicAgent',
+      'ArtanisTraceTree',
       'ProductPromises',
       'Stats',
       'PublicStatsArchive',
@@ -300,6 +302,7 @@ const startupRouteForCompleteOnboarding = (
     ),
     M.tag(
       'PublicAgent',
+      'ArtanisTraceTree',
       'ProductPromises',
       'PublicTrainingRuns',
       'PublicTrainingRun',
@@ -490,6 +493,7 @@ export const startupCompleteDisposition = {
   Blog: 'gated',
   BlogPost: 'gated',
   PublicAgent: 'public',
+  ArtanisTraceTree: 'public',
   Share: 'public',
   Trace: 'public',
   TraceCompare: 'public',

--- a/apps/openagents.com/apps/web/src/view.ts
+++ b/apps/openagents.com/apps/web/src/view.ts
@@ -13,6 +13,7 @@ import type { Model } from './model'
 import { Demo, LoggedIn, LoggedOut } from './model'
 import * as Activity from './page/activity'
 import * as Animations from './page/animations'
+import * as ArtanisTraceTree from './page/artanisTraceTree'
 import * as Blog from './page/blog'
 import * as Business from './page/business'
 import * as Components from './page/components'
@@ -414,6 +415,8 @@ const title = (model: Model): string => {
       return 'Log in - OpenAgents'
     case 'PublicAgent':
       return `${model.route.agentRef} - OpenAgents`
+    case 'ArtanisTraceTree':
+      return ArtanisTraceTree.title()
     case 'Share':
       return 'Shared Workroom - OpenAgents'
     case 'Trace':
@@ -628,6 +631,7 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
       model.route._tag !== 'TassadarReplay' &&
       model.route._tag !== 'Trace' &&
       model.route._tag !== 'TraceCompare' &&
+      model.route._tag !== 'ArtanisTraceTree' &&
       model.route._tag !== 'PylonCodexAssignmentStatus'
     ) {
       return undefined
@@ -691,6 +695,10 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
 
   if (model.route._tag === 'PylonCodexAssignmentStatus') {
     return PylonCodexAssignmentStatus.view<Message>(model.route, authState)
+  }
+
+  if (model.route._tag === 'ArtanisTraceTree') {
+    return ArtanisTraceTree.view<Message>(authState)
   }
 
   if (model.route._tag === 'Animations') {


### PR DESCRIPTION
Addresses #6687.

### Changes
- Added the `/artanis/traces` route as `ArtanisTraceTree` across the web route schema, parser, route table, startup routing, and product intent mapping.
- Wired the Artanis trace tree page into logged-out rendering and logged-in route handling.
- Added route coverage for `/artanis/traces` and trace tree page tests.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).