### PR TITLE
fix(codex-fleet): base every assignment on fresh origin/main (stop stale-base deletion-poisoned PRs)

### DIFF
--- a/apps/pylon/scripts/claude-supervisor/claude-supervisor.sh
+++ b/apps/pylon/scripts/claude-supervisor/claude-supervisor.sh
@@ -66,6 +66,10 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 
 # shellcheck source=../supervisor-task-pool.sh
 source "$SCRIPT_DIR/../supervisor-task-pool.sh"
+# Fresh-base resolver (#6719 deletion-poison fix): every dispatch must base on
+# CURRENT origin/main, never the supervisor's stale local HEAD.
+# shellcheck source=../supervisor-fresh-base.sh
+source "$SCRIPT_DIR/../supervisor-fresh-base.sh"
 
 # --- Config (all overridable via env) ---
 export PYLON_OPENAGENTS_BASE_URL="${PYLON_OPENAGENTS_BASE_URL:-https://openagents.com}"
@@ -255,8 +259,24 @@ worker_loop() {
       backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
       continue
     fi
-    local commit; commit=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)
-    [ -z "$commit" ] && { sleep 15; continue; }
+    # Base every assignment on FRESH origin/main, never the supervisor's stale
+    # local HEAD. $REPO_ROOT can lag origin/main badly (idle clone, or another
+    # agent's dirty worktree). main moves fast, so a stale base makes the worker
+    # branch from an old commit and the PR diff vs current main looks like a mass
+    # deletion of everything added since (the #6719 deletion-poison pattern).
+    # Resolve the live remote main SHA with a pure `git ls-remote` (no
+    # working-tree / local-ref mutation; safe in a dirty or shared checkout). If
+    # it can't be resolved, SKIP this dispatch rather than poison it.
+    local commit local_head
+    commit=$(supervisor_resolve_fresh_origin_main_sha "$SUP_REPO")
+    if [ -z "$commit" ]; then
+      log "slot=$slot SKIP could not resolve fresh origin/main sha for $SUP_REPO; not dispatching a stale base (anti-#6719)"
+      sleep 15; continue
+    fi
+    local_head=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo "")
+    if [ -n "$local_head" ] && [ "$local_head" != "$commit" ]; then
+      log "slot=$slot BASE-DRIFT local HEAD ${local_head:0:12} != origin/main ${commit:0:12}; dispatching FRESH origin/main (anti-#6719 deletion-poison)"
+    fi
 
     local out="$SUP_STATE_DIR/slot.$slot.json"
     "${PYLON[@]}" khala request \

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -63,6 +63,10 @@ source "$SCRIPT_DIR/lockout.sh"
 source "$SCRIPT_DIR/virtual-merge-queue.sh"
 # shellcheck source=../supervisor-task-pool.sh
 source "$SCRIPT_DIR/../supervisor-task-pool.sh"
+# Fresh-base resolver (#6719 deletion-poison fix): every dispatch must base on
+# CURRENT origin/main, never the supervisor's stale local HEAD.
+# shellcheck source=../supervisor-fresh-base.sh
+source "$SCRIPT_DIR/../supervisor-fresh-base.sh"
 # Fleet-saturation engine (#6711): label-priority dispatch ordering so slots
 # always burn the highest tier first and FALL THROUGH locked/empty tiers, plus
 # standing-task auto-recreate so the priority queue is self-sustaining.
@@ -358,10 +362,29 @@ worker_loop() {
       backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
       continue
     fi
-    local commit real_commit
-    real_commit=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)
-    commit=$(sup_vmq_project_head "$REPO_ROOT" "${real_commit:-HEAD}" 2>/dev/null)
-    [ -z "$commit" ] && commit="$real_commit"
+    # Base every assignment on FRESH origin/main, never the supervisor's stale
+    # local HEAD. $REPO_ROOT can lag origin/main badly (idle clone, or another
+    # agent's dirty worktree). main moves fast, so a stale base makes the worker
+    # branch from an old commit and the PR diff vs current main looks like a mass
+    # deletion of everything added since (the #6719 deletion-poison pattern,
+    # recurred on #6734/#6736, nearly #6761). Resolve the live remote main SHA
+    # with a pure `git ls-remote` (no working-tree / local-ref mutation; safe in
+    # a dirty or shared checkout). If it can't be resolved, SKIP this dispatch
+    # rather than poison it with a stale base.
+    local commit fresh_main local_head
+    fresh_main=$(supervisor_resolve_fresh_origin_main_sha "$SUP_REPO")
+    if [ -z "$fresh_main" ]; then
+      log "slot=$slot SKIP could not resolve fresh origin/main sha for $SUP_REPO; not dispatching a stale base (anti-#6719)"
+      sleep 15; continue
+    fi
+    local_head=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo "")
+    if [ -n "$local_head" ] && [ "$local_head" != "$fresh_main" ]; then
+      log "slot=$slot BASE-DRIFT local HEAD ${local_head:0:12} != origin/main ${fresh_main:0:12}; dispatching FRESH origin/main (anti-#6719 deletion-poison)"
+    fi
+    # Optional virtual-merge-queue projection still anchors on FRESH main, so the
+    # projected base is fresh main plus in-flight assignment branches.
+    commit=$(sup_vmq_project_head "$REPO_ROOT" "$fresh_main" 2>/dev/null)
+    [ -z "$commit" ] && commit="$fresh_main"
     [ -z "$commit" ] && { sleep 15; continue; }
 
     # Record the dispatch ATTEMPT timestamp (#6646) right before firing the

