### PR TITLE
fix(autopilot): add typed decision command API

### DIFF
--- a/apps/openagents.com/workers/api/src/autopilot-decision-act-routing.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-decision-act-routing.test.ts
@@ -76,6 +76,7 @@ describe('classifyAutopilotDecisionActRoute', () => {
   it('routes every other actionable kind to the evidence-command path', () => {
     for (const kind of [
       'continue',
+      'create_followup_mission',
       'provide_context',
       'rerun_tests',
       'retry_account',
@@ -96,7 +97,6 @@ describe('classifyAutopilotDecisionActRoute', () => {
 
   it('marks informational/blocked kinds as not actionable', () => {
     for (const kind of [
-      'create_followup_mission',
       'mark_unavailable',
       'request_customer_input',
     ] as const) {

--- a/apps/openagents.com/workers/api/src/autopilot-decision-act.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-decision-act.test.ts
@@ -70,6 +70,9 @@ describe('authorizeAutopilotDecisionAct', () => {
       expect(result.ok).toBe(true)
     }
     expect(AUTOPILOT_DECISION_ACTIONABLE_KINDS).toContain('approve_pr_draft')
+    expect(AUTOPILOT_DECISION_ACTIONABLE_KINDS).toContain(
+      'create_followup_mission',
+    )
     expect(AUTOPILOT_DECISION_ACTIONABLE_KINDS.length).toBeGreaterThan(1)
   })
 

--- a/apps/openagents.com/workers/api/src/autopilot-decision-act.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-decision-act.ts
@@ -28,6 +28,7 @@ import type {
 export const AUTOPILOT_DECISION_ACTIONABLE_KINDS = [
   'approve_pr_draft',
   'continue',
+  'create_followup_mission',
   'provide_context',
   'rerun_tests',
   'retry_account',

--- a/apps/openagents.com/workers/api/src/autopilot-decision-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-decision-routes.test.ts
@@ -495,6 +495,110 @@ describe('autopilot decision queue routes', () => {
     )
   })
 
+  test('accepts the public accept command name for the review action', async () => {
+    const store = new MemoryAutopilotWorkStore()
+
+    await store.createWorkOrder(deliveredWorkOrderRecord())
+
+    const response = await route(
+      store,
+      '/api/autopilot/decisions/decision_action.autopilot_work_order.decision_test_1.approve_pr_draft/actions',
+      {
+        body: { action: 'accept' },
+        idempotencyKey: 'decision-public-accept-1',
+        method: 'POST',
+      },
+    )
+    const body = (await response.json()) as DecisionActBody
+
+    expect(response.status).toBe(201)
+    expect(body.work.state).toBe('accepted')
+    expect(body.decision?.receiptRefs).toContain(
+      'decision.queue.accept.autopilot_work_order.decision_test_1',
+    )
+  })
+
+  test('rejects unknown public decision commands at the schema boundary', async () => {
+    const store = new MemoryAutopilotWorkStore()
+
+    await store.createWorkOrder(deliveredWorkOrderRecord())
+
+    const response = await route(
+      store,
+      '/api/autopilot/decisions/decision_action.autopilot_work_order.decision_test_1.approve_pr_draft/actions',
+      {
+        body: { action: 'delete-repo' },
+        idempotencyKey: 'decision-unknown-command-1',
+        method: 'POST',
+      },
+    )
+
+    expect(response.status).toBe(400)
+  })
+
+  test('requires owner approval before sensitive evidence commands apply', async () => {
+    const store = new MemoryAutopilotWorkStore()
+
+    await store.createWorkOrder(workOrderRecord())
+
+    const response = await route(
+      store,
+      '/api/autopilot/decisions/decision_action.autopilot_work_order.decision_test_1.stop/actions',
+      {
+        body: { action: 'stop' },
+        idempotencyKey: 'decision-stop-1',
+        method: 'POST',
+      },
+    )
+    const body = (await response.json()) as DecisionActBody & Readonly<{
+      authorityBoundary: string
+      reason: string
+    }>
+
+    expect(response.status).toBe(403)
+    expect(body.error).toBe('autopilot_decision_owner_approval_required')
+    expect(body.authorityBoundary).toBe('owner_approval_required')
+    expect(body.reason).toContain('ownerApprovalRef')
+  })
+
+  test('accepts typed evidence commands with owner approval as evidence-only receipts', async () => {
+    const store = new MemoryAutopilotWorkStore()
+
+    await store.createWorkOrder(workOrderRecord())
+
+    const response = await route(
+      store,
+      '/api/autopilot/decisions/decision_action.autopilot_work_order.decision_test_1.stop/actions',
+      {
+        body: {
+          action: 'stop',
+          ownerApprovalRef: 'approval.public.autopilot.stop.test',
+        },
+        idempotencyKey: 'decision-stop-approved-1',
+        method: 'POST',
+      },
+    )
+    const body = (await response.json()) as Readonly<{
+      command: Readonly<{
+        authorityBoundary: string
+        directEffectPermitted: false
+        ownerApprovalRef: string
+        resolution: string
+      }>
+      directEffectPermitted: false
+      receipt: Readonly<{ outcome: string }>
+    }>
+
+    expect(response.status).toBe(202)
+    expect(body.directEffectPermitted).toBe(false)
+    expect(body.command.resolution).toBe('stop')
+    expect(body.command.ownerApprovalRef).toBe(
+      'approval.public.autopilot.stop.test',
+    )
+    expect(body.command.authorityBoundary).toBe('evidence_only')
+    expect(body.receipt.outcome).toBe('accepted_for_evidence')
+  })
+
   test('replays an identical decision action idempotently', async () => {
     const store = new MemoryAutopilotWorkStore()
 

--- a/apps/openagents.com/workers/api/src/autopilot-decision-routes.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-decision-routes.ts
@@ -2,6 +2,14 @@ import { Effect, Match as M, Schema as S } from 'effect'
 
 import type { AgentRegistrationStore } from './agent-registration'
 import { sha256Hex } from './agent-registration'
+import {
+  type AutopilotDecisionActionableKind,
+  type AutopilotDecisionActRequest as EvidenceAutopilotDecisionActRequest,
+  authorizeAutopilotDecisionAct,
+} from './autopilot-decision-act'
+import {
+  classifyAutopilotDecisionActRoute,
+} from './autopilot-decision-act-routing'
 import { buildAutopilotDecisionCloseoutReceipt } from './autopilot-decision-closeout'
 import {
   type AutopilotWorkOrderRecord,
@@ -52,13 +60,79 @@ const safeDecisionRefs = (
     decisionRefPattern.test(ref)
   ))].sort()
 
+export const AutopilotDecisionCommandAction = S.Literals([
+  'accept',
+  'continue',
+  'create-follow-up-mission',
+  'provide-context',
+  'rerun-tests',
+  'retry-with-another-account',
+  'steer',
+  'stop',
+])
+export type AutopilotDecisionCommandAction =
+  typeof AutopilotDecisionCommandAction.Type
+
+const LegacyAutopilotDecisionReviewAction = S.Literals([
+  'reject',
+  'request_changes',
+])
+
 const AutopilotDecisionActRequest = S.Struct({
-  action: S.Literals(['accept', 'reject', 'request_changes']),
+  action: S.Union([
+    AutopilotDecisionCommandAction,
+    LegacyAutopilotDecisionReviewAction,
+  ]),
+  contextRefs: S.optionalKey(S.Array(S.String)),
   decisionRefs: S.optionalKey(S.Array(S.String)),
+  ownerApprovalRef: S.optionalKey(S.String),
   rejectionRefs: S.optionalKey(S.Array(S.String)),
   revisionRequestRefs: S.optionalKey(S.Array(S.String)),
 })
 type AutopilotDecisionActRequest = typeof AutopilotDecisionActRequest.Type
+
+const commandActionToDecisionKind: Record<
+  AutopilotDecisionCommandAction,
+  AutopilotDecisionActionableKind
+> = {
+  accept: 'approve_pr_draft',
+  continue: 'continue',
+  'create-follow-up-mission': 'create_followup_mission',
+  'provide-context': 'provide_context',
+  'rerun-tests': 'rerun_tests',
+  'retry-with-another-account': 'retry_account',
+  steer: 'steer',
+  stop: 'stop',
+}
+
+const ownerApprovalRequiredActions: ReadonlySet<AutopilotDecisionCommandAction> =
+  new Set([
+    'create-follow-up-mission',
+    'retry-with-another-account',
+    'stop',
+  ])
+
+const evidenceRequestForCommand = (
+  body: AutopilotDecisionActRequest,
+): EvidenceAutopilotDecisionActRequest | undefined => {
+  if (body.action === 'reject' || body.action === 'request_changes') {
+    return undefined
+  }
+
+  const resolution = commandActionToDecisionKind[body.action]
+
+  if (resolution === 'approve_pr_draft') {
+    return undefined
+  }
+
+  return {
+    resolution,
+    verb: 'submit',
+    ...(body.contextRefs === undefined
+      ? {}
+      : { contextRefs: body.contextRefs }),
+  }
+}
 
 export type AutopilotWorkDecisionContext = Readonly<{
   createdAt: string
@@ -317,7 +391,9 @@ const validateDecisionActRefs = (
   body: AutopilotDecisionActRequest,
 ): Effect.Effect<AutopilotDecisionActRequest, AutopilotWorkStoreError> => {
   const provided = [
+    ...(body.contextRefs ?? []),
     ...(body.decisionRefs ?? []),
+    ...(body.ownerApprovalRef === undefined ? [] : [body.ownerApprovalRef]),
     ...(body.rejectionRefs ?? []),
     ...(body.revisionRequestRefs ?? []),
   ]
@@ -352,28 +428,38 @@ const reviewDecisionForDecisionAct = (
     workOrderRef: string
   }>,
 ): AutopilotWorkReviewDecisionRecord => {
-  const defaultRef =
-    `decision.queue.${input.body.action}.${input.workOrderRef}`
+  const action = reviewActionForCommand(input.body)
+  const defaultRef = `decision.queue.${action}.${input.workOrderRef}`
 
   return {
-    action: input.body.action,
+    action,
     actorAgentCredentialId: input.actorAgentCredentialId,
     actorAgentUserId: input.actorAgentUserId,
-    decisionRefs: input.body.action === 'accept'
+    decisionRefs: action === 'accept'
       ? safeDecisionRefs([...(input.body.decisionRefs ?? []), defaultRef])
       : safeDecisionRefs(input.body.decisionRefs ?? []),
     idempotencyKeyHash: input.idempotencyKeyHash,
     recordedAt: input.nowIso,
-    rejectionRefs: input.body.action === 'reject'
+    rejectionRefs: action === 'reject'
       ? safeDecisionRefs([...(input.body.rejectionRefs ?? []), defaultRef])
       : safeDecisionRefs(input.body.rejectionRefs ?? []),
-    revisionRequestRefs: input.body.action === 'request_changes'
+    revisionRequestRefs: action === 'request_changes'
       ? safeDecisionRefs([
           ...(input.body.revisionRequestRefs ?? []),
           defaultRef,
         ])
       : safeDecisionRefs(input.body.revisionRequestRefs ?? []),
   }
+}
+
+const reviewActionForCommand = (
+  body: AutopilotDecisionActRequest,
+): AutopilotWorkReviewAction => {
+  if (body.action === 'reject' || body.action === 'request_changes') {
+    return body.action
+  }
+
+  return 'accept'
 }
 
 const decisionActionsRefFromPath = (pathname: string): string | undefined => {
@@ -385,9 +471,33 @@ const decisionActionsRefFromPath = (pathname: string): string | undefined => {
 const workOrderRefFromDecisionRef = (
   decisionRef: string,
 ): string | undefined => {
-  const match = /^decision_action\.(.+)\.approve_pr_draft$/.exec(decisionRef)
+  const match = /^decision_action\.(.+)\.[A-Za-z0-9_]+$/.exec(decisionRef)
 
   return match?.[1]
+}
+
+const decisionKindFromDecisionRef = (
+  decisionRef: string,
+): CodingAutopilotDecisionActionKind | undefined => {
+  const match = /^decision_action\..+\.([A-Za-z0-9_]+)$/.exec(decisionRef)
+  const kind = match?.[1]
+
+  if (
+    kind === 'approve_pr_draft' ||
+    kind === 'continue' ||
+    kind === 'create_followup_mission' ||
+    kind === 'mark_unavailable' ||
+    kind === 'provide_context' ||
+    kind === 'request_customer_input' ||
+    kind === 'rerun_tests' ||
+    kind === 'retry_account' ||
+    kind === 'steer' ||
+    kind === 'stop'
+  ) {
+    return kind
+  }
+
+  return undefined
 }
 
 const listDecisions = <Bindings extends AutopilotDecisionRouteEnv>(
@@ -458,12 +568,13 @@ const actOnDecision = <Bindings extends AutopilotDecisionRouteEnv>(
       },
     )
     const workOrderRef = workOrderRefFromDecisionRef(decisionRef)
+    const decisionKind = decisionKindFromDecisionRef(decisionRef)
 
-    if (workOrderRef === undefined) {
+    if (workOrderRef === undefined || decisionKind === undefined) {
       return yield* new AutopilotWorkStoreError({
         kind: 'validation_error',
         reason:
-          'Only approve_pr_draft decision actions are actionable through the decision queue.',
+          'Autopilot decision action refs must name a known decision kind.',
       })
     }
 
@@ -472,6 +583,90 @@ const actOnDecision = <Bindings extends AutopilotDecisionRouteEnv>(
       decodeDecisionActRequest(request),
       validateDecisionActRefs,
     )
+    const expectedKind = body.action === 'reject' || body.action === 'request_changes'
+      ? 'approve_pr_draft'
+      : commandActionToDecisionKind[body.action]
+
+    if (expectedKind !== decisionKind) {
+      return yield* new AutopilotWorkStoreError({
+        kind: 'validation_error',
+        reason:
+          `Decision command ${body.action} cannot resolve ${decisionKind}.`,
+      })
+    }
+
+    if (
+      body.action !== 'reject' &&
+      body.action !== 'request_changes' &&
+      ownerApprovalRequiredActions.has(body.action) &&
+      (body.ownerApprovalRef ?? '').trim() === ''
+    ) {
+      return noStoreJsonResponse(
+        {
+          authorityBoundary: 'owner_approval_required',
+          directEffectPermitted: false,
+          error: 'autopilot_decision_owner_approval_required',
+          generatedAt: nowIso,
+          idempotent: false,
+          reason:
+            `Decision command ${body.action} requires ownerApprovalRef before it can be applied.`,
+        },
+        { status: 403 },
+      )
+    }
+
+    if (decisionKind !== 'approve_pr_draft') {
+      const evidenceRequest = evidenceRequestForCommand(body)
+      const routing = classifyAutopilotDecisionActRoute({
+        actionKind: decisionKind,
+        actionRef: decisionRef,
+        status: 'available',
+      })
+
+      if (routing.route !== 'evidence_command' || evidenceRequest === undefined) {
+        return yield* new AutopilotWorkStoreError({
+          kind: 'validation_error',
+          reason:
+            `Decision kind ${decisionKind} is not actionable through this command API.`,
+        })
+      }
+
+      const authorized = authorizeAutopilotDecisionAct({
+        request: evidenceRequest,
+        target: routing.target,
+      })
+
+      if (!authorized.ok) {
+        return noStoreJsonResponse(
+          {
+            directEffectPermitted: false,
+            error: 'autopilot_decision_command_rejected',
+            errors: authorized.errors,
+            generatedAt: nowIso,
+            idempotent: false,
+          },
+          { status: 400 },
+        )
+      }
+
+      return noStoreJsonResponse(
+        {
+          command: {
+            ...authorized.command,
+            ownerApprovalRef: body.ownerApprovalRef ?? null,
+          },
+          directEffectPermitted: false,
+          generatedAt: nowIso,
+          idempotent: false,
+          receipt: {
+            closeoutRef: authorized.command.closeoutRef,
+            outcome: 'accepted_for_evidence',
+          },
+        },
+        { status: 202 },
+      )
+    }
+
     const reviewDecision = reviewDecisionForDecisionAct({
       actorAgentCredentialId: auth.actorAgentCredentialId,
       actorAgentUserId: auth.actorAgentUserId,
@@ -492,7 +687,7 @@ const actOnDecision = <Bindings extends AutopilotDecisionRouteEnv>(
         dependencies.makeStore(env).recordReviewDecision({
           ownerUserId: auth.ownerUserId,
           reviewDecision,
-          state: reviewStateForAction(body.action),
+          state: reviewStateForAction(reviewDecision.action),
           updatedAt: nowIso,
           workOrderRef,
         }),

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1633,10 +1633,10 @@ const schemaComponents = (): JsonSchema => ({
     'Autopilot decision queue envelope with generatedAt, pendingCount, directEffectPermitted: false, and decision items. Each item pairs a customer-audience decision-action projection (actionKind, actionLabel, status, statusLabel, safeSummaryRef, customerNextActionRef, blockedReasonRefs, evidenceRefs, receiptRefs, actionSubmissionRequired, directEffectPermitted: false) with the public-safe work-order context (workOrderRef, state, taskRefs, updatedAt). Decisions are evidence pointers to gated submissions; the queue grants no deploy, spend, payout, or settlement authority.',
   ),
   AutopilotDecisionActionRequest: objectSummary(
-    'Public-safe Autopilot decision action request. action is accept, reject, or request_changes; optional decisionRefs, rejectionRefs, and revisionRequestRefs arrays must contain public-safe refs only. A default decision.queue.<action>.<workOrderRef> ref is recorded when none is supplied.',
+    'Public-safe Autopilot decision action request. action is one of accept, continue, steer, provide-context, rerun-tests, retry-with-another-account, stop, create-follow-up-mission, plus legacy review actions reject and request_changes. Optional contextRefs, decisionRefs, ownerApprovalRef, rejectionRefs, and revisionRequestRefs must contain public-safe refs only. Sensitive evidence commands require ownerApprovalRef; the delivered-work accept path records a default decision.queue.<action>.<workOrderRef> ref when none is supplied.',
   ),
   AutopilotDecisionActionEnvelope: objectSummary(
-    'Autopilot decision action envelope with generatedAt, idempotent flag, directEffectPermitted: false, the completed decision-action projection, and the public-safe work-order context after the gated review submission was recorded.',
+    'Autopilot decision action envelope with generatedAt, idempotent flag, and directEffectPermitted: false. The delivered-work accept path returns the completed decision-action projection and public-safe work-order context after the gated review submission is recorded; non-review command responses return an evidence-only command receipt and never grant direct effect authority.',
   ),
   XClaimRewardDispatchRequest: objectSummary(
     'Operator dispatch action for a promotional X-claim reward: action (approve_dispatch, mark_dispatched, mark_settled, mark_failed, refuse), optional public-safe evidenceRefs (required for mark_settled), optional stateReasonRef.',
@@ -9453,7 +9453,7 @@ const paths = (): JsonSchema => ({
       operationId: 'actOnAutopilotDecision',
       summary: 'Act on a pending Autopilot decision',
       description:
-        'Records a one-tap decision action (accept, reject, or request_changes) for a pending approve_pr_draft decision as a gated review submission on the underlying delivered work order. Decision actions are evidence pointers only: directEffectPermitted stays false and the action grants no deploy authority, worker payout authority, settlement authority, or Forum publication authority. Requires customer_orders.write and Idempotency-Key; retrying the same idempotency key replays the recorded decision.',
+        'Records a one-tap decision command for the public decision queue. The delivered-work accept command for approve_pr_draft is applied as a gated review submission on the underlying delivered work order; the legacy reject/request_changes review actions remain accepted for compatibility. Continue, steer, provide-context, rerun-tests, retry-with-another-account, stop, and create-follow-up-mission are decoded as explicit typed commands and remain evidence-only; sensitive commands require ownerApprovalRef. Decision actions are evidence pointers only: directEffectPermitted stays false and the action grants no deploy authority, worker payout authority, settlement authority, or Forum publication authority. Requires customer_orders.write and Idempotency-Key; retrying the same idempotency key on the review path replays the recorded decision.',
       tags: ['Autopilot Work'],
       security: browserSessionOrAgentBearer,
       parameters: [

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1691,7 +1691,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Autopilot should expose a decision queue for continue, steer, provide context, rerun tests, retry with another account, stop, accept, or create a follow-up mission.',
         safeCopy:
-          'Decision-queue actions are planned/scoped and must remain route-authorized and receipt-backed. The exactly-once decision queue spanning desktop / web / Expo is tracked as Coder Cloud Phase 3 (#5004), gated behind the Pylon remote bridge transport (#5000); workroom decisions and voice command proposals provide precursor decision/approval state.',
+          'Decision-queue actions are planned/scoped and must remain route-authorized and receipt-backed. A Worker command route now decodes the public action enum, requires Idempotency-Key, applies the delivered-work accept command through the review store, and keeps non-review commands evidence-only with owner-approval gating where required. The exactly-once decision queue spanning desktop / web / Expo is still tracked as Coder Cloud Phase 3 (#5004), gated behind the Pylon remote bridge transport (#5000); workroom decisions and voice command proposals provide precursor decision/approval state.',
         unsafeCopy:
           'Do not claim agents can freely continue, retry, spend, mutate repositories, or switch accounts from public docs, or that the cross-client decision queue is live.',
         evidenceRefs: [
@@ -1702,17 +1702,21 @@ export const publicProductPromisesDocument = () => {
           'packages/autopilot-control-protocol/src/remote-decision-queue.test.ts',
           'packages/autopilot-control-protocol/src/decision-closeout-receipt.ts',
           'packages/autopilot-control-protocol/src/decision-closeout-receipt.test.ts',
+          'apps/openagents.com/workers/api/src/autopilot-decision-routes.ts',
+          'apps/openagents.com/workers/api/src/autopilot-decision-routes.test.ts',
+          'apps/openagents.com/workers/api/src/autopilot-decision-act.ts',
+          'apps/openagents.com/workers/api/src/autopilot-decision-act-routing.ts',
           'docs/launch/vertex-fleet/autopilot.decision_queue.v1.md',
           'https://github.com/OpenAgentsInc/openagents/issues/5000',
           'https://github.com/OpenAgentsInc/openagents/issues/5004',
         ],
         blockerRefs: [
-          'blocker.product_promises.decision_queue_api_missing',
+          'blocker.product_promises.cross_client_command_store_missing',
           'blocker.product_promises.cross_client_exactly_once_decisions_missing',
           'blocker.product_promises.receipt_backed_command_closeout_missing',
         ],
         verification:
-          'Green requires authenticated command APIs with explicit action enums, idempotency, owner approval where needed, receipt closeout, and UI projection.',
+          'Current source verification covers authenticated command decoding, explicit public action enums, Idempotency-Key requirement, owner-approval-required rejection for sensitive actions, evidence-only non-review command acceptance, and idempotent accept review application in autopilot-decision-routes.test.ts. Green still requires persistent cross-client command storage, real desktop/web/mobile exactly-once replay evidence, receipt closeout storage, and UI projection.',
         authorityBoundary:
           'A visible decision does not grant account, repository, spend, deploy, or continuation authority.',
       },


### PR DESCRIPTION
Addresses #6828.

### Changes
- Added the public decision command action enum for authenticated decision actions, including accept, continue, follow-up mission, context, rerun, retry, steer, and stop commands.
- Routed actionable decision kinds through the command/evidence path, including create_followup_mission.
- Added owner-approval enforcement for sensitive evidence commands and evidence-only receipts when approved.
- Updated OpenAPI and product promise metadata for the decision queue command API.
- Added route coverage for public accept commands, schema rejection of unknown commands, owner-approval failures, approved evidence commands, and idempotent replay behavior.

### Verification
`bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`

Result: passed (exit 0)