### PR TITLE
feat(khala-chat): add session-aware Pylon context

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -623,7 +623,10 @@ import { makeForgeGitIntakeRoutes } from './forge-git-intake-routes'
 import { makeD1R2ForgeGitPackfileArchiveStore } from './forge-git-packfile-archive-store'
 import { makeD1ForgeTenantGitAuthStore } from './forge-tenant-git-auth-store'
 import type { KhalaChatStreamClient } from './khala-chat-program'
-import { loadKhalaChatPylonContext } from './khala-chat-pylon-context'
+import {
+  loadKhalaChatAccountPylonContext,
+  loadKhalaChatPylonContext,
+} from './khala-chat-pylon-context'
 import { makeKhalaChatRoutes } from './khala-chat-routes'
 import {
   handleKhalaFeedbackSubmit,
@@ -10160,11 +10163,57 @@ const makeArtanisResponderKhalaClient = (
     })
 }
 
+class KhalaChatSessionLookupError extends S.TaggedErrorClass<KhalaChatSessionLookupError>()(
+  'KhalaChatSessionLookupError',
+  {
+    reason: S.String,
+  },
+) {}
+
 const khalaChatRoutes = makeKhalaChatRoutes({
-  loadPylonContext: env =>
-    loadKhalaChatPylonContext(
-      makeD1PylonApiStore(openAgentsDatabase(env as WorkerBindings)),
-    ),
+  loadPylonContext: ({ ctx, env, request }) =>
+    Effect.gen(function* () {
+      const workerEnv = env as Env & WorkerBindings
+      const db = openAgentsDatabase(workerEnv)
+      const pylonStore = makeD1PylonApiStore(db)
+      const publicContext = yield* loadKhalaChatPylonContext(pylonStore)
+
+      if (ctx === undefined) {
+        return {
+          mode: 'anonymous_public' as const,
+          publicContext,
+        }
+      }
+
+      const session = yield* Effect.tryPromise({
+        catch: error =>
+          new KhalaChatSessionLookupError({
+            reason: error instanceof Error ? error.message : String(error),
+          }),
+        try: () => verifySession(request, workerEnv, ctx),
+      }).pipe(Effect.catch(() => Effect.void))
+
+      if (session === undefined) {
+        return {
+          mode: 'anonymous_public' as const,
+          publicContext,
+        }
+      }
+
+      const accountContext = yield* loadKhalaChatAccountPylonContext(
+        {
+          agentStore: makeD1AgentRegistrationStore(db),
+          pylonStore,
+        },
+        session.user.userId,
+      ).pipe(Effect.catch(() => Effect.void))
+
+      return {
+        ...(accountContext === undefined ? {} : { accountContext }),
+        mode: 'authenticated_account' as const,
+        publicContext,
+      }
+    }),
   makeStreamClient: env =>
     makeKhalaChatStreamClient(env as OnboardingInferenceEnv),
   recordServedTokens: recordPublicKhalaChatServedTokens,

--- a/apps/openagents.com/workers/api/src/khala-chat-program.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-program.ts
@@ -41,8 +41,8 @@ import {
   type InferenceRequest,
 } from './inference/provider-adapter'
 import {
-  type KhalaChatPylonContext,
-  renderKhalaChatPylonContextForPrompt,
+  type KhalaChatPylonContextEnvelope,
+  renderKhalaChatPylonContextEnvelopeForPrompt,
 } from './khala-chat-pylon-context'
 
 // The live public Khala model for the generic chat demo (same model id the
@@ -92,7 +92,7 @@ export const KHALA_CHAT_INSTRUCTION = [
 ].join(' ')
 
 export type KhalaChatRequestContext = Readonly<{
-  pylonContext?: KhalaChatPylonContext | undefined
+  pylonContext?: KhalaChatPylonContextEnvelope | undefined
 }>
 
 const khalaChatContextInstruction = (
@@ -100,7 +100,7 @@ const khalaChatContextInstruction = (
 ): string =>
   context?.pylonContext === undefined
     ? ''
-    : `\n\n${renderKhalaChatPylonContextForPrompt(context.pylonContext)}`
+    : `\n\n${renderKhalaChatPylonContextEnvelopeForPrompt(context.pylonContext)}`
 
 // STREAMING INFERENCE SEAM ------------------------------------------------
 

--- a/apps/openagents.com/workers/api/src/khala-chat-pylon-context.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-pylon-context.ts
@@ -5,6 +5,10 @@ import {
   publicPylonStatsFromRegistrations,
 } from './public-pylon-stats'
 import type {
+  AgentRegistrationStore,
+  LinkedAgentOwnerRecord,
+} from './agent-registration'
+import type {
   PylonApiRegistrationRecord,
   PylonApiStore,
   PylonCodingServiceCapacityProjection,
@@ -54,15 +58,51 @@ export type KhalaChatPylonContext = Readonly<{
   }>
 }>
 
+export type KhalaChatLinkedAgentSummary = Readonly<{
+  agentUserId: string
+  displayName: string
+  linkKind: LinkedAgentOwnerRecord['linkKind']
+}>
+
+export type KhalaChatAccountPylonContext = Readonly<{
+  asOfIso: string
+  caveatRefs: ReadonlyArray<string>
+  linkedAgents: ReadonlyArray<KhalaChatLinkedAgentSummary>
+  pylons: ReadonlyArray<KhalaChatPylonSummary>
+  sourceRefs: ReadonlyArray<string>
+  totals: Readonly<{
+    assignmentReadyNow: number
+    linkedAgents: number
+    linkedPylons: number
+    onlineNow: number
+    walletReadyNow: number
+  }>
+}>
+
+export type KhalaChatPylonContextEnvelope = Readonly<{
+  accountContext?: KhalaChatAccountPylonContext | undefined
+  mode: 'anonymous_public' | 'authenticated_account'
+  publicContext?: KhalaChatPylonContext | undefined
+}>
+
 export type KhalaChatPylonContextStore = Pick<
   PylonApiStore,
   'listRegistrations'
 >
 
+export type KhalaChatAccountPylonContextStores = Readonly<{
+  agentStore: Pick<AgentRegistrationStore, 'listLinkedAgentsForOpenAuthUser'>
+  pylonStore: Pick<
+    PylonApiStore,
+    'listRegistrations' | 'listRegistrationsForOwnerAgentUserIds'
+  >
+}>
+
 export type KhalaChatPylonQuestionKind =
   | 'capabilities'
   | 'interaction'
   | 'list_connected'
+  | 'ownership'
   | 'register'
 
 export class KhalaChatPylonContextError extends S.TaggedErrorClass<KhalaChatPylonContextError>()(
@@ -196,6 +236,104 @@ export const loadKhalaChatPylonContext = (
     }),
   )
 
+export const loadKhalaChatAccountPylonContext = (
+  stores: KhalaChatAccountPylonContextStores,
+  openauthUserId: string,
+  nowUnixMs: number = currentEpochMillis(),
+): Effect.Effect<KhalaChatAccountPylonContext, KhalaChatPylonContextError> =>
+  Effect.gen(function* () {
+    const linkedAgents = yield* Effect.tryPromise({
+      catch: error =>
+        new KhalaChatPylonContextError({
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      try: () =>
+        stores.agentStore.listLinkedAgentsForOpenAuthUser === undefined
+          ? Promise.resolve([])
+          : stores.agentStore.listLinkedAgentsForOpenAuthUser(
+              openauthUserId,
+              100,
+            ),
+    })
+
+    const ownerIds = [...new Set(linkedAgents.map(agent => agent.agentUserId))]
+    const registrations = yield* Effect.tryPromise({
+      catch: error =>
+        new KhalaChatPylonContextError({
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      try: () =>
+        stores.pylonStore.listRegistrationsForOwnerAgentUserIds === undefined
+          ? stores.pylonStore
+              .listRegistrations(200)
+              .then(rows =>
+                rows.filter(registration =>
+                  ownerIds.includes(registration.ownerAgentUserId),
+                ),
+              )
+          : stores.pylonStore.listRegistrationsForOwnerAgentUserIds(
+              ownerIds,
+              200,
+            ),
+    })
+
+    const stats = publicPylonStatsFromRegistrations(registrations, nowUnixMs)
+    const recentByPylonRef = new Map(
+      stats.recentPylons
+        .filter(pylon => pylon.pylonRef !== null)
+        .map(pylon => [
+          pylon.pylonRef!,
+          {
+            assignmentReadyNow: pylon.assignmentReadyNow,
+            onlineNow: pylon.onlineNow,
+            walletReadyNow: pylon.walletReadyNow,
+          },
+        ]),
+    )
+    const pylons = registrations
+      .map(registration =>
+        summarizeRegistration(registration, nowUnixMs, recentByPylonRef),
+      )
+      .sort((left, right) => {
+        if (left.onlineNow !== right.onlineNow) {
+          return left.onlineNow ? -1 : 1
+        }
+        return (
+          (left.latestHeartbeatAgeSeconds ?? Number.MAX_SAFE_INTEGER) -
+          (right.latestHeartbeatAgeSeconds ?? Number.MAX_SAFE_INTEGER)
+        )
+      })
+      .slice(0, MAX_CONTEXT_PYLONS)
+
+    return {
+      asOfIso: epochMillisToIsoTimestamp(nowUnixMs),
+      caveatRefs: [
+        'caveat.account.pylon_chat_reads_authenticated_owner_links_only',
+        'caveat.account.pylon_context_excludes_tokens_wallets_raw_traces',
+        'caveat.public.assignment_ready_is_not_payout_evidence',
+      ],
+      linkedAgents: linkedAgents.slice(0, 20).map(agent => ({
+        agentUserId: agent.agentUserId,
+        displayName: agent.displayName,
+        linkKind: agent.linkKind,
+      })),
+      pylons,
+      sourceRefs: [
+        'route:/api/khala/chat',
+        'route:/api/account/pylons',
+        'openagents.account.pylon_openauth_links',
+      ],
+      totals: {
+        assignmentReadyNow: pylons.filter(pylon => pylon.assignmentReadyNow)
+          .length,
+        linkedAgents: linkedAgents.length,
+        linkedPylons: registrations.length,
+        onlineNow: pylons.filter(pylon => pylon.onlineNow).length,
+        walletReadyNow: pylons.filter(pylon => pylon.walletReadyNow).length,
+      },
+    }
+  })
+
 const ageLabel = (seconds: number | null): string =>
   seconds === null
     ? 'no heartbeat'
@@ -251,6 +389,16 @@ const contextHeader = (context: KhalaChatPylonContext): string =>
     `- ${context.totals.assignmentReadyNow} assignment-ready now`,
   ].join('\n')
 
+const accountContextHeader = (context: KhalaChatAccountPylonContext): string =>
+  [
+    `Authenticated OpenAgents account Pylon context as of ${context.asOfIso}:`,
+    `- ${context.totals.linkedAgents} linked agent${context.totals.linkedAgents === 1 ? '' : 's'}`,
+    `- ${context.totals.linkedPylons} linked Pylon${context.totals.linkedPylons === 1 ? '' : 's'}`,
+    `- ${context.totals.onlineNow} of your linked Pylons online now`,
+    `- ${context.totals.walletReadyNow} wallet-ready now`,
+    `- ${context.totals.assignmentReadyNow} assignment-ready now`,
+  ].join('\n')
+
 export const renderKhalaChatPylonContextForPrompt = (
   context: KhalaChatPylonContext,
 ): string =>
@@ -265,6 +413,39 @@ export const renderKhalaChatPylonContextForPrompt = (
     `Source refs: ${context.sourceRefs.join(', ')}`,
     `Caveat refs: ${context.caveatRefs.join(', ')}`,
   ].join('\n')
+
+export const renderKhalaChatPylonContextEnvelopeForPrompt = (
+  envelope: KhalaChatPylonContextEnvelope,
+): string =>
+  [
+    ...(envelope.publicContext === undefined
+      ? []
+      : [renderKhalaChatPylonContextForPrompt(envelope.publicContext)]),
+    ...(envelope.accountContext === undefined
+      ? []
+      : [
+          [
+            'The request has a verified OpenAuth browser session. Use the following account-owned Pylon context only for this authenticated request.',
+            'Do not expose bearer tokens, token prefixes, wallet material, raw prompts, private traces, local paths, or another account owner link.',
+            accountContextHeader(envelope.accountContext),
+            'Linked agents:',
+            ...(envelope.accountContext.linkedAgents.length === 0
+              ? ['- none linked to this OpenAuth account']
+              : envelope.accountContext.linkedAgents.map(
+                  agent =>
+                    `- ${agent.agentUserId} (${agent.displayName}); link ${agent.linkKind}`,
+                )),
+            'Your linked Pylon rows:',
+            ...(envelope.accountContext.pylons.length === 0
+              ? ['- none linked to this OpenAuth account']
+              : envelope.accountContext.pylons
+                  .slice(0, MAX_CONTEXT_PYLONS)
+                  .map(pylonStatusLine)),
+            `Source refs: ${envelope.accountContext.sourceRefs.join(', ')}`,
+            `Caveat refs: ${envelope.accountContext.caveatRefs.join(', ')}`,
+          ].join('\n'),
+        ]),
+  ].join('\n\n')
 
 const normalizeQuestion = (input: string): string =>
   input
@@ -281,6 +462,15 @@ export const classifyKhalaChatPylonQuestion = (
   const question = normalizeQuestion(content)
   if (!/\bpylons?\b/.test(question)) {
     return null
+  }
+
+  if (
+    /\b(my|mine|owned|owner|account|linked)\b/.test(question) ||
+    /\b(use my|show my|which pylons are mine|are those mine|are these mine)\b/.test(
+      question,
+    )
+  ) {
+    return 'ownership'
   }
 
   if (
@@ -315,20 +505,21 @@ export const classifyKhalaChatPylonQuestion = (
 }
 
 const connectedPylonAnswer = (
-  context: KhalaChatPylonContext | undefined,
+  context: KhalaChatPylonContextEnvelope | undefined,
 ): string => {
-  if (context === undefined) {
+  if (context?.publicContext === undefined) {
     return [
       'I cannot read the live Pylon registry from this chat turn right now.',
       'The public read surfaces are GET /api/pylons and GET /api/public/pylon-stats.',
     ].join('\n\n')
   }
 
-  const connected = context.pylons.filter(pylon => pylon.onlineNow)
-  const rows = connected.length === 0 ? context.pylons : connected
+  const publicContext = context.publicContext
+  const connected = publicContext.pylons.filter(pylon => pylon.onlineNow)
+  const rows = connected.length === 0 ? publicContext.pylons : connected
 
   return [
-    contextHeader(context),
+    contextHeader(publicContext),
     '',
     connected.length === 0
       ? 'No Pylons are online in the public stats window right now. The most recent registry rows I can see are:'
@@ -342,22 +533,24 @@ const connectedPylonAnswer = (
 }
 
 const capabilityAnswer = (
-  context: KhalaChatPylonContext | undefined,
+  context: KhalaChatPylonContextEnvelope | undefined,
 ): string => {
-  if (context === undefined) {
+  if (context?.publicContext === undefined) {
     return [
       'I cannot read live Pylon capabilities from this chat turn right now.',
       'Use GET /api/pylons to inspect public capabilityRefs, codingCapacity, NIP-90 lane refs, and heartbeat fields.',
     ].join('\n\n')
   }
 
+  const publicContext = context.publicContext
+
   return [
-    contextHeader(context),
+    contextHeader(publicContext),
     '',
     'Advertised Pylon capabilities:',
-    ...(context.pylons.length === 0
+    ...(publicContext.pylons.length === 0
       ? ['- none returned by the registry projection']
-      : context.pylons
+      : publicContext.pylons
           .slice(0, MAX_ANSWER_PYLONS)
           .map(pylon =>
             [
@@ -406,9 +599,51 @@ const interactionAnswer = (): string =>
     'This public chat route does not dispatch paid work, approve payout targets, spend bitcoin, settle providers, or mutate Pylon state by itself.',
   ].join('\n')
 
+const ownershipAnswer = (
+  context: KhalaChatPylonContextEnvelope | undefined,
+): string => {
+  if (context?.accountContext === undefined) {
+    if (context?.mode === 'authenticated_account') {
+      return [
+        'Your browser session is signed in, but I cannot read your account Pylon links for this chat turn right now.',
+        'I will not infer ownership from the public registry. Try again, or use the account Pylon page/API for the owner-scoped view.',
+      ].join('\n\n')
+    }
+
+    return [
+      'I cannot verify Pylon ownership from the public registry alone.',
+      'Sign in at /login?returnTo=/chat, then link an OpenAgents agent token through the account Pylon flow so I can answer from your OpenAuth-owned Pylons.',
+    ].join('\n\n')
+  }
+
+  const accountContext = context.accountContext
+  if (accountContext.totals.linkedPylons === 0) {
+    return [
+      accountContextHeader(accountContext),
+      '',
+      'No Pylons are linked to your OpenAuth account yet.',
+      'Link an OpenAgents agent token in the account Pylon flow, then heartbeat/register the Pylon from that linked agent.',
+    ].join('\n')
+  }
+
+  const onlineRows = accountContext.pylons.filter(pylon => pylon.onlineNow)
+  const rows = onlineRows.length === 0 ? accountContext.pylons : onlineRows
+
+  return [
+    accountContextHeader(accountContext),
+    '',
+    'Your linked Pylons:',
+    ...(rows.length === 0
+      ? ['- none']
+      : rows.slice(0, MAX_ANSWER_PYLONS).map(pylonStatusLine)),
+    '',
+    'This is owner-scoped to your verified OpenAuth session. Public registry rows may include other Pylons, but I am not treating those as yours.',
+  ].join('\n')
+}
+
 export const answerKhalaChatPylonQuestion = (
   latestUserContent: string,
-  context: KhalaChatPylonContext | undefined,
+  context: KhalaChatPylonContextEnvelope | undefined,
 ): string | null => {
   const kind = classifyKhalaChatPylonQuestion(latestUserContent)
   switch (kind) {
@@ -418,6 +653,8 @@ export const answerKhalaChatPylonQuestion = (
       return interactionAnswer()
     case 'list_connected':
       return connectedPylonAnswer(context)
+    case 'ownership':
+      return ownershipAnswer(context)
     case 'register':
       return registerAnswer()
     case null:

--- a/apps/openagents.com/workers/api/src/khala-chat-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-routes.test.ts
@@ -9,7 +9,11 @@ import {
   type KhalaChatStreamClient,
   type KhalaChatStreamSource,
 } from './khala-chat-program'
-import type { KhalaChatPylonContext } from './khala-chat-pylon-context'
+import type {
+  KhalaChatAccountPylonContext,
+  KhalaChatPylonContext,
+  KhalaChatPylonContextEnvelope,
+} from './khala-chat-pylon-context'
 import { makeKhalaChatRoutes } from './khala-chat-routes'
 
 const run = (
@@ -139,6 +143,76 @@ const stubPylonContext = (): KhalaChatPylonContext => ({
     seen24h: 1,
     statsRegisteredTotal: 1,
     walletReadyNow: 1,
+  },
+})
+
+const stubPylonEnvelope = (): KhalaChatPylonContextEnvelope => ({
+  mode: 'anonymous_public',
+  publicContext: stubPylonContext(),
+})
+
+const firstStubPylon = () => {
+  const first = stubPylonContext().pylons[0]
+  if (first === undefined) {
+    throw new Error('missing stub Pylon')
+  }
+  return first
+}
+
+const stubAccountPylonContext = (): KhalaChatAccountPylonContext => ({
+  asOfIso: '2026-06-28T00:00:00.000Z',
+  caveatRefs: [
+    'caveat.account.pylon_chat_reads_authenticated_owner_links_only',
+  ],
+  linkedAgents: [
+    {
+      agentUserId: 'agent-owner-one',
+      displayName: 'Owner Codex Agent',
+      linkKind: 'credential_anchor',
+    },
+  ],
+  pylons: [
+    {
+      ...firstStubPylon(),
+      displayName: 'Owner Codex Pylon',
+      pylonRef: 'pylon.owner.codex',
+    },
+  ],
+  sourceRefs: [
+    'route:/api/khala/chat',
+    'route:/api/account/pylons',
+    'openagents.account.pylon_openauth_links',
+  ],
+  totals: {
+    assignmentReadyNow: 1,
+    linkedAgents: 1,
+    linkedPylons: 1,
+    onlineNow: 1,
+    walletReadyNow: 1,
+  },
+})
+
+const stubAuthenticatedPylonEnvelope = (): KhalaChatPylonContextEnvelope => ({
+  accountContext: stubAccountPylonContext(),
+  mode: 'authenticated_account',
+  publicContext: {
+    ...stubPylonContext(),
+    pylons: [
+      ...stubPylonContext().pylons,
+      {
+        ...firstStubPylon(),
+        displayName: 'Foreign Public Pylon',
+        pylonRef: 'pylon.foreign.public',
+      },
+    ],
+    totals: {
+      ...stubPylonContext().totals,
+      activeRegistrations: 2,
+      onlineNow: 2,
+      registryRowsRead: 2,
+      seen24h: 2,
+      statsRegisteredTotal: 2,
+    },
   },
 })
 
@@ -392,7 +466,7 @@ describe('khala chat route', () => {
   test('answers connected Pylon questions from public registry context without opening a provider stream', async () => {
     let openedProvider = false
     const routes = makeKhalaChatRoutes({
-      loadPylonContext: () => Effect.succeed(stubPylonContext()),
+      loadPylonContext: () => Effect.succeed(stubPylonEnvelope()),
       makeStreamClient: () => () => {
         openedProvider = true
         return Effect.fail(
@@ -489,7 +563,7 @@ describe('khala chat route', () => {
       | { messages: ReadonlyArray<{ role: string; content: string }> }
       | undefined
     const routes = makeKhalaChatRoutes({
-      loadPylonContext: () => Effect.succeed(stubPylonContext()),
+      loadPylonContext: () => Effect.succeed(stubPylonEnvelope()),
       makeStreamClient: () =>
         capturingStream(['ok'], request => {
           captured = request
@@ -516,6 +590,102 @@ describe('khala chat route', () => {
       'OpenAgents Pylon registry as of 2026-06-28T00:00:00.000Z',
     )
     expect(system).toContain('pylon.studio.codex')
+  })
+
+  test('does not infer ownership for anonymous Pylon ownership questions', async () => {
+    let openedProvider = false
+    const routes = makeKhalaChatRoutes({
+      loadPylonContext: () => Effect.succeed(stubPylonEnvelope()),
+      makeStreamClient: () => () => {
+        openedProvider = true
+        return Effect.fail(
+          new OnboardingInferenceError({ reason: 'provider should not open' }),
+        )
+      },
+      rateLimit: allowAll,
+    })
+
+    const response = await run(
+      routes.routeKhalaChatRequest(
+        chatRequest({
+          messages: [{ role: 'user', content: 'are those pylons mine?' }],
+        }),
+        {},
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(openedProvider).toBe(false)
+    const text = await response.text()
+    expect(text).toContain('cannot verify Pylon ownership')
+    expect(text).toContain('/login?returnTo=/chat')
+    expect(text).not.toContain('Your linked Pylons')
+  })
+
+  test('answers authenticated ownership questions from account-owned Pylon context', async () => {
+    let openedProvider = false
+    const routes = makeKhalaChatRoutes({
+      loadPylonContext: () =>
+        Effect.succeed(stubAuthenticatedPylonEnvelope()),
+      makeStreamClient: () => () => {
+        openedProvider = true
+        return Effect.fail(
+          new OnboardingInferenceError({ reason: 'provider should not open' }),
+        )
+      },
+      rateLimit: allowAll,
+    })
+
+    const response = await run(
+      routes.routeKhalaChatRequest(
+        chatRequest({
+          messages: [{ role: 'user', content: 'which pylons are mine?' }],
+        }),
+        {},
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(openedProvider).toBe(false)
+    const text = await response.text()
+    expect(text).toContain('Authenticated OpenAgents account Pylon context')
+    expect(text).toContain('Your linked Pylons')
+    expect(text).toContain('pylon.owner.codex')
+    expect(text).not.toContain('pylon.foreign.public')
+    expect(text).not.toContain('oa_agent_')
+    expect(text).not.toContain('tokenPrefix')
+  })
+
+  test('passes authenticated Pylon context to generic inference without private credential leakage', async () => {
+    let captured:
+      | { messages: ReadonlyArray<{ role: string; content: string }> }
+      | undefined
+    const routes = makeKhalaChatRoutes({
+      loadPylonContext: () =>
+        Effect.succeed(stubAuthenticatedPylonEnvelope()),
+      makeStreamClient: () =>
+        capturingStream(['ok'], request => {
+          captured = request
+        }),
+      rateLimit: allowAll,
+    })
+
+    await run(
+      routes.routeKhalaChatRequest(
+        chatRequest({
+          messages: [{ role: 'user', content: 'summarize platform status' }],
+        }),
+        {},
+      ),
+    )
+
+    const system = captured?.messages[0]?.content ?? ''
+    expect(system).toContain('verified OpenAuth browser session')
+    expect(system).toContain('pylon.owner.codex')
+    expect(system).toContain('pylon.foreign.public')
+    expect(system).toContain('public registry projection')
+    expect(system).not.toContain('tokenPrefix')
+    expect(system).not.toContain('oa_agent_')
   })
 
   test('rejects a non-POST method', async () => {

--- a/apps/openagents.com/workers/api/src/khala-chat-routes.ts
+++ b/apps/openagents.com/workers/api/src/khala-chat-routes.ts
@@ -42,7 +42,7 @@ import type {
   KhalaChatStreamSource,
 } from './khala-chat-program'
 import {
-  type KhalaChatPylonContext,
+  type KhalaChatPylonContextEnvelope,
   answerKhalaChatPylonQuestion,
 } from './khala-chat-pylon-context'
 import { logWorkerRouteError } from './observability'
@@ -76,7 +76,11 @@ export type KhalaChatRouteDependencies = Readonly<{
   // a deterministic stub.
   makeStreamClient: (env: unknown) => KhalaChatStreamClient
   loadPylonContext?:
-    | ((env: unknown) => Effect.Effect<KhalaChatPylonContext, unknown>)
+    | ((input: {
+        ctx: ExecutionContext | undefined
+        env: unknown
+        request: Request
+      }) => Effect.Effect<KhalaChatPylonContextEnvelope, unknown>)
     | undefined
   // Overridable for tests; defaults to a per-IP token bucket. Returns false when
   // the caller is over budget.
@@ -257,14 +261,16 @@ const latestUserContent = (messages: ReadonlyArray<KhalaChatMessage>): string =>
 const loadPylonContext = (
   dependencies: KhalaChatRouteDependencies,
   env: unknown,
+  request: Request,
+  ctx: ExecutionContext | undefined,
   trace: string,
-): Effect.Effect<KhalaChatPylonContext | undefined> => {
+): Effect.Effect<KhalaChatPylonContextEnvelope | undefined> => {
   if (dependencies.loadPylonContext === undefined) {
-    return Effect.sync((): KhalaChatPylonContext | undefined => undefined)
+    return Effect.sync((): KhalaChatPylonContextEnvelope | undefined => undefined)
   }
 
   return dependencies
-    .loadPylonContext(env)
+    .loadPylonContext({ ctx, env, request })
     .pipe(
       Effect.catch(error =>
         Effect.sync(() =>
@@ -399,6 +405,7 @@ export const makeKhalaChatRoutes = (
   const streamResponse = (
     request: Request,
     env: unknown,
+    ctx: ExecutionContext | undefined,
   ): KhalaChatRouteEffect => {
     const requestTraceRef = traceRef()
     if (!rateLimit(request)) {
@@ -419,7 +426,13 @@ export const makeKhalaChatRoutes = (
           ? Effect.succeed(fastGreetingSource())
           : isKhalaArtanisPublicReadOnlyTurn(messages)
             ? Effect.succeed(artanisPublicReadOnlySource())
-          : loadPylonContext(dependencies, env, requestTraceRef).pipe(
+          : loadPylonContext(
+              dependencies,
+              env,
+              request,
+              ctx,
+              requestTraceRef,
+            ).pipe(
               Effect.flatMap(pylonContext => {
                 const pylonAnswer = answerKhalaChatPylonQuestion(
                   latestUserContent(messages),
@@ -477,6 +490,7 @@ export const makeKhalaChatRoutes = (
     routeKhalaChatRequest: (
       request: Request,
       env: unknown,
+      ctx?: ExecutionContext,
     ): KhalaChatRouteEffect | undefined => {
       const url = new URL(request.url)
       if (url.pathname !== '/api/khala/chat') {
@@ -485,7 +499,7 @@ export const makeKhalaChatRoutes = (
       if (request.method !== 'POST') {
         return Effect.succeed(methodNotAllowed(['POST']))
       }
-      return streamResponse(request, env)
+      return streamResponse(request, env, ctx)
     },
   }
 }


### PR DESCRIPTION
Addresses #6700.

### Changes
- Adds an authenticated Khala chat Pylon context envelope that distinguishes anonymous public context from authenticated account context.
- Loads linked agent and owned Pylon summaries for verified sessions while preserving anonymous fallback behavior when no valid session is present.
- Updates Khala chat prompt rendering and route tests for ownership-aware Pylon context.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).