### PR TITLE
feat(artanis): add sub-query decomposition parser

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-subquery-decomposition.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-subquery-decomposition.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  type ArtanisSubQueryExecutionTarget,
+  ArtanisSubQueryDecompositionParseError,
+  parseArtanisSubQueryDecomposition,
+} from './artanis-subquery-decomposition'
+
+type TestSubQuery = {
+  dependsOnSubQueryIds: string[]
+  evidenceRefs: string[]
+  maxTokens?: number
+  purposeRef: string
+  selectedProgramSignatureIds: string[]
+  subQueryId: string
+  target: ArtanisSubQueryExecutionTarget
+  text: string
+}
+
+type TestDecomposition = {
+  decompositionRef: string
+  objectiveRef: string
+  rootQuery: string
+  sourceRefs: string[]
+  subQueries: TestSubQuery[]
+}
+
+const validDecomposition = (): TestDecomposition => ({
+  decompositionRef: 'decomposition.public.artanis.frlm.issue_6680',
+  objectiveRef: 'objective.public.issue_6680',
+  rootQuery:
+    'Decompose the public issue into governed Blueprint-signature work steps.',
+  sourceRefs: [
+    'issue.github.openagents.6680',
+    'doc.public.artanis.blueprint_autonomous_ops_v1',
+  ],
+  subQueries: [
+    {
+      dependsOnSubQueryIds: [],
+      evidenceRefs: ['evidence.public.issue_6680.read'],
+      maxTokens: 4096,
+      purposeRef: 'purpose.public.frlm.collect_context',
+      selectedProgramSignatureIds: [
+        'program_signature.artanis.frlm.context_retrieval.v1',
+      ],
+      subQueryId: 'collect_context',
+      target: 'context_retrieval',
+      text: 'Collect public issue and Blueprint registry context.',
+    },
+    {
+      dependsOnSubQueryIds: ['collect_context'],
+      evidenceRefs: ['evidence.public.blueprint.signature_lookup'],
+      purposeRef: 'purpose.public.frlm.select_signatures',
+      selectedProgramSignatureIds: [
+        'program_signature.artanis.frlm.signature_selection.v1',
+      ],
+      subQueryId: 'select_signatures',
+      target: 'blueprint_signature_lookup',
+      text: 'Resolve the governed Blueprint signatures for each sub-query.',
+    },
+    {
+      dependsOnSubQueryIds: ['collect_context', 'select_signatures'],
+      evidenceRefs: ['evidence.public.frlm.leaf_executor_ready'],
+      purposeRef: 'purpose.public.frlm.execute_leaf',
+      selectedProgramSignatureIds: [
+        'program_signature.artanis.frlm.leaf_executor.v1',
+        'program_signature.artanis.frlm.signature_selection.v1',
+      ],
+      subQueryId: 'execute_leaf',
+      target: 'local_rlm_executor',
+      text: 'Run the bounded leaf executor and return redacted evidence only.',
+    },
+  ],
+})
+
+describe('Artanis sub-query decomposition parser', () => {
+  test('parses fenced FRLM JSON and preserves Blueprint signature refs', () => {
+    const parsed = parseArtanisSubQueryDecomposition(
+      `\n\`\`\`json\n${JSON.stringify(validDecomposition())}\n\`\`\`\n`,
+    )
+
+    expect(parsed.actionSubmissionRequiredForDirectEffects).toBe(true)
+    expect(parsed.decompositionRef).toBe(
+      'decomposition.public.artanis.frlm.issue_6680',
+    )
+    expect(parsed.subQueries.map(step => step.subQueryId)).toEqual([
+      'collect_context',
+      'select_signatures',
+      'execute_leaf',
+    ])
+    expect(parsed.selectedProgramSignatureIds).toEqual([
+      'program_signature.artanis.frlm.context_retrieval.v1',
+      'program_signature.artanis.frlm.signature_selection.v1',
+      'program_signature.artanis.frlm.leaf_executor.v1',
+    ])
+  })
+
+  test('accepts object input and normalizes repeated refs', () => {
+    const input = validDecomposition()
+    input.sourceRefs.push('issue.github.openagents.6680')
+    input.subQueries[2]?.selectedProgramSignatureIds.push(
+      'program_signature.artanis.frlm.leaf_executor.v1',
+    )
+
+    const parsed = parseArtanisSubQueryDecomposition(input)
+
+    expect(parsed.sourceRefs).toEqual([
+      'issue.github.openagents.6680',
+      'doc.public.artanis.blueprint_autonomous_ops_v1',
+    ])
+    expect(parsed.subQueries[2]?.selectedProgramSignatureIds).toEqual([
+      'program_signature.artanis.frlm.leaf_executor.v1',
+      'program_signature.artanis.frlm.signature_selection.v1',
+    ])
+  })
+
+  test('rejects steps without Blueprint Program Signature refs', () => {
+    const input = validDecomposition()
+    const firstStep = requiredStep(input, 0)
+    input.subQueries[0] = {
+      ...firstStep,
+      selectedProgramSignatureIds: ['signature.keyword.context'],
+    }
+
+    expect(() => parseArtanisSubQueryDecomposition(input)).toThrow(
+      ArtanisSubQueryDecompositionParseError,
+    )
+  })
+
+  test('rejects unknown and cyclic sub-query dependencies', () => {
+    const unknownDependency = validDecomposition()
+    const secondStep = requiredStep(unknownDependency, 1)
+    unknownDependency.subQueries[1] = {
+      ...secondStep,
+      dependsOnSubQueryIds: ['missing_context'],
+    }
+
+    expect(() => parseArtanisSubQueryDecomposition(unknownDependency)).toThrow(
+      ArtanisSubQueryDecompositionParseError,
+    )
+
+    const cyclic = validDecomposition()
+    const firstStep = requiredStep(cyclic, 0)
+    cyclic.subQueries[0] = {
+      ...firstStep,
+      dependsOnSubQueryIds: ['execute_leaf'],
+    }
+
+    expect(() => parseArtanisSubQueryDecomposition(cyclic)).toThrow(
+      ArtanisSubQueryDecompositionParseError,
+    )
+  })
+
+  test('rejects private paths, raw traces, and secret-like material', () => {
+    const input = validDecomposition()
+    const firstStep = requiredStep(input, 0)
+    input.subQueries[0] = {
+      ...firstStep,
+      text: 'Read /Users/operator/.codex/auth.json for the missing token.',
+    }
+
+    expect(() => parseArtanisSubQueryDecomposition(input)).toThrow(
+      ArtanisSubQueryDecompositionParseError,
+    )
+  })
+
+  test('rejects invalid JSON before schema validation', () => {
+    expect(() => parseArtanisSubQueryDecomposition('not json')).toThrow(
+      ArtanisSubQueryDecompositionParseError,
+    )
+  })
+})
+
+const requiredStep = (
+  decomposition: TestDecomposition,
+  index: number,
+): TestSubQuery => {
+  const step = decomposition.subQueries[index]
+  if (step === undefined) {
+    throw new Error(`missing test sub-query at index ${index}`)
+  }
+  return step
+}

