### PR TITLE
feat(forge): import OpenAgents canonical refs

### DIFF
--- a/apps/forge/README.md
+++ b/apps/forge/README.md
@@ -22,20 +22,24 @@ keeps the landing copy as the app brand header and owns static routes for:
 - `/changes` — change inspector shape for base/head refs and blockers.
 - `/verification` — verification receipt shape.
 - `/queue` — virtual merge queue and promotion gate shape.
-- `/refs` — canonical Forge ref namespaces and GitHub mirror state.
+- `/refs` — canonical Forge refs for `tenant.openagents` /
+  `repo.openagents.openagents`, starting with `refs/heads/main`.
 
 The shell imports shared `@openagentsinc/ui` tokens so the Forge surface starts
 from the OpenAgents visual system while keeping its navigation, route model, and
 deploy path separate. It deliberately does not expand the old
 `openagents.com` logged-in Forge page.
 
-`/shell.json` exposes public-safe route metadata and stub preview state shaped
-for the future `/api/forge/*` control-plane. The SU-7 dogfood lane is rendered
-from the same public-safe contract so the operator workbench can show the
-selected OpenAgents lane across work, change, verification, queue, promotion,
-and mirror state without claiming authority owned by the API Worker. The UI app
-keeps `/api/forge/*` closed; those routes belong to the control-plane Worker
-contract, not this static shell slice.
+`/shell.json` exposes public-safe route metadata and live API contract shape for
+the `/api/forge/*` control-plane. The SU-7 dogfood lane is rendered from the same
+public-safe contract so the operator workbench can show the selected OpenAgents
+lane across work, change, verification, queue, promotion, and mirror state
+without claiming authority owned by the API Worker. The UI app keeps
+`/api/forge/*` closed; those routes belong to the control-plane Worker contract,
+not this static shell slice.
+
+The OpenAgents dogfood import is refreshed through
+`docs/forge/2026-06-28-forge-openagents-import-runbook.md`.
 
 ## SU-7 Dogfood Lane
 

