### PR TITLE
feat(khala-desktop): bundle Apple FM sidecar

### DIFF
--- a/clients/khala-desktop/electrobun.config.ts
+++ b/clients/khala-desktop/electrobun.config.ts
@@ -1,3 +1,8 @@
+import {
+  APPLE_FM_BRIDGE_ELECTROBUN_COPY_DEST,
+  APPLE_FM_BRIDGE_ELECTROBUN_COPY_SOURCE,
+} from "./src/shared/apple-fm-packaging.js"
+
 export default {
   app: {
     name: "Khala",
@@ -15,6 +20,7 @@ export default {
     },
     copy: {
       "src/ui/index.html": "views/khala-desktop/index.html",
+      [APPLE_FM_BRIDGE_ELECTROBUN_COPY_SOURCE]: APPLE_FM_BRIDGE_ELECTROBUN_COPY_DEST,
     },
   },
 }

--- a/clients/khala-desktop/package.json
+++ b/clients/khala-desktop/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "bun build src/ui/main.ts --outdir resources/ui --target browser && electrobun dev",
+    "prepare:apple-fm-bridge": "bash scripts/prepare-apple-fm-bridge.sh",
+    "verify:apple-fm-bridge": "bun scripts/verify-packaged-apple-fm-bridge.ts",
     "build:ui": "bun build src/ui/main.ts --outdir resources/ui --target browser",
-    "build": "bun run build:ui && electrobun build",
+    "build": "bun run prepare:apple-fm-bridge && bun run build:ui && electrobun build",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "test": "bun test tests/*.test.ts",
     "verify": "bun run typecheck && bun test tests/*.test.ts && bun run build:ui && bun build src/bun/index.ts --outdir /tmp/khala-desktop-bun-build --target bun"

--- a/clients/khala-desktop/resources/.gitignore
+++ b/clients/khala-desktop/resources/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/clients/khala-desktop/scripts/prepare-apple-fm-bridge.sh
+++ b/clients/khala-desktop/scripts/prepare-apple-fm-bridge.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+desktop_root="$(cd "$script_dir/.." && pwd)"
+repo_root="$(cd "$desktop_root/../.." && pwd)"
+bridge_root="$repo_root/apps/pylon/swift/foundation-bridge"
+bridge_binary="$bridge_root/.build/release/foundation-bridge"
+target_dir="$desktop_root/resources/apple-fm-bridge"
+target="$target_dir/foundation-bridge"
+
+bash "$bridge_root/build.sh"
+
+if [[ ! -x "$bridge_binary" ]]; then
+  echo "foundation-bridge build did not produce an executable at $bridge_binary" >&2
+  exit 1
+fi
+
+mkdir -p "$target_dir"
+cp "$bridge_binary" "$target"
+chmod 755 "$target"
+printf 'Khala Desktop Apple FM bridge prepared: %s\n' "$target"

--- a/clients/khala-desktop/scripts/verify-packaged-apple-fm-bridge.ts
+++ b/clients/khala-desktop/scripts/verify-packaged-apple-fm-bridge.ts
@@ -1,0 +1,37 @@
+import { existsSync, statSync } from "node:fs"
+
+import {
+  verifyPackagedAppleFmBridge,
+  type AppleFmBridgeProbe,
+} from "../src/shared/apple-fm-packaging.js"
+
+const fsProbe: AppleFmBridgeProbe = (helperPath) => {
+  if (!existsSync(helperPath)) {
+    return { exists: false, nonEmpty: false, executable: false }
+  }
+  const stat = statSync(helperPath)
+  return {
+    exists: true,
+    nonEmpty: stat.size > 0,
+    executable: stat.isFile() && (stat.mode & 0o100) !== 0,
+  }
+}
+
+const result = verifyPackagedAppleFmBridge({ probe: fsProbe })
+
+if (result.ok) {
+  console.log(
+    `Packaged Apple FM bridge helper verified (${result.verifiedEnv}): ${result.verifiedPath}`,
+  )
+  process.exit(0)
+}
+
+console.error(
+  [
+    "Packaged Apple FM bridge helper is missing or unusable.",
+    "Khala Desktop Apple builds must bundle foundation-bridge before signing.",
+    "Checked candidates:",
+    ...result.failures.map((failure) => `- ${failure.bundleDir}: ${failure.reason}`),
+  ].join("\n"),
+)
+process.exit(1)

