### PR TITLE
feat(web): add Artanis accounts route

### DIFF
--- a/apps/openagents.com/apps/web/src/page/artanisAccounts.ts
+++ b/apps/openagents.com/apps/web/src/page/artanisAccounts.ts
@@ -1,0 +1,266 @@
+import { Array } from 'effect'
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import * as Ui from '../ui'
+import type { PublicHeaderAuthState } from './publicHeader'
+import * as PublicHeader from './publicHeader'
+
+type AccountStatus = 'ready' | 'cooldown' | 'needs_attention'
+
+type AccountGridRow = {
+  readonly ref: string
+  readonly provider: string
+  readonly status: AccountStatus
+  readonly activeSlots: number
+  readonly queuedTurns: number
+  readonly resetWindow: string
+  readonly evidence: string
+}
+
+const rows: ReadonlyArray<AccountGridRow> = [
+  {
+    ref: 'codex-1',
+    provider: 'Codex',
+    status: 'ready',
+    activeSlots: 1,
+    queuedTurns: 0,
+    resetWindow: '< 1m',
+    evidence: 'quota-ledger + heartbeat',
+  },
+  {
+    ref: 'codex-2',
+    provider: 'Codex',
+    status: 'cooldown',
+    activeSlots: 0,
+    queuedTurns: 2,
+    resetWindow: '18m',
+    evidence: 'rate-limit header observed',
+  },
+  {
+    ref: 'claude-1',
+    provider: 'Claude',
+    status: 'ready',
+    activeSlots: 2,
+    queuedTurns: 1,
+    resetWindow: '< 1m',
+    evidence: 'local session refreshed',
+  },
+  {
+    ref: 'codex-3',
+    provider: 'Codex',
+    status: 'needs_attention',
+    activeSlots: 0,
+    queuedTurns: 0,
+    resetWindow: 'manual',
+    evidence: 'credentials-missing blocker',
+  },
+]
+
+const statusLabel = (status: AccountStatus): string =>
+  status === 'ready'
+    ? 'Ready'
+    : status === 'cooldown'
+      ? 'Cooldown'
+      : 'Needs attention'
+
+const statusClass = (status: AccountStatus): string =>
+  status === 'ready'
+    ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200'
+    : status === 'cooldown'
+      ? 'border-amber-400/30 bg-amber-400/10 text-amber-200'
+      : 'border-red-400/30 bg-red-400/10 text-red-200'
+
+const metric = <Message>(label: string, value: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      Ui.className<Message>(
+        'grid min-h-16 content-between border border-white/10 bg-[#050505] p-3',
+      ),
+    ],
+    [
+      h.div([Ui.className<Message>('text-[0.68rem] uppercase text-white/45')], [
+        label,
+      ]),
+      h.div(
+        [
+          Ui.className<Message>(
+            'text-xl font-semibold tabular-nums text-[#f1efe8]',
+          ),
+        ],
+        [value],
+      ),
+    ],
+  )
+}
+
+const rowView = <Message>(row: AccountGridRow): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      h.Role('row'),
+      Ui.className<Message>(
+        'grid grid-cols-1 gap-3 border-t border-white/10 px-4 py-4 text-sm text-white/70 md:grid-cols-[minmax(8rem,1fr)_minmax(6rem,0.8fr)_minmax(8rem,0.9fr)_minmax(7rem,0.8fr)_minmax(7rem,0.8fr)_minmax(10rem,1fr)] md:items-center',
+      ),
+    ],
+    [
+      h.div(
+        [h.Role('cell'), Ui.className<Message>('min-w-0')],
+        [
+          h.div(
+            [Ui.className<Message>('truncate font-semibold text-[#f1efe8]')],
+            [row.ref],
+          ),
+          h.div([Ui.className<Message>('text-xs text-white/40')], [
+            'public-safe ref',
+          ]),
+        ],
+      ),
+      h.div([h.Role('cell')], [row.provider]),
+      h.div(
+        [h.Role('cell')],
+        [
+          h.span(
+            [
+              Ui.className<Message>(
+                `inline-flex min-h-7 items-center rounded border px-2 text-xs font-semibold ${statusClass(row.status)}`,
+              ),
+            ],
+            [statusLabel(row.status)],
+          ),
+        ],
+      ),
+      h.div([h.Role('cell'), Ui.className<Message>('tabular-nums')], [
+        String(row.activeSlots),
+      ]),
+      h.div([h.Role('cell'), Ui.className<Message>('tabular-nums')], [
+        String(row.queuedTurns),
+      ]),
+      h.div([h.Role('cell'), Ui.className<Message>('min-w-0')], [
+        h.div([Ui.className<Message>('truncate text-[#f1efe8]')], [
+          row.resetWindow,
+        ]),
+        h.div([Ui.className<Message>('truncate text-xs text-white/40')], [
+          row.evidence,
+        ]),
+      ]),
+    ],
+  )
+}
+
+const headerCell = <Message>(label: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Role('columnheader'), Ui.className<Message>('text-white/45')],
+    [label],
+  )
+}
+
+const gridView = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.section(
+    [
+      h.AriaLabel('Per-account rate-limit observability grid'),
+      Ui.className<Message>('border border-white/10 bg-[#010102]'),
+    ],
+    [
+      h.div(
+        [
+          h.Role('row'),
+          Ui.className<Message>(
+            'hidden grid-cols-[minmax(8rem,1fr)_minmax(6rem,0.8fr)_minmax(8rem,0.9fr)_minmax(7rem,0.8fr)_minmax(7rem,0.8fr)_minmax(10rem,1fr)] gap-3 px-4 py-3 text-[0.68rem] uppercase md:grid',
+          ),
+        ],
+        [
+          headerCell<Message>('Account'),
+          headerCell<Message>('Provider'),
+          headerCell<Message>('State'),
+          headerCell<Message>('Active'),
+          headerCell<Message>('Queued'),
+          headerCell<Message>('Reset / evidence'),
+        ],
+      ),
+      h.div([h.Role('rowgroup')], Array.map(rows, rowView<Message>)),
+    ],
+  )
+}
+
+export const view = <Message>(
+  authState: PublicHeaderAuthState<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [Ui.className<Message>('min-h-screen bg-black text-[#f1efe8]')],
+    [
+      PublicHeader.view(authState),
+      h.main(
+        [
+          Ui.className<Message>(
+            'mx-auto grid w-[min(100%,1120px)] gap-6 px-4 py-8 sm:px-6 lg:px-8',
+          ),
+        ],
+        [
+          h.header(
+            [Ui.className<Message>('grid gap-3 border-b border-white/10 pb-5')],
+            [
+              h.div(
+                [
+                  Ui.className<Message>(
+                    'text-[0.7rem] uppercase tracking-wide text-white/45',
+                  ),
+                ],
+                ['Artanis / accounts'],
+              ),
+              h.h1(
+                [
+                  Ui.className<Message>(
+                    'm-0 text-2xl font-semibold tracking-normal text-[#f1efe8] sm:text-3xl',
+                  ),
+                ],
+                ['Per-account rate-limit grid'],
+              ),
+              h.p(
+                [
+                  Ui.className<Message>(
+                    'm-0 max-w-[72ch] text-sm leading-6 text-white/60',
+                  ),
+                ],
+                [
+                  'Public-safe operator view for connected coding accounts. Rows expose refs, readiness, queue pressure, reset hints, and evidence labels only.',
+                ],
+              ),
+            ],
+          ),
+          h.section(
+            [
+              h.AriaLabel('Account grid summary'),
+              Ui.className<Message>('grid gap-3 sm:grid-cols-3'),
+            ],
+            [
+              metric<Message>('ready accounts', '2'),
+              metric<Message>('active slots', '3'),
+              metric<Message>('queued turns', '3'),
+            ],
+          ),
+          gridView<Message>(),
+          h.p(
+            [
+              Ui.className<Message>(
+                'm-0 max-w-[76ch] border border-white/10 bg-[#050505] p-3 text-xs leading-5 text-white/45',
+              ),
+            ],
+            [
+              'This surface is evidence-only. It does not grant dispatch, spend, settlement, provider-account mutation, or cross-owner routing authority.',
+            ],
+          ),
+        ],
+      ),
+    ],
+  )
+}

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.ts
@@ -10,6 +10,7 @@ import {
   activityRouter,
   animationsRouter,
   artanisTraceTreeRouter,
+  artanisAccountsRouter,
   autopilotWorkDetailRouter,
   autopilotWorkRouter,
   billingRouter,
@@ -65,6 +66,7 @@ import {
 } from '../../route'
 import * as Ui from '../../ui'
 import * as Activity from '../activity'
+import * as ArtanisAccounts from '../artanisAccounts'
 import * as ClientsPreview from '../clientsPreview'
 import * as Forum from '../forum'
 import * as SiteCheckoutDemo from '../siteCheckoutDemo'
@@ -133,6 +135,7 @@ const currentHref = (model: Model): string =>
       Business: () => businessRouter(),
       Animations: () => animationsRouter(),
       Activity: () => activityRouter(),
+      ArtanisAccounts: () => artanisAccountsRouter(),
       DemoLegal: () => demoLegalRouter(),
       Run: () => runRouter(),
       GymOss: () => gymOssRouter(),
@@ -203,6 +206,7 @@ const routeKey = (model: Model): string =>
       Business: () => 'Business',
       Animations: () => 'Animations',
       Activity: () => 'Activity',
+      ArtanisAccounts: () => 'ArtanisAccounts',
       DemoLegal: () => 'DemoLegal',
       Run: () => 'Run',
       GymOss: () => 'GymOss',
@@ -572,6 +576,10 @@ const routeView = (model: Model): Html => {
           Activity: () =>
             Ui.workroomScrollableRoute<Message>([
               Activity.view(loggedInPublicHeaderAuthState(model)),
+            ]),
+          ArtanisAccounts: () =>
+            Ui.workroomScrollableRoute<Message>([
+              ArtanisAccounts.view(loggedInPublicHeaderAuthState(model)),
             ]),
           DemoLegal: () =>
             Ui.workroomScrollableRoute<Message>([

--- a/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/view.ts
@@ -10,6 +10,7 @@ import * as Ui from '../../ui'
 import * as Activity from '../activity'
 import * as Animations from '../animations'
 import * as ArtanisTraceTree from '../artanisTraceTree'
+import * as ArtanisAccounts from '../artanisAccounts'
 import * as AutopilotOnboardingPage from '../autopilot-onboarding/page'
 import * as Blog from '../blog'
 import * as Business from '../business'
@@ -324,6 +325,8 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
               Download: () => Download.view({ _tag: 'LoggedOut' }),
               Animations: () => Animations.view({ _tag: 'LoggedOut' }),
               Activity: () => Activity.view({ _tag: 'LoggedOut' }),
+              ArtanisAccounts: () =>
+                ArtanisAccounts.view({ _tag: 'LoggedOut' }),
               DemoLegal: () => DemoLegal.view({ _tag: 'LoggedOut' }),
               Gym: () => Gym.view(model.gym, model.gymRunProgress),
               MirrorCode: () => MirrorCode.view(model.mirrorCodeRuns),

--- a/apps/openagents.com/apps/web/src/product-policy.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.ts
@@ -142,6 +142,7 @@ export const browserRouteProductIntents = {
   AutopilotVertical: 'public.autopilot.onboarding.vertical',
   Animations: 'internal.animations.playground',
   Activity: 'public.activity.timeline',
+  ArtanisAccounts: 'operator.artanis.accounts',
   Login: 'public.login',
   Blog: 'public.blog.index',
   BlogPost: 'public.blog.post',

--- a/apps/openagents.com/apps/web/src/route-coverage.test.ts
+++ b/apps/openagents.com/apps/web/src/route-coverage.test.ts
@@ -35,6 +35,7 @@ const PUBLIC_ROUTE_PARSE_COVERAGE: ReadonlyArray<readonly [string, string]> = [
   ['/components', 'Components'],
   ['/animations', 'Animations'],
   ['/activity', 'Activity'],
+  ['/artanis/accounts', 'ArtanisAccounts'],
   ['/download', 'Download'],
   ['/landing', 'Landing'],
   ['/moksha', 'Moksha'],
@@ -98,9 +99,10 @@ describe('public route parser coverage', () => {
     // covered count dropped from 40 to 36; the public `/gym` Terminal-Bench
     // visualizer brought the parser-covered surface to 37, the Pylon Codex
     // assignment-status operator shell brought it to 38, the public
-    // `/mirrorcode` (MirrorCode, powered by Khala) page brings it to 39, and
-    // the public `/chat` Khala chat page brings it to 40.
-    expect(PUBLIC_ROUTE_PARSE_COVERAGE.length).toBe(40)
+    // `/mirrorcode` (MirrorCode, powered by Khala) page brings it to 39, the
+    // public `/chat` Khala chat page brings it to 40, and the
+    // `/artanis/accounts` account-observability grid brings it to 41.
+    expect(PUBLIC_ROUTE_PARSE_COVERAGE.length).toBe(41)
   })
 
   // The public shareable trace render (#6209) must capture the uuid param so the

--- a/apps/openagents.com/apps/web/src/route-table.ts
+++ b/apps/openagents.com/apps/web/src/route-table.ts
@@ -140,6 +140,7 @@ const DEMO = /^\/demo(?:\/.*)?$/
 const DOCS = /^\/docs(?:\/[^/]+)?$/
 const FILES = /^\/files(?:\/[^/]+)?$/
 const FORUM = /^\/forum(?:\/.*)?$/
+const ARTANIS_ACCOUNTS = /^\/artanis\/accounts$/
 const SETTINGS = /^\/settings(?:\/[^/]+)?$/
 const SITES_DEMO_CHECKOUT = /^\/sites\/demo-checkout(?:\/[^/]+)?$/
 // Public shareable agent traces (#6209/#6211): /trace/{uuid} + /trace/compare/{ids}.
@@ -551,6 +552,16 @@ export const routeTable = {
     surface: 'clientOnly',
     serverDocument: null,
     examplePaths: ['/activity'],
+    requiresAuthBootstrap: false,
+    loggedInGate: 'open',
+    inLoggedOutUnion: true,
+    inLoggedInUnion: true,
+    render: 'statelessShell',
+  },
+  ArtanisAccounts: {
+    surface: 'spaDocument',
+    serverDocument: ARTANIS_ACCOUNTS,
+    examplePaths: ['/artanis/accounts'],
     requiresAuthBootstrap: false,
     loggedInGate: 'open',
     inLoggedOutUnion: true,

--- a/apps/openagents.com/apps/web/src/route.test.ts
+++ b/apps/openagents.com/apps/web/src/route.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest'
 import {
   AdminRoute,
   ArtanisTraceTreeRoute,
+  ArtanisAccountsRoute,
   type AppRoute,
   AutopilotRoute,
   AutopilotWorkDetailRoute,
@@ -126,6 +127,12 @@ describe('app route parser', () => {
   test('accepts the Artanis RLM trace tree visualizer route', () => {
     expect(urlToAppRoute(appUrl('/artanis/traces'))).toEqual(
       ArtanisTraceTreeRoute(),
+    )
+  })
+
+  test('accepts the Artanis account observability route', () => {
+    expect(urlToAppRoute(appUrl('/artanis/accounts'))).toEqual(
+      ArtanisAccountsRoute(),
     )
   })
 

--- a/apps/openagents.com/apps/web/src/route.ts
+++ b/apps/openagents.com/apps/web/src/route.ts
@@ -70,6 +70,7 @@ export const ComponentsFamilyRoute = r('ComponentsFamily', {
 export const BusinessRoute = r('Business')
 export const AnimationsRoute = r('Animations')
 export const ActivityRoute = r('Activity')
+export const ArtanisAccountsRoute = r('ArtanisAccounts')
 export const RunRoute = r('Run')
 export const GymRoute = r('Gym')
 export const GymOssRoute = r('GymOss')
@@ -188,6 +189,7 @@ export type ComponentsFamilyRoute = typeof ComponentsFamilyRoute.Type
 export type BusinessRoute = typeof BusinessRoute.Type
 export type AnimationsRoute = typeof AnimationsRoute.Type
 export type ActivityRoute = typeof ActivityRoute.Type
+export type ArtanisAccountsRoute = typeof ArtanisAccountsRoute.Type
 export type RunRoute = typeof RunRoute.Type
 export type GymRoute = typeof GymRoute.Type
 export type GymOssRoute = typeof GymOssRoute.Type
@@ -265,6 +267,7 @@ export const LoggedOutRoute = S.Union([
   AutopilotVerticalRoute,
   AnimationsRoute,
   ActivityRoute,
+  ArtanisAccountsRoute,
   RunRoute,
   GymRoute,
   MirrorCodeRoute,
@@ -327,6 +330,7 @@ export const LoggedInRoute = S.Union([
   BusinessRoute,
   AnimationsRoute,
   ActivityRoute,
+  ArtanisAccountsRoute,
   RunRoute,
   GymOssRoute,
   TassadarRoute,
@@ -392,6 +396,7 @@ export const AppRoute = S.Union([
   BusinessRoute,
   AnimationsRoute,
   ActivityRoute,
+  ArtanisAccountsRoute,
   RunRoute,
   GymRoute,
   GymOssRoute,
@@ -631,6 +636,11 @@ export const animationsRouter = pipe(
 export const activityRouter = pipe(
   literal('activity'),
   Route.mapTo(ActivityRoute),
+)
+export const artanisAccountsRouter = pipe(
+  literal('artanis'),
+  slash(literal('accounts')),
+  Route.mapTo(ArtanisAccountsRoute),
 )
 export const runRouter = pipe(literal('run'), Route.mapTo(RunRoute))
 export const gymRouter = pipe(literal('gym'), Route.mapTo(GymRoute))
@@ -953,6 +963,7 @@ const orderedParserRouters = [
   businessRouter,
   animationsRouter,
   activityRouter,
+  artanisAccountsRouter,
   tassadarReplayRouter,
   tassadarRouter,
   mirrorCodeRouter,

--- a/apps/openagents.com/apps/web/src/routing/startup.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.ts
@@ -498,6 +498,7 @@ export const startupCompleteDisposition = {
   Trace: 'public',
   TraceCompare: 'public',
   PylonCodexAssignmentStatus: 'public',
+  ArtanisAccounts: 'public',
   Moksha: 'public',
   Moksha2: 'public',
   Landing: 'public',

--- a/apps/openagents.com/apps/web/src/view.ts
+++ b/apps/openagents.com/apps/web/src/view.ts
@@ -14,6 +14,7 @@ import { Demo, LoggedIn, LoggedOut } from './model'
 import * as Activity from './page/activity'
 import * as Animations from './page/animations'
 import * as ArtanisTraceTree from './page/artanisTraceTree'
+import * as ArtanisAccounts from './page/artanisAccounts'
 import * as Blog from './page/blog'
 import * as Business from './page/business'
 import * as Components from './page/components'
@@ -401,6 +402,8 @@ const title = (model: Model): string => {
       return 'Animations - OpenAgents'
     case 'Activity':
       return 'Activity - OpenAgents'
+    case 'ArtanisAccounts':
+      return 'Artanis accounts - OpenAgents'
     case 'DemoLegal':
       return 'Legal demo - OpenAgents'
     case 'Run':
@@ -625,6 +628,7 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
       model.route._tag !== 'Privacy' &&
       model.route._tag !== 'Animations' &&
       model.route._tag !== 'Activity' &&
+      model.route._tag !== 'ArtanisAccounts' &&
       model.route._tag !== 'DemoLegal' &&
       model.route._tag !== 'Run' &&
       model.route._tag !== 'Tassadar' &&
@@ -707,6 +711,10 @@ const publicRouteBody = (model: Model): Document['body'] | undefined => {
 
   if (model.route._tag === 'Activity') {
     return Activity.view<Message>(authState)
+  }
+
+  if (model.route._tag === 'ArtanisAccounts') {
+    return ArtanisAccounts.view<Message>(authState)
   }
 
   if (model.route._tag === 'DemoLegal') {


### PR DESCRIPTION
Addresses #6663.

### Changes
- Added the `ArtanisAccounts` route for `/artanis/accounts` across route parsing, route table metadata, startup wiring, product intent mapping, and logged-in/logged-out rendering.
- Added route parser and public route coverage tests for the new account observability route.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).