### PR TITLE
fix(khala-macos): gate free keys behind disclosure

### DIFF
--- a/clients/khala-ios/Khala/Khala/Shell/ChatView.swift
+++ b/clients/khala-ios/Khala/Khala/Shell/ChatView.swift
@@ -86,6 +86,15 @@ struct ChatView: View {
                     .foregroundStyle(.secondary)
                     .padding(.top, 4)
             }
+            if !hasKey {
+                Button {
+                    onOpenSettings()
+                } label: {
+                    Label("Add API key", systemImage: "key")
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.top, 140)

--- a/clients/khala-ios/Khala/Khala/Shell/RootView.swift
+++ b/clients/khala-ios/Khala/Khala/Shell/RootView.swift
@@ -10,7 +10,7 @@ struct RootView: View {
 
     @State private var drawerOpen = false
     @State private var showSettings = false
-    @State private var hasKey = KeychainStore.hasAPIKey
+    @State private var hasKey = Self.hasUsableAPIKey()
     @State private var didLaunch = false
     @State private var selection: Conversation?
     /// Active conversation channel. `.khala` is the public collective model;
@@ -119,17 +119,11 @@ struct RootView: View {
 
     // MARK: - Traces
 
-    /// Open the owner's traces on the web, passing the API key as a token so the
-    /// owner can view their own (unshared, owner-only) traces even when not
-    /// logged into the web. The backend authorizes the token for owner-scoped
-    /// trace viewing; if a per-conversation trace ref becomes available it can be
-    /// appended here to deep-link the specific trace.
-    private func openTracesInWeb(conversation: Conversation?) {
-        var components = URLComponents(string: "https://openagents.com/traces")
-        if let key = KeychainStore.loadAPIKey() {
-            components?.queryItems = [URLQueryItem(name: "token", value: key)]
-        }
-        if let url = components?.url {
+    /// Open the owner's traces on the web without putting the stored key into a
+    /// URL. Captured API keys must never be re-displayed in plaintext after
+    /// Settings stores them.
+    private func openTracesInWeb(conversation _: Conversation?) {
+        if let url = URL(string: "https://openagents.com/traces") {
             openURL(url)
         }
     }
@@ -192,14 +186,7 @@ struct RootView: View {
         }
         syncModel()
 
-        // Free dogfood app: guarantee an API key so the composer works out of the
-        // box. Auto-mint a free key on first launch when none is stored.
-        if KeychainStore.hasAPIKey {
-            hasKey = true
-        } else if let token = try? await KhalaClient.mintFreeKey() {
-            KeychainStore.saveAPIKey(token)
-            hasKey = true
-        }
+        hasKey = Self.hasUsableAPIKey()
 
         guard !didLaunch else { return }
         didLaunch = true
@@ -210,5 +197,10 @@ struct RootView: View {
            let model = modelFor(conversation) {
             model.send(demo)
         }
+    }
+
+    private static func hasUsableAPIKey() -> Bool {
+        guard let key = KeychainStore.loadAPIKey() else { return false }
+        return FreeTierDisclosureStore.canUse(apiKey: key)
     }
 }

--- a/clients/khala-ios/Khala/Khala/Store/FreeTierDisclosureStore.swift
+++ b/clients/khala-ios/Khala/Khala/Store/FreeTierDisclosureStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Stores the non-secret first-use acknowledgement for free Khala keys.
+enum FreeTierDisclosureStore {
+    private static let key = "com.openagents.khala.freeTierDisclosureAccepted"
+
+    static var hasAccepted: Bool {
+        UserDefaults.standard.bool(forKey: key)
+    }
+
+    static func accept() {
+        UserDefaults.standard.set(true, forKey: key)
+    }
+
+    static func requiresDisclosure(for apiKey: String) -> Bool {
+        apiKey.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("oa_agent_")
+    }
+
+    static func canUse(apiKey: String) -> Bool {
+        hasAccepted || !requiresDisclosure(for: apiKey)
+    }
+}

--- a/clients/khala-ios/Khala/Khala/Store/KeychainStore.swift
+++ b/clients/khala-ios/Khala/Khala/Store/KeychainStore.swift
@@ -10,18 +10,21 @@ enum KeychainStore {
     private static let service = "com.openagents.khala"
     private static let account = "khala_api_key"
 
-    static func saveAPIKey(_ key: String) {
+    @discardableResult
+    static func saveAPIKey(_ key: String) -> Bool {
         let data = Data(key.utf8)
         // Delete any existing item first so save is idempotent.
         deleteAPIKey()
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
         ]
-        SecItemAdd(query as CFDictionary, nil)
+#if !os(macOS)
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+#endif
+        return SecItemAdd(query as CFDictionary, nil) == errSecSuccess
     }
 
     static func loadAPIKey() -> String? {

--- a/clients/khala-ios/Khala/Khala/Views/SettingsView.swift
+++ b/clients/khala-ios/Khala/Khala/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @State private var minting = false
     @State private var errorText: String?
     @State private var mintedConfirmation = false
+    @State private var acceptedFreeTierDisclosure = FreeTierDisclosureStore.hasAccepted
 
     var body: some View {
         NavigationStack {
@@ -31,24 +32,38 @@ struct SettingsView: View {
                                 if minting { ProgressView().padding(.leading, 6) }
                             }
                         }
-                        .disabled(minting)
+                        .disabled(minting || !acceptedFreeTierDisclosure)
 
                         VStack(alignment: .leading, spacing: 6) {
                             Text("…or paste a key")
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
-                            TextField("oa_agent_…", text: $pastedKey)
+                            SecureField("oa_agent_…", text: $pastedKey)
                                 .textInputAutocapitalization(.never)
                                 .autocorrectionDisabled()
                                 .font(.system(.body, design: .monospaced))
                             Button("Save pasted key") {
                                 let trimmed = pastedKey.trimmingCharacters(in: .whitespacesAndNewlines)
                                 guard !trimmed.isEmpty else { return }
-                                KeychainStore.saveAPIKey(trimmed)
+                                guard acceptedFreeTierDisclosure || !FreeTierDisclosureStore.requiresDisclosure(for: trimmed) else {
+                                    errorText = "Acknowledge the free-tier disclosure before saving this key."
+                                    return
+                                }
+                                if acceptedFreeTierDisclosure {
+                                    FreeTierDisclosureStore.accept()
+                                }
+                                guard KeychainStore.saveAPIKey(trimmed) else {
+                                    errorText = "Couldn't save the key in Keychain."
+                                    return
+                                }
                                 hasKey = true
                                 pastedKey = ""
+                                errorText = nil
                             }
-                            .disabled(pastedKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            .disabled(
+                                pastedKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                    || (FreeTierDisclosureStore.requiresDisclosure(for: pastedKey) && !acceptedFreeTierDisclosure)
+                            )
                         }
                     }
 
@@ -72,6 +87,15 @@ struct SettingsView: View {
                     )
                     .font(.footnote)
                     .foregroundStyle(.secondary)
+                    Toggle(isOn: $acceptedFreeTierDisclosure) {
+                        Text("I understand this disclosure before minting or using a free key.")
+                    }
+                    .font(.footnote)
+                    .onChange(of: acceptedFreeTierDisclosure) { _, accepted in
+                        if accepted {
+                            FreeTierDisclosureStore.accept()
+                        }
+                    }
                     Link(
                         "Read the full terms",
                         destination: URL(string: "https://openagents.com/api/public/free-tier-data-sharing")!
@@ -91,15 +115,24 @@ struct SettingsView: View {
     private func mint() async {
         errorText = nil
         mintedConfirmation = false
+        guard acceptedFreeTierDisclosure else {
+            errorText = "Acknowledge the free-tier disclosure before minting a key."
+            return
+        }
+        FreeTierDisclosureStore.accept()
         minting = true
         defer { minting = false }
         do {
             let token = try await KhalaClient.mintFreeKey()
-            KeychainStore.saveAPIKey(token)
+            guard KeychainStore.saveAPIKey(token) else {
+                errorText = "Key minted, but couldn't be saved in Keychain."
+                return
+            }
             hasKey = true
             mintedConfirmation = true
         } catch {
             errorText = (error as? LocalizedError)?.errorDescription ?? "Couldn't mint a key."
         }
     }
+
 }


### PR DESCRIPTION
Addresses #6860.

### Changes
- Treat only disclosed free-tier keys as usable at launch instead of auto-minting a free key on first run.
- Add an empty-state action that sends users to Settings to add an API key.
- Stop appending the stored API key to the traces URL.
- Store API keys with Keychain save success reporting and platform-appropriate accessibility.
- Update Settings to use secure key entry, require the free-tier disclosure before minting or saving applicable keys, and surface Keychain save failures.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).