### PR TITLE
feat(khala-macos): supervise local Pylon lifecycle

### DIFF
--- a/clients/khala-macos/Khala/Khala/KhalaApp.swift
+++ b/clients/khala-macos/Khala/Khala/KhalaApp.swift
@@ -3,11 +3,17 @@ import SwiftUI
 @main
 struct KhalaApp: App {
     @StateObject private var store = ConversationStore()
+    @StateObject private var pylonSupervisor = PylonSupervisor()
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
-            RootView(store: store)
+            RootView(store: store, pylonSupervisor: pylonSupervisor)
                 .frame(minWidth: 1060, minHeight: 720)
+                .task { await pylonSupervisor.start() }
+                .onChange(of: scenePhase) { _, phase in
+                    if phase == .background { pylonSupervisor.stop() }
+                }
         }
         .windowStyle(.titleBar)
         .commands {

--- a/clients/khala-macos/Khala/Khala/Node/PylonSupervisor.swift
+++ b/clients/khala-macos/Khala/Khala/Node/PylonSupervisor.swift
@@ -1,0 +1,283 @@
+import Foundation
+
+enum PylonSupervisorMode: String {
+    case disconnected = "Disconnected"
+    case connectedExisting = "Connected"
+    case bootingBundled = "Booting"
+    case bundledRunning = "Bundled"
+    case stopped = "Stopped"
+}
+
+struct PylonSupervisorSnapshot: Equatable {
+    var mode: PylonSupervisorMode = .disconnected
+    var controlURL: URL
+    var pylonHome: URL
+    var identitySummary = "Unknown"
+    var accountsSummary = "Not loaded"
+    var capacitySummary = "Offline"
+    var assignmentsSummary = "Not loaded"
+    var lastError: String?
+    var logLines: [String] = []
+
+    var pylonStatusText: String {
+        switch mode {
+        case .connectedExisting: return "Attached"
+        case .bootingBundled: return "Booting"
+        case .bundledRunning: return "Running"
+        case .stopped: return "Stopped"
+        case .disconnected: return "Unavailable"
+        }
+    }
+
+    var providerStatusText: String {
+        capacitySummary.contains("available=1") || capacitySummary.contains("ready=1") ? "Online" : "Offline"
+    }
+}
+
+struct PylonSupervisorConfiguration: Equatable {
+    var controlURL: URL
+    var bundledPylonEntry: URL
+    var bundledBunExecutable: URL
+    var appManagedPylonHome: URL
+    var existingPylonHome: URL
+    var appleFmBridgePath: URL
+    var openAgentsBaseURL: String
+    var controlTokenOverride: String?
+
+    static func `default`(
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> PylonSupervisorConfiguration {
+        let controlURL = URL(string: environment["PYLON_CONTROL_URL"] ?? "http://127.0.0.1:\(environment["PYLON_CONTROL_PORT"] ?? "4716")")!
+        let resources = bundle.resourceURL ?? URL(fileURLWithPath: ".")
+        let support = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? fileManager.temporaryDirectory
+        let appHome = support.appendingPathComponent("OpenAgents", isDirectory: true)
+            .appendingPathComponent("KhalaDesktop", isDirectory: true)
+            .appendingPathComponent("Pylon", isDirectory: true)
+        let defaultExistingHome = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(".openagents", isDirectory: true)
+            .appendingPathComponent("pylon", isDirectory: true)
+        return PylonSupervisorConfiguration(
+            controlURL: controlURL,
+            bundledPylonEntry: resources.appendingPathComponent("app/pylon-node/index.js"),
+            bundledBunExecutable: bundle.executableURL?.deletingLastPathComponent().appendingPathComponent("bun") ?? URL(fileURLWithPath: "/usr/bin/env"),
+            appManagedPylonHome: appHome,
+            existingPylonHome: URL(fileURLWithPath: environment["PYLON_HOME"] ?? defaultExistingHome.path),
+            appleFmBridgePath: resources.appendingPathComponent("app/apple-fm-bridge/foundation-bridge"),
+            openAgentsBaseURL: environment["PYLON_OPENAGENTS_BASE_URL"] ?? "https://openagents.com",
+            controlTokenOverride: environment["PYLON_CONTROL_TOKEN"]
+        )
+    }
+}
+
+protocol PylonProcessLaunching {
+    func launchPylonNode(configuration: PylonSupervisorConfiguration) throws -> PylonChildProcess
+}
+
+protocol PylonChildProcess: AnyObject {
+    var isRunning: Bool { get }
+    var terminationHandler: (() -> Void)? { get set }
+    func terminate()
+}
+
+final class ProcessPylonLauncher: PylonProcessLaunching {
+    func launchPylonNode(configuration: PylonSupervisorConfiguration) throws -> PylonChildProcess {
+        try FileManager.default.createDirectory(at: configuration.appManagedPylonHome, withIntermediateDirectories: true)
+        let process = Process()
+        process.executableURL = configuration.bundledBunExecutable
+        if configuration.bundledBunExecutable.lastPathComponent == "env" {
+            process.arguments = ["bun", configuration.bundledPylonEntry.path, "node"]
+        } else {
+            process.arguments = [configuration.bundledPylonEntry.path, "node"]
+        }
+        var environment = ProcessInfo.processInfo.environment
+        environment["PYLON_HOME"] = configuration.appManagedPylonHome.path
+        environment["PYLON_APPLE_FM_SUPERVISE"] = "1"
+        environment["OPENAGENTS_APPLE_FM_BRIDGE_PATH"] = configuration.appleFmBridgePath.path
+        environment["PYLON_ASSIGNMENT_WORKER"] = "1"
+        environment["PYLON_OPENAGENTS_BASE_URL"] = configuration.openAgentsBaseURL
+        environment.removeValue(forKey: "CODEX_HOME")
+        process.environment = environment
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        return ProcessChild(process: process)
+    }
+}
+
+private final class ProcessChild: PylonChildProcess {
+    private let process: Process
+    var terminationHandler: (() -> Void)?
+    var isRunning: Bool { process.isRunning }
+
+    init(process: Process) {
+        self.process = process
+        process.terminationHandler = { [weak self] _ in self?.terminationHandler?() }
+    }
+
+    func terminate() { if process.isRunning { process.terminate() } }
+}
+
+@MainActor
+final class PylonSupervisor: ObservableObject {
+    @Published private(set) var snapshot: PylonSupervisorSnapshot
+
+    private let configuration: PylonSupervisorConfiguration
+    private let launcher: PylonProcessLaunching
+    private let session: URLSession
+    private var child: PylonChildProcess?
+    private var token: String?
+    private var ownsChild = false
+
+    init(
+        configuration: PylonSupervisorConfiguration = .default(),
+        launcher: PylonProcessLaunching = ProcessPylonLauncher(),
+        session: URLSession = .shared
+    ) {
+        self.configuration = configuration
+        self.launcher = launcher
+        self.session = session
+        self.snapshot = PylonSupervisorSnapshot(
+            controlURL: configuration.controlURL,
+            pylonHome: configuration.appManagedPylonHome
+        )
+    }
+
+    func start() async {
+        if await attachExisting() {
+            await refreshReadiness()
+            return
+        }
+        await bootBundled()
+        await refreshReadiness()
+    }
+
+    func stop() {
+        guard ownsChild else {
+            snapshot.mode = .stopped
+            return
+        }
+        child?.terminationHandler = nil
+        child?.terminate()
+        child = nil
+        ownsChild = false
+        snapshot.mode = .stopped
+        appendLog("Stopped bundled Pylon.")
+    }
+
+    func refreshReadiness() async {
+        guard token != nil else { return }
+        async let accounts = controlCommand(["type": "accounts.list"])
+        async let accountStatus = controlCommand(["type": "accounts.status"])
+        async let appleFm = controlCommand(["type": "apple_fm.status"])
+        async let assignments = controlCommand(["type": "assignments.poll"])
+        let results = await (accounts, accountStatus, appleFm, assignments)
+        snapshot.accountsSummary = summarize(results.0) ?? summarize(results.1) ?? "No accounts projected"
+        snapshot.capacitySummary = summarize(results.2) ?? "Apple FM unavailable"
+        snapshot.assignmentsSummary = summarize(results.3) ?? "No assignments"
+        snapshot.identitySummary = "Control: \(configuration.controlURL.host ?? "loopback")"
+    }
+
+    private func attachExisting() async -> Bool {
+        guard await healthIsReachable() else { return false }
+        guard let resolved = readExistingControlToken() else {
+            snapshot.lastError = "Pylon is running, but no local control token was available."
+            return false
+        }
+        token = resolved
+        ownsChild = false
+        snapshot.mode = .connectedExisting
+        snapshot.pylonHome = configuration.existingPylonHome
+        appendLog("Attached to existing Pylon at \(configuration.controlURL.absoluteString).")
+        return true
+    }
+
+    private func bootBundled() async {
+        snapshot.mode = .bootingBundled
+        snapshot.pylonHome = configuration.appManagedPylonHome
+        do {
+            child = try launcher.launchPylonNode(configuration: configuration)
+            ownsChild = true
+            child?.terminationHandler = { [weak self] in
+                Task { @MainActor in self?.handleChildExit() }
+            }
+            token = readControlToken(from: configuration.appManagedPylonHome)
+            snapshot.mode = .bundledRunning
+            appendLog("Launched bundled Pylon with app-managed PYLON_HOME.")
+        } catch {
+            snapshot.mode = .disconnected
+            snapshot.lastError = error.localizedDescription
+            appendLog("Bundled Pylon launch failed.")
+        }
+    }
+
+    private func handleChildExit() {
+        guard ownsChild else { return }
+        appendLog("Bundled Pylon exited; attempting one recovery launch.")
+        ownsChild = false
+        child = nil
+        Task { await bootBundled() }
+    }
+
+    private func healthIsReachable() async -> Bool {
+        do {
+            let (data, response) = try await session.data(from: configuration.controlURL.appendingPathComponent("health"))
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return false }
+            let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            return object?["ok"] as? Bool == true
+        } catch {
+            return false
+        }
+    }
+
+    private func controlCommand(_ command: [String: Any]) async -> Any? {
+        guard let token else { return nil }
+        do {
+            var request = URLRequest(url: configuration.controlURL.appendingPathComponent("command"))
+            request.httpMethod = "POST"
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: command)
+            let (data, response) = try await session.data(for: request)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+            let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            return object?["result"]
+        } catch {
+            return nil
+        }
+    }
+
+    private func readControlToken(from home: URL) -> String? {
+        let tokenURL = home.appendingPathComponent("control-token")
+        guard let text = try? String(contentsOf: tokenURL, encoding: .utf8) else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.count >= 16 ? trimmed : nil
+    }
+
+    private func readExistingControlToken() -> String? {
+        let override = configuration.controlTokenOverride?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let override, override.count >= 16 { return override }
+        return readControlToken(from: configuration.existingPylonHome)
+    }
+
+    private func summarize(_ value: Any?) -> String? {
+        guard let value else { return nil }
+        if let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+           let text = String(data: data, encoding: .utf8) {
+            return redact(text)
+        }
+        return redact(String(describing: value))
+    }
+
+    private func redact(_ text: String) -> String {
+        text.replacingOccurrences(of: #"Bearer\s+[A-Za-z0-9._-]+"#, with: "Bearer [redacted]", options: .regularExpression)
+            .replacingOccurrences(of: #""token"\s*:\s*"[^"]+""#, with: #""token":"[redacted]""#, options: .regularExpression)
+            .replacingOccurrences(of: #"oa_agent_[A-Za-z0-9._-]+"#, with: "oa_agent_[redacted]", options: .regularExpression)
+    }
+
+    private func appendLog(_ line: String) {
+        snapshot.logLines.append(redact(line))
+        if snapshot.logLines.count > 20 { snapshot.logLines.removeFirst(snapshot.logLines.count - 20) }
+    }
+}

--- a/clients/khala-macos/Khala/Khala/Shell/RootView.swift
+++ b/clients/khala-macos/Khala/Khala/Shell/RootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct RootView: View {
     @ObservedObject var store: ConversationStore
+    @ObservedObject var pylonSupervisor: PylonSupervisor
     @State private var draft = ""
     @State private var apiKeyDraft = ""
     @State private var isShowingSettings = false
@@ -42,9 +43,9 @@ struct RootView: View {
                 }
             }
             Divider()
-            StatusLine(title: "Local Pylon", value: "Unavailable", systemImage: "bolt.horizontal")
-            StatusLine(title: "Apple FM", value: "Not attached", systemImage: "cpu")
-            StatusLine(title: "Provider Mode", value: "Offline", systemImage: "antenna.radiowaves.left.and.right")
+            StatusLine(title: "Local Pylon", value: pylonSupervisor.snapshot.pylonStatusText, systemImage: "bolt.horizontal")
+            StatusLine(title: "Apple FM", value: pylonSupervisor.snapshot.capacitySummary.contains("ready=1") ? "Ready" : "Not attached", systemImage: "cpu")
+            StatusLine(title: "Provider Mode", value: pylonSupervisor.snapshot.providerStatusText, systemImage: "antenna.radiowaves.left.and.right")
         }
         .padding()
         .frame(minWidth: 250)
@@ -92,11 +93,24 @@ struct RootView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 Text("Node").font(.title2.bold())
-                InspectorCard(title: "Pylon Supervisor", status: "Unavailable") { Text("This scaffold does not launch or attach to Pylon yet. Provider capacity stays offline until a verified local supervisor is implemented.") }
-                InspectorCard(title: "Apple FM Bridge", status: "Not attached") { Text("No Apple FM helper is bundled by this target. The app will not advertise Apple FM capacity.") }
-                InspectorCard(title: "Fleet", status: "Local only") { Text("Connected accounts, assignments, closeouts, and receipts are reserved for the Pylon integration pass.") }
+                InspectorCard(title: "Pylon Supervisor", status: pylonSupervisor.snapshot.pylonStatusText) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(pylonSupervisor.snapshot.controlURL.absoluteString).font(.caption.monospaced())
+                        Text(pylonSupervisor.snapshot.pylonHome.path).font(.caption.monospaced())
+                        if let error = pylonSupervisor.snapshot.lastError { Text(error) }
+                    }
+                }
+                InspectorCard(title: "Apple FM Bridge", status: pylonSupervisor.snapshot.capacitySummary.contains("ready=1") ? "Ready" : "Unavailable") { Text(pylonSupervisor.snapshot.capacitySummary).lineLimit(6) }
+                InspectorCard(title: "Fleet", status: pylonSupervisor.snapshot.accountsSummary == "Not loaded" ? "Loading" : "Visible") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(pylonSupervisor.snapshot.identitySummary).lineLimit(3)
+                        Text(pylonSupervisor.snapshot.accountsSummary).lineLimit(6)
+                        Text(pylonSupervisor.snapshot.assignmentsSummary).lineLimit(6)
+                    }
+                }
+                Button { Task { await pylonSupervisor.refreshReadiness() } } label: { Label("Refresh Node", systemImage: "arrow.clockwise") }
                 Text("Privacy").font(.headline)
