### PR TITLE
docs(adr): adopt MADR architecture decision records

### DIFF
--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,80 @@
+---
+status: "accepted"
+date: 2026-06-28
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, CLAUDE.md, INVARIANTS.md, public issue #6945, MADR
+informed: OpenAgents contributors and agents
+---
+
+# Record architecture decisions
+
+## Context and Problem Statement
+
+OpenAgents already carries architectural rules across `AGENTS.md`,
+`CLAUDE.md`, root and app-specific invariant ledgers, deployment runbooks, and
+dated audit documents. Those sources are authoritative, but they are optimized
+for operating instructions and constraints rather than a chronological decision
+log. Contributors and agents need a concise way to understand settled
+architecture choices before changing the repo.
+
+## Decision Drivers
+
+* Keep architecture rationale close to the code.
+* Preserve invariant ledgers and runbooks as operating authority.
+* Use a common lightweight format that is easy to review in PRs.
+* Make new decisions discoverable by number and title.
+
+## Considered Options
+
+* MADR-style ADRs in `docs/adr/`
+* Only invariant ledgers and runbooks
+* External wiki or issue-only decision history
+
+## Decision Outcome
+
+Chosen option: "MADR-style ADRs in `docs/adr/`", because it creates a compact
+decision log while leaving existing invariants, runbooks, tests, and product
+promise records in their current roles.
+
+### Consequences
+
+* Good, because architectural context becomes easier to scan before editing.
+* Good, because decisions can link to existing source records instead of
+  duplicating every rule.
+* Bad, because contributors must keep ADRs and invariant ledgers aligned when a
+  decision changes.
+
+### Confirmation
+
+New or changed architecture decisions should update `docs/adr/` in the same PR
+as the implementation or invariant change. The repository review process and
+`bun run --cwd apps/openagents.com check:deploy` remain the gate for changes.
+
+## Pros and Cons of the Options
+
+### MADR-style ADRs in `docs/adr/`
+
+* Good, because MADR gives a known structure: status, context, considered
+  options, outcome, consequences, and confirmation.
+* Good, because numbered filenames make the decision log stable.
+* Bad, because stale ADRs can mislead if they are not updated when decisions are
+  superseded.
+
+### Only invariant ledgers and runbooks
+
+* Good, because those files already exist and are authoritative.
+* Bad, because they mix current rules, process detail, and historical rationale.
+
+### External wiki or issue-only decision history
+
+* Good, because it avoids adding repository files.
+* Bad, because decisions drift away from the code and are harder for agents to
+  load in bounded checkouts.
+
+## More Information
+
+* `AGENTS.md`
+* `CLAUDE.md`
+* `INVARIANTS.md`
+* `apps/openagents.com/INVARIANTS.md`
+* <https://github.com/adr/madr>