--- a/apps/openagents.com/workers/api/src/artanis-subquery-decomposition.ts
+++ b/apps/openagents.com/workers/api/src/artanis-subquery-decomposition.ts
@@ -1,0 +1,313 @@
+import { Schema as S } from 'effect'
+
+import { parseJsonUnknown } from './json-boundary'
+
+export const ArtanisSubQueryExecutionTarget = S.Literals([
+  'blueprint_signature_lookup',
+  'context_retrieval',
+  'local_rlm_executor',
+  'nip90_market',
+])
+export type ArtanisSubQueryExecutionTarget =
+  typeof ArtanisSubQueryExecutionTarget.Type
+
+export class ArtanisSubQueryDecompositionStep extends S.Class<ArtanisSubQueryDecompositionStep>(
+  'ArtanisSubQueryDecompositionStep',
+)({
+  dependsOnSubQueryIds: S.Array(S.String),
+  evidenceRefs: S.Array(S.String),
+  maxTokens: S.optional(S.Int),
+  purposeRef: S.String,
+  selectedProgramSignatureIds: S.Array(S.String),
+  subQueryId: S.String,
+  target: ArtanisSubQueryExecutionTarget,
+  text: S.String,
+}) {}
+
+export class ArtanisSubQueryDecompositionInput extends S.Class<ArtanisSubQueryDecompositionInput>(
+  'ArtanisSubQueryDecompositionInput',
+)({
+  decompositionRef: S.String,
+  objectiveRef: S.String,
+  rootQuery: S.String,
+  sourceRefs: S.Array(S.String),
+  subQueries: S.Array(ArtanisSubQueryDecompositionStep),
+}) {}
+
+export class ArtanisParsedSubQueryDecomposition extends S.Class<ArtanisParsedSubQueryDecomposition>(
+  'ArtanisParsedSubQueryDecomposition',
+)({
+  actionSubmissionRequiredForDirectEffects: S.Literal(true),
+  decompositionRef: S.String,
+  objectiveRef: S.String,
+  rootQuery: S.String,
+  selectedProgramSignatureIds: S.Array(S.String),
+  sourceRefs: S.Array(S.String),
+  subQueries: S.Array(ArtanisSubQueryDecompositionStep),
+}) {}
+
+export class ArtanisSubQueryDecompositionParseError extends S.TaggedErrorClass<ArtanisSubQueryDecompositionParseError>()(
+  'ArtanisSubQueryDecompositionParseError',
+  {
+    reason: S.String,
+  },
+) {}
+
+const MAX_ROOT_QUERY_LENGTH = 4_000
+const MAX_SUB_QUERY_TEXT_LENGTH = 2_000
+const MAX_SUB_QUERY_COUNT = 32
+const MAX_REF_COUNT = 64
+const MAX_TOKENS_PER_SUB_QUERY = 64_000
+
+const safeRefPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/{}-]{0,260}$/
+const subQueryIdPattern = /^[a-z][a-z0-9_-]{0,63}$/
+const programSignatureRefPattern = /^program_signature\.[A-Za-z0-9_.:-]+$/
+const unsafeMaterialPattern =
+  /(@|\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer|callback[_-]?token|cookie|customer[_-]?(email|name|phone|prompt|record|value)|dataset\.raw|email[_-]?(address|body|html|raw|text)|full[_-]?(prompt|source|trace)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice[_-]?(id|raw)|lnbc|lntb|lnbcrt|lno1|lnurl|macaroon|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|model[_-]?(weights|raw|secret)|oauth|opencode_auth_content|payment[_-]?(hash|id|invoice|preimage|proof|secret)|payout[_-]?(address|destination|private|raw|target)|preimage|private[_-]?(archive|customer|dataset|key|prompt|source|trace|wallet)|provider[_-]?(account|credential|grant|payload|secret|token)|raw[_-]?(artifact|auth|customer|dataset|email|invoice|log|model|payment|payload|payout|prompt|provider|record|repo|runner|run[_-]?log|source|state|target|telemetry|text|trace|training|weights|webhook)|recovery[_-]?phrase|runner[_-]?(payload|secret|token)|seed[_-]?phrase|sk-[a-z0-9]|token|wallet[._-]?(key|material|mnemonic|payment|preimage|secret|seed)|weights\.(bin|gguf|safetensors|pt|pth))/i
+
+export const parseArtanisSubQueryDecomposition = (
+  input: unknown,
+): ArtanisParsedSubQueryDecomposition => {
+  const decoded = decodeDecompositionInput(input)
+  validateDecomposition(decoded)
+
+  return new ArtanisParsedSubQueryDecomposition({
+    actionSubmissionRequiredForDirectEffects: true,
+    decompositionRef: decoded.decompositionRef.trim(),
+    objectiveRef: decoded.objectiveRef.trim(),
+    rootQuery: decoded.rootQuery.trim(),
+    selectedProgramSignatureIds: uniqueRefs(
+      decoded.subQueries.flatMap(step => step.selectedProgramSignatureIds),
+    ),
+    sourceRefs: uniqueRefs(decoded.sourceRefs),
+    subQueries: decoded.subQueries.map(normalizeStep),
+  })
+}
+
+const decodeDecompositionInput = (
+  input: unknown,
+): ArtanisSubQueryDecompositionInput => {
+  const candidate = typeof input === 'string'
+    ? parseJsonCandidate(input)
+    : input
+
+  try {
+    return S.decodeUnknownSync(ArtanisSubQueryDecompositionInput)(candidate)
+  } catch {
+    throw new ArtanisSubQueryDecompositionParseError({
+      reason: 'sub-query decomposition must match the Artanis FRLM JSON schema',
+    })
+  }
+}
+
+const parseJsonCandidate = (input: string): unknown => {
+  const text = input.trim()
+
+  if (text === '') {
+    throw new ArtanisSubQueryDecompositionParseError({
+      reason: 'sub-query decomposition JSON is empty',
+    })
+  }
+
+  const fenced = text.match(/^```(?:json|JSON)?\s*([\s\S]*?)\s*```$/)
+  const jsonText = fenced?.[1] ?? extractJsonObject(text)
+
+  try {
+    return parseJsonUnknown(jsonText)
+  } catch {
+    throw new ArtanisSubQueryDecompositionParseError({
+      reason: 'sub-query decomposition is not valid JSON',
+    })
+  }
+}
+
+const extractJsonObject = (text: string): string => {
+  const start = text.indexOf('{')
+  const end = text.lastIndexOf('}')
+
+  if (start === -1 || end === -1 || end <= start) {
+    throw new ArtanisSubQueryDecompositionParseError({
+      reason: 'sub-query decomposition must contain one JSON object',
+    })
+  }
+
+  return text.slice(start, end + 1)
+}
+
+const validateDecomposition = (
+  decomposition: ArtanisSubQueryDecompositionInput,
+): void => {
+  assertSafeRef('decompositionRef', decomposition.decompositionRef)
+  assertSafeRef('objectiveRef', decomposition.objectiveRef)
+  assertSafeText('rootQuery', decomposition.rootQuery, MAX_ROOT_QUERY_LENGTH)
+  assertRefList('sourceRefs', decomposition.sourceRefs, 1)
+
+  if (
+    decomposition.subQueries.length === 0 ||
+    decomposition.subQueries.length > MAX_SUB_QUERY_COUNT
+  ) {
+    throw parseError(
+      `subQueries must contain between 1 and ${MAX_SUB_QUERY_COUNT} steps`,
+    )
+  }
+
+  const ids = new Set<string>()
+
+  for (const step of decomposition.subQueries) {
+    const id = step.subQueryId.trim()
+    if (!subQueryIdPattern.test(id)) {
+      throw parseError('subQueryId must be a stable lowercase scheduler id')
+    }
+
+    if (ids.has(id)) {
+      throw parseError('subQueryId values must be unique')
+    }
+
+    ids.add(id)
+    assertSafeRef('purposeRef', step.purposeRef)
+    assertSafeText('subQuery.text', step.text, MAX_SUB_QUERY_TEXT_LENGTH)
+    assertRefList('subQuery.evidenceRefs', step.evidenceRefs, 1)
+    assertProgramSignatureRefs(step.selectedProgramSignatureIds)
+
+    if (
+      step.maxTokens !== undefined &&
+      (step.maxTokens < 1 || step.maxTokens > MAX_TOKENS_PER_SUB_QUERY)
+    ) {
+      throw parseError(
+        `maxTokens must be between 1 and ${MAX_TOKENS_PER_SUB_QUERY}`,
+      )
+    }
+  }
+
+  for (const step of decomposition.subQueries) {
+    for (const dependencyId of step.dependsOnSubQueryIds) {
+      if (dependencyId === step.subQueryId) {
+        throw parseError('subQueries must not depend on themselves')
+      }
+
+      if (!ids.has(dependencyId)) {
+        throw parseError('subQuery dependency ids must reference known steps')
+      }
+    }
+  }
+
+  assertAcyclic(decomposition.subQueries)
+}
+
+const normalizeStep = (
+  step: ArtanisSubQueryDecompositionStep,
+): ArtanisSubQueryDecompositionStep =>
+  new ArtanisSubQueryDecompositionStep({
+    dependsOnSubQueryIds: uniqueRefs(step.dependsOnSubQueryIds),
+    evidenceRefs: uniqueRefs(step.evidenceRefs),
+    maxTokens: step.maxTokens,
+    purposeRef: step.purposeRef.trim(),
+    selectedProgramSignatureIds: uniqueRefs(step.selectedProgramSignatureIds),
+    subQueryId: step.subQueryId.trim(),
+    target: step.target,
+    text: step.text.trim(),
+  })
+
+const assertRefList = (
+  label: string,
+  refs: ReadonlyArray<string>,
+  minimumCount: number,
+): void => {
+  if (refs.length < minimumCount || refs.length > MAX_REF_COUNT) {
+    throw parseError(
+      `${label} must contain between ${minimumCount} and ${MAX_REF_COUNT} refs`,
+    )
+  }
+
+  for (const ref of refs) {
+    assertSafeRef(label, ref)
+  }
+}
+
+const assertProgramSignatureRefs = (
+  refs: ReadonlyArray<string>,
+): void => {
+  assertRefList('selectedProgramSignatureIds', refs, 1)
+
+  for (const ref of refs) {
+    if (!programSignatureRefPattern.test(ref.trim())) {
+      throw parseError(
+        'selectedProgramSignatureIds must be Blueprint Program Signature refs',
+      )
+    }
+  }
+}
+
+const assertSafeRef = (label: string, ref: string): void => {
+  const trimmed = ref.trim()
+  if (
+    trimmed === '' ||
+    !safeRefPattern.test(trimmed) ||
+    unsafeMaterialPattern.test(trimmed)
+  ) {
+    throw parseError(
+      `${label} contains unsafe private, secret, wallet, provider, raw trace, or local path material`,
+    )
+  }
+}
+
+const assertSafeText = (
+  label: string,
+  text: string,
+  maxLength: number,
+): void => {
+  const trimmed = text.trim()
+  if (
+    trimmed === '' ||
+    trimmed.length > maxLength ||
+    unsafeMaterialPattern.test(trimmed)
+  ) {
+    throw parseError(
+      `${label} must be non-empty, bounded, and free of private or secret material`,
+    )
+  }
+}
+
+const assertAcyclic = (
+  steps: ReadonlyArray<ArtanisSubQueryDecompositionStep>,
+): void => {
+  const dependenciesById = new Map(
+    steps.map(step => [
+      step.subQueryId,
+      new Set(step.dependsOnSubQueryIds),
+    ]),
+  )
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+
+  const visit = (id: string): void => {
+    if (visited.has(id)) {
+      return
+    }
+
+    if (visiting.has(id)) {
+      throw parseError('subQuery dependencies must form an acyclic graph')
+    }
+
+    visiting.add(id)
+    for (const dependencyId of dependenciesById.get(id) ?? []) {
+      visit(dependencyId)
+    }
+    visiting.delete(id)
+    visited.add(id)
+  }
+
+  for (const step of steps) {
+    visit(step.subQueryId)
+  }
+}
+
+const uniqueRefs = (
+  refs: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+  [...new Set(refs.map(ref => ref.trim()).filter(ref => ref !== ''))]
+
+const parseError = (
+  reason: string,
+): ArtanisSubQueryDecompositionParseError =>
+  new ArtanisSubQueryDecompositionParseError({ reason })


### PR DESCRIPTION
Addresses #6680.

### Changes
- Adds the Artanis sub-query decomposition parser implementation.
- Adds tests covering the parser behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` - passed (exit 0)