### PR TITLE
feat(pylon): add operator account manual reset endpoint

### DIFF
--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -1158,7 +1158,19 @@ const runHeadlessNode = Effect.gen(function* () {
       sessions: headlessSessionsWithExternal,
       intents: makeIntentActions(headlessIntentQueue),
       accountsList: () => collectPylonAccountsList(bootstrapSummary),
-      accountsStatus: () => collectPylonOperatorAccountStatus(bootstrapSummary),
+      accountsStatus: (input) => input?.reset && input.accountRef
+        ? collectPylonAccountsStatus(
+            bootstrapSummary,
+            {
+              accountRef: input.accountRef,
+              provider: null,
+              all: false,
+              json: true,
+              reset: true,
+            },
+            { env: Bun.env },
+          )
+        : collectPylonOperatorAccountStatus(bootstrapSummary),
       // The supervisor-status provider comes from the launch lifecycle owner
       // above (undefined unless PYLON_APPLE_FM_SUPERVISE=1 and a helper exists),
       // so by default this is the unsupervised projection unchanged.

--- a/apps/pylon/src/node/control-server.ts
+++ b/apps/pylon/src/node/control-server.ts
@@ -133,7 +133,7 @@ export interface ControlCommandActions {
   }
   // CL-18: read-only accounts + readiness panel (public-projection-safe).
   accountsList?: () => Promise<unknown>
-  accountsStatus?: () => Promise<unknown>
+  accountsStatus?: (input?: { accountRef?: string; reset?: boolean }) => Promise<unknown>
   // CL-16: read-only pending approvals + exactly-once resolve (approve/deny/answer).
   approvals?: {
     list: () => Promise<unknown>
@@ -707,6 +707,39 @@ export const startControlServer = (
               return Response.json(await options.actions.accountsStatus(), {
                 headers: { "cache-control": "no-store" },
               })
+            }
+
+            const accountManualResetMatch =
+              request.method === "POST"
+                ? (
+                    /^\/api\/operator\/accounts\/([^/]+)\/manual-reset$/.exec(url.pathname) ??
+                    /^\/api\/operator\/accounts\/status\/([^/]+)\/manual-reset$/.exec(url.pathname)
+                  )
+                : null
+            if (accountManualResetMatch) {
+              if (!authorized(request)) {
+                return Response.json(
+                  { error: "operator ledger access required" },
+                  { status: 403, headers: { "cache-control": "no-store" } },
+                )
+              }
+              if (!options.actions.accountsStatus) {
+                return Response.json(
+                  { error: "account status unavailable" },
+                  { status: 404, headers: { "cache-control": "no-store" } },
+                )
+              }
+              const accountRef = decodeURIComponent(accountManualResetMatch[1] ?? "")
+              if (accountRef.length === 0) {
+                return Response.json(
+                  { error: "account ref required" },
+                  { status: 400, headers: { "cache-control": "no-store" } },
+                )
+              }
+              return Response.json(
+                await options.actions.accountsStatus({ accountRef, reset: true }),
+                { headers: { "cache-control": "no-store" } },
+              )
             }
 
             if (!authorized(request)) return unauthorized()

--- a/apps/pylon/tests/control-protocol.test.ts
+++ b/apps/pylon/tests/control-protocol.test.ts
@@ -306,6 +306,64 @@ describe("control protocol", () => {
     )
   })
 
+  test("operator manual account reset endpoint is bearer gated and no-store", async () => {
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const calls: Array<Record<string, unknown>> = []
+          const runtime = yield* makePylonNodeRuntime
+          const server = yield* startControlServer(runtime, {
+            token: "test-token-0123456789abcdef",
+            actions: {
+              ...stubActions([]),
+              accountsStatus: async (input?: { accountRef?: string; reset?: boolean }) => {
+                calls.push({ input })
+                return {
+                  schema: "openagents.pylon.accounts_status.v0.1",
+                  observedAt: "2026-06-28T00:00:00.000Z",
+                  accounts: [
+                    {
+                      accountRefHash: "account.pylon.codex.abc",
+                      provider: "codex",
+                      accountRef: "codex",
+                      quota: { state: "available", cooldownExpiresAt: null },
+                      manualReset: { performed: true, manualResetsRemaining: 2 },
+                    },
+                  ],
+                  blockerRefs: [],
+                }
+              },
+            },
+            port: 0,
+          })
+
+          const denied = yield* Effect.promise(() =>
+            fetch(`${server.url}/api/operator/accounts/codex/manual-reset`, {
+              method: "POST",
+              headers: { authorization: "Bearer wrong" },
+            }),
+          )
+          expect(denied.status).toBe(403)
+          expect(denied.headers.get("cache-control")).toBe("no-store")
+          const deniedBody = yield* Effect.promise(() => denied.text())
+          expect(deniedBody).not.toContain("account.pylon.codex.abc")
+
+          const allowed = yield* Effect.promise(() =>
+            fetch(`${server.url}/api/operator/accounts/codex/manual-reset`, {
+              method: "POST",
+              headers: { authorization: "Bearer test-token-0123456789abcdef" },
+            }),
+          )
+          expect(allowed.status).toBe(200)
+          expect(allowed.headers.get("cache-control")).toBe("no-store")
+          expect(calls).toEqual([{ input: { accountRef: "codex", reset: true } }])
+          const body = yield* Effect.promise(() => allowed.json() as Promise<{ accounts: unknown[] }>)
+          expect(body.accounts).toHaveLength(1)
+        }),
+      ),
+    )
+  })
+
   test("assignments commands round-trip and report unavailability", async () => {
     const calls: Array<Record<string, unknown>> = []
     await Effect.runPromise(


### PR DESCRIPTION
Addresses #6637.

### Changes
- Adds a bearer-gated operator manual reset endpoint for account status.
- Routes manual reset requests through the Pylon account status action with the selected account ref.
- Adds control protocol coverage for authorization, no-store headers, and reset invocation.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).