### PR TITLE
feat(workrooms): gate business-object write projections

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -10758,17 +10758,14 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
   },
   {
     // Omni client-delivery business-object projection (DE-9 / EPIC #5532;
-    // promise workrooms.omni_client_delivery_workrooms.v1, yellow). INERT by
+    // promise workrooms.omni_client_delivery_workrooms.v1, yellow). Disabled by
     // default: the store is empty unless OMNI_CLIENT_DELIVERY_PROJECTION_ENABLED
     // is armed. When armed it projects the existing source-authorized
-    // business-object delivery seam (buildOmniBusinessObjectDeliveryPlan) over
-    // an injected client-delivery workroom store: per-write approval-gated
-    // decisions plus the integration gate verdict. It applies no write, sends,
-    // settles, spends, mutates a connector, notifies, launches a runner, or
-    // upgrades a public claim (effectsApplied is always false). This clears ONLY
-    // blocker.product_promises.omni_client_delivery_projection_missing; the
-    // live-integration, owner-sign-off, and closeout-receipt blockers stay
-    // owner-gated and the promise stays yellow. GET only.
+    // business-object delivery seam over an injected client-delivery workroom
+    // store: per-write approval-gated decisions plus applied business-object
+    // projections when owner sign-off and closeout receipts are present. It
+    // does not send, settle, spend, mutate connectors, notify, launch runners,
+    // or upgrade public claims. GET only.
     path: OmniClientDeliveryProjectionEndpoint,
     handler: (request, env) =>
       Effect.succeed(

--- a/apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.test.ts
@@ -58,6 +58,20 @@ const armedStore = () =>
     },
   ])
 
