### PR TITLE
test(pylon): cover rolling-window account usage

### DIFF
--- a/apps/pylon/src/account-status.ts
+++ b/apps/pylon/src/account-status.ts
@@ -9,6 +9,7 @@ import {
   type QuotaRecord,
 } from "./account-quota-ledger.js"
 import {
+  countAccountRollingWindowLocalSessionTokens,
   loadAccountUsageStore,
   type PylonAccountUsageStoreEntry,
   type PylonProviderRateLimitSnapshot,
@@ -79,11 +80,12 @@ function usageFor(
   entry: PylonAccountUsageStoreEntry | undefined,
   kind: "hourly" | "weekly",
   cap: number | null,
+  now: Date,
 ): number | null {
   const snapshots = entry?.providerTruth?.snapshots ?? []
   const fromProvider = snapshotWindowUsage(snapshots, kind, cap)
   if (fromProvider !== null) return fromProvider
-  if (kind === "hourly") return entry?.localSessionTruth?.usage.totalTokens ?? null
+  if (kind === "hourly") return countAccountRollingWindowLocalSessionTokens(entry, { now, windowMinutes: 60 })
   return null
 }
 
@@ -106,9 +108,9 @@ export async function collectPylonOperatorAccountStatus(
       isRateLimited: !isAccountAvailable(quotaRecord, now),
       cooldownExpiresAt: cooldownExpiresAt(quotaRecord, now),
       hourlyCap: account.hourlyCap,
-      hourlyUsage: usageFor(usageEntry, "hourly", account.hourlyCap),
+      hourlyUsage: usageFor(usageEntry, "hourly", account.hourlyCap, now),
       weeklyCap: account.weeklyCap,
-      weeklyUsage: usageFor(usageEntry, "weekly", account.weeklyCap),
+      weeklyUsage: usageFor(usageEntry, "weekly", account.weeklyCap, now),
       manualResetsRemaining: account.manualResetsRemaining,
     })
   }

--- a/apps/pylon/src/account-usage.ts
+++ b/apps/pylon/src/account-usage.ts
@@ -84,7 +84,13 @@ export type PylonAccountUsageStoreEntry = {
     observedAt: string
     usage: PylonLocalSessionUsageSnapshot
   } | null
+  localSessionUsageHistory?: PylonLocalSessionUsageObservation[]
   updatedAt: string
