### PR TITLE
feat(pylon): add operator provider account reset

### DIFF
--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1659,6 +1659,12 @@ const schemaComponents = (): JsonSchema => ({
   ProviderAccountPoolManualResetResponse: objectSummary(
     'Manual reset receipt with ok, providerAccountRef, and resetAt. It confirms only that the signed-in owners local cooldown/rate-limit marker was cleared; callers should re-read the pool projection for current eligibility.',
   ),
+  OperatorProviderAccountResetRequest: objectSummary(
+    'Admin-token-gated operator request to clear operational provider-account failure markers for one selected target user account by providerAccountRef. The target user selector is resolved server-side; the reset does not touch provider credentials, grants, leases, spend, or accounts outside the selected owner scope.',
+  ),
+  OperatorProviderAccountResetResponse: objectSummary(
+    'Operator reset receipt with ok, providerAccountRef, and resetAt. It confirms only that cooldown, recent failure, low-credit, and eligible connected-account health markers were cleared; callers should re-read the operator fleet dashboard for current eligibility.',
+  ),
   BuiltinComputeAgentGrantEnvelope: objectSummary(
     'Built-in hosted-Gemini grant result for the no-key built-in agent path. A granted response returns a short-lived redacted grant with provider secret refs, free-tier budget refs, expiry, and materialization instructions only; it never returns the hosted key, provider payloads, prompts, completions, or broad provider-account mutation authority. Not-configured and quota-exhausted states are explicit.',
   ),
@@ -11478,6 +11484,26 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Provider account manual reset receipt.',
           '#/components/schemas/ProviderAccountPoolManualResetResponse',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/operator/accounts/reset': {
+    post: operation({
+      operationId: 'resetOperatorProviderAccount',
+      summary: 'Operator reset provider account failure markers',
+      description:
+        'Admin-bearer operator action that selects a target user with the standard operator target selector, clears the selected provider accounts cooldown, recent failure, low-credit, and eligible connected-account health markers by providerAccountRef, and returns a reset receipt. It does not expose or mutate provider credentials, active leases, spend, or accounts outside the selected target user scope.',
+      tags: ['Provider Accounts'],
+      security: adminBearer,
+      requestBody: jsonContent(
+        '#/components/schemas/OperatorProviderAccountResetRequest',
+      ),
+      responses: {
+        '200': okJson(
+          'Operator provider account reset receipt.',
+          '#/components/schemas/OperatorProviderAccountResetResponse',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/operator-provider-account-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-provider-account-routes.test.ts
@@ -323,9 +323,9 @@ class FakeD1Statement {
     })
 
   run = () => {
-    this.database.run(this.query, this.values)
+    const changes = this.database.run(this.query, this.values)
 
-    return Promise.resolve({ success: true })
+    return Promise.resolve({ meta: { changes }, success: true })
   }
 }
 
@@ -611,7 +611,45 @@ class FakeProviderAccountD1 {
     return []
   }
 
-  run = (query: string, values: Array<unknown>) => {
+  run = (query: string, values: Array<unknown>): number => {
+    let changes = 0
+
+    if (
+      query.includes('UPDATE provider_accounts') &&
+      query.includes('cooldown_until = NULL') &&
+      query.includes('recent_failure_class = NULL')
+    ) {
+      const userId = values[2]
+      const providerAccountRef = values[3]
+      this.accounts = this.accounts.map(account => {
+        if (
+          account.user_id !== userId ||
+          account.provider_account_ref !== providerAccountRef ||
+          account.deleted_at !== null
+        ) {
+          return account
+        }
+
+        changes += 1
+
+        return {
+          ...account,
+          cooldown_until: null,
+          health:
+            account.status === 'connected' &&
+            (account.reauth_required_reason === undefined ||
+              account.reauth_required_reason === null)
+              ? 'healthy'
+              : account.health,
+          low_credit_flag: 0,
+          recent_failure_class: null,
+          refill_note: null,
+        }
+      })
+
+      return changes
+    }
+
     if (
       query.includes('UPDATE provider_account_leases') &&
       query.includes("SET status = 'failed'")
@@ -709,7 +747,10 @@ class FakeProviderAccountD1 {
         run_id: runId as string | null,
         attempt_number: attemptNumber as number,
       })
+      changes += 1
     }
+
+    return changes
   }
 
   private activeLeaseCount = (accountId: string, now: string): number =>
@@ -1874,6 +1915,140 @@ describe('operator provider account routes', () => {
     expect(text).not.toContain('access-token')
     expect(text).not.toContain('auth.json')
     expect(text).not.toContain('grant')
+  })
+
+  test('operator reset clears account cooldown and rate-limit markers without secrets', async () => {
+    const repository = new FakeProviderAccountRepository()
+    const database = new FakeProviderAccountD1()
+    database.accounts.push(
+      fakeAccountRow(
+        'provider_account_rate_limited',
+        'provider-account_ref_rate_limited',
+        {
+          account_label: 'rate limited',
+          cooldown_until: '2099-01-01T00:00:00.000Z',
+          health: 'unhealthy',
+          low_credit_flag: 1,
+          recent_failure_class: 'rate_limited',
+          refill_note: 'Refill before reuse.',
+        },
+      ),
+    )
+
+    const response = await run(
+      repository,
+      '/api/operator/accounts/reset',
+      {
+        body: JSON.stringify({
+          email: 'chris@openagents.com',
+          providerAccountRef: 'provider-account_ref_rate_limited',
+        }),
+        method: 'POST',
+      },
+      undefined,
+      database.asD1(),
+    )
+    const text = await response.text()
+    const body = JSON.parse(text)
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      providerAccountRef: 'provider-account_ref_rate_limited',
+      resetAt: expect.any(String),
+    })
+    expect(database.accounts[0]).toMatchObject({
+      cooldown_until: null,
+      health: 'healthy',
+      low_credit_flag: 0,
+      recent_failure_class: null,
+      refill_note: null,
+    })
+    expect(text).not.toContain('codex-auth://')
+    expect(text).not.toContain('access-token')
+    expect(text).not.toContain('grant')
+  })
+
+  test('operator reset is admin-gated and scoped to the selected target user', async () => {
+    const repository = new FakeProviderAccountRepository()
+    const database = new FakeProviderAccountD1()
+    database.accounts.push(
+      fakeAccountRow('provider_account_other', 'provider-account_ref_other', {
+        user_id: 'user_other',
+        cooldown_until: '2099-01-01T00:00:00.000Z',
+        health: 'unhealthy',
+        recent_failure_class: 'rate_limited',
+      }),
+    )
+
+    const unauthorized = await run(
+      repository,
+      '/api/operator/accounts/reset',
+      {
+        body: JSON.stringify({
+          email: 'chris@openagents.com',
+          providerAccountRef: 'provider-account_ref_other',
+        }),
+        method: 'POST',
+      },
+      { authorized: false },
+      database.asD1(),
+    )
+
+    expect(unauthorized.status).toBe(401)
+
+    const crossOwner = await run(
+      repository,
+      '/api/operator/accounts/reset',
+      {
+        body: JSON.stringify({
+          email: 'chris@openagents.com',
+          providerAccountRef: 'provider-account_ref_other',
+        }),
+        method: 'POST',
+      },
+      undefined,
+      database.asD1(),
+    )
+
+    expect(crossOwner.status).toBe(404)
+    expect(database.accounts[0]).toMatchObject({
+      cooldown_until: '2099-01-01T00:00:00.000Z',
+      health: 'unhealthy',
+      recent_failure_class: 'rate_limited',
+    })
+  })
+
+  test('operator reset rejects non-POST methods and missing providerAccountRef', async () => {
+    const repository = new FakeProviderAccountRepository()
+    const database = new FakeProviderAccountD1()
+
+    const wrongMethod = await run(
+      repository,
+      '/api/operator/accounts/reset',
+      { method: 'GET' },
+      undefined,
+      database.asD1(),
+    )
+
+    expect(wrongMethod.status).toBe(405)
+
+    const missingRef = await run(
+      repository,
+      '/api/operator/accounts/reset',
+      {
+        body: JSON.stringify({ email: 'chris@openagents.com' }),
+        method: 'POST',
+      },
+      undefined,
+      database.asD1(),
+    )
+
+    expect(missingRef.status).toBe(400)
+    await expect(missingRef.json()).resolves.toEqual({
+      error: 'bad_request',
+      reason: 'providerAccountRef is required',
+    })
   })
 
   test('lease acquisition skips accounts with stale reconnect markers', async () => {

--- a/apps/openagents.com/workers/api/src/operator-provider-account-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-provider-account-routes.ts
@@ -314,6 +314,12 @@ type ProviderAccountFleetDashboardResponse = Readonly<{
   }>
 }>
 
+type OperatorProviderAccountResetResponse = Readonly<{
+  ok: true
+  providerAccountRef: string
+  resetAt: string
+}>
+
 type OperatorDeviceLoginStartResponse = Readonly<{
   status: 'pending'
   targetUser: OperatorDeviceLoginTargetUser
@@ -1439,6 +1445,39 @@ const providerAccountFleetDashboard = async (
         .length,
     },
   }
+}
+
+const resetOperatorProviderAccount = async (
+  db: D1Database,
+  input: Readonly<{
+    providerAccountRef: string
+    resetAt: string
+    userId: string
+  }>,
+): Promise<boolean> => {
+  const result = await db
+    .prepare(
+      `UPDATE provider_accounts
+          SET health = CASE
+                WHEN status = 'connected'
+                 AND reauth_required_reason IS NULL
+                THEN 'healthy'
+                ELSE health
+              END,
+              low_credit_flag = 0,
+              cooldown_until = NULL,
+              recent_failure_class = NULL,
+              refill_note = NULL,
+              last_status_at = ?,
+              updated_at = ?
+        WHERE user_id = ?
+          AND provider_account_ref = ?
+          AND deleted_at IS NULL`,
+    )
+    .bind(input.resetAt, input.resetAt, input.userId, input.providerAccountRef)
+    .run()
+
+  return (result.meta?.changes ?? 0) > 0
 }
 
 const touchProviderAccountLease = async (
@@ -2765,12 +2804,68 @@ export const makeOperatorProviderAccountRoutes = <
       : noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
   }
 
+  const resetAccount = async (
+    request: Request,
+    env: Bindings,
+  ): Promise<HttpResponse> => {
+    const rejected = await rejectUnlessOperatorAdminRoute(request, env, 'POST')
+
+    if (rejected !== undefined) {
+      return rejected
+    }
+
+    const body = await readJsonObject(request).catch(
+      (): Record<string, unknown> => ({}),
+    )
+    const targetUser = await dependencies.readSelectedOperatorTargetUser(
+      openAgentsDatabase(env),
+      body,
+    )
+
+    if (targetUser === undefined) {
+      return noStoreJsonResponse(
+        { error: 'target_user_not_found' },
+        { status: 404 },
+      )
+    }
+
+    const providerAccountRef = optionalString(body.providerAccountRef)
+
+    if (providerAccountRef === undefined) {
+      return noStoreJsonResponse(
+        { error: 'bad_request', reason: 'providerAccountRef is required' },
+        { status: 400 },
+      )
+    }
+
+    const resetAt = currentIsoTimestamp()
+    const reset = await resetOperatorProviderAccount(openAgentsDatabase(env), {
+      providerAccountRef,
+      resetAt,
+      userId: targetUser.userId,
+    })
+
+    if (!reset) {
+      return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
+    }
+
+    return noStoreJsonResponse({
+      ok: true,
+      providerAccountRef,
+      resetAt,
+    } satisfies OperatorProviderAccountResetResponse)
+  }
+
   return {
     routeOperatorProviderAccountRequest: (
       request: Request,
       env: Bindings,
     ): Promise<HttpResponse> | undefined => {
       const url = new URL(request.url)
+
+      if (url.pathname === '/api/operator/accounts/reset') {
+        return resetAccount(request, env)
+      }
 
       if (
         url.pathname ===


### PR DESCRIPTION
Addresses #6662.

### Changes
- Added the admin-bearer `POST /api/operator/accounts/reset` route for resetting selected provider account failure markers within the resolved operator target user scope.
- Documented the new request and response schemas in the OpenAPI surface.
- Expanded operator provider account route tests for admin gating, target-user scoping, reset behavior, not-found behavior, and secret-safe responses.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).