### PR TITLE
feat(pylon): share node_modules across codex worktrees via lockfile-keyed cache (skip per-task bun install)

### DIFF
--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -1,6 +1,6 @@
-import { access, mkdir, readFile, writeFile } from "node:fs/promises"
-import { dirname, isAbsolute, join, resolve } from "node:path"
-import { createHash } from "node:crypto"
+import { access, lstat, mkdir, readFile, readlink, rename, rm, symlink, writeFile } from "node:fs/promises"
+import { dirname, isAbsolute, join, relative, resolve } from "node:path"
+import { createHash, randomUUID } from "node:crypto"
 import {
   CODEX_AGENT_SDK_PACKAGE,
   loadCodexAgentConfig,
@@ -385,11 +385,109 @@ async function dependencyInstallDirectories(input: {
   return [...new Set(dirs)]
 }
 
-async function prepareWorkspaceDependencies(input: {
+/**
+ * Shared node_modules cache across Codex worktrees (concurrency fix).
+ *
+ * A git worktree shares the bare object store but never shares
+ * `node_modules`, so N concurrent `codex_agent_task` assignments each ran a
+ * fresh `bun install` and thrashed disk/CPU, serializing fleet startup. The
+ * helpers below let the FIRST task install once and every subsequent task with
+ * a matching lockfile symlink the prebuilt `node_modules` in instantly.
+ *
+ * Correctness rule: reuse is keyed by the SHA-256 of the workspace `bun.lock`,
+ * so stale dependency trees are never shared. Any miss/mismatch falls back to a
+ * fresh `bun install`. Sharing is a read-only symlink; the one-time cache
+ * populate is guarded by an atomic mkdir lock so concurrent first-runs cannot
+ * corrupt the shared entry.
+ */
+async function workspaceLockfileHash(workspaceRoot: string): Promise<string | null> {
+  for (const name of ["bun.lock", "bun.lockb"]) {
+    try {
+      const bytes = await readFile(join(workspaceRoot, name))
+      return createHash("sha256").update(bytes).digest("hex").slice(0, 24)
+    } catch {
+      // Try the next candidate lockfile name.
+    }
+  }
+  return null
+}
+
+/**
+ * Filesystem-safe per-install-directory key. The workspace root and each
+ * hoisted/per-package install directory get a distinct cached `node_modules`.
+ */
+function sharedInstallDirectoryKey(workspaceRoot: string, directory: string): string {
+  const rel = relative(workspaceRoot, directory)
+  if (rel.length === 0) return "__root__"
+  return `dir-${createHash("sha256").update(rel).digest("hex").slice(0, 24)}`
+}
+
+/**
+ * Symlinks a shared, lockfile-matched `node_modules` into a worktree install
+ * directory. Clears a stale/broken symlink first but never clobbers a real
+ * directory. Returns true only when the worktree now points at the shared tree.
+ */
+async function linkSharedNodeModules(cacheEntryDir: string, targetNodeModules: string): Promise<boolean> {
+  try {
+    const existing = await lstat(targetNodeModules).catch(() => null)
+    if (existing !== null) {
+      if (!existing.isSymbolicLink()) return false
+      await rm(targetNodeModules, { force: true })
+    }
+    await symlink(cacheEntryDir, targetNodeModules, "dir")
+    return true
+  } catch {
+    return false
+  }
+}
+
+type SharedCachePopulation = "linked" | "exists" | "skipped"
+
+/**
+ * Moves a freshly installed `node_modules` into the shared cache and symlinks
+ * it back into the worktree, guarded by an atomic mkdir lock so concurrent
+ * first-runs cannot collide. Best-effort: any failure leaves the worktree's
+ * real `node_modules` untouched and returns "skipped".
+ */
+async function populateSharedNodeModules(input: {
+  cacheEntryDir: string
+  lockDir: string
+  sourceNodeModules: string
+  targetNodeModules: string
+}): Promise<SharedCachePopulation> {
+  try {
+    await mkdir(dirname(input.lockDir), { recursive: true })
+  } catch {
+    return "skipped"
+  }
+  try {
+    await mkdir(input.lockDir)
+  } catch {
+    // Another worktree is populating this exact lockfile/dir entry right now.
+    return "skipped"
+  }
+  try {
+    if (await pathExists(input.cacheEntryDir)) return "exists"
+    const tmp = `${input.cacheEntryDir}.tmp-${randomUUID()}`
+    await rm(tmp, { force: true, recursive: true })
+    await rename(input.sourceNodeModules, tmp)
+    await rename(tmp, input.cacheEntryDir)
+    await linkSharedNodeModules(input.cacheEntryDir, input.targetNodeModules)
+    return "linked"
+  } catch {
+    return "skipped"
+  } finally {
+    await rm(input.lockDir, { force: true, recursive: true }).catch(() => {})
+  }
+}
+
+export async function prepareWorkspaceDependencies(input: {
   installer?: LocalCommandRunner
+  sharedCacheRoot?: string
   verificationArgs: string[]
   workspace: string
 }): Promise<DependencyPreparation> {
+  const workspaceRoot = resolve(input.workspace)
   const hasPackageJson = await pathExists(join(input.workspace, "package.json"))
   const hasBunLock =
     (await pathExists(join(input.workspace, "bun.lock"))) ||
@@ -416,9 +514,36 @@ async function prepareWorkspaceDependencies(input: {
     }
   }
 
+  // Lockfile-keyed shared cache root: only reuse when bun.lock matches exactly.
+  const lockHash = await workspaceLockfileHash(workspaceRoot)
+  const sharedCacheRoot =
+    input.sharedCacheRoot !== undefined && lockHash !== null
+      ? join(input.sharedCacheRoot, lockHash)
+      : null
+
   const installer = input.installer ?? runCommand
   const installReceipts: string[] = []
+  let installedDirectoryCount = 0
   for (const directory of missingInstallDirectories) {
+    const sharedKey = sharedInstallDirectoryKey(workspaceRoot, directory)
+    const sharedEntryDir =
+      sharedCacheRoot === null ? null : join(sharedCacheRoot, sharedKey, "node_modules")
+    const targetNodeModules = join(directory, "node_modules")
+
+    // Cache hit: symlink the shared, lockfile-matched node_modules and skip install.
+    if (sharedEntryDir !== null && (await pathExists(sharedEntryDir))) {
+      if (await linkSharedNodeModules(sharedEntryDir, targetNodeModules)) {
+        installReceipts.push(
+          stableRef(
+            "dependency.pylon.codex_agent_task.node_modules_shared_reuse",
+            `${relative(workspaceRoot, directory) || "."}:${lockHash}`,
+          ),
+        )
+        continue
+      }
+    }
+
+    // Cache miss (or mismatch/missing cache): install into this worktree directory.
     const install = await installer({
       args: ["bun", "install", "--no-save", "--ignore-scripts"],
       cwd: directory,
@@ -431,6 +556,30 @@ async function prepareWorkspaceDependencies(input: {
     installReceipts.push(receiptRef)
     if (install.exitCode !== 0 || install.timedOut) {
       return { ok: false, receiptRef }
+    }
+    installedDirectoryCount += 1
+
+    // Populate the shared cache so the next concurrent/later task reuses it.
+    if (sharedCacheRoot !== null && sharedEntryDir !== null && (await pathExists(targetNodeModules))) {
+      await populateSharedNodeModules({
+        cacheEntryDir: sharedEntryDir,
+        lockDir: join(sharedCacheRoot, sharedKey, ".populate.lock"),
+        sourceNodeModules: targetNodeModules,
+        targetNodeModules,
+      })
+    }
+  }
+
+  // Only a real `bun install` can dirty tracked files (package.json/bun.lock);
+  // a pure symlink-reuse pass leaves the checkout pristine, so skip the restore.
+  if (installedDirectoryCount === 0) {
+    return {
+      ok: true,
+      prepared: true,
+      receiptRef: stableRef(
+        "dependency.pylon.codex_agent_task.node_modules_shared_reuse",
+        installReceipts.join(":"),
+      ),
     }
   }
   const restore = await installer({
@@ -1024,6 +1173,7 @@ export async function executeCodexAgentAssignment(
 
   const dependencies = await prepareWorkspaceDependencies({
     ...(options.dependencyInstaller === undefined ? {} : { installer: options.dependencyInstaller }),
+    sharedCacheRoot: join(state.paths.cache, "codex-agent-tasks-node-modules-shared"),
     verificationArgs: materialized.verificationArgs,
     workspace: materialized.workspace,
   })

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test"
 import { existsSync } from "node:fs"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { lstat, mkdir, mkdtemp, readdir, readFile, readlink, rm, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { tmpdir } from "node:os"
 import {
@@ -10,6 +10,7 @@ import {
   effectiveSandboxMode,
   executeCodexAgentAssignment,
   fileChangeEscapesWorkspace,
+  prepareWorkspaceDependencies,
   runWithCodexSdk,
   type CodexAgentRunner,
 } from "../src/codex-agent-executor"
@@ -992,5 +993,149 @@ describe("codex git_checkout workspace (shared B2 contract)", () => {
       assertPublicProjectionSafe(record)
       expect(JSON.stringify(record)).not.toContain(state.paths.cache)
     })
+  })
+})
+
+describe("shared node_modules cache across codex worktrees", () => {
+  // Each git worktree gets a fresh checkout but never shares node_modules, so the
+  // fleet used to run one full `bun install` per assignment and thrash concurrency.
+  // The cache lets the first task install once and later matching tasks symlink.
+  const LOCK_A = "lockfile-contents-A\n"
+  const LOCK_B = "lockfile-contents-B-different\n"
+
+  async function makeWorktree(root: string, lockContents: string): Promise<string> {
+    const dir = await mkdtemp(join(root, "worktree-"))
+    await writeFile(join(dir, "package.json"), `${JSON.stringify({ private: true, type: "module" })}\n`)
+    await writeFile(join(dir, "bun.lock"), lockContents)
+    return dir
+  }
+
+  // A real installer that materializes a node_modules tree (a marker file) so the
+  // cache populate path has something to move, unlike the public-fixture mock.
+  function countingInstaller() {
+    const commands: string[] = []
+    const installer = async (input: { args: string[]; cwd: string }) => {
+      commands.push(input.args.join(" "))
+      if (input.args[0] === "bun" && input.args[1] === "install") {
+        await mkdir(join(input.cwd, "node_modules"), { recursive: true })
+        await writeFile(join(input.cwd, "node_modules", ".installed"), "ok\n")
+      }
+      return { exitCode: 0, stderrBytes: 0, stdoutBytes: 8, timedOut: false }
+    }
+    const installCount = () => commands.filter((c) => c.startsWith("bun install")).length
+    return { commands, installCount, installer }
+  }
+
+  test("(a) a matching shared cache skips bun install and symlinks node_modules in", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-nm-cache-a-"))
+    try {
+      const sharedCacheRoot = join(root, "shared")
+      const first = countingInstaller()
+      const wtA = await makeWorktree(root, LOCK_A)
+      const prepA = await prepareWorkspaceDependencies({
+        installer: first.installer,
+        sharedCacheRoot,
+        verificationArgs: ["bun", "test", "sum.test.ts"],
+        workspace: wtA,
+      })
+      expect(prepA.ok).toBe(true)
+      // First task installs once, then publishes the tree into the shared cache.
+      expect(first.installCount()).toBe(1)
+      const linkedA = await lstat(join(wtA, "node_modules"))
+      expect(linkedA.isSymbolicLink()).toBe(true)
+
+      // A second, independent worktree with the SAME lockfile must reuse the cache.
+      const second = countingInstaller()
+      const wtB = await makeWorktree(root, LOCK_A)
+      const prepB = await prepareWorkspaceDependencies({
+        installer: second.installer,
+        sharedCacheRoot,
+        verificationArgs: ["bun", "test", "sum.test.ts"],
+        workspace: wtB,
+      })
+      expect(prepB.ok).toBe(true)
+      // No install, and not even the post-install git restore should run.
+      expect(second.commands).toEqual([])
+      const linkedB = await lstat(join(wtB, "node_modules"))
+      expect(linkedB.isSymbolicLink()).toBe(true)
+      const targetB = await readlink(join(wtB, "node_modules"))
+      expect(existsSync(join(targetB, ".installed"))).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("(b) a lockfile-hash mismatch falls back to a fresh install", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-nm-cache-b-"))
+    try {
+      const sharedCacheRoot = join(root, "shared")
+      const first = countingInstaller()
+      const wtA = await makeWorktree(root, LOCK_A)
+      await prepareWorkspaceDependencies({
+        installer: first.installer,
+        sharedCacheRoot,
+        verificationArgs: ["bun", "test", "sum.test.ts"],
+        workspace: wtA,
+      })
+      expect(first.installCount()).toBe(1)
+
+      // Different bun.lock -> different hash -> the LOCK_A cache must not be reused.
+      const second = countingInstaller()
+      const wtB = await makeWorktree(root, LOCK_B)
+      await prepareWorkspaceDependencies({
+        installer: second.installer,
+        sharedCacheRoot,
+        verificationArgs: ["bun", "test", "sum.test.ts"],
+        workspace: wtB,
+      })
+      expect(second.installCount()).toBe(1)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("(c) concurrent materializations do not corrupt the shared cache", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-nm-cache-c-"))
+    try {
+      const sharedCacheRoot = join(root, "shared")
+      const worktrees = await Promise.all(
+        Array.from({ length: 6 }, () => makeWorktree(root, LOCK_A)),
+      )
+      const installers = worktrees.map(() => countingInstaller())
+      const results = await Promise.all(
+        worktrees.map((workspace, index) =>
+          prepareWorkspaceDependencies({
+            installer: installers[index].installer,
+            sharedCacheRoot,
+            verificationArgs: ["bun", "test", "sum.test.ts"],
+            workspace,
+          }),
+        ),
+      )
+
+      // Every materialization succeeded and ended with a usable node_modules.
+      for (const result of results) expect(result.ok).toBe(true)
+      for (const workspace of worktrees) {
+        const stat = await lstat(join(workspace, "node_modules"))
+        const dir = stat.isSymbolicLink()
+          ? await readlink(join(workspace, "node_modules"))
+          : join(workspace, "node_modules")
+        expect(existsSync(join(dir, ".installed"))).toBe(true)
+      }
+
+      // Exactly one valid, uncorrupted shared cache entry exists for this lockfile,
+      // with no leftover populate locks or half-written temp directories. Layout is
+      // <sharedCacheRoot>/<lockHash>/<install-dir-key>/node_modules.
+      const lockHashDirs = await readdir(sharedCacheRoot)
+      expect(lockHashDirs).toHaveLength(1)
+      const installKeyDirs = await readdir(join(sharedCacheRoot, lockHashDirs[0]))
+      expect(installKeyDirs).toHaveLength(1)
+      const keyDir = join(sharedCacheRoot, lockHashDirs[0], installKeyDirs[0])
+      const keyEntries = await readdir(keyDir)
+      expect(keyEntries).toEqual(["node_modules"])
+      expect(existsSync(join(keyDir, "node_modules", ".installed"))).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Problem

The `codex_agent_task` fleet caps at ~3-5 concurrent on one machine because each assignment's git worktree runs a fresh `bun install`. The git side is already efficient (shared bare object store + shallow fetch + worktrees in `apps/pylon/src/workspace-materializer.ts`), but a git worktree does **not** share `node_modules`. So `prepareWorkspaceDependencies` in `apps/pylon/src/codex-agent-executor.ts` sees no `node_modules` and runs `bun install --no-save --ignore-scripts` per worktree. For this monorepo that is slow and disk/CPU-heavy, so N concurrent tasks = N concurrent installs thrashing → serializes → caps concurrency and slows task startup.

## Fix

Add a Pylon-owned shared `node_modules` cache, **keyed by the SHA-256 of the workspace `bun.lock`**, under `<pylon home>/cache/codex-agent-tasks-node-modules-shared/<lockHash>/<install-dir-key>/node_modules`:

- **Cache hit** (matching lockfile): symlink the shared, read-only `node_modules` into the worktree install directory. The existing `pathExists(node_modules)` check then passes, so `bun install` is skipped.
- **Cache miss / lockfile mismatch / missing cache**: fall back to a fresh `bun install` (stale dependency trees are never shared), then publish the freshly installed tree into the shared cache so the next task reuses it. The first task installs once; every subsequent/concurrent matching task symlinks instantly.
- **Concurrency-safe**: the one-time populate is guarded by an atomic `mkdir` lock and published with a temp-dir + atomic `rename`. Many worktrees symlinking the same read-only entry simultaneously is safe; a contended first-run keeps its own freshly-installed tree rather than colliding.
- Handles the bun workspace-root (hoisted) `node_modules` plus any per-package verifier install directories that `dependencyInstallDirectories` already enumerates.
- A pure symlink-reuse pass leaves the checkout pristine, so it skips the post-install `git restore`.

## Tests

Added `describe("shared node_modules cache across codex worktrees")` in `apps/pylon/tests/codex-agent-executor.test.ts`:

- (a) a matching shared cache skips `bun install` and symlinks `node_modules` in
- (b) a lockfile-hash mismatch falls back to a fresh install
- (c) concurrent materializations (6 worktrees) do not corrupt the shared cache (exactly one valid entry, no leftover locks/temp dirs)

Full `apps/pylon` suite: 1894 pass / 0 fail. `apps/pylon` typecheck: clean. `bun run --cwd apps/openagents.com check:deploy`: green.

## Deploy

No deploy needed — this is local Pylon runtime code. It takes effect on the next supervisor restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)