### PR TITLE
feat(codex-supervisor): reduce inter-turn idle

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# backoff-policy.sh — idle/backoff helpers for codex-supervisor (#6900).
+#
+# Source-only, test-friendly policy for two supervisor saturation problems:
+#   * deep open backlog should not wait 15s+ just because every current top
+#     candidate is claimed/settling;
+#   * codex_agent_execution_refused is a per-account local executor ceiling, not
+#     the same signal as a remote 429. Repeated executor refusals tune that
+#     account's same-account concurrency down one slot.
+
+: "${SUP_STATE_DIR:=$HOME/.codex-supervisor}"
+: "${SUP_PER_ACCOUNT:=2}"
+: "${SUP_MAX_SLOTS:=8}"
+: "${SUP_BACKOFF_MIN:=15}"
+: "${SUP_CODEX_REFUSAL_TUNE_THRESHOLD:=3}"
+: "${SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS:=1}"
+
+sup_backoff_policy_dir() {
+  local d="${SUP_BACKOFF_POLICY_DIR:-$SUP_STATE_DIR/backoff-policy}"
+  mkdir -p "$d" 2>/dev/null || true
+  printf '%s' "$d"
+}
+
+sup_account_policy_ref() {
+  printf '%s' "${1:-default}" | tr -c 'A-Za-z0-9._-' '_'
+}
+
+sup_account_limit_file() {
+  printf '%s/account-limit.%s' "$(sup_backoff_policy_dir)" "$(sup_account_policy_ref "$1")"
+}
+
+sup_account_refusal_file() {
+  printf '%s/refusals.%s' "$(sup_backoff_policy_dir)" "$(sup_account_policy_ref "$1")"
+}
+
+sup_account_effective_limit() {
+  local acc="$1"
+  local limit="$SUP_PER_ACCOUNT"
+  local file; file="$(sup_account_limit_file "$acc")"
+  if [ -f "$file" ]; then
+    local stored; stored="$(cat "$file" 2>/dev/null)"
+    if [ "$stored" -ge 1 ] 2>/dev/null; then
+      limit="$stored"
+    fi
+  fi
+  [ "$limit" -lt 1 ] 2>/dev/null && limit=1
+  [ "$limit" -gt "$SUP_PER_ACCOUNT" ] 2>/dev/null && limit="$SUP_PER_ACCOUNT"
+  printf '%s' "$limit"
+}
+
+sup_set_account_effective_limit() {
+  local acc="$1"
+  local limit="$2"
+  [ "$limit" -lt 1 ] 2>/dev/null && limit=1
+  [ "$limit" -gt "$SUP_PER_ACCOUNT" ] 2>/dev/null && limit="$SUP_PER_ACCOUNT"
+  printf '%s' "$limit" > "$(sup_account_limit_file "$acc")" 2>/dev/null || true
+}
+
+# sup_expand_account_slots <account-ref...>
+#   Prints one account ref per currently admitted slot, respecting the tuned
+#   per-account limit. The caller caps the final total at SUP_MAX_SLOTS.
+sup_expand_account_slots() {
+  local acc limit i emitted=0
+  for acc in "$@"; do
+    [ -n "$acc" ] || continue
+    limit="$(sup_account_effective_limit "$acc")"
+    for (( i=0; i<limit; i++ )); do
+      [ "$emitted" -ge "$SUP_MAX_SLOTS" ] 2>/dev/null && return 0
+      printf '%s\n' "$acc"
+      emitted=$(( emitted + 1 ))
+    done
+  done
+}
+
+sup_reset_account_refusals() {
+  rm -f "$(sup_account_refusal_file "$1")" 2>/dev/null || true
+}
+
+# sup_record_account_refusal <account> <signature>
+#   Prints a public-safe action line when a repeated local Codex executor
+#   refusal lowers that account's limit, else prints nothing.
+sup_record_account_refusal() {
+  local acc="$1"
+  local sig="$2"
+  if [ "$sig" != "codex_agent_execution_refused" ]; then
+    return 0
+  fi
+
+  local file count limit next
+  file="$(sup_account_refusal_file "$acc")"
+  count="$(cat "$file" 2>/dev/null || echo 0)"
+  [ "$count" -ge 0 ] 2>/dev/null || count=0
+  count=$(( count + 1 ))
+  printf '%s' "$count" > "$file" 2>/dev/null || true
+
+  if [ "$count" -lt "$SUP_CODEX_REFUSAL_TUNE_THRESHOLD" ]; then
+    return 0
+  fi
+
+  limit="$(sup_account_effective_limit "$acc")"
+  if [ "$limit" -le 1 ] 2>/dev/null; then
+    printf 'account=%s refusal_cause=%s repeated=%s limit_held=%s' "$acc" "$sig" "$count" "$limit"
+    return 0
+  fi
+
+  next=$(( limit - 1 ))
+  sup_set_account_effective_limit "$acc" "$next"
+  printf 'account=%s refusal_cause=%s repeated=%s limit_tuned=%s->%s' "$acc" "$sig" "$count" "$limit" "$next"
+  printf '0' > "$file" 2>/dev/null || true
+}
+
+sup_dispatch_failure_signature() {
+  local out="$1"
+  if grep -qiE 'codex_agent_execution_refused|execution[_ -]?refused' "$out" 2>/dev/null; then
+    printf 'codex_agent_execution_refused'
+    return 0
+  fi
+  if grep -qiE '429|rate.?limit|too many requests|quota|lockout' "$out" 2>/dev/null; then
+    printf 'rate_limited'
+    return 0
+  fi
+  if grep -qiE '409|dispatch gate refused|target_pylon_unavailable|duplicate_active_assignment' "$out" 2>/dev/null; then
+    printf 'refused'
+    return 0
+  fi
+  printf 'other'
+}
+
+sup_claimed_pick_backoff_secs() {
+  local open_count="$1"
+  local desired_slots="$2"
+  local current_backoff="$3"
+  if [ "$open_count" -gt "$desired_slots" ] 2>/dev/null && [ "$desired_slots" -gt 0 ] 2>/dev/null; then
+    printf '%s' "$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
+    return 0
+  fi
+  printf '%s' "$current_backoff"
+}

