### PR TITLE
feat(compute): define kernel optimization dispatch receipts

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -1471,6 +1471,45 @@ describe('public product promises document', () => {
     )
   })
 
+  test('keeps kernel optimization planned while exposing code-backed dispatch and parity receipt machinery', () => {
+    const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
+      publicProductPromisesDocument(),
+    )
+    const kernelPromise = decoded.promises.find(
+      promise =>
+        promise.promiseId ===
+        'compute.agentic_kernel_optimization_at_scale.v1',
+    )
+
+    expect(kernelPromise).toMatchObject({
+      state: 'planned',
+      blockerRefs: [
+        'blocker.product_promises.agentic_kernel_optimization_at_scale_run_missing',
+        'blocker.product_promises.agentic_kernel_optimization_settlement_receipts_missing',
+      ],
+    })
+    expect(kernelPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.agentic_kernel_optimization_throughput_parity_verification_missing',
+    )
+    expect(kernelPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.agentic_kernel_optimization_market_dispatch_missing',
+    )
+    expect(kernelPromise?.evidenceRefs).toEqual(
+      expect.arrayContaining([
+        'packages/tassadar-executor/src/kernel-optimization-dispatch.ts',
+        'packages/tassadar-executor/src/kernel-optimization-dispatch.test.ts',
+        'packages/tassadar-executor/src/kernel-optimization-parity.ts',
+        'packages/tassadar-executor/src/kernel-optimization-parity.test.ts',
+      ]),
+    )
+    expect(kernelPromise?.safeCopy).toContain(
+      'buildKernelOptimizationAcceptedWorkReceipt',
+    )
+    expect(kernelPromise?.verification).toContain(
+      'Green still requires a real live market-dispatched optimized kernel',
+    )
+  })
+
   test('blocks announcement copy until the live endpoint serves the announced version', () => {
     const document = publicProductPromisesDocument()
 

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-27.2'
+export const PublicProductPromisesVersion = '2026-06-28.1'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -26,6 +26,11 @@ const sourceRefs = [
   'docs/training/2026-06-20-ablation-eval-reproduction-receipt.md',
   'docs/tassadar/2026-06-20-tassadar-percepta-architecture-receipt.md',
   'docs/tassadar/2026-06-21-tassadar-cpu-transform-training-receipt-surface.md',
+  'docs/tassadar/2026-06-19-agentic-kernel-optimization-work-definition-and-parity-protocol.md',
+  'packages/tassadar-executor/src/kernel-optimization-parity.ts',
+  'packages/tassadar-executor/src/kernel-optimization-dispatch.ts',
+  'packages/tassadar-executor/src/kernel-optimization-parity.test.ts',
+  'packages/tassadar-executor/src/kernel-optimization-dispatch.test.ts',
   'docs/training/2026-06-20-psion-instruct-sft-lane-receipt.md',
   'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
   'docs/launch/vertex-fleet/training.post_training_arc.v1.md',
@@ -142,7 +147,7 @@ export const publicProductPromisesDocument = () => {
     generatedAt: currentIsoTimestamp(),
     maxStalenessSeconds: staleness.maxStalenessSeconds,
     staleness,
-    lastUpdated: '2026-06-27',
+    lastUpdated: '2026-06-28',
     canonicalDocsUrl:
       'https://github.com/OpenAgentsInc/openagents/tree/main/docs/promises',
     sourceRefs,
@@ -2388,12 +2393,16 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Coding agents continuously write and optimize inference kernels across open models and device types (CUDA/Metal/WebGPU), measured by both throughput (tokens/second) and output-parity (an optimized kernel must reproduce identical outputs, verified by exact replay on an independent device), with that work dispatched and paid through the verified-work market as part of the decentralized inference and training mesh.',
         safeCopy:
-          'This is the direction, not a shipped network capability. The demonstrated piece is a single historical development result, captured on a public build-series video, not a live dereferenceable receipt: in March 2026 an agent wrote custom CUDA kernels that took the OpenAgents Rust ML library Psionic to ~523 tok/s versus a leading local inference runtime\u2019s ~328 tok/s on the smallest Qwen 3.5 model, and Psionic beat that runtime on the four smallest Qwen 3.5 models (docs/transcripts/217.md). The correctness anchor \u2014 an optimized kernel must produce identical outputs, proven by exact replay on a separate device \u2014 is the same exact-trace-replay verification proven for bounded workloads under compute.tassadar_executor_poc.v1; the verified-work payment rail is the labor market proven under labor.forum_work_requests.v1 / labor.nostr_negotiation_market.v1. A public kernel-optimization WORK DEFINITION and a THROUGHPUT-PARITY verification protocol now exist on paper (docs/tassadar/2026-06-19-agentic-kernel-optimization-work-definition-and-parity-protocol.md): a job names a target model+device, a named-baseline tok/s record, and an output-parity verdict via the exact-trace-replay engine (packages/tassadar-executor), cleared through the verified-work rail. That is the protocol + correctness-anchor binding, DEFINED not executed. Continuous, at-scale, across-the-mesh agentic kernel optimization \u2014 many agents optimizing kernels for open models and devices, dispatched and paid through the market \u2014 has not been built, run as a network workload, verified at scale, or settled.',
+          'This is the direction, not a shipped network capability. The demonstrated piece is a single historical development result, captured on a public build-series video, not a live dereferenceable market receipt: in March 2026 an agent wrote custom CUDA kernels that took the OpenAgents Rust ML library Psionic to ~523 tok/s versus a leading local inference runtime\u2019s ~328 tok/s on the smallest Qwen 3.5 model, and Psionic beat that runtime on the four smallest Qwen 3.5 models (docs/transcripts/217.md). The correctness anchor \u2014 an optimized kernel must produce identical outputs, proven by exact replay on a separate device \u2014 is the same exact-trace-replay verification proven for bounded workloads under compute.tassadar_executor_poc.v1; the verified-work payment rail is the labor market proven under labor.forum_work_requests.v1 / labor.nostr_negotiation_market.v1. The public kernel-optimization definition is now code-backed in packages/tassadar-executor: buildKernelOptimizationWorkRequest creates a market-dispatchable request with target model+device+hardware, named baseline tok/s, budget, validator device, and dual acceptance criteria; verifyKernelOptimizationParity accepts only when the optimized kernel is distinct, faster, graph-bound to the replayed trace, and output-identical to the baseline on an independent validator; buildKernelOptimizationAcceptedWorkReceipt binds the request, throughput record, parity verdict, and born-verified settlement claim into a public-safe accepted-work receipt shape. This clears the protocol, market-dispatch shape, and throughput/parity receipt-machinery gaps. Continuous, at-scale, across-the-mesh agentic kernel optimization \u2014 many agents optimizing kernels for open models and devices, dispatched and paid through the live market \u2014 has not been run as a network workload or settled.',
         unsafeCopy:
           'Do not claim that agents are continuously optimizing kernels across the mesh today, that this is a live or paying network workload, that the March Psionic/Qwen result is a current benchmark or a dereferenceable on-chain/worker receipt, that Psionic is the fastest inference engine, that throughput-and-parity verification runs at scale, or that this lane is earning contributors bitcoin. The demonstrated result is one historical demo on the four smallest Qwen 3.5 models on a single machine; do not generalize it to other models, larger models, other devices, broad superiority, or paid market liveness.',
         evidenceRefs: [
           'docs/transcripts/217.md',
           'docs/tassadar/2026-06-19-agentic-kernel-optimization-work-definition-and-parity-protocol.md',
+          'packages/tassadar-executor/src/kernel-optimization-dispatch.ts',
+          'packages/tassadar-executor/src/kernel-optimization-dispatch.test.ts',
+          'packages/tassadar-executor/src/kernel-optimization-parity.ts',
+          'packages/tassadar-executor/src/kernel-optimization-parity.test.ts',
           'packages/tassadar-executor/src/replay.ts',
           'https://github.com/OpenAgentsInc/psionic',
           'promise:compute.tassadar_executor_poc.v1',
@@ -2403,14 +2412,11 @@ export const publicProductPromisesDocument = () => {
           'promise:proof.demand_provenance.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.agentic_kernel_optimization_demo_only_no_receipt',
-          'blocker.product_promises.agentic_kernel_optimization_throughput_parity_verification_missing',
-          'blocker.product_promises.agentic_kernel_optimization_market_dispatch_missing',
           'blocker.product_promises.agentic_kernel_optimization_at_scale_run_missing',
           'blocker.product_promises.agentic_kernel_optimization_settlement_receipts_missing',
         ],
         verification:
-          'Green requires a public kernel-optimization work definition; an agent-authored optimized kernel dispatched through the verified-work market; a public throughput (tok/s) improvement record against a named baseline on declared hardware; an output-parity verdict in which an independent device replays the optimized kernel\u2019s outputs and confirms they match the baseline byte-for-byte (exact-trace-replay, per compute.tassadar_executor_poc.v1); accepted-work and settlement receipts for that job; and a participant/scale methodology before any at-scale or across-the-mesh claim. The March 2026 Psionic/Qwen 3.5 result is historical-demo evidence (a build-series video, docs/transcripts/217.md) only and does not satisfy any of these gates. Per proof.demand_provenance.v1, internal first-party optimization is plumbing proof, not market proof.',
+          'Code-backed machinery exists and is tested in packages/tassadar-executor: buildKernelOptimizationWorkRequest defines the market request; verifyKernelOptimizationParity checks named-baseline tok/s improvement plus independent-device exact-replay output parity; buildKernelOptimizationAcceptedWorkReceipt records the accepted-work receipt shape only when the request, throughput record, parity verdict, and settlement claim all bind. Green still requires a real live market-dispatched optimized kernel, accepted-work and settlement receipts for that live job, and a participant/scale methodology before any at-scale or across-the-mesh claim. The March 2026 Psionic/Qwen 3.5 result is historical-demo evidence (a build-series video, docs/transcripts/217.md) only and is not a live market receipt. Per proof.demand_provenance.v1, internal first-party optimization is plumbing proof, not market proof.',
         authorityBoundary:
           'A demonstrated single-machine throughput result and a stated direction grant no network capability, no paid-work authority, no at-scale claim, no cross-model or cross-device generalization, no performance-superiority claim, and no settlement authority. Throughput improvement without an independent exact-replay output-parity verdict is not an accepted optimized kernel; an accepted kernel is not paid work until the verified-work market records accepted-work and settlement receipts.',
       },

--- a/packages/tassadar-executor/src/kernel-optimization-dispatch.test.ts
+++ b/packages/tassadar-executor/src/kernel-optimization-dispatch.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  KERNEL_OPTIMIZATION_ACCEPTED_WORK_RECEIPT_SCHEMA,
   KERNEL_OPTIMIZATION_PROMISE_ID,
   KERNEL_OPTIMIZATION_SETTLEMENT_CLAIM_SCHEMA,
   KERNEL_OPTIMIZATION_SETTLEMENT_MODE,
   KERNEL_OPTIMIZATION_WORK_REQUEST_SCHEMA,
+  buildKernelOptimizationAcceptedWorkReceipt,
   buildKernelOptimizationSettlementClaim,
   buildKernelOptimizationWorkRequest,
   type KernelOptimizationJobSpec,
@@ -143,5 +145,86 @@ describe("buildKernelOptimizationSettlementClaim", () => {
     }
     const result = buildKernelOptimizationSettlementClaim(noSpeedup)
     expect(result.ok).toBe(false)
+  })
+})
+
+describe("buildKernelOptimizationAcceptedWorkReceipt", () => {
+  test("records an accepted-work receipt bound to request, throughput, parity, and settlement", () => {
+    const request = buildKernelOptimizationWorkRequest(spec)
+    const result = buildKernelOptimizationAcceptedWorkReceipt({
+      acceptedWorkRef: "accepted.kernel_opt.qwen35.rmsnorm.fixture.v1",
+      parityVerdictRef: "verdict.kernel_opt.parity.fixture.v1",
+      throughputRecordRef: "throughput.kernel_opt.qwen35.rmsnorm.fixture.v1",
+      verdict: acceptedVerdict,
+      workRequest: request,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error("expected accepted-work receipt")
+    expect(result.receipt.schema).toBe(
+      KERNEL_OPTIMIZATION_ACCEPTED_WORK_RECEIPT_SCHEMA,
+    )
+    expect(result.receipt.receiptState).toBe("accepted_work_proven")
+    expect(result.receipt.settlementState).toBe("not_settled")
+    expect(result.receipt.payoutClaimAllowed).toBe(false)
+    expect(result.receipt.workRequest).toBe(request)
+    expect(result.receipt.settlementClaim.speedupRatio).toBeCloseTo(523 / 328)
+    expect(result.receipt.marketRailRefs).toEqual([
+      "promise:labor.forum_work_requests.v1",
+      "promise:labor.nostr_negotiation_market.v1",
+    ])
+  })
+
+  test("refuses to bind a verdict for a different requested op", () => {
+    const request = buildKernelOptimizationWorkRequest({
+      ...spec,
+      baseline: { ...baseline, opRef: "attention.flash" },
+      opRef: "attention.flash",
+    })
+    const result = buildKernelOptimizationAcceptedWorkReceipt({
+      acceptedWorkRef: "accepted.kernel_opt.qwen35.attention.fixture.v1",
+      parityVerdictRef: "verdict.kernel_opt.parity.fixture.v1",
+      throughputRecordRef: "throughput.kernel_opt.qwen35.rmsnorm.fixture.v1",
+      verdict: acceptedVerdict,
+      workRequest: request,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error("op-mismatched receipt must fail")
+    expect(result.reason).toBe("request_verdict_mismatch")
+  })
+
+  test("refuses to record accepted work for a rejected verdict", () => {
+    const request = buildKernelOptimizationWorkRequest(spec)
+    const rejected: KernelOptimizationVerdict = {
+      ...acceptedVerdict,
+      outcome: "rejected",
+      parityOutcome: "rejected",
+      rejection: { parityRejection: null, reason: "parity_rejected" },
+    }
+    const result = buildKernelOptimizationAcceptedWorkReceipt({
+      acceptedWorkRef: "accepted.kernel_opt.qwen35.rmsnorm.fixture.v1",
+      parityVerdictRef: "verdict.kernel_opt.parity.rejected.fixture.v1",
+      throughputRecordRef: "throughput.kernel_opt.qwen35.rmsnorm.fixture.v1",
+      verdict: rejected,
+      workRequest: request,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error("rejected verdict receipt must fail")
+    expect(result.reason).toBe("verdict_not_accepted")
+  })
+
+  test("refuses unsafe refs in receipt evidence fields", () => {
+    const request = buildKernelOptimizationWorkRequest(spec)
+    expect(() =>
+      buildKernelOptimizationAcceptedWorkReceipt({
+        acceptedWorkRef: "/Users/local/private/result",
+        parityVerdictRef: "verdict.kernel_opt.parity.fixture.v1",
+        throughputRecordRef: "throughput.kernel_opt.qwen35.rmsnorm.fixture.v1",
+        verdict: acceptedVerdict,
+        workRequest: request,
+      }),
+    ).toThrow(/private, payment, credential/)
   })
 })

--- a/packages/tassadar-executor/src/kernel-optimization-dispatch.ts
+++ b/packages/tassadar-executor/src/kernel-optimization-dispatch.ts
@@ -44,6 +44,9 @@ export const KERNEL_OPTIMIZATION_WORK_REQUEST_SCHEMA =
 export const KERNEL_OPTIMIZATION_SETTLEMENT_CLAIM_SCHEMA =
   "openagents.kernel_optimization_settlement_claim.v1"
 
+export const KERNEL_OPTIMIZATION_ACCEPTED_WORK_RECEIPT_SCHEMA =
+  "openagents.kernel_optimization_accepted_work_receipt.v1"
+
 /**
  * Same posture as the green labor rail: a worker payout only ever follows
  * accepted work, never on dispatch. Surfaced on both the request (the promise to
@@ -299,5 +302,137 @@ export const buildKernelOptimizationSettlementClaim = (
       target: verdict.target,
     },
     ok: true,
+  }
+}
+
+export type KernelOptimizationAcceptedWorkReceipt = Readonly<{
+  schema: typeof KERNEL_OPTIMIZATION_ACCEPTED_WORK_RECEIPT_SCHEMA
+  promiseId: typeof KERNEL_OPTIMIZATION_PROMISE_ID
+  workRequestSchema: typeof KERNEL_OPTIMIZATION_WORK_REQUEST_SCHEMA
+  settlementClaimSchema: typeof KERNEL_OPTIMIZATION_SETTLEMENT_CLAIM_SCHEMA
+  acceptedWorkRef: string
+  throughputRecordRef: string
+  parityVerdictRef: string
+  receiptState: "accepted_work_proven"
+  marketRailRefs: ReadonlyArray<string>
+  workRequest: KernelOptimizationWorkRequest
+  settlementClaim: KernelOptimizationSettlementClaim
+  settlementState: "not_settled"
+  payoutClaimAllowed: false
+}>
+
+export type KernelOptimizationAcceptedWorkReceiptResult =
+  | Readonly<{ ok: true; receipt: KernelOptimizationAcceptedWorkReceipt }>
+  | Readonly<{
+      ok: false
+      reason: "request_verdict_mismatch" | "verdict_not_accepted"
+      detail: string
+    }>
+
+const sameTarget = (
+  request: KernelOptimizationWorkRequest,
+  verdict: KernelOptimizationVerdict,
+): boolean =>
+  request.target.targetModel === verdict.target.targetModel &&
+  request.target.device === verdict.target.device &&
+  request.target.hardwareRef === verdict.target.hardwareRef
+
+/**
+ * Bind a dispatched kernel-optimization request to the accepted throughput +
+ * parity verdict and the born-verified settlement claim.
+ *
+ * This is the public-safe receipt shape the verified-work market can record for
+ * an accepted kernel optimization. It is deliberately not a payout or settled
+ * payment receipt: it proves the work is accepted and settlement-ready, while
+ * keeping actual payout/settlement authority on the existing verified-work rail.
+ */
+export const buildKernelOptimizationAcceptedWorkReceipt = (
+  input: Readonly<{
+    workRequest: KernelOptimizationWorkRequest
+    verdict: KernelOptimizationVerdict
+    acceptedWorkRef: string
+    throughputRecordRef: string
+    parityVerdictRef: string
+  }>,
+): KernelOptimizationAcceptedWorkReceiptResult => {
+  const acceptedWorkRef = assertNonEmpty(
+    input.acceptedWorkRef,
+    "acceptedWorkRef",
+  )
+  const throughputRecordRef = assertNonEmpty(
+    input.throughputRecordRef,
+    "throughputRecordRef",
+  )
+  const parityVerdictRef = assertNonEmpty(
+    input.parityVerdictRef,
+    "parityVerdictRef",
+  )
+
+  if (!sameTarget(input.workRequest, input.verdict)) {
+    return {
+      detail: `request target ${input.workRequest.target.targetModel}/${input.workRequest.target.device}/${input.workRequest.target.hardwareRef} != verdict target ${input.verdict.target.targetModel}/${input.verdict.target.device}/${input.verdict.target.hardwareRef}`,
+      ok: false,
+      reason: "request_verdict_mismatch",
+    }
+  }
+  if (
+    input.workRequest.opRef.trim().toLowerCase() !==
+    input.verdict.optimizedOpRef.trim().toLowerCase()
+  ) {
+    return {
+      detail: `request op "${input.workRequest.opRef.trim()}" != verdict op "${input.verdict.optimizedOpRef.trim()}"`,
+      ok: false,
+      reason: "request_verdict_mismatch",
+    }
+  }
+  if (
+    input.workRequest.namedBaseline.tokensPerSecond !==
+    input.verdict.baselineTokensPerSecond
+  ) {
+    return {
+      detail: `request baseline tok/s ${input.workRequest.namedBaseline.tokensPerSecond} != verdict baseline tok/s ${input.verdict.baselineTokensPerSecond}`,
+      ok: false,
+      reason: "request_verdict_mismatch",
+    }
+  }
+  if (
+    input.workRequest.validatorDeviceRef !== input.verdict.parityValidatorDeviceRef
+  ) {
+    return {
+      detail: `request validator ${input.workRequest.validatorDeviceRef} != verdict validator ${input.verdict.parityValidatorDeviceRef}`,
+      ok: false,
+      reason: "request_verdict_mismatch",
+    }
+  }
+
+  const settlement = buildKernelOptimizationSettlementClaim(input.verdict)
+  if (!settlement.ok) {
+    return {
+      detail: settlement.detail,
+      ok: false,
+      reason: "verdict_not_accepted",
+    }
+  }
+
+  return {
+    ok: true,
+    receipt: {
+      acceptedWorkRef,
+      marketRailRefs: [
+        "promise:labor.forum_work_requests.v1",
+        "promise:labor.nostr_negotiation_market.v1",
+      ],
+      parityVerdictRef,
+      payoutClaimAllowed: false,
+      promiseId: KERNEL_OPTIMIZATION_PROMISE_ID,
+      receiptState: "accepted_work_proven",
+      schema: KERNEL_OPTIMIZATION_ACCEPTED_WORK_RECEIPT_SCHEMA,
+      settlementClaim: settlement.claim,
+      settlementClaimSchema: KERNEL_OPTIMIZATION_SETTLEMENT_CLAIM_SCHEMA,
+      settlementState: "not_settled",
+      throughputRecordRef,
+      workRequest: input.workRequest,
+      workRequestSchema: KERNEL_OPTIMIZATION_WORK_REQUEST_SCHEMA,
+    },
   }
 }


### PR DESCRIPTION
Addresses #6881.

### Changes
- Added code-backed kernel optimization dispatch helpers for market-dispatchable work requests, parity verdict validation, and accepted-work receipt construction.
- Added Tassadar executor tests covering kernel optimization request construction, throughput/parity acceptance, and rejection cases.
- Updated the public product promise evidence, safe copy, blockers, version, and tests to reflect that dispatch shape and throughput/parity receipt machinery now exist while the promise remains planned pending live market execution and settlement receipts.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)