### PR TITLE
feat(inference): record referral margin splits

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0257_inference_referral_margin_splits.sql
+++ b/apps/openagents.com/workers/api/migrations/0257_inference_referral_margin_splits.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS inference_referral_margin_splits (
+  id TEXT PRIMARY KEY NOT NULL,
+  request_id TEXT NOT NULL UNIQUE,
+  account_ref TEXT NOT NULL,
+  referred_user_id TEXT NOT NULL,
+  referrer_user_id TEXT NOT NULL,
+  referral_attribution_id TEXT NOT NULL
+    REFERENCES referral_attributions(id) ON DELETE RESTRICT,
+  referral_source_id TEXT NOT NULL
+    REFERENCES site_referral_sources(id) ON DELETE RESTRICT,
+  referral_invite_id TEXT,
+  payout_ref TEXT NOT NULL,
+  qualifying_event_ref TEXT NOT NULL,
+  charge_receipt_ref TEXT NOT NULL,
+  funding_kind TEXT NOT NULL,
+  adapter_id TEXT NOT NULL,
+  requested_model TEXT NOT NULL,
+  served_model TEXT NOT NULL,
+  served_by_contributor INTEGER NOT NULL DEFAULT 0 CHECK (served_by_contributor IN (0, 1)),
+  serving_node_count INTEGER NOT NULL DEFAULT 0 CHECK (serving_node_count >= 0),
+  charge_usd REAL NOT NULL CHECK (charge_usd >= 0),
+  cost_usd REAL NOT NULL CHECK (cost_usd >= 0),
+  margin_usd REAL NOT NULL CHECK (margin_usd >= 0),
+  margin_sats INTEGER NOT NULL CHECK (margin_sats >= 0),
+  openagents_usd REAL NOT NULL CHECK (openagents_usd >= 0),
+  openagents_sats INTEGER NOT NULL CHECK (openagents_sats >= 0),
+  serving_node_usd REAL NOT NULL CHECK (serving_node_usd >= 0),
+  serving_node_sats INTEGER NOT NULL CHECK (serving_node_sats >= 0),
+  referrer_usd REAL NOT NULL CHECK (referrer_usd >= 0),
+  referrer_sats INTEGER NOT NULL CHECK (referrer_sats >= 0),
+  created_at TEXT NOT NULL,
+  archived_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_inference_referral_margin_splits_referrer
+  ON inference_referral_margin_splits(referrer_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_inference_referral_margin_splits_attribution
+  ON inference_referral_margin_splits(referral_attribution_id, created_at DESC);
+

--- a/apps/openagents.com/workers/api/src/inference/inference-referral-accrual.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-referral-accrual.test.ts
@@ -12,10 +12,12 @@ import { type InferenceUsage } from './provider-adapter'
 import {
   accrueInferenceReferral,
   inferenceReferralIdempotencyKey,
+  inferenceReferralMarginSplitRef,
   inferenceReferralPeriodKey,
   parseReferredParty,
   withReferralAccrual,
 } from './inference-referral-accrual'
+import type { ServingReceipt } from './openagents-network-adapter'
 import { readInferenceReferralDashboard } from './inference-referral-dashboard'
 import { dispatchInferenceReferralPayout } from './inference-referral-dispatch'
 import {
@@ -139,6 +141,37 @@ CREATE TABLE site_referral_payout_ledger_entries (
   created_at TEXT NOT NULL,
   archived_at TEXT
 );
+CREATE TABLE inference_referral_margin_splits (
+  id TEXT PRIMARY KEY NOT NULL,
+  request_id TEXT NOT NULL UNIQUE,
+  account_ref TEXT NOT NULL,
+  referred_user_id TEXT NOT NULL,
+  referrer_user_id TEXT NOT NULL,
+  referral_attribution_id TEXT NOT NULL,
+  referral_source_id TEXT NOT NULL,
+  referral_invite_id TEXT,
+  payout_ref TEXT NOT NULL,
+  qualifying_event_ref TEXT NOT NULL,
+  charge_receipt_ref TEXT NOT NULL,
+  funding_kind TEXT NOT NULL,
+  adapter_id TEXT NOT NULL,
+  requested_model TEXT NOT NULL,
+  served_model TEXT NOT NULL,
+  served_by_contributor INTEGER NOT NULL DEFAULT 0,
+  serving_node_count INTEGER NOT NULL DEFAULT 0,
+  charge_usd REAL NOT NULL,
+  cost_usd REAL NOT NULL,
+  margin_usd REAL NOT NULL,
+  margin_sats INTEGER NOT NULL,
+  openagents_usd REAL NOT NULL,
+  openagents_sats INTEGER NOT NULL,
+  serving_node_usd REAL NOT NULL,
+  serving_node_sats INTEGER NOT NULL,
+  referrer_usd REAL NOT NULL,
+  referrer_sats INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  archived_at TEXT
+);
 `
 
 const NOW = '2026-06-19T12:00:00.000Z'
@@ -198,6 +231,22 @@ const context = (
   ...overrides,
 })
 
+const servingReceipt: ServingReceipt = {
+  paidTrafficVerification: {
+    blockerRefs: [],
+    canaryPassed: true,
+    parityPassed: true,
+    payoutEligible: true,
+    replayPassed: true,
+  },
+  parityMode: 'exact_greedy_parity',
+  parityVerified: true,
+  servedModel: 'sonnet',
+  servingRunRef: 'serving.run.req-1',
+  sharded: false,
+  stages: [{ layerEnd: 32, layerStart: 0, nodeRef: 'pylon:one', role: 'stage' }],
+}
+
 const run = <A>(effect: Effect.Effect<A>): Promise<A> =>
   Effect.runPromise(effect)
 
@@ -240,6 +289,53 @@ describe('accrueInferenceReferral (#5487 attribution + #5488 ongoing accrual)', 
     expect(result.entry.referredUserId).toBe(AGENT)
     expect(result.entry.qualifyingEventKind).toBe('inference_paid_request')
     expect(result.entry.amountSats).toBeGreaterThan(0)
+    expect(result.marginSplitRef).toBe(inferenceReferralMarginSplitRef('req-1'))
+  })
+
+  test('records the per-request OpenAgents / serving-node / referrer margin split', async () => {
+    const db = makeDb()
+    await seedReferredAgent(db)
+
+    const result = await accrueInferenceReferral(db, {
+      context: context({ servingReceipt }),
+      nowIso: () => NOW,
+    })
+
+    expect(result._tag).toBe('recorded')
+    const row = await db
+      .prepare(
+        `SELECT request_id, account_ref, referred_user_id, referrer_user_id,
+                served_by_contributor, serving_node_count, margin_sats,
+                openagents_sats, serving_node_sats, referrer_sats
+           FROM inference_referral_margin_splits
+          WHERE request_id = ?`,
+      )
+      .bind('req-1')
+      .first<{
+        account_ref: string
+        margin_sats: number
+        openagents_sats: number
+        referred_user_id: string
+        referrer_sats: number
+        referrer_user_id: string
+        request_id: string
+        served_by_contributor: number
+        serving_node_count: number
+        serving_node_sats: number
+      }>()
+
+    expect(row).toMatchObject({
+      account_ref: `agent:${AGENT}`,
+      referred_user_id: AGENT,
+      referrer_user_id: REFERRER,
+      request_id: 'req-1',
+      served_by_contributor: 1,
+      serving_node_count: 1,
+    })
+    expect(Number(row?.margin_sats)).toBeGreaterThan(0)
+    expect(Number(row?.openagents_sats)).toBeGreaterThan(0)
+    expect(Number(row?.serving_node_sats)).toBeGreaterThan(0)
+    expect(Number(row?.referrer_sats)).toBeGreaterThan(0)
   })
 
   test('ACCRUES ON EVERY PAID REQUEST (ongoing, not one-time)', async () => {
@@ -291,6 +387,15 @@ describe('accrueInferenceReferral (#5487 attribution + #5488 ongoing accrual)', 
       .bind(inferenceReferralIdempotencyKey('dup'))
       .first<{ n: number }>()
     expect(Number(countRow?.n)).toBe(1)
+
+    const splitCountRow = await db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM inference_referral_margin_splits
+          WHERE id = ?`,
+      )
+      .bind(inferenceReferralMarginSplitRef('dup'))
+      .first<{ n: number }>()
+    expect(Number(splitCountRow?.n)).toBe(1)
   })
 
   test('no_attribution when the account was not referred', async () => {

--- a/apps/openagents.com/workers/api/src/inference/inference-referral-accrual.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-referral-accrual.ts
@@ -53,6 +53,7 @@ import {
 } from './metering-hook'
 import { type FundingKind, priceRequest } from './pricing'
 import {
+  type InferenceSplit,
   type InferenceSplitWeights,
   computeInferenceSplit,
 } from './inference-referral-split'
@@ -183,6 +184,12 @@ export const inferenceReferralPayoutRef = (requestId: string): string =>
 export const INFERENCE_REFERRAL_QUALIFYING_EVENT_KIND =
   'inference_paid_request' as const
 
+export const inferenceReferralMarginSplitRef = (requestId: string): string =>
+  `inference.referral.margin_split.${requestId}`
+
+export const inferenceReferralChargeReceiptRef = (requestId: string): string =>
+  `receipt.inference.charge.${requestId}`
+
 // Period key for the ledger's per-referrer-period caps. Inference accrual is
 // ongoing, so a calendar-month bucket (YYYY-MM, UTC) is the period the existing
 // per-referrer-period cap applies over. Derived from the request's ISO time.
@@ -207,7 +214,77 @@ export type AccrueInferenceReferralResult =
   | Readonly<{ _tag: 'self_attribution' }>
   | Readonly<{ _tag: 'zero_referrer_share' }>
   | Readonly<{ _tag: 'boundary_refused'; reasonRef: string }>
-  | Readonly<{ _tag: 'recorded'; entry: SiteReferralPayoutLedgerEntry }>
+  | Readonly<{
+      _tag: 'recorded'
+      entry: SiteReferralPayoutLedgerEntry
+      marginSplitRef: string
+    }>
+
+const countServingNodes = (context: MeteringContext): number => {
+  const stages = context.servingReceipt?.stages ?? []
+  return new Set(stages.map(stage => stage.nodeRef)).size
+}
+
+const recordInferenceReferralMarginSplit = async (
+  db: D1Database,
+  input: Readonly<{
+    attribution: ConsumedAttributionRow
+    context: MeteringContext
+    nowIso: string
+    party: Exclude<ReferredParty, null>
+    split: InferenceSplit
+  }>,
+): Promise<string> => {
+  const requestId = input.context.requestId
+  const splitRef = inferenceReferralMarginSplitRef(requestId)
+  const servingNodeCount = countServingNodes(input.context)
+
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO inference_referral_margin_splits
+         (id, request_id, account_ref, referred_user_id, referrer_user_id,
+          referral_attribution_id, referral_source_id, referral_invite_id,
+          payout_ref, qualifying_event_ref, charge_receipt_ref, funding_kind,
+          adapter_id, requested_model, served_model, served_by_contributor,
+          serving_node_count, charge_usd, cost_usd, margin_usd, margin_sats,
+          openagents_usd, openagents_sats, serving_node_usd, serving_node_sats,
+          referrer_usd, referrer_sats, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      splitRef,
+      requestId,
+      input.context.accountRef,
+      input.party.userId,
+      input.attribution.referrer_user_id,
+      input.attribution.referral_attribution_id,
+      input.attribution.referral_source_id,
+      input.attribution.referral_invite_id,
+      inferenceReferralPayoutRef(requestId),
+      inferenceReferralQualifyingEventRef(requestId),
+      inferenceReferralChargeReceiptRef(requestId),
+      input.context.fundingKind,
+      input.context.adapterId,
+      input.context.requestedModel,
+      input.context.servedModel,
+      input.context.servingReceipt === undefined ? 0 : 1,
+      servingNodeCount,
+      input.split.chargeUsd,
+      input.split.costUsd,
+      input.split.marginUsd,
+      input.split.marginSats,
+      input.split.openagents.usd,
+      input.split.openagents.sats,
+      input.split.servingNode.usd,
+      input.split.servingNode.sats,
+      input.split.referrer.usd,
+      input.split.referrer.sats,
+      input.nowIso,
+    )
+    .run()
+
+  return splitRef
+}
 
 /**
  * Accrue the referrer's ongoing cut for ONE paid inference request. Resolves the
@@ -261,11 +338,10 @@ export const accrueInferenceReferral = async (
 
   const split = computeInferenceSplit({
     priced,
-    // Referral accrual does not depend on the serving node, so contributor
-    // attribution is irrelevant to the referrer share. Pass false; the referrer
-    // share is the same regardless. (The serving-node share — when present — is
-    // fed by the sibling serving-node payout work, not here.)
-    servedByContributor: false,
+    // The referrer share is independent of who served it, but the receipt-first
+    // split row must preserve the actual three-party posture for this request:
+    // OpenAgents, serving node aggregate, and referrer.
+    servedByContributor: context.servingReceipt !== undefined,
     ...(input.weights === undefined ? {} : { weights: input.weights }),
   })
 
@@ -321,7 +397,14 @@ export const accrueInferenceReferral = async (
   }
 
   const entry = await createReferralPayoutEligibility(db, createInput)
-  return { _tag: 'recorded', entry }
+  const marginSplitRef = await recordInferenceReferralMarginSplit(db, {
+    attribution,
+    context,
+    nowIso,
+    party,
+    split,
+  })
+  return { _tag: 'recorded', entry, marginSplitRef }
 }
 
 export type ReferralAccrualDeps = Readonly<{

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3356,32 +3356,36 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Anyone who refers a user, agent, or business that funds an OpenAgents inference account earns an ongoing referral revshare cut of ALL of that account’s inference spend, indefinitely (not a one-time bounty), settled in credits or Bitcoin.',
         safeCopy:
-          'Referral-on-all-inference is roadmap/contract language only (sub-EPIC #5475). It is designed to reuse the RL-1 referral ledger (attribution -> eligibility -> dispatch) and the credit<->Bitcoin asset-boundary/no-resale guards (RL-3), and to be implemented to span categories from the start. None of it is built: there is no live inference gateway to spend through, no inference referral attribution, no ongoing per-spend accrual, and no settled inference referral payout. The Sites 5% referral payout ledger is a separate, narrower surface that is wired but has paid no real payout (sites.referral_bitcoin_stream.v1, yellow); it is not the inference referral product and does not make this planned claim live.',
+          'Referral-on-all-inference remains planned, not green. The implementation now reuses the RL-1 referral attribution and payout ledger for referred inference principals, accrues eligibility after receipt-first metered paid requests, and records a per-request margin split across OpenAgents, the aggregate serving-node share, and the referrer. That is still not a live earning claim: the paid-credits path is not collectable end-to-end for customers, inference referral payout dispatch remains owner-gated, and no real referred-inference payout has settled with a dereferenceable receipt. The Sites 5% referral payout ledger is a related narrower surface; it does not by itself make this inference referral claim live.',
         unsafeCopy:
-          'Do not claim anyone earns a cut of referred inference spend, that ongoing/indefinite inference referral revshare exists, or that pointing a business at OpenAgents pays the referrer today. Do not present the wired Sites referral ledger as proof this inference referral claim is live.',
+          'Do not claim anyone has received a settled payout from referred inference spend, that pointing a business at OpenAgents pays the referrer today, or that the promise is green. Do not present eligibility rows, split rows, or the wired Sites referral ledger as settled payout proof.',
         evidenceRefs: [
           'docs/inference/2026-06-19-inference-gateway-business.md',
           'docs/inference/2026-06-19-decentralized-serving-shard-wan.md',
           'docs/inference/2026-06-19-agent-cloud-revshare-everywhere.md',
+          'apps/openagents.com/workers/api/src/inference/inference-referral-accrual.ts',
+          'apps/openagents.com/workers/api/src/inference/inference-referral-accrual.test.ts',
+          'apps/openagents.com/workers/api/src/inference/inference-referral-split.ts',
+          'apps/openagents.com/workers/api/migrations/0257_inference_referral_margin_splits.sql',
           'https://github.com/OpenAgentsInc/openagents/issues/5475',
           'https://github.com/OpenAgentsInc/openagents/issues/5487',
           'https://github.com/OpenAgentsInc/openagents/issues/5488',
           'https://github.com/OpenAgentsInc/openagents/issues/5489',
           'https://github.com/OpenAgentsInc/openagents/issues/5490',
           'https://github.com/OpenAgentsInc/openagents/issues/5491',
+          'https://github.com/OpenAgentsInc/openagents/issues/6839',
           'promise:inference.gateway_credits_business.v1',
           'promise:sites.referral_bitcoin_stream.v1',
         ],
         blockerRefs: [
           'blocker.product_promises.inference_paid_credits_card_to_credit_not_collectable',
-          'blocker.product_promises.inference_referral_attribution_unbuilt',
-          'blocker.product_promises.inference_referral_accrual_unbuilt',
+          'blocker.product_promises.inference_referral_first_real_paid_receipt_pending',
           'blocker.product_promises.referral_first_real_payout_pending',
         ],
         verification:
-          'Planned until the PAID inference gateway exists (the request surface is live, but no customer can fund inference spend through it end-to-end yet — inference.gateway_credits_business.v1 stays red on the paid-credits path), inference referral attribution binds a funded referee account to a referrer, ongoing accrual computes a referral % off receipt-first metered inference spend, a three-way per-request margin split (OpenAgents / serving node / referrer) is implemented, and a real referred-inference referral payout settles with a dereferenceable receipt under RL-1/2/3 and the asset-boundary/no-resale guards.',
+          'Planned until the PAID inference gateway is customer-collectable end-to-end, the existing RL-1-backed referred-account accrual path is exercised by real funded inference spend, the recorded per-request split rows reconcile to the metered charge receipt and payout eligibility row, and a real referred-inference referral payout settles with a dereferenceable receipt under RL-1/2/3 and the asset-boundary/no-resale guards.',
         authorityBoundary:
-          'Design intent for cross-category, indefinite referral revshare is roadmap evidence only. It grants no attribution, accrual, eligibility, payout, or settlement authority, and referral attribution is never payout eligibility or spendable settlement by itself.',
+          'Referral attribution, eligibility rows, and recorded split rows are accounting evidence only. They grant no spendable settlement or public green-claim authority until owner-gated dispatch settles a real payout with public-safe receipt evidence.',
       },
       {
         ...basePromiseFields,


### PR DESCRIPTION
Addresses #6839.

### Changes
- Adds per-request inference referral margin split recording for OpenAgents, serving-node, and referrer shares.
- Adds stable refs for inference referral margin splits and charge receipts.
- Persists contributor-serving metadata, margin totals, and split sats/USD values idempotently.
- Updates inference referral promise metadata for the new margin-split behavior.
- Adds coverage for split recording and duplicate request idempotency.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)