--- a/docs/adr/0002-adopt-effect-as-the-core-runtime-model.md
+++ b/docs/adr/0002-adopt-effect-as-the-core-runtime-model.md
@@ -1,0 +1,80 @@
+---
+status: "accepted"
+date: 2026-06-28
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, CLAUDE.md, INVARIANTS.md, apps/openagents.com/AGENTS.md, apps/openagents.com/INVARIANTS.md
+informed: OpenAgents contributors and agents
+---
+
+# Adopt Effect as the core runtime model
+
+## Context and Problem Statement
+
+The repo is the OpenAgents Bun and Effect monorepo. Root invariants require new
+production TypeScript code to use Bun and Effect, and external boundaries to be
+modeled with typed data structures or Effect Schema. `apps/openagents.com` is a
+Foldkit app built on Effect, with a Cloudflare Worker API, a Foldkit browser
+app, and shared Effect Schema packages.
+
+## Decision Drivers
+
+* Keep effectful work explicit, typed, and testable.
+* Model external boundaries with Effect Schema rather than ad hoc payloads.
+* Share contracts across Workers, clients, CLIs, and packages.
+* Keep authority paths away from raw throws, untyped Promise chains, and keyword
+  routing.
+
+## Considered Options
+
+* Effect, Effect Schema, and Foldkit on Bun and Cloudflare Workers
+* Plain TypeScript promises and ad hoc runtime validation
+* A different application framework and validation stack
+
+## Decision Outcome
+
+Chosen option: "Effect, Effect Schema, and Foldkit on Bun and Cloudflare
+Workers", because it matches the existing codebase and the invariant that
+production TypeScript, app composition, and shared contracts stay Effect-first.
+
+### Consequences
+
+* Good, because expected failures, services, layers, commands, and schemas have
+  explicit boundaries.
+* Good, because web, Worker, and shared packages can validate public contracts
+  consistently.
+* Bad, because contributors must learn the repository's Effect and Foldkit
+  patterns before changing authority paths.
+
+### Confirmation
+
+Compliance is checked by code review, app-specific invariant ledgers, typecheck
+targets, architecture guards, and the `check:deploy` gate in
+`apps/openagents.com/package.json`.
+
+## Pros and Cons of the Options
+
+### Effect, Effect Schema, and Foldkit on Bun and Cloudflare Workers
+
+* Good, because it is already documented in root and app-specific instructions.
+* Good, because Foldkit keeps browser state and side effects separated.
+* Bad, because it constrains library and framework choices in production paths.
+
+### Plain TypeScript promises and ad hoc runtime validation
+
+* Good, because many TypeScript developers know it.
+* Bad, because it weakens typed error handling and boundary validation.
+* Bad, because it conflicts with current invariants.
+
+### A different application framework and validation stack
+
+* Good, because alternatives may have larger ecosystems.
+* Bad, because it would fragment the monorepo and bypass settled app patterns.
+
+## More Information
+
+* `INVARIANTS.md` ("Effect Workspace Boundary")
+* `AGENTS.md`
+* `apps/openagents.com/AGENTS.md`
+* `apps/openagents.com/package.json`
+* `packages/world-contract/`
+* `packages/world-client/`

--- a/docs/adr/0003-use-bun-as-the-workspace-runtime-and-toolchain.md
+++ b/docs/adr/0003-use-bun-as-the-workspace-runtime-and-toolchain.md
@@ -1,0 +1,75 @@
+---
+status: "accepted"
+date: 2026-06-28
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, CLAUDE.md, INVARIANTS.md, package.json, apps/openagents.com/package.json
+informed: OpenAgents contributors and agents
+---
+
+# Use Bun as the workspace runtime and toolchain
+
+## Context and Problem Statement
+
+OpenAgents is organized as a Bun workspace with apps and shared packages. The
+root package scripts delegate checks into app workspaces, and
+`apps/openagents.com` uses Bun scripts for typechecking, tests, architecture
+guards, web builds, Worker checks, and deployment gates.
+
+## Decision Drivers
+
+* Keep local development and verification commands consistent across the
+  monorepo.
+* Use one fast TypeScript-oriented runtime for scripts, tests, and tooling.
+* Align app and package instructions with the existing lockfiles and scripts.
+
+## Considered Options
+
+* Bun as the workspace runtime and package tool
+* Node/npm as the primary workspace runtime
+* Mixed runtime ownership per app
+
+## Decision Outcome
+
+Chosen option: "Bun as the workspace runtime and package tool", because the
+repo, scripts, lockfiles, and operating instructions already assume Bun for
+production TypeScript work and verification.
+
+### Consequences
+
+* Good, because contributors can use a consistent command shape such as
+  `bun run --cwd apps/openagents.com check:deploy`.
+* Good, because package and app checks share one default runtime.
+* Bad, because Node-only packages or CLIs need explicit compatibility handling
+  instead of becoming the default.
+
+### Confirmation
+
+The root `package.json`, app `package.json` files, `bun.lock`, app lockfiles,
+and `check:deploy` scripts confirm this decision. Pull requests should keep new
+workspace commands on Bun unless an app-specific runbook documents otherwise.
+
+## Pros and Cons of the Options
+
+### Bun as the workspace runtime and package tool
+
+* Good, because it matches the current monorepo setup.
+* Good, because the verification and deploy commands are already Bun scripts.
+* Bad, because contributors need Bun installed even for documentation-adjacent
+  changes that run full verification.
+
+### Node/npm as the primary workspace runtime
+
+* Good, because it is widely installed.
+* Bad, because it conflicts with current scripts and lockfile ownership.
+
+### Mixed runtime ownership per app
+
+* Good, because each app could pick its preferred tool.
+* Bad, because it would fragment verification and increase agent instructions.
+
+## More Information
+
+* `package.json`
+* `bun.lock`
+* `apps/openagents.com/package.json`
+* `apps/openagents.com/AGENTS.md`

