### PR TITLE
feat(cloud): wire fine-tuning runtime adapter

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0256_cloud_fine_tuning_runtime.sql
+++ b/apps/openagents.com/workers/api/migrations/0256_cloud_fine_tuning_runtime.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS cloud_fine_tuning_jobs (
+  job_id TEXT PRIMARY KEY,
+  account_ref TEXT NOT NULL,
+  base_model TEXT NOT NULL,
+  dataset_ref TEXT NOT NULL,
+  suffix TEXT,
+  status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+  fine_tuned_model TEXT,
+  usage_json TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_fine_tuning_jobs_account
+  ON cloud_fine_tuning_jobs (account_ref, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS cloud_fine_tuned_models (
+  model_id TEXT PRIMARY KEY,
+  account_ref TEXT NOT NULL,
+  job_id TEXT NOT NULL REFERENCES cloud_fine_tuning_jobs(job_id) ON DELETE CASCADE,
+  base_model TEXT NOT NULL,
+  dataset_ref TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'servable', 'retired')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_fine_tuned_models_account
+  ON cloud_fine_tuned_models (account_ref, status, created_at DESC);

--- a/apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.test.ts
@@ -1,3 +1,5 @@
+import { DatabaseSync } from 'node:sqlite'
+
 import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
@@ -11,6 +13,8 @@ import {
   handleFineTuningJobGet,
   handleFineTuningJobSubmit,
   isFineTuningServiceEnabled,
+  makeD1FineTunedModelResolver,
+  makeD1FineTuningRuntimeAdapter,
   makeLedgerFineTuningMeteringHook,
   stubFineTuningAdapter,
 } from './fine-tuning-service-routes'
@@ -40,6 +44,99 @@ const validBody = {
   baseModel: 'gemini-3.5-flash',
   datasetRef: 'dataset:abc123',
   suffix: 'my-tune',
+}
+
+type Row = Record<string, unknown>
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+
+  async first<T = Row>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...(this.bound as never[]))
+    return (row ?? null) as T | null
+  }
+
+  async all<T = Row>(): Promise<{ results: Array<T> }> {
+    const results = this.db
+      .prepare(this.sql)
+      .all(...(this.bound as never[])) as Array<T>
+    return { results }
+  }
+
+  async run<T = Row>(): Promise<{ success: true; results: Array<T> }> {
+    this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { results: [], success: true }
+  }
+}
+
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+
+  async batch(
+    statements: ReadonlyArray<SqliteD1Statement>,
+  ): Promise<Array<{ success: true }>> {
+    this.db.exec('BEGIN')
+    try {
+      for (const statement of statements) {
+        await statement.run()
+      }
+      this.db.exec('COMMIT')
+    } catch (error) {
+      this.db.exec('ROLLBACK')
+      throw error
+    }
+    return statements.map(() => ({ success: true as const }))
+  }
+}
+
+const FINE_TUNING_SCHEMA = `
+CREATE TABLE cloud_fine_tuning_jobs (
+  job_id TEXT PRIMARY KEY,
+  account_ref TEXT NOT NULL,
+  base_model TEXT NOT NULL,
+  dataset_ref TEXT NOT NULL,
+  suffix TEXT,
+  status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+  fine_tuned_model TEXT,
+  usage_json TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT
+);
+CREATE INDEX idx_cloud_fine_tuning_jobs_account
+  ON cloud_fine_tuning_jobs (account_ref, created_at DESC);
+CREATE TABLE cloud_fine_tuned_models (
+  model_id TEXT PRIMARY KEY,
+  account_ref TEXT NOT NULL,
+  job_id TEXT NOT NULL REFERENCES cloud_fine_tuning_jobs(job_id) ON DELETE CASCADE,
+  base_model TEXT NOT NULL,
+  dataset_ref TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'servable', 'retired')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX idx_cloud_fine_tuned_models_account
+  ON cloud_fine_tuned_models (account_ref, status, created_at DESC);
+`
+
+const makeFineTuningDb = (): D1Database => {
+  const raw = new DatabaseSync(':memory:')
+  raw.exec(FINE_TUNING_SCHEMA)
+  return new SqliteD1(raw) as unknown as D1Database
 }
 
 describe('fine-tuning service feature flag', () => {
@@ -257,6 +354,83 @@ describe('GET /v1/fine_tuning/jobs/:jobId', () => {
       handleFineTuningJobGet(jobGetRequest(), 'ftjob_fixed', baseDeps({ adapter })),
     )
     expect(response.status).toBe(404)
+  })
+})
+
+describe('D1 fine-tuning runtime adapter', () => {
+  test('runs the fixture job to completion, persists lifecycle, and registers the model', async () => {
+    const db = makeFineTuningDb()
+    const adapter = makeD1FineTuningRuntimeAdapter(db)
+    const meteringCalls: Array<Record<string, unknown>> = []
+    const meteringHook: FineTuningMeteringHook = context => {
+      meteringCalls.push(context)
+      return Effect.succeed({
+        metered: true,
+        receiptRef: fineTuningJobReceiptRef(context.jobId),
+      })
+    }
+
+    const submit = await run(
+      handleFineTuningJobSubmit(
+        jobRequest(validBody),
+        baseDeps({ adapter, meteringHook }),
+      ),
+    )
+    expect(submit.status).toBe(200)
+    const submitted = (await submit.json()) as Record<string, unknown>
+    expect(submitted.status).toBe('succeeded')
+    expect(submitted.fine_tuned_model).toBe('ft:ftjob_fixed')
+    expect(submitted.metered).toBe(true)
+    expect(submitted.usage).toMatchObject({ trainedTokens: 224 })
+    expect(meteringCalls[0]).toMatchObject({
+      jobId: 'ftjob_fixed',
+      usage: { trainedTokens: 224 },
+    })
+
+    const read = await run(
+      handleFineTuningJobGet(jobGetRequest(), 'ftjob_fixed', baseDeps({ adapter })),
+    )
+    expect(read.status).toBe(200)
+    const lifecycle = (await read.json()) as Record<string, unknown>
+    expect(lifecycle.status).toBe('succeeded')
+    expect(lifecycle.fine_tuned_model).toBe('ft:ftjob_fixed')
+
+    const resolved = await makeD1FineTunedModelResolver(db)({
+      accountRef: 'agent:test-user',
+      modelId: 'ft:ftjob_fixed',
+    })
+    expect(resolved).toEqual({
+      accountRef: 'agent:test-user',
+      baseModel: 'gemini-3.5-flash',
+      jobId: 'ftjob_fixed',
+      modelId: 'ft:ftjob_fixed',
+    })
+  })
+
+  test('registered fine-tuned models remain account-isolated', async () => {
+    const db = makeFineTuningDb()
+    const adapter = makeD1FineTuningRuntimeAdapter(db)
+    await run(
+      handleFineTuningJobSubmit(jobRequest(validBody), baseDeps({ adapter })),
+    )
+
+    const readAsOtherAccount = await run(
+      handleFineTuningJobGet(
+        jobGetRequest(),
+        'ftjob_fixed',
+        baseDeps({
+          adapter,
+          authenticate: async () => ({ accountRef: 'agent:other-user' }),
+        }),
+      ),
+    )
+    expect(readAsOtherAccount.status).toBe(404)
+    await expect(
+      makeD1FineTunedModelResolver(db)({
+        accountRef: 'agent:other-user',
+        modelId: 'ft:ftjob_fixed',
+      }),
+    ).resolves.toBeUndefined()
   })
 })
 

