### PR TITLE
fix(api): declare Cloudflare Workers types

### DIFF
--- a/apps/openagents.com/workers/api/src/labor-earnings.ts
+++ b/apps/openagents.com/workers/api/src/labor-earnings.ts
@@ -1,5 +1,5 @@
 import { Schema as S } from 'effect'
-import { type D1Database } from '@cloudflare/workers-types'
+import type { D1Database } from '@cloudflare/workers-types'
 import { assertLaborEscrowPublicSafe } from './labor-escrow'
 import {
   PublicProjectionStalenessContract,


### PR DESCRIPTION
Addresses #6891.

### Changes
- Added `@cloudflare/workers-types` as an API dev dependency.
- Updated the `D1Database` import in labor earnings code to use type-only import syntax.
- Updated the Bun lockfile for the new dependency.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` passed (exit 0).