### PR TITLE
fix(openagents): gate X-claim rewards to BOLT12 recipients

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1940,7 +1940,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'An owner who verifies agent ownership with an X verification tweet can become eligible for a promotional 1000-sat reward.',
         safeCopy:
-          'Verified X owner claims record a 1000-sat reward eligibility row in a bounded campaign ledger with anti-Sybil dedupe (one reward per X account and per challenge) and a campaign budget cap. Eligibility, operator-approved dispatch, treasury dispatch, and settlement are separate states. The Worker-side dispatcher is implemented behind TREASURY_DISPATCH_ENABLED=false by default with per-run and per-day caps, pending-payment polling, and public-safe status stats. No reward has completed a live dispatch smoke yet.',
+          'Verified X owner claims record a 1000-sat reward eligibility row in a bounded campaign ledger with anti-Sybil dedupe (one reward per X account and per challenge) and a campaign budget cap. Eligibility, operator-approved dispatch, treasury dispatch, and settlement are separate states. The Worker-side dispatcher is implemented behind TREASURY_DISPATCH_ENABLED=false by default with BOLT12-only recipient resolution, per-run and per-day caps, pending-payment polling, public-safe status stats, and smoke gates for candidate, preflight, dispatch outcome, settlement evidence, settled receipt audit, and transition-request assembly. No owner-armed reward has completed a live dispatch smoke to a real receive code yet.',
         unsafeCopy:
           'Do not claim verified owners are instantly or automatically paid, do not present eligibility as spendable balance or settlement, and do not describe the promotional reward as Forum tip settlement or accepted-work payout.',
         evidenceRefs: [
@@ -1949,13 +1949,18 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/migrations/0149_x_claim_reward_ledger.sql',
           'apps/openagents.com/workers/api/migrations/0164_x_claim_reward_treasury_dispatch.sql',
           'apps/openagents.com/workers/api/src/agent-owner-claim-routes.test.ts',
+          'apps/openagents.com/workers/api/src/x-claim-reward-smoke-candidate.test.ts',
+          'apps/openagents.com/workers/api/src/x-claim-reward-smoke-dispatch-outcome.test.ts',
+          'apps/openagents.com/workers/api/src/x-claim-reward-smoke-receipt-audit.test.ts',
+          'apps/openagents.com/workers/api/src/x-claim-reward-smoke-completion.test.ts',
+          'apps/openagents.com/workers/api/src/x-claim-reward-settlement-evidence.test.ts',
           'apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.test.ts',
         ],
         blockerRefs: [
           'blocker.product_promises.x_claim_reward_live_dispatch_smoke_missing',
         ],
         verification:
-          'Run the agent-owner-claim reward tests and the X-claim treasury dispatcher tests: verified X claims must create eligibility with dedupe and budget refusal, dispatch transitions must be admin-gated, the dispatcher must stay flag-off by default, resolve only registered BOLT12 recipient identity, enforce caps, poll pending payments without re-paying, and redact payment material. Green requires one live operator-dispatched reward settled to a real owner receive code with public-safe receipt refs.',
+          'Run the agent-owner-claim reward tests, X-claim treasury dispatcher tests, and X-claim smoke harness tests: verified X claims must create eligibility with dedupe and budget refusal, dispatch transitions must be admin-gated, the dispatcher must stay flag-off by default, resolve only registered BOLT12 recipient identity, enforce caps, poll pending payments without re-paying, redact payment material, reject unsafe settlement evidence before persistence, and emit a transition request only after both the dispatch outcome and settled receipt audits pass. Green requires one live operator-dispatched reward settled to a real owner receive code with public-safe receipt refs and owner sign-off.',
         authorityBoundary:
           'Reward eligibility is a promotional campaign state, not Forum tip settlement, accepted-work payout, Treasury authority, or spendable balance. Dispatch requires the operator admin gate.',
       },