--- a/apps/pylon/scripts/codex-supervisor/virtual-merge-queue.sh
+++ b/apps/pylon/scripts/codex-supervisor/virtual-merge-queue.sh
@@ -96,14 +96,20 @@ sup_vmq_project_head() {
   local source_base="${2:-HEAD}"
   [ "${SUP_VMQ_ENABLED:-1}" = "1" ] || return 1
 
-  local real_base
-  real_base="$(sup_vmq_sha "$source_repo" "$source_base")" || return 1
-  [ -n "$real_base" ] || return 1
-
   if ! sup_vmq_sync_repo "$source_repo"; then
-    sup_vmq_log "VMQ unavailable: sync failed; using real base $real_base"
+    sup_vmq_log "VMQ unavailable: sync failed"
     return 1
   fi
+
+  # Resolve the base INSIDE the freshly-fetched clone so the projection is always
+  # anchored to a CURRENT object (the caller passes the fresh origin/main SHA),
+  # never the supervisor's stale local HEAD which would deletion-poison the PR
+  # diff (#6719). If the requested base object is somehow absent, fall back to the
+  # freshly fetched base-branch tip in the clone — still fresh, never stale-local.
+  local real_base
+  real_base="$(sup_vmq_sha "$SUP_VMQ_DIR" "$source_base")"
+  [ -n "$real_base" ] || real_base="$(sup_vmq_sha "$SUP_VMQ_DIR" "$SUP_VMQ_REMOTE/$SUP_VMQ_BASE_BRANCH")"
+  [ -n "$real_base" ] || return 1
 
   local work_branch="pylon/virtual-merge-queue"
   sup_vmq_git checkout --quiet -B "$work_branch" "$real_base" >/dev/null 2>&1 || return 1

--- a/apps/pylon/scripts/supervisor-fresh-base.sh
+++ b/apps/pylon/scripts/supervisor-fresh-base.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# supervisor-fresh-base.sh — resolve the CURRENT origin/main commit so every
+# dispatched assignment bases on FRESH origin/main, never a stale local HEAD.
+#
+# ROOT CAUSE THIS FIXES (#6719 deletion-poison; recurred #6734/#6736, nearly
+# #6761): the codex/claude supervisors pinned each assignment's `--commit` to the
+# LOCAL checkout HEAD (`git -C "$REPO_ROOT" rev-parse HEAD`). The supervisor's
+# $REPO_ROOT can lag far behind origin/main (an idle clone, or another agent's
+# dirty worktree that is never fast-forwarded). main moves fast, so a stale local
+# HEAD makes every worker materialize its bounded workspace from an OLD base; the
+# resulting PR diff vs current main then looks like a mass deletion of everything
+# added since that old base — i.e. squashing it would DELETE clients/,
+# INVARIANTS.md, PRODUCT.md, apps/, etc.
+#
+# The fix anchors dispatch on the live remote main SHA via `git ls-remote` — a
+# pure network READ that NEVER mutates the working tree or local refs, so it is
+# safe in a dirty or shared checkout (no fetch/reset/checkout of the supervisor's
+# own repo, which would clobber a concurrent agent's work).
+#
+# This file performs no work at source time; it only defines functions.
+
+: "${SUP_REPO:=OpenAgentsInc/openagents}"
+: "${SUP_BASE_BRANCH:=main}"
+: "${SUP_GIT_BIN:=git}"
+
+# supervisor_resolve_fresh_origin_main_sha [full_name] [base_branch]
+#
+# Echo the 40-char lowercase commit SHA of refs/heads/<base_branch> for the given
+# GitHub <full_name> (defaults: $SUP_REPO, $SUP_BASE_BRANCH), or echo nothing and
+# return 1 on any failure. Pure read; never mutates local git state.
+#
+# Callers MUST treat a non-zero return / empty output as "do not dispatch": it is
+# always safer to skip a dispatch than to pin work to a stale base and poison the
+# resulting PR into a mass-deletion diff.
+supervisor_resolve_fresh_origin_main_sha() {
+  local full_name="${1:-$SUP_REPO}"
+  local base_branch="${2:-${SUP_BASE_BRANCH:-main}}"
+  [ -n "$full_name" ] || return 1
+
+  local out sha
+  out=$("$SUP_GIT_BIN" ls-remote "https://github.com/${full_name}.git" \
+    "refs/heads/${base_branch}" 2>/dev/null) || return 1
+  sha=$(printf '%s\n' "$out" | awk 'NR==1{print $1}')
+  sha=$(printf '%s' "$sha" | tr '[:upper:]' '[:lower:]')
+  if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+    printf '%s' "$sha"
+    return 0
+  fi
+  return 1
+}

--- a/apps/pylon/scripts/supervisor-fresh-base.test.sh
+++ b/apps/pylon/scripts/supervisor-fresh-base.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# supervisor-fresh-base.test.sh — focused tests for the fresh-base resolver.
+#
+# Stubs `git` (no network) and asserts that supervisor_resolve_fresh_origin_main_sha:
+#   * returns the 40-char SHA from a well-formed `git ls-remote` line,
+#   * queries the correct https URL + refs/heads/<branch> for the repo,
+#   * lower-cases an upper-case SHA,
+#   * fails (empty, rc!=0) when ls-remote errors,
+#   * fails when ls-remote returns a non-SHA / truncated value,
+#   * never invokes any mutating git verb (fetch/reset/checkout/clone/worktree).
+#
+# Run: bash apps/pylon/scripts/supervisor-fresh-base.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# Stub git: log the full argv, then behave per SUP_TEST_MODE.
+cat > "$WORK/git" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GIT_CALL_LOG"
+case "${SUP_TEST_MODE:-ok}" in
+  fail)     exit 2 ;;
+  garbage)  printf 'not-a-sha\trefs/heads/main\n'; exit 0 ;;
+  short)    printf 'abc123\trefs/heads/main\n'; exit 0 ;;
+  upper)    printf '%s\trefs/heads/main\n' "A1B2C3D4E5F60718293A4B5C6D7E8F9001122334"; exit 0 ;;
+  ok|*)     printf '%s\trefs/heads/%s\n' "0123456789abcdef0123456789abcdef01234567" "${SUP_TEST_BRANCH:-main}"; exit 0 ;;
+esac
+STUB
+chmod +x "$WORK/git"
+
+export SUP_GIT_BIN="$WORK/git"
+export GIT_CALL_LOG="$WORK/git-calls.log"
+: > "$GIT_CALL_LOG"
+
+# shellcheck source=supervisor-fresh-base.sh
+source "$SCRIPT_DIR/supervisor-fresh-base.sh"
+
+# 1. Well-formed ls-remote line -> SHA.
+export SUP_TEST_MODE=ok; got="$(supervisor_resolve_fresh_origin_main_sha OpenAgentsInc/openagents)"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$got" = "0123456789abcdef0123456789abcdef01234567" ]; then
+  ok "returns the SHA from a well-formed ls-remote line"
+else
+  bad "expected SHA, got '$got' rc=$rc"
+fi
+
+# 2. Queries the correct URL + ref.
+if grep -q "ls-remote https://github.com/OpenAgentsInc/openagents.git refs/heads/main" "$GIT_CALL_LOG"; then
+  ok "queries the correct https url and refs/heads/main"
+else
+  bad "did not query the expected url/ref: $(cat "$GIT_CALL_LOG")"
+fi
+
+# 3. Lower-cases an upper-case SHA.
+export SUP_TEST_MODE=upper; got="$(supervisor_resolve_fresh_origin_main_sha OpenAgentsInc/openagents)"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$got" = "a1b2c3d4e5f60718293a4b5c6d7e8f9001122334" ]; then
+  ok "lower-cases the resolved SHA"
+else
+  bad "expected lowercased SHA, got '$got' rc=$rc"
+fi
+
+# 4. ls-remote error -> empty + rc!=0.
+export SUP_TEST_MODE=fail; got="$(supervisor_resolve_fresh_origin_main_sha OpenAgentsInc/openagents)"; rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$got" ]; then
+  ok "fails closed when ls-remote errors"
+else
+  bad "expected failure on ls-remote error, got '$got' rc=$rc"
+fi
+
+# 5. Non-SHA output -> empty + rc!=0.
+export SUP_TEST_MODE=garbage; got="$(supervisor_resolve_fresh_origin_main_sha OpenAgentsInc/openagents)"; rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$got" ]; then
+  ok "fails closed when ls-remote returns a non-SHA"
+else
+  bad "expected failure on non-SHA, got '$got' rc=$rc"
+fi
+
+# 6. Truncated SHA -> empty + rc!=0.
+export SUP_TEST_MODE=short; got="$(supervisor_resolve_fresh_origin_main_sha OpenAgentsInc/openagents)"; rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$got" ]; then
+  ok "fails closed when ls-remote returns a truncated SHA"
+else
+  bad "expected failure on truncated SHA, got '$got' rc=$rc"
+fi
+
+# 7. Custom branch is honored.
+: > "$GIT_CALL_LOG"
+export SUP_TEST_MODE=ok SUP_TEST_BRANCH=release; supervisor_resolve_fresh_origin_main_sha OpenAgentsInc/openagents release >/dev/null; unset SUP_TEST_BRANCH
+if grep -q "refs/heads/release" "$GIT_CALL_LOG"; then
+  ok "honors a non-default base branch"
+else
+  bad "did not query the requested base branch: $(cat "$GIT_CALL_LOG")"
+fi
+
+# 8. Never invokes a mutating git verb.
+if grep -Eq '(^| )(fetch|reset|checkout|clone|worktree|merge|pull|push|update-ref)( |$)' "$WORK/git-calls.log"; then
+  bad "invoked a mutating git verb: $(cat "$WORK/git-calls.log")"
+else
+  ok "uses only the read-only ls-remote verb (no working-tree/ref mutation)"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Root cause

