### PR TITLE
fix(web): restore main green — runtime time helpers in Artanis accounts countdown

### DIFF
--- a/apps/openagents.com/apps/web/src/page/artanisAccounts.ts
+++ b/apps/openagents.com/apps/web/src/page/artanisAccounts.ts
@@ -5,6 +5,7 @@ import { html } from 'foldkit/html'
 import * as Ui from '../ui'
 import type { PublicHeaderAuthState } from './publicHeader'
 import * as PublicHeader from './publicHeader'
+import { currentUnixMs } from '../time-format'
 
 type AccountUsageWindow = Readonly<{
   cap: number | null
@@ -69,12 +70,12 @@ const labelForProvider = (provider: string): string =>
 const shortAccountRef = (ref: string): string =>
   ref.length <= 18 ? ref : `${ref.slice(0, 14)}...${ref.slice(-4)}`
 
-const countdownLabel = (expiresAt: string | null, now = Date.now()): string => {
+const countdownLabel = (expiresAt: string | null, now = currentUnixMs()): string => {
   if (expiresAt === null) {
     return 'available'
   }
 
-  const remainingMs = new Date(expiresAt).getTime() - now
+  const remainingMs = Date.parse(expiresAt) - now
 
   if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
     return 'ready now'


### PR DESCRIPTION
PR #6807 merged with two raw time primitives in `apps/openagents.com/apps/web/src/page/artanisAccounts.ts` (a `Date.now()` default param and `new Date(expiresAt).getTime()`), which trips the zero-debt architecture check (`raw time/id/random primitives` budget = 0) and turned `main` red on `check:deploy`.

This restores green by using the existing `apps/web/src/time-format.ts` convention: `currentUnixMs()` (the allowlisted now helper) and `Date.parse()` (which the canonical helper itself uses and the checker does not flag). No behavior change.

`bun run check:deploy` green locally.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>