--- a/clients/khala-desktop/src/bun/apple-fm-sidecar.ts
+++ b/clients/khala-desktop/src/bun/apple-fm-sidecar.ts
@@ -1,0 +1,218 @@
+import { existsSync, statSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+
+import {
+  APPLE_FM_BRIDGE_RESOURCES_SUBPATH,
+} from "../shared/apple-fm-packaging.js"
+import {
+  buildKhalaAppleFmReadiness,
+  type KhalaAppleFmReadiness,
+  type PylonAppleFmStatusPublicInput,
+} from "../shared/apple-fm-readiness.js"
+
+type SidecarLaunchState = "idle" | "launching" | "running" | "failed" | "stopped" | "adopted"
+type HelperSource = "env" | "source-wrapper" | "source-build" | "packaged-resource"
+
+type DiscoveredAppleFmBridgeHelper = {
+  readonly path: string
+  readonly source: HelperSource
+}
+
+export type AppleFmSidecarHost = {
+  readonly readiness: () => Promise<KhalaAppleFmReadiness>
+  readonly stop: () => void
+}
+
+type AppleFmSidecarHostOptions = {
+  readonly env?: Readonly<Record<string, string | undefined>>
+  readonly platform?: NodeJS.Platform
+  readonly arch?: string
+  readonly resourcesDir?: string
+  readonly fetchFn?: typeof fetch
+  readonly spawn?: typeof Bun.spawn
+  readonly now?: () => string
+}
+
+const APPLE_FM_BRIDGE_DEFAULT_PORT = 11435
+
+const trim = (value: string | undefined): string | null => {
+  const trimmed = value?.trim() ?? ""
+  return trimmed.length === 0 ? null : trimmed
+}
+
+function ancestors(start: string): ReadonlyArray<string> {
+  const values: string[] = []
+  let current = start
+  while (true) {
+    values.push(current)
+    const next = dirname(current)
+    if (next === current) return values
+    current = next
+  }
+}
+
+function discoverAppleFmBridgeHelper(input: {
+  readonly cwd: string
+  readonly env: Readonly<Record<string, string | undefined>>
+  readonly resourcesDir?: string
+}): DiscoveredAppleFmBridgeHelper | null {
+  const explicit = trim(input.env.OPENAGENTS_APPLE_FM_BRIDGE_PATH)
+  if (explicit !== null) {
+    const path = resolve(explicit)
+    if (existsSync(path)) return { path, source: "env" }
+  }
+
+  if (input.resourcesDir !== undefined) {
+    const packaged = join(input.resourcesDir, APPLE_FM_BRIDGE_RESOURCES_SUBPATH)
+    if (existsSync(packaged)) return { path: packaged, source: "packaged-resource" }
+  }
+
+  for (const ancestor of ancestors(resolve(input.cwd))) {
+    for (const pylonRoot of [ancestor, join(ancestor, "apps", "pylon")]) {
+      const wrapper = join(pylonRoot, "bin", "foundation-bridge")
+      if (existsSync(wrapper)) return { path: wrapper, source: "source-wrapper" }
+
+      const sourceBuild = join(pylonRoot, "swift", "foundation-bridge", ".build", "release", "foundation-bridge")
+      if (existsSync(sourceBuild)) return { path: sourceBuild, source: "source-build" }
+    }
+  }
+
+  return null
+}
+
+function controlBaseUrlFromEnv(env: Readonly<Record<string, string | undefined>>): string {
+  const explicit = trim(env.PYLON_CONTROL_URL)
+  if (explicit !== null) return explicit.replace(/\/+$/, "")
+  const host = trim(env.PYLON_CONTROL_HOST) ?? "127.0.0.1"
+  const port = Number(trim(env.PYLON_CONTROL_PORT) ?? 4716)
+  return `http://${host}:${Number.isFinite(port) ? port : 4716}`
+}
+
+async function controlTokenFromEnv(
+  env: Readonly<Record<string, string | undefined>>,
+): Promise<string | null> {
+  const explicit = trim(env.PYLON_CONTROL_TOKEN)
+  if (explicit !== null) return explicit
+  const home = trim(env.PYLON_HOME)
+  if (home === null) return null
+  try {
+    const text = await Bun.file(join(home, "control-token")).text()
+    const token = text.trim()
+    return token.length >= 16 ? token : null
+  } catch {
+    return null
+  }
+}
+
+function helperExecutable(path: string): boolean {
+  try {
+    const stat = statSync(path)
+    return stat.isFile() && stat.size > 0 && (stat.mode & 0o100) !== 0
+  } catch {
+    return false
+  }
+}
+
+async function fetchPylonAppleFmStatus(input: {
+  readonly baseUrl: string
+  readonly token: string
+  readonly fetchFn: typeof fetch
+}): Promise<PylonAppleFmStatusPublicInput | null> {
+  try {
+    const response = await input.fetchFn(`${input.baseUrl}/command`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ type: "apple_fm.status" }),
+      signal: AbortSignal.timeout(1_500),
+    })
+    if (!response.ok) return null
+    const json = await response.json() as { ok?: unknown; result?: unknown }
+    return json.ok === true && typeof json.result === "object" && json.result !== null
+      ? json.result as PylonAppleFmStatusPublicInput
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function createAppleFmSidecarHost(
+  options: AppleFmSidecarHostOptions = {},
+): AppleFmSidecarHost {
+  const env = options.env ?? Bun.env
+  const platform = options.platform ?? process.platform
+  const arch = options.arch ?? process.arch
+  const resourcesDir = options.resourcesDir ?? (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+  const fetchFn = options.fetchFn ?? fetch
+  const spawn = options.spawn ?? Bun.spawn
+  const now = options.now ?? (() => new Date().toISOString())
+  const discoverOptions = {
+    cwd: process.cwd(),
+    env,
+    ...(resourcesDir === undefined ? {} : { resourcesDir }),
+  }
+  const helper = discoverAppleFmBridgeHelper(discoverOptions)
+  const supported = platform === "darwin" && arch === "arm64"
+  const executable = helper === null ? false : helperExecutable(helper.path)
+  let launchState: SidecarLaunchState = "idle"
+  let child: ReturnType<typeof Bun.spawn> | null = null
+
+  const start = () => {
+    if (!supported || helper === null || !executable || child !== null) return
+    if (helper.source !== "packaged-resource" && trim(env.OPENAGENTS_APPLE_FM_BRIDGE_PATH) === null) {
+      launchState = "adopted"
+      return
+    }
+    try {
+      launchState = "launching"
+      child = spawn([helper.path, "--port", String(APPLE_FM_BRIDGE_DEFAULT_PORT)], {
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "ignore",
+      })
+      launchState = "running"
+      void child.exited.then((exitCode) => {
+        child = null
+        launchState = exitCode === 0 ? "stopped" : "failed"
+      })
+    } catch {
+      launchState = "failed"
+      child = null
+    }
+  }
+
+  return {
+    async readiness() {
+      start()
+      const token = await controlTokenFromEnv(env)
+      const pylonStatus =
+        token === null
+          ? null
+          : await fetchPylonAppleFmStatus({
+              baseUrl: controlBaseUrlFromEnv(env),
+              token,
+              fetchFn,
+            })
+      return buildKhalaAppleFmReadiness({
+        platform: { platform, arch },
+        helperFound: helper !== null,
+        helperExecutable: executable,
+        helperLaunchState: launchState,
+        pylonControlConfigured: token !== null,
+        pylonStatus,
+        observedAt: now(),
+      })
+    },
+    stop() {
+      if (child !== null) {
+        child.kill()
+        child = null
+      }
+      if (launchState === "running" || launchState === "launching") {
+        launchState = "stopped"
+      }
+    },
+  }
+}

--- a/clients/khala-desktop/src/bun/index.ts
+++ b/clients/khala-desktop/src/bun/index.ts
@@ -9,16 +9,21 @@ import {
   KHALA_DESKTOP_RPC_MAX_REQUEST_TIME_MS,
   type KhalaDesktopRPCSchema,
 } from "../shared/rpc.js"
+import { createAppleFmSidecarHost } from "./apple-fm-sidecar.js"
 
 const baseUrl =
   Bun.env.PYLON_OPENAGENTS_BASE_URL ??
   Bun.env.OPENAGENTS_COM_BASE_URL ??
   KHALA_OPERATOR_DEFAULT_BASE_URL
+const appleFmSidecar = createAppleFmSidecarHost()
 
 const rpc = BrowserView.defineRPC<KhalaDesktopRPCSchema>({
   maxRequestTime: KHALA_DESKTOP_RPC_MAX_REQUEST_TIME_MS,
   handlers: {
     requests: {
+      async appleFmReadiness() {
+        return appleFmSidecar.readiness()
+      },
       async operatorDashboard() {
         return Effect.runPromise(
           fetchOperatorDashboard({
@@ -40,6 +45,10 @@ const rpc = BrowserView.defineRPC<KhalaDesktopRPCSchema>({
     },
     messages: {},
   },
+})
+
+process.on("beforeExit", () => {
+  appleFmSidecar.stop()
 })
 
 new BrowserWindow({

--- a/clients/khala-desktop/src/shared/apple-fm-packaging.ts
+++ b/clients/khala-desktop/src/shared/apple-fm-packaging.ts
@@ -1,0 +1,89 @@
+export const APPLE_FM_BRIDGE_HELPER_BASENAME = "foundation-bridge" as const
+export const APPLE_FM_BRIDGE_ELECTROBUN_COPY_SOURCE =
+  "resources/apple-fm-bridge/foundation-bridge" as const
+export const APPLE_FM_BRIDGE_ELECTROBUN_COPY_DEST =
+  "apple-fm-bridge/foundation-bridge" as const
+export const APPLE_FM_BRIDGE_RESOURCES_SUBPATH =
+  "app/apple-fm-bridge/foundation-bridge" as const
+
+const MACOS_APP_RESOURCES_RELATIVE = "Contents/Resources" as const
+
+export const KHALA_PACKAGED_APP_BUNDLE_CANDIDATES: ReadonlyArray<{
+  readonly env: "dev" | "canary" | "stable"
+  readonly bundleDir: string
+}> = [
+  { env: "dev", bundleDir: "build/dev-macos-arm64/Khala-dev.app" },
+  { env: "canary", bundleDir: "build/canary-macos-arm64/Khala-canary.app" },
+  { env: "stable", bundleDir: "build/stable-macos-arm64/Khala.app" },
+]
+
+function joinPosix(...segments: ReadonlyArray<string>): string {
+  return segments
+    .map((segment, index) =>
+      index === 0
+        ? segment.replace(/\/+$/, "")
+        : segment.replace(/^\/+|\/+$/g, ""),
+    )
+    .filter((segment) => segment.length > 0)
+    .join("/")
+}
+
+export function packagedAppleFmBridgePath(bundleDir: string): string {
+  return joinPosix(
+    bundleDir,
+    MACOS_APP_RESOURCES_RELATIVE,
+    APPLE_FM_BRIDGE_RESOURCES_SUBPATH,
+  )
+}
+
+export type AppleFmBridgeProbeResult = {
+  readonly exists: boolean
+  readonly nonEmpty: boolean
+  readonly executable: boolean
+}
+
+export type AppleFmBridgeProbe = (helperPath: string) => AppleFmBridgeProbeResult
+
+export type VerifyPackagedAppleFmBridgeInput = {
+  readonly candidates?: ReadonlyArray<{ readonly env: string; readonly bundleDir: string }>
+  readonly probe: AppleFmBridgeProbe
+}
+
+export type VerifyPackagedAppleFmBridgeResult = {
+  readonly ok: boolean
+  readonly verifiedPath: string | null
+  readonly verifiedEnv: string | null
+  readonly failures: ReadonlyArray<{ readonly bundleDir: string; readonly reason: string }>
+}
+
+export function verifyPackagedAppleFmBridge(
+  input: VerifyPackagedAppleFmBridgeInput,
+): VerifyPackagedAppleFmBridgeResult {
+  const candidates = input.candidates ?? KHALA_PACKAGED_APP_BUNDLE_CANDIDATES
+  const failures: Array<{ readonly bundleDir: string; readonly reason: string }> = []
+
+  for (const candidate of candidates) {
+    const helperPath = packagedAppleFmBridgePath(candidate.bundleDir)
+    const result = input.probe(helperPath)
+    if (!result.exists) {
+      failures.push({ bundleDir: candidate.bundleDir, reason: "helper missing" })
+      continue
+    }
+    if (!result.nonEmpty) {
+      failures.push({ bundleDir: candidate.bundleDir, reason: "helper is empty" })
+      continue
+    }
+    if (!result.executable) {
+      failures.push({ bundleDir: candidate.bundleDir, reason: "helper not executable" })
+      continue
+    }
+    return {
+      ok: true,
+      verifiedPath: helperPath,
+      verifiedEnv: candidate.env,
+      failures: [],
+    }
+  }
+
+  return { ok: false, verifiedPath: null, verifiedEnv: null, failures }
+}

--- a/clients/khala-desktop/src/shared/apple-fm-readiness.ts
+++ b/clients/khala-desktop/src/shared/apple-fm-readiness.ts
@@ -1,0 +1,219 @@
+export const KHALA_APPLE_FM_READINESS_SCHEMA =
+  "openagents.khala_desktop.apple_fm.readiness.v0.1" as const
+export const APPLE_FM_BACKEND_KIND = "apple_fm_bridge" as const
+export const APPLE_FM_LOCAL_PROFILE_ID = "apple-fm-local" as const
+export const APPLE_FM_MODEL_ID = "apple-foundation-model" as const
+export const APPLE_FM_CAPABILITY = "probe.backend.apple_fm_bridge" as const
+export const KHALA_APPLE_FM_TOKEN_PROVIDER =
+  "pylon-apple-fm-own-capacity" as const
+export const KHALA_APPLE_FM_DEMAND_SOURCE =
+  "khala_apple_fm_delegation" as const
+
+export type KhalaAppleFmSidecarState =
+  | "not_supported"
+  | "helper_missing"
+  | "launching"
+  | "adopted"
+  | "running"
+  | "ready"
+  | "unavailable"
+  | "failed"
+  | "stopped"
+
+export type AppleFmRuntimePlatform = {
+  readonly platform: string
+  readonly arch: string
+}
+
+export type PylonAppleFmStatusPublicInput = {
+  readonly [key: string]: unknown
+  readonly available?: unknown
+  readonly status?: unknown
+  readonly backendKind?: unknown
+  readonly profileId?: unknown
+  readonly model?: unknown
+  readonly capability?: unknown
+  readonly advertisedCapabilities?: unknown
+  readonly unavailableReason?: unknown
+  readonly message?: unknown
+  readonly blockerRefs?: unknown
+  readonly supervisor?: unknown
+}
+
+export type SanitizedPylonAppleFmStatus = {
+  readonly available: boolean
+  readonly status: string
+  readonly backendKind: string
+  readonly profileId: string
+  readonly model: string
+  readonly capability: string
+  readonly advertisedCapabilities: ReadonlyArray<string>
+  readonly unavailableReason: string | null
+  readonly message: string | null
+  readonly blockerRefs: ReadonlyArray<string>
+  readonly supervisor: {
+    readonly health: string
+    readonly phase: string
+    readonly supervised: boolean
+    readonly blockerRefs: ReadonlyArray<string>
+    readonly contentRedacted: true
+  } | null
+}
+
+export type KhalaAppleFmReadiness = {
+  readonly schema: typeof KHALA_APPLE_FM_READINESS_SCHEMA
+  readonly kind: "khala_desktop_apple_fm_readiness"
+  readonly supported: boolean
+  readonly available: boolean
+  readonly state: KhalaAppleFmSidecarState
+  readonly backendKind: typeof APPLE_FM_BACKEND_KIND
+  readonly profileId: typeof APPLE_FM_LOCAL_PROFILE_ID
+  readonly model: typeof APPLE_FM_MODEL_ID
+  readonly capability: typeof APPLE_FM_CAPABILITY
+  readonly provider: typeof KHALA_APPLE_FM_TOKEN_PROVIDER
+  readonly demandKind: "own_capacity"
+  readonly demandSource: typeof KHALA_APPLE_FM_DEMAND_SOURCE
+  readonly usageTruth: "estimated"
+  readonly pylonControlConfigured: boolean
+  readonly pylon: SanitizedPylonAppleFmStatus | null
+  readonly blockerRefs: ReadonlyArray<string>
+  readonly observedAt: string
+  readonly contentRedacted: true
+}
+
+export type BuildKhalaAppleFmReadinessInput = {
+  readonly platform: AppleFmRuntimePlatform
+  readonly helperFound: boolean
+  readonly helperExecutable?: boolean
+  readonly helperLaunchState?: "idle" | "launching" | "running" | "failed" | "stopped" | "adopted"
+  readonly pylonControlConfigured?: boolean
+  readonly pylonStatus?: PylonAppleFmStatusPublicInput | null
+  readonly observedAt?: string
+}
+
+const stringArray = (value: unknown): ReadonlyArray<string> =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+    : []
+
+const optionalString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim() !== "" ? value.trim() : null
+
+const requiredString = (value: unknown, fallback: string): string =>
+  optionalString(value) ?? fallback
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+
+export function appleFmSupportedOn(platform: AppleFmRuntimePlatform): boolean {
+  return platform.platform === "darwin" && platform.arch === "arm64"
+}
+
+export function sanitizePylonAppleFmStatus(
+  input: PylonAppleFmStatusPublicInput,
+): SanitizedPylonAppleFmStatus {
+  const supervisor = asRecord(input.supervisor)
+  const supervisorStatus =
+    Object.keys(supervisor).length === 0
+      ? null
+      : {
+          health: requiredString(supervisor.health, "unknown"),
+          phase: requiredString(supervisor.phase, "unknown"),
+          supervised: supervisor.supervised === true,
+          blockerRefs: stringArray(supervisor.blockerRefs),
+          contentRedacted: true as const,
+        }
+
+  return {
+    available: input.available === true,
+    status: requiredString(input.status, input.available === true ? "ready" : "unavailable"),
+    backendKind: requiredString(input.backendKind, APPLE_FM_BACKEND_KIND),
+    profileId: requiredString(input.profileId, APPLE_FM_LOCAL_PROFILE_ID),
+    model: requiredString(input.model, APPLE_FM_MODEL_ID),
+    capability: requiredString(input.capability, APPLE_FM_CAPABILITY),
+    advertisedCapabilities: stringArray(input.advertisedCapabilities),
+    unavailableReason: optionalString(input.unavailableReason),
+    message: optionalString(input.message),
+    blockerRefs: stringArray(input.blockerRefs),
+    supervisor: supervisorStatus,
+  }
+}
+
+export function buildKhalaAppleFmReadiness(
+  input: BuildKhalaAppleFmReadinessInput,
+): KhalaAppleFmReadiness {
+  const supported = appleFmSupportedOn(input.platform)
+  const pylon =
+    input.pylonStatus === null || input.pylonStatus === undefined
+      ? null
+      : sanitizePylonAppleFmStatus(input.pylonStatus)
+  const pylonReady =
+    pylon !== null &&
+    pylon.available &&
+    pylon.status === "ready" &&
+    pylon.advertisedCapabilities.includes(pylon.capability) &&
+    pylon.blockerRefs.length === 0
+  const helperUsable = input.helperFound && input.helperExecutable !== false
+
+  const blockers = new Set<string>()
+  let state: KhalaAppleFmSidecarState = "unavailable"
+
+  if (!supported) {
+    state = "not_supported"
+    blockers.add("blocker.khala_desktop.apple_fm.unsupported_platform")
+  } else if (!input.helperFound) {
+    state = "helper_missing"
+    blockers.add("blocker.khala_desktop.apple_fm.helper_missing")
+  } else if (!helperUsable) {
+    state = "helper_missing"
+    blockers.add("blocker.khala_desktop.apple_fm.helper_not_executable")
+  } else if (pylonReady) {
+    state = "ready"
+  } else if (input.helperLaunchState === "adopted") {
+    state = "adopted"
+  } else if (input.helperLaunchState === "running") {
+    state = "running"
+  } else if (input.helperLaunchState === "launching") {
+    state = "launching"
+  } else if (input.helperLaunchState === "failed") {
+    state = "failed"
+    blockers.add("blocker.khala_desktop.apple_fm.sidecar_failed")
+  } else if (input.helperLaunchState === "stopped") {
+    state = "stopped"
+    blockers.add("blocker.khala_desktop.apple_fm.sidecar_stopped")
+  }
+
+  if (supported && helperUsable && !pylonReady) {
+    if (input.pylonControlConfigured === true) {
+      blockers.add("blocker.khala_desktop.apple_fm.pylon_not_ready")
+    } else {
+      blockers.add("blocker.khala_desktop.apple_fm.pylon_control_unconfigured")
+    }
+  }
+
+  for (const blockerRef of pylon?.blockerRefs ?? []) blockers.add(blockerRef)
+  for (const blockerRef of pylon?.supervisor?.blockerRefs ?? []) blockers.add(blockerRef)
+
+  return {
+    schema: KHALA_APPLE_FM_READINESS_SCHEMA,
+    kind: "khala_desktop_apple_fm_readiness",
+    supported,
+    available: state === "ready",
+    state,
+    backendKind: APPLE_FM_BACKEND_KIND,
+    profileId: APPLE_FM_LOCAL_PROFILE_ID,
+    model: APPLE_FM_MODEL_ID,
+    capability: APPLE_FM_CAPABILITY,
+    provider: KHALA_APPLE_FM_TOKEN_PROVIDER,
+    demandKind: "own_capacity",
+    demandSource: KHALA_APPLE_FM_DEMAND_SOURCE,
+    usageTruth: "estimated",
+    pylonControlConfigured: input.pylonControlConfigured === true,
+    pylon,
+    blockerRefs: [...blockers].sort(),
+    observedAt: input.observedAt ?? new Date().toISOString(),
+    contentRedacted: true,
+  }
+}

--- a/clients/khala-desktop/src/shared/operator-dashboard.ts
+++ b/clients/khala-desktop/src/shared/operator-dashboard.ts
@@ -97,6 +97,14 @@ export type OperatorFetchOptions = {
   readonly fetch?: typeof fetch
 }
 
+export class KhalaOperatorDashboardFetchError extends S.TaggedErrorClass<KhalaOperatorDashboardFetchError>()(
+  "KhalaOperatorDashboardFetchError",
+  {
+    cause: S.Unknown,
+    message: S.String,
+  },
+) {}
+
 const asRecord = (value: unknown): Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -284,9 +292,13 @@ const fetchJson = (options: {
   readonly fetch: typeof fetch
   readonly path: string
   readonly token: string
-}): Effect.Effect<unknown, Error> =>
+}): Effect.Effect<unknown, KhalaOperatorDashboardFetchError> =>
   Effect.tryPromise({
-    catch: (error: unknown) => error instanceof Error ? error : new Error(String(error)),
+    catch: (error: unknown) =>
+      new KhalaOperatorDashboardFetchError({
+        cause: error,
+        message: error instanceof Error ? error.message : String(error),
+      }),
     try: async () => {
       const response = await options.fetch(`${options.baseUrl}${options.path}`, {
         headers: {
@@ -331,7 +343,7 @@ export const fetchOperatorDashboard = (
       }),
     }
   }).pipe(
-    Effect.catch((error: Error) =>
+    Effect.catch((error: KhalaOperatorDashboardFetchError) =>
       Effect.succeed({
         ok: false as const,
         error: error.message,

--- a/clients/khala-desktop/src/shared/rpc.ts
+++ b/clients/khala-desktop/src/shared/rpc.ts
@@ -1,9 +1,11 @@
+import type { KhalaAppleFmReadiness } from "./apple-fm-readiness.js"
 import type { KhalaDesktopDashboardResult } from "./operator-dashboard.js"
 
 export const KHALA_DESKTOP_RPC_MAX_REQUEST_TIME_MS = 60_000
 
 export type KhalaDesktopRPCSchema = {
   requests: {
+    appleFmReadiness(): Promise<KhalaAppleFmReadiness>
     operatorDashboard(): Promise<KhalaDesktopDashboardResult>
     openExternal(input: { readonly url: string }): Promise<{ readonly ok: true }>
   }

--- a/clients/khala-desktop/src/ui/main.ts
+++ b/clients/khala-desktop/src/ui/main.ts
@@ -1,12 +1,12 @@
 import { Electroview } from "electrobun/view"
 
+import type { KhalaAppleFmReadiness } from "../shared/apple-fm-readiness.js"
 import {
   KHALA_OPERATOR_POLL_INTERVAL_MS,
   type DashboardAccount,
   type DashboardPylon,
   type DashboardSession,
   type KhalaDesktopDashboard,
-  type KhalaDesktopDashboardResult,
 } from "../shared/operator-dashboard.js"
 import {
   KHALA_DESKTOP_RPC_MAX_REQUEST_TIME_MS,
@@ -26,7 +26,11 @@ new Electroview({ rpc })
 
 type ViewState =
   | { readonly status: "loading" }
-  | { readonly status: "ready"; readonly dashboard: KhalaDesktopDashboard }
+  | {
+      readonly status: "ready"
+      readonly appleFmReadiness: KhalaAppleFmReadiness
+      readonly dashboard: KhalaDesktopDashboard
+    }
   | { readonly status: "error"; readonly error: string; readonly observedAt: string }
 
 const app = document.querySelector<HTMLElement>("#app")
@@ -53,6 +57,9 @@ const formatElapsed = (elapsedMs: number): string => {
 
 const readinessLabel = (readiness: DashboardAccount["readiness"]): string =>
   readiness.replace(/_/g, " ")
+
+const appleFmStateLabel = (state: KhalaAppleFmReadiness["state"]): string =>
+  state.replace(/_/g, " ")
 
 const escapeHtml = (value: string): string =>
   value.replace(/[&<>"']/g, character => {
@@ -110,7 +117,35 @@ const sessionRow = (session: DashboardSession): string => `
 const emptyRow = (message: string, columns: number): string =>
   `<tr><td class="empty-row" colspan="${columns}">${escapeHtml(message)}</td></tr>`
 
-const renderDashboard = (dashboard: KhalaDesktopDashboard): string => `
+const renderAppleFmReadiness = (readiness: KhalaAppleFmReadiness): string => {
+  const pylonStatus = readiness.pylon === null
+    ? "not connected"
+    : readiness.pylon.available
+      ? readiness.pylon.status
+      : readiness.pylon.unavailableReason ?? readiness.pylon.status
+  const blockers = readiness.blockerRefs.length === 0
+    ? "<span class=\"muted\">none</span>"
+    : readiness.blockerRefs.map((ref: string) => `<code>${escapeHtml(ref)}</code>`).join("")
+  return `
+    <section class="panel">
+      <div class="section-heading">
+        <h2>Apple FM Sidecar</h2>
+        <span>${escapeHtml(readiness.provider)}</span>
+      </div>
+      <div class="status-grid">
+        <article><span>State</span><strong><span class="pill ${readiness.available ? "pill-ready" : "pill-warn"}">${escapeHtml(appleFmStateLabel(readiness.state))}</span></strong></article>
+        <article><span>Pylon</span><strong>${escapeHtml(pylonStatus)}</strong></article>
+        <article><span>Demand</span><strong>${escapeHtml(readiness.demandSource)}</strong></article>
+        <article><span>Usage truth</span><strong>${escapeHtml(readiness.usageTruth)}</strong></article>
+      </div>
+      <div class="blocker-list">${blockers}</div>
+    </section>`
+}
+
+const renderDashboard = (
+  dashboard: KhalaDesktopDashboard,
+  appleFmReadiness: KhalaAppleFmReadiness,
+): string => `
   <section class="hero">
     <div>
       <p class="kicker">Khala operator desktop</p>
@@ -130,6 +165,8 @@ const renderDashboard = (dashboard: KhalaDesktopDashboard): string => `
     <article><span>Ready accounts</span><strong>${formatNumber(dashboard.totals.readyAccounts)}</strong></article>
     <article><span>Tokens today</span><strong>${formatNumber(dashboard.totals.tokensToday)}</strong></article>
   </section>
+
+  ${renderAppleFmReadiness(appleFmReadiness)}
 
   <section class="panel">
     <div class="section-heading">
@@ -194,13 +231,16 @@ const render = (state: ViewState): void => {
     return
   }
 
-  app.innerHTML = renderDashboard(state.dashboard)
+  app.innerHTML = renderDashboard(state.dashboard, state.appleFmReadiness)
 }
 
 const load = async (): Promise<void> => {
-  const result: KhalaDesktopDashboardResult = await rpc.request.operatorDashboard()
+  const [result, appleFmReadiness] = await Promise.all([
+    rpc.request.operatorDashboard(),
+    rpc.request.appleFmReadiness(),
+  ])
   if (result.ok) {
-    render({ status: "ready", dashboard: result.dashboard })
+    render({ status: "ready", dashboard: result.dashboard, appleFmReadiness })
   } else {
     render({ status: "error", error: result.error, observedAt: result.observedAt })
   }

--- a/clients/khala-desktop/src/ui/styles.css
+++ b/clients/khala-desktop/src/ui/styles.css
@@ -104,6 +104,55 @@ h2 {
   margin: 18px 0;
 }
 
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  background: #1d2530;
+}
+
+.status-grid article {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 16px 18px;
+  background: rgba(12, 15, 19, 0.92);
+}
+
+.status-grid span {
+  color: #aeb9c6;
+  font-size: 12px;
+}
+
+.status-grid strong {
+  min-width: 0;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.blocker-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid #1d2530;
+}
+
+.blocker-list code {
+  padding: 5px 8px;
+  border: 1px solid #2b3646;
+  border-radius: 6px;
+  color: #c9d2dd;
+  font-size: 11px;
+}
+
+.muted {
+  color: #aeb9c6;
+  font-size: 12px;
+}
+
 .metrics article,
 .panel {
   background: rgba(12, 15, 19, 0.92);
@@ -250,6 +299,10 @@ code,
   }
 
   .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .status-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/clients/khala-desktop/tests/apple-fm-packaging.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-packaging.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  APPLE_FM_BRIDGE_ELECTROBUN_COPY_DEST,
+  APPLE_FM_BRIDGE_ELECTROBUN_COPY_SOURCE,
+  APPLE_FM_BRIDGE_RESOURCES_SUBPATH,
+  KHALA_PACKAGED_APP_BUNDLE_CANDIDATES,
+  packagedAppleFmBridgePath,
+  verifyPackagedAppleFmBridge,
+  type AppleFmBridgeProbe,
+} from "../src/shared/apple-fm-packaging.js"
+
+const healthy: AppleFmBridgeProbe = () => ({
+  exists: true,
+  nonEmpty: true,
+  executable: true,
+})
+
+describe("khala desktop Apple FM packaging", () => {
+  test("electrobun copy source and destination land at Pylon's resource path", () => {
+    expect(APPLE_FM_BRIDGE_ELECTROBUN_COPY_SOURCE).toBe(
+      "resources/apple-fm-bridge/foundation-bridge",
+    )
+    expect(`app/${APPLE_FM_BRIDGE_ELECTROBUN_COPY_DEST}`).toBe(
+      APPLE_FM_BRIDGE_RESOURCES_SUBPATH,
+    )
+  })
+
+  test("packaged helper path stays inside the Khala app bundle", () => {
+    expect(packagedAppleFmBridgePath("build/stable-macos-arm64/Khala.app")).toBe(
+      "build/stable-macos-arm64/Khala.app/Contents/Resources/app/apple-fm-bridge/foundation-bridge",
+    )
+  })
+
+  test("verifier accepts the first non-empty executable helper", () => {
+    const result = verifyPackagedAppleFmBridge({ probe: healthy })
+    expect(result.ok).toBe(true)
+    expect(result.verifiedPath).toContain("Khala-dev.app")
+  })
+
+  test("verifier rejects missing, empty, and non-executable helpers", () => {
+    const missing = verifyPackagedAppleFmBridge({
+      probe: () => ({ exists: false, nonEmpty: false, executable: false }),
+    })
+    expect(missing.ok).toBe(false)
+    expect(missing.failures).toHaveLength(KHALA_PACKAGED_APP_BUNDLE_CANDIDATES.length)
+    expect(missing.failures.every((failure) => failure.reason === "helper missing")).toBe(true)
+
+    const empty = verifyPackagedAppleFmBridge({
+      probe: () => ({ exists: true, nonEmpty: false, executable: true }),
+    })
+    expect(empty.ok).toBe(false)
+    expect(empty.failures.every((failure) => failure.reason === "helper is empty")).toBe(true)
+
+    const nonExecutable = verifyPackagedAppleFmBridge({
+      probe: () => ({ exists: true, nonEmpty: true, executable: false }),
+    })
+    expect(nonExecutable.ok).toBe(false)
+    expect(
+      nonExecutable.failures.every((failure) => failure.reason === "helper not executable"),
+    ).toBe(true)
+  })
+})

--- a/clients/khala-desktop/tests/apple-fm-readiness.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-readiness.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  APPLE_FM_CAPABILITY,
+  buildKhalaAppleFmReadiness,
+  sanitizePylonAppleFmStatus,
+} from "../src/shared/apple-fm-readiness.js"
+
+describe("khala desktop Apple FM readiness", () => {
+  test("does not advertise Apple FM capacity from hardware alone", () => {
+    const readiness = buildKhalaAppleFmReadiness({
+      platform: { platform: "darwin", arch: "arm64" },
+      helperFound: true,
+      helperExecutable: true,
+      helperLaunchState: "running",
+      pylonControlConfigured: false,
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
+    expect(readiness.available).toBe(false)
+    expect(readiness.state).toBe("running")
+    expect(readiness.blockerRefs).toContain(
+      "blocker.khala_desktop.apple_fm.pylon_control_unconfigured",
+    )
+  })
+
+  test("reports ready only after live Pylon Apple FM status is ready", () => {
+    const readiness = buildKhalaAppleFmReadiness({
+      platform: { platform: "darwin", arch: "arm64" },
+      helperFound: true,
+      helperExecutable: true,
+      helperLaunchState: "running",
+      pylonControlConfigured: true,
+      pylonStatus: {
+        available: true,
+        status: "ready",
+        advertisedCapabilities: [APPLE_FM_CAPABILITY, "probe.blueprint.tool_menu"],
+        blockerRefs: [],
+      },
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
+    expect(readiness.available).toBe(true)
+    expect(readiness.state).toBe("ready")
+    expect(readiness.provider).toBe("pylon-apple-fm-own-capacity")
+    expect(readiness.demandSource).toBe("khala_apple_fm_delegation")
+    expect(readiness.usageTruth).toBe("estimated")
+  })
+
+  test("keeps Pylon status public-safe and omits loopback paths and tokens", () => {
+    const status = sanitizePylonAppleFmStatus({
+      available: false,
+      status: "unreachable",
+      baseUrl: "http://127.0.0.1:4716",
+      helperPath: "/Users/example/app/apple-fm-bridge/foundation-bridge",
+      controlToken: "secret-token",
+      callbackUrl: "http://127.0.0.1/callback",
+      blockerRefs: ["blocker.pylon.apple_fm.bridge_unreachable"],
+      supervisor: {
+        health: "recovering",
+        phase: "backoff",
+        supervised: true,
+        blockerRefs: [],
+      },
+    })
+
+    const json = JSON.stringify(status)
+    expect(json).not.toContain("127.0.0.1")
+    expect(json).not.toContain("/Users/example")
+    expect(json).not.toContain("secret-token")
+    expect(json).not.toContain("callback")
+    expect(status.blockerRefs).toEqual(["blocker.pylon.apple_fm.bridge_unreachable"])
+    expect(status.supervisor?.contentRedacted).toBe(true)
+  })
+
+  test("unsupported platforms fail closed", () => {
+    const readiness = buildKhalaAppleFmReadiness({
+      platform: { platform: "linux", arch: "x64" },
+      helperFound: true,
+      helperExecutable: true,
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
+    expect(readiness.supported).toBe(false)
+    expect(readiness.available).toBe(false)
+    expect(readiness.state).toBe("not_supported")
+  })
+})


### PR DESCRIPTION
## Summary

- Bundles the Apple FM `foundation-bridge` helper into Khala Desktop's Electrobun Apple resources via a build-time prepare script and packaged-helper verifier.
- Adds a Bun-host sidecar/readiness surface that launches/adopts only on macOS arm64, delegates readiness truth to Pylon `apple_fm.status`, and keeps helper paths, tokens, URLs, prompts, and local files out of the webview projection.
- Renders public-safe Apple FM sidecar status in the Khala Desktop dashboard and adds focused packaging/readiness tests.

## Verification

- `bun run --cwd clients/khala-desktop verify`
- `bun run --cwd apps/openagents.com check:deploy`

Addresses #6973.
