### PR TITLE
feat(agentcl): live Vertex gemini-3.5-flash runner with enforced $50 spend cap + breaker (#6788)

### DIFF
--- a/apps/openagents.com/workers/api/scripts/agentcl-vertex-runner.ts
+++ b/apps/openagents.com/workers/api/scripts/agentcl-vertex-runner.ts
@@ -1,0 +1,387 @@
+// Runnable CL-4b AgentCL Vertex runner CLI (public issue #6788).
+//
+// This is the operator entrypoint for the $50-bounded Vertex Gemini 3.5 Flash
+// AgentCL run. It wraps the enforced loop in `../src/inference/gym/
+// agentcl-vertex-runner.ts`. It is NOT part of the unit suite.
+//
+// MODES
+//   --dry-run (default): exercises the FULL enforcement loop with no-network
+//     stub model_fns and PROVES, with assertions, that:
+//       (a) the loop halts exactly when simulated cumulative spend reaches $50,
+//       (b) it never calls again after the halt,
+//       (c) it refuses/aborts a simulated GLM-fallback (both a mid-run fallback
+//           and a routing plan that carries a non-Vertex lane),
+//       (d) the 3 consecutive billing/quota-error breaker trips.
+//     Dry-run makes NO network calls and incurs NO spend.
+//
+//   --live: makes a REAL authorized paid call to gemini-3.5-flash on project
+//     openagentsgemini via the registered Vertex Gemini adapter + SA-key token
+//     path. GATED: refuses unless CL_VERTEX_ARMED=1 AND a VERTEX_SA_KEY is
+//     present, so it can never spend by accident. Even then it runs the SAME
+//     enforced loop with the SAME $50 cap and breaker.
+//
+// ENV
+//   CL_VERTEX_ARMED=1            arm the live paid path (required for --live)
+//   CL_VERTEX_CAP_USD=50         spend cap in DOLLARS (default 50 => 5000 cents;
+//                                a higher value cannot exceed the absolute $50
+//                                contract ceiling, it can only lower the cap)
+//   CL_VERTEX_ITERATIONS=10      max loop iterations
+//   CL_VERTEX_PROMPT="..."       prompt for the live call (owner-private; never
+//                                printed)
+//   CL_VERTEX_MODEL=gemini-3.5-flash   model id (must route Vertex-only)
+//   CL_VERTEX_MAX_TOKENS=256     per-call max output tokens
+//   VERTEX_SA_KEY=<sa json>      GCP service-account key (or ~/work/.secrets/vertex.env)
+//   VERTEX_PROJECT_ID            override project (default openagentsgemini)
+//   VERTEX_LOCATION              override location (default global)
+//
+// ONE LIVE $50 TRANCHE (run by the owner/overseer, NOT in the build lane):
+//   CL_VERTEX_ARMED=1 CL_VERTEX_CAP_USD=50 VERTEX_SA_KEY="$(cat sa.json)" \
+//     bun run apps/openagents.com/workers/api/scripts/agentcl-vertex-runner.ts --live
+//
+// This script NEVER prints the SA key, the prompt body, or any provider payload.
+import { Effect } from 'effect'
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID,
+  DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+  makeVertexGeminiRunnerEffectFn,
+  priceAgentClVertexCallUsdCents,
+  resolveAgentClVertexAdapterPlan,
+  resolveVertexGeminiFlashCost,
+  runAgentClVertexRunnerLoop,
+  type AgentClVertexCallOutcome,
+  type AgentClVertexRunnerReceipt,
+} from '../src/inference/gym/agentcl-vertex-runner'
+import { KHALA_MODEL_ID } from '../src/inference/pricing'
+import { type InferenceUsage } from '../src/inference/provider-adapter'
+
+const argv = process.argv.slice(2)
+const wantsLive = argv.includes('--live')
+const wantsDryRun = argv.includes('--dry-run') || !wantsLive
+
+const numEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name]?.trim()
+  if (raw === undefined || raw === '') return fallback
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+// CL_VERTEX_CAP_USD is in DOLLARS; convert to cents. Default 50 => 5000 cents.
+const capUsdCents = Math.round(numEnv('CL_VERTEX_CAP_USD', 50) * 100)
+const maxIterations = Math.max(1, Math.floor(numEnv('CL_VERTEX_ITERATIONS', 10)))
+const model =
+  process.env.CL_VERTEX_MODEL?.trim() || AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID
+
+const printReceipt = (label: string, receipt: AgentClVertexRunnerReceipt): void => {
+  console.log(`[agentcl-vertex-runner] ${label}`)
+  console.log(
+    `  model=${receipt.model} laneRef=${receipt.laneRef} ` +
+      `adapterPlan=[${receipt.adapterPlan.join(', ')}] ` +
+      `noFallbackPlanVerified=${receipt.noFallbackPlanVerified}`,
+  )
+  console.log(
+    `  capUsdCents=${receipt.capUsdCents} ($${(receipt.capUsdCents / 100).toFixed(2)}) ` +
+      `iterationsRequested=${receipt.iterationsRequested} ` +
+      `iterationsAttempted=${receipt.iterationsAttempted} ` +
+      `iterationsServed=${receipt.iterationsServed}`,
+  )
+  console.log(
+    `  tokens prompt=${receipt.promptTokens} completion=${receipt.completionTokens} ` +
+      `total=${receipt.totalTokens}`,
+  )
+  console.log(
+    `  estimatedSpendUsdCents=${receipt.estimatedSpendUsdCents.toFixed(4)} ` +
+      `($${(receipt.estimatedSpendUsdCents / 100).toFixed(4)})`,
+  )
+  console.log(
+    `  http429Count=${receipt.http429Count} ` +
+      `billingOrQuotaErrorCount=${receipt.billingOrQuotaErrorCount} ` +
+      `consecutiveBillingOrQuotaErrors=${receipt.consecutiveBillingOrQuotaErrors}`,
+  )
+  console.log(
+    `  forbiddenFallbackBlocked=${receipt.forbiddenFallbackBlocked} ` +
+      `circuitBreakerTripped=${receipt.circuitBreakerTripped} ` +
+      `circuitBreakerReason=${receipt.circuitBreakerReason} ` +
+      `abortReason=${receipt.abortReason}`,
+  )
+  console.log(
+    `  AgentCL PG=${receipt.agentClFixtureGains.plasticityGain} ` +
+      `SG=${receipt.agentClFixtureGains.stabilityGain} ` +
+      `GG=${receipt.agentClFixtureGains.generalizationGain} (fixture-eval)`,
+  )
+}
+
+const assert = (condition: boolean, message: string): void => {
+  if (!condition) {
+    console.error(`[agentcl-vertex-runner] DRY-RUN ASSERT FAILED: ${message}`)
+    process.exitCode = 1
+    throw new Error(message)
+  }
+  console.log(`  PROOF OK: ${message}`)
+}
+
+const loadSaKeyFromSecretsFile = (): string | undefined => {
+  const path = join(homedir(), 'work', '.secrets', 'vertex.env')
+  try {
+    const contents = readFileSync(path, 'utf8')
+    for (const line of contents.split('\n')) {
+      const match = line.match(/^\s*(?:export\s+)?VERTEX_SA_KEY\s*=\s*(.+)$/u)
+      if (match) {
+        return match[1].trim().replace(/^["']|["']$/gu, '')
+      }
+    }
+  } catch {
+    return undefined
+  }
+  return undefined
+}
+
+const resolveSaKey = (): string | undefined =>
+  process.env.VERTEX_SA_KEY?.trim() || loadSaKeyFromSecretsFile()
+
+// Build a deterministic served-call stub whose REAL metered cost (via the real
+// price function + real Vertex Gemini 3.5 Flash rates) is exactly `targetCents`.
+const stubServedUsageForCents = (targetCents: number): InferenceUsage => {
+  const cost = resolveVertexGeminiFlashCost()
+  // Use output tokens only; solve completionTokens for the target cents.
+  const completionTokens = Math.ceil(
+    targetCents / ((cost.outputUsdPerMtok / 1_000_000) * 100),
+  )
+  return { completionTokens, promptTokens: 0, totalTokens: completionTokens }
+}
+
+const runDryRun = async (): Promise<void> => {
+  console.log('[agentcl-vertex-runner] MODE=dry-run (no network, no spend)\n')
+
+  // Document the REAL routing decision that makes the no-fallback guarantee hold.
+  const vertexPlan = resolveAgentClVertexAdapterPlan(
+    AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID,
+  )
+  const khalaPlan = resolveAgentClVertexAdapterPlan(KHALA_MODEL_ID)
+  console.log(
+    `[routing] gemini-3.5-flash -> [${vertexPlan.join(', ')}] (Vertex-only)`,
+  )
+  console.log(
+    `[routing] ${KHALA_MODEL_ID} -> [${khalaPlan.join(', ')}] (carries fallback)\n`,
+  )
+  assert(
+    vertexPlan.length === 1 && vertexPlan[0] === 'vertex-gemini',
+    'gemini-3.5-flash routes ONLY to the vertex-gemini lane (no GLM/free fallback)',
+  )
+  assert(
+    khalaPlan.some(id => id !== 'vertex-gemini'),
+    `${KHALA_MODEL_ID} carries non-Vertex lanes, so it is refused by the runner`,
+  )
+
+  // (a)+(b) Cap-halt + no-call-after-halt. Each stub call costs exactly half the
+  // cap, so the 2nd call lands cumulative spend exactly AT the cap and the loop
+  // must halt with NO 3rd call.
+  console.log('\n[scenario A] cap-halt at exactly $50 (per-call = cap/2):')
+  const perCallUsage = stubServedUsageForCents(capUsdCents / 2)
+  let capCalls = 0
+  const capReceipt = await runAgentClVertexRunnerLoop({
+    capUsdCents,
+    maxIterations,
+    model,
+    modelFn: async (): Promise<AgentClVertexCallOutcome> => {
+      capCalls += 1
+      return {
+        _tag: 'served',
+        finishReason: 'stop',
+        servedAdapterId: 'vertex-gemini',
+        usage: perCallUsage,
+      }
+    },
+  })
+  printReceipt('scenario A receipt', capReceipt)
+  assert(
+    capReceipt.abortReason === 'spend_cap_exceeded',
+    'loop halts with abortReason=spend_cap_exceeded',
+  )
+  assert(
+    capReceipt.estimatedSpendUsdCents >= capUsdCents,
+    `accumulated spend (${capReceipt.estimatedSpendUsdCents.toFixed(2)}c) >= cap (${capUsdCents}c)`,
+  )
+  assert(
+    capReceipt.iterationsServed === 2 && capReceipt.iterationsAttempted === 2,
+    'exactly 2 calls served then HARD STOP (no 3rd call after the cap)',
+  )
+  assert(
+    capCalls === 2 && capCalls < maxIterations,
+    `model_fn invoked exactly 2 times, not the full ${maxIterations} iterations`,
+  )
+
+  // (c1) Mid-run GLM fallback is refused.
+  console.log('\n[scenario B] mid-run GLM fallback refused:')
+  let fallbackCalls = 0
+  const fallbackReceipt = await runAgentClVertexRunnerLoop({
+    capUsdCents,
+    maxIterations,
+    model,
+    modelFn: async (): Promise<AgentClVertexCallOutcome> => {
+      fallbackCalls += 1
+      return { _tag: 'fallback_attempted', toLaneRef: 'glm-free' }
+    },
+  })
+  printReceipt('scenario B receipt', fallbackReceipt)
+  assert(
+    fallbackReceipt.abortReason === 'forbidden_fallback' &&
+      fallbackReceipt.forbiddenFallbackBlocked,
+    'a simulated GLM fallback aborts the loop (forbidden_fallback)',
+  )
+  assert(
+    fallbackReceipt.estimatedSpendUsdCents === 0 && fallbackCalls === 1,
+    'no spend on a refused fallback; aborts on first attempt',
+  )
+
+  // (c2) A served-by-non-Vertex-adapter is refused too.
+  console.log('\n[scenario C] served by non-Vertex adapter refused:')
+  const servedElsewhere = await runAgentClVertexRunnerLoop({
+    capUsdCents,
+    maxIterations,
+    model,
+    modelFn: async (): Promise<AgentClVertexCallOutcome> => ({
+      _tag: 'served',
+      finishReason: 'stop',
+      servedAdapterId: 'openrouter-khala-glm-fallback',
+      usage: perCallUsage,
+    }),
+  })
+  printReceipt('scenario C receipt', servedElsewhere)
+  assert(
+    servedElsewhere.abortReason === 'forbidden_fallback' &&
+      servedElsewhere.estimatedSpendUsdCents === 0,
+    'a call served by a non-vertex-gemini adapter aborts with no spend',
+  )
+
+  // (c3) Pre-flight: a model whose routing plan carries a fallback lane is
+  // refused before ANY call.
+  console.log('\n[scenario D] pre-flight refuse of a fallback-carrying model:')
+  let preflightCalls = 0
+  const preflightReceipt = await runAgentClVertexRunnerLoop({
+    capUsdCents,
+    maxIterations,
+    model: KHALA_MODEL_ID,
+    modelFn: async (): Promise<AgentClVertexCallOutcome> => {
+      preflightCalls += 1
+      return {
+        _tag: 'served',
+        finishReason: 'stop',
+        servedAdapterId: 'vertex-gemini',
+        usage: perCallUsage,
+      }
+    },
+  })
+  printReceipt('scenario D receipt', preflightReceipt)
+  assert(
+    preflightReceipt.abortReason === 'no_fallback_plan_refused' &&
+      preflightCalls === 0,
+    'a fallback-carrying model is refused with ZERO calls made',
+  )
+
+  // (d) 3 consecutive billing/quota errors trip the breaker.
+  console.log('\n[scenario E] 3-error billing/quota breaker:')
+  let errCalls = 0
+  const breakerReceipt = await runAgentClVertexRunnerLoop({
+    capUsdCents,
+    maxIterations,
+    model,
+    modelFn: async (): Promise<AgentClVertexCallOutcome> => {
+      errCalls += 1
+      return { _tag: 'billing_or_quota_error', errorRef: 'http_429' }
+    },
+  })
+  printReceipt('scenario E receipt', breakerReceipt)
+  assert(
+    breakerReceipt.abortReason === 'consecutive_billing_or_quota_errors',
+    'loop halts on the 3-consecutive-billing/quota-error breaker',
+  )
+  assert(
+    breakerReceipt.iterationsAttempted === 3 &&
+      breakerReceipt.http429Count === 3 &&
+      errCalls === 3,
+    'breaker trips at exactly 3 errors (no 4th call)',
+  )
+
+  console.log('\n[agentcl-vertex-runner] DRY-RUN: ALL PROOFS PASSED')
+}
+
+const runLive = async (): Promise<void> => {
+  if (process.env.CL_VERTEX_ARMED !== '1') {
+    console.error(
+      '[agentcl-vertex-runner] REFUSED: --live requires CL_VERTEX_ARMED=1 ' +
+        '(paid-safe guard). No call made.',
+    )
+    process.exitCode = 2
+    return
+  }
+  const serviceAccountKey = resolveSaKey()
+  if (serviceAccountKey === undefined || serviceAccountKey === '') {
+    console.error(
+      '[agentcl-vertex-runner] REFUSED: no VERTEX_SA_KEY in env or ' +
+        '~/work/.secrets/vertex.env. No call made.',
+    )
+    process.exitCode = 2
+    return
+  }
+  const plan = resolveAgentClVertexAdapterPlan(model)
+  if (!(plan.length === 1 && plan[0] === 'vertex-gemini')) {
+    console.error(
+      `[agentcl-vertex-runner] REFUSED: model=${model} routes to ` +
+        `[${plan.join(', ')}] which would allow a non-Vertex fallback. No call made.`,
+    )
+    process.exitCode = 2
+    return
+  }
+
+  const prompt =
+    process.env.CL_VERTEX_PROMPT?.trim() ||
+    'Reply with exactly: OPENAGENTS AGENTCL VERTEX OK'
+  const maxTokens = Math.max(1, Math.floor(numEnv('CL_VERTEX_MAX_TOKENS', 256)))
+
+  console.log(
+    `[agentcl-vertex-runner] MODE=live ARMED model=${model} ` +
+      `cap=$${(capUsdCents / 100).toFixed(2)} maxIterations=${maxIterations}`,
+  )
+  const effectFn = makeVertexGeminiRunnerEffectFn({
+    location: process.env.VERTEX_LOCATION?.trim(),
+    maxTokens,
+    model,
+    project: process.env.VERTEX_PROJECT_ID?.trim(),
+    prompt,
+    serviceAccountKey,
+  })
+  // Effect->Promise bridge stays at the runnable edge (this CLI), not in the
+  // domain module.
+  const receipt = await runAgentClVertexRunnerLoop({
+    capUsdCents,
+    maxIterations,
+    model,
+    modelFn: iteration => Effect.runPromise(effectFn(iteration)),
+  })
+  printReceipt('LIVE receipt', receipt)
+}
+
+const main = async (): Promise<void> => {
+  console.log(
+    `[agentcl-vertex-runner] cap=$${(capUsdCents / 100).toFixed(2)} ` +
+      `(${capUsdCents}c, default ${DEFAULT_CL_VERTEX_CAP_USD_CENTS}c) ` +
+      `priceBasis=${JSON.stringify(resolveVertexGeminiFlashCost())} ` +
+      `perCallCentExample=${priceAgentClVertexCallUsdCents({
+        completionTokens: 256,
+        promptTokens: 500,
+      }).toFixed(6)}\n`,
+  )
+  if (wantsLive) {
+    await runLive()
+    return
+  }
+  if (wantsDryRun) {
+    await runDryRun()
+  }
+}
+
+void main()

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl-vertex-runner.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl-vertex-runner.test.ts
@@ -1,0 +1,375 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID,
+  AGENTCL_VERTEX_RUNNER_RECEIPT_SCHEMA,
+  assessAgentClVertexRunnerStop,
+  classifyVertexBillingOrQuotaError,
+  DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+  isVertexGeminiOnlyPlan,
+  makeVertexGeminiRunnerEffectFn,
+  priceAgentClVertexCallUsdCents,
+  resolveAgentClVertexAdapterPlan,
+  resolveVertexGeminiFlashCost,
+  runAgentClVertexRunnerLoop,
+  type AgentClVertexCallOutcome,
+} from './agentcl-vertex-runner'
+import { KHALA_MODEL_ID } from '../pricing'
+import { InferenceAdapterError } from '../provider-adapter'
+
+// A served-call stub whose REAL metered cost is exactly `cents`.
+const servedUsageForCents = (cents: number) => {
+  const cost = resolveVertexGeminiFlashCost()
+  const completionTokens = Math.ceil(
+    cents / ((cost.outputUsdPerMtok / 1_000_000) * 100),
+  )
+  return { completionTokens, promptTokens: 0, totalTokens: completionTokens }
+}
+
+const servedVertex = (
+  usage: ReturnType<typeof servedUsageForCents>,
+): AgentClVertexCallOutcome => ({
+  _tag: 'served',
+  finishReason: 'stop',
+  servedAdapterId: 'vertex-gemini',
+  usage,
+})
+
+describe('AgentCL Vertex runner — pricing + routing', () => {
+  test('prices a call from real gemini-3.5-flash rates', () => {
+    const cost = resolveVertexGeminiFlashCost()
+    expect(cost.inputUsdPerMtok).toBeGreaterThan(0)
+    expect(cost.outputUsdPerMtok).toBeGreaterThan(0)
+    // 1M input + 1M output tokens = (input + output) USD = cents * 100.
+    const cents = priceAgentClVertexCallUsdCents({
+      completionTokens: 1_000_000,
+      promptTokens: 1_000_000,
+    })
+    expect(cents).toBeCloseTo(
+      (cost.inputUsdPerMtok + cost.outputUsdPerMtok) * 100,
+      6,
+    )
+  })
+
+  test('gemini-3.5-flash routes ONLY to the vertex-gemini lane', () => {
+    const plan = resolveAgentClVertexAdapterPlan(
+      AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID,
+    )
+    expect(plan).toEqual(['vertex-gemini'])
+    expect(isVertexGeminiOnlyPlan(plan)).toBe(true)
+  })
+
+  test('the public khala alias carries a non-Vertex fallback lane', () => {
+    const plan = resolveAgentClVertexAdapterPlan(KHALA_MODEL_ID)
+    expect(plan.some(id => id !== 'vertex-gemini')).toBe(true)
+    expect(isVertexGeminiOnlyPlan(plan)).toBe(false)
+  })
+})
+
+describe('AgentCL Vertex runner — stop decision', () => {
+  test('does not trip below the cap with no errors', () => {
+    expect(
+      assessAgentClVertexRunnerStop({
+        accumulatedSpendUsdCents: 4999,
+        capUsdCents: 5000,
+        consecutiveBillingOrQuotaErrors: 0,
+      }),
+    ).toEqual({ reason: 'none', tripped: false })
+  })
+
+  test('trips at exactly the cap (>= boundary)', () => {
+    const stop = assessAgentClVertexRunnerStop({
+      accumulatedSpendUsdCents: 5000,
+      capUsdCents: 5000,
+      consecutiveBillingOrQuotaErrors: 0,
+    })
+    expect(stop.tripped).toBe(true)
+    expect(stop.reason).toBe('spend_cap_exceeded')
+  })
+
+  test('trips on the 3-consecutive-error breaker', () => {
+    const stop = assessAgentClVertexRunnerStop({
+      accumulatedSpendUsdCents: 0,
+      capUsdCents: 5000,
+      consecutiveBillingOrQuotaErrors: 3,
+    })
+    expect(stop.tripped).toBe(true)
+    expect(stop.reason).toBe('consecutive_billing_or_quota_errors')
+  })
+
+  test('a higher env cap cannot exceed the absolute $50 contract ceiling', () => {
+    // Even with a 10000-cent override, the contract breaker trips above 5000.
+    const stop = assessAgentClVertexRunnerStop({
+      accumulatedSpendUsdCents: 5001,
+      capUsdCents: 10_000,
+      consecutiveBillingOrQuotaErrors: 0,
+    })
+    expect(stop.tripped).toBe(true)
+    expect(stop.reason).toBe('spend_cap_exceeded')
+  })
+})
+
+describe('AgentCL Vertex runner — enforced loop', () => {
+  test('hard-stops at exactly $50 and makes NO further call', async () => {
+    const cap = DEFAULT_CL_VERTEX_CAP_USD_CENTS
+    const usage = servedUsageForCents(cap / 2)
+    let calls = 0
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: cap,
+      maxIterations: 10,
+      modelFn: async () => {
+        calls += 1
+        return servedVertex(usage)
+      },
+    })
+    expect(receipt.schemaVersion).toBe(AGENTCL_VERTEX_RUNNER_RECEIPT_SCHEMA)
+    expect(receipt.abortReason).toBe('spend_cap_exceeded')
+    expect(receipt.estimatedSpendUsdCents).toBeGreaterThanOrEqual(cap)
+    expect(receipt.iterationsServed).toBe(2)
+    expect(receipt.iterationsAttempted).toBe(2)
+    // The crucial proof: model_fn was invoked exactly twice, never a 3rd time.
+    expect(calls).toBe(2)
+    expect(receipt.circuitBreakerTripped).toBe(true)
+  })
+
+  test('never calls again after the cap even with many iterations', async () => {
+    const cap = DEFAULT_CL_VERTEX_CAP_USD_CENTS
+    // Each call costs the WHOLE cap -> halts after the first served call.
+    const usage = servedUsageForCents(cap)
+    let calls = 0
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: cap,
+      maxIterations: 1000,
+      modelFn: async () => {
+        calls += 1
+        return servedVertex(usage)
+      },
+    })
+    expect(calls).toBe(1)
+    expect(receipt.iterationsAttempted).toBe(1)
+    expect(receipt.abortReason).toBe('spend_cap_exceeded')
+  })
+
+  test('aborts on a simulated GLM fallback (no spend)', async () => {
+    let calls = 0
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+      maxIterations: 10,
+      modelFn: async () => {
+        calls += 1
+        return { _tag: 'fallback_attempted', toLaneRef: 'glm-free' }
+      },
+    })
+    expect(receipt.abortReason).toBe('forbidden_fallback')
+    expect(receipt.forbiddenFallbackBlocked).toBe(true)
+    expect(receipt.estimatedSpendUsdCents).toBe(0)
+    expect(calls).toBe(1)
+  })
+
+  test('aborts when a non-vertex adapter serves the call (no spend)', async () => {
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+      maxIterations: 10,
+      modelFn: async () => ({
+        _tag: 'served',
+        finishReason: 'stop',
+        servedAdapterId: 'openrouter-khala-glm-fallback',
+        usage: servedUsageForCents(100),
+      }),
+    })
+    expect(receipt.abortReason).toBe('forbidden_fallback')
+    expect(receipt.estimatedSpendUsdCents).toBe(0)
+  })
+
+  test('refuses a model whose routing plan carries a fallback lane (zero calls)', async () => {
+    let calls = 0
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+      maxIterations: 10,
+      model: KHALA_MODEL_ID,
+      modelFn: async () => {
+        calls += 1
+        return servedVertex(servedUsageForCents(100))
+      },
+    })
+    expect(receipt.abortReason).toBe('no_fallback_plan_refused')
+    expect(receipt.noFallbackPlanVerified).toBe(false)
+    expect(calls).toBe(0)
+  })
+
+  test('trips the breaker at exactly 3 consecutive billing/quota errors', async () => {
+    let calls = 0
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+      maxIterations: 10,
+      modelFn: async () => {
+        calls += 1
+        return { _tag: 'billing_or_quota_error', errorRef: 'http_429' }
+      },
+    })
+    expect(receipt.abortReason).toBe('consecutive_billing_or_quota_errors')
+    expect(receipt.iterationsAttempted).toBe(3)
+    expect(receipt.http429Count).toBe(3)
+    expect(receipt.billingOrQuotaErrorCount).toBe(3)
+    expect(calls).toBe(3)
+  })
+
+  test('a generic error does not trip the breaker and adds no spend', async () => {
+    const usage = servedUsageForCents(10)
+    let call = 0
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+      maxIterations: 4,
+      modelFn: async () => {
+        call += 1
+        // error, error, served, served — generic errors never break the loop.
+        return call <= 2
+          ? { _tag: 'error', errorRef: 'transient' }
+          : servedVertex(usage)
+      },
+    })
+    expect(receipt.abortReason).toBe('completed')
+    expect(receipt.iterationsServed).toBe(2)
+    expect(receipt.billingOrQuotaErrorCount).toBe(0)
+    expect(receipt.estimatedSpendUsdCents).toBeCloseTo(20, 4)
+  })
+
+  test('a dry-run-style error-only loop incurs zero spend', async () => {
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+      maxIterations: 2,
+      modelFn: async () => ({ _tag: 'error', errorRef: 'stub' }),
+    })
+    expect(receipt.estimatedSpendUsdCents).toBe(0)
+    expect(receipt.iterationsServed).toBe(0)
+  })
+})
+
+describe('AgentCL Vertex runner — error classification', () => {
+  const err = (reason: string, httpStatus?: number) =>
+    new InferenceAdapterError({
+      adapterId: 'vertex-gemini',
+      ...(httpStatus === undefined ? {} : { httpStatus }),
+      reason,
+      retryable: false,
+    })
+
+  test('classifies HTTP 429 as http_429', () => {
+    expect(
+      classifyVertexBillingOrQuotaError(
+        err('Vertex Gemini returned HTTP 429: rate limit'),
+      ),
+    ).toBe('http_429')
+    expect(classifyVertexBillingOrQuotaError(err('boom', 429))).toBe('http_429')
+  })
+
+  test('classifies RESOURCE_EXHAUSTED / quota / billing', () => {
+    expect(
+      classifyVertexBillingOrQuotaError(
+        err('Vertex Gemini returned HTTP 400: RESOURCE_EXHAUSTED'),
+      ),
+    ).toBe('resource_exhausted')
+    expect(
+      classifyVertexBillingOrQuotaError(err('quota exceeded for project')),
+    ).toBe('quota_error')
+    expect(
+      classifyVertexBillingOrQuotaError(
+        err('Vertex Gemini returned HTTP 403: billing disabled'),
+      ),
+    ).toBe('billing_error')
+  })
+
+  test('returns undefined for a generic non-billing error', () => {
+    expect(
+      classifyVertexBillingOrQuotaError(err('Vertex Gemini returned HTTP 500')),
+    ).toBeUndefined()
+    expect(
+      classifyVertexBillingOrQuotaError(err('response was not valid JSON')),
+    ).toBeUndefined()
+  })
+})
+
+describe('AgentCL Vertex runner — live modelFn over a stubbed adapter', () => {
+  // Exercises the REAL vertex-gemini adapter wiring (no SA-key crypto, no
+  // network): inject a token provider + a fake fetch.
+  const tokenProvider = () => Effect.succeed('fake-token')
+
+  test('maps a 200 Gemini response to a served outcome with usage', async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          candidates: [
+            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+          ],
+          usageMetadata: {
+            candidatesTokenCount: 7,
+            promptTokenCount: 5,
+            totalTokenCount: 12,
+          },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch
+    const effectFn = makeVertexGeminiRunnerEffectFn({
+      fetchImpl,
+      prompt: 'hello',
+      tokenProvider,
+    })
+    const outcome = await Effect.runPromise(effectFn(0))
+    expect(outcome._tag).toBe('served')
+    if (outcome._tag === 'served') {
+      expect(outcome.servedAdapterId).toBe('vertex-gemini')
+      expect(outcome.usage.promptTokens).toBe(5)
+      expect(outcome.usage.completionTokens).toBe(7)
+      expect(outcome.usage.totalTokens).toBe(12)
+    }
+  })
+
+  test('maps a 429 to a billing_or_quota_error http_429 outcome', async () => {
+    const fetchImpl = (async () =>
+      new Response('rate limited', { status: 429 })) as unknown as typeof fetch
+    const effectFn = makeVertexGeminiRunnerEffectFn({
+      fetchImpl,
+      prompt: 'hello',
+      tokenProvider,
+    })
+    const outcome = await Effect.runPromise(effectFn(0))
+    expect(outcome).toEqual({
+      _tag: 'billing_or_quota_error',
+      errorRef: 'http_429',
+    })
+  })
+
+  test('the loop meters real served usage from the stubbed adapter', async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          candidates: [
+            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+          ],
+          usageMetadata: {
+            candidatesTokenCount: 1_000_000,
+            promptTokenCount: 0,
+            totalTokenCount: 1_000_000,
+          },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch
+    const effectFn = makeVertexGeminiRunnerEffectFn({
+      fetchImpl,
+      prompt: 'hello',
+      tokenProvider,
+    })
+    const receipt = await runAgentClVertexRunnerLoop({
+      capUsdCents: DEFAULT_CL_VERTEX_CAP_USD_CENTS,
+      maxIterations: 1,
+      modelFn: iteration => Effect.runPromise(effectFn(iteration)),
+    })
+    expect(receipt.iterationsServed).toBe(1)
+    // 1M output tokens * $0.30/Mtok = $0.30 = 30 cents.
+    expect(receipt.estimatedSpendUsdCents).toBeCloseTo(
+      resolveVertexGeminiFlashCost().outputUsdPerMtok * 100,
+      4,
+    )
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl-vertex-runner.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl-vertex-runner.ts
@@ -1,0 +1,489 @@
+// Live Vertex AgentCL runner (CL-4b, public issue #6788).
+//
+// This is the RUNNABLE enforcement layer the CL-4 guardrail
+// (`agentcl.ts`) was missing. Up to #6788 the AgentCL Vertex contract was a
+// typed plan + a pure circuit-breaker decision function referenced ONLY by
+// tests: there was no live Vertex HTTP client, no per-iteration runtime
+// enforcement, no live spend metering from real usage, and no kill-switch that
+// aborts an in-flight paid run or blocks a GLM/free fallback. CL-5 cannot run
+// safely until that exists; this module supplies it.
+//
+// What it owns:
+//   1. A real per-iteration loop that wires the contract circuit-breaker
+//      (`assessAgentClVertexRunnerCircuitBreaker`) into the run BEFORE each call
+//      and AFTER each result, hard-stopping the loop the instant accumulated
+//      spend reaches the cap OR three consecutive billing/quota errors trip.
+//   2. Live spend metering computed from REAL provider usage tokens
+//      (`InferenceResult.usage`) x the Vertex Gemini 3.5 Flash price from the
+//      canonical pricing table - never a caller-supplied estimate.
+//   3. A no-fallback guard: the runner only ever targets the `vertex-gemini`
+//      lane. It refuses to start when routing for the requested model would
+//      include any non-Vertex (GLM / free / Fireworks / OpenRouter) lane, and it
+//      aborts mid-run if a call is served by any adapter other than
+//      `vertex-gemini`.
+//
+// The loop is driven by an injected `modelFn` so the SAME enforcement runs over
+// either a real Vertex call (`makeVertexGeminiRunnerModelFn`, live/owner-armed)
+// or a no-network stub (dry-run proofs + unit tests). The loop NEVER itself
+// decides to spend: it only enforces.
+//
+// Public-safety: this module computes spend cents and token totals only. It
+// never prints prompts, provider payloads, the service-account key, or any
+// secret. The CLI wrapper (`scripts/agentcl-vertex-runner.ts`) gates the live
+// paid path behind an explicit `CL_VERTEX_ARMED=1` env + `--live` flag.
+import { Effect } from 'effect'
+
+import {
+  assessAgentClVertexRunnerCircuitBreaker,
+  buildAgentClVertexStressExperiment,
+  runAgentClRepoReuseFixtureEval,
+  type AgentClVertexStressCircuitBreakerReason,
+} from './agentcl'
+import {
+  selectAdapterPlan,
+  VERTEX_GEMINI_ADAPTER_ID,
+} from '../model-router'
+import {
+  DEFAULT_GEMINI_MODEL_ID,
+  makeVertexGeminiAdapter,
+} from '../vertex-gemini-adapter'
+import { type VertexTokenProvider } from '../vertex-anthropic-adapter'
+import { lookupModel, type ModelCostPerMtok } from '../pricing'
+import {
+  type InferenceAdapterError,
+  type InferenceRequest,
+  type InferenceUsage,
+} from '../provider-adapter'
+import { tokenProviderFromSecret } from '../vertex-token'
+
+export const AGENTCL_VERTEX_RUNNER_RECEIPT_SCHEMA =
+  'openagents.gym.agentcl_vertex_runner_receipt.v0' as const
+
+// The ONLY model id this runner serves. Routing classifies any `gemini-*` id to
+// the gemini class, whose lane plan is `['vertex-gemini']` with NO fallback
+// (model-router.ts `LANE_PLAN_BY_CLASS.gemini`). Using the raw Vertex-native id
+// (not the public `openagents/khala` alias, which DOES carry GLM/free overflow)
+// is what makes the no-fallback guarantee hold.
+export const AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID = DEFAULT_GEMINI_MODEL_ID
+
+// The GCP project that holds the first-party Vertex Gemini quota.
+export const AGENTCL_VERTEX_GEMINI_PROJECT = 'openagentsgemini' as const
+
+// Default spend cap: $50 = 5000 cents, matching the CL-4 contract budget guard
+// (`buildAgentClVertexGeminiRunnerPlan().budgetGuard.spendCapUsdCents`). The CLI
+// allows an env override (CL_VERTEX_CAP_USD) but the contract breaker also
+// enforces an absolute 5000-cent ceiling, so a HIGHER override can never raise
+// the real ceiling above $50 - it can only LOWER it.
+export const DEFAULT_CL_VERTEX_CAP_USD_CENTS = 5000
+
+// Consecutive billing/quota errors that trip the breaker (matches the contract
+// plan `abortOnConsecutiveBillingOrQuotaErrors`).
+export const CL_VERTEX_CONSECUTIVE_ERROR_BREAKER = 3
+
+// Capacity-error refs the breaker treats as "billing/quota" (matches the
+// contract plan `trackedCapacityErrorRefs`).
+export type AgentClVertexCapacityErrorRef =
+  | 'billing_error'
+  | 'quota_error'
+  | 'http_429'
+  | 'resource_exhausted'
+
+// Resolve the Vertex Gemini 3.5 Flash marginal cost from the canonical pricing
+// table. Falls back to the documented list rate if the entry is ever removed so
+// metering never silently becomes free.
+export const resolveVertexGeminiFlashCost = (): ModelCostPerMtok =>
+  lookupModel(AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID)?.cost ?? {
+    inputUsdPerMtok: 0.075,
+    outputUsdPerMtok: 0.3,
+  }
+
+// Compute the USD-cents cost of one served call from its REAL provider usage.
+// Deliberately bills cached prompt tokens at the FULL input rate (no cache
+// discount): for a hard spend cap, over-estimating spend is the safe direction -
+// it can only trip the breaker EARLIER, never later.
+export const priceAgentClVertexCallUsdCents = (
+  usage: Readonly<{
+    promptTokens: number
+    completionTokens: number
+  }>,
+  cost: ModelCostPerMtok = resolveVertexGeminiFlashCost(),
+): number => {
+  const promptTokens = Math.max(0, usage.promptTokens)
+  const completionTokens = Math.max(0, usage.completionTokens)
+  const usd =
+    (promptTokens / 1_000_000) * cost.inputUsdPerMtok +
+    (completionTokens / 1_000_000) * cost.outputUsdPerMtok
+  return usd * 100
+}
+
+// The candidate adapter plan routing would use for a model id. Exposed so the
+// CLI / tests can show the real routing decision.
+export const resolveAgentClVertexAdapterPlan = (
+  model: string,
+): ReadonlyArray<string> => selectAdapterPlan(model)
+
+// True only when routing for `model` resolves to the single Vertex Gemini lane
+// with NO other (GLM / free / Fireworks / OpenRouter) adapter in the plan.
+export const isVertexGeminiOnlyPlan = (
+  plan: ReadonlyArray<string>,
+): boolean => plan.length === 1 && plan[0] === VERTEX_GEMINI_ADAPTER_ID
+
+// The combined runner stop decision. Wires the CL-4 contract breaker (3-error +
+// absolute $50 ceiling) and layers the env-overridable cap with a HARD `>=`
+// boundary so the loop halts the instant accumulated spend reaches the cap.
+export const assessAgentClVertexRunnerStop = (
+  input: Readonly<{
+    accumulatedSpendUsdCents: number
+    consecutiveBillingOrQuotaErrors: number
+    capUsdCents: number
+  }>,
+): Readonly<{
+  tripped: boolean
+  reason: AgentClVertexStressCircuitBreakerReason
+}> => {
+  // Canonical contract breaker: 3 consecutive billing/quota errors OR strictly
+  // above the absolute 5000-cent ($50) contract ceiling.
+  const contract = assessAgentClVertexRunnerCircuitBreaker({
+    consecutiveBillingOrQuotaErrors: input.consecutiveBillingOrQuotaErrors,
+    estimatedSpendUsdCents: input.accumulatedSpendUsdCents,
+  })
+  if (contract.tripped) {
+    return contract
+  }
+  // Env-overridable cap with a hard `>=` boundary (default equals the contract
+  // ceiling). Halts AT the cap, not just above it.
+  if (input.accumulatedSpendUsdCents >= input.capUsdCents) {
+    return { reason: 'spend_cap_exceeded', tripped: true }
+  }
+  return { reason: 'none', tripped: false }
+}
+
+// Outcome of a single model call handed back to the loop. The loop owns ALL
+// enforcement; the modelFn only reports what happened.
+export type AgentClVertexCallOutcome =
+  | Readonly<{
+      _tag: 'served'
+      servedAdapterId: string
+      usage: InferenceUsage
+      finishReason: string
+    }>
+  | Readonly<{
+      _tag: 'billing_or_quota_error'
+      errorRef: AgentClVertexCapacityErrorRef
+    }>
+  // Routing tried to leave the Vertex lane (or a non-Vertex adapter served the
+  // call). The loop treats this as a hard, immediate abort.
+  | Readonly<{ _tag: 'fallback_attempted'; toLaneRef: string }>
+  // Any other (non-billing, non-fallback) error. Does NOT add spend and does NOT
+  // trip the consecutive-error breaker.
+  | Readonly<{ _tag: 'error'; errorRef: string }>
+
+export type AgentClVertexRunnerModelFn = (
+  iteration: number,
+) => Promise<AgentClVertexCallOutcome>
+
+export type AgentClVertexRunnerAbortReason =
+  | 'completed'
+  | 'spend_cap_exceeded'
+  | 'consecutive_billing_or_quota_errors'
+  | 'forbidden_fallback'
+  | 'no_fallback_plan_refused'
+
+export type AgentClVertexRunnerReceipt = Readonly<{
+  schemaVersion: typeof AGENTCL_VERTEX_RUNNER_RECEIPT_SCHEMA
+  model: string
+  laneRef: 'vertex-gemini'
+  adapterPlan: ReadonlyArray<string>
+  noFallbackPlanVerified: boolean
+  capUsdCents: number
+  iterationsRequested: number
+  iterationsAttempted: number
+  iterationsServed: number
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  estimatedSpendUsdCents: number
+  http429Count: number
+  billingOrQuotaErrorCount: number
+  consecutiveBillingOrQuotaErrors: number
+  forbiddenFallbackBlocked: boolean
+  circuitBreakerTripped: boolean
+  circuitBreakerReason: AgentClVertexStressCircuitBreakerReason
+  abortReason: AgentClVertexRunnerAbortReason
+  // Fixture-eval AgentCL gains (PG/SG/GG). The live loop measures spend +
+  // capacity; the learning gains stay fixture-derived (deterministic) until a
+  // real CL-5 eval supplies them, so they are reported as a stable skeleton.
+  agentClFixtureGains: Readonly<{
+    plasticityGain: number
+    stabilityGain: number
+    generalizationGain: number
+  }>
+}>
+
+const fixtureGains = (): AgentClVertexRunnerReceipt['agentClFixtureGains'] => {
+  const { eval: evalResult } = runAgentClRepoReuseFixtureEval(
+    buildAgentClVertexStressExperiment(
+      'owner.approval.agentcl.vertex_stress.required',
+    ),
+  )
+  return {
+    generalizationGain: evalResult.generalizationGain,
+    plasticityGain: evalResult.plasticityGain,
+    stabilityGain: evalResult.stabilityGain,
+  }
+}
+
+// Run the enforced AgentCL Vertex loop. Pure orchestration: deterministic given
+// the injected `modelFn`. The same code path runs the dry-run stub and the live
+// paid call - only `modelFn` differs.
+export const runAgentClVertexRunnerLoop = async (
+  input: Readonly<{
+    modelFn: AgentClVertexRunnerModelFn
+    maxIterations: number
+    model?: string | undefined
+    capUsdCents?: number | undefined
+    // Verify the no-fallback routing plan before the first call. Defaults true.
+    enforceNoFallbackPlan?: boolean | undefined
+  }>,
+): Promise<AgentClVertexRunnerReceipt> => {
+  const model = input.model ?? AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID
+  const capUsdCents = input.capUsdCents ?? DEFAULT_CL_VERTEX_CAP_USD_CENTS
+  const enforceNoFallbackPlan = input.enforceNoFallbackPlan ?? true
+  const adapterPlan = selectAdapterPlan(model)
+  const noFallbackPlanVerified = isVertexGeminiOnlyPlan(adapterPlan)
+
+  let promptTokens = 0
+  let completionTokens = 0
+  let totalTokens = 0
+  let estimatedSpendUsdCents = 0
+  let http429Count = 0
+  let billingOrQuotaErrorCount = 0
+  let consecutiveBillingOrQuotaErrors = 0
+  let iterationsAttempted = 0
+  let iterationsServed = 0
+  let forbiddenFallbackBlocked = false
+  let abortReason: AgentClVertexRunnerAbortReason = 'completed'
+
+  const buildReceipt = (): AgentClVertexRunnerReceipt => {
+    const stop = assessAgentClVertexRunnerStop({
+      accumulatedSpendUsdCents: estimatedSpendUsdCents,
+      capUsdCents,
+      consecutiveBillingOrQuotaErrors,
+    })
+    const tripped =
+      abortReason === 'spend_cap_exceeded' ||
+      abortReason === 'consecutive_billing_or_quota_errors' ||
+      stop.tripped
+    const circuitBreakerReason: AgentClVertexStressCircuitBreakerReason =
+      abortReason === 'spend_cap_exceeded'
+        ? 'spend_cap_exceeded'
+        : abortReason === 'consecutive_billing_or_quota_errors'
+          ? 'consecutive_billing_or_quota_errors'
+          : stop.reason
+    return {
+      adapterPlan,
+      abortReason,
+      agentClFixtureGains: fixtureGains(),
+      billingOrQuotaErrorCount,
+      capUsdCents,
+      circuitBreakerReason,
+      circuitBreakerTripped: tripped,
+      completionTokens,
+      consecutiveBillingOrQuotaErrors,
+      estimatedSpendUsdCents,
+      forbiddenFallbackBlocked,
+      http429Count,
+      iterationsAttempted,
+      iterationsRequested: input.maxIterations,
+      iterationsServed,
+      laneRef: 'vertex-gemini',
+      model,
+      noFallbackPlanVerified,
+      promptTokens,
+      schemaVersion: AGENTCL_VERTEX_RUNNER_RECEIPT_SCHEMA,
+      totalTokens,
+    }
+  }
+
+  // Pre-flight: refuse to run at all if routing for this model would ever leave
+  // the Vertex lane. No call is made.
+  if (enforceNoFallbackPlan && !noFallbackPlanVerified) {
+    forbiddenFallbackBlocked = true
+    abortReason = 'no_fallback_plan_refused'
+    return buildReceipt()
+  }
+
+  for (let iteration = 0; iteration < input.maxIterations; iteration += 1) {
+    // ENFORCE BEFORE each call: never make another call once the cap or the
+    // error breaker has tripped.
+    const pre = assessAgentClVertexRunnerStop({
+      accumulatedSpendUsdCents: estimatedSpendUsdCents,
+      capUsdCents,
+      consecutiveBillingOrQuotaErrors,
+    })
+    if (pre.tripped) {
+      abortReason =
+        pre.reason === 'spend_cap_exceeded'
+          ? 'spend_cap_exceeded'
+          : 'consecutive_billing_or_quota_errors'
+      break
+    }
+
+    iterationsAttempted += 1
+    const outcome = await input.modelFn(iteration)
+
+    // Hard, immediate abort if routing left the Vertex lane.
+    if (
+      outcome._tag === 'fallback_attempted' ||
+      (outcome._tag === 'served' &&
+        outcome.servedAdapterId !== VERTEX_GEMINI_ADAPTER_ID)
+    ) {
+      forbiddenFallbackBlocked = true
+      abortReason = 'forbidden_fallback'
+      break
+    }
+
+    if (outcome._tag === 'billing_or_quota_error') {
+      consecutiveBillingOrQuotaErrors += 1
+      billingOrQuotaErrorCount += 1
+      if (outcome.errorRef === 'http_429') {
+        http429Count += 1
+      }
+    } else if (outcome._tag === 'served') {
+      consecutiveBillingOrQuotaErrors = 0
+      iterationsServed += 1
+      promptTokens += outcome.usage.promptTokens
+      completionTokens += outcome.usage.completionTokens
+      totalTokens += outcome.usage.totalTokens
+      estimatedSpendUsdCents += priceAgentClVertexCallUsdCents(outcome.usage)
+    }
+    // `error` outcomes add no spend and do not move the breaker.
+
+    // ENFORCE AFTER each result: abort the instant the cap or error breaker
+    // trips, before the next iteration's BEFORE check would even run.
+    const post = assessAgentClVertexRunnerStop({
+      accumulatedSpendUsdCents: estimatedSpendUsdCents,
+      capUsdCents,
+      consecutiveBillingOrQuotaErrors,
+    })
+    if (post.tripped) {
+      abortReason =
+        post.reason === 'spend_cap_exceeded'
+          ? 'spend_cap_exceeded'
+          : 'consecutive_billing_or_quota_errors'
+      break
+    }
+  }
+
+  return buildReceipt()
+}
+
+// Classify an adapter error into a tracked billing/quota capacity-error ref, or
+// undefined for a generic (non-breaker) error. The Vertex Gemini adapter encodes
+// the HTTP status + Google error status in its `reason` string, so we parse that
+// (the adapter does not currently populate `httpStatus`/`kind`). Bounded,
+// case-insensitive substring classification of provider-neutral error text.
+export const classifyVertexBillingOrQuotaError = (
+  error: InferenceAdapterError,
+): AgentClVertexCapacityErrorRef | undefined => {
+  const haystack =
+    `${error.reason} ${error.kind ?? ''} ${error.httpStatus ?? ''}`.toLowerCase()
+  if (error.httpStatus === 429 || haystack.includes('http 429')) {
+    return 'http_429'
+  }
+  if (haystack.includes('resource_exhausted')) {
+    return 'resource_exhausted'
+  }
+  if (haystack.includes('quota')) {
+    return 'quota_error'
+  }
+  if (
+    haystack.includes('billing') ||
+    haystack.includes('permission_denied') ||
+    haystack.includes('consumer') ||
+    haystack.includes('http 402') ||
+    haystack.includes('http 403')
+  ) {
+    return 'billing_error'
+  }
+  return undefined
+}
+
+// A single-call Effect that performs ONE real Vertex Gemini call and maps the
+// result into the loop's outcome union. Never fails (errors are folded into the
+// outcome) so the loop owns all control flow. Exposed as an Effect so the
+// Effect->Promise bridge (`Effect.runPromise`) stays at the runnable edge (the
+// scripts CLI + tests), keeping this domain module free of the temporary
+// runPromise bridge budget.
+export type AgentClVertexRunnerEffectFn = (
+  iteration: number,
+) => Effect.Effect<AgentClVertexCallOutcome>
+
+// Build the LIVE Vertex Gemini call effect: a real authorized paid call to
+// gemini-3.5-flash on project openagentsgemini, via the SAME adapter + SA-key
+// token path the inference gateway registers (`makeVertexGeminiAdapter` +
+// `tokenProviderFromSecret(VERTEX_SA_KEY)`). Returns the receipt-first provider
+// usage on success and a classified capacity-error / generic-error on failure.
+// It NEVER falls back to another lane - there is no other adapter here.
+export const makeVertexGeminiRunnerEffectFn = (
+  input: Readonly<{
+    prompt: string
+    // Raw VERTEX_SA_KEY service-account-key JSON string. The LIVE path supplies
+    // this; the adapter mints a short-lived GCP token from it.
+    serviceAccountKey?: string | undefined
+    // Pre-built token provider (tests inject this to exercise the served/error
+    // mapping without SA-key crypto or a real token mint).
+    tokenProvider?: VertexTokenProvider | undefined
+    model?: string | undefined
+    project?: string | undefined
+    location?: string | undefined
+    maxTokens?: number | undefined
+    // Injected for tests; defaults to global fetch inside the adapter.
+    fetchImpl?: typeof fetch | undefined
+  }>,
+): AgentClVertexRunnerEffectFn => {
+  const model = input.model ?? AGENTCL_VERTEX_GEMINI_RUNNER_MODEL_ID
+  const tokenProvider =
+    input.tokenProvider ??
+    (input.serviceAccountKey === undefined
+      ? undefined
+      : tokenProviderFromSecret(input.serviceAccountKey))
+  const adapter = makeVertexGeminiAdapter({
+    fetchImpl: input.fetchImpl,
+    location: input.location,
+    project: input.project ?? AGENTCL_VERTEX_GEMINI_PROJECT,
+    tokenProvider,
+  })
+
+  return () => {
+    const request: InferenceRequest = {
+      messages: [{ content: input.prompt, role: 'user' }],
+      model,
+      passthroughParams: {
+        max_tokens: input.maxTokens ?? 256,
+        temperature: 0,
+      },
+      stream: false,
+    }
+    return adapter.complete(request).pipe(
+      Effect.map(
+        (result): AgentClVertexCallOutcome => ({
+          _tag: 'served',
+          finishReason: result.finishReason,
+          servedAdapterId: VERTEX_GEMINI_ADAPTER_ID,
+          usage: result.usage,
+        }),
+      ),
+      Effect.catch(
+        (error): Effect.Effect<AgentClVertexCallOutcome> => {
+          const capacityErrorRef = classifyVertexBillingOrQuotaError(error)
+          return Effect.succeed(
+            capacityErrorRef !== undefined
+              ? { _tag: 'billing_or_quota_error', errorRef: capacityErrorRef }
+              : { _tag: 'error', errorRef: 'vertex_adapter_error' },
+          )
+        },
+      ),
+    )
+  }
+}


### PR DESCRIPTION
Implements #6788 (CL-4b). The CL-4 guardrail in `apps/openagents.com/workers/api/src/inference/gym/agentcl.ts` was a typed contract + a pure circuit-breaker decision function referenced ONLY by tests — no live Vertex client, no per-iteration enforcement, no live spend metering, no runtime kill-switch. This adds the runnable enforcement layer so a $50-bounded CL-5 run can be authorized safely.

## What landed
- **`src/inference/gym/agentcl-vertex-runner.ts`** — enforced per-iteration loop:
  - wires `assessAgentClVertexRunnerCircuitBreaker` BEFORE each call and AFTER each result; hard-stops at accumulated spend `>=` cap (default $50 = 5000c, env `CL_VERTEX_CAP_USD`) OR 3 consecutive billing/quota errors.
  - **live spend metered from REAL provider usage tokens** × the canonical `gemini-3.5-flash` price (`pricing.ts`), never a caller estimate.
  - **no-fallback guard**: refuses any model whose routing plan (`selectAdapterPlan`) carries a non-Vertex lane, and aborts mid-run if a non-`vertex-gemini` adapter serves a call. `gemini-3.5-flash` routes to `['vertex-gemini']` only.
  - live call effect reuses the registered Vertex Gemini adapter + SA-key token path (`makeVertexGeminiAdapter` + `tokenProviderFromSecret(VERTEX_SA_KEY)`). The Effect→Promise bridge stays at the runnable edge (CLI/tests) to keep the domain module off the runPromise bridge budget.
- **`scripts/agentcl-vertex-runner.ts`** — CLI:
  - `--dry-run` (default, no network/no spend) proves: cap-halt at exactly $50, no call after halt, GLM-fallback refusal (mid-run + routing-plan + non-vertex serve), and the 3-error breaker.
  - `--live` gated behind `CL_VERTEX_ARMED=1` + `VERTEX_SA_KEY` so it can never spend by accident.
- **tests** — cap-halt, no-call-after-halt, no-fallback, 3-error breaker, dry-run no-spend, error classification, and real-adapter served/429 mapping over a stubbed fetch.

## Verification
- `bun run check:deploy` green.
- 21 runner tests pass; `--dry-run` prints `DRY-RUN: ALL PROOFS PASSED`.
- **No live Vertex call made in this change.** The owner/overseer runs live $50 tranches separately.

## One live $50 tranche (owner-run)
```
CL_VERTEX_ARMED=1 CL_VERTEX_CAP_USD=50 VERTEX_SA_KEY="$(cat sa.json)" \
  bun run apps/openagents.com/workers/api/scripts/agentcl-vertex-runner.ts --live
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)