### PR TITLE
fix(glm): admit own-capacity lane without reserved headroom

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.test.ts
@@ -7,6 +7,7 @@ import {
   makeHydraliskVllmAdapter,
   makeHydraliskVllmPoolAdapter,
   makeHydraliskVllmPoolRuntime,
+  readHydraliskPoolRouteAdmission,
 } from './hydralisk-adapter'
 import { HYDRALISK_ADAPTER_ID } from './model-router'
 import { HYDRALISK_GPT_OSS_20B_MODEL_ID } from './pricing'
@@ -335,8 +336,8 @@ describe('hydralisk vLLM adapter', () => {
     await startedFetchPromise
 
     expect(runtime.routeAdmission()).toEqual({
-      reason: 'glm_reserved_external_headroom_unavailable',
-      reservedExternalHeadroomAvailable: false,
+      reason: 'glm_reserved_external_headroom_available',
+      reservedExternalHeadroomAvailable: true,
     })
 
     releaseFetch?.()
@@ -348,7 +349,30 @@ describe('hydralisk vLLM adapter', () => {
     })
   })
 
-  it('does not count degraded replicas as reserved external route headroom', async () => {
+  it('rejects route admission only when eligible GLM headroom is exhausted', () => {
+    const config = {
+      id: GLM_POOL_ADAPTER_ID,
+      replicas: [
+        replicaFixture('primary', {
+          maxInflight: 1,
+        }),
+      ],
+      upstreamModel: 'openagents/glm-5.2-reap-504b',
+    }
+
+    expect(readHydraliskPoolRouteAdmission(config)).toEqual({
+      reason: 'glm_reserved_external_headroom_available',
+      reservedExternalHeadroomAvailable: true,
+    })
+    expect(
+      readHydraliskPoolRouteAdmission(config, new Map([['primary', 1]])),
+    ).toEqual({
+      reason: 'glm_aggregate_external_headroom_zero',
+      reservedExternalHeadroomAvailable: false,
+    })
+  })
+
+  it('does not count degraded replicas as external route headroom', async () => {
     let releaseFetch: (() => void) | undefined
     let startedFetch: (() => void) | undefined
     const startedFetchPromise = new Promise<void>(resolve => {
@@ -387,8 +411,8 @@ describe('hydralisk vLLM adapter', () => {
     await startedFetchPromise
 
     expect(runtime.routeAdmission()).toEqual({
-      reason: 'glm_reserved_external_headroom_unavailable',
-      reservedExternalHeadroomAvailable: false,
+      reason: 'glm_reserved_external_headroom_available',
+      reservedExternalHeadroomAvailable: true,
     })
 
     releaseFetch?.()

--- a/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.ts
@@ -128,7 +128,6 @@ export type HydraliskVllmPoolRuntime = Readonly<{
 
 const DEFAULT_GLM_ASYNC_QUEUE_WAIT_MS = 250
 const MAX_GLM_EDGE_QUEUE_WAIT_MS = 1_000
-const DEFAULT_RESERVED_EXTERNAL_HEADROOM_SLOTS = 1
 
 const requestUrl = (config: HydraliskAdapterConfig): string =>
   `${config.baseUrl.replace(/\/+$/u, '')}/v1/chat/completions`
@@ -965,15 +964,6 @@ const routeAdmissionForHeadroom = (
   if (headroom.aggregateExternalHeadroom <= 0) {
     return {
       reason: 'glm_aggregate_external_headroom_zero',
-      reservedExternalHeadroomAvailable: false,
-    }
-  }
-  if (
-    headroom.aggregateExternalHeadroom <=
-    DEFAULT_RESERVED_EXTERNAL_HEADROOM_SLOTS
-  ) {
-    return {
-      reason: 'glm_reserved_external_headroom_unavailable',
       reservedExternalHeadroomAvailable: false,
     }
   }


### PR DESCRIPTION
Addresses #6963.

### Changes
- Removed the reserved external headroom slot gate from GLM route admission so admission only rejects when aggregate eligible external headroom is exhausted.
- Updated Hydralisk adapter tests to cover the exhausted-headroom rejection case and the revised route admission behavior while requests are in flight.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).