--- a/docs/adr/0004-prefer-cloudflare-native-product-infrastructure.md
+++ b/docs/adr/0004-prefer-cloudflare-native-product-infrastructure.md
@@ -1,0 +1,81 @@
+---
+status: "accepted"
+date: 2026-06-28
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, CLAUDE.md, INVARIANTS.md, docs/DEPLOYMENT.md, apps/openagents.com/INVARIANTS.md
+informed: OpenAgents contributors and agents
+---
+
+# Prefer Cloudflare-native product infrastructure
+
+## Context and Problem Statement
+
+The public product surface is centered on Cloudflare Workers and Cloudflare data
+primitives. `apps/openagents.com` owns the main Worker, web app, Forum routes,
+public proof routes, product promises, and API surfaces. `apps/openagents-world`
+owns the Cloudflare Worker plus Region Durable Object Verse world service with
+D1 projection rows, queues, hibernatable WebSockets, and alarms.
+
+## Decision Drivers
+
+* Keep public product authority at the edge where the app is deployed.
+* Prefer typed Worker/D1/Durable Object/R2/Queue boundaries over unrelated
+  third-party infrastructure.
+* Preserve public-safe projection and authority boundaries.
+* Avoid reintroducing deleted self-hosted world infrastructure.
+
+## Considered Options
+
+* Cloudflare-native Workers, D1, Durable Objects, Queues, R2, and Analytics
+  Engine
+* Reintroduce the old self-hosted world module
+* Split product authority across unrelated third-party services
+
+## Decision Outcome
+
+Chosen option: "Cloudflare-native Workers, D1, Durable Objects, Queues, R2, and
+Analytics Engine", because it matches the current product deployment model,
+world-service ownership, and invariant boundaries.
+
+### Consequences
+
+* Good, because public projections, receipts, D1 rows, Durable Object state, and
+  Worker routes share the same deployment platform.
+* Good, because deleted historical infrastructure remains reference material
+  rather than production ownership.
+* Bad, because platform-specific limits and deployment runbooks must be handled
+  directly.
+
+### Confirmation
+
+Compliance is confirmed by the app layout, Cloudflare deployment runbooks,
+Worker tests, migration guards, world-service docs, and `check:deploy`.
+
+## Pros and Cons of the Options
+
+### Cloudflare-native Workers, D1, Durable Objects, Queues, R2, and Analytics Engine
+
+* Good, because it reflects deployed OpenAgents product surfaces.
+* Good, because it keeps authority and public projection code near the Worker.
+* Bad, because some local development and migration flows require Cloudflare
+  tooling.
+
+### Reintroduce the old self-hosted world module
+
+* Good, because historical schema ideas may be familiar.
+* Bad, because root invariants explicitly forbid production world features in
+  that deleted path.
+
+### Split product authority across unrelated third-party services
+
+* Good, because specialized services can be convenient.
+* Bad, because it would make public authority, settlement, and projection
+  boundaries harder to verify.
+
+## More Information
+
+* `AGENTS.md`
+* `INVARIANTS.md` ("Cloudflare Verse World Service")
+* `docs/DEPLOYMENT.md`
+* `apps/openagents-world/`
+* `apps/openagents.com/workers/api/`