--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# backoff-policy.test.sh — no-network tests for codex-supervisor idle/refusal policy.
+#
+# Run: bash apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+export SUP_STATE_DIR="$WORK/state"
+export SUP_BACKOFF_POLICY_DIR="$WORK/policy"
+export SUP_PER_ACCOUNT=3
+export SUP_MAX_SLOTS=8
+export SUP_CODEX_REFUSAL_TUNE_THRESHOLD=3
+export SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS=1
+mkdir -p "$SUP_STATE_DIR" "$SUP_BACKOFF_POLICY_DIR"
+
+# shellcheck source=backoff-policy.sh
+source "$SCRIPT_DIR/backoff-policy.sh"
+
+slots="$(sup_expand_account_slots codex codex-2 | tr '\n' ' ')"
+if [ "$slots" = "codex codex codex codex-2 codex-2 codex-2 " ]; then
+  ok "account slots expand to SUP_PER_ACCOUNT per ready account"
+else
+  bad "unexpected expanded slots: '$slots'"
+fi
+
+sup_set_account_effective_limit codex 2
+slots="$(sup_expand_account_slots codex codex-2 | tr '\n' ' ')"
+if [ "$slots" = "codex codex codex-2 codex-2 codex-2 " ]; then
+  ok "tuned account limit shrinks only that account"
+else
+  bad "unexpected tuned slots: '$slots'"
+fi
+
+printf '%s' '{"error":"codex_agent_execution_refused"}' > "$WORK/executor-refused.json"
+printf '%s' '{"error":"target_pylon_unavailable"}' > "$WORK/gate-refused.json"
+printf '%s' 'HTTP 429 too many requests' > "$WORK/rate.txt"
+printf '%s' 'plain failure' > "$WORK/other.txt"
+
+if [ "$(sup_dispatch_failure_signature "$WORK/executor-refused.json")" = "codex_agent_execution_refused" ]; then
+  ok "executor refusal is classified distinctly"
+else
+  bad "executor refusal classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/gate-refused.json")" = "refused" ]; then
+  ok "gate refusal remains generic refused"
+else
+  bad "gate refusal classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/rate.txt")" = "rate_limited" ]; then
+  ok "429/rate limit remains rate_limited"
+else
+  bad "rate limit classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/other.txt")" = "other" ]; then
+  ok "unknown failure is classified as other"
+else
+  bad "other classification failed"
+fi
+
+sup_set_account_effective_limit codex 3
+first="$(sup_record_account_refusal codex codex_agent_execution_refused)"
+second="$(sup_record_account_refusal codex codex_agent_execution_refused)"
+third="$(sup_record_account_refusal codex codex_agent_execution_refused)"
+if [ -z "$first" ] && [ -z "$second" ] &&
+   printf '%s' "$third" | grep -q 'limit_tuned=3->2' &&
+   [ "$(sup_account_effective_limit codex)" = "2" ]; then
+  ok "repeated executor refusals tune account limit down one slot"
+else
+  bad "executor refusal tuning failed: first='$first' second='$second' third='$third' limit=$(sup_account_effective_limit codex)"
+fi
+
+before="$(sup_account_effective_limit codex)"
+sup_record_account_refusal codex rate_limited >/dev/null
+after="$(sup_account_effective_limit codex)"
+if [ "$before" = "$after" ]; then
+  ok "rate limits do not tune local account concurrency"
+else
+  bad "rate limit changed account limit: $before -> $after"
+fi
+
+if [ "$(sup_claimed_pick_backoff_secs 12 4 15)" = "1" ]; then
+  ok "deep open backlog uses near-immediate claimed-pick retry"
+else
+  bad "deep backlog retry did not shorten"
+fi
+
+if [ "$(sup_claimed_pick_backoff_secs 4 4 15)" = "15" ]; then
+  ok "shallow/equal backlog keeps normal backoff"
+else
+  bad "shallow backlog should keep normal backoff"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -74,6 +74,9 @@ source "$SCRIPT_DIR/../supervisor-fresh-base.sh"
 source "$SCRIPT_DIR/priority-dispatch.sh"
 # shellcheck source=standing-tasks.sh
 source "$SCRIPT_DIR/standing-tasks.sh"
