### PR TITLE
fix(pylon): scope event idempotency keys

### DIFF
--- a/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
@@ -62,6 +62,11 @@ type PylonRouteJson = Readonly<{
     walletSpendAllowed?: boolean
   }>
   error?: string
+  event?: Readonly<{
+    eventKind?: string
+    pylonRef?: string
+    status?: string
+  }>
   reason?: string
   events?: ReadonlyArray<unknown>
   idempotent?: boolean
@@ -3401,15 +3406,54 @@ describe('Pylon API routes', () => {
     expect(rejectedBody.assignment?.state).toBe('rejected')
   })
 
-  test('rejects idempotency key reuse across Pylons, agents, and event kinds', async () => {
+  test('scopes event idempotency keys by owner, Pylon, event kind, and assignment', async () => {
     const store = new MemoryPylonApiStore()
     await registerPylon(store)
-    await route(store, '/api/pylons/pylon.test.one/heartbeat', {
-      body: { healthRefs: ['health.public.ok'] },
-      idempotencyKey: 'pylon-event-key',
-      method: 'POST',
+    const firstHeartbeat = await route(
+      store,
+      '/api/pylons/pylon.test.one/heartbeat',
+      {
+        body: { healthRefs: ['health.public.ok'] },
+        idempotencyKey: 'pylon-event-key',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
+    const replayHeartbeat = await route(
+      store,
+      '/api/pylons/pylon.test.one/heartbeat',
+      {
+        body: { healthRefs: ['health.public.changed'] },
+        idempotencyKey: 'pylon-event-key',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
+    await registerPylon(store, {
+      idempotencyKey: 'register-pylon-test-two',
+      pylonRef: 'pylon.test.two',
       tokenUserId: 'agent-one',
     })
+    const sameKeyDifferentPylon = await route(
+      store,
+      '/api/pylons/pylon.test.two/heartbeat',
+      {
+        body: { healthRefs: ['health.public.ok'] },
+        idempotencyKey: 'pylon-event-key',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
+    const sameKeyDifferentEventKind = await route(
+      store,
+      '/api/pylons/pylon.test.one/wallet-readiness',
+      {
+        body: { walletReady: true },
+        idempotencyKey: 'pylon-event-key',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
     const wrongOwner = await route(
       store,
       '/api/pylons/pylon.test.one/heartbeat',
@@ -3420,22 +3464,16 @@ describe('Pylon API routes', () => {
         tokenUserId: 'agent-two',
       },
     )
-    const wrongEventKind = await route(
+    const registrationWithSameClientKey = await route(
       store,
-      '/api/pylons/pylon.test.one/wallet-readiness',
+      '/api/pylons/register',
       {
-        body: { walletReady: true },
+        body: { pylonRef: 'pylon.test.from-event-key' },
         idempotencyKey: 'pylon-event-key',
         method: 'POST',
         tokenUserId: 'agent-one',
       },
     )
-    const wrongRegisterKind = await route(store, '/api/pylons/register', {
-      body: { pylonRef: 'pylon.test.from-event-key' },
-      idempotencyKey: 'pylon-event-key',
-      method: 'POST',
-      tokenUserId: 'agent-one',
-    })
     const registerReplayWithDifferentPylon = await route(
       store,
       '/api/pylons/register',
@@ -3446,18 +3484,30 @@ describe('Pylon API routes', () => {
         tokenUserId: 'agent-one',
       },
     )
+    const replayHeartbeatBody = await responseJson<PylonRouteJson>(
+      replayHeartbeat,
+    )
     const registerReplayBody = await responseJson<PylonRouteJson>(
       registerReplayWithDifferentPylon,
     )
 
+    expect(firstHeartbeat.status).toBe(201)
+    expect(replayHeartbeat.status).toBe(200)
+    expect(replayHeartbeatBody.idempotent).toBe(true)
+    expect(replayHeartbeatBody.event).toMatchObject({
+      eventKind: 'heartbeat',
+      pylonRef: 'pylon.test.one',
+      status: 'online',
+    })
+    expect(sameKeyDifferentPylon.status).toBe(201)
+    expect(sameKeyDifferentEventKind.status).toBe(201)
     expect(wrongOwner.status).toBe(403)
-    expect(wrongEventKind.status).toBe(409)
-    expect(wrongRegisterKind.status).toBe(409)
+    expect(registrationWithSameClientKey.status).toBe(201)
     expect(registerReplayWithDifferentPylon.status).toBe(200)
     expect(registerReplayBody.idempotent).toBe(true)
     expect(registerReplayBody.pylon?.pylonRef).toBe('pylon.test.one')
     expect(store.registrations.has('pylon.test.different')).toBe(false)
-    expect(store.registrations.has('pylon.test.from-event-key')).toBe(false)
+    expect(store.registrations.has('pylon.test.from-event-key')).toBe(true)
   })
 
   test('requires registered-agent auth and registration ownership for writes', async () => {

--- a/apps/openagents.com/workers/api/src/pylon-api-routes.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.ts
@@ -224,6 +224,26 @@ const requireIdempotencyHash = (
   return Effect.promise(() => sha256Hex(idempotencyKey))
 }
 
+const requireScopedIdempotencyHash = (
+  request: Request,
+  scope: readonly string[],
+): Effect.Effect<string, PylonApiStoreError> => {
+  const idempotencyKey = idempotencyKeyFromRequest(request)
+
+  if (idempotencyKey === undefined) {
+    return Effect.fail(
+      new PylonApiStoreError({
+        kind: 'validation_error',
+        reason: 'Idempotency-Key header is required.',
+      }),
+    )
+  }
+
+  return Effect.promise(() =>
+    sha256Hex(['pylon_api_event_v2', ...scope, idempotencyKey].join('\0')),
+  )
+}
+
 const decodeBody = <A>(
   request: Request,
   schema: S.Decoder<A>,
@@ -1607,9 +1627,20 @@ const routeEvent = <Bindings extends PylonApiRouteEnv>(
 ) =>
   Effect.gen(function* () {
     const session = yield* requireAgent(dependencies, request, env)
-    const idempotencyKeyHash = yield* requireIdempotencyHash(request)
     const pylonRef = input.pylonRef
     const assignmentRef = input.assignmentRef ?? null
+    const registration = yield* requireOwnedRegistration(
+      dependencies,
+      env,
+      pylonRef,
+      session,
+    )
+    const idempotencyKeyHash = yield* requireScopedIdempotencyHash(request, [
+      registration.ownerAgentUserId,
+      pylonRef,
+      input.eventKind,
+      assignmentRef ?? '',
+    ])
     const store = routeStore(dependencies, env)
     const existingEvent = yield* Effect.tryPromise({
       catch: pylonApiStoreErrorFromUnknown,
@@ -1678,12 +1709,6 @@ const routeEvent = <Bindings extends PylonApiRouteEnv>(
       )
     }
 
-    const registration = yield* requireOwnedRegistration(
-      dependencies,
-      env,
-      pylonRef,
-      session,
-    )
     const nowIso = routeNowIso(dependencies)
     const assignment =
       input.assignmentRef === undefined
@@ -1922,9 +1947,20 @@ const routeRegisterSparkPayoutTarget = <Bindings extends PylonApiRouteEnv>(
       )
     }
 
-    const idempotencyKeyHash = yield* requireIdempotencyHash(request)
     const store = routeStore(dependencies, env)
     const sparkStore = makeSparkStore(env)
+    const registration = yield* requireOwnedRegistration(
+      dependencies,
+      env,
+      pylonRef,
+      session,
+    )
+    const idempotencyKeyHash = yield* requireScopedIdempotencyHash(request, [
+      registration.ownerAgentUserId,
+      pylonRef,
+      'payout_target_admission',
+      '',
+    ])
 
     const existingEvent = yield* Effect.tryPromise({
       catch: pylonApiStoreErrorFromUnknown,
@@ -1990,12 +2026,6 @@ const routeRegisterSparkPayoutTarget = <Bindings extends PylonApiRouteEnv>(
       )
     }
 
-    const registration = yield* requireOwnedRegistration(
-      dependencies,
-      env,
-      pylonRef,
-      session,
-    )
     // The schema validates the raw `spark1…` shape and the redacted digest ref
     // shape at the JSON boundary; the raw address never reaches here unvalidated.
     const body = yield* decodeBody(


### PR DESCRIPTION
Addresses #6820.

### Changes
- Added scoped Pylon event idempotency hashing so event keys are isolated by owner, Pylon, event kind, and assignment.
- Applied the scoped idempotency path to Pylon event writes and Spark payout target admission events after ownership validation.
- Updated Pylon API route coverage to verify same-key replays, cross-Pylon use, cross-event-kind use, owner rejection, and independent registration idempotency behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).