### PR TITLE
feat(web): add Artanis operator accounts dashboard

### DIFF
--- a/apps/openagents.com/apps/web/src/page/artanisAccounts.ts
+++ b/apps/openagents.com/apps/web/src/page/artanisAccounts.ts
@@ -1,193 +1,651 @@
-import { Array } from 'effect'
-import type { Html } from 'foldkit/html'
+import { define as defineCustomElement } from 'foldkit/customElement'
+import type { Attribute, Html } from 'foldkit/html'
 import { html } from 'foldkit/html'
 
 import * as Ui from '../ui'
 import type { PublicHeaderAuthState } from './publicHeader'
 import * as PublicHeader from './publicHeader'
 
-type AccountStatus = 'ready' | 'cooldown' | 'needs_attention'
+type AccountUsageWindow = Readonly<{
+  cap: number | null
+  label: 'hourly' | 'weekly'
+  percentUsed: number
+  remaining: number | null
+  used: number | null
+}>
 
-type AccountGridRow = {
-  readonly ref: string
-  readonly provider: string
-  readonly status: AccountStatus
-  readonly activeSlots: number
-  readonly queuedTurns: number
-  readonly resetWindow: string
-  readonly evidence: string
+type AccountStatusEntry = Readonly<{
+  accountRefHash: string
+  cooldownExpiresAt: string | null
+  isRateLimited: boolean
+  manualResetsRemaining: number | null
+  provider: string
+  windows: ReadonlyArray<AccountUsageWindow>
+}>
+
+type AccountsStatusResponse = Readonly<{
+  accounts: ReadonlyArray<AccountStatusEntry>
+  observedAt: string
+}>
+
+type DashboardState =
+  | Readonly<{ tag: 'loading' }>
+  | Readonly<{ tag: 'unauthorized'; status: number }>
+  | Readonly<{ tag: 'failed'; message: string }>
+  | Readonly<{
+      tag: 'loaded'
+      response: AccountsStatusResponse
+      resettingAccountRefHash: string | null
+    }>
+
+const dashboardTagName = 'oa-artanis-accounts-dashboard'
+
+const dashboardElement = defineCustomElement({
+  events: {},
+  properties: {},
+  tag: dashboardTagName,
+})
+
+const numberFormatter = new Intl.NumberFormat('en-US')
+
+const formatNumber = (value: number | null): string =>
+  value === null ? '-' : numberFormatter.format(value)
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+const labelForProvider = (provider: string): string =>
+  provider === 'codex'
+    ? 'Codex'
+    : provider === 'claude'
+      ? 'Claude'
+      : provider
+
+const shortAccountRef = (ref: string): string =>
+  ref.length <= 18 ? ref : `${ref.slice(0, 14)}...${ref.slice(-4)}`
+
+const countdownLabel = (expiresAt: string | null, now = Date.now()): string => {
+  if (expiresAt === null) {
+    return 'available'
+  }
+
+  const remainingMs = new Date(expiresAt).getTime() - now
+
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+    return 'ready now'
+  }
+
+  const totalSeconds = Math.ceil(remainingMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
 }
 
-const rows: ReadonlyArray<AccountGridRow> = [
-  {
-    ref: 'codex-1',
-    provider: 'Codex',
-    status: 'ready',
-    activeSlots: 1,
-    queuedTurns: 0,
-    resetWindow: '< 1m',
-    evidence: 'quota-ledger + heartbeat',
-  },
-  {
-    ref: 'codex-2',
-    provider: 'Codex',
-    status: 'cooldown',
-    activeSlots: 0,
-    queuedTurns: 2,
-    resetWindow: '18m',
-    evidence: 'rate-limit header observed',
-  },
-  {
-    ref: 'claude-1',
-    provider: 'Claude',
-    status: 'ready',
-    activeSlots: 2,
-    queuedTurns: 1,
-    resetWindow: '< 1m',
-    evidence: 'local session refreshed',
-  },
-  {
-    ref: 'codex-3',
-    provider: 'Codex',
-    status: 'needs_attention',
-    activeSlots: 0,
-    queuedTurns: 0,
-    resetWindow: 'manual',
-    evidence: 'credentials-missing blocker',
-  },
-]
+const responseIsAccountsStatus = (
+  value: unknown,
+): value is AccountsStatusResponse => {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
 
-const statusLabel = (status: AccountStatus): string =>
-  status === 'ready'
-    ? 'Ready'
-    : status === 'cooldown'
-      ? 'Cooldown'
-      : 'Needs attention'
-
-const statusClass = (status: AccountStatus): string =>
-  status === 'ready'
-    ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200'
-    : status === 'cooldown'
-      ? 'border-amber-400/30 bg-amber-400/10 text-amber-200'
-      : 'border-red-400/30 bg-red-400/10 text-red-200'
-
-const metric = <Message>(label: string, value: string): Html => {
-  const h = html<Message>()
-
-  return h.div(
-    [
-      Ui.className<Message>(
-        'grid min-h-16 content-between border border-white/10 bg-[#050505] p-3',
-      ),
-    ],
-    [
-      h.div([Ui.className<Message>('text-[0.68rem] uppercase text-white/45')], [
-        label,
-      ]),
-      h.div(
-        [
-          Ui.className<Message>(
-            'text-xl font-semibold tabular-nums text-[#f1efe8]',
-          ),
-        ],
-        [value],
-      ),
-    ],
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.observedAt === 'string' &&
+    Array.isArray(candidate.accounts)
   )
 }
 
-const rowView = <Message>(row: AccountGridRow): Html => {
-  const h = html<Message>()
+const resetResponseStatus = (value: unknown): AccountsStatusResponse | null => {
+  if (typeof value !== 'object' || value === null) {
+    return null
+  }
 
-  return h.div(
-    [
-      h.Role('row'),
-      Ui.className<Message>(
-        'grid grid-cols-1 gap-3 border-t border-white/10 px-4 py-4 text-sm text-white/70 md:grid-cols-[minmax(8rem,1fr)_minmax(6rem,0.8fr)_minmax(8rem,0.9fr)_minmax(7rem,0.8fr)_minmax(7rem,0.8fr)_minmax(10rem,1fr)] md:items-center',
-      ),
-    ],
-    [
-      h.div(
-        [h.Role('cell'), Ui.className<Message>('min-w-0')],
-        [
-          h.div(
-            [Ui.className<Message>('truncate font-semibold text-[#f1efe8]')],
-            [row.ref],
-          ),
-          h.div([Ui.className<Message>('text-xs text-white/40')], [
-            'public-safe ref',
-          ]),
-        ],
-      ),
-      h.div([h.Role('cell')], [row.provider]),
-      h.div(
-        [h.Role('cell')],
-        [
-          h.span(
-            [
-              Ui.className<Message>(
-                `inline-flex min-h-7 items-center rounded border px-2 text-xs font-semibold ${statusClass(row.status)}`,
-              ),
-            ],
-            [statusLabel(row.status)],
-          ),
-        ],
-      ),
-      h.div([h.Role('cell'), Ui.className<Message>('tabular-nums')], [
-        String(row.activeSlots),
-      ]),
-      h.div([h.Role('cell'), Ui.className<Message>('tabular-nums')], [
-        String(row.queuedTurns),
-      ]),
-      h.div([h.Role('cell'), Ui.className<Message>('min-w-0')], [
-        h.div([Ui.className<Message>('truncate text-[#f1efe8]')], [
-          row.resetWindow,
+  const status = (value as Record<string, unknown>).status
+  return responseIsAccountsStatus(status) ? status : null
+}
+
+const dashboardCss = `
+:host {
+  display: block;
+  color: #f1efe8;
+  font-family: 'Berkeley Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+* { box-sizing: border-box; }
+.shell { display: grid; gap: 1rem; }
+.summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+.metric {
+  min-height: 5rem;
+  display: grid;
+  align-content: space-between;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #050505;
+  padding: 0.75rem;
+}
+.metric-label {
+  color: rgba(255, 255, 255, 0.46);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+.metric-value {
+  color: #f1efe8;
+  font-size: 1.35rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.toolbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #010102;
+  padding: 0.875rem;
+}
+.toolbar-title {
+  margin: 0;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+.toolbar-detail {
+  margin: 0.25rem 0 0;
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 0.76rem;
+}
+.refresh,
+.reset {
+  min-height: 2.25rem;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+.refresh {
+  border: 1px solid rgba(255, 180, 0, 0.45);
+  background: rgba(255, 180, 0, 0.12);
+  color: #ffe0a3;
+  padding: 0 0.75rem;
+}
+.refresh:hover { background: rgba(255, 180, 0, 0.18); }
+.refresh:focus-visible,
+.reset:focus-visible {
+  outline: 2px solid #ffb400;
+  outline-offset: 2px;
+}
+.grid {
+  display: grid;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #010102;
+}
+.header,
+.row {
+  display: grid;
+  grid-template-columns: minmax(9rem, 1.15fr) minmax(5rem, 0.55fr) minmax(8rem, 0.8fr) minmax(13rem, 1.1fr) minmax(13rem, 1.1fr) minmax(9rem, 0.85fr);
+  gap: 0.75rem;
+  align-items: center;
+}
+.header {
+  padding: 0.75rem 1rem;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+.row {
+  min-height: 7.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1rem;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 0.78rem;
+}
+.account { min-width: 0; display: grid; gap: 0.35rem; }
+.account-ref {
+  overflow-wrap: anywhere;
+  color: #f1efe8;
+  font-weight: 700;
+}
+.account-full {
+  color: rgba(255, 255, 255, 0.36);
+  font-size: 0.68rem;
+}
+.status {
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid rgba(0, 200, 83, 0.35);
+  background: rgba(0, 200, 83, 0.12);
+  color: #a8f5c2;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+.status::before {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: #00c853;
+  content: '';
+}
+.status.limited {
+  border-color: rgba(211, 47, 47, 0.45);
+  background: rgba(211, 47, 47, 0.13);
+  color: #ffb4b4;
+}
+.status.limited::before { background: #d32f2f; }
+.window { display: grid; gap: 0.45rem; }
+.window-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.56);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+.bar {
+  height: 0.5rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #000000;
+}
+.fill {
+  height: 100%;
+  width: var(--fill);
+  background: #2979ff;
+  transition: width 180ms ease-out;
+}
+.fill.warn { background: #ff6f00; }
+.usage {
+  color: rgba(255, 255, 255, 0.46);
+  font-size: 0.68rem;
+}
+.reset-cell { display: grid; gap: 0.5rem; }
+.reset {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: #0b0b0b;
+  color: #f1efe8;
+  padding: 0 0.65rem;
+}
+.reset:hover:not(:disabled) { background: #141414; }
+.reset:disabled {
+  cursor: not-allowed;
+  color: rgba(255, 255, 255, 0.36);
+}
+.reset-detail {
+  color: rgba(255, 255, 255, 0.42);
+  font-size: 0.68rem;
+}
+.state {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #050505;
+  padding: 1rem;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+.state strong { color: #f1efe8; }
+@media (max-width: 980px) {
+  .summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .header { display: none; }
+  .row { grid-template-columns: 1fr; }
+}
+@media (max-width: 560px) {
+  .summary { grid-template-columns: 1fr; }
+  .toolbar { display: grid; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fill { transition: none; }
+}
+`
+
+const statusSummary = (accounts: ReadonlyArray<AccountStatusEntry>) => {
+  const limited = accounts.filter(account => account.isRateLimited).length
+  const available = accounts.length - limited
+  const manualResets = accounts.reduce(
+    (total, account) => total + (account.manualResetsRemaining ?? 0),
+    0,
+  )
+  const knownWindows = accounts.flatMap(account => account.windows)
+  const averageUsage =
+    knownWindows.length === 0
+      ? 0
+      : Math.round(
+          knownWindows.reduce(
+            (total, window) => total + window.percentUsed,
+            0,
+          ) / knownWindows.length,
+        )
+
+  return { available, averageUsage, limited, manualResets }
+}
+
+const renderWindow = (
+  entry: AccountStatusEntry,
+  window: AccountUsageWindow,
+): string => {
+  const percent = Math.max(0, Math.min(100, window.percentUsed))
+  const fillClass = percent >= 80 ? 'fill warn' : 'fill'
+  const usage =
+    window.cap === null
+      ? 'No cap reported'
+      : `${formatNumber(window.used)} / ${formatNumber(window.cap)} used, ${formatNumber(window.remaining)} left`
+
+  return `
+    <div class="window">
+      <div class="window-head">
+        <span>${window.label}</span>
+        <span>${percent}%</span>
+      </div>
+      <div class="bar" role="meter" aria-label="${escapeHtml(entry.provider)} ${window.label} token usage ${percent}%" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${percent}">
+        <div class="${fillClass}" style="--fill: ${percent}%"></div>
+      </div>
+      <div class="usage">${usage}</div>
+    </div>
+  `
+}
+
+const renderRow = (
+  entry: AccountStatusEntry,
+  resettingAccountRefHash: string | null,
+): string => {
+  const resetCount =
+    entry.manualResetsRemaining === null
+      ? 'N'
+      : String(entry.manualResetsRemaining)
+  const resetDisabled =
+    resettingAccountRefHash === entry.accountRefHash ||
+    entry.manualResetsRemaining === 0
+  const resetLabel =
+    resettingAccountRefHash === entry.accountRefHash
+      ? 'Resetting'
+      : `Manual Reset (${resetCount} left)`
+  const statusClass = entry.isRateLimited ? 'status limited' : 'status'
+  const statusText = entry.isRateLimited ? 'rate-limited' : 'available'
+  const accountRefHash = escapeHtml(entry.accountRefHash)
+  const provider = escapeHtml(labelForProvider(entry.provider))
+
+  return `
+    <div class="row" role="row" data-account-ref="${accountRefHash}">
+      <div class="account" role="cell">
+        <div class="account-ref">${escapeHtml(shortAccountRef(entry.accountRefHash))}</div>
+        <div class="account-full">${accountRefHash}</div>
+      </div>
+      <div role="cell">${provider}</div>
+      <div role="cell">
+        <span class="${statusClass}"><span>${statusText}</span></span>
+      </div>
+      ${entry.windows.map(window => `<div role="cell">${renderWindow(entry, window)}</div>`).join('')}
+      <div class="reset-cell" role="cell">
+        <button class="reset" type="button" data-reset-account="${accountRefHash}" ${resetDisabled ? 'disabled' : ''}>${resetLabel}</button>
+        <div class="reset-detail" data-countdown-for="${accountRefHash}">${entry.isRateLimited ? countdownLabel(entry.cooldownExpiresAt) : 'available'}</div>
+      </div>
+    </div>
+  `
+}
+
+const renderLoaded = (
+  response: AccountsStatusResponse,
+  resettingAccountRefHash: string | null,
+): string => {
+  const summary = statusSummary(response.accounts)
+
+  return `
+    <div class="shell">
+      <div class="summary" aria-label="Account summary">
+        <div class="metric"><div class="metric-label">accounts</div><div class="metric-value">${response.accounts.length} / 9</div></div>
+        <div class="metric"><div class="metric-label">available</div><div class="metric-value">${summary.available}</div></div>
+        <div class="metric"><div class="metric-label">rate-limited</div><div class="metric-value">${summary.limited}</div></div>
+        <div class="metric"><div class="metric-label">manual resets</div><div class="metric-value">${summary.manualResets}</div></div>
+      </div>
+      <div class="toolbar">
+        <div>
+          <h2 class="toolbar-title">Account status</h2>
+          <p class="toolbar-detail">Observed ${escapeHtml(response.observedAt)}. Average usage ${summary.averageUsage}%.</p>
+        </div>
+        <button class="refresh" type="button" data-refresh>Refresh</button>
+      </div>
+      <div class="grid" role="table" aria-label="Operator account status">
+        <div class="header" role="row">
+          <div role="columnheader">Account</div>
+          <div role="columnheader">Provider</div>
+          <div role="columnheader">State</div>
+          <div role="columnheader">Hourly</div>
+          <div role="columnheader">Weekly</div>
+          <div role="columnheader">Reset</div>
+        </div>
+        ${response.accounts.length === 0 ? '<div class="state">No operator account rows are available.</div>' : response.accounts.map(entry => renderRow(entry, resettingAccountRefHash)).join('')}
+      </div>
+    </div>
+  `
+}
+
+const renderState = (state: DashboardState): string => {
+  if (state.tag === 'loading') {
+    return '<div class="state"><strong>Loading account status.</strong></div>'
+  }
+
+  if (state.tag === 'unauthorized') {
+    return `<div class="state"><strong>Unauthorized.</strong> This owner-only account dashboard is not available for the current session. (${state.status})</div>`
+  }
+
+  if (state.tag === 'failed') {
+    return `<div class="state"><strong>Status unavailable.</strong> ${escapeHtml(state.message)}</div>`
+  }
+
+  return renderLoaded(state.response, state.resettingAccountRefHash)
+}
+
+const makeDashboardElement = (): CustomElementConstructor =>
+  class ArtanisAccountsDashboardElement extends HTMLElement {
+    #state: DashboardState = { tag: 'loading' }
+    #timer: number | null = null
+
+    connectedCallback(): void {
+      const shadow = this.shadowRoot ?? this.attachShadow({ mode: 'open' })
+
+      if (shadow.childNodes.length === 0) {
+        const style = document.createElement('style')
+        style.textContent = dashboardCss
+        const root = document.createElement('div')
+        root.setAttribute('data-root', '')
+        shadow.append(style, root)
+      }
+
+      this.#render()
+      void this.#load()
+      this.#timer = window.setInterval(() => this.#updateCountdowns(), 1000)
+    }
+
+    disconnectedCallback(): void {
+      if (this.#timer !== null) {
+        window.clearInterval(this.#timer)
+        this.#timer = null
+      }
+    }
+
+    async #load(): Promise<void> {
+      this.#state = { tag: 'loading' }
+      this.#render()
+
+      try {
+        const response = await fetch('/api/operator/accounts/status', {
+          cache: 'no-store',
+          credentials: 'include',
+          headers: { accept: 'application/json' },
+        })
+
+        if (response.status === 401 || response.status === 403) {
+          this.#state = { tag: 'unauthorized', status: response.status }
+          this.#render()
+          return
+        }
+
+        if (!response.ok) {
+          this.#state = {
+            message: `GET /api/operator/accounts/status returned ${response.status}.`,
+            tag: 'failed',
+          }
+          this.#render()
+          return
+        }
+
+        const body = await response.json()
+        this.#state = responseIsAccountsStatus(body)
+          ? { response: body, resettingAccountRefHash: null, tag: 'loaded' }
+          : {
+              message: 'The status payload did not match the account schema.',
+              tag: 'failed',
+            }
+        this.#render()
+      } catch (error) {
+        this.#state = {
+          message:
+            error instanceof Error ? error.message : 'Unknown fetch error.',
+          tag: 'failed',
+        }
+        this.#render()
+      }
+    }
+
+    async #reset(accountRefHash: string): Promise<void> {
+      if (this.#state.tag !== 'loaded') {
+        return
+      }
+
+      this.#state = {
+        response: this.#state.response,
+        resettingAccountRefHash: accountRefHash,
+        tag: 'loaded',
+      }
+      this.#render()
+
+      try {
+        const response = await fetch('/api/operator/accounts/reset', {
+          body: JSON.stringify({ accountRefHash }),
+          cache: 'no-store',
+          credentials: 'include',
+          headers: {
+            accept: 'application/json',
+            'content-type': 'application/json',
+          },
+          method: 'POST',
+        })
+
+        if (response.status === 401 || response.status === 403) {
+          this.#state = { tag: 'unauthorized', status: response.status }
+          this.#render()
+          return
+        }
+
+        if (!response.ok) {
+          this.#state = {
+            message: `POST /api/operator/accounts/reset returned ${response.status}.`,
+            tag: 'failed',
+          }
+          this.#render()
+          return
+        }
+
+        const status = resetResponseStatus(await response.json())
+        this.#state =
+          status === null
+            ? {
+                message: 'The reset payload did not include refreshed status.',
+                tag: 'failed',
+              }
+            : { response: status, resettingAccountRefHash: null, tag: 'loaded' }
+        this.#render()
+      } catch (error) {
+        this.#state = {
+          message:
+            error instanceof Error ? error.message : 'Unknown reset error.',
+          tag: 'failed',
+        }
+        this.#render()
+      }
+    }
+
+    #render(): void {
+      const root = this.shadowRoot?.querySelector('[data-root]')
+
+      if (!(root instanceof HTMLElement)) {
+        return
+      }
+
+      root.innerHTML = renderState(this.#state)
+      root
+        .querySelector('[data-refresh]')
+        ?.addEventListener('click', () => void this.#load())
+      root.querySelectorAll('[data-reset-account]').forEach(button => {
+        button.addEventListener('click', () => {
+          const accountRefHash = button.getAttribute('data-reset-account')
+
+          if (accountRefHash !== null) {
+            void this.#reset(accountRefHash)
+          }
+        })
+      })
+      this.#updateCountdowns()
+    }
+
+    #updateCountdowns(): void {
+      if (this.#state.tag !== 'loaded') {
+        return
+      }
+
+      const accounts = new Map(
+        this.#state.response.accounts.map(account => [
+          account.accountRefHash,
+          account,
         ]),
-        h.div([Ui.className<Message>('truncate text-xs text-white/40')], [
-          row.evidence,
-        ]),
-      ]),
-    ],
-  )
+      )
+
+      this.shadowRoot
+        ?.querySelectorAll('[data-countdown-for]')
+        .forEach(countdown => {
+          const accountRefHash = countdown.getAttribute('data-countdown-for')
+          const account =
+            accountRefHash === null ? undefined : accounts.get(accountRefHash)
+
+          if (account !== undefined) {
+            countdown.textContent = account.isRateLimited
+              ? countdownLabel(account.cooldownExpiresAt)
+              : 'available'
+          }
+        })
+    }
+  }
+
+const registerDashboardElement = (): void => {
+  if (typeof customElements === 'undefined') {
+    return
+  }
+
+  if (typeof HTMLElement === 'undefined') {
+    return
+  }
+
+  if (customElements.get(dashboardTagName) !== undefined) {
+    return
+  }
+
+  customElements.define(dashboardTagName, makeDashboardElement())
 }
 
