### PR TITLE
fix(pylon): record paid GEPA settlement receipts

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0256_pylon_api_assignment_payment_mode.sql
+++ b/apps/openagents.com/workers/api/migrations/0256_pylon_api_assignment_payment_mode.sql
@@ -1,0 +1,9 @@
+ALTER TABLE pylon_api_assignments
+  ADD COLUMN payment_mode TEXT NOT NULL DEFAULT 'unpaid_smoke'
+  CHECK (payment_mode IN (
+    'unpaid_smoke',
+    'operator_credit',
+    'payable_pending_settlement',
+    'settled_bitcoin',
+    'rejected_no_pay'
+  ));

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1962,9 +1962,9 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Pylon v1.0 can run GEPA-first assignment work through the in-repo runtime.',
         safeCopy:
-          'Pylon v1.0 has assignment, GEPA capability, and runtime contracts with fake-server/no-spend coverage. A 2026-06-11 live no-spend OpenAgents endpoint smoke created, accepted, progressed, artifact-submitted, and operator-closed an unpaid assignment in production. Paid GEPA settlement remains gated.',
+          'Pylon v1.0 has assignment, GEPA capability, runtime contracts, fake-server/no-spend coverage, and an in-repo paid GEPA-style closeout path: a settled_bitcoin assignment can be accepted, closed out, followed by payment-receipt and Spark treasury settlement-status events, and projected with realBitcoinMoved:true plus a paid-settlement transition receipt ref. The public promise stays planned until an owner-armed live paid GEPA settlement receipt is recorded and reviewed.',
         unsafeCopy:
