### PR TITLE
feat(khala-macos): add fleet inspector panel

### DIFF
--- a/clients/khala-ios/Khala/Khala/Net/FleetInspectorStatus.swift
+++ b/clients/khala-ios/Khala/Khala/Net/FleetInspectorStatus.swift
@@ -1,0 +1,316 @@
+import Foundation
+
+struct FleetInspectorStatus: Equatable {
+    enum Availability: String, Equatable {
+        case available
+        case stale
+        case blocked
+        case unknown
+
+        var label: String {
+            switch self {
+            case .available: return "Available"
+            case .stale: return "Stale"
+            case .blocked: return "Blocked"
+            case .unknown: return "Unknown"
+            }
+        }
+    }
+
+    struct ProviderAccount: Equatable, Identifiable {
+        var id: String { provider + ":" + ref }
+        let provider: String
+        let ref: String
+        let readiness: Availability
+        let detail: String?
+    }
+
+    struct AppleFM: Equatable {
+        let readiness: Availability
+        let summary: String
+        let blockerRefs: [String]
+    }
+
+    struct RecentRef: Equatable, Identifiable {
+        var id: String { kind + ":" + value }
+        let kind: String
+        let value: String
+    }
+
+    let fetchedAt: Date
+    let connectedIdentity: String?
+    let localAgentIdentity: String?
+    let pylonRef: String?
+    let pylonReadiness: Availability
+    let heartbeatObservedAt: String?
+    let heartbeatFresh: Bool?
+    let providerAccounts: [ProviderAccount]
+    let appleFM: AppleFM
+    let capacityRefs: [String]
+    let loadRefs: [String]
+    let blockerRefs: [String]
+    let recentRefs: [RecentRef]
+    let proofRefs: [String]
+
+    static func decode(from data: Data, fetchedAt: Date = Date()) throws -> FleetInspectorStatus {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw KhalaClient.KhalaError.decoding
+        }
+        return fromPayload(object, fetchedAt: fetchedAt)
+    }
+
+    static func fromPayload(_ payload: [String: Any], fetchedAt: Date = Date()) -> FleetInspectorStatus {
+        let allRefs = publicRefs(in: payload)
+        let pylon = firstRecord(payload, keys: ["pylon", "node", "registration", "pylonRegistration"])
+        let identity = firstRecord(payload, keys: ["identity", "owner", "openagentsIdentity", "openAgentsIdentity"])
+        let localAgent = firstRecord(payload, keys: ["localAgent", "agent", "pylonAgent"])
+        let apple = firstRecord(payload, keys: ["appleFM", "appleFm", "apple_fm", "appleFoundationModels"])
+
+        let pylonRef = firstString(in: pylon, keys: ["pylonRef", "ref", "registrationRef", "agentRef"])
+            ?? firstString(in: payload, keys: ["pylonRef", "targetPylonRef"])
+            ?? allRefs.first(where: { $0.hasPrefix("pylon.") })
+        let heartbeat = firstString(in: pylon, keys: ["lastHeartbeatAt", "latestHeartbeatAt", "heartbeatAt"])
+            ?? firstString(in: payload, keys: ["lastHeartbeatAt", "latestHeartbeatAt", "heartbeatAt"])
+        let heartbeatFresh = firstBool(in: pylon, keys: ["heartbeatFresh", "fresh", "isFresh"])
+            ?? firstBool(in: payload, keys: ["heartbeatFresh", "pylonHeartbeatFresh"])
+
+        let capacityRefs = unique(
+            explicitStringArray(in: payload, keys: ["capacityRefs", "advertisedCapacityRefs"])
+            + explicitStringArray(in: pylon, keys: ["capacityRefs", "advertisedCapacityRefs"])
+            + allRefs.filter { $0.hasPrefix("capacity.") }
+        )
+        let loadRefs = unique(
+            explicitStringArray(in: payload, keys: ["loadRefs"])
+            + explicitStringArray(in: pylon, keys: ["loadRefs"])
+            + allRefs.filter { $0.hasPrefix("load.") }
+        )
+        let blockerRefs = unique(
+            explicitStringArray(in: payload, keys: ["blockerRefs", "blockers"])
+            + explicitStringArray(in: pylon, keys: ["blockerRefs", "blockers"])
+            + explicitStringArray(in: apple, keys: ["blockerRefs", "blockers"])
+            + allRefs.filter { $0.hasPrefix("blocker.") }
+        )
+        let proofRefs = unique(
+            explicitStringArray(in: payload, keys: ["proofRefs"])
+            + allRefs.filter { $0.hasPrefix("proof.") || $0.hasPrefix("artifact.") }
+        )
+        let recentRefs = recentWorkRefs(from: payload, allRefs: allRefs)
+
+        return FleetInspectorStatus(
+            fetchedAt: fetchedAt,
+            connectedIdentity: firstString(in: identity, keys: ["userRef", "ownerRef", "actorUserId", "accountRef", "ref"])
+                ?? firstString(in: payload, keys: ["userRef", "ownerRef", "actorUserId"]),
+            localAgentIdentity: firstString(in: localAgent, keys: ["agentRef", "pylonRef", "ref"])
+                ?? pylonRef,
+            pylonRef: pylonRef,
+            pylonReadiness: readiness(from: pylon, fallbackRefs: allRefs, availableHints: ["active", "ready", "online"]),
+            heartbeatObservedAt: heartbeat,
+            heartbeatFresh: heartbeatFresh,
+            providerAccounts: providerAccounts(from: payload, refs: allRefs),
+            appleFM: appleFM(from: apple, refs: allRefs),
+            capacityRefs: capacityRefs,
+            loadRefs: loadRefs,
+            blockerRefs: blockerRefs,
+            recentRefs: recentRefs,
+            proofRefs: proofRefs
+        )
+    }
+
+    static func redactedForDisplay(_ value: String, key: String? = nil) -> String {
+        sanitize(value, key: key) ?? "[redacted]"
+    }
+
+    private static func providerAccounts(from payload: [String: Any], refs: [String]) -> [ProviderAccount] {
+        let candidates = firstArray(payload, keys: ["providerAccounts", "accounts", "codexAccounts", "connectedAccounts"])
+        var accounts: [ProviderAccount] = candidates.compactMap { entry in
+            guard let record = entry as? [String: Any] else { return nil }
+            let provider = firstString(in: record, keys: ["provider", "kind", "type"]) ?? "codex"
+            guard let ref = firstString(in: record, keys: ["accountRef", "ref", "id"]) else { return nil }
+            return ProviderAccount(
+                provider: provider,
+                ref: ref,
+                readiness: readiness(from: record, fallbackRefs: []),
+                detail: firstString(in: record, keys: ["readiness", "state", "status"])
+            )
+        }
+        if accounts.isEmpty {
+            accounts = refs
+                .filter { $0.hasPrefix("account.") || $0.hasPrefix("capacity.coding.codex.account.") }
+                .prefix(6)
+                .map { ProviderAccount(provider: "codex", ref: $0, readiness: .unknown, detail: nil) }
+        }
+        return uniqueAccounts(accounts)
+    }
+
+    private static func appleFM(from record: [String: Any]?, refs: [String]) -> AppleFM {
+        let appleRefs = refs.filter { $0.contains("apple_fm") || $0.contains("apple-fm") || $0.contains("apple.foundation") }
+        let blockerRefs = unique(
+            explicitStringArray(in: record, keys: ["blockerRefs", "blockers"])
+            + appleRefs.filter { $0.hasPrefix("blocker.") }
+        )
+        let status = readiness(from: record, fallbackRefs: appleRefs)
+        let summary = firstString(in: record, keys: ["summary", "status", "state", "readiness"])
+            ?? (appleRefs.isEmpty ? "No Apple FM status published" : "Apple FM refs published")
+        return AppleFM(readiness: blockerRefs.isEmpty ? status : .blocked, summary: summary, blockerRefs: blockerRefs)
+    }
+
+    private static func recentWorkRefs(from payload: [String: Any], allRefs: [String]) -> [RecentRef] {
+        let explicit = explicitStringArray(in: payload, keys: ["recentRefs", "recentCloseoutRefs", "closeoutRefs", "assignmentRefs"])
+        return unique(explicit + allRefs)
+            .filter {
+                $0.hasPrefix("assignment.")
+                    || $0.hasPrefix("closeout.")
+                    || $0.hasPrefix("accepted_work.")
+                    || $0.hasPrefix("worker_closeout.")
+            }
+            .prefix(10)
+            .map { ref in
+                let kind = ref.hasPrefix("assignment.") ? "assignment"
+                    : ref.hasPrefix("closeout.") || ref.hasPrefix("worker_closeout.") ? "closeout"
+                    : "work"
+                return RecentRef(kind: kind, value: ref)
+            }
+    }
+
+    private static func publicRefs(in value: Any, key: String? = nil) -> [String] {
+        if let text = value as? String {
+            guard let safe = sanitize(text, key: key), looksLikePublicRef(safe) else { return [] }
+            return [safe]
+        }
+        if let array = value as? [Any] {
+            return array.flatMap { publicRefs(in: $0, key: key) }
+        }
+        if let record = value as? [String: Any] {
+            return record.flatMap { entry in publicRefs(in: entry.value, key: entry.key) }
+        }
+        return []
+    }
+
+    private static func firstRecord(_ record: [String: Any], keys: [String]) -> [String: Any]? {
+        for key in keys {
+            if let value = record[key] as? [String: Any] { return value }
+        }
+        return nil
+    }
+
+    private static func firstString(in record: [String: Any]?, keys: [String]) -> String? {
+        guard let record else { return nil }
+        for key in keys {
+            if let value = record[key] as? String,
+               let safe = sanitize(value, key: key),
+               !safe.isEmpty {
+                return safe
+            }
+            if let value = record[key], !(value is [String: Any]), !(value is [Any]) {
+                let text = String(describing: value)
+                if let safe = sanitize(text, key: key), !safe.isEmpty {
+                    return safe
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func firstBool(in record: [String: Any]?, keys: [String]) -> Bool? {
+        guard let record else { return nil }
+        for key in keys {
+            if let value = record[key] as? Bool { return value }
+        }
+        return nil
+    }
+
+    private static func firstArray(_ record: [String: Any], keys: [String]) -> [Any] {
+        for key in keys {
+            if let value = record[key] as? [Any] { return value }
+        }
+        return []
+    }
+
+    private static func explicitStringArray(in record: [String: Any]?, keys: [String]) -> [String] {
+        guard let record else { return [] }
+        return keys.flatMap { key -> [String] in
+            if let values = record[key] as? [String] {
+                return values.compactMap { sanitize($0, key: key) }
+            }
+            if let values = record[key] as? [Any] {
+                return values.compactMap { value in sanitize(String(describing: value), key: key) }
+            }
+            if let value = record[key] as? String, let safe = sanitize(value, key: key) {
+                return [safe]
+            }
+            return []
+        }
+    }
+
+    private static func readiness(
+        from record: [String: Any]?,
+        fallbackRefs: [String],
+        availableHints: [String] = ["ready", "available", "healthy", "online", "fresh"]
+    ) -> Availability {
+        let status = firstString(in: record, keys: ["readiness", "state", "status", "availability"])?.lowercased()
+        let text = ([status].compactMap { $0 } + fallbackRefs.map { $0.lowercased() }).joined(separator: " ")
+        if text.contains("blocked") || text.contains("unavailable") || text.contains("missing") || text.contains("failed") {
+            return .blocked
+        }
+        if text.contains("stale") || text.contains("expired") {
+            return .stale
+        }
+        if availableHints.contains(where: { text.contains($0) }) {
+            return .available
+        }
+        return .unknown
+    }
+
+    private static func sanitize(_ value: String, key: String?) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let lowerKey = key?.lowercased() ?? ""
+        if lowerKey.contains("email") {
+            return "[redacted-email]"
+        }
+        let sensitiveKeyParts = ["auth", "credential", "mnemonic", "password", "private", "raw", "secret", "wallet"]
+        if sensitiveKeyParts.contains(where: { lowerKey.contains($0) }) {
+            return "[redacted]"
+        }
+        let sensitivePatterns = [
+            #"oa_agent_[A-Za-z0-9._-]+"#,
+            #"sk-[A-Za-z0-9._-]+"#,
+            #"Bearer\s+[A-Za-z0-9._-]+"#,
+            #"/Users/[^\s,\]\}"]+"#,
+            #"/home/[^\s,\]\}"]+"#,
+            #"~/.codex[^\s,\]\}"]*"#,
+            #"auth\.json"#,
+            #"spark1[ac-hj-np-z02-9]+"#,
+            #"lnbc[ac-hj-np-z02-9]+"#,
+            #"lntb[ac-hj-np-z02-9]+"#
+        ]
+        if sensitivePatterns.contains(where: { trimmed.range(of: $0, options: .regularExpression) != nil }) {
+            return "[redacted]"
+        }
+        return trimmed
+    }
+
+    private static func looksLikePublicRef(_ value: String) -> Bool {
+        value.range(of: #"^[a-z][a-z0-9_.:-]+(\.[a-z0-9_.:-]+)*=?[A-Za-z0-9_.:-]*$"#, options: .regularExpression) != nil
+    }
+
+    private static func unique(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var output: [String] = []
+        for value in values where !seen.contains(value) {
+            seen.insert(value)
+            output.append(value)
+        }
+        return output
+    }
+
+    private static func uniqueAccounts(_ values: [ProviderAccount]) -> [ProviderAccount] {
+        var seen = Set<String>()
+        var output: [ProviderAccount] = []
+        for value in values where !seen.contains(value.id) {
+            seen.insert(value.id)
+            output.append(value)
+        }
+        return output
+    }
+}

--- a/clients/khala-ios/Khala/Khala/Net/KhalaClient.swift
+++ b/clients/khala-ios/Khala/Khala/Net/KhalaClient.swift
@@ -11,6 +11,7 @@ import Foundation
 enum KhalaClient {
     static let baseURL = URL(string: "https://openagents.com/api/v1")!
     static let freeKeyURL = URL(string: "https://openagents.com/api/keys/free")!
+    static let operatorFleetStatusURL = URL(string: "https://openagents.com/api/operator/fleet/status")!
     static let model = "openagents/khala"
 
     enum KhalaError: Error, LocalizedError {
@@ -166,6 +167,33 @@ enum KhalaClient {
                 throw KhalaError.decoding
             }
             return token
+        } catch let err as KhalaError {
+            throw err
+        } catch {
+            throw KhalaError.transport(error)
+        }
+    }
+
+    // MARK: - Fleet inspector
+
+    static func fetchFleetInspectorStatus(
+        apiKey: String,
+        session: URLSession = .shared
+    ) async throws -> FleetInspectorStatus {
+        var request = URLRequest(url: operatorFleetStatusURL)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { throw KhalaError.decoding }
+            if http.statusCode == 401 || http.statusCode == 403 { throw KhalaError.unauthorized }
+            if http.statusCode == 402 { throw KhalaError.quotaExceeded }
+            guard (200..<300).contains(http.statusCode) else {
+                throw KhalaError.http(http.statusCode, String(data: data, encoding: .utf8) ?? "")
+            }
+            return try FleetInspectorStatus.decode(from: data)
         } catch let err as KhalaError {
             throw err
         } catch {

--- a/clients/khala-ios/Khala/Khala/Shell/FleetInspectorView.swift
+++ b/clients/khala-ios/Khala/Khala/Shell/FleetInspectorView.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+
+struct FleetInspectorView: View {
+    let status: FleetInspectorStatus?
+    let isLoading: Bool
+    let errorText: String?
+    let onRefresh: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    if let errorText {
+                        notice(icon: "exclamationmark.triangle.fill", title: "Inspector unavailable", text: errorText, color: .orange)
+                    }
+                    if let status {
+                        identitySection(status)
+                        pylonSection(status)
+                        appleSection(status.appleFM)
+                        refsSection("Capacity", icon: "bolt.horizontal.circle", refs: status.capacityRefs)
+                        refsSection("Load", icon: "tray.2", refs: status.loadRefs)
+                        recentSection(status)
+                        refsSection("Proofs", icon: "checkmark.seal", refs: status.proofRefs)
+                        refsSection("Blockers", icon: "xmark.octagon", refs: status.blockerRefs)
+                    } else if isLoading {
+                        ProgressView("Loading fleet status...")
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.top, 36)
+                    } else {
+                        notice(
+                            icon: "network",
+                            title: "No fleet snapshot",
+                            text: "OpenAgents identity, Pylon readiness, provider accounts, Apple FM status, capacity, load, and proof refs appear here after refresh.",
+                            color: .secondary
+                        )
+                    }
+                }
+                .padding(16)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(.regularMaterial)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "rectangle.righthalf.inset.filled")
+                .font(.title3)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Fleet")
+                    .font(.headline)
+                Text(status.map { "Updated \($0.fetchedAt.formatted(date: .omitted, time: .shortened))" } ?? "Node readiness")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button(action: onRefresh) {
+                Image(systemName: "arrow.clockwise")
+                    .frame(width: 34, height: 34)
+            }
+            .disabled(isLoading)
+            .accessibilityLabel("Refresh fleet status")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
+    private func identitySection(_ status: FleetInspectorStatus) -> some View {
+        section("Identity", icon: "person.crop.circle.badge.checkmark") {
+            detailRow("OpenAgents", status.connectedIdentity ?? "Not published")
+            detailRow("Local agent", status.localAgentIdentity ?? "Not published")
+        }
+    }
+
+    private func pylonSection(_ status: FleetInspectorStatus) -> some View {
+        section("Pylon", icon: "antenna.radiowaves.left.and.right") {
+            HStack {
+                detailRow("Readiness", status.pylonReadiness.label)
+                Spacer()
+                badge(status.pylonReadiness)
+            }
+            detailRow("Pylon ref", status.pylonRef ?? "Not published")
+            if let heartbeatObservedAt = status.heartbeatObservedAt {
+                detailRow("Heartbeat", heartbeatObservedAt)
+            }
+            if let heartbeatFresh = status.heartbeatFresh {
+                HStack {
+                    detailRow("Freshness", heartbeatFresh ? "Fresh" : "Stale")
+                    Spacer()
+                    badge(heartbeatFresh ? .available : .stale)
+                }
+            }
+            if status.providerAccounts.isEmpty {
+                detailRow("Providers", "No connected provider accounts published")
+            } else {
+                ForEach(status.providerAccounts) { account in
+                    HStack(alignment: .firstTextBaseline) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("\(account.provider) \(account.ref)")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(.primary)
+                            if let detail = account.detail {
+                                Text(detail)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            }
+                        }
+                        Spacer()
+                        badge(account.readiness)
+                    }
+                }
+            }
+        }
+    }
+
+    private func appleSection(_ apple: FleetInspectorStatus.AppleFM) -> some View {
+        section("Apple FM", icon: "apple.logo") {
+            HStack {
+                detailRow("Readiness", apple.summary)
+                Spacer()
+                badge(apple.readiness)
+            }
+            ForEach(apple.blockerRefs, id: \.self) { ref in
+                refPill(ref, tone: .blocked)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func refsSection(_ title: String, icon: String, refs: [String]) -> some View {
+        section(title, icon: icon) {
+            if refs.isEmpty {
+                detailRow(title, "No refs published")
+            } else {
+                FlowStack(items: refs) { ref in
+                    refPill(ref)
+                }
+            }
+        }
+    }
+
+    private func recentSection(_ status: FleetInspectorStatus) -> some View {
+        section("Recent Work", icon: "clock.arrow.circlepath") {
+            if status.recentRefs.isEmpty {
+                detailRow("Closeouts", "No recent assignment or closeout refs published")
+            } else {
+                ForEach(status.recentRefs) { ref in
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(ref.kind.capitalized)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        refPill(ref.value)
+                    }
+                }
+            }
+        }
+    }
+
+    private func section<Content: View>(_ title: String, icon: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(title, systemImage: icon)
+                .font(.subheadline.weight(.semibold))
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.footnote)
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func badge(_ availability: FleetInspectorStatus.Availability) -> some View {
+        Label(availability.label, systemImage: badgeIcon(availability))
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(badgeColor(availability).opacity(0.16), in: Capsule())
+            .foregroundStyle(badgeColor(availability))
+    }
+
+    private func refPill(_ ref: String, tone: FleetInspectorStatus.Availability = .unknown) -> some View {
+        Text(ref)
+            .font(.caption.monospaced())
+            .foregroundStyle(.primary)
+            .lineLimit(3)
+            .textSelection(.enabled)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(badgeColor(tone).opacity(tone == .unknown ? 0.10 : 0.16), in: RoundedRectangle(cornerRadius: 7))
+    }
+
+    private func notice(icon: String, title: String, text: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: icon)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(color)
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func badgeIcon(_ availability: FleetInspectorStatus.Availability) -> String {
+        switch availability {
+        case .available: return "checkmark.circle.fill"
+        case .stale: return "clock.badge.exclamationmark.fill"
+        case .blocked: return "xmark.octagon.fill"
+        case .unknown: return "questionmark.circle.fill"
+        }
+    }
+
+    private func badgeColor(_ availability: FleetInspectorStatus.Availability) -> Color {
+        switch availability {
+        case .available: return .green
+        case .stale: return .orange
+        case .blocked: return .red
+        case .unknown: return .secondary
+        }
+    }
+}
+
+private struct FlowStack<Item: Hashable, Content: View>: View {
+    let items: [Item]
+    let content: (Item) -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(items, id: \.self) { item in
+                content(item)
+            }
+        }
+    }
+}

