### PR TITLE
fix(khala-macos): add Apple FM readiness UI

### DIFF
--- a/clients/khala-ios/Khala/Khala/Net/AppleFMClient.swift
+++ b/clients/khala-ios/Khala/Khala/Net/AppleFMClient.swift
@@ -1,0 +1,264 @@
+import Foundation
+
+/// Attach-only client for the local Apple Foundation Models bridge.
+///
+/// The bridge is intentionally local and readiness-first. We always check
+/// `GET /health` before inference, and unsupported machines are modeled as an
+/// honest status rather than as a transport failure.
+enum AppleFMClient {
+    static let defaultBaseURL = URL(string: "http://127.0.0.1:11435")!
+    static let model = "apple-foundation-model"
+
+    enum Availability: String, Equatable, Sendable {
+        case ready
+        case unavailable
+        case unsupported
+    }
+
+    enum UsageTruth: String, Equatable, Sendable {
+        case exact
+        case estimated
+        case unknown
+    }
+
+    struct Status: Equatable, Sendable {
+        let availability: Availability
+        let baseURL: URL
+        let model: String
+        let message: String
+        let blockerRefs: [String]
+        let platform: String?
+
+        var isReady: Bool { availability == .ready }
+
+        static func unavailable(baseURL: URL, message: String, blockerRefs: [String]) -> Status {
+            Status(
+                availability: .unavailable,
+                baseURL: baseURL,
+                model: AppleFMClient.model,
+                message: message,
+                blockerRefs: blockerRefs,
+                platform: nil
+            )
+        }
+    }
+
+    struct Snapshot: Equatable, Sendable {
+        let content: String
+        let usageTruth: UsageTruth
+    }
+
+    enum AppleFMError: Error, LocalizedError, Equatable {
+        case notReady(Status)
+        case http(Int, String)
+        case decoding
+        case transport(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notReady(let status):
+                return status.message
+            case .http(let code, _):
+                return "Apple FM bridge returned HTTP \(code)."
+            case .decoding:
+                return "Could not read the Apple FM bridge response."
+            case .transport(let message):
+                return message
+            }
+        }
+    }
+
+    static func resolvedBaseURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
+        for key in ["PROBE_APPLE_FM_BASE_URL", "OPENAGENTS_APPLE_FM_BASE_URL"] {
+            if let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !raw.isEmpty,
+               let url = URL(string: raw) {
+                return url
+            }
+        }
+        return defaultBaseURL
+    }
+
+    static func health(
+        baseURL: URL = resolvedBaseURL(),
+        session: URLSession = .shared
+    ) async -> Status {
+        let url = baseURL.appendingPathComponent("health")
+        do {
+            let (data, response) = try await session.data(for: URLRequest(url: url))
+            guard let http = response as? HTTPURLResponse else {
+                return .unavailable(
+                    baseURL: baseURL,
+                    message: "The Apple FM bridge did not return an HTTP response.",
+                    blockerRefs: ["blocker.apple_fm.bridge_malformed_response"]
+                )
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                return .unavailable(
+                    baseURL: baseURL,
+                    message: "The Apple FM bridge is not ready (HTTP \(http.statusCode)).",
+                    blockerRefs: ["blocker.apple_fm.bridge_http_\(http.statusCode)"]
+                )
+            }
+            return parseHealth(data, baseURL: baseURL)
+        } catch {
+            return .unavailable(
+                baseURL: baseURL,
+                message: "Start the local Apple FM bridge at \(baseURL.absoluteString), then try again.",
+                blockerRefs: ["blocker.apple_fm.bridge_missing"]
+            )
+        }
+    }
+
+    static func streamSnapshotCompletion(
+        messages: [KhalaClient.OutgoingMessage],
+        baseURL: URL = resolvedBaseURL(),
+        session: URLSession = .shared
+    ) -> AsyncThrowingStream<Snapshot, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let status = await health(baseURL: baseURL, session: session)
+                    guard status.isReady else { throw AppleFMError.notReady(status) }
+
+                    let snapshot = try await completePlainText(
+                        messages: messages,
+                        baseURL: baseURL,
+                        session: session
+                    )
+                    continuation.yield(snapshot)
+                    continuation.finish()
+                } catch let error as AppleFMError {
+                    continuation.finish(throwing: error)
+                } catch let urlError as URLError where urlError.code == .cancelled {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: AppleFMError.transport(error.localizedDescription))
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private static func completePlainText(
+        messages: [KhalaClient.OutgoingMessage],
+        baseURL: URL,
+        session: URLSession
+    ) async throws -> Snapshot {
+        var request = URLRequest(url: baseURL.appendingPathComponent("v1/chat/completions"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let body: [String: Any] = [
+            "model": model,
+            "stream": false,
+            "messages": messages.map(\.json),
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw AppleFMError.decoding }
+        guard (200..<300).contains(http.statusCode) else {
+            throw AppleFMError.http(http.statusCode, String(data: data, encoding: .utf8) ?? "")
+        }
+        return try parseCompletion(data)
+    }
+
+    private static func parseHealth(_ data: Data, baseURL: URL) -> Status {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .unavailable(
+                baseURL: baseURL,
+                message: "The Apple FM bridge health response was not JSON.",
+                blockerRefs: ["blocker.apple_fm.malformed_health"]
+            )
+        }
+
+        let rawState = string(in: obj, keys: ["availability", "state", "status"])?.lowercased()
+        let ready = bool(in: obj, keys: ["ready", "isReady", "available"]) == true
+            || rawState == "ready"
+            || rawState == "ok"
+            || rawState == "healthy"
+        let blockers = stringArray(in: obj, keys: ["blockerRefs", "blockers", "reasons", "unavailableReasons"])
+        let lowerBlockers = blockers.map { $0.lowercased() }
+        let unsupported = rawState == "unsupported"
+            || bool(in: obj, keys: ["unsupported"]) == true
+            || lowerBlockers.contains(where: { $0.contains("unsupported") || $0.contains("not_admitted") })
+        let availability: Availability = ready ? .ready : (unsupported ? .unsupported : .unavailable)
+        let fallbackMessage: String
+        switch availability {
+        case .ready:
+            fallbackMessage = "Apple FM local backend ready."
+        case .unsupported:
+            fallbackMessage = "This Mac is not admitted for Apple FM yet."
+        case .unavailable:
+            fallbackMessage = "Apple FM bridge is reachable but not ready."
+        }
+
+        return Status(
+            availability: availability,
+            baseURL: baseURL,
+            model: string(in: obj, keys: ["model", "modelId"]) ?? model,
+            message: string(in: obj, keys: ["message", "detail", "reason"]) ?? fallbackMessage,
+            blockerRefs: blockers,
+            platform: string(in: obj, keys: ["platform", "system", "version"])
+        )
+    }
+
+    private static func parseCompletion(_ data: Data) throws -> Snapshot {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AppleFMError.decoding
+        }
+
+        let content: String?
+        if let choices = obj["choices"] as? [[String: Any]],
+           let first = choices.first {
+            if let message = first["message"] as? [String: Any] {
+                content = message["content"] as? String
+            } else {
+                content = first["text"] as? String
+            }
+        } else {
+            content = obj["content"] as? String ?? obj["text"] as? String
+        }
+        guard let content else { throw AppleFMError.decoding }
+
+        let usage = obj["usage"] as? [String: Any]
+        let rawTruth = (
+            string(in: usage ?? [:], keys: ["truth", "usageTruth", "measurement"])
+                ?? string(in: obj, keys: ["usageTruth"])
+                ?? ""
+        ).lowercased()
+        let usageTruth = UsageTruth(rawValue: rawTruth) ?? .unknown
+        return Snapshot(content: content, usageTruth: usageTruth)
+    }
+
+    private static func string(in obj: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let value = obj[key] as? String, !value.isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func bool(in obj: [String: Any], keys: [String]) -> Bool? {
+        for key in keys {
+            if let value = obj[key] as? Bool {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func stringArray(in obj: [String: Any], keys: [String]) -> [String] {
+        for key in keys {
+            if let values = obj[key] as? [String] {
+                return values
+            }
+            if let values = obj[key] as? [Any] {
+                return values.compactMap { $0 as? String }
+            }
+        }
+        return []
+    }
+}

--- a/clients/khala-ios/Khala/Khala/Shell/ChatView.swift
+++ b/clients/khala-ios/Khala/Khala/Shell/ChatView.swift
@@ -27,6 +27,9 @@ struct ChatView: View {
                         if messages.isEmpty && model.error == nil {
                             emptyState
                         } else {
+                            if model.channel == .appleFM {
+                                appleFMStatusPanel
+                            }
                             ForEach(messages) { message in
                                 MessageBubble(
                                     title: message.role == .user ? "You" : model.channel.speaker,
@@ -60,6 +63,7 @@ struct ChatView: View {
                 .background(.thinMaterial)
         }
         .onAppear {
+            model.refreshAppleFMStatus()
             // New/empty chat: autofocus the composer so the keyboard opens
             // immediately. A short delay lets the view settle so focus reliably
             // takes and the keyboard animates up.
@@ -98,6 +102,67 @@ struct ChatView: View {
             return "Collective intelligence behind a free API. Ask anything."
         case .artanis:
             return "You are talking to the operator agent that runs the loop — not the public Khala collective. Ask what it's working on."
+        case .appleFM:
+            return "Local Apple Foundation Models through the bridge on this Mac."
+        }
+    }
+
+    private var appleFMStatusPanel: some View {
+        let status = model.appleFMStatus
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: appleFMStatusIcon(status?.availability))
+                    .foregroundStyle(appleFMStatusColor(status?.availability))
+                Text(appleFMStatusTitle(status?.availability))
+                    .font(.callout.weight(.semibold))
+            }
+            Text(status?.message ?? "Checking the local Apple FM bridge.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("Bridge: \(status?.baseURL.absoluteString ?? AppleFMClient.resolvedBaseURL().absoluteString)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if let status, !status.blockerRefs.isEmpty {
+                Text(status.blockerRefs.joined(separator: "\n"))
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            Button(action: model.refreshAppleFMStatus) {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func appleFMStatusTitle(_ availability: AppleFMClient.Availability?) -> String {
+        switch availability {
+        case .ready: return "Apple FM ready"
+        case .unsupported: return "Apple FM unsupported"
+        case .unavailable: return "Apple FM unavailable"
+        case nil: return "Apple FM checking"
+        }
+    }
+
+    private func appleFMStatusIcon(_ availability: AppleFMClient.Availability?) -> String {
+        switch availability {
+        case .ready: return "checkmark.circle.fill"
+        case .unsupported: return "exclamationmark.triangle.fill"
+        case .unavailable: return "xmark.circle.fill"
+        case nil: return "clock"
+        }
+    }
+
+    private func appleFMStatusColor(_ availability: AppleFMClient.Availability?) -> Color {
+        switch availability {
+        case .ready: return .green
+        case .unsupported: return .orange
+        case .unavailable: return .red
+        case nil: return .secondary
         }
     }
 
@@ -168,7 +233,7 @@ struct ChatView: View {
     }
 
     private var canSend: Bool {
-        hasKey && !model.isStreaming
+        (!model.channel.requiresAPIKey || hasKey) && !model.isStreaming
             && !typedMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 

--- a/clients/khala-ios/Khala/Khala/Shell/ChatViewModel.swift
+++ b/clients/khala-ios/Khala/Khala/Shell/ChatViewModel.swift
@@ -31,12 +31,21 @@ final class ChatViewModel: ObservableObject {
     enum Channel: Equatable {
         case khala
         case artanis
+        case appleFM
 
         /// The name shown on the assistant's bubbles for this channel.
         var speaker: String {
             switch self {
             case .khala: return "Khala"
             case .artanis: return "Artanis"
+            case .appleFM: return "Apple FM"
+            }
+        }
+
+        var requiresAPIKey: Bool {
+            switch self {
+            case .khala, .artanis: return true
+            case .appleFM: return false
             }
         }
     }
@@ -56,6 +65,7 @@ final class ChatViewModel: ObservableObject {
     /// Inline error for the active turn (402 / network / HTTP). Cleared on the
     /// next send or retry.
     @Published private(set) var error: ChatError?
+    @Published private(set) var appleFMStatus: AppleFMClient.Status?
     /// Monotonic counter bumped on every streamed delta so the chat view can
     /// auto-scroll as the assistant turn grows (SwiftData content mutations do
     /// not always re-fire `onChange` on a stable identity).
@@ -98,7 +108,8 @@ final class ChatViewModel: ObservableObject {
         guard !trimmed.isEmpty else { return }
         guard !isStreaming else { return }
 
-        guard let key = KeychainStore.loadAPIKey() else {
+        let apiKey = KeychainStore.loadAPIKey()
+        guard !channel.requiresAPIKey || apiKey != nil else {
             error = ChatError(
                 title: KhalaClient.KhalaError.missingKey.recoveryTitle,
                 message: KhalaClient.KhalaError.missingKey.recoveryMessage,
@@ -113,7 +124,7 @@ final class ChatViewModel: ObservableObject {
             store.appendMessage(.user, content: trimmed, to: conversation)
         }
 
-        startStream(apiKey: key)
+        startStream(apiKey: apiKey)
     }
 
     /// Re-stream the last user turn: drop the most recent assistant turn (if any)
@@ -121,7 +132,8 @@ final class ChatViewModel: ObservableObject {
     /// `MessageBubble` regenerate hook.
     func regenerate() {
         guard !isStreaming else { return }
-        guard let key = KeychainStore.loadAPIKey() else {
+        let apiKey = KeychainStore.loadAPIKey()
+        guard !channel.requiresAPIKey || apiKey != nil else {
             error = ChatError(
                 title: KhalaClient.KhalaError.missingKey.recoveryTitle,
                 message: KhalaClient.KhalaError.missingKey.recoveryMessage,
@@ -138,7 +150,7 @@ final class ChatViewModel: ObservableObject {
         if let lastAssistant = conversation.sortedMessages.last(where: { $0.role == .assistant }) {
             store.deleteMessage(lastAssistant, from: conversation)
         }
-        startStream(apiKey: key)
+        startStream(apiKey: apiKey)
     }
 
     /// Retry after a retryable error (network / 5xx). The user turn is already
@@ -147,13 +159,12 @@ final class ChatViewModel: ObservableObject {
     /// retry produces a single clean reply.
     func retry() {
         guard !isStreaming, error?.isRetryable == true else { return }
-        guard let key = KeychainStore.loadAPIKey() else { return }
         error = nil
         if let trailingAssistant = conversation.sortedMessages.last,
            trailingAssistant.role == .assistant {
             store.deleteMessage(trailingAssistant, from: conversation)
         }
-        startStream(apiKey: key)
+        startStream(apiKey: KeychainStore.loadAPIKey())
     }
 
     /// Cancel the in-flight stream. Whatever streamed so far is kept and the
@@ -165,7 +176,15 @@ final class ChatViewModel: ObservableObject {
 
     // MARK: - Streaming core
 
-    private func startStream(apiKey: String) {
+    func refreshAppleFMStatus() {
+        guard channel == .appleFM else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            self.appleFMStatus = await AppleFMClient.health()
+        }
+    }
+
+    private func startStream(apiKey: String?) {
         // Build the outgoing history from the persisted transcript (multi-turn).
         let history = conversation.sortedMessages
             .filter { $0.role != .system && !$0.content.isEmpty }
@@ -182,20 +201,34 @@ final class ChatViewModel: ObservableObject {
         task = Task { [weak self] in
             guard let self else { return }
             do {
-                let stream = activeChannel == .artanis
-                    ? KhalaClient.streamArtanisCompletion(messages: history, apiKey: apiKey)
-                    : KhalaClient.streamCompletion(messages: history, apiKey: apiKey)
-                for try await delta in stream {
-                    // Append live; the SwiftData model is observable so the
-                    // bubble grows token-by-token.
-                    assistant.content += delta
-                    self.streamTick &+= 1
+                switch activeChannel {
+                case .khala:
+                    guard let apiKey else { throw KhalaClient.KhalaError.missingKey }
+                    for try await delta in KhalaClient.streamCompletion(messages: history, apiKey: apiKey) {
+                        assistant.content += delta
+                        self.streamTick &+= 1
+                    }
+                case .artanis:
+                    guard let apiKey else { throw KhalaClient.KhalaError.missingKey }
+                    for try await delta in KhalaClient.streamArtanisCompletion(messages: history, apiKey: apiKey) {
+                        assistant.content += delta
+                        self.streamTick &+= 1
+                    }
+                case .appleFM:
+                    for try await snapshot in AppleFMClient.streamSnapshotCompletion(messages: history) {
+                        // Apple FM bridge streams full snapshots, not token
+                        // deltas. Replace the active assistant text in place.
+                        assistant.content = snapshot.content
+                        self.streamTick &+= 1
+                    }
                 }
                 self.settle(assistant)
             } catch is CancellationError {
                 self.settle(assistant)
             } catch let khala as KhalaClient.KhalaError {
                 self.fail(khala, assistant: assistant)
+            } catch let appleFM as AppleFMClient.AppleFMError {
+                self.fail(appleFM, assistant: assistant)
             } catch {
                 self.fail(.transport(error), assistant: assistant)
             }
@@ -230,6 +263,25 @@ final class ChatViewModel: ObservableObject {
             title: khala.recoveryTitle,
             message: khala.recoveryMessage,
             isRetryable: khala.isRetryable
+        )
+        streamingMessageID = nil
+        isStreaming = false
+        task = nil
+    }
+
+    private func fail(_ appleFM: AppleFMClient.AppleFMError, assistant: Message) {
+        if case .notReady(let status) = appleFM {
+            appleFMStatus = status
+        }
+        if assistant.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            store.deleteMessage(assistant, from: conversation)
+        } else {
+            store.persist()
+        }
+        error = ChatError(
+            title: "Apple FM not ready",
+            message: appleFM.errorDescription ?? "Apple FM cannot run this turn yet.",
+            isRetryable: false
         )
         streamingMessageID = nil
         isStreaming = false

--- a/clients/khala-ios/Khala/Khala/Shell/RootView.swift
+++ b/clients/khala-ios/Khala/Khala/Shell/RootView.swift
@@ -86,6 +86,11 @@ struct RootView: View {
                             }
                         }
                         Button {
+                            switchChannel(to: .appleFM)
+                        } label: {
+                            Label("Use Apple FM", systemImage: "desktopcomputer")
+                        }
+                        Button {
                             openTracesInWeb(conversation: activeConversation)
                         } label: {
                             Label("Open traces in web", systemImage: "safari")
@@ -105,7 +110,7 @@ struct RootView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    .accessibilityLabel(channel == .artanis ? "Artanis menu" : "Khala menu")
+                    .accessibilityLabel("\(channel.speaker) menu")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(action: newChat) {

--- a/clients/khala-ios/Khala/Khala/Views/SettingsView.swift
+++ b/clients/khala-ios/Khala/Khala/Views/SettingsView.swift
@@ -78,6 +78,15 @@ struct SettingsView: View {
                     )
                     .font(.footnote)
                 }
+
+                Section("Apple FM local bridge") {
+                    Text("Apple FM uses the local bridge health endpoint before inference. Base URL order: PROBE_APPLE_FM_BASE_URL, OPENAGENTS_APPLE_FM_BASE_URL, then http://127.0.0.1:11435.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Text("If the bridge reports unsupported, use an admitted Apple Silicon Mac with Apple Intelligence enabled and the packaged helper installed/executable.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
             }
             .navigationTitle("Settings")
             .toolbar {

--- a/clients/khala-ios/Khala/KhalaTests/AppleFMClientTests.swift
+++ b/clients/khala-ios/Khala/KhalaTests/AppleFMClientTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+@testable import Khala
+import XCTest
+
+final class AppleFMClientTests: XCTestCase {
+    override func tearDown() {
+        AppleFMMockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testBaseURLResolutionUsesProbeThenOpenAgentsThenDefault() {
+        XCTAssertEqual(
+            AppleFMClient.resolvedBaseURL(environment: [
+                "PROBE_APPLE_FM_BASE_URL": "http://127.0.0.1:19001",
+                "OPENAGENTS_APPLE_FM_BASE_URL": "http://127.0.0.1:19002",
+            ]).absoluteString,
+            "http://127.0.0.1:19001"
+        )
+        XCTAssertEqual(
+            AppleFMClient.resolvedBaseURL(environment: [
+                "OPENAGENTS_APPLE_FM_BASE_URL": "http://127.0.0.1:19002",
+            ]).absoluteString,
+            "http://127.0.0.1:19002"
+        )
+        XCTAssertEqual(AppleFMClient.resolvedBaseURL(environment: [:]), AppleFMClient.defaultBaseURL)
+    }
+
+    func testHealthMapsReadyBridge() async throws {
+        let session = makeSession()
+        AppleFMMockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/health")
+            return (
+                Self.status(request, 200),
+                Data("""
+                {
+                  "ready": true,
+                  "model": "apple-foundation-model",
+                  "message": "ready",
+                  "platform": "macOS"
+                }
+                """.utf8)
+            )
+        }
+
+        let status = await AppleFMClient.health(baseURL: Self.baseURL, session: session)
+
+        XCTAssertEqual(status.availability, .ready)
+        XCTAssertTrue(status.isReady)
+        XCTAssertEqual(status.platform, "macOS")
+    }
+
+    func testHealthMapsUnsupportedAsNonFailure() async throws {
+        let session = makeSession()
+        AppleFMMockURLProtocol.requestHandler = { request in
+            (
+                Self.status(request, 200),
+                Data("""
+                {
+                  "state": "unsupported",
+                  "message": "Apple Intelligence is disabled.",
+                  "blockerRefs": ["blocker.apple_fm.apple_intelligence_disabled"]
+                }
+                """.utf8)
+            )
+        }
+
+        let status = await AppleFMClient.health(baseURL: Self.baseURL, session: session)
+
+        XCTAssertEqual(status.availability, .unsupported)
+        XCTAssertFalse(status.isReady)
+        XCTAssertEqual(status.blockerRefs, ["blocker.apple_fm.apple_intelligence_disabled"])
+    }
+
+    func testSnapshotCompletionChecksHealthBeforeInferenceAndCarriesUsageTruth() async throws {
+        let session = makeSession()
+        var paths: [String] = []
+        AppleFMMockURLProtocol.requestHandler = { request in
+            paths.append(request.url?.path ?? "")
+            if request.url?.path == "/health" {
+                return (Self.status(request, 200), Data(#"{ "ready": true }"#.utf8))
+            }
+            XCTAssertEqual(request.url?.path, "/v1/chat/completions")
+            let body = try XCTUnwrap(request.httpBodyStream.flatMap(Self.data(from:)))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(json["model"] as? String, AppleFMClient.model)
+            XCTAssertEqual(json["stream"] as? Bool, false)
+
+            return (
+                Self.status(request, 200),
+                Data("""
+                {
+                  "choices": [
+                    { "message": { "content": "local snapshot" } }
+                  ],
+                  "usage": { "truth": "estimated" }
+                }
+                """.utf8)
+            )
+        }
+
+        var snapshots: [AppleFMClient.Snapshot] = []
+        for try await snapshot in AppleFMClient.streamSnapshotCompletion(
+            messages: [.init(role: "user", content: "hello")],
+            baseURL: Self.baseURL,
+            session: session
+        ) {
+            snapshots.append(snapshot)
+        }
+
+        XCTAssertEqual(paths, ["/health", "/v1/chat/completions"])
+        XCTAssertEqual(snapshots, [.init(content: "local snapshot", usageTruth: .estimated)])
+    }
+
+    func testSnapshotCompletionRefusesBeforeInferenceWhenHealthIsNotReady() async throws {
+        let session = makeSession()
+        var paths: [String] = []
+        AppleFMMockURLProtocol.requestHandler = { request in
+            paths.append(request.url?.path ?? "")
+            return (
+                Self.status(request, 200),
+                Data("""
+                {
+                  "ready": false,
+                  "message": "helper missing",
+                  "blockers": ["blocker.apple_fm.helper_missing"]
+                }
+                """.utf8)
+            )
+        }
+
+        do {
+            for try await _ in AppleFMClient.streamSnapshotCompletion(
+                messages: [.init(role: "user", content: "hello")],
+                baseURL: Self.baseURL,
+                session: session
+            ) {}
+            XCTFail("Expected notReady")
+        } catch let error as AppleFMClient.AppleFMError {
+            guard case .notReady(let status) = error else {
+                return XCTFail("Expected notReady, got \(error)")
+            }
+            XCTAssertEqual(status.availability, .unavailable)
+            XCTAssertEqual(status.blockerRefs, ["blocker.apple_fm.helper_missing"])
+        }
+
+        XCTAssertEqual(paths, ["/health"])
+    }
+
+    private static let baseURL = URL(string: "http://apple-fm.test")!
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [AppleFMMockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    private static func status(_ request: URLRequest, _ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url!,
+            statusCode: code,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private static func data(from stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count > 0 { data.append(buffer, count: count) } else { break }
+        }
+        return data
+    }
+}
+
+private final class AppleFMMockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
Addresses #6873.

### Changes
- Adds Apple FM as a chat channel that can send without requiring a Khala API key.
- Shows a local Apple FM bridge readiness panel with availability, bridge URL, blocker refs, and a manual refresh action.
- Refreshes Apple FM status when the chat appears and wires the settings/root UI into the Apple FM lifecycle.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).