### PR TITLE
feat(pylon): add VMQ PR fast-forward plan API

### DIFF
--- a/apps/pylon/src/cli-catalog.ts
+++ b/apps/pylon/src/cli-catalog.ts
@@ -237,6 +237,19 @@ export const PYLON_COMMAND_CATALOG: readonly PylonCommandEntry[] = [
     ],
   },
   {
+    command: "vmq",
+    summary: "Plan Pylon virtual merge queue supervisor operations through the running node.",
+    mutates: false,
+    spends: false,
+    needsNode: true,
+    json: true,
+    args: [
+      pos("pr-fast-forward-plan", "Subcommand."),
+      opt("--projection", "Path to a virtual merge queue projection JSON file.", true),
+      opt("--request", "Path to a PR fast-forward request JSON file.", true),
+    ],
+  },
+  {
     command: "deploy",
     summary: "Trigger/inspect a node cloud deploy (gated by OA_DEPLOY_ENABLE=1).",
     mutates: true,

--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -2754,6 +2754,38 @@ async function main() {
     }
   }
 
+  // #6695 VMQ supervisor API: expose the node-local PR fast-forward planner so
+  // supervisors can verify the next actual promotion before any git push exists.
+  if (args[0] === "vmq") {
+    const command = args[1]
+    const options = parseCliOptions(args.slice(2))
+    try {
+      if (command === "pr-fast-forward-plan") {
+        const projectionPath = optionString(options, "projection")
+        const requestPath = optionString(options, "request")
+        if (!projectionPath || !requestPath) {
+          throw new Error("vmq pr-fast-forward-plan requires --projection <json> and --request <json>")
+        }
+        const projection = JSON.parse(await readFile(projectionPath, "utf8"))
+        const request = JSON.parse(await readFile(requestPath, "utf8"))
+        const { result } = await runControlCommand(
+          {
+            type: "virtual_merge_queue.pr_fast_forward.plan",
+            projection,
+            request,
+          },
+          Bun.env,
+        )
+        process.stdout.write(`${JSON.stringify({ ok: true, result }, null, 2)}\n`)
+        return
+      }
+      throw new Error("usage: pylon vmq pr-fast-forward-plan --projection projection.json --request request.json")
+    } catch (error) {
+      emitControlError("vmq", error)
+      return
+    }
+  }
+
   // CL-5035 deploy: surface the gated node deploy-cloud action as a CLI verb.
   // Execution stays gated on the node behind OA_DEPLOY_ENABLE=1 (fail-safe);
   // this verb only forwards the request to the running node.

--- a/apps/pylon/src/node/control-server.ts
+++ b/apps/pylon/src/node/control-server.ts
@@ -31,6 +31,11 @@ import type {
   ControlSessionReplyCommand,
   ControlSessionSpawnCommand,
 } from "./control-sessions.js"
+import {
+  planVirtualMergeQueuePrFastForward,
+  type VirtualMergeQueuePrFastForwardRequest,
+  type VirtualMergeQueueProjection,
+} from "../blueprint-gates/virtual-merge-queue.js"
 
 export const defaultControlPort = 4716
 export const controlTokenFileName = "control-token"
@@ -106,6 +111,13 @@ export type ControlCommand =
   // revokes a paired credential by its pairingRef.
   | { type: "bridge.clients.list" }
   | { type: "bridge.revoke"; pairingRef: string }
+  // #6695: public-safe supervisor API for planning the one allowed PR
+  // fast-forward from the Pylon-native virtual merge queue.
+  | {
+      type: "virtual_merge_queue.pr_fast_forward.plan"
+      projection: VirtualMergeQueueProjection
+      request: VirtualMergeQueuePrFastForwardRequest
+    }
 
 export interface ControlCommandActions {
   walletSend: (destinationRef: string, amountSats?: number) => Promise<unknown>
@@ -365,6 +377,11 @@ export const startControlServer = (
           }
           return { revoked: bridgePairing.revoke(command.pairingRef) }
         }