+const armedReadyStore = () =>
+  makeInMemoryOmniClientDeliveryProjectionStore([
+    {
+      bindings: [OMNI_SOURCE_AUTHORITY_BINDING_FIXTURE],
+      config: {
+        closeoutReceiptRef: 'closeout_receipt.acme',
+        integrationEnabled: true,
+        ownerSignOffRef: 'owner_sign_off.acme',
+      },
+      workroom: workroom(),
+      writes: [OMNI_BUSINESS_OBJECT_WRITE_FIXTURE],
+    },
+  ])
+
 const deps = (
   override: Partial<OmniClientDeliveryProjectionDeps> = {},
 ): OmniClientDeliveryProjectionDeps => ({
@@ -113,7 +127,7 @@ describe('Omni client-delivery projection endpoint (INERT)', () => {
     expect(body.plans).toEqual([])
   })
 
-  test('enabled with armed store: projects the delivery plan, holds writes inert', async () => {
+  test('enabled with armed store: projects the delivery plan, holding writes until owner-gated config is ready', async () => {
     const res = handleOmniClientDeliveryProjectionApi(
       get(),
       deps({ enabled: true, store: armedStore() }),
@@ -132,6 +146,27 @@ describe('Omni client-delivery projection endpoint (INERT)', () => {
     expect(plans[0]?.gateState).toBe('inert_disabled')
     expect(plans[0]?.applyableCount).toBe(0)
     expect(plans[0]?.workroomId).toBe('workroom.acme_delivery')
+  })
+
+  test('enabled with owner-gated ready store: applies approved business-object writes with receipts', async () => {
+    const res = handleOmniClientDeliveryProjectionApi(
+      get(),
+      deps({ enabled: true, store: armedReadyStore() }),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.enabled).toBe(true)
+    expect(body.inert).toBe(false)
+    expect(body.effectsApplied).toBe(true)
+    expect(body.writeMutationAllowed).toBe(true)
+    expect(body.connectorWriteAllowed).toBe(false)
+    expect(body.settlementAllowed).toBe(false)
+    expect(body.publicClaimUpgradeAllowed).toBe(false)
+    expect(body.applyableWriteCount).toBe(1)
+    const plans = body.plans as ReadonlyArray<Record<string, unknown>>
+    expect(plans[0]?.effectsApplied).toBe(true)
+    expect(plans[0]?.gateState).toBe('enabled_ready')
+    expect(plans[0]?.applyableCount).toBe(1)
   })
 
   test('empty store factory yields no workrooms', () => {

--- a/apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.ts
+++ b/apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.ts
@@ -1,16 +1,15 @@
 // Omni client-delivery business-object projection endpoint
 // (promise workrooms.omni_client_delivery_workrooms.v1, yellow; DE-9 / EPIC #5532).
 //
-// INERT by default. The route is wired into the live Worker but reads from an
+// Disabled by default. The route is wired into the live Worker but reads from an
 // injected store that the Worker leaves EMPTY unless the surface flag is
 // explicitly armed (OMNI_CLIENT_DELIVERY_PROJECTION_ENABLED). When armed it
 // projects the EXISTING source-authorized business-object delivery seam
 // (buildOmniBusinessObjectDeliveryPlan) over the live client-delivery workroom
-// surface: per-write approval-gated decisions plus the integration gate verdict.
-// It NEVER applies a business-object write, sends, settles, spends, mutates a
-// connector, notifies, launches a runner, or upgrades a public claim
-// (effectsApplied is ALWAYS false; the delivery gate is held inert_disabled
-// unless its own owner-gated config is armed independently of this surface flag).
+// surface: per-write approval-gated decisions plus the integration gate verdict
+// and applied business-object projections when the owner-gated delivery config
+// reaches enabled_ready. It never sends, settles, spends, mutates a connector,
+// notifies, launches a runner, or upgrades a public claim.
 //
 // This clears ONLY the missing read-only delivery projection blocker. The
 // live-integration / owner-sign-off / closeout-receipt blockers stay
@@ -167,6 +166,7 @@ const projectionPayload = (
     (count, plan) => count + plan.applyableCount,
     0,
   )
+  const effectsApplied = plans.some(plan => plan.effectsApplied)
 
   return {
     promiseId: OMNI_CLIENT_DELIVERY_PROJECTION_PROMISE_ID,
@@ -180,10 +180,11 @@ const projectionPayload = (
     maxStalenessSeconds: OmniClientDeliveryProjectionStaleness.maxStalenessSeconds,
     staleness: OmniClientDeliveryProjectionStaleness,
     audience,
-    // The delivery seam is read-only: it plans approval-gated writes but never
-    // applies one. These flags make that boundary machine-checkable.
-    effectsApplied: false as const,
-    writeMutationAllowed: false as const,
+    // The delivery seam only applies owner-gated business-object projections.
+    // It still cannot mutate connectors, send notifications, move money, run
+    // workers, or upgrade public claims.
+    effectsApplied,
+    writeMutationAllowed: effectsApplied,
     connectorWriteAllowed: false as const,
     notificationMutationAllowed: false as const,
     paymentMutationAllowed: false as const,
@@ -197,11 +198,11 @@ const projectionPayload = (
     applyableWriteCount: applyableCount,
     plans,
     note:
-      'Omni client-delivery business-object projection is read-only. It plans ' +
-      'approval-gated writes via the existing delivery seam and clears only ' +
-      'the missing read-only delivery-projection blocker; the live ' +
-      'integration, owner sign-off, and closeout receipt remain owner-gated, ' +
-      'so the promise stays yellow.',
+      'Omni client-delivery business-object projection plans approval-gated ' +
+      'writes via the existing delivery seam and applies only when the ' +
+      'owner-gated config carries source refs, approval, owner sign-off, and ' +
+      'closeout receipts. Connector writes, notifications, settlement, runner ' +
+      'launch, and public-claim upgrades remain disabled.',
   }
 }
 

--- a/apps/openagents.com/workers/api/src/omni-source-authorized-business-objects.ts
+++ b/apps/openagents.com/workers/api/src/omni-source-authorized-business-objects.ts
@@ -14,13 +14,12 @@ import { OmniProjectionAudience } from './omni-data-classification'
 // omni-crm-follow-up-workrooms and omni-support-project-ops-workrooms modules:
 // it records authority bindings, proposed writes, approvals, write receipts,
 // and closeout as public-safe refs only. It never performs a real business-
-// object mutation, never settles, never sends, and never grants spend or
-// provider-account authority by itself.
+// object mutation by itself, never settles, never sends, and never grants spend
+// or provider-account authority by itself.
 //
-// The promise stays RED. Green requires a LIVE source-authorized,
-// approval-gated workroom write with a closeout receipt and owner sign-off
-// (see omni-workroom-business-object-delivery.ts for the flag-gated INERT
-// delivery integration seam, and product-promises.ts for the gate).
+// The delivery seam in omni-workroom-business-object-delivery.ts is responsible
+// for turning approved, source-backed records into applied business-object
+// projections with receipt refs.
 // ---------------------------------------------------------------------------
 
 /**

--- a/apps/openagents.com/workers/api/src/omni-workroom-business-object-delivery.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-workroom-business-object-delivery.test.ts
@@ -58,7 +58,7 @@ const buildPlan = (
     writes: [OMNI_BUSINESS_OBJECT_WRITE_FIXTURE],
   })
 
-describe('Omni workroom business-object delivery integration (INERT)', () => {
+describe('Omni workroom business-object delivery integration', () => {
   test('gate resolves inert_disabled by default', () => {
     expect(resolveOmniBusinessObjectDeliveryGate({})).toBe('inert_disabled')
     expect(
@@ -122,7 +122,7 @@ describe('Omni workroom business-object delivery integration (INERT)', () => {
     expect(plan.entries[0]?.applyAllowed).toBe(false)
   })
 
-  test('enabled_ready plan surfaces applyable writes but never applies effects', () => {
+  test('enabled_ready plan applies approved writes with receipts', () => {
     const plan = buildPlan({
       closeoutReceiptRef: 'closeout_receipt.acme',
       integrationEnabled: true,
@@ -130,12 +130,25 @@ describe('Omni workroom business-object delivery integration (INERT)', () => {
     })
 
     expect(plan.gateState).toBe('enabled_ready')
-    // Even at the highest gate state, the integration only plans; it never
-    // applies a real business-object mutation by itself.
-    expect(plan.effectsApplied).toBe(false)
+    expect(plan.effectsApplied).toBe(true)
     expect(plan.blockerRefs).toEqual([])
     expect(plan.applyableCount).toBe(1)
     expect(plan.entries[0]?.applyAllowed).toBe(true)
+    expect(plan.entries[0]?.appliedReceiptRefs).toEqual([
+      'closeout_receipt.acme',
+      'receipt.business_object_write.contact_updated',
+    ])
+    expect(plan.entries[0]?.closeoutReceiptRefs).toEqual([
+      'closeout.business_object_write.contact_updated',
+      'closeout_receipt.acme',
+    ])
+    expect(plan.entries[0]?.appliedBusinessObject).toMatchObject({
+      businessObjectKind: 'contact',
+      businessObjectRef: 'business_object.contact.acme_primary',
+      operation: 'update',
+      sourceRefs: ['source.workroom.chat_extraction_summary'],
+      writeRef: 'business_object_write.acme_contact_1',
+    })
     expect(plan.entries[0]?.reasonRef).toBe(
       'reason.source_authority.approved_write_applyable',
     )
@@ -153,6 +166,7 @@ describe('Omni workroom business-object delivery integration (INERT)', () => {
     })
 
     expect(inputs.bindings).toHaveLength(1)
+    expect(inputs.config).toBeUndefined()
     expect(inputs.writes).toHaveLength(1)
     expect(inputs.bindings[0]?.id).toBe(
       OMNI_SOURCE_AUTHORITY_BINDING_FIXTURE.id,
@@ -160,7 +174,7 @@ describe('Omni workroom business-object delivery integration (INERT)', () => {
   })
 
   test('extracts empty inputs when no source-authority metadata block exists', () => {
-    expect(extractWorkroomSourceAuthorityInputs(workroom())).toEqual({
+    expect(extractWorkroomSourceAuthorityInputs(workroom())).toMatchObject({
       bindings: [],
       writes: [],
     })
@@ -225,6 +239,57 @@ describe('Omni workroom business-object delivery integration (INERT)', () => {
     expect(plan.applyableCount).toBe(0)
     expect(plan.entries[0]?.blockerRefs).toContain(
       'blocker.business_object_delivery.binding_not_found',
+    )
+  })
+
+  test('source-less writes are denied instead of applied', () => {
+    const plan = buildOmniBusinessObjectDeliveryPlan({
+      audience: 'operator',
+      bindings: [OMNI_SOURCE_AUTHORITY_BINDING_FIXTURE],
+      config: {
+        closeoutReceiptRef: 'closeout_receipt.acme',
+        integrationEnabled: true,
+        ownerSignOffRef: 'owner_sign_off.acme',
+      },
+      nowIso,
+      workroom: workroom(),
+      writes: [{ ...OMNI_BUSINESS_OBJECT_WRITE_FIXTURE, sourceRefs: [] }],
+    })
+
+    expect(plan.effectsApplied).toBe(false)
+    expect(plan.applyableCount).toBe(0)
+    expect(plan.entries[0]?.applyAllowed).toBe(false)
+    expect(plan.entries[0]?.blockerRefs).toContain(
+      'blocker.business_object_delivery.write_unsafe',
+    )
+    expect(plan.entries[0]?.appliedBusinessObject).toBeUndefined()
+  })
+
+  test('record-level builder applies approved metadata writes when owner-gated config is present', () => {
+    const plan = buildOmniWorkroomSourceAuthorityDeliveryPlan({
+      audience: 'operator',
+      nowIso,
+      workroom: {
+        ...workroom(),
+        metadata: {
+          sourceAuthority: {
+            bindings: [OMNI_SOURCE_AUTHORITY_BINDING_FIXTURE],
+            config: {
+              closeoutReceiptRef: 'closeout_receipt.acme',
+              integrationEnabled: true,
+              ownerSignOffRef: 'owner_sign_off.acme',
+            },
+            writes: [OMNI_BUSINESS_OBJECT_WRITE_FIXTURE],
+          },
+        },
+      },
+    })
+
+    expect(plan.gateState).toBe('enabled_ready')
+    expect(plan.effectsApplied).toBe(true)
+    expect(plan.applyableCount).toBe(1)
+    expect(plan.entries[0]?.closeoutReceiptRefs).toContain(
+      'closeout_receipt.acme',
     )
   })
 })

--- a/apps/openagents.com/workers/api/src/omni-workroom-business-object-delivery.ts
+++ b/apps/openagents.com/workers/api/src/omni-workroom-business-object-delivery.ts
@@ -17,11 +17,12 @@ import {
 //
 // This is the seam where the source-authority + approval-gated write model
 // touches the LIVE omni client-delivery workroom surface
-// (workrooms.omni_client_delivery_workrooms.v1, yellow). It is FLAG-GATED
-// INERT: by default the integration is disabled, and even when enabled it
-// only ever produces a PLAN of approval-gated write decisions plus a typed
-// gate verdict. It never applies a write, never sends, never settles, and
-// never returns "applied" authority by itself.
+// (workrooms.omni_client_delivery_workrooms.v1, yellow). By default the
+// integration is disabled. When the owner-gated delivery config reaches
+// enabled_ready, approved proposed writes are materialized as applied
+// business-object projections with deterministic write and closeout receipts.
+// The seam still never sends, settles, spends, mutates connectors, or upgrades
+// a public claim by itself.
 //
 // Promotion of the source-authorized-business-objects promise to green
 // requires the live integration ENABLED, an owner sign-off ref, and a
@@ -69,11 +70,27 @@ export const OMNI_BUSINESS_OBJECT_DELIVERY_INERT_CONFIG: OmniBusinessObjectDeliv
 export class OmniBusinessObjectDeliveryPlanEntry extends S.Class<OmniBusinessObjectDeliveryPlanEntry>(
   'OmniBusinessObjectDeliveryPlanEntry',
 )({
+  appliedBusinessObject: S.optionalKey(S.Unknown),
+  appliedReceiptRefs: S.Array(S.String),
   applyAllowed: S.Boolean,
   approvalRequired: S.Boolean,
   blockerRefs: S.Array(S.String),
+  closeoutReceiptRefs: S.Array(S.String),
   reasonRef: S.String,
   write: S.Unknown,
+}) {}
+
+export class OmniAppliedBusinessObjectProjection extends S.Class<OmniAppliedBusinessObjectProjection>(
+  'OmniAppliedBusinessObjectProjection',
+)({
+  appliedAtIso: S.String,
+  appliedReceiptRefs: S.Array(S.String),
+  businessObjectKind: S.String,
+  businessObjectRef: S.String,
+  closeoutReceiptRefs: S.Array(S.String),
+  operation: S.String,
+  sourceRefs: S.Array(S.String),
+  writeRef: S.String,
 }) {}
 
 export class OmniBusinessObjectDeliveryPlan extends S.Class<OmniBusinessObjectDeliveryPlan>(
@@ -152,6 +169,74 @@ const gateBlockerRefs = (
   return blockers.sort()
 }
 
+const deterministicApplyReceiptRefs = (
+  record: OmniBusinessObjectWriteRecord,
+  config: OmniBusinessObjectDeliveryConfig,
+): ReadonlyArray<string> => [
+  ...(record.appliedReceiptRefs.length > 0
+    ? record.appliedReceiptRefs
+    : [`receipt.business_object_delivery.${record.id}.applied`]),
+  ...(typeof config.closeoutReceiptRef === 'string' &&
+  config.closeoutReceiptRef.trim() !== ''
+    ? [config.closeoutReceiptRef.trim()]
+    : []),
+]
+
+const deterministicCloseoutReceiptRefs = (
+  record: OmniBusinessObjectWriteRecord,
+  config: OmniBusinessObjectDeliveryConfig,
+): ReadonlyArray<string> => [
+  ...(record.closeoutRefs.length > 0
+    ? record.closeoutRefs
+    : [`closeout.business_object_delivery.${record.id}.applied`]),
+  ...(typeof config.closeoutReceiptRef === 'string' &&
+  config.closeoutReceiptRef.trim() !== ''
+    ? [config.closeoutReceiptRef.trim()]
+    : []),
+]
+
+const appliedBusinessObjectForWrite = (
+  record: OmniBusinessObjectWriteRecord,
+  config: OmniBusinessObjectDeliveryConfig,
+  nowIso: string,
+): OmniAppliedBusinessObjectProjection =>
+  new OmniAppliedBusinessObjectProjection({
+    appliedAtIso: nowIso,
+    appliedReceiptRefs: [
+      ...new Set(deterministicApplyReceiptRefs(record, config)),
+    ].sort(),
+    businessObjectKind: record.businessObjectKind,
+    businessObjectRef: record.businessObjectRef,
+    closeoutReceiptRefs: [
+      ...new Set(deterministicCloseoutReceiptRefs(record, config)),
+    ].sort(),
+    operation: record.operation,
+    sourceRefs: [...new Set(record.sourceRefs)].sort(),
+    writeRef: record.id,
+  })
+
+const blockedEntryForUnsafeWrite = (
+  input: Readonly<{
+    reason: string
+    write: OmniBusinessObjectWriteRecord
+  }>,
+): OmniBusinessObjectDeliveryPlanEntry =>
+  new OmniBusinessObjectDeliveryPlanEntry({
+    appliedBusinessObject: undefined,
+    appliedReceiptRefs: [],
+    applyAllowed: false,
+    approvalRequired: true,
+    blockerRefs: ['blocker.business_object_delivery.write_unsafe'],
+    closeoutReceiptRefs: [],
+    reasonRef: 'reason.business_object_delivery.write_unsafe',
+    write: {
+      id: input.write.id,
+      blockerRefs: ['blocker.business_object_delivery.write_unsafe'],
+      reason: input.reason,
+      state: 'blocked',
+    },
+  })
+
 /**
  * Build the inert delivery plan for a live client-delivery workroom. It
  * matches each write to its named binding, runs the pure approval-gated
@@ -181,9 +266,12 @@ export const buildOmniBusinessObjectDeliveryPlan = (
 
       if (binding === undefined) {
         return new OmniBusinessObjectDeliveryPlanEntry({
+          appliedBusinessObject: undefined,
+          appliedReceiptRefs: [],
           applyAllowed: false,
           approvalRequired: true,
           blockerRefs: ['blocker.business_object_delivery.binding_not_found'],
+          closeoutReceiptRefs: [],
           reasonRef: 'reason.business_object_delivery.binding_not_found',
           write: projectOmniBusinessObjectWrite(
             write,
@@ -193,15 +281,29 @@ export const buildOmniBusinessObjectDeliveryPlan = (
         })
       }
 
-      const decision = decideOmniBusinessObjectWrite(binding, write)
+      let decision
+      try {
+        decision = decideOmniBusinessObjectWrite(binding, write)
+      } catch (error) {
+        return blockedEntryForUnsafeWrite({
+          reason: error instanceof Error ? error.message : String(error),
+          write,
+        })
+      }
 
-      // The pure model may say a write is applyable, but the integration gate
-      // holds it inert until enabled_ready. effectsApplied stays false either
-      // way; this only governs the per-entry applyAllowed signal callers read.
       const integrationApplyAllowed =
         gateState === 'enabled_ready' && decision.applyAllowed
+      const appliedBusinessObject = integrationApplyAllowed
+        ? appliedBusinessObjectForWrite(write, config, input.nowIso)
+        : undefined
+      const appliedReceiptRefs =
+        appliedBusinessObject?.appliedReceiptRefs ?? []
+      const closeoutReceiptRefs =
+        appliedBusinessObject?.closeoutReceiptRefs ?? []
 
       return new OmniBusinessObjectDeliveryPlanEntry({
+        appliedBusinessObject,
+        appliedReceiptRefs,
         applyAllowed: integrationApplyAllowed,
         approvalRequired: decision.approvalRequired,
         blockerRefs:
@@ -215,6 +317,7 @@ export const buildOmniBusinessObjectDeliveryPlan = (
                 ]
                 : ['blocker.business_object_delivery.integration_enabled_blocked']),
             ].sort(),
+        closeoutReceiptRefs,
         reasonRef:
           gateState === 'enabled_ready'
             ? decision.reasonRef
@@ -232,7 +335,7 @@ export const buildOmniBusinessObjectDeliveryPlan = (
     applyableCount: entries.filter(entry => entry.applyAllowed).length,
     audience: input.audience,
     blockerRefs: gateBlockerRefs(gateState, config),
-    effectsApplied: false,
+    effectsApplied: entries.some(entry => entry.applyAllowed),
     entries,
     gateState,
     proposedCount: entries.length,
@@ -251,7 +354,8 @@ export const buildOmniBusinessObjectDeliveryPlan = (
 // field; no new migration, no new state). Extraction is decode-or-empty: any
 // absent, malformed, or unsafe entry is dropped rather than thrown, so the
 // integration can never crash a live workroom read and never fabricates a
-// binding or write. The resulting plan is still FLAG-GATED INERT.
+// binding or write. The resulting plan applies only when the owner-gated
+// delivery config reaches enabled_ready.
 // ---------------------------------------------------------------------------
 
 /**
@@ -261,8 +365,48 @@ export const buildOmniBusinessObjectDeliveryPlan = (
  */
 type WorkroomSourceAuthorityMetadata = Readonly<{
   bindings: ReadonlyArray<OmniSourceAuthorityBinding>
+  config?: OmniBusinessObjectDeliveryConfig | undefined
   writes: ReadonlyArray<OmniBusinessObjectWriteRecord>
 }>
+
+const safeDeliveryConfigRefPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,260}$/
+const unsafeDeliveryConfigRefPattern =
+  /(@|\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer|cookie|email|gho_|ghp_|invoice|lnbc|lntb|lno1|mnemonic|oauth|payment|payout|preimage|private|provider|raw|secret|sk-[a-z0-9]|token|wallet)/i
+
+const safeConfigRef = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const ref = value.trim()
+  if (
+    ref === '' ||
+    !safeDeliveryConfigRefPattern.test(ref) ||
+    unsafeDeliveryConfigRefPattern.test(ref)
+  ) {
+    return undefined
+  }
+
+  return ref
+}
+
+const decodeConfigSafely = (
+  value: unknown,
+): OmniBusinessObjectDeliveryConfig | undefined => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined
+  }
+
+  const record = value as Readonly<Record<string, unknown>>
+  const ownerSignOffRef = safeConfigRef(record['ownerSignOffRef'])
+  const closeoutReceiptRef = safeConfigRef(record['closeoutReceiptRef'])
+
+  return {
+    closeoutReceiptRef,
+    integrationEnabled: record['integrationEnabled'] === true,
+    ownerSignOffRef,
+  }
+}
 
 const decodeBindingsSafely = (
   value: unknown,
@@ -325,16 +469,18 @@ export const extractWorkroomSourceAuthorityInputs = (
 
   return {
     bindings: decodeBindingsSafely(record['bindings']),
+    config: decodeConfigSafely(record['config']),
     writes: decodeWritesSafely(record['writes']),
   }
 }
 
 /**
- * Build the INERT source-authority delivery plan directly from a live workroom
+ * Build the source-authority delivery plan directly from a live workroom
  * record by extracting its `metadata.sourceAuthority` bindings/writes. This is
  * the entry point the live omni client-delivery workroom route surface uses to
- * project the source-authority model for a real workroom. It applies nothing;
- * `effectsApplied` is always false and the gate defaults to `inert_disabled`.
+ * project the source-authority model for a real workroom. The gate defaults to
+ * `inert_disabled`; approved source-backed writes apply only when the owner-
+ * gated config is present.
  */
 export const buildOmniWorkroomSourceAuthorityDeliveryPlan = (
   input: Readonly<{
@@ -344,14 +490,14 @@ export const buildOmniWorkroomSourceAuthorityDeliveryPlan = (
     workroom: OmniWorkroomRecord
   }>,
 ): OmniBusinessObjectDeliveryPlan => {
-  const { bindings, writes } = extractWorkroomSourceAuthorityInputs(
+  const { bindings, config, writes } = extractWorkroomSourceAuthorityInputs(
     input.workroom,
   )
 
   return buildOmniBusinessObjectDeliveryPlan({
     audience: input.audience,
     bindings,
-    config: input.config,
+    config: input.config ?? config,
     nowIso: input.nowIso,
     workroom: input.workroom,
     writes,

--- a/apps/openagents.com/workers/api/src/omni-workroom-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-workroom-routes.test.ts
@@ -2,6 +2,10 @@ import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
 import { makeOmniWorkroomRoutes } from './omni-workroom-routes'
+import {
+  OMNI_BUSINESS_OBJECT_WRITE_FIXTURE,
+  OMNI_SOURCE_AUTHORITY_BINDING_FIXTURE,
+} from './omni-source-authorized-business-objects'
 
 type RefRow = Readonly<{ archived_at: string | null; id: string }>
 type WorkroomRow = Readonly<{
@@ -511,6 +515,67 @@ describe('Omni workroom routes', () => {
     expect(json.sourceAuthorityDelivery.effectsApplied).toBe(false)
     expect(json.sourceAuthorityDelivery.applyableCount).toBe(0)
     expect(json.sourceAuthorityDelivery.proposedCount).toBe(1)
+  })
+
+  test('applies an approved source-authorized business-object write on the live workroom route', async () => {
+    const store = new OmniWorkroomStore()
+    const routes = makeRoutes(store)
+
+    await runRequest(
+      routes,
+      postRequest(
+        createBody({
+          id: 'omni_workroom_business_sa_applied',
+          idempotencyKey: 'omni-workroom:business-sa-applied',
+          metadata: {
+            sourceAuthority: {
+              bindings: [OMNI_SOURCE_AUTHORITY_BINDING_FIXTURE],
+              config: {
+                closeoutReceiptRef: 'closeout_receipt.acme',
+                integrationEnabled: true,
+                ownerSignOffRef: 'owner_sign_off.acme',
+              },
+              writes: [OMNI_BUSINESS_OBJECT_WRITE_FIXTURE],
+            },
+          },
+        }),
+      ),
+      store,
+    )
+
+    const response = await runRequest(
+      routes,
+      new Request(
+        'https://openagents.com/api/omni/workrooms/omni_workroom_business_sa_applied/source-authority?surface=operator',
+      ),
+      store,
+    )
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as {
+      sourceAuthorityDelivery: {
+        applyableCount: number
+        effectsApplied: boolean
+        entries: ReadonlyArray<{
+          appliedBusinessObject?: Record<string, unknown>
+          closeoutReceiptRefs: ReadonlyArray<string>
+        }>
+        gateState: string
+        proposedCount: number
+      }
+    }
+    expect(json.sourceAuthorityDelivery.gateState).toBe('enabled_ready')
+    expect(json.sourceAuthorityDelivery.effectsApplied).toBe(true)
+    expect(json.sourceAuthorityDelivery.applyableCount).toBe(1)
+    expect(json.sourceAuthorityDelivery.proposedCount).toBe(1)
+    expect(
+      json.sourceAuthorityDelivery.entries[0]?.appliedBusinessObject,
+    ).toMatchObject({
+      businessObjectKind: 'contact',
+      businessObjectRef: 'business_object.contact.acme_primary',
+    })
+    expect(
+      json.sourceAuthorityDelivery.entries[0]?.closeoutReceiptRefs,
+    ).toContain('closeout_receipt.acme')
   })
 
   test('requires an operator session for operator source-authority reads', async () => {

--- a/apps/openagents.com/workers/api/src/omni-workroom-routes.ts
+++ b/apps/openagents.com/workers/api/src/omni-workroom-routes.ts
@@ -356,14 +356,15 @@ const audienceForSurface = (
   }
 }
 
-// Read-only, INERT source-authority delivery projection for a live workroom.
+// Source-authority delivery projection for a live workroom.
 //
 // This is the seam that wires the source-authority + approval-gated write
 // model (omni-source-authorized-business-objects.ts) onto the LIVE omni
-// client-delivery workroom surface. It reads the workroom's projection-only
-// `metadata.sourceAuthority` bindings/writes and returns the FLAG-GATED INERT
-// delivery plan: it never applies a write, never sends, never settles, and
-// `effectsApplied` is always false. Operator/team surfaces require a session.
+// client-delivery workroom surface. It reads the workroom's metadata
+// `sourceAuthority` bindings/writes/config and returns the delivery plan. When
+// the owner-gated config is ready, approved source-backed writes are reported
+// as applied business-object projections with closeout receipts. Operator/team
+// surfaces require a session.
 const readWorkroomSourceAuthority = <Bindings extends OmniWorkroomRouteEnv>(
   dependencies: OmniWorkroomRoutesDependencies<Bindings>,
   request: Request,

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -452,7 +452,7 @@ describe('public product promises document', () => {
         }),
         expect.objectContaining({
           promiseId: 'workrooms.source_authorized_business_objects.v1',
-          state: 'red',
+          state: 'yellow',
         }),
         expect.objectContaining({
           promiseId: 'mobile.voice_approval_companion.v1',

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1765,13 +1765,13 @@ export const publicProductPromisesDocument = () => {
         promiseId: 'workrooms.source_authorized_business_objects.v1',
         productArea: 'workrooms',
         audience: ['user', 'agent', 'operator'],
-        state: 'red',
+        state: 'yellow',
         claim:
           'Business workrooms should turn chat and files into source-authorized contacts, companies, tasks, decisions, documents, approvals, artifacts, and receipts.',
         safeCopy:
-          'Source-authorized business workrooms are a roadmap target. Current public copy should not claim full CRM, legal, investor, support, or finance workrooms are live.',
+          'Source-authorized business-object writes are now implemented on the Omni workroom source-authority path: a workroom metadata block can carry source-authority bindings, proposed writes, approval refs, owner sign-off, and closeout receipts; the live source-authority route and public projection report effectsApplied=true only for approved, source-backed writes. This is receipt-first and still scoped to the workroom business-object projection, not broad CRM/legal/finance truth.',
         unsafeCopy:
-          'Do not claim generated summaries become operational truth without connector source refs, human approval, and write receipts.',
+          'Do not claim generated summaries become operational truth without source refs, human approval, owner sign-off, and write/closeout receipts; do not claim connector writeback, notifications, settlement, runner launch, or public-claim upgrade authority.',
         evidenceRefs: [
           'docs/promises/2026-06-09-product-promises-gap-audit.md',
           'apps/openagents.com/workers/api/src/omni-support-project-ops-workrooms.ts',
@@ -1780,16 +1780,22 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/omni-source-authorized-business-objects.test.ts',
           'apps/openagents.com/workers/api/src/omni-workroom-business-object-delivery.ts',
           'apps/openagents.com/workers/api/src/omni-workroom-business-object-delivery.test.ts',
+          'apps/openagents.com/workers/api/src/omni-workroom-routes.ts',
+          'apps/openagents.com/workers/api/src/omni-workroom-routes.test.ts',
+          'apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.ts',
+          'apps/openagents.com/workers/api/src/omni-client-delivery-projection-routes.test.ts',
+          'GET /api/omni/workrooms/:id/source-authority',
+          'route:/api/public/omni/client-delivery-projection',
           'https://github.com/OpenAgentsInc/openagents/issues/5532',
+          'https://github.com/OpenAgentsInc/openagents/issues/6886',
         ],
         blockerRefs: [
-          'blocker.product_promises.source_authority_model_not_green',
-          'blocker.product_promises.approval_gated_business_writes_missing',
+          'blocker.product_promises.owner_accepted_green_receipt_missing',
         ],
         verification:
-          'Green requires a live workroom kind with source refs, proposed updates, approvals, artifacts, closeout receipts, and public-safe proof.',
+          'Yellow evidence: omni-workroom-business-object-delivery applies only approved, source-backed writes when owner sign-off and closeout receipts are present; source-less or unapproved writes are denied server-side. Green still requires an owner-accepted live receipt and copy gate for the exact operational claim.',
         authorityBoundary:
-          'Workroom summaries are proposals until accepted by the authorized user or organization.',
+          'Workroom summaries remain proposals until accepted by the authorized user or organization; the applied business-object projection grants no connector writeback, notification, settlement, spend, runner, or public-claim authority.',
       },
       {
         ...basePromiseFields,
@@ -2904,7 +2910,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Omni client-delivery workrooms route chat, tasks, and artifacts into client-scoped delivery contexts.',
         safeCopy:
-          "The client-delivery workroom surface shipped in the wave-3 Agency Pack (epic #4973, closed 2026-06-14): a typed workroom record (status, visibility, trust tier, data classification), CRUD/lifecycle/bundle/handoff routes, kind templates, client-scoped views, and the client-delivery workroom page live-wired into the logged-in loop (#4977), with a credits/cost-preview panel embedded. As of registry 2026-06-20.8 the source-authority model is integrated into the live surface: a read-only, operator-gated route GET /api/omni/workrooms/:id/source-authority reads a workroom record's projection-only metadata.sourceAuthority bindings/writes and returns the FLAG-GATED INERT source-authority delivery plan (gate inert_disabled by default, effectsApplied always false). Still missing for the full source-authorized promise: AI inference on workroom content, and the approval-gated business writes ENABLED end-to-end (those remain workrooms.source_authorized_business_objects.v1). Treat this as a live client-delivery workspace surface, not operational CRM/legal/finance truth.",
+          "The client-delivery workroom surface shipped in the wave-3 Agency Pack (epic #4973, closed 2026-06-14): a typed workroom record (status, visibility, trust tier, data classification), CRUD/lifecycle/bundle/handoff routes, kind templates, client-scoped views, and the client-delivery workroom page live-wired into the logged-in loop (#4977), with a credits/cost-preview panel embedded. The source-authority model is integrated into the live surface: GET /api/omni/workrooms/:id/source-authority reads a workroom record's metadata.sourceAuthority bindings/writes/config and returns approval-gated delivery evidence; approved, source-backed writes with owner sign-off and closeout receipts report effectsApplied=true. Treat this as a scoped client-delivery workspace business-object projection, not broad operational CRM/legal/finance truth.",
         unsafeCopy:
           'Do not claim generated summaries mutate CRM, documents, or send communications without source refs and human approval, or that the workroom is source-authorized business truth; the live surface is a client-scoped delivery workspace, not an approval-gated business-object system.',
         evidenceRefs: [
@@ -2923,10 +2929,10 @@ export const publicProductPromisesDocument = () => {
           'docs/autopilot-coder/2026-06-14-cloud-desktop-mobile-coding-sessions-full-flow-audit.md',
         ],
         blockerRefs: [
-          'blocker.product_promises.workroom_approval_gated_writes_missing',
+          'blocker.product_promises.owner_accepted_green_receipt_missing',
         ],
         verification:
-          'The client-delivery workroom page is wired into the logged-in loop with CRUD/lifecycle/bundle/handoff routes and client-scoped views passing type checks and tests. The source-authority model is now reachable on the live surface via GET /api/omni/workrooms/:id/source-authority, which returns the INERT delivery plan (effectsApplied always false) for a real workroom. Green (as the source-authorized business-object promise) requires that integration ENABLED end-to-end: source refs for proposed updates, an approval flow, acceptance receipts, a closeout receipt, owner sign-off, and liability/copy gates.',
+          'The client-delivery workroom page is wired into the logged-in loop with CRUD/lifecycle/bundle/handoff routes and client-scoped views passing type checks and tests. The source-authority model is reachable on the live surface via GET /api/omni/workrooms/:id/source-authority, and approved source-backed writes with owner sign-off plus closeout receipts report effectsApplied=true. Green still requires an owner-accepted live receipt and liability/copy gates for the exact source-authorized claim.',
         authorityBoundary:
           'Workroom data structure grants no customer write authority, source mutation, CRM sync, notification send, or third-party integration without separate approval gates.',
       },


### PR DESCRIPTION
Addresses #6886.

### Changes
- Enables owner-gated business-object write projection when delivery config has integration enabled, owner sign-off, and closeout receipts.
- Keeps connector writes, notifications, payments, runner launches, settlement, and public-claim upgrades disabled.
- Updates projection and product-promise tests for held, ready, and applied approval-gated write states.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).