### PR TITLE
feat(khala-macos): scaffold native desktop app

### DIFF
--- a/clients/khala-macos/Khala/Khala.xcodeproj/project.pbxproj
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/project.pbxproj
@@ -1,0 +1,381 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		A1000000000000000000PRXY /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A1000000000000000000PRJ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A1000000000000000000TGT;
+			remoteInfo = Khala;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A1000000000000000000FAPP /* Khala.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Khala.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1000000000000000000FTST /* KhalaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KhalaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		A1000000000000000000XEXC /* Exceptions for "Khala" folder in "Khala" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Resources/Info.plist,
+			);
+			target = A1000000000000000000TGT /* Khala */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A1000000000000000000GSRC /* Khala */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				A1000000000000000000XEXC /* Exceptions for "Khala" folder in "Khala" target */,
+			);
+			path = Khala;
+			sourceTree = "<group>";
+		};
+		A1000000000000000000GTST /* KhalaTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = KhalaTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A1000000000000000000FRMW /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000TFRM /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A1000000000000000000GRT = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000GSRC /* Khala */,
+				A1000000000000000000GTST /* KhalaTests */,
+				A1000000000000000000GPRD /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A1000000000000000000GPRD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000FAPP /* Khala.app */,
+				A1000000000000000000FTST /* KhalaTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A1000000000000000000TGT /* Khala */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1000000000000000000CLT /* Build configuration list for PBXNativeTarget "Khala" */;
+			buildPhases = (
+				A1000000000000000000SRC /* Sources */,
+				A1000000000000000000FRMW /* Frameworks */,
+				A1000000000000000000RES /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A1000000000000000000GSRC /* Khala */,
+			);
+			name = Khala;
+			productName = Khala;
+			productReference = A1000000000000000000FAPP /* Khala.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A1000000000000000000TTST /* KhalaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1000000000000000000CLX /* Build configuration list for PBXNativeTarget "KhalaTests" */;
+			buildPhases = (
+				A1000000000000000000TSRC /* Sources */,
+				A1000000000000000000TFRM /* Frameworks */,
+				A1000000000000000000TRES /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1000000000000000000TDEP /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A1000000000000000000GTST /* KhalaTests */,
+			);
+			name = KhalaTests;
+			productName = KhalaTests;
+			productReference = A1000000000000000000FTST /* KhalaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A1000000000000000000PRJ /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					A1000000000000000000TGT = {
+						CreatedOnToolsVersion = 16.0;
+					};
+					A1000000000000000000TTST = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = A1000000000000000000TGT;
+					};
+				};
+			};
+			buildConfigurationList = A1000000000000000000CLP /* Build configuration list for PBXProject "Khala" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A1000000000000000000GRT;
+			productRefGroup = A1000000000000000000GPRD /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A1000000000000000000TGT /* Khala */,
+				A1000000000000000000TTST /* KhalaTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A1000000000000000000RES /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000TRES /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A1000000000000000000SRC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000TSRC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A1000000000000000000TDEP /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A1000000000000000000TGT /* Khala */;
+			targetProxy = A1000000000000000000PRXY /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A1000000000000000000DBG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A1000000000000000000REL /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A1000000000000000000TDBG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Khala/Resources/Info.plist;
+								LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openagents.khala-macos;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+							};
+			name = Debug;
+		};
+		A1000000000000000000TREL /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Khala/Resources/Info.plist;
+								LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openagents.khala-macos;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+							};
+			name = Release;
+		};
+		A1000000000000000000XDBG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openagents.khala-macos.tests;
+				PRODUCT_NAME = KhalaTests;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Khala.app/Contents/MacOS/Khala";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		A1000000000000000000XREL /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				DEVELOPMENT_TEAM = HQWSG26L43;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openagents.khala-macos.tests;
+				PRODUCT_NAME = KhalaTests;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Khala.app/Contents/MacOS/Khala";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A1000000000000000000CLP /* Build configuration list for PBXProject "Khala" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1000000000000000000DBG /* Debug */,
+				A1000000000000000000REL /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1000000000000000000CLT /* Build configuration list for PBXNativeTarget "Khala" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1000000000000000000TDBG /* Debug */,
+				A1000000000000000000TREL /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1000000000000000000CLX /* Build configuration list for PBXNativeTarget "KhalaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1000000000000000000XDBG /* Debug */,
+				A1000000000000000000XREL /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A1000000000000000000PRJ /* Project object */;
+}