--- a/docs/adr/0005-land-through-pr-review-and-check-deploy.md
+++ b/docs/adr/0005-land-through-pr-review-and-check-deploy.md
@@ -1,0 +1,76 @@
+---
+status: "accepted"
+date: 2026-06-28
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, CLAUDE.md, INVARIANTS.md, docs/DEPLOYMENT.md, apps/openagents.com/package.json
+informed: OpenAgents contributors and agents
+---
+
+# Land through PR review and the check:deploy gate
+
+## Context and Problem Statement
+
+OpenAgents changes land through pull requests, with verification expected before
+merge. Root instructions require relevant tests and `check:deploy` to be green
+for PRs, and root invariants ban GitHub-hosted CI workflows. The deployment
+runbook names `check:deploy` as the pre-deploy gate for the main product
+surface.
+
+## Decision Drivers
+
+* Keep merge evidence explicit and reviewable.
+* Avoid GitHub-hosted CI and scheduled automation.
+* Ensure product, Worker, contract, architecture, and projection guards run
+  before deploy-sensitive changes land.
+* Keep deployment separate from ordinary PR verification.
+
+## Considered Options
+
+* Pull requests with local or agent-run `check:deploy`
+* GitHub Actions as the merge gate
+* Merge without a full deploy gate
+
+## Decision Outcome
+
+Chosen option: "Pull requests with local or agent-run `check:deploy`", because
+it matches the no-GitHub-Actions invariant and the existing `apps/openagents.com`
+deploy gate.
+
+### Consequences
+
+* Good, because contributors and agents produce concrete verification evidence.
+* Good, because the same gate protects public product, Worker, API, and shared
+  package changes.
+* Bad, because the full gate can take longer than targeted tests.
+
+### Confirmation
+
+The root no-GitHub-Actions invariant is enforced by `check:no-github-actions`
+inside `check:deploy`. The `apps/openagents.com/package.json` script lists the
+current guard, typecheck, and test suite.
+
+## Pros and Cons of the Options
+
+### Pull requests with local or agent-run `check:deploy`
+
+* Good, because it keeps the repo free of GitHub-hosted workflow files.
+* Good, because PR evidence can include the exact command run.
+* Bad, because agents need enough local capacity to run the full gate.
+
+### GitHub Actions as the merge gate
+
+* Good, because it is common for public repositories.
+* Bad, because it violates the root invariant banning GitHub-hosted CI.
+
+### Merge without a full deploy gate
+
+* Good, because it is faster in the short term.
+* Bad, because it increases the chance of breaking public routes, contracts, or
+  deployment assumptions.
+
+## More Information
+
+* `INVARIANTS.md` ("No GitHub-Hosted CI / Cloud Actions")
+* `AGENTS.md`
+* `docs/DEPLOYMENT.md`
+* `apps/openagents.com/package.json`

--- a/docs/adr/0006-route-khala-coding-delegation-through-owner-local-pylon-capacity.md
+++ b/docs/adr/0006-route-khala-coding-delegation-through-owner-local-pylon-capacity.md
@@ -1,0 +1,83 @@
+---
+status: "accepted"
+date: 2026-06-28
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, CLAUDE.md, INVARIANTS.md, apps/openagents.com/INVARIANTS.md, docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md
+informed: OpenAgents contributors, agents, and Pylon operators
+---
+
+# Route Khala coding delegation through owner-local Pylon capacity
+
+## Context and Problem Statement
+
+Khala coding delegation routes caller-owned work to the caller's linked local
+Pylon and then to local Codex-capable capacity. The runbook and invariants
+require owner-local execution, no-spend assignment settlement, exact downstream
+Codex token rows, owner-only redacted traces, and public-safe projections.
+Untrusted labor and provider paths must not inherit local danger-mode authority.
+
+## Decision Drivers
+
+* Use the caller's own linked Pylon capacity for coding work.
+* Keep no-spend owner-local execution separate from settlement-bearing labor.
+* Count exact downstream Codex tokens from SDK usage rows.
+* Keep raw prompts, local paths, shell output, and credentials out of public
+  traces and counters.
+
+## Considered Options
+
+* Owner-local Pylon/Codex own-capacity delegation with exact token accounting
+* Normal provider routing for coding delegation
+* Marketplace or third-party pooled coding capacity
+
+## Decision Outcome
+
+Chosen option: "Owner-local Pylon/Codex own-capacity delegation with exact token
+accounting", because it is the established path documented by the Khala/Pylon
+runbook and invariant ledger.
+
+### Consequences
+
+* Good, because the caller can use their own linked Codex capacity without
+  spending OpenAgents-funded provider capacity.
+* Good, because exact `token_usage_events` rows back public counters.
+* Good, because owner-only traces and raw-event archives keep private execution
+  details out of public projections.
+* Bad, because operators must verify Pylon presence, assignment closeout, token
+  rows, traces, and counter projection rather than trusting counter movement
+  alone.
+
+### Confirmation
+
+The runbook verifies Pylon account readiness, presence heartbeat, typed Khala
+request creation, local no-spend execution, closeout proof, durable resume,
+exact `token_usage_events`, owner-only `agent_traces`, private raw event chunk
+rows, and the public counter projection.
+
+## Pros and Cons of the Options
+
+### Owner-local Pylon/Codex own-capacity delegation with exact token accounting
+
+* Good, because it preserves the owner-local authority boundary.
+* Good, because usage truth is exact rather than estimated.
+* Bad, because the proof path has several required checks.
+
+### Normal provider routing for coding delegation
+
+* Good, because it is simpler to request.
+* Bad, because the runbook treats provider fallthrough as a delegation failure
+  for this workflow.
+
+### Marketplace or third-party pooled coding capacity
+
+* Good, because it could broaden supply later.
+* Bad, because it would require separate authorization, settlement, and trust
+  boundaries that are not part of this own-capacity path.
+
+## More Information
+
+* `AGENTS.md` ("Khala -> Pylon -> Codex Coding Delegation Runbook")
+* `CLAUDE.md`
+* `INVARIANTS.md` ("Authority Boundaries")
+* `apps/openagents.com/INVARIANTS.md` ("Khala Coding Delegation Through Pylons")
+* `docs/ops/2026-06-27-khala-codex-own-capacity-burn-runbook.md`

