### PR TITLE
fix(codex-supervisor): reduce idle after dispatch refusals

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
@@ -15,6 +15,7 @@
 : "${SUP_BACKOFF_MIN:=15}"
 : "${SUP_CODEX_REFUSAL_TUNE_THRESHOLD:=3}"
 : "${SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS:=1}"
+: "${SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD:=2}"
 
 sup_backoff_policy_dir() {
   local d="${SUP_BACKOFF_POLICY_DIR:-$SUP_STATE_DIR/backoff-policy}"
@@ -136,4 +137,13 @@ sup_claimed_pick_backoff_secs() {
     return 0
   fi
   printf '%s' "$current_backoff"
+}
+
+sup_should_escalate_failure_backoff() {
+  local sig="$1"
+  local repeated="$2"
+  if [ "$sig" = "codex_agent_execution_refused" ]; then
+    return 1
+  fi
+  [ "$repeated" -ge "$SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD" ] 2>/dev/null
 }

--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
@@ -20,6 +20,7 @@ export SUP_PER_ACCOUNT=3
 export SUP_MAX_SLOTS=8
 export SUP_CODEX_REFUSAL_TUNE_THRESHOLD=3
 export SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS=1
+export SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD=2
 mkdir -p "$SUP_STATE_DIR" "$SUP_BACKOFF_POLICY_DIR"
 
 # shellcheck source=backoff-policy.sh
@@ -100,6 +101,24 @@ if [ "$(sup_claimed_pick_backoff_secs 4 4 15)" = "15" ]; then
   ok "shallow/equal backlog keeps normal backoff"
 else
   bad "shallow backlog should keep normal backoff"
+fi
+
+if sup_should_escalate_failure_backoff refused 1; then
+  bad "first genuine refusal should not escalate backoff"
+else
+  ok "first genuine refusal does not escalate backoff"
+fi
+
+if sup_should_escalate_failure_backoff refused 2; then
+  ok "repeated genuine refusal escalates backoff"
+else
+  bad "repeated genuine refusal should escalate backoff"
+fi
+
+if sup_should_escalate_failure_backoff codex_agent_execution_refused 9; then
+  bad "executor refusal should not escalate general backoff"
+else
+  ok "executor refusal never escalates general backoff"
 fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -292,6 +292,8 @@ worker_loop() {
   local slot="$1"
   local backoff="$SUP_BACKOFF_MIN"
   local iter=0
+  local last_failure_sig=""
+  local failure_repeat=0
   while true; do
     if [ -f "$PAUSE_FILE" ]; then sleep 30; continue; fi
     local desired; desired=$(cat "$DESIRED_FILE" 2>/dev/null || echo 0)
@@ -434,6 +436,8 @@ worker_loop() {
 
     if grep -qiE '"ok": ?true|"closeout"|accepted' "$out" 2>/dev/null && [ "$rc" -eq 0 ]; then
       backoff="$SUP_BACKOFF_MIN"
+      last_failure_sig=""
+      failure_repeat=0
       sup_reset_account_refusals "$acc"
       # Keep the issue claimed (refresh TTL) so no other slot re-picks it while
       # its PR/lockout state settles; the open-PR lockout then takes over and the
@@ -447,6 +451,12 @@ worker_loop() {
     # pool settles at the login's real headroom.
     local sig="other"
     sig="$(sup_dispatch_failure_signature "$out")"
+    if [ "$sig" = "$last_failure_sig" ]; then
+      failure_repeat=$(( failure_repeat + 1 ))
+    else
+      last_failure_sig="$sig"
+      failure_repeat=1
+    fi
     if [ "$sig" = "refused" ]; then
       # The gate already has an active assignment for this issue (it is busy
       # elsewhere). PARK it for the full claim TTL so the fleet stops hammering
@@ -466,8 +476,10 @@ worker_loop() {
     if [ "$sig" = "codex_agent_execution_refused" ]; then
       failure_sleep="$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
       escalate_backoff=0
+    elif ! sup_should_escalate_failure_backoff "$sig" "$failure_repeat"; then
+      escalate_backoff=0
     fi
-    log "slot=$slot acc=$acc issue=#$issue NO-DISPATCH ($sig rc=$rc); backoff ${failure_sleep}s"
+    log "slot=$slot acc=$acc issue=#$issue NO-DISPATCH ($sig rc=$rc repeated=$failure_repeat); backoff ${failure_sleep}s"
     sleep "$failure_sleep"
     if [ "$escalate_backoff" -eq 1 ]; then
       backoff=$(( backoff * 2 )); [ "$backoff" -gt "$SUP_BACKOFF_MAX" ] && backoff="$SUP_BACKOFF_MAX"


### PR DESCRIPTION
Addresses #6900.

### Changes
- Added a supervisor backoff policy helper that only escalates general failure backoff after repeated matching failures.
- Kept `codex_agent_execution_refused` on the short deep-backlog sleep path instead of escalating general backoff.
- Reset repeated failure tracking after successful assignment closeout and included repeat counts in no-dispatch logs.
- Added shell tests for repeated refusal escalation and executor-refusal backoff behavior.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).