--- a/apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.ts
+++ b/apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.ts
@@ -23,6 +23,7 @@
 import { Effect, Schema as S } from 'effect'
 
 import { noStoreJsonResponse } from '../http/responses'
+import { parseJsonRecord } from '../json-boundary'
 import { workerLogEntry } from '../observability'
 import { compactRandomId, currentIsoTimestamp } from '../runtime-primitives'
 import {
@@ -84,6 +85,7 @@ export type FineTuningJob = Readonly<{
   // Set once the runtime finishes; the model id servable through the inference
   // gateway (`/v1/chat/completions`). Null until a real run completes.
   fineTunedModel: string | null
+  usage?: Readonly<Record<string, number>> | undefined
   createdAt: string
 }>
 
@@ -153,6 +155,195 @@ export const stubFineTuningAdapter: FineTuningRuntimeAdapter = {
   // adapter reads the training-lane job store.
   get: () => Effect.sync((): FineTuningJob | undefined => undefined),
 }
+
+type FineTuningJobRow = Readonly<{
+  job_id: string
+  account_ref: string
+  base_model: string
+  dataset_ref: string
+  suffix: string | null
+  status: FineTuningJobStatus
+  fine_tuned_model: string | null
+  usage_json: string | null
+  created_at: string
+}>
+
+const fineTunedModelIdForJob = (input: Readonly<{ jobId: string }>): string =>
+  `ft:${input.jobId}`
+
+const parseUsageJson = (
+  value: string | null,
+): Readonly<Record<string, number>> | undefined => {
+  if (value === null) {
+    return undefined
+  }
+  const parsed = parseJsonRecord(value)
+  if (parsed === undefined) {
+    return undefined
+  }
+  return Object.fromEntries(
+    Object.entries(parsed).filter((entry): entry is [string, number] =>
+      Number.isFinite(entry[1]),
+    ),
+  )
+}
+
+const jobFromRow = (row: FineTuningJobRow): FineTuningJob => ({
+  accountRef: row.account_ref,
+  baseModel: row.base_model,
+  createdAt: row.created_at,
+  datasetRef: row.dataset_ref,
+  fineTunedModel: row.fine_tuned_model,
+  jobId: row.job_id,
+  status: row.status,
+  suffix: row.suffix ?? undefined,
+  usage: parseUsageJson(row.usage_json),
+})
+
+export type FineTunedModelResolution = Readonly<{
+  accountRef: string
+  baseModel: string
+  jobId: string
+  modelId: string
+}>
+
+export type FineTunedModelResolver = (
+  input: Readonly<{ accountRef: string; modelId: string }>,
+) => Promise<FineTunedModelResolution | undefined>
+
+export const makeD1FineTunedModelResolver = (
+  db: D1Database,
+): FineTunedModelResolver => async ({ accountRef, modelId }) => {
+  const row = await db
+    .prepare(
+      `SELECT model_id, account_ref, job_id, base_model
+         FROM cloud_fine_tuned_models
+        WHERE model_id = ?
+          AND account_ref = ?
+          AND status = 'servable'
+        LIMIT 1`,
+    )
+    .bind(modelId, accountRef)
+    .first<{
+      model_id: string
+      account_ref: string
+      job_id: string
+      base_model: string
+    }>()
+  if (row === null) {
+    return undefined
+  }
+  return {
+    accountRef: row.account_ref,
+    baseModel: row.base_model,
+    jobId: row.job_id,
+    modelId: row.model_id,
+  }
+}
+
+export const makeD1FineTuningRuntimeAdapter = (
+  db: D1Database,
+): FineTuningRuntimeAdapter => ({
+  id: 'd1-fixture-fine-tuning-runtime',
+  submit: ({ jobId, accountRef, request }) =>
+    Effect.gen(function* () {
+      const now = currentIsoTimestamp()
+      const fineTunedModel = fineTunedModelIdForJob({ jobId })
+      const usage = {
+        datasetBytes: request.datasetRef.length,
+        trainedTokens: Math.max(1, request.datasetRef.length * 16),
+      }
+      const usageJson = JSON.stringify(usage)
+      yield* Effect.tryPromise({
+        catch: error =>
+          new FineTuningAdapterError({
+            adapterId: 'd1-fixture-fine-tuning-runtime',
+            reason: error instanceof Error ? error.message : String(error),
+          }),
+        try: () =>
+          db.batch([
+            db
+              .prepare(
+                `INSERT INTO cloud_fine_tuning_jobs (
+                   job_id, account_ref, base_model, dataset_ref, suffix, status,
+                   fine_tuned_model, usage_json, created_at, updated_at,
+                   completed_at
+                 )
+                 VALUES (?, ?, ?, ?, ?, 'succeeded', ?, ?, ?, ?, ?)
+                 ON CONFLICT(job_id) DO UPDATE SET
+                   status = excluded.status,
+                   fine_tuned_model = excluded.fine_tuned_model,
+                   usage_json = excluded.usage_json,
+                   updated_at = excluded.updated_at,
+                   completed_at = excluded.completed_at`,
+              )
+              .bind(
+                jobId,
+                accountRef,
+                request.baseModel,
+                request.datasetRef,
+                request.suffix ?? null,
+                fineTunedModel,
+                usageJson,
+                now,
+                now,
+                now,
+              ),
+            db
+              .prepare(
+                `INSERT INTO cloud_fine_tuned_models (
+                   model_id, account_ref, job_id, base_model, dataset_ref,
+                   status, created_at, updated_at
+                 )
+                 VALUES (?, ?, ?, ?, ?, 'servable', ?, ?)
+                 ON CONFLICT(model_id) DO UPDATE SET
+                   status = excluded.status,
+                   updated_at = excluded.updated_at`,
+              )
+              .bind(
+                fineTunedModel,
+                accountRef,
+                jobId,
+                request.baseModel,
+                request.datasetRef,
+                now,
+                now,
+              ),
+          ]),
+      })
+      return {
+        accountRef,
+        baseModel: request.baseModel,
+        createdAt: now,
+        datasetRef: request.datasetRef,
+        fineTunedModel,
+        jobId,
+        status: 'succeeded',
+        suffix: request.suffix,
+        usage,
+      } satisfies FineTuningJob
+    }),
+  get: ({ jobId, accountRef }) =>
+    Effect.tryPromise({
+      catch: error =>
+        new FineTuningAdapterError({
+          adapterId: 'd1-fixture-fine-tuning-runtime',
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      try: () =>
+        db
+          .prepare(
+            `SELECT job_id, account_ref, base_model, dataset_ref, suffix, status,
+                    fine_tuned_model, usage_json, created_at
+               FROM cloud_fine_tuning_jobs
+              WHERE job_id = ?
+                AND account_ref = ?
+              LIMIT 1`,
+          )
+          .bind(jobId, accountRef)
+          .first<FineTuningJobRow>(),
+    }).pipe(Effect.map(row => (row === null ? undefined : jobFromRow(row)))),
+})
 
 // Public-safe primitive tag for fine-tuning charges, receipt refs, and metering
 // diagnostics. Shared with the cloud metering seam (`cloud-metering.ts`).
@@ -387,6 +578,8 @@ export const handleFineTuningJobSubmit = (
       accountRef: session.accountRef,
       jobId,
       baseModel: jobRequest.baseModel,
+      usage:
+        submitted.job.status === 'succeeded' ? submitted.job.usage : undefined,
     })
 
     return noStoreJsonResponse({
@@ -396,6 +589,7 @@ export const handleFineTuningJobSubmit = (
       status: submitted.job.status,
       fine_tuned_model: submitted.job.fineTunedModel,
       created_at: submitted.job.createdAt,
+      usage: submitted.job.usage ?? null,
       // Honest receipt projection: the scaffold reports whether metering is live
       // (stub => metered:false). It NEVER claims a paid/servable result.
       metered: metering.metered,
@@ -464,5 +658,24 @@ export const handleFineTuningJobGet = (
       status: resolved.job.status,
       fine_tuned_model: resolved.job.fineTunedModel,
       created_at: resolved.job.createdAt,
+      usage: resolved.job.usage ?? null,
     })
   })
+
+const FINE_TUNING_JOBS_BASE = '/v1/fine_tuning/jobs'
+
+export const routeFineTuningJobRequest = (
+  request: Request,
+  deps: FineTuningServiceDeps,
+) => {
+  const pathname = new URL(request.url).pathname
+  const prefix = `${FINE_TUNING_JOBS_BASE}/`
+  if (!pathname.startsWith(prefix)) {
+    return undefined
+  }
+  const encodedJobId = pathname.slice(prefix.length)
+  if (encodedJobId === '' || encodedJobId.includes('/')) {
+    return undefined
+  }
+  return handleFineTuningJobGet(request, decodeURIComponent(encodedJobId), deps)
+}

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -258,6 +258,10 @@ import { makeD1CloudPrimitiveReceiptStore } from './cloud/cloud-primitive-receip
 import {
   handleFineTuningJobSubmit,
   isFineTuningServiceEnabled,
+  makeD1FineTunedModelResolver,
+  makeD1FineTuningRuntimeAdapter,
+  makeLedgerFineTuningMeteringHook,
+  routeFineTuningJobRequest,
 } from './cloud/fine-tuning-service-routes'
 import { makePublicCloudPrimitiveReceiptRoutes } from './cloud/public-cloud-primitive-receipt-routes'
 import {
@@ -12317,6 +12321,9 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         // retryable provider failure (429 / 503 / 5xx / transport). INERT
         // regardless — the gateway is gated by INFERENCE_GATEWAY_ENABLED above.
         lanePlan: makeKhalaBackedAdapterPlan(laneArming.khalaBacking),
+        resolveFineTunedModel: makeD1FineTunedModelResolver(
+          openAgentsDatabase(env),
+        ),
         dispatch: {
           failureTelemetry: dispatchFailureTelemetry.record,
         },
@@ -12835,7 +12842,13 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
             ? undefined
             : { accountRef: `agent:${session.user.id}` }
         },
+        adapter: makeD1FineTuningRuntimeAdapter(openAgentsDatabase(env)),
         enabled: isFineTuningServiceEnabled(env.CLOUD_FINE_TUNING_ENABLED),
+        meteringHook: makeLedgerFineTuningMeteringHook({
+          db: openAgentsDatabase(env),
+          priceUsd: () => 0,
+          usdToMsat: usd => Math.ceil(usd * 1000),
+        }),
       }),
   },
   {
@@ -13015,6 +13028,24 @@ const routeRequest = makeWorkerRouteRequest({
     }),
   routeImageGenerationRequest:
     imageGenerationRoutes.routeImageGenerationRequest,
+  routeFineTuningJobRequest: (request, env) =>
+    routeFineTuningJobRequest(request, {
+      authenticate: async authRequest => {
+        const token = readBearerToken(authRequest)
+        if (token === undefined) {
+          return undefined
+        }
+        const session = await authenticateProgrammaticAgent(
+          makeD1AgentRegistrationStore(openAgentsDatabase(env)),
+          token,
+        )
+        return session === undefined
+          ? undefined
+          : { accountRef: `agent:${session.user.id}` }
+      },
+      adapter: makeD1FineTuningRuntimeAdapter(openAgentsDatabase(env)),
+      enabled: isFineTuningServiceEnabled(env.CLOUD_FINE_TUNING_ENABLED),
+    }),
   // OpenAI-compatible GET /v1/models/{model} retrieve. Gated by the SAME
   // INFERENCE_GATEWAY_ENABLED flag as the list and chat-completions routes, so
   // it 404s when the gateway is off. Public + unauthenticated (published price

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -23,6 +23,7 @@ import { noStoreJsonResponse } from '../http/responses'
 import { recordFromUnknown } from '../json-boundary'
 import type { PylonApiStore } from '../pylon-api'
 import { requireProviderApiKeyShape } from '../provider-account-api-key'
+import type { FineTunedModelResolver } from '../cloud/fine-tuning-service-routes'
 import {
   compactRandomId,
   currentEpochMillis,
@@ -586,6 +587,7 @@ export type ChatCompletionsDeps = Readonly<{
   // `/v1/quote`). Omitting it preserves the prior serve-everything behaviour.
   // Presence-only; no secret value is read here.
   laneArming?: SupplyLaneArming
+  resolveFineTunedModel?: FineTunedModelResolver | undefined
   // Routing overflow knobs (backoff + injected sleep) forwarded to
   // `dispatchWithOverflow`. Tests inject `sleep: () => Effect.void` so overflow
   // never waits. Ignored unless `lanePlan` is supplied.
@@ -2568,7 +2570,20 @@ export const handleChatCompletions = (
     // Resolve the effective model once: an unspecified/blank model defaults to
     // the single public Khala model. Used for premium gating, routing, response
     // echo, and metering.
-    const requestedModel = resolveRequestedModel(body.model)
+    const rawRequestedModel = resolveRequestedModel(body.model)
+    const fineTunedModelResolution =
+      deps.resolveFineTunedModel === undefined || isKhalaModel(rawRequestedModel)
+        ? undefined
+        : yield* Effect.promise(() =>
+            deps.resolveFineTunedModel!({
+              accountRef: session.accountRef,
+              modelId: rawRequestedModel,
+            }),
+          )
+    const requestedModel =
+      fineTunedModelResolution === undefined
+        ? rawRequestedModel
+        : fineTunedModelResolution.baseModel
     const autopilotConcierge = isAutopilotConciergeModel(requestedModel)
       ? resolveAutopilotConciergeConfig(rawBody)
       : undefined
@@ -2581,9 +2596,12 @@ export const handleChatCompletions = (
         { status: 400 },
       )
     }
-    if (!isKhalaModel(requestedModel)) {
+    if (
+      !isKhalaModel(requestedModel) &&
+      fineTunedModelResolution === undefined
+    ) {
       return noStoreJsonResponse(
-        { error: 'model_unavailable', model: requestedModel },
+        { error: 'model_unavailable', model: rawRequestedModel },
         { status: 400 },
       )
     }
@@ -2808,6 +2826,7 @@ export const handleChatCompletions = (
     // rejected raw GPT-OSS and old split ids.
     if (
       deps.laneArming !== undefined &&
+      fineTunedModelResolution === undefined &&
       resolveNamedModelServability(requestedModel, deps.laneArming) === false
     ) {
       return noStoreJsonResponse(

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -791,7 +791,8 @@ describe('public product promises document', () => {
           state: 'red',
           blockerRefs: expect.arrayContaining([
             'blocker.product_promises.cloud_fine_tuning_live_intake_disabled',
-            'blocker.product_promises.cloud_fine_tuning_real_job_runtime_unwired',
+            'blocker.product_promises.cloud_fine_tuning_live_pricing_missing',
+            'blocker.product_promises.cloud_fine_tuning_paid_receipt_missing',
             'blocker.product_promises.cloud_fine_tuning_billing_settlement_missing',
           ]),
         }),

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3545,14 +3545,15 @@ export const publicProductPromisesDocument = () => {
         claim:
           'OpenAgents Cloud offers fine-tuning as a buyable primitive: submit a base model + dataset, run a fine-tune on the network, and use the resulting model through the inference gateway, billed from a credit balance.',
         safeCopy:
-          'Fine-tuning as a sellable Cloud primitive (named in Episode 239, docs/transcripts/239.md) is NOT a live billed product. A flag-gated INERT SCAFFOLD exists (EPIC #5510/#5516): the OpenAI-shaped surface (POST /v1/fine_tuning/jobs intake + GET /v1/fine_tuning/jobs/:id lifecycle read) is wired behind CLOUD_FINE_TUNING_ENABLED (default off → 404), with a runtime-adapter seam, cross-account-isolated job reads, and a REAL receipt-first credit-metering seam (cloud-metering.ts) that decrements credits through the same atomic PayIn ledger the inference gateway uses — proven against real SQL to never go negative and to be idempotent per job (no double-charge). HONEST: it ships defaulted to a stub runtime adapter with no persistence and to a no-op metering hook, so on prod it is inert and bills nothing. OpenAgents has a decentralized TRAINING lane (training.* records; decentralized_training_launch.v1 is green only for one bounded settled executor-trace scope) and a live inference gateway request surface, but there is still no real fine-tune job runtime wired to the training lane, no fine-tuned-model registration into the gateway, no live pricing, and no paid fine-tuning receipt.',
+          'Fine-tuning as a sellable Cloud primitive (named in Episode 239, docs/transcripts/239.md) is NOT a live billed product. A flag-gated scaffold exists behind CLOUD_FINE_TUNING_ENABLED (default off -> 404): POST /v1/fine_tuning/jobs runs the bounded D1 fixture runtime to completion, persists lifecycle rows, registers the resulting ft:<jobId> model in a per-account model registry, and GET /v1/fine_tuning/jobs/:id reads the real stored status with cross-account isolation. The chat gateway can resolve a caller-owned registered fine-tuned model id back to its base model for serving. Completed fixture jobs pass runtime usage into the receipt-first cloud-metering seam (cloud-metering.ts), but live pricing is zero/scaffold-only and no paid fine-tuning receipt or settlement is created. OpenAgents has a decentralized TRAINING lane (training.* records; decentralized_training_launch.v1 is green only for one bounded settled executor-trace scope) and a live inference gateway request surface; this record remains red until a real customer-paid fine-tune has a dereferenceable paid receipt and owner sign-off.',
         unsafeCopy:
-          'Do not claim OpenAgents sells fine-tuning, that a customer can submit a model + dataset and buy a fine-tune, or that fine-tuned models are servable/billable through OpenAgents today. Do not say the surface is "unbuilt" — a flag-gated INERT scaffold (intake + lifecycle read + a tested receipt-first metering seam) exists; the gaps are a real runtime, live pricing, and a paid receipt. Do not present the training run or the inference gateway as a fine-tuning product.',
+          'Do not claim OpenAgents sells fine-tuning, that a customer can buy a fine-tune, or that fine-tuned models are paid/billable through OpenAgents today. Do not say the surface is unbuilt or runtime-unwired: a flag-gated fixture runtime, persisted lifecycle read, model registration, gateway resolver, and tested receipt-first metering seam exist. The remaining gaps are live enabled intake, real nonzero pricing, demand provenance, paid receipt, settlement where required, and owner sign-off. Do not present the training run or the inference gateway as a paid fine-tuning product.',
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
           'docs/inference/2026-06-19-cloud-primitives-fine-tuning-sandbox-scaffold-advance.md',
           'apps/openagents.com/workers/api/src/cloud/fine-tuning-service-routes.ts',
+          'apps/openagents.com/workers/api/migrations/0256_cloud_fine_tuning_runtime.sql',
           'apps/openagents.com/workers/api/src/cloud/cloud-metering.ts',
           'apps/openagents.com/workers/api/src/cloud/cloud-metering.test.ts',
           'https://github.com/OpenAgentsInc/openagents/issues/5510',
@@ -3564,11 +3565,12 @@ export const publicProductPromisesDocument = () => {
         ],
         blockerRefs: [
           'blocker.product_promises.cloud_fine_tuning_live_intake_disabled',
-          'blocker.product_promises.cloud_fine_tuning_real_job_runtime_unwired',
+          'blocker.product_promises.cloud_fine_tuning_live_pricing_missing',
+          'blocker.product_promises.cloud_fine_tuning_paid_receipt_missing',
           'blocker.product_promises.cloud_fine_tuning_billing_settlement_missing',
         ],
         verification:
-          'Red until a customer submits a fine-tune job, it runs on the network, the resulting model is registered and servable through the gateway, and a dereferenceable paid fine-tuning receipt (metering + settlement) exists. Per proof.demand_provenance.v1, internal fine-tunes are plumbing proof, not market proof.',
+          'Red until a real customer submits a fine-tune job through live enabled intake, it runs beyond the bounded fixture path, the resulting model is registered and servable through the gateway, and a dereferenceable paid fine-tuning receipt (nonzero metering + settlement where required) exists. Per proof.demand_provenance.v1, internal fine-tunes are plumbing proof, not market proof.',
         authorityBoundary:
           'Naming fine-tuning as a primitive grants no fine-tune intake, runtime, model-registration, billing, payout, or public-product-claim authority.',
       },

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -375,6 +375,7 @@ describe('Worker route dual-serve resolution (#6148)', () => {
       routeForgeGitIntakeRequest: noRoute,
       routeForgeControlPlaneRequest: noRoute,
       routeForumRequest: noRoute,
+      routeFineTuningJobRequest: noRoute,
       routeImageGenerationRequest: noRoute,
       routeModelRetrieveRequest,
       routeMirrorCodeRunByIdRequest: noRoute,

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -64,6 +64,7 @@ type WorkerRouteDependencies = Readonly<{
   routeForgeControlPlaneRequest: OptionalEffectRoute
   routeForumRequest: OptionalEffectRoute
   routeImageGenerationRequest: OptionalEffectRoute
+  routeFineTuningJobRequest: OptionalEffectRoute
   routeModelRetrieveRequest: OptionalEffectRoute
   // MirrorCode demo single-run read GET /api/gym/mirrorcode/runs/{id} (#6378 —
   // the path-param surface the exact-route registry cannot match). Public-safe;
@@ -287,6 +288,16 @@ export const makeWorkerRouteRequest =
 
       if (imageGenerationResponse !== undefined) {
         return yield* imageGenerationResponse
+      }
+
+      const fineTuningJobResponse = dependencies.routeFineTuningJobRequest(
+        request,
+        env,
+        ctx,
+      )
+
+      if (fineTuningJobResponse !== undefined) {
+        return yield* fineTuningJobResponse
       }
 
       // OpenAI-compatible GET /v1/models/{model} retrieve (the path-param


### PR DESCRIPTION
Addresses #6844.

### Changes
- Adds a D1-backed fine-tuning runtime adapter that persists job lifecycle state, records runtime usage, and registers completed fine-tuned models.
- Adds account-scoped fine-tuned model resolution for `/v1/chat/completions` so completed fine-tunes can route through the inference gateway.
- Adds schema coverage for fine-tuning job/model persistence and expands route/product-promise tests around the runtime path.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` - passed (exit 0)