--- a/docs/adr/0007-gate-public-product-claims-through-product-promises.md
+++ b/docs/adr/0007-gate-public-product-claims-through-product-promises.md
@@ -1,0 +1,79 @@
+---
+status: "accepted"
+date: 2026-06-28
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, CLAUDE.md, INVARIANTS.md, docs/promises/README.md, apps/openagents.com/INVARIANTS.md
+informed: OpenAgents contributors, agents, and product-reporting users
+---
+
+# Gate public product claims through product promises
+
+## Context and Problem Statement
+
+OpenAgents has public product surfaces, docs, Forum routes, proof routes, and
+agent-readable endpoints. Root invariants require user-facing and agent-facing
+product claims to go through `docs/promises/` before copy broadens beyond
+implementation notes. Reports and loose product commentary are Forum-first,
+while GitHub issues are reserved for concrete reproducible bugs.
+
+## Decision Drivers
+
+* Keep public claims tied to evidence, authority boundaries, freshness, and copy
+  gates.
+* Avoid broadening marketing or UI copy ahead of implementation truth.
+* Give users and agents a stable product-promise registry and Forum intake path.
+* Keep GitHub issues focused on strict reproducible bugs.
+
+## Considered Options
+
+* Product-promise records under `docs/promises/`
+* Free-form public copy updates
+* GitHub issues as the main product-claim intake
+
+## Decision Outcome
+
+Chosen option: "Product-promise records under `docs/promises/`", because it is
+the established repository boundary for product claims, launch-promise source
+sets, verification gates, copy gates, and report templates.
+
+### Consequences
+
+* Good, because public and agent-readable claims can be checked against source
+  evidence.
+* Good, because stale, partial, planned, or degraded behavior can be labeled
+  accurately.
+* Bad, because copy changes need promise-record work before broadening claims.
+
+### Confirmation
+
+Compliance is confirmed by product-promise records, the product promises page,
+the public promise API, Forum-first report intake, issue-template constraints,
+and review of public copy changes.
+
+## Pros and Cons of the Options
+
+### Product-promise records under `docs/promises/`
+
+* Good, because they bind claims to evidence and copy gates.
+* Good, because the registry is both human-readable and agent-readable.
+* Bad, because it adds process for claim changes.
+
+### Free-form public copy updates
+
+* Good, because it is fast.
+* Bad, because it can overstate implementation status or freshness.
+
+### GitHub issues as the main product-claim intake
+
+* Good, because issues are familiar to developers.
+* Bad, because root instructions reserve GitHub issues for strict reproducible
+  bugs and route broader reports to the Forum.
+
+## More Information
+
+* `INVARIANTS.md` ("Product Promise Claims")
+* `AGENTS.md`
+* `docs/promises/`
+* `docs/promises/README.md`
+* <https://openagents.com/docs/product-promises>
+* <https://openagents.com/api/public/product-promises>

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,32 @@
+# Architecture Decision Records
+
+This directory records accepted OpenAgents architecture decisions as Markdown
+Any Decision Records (MADR). ADRs explain decisions that are already made or
+being made, the options considered, and the consequences that future work must
+respect.
+
+## Process
+
+1. Copy `adr-template.md` to the next numbered file:
+   `NNNN-short-title.md`.
+2. Use a short lowercase dash-separated title after the number.
+3. Set `status: "accepted"` for settled decisions. Use another MADR status only
+   when replacing, rejecting, or deprecating a previous ADR.
+4. Ground the context in repository sources such as `AGENTS.md`, `CLAUDE.md`,
+   `INVARIANTS.md`, app-specific invariant ledgers, deployment runbooks, code,
+   package manifests, and tests.
+5. Keep each ADR focused on one architectural decision.
+6. Update the index below in the same PR.
+
+ADRs do not replace invariant ledgers, runbooks, tests, or product-promise
+records. They provide a stable decision log that links those sources together.
+
+## Index
+
+* [ADR-0001: Record architecture decisions](0001-record-architecture-decisions.md)
+* [ADR-0002: Adopt Effect as the core runtime model](0002-adopt-effect-as-the-core-runtime-model.md)
+* [ADR-0003: Use Bun as the workspace runtime and toolchain](0003-use-bun-as-the-workspace-runtime-and-toolchain.md)
+* [ADR-0004: Prefer Cloudflare-native product infrastructure](0004-prefer-cloudflare-native-product-infrastructure.md)
+* [ADR-0005: Land through PR review and the `check:deploy` gate](0005-land-through-pr-review-and-check-deploy.md)
+* [ADR-0006: Route Khala coding delegation through owner-local Pylon capacity](0006-route-khala-coding-delegation-through-owner-local-pylon-capacity.md)
+* [ADR-0007: Gate public product claims through product promises](0007-gate-public-product-claims-through-product-promises.md)

