### PR TITLE
feat(operator): add owner-scoped fleet state

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -8965,6 +8965,15 @@ const operatorPylonMarketplaceRoutes = makeOperatorPylonMarketplaceRoutes({
 })
 
 const operatorFleetStatusRoutes = makeOperatorFleetStatusRoutes({
+  authenticateAgentToken: async (request, env) => {
+    const token = readBearerToken(request)
+    if (token === undefined) return undefined
+    const session = await authenticateProgrammaticAgent(
+      makeD1AgentRegistrationStore(openAgentsDatabase(env)),
+      token,
+    )
+    return session === undefined ? undefined : { userId: session.user.id }
+  },
   requireAdminApiToken,
 })
 
@@ -11261,6 +11270,13 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
   },
   {
     path: '/api/operator/fleet/status',
+    handler: (request, env) =>
+      Effect.promise(() =>
+        operatorFleetStatusRoutes.handleOperatorFleetStatusApi(request, env),
+      ),
+  },
+  {
+    path: '/api/operator/fleet/state',
     handler: (request, env) =>
       Effect.promise(() =>
         operatorFleetStatusRoutes.handleOperatorFleetStatusApi(request, env),

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -1283,6 +1283,7 @@ const intentionallyUndocumentedApiRoutes: ReadonlyArray<string> = [
   // internal Artanis and fleet surfaces; public pages consume a later
   // public-safe projection, not this operator route directly.
   '/api/operator/fleet/status',
+  '/api/operator/fleet/state',
   '/api/admin/provider-accounts/usage',
   '/api/admin/sync/notify',
   // Self-hosted trace media blob serving (#6223): serves the public-safe R2 blob

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -64,6 +64,33 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
     ]
   }
 
+  if (sql.includes('FROM provider_accounts')) {
+    return [
+      {
+        cooldown_until: '2026-06-27T19:00:00.000Z',
+        health: 'healthy',
+        lease_limit: 2,
+        low_credit_flag: 0,
+        provider: 'chatgpt_codex',
+        provider_account_ref: 'acct_hash_codex_3',
+        reauth_required_reason: null,
+        recent_failure_class: 'rate_limited',
+        status: 'connected',
+      },
+      {
+        cooldown_until: null,
+        health: 'healthy',
+        lease_limit: 1,
+        low_credit_flag: 0,
+        provider: 'chatgpt_codex',
+        provider_account_ref: 'acct_hash_codex_4',
+        reauth_required_reason: null,
+        recent_failure_class: null,
+        status: 'connected',
+      },
+    ]
+  }
+
   if (sql.includes('FROM fleet_alerts')) {
     return [
       {
@@ -115,8 +142,8 @@ const fakeDb = (log: QueryLog): D1Database =>
     prepare: (sql: string) => new FakeStatement(sql, log),
   }) as unknown as D1Database
 
-const request = (method = 'GET'): Request =>
-  new Request('https://openagents.com/api/operator/fleet/status', { method })
+const request = (method = 'GET', path = '/api/operator/fleet/state'): Request =>
+  new Request(`https://openagents.com${path}`, { method })
 
 describe('operator fleet status route', () => {
   test('requires GET', async () => {
@@ -164,7 +191,7 @@ describe('operator fleet status route', () => {
     expect(first.headers.get('x-openagents-cache')).toBe('miss')
     expect(second.headers.get('x-openagents-cache')).toBe('hit')
     expect(log.length).toBeGreaterThan(0)
-    expect(log.length).toBe(8)
+    expect(log.length).toBe(9)
     expect(cachedBody).toEqual(body)
     expect(body).toMatchObject({
       authority: {
@@ -178,6 +205,15 @@ describe('operator fleet status route', () => {
       },
       fleet: {
         activeAssignmentCount: 1,
+        activeAssignments: [
+          {
+            assignmentRef: 'assignment.public.issue_6427',
+            elapsedMs: 660000,
+            lastProgressEvent: null,
+            phase: 'running',
+            tokensSoFar: null,
+          },
+        ],
         activeSlots: 3,
         busySlots: 1,
         queuedSlots: 0,
@@ -196,7 +232,35 @@ describe('operator fleet status route', () => {
         todayTokens: 1200,
         yesterdayTokens: 250,
       },
+      accounts: {
+        healthyCount: 1,
+        limitedCount: 1,
+        status: [
+          {
+            accountRefHash: 'acct_hash_codex_3',
+            concurrency: 2,
+            provider: 'codex',
+            reason: 'rate_limited',
+            resetAt: '2026-06-27T19:00:00.000Z',
+            status: 'rate_limited',
+          },
+          {
+            accountRefHash: 'acct_hash_codex_4',
+            concurrency: 1,
+            provider: 'codex',
+            reason: null,
+            resetAt: null,
+            status: 'healthy',
+          },
+        ],
+      },
       schemaVersion: 'operator.fleet_status.v1',
+      supervisor: {
+        availableCodexSlots: 3,
+        desiredCodexSlots: 2,
+        queueDepth: 0,
+        state: 'ready',
+      },
       watchdog: {
         activeLeases: 1,
         state: 'STALLED',
@@ -205,5 +269,25 @@ describe('operator fleet status route', () => {
     expect(JSON.stringify(body)).not.toContain('/Users/')
     expect(JSON.stringify(body)).not.toContain('auth.json')
     expect(JSON.stringify(body)).not.toContain('Fan out bounded')
+  })
+
+  test('accepts a registered agent token through the owner-scoped state path', async () => {
+    clearOperatorFleetStatusCacheForTests()
+    const log: QueryLog = []
+    const routes = makeOperatorFleetStatusRoutes({
+      authenticateAgentToken: async () => ({ userId: 'agent_owner_public' }),
+      currentIsoTimestamp: () => '2026-06-27T18:41:00.000Z',
+      requireAdminApiToken: async () => false,
+    })
+    const response = await routes.handleOperatorFleetStatusApi(
+      request('GET', '/api/operator/fleet/state'),
+      { OPENAGENTS_DB: fakeDb(log) },
+    )
+    const body = await response.json() as Record<string, any>
+
+    expect(response.status).toBe(200)
+    expect(body.fleet.sourceRefs).toContain('d1:pylon_api_registrations')
+    expect(log.some(sql => sql.includes('owner_agent_user_id = ?'))).toBe(true)
+    expect(log.some(sql => sql.includes('AND user_id = ?'))).toBe(true)
   })
 })

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -290,4 +290,21 @@ describe('operator fleet status route', () => {
     expect(log.some(sql => sql.includes('owner_agent_user_id = ?'))).toBe(true)
     expect(log.some(sql => sql.includes('AND user_id = ?'))).toBe(true)
   })
+
+  test('keeps the legacy fleet status path admin-token only', async () => {
+    clearOperatorFleetStatusCacheForTests()
+    const routes = makeOperatorFleetStatusRoutes({
+      authenticateAgentToken: async () => ({ userId: 'agent_owner_public' }),
+      currentIsoTimestamp: () => '2026-06-27T18:41:00.000Z',
+      requireAdminApiToken: async () => false,
+    })
+
+    const response = await routes.handleOperatorFleetStatusApi(
+      request('GET', '/api/operator/fleet/status'),
+      { OPENAGENTS_DB: fakeDb([]) },
+    )
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+  })
 })

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -6,6 +6,7 @@ import { openAgentsDatabase } from './runtime'
 import { currentIsoTimestamp } from './runtime-primitives'
 
 export const OPERATOR_FLEET_STATUS_PATH = '/api/operator/fleet/status'
+export const OPERATOR_FLEET_STATE_PATH = '/api/operator/fleet/state'
 const CACHE_TTL_MILLIS = 10_000
 
 type OperatorFleetStatusEnv = Readonly<{
@@ -14,6 +15,10 @@ type OperatorFleetStatusEnv = Readonly<{
 
 type OperatorFleetStatusDependencies<Bindings extends OperatorFleetStatusEnv> =
   Readonly<{
+    authenticateAgentToken?: (
+      request: Request,
+      env: Bindings,
+    ) => Promise<{ userId: string } | undefined>
     currentIsoTimestamp?: () => string
     requireAdminApiToken: (request: Request, env: Bindings) => Promise<boolean>
   }>
@@ -47,6 +52,18 @@ type AlertRow = Readonly<{
   reason_ref: string
   active_assignments: number
   queued_assignments: number
+}>
+
+type ProviderAccountRow = Readonly<{
+  provider_account_ref: string
+  provider: string
+  status: string | null
+  health: string | null
+  cooldown_until: string | null
+  recent_failure_class: string | null
+  reauth_required_reason: string | null
+  low_credit_flag: number | null
+  lease_limit: number | null
 }>
 
 type TokenTodayRow = Readonly<{ tokens_today: number | null }>
@@ -127,10 +144,25 @@ const safeFirst = async <T>(
 const buildFleetStatusSnapshot = async (
   db: D1Database,
   nowIso: string,
+  scope: OperatorFleetReadScope,
 ): Promise<unknown> => {
+  const registrationOwnerClause =
+    scope.kind === 'agent' ? 'AND owner_agent_user_id = ?' : ''
+  const assignmentOwnerClause =
+    scope.kind === 'agent'
+      ? `AND pylon_ref IN (
+           SELECT pylon_ref
+             FROM pylon_api_registrations
+            WHERE archived_at IS NULL
+              AND owner_agent_user_id = ?
+         )`
+      : ''
+  const accountOwnerClause = scope.kind === 'agent' ? 'AND user_id = ?' : ''
+  const ownerBindings = scope.kind === 'agent' ? [scope.userId] : []
   const [
     registrations,
     assignments,
+    providerAccounts,
     latestAlert,
     today,
     yesterday,
@@ -145,8 +177,10 @@ const buildFleetStatusSnapshot = async (
               capability_refs_json, status
          FROM pylon_api_registrations
         WHERE archived_at IS NULL
+          ${registrationOwnerClause}
         ORDER BY updated_at DESC
         LIMIT 100`,
+      ...ownerBindings,
     ),
     safeAll<AssignmentRow>(
       db,
@@ -154,9 +188,26 @@ const buildFleetStatusSnapshot = async (
               lease_expires_at
          FROM pylon_api_assignments
         WHERE archived_at IS NULL
+          ${assignmentOwnerClause}
           AND state IN ('offered','accepted','running','proof_submitted')
         ORDER BY updated_at DESC
         LIMIT 50`,
+      ...ownerBindings,
+    ),
+    safeAll<ProviderAccountRow>(
+      db,
+      `SELECT provider_account_ref, provider, status, health, cooldown_until,
+              recent_failure_class, reauth_required_reason, low_credit_flag,
+              lease_limit
+         FROM provider_accounts
+        WHERE deleted_at IS NULL
+          AND provider IN ('chatgpt_codex', 'claude')
+          ${accountOwnerClause}
+        ORDER BY
+          CASE provider WHEN 'chatgpt_codex' THEN 0 ELSE 1 END,
+          provider_account_ref ASC
+        LIMIT 100`,
+      ...ownerBindings,
     ),
     safeFirst<AlertRow>(
       db,
@@ -233,6 +284,35 @@ const buildFleetStatusSnapshot = async (
   const activeAssignments = assignments.filter(row =>
     row.state === 'accepted' || row.state === 'running' || row.state === 'proof_submitted',
   )
+  const accountLedger = providerAccounts.map(row => {
+    const cooldownExpiresAt =
+      row.cooldown_until !== null && row.cooldown_until > nowIso
+        ? row.cooldown_until
+        : null
+    const reason =
+      row.reauth_required_reason ??
+      row.recent_failure_class ??
+      (row.low_credit_flag === 1 ? 'low_credit' : null)
+    const status =
+      row.reauth_required_reason !== null
+        ? 'revoked'
+        : cooldownExpiresAt !== null || row.recent_failure_class === 'rate_limited'
+          ? 'rate_limited'
+          : row.recent_failure_class === 'usage_limited'
+            ? 'usage_limited'
+            : row.status === 'connected' && (row.health === null || row.health === 'healthy')
+              ? 'healthy'
+              : row.health ?? row.status ?? 'unknown'
+
+    return {
+      accountRefHash: row.provider_account_ref,
+      provider: row.provider === 'chatgpt_codex' ? 'codex' : row.provider,
+      status,
+      resetAt: cooldownExpiresAt,
+      concurrency: Math.max(1, Math.trunc(row.lease_limit ?? 1)),
+      reason,
+    }
+  })
 
   const todayTokens = Math.max(0, Math.trunc(today?.tokens_today ?? 0))
   const yesterdayTokens = Math.max(0, Math.trunc(yesterday?.tokens_yesterday ?? 0))
@@ -289,6 +369,24 @@ const buildFleetStatusSnapshot = async (
       busySlots,
       queuedSlots,
       spread: fleetAccounts,
+      activeAssignments: assignments.map(row => ({
+        assignmentRef: row.assignment_ref,
+        pylonRef: row.pylon_ref,
+        jobKind: row.job_kind,
+        state: row.state,
+        elapsedMs: millisBetween(row.created_at, nowIso),
+        phase:
+          row.state === 'proof_submitted'
+            ? 'proof'
+            : row.state === 'running' || row.state === 'accepted'
+              ? 'running'
+              : 'queued',
+        tokensSoFar: null,
+        lastProgressEvent: null,
+        lastLog: null,
+        updatedAt: row.updated_at,
+        leaseExpiresAt: row.lease_expires_at,
+      })),
       inFlightAssignments: assignments.map(row => ({
         assignmentRef: row.assignment_ref,
         pylonRef: row.pylon_ref,
@@ -301,6 +399,40 @@ const buildFleetStatusSnapshot = async (
       activeAssignmentCount: activeAssignments.length,
       sourceRefs: ['d1:pylon_api_registrations', 'd1:pylon_api_assignments'],
     },
+    accounts: {
+      status: accountLedger,
+      healthyCount: accountLedger.filter(row => row.status === 'healthy').length,
+      limitedCount: accountLedger.filter(row =>
+        row.status === 'rate_limited' || row.status === 'usage_limited',
+      ).length,
+      sourceRefs: ['d1:provider_accounts'],
+    },
+    supervisor: {
+      state: readySlots > busySlots ? 'ready' : activeAssignments.length > 0 ? 'busy' : 'idle',
+      desiredCodexSlots: readySlots,
+      availableCodexSlots: activeSlots,
+      queueDepth: queuedSlots,
+      sourceRefs: ['d1:pylon_api_registrations'],
+    },
+    recentFailures: [
+      ...accountLedger
+        .filter(row => row.reason !== null && row.status !== 'healthy')
+        .slice(0, 10)
+        .map(row => ({
+          scope: 'account',
+          ref: row.accountRefHash,
+          reasonCode: row.reason,
+          observedAt: nowIso,
+        })),
+      ...(latestAlert === null || latestAlertAgeMs > 5 * 60_000
+        ? []
+        : [{
+            scope: 'fleet',
+            ref: latestAlert.alert_ref,
+            reasonCode: latestAlert.reason_ref,
+            observedAt: latestAlert.detected_at,
+          }]),
+    ].slice(0, 10),
     watchdog: {
       state: watchdogState,
       lastCronHeartbeatAt: latestAlert?.detected_at ?? null,
@@ -338,6 +470,27 @@ const buildFleetStatusSnapshot = async (
   }
 }
 
+type OperatorFleetReadScope =
+  | Readonly<{ kind: 'admin' }>
+  | Readonly<{ kind: 'agent'; userId: string }>
+
+const authorizeFleetRead = async <Bindings extends OperatorFleetStatusEnv>(
+  dependencies: OperatorFleetStatusDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+): Promise<OperatorFleetReadScope | null> => {
+  if (await dependencies.requireAdminApiToken(request, env)) {
+    return { kind: 'admin' }
+  }
+
+  const agent = await dependencies.authenticateAgentToken?.(request, env)
+  if (agent !== undefined) {
+    return { kind: 'agent', userId: agent.userId }
+  }
+
+  return null
+}
+
 export const makeOperatorFleetStatusRoutes = <
   Bindings extends OperatorFleetStatusEnv,
 >(
@@ -351,12 +504,16 @@ export const makeOperatorFleetStatusRoutes = <
       return methodNotAllowed(['GET'])
     }
 
-    if (!(await dependencies.requireAdminApiToken(request, env))) {
+    const scope = await authorizeFleetRead(dependencies, request, env)
+    if (scope === null) {
       return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
     }
 
     const nowIso = (dependencies.currentIsoTimestamp ?? currentIsoTimestamp)()
-    const cacheKey = 'operator:fleet:status:v1'
+    const cacheKey =
+      scope.kind === 'admin'
+        ? 'operator:fleet:state:v1:admin'
+        : `operator:fleet:state:v1:agent:${scope.userId}`
     const cached = snapshotCache.get(cacheKey)
     const nowMs = Date.parse(nowIso)
     if (
@@ -372,7 +529,11 @@ export const makeOperatorFleetStatusRoutes = <
       })
     }
 
-    const response = await buildFleetStatusSnapshot(openAgentsDatabase(env), nowIso)
+    const response = await buildFleetStatusSnapshot(
+      openAgentsDatabase(env),
+      nowIso,
+      scope,
+    )
     if (Number.isFinite(nowMs)) {
       snapshotCache.set(cacheKey, {
         expiresAt: nowMs + CACHE_TTL_MILLIS,

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -478,9 +478,14 @@ const authorizeFleetRead = async <Bindings extends OperatorFleetStatusEnv>(
   dependencies: OperatorFleetStatusDependencies<Bindings>,
   request: Request,
   env: Bindings,
+  allowAgentToken: boolean,
 ): Promise<OperatorFleetReadScope | null> => {
   if (await dependencies.requireAdminApiToken(request, env)) {
     return { kind: 'admin' }
+  }
+
+  if (!allowAgentToken) {
+    return null
   }
 
   const agent = await dependencies.authenticateAgentToken?.(request, env)
@@ -504,7 +509,14 @@ export const makeOperatorFleetStatusRoutes = <
       return methodNotAllowed(['GET'])
     }
 
-    const scope = await authorizeFleetRead(dependencies, request, env)
+    const allowAgentToken =
+      new URL(request.url).pathname === OPERATOR_FLEET_STATE_PATH
+    const scope = await authorizeFleetRead(
+      dependencies,
+      request,
+      env,
+      allowAgentToken,
+    )
     if (scope === null) {
       return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
     }

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -92,6 +92,7 @@ const approvedExactRoutePaths = [
   '/api/stats/token-usage/aggregate',
   '/api/admin/inference-analytics',
   '/api/operator/fleet/status',
+  '/api/operator/fleet/state',
   '/api/stats/token-usage/leaderboards',
   '/api/stats/token-usage/leaderboard-preference',
   '/api/auth/teams',

--- a/apps/pylon/src/agent-runner-registry.ts
+++ b/apps/pylon/src/agent-runner-registry.ts
@@ -20,6 +20,7 @@ import {
   codexAgentTaskFrom,
   executeCodexAgentAssignment,
   type CodexAgentExecutionOptions,
+  type CodexAgentRuntimeProgress,
   type CodexAgentRunner,
 } from "./codex-agent-executor.js"
 import type { PylonAssignmentLease } from "./assignment.js"
@@ -52,6 +53,7 @@ export type AgentRunnerExecutionOptions = {
   claudeAgentRunner?: ClaudeAgentRunner
   codexAgentProbe?: CodexAgentProbeOptions
   codexAgentRunner?: CodexAgentRunner
+  onCodexProgress?: (progress: CodexAgentRuntimeProgress) => void | Promise<void>
   fetch?: typeof fetch
 }
 
@@ -114,6 +116,7 @@ export const AGENT_RUNNER_REGISTRY: ReadonlyArray<AgentRunnerDescriptor> = [
         ...commonExecutionOptions(options),
         ...(options.codexAgentProbe === undefined ? {} : { codexAgentProbe: options.codexAgentProbe }),
         ...(options.codexAgentRunner === undefined ? {} : { codexAgentRunner: options.codexAgentRunner }),
+        ...(options.onCodexProgress === undefined ? {} : { onProgress: options.onCodexProgress }),
       } satisfies CodexAgentExecutionOptions),
   },
 ]

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -24,7 +24,7 @@ import {
   probeCodexAgentReadiness,
   type CodexAgentProbeOptions,
 } from "./codex-agent.js"
-import type { CodexAgentRunner } from "./codex-agent-executor.js"
+import type { CodexAgentRuntimePhase, CodexAgentRunner } from "./codex-agent-executor.js"
 import {
   agentRunnerForLease,
   agentRunnerServiceForLease,
@@ -199,8 +199,9 @@ export type AssignmentRunLifecycleEvent = {
   closeoutRef?: string
   accountRefHash?: string
   elapsedMs?: number
-  phase?: "runtime_active"
-  lastProgressEvent?: AssignmentRunLifecycleEvent["event"]
+  phase?: "runtime_active" | CodexAgentRuntimePhase
+  tokensSoFar?: number
+  lastProgressEvent?: AssignmentRunLifecycleEvent["event"] | string
   blockerRefs?: string[]
 }
 
@@ -1814,6 +1815,18 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
           ...(options.codexAgentRunner === undefined ? {} : { codexAgentRunner: options.codexAgentRunner }),
           ...(options.codexAgentProbe === undefined ? {} : { codexAgentProbe: options.codexAgentProbe }),
           ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+          onCodexProgress: async (progress) => {
+            await emitLifecycleEvent({
+              event: "assignment_run.runtime_progress",
+              assignmentRef: lease.assignmentRef,
+              ...(agentAccount.accountRefHash === undefined ? {} : { accountRefHash: agentAccount.accountRefHash }),
+              leaseRef: lease.leaseRef,
+              phase: progress.phase,
+              elapsedMs: Math.max(0, Date.now() - runtimeStartedAtMs),
+              ...(progress.tokensSoFar === undefined ? {} : { tokensSoFar: progress.tokensSoFar }),
+              ...(progress.lastProgressEvent === undefined ? {} : { lastProgressEvent: progress.lastProgressEvent }),
+            })
+          },
         })) ??
         (await executeRuntimeGate(state, lease, observedAtDate)),
     })

--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -101,6 +101,21 @@ export type CodexAgentRunInput = {
   sandboxMode: CodexAgentRuntimeSandboxMode
   timeoutMs: number
   model?: string
+  onProgress?: (progress: CodexAgentRuntimeProgress) => void | Promise<void>
+}
+
+export type CodexAgentRuntimePhase =
+  | "materializing"
+  | "installing"
+  | "running"
+  | "testing"
+  | "diff"
+  | "proof"
+
+export type CodexAgentRuntimeProgress = {
+  phase: CodexAgentRuntimePhase
+  tokensSoFar?: number
+  lastProgressEvent?: string
 }
 
 export type CodexAgentRunOutcome =
@@ -145,6 +160,7 @@ export type CodexAgentExecutionOptions = {
    * diff, pushes a scoped branch, and opens one PR against the base branch.
    */
   pullRequestPublisher?: AssignmentPullRequestPublisher
+  onProgress?: (progress: CodexAgentRuntimeProgress) => void | Promise<void>
 }
 
 type CodexAgentFixture = {
@@ -499,6 +515,19 @@ function usageFromTurnCompleted(event: CodexThreadEvent): CodexTurnUsage | undef
   }
 }
 
+function totalTokensFromUsage(usage: CodexTurnUsage | undefined): number | undefined {
+  if (usage === undefined) return undefined
+  return usage.inputTokens + usage.outputTokens + (usage.reasoningOutputTokens ?? 0)
+}
+
+async function emitCodexProgress(
+  reporter: CodexAgentRunInput["onProgress"],
+  progress: CodexAgentRuntimeProgress,
+) {
+  if (reporter === undefined) return
+  await Promise.resolve(reporter(progress)).catch(() => undefined)
+}
+
 function outputBytes(item: CodexThreadEvent["item"]): number | undefined {
   if (typeof item?.aggregated_output !== "string") return undefined
   return new TextEncoder().encode(item.aggregated_output).byteLength
@@ -675,6 +704,7 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
   let threadId: string | null = null
   let failed = false
   let activeTurnIndex = 0
+  let tokensSoFar = 0
   let itemOrdinal = 0
   let currentTurnChunkIndex = 0
   let currentTurnItems: Array<CodexTurnReportItem> = []
@@ -735,6 +765,10 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
         currentRawEvents = rawEvent === undefined ? pendingRawEvents : [...pendingRawEvents, rawEvent]
         pendingRawEvents = []
         await flushEventChunk(activeTurnIndex)
+        await emitCodexProgress(input.onProgress, {
+          phase: "running",
+          lastProgressEvent: "turn.started",
+        })
       }
       if (event.type === "turn.completed") {
         const completedTurnIndex = activeTurnIndex > 0 ? activeTurnIndex : turnCount + 1
@@ -743,6 +777,7 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
         turnCount += 1
         const sessionRef =
           threadId === null ? undefined : stableRef("session.pylon.codex_agent", threadId)
+        const usage = usageFromTurnCompleted(event)
         await reportCodexTurn({
           eventReporter: input.eventReporter,
           items: currentTurnItems,
@@ -750,7 +785,13 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
           runInput: input,
           sessionRef,
           turnIndex: completedTurnIndex,
-          usage: usageFromTurnCompleted(event),
+          usage,
+        })
+        tokensSoFar += totalTokensFromUsage(usage) ?? 0
+        await emitCodexProgress(input.onProgress, {
+          phase: "running",
+          tokensSoFar,
+          lastProgressEvent: "turn.completed",
         })
         currentTurnItems = []
         currentRawEvents = []
@@ -762,6 +803,10 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
       if (event.type === "turn.failed" || event.type === "error") failed = true
       if (event.type === "item.completed" && event.item?.type === "command_execution") {
         commandCount += 1
+        await emitCodexProgress(input.onProgress, {
+          phase: "testing",
+          lastProgressEvent: "command_execution.completed",
+        })
       }
       if (event.type === "item.completed") {
         const projected = projectCodexItem(event.item, itemOrdinal + 1)
@@ -775,6 +820,10 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
       if (event.type === "item.completed" && event.item?.type === "file_change") {
         const changes = Array.isArray(event.item.changes) ? event.item.changes : []
         editedFileCount += changes.length
+        await emitCodexProgress(input.onProgress, {
+          phase: "diff",
+          lastProgressEvent: "file_change.completed",
+        })
         for (const change of changes) {
           if (typeof change.path === "string" && fileChangeEscapesWorkspace(change.path, input.cwd)) {
             escaped = true
@@ -1001,6 +1050,10 @@ export async function executeCodexAgentAssignment(
 
   let materialized: Awaited<ReturnType<typeof materializeCodexAgentWorkspace>>
   try {
+    await Promise.resolve(options.onProgress?.({
+      phase: "materializing",
+      lastProgressEvent: "workspace.materializing",
+    })).catch(() => undefined)
     materialized = await materializeCodexAgentWorkspace({
       ...(options.checkoutRunner === undefined ? {} : { checkoutRunner: options.checkoutRunner }),
       leaseRef: lease.leaseRef,
@@ -1027,6 +1080,10 @@ export async function executeCodexAgentAssignment(
     verificationArgs: materialized.verificationArgs,
     workspace: materialized.workspace,
   })
+  await Promise.resolve(options.onProgress?.({
+    phase: "installing",
+    lastProgressEvent: dependencies.ok ? "dependencies.prepared" : "dependencies.failed",
+  })).catch(() => undefined)
   if (!dependencies.ok) {
     await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
@@ -1081,6 +1138,7 @@ export async function executeCodexAgentAssignment(
       sandboxMode: effectiveSandboxMode(task.sandboxMode, config.sandboxMode),
       timeoutMs,
       ...(config.model === undefined ? {} : { model: config.model }),
+      ...(options.onProgress === undefined ? {} : { onProgress: options.onProgress }),
       workspaceRef: materialized.workspaceRef,
     })
   } catch {
@@ -1128,7 +1186,15 @@ export async function executeCodexAgentAssignment(
     })
   }
 
+  await Promise.resolve(options.onProgress?.({
+    phase: "testing",
+    lastProgressEvent: "verification.started",
+  })).catch(() => undefined)
   const verification = await runCommand({ args: materialized.verificationArgs, cwd: materialized.workspace })
+  await Promise.resolve(options.onProgress?.({
+    phase: "proof",
+    lastProgressEvent: verification.exitCode === 0 ? "verification.passed" : "verification.failed",
+  })).catch(() => undefined)
   const commandRef = stableRef(
     "command.pylon.codex_agent_task.verification",
     `${lease.leaseRef}:${verification.exitCode}:${verification.stdoutBytes}:${verification.stderrBytes}`,

--- a/apps/pylon/tests/assignment.test.ts
+++ b/apps/pylon/tests/assignment.test.ts
@@ -581,7 +581,10 @@ describe("Pylon assignment lease flow", () => {
         (event) => event.event === "assignment_run.runtime_progress",
       )
       expect(progressEvents.length).toBeGreaterThan(0)
-      expect(progressEvents[0]).toMatchObject({
+      const runtimeActiveProgress = progressEvents.find(
+        (event) => event.phase === "runtime_active",
+      )
+      expect(runtimeActiveProgress).toMatchObject({
         schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
         assignmentRef: codexLease.assignmentRef,
         accountRefHash: expect.stringMatching(/^account\.pylon\.codex\.[a-f0-9]{24}$/),
@@ -589,8 +592,8 @@ describe("Pylon assignment lease flow", () => {
         phase: "runtime_active",
         lastProgressEvent: "assignment_run.runtime_started",
       })
-      expect(typeof progressEvents[0].elapsedMs).toBe("number")
-      expect(progressEvents[0].elapsedMs).toBeGreaterThanOrEqual(0)
+      expect(typeof runtimeActiveProgress?.elapsedMs).toBe("number")
+      expect(runtimeActiveProgress?.elapsedMs).toBeGreaterThanOrEqual(0)
 
       const lifecycleJson = JSON.stringify(lifecycleEvents)
       expect(lifecycleJson).not.toContain(home)

--- a/clients/khala-cli/README.md
+++ b/clients/khala-cli/README.md
@@ -86,7 +86,7 @@ two modes:
   Capability questions answer with the `/spawn` and `khala spawn --count`
   command paths instead of falling through to a generic chat refusal.
 - **Fleet live dashboard:** `khala fleet status --live` polls the owner-only
-  `/api/operator/fleet/status` endpoint about every five seconds and renders
+  `/api/operator/fleet/state` endpoint about every five seconds and renders
   Pace, Fleet, Watchdog, GLM, and Brain/Artanis blocks as a terminal dashboard.
   It uses your `khala login` token, `OPENAGENTS_AGENT_TOKEN`, or `--token`.
 - **Utility commands:** `khala feedback "..."` saves feedback to
@@ -171,7 +171,7 @@ no long-string pasting:
   the standing GEPA/DSPy loop, source audits over Pylon/clients/Worker code, and
   test/lint/typecheck sweeps.
 - `khala fleet status --live` polls the owner-only
-  `/api/operator/fleet/status` endpoint about every five seconds and renders the
+  `/api/operator/fleet/state` endpoint about every five seconds and renders the
   Pace, Fleet, Watchdog, GLM, and Brain/Artanis blocks as a terminal dashboard.
   It uses your `khala login` token, `OPENAGENTS_AGENT_TOKEN`, or `--token`.
 

--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -278,7 +278,7 @@ describe("Khala CLI info diagnostics", () => {
       port: 0,
       fetch: request => {
         authHeaders.push(request.headers.get("authorization"))
-        expect(new URL(request.url).pathname).toBe("/api/operator/fleet/status")
+        expect(new URL(request.url).pathname).toBe("/api/operator/fleet/state")
         return Response.json({
           pace: { burnRate: "900 tokens/min", paceToFloor: "on pace" },
           fleet: { concurrency: 2, inFlightIssues: ["#6429"] },

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -2185,7 +2185,7 @@ Flags:
   --per-account <n>    Fleet run slots per ready Codex account (default: 1)
   --once               Fleet run one refill round, then exit
   --dry-run            Fleet run prints the resolved plan without dispatching
-  --live               Poll /api/operator/fleet/status for khala fleet status
+  --live               Poll /api/operator/fleet/state for khala fleet status
   --help, -h           Show this help
 `
 }

--- a/clients/khala-cli/src/fleet.test.ts
+++ b/clients/khala-cli/src/fleet.test.ts
@@ -254,7 +254,7 @@ describe("operator fleet live status", () => {
         seenAuth.push(init?.headers instanceof Headers
           ? init.headers.get("authorization")
           : (init?.headers as Record<string, string> | undefined)?.authorization ?? null)
-        expect(String(input)).toBe("https://example.test/api/operator/fleet/status")
+        expect(String(input)).toBe("https://example.test/api/operator/fleet/state")
         return Response.json({ pace: { burnRate: 12 }, fleet: { ready: 2 } })
       },
     })

--- a/clients/khala-cli/src/fleet.ts
+++ b/clients/khala-cli/src/fleet.ts
@@ -617,7 +617,7 @@ export async function fetchOperatorFleetStatus(options: {
   if (token.length === 0) {
     throw new Error("khala fleet status --live requires an owner token. Run `khala login` or pass --token.")
   }
-  const response = await (options.fetch ?? fetch)(`${baseUrl}/api/operator/fleet/status`, {
+  const response = await (options.fetch ?? fetch)(`${baseUrl}/api/operator/fleet/state`, {
     method: "GET",
     headers: {
       accept: "application/json",
@@ -684,7 +684,7 @@ export function formatOperatorFleetDashboard(snapshot: KhalaOperatorFleetStatusS
   const payload = asRecord(snapshot.payload) ?? {}
   const lines = [
     `Khala fleet live dashboard`,
-    `updated: ${snapshot.fetchedAt}  source: ${snapshot.baseUrl}/api/operator/fleet/status`,
+    `updated: ${snapshot.fetchedAt}  source: ${snapshot.baseUrl}/api/operator/fleet/state`,
     "",
     formatDashboardBlock("Pace", firstRecord(payload, ["pace", "paceToFloor", "pace_to_floor", "burnPace"])),
     formatDashboardBlock("Fleet", firstRecord(payload, ["fleet", "codexFleet", "capacity", "pylons"])),


### PR DESCRIPTION
Addresses #6958.

### Changes
- Added `/api/operator/fleet/state` as an owner-scoped fleet observability endpoint while keeping the existing operator fleet status route.
- Added registered agent token authentication for the fleet state path and scoped fleet queries by owner user.
- Expanded fleet status payloads with active assignment progress, supervisor slot state, and Codex account health/rate-limit details.
- Updated Pylon and Khala CLI fleet/status naming and tests to use the unified fleet state surface.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)