### PR TITLE
fix(operator): accept accountRefHash for account resets

### DIFF
--- a/apps/openagents.com/workers/api/src/operator-provider-account-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-provider-account-routes.test.ts
@@ -2019,7 +2019,48 @@ describe('operator provider account routes', () => {
     })
   })
 
-  test('operator reset rejects non-POST methods and missing providerAccountRef', async () => {
+  test('operator reset accepts accountRefHash alias for the Artanis accounts dashboard', async () => {
+    const repository = new FakeProviderAccountRepository()
+    const database = new FakeProviderAccountD1()
+    database.accounts.push(
+      fakeAccountRow(
+        'provider_account_rate_limited',
+        'provider-account_ref_rate_limited',
+        {
+          cooldown_until: '2099-01-01T00:00:00.000Z',
+          health: 'unhealthy',
+          recent_failure_class: 'rate_limited',
+        },
+      ),
+    )
+
+    const response = await run(
+      repository,
+      '/api/operator/accounts/reset',
+      {
+        body: JSON.stringify({
+          accountRefHash: 'provider-account_ref_rate_limited',
+          email: 'chris@openagents.com',
+        }),
+        method: 'POST',
+      },
+      undefined,
+      database.asD1(),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      providerAccountRef: 'provider-account_ref_rate_limited',
+    })
+    expect(database.accounts[0]).toMatchObject({
+      cooldown_until: null,
+      health: 'healthy',
+      recent_failure_class: null,
+    })
+  })
+
+  test('operator reset rejects non-POST methods and missing provider account ref', async () => {
     const repository = new FakeProviderAccountRepository()
     const database = new FakeProviderAccountD1()
 
@@ -2047,7 +2088,7 @@ describe('operator provider account routes', () => {
     expect(missingRef.status).toBe(400)
     await expect(missingRef.json()).resolves.toEqual({
       error: 'bad_request',
-      reason: 'providerAccountRef is required',
+      reason: 'providerAccountRef or accountRefHash is required',
     })
   })
 

--- a/apps/openagents.com/workers/api/src/operator-provider-account-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-provider-account-routes.ts
@@ -2829,11 +2829,15 @@ export const makeOperatorProviderAccountRoutes = <
       )
     }
 
-    const providerAccountRef = optionalString(body.providerAccountRef)
+    const providerAccountRef =
+      optionalString(body.providerAccountRef) ?? optionalString(body.accountRefHash)
 
     if (providerAccountRef === undefined) {
       return noStoreJsonResponse(
-        { error: 'bad_request', reason: 'providerAccountRef is required' },
+        {
+          error: 'bad_request',
+          reason: 'providerAccountRef or accountRefHash is required',
+        },
         { status: 400 },
       )
     }


### PR DESCRIPTION
Addresses #6637.

### Changes
- Allows the operator account reset route to accept `accountRefHash` as an alias for `providerAccountRef`.
- Updates the missing-reference validation message to mention both accepted fields.
- Adds coverage for resetting a rate-limited account through the dashboard alias.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` - passed (exit 0)