-const headerCell = <Message>(label: string): Html => {
-  const h = html<Message>()
-
-  return h.div(
-    [h.Role('columnheader'), Ui.className<Message>('text-white/45')],
-    [label],
-  )
-}
-
-const gridView = <Message>(): Html => {
-  const h = html<Message>()
-
-  return h.section(
-    [
-      h.AriaLabel('Per-account rate-limit observability grid'),
-      Ui.className<Message>('border border-white/10 bg-[#010102]'),
-    ],
-    [
-      h.div(
-        [
-          h.Role('row'),
-          Ui.className<Message>(
-            'hidden grid-cols-[minmax(8rem,1fr)_minmax(6rem,0.8fr)_minmax(8rem,0.9fr)_minmax(7rem,0.8fr)_minmax(7rem,0.8fr)_minmax(10rem,1fr)] gap-3 px-4 py-3 text-[0.68rem] uppercase md:grid',
-          ),
-        ],
-        [
-          headerCell<Message>('Account'),
-          headerCell<Message>('Provider'),
-          headerCell<Message>('State'),
-          headerCell<Message>('Active'),
-          headerCell<Message>('Queued'),
-          headerCell<Message>('Reset / evidence'),
-        ],
-      ),
-      h.div([h.Role('rowgroup')], Array.map(rows, rowView<Message>)),
-    ],
-  )
+const dashboardView = <Message>(
+  attributes: ReadonlyArray<Attribute<Message>> = [],
+): Html => {
+  registerDashboardElement()
+  return dashboardElement.withMessage<Message>()(attributes, [])
 }
 
 export const view = <Message>(
@@ -202,7 +660,7 @@ export const view = <Message>(
       h.main(
         [
           Ui.className<Message>(
-            'mx-auto grid w-[min(100%,1120px)] gap-6 px-4 py-8 sm:px-6 lg:px-8',
+            'mx-auto grid w-[min(100%,1180px)] gap-6 px-4 py-8 sm:px-6 lg:px-8',
           ),
         ],
         [
@@ -223,7 +681,7 @@ export const view = <Message>(
                     'm-0 text-2xl font-semibold tracking-normal text-[#f1efe8] sm:text-3xl',
                   ),
                 ],
-                ['Per-account rate-limit grid'],
+                ['Operator account observability'],
               ),
               h.p(
                 [
@@ -232,23 +690,14 @@ export const view = <Message>(
                   ),
                 ],
                 [
-                  'Public-safe operator view for connected coding accounts. Rows expose refs, readiness, queue pressure, reset hints, and evidence labels only.',
+                  'Owner-only status for Codex and Claude coding accounts: live cooldowns, usage windows, and manual reset controls.',
                 ],
               ),
             ],
           ),
-          h.section(
-            [
-              h.AriaLabel('Account grid summary'),
-              Ui.className<Message>('grid gap-3 sm:grid-cols-3'),
-            ],
-            [
-              metric<Message>('ready accounts', '2'),
-              metric<Message>('active slots', '3'),
-              metric<Message>('queued turns', '3'),
-            ],
-          ),
-          gridView<Message>(),
+          dashboardView<Message>([
+            h.AriaLabel('Operator account observability dashboard'),
+          ]),
           h.p(
             [
               Ui.className<Message>(
@@ -256,7 +705,7 @@ export const view = <Message>(
               ),
             ],
             [
-              'This surface is evidence-only. It does not grant dispatch, spend, settlement, provider-account mutation, or cross-owner routing authority.',
+              'This surface is operator evidence and control only. It does not grant dispatch, spend, settlement, provider-account ownership transfer, or cross-owner routing authority.',
             ],
           ),
         ],

--- a/apps/openagents.com/workers/api/src/artanis-operator-dashboard-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dashboard-routes.test.ts
@@ -32,6 +32,15 @@ type MessageRow = Readonly<{
   created_at: string
 }>
 
+type AccountRow = {
+  provider_account_ref: string
+  provider: string
+  cooldown_until: string | null
+  recent_failure_class: string | null
+  user_id: string
+  deleted_at: string | null
+}
+
 const threads: ReadonlyArray<ThreadRow> = [
   {
     caller_id: 'github:14167547',
@@ -91,17 +100,70 @@ const messages: ReadonlyArray<MessageRow> = [
   },
 ]
 
-const makeFakeD1 = (): D1Database =>
+const accountRows = (): Array<AccountRow> => [
+  {
+    cooldown_until: '2099-01-01T00:00:00.000Z',
+    deleted_at: null,
+    provider: 'chatgpt_codex',
+    provider_account_ref: 'acct_hash_codex_1',
+    recent_failure_class: 'rate_limited',
+    user_id: 'github:operator',
+  },
+  {
+    cooldown_until: null,
+    deleted_at: null,
+    provider: 'claude',
+    provider_account_ref: 'acct_hash_claude_1',
+    recent_failure_class: null,
+    user_id: 'github:operator',
+  },
+  {
+    cooldown_until: '2099-01-01T00:00:00.000Z',
+    deleted_at: null,
+    provider: 'chatgpt_codex',
+    provider_account_ref: 'acct_hash_other',
+    recent_failure_class: 'rate_limited',
+    user_id: 'github:other',
+  },
+]
+
+const makeFakeD1 = (accounts: Array<AccountRow> = accountRows()): D1Database =>
   ({
     prepare: (sql: string) => ({
       bind: (...values: ReadonlyArray<unknown>) => ({
-        all: async () => query(sql, values),
+        all: async () => query(sql, values, accounts),
+        run: async () => run(sql, values, accounts),
       }),
-      all: async () => query(sql, []),
+      all: async () => query(sql, [], accounts),
     }),
   }) as unknown as D1Database
 
-const query = (sql: string, values: ReadonlyArray<unknown>) => {
+const query = (
+  sql: string,
+  values: ReadonlyArray<unknown>,
+  accounts: Array<AccountRow>,
+) => {
+  if (sql.includes('FROM provider_accounts')) {
+    const userId = typeof values[0] === 'string' ? values[0] : ''
+
+    return {
+      results: accounts
+        .filter(
+          account =>
+            account.user_id === userId &&
+            account.deleted_at === null &&
+            (account.provider === 'chatgpt_codex' ||
+              account.provider === 'claude'),
+        )
+        .map(account => ({
+          cooldown_until: account.cooldown_until,
+          provider: account.provider,
+          provider_account_ref: account.provider_account_ref,
+          recent_failure_class: account.recent_failure_class,
+        })),
+    }
+  }
+
   if (sql.includes('FROM artanis_threads')) {
     const callerId = typeof values[0] === 'string' ? values[0] : undefined
     const rows = threads
@@ -123,6 +185,33 @@ const query = (sql: string, values: ReadonlyArray<unknown>) => {
   return {
     results: messages.filter(message => message.thread_ref === threadRef),
   }
+}
+
+const run = (
+  sql: string,
+  values: ReadonlyArray<unknown>,
+  accounts: Array<AccountRow>,
+) => {
+  if (sql.includes('UPDATE provider_accounts')) {
+    const [, userId, accountRefHash] = values as [string, string, string]
+    const account = accounts.find(
+      candidate =>
+        candidate.user_id === userId &&
+        candidate.provider_account_ref === accountRefHash &&
+        candidate.deleted_at === null,
+    )
+
+    if (account === undefined) {
+      return { meta: { changes: 0 }, success: true }
+    }
+
+    account.cooldown_until = null
+    account.recent_failure_class = null
+
+    return { meta: { changes: 1 }, success: true }
+  }
+
+  return { meta: { changes: 0 }, success: true }
 }
 
 const route = (options: {
@@ -232,6 +321,73 @@ describe('Artanis operator dashboard routes', () => {
           title: 'Claude needs steering',
         },
       ],
+    })
+  })
+
+  test('serves owner-only account status rows for the Artanis accounts page', async () => {
+    const response = await Effect.runPromise(
+      route({ browserEmail: 'chris@openagents.com' })(
+        request('/api/operator/accounts/status'),
+        { OPENAGENTS_DB: makeFakeD1() },
+        executionContext,
+      )!,
+    )
+    const body = await response.json() as Record<string, unknown>
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      accounts: [
+        {
+          accountRefHash: 'acct_hash_codex_1',
+          cooldownExpiresAt: '2099-01-01T00:00:00.000Z',
+          isRateLimited: true,
+          provider: 'codex',
+        },
+        {
+          accountRefHash: 'acct_hash_claude_1',
+          cooldownExpiresAt: null,
+          isRateLimited: false,
+          provider: 'claude',
+        },
+      ],
+    })
+  })
+
+  test('manual reset clears the selected owner account cooldown', async () => {
+    const accounts = accountRows()
+    const response = await Effect.runPromise(
+      route({ browserEmail: 'chris@openagents.com' })(
+        new Request('https://openagents.com/api/operator/accounts/reset', {
+          body: JSON.stringify({ accountRefHash: 'acct_hash_codex_1' }),
+          headers: { authorization: 'Bearer admin' },
+          method: 'POST',
+        }),
+        { OPENAGENTS_DB: makeFakeD1(accounts) },
+        executionContext,
+      )!,
+    )
+    const body = await response.json() as Record<string, unknown>
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      status: {
+        accounts: expect.arrayContaining([
+          expect.objectContaining({
+            accountRefHash: 'acct_hash_codex_1',
+            cooldownExpiresAt: null,
+            isRateLimited: false,
+          }),
+        ]),
+      },
+    })
+    expect(accounts[0]).toMatchObject({
+      cooldown_until: null,
+      recent_failure_class: null,
+    })
+    expect(accounts[2]).toMatchObject({
+      cooldown_until: '2099-01-01T00:00:00.000Z',
+      recent_failure_class: 'rate_limited',
     })
   })
 

