### PR TITLE
feat(pylon): advertise Apple FM backend capacity

### DIFF
--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -78,6 +78,11 @@ import {
 } from "./node/control-server.js"
 import { createSupervisedAppleFmStatusAction } from "./node/apple-fm-supervised-status.js"
 import {
+  appleFmBackendCapacityRefs,
+  collectPylonAppleFmStatus,
+  withAppleFmBackendCapabilities,
+} from "./node/apple-fm-status.js"
+import {
   createAppleFmSupervisedLaunch,
   type AppleFmSupervisedLaunch,
 } from "./node/apple-fm-supervised-launch.js"
@@ -4939,6 +4944,10 @@ async function main() {
           config: await loadCodexAgentConfig(summary),
           codexAccountHomes: connectedCodexHomes,
         })
+        const appleFmStatus = await collectPylonAppleFmStatus({
+          env: Bun.env,
+          summary,
+        })
         // W4.1 (#4750): the Tassadar executor capability is declared
         // only behind a passing self-test receipt — a real digest-pinned
         // execution on this device — never by configuration assertion.
@@ -4953,11 +4962,14 @@ async function main() {
           capabilityRefs: withWorkspaceMaterializerCapability(
             withCodexAgentCapability(
               withClaudeAgentCapability(
-                [...new Set([
-                  ...mergeTassadarCapabilityRefs(state.runtime.capabilityRefs, tassadarDeclaration),
-                  PYLON_NIP90_PROVIDER_CAPABILITY_REF,
-                  PYLON_LABOR_CAPABILITY_REF,
-                ])],
+                withAppleFmBackendCapabilities(
+                  [...new Set([
+                    ...mergeTassadarCapabilityRefs(state.runtime.capabilityRefs, tassadarDeclaration),
+                    PYLON_NIP90_PROVIDER_CAPABILITY_REF,
+                    PYLON_LABOR_CAPABILITY_REF,
+                  ])],
+                  appleFmStatus,
+                ),
                 claudeAgentReadiness,
               ),
               codexAgentReadiness,
@@ -4969,6 +4981,7 @@ async function main() {
               ref !== PYLON_TASSADAR_SELF_TEST_FAILED_BLOCKER_REF,
             ),
             ...tassadarDeclaration.blockerRefs,
+            ...appleFmStatus.blockerRefs,
           ])],
         }
         await writeRuntimeState(state.paths, nextRuntime)
@@ -4989,6 +5002,7 @@ async function main() {
           ),
         )
         const codexAccountRefs = codexAccountCapacityRefs(codexAccounts)