+}
+
+export type PylonLocalSessionUsageObservation = {
+  observedAt: string
+  usage: PylonLocalSessionUsageSnapshot
 }
 
 export type PylonAccountUsageStore = {
@@ -265,6 +271,7 @@ type AccountUsageObservation = {
 }
 
 const ACCOUNT_USAGE_STALE_SECONDS = 15 * 60
+const LOCAL_SESSION_USAGE_HISTORY_LIMIT = 256
 const costStatement =
   "pylon accounts usage --refresh runs one minimal bounded provider inference per selected account and may consume paid provider tokens."
 
@@ -483,6 +490,60 @@ function uniqueSnapshots(snapshots: PylonProviderRateLimitSnapshot[]) {
   return result
 }
 
+function localSessionUsageHistoryWith(
+  existing: PylonAccountUsageStoreEntry | undefined,
+  next: PylonLocalSessionUsageObservation | null,
+): PylonLocalSessionUsageObservation[] | undefined {
+  const history = existing?.localSessionUsageHistory
+    ? [...existing.localSessionUsageHistory]
+    : existing?.localSessionTruth
+      ? [existing.localSessionTruth]
+      : []
+  if (next) history.push(next)
+  if (history.length === 0) return undefined
+  return history
+    .sort((left, right) => Date.parse(left.observedAt) - Date.parse(right.observedAt))
+    .slice(-LOCAL_SESSION_USAGE_HISTORY_LIMIT)
+}
+
+export function countRollingWindowLocalSessionTokens(
+  observations: readonly PylonLocalSessionUsageObservation[],
+  options: { now: Date; windowMinutes: number },
+): number {
+  const windowMs = Math.max(0, options.windowMinutes) * 60_000
+  const windowStartMs = options.now.getTime() - windowMs
+  const windowEndMs = options.now.getTime()
+  const previousTotalsBySession = new Map<string, number>()
+  let tokenCount = 0
+  const sorted = observations
+    .map((observation, index) => ({ observation, index, observedMs: Date.parse(observation.observedAt) }))
+    .filter((entry) => Number.isFinite(entry.observedMs) && entry.observedMs <= windowEndMs)
+    .sort((left, right) => left.observedMs - right.observedMs || left.index - right.index)
+
+  for (const { observation, index, observedMs } of sorted) {
+    const totalTokens = Math.max(0, Math.round(observation.usage.totalTokens))
+    const sessionKey = observation.usage.sessionRef ?? `observation:${observation.observedAt}:${index}`
+    const previousTotal = previousTotalsBySession.get(sessionKey)
+    const delta = previousTotal === undefined
+      ? totalTokens
+      : totalTokens >= previousTotal
+        ? totalTokens - previousTotal
+        : totalTokens
+    if (observedMs >= windowStartMs && observedMs <= windowEndMs) tokenCount += delta
+    previousTotalsBySession.set(sessionKey, totalTokens)
+  }
+  return tokenCount
+}
+
+export function countAccountRollingWindowLocalSessionTokens(
+  entry: PylonAccountUsageStoreEntry | undefined,
+  options: { now: Date; windowMinutes: number },
+): number | null {
+  const history = entry?.localSessionUsageHistory ?? (entry?.localSessionTruth ? [entry.localSessionTruth] : [])
+  if (history.length === 0) return null
+  return countRollingWindowLocalSessionTokens(history, options)
+}
+
 export function parseCodexRateLimitHeaders(headers: Record<string, unknown>): PylonProviderRateLimitSnapshot[] {
   const lower = new Map<string, unknown>()
   for (const [key, value] of Object.entries(headers)) lower.set(key.toLowerCase(), value)
@@ -535,6 +596,9 @@ export async function recordPylonAccountUsageObservation(
   const identity = accountIdentity(observation.provider, observation.account)
   const store = await loadAccountUsageStore(summary)
   const existing = store.accounts[identity.accountRefHash]
+  const localSessionObservation = observation.localSessionUsage
+    ? { observedAt, usage: observation.localSessionUsage }
+    : null
   const updated: PylonAccountUsageStoreEntry = {
     provider: observation.provider,
     selector: identity.selector,
@@ -544,9 +608,10 @@ export async function recordPylonAccountUsageObservation(
         ? { observedAt, snapshots: observation.providerSnapshots }
         : existing?.providerTruth ?? null,
     localSessionTruth:
-      observation.localSessionUsage
-        ? { observedAt, usage: observation.localSessionUsage }
+      localSessionObservation
+        ? localSessionObservation
         : existing?.localSessionTruth ?? null,
+    localSessionUsageHistory: localSessionUsageHistoryWith(existing, localSessionObservation),
     updatedAt: observedAt,
   }
   store.accounts[identity.accountRefHash] = updated

--- a/apps/pylon/tests/account-status.test.ts
+++ b/apps/pylon/tests/account-status.test.ts
@@ -112,4 +112,85 @@ describe("pylon operator account status", () => {
       assertPublicProjectionSafe(projection)
     })
   })
+
+  test("uses rolling local-session token deltas when provider windows are missing", async () => {
+    await withHome(async (home) => {
+      const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+      const codexHome = join(home, "codex-a")
+      await mkdir(codexHome, { recursive: true })
+      await writeFile(
+        summary.paths.config,
+        `${JSON.stringify(
+          {
+            dev: {
+              accounts: [
+                {
+                  ref: "codex-a",
+                  provider: "codex",
+                  home: codexHome,
+                  hourlyCap: 1_000,
+                  weeklyCap: 10_000,
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      )
+
+      const accountRefHash = hashPylonAccountRef("codex", "codex-a")
+      const account = {
+        provider: "codex" as const,
+        selector: "registry_ref" as const,
+        accountRef: "codex-a",
+        accountRefHash,
+        home: codexHome,
+      }
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        account,
+        localSessionUsage: {
+          provider: "codex",
+          sessionRef: "session.pylon.codex.status",
+          inputTokens: 0,
+          outputTokens: 100,
+          totalTokens: 100,
+        },
+        observedAt: new Date("2026-06-28T10:30:00.000Z"),
+      })
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        account,
+        localSessionUsage: {
+          provider: "codex",
+          sessionRef: "session.pylon.codex.status",
+          inputTokens: 0,
+          outputTokens: 160,
+          totalTokens: 160,
+        },
+        observedAt: new Date("2026-06-28T11:05:00.000Z"),
+      })
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        account,
+        localSessionUsage: {
+          provider: "codex",
+          sessionRef: "session.pylon.codex.status",
+          inputTokens: 0,
+          outputTokens: 210,
+          totalTokens: 210,
+        },
+        observedAt: new Date("2026-06-28T11:45:00.000Z"),
+      })
+
+      const projection = await collectPylonOperatorAccountStatus(summary, {
+        now: new Date("2026-06-28T12:00:00.000Z"),
+      })
+
+      expect(projection.accounts[0]?.hourlyUsage).toBe(110)
+      expect(projection.accounts[0]?.weeklyUsage).toBe(null)
+      assertPublicProjectionSafe(projection)
+    })
+  })
 })

--- a/apps/pylon/tests/account-usage.test.ts
+++ b/apps/pylon/tests/account-usage.test.ts
@@ -3,9 +3,11 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import {
+  countRollingWindowLocalSessionTokens,
   collectPylonAccountUsageSummary,
   collectPylonAccountsList,
   collectPylonAccountsUsage,
+  loadAccountUsageStore,
   parseCodexRateLimitHeaders,
   parsePylonAccountsUsageArgs,
   providerRateLimitSnapshotsFromEvent,
@@ -48,6 +50,63 @@ async function runPylonCli(args: string[], env: Record<string, string | undefine
 }
 
 describe("pylon account usage", () => {
+  test("counts cumulative local-session token deltas inside a rolling window", () => {
+    const now = new Date("2026-06-28T12:00:00.000Z")
+    const usage = (observedAt: string, totalTokens: number, sessionRef = "session.pylon.codex.fixture") => ({
+      observedAt,
+      usage: {
+        provider: "codex" as const,
+        sessionRef,
+        inputTokens: 0,
+        outputTokens: totalTokens,
+        totalTokens,
+      },
+    })
+
+    expect(countRollingWindowLocalSessionTokens([
+      usage("2026-06-28T10:30:00.000Z", 100),
+      usage("2026-06-28T11:05:00.000Z", 160),
+      usage("2026-06-28T11:45:00.000Z", 210),
+      usage("2026-06-28T12:05:00.000Z", 300),
+    ], { now, windowMinutes: 60 })).toBe(110)
+  })
+
+  test("counts first in-window totals, reset totals, and null-session observations safely", () => {
+    const now = new Date("2026-06-28T12:00:00.000Z")
+    expect(countRollingWindowLocalSessionTokens([
+      {
+        observedAt: "2026-06-28T11:15:00.000Z",
+        usage: {
+          provider: "codex",
+          sessionRef: "session.pylon.codex.first_seen",
+          inputTokens: 20,
+          outputTokens: 80,
+          totalTokens: 100,
+        },
+      },
+      {
+        observedAt: "2026-06-28T11:30:00.000Z",
+        usage: {
+          provider: "codex",
+          sessionRef: "session.pylon.codex.first_seen",
+          inputTokens: 5,
+          outputTokens: 35,
+          totalTokens: 40,
+        },
+      },
+      {
+        observedAt: "2026-06-28T11:45:00.000Z",
+        usage: {
+          provider: "codex",
+          sessionRef: null,
+          inputTokens: 3,
+          outputTokens: 7,
+          totalTokens: 10,
+        },
+      },
+    ], { now, windowMinutes: 60 })).toBe(150)
+  })
+
   test("codex accounts list aliases the local account inventory command", async () => {
     await withHome(async (home) => {
       const proc = await runPylonCli(["codex", "accounts", "list", "--json"], {
@@ -163,6 +222,38 @@ describe("pylon account usage", () => {
         now: new Date("2026-06-12T12:20:00.000Z"),
       })
       expect(summaryProjection?.staleProviderTruthCount).toBe(1)
+    })
+  })
+
+  test("persists local-session usage history for rolling-window counters", async () => {
+    await withHome(async (home) => {
+      const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        localSessionUsage: {
+          provider: "codex",
+          sessionRef: "session.pylon.codex.history",
+          inputTokens: 0,
+          outputTokens: 100,
+          totalTokens: 100,
+        },
+        observedAt: new Date("2026-06-28T11:00:00.000Z"),
+      })
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        localSessionUsage: {
+          provider: "codex",
+          sessionRef: "session.pylon.codex.history",
+          inputTokens: 0,
+          outputTokens: 175,
+          totalTokens: 175,
+        },
+        observedAt: new Date("2026-06-28T11:30:00.000Z"),
+      })
+
+      const account = (await loadAccountUsageStore(summary)).accounts[hashPylonAccountRef("codex", "default")]
+      expect(account?.localSessionTruth?.usage.totalTokens).toBe(175)
+      expect(account?.localSessionUsageHistory?.map((entry) => entry.usage.totalTokens)).toEqual([100, 175])
     })
   })
 


### PR DESCRIPTION
Addresses #6660.

### Changes
- Added rolling-window local session token counting with per-session delta handling and bounded usage history storage.
- Updated Pylon account status to use rolling local-session totals when provider window snapshots are unavailable.
- Added unit coverage for account usage rolling-window behavior and account status fallback projection.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).