### PR TITLE
fix(ops): triage only unlabeled backlog issues

### DIFF
--- a/scripts/github-issue-triage.test.ts
+++ b/scripts/github-issue-triage.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import {
   buildTechnicalPlan,
+  buildCandidateIssueSearch,
   classifyIssuePriority,
   findDuplicateCandidates,
   inferRelevantFiles,
+  issueHasAnyLabel,
   issueHasPriorityLabel,
   renderTriageComment,
   tokenizeIssueText,
@@ -112,6 +114,16 @@ describe("github issue triage output", () => {
   test("detects existing prio labels", () => {
     expect(issueHasPriorityLabel(issue({ labels: [{ name: "prio:2-issue-triage" }] }))).toBe(true)
     expect(issueHasPriorityLabel(issue({ labels: [{ name: "bug" }] }))).toBe(false)
+  })
+
+  test("detects any existing labels for the default unlabeled queue", () => {
+    expect(issueHasAnyLabel(issue({ labels: [] }))).toBe(false)
+    expect(issueHasAnyLabel(issue({ labels: [{ name: "standing-task" }] }))).toBe(true)
+  })
+
+  test("builds the default candidate query from newly opened unlabeled issues", () => {
+    expect(buildCandidateIssueSearch(false)).toBe("is:issue is:open no:label sort:created-desc")
+    expect(buildCandidateIssueSearch(true)).toBe("is:issue is:open sort:created-desc")
   })
 
   test("builds a scoped execution plan and rendered comment", () => {

--- a/scripts/github-issue-triage.ts
+++ b/scripts/github-issue-triage.ts
@@ -143,6 +143,8 @@ const issueText = (issue: Pick<GitHubIssue, "body" | "title">): string =>
 export const issueHasPriorityLabel = (issue: GitHubIssue): boolean =>
   issue.labels.some(label => PRIORITY_LABELS.includes(label.name as PriorityLabel))
 
+export const issueHasAnyLabel = (issue: GitHubIssue): boolean => issue.labels.length > 0
+
 export const tokenizeIssueText = (value: string): ReadonlyArray<string> =>
   uniqueSorted(
     value
@@ -308,12 +310,15 @@ export const listRepositoryFiles = (cwd: string): ReadonlyArray<string> => {
   return uniqueSorted(output.split("\n").map(line => line.trim()).filter(Boolean))
 }
 
+export const buildCandidateIssueSearch = (includeLabeled: boolean): string =>
+  includeLabeled ? "is:issue is:open sort:created-desc" : "is:issue is:open no:label sort:created-desc"
+
 const listCandidateIssues = (
   repo: string,
   limit: number,
-  _includeLabeled: boolean,
+  includeLabeled: boolean,
 ): ReadonlyArray<GitHubIssue> => {
-  const search = "is:issue is:open sort:created-desc"
+  const search = buildCandidateIssueSearch(includeLabeled)
   return runGhJson([
     "issue",
     "list",
@@ -373,7 +378,7 @@ const main = () => {
   const options = parseArgs(Bun.argv.slice(2))
   const repositoryFiles = listRepositoryFiles(process.cwd())
   const candidates = listCandidateIssues(options.repo, options.limit, options.includeLabeled).filter(
-    issue => options.includeLabeled || !issueHasPriorityLabel(issue),
+    issue => options.includeLabeled || !issueHasAnyLabel(issue),
   )
   const openIssues = listOpenIssues(options.repo, Math.max(options.limit, 100))
   const decisions = candidates.map(issue =>


### PR DESCRIPTION
Addresses #6708.

### Changes
- Adds a shared candidate issue search builder that defaults to `no:label` unless labeled issues are explicitly included.
- Updates triage filtering to skip any already-labeled issue in the default unlabeled queue, not just priority-labeled issues.
- Adds tests for label detection and default candidate query construction.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).