The codex/claude supervisors pinned each dispatched assignment's `--commit` to the supervisor's **local checkout HEAD** (`git -C "$REPO_ROOT" rev-parse HEAD`):

- `apps/pylon/scripts/codex-supervisor/codex-supervisor.sh` (commit-pin site; also via the virtual-merge-queue which anchored on that same local HEAD)
- `apps/pylon/scripts/claude-supervisor/claude-supervisor.sh`

`$REPO_ROOT` can lag far behind `origin/main` (an idle clone, or another agent's dirty worktree that is never fast-forwarded). `main` moves fast, so a stale local HEAD made every worker materialize its bounded workspace from an **old base**. The resulting PR diff vs current `main` then looked like a **mass deletion of everything added since that base** — squashing it would delete `clients/`, `INVARIANTS.md`, `PRODUCT.md`, `apps/`, etc. This is the #6719 deletion-poison pattern (recurred on #6734/#6736, nearly #6761).

## Fix

- New shared helper `apps/pylon/scripts/supervisor-fresh-base.sh` — `supervisor_resolve_fresh_origin_main_sha` resolves the live remote `main` SHA via a pure `git ls-remote` (a network **read** that never mutates the working tree or local refs, so it is safe in a dirty/shared checkout — no fetch/reset/checkout of the supervisor's repo).
- Both supervisors source the helper and pin every dispatch to that **fresh** SHA, never local HEAD. If the fresh SHA can't be resolved, the dispatch is **skipped** rather than poisoned with a stale base.
- A `BASE-DRIFT` log line fires whenever local HEAD differs from the dispatched fresh `origin/main`, so a stale base can no longer silently produce a mass-deletion diff (the requested guard/log).
- The codex `virtual-merge-queue.sh` now resolves its base **inside the freshly-fetched clone** (fresh `origin/main` + in-flight assignment branches), so it stays fresh and robust even when the supervisor's local checkout is stale.

### Before / after

- **Before:** `commit = local HEAD` (stale) → worker branches from old base → PR diff looks like a mass deletion of everything added since.
- **After:** `commit = ls-remote refs/heads/main` (current) → worker branches from current `main` → PR diff is just the worker's real change; unresolvable → skip, never poison.

## Verification

- New `apps/pylon/scripts/supervisor-fresh-base.test.sh` (8 cases): returns SHA from a well-formed `ls-remote` line, queries the correct URL/ref, lower-cases the SHA, fails-closed on error / non-SHA / truncated SHA, honors a custom base branch, and asserts it uses **only** the read-only `ls-remote` verb (no working-tree/ref mutation).
- Existing `virtual-merge-queue.test.sh`, `supervisor-task-pool.test.sh`, `lockout.test.sh` still green; `bash -n` clean on all touched scripts.
- `bun run check:deploy` green.

This PR is itself based on fresh `origin/main` and only adds/edits the 5 scoped supervisor files — no deletions of protected paths (anti-#6719 guard applied to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)