### PR TITLE
fix(khala): reject decision-grade MirrorCode launches

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
@@ -427,6 +427,11 @@ export const buildMirrorCodeLaunchRun = (
     throw new MirrorCodeRunError('taskId must contain a public-safe id.')
   }
   assertPublicTarget(launch)
+  if (launch.grade === 'decision_grade') {
+    throw new MirrorCodeRunError(
+      'MirrorCode launch intents are smoke-only; post the scored decision_grade result with exactTokenUsageEventRefs after execution.',
+    )
+  }
 
   return buildMirrorCodeRun({
     runId: `mc-${launch.bucket.toLowerCase()}-${taskPart}-${languagePart}-${timestampPart}`,
@@ -440,7 +445,7 @@ export const buildMirrorCodeLaunchRun = (
     startedAt: nowIso,
     finishedAt: null,
     summary: `Owner-gated MirrorCode launch queued for ${launch.taskId} (${launch.bucket} bucket) through openagents/khala.`,
-    grade: launch.grade ?? 'smoke',
+    grade: 'smoke',
   })
 }
 

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
@@ -129,6 +129,21 @@ describe('buildMirrorCodeRun', () => {
       ),
     ).toThrow(MirrorCodeRunError)
   })
+
+  test('rejects decision-grade launch intents until scored exact-token results are posted', () => {
+    expect(() =>
+      buildMirrorCodeLaunchRun(
+        {
+          kind: 'launch',
+          taskId: 'qsv_select',
+          bucket: 'S',
+          language: 'python',
+          grade: 'decision_grade',
+        },
+        '2026-06-27T02:03:04.000Z',
+      ),
+    ).toThrow(MirrorCodeRunError)
+  })
 })
 
 describe('buildMirrorCodeTokenBurnReport', () => {
@@ -359,6 +374,36 @@ describe('handleMirrorCodeRunsApi POST', () => {
     expect(body.run.status).toBe('queued')
     expect(body.run.tokensTotal).toBe(0)
     expect(storedRunId).toBe('mc-s-qsv-select-python-20260627020304')
+  })
+
+  test('authorized POST rejects decision-grade launch intents without storing', async () => {
+    let stored = 0
+    const response = await run(
+      handleMirrorCodeRunsApi(
+        postRequest({
+          kind: 'launch',
+          taskId: 'qsv_select',
+          bucket: 'S',
+          language: 'python',
+          grade: 'decision_grade',
+        }),
+        {
+          requireAdminApiToken: async () => true,
+          nowIso: () => '2026-06-27T02:03:04.000Z',
+          store: {
+            listRuns: () => Effect.succeed([]),
+            getRun: () => Effect.sync(() => undefined),
+            upsertRun: () => Effect.sync(() => {
+              stored += 1
+            }),
+          },
+        },
+      ),
+    )
+    expect(response.status).toBe(400)
+    expect(stored).toBe(0)
+    const body = (await response.json()) as { reason: string }
+    expect(body.reason).toContain('launch intents are smoke-only')
   })
 
   test('authorized POST with task contents is rejected 400', async () => {

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1741,7 +1741,7 @@ const schemaComponents = (): JsonSchema => ({
     'Public-safe single MirrorCode run (#6378): schemaVersion, scope="public", generatedAt, the live_at_read staleness contract, and the one run object, or a typed 404 when the runId is unknown. Same public-safe fields as the leaderboard run rows; never carries task contents or canary strings.',
   ),
   MirrorCodeRunRecordRequest: objectSummary(
-    'Owner-gated (admin bearer) launch/record body for a Khala MirrorCode run (#6378): either a launch intent { kind:"launch", taskId, bucket, language?, grade? }, which creates a queued zero-token run row, or the public-safe result contract { runId, model:"openagents/khala", taskId, bucket, language?, status, passRate?, tokens:{total}, exactTokenUsageEventRefs?, startedAt, finishedAt?, summary, grade? }. The Worker rebuilds both shapes through the no-task-contents / no-canary public-safety boundary and upserts by runId; anything carrying task source, test data, prompts, or canary strings is rejected with a typed 400 and never stored. A smoke (Phase-0) run is always decisionGrade:false. A scored decision_grade run requires exactTokenUsageEventRefs before it can be stored or published into the ladder.',
+    'Owner-gated (admin bearer) launch/record body for a Khala MirrorCode run (#6378): either a smoke-only launch intent { kind:"launch", taskId, bucket, language? }, which creates a queued zero-token run row, or the public-safe result contract { runId, model:"openagents/khala", taskId, bucket, language?, status, passRate?, tokens:{total}, exactTokenUsageEventRefs?, startedAt, finishedAt?, summary, grade? }. The Worker rebuilds both shapes through the no-task-contents / no-canary public-safety boundary and upserts by runId; anything carrying task source, test data, prompts, canary strings, or a premature decision_grade launch is rejected with a typed 400 and never stored. A smoke (Phase-0) run is always decisionGrade:false. A scored decision_grade run requires exactTokenUsageEventRefs before it can be stored or published into the ladder.',
   ),
   MirrorCodeRunRecordEnvelope: objectSummary(
     'Admin-bearer-gated launch/record receipt for a MirrorCode run (#6378): schemaVersion, kind="mirrorcode_run_launched" or "mirrorcode_run_recorded", and the stored public-safe run object. Storage/projection evidence only; grants no spend, settlement, payout, or public-claim authority.',
@@ -5143,6 +5143,10 @@ const paths = (): JsonSchema => ({
       security: adminBearer,
       requestBody: jsonContent('#/components/schemas/MirrorCodeRunRecordRequest'),
       responses: {
+        '202': okJson(
+          'Queued smoke-only MirrorCode launch intent.',
+          '#/components/schemas/MirrorCodeRunRecordEnvelope',
+        ),
         '201': okJson(
           'Recorded public-safe MirrorCode run.',
           '#/components/schemas/MirrorCodeRunRecordEnvelope',


### PR DESCRIPTION
Addresses #6376.

### Changes
- Reject `decision_grade` MirrorCode launch intents before storage, keeping launch intents smoke-only.
- Force accepted launch intents to create smoke-grade queued run rows.
- Add route and contract tests covering premature decision-grade launch rejection.
- Update the OpenAPI MirrorCode run record request/response docs for smoke-only launches and typed rejection.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0)