--- a/apps/openagents.com/workers/api/src/artanis-operator-dashboard-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dashboard-routes.ts
@@ -99,6 +99,13 @@ type OperatorAccountUsageRow = Readonly<{
   manualResetsRemaining: number | null
 }>
 
+type OperatorAccountStatusRow = Readonly<{
+  provider_account_ref: string
+  provider: string
+  cooldown_until: string | null
+  recent_failure_class: string | null
+}>
+
 const boundedPercent = (usage: number | null, cap: number | null): number => {
   if (usage === null || cap === null || cap <= 0) {
     return 0
@@ -232,6 +239,32 @@ const messageProjection = (row: ArtanisMessageRow) => ({
   threadRef: row.thread_ref,
 })
 
+const normalizeAccountProvider = (provider: string): string =>
+  provider === 'chatgpt_codex' ? 'codex' : provider
+
+const statusRowToUsageRow = (
+  row: OperatorAccountStatusRow,
+  now: string,
+): OperatorAccountUsageRow => {
+  const cooldownExpiresAt =
+    row.cooldown_until !== null && row.cooldown_until > now
+      ? row.cooldown_until
+      : null
+
+  return {
+    accountRefHash: row.provider_account_ref,
+    cooldownExpiresAt,
+    hourlyCap: null,
+    hourlyUsage: null,
+    isRateLimited:
+      cooldownExpiresAt !== null || row.recent_failure_class === 'rate_limited',
+    manualResetsRemaining: null,
+    provider: normalizeAccountProvider(row.provider),
+    weeklyCap: null,
+    weeklyUsage: null,
+  }
+}
+
 const listThreads = (
   db: D1Database,
   callerId: string | undefined,
@@ -287,6 +320,77 @@ const listMessages = (
     .then(rows => rows.results ?? [])
 }
 
+const listOperatorAccountStatusRows = (
+  db: D1Database,
+  userId: string,
+): Promise<ReadonlyArray<OperatorAccountStatusRow>> =>
+  db
+    .prepare(
+      `SELECT provider_account_ref,
+              provider,
+              cooldown_until,
+              recent_failure_class
+         FROM provider_accounts
+        WHERE user_id = ?
+          AND deleted_at IS NULL
+          AND provider IN ('chatgpt_codex', 'claude')
+        ORDER BY
+          CASE provider WHEN 'chatgpt_codex' THEN 0 ELSE 1 END,
+          provider_account_ref ASC
+        LIMIT 200`,
+    )
+    .bind(userId)
+    .all<OperatorAccountStatusRow>()
+    .then(rows => rows.results ?? [])
+
+const operatorAccountStatusProjection = (
+  rows: ReadonlyArray<OperatorAccountStatusRow>,
+  observedAt: string,
+) =>
+  operatorAccountUsageProjection(
+    rows.map(row => statusRowToUsageRow(row, observedAt)),
+    observedAt,
+  )
+
+const readAccountRefHash = (request: Request): Promise<string | undefined> =>
+  request
+    .json()
+    .then(value => {
+      if (typeof value !== 'object' || value === null) {
+        return undefined
+      }
+
+      const raw = (value as Record<string, unknown>).accountRefHash
+      return typeof raw === 'string' && raw.trim() !== ''
+        ? raw.trim()
+        : undefined
+    })
+    .catch(() => undefined)
+
+const resetOperatorAccountCooldown = async (
+  db: D1Database,
+  input: Readonly<{
+    accountRefHash: string
+    now: string
+    userId: string
+  }>,
+): Promise<boolean> => {
+  const result = await db
+    .prepare(
+      `UPDATE provider_accounts
+          SET cooldown_until = NULL,
+              recent_failure_class = NULL,
+              last_failed_launch_at = ?
+        WHERE user_id = ?
+          AND provider_account_ref = ?
+          AND deleted_at IS NULL`,
+    )
+    .bind(input.now, input.userId, input.accountRefHash)
+    .run()
+
+  return (result.meta?.changes ?? 0) > 0
+}
+
 export const makeOperatorArtanisDashboardRoutes = <
   Session extends OperatorArtanisDashboardSession,
   Bindings extends OperatorArtanisDashboardEnv,
@@ -300,17 +404,81 @@ export const makeOperatorArtanisDashboardRoutes = <
   ): Effect.Effect<globalThis.Response> | undefined => {
     const url = new URL(request.url)
 
-    if (url.pathname !== '/api/operator/artanis/dashboard') {
+    const isDashboard = url.pathname === '/api/operator/artanis/dashboard'
+    const isAccountsStatus = url.pathname === '/api/operator/accounts/status'
+    const isAccountsReset = url.pathname === '/api/operator/accounts/reset'
+
+    if (!isDashboard && !isAccountsStatus && !isAccountsReset) {
       return undefined
     }
 
-    if (request.method !== 'GET') {
+    if ((isDashboard || isAccountsStatus) && request.method !== 'GET') {
       return Effect.succeed(methodNotAllowed(['GET']))
+    }
+
+    if (isAccountsReset && request.method !== 'POST') {
+      return Effect.succeed(methodNotAllowed(['POST']))
     }
 
     return Effect.gen(function* () {
       const session = yield* requireAdminSession(dependencies, request, env, ctx)
       const db = openAgentsDatabase(env)
+      const now = currentIsoTimestamp()
+
+      if (isAccountsStatus) {
+        const rows = yield* Effect.tryPromise({
+          catch: error => new OperatorArtanisDashboardStorageError({ error }),
+          try: () => listOperatorAccountStatusRows(db, session.user.userId),
+        })
+
+        return dependencies.appendRefreshedSessionCookies(
+          noStoreJsonResponse(operatorAccountStatusProjection(rows, now)),
+          session,
+        )
+      }
+
+      if (isAccountsReset) {
+        const accountRefHash = yield* Effect.tryPromise({
+          catch: error => new OperatorArtanisDashboardStorageError({ error }),
+          try: () => readAccountRefHash(request),
+        })
+
+        if (accountRefHash === undefined) {
+          return noStoreJsonResponse(
+            { error: 'bad_request', reason: 'accountRefHash is required' },
+            { status: 400 },
+          )
+        }
+
+        const didReset = yield* Effect.tryPromise({
+          catch: error => new OperatorArtanisDashboardStorageError({ error }),
+          try: () =>
+            resetOperatorAccountCooldown(db, {
+              accountRefHash,
+              now,
+              userId: session.user.userId,
+            }),
+        })
+
+        if (!didReset) {
+          return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
+        }
+
+        const rows = yield* Effect.tryPromise({
+          catch: error => new OperatorArtanisDashboardStorageError({ error }),
+          try: () => listOperatorAccountStatusRows(db, session.user.userId),
+        })
+
+        return dependencies.appendRefreshedSessionCookies(
+          noStoreJsonResponse({
+            ok: true,
+            resetAt: now,
+            status: operatorAccountStatusProjection(rows, now),
+          }),
+          session,
+        )
+      }
+
       const callerId = cleanQueryValue(url, 'caller_id')
       const requestedThreadRef = cleanQueryValue(url, 'thread_ref')
 
@@ -329,7 +497,7 @@ export const makeOperatorArtanisDashboardRoutes = <
 
       return dependencies.appendRefreshedSessionCookies(
         noStoreJsonResponse({
-          accountUsage: operatorAccountUsageProjection([], currentIsoTimestamp()),
+          accountUsage: operatorAccountUsageProjection([], now),
           callerIdFilter: callerId ?? null,
           dashboardRef: 'operator.artanis.dashboard',
           messages: messages.map(messageProjection),


### PR DESCRIPTION
Addresses #6640.

### Changes
- Replaced the static Artanis accounts mock table with a custom dashboard element that loads account status data from the operator dashboard API.
- Added public-safe account usage, cooldown, and manual reset state rendering for operator accounts.
- Extended the operator dashboard route implementation and tests for the account observability surface.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).