--- a/apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.test.ts
+++ b/apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.test.ts
@@ -9,6 +9,7 @@ import {
   type XClaimRewardTreasuryDispatchStats,
   type XClaimRewardTreasuryDispatchStore,
   evaluateXClaimRewardSmokePreflight,
+  makeD1XClaimRewardRecipientResolver,
   readXClaimRewardTreasuryDispatchConfig,
   runXClaimRewardTreasuryDispatch,
   xClaimRewardDispatchDayStartIso,
@@ -233,6 +234,25 @@ class FakeTreasury implements XClaimRewardTreasuryClient {
     }
 }
 
+const recipientDb = (
+  row: Readonly<{
+    bolt12_offer: string | null
+    lightning_address?: string | null
+    wallet_ref: string
+  }> | null,
+): D1Database =>
+  ({
+    prepare: (query: string) => ({
+      bind: () => ({
+        first: async () =>
+          query.includes('bolt12_offer IS NOT NULL') &&
+          row?.bolt12_offer === null
+            ? null
+            : row,
+      }),
+    }),
+  }) as unknown as D1Database
+
 const runDispatch = (
   store: MemoryDispatchStore,
   treasury: XClaimRewardTreasuryClient | null,
@@ -334,6 +354,29 @@ describe('X claim reward treasury dispatcher', () => {
     expect(reward?.stateReasonRef).toBe(
       'reason.public.x_claim_reward_recipient_wallet_missing',
     )
+  })
+
+  test('resolves only a registered BOLT12 recipient for live reward dispatch', async () => {
+    const bolt12Recipient = await makeD1XClaimRewardRecipientResolver(
+      recipientDb({
+        bolt12_offer: safeOffer,
+        lightning_address: 'owner@example.com',
+        wallet_ref: 'wallet.public.agent.bolt12',
+      }),
+    )(rewardRecord())
+    const lightningOnlyRecipient = await makeD1XClaimRewardRecipientResolver(
+      recipientDb({
+        bolt12_offer: null,
+        lightning_address: 'owner@example.com',
+        wallet_ref: 'wallet.public.agent.lightning_address_only',
+      }),
+    )(rewardRecord())
+
+    expect(bolt12Recipient).toEqual({
+      destination: safeOffer,
+      destinationSourceRef: 'wallet.public.agent.bolt12',
+    })
+    expect(lightningOnlyRecipient).toBeNull()
   })
 
   test('enforces per-run, per-day, and liquidity caps before new sends', async () => {

--- a/apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.ts
+++ b/apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.ts
@@ -543,25 +543,23 @@ export const makeD1XClaimRewardRecipientResolver =
     const row = await db
       .prepare(
         `SELECT wallet_ref, bolt12_offer
-                , lightning_address
            FROM forum_tip_recipient_wallets
           WHERE actor_ref = ?
             AND state = 'ready'
             AND archived_at IS NULL
-            AND (lightning_address IS NOT NULL OR bolt12_offer IS NOT NULL)
+            AND bolt12_offer IS NOT NULL
           LIMIT 1`,
       )
       .bind(`agent:${reward.agentUserId}`)
       .first<{
         wallet_ref: string
         bolt12_offer: string | null
-        lightning_address: string | null
       }>()
 
     return row === null
       ? null
       : {
-          destination: row.lightning_address ?? row.bolt12_offer!,
+          destination: row.bolt12_offer!,
           destinationSourceRef: row.wallet_ref,
         }
   }


### PR DESCRIPTION
Addresses #6856.

### Changes
- Updated the X-claim reward product promise copy, evidence refs, and verification text to reflect BOLT12-only recipient resolution and the added smoke gates.
- Tightened the treasury dispatcher recipient lookup so live reward dispatch resolves only registered ready wallets with a BOLT12 offer.
- Added dispatcher coverage proving BOLT12 wallets resolve and lightning-address-only wallets are rejected.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- passed (exit 0)