### PR TITLE
feat(mirrorcode): show public token attribution proof

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedOut/mirrorcode/runs.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/mirrorcode/runs.ts
@@ -51,11 +51,18 @@ export const MirrorCodeRun = S.Struct({
   status: MirrorCodeRunStatus,
   passRate: MaybeNumber,
   tokensTotal: S.Number,
+  exactTokenUsageEventRefs: S.Array(S.String),
+  tokenAttributionTruth: S.String,
+  tokenAttributionProofRef: S.String,
   startedAt: S.String,
   finishedAt: MaybeString,
   summary: S.String,
   grade: MirrorCodeGrade,
   decisionGrade: S.Boolean,
+  demandKind: S.String,
+  demandSource: S.String,
+  generalizationSet: S.String,
+  memoryPolicy: S.String,
 })
 export type MirrorCodeRun = typeof MirrorCodeRun.Type
 

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/mirrorcode.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/mirrorcode.test.ts
@@ -86,11 +86,19 @@ const response: MirrorCodeRunsResponse = {
       status: 'passed',
       passRate: 1,
       tokensTotal: 12_345_678,
+      exactTokenUsageEventRefs: ['token_usage_event.gym_mirrorcode.leftpad.0001'],
+      tokenAttributionTruth: 'exact_rows_as_proof',
+      tokenAttributionProofRef:
+        'proof.gym.mirrorcode.exact_token_rows.run.mirrorcode.khala.smoke-001',
       startedAt: '2026-06-27T04:00:00.000Z',
       finishedAt: '2026-06-27T04:05:00.000Z',
       summary: 'Reimplemented left-pad from scratch; held-out suite passed.',
       grade: 'smoke',
       decisionGrade: false,
+      demandKind: 'internal',
+      demandSource: 'gym_mirrorcode',
+      generalizationSet: 'mirrorcode_public_tasks_no_rag',
+      memoryPolicy: 'no_rag_public_tasks_only',
     },
     {
       runId: 'run.mirrorcode.khala.smoke-002',
@@ -101,11 +109,19 @@ const response: MirrorCodeRunsResponse = {
       status: 'running',
       passRate: null,
       tokensTotal: 4_200,
+      exactTokenUsageEventRefs: [],
+      tokenAttributionTruth: 'exact_rows_as_proof',
+      tokenAttributionProofRef:
+        'proof.gym.mirrorcode.exact_token_rows.run.mirrorcode.khala.smoke-002',
       startedAt: '2026-06-27T04:30:00.000Z',
       finishedAt: null,
       summary: 'In flight against the JSON parser task.',
       grade: 'smoke',
       decisionGrade: false,
+      demandKind: 'internal',
+      demandSource: 'gym_mirrorcode',
+      generalizationSet: 'mirrorcode_public_tasks_no_rag',
+      memoryPolicy: 'no_rag_public_tasks_only',
     },
   ],
   comparators: [
@@ -170,6 +186,16 @@ describe('public MirrorCode page', () => {
 
     // Smoke runs are labeled Phase-0 smoke, never a frontier number.
     expect(rendered).toContain('Phase-0 smoke')
+
+    // Public proof and attribution fields from the Worker projection are
+    // preserved by the browser schema and rendered on the latest run.
+    expect(rendered).toContain('data-mirrorcode-token-proof')
+    expect(rendered).toContain(
+      'proof.gym.mirrorcode.exact_token_rows.run.mirrorcode.khala.smoke-002',
+    )
+    expect(rendered).toContain('exact rows: none yet')
+    expect(rendered).toContain('internal/gym_mirrorcode')
+    expect(rendered).toContain('mirrorcode_public_tasks_no_rag')
 
     // Leaderboard + comparators tables present.
     expect(rendered).toContain('data-mirrorcode-leaderboard')

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/mirrorcode.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/mirrorcode.ts
@@ -222,6 +222,10 @@ const livePanelError = (error: string): Html =>
 
 const latestRunCard = (run: MirrorCodeRun): Html => {
   const h = html<Message>()
+  const exactTokenRefs =
+    run.exactTokenUsageEventRefs.length === 0
+      ? 'none yet'
+      : run.exactTokenUsageEventRefs.join(', ')
 
   return h.article(
     [
@@ -263,6 +267,29 @@ const latestRunCard = (run: MirrorCodeRun): Html => {
         [
           stat('Started', run.startedAt),
           stat('Finished', run.finishedAt ?? 'in progress'),
+        ],
+      ),
+      h.div(
+        [
+          h.DataAttribute('mirrorcode-token-proof', run.tokenAttributionProofRef),
+          Ui.className<Message>(
+            'grid gap-2 border border-white/10 bg-white/[0.03] p-3 text-[0.78rem] text-white/60',
+          ),
+        ],
+        [
+          h.p(
+            [Ui.className<Message>('m-0 font-semibold uppercase tracking-wide text-white/70')],
+            ['Token proof'],
+          ),
+          h.p([Ui.className<Message>('m-0 break-words')], [
+            `${run.tokenAttributionTruth}: ${run.tokenAttributionProofRef}`,
+          ]),
+          h.p([Ui.className<Message>('m-0 break-words')], [
+            `exact rows: ${exactTokenRefs}`,
+          ]),
+          h.p([Ui.className<Message>('m-0 break-words')], [
+            `demand: ${run.demandKind}/${run.demandSource} · ${run.generalizationSet} · ${run.memoryPolicy}`,
+          ]),
         ],
       ),
       h.p(


### PR DESCRIPTION
Addresses #6376.

### Changes
- Extends the MirrorCode run schema with token attribution, demand source, generalization set, and memory policy fields.
- Renders the latest run token proof, exact token row refs, and attribution metadata on the public MirrorCode page.
- Adds coverage that the browser schema preserves and renders the new public proof fields.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).