### PR TITLE
feat(artanis-web): rebuild fleet map task board

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.story.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.story.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from 'vitest'
+import type { PublicActivityTimelineEnvelope } from '@openagentsinc/public-activity-timeline'
 
 import { PublicAgentRoute } from '../../../route'
 import {
+  SucceededLoadPublicActivityTimeline,
   SucceededLoadPublicAgentGoal,
   SucceededLoadPublicKhalaTokensServedHistory,
+  SucceededLoadPublicPylonStats,
 } from '../message'
-import { PublicKhalaTokensServedHistory, init } from '../model'
+import {
+  PublicKhalaTokensServedHistory,
+  init,
+  type PublicPylonStats,
+} from '../model'
 import { update } from '../update'
 import * as PublicAgent from './publicAgent'
 
@@ -20,6 +27,209 @@ const sampleHistory = PublicKhalaTokensServedHistory.make({
     { day: '2026-06-27', tokensServed: 100_000_000 },
   ],
 })
+
+const samplePylonStats: PublicPylonStats = {
+  available: true,
+  asOfLabel: '2026-06-27T17:00:00.000Z',
+  asOfUnixMs: 1_782_580_800_000,
+  caveatRefs: ['caveat.public.assignment_ready_is_not_payout_evidence'],
+  earningLaunchGate: {
+    blockedClaimRefs: [],
+    blockerRefs: [],
+    caveatRefs: [],
+    gateRef: 'gate.public.pylon.earning',
+    publicEarningCopyAllowed: true,
+    requiredAssignmentReadyPylonsPresent: true,
+    requiredOnlinePylonsPresent: true,
+    requiredWalletReadyPylonsPresent: true,
+    sourceRefs: ['source.public.pylon_stats'],
+    state: 'ready',
+    stateLabel: 'Ready',
+  },
+  error: null,
+  hostedNexusRelayUrl: 'wss://relay.openagents.example',
+  minimumClientVersion: '0.2.5',
+  nexusAcceptedWorkPayoutReceiptRefs: [],
+  nexusAcceptedWorkPayoutSatsPaid24h: null,
+  nexusAcceptedWorkPayoutSatsPaidTotal: null,
+  nexusAcceptedWorkSettlementGate: {
+    blockerRefs: [],
+    caveatRefs: ['caveat.public.receipt_backed_totals_only'],
+    gateRef: 'gate.public.pylon.accepted_work_settlement',
+    publicPaidWorkTotalsAllowed: false,
+    receiptBackedTotalsAvailable: false,
+    settledReceiptRefs: [],
+    sourceRefs: ['source.public.pylon_stats'],
+    state: 'blocked',
+    stateLabel: 'Blocked',
+  },
+  nexusPayoutSatsPaidTotal: null,
+  publicRealSatsSettled24h: null,
+  publicRealSatsSettledTotal: null,
+  pylonSessionsOnlineNow: 2,
+  pylonsAssignmentReadyNow: 2,
+  pylonsByClientVersion: { '0.2.5': 3 },
+  pylonsByResourceMode: { coding: 2, training: 1 },
+  pylonsOnlineNow: 3,
+  pylonsRegisteredTotal: 7,
+  pylonsSeen24h: 4,
+  pylonsWalletReadyNow: 2,
+  recentPylons: [
+    {
+      assignmentReadyNow: true,
+      clientVersion: '0.2.5',
+      eligibleProductCount: 3,
+      lastHeartbeatAgeSeconds: 12,
+      lastSeenAtLabel: '2026-06-27T16:59:48.000Z',
+      lastSeenAtUnixMs: 1_782_580_788_000,
+      nodeLabel: 'codex-east-1',
+      nostrPubkeyShort: 'npub-east',
+      onlineNow: true,
+      ownerAgentRef: null,
+      products: ['codex_agent_task'],
+      pylonRef: 'pylon.public.codex-east-1',
+      readyModel: 'openagents/pylon-codex',
+      relayUrls: ['wss://relay.openagents.example'],
+      runtimeState: 'online',
+      tippingAvailable: false,
+      tipEndpoint: null,
+      walletReadyNow: true,
+    },
+    {
+      assignmentReadyNow: true,
+      clientVersion: '0.2.5',
+      eligibleProductCount: 2,
+      lastHeartbeatAgeSeconds: 22,
+      lastSeenAtLabel: '2026-06-27T16:59:38.000Z',
+      lastSeenAtUnixMs: 1_782_580_778_000,
+      nodeLabel: 'codex-west-2',
+      nostrPubkeyShort: 'npub-west',
+      onlineNow: true,
+      ownerAgentRef: null,
+      products: ['codex_agent_task'],
+      pylonRef: 'pylon.public.codex-west-2',
+      readyModel: 'openagents/pylon-codex',
+      relayUrls: ['wss://relay.openagents.example'],
+      runtimeState: 'online',
+      tippingAvailable: false,
+      tipEndpoint: null,
+      walletReadyNow: true,
+    },
+    {
+      assignmentReadyNow: false,
+      clientVersion: '0.2.5',
+      eligibleProductCount: 1,
+      lastHeartbeatAgeSeconds: 45,
+      lastSeenAtLabel: '2026-06-27T16:59:15.000Z',
+      lastSeenAtUnixMs: 1_782_580_755_000,
+      nodeLabel: 'training-lab-1',
+      nostrPubkeyShort: 'npub-lab',
+      onlineNow: true,
+      ownerAgentRef: null,
+      products: ['training_trace'],
+      pylonRef: 'pylon.public.training-lab-1',
+      readyModel: 'openagents/training',
+      relayUrls: ['wss://relay.openagents.example'],
+      runtimeState: 'online',
+      tippingAvailable: false,
+      tipEndpoint: null,
+      walletReadyNow: false,
+    },
+  ],
+  sellablePylonsOnlineNow: 2,
+  sourceRefs: ['source.public.pylon_stats'],
+  sourceUrl: 'https://openagents.example/api/public/pylon-stats',
+  status: 'live',
+  trainingAcceptedContributors: 9,
+  trainingAssignedContributors: 12,
+  trainingModelProgressContributors: 4,
+  treasuryPayoutCount24h: null,
+  treasuryPayoutCountTotal: null,
+  treasuryPayoutSatsPaid24h: null,
+  treasuryPayoutSatsPaidTotal: null,
+}
+
+const sampleActivityTimeline: PublicActivityTimelineEnvelope = {
+  events: [
+    {
+      actorRef: 'pylon.public.codex-east-1',
+      blockerRefs: [],
+      caveatRefs: [],
+      cursor:
+        '2026-06-27T16:59:55.000Z:pylon_presence:event.public.assignment_ready.codex-east-1',
+      eventRef: 'event.public.assignment_ready.codex-east-1',
+      kind: 'assignment_ready',
+      refs: ['pylon.public.codex-east-1'],
+      sourceKind: 'pylon_presence',
+      sourceRefs: ['pylon.public.codex-east-1'],
+      state: 'ready',
+      text: 'Codex East is ready for a public coding assignment.',
+      ts: '2026-06-27T16:59:55.000Z',
+    },
+    {
+      actorRef: 'pylon.public.codex-west-2',
+      blockerRefs: [],
+      caveatRefs: [],
+      cursor:
+        '2026-06-27T16:59:45.000Z:training_window:event.public.work_claimed.6656',
+      eventRef: 'event.public.work_claimed.6656',
+      kind: 'work_claimed',
+      refs: ['pylon.public.codex-west-2', 'issue.public.github.6656'],
+      runRef: 'run.public.issue.6656',
+      sourceKind: 'training_window',
+      sourceRefs: ['issue.public.github.6656'],
+      state: 'claimed',
+      targetRef: 'issue.public.github.6656',
+      text: 'Issue 6656 fleet board work claimed.',
+      ts: '2026-06-27T16:59:45.000Z',
+    },
+    {
+      blockerRefs: [],
+      caveatRefs: [],
+      cursor:
+        '2026-06-27T16:59:30.000Z:training_verification:event.public.verification_queued.6656',
+      eventRef: 'event.public.verification_queued.6656',
+      kind: 'verification_queued',
+      refs: ['verification.public.issue.6656'],
+      runRef: 'run.public.issue.6656',
+      sourceKind: 'training_verification',
+      sourceRefs: ['verification.public.issue.6656'],
+      state: 'queued',
+      targetRef: 'verification.public.issue.6656',
+      text: 'Issue 6656 public verification queued.',
+      ts: '2026-06-27T16:59:30.000Z',
+    },
+  ],
+  generatedAt: '2026-06-27T17:00:00.000Z',
+  nextCursor: null,
+  range: {
+    filterKinds: [],
+    from: '2026-06-27T16:59:00.000Z',
+    limit: 60,
+    since: null,
+    to: '2026-06-27T17:00:00.000Z',
+  },
+  schemaVersion: 'openagents.public_activity_timeline.v1',
+  sourceLag: [
+    {
+      blockerRefs: [],
+      caveatRefs: [],
+      lagSeconds: 0,
+      latestSourceEventAt: '2026-06-27T16:59:55.000Z',
+      maxStalenessSeconds: 300,
+      observedAt: '2026-06-27T17:00:00.000Z',
+      sourceKind: 'pylon_presence',
+      sourceRefs: ['pylon.public.codex-east-1'],
+      status: 'current',
+    },
+  ],
+  staleness: {
+    composition: 'live_at_read',
+    contractVersion: 'projection_staleness.v1',
+    maxStalenessSeconds: 0,
+    rebuildsOn: ['public_activity_timeline_read'],
+  },
+}
 
 const loadedArtanisModel = () => {
   const [withGoal] = update(
@@ -53,7 +263,17 @@ const loadedArtanisModel = () => {
     SucceededLoadPublicKhalaTokensServedHistory({ history: sampleHistory }),
   )
 
-  return withHistory
+  const [withPylons] = update(
+    withHistory,
+    SucceededLoadPublicPylonStats({ stats: samplePylonStats }),
+  )
+
+  const [withTimeline] = update(
+    withPylons,
+    SucceededLoadPublicActivityTimeline({ envelope: sampleActivityTimeline }),
+  )
+
+  return withTimeline
 }
 
 describe('public Artanis Pulse panel', () => {
@@ -75,6 +295,20 @@ describe('public Artanis Pulse panel', () => {
     expect(markup).toContain('Gap 1.1B')
     expect(markup).toContain('2026-06-27: 100,000,000 tokens')
     expect(markup).toContain('no user, prompt, or provider rows exposed')
+    expect(markup).toContain('artanis-fleet-map-task-board')
+    expect(markup).toContain('Fleet map')
+    expect(markup).toContain('Pylons, slots, active tasks')
+    expect(markup).toContain('codex-east-1')
+    expect(markup).toContain('codex-west-2')
+    expect(markup).toContain('assignment-ready')
+    expect(markup).toContain('3 online / 2 wallet-ready / 2 assignment-ready')
+    expect(markup).toContain('Active Task Board')
+    expect(markup).toContain('Ready')
+    expect(markup).toContain('Claimed')
+    expect(markup).toContain('Verifying')
+    expect(markup).toContain('Issue 6656 fleet board work claimed.')
+    expect(markup).toContain('Issue 6656 public verification queued.')
+    expect(markup).toContain('Only public activity rows are shown')
     expect(markup).toContain('artanis-virtual-merge-queue')
     expect(markup).toContain('Virtual merge queue')
     expect(markup).toContain('Projected branch base for parallel agents')

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
@@ -1580,6 +1580,375 @@ const fleetShippingView = (model: PublicActivityTimelineModel): Html => {
   return fleetShippingMessageView('Loading live fleet activity.')
 }
 
+type FleetMapSlot = Readonly<{
+  index: number
+  pylon: PublicRecentPylon | null
+}>
+
+const fleetMapSlots = (
+  stats: PublicPylonStats | null,
+): ReadonlyArray<FleetMapSlot> => {
+  const pylons = stats?.recentPylons ?? []
+  const visibleSlotCount =
+    stats === null
+      ? 8
+      : Math.max(
+          8,
+          Math.min(
+            24,
+            stats.pylonsOnlineNow,
+            pylons.length || stats.pylonsOnlineNow,
+          ),
+        )
+
+  return globalThis.Array.from({ length: visibleSlotCount }, (_, index) => ({
+    index,
+    pylon: pylons[index] ?? null,
+  }))
+}
+
+const pylonSlotState = (
+  pylon: PublicRecentPylon | null,
+): 'assignment' | 'wallet' | 'online' | 'empty' => {
+  if (pylon === null) {
+    return 'empty'
+  }
+  if (pylon.assignmentReadyNow === true) {
+    return 'assignment'
+  }
+  if (pylon.walletReadyNow === true) {
+    return 'wallet'
+  }
+  return pylon.onlineNow === false ? 'empty' : 'online'
+}
+
+const pylonSlotToneClass: Record<ReturnType<typeof pylonSlotState>, string> = {
+  assignment: 'border-[#00c853]/60 bg-[#06140a] text-[#9ad6b7]',
+  empty: 'border-[#1b1b1b] bg-black text-white/25',
+  online: 'border-[#333] bg-[#0a0a0a] text-white/55',
+  wallet: 'border-[#ffb400]/55 bg-[#171102] text-[#f0d28a]',
+}
+
+const pylonSlotStateLabel: Record<ReturnType<typeof pylonSlotState>, string> = {
+  assignment: 'assignment-ready',
+  empty: 'empty',
+  online: 'online',
+  wallet: 'wallet-ready',
+}
+
+const pylonSlotView = (slot: FleetMapSlot): Html => {
+  const h = html<Message>()
+  const state = pylonSlotState(slot.pylon)
+  const label =
+    slot.pylon?.nodeLabel ??
+    slot.pylon?.pylonRef ??
+    slot.pylon?.nostrPubkeyShort ??
+    `slot ${slot.index + 1}`
+  const detail =
+    slot.pylon === null
+      ? 'no public heartbeat'
+      : `${slot.pylon.readyModel ?? 'model unknown'} / ${slot.pylon.lastSeenAtLabel ?? 'freshness unknown'}`
+
+  return h.li(
+    [
+      h.DataAttribute('fleet-map-slot', state),
+      Ui.className<Message>(
+        `grid min-h-24 content-between gap-3 border p-2 ${pylonSlotToneClass[state]}`,
+      ),
+    ],
+    [
+      h.div([Ui.className<Message>('flex items-center justify-between gap-2')], [
+        h.span(
+          [
+            Ui.className<Message>(
+              'text-[0.625rem] uppercase tracking-wide text-white/40',
+            ),
+          ],
+          [`${slot.index + 1}`.padStart(2, '0')],
+        ),
+        h.span(
+          [Ui.className<Message>('text-[0.625rem] text-current')],
+          [pylonSlotStateLabel[state]],
+        ),
+      ]),
+      h.div([Ui.className<Message>('grid min-w-0 gap-1')], [
+        h.span(
+          [
+            Ui.className<Message>(
+              'truncate text-[0.75rem] font-semibold text-[#f1efe8]',
+            ),
+          ],
+          [label],
+        ),
+        h.span(
+          [
+            Ui.className<Message>(
+              'truncate text-[0.6875rem] text-white/40',
+            ),
+          ],
+          [detail],
+        ),
+      ]),
+    ],
+  )
+}
+
+const taskBoardKinds = new Set<PublicActivityTimelineEvent['kind']>([
+  'assignment_ready',
+  'work_claimed',
+  'trace_submitted',
+  'verification_queued',
+  'verification_verified',
+  'verification_rejected',
+])
+
+type TaskBoardLane = Readonly<{
+  label: string
+  detail: string
+  kinds: ReadonlySet<PublicActivityTimelineEvent['kind']>
+}>
+
+const taskBoardLanes: ReadonlyArray<TaskBoardLane> = [
+  {
+    detail: 'Slots ready to accept work',
+    kinds: new Set<PublicActivityTimelineEvent['kind']>(['assignment_ready']),
+    label: 'Ready',
+  },
+  {
+    detail: 'Work claimed by public Pylon refs',
+    kinds: new Set<PublicActivityTimelineEvent['kind']>(['work_claimed']),
+    label: 'Claimed',
+  },
+  {
+    detail: 'Trace and verification work in flight',
+    kinds: new Set<PublicActivityTimelineEvent['kind']>([
+      'trace_submitted',
+      'verification_queued',
+    ]),
+    label: 'Verifying',
+  },
+  {
+    detail: 'Verifier outcomes from the public feed',
+    kinds: new Set<PublicActivityTimelineEvent['kind']>([
+      'verification_verified',
+      'verification_rejected',
+    ]),
+    label: 'Resolved',
+  },
+]
+
+const activeTaskBoardEvents = (
+  model: PublicActivityTimelineModel,
+): ReadonlyArray<PublicActivityTimelineEvent> => {
+  if (model._tag !== 'PublicActivityTimelineLoaded') {
+    return []
+  }
+  const generatedMs = parseMs(model.envelope.generatedAt)
+
+  return fleetFeedEvents(model.envelope.events)
+    .filter(event => taskBoardKinds.has(event.kind))
+    .filter(event => {
+      if (generatedMs === null) {
+        return true
+      }
+      const eventMs = parseMs(event.ts)
+      return (
+        eventMs !== null && generatedMs - eventMs <= FLEET_FEED_FRESH_WINDOW_MS
+      )
+    })
+}
+
+const taskBoardRow = (event: PublicActivityTimelineEvent): Html => {
+  const h = html<Message>()
+  const actor = event.actorRef ?? event.targetRef ?? event.runRef ?? 'public ref'
+
+  return h.li(
+    [
+      Ui.className<Message>(
+        'grid gap-1 border-b border-[#1b1b1b] py-2 last:border-b-0',
+      ),
+    ],
+    [
+      h.div(
+        [Ui.className<Message>('text-[0.75rem] leading-5 text-[#f1efe8]')],
+        [event.text],
+      ),
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex flex-wrap justify-between gap-2 text-[0.6875rem] text-white/35',
+          ),
+        ],
+        [
+          h.span([Ui.className<Message>('truncate')], [actor]),
+          h.span([Ui.className<Message>('tabular-nums')], [
+            friendlyRelativeTime(event.ts),
+          ]),
+        ],
+      ),
+    ],
+  )
+}
+
+const taskBoardLaneView = (
+  lane: TaskBoardLane,
+  events: ReadonlyArray<PublicActivityTimelineEvent>,
+): Html => {
+  const h = html<Message>()
+  const rows = events.filter(event => lane.kinds.has(event.kind)).slice(0, 4)
+
+  return h.div(
+    [
+      Ui.className<Message>(
+        'grid min-h-48 content-start gap-3 border border-[#222] bg-[#010102] p-3',
+      ),
+    ],
+    [
+      h.div([Ui.className<Message>('grid gap-1')], [
+        h.div(
+          [Ui.className<Message>('flex items-center justify-between gap-2')],
+          [
+            h.span(
+              [
+                Ui.className<Message>(
+                  'text-[0.75rem] font-semibold text-[#f1efe8]',
+                ),
+              ],
+              [lane.label],
+            ),
+            h.span(
+              [
+                Ui.className<Message>(
+                  'tabular-nums text-[0.6875rem] text-white/35',
+                ),
+              ],
+              [formatNumber(rows.length)],
+            ),
+          ],
+        ),
+        h.div([Ui.className<Message>('text-[0.6875rem] text-white/35')], [
+          lane.detail,
+        ]),
+      ]),
+      Array.match(rows, {
+        onEmpty: () =>
+          h.div(
+            [
+              h.Role('status'),
+              Ui.className<Message>(
+                'border border-[#1b1b1b] bg-black p-3 text-[0.75rem] text-white/35',
+              ),
+            ],
+            ['No public rows in this lane.'],
+          ),
+        onNonEmpty: values =>
+          h.ol([Ui.className<Message>('grid')], values.map(taskBoardRow)),
+      }),
+    ],
+  )
+}
+
+const artanisFleetMapAndTaskBoardView = (
+  pylonStats: PublicPylonStatsModel,
+  activityTimeline: PublicActivityTimelineModel,
+): Html => {
+  const h = html<Message>()
+  const stats = pylonStatsFromModel(pylonStats)
+  const slots = fleetMapSlots(stats)
+  const tasks = activeTaskBoardEvents(activityTimeline)
+  const assignmentReady = slots.filter(
+    slot => pylonSlotState(slot.pylon) === 'assignment',
+  ).length
+
+  return h.section(
+    [
+      h.DataAttribute('component', 'artanis-fleet-map-task-board'),
+      Ui.className<Message>('grid gap-4 border-b border-[#222] pb-6'),
+    ],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex flex-wrap items-end justify-between gap-3',
+          ),
+        ],
+        [
+          h.div([Ui.className<Message>('grid gap-2')], [
+            h.div([Ui.className<Message>(Ui.eyebrowClass)], ['Fleet map']),
+            h.h2(
+              [
+                Ui.className<Message>(
+                  'm-0 text-lg font-semibold tracking-normal text-[#f1efe8]',
+                ),
+              ],
+              ['Pylons, slots, active tasks'],
+            ),
+          ]),
+          h.div(
+            [
+              Ui.className<Message>(
+                'flex flex-wrap gap-2 text-[0.75rem] text-white/45',
+              ),
+            ],
+            [
+              h.span([], [`${formatNumber(assignmentReady)} assignment-ready`]),
+              h.span([], [`${formatNumber(tasks.length)} task rows`]),
+            ],
+          ),
+        ],
+      ),
+      h.div(
+        [
+          Ui.className<Message>(
+            'grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]',
+          ),
+        ],
+        [
+          h.div([Ui.className<Message>('grid content-start gap-3')], [
+            h.div(
+              [
+                Ui.className<Message>(
+                  'grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-4',
+                ),
+              ],
+              slots.map(pylonSlotView),
+            ),
+            h.div(
+              [Ui.className<Message>('text-[0.75rem] leading-5 text-white/35')],
+              [
+                stats === null
+                  ? 'Loading public Pylon slots from the live stats projection.'
+                  : `${formatNumber(stats.pylonsOnlineNow)} online / ${formatNumber(stats.pylonsWalletReadyNow)} wallet-ready / ${formatNumber(stats.pylonsAssignmentReadyNow)} assignment-ready.`,
+              ],
+            ),
+          ]),
+          h.div([Ui.className<Message>('grid content-start gap-3')], [
+            h.div([Ui.className<Message>('grid gap-1')], [
+              h.div([Ui.className<Message>(Ui.eyebrowClass)], [
+                'Active Task Board',
+              ]),
+              h.div(
+                [Ui.className<Message>('text-[0.75rem] text-white/35')],
+                ['Work and verification lanes from the public activity feed.'],
+              ),
+            ]),
+            h.div(
+              [Ui.className<Message>('grid gap-2 md:grid-cols-2')],
+              taskBoardLanes.map(lane => taskBoardLaneView(lane, tasks)),
+            ),
+            h.div(
+              [Ui.className<Message>('text-[0.75rem] leading-5 text-white/35')],
+              [
+                'Only public activity rows are shown; prompts, local workspaces, private traces, and provider payloads stay out of this board.',
+              ],
+            ),
+          ]),
+        ],
+      ),
+    ],
+  )
+}
+
 type VirtualMergeQueueLane = Readonly<{
   label: string
   value: string
@@ -2131,6 +2500,7 @@ const artanisLoadedView = (
       // HERO: the live token-burn Pulse is the strongest signal that an
       // autonomous fleet is building in real time, so it spans the console.
       artanisPulseView(khalaTokensServedHistory),
+      artanisFleetMapAndTaskBoardView(pylonStats, activityTimeline),
       artanisVirtualMergeQueueView(),
       h.div(
         [


### PR DESCRIPTION
Addresses #6656.

### Changes
- Rebuilt the public Artanis surface with a Fleet Map grid backed by public Pylon stats.
- Added an Active Task Board using the public activity timeline data for ready, claimed, and verification states.
- Expanded the public agent story test fixtures and assertions to cover Pylon stats, recent pylons, and activity timeline rendering.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts`
- Result: passed (exit 0)