### PR TITLE
feat(artanis): enforce Blueprint grounding/command gates in the operator loop (full-Blueprint-set wiring, slice 1)

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-grounding-gate.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-grounding-gate.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  ARTANIS_GROUNDING_ADDENDUM_HEADER,
+  enforceArtanisGroundingGate,
+  evaluateArtanisGroundingGate,
+  extractArtanisGroundingLookup,
+  extractArtanisRunnableArtifacts,
+  type ArtanisGroundingLookup,
+} from './artanis-operator-grounding-gate'
+
+describe('artanis grounding gate — runnable-artifact extraction', () => {
+  test('extracts file paths, scripts (as commands), and API endpoints', () => {
+    const reply = [
+      'Run `bun apps/pylon/scripts/multi-session-campaign.ts --burst 4` to start.',
+      'Then call POST /api/admin/khala/mint and read docs/roadmap.md.',
+    ].join('\n')
+    const artifacts = extractArtanisRunnableArtifacts(reply)
+    const kinds = artifacts.map(a => `${a.kind}:${a.ref}`)
+    expect(kinds).toContain('file_path:apps/pylon/scripts/multi-session-campaign.ts')
+    expect(kinds).toContain('command:apps/pylon/scripts/multi-session-campaign.ts')
+    expect(kinds).toContain('file_path:docs/roadmap.md')
+    const endpoint = artifacts.find(a => a.kind === 'api_endpoint')
+    expect(endpoint?.ref).toBe('/api/admin/khala/mint')
+    expect(endpoint?.method).toBe('POST')
+    const command = artifacts.find(a => a.kind === 'command')
+    expect(command?.flags).toContain('--burst')
+  })
+
+  test('does not extract bare prose words without a path separator', () => {
+    expect(extractArtanisRunnableArtifacts('I improved the index today.')).toEqual(
+      [],
+    )
+    // "../" traversal-shaped tokens are never treated as artifacts.
+    expect(
+      extractArtanisRunnableArtifacts('see ../../etc/passwd.sh maybe'),
+    ).toEqual([])
+  })
+})
+
+describe('artanis grounding gate — lookup extraction from tool results', () => {
+  test('repo_path_exists positive and negative', () => {
+    const positive = extractArtanisGroundingLookup({
+      toolName: 'repo_path_exists',
+      rawArguments: '{"path":"apps/pylon/scripts/multi-session-campaign.ts"}',
+      content: 'GROUNDED: "apps/pylon/scripts/multi-session-campaign.ts" EXISTS (file, 900 bytes) in OpenAgentsInc/openagents@main.',
+    })
+    expect(positive).toMatchObject({
+      tool: 'repo_path_exists',
+      ref: 'apps/pylon/scripts/multi-session-campaign.ts',
+      result: 'positive',
+    })
+    const negative = extractArtanisGroundingLookup({
+      toolName: 'repo_path_exists',
+      rawArguments: '{"path":"scripts/distill_traces.ts"}',
+      content: 'GROUNDING: "scripts/distill_traces.ts" does NOT exist in OpenAgentsInc/openagents@main. UNGROUNDED — do not present it as a real file/script/command; label it SPECULATIVE.',
+    })
+    expect(negative?.result).toBe('negative')
+  })
+
+  test('route_exists positive and negative', () => {
+    const positive = extractArtanisGroundingLookup({
+      toolName: 'route_exists',
+      rawArguments: '{"method":"POST","path":"/api/v1/chat/completions"}',
+      content: 'GROUNDED: POST "/api/v1/chat/completions" is a registered route in the OpenAPI registry. Registered methods: POST.',
+    })
+    expect(positive?.result).toBe('positive')
+    const negative = extractArtanisGroundingLookup({
+      toolName: 'route_exists',
+      rawArguments: '{"method":"POST","path":"/api/admin/khala/mint"}',
+      content: 'GROUNDING: "/api/admin/khala/mint" is NOT in the OpenAPI route registry. UNGROUNDED — do not present "POST /api/admin/khala/mint" as a real endpoint; label it SPECULATIVE.',
+    })
+    expect(negative?.result).toBe('negative')
+  })
+
+  test('read_repo_file success counts as path grounding, error does not', () => {
+    const success = extractArtanisGroundingLookup({
+      toolName: 'read_repo_file',
+      rawArguments: '{"path":"docs/roadmap.md"}',
+      content: '# Roadmap\nFirst priority is the #6316 track.',
+    })
+    expect(success?.result).toBe('positive')
+    const missing = extractArtanisGroundingLookup({
+      toolName: 'read_repo_file',
+      rawArguments: '{"path":"docs/does-not-exist.md"}',
+      content: '(file not found: "docs/does-not-exist.md")',
+    })
+    expect(missing?.result).toBe('negative')
+  })
+
+  test('non-grounding tools produce no lookup', () => {
+    expect(
+      extractArtanisGroundingLookup({
+        toolName: 'get_network_stats',
+        rawArguments: '{}',
+        content: 'tokens served: 1B',
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('artanis grounding gate — evaluation + enforcement', () => {
+  test('a fabricated script path is flagged SPECULATIVE (UNGROUNDED)', () => {
+    const reply =
+      'You can regenerate the traces with `bun scripts/distill_traces.ts --since 24h`.'
+    const { reply: out, gate } = enforceArtanisGroundingGate({
+      reply,
+      lookups: [],
+    })
+    expect(gate.allGrounded).toBe(false)
+    expect(gate.enforced).toBe(true)
+    expect(out).toContain(ARTANIS_GROUNDING_ADDENDUM_HEADER)
+    expect(out).toContain('scripts/distill_traces.ts')
+    expect(out).toContain('SPECULATIVE')
+    expect(
+      gate.speculativeArtifacts.some(
+        a => a.artifactRef === 'scripts/distill_traces.ts',
+      ),
+    ).toBe(true)
+  })
+
+  test('a fabricated API endpoint with a negative route lookup is gated', () => {
+    const reply = 'I will mint via POST /api/admin/khala/mint.'
+    const lookups: ReadonlyArray<ArtanisGroundingLookup> = [
+      {
+        tool: 'route_exists',
+        ref: '/api/admin/khala/mint',
+        result: 'negative',
+        matchedFlags: [],
+        matchedText: null,
+      },
+    ]
+    const { gate } = enforceArtanisGroundingGate({ reply, lookups })
+    expect(gate.allGrounded).toBe(false)
+    const verdict = gate.evaluated.find(
+      v => v.artifactRef === '/api/admin/khala/mint',
+    )
+    expect(verdict?.state).toBe('LOOKED_UP')
+    expect(verdict?.grounded).toBe(false)
+  })
+
+  test('a verified path + route passes GROUNDED with no addendum', () => {
+    const reply = [
+      'Run `bun apps/pylon/scripts/multi-session-campaign.ts --burst 4`.',
+      'It posts to POST /api/v1/chat/completions.',
+    ].join('\n')
+    const lookups: ReadonlyArray<ArtanisGroundingLookup> = [
+      {
+        tool: 'repo_path_exists',
+        ref: 'apps/pylon/scripts/multi-session-campaign.ts',
+        result: 'positive',
+        matchedFlags: [],
+        matchedText: null,
+      },
+      {
+        tool: 'repo_grep',
+        ref: 'apps/pylon/scripts/multi-session-campaign.ts',
+        result: 'positive',
+        matchedFlags: ['--burst'],
+        matchedText: 'GROUNDED: /--burst/ matched 1 line(s)',
+      },
+      {
+        tool: 'route_exists',
+        ref: '/api/v1/chat/completions',
+        result: 'positive',
+        matchedFlags: [],
+        matchedText: null,
+      },
+    ]
+    const { reply: out, gate } = enforceArtanisGroundingGate({ reply, lookups })
+    expect(gate.allGrounded).toBe(true)
+    expect(gate.enforced).toBe(false)
+    expect(out).toBe(reply)
+    // The command artifact carries an attached S4 sub-verdict.
+    const command = gate.evaluated.find(v => v.artifactKind === 'command')
+    expect(command?.commandSourceVerified).not.toBeNull()
+    expect(command?.commandSourceVerified?.satisfiedEvidence).toContain(
+      'evidence://command/flag-verification',
+    )
+  })
+
+  test('does not double-flag an artifact the reply already marked SPECULATIVE', () => {
+    const reply =
+      'There may be a script scripts/distill_traces.ts but I have not verified it exists (SPECULATIVE).'
+    const { gate } = evaluateAndEnforce(reply)
+    expect(gate.speculativeArtifacts).toEqual([])
+    expect(gate.enforced).toBe(false)
+  })
+
+  test('a reply naming no runnable artifact is left untouched', () => {
+    const reply = 'The burndown is healthy; three assignments merged today.'
+    const gate = evaluateArtanisGroundingGate({ reply, lookups: [] })
+    expect(gate.evaluated).toEqual([])
+    expect(gate.allGrounded).toBe(true)
+  })
+})
+
+const evaluateAndEnforce = (reply: string) =>
+  enforceArtanisGroundingGate({ reply, lookups: [] })

--- a/apps/openagents.com/workers/api/src/artanis-operator-grounding-gate.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-grounding-gate.ts
@@ -1,0 +1,538 @@
+// Artanis operator GROUNDING GATE — the enforcement layer that makes the
+// Blueprint Signature-6 `operator-grounded-assertion` (and the Signature-4
+// `command-execution-source-verified` sub-check) STRUCTURAL rather than merely
+// prompt-level. (Epic: full-Blueprint-set wiring, slice 1.)
+//
+// WHY THIS EXISTS
+// ---------------
+// The operator system prompt has a GROUNDED-ASSERTION RULE telling Artanis to
+// call the grounding tools (repo_path_exists / repo_grep / route_exists) before
+// naming a runnable artifact. But a PROMPT is advisory: a headless model can —
+// and historically did — present a fabricated `scripts/distill_traces.ts` or a
+// hallucinated `POST /api/admin/khala/mint` endpoint as if it were real, never
+// having looked it up. This module turns that rule into a GATE: it audits the
+// operator's OWN final reply for runnable-artifact references, correlates each
+// against the grounding lookups actually performed THIS turn, runs the shared
+// Blueprint gate state machines (imported, not re-described, from
+// `@openagentsinc/blueprint-contracts`), and forces any UNGROUNDED reference to
+// be labeled SPECULATIVE in the returned reply. A path the model never verified
+// can no longer reach the owner as "runnable".
+//
+// SCOPE / BOUNDARY (honest):
+//   - This is a bounded AUDIT predicate over Artanis's own output (like the
+//     persona-separation guard) — NOT user-intent routing.
+//   - The ENFORCED gate is S6 (operator-grounded-assertion): UNGROUNDED
+//     references are tagged SPECULATIVE. S4 (command-execution-source-verified)
+//     is applied and ATTACHED as structured evidence for command artifacts using
+//     the evidence reachable to a headless operator (source-read + flag content
+//     match); the runtime `--help`/dry-run predicate is NOT reachable headless,
+//     so S4 cannot reach SAFE_TO_PROPOSE here — that final probe is a documented
+//     server-side follow-up. S6 is the blocker; S4 is the report.
+//   - Grounding evidence comes from the three canonical S6 tools
+//     (repo_path_exists / repo_grep / route_exists). A successful repo READ
+//     (read_repo_file / list_repo_dir) is also accepted as path-existence
+//     grounding because it is strictly stronger evidence the path exists; this
+//     avoids false-flagging a file Artanis actually read.
+
+import {
+  COMMAND_SOURCE_VERIFIED_EVIDENCE,
+  evaluateCommandSourceVerified,
+  evaluateOperatorGroundedAssertion,
+  parseCommandFlags,
+  type CommandSourceVerifiedResult,
+  type OperatorGroundedArtifactKind,
+  type OperatorGroundedAssertionState,
+  type OperatorGroundedLookupResult,
+} from '@openagentsinc/blueprint-contracts'
+
+import { parseJsonUnknown } from './json-boundary'
+
+// ---------------------------------------------------------------------------
+// Runnable-artifact extraction (the audit predicate over the operator's reply).
+// ---------------------------------------------------------------------------
+
+// File/script extensions we treat as a referenced repo path. A path must also
+// contain a "/" so a bare word like "index.ts" in prose is not mis-extracted.
+const ARTANIS_PATH_EXTENSIONS = [
+  'ts',
+  'tsx',
+  'js',
+  'jsx',
+  'mjs',
+  'cjs',
+  'sh',
+  'py',
+  'sql',
+  'toml',
+  'yml',
+  'yaml',
+  'rs',
+  'md',
+] as const
+
+// Extensions whose files are runnable scripts (drive the S4 command sub-check).
+const ARTANIS_RUNNABLE_SCRIPT_EXTENSIONS: ReadonlyArray<string> = [
+  'ts',
+  'js',
+  'mjs',
+  'cjs',
+  'sh',
+  'py',
+  'rs',
+]
+
+const PATH_REGEX = new RegExp(
+  // The negative lookbehind rejects a token that is itself the tail of a larger
+  // path or a "../" traversal (so "../../etc/passwd.sh" is not mined as a ref).
+  `(?<![A-Za-z0-9_./-])([A-Za-z0-9_][A-Za-z0-9_./-]*\\/[A-Za-z0-9_./-]*\\.(?:${ARTANIS_PATH_EXTENSIONS.join('|')}))`,
+  'g',
+)
+
+// METHOD + path, e.g. "POST /api/admin/khala/mint".
+const METHOD_ENDPOINT_REGEX =
+  /\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(\/[A-Za-z0-9_./{}:-]+)/g
+
+// Bare API path, e.g. "/api/admin/khala/mint" (method unknown).
+const BARE_API_PATH_REGEX = /(\/api\/[A-Za-z0-9_./{}:-]+)/g
+
+// Trim trailing punctuation a model leaves on an inline ref ("...mint." -> path).
+const trimArtifactRef = (raw: string): string =>
+  raw.replace(/[.,;:)\]\}>'"`]+$/, '').trim()
+
+export type ArtanisRunnableArtifact = Readonly<{
+  kind: 'file_path' | 'api_endpoint' | 'command'
+  // For file_path/api_endpoint: the path. For command: the path of the script
+  // the command runs (commands are anchored to a runnable repo script).
+  ref: string
+  // For api_endpoint: the HTTP method when present, else null.
+  method: string | null
+  // For command: the full command-line text and its parsed flags.
+  commandString: string | null
+  flags: ReadonlyArray<string>
+}>
+
+// Pull the line containing `index` so a command artifact can carry its flags.
+const lineContaining = (text: string, index: number): string => {
+  const start = text.lastIndexOf('\n', index) + 1
+  const endNl = text.indexOf('\n', index)
+  const end = endNl === -1 ? text.length : endNl
+  return text.slice(start, end)
+}
+
+const extensionOf = (path: string): string => {
+  const dot = path.lastIndexOf('.')
+  return dot === -1 ? '' : path.slice(dot + 1).toLowerCase()
+}
+
+// Extract the runnable artifacts referenced by the reply. High-precision: only
+// "/"-bearing paths with a known extension and absolute API paths are caught. A
+// runnable-script path that appears on a line carrying flags is ALSO emitted as
+// a `command` artifact so the S4 sub-check can run.
+export const extractArtanisRunnableArtifacts = (
+  reply: string,
+): ReadonlyArray<ArtanisRunnableArtifact> => {
+  if (typeof reply !== 'string' || reply.trim() === '') return []
+  const out: Array<ArtanisRunnableArtifact> = []
+  const seen = new Set<string>()
+
+  const push = (artifact: ArtanisRunnableArtifact): void => {
+    const key = `${artifact.kind}:${artifact.method ?? ''}:${artifact.ref}:${artifact.commandString ?? ''}`
+    if (seen.has(key)) return
+    seen.add(key)
+    out.push(artifact)
+  }
+
+  // File / script paths.
+  for (const match of reply.matchAll(PATH_REGEX)) {
+    const ref = trimArtifactRef(match[1] ?? '')
+    if (ref === '' || ref.includes('..')) continue
+    push({ kind: 'file_path', ref, method: null, commandString: null, flags: [] })
+
+    // If this is a runnable script and its line carries flags, emit a command.
+    if (ARTANIS_RUNNABLE_SCRIPT_EXTENSIONS.includes(extensionOf(ref))) {
+      const line = lineContaining(reply, match.index ?? 0).trim()
+      const flags = parseCommandFlags(line)
+      if (flags.length > 0) {
+        push({
+          kind: 'command',
+          ref,
+          method: null,
+          commandString: line,
+          flags,
+        })
+      }
+    }
+  }
+
+  // METHOD + endpoint.
+  const methodPaths = new Set<string>()
+  for (const match of reply.matchAll(METHOD_ENDPOINT_REGEX)) {
+    const method = (match[1] ?? '').toUpperCase()
+    const ref = trimArtifactRef(match[2] ?? '')
+    if (ref === '' || ref.includes('..')) continue
+    methodPaths.add(ref)
+    push({ kind: 'api_endpoint', ref, method, commandString: null, flags: [] })
+  }
+
+  // Bare API paths (only if not already captured with a method).
+  for (const match of reply.matchAll(BARE_API_PATH_REGEX)) {
+    const ref = trimArtifactRef(match[1] ?? '')
+    if (ref === '' || ref.includes('..') || methodPaths.has(ref)) continue
+    push({ kind: 'api_endpoint', ref, method: null, commandString: null, flags: [] })
+  }
+
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Grounding-lookup capture (correlate the operator's tool calls to artifacts).
+// ---------------------------------------------------------------------------
+
+// The grounding/read tools whose outputs ground a runnable artifact's existence.
+export const ARTANIS_GROUNDING_TOOL_NAMES: ReadonlyArray<string> = [
+  'repo_path_exists',
+  'repo_grep',
+  'route_exists',
+  'read_repo_file',
+  'list_repo_dir',
+]
+
+// A single grounding lookup Artanis actually performed this turn, distilled from
+// a grounding/read tool call's arguments + result text.
+export type ArtanisGroundingLookup = Readonly<{
+  tool: string
+  // The repo path or API path that was looked up.
+  ref: string
+  result: 'positive' | 'negative'
+  // For repo_grep positives: flag tokens found in the matched lines (feeds the
+  // S4 `declaredFlags` argument surface) and the matched text (S4 source hash).
+  matchedFlags: ReadonlyArray<string>
+  matchedText: string | null
+}>
+
+// Read-tool error prefixes: a read whose result starts with one of these did
+// NOT confirm the path. Everything else from a read tool is real file/dir body.
+const READ_NEGATIVE_PREFIXES: ReadonlyArray<string> = [
+  '(tool error',
+  '(file not found',
+  '(blocked',
+  '(could not',
+  '(read failed',
+  '(invalid',
+  '("',
+]
+
+const startsWithAny = (text: string, prefixes: ReadonlyArray<string>): boolean =>
+  prefixes.some(prefix => text.startsWith(prefix))
+
+const readPathArgument = (args: unknown): string | undefined => {
+  if (typeof args !== 'object' || args === null) return undefined
+  const value = (args as Record<string, unknown>).path
+  return typeof value === 'string' && value.trim() !== ''
+    ? trimArtifactRef(value.trim())
+    : undefined
+}
+
+const parseArgs = (raw: string): unknown => {
+  const trimmed = (raw ?? '').trim()
+  if (trimmed === '') return {}
+  try {
+    return parseJsonUnknown(trimmed)
+  } catch {
+    return {}
+  }
+}
+
+// Pull flag tokens out of repo_grep matched-line text (the script's declared
+// argument surface, as observed in the real file).
+const flagsInText = (text: string): ReadonlyArray<string> => {
+  const flags: Array<string> = []
+  for (const match of text.matchAll(/(?:^|[\s"'`(])(--?[A-Za-z][A-Za-z0-9-]*)/g)) {
+    const flag = match[1] ?? ''
+    if (flag.length > 1 && !flags.includes(flag)) flags.push(flag)
+  }
+  return flags
+}
+
+// Distill a grounding lookup from one grounding/read tool result, or null when
+// the tool is not a grounding/read tool or carried no usable path argument.
+export const extractArtanisGroundingLookup = (input: {
+  toolName: string
+  rawArguments: string
+  content: string
+}): ArtanisGroundingLookup | null => {
+  const { toolName, content } = input
+  if (!ARTANIS_GROUNDING_TOOL_NAMES.includes(toolName)) return null
+  const args = parseArgs(input.rawArguments)
+  const ref = readPathArgument(args)
+  if (ref === undefined) return null
+
+  if (toolName === 'read_repo_file' || toolName === 'list_repo_dir') {
+    const negative = startsWithAny(content.trim(), READ_NEGATIVE_PREFIXES)
+    return {
+      tool: toolName,
+      ref,
+      result: negative ? 'negative' : 'positive',
+      matchedFlags: [],
+      matchedText: null,
+    }
+  }
+
+  // The three canonical S6 grounding tools emit a "GROUNDED:" prefix on a
+  // positive lookup and "UNGROUNDED" (within "GROUNDING: …") on a negative one.
+  const positive =
+    content.startsWith('GROUNDED:') && !content.includes('UNGROUNDED')
+  if (toolName === 'repo_grep') {
+    return {
+      tool: toolName,
+      ref,
+      result: positive ? 'positive' : 'negative',
+      matchedFlags: positive ? flagsInText(content) : [],
+      matchedText: positive ? content : null,
+    }
+  }
+  return {
+    tool: toolName,
+    ref,
+    result: positive ? 'positive' : 'negative',
+    matchedFlags: [],
+    matchedText: null,
+  }
+}
+
+// True when a concrete request path matches an OpenAPI-style template segment
+// (a `{param}` segment matches any one non-empty concrete segment). Mirrors the
+// route_exists matcher so a concrete endpoint grounds against a templated lookup.
+const pathMatchesTemplate = (requestPath: string, template: string): boolean => {
+  if (requestPath === template) return true
+  const a = requestPath.split('/')
+  const b = template.split('/')
+  if (a.length !== b.length) return false
+  for (let i = 0; i < b.length; i += 1) {
+    const t = b[i] ?? ''
+    const r = a[i] ?? ''
+    if (t.startsWith('{') && t.endsWith('}')) {
+      if (r === '') return false
+      continue
+    }
+    if (t !== r) return false
+  }
+  return true
+}
+
+// Find the lookup that grounds an artifact, or null if it was never looked up.
+const findLookupForArtifact = (
+  artifact: ArtanisRunnableArtifact,
+  lookups: ReadonlyArray<ArtanisGroundingLookup>,
+): ArtanisGroundingLookup | null => {
+  const candidates =
+    artifact.kind === 'api_endpoint'
+      ? lookups.filter(
+          lookup =>
+            lookup.tool === 'route_exists' &&
+            pathMatchesTemplate(artifact.ref, lookup.ref),
+        )
+      : lookups.filter(
+          lookup =>
+            lookup.tool !== 'route_exists' && lookup.ref === artifact.ref,
+        )
+  if (candidates.length === 0) return null
+  // A positive lookup grounds; otherwise report the (negative) lookup that ran.
+  return candidates.find(lookup => lookup.result === 'positive') ?? candidates[0] ?? null
+}
+
+// ---------------------------------------------------------------------------
+// The gate verdict (structured, attached to the turn).
+// ---------------------------------------------------------------------------
+
+export type ArtanisGroundingArtifactVerdict = Readonly<{
+  artifactKind: OperatorGroundedArtifactKind
+  artifactRef: string
+  state: OperatorGroundedAssertionState
+  grounded: boolean
+  lookupTool: string | null
+  lookupResult: OperatorGroundedLookupResult
+  satisfiedEvidence: ReadonlyArray<string>
+  missingEvidence: ReadonlyArray<string>
+  // S4 sub-verdict for `command` artifacts; null for file_path/api_endpoint.
+  commandSourceVerified: CommandSourceVerifiedResult | null
+}>
+
+export type ArtanisOperatorGroundingGateResult = Readonly<{
+  evaluated: ReadonlyArray<ArtanisGroundingArtifactVerdict>
+  // True when every referenced artifact reached GROUNDED (or none were named).
+  allGrounded: boolean
+  // The ungrounded references that were (or would be) tagged SPECULATIVE.
+  speculativeArtifacts: ReadonlyArray<
+    Readonly<{ artifactKind: OperatorGroundedArtifactKind; artifactRef: string }>
+  >
+  // True when the reply was augmented with the grounding addendum.
+  enforced: boolean
+}>
+
+const EMPTY_GATE: ArtanisOperatorGroundingGateResult = {
+  evaluated: [],
+  allGrounded: true,
+  speculativeArtifacts: [],
+  enforced: false,
+}
+
+const artifactKindFor = (
+  artifact: ArtanisRunnableArtifact,
+): OperatorGroundedArtifactKind =>
+  artifact.kind === 'command'
+    ? 'command'
+    : artifact.kind === 'api_endpoint'
+      ? 'api_endpoint'
+      : 'file_path'
+
+// Speculative-marker tokens (lowercased) used to detect that the reply ALREADY
+// flagged an artifact, so the gate does not double-tag it.
+export const ARTANIS_SPECULATIVE_MARKERS: ReadonlyArray<string> = [
+  'speculative',
+  'have not verified',
+  "haven't verified",
+  'not verified',
+  'unverified',
+  'unconfirmed',
+  'did not verify',
+  'cannot confirm',
+  "can't confirm",
+  'does not exist',
+  "doesn't exist",
+  'may not exist',
+  'if it exists',
+]
+
+// True when the reply already labels `ref` speculative within its own line.
+const replyAlreadyFlags = (reply: string, ref: string): boolean => {
+  const lower = reply.toLowerCase()
+  const refLower = ref.toLowerCase()
+  let from = 0
+  for (;;) {
+    const at = lower.indexOf(refLower, from)
+    if (at === -1) return false
+    const line = lineContaining(lower, at)
+    if (ARTANIS_SPECULATIVE_MARKERS.some(marker => line.includes(marker))) {
+      return true
+    }
+    from = at + refLower.length
+  }
+}
+
+// Evaluate the grounding gate over a reply + the lookups performed this turn.
+// Pure: produces the structured verdict list WITHOUT mutating the reply.
+export const evaluateArtanisGroundingGate = (input: {
+  reply: string
+  lookups: ReadonlyArray<ArtanisGroundingLookup>
+}): ArtanisOperatorGroundingGateResult => {
+  const artifacts = extractArtanisRunnableArtifacts(input.reply)
+  if (artifacts.length === 0) return EMPTY_GATE
+
+  const evaluated: Array<ArtanisGroundingArtifactVerdict> = []
+  const speculative: Array<{
+    artifactKind: OperatorGroundedArtifactKind
+    artifactRef: string
+  }> = []
+
+  for (const artifact of artifacts) {
+    const lookup = findLookupForArtifact(artifact, input.lookups)
+    const lookupResult: OperatorGroundedLookupResult =
+      lookup === null ? 'not_looked_up' : lookup.result === 'positive' ? 'positive' : 'negative'
+    const artifactKind = artifactKindFor(artifact)
+    const refForGate = artifact.kind === 'command' ? artifact.ref : artifact.ref
+
+    const s6 = evaluateOperatorGroundedAssertion({
+      artifactKind,
+      artifactRef: refForGate,
+      lookupTool: lookup?.tool ?? null,
+      lookupResult,
+    })
+
+    // S4 sub-check for command artifacts: apply the shared evaluator with the
+    // evidence reachable headless (source-read + flag content match). The
+    // dry-run runtime probe is NOT reachable here, so S4 cannot reach
+    // SAFE_TO_PROPOSE — it is attached as structured evidence, not a blocker.
+    let commandSourceVerified: CommandSourceVerifiedResult | null = null
+    if (artifact.kind === 'command') {
+      const grep = input.lookups.find(
+        candidate =>
+          candidate.tool === 'repo_grep' &&
+          candidate.ref === artifact.ref &&
+          candidate.result === 'positive',
+      )
+      const grounded = lookup !== null && lookup.result === 'positive'
+      commandSourceVerified = evaluateCommandSourceVerified({
+        commandString: artifact.commandString ?? '',
+        scriptPath: artifact.ref,
+        expectedFlags: artifact.flags,
+        sourceReadHash: grounded ? `grounded:${lookup?.tool}:${artifact.ref}` : null,
+        declaredFlags: grep?.matchedFlags ?? [],
+        dryRunExitCode: null,
+      })
+    }
+
+    evaluated.push({
+      artifactKind,
+      artifactRef: refForGate,
+      state: s6.state,
+      grounded: s6.canAssert,
+      lookupTool: s6.lookupTool,
+      lookupResult: s6.lookupResult,
+      satisfiedEvidence: s6.satisfiedEvidence,
+      missingEvidence: s6.missingEvidence,
+      commandSourceVerified,
+    })
+
+    if (!s6.canAssert && !replyAlreadyFlags(input.reply, refForGate)) {
+      speculative.push({ artifactKind, artifactRef: refForGate })
+    }
+  }
+
+  return {
+    evaluated,
+    allGrounded: evaluated.every(verdict => verdict.grounded),
+    speculativeArtifacts: speculative,
+    enforced: false,
+  }
+}
+
+// The header line of the enforcement addendum (exported for tests).
+export const ARTANIS_GROUNDING_ADDENDUM_HEADER =
+  'GROUNDING GATE (Blueprint Signature 6 — operator-grounded-assertion):'
+
+const reasonFor = (artifactKind: OperatorGroundedArtifactKind): string =>
+  artifactKind === 'api_endpoint'
+    ? 'not confirmed in the OpenAPI route registry this turn'
+    : 'no repo grounding lookup confirmed it this turn'
+
+// Enforce the gate: evaluate it, and if any referenced artifact is UNGROUNDED
+// and not already labeled, APPEND a SPECULATIVE addendum to the reply so the
+// model can never present an unverified path/endpoint as runnable. Returns the
+// (possibly augmented) reply and the final gate result (with `enforced` set).
+export const enforceArtanisGroundingGate = (input: {
+  reply: string
+  lookups: ReadonlyArray<ArtanisGroundingLookup>
+}): Readonly<{ reply: string; gate: ArtanisOperatorGroundingGateResult }> => {
+  const gate = evaluateArtanisGroundingGate(input)
+  if (gate.speculativeArtifacts.length === 0) {
+    return { reply: input.reply, gate }
+  }
+
+  const lines = [
+    '',
+    '---',
+    `${ARTANIS_GROUNDING_ADDENDUM_HEADER} I referenced ${gate.speculativeArtifacts.length} runnable artifact(s) I did not verify exist this turn. Treat these as SPECULATIVE (unverified), not as confirmed runnable:`,
+    ...gate.speculativeArtifacts.map(
+      artifact =>
+        `- [${artifact.artifactKind}] ${artifact.artifactRef} — UNGROUNDED (${reasonFor(artifact.artifactKind)})`,
+    ),
+  ]
+  return {
+    reply: `${input.reply}\n${lines.join('\n')}`,
+    gate: { ...gate, enforced: true },
+  }
+}
+
+// Re-export the gate evidence vocabulary so the doc/tests share one source.
+export { COMMAND_SOURCE_VERIFIED_EVIDENCE }

--- a/apps/openagents.com/workers/api/src/artanis-operator.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.test.ts
@@ -29,8 +29,10 @@ import {
 } from './inference/provider-adapter'
 import {
   makeArtanisGetKhalaFeedbackTool,
+  makeArtanisRepoPathExistsTool,
   makeArtanisTriggerSyntheticLoadTool,
 } from './artanis-operator-tools'
+import { ARTANIS_GROUNDING_ADDENDUM_HEADER } from './artanis-operator-grounding-gate'
 
 // Real owner-memory entries (most-recent-first, as the store returns them).
 const exampleMemory: ReadonlyArray<ArtanisMemoryEntry> = [
@@ -1155,5 +1157,128 @@ describe('#6359 the turn never returns an empty reply (cap / blank-completion gu
       ARTANIS_OPERATOR_TOOL_RESULT_CONTEXT_MAX_CHARS + 200,
     )
     expect(toolMessage?.content).toContain('truncated at')
+  })
+})
+
+
+// ---------------------------------------------------------------------------
+// Full-Blueprint-set wiring, slice 1: the operator loop ENFORCES the Blueprint
+// Signature-6 grounding gate over the final reply. A fabricated path/endpoint is
+// structurally tagged SPECULATIVE; a verified one passes GROUNDED. This is the
+// "headless but full Blueprint set" guarantee — grounding is no longer merely a
+// prompt instruction the model can ignore.
+// ---------------------------------------------------------------------------
+
+describe('artanis operator grounding gate enforcement (Blueprint Signature 6)', () => {
+  test('a turn that fabricates a script path AND an API endpoint is gated SPECULATIVE', async () => {
+    // The model ignores the GROUNDED-ASSERTION RULE and names two artifacts it
+    // never looked up. With no grounding lookups performed, the loop must gate
+    // them — the prompt-level rule is now a structural gate.
+    const { client } = makeScriptedKhalaClient([
+      textResult(
+        'Regenerate the traces with `bun scripts/distill_traces.ts --since 24h`, then mint via POST /api/admin/khala/mint.',
+      ),
+    ])
+
+    const result = await Effect.runPromise(
+      artanisOperatorTurn({
+        awareness: exampleAwareness,
+        khalaClient: client,
+        memory: exampleMemory,
+        messages: [{ content: 'how do I regenerate the traces?', role: 'user' }],
+        ownerId: 'owner:github:14167547',
+      }),
+    )
+
+    expect('error' in result).toBe(false)
+    if ('error' in result) return
+    expect(result.groundingGate.allGrounded).toBe(false)
+    expect(result.groundingGate.enforced).toBe(true)
+    // Both fabricated artifacts are recorded as SPECULATIVE on the turn.
+    const refs = result.groundingGate.speculativeArtifacts.map(a => a.artifactRef)
+    expect(refs).toContain('scripts/distill_traces.ts')
+    expect(refs).toContain('/api/admin/khala/mint')
+    // The reply itself now carries the structural SPECULATIVE addendum, so the
+    // owner can never read a fabricated path as runnable.
+    expect(result.reply).toContain(ARTANIS_GROUNDING_ADDENDUM_HEADER)
+    expect(result.reply).toContain('SPECULATIVE')
+    // None of the artifacts reached GROUNDED.
+    expect(result.groundingGate.evaluated.every(v => !v.grounded)).toBe(true)
+  })
+
+  test('a turn that VERIFIES a path via repo_path_exists passes GROUNDED with no addendum', async () => {
+    const realPath = 'apps/pylon/scripts/multi-session-campaign.ts'
+    // repo_path_exists fetch returns a 200 file object => GROUNDED existence.
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ size: 900, type: 'file' }), {
+        status: 200,
+      })) as unknown as typeof fetch
+    const tool = makeArtanisRepoPathExistsTool({ fetchImpl })
+
+    const { client } = makeScriptedKhalaClient([
+      toolCallResult('repo_path_exists', JSON.stringify({ path: realPath })),
+      textResult(`Use ${realPath} for the campaign run.`),
+    ])
+
+    const result = await Effect.runPromise(
+      artanisOperatorTurn({
+        awareness: exampleAwareness,
+        khalaClient: client,
+        memory: exampleMemory,
+        messages: [{ content: 'which script runs the campaign?', role: 'user' }],
+        ownerId: 'owner:github:14167547',
+        tools: [tool],
+      }),
+    )
+
+    expect('error' in result).toBe(false)
+    if ('error' in result) return
+    expect(result.groundingGate.allGrounded).toBe(true)
+    expect(result.groundingGate.enforced).toBe(false)
+    expect(result.groundingGate.speculativeArtifacts).toEqual([])
+    // The reply is delivered untouched: no SPECULATIVE addendum.
+    expect(result.reply).not.toContain(ARTANIS_GROUNDING_ADDENDUM_HEADER)
+    expect(result.reply).toContain(realPath)
+    const verdict = result.groundingGate.evaluated.find(
+      v => v.artifactRef === realPath,
+    )
+    expect(verdict?.state).toBe('GROUNDED')
+    expect(verdict?.grounded).toBe(true)
+    expect(verdict?.lookupTool).toBe('repo_path_exists')
+  })
+
+  test('a fabricated path looked up with a NEGATIVE result is still gated', async () => {
+    const fakePath = 'scripts/distill_traces.ts'
+    // repo_path_exists fetch returns 404 => existence UNGROUNDED.
+    const fetchImpl = (async () =>
+      new Response('Not Found', { status: 404 })) as unknown as typeof fetch
+    const tool = makeArtanisRepoPathExistsTool({ fetchImpl })
+
+    const { client } = makeScriptedKhalaClient([
+      toolCallResult('repo_path_exists', JSON.stringify({ path: fakePath })),
+      textResult(`I would run ${fakePath} to rebuild the traces.`),
+    ])
+
+    const result = await Effect.runPromise(
+      artanisOperatorTurn({
+        awareness: exampleAwareness,
+        khalaClient: client,
+        memory: exampleMemory,
+        messages: [{ content: 'rebuild the traces', role: 'user' }],
+        ownerId: 'owner:github:14167547',
+        tools: [tool],
+      }),
+    )
+
+    expect('error' in result).toBe(false)
+    if ('error' in result) return
+    expect(result.groundingGate.allGrounded).toBe(false)
+    expect(result.groundingGate.enforced).toBe(true)
+    const verdict = result.groundingGate.evaluated.find(
+      v => v.artifactRef === fakePath,
+    )
+    expect(verdict?.state).toBe('LOOKED_UP')
+    expect(verdict?.lookupResult).toBe('negative')
+    expect(result.reply).toContain('SPECULATIVE')
   })
 })

--- a/apps/openagents.com/workers/api/src/artanis-operator.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.ts
@@ -62,12 +62,20 @@ import { formatArtanisTokenPaceLine } from './artanis-token-pace'
 
 import { parseJsonUnknown } from './json-boundary'
 
+import {
+  enforceArtanisGroundingGate,
+  extractArtanisGroundingLookup,
+  type ArtanisGroundingLookup,
+  type ArtanisOperatorGroundingGateResult,
+} from './artanis-operator-grounding-gate'
+
 export type { ArtanisRiskyActionKind } from './artanis-approval-gates'
 
 // Re-export the real grounding types so the surface + memory lanes have a single
 // import site for the operator-core contract.
 export type { ArtanisMemoryEntry } from './artanis-owner-memory'
 export type { ArtanisSituationalAwareness } from './artanis-situational-awareness'
+export type { ArtanisOperatorGroundingGateResult } from './artanis-operator-grounding-gate'
 
 // ---------------------------------------------------------------------------
 // Model + identity constants.
@@ -709,6 +717,12 @@ export type ArtanisOperatorTurnResult = Readonly<{
   // Typed pending approval gates produced by risky/gated tool deferrals. This
   // supersedes treating `deferredToApprovalGate` as the only machine signal.
   pendingApprovalGates: ReadonlyArray<ArtanisOperatorPendingApprovalGate>
+  // The Blueprint Signature-6 grounding-gate verdict over the FINAL reply: the
+  // structured per-artifact grounded/SPECULATIVE results, whether every named
+  // runnable artifact was GROUNDED, and whether the reply was augmented with the
+  // SPECULATIVE addendum. This is the machine-readable proof that ungrounded
+  // references were structurally gated, not just discouraged by the prompt.
+  groundingGate: ArtanisOperatorGroundingGateResult
   // How many Khala completions the turn made (1 for a no-tool turn, more when
   // the loop executed tools and re-called Khala).
   iterations: number
@@ -992,6 +1006,10 @@ export const artanisOperatorTurn = (input: {
     // composition retry and the grounded synthesis fallback so a blown-up
     // conversation (or a failed late Khala call) never costs the owner a reply.
     const gathered: Array<ArtanisGatheredToolResult> = []
+    // The grounding lookups Artanis actually performed this turn (distilled from
+    // his repo_path_exists / repo_grep / route_exists / repo-read tool calls).
+    // The Signature-6 gate correlates the final reply's artifacts against these.
+    const groundingLookups: Array<ArtanisGroundingLookup> = []
     let toolsDeferred = false
     let served: InferenceResult | undefined
 
@@ -1095,6 +1113,12 @@ export const artanisOperatorTurn = (input: {
           ARTANIS_OPERATOR_TOOL_RESULT_CONTEXT_MAX_CHARS,
         )
         gathered.push({ content: boundedContent, name: toolCall.function.name })
+        const groundingLookup = extractArtanisGroundingLookup({
+          content: boundedContent,
+          rawArguments: toolCall.function.arguments,
+          toolName: toolCall.function.name,
+        })
+        if (groundingLookup !== null) groundingLookups.push(groundingLookup)
         nextMessages.push({
           content: boundedContent,
           name: toolCall.function.name,
@@ -1175,6 +1199,17 @@ export const artanisOperatorTurn = (input: {
         ? finalServed.content
         : synthesizeArtanisGroundedReply(gathered)
 
+    // Enforce the Blueprint Signature-6 grounding gate over the FINAL reply.
+    // Any runnable artifact (file path, script, command, or API endpoint)
+    // Artanis named that he did NOT verify exists this turn is structurally
+    // tagged SPECULATIVE here — he can no longer present a fabricated path or
+    // endpoint as runnable. (full-Blueprint-set wiring, slice 1.)
+    const grounding = enforceArtanisGroundingGate({
+      lookups: groundingLookups,
+      reply: replyText,
+    })
+    const groundedReplyText = grounding.reply
+
     // The provider-native model id to report. Prefer the model that produced the
     // final reply; fall back to the last successful completion, then the alias.
     const servedModel =
@@ -1185,10 +1220,11 @@ export const artanisOperatorTurn = (input: {
     return {
       deferredToApprovalGate:
         mentionsSpendOrDestructive(input.messages) || toolsDeferred,
+      groundingGate: grounding.gate,
       iterations,
       pendingApprovalGates,
-      persona: verifyArtanisOperatorPersona(replyText),
-      reply: replyText,
+      persona: verifyArtanisOperatorPersona(groundedReplyText),
+      reply: groundedReplyText,
       requestedModel: ARTANIS_OPERATOR_KHALA_MODEL,
       servedModel,
       servedVia: 'openagents_khala' as const,

--- a/apps/pylon/src/blueprint-gates/command-execution-source-verified.ts
+++ b/apps/pylon/src/blueprint-gates/command-execution-source-verified.ts
@@ -3,227 +3,28 @@
  *
  * No command is recommended without reading its source.
  *
- * Pure, ordered-predicate state machine implementing the gate from
- * `docs/artanis/2026-06-28-blueprint-signature-governed-autonomous-ops.md`:
+ * The evaluator now lives in the cross-consumer Blueprint contract home,
+ * `@openagentsinc/blueprint-contracts`, so this Pylon gate module and the
+ * openagents.com Worker operator loop import + apply the SAME pure function
+ * instead of keeping two copies that can drift. This file preserves the original
+ * public API of the gate by re-exporting it; consumers (`./index.ts`, the gate
+ * test) are unchanged.
  *
- *   UNVERIFIED → SOURCE_READ → FLAGS_VERIFIED → RUNTIME_CONFIRMED → SAFE_TO_PROPOSE
- *
- * Only the terminal state `SAFE_TO_PROPOSE` unlocks proposing the command.
- *
- * Ordered predicates:
- *  1. source-read    — the file contents were read + hashed (a content hash is
- *                      present) before proposing.
- *  2. flag-verification — every flag in the proposed command exists in the
- *                      script's actual parsed argument surface (`declaredFlags`).
- *                      A stub with zero declared flags fails here, so the
- *                      "fabricated executable" mistake (a command recommended
- *                      against a script that does not accept those flags) is
- *                      structurally impossible.
- *  3. runtime-check  — a dry-run / `--help` probe exited 0, proving the script is
- *                      executable and accepts the expected flags.
- *
- * This module is a pure library (types + functions). It is intentionally not
- * wired into the live supervisor/watcher; wiring is a follow-up.
+ * See `docs/artanis/2026-06-28-blueprint-signature-governed-autonomous-ops.md`
+ * for the gate's ordered-predicate state machine
+ * (UNVERIFIED → SOURCE_READ → FLAGS_VERIFIED → RUNTIME_CONFIRMED → SAFE_TO_PROPOSE).
  */
 
-export const COMMAND_SOURCE_VERIFIED_STATES = [
-  "UNVERIFIED",
-  "SOURCE_READ",
-  "FLAGS_VERIFIED",
-  "RUNTIME_CONFIRMED",
-  "SAFE_TO_PROPOSE",
-] as const
+export {
+  COMMAND_SOURCE_VERIFIED_STATES,
+  COMMAND_SOURCE_VERIFIED_EVIDENCE,
+  parseCommandFlags,
+  evaluateCommandSourceVerified,
+} from "@openagentsinc/blueprint-contracts"
 
-export type CommandSourceVerifiedState =
-  (typeof COMMAND_SOURCE_VERIFIED_STATES)[number]
-
-export const COMMAND_SOURCE_VERIFIED_EVIDENCE = {
-  sourceRead: "evidence://command/source-read",
-  flagVerification: "evidence://command/flag-verification",
-  runtimeCheck: "evidence://command/runtime-check",
-} as const
-
-export type CommandSourceVerifiedEvidenceRef =
-  (typeof COMMAND_SOURCE_VERIFIED_EVIDENCE)[keyof typeof COMMAND_SOURCE_VERIFIED_EVIDENCE]
-
-export interface CommandSourceVerifiedInputs {
-  /** The full command line that is being proposed. */
-  readonly commandString: string
-  /** Path to the script the command invokes. */
-  readonly scriptPath: string
-  /** The flags the proposed command intends to use. */
-  readonly expectedFlags: ReadonlyArray<string>
-  /**
-   * evidence://command/source-read — a content hash of the script, present only
-   * after the file was actually read.
-   */
-  readonly sourceReadHash: string | null
-  /**
-   * evidence://command/flag-verification — the script's actual parsed argument
-   * surface: every flag its argument parser declares. A stub declares none.
-   */
-  readonly declaredFlags: ReadonlyArray<string>
-  /**
-   * evidence://command/runtime-check — exit code of a dry-run / `--help` probe.
-   * `0` means the probe succeeded; `null` means no probe was run.
-   */
-  readonly dryRunExitCode: number | null
-}
-
-export interface CommandSourceVerifiedResult {
-  readonly state: CommandSourceVerifiedState
-  /** True only when the terminal state SAFE_TO_PROPOSE is reached. */
-  readonly canPropose: boolean
-  /** Flags considered (command-parsed flags unioned with expectedFlags). */
-  readonly proposedFlags: ReadonlyArray<string>
-  /** Proposed flags absent from the declared argument surface. */
-  readonly unknownFlags: ReadonlyArray<string>
-  readonly satisfiedEvidence: ReadonlyArray<CommandSourceVerifiedEvidenceRef>
-  readonly missingEvidence: ReadonlyArray<CommandSourceVerifiedEvidenceRef>
-  readonly locked: boolean
-  readonly lockedAt: CommandSourceVerifiedState | null
-  readonly blockedReason: string | null
-}
-
-/**
- * Parse the flag tokens from a command string. A flag is a token beginning with
- * `-`; `--flag=value` is normalized to `--flag`. Bare `--` (end-of-options) is
- * ignored.
- */
-export function parseCommandFlags(
-  commandString: string,
-): ReadonlyArray<string> {
-  if (typeof commandString !== "string" || commandString.trim().length === 0) {
-    return []
-  }
-  const flags: Array<string> = []
-  for (const rawToken of commandString.trim().split(/\s+/)) {
-    // `--` is end-of-options: everything after it is positional, not a flag.
-    if (rawToken === "--") {
-      break
-    }
-    if (!rawToken.startsWith("-")) {
-      continue
-    }
-    const eq = rawToken.indexOf("=")
-    const flag = eq === -1 ? rawToken : rawToken.slice(0, eq)
-    if (flag.length > 1 && !flags.includes(flag)) {
-      flags.push(flag)
-    }
-  }
-  return flags
-}
-
-function uniqueFlags(
-  flags: ReadonlyArray<string>,
-  extra: ReadonlyArray<string>,
-): ReadonlyArray<string> {
-  const out: Array<string> = []
-  for (const flag of [...flags, ...extra]) {
-    if (flag.length > 0 && !out.includes(flag)) {
-      out.push(flag)
-    }
-  }
-  return out
-}
-
-/**
- * Evaluate the `command-execution-source-verified` gate. Pure function.
- */
-export function evaluateCommandSourceVerified(
-  inputs: CommandSourceVerifiedInputs,
-): CommandSourceVerifiedResult {
-  const satisfied: Array<CommandSourceVerifiedEvidenceRef> = []
-  const proposedFlags = uniqueFlags(
-    parseCommandFlags(inputs.commandString),
-    inputs.expectedFlags ?? [],
-  )
-  const declared = inputs.declaredFlags ?? []
-  const unknownFlags = proposedFlags.filter((flag) => !declared.includes(flag))
-
-  const lock = (
-    state: CommandSourceVerifiedState,
-    lockedAt: CommandSourceVerifiedState,
-    blockedReason: string,
-    missing: ReadonlyArray<CommandSourceVerifiedEvidenceRef>,
-  ): CommandSourceVerifiedResult => ({
-    state,
-    canPropose: false,
-    proposedFlags,
-    unknownFlags,
-    satisfiedEvidence: satisfied,
-    missingEvidence: missing,
-    locked: true,
-    lockedAt,
-    blockedReason,
-  })
-
-  // Predicate 1 — source read + hashed.
-  if (
-    typeof inputs.sourceReadHash !== "string" ||
-    inputs.sourceReadHash.trim().length === 0
-  ) {
-    return lock(
-      "UNVERIFIED",
-      "SOURCE_READ",
-      `script ${inputs.scriptPath} was not read + hashed before proposing`,
-      [
-        COMMAND_SOURCE_VERIFIED_EVIDENCE.sourceRead,
-        COMMAND_SOURCE_VERIFIED_EVIDENCE.flagVerification,
-        COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck,
-      ],
-    )
-  }
-  satisfied.push(COMMAND_SOURCE_VERIFIED_EVIDENCE.sourceRead)
-
-  // Predicate 2 — flag verification. A real command being verified must carry at
-  // least one flag, and every proposed flag must exist in the declared surface.
-  if (proposedFlags.length === 0) {
-    return lock(
-      "SOURCE_READ",
-      "FLAGS_VERIFIED",
-      "no flags were proposed or expected; nothing to verify against the argument surface",
-      [
-        COMMAND_SOURCE_VERIFIED_EVIDENCE.flagVerification,
-        COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck,
-      ],
-    )
-  }
-  if (unknownFlags.length > 0) {
-    return lock(
-      "SOURCE_READ",
-      "FLAGS_VERIFIED",
-      `proposed flags not present in the parsed argument surface: ${unknownFlags.join(", ")}`,
-      [
-        COMMAND_SOURCE_VERIFIED_EVIDENCE.flagVerification,
-        COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck,
-      ],
-    )
-  }
-  satisfied.push(COMMAND_SOURCE_VERIFIED_EVIDENCE.flagVerification)
-
-  // Predicate 3 — runtime / dry-run probe succeeded.
-  if (inputs.dryRunExitCode !== 0) {
-    return lock(
-      "FLAGS_VERIFIED",
-      "RUNTIME_CONFIRMED",
-      inputs.dryRunExitCode === null
-        ? "no dry-run / --help probe was run"
-        : `dry-run / --help probe exited ${inputs.dryRunExitCode}`,
-      [COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck],
-    )
-  }
-  satisfied.push(COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck)
-
-  return {
-    state: "SAFE_TO_PROPOSE",
-    canPropose: true,
-    proposedFlags,
-    unknownFlags,
-    satisfiedEvidence: satisfied,
-    missingEvidence: [],
-    locked: false,
-    lockedAt: null,
-    blockedReason: null,
-  }
-}
+export type {
+  CommandSourceVerifiedState,
+  CommandSourceVerifiedEvidenceRef,
+  CommandSourceVerifiedInputs,
+  CommandSourceVerifiedResult,
+} from "@openagentsinc/blueprint-contracts"

--- a/docs/artanis/2026-06-28-blueprint-signature-governed-autonomous-ops.md
+++ b/docs/artanis/2026-06-28-blueprint-signature-governed-autonomous-ops.md
@@ -293,6 +293,67 @@ the right points:
    Artanis can verify an artifact exists before asserting it instead of inventing
    it from memory.
 
+### Operator-loop enforcement (full-Blueprint-set wiring, slice 1)
+
+The grounding tools above were necessary but not sufficient: a system-prompt
+rule is advisory, and a headless model can still present a fabricated artifact as
+runnable without ever calling them. Slice 1 of the full-Blueprint-set wiring
+makes Signature 6 a **structural gate inside the operator turn loop** rather than
+a prompt instruction:
+
+- **Gate state machine, single authority.** `operator-grounded-assertion`
+  (`UNGROUNDED → REFERENCED → LOOKED_UP → GROUNDED`) and the Signature-4
+  `command-execution-source-verified` evaluator now live in the cross-consumer
+  package `@openagentsinc/blueprint-contracts`
+  (`packages/blueprint-contracts/src/operator-grounded-assertion.ts`,
+  `.../command-execution-source-verified.ts`). The Pylon `blueprint-gates` module
+  re-exports the S4 evaluator from there, and the openagents.com Worker imports +
+  applies the SAME functions — neither re-describes the gate, so the two
+  consumers cannot drift. (The Worker cannot depend on the Pylon CLI app, so the
+  shared contracts package — which both already depend on — is the correct home.)
+- **Enforcement in the loop.** After the operator composes its final reply, the
+  turn loop (`apps/openagents.com/workers/api/src/artanis-operator.ts`) runs
+  `enforceArtanisGroundingGate`
+  (`apps/openagents.com/workers/api/src/artanis-operator-grounding-gate.ts`). It
+  extracts every runnable artifact the reply names (file path, script, command,
+  API endpoint — a bounded audit predicate over Artanis's own output, NOT intent
+  routing), correlates each against the grounding lookups actually performed that
+  turn (distilled from the `repo_path_exists` / `repo_grep` / `route_exists`
+  tool calls, plus a successful `read_repo_file` / `list_repo_dir` as stronger
+  path-existence evidence), and runs the S6 gate per artifact. Any artifact that
+  does not reach `GROUNDED` is appended to a structural **SPECULATIVE addendum**
+  in the returned reply and recorded in a new typed `groundingGate` field on the
+  turn result (per-artifact state, satisfied/missing evidence refs, the S4
+  sub-verdict for commands). A fabricated `scripts/distill_traces.ts` or
+  `POST /api/admin/khala/mint` can no longer be delivered to the owner as
+  runnable; it is labeled unverified or it does not pass.
+- **Evidence-aligned.** The structured `groundingGate` verdicts carry the same
+  `evidence://grounding/*` refs the design specifies, so they line up with the
+  evidence-only Action Submission model.
+
+What is **ENFORCED now** (vs. prompt-level before): S6 grounded-assertion over
+the operator's final reply, for file paths, scripts, commands, and API
+endpoints.
+
+What is **honestly still follow-up** (not faked here):
+
+- **S4 runtime predicate.** `command-execution-source-verified` is applied and
+  attached for command artifacts using the evidence reachable headless
+  (source-read + flag content-match via `repo_grep`), but the terminal
+  `RUNTIME_CONFIRMED`/`SAFE_TO_PROPOSE` step needs a real dry-run/`--help`
+  probe, which only a runtime with a working tree has. Wiring that probe
+  server-/Pylon-side is the next slice; today S6 is the blocker and S4 is the
+  attached report.
+- **Signature Lookup Service registration.** The gates are not yet registered as
+  `program_signature` contributions, and the evidence refs are not yet written
+  through the Action Submission evidence-only boundary as durable receipts.
+- **RLM / Program substrate + cycle-report gating.** S1–S5 server-side wiring,
+  the overseer evidence packet, and GEPA optimization against the "zero unforced
+  errors" metric remain as designed above and are not yet implemented.
+- **Read-tool grounding scope.** Grounding correlation uses the three canonical
+  S6 tools plus successful repo reads; a repo-wide grep remains unavailable from
+  the Worker (documented honest boundary of `repo_grep`).
+
 GEPA optimization (bounded scheduled runner,
 `docs/artanis/2026-06-08-bounded-gepa-scheduled-runner.md`) tunes the Program
 against the "zero unforced errors" metric over time.

--- a/packages/blueprint-contracts/src/command-execution-source-verified.ts
+++ b/packages/blueprint-contracts/src/command-execution-source-verified.ts
@@ -1,0 +1,234 @@
+/**
+ * Blueprint Signature 4 — `command-execution-source-verified`
+ *
+ * No command is recommended without reading its source.
+ *
+ * Pure, ordered-predicate state machine implementing the gate from
+ * `docs/artanis/2026-06-28-blueprint-signature-governed-autonomous-ops.md`:
+ *
+ *   UNVERIFIED → SOURCE_READ → FLAGS_VERIFIED → RUNTIME_CONFIRMED → SAFE_TO_PROPOSE
+ *
+ * Only the terminal state `SAFE_TO_PROPOSE` unlocks proposing the command.
+ *
+ * Ordered predicates:
+ *  1. source-read    — the file contents were read + hashed (a content hash is
+ *                      present) before proposing.
+ *  2. flag-verification — every flag in the proposed command exists in the
+ *                      script's actual parsed argument surface (`declaredFlags`).
+ *                      A stub with zero declared flags fails here, so the
+ *                      "fabricated executable" mistake (a command recommended
+ *                      against a script that does not accept those flags) is
+ *                      structurally impossible.
+ *  3. runtime-check  — a dry-run / `--help` probe exited 0, proving the script is
+ *                      executable and accepts the expected flags.
+ *
+ * SINGLE AUTHORITY: this is the one home for the S4 evaluator. The Pylon gate
+ * module (`apps/pylon/src/blueprint-gates/command-execution-source-verified.ts`)
+ * and the openagents.com Worker operator loop both import + apply THIS function
+ * rather than re-describing it, so the two consumers can never drift. This
+ * package is `@openagentsinc/blueprint-contracts` — a dependency-light,
+ * cross-consumer Blueprint contract home (it already hosts the canonical
+ * private-data-safety predicate family). Both consumers already depend on it.
+ */
+
+export const COMMAND_SOURCE_VERIFIED_STATES = [
+  "UNVERIFIED",
+  "SOURCE_READ",
+  "FLAGS_VERIFIED",
+  "RUNTIME_CONFIRMED",
+  "SAFE_TO_PROPOSE",
+] as const
+
+export type CommandSourceVerifiedState =
+  (typeof COMMAND_SOURCE_VERIFIED_STATES)[number]
+
+export const COMMAND_SOURCE_VERIFIED_EVIDENCE = {
+  sourceRead: "evidence://command/source-read",
+  flagVerification: "evidence://command/flag-verification",
+  runtimeCheck: "evidence://command/runtime-check",
+} as const
+
+export type CommandSourceVerifiedEvidenceRef =
+  (typeof COMMAND_SOURCE_VERIFIED_EVIDENCE)[keyof typeof COMMAND_SOURCE_VERIFIED_EVIDENCE]
+
+export interface CommandSourceVerifiedInputs {
+  /** The full command line that is being proposed. */
+  readonly commandString: string
+  /** Path to the script the command invokes. */
+  readonly scriptPath: string
+  /** The flags the proposed command intends to use. */
+  readonly expectedFlags: ReadonlyArray<string>
+  /**
+   * evidence://command/source-read — a content hash of the script, present only
+   * after the file was actually read.
+   */
+  readonly sourceReadHash: string | null
+  /**
+   * evidence://command/flag-verification — the script's actual parsed argument
+   * surface: every flag its argument parser declares. A stub declares none.
+   */
+  readonly declaredFlags: ReadonlyArray<string>
+  /**
+   * evidence://command/runtime-check — exit code of a dry-run / `--help` probe.
+   * `0` means the probe succeeded; `null` means no probe was run.
+   */
+  readonly dryRunExitCode: number | null
+}
+
+export interface CommandSourceVerifiedResult {
+  readonly state: CommandSourceVerifiedState
+  /** True only when the terminal state SAFE_TO_PROPOSE is reached. */
+  readonly canPropose: boolean
+  /** Flags considered (command-parsed flags unioned with expectedFlags). */
+  readonly proposedFlags: ReadonlyArray<string>
+  /** Proposed flags absent from the declared argument surface. */
+  readonly unknownFlags: ReadonlyArray<string>
+  readonly satisfiedEvidence: ReadonlyArray<CommandSourceVerifiedEvidenceRef>
+  readonly missingEvidence: ReadonlyArray<CommandSourceVerifiedEvidenceRef>
+  readonly locked: boolean
+  readonly lockedAt: CommandSourceVerifiedState | null
+  readonly blockedReason: string | null
+}
+
+/**
+ * Parse the flag tokens from a command string. A flag is a token beginning with
+ * `-`; `--flag=value` is normalized to `--flag`. Bare `--` (end-of-options) is
+ * ignored.
+ */
+export function parseCommandFlags(
+  commandString: string,
+): ReadonlyArray<string> {
+  if (typeof commandString !== "string" || commandString.trim().length === 0) {
+    return []
+  }
+  const flags: Array<string> = []
+  for (const rawToken of commandString.trim().split(/\s+/)) {
+    // `--` is end-of-options: everything after it is positional, not a flag.
+    if (rawToken === "--") {
+      break
+    }
+    if (!rawToken.startsWith("-")) {
+      continue
+    }
+    const eq = rawToken.indexOf("=")
+    const flag = eq === -1 ? rawToken : rawToken.slice(0, eq)
+    if (flag.length > 1 && !flags.includes(flag)) {
+      flags.push(flag)
+    }
+  }
+  return flags
+}
+
+function uniqueFlags(
+  flags: ReadonlyArray<string>,
+  extra: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const out: Array<string> = []
+  for (const flag of [...flags, ...extra]) {
+    if (flag.length > 0 && !out.includes(flag)) {
+      out.push(flag)
+    }
+  }
+  return out
+}
+
+/**
+ * Evaluate the `command-execution-source-verified` gate. Pure function.
+ */
+export function evaluateCommandSourceVerified(
+  inputs: CommandSourceVerifiedInputs,
+): CommandSourceVerifiedResult {
+  const satisfied: Array<CommandSourceVerifiedEvidenceRef> = []
+  const proposedFlags = uniqueFlags(
+    parseCommandFlags(inputs.commandString),
+    inputs.expectedFlags ?? [],
+  )
+  const declared = inputs.declaredFlags ?? []
+  const unknownFlags = proposedFlags.filter((flag) => !declared.includes(flag))
+
+  const lock = (
+    state: CommandSourceVerifiedState,
+    lockedAt: CommandSourceVerifiedState,
+    blockedReason: string,
+    missing: ReadonlyArray<CommandSourceVerifiedEvidenceRef>,
+  ): CommandSourceVerifiedResult => ({
+    state,
+    canPropose: false,
+    proposedFlags,
+    unknownFlags,
+    satisfiedEvidence: satisfied,
+    missingEvidence: missing,
+    locked: true,
+    lockedAt,
+    blockedReason,
+  })
+
+  // Predicate 1 — source read + hashed.
+  if (
+    typeof inputs.sourceReadHash !== "string" ||
+    inputs.sourceReadHash.trim().length === 0
+  ) {
+    return lock(
+      "UNVERIFIED",
+      "SOURCE_READ",
+      `script ${inputs.scriptPath} was not read + hashed before proposing`,
+      [
+        COMMAND_SOURCE_VERIFIED_EVIDENCE.sourceRead,
+        COMMAND_SOURCE_VERIFIED_EVIDENCE.flagVerification,
+        COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck,
+      ],
+    )
+  }
+  satisfied.push(COMMAND_SOURCE_VERIFIED_EVIDENCE.sourceRead)
+
+  // Predicate 2 — flag verification. A real command being verified must carry at
+  // least one flag, and every proposed flag must exist in the declared surface.
+  if (proposedFlags.length === 0) {
+    return lock(
+      "SOURCE_READ",
+      "FLAGS_VERIFIED",
+      "no flags were proposed or expected; nothing to verify against the argument surface",
+      [
+        COMMAND_SOURCE_VERIFIED_EVIDENCE.flagVerification,
+        COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck,
+      ],
+    )
+  }
+  if (unknownFlags.length > 0) {
+    return lock(
+      "SOURCE_READ",
+      "FLAGS_VERIFIED",
+      `proposed flags not present in the parsed argument surface: ${unknownFlags.join(", ")}`,
+      [
+        COMMAND_SOURCE_VERIFIED_EVIDENCE.flagVerification,
+        COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck,
+      ],
+    )
+  }
+  satisfied.push(COMMAND_SOURCE_VERIFIED_EVIDENCE.flagVerification)
+
+  // Predicate 3 — runtime / dry-run probe succeeded.
+  if (inputs.dryRunExitCode !== 0) {
+    return lock(
+      "FLAGS_VERIFIED",
+      "RUNTIME_CONFIRMED",
+      inputs.dryRunExitCode === null
+        ? "no dry-run / --help probe was run"
+        : `dry-run / --help probe exited ${inputs.dryRunExitCode}`,
+      [COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck],
+    )
+  }
+  satisfied.push(COMMAND_SOURCE_VERIFIED_EVIDENCE.runtimeCheck)
+
+  return {
+    state: "SAFE_TO_PROPOSE",
+    canPropose: true,
+    proposedFlags,
+    unknownFlags,
+    satisfiedEvidence: satisfied,
+    missingEvidence: [],
+    locked: false,
+    lockedAt: null,
+    blockedReason: null,
+  }
+}

--- a/packages/blueprint-contracts/src/index.ts
+++ b/packages/blueprint-contracts/src/index.ts
@@ -1,5 +1,12 @@
 import { Schema as S } from "effect";
 
+// Blueprint Signature-governed autonomous-ops gate state machines. These pure,
+// ordered-predicate evaluators live here (the cross-consumer Blueprint contract
+// home) so the openagents.com Worker operator loop and the Pylon blueprint-gates
+// both import + apply the SAME function instead of re-describing it.
+export * from "./command-execution-source-verified.js";
+export * from "./operator-grounded-assertion.js";
+
 // ---------------------------------------------------------------------------
 // Canonical Blueprint contract-export security contract.
 //

--- a/packages/blueprint-contracts/src/operator-grounded-assertion.test.ts
+++ b/packages/blueprint-contracts/src/operator-grounded-assertion.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  OPERATOR_GROUNDED_ASSERTION_EVIDENCE,
+  evaluateOperatorGroundedAssertion,
+} from "./operator-grounded-assertion.js"
+
+describe("operator-grounded-assertion gate (Blueprint Signature 6)", () => {
+  test("a referenced-but-unlooked-up artifact stays UNGROUNDED at REFERENCED", () => {
+    const result = evaluateOperatorGroundedAssertion({
+      artifactKind: "file_path",
+      artifactRef: "scripts/distill_traces.ts",
+      lookupTool: null,
+      lookupResult: "not_looked_up",
+    })
+    expect(result.state).toBe("REFERENCED")
+    expect(result.canAssert).toBe(false)
+    expect(result.lockedAt).toBe("LOOKED_UP")
+    expect(result.missingEvidence).toContain(
+      OPERATOR_GROUNDED_ASSERTION_EVIDENCE.pathExists,
+    )
+  })
+
+  test("a looked-up-but-negative artifact stays UNGROUNDED at LOOKED_UP", () => {
+    const result = evaluateOperatorGroundedAssertion({
+      artifactKind: "file_path",
+      artifactRef: "scripts/distill_traces.ts",
+      lookupTool: "repo_path_exists",
+      lookupResult: "negative",
+    })
+    expect(result.state).toBe("LOOKED_UP")
+    expect(result.canAssert).toBe(false)
+    expect(result.lockedAt).toBe("GROUNDED")
+    expect(result.blockedReason).toContain("did not confirm")
+  })
+
+  test("a positive lookup reaches GROUNDED and unlocks the assertion", () => {
+    const result = evaluateOperatorGroundedAssertion({
+      artifactKind: "file_path",
+      artifactRef: "apps/pylon/scripts/multi-session-campaign.ts",
+      lookupTool: "repo_path_exists",
+      lookupResult: "positive",
+    })
+    expect(result.state).toBe("GROUNDED")
+    expect(result.canAssert).toBe(true)
+    expect(result.locked).toBe(false)
+    expect(result.satisfiedEvidence).toEqual([
+      OPERATOR_GROUNDED_ASSERTION_EVIDENCE.pathExists,
+    ])
+    expect(result.missingEvidence).toEqual([])
+  })
+
+  test("an api_endpoint grounds against the route-registered evidence", () => {
+    const grounded = evaluateOperatorGroundedAssertion({
+      artifactKind: "api_endpoint",
+      artifactRef: "/api/v1/chat/completions",
+      lookupTool: "route_exists",
+      lookupResult: "positive",
+    })
+    expect(grounded.state).toBe("GROUNDED")
+    expect(grounded.satisfiedEvidence).toEqual([
+      OPERATOR_GROUNDED_ASSERTION_EVIDENCE.routeRegistered,
+    ])
+
+    const fabricated = evaluateOperatorGroundedAssertion({
+      artifactKind: "api_endpoint",
+      artifactRef: "/api/admin/khala/mint",
+      lookupTool: "route_exists",
+      lookupResult: "negative",
+    })
+    expect(fabricated.canAssert).toBe(false)
+    expect(fabricated.missingEvidence).toContain(
+      OPERATOR_GROUNDED_ASSERTION_EVIDENCE.routeRegistered,
+    )
+  })
+
+  test("an empty artifact ref is not an assertion at all", () => {
+    const result = evaluateOperatorGroundedAssertion({
+      artifactKind: "command",
+      artifactRef: "   ",
+      lookupTool: "repo_grep",
+      lookupResult: "positive",
+    })
+    expect(result.state).toBe("UNGROUNDED")
+    expect(result.canAssert).toBe(false)
+  })
+})

--- a/packages/blueprint-contracts/src/operator-grounded-assertion.ts
+++ b/packages/blueprint-contracts/src/operator-grounded-assertion.ts
@@ -1,0 +1,191 @@
+/**
+ * Blueprint Signature 6 — `operator-grounded-assertion`
+ *
+ * No runnable artifact reaches the owner unless it has been verified to exist.
+ *
+ * Pure, ordered-predicate state machine implementing the gate from
+ * `docs/artanis/2026-06-28-blueprint-signature-governed-autonomous-ops.md`:
+ *
+ *   UNGROUNDED → REFERENCED → LOOKED_UP → GROUNDED
+ *
+ * Only the terminal state `GROUNDED` unlocks presenting the artifact as
+ * runnable/real. Any operator output that references a runnable COMMAND, FILE
+ * PATH, SCRIPT, or API ENDPOINT must reach `GROUNDED` (a positive existence
+ * lookup THIS turn) or be explicitly labeled SPECULATIVE / omitted.
+ *
+ * Ordered predicates (terminal-last):
+ *  1. referenced — an artifact ref is in hand.
+ *  2. looked-up  — the matching grounding tool was actually called this turn
+ *                  (`repo_path_exists` / `repo_grep` for a file/script/command
+ *                  source; `route_exists` for an api_endpoint). A reference with
+ *                  no lookup stays below GROUNDED, so a path/endpoint invented
+ *                  from memory cannot be asserted.
+ *  3. grounded   — the lookup returned a POSITIVE existence result (EXISTS / is
+ *                  a registered route / pattern matched). A negative lookup
+ *                  (does-not-exist / not-in-registry / no-match / a read failure)
+ *                  holds the gate at LOOKED_UP and the artifact stays UNGROUNDED.
+ *
+ * This makes the MirrorCode / `distill_traces` / admin-endpoint fabrication
+ * class structurally impossible: the terminal state that unlocks "assert as
+ * real" is unreachable without a positive lookup of the real repo / real
+ * OpenAPI registry.
+ *
+ * SINGLE AUTHORITY: this is the one home for the S6 gate so the openagents.com
+ * Worker operator loop (which produces the S6 evidence via its grounding tools)
+ * and Pylon both import + apply THIS function rather than re-describing it.
+ */
+
+export const OPERATOR_GROUNDED_ASSERTION_STATES = [
+  "UNGROUNDED",
+  "REFERENCED",
+  "LOOKED_UP",
+  "GROUNDED",
+] as const
+
+export type OperatorGroundedAssertionState =
+  (typeof OPERATOR_GROUNDED_ASSERTION_STATES)[number]
+
+export const OPERATOR_GROUNDED_ASSERTION_EVIDENCE = {
+  /** A file/script/command source confirmed to exist via repo_path_exists. */
+  pathExists: "evidence://grounding/path-exists",
+  /** A flag/symbol confirmed present in a real file via repo_grep. */
+  contentMatch: "evidence://grounding/content-match",
+  /** An API endpoint confirmed registered via route_exists. */
+  routeRegistered: "evidence://grounding/route-registered",
+} as const
+
+export type OperatorGroundedAssertionEvidenceRef =
+  (typeof OPERATOR_GROUNDED_ASSERTION_EVIDENCE)[keyof typeof OPERATOR_GROUNDED_ASSERTION_EVIDENCE]
+
+/**
+ * The kind of runnable artifact being asserted. `command`, `file_path`, and
+ * `script` all ground through the path/content evidence; `api_endpoint` grounds
+ * through the route-registry evidence.
+ */
+export const OPERATOR_GROUNDED_ARTIFACT_KINDS = [
+  "command",
+  "file_path",
+  "script",
+  "api_endpoint",
+] as const
+
+export type OperatorGroundedArtifactKind =
+  (typeof OPERATOR_GROUNDED_ARTIFACT_KINDS)[number]
+
+/**
+ * The outcome of the matching grounding lookup for the artifact:
+ *  - `positive`      — the tool confirmed existence (EXISTS / registered route /
+ *                      pattern matched).
+ *  - `negative`      — the tool ran and reported non-existence / not-registered /
+ *                      no-match / an unrecoverable read failure.
+ *  - `not_looked_up` — no matching grounding lookup was performed this turn.
+ */
+export type OperatorGroundedLookupResult =
+  | "positive"
+  | "negative"
+  | "not_looked_up"
+
+export interface OperatorGroundedAssertionInputs {
+  readonly artifactKind: OperatorGroundedArtifactKind
+  readonly artifactRef: string
+  /** The grounding tool that produced `lookupResult`, or null if none ran. */
+  readonly lookupTool: string | null
+  readonly lookupResult: OperatorGroundedLookupResult
+}
+
+export interface OperatorGroundedAssertionResult {
+  readonly state: OperatorGroundedAssertionState
+  /** True only when the terminal state GROUNDED is reached. */
+  readonly canAssert: boolean
+  readonly artifactKind: OperatorGroundedArtifactKind
+  readonly artifactRef: string
+  readonly lookupTool: string | null
+  readonly lookupResult: OperatorGroundedLookupResult
+  readonly satisfiedEvidence: ReadonlyArray<OperatorGroundedAssertionEvidenceRef>
+  readonly missingEvidence: ReadonlyArray<OperatorGroundedAssertionEvidenceRef>
+  readonly locked: boolean
+  readonly lockedAt: OperatorGroundedAssertionState | null
+  readonly blockedReason: string | null
+}
+
+/** The evidence ref a given artifact kind must satisfy to reach GROUNDED. */
+function requiredEvidenceFor(
+  kind: OperatorGroundedArtifactKind,
+): OperatorGroundedAssertionEvidenceRef {
+  return kind === "api_endpoint"
+    ? OPERATOR_GROUNDED_ASSERTION_EVIDENCE.routeRegistered
+    : OPERATOR_GROUNDED_ASSERTION_EVIDENCE.pathExists
+}
+
+/**
+ * Evaluate the `operator-grounded-assertion` gate. Pure function.
+ */
+export function evaluateOperatorGroundedAssertion(
+  inputs: OperatorGroundedAssertionInputs,
+): OperatorGroundedAssertionResult {
+  const requiredEvidence = requiredEvidenceFor(inputs.artifactKind)
+
+  const lock = (
+    state: OperatorGroundedAssertionState,
+    lockedAt: OperatorGroundedAssertionState,
+    blockedReason: string,
+  ): OperatorGroundedAssertionResult => ({
+    state,
+    canAssert: false,
+    artifactKind: inputs.artifactKind,
+    artifactRef: inputs.artifactRef,
+    lookupTool: inputs.lookupTool,
+    lookupResult: inputs.lookupResult,
+    satisfiedEvidence: [],
+    missingEvidence: [requiredEvidence],
+    locked: true,
+    lockedAt,
+    blockedReason,
+  })
+
+  // Predicate 1 — referenced. An empty ref is not an assertion at all.
+  if (
+    typeof inputs.artifactRef !== "string" ||
+    inputs.artifactRef.trim().length === 0
+  ) {
+    return lock(
+      "UNGROUNDED",
+      "REFERENCED",
+      "no artifact ref was supplied",
+    )
+  }
+
+  // Predicate 2 — looked up. A reference with no matching grounding lookup this
+  // turn stays UNGROUNDED: a path/endpoint recalled from memory cannot reach
+  // GROUNDED without actually checking the real repo / OpenAPI registry.
+  if (inputs.lookupTool === null || inputs.lookupResult === "not_looked_up") {
+    return lock(
+      "REFERENCED",
+      "LOOKED_UP",
+      `"${inputs.artifactRef}" was referenced but no grounding lookup was run for it this turn — UNGROUNDED, label it SPECULATIVE`,
+    )
+  }
+
+  // Predicate 3 — grounded. The lookup ran but did not confirm existence.
+  if (inputs.lookupResult === "negative") {
+    return lock(
+      "LOOKED_UP",
+      "GROUNDED",
+      `"${inputs.artifactRef}" was looked up via ${inputs.lookupTool} but the lookup did not confirm it exists — UNGROUNDED, label it SPECULATIVE`,
+    )
+  }
+
+  return {
+    state: "GROUNDED",
+    canAssert: true,
+    artifactKind: inputs.artifactKind,
+    artifactRef: inputs.artifactRef,
+    lookupTool: inputs.lookupTool,
+    lookupResult: inputs.lookupResult,
+    satisfiedEvidence: [requiredEvidence],
+    missingEvidence: [],
+    locked: false,
+    lockedAt: null,
+    blockedReason: null,
+  }
+}


### PR DESCRIPTION
## What

Make Artanis execute under his **full Blueprint gate set**, not just a system prompt. The operator turn loop now **structurally enforces** Blueprint Signature 6 (`operator-grounded-assertion`) over its final reply, so a headless operator can no longer present a fabricated path/endpoint as runnable just because the prompt told it not to.

This is **slice 1** of the full-Blueprint-set wiring. It is real, bounded, and green — it does not boil the ocean.

## ENFORCED now (vs prompt-level before)

- **S6 operator-grounded-assertion** over the operator's final reply, for file paths, scripts, commands, and API endpoints. Any artifact the model names that it did **not** verify exists this turn is tagged **SPECULATIVE** in the returned reply and recorded on a typed `groundingGate` turn field. A fabricated `scripts/distill_traces.ts` or `POST /api/admin/khala/mint` is gated; a `repo_path_exists`-verified path passes **GROUNDED** untouched.

## Gates wired (imported + applied, not re-described)

- Added the **S6 gate state machine** (`UNGROUNDED → REFERENCED → LOOKED_UP → GROUNDED`) to the cross-consumer package `@openagentsinc/blueprint-contracts`.
- Re-homed the **S4 `command-execution-source-verified`** evaluator to the same shared package as the single authority; Pylon `blueprint-gates` re-exports it and the openagents.com Worker imports the same functions (no drift). The Worker cannot depend on the Pylon CLI app, so the shared contracts package both already depend on is the correct home.
- Loop enforcement lives in `artanis-operator-grounding-gate.ts`: bounded artifact extraction (an audit predicate over Artanis's own output, **not** intent routing), correlation against the grounding lookups actually performed this turn (`repo_path_exists` / `repo_grep` / `route_exists`, plus a successful repo read as stronger path-existence evidence), per-artifact S6 gate, and an attached S4 sub-verdict for commands.

## Tests

- S6 gate state machine (`packages/blueprint-contracts`).
- Extraction / correlation / enforcement unit tests.
- End-to-end loop tests: fabricated path+endpoint gated SPECULATIVE; negative lookup gated; verified path passes GROUNDED with no addendum.
- `bun run check:deploy` green; existing operator suite (36 + 196 + route subsets) all pass.

## Honest follow-ups (not faked here)

- **S4 runtime predicate**: applied/attached headless via source-read + flag content-match, but the `RUNTIME_CONFIRMED`/`SAFE_TO_PROPOSE` dry-run probe needs a working tree → server/Pylon-side next slice.
- **Signature Lookup registration** + Action Submission evidence receipts.
- **RLM/Program substrate**, S1–S5 server wiring, overseer evidence packet, GEPA metric.
- Repo-wide grep remains unavailable from the Worker (documented boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)