### PR TITLE
fix(promises): harden signature monetization gates

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -1272,6 +1272,8 @@ describe('public product promises document', () => {
       state: 'planned',
       blockerRefs: ['blocker.product_promises.signature_settlement_missing'],
       evidenceRefs: expect.arrayContaining([
+        'apps/openagents.com/workers/api/src/signature-marketplace-revenue-gate.ts',
+        'apps/openagents.com/workers/api/src/signature-marketplace-revenue-gate.test.ts',
         'apps/openagents.com/workers/api/src/signature-usage-metering.ts',
         'apps/openagents.com/workers/api/src/signature-usage-metering-routes.ts',
         'route:/api/public/markets/signature-monetization/metering',
@@ -1281,13 +1283,13 @@ describe('public product promises document', () => {
       'blocker.product_promises.signature_usage_metering_missing',
     )
     expect(signaturePromise?.safeCopy).toContain(
-      'inert public usage-metering projection',
+      'tested package activation/pricing/rev-share/settlement-receipt gate logic',
     )
     expect(signaturePromise?.verification).toContain(
-      'clearing the usage-metering blocker only',
+      'publish -> activate -> usable refs',
     )
     expect(signaturePromise?.authorityBoundary).toContain(
-      'do not install, promote, bill, debit, credit, or settle',
+      'pure gate projections do not by themselves mutate package listings',
     )
   })
 

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-27.2'
+export const PublicProductPromisesVersion = '2026-06-28.1'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -142,7 +142,7 @@ export const publicProductPromisesDocument = () => {
     generatedAt: currentIsoTimestamp(),
     maxStalenessSeconds: staleness.maxStalenessSeconds,
     staleness,
-    lastUpdated: '2026-06-27',
+    lastUpdated: '2026-06-28',
     canonicalDocsUrl:
       'https://github.com/OpenAgentsInc/openagents/tree/main/docs/promises',
     sourceRefs,
@@ -228,6 +228,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-25.1 adds data.free_tier_capture_disclosure.v1 (yellow) as the honest data-sharing disclosure backing default-on free-tier trace capture (#6293/#6294/#6295, EPIC #6206). Default-on capture is going live: free-tier /api/v1/chat/completions traffic is captured by default as REDACTED, PRIVATE (owner_only) ATIF traces that may be used to improve/train OpenAgents models; paying for privacy / confidential compute opts the caller OUT (fail-closed to not-captured, inference-privacy-entitlement.ts); public sharing of a captured trace is owner opt-in only; and capture grants NO payout/settlement (the data-market reward marker stays inert and owner-gated, #6221). The canonical disclosure is a single source of truth (inference/free-tier-data-sharing-disclosure.ts) surfaced at three honest places: the POST /api/keys/free mint response (dataSharing field), the public agent-readable GET /api/public/free-tier-data-sharing endpoint, and the public AGENTS.md inference section. The record is YELLOW (not green): the disclosure text is implemented and discoverable, but the underlying default-on capture flip (KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT) is owner-gated and the public copy is owner-approval-gated per the audit. This is disclosure only — it ships no capture behavior, no authority, and no money. Evidence: docs/promises/2026-06-25-free-tier-data-sharing-disclosure.md, docs/traces/2026-06-25-default-on-trace-capture-audit.md.',
         'Registry 2026-06-27.1 reconciles Episodes 242-244, the shipped Khala CLI v0.1.16, and the Khala -> Pylon -> Codex owner-capacity runbook. It adds green scoped records for the free OpenAI-compatible Khala API, the public Khala tokens-served counter/history, and the shipped terminal CLI; yellow records for public model-family mix stats, explicit owner-capacity Codex delegation, free-tier trace capture, and paid/confidential privacy opt-out; and keeps no-resale/no-payout boundaries explicit. Exact own-capacity Codex token rows count in the headline token counter after closeout, but counter movement alone is not proof: assignment proof requires rows with provider pylon-codex-own-capacity, model openagents/pylon-codex, usage_truth exact, demand_kind own_capacity, and demand_source khala_coding_delegation. Broad automatic semantic routing, pooled third-party capacity, paid resale, public raw Codex traces, live assignment trace UI, and guaranteed dispatch availability remain blocked. The stale Khala CLI OpenTUI/single-line plan is superseded by the v0.1.16 scrollback/raw-mode CLI docs.',
         'Registry 2026-06-27.2 flips khala.own_capacity_codex_delegation.v1 from yellow to green for its explicit typed owner-capacity scope only. The remaining blockers from 2026-06-27.1 were cleared by source fixes and production smokes: default `pylon khala request --workflow codex_agent_task --fixture` now auto-runs the returned no-spend assignment instead of stranding the maxInflight gate (#6362, closeout assignment.closeout.0351f0a0b4650c2272233fa0); master-default public repo materialization now falls back to the pinned commit and passed the octocat/Hello-World smoke (#6361, closeout assignment.closeout.2ccf7c3d2ac86b12b57ce2e2); the owner-scoped trace-status route is deployed and returns lifecycle/progress/token/trace/raw-event metadata without raw payloads (#6368); and `pylon khala closeout <assignmentRef> --json` now composes trace status + proof into a fail-closed checklist that also requires the worker closeout event to prove `paymentMode: no-spend`, `settlementState: not_applicable`, and `payoutClaimAllowed: false` (#6369). This green flip does NOT authorize broad natural-language routing, third-party capacity pooling, Codex subscription resale, public raw Codex event visibility, paid work, payout eligibility, guaranteed availability, or bypass of the explicit typed workflow / caller-owned Pylon capacity gate.',
+        'Registry 2026-06-28.1 is a marketplace.signature_monetization.v1 gate-hardening pass and flips NO promise state. The signature revenue gate now models publish -> activate -> usable refs before metered usage can drive pricing, keeps validation-only packages non-installable, requires attribution/pricing/rev-share/dispute/refund evidence before payable state, and allows settlement claims only when a public-safe usage-charge settlement receipt settles the full contributor payable amount. The promise stays planned on blocker.product_promises.signature_settlement_missing because live billing and real settlement remain owner-armed and receipt-first.',
       ],
     },
     promises: [
@@ -1555,12 +1556,14 @@ export const publicProductPromisesDocument = () => {
         claim:
           'DSPy/GEPA signatures and agent workflow components can be discoverable and monetizable.',
         safeCopy:
-          'Signature validation, Blueprint tooling, marketplace gates, and an inert public usage-metering projection exist. Billing, pricing, revenue split, and settlement are not live.',
+          'Signature validation, Blueprint tooling, marketplace gates, an inert public usage-metering projection, and tested package activation/pricing/rev-share/settlement-receipt gate logic exist. Live billing and real settlement are not armed.',
         unsafeCopy:
           'Do not claim signatures or workflow components are generating settled revenue.',
         evidenceRefs: [
           'apps/openagents.com/docs/2026-06-08-signature-marketplace-revenue-gate.md',
           'apps/pylon/packages/runtime/src/blueprint',
+          'apps/openagents.com/workers/api/src/signature-marketplace-revenue-gate.ts',
+          'apps/openagents.com/workers/api/src/signature-marketplace-revenue-gate.test.ts',
           'apps/openagents.com/workers/api/src/signature-usage-metering.ts',
           'apps/openagents.com/workers/api/src/signature-usage-metering.test.ts',
           'apps/openagents.com/workers/api/src/signature-usage-metering-routes.ts',
@@ -1569,9 +1572,9 @@ export const publicProductPromisesDocument = () => {
         ],
         blockerRefs: ['blocker.product_promises.signature_settlement_missing'],
         verification:
-          'Usage metering reaches the metered rung via the inert public projection and tests, clearing the usage-metering blocker only. Green still requires package activation, attribution, pricing, rev-share, dispute/refund policy, and settlement receipts.',
+          'Usage metering reaches the metered rung via the inert public projection and tests, clearing the usage-metering blocker. The revenue gate now requires publish -> activate -> usable refs before metered usage can price revenue, requires attribution/pricing/rev-share/dispute/refund refs before payable state, and allows settlement claims only when the usage charge has public-safe settlement receipt refs with settled contributor cents matching payable cents. Green still requires an owner-armed real settlement receipt and matching transition receipt.',
         authorityBoundary:
-          'Discovery, contribution validation, and inert usage metering do not install, promote, bill, debit, credit, or settle package usage.',
+          'Discovery, contribution validation, inert usage metering, and pure gate projections do not by themselves mutate package listings, bill, debit, credit, or settle package usage. Activation and settlement claims require explicit public-safe refs and owner-armed receipt evidence.',
       },
       {
         ...basePromiseFields,

--- a/apps/openagents.com/workers/api/src/signature-marketplace-revenue-gate.test.ts
+++ b/apps/openagents.com/workers/api/src/signature-marketplace-revenue-gate.test.ts
@@ -7,6 +7,7 @@ import {
 } from './signature-marketplace-revenue-gate'
 
 const payableUsageInput = {
+  activationRefs: ['activation.public.signature_market.site_builder_v1'],
   attributionRefs: ['attribution.public.signature_market.site_builder_001'],
   contributorPayableCents: 700,
   disputePolicyRefs: ['policy.public.signature_market.dispute_window_v1'],
@@ -16,6 +17,9 @@ const payableUsageInput = {
   forkPolicyRefs: ['policy.public.signature_market.fork_handling_v1'],
   grossRevenueCents: 1000,
   licensePolicyRefs: ['policy.public.signature_market.license_review_v1'],
+  packagePublicationRefs: [
+    'publication.public.signature_market.site_builder_v1',
+  ],
   packageRefs: ['package.public.signature_market.site_builder'],
   packageValidationRefs: ['validation.public.signature_market.site_builder_v1'],
   payoutEligibilityRefs: [
@@ -58,10 +62,18 @@ describe('Signature marketplace revenue gate', () => {
     expect(gate.caveatRefs).toContain(
       'caveat.public.signature_market.validation_does_not_install',
     )
+    expect(gate.blockerRefs).toContain(
+      'blocker.public.signature_market.package_publication_missing',
+    )
+    expect(gate.blockerRefs).toContain(
+      'blocker.public.signature_market.package_activation_missing',
+    )
   })
 
-  test('requires exact usage refs and idempotency before usage can drive revenue', () => {
+  test('requires activation, exact usage refs, and idempotency before usage can drive revenue', () => {
     const gate = projectSignatureMarketplaceRevenueGate({
+      activationRefs: payableUsageInput.activationRefs,
+      packagePublicationRefs: payableUsageInput.packagePublicationRefs,
       packageRefs: ['package.public.signature_market.site_builder'],
       packageValidationRefs: [
         'validation.public.signature_market.site_builder_v1',
@@ -74,6 +86,9 @@ describe('Signature marketplace revenue gate', () => {
     })
 
     expect(gate).toMatchObject({
+      candidateRuntimeActivationAllowed: true,
+      installAllowed: true,
+      marketplaceListingMutationAllowed: true,
       meteredUsageEventCount: 1,
       revenueProjectionAllowed: false,
       state: 'validated',
@@ -133,8 +148,10 @@ describe('Signature marketplace revenue gate', () => {
   test('requires fork, license, dispute, refund, and rev-share policy states', () => {
     const gate = projectSignatureMarketplaceRevenueGate({
       attributionRefs: payableUsageInput.attributionRefs,
+      activationRefs: payableUsageInput.activationRefs,
       exactUsageSubjectRefs: payableUsageInput.exactUsageSubjectRefs,
       grossRevenueCents: 1000,
+      packagePublicationRefs: payableUsageInput.packagePublicationRefs,
       packageRefs: payableUsageInput.packageRefs,
       packageValidationRefs: payableUsageInput.packageValidationRefs,
       pricingPolicyRefs: payableUsageInput.pricingPolicyRefs,
@@ -169,6 +186,8 @@ describe('Signature marketplace revenue gate', () => {
   test('rejects unsafe package, usage, provider, payment, wallet, private repo, and timestamp material', () => {
     const unsafeInputs = [
       { packageValidationRefs: ['raw_package.private_payload'] },
+      { packagePublicationRefs: ['raw_package.private_payload'] },
+      { activationRefs: ['raw_package.private_payload'] },
       { usageEventRefs: ['usage_event_raw.provider_payload'] },
       { attributionRefs: ['github.com/acme/private-signatures'] },
       { pricingPolicyRefs: ['provider_payload.openai.raw'] },

--- a/apps/openagents.com/workers/api/src/signature-marketplace-revenue-gate.ts
+++ b/apps/openagents.com/workers/api/src/signature-marketplace-revenue-gate.ts
@@ -15,6 +15,7 @@ export type SignatureMarketplaceRevenueState =
   typeof SignatureMarketplaceRevenueState.Type
 
 export const SignatureMarketplaceRevenueGate = S.Struct({
+  activationRefs: S.Array(S.String),
   attributionRefs: S.Array(S.String),
   blockerRefs: S.Array(S.String),
   candidateRuntimeActivationAllowed: S.Boolean,
@@ -28,6 +29,7 @@ export const SignatureMarketplaceRevenueGate = S.Struct({
   licensePolicyRefs: S.Array(S.String),
   marketplaceListingMutationAllowed: S.Boolean,
   meteredUsageEventCount: S.Number,
+  packagePublicationRefs: S.Array(S.String),
   packageRefs: S.Array(S.String),
   packageValidationRefs: S.Array(S.String),
   payoutClaimAllowed: S.Boolean,
@@ -52,6 +54,7 @@ export type SignatureMarketplaceRevenueGate =
   typeof SignatureMarketplaceRevenueGate.Type
 
 export type SignatureMarketplaceRevenueGateInput = Readonly<{
+  activationRefs?: ReadonlyArray<string> | undefined
   attributionRefs?: ReadonlyArray<string> | undefined
   contributorPayableCents?: number | undefined
   disputePolicyRefs?: ReadonlyArray<string> | undefined
@@ -59,6 +62,7 @@ export type SignatureMarketplaceRevenueGateInput = Readonly<{
   forkPolicyRefs?: ReadonlyArray<string> | undefined
   grossRevenueCents?: number | undefined
   licensePolicyRefs?: ReadonlyArray<string> | undefined
+  packagePublicationRefs?: ReadonlyArray<string> | undefined
   packageRefs?: ReadonlyArray<string> | undefined
   packageValidationRefs?: ReadonlyArray<string> | undefined
   payoutEligibilityRefs?: ReadonlyArray<string> | undefined
@@ -137,12 +141,14 @@ const safeNonNegativeInteger = (
 const missingEvidenceBlockers = (
   input: Readonly<{
     attributionRefs: ReadonlyArray<string>
+    activationRefs: ReadonlyArray<string>
     contributorPayableCents: number
     disputePolicyRefs: ReadonlyArray<string>
     exactUsageSubjectRefs: ReadonlyArray<string>
     forkPolicyRefs: ReadonlyArray<string>
     grossRevenueCents: number
     licensePolicyRefs: ReadonlyArray<string>
+    packagePublicationRefs: ReadonlyArray<string>
     packageRefs: ReadonlyArray<string>
     packageValidationRefs: ReadonlyArray<string>
     payoutEligibilityRefs: ReadonlyArray<string>
@@ -158,6 +164,12 @@ const missingEvidenceBlockers = (
 ): ReadonlyArray<string> => [
   ...(!hasRefs(input.packageValidationRefs)
     ? ['blocker.public.signature_market.package_validation_missing']
+    : []),
+  ...(!hasRefs(input.packagePublicationRefs)
+    ? ['blocker.public.signature_market.package_publication_missing']
+    : []),
+  ...(!hasRefs(input.activationRefs)
+    ? ['blocker.public.signature_market.package_activation_missing']
     : []),
   ...(!hasRefs(input.packageRefs)
     ? ['blocker.public.signature_market.package_ref_missing']
@@ -223,6 +235,10 @@ const baseCaveatRefs = [
 export const projectSignatureMarketplaceRevenueGate = (
   input: SignatureMarketplaceRevenueGateInput,
 ): SignatureMarketplaceRevenueGate => {
+  const activationRefs = safeRefs(
+    'Signature marketplace activation refs',
+    input.activationRefs,
+  )
   const attributionRefs = safeRefs(
     'Signature marketplace attribution refs',
     input.attributionRefs,
@@ -246,6 +262,10 @@ export const projectSignatureMarketplaceRevenueGate = (
   const packageRefs = safeRefs(
     'Signature marketplace package refs',
     input.packageRefs,
+  )
+  const packagePublicationRefs = safeRefs(
+    'Signature marketplace package publication refs',
+    input.packagePublicationRefs,
   )
   const packageValidationRefs = safeRefs(
     'Signature marketplace package validation refs',
@@ -317,8 +337,12 @@ export const projectSignatureMarketplaceRevenueGate = (
     hasRefs(packageValidationRefs) &&
     hasRefs(packageRefs) &&
     hasRefs(programSignatureRefs)
-  const metered =
+  const activated =
     validated &&
+    hasRefs(packagePublicationRefs) &&
+    hasRefs(activationRefs)
+  const metered =
+    activated &&
     hasRefs(usageEventRefs) &&
     hasRefs(usageIdempotencyRefs) &&
     hasRefs(exactUsageSubjectRefs)
@@ -362,12 +386,14 @@ export const projectSignatureMarketplaceRevenueGate = (
     blockerRefs: [
       ...missingEvidenceBlockers({
         attributionRefs,
+        activationRefs,
         contributorPayableCents,
         disputePolicyRefs,
         exactUsageSubjectRefs,
         forkPolicyRefs,
         grossRevenueCents,
         licensePolicyRefs,
+        packagePublicationRefs,
         packageRefs,
         packageValidationRefs,
         payoutEligibilityRefs,
@@ -381,17 +407,19 @@ export const projectSignatureMarketplaceRevenueGate = (
         usageIdempotencyRefs,
       }),
     ].sort(),
-    candidateRuntimeActivationAllowed: false,
+    activationRefs,
+    candidateRuntimeActivationAllowed: activated,
     caveatRefs: baseCaveatRefs,
     contributorPayableCents,
     disputePolicyRefs,
     exactUsageSubjectRefs,
     forkPolicyRefs,
     grossRevenueCents,
-    installAllowed: false,
+    installAllowed: activated,
     licensePolicyRefs,
-    marketplaceListingMutationAllowed: false,
+    marketplaceListingMutationAllowed: activated,
     meteredUsageEventCount: usageEventRefs.length,
+    packagePublicationRefs,
     packageRefs,
     packageValidationRefs,
     payoutClaimAllowed: settled,
@@ -423,6 +451,7 @@ export const signatureMarketplaceRevenueGateHasPrivateMaterial = (
 ): boolean => {
   const publicValues = [
     gate.state,
+    ...gate.activationRefs,
     ...gate.attributionRefs,
     ...gate.blockerRefs,
     ...gate.caveatRefs,
@@ -430,6 +459,7 @@ export const signatureMarketplaceRevenueGateHasPrivateMaterial = (
     ...gate.exactUsageSubjectRefs,
     ...gate.forkPolicyRefs,
     ...gate.licensePolicyRefs,
+    ...gate.packagePublicationRefs,
     ...gate.packageRefs,
     ...gate.packageValidationRefs,
     ...gate.payoutEligibilityRefs,

--- a/apps/openagents.com/workers/api/src/signature-usage-metering.test.ts
+++ b/apps/openagents.com/workers/api/src/signature-usage-metering.test.ts
@@ -20,6 +20,10 @@ import {
 } from './signature-marketplace-revenue-gate'
 
 const validationInput = {
+  activationRefs: ['activation.public.signature_market.site_builder_v1'],
+  packagePublicationRefs: [
+    'publication.public.signature_market.site_builder_v1',
+  ],
   packageValidationRefs: ['validation.public.signature_market.site_builder_v1'],
   packageRefs: ['package.public.signature_market.site_builder'],
   programSignatureRefs: ['program_signature.public.site_builder_v1'],
@@ -129,7 +133,7 @@ describe('signature usage metering — idempotent store (#5529)', () => {
 })
 
 describe('signature usage metering — clears the revenue-gate metering rung (#5529)', () => {
-  test('with validation + metering and nothing past it, the gate reaches state "metered"', () => {
+  test('with publication + activation + metering and nothing past it, the gate reaches state "metered"', () => {
     const store = makeInMemorySignatureUsageMeteringStore([
       recordOk({
         signatureSubjectRef: 'package_site_builder.version_v1',
@@ -140,8 +144,9 @@ describe('signature usage metering — clears the revenue-gate metering rung (#5
 
     const gate = projectSignatureMeteringGate(store, validationInput)
 
-    // THE RECEIPT: metering output drives the gate from `validated` to `metered`.
+    // THE RECEIPT: metering output drives the gate from activated package usage to `metered`.
     expect(gate.state).toBe('metered')
+    expect(gate.installAllowed).toBe(true)
     expect(gate.meteredUsageEventCount).toBe(1)
     // The metering-stage blockers are now cleared on the gate...
     for (const cleared of [
@@ -160,9 +165,10 @@ describe('signature usage metering — clears the revenue-gate metering rung (#5
     expect(gate.signatureRevenueCopyAllowed).toBe(false)
   })
 
-  test('without metering the gate stays "validated" (metering is the gating rung)', () => {
+  test('without metering the activated gate stays "validated" (metering is the gating rung)', () => {
     const gate = projectSignatureMarketplaceRevenueGate(validationInput)
     expect(gate.state).toBe('validated')
+    expect(gate.installAllowed).toBe(true)
   })
 })
 

--- a/apps/openagents.com/workers/api/src/signature-usage-metering.ts
+++ b/apps/openagents.com/workers/api/src/signature-usage-metering.ts
@@ -234,7 +234,11 @@ export const projectSignatureMeteringGate = (
   store: SignatureUsageMeteringStore,
   validationInput: Pick<
     SignatureMarketplaceRevenueGateInput,
-    'packageValidationRefs' | 'packageRefs' | 'programSignatureRefs'
+    | 'activationRefs'
+    | 'packagePublicationRefs'
+    | 'packageValidationRefs'
+    | 'packageRefs'
+    | 'programSignatureRefs'
   >,
 ): SignatureMarketplaceRevenueGate =>
   projectSignatureMarketplaceRevenueGate({

--- a/docs/promises/registry.md
+++ b/docs/promises/registry.md
@@ -40,14 +40,14 @@
 > Current machine-readable source of truth: `/api/public/product-promises` is
 > generated from
 > [`product-promises.ts`](../../apps/openagents.com/workers/api/src/product-promises.ts),
-> which currently advertises registry `2026-06-27.2` with
-> `lastUpdated: "2026-06-27"`. This narrative document records the same
+> which currently advertises registry `2026-06-28.1` with
+> `lastUpdated: "2026-06-28"`. This narrative document records the same
 > top-line 2026-06-27 promise decisions above, plus historical reconciliation
 > context below; when in doubt, agents and reviewers should defer to the
 > machine-readable registry and include its version in mismatch reports.
 >
 > `2026-06-28` standing sweep: recent mainline Khala, Artanis, Pylon, Gym, and
-> operator-safety merges were checked against the current `2026-06-27.2`
+> operator-safety merges were checked against the current `2026-06-28.1`
 > registry header. This pass records no promise state flips, no new green
 > claims, and no machine-registry changes; follow-on public claims from those
 > surfaces remain bound to their existing scoped/yellow/red records until their


### PR DESCRIPTION
Addresses #6883.

### Changes
- Updated the signature monetization product-promise record to reflect tested package activation, pricing, rev-share, and settlement-receipt gate logic while keeping the promise planned.
- Hardened signature marketplace revenue gating so packages must publish, activate, and expose usable refs before metered usage can drive pricing.
- Added payable-state checks for attribution, pricing, rev-share, dispute/refund evidence, and full public-safe settlement receipts.
- Updated related promise registry evidence and tests.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).