### PR TITLE
fix(stats): clarify Khala model mix contract

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/model.ts
@@ -1123,6 +1123,7 @@ export const PublicKhalaTokensServedModelMix = S.Struct({
   window: S.String,
   totalTokens: S.Number,
   groups: S.Array(PublicKhalaTokensServedModelMixFamily),
+  liveAt: S.optionalKey(S.String),
   generatedAt: S.String,
   staleness: S.optionalKey(S.Unknown),
 })

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/home.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/home.ts
@@ -1718,16 +1718,16 @@ export const khalaTokensServedModelMixPanel = (
             historyChartShell(
               true,
               modelMixPlaceholder('No model-family rows yet.'),
-              `Canonical model-family mix for ${mix.window}, all demand included.`,
+              `Canonical model-family mix for ${mix.window}; headline served volume includes external, internal, unlabeled, and Pylon-Codex own-capacity rows, but is not revenue or external-demand proof.`,
               'Model Family Mix',
             ),
           onNonEmpty: groups =>
             historyChartShell(
               true,
               modelMixRows(groups),
-              `Canonical model-family mix for ${mix.window}, all demand included. Total ${formatNumber(
+              `Canonical model-family mix for ${mix.window}. Total ${formatNumber(
                 mix.totalTokens,
-              )} tokens served.`,
+              )} headline tokens served across external, internal, unlabeled, and Pylon-Codex own-capacity rows; not revenue or external-demand proof.`,
               'Model Family Mix',
             ),
         }),

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/khalaTokensServed.story.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/khalaTokensServed.story.test.ts
@@ -84,6 +84,7 @@ const statsInputWithModelMix = () => ({
       schemaVersion: 'openagents.public_khala_model_mix.v1',
       window: '30d',
       totalTokens: 1_250_000,
+      liveAt: '2026-06-24T12:00:00.000Z',
       generatedAt: '2026-06-24T12:00:00.000Z',
       groups: [
         {
@@ -324,7 +325,9 @@ describe('Khala Tokens Served history chart (#6227)', () => {
     expect(markup).toContain('Model Family Mix')
     expect(markup).toContain('GLM family')
     expect(markup).toContain('Pylon-Codex')
-    expect(markup).toContain('all demand included')
+    expect(markup).toContain('headline tokens served')
+    expect(markup).toContain('external, internal, unlabeled')
+    expect(markup).toContain('not revenue or external-demand proof')
     expect(markup).not.toContain('gpt-')
     expect(markup).not.toContain('provider')
     expect(markup).not.toContain('accountRef')

--- a/apps/openagents.com/docs/stats/2026-06-26-stats-page-audit.md
+++ b/apps/openagents.com/docs/stats/2026-06-26-stats-page-audit.md
@@ -51,6 +51,7 @@ uses the `EOD est.` label, not counted as observed tokens.
 {
   "schemaVersion": "openagents.public_khala_model_mix.v1",
   "window": "30d",
+  "liveAt": "2026-06-26T00:00:00.000Z",
   "generatedAt": "2026-06-26T00:00:00.000Z",
   "totalTokens": 0,
   "groups": [
@@ -63,14 +64,27 @@ uses the `EOD est.` label, not counted as observed tokens.
     }
   ],
   "staleness": {
-    "mode": "live_at_read"
+    "composition": "live_at_read",
+    "contractVersion": "projection_staleness.v1",
+    "maxStalenessSeconds": 0,
+    "rebuildsOn": ["token_usage_events"]
   }
 }
 ```
 
 Supported windows are `today`, `7d`, `30d`, and `all`; the default is `30d`.
 
-The projection is live-at-read over `token_usage_events`, aggregates input plus output tokens, and includes all real demand kinds (`internal`, `internal_stress`, `own_capacity`, `external`, and unlabeled). It remains public-safe by collapsing provider/model identifiers before serving and exposing no per-user, per-team, demand label, prompt, raw provider/model, key, wallet, payment, settlement, or routing material.
+The projection is live-at-read over `token_usage_events`, so `liveAt` and
+`generatedAt` are the request-time read timestamp and the declared maximum
+staleness is `0` seconds. It aggregates input plus output tokens and includes
+all real demand kinds (`internal`, `internal_stress`, `own_capacity`,
+`external`, and unlabeled), including Pylon-Codex own-capacity rows. That
+headline served volume is not an external-demand, revenue, paid resale, or
+marketplace-health claim. Those claims require separate demand provenance and
+receipt evidence. The model-mix payload remains public-safe by collapsing
+provider/model identifiers before serving and exposing no per-user, per-team,
+demand label, prompt, raw provider/model, key, wallet, payment, settlement, or
+routing material.
 
 ## 5c Canonical Model Grouping
 

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -1512,6 +1512,34 @@ describe('public product promises document', () => {
     )
   })
 
+  test('keeps Khala model-family mix yellow with explicit staleness and demand caveats', () => {
+    const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
+      publicProductPromisesDocument(),
+    )
+    const modelMixPromise = decoded.promises.find(
+      promise => promise.promiseId === 'metrics.khala_model_family_mix_public.v1',
+    )
+
+    expect(modelMixPromise?.state).toBe('yellow')
+    expect(modelMixPromise?.safeCopy).toContain('liveAt/generatedAt')
+    expect(modelMixPromise?.safeCopy).toContain('maxStalenessSeconds:0')
+    expect(modelMixPromise?.safeCopy).toContain('stable public model-family')
+    expect(modelMixPromise?.safeCopy).toContain('Pylon-Codex own-capacity')
+    expect(modelMixPromise?.unsafeCopy).toContain(
+      'external customer demand, revenue',
+    )
+    expect(modelMixPromise?.evidenceRefs).toContain(
+      'route:/api/public/khala-tokens-served/model-mix',
+    )
+    expect(modelMixPromise?.blockerRefs).toEqual([
+      'blocker.product_promises.model_mix_green_owner_signoff_pending',
+    ])
+    expect(modelMixPromise?.verification).toContain('issue #6858')
+    expect(modelMixPromise?.verification).toContain(
+      'Green still requires a live receipt/owner sign-off',
+    )
+  })
+
   test('keeps kernel optimization planned while exposing code-backed dispatch and parity receipt machinery', () => {
     const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
       publicProductPromisesDocument(),

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1372,20 +1372,20 @@ export const publicProductPromisesDocument = () => {
         claim:
           'The Khala stats surface shows model-family/provider mix and daily token volume.',
         safeCopy:
-          'The /stats direction includes public model-family/provider mix and daily token-volume views for Khala, including Pylon-Codex owner-capacity volume where exact token rows exist. Treat this as a yellow transparency surface: it is useful for reading the mix of served work, but it must preserve staleness, model-family normalization, and internal/external/unlabeled demand caveats.',
+          'The /stats surface includes public model-family/provider mix and daily token-volume views for Khala. The model-mix route is live-at-read over token_usage_events (liveAt/generatedAt, projection_staleness.v1, maxStalenessSeconds:0), uses stable public model-family normalization, and includes headline served volume across external, internal, internal-stress, unlabeled, and Pylon-Codex own-capacity token rows. Treat this as a yellow transparency surface until live receipt/sign-off evidence authorizes stronger public copy.',
         unsafeCopy:
           'Do not use model-mix percentages as proof of external customer demand, revenue, model preference, paid provider resale, or marketplace health. Do not hide internal dogfood or own-capacity provenance when making demand claims.',
         evidenceRefs: [
+          'route:/api/public/khala-tokens-served/model-mix',
           'docs/stats/2026-06-26-stats-page-audit.md',
           'docs/inference/2026-06-25-khala-inference-gtm-push.md',
           'docs/transcripts/244.md',
         ],
         blockerRefs: [
-          'blocker.product_promises.model_mix_staleness_methodology_pending',
-          'blocker.product_promises.model_mix_demand_segmentation_copy_pending',
+          'blocker.product_promises.model_mix_green_owner_signoff_pending',
         ],
         verification:
-          'Yellow until the public /stats model-mix route/page has a documented staleness contract, stable model-family normalization, and copy that distinguishes headline served volume from external demand and revenue.',
+          'Yellow after issue #6858: route/test evidence now covers liveAt/generatedAt live_at_read staleness, stable public model-family normalization, and /stats copy separating headline served volume from external demand and revenue. Green still requires a live receipt/owner sign-off under proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'Model-mix transparency is not routing authority, provider resale authority, benchmark proof, revenue proof, or public raw-event disclosure.',
       },

--- a/apps/openagents.com/workers/api/src/public-khala-tokens-served-model-mix-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/public-khala-tokens-served-model-mix-routes.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest'
 import { handlePublicKhalaTokensServedModelMixApi } from './public-khala-tokens-served-model-mix-routes'
 import {
   makeD1TokenUsageLedger,
+  publicModelFamilyFromProviderAndModel,
   type TokenUsageLedgerRuntime,
   type TokenUsageLedgerShape,
 } from './token-usage-ledger'
@@ -83,9 +84,12 @@ describe('GET /api/public/khala-tokens-served/model-mix', () => {
     expect(body.window).toBe('30d')
     expect(body.totalTokens).toBe(2_000)
     expect(body.generatedAt).toBe(nowIso)
+    expect(body.liveAt).toBe(nowIso)
     expect(body.staleness).toMatchObject({
       composition: 'live_at_read',
+      contractVersion: 'projection_staleness.v1',
       maxStalenessSeconds: 0,
+      rebuildsOn: ['token_usage_events'],
     })
     expect(body.groups).toEqual([
       {
@@ -192,6 +196,7 @@ describe('GET /api/public/khala-tokens-served/model-mix', () => {
     expect(Object.keys(body).sort()).toEqual([
       'generatedAt',
       'groups',
+      'liveAt',
       'schemaVersion',
       'staleness',
       'totalTokens',
@@ -209,5 +214,36 @@ describe('GET /api/public/khala-tokens-served/model-mix', () => {
     ])
     expect(JSON.stringify(body)).not.toContain('gpt-4.1-secret-experiment')
     expect(JSON.stringify(body)).not.toContain('openai-private-lane')
+  })
+
+  test('normalizes provider and model variants into stable public families', () => {
+    expect(publicModelFamilyFromProviderAndModel('reap', 'glm-4.5')).toBe('glm')
+    expect(publicModelFamilyFromProviderAndModel('Z.AI', 'zhipu-chat')).toBe(
+      'glm',
+    )
+    expect(
+      publicModelFamilyFromProviderAndModel('fireworks-ai', 'deepseek-v3'),
+    ).toBe('fireworks_deepseek')
+    expect(
+      publicModelFamilyFromProviderAndModel(
+        'pylon-codex-own-capacity',
+        'openagents/pylon-codex',
+      ),
+    ).toBe('pylon_codex')
+    expect(
+      publicModelFamilyFromProviderAndModel(
+        'pylon_claude_own_capacity',
+        'openagents/pylon-claude',
+      ),
+    ).toBe('pylon_claude')
+    expect(publicModelFamilyFromProviderAndModel('openrouter', 'gpt_oss_120b')).toBe(
+      'gpt_oss',
+    )
+    expect(publicModelFamilyFromProviderAndModel('google_vertex', 'gemini-pro')).toBe(
+      'gemini',
+    )
+    expect(publicModelFamilyFromProviderAndModel('private-provider', 'x')).toBe(
+      'other',
+    )
   })
 })

--- a/apps/openagents.com/workers/api/src/public-khala-tokens-served-model-mix-routes.ts
+++ b/apps/openagents.com/workers/api/src/public-khala-tokens-served-model-mix-routes.ts
@@ -26,6 +26,7 @@ export const PublicKhalaTokensServedModelMixGroup = S.Struct({
 export const PublicKhalaTokensServedModelMixResponse = S.Struct({
   schemaVersion: S.Literal('openagents.public_khala_model_mix.v1'),
   window: PublicKhalaTokensServedHistoryWindow,
+  liveAt: S.String,
   totalTokens: S.Int,
   groups: S.Array(PublicKhalaTokensServedModelMixGroup),
   generatedAt: S.String,
@@ -56,9 +57,11 @@ export const handlePublicKhalaTokensServedModelMixApi = (
 
   return ledger.readPublicTokensServedModelMix({ window }).pipe(
     Effect.map(mix => {
+      const readAt = nowIso()
       const payload: PublicKhalaTokensServedModelMixResponse = {
         schemaVersion: 'openagents.public_khala_model_mix.v1',
         window: mix.window,
+        liveAt: readAt,
         totalTokens: mix.totalTokens,
         groups: mix.groups.map(group => ({
           family: group.family,
@@ -67,7 +70,7 @@ export const handlePublicKhalaTokensServedModelMixApi = (
           reqs: group.reqs,
           pct: group.pct,
         })),
-        generatedAt: nowIso(),
+        generatedAt: readAt,
         staleness: liveAtReadStaleness(['token_usage_events']),
       }
 

--- a/apps/openagents.com/workers/api/src/token-usage-ledger.ts
+++ b/apps/openagents.com/workers/api/src/token-usage-ledger.ts
@@ -1340,11 +1340,21 @@ const normalizeHistoryTimezone = (
   })
 }
 
-const publicModelFamilyFromProviderAndModel = (
+const normalizedModelIdentityText = (
+  provider: string | null | undefined,
+  model: string | null | undefined,
+): string =>
+  `${provider ?? ''} ${model ?? ''}`
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9/._:-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+
+export const publicModelFamilyFromProviderAndModel = (
   provider: string | null | undefined,
   model: string | null | undefined,
 ): PublicKhalaTokensServedModelFamily => {
-  const text = `${provider ?? ''} ${model ?? ''}`.trim().toLowerCase()
+  const text = normalizedModelIdentityText(provider, model)
 
   if (
     text.includes('glm') ||
@@ -1397,7 +1407,7 @@ const publicModelFamilyFromProviderAndModel = (
   return 'other'
 }
 
-const publicModelFamilyLabel = (
+export const publicModelFamilyLabel = (
   family: PublicKhalaTokensServedModelFamily,
 ): string =>
   family === 'glm'


### PR DESCRIPTION
Addresses #6858.

### Changes
- Added `liveAt` to the public Khala model-family mix contract and documented the live-at-read staleness contract with `maxStalenessSeconds:0`.
- Updated `/stats` model-family mix copy to clarify headline served tokens include external, internal, unlabeled, and Pylon-Codex own-capacity rows, and are not revenue or external-demand proof.
- Strengthened model-family normalization and public-safety coverage with route, story, ledger, and product-promise tests.
- Updated the stats audit and product promise entry to keep the promise yellow pending owner receipt/sign-off evidence.

### Verification
`bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`

Result: passed (exit 0)