-                Text("The API key is stored in Keychain. Local chat history stays in Application Support on this Mac.").foregroundStyle(.secondary)
+                Text("The API key is stored in Keychain. Local chat history and the bundled Pylon home stay in Application Support on this Mac. The supervisor never writes to the default Codex home.").foregroundStyle(.secondary)
             }.padding(24)
         }.frame(minWidth: 300)
     }

--- a/clients/khala-macos/Khala/KhalaTests/PylonSupervisorTests.swift
+++ b/clients/khala-macos/Khala/KhalaTests/PylonSupervisorTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import XCTest
+@testable import Khala
+
+final class PylonSupervisorTests: XCTestCase {
+    override func tearDown() {
+        PylonMockURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func testAttachesToExistingPylonWhenHealthAndTokenArePresent() async throws {
+        let root = try makeTempDirectory()
+        let existingHome = root.appendingPathComponent("existing", isDirectory: true)
+        try FileManager.default.createDirectory(at: existingHome, withIntermediateDirectories: true)
+        try "0123456789abcdef".write(to: existingHome.appendingPathComponent("control-token"), atomically: true, encoding: .utf8)
+        let launcher = FakePylonLauncher()
+        PylonMockURLProtocol.handler = { request in
+            if request.url?.path == "/health" {
+                return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(#"{"ok":true}"#.utf8))
+            }
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer 0123456789abcdef")
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(#"{"ok":true,"result":{"refs":["capacity.inference.apple_fm.ready=1","capacity.inference.apple_fm.available=1"]}}"#.utf8))
+        }
+
+        let supervisor = PylonSupervisor(
+            configuration: configuration(root: root, existingHome: existingHome),
+            launcher: launcher,
+            session: mockSession()
+        )
+
+        await supervisor.start()
+
+        XCTAssertEqual(supervisor.snapshot.mode, .connectedExisting)
+        XCTAssertEqual(supervisor.snapshot.pylonHome, existingHome)
+        XCTAssertEqual(launcher.launchCount, 0)
+        XCTAssertEqual(supervisor.snapshot.providerStatusText, "Online")
+    }
+
+    @MainActor
+    func testBootsBundledPylonWithAppManagedHomeWhenNoExistingNodeIsReachable() async throws {
+        let root = try makeTempDirectory()
+        let launcher = FakePylonLauncher()
+        PylonMockURLProtocol.handler = { request in
+            if request.url?.path == "/health" {
+                throw URLError(.cannotConnectToHost)
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!, Data())
+        }
+
+        let supervisor = PylonSupervisor(
+            configuration: configuration(root: root),
+            launcher: launcher,
+            session: mockSession()
+        )
+
+        await supervisor.start()
+
+        XCTAssertEqual(supervisor.snapshot.mode, .bundledRunning)
+        XCTAssertEqual(launcher.launchCount, 1)
+        XCTAssertEqual(launcher.lastConfiguration?.appManagedPylonHome.path, root.appendingPathComponent("app-home").path)
+        XCTAssertFalse(supervisor.snapshot.pylonHome.path.contains(".codex"))
+    }
+
+    @MainActor
+    func testAttachCanUseInjectedControlTokenWithoutReadingHomeToken() async throws {
+        let root = try makeTempDirectory()
+        var config = configuration(root: root)
+        config.controlTokenOverride = "override-token-123456"
+        PylonMockURLProtocol.handler = { request in
+            if request.url?.path == "/health" {
+                return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(#"{"ok":true}"#.utf8))
+            }
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer override-token-123456")
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(#"{"ok":true,"result":{"accounts":[]}}"#.utf8))
+        }
+
+        let supervisor = PylonSupervisor(configuration: config, launcher: FakePylonLauncher(), session: mockSession())
+
+        await supervisor.start()
+
+        XCTAssertEqual(supervisor.snapshot.mode, .connectedExisting)
+    }
+
+    @MainActor
+    func testStopTerminatesOnlyBundledChild() async throws {
+        let root = try makeTempDirectory()
+        let launcher = FakePylonLauncher()
+        PylonMockURLProtocol.handler = { request in
+            if request.url?.path == "/health" { throw URLError(.cannotConnectToHost) }
+            return (HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!, Data())
+        }
+        let supervisor = PylonSupervisor(configuration: configuration(root: root), launcher: launcher, session: mockSession())
+        await supervisor.start()
+
+        supervisor.stop()
+
+        XCTAssertEqual(supervisor.snapshot.mode, .stopped)
+        XCTAssertEqual(launcher.child.terminateCount, 1)
+    }
+
+    @MainActor
+    func testCrashRecoveryRelaunchesBundledChildOncePerExit() async throws {
+        let root = try makeTempDirectory()
+        let launcher = FakePylonLauncher()
+        PylonMockURLProtocol.handler = { request in
+            if request.url?.path == "/health" { throw URLError(.cannotConnectToHost) }
+            return (HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!, Data())
+        }
+        let supervisor = PylonSupervisor(configuration: configuration(root: root), launcher: launcher, session: mockSession())
+        await supervisor.start()
+
+        launcher.child.terminationHandler?()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(launcher.launchCount, 2)
+        XCTAssertEqual(supervisor.snapshot.mode, .bundledRunning)
+    }
+
+    @MainActor
+    func testProjectionSummariesRedactTokens() async throws {
+        let root = try makeTempDirectory()
+        let existingHome = root.appendingPathComponent("existing", isDirectory: true)
+        try FileManager.default.createDirectory(at: existingHome, withIntermediateDirectories: true)
+        try "0123456789abcdef".write(to: existingHome.appendingPathComponent("control-token"), atomically: true, encoding: .utf8)
+        PylonMockURLProtocol.handler = { request in
+            if request.url?.path == "/health" {
+                return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(#"{"ok":true}"#.utf8))
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data(#"{"ok":true,"result":{"token":"oa_agent_secret","header":"Bearer abcdefghijklmnop"}}"#.utf8))
+        }
+        let supervisor = PylonSupervisor(configuration: configuration(root: root, existingHome: existingHome), launcher: FakePylonLauncher(), session: mockSession())
+
+        await supervisor.start()
+
+        XCTAssertFalse(supervisor.snapshot.accountsSummary.contains("oa_agent_secret"))
+        XCTAssertFalse(supervisor.snapshot.accountsSummary.contains("Bearer abcdefghijklmnop"))
+        XCTAssertTrue(supervisor.snapshot.accountsSummary.contains("[redacted]"))
+    }
+
+    private func configuration(root: URL, existingHome: URL? = nil) -> PylonSupervisorConfiguration {
+        PylonSupervisorConfiguration(
+            controlURL: URL(string: "http://127.0.0.1:4716")!,
+            bundledPylonEntry: root.appendingPathComponent("pylon-node/index.js"),
+            bundledBunExecutable: root.appendingPathComponent("bun"),
+            appManagedPylonHome: root.appendingPathComponent("app-home", isDirectory: true),
+            existingPylonHome: existingHome ?? root.appendingPathComponent("existing", isDirectory: true),
+            appleFmBridgePath: root.appendingPathComponent("foundation-bridge"),
+            openAgentsBaseURL: "https://openagents.com",
+            controlTokenOverride: nil
+        )
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func mockSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [PylonMockURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+private final class PylonMockURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            guard let handler = Self.handler else { throw URLError(.badServerResponse) }
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private final class FakePylonLauncher: PylonProcessLaunching {
+    let child = FakePylonChild()
+    var launchCount = 0
+    var lastConfiguration: PylonSupervisorConfiguration?
+
+    func launchPylonNode(configuration: PylonSupervisorConfiguration) throws -> PylonChildProcess {
+        launchCount += 1
+        lastConfiguration = configuration
+        try FileManager.default.createDirectory(at: configuration.appManagedPylonHome, withIntermediateDirectories: true)
+        try "fedcba9876543210".write(to: configuration.appManagedPylonHome.appendingPathComponent("control-token"), atomically: true, encoding: .utf8)
+        return child
+    }
+}
+
+private final class FakePylonChild: PylonChildProcess {
+    var isRunning = true
+    var terminationHandler: (() -> Void)?
+    var terminateCount = 0
+
+    func terminate() {
+        terminateCount += 1
+        isRunning = false
+    }
+}

--- a/clients/khala-macos/Khala/README.md
+++ b/clients/khala-macos/Khala/README.md
@@ -13,7 +13,8 @@ Khala Desktop is the native macOS sibling of the iOS Khala app at `clients/khala
 - Chat with the public Khala API after storing an `oa_agent_...` key in Keychain.
 - Local conversation history persisted as JSON in Application Support.
 - Desktop shell with conversation sidebar, main chat pane, and right inspector.
-- Truthful node readiness placeholders for Pylon and Apple FM: unavailable until the supervisor and packaged bridge lifecycle are implemented.
+- Pylon supervisor: attaches to a running local Pylon control endpoint when one is available, otherwise boots the bundled Pylon runtime with an app-managed `PYLON_HOME`.
+- Node inspector: shows Pylon mode, control URL, isolated Pylon home, account/capacity summaries, and assignment summaries.
 - XcodeGen `project.yml` plus a committed `.xcodeproj` using synchronized source folders so the app opens without XcodeGen installed.
 
 ## Build locally
@@ -36,4 +37,4 @@ xcodebuild -project Khala.xcodeproj -scheme Khala -destination 'platform=macOS' 
 
 ## Not in this scaffold
 
-The app does not yet launch a bundled Pylon, publish provider capacity, or ship the Apple FM helper. The UI marks those surfaces unavailable rather than advertising capability that has not been verified.
+The app does not print control tokens or API keys. Bundled Pylon runs with its own Application Support home and does not set or write the default Codex home.

--- a/clients/khala-macos/README.md
+++ b/clients/khala-macos/README.md
@@ -9,10 +9,13 @@ Autopilot Desktop/Pylon Apple FM bridge shape:
 - Apple FM bridge: `foundation-bridge` on loopback `http://127.0.0.1:11435`.
 - Packaged helper path: `Resources/app/apple-fm-bridge/foundation-bridge`.
 - Packaged Pylon entry path: `Resources/app/pylon-node/index.js`.
-- One-launch UX: adopt an already-running Pylon when present, otherwise launch
-  the embedded Pylon node with Apple FM bridge supervision enabled.
+- One-launch UX: adopt an already-running Pylon control endpoint when present,
+  otherwise launch the embedded Pylon node with Apple FM bridge supervision
+  enabled and an app-managed `PYLON_HOME` under Application Support.
 - Demand attribution: local Apple FM turns are marked as owner capacity and keep
   estimated usage truth instead of pretending token counts are exact.
 
-The package does not spawn processes yet. Native app wiring should execute the
-launch plan produced by `buildKhalaMacosLaunchPlan`.
+The native app mirrors this contract in `PylonSupervisor`: it probes the
+loopback control endpoint, authenticates with the local control token, surfaces
+accounts/capacity/assignments in the inspector, and only owns stop/restart for a
+child it launched itself.

--- a/clients/khala-macos/src/launch-plan.test.ts
+++ b/clients/khala-macos/src/launch-plan.test.ts
@@ -3,6 +3,7 @@ import {
   APPLE_FM_BRIDGE_DEFAULT_BASE_URL,
   APPLE_FM_DEFAULT_MODEL_ID,
   APPLE_FM_PACKAGED_HELPER_SUBPATH,
+  KHALA_MACOS_APP_SUPPORT_PYLON_SUBPATH,
   KHALA_APPLE_FM_DEMAND_SOURCE,
   KHALA_APPLE_FM_TOKEN_PROVIDER,
   PYLON_PACKAGED_NODE_SUBPATH,
@@ -46,7 +47,9 @@ describe("Khala macOS Apple FM launch plan", () => {
       `/Applications/Khala.app/Contents/Resources/${PYLON_PACKAGED_NODE_SUBPATH}`,
       "node",
     ])
-    expect(plan.pylonHome).toBe("/Users/alice/.openagents/khala-macos/pylon")
+    expect(plan.pylonHome).toBe(
+      `/Users/alice/${KHALA_MACOS_APP_SUPPORT_PYLON_SUBPATH}`,
+    )
     expect(plan.appleFmBridgePath).toBe(
       `/Applications/Khala.app/Contents/Resources/${APPLE_FM_PACKAGED_HELPER_SUBPATH}`,
     )

--- a/clients/khala-macos/src/launch-plan.ts
+++ b/clients/khala-macos/src/launch-plan.ts
@@ -6,6 +6,8 @@ export const APPLE_FM_BRIDGE_HELPER_BASENAME = "foundation-bridge" as const
 export const APPLE_FM_PACKAGED_HELPER_SUBPATH =
   "app/apple-fm-bridge/foundation-bridge" as const
 export const PYLON_PACKAGED_NODE_SUBPATH = "app/pylon-node/index.js" as const
+export const KHALA_MACOS_APP_SUPPORT_PYLON_SUBPATH =
+  "Library/Application Support/OpenAgents/KhalaDesktop/Pylon" as const
 
 export const KHALA_APPLE_FM_TOKEN_PROVIDER =
   "pylon-apple-fm-own-capacity" as const
@@ -107,7 +109,9 @@ export function buildKhalaMacosLaunchPlan(
     input.resourcesDir,
     APPLE_FM_PACKAGED_HELPER_SUBPATH,
   )
-  const pylonHome = trimValue(env.PYLON_HOME) ?? joinPath(input.homeDir, ".openagents", "khala-macos", "pylon")
+  const pylonHome =
+    trimValue(env.PYLON_HOME) ??
+    joinPath(input.homeDir, KHALA_MACOS_APP_SUPPORT_PYLON_SUBPATH)
   const pylonEntry = joinPath(input.resourcesDir, PYLON_PACKAGED_NODE_SUBPATH)
   const bunPath = trimValue(input.bunPath) ?? "bun"
 


### PR DESCRIPTION
Addresses #6867.

### Changes
- Added a macOS `PylonSupervisor` lifecycle to start with the app, stop in the background, and feed node readiness into `RootView`.
- Updated the node inspector to show Pylon mode, control URL, app-managed `PYLON_HOME`, account/capacity summaries, assignment summaries, and refresh control.
- Updated macOS launch-plan docs/tests to describe adopting an existing control endpoint or booting bundled Pylon with isolated Application Support state.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).