+        case "virtual_merge_queue.pr_fast_forward.plan":
+          return planVirtualMergeQueuePrFastForward({
+            projection: command.projection,
+            request: command.request,
+          })
         default:
           throw new Error(`unknown command: ${(command as { type?: string }).type}`)
       }

--- a/apps/pylon/tests/control-protocol.test.ts
+++ b/apps/pylon/tests/control-protocol.test.ts
@@ -33,6 +33,7 @@ import {
   workspaceLeaseRecordFor,
   type WorkspaceCheckoutRunner,
 } from "../src/workspace-materializer"
+import { projectVirtualMergeQueue } from "../src/blueprint-gates/virtual-merge-queue"
 
 const appleFmControlEnv = {
   PYLON_HOME: "/tmp/pylon-apple-fm-control-test",
@@ -245,6 +246,82 @@ describe("control protocol", () => {
             ),
           )
           expect(bogus).toMatch(/unknown command/)
+        }),
+      ),
+    )
+  })
+
+  test("control command plans supervisor virtual merge queue PR fast-forward", async () => {
+    const actualHead = "a".repeat(40)
+    const firstHead = "b".repeat(40)
+    const secondHead = "c".repeat(40)
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const runtime = yield* makePylonNodeRuntime
+          const server = yield* startControlServer(runtime, {
+            token: "test-token-0123456789abcdef",
+            actions: stubActions([]),
+            port: 0,
+          })
+          const projection = projectVirtualMergeQueue({
+            actualHead,
+            candidates: [
+              {
+                candidateRef: "candidate.public.pylon_vmq.issue_6695",
+                issueNumber: 6695,
+                baseCommit: actualHead,
+                patchCommit: firstHead,
+                verificationPassed: true,
+                issueOpen: true,
+                hasOpenPullRequest: false,
+                queuedAt: "2026-06-28T00:00:01.000Z",
+              },
+              {
+                candidateRef: "candidate.public.pylon_vmq.issue_6696",
+                issueNumber: 6696,
+                baseCommit: firstHead,
+                patchCommit: secondHead,
+                verificationPassed: true,
+                issueOpen: true,
+                hasOpenPullRequest: false,
+                queuedAt: "2026-06-28T00:00:02.000Z",
+              },
+            ],
+          })
+
+          const result = yield* Effect.promise(() =>
+            sendControlCommand(server.url, "test-token-0123456789abcdef", {
+              type: "virtual_merge_queue.pr_fast_forward.plan",
+              projection,
+              request: {
+                supervisorRef: "supervisor.public.pylon_vmq.sig_abcdef",
+                repository: "OpenAgentsInc/openagents",
+                branch: "main",
+                actualHead,
+                prNumber: 6695,
+                prBaseCommit: actualHead,
+                prHeadCommit: firstHead,
+                promotionRef: projection.nextActualPromotion?.promotionRef ?? "",
+              },
+            }),
+          )
+
+          expect(result).toMatchObject({
+            schema: "openagents.pylon.virtual_merge_queue.pr_fast_forward.v1",
+            state: "ready",
+            issueNumber: 6695,
+            expectedActualHeadBefore: actualHead,
+            fastForwardHead: firstHead,
+            nextVirtualHeadAfter: secondHead,
+          })
+          expect((result as { commands: Array<{ kind: string }> }).commands.map((command) => command.kind)).toEqual([
+            "git_fetch_pr_head",
+            "git_checkout_branch",
+            "git_reset_actual_head",
+            "git_merge_ff_only",
+            "git_push_branch",
+          ])
         }),
       ),
     )


### PR DESCRIPTION
Addresses #6695.

### Changes
- Added a `pylon vmq pr-fast-forward-plan` CLI entry that reads projection and request JSON files and forwards the planner request to the running node.
- Added a control protocol command for `virtual_merge_queue.pr_fast_forward.plan` backed by the existing virtual merge queue planner.
- Added protocol coverage for supervisor PR fast-forward planning, including the expected git command plan.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).