### PR TITLE
docs(promises): update refinery dispatch proof copy

### DIFF
--- a/apps/openagents.com/workers/api/src/cs336-a4-paid-refinery-shard-dispatch.test.ts
+++ b/apps/openagents.com/workers/api/src/cs336-a4-paid-refinery-shard-dispatch.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  deriveCs336A4CrawlShardAssignments,
+  type Cs336A4CrawlShardAssignment,
+} from './cs336-a4-crawl-shard-assignment'
+import { buildCs336A4CrawlShardBatchCloseoutReceipt } from './cs336-a4-crawl-shard-batch-closeout'
+import {
+  buildCs336A4CrawlShardDispatchManifest,
+  type Cs336A4CrawlShardDispatchManifest,
+} from './cs336-a4-crawl-shard-dispatch-manifest'
+import {
+  buildCs336A4CrawlShardPlan,
+  type Cs336A4CrawlSnapshotDescriptor,
+} from './cs336-a4-crawl-shard-plan'
+import {
+  buildCs336A4EvalDeltaDecontaminationReceipt,
+  type Cs336A4EvalDeltaDecontaminationReceipt,
+} from './cs336-a4-eval-delta-decontamination'
+import {
+  type Cs336A4EvalDeltaMeasurement,
+  type Cs336A4EvalDeltaPaymentInput,
+} from './cs336-a4-eval-delta-payment'
+import {
+  closeCs336A4EvalDeltaSettlement,
+  type Cs336A4EvalDeltaSettlementCloseout,
+} from './cs336-a4-eval-delta-settlement-closeout'
+import {
+  buildCs336A4PaidRefineryShardDispatchReceipt,
+  Cs336A4PaidRefineryShardDispatchError,
+  Cs336A4PaidRefineryShardDispatchSchemaVersion,
+  Cs336A4PaidRefineryShardDispatchUnsafeMaterialError,
+} from './cs336-a4-paid-refinery-shard-dispatch'
+import {
+  buildCs336A4ProvenanceReceipt,
+  type Cs336A4ProvenanceReceipt,
+} from './cs336-a4-provenance'
+
+const descriptor: Cs336A4CrawlSnapshotDescriptor = {
+  acquisitionMode: 'public_crawl_snapshot',
+  licenseRef: 'license.public.cc_main.2026_05',
+  segmentCount: 4,
+  snapshotRef: 'snapshot.cc_main.2026_05',
+  sourceRef: 'source.cc_main',
+}
+
+const buildProvenanceReceipt = (
+  assignment: Cs336A4CrawlShardAssignment,
+): Promise<Cs336A4ProvenanceReceipt> => {
+  const sourceInputDigestRef = `digest.cs336_a4.source.${assignment.index}`
+  const finalOutputDigestRef = `digest.cs336_a4.final.${assignment.index}`
+
+  return buildCs336A4ProvenanceReceipt({
+    assignmentRef: assignment.assignmentRef,
+    finalOutputDigestRef,
+    inputShardRef: assignment.inputShardRef,
+    provenance: assignment.provenanceSource,
+    sourceInputDigestRef,
+    transformChain: [
+      {
+        codeVersionRef: 'psionic.refinery.v1.pii_masking',
+        inputDigestRef: sourceInputDigestRef,
+        outputDigestRef: finalOutputDigestRef,
+        recomputedDigestRef: finalOutputDigestRef,
+        stage: 'pii_masking',
+      },
+    ],
+  })
+}
+
+const measurementFor = (
+  assignment: Cs336A4CrawlShardAssignment,
+): Cs336A4EvalDeltaMeasurement => ({
+  baselineScore: 0.4,
+  filteredScore: 0.5,
+  fixedReferenceModelRef: 'config.cs336_a4.fixed_reference_trainer.v1',
+  heldOutEvalSetRef: 'eval.cs336_a4.held_out.v1',
+  sourceRef: assignment.provenanceSource.sourceRef,
+})
+
+const buildDecontaminationReceipt = (
+  measurement: Cs336A4EvalDeltaPaymentInput['measurement'],
+): Promise<Cs336A4EvalDeltaDecontaminationReceipt> =>
+  buildCs336A4EvalDeltaDecontaminationReceipt({
+    contaminatedSpansDetected: 1,
+    contaminatedSpansRemoved: 1,
+    heldOutEvalSetRef: measurement.heldOutEvalSetRef,
+    methodRef: 'method.cs336_a4.ngram_overlap.v1',
+    ngramSize: 13,
+    postDecontaminationDigestRef: 'digest.cs336_a4.corpus.post.0001',
+    preDecontaminationDigestRef: 'digest.cs336_a4.corpus.pre.0001',
+    recomputedPostDigestRef: 'digest.cs336_a4.corpus.post.0001',
+    sourceRef: measurement.sourceRef,
+  })
+
+const setup = async (): Promise<{
+  assignments: ReadonlyArray<Cs336A4CrawlShardAssignment>
+  closeout: Awaited<ReturnType<typeof buildCs336A4CrawlShardBatchCloseoutReceipt>>
+  evalDeltaCloseout: Cs336A4EvalDeltaSettlementCloseout
+  manifest: Cs336A4CrawlShardDispatchManifest
+}> => {
+  const plan = await buildCs336A4CrawlShardPlan({
+    descriptor,
+    targetShardCount: 2,
+  })
+  const assignments = await deriveCs336A4CrawlShardAssignments(plan)
+  const manifest = await buildCs336A4CrawlShardDispatchManifest({
+    assignments,
+    plan,
+  })
+  const provenanceReceipts = await Promise.all(
+    assignments.map(buildProvenanceReceipt),
+  )
+  const closeout = await buildCs336A4CrawlShardBatchCloseoutReceipt({
+    assignments,
+    manifest,
+    receipts: provenanceReceipts,
+  })
+  const measurement = measurementFor(assignments[0]!)
+  const evalDeltaCloseout = await closeCs336A4EvalDeltaSettlement({
+    decontaminationReceipt: await buildDecontaminationReceipt(measurement),
+    fundingParameters: { bonusRateSatsPerUnit: 1000, deltaCap: 1 },
+    measurement,
+    provenanceReceipt: provenanceReceipts[0]!,
+  })
+
+  return { assignments, closeout, evalDeltaCloseout, manifest }
+}
+
+describe('buildCs336A4PaidRefineryShardDispatchReceipt', () => {
+  it('binds paid shard dispatch, provenance closeout, recompute refs, and an eval-delta payment', async () => {
+    const { closeout, evalDeltaCloseout, manifest } = await setup()
+
+    const receipt = await buildCs336A4PaidRefineryShardDispatchReceipt({
+      baseRateSatsPerVerifiedShard: 25,
+      closeout,
+      evalDeltaCloseouts: [evalDeltaCloseout],
+      manifest,
+      verificationRefs: ['challenge.cs336_a4.deterministic_recompute.1'],
+    })
+
+    expect(receipt.schemaVersion).toBe(
+      Cs336A4PaidRefineryShardDispatchSchemaVersion,
+    )
+    expect(receipt.assignmentCount).toBe(manifest.assignmentCount)
+    expect(receipt.basePayoutSats).toBe(50)
+    expect(receipt.evalDeltaSettledBonusSats).toBe(100)
+    expect(receipt.totalComputedPayoutSats).toBe(150)
+    expect(receipt.dispatchManifestRef).toBe(manifest.manifestRef)
+    expect(receipt.batchCloseoutRef).toBe(closeout.closeoutRef)
+    expect(receipt.evalDeltaSettlementReceiptRefs).toEqual([
+      evalDeltaCloseout.settlementReceipt.receiptRef,
+    ])
+    expect(receipt.paidAssignmentRefs).toEqual([...manifest.assignmentRefs].sort())
+    expect(receipt.provenanceReceiptRefs).toEqual(
+      closeout.closures
+        .map(closure => closure.provenanceReceiptRef)
+        .sort(),
+    )
+    expect(receipt.receiptRef).toContain(receipt.contentDigestRef.slice(0, 16))
+  })
+
+  it('is deterministic for the same inputs', async () => {
+    const { closeout, evalDeltaCloseout, manifest } = await setup()
+    const input = {
+      baseRateSatsPerVerifiedShard: 25,
+      closeout,
+      evalDeltaCloseouts: [evalDeltaCloseout],
+      manifest,
+      verificationRefs: ['challenge.cs336_a4.deterministic_recompute.1'],
+    }
+
+    const first = await buildCs336A4PaidRefineryShardDispatchReceipt(input)
+    const second = await buildCs336A4PaidRefineryShardDispatchReceipt(input)
+
+    expect(second.receiptRef).toBe(first.receiptRef)
+    expect(second.contentDigestRef).toBe(first.contentDigestRef)
+  })
+
+  it('rejects paid dispatch when no payable eval-delta closeout exists', async () => {
+    const { assignments, closeout, manifest } = await setup()
+    const provenanceReceipt = await buildProvenanceReceipt(assignments[0]!)
+    const measurement = measurementFor(assignments[0]!)
+    const blockedEvalDeltaCloseout = await closeCs336A4EvalDeltaSettlement({
+      decontaminationReceipt: await buildDecontaminationReceipt(measurement),
+      measurement,
+      provenanceReceipt,
+    })
+
+    await expect(
+      buildCs336A4PaidRefineryShardDispatchReceipt({
+        baseRateSatsPerVerifiedShard: 25,
+        closeout,
+        evalDeltaCloseouts: [blockedEvalDeltaCloseout],
+        manifest,
+        verificationRefs: ['challenge.cs336_a4.deterministic_recompute.1'],
+      }),
+    ).rejects.toThrow(Cs336A4PaidRefineryShardDispatchError)
+  })
+
+  it('rejects an eval-delta closeout for an assignment outside the dispatched batch', async () => {
+    const { closeout, evalDeltaCloseout, manifest } = await setup()
+    const strayEvalDeltaCloseout: Cs336A4EvalDeltaSettlementCloseout = {
+      ...evalDeltaCloseout,
+      settlementReceipt: {
+        ...evalDeltaCloseout.settlementReceipt,
+        assignmentRef: 'assignment.cs336_a4.crawl_shard.stray.0_1.deadbeef',
+      },
+    }
+
+    await expect(
+      buildCs336A4PaidRefineryShardDispatchReceipt({
+        baseRateSatsPerVerifiedShard: 25,
+        closeout,
+        evalDeltaCloseouts: [strayEvalDeltaCloseout],
+        manifest,
+        verificationRefs: ['challenge.cs336_a4.deterministic_recompute.1'],
+      }),
+    ).rejects.toThrow(Cs336A4PaidRefineryShardDispatchError)
+  })
+
+  it('rejects a closeout that does not match the dispatch manifest', async () => {
+    const { closeout, evalDeltaCloseout, manifest } = await setup()
+
+    await expect(
+      buildCs336A4PaidRefineryShardDispatchReceipt({
+        baseRateSatsPerVerifiedShard: 25,
+        closeout: { ...closeout, manifestRef: 'manifest.cs336_a4.other' },
+        evalDeltaCloseouts: [evalDeltaCloseout],
+        manifest,
+        verificationRefs: ['challenge.cs336_a4.deterministic_recompute.1'],
+      }),
+    ).rejects.toThrow(Cs336A4PaidRefineryShardDispatchError)
+  })
+
+  it('rejects unsafe public refs', async () => {
+    const { closeout, evalDeltaCloseout, manifest } = await setup()
+
+    await expect(
+      buildCs336A4PaidRefineryShardDispatchReceipt({
+        baseRateSatsPerVerifiedShard: 25,
+        closeout,
+        evalDeltaCloseouts: [evalDeltaCloseout],
+        manifest,
+        verificationRefs: ['challenge.cs336_a4.wallet.lnbc1leak'],
+      }),
+    ).rejects.toThrow(Cs336A4PaidRefineryShardDispatchUnsafeMaterialError)
+  })
+})

