### PR TITLE
inference: fan out internal-stress/CL burn demand across multiple Khala lanes

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -2446,6 +2446,156 @@ describe('POST /v1/chat/completions', () => {
     expect(body.openagents?.worker).toBe(FIREWORKS_STRONG_CODING_ADAPTER_ID)
   })
 
+  test('fans out internal_stress cl-saturation Khala traffic across every registered lane, counting each serve + trace', async () => {
+    // The throughput unlock: with GLM own-capacity down, three paid lanes are
+    // registered (Vertex + Fireworks + OpenRouter). Burn traffic must SPREAD
+    // round-robin across all three so aggregate throughput is the SUM of their
+    // serve rates, instead of pinning the single primary lane (Vertex).
+    const registry = new InferenceProviderRegistry()
+    registry.register(echoAdapter(VERTEX_GEMINI_ADAPTER_ID))
+    registry.register(echoAdapter(FIREWORKS_ADAPTER_ID))
+    registry.register(echoAdapter(OPENROUTER_KHALA_FALLBACK_ADAPTER_ID))
+
+    const recorded: Array<
+      Readonly<{
+        adapterId: string
+        demandKind: string
+        demandSource: string | undefined
+        requestedModel: string
+      }>
+    > = []
+    const traced: Array<string | undefined> = []
+    let rotation = 0
+
+    const servedWorkers: Array<string> = []
+    for (let index = 0; index < 4; index += 1) {
+      const response = await run(
+        handleChatCompletions(
+          chatRequest(
+            { ...helloBody, oa_emit_trace: true },
+            {
+              headers: {
+                [INFERENCE_CLIENT_HEADER]: 'cl-burn-harness',
+                [INFERENCE_DEMAND_KIND_HEADER]: 'internal_stress',
+                [INFERENCE_DEMAND_SOURCE_HEADER]: 'cl-saturation',
+              },
+            },
+          ),
+          baseDeps({
+            dispatch: { sleep: () => Effect.void },
+            // The full conversational Khala plan (four lanes); GLM is NOT
+            // registered, so the fan-out spreads over the three real lanes only.
+            lanePlan: () => [
+              VERTEX_GEMINI_ADAPTER_ID,
+              FIREWORKS_ADAPTER_ID,
+              HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+              OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+            ],
+            // Deterministic round-robin sequence 0,1,2,3 for this test.
+            multiLaneBurnRotation: () => rotation++,
+            recordTokensServed: input =>
+              Effect.sync(() => {
+                recorded.push({
+                  adapterId: input.adapterId,
+                  demandKind: input.requestAttribution?.demandKind ?? 'none',
+                  demandSource: input.requestAttribution?.demandSource,
+                  requestedModel: input.requestedModel,
+                })
+              }),
+            registry,
+            traceEmit: {
+              emit: async emitInput => {
+                traced.push(emitInput.requestAttribution?.demandSource)
+                return { emitted: true }
+              },
+              enabled: true,
+            },
+          }),
+        ),
+      )
+      expect(response.status).toBe(200)
+      const body = (await response.json()) as {
+        openagents?: { worker?: string }
+      }
+      servedWorkers.push(body.openagents!.worker!)
+    }
+
+    // Four concurrent burn requests cover ALL THREE registered lanes round-robin
+    // (the unregistered GLM rotation slot is skipped, the 4th wraps to Vertex).
+    expect(new Set(servedWorkers.slice(0, 3)).size).toBe(3)
+    expect(servedWorkers).toEqual([
+      VERTEX_GEMINI_ADAPTER_ID,
+      FIREWORKS_ADAPTER_ID,
+      OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      VERTEX_GEMINI_ADAPTER_ID,
+    ])
+    // Each served request recorded exactly one token_usage row on the lane that
+    // actually served — the khala counter keeps counting on every lane.
+    expect(recorded.map(entry => entry.adapterId)).toEqual(servedWorkers)
+    // ...and every row keeps the Khala model + internal_stress/cl-saturation
+    // attribution intact (so the public counter projects them on `openagents/khala`).
+    expect(
+      recorded.every(
+        entry =>
+          entry.requestedModel === KHALA_MODEL_ID &&
+          entry.demandKind === 'internal_stress' &&
+          entry.demandSource === 'cl-saturation',
+      ),
+    ).toBe(true)
+    // ...and emitted exactly one trace per served request.
+    expect(traced).toEqual([
+      'cl-saturation',
+      'cl-saturation',
+      'cl-saturation',
+      'cl-saturation',
+    ])
+  })
+
+  test('does NOT fan out normal (non-burn) Khala traffic; default routing unchanged', async () => {
+    // A plain Khala request must keep today's behavior: pin the primary lane and
+    // never consult the fan-out rotation. (Overflow still applies on failure.)
+    const registry = new InferenceProviderRegistry()
+    registry.register(echoAdapter(VERTEX_GEMINI_ADAPTER_ID))
+    registry.register(echoAdapter(FIREWORKS_ADAPTER_ID))
+    registry.register(echoAdapter(OPENROUTER_KHALA_FALLBACK_ADAPTER_ID))
+
+    let rotationCalls = 0
+    const servedWorkers: Array<string> = []
+    for (let index = 0; index < 3; index += 1) {
+      const response = await run(
+        handleChatCompletions(
+          chatRequest(helloBody),
+          baseDeps({
+            dispatch: { sleep: () => Effect.void },
+            lanePlan: () => [
+              VERTEX_GEMINI_ADAPTER_ID,
+              FIREWORKS_ADAPTER_ID,
+              OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+            ],
+            multiLaneBurnRotation: () => {
+              rotationCalls += 1
+              return rotationCalls
+            },
+            registry,
+          }),
+        ),
+      )
+      expect(response.status).toBe(200)
+      const body = (await response.json()) as {
+        openagents?: { worker?: string }
+      }
+      servedWorkers.push(body.openagents!.worker!)
+    }
+
+    expect(servedWorkers).toEqual([
+      VERTEX_GEMINI_ADAPTER_ID,
+      VERTEX_GEMINI_ADAPTER_ID,
+      VERTEX_GEMINI_ADAPTER_ID,
+    ])
+    // The rotation counter is never consulted for non-burn traffic.
+    expect(rotationCalls).toBe(0)
+  })
+
   test('keeps GLM saturation internal_stress on GLM instead of overflowing to Fireworks', async () => {
     let fireworksCalls = 0
     let glmCalls = 0

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -153,6 +153,8 @@ import {
   classifyModel,
   dispatchWithOverflow,
   dispatchWithOverflowWithMetadata,
+  isMultiLaneBurnDemandSource,
+  selectAdapterPlanForKhalaMultiLaneBurnRequest,
   selectAdapterPlanForKhalaStrongCodingRequest,
   selectAdapterPlanForKhalaToolRequest,
 } from './model-router'
@@ -338,6 +340,22 @@ const routeDemandClassFromAttribution = (
         attribution?.demandKind === undefined
       ? 'external'
       : 'batch'
+
+// Private module-level round-robin counter for MULTI-LANE FAN-OUT (throughput
+// unlock). Advances once per burn request so successive concurrent
+// continual-learning / stress requests start on different lanes. Wraps well
+// below MAX_SAFE_INTEGER; only the value mod laneCount matters. This is the
+// DEFAULT source for `deps.multiLaneBurnRotation`, so the fan-out mode needs no
+// Worker wiring change — the request headers alone select it.
+let multiLaneBurnRotationCounter = 0
+const nextMultiLaneBurnRotationIndex = (): number => {
+  const index = multiLaneBurnRotationCounter
+  multiLaneBurnRotationCounter =
+    multiLaneBurnRotationCounter >= Number.MAX_SAFE_INTEGER - 1
+      ? 0
+      : multiLaneBurnRotationCounter + 1
+  return index
+}
 
 const booleanBodyFlag = (body: Record<string, unknown>, key: string): boolean =>
   body[key] === true || body[key] === 'true' || body[key] === 1
@@ -544,6 +562,18 @@ export type ChatCompletionsDeps = Readonly<{
   // When present, the route dispatches across the plan with bounded-backoff
   // overflow on retryable failures. The Worker wires this to `selectAdapterPlan`.
   lanePlan?: ModelLanePlanner
+  // MULTI-LANE FAN-OUT ROTATION (throughput unlock). Returns the per-request
+  // round-robin index used to rotate the Khala lane plan ONLY for the internal
+  // continual-learning / stress "burn" demand-source (demand_kind=internal_stress
+  // + demand_source in MULTILANE_BURN_DEMAND_SOURCES). Each call should return a
+  // monotonically advancing integer so successive concurrent burn requests start
+  // on different lanes and aggregate throughput becomes the SUM of the healthy
+  // paid lanes' capacities instead of one lane's serve rate. Default: a private
+  // module-level monotonic counter, so the mode works in prod with NO Worker
+  // wiring change — only the request headers select it. Tests inject a controlled
+  // sequence to assert deterministic spread. Never consulted for any other
+  // demand class or model, so default user routing is unaffected.
+  multiLaneBurnRotation?: (() => number) | undefined
   // PROVIDER SERVING POLICY (blocker.product_promises.public_paid_model_gateway_missing
   // on api.hosted_gemini.v1). The SAME presence-derived lane arming the public
   // catalog (`/v1/models`) and the pre-purchase quote (`/v1/quote`) are gated on.
@@ -2925,6 +2955,21 @@ export const handleChatCompletions = (
       isKhalaModel(requestedModel) &&
       requestAttribution?.demandKind === 'internal_stress' &&
       requestAttribution.demandSource === 'glm-saturation'
+    // MULTI-LANE FAN-OUT (throughput unlock). Honestly-tagged internal
+    // continual-learning / stress burn traffic (`demand_kind=internal_stress`,
+    // `demand_source` in MULTILANE_BURN_DEMAND_SOURCES) is SPREAD across the
+    // healthy paid lanes instead of pinning the single primary lane. Each request
+    // rotates the registered Khala lane plan by a per-request round-robin index,
+    // so concurrent burn requests start on different lanes (Vertex + Fireworks +
+    // OpenRouter + GLM-when-up) and aggregate throughput becomes the SUM of those
+    // lanes' serve rates rather than one lane's cap. Gated on the internal burn
+    // demand-source only, so normal conversational, tool, mirrorcode, and external
+    // Khala routing is completely unchanged. The chosen primary still keeps the
+    // full remaining plan behind it, preserving overflow + fail-closed posture.
+    const multiLaneBurnKhalaRequest =
+      isKhalaModel(requestedModel) &&
+      requestAttribution?.demandKind === 'internal_stress' &&
+      isMultiLaneBurnDemandSource(requestAttribution.demandSource)
     // INTERNAL FRONTIER-CODING OVERRIDE (MirrorCode gym rung). Honestly-tagged
     // internal frontier-coding eval load (`demand_kind=internal`,
     // `demand_source=gym_mirrorcode`) that is tool-bearing is routed to the
@@ -2939,20 +2984,31 @@ export const handleChatCompletions = (
       requestAttribution.demandSource === 'gym_mirrorcode'
     const basePlannedIds = callerPaidByok
       ? [OPENROUTER_KHALA_FALLBACK_ADAPTER_ID]
-      : mirrorcodeStrongCodingKhalaRequest
-        ? selectAdapterPlanForKhalaStrongCodingRequest(
+      : multiLaneBurnKhalaRequest
+        ? // Rotate only across lanes that are actually registered (so the spread
+          // lands on lanes that can serve), keeping the per-request round-robin
+          // index from the injected counter / module-level default.
+          selectAdapterPlanForKhalaMultiLaneBurnRequest(
             requestedModel,
-            plannedIdsForModel,
+            plannedIdsForModel.filter(
+              id => deps.registry.resolve(id) !== undefined,
+            ),
+            (deps.multiLaneBurnRotation ?? nextMultiLaneBurnRotationIndex)(),
           )
-        : glmSaturationStressKhalaRequest &&
-            plannedIdsForModel.includes(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID)
-          ? [HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID]
-          : toolBearingKhalaRequest || glmSaturationStressKhalaRequest
-            ? selectAdapterPlanForKhalaToolRequest(
-                requestedModel,
-                plannedIdsForModel,
-              )
-            : plannedIdsForModel
+        : mirrorcodeStrongCodingKhalaRequest
+          ? selectAdapterPlanForKhalaStrongCodingRequest(
+              requestedModel,
+              plannedIdsForModel,
+            )
+          : glmSaturationStressKhalaRequest &&
+              plannedIdsForModel.includes(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID)
+            ? [HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID]
+            : toolBearingKhalaRequest || glmSaturationStressKhalaRequest
+              ? selectAdapterPlanForKhalaToolRequest(
+                  requestedModel,
+                  plannedIdsForModel,
+                )
+              : plannedIdsForModel
 
     // CACHE-AFFINITY RESOLUTION (book P0-2 deliverables 3+4). Compose the
     // account/session/codebase key, its public-safe hash (for the receipt), and
@@ -2969,19 +3025,25 @@ export const handleChatCompletions = (
     // passing health + privacy/region gates. Pure reorder: the overflow tail is
     // preserved behind the warm lane. Inert when no oracle is wired (plan
     // unchanged) so existing behavior is unaffected until the Worker wires it.
-    const routingDecision = decideCacheAwareRouting({
-      affinityHash: affinity.hash,
-      plannedLanes: basePlannedIds,
-      ...(deps.cacheWarmthOracle === undefined
-        ? {}
-        : { warmthOracle: deps.cacheWarmthOracle }),
-      ...(deps.laneHealthOracle === undefined
-        ? {}
-        : { healthOracle: deps.laneHealthOracle }),
-      ...(deps.cachePinPolicy === undefined
-        ? {}
-        : { pinPolicy: deps.cachePinPolicy }),
-    })
+    // MULTI-LANE FAN-OUT bypasses cache-warmth reordering: a burn request
+    // deliberately wants to SPREAD across lanes (round-robin primary), not pin to
+    // the cache-warm lane, so the rotation must survive intact. Cache-aware
+    // routing still governs every normal request unchanged.
+    const routingDecision = multiLaneBurnKhalaRequest
+      ? { lanes: basePlannedIds }
+      : decideCacheAwareRouting({
+          affinityHash: affinity.hash,
+          plannedLanes: basePlannedIds,
+          ...(deps.cacheWarmthOracle === undefined
+            ? {}
+            : { warmthOracle: deps.cacheWarmthOracle }),
+          ...(deps.laneHealthOracle === undefined
+            ? {}
+            : { healthOracle: deps.laneHealthOracle }),
+          ...(deps.cachePinPolicy === undefined
+            ? {}
+            : { pinPolicy: deps.cachePinPolicy }),
+        })
     const plannedIds = routingDecision.lanes
 
     // model_unavailable when no lane is configured OR none of the planned lanes

--- a/apps/openagents.com/workers/api/src/inference/model-router.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.test.ts
@@ -19,11 +19,14 @@ import {
   classifyModel,
   dispatchWithOverflow,
   dispatchWithOverflowWithMetadata,
+  isMultiLaneBurnDemandSource,
   makeBoundedDispatchFailureTelemetry,
   makeKhalaBackedAdapterPlan,
   openModelsByCost,
+  rotateAdapterPlan,
   selectAdapterPlan,
   selectAdapterPlanForKhalaBacking,
+  selectAdapterPlanForKhalaMultiLaneBurnRequest,
   selectAdapterPlanForKhalaStrongCodingRequest,
   selectAdapterPlanForKhalaToolRequest,
   selectPrimaryAdapterId,
@@ -1564,5 +1567,120 @@ describe('dispatchWithOverflow', () => {
     expect(DEFAULT_OVERFLOW_BACKOFF.maxDelayMs).toBeGreaterThanOrEqual(
       DEFAULT_OVERFLOW_BACKOFF.baseDelayMs,
     )
+  })
+})
+
+describe('multi-lane fan-out (throughput unlock)', () => {
+  test('recognizes the burn demand sources case-insensitively', () => {
+    expect(isMultiLaneBurnDemandSource('multilane-burn')).toBe(true)
+    expect(isMultiLaneBurnDemandSource('cl-saturation')).toBe(true)
+    expect(isMultiLaneBurnDemandSource(' CL-Saturation ')).toBe(true)
+    // The existing GLM-pin source and an unknown source do NOT fan out.
+    expect(isMultiLaneBurnDemandSource('glm-saturation')).toBe(false)
+    expect(isMultiLaneBurnDemandSource('gym_mirrorcode')).toBe(false)
+    expect(isMultiLaneBurnDemandSource(undefined)).toBe(false)
+  })
+
+  test('rotateAdapterPlan is a left rotation and a pure permutation', () => {
+    const plan = ['a', 'b', 'c', 'd']
+    expect(rotateAdapterPlan(plan, 0)).toEqual(['a', 'b', 'c', 'd'])
+    expect(rotateAdapterPlan(plan, 1)).toEqual(['b', 'c', 'd', 'a'])
+    expect(rotateAdapterPlan(plan, 2)).toEqual(['c', 'd', 'a', 'b'])
+    expect(rotateAdapterPlan(plan, 3)).toEqual(['d', 'a', 'b', 'c'])
+    // Wraps modulo length, so request N starts on lane N mod laneCount.
+    expect(rotateAdapterPlan(plan, 4)).toEqual(['a', 'b', 'c', 'd'])
+    expect(rotateAdapterPlan(plan, 5)).toEqual(['b', 'c', 'd', 'a'])
+    // Every rotation is a permutation: same multiset, no lane dropped or added.
+    for (let index = 0; index < 12; index += 1) {
+      expect([...rotateAdapterPlan(plan, index)].sort()).toEqual([
+        'a',
+        'b',
+        'c',
+        'd',
+      ])
+    }
+  })
+
+  test('rotateAdapterPlan normalizes non-finite / negative / fractional indices', () => {
+    const plan = ['a', 'b', 'c']
+    expect(rotateAdapterPlan(plan, -1)).toEqual(['c', 'a', 'b'])
+    expect(rotateAdapterPlan(plan, 1.9)).toEqual(['b', 'c', 'a'])
+    expect(rotateAdapterPlan(plan, Number.NaN)).toEqual(['a', 'b', 'c'])
+    expect(rotateAdapterPlan(plan, Number.POSITIVE_INFINITY)).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+    // A 0/1-element plan can never fan out and is returned unchanged.
+    expect(rotateAdapterPlan([], 3)).toEqual([])
+    expect(rotateAdapterPlan(['only'], 3)).toEqual(['only'])
+  })
+
+  test('fan-out plan rotates the Khala plan so successive requests start on different lanes', () => {
+    const base = [
+      VERTEX_GEMINI_ADAPTER_ID,
+      FIREWORKS_ADAPTER_ID,
+      HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+      OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+    ]
+    const primaries = [0, 1, 2, 3, 4].map(
+      index =>
+        selectAdapterPlanForKhalaMultiLaneBurnRequest(
+          KHALA_MODEL_ID,
+          base,
+          index,
+        )[0],
+    )
+    // Four concurrent burn requests cover ALL four lanes (sum-of-capacity spread).
+    expect(new Set(primaries.slice(0, 4)).size).toBe(4)
+    expect(primaries).toEqual([
+      VERTEX_GEMINI_ADAPTER_ID,
+      FIREWORKS_ADAPTER_ID,
+      HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+      OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      VERTEX_GEMINI_ADAPTER_ID,
+    ])
+    // Each rotated plan still carries the full overflow tail (fail-closed).
+    for (let index = 0; index < 4; index += 1) {
+      expect(
+        [
+          ...selectAdapterPlanForKhalaMultiLaneBurnRequest(
+            KHALA_MODEL_ID,
+            base,
+            index,
+          ),
+        ].sort(),
+      ).toEqual([...base].sort())
+    }
+  })
+
+  test('fan-out spreads only across the registered/eligible lanes it is given', () => {
+    // The route passes only the registered lanes; with GLM down, the burn spread
+    // is across Vertex + Fireworks + OpenRouter (the real paid lanes today).
+    const registeredOnly = [
+      VERTEX_GEMINI_ADAPTER_ID,
+      FIREWORKS_ADAPTER_ID,
+      OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+    ]
+    const primaries = [0, 1, 2, 3].map(
+      index =>
+        selectAdapterPlanForKhalaMultiLaneBurnRequest(
+          KHALA_MODEL_ID,
+          registeredOnly,
+          index,
+        )[0],
+    )
+    expect(new Set(primaries.slice(0, 3)).size).toBe(3)
+    expect(primaries[3]).toBe(VERTEX_GEMINI_ADAPTER_ID)
+  })
+
+  test('non-Khala models never fan out (default routing unchanged)', () => {
+    const base = ['lane-a', 'lane-b', 'lane-c']
+    expect(
+      selectAdapterPlanForKhalaMultiLaneBurnRequest('claude-3-5-sonnet', base, 1),
+    ).toEqual(base)
+    expect(
+      selectAdapterPlanForKhalaMultiLaneBurnRequest('gemini-3.5-flash', base, 2),
+    ).toEqual(base)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/model-router.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.ts
@@ -366,6 +366,86 @@ export const makeKhalaBackedAdapterPlan =
       khalaBacking ?? KHALA_BACKING_HYDRALISK_GPT_OSS,
     )
 
+// ----------------------------------------------------------------------------
+// MULTI-LANE FAN-OUT (throughput unlock)
+// ----------------------------------------------------------------------------
+//
+// The normal Khala plan is an ORDERED overflow chain: every request starts on
+// the same primary lane (Vertex Gemini today) and only moves to the next lane
+// when the primary typed-fails retryably (429 / 503 / transport). When the
+// primary lane serves at its own rate WITHOUT 429ing (exactly Vertex's
+// behavior), every request pins to that one lane and aggregate throughput is
+// capped at a single lane's serve rate — overflow never triggers, so the other
+// healthy paid lanes sit idle.
+//
+// For honestly-tagged internal continual-learning / stress burn demand we want
+// the opposite: spread successive concurrent requests ACROSS the healthy paid
+// lanes so aggregate throughput becomes the SUM of the lanes' capacities. This
+// is a pure ROTATION of the lane plan by a per-request round-robin index: request
+// N starts on lane (N mod laneCount), and each request still keeps the full
+// remaining plan behind its chosen primary, so a chosen lane that rate-limits or
+// is quarantined still overflows down the rest of the chain (fail-closed posture
+// and the no-fallback guarantees of other modes are untouched — this only
+// activates for the new burn demand-source on the Khala model).
+//
+// Round-robin (rotate the plan) rather than random so a bounded number of
+// concurrent requests provably touches every lane, and so tests are
+// deterministic given the injected index sequence.
+
+// Demand-source tokens (lowercased `x-openagents-demand-source` values) that
+// opt an `internal_stress` Khala request into multi-lane fan-out. Both spellings
+// are accepted so callers can label the lane by intent (a generic multi-lane
+// burn, or a continual-learning saturation run) without a code change.
+export const MULTILANE_BURN_DEMAND_SOURCES: ReadonlyArray<string> = [
+  'multilane-burn',
+  'cl-saturation',
+]
+
+export const isMultiLaneBurnDemandSource = (
+  demandSource: string | undefined,
+): boolean =>
+  demandSource !== undefined &&
+  MULTILANE_BURN_DEMAND_SOURCES.includes(demandSource.trim().toLowerCase())
+
+// Rotate an ordered adapter plan left by `rotationIndex` positions. Pure +
+// deterministic: a non-finite / fractional / negative index is normalized into
+// `[0, length)`. The rotated list is a permutation of the input — no lane is
+// dropped or added — so the chosen primary still overflows down the full
+// remaining chain. A 0/1-element plan is returned unchanged.
+export const rotateAdapterPlan = (
+  adapterIds: ReadonlyArray<string>,
+  rotationIndex: number,
+): ReadonlyArray<string> => {
+  const length = adapterIds.length
+  if (length <= 1) {
+    return adapterIds
+  }
+  const safeIndex = Number.isFinite(rotationIndex)
+    ? Math.trunc(rotationIndex)
+    : 0
+  const offset = ((safeIndex % length) + length) % length
+  if (offset === 0) {
+    return adapterIds
+  }
+  return [...adapterIds.slice(offset), ...adapterIds.slice(0, offset)]
+}
+
+// Resolve the MULTI-LANE FAN-OUT plan for a Khala burn request. Only the public
+// Khala alias fans out; any other model id keeps its base plan unchanged. The
+// caller passes the already health/registration-eligible base plan (so rotation
+// spreads only across lanes that can actually serve) plus the per-request
+// round-robin index. Deterministic + pure; the caller gates this on the
+// internal burn demand-source so normal conversational, tool, and external Khala
+// routing is never affected.
+export const selectAdapterPlanForKhalaMultiLaneBurnRequest = (
+  model: string,
+  basePlan: ReadonlyArray<string>,
+  rotationIndex: number,
+): ReadonlyArray<string> =>
+  normalizeKhalaModelId(model) === KHALA_MODEL_ID
+    ? rotateAdapterPlan(basePlan, rotationIndex)
+    : basePlan
+
 // Resolve a requested model to its ORDERED list of candidate adapter ids
 // (cheapest viable first, then overflow fallbacks). Deterministic + pure.
 export const selectAdapterPlan = (model: string): ReadonlyArray<string> => {


### PR DESCRIPTION
## Throughput unlock

The Khala route was capped at ~one lane's serve rate: every `openagents/khala`
request starts on the same primary lane (Vertex Gemini), and Vertex serves at
its own rate without 429ing, so the existing overflow-to-next-lane chain never
triggers and the other healthy paid lanes sit idle.

This adds a **multi-lane fan-out** mode for honestly-tagged internal
continual-learning / stress *burn* demand so concurrent CL/stress traffic uses
all healthy paid lanes at once and aggregate throughput becomes the **SUM** of
the lanes' capacities.

## How to invoke

Send to model `openagents/khala` with headers:

- `x-openagents-demand-kind: internal_stress`
- `x-openagents-demand-source: cl-saturation` (or `multilane-burn`)

## Lanes it spreads across

The registered subset of the conversational Khala plan, round-robin per request:
**Vertex Gemini + Fireworks + OpenRouter** (and **GLM/hydralisk** when up).
Unregistered/quarantined lanes are skipped; the chosen primary still overflows
down the full remaining plan (fail-closed posture preserved).

## Guarantees

- **Default user routing unchanged** — plain `openagents/khala` for real users
  keeps current behavior; the rotation counter is never consulted off the burn
  path. Tool/mirrorcode/glm-saturation/external modes untouched.
- **Counting preserved** — each served request still records one
  `token_usage_events` row + one `agent_traces` row on whichever lane served,
  keyed off the served adapter id / requested model, so the public Khala counter
  keeps counting on `openagents/khala` across all lanes.
- **Privacy/region + no-fallback** modes are unaffected (burn gated on the new
  demand-source only); cache-warmth reorder is bypassed for burn so the spread
  survives.
- Prod needs **no Worker wiring change** — the headers alone select the mode
  (module-level round-robin default).

## Tests

- `model-router.test.ts`: pure `rotateAdapterPlan`, `isMultiLaneBurnDemandSource`,
  `selectAdapterPlanForKhalaMultiLaneBurnRequest` (spread + permutation + non-Khala unchanged).
- `chat-completions-routes.test.ts`: burn spreads across all registered lanes
  round-robin with one usage row + one trace per served request; non-burn Khala
  traffic never rotates.

`bun run check:deploy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)