### PR TITLE
fix(codex-supervisor): block unsafe VMQ deletion squashes

### DIFF
--- a/apps/pylon/src/blueprint-gates/virtual-merge-queue.test.ts
+++ b/apps/pylon/src/blueprint-gates/virtual-merge-queue.test.ts
@@ -101,7 +101,134 @@ describe("virtual merge queue", () => {
     expect(projection.blocked[0]?.blockedReasonRef).toBe(
       "virtual_merge_queue.blocked.stale_base",
     )
+    expect(projection.blocked[0]?.status).toBe("needs-rebase")
     expect(projection.branchBaseForNextAssignment).toBe(B)
+  })
+
+  test("blocks a stale-based branch before a squash can delete files added since its base", () => {
+    const projection = projectVirtualMergeQueue({
+      actualHead: C,
+      candidates: [
+        candidate({
+          candidateRef: "candidate.public.pylon_vmq.stale_deletion_poison",
+          issueNumber: 6723,
+          baseCommit: A,
+          patchCommit: D,
+          changedFiles: [
+            { path: "clients/mobile/Khala/README.md", status: "deleted" },
+            { path: "INVARIANTS.md", status: "deleted" },
+          ],
+        }),
+      ],
+    })
+
+    expect(projection.ready).toEqual([])
+    expect(projection.nextActualPromotion).toBeNull()
+    expect(projection.blocked[0]?.blockedReasonRef).toBe(
+      "virtual_merge_queue.blocked.stale_base",
+    )
+    expect(projection.blocked[0]?.status).toBe("needs-rebase")
+  })
+
+  test("blocks protected path deletions even when the branch is otherwise fresh", () => {
+    const projection = projectVirtualMergeQueue({
+      actualHead: A,
+      candidates: [
+        candidate({
+          candidateRef: "candidate.public.pylon_vmq.protected_delete",
+          issueNumber: 6724,
+          baseCommit: A,
+          patchCommit: B,
+          changedFiles: [
+            { path: "apps/pylon/src/index.ts", status: "deleted" },
+          ],
+        }),
+      ],
+    })
+
+    expect(projection.ready).toEqual([])
+    expect(projection.blocked[0]?.blockedReasonRef).toBe(
+      "virtual_merge_queue.blocked.protected_path_deleted",
+    )
+  })
+
+  test("blocks candidates over the mass deletion threshold", () => {
+    const projection = projectVirtualMergeQueue({
+      actualHead: A,
+      candidates: [
+        candidate({
+          candidateRef: "candidate.public.pylon_vmq.mass_delete",
+          issueNumber: 6725,
+          baseCommit: A,
+          patchCommit: B,
+          changedFiles: Array.from({ length: 6 }, (_, index) => ({
+            path: `docs/refactor/pruned-${index}.md`,
+            status: "deleted" as const,
+          })),
+        }),
+      ],
+    })
+
+    expect(projection.ready).toEqual([])
+    expect(projection.blocked[0]?.blockedReasonRef).toBe(
+      "virtual_merge_queue.blocked.mass_deletion_threshold",
+    )
+  })
+
+  test("lets a clean in-scope candidate merge normally", () => {
+    const projection = projectVirtualMergeQueue({
+      actualHead: A,
+      candidates: [
+        candidate({
+          candidateRef: "candidate.public.pylon_vmq.clean",
+          issueNumber: 6726,
+          baseCommit: A,
+          patchCommit: B,
+          changedFiles: [
+            { path: "packages/world-contract/src/index.ts", status: "modified" },
+          ],
+        }),
+      ],
+    })
+
+    expect(projection.ready.map((entry) => entry.issueNumber)).toEqual([6726])
+    expect(projection.nextActualPromotion?.issueNumber).toBe(6726)
+    expect(projection.blocked).toEqual([])
+  })
+
+  test("honors only an explicit signed operator override for stale or large deletion guards", () => {
+    const projection = projectVirtualMergeQueue({
+      actualHead: C,
+      candidates: [
+        candidate({
+          candidateRef: "candidate.public.pylon_vmq.unsigned_override",
+          issueNumber: 6727,
+          baseCommit: A,
+          patchCommit: D,
+          signedOperatorOverrideRef: "operator-said-ok",
+          changedFiles: [
+            { path: "INVARIANTS.md", status: "deleted" },
+          ],
+        }),
+        candidate({
+          candidateRef: "candidate.public.pylon_vmq.signed_override",
+          issueNumber: 6728,
+          baseCommit: C,
+          patchCommit: D,
+          queuedAt: "2026-06-28T00:00:01.000Z",
+          signedOperatorOverrideRef: "override.signed.operator.issue_6728.sig_abcdef",
+          changedFiles: [
+            { path: "INVARIANTS.md", status: "deleted" },
+          ],
+        }),
+      ],
+    })
+
+    expect(projection.blocked.map((entry) => entry.issueNumber)).toEqual([6727])
+    expect(projection.blocked[0]?.blockedReasonRef).toBe(
+      "virtual_merge_queue.blocked.stale_base",
+    )
+    expect(projection.ready.map((entry) => entry.issueNumber)).toEqual([6728])
   })
 
   test("keeps issue and PR lockouts load-bearing", () => {

--- a/apps/pylon/src/blueprint-gates/virtual-merge-queue.ts
+++ b/apps/pylon/src/blueprint-gates/virtual-merge-queue.ts
@@ -16,10 +16,17 @@ export type VirtualMergeQueueCandidate = {
   readonly issueNumber: number
   readonly baseCommit: string
   readonly patchCommit: string
+  readonly changedFiles?: ReadonlyArray<VirtualMergeQueueFileChange>
+  readonly signedOperatorOverrideRef?: string | undefined
   readonly verificationPassed: boolean
   readonly issueOpen: boolean
   readonly hasOpenPullRequest: boolean
   readonly queuedAt: string
+}
+
+export type VirtualMergeQueueFileChange = {
+  readonly path: string
+  readonly status: "added" | "modified" | "deleted" | "renamed"
 }
 
 export type VirtualMergeQueueReadyEntry = {
@@ -35,6 +42,7 @@ export type VirtualMergeQueueBlockedEntry = {
   readonly candidateRef: string
   readonly issueNumber: number
   readonly blockedReasonRef: VirtualMergeQueueBlockedReasonRef
+  readonly status: "blocked" | "needs-rebase"
   readonly detail: string
 }
 
@@ -45,6 +53,8 @@ export type VirtualMergeQueueBlockedReasonRef =
   | "virtual_merge_queue.blocked.stale_base"
   | "virtual_merge_queue.blocked.invalid_commit"
   | "virtual_merge_queue.blocked.duplicate_issue"
+  | "virtual_merge_queue.blocked.protected_path_deleted"
+  | "virtual_merge_queue.blocked.mass_deletion_threshold"
 
 export type VirtualMergeQueueProjection = {
   readonly actualHead: string
@@ -56,6 +66,16 @@ export type VirtualMergeQueueProjection = {
 }
 
 const gitCommitShaPattern = /^[a-f0-9]{40}$/i
+const safePathPattern = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._/@+-]+(?:\/[A-Za-z0-9._/@+-]+)*$/
+const signedOperatorOverridePattern = /^override\.signed\.operator\.[A-Za-z0-9._:-]{6,160}$/
+const massDeletionThreshold = 5
+const protectedDeletedRootPaths = new Set([
+  ".githooks",
+  "INVARIANTS.md",
+  "PRODUCT.md",
+  "package.json",
+  "tsconfig.json",
+])
 
 function stableRef(prefix: string, value: string): string {
   return `${prefix}.${createHash("sha256").update(value).digest("hex").slice(0, 24)}`
@@ -63,6 +83,25 @@ function stableRef(prefix: string, value: string): string {
 
 function isCommitSha(value: string): boolean {
   return gitCommitShaPattern.test(value)
+}
+
+function hasSignedOperatorOverride(candidate: VirtualMergeQueueCandidate): boolean {
+  return candidate.signedOperatorOverrideRef !== undefined &&
+    signedOperatorOverridePattern.test(candidate.signedOperatorOverrideRef)
+}
+
+function deletedPaths(candidate: VirtualMergeQueueCandidate): ReadonlyArray<string> {
+  return (candidate.changedFiles ?? [])
+    .filter((change) => change.status === "deleted")
+    .map((change) => change.path.trim())
+    .filter((path) => path.length > 0)
+}
+
+function isProtectedDeletion(path: string): boolean {
+  return path.startsWith("apps/") ||
+    path.startsWith("clients/") ||
+    protectedDeletedRootPaths.has(path) ||
+    path.startsWith(".githooks/")
 }
 
 function candidateSortKey(candidate: VirtualMergeQueueCandidate): string {
@@ -78,6 +117,7 @@ function block(
     candidateRef: candidate.candidateRef,
     issueNumber: candidate.issueNumber,
     blockedReasonRef,
+    status: blockedReasonRef === "virtual_merge_queue.blocked.stale_base" ? "needs-rebase" : "blocked",
     detail,
   }
 }
@@ -159,12 +199,38 @@ export function projectVirtualMergeQueue(input: {
       )
       continue
     }
-    if (candidate.baseCommit.toLowerCase() !== virtualHead.toLowerCase()) {
+    const override = hasSignedOperatorOverride(candidate)
+    const deletions = deletedPaths(candidate)
+    const unsafeDeletionPath = deletions.find((path) => !safePathPattern.test(path))
+    const protectedDeletionPath = deletions.find(isProtectedDeletion)
+    if (!override && candidate.baseCommit.toLowerCase() !== virtualHead.toLowerCase()) {
       blocked.push(
         block(
           candidate,
           "virtual_merge_queue.blocked.stale_base",
           `candidate base ${candidate.baseCommit} does not match virtual head ${virtualHead}`,
+        ),
+      )
+      continue
+    }
+    if (!override && (unsafeDeletionPath !== undefined || protectedDeletionPath !== undefined)) {
+      blocked.push(
+        block(
+          candidate,
+          "virtual_merge_queue.blocked.protected_path_deleted",
+          unsafeDeletionPath !== undefined
+            ? `candidate deletes an unsafe path ${unsafeDeletionPath}`
+            : `candidate deletes protected path ${protectedDeletionPath}`,
+        ),
+      )
+      continue
+    }
+    if (!override && deletions.length > massDeletionThreshold) {
+      blocked.push(
+        block(
+          candidate,
+          "virtual_merge_queue.blocked.mass_deletion_threshold",
+          `candidate deletes ${deletions.length} files; threshold is ${massDeletionThreshold}`,
         ),
       )
       continue


### PR DESCRIPTION
Addresses #6723.

### Changes
- Added virtual merge queue guards for protected path deletions and mass deletion threshold violations.
- Marked stale-base blocks with `needs-rebase` status before promotion can proceed.
- Added signed operator override validation for stale or large deletion guards.
- Added regression coverage for stale deletion poisoning, protected deletions, mass deletions, clean candidates, and signed override behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).