### PR TITLE
fix(forge): enforce tenant-scoped control-plane access

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0256_forge_tenant_isolation_posture.sql
+++ b/apps/openagents.com/workers/api/migrations/0256_forge_tenant_isolation_posture.sql
@@ -1,0 +1,19 @@
+-- FORGE SU-8 (#6798): tenant isolation posture metadata.
+--
+-- These nullable fields let external-fleet onboarding and UI read models expose
+-- public-safe confidential-workspace posture without storing raw attestations,
+-- private knowledge packs, repository contents, prompts, tokens, or secrets.
+
+ALTER TABLE forge_tenants ADD COLUMN confidential_workspace_mode TEXT
+  CHECK (
+    confidential_workspace_mode IS NULL OR
+    confidential_workspace_mode IN ('disabled', 'enabled', 'attested')
+  );
+
+ALTER TABLE forge_tenants ADD COLUMN attestation_ref TEXT;
+
+ALTER TABLE forge_tenants ADD COLUMN encrypted_knowledge_pack_ref TEXT;
+
+ALTER TABLE forge_tenants ADD COLUMN refusal_reason TEXT;
+
+ALTER TABLE forge_tenants ADD COLUMN retention_policy_ref TEXT;

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -74,6 +74,7 @@ const controlPlaneToken = 'forge-control-token'
 const authHeaders = (scopes: string): HeadersInit => ({
   authorization: `Bearer ${controlPlaneToken}`,
   'content-type': 'application/json',
+  'x-openagents-forge-tenant-ref': 'tenant.openagents',
   'x-openagents-forge-scopes': scopes,
 })
 
@@ -156,6 +157,41 @@ describe('Forge control-plane routes', () => {
 
     expect(response.status).toBe(403)
     expect(body.error).toBe('forge_control_plane_forbidden')
+  })
+
+  test('rejects control-plane reads for the wrong tenant scope', async () => {
+    const { run } = makeHarness()
+    const response = await run(
+      new Request(
+        'https://openagents.com/api/forge/work-records?tenantRef=tenant.external',
+        { headers: authHeaders('forge:work:read') },
+      ),
+    )
+    const body = (await response.json()) as { error: string; reason: string }
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('forge_control_plane_wrong_tenant')
+    expect(body.reason).toContain('scoped to one tenant')
+  })
+
+  test('rejects control-plane mutations for the wrong tenant scope', async () => {
+    const { run } = makeHarness()
+    const response = await run(
+      requestJson('/api/forge/work-records', {
+        json: {
+          tenantRef: 'tenant.external',
+          issueRef: 'issue.forge.external',
+          title: 'External tenant work',
+          state: 'open',
+        },
+        headers: authHeaders('forge:work:write'),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('forge_control_plane_wrong_tenant')
   })
 
   test('creates work, change, and status rows through scoped live routes', async () => {

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -24,6 +24,7 @@ export type ForgeControlPlaneAuth = Readonly<{
   mode: 'admin' | 'control_plane'
   subjectRef: string
   scopes: ReadonlyArray<ForgeControlPlaneScope>
+  tenantRef: string | null
 }>
 
 export type ForgeControlPlaneAuthorize<Bindings> = (
@@ -144,6 +145,14 @@ const readForgeScopeHeader = (
   }
 }
 
+const readForgeTenantHeader = (request: Request): string | undefined => {
+  const raw =
+    request.headers.get('x-openagents-forge-tenant-ref') ??
+    request.headers.get('x-openagents-forge-tenant')
+
+  return raw === null || raw.trim() === '' ? undefined : raw.trim()
+}
+
 export const authorizeForgeControlPlaneBearer = async (
   request: Request,
   expectedToken: string | undefined,
@@ -161,9 +170,11 @@ export const authorizeForgeControlPlaneBearer = async (
   }
 
   const scopes = readForgeScopeHeader(request)
+  const tenantRef = readForgeTenantHeader(request)
 
   if (
     scopes === undefined ||
+    tenantRef === undefined ||
     (!scopes.includes(requiredScope) && !scopes.includes('forge:admin'))
   ) {
     return undefined
@@ -173,6 +184,7 @@ export const authorizeForgeControlPlaneBearer = async (
     mode: 'control_plane',
     scopes,
     subjectRef: 'forge.control-plane.service',
+    tenantRef,
   }
 }
 
@@ -256,6 +268,7 @@ const requireScope = async <Bindings>(
   request: Request,
   env: Bindings,
   requiredScope: ForgeControlPlaneScope,
+  tenantRef: string,
 ): Promise<ForgeControlPlaneAuth> => {
   const token = readBearerToken(request)
 
@@ -268,7 +281,7 @@ const requireScope = async <Bindings>(
   }
 
   if ((await dependencies.requireAdminApiToken?.(request, env)) === true) {
-    return { mode: 'admin', scopes: ['forge:admin'], subjectRef: 'admin' }
+    return { mode: 'admin', scopes: ['forge:admin'], subjectRef: 'admin', tenantRef: null }
   }
 
   const controlPlaneAuth =
@@ -279,6 +292,17 @@ const requireScope = async <Bindings>(
     )
 
   if (controlPlaneAuth !== undefined) {
+    if (
+      controlPlaneAuth.tenantRef !== null &&
+      controlPlaneAuth.tenantRef !== tenantRef
+    ) {
+      throw new ForgeControlPlaneHttpError(
+        403,
+        'forge_control_plane_wrong_tenant',
+        'Forge control-plane tokens are scoped to one tenant and cannot read or mutate another tenant.',
+      )
+    }
+
     return controlPlaneAuth
   }
 
@@ -311,8 +335,8 @@ const routeWorkRecords = async <Bindings>(
   const store = dependencies.makeStore(env)
 
   if (request.method === 'GET') {
-    await requireScope(dependencies, request, env, 'forge:work:read')
     const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:work:read', tenantRef)
     return noStoreJsonResponse({
       limit: limitFromQuery(url),
       tenantRef,
@@ -324,8 +348,8 @@ const routeWorkRecords = async <Bindings>(
     return methodNotAllowed(['GET', 'POST'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:work:write')
   const body = await decodeBody(request, ForgeWorkRecordRequest)
+  await requireScope(dependencies, request, env, 'forge:work:write', body.tenantRef)
   const workRecord = await store.upsertIssue({
     tenantRef: body.tenantRef,
     issueRef: body.issueRef,
@@ -351,8 +375,8 @@ const routeChanges = async <Bindings>(
   const store = dependencies.makeStore(env)
 
   if (request.method === 'GET') {
-    await requireScope(dependencies, request, env, 'forge:change:read')
     const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:change:read', tenantRef)
     const limit = limitFromQuery(url)
     return noStoreJsonResponse({
       changes: await store.listChanges(
@@ -369,8 +393,8 @@ const routeChanges = async <Bindings>(
     return methodNotAllowed(['GET', 'POST'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:change:write')
   const body = await decodeBody(request, ForgeChangeRecordRequest)
+  await requireScope(dependencies, request, env, 'forge:change:write', body.tenantRef)
   const change = await store.upsertChange({
     tenantRef: body.tenantRef,
     prRef: body.prRef,
@@ -400,8 +424,8 @@ const routeChangeStatus = async <Bindings>(
     return methodNotAllowed(['PATCH'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:status:write')
   const body = await decodeBody(request, ForgeStatusTransitionRequest)
+  await requireScope(dependencies, request, env, 'forge:status:write', body.tenantRef)
   const status = await dependencies.makeStore(env).recordStatus({
     tenantRef: body.tenantRef,
     statusRef: body.statusRef,
@@ -425,8 +449,8 @@ const routeStatuses = async <Bindings>(
     return methodNotAllowed(['GET'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:change:read')
   const tenantRef = tenantRefFromQuery(url)
+  await requireScope(dependencies, request, env, 'forge:change:read', tenantRef)
   const limit = limitFromQuery(url)
 
   return noStoreJsonResponse({
@@ -447,8 +471,8 @@ const routeLeases = async <Bindings>(
   const store = dependencies.makeStore(env)
 
   if (request.method === 'GET') {
-    await requireScope(dependencies, request, env, 'forge:lease:write')
     const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:lease:write', tenantRef)
     const limit = limitFromQuery(url)
     return noStoreJsonResponse({
       leases: await store.listDispatchLeases(
@@ -465,8 +489,8 @@ const routeLeases = async <Bindings>(
     return methodNotAllowed(['GET', 'POST'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:lease:write')
   const body = await decodeBody(request, ForgeDispatchLeaseRequest)
+  await requireScope(dependencies, request, env, 'forge:lease:write', body.tenantRef)
   const result = await store.acquireDispatchLease({
     tenantRef: body.tenantRef,
     leaseRef: body.leaseRef,
@@ -493,8 +517,8 @@ const routeQueue = async <Bindings>(
     return methodNotAllowed(['GET'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:queue:read')
   const tenantRef = tenantRefFromQuery(url)
+  await requireScope(dependencies, request, env, 'forge:queue:read', tenantRef)
   const limit = limitFromQuery(url)
   const store = dependencies.makeStore(env)
 
@@ -515,8 +539,8 @@ const routeQueueSnapshots = async <Bindings>(
     return methodNotAllowed(['POST'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:queue:write')
   const body = await decodeBody(request, ForgeMergeQueueSnapshotRequest)
+  await requireScope(dependencies, request, env, 'forge:queue:write', body.tenantRef)
   const queueSnapshot = await dependencies.makeStore(env).recordMergeQueueLedger({
     tenantRef: body.tenantRef,
     queueRef: body.queueRef,
@@ -545,8 +569,8 @@ const routeVerificationReceipts = async <Bindings>(
   const store = dependencies.makeStore(env)
 
   if (request.method === 'GET') {
-    await requireScope(dependencies, request, env, 'forge:change:read')
     const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:change:read', tenantRef)
     const limit = limitFromQuery(url)
     return noStoreJsonResponse({
       limit,
@@ -563,8 +587,8 @@ const routeVerificationReceipts = async <Bindings>(
     return methodNotAllowed(['GET', 'POST'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:receipt:write')
   const receipt = await decodeBody(request, ForgeVerificationReceipt)
+  await requireScope(dependencies, request, env, 'forge:receipt:write', receipt.tenant_ref)
   const verificationReceipt = await store.recordVerificationReceipt(
     receipt,
     routeNowIso(dependencies),
@@ -582,8 +606,8 @@ const routePromotionDecisions = async <Bindings>(
   const store = dependencies.makeStore(env)
 
   if (request.method === 'GET') {
-    await requireScope(dependencies, request, env, 'forge:queue:read')
     const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:queue:read', tenantRef)
     const limit = limitFromQuery(url)
     return noStoreJsonResponse({
       limit,
@@ -600,8 +624,14 @@ const routePromotionDecisions = async <Bindings>(
     return methodNotAllowed(['GET', 'POST'])
   }
 
-  await requireScope(dependencies, request, env, 'forge:promotion:decide')
   const receipt = await decodeBody(request, ForgePromotionDecisionReceipt)
+  await requireScope(
+    dependencies,
+    request,
+    env,
+    'forge:promotion:decide',
+    receipt.tenant_ref,
+  )
   const promotionDecision = await store.recordPromotionDecisionReceipt(
     receipt,
     routeNowIso(dependencies),

--- a/apps/openagents.com/workers/api/src/forge-git-intake-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-git-intake-routes.test.ts
@@ -134,6 +134,7 @@ const migrations = [
   '0253_forge_tenant_git_access_tokens.sql',
   '0254_forge_control_plane_receipts.sql',
   '0255_forge_git_canonical_store.sql',
+  '0256_forge_tenant_isolation_posture.sql',
 ].map(migration)
 
 const textEncoder = new TextEncoder()

--- a/apps/openagents.com/workers/api/src/forge-git-packfile-archive-store.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-git-packfile-archive-store.test.ts
@@ -256,4 +256,33 @@ describe('forge git packfile archive D1/R2 store', () => {
       'packfile.forge.readback',
     ])
   })
+
+  test('fails closed for wrong-tenant artifact refs without leaking R2 bytes', async () => {
+    const { store } = makeStore()
+    const stored = await store.putPackfile({
+      body: packBytes.buffer,
+      capabilities: ['object-format=sha1'],
+      objectFormat: 'sha1',
+      packfileBytes: packBytes.byteLength,
+      packfileRef: 'packfile.forge.tenant-boundary',
+      packfileSha256: packSha256,
+      refUpdates: [],
+      repositoryRef: 'repo.openagents.openagents',
+      sourceRefs: [],
+      tenantRef: 'tenant.openagents',
+      nowIso,
+    })
+
+    await expect(
+      store.readPackfileObject('tenant.external-fleet', stored.record.packfile_ref),
+    ).resolves.toBeUndefined()
+    await expect(
+      store.readPackfile('tenant.external-fleet', stored.record.packfile_ref),
+    ).resolves.toBeUndefined()
+    await expect(
+      store.listPackfiles('tenant.external-fleet', {
+        repositoryRef: 'repo.openagents.openagents',
+      }),
+    ).resolves.toEqual([])
+  })
 })

--- a/apps/openagents.com/workers/api/src/forge-tenant-git-auth-store.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-tenant-git-auth-store.test.ts
@@ -52,6 +52,10 @@ const migration = readFileSync(
   new URL('../migrations/0253_forge_tenant_git_access_tokens.sql', import.meta.url),
   'utf8',
 )
+const tenantIsolationPostureMigration = readFileSync(
+  new URL('../migrations/0256_forge_tenant_isolation_posture.sql', import.meta.url),
+  'utf8',
+)
 
 const makeStore = (): {
   db: DatabaseSync
@@ -60,6 +64,7 @@ const makeStore = (): {
   const db = new DatabaseSync(':memory:')
   db.exec('PRAGMA foreign_keys = ON')
   db.exec(migration)
+  db.exec(tenantIsolationPostureMigration)
   return {
     db,
     store: makeD1ForgeTenantGitAuthStore(
@@ -144,6 +149,28 @@ describe('forge tenant git auth store', () => {
       'forge_git_token.receive_pack',
     )
     expect(stored?.last_used_at).toBe(laterIso)
+  })
+
+  test('stores tenant confidential posture as public-safe refs', async () => {
+    const { store } = makeStore()
+    const tenant = await store.upsertTenant({
+      tenantRef: 'tenant.external-fleet',
+      displayName: 'External Fleet',
+      confidentialWorkspaceMode: 'attested',
+      attestationRef: 'attestation.forge.external_fleet.public',
+      encryptedKnowledgePackRef: 'knowledge-pack.forge.external_fleet.encrypted',
+      refusalReason: null,
+      retentionPolicyRef: 'retention.forge.external_fleet.7d',
+      nowIso,
+    })
+
+    expect(tenant).toMatchObject({
+      tenant_ref: 'tenant.external-fleet',
+      confidential_workspace_mode: 'attested',
+      attestation_ref: 'attestation.forge.external_fleet.public',
+      encrypted_knowledge_pack_ref: 'knowledge-pack.forge.external_fleet.encrypted',
+      retention_policy_ref: 'retention.forge.external_fleet.7d',
+    })
   })
 
   test('git:admin grants both upload-pack and receive-pack', async () => {

--- a/apps/openagents.com/workers/api/src/forge-tenant-git-auth-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-tenant-git-auth-store.ts
@@ -5,6 +5,7 @@ import {
   type ForgeGitAccessScope,
   type ForgeGitAccessTokenRow,
   type ForgeGitAccessTokenScopeRow,
+  type ForgeTenantConfidentialWorkspaceMode,
   type ForgeTenantRow,
   type ForgeTenantState,
 } from '@openagentsinc/forge-protocol'
@@ -17,6 +18,11 @@ export type ForgeTenantInput = Readonly<{
   tenantRef: string
   displayName: string
   state?: ForgeTenantState
+  confidentialWorkspaceMode?: ForgeTenantConfidentialWorkspaceMode | null
+  attestationRef?: string | null
+  encryptedKnowledgePackRef?: string | null
+  refusalReason?: string | null
+  retentionPolicyRef?: string | null
   nowIso: string
 }>
 
@@ -226,12 +232,22 @@ export const makeD1ForgeTenantGitAuthStore = (
             tenant_ref,
             display_name,
             state,
+            confidential_workspace_mode,
+            attestation_ref,
+            encrypted_knowledge_pack_ref,
+            refusal_reason,
+            retention_policy_ref,
             created_at,
             updated_at
-          ) VALUES (?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT (tenant_ref) DO UPDATE SET
             display_name = excluded.display_name,
             state = excluded.state,
+            confidential_workspace_mode = excluded.confidential_workspace_mode,
+            attestation_ref = excluded.attestation_ref,
+            encrypted_knowledge_pack_ref = excluded.encrypted_knowledge_pack_ref,
+            refusal_reason = excluded.refusal_reason,
+            retention_policy_ref = excluded.retention_policy_ref,
             updated_at = excluded.updated_at
         `,
       )
@@ -239,6 +255,11 @@ export const makeD1ForgeTenantGitAuthStore = (
         input.tenantRef,
         input.displayName,
         input.state ?? 'active',
+        input.confidentialWorkspaceMode ?? null,
+        input.attestationRef ?? null,
+        input.encryptedKnowledgePackRef ?? null,
+        input.refusalReason ?? null,
+        input.retentionPolicyRef ?? null,
         input.nowIso,
         input.nowIso,
       )

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -4691,9 +4691,9 @@ const components = (): JsonSchema => ({
       type: 'http',
       scheme: 'bearer',
       bearerFormat:
-        'OpenAgents Forge control-plane token plus X-OpenAgents-Forge-Scopes',
+        'OpenAgents Forge control-plane token plus X-OpenAgents-Forge-Scopes and X-OpenAgents-Forge-Tenant-Ref',
       description:
-        'Dedicated Forge control-plane bearer token. Send X-OpenAgents-Forge-Scopes with one or more forge:* scopes such as forge:work:write or forge:admin. Forge smart-Git tokens (oa_forge_git_*) are rejected for /api/forge routes.',
+        'Dedicated Forge control-plane bearer token. Send X-OpenAgents-Forge-Scopes with one or more forge:* scopes such as forge:work:write or forge:admin, plus X-OpenAgents-Forge-Tenant-Ref for the tenant being read or mutated. Forge smart-Git tokens (oa_forge_git_*) are rejected for /api/forge routes, and tenant-scoped control-plane tokens cannot read or mutate another tenant.',
     },
   },
   schemas: {

--- a/clients/khala-macos/Khala/Khala.xcodeproj/project.pbxproj
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/project.pbxproj
@@ -1,0 +1,381 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		A1000000000000000000PRXY /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A1000000000000000000PRJ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A1000000000000000000TGT;
+			remoteInfo = Khala;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A1000000000000000000FAPP /* Khala.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Khala.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1000000000000000000FTST /* KhalaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KhalaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		A1000000000000000000XEXC /* Exceptions for "Khala" folder in "Khala" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Resources/Info.plist,
+			);
+			target = A1000000000000000000TGT /* Khala */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A1000000000000000000GSRC /* Khala */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				A1000000000000000000XEXC /* Exceptions for "Khala" folder in "Khala" target */,
+			);
+			path = Khala;
+			sourceTree = "<group>";
+		};
+		A1000000000000000000GTST /* KhalaTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = KhalaTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A1000000000000000000FRMW /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000TFRM /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A1000000000000000000GRT = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000GSRC /* Khala */,
+				A1000000000000000000GTST /* KhalaTests */,
+				A1000000000000000000GPRD /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A1000000000000000000GPRD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000FAPP /* Khala.app */,
+				A1000000000000000000FTST /* KhalaTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A1000000000000000000TGT /* Khala */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1000000000000000000CLT /* Build configuration list for PBXNativeTarget "Khala" */;
+			buildPhases = (
+				A1000000000000000000SRC /* Sources */,
+				A1000000000000000000FRMW /* Frameworks */,
+				A1000000000000000000RES /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A1000000000000000000GSRC /* Khala */,
+			);
+			name = Khala;
+			productName = Khala;
+			productReference = A1000000000000000000FAPP /* Khala.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A1000000000000000000TTST /* KhalaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1000000000000000000CLX /* Build configuration list for PBXNativeTarget "KhalaTests" */;
+			buildPhases = (
+				A1000000000000000000TSRC /* Sources */,
+				A1000000000000000000TFRM /* Frameworks */,
+				A1000000000000000000TRES /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1000000000000000000TDEP /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A1000000000000000000GTST /* KhalaTests */,
+			);
+			name = KhalaTests;
+			productName = KhalaTests;
+			productReference = A1000000000000000000FTST /* KhalaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A1000000000000000000PRJ /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					A1000000000000000000TGT = {
+						CreatedOnToolsVersion = 16.0;
+					};
+					A1000000000000000000TTST = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = A1000000000000000000TGT;
+					};
+				};
+			};
+			buildConfigurationList = A1000000000000000000CLP /* Build configuration list for PBXProject "Khala" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A1000000000000000000GRT;
+			productRefGroup = A1000000000000000000GPRD /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A1000000000000000000TGT /* Khala */,
+				A1000000000000000000TTST /* KhalaTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A1000000000000000000RES /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000TRES /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A1000000000000000000SRC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000TSRC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A1000000000000000000TDEP /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A1000000000000000000TGT /* Khala */;
+			targetProxy = A1000000000000000000PRXY /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A1000000000000000000DBG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A1000000000000000000REL /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A1000000000000000000TDBG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Khala/Resources/Info.plist;
+								LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openagents.khala-macos;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+							};
+			name = Debug;
+		};
+		A1000000000000000000TREL /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Khala/Resources/Info.plist;
+								LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openagents.khala-macos;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+							};
+			name = Release;
+		};
+		A1000000000000000000XDBG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openagents.khala-macos.tests;
+				PRODUCT_NAME = KhalaTests;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Khala.app/Contents/MacOS/Khala";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		A1000000000000000000XREL /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openagents.khala-macos.tests;
+				PRODUCT_NAME = KhalaTests;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Khala.app/Contents/MacOS/Khala";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A1000000000000000000CLP /* Build configuration list for PBXProject "Khala" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1000000000000000000DBG /* Debug */,
+				A1000000000000000000REL /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1000000000000000000CLT /* Build configuration list for PBXNativeTarget "Khala" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1000000000000000000TDBG /* Debug */,
+				A1000000000000000000TREL /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1000000000000000000CLX /* Build configuration list for PBXNativeTarget "KhalaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1000000000000000000XDBG /* Debug */,
+				A1000000000000000000XREL /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A1000000000000000000PRJ /* Project object */;
+}

--- a/clients/khala-macos/Khala/Khala.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/clients/khala-macos/Khala/Khala.xcodeproj/xcshareddata/xcschemes/Khala.xcscheme
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/xcshareddata/xcschemes/Khala.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000000000000000000TTST"
+               BuildableName = "KhalaTests.xctest"
+               BlueprintName = "KhalaTests"
+               ReferencedContainer = "container:Khala.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000000000000000000TGT"
+               BuildableName = "Khala.app"
+               BlueprintName = "Khala"
+               ReferencedContainer = "container:Khala.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000000000000000000TTST"
+               BuildableName = "KhalaTests.xctest"
+               BlueprintName = "KhalaTests"
+               ReferencedContainer = "container:Khala.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1000000000000000000TGT"
+            BuildableName = "Khala.app"
+            BlueprintName = "Khala"
+            ReferencedContainer = "container:Khala.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1000000000000000000TGT"
+            BuildableName = "Khala.app"
+            BlueprintName = "Khala"
+            ReferencedContainer = "container:Khala.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/clients/khala-macos/Khala/Khala/KhalaApp.swift
+++ b/clients/khala-macos/Khala/Khala/KhalaApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@main
+struct KhalaApp: App {
+    @StateObject private var store = ConversationStore()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView(store: store)
+                .frame(minWidth: 1060, minHeight: 720)
+        }
+        .windowStyle(.titleBar)
+        .commands {
+            CommandGroup(replacing: .newItem) {
+                Button("New Chat") { store.createConversation() }
+                    .keyboardShortcut("n")
+            }
+        }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Model/Conversation.swift
+++ b/clients/khala-macos/Khala/Khala/Model/Conversation.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum MessageRole: String, Codable, CaseIterable, Identifiable, Sendable {
+    case user
+    case assistant
+    var id: String { rawValue }
+}
+
+struct ChatMessage: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var role: MessageRole
+    var content: String
+    var createdAt: Date
+
+    init(id: UUID = UUID(), role: MessageRole, content: String, createdAt: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+    }
+}
+
+struct Conversation: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var title: String
+    var createdAt: Date
+    var updatedAt: Date
+    var messages: [ChatMessage]
+
+    init(id: UUID = UUID(), title: String = Conversation.defaultTitle, createdAt: Date = Date(), updatedAt: Date = Date(), messages: [ChatMessage] = []) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messages = messages
+    }
+
+    static let defaultTitle = "New Chat"
+
+    static func derivedTitle(from text: String, maxLength: Int = 48) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return defaultTitle }
+        let firstLine = trimmed.split(whereSeparator: \.isNewline).first.map(String.init) ?? trimmed
+        if firstLine.count <= maxLength { return firstLine }
+        let end = firstLine.index(firstLine.startIndex, offsetBy: maxLength)
+        return String(firstLine[..<end]).trimmingCharacters(in: .whitespaces) + "..."
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Model/ConversationStore.swift
+++ b/clients/khala-macos/Khala/Khala/Model/ConversationStore.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+@MainActor
+final class ConversationStore: ObservableObject {
+    @Published private(set) var conversations: [Conversation]
+    @Published private(set) var selectedConversationID: Conversation.ID?
+    @Published private(set) var persistenceError: String?
+
+    private let storeURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(storeURL: URL? = nil) {
+        self.storeURL = storeURL ?? Self.defaultStoreURL()
+        self.conversations = []
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+        load()
+        if conversations.isEmpty { _ = createConversation() } else { selectedConversationID = conversations.first?.id }
+    }
+
+    var selectedConversation: Conversation? {
+        guard let selectedConversationID else { return conversations.first }
+        return conversations.first { $0.id == selectedConversationID } ?? conversations.first
+    }
+
+    @discardableResult
+    func createConversation() -> Conversation {
+        let conversation = Conversation()
+        conversations.insert(conversation, at: 0)
+        selectedConversationID = conversation.id
+        persist()
+        return conversation
+    }
+
+    func select(_ conversation: Conversation) { selectedConversationID = conversation.id }
+
+    func delete(_ conversation: Conversation) {
+        conversations.removeAll { $0.id == conversation.id }
+        if conversations.isEmpty { _ = createConversation() } else if selectedConversationID == conversation.id { selectedConversationID = conversations.first?.id }
+        persist()
+    }
+
+    @discardableResult
+    func appendMessage(_ role: MessageRole, content: String, to conversationID: Conversation.ID) -> ChatMessage? {
+        guard let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return nil }
+        let message = ChatMessage(role: role, content: content)
+        conversations[index].messages.append(message)
+        conversations[index].updatedAt = Date()
+        if conversations[index].title == Conversation.defaultTitle, role == .user { conversations[index].title = Conversation.derivedTitle(from: content) }
+        resort()
+        selectedConversationID = conversationID
+        persist()
+        return message
+    }
+
+    func updateMessage(_ messageID: ChatMessage.ID, in conversationID: Conversation.ID, content: String) {
+        guard let conversationIndex = conversations.firstIndex(where: { $0.id == conversationID }), let messageIndex = conversations[conversationIndex].messages.firstIndex(where: { $0.id == messageID }) else { return }
+        conversations[conversationIndex].messages[messageIndex].content = content
+        conversations[conversationIndex].updatedAt = Date()
+        resort()
+        selectedConversationID = conversationID
+        persist()
+    }
+
+    private func resort() { conversations.sort { $0.updatedAt > $1.updatedAt } }
+
+    private func load() {
+        do {
+            let data = try Data(contentsOf: storeURL)
+            conversations = try decoder.decode([Conversation].self, from: data)
+            resort()
+            persistenceError = nil
+        } catch CocoaError.fileReadNoSuchFile {
+            conversations = []
+        } catch {
+            conversations = []
+            persistenceError = "Could not read local chat history. A fresh session was opened."
+        }
+    }
+
+    private func persist() {
+        do {
+            try FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let data = try encoder.encode(conversations)
+            try data.write(to: storeURL, options: [.atomic])
+            persistenceError = nil
+        } catch {
+            persistenceError = "Could not save local chat history."
+        }
+    }
+
+    private static func defaultStoreURL() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent("OpenAgents", isDirectory: true).appendingPathComponent("KhalaDesktop", isDirectory: true).appendingPathComponent("conversations.json")
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Net/KhalaClient.swift
+++ b/clients/khala-macos/Khala/Khala/Net/KhalaClient.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum KhalaClient {
+    static let baseURL = URL(string: "https://openagents.com/api/v1")!
+    static let model = "openagents/khala"
+
+    enum KhalaError: Error, LocalizedError, Equatable {
+        case missingKey
+        case unauthorized
+        case quotaExceeded
+        case http(Int, String)
+        case decoding
+        case transport(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingKey: return "Add a Khala API key in Settings before sending."
+            case .unauthorized: return "Khala rejected this API key."
+            case .quotaExceeded: return "Free quota reached. Add credits or wait for the reset."
+            case .http(let code, _): return "Khala API error (\(code))."
+            case .decoding: return "Could not read the Khala response."
+            case .transport(let message): return "Network error: \(message)"
+            }
+        }
+    }
+
+    static func complete(prompt: String, apiKey: String, session: URLSession = .shared) async throws -> String {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { throw KhalaError.missingKey }
+        var request = URLRequest(url: baseURL.appendingPathComponent("chat/completions"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["model": model, "messages": [["role": "user", "content": trimmed]]])
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { throw KhalaError.decoding }
+            if http.statusCode == 401 || http.statusCode == 403 { throw KhalaError.unauthorized }
+            if http.statusCode == 402 { throw KhalaError.quotaExceeded }
+            guard (200..<300).contains(http.statusCode) else { throw KhalaError.http(http.statusCode, String(data: data, encoding: .utf8) ?? "") }
+            return try parseContent(from: data)
+        } catch let error as KhalaError {
+            throw error
+        } catch {
+            throw KhalaError.transport(error.localizedDescription)
+        }
+    }
+
+    static func parseContent(from data: Data) throws -> String {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any], let choices = object["choices"] as? [[String: Any]], let first = choices.first, let message = first["message"] as? [String: Any], let content = message["content"] as? String else { throw KhalaError.decoding }
+        return content
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Resources/Info.plist
+++ b/clients/khala-macos/Khala/Khala/Resources/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Khala</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>14.0</string>
+</dict>
+</plist>

--- a/clients/khala-macos/Khala/Khala/Shell/RootView.swift
+++ b/clients/khala-macos/Khala/Khala/Shell/RootView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+struct RootView: View {
+    @ObservedObject var store: ConversationStore
+    @State private var draft = ""
+    @State private var apiKeyDraft = ""
+    @State private var isShowingSettings = false
+    @State private var isSending = false
+    @State private var banner: String?
+
+    var body: some View {
+        NavigationSplitView { sidebar } content: { chatPane } detail: { inspector }
+            .navigationTitle("Khala")
+            .toolbar {
+                ToolbarItemGroup {
+                    Text("Khala").font(.caption.weight(.semibold)).padding(.horizontal, 10).padding(.vertical, 5).background(.quaternary, in: Capsule())
+                    Button { store.createConversation() } label: { Label("New Chat", systemImage: "square.and.pencil") }
+                    Button { isShowingSettings.toggle() } label: { Label("Settings", systemImage: "gearshape") }
+                }
+            }
+            .sheet(isPresented: $isShowingSettings) { settings }
+    }
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Conversations").font(.headline)
+                Spacer()
+                Button { store.createConversation() } label: { Image(systemName: "plus") }.buttonStyle(.borderless).help("New Chat")
+            }
+            List(selection: Binding(get: { store.selectedConversationID }, set: { id in
+                guard let id, let conversation = store.conversations.first(where: { $0.id == id }) else { return }
+                store.select(conversation)
+            })) {
+                ForEach(store.conversations) { conversation in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(conversation.title).lineLimit(1)
+                        Text(conversation.updatedAt, style: .relative).font(.caption).foregroundStyle(.secondary)
+                    }
+                    .tag(conversation.id)
+                    .contextMenu { Button("Delete") { store.delete(conversation) } }
+                }
+            }
+            Divider()
+            StatusLine(title: "Local Pylon", value: "Unavailable", systemImage: "bolt.horizontal")
+            StatusLine(title: "Apple FM", value: "Not attached", systemImage: "cpu")
+            StatusLine(title: "Provider Mode", value: "Offline", systemImage: "antenna.radiowaves.left.and.right")
+        }
+        .padding()
+        .frame(minWidth: 250)
+    }
+
+    private var chatPane: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 14) {
+                        if let text = store.persistenceError { BannerView(text: text, systemImage: "exclamationmark.triangle") }
+                        if let banner { BannerView(text: banner, systemImage: "info.circle") }
+                        ForEach(store.selectedConversation?.messages ?? []) { message in MessageRow(message: message).id(message.id) }
+                        if store.selectedConversation?.messages.isEmpty ?? true { emptyState }
+                    }.padding(24)
+                }
+                .onChange(of: store.selectedConversation?.messages.last?.id) { _, id in
+                    guard let id else { return }
+                    withAnimation { proxy.scrollTo(id, anchor: .bottom) }
+                }
+            }
+            Divider()
+            composer
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Khala").font(.largeTitle.bold())
+            Text("Ask a question or send a bounded public coding task prompt.").foregroundStyle(.secondary)
+            Text("Model: \(KhalaClient.model)").font(.caption.monospaced()).foregroundStyle(.secondary)
+        }.frame(maxWidth: .infinity, alignment: .leading).padding(.top, 120)
+    }
+
+    private var composer: some View {
+        HStack(alignment: .bottom, spacing: 12) {
+            TextField("Message Khala", text: $draft, axis: .vertical)
+                .textFieldStyle(.plain).lineLimit(1...6).padding(12).background(.quinary, in: RoundedRectangle(cornerRadius: 8)).onSubmit(send)
+            Button { send() } label: { Image(systemName: isSending ? "hourglass" : "paperplane.fill") }
+                .keyboardShortcut(.return, modifiers: [.command]).disabled(isSending || draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty).buttonStyle(.borderedProminent).help("Send")
+        }.padding()
+    }
+
+    private var inspector: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                Text("Node").font(.title2.bold())
+                InspectorCard(title: "Pylon Supervisor", status: "Unavailable") { Text("This scaffold does not launch or attach to Pylon yet. Provider capacity stays offline until a verified local supervisor is implemented.") }
+                InspectorCard(title: "Apple FM Bridge", status: "Not attached") { Text("No Apple FM helper is bundled by this target. The app will not advertise Apple FM capacity.") }
+                InspectorCard(title: "Fleet", status: "Local only") { Text("Connected accounts, assignments, closeouts, and receipts are reserved for the Pylon integration pass.") }
+                Text("Privacy").font(.headline)
+                Text("The API key is stored in Keychain. Local chat history stays in Application Support on this Mac.").foregroundStyle(.secondary)
+            }.padding(24)
+        }.frame(minWidth: 300)
+    }
+
+    private var settings: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Settings").font(.title2.bold())
+            Text("Paste an `oa_agent_...` key for Khala chat. The value is stored in Keychain and is not displayed after saving.").foregroundStyle(.secondary)
+            SecureField("Khala API key", text: $apiKeyDraft).textFieldStyle(.roundedBorder)
+            HStack {
+                Button("Save Key") {
+                    let key = apiKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !key.isEmpty else { return }
+                    KeychainStore.saveAPIKey(key); apiKeyDraft = ""; isShowingSettings = false
+                }.buttonStyle(.borderedProminent)
+                Button("Remove Key") { KeychainStore.deleteAPIKey(); apiKeyDraft = "" }
+                Spacer()
+                Button("Done") { isShowingSettings = false }
+            }
+        }.padding(24).frame(width: 460)
+    }
+
+    private func send() {
+        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty, !isSending else { return }
+        guard let apiKey = KeychainStore.loadAPIKey() else { banner = "Add a Khala API key in Settings before sending."; isShowingSettings = true; return }
+        let conversationID = store.selectedConversation?.id ?? store.createConversation().id
+        draft = ""; banner = nil
+        store.appendMessage(.user, content: prompt, to: conversationID)
+        guard let assistant = store.appendMessage(.assistant, content: "Thinking...", to: conversationID) else { return }
+        isSending = true
+        Task {
+            do {
+                let response = try await KhalaClient.complete(prompt: prompt, apiKey: apiKey)
+                await MainActor.run { store.updateMessage(assistant.id, in: conversationID, content: response); isSending = false }
+            } catch {
+                await MainActor.run { store.updateMessage(assistant.id, in: conversationID, content: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription); isSending = false }
+            }
+        }
+    }
+}
+
+private struct MessageRow: View {
+    let message: ChatMessage
+    var body: some View { HStack(alignment: .top) { if message.role == .assistant { content; Spacer(minLength: 80) } else { Spacer(minLength: 80); content } } }
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(message.role == .assistant ? "Khala" : "You").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            Text(message.content).textSelection(.enabled).padding(12).background(message.role == .assistant ? Color(nsColor: .controlBackgroundColor) : Color.accentColor.opacity(0.18)).clipShape(RoundedRectangle(cornerRadius: 8))
+        }.frame(maxWidth: 680, alignment: .leading)
+    }
+}
+
+private struct StatusLine: View {
+    let title: String
+    let value: String
+    let systemImage: String
+    var body: some View { HStack(spacing: 8) { Image(systemName: systemImage).frame(width: 18); VStack(alignment: .leading, spacing: 2) { Text(title).font(.caption).foregroundStyle(.secondary); Text(value).font(.callout.weight(.medium)) }; Spacer() } }
+}
+
+private struct InspectorCard<Content: View>: View {
+    let title: String
+    let status: String
+    @ViewBuilder let content: Content
+    var body: some View { VStack(alignment: .leading, spacing: 8) { HStack { Text(title).font(.headline); Spacer(); Text(status).font(.caption.weight(.semibold)).padding(.horizontal, 8).padding(.vertical, 4).background(.quaternary, in: Capsule()) }; content.font(.callout).foregroundStyle(.secondary) }.padding(14).background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8)) }
+}
+
+private struct BannerView: View {
+    let text: String
+    let systemImage: String
+    var body: some View { HStack(spacing: 8) { Image(systemName: systemImage); Text(text); Spacer() }.font(.callout).padding(10).background(Color.yellow.opacity(0.16), in: RoundedRectangle(cornerRadius: 8)) }
+}

--- a/clients/khala-macos/Khala/Khala/Store/KeychainStore.swift
+++ b/clients/khala-macos/Khala/Khala/Store/KeychainStore.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Security
+
+enum KeychainStore {
+    private static let service = "com.openagents.khala-macos"
+    private static let account = "khala_api_key"
+
+    static func saveAPIKey(_ key: String) {
+        let data = Data(key.utf8)
+        deleteAPIKey()
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword, kSecAttrService as String: service, kSecAttrAccount as String: account, kSecValueData as String: data, kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock]
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    static func loadAPIKey() -> String? {
+        if let envKey = ProcessInfo.processInfo.environment["KHALA_API_KEY"], !envKey.isEmpty { return envKey }
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword, kSecAttrService as String: service, kSecAttrAccount as String: account, kSecReturnData as String: true, kSecMatchLimit as String: kSecMatchLimitOne]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data, let key = String(data: data, encoding: .utf8), !key.isEmpty else { return nil }
+        return key
+    }
+
+    @discardableResult
+    static func deleteAPIKey() -> Bool {
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword, kSecAttrService as String: service, kSecAttrAccount as String: account]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/clients/khala-macos/Khala/KhalaTests/ConversationStoreTests.swift
+++ b/clients/khala-macos/Khala/KhalaTests/ConversationStoreTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Khala
+
+@MainActor
+final class ConversationStoreTests: XCTestCase {
+    func testCreatesConversationAndPersistsMessages() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = ConversationStore(storeURL: url)
+        let conversation = try XCTUnwrap(store.selectedConversation)
+        store.appendMessage(.user, content: "Hello Khala", to: conversation.id)
+        store.appendMessage(.assistant, content: "Hello.", to: conversation.id)
+        let reloaded = ConversationStore(storeURL: url)
+        let persisted = try XCTUnwrap(reloaded.selectedConversation)
+        XCTAssertEqual(persisted.title, "Hello Khala")
+        XCTAssertEqual(persisted.messages.map(\.role), [.user, .assistant])
+    }
+
+    func testDerivedTitleTrimsLongFirstLine() {
+        let title = Conversation.derivedTitle(from: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        XCTAssertEqual(title, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV...")
+    }
+}

--- a/clients/khala-macos/Khala/KhalaTests/KhalaClientTests.swift
+++ b/clients/khala-macos/Khala/KhalaTests/KhalaClientTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+@testable import Khala
+
+final class KhalaClientTests: XCTestCase {
+    func testParseOpenAICompatibleContent() throws {
+        let data = Data("""
+        {"choices":[{"message":{"role":"assistant","content":"Ready."}}]}
+        """.utf8)
+        XCTAssertEqual(try KhalaClient.parseContent(from: data), "Ready.")
+    }
+
+    func testParseRejectsUnexpectedShape() {
+        let data = Data(#"{"choices":[]}"#.utf8)
+        XCTAssertThrowsError(try KhalaClient.parseContent(from: data))
+    }
+}

--- a/clients/khala-macos/Khala/README.md
+++ b/clients/khala-macos/Khala/README.md
@@ -1,0 +1,39 @@
+# Khala Desktop - native macOS SwiftUI app
+
+Khala Desktop is the native macOS sibling of the iOS Khala app at `clients/khala-ios/Khala`. It opens to a desktop `NavigationSplitView` shell with local chat history, Keychain-backed Khala API auth, and visible local node readiness panels.
+
+- **Bundle id:** `com.openagents.khala-macos`
+- **Platform:** macOS 14+, native SwiftUI. No Expo, EAS, Electron, or web shell.
+- **Spec:** `../../../docs/desktop/2026-06-28-khala-desktop-spec.md`
+- **Model:** `openagents/khala` through `https://openagents.com/api/v1`
+- **Signing team:** `HQWSG26L43`
+
+## Current MVP
+
+- Chat with the public Khala API after storing an `oa_agent_...` key in Keychain.
+- Local conversation history persisted as JSON in Application Support.
+- Desktop shell with conversation sidebar, main chat pane, and right inspector.
+- Truthful node readiness placeholders for Pylon and Apple FM: unavailable until the supervisor and packaged bridge lifecycle are implemented.
+- XcodeGen `project.yml` plus a committed `.xcodeproj` using synchronized source folders so the app opens without XcodeGen installed.
+
+## Build locally
+
+```sh
+cd clients/khala-macos/Khala
+xcodebuild -project Khala.xcodeproj -scheme Khala -destination 'platform=macOS' build
+```
+
+Run tests:
+
+```sh
+cd clients/khala-macos/Khala
+xcodebuild -project Khala.xcodeproj -scheme Khala -destination 'platform=macOS' test
+```
+
+## Environment hooks
+
+- `KHALA_API_KEY` injects a bearer key for local smoke runs and bypasses Keychain reads. Normal user flows store the key in Keychain only.
+
+## Not in this scaffold
+
+The app does not yet launch a bundled Pylon, publish provider capacity, or ship the Apple FM helper. The UI marks those surfaces unavailable rather than advertising capability that has not been verified.

--- a/clients/khala-macos/Khala/project.yml
+++ b/clients/khala-macos/Khala/project.yml
@@ -1,0 +1,43 @@
+# XcodeGen spec for the Khala native macOS SwiftUI app.
+# Regenerate Khala.xcodeproj with: xcodegen generate
+name: Khala
+options:
+  bundleIdPrefix: com.openagents
+  deploymentTarget:
+    macOS: "14.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+    SWIFT_VERSION: "5.9"
+    DEVELOPMENT_TEAM: HQWSG26L43
+    CODE_SIGN_STYLE: Automatic
+targets:
+  Khala:
+    type: application
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: Khala
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openagents.khala-macos
+        PRODUCT_NAME: Khala
+        INFOPLIST_FILE: Khala/Resources/Info.plist
+        GENERATE_INFOPLIST_FILE: NO
+  KhalaTests:
+    type: bundle.unit-test
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: KhalaTests
+    dependencies:
+      - target: Khala
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openagents.khala-macos.tests
+        PRODUCT_NAME: KhalaTests
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Khala.app/Contents/MacOS/Khala"
+        BUNDLE_LOADER: "$(TEST_HOST)"

--- a/docs/forge/2026-06-28-forge-boundary-contract.md
+++ b/docs/forge/2026-06-28-forge-boundary-contract.md
@@ -16,7 +16,10 @@ Forge has two separate auth planes:
   `git:upload-pack`, `git:receive-pack`, and `git:admin`.
 - **Control plane:** service, session, or admin credentials with
   `ForgeControlPlaneScope` values. These scopes are all prefixed with
-  `forge:*` and are the only scopes accepted by `/api/forge/*`.
+  `forge:*` and are the only scopes accepted by `/api/forge/*`. Non-admin
+  control-plane bearer tokens are also bound to one tenant ref; callers send
+  that scope as `X-OpenAgents-Forge-Tenant-Ref`, and the Worker rejects any
+  request body or query `tenantRef` that does not match it.
 
 Tenant git tokens must not authorize control-plane calls. A route that accepts
 `git:receive-pack` or `git:admin` for `/api/forge/*` is out of contract.
@@ -72,7 +75,16 @@ reuse the existing D1/R2/DO bindings. The UI remains owned by `apps/forge/` on
 
 Every route decodes through typed data structures from
 `@openagentsinc/forge-protocol`. Routes must fail closed when a caller presents
-only tenant smart-Git credentials.
+only tenant smart-Git credentials or when a tenant-scoped control-plane token
+attempts to read or mutate another tenant's rows, receipts, leases, refs, or
+artifact metadata.
+
+Forge tenant records may carry optional confidential-workspace posture fields:
+`confidential_workspace_mode`, `attestation_ref`,
+`encrypted_knowledge_pack_ref`, `refusal_reason`, and `retention_policy_ref`.
+These fields are refs and bounded state only. They do not carry raw
+attestations, raw knowledge packs, private repo contents, prompts, tokens, or
+secrets.
 
 ## Smart-Git Route Notes
 

--- a/packages/forge-protocol/README.md
+++ b/packages/forge-protocol/README.md
@@ -14,7 +14,10 @@ code import these schemas instead of re-declaring local coordination records.
 
 Control-plane calls use the separate `ForgeControlPlaneScope` set
 (`forge:*`). Tenant git access scopes are only valid for smart Git HTTP and must
-not authorize `/api/forge/*` routes. The boundary contract is documented in
+not authorize `/api/forge/*` routes. Non-admin control-plane tokens are scoped
+to one tenant ref, and route handlers compare that authenticated tenant to the
+query or body `tenantRef` before returning rows or persisting mutations. The
+boundary contract is documented in
 `docs/forge/2026-06-28-forge-boundary-contract.md`.
 
 The package also defines the first Pylon-to-Forge dispatch messages:
@@ -34,3 +37,10 @@ The package is public-safe by default: records carry refs, bounded state,
 timestamps, and JSON-encoded ref arrays. They do not carry raw prompts, raw
 provider payloads, private repository contents, local paths, raw git tokens,
 secrets, or wallet material.
+
+Tenant rows also define optional external-fleet posture refs:
+`confidential_workspace_mode`, `attestation_ref`,
+`encrypted_knowledge_pack_ref`, `refusal_reason`, and
+`retention_policy_ref`. These are safe read-model fields for onboarding and
+policy display only; they do not grant API, Git, promotion, mirror, or artifact
+authority.

--- a/packages/forge-protocol/src/index.test.ts
+++ b/packages/forge-protocol/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, test } from "bun:test";
 
 import {
   FORGE_PROTOCOL_SCHEMA_VERSION,
@@ -22,28 +22,32 @@ import {
   forgeCoordinationStatusStateForNip34Kind,
   forgeCoordinationStatusStates,
   forgeNip34StatusKindForState,
-} from "./index.js"
+} from "./index.js";
 
-const at = "2026-06-28T16:00:00.000Z"
+const at = "2026-06-28T16:00:00.000Z";
 
 describe("@openagentsinc/forge-protocol", () => {
   test("exports the phase 0 schema version", () => {
-    expect(FORGE_PROTOCOL_SCHEMA_VERSION).toBe("openagents.forge.protocol.v0.1")
-  })
+    expect(FORGE_PROTOCOL_SCHEMA_VERSION).toBe(
+      "openagents.forge.protocol.v0.1",
+    );
+  });
 
   test("round-trips NIP-34 status states and kinds", () => {
     for (const state of forgeCoordinationStatusStates) {
-      const kind = forgeNip34StatusKindForState(state)
-      expect(forgeCoordinationStatusStateForNip34Kind(kind)).toBe(state)
+      const kind = forgeNip34StatusKindForState(state);
+      expect(forgeCoordinationStatusStateForNip34Kind(kind)).toBe(state);
     }
-  })
+  });
 
   test("keeps control-plane scopes separate from smart Git token scopes", () => {
-    expect(forgeControlPlaneScopes).toContain("forge:promotion:decide")
-    expect(decodeForgeControlPlaneScope("forge:work:write")).toBe("forge:work:write")
-    expect(() => decodeForgeControlPlaneScope("git:receive-pack")).toThrow()
-    expect(() => decodeForgeControlPlaneScope("git:admin")).toThrow()
-  })
+    expect(forgeControlPlaneScopes).toContain("forge:promotion:decide");
+    expect(decodeForgeControlPlaneScope("forge:work:write")).toBe(
+      "forge:work:write",
+    );
+    expect(() => decodeForgeControlPlaneScope("git:receive-pack")).toThrow();
+    expect(() => decodeForgeControlPlaneScope("git:admin")).toThrow();
+  });
 
   test("decodes the D1 coordination source-of-truth row shapes", () => {
     expect(
@@ -54,11 +58,13 @@ describe("@openagentsinc/forge-protocol", () => {
         title: "D1 coordination schema",
         state: "open",
         priority_ref: "prio:0-pr-burndown",
-        source_refs_json: JSON.stringify(["github:OpenAgentsInc/openagents#6746"]),
+        source_refs_json: JSON.stringify([
+          "github:OpenAgentsInc/openagents#6746",
+        ]),
         created_at: at,
         updated_at: at,
       }).issue_ref,
-    ).toBe("issue.forge.6746")
+    ).toBe("issue.forge.6746");
 
     expect(
       decodeForgeCoordinationPrRow({
@@ -75,7 +81,7 @@ describe("@openagentsinc/forge-protocol", () => {
         created_at: at,
         updated_at: at,
       }).state,
-    ).toBe("ready")
+    ).toBe("ready");
 
     expect(
       decodeForgeCoordinationStatusRow({
@@ -88,7 +94,7 @@ describe("@openagentsinc/forge-protocol", () => {
         source_refs_json: "[]",
         created_at: at,
       }).nip34_kind,
-    ).toBe(1630)
+    ).toBe(1630);
 
     expect(
       decodeForgeDispatchLeaseRow({
@@ -104,7 +110,7 @@ describe("@openagentsinc/forge-protocol", () => {
         released_at: null,
         source_refs_json: "[]",
       }).state,
-    ).toBe("active")
+    ).toBe("active");
 
     expect(
       decodeForgeMergeQueueLedgerRow({
@@ -121,7 +127,7 @@ describe("@openagentsinc/forge-protocol", () => {
         created_at: at,
         updated_at: at,
       }).state,
-    ).toBe("projected")
+    ).toBe("projected");
 
     expect(
       decodeForgeGitPackfileArchiveRow({
@@ -136,7 +142,7 @@ describe("@openagentsinc/forge-protocol", () => {
         packfile_bytes: 128,
         object_format: "sha1",
         command_count: 1,
-        capabilities_json: "[\"report-status\"]",
+        capabilities_json: '["report-status"]',
         ref_updates_json: "[]",
         source_refs_json: "[]",
         content_type: "application/x-git-packed-objects",
@@ -144,17 +150,23 @@ describe("@openagentsinc/forge-protocol", () => {
         created_at: at,
         updated_at: at,
       }).object_format,
-    ).toBe("sha1")
+    ).toBe("sha1");
 
     expect(
       decodeForgeTenantRow({
         tenant_ref: "tenant.openagents",
         display_name: "OpenAgents",
         state: "active",
+        confidential_workspace_mode: "attested",
+        attestation_ref: "attestation.forge.openagents.sgx.public",
+        encrypted_knowledge_pack_ref:
+          "knowledge-pack.forge.openagents.encrypted",
+        refusal_reason: null,
+        retention_policy_ref: "retention.forge.openagents.30d",
         created_at: at,
         updated_at: at,
-      }).state,
-    ).toBe("active")
+      }).confidential_workspace_mode,
+    ).toBe("attested");
 
     expect(
       decodeForgeGitAccessTokenRow({
@@ -171,7 +183,7 @@ describe("@openagentsinc/forge-protocol", () => {
         revoked_at: null,
         source_refs_json: "[]",
       }).repository_ref,
-    ).toBe("repo.openagents.openagents")
+    ).toBe("repo.openagents.openagents");
 
     expect(
       decodeForgeGitAccessTokenScopeRow({
@@ -180,8 +192,8 @@ describe("@openagentsinc/forge-protocol", () => {
         scope: "git:receive-pack",
         created_at: at,
       }).scope,
-    ).toBe("git:receive-pack")
-  })
+    ).toBe("git:receive-pack");
+  });
 
   test("decodes Pylon-to-Forge dispatch messages", () => {
     const workItem = decodeForgeDispatchWorkItem({
@@ -221,9 +233,9 @@ describe("@openagentsinc/forge-protocol", () => {
       expires_at: "2026-06-28T17:00:00.000Z",
       created_at: at,
       source_refs: ["github:OpenAgentsInc/openagents#6751"],
-    })
-    expect(workItem.git.git_access.scopes).toEqual(["git:receive-pack"])
-    expect(decodeForgeDispatchMessage(workItem).schema).toBe(workItem.schema)
+    });
+    expect(workItem.git.git_access.scopes).toEqual(["git:receive-pack"]);
+    expect(decodeForgeDispatchMessage(workItem).schema).toBe(workItem.schema);
 
     const decision = decodeForgeDispatchDecision({
       schema: "openagents.forge.dispatch.decision.v0.1",
@@ -237,8 +249,8 @@ describe("@openagentsinc/forge-protocol", () => {
       rejected_at: null,
       blocker_refs: [],
       source_refs: workItem.source_refs,
-    })
-    expect(decision.accepted_at).toBe(at)
+    });
+    expect(decision.accepted_at).toBe(at);
 
     const closeout = decodeForgeDispatchCloseout({
       schema: "openagents.forge.dispatch.closeout.v0.1",
@@ -267,10 +279,10 @@ describe("@openagentsinc/forge-protocol", () => {
       source_refs: workItem.source_refs,
       redacted: true,
       completed_at: at,
-    })
-    expect(closeout.packfile_ref).toBe("packfile.forge.6751")
-    expect(decodeForgeDispatchMessage(closeout).schema).toBe(closeout.schema)
-  })
+    });
+    expect(closeout.packfile_ref).toBe("packfile.forge.6751");
+    expect(decodeForgeDispatchMessage(closeout).schema).toBe(closeout.schema);
+  });
 
   test("decodes redacted verification and promotion decision receipts", () => {
     const verification = decodeForgeVerificationReceipt({
@@ -296,9 +308,9 @@ describe("@openagentsinc/forge-protocol", () => {
       log_sha256: "d".repeat(64),
       source_refs: ["github:OpenAgentsInc/openagents#6768"],
       redacted: true,
-    })
-    expect(verification.change_ref).toBe("change.forge.6768")
-    expect(verification.packfile_sha256).toHaveLength(64)
+    });
+    expect(verification.change_ref).toBe("change.forge.6768");
+    expect(verification.packfile_sha256).toHaveLength(64);
 
     const promotion = decodeForgePromotionDecisionReceipt({
       schema: "openagents.forge.promotion.decision.v0.1",
@@ -317,8 +329,8 @@ describe("@openagentsinc/forge-protocol", () => {
       decided_at: "2026-06-28T16:02:00.000Z",
       source_refs: verification.source_refs,
       redacted: true,
-    })
-    expect(promotion.decision).toBe("approved")
-    expect(promotion.promoted_head).toBe(verification.head_head)
-  })
-})
+    });
+    expect(promotion.decision).toBe("approved");
+    expect(promotion.promoted_head).toBe(verification.head_head);
+  });
+});

--- a/packages/forge-protocol/src/index.ts
+++ b/packages/forge-protocol/src/index.ts
@@ -1,32 +1,32 @@
-import { Schema as S } from "effect"
+import { Schema as S } from "effect";
 
-export const ForgeProtocolSchemaVersion = S.Literal("openagents.forge.protocol.v0.1")
-export type ForgeProtocolSchemaVersion = typeof ForgeProtocolSchemaVersion.Type
+export const ForgeProtocolSchemaVersion = S.Literal(
+  "openagents.forge.protocol.v0.1",
+);
+export type ForgeProtocolSchemaVersion = typeof ForgeProtocolSchemaVersion.Type;
 
 export const FORGE_PROTOCOL_SCHEMA_VERSION: ForgeProtocolSchemaVersion =
-  "openagents.forge.protocol.v0.1"
+  "openagents.forge.protocol.v0.1";
 
 export const ForgeCoordinationStatusState = S.Literals([
   "open",
   "applied",
   "closed",
   "draft",
-])
-export type ForgeCoordinationStatusState = typeof ForgeCoordinationStatusState.Type
+]);
+export type ForgeCoordinationStatusState =
+  typeof ForgeCoordinationStatusState.Type;
 
-export const forgeCoordinationStatusStates: ReadonlyArray<ForgeCoordinationStatusState> = [
-  "open",
-  "applied",
-  "closed",
-  "draft",
-]
+export const forgeCoordinationStatusStates: ReadonlyArray<ForgeCoordinationStatusState> =
+  ["open", "applied", "closed", "draft"];
 
 export const ForgeCoordinationIssueState = S.Literals([
   "open",
   "closed",
   "draft",
-])
-export type ForgeCoordinationIssueState = typeof ForgeCoordinationIssueState.Type
+]);
+export type ForgeCoordinationIssueState =
+  typeof ForgeCoordinationIssueState.Type;
 
 export const ForgeCoordinationChangeState = S.Literals([
   "draft",
@@ -35,16 +35,17 @@ export const ForgeCoordinationChangeState = S.Literals([
   "blocked",
   "applied",
   "closed",
-])
-export type ForgeCoordinationChangeState = typeof ForgeCoordinationChangeState.Type
+]);
+export type ForgeCoordinationChangeState =
+  typeof ForgeCoordinationChangeState.Type;
 
 export const ForgeDispatchLeaseState = S.Literals([
   "active",
   "released",
   "expired",
   "cancelled",
-])
-export type ForgeDispatchLeaseState = typeof ForgeDispatchLeaseState.Type
+]);
+export type ForgeDispatchLeaseState = typeof ForgeDispatchLeaseState.Type;
 
 export const ForgeMergeQueueLedgerState = S.Literals([
   "projected",
@@ -52,32 +53,41 @@ export const ForgeMergeQueueLedgerState = S.Literals([
   "promoting",
   "promoted",
   "superseded",
-])
-export type ForgeMergeQueueLedgerState = typeof ForgeMergeQueueLedgerState.Type
+]);
+export type ForgeMergeQueueLedgerState = typeof ForgeMergeQueueLedgerState.Type;
 
 export const ForgeGitPackfileObjectFormat = S.Literals([
   "sha1",
   "sha256",
   "unknown",
-])
-export type ForgeGitPackfileObjectFormat = typeof ForgeGitPackfileObjectFormat.Type
+]);
+export type ForgeGitPackfileObjectFormat =
+  typeof ForgeGitPackfileObjectFormat.Type;
 
-export const ForgeTenantState = S.Literals(["active", "suspended"])
-export type ForgeTenantState = typeof ForgeTenantState.Type
+export const ForgeTenantState = S.Literals(["active", "suspended"]);
+export type ForgeTenantState = typeof ForgeTenantState.Type;
+
+export const ForgeTenantConfidentialWorkspaceMode = S.Literals([
+  "disabled",
+  "enabled",
+  "attested",
+]);
+export type ForgeTenantConfidentialWorkspaceMode =
+  typeof ForgeTenantConfidentialWorkspaceMode.Type;
 
 export const ForgeGitAccessTokenState = S.Literals([
   "active",
   "revoked",
   "expired",
-])
-export type ForgeGitAccessTokenState = typeof ForgeGitAccessTokenState.Type
+]);
+export type ForgeGitAccessTokenState = typeof ForgeGitAccessTokenState.Type;
 
 export const ForgeGitAccessScope = S.Literals([
   "git:upload-pack",
   "git:receive-pack",
   "git:admin",
-])
-export type ForgeGitAccessScope = typeof ForgeGitAccessScope.Type
+]);
+export type ForgeGitAccessScope = typeof ForgeGitAccessScope.Type;
 
 export const ForgeControlPlaneScope = S.Literals([
   "forge:work:read",
@@ -91,8 +101,8 @@ export const ForgeControlPlaneScope = S.Literals([
   "forge:receipt:write",
   "forge:promotion:decide",
   "forge:admin",
-])
-export type ForgeControlPlaneScope = typeof ForgeControlPlaneScope.Type
+]);
+export type ForgeControlPlaneScope = typeof ForgeControlPlaneScope.Type;
 
 export const forgeControlPlaneScopes: ReadonlyArray<ForgeControlPlaneScope> = [
   "forge:work:read",
@@ -106,20 +116,20 @@ export const forgeControlPlaneScopes: ReadonlyArray<ForgeControlPlaneScope> = [
   "forge:receipt:write",
   "forge:promotion:decide",
   "forge:admin",
-]
+];
 
 export const ForgeDispatchWorkClass = S.Literals([
   "codex_agent_task",
   "claude_agent_task",
   "cloud_coding_session",
-])
-export type ForgeDispatchWorkClass = typeof ForgeDispatchWorkClass.Type
+]);
+export type ForgeDispatchWorkClass = typeof ForgeDispatchWorkClass.Type;
 
-export const ForgeDispatchPaymentMode = S.Literals(["no-spend", "paid"])
-export type ForgeDispatchPaymentMode = typeof ForgeDispatchPaymentMode.Type
+export const ForgeDispatchPaymentMode = S.Literals(["no-spend", "paid"]);
+export type ForgeDispatchPaymentMode = typeof ForgeDispatchPaymentMode.Type;
 
-export const ForgeDispatchDecisionState = S.Literals(["accepted", "rejected"])
-export type ForgeDispatchDecisionState = typeof ForgeDispatchDecisionState.Type
+export const ForgeDispatchDecisionState = S.Literals(["accepted", "rejected"]);
+export type ForgeDispatchDecisionState = typeof ForgeDispatchDecisionState.Type;
 
 export const ForgeDispatchCloseoutStatus = S.Literals([
   "accepted",
@@ -127,16 +137,18 @@ export const ForgeDispatchCloseoutStatus = S.Literals([
   "cancelled",
   "timed-out",
   "stale",
-])
-export type ForgeDispatchCloseoutStatus = typeof ForgeDispatchCloseoutStatus.Type
+]);
+export type ForgeDispatchCloseoutStatus =
+  typeof ForgeDispatchCloseoutStatus.Type;
 
 export const ForgeDispatchSettlementState = S.Literals([
   "not_applicable",
   "pending",
   "recorded",
   "blocked",
-])
-export type ForgeDispatchSettlementState = typeof ForgeDispatchSettlementState.Type
+]);
+export type ForgeDispatchSettlementState =
+  typeof ForgeDispatchSettlementState.Type;
 
 export const ForgeVerificationVerdict = S.Literals([
   "passed",
@@ -144,25 +156,26 @@ export const ForgeVerificationVerdict = S.Literals([
   "timed_out",
   "cancelled",
   "errored",
-])
-export type ForgeVerificationVerdict = typeof ForgeVerificationVerdict.Type
+]);
+export type ForgeVerificationVerdict = typeof ForgeVerificationVerdict.Type;
 
 export const ForgePromotionDecisionState = S.Literals([
   "approved",
   "blocked",
   "superseded",
-])
-export type ForgePromotionDecisionState = typeof ForgePromotionDecisionState.Type
+]);
+export type ForgePromotionDecisionState =
+  typeof ForgePromotionDecisionState.Type;
 
 export const ForgeDispatchGitAccessDelivery = S.Literals([
   "out_of_band",
   "same_response_ephemeral",
-])
+]);
 export type ForgeDispatchGitAccessDelivery =
-  typeof ForgeDispatchGitAccessDelivery.Type
+  typeof ForgeDispatchGitAccessDelivery.Type;
 
-export const ForgeNip34StatusKind = S.Literals([1630, 1631, 1632, 1633])
-export type ForgeNip34StatusKind = typeof ForgeNip34StatusKind.Type
+export const ForgeNip34StatusKind = S.Literals([1630, 1631, 1632, 1633]);
+export type ForgeNip34StatusKind = typeof ForgeNip34StatusKind.Type;
 
 export const forgeNip34StatusKindForState = (
   state: ForgeCoordinationStatusState,
@@ -173,7 +186,7 @@ export const forgeNip34StatusKindForState = (
       ? 1631
       : state === "closed"
         ? 1632
-        : 1633
+        : 1633;
 
 export const ForgeCoordinationIssueRow = S.Struct({
   tenant_ref: S.String,
@@ -185,8 +198,8 @@ export const ForgeCoordinationIssueRow = S.Struct({
   source_refs_json: S.String,
   created_at: S.String,
   updated_at: S.String,
-})
-export type ForgeCoordinationIssueRow = typeof ForgeCoordinationIssueRow.Type
+});
+export type ForgeCoordinationIssueRow = typeof ForgeCoordinationIssueRow.Type;
 
 export const ForgeCoordinationPrRow = S.Struct({
   tenant_ref: S.String,
@@ -201,8 +214,8 @@ export const ForgeCoordinationPrRow = S.Struct({
   source_refs_json: S.String,
   created_at: S.String,
   updated_at: S.String,
-})
-export type ForgeCoordinationPrRow = typeof ForgeCoordinationPrRow.Type
+});
+export type ForgeCoordinationPrRow = typeof ForgeCoordinationPrRow.Type;
 
 export const ForgeCoordinationStatusRow = S.Struct({
   tenant_ref: S.String,
@@ -213,8 +226,8 @@ export const ForgeCoordinationStatusRow = S.Struct({
   actor_ref: S.String,
   source_refs_json: S.String,
   created_at: S.String,
-})
-export type ForgeCoordinationStatusRow = typeof ForgeCoordinationStatusRow.Type
+});
+export type ForgeCoordinationStatusRow = typeof ForgeCoordinationStatusRow.Type;
 
 export const ForgeDispatchLeaseRow = S.Struct({
   tenant_ref: S.String,
@@ -228,8 +241,8 @@ export const ForgeDispatchLeaseRow = S.Struct({
   expires_at: S.String,
   released_at: S.NullOr(S.String),
   source_refs_json: S.String,
-})
-export type ForgeDispatchLeaseRow = typeof ForgeDispatchLeaseRow.Type
+});
+export type ForgeDispatchLeaseRow = typeof ForgeDispatchLeaseRow.Type;
 
 export const ForgeMergeQueueLedgerRow = S.Struct({
   tenant_ref: S.String,
@@ -244,8 +257,8 @@ export const ForgeMergeQueueLedgerRow = S.Struct({
   source_refs_json: S.String,
   created_at: S.String,
   updated_at: S.String,
-})
-export type ForgeMergeQueueLedgerRow = typeof ForgeMergeQueueLedgerRow.Type
+});
+export type ForgeMergeQueueLedgerRow = typeof ForgeMergeQueueLedgerRow.Type;
 
 export const ForgeGitPackfileArchiveRow = S.Struct({
   tenant_ref: S.String,
@@ -265,17 +278,24 @@ export const ForgeGitPackfileArchiveRow = S.Struct({
   visibility: S.Literal("operator_only"),
   created_at: S.String,
   updated_at: S.String,
-})
-export type ForgeGitPackfileArchiveRow = typeof ForgeGitPackfileArchiveRow.Type
+});
+export type ForgeGitPackfileArchiveRow = typeof ForgeGitPackfileArchiveRow.Type;
 
 export const ForgeTenantRow = S.Struct({
   tenant_ref: S.String,
   display_name: S.String,
   state: ForgeTenantState,
+  confidential_workspace_mode: S.optionalKey(
+    S.NullOr(ForgeTenantConfidentialWorkspaceMode),
+  ),
+  attestation_ref: S.optionalKey(S.NullOr(S.String)),
+  encrypted_knowledge_pack_ref: S.optionalKey(S.NullOr(S.String)),
+  refusal_reason: S.optionalKey(S.NullOr(S.String)),
+  retention_policy_ref: S.optionalKey(S.NullOr(S.String)),
   created_at: S.String,
   updated_at: S.String,
-})
-export type ForgeTenantRow = typeof ForgeTenantRow.Type
+});
+export type ForgeTenantRow = typeof ForgeTenantRow.Type;
 
 export const ForgeGitAccessTokenRow = S.Struct({
   tenant_ref: S.String,
@@ -290,17 +310,17 @@ export const ForgeGitAccessTokenRow = S.Struct({
   last_used_at: S.NullOr(S.String),
   revoked_at: S.NullOr(S.String),
   source_refs_json: S.String,
-})
-export type ForgeGitAccessTokenRow = typeof ForgeGitAccessTokenRow.Type
+});
+export type ForgeGitAccessTokenRow = typeof ForgeGitAccessTokenRow.Type;
 
 export const ForgeGitAccessTokenScopeRow = S.Struct({
   tenant_ref: S.String,
   token_ref: S.String,
   scope: ForgeGitAccessScope,
   created_at: S.String,
-})
+});
 export type ForgeGitAccessTokenScopeRow =
-  typeof ForgeGitAccessTokenScopeRow.Type
+  typeof ForgeGitAccessTokenScopeRow.Type;
 
 export const ForgeDispatchGitAccess = S.Struct({
   token_ref: S.String,
@@ -308,8 +328,8 @@ export const ForgeDispatchGitAccess = S.Struct({
   scopes: S.Array(ForgeGitAccessScope),
   expires_at: S.String,
   delivery: ForgeDispatchGitAccessDelivery,
-})
-export type ForgeDispatchGitAccess = typeof ForgeDispatchGitAccess.Type
+});
+export type ForgeDispatchGitAccess = typeof ForgeDispatchGitAccess.Type;
 
 export const ForgeDispatchVerificationCommand = S.Struct({
   command_ref: S.String,
@@ -317,9 +337,9 @@ export const ForgeDispatchVerificationCommand = S.Struct({
   working_directory: S.String,
   args: S.Array(S.String),
   timeout_seconds: S.Number,
-})
+});
 export type ForgeDispatchVerificationCommand =
-  typeof ForgeDispatchVerificationCommand.Type
+  typeof ForgeDispatchVerificationCommand.Type;
 
 export const ForgeDispatchGitTarget = S.Struct({
   repository_ref: S.String,
@@ -329,8 +349,8 @@ export const ForgeDispatchGitTarget = S.Struct({
   branch_ref: S.String,
   receive_pack_ref: S.String,
   git_access: ForgeDispatchGitAccess,
-})
-export type ForgeDispatchGitTarget = typeof ForgeDispatchGitTarget.Type
+});
+export type ForgeDispatchGitTarget = typeof ForgeDispatchGitTarget.Type;
 
 export const ForgeDispatchWorkItem = S.Struct({
   schema: S.Literal("openagents.forge.dispatch.work_item.v0.1"),
@@ -349,8 +369,8 @@ export const ForgeDispatchWorkItem = S.Struct({
   expires_at: S.String,
   created_at: S.String,
   source_refs: S.Array(S.String),
-})
-export type ForgeDispatchWorkItem = typeof ForgeDispatchWorkItem.Type
+});
+export type ForgeDispatchWorkItem = typeof ForgeDispatchWorkItem.Type;
 
 export const ForgeDispatchDecision = S.Struct({
   schema: S.Literal("openagents.forge.dispatch.decision.v0.1"),
@@ -364,8 +384,8 @@ export const ForgeDispatchDecision = S.Struct({
   rejected_at: S.NullOr(S.String),
   blocker_refs: S.Array(S.String),
   source_refs: S.Array(S.String),
-})
-export type ForgeDispatchDecision = typeof ForgeDispatchDecision.Type
+});
+export type ForgeDispatchDecision = typeof ForgeDispatchDecision.Type;
 
 export const ForgeDispatchCloseout = S.Struct({
   schema: S.Literal("openagents.forge.dispatch.closeout.v0.1"),
@@ -394,8 +414,8 @@ export const ForgeDispatchCloseout = S.Struct({
   source_refs: S.Array(S.String),
   redacted: S.Literal(true),
   completed_at: S.String,
-})
-export type ForgeDispatchCloseout = typeof ForgeDispatchCloseout.Type
+});
+export type ForgeDispatchCloseout = typeof ForgeDispatchCloseout.Type;
 
 export const ForgeVerificationReceipt = S.Struct({
   schema: S.Literal("openagents.forge.verification.receipt.v0.1"),
@@ -420,8 +440,8 @@ export const ForgeVerificationReceipt = S.Struct({
   log_sha256: S.String,
   source_refs: S.Array(S.String),
   redacted: S.Literal(true),
-})
-export type ForgeVerificationReceipt = typeof ForgeVerificationReceipt.Type
+});
+export type ForgeVerificationReceipt = typeof ForgeVerificationReceipt.Type;
 
 export const ForgePromotionDecisionReceipt = S.Struct({
   schema: S.Literal("openagents.forge.promotion.decision.v0.1"),
@@ -440,16 +460,16 @@ export const ForgePromotionDecisionReceipt = S.Struct({
   decided_at: S.String,
   source_refs: S.Array(S.String),
   redacted: S.Literal(true),
-})
+});
 export type ForgePromotionDecisionReceipt =
-  typeof ForgePromotionDecisionReceipt.Type
+  typeof ForgePromotionDecisionReceipt.Type;
 
 export const ForgeDispatchMessage = S.Union([
   ForgeDispatchWorkItem,
   ForgeDispatchDecision,
   ForgeDispatchCloseout,
-])
-export type ForgeDispatchMessage = typeof ForgeDispatchMessage.Type
+]);
+export type ForgeDispatchMessage = typeof ForgeDispatchMessage.Type;
 
 export const ForgeCoordinationRow = S.Union([
   ForgeCoordinationIssueRow,
@@ -461,45 +481,62 @@ export const ForgeCoordinationRow = S.Union([
   ForgeTenantRow,
   ForgeGitAccessTokenRow,
   ForgeGitAccessTokenScopeRow,
-])
-export type ForgeCoordinationRow = typeof ForgeCoordinationRow.Type
+]);
+export type ForgeCoordinationRow = typeof ForgeCoordinationRow.Type;
 
 export const decodeForgeCoordinationIssueRow = S.decodeUnknownSync(
   ForgeCoordinationIssueRow,
-)
-export const decodeForgeCoordinationPrRow = S.decodeUnknownSync(ForgeCoordinationPrRow)
+);
+export const decodeForgeCoordinationPrRow = S.decodeUnknownSync(
+  ForgeCoordinationPrRow,
+);
 export const decodeForgeCoordinationStatusRow = S.decodeUnknownSync(
   ForgeCoordinationStatusRow,
-)
-export const decodeForgeDispatchLeaseRow = S.decodeUnknownSync(ForgeDispatchLeaseRow)
+);
+export const decodeForgeDispatchLeaseRow = S.decodeUnknownSync(
+  ForgeDispatchLeaseRow,
+);
 export const decodeForgeMergeQueueLedgerRow = S.decodeUnknownSync(
   ForgeMergeQueueLedgerRow,
-)
+);
 export const decodeForgeGitPackfileArchiveRow = S.decodeUnknownSync(
   ForgeGitPackfileArchiveRow,
-)
-export const decodeForgeTenantRow = S.decodeUnknownSync(ForgeTenantRow)
+);
+export const decodeForgeTenantRow = S.decodeUnknownSync(ForgeTenantRow);
 export const decodeForgeGitAccessTokenRow = S.decodeUnknownSync(
   ForgeGitAccessTokenRow,
-)
+);
 export const decodeForgeGitAccessTokenScopeRow = S.decodeUnknownSync(
   ForgeGitAccessTokenScopeRow,
-)
+);
 export const decodeForgeControlPlaneScope = S.decodeUnknownSync(
   ForgeControlPlaneScope,
-)
-export const decodeForgeDispatchWorkItem = S.decodeUnknownSync(ForgeDispatchWorkItem)
-export const decodeForgeDispatchDecision = S.decodeUnknownSync(ForgeDispatchDecision)
-export const decodeForgeDispatchCloseout = S.decodeUnknownSync(ForgeDispatchCloseout)
-export const decodeForgeDispatchMessage = S.decodeUnknownSync(ForgeDispatchMessage)
+);
+export const decodeForgeDispatchWorkItem = S.decodeUnknownSync(
+  ForgeDispatchWorkItem,
+);
+export const decodeForgeDispatchDecision = S.decodeUnknownSync(
+  ForgeDispatchDecision,
+);
+export const decodeForgeDispatchCloseout = S.decodeUnknownSync(
+  ForgeDispatchCloseout,
+);
+export const decodeForgeDispatchMessage =
+  S.decodeUnknownSync(ForgeDispatchMessage);
 export const decodeForgeVerificationReceipt = S.decodeUnknownSync(
   ForgeVerificationReceipt,
-)
+);
 export const decodeForgePromotionDecisionReceipt = S.decodeUnknownSync(
   ForgePromotionDecisionReceipt,
-)
+);
 
 export const forgeCoordinationStatusStateForNip34Kind = (
   kind: ForgeNip34StatusKind,
 ): ForgeCoordinationStatusState =>
-  kind === 1630 ? "open" : kind === 1631 ? "applied" : kind === 1632 ? "closed" : "draft"
+  kind === 1630
+    ? "open"
+    : kind === 1631
+      ? "applied"
+      : kind === 1632
+        ? "closed"
+        : "draft";


### PR DESCRIPTION
Addresses #6798.

### Changes
- Require Forge control-plane bearer requests to include a tenant scope header.
- Reject control-plane reads and mutations when the requested tenant differs from the token-scoped tenant.
- Update Forge protocol schemas, tests, OpenAPI metadata, and boundary docs for tenant isolation and scoped API behavior.
- Add coverage for tenant-scoped auth stores, packfile archive behavior, and wrong-tenant control-plane access.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).