### PR TITLE
fix(autopilot): bind payment particles to bitcoin evidence

### DIFF
--- a/apps/autopilot-desktop/src/shared/chat-world-scene.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-scene.ts
@@ -268,6 +268,8 @@ export type ActivityEvent = {
   readonly text?: string
 }
 
+export type PaymentParticleKind = "real_bitcoin_moved" | "settlement_recorded"
+
 // A renderer-agnostic descriptor for one payment particle. The P0 scene maps
 // fromRef/toRef → node positions and feeds size/color/evidence into
 // three-effect createFlowBeam + createEvidenceBackedEventBurst. EVIDENCE-BOUND:
@@ -275,14 +277,16 @@ export type ActivityEvent = {
 // real receipt/event.
 export type PaymentParticle = {
   readonly id: string
+  /** originating public activity event kind. */
+  readonly kind: PaymentParticleKind
   /** sender node ref (actorRef). */
   readonly fromRef: string
   /** recipient node ref (targetRef). */
   readonly toRef: string
   readonly amountSats: number
-  /** real bitcoin (gold) vs credited/non-bitcoin (dim). */
+  /** accepted payment particles are real-bitcoin settlement evidence. */
   readonly realBitcoinMoved: boolean
-  /** gold for real bitcoin, dim blue for credited flows. */
+  /** gold for real bitcoin movement. */
   readonly color: number
   /** [0.2,1] visual size ∝ amountSats (log-scaled, clamped). */
   readonly size: number
@@ -293,13 +297,15 @@ export type PaymentParticle = {
 }
 
 export const PAYMENT_PARTICLE_GOLD = 0xf5b73a // real bitcoin moved
-export const PAYMENT_PARTICLE_DIM = 0x4a5570 // credited / non-bitcoin
 
 // Kinds that produce a sender→recipient money particle.
 const PAYMENT_EVENT_KINDS = new Set(["real_bitcoin_moved", "settlement_recorded"])
 
 export const isPaymentEvent = (event: ActivityEvent): boolean =>
   PAYMENT_EVENT_KINDS.has(event.kind)
+
+const paymentParticleKind = (kind: string): PaymentParticleKind | null =>
+  kind === "real_bitcoin_moved" || kind === "settlement_recorded" ? kind : null
 
 // Log-scale size in [0.2, 1] so a 10-sat tip and a 10M-sat settlement both read,
 // with bigger amounts visibly larger. 0 sats → smallest visible particle.
@@ -324,7 +330,9 @@ export const particleSize = (amountSats: number): number => {
 export const activityEventToParticle = (
   event: ActivityEvent,
 ): PaymentParticle | null => {
-  if (!isPaymentEvent(event)) return null
+  const kind = paymentParticleKind(event.kind)
+  if (kind === null) return null
+  if (event.realBitcoinMoved !== true) return null
 
   const fromRef = event.actorRef
   const toRef = event.targetRef
@@ -335,7 +343,6 @@ export const activityEventToParticle = (
   )
   if (sourceRefs.length === 0) return null // never fake a clickable receipt
 
-  const real = event.realBitcoinMoved === true
   const amountSats =
     typeof event.amountSats === "number" && event.amountSats > 0
       ? event.amountSats
@@ -343,11 +350,12 @@ export const activityEventToParticle = (
 
   return {
     id: event.eventRef,
+    kind,
     fromRef,
     toRef,
     amountSats,
-    realBitcoinMoved: real,
-    color: real ? PAYMENT_PARTICLE_GOLD : PAYMENT_PARTICLE_DIM,
+    realBitcoinMoved: true,
+    color: PAYMENT_PARTICLE_GOLD,
     size: particleSize(amountSats),
     sourceRefs,
     ts: event.ts ?? null,

--- a/apps/autopilot-desktop/src/shared/chat-world-visualization.ts
+++ b/apps/autopilot-desktop/src/shared/chat-world-visualization.ts
@@ -14,8 +14,8 @@
 //      bezier graph. A null/empty live scene falls back to the caller's static
 //      seed so zero-state / pre-load is calm, never blank.
 //   2. PAYMENTS — each PaymentParticle becomes an EVIDENCE-BOUND beam from the
-//      actor pylon → target pylon (gold motionKind for real bitcoin, dim for
-//      credited), with a settlement burst on the target, plus clickable endpoint
+//      actor pylon → target pylon (gold real-bitcoin motion), with a settlement
+//      burst on the target, plus clickable endpoint
 //      entities that carry the receipt sourceRef. motionPolicy.evidence is
 //      "required", so the renderer refuses to animate any motion without refs —
 //      and activityEventToParticle already drops particles with no sourceRef, so
@@ -117,11 +117,9 @@ const endpointRingPosition = (index: number, count: number): TrainingRunVector =
   ])
 }
 
-// An entity status the renderer's status→color map reads. real_bitcoin earns the
-// "verified" (gold-family) tone; credited settlement reads as "active". These are
-// the public statuses the shared training-run entity color map honors.
-const endpointStatus = (particle: PaymentParticle): string =>
-  particle.realBitcoinMoved ? "verified" : "active"
+// An entity status the renderer's status→color map reads. Real bitcoin earns the
+// "verified" (gold-family) tone.
+const endpointStatus = (_particle: PaymentParticle): string => "verified"
 
 export type ChatWorldPaymentEndpointSource =
   | "avatar"
@@ -589,15 +587,13 @@ export const chatWorldPaymentLayer = (
         label: endpointLabel(toEndpoint, "to"),
         detail: endpointDetail(primaryRef, toEndpoint, particle, "to"),
         position: toEndpoint.position,
-        iconRecipe: verseIconRecipeForId(
-          particle.realBitcoinMoved ? "zap" : "settlement",
-        ),
+        iconRecipe: verseIconRecipeForId("zap"),
       })
     }
 
     const evidence = {
       motionId: particle.id,
-      motionKind: particle.realBitcoinMoved ? "real_bitcoin_moved" : "settlement_recorded",
+      motionKind: particle.kind,
       sourceRefs: particle.sourceRefs,
       ...(typeof particle.ts === "string" ? { generatedAt: particle.ts } : {}),
       simulated: false,

--- a/apps/autopilot-desktop/tests/chat-world-scene.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-scene.test.ts
@@ -8,7 +8,6 @@ import {
   LIVE_PYLON_STATE_COLOR,
   livePylonState,
   particleSize,
-  PAYMENT_PARTICLE_DIM,
   PAYMENT_PARTICLE_GOLD,
   PAYMENT_PARTICLE_WINDOW_MS,
   paymentParticleTsMs,
@@ -233,6 +232,7 @@ describe("activityEventToParticle (evidence-bound §5)", () => {
     const p = activityEventToParticle(paymentEvent())!
     expect(p).not.toBeNull()
     expect(p.id).toBe("evt-1")
+    expect(p.kind).toBe("real_bitcoin_moved")
     expect(p.fromRef).toBe("pylon:payer")
     expect(p.toRef).toBe("pylon:payee")
     expect(p.realBitcoinMoved).toBe(true)
@@ -241,12 +241,26 @@ describe("activityEventToParticle (evidence-bound §5)", () => {
     expect(p.sourceRefs).toContain(receiptRef)
   })
 
-  test("credited / non-bitcoin flow renders dim", () => {
-    const p = activityEventToParticle(
-      paymentEvent({ kind: "settlement_recorded", realBitcoinMoved: false }),
-    )!
-    expect(p.realBitcoinMoved).toBe(false)
-    expect(p.color).toBe(PAYMENT_PARTICLE_DIM)
+  test("settlement records with real bitcoin → gold particle carrying sourceRefs", () => {
+    const p = activityEventToParticle(paymentEvent({ kind: "settlement_recorded" }))!
+    expect(p).not.toBeNull()
+    expect(p.kind).toBe("settlement_recorded")
+    expect(p.realBitcoinMoved).toBe(true)
+    expect(p.color).toBe(PAYMENT_PARTICLE_GOLD)
+    expect(p.sourceRefs).toContain(receiptRef)
+  })
+
+  test("refuses non-real settlement records", () => {
+    expect(
+      activityEventToParticle(
+        paymentEvent({ kind: "settlement_recorded", realBitcoinMoved: false }),
+      ),
+    ).toBeNull()
+    expect(
+      activityEventToParticle(
+        paymentEvent({ kind: "settlement_recorded", realBitcoinMoved: undefined }),
+      ),
+    ).toBeNull()
   })
 
   test("refuses non-payment kinds", () => {
@@ -278,6 +292,7 @@ describe("activityEventToParticle (evidence-bound §5)", () => {
 
 const particleAt = (id: string, ts: string | null): PaymentParticle => ({
   id,
+  kind: "real_bitcoin_moved",
   fromRef: "pylon:payer",
   toRef: "pylon:payee",
   amountSats: 1_000,

--- a/apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts
@@ -273,22 +273,44 @@ describe("subscribePaymentParticles (flag-gated, evidence-bound)", () => {
               realBitcoinMoved: true,
               sourceRefs: ["receipt.ok"],
             },
+            {
+              eventRef: "settlement-ok",
+              kind: "settlement_recorded",
+              actorRef: "a",
+              targetRef: "b",
+              amountSats: 8,
+              realBitcoinMoved: true,
+              sourceRefs: ["receipt.settlement.ok"],
+            },
             // dropped: no sourceRef
             {
               eventRef: "bad",
               kind: "real_bitcoin_moved",
               actorRef: "a",
               targetRef: "b",
+              realBitcoinMoved: true,
               sourceRefs: [],
+            },
+            // dropped: settlement record without real bitcoin movement
+            {
+              eventRef: "simulated-settlement",
+              kind: "settlement_recorded",
+              actorRef: "a",
+              targetRef: "b",
+              realBitcoinMoved: false,
+              sourceRefs: ["receipt.simulated"],
             },
           ],
         })) as unknown as typeof fetch,
     })
     await new Promise((r) => setTimeout(r, 5))
     stop()
-    expect(particles).toHaveLength(1)
+    expect(particles).toHaveLength(2)
     expect(particles[0]!.id).toBe("ok")
     expect(particles[0]!.sourceRefs).toContain("receipt.ok")
+    expect(particles[1]!.id).toBe("settlement-ok")
+    expect(particles[1]!.kind).toBe("settlement_recorded")
+    expect(particles[1]!.sourceRefs).toContain("receipt.settlement.ok")
   })
 })
 

--- a/apps/autopilot-desktop/tests/chat-world-visualization.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-visualization.test.ts
@@ -21,7 +21,6 @@ import type {
 } from "../src/shared/chat-world-scene"
 import type { ChatWorldMultiplayerProjection } from "../src/shared/chat-world-multiplayer"
 import {
-  PAYMENT_PARTICLE_DIM,
   PAYMENT_PARTICLE_GOLD,
   pylonGrowthTier,
 } from "../src/shared/chat-world-scene"
@@ -115,6 +114,7 @@ describe("liveChatWorldNetworkScene", () => {
 
 const particle = (overrides: Partial<PaymentParticle> = {}): PaymentParticle => ({
   id: "evt-1",
+  kind: "real_bitcoin_moved",
   fromRef: "pylon:alpha",
   toRef: "pylon:bravo",
   amountSats: 21_000,
@@ -380,11 +380,14 @@ describe("chatWorldPaymentLayer (evidence-bound motion)", () => {
     expect(toEntity.position?.[2]).not.toBe(0)
   })
 
-  test("credited (non-bitcoin) particles tag settlement_recorded", () => {
+  test("settlement-record particles keep their evidence motion kind", () => {
     const layer = chatWorldPaymentLayer([
-      particle({ realBitcoinMoved: false, color: PAYMENT_PARTICLE_DIM }),
+      particle({ kind: "settlement_recorded" }),
     ])
     expect(layer.beams[0]!.motionKind).toBe("settlement_recorded")
+    expect(
+      layer.entities.find(entity => entity.id === "pay:evt-1:to")?.iconRecipe?.kind,
+    ).toBe("zap")
   })
 
   test("refuses particles with no sourceRef (never fakes a receipt)", () => {
@@ -539,12 +542,12 @@ describe("shared Verse procedural icons", () => {
     expect(station.iconRecipe?.fallback).toBe(false)
   })
 
-  test("credited payment endpoints use settlement taxonomy", () => {
+  test("settlement-record payment endpoints use gold zap taxonomy", () => {
     const layer = chatWorldPaymentLayer([
-      particle({ realBitcoinMoved: false, color: PAYMENT_PARTICLE_DIM }),
+      particle({ kind: "settlement_recorded" }),
     ])
     const target = layer.entities.find(entity => entity.id === "pay:evt-1:to")!
-    expect(target.iconRecipe?.kind).toBe("settlement")
+    expect(target.iconRecipe?.kind).toBe("zap")
   })
 })
 

--- a/apps/autopilot-desktop/tests/pylon-base-scene.test.ts
+++ b/apps/autopilot-desktop/tests/pylon-base-scene.test.ts
@@ -110,6 +110,7 @@ const scene = (
 
 const particle = (overrides: Partial<PaymentParticle> = {}): PaymentParticle => ({
   id: "evt-1",
+  kind: "real_bitcoin_moved",
   fromRef: "pylon:local",
   toRef: "pylon:buyer",
   amountSats: 1_000,

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3886,7 +3886,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Real Bitcoin settlements are visualized in the agent world as gold particles flying agent-to-agent, each particle bound to a real settlement receipt and clickable to its evidence.',
         safeCopy:
-          'The Bitcoin payment visualization is merged to main behind the default-off CHAT_WORLD_PAYMENTS flag (PR #5743). It is evidence-bound by construction: a payment particle is only emitted for a real_bitcoin_moved or settlement_recorded event that carries at least one sourceRef, and the mappers refuse to emit a particle with no sourceRef. It is not yet wired into the live running scene and the flag is off by default.',
+          'The Bitcoin payment visualization is wired into the live running agent-world scene behind the default-off CHAT_WORLD_PAYMENTS flag. It is evidence-bound by construction: a gold payment particle is only emitted for a real_bitcoin_moved or settlement_recorded event that proves realBitcoinMoved:true and carries at least one sourceRef, and the mappers refuse to emit a particle with no sourceRef or simulated settlement evidence.',
         unsafeCopy:
           'Do not say payment particles are live for all users, that the visualization is on by default, that it shows simulated or unbacked payments, or that visualizing a settlement implies any new earning, payout, or settlement authority.',
         evidenceRefs: [
@@ -3895,16 +3895,20 @@ export const publicProductPromisesDocument = () => {
           'https://github.com/OpenAgentsInc/openagents/issues/5730',
           'https://github.com/OpenAgentsInc/openagents/issues/5736',
           'apps/autopilot-desktop/src/shared/chat-world-scene.ts',
+          'apps/autopilot-desktop/src/shared/chat-world-visualization.ts',
           'apps/autopilot-desktop/src/ui/chat-world-subscriptions.ts',
+          'apps/autopilot-desktop/src/ui/view.ts',
+          'apps/autopilot-desktop/tests/chat-world-scene.test.ts',
+          'apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts',
+          'apps/autopilot-desktop/tests/chat-world-visualization.test.ts',
           'promise:autopilot.agent_world_scene.v1',
           'promise:training.decentralized_training_launch.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.payment_visualization_not_wired_into_live_scene',
           'blocker.product_promises.payment_visualization_flag_default_off',
         ],
         verification:
-          'Yellow is limited to the merged, tested mappers in chat-world-scene.ts (PR #5743): PAYMENT_EVENT_KINDS is exactly {real_bitcoin_moved, settlement_recorded}, sourceRefs is required and non-empty so every particle is clickable to a real receipt, and an event with no sourceRef returns null (never a faked clickable receipt). True today: the descriptor builder is evidence-bound and flag-gated. Green requires the visualization wired into the live running scene end to end, an owner decision on default-on, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'Yellow covers the live wiring behind CHAT_WORLD_PAYMENTS: chat-world-subscriptions.ts backfills and streams public activity-timeline events into GotChatWorldPaymentParticle, update.ts stores the bounded active set, view.ts composes modelChatWorldParticles through withChatWorldPaymentLayer, and chat-world-visualization.ts turns each accepted particle into clickable beam/burst endpoint evidence. PAYMENT_EVENT_KINDS remains exactly {real_bitcoin_moved, settlement_recorded}; realBitcoinMoved:true and sourceRefs are required, so an event with no sourceRef or simulated settlement evidence returns null. Green requires an owner decision on default-on and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'Visualizing a Bitcoin settlement grants no payment authority, no spend, no payout, and no settlement authority. The particle is a clickable projection of an already-public receipt or event; it never moves money and never asserts a settlement that the underlying receipt does not.',
       },


### PR DESCRIPTION
Addresses #6866.

### Changes
- Restricted payment particle creation to real-bitcoin activity events with receipt source refs, carrying the originating payment kind through the particle descriptor.
- Removed the dim credited-flow particle path so live payment motion renders as gold, verified, evidence-backed bitcoin movement.
- Updated chat world payment visualization and related tests to assert evidence-bound particle behavior, motion evidence kind, endpoint rendering, and product-promise wiring.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).