+# Refusal-aware backoff and per-account concurrency tuning (#6900).
+# shellcheck source=backoff-policy.sh
+source "$SCRIPT_DIR/backoff-policy.sh"
 
 # --- Config (all overridable via env) ---
 export PYLON_OPENAGENTS_BASE_URL="${PYLON_OPENAGENTS_BASE_URL:-https://openagents.com}"
@@ -266,10 +269,10 @@ standing_task_keeper_loop() {
 heartbeater_loop() {
   while true; do
     [ -f "$PAUSE_FILE" ] && { sleep "$SUP_HEARTBEAT_SECS"; continue; }
-    local ready desired
+    local ready desired account_slots=()
     ready=$(ready_codex_account_refs | grep -c . || echo 0)
-    desired=$(( ready * SUP_PER_ACCOUNT ))
-    [ "$desired" -gt "$SUP_MAX_SLOTS" ] && desired="$SUP_MAX_SLOTS"
+    while IFS= read -r slot_acc; do account_slots+=("$slot_acc"); done < <(sup_expand_account_slots $(ready_codex_account_refs))
+    desired="${#account_slots[@]}"
     echo "$desired" > "$DESIRED_FILE"
     OPENAGENTS_PYLON_CODEX_CONCURRENCY="$desired" \
     OPENAGENTS_PYLON_CODEX_BUSY=0 \
@@ -278,7 +281,7 @@ heartbeater_loop() {
     # last_dispatch_time telemetry (#6646): emitted on the heartbeat line so a
     # wedged loop (heartbeat firing, dispatch stalled) is visible in the log and
     # the watcher's liveness check has a fresh value to read.
-    log "heartbeat ready_codex=$ready desired_slots=$desired last_dispatch_time=$(read_last_dispatch_time)"
+    log "heartbeat ready_codex=$ready desired_slots=$desired tuned_account_slots=${account_slots[*]:-none} last_dispatch_time=$(read_last_dispatch_time)"
     bound_log
     sleep "$SUP_HEARTBEAT_SECS"
   done
@@ -294,10 +297,16 @@ worker_loop() {
     local desired; desired=$(cat "$DESIRED_FILE" 2>/dev/null || echo 0)
     if [ "$slot" -ge "$desired" ]; then sleep 10; continue; fi
 
-    # Round-robin account across the live ready set; default omits --account-ref.
+    # Round-robin account across the live tuned slot set; default omits
+    # --account-ref. Repeated local Codex executor refusals shrink a specific
+    # account's expansion here, so the fleet finds the clean per-account ceiling
+    # without forcing every account down.
     local refs=(); while IFS= read -r r; do refs+=("$r"); done < <(ready_codex_account_refs)
     [ "${#refs[@]}" -eq 0 ] && { sleep 20; continue; }
-    local acc="${refs[$(( slot % ${#refs[@]} ))]}"
+    local account_slots=(); while IFS= read -r slot_acc; do account_slots+=("$slot_acc"); done < <(sup_expand_account_slots "${refs[@]}")
+    [ "${#account_slots[@]}" -eq 0 ] && { sleep 20; continue; }
+    if [ "$slot" -ge "${#account_slots[@]}" ]; then sleep 10; continue; fi
+    local acc="${account_slots[$slot]}"
     local acc_args=(); [ "$acc" != "default" ] && acc_args=(--account-ref "$acc")
 
     # Refresh the active pool from the unsupported-request ledger, with a short
@@ -364,9 +373,13 @@ worker_loop() {
     local issue
     issue=$(pick_and_claim_unlocked_issue 0 "${ordered[@]}")
     if [ -z "$issue" ]; then
-      log "slot=$slot LOCKOUT all backlog issues are closed, already have open PRs, or are claimed by other slots; backing off ${backoff}s"
-      sleep "$backoff"
-      backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
+      local pick_sleep
+      pick_sleep="$(sup_claimed_pick_backoff_secs "${#issues[@]}" "$desired" "$backoff")"
+      log "slot=$slot LOCKOUT all backlog issues are closed, already have open PRs, or are claimed by other slots; open_backlog=${#issues[@]} desired_slots=$desired backing off ${pick_sleep}s"
+      sleep "$pick_sleep"
+      if [ "$pick_sleep" = "$backoff" ]; then
+        backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
+      fi
       continue
     fi
     # Base every assignment on FRESH origin/main, never the supervisor's stale
@@ -421,6 +434,7 @@ worker_loop() {
 
     if grep -qiE '"ok": ?true|"closeout"|accepted' "$out" 2>/dev/null && [ "$rc" -eq 0 ]; then
       backoff="$SUP_BACKOFF_MIN"
+      sup_reset_account_refusals "$acc"
       # Keep the issue claimed (refresh TTL) so no other slot re-picks it while
       # its PR/lockout state settles; the open-PR lockout then takes over and the
       # claim eventually GCs.
@@ -432,8 +446,7 @@ worker_loop() {
     # Refused / unavailable / rate-limited / error -> exponential backoff so the
     # pool settles at the login's real headroom.
     local sig="other"
-    grep -qiE '409|dispatch gate refused|target_pylon_unavailable|duplicate_active_assignment' "$out" 2>/dev/null && sig="refused"
-    grep -qiE '429|rate.?limit|too many requests|quota' "$out" 2>/dev/null && sig="rate_limited"
+    sig="$(sup_dispatch_failure_signature "$out")"
     if [ "$sig" = "refused" ]; then
       # The gate already has an active assignment for this issue (it is busy
       # elsewhere). PARK it for the full claim TTL so the fleet stops hammering
@@ -445,9 +458,20 @@ worker_loop() {
       # the claim so another (less throttled) slot/account can retry this issue.
       sup_release_claim "$issue"
     fi
-    log "slot=$slot acc=$acc issue=#$issue NO-DISPATCH ($sig rc=$rc); backoff ${backoff}s"
-    sleep "$backoff"
-    backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
+    local tune_action
+    tune_action="$(sup_record_account_refusal "$acc" "$sig")"
+    [ -n "$tune_action" ] && log "slot=$slot acc=$acc REFUSAL-TUNE $tune_action"
+    local failure_sleep="$backoff"
+    local escalate_backoff=1
+    if [ "$sig" = "codex_agent_execution_refused" ]; then
+      failure_sleep="$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
+      escalate_backoff=0
+    fi
+    log "slot=$slot acc=$acc issue=#$issue NO-DISPATCH ($sig rc=$rc); backoff ${failure_sleep}s"
+    sleep "$failure_sleep"
+    if [ "$escalate_backoff" -eq 1 ]; then
+      backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"
+    fi
   done
 }
 

--- a/apps/pylon/scripts/codex-supervisor/priority-dispatch.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/priority-dispatch.test.sh
@@ -47,15 +47,17 @@ source "$SCRIPT_DIR/priority-dispatch.sh"
 [ "$(sup_priority_rank_for_labels 'prio:0-pr-burndown-extra')" = "99" ] && ok "rank ignores non-exact prio label" || bad "rank non-exact"
 
 # --- sup_order_pool_by_priority -------------------------------------------
-# Inject labels directly (override the map lookup; no gh needed).
-declare -A LBL=(
-  [10]="prio:4-backstop-burn"
-  [11]="prio:0-pr-burndown"
-  [12]="bug"
-  [13]="prio:2-issue-triage"
-  [14]="prio:0-pr-burndown"
-)
-sup_labels_for_issue() { printf '%s' "${LBL[$1]:-}"; }
+# Inject labels directly (override the map lookup; no gh needed). Use a case
+# statement instead of associative arrays so stock macOS Bash 3 can run this.
+sup_labels_for_issue() {
+  case "$1" in
+    10) printf 'prio:4-backstop-burn' ;;
+    11) printf 'prio:0-pr-burndown' ;;
+    12) printf 'bug' ;;
+    13) printf 'prio:2-issue-triage' ;;
+    14) printf 'prio:0-pr-burndown' ;;
+  esac
+}
 
 # start=0: tiers ascending; within prio:0, input order (11 then 14) preserved.
 order="$(sup_order_pool_by_priority 0 10 11 12 13 14 | tr '\n' ' ')"


### PR DESCRIPTION
Addresses #6900.

### Changes

- Wired the codex supervisor into the backoff policy helpers for refusal-aware slot tuning.
- Tuned heartbeat and worker slot selection to use expanded per-account slots, with refusal resets after successful dispatch.
- Added shorter claimed-backlog sleeps and special handling for `codex_agent_execution_refused` so slots can re-task without escalating general backoff.
- Updated the priority dispatch test label fixture to avoid associative arrays so it runs on stock macOS Bash 3.

### Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).