### PR TITLE
feat(khala-macos): scaffold native SwiftUI app

### DIFF
--- a/clients/khala-macos/Khala/Khala.xcodeproj/project.pbxproj
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/project.pbxproj
@@ -1,0 +1,251 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		B1000000000000000000FAPP /* Khala.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Khala.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		B1000000000000000000XEXC /* Exceptions for "Khala" folder in "Khala" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Resources/Info.plist,
+			);
+			target = B1000000000000000000TGT /* Khala */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		B1000000000000000000GSRC /* Khala */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				B1000000000000000000XEXC /* Exceptions for "Khala" folder in "Khala" target */,
+			);
+			path = Khala;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B1000000000000000000FRMW /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B1000000000000000000GRT = {
+			isa = PBXGroup;
+			children = (
+				B1000000000000000000GSRC /* Khala */,
+				B1000000000000000000GPRD /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B1000000000000000000GPRD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B1000000000000000000FAPP /* Khala.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B1000000000000000000TGT /* Khala */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B1000000000000000000CLT /* Build configuration list for PBXNativeTarget "Khala" */;
+			buildPhases = (
+				B1000000000000000000SRC /* Sources */,
+				B1000000000000000000FRMW /* Frameworks */,
+				B1000000000000000000RES /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				B1000000000000000000GSRC /* Khala */,
+			);
+			name = Khala;
+			productName = Khala;
+			productReference = B1000000000000000000FAPP /* Khala.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B1000000000000000000PRJ /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2600;
+				LastUpgradeCheck = 2600;
+				TargetAttributes = {
+					B1000000000000000000TGT = {
+						CreatedOnToolsVersion = 26.0;
+					};
+				};
+			};
+			buildConfigurationList = B1000000000000000000CLP /* Build configuration list for PBXProject "Khala" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B1000000000000000000GRT;
+			productRefGroup = B1000000000000000000GPRD /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B1000000000000000000TGT /* Khala */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B1000000000000000000RES /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B1000000000000000000SRC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		B1000000000000000000DBG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B1000000000000000000REL /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B1000000000000000000TDBG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Khala/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.openagents.khala-macos";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		B1000000000000000000TREL /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Khala/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.openagents.khala-macos";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B1000000000000000000CLP /* Build configuration list for PBXProject "Khala" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B1000000000000000000DBG /* Debug */,
+				B1000000000000000000REL /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B1000000000000000000CLT /* Build configuration list for PBXNativeTarget "Khala" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B1000000000000000000TDBG /* Debug */,
+				B1000000000000000000TREL /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = B1000000000000000000PRJ /* Project object */;
+}

--- a/clients/khala-macos/Khala/Khala.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/clients/khala-macos/Khala/Khala.xcodeproj/xcshareddata/xcschemes/Khala.xcscheme
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/xcshareddata/xcschemes/Khala.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B1000000000000000000TGT"
+               BuildableName = "Khala.app"
+               BlueprintName = "Khala"
+               ReferencedContainer = "container:Khala.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B1000000000000000000TGT"
+            BuildableName = "Khala.app"
+            BlueprintName = "Khala"
+            ReferencedContainer = "container:Khala.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B1000000000000000000TGT"
+            BuildableName = "Khala.app"
+            BlueprintName = "Khala"
+            ReferencedContainer = "container:Khala.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/clients/khala-macos/Khala/Khala/KhalaApp.swift
+++ b/clients/khala-macos/Khala/Khala/KhalaApp.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@main
+struct KhalaApp: App {
+    @StateObject private var store = ConversationStore()
+
+    var body: some Scene {
+        WindowGroup {
+            DesktopRootView(store: store)
+                .preferredColorScheme(.dark)
+                .frame(minWidth: 980, minHeight: 680)
+        }
+        .windowStyle(.titleBar)
+        .windowToolbarStyle(.unified)
+
+        Settings {
+            SettingsView()
+                .preferredColorScheme(.dark)
+        }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Model/Conversation.swift
+++ b/clients/khala-macos/Khala/Khala/Model/Conversation.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum MessageRole: String, Codable, CaseIterable, Sendable {
+    case system
+    case user
+    case assistant
+}
+
+struct Message: Identifiable, Codable, Equatable, Sendable {
+    var id: UUID
+    var role: MessageRole
+    var content: String
+    var createdAt: Date
+
+    init(id: UUID = UUID(), role: MessageRole, content: String, createdAt: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+    }
+}
+
+struct Conversation: Identifiable, Codable, Equatable, Sendable {
+    var id: UUID
+    var title: String
+    var createdAt: Date
+    var updatedAt: Date
+    var messages: [Message]
+
+    init(
+        id: UUID = UUID(),
+        title: String = Conversation.defaultTitle,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        messages: [Message] = []
+    ) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messages = messages
+    }
+
+    static let defaultTitle = "New Chat"
+
+    static func derivedTitle(from text: String, maxLength: Int = 48) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return defaultTitle }
+        let firstLine = trimmed.split(whereSeparator: \.isNewline).first.map(String.init) ?? trimmed
+        guard firstLine.count > maxLength else { return firstLine }
+        let end = firstLine.index(firstLine.startIndex, offsetBy: maxLength)
+        return String(firstLine[..<end]).trimmingCharacters(in: .whitespaces) + "..."
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Model/ConversationStore.swift
+++ b/clients/khala-macos/Khala/Khala/Model/ConversationStore.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+@MainActor
+final class ConversationStore: ObservableObject {
+    @Published private(set) var conversations: [Conversation] = []
+    @Published private(set) var isUsingEphemeralFallback = false
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let fileURL: URL?
+
+    init() {
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let fileManager = FileManager.default
+        if let appSupport = try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) {
+            let directory = appSupport.appendingPathComponent("com.openagents.khala-macos", isDirectory: true)
+            try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            fileURL = directory.appendingPathComponent("conversations.json")
+        } else {
+            fileURL = nil
+            isUsingEphemeralFallback = true
+        }
+
+        load()
+    }
+
+    var mostRecent: Conversation? {
+        conversations.sorted { $0.updatedAt > $1.updatedAt }.first
+    }
+
+    @discardableResult
+    func createConversation() -> Conversation {
+        let conversation = Conversation()
+        conversations.insert(conversation, at: 0)
+        persist()
+        return conversation
+    }
+
+    func delete(_ conversation: Conversation) {
+        conversations.removeAll { $0.id == conversation.id }
+        persist()
+    }
+
+    func rename(_ conversation: Conversation, to title: String) {
+        update(conversation.id) { item in
+            let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            item.title = trimmed.isEmpty ? Conversation.defaultTitle : trimmed
+            item.updatedAt = Date()
+        }
+    }
+
+    @discardableResult
+    func appendMessage(_ role: MessageRole, content: String, to conversation: Conversation) -> Message {
+        let message = Message(role: role, content: content)
+        update(conversation.id) { item in
+            item.messages.append(message)
+            item.updatedAt = Date()
+            if item.title == Conversation.defaultTitle,
+               role == .user,
+               item.messages.filter({ $0.role == .user }).count == 1 {
+                item.title = Conversation.derivedTitle(from: content)
+            }
+        }
+        return message
+    }
+
+    func updateMessage(_ messageID: UUID, in conversationID: UUID, content: String) {
+        update(conversationID) { item in
+            guard let index = item.messages.firstIndex(where: { $0.id == messageID }) else { return }
+            item.messages[index].content = content
+            item.updatedAt = Date()
+        }
+    }
+
+    func deleteMessage(_ messageID: UUID, from conversationID: UUID) {
+        update(conversationID) { item in
+            item.messages.removeAll { $0.id == messageID }
+            item.updatedAt = Date()
+        }
+    }
+
+    func conversation(id: UUID) -> Conversation? {
+        conversations.first { $0.id == id }
+    }
+
+    private func update(_ id: UUID, mutate: (inout Conversation) -> Void) {
+        guard let index = conversations.firstIndex(where: { $0.id == id }) else { return }
+        mutate(&conversations[index])
+        conversations.sort { $0.updatedAt > $1.updatedAt }
+        persist()
+    }
+
+    private func load() {
+        guard let fileURL, let data = try? Data(contentsOf: fileURL), !data.isEmpty else {
+            conversations = []
+            return
+        }
+        conversations = ((try? decoder.decode([Conversation].self, from: data)) ?? [])
+            .sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    private func persist() {
+        guard let fileURL else {
+            isUsingEphemeralFallback = true
+            return
+        }
+        do {
+            let data = try encoder.encode(conversations)
+            try data.write(to: fileURL, options: [.atomic])
+        } catch {
+            isUsingEphemeralFallback = true
+        }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Net/KhalaClient.swift
+++ b/clients/khala-macos/Khala/Khala/Net/KhalaClient.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+enum KhalaClient {
+    static let baseURL = URL(string: "https://openagents.com/api/v1")!
+    static let freeKeyURL = URL(string: "https://openagents.com/api/keys/free")!
+    static let model = "openagents/khala"
+
+    enum KhalaError: Error, LocalizedError, Equatable {
+        case missingKey
+        case unauthorized
+        case quotaExceeded
+        case http(Int, String)
+        case decoding
+        case transport(String)
+
+        var errorDescription: String? {
+            recoveryMessage
+        }
+
+        var recoveryTitle: String {
+            switch self {
+            case .quotaExceeded: return "Free quota reached"
+            case .http(let code, _) where code >= 500: return "Temporary Khala error"
+            case .transport: return "Connection interrupted"
+            case .missingKey: return "Missing API key"
+            case .unauthorized: return "Key rejected"
+            case .http: return "Khala API error"
+            case .decoding: return "Unexpected response"
+            }
+        }
+
+        var recoveryMessage: String {
+            switch self {
+            case .quotaExceeded:
+                return "Your free quota is out for now. Add credits or wait for the UTC reset before sending again."
+            case .http(let code, _) where code >= 500:
+                return "The server returned \(code). This is usually temporary, so the same message can be retried."
+            case .transport(let message):
+                return "The request did not reach Khala cleanly: \(message). Check the connection and retry."
+            case .missingKey:
+                return "Mint or paste a Khala key in Settings, then send the message again."
+            case .unauthorized:
+                return "Khala did not accept this API key. Open Settings to mint a free key or paste a valid one."
+            case .http(let code, _):
+                return "Khala returned HTTP \(code). Update the request or try again after checking Settings."
+            case .decoding:
+                return "Khala responded, but the app could not read the response body."
+            }
+        }
+
+        var isRetryable: Bool {
+            switch self {
+            case .http(let code, _) where code >= 500: return true
+            case .transport: return true
+            default: return false
+            }
+        }
+    }
+
+    static func mintFreeKey(session: URLSession = .shared) async throws -> String {
+        var request = URLRequest(url: freeKeyURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { throw KhalaError.decoding }
+            guard (200..<300).contains(http.statusCode) else {
+                throw KhalaError.http(http.statusCode, String(data: data, encoding: .utf8) ?? "")
+            }
+            guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let credential = object["credential"] as? [String: Any],
+                  let token = credential["token"] as? String,
+                  !token.isEmpty
+            else {
+                throw KhalaError.decoding
+            }
+            return token
+        } catch let error as KhalaError {
+            throw error
+        } catch {
+            throw KhalaError.transport(error.localizedDescription)
+        }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Net/KhalaStream.swift
+++ b/clients/khala-macos/Khala/Khala/Net/KhalaStream.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+extension KhalaClient {
+    struct OutgoingMessage: Sendable, Equatable {
+        let role: String
+        let content: String
+
+        var json: [String: String] {
+            ["role": role, "content": content]
+        }
+    }
+
+    struct SSEDelta: Equatable {
+        let content: String?
+        let isDone: Bool
+    }
+
+    static func streamCompletion(
+        messages: [OutgoingMessage],
+        apiKey: String,
+        session: URLSession = .shared
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let request = try makeStreamRequest(messages: messages, apiKey: apiKey)
+                    let (bytes, response) = try await session.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else { throw KhalaError.decoding }
+                    if http.statusCode == 401 || http.statusCode == 403 { throw KhalaError.unauthorized }
+                    if http.statusCode == 402 { throw KhalaError.quotaExceeded }
+                    guard (200..<300).contains(http.statusCode) else {
+                        let body = await collectErrorBody(from: bytes)
+                        throw KhalaError.http(http.statusCode, body)
+                    }
+
+                    for try await line in bytes.lines {
+                        try Task.checkCancellation()
+                        guard let delta = delta(fromSSELine: line) else { continue }
+                        if delta.isDone { break }
+                        if let content = delta.content, !content.isEmpty {
+                            continuation.yield(content)
+                        }
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch let error as KhalaError {
+                    continuation.finish(throwing: error)
+                } catch let urlError as URLError where urlError.code == .cancelled {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: KhalaError.transport(error.localizedDescription))
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    private static func makeStreamRequest(messages: [OutgoingMessage], apiKey: String) throws -> URLRequest {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { throw KhalaError.missingKey }
+
+        let url = baseURL.appendingPathComponent("chat/completions")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: Any] = [
+            "model": model,
+            "stream": true,
+            "messages": messages.map(\.json),
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    static func delta(fromSSELine line: String) -> SSEDelta? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("data:") else { return nil }
+
+        let payload = String(trimmed.dropFirst("data:".count)).trimmingCharacters(in: .whitespaces)
+        guard !payload.isEmpty else { return nil }
+        if payload == "[DONE]" { return SSEDelta(content: nil, isDone: true) }
+
+        guard let data = payload.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = object["choices"] as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        let content = choices.compactMap { choice -> String? in
+            if let delta = choice["delta"] as? [String: Any],
+               let content = delta["content"] as? String {
+                return content
+            }
+            if let message = choice["message"] as? [String: Any],
+               let content = message["content"] as? String {
+                return content
+            }
+            return nil
+        }.joined()
+
+        return SSEDelta(content: content.isEmpty ? nil : content, isDone: false)
+    }
+
+    private static func collectErrorBody(from bytes: URLSession.AsyncBytes, limit: Int = 2_048) async -> String {
+        var data = Data()
+        do {
+            for try await byte in bytes {
+                data.append(byte)
+                if data.count >= limit { break }
+            }
+        } catch {
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Resources/Info.plist
+++ b/clients/khala-macos/Khala/Khala/Resources/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright OpenAgents Inc.</string>
+</dict>
+</plist>

--- a/clients/khala-macos/Khala/Khala/Store/KeychainStore.swift
+++ b/clients/khala-macos/Khala/Khala/Store/KeychainStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Security
+
+enum KeychainStore {
+    private static let service = "com.openagents.khala-macos"
+    private static let account = "khala_api_key"
+
+    static func saveAPIKey(_ key: String) {
+        let data = Data(key.trimmingCharacters(in: .whitespacesAndNewlines).utf8)
+        deleteAPIKey()
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+        ]
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    static func loadAPIKey() -> String? {
+        if let envKey = ProcessInfo.processInfo.environment["KHALA_API_KEY"],
+           !envKey.isEmpty {
+            return envKey
+        }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let key = String(data: data, encoding: .utf8),
+              !key.isEmpty
+        else {
+            return nil
+        }
+        return key
+    }
+
+    @discardableResult
+    static func deleteAPIKey() -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+
+    static var hasAPIKey: Bool {
+        loadAPIKey() != nil
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Views/ChatView.swift
+++ b/clients/khala-macos/Khala/Khala/Views/ChatView.swift
@@ -1,0 +1,257 @@
+import SwiftUI
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    struct ChatError: Equatable {
+        let title: String
+        let message: String
+        let isRetryable: Bool
+    }
+
+    @Published private(set) var streamingMessageID: UUID?
+    @Published private(set) var isStreaming = false
+    @Published private(set) var error: ChatError?
+    @Published private(set) var streamTick = 0
+
+    private let store: ConversationStore
+    private let conversationID: UUID
+    private var task: Task<Void, Never>?
+
+    init(store: ConversationStore, conversationID: UUID) {
+        self.store = store
+        self.conversationID = conversationID
+    }
+
+    func send(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isStreaming else { return }
+        guard let key = KeychainStore.loadAPIKey() else {
+            error = ChatError(
+                title: KhalaClient.KhalaError.missingKey.recoveryTitle,
+                message: KhalaClient.KhalaError.missingKey.recoveryMessage,
+                isRetryable: false
+            )
+            return
+        }
+
+        error = nil
+        guard let conversation = store.conversation(id: conversationID) else { return }
+        store.appendMessage(.user, content: trimmed, to: conversation)
+        startStream(apiKey: key)
+    }
+
+    func retry() {
+        guard !isStreaming, error?.isRetryable == true else { return }
+        guard let key = KeychainStore.loadAPIKey() else { return }
+        error = nil
+        startStream(apiKey: key)
+    }
+
+    func stop() {
+        task?.cancel()
+    }
+
+    private func startStream(apiKey: String) {
+        guard let conversation = store.conversation(id: conversationID) else { return }
+        let history = conversation.messages
+            .sorted { $0.createdAt < $1.createdAt }
+            .filter { $0.role != .system && !$0.content.isEmpty }
+            .map { KhalaClient.OutgoingMessage(role: $0.role.rawValue, content: $0.content) }
+        guard !history.isEmpty else { return }
+
+        let assistant = store.appendMessage(.assistant, content: "", to: conversation)
+        streamingMessageID = assistant.id
+        isStreaming = true
+        streamTick &+= 1
+
+        task = Task { [weak self] in
+            guard let self else { return }
+            var assembled = ""
+            do {
+                for try await delta in KhalaClient.streamCompletion(messages: history, apiKey: apiKey) {
+                    assembled += delta
+                    self.store.updateMessage(assistant.id, in: self.conversationID, content: assembled)
+                    self.streamTick &+= 1
+                }
+                self.settle(assistantID: assistant.id, content: assembled)
+            } catch is CancellationError {
+                self.settle(assistantID: assistant.id, content: assembled)
+            } catch let khala as KhalaClient.KhalaError {
+                self.fail(khala, assistantID: assistant.id, content: assembled)
+            } catch {
+                self.fail(.transport(error.localizedDescription), assistantID: assistant.id, content: assembled)
+            }
+        }
+    }
+
+    private func settle(assistantID: UUID, content: String) {
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            store.deleteMessage(assistantID, from: conversationID)
+        }
+        streamingMessageID = nil
+        isStreaming = false
+        task = nil
+    }
+
+    private func fail(_ khala: KhalaClient.KhalaError, assistantID: UUID, content: String) {
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            store.deleteMessage(assistantID, from: conversationID)
+        }
+        error = ChatError(title: khala.recoveryTitle, message: khala.recoveryMessage, isRetryable: khala.isRetryable)
+        streamingMessageID = nil
+        isStreaming = false
+        task = nil
+    }
+}
+
+struct ChatView: View {
+    @ObservedObject var store: ConversationStore
+    let conversationID: UUID?
+    @Binding var hasKey: Bool
+    let onOpenSettings: () -> Void
+
+    @State private var typedMessage = ""
+    @State private var model: ChatViewModel?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let conversation = conversation, let model = model {
+                transcript(conversation: conversation, model: model)
+                composer(model: model)
+            } else {
+                ContentUnavailableView("No conversation", systemImage: "bubble.left.and.bubble.right")
+            }
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+        .onAppear(perform: syncModel)
+        .onChange(of: conversationID) { _, _ in syncModel() }
+    }
+
+    private var conversation: Conversation? {
+        guard let conversationID else { return nil }
+        return store.conversation(id: conversationID)
+    }
+
+    private func transcript(conversation: Conversation, model: ChatViewModel) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    if conversation.messages.isEmpty && model.error == nil {
+                        emptyState
+                    } else {
+                        ForEach(conversation.messages.sorted { $0.createdAt < $1.createdAt }) { message in
+                            if message.role != .system {
+                                MessageBubble(
+                                    title: message.role == .user ? "You" : "Khala",
+                                    text: message.content,
+                                    outgoing: message.role == .user,
+                                    isStreaming: message.id == model.streamingMessageID
+                                )
+                                .id(message.id)
+                            }
+                        }
+                    }
+
+                    if let error = model.error {
+                        chatErrorNotice(error, model: model)
+                    }
+
+                    Color.clear.frame(height: 1).id("bottom")
+                }
+                .frame(maxWidth: 860)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 28)
+                .padding(.vertical, 24)
+            }
+            .onChange(of: model.streamTick) { _, _ in scroll(proxy) }
+            .onChange(of: conversation.messages.count) { _, _ in scroll(proxy) }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Text("Khala")
+                .font(.largeTitle.weight(.semibold))
+            Text("Collective intelligence behind a free API. Ask anything.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 140)
+    }
+
+    private func chatErrorNotice(_ error: ChatViewModel.ChatError, model: ChatViewModel) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(error.title, systemImage: error.isRetryable ? "arrow.clockwise.circle.fill" : "exclamationmark.circle.fill")
+                .font(.callout.weight(.semibold))
+            Text(error.message)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            HStack {
+                if error.isRetryable {
+                    Button("Retry", action: model.retry)
+                } else if !hasKey {
+                    Button("Open Settings", action: onOpenSettings)
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func composer(model: ChatViewModel) -> some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            TextField("Ask Khala", text: $typedMessage, axis: .vertical)
+                .lineLimit(1...5)
+                .textFieldStyle(.plain)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                .onSubmit { send(model: model) }
+                .disabled(model.isStreaming)
+
+            if model.isStreaming {
+                Button(action: model.stop) {
+                    Image(systemName: "stop.circle.fill")
+                }
+                .font(.title2)
+                .accessibilityLabel("Stop generating")
+            } else {
+                Button(action: { send(model: model) }) {
+                    Image(systemName: "arrow.up.circle.fill")
+                }
+                .font(.title2)
+                .disabled(!canSend(model: model))
+                .accessibilityLabel("Send message")
+            }
+        }
+        .padding(16)
+        .background(.bar)
+    }
+
+    private func canSend(model: ChatViewModel) -> Bool {
+        hasKey && !model.isStreaming && !typedMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func send(model: ChatViewModel) {
+        guard canSend(model: model) else { return }
+        let text = typedMessage
+        typedMessage = ""
+        model.send(text)
+    }
+
+    private func syncModel() {
+        guard let conversationID else {
+            model = nil
+            return
+        }
+        model = ChatViewModel(store: store, conversationID: conversationID)
+    }
+
+    private func scroll(_ proxy: ScrollViewProxy) {
+        withAnimation(.easeOut(duration: 0.2)) {
+            proxy.scrollTo("bottom", anchor: .bottom)
+        }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Views/DesktopRootView.swift
+++ b/clients/khala-macos/Khala/Khala/Views/DesktopRootView.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+
+struct DesktopRootView: View {
+    @ObservedObject var store: ConversationStore
+
+    @State private var selection: UUID?
+    @State private var showSettings = false
+    @State private var hasKey = KeychainStore.hasAPIKey
+    @State private var columnVisibility = NavigationSplitViewVisibility.all
+
+    var body: some View {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            sidebar
+        } content: {
+            ChatView(
+                store: store,
+                conversationID: activeConversation?.id,
+                hasKey: $hasKey,
+                onOpenSettings: { showSettings = true }
+            )
+        } detail: {
+            NodeInspectorView(hasKey: hasKey, isUsingEphemeralFallback: store.isUsingEphemeralFallback)
+        }
+        .navigationTitle("Khala")
+        .toolbar {
+            ToolbarItemGroup {
+                Button(action: newChat) {
+                    Label("New Chat", systemImage: "square.and.pencil")
+                }
+                Button {
+                    showSettings = true
+                } label: {
+                    Label("Settings", systemImage: "gearshape")
+                }
+            }
+        }
+        .sheet(isPresented: $showSettings, onDismiss: { hasKey = KeychainStore.hasAPIKey }) {
+            SettingsView()
+                .frame(width: 460)
+        }
+        .task {
+            if store.conversations.isEmpty {
+                selection = store.createConversation().id
+            } else if selection == nil {
+                selection = store.mostRecent?.id
+            }
+            if !KeychainStore.hasAPIKey,
+               let token = try? await KhalaClient.mintFreeKey() {
+                KeychainStore.saveAPIKey(token)
+                hasKey = true
+            }
+        }
+        .onChange(of: store.conversations) { _, conversations in
+            guard selection == nil || !conversations.contains(where: { $0.id == selection }) else { return }
+            selection = conversations.first?.id
+        }
+    }
+
+    private var sidebar: some View {
+        List(selection: $selection) {
+            Section("Conversations") {
+                ForEach(store.conversations) { conversation in
+                    ConversationRow(conversation: conversation)
+                        .tag(conversation.id)
+                        .contextMenu {
+                            Button("Rename") {
+                                store.rename(conversation, to: Conversation.derivedTitle(from: conversation.title))
+                            }
+                            Button("Delete", role: .destructive) {
+                                store.delete(conversation)
+                            }
+                        }
+                }
+            }
+
+            Section("Local Node") {
+                Label("Pylon not connected", systemImage: "bolt.horizontal.circle")
+                Label("Apple FM unavailable", systemImage: "cpu")
+                Label("Provider mode offline", systemImage: "power.circle")
+            }
+            .foregroundStyle(.secondary)
+        }
+        .safeAreaInset(edge: .bottom) {
+            Button(action: newChat) {
+                Label("New Chat", systemImage: "plus")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+        }
+        .navigationSplitViewColumnWidth(min: 240, ideal: 280, max: 340)
+    }
+
+    private var activeConversation: Conversation? {
+        if let selection, let conversation = store.conversation(id: selection) {
+            return conversation
+        }
+        return store.mostRecent
+    }
+
+    private func newChat() {
+        selection = store.createConversation().id
+    }
+}
+
+private struct ConversationRow: View {
+    let conversation: Conversation
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(conversation.title)
+                .font(.callout.weight(.medium))
+                .lineLimit(1)
+            Text(conversation.updatedAt, style: .relative)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var apiKey = KeychainStore.loadAPIKey() ?? ""
+    @State private var status = ""
+    @State private var isMinting = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Khala Settings")
+                .font(.title2.weight(.semibold))
+
+            Text("API key")
+                .font(.headline)
+            SecureField("oa_agent_...", text: $apiKey)
+                .textFieldStyle(.roundedBorder)
+
+            Text("Free keys use the public Khala API and may be used for service-quality and safety review according to the OpenAgents free-tier disclosure.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !status.isEmpty {
+                Text(status)
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Button("Mint Free Key") {
+                    Task { await mint() }
+                }
+                .disabled(isMinting)
+
+                Spacer()
+
+                Button("Delete Key", role: .destructive) {
+                    KeychainStore.deleteAPIKey()
+                    apiKey = ""
+                    status = "Key deleted."
+                }
+                Button("Save") {
+                    let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmed.isEmpty {
+                        KeychainStore.deleteAPIKey()
+                    } else {
+                        KeychainStore.saveAPIKey(trimmed)
+                    }
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(24)
+    }
+
+    private func mint() async {
+        isMinting = true
+        defer { isMinting = false }
+        do {
+            let token = try await KhalaClient.mintFreeKey()
+            apiKey = token
+            KeychainStore.saveAPIKey(token)
+            status = "Free key saved."
+        } catch {
+            status = "Could not mint a free key: \(error.localizedDescription)"
+        }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Views/MarkdownMessage.swift
+++ b/clients/khala-macos/Khala/Khala/Views/MarkdownMessage.swift
@@ -1,0 +1,145 @@
+import AppKit
+import SwiftUI
+
+struct MarkdownMessage: View {
+    let content: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(parseBlocks(), id: \.id) { block in
+                switch block.kind {
+                case .code(let language, let code):
+                    CodeBlockView(language: language, code: code)
+                case .heading(let level, let text):
+                    Text(attributed(text))
+                        .font(headingFont(level))
+                        .textSelection(.enabled)
+                case .paragraph(let text):
+                    Text(attributed(text))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func parseBlocks() -> [MarkdownBlock] {
+        var blocks: [MarkdownBlock] = []
+        var paragraph: [String] = []
+        var code: [String] = []
+        var codeLanguage: String?
+        var inCode = false
+
+        func flushParagraph() {
+            let text = paragraph.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                blocks.append(MarkdownBlock(kind: .paragraph(text)))
+            }
+            paragraph.removeAll()
+        }
+
+        for line in content.components(separatedBy: .newlines) {
+            if line.hasPrefix("```") {
+                if inCode {
+                    blocks.append(MarkdownBlock(kind: .code(codeLanguage, code.joined(separator: "\n"))))
+                    code.removeAll()
+                    codeLanguage = nil
+                    inCode = false
+                } else {
+                    flushParagraph()
+                    codeLanguage = String(line.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+                    inCode = true
+                }
+                continue
+            }
+
+            if inCode {
+                code.append(line)
+            } else if line.hasPrefix("#") {
+                flushParagraph()
+                let level = line.prefix { $0 == "#" }.count
+                let text = line.dropFirst(level).trimmingCharacters(in: .whitespaces)
+                blocks.append(MarkdownBlock(kind: .heading(level, String(text))))
+            } else if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                flushParagraph()
+            } else {
+                paragraph.append(line)
+            }
+        }
+
+        if inCode {
+            blocks.append(MarkdownBlock(kind: .code(codeLanguage, code.joined(separator: "\n"))))
+        }
+        flushParagraph()
+        if blocks.isEmpty {
+            blocks.append(MarkdownBlock(kind: .paragraph(content)))
+        }
+        return blocks
+    }
+
+    private func attributed(_ text: String) -> AttributedString {
+        (try? AttributedString(markdown: text)) ?? AttributedString(text)
+    }
+
+    private func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: return .title2.weight(.bold)
+        case 2: return .title3.weight(.bold)
+        case 3: return .headline
+        default: return .subheadline.weight(.semibold)
+        }
+    }
+}
+
+private struct MarkdownBlock: Identifiable {
+    let id = UUID()
+    let kind: Kind
+
+    enum Kind {
+        case paragraph(String)
+        case heading(Int, String)
+        case code(String?, String)
+    }
+}
+
+private struct CodeBlockView: View {
+    let language: String?
+    let code: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text((language?.isEmpty == false ? language! : "code").uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(code, forType: .string)
+                } label: {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+                .buttonStyle(.plain)
+                .font(.caption2.weight(.semibold))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            ScrollView(.horizontal) {
+                Text(code)
+                    .font(.system(.footnote, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(12)
+                    .fixedSize(horizontal: true, vertical: true)
+            }
+        }
+        .background(Color.black.opacity(0.35), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+        )
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Views/MessageBubble.swift
+++ b/clients/khala-macos/Khala/Khala/Views/MessageBubble.swift
@@ -1,0 +1,47 @@
+import AppKit
+import SwiftUI
+
+struct MessageBubble: View {
+    let title: String
+    let text: String
+    let outgoing: Bool
+    var isStreaming = false
+
+    var body: some View {
+        if outgoing {
+            HStack {
+                Spacer(minLength: 80)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(text)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(14)
+                .frame(maxWidth: 560, alignment: .leading)
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                MarkdownMessage(content: text)
+                if !isStreaming, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(text, forType: .string)
+                    } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
+                    .buttonStyle(.plain)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Views/NodeInspectorView.swift
+++ b/clients/khala-macos/Khala/Khala/Views/NodeInspectorView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct NodeInspectorView: View {
+    let hasKey: Bool
+    let isUsingEphemeralFallback: Bool
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                statusCard(
+                    title: "Khala Chat",
+                    rows: [
+                        StatusRow(label: "Model", value: "openagents/khala", systemImage: "sparkles", tone: .ready),
+                        StatusRow(label: "API key", value: hasKey ? "stored in Keychain" : "missing", systemImage: "key", tone: hasKey ? .ready : .blocked),
+                        StatusRow(label: "History", value: isUsingEphemeralFallback ? "memory only" : "local file", systemImage: "tray.full", tone: isUsingEphemeralFallback ? .blocked : .ready),
+                    ]
+                )
+
+                statusCard(
+                    title: "Local Pylon",
+                    rows: [
+                        StatusRow(label: "Supervisor", value: "not connected", systemImage: "bolt.horizontal.circle", tone: .neutral),
+                        StatusRow(label: "Heartbeat", value: "offline", systemImage: "waveform.path.ecg", tone: .neutral),
+                        StatusRow(label: "Provider mode", value: "offline", systemImage: "power.circle", tone: .neutral),
+                    ]
+                )
+
+                statusCard(
+                    title: "Apple FM",
+                    rows: [
+                        StatusRow(label: "Bridge", value: "unavailable", systemImage: "cpu", tone: .neutral),
+                        StatusRow(label: "Backend", value: "apple_fm_bridge", systemImage: "shippingbox", tone: .neutral),
+                        StatusRow(label: "Usage truth", value: "not measured", systemImage: "number", tone: .neutral),
+                    ]
+                )
+
+                statusCard(
+                    title: "Fleet",
+                    rows: [
+                        StatusRow(label: "Connected accounts", value: "none loaded", systemImage: "person.2", tone: .neutral),
+                        StatusRow(label: "Assignments", value: "none active", systemImage: "checklist", tone: .neutral),
+                        StatusRow(label: "Receipts", value: "not connected", systemImage: "doc.text.magnifyingglass", tone: .neutral),
+                    ]
+                )
+            }
+            .padding(20)
+        }
+        .navigationSplitViewColumnWidth(min: 260, ideal: 320, max: 420)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private func statusCard(title: String, rows: [StatusRow]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+            ForEach(rows) { row in
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    Image(systemName: row.systemImage)
+                        .foregroundStyle(row.tone.color)
+                        .frame(width: 18)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(row.label)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(row.value)
+                            .font(.callout.weight(.medium))
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(14)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct StatusRow: Identifiable {
+    let id = UUID()
+    let label: String
+    let value: String
+    let systemImage: String
+    let tone: Tone
+
+    enum Tone {
+        case ready
+        case neutral
+        case blocked
+
+        var color: Color {
+            switch self {
+            case .ready: return .green
+            case .neutral: return .secondary
+            case .blocked: return .orange
+            }
+        }
+    }
+}

--- a/clients/khala-macos/Khala/README.md
+++ b/clients/khala-macos/Khala/README.md
@@ -1,0 +1,55 @@
+# Khala Desktop - native macOS SwiftUI app
+
+Khala Desktop is the native macOS sibling of `clients/khala-ios/Khala`. This
+first scaffold follows `docs/desktop/2026-06-28-khala-desktop-spec.md`: a
+buildable SwiftUI app shell with a desktop chat layout, local history,
+Keychain-backed Khala API auth, streaming `openagents/khala` chat, and visible
+local-node readiness surfaces for the future Pylon / Apple FM supervisor.
+
+- **Bundle id:** `com.openagents.khala-macos`
+- **Platform:** macOS 14+, native SwiftUI. **No Expo / React Native / EAS.**
+- **Project:** XcodeGen source in `project.yml`, with a committed
+  `Khala.xcodeproj` so the app opens and builds without xcodegen installed.
+- **Signing team:** `HQWSG26L43`
+
+## Layout
+
+```
+clients/khala-macos/Khala/
+├── project.yml
+├── Khala.xcodeproj/
+└── Khala/
+    ├── KhalaApp.swift
+    ├── Model/Conversation.swift
+    ├── Model/ConversationStore.swift
+    ├── Net/KhalaClient.swift
+    ├── Net/KhalaStream.swift
+    ├── Store/KeychainStore.swift
+    ├── Views/ChatView.swift
+    ├── Views/DesktopRootView.swift
+    ├── Views/MarkdownMessage.swift
+    ├── Views/MessageBubble.swift
+    ├── Views/NodeInspectorView.swift
+    └── Resources/Info.plist
+```
+
+## Build
+
+```sh
+cd clients/khala-macos/Khala
+xcodebuild -project Khala.xcodeproj -scheme Khala \
+  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
+```
+
+Regenerate the project from the XcodeGen spec if needed:
+
+```sh
+cd clients/khala-macos/Khala
+xcodegen generate
+```
+
+## Scope
+
+This scaffold does not claim a live bundled Pylon or Apple FM backend yet. The
+right inspector shows truthful `not connected` / `unavailable` states until the
+supervisor and packaged bridge lifecycle are implemented.

--- a/clients/khala-macos/Khala/project.yml
+++ b/clients/khala-macos/Khala/project.yml
@@ -1,0 +1,34 @@
+# XcodeGen spec for the Khala native macOS SwiftUI app.
+# Regenerate Khala.xcodeproj with:  xcodegen generate
+# A committed Khala.xcodeproj is included so Xcode/xcodebuild work without
+# xcodegen installed.
+name: Khala
+options:
+  bundleIdPrefix: com.openagents
+  deploymentTarget:
+    macOS: "14.0"
+  createIntermediateGroups: true
+
+settings:
+  base:
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+    SWIFT_VERSION: "5.9"
+    DEVELOPMENT_TEAM: HQWSG26L43
+    CODE_SIGN_STYLE: Automatic
+
+targets:
+  Khala:
+    type: application
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: Khala
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openagents.khala-macos
+        PRODUCT_NAME: Khala
+        INFOPLIST_FILE: Khala/Resources/Info.plist
+        GENERATE_INFOPLIST_FILE: NO
+        ENABLE_PREVIEWS: YES
+        SWIFT_EMIT_LOC_STRINGS: YES


### PR DESCRIPTION
Addresses #6811.

### Changes
- Adds the native Khala macOS SwiftUI app scaffold with Xcode project, workspace, shared scheme, Info.plist, and project.yml.
- Adds initial app entry point, desktop root, chat, markdown message, message bubble, and node inspector views.
- Adds conversation models/store plus Khala client, streaming, and keychain storage foundations.
- Documents the macOS app scaffold in the Khala README.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` - passed (exit 0)