### PR TITLE
feat(autopilot): add decision closeout receipts

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedIn/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/model.ts
@@ -6176,7 +6176,19 @@ export const AutopilotDecisionWorkContext = S.Struct({
 export type AutopilotDecisionWorkContext =
   typeof AutopilotDecisionWorkContext.Type
 
+export const AutopilotDecisionCloseoutReceipt = S.Struct({
+  action: S.String,
+  closeoutRef: S.String,
+  decidedAt: S.String,
+  outcome: S.String,
+  receiptRefs: S.Array(S.String),
+  resolvedState: S.String,
+})
+export type AutopilotDecisionCloseoutReceipt =
+  typeof AutopilotDecisionCloseoutReceipt.Type
+
 export const AutopilotDecisionQueueItem = S.Struct({
+  closeoutReceipts: S.Array(AutopilotDecisionCloseoutReceipt),
   decision: AutopilotDecisionProjection,
   work: AutopilotDecisionWorkContext,
 })
@@ -6192,6 +6204,7 @@ export type AutopilotDecisionListResponse =
   typeof AutopilotDecisionListResponse.Type
 
 export const AutopilotDecisionActionResponse = S.Struct({
+  closeout: S.optionalKey(AutopilotDecisionCloseoutReceipt),
   decision: S.NullOr(AutopilotDecisionProjection),
   directEffectPermitted: S.Boolean,
   generatedAt: S.String,

--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/decisions.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/decisions.test.ts
@@ -1,0 +1,143 @@
+import type { Html } from 'foldkit/html'
+import { describe, expect, test } from 'vitest'
+
+import {
+  AutopilotDecisionActIdle,
+  AutopilotDecisionsLoaded,
+} from '../model'
+import type { Model } from '../model'
+import { view } from './decisions'
+
+type VNodeLike = Readonly<{
+  sel?: string
+  text?: string
+  children?: ReadonlyArray<VNodeLike | string | null>
+  data?: {
+    attrs?: Record<string, unknown>
+    props?: Record<string, unknown>
+    class?: Record<string, boolean>
+  }
+}>
+
+const isVNodeLike = (value: unknown): value is VNodeLike =>
+  typeof value === 'object' && value !== null
+
+const attrsToString = (node: VNodeLike): string => {
+  const attrs = node.data?.attrs ?? {}
+  const props = node.data?.props ?? {}
+  const classes = Object.entries(node.data?.class ?? {})
+    .filter(([, enabled]) => enabled)
+    .map(([className]) => className)
+    .join(' ')
+  const pairs = [
+    ...Object.entries(attrs),
+    ...Object.entries(props),
+    ...(classes.length === 0 ? [] : [['class', classes] as const]),
+  ]
+
+  return pairs
+    .filter(
+      ([, value]) => value !== false && value !== undefined && value !== null,
+    )
+    .map(([name, value]) =>
+      value === true ? ` ${name}` : ` ${name}="${String(value)}"`,
+    )
+    .join('')
+}
+
+const renderHtml = (html: Html): string => {
+  if (html === null || !isVNodeLike(html)) {
+    return ''
+  }
+
+  const tag = html.sel ?? 'node'
+  const children = (html.children ?? [])
+    .map(child =>
+      typeof child === 'string'
+        ? child
+        : child === null
+          ? ''
+          : renderHtml(child),
+    )
+    .join('')
+  const text = html.text ?? ''
+
+  return `<${tag}${attrsToString(html)}>${text}${children}</${tag}>`
+}
+
+describe('Autopilot decisions page', () => {
+  test('renders closeout receipt state from the decision projection', () => {
+    const model = {
+      autopilotDecisionAct: AutopilotDecisionActIdle(),
+      autopilotDecisions: AutopilotDecisionsLoaded({
+        response: {
+          decisions: [
+            {
+              closeoutReceipts: [
+                {
+                  action: 'accept',
+                  closeoutRef:
+                    'decision.closeout.accept.autopilot_work_order.test_1',
+                  decidedAt: '2026-06-11T17:30:00.000Z',
+                  outcome: 'applied',
+                  receiptRefs: [
+                    'receipt.review.accept.autopilot_work_order.test_1',
+                  ],
+                  resolvedState: 'accepted',
+                },
+              ],
+              decision: {
+                accountLeaseRefs: [],
+                actionKind: 'approve_pr_draft',
+                actionLabel: 'Approve PR draft',
+                actionRef:
+                  'decision_action.autopilot_work_order.test_1.approve_pr_draft',
+                actionSubmissionRefs: [],
+                actionSubmissionRequired: true,
+                assignmentRefs: [],
+                audience: 'customer',
+                blockedReasonRefs: [],
+                createdAtDisplay: 'just now',
+                customerNextActionRef: 'next_action.review_recorded',
+                directEffectPermitted: false,
+                evidenceRefs: [],
+                id: 'decision_action.autopilot_work_order.test_1.approve_pr_draft',
+                missionRef: 'mission.autopilot_work_order.test_1',
+                prerequisiteRefs: [],
+                programRunRef: null,
+                receiptRefs: [
+                  'receipt.review.accept.autopilot_work_order.test_1',
+                ],
+                routeRefs: [],
+                safeSummaryRef: 'summary.review_decision_recorded',
+                sourceAuthorityRefs: [],
+                status: 'completed',
+                statusLabel: 'Completed',
+                updatedAtDisplay: 'just now',
+                workroomRefs: [],
+              },
+              work: {
+                createdAt: '2026-06-11T16:00:00.000Z',
+                state: 'accepted',
+                taskRefs: ['task.public.test'],
+                updatedAt: '2026-06-11T17:30:00.000Z',
+                workOrderRef: 'autopilot_work_order.test_1',
+              },
+            },
+          ],
+          directEffectPermitted: false,
+          generatedAt: '2026-06-11T17:30:00.000Z',
+          pendingCount: 0,
+        },
+      }),
+    } as Model
+
+    const rendered = renderHtml(view(model))
+
+    expect(rendered).toContain(
+      'decision.closeout.accept.autopilot_work_order.test_1',
+    )
+    expect(rendered).toContain('accepted')
+    expect(rendered).toContain('applied')
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/decisions.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/decisions.ts
@@ -11,6 +11,7 @@ import {
   SubmittedAutopilotDecisionAction,
 } from '../message'
 import type {
+  AutopilotDecisionCloseoutReceipt,
   AutopilotDecisionQueueItem,
   AutopilotWorkReviewAction,
   Model,
@@ -103,6 +104,42 @@ const refChips = (refs: ReadonlyArray<string>): ReadonlyArray<Html> => {
       ],
       [ref],
     ),
+  )
+}
+
+const closeoutReceiptRow = (
+  receipt: AutopilotDecisionCloseoutReceipt,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      Ui.className<Message>(
+        'grid gap-2 border border-[#222] bg-[#080808] px-3 py-2 text-xs text-white/55',
+      ),
+    ],
+    [
+      h.div([Ui.className<Message>('flex flex-wrap items-center gap-2')], [
+        badge(receipt.outcome, 'positive'),
+        h.span([Ui.className<Message>('text-white/65')], [
+          receipt.resolvedState.replaceAll('_', ' '),
+        ]),
+        h.span([Ui.className<Message>('text-white/35')], [
+          formatIsoDateTime(receipt.decidedAt),
+        ]),
+      ]),
+      h.a(
+        [
+          h.Href(
+            `/api/autopilot/decision-closeouts/${encodeURIComponent(receipt.closeoutRef)}`,
+          ),
+          Ui.className<Message>(
+            'min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-white/45 underline underline-offset-[3px] hover:text-[#ffb400]',
+          ),
+        ],
+        [receipt.closeoutRef],
+      ),
+    ],
   )
 }
 
@@ -223,6 +260,12 @@ const decisionCard = (model: Model, item: AutopilotDecisionQueueItem): Html => {
         : h.div(
             [Ui.className<Message>('flex flex-wrap gap-2')],
             refChips(item.decision.receiptRefs),
+          ),
+      item.closeoutReceipts.length === 0
+        ? empty()
+        : h.div(
+            [Ui.className<Message>('grid gap-2')],
+            item.closeoutReceipts.map(closeoutReceiptRow),
           ),
       decisionActions(model, item),
     ],

--- a/apps/openagents.com/workers/api/migrations/0258_autopilot_decision_closeout_receipts.sql
+++ b/apps/openagents.com/workers/api/migrations/0258_autopilot_decision_closeout_receipts.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS autopilot_decision_closeout_receipts (
+  closeout_ref TEXT PRIMARY KEY,
+  decision_ref TEXT NOT NULL,
+  work_order_ref TEXT NOT NULL,
+  action TEXT NOT NULL,
+  resolved_state TEXT NOT NULL,
+  outcome TEXT NOT NULL,
+  actor_agent_user_id TEXT NOT NULL,
+  decided_at TEXT NOT NULL,
+  receipt_refs_json TEXT NOT NULL,
+  has_answer INTEGER NOT NULL DEFAULT 0,
+  line TEXT NOT NULL,
+  receipt_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_autopilot_decision_closeout_receipts_work
+  ON autopilot_decision_closeout_receipts(work_order_ref, decided_at DESC);

--- a/apps/openagents.com/workers/api/src/autopilot-decision-closeout.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-decision-closeout.ts
@@ -180,7 +180,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 // reconstructs byte-identically from the validated fields.
 export const validateAutopilotDecisionCloseoutReceipt = (
   receipt: unknown,
-): boolean => {
+): receipt is AutopilotDecisionCloseoutReceipt => {
   if (!isRecord(receipt)) return false
   if (receipt.kind !== 'autopilot_decision_closeout_receipt') return false
   if (typeof receipt.decisionRef !== 'string') return false

--- a/apps/openagents.com/workers/api/src/autopilot-decision-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-decision-routes.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest'
 import { AGENT_TOKEN_PREFIX } from './agent-registration'
 import type { AgentRegistrationStore } from './agent-registration'
 import { makeAutopilotDecisionRoutes } from './autopilot-decision-routes'
+import type { AutopilotDecisionCloseoutReceipt } from './autopilot-decision-closeout'
 import {
   OPENAGENTS_AUTOPILOT_WORK_REQUEST_FIXTURES,
   decodeOpenAgentsAutopilotWorkRequest,
@@ -21,6 +22,8 @@ const fixtureNowIso = '2026-06-11T17:30:00.000Z'
 const ownerUserId = 'github:autopilot-owner'
 
 class MemoryAutopilotWorkStore implements AutopilotWorkStore {
+  readonly closeoutReceipts =
+    new Map<string, AutopilotDecisionCloseoutReceipt>()
   readonly records = new Map<string, AutopilotWorkOrderRecord>()
 
   createWorkOrder = async (record: AutopilotWorkOrderRecord) => {
@@ -129,6 +132,40 @@ class MemoryAutopilotWorkStore implements AutopilotWorkStore {
     this.records.set(existing.workOrderRef, updated)
 
     return { idempotent: false, record: updated }
+  }
+
+  recordDecisionCloseoutReceipt = async (
+    receipt: AutopilotDecisionCloseoutReceipt,
+  ) => {
+    this.closeoutReceipts.set(receipt.closeoutRef, receipt)
+  }
+
+  listDecisionCloseoutReceiptsForWorkOrder = async (
+    input: Readonly<{ ownerUserId: string; workOrderRef: string }>,
+  ) => {
+    const record = this.records.get(input.workOrderRef)
+
+    if (record?.ownerUserId !== input.ownerUserId) {
+      return []
+    }
+
+    return [...this.closeoutReceipts.values()].filter(
+      receipt => receipt.workOrderRef === input.workOrderRef,
+    )
+  }
+
+  readDecisionCloseoutReceipt = async (
+    input: Readonly<{ closeoutRef: string; ownerUserId: string }>,
+  ) => {
+    const receipt = this.closeoutReceipts.get(input.closeoutRef)
+
+    if (receipt === undefined) {
+      return undefined
+    }
+
+    const record = this.records.get(receipt.workOrderRef)
+
+    return record?.ownerUserId === input.ownerUserId ? receipt : undefined
   }
 }
 
@@ -291,6 +328,14 @@ type DecisionListBody = Readonly<{
         status: string
         statusLabel: string
       }>
+      closeoutReceipts: ReadonlyArray<
+        Readonly<{
+          action: string
+          closeoutRef: string
+          outcome: string
+          resolvedState: string
+        }>
+      >
       work: Readonly<{
         state: string
         taskRefs: ReadonlyArray<string>
@@ -305,6 +350,11 @@ type DecisionListBody = Readonly<{
 }>
 
 type DecisionActBody = Readonly<{
+  closeout: Readonly<{
+    closeoutRef: string
+    outcome: string
+    resolvedState: string
+  }>
   decision: Readonly<{
     actionKind: string
     receiptRefs: ReadonlyArray<string>
@@ -482,6 +532,10 @@ describe('autopilot decision queue routes', () => {
     expect(body.idempotent).toBe(false)
     expect(body.directEffectPermitted).toBe(false)
     expect(body.work.state).toBe('accepted')
+    expect(body.closeout.closeoutRef).toBe(
+      'decision.closeout.accept.autopilot_work_order.decision_test_1',
+    )
+    expect(body.closeout.resolvedState).toBe('accepted')
     expect(body.decision?.status).toBe('completed')
     expect(body.decision?.receiptRefs).toContain(
       'decision.queue.accept.autopilot_work_order.decision_test_1',
@@ -493,6 +547,11 @@ describe('autopilot decision queue routes', () => {
     expect(record?.reviewDecision?.decisionRefs).toContain(
       'decision.queue.accept.autopilot_work_order.decision_test_1',
     )
+    expect(
+      store.closeoutReceipts.get(
+        'decision.closeout.accept.autopilot_work_order.decision_test_1',
+      )?.receiptRefs,
+    ).toContain('receipt.review.accept.autopilot_work_order.decision_test_1')
   })
 
   test('accepts the public accept command name for the review action', async () => {
@@ -720,6 +779,87 @@ describe('autopilot decision queue routes', () => {
     expect(body.decisions[0]?.decision.receiptRefs).toContain(
       'receipt.review.accept.autopilot_work_order.decision_test_1',
     )
+    expect(body.decisions[0]?.closeoutReceipts[0]?.closeoutRef).toBe(
+      'decision.closeout.accept.autopilot_work_order.decision_test_1',
+    )
+  })
+
+  test('returns pending and decided decisions for one work order with closeout receipt rows', async () => {
+    const store = new MemoryAutopilotWorkStore()
+
+    await store.createWorkOrder(deliveredWorkOrderRecord())
+
+    const pending = await route(
+      store,
+      '/api/autopilot/work/autopilot_work_order.decision_test_1/decisions',
+    )
+    const pendingBody = (await pending.json()) as DecisionListBody
+
+    expect(pending.status).toBe(200)
+    expect(pendingBody.pendingCount).toBe(1)
+    expect(pendingBody.decisions[0]?.decision.status).toBe('available')
+    expect(pendingBody.decisions[0]?.closeoutReceipts).toEqual([])
+
+    await route(
+      store,
+      '/api/autopilot/decisions/decision_action.autopilot_work_order.decision_test_1.approve_pr_draft/actions',
+      {
+        body: { action: 'accept' },
+        idempotencyKey: 'decision-accept-scoped-1',
+        method: 'POST',
+      },
+    )
+
+    const decided = await route(
+      store,
+      '/api/autopilot/work/autopilot_work_order.decision_test_1/decisions',
+    )
+    const decidedBody = (await decided.json()) as DecisionListBody
+
+    expect(decided.status).toBe(200)
+    expect(decidedBody.pendingCount).toBe(0)
+    expect(decidedBody.decisions[0]?.decision.status).toBe('completed')
+    expect(decidedBody.decisions[0]?.closeoutReceipts[0]?.outcome).toBe(
+      'applied',
+    )
+  })
+
+  test('dereferences an owner-scoped decision closeout receipt', async () => {
+    const store = new MemoryAutopilotWorkStore()
+
+    await store.createWorkOrder(deliveredWorkOrderRecord())
+    await route(
+      store,
+      '/api/autopilot/decisions/decision_action.autopilot_work_order.decision_test_1.approve_pr_draft/actions',
+      {
+        body: { action: 'accept' },
+        idempotencyKey: 'decision-closeout-read-1',
+        method: 'POST',
+      },
+    )
+
+    const response = await route(
+      store,
+      '/api/autopilot/decision-closeouts/decision.closeout.accept.autopilot_work_order.decision_test_1',
+    )
+    const body = (await response.json()) as Readonly<{
+      directEffectPermitted: false
+      receipt: Readonly<{
+        closeoutRef: string
+        line: string
+        workOrderRef: string
+      }>
+    }>
+
+    expect(response.status).toBe(200)
+    expect(body.directEffectPermitted).toBe(false)
+    expect(body.receipt.closeoutRef).toBe(
+      'decision.closeout.accept.autopilot_work_order.decision_test_1',
+    )
+    expect(body.receipt.workOrderRef).toBe(
+      'autopilot_work_order.decision_test_1',
+    )
+    expect(body.receipt.line).toContain('closed out as applied')
   })
 
   test('rejects mutation methods on the decision list route', async () => {

--- a/apps/openagents.com/workers/api/src/autopilot-decision-routes.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-decision-routes.ts
@@ -10,7 +10,11 @@ import {
 import {
   classifyAutopilotDecisionActRoute,
 } from './autopilot-decision-act-routing'
-import { buildAutopilotDecisionCloseoutReceipt } from './autopilot-decision-closeout'
+import {
+  type AutopilotDecisionCloseoutReceipt,
+  buildAutopilotDecisionCloseoutReceipt,
+  validateAutopilotDecisionCloseoutReceipt,
+} from './autopilot-decision-closeout'
 import {
   type AutopilotWorkOrderRecord,
   type AutopilotWorkReviewAction,
@@ -143,6 +147,7 @@ export type AutopilotWorkDecisionContext = Readonly<{
 }>
 
 export type AutopilotDecisionQueueItem = Readonly<{
+  closeoutReceipts: ReadonlyArray<AutopilotDecisionCloseoutReceipt>
   decision: CodingAutopilotDecisionActionProjection
   work: AutopilotWorkDecisionContext
 }>
@@ -297,12 +302,18 @@ export const decisionRecordsForWorkOrder = (
 const projectedQueueItems = (
   records: ReadonlyArray<AutopilotWorkOrderRecord>,
   nowIso: string,
+  closeoutReceiptsByWorkOrder: ReadonlyMap<
+    string,
+    ReadonlyArray<AutopilotDecisionCloseoutReceipt>
+  > = new Map(),
 ): ReadonlyArray<AutopilotDecisionQueueItem> =>
   records.flatMap(record =>
     decisionRecordsForWorkOrder(record).flatMap(decisionRecord => {
       try {
         return [
           {
+            closeoutReceipts:
+              closeoutReceiptsByWorkOrder.get(record.workOrderRef) ?? [],
             decision: projectCodingAutopilotDecisionActionRecord(
               decisionRecord,
               'customer',
@@ -354,6 +365,51 @@ const routeErrorResponse = (error: AutopilotWorkStoreError): HttpResponse =>
               : 400,
     },
   )
+
+const closeoutReceiptsForWorkOrder = <Bindings>(
+  dependencies: AutopilotDecisionRoutesDependencies<Bindings>,
+  env: Bindings,
+  input: Readonly<{ ownerUserId: string; workOrderRef: string }>,
+): Effect.Effect<
+  ReadonlyArray<AutopilotDecisionCloseoutReceipt>,
+  AutopilotWorkStoreError
+> =>
+  Effect.tryPromise({
+    catch: error =>
+      new AutopilotWorkStoreError({
+        kind: 'storage_error',
+        reason: error instanceof Error ? error.message : String(error),
+      }),
+    try: async () =>
+      dependencies.makeStore(env).listDecisionCloseoutReceiptsForWorkOrder?.(
+        input,
+      ) ?? [],
+  }).pipe(
+    Effect.map(receipts =>
+      receipts.filter(receipt =>
+        validateAutopilotDecisionCloseoutReceipt(receipt)
+      )
+    ),
+  )
+
+const closeoutReceiptMapForRecords = <Bindings>(
+  dependencies: AutopilotDecisionRoutesDependencies<Bindings>,
+  env: Bindings,
+  ownerUserId: string,
+  records: ReadonlyArray<AutopilotWorkOrderRecord>,
+): Effect.Effect<
+  ReadonlyMap<string, ReadonlyArray<AutopilotDecisionCloseoutReceipt>>,
+  AutopilotWorkStoreError
+> =>
+  Effect.forEach(records, record =>
+    Effect.map(
+      closeoutReceiptsForWorkOrder(dependencies, env, {
+        ownerUserId,
+        workOrderRef: record.workOrderRef,
+      }),
+      receipts => [record.workOrderRef, receipts] as const,
+    )
+  ).pipe(Effect.map(entries => new Map(entries)))
 
 const requireIdempotencyHash = (
   request: Request,
@@ -530,7 +586,15 @@ const listDecisions = <Bindings extends AutopilotDecisionRouteEnv>(
           ownerUserId: auth.ownerUserId,
         }),
     })
-    const decisions = orderedQueueItems(projectedQueueItems(records, nowIso))
+    const closeoutReceiptsByWorkOrder = yield* closeoutReceiptMapForRecords(
+      dependencies,
+      env,
+      auth.ownerUserId,
+      records,
+    )
+    const decisions = orderedQueueItems(
+      projectedQueueItems(records, nowIso, closeoutReceiptsByWorkOrder),
+    )
     const pendingCount = decisions.filter(
       item => item.decision.status !== 'completed',
     ).length
@@ -540,6 +604,144 @@ const listDecisions = <Bindings extends AutopilotDecisionRouteEnv>(
       directEffectPermitted: false,
       generatedAt: nowIso,
       pendingCount,
+    })
+  }).pipe(
+    Effect.catchTag('CustomerOrderAgentAuthFailure', () =>
+      Effect.succeed(unauthorized())
+    ),
+    Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
+  )
+
+const listDecisionsForWorkOrder = <Bindings extends AutopilotDecisionRouteEnv>(
+  dependencies: AutopilotDecisionRoutesDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  ctx: ExecutionContext,
+  workOrderRef: string,
+): Effect.Effect<HttpResponse> =>
+  Effect.gen(function* () {
+    const nowIso = routeNowIso(dependencies)
+    const auth = yield* authenticateAutopilotWorkRequest(
+      dependencies,
+      request,
+      env,
+      {
+        ctx,
+        nowIso: () => nowIso,
+        requiredScope: 'customer_orders.read',
+      },
+    )
+    const record = yield* Effect.tryPromise({
+      catch: error =>
+        new AutopilotWorkStoreError({
+          kind: 'storage_error',
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      try: () => dependencies.makeStore(env).readWorkOrder(workOrderRef),
+    })
+
+    if (record === undefined || record.ownerUserId !== auth.ownerUserId) {
+      return noStoreJsonResponse(
+        {
+          error: 'autopilot_decision_not_found',
+          reason: 'Autopilot work-order decision projection was not found.',
+        },
+        { status: 404 },
+      )
+    }
+
+    const closeoutReceipts = yield* closeoutReceiptsForWorkOrder(
+      dependencies,
+      env,
+      { ownerUserId: auth.ownerUserId, workOrderRef },
+    )
+    const decisions = orderedQueueItems(
+      projectedQueueItems(
+        [record],
+        nowIso,
+        new Map([[workOrderRef, closeoutReceipts]]),
+      ),
+    )
+
+    return noStoreJsonResponse({
+      decisions,
+      directEffectPermitted: false,
+      generatedAt: nowIso,
+      pendingCount: decisions.filter(
+        item => item.decision.status !== 'completed',
+      ).length,
+      work: workDecisionContext(record),
+    })
+  }).pipe(
+    Effect.catchTag('CustomerOrderAgentAuthFailure', () =>
+      Effect.succeed(unauthorized())
+    ),
+    Effect.catch(error => Effect.succeed(routeErrorResponse(error))),
+  )
+
+const closeoutRefFromPath = (pathname: string): string | undefined => {
+  const match = /^\/api\/autopilot\/decision-closeouts\/([^/]+)$/.exec(
+    pathname,
+  )
+
+  return match?.[1] === undefined ? undefined : decodeURIComponent(match[1])
+}
+
+const decisionsWorkOrderRefFromPath = (pathname: string): string | undefined => {
+  const match = /^\/api\/autopilot\/work\/([^/]+)\/decisions$/.exec(pathname)
+
+  return match?.[1] === undefined ? undefined : decodeURIComponent(match[1])
+}
+
+const readDecisionCloseout = <Bindings extends AutopilotDecisionRouteEnv>(
+  dependencies: AutopilotDecisionRoutesDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  ctx: ExecutionContext,
+  closeoutRef: string,
+): Effect.Effect<HttpResponse> =>
+  Effect.gen(function* () {
+    const nowIso = routeNowIso(dependencies)
+    const auth = yield* authenticateAutopilotWorkRequest(
+      dependencies,
+      request,
+      env,
+      {
+        ctx,
+        nowIso: () => nowIso,
+        requiredScope: 'customer_orders.read',
+      },
+    )
+    const receipt = yield* Effect.tryPromise({
+      catch: error =>
+        new AutopilotWorkStoreError({
+          kind: 'storage_error',
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      try: () =>
+        dependencies.makeStore(env).readDecisionCloseoutReceipt?.({
+          closeoutRef,
+          ownerUserId: auth.ownerUserId,
+        }) ?? Promise.resolve(undefined),
+    })
+
+    if (
+      receipt === undefined ||
+      !validateAutopilotDecisionCloseoutReceipt(receipt)
+    ) {
+      return noStoreJsonResponse(
+        {
+          error: 'autopilot_decision_closeout_not_found',
+          reason: 'Autopilot decision closeout receipt was not found.',
+        },
+        { status: 404 },
+      )
+    }
+
+    return noStoreJsonResponse({
+      directEffectPermitted: false,
+      generatedAt: nowIso,
+      receipt,
     })
   }).pipe(
     Effect.catchTag('CustomerOrderAgentAuthFailure', () =>
@@ -720,6 +922,16 @@ const actOnDecision = <Bindings extends AutopilotDecisionRouteEnv>(
       reviewDecision,
       workOrderRef,
     })
+    yield* Effect.tryPromise({
+      catch: error =>
+        new AutopilotWorkStoreError({
+          kind: 'storage_error',
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      try: () =>
+        dependencies.makeStore(env).recordDecisionCloseoutReceipt?.(closeout) ??
+        Promise.resolve(),
+    })
 
     return noStoreJsonResponse(
       {
@@ -754,6 +966,34 @@ export const makeAutopilotDecisionRoutes = <
     if (url.pathname === '/api/autopilot/decisions') {
       return M.value(request.method).pipe(
         M.when('GET', () => listDecisions(dependencies, request, env, ctx)),
+        M.orElse(() => Effect.succeed(methodNotAllowed(['GET']))),
+      )
+    }
+
+    const workOrderRef = decisionsWorkOrderRefFromPath(url.pathname)
+
+    if (workOrderRef !== undefined) {
+      return M.value(request.method).pipe(
+        M.when('GET', () =>
+          listDecisionsForWorkOrder(
+            dependencies,
+            request,
+            env,
+            ctx,
+            workOrderRef,
+          )
+        ),
+        M.orElse(() => Effect.succeed(methodNotAllowed(['GET']))),
+      )
+    }
+
+    const closeoutRef = closeoutRefFromPath(url.pathname)
+
+    if (closeoutRef !== undefined) {
+      return M.value(request.method).pipe(
+        M.when('GET', () =>
+          readDecisionCloseout(dependencies, request, env, ctx, closeoutRef)
+        ),
         M.orElse(() => Effect.succeed(methodNotAllowed(['GET']))),
       )
     }

--- a/apps/openagents.com/workers/api/src/autopilot-work-routes.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-work-routes.ts
@@ -7,6 +7,9 @@ import {
 import {
   autopilotCodingAssignmentsForWork,
 } from './autopilot-coding-assignment'
+import {
+  validateAutopilotDecisionCloseoutReceipt,
+} from './autopilot-decision-closeout'
 import { missionBriefingForWorkOrder } from './autopilot-mission-briefing'
 import {
   assignmentIntentsForWorkOrder,
@@ -477,6 +480,22 @@ export type AutopilotWorkStore = Readonly<{
     }>,
   ) => Promise<
     | Readonly<{ idempotent: boolean; record: AutopilotWorkOrderRecord }>
+    | undefined
+  >
+  recordDecisionCloseoutReceipt?: (
+    receipt: import('./autopilot-decision-closeout').AutopilotDecisionCloseoutReceipt,
+  ) => Promise<void>
+  listDecisionCloseoutReceiptsForWorkOrder?: (
+    input: Readonly<{ ownerUserId: string; workOrderRef: string }>,
+  ) => Promise<
+    ReadonlyArray<
+      import('./autopilot-decision-closeout').AutopilotDecisionCloseoutReceipt
+    >
+  >
+  readDecisionCloseoutReceipt?: (
+    input: Readonly<{ closeoutRef: string; ownerUserId: string }>,
+  ) => Promise<
+    | import('./autopilot-decision-closeout').AutopilotDecisionCloseoutReceipt
     | undefined
   >
   recordBuyerPaymentProof: (
@@ -4179,6 +4198,104 @@ export const makeD1AutopilotWorkStore = (
     return row === null
       ? undefined
       : { idempotent: false, record: recordFromRow(row) }
+  },
+  recordDecisionCloseoutReceipt: async receipt => {
+    await db
+      .prepare(
+        `INSERT INTO autopilot_decision_closeout_receipts (
+          closeout_ref,
+          decision_ref,
+          work_order_ref,
+          action,
+          resolved_state,
+          outcome,
+          actor_agent_user_id,
+          decided_at,
+          receipt_refs_json,
+          has_answer,
+          line,
+          receipt_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(closeout_ref) DO UPDATE SET
+          outcome = excluded.outcome,
+          receipt_refs_json = excluded.receipt_refs_json,
+          receipt_json = excluded.receipt_json`,
+      )
+      .bind(
+        receipt.closeoutRef,
+        receipt.decisionRef,
+        receipt.workOrderRef,
+        receipt.action,
+        receipt.resolvedState,
+        receipt.outcome,
+        receipt.actorAgentUserId,
+        receipt.decidedAt,
+        JSON.stringify(receipt.receiptRefs),
+        receipt.hasAnswer ? 1 : 0,
+        receipt.line,
+        JSON.stringify(receipt),
+      )
+      .run()
+  },
+  listDecisionCloseoutReceiptsForWorkOrder: async input => {
+    const rows = await db
+      .prepare(
+        `SELECT r.receipt_json
+         FROM autopilot_decision_closeout_receipts r
+         INNER JOIN autopilot_work_orders w
+           ON w.work_order_ref = r.work_order_ref
+         WHERE r.work_order_ref = ?
+           AND w.owner_user_id = ?
+           AND w.archived_at IS NULL
+         ORDER BY r.decided_at DESC`,
+      )
+      .bind(input.workOrderRef, input.ownerUserId)
+      .all<Record<string, unknown>>()
+
+    return (rows.results ?? []).flatMap(row => {
+      if (typeof row.receipt_json !== 'string') {
+        return []
+      }
+
+      try {
+        const parsed = parseJsonUnknown(row.receipt_json)
+
+        return validateAutopilotDecisionCloseoutReceipt(parsed)
+          ? [parsed]
+          : []
+      } catch {
+        return []
+      }
+    })
+  },
+  readDecisionCloseoutReceipt: async input => {
+    const row = await db
+      .prepare(
+        `SELECT r.receipt_json
+         FROM autopilot_decision_closeout_receipts r
+         INNER JOIN autopilot_work_orders w
+           ON w.work_order_ref = r.work_order_ref
+         WHERE r.closeout_ref = ?
+           AND w.owner_user_id = ?
+           AND w.archived_at IS NULL
+         LIMIT 1`,
+      )
+      .bind(input.closeoutRef, input.ownerUserId)
+      .first<Record<string, unknown>>()
+
+    if (typeof row?.receipt_json !== 'string') {
+      return undefined
+    }
+
+    try {
+      const parsed = parseJsonUnknown(row.receipt_json)
+
+      return validateAutopilotDecisionCloseoutReceipt(parsed)
+        ? parsed
+        : undefined
+    } catch {
+      return undefined
+    }
   },
   recordBuyerPaymentProof: async input => {
     await db

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1719,7 +1719,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Autopilot should expose a decision queue for continue, steer, provide context, rerun tests, retry with another account, stop, accept, or create a follow-up mission.',
         safeCopy:
-          'Decision-queue actions are planned/scoped and must remain route-authorized and receipt-backed. A Worker command route now decodes the public action enum, requires Idempotency-Key, applies the delivered-work accept command through the review store, and keeps non-review commands evidence-only with owner-approval gating where required. The exactly-once decision queue spanning desktop / web / Expo is still tracked as Coder Cloud Phase 3 (#5004), gated behind the Pylon remote bridge transport (#5000); workroom decisions and voice command proposals provide precursor decision/approval state.',
+          'Decision-queue actions are planned/scoped and must remain route-authorized and receipt-backed. A Worker command route now decodes the public action enum, requires Idempotency-Key, applies delivered-work review commands through the review store, persists a dereferenceable decision closeout receipt row, exposes owner-scoped pending/decided projections for the queue and each work order, and keeps non-review commands evidence-only with owner-approval gating where required. The exactly-once decision queue spanning desktop / web / mobile is still tracked as Coder Cloud Phase 3 (#5004), gated behind the Pylon remote bridge transport (#5000); workroom decisions and voice command proposals provide precursor decision/approval state.',
         unsafeCopy:
           'Do not claim agents can freely continue, retry, spend, mutate repositories, or switch accounts from public docs, or that the cross-client decision queue is live.',
         evidenceRefs: [
@@ -1732,6 +1732,9 @@ export const publicProductPromisesDocument = () => {
           'packages/autopilot-control-protocol/src/decision-closeout-receipt.test.ts',
           'apps/openagents.com/workers/api/src/autopilot-decision-routes.ts',
           'apps/openagents.com/workers/api/src/autopilot-decision-routes.test.ts',
+          'apps/openagents.com/workers/api/src/autopilot-decision-closeout.ts',
+          'apps/openagents.com/workers/api/migrations/0258_autopilot_decision_closeout_receipts.sql',
+          'apps/openagents.com/apps/web/src/page/loggedIn/page/decisions.ts',
           'apps/openagents.com/workers/api/src/autopilot-decision-act.ts',
           'apps/openagents.com/workers/api/src/autopilot-decision-act-routing.ts',
           'docs/launch/vertex-fleet/autopilot.decision_queue.v1.md',
@@ -1741,10 +1744,9 @@ export const publicProductPromisesDocument = () => {
         blockerRefs: [
           'blocker.product_promises.cross_client_command_store_missing',
           'blocker.product_promises.cross_client_exactly_once_decisions_missing',
-          'blocker.product_promises.receipt_backed_command_closeout_missing',
         ],
         verification:
-          'Current source verification covers authenticated command decoding, explicit public action enums, Idempotency-Key requirement, owner-approval-required rejection for sensitive actions, evidence-only non-review command acceptance, and idempotent accept review application in autopilot-decision-routes.test.ts. Green still requires persistent cross-client command storage, real desktop/web/mobile exactly-once replay evidence, receipt closeout storage, and UI projection.',
+          'Current source verification covers authenticated command decoding, explicit public action enums, Idempotency-Key requirement, owner-approval-required rejection for sensitive actions, evidence-only non-review command acceptance, idempotent review application, persisted decision.closeout.* receipt rows, owner-scoped closeout dereference, work-order pending/decided projections, and browser UI rendering of closeout receipt state in autopilot-decision-routes.test.ts plus the decisions page schema/view. Green still requires persistent cross-client command storage and real desktop/web/mobile exactly-once replay evidence with owner sign-off.',
         authorityBoundary:
           'A visible decision does not grant account, repository, spend, deploy, or continuation authority.',
       },


### PR DESCRIPTION
Addresses #6829.

### Changes
- Adds receipt-backed Autopilot decision closeout data to queue and action responses.
- Persists and reads decision closeout receipts for work orders, including owner-scoped lookup endpoints.
- Projects closeout receipts in the logged-in decision queue UI.
- Updates product promise metadata and tests for decision closeout receipt behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).