-          'Do not claim Pylon v1.0 runs the full live GEPA network or settles paid GEPA work.',
+          'Do not claim Pylon v1.0 runs the full live GEPA network, has broadly launched paid GEPA work, or has a live owner-reviewed paid GEPA settlement receipt.',
         evidenceRefs: [
           'transition:promise_transition_5decf651-f137-4bd2-b3c6-df26144ac79e',
           'directive.owner.20260611.focus_tassadar_psion_cs336',
@@ -1974,14 +1974,18 @@ export const publicProductPromisesDocument = () => {
           'apps/pylon/docs/2026-06-10-v03-live-worker-loop-smoke.md#recheck-2026-06-11-0110-utc',
           'promise_transition_d0f7edc5-1688-4039-bcdf-8971b79512ef',
           'docs/promises/2026-06-19-pylon-non-green-promise-assault-assessment.md',
+          'apps/openagents.com/workers/api/src/pylon-api.ts',
+          'apps/openagents.com/workers/api/src/pylon-api-routes.ts',
+          'apps/openagents.com/workers/api/src/pylon-api-routes.test.ts',
+          'apps/openagents.com/workers/api/migrations/0256_pylon_api_assignment_payment_mode.sql',
         ],
         blockerRefs: [
-          'blocker.product_promises.paid_gepa_settlement_v03_missing',
+          'blocker.product_promises.live_paid_gepa_settlement_receipt_missing',
         ],
         verification:
-          'Run v1.0 assignment fake-server/no-spend tests locally and the production no-spend assignment smoke. Green network copy still requires one settled paid GEPA assignment receipt, a paid-settlement transition receipt before registry edit, and a deployed registry bump.',
+          'Run v1.0 assignment fake-server/no-spend tests locally, the production no-spend assignment smoke, and bun run --cwd apps/openagents.com/workers/api test -- src/pylon-api-routes.test.ts. The paid GEPA-style route test must show a settled_bitcoin assignment with paymentReceiptRefs, settlementRefs, treasuryReceiptRefs, payoutClaimAllowed:true, realBitcoinMoved:true, and a paid-settlement transitionReceiptRef. Green network copy still requires one live owner-armed settled paid GEPA assignment receipt and owner review per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
-          'No-spend closeout and retained fixtures do not prove paid settlement or live campaign authority.',
+          'In-repo paid-settlement machinery and route tests do not prove live network scale, owner-armed treasury spend, or broad paid campaign authority. Only dereferenceable live settlement receipts may support those claims.',
       },
       {
         ...basePromiseFields,

--- a/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
@@ -40,6 +40,16 @@ type PylonRouteJson = Readonly<{
     closeoutRefs?: ReadonlyArray<string>
     codingAssignment?: Record<string, unknown> | null
     leaseState?: string
+    paymentMode?: string
+    settlement?: Readonly<{
+      paymentReceiptRefs?: ReadonlyArray<string>
+      payoutClaimAllowed?: boolean
+      realBitcoinMoved?: boolean
+      settlementRefs?: ReadonlyArray<string>
+      settlementState?: string
+      transitionReceiptRefs?: ReadonlyArray<string>
+      treasuryReceiptRefs?: ReadonlyArray<string>
+    }>
     state?: string
   }>
   assignments?: ReadonlyArray<
@@ -49,6 +59,7 @@ type PylonRouteJson = Readonly<{
       closeoutRefs?: ReadonlyArray<string>
       codingAssignment?: Record<string, unknown> | null
       leaseState?: string
+      paymentMode?: string
       state?: string
     }>
   >
@@ -3260,6 +3271,149 @@ describe('Pylon API routes', () => {
     expect(paymentReceiptBody.assignment?.state).toBe('accepted_work')
     expect(progressAfterCloseout.status).toBe(409)
     expect(progressAfterCloseoutBody.error).toBe('pylon_api_conflict')
+  })
+
+  test('records a settled paid GEPA-style assignment receipt after accepted closeout', async () => {
+    const store = new MemoryPylonApiStore()
+    await registerPylon(store, {
+      capabilityRefs: ['capability.public.probe_gepa_metric_call'],
+    })
+    await markOnline(store, {
+      capacityRefs: ['capacity.public.probe_gepa_metric_call.available=1'],
+    })
+    await markWalletReady(store)
+
+    const assignmentRef =
+      'assignment.public.pylon_gepa_metric_call.stage0.paid_settlement'
+    const create = await createAssignment(store, {
+      assignmentRef,
+      campaignPolicyRefs: ['policy.public.probe_gepa.paid_settlement'],
+      idempotencyKey: 'assignment-gepa-paid-settlement',
+      paymentMode: 'settled_bitcoin',
+      requiredCapabilityRefs: ['capability.public.probe_gepa_metric_call'],
+      spendCapRefs: ['spend_cap.public.probe_gepa.one_sat'],
+    })
+    const createBody = await responseJson<PylonRouteJson>(create)
+
+    expect(create.status).toBe(201)
+    expect(createBody.assignment?.paymentMode).toBe('settled_bitcoin')
+    expect(createBody.dispatchGate?.paymentMode).toBe('settled_bitcoin')
+
+    await route(
+      store,
+      `/api/pylons/pylon.test.one/assignments/${assignmentRef}/accept`,
+      {
+        body: {
+          acceptanceRefs: ['acceptance.public.probe_gepa.worker_claimed'],
+          accepted: true,
+        },
+        idempotencyKey: 'accept-gepa-paid-settlement',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
+    await route(
+      store,
+      `/api/pylons/pylon.test.one/assignments/${assignmentRef}/artifacts`,
+      {
+        body: {
+          artifactRefs: ['artifact.public.probe_gepa.metric_call.bundle'],
+          proofRefs: ['proof.public.probe_gepa.metric_call.verifier_passed'],
+        },
+        idempotencyKey: 'artifacts-gepa-paid-settlement',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
+    await route(
+      store,
+      `/api/pylons/pylon.test.one/assignments/${assignmentRef}/closeout`,
+      {
+        body: {
+          artifactRefs: ['artifact.public.probe_gepa.metric_call.bundle'],
+          closeoutRefs: ['closeout.public.probe_gepa.metric_call.accepted'],
+          proofRefs: ['proof.public.probe_gepa.metric_call.verifier_passed'],
+          resultRefs: ['result.public.probe_gepa.metric_call.completed'],
+          status: 'closeout_submitted',
+          testRefs: ['test.public.probe_gepa.metric_call.passed'],
+        },
+        idempotencyKey: 'worker-closeout-gepa-paid-settlement',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
+    await route(
+      store,
+      `/api/operator/pylons/assignments/${assignmentRef}/closeout`,
+      {
+        adminToken: true,
+        body: {
+          accepted: true,
+          acceptedWorkRefs: ['accepted_work.public.probe_gepa.metric_call'],
+          closeoutRefs: ['closeout.public.operator.probe_gepa.accepted'],
+        },
+        method: 'POST',
+      },
+    )
+    const payment = await route(
+      store,
+      `/api/pylons/pylon.test.one/assignments/${assignmentRef}/payment-receipts`,
+      {
+        body: {
+          paymentProofRefs: ['payment_proof.public.probe_gepa.redacted'],
+          receiptRefs: ['receipt.public.probe_gepa.paid_assignment'],
+          settlementRefs: ['settlement.public.probe_gepa.spark.pending'],
+        },
+        idempotencyKey: 'payment-gepa-paid-settlement',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
+    const settlement = await route(
+      store,
+      `/api/pylons/pylon.test.one/assignments/${assignmentRef}/settlement-status`,
+      {
+        body: {
+          settlementRefs: ['settlement.public.probe_gepa.spark.settled'],
+          status: 'settled',
+          treasuryReceiptRefs: [
+            'treasury_receipt.public.spark.probe_gepa.paid_assignment',
+          ],
+        },
+        idempotencyKey: 'settlement-gepa-paid-settlement',
+        method: 'POST',
+        tokenUserId: 'agent-one',
+      },
+    )
+    const paymentBody = await responseJson<PylonRouteJson>(payment)
+    const settlementBody = await responseJson<PylonRouteJson>(settlement)
+
+    expect(payment.status).toBe(201)
+    expect(paymentBody.assignment?.settlement).toMatchObject({
+      paymentReceiptRefs: ['receipt.public.probe_gepa.paid_assignment'],
+      payoutClaimAllowed: false,
+      realBitcoinMoved: false,
+      settlementState: 'paid_receipt_recorded',
+    })
+    expect(settlement.status).toBe(201)
+    expect(settlementBody.assignment?.settlement).toMatchObject({
+      paymentReceiptRefs: ['receipt.public.probe_gepa.paid_assignment'],
+      payoutClaimAllowed: true,
+      realBitcoinMoved: true,
+      settlementRefs: [
+        'settlement.public.probe_gepa.spark.pending',
+        'settlement.public.probe_gepa.spark.settled',
+      ],
+      settlementState: 'settled',
+      treasuryReceiptRefs: [
+        'treasury_receipt.public.spark.probe_gepa.paid_assignment',
+      ],
+    })
+    expect(
+      settlementBody.assignment?.settlement?.transitionReceiptRefs?.[0],
+    ).toContain(
+      'receipt.public.pylon_assignment.paid_settlement_transition.assignment.public.pylon_gepa_metric_call.stage0.paid_settlement',
+    )
   })
 
   test('does not record acceptance events after a lost assignment-claim race', async () => {

--- a/apps/openagents.com/workers/api/src/pylon-api-routes.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.ts
@@ -23,6 +23,7 @@ import {
   PylonApiAssignmentCloseoutRequest,
   PylonApiAssignmentProgressRequest,
   type PylonApiAssignmentRecord,
+  type PylonApiEventRecord,
   type PylonApiAssignmentState,
   PylonApiAssignmentWorkerCloseoutRequest,
   PylonApiCreateAssignmentRequest,
@@ -49,6 +50,7 @@ import {
   closeoutPylonApiAssignmentRecord,
   nextAssignmentForEvent,
   nextRegistrationForEvent,
+  pylonApiAssignmentSettlementProjection,
   publicPylonApiAssignmentProjection,
   publicPylonApiEventProjection,
   publicPylonApiQuarantineProjection,
@@ -1593,6 +1595,15 @@ const maybeRecordAutopilotWorkerCloseout = <Bindings extends PylonApiRouteEnv>(
       }).pipe(Effect.asVoid)
 }
 
+const publicAssignmentWithSettlementProjection = (
+  assignment: PylonApiAssignmentRecord,
+  nowIso: string,
+  events: ReadonlyArray<PylonApiEventRecord>,
+) => ({
+  ...publicPylonApiAssignmentProjection(assignment, nowIso),
+  settlement: pylonApiAssignmentSettlementProjection(assignment, events),
+})
+
 const routeEvent = <Bindings extends PylonApiRouteEnv>(
   dependencies: PylonApiRouteDependencies<Bindings>,
   request: Request,
@@ -1822,6 +1833,14 @@ const routeEvent = <Bindings extends PylonApiRouteEnv>(
         nowIso,
       })
     }
+    const assignmentEvents =
+      storedAssignment === undefined
+        ? []
+        : yield* Effect.tryPromise({
+            catch: pylonApiStoreErrorFromUnknown,
+            try: () =>
+              store.listEventsForAssignment(storedAssignment.assignmentRef, 100),
+          })
     const nextRegistrationBase = nextRegistrationForEvent(
       registration,
       eventResult.record,
@@ -1863,9 +1882,10 @@ const routeEvent = <Bindings extends PylonApiRouteEnv>(
         ...(storedAssignment === undefined
           ? {}
           : {
-              assignment: publicPylonApiAssignmentProjection(
+              assignment: publicAssignmentWithSettlementProjection(
                 storedAssignment,
                 nowIso,
+                assignmentEvents,
               ),
             }),
         event: publicPylonApiEventProjection(eventResult.record, nowIso),

--- a/apps/openagents.com/workers/api/src/pylon-api.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api.ts
@@ -685,6 +685,7 @@ export type PylonApiAssignmentRecord = Readonly<{
   jobKind: PylonApiAssignmentJobKind
   leaseExpiresAt: string
   ownerAgentUserId: string
+  paymentMode?: PylonApiAssignmentPaymentMode | undefined
   proofRefs: ReadonlyArray<string>
   publicProjectionJson: string
   pylonRef: string
@@ -802,6 +803,7 @@ export type PylonApiAssignmentProjection = Readonly<{
   jobKind: PylonApiAssignmentJobKind
   leaseExpiresInSeconds: number
   leaseState: 'active' | 'expired' | 'terminal'
+  paymentMode: PylonApiAssignmentPaymentMode
   proofRefs: ReadonlyArray<string>
   pylonRef: string
   rejectionRefs: ReadonlyArray<string>
@@ -809,6 +811,18 @@ export type PylonApiAssignmentProjection = Readonly<{
   state: PylonApiAssignmentState
   taskRefs: ReadonlyArray<string>
   updatedAtDisplay: string
+}>
+
+export type PylonApiAssignmentSettlementProjection = Readonly<{
+  caveatRefs: ReadonlyArray<string>
+  paymentProofRefs: ReadonlyArray<string>
+  paymentReceiptRefs: ReadonlyArray<string>
+  payoutClaimAllowed: boolean
+  realBitcoinMoved: boolean
+  settlementRefs: ReadonlyArray<string>
+  settlementState: 'not_applicable' | 'paid_receipt_recorded' | 'settled'
+  transitionReceiptRefs: ReadonlyArray<string>
+  treasuryReceiptRefs: ReadonlyArray<string>
 }>
 
 export type PylonProviderJobLifecycleStage =
@@ -982,6 +996,7 @@ type PylonApiAssignmentRow = Readonly<{
   job_kind: PylonApiAssignmentJobKind
   lease_expires_at: string
   owner_agent_user_id: string
+  payment_mode?: PylonApiAssignmentPaymentMode | null
   proof_refs_json: string
   public_projection_json: string
   pylon_ref: string
@@ -1443,6 +1458,111 @@ const assignmentLeaseExpiresInSeconds = (
     Math.floor((Date.parse(record.leaseExpiresAt) - Date.parse(nowIso)) / 1000),
   )
 
+const refsFromAssignmentEvents = (
+  events: ReadonlyArray<PylonApiEventRecord>,
+  eventKind: PylonApiEventKind,
+  key: string,
+): ReadonlyArray<string> =>
+  uniqueRefs(
+    events
+      .filter(event => event.eventKind === eventKind)
+      .flatMap(event => stringRefsFromEventBody(event.eventBody, key, [])),
+  )
+
+const paidSettlementTransitionReceiptRef = (assignmentRef: string): string =>
+  `receipt.public.pylon_assignment.paid_settlement_transition.${assignmentRef.replaceAll(
+    /[^A-Za-z0-9_.:-]+/g,
+    '_',
+  )}`
+
+const pylonApiAssignmentPaymentMode = (
+  assignment: PylonApiAssignmentRecord,
+): PylonApiAssignmentPaymentMode => assignment.paymentMode ?? 'unpaid_smoke'
+
+export const pylonApiAssignmentSettlementProjection = (
+  assignment: PylonApiAssignmentRecord,
+  events: ReadonlyArray<PylonApiEventRecord>,
+): PylonApiAssignmentSettlementProjection => {
+  const assignmentEvents = events.filter(
+    event => event.assignmentRef === assignment.assignmentRef,
+  )
+  const paymentProofRefs = publicScannerSafeRefs(
+    'payment_proof.public.pylon_assignment',
+    refsFromAssignmentEvents(
+      assignmentEvents,
+      'payment_receipt',
+      'paymentProofRefs',
+    ),
+  )
+  const paymentReceiptRefs = publicScannerSafeRefs(
+    'receipt.public.pylon_assignment.payment',
+    refsFromAssignmentEvents(assignmentEvents, 'payment_receipt', 'receiptRefs'),
+  )
+  const paymentSettlementRefs = refsFromAssignmentEvents(
+    assignmentEvents,
+    'payment_receipt',
+    'settlementRefs',
+  )
+  const statusSettlementRefs = refsFromAssignmentEvents(
+    assignmentEvents,
+    'settlement_status',
+    'settlementRefs',
+  )
+  const settlementRefs = publicScannerSafeRefs(
+    'settlement.public.pylon_assignment',
+    [...paymentSettlementRefs, ...statusSettlementRefs],
+  )
+  const treasuryReceiptRefs = publicScannerSafeRefs(
+    'treasury_receipt.public.pylon_assignment',
+    refsFromAssignmentEvents(
+      assignmentEvents,
+      'settlement_status',
+      'treasuryReceiptRefs',
+    ),
+  )
+  const settledStatusRecorded = assignmentEvents.some(
+    event =>
+      event.eventKind === 'settlement_status' && event.status === 'settled',
+  )
+  const realBitcoinMoved =
+    assignment.state === 'accepted_work' &&
+    pylonApiAssignmentPaymentMode(assignment) === 'settled_bitcoin' &&
+    paymentReceiptRefs.length > 0 &&
+    settlementRefs.length > 0 &&
+    treasuryReceiptRefs.length > 0 &&
+    settledStatusRecorded
+  const paidReceiptRecorded =
+    assignment.state === 'accepted_work' &&
+    pylonApiAssignmentPaymentMode(assignment) !== 'unpaid_smoke' &&
+    paymentReceiptRefs.length > 0
+  const settlementState = realBitcoinMoved
+    ? 'settled'
+    : paidReceiptRecorded
+      ? 'paid_receipt_recorded'
+      : 'not_applicable'
+
+  return {
+    caveatRefs: [
+      ...(realBitcoinMoved
+        ? []
+        : [
+            'caveat.public.pylon_assignment.no_real_bitcoin_moved_without_settlement_receipt',
+          ]),
+      'caveat.public.pylon_assignment.raw_payment_material_not_projected',
+    ],
+    paymentProofRefs,
+    paymentReceiptRefs,
+    payoutClaimAllowed: realBitcoinMoved,
+    realBitcoinMoved,
+    settlementRefs,
+    settlementState,
+    transitionReceiptRefs: realBitcoinMoved
+      ? [paidSettlementTransitionReceiptRef(assignment.assignmentRef)]
+      : [],
+    treasuryReceiptRefs,
+  }
+}
+
 export const publicPylonApiAssignmentProjection = (
   record: PylonApiAssignmentRecord,
   nowIso: string,
@@ -1476,6 +1596,7 @@ export const publicPylonApiAssignmentProjection = (
     'proof.public.pylon_assignment',
     record.proofRefs,
   ),
+  paymentMode: pylonApiAssignmentPaymentMode(record),
   pylonRef: record.pylonRef,
   rejectionRefs: publicScannerSafeRefs(
     'rejection.public.pylon_assignment',
@@ -1689,6 +1810,7 @@ export const buildPylonApiAssignmentRecord = (
       leaseSecondsForRequest(input.request) * 1000,
     ),
     ownerAgentUserId: input.ownerAgentUserId,
+    paymentMode: input.request.paymentMode ?? 'unpaid_smoke',
     proofRefs: [],
     publicProjectionJson: '{}',
     pylonRef: input.request.pylonRef,
@@ -2050,6 +2172,7 @@ const rowToAssignment = (
   jobKind: row.job_kind,
   leaseExpiresAt: row.lease_expires_at,
   ownerAgentUserId: row.owner_agent_user_id,
+  paymentMode: row.payment_mode ?? 'unpaid_smoke',
   proofRefs: parseJsonStringArray(row.proof_refs_json),
   publicProjectionJson: row.public_projection_json,
   pylonRef: row.pylon_ref,
@@ -2155,13 +2278,13 @@ const insertAssignmentStatement = (
     .prepare(
       `INSERT INTO pylon_api_assignments
         (id, assignment_ref, pylon_ref, owner_agent_user_id,
-         idempotency_key_hash, job_kind, state, lease_expires_at,
+         idempotency_key_hash, job_kind, state, payment_mode, lease_expires_at,
          task_refs_json, acceptance_criteria_refs_json,
          result_expectation_refs_json, artifact_refs_json, proof_refs_json,
          accepted_work_refs_json, rejection_refs_json, closeout_refs_json,
          coding_assignment_json, public_projection_json, created_at,
          updated_at, archived_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
     )
     .bind(
       record.id,
@@ -2171,6 +2294,7 @@ const insertAssignmentStatement = (
       record.idempotencyKeyHash,
       record.jobKind,
       record.state,
+      pylonApiAssignmentPaymentMode(record),
       record.leaseExpiresAt,
       JSON.stringify(record.taskRefs),
       JSON.stringify(record.acceptanceCriteriaRefs),
@@ -2557,6 +2681,7 @@ export const makeD1PylonApiStore = (db: D1Database): PylonApiStore => ({
       .prepare(
         `UPDATE pylon_api_assignments
             SET state = ?,
+                payment_mode = ?,
                 artifact_refs_json = ?,
                 proof_refs_json = ?,
                 accepted_work_refs_json = ?,
@@ -2571,6 +2696,7 @@ export const makeD1PylonApiStore = (db: D1Database): PylonApiStore => ({
       )
       .bind(
         record.state,
+        pylonApiAssignmentPaymentMode(record),
         JSON.stringify(record.artifactRefs),
         JSON.stringify(record.proofRefs),
         JSON.stringify(record.acceptedWorkRefs),
@@ -2609,6 +2735,7 @@ export const makeD1PylonApiStore = (db: D1Database): PylonApiStore => ({
       .prepare(
         `UPDATE pylon_api_assignments
             SET state = ?,
+                payment_mode = ?,
                 artifact_refs_json = ?,
                 proof_refs_json = ?,
                 accepted_work_refs_json = ?,
@@ -2624,6 +2751,7 @@ export const makeD1PylonApiStore = (db: D1Database): PylonApiStore => ({
       )
       .bind(
         record.state,
+        pylonApiAssignmentPaymentMode(record),
         JSON.stringify(record.artifactRefs),
         JSON.stringify(record.proofRefs),
         JSON.stringify(record.acceptedWorkRefs),


### PR DESCRIPTION
Addresses #6890.

### Changes
- Adds paid GEPA-style assignment closeout coverage for `settled_bitcoin` assignments, including payment receipt refs, settlement refs, treasury receipt refs, payout eligibility, real bitcoin movement, and paid-settlement transition receipt projection.
- Extends Pylon API assignment handling and routes to carry payment mode and settlement state through accepted closeout and operator settlement events.
- Updates the Pylon GEPA worker loop product promise copy to describe the in-repo paid settlement path while keeping live paid settlement claims gated on owner-reviewed receipts.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- passed (exit 0)