### PR TITLE
Add AgentCL Vertex runtime guard

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
 import {
@@ -13,10 +14,48 @@ import {
   buildAgentClVertexGeminiRunnerPlan,
   buildAgentClVertexStressBaselineReport,
   buildAgentClVertexStressExperiment,
+  runAgentClVertexRunnerLoop,
   runAgentClRepoReuseFixtureEval,
   runAgentClSequentialLoop,
   runAgentClTaskRunner,
 } from './agentcl'
+import {
+  InferenceAdapterError,
+  type InferenceProviderAdapter,
+  type InferenceRequest,
+  type InferenceResult,
+} from '../provider-adapter'
+
+const vertexResult = (
+  usage: InferenceResult['usage'],
+): InferenceResult => ({
+  content: 'public-safe AgentCL fixture outcome',
+  finishReason: 'stop',
+  servedModel: 'gemini-3.5-flash',
+  usage,
+})
+
+const fakeVertexAdapter = (
+  complete: (
+    request: InferenceRequest,
+  ) => Effect.Effect<InferenceResult, InferenceAdapterError>,
+): InferenceProviderAdapter => ({
+  complete,
+  id: 'vertex-gemini',
+  stream: () =>
+    Effect.succeed([
+      {
+        contentDelta: '',
+        finishReason: 'stop',
+        servedModel: 'gemini-3.5-flash',
+        usage: {
+          completionTokens: 1,
+          promptTokens: 1,
+          totalTokens: 2,
+        },
+      },
+    ]),
+})
 
 describe('AgentCL repo-reuse gym environment', () => {
   test('builds a public-safe two-pass compositional stream plan', () => {
@@ -319,6 +358,122 @@ describe('AgentCL repo-reuse gym environment', () => {
         consecutiveBillingOrQuotaErrors: 0,
       }),
     ).toEqual({ tripped: true, reason: 'spend_cap_exceeded' })
+  })
+
+  test('keeps the AgentCL Vertex runner no-spend unless owner_armed_real is selected', async () => {
+    let calls = 0
+    const result = await Effect.runPromise(
+      runAgentClVertexRunnerLoop({
+        adapter: fakeVertexAdapter(() => {
+          calls += 1
+          return Effect.succeed(
+            vertexResult({
+              completionTokens: 1,
+              promptTokens: 1,
+              totalTokens: 2,
+            }),
+          )
+        }),
+        ownerApprovalRef: 'owner.approval.agentcl.vertex_stress.20260628',
+        runMode: 'fixture_baseline',
+      }),
+    )
+
+    expect(result.status).toBe('blocked_unarmed')
+    expect(result.failureRefs).toContain(
+      'blocker.gym.agentcl.vertex_runner_not_owner_armed_real',
+    )
+    expect(calls).toBe(0)
+  })
+
+  test('blocks AgentCL live execution when the supplied lane is a forbidden fallback', async () => {
+    const fallbackAdapter: InferenceProviderAdapter = {
+      ...fakeVertexAdapter(() =>
+        Effect.succeed(
+          vertexResult({
+            completionTokens: 1,
+            promptTokens: 1,
+            totalTokens: 2,
+          }),
+        ),
+      ),
+      id: 'openrouter-khala-glm-fallback',
+    }
+
+    const result = await Effect.runPromise(
+      runAgentClVertexRunnerLoop({
+        adapter: fallbackAdapter,
+        ownerApprovalRef: 'owner.approval.agentcl.vertex_stress.20260628',
+        runMode: 'owner_armed_real',
+      }),
+    )
+
+    expect(result.status).toBe('blocked_forbidden_fallback')
+    expect(result.failureRefs).toContain(
+      'blocker.gym.agentcl.vertex_runner_forbidden_fallback_lane',
+    )
+  })
+
+  test('runs AgentCL live calls through Vertex only and aborts after measured spend crosses the $50 cap', async () => {
+    let calls = 0
+    const result = await Effect.runPromise(
+      runAgentClVertexRunnerLoop({
+        adapter: fakeVertexAdapter(request => {
+          calls += 1
+          expect(request.model).toBe('gemini-3.5-flash')
+          expect(request.priority).toBe('internal_stress')
+          return Effect.succeed(
+            vertexResult({
+              completionTokens: 166_666_668,
+              promptTokens: 0,
+              totalTokens: 166_666_668,
+            }),
+          )
+        }),
+        ownerApprovalRef: 'owner.approval.agentcl.vertex_stress.20260628',
+        runMode: 'owner_armed_real',
+      }),
+    )
+
+    expect(calls).toBe(1)
+    expect(result.status).toBe('aborted_circuit_breaker')
+    expect(result.report.budgetGuard.circuitBreakerTripped).toBe(true)
+    expect(result.report.budgetGuard.circuitBreakerReason).toBe(
+      'spend_cap_exceeded',
+    )
+    expect(result.report.budgetGuard.estimatedSpendUsdCents).toBeGreaterThan(
+      5000,
+    )
+  })
+
+  test('aborts AgentCL live execution after three consecutive billing or quota errors', async () => {
+    let calls = 0
+    const result = await Effect.runPromise(
+      runAgentClVertexRunnerLoop({
+        adapter: fakeVertexAdapter(() => {
+          calls += 1
+          return Effect.fail(
+            new InferenceAdapterError({
+              adapterId: 'vertex-gemini',
+              httpStatus: 429,
+              kind: 'quota_error',
+              reason: 'Vertex Gemini returned HTTP 429: resource exhausted',
+              retryable: true,
+            }),
+          )
+        }),
+        ownerApprovalRef: 'owner.approval.agentcl.vertex_stress.20260628',
+        runMode: 'owner_armed_real',
+      }),
+    )
+
+    expect(calls).toBe(3)
+    expect(result.status).toBe('aborted_circuit_breaker')
+    expect(result.report.budgetGuard.consecutiveBillingOrQuotaErrors).toBe(3)
+    expect(result.report.budgetGuard.circuitBreakerReason).toBe(
+      'consecutive_billing_or_quota_errors',
+    )
+    expect(result.report.capacityReport.http429Count).toBe(3)
   })
 
   test('emits the CL-5 baseline report with separate PG, SG, and GG curves plus capacity blockers', () => {

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
@@ -1,4 +1,4 @@
-import { Schema as S } from 'effect'
+import { Effect, Schema as S } from 'effect'
 
 import {
   AGENTCL_REPO_REUSE_GYM_EXPERIMENT,
@@ -11,6 +11,18 @@ import {
 } from './experiment'
 import { exampleArtanisContinualLearningTemplateLedger } from '../../artanis-continual-learning-templates'
 import type { BenchmarkWorkload } from '../benchmark'
+import {
+  type InferenceMessage,
+  type InferenceProviderAdapter,
+  type InferenceRequest,
+  type InferenceResult,
+  type InferenceUsage,
+} from '../provider-adapter'
+import { priceRequest } from '../pricing'
+import {
+  DEFAULT_GEMINI_MODEL_ID,
+  VERTEX_GEMINI_ADAPTER_ID,
+} from '../vertex-gemini-adapter'
 
 export { AGENTCL_REPO_REUSE_GYM_EXPERIMENT } from './experiment'
 
@@ -316,7 +328,7 @@ export const AgentClVertexStressReportV0 = S.Struct({
   budgetGuard: S.Struct({
     spendCapUsdCents: S.Literal(5000),
     estimatedSpendUsdCents: S.Number.check(
-      S.isBetween({ minimum: 0, maximum: 5000 }),
+      S.isBetween({ minimum: 0, maximum: 1_000_000 }),
     ),
     consecutiveBillingOrQuotaErrors: S.Number.check(
       S.isBetween({ minimum: 0, maximum: 3 }),
@@ -359,6 +371,19 @@ export type AgentClLearningClaimEvidence = Readonly<{
     decisionGrade?: boolean
     publicClaimEligible?: boolean
   }>
+}>
+
+export type AgentClVertexRunnerLoopStatus =
+  | 'completed'
+  | 'aborted_circuit_breaker'
+  | 'blocked_unarmed'
+  | 'blocked_forbidden_fallback'
+
+export type AgentClVertexRunnerLoopResult = Readonly<{
+  status: AgentClVertexRunnerLoopStatus
+  report: AgentClVertexStressReportV0
+  results: ReadonlyArray<InferenceResult>
+  failureRefs: ReadonlyArray<string>
 }>
 
 const decodePlan = S.decodeUnknownSync(AgentClRepoReusePlan)
@@ -1013,6 +1038,213 @@ export const assessAgentClVertexRunnerCircuitBreaker = (
     reason,
   }
 }
+
+const agentClVertexPromptForTask = (
+  entry: AgentClTaskSequenceEntry,
+): ReadonlyArray<InferenceMessage> => [
+  {
+    content:
+      'Run the public AgentCL repo-reuse task. Use only public task refs and return a concise public-safe outcome summary.',
+    role: 'system',
+  },
+  {
+    content: [
+      `taskRef=${entry.taskRef}`,
+      `taskRole=${entry.taskRole}`,
+      `workload=${entry.workload}`,
+      `pass=${entry.pass}`,
+      `memoryAccess=${entry.memoryAccess}`,
+      `verifierRef=${entry.verifierRef}`,
+    ].join('\n'),
+    role: 'user',
+  },
+]
+
+const agentClVertexRequestForTask = (
+  entry: AgentClTaskSequenceEntry,
+): InferenceRequest => ({
+  messages: agentClVertexPromptForTask(entry),
+  model: DEFAULT_GEMINI_MODEL_ID,
+  passthroughParams: {
+    max_tokens: 1024,
+    temperature: 0.2,
+  },
+  priority: 'internal_stress',
+  stream: false,
+})
+
+const estimatedVertexSpendCentsForUsage = (usage: InferenceUsage): number =>
+  priceRequest({
+    fundingKind: 'card',
+    margin: 0,
+    model: DEFAULT_GEMINI_MODEL_ID,
+    usage,
+  }).costUsd * 100
+
+const isAgentClBillingOrQuotaError = (error: Readonly<{
+  httpStatus?: number | undefined
+  kind?: string | undefined
+  reason: string
+}>): boolean => {
+  const reason = error.reason.toLowerCase()
+  const kind = error.kind?.toLowerCase() ?? ''
+  return (
+    error.httpStatus === 429 ||
+    kind.includes('quota') ||
+    kind.includes('billing') ||
+    kind.includes('rate_limited') ||
+    kind.includes('resource_exhausted') ||
+    reason.includes('quota') ||
+    reason.includes('billing') ||
+    reason.includes('http 429') ||
+    reason.includes('resource exhausted') ||
+    reason.includes('resource_exhausted')
+  )
+}
+
+export const runAgentClVertexRunnerLoop = (
+  input: Readonly<{
+    adapter: InferenceProviderAdapter
+    ownerApprovalRef: string
+    runMode: AgentClVertexStressRunMode
+    experiment?: GymExperiment | undefined
+  }>,
+): Effect.Effect<AgentClVertexRunnerLoopResult> =>
+  Effect.gen(function* () {
+    if (input.runMode !== 'owner_armed_real') {
+      return {
+        failureRefs: ['blocker.gym.agentcl.vertex_runner_not_owner_armed_real'],
+        report: buildAgentClVertexStressBaselineReport({
+          runMode: input.runMode,
+        }),
+        results: [],
+        status: 'blocked_unarmed',
+      }
+    }
+
+    if (input.adapter.id !== VERTEX_GEMINI_ADAPTER_ID) {
+      return {
+        failureRefs: [
+          'blocker.gym.agentcl.vertex_runner_forbidden_fallback_lane',
+        ],
+        report: buildAgentClVertexStressBaselineReport({
+          runMode: input.runMode,
+        }),
+        results: [],
+        status: 'blocked_forbidden_fallback',
+      }
+    }
+
+    const stressExperiment =
+      input.experiment ??
+      buildAgentClVertexStressExperiment(input.ownerApprovalRef)
+    const { compiled, plan } = buildAgentClRepoReusePlan(stressExperiment)
+    const taskSequence = taskSequenceForPlan(plan, compiled)
+    const results: Array<InferenceResult> = []
+    const failureRefs: Array<string> = []
+    let estimatedSpendUsdCents = 0
+    let consecutiveBillingOrQuotaErrors = 0
+    let http429Count = 0
+    let resourceExhaustedCount = 0
+    let status: AgentClVertexRunnerLoopStatus = 'completed'
+    const runnerPlan = buildAgentClVertexGeminiRunnerPlan(input.ownerApprovalRef)
+    const plannedIterations = runnerPlan.parallelism.plannedParallelSequences
+
+    for (const entry of taskSequence.slice(0, plannedIterations)) {
+      const beforeCallBreaker = assessAgentClVertexRunnerCircuitBreaker({
+        consecutiveBillingOrQuotaErrors,
+        estimatedSpendUsdCents,
+      })
+      if (beforeCallBreaker.tripped) {
+        status = 'aborted_circuit_breaker'
+        failureRefs.push(
+          `blocker.gym.agentcl.vertex_runner.${beforeCallBreaker.reason}`,
+        )
+        break
+      }
+
+      const request = agentClVertexRequestForTask(entry)
+      const outcome = yield* input.adapter
+        .complete(request)
+        .pipe(
+          Effect.map(result => ({ result, ok: true as const })),
+          Effect.catch(error =>
+            Effect.succeed({ error, ok: false as const }),
+          ),
+        )
+
+      if (!outcome.ok) {
+        if (isAgentClBillingOrQuotaError(outcome.error)) {
+          consecutiveBillingOrQuotaErrors += 1
+          if (
+            outcome.error.httpStatus === 429 ||
+            outcome.error.reason.toLowerCase().includes('http 429')
+          ) {
+            http429Count += 1
+          }
+          if (
+            outcome.error.reason.toLowerCase().includes('resource exhausted') ||
+            outcome.error.reason.toLowerCase().includes('resource_exhausted') ||
+            outcome.error.kind?.toLowerCase().includes('resource_exhausted') ===
+              true
+          ) {
+            resourceExhaustedCount += 1
+          }
+        }
+        const afterErrorBreaker = assessAgentClVertexRunnerCircuitBreaker({
+          consecutiveBillingOrQuotaErrors,
+          estimatedSpendUsdCents,
+        })
+        if (afterErrorBreaker.tripped) {
+          status = 'aborted_circuit_breaker'
+          failureRefs.push(
+            `blocker.gym.agentcl.vertex_runner.${afterErrorBreaker.reason}`,
+          )
+          break
+        }
+        continue
+      }
+
+      consecutiveBillingOrQuotaErrors = 0
+      results.push(outcome.result)
+      estimatedSpendUsdCents += estimatedVertexSpendCentsForUsage(
+        outcome.result.usage,
+      )
+
+      const afterResultBreaker = assessAgentClVertexRunnerCircuitBreaker({
+        consecutiveBillingOrQuotaErrors,
+        estimatedSpendUsdCents,
+      })
+      if (afterResultBreaker.tripped) {
+        status = 'aborted_circuit_breaker'
+        failureRefs.push(
+          `blocker.gym.agentcl.vertex_runner.${afterResultBreaker.reason}`,
+        )
+        break
+      }
+    }
+
+    return {
+      failureRefs,
+      report: buildAgentClVertexStressBaselineReport({
+        attemptedSequences:
+          results.length + http429Count + resourceExhaustedCount,
+        completedSequences: results.length,
+        consecutiveBillingOrQuotaErrors,
+        estimatedSpendUsdCents,
+        http429Count,
+        peakAcceptedParallelSequences: Math.min(
+          results.length,
+          plannedIterations,
+        ),
+        resourceExhaustedCount,
+        runMode: input.runMode,
+        verifiedVertexBeforeScale: true,
+      }),
+      results,
+      status,
+    }
+  })
 
 export const buildAgentClVertexStressBaselineReport = (
   input: Readonly<{


### PR DESCRIPTION
Closes #6788.

## Summary
- Adds an owner-armed AgentCL Vertex runner loop that calls only the `vertex-gemini` adapter with `gemini-3.5-flash` requests.
- Blocks fixture/default mode from spending and rejects non-Vertex adapters as forbidden fallback lanes.
- Meters spend from provider-reported usage via the Vertex Gemini pricing row, checks the circuit breaker before each call and after each result, and aborts on either over-$50 measured spend or three consecutive billing/quota errors.
- Adds no-spend tests for owner gating, fallback blocking, spend-cap abort, and quota-error abort.

## Verification
- PASS: `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/agentcl.test.ts`
- PASS: `bun run --cwd apps/openagents.com/workers/api typecheck` (exits 0; Effect language-service advisory messages remain in unrelated files)
- FAIL: `bun run --cwd apps/openagents.com/workers/api test` has unrelated existing failures: `worker-exact-routes.test.ts` route manifest drift for `/api/operator/rlm/traces` and `/api/public/artanis/activity`, plus 6 MPP route tests receiving 400 instead of expected 200.

Note: I could not recover the argv behind `command.public.pylon_khala.verify.c3e6eb50a068e673eabdd645` from local Pylon metadata; the relevant focused AgentCL test and worker typecheck above were run.
