### PR TITLE
feat(web): add Artanis Gym MirrorCode route

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/artanisGym.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/artanisGym.ts
@@ -1,0 +1,253 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import { gymOssRouter, mirrorCodeRouter } from '../../../route'
+import * as Ui from '../../../ui'
+import type { Message } from '../message'
+
+type AnchorAttr = Parameters<ReturnType<typeof html<Message>>['a']>[0][number]
+
+type LeaderboardRow = Readonly<{
+  rank: string
+  bucket: string
+  target: string
+  state: string
+  passRate: string
+  tokens: string
+  proof: string
+}>
+
+const mirrorCodeRows: ReadonlyArray<LeaderboardRow> = [
+  {
+    rank: '01',
+    bucket: 'S',
+    target: 'cal',
+    state: 'queued / smoke',
+    passRate: 'pending',
+    tokens: 'exact rows required',
+    proof: 'public run projection',
+  },
+  {
+    rank: '02',
+    bucket: 'M',
+    target: 'gotree',
+    state: 'awaiting owner',
+    passRate: 'not published',
+    tokens: 'exact rows required',
+    proof: 'owner-gated run',
+  },
+  {
+    rank: '03',
+    bucket: 'L',
+    target: 'ruff',
+    state: 'awaiting owner',
+    passRate: 'not published',
+    tokens: 'exact rows required',
+    proof: 'owner-gated run',
+  },
+]
+
+const tabLink = (
+  label: string,
+  href: string,
+  active: boolean,
+  attrs: ReadonlyArray<AnchorAttr> = [],
+): Html => {
+  const h = html<Message>()
+
+  return h.a(
+    [
+      ...attrs,
+      h.Href(href),
+      Ui.className<Message>(
+        active
+          ? 'border border-[#ffb400]/45 bg-[#130e03] px-3 py-2 text-[0.78rem] font-semibold text-[#ffd884]'
+          : 'border border-white/10 bg-black px-3 py-2 text-[0.78rem] font-semibold text-white/60 hover:border-white/20 hover:text-white',
+      ),
+      ...(active ? [h.AriaCurrent('page')] : []),
+    ],
+    [label],
+  )
+}
+
+const metric = (label: string, value: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [Ui.className<Message>('grid gap-1 border border-white/10 bg-black p-3')],
+    [
+      h.span([Ui.className<Message>('text-[0.72rem] text-white/45')], [label]),
+      h.span([Ui.className<Message>('text-sm font-semibold text-white')], [
+        value,
+      ]),
+    ],
+  )
+}
+
+const rowView = (row: LeaderboardRow): Html => {
+  const h = html<Message>()
+  const cell =
+    'border-b border-white/5 px-3 py-2 text-left align-top text-[0.8125rem] text-white/75'
+
+  return h.tr([h.DataAttribute('artanis-gym-mirrorcode-row', row.target)], [
+    h.td([Ui.className<Message>(`${cell} font-semibold text-white/55`)], [
+      row.rank,
+    ]),
+    h.td([Ui.className<Message>(cell)], [row.bucket]),
+    h.td([Ui.className<Message>(`${cell} font-semibold text-white`)], [
+      row.target,
+    ]),
+    h.td([Ui.className<Message>(cell)], [row.state]),
+    h.td([Ui.className<Message>(cell)], [row.passRate]),
+    h.td([Ui.className<Message>(cell)], [row.tokens]),
+    h.td([Ui.className<Message>(cell)], [row.proof]),
+  ])
+}
+
+const mirrorCodeLeaderboard = (): Html => {
+  const h = html<Message>()
+  const head =
+    'border-b border-white/10 px-3 py-2 text-left text-[0.7rem] font-semibold uppercase tracking-wide text-white/40'
+
+  return h.section(
+    [
+      h.DataAttribute('artanis-gym-mirrorcode-tab', ''),
+      Ui.className<Message>(
+        'grid gap-4 border border-white/10 bg-[#050505] p-4',
+      ),
+    ],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'grid gap-2 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start',
+          ),
+        ],
+        [
+          h.div([Ui.className<Message>('grid gap-2')], [
+            h.p(
+              [
+                Ui.className<Message>(
+                  'm-0 font-mono text-[0.78rem] font-semibold uppercase tracking-wide text-white/55',
+                ),
+              ],
+              ['MirrorCode leaderboard'],
+            ),
+            h.h2(
+              [Ui.className<Message>('m-0 text-2xl font-semibold text-white')],
+              ['Public-bucket reproduction ladder'],
+            ),
+            h.p(
+              [
+                Ui.className<Message>(
+                  'm-0 max-w-[78ch] text-sm leading-6 text-white/62',
+                ),
+              ],
+              [
+                'Tracks Khala runs against Epoch Research MirrorCode public tasks. Decision-grade numbers require exact token rows; owner-gated or smoke rows stay labeled instead of becoming leaderboard claims.',
+              ],
+            ),
+          ]),
+          h.div(
+            [
+              h.DataAttribute('artanis-gym-mirrorcode-gate', ''),
+              Ui.className<Message>(
+                'grid gap-1 border border-[#ffb400]/30 bg-[#120d02] p-3 text-[0.78rem] text-[#ffd884]',
+              ),
+            ],
+            [
+              h.span(
+                [Ui.className<Message>('font-semibold uppercase tracking-wide')],
+                ['Gate'],
+              ),
+              h.span([], [
+                'decision-grade requires exact token usage evidence',
+              ]),
+            ],
+          ),
+        ],
+      ),
+      h.div([Ui.className<Message>('grid gap-3 sm:grid-cols-3')], [
+        metric('Benchmark family', 'mirrorcode_public_bucket'),
+        metric('Scope', 'public tasks only'),
+        metric('Demand source', 'gym_mirrorcode'),
+      ]),
+      h.div([Ui.className<Message>('min-w-0 overflow-x-auto')], [
+        h.table(
+          [
+            h.DataAttribute('artanis-gym-mirrorcode-leaderboard', ''),
+            Ui.className<Message>('w-full min-w-[48rem] border-collapse'),
+          ],
+          [
+            h.thead([], [
+              h.tr([], [
+                h.th([Ui.className<Message>(head)], ['Rank']),
+                h.th([Ui.className<Message>(head)], ['Bucket']),
+                h.th([Ui.className<Message>(head)], ['Target']),
+                h.th([Ui.className<Message>(head)], ['State']),
+                h.th([Ui.className<Message>(head)], ['Pass rate']),
+                h.th([Ui.className<Message>(head)], ['Tokens']),
+                h.th([Ui.className<Message>(head)], ['Proof']),
+              ]),
+            ]),
+            h.tbody([], mirrorCodeRows.map(rowView)),
+          ],
+        ),
+      ]),
+      h.div([Ui.className<Message>('flex flex-wrap gap-2')], [
+        h.a(
+          [
+            h.Href(mirrorCodeRouter()),
+            Ui.className<Message>(
+              'border border-white/15 bg-black px-3 py-2 text-[0.78rem] font-semibold text-white/70 hover:border-white/25 hover:text-white',
+            ),
+          ],
+          ['Open public MirrorCode page'],
+        ),
+        h.a(
+          [
+            h.Href('/api/public/gym/leaderboard'),
+            Ui.className<Message>(
+              'border border-white/15 bg-black px-3 py-2 text-[0.78rem] font-semibold text-white/70 hover:border-white/25 hover:text-white',
+            ),
+          ],
+          ['Read ladder JSON'],
+        ),
+      ]),
+    ],
+  )
+}
+
+export const view = (_model: Model): Html => {
+  const h = html<Message>()
+
+  return Ui.container<Message>(
+    [
+      Ui.pageHeader<Message>({
+        eyebrow: 'Artanis / Gym',
+        title: 'Artanis Gym',
+        body: 'Operator view for benchmark surfaces Artanis uses to track Khala progress. Tabs stay evidence-first: public projections, explicit gates, and no private task material.',
+      }),
+      h.nav(
+        [
+          h.AriaLabel('Artanis Gym tabs'),
+          Ui.className<Message>('mt-4 flex flex-wrap gap-2'),
+        ],
+        [
+          tabLink('MirrorCode', '/artanis/gym', true, [
+            h.DataAttribute('artanis-gym-tab', 'mirrorcode'),
+          ]),
+          tabLink('GPT-OSS latency', gymOssRouter(), false, [
+            h.DataAttribute('artanis-gym-tab', 'gpt-oss'),
+          ]),
+        ],
+      ),
+      h.div([Ui.className<Message>('mt-4 grid gap-4')], [
+        mirrorCodeLeaderboard(),
+      ]),
+    ],
+    [Ui.className<Message>('py-4')],
+  )
+}
+
+type Model = import('../model').Model

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
@@ -25,6 +25,7 @@ import { GotLoggedInMessage } from '../../message'
 import { LoggedIn } from '../../model'
 import {
   AdminRoute,
+  ArtanisGymRoute,
   ChatRoute,
   ForgeRoute,
   GymOssRoute,
@@ -1781,6 +1782,23 @@ describe('logged-in workroom sidebar', () => {
       // (The neutral lane label + honest-number assertions are covered in
       // gymOss.test.ts; here we only assert the page+element render.)
       Scene.expect(Scene.selector('oa-gym-oss-controller')).toExist(),
+    )
+  })
+
+  test('renders the Artanis Gym MirrorCode leaderboard tab', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(LoggedIn.init(ArtanisGymRoute(), auth)),
+      Scene.expect(Scene.role('heading', { name: 'Artanis Gym' })).toExist(),
+      Scene.expect(Scene.text('MirrorCode')).toExist(),
+      Scene.expect(
+        Scene.selector('[data-artanis-gym-mirrorcode-tab]'),
+      ).toExist(),
+      Scene.expect(
+        Scene.selector('[data-artanis-gym-mirrorcode-leaderboard]'),
+      ).toExist(),
+      Scene.expect(Scene.text('mirrorcode_public_bucket')).toExist(),
+      Scene.expect(Scene.text('exact rows required')).toExist(),
     )
   })
 

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.ts
@@ -11,6 +11,7 @@ import {
   animationsRouter,
   artanisTraceTreeRouter,
   artanisAccountsRouter,
+  artanisGymRouter,
   autopilotWorkDetailRouter,
   autopilotWorkRouter,
   billingRouter,
@@ -76,6 +77,7 @@ import { type Model, type SidebarModel, teamRouteRef } from './model'
 import * as Mullet from './mullet/view'
 import { notificationsPanel } from './notifications/view'
 import * as Admin from './page/admin'
+import * as ArtanisGym from './page/artanisGym'
 import * as ArtanisDashboard from './artanis-dashboard/view'
 import * as AutopilotWork from './page/autopilot-work'
 import * as Billing from './page/billing'
@@ -136,6 +138,7 @@ const currentHref = (model: Model): string =>
       Animations: () => animationsRouter(),
       Activity: () => activityRouter(),
       ArtanisAccounts: () => artanisAccountsRouter(),
+      ArtanisGym: () => artanisGymRouter(),
       DemoLegal: () => demoLegalRouter(),
       Run: () => runRouter(),
       GymOss: () => gymOssRouter(),
@@ -207,6 +210,7 @@ const routeKey = (model: Model): string =>
       Animations: () => 'Animations',
       Activity: () => 'Activity',
       ArtanisAccounts: () => 'ArtanisAccounts',
+      ArtanisGym: () => 'ArtanisGym',
       DemoLegal: () => 'DemoLegal',
       Run: () => 'Run',
       GymOss: () => 'GymOss',
@@ -581,6 +585,8 @@ const routeView = (model: Model): Html => {
             Ui.workroomScrollableRoute<Message>([
               ArtanisAccounts.view(loggedInPublicHeaderAuthState(model)),
             ]),
+          ArtanisGym: () =>
+            Ui.workroomScrollableRoute<Message>([ArtanisGym.view(model)]),
           DemoLegal: () =>
             Ui.workroomScrollableRoute<Message>([
               notFoundView('/demo/legal', chatRouter(), 'Go to Chat'),

--- a/apps/openagents.com/apps/web/src/product-policy.ts
+++ b/apps/openagents.com/apps/web/src/product-policy.ts
@@ -196,6 +196,7 @@ export const browserRouteProductIntents = {
   ProductPromises: 'public.product-promises',
   PublicAgent: 'public.agent.profile',
   ArtanisTraceTree: 'public.artanis.rlm-traces',
+  ArtanisGym: 'operator.artanis.gym',
   PublicStatsArchive: 'public.stats.archive',
   PublicTrainingRun: 'public.training.run',
   PublicTrainingRuns: 'public.training.runs',

--- a/apps/openagents.com/apps/web/src/route-coverage.test.ts
+++ b/apps/openagents.com/apps/web/src/route-coverage.test.ts
@@ -36,6 +36,7 @@ const PUBLIC_ROUTE_PARSE_COVERAGE: ReadonlyArray<readonly [string, string]> = [
   ['/animations', 'Animations'],
   ['/activity', 'Activity'],
   ['/artanis/accounts', 'ArtanisAccounts'],
+  ['/artanis/gym', 'ArtanisGym'],
   ['/download', 'Download'],
   ['/landing', 'Landing'],
   ['/moksha', 'Moksha'],
@@ -100,9 +101,10 @@ describe('public route parser coverage', () => {
     // visualizer brought the parser-covered surface to 37, the Pylon Codex
     // assignment-status operator shell brought it to 38, the public
     // `/mirrorcode` (MirrorCode, powered by Khala) page brings it to 39, the
-    // public `/chat` Khala chat page brings it to 40, and the
-    // `/artanis/accounts` account-observability grid brings it to 41.
-    expect(PUBLIC_ROUTE_PARSE_COVERAGE.length).toBe(41)
+    // public `/chat` Khala chat page brings it to 40, the
+    // `/artanis/accounts` account-observability grid brings it to 41, and the
+    // `/artanis/gym` operator Gym tab surface brings it to 42.
+    expect(PUBLIC_ROUTE_PARSE_COVERAGE.length).toBe(42)
   })
 
   // The public shareable trace render (#6209) must capture the uuid param so the

--- a/apps/openagents.com/apps/web/src/route-table.ts
+++ b/apps/openagents.com/apps/web/src/route-table.ts
@@ -152,6 +152,7 @@ const THREAD = /^\/t\/[^/]+$/
 const TRAINING_RUNS = /^\/training\/runs(?:\/[^/]+)?$/
 const AGENTS = /^\/agents\/[^/]+$/
 const ARTANIS_TRACES = /^\/artanis\/traces$/
+const ARTANIS_GYM = /^\/artanis\/gym$/
 
 // The full table, keyed by `AppRoute['_tag']`. `route.ts` enforces, at compile
 // time, that these keys are EXACTLY the `AppRoute` tag union (no missing, no
@@ -567,6 +568,16 @@ export const routeTable = {
     inLoggedOutUnion: true,
     inLoggedInUnion: true,
     render: 'statelessShell',
+  },
+  ArtanisGym: {
+    surface: 'spaDocument',
+    serverDocument: ARTANIS_GYM,
+    examplePaths: ['/artanis/gym'],
+    requiresAuthBootstrap: true,
+    loggedInGate: 'admin',
+    inLoggedOutUnion: false,
+    inLoggedInUnion: true,
+    render: 'loggedInOnly',
   },
   Run: {
     surface: 'spaDocument',

--- a/apps/openagents.com/apps/web/src/route.test.ts
+++ b/apps/openagents.com/apps/web/src/route.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
   AdminRoute,
+  ArtanisGymRoute,
   ArtanisTraceTreeRoute,
   ArtanisAccountsRoute,
   type AppRoute,
@@ -195,6 +196,10 @@ describe('app route parser', () => {
 
   test('accepts the owner-gated GPT-OSS Gym latency playground route', () => {
     expect(urlToAppRoute(appUrl('/gym/oss'))).toEqual(GymOssRoute())
+  })
+
+  test('accepts the owner-gated Artanis Gym route', () => {
+    expect(urlToAppRoute(appUrl('/artanis/gym'))).toEqual(ArtanisGymRoute())
   })
 
   test('accepts the public live Tassadar run route', () => {

--- a/apps/openagents.com/apps/web/src/route.ts
+++ b/apps/openagents.com/apps/web/src/route.ts
@@ -71,6 +71,7 @@ export const BusinessRoute = r('Business')
 export const AnimationsRoute = r('Animations')
 export const ActivityRoute = r('Activity')
 export const ArtanisAccountsRoute = r('ArtanisAccounts')
+export const ArtanisGymRoute = r('ArtanisGym')
 export const RunRoute = r('Run')
 export const GymRoute = r('Gym')
 export const GymOssRoute = r('GymOss')
@@ -190,6 +191,7 @@ export type BusinessRoute = typeof BusinessRoute.Type
 export type AnimationsRoute = typeof AnimationsRoute.Type
 export type ActivityRoute = typeof ActivityRoute.Type
 export type ArtanisAccountsRoute = typeof ArtanisAccountsRoute.Type
+export type ArtanisGymRoute = typeof ArtanisGymRoute.Type
 export type RunRoute = typeof RunRoute.Type
 export type GymRoute = typeof GymRoute.Type
 export type GymOssRoute = typeof GymOssRoute.Type
@@ -331,6 +333,7 @@ export const LoggedInRoute = S.Union([
   AnimationsRoute,
   ActivityRoute,
   ArtanisAccountsRoute,
+  ArtanisGymRoute,
   RunRoute,
   GymOssRoute,
   TassadarRoute,
@@ -397,6 +400,7 @@ export const AppRoute = S.Union([
   AnimationsRoute,
   ActivityRoute,
   ArtanisAccountsRoute,
+  ArtanisGymRoute,
   RunRoute,
   GymRoute,
   GymOssRoute,
@@ -641,6 +645,11 @@ export const artanisAccountsRouter = pipe(
   literal('artanis'),
   slash(literal('accounts')),
   Route.mapTo(ArtanisAccountsRoute),
+)
+export const artanisGymRouter = pipe(
+  literal('artanis'),
+  slash(literal('gym')),
+  Route.mapTo(ArtanisGymRoute),
 )
 export const runRouter = pipe(literal('run'), Route.mapTo(RunRoute))
 export const gymRouter = pipe(literal('gym'), Route.mapTo(GymRoute))
@@ -964,6 +973,7 @@ const orderedParserRouters = [
   animationsRouter,
   activityRouter,
   artanisAccountsRouter,
+  artanisGymRouter,
   tassadarReplayRouter,
   tassadarRouter,
   mirrorCodeRouter,

--- a/apps/openagents.com/apps/web/src/routing/startup.ts
+++ b/apps/openagents.com/apps/web/src/routing/startup.ts
@@ -487,6 +487,7 @@ export const startupCompleteDisposition = {
   Gym: 'public',
   MirrorCode: 'public',
   GymOss: 'gated',
+  ArtanisGym: 'gated',
   Tassadar: 'gated',
   TassadarReplay: 'gated',
   Login: 'gated',

--- a/apps/openagents.com/apps/web/src/view.ts
+++ b/apps/openagents.com/apps/web/src/view.ts
@@ -404,6 +404,8 @@ const title = (model: Model): string => {
       return 'Activity - OpenAgents'
     case 'ArtanisAccounts':
       return 'Artanis accounts - OpenAgents'
+    case 'ArtanisGym':
+      return 'Artanis Gym - OpenAgents'
     case 'DemoLegal':
       return 'Legal demo - OpenAgents'
     case 'Run':


### PR DESCRIPTION
Addresses #6672.

### Changes
- Added the owner-gated `/artanis/gym` route to the web route parser, route table, startup routing, product policy intents, and logged-in view dispatch.
- Rendered the Artanis Gym page with a MirrorCode leaderboard tab, including leaderboard data markers for `mirrorcode_public_bucket` and exact-row requirements.
- Added route parser, route coverage, and logged-in scene coverage for the new Artanis Gym surface.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).