### PR TITLE
fix(gym): retarget MirrorCode backstop burn to issue 6923

### DIFF
--- a/apps/openagents.com/scripts/mirrorcode/README.md
+++ b/apps/openagents.com/scripts/mirrorcode/README.md
@@ -8,7 +8,7 @@ result JSON in the shared gym contract.
 - Phase 0 issue: **#6377**
 - Design: [`docs/benchmarks/2026-06-27-mirrorcode-khala-gym-integration-analysis.md`](../../../../docs/benchmarks/2026-06-27-mirrorcode-khala-gym-integration-analysis.md)
 
-## Gym backstop runner (`backstop-run.sh` / `backstop_eval.py`, issue #6710)
+## Gym backstop runner (`backstop-run.sh` / `backstop_eval.py`, issue #6923)
 
 The fleet-saturation **prio:4 backstop** (`prio:4-backstop-burn`) standing task
 needs a runner that does **genuine own-capacity ($0) high-density work** whenever
@@ -57,7 +57,7 @@ problems; it is the smallest **real slice** that does genuine model work + recor
 traces. It is **not** the MirrorCode paper benchmark and must never be published
 as a MirrorCode score (`grade: "backstop"`, `decisionGrade: false`).
 
-**Follow-up (#6710):** wire the full Docker MirrorCode harness (`run.sh`) into the
+**Follow-up (#6923):** wire the full Docker MirrorCode harness (`run.sh`) into the
 backstop as an opt-in escalation path that pulls a bounded batch of real S-bucket
 tasks when Docker + the clone are present and token/wall-clock budget allows. The
 full harness burns ≥1B tokens per sample, so it is intentionally out of the

--- a/apps/openagents.com/scripts/mirrorcode/backstop-run.sh
+++ b/apps/openagents.com/scripts/mirrorcode/backstop-run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# backstop-run.sh — MirrorCode gym backstop runner (issue #6710).
+# backstop-run.sh — MirrorCode gym backstop runner (issue #6923).
 #
 # The fleet-saturation prio:4 (`prio:4-backstop-burn`) standing task invokes this
 # to do GENUINE own-capacity ($0) high-density work whenever the higher tiers are

--- a/apps/openagents.com/scripts/mirrorcode/backstop_eval.py
+++ b/apps/openagents.com/scripts/mirrorcode/backstop_eval.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""MirrorCode gym backstop runner (issue #6710) — the prio:4 density burner.
+"""MirrorCode gym backstop runner (issue #6923) — the prio:4 density burner.
 
 The fleet-saturation backstop task (`prio:4-backstop-burn`) needs a REAL runner
 that does genuine own-capacity ($0) high-density work whenever the higher tiers
@@ -501,7 +501,7 @@ def live_preflight(
     }
 
 def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description="MirrorCode gym backstop runner (#6710)")
+    parser = argparse.ArgumentParser(description="MirrorCode gym backstop runner (#6923)")
     parser.add_argument("--limit", type=int, default=int(os.environ.get("MC_BACKSTOP_LIMIT", "8")), help="Max problems in the bounded batch (0 = all).")
     parser.add_argument("--out", default=os.environ.get("MC_BACKSTOP_OUT", os.path.join(os.path.dirname(os.path.abspath(__file__)), "results", "backstop")), help="Results output dir.")
     parser.add_argument("--live", action="store_true", help="Use the live Khala model (needs OPENAI_API_KEY / OPENAI_BASE_URL).")

--- a/apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py
+++ b/apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the MirrorCode gym backstop runner core (#6710).
+"""Tests for the MirrorCode gym backstop runner core (#6923).
 
 Verifies the genuine-work pieces with NO network and NO Khala spend:
   * extract_code pulls a fenced python block and falls back to raw text;

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.test.ts
@@ -10,7 +10,7 @@ import {
 import { buildMirrorCodeRun } from './mirrorcode-contract'
 
 describe('MirrorCode standing backstop burn', () => {
-  test('plans a bounded public-target batch for issue #6710 with gym demand tags', () => {
+  test('plans a bounded public-target batch for issue #6923 with gym demand tags', () => {
     const plan = buildMirrorCodeBackstopBatchPlan({
       batchRef: 'batch.public.gym.mirrorcode.backstop_burn.2026-06-28',
       maxTasks: 4,
@@ -93,7 +93,7 @@ describe('MirrorCode standing backstop burn', () => {
     expect(report.schemaVersion).toBe(
       'openagents.gym.mirrorcode_backstop_burn.v1',
     )
-    expect(report.issueNumber).toBe(6710)
+    expect(report.issueNumber).toBe(6923)
     expect(report.runCount).toBe(2)
     expect(report.terminalRunCount).toBe(2)
     expect(report.passedRunCount).toBe(1)

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.ts
@@ -12,13 +12,13 @@ import {
 export const MirrorCodeBackstopBurnSchemaVersion =
   'openagents.gym.mirrorcode_backstop_burn.v1'
 
-export const MIRRORCODE_BACKSTOP_ISSUE_NUMBER = 6710
+export const MIRRORCODE_BACKSTOP_ISSUE_NUMBER = 6923
 export const MIRRORCODE_BACKSTOP_TASK_REF =
-  'issue.public.openagents.6710.mirrorcode_backstop_burn'
+  'issue.public.openagents.6923.mirrorcode_backstop_burn'
 export const MIRRORCODE_BACKSTOP_WORKFLOW_REF =
-  'workflow.public.gym.mirrorcode.backstop_burn.6710'
+  'workflow.public.gym.mirrorcode.backstop_burn.6923'
 export const MIRRORCODE_BACKSTOP_LEDGER_REF =
-  'ledger.public.gym.mirrorcode.backstop_burn.6710'
+  'ledger.public.gym.mirrorcode.backstop_burn.6923'
 
 const DEFAULT_BATCH_REF = 'batch.public.gym.mirrorcode.backstop_burn.next'
 const DEFAULT_LANGUAGE = 'python'


### PR DESCRIPTION
Addresses #6923.

### Changes
- Updated MirrorCode backstop runner docs, script headers, and CLI description from issue #6710 to #6923.
- Retargeted MirrorCode backstop burn constants for task, workflow, ledger, and issue number to #6923.
- Updated related Python and TypeScript tests to expect the #6923 backstop issue.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).