--- a/apps/forge/src/index.test.ts
+++ b/apps/forge/src/index.test.ts
@@ -3,6 +3,9 @@ import { Effect } from "effect"
 
 import {
   FORGE_UI_WORKER_VERSION,
+  OPENAGENTS_FORGE_DEFAULT_BRANCH_REF,
+  OPENAGENTS_FORGE_REPOSITORY_REF,
+  OPENAGENTS_FORGE_TENANT_REF,
   defaultForgeMount,
   forgeLandingCopy,
   forgeShellContract,
@@ -77,7 +80,7 @@ describe("Forge UI Worker", () => {
     expect(body.mount).toEqual(defaultForgeMount)
     expect(body.routes).toEqual(forgeShellRoutes)
     expect(body.preview).toEqual(forgeShellPreviewState)
-    expect(body.preview.dataMode).toBe("stubbed-public-contract")
+    expect(body.preview.dataMode).toBe("live-api-contract")
     expect(body.preview.apiBasePath).toBe("/api/forge")
     expect(body.preview.dogfoodLanes).toHaveLength(1)
     expect(body.preview.dogfoodLanes[0]?.issueRef).toBe("#6797")
@@ -104,6 +107,16 @@ describe("Forge UI Worker", () => {
     expect(html).toContain("mirror.github.openagents.main.su7")
     expect(html).toContain("bun run --cwd apps/openagents.com check:deploy")
     expect(html).toContain("GitHub stays downstream visibility only")
+  })
+
+  it("renders the OpenAgents canonical repo in the refs view", () => {
+    const html = renderForgeShellHtml("refs")
+
+    expect(html).toContain(OPENAGENTS_FORGE_TENANT_REF)
+    expect(html).toContain(OPENAGENTS_FORGE_REPOSITORY_REF)
+    expect(html).toContain(OPENAGENTS_FORGE_DEFAULT_BRANCH_REF)
+    expect(html).toContain("OpenAgentsInc/openagents default branch")
+    expect(html).toContain("/api/forge/refs live canonical store")
   })
 
   it("reports health without claiming any coordination authority", async () => {

--- a/apps/forge/src/index.ts
+++ b/apps/forge/src/index.ts
@@ -7,6 +7,9 @@ import {
 } from "@openagentsinc/ui/tokens"
 
 export const FORGE_UI_WORKER_VERSION = "forge-ui.2026-06-28.6769"
+export const OPENAGENTS_FORGE_TENANT_REF = "tenant.openagents"
+export const OPENAGENTS_FORGE_REPOSITORY_REF = "repo.openagents.openagents"
+export const OPENAGENTS_FORGE_DEFAULT_BRANCH_REF = "refs/heads/main"
 
 export const ForgeMount = Schema.Struct({
   product: Schema.Literal("forge"),
@@ -145,6 +148,8 @@ export const ForgeShellQueueItem = Schema.Struct({
 export type ForgeShellQueueItem = typeof ForgeShellQueueItem.Type
 
 export const ForgeShellRefItem = Schema.Struct({
+  tenantRef: Schema.String,
+  repositoryRef: Schema.String,
   ref: Schema.String,
   target: Schema.String,
   authority: Schema.String,
@@ -175,7 +180,7 @@ export const ForgeShellDogfoodLane = Schema.Struct({
 export type ForgeShellDogfoodLane = typeof ForgeShellDogfoodLane.Type
 
 export const ForgeShellSnapshot = Schema.Struct({
-  dataMode: Schema.Literal("stubbed-public-contract"),
+  dataMode: Schema.Literal("live-api-contract"),
   apiBasePath: Schema.Literal("/api/forge"),
   generatedAt: Schema.String,
   dogfoodLanes: Schema.Array(ForgeShellDogfoodLane),
@@ -188,7 +193,7 @@ export const ForgeShellSnapshot = Schema.Struct({
 export type ForgeShellSnapshot = typeof ForgeShellSnapshot.Type
 
 export const forgeShellPreviewState: ForgeShellSnapshot = {
-  dataMode: "stubbed-public-contract",
+  dataMode: "live-api-contract",
   apiBasePath: "/api/forge",
   generatedAt: "2026-06-28T00:00:00.000Z",
   dogfoodLanes: [
@@ -336,30 +341,48 @@ export const forgeShellPreviewState: ForgeShellSnapshot = {
   ],
   refs: [
     {
+      tenantRef: OPENAGENTS_FORGE_TENANT_REF,
+      repositoryRef: OPENAGENTS_FORGE_REPOSITORY_REF,
       ref: "refs/forge/intake/openagents/codex-low-risk",
       target: "selected low-risk OpenAgents Codex/Pylon lane",
       authority: "Forge smart-Git intake",
       state: "dogfood-lane",
     },
     {
+      tenantRef: OPENAGENTS_FORGE_TENANT_REF,
+      repositoryRef: OPENAGENTS_FORGE_REPOSITORY_REF,
       ref: "refs/forge/mirror/github/openagents/main",
       target: "GitHub downstream visibility after SU-6",
       authority: "Forge mirror worker",
       state: "mirror-only",
     },
     {
+      tenantRef: OPENAGENTS_FORGE_TENANT_REF,
+      repositoryRef: OPENAGENTS_FORGE_REPOSITORY_REF,
       ref: "refs/heads/main",
       target: "GitHub mirror until SU-3",
       authority: "mirror projection",
       state: "readable",
     },
     {
+      tenantRef: OPENAGENTS_FORGE_TENANT_REF,
+      repositoryRef: OPENAGENTS_FORGE_REPOSITORY_REF,
+      ref: OPENAGENTS_FORGE_DEFAULT_BRANCH_REF,
+      target: "OpenAgentsInc/openagents default branch",
+      authority: "/api/forge/refs live canonical store",
+      state: "import-ready",
+    },
+    {
+      tenantRef: OPENAGENTS_FORGE_TENANT_REF,
+      repositoryRef: OPENAGENTS_FORGE_REPOSITORY_REF,
       ref: "refs/forge/changes/*",
       target: "canonical change heads",
       authority: "Forge control plane",
       state: "contracted",
     },
     {
+      tenantRef: OPENAGENTS_FORGE_TENANT_REF,
+      repositoryRef: OPENAGENTS_FORGE_REPOSITORY_REF,
       ref: "refs/forge/virtual/*",
       target: "virtual merge queue heads",
       authority: "Blueprint gates",
@@ -1180,12 +1203,13 @@ const renderQueue = (): string => `<section class="forge-panel" data-span="wide"
 const renderRefs = (): string => `<section class="forge-panel" data-span="wide">
   <div class="forge-panel-head">
     <h3 class="forge-panel-title">Canonical Refs</h3>
-    <span class="forge-table-caption">${forgeShellPreviewState.refs.length} namespaces</span>
+    <span class="forge-table-caption">${escapeHtml(OPENAGENTS_FORGE_TENANT_REF)} / ${escapeHtml(OPENAGENTS_FORGE_REPOSITORY_REF)}</span>
   </div>
   <div class="forge-table-wrap">
     <table class="forge-table">
       <thead>
         <tr>
+          <th>Repository</th>
           <th>Ref</th>
           <th>Target</th>
           <th>Authority</th>
@@ -1196,6 +1220,7 @@ const renderRefs = (): string => `<section class="forge-panel" data-span="wide">
         ${forgeShellPreviewState.refs
           .map(
             item => `<tr>
+              <td><span class="forge-code">${escapeHtml(item.tenantRef)}</span><br><span class="forge-muted">${escapeHtml(item.repositoryRef)}</span></td>
               <td class="forge-code">${escapeHtml(item.ref)}</td>
               <td>${escapeHtml(item.target)}</td>
               <td class="forge-muted">${escapeHtml(item.authority)}</td>

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -12,6 +12,10 @@ import {
   makeD1ForgeCoordinationStore,
   type ForgeCoordinationStore,
 } from './forge-coordination-store'
+import {
+  makeD1ForgeGitCanonicalStore,
+  type ForgeGitCanonicalStore,
+} from './forge-git-canonical-store'
 
 class SqliteD1Statement {
   private bound: ReadonlyArray<unknown> = []
@@ -37,9 +41,9 @@ class SqliteD1Statement {
     }
   }
 
-  async run(): Promise<{ success: true; results: [] }> {
-    this.db.prepare(this.sql).run(...(this.bound as never[]))
-    return { results: [], success: true }
+  async run(): Promise<{ success: true; results: []; meta: { changes: number } }> {
+    const result = this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { meta: { changes: Number(result.changes) }, results: [], success: true }
   }
 }
 
@@ -59,13 +63,25 @@ const controlPlaneReceiptsMigration = readFileSync(
   new URL('../migrations/0254_forge_control_plane_receipts.sql', import.meta.url),
   'utf8',
 )
+const canonicalGitMigration = readFileSync(
+  new URL('../migrations/0255_forge_git_canonical_store.sql', import.meta.url),
+  'utf8',
+)
 
-const makeStore = (): ForgeCoordinationStore => {
+const makeStores = (): Readonly<{
+  canonicalStore: ForgeGitCanonicalStore
+  coordinationStore: ForgeCoordinationStore
+}> => {
   const db = new DatabaseSync(':memory:')
   db.exec('PRAGMA foreign_keys = ON')
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
-  return makeD1ForgeCoordinationStore(new SqliteD1(db) as unknown as D1Database)
+  db.exec(canonicalGitMigration)
+  const d1 = new SqliteD1(db) as unknown as D1Database
+  return {
+    canonicalStore: makeD1ForgeGitCanonicalStore(d1),
+    coordinationStore: makeD1ForgeCoordinationStore(d1),
+  }
 }
 
 const now = '2026-06-28T17:00:00.000Z'
@@ -77,6 +93,18 @@ const authHeaders = (scopes: string): HeadersInit => ({
   'x-openagents-forge-tenant-ref': 'tenant.openagents',
   'x-openagents-forge-scopes': scopes,
 })
+
+const githubMainSha = '1234567890abcdef1234567890abcdef12345678'
+const makeGitHubFetch = (sha: string = githubMainSha): typeof fetch =>
+  (async () =>
+    Response.json({
+      ref: 'refs/heads/main',
+      object: {
+        sha,
+        type: 'commit',
+        url: `https://api.github.com/repos/OpenAgentsInc/openagents/git/commits/${sha}`,
+      },
+    })) as typeof fetch
 
 type JsonRequestInit = Omit<RequestInit, 'body'> & Readonly<{ json?: unknown }>
 
@@ -94,11 +122,13 @@ const requestJson = (
   })
 
 const makeHarness = () => {
-  const store = makeStore()
+  const { canonicalStore, coordinationStore } = makeStores()
   const routes = makeForgeControlPlaneRoutes({
     authorizeControlPlaneBearer: (request, _env, scope) =>
       authorizeForgeControlPlaneBearer(request, controlPlaneToken, scope),
-    makeStore: () => store,
+    fetch: makeGitHubFetch(),
+    makeCanonicalStore: () => canonicalStore,
+    makeStore: () => coordinationStore,
     nowIso: () => now,
     requireAdminApiToken: () => Promise.resolve(false),
   })
@@ -112,7 +142,7 @@ const makeHarness = () => {
     return Effect.runPromise(effect)
   }
 
-  return { run, store }
+  return { canonicalStore, run, store: coordinationStore }
 }
 
 describe('Forge control-plane routes', () => {
@@ -359,5 +389,95 @@ describe('Forge control-plane routes', () => {
       promotionDecisions: ReadonlyArray<unknown>
     }
     expect(decisionsBody.promotionDecisions).toHaveLength(1)
+  })
+
+  test('imports the public OpenAgents main ref into canonical refs idempotently', async () => {
+    const { canonicalStore, run } = makeHarness()
+    const headers = authHeaders('forge:admin forge:change:read')
+    const json = {
+      tenantRef: 'tenant.openagents',
+      repositoryRef: 'repo.openagents.openagents',
+    }
+
+    const firstResponse = await run(
+      requestJson('/api/forge/admin/import-openagents', {
+        json,
+        headers,
+        method: 'POST',
+      }),
+    )
+    const firstBody = (await firstResponse.json()) as {
+      changed: boolean
+      defaultBranch: { ref_name: string; object_id: string }
+      import: { tenantRef: string; repositoryRef: string; defaultBranchRef: string }
+    }
+
+    expect(firstResponse.status).toBe(201)
+    expect(firstBody.changed).toBe(true)
+    expect(firstBody.import).toMatchObject({
+      defaultBranchRef: 'refs/heads/main',
+      repositoryRef: 'repo.openagents.openagents',
+      tenantRef: 'tenant.openagents',
+    })
+    expect(firstBody.defaultBranch).toMatchObject({
+      object_id: githubMainSha,
+      ref_name: 'refs/heads/main',
+    })
+
+    const secondResponse = await run(
+      requestJson('/api/forge/admin/import-openagents', {
+        json,
+        headers,
+        method: 'POST',
+      }),
+    )
+    const secondBody = (await secondResponse.json()) as { changed: boolean }
+    expect(secondResponse.status).toBe(200)
+    expect(secondBody.changed).toBe(false)
+
+    await expect(
+      canonicalStore.listRefs('tenant.openagents', 'repo.openagents.openagents'),
+    ).resolves.toHaveLength(1)
+
+    const refsResponse = await run(
+      new Request(
+        'https://openagents.com/api/forge/refs?tenantRef=tenant.openagents&repositoryRef=repo.openagents.openagents',
+        { headers },
+      ),
+    )
+    const refsBody = (await refsResponse.json()) as {
+      defaultBranch: { object_id: string; ref_name: string }
+      refs: ReadonlyArray<unknown>
+      repository: { github: string; defaultBranchRef: string }
+    }
+
+    expect(refsResponse.status).toBe(200)
+    expect(refsBody.refs).toHaveLength(1)
+    expect(refsBody.defaultBranch).toMatchObject({
+      object_id: githubMainSha,
+      ref_name: 'refs/heads/main',
+    })
+    expect(refsBody.repository).toMatchObject({
+      defaultBranchRef: 'refs/heads/main',
+      github: 'OpenAgentsInc/openagents',
+    })
+  })
+
+  test('fails closed for wrong OpenAgents import targets', async () => {
+    const { run } = makeHarness()
+    const response = await run(
+      requestJson('/api/forge/admin/import-openagents', {
+        json: {
+          tenantRef: 'tenant.other',
+          repositoryRef: 'repo.openagents.openagents',
+        },
+        headers: authHeaders('forge:admin'),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('forge_openagents_import_target_forbidden')
   })
 })

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -14,11 +14,19 @@ import { timingSafeEqual } from './agent-registration'
 import {
   type ForgeCoordinationStore,
 } from './forge-coordination-store'
+import type {
+  ForgeGitCanonicalStore,
+} from './forge-git-canonical-store'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import { decodeUnknownWithSchema, readJsonObject } from './json-boundary'
 import { currentIsoTimestamp } from './runtime-primitives'
 
 const FORGE_GIT_TOKEN_PREFIX = 'oa_forge_git_'
+const OPENAGENTS_FORGE_TENANT_REF = 'tenant.openagents'
+const OPENAGENTS_FORGE_REPOSITORY_REF = 'repo.openagents.openagents'
+const OPENAGENTS_GITHUB_OWNER = 'OpenAgentsInc'
+const OPENAGENTS_GITHUB_REPO = 'openagents'
+const OPENAGENTS_DEFAULT_BRANCH_REF = 'refs/heads/main'
 
 export type ForgeControlPlaneAuth = Readonly<{
   mode: 'admin' | 'control_plane'
@@ -35,6 +43,8 @@ export type ForgeControlPlaneAuthorize<Bindings> = (
 
 type ForgeControlPlaneRouteDependencies<Bindings> = Readonly<{
   authorizeControlPlaneBearer?: ForgeControlPlaneAuthorize<Bindings> | undefined
+  fetch?: typeof fetch
+  makeCanonicalStore: (env: Bindings) => ForgeGitCanonicalStore
   makeStore: (env: Bindings) => ForgeCoordinationStore
   nowIso?: () => string
   requireAdminApiToken?: (request: Request, env: Bindings) => Promise<boolean>
@@ -105,6 +115,11 @@ const ForgeMergeQueueSnapshotRequest = S.Struct({
   ready: S.Unknown,
   blocked: S.Unknown,
   sourceRefs: S.optionalKey(S.Array(S.String)),
+})
+
+const ForgeOpenAgentsImportRequest = S.Struct({
+  tenantRef: S.String,
+  repositoryRef: S.String,
 })
 
 const readBearerToken = (request: Request): string | undefined => {
@@ -640,6 +655,158 @@ const routePromotionDecisions = async <Bindings>(
   return noStoreJsonResponse({ promotionDecision }, { status: 201 })
 }
 
+const sha256Hex = async (value: string): Promise<string> => {
+  const bytes = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(value),
+  )
+  return [...new Uint8Array(bytes)]
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+const readGitHubMainTip = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+): Promise<Readonly<{ objectId: string; sourceUrl: string }>> => {
+  const url = `https://api.github.com/repos/${OPENAGENTS_GITHUB_OWNER}/${OPENAGENTS_GITHUB_REPO}/git/ref/heads/main`
+  const response = await (dependencies.fetch ?? fetch)(url, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      'user-agent': 'openagents-forge-import',
+    },
+  })
+  if (!response.ok) {
+    throw new ForgeControlPlaneHttpError(
+      502,
+      'forge_openagents_import_upstream_failed',
+      `GitHub ref lookup failed with HTTP ${response.status}.`,
+    )
+  }
+  const body = (await response.json()) as {
+    object?: { sha?: unknown; url?: unknown }
+  }
+  const objectId =
+    typeof body.object?.sha === 'string' ? body.object.sha.toLowerCase() : ''
+  if (!/^[0-9a-f]{40}$/u.test(objectId)) {
+    throw new ForgeControlPlaneHttpError(
+      502,
+      'forge_openagents_import_bad_upstream_ref',
+      'GitHub main ref did not include a SHA-1 object id.',
+    )
+  }
+  return {
+    objectId,
+    sourceUrl: typeof body.object?.url === 'string' ? body.object.url : url,
+  }
+}
+
+const routeRefs = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  url: URL,
+) => {
+  if (request.method !== 'GET') {
+    return methodNotAllowed(['GET'])
+  }
+  const tenantRef = tenantRefFromQuery(url)
+  await requireScope(dependencies, request, env, 'forge:change:read', tenantRef)
+  const repositoryRef = optionalQuery(url, 'repositoryRef')
+  if (repositoryRef === undefined) {
+    throw new ForgeControlPlaneHttpError(
+      400,
+      'forge_control_plane_repository_ref_required',
+    )
+  }
+  const refs = await dependencies
+    .makeCanonicalStore(env)
+    .listRefs(tenantRef, repositoryRef, {
+      limit: limitFromQuery(url),
+      state: optionalQuery(url, 'state') === 'deleted' ? 'deleted' : 'active',
+    })
+  return noStoreJsonResponse({
+    defaultBranch: refs.find(ref => ref.ref_name === OPENAGENTS_DEFAULT_BRANCH_REF),
+    defaultBranchRef: OPENAGENTS_DEFAULT_BRANCH_REF,
+    limit: limitFromQuery(url),
+    refs,
+    repository: {
+      defaultBranchRef: OPENAGENTS_DEFAULT_BRANCH_REF,
+      github: `${OPENAGENTS_GITHUB_OWNER}/${OPENAGENTS_GITHUB_REPO}`,
+      repositoryRef,
+      tenantRef,
+    },
+    repositoryRef,
+    tenantRef,
+  })
+}
+
+const routeOpenAgentsImport = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+) => {
+  if (request.method !== 'POST') {
+    return methodNotAllowed(['POST'])
+  }
+  await requireScope(dependencies, request, env, 'forge:admin', OPENAGENTS_FORGE_TENANT_REF)
+  const body = await decodeBody(request, ForgeOpenAgentsImportRequest)
+  if (
+    body.tenantRef !== OPENAGENTS_FORGE_TENANT_REF ||
+    body.repositoryRef !== OPENAGENTS_FORGE_REPOSITORY_REF
+  ) {
+    throw new ForgeControlPlaneHttpError(
+      403,
+      'forge_openagents_import_target_forbidden',
+      `OpenAgents dogfood import is pinned to ${OPENAGENTS_FORGE_TENANT_REF}/${OPENAGENTS_FORGE_REPOSITORY_REF}.`,
+    )
+  }
+  const tip = await readGitHubMainTip(dependencies)
+  const sourceRefs = [
+    'github:OpenAgentsInc/openagents',
+    'github:OpenAgentsInc/openagents#6793',
+    `github:OpenAgentsInc/openagents@${tip.objectId}`,
+    'docs/forge/2026-06-28-forge-openagents-import-runbook.md',
+  ]
+  const digest = await sha256Hex(
+    JSON.stringify({
+      github: `${OPENAGENTS_GITHUB_OWNER}/${OPENAGENTS_GITHUB_REPO}`,
+      objectId: tip.objectId,
+      ref: OPENAGENTS_DEFAULT_BRANCH_REF,
+      sourceUrl: tip.sourceUrl,
+    }),
+  )
+  const shortTip = tip.objectId.slice(0, 16)
+  const result = await dependencies.makeCanonicalStore(env).importExternalRef({
+    changeRef: `change.forge.import.openagents.${shortTip}`,
+    objectFormat: 'sha1',
+    objectId: tip.objectId,
+    packfileRef: `packfile.forge.github.openagents.main.${shortTip}`,
+    receivePackRef: `receive-pack.forge.import.openagents.main.${shortTip}`,
+    refName: OPENAGENTS_DEFAULT_BRANCH_REF,
+    repositoryRef: body.repositoryRef,
+    sourceDigestSha256: digest,
+    sourceRefs,
+    tenantRef: body.tenantRef,
+    nowIso: routeNowIso(dependencies),
+  })
+  return noStoreJsonResponse(
+    {
+      changed: result.changed,
+      defaultBranch: result.ref,
+      import: {
+        defaultBranchRef: OPENAGENTS_DEFAULT_BRANCH_REF,
+        github: `${OPENAGENTS_GITHUB_OWNER}/${OPENAGENTS_GITHUB_REPO}`,
+        objectId: tip.objectId,
+        repositoryRef: body.repositoryRef,
+        sourceRefs,
+        tenantRef: body.tenantRef,
+      },
+      object: result.object,
+    },
+    { status: result.changed ? 201 : 200 },
+  )
+}
+
 export const makeForgeControlPlaneRoutes = <Bindings>(
   dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
 ) => ({
@@ -689,6 +856,10 @@ export const makeForgeControlPlaneRoutes = <Bindings>(
       return routeEffect(() => routeQueue(dependencies, request, env, url))
     }
 
+    if (route.length === 1 && route[0] === 'refs') {
+      return routeEffect(() => routeRefs(dependencies, request, env, url))
+    }
+
     if (route.length === 2 && route[0] === 'queue' && route[1] === 'snapshots') {
       return routeEffect(() => routeQueueSnapshots(dependencies, request, env))
     }
@@ -702,6 +873,16 @@ export const makeForgeControlPlaneRoutes = <Bindings>(
     if (route.length === 1 && route[0] === 'promotion-decisions') {
       return routeEffect(() =>
         routePromotionDecisions(dependencies, request, env, url),
+      )
+    }
+
+    if (
+      route.length === 2 &&
+      route[0] === 'admin' &&
+      route[1] === 'import-openagents'
+    ) {
+      return routeEffect(() =>
+        routeOpenAgentsImport(dependencies, request, env),
       )
     }
 

--- a/apps/openagents.com/workers/api/src/forge-git-canonical-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-git-canonical-store.ts
@@ -71,6 +71,26 @@ export type ForgeGitCanonicalReceivePackInput = Readonly<{
   nowIso: string
 }>
 
+export type ForgeGitCanonicalExternalRefImportInput = Readonly<{
+  tenantRef: string
+  repositoryRef: string
+  refName: string
+  objectId: string
+  objectFormat: Exclude<ForgeGitPackfileObjectFormat, 'unknown'>
+  changeRef: string
+  packfileRef: string
+  receivePackRef: string
+  sourceDigestSha256: string
+  sourceRefs: ReadonlyArray<string>
+  nowIso: string
+}>
+
+export type ForgeGitCanonicalExternalRefImportResult = Readonly<{
+  changed: boolean
+  ref: ForgeGitCanonicalRefRow
+  object: ForgeGitCanonicalObjectRow
+}>
+
 export type ForgeGitCanonicalPreflightInput = Pick<
   ForgeGitCanonicalReceivePackInput,
   | 'tenantRef'
@@ -95,6 +115,9 @@ export type ForgeGitCanonicalStore = Readonly<{
   applyReceivePack: (
     input: ForgeGitCanonicalReceivePackInput,
   ) => Promise<ForgeGitCanonicalApplyResult>
+  importExternalRef: (
+    input: ForgeGitCanonicalExternalRefImportInput,
+  ) => Promise<ForgeGitCanonicalExternalRefImportResult>
   readRef: (
     tenantRef: string,
     repositoryRef: string,
@@ -386,8 +409,8 @@ const runChanges = (result: unknown): number | undefined => {
   return typeof changes === 'number' ? changes : undefined
 }
 
-const rowOrFail = <T>(row: T | null, label: string): T => {
-  if (row === null) {
+const rowOrFail = <T>(row: T | null | undefined, label: string): T => {
+  if (row === null || row === undefined) {
     throw new ForgeGitCanonicalStoreError(
       'forge_git_invalid_object_id',
       `${label} was not persisted`,
@@ -879,6 +902,137 @@ const recordAcceptedIntake = async (
     .run()
 }
 
+const insertExternalObjectTip = async (
+  db: D1Database,
+  input: ForgeGitCanonicalExternalRefImportInput,
+) => {
+  await db
+    .prepare(
+      `
+        INSERT INTO forge_git_objects (
+          tenant_ref,
+          repository_ref,
+          object_id,
+          object_format,
+          packfile_ref,
+          packfile_sha256,
+          first_seen_at,
+          latest_seen_at,
+          source_refs_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (tenant_ref, repository_ref, object_id) DO UPDATE SET
+          packfile_ref = excluded.packfile_ref,
+          packfile_sha256 = excluded.packfile_sha256,
+          latest_seen_at = excluded.latest_seen_at,
+          source_refs_json = excluded.source_refs_json
+      `,
+    )
+    .bind(
+      input.tenantRef,
+      input.repositoryRef,
+      input.objectId,
+      input.objectFormat,
+      input.packfileRef,
+      validateSha256(input.sourceDigestSha256),
+      input.nowIso,
+      input.nowIso,
+      jsonArray(input.sourceRefs),
+    )
+    .run()
+}
+
+const importExternalRef = async (
+  db: D1Database,
+  input: ForgeGitCanonicalExternalRefImportInput,
+): Promise<ForgeGitCanonicalExternalRefImportResult> => {
+  if (!safeRefUpdateTarget(input.refName)) {
+    throw new ForgeGitCanonicalStoreError(
+      'forge_git_unsafe_ref_update',
+      'Forge external imports only accept refs/heads/* and refs/tags/* targets',
+      409,
+    )
+  }
+  if (objectFormatForObjectId(input.objectId) !== input.objectFormat) {
+    throw new ForgeGitCanonicalStoreError(
+      'forge_git_invalid_object_id',
+      'external import object id does not match its declared format',
+      400,
+    )
+  }
+  if (normalizeObjectId(input.objectId) !== input.objectId) {
+    throw new ForgeGitCanonicalStoreError(
+      'forge_git_invalid_object_id',
+      'external import object id must be normalized lowercase hex',
+      400,
+    )
+  }
+
+  await insertExternalObjectTip(db, input)
+
+  const result = await db
+    .prepare(
+      `
+        INSERT INTO forge_git_refs (
+          tenant_ref,
+          repository_ref,
+          ref_name,
+          object_id,
+          previous_object_id,
+          object_format,
+          state,
+          updated_by_change_ref,
+          updated_by_packfile_ref,
+          updated_by_receive_pack_ref,
+          source_refs_json,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, NULL, ?, 'active', ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (tenant_ref, repository_ref, ref_name) DO UPDATE SET
+          previous_object_id = CASE
+            WHEN forge_git_refs.object_id = excluded.object_id THEN forge_git_refs.previous_object_id
+            ELSE forge_git_refs.object_id
+          END,
+          object_id = excluded.object_id,
+          object_format = excluded.object_format,
+          state = 'active',
+          updated_by_change_ref = excluded.updated_by_change_ref,
+          updated_by_packfile_ref = excluded.updated_by_packfile_ref,
+          updated_by_receive_pack_ref = excluded.updated_by_receive_pack_ref,
+          source_refs_json = excluded.source_refs_json,
+          updated_at = excluded.updated_at
+        WHERE forge_git_refs.state = 'deleted'
+          OR forge_git_refs.object_id IS NOT excluded.object_id
+          OR forge_git_refs.object_format IS NOT excluded.object_format
+      `,
+    )
+    .bind(
+      input.tenantRef,
+      input.repositoryRef,
+      input.refName,
+      input.objectId,
+      input.objectFormat,
+      input.changeRef,
+      input.packfileRef,
+      input.receivePackRef,
+      jsonArray(input.sourceRefs),
+      input.nowIso,
+      input.nowIso,
+    )
+    .run()
+
+  return {
+    changed: (runChanges(result) ?? 1) > 0,
+    ref: rowOrFail(
+      await readRefRow(db, input.tenantRef, input.repositoryRef, input.refName),
+      'forge git external import ref',
+    ),
+    object: rowOrFail(
+      await readObjectRow(db, input.tenantRef, input.repositoryRef, input.objectId),
+      'forge git external import object',
+    ),
+  }
+}
+
 const readIntake = async (
   db: D1Database,
   tenantRef: string,
@@ -925,6 +1079,8 @@ export const makeD1ForgeGitCanonicalStore = (
   db: D1Database,
 ): ForgeGitCanonicalStore => ({
   preflightReceivePack: input => validateRefPreconditions(db, input),
+
+  importExternalRef: input => importExternalRef(db, input),
 
   async applyReceivePack(input) {
     const objectFormat = await validateRefPreconditions(db, input)

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -13364,6 +13364,8 @@ const routeRequest = makeWorkerRouteRequest({
           getForgeControlPlaneToken(authEnv),
           requiredScope,
         ),
+      makeCanonicalStore: storeEnv =>
+        makeD1ForgeGitCanonicalStore(openAgentsDatabase(storeEnv)),
       makeStore: storeEnv =>
         makeD1ForgeCoordinationStore(openAgentsDatabase(storeEnv)),
       nowIso: currentIsoTimestamp,

--- a/docs/forge/2026-06-28-forge-boundary-contract.md
+++ b/docs/forge/2026-06-28-forge-boundary-contract.md
@@ -67,10 +67,12 @@ reuse the existing D1/R2/DO bindings. The UI remains owned by `apps/forge/` on
 | `POST /api/forge/leases` | `forge:lease:write` | Acquire or release dispatch leases. |
 | `GET /api/forge/queue` | `forge:queue:read` | Inspect merge queue state. |
 | `POST /api/forge/queue/snapshots` | `forge:queue:write` | Persist virtual merge queue projections. |
+| `GET /api/forge/refs` | `forge:change:read` | Inspect canonical git refs for a tenant/repository. |
 | `GET /api/forge/verification-receipts` | `forge:change:read` | List redacted verification receipts. |
 | `POST /api/forge/verification-receipts` | `forge:receipt:write` | Record redacted verification receipts. |
 | `GET /api/forge/promotion-decisions` | `forge:queue:read` | List gated promotion decisions. |
 | `POST /api/forge/promotion-decisions` | `forge:promotion:decide` | Record gated promotion decisions. |
+| `POST /api/forge/admin/import-openagents` | `forge:admin` | Refresh the dogfood `OpenAgentsInc/openagents` import for `tenant.openagents` / `repo.openagents.openagents`. |
 | `/api/forge/admin/*` | `forge:admin` | Operator-only administrative actions. |
 
 Every route decodes through typed data structures from

--- a/docs/forge/2026-06-28-forge-openagents-import-runbook.md
+++ b/docs/forge/2026-06-28-forge-openagents-import-runbook.md
@@ -1,0 +1,35 @@
+# Forge OpenAgents Import Runbook
+
+Issue #6793 seeds the public `OpenAgentsInc/openagents` repository into the
+Forge canonical git/ref store for dogfood visibility before SU-6 makes GitHub a
+mirror.
+
+Canonical dogfood refs:
+
+- Tenant: `tenant.openagents`
+- Repository: `repo.openagents.openagents`
+- Default branch: `refs/heads/main`
+- Upstream refresh source, until SU-6: `OpenAgentsInc/openagents` on GitHub
+
+Refresh the import with an admin-scoped Forge control-plane token:
+
+```sh
+curl -fsS https://openagents.com/api/forge/admin/import-openagents \
+  -H "authorization: Bearer $OPENAGENTS_ADMIN_API_TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"tenantRef":"tenant.openagents","repositoryRef":"repo.openagents.openagents"}'
+```
+
+Then inspect the live canonical refs:
+
+```sh
+curl -fsS "https://openagents.com/api/forge/refs?tenantRef=tenant.openagents&repositoryRef=repo.openagents.openagents" \
+  -H "authorization: Bearer $OPENAGENTS_FORGE_CONTROL_PLANE_TOKEN" \
+  -H "x-openagents-forge-scopes: forge:change:read"
+```
+
+The import route is intentionally narrow: any tenant or repository other than
+`tenant.openagents` / `repo.openagents.openagents` fails closed. Re-running the
+same GitHub `main` tip is idempotent and returns `changed: false`; a later
+GitHub `main` tip updates only the canonical `refs/heads/main` row and the tip
+object metadata.


### PR DESCRIPTION
Addresses #6793.

### Changes
- Adds OpenAgents canonical tenant, repository, and default branch refs to the Forge UI `/refs` surface and shell contract.
- Switches Forge shell preview metadata from stubbed state to the live `/api/forge` contract shape.
- Extends the Forge control-plane canonical git store and routes for OpenAgents ref import/read behavior, with focused route coverage.
- Documents the Forge boundary contract and OpenAgents import runbook.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).