--- a/apps/openagents.com/workers/api/src/cs336-a4-paid-refinery-shard-dispatch.ts
+++ b/apps/openagents.com/workers/api/src/cs336-a4-paid-refinery-shard-dispatch.ts
@@ -1,0 +1,258 @@
+import type { Cs336A4CrawlShardBatchCloseoutReceipt } from './cs336-a4-crawl-shard-batch-closeout'
+import type { Cs336A4CrawlShardDispatchManifest } from './cs336-a4-crawl-shard-dispatch-manifest'
+import { Cs336A4DataRefineryJobKind } from './cs336-a4-data-refinery'
+import type { Cs336A4EvalDeltaSettlementCloseout } from './cs336-a4-eval-delta-settlement-closeout'
+
+/**
+ * Paid CS336 A4 refinery shard dispatch receipt.
+ *
+ * The lower-level crawl-shard modules prove that a batch of assignments is
+ * authentic/complete and that the returned provenance receipts uniquely close
+ * it out. The eval-delta closeout proves a fixed-reference-model quality
+ * payment can be computed against a recompute-verified, decontaminated shard.
+ *
+ * This module binds those artifacts into the public-safe receipt an operator
+ * can use as the paid-dispatch evidence record: every dispatched assignment is
+ * priced at the base verified-shard rate, the batch closeout must match the
+ * dispatch manifest exactly, and at least one assignment must carry a payable
+ * eval-delta settlement receipt. It computes sats only; it never emits wallet,
+ * invoice, preimage, raw crawl payload, or private material.
+ */
+
+export const Cs336A4PaidRefineryShardDispatchSchemaVersion =
+  'openagents.training.data_refinery.paid_refinery_shard_dispatch.v1' as const
+
+export type Cs336A4PaidRefineryShardDispatchReceipt = Readonly<{
+  assignmentCount: number
+  basePayoutSats: number
+  baseRateSatsPerVerifiedShard: number
+  batchCloseoutRef: string
+  contentDigestRef: string
+  dispatchManifestRef: string
+  evalDeltaSettlementReceiptRefs: ReadonlyArray<string>
+  evalDeltaSettledBonusSats: number
+  jobKind: typeof Cs336A4DataRefineryJobKind
+  paidAssignmentRefs: ReadonlyArray<string>
+  planRef: string
+  provenanceReceiptRefs: ReadonlyArray<string>
+  receiptRef: string
+  schemaVersion: typeof Cs336A4PaidRefineryShardDispatchSchemaVersion
+  snapshotRef: string
+  totalComputedPayoutSats: number
+  verificationRefs: ReadonlyArray<string>
+}>
+
+export class Cs336A4PaidRefineryShardDispatchError extends Error {
+  readonly _tag = 'Cs336A4PaidRefineryShardDispatchError'
+}
+
+export class Cs336A4PaidRefineryShardDispatchUnsafeMaterialError extends Error {
+  readonly _tag = 'Cs336A4PaidRefineryShardDispatchUnsafeMaterialError'
+}
+
+const unsafeMaterialPattern =
+  /(\/Users\/|\/home\/|api[_-]?key|bearer|bolt11|bolt12|https?:\/\/|invoice|lnbc|lntb|lnbcrt|lno1|mnemonic|payment[_-]?(hash|preimage)|preimage|private|raw[_-]?(crawl|dataset|invoice|payment|payload|prompt|runner|shard|warc)|secret|seed[_-]?phrase|sk-[a-z0-9]|wallet|warc)/i
+
+const uniqueRefs = (refs: ReadonlyArray<string>): ReadonlyArray<string> =>
+  [...new Set(refs.map(ref => ref.trim()).filter(ref => ref !== ''))].sort()
+
+const assertPublicSafeRefs = (refs: ReadonlyArray<string>): void => {
+  for (const ref of refs) {
+    if (unsafeMaterialPattern.test(ref)) {
+      throw new Cs336A4PaidRefineryShardDispatchUnsafeMaterialError(
+        'CS336 A4 paid refinery dispatch receipt contains wallet, payment, raw payload, URL, or private material.',
+      )
+    }
+  }
+}
+
+const sameRefSet = (
+  left: ReadonlyArray<string>,
+  right: ReadonlyArray<string>,
+): boolean => {
+  const normalizedLeft = uniqueRefs(left)
+  const normalizedRight = uniqueRefs(right)
+
+  return (
+    normalizedLeft.length === normalizedRight.length &&
+    normalizedLeft.every((ref, index) => ref === normalizedRight[index])
+  )
+}
+
+const sha256Hex = async (value: string): Promise<string> => {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(value),
+  )
+
+  return [...new Uint8Array(digest)]
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+const canonicalReceiptBody = (
+  input: Omit<Cs336A4PaidRefineryShardDispatchReceipt, 'contentDigestRef' | 'receiptRef'>,
+): string =>
+  JSON.stringify({
+    assignmentCount: input.assignmentCount,
+    basePayoutSats: input.basePayoutSats,
+    baseRateSatsPerVerifiedShard: input.baseRateSatsPerVerifiedShard,
+    batchCloseoutRef: input.batchCloseoutRef,
+    dispatchManifestRef: input.dispatchManifestRef,
+    evalDeltaSettlementReceiptRefs: input.evalDeltaSettlementReceiptRefs,
+    evalDeltaSettledBonusSats: input.evalDeltaSettledBonusSats,
+    jobKind: input.jobKind,
+    paidAssignmentRefs: input.paidAssignmentRefs,
+    planRef: input.planRef,
+    provenanceReceiptRefs: input.provenanceReceiptRefs,
+    schemaVersion: input.schemaVersion,
+    snapshotRef: input.snapshotRef,
+    totalComputedPayoutSats: input.totalComputedPayoutSats,
+    verificationRefs: input.verificationRefs,
+  })
+
+/**
+ * Builds a deterministic paid-dispatch receipt for a fully closed out A4
+ * refinery shard batch. Fails closed unless:
+ *
+ *  - the closeout receipt binds to the same manifest/plan/snapshot;
+ *  - closeout closures cover exactly the manifest's assignment refs;
+ *  - the base rate is a positive integer sats amount;
+ *  - at least one fixed-reference-model eval-delta closeout is payable; and
+ *  - every payable eval-delta receipt names an assignment in the dispatched set.
+ */
+export const buildCs336A4PaidRefineryShardDispatchReceipt = async (
+  input: Readonly<{
+    baseRateSatsPerVerifiedShard: number
+    closeout: Cs336A4CrawlShardBatchCloseoutReceipt
+    evalDeltaCloseouts: ReadonlyArray<Cs336A4EvalDeltaSettlementCloseout>
+    manifest: Cs336A4CrawlShardDispatchManifest
+    verificationRefs: ReadonlyArray<string>
+  }>,
+): Promise<Cs336A4PaidRefineryShardDispatchReceipt> => {
+  const {
+    baseRateSatsPerVerifiedShard,
+    closeout,
+    evalDeltaCloseouts,
+    manifest,
+    verificationRefs,
+  } = input
+
+  if (
+    !Number.isInteger(baseRateSatsPerVerifiedShard) ||
+    baseRateSatsPerVerifiedShard <= 0
+  ) {
+    throw new Cs336A4PaidRefineryShardDispatchError(
+      'CS336 A4 paid refinery dispatch requires a positive integer baseRateSatsPerVerifiedShard.',
+    )
+  }
+
+  if (manifest.assignmentRefs.length === 0) {
+    throw new Cs336A4PaidRefineryShardDispatchError(
+      'CS336 A4 paid refinery dispatch requires a non-empty dispatch manifest.',
+    )
+  }
+
+  if (
+    closeout.manifestRef !== manifest.manifestRef ||
+    closeout.planRef !== manifest.planRef ||
+    closeout.snapshotRef !== manifest.snapshotRef
+  ) {
+    throw new Cs336A4PaidRefineryShardDispatchError(
+      'CS336 A4 paid refinery dispatch requires the batch closeout to match the dispatch manifest.',
+    )
+  }
+
+  const closedAssignmentRefs = closeout.closures.map(
+    closure => closure.assignmentRef,
+  )
+  if (!sameRefSet(closedAssignmentRefs, manifest.assignmentRefs)) {
+    throw new Cs336A4PaidRefineryShardDispatchError(
+      'CS336 A4 paid refinery dispatch requires closeout closures to cover exactly the dispatched assignment refs.',
+    )
+  }
+
+  const paidAssignmentRefs = uniqueRefs(manifest.assignmentRefs)
+  const dispatched = new Set(paidAssignmentRefs)
+  const payableEvalCloseouts = evalDeltaCloseouts.filter(
+    closeout => closeout.settlementReceipt.payable,
+  )
+
+  if (payableEvalCloseouts.length === 0) {
+    throw new Cs336A4PaidRefineryShardDispatchError(
+      'CS336 A4 paid refinery dispatch requires at least one payable eval-delta settlement closeout.',
+    )
+  }
+
+  for (const evalCloseout of payableEvalCloseouts) {
+    if (!dispatched.has(evalCloseout.settlementReceipt.assignmentRef)) {
+      throw new Cs336A4PaidRefineryShardDispatchError(
+        'CS336 A4 paid refinery dispatch received an eval-delta settlement for an assignment outside the dispatched batch.',
+      )
+    }
+  }
+
+  const normalizedVerificationRefs = uniqueRefs(verificationRefs)
+  if (normalizedVerificationRefs.length === 0) {
+    throw new Cs336A4PaidRefineryShardDispatchError(
+      'CS336 A4 paid refinery dispatch requires deterministic-recompute verification refs.',
+    )
+  }
+
+  const provenanceReceiptRefs = uniqueRefs(
+    closeout.closures.map(closure => closure.provenanceReceiptRef),
+  )
+  const evalDeltaSettlementReceiptRefs = uniqueRefs(
+    payableEvalCloseouts.map(
+      closeout => closeout.settlementReceipt.receiptRef,
+    ),
+  )
+  const evalDeltaSettledBonusSats = payableEvalCloseouts.reduce(
+    (total, closeout) => total + closeout.settlementReceipt.settledBonusSats,
+    0,
+  )
+  const basePayoutSats =
+    paidAssignmentRefs.length * baseRateSatsPerVerifiedShard
+
+  const bodyWithoutDigest = {
+    assignmentCount: paidAssignmentRefs.length,
+    basePayoutSats,
+    baseRateSatsPerVerifiedShard,
+    batchCloseoutRef: closeout.closeoutRef,
+    dispatchManifestRef: manifest.manifestRef,
+    evalDeltaSettlementReceiptRefs,
+    evalDeltaSettledBonusSats,
+    jobKind: Cs336A4DataRefineryJobKind,
+    paidAssignmentRefs,
+    planRef: manifest.planRef,
+    provenanceReceiptRefs,
+    schemaVersion: Cs336A4PaidRefineryShardDispatchSchemaVersion,
+    snapshotRef: manifest.snapshotRef,
+    totalComputedPayoutSats: basePayoutSats + evalDeltaSettledBonusSats,
+    verificationRefs: normalizedVerificationRefs,
+  } satisfies Omit<
+    Cs336A4PaidRefineryShardDispatchReceipt,
+    'contentDigestRef' | 'receiptRef'
+  >
+
+  assertPublicSafeRefs([
+    bodyWithoutDigest.batchCloseoutRef,
+    bodyWithoutDigest.dispatchManifestRef,
+    ...bodyWithoutDigest.evalDeltaSettlementReceiptRefs,
+    ...bodyWithoutDigest.paidAssignmentRefs,
+    bodyWithoutDigest.planRef,
+    ...bodyWithoutDigest.provenanceReceiptRefs,
+    bodyWithoutDigest.snapshotRef,
+    ...bodyWithoutDigest.verificationRefs,
+  ])
+
+  const contentDigestRef = await sha256Hex(
+    canonicalReceiptBody(bodyWithoutDigest),
+  )
+
+  return {
+    ...bodyWithoutDigest,
+    contentDigestRef,
+    receiptRef: `receipt.cs336_a4.paid_refinery_dispatch.${manifest.snapshotRef}.${contentDigestRef.slice(0, 16)}`,
+  }
+}

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -530,6 +530,8 @@ describe('public product promises document', () => {
             'docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md',
             'apps/openagents.com/workers/api/src/cs336-a4-eval-delta-payment.ts',
             'apps/openagents.com/workers/api/src/cs336-a4-eval-delta-payment.test.ts',
+            'apps/openagents.com/workers/api/src/cs336-a4-paid-refinery-shard-dispatch.ts',
+            'apps/openagents.com/workers/api/src/cs336-a4-paid-refinery-shard-dispatch.test.ts',
             'apps/openagents.com/workers/api/src/cs336-a4-provenance.ts',
             'apps/openagents.com/workers/api/src/cs336-a4-provenance.test.ts',
             'apps/openagents.com/workers/api/src/training-data-refinery.ts',
@@ -543,7 +545,7 @@ describe('public product promises document', () => {
           ],
           safeCopy: expect.stringContaining('evalDeltaPaymentGate'),
           verification: expect.stringContaining(
-            'paymentComputationAvailable=true',
+            'paid-dispatch receipt builder',
           ),
         }),
         expect.objectContaining({

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-28.1'
+export const PublicProductPromisesVersion = '2026-06-28.2'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -2087,7 +2087,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Pretraining corpora are produced by an owned data refinery over public crawl-class sources, processed as paid CPU work with provenance and transform digests, mixture ablations, a multi-stage curriculum, decontamination receipts, and eval-delta payment for data quality.',
         safeCopy:
-          'The A4 deterministic refinery core landed in psionic (PII masking, Gopher quality rules, exact and MinHash dedup) and the live a4_eval_delta leaderboard serves an honest empty state. The live A4 evidence admission path now requires each newly admitted shard to carry a corpusProvenanceReceipt whose source provenance and linked transform digests validate against the shard output digest, and the A4 public projection reports corpusProvenanceReceiptStatus/Refs/BlockerRefs plus evalDeltaPaymentGate. The eval-delta payment computation is code-backed and visible, but fixed-trainer measurements, operator funding parameters, settlement receipts, and greenGateSatisfied remain false. Psion’s current corpus is a frozen bounded mixture; crawl-scale acquisition, paid shard assignments with live provenance receipts, decontamination receipts, and eval-delta payment remain planned.',
+          'The A4 deterministic refinery core landed in psionic (PII masking, Gopher quality rules, exact and MinHash dedup) and the live a4_eval_delta leaderboard serves an honest empty state. The live A4 evidence admission path now requires each newly admitted shard to carry a corpusProvenanceReceipt whose source provenance and linked transform digests validate against the shard output digest, and the A4 public projection reports corpusProvenanceReceiptStatus/Refs/BlockerRefs plus evalDeltaPaymentGate. The paid refinery dispatch receipt path is now code-backed: it composes an authentic crawl-shard dispatch manifest, full provenance closeout, deterministic-recompute verification refs, base paid-shard pricing, and at least one payable fixed-reference eval-delta settlement receipt. It is not yet a live crawl-scale corpus claim; real live receipts, operator funding/owner sign-off, decontamination evidence, settlement receipts, and greenGateSatisfied remain false.',
         unsafeCopy:
           'Do not claim a crawl-scale receipted corpus exists, that contributors are currently paid for data-refinery work, or that data quality is paid on measured eval delta.',
         evidenceRefs: [
@@ -2098,6 +2098,8 @@ export const publicProductPromisesDocument = () => {
           'docs/launch/vertex-fleet/training.data_refinery_corpus.v1.md',
           'apps/openagents.com/workers/api/src/cs336-a4-eval-delta-payment.ts',
           'apps/openagents.com/workers/api/src/cs336-a4-eval-delta-payment.test.ts',
+          'apps/openagents.com/workers/api/src/cs336-a4-paid-refinery-shard-dispatch.ts',
+          'apps/openagents.com/workers/api/src/cs336-a4-paid-refinery-shard-dispatch.test.ts',
           'apps/openagents.com/workers/api/src/cs336-a4-provenance.ts',
           'apps/openagents.com/workers/api/src/cs336-a4-provenance.test.ts',
           'apps/openagents.com/workers/api/src/training-data-refinery.ts',
@@ -2111,7 +2113,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.eval_delta_payment_missing',
         ],
         verification:
-          'Green requires refinery shards dispatched as paid assignments with deterministic-recompute verification, every shard carrying source-provenance and transform digests, mixture/annealing ablation receipts, decontamination receipts against the eval suite, and at least one eval-delta payment computed from a fixed reference model. The A4 route now rejects newly admitted shards without a linked, recompute-verified corpusProvenanceReceipt and projects corpusProvenanceReceiptStatus/Refs/BlockerRefs, but blocker.product_promises.corpus_provenance_receipts_missing remains because no live paid refinery shard closeout has produced one of those receipts. The a4_eval_delta leaderboard lane is live-but-empty in training-leaderboards.ts and GET /api/training/refinery/a4 now exposes evalDeltaPaymentGate: paymentComputationAvailable=true, fixedTrainerEvalMeasurementAvailable=false, operatorFundingParametersAvailable=false, settlementReceiptAvailable=false, and greenGateSatisfied=false. The single concrete missing receipt is one Verified deterministic_recompute refinery-shard challenge whose closeout records an eval-delta payment, which would populate the first a4_eval_delta leaderboard row.',
+          'Green requires real refinery shards dispatched as paid assignments with deterministic-recompute verification, every shard carrying source-provenance and transform digests, mixture/annealing ablation receipts, decontamination receipts against the eval suite, and at least one eval-delta payment computed from a fixed reference model. The A4 route now rejects newly admitted shards without a linked, recompute-verified corpusProvenanceReceipt and projects corpusProvenanceReceiptStatus/Refs/BlockerRefs. The code-backed paid-dispatch receipt builder now fails closed unless a dispatch manifest, full provenance batch closeout, deterministic-recompute verification refs, positive base paid-shard rate, and a payable eval-delta settlement receipt all bind to the same dispatched assignment set. The a4_eval_delta leaderboard lane remains live-but-empty in training-leaderboards.ts and GET /api/training/refinery/a4 still exposes evalDeltaPaymentGate with greenGateSatisfied=false until live owner-reviewed receipts populate the projection.',
         authorityBoundary:
           'Refinery output is corpus material, not a dataset sale; the data-market promises govern selling, and privacy rules forbid publishing raw crawl or contributor content.',
       },


### PR DESCRIPTION
Addresses #6880.

### Changes
- Updated the public product promise version for the training data refinery corpus claim.
- Added the paid refinery shard dispatch implementation and test to the promise evidence references.
- Revised the safe copy and verification text to describe the code-backed paid-dispatch receipt builder while keeping the live crawl-scale corpus gate false.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).