--- a/docs/adr/adr-template.md
+++ b/docs/adr/adr-template.md
@@ -1,0 +1,55 @@
+---
+status: "{proposed | rejected | accepted | deprecated | superseded by ADR-0123}"
+date: {YYYY-MM-DD when the decision was last updated}
+decision-makers: {team or role}
+consulted: {teams, roles, or source records consulted}
+informed: {teams, roles, or audiences informed}
+---
+
+# {short title, representative of solved problem and found solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement. Make the scope of the decision
+explicit and link to source records, code, or tests that ground it.}
+
+## Decision Drivers
+
+* {decision driver 1}
+* {decision driver 2}
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because {justification}.
+
+### Consequences
+
+* Good, because {positive consequence}.
+* Bad, because {negative consequence or tradeoff}.
+
+### Confirmation
+
+{Describe how compliance is confirmed, for example by code review, tests,
+invariant ledgers, or deployment gates.}
+
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+* Good, because {argument}.
+* Bad, because {argument}.
+
+### {title of option 2}
+
+* Good, because {argument}.
+* Bad, because {argument}.
+
+## More Information
+
+{Links to source records, related ADRs, runbooks, code, or tests.}


### PR DESCRIPTION
## Summary

- Add `docs/adr/` with a short process README and adopted MADR template.
- Seed accepted ADRs for already-established decisions: ADR practice, Effect runtime model, Bun workspace tooling, Cloudflare-native infrastructure, PR + `check:deploy`, Khala owner-local Pylon/Codex delegation, and product-promise claim gates.
- Ground records in `AGENTS.md`, `CLAUDE.md`, root/app invariant ledgers, deployment docs, and existing repo layout.

Closes #6945

## Verification

- `bun run --cwd apps/openagents.com check:deploy`
