### PR TITLE
fix(codex-supervisor): replenish immediately after lockout

### DIFF
--- a/clients/khala-cli/src/fleet-run.test.ts
+++ b/clients/khala-cli/src/fleet-run.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import {
   buildFleetRunPlan,
+  nextFleetSupervisorDelay,
   parseFleetIssueList,
   plannedReplenishmentRounds,
   runKhalaFleetSupervisor,
@@ -76,6 +77,24 @@ describe("fleet run planning", () => {
     const second = plannedReplenishmentRounds(plan, new Set(first.map(round => round.dedupeKey ?? "")))
     expect(second).toHaveLength(1)
     expect(second[0]?.dedupeKey).toBe("test-lint-typecheck-sweep")
+  })
+
+  test("keeps lockout recovery in the short supervisor cadence", () => {
+    const firstLockoutWait = nextFleetSupervisorDelay({
+      anyRefused: true,
+      lockout: true,
+      refusedBackoffMs: 15_000,
+    })
+    expect(firstLockoutWait.delayMs).toBe(2_000)
+    expect(firstLockoutWait.refusedBackoffMs).toBe(15_000)
+
+    const partialRefusalWait = nextFleetSupervisorDelay({
+      anyRefused: true,
+      lockout: false,
+      refusedBackoffMs: 15_000,
+    })
+    expect(partialRefusalWait.delayMs).toBe(15_000)
+    expect(partialRefusalWait.refusedBackoffMs).toBe(30_000)
   })
 })
 

--- a/clients/khala-cli/src/fleet-run.ts
+++ b/clients/khala-cli/src/fleet-run.ts
@@ -65,7 +65,7 @@ const DEFAULT_MAX_SLOTS = 8
 const SUPERVISOR_IDLE_MS = 2_000
 const REFUSED_BACKOFF_MS = 15_000
 const MAX_REFUSED_BACKOFF_MS = 120_000
-const LOCKOUT_REPLENISH_AFTER_ROUNDS = 2
+const LOCKOUT_REPLENISH_AFTER_ROUNDS = 1
 
 type FleetRunSlot = Omit<KhalaFleetRunRound, "ok" | "status" | "assignmentRef">
 
@@ -243,6 +243,23 @@ export function plannedReplenishmentRounds(
   }))
 }
 
+export function nextFleetSupervisorDelay(input: {
+  readonly anyRefused: boolean
+  readonly lockout: boolean
+  readonly refusedBackoffMs: number
+}): { readonly delayMs: number; readonly refusedBackoffMs: number } {
+  if (input.lockout) {
+    return { delayMs: SUPERVISOR_IDLE_MS, refusedBackoffMs: REFUSED_BACKOFF_MS }
+  }
+  if (input.anyRefused) {
+    return {
+      delayMs: input.refusedBackoffMs,
+      refusedBackoffMs: Math.min(input.refusedBackoffMs * 2, MAX_REFUSED_BACKOFF_MS),
+    }
+  }
+  return { delayMs: SUPERVISOR_IDLE_MS, refusedBackoffMs: REFUSED_BACKOFF_MS }
+}
+
 async function runSupervisorLoop(input: {
   readonly env: Record<string, string | undefined>
   readonly plan: KhalaFleetRunPlan
@@ -278,14 +295,17 @@ async function runSupervisorLoop(input: {
         await delay(SUPERVISOR_IDLE_MS)
         continue
       }
-    }
-    if (round.some(item => item.status === "refused")) {
-      await delay(refusedBackoffMs)
-      refusedBackoffMs = Math.min(refusedBackoffMs * 2, MAX_REFUSED_BACKOFF_MS)
-    } else {
       refusedBackoffMs = REFUSED_BACKOFF_MS
       await delay(SUPERVISOR_IDLE_MS)
+      continue
     }
+    const wait = nextFleetSupervisorDelay({
+      anyRefused: round.some(item => item.status === "refused"),
+      lockout,
+      refusedBackoffMs,
+    })
+    refusedBackoffMs = wait.refusedBackoffMs
+    await delay(wait.delayMs)
   }
 }
 


### PR DESCRIPTION
Addresses #6822.

### Changes
- Replenishes fleet supervisor work after the first lockout round instead of waiting for two rounds.
- Adds `nextFleetSupervisorDelay` so lockout recovery stays on the short supervisor cadence while non-lockout refusals keep exponential backoff behavior.
- Adds test coverage for lockout delay handling and partial refusal backoff.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).