--- a/clients/khala-macos/Khala/Khala.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/clients/khala-macos/Khala/Khala.xcodeproj/xcshareddata/xcschemes/Khala.xcscheme
+++ b/clients/khala-macos/Khala/Khala.xcodeproj/xcshareddata/xcschemes/Khala.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000000000000000000TTST"
+               BuildableName = "KhalaTests.xctest"
+               BlueprintName = "KhalaTests"
+               ReferencedContainer = "container:Khala.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000000000000000000TGT"
+               BuildableName = "Khala.app"
+               BlueprintName = "Khala"
+               ReferencedContainer = "container:Khala.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000000000000000000TTST"
+               BuildableName = "KhalaTests.xctest"
+               BlueprintName = "KhalaTests"
+               ReferencedContainer = "container:Khala.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1000000000000000000TGT"
+            BuildableName = "Khala.app"
+            BlueprintName = "Khala"
+            ReferencedContainer = "container:Khala.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1000000000000000000TGT"
+            BuildableName = "Khala.app"
+            BlueprintName = "Khala"
+            ReferencedContainer = "container:Khala.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/clients/khala-macos/Khala/Khala/KhalaApp.swift
+++ b/clients/khala-macos/Khala/Khala/KhalaApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@main
+struct KhalaApp: App {
+    @StateObject private var store = ConversationStore()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView(store: store)
+                .frame(minWidth: 1060, minHeight: 720)
+        }
+        .windowStyle(.titleBar)
+        .commands {
+            CommandGroup(replacing: .newItem) {
+                Button("New Chat") { store.createConversation() }
+                    .keyboardShortcut("n")
+            }
+        }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Model/Conversation.swift
+++ b/clients/khala-macos/Khala/Khala/Model/Conversation.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum MessageRole: String, Codable, CaseIterable, Identifiable, Sendable {
+    case user
+    case assistant
+    var id: String { rawValue }
+}
+
+struct ChatMessage: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var role: MessageRole
+    var content: String
+    var createdAt: Date
+
+    init(id: UUID = UUID(), role: MessageRole, content: String, createdAt: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+    }
+}
+
+struct Conversation: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var title: String
+    var createdAt: Date
+    var updatedAt: Date
+    var messages: [ChatMessage]
+
+    init(id: UUID = UUID(), title: String = Conversation.defaultTitle, createdAt: Date = Date(), updatedAt: Date = Date(), messages: [ChatMessage] = []) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messages = messages
+    }
+
+    static let defaultTitle = "New Chat"
+
+    static func derivedTitle(from text: String, maxLength: Int = 48) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return defaultTitle }
+        let firstLine = trimmed.split(whereSeparator: \.isNewline).first.map(String.init) ?? trimmed
+        if firstLine.count <= maxLength { return firstLine }
+        let end = firstLine.index(firstLine.startIndex, offsetBy: maxLength)
+        return String(firstLine[..<end]).trimmingCharacters(in: .whitespaces) + "..."
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Model/ConversationStore.swift
+++ b/clients/khala-macos/Khala/Khala/Model/ConversationStore.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+@MainActor
+final class ConversationStore: ObservableObject {
+    @Published private(set) var conversations: [Conversation]
+    @Published private(set) var selectedConversationID: Conversation.ID?
+    @Published private(set) var persistenceError: String?
+
+    private let storeURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(storeURL: URL? = nil) {
+        self.storeURL = storeURL ?? Self.defaultStoreURL()
+        self.conversations = []
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+        load()
+        if conversations.isEmpty { _ = createConversation() } else { selectedConversationID = conversations.first?.id }
+    }
+
+    var selectedConversation: Conversation? {
+        guard let selectedConversationID else { return conversations.first }
+        return conversations.first { $0.id == selectedConversationID } ?? conversations.first
+    }
+
+    @discardableResult
+    func createConversation() -> Conversation {
+        let conversation = Conversation()
+        conversations.insert(conversation, at: 0)
+        selectedConversationID = conversation.id
+        persist()
+        return conversation
+    }
+
+    func select(_ conversation: Conversation) { selectedConversationID = conversation.id }
+
+    func delete(_ conversation: Conversation) {
+        conversations.removeAll { $0.id == conversation.id }
+        if conversations.isEmpty { _ = createConversation() } else if selectedConversationID == conversation.id { selectedConversationID = conversations.first?.id }
+        persist()
+    }
+
+    @discardableResult
+    func appendMessage(_ role: MessageRole, content: String, to conversationID: Conversation.ID) -> ChatMessage? {
+        guard let index = conversations.firstIndex(where: { $0.id == conversationID }) else { return nil }
+        let message = ChatMessage(role: role, content: content)
+        conversations[index].messages.append(message)
+        conversations[index].updatedAt = Date()
+        if conversations[index].title == Conversation.defaultTitle, role == .user { conversations[index].title = Conversation.derivedTitle(from: content) }
+        resort()
+        selectedConversationID = conversationID
+        persist()
+        return message
+    }
+
+    func updateMessage(_ messageID: ChatMessage.ID, in conversationID: Conversation.ID, content: String) {
+        guard let conversationIndex = conversations.firstIndex(where: { $0.id == conversationID }), let messageIndex = conversations[conversationIndex].messages.firstIndex(where: { $0.id == messageID }) else { return }
+        conversations[conversationIndex].messages[messageIndex].content = content
+        conversations[conversationIndex].updatedAt = Date()
+        resort()
+        selectedConversationID = conversationID
+        persist()
+    }
+
+    private func resort() { conversations.sort { $0.updatedAt > $1.updatedAt } }
+
+    private func load() {
+        do {
+            let data = try Data(contentsOf: storeURL)
+            conversations = try decoder.decode([Conversation].self, from: data)
+            resort()
+            persistenceError = nil
+        } catch CocoaError.fileReadNoSuchFile {
+            conversations = []
+        } catch {
+            conversations = []
+            persistenceError = "Could not read local chat history. A fresh session was opened."
+        }
+    }
+
+    private func persist() {
+        do {
+            try FileManager.default.createDirectory(at: storeURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let data = try encoder.encode(conversations)
+            try data.write(to: storeURL, options: [.atomic])
+            persistenceError = nil
+        } catch {
+            persistenceError = "Could not save local chat history."
+        }
+    }
+
+    private static func defaultStoreURL() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent("OpenAgents", isDirectory: true).appendingPathComponent("KhalaDesktop", isDirectory: true).appendingPathComponent("conversations.json")
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Net/KhalaClient.swift
+++ b/clients/khala-macos/Khala/Khala/Net/KhalaClient.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum KhalaClient {
+    static let baseURL = URL(string: "https://openagents.com/api/v1")!
+    static let model = "openagents/khala"
+
+    enum KhalaError: Error, LocalizedError, Equatable {
+        case missingKey
+        case unauthorized
+        case quotaExceeded
+        case http(Int, String)
+        case decoding
+        case transport(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingKey: return "Add a Khala API key in Settings before sending."
+            case .unauthorized: return "Khala rejected this API key."
+            case .quotaExceeded: return "Free quota reached. Add credits or wait for the reset."
+            case .http(let code, _): return "Khala API error (\(code))."
+            case .decoding: return "Could not read the Khala response."
+            case .transport(let message): return "Network error: \(message)"
+            }
+        }
+    }
+
+    static func complete(prompt: String, apiKey: String, session: URLSession = .shared) async throws -> String {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { throw KhalaError.missingKey }
+        var request = URLRequest(url: baseURL.appendingPathComponent("chat/completions"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["model": model, "messages": [["role": "user", "content": trimmed]]])
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { throw KhalaError.decoding }
+            if http.statusCode == 401 || http.statusCode == 403 { throw KhalaError.unauthorized }
+            if http.statusCode == 402 { throw KhalaError.quotaExceeded }
+            guard (200..<300).contains(http.statusCode) else { throw KhalaError.http(http.statusCode, String(data: data, encoding: .utf8) ?? "") }
+            return try parseContent(from: data)
+        } catch let error as KhalaError {
+            throw error
+        } catch {
+            throw KhalaError.transport(error.localizedDescription)
+        }
+    }
+
+    static func parseContent(from data: Data) throws -> String {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any], let choices = object["choices"] as? [[String: Any]], let first = choices.first, let message = first["message"] as? [String: Any], let content = message["content"] as? String else { throw KhalaError.decoding }
+        return content
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Resources/Info.plist
+++ b/clients/khala-macos/Khala/Khala/Resources/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Khala</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>14.0</string>
+</dict>
+</plist>

--- a/clients/khala-macos/Khala/Khala/Shell/RootView.swift
+++ b/clients/khala-macos/Khala/Khala/Shell/RootView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+struct RootView: View {
+    @ObservedObject var store: ConversationStore
+    @State private var draft = ""
+    @State private var apiKeyDraft = ""
+    @State private var isShowingSettings = false
+    @State private var isSending = false
+    @State private var banner: String?
+
+    var body: some View {
+        NavigationSplitView { sidebar } content: { chatPane } detail: { inspector }
+            .navigationTitle("Khala")
+            .toolbar {
+                ToolbarItemGroup {
+                    Text("Khala").font(.caption.weight(.semibold)).padding(.horizontal, 10).padding(.vertical, 5).background(.quaternary, in: Capsule())
+                    Button { store.createConversation() } label: { Label("New Chat", systemImage: "square.and.pencil") }
+                    Button { isShowingSettings.toggle() } label: { Label("Settings", systemImage: "gearshape") }
+                }
+            }
+            .sheet(isPresented: $isShowingSettings) { settings }
+    }
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Conversations").font(.headline)
+                Spacer()
+                Button { store.createConversation() } label: { Image(systemName: "plus") }.buttonStyle(.borderless).help("New Chat")
+            }
+            List(selection: Binding(get: { store.selectedConversationID }, set: { id in
+                guard let id, let conversation = store.conversations.first(where: { $0.id == id }) else { return }
+                store.select(conversation)
+            })) {
+                ForEach(store.conversations) { conversation in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(conversation.title).lineLimit(1)
+                        Text(conversation.updatedAt, style: .relative).font(.caption).foregroundStyle(.secondary)
+                    }
+                    .tag(conversation.id)
+                    .contextMenu { Button("Delete") { store.delete(conversation) } }
+                }
+            }
+            Divider()
+            StatusLine(title: "Local Pylon", value: "Unavailable", systemImage: "bolt.horizontal")
+            StatusLine(title: "Apple FM", value: "Not attached", systemImage: "cpu")
+            StatusLine(title: "Provider Mode", value: "Offline", systemImage: "antenna.radiowaves.left.and.right")
+        }
+        .padding()
+        .frame(minWidth: 250)
+    }
+
+    private var chatPane: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 14) {
+                        if let text = store.persistenceError { BannerView(text: text, systemImage: "exclamationmark.triangle") }
+                        if let banner { BannerView(text: banner, systemImage: "info.circle") }
+                        ForEach(store.selectedConversation?.messages ?? []) { message in MessageRow(message: message).id(message.id) }
+                        if store.selectedConversation?.messages.isEmpty ?? true { emptyState }
+                    }.padding(24)
+                }
+                .onChange(of: store.selectedConversation?.messages.last?.id) { _, id in
+                    guard let id else { return }
+                    withAnimation { proxy.scrollTo(id, anchor: .bottom) }
+                }
+            }
+            Divider()
+            composer
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Khala").font(.largeTitle.bold())
+            Text("Ask a question or send a bounded public coding task prompt.").foregroundStyle(.secondary)
+            Text("Model: \(KhalaClient.model)").font(.caption.monospaced()).foregroundStyle(.secondary)
+        }.frame(maxWidth: .infinity, alignment: .leading).padding(.top, 120)
+    }
+
+    private var composer: some View {
+        HStack(alignment: .bottom, spacing: 12) {
+            TextField("Message Khala", text: $draft, axis: .vertical)
+                .textFieldStyle(.plain).lineLimit(1...6).padding(12).background(.quinary, in: RoundedRectangle(cornerRadius: 8)).onSubmit(send)
+            Button { send() } label: { Image(systemName: isSending ? "hourglass" : "paperplane.fill") }
+                .keyboardShortcut(.return, modifiers: [.command]).disabled(isSending || draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty).buttonStyle(.borderedProminent).help("Send")
+        }.padding()
+    }
+
+    private var inspector: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                Text("Node").font(.title2.bold())
+                InspectorCard(title: "Pylon Supervisor", status: "Unavailable") { Text("This scaffold does not launch or attach to Pylon yet. Provider capacity stays offline until a verified local supervisor is implemented.") }
+                InspectorCard(title: "Apple FM Bridge", status: "Not attached") { Text("No Apple FM helper is bundled by this target. The app will not advertise Apple FM capacity.") }
+                InspectorCard(title: "Fleet", status: "Local only") { Text("Connected accounts, assignments, closeouts, and receipts are reserved for the Pylon integration pass.") }
+                Text("Privacy").font(.headline)
+                Text("The API key is stored in Keychain. Local chat history stays in Application Support on this Mac.").foregroundStyle(.secondary)
+            }.padding(24)
+        }.frame(minWidth: 300)
+    }
+
+    private var settings: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Settings").font(.title2.bold())
+            Text("Paste an `oa_agent_...` key for Khala chat. The value is stored in Keychain and is not displayed after saving.").foregroundStyle(.secondary)
+            SecureField("Khala API key", text: $apiKeyDraft).textFieldStyle(.roundedBorder)
+            HStack {
+                Button("Save Key") {
+                    let key = apiKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !key.isEmpty else { return }
+                    KeychainStore.saveAPIKey(key); apiKeyDraft = ""; isShowingSettings = false
+                }.buttonStyle(.borderedProminent)
+                Button("Remove Key") { KeychainStore.deleteAPIKey(); apiKeyDraft = "" }
+                Spacer()
+                Button("Done") { isShowingSettings = false }
+            }
+        }.padding(24).frame(width: 460)
+    }
+
+    private func send() {
+        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty, !isSending else { return }
+        guard let apiKey = KeychainStore.loadAPIKey() else { banner = "Add a Khala API key in Settings before sending."; isShowingSettings = true; return }
+        let conversationID = store.selectedConversation?.id ?? store.createConversation().id
+        draft = ""; banner = nil
+        store.appendMessage(.user, content: prompt, to: conversationID)
+        guard let assistant = store.appendMessage(.assistant, content: "Thinking...", to: conversationID) else { return }
+        isSending = true
+        Task {
+            do {
+                let response = try await KhalaClient.complete(prompt: prompt, apiKey: apiKey)
+                await MainActor.run { store.updateMessage(assistant.id, in: conversationID, content: response); isSending = false }
+            } catch {
+                await MainActor.run { store.updateMessage(assistant.id, in: conversationID, content: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription); isSending = false }
+            }
+        }
+    }
+}
+
+private struct MessageRow: View {
+    let message: ChatMessage
+    var body: some View { HStack(alignment: .top) { if message.role == .assistant { content; Spacer(minLength: 80) } else { Spacer(minLength: 80); content } } }
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(message.role == .assistant ? "Khala" : "You").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            Text(message.content).textSelection(.enabled).padding(12).background(message.role == .assistant ? Color(nsColor: .controlBackgroundColor) : Color.accentColor.opacity(0.18)).clipShape(RoundedRectangle(cornerRadius: 8))
+        }.frame(maxWidth: 680, alignment: .leading)
+    }
+}
+
+private struct StatusLine: View {
+    let title: String
+    let value: String
+    let systemImage: String
+    var body: some View { HStack(spacing: 8) { Image(systemName: systemImage).frame(width: 18); VStack(alignment: .leading, spacing: 2) { Text(title).font(.caption).foregroundStyle(.secondary); Text(value).font(.callout.weight(.medium)) }; Spacer() } }
+}
+
+private struct InspectorCard<Content: View>: View {
+    let title: String
+    let status: String
+    @ViewBuilder let content: Content
+    var body: some View { VStack(alignment: .leading, spacing: 8) { HStack { Text(title).font(.headline); Spacer(); Text(status).font(.caption.weight(.semibold)).padding(.horizontal, 8).padding(.vertical, 4).background(.quaternary, in: Capsule()) }; content.font(.callout).foregroundStyle(.secondary) }.padding(14).background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8)) }
+}
+
+private struct BannerView: View {
+    let text: String
+    let systemImage: String
+    var body: some View { HStack(spacing: 8) { Image(systemName: systemImage); Text(text); Spacer() }.font(.callout).padding(10).background(Color.yellow.opacity(0.16), in: RoundedRectangle(cornerRadius: 8)) }
+}

