### PR TITLE
feat(metrics): ingest measured AO/kWh telemetry

### DIFF
--- a/apps/openagents.com/workers/api/src/accepted-outcomes-per-kwh.test.ts
+++ b/apps/openagents.com/workers/api/src/accepted-outcomes-per-kwh.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from 'vitest'
 
 import {
   AcceptedOutcomesPerKwhEndpoint,
+  AcceptedOutcomesPerKwhMeasuredTelemetryInput,
   AcceptedOutcomesPerKwhProjection,
   AcceptedOutcomesPerKwhRequiredMeasuredDatapoints,
+  measuredTelemetryAoKwhDatapoint,
   modeledLabor4777AoKwhDatapoint,
   projectAcceptedOutcomesPerKwh,
 } from './accepted-outcomes-per-kwh'
@@ -15,6 +17,36 @@ type AcceptedOutcomesPerKwhBody = Readonly<{
   datapoints: ReadonlyArray<unknown>
   metricId: string
 }>
+
+const measuredTelemetry = (
+  datapointId: string,
+  measuredEnergyWh: number,
+) =>
+  new AcceptedOutcomesPerKwhMeasuredTelemetryInput({
+    acceptedOutcomeCount: 2,
+    acceptedOutcomeRefs: [
+      `accepted_outcome.public.${datapointId}.one`,
+      `accepted_outcome.public.${datapointId}.two`,
+    ],
+    caveatRefs: ['caveat.ao_kwh.measured_single_device_window'],
+    datapointId,
+    demandProvenance: {
+      evidenceRefs: [`receipt.public.${datapointId}.customer_payment`],
+      kind: 'external',
+      rationale:
+        'This fixture datapoint represents a third-party paid accepted-outcome window.',
+    },
+    deviceRef: `device.public.${datapointId}`,
+    label: `Measured fixture ${datapointId}`,
+    measuredEnergyWh,
+    measurementMethod: 'wall_meter_wh_for_bounded_accepted_outcome_window',
+    meterEvidenceRefs: [`meter.public.${datapointId}.wh`],
+    settlementReceiptRefs: [`settlement.public.${datapointId}`],
+    sourceRefs: [`source.public.${datapointId}`],
+    verificationRefs: [`verdict.public.${datapointId}`],
+    windowEnd: '2026-06-28T01:30:00.000Z',
+    windowStart: '2026-06-28T01:00:00.000Z',
+  })
 
 describe('Accepted Outcomes per kWh metric', () => {
   test('publishes a receipt-backed modeled seed datapoint with caveats', () => {
@@ -75,7 +107,63 @@ describe('Accepted Outcomes per kWh metric', () => {
     expect(projection.gate.blockerRefs).toContain(
       'blocker.product_promises.ao_kwh_requires_two_measured_datapoints',
     )
-    expect(projection.statusLabel).toContain('0 of 2 measured datapoints')
+    expect(projection.statusLabel).toContain('0 of 2 required measured datapoints')
+  })
+
+  test('ingests measured per-device telemetry into a measured AO/kWh datapoint', () => {
+    const input = measuredTelemetry('ao_kwh.measured.fixture_one', 250)
+    const datapoint = measuredTelemetryAoKwhDatapoint(input)
+
+    expect(datapoint.energyEvidenceState).toBe('measured')
+    expect(datapoint.energyModel).toBeNull()
+    expect(datapoint.measuredEnergyTelemetry).toMatchObject({
+      deviceRef: 'device.public.ao_kwh.measured.fixture_one',
+      measuredEnergyKwh: 0.25,
+      measuredEnergyWh: 250,
+      measurementMethod: 'wall_meter_wh_for_bounded_accepted_outcome_window',
+    })
+    expect(datapoint.measuredEnergyTelemetry?.meterEvidenceRefs).toContain(
+      'meter.public.ao_kwh.measured.fixture_one.wh',
+    )
+    expect(datapoint.acceptedOutcomesPerKwh).toBe(8)
+  })
+
+  test('projects measured datapoints and satisfies the measured telemetry gate only at two measured datapoints', () => {
+    const oneMeasured = projectAcceptedOutcomesPerKwh({
+      generatedAt: '2026-06-28T01:45:00.000Z',
+      measuredTelemetry: [measuredTelemetry('ao_kwh.measured.fixture_one', 250)],
+    })
+    const twoMeasured = projectAcceptedOutcomesPerKwh({
+      generatedAt: '2026-06-28T01:45:00.000Z',
+      measuredTelemetry: [
+        measuredTelemetry('ao_kwh.measured.fixture_one', 250),
+        measuredTelemetry('ao_kwh.measured.fixture_two', 500),
+      ],
+    })
+
+    expect(oneMeasured.datapoints).toHaveLength(2)
+    expect(oneMeasured.energyAccounting.evidenceState).toBe(
+      'modeled_and_measured',
+    )
+    expect(oneMeasured.energyAccounting.measuredDatapointCount).toBe(1)
+    expect(oneMeasured.gate.measuredTelemetryGateSatisfied).toBe(false)
+    expect(oneMeasured.gate.measuredFigurePublicationAllowed).toBe(false)
+    expect(oneMeasured.gate.measuredDatapointShortfall).toBe(1)
+
+    expect(twoMeasured.datapoints).toHaveLength(3)
+    expect(twoMeasured.energyAccounting.measuredDatapointCount).toBe(2)
+    expect(twoMeasured.energyAccounting.modeledDatapointCount).toBe(1)
+    expect(twoMeasured.gate.measuredTelemetryGateSatisfied).toBe(true)
+    expect(twoMeasured.gate.measuredFigurePublicationAllowed).toBe(true)
+    expect(twoMeasured.gate.measuredDatapointShortfall).toBe(0)
+    expect(twoMeasured.gate.blockerRefs).not.toContain(
+      'blocker.product_promises.ao_kwh_requires_two_measured_datapoints',
+    )
+    expect(twoMeasured.gate.blockerRefs).toContain(
+      'blocker.product_promises.ao_kwh_green_transition_receipt_missing',
+    )
+    expect(twoMeasured.gate.greenGateSatisfied).toBe(false)
+    expect(twoMeasured.gate.state).toBe('yellow')
   })
 
   test('labels demand provenance internal/external and forbids unlabeled market-demand claims', () => {
@@ -122,12 +210,13 @@ describe('Accepted Outcomes per kWh metric', () => {
 
     expect(datapoint.windowStart).toBe('2026-06-14T02:36:58.442Z')
     expect(datapoint.windowEnd).toBe('2026-06-14T03:06:15.399Z')
-    expect(datapoint.energyModel.method).toBe(
+    expect(datapoint.energyModel).not.toBeNull()
+    expect(datapoint.energyModel?.method).toBe(
       'modeled_power_kw_times_acceptance_to_result_wall_clock',
     )
-    expect(datapoint.energyModel.modeledPowerKw).toBe(0.1)
-    expect(datapoint.energyModel.wallClockSeconds).toBe(1756.957)
-    expect(datapoint.energyModel.energyKwh).toBe(0.048804)
+    expect(datapoint.energyModel?.modeledPowerKw).toBe(0.1)
+    expect(datapoint.energyModel?.wallClockSeconds).toBe(1756.957)
+    expect(datapoint.energyModel?.energyKwh).toBe(0.048804)
     expect(datapoint.acceptedOutcomesPerKwh).toBe(20.49)
   })
 

--- a/apps/openagents.com/workers/api/src/accepted-outcomes-per-kwh.ts
+++ b/apps/openagents.com/workers/api/src/accepted-outcomes-per-kwh.ts
@@ -54,6 +54,16 @@ export class AcceptedOutcomesPerKwhEnergyModel extends S.Class<AcceptedOutcomesP
   assumptionRefs: S.Array(S.String),
 }) {}
 
+export class AcceptedOutcomesPerKwhMeasuredEnergyTelemetry extends S.Class<AcceptedOutcomesPerKwhMeasuredEnergyTelemetry>(
+  'AcceptedOutcomesPerKwhMeasuredEnergyTelemetry',
+)({
+  measurementMethod: S.String,
+  measuredEnergyWh: S.Number,
+  measuredEnergyKwh: S.Number,
+  meterEvidenceRefs: S.Array(S.String),
+  deviceRef: S.String,
+}) {}
+
 export class AcceptedOutcomesPerKwhDatapoint extends S.Class<AcceptedOutcomesPerKwhDatapoint>(
   'AcceptedOutcomesPerKwhDatapoint',
 )({
@@ -67,11 +77,32 @@ export class AcceptedOutcomesPerKwhDatapoint extends S.Class<AcceptedOutcomesPer
   verificationRefs: S.Array(S.String),
   settlementReceiptRefs: S.Array(S.String),
   demandProvenance: AcceptedOutcomesPerKwhDemandProvenance,
-  energyEvidenceState: S.Literal('modeled'),
-  energyModel: AcceptedOutcomesPerKwhEnergyModel,
+  energyEvidenceState: S.Literals(['modeled', 'measured']),
+  energyModel: S.NullOr(AcceptedOutcomesPerKwhEnergyModel),
+  measuredEnergyTelemetry: S.NullOr(AcceptedOutcomesPerKwhMeasuredEnergyTelemetry),
   acceptedOutcomesPerKwh: S.Number,
   caveatRefs: S.Array(S.String),
   sourceRefs: S.Array(S.String),
+}) {}
+
+export class AcceptedOutcomesPerKwhMeasuredTelemetryInput extends S.Class<AcceptedOutcomesPerKwhMeasuredTelemetryInput>(
+  'AcceptedOutcomesPerKwhMeasuredTelemetryInput',
+)({
+  acceptedOutcomeCount: S.Int,
+  acceptedOutcomeRefs: S.Array(S.String),
+  caveatRefs: S.Array(S.String),
+  datapointId: S.String,
+  demandProvenance: AcceptedOutcomesPerKwhDemandProvenance,
+  deviceRef: S.String,
+  label: S.String,
+  measuredEnergyWh: S.Number,
+  measurementMethod: S.String,
+  meterEvidenceRefs: S.Array(S.String),
+  settlementReceiptRefs: S.Array(S.String),
+  sourceRefs: S.Array(S.String),
+  verificationRefs: S.Array(S.String),
+  windowEnd: S.String,
+  windowStart: S.String,
 }) {}
 
 export class AcceptedOutcomesPerKwhGate extends S.Class<AcceptedOutcomesPerKwhGate>(
@@ -106,7 +137,7 @@ export class AcceptedOutcomesPerKwhProjection extends S.Class<AcceptedOutcomesPe
     sourceRefs: S.Array(S.String),
   }),
   energyAccounting: S.Struct({
-    evidenceState: S.Literal('modeled_seed'),
+    evidenceState: S.Literals(['modeled_seed', 'modeled_and_measured']),
     measuredDatapointCount: S.Int,
     modeledDatapointCount: S.Int,
     sourceRefs: S.Array(S.String),
@@ -201,6 +232,7 @@ export const modeledLabor4777AoKwhDatapoint =
         wallClockHours: round(wallClockHours),
         wallClockSeconds: round(wallClockSeconds, 3),
       }),
+      measuredEnergyTelemetry: null,
       label: 'First settled labor job (#4777), modeled energy seed',
       settlementReceiptRefs: [...ACCEPTED_LABOR_4777.settlementReceiptRefs],
       sourceRefs: [...ACCEPTED_LABOR_4777.sourceRefs],
@@ -210,12 +242,63 @@ export const modeledLabor4777AoKwhDatapoint =
     })
   }
 
+export const measuredTelemetryAoKwhDatapoint = (
+  input: AcceptedOutcomesPerKwhMeasuredTelemetryInput,
+): AcceptedOutcomesPerKwhDatapoint => {
+  if (input.acceptedOutcomeCount <= 0) {
+    throw new RangeError(
+      'AO/kWh measured telemetry requires at least one accepted outcome',
+    )
+  }
+  if (input.measuredEnergyWh <= 0) {
+    throw new RangeError(
+      'AO/kWh measured telemetry requires measuredEnergyWh > 0',
+    )
+  }
+  const measuredEnergyKwh = round(input.measuredEnergyWh / 1000)
+  const acceptedOutcomesPerKwh = round(
+    input.acceptedOutcomeCount / measuredEnergyKwh,
+    3,
+  )
+
+  return new AcceptedOutcomesPerKwhDatapoint({
+    acceptedOutcomeCount: input.acceptedOutcomeCount,
+    acceptedOutcomeEvidenceState: 'receipt_backed',
+    acceptedOutcomeRefs: [...input.acceptedOutcomeRefs],
+    acceptedOutcomesPerKwh,
+    caveatRefs: [...input.caveatRefs],
+    datapointId: input.datapointId,
+    demandProvenance: input.demandProvenance,
+    energyEvidenceState: 'measured',
+    energyModel: null,
+    label: input.label,
+    measuredEnergyTelemetry: new AcceptedOutcomesPerKwhMeasuredEnergyTelemetry({
+      deviceRef: input.deviceRef,
+      measuredEnergyKwh,
+      measuredEnergyWh: input.measuredEnergyWh,
+      measurementMethod: input.measurementMethod,
+      meterEvidenceRefs: [...input.meterEvidenceRefs],
+    }),
+    settlementReceiptRefs: [...input.settlementReceiptRefs],
+    sourceRefs: [...input.sourceRefs],
+    verificationRefs: [...input.verificationRefs],
+    windowEnd: input.windowEnd,
+    windowStart: input.windowStart,
+  })
+}
+
 export const projectAcceptedOutcomesPerKwh = (
-  input: { generatedAt?: string | undefined } = {},
+  input: {
+    generatedAt?: string | undefined
+    measuredTelemetry?: ReadonlyArray<AcceptedOutcomesPerKwhMeasuredTelemetryInput>
+  } = {},
 ): AcceptedOutcomesPerKwhProjection => {
-  const datapoints = [modeledLabor4777AoKwhDatapoint()]
+  const measuredDatapoints = (input.measuredTelemetry ?? []).map(
+    measuredTelemetryAoKwhDatapoint,
+  )
+  const datapoints = [modeledLabor4777AoKwhDatapoint(), ...measuredDatapoints]
   const measuredDatapointCount = datapoints.filter(
-    datapoint => datapoint.energyEvidenceState !== 'modeled',
+    datapoint => datapoint.energyEvidenceState === 'measured',
   ).length
   const measuredDatapointShortfall = Math.max(
     0,
@@ -256,22 +339,25 @@ export const projectAcceptedOutcomesPerKwh = (
       rule: 'no_external_dollar_no_demand_claim',
     },
     energyAccounting: {
-      evidenceState: 'modeled_seed',
+      evidenceState:
+        measuredDatapointCount > 0 ? 'modeled_and_measured' : 'modeled_seed',
       measuredDatapointCount,
       modeledDatapointCount: datapoints.filter(
         datapoint => datapoint.energyEvidenceState === 'modeled',
       ).length,
       sourceRefs: datapoints.flatMap(datapoint => [
-        ...datapoint.energyModel.assumptionRefs,
+        ...(datapoint.energyModel?.assumptionRefs ?? []),
+        ...(datapoint.measuredEnergyTelemetry?.meterEvidenceRefs ?? []),
         ...datapoint.sourceRefs,
       ]),
     },
     gate: new AcceptedOutcomesPerKwhGate({
-      blockerRefs: [
-        'blocker.product_promises.energy_accounting_measured_telemetry_missing',
-        'blocker.product_promises.ao_kwh_only_single_modeled_seed_datapoint',
-        'blocker.product_promises.ao_kwh_requires_two_measured_datapoints',
-      ],
+      blockerRefs: measuredTelemetryGateSatisfied
+        ? ['blocker.product_promises.ao_kwh_green_transition_receipt_missing']
+        : [
+            'blocker.product_promises.ao_kwh_measured_datapoints_missing',
+            'blocker.product_promises.ao_kwh_requires_two_measured_datapoints',
+          ],
       caveatRefs: [
         'caveat.ao_kwh.figures_must_label_modeled_vs_measured',
         'caveat.ao_kwh.seed_not_a_ranking_or_efficiency_claim',
@@ -279,7 +365,7 @@ export const projectAcceptedOutcomesPerKwh = (
       currentMeasuredDatapointCount: measuredDatapointCount,
       greenGateSatisfied: false,
       measuredDatapointShortfall,
-      measuredFigurePublicationAllowed: false,
+      measuredFigurePublicationAllowed: measuredTelemetryGateSatisfied,
       measuredTelemetryGateSatisfied,
       modeledFigurePublicationAllowed: true,
       requiredMeasuredDatapointCount:
@@ -298,7 +384,7 @@ export const projectAcceptedOutcomesPerKwh = (
     staleness: AcceptedOutcomesPerKwhStaleness,
     status: 'instrumented_modeled_seed',
     statusLabel:
-      'AO/kWh has one receipt-backed modeled seed datapoint; measured energy telemetry remains missing (0 of 2 measured datapoints).',
+      `AO/kWh has one receipt-backed modeled seed datapoint and ${measuredDatapointCount} of ${AcceptedOutcomesPerKwhRequiredMeasuredDatapoints} required measured datapoints.`,
     unsafeCopy:
       'Do not describe the seed datapoint as measured, broadly representative, a ranking, a provider efficiency claim, investment advice, grid advice, or proof that production energy routing is live. Do not present AO/kWh as green or measured until at least two real telemetry datapoints are published with evidence-state labels and transition receipts. Do not present the internal, operator-staged accepted outcome as external market demand or revenue: no external dollar, no demand claim.',
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3114,7 +3114,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'OpenAgents defines and will measure Accepted Outcomes Per Kilowatt-Hour (AO/kWh) — verified, accepted outcomes produced per kilowatt-hour of energy — as the primary efficiency metric for converting electricity into accepted agent work.',
         safeCopy:
-          'AO/kWh is now instrumented as a yellow, caveated metric: /api/public/metrics/accepted-outcomes-per-kwh publishes the frozen definition plus one receipt-backed modeled seed datapoint from the first settled labor job (#4777). The seed is explicitly modeled, not measured: it uses acceptance-to-result wall-clock timing and a documented 100 W provider-power assumption. The projection also carries a typed demand-provenance split (proof.demand_provenance.v1): the seed outcome is labeled internal (operator-staged, credit-ledger), externalDemandClaimAllowed stays false, and the copy gate forbids presenting it as external market demand. The green gate now exposes the exact measured-telemetry threshold: 0 of 2 required measured AO/kWh datapoints are present. Describe it only as a modeled, internal-demand seed datapoint while measured energy telemetry is still missing.',
+          'AO/kWh is now instrumented as a yellow, caveated metric: /api/public/metrics/accepted-outcomes-per-kwh publishes the frozen definition plus one receipt-backed modeled seed datapoint from the first settled labor job (#4777). The seed is explicitly modeled, not measured: it uses acceptance-to-result wall-clock timing and a documented 100 W provider-power assumption. The source now includes a typed measured per-device telemetry ingestion contract that turns real Wh measurements for accepted-outcome windows into measured AO/kWh datapoints, but the live projection still has 0 of 2 required measured datapoints. The projection also carries a typed demand-provenance split (proof.demand_provenance.v1): the seed outcome is labeled internal (operator-staged, credit-ledger), externalDemandClaimAllowed stays false, and the copy gate forbids presenting it as external market demand. Describe the live endpoint only as a modeled, internal-demand seed datapoint until measured telemetry datapoints are published.',
         unsafeCopy:
           'Do not describe the AO/kWh seed as measured, broadly representative, a provider ranking, a production routing policy, investment advice, grid advice, or proof that live energy dispatch is running. Do not cite any figure without the modeled/measurement evidence label and caveats. Do not present AO/kWh as green or measured until at least two real telemetry datapoints are published with evidence-state labels and transition receipts.',
         evidenceRefs: [
@@ -3129,12 +3129,11 @@ export const publicProductPromisesDocument = () => {
           'promise:proof.demand_provenance.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.energy_accounting_measured_telemetry_missing',
-          'blocker.product_promises.ao_kwh_only_single_modeled_seed_datapoint',
+          'blocker.product_promises.ao_kwh_measured_datapoints_missing',
           'blocker.product_promises.ao_kwh_requires_two_measured_datapoints',
         ],
         verification:
-          'GET /api/public/metrics/accepted-outcomes-per-kwh. Yellow is satisfied when the response decodes, carries schemaVersion openagents.metrics.accepted_outcomes_per_kwh.v1, includes one receipt-backed accepted outcome, labels energyEvidenceState as modeled, and keeps measuredFigurePublicationAllowed false. Green requires at least two measured AO/kWh datapoints from real per-device telemetry, measuredTelemetryGateSatisfied true, and transition receipts.',
+          'GET /api/public/metrics/accepted-outcomes-per-kwh plus accepted-outcomes-per-kwh.test.ts. Yellow is satisfied when the response decodes, carries schemaVersion openagents.metrics.accepted_outcomes_per_kwh.v1, includes one receipt-backed accepted outcome, labels the seed energyEvidenceState as modeled, exposes the measured telemetry gate, and keeps measuredFigurePublicationAllowed false while fewer than two measured datapoints are present. The source ingestion contract accepts real per-device Wh telemetry and computes measured AO/kWh datapoints with energyEvidenceState measured. Green requires at least two measured AO/kWh datapoints from real per-device telemetry, measuredTelemetryGateSatisfied true, and owner-signed transition receipts.',
         authorityBoundary:
           'A defined metric is not a measured result. AO/kWh figures are operational estimates, not investment, grid, utility, or financial advice.',
       },


### PR DESCRIPTION
Addresses #6857.

### Changes
- Added measured per-device energy telemetry schema and AO/kWh datapoint projection support.
- Updated the AO/kWh projection gate to count measured datapoints and allow measured figure publication only after two measured datapoints.
- Extended product promise metric output to include measured telemetry status details.
- Added tests for measured telemetry ingestion, gate behavior, and modeled datapoint compatibility.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).