### PR TITLE
fix(khala-macos): bundle Apple FM bridge in app builds

### DIFF
--- a/clients/khala-ios/Khala/Khala.xcodeproj/project.pbxproj
+++ b/clients/khala-ios/Khala/Khala.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 				A1000000000000000000SRC /* Sources */,
 				A1000000000000000000FRMW /* Frameworks */,
 				A1000000000000000000RES /* Resources */,
+				A1000000000000000000AFMP /* Bundle Apple FM bridge helper */,
 			);
 			buildRules = (
 			);
@@ -181,6 +182,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A1000000000000000000AFMP /* Bundle Apple FM bridge helper */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle Apple FM bridge helper";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash \"$SRCROOT/scripts/copy-packaged-apple-fm-bridge.sh\"";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A1000000000000000000SRC /* Sources */ = {

--- a/clients/khala-ios/Khala/README.md
+++ b/clients/khala-ios/Khala/README.md
@@ -100,6 +100,35 @@ xcodebuild -exportArchive -archivePath build/Khala.xcarchive \
   -exportPath build -exportOptionsPlist ExportOptions.plist
 ```
 
+## macOS Apple FM packaging gate
+
+Khala macOS builds that advertise Apple FM support must bundle the Pylon
+Foundation Models helper at:
+
+```text
+Khala.app/Contents/Resources/app/apple-fm-bridge/foundation-bridge
+```
+
+The Xcode target runs `scripts/copy-packaged-apple-fm-bridge.sh` as a macOS-only
+post-build phase. It copies `apps/pylon/bin/foundation-bridge` by default; build
+it first with:
+
+```sh
+bash ../../../apps/pylon/swift/foundation-bridge/build.sh
+```
+
+Before signing/notarization, run:
+
+```sh
+bun scripts/verify-packaged-apple-fm-bridge.ts /path/to/Khala.app
+```
+
+The verifier fails if the helper is missing, empty, or not executable. To ship an
+intentional Apple-FM-less build, set `KHALA_SKIP_APPLE_FM_BRIDGE_CHECK=1` during
+the Xcode build and during verification; the copy phase writes an explicit
+`APPLE_FM_UNAVAILABLE.txt` marker into the bundle instead of silently omitting
+the helper.
+
 TestFlight upload is **Apple-native** (`xcrun altool` / Transporter), using the
 App Store Connect API key in workspace `.secrets/appstoreconnect.env`. Per the
 repo mobile policy (root `AGENTS.md`), **never** use `eas build`/`submit`/

--- a/clients/khala-ios/Khala/project.yml
+++ b/clients/khala-ios/Khala/project.yml
@@ -24,6 +24,9 @@ targets:
     deploymentTarget: "17.0"
     sources:
       - path: Khala
+    postBuildScripts:
+      - name: Bundle Apple FM bridge helper
+        script: bash "$SRCROOT/scripts/copy-packaged-apple-fm-bridge.sh"
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openagents.khala

--- a/clients/khala-ios/Khala/scripts/copy-packaged-apple-fm-bridge.sh
+++ b/clients/khala-ios/Khala/scripts/copy-packaged-apple-fm-bridge.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Xcode build phase: bundle the Apple FM helper into a macOS Khala .app.
+set -euo pipefail
+
+if [[ "${PLATFORM_NAME:-}" != macosx* ]]; then
+  exit 0
+fi
+
+if [[ -z "${TARGET_BUILD_DIR:-}" || -z "${UNLOCALIZED_RESOURCES_FOLDER_PATH:-}" ]]; then
+  echo "Khala Apple FM packaging requires Xcode TARGET_BUILD_DIR and UNLOCALIZED_RESOURCES_FOLDER_PATH" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+source_helper="${KHALA_APPLE_FM_BRIDGE_HELPER_PATH:-$repo_root/apps/pylon/bin/foundation-bridge}"
+dest_dir="$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/app/apple-fm-bridge"
+dest_helper="$dest_dir/foundation-bridge"
+unavailable_marker="$dest_dir/APPLE_FM_UNAVAILABLE.txt"
+
+mkdir -p "$dest_dir"
+
+if [[ "${KHALA_SKIP_APPLE_FM_BRIDGE_CHECK:-0}" == "1" ]]; then
+  rm -f "$dest_helper"
+  printf '%s\n' "Apple FM unavailable: KHALA_SKIP_APPLE_FM_BRIDGE_CHECK=1 at build time." > "$unavailable_marker"
+  exit 0
+fi
+
+if [[ ! -f "$source_helper" ]]; then
+  echo "Khala Apple FM helper missing at $source_helper" >&2
+  echo "Run apps/pylon/swift/foundation-bridge/build.sh or set KHALA_APPLE_FM_BRIDGE_HELPER_PATH." >&2
+  exit 1
+fi
+
+if [[ ! -s "$source_helper" ]]; then
+  echo "Khala Apple FM helper is empty at $source_helper" >&2
+  exit 1
+fi
+
+if [[ ! -x "$source_helper" ]]; then
+  echo "Khala Apple FM helper is not executable at $source_helper" >&2
+  exit 1
+fi
+
+rm -f "$unavailable_marker"
+cp "$source_helper" "$dest_helper"
+chmod 755 "$dest_helper"
+
+if [[ ! -s "$dest_helper" || ! -x "$dest_helper" ]]; then
+  echo "Khala Apple FM helper copy failed verification at $dest_helper" >&2
+  exit 1
+fi
+
+echo "Khala Apple FM helper bundled at $dest_helper"

--- a/clients/khala-ios/Khala/scripts/khala-apple-fm-packaging.test.ts
+++ b/clients/khala-ios/Khala/scripts/khala-apple-fm-packaging.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test"
+import {
+  KHALA_APPLE_FM_BRIDGE_RESOURCES_SUBPATH,
+  KHALA_APPLE_FM_UNAVAILABLE_MARKER_SUBPATH,
+  packagedKhalaAppleFmBridgePath,
+  packagedKhalaAppleFmUnavailableMarkerPath,
+  verifyPackagedKhalaAppleFmBridge,
+  type KhalaAppleFmBridgeProbe,
+} from "./khala-apple-fm-packaging"
+
+const healthy: KhalaAppleFmBridgeProbe = () => ({
+  exists: true,
+  nonEmpty: true,
+  executable: true,
+})
+
+describe("Khala Apple FM packaging contract", () => {
+  test("helper path matches the Pylon packaged-resource discovery path", () => {
+    expect(KHALA_APPLE_FM_BRIDGE_RESOURCES_SUBPATH).toBe(
+      "app/apple-fm-bridge/foundation-bridge",
+    )
+    expect(packagedKhalaAppleFmBridgePath("build/Release/Khala.app")).toBe(
+      "build/Release/Khala.app/Contents/Resources/app/apple-fm-bridge/foundation-bridge",
+    )
+  })
+
+  test("verifier accepts a non-empty executable helper", () => {
+    const result = verifyPackagedKhalaAppleFmBridge({
+      bundleDir: "build/Release/Khala.app",
+      probe: healthy,
+    })
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe("available")
+  })
+
+  test("verifier rejects missing, empty, and non-executable helpers", () => {
+    const missing = verifyPackagedKhalaAppleFmBridge({
+      bundleDir: "build/Release/Khala.app",
+      probe: () => ({ exists: false, nonEmpty: false, executable: false }),
+    })
+    expect(missing).toMatchObject({ ok: false, status: "missing" })
+
+    const empty = verifyPackagedKhalaAppleFmBridge({
+      bundleDir: "build/Release/Khala.app",
+      probe: () => ({ exists: true, nonEmpty: false, executable: true }),
+    })
+    expect(empty).toMatchObject({ ok: false, status: "empty" })
+
+    const notExecutable = verifyPackagedKhalaAppleFmBridge({
+      bundleDir: "build/Release/Khala.app",
+      probe: () => ({ exists: true, nonEmpty: true, executable: false }),
+    })
+    expect(notExecutable).toMatchObject({ ok: false, status: "not_executable" })
+  })
+
+  test("intentional Apple-FM-less builds require a marker", () => {
+    expect(KHALA_APPLE_FM_UNAVAILABLE_MARKER_SUBPATH).toBe(
+      "app/apple-fm-bridge/APPLE_FM_UNAVAILABLE.txt",
+    )
+    expect(packagedKhalaAppleFmUnavailableMarkerPath("build/Release/Khala.app")).toBe(
+      "build/Release/Khala.app/Contents/Resources/app/apple-fm-bridge/APPLE_FM_UNAVAILABLE.txt",
+    )
+
+    const result = verifyPackagedKhalaAppleFmBridge({
+      bundleDir: "build/Release/Khala.app",
+      probe: () => ({ exists: false, nonEmpty: false, executable: false }),
+      allowUnavailableMarker: true,
+      markerProbe: () => ({ exists: true, nonEmpty: true }),
+    })
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe("unavailable")
+  })
+
+  test("allowing unavailable still fails without the explicit marker", () => {
+    const result = verifyPackagedKhalaAppleFmBridge({
+      bundleDir: "build/Release/Khala.app",
+      probe: () => ({ exists: false, nonEmpty: false, executable: false }),
+      allowUnavailableMarker: true,
+      markerProbe: () => ({ exists: false, nonEmpty: false }),
+    })
+    expect(result).toMatchObject({ ok: false, status: "unmarked_unavailable" })
+  })
+})

--- a/clients/khala-ios/Khala/scripts/khala-apple-fm-packaging.ts
+++ b/clients/khala-ios/Khala/scripts/khala-apple-fm-packaging.ts
@@ -1,0 +1,143 @@
+/**
+ * Packaging contract for the Khala macOS Apple FM Foundation Models bridge.
+ *
+ * A signed Khala macOS app that advertises Apple FM support must ship the
+ * `foundation-bridge` helper at the same packaged-resource path Pylon uses:
+ *
+ *   <Khala.app>/Contents/Resources/app/apple-fm-bridge/foundation-bridge
+ *
+ * The verifier is intentionally structural: it checks presence, non-empty file
+ * size, and owner-executable bit without reading file contents.
+ */
+
+export const KHALA_APPLE_FM_BRIDGE_HELPER_BASENAME = "foundation-bridge" as const
+
+export const KHALA_APPLE_FM_BRIDGE_RESOURCES_SUBPATH =
+  "app/apple-fm-bridge/foundation-bridge" as const
+
+export const KHALA_APPLE_FM_UNAVAILABLE_MARKER_SUBPATH =
+  "app/apple-fm-bridge/APPLE_FM_UNAVAILABLE.txt" as const
+
+const MACOS_APP_RESOURCES_RELATIVE = "Contents/Resources" as const
+
+function joinPosix(...segments: ReadonlyArray<string>): string {
+  return segments
+    .map((segment, index) =>
+      index === 0 ? segment.replace(/\/+$/, "") : segment.replace(/^\/+|\/+$/g, ""),
+    )
+    .filter((segment) => segment.length > 0)
+    .join("/")
+}
+
+export function packagedKhalaAppleFmBridgePath(bundleDir: string): string {
+  return joinPosix(
+    bundleDir,
+    MACOS_APP_RESOURCES_RELATIVE,
+    KHALA_APPLE_FM_BRIDGE_RESOURCES_SUBPATH,
+  )
+}
+
+export function packagedKhalaAppleFmUnavailableMarkerPath(bundleDir: string): string {
+  return joinPosix(
+    bundleDir,
+    MACOS_APP_RESOURCES_RELATIVE,
+    KHALA_APPLE_FM_UNAVAILABLE_MARKER_SUBPATH,
+  )
+}
+
+export type KhalaAppleFmProbeResult = {
+  readonly exists: boolean
+  readonly nonEmpty: boolean
+  readonly executable: boolean
+}
+
+export type KhalaAppleFmMarkerProbeResult = {
+  readonly exists: boolean
+  readonly nonEmpty: boolean
+}
+
+export type KhalaAppleFmBridgeProbe = (helperPath: string) => KhalaAppleFmProbeResult
+export type KhalaAppleFmMarkerProbe = (markerPath: string) => KhalaAppleFmMarkerProbeResult
+
+export type VerifyPackagedKhalaAppleFmBridgeInput = {
+  readonly bundleDir: string
+  readonly probe: KhalaAppleFmBridgeProbe
+  readonly markerProbe?: KhalaAppleFmMarkerProbe
+  readonly allowUnavailableMarker?: boolean
+}
+
+export type VerifyPackagedKhalaAppleFmBridgeResult =
+  | {
+      readonly ok: true
+      readonly status: "available"
+      readonly verifiedPath: string
+    }
+  | {
+      readonly ok: true
+      readonly status: "unavailable"
+      readonly markerPath: string
+    }
+  | {
+      readonly ok: false
+      readonly status: "missing" | "empty" | "not_executable" | "unmarked_unavailable"
+      readonly checkedPath: string
+      readonly reason: string
+    }
+
+export function verifyPackagedKhalaAppleFmBridge(
+  input: VerifyPackagedKhalaAppleFmBridgeInput,
+): VerifyPackagedKhalaAppleFmBridgeResult {
+  const helperPath = packagedKhalaAppleFmBridgePath(input.bundleDir)
+  const result = input.probe(helperPath)
+
+  if (result.exists && !result.nonEmpty) {
+    return {
+      ok: false,
+      status: "empty",
+      checkedPath: helperPath,
+      reason: "helper is empty",
+    }
+  }
+
+  if (result.exists && !result.executable) {
+    return {
+      ok: false,
+      status: "not_executable",
+      checkedPath: helperPath,
+      reason: "helper not executable",
+    }
+  }
+
+  if (result.exists) {
+    return {
+      ok: true,
+      status: "available",
+      verifiedPath: helperPath,
+    }
+  }
+
+  if (input.allowUnavailableMarker === true && input.markerProbe !== undefined) {
+    const markerPath = packagedKhalaAppleFmUnavailableMarkerPath(input.bundleDir)
+    const marker = input.markerProbe(markerPath)
+    if (marker.exists && marker.nonEmpty) {
+      return {
+        ok: true,
+        status: "unavailable",
+        markerPath,
+      }
+    }
+    return {
+      ok: false,
+      status: "unmarked_unavailable",
+      checkedPath: markerPath,
+      reason: "Apple FM unavailable marker missing or empty",
+    }
+  }
+
+  return {
+    ok: false,
+    status: "missing",
+    checkedPath: helperPath,
+    reason: "helper missing",
+  }
+}

--- a/clients/khala-ios/Khala/scripts/verify-packaged-apple-fm-bridge.ts
+++ b/clients/khala-ios/Khala/scripts/verify-packaged-apple-fm-bridge.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+/**
+ * Pre-notarization gate for Khala macOS Apple FM support.
+ *
+ * Usage:
+ *   bun scripts/verify-packaged-apple-fm-bridge.ts /path/to/Khala.app
+ *
+ * Exit 0 only when the built app contains a non-empty executable
+ * `Contents/Resources/app/apple-fm-bridge/foundation-bridge` helper. Set
+ * KHALA_SKIP_APPLE_FM_BRIDGE_CHECK=1 to accept an intentionally Apple-FM-less
+ * build only when the app bundle contains the unavailable marker written by the
+ * Xcode copy phase.
+ */
+import { existsSync, statSync } from "node:fs"
+import {
+  verifyPackagedKhalaAppleFmBridge,
+  type KhalaAppleFmBridgeProbe,
+  type KhalaAppleFmMarkerProbe,
+} from "./khala-apple-fm-packaging"
+
+const bundleDir = process.argv[2]
+
+if (bundleDir === undefined || bundleDir.trim() === "") {
+  console.error("Usage: bun scripts/verify-packaged-apple-fm-bridge.ts /path/to/Khala.app")
+  process.exit(2)
+}
+
+const bridgeProbe: KhalaAppleFmBridgeProbe = (helperPath) => {
+  if (!existsSync(helperPath)) {
+    return { exists: false, nonEmpty: false, executable: false }
+  }
+  const stat = statSync(helperPath)
+  return {
+    exists: stat.isFile(),
+    nonEmpty: stat.size > 0,
+    executable: stat.isFile() && (stat.mode & 0o100) !== 0,
+  }
+}
+
+const markerProbe: KhalaAppleFmMarkerProbe = (markerPath) => {
+  if (!existsSync(markerPath)) {
+    return { exists: false, nonEmpty: false }
+  }
+  const stat = statSync(markerPath)
+  return {
+    exists: stat.isFile(),
+    nonEmpty: stat.size > 0,
+  }
+}
+
+const result = verifyPackagedKhalaAppleFmBridge({
+  bundleDir,
+  probe: bridgeProbe,
+  markerProbe,
+  allowUnavailableMarker: process.env.KHALA_SKIP_APPLE_FM_BRIDGE_CHECK === "1",
+})
+
+if (result.ok && result.status === "available") {
+  console.log(`Khala Apple FM bridge helper verified: ${result.verifiedPath}`)
+  process.exit(0)
+}
+
+if (result.ok && result.status === "unavailable") {
+  console.log(`Khala Apple FM unavailable marker verified: ${result.markerPath}`)
+  process.exit(0)
+}
+
+console.error(
+  [
+    "Khala Apple FM bridge helper is missing or unusable.",
+    "A signed macOS app that advertises Apple FM support must bundle the",
+    "foundation-bridge helper before notarization.",
+    `Checked: ${result.checkedPath}`,
+    `Reason: ${result.reason}`,
+  ].join("\n"),
+)
+process.exit(1)

--- a/docs/mobile/2026-06-26-khala-testflight-release-runbook.md
+++ b/docs/mobile/2026-06-26-khala-testflight-release-runbook.md
@@ -41,6 +41,23 @@ cd /tmp/oa-ship/clients/khala-ios/Khala
 set -a; . ~/work/.secrets/appstoreconnect.env; set +a
 ```
 
+### macOS Apple FM packaging guard
+
+If this lane is producing a signed/notarized Khala macOS `.app` with Apple FM
+support, build the helper and verify the app bundle before codesign/notary:
+
+```sh
+bash ../../../apps/pylon/swift/foundation-bridge/build.sh
+xcodebuild -project Khala.xcodeproj -scheme Khala -configuration Release build
+bun scripts/verify-packaged-apple-fm-bridge.ts /path/to/Khala.app
+```
+
+The helper must be present, non-empty, and executable at
+`Contents/Resources/app/apple-fm-bridge/foundation-bridge`. An intentionally
+Apple-FM-less build must set `KHALA_SKIP_APPLE_FM_BRIDGE_CHECK=1` at build and
+verify time so the bundle carries the explicit `APPLE_FM_UNAVAILABLE.txt`
+marker instead of a false-green Apple FM claim.
+
 ### 1. Bump the build number (REQUIRED — each upload needs a unique, higher build)
 Version keys are **hardcoded in `Khala/Resources/Info.plist`** (the project sets
 `GENERATE_INFOPLIST_FILE=NO`), so bump there AND in the pbxproj:


### PR DESCRIPTION
Addresses #6884.

### Changes
- Adds a Khala macOS Xcode post-build phase to run the Apple FM bridge helper bundling script.
- Mirrors the post-build script in `project.yml` so regenerated project files keep the helper bundling step.
- Documents the required helper path, pre-notarization verification command, and explicit Apple-FM-less skip marker flow in the Khala README and TestFlight release runbook.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).