### PR TITLE
feat(pylon): track manual resets in quota status

### DIFF
--- a/apps/pylon/src/account-quota-ledger.ts
+++ b/apps/pylon/src/account-quota-ledger.ts
@@ -11,6 +11,7 @@ export type QuotaRecord = {
   observedAt: string
   retryAtIso: string | null
   sourceDigestRef: string
+  manualResetsRemaining: number | null
 }
 
 export type ManualQuotaResetRecord = {
@@ -61,12 +62,19 @@ function quotaRecordFrom(value: unknown): QuotaRecord | null {
   if (typeof record.observedAt !== "string") return null
   if (record.retryAtIso !== null && typeof record.retryAtIso !== "string") return null
   if (typeof record.sourceDigestRef !== "string") return null
+  const manualResetsRemaining = record.manualResetsRemaining === undefined || record.manualResetsRemaining === null
+    ? null
+    : nonNegativeInteger(record.manualResetsRemaining)
+  if (record.manualResetsRemaining !== undefined && record.manualResetsRemaining !== null && manualResetsRemaining === null) {
+    return null
+  }
   return {
     accountRefHash: record.accountRefHash,
     provider: record.provider,
     observedAt: record.observedAt,
     retryAtIso: record.retryAtIso,
     sourceDigestRef: record.sourceDigestRef,
+    manualResetsRemaining,
   }
 }
 
@@ -107,15 +115,26 @@ export async function recordQuotaBlock(
     provider: string
     retryAtIso: string | null
     sourceDigestRef: string
+    manualResetsRemaining?: number | null
     now?: Date
   },
 ): Promise<void> {
+  const resetRecord = input.manualResetsRemaining === undefined
+    ? await loadManualQuotaResetRecord(summary, {
+        accountRefHash: input.accountRefHash,
+        provider: input.provider,
+      })
+    : null
+  const explicitManualResetsRemaining = input.manualResetsRemaining === undefined || input.manualResetsRemaining === null
+    ? null
+    : nonNegativeInteger(input.manualResetsRemaining)
   const record: QuotaRecord = {
     accountRefHash: input.accountRefHash,
     provider: publicProviderRef(input.provider),
     observedAt: (input.now ?? new Date()).toISOString(),
     retryAtIso: input.retryAtIso,
     sourceDigestRef: input.sourceDigestRef,
+    manualResetsRemaining: explicitManualResetsRemaining ?? resetRecord?.manualResetsRemaining ?? null,
   }
   await mkdir(quotaDirectory(summary), { recursive: true })
   await writeFile(

--- a/apps/pylon/src/account-status.test.ts
+++ b/apps/pylon/src/account-status.test.ts
@@ -119,6 +119,7 @@ describe("#6637 account status observability", () => {
         state: "limited",
         cooldownExpiresAt: "2026-06-28T22:00:00.000Z",
         cooldownSecondsRemaining: 900,
+        manualResetsRemaining: 3,
       })
       expect(status.accounts[0]?.capacity.hourly?.remainingPercent).toBe(75)
       expect(status.accounts[0]?.capacity.weekly?.remainingPercent).toBe(50)

--- a/apps/pylon/src/account-usage.ts
+++ b/apps/pylon/src/account-usage.ts
@@ -150,6 +150,7 @@ export type PylonAccountsStatusProjection = {
       cooldownExpiresAt: string | null
       cooldownSecondsRemaining: number | null
       sourceDigestRef: string | null
+      manualResetsRemaining: number
     }
     capacity: {
       hourly: PylonAccountWindowStatus | null
@@ -1117,6 +1118,7 @@ export async function collectPylonAccountsStatus(
       cooldownExpiresAt: quotaCooldownExpiresAt(quotaRecord),
       cooldownSecondsRemaining: quotaCooldownSecondsRemaining(quotaRecord, now),
       sourceDigestRef: quotaRecord?.sourceDigestRef ?? null,
+      manualResetsRemaining: resetRecord.manualResetsRemaining,
     }
     const manualReset = {
       performed: resetPerformed,

--- a/apps/pylon/tests/account-quota-ledger.test.ts
+++ b/apps/pylon/tests/account-quota-ledger.test.ts
@@ -53,6 +53,7 @@ describe("account quota ledger", () => {
         observedAt: now.toISOString(),
         retryAtIso: retryAt.toISOString(),
         sourceDigestRef: "digest.pylon.quota.source.test",
+        manualResetsRemaining: 3,
       })
     })
   })


### PR DESCRIPTION
Addresses #6661.

### Changes
- Added `manualResetsRemaining` to quota ledger records, including validation and persisted quota block output.
- Carried manual reset counts into account status projections.
- Updated quota ledger and account status tests to assert the new field.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).