### PR TITLE
fix(codex-supervisor): spread concurrent slots across distinct issues (fix duplicate-dispatch under-fill)

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# claim-dispatch.test.sh — tests for the codex-supervisor in-flight claim
+# registry that makes concurrent worker slots select DISTINCT issues per cycle.
+#
+# This guards the duplicate-dispatch under-fill bug: N independent worker slots
+# ordered the same pool by priority and each picked the FIRST dispatchable issue,
+# so multiple slots collided on the same top issue, the dispatch gate admitted
+# one and refused the duplicates (409 / duplicate_active_assignment /
+# target_pylon_unavailable), and the fleet under-filled. The claim registry makes
+# each concurrent slot atomically reserve a distinct unlocked issue.
+#
+# Covers:
+#   * sup_try_claim_issue is atomic: a second claim of a held issue fails.
+#   * sup_claim_is_active reflects held vs released vs stale claims.
+#   * sup_release_claim frees a claim immediately.
+#   * sup_gc_stale_claims removes only entries past SUP_CLAIM_TTL_SECS.
+#   * sup_refresh_claim renews a claim's TTL window.
+#   * pick_and_claim_unlocked_issue returns DISTINCT issues on repeated calls,
+#     still honors the CLOSED/open-PR lockout, and reports rc 1 when nothing
+#     distinct+unlocked remains.
+#   * CONCURRENCY: many slots racing the SAME ordered pool resolve to distinct
+#     issues with no duplicates (the core regression assertion).
+#
+# Run: bash apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+# --- stub gh: every pool issue is OPEN with no referencing PR ---------------
+STUB_DIR="$WORK/fixtures"
+mkdir -p "$STUB_DIR"
+cat > "$WORK/gh" <<'STUB'
+#!/usr/bin/env bash
+sub="${1:-}"; shift || true
+case "$sub" in
+  pr)
+    # No referencing PRs for any issue in this suite.
+    echo "[]"
+    ;;
+  issue)
+    action="${1:-}"; shift || true
+    case "$action" in
+      view)
+        n="${1:-}"
+        f="$STUB_DIR/state.$n"
+        if [ -f "$f" ]; then cat "$f"; fi   # absent -> empty == gh error
+        ;;
+      list)
+        f="$STUB_DIR/openlist.json"
+        if [ -f "$f" ]; then cat "$f"; else echo "[]"; fi
+        ;;
+    esac
+    ;;
+esac
+STUB
+chmod +x "$WORK/gh"
+
+export STUB_DIR
+export SUP_GH_BIN="$WORK/gh"
+export SUP_REPO="OpenAgentsInc/openagents"
+export SUP_STATE_DIR="$WORK/state"
+export SUP_LOCKOUT_CACHE_DIR="$WORK/cache"
+export SUP_LOCKOUT_TTL_SECS=90
+export SUP_CLAIM_TTL_SECS=3600
+mkdir -p "$SUP_STATE_DIR" "$SUP_LOCKOUT_CACHE_DIR"
+
+# Mark a generous OPEN issue set (700..720) so all pool members are dispatchable.
+for n in $(seq 700 720); do printf 'OPEN' > "$STUB_DIR/state.$n"; done
+# A CLOSED issue used by the lockout assertion.
+printf 'CLOSED' > "$STUB_DIR/state.799"
+
+# shellcheck source=lockout.sh
+source "$SCRIPT_DIR/lockout.sh"
+
+# --- sup_try_claim_issue atomicity -----------------------------------------
+if sup_try_claim_issue 700; then ok "first claim of #700 succeeds"; else bad "first claim of #700 should succeed"; fi
+if sup_try_claim_issue 700; then bad "second claim of held #700 must fail"; else ok "second claim of held #700 fails (atomic)"; fi
+if sup_claim_is_active 700; then ok "#700 reports active claim"; else bad "#700 should report active claim"; fi
+
+# --- sup_release_claim ------------------------------------------------------
+sup_release_claim 700
+if sup_claim_is_active 700; then bad "#700 should be free after release"; else ok "#700 free after sup_release_claim"; fi
+if sup_try_claim_issue 700; then ok "#700 re-claimable after release"; else bad "#700 should be re-claimable after release"; fi
+sup_release_claim 700
+
+# --- sup_gc_stale_claims ----------------------------------------------------
+sup_try_claim_issue 701 >/dev/null
+sup_try_claim_issue 702 >/dev/null
+# Backdate #701's claim well past the TTL; #702 stays fresh.
+touch -t 200001010000 "$(sup_claims_dir)/claim.701" 2>/dev/null || true
+sup_gc_stale_claims
+if sup_claim_is_active 701; then bad "stale #701 should be GC'd"; else ok "stale #701 GC'd by sup_gc_stale_claims"; fi
+if sup_claim_is_active 702; then ok "fresh #702 survives GC"; else bad "fresh #702 should survive GC"; fi
+sup_release_claim 702
+
+# --- sup_refresh_claim renews TTL ------------------------------------------
+sup_try_claim_issue 703 >/dev/null
+touch -t 200001010000 "$(sup_claims_dir)/claim.703" 2>/dev/null || true
+sup_refresh_claim 703
+sup_gc_stale_claims
+if sup_claim_is_active 703; then ok "sup_refresh_claim renews TTL (survives GC)"; else bad "refreshed #703 should survive GC"; fi
+sup_release_claim 703
+
+# --- pick_and_claim_unlocked_issue returns DISTINCT issues ------------------
+# Sequential calls against the same pool must hand out different issues.
+a=$(pick_and_claim_unlocked_issue 0 710 711 712)
+b=$(pick_and_claim_unlocked_issue 0 710 711 712)
+c=$(pick_and_claim_unlocked_issue 0 710 711 712)
+if [ -n "$a" ] && [ -n "$b" ] && [ -n "$c" ] && [ "$a" != "$b" ] && [ "$a" != "$c" ] && [ "$b" != "$c" ]; then
+  ok "sequential picks are distinct ($a,$b,$c)"
+else
+  bad "sequential picks not distinct (a=$a b=$b c=$c)"
+fi
+# Pool exhausted (all three claimed) -> rc 1 / empty.
+if d=$(pick_and_claim_unlocked_issue 0 710 711 712) && [ -n "$d" ]; then
+  bad "exhausted pool should yield nothing (got '$d')"
+else
+  ok "exhausted claimed pool reports nothing (rc 1)"
+fi
+sup_release_claim 710; sup_release_claim 711; sup_release_claim 712
+
+# --- pick_and_claim honors the CLOSED lockout ------------------------------
+# #799 is CLOSED, #713 is open -> must pick #713, never the closed one.
+picked=$(pick_and_claim_unlocked_issue 0 799 713)
+if [ "$picked" = "713" ]; then ok "pick_and_claim skips CLOSED #799 -> #713"; else bad "expected 713, got '$picked'"; fi
+sup_release_claim 713
+
+# --- CONCURRENCY: N slots, same pool -> all DISTINCT, no duplicates ---------
+# This is the core regression assertion for the duplicate-dispatch bug.
+POOL=(710 711 712 713 714 715 716 717)   # 8 distinct unlocked issues
+SLOTS=8
+# Clear any residual claims so every pool member is free.
+for n in "${POOL[@]}"; do sup_release_claim "$n"; done
+pids=()
+for i in $(seq 0 $((SLOTS-1))); do
+  ( pick_and_claim_unlocked_issue 0 "${POOL[@]}" > "$WORK/res.$i" 2>/dev/null ) &
+  pids+=("$!")
+done
+for p in "${pids[@]}"; do wait "$p"; done
+
+results=()
+for i in $(seq 0 $((SLOTS-1))); do
+  r="$(cat "$WORK/res.$i" 2>/dev/null)"
+  [ -n "$r" ] && results+=("$r")
+done
+total="${#results[@]}"
+distinct="$(printf '%s\n' "${results[@]}" | sort -u | grep -c .)"
+if [ "$total" = "$SLOTS" ] && [ "$distinct" = "$SLOTS" ]; then
+  ok "concurrent $SLOTS slots claimed $distinct DISTINCT issues (no collisions)"
+else
+  bad "concurrent claim collision: total=$total distinct=$distinct (want $SLOTS/$SLOTS): ${results[*]}"
+fi
+
+# --- CONCURRENCY: more slots than issues -> exactly pool-size distinct ------
+for n in "${POOL[@]}"; do sup_release_claim "$n"; done
+SMALL=(720 711 712)   # 3 distinct unlocked issues
+MORE_SLOTS=6
+pids=()
+for i in $(seq 0 $((MORE_SLOTS-1))); do
+  ( pick_and_claim_unlocked_issue 0 "${SMALL[@]}" > "$WORK/small.$i" 2>/dev/null ) &
+  pids+=("$!")
+done
+for p in "${pids[@]}"; do wait "$p"; done
+sresults=()
+for i in $(seq 0 $((MORE_SLOTS-1))); do
+  r="$(cat "$WORK/small.$i" 2>/dev/null)"
+  [ -n "$r" ] && sresults+=("$r")
+done
+stotal="${#sresults[@]}"
+sdistinct="$(printf '%s\n' "${sresults[@]}" | sort -u | grep -c .)"
+if [ "$stotal" = "3" ] && [ "$sdistinct" = "3" ]; then
+  ok "6 slots / 3 issues -> exactly 3 distinct winners, 3 empty (no over-claim)"
+else
+  bad "small-pool over-claim: total=$stotal distinct=$sdistinct (want 3/3): ${sresults[*]}"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -354,10 +354,17 @@ worker_loop() {
     done < <(sup_order_pool_by_priority "$start_idx" "${issues[@]}")
     [ "${#ordered[@]}" -gt 0 ] || ordered=("${issues[@]}")
 
+    # Concurrent-slot distinct-issue selection: ATOMICALLY CLAIM a distinct
+    # unlocked issue so two slots in the same cycle never pick the same one (the
+    # duplicate-dispatch under-fill bug). In addition to the existing lockout
+    # (skip CLOSED + open-PR issues), pick_and_claim_unlocked_issue skips any
+    # issue already claimed by another slot's in-flight assignment and reserves
+    # the chosen issue under SUP_CLAIM_TTL_SECS. N slots -> up to N distinct
+    # issues, restoring same-account parallelism across different issues.
     local issue
-    issue=$(pick_unlocked_issue 0 "${ordered[@]}")
+    issue=$(pick_and_claim_unlocked_issue 0 "${ordered[@]}")
     if [ -z "$issue" ]; then
-      log "slot=$slot LOCKOUT all backlog issues are closed or already have open PRs; backing off ${backoff}s"
+      log "slot=$slot LOCKOUT all backlog issues are closed, already have open PRs, or are claimed by other slots; backing off ${backoff}s"
       sleep "$backoff"
       backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
       continue
@@ -374,6 +381,9 @@ worker_loop() {
     local commit fresh_main local_head
     fresh_main=$(supervisor_resolve_fresh_origin_main_sha "$SUP_REPO")
     if [ -z "$fresh_main" ]; then
+      # Pre-dispatch bail: release the claim so this issue is not parked while we
+      # never actually dispatched it.
+      sup_release_claim "$issue"
       log "slot=$slot SKIP could not resolve fresh origin/main sha for $SUP_REPO; not dispatching a stale base (anti-#6719)"
       sleep 15; continue
     fi
@@ -385,7 +395,7 @@ worker_loop() {
     # projected base is fresh main plus in-flight assignment branches.
     commit=$(sup_vmq_project_head "$REPO_ROOT" "$fresh_main" 2>/dev/null)
     [ -z "$commit" ] && commit="$fresh_main"
-    [ -z "$commit" ] && { sleep 15; continue; }
+    [ -z "$commit" ] && { sup_release_claim "$issue"; sleep 15; continue; }
 
     # Record the dispatch ATTEMPT timestamp (#6646) right before firing the
     # request, so last_dispatch_time advances every pick+dispatch cycle and a
@@ -411,6 +421,10 @@ worker_loop() {
 
     if grep -qiE '"ok": ?true|"closeout"|accepted' "$out" 2>/dev/null && [ "$rc" -eq 0 ]; then
       backoff="$SUP_BACKOFF_MIN"
+      # Keep the issue claimed (refresh TTL) so no other slot re-picks it while
+      # its PR/lockout state settles; the open-PR lockout then takes over and the
+      # claim eventually GCs.
+      sup_refresh_claim "$issue"
       log "slot=$slot acc=$acc issue=#$issue OK (rc=$rc)"
       continue
     fi
@@ -418,8 +432,19 @@ worker_loop() {
     # Refused / unavailable / rate-limited / error -> exponential backoff so the
     # pool settles at the login's real headroom.
     local sig="other"
-    grep -qiE '409|dispatch gate refused|target_pylon_unavailable' "$out" 2>/dev/null && sig="refused"
+    grep -qiE '409|dispatch gate refused|target_pylon_unavailable|duplicate_active_assignment' "$out" 2>/dev/null && sig="refused"
     grep -qiE '429|rate.?limit|too many requests|quota' "$out" 2>/dev/null && sig="rate_limited"
+    if [ "$sig" = "refused" ]; then
+      # The gate already has an active assignment for this issue (it is busy
+      # elsewhere). PARK it for the full claim TTL so the fleet stops hammering
+      # the same stuck issue (#6661/#6662) and other slots spread to distinct
+      # work; the claim GCs once the TTL elapses for a later retry.
+      sup_refresh_claim "$issue"
+    else
+      # Transient rate-limit/error on our side, not the issue's fault: release
+      # the claim so another (less throttled) slot/account can retry this issue.
+      sup_release_claim "$issue"
+    fi
     log "slot=$slot acc=$acc issue=#$issue NO-DISPATCH ($sig rc=$rc); backoff ${backoff}s"
     sleep "$backoff"
     backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"

--- a/apps/pylon/scripts/codex-supervisor/lockout.sh
+++ b/apps/pylon/scripts/codex-supervisor/lockout.sh
@@ -238,3 +238,156 @@ pick_unlocked_issue() {
   done
   return 1
 }
+
+# --- In-flight claim registry (concurrent-slot distinct-issue dispatch) ------
+#
+# ROOT CAUSE this fixes: the supervisor runs N worker slots as independent
+# background loops. Per cycle each slot independently ordered the SAME pool by
+# priority and called `pick_unlocked_issue 0 ...`, which returns the FIRST
+# dispatchable issue. The only cross-slot spread was a start-index rotation that
+# the priority bucket-sort then collapsed: whenever the highest non-empty tier
+# held only a few issues, EVERY concurrent slot picked the SAME top issue. The
+# dispatch gate admits ONE assignment per issue and refused the duplicates
+# (409 / duplicate_active_assignment / target_pylon_unavailable), so N-1 slots
+# backed off and the fleet under-filled (e.g. ~10 turns instead of 12+, with the
+# same 1-2 issues hammered dozens of times).
+#
+# FIX: a shared on-disk claim registry under the state dir. Before a slot
+# dispatches an issue it must ATOMICALLY acquire that issue's claim; another slot
+# that already holds a fresh claim is skipped. So N concurrent slots resolve to
+# up to N DISTINCT unlocked issues, restoring same-account parallelism across
+# different issues. A claim is held for SUP_CLAIM_TTL_SECS (defaults to the
+# dispatch timeout) so it covers the whole in-flight assignment; a refused/busy
+# issue stays parked for the TTL (the fleet moves on to other work instead of
+# re-hammering the stuck #6661/#6662-style issue), while a transiently
+# rate-limited/errored issue is released immediately so other accounts can retry
+# it. Stale claims (TTL elapsed) are garbage-collected so finished/abandoned work
+# frees the issue for a later retry.
+#
+# Atomicity: `mkdir` is the POSIX atomic create primitive — exactly one slot wins
+# the create. Staleness is handled by a separate GC sweep (sup_gc_stale_claims)
+# rather than an in-acquire delete+create, so there is never a window where two
+# slots both believe they own the same issue.
+
+# Claim TTL: cover the full in-flight assignment so concurrent slots never grab
+# an issue another slot is actively working. Defaults to the dispatch timeout
+# when set, else 30m.
+: "${SUP_CLAIM_TTL_SECS:=${SUP_DISPATCH_TIMEOUT_SECS:-1800}}"
+
+sup_claims_dir() {
+  local d="${SUP_LOCKOUT_CACHE_DIR:-$SUP_STATE_DIR}/claims"
+  mkdir -p "$d" 2>/dev/null || true
+  printf '%s' "$d"
+}
+
+# sup_gc_stale_claims
+#   Remove claim entries whose age has reached SUP_CLAIM_TTL_SECS. A claim that
+#   old means its dispatch (bounded by SUP_DISPATCH_TIMEOUT_SECS <= TTL) has
+#   ended, so freeing it cannot race a live dispatch. Idempotent; safe to run
+#   concurrently from every slot (rm is a no-op on an already-removed entry).
+sup_gc_stale_claims() {
+  local dir; dir="$(sup_claims_dir)"
+  local now claim age
+  now=$(date +%s)
+  for claim in "$dir"/claim.*; do
+    [ -e "$claim" ] || continue
+    age=$(( now - $(sup_file_mtime "$claim") ))
+    if [ "$age" -lt 0 ] || [ "$age" -ge "$SUP_CLAIM_TTL_SECS" ]; then
+      rm -rf "$claim" 2>/dev/null || true
+    fi
+  done
+}
+
+# sup_claim_is_active <issue>
+#   rc 0 if a FRESH claim is held for the issue (reserved by some slot), rc 1
+#   otherwise. Does not mutate; GC of stale entries is sup_gc_stale_claims's job.
+sup_claim_is_active() {
+  local issue="$1"; [ -n "$issue" ] || return 1
+  local f; f="$(sup_claims_dir)/claim.$issue"
+  [ -e "$f" ] || return 1
+  local now age
+  now=$(date +%s)
+  age=$(( now - $(sup_file_mtime "$f") ))
+  [ "$age" -ge 0 ] && [ "$age" -lt "$SUP_CLAIM_TTL_SECS" ]
+}
+
+# sup_try_claim_issue <issue> [owner]
+#   ATOMICALLY acquire the in-flight claim for <issue>. rc 0 (and the claim is
+#   now held by this caller) only for the single slot that wins the create;
+#   rc 1 if another slot already holds a fresh claim. Relies on the caller (or a
+#   preceding sup_gc_stale_claims) to have cleared expired claims first.
+sup_try_claim_issue() {
+  local issue="$1"; local owner="${2:-$$}"
+  [ -n "$issue" ] || return 1
+  local dir; dir="$(sup_claims_dir)"
+  local claim="$dir/claim.$issue"
+  if mkdir "$claim" 2>/dev/null; then
+    printf '%s %s\n' "$owner" "$(date +%s)" > "$claim/meta" 2>/dev/null || true
+    return 0
+  fi
+  return 1
+}
+
+# sup_refresh_claim <issue> [owner]
+#   Bump a held claim's mtime so its TTL window restarts (e.g. on a successful
+#   dispatch, keep the issue parked while its PR/lockout state settles). No-op if
+#   the claim does not exist.
+sup_refresh_claim() {
+  local issue="$1"; [ -n "$issue" ] || return 0
+  local claim; claim="$(sup_claims_dir)/claim.$issue"
+  [ -e "$claim" ] || return 0
+  # Bump the claim DIRECTORY's mtime (the value sup_claim_is_active /
+  # sup_gc_stale_claims read); overwriting an existing inner file does not
+  # reliably update the directory mtime on all filesystems.
+  touch "$claim" 2>/dev/null || true
+  printf '%s %s\n' "${2:-$$}" "$(date +%s)" > "$claim/meta" 2>/dev/null || true
+}
+
+# sup_release_claim <issue>
+#   Free an issue's claim immediately (e.g. a transient rate-limit/error, or a
+#   pre-dispatch bail) so another slot/account can retry it without waiting for
+#   the TTL to elapse.
+sup_release_claim() {
+  local issue="$1"; [ -n "$issue" ] || return 0
+  rm -rf "$(sup_claims_dir)/claim.$issue" 2>/dev/null || true
+}
+
+# pick_and_claim_unlocked_issue <start_index> <issue...>
+#   Like pick_unlocked_issue, but additionally enforces cross-slot distinctness:
+#   it GCs stale claims, then scans the rotation skipping issues that are CLOSED,
+#   already have an open PR, OR already have a fresh in-flight claim, and
+#   ATOMICALLY claims the first remaining issue before returning it. Two slots
+#   racing the same ordered pool therefore resolve to DISTINCT issues. rc 0 with
+#   the claimed issue on stdout; rc 1 when no distinct unlocked+unclaimed issue
+#   is available.
+pick_and_claim_unlocked_issue() {
+  local start="$1"; shift
+  local arr=("$@")
+  local n="${#arr[@]}"
+  [ "$n" -gt 0 ] || return 1
+  sup_gc_stale_claims
+  local k i issue
+  for (( k=0; k<n; k++ )); do
+    i=$(( (start + k) % n ))
+    issue="${arr[$i]}"
+    # Already reserved by another slot this window -> spread to a distinct issue.
+    if sup_claim_is_active "$issue"; then
+      continue
+    fi
+    # Closed/merged during the run (stale-snapshot redo guard).
+    if ! issue_is_open "$issue"; then
+      continue
+    fi
+    # Already has an open PR (duplicate-PR guard).
+    if issue_has_open_pr "$issue"; then
+      continue
+    fi
+    # Atomic acquire: only the winning slot proceeds; a loser falls through to
+    # the next candidate so concurrent slots never collide on one issue.
+    if sup_try_claim_issue "$issue"; then
+      printf '%s' "$issue"
+      return 0
+    fi
+  done
+  return 1
+}


### PR DESCRIPTION
## Problem (live symptom)

With ~12 desired slots and ~22 dispatchable open issues, the codex-supervisor was only achieving ~10 effective turns. The supervisor log showed many concurrent slots picking the SAME issue and colliding at the dispatch gate:

```
slot=4..11 acc=codex-* issue=#6661 NO-DISPATCH (refused rc=1)
```

In the last 60 attempts before the fix, issues tried: #6662 x25, #6661 x16, #6763 x7 — concurrent slots were NOT spread across distinct issues.

## Root cause

`apps/pylon/scripts/codex-supervisor/codex-supervisor.sh` runs N `worker_loop` slots as independent background processes. Per cycle each slot independently ordered the same pool by priority (`sup_order_pool_by_priority`) and called `pick_unlocked_issue 0 ...` (`lockout.sh:219`), which returns the FIRST dispatchable issue. The only cross-slot spread was a per-slot start-index rotation, which the priority bucket-sort then collapsed: whenever the highest non-empty tier held only a few issues, every concurrent slot resolved to the SAME top issue. The dispatch gate admits one assignment per issue and refused the duplicates (`409` / `duplicate_active_assignment` / `target_pylon_unavailable`), so N-1 slots backed off and the fleet under-filled. #6661/#6662 also had perpetual active leases, so every slot kept re-picking and re-hammering them.

There was no cross-slot coordination and no skip for issues with an active assignment/lease — that is the bug.

## Fix

Add a shared on-disk in-flight **claim registry** in `lockout.sh`:

- `pick_and_claim_unlocked_issue` GCs stale claims, then scans the priority-ordered rotation skipping CLOSED, open-PR, AND already-claimed issues, and ATOMICALLY reserves the chosen issue via `mkdir` (POSIX atomic create) before returning it. N concurrent slots therefore resolve to up to N DISTINCT issues.
- A refused/busy issue (`duplicate_active_assignment`) is **parked** for the claim TTL so the fleet moves on to distinct work instead of re-hammering the stuck issue; a transient rate-limit/error **releases** the claim immediately for retry; a successful dispatch keeps the claim refreshed while the PR/lockout state settles. Stale claims (past `SUP_CLAIM_TTL_SECS`, default = dispatch timeout) are GC'd for later retry.

Preserves the existing lockout (open-PR + closed), the priority tier ordering and intra-tier rotation, the fresh-origin/main base fix (anti-#6719), and the 429 backoff. `SUP_PER_ACCOUNT>1` keeps working — multiple sessions per account now land on DIFFERENT issues.

## Tests

New `claim-dispatch.test.sh` (13 assertions): atomic claim, GC/refresh/release, distinct sequential picks, CLOSED-lockout interplay, and the core regression — concurrent N-slot selection returns DISTINCT issues with no collisions (incl. more-slots-than-issues over-claim guard).

```
lockout:             12 passed   priority-dispatch:   18 passed
standing-tasks:       8 passed   virtual-merge-queue:  6 passed
timeout:              4 passed   fleet-offload:        7 passed
task-pool:            3 passed   claim-dispatch:      13 passed (new)
```

`bun run check:deploy` is green (web 555 tests, api 206 tests, all typechecks/guards pass).

## Before / after selection behavior

- **Before:** every concurrent slot scanned the same priority-ordered pool from the top and returned the same first dispatchable issue → 1 admitted, N-1 refused → under-fill.
- **After:** the first slot to atomically claim each issue wins; losers fall through to the next distinct unlocked+unclaimed issue → up to N distinct issues dispatched per cycle.

> NOTE: the **running supervisor must be restarted** onto this fix to take effect (the loop runs the on-disk script at start). No deploy is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)