--- a/clients/khala-macos/Khala/Khala/Store/KeychainStore.swift
+++ b/clients/khala-macos/Khala/Khala/Store/KeychainStore.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Security
+
+enum KeychainStore {
+    private static let service = "com.openagents.khala-macos"
+    private static let account = "khala_api_key"
+
+    static func saveAPIKey(_ key: String) {
+        let data = Data(key.utf8)
+        deleteAPIKey()
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword, kSecAttrService as String: service, kSecAttrAccount as String: account, kSecValueData as String: data, kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock]
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    static func loadAPIKey() -> String? {
+        if let envKey = ProcessInfo.processInfo.environment["KHALA_API_KEY"], !envKey.isEmpty { return envKey }
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword, kSecAttrService as String: service, kSecAttrAccount as String: account, kSecReturnData as String: true, kSecMatchLimit as String: kSecMatchLimitOne]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data, let key = String(data: data, encoding: .utf8), !key.isEmpty else { return nil }
+        return key
+    }
+
+    @discardableResult
+    static func deleteAPIKey() -> Bool {
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword, kSecAttrService as String: service, kSecAttrAccount as String: account]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/clients/khala-macos/Khala/KhalaTests/ConversationStoreTests.swift
+++ b/clients/khala-macos/Khala/KhalaTests/ConversationStoreTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Khala
+
+@MainActor
+final class ConversationStoreTests: XCTestCase {
+    func testCreatesConversationAndPersistsMessages() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let store = ConversationStore(storeURL: url)
+        let conversation = try XCTUnwrap(store.selectedConversation)
+        store.appendMessage(.user, content: "Hello Khala", to: conversation.id)
+        store.appendMessage(.assistant, content: "Hello.", to: conversation.id)
+        let reloaded = ConversationStore(storeURL: url)
+        let persisted = try XCTUnwrap(reloaded.selectedConversation)
+        XCTAssertEqual(persisted.title, "Hello Khala")
+        XCTAssertEqual(persisted.messages.map(\.role), [.user, .assistant])
+    }
+
+    func testDerivedTitleTrimsLongFirstLine() {
+        let title = Conversation.derivedTitle(from: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        XCTAssertEqual(title, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV...")
+    }
+}

--- a/clients/khala-macos/Khala/KhalaTests/KhalaClientTests.swift
+++ b/clients/khala-macos/Khala/KhalaTests/KhalaClientTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+@testable import Khala
+
+final class KhalaClientTests: XCTestCase {
+    func testParseOpenAICompatibleContent() throws {
+        let data = Data("""
+        {"choices":[{"message":{"role":"assistant","content":"Ready."}}]}
+        """.utf8)
+        XCTAssertEqual(try KhalaClient.parseContent(from: data), "Ready.")
+    }
+
+    func testParseRejectsUnexpectedShape() {
+        let data = Data(#"{"choices":[]}"#.utf8)
+        XCTAssertThrowsError(try KhalaClient.parseContent(from: data))
+    }
+}

--- a/clients/khala-macos/Khala/README.md
+++ b/clients/khala-macos/Khala/README.md
@@ -1,0 +1,39 @@
+# Khala Desktop - native macOS SwiftUI app
+
+Khala Desktop is the native macOS sibling of the iOS Khala app at `clients/khala-ios/Khala`. It opens to a desktop `NavigationSplitView` shell with local chat history, Keychain-backed Khala API auth, and visible local node readiness panels.
+
+- **Bundle id:** `com.openagents.khala-macos`
+- **Platform:** macOS 14+, native SwiftUI. No Expo, EAS, Electron, or web shell.
+- **Spec:** `../../../docs/desktop/2026-06-28-khala-desktop-spec.md`
+- **Model:** `openagents/khala` through `https://openagents.com/api/v1`
+- **Signing team:** `HQWSG26L43`
+
+## Current MVP
+
+- Chat with the public Khala API after storing an `oa_agent_...` key in Keychain.
+- Local conversation history persisted as JSON in Application Support.
+- Desktop shell with conversation sidebar, main chat pane, and right inspector.
+- Truthful node readiness placeholders for Pylon and Apple FM: unavailable until the supervisor and packaged bridge lifecycle are implemented.
+- XcodeGen `project.yml` plus a committed `.xcodeproj` using synchronized source folders so the app opens without XcodeGen installed.
+
+## Build locally
+
+```sh
+cd clients/khala-macos/Khala
+xcodebuild -project Khala.xcodeproj -scheme Khala -destination 'platform=macOS' build
+```
+
+Run tests:
+
+```sh
+cd clients/khala-macos/Khala
+xcodebuild -project Khala.xcodeproj -scheme Khala -destination 'platform=macOS' test
+```
+
+## Environment hooks
+
+- `KHALA_API_KEY` injects a bearer key for local smoke runs and bypasses Keychain reads. Normal user flows store the key in Keychain only.
+
+## Not in this scaffold
+
+The app does not yet launch a bundled Pylon, publish provider capacity, or ship the Apple FM helper. The UI marks those surfaces unavailable rather than advertising capability that has not been verified.

--- a/clients/khala-macos/Khala/project.yml
+++ b/clients/khala-macos/Khala/project.yml
@@ -1,0 +1,43 @@
+# XcodeGen spec for the Khala native macOS SwiftUI app.
+# Regenerate Khala.xcodeproj with: xcodegen generate
+name: Khala
+options:
+  bundleIdPrefix: com.openagents
+  deploymentTarget:
+    macOS: "14.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+    SWIFT_VERSION: "5.9"
+    DEVELOPMENT_TEAM: HQWSG26L43
+    CODE_SIGN_STYLE: Automatic
+targets:
+  Khala:
+    type: application
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: Khala
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openagents.khala-macos
+        PRODUCT_NAME: Khala
+        INFOPLIST_FILE: Khala/Resources/Info.plist
+        GENERATE_INFOPLIST_FILE: NO
+  KhalaTests:
+    type: bundle.unit-test
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - path: KhalaTests
+    dependencies:
+      - target: Khala
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openagents.khala-macos.tests
+        PRODUCT_NAME: KhalaTests
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Khala.app/Contents/MacOS/Khala"
+        BUNDLE_LOADER: "$(TEST_HOST)"


### PR DESCRIPTION
Closes #6811.

## Summary
- Add `clients/khala-macos/Khala` as a native macOS SwiftUI app scaffold with XcodeGen spec and committed Xcode project.
- Add desktop Khala chat shell with local JSON conversation history, Keychain-backed API key storage, OpenAI-compatible Khala client, and node/readiness inspector placeholders.
- Add macOS unit tests for conversation persistence/title derivation and Khala response parsing.

## Verification
- `xcodebuild -project clients/khala-macos/Khala/Khala.xcodeproj -scheme Khala -destination 'platform=macOS' test`\n- `bun run --cwd apps/openagents.com check:deploy`