--- a/clients/khala-ios/Khala/Khala/Shell/RootView.swift
+++ b/clients/khala-ios/Khala/Khala/Shell/RootView.swift
@@ -9,11 +9,15 @@ struct RootView: View {
     @Environment(\.openURL) private var openURL
 
     @State private var drawerOpen = false
+    @State private var inspectorOpen = false
     @State private var showSettings = false
     @State private var showDiagnostics = false
     @State private var hasKey = Self.hasUsableAPIKey()
     @State private var didLaunch = false
     @State private var selection: Conversation?
+    @State private var fleetStatus: FleetInspectorStatus?
+    @State private var fleetStatusLoading = false
+    @State private var fleetStatusError: String?
     /// Active conversation channel. `.khala` is the public collective model;
     /// `.artanis` is the owner-only operator channel (#6363). Toggled from the
     /// title menu; switching starts a fresh conversation so the two personas
@@ -23,16 +27,34 @@ struct RootView: View {
     @State private var model: ChatViewModel?
 
     var body: some View {
-        DrawerContainer(isOpen: $drawerOpen) {
-            chatStack
-        } drawer: {
-            DrawerContentView(
-                store: store,
-                selection: $selection,
-                onNewChat: newChat,
-                onOpenSettings: { drawerOpen = false; showSettings = true },
-                onSelect: open(_:)
-            )
+        ZStack(alignment: .trailing) {
+            DrawerContainer(isOpen: $drawerOpen) {
+                chatStack
+            } drawer: {
+                DrawerContentView(
+                    store: store,
+                    selection: $selection,
+                    onNewChat: newChat,
+                    onOpenSettings: { drawerOpen = false; showSettings = true },
+                    onSelect: open(_:)
+                )
+            }
+            if inspectorOpen {
+                Color.black.opacity(0.32)
+                    .ignoresSafeArea()
+                    .onTapGesture { withAnimation { inspectorOpen = false } }
+                    .transition(.opacity)
+                FleetInspectorView(
+                    status: fleetStatus,
+                    isLoading: fleetStatusLoading,
+                    errorText: fleetStatusError,
+                    onRefresh: { Task { await refreshFleetStatus() } }
+                )
+                .frame(width: 340)
+                .ignoresSafeArea(edges: .vertical)
+                .transition(.move(edge: .trailing))
+                .shadow(radius: 18)
+            }
         }
         .sheet(isPresented: $showSettings) {
             SettingsView(hasKey: $hasKey)
@@ -42,6 +64,11 @@ struct RootView: View {
         }
         .task { await onAppear() }
         .onChange(of: selection?.id) { _, _ in syncModel() }
+        .onChange(of: inspectorOpen) { _, isOpen in
+            guard isOpen else { return }
+            drawerOpen = false
+            Task { await refreshFleetStatus() }
+        }
     }
 
     private var chatStack: some View {
@@ -122,10 +149,18 @@ struct RootView: View {
                     .accessibilityLabel("\(channel.speaker) menu")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button(action: newChat) {
-                        Image(systemName: "square.and.pencil")
+                    HStack(spacing: 10) {
+                        Button {
+                            withAnimation { inspectorOpen.toggle() }
+                        } label: {
+                            Image(systemName: "rectangle.righthalf.inset.filled")
+                        }
+                        .accessibilityLabel("Fleet inspector")
+                        Button(action: newChat) {
+                            Image(systemName: "square.and.pencil")
+                        }
+                        .accessibilityLabel("New chat")
                     }
-                    .accessibilityLabel("New chat")
                 }
             }
         }
@@ -227,5 +262,25 @@ struct RootView: View {
     private static func hasUsableAPIKey() -> Bool {
         guard let key = KeychainStore.loadAPIKey() else { return false }
         return FreeTierDisclosureStore.canUse(apiKey: key)
+    }
+
+    @MainActor
+    private func refreshFleetStatus() async {
+        guard inspectorOpen else { return }
+        guard let key = KeychainStore.loadAPIKey() else {
+            fleetStatusError = "Mint or paste a Khala key in Settings to read owner-scoped fleet status."
+            fleetStatus = nil
+            return
+        }
+        fleetStatusLoading = true
+        fleetStatusError = nil
+        defer { fleetStatusLoading = false }
+        do {
+            fleetStatus = try await KhalaClient.fetchFleetInspectorStatus(apiKey: key)
+        } catch let khala as KhalaClient.KhalaError {
+            fleetStatusError = khala.recoveryMessage
+        } catch {
+            fleetStatusError = error.localizedDescription
+        }
     }
 }

--- a/clients/khala-ios/Khala/KhalaTests/KhalaClientTests.swift
+++ b/clients/khala-ios/Khala/KhalaTests/KhalaClientTests.swift
@@ -383,6 +383,99 @@ final class KhalaClientTests: XCTestCase {
         }
     }
 
+    func testFetchFleetInspectorStatusUsesBearerAuthAndDecodesPublicRefs() async throws {
+        let session = makeSession()
+        let apiKey = "oa_agent_fleet_status_test"
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://openagents.com/api/operator/fleet/status")
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(apiKey)")
+
+            return (
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                Data("""
+                {
+                  "identity": {
+                    "userRef": "user.public.owner",
+                    "email": "owner@example.com"
+                  },
+                  "pylon": {
+                    "pylonRef": "pylon.owner.codex",
+                    "status": "ready",
+                    "lastHeartbeatAt": "2026-06-28T12:00:00Z",
+                    "heartbeatFresh": true,
+                    "capacityRefs": [
+                      "capacity.coding.codex.ready=2",
+                      "capacity.coding.codex.available=1"
+                    ],
+                    "loadRefs": [
+                      "load.coding.codex.busy=1",
+                      "load.coding.codex.queued=0"
+                    ]
+                  },
+                  "providerAccounts": [
+                    { "provider": "codex", "accountRef": "codex", "readiness": "ready" }
+                  ],
+                  "appleFM": {
+                    "status": "blocked",
+                    "blockerRefs": ["blocker.apple_fm.backend_missing"]
+                  },
+                  "recentCloseoutRefs": [
+                    "assignment.public.khala_coding.fixture",
+                    "closeout.public.khala_coding.fixture"
+                  ],
+                  "proofRefs": ["proof.public.khala_coding.fixture"],
+                  "rawPrompt": "do not display me",
+                  "localPath": "/Users/example/.codex/auth.json",
+                  "token": "oa_agent_should_not_render"
+                }
+                """.utf8)
+            )
+        }
+
+        let status = try await KhalaClient.fetchFleetInspectorStatus(apiKey: apiKey, session: session)
+
+        XCTAssertEqual(status.connectedIdentity, "user.public.owner")
+        XCTAssertEqual(status.localAgentIdentity, "pylon.owner.codex")
+        XCTAssertEqual(status.pylonRef, "pylon.owner.codex")
+        XCTAssertEqual(status.pylonReadiness, .available)
+        XCTAssertEqual(status.heartbeatObservedAt, "2026-06-28T12:00:00Z")
+        XCTAssertEqual(status.heartbeatFresh, true)
+        XCTAssertEqual(status.providerAccounts, [
+            FleetInspectorStatus.ProviderAccount(provider: "codex", ref: "codex", readiness: .available, detail: "ready"),
+        ])
+        XCTAssertEqual(status.appleFM.readiness, .blocked)
+        XCTAssertEqual(status.capacityRefs, [
+            "capacity.coding.codex.ready=2",
+            "capacity.coding.codex.available=1",
+        ])
+        XCTAssertEqual(status.loadRefs, [
+            "load.coding.codex.busy=1",
+            "load.coding.codex.queued=0",
+        ])
+        XCTAssertEqual(status.recentRefs.map(\.value), [
+            "assignment.public.khala_coding.fixture",
+            "closeout.public.khala_coding.fixture",
+        ])
+        XCTAssertEqual(status.proofRefs, ["proof.public.khala_coding.fixture"])
+        XCTAssertFalse(status.capacityRefs.contains { $0.contains("oa_agent_should_not_render") })
+        XCTAssertFalse(status.proofRefs.contains { $0.contains("/Users/") })
+    }
+
+    func testFleetInspectorRedactsSensitiveDisplayStrings() {
+        XCTAssertEqual(FleetInspectorStatus.redactedForDisplay("oa_agent_secret"), "[redacted]")
+        XCTAssertEqual(FleetInspectorStatus.redactedForDisplay("/Users/me/.codex/auth.json"), "[redacted]")
+        XCTAssertEqual(FleetInspectorStatus.redactedForDisplay("person@example.com", key: "email"), "[redacted-email]")
+        XCTAssertEqual(FleetInspectorStatus.redactedForDisplay("capacity.coding.codex.available=2"), "capacity.coding.codex.available=2")
+    }
+
     private func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]


### PR DESCRIPTION
Addresses #6876.

### Changes
- Adds a Khala client call for the operator fleet status endpoint with bearer auth, status handling, and `FleetInspectorStatus` decoding.
- Adds a right-side fleet inspector panel from the chat shell, including refresh, loading, and error states.
- Adds client tests covering auth headers, decoded public refs, empty responses, and unauthorized failures.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).