+        const appleFmRefs = appleFmBackendCapacityRefs(appleFmStatus)
         const codexCapacity = codingCapacity.find((item) => item.service === "codex") ?? {
           available: 0,
           busy: 0,
@@ -5009,6 +5023,17 @@ async function main() {
           codexAgent: {
             state: codexAgentReadiness.state,
             credentialSourceRef: codexAgentReadiness.credentialSourceRef,
+          },
+          appleFmBackend: {
+            backendKind: appleFmStatus.backendKind,
+            profileId: appleFmStatus.profileId,
+            model: appleFmStatus.model,
+            status: appleFmStatus.status,
+            available: appleFmStatus.available,
+            capabilityRef: appleFmStatus.capability,
+            advertisedCapabilities: appleFmStatus.advertisedCapabilities,
+            capacityRefs: appleFmRefs.capacityRefs,
+            blockerRefs: appleFmStatus.blockerRefs,
           },
           ownCapacityDispatch: {
             schema: "openagents.pylon.own_capacity_dispatch.v1",

--- a/apps/pylon/src/inventory.ts
+++ b/apps/pylon/src/inventory.ts
@@ -281,7 +281,7 @@ export async function discoverHostInventory(input: { now?: Date; env?: Record<st
     externalNetworkInterfaceCount: net.externalInterfaceCount,
     opencodeInstalled: Boolean(Bun.which("opencode")),
     geminiConfigured: Boolean((input.env ?? Bun.env).GEMINI_API_KEY || (input.env ?? Bun.env).GOOGLE_GENERATIVE_AI_API_KEY),
-    appleFmReady: platform() === "darwin" && arch() === "arm64",
+    appleFmReady: false,
     psionicConfigured: Boolean((input.env ?? Bun.env).PYLON_PSIONIC_BASE_URL || (input.env ?? Bun.env).PROBE_PSIONIC_BASE_URL),
     psionicReady: false,
     psionicModelRefs: [],

--- a/apps/pylon/src/node/apple-fm-status.ts
+++ b/apps/pylon/src/node/apple-fm-status.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect"
 import type { BootstrapSummary } from "../bootstrap.js"
 import {
+  PROBE_APPLE_FM_BACKEND_CAPABILITY,
   reportAppleFmBackendCapability,
   type ProbeBackendCapabilityReport,
   type ProbeRunnerIdentity,
@@ -8,6 +9,15 @@ import {
 import type { PylonAppleFmSupervisorStatus } from "./apple-fm-bridge-supervisor-status.js"
 
 export const PYLON_APPLE_FM_STATUS_SCHEMA = "openagents.pylon.apple_fm.status.v0.1" as const
+export const PYLON_APPLE_FM_CAPACITY_SERVICE = "apple_fm_bridge" as const
+
+const APPLE_FM_DERIVED_CAPABILITY_REFS = new Set([
+  PROBE_APPLE_FM_BACKEND_CAPABILITY,
+  "adapter.probe.apple_fm.blueprint_tools.v1",
+  "probe.blueprint.signature_lookup",
+  "probe.blueprint.tool_menu",
+  "probe.program_run.evidence.local_offline",
+])
 
 export type PylonAppleFmStatusProjection = {
   readonly schema: typeof PYLON_APPLE_FM_STATUS_SCHEMA
@@ -92,6 +102,41 @@ export function pylonAppleFmStatusFromReport(
     blockerRefs: appleFmBlockerRefs(report),
     observedAt: report.observedAt,
     contentRedacted: true,
+  }
+}
+
+export function withAppleFmBackendCapabilities(
+  capabilityRefs: ReadonlyArray<string>,
+  projection: PylonAppleFmStatusProjection,
+): string[] {
+  const base = capabilityRefs.filter((ref) => !APPLE_FM_DERIVED_CAPABILITY_REFS.has(ref))
+  if (!projection.available || !projection.advertisedCapabilities.includes(PROBE_APPLE_FM_BACKEND_CAPABILITY)) {
+    return [...new Set(base)]
+  }
+  return [...new Set([...base, ...projection.advertisedCapabilities])].sort()
+}
+
+export function appleFmBackendCapacityRefs(
+  projection: PylonAppleFmStatusProjection,
+): { capacityRefs: string[]; loadRefs: string[]; healthRefs: string[] } {
+  if (!projection.available || !projection.advertisedCapabilities.includes(PROBE_APPLE_FM_BACKEND_CAPABILITY)) {
+    return { capacityRefs: [], healthRefs: [], loadRefs: [] }
+  }
+
+  return {
+    capacityRefs: [
+      `capacity.inference.${PYLON_APPLE_FM_CAPACITY_SERVICE}.ready=1`,
+      `capacity.inference.${PYLON_APPLE_FM_CAPACITY_SERVICE}.available=1`,
+    ],
+    healthRefs: [
+      `health.inference.${PYLON_APPLE_FM_CAPACITY_SERVICE}.ready`,
+      `model.inference.${PYLON_APPLE_FM_CAPACITY_SERVICE}.apple_foundation_model`,
+      `profile.inference.${PYLON_APPLE_FM_CAPACITY_SERVICE}.apple_fm_local`,
+    ],
+    loadRefs: [
+      `load.inference.${PYLON_APPLE_FM_CAPACITY_SERVICE}.busy=0`,
+      `load.inference.${PYLON_APPLE_FM_CAPACITY_SERVICE}.queued=0`,
+    ],
   }
 }
 

--- a/apps/pylon/src/presence.ts
+++ b/apps/pylon/src/presence.ts
@@ -18,6 +18,12 @@ import {
 } from "./provider-nip90.js"
 import { CODEX_AGENT_CAPABILITY_REF } from "./codex-agent.js"
 import { CLAUDE_AGENT_CAPABILITY_REF } from "./claude-agent.js"
+import {
+  appleFmBackendCapacityRefs,
+  collectPylonAppleFmStatus,
+  withAppleFmBackendCapabilities,
+  type PylonAppleFmStatusProjection,
+} from "./node/apple-fm-status.js"
 import { publishableCapabilityRefs } from "./tassadar-capability.js"
 import { createNip98Event, encodeNip98Authorization, loadOrCreateNostrIdentity } from "./nostr-identity.js"
 import {
@@ -64,6 +70,10 @@ export type PresenceClientOptions = {
   // orchestration from the assignment poll route. This keeps heartbeat capacity
   // honest when a prior no-spend lease exists but no fresh local marker remains.
   activeRunCounts?: PylonActiveCodingRunCounts
+  // Test and node-internal seam for the live Apple FM bridge readiness report.
+  // When omitted, heartbeat probes the local /health endpoint through the shared
+  // Probe runtime capability reporter.
+  appleFmStatusProbe?: () => Promise<PylonAppleFmStatusProjection>
 }
 
 // Map the local wallet probe to the heartbeat's public readiness fields. The
@@ -729,6 +739,17 @@ export async function sendHeartbeat(summary: BootstrapSummary, options: Presence
       claudeBusyByAccount(activeRunCountsByAccount),
     ),
   )
+  const appleFmStatus = options.appleFmStatusProbe === undefined
+    ? await collectPylonAppleFmStatus({
+        env: presenceEnv,
+        now: options.now?.(),
+        summary,
+      })
+    : await options.appleFmStatusProbe()
+  const appleFmRefs = appleFmBackendCapacityRefs(appleFmStatus)
+  const capabilityRefs = publishableCapabilityRefs(
+    withAppleFmBackendCapabilities(state.runtime.capabilityRefs, appleFmStatus),
+  )
   const body: PylonHeartbeatRequest = {
     schema: "openagents.pylon.heartbeat.v0.3",
     pylonRef: state.identity.pylonRef,
@@ -740,23 +761,25 @@ export async function sendHeartbeat(summary: BootstrapSummary, options: Presence
       ...codingRefs.capacityRefs,
       ...codexAccountRefs.capacityRefs,
       ...claudeAccountRefs.capacityRefs,
+      ...appleFmRefs.capacityRefs,
     ],
     clientProtocolVersion: "0.3.0",
     clientVersion: PYLON_CLIENT_VERSION,
-    healthRefs: ["health.public.pylon_cli.ok"],
+    healthRefs: ["health.public.pylon_cli.ok", ...appleFmRefs.healthRefs],
     loadRefs: [
       "load.public.pylon_cli.low",
       ...codingRefs.loadRefs,
       ...codexAccountRefs.loadRefs,
       ...claudeAccountRefs.loadRefs,
+      ...appleFmRefs.loadRefs,
     ],
     resourceMode: state.runtime.resourceMode,
     status: "online",
     walletReadiness,
     ...(walletReady === undefined ? {} : { walletReady }),
     assignmentReadiness: state.runtime.lifecycle === "assignment-ready" ? "ready" : "not-ready",
-    capabilityRefs: publishableCapabilityRefs(state.runtime.capabilityRefs),
-    blockerRefs: [...state.runtime.blockerRefs, ...presence.blockerRefs],
+    capabilityRefs,
+    blockerRefs: [...new Set([...state.runtime.blockerRefs, ...presence.blockerRefs, ...appleFmStatus.blockerRefs])],
     ...providerDiscoveryFields(state, options.env ?? process.env),
   }
   await postJson(options, {

--- a/apps/pylon/tests/apple-fm-status-supervisor.test.ts
+++ b/apps/pylon/tests/apple-fm-status-supervisor.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import {
+  appleFmBackendCapacityRefs,
   collectPylonAppleFmStatus,
+  withAppleFmBackendCapabilities,
   withAppleFmSupervisorStatus,
   type PylonAppleFmStatusProjection,
 } from "../src/node/apple-fm-status"
@@ -54,6 +56,62 @@ function drive(
 }
 
 describe("withAppleFmSupervisorStatus", () => {
+  test("live ready status adds Apple FM capability and inference capacity refs", async () => {
+    const projection = await readyProjection()
+
+    expect(withAppleFmBackendCapabilities([], projection)).toEqual(
+      expect.arrayContaining([
+        "probe.backend.apple_fm_bridge",
+        "adapter.probe.apple_fm.blueprint_tools.v1",
+        "probe.program_run.evidence.local_offline",
+      ]),
+    )
+    expect(appleFmBackendCapacityRefs(projection)).toEqual({
+      capacityRefs: [
+        "capacity.inference.apple_fm_bridge.ready=1",
+        "capacity.inference.apple_fm_bridge.available=1",
+      ],
+      healthRefs: [
+        "health.inference.apple_fm_bridge.ready",
+        "model.inference.apple_fm_bridge.apple_foundation_model",
+        "profile.inference.apple_fm_bridge.apple_fm_local",
+      ],
+      loadRefs: [
+        "load.inference.apple_fm_bridge.busy=0",
+        "load.inference.apple_fm_bridge.queued=0",
+      ],
+    })
+  })
+
+  test("blocked status strips stale Apple FM capability and publishes no capacity", async () => {
+    const summary = createBootstrapSummary(
+      parseBootstrapArgs(["--json", "--pylon-ref", "pylon.test.apple-fm-blocked"]),
+      env,
+    )
+    const blocked = await collectPylonAppleFmStatus({
+      summary,
+      env,
+      fetch: (async () =>
+        Response.json({
+          ready: false,
+          unavailableReason: "apple_intelligence_disabled",
+        })) as typeof fetch,
+      now: new Date("2026-06-15T00:00:00.000Z"),
+    })
+
+    expect(
+      withAppleFmBackendCapabilities(
+        ["probe.backend.apple_fm_bridge", "probe.blueprint.tool_menu", "capability.pylon.local_codex"],
+        blocked,
+      ),
+    ).toEqual(["capability.pylon.local_codex"])
+    expect(appleFmBackendCapacityRefs(blocked)).toEqual({
+      capacityRefs: [],
+      healthRefs: [],
+      loadRefs: [],
+    })
+  })
+
   test("base projection has no supervisor until one is attached", async () => {
     const base = await readyProjection()
     expect(base.available).toBe(true)

--- a/apps/pylon/tests/presence.test.ts
+++ b/apps/pylon/tests/presence.test.ts
@@ -24,6 +24,7 @@ import { registerSparkPayoutTarget, sparkPayoutTargetRef } from "../src/wallet"
 import { CODEX_AGENT_CAPABILITY_REF } from "../src/codex-agent"
 import { CLAUDE_AGENT_CAPABILITY_REF } from "../src/claude-agent"
 import { registerActiveCodingRun } from "../src/active-assignment-runs"
+import { PYLON_APPLE_FM_STATUS_SCHEMA, type PylonAppleFmStatusProjection } from "../src/node/apple-fm-status"
 
 const INDEX = join(import.meta.dir, "..", "src", "index.ts")
 const CWD = join(import.meta.dir, "..")
@@ -156,6 +157,61 @@ function fakePresenceCliServer() {
 
 const nonAssignmentRequestPaths = (requests: { path: string }[]) =>
   requests.map((request) => request.path).filter((path) => !path.endsWith("/assignments"))
+
+function fakeAppleFmStatus(overrides: Partial<PylonAppleFmStatusProjection> = {}): PylonAppleFmStatusProjection {
+  return {
+    schema: PYLON_APPLE_FM_STATUS_SCHEMA,
+    kind: "pylon_apple_fm_status",
+    runnerId: "pylon.test.apple-fm",
+    runnerKind: "pylon",
+    backendKind: "apple_fm_bridge",
+    profileId: "apple-fm-local",
+    model: "apple-foundation-model",
+    capability: "probe.backend.apple_fm_bridge",
+    advertisedCapabilities: [],
+    available: false,
+    status: "unreachable",
+    baseUrl: "http://127.0.0.1:11435",
+    requirements: {
+      appleSilicon: "required",
+      appleIntelligence: "required",
+      liveHealth: "required",
+    },
+    support: {
+      snapshotStreaming: true,
+      toolCallbacks: true,
+    },
+    blueprintSupport: {
+      appleFmSchemaProjection: {
+        maxProjectedToolCount: 16,
+        supported: true,
+        supportedInputSchemaRefs: [],
+      },
+      backendAvailability: {
+        api: false,
+        local: false,
+        swarm: false,
+      },
+      backendToolProjectionAdapters: [],
+      localProgramRunEvidenceOffline: false,
+      moduleVersionRefs: [],
+      programFamilies: [],
+      programSignatureRefs: [],
+      programTypeRefs: [],
+      registryVersionRefs: [],
+      safeProjection: true,
+      safeProjectionPolicyRefs: [],
+      supportedBlueprintCapabilityRefs: [],
+      toolRefs: [],
+      warnings: [],
+    },
+    receipt: null,
+    blockerRefs: ["blocker.pylon.apple_fm.bridge_unreachable"],
+    observedAt: "2026-06-28T00:00:00.000Z",
+    contentRedacted: true,
+    ...overrides,
+  } as PylonAppleFmStatusProjection
+}
 
 async function runPresenceCli(input: {
   args: string[]
@@ -421,6 +477,69 @@ describe("Pylon presence registration and heartbeat", () => {
           "load.coding.claude.queued=3",
         ]),
       )
+    })
+  })
+
+  test("heartbeat advertises Apple FM inference capacity only after live readiness", async () => {
+    await withTempHome(async (home) => {
+      const fake = fakePresenceServer()
+      const summary = createBootstrapSummary(
+        parseBootstrapArgs([
+          "--display-name",
+          "Apple FM Presence Test",
+          "--capability-ref",
+          "probe.backend.apple_fm_bridge",
+        ]),
+        { PYLON_HOME: home },
+        "darwin",
+      )
+
+      await sendHeartbeat(summary, {
+        baseUrl: fake.baseUrl,
+        walletProbe: offlineWalletProbe,
+        appleFmStatusProbe: async () =>
+          fakeAppleFmStatus({
+            advertisedCapabilities: [
+              "probe.backend.apple_fm_bridge",
+              "adapter.probe.apple_fm.blueprint_tools.v1",
+              "probe.program_run.evidence.local_offline",
+            ],
+            available: true,
+            status: "ready",
+            blockerRefs: [],
+          }),
+      })
+      const readyHeartbeat = fake.requests.filter(r => r.path.includes("/heartbeat")).at(-1)!
+      expect(readyHeartbeat.body.capabilityRefs).toEqual(
+        expect.arrayContaining([
+          "probe.backend.apple_fm_bridge",
+          "adapter.probe.apple_fm.blueprint_tools.v1",
+          "probe.program_run.evidence.local_offline",
+        ]),
+      )
+      expect(readyHeartbeat.body.capacityRefs).toEqual(
+        expect.arrayContaining([
+          "capacity.inference.apple_fm_bridge.ready=1",
+          "capacity.inference.apple_fm_bridge.available=1",
+        ]),
+      )
+
+      await sendHeartbeat(summary, {
+        baseUrl: fake.baseUrl,
+        walletProbe: offlineWalletProbe,
+        appleFmStatusProbe: async () =>
+          fakeAppleFmStatus({
+            blockerRefs: ["blocker.pylon.apple_fm.apple_intelligence_disabled"],
+            status: "unavailable",
+            unavailableReason: "apple_intelligence_disabled",
+          }),
+      })
+      const blockedHeartbeat = fake.requests.filter(r => r.path.includes("/heartbeat")).at(-1)!
+      expect(blockedHeartbeat.body.capabilityRefs).not.toContain("probe.backend.apple_fm_bridge")
+      expect(blockedHeartbeat.body.capabilityRefs).not.toContain("adapter.probe.apple_fm.blueprint_tools.v1")
+      expect(blockedHeartbeat.body.capacityRefs).not.toContain("capacity.inference.apple_fm_bridge.ready=1")
+      expect(blockedHeartbeat.body.capacityRefs).not.toContain("capacity.inference.apple_fm_bridge.available=1")
+      expect(blockedHeartbeat.body.blockerRefs).toContain("blocker.pylon.apple_fm.apple_intelligence_disabled")
     })
   })
 


### PR DESCRIPTION
Addresses #6874.

### Changes
- Registers Apple Foundation Models bridge status in Pylon runtime state and heartbeat payloads.
- Advertises Apple FM backend capabilities and truthful inference capacity/load refs only when the local backend report is available.
- Stops treating Darwin arm64 host inventory alone as proof that Apple FM is ready.
- Adds tests for Apple FM supervisor status and presence capacity projection.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` - passed (exit 0)