### PR TITLE
fix(payments): expose settlement evidence refs

### DIFF
--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle.test.ts
@@ -134,15 +134,21 @@ describe('OmniAcceptedOutcomeSettlementBundleInvariantError', () => {
 })
 
 describe('publicOmniAcceptedOutcomeSettlementBundleProjection', () => {
-  test('drops internal figures but keeps lifecycle + evidence labels', () => {
+  test('drops internal figures but keeps lifecycle + public-safe evidence refs', () => {
     const bundle = buildOmniAcceptedOutcomeSettlementBundle(baseRecord)
     const projection =
       publicOmniAcceptedOutcomeSettlementBundleProjection(bundle)
     expect(projection.settlementComplete).toBe(true)
     expect(projection.settlementMachine.transitions).toHaveLength(8)
+    expect(
+      new Set(
+        projection.settlementMachine.transitions.map(t => t.evidenceRef),
+      ).size,
+    ).toBe(8)
     for (const transition of projection.settlementMachine.transitions) {
       expect(transition).not.toHaveProperty('amountCents')
       expect(transition).toHaveProperty('evidenceKind')
+      expect(transition).toHaveProperty('evidenceRef')
     }
     // accrual view keeps evidence labels, drops figures
     for (const entry of projection.contributorAccrualBundle

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.test.ts
@@ -90,6 +90,7 @@ describe('advanceOmniAcceptedOutcomeSettlementMachine', () => {
     expect(machine.state).toBe('margin')
     // Eight DISTINCT states; none collapsed.
     expect(new Set(machine.transitions.map(t => t.stateId)).size).toBe(8)
+    expect(new Set(machine.transitions.map(t => t.evidenceRef)).size).toBe(8)
   })
 
   test('is idempotent: re-recording the current state is a no-op', () => {
@@ -219,17 +220,20 @@ describe('advanceOmniAcceptedOutcomeSettlementMachine', () => {
 })
 
 describe('publicOmniAcceptedOutcomeSettlementMachineProjection', () => {
-  test('drops monetary figures and refs but keeps honest evidence labels', () => {
+  test('drops monetary figures but keeps public-safe evidence refs and labels', () => {
     const machine = advanceThrough(baseRecord, OMNI_SETTLEMENT_STATE_ORDER)
     const projection =
       publicOmniAcceptedOutcomeSettlementMachineProjection(machine)
     expect(projection.complete).toBe(true)
     expect(projection.state).toBe('margin')
     expect(projection.transitions).toHaveLength(8)
+    expect(new Set(projection.transitions.map(t => t.evidenceRef)).size).toBe(
+      8,
+    )
     for (const transition of projection.transitions) {
       expect(transition).not.toHaveProperty('amountCents')
-      expect(transition).not.toHaveProperty('evidenceRef')
       expect(transition).toHaveProperty('evidenceKind')
+      expect(transition).toHaveProperty('evidenceRef')
       expect(transition).toHaveProperty('movedMoney')
     }
   })

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.ts
@@ -386,7 +386,9 @@ export const isOmniSettlementMachineComplete = (
 /**
  * Public projection: keeps the full ordered lifecycle and honest evidence labels
  * visible (so a reader can see exactly which states were money-moving vs
- * intent-only) while dropping internal monetary figures and refs.
+ * intent-only) while dropping internal monetary figures. Evidence refs are
+ * retained because `assertSafeEvidenceRef` admits only public-safe refs and the
+ * promise verification requires one distinct receipt/evidence anchor per state.
  */
 export const publicOmniAcceptedOutcomeSettlementMachineProjection = (
   machine: OmniAcceptedOutcomeSettlementMachine,
@@ -400,6 +402,7 @@ export const publicOmniAcceptedOutcomeSettlementMachineProjection = (
   state: machine.state,
   transitions: machine.transitions.map(transition => ({
     evidenceKind: transition.evidenceKind,
+    evidenceRef: transition.evidenceRef,
     movedMoney: transition.movedMoney,
     stateId: transition.stateId,
   })),

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -470,6 +470,18 @@ describe('public product promises document', () => {
         expect.objectContaining({
           promiseId: 'payments.accepted_outcome_economics.v1',
           state: 'red',
+          evidenceRefs: expect.arrayContaining([
+            'route:/api/public/accepted-outcome/settlement/{economicsId}',
+            'apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.ts',
+            'apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.test.ts',
+          ]),
+          blockerRefs: expect.not.arrayContaining([
+            'blocker.product_promises.settlement_state_machine_incomplete',
+          ]),
+          safeCopy: expect.stringContaining('public-safe evidence ref'),
+          verification: expect.stringContaining(
+            'eight distinct public-safe evidenceRef values',
+          ),
         }),
         expect.objectContaining({
           promiseId: 'energy.flexible_load_proof.v1',

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-27.2'
+export const PublicProductPromisesVersion = '2026-06-28.1'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -1816,23 +1816,27 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Every accepted outcome should distinguish buyer payment, accepted value, pending balance adjustment, payout intent, settlement attempt, reconciliation, and gross margin.',
         safeCopy:
-          'Accepted-outcome economics are a required roadmap gate before broad payout or marketplace-margin claims go green.',
+          'Accepted-outcome economics now expose a receipt-first settlement state history for one accepted outcome at GET /api/public/accepted-outcome/settlement/{economicsId}: authorized, paid, accepted, pending payout, dispatched, confirmed, reconciled, and margin each carry their own public-safe evidence ref. The projection is inert by default and does not by itself prove real payout settlement or make broad marketplace-margin claims green.',
         unsafeCopy:
           'Do not collapse paid, accepted, payable, dispatched, confirmed, reconciled, settled, and gross-margin states into one claim.',
         evidenceRefs: [
           'docs/promises/2026-06-09-product-promises-gap-audit.md',
           'apps/openagents.com/workers/api/src/pylon-accepted-work-payout-slo.ts',
           'apps/openagents.com/workers/api/src/pylon-accepted-work-proof-links.ts',
+          'route:/api/public/accepted-outcome/settlement/{economicsId}',
+          'apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.ts',
+          'apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-state-machine.test.ts',
+          'apps/openagents.com/workers/api/src/omni-accepted-outcome-settlement-bundle.ts',
+          'apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.test.ts',
         ],
         blockerRefs: [
-          'blocker.product_promises.settlement_state_machine_incomplete',
           'blocker.product_promises.contributor_ledger_missing',
           'blocker.product_promises.gross_margin_receipts_missing',
         ],
         verification:
-          'Green requires one accepted outcome with separate authorized, paid, accepted, pending payout, dispatched, confirmed, reconciled, and margin evidence.',
+          'State-machine verification: dereference GET /api/public/accepted-outcome/settlement/{economicsId} and confirm the ordered settlementMachine transitions are authorized, paid, accepted, pending_payout, dispatched, confirmed, reconciled, and margin, with eight distinct public-safe evidenceRef values; illegal transitions are rejected and re-recording the current state is idempotent in omni-accepted-outcome-settlement-state-machine.test.ts. Green still requires a real accepted outcome with contributor ledger and gross-margin receipts reconciled to actual settlement evidence.',
         authorityBoundary:
-          'Payment evidence alone is not accepted-work payout or final settlement evidence.',
+          'The settlement state projection is read-only and inert by default. It grants no dispatch, spend, payout, settlement, withdrawal, or public-claim authority; payment/state-history evidence alone is not final payout settlement evidence.',
       },
       {
         ...basePromiseFields,

--- a/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/public-accepted-outcome-settlement-routes.test.ts
@@ -99,6 +99,13 @@ describe('public accepted-outcome settlement routes', () => {
       'reconciled',
       'margin',
     ])
+    expect(
+      new Set(
+        body.settlement.settlementMachine.transitions.map(
+          (t: any) => t.evidenceRef,
+        ),
+      ).size,
+    ).toBe(8)
     // No internal monetary figures leak.
     expect(JSON.stringify(body)).not.toMatch(
       /amountCents|accruedMarginCents|grossMarginCents|4400|5000/,


### PR DESCRIPTION
Addresses #6847.

### Changes
- Retains public-safe `evidenceRef` values in the accepted-outcome settlement state machine projection while still dropping monetary figures.
- Updates settlement bundle and route tests to assert eight distinct public-safe evidence refs across the full lifecycle.
- Updates the product promise entry and tests for `payments.accepted_outcome_economics.v1` to remove the incomplete-state-machine blocker and describe the receipt-first settlement history.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).