### PR TITLE
feat(energy): expose flexible-load proof projection

### DIFF
--- a/apps/openagents.com/workers/api/src/energy-flexible-load-proof.test.ts
+++ b/apps/openagents.com/workers/api/src/energy-flexible-load-proof.test.ts
@@ -1,10 +1,13 @@
-import { Schema as S } from 'effect'
+import { Effect, Schema as S } from 'effect'
 import { describe, expect, test } from 'vitest'
 
 import {
+  EnergyFlexibleLoadProofEndpoint,
   EnergyFlexibleLoadProofProjection,
   projectEnergyFlexibleLoadProof,
 } from './energy-flexible-load-proof'
+import { handleEnergyFlexibleLoadProofApi } from './energy-flexible-load-proof-routes'
+import { openAgentsOpenApiDocument } from './openagents-openapi'
 
 describe('energy flexible-load proof projection', () => {
   test('returns decoded market rows, queryable flex profiles, and labeled event history without flipping green', () => {
@@ -45,5 +48,32 @@ describe('energy flexible-load proof projection', () => {
       'blocker.product_promises.owner_signed_energy_green_transition_missing',
     ])
     expect(projection.authorityBoundary).toContain('grants no grid dispatch')
+  })
+
+  test('serves the public route as no-store JSON and documents it in OpenAPI', async () => {
+    const response = await Effect.runPromise(
+      handleEnergyFlexibleLoadProofApi(
+        new Request(`https://openagents.com${EnergyFlexibleLoadProofEndpoint}`),
+      ),
+    )
+    const body = await response.json()
+    const document = await Effect.runPromise(openAgentsOpenApiDocument())
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body).toEqual(expect.objectContaining({
+      promiseId: 'energy.flexible_load_proof.v1',
+      status: 'evidence_scaffolded_receipt_gated',
+    }))
+    expect(
+      (
+        document.paths[EnergyFlexibleLoadProofEndpoint] as
+          | { get?: { operationId?: string } }
+          | undefined
+      )?.get?.operationId,
+    ).toBe('getEnergyFlexibleLoadProof')
+    expect(
+      (document.components as { schemas: Record<string, unknown> }).schemas,
+    ).toHaveProperty('EnergyFlexibleLoadProofProjection')
   })
 })

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -26,6 +26,8 @@ import { Exit } from 'effect'
 import { WorkerEnvironment } from 'effect-cf'
 
 import { handleAcceptedOutcomesPerKwhApi } from './accepted-outcomes-per-kwh-routes'
+import { EnergyFlexibleLoadProofEndpoint } from './energy-flexible-load-proof'
+import { handleEnergyFlexibleLoadProofApi } from './energy-flexible-load-proof-routes'
 import { AdjutantEnrichmentQueueMessage } from './adjutant-enrichment-jobs'
 import type { AdjutantTaskPacketRefValidationInput } from './adjutant-task-packets'
 import { recordAdjutantUsageReceipt } from './adjutant-usage-receipts'
