### PR TITLE
feat(khala-macos): add local diagnostics entry point

### DIFF
--- a/clients/khala-ios/Khala/Khala/Diagnostics/LocalDiagnostics.swift
+++ b/clients/khala-ios/Khala/Khala/Diagnostics/LocalDiagnostics.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+struct LocalDiagnosticsSnapshot: Equatable {
+    struct Row: Identifiable, Equatable {
+        let id: String
+        let label: String
+        let value: String
+        let systemImage: String
+    }
+
+    let generatedAt: Date
+    let publicRows: [Row]
+    let rawRows: [Row]
+
+    static func make(
+        generatedAt: Date = Date(),
+        hasAPIKey: Bool,
+        channelName: String,
+        isStreaming: Bool,
+        activeConversation: Conversation?,
+        conversationCount: Int,
+        isUsingEphemeralFallback: Bool,
+        processInfo: ProcessInfo = .processInfo,
+        bundle: Bundle = .main
+    ) -> LocalDiagnosticsSnapshot {
+        let messages = activeConversation?.sortedMessages ?? []
+        let lastAssignmentRef = messages
+            .lazy
+            .compactMap { Self.firstAssignmentRef(in: $0.content) }
+            .first
+
+        let publicRows = [
+            Row(
+                id: "apple-runtime",
+                label: "Apple runtime",
+                value: "Native SwiftUI lifecycle active",
+                systemImage: "apple.logo"
+            ),
+            Row(
+                id: "pylon",
+                label: "Pylon",
+                value: lastAssignmentRef == nil ? "No local assignment linked" : "Assignment \(lastAssignmentRef!)",
+                systemImage: "point.3.connected.trianglepath.dotted"
+            ),
+            Row(
+                id: "assignment",
+                label: "Assignment status",
+                value: isStreaming ? "Streaming owner request" : "Idle",
+                systemImage: isStreaming ? "dot.radiowaves.left.and.right" : "checkmark.circle"
+            ),
+            Row(
+                id: "privacy",
+                label: "Default privacy",
+                value: "Public-safe summary only",
+                systemImage: "lock.shield"
+            ),
+            Row(
+                id: "storage",
+                label: "Local history",
+                value: isUsingEphemeralFallback ? "Ephemeral for this session" : "\(conversationCount) local chats",
+                systemImage: "internaldrive"
+            ),
+        ]
+
+        let bundleID = bundle.bundleIdentifier ?? "unknown"
+        let version = [
+            bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
+        ]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        let rawRows = [
+            Row(
+                id: "raw-channel",
+                label: "Channel",
+                value: channelName,
+                systemImage: "bubble.left.and.bubble.right"
+            ),
+            Row(
+                id: "raw-bundle",
+                label: "Bundle",
+                value: [bundleID, version].filter { !$0.isEmpty }.joined(separator: " "),
+                systemImage: "app"
+            ),
+            Row(
+                id: "raw-key",
+                label: "Keychain",
+                value: hasAPIKey ? "API key present: \(redactSecret("oa_agent_local_key_present"))" : "No API key stored",
+                systemImage: "key"
+            ),
+            Row(
+                id: "raw-store",
+                label: "Store",
+                value: redactSensitiveText(localSupportPath(processInfo: processInfo)),
+                systemImage: "folder"
+            ),
+            Row(
+                id: "raw-transcript",
+                label: "Active transcript",
+                value: "\(messages.count) messages; prompts/content hidden in default view",
+                systemImage: "text.bubble"
+            ),
+        ]
+
+        return LocalDiagnosticsSnapshot(
+            generatedAt: generatedAt,
+            publicRows: publicRows,
+            rawRows: rawRows
+        )
+    }
+
+    static func redactSensitiveText(_ value: String) -> String {
+        var redacted = value
+
+        let patterns = [
+            #"oa_agent_[A-Za-z0-9._:-]+"#,
+            #"(?i)bearer\s+[A-Za-z0-9._~+/=-]+"#,
+            #"(?i)(api[_ -]?key|authorization|password|private[_ -]?key|mnemonic|secret)\s*[:=]\s*[^\s,;]+"#,
+            #"spark1[A-Za-z0-9]+"#,
+            #"/Users/[^/\s]+(?:/[^\s,;:]+)*"#,
+            #"~/.codex(?:/[^\s,;:]+)*"#,
+        ]
+
+        for pattern in patterns {
+            redacted = redacted.replacingOccurrences(
+                of: pattern,
+                with: replacement(for: pattern),
+                options: .regularExpression
+            )
+        }
+        return redacted
+    }
+
+    private static func replacement(for pattern: String) -> String {
+        if pattern.contains("/Users/") || pattern.contains("~/.codex") {
+            return "<local-path>"
+        }
+        return "<redacted>"
+    }
+
+    private static func redactSecret(_ value: String) -> String {
+        redactSensitiveText(value)
+    }
+
+    private static func localSupportPath(processInfo: ProcessInfo) -> String {
+        if let override = processInfo.environment["KHALA_DIAGNOSTICS_STORE_PATH"], !override.isEmpty {
+            return override
+        }
+
+        return FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("Khala", isDirectory: true)
+            .path ?? "Application Support/Khala"
+    }
+
+    private static func firstAssignmentRef(in text: String) -> String? {
+        guard let match = text.range(
+            of: #"Assignment:\s*([A-Za-z0-9_.:-]+)"#,
+            options: .regularExpression
+        ) else {
+            return nil
+        }
+
+        let matched = String(text[match])
+        return matched
+            .replacingOccurrences(of: "Assignment:", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/clients/khala-ios/Khala/Khala/Shell/RootView.swift
+++ b/clients/khala-ios/Khala/Khala/Shell/RootView.swift
@@ -10,6 +10,7 @@ struct RootView: View {
 
     @State private var drawerOpen = false
     @State private var showSettings = false
+    @State private var showDiagnostics = false
     @State private var hasKey = Self.hasUsableAPIKey()
     @State private var didLaunch = false
     @State private var selection: Conversation?
@@ -35,6 +36,9 @@ struct RootView: View {
         }
         .sheet(isPresented: $showSettings) {
             SettingsView(hasKey: $hasKey)
+        }
+        .sheet(isPresented: $showDiagnostics) {
+            DiagnosticsView(snapshot: diagnosticsSnapshot)
         }
         .task { await onAppear() }
         .onChange(of: selection?.id) { _, _ in syncModel() }
@@ -96,6 +100,11 @@ struct RootView: View {
                             Label("Open traces in web", systemImage: "safari")
                         }
                         Button {
+                            showDiagnostics = true
+                        } label: {
+                            Label("Diagnostics", systemImage: "lock.shield")
+                        }
+                        Button {
                             showSettings = true
                         } label: {
                             Label("Settings", systemImage: "gearshape")
@@ -137,6 +146,17 @@ struct RootView: View {
 
     private var activeConversation: Conversation? {
         selection ?? store.mostRecent
+    }
+
+    private var diagnosticsSnapshot: LocalDiagnosticsSnapshot {
+        LocalDiagnosticsSnapshot.make(
+            hasAPIKey: hasKey,
+            channelName: channel.speaker,
+            isStreaming: model?.isStreaming ?? false,
+            activeConversation: activeConversation,
+            conversationCount: store.conversations.count,
+            isUsingEphemeralFallback: store.isUsingEphemeralFallback
+        )
     }
 
     private func modelFor(_ conversation: Conversation) -> ChatViewModel? {

--- a/clients/khala-ios/Khala/Khala/Views/DiagnosticsView.swift
+++ b/clients/khala-ios/Khala/Khala/Views/DiagnosticsView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct DiagnosticsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let snapshot: LocalDiagnosticsSnapshot
+    @State private var showOwnerRawDetail = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    ForEach(snapshot.publicRows) { row in
+                        DiagnosticsRow(row: row)
+                    }
+                } header: {
+                    Text("Public-safe summary")
+                } footer: {
+                    Text("This default view excludes prompts, raw command output, local paths, credentials, wallet material, and private repository data.")
+                }
+
+                Section {
+                    Toggle(isOn: $showOwnerRawDetail) {
+                        Label("Show owner-only raw local detail", systemImage: "lock.open")
+                    }
+                    .tint(.orange)
+
+                    if showOwnerRawDetail {
+                        ForEach(snapshot.rawRows) { row in
+                            DiagnosticsRow(row: row)
+                        }
+                    }
+                } header: {
+                    Text("Owner-only local access")
+                } footer: {
+                    Text("Raw diagnostics stay on this device. Values are still redacted before rendering and must not be copied into public reports or projections.")
+                }
+            }
+            .navigationTitle("Diagnostics")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+private struct DiagnosticsRow: View {
+    let row: LocalDiagnosticsSnapshot.Row
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: row.systemImage)
+                .frame(width: 22)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(row.label)
+                    .font(.subheadline.weight(.semibold))
+                Text(row.value)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/clients/khala-ios/Khala/KhalaTests/LocalDiagnosticsTests.swift
+++ b/clients/khala-ios/Khala/KhalaTests/LocalDiagnosticsTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+@testable import Khala
+import XCTest
+
+final class LocalDiagnosticsTests: XCTestCase {
+    func testDefaultSnapshotDoesNotRenderSecretsOrLocalPaths() {
+        let snapshot = LocalDiagnosticsSnapshot.make(
+            generatedAt: Date(timeIntervalSince1970: 0),
+            hasAPIKey: true,
+            channelName: "Artanis",
+            isStreaming: false,
+            activeConversation: nil,
+            conversationCount: 2,
+            isUsingEphemeralFallback: false
+        )
+
+        let publicText = snapshot.publicRows.map(\.value).joined(separator: "\n")
+        XCTAssertTrue(publicText.contains("Public-safe summary only"))
+        XCTAssertFalse(publicText.contains("oa_agent_"))
+        XCTAssertFalse(publicText.contains("/Users/"))
+        XCTAssertFalse(publicText.localizedCaseInsensitiveContains("prompt"))
+        XCTAssertFalse(publicText.localizedCaseInsensitiveContains("private key"))
+    }
+
+    func testRawDiagnosticsAreRedactedBeforeRendering() {
+        let raw = """
+        Authorization: Bearer oa_agent_secret_token
+        api_key=oa_agent_second_secret
+        path=/Users/operator/work/private-repo
+        wallet=spark1abc123
+        ~/.codex/auth.json
+        """
+
+        let redacted = LocalDiagnosticsSnapshot.redactSensitiveText(raw)
+
+        XCTAssertFalse(redacted.contains("oa_agent_secret_token"))
+        XCTAssertFalse(redacted.contains("oa_agent_second_secret"))
+        XCTAssertFalse(redacted.contains("/Users/operator"))
+        XCTAssertFalse(redacted.contains("spark1abc123"))
+        XCTAssertFalse(redacted.contains("~/.codex"))
+        XCTAssertTrue(redacted.contains("<redacted>"))
+        XCTAssertTrue(redacted.contains("<local-path>"))
+    }
+}


### PR DESCRIPTION
Addresses #6879.

### Changes
- Adds RootView state and sheet presentation for the local Diagnostics view.
- Adds a Diagnostics menu item with a lock shield icon.
- Builds a local diagnostics snapshot from API key, channel, streaming, conversation, count, and fallback state.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).