@@ -10507,6 +10509,14 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
   {
     path: '/api/public/metrics/accepted-outcomes-per-kwh',
     handler: request => handleAcceptedOutcomesPerKwhApi(request),
+  },
+  {
+    // Public flexible-load proof evidence scaffold for
+    // energy.flexible_load_proof.v1 (#6851). Read-only: decodes public ERCOT
+    // fixture rows, exposes work-class flex profiles, and projects labeled
+    // flexible-load event history while keeping the green gate receipt-blocked.
+    path: EnergyFlexibleLoadProofEndpoint,
+    handler: request => handleEnergyFlexibleLoadProofApi(request),
   },
   {
     // Public seed TraceRank/EigenTrust projection over replay-verified,

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -872,7 +872,7 @@ describe('OpenAgents OpenAPI route', () => {
     ).toEqual(
       expect.objectContaining({
         bearerFormat:
-          'OpenAgents Forge control-plane token plus X-OpenAgents-Forge-Scopes',
+          'OpenAgents Forge control-plane token plus X-OpenAgents-Forge-Scopes and X-OpenAgents-Forge-Tenant-Ref',
         type: 'http',
       }),
     )
@@ -1255,6 +1255,8 @@ const intentionallyUndocumentedApiRoutes: ReadonlyArray<string> = [
   // Owner-gated inference cost / provider-lane analytics (#6232): internal cost
   // + provider data, owner session only, not part of the public OpenAPI surface.
   '/api/admin/inference-analytics',
+  '/api/operator/accounts/status',
+  '/api/operator/artanis/dashboard',
   // Operator fleet status aggregator (#6427): admin/operator snapshot for
   // internal Artanis and fleet surfaces; public pages consume a later
   // public-safe projection, not this operator route directly.
@@ -1293,6 +1295,8 @@ const intentionallyUndocumentedApiRoutes: ReadonlyArray<string> = [
   '/api/operator/adjutant/assignments/{param}/current-run/clear',
   '/api/operator/adjutant/assignments/{param}/enrichment',
   '/api/operator/adjutant/assignments/{param}/enrichment/briefs/{param}/review',
+  '/api/public/inference/privacy-receipts/:receiptRef',
+  '/api/public/inference/privacy-receipts/{param}',
   '/api/operator/adjutant/assignments/{param}/enrichment/enqueue',
   '/api/operator/adjutant/assignments/{param}/enrichment/plan',
   '/api/operator/adjutant/assignments/{param}/enrichment/refresh',

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -12,6 +12,7 @@ import {
 } from './agent-search'
 import { CustomerOneCohortEndpoint } from './customer-one-cohort-projection'
 import { DemandProvenanceEndpoint } from './demand-provenance'
+import { EnergyFlexibleLoadProofEndpoint } from './energy-flexible-load-proof'
 import { ForumPostBodyTextMaxLength } from './forum-limits'
 import { OmniApiSdkSeedEndpoint } from './omni-api-sdk-seed'
 import {
@@ -818,6 +819,92 @@ export const TrainingMarathonOperationsEnvelope: JsonSchema = {
     staleness: { type: 'object' },
     status: { type: 'string' },
     unsafeCopy: { type: 'string' },
+  },
+}
+
+export const EnergyFlexibleLoadProofProjectionSchema: JsonSchema = {
+  type: 'object',
+  additionalProperties: true,
+  description:
+    'Public-safe flexible-load proof projection for energy.flexible_load_proof.v1. It decodes ERCOT public price fixture rows, exposes read-only work-class flexibility profiles, and projects labeled flexible-load event history while keeping greenGateSatisfied=false until real flexible-load receipts and owner-signed transition evidence exist. It grants no grid dispatch, capacity assignment, runner launch, wallet spend, payout, settlement, or public promise-state authority.',
+  required: [
+    'authorityBoundary',
+    'eventHistory',
+    'gate',
+    'generatedAt',
+    'marketPrices',
+    'promiseId',
+    'schemaVersion',
+    'sourceRefs',
+    'staleness',
+    'status',
+    'workClassFlexProfiles',
+  ],
+  properties: {
+    authorityBoundary: { type: 'string' },
+    eventHistory: {
+      type: 'object',
+      additionalProperties: true,
+      required: ['evidenceStateLabels', 'events', 'projectedEventCount'],
+      properties: {
+        evidenceStateLabels: { type: 'array', items: { type: 'string' } },
+        events: { type: 'array', items: { type: 'object' } },
+        projectedEventCount: { type: 'integer' },
+      },
+    },
+    gate: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'blockerRefs',
+        'greenGateSatisfied',
+        'marketPriceIngestionAvailable',
+        'modeledOperatorReportAvailable',
+        'ownerSignedTransitionReceiptAvailable',
+        'realFlexibleLoadReceiptAvailable',
+        'workClassFlexProfilesAvailable',
+      ],
+      properties: {
+        blockerRefs: { type: 'array', items: { type: 'string' } },
+        greenGateSatisfied: { type: 'boolean' },
+        marketPriceIngestionAvailable: { type: 'boolean' },
+        modeledOperatorReportAvailable: { type: 'boolean' },
+        ownerSignedTransitionReceiptAvailable: { type: 'boolean' },
+        realFlexibleLoadReceiptAvailable: { type: 'boolean' },
+        workClassFlexProfilesAvailable: { type: 'boolean' },
+      },
+    },
+    generatedAt: { type: 'string' },
+    marketPrices: {
+      type: 'object',
+      additionalProperties: true,
+      required: ['decodedRowCount', 'source', 'windows'],
+      properties: {
+        decodedRowCount: { type: 'integer' },
+        source: { type: 'string', enum: ['ercot_public_api_v2_fixture'] },
+        windows: { type: 'array', items: { type: 'object' } },
+      },
+    },
+    promiseId: {
+      type: 'string',
+      enum: ['energy.flexible_load_proof.v1'],
+    },
+    schemaVersion: { type: 'string' },
+    sourceRefs: { type: 'array', items: { type: 'string' } },
+    staleness: { type: 'object' },
+    status: {
+      type: 'string',
+      enum: ['evidence_scaffolded_receipt_gated'],
+    },
+    workClassFlexProfiles: {
+      type: 'object',
+      additionalProperties: true,
+      required: ['profiles', 'projectedProfileCount'],
+      properties: {
+        profiles: { type: 'array', items: { type: 'object' } },
+        projectedProfileCount: { type: 'integer' },
+      },
+    },
   },
 }
 
@@ -1677,6 +1764,7 @@ const schemaComponents = (): JsonSchema => ({
   AcceptedOutcomesPerKwhProjection: objectSummary(
     'Public-safe Accepted Outcomes per Kilowatt-Hour projection. Includes generatedAt, the declared staleness contract, the frozen metric definition ref, receipt-backed accepted-outcome counter, modeled/measured energy evidence labels, a typed internal/external demand-provenance split (proof.demand_provenance.v1, rule no_external_dollar_no_demand_claim, with externalDemandClaimAllowed gating market-demand claims), gate state, blocker refs, caveats, and published datapoints. Modeled seed datapoints are clearly labeled and do not grant payout, settlement, dispatch, energy-market, investment, or grid-operation authority, and internal demand is never presented as external market demand.',
   ),
+  EnergyFlexibleLoadProofProjection: EnergyFlexibleLoadProofProjectionSchema,
   VerifiedOutcomeReputationProjection: objectSummary(
     'Public-safe verified-outcome reputation projection. Includes generatedAt, the declared live_at_read staleness contract, TraceRank/EigenTrust algorithm metadata, graph counts, ignored edge refs, score rows, and copy gates. Only replay-verified outcomes with public-safe Bitcoin settlement receipts affect scores; self-reported feedback, unpaid no-spend work, unverified reviews, and missing-receipt edges are ignored. The seed projection is read-only and grants no dispatch, marketplace ranking, assignment, payout, settlement, moderation, identity, ERC-8004 publication, or spend authority.',
   ),
@@ -4959,6 +5047,23 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Accepted Outcomes per kWh metric.',
           '#/components/schemas/AcceptedOutcomesPerKwhProjection',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  [EnergyFlexibleLoadProofEndpoint]: {
+    get: operation({
+      operationId: 'getEnergyFlexibleLoadProof',
+      summary: 'Read flexible-load proof projection',
+      description:
+        'Returns the public-safe flexible-load proof projection for energy.flexible_load_proof.v1. The current response includes fixture-backed ERCOT market price rows, read-only work-class flexibility profiles, and labeled flexible-load event history while keeping greenGateSatisfied=false until real flexible-load receipts and owner-signed transition evidence exist. Read-only; grants no grid dispatch, capacity assignment, runner launch, wallet spend, payout, settlement, or public promise-state authority.',
+      tags: ['Public Proof'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Flexible-load proof projection.',
+          '#/components/schemas/EnergyFlexibleLoadProofProjection',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -493,6 +493,21 @@ describe('public product promises document', () => {
         expect.objectContaining({
           promiseId: 'energy.flexible_load_proof.v1',
           state: 'planned',
+          evidenceRefs: expect.arrayContaining([
+            'route:/api/public/energy/flexible-load-proof',
+            'apps/openagents.com/workers/api/src/ercot-lmp-ingestion.ts',
+            'apps/openagents.com/workers/api/src/pylon-flexible-load-profiles.ts',
+            'apps/openagents.com/workers/api/src/pylon-flexible-load-events.ts',
+            'apps/openagents.com/workers/api/src/energy-flexible-load-proof.ts',
+          ]),
+          blockerRefs: [
+            'blocker.product_promises.real_flexible_load_receipt_missing',
+            'blocker.product_promises.owner_signed_energy_green_transition_missing',
+          ],
+          safeCopy: expect.stringContaining(
+            '/api/public/energy/flexible-load-proof',
+          ),
+          verification: expect.stringContaining('greenGateSatisfied=false'),
         }),
         expect.objectContaining({
           promiseId: 'training.full_pipeline_program.v1',

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1879,7 +1879,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'OpenAgents should compare accepted outcomes, mining, grid service, AI-load smoothing, forward-purchased power capture, curtailment, reserve, and idle states with evidence labels.',
         safeCopy:
-          'Flexible-load economics are planned/modeling work and must be labeled as modeled until measured operator proof exists. A MODELED operator proof report now exists (docs/metrics/2026-06-19-flexible-load-operator-proof-report-modeled.md): it compares accepted outcomes, AI inference, mining, grid service, AI-load smoothing, forward-purchased power capture, curtailment, reserve, and idle states with per-row evidence labels, in dollars-per-MWh, derived from the studied oa_aibtc_model + ERCOT references and the single receipt-backed accepted-outcome datapoint (#4777). Everything except that one datapoint is explicitly MODELED, not measured operator telemetry. Still missing for green: live energy-market ingestion, work-class flex profiles from real telemetry, and a real flexible-load event history (the planned training-marathon curtailment drill receipt).',
+          'Flexible-load economics remain planned/receipt-gated and must be labeled as modeled until measured operator proof exists. GET /api/public/energy/flexible-load-proof now exposes the public evidence scaffold: fixture-backed ERCOT public price rows decoded into a typed time-series, read-only work-class flex profiles, and a labeled flexible-load event-history projection. The MODELED operator proof report still compares accepted outcomes, AI inference, mining, grid service, AI-load smoothing, forward-purchased power capture, curtailment, reserve, and idle states with per-row evidence labels in dollars-per-MWh; everything except the single receipt-backed accepted-outcome datapoint (#4777) remains explicitly MODELED, not measured operator telemetry. Still missing for green: a real flexible-load receipt and an owner-signed promise transition.',
         unsafeCopy:
           'Do not claim grid-service revenue, AI-load smoothing revenue, avoided interconnection cost, or energy-market optimization without event proof and caveats. Do not present the MODELED operator proof report as measured operator results — every figure except the single accepted-outcome datapoint is a modeled estimate.',
         evidenceRefs: [
@@ -1888,19 +1888,26 @@ export const publicProductPromisesDocument = () => {
           'docs/training/2026-06-10-psion-full-pipeline-buildout-plan.md',
           'docs/metrics/2026-06-19-flexible-load-operator-proof-report-modeled.md',
           'docs/metrics/2026-06-15-accepted-outcomes-per-kwh.md',
+          'route:/api/public/energy/flexible-load-proof',
+          'apps/openagents.com/workers/api/src/ercot-lmp-ingestion.ts',
+          'apps/openagents.com/workers/api/src/ercot-lmp-ingestion.test.ts',
+          'apps/openagents.com/workers/api/src/pylon-flexible-load-profiles.ts',
+          'apps/openagents.com/workers/api/src/pylon-flexible-load-profiles.test.ts',
+          'apps/openagents.com/workers/api/src/pylon-flexible-load-events.ts',
+          'apps/openagents.com/workers/api/src/pylon-flexible-load-events.test.ts',
+          'apps/openagents.com/workers/api/src/energy-flexible-load-proof.ts',
+          'apps/openagents.com/workers/api/src/energy-flexible-load-proof.test.ts',
           'promise:metrics.accepted_outcomes_per_kwh.v1',
           'promise:training.marathon_operations.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.energy_market_ingestion_missing',
-          'blocker.product_promises.work_class_flex_profiles_missing',
-          'blocker.product_promises.flexible_load_event_history_missing',
-          'blocker.product_promises.operator_proof_report_missing',
+          'blocker.product_promises.real_flexible_load_receipt_missing',
+          'blocker.product_promises.owner_signed_energy_green_transition_missing',
         ],
         verification:
-          'Green requires an operator report with measured or explicitly modeled dollars per MWh, evidence-state labels, and public-safe caveats. A planned evidence path is the training marathon’s scheduled curtailment drill (training.marathon_operations.v1): shed part of the fleet on schedule, resume from sealed checkpoints, publish the receipt.',
+          'Dereference GET /api/public/energy/flexible-load-proof and confirm gate.greenGateSatisfied=false, marketPriceIngestionAvailable=true, workClassFlexProfilesAvailable=true, marketPrices.decodedRowCount=96, and eventHistory.evidenceStateLabels includes measured, verified, and settled labels. Green still requires a real flexible-load receipt plus an owner-signed promise transition.',
         authorityBoundary:
-          'Energy models are operational estimates, not investment, grid, utility, or financial advice.',
+          'Energy models and flexible-load projections are operational estimates, not investment, grid, utility, or financial advice. The public projection is read-only and grants no grid dispatch, capacity assignment, runner launch, wallet spend, payout, settlement, or public promise-state authority.',
       },
       {
         ...basePromiseFields,

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -26,6 +26,7 @@ const approvedExactRoutePaths = [
   '/api/public/product-promises/transitions',
   '/api/public/product-promises/audit',
   '/api/public/metrics/accepted-outcomes-per-kwh',
+  '/api/public/energy/flexible-load-proof',
   '/api/public/reputation/verified-outcomes',
   '/api/public/gym/run-progress',
   '/api/public/gym/leaderboard',


### PR DESCRIPTION
Addresses #6851.

### Changes
- Registers the public flexible-load proof evidence endpoint for `energy.flexible_load_proof.v1`.
- Adds OpenAPI schema and operation coverage for the projection, including market prices, work-class flex profiles, event history, staleness, gate, and authority boundary fields.
- Updates product-promise and route coverage so the scaffold remains receipt-gated rather than marked green.
- Expands tests for the public route, no-store JSON response, OpenAPI documentation, and exact-route registration.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).