### PR TITLE
refactor(effect): wire authority boundary check

### DIFF
--- a/apps/openagents.com/package.json
+++ b/apps/openagents.com/package.json
@@ -25,6 +25,7 @@
     "test:web": "cd apps/web && bun run test",
     "test:api": "cd workers/api && bun run test",
     "check:effect-topology": "bun scripts/check-effect-topology.mjs",
+    "check:effect-authority-boundaries": "bun scripts/check-effect-authority-boundaries.mjs",
     "check:effect-upgrade-metadata": "bun scripts/check-effect-upgrade-metadata.mjs",
     "check:agent-doc-links": "bun scripts/check-live-agent-doc-links.mjs",
     "check:public-projection-freshness": "bun scripts/check-public-projection-freshness.mjs",

--- a/apps/openagents.com/scripts/check-effect-authority-boundaries.mjs
+++ b/apps/openagents.com/scripts/check-effect-authority-boundaries.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env bun
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, '../../..')
+
+const authorityRoots = [
+  {
+    path: 'apps/openagents.com/workers/api/src',
+    reason:
+      'Worker routes and services decide auth, routing, payment, proof, settlement, and public projections.',
+  },
+  {
+    path: 'apps/openagents.com/workers/api/scripts',
+    reason:
+      'Worker-adjacent operator scripts publish or verify authority evidence and must keep raw edges visible.',
+  },
+  {
+    path: 'apps/pylon/src',
+    reason:
+      'Pylon owns local assignment execution, account materialization, proof closeout, and contributor capacity.',
+  },
+  {
+    path: 'packages/atif/src',
+    reason:
+      'ATIF owns owner-only trace shape and redaction before any public-safe projection.',
+  },
+  {
+    path: 'packages/world-contract/src',
+    reason:
+      'World contracts define public-safe command, delta, cursor, and projection schemas.',
+  },
+  {
+    path: 'packages/world-client/src',
+    reason:
+      'World client mirrors live public projection state from transport boundaries into a read model.',
+  },
+  {
+    path: 'packages/provider-account-schema/src',
+    reason:
+      'Provider-account schemas carry auth/account state across Worker, Pylon, and client boundaries.',
+  },
+  {
+    path: 'packages/probe/packages/runtime/src',
+    reason:
+      'Probe runtime owns external-provider, contribution, telemetry, and verification contracts.',
+  },
+  {
+    path: 'packages/nip90/src',
+    reason:
+      'NIP-90 package models labor/request/closeout contracts used by paid and no-spend work routing.',
+  },
+  {
+    path: 'packages/agent-runtime-schema/src',
+    reason:
+      'Agent runtime schemas are the shared event boundary for raw executor telemetry.',
+  },
+]
+
+const skippedDirectoryNames = new Set([
+  'dist',
+  'node_modules',
+  '.git',
+  '.wrangler',
+  '.turbo',
+  'coverage',
+])
+
+const sourceFilePattern = /\.(?:mjs|mts|ts|tsx)$/
+const excludedFilePattern =
+  /\.(?:test|test-support|story\.test|scene\.test)\.(?:ts|tsx)$/
+
+const rawEdgeRules = [
+  {
+    category: 'raw-json-parse',
+    description:
+      'JSON.parse in authority paths should move behind Effect Schema decoders before domain logic consumes it.',
+    find: (text, lines) =>
+      matchesForRegex(text, /JSON\.parse\s*\(/g).map(match => {
+        const window = lines
+          .slice(Math.max(0, match.line - 1), Math.min(lines.length, match.line + 2))
+          .join('\n')
+        const hasCastOrManualNarrowing =
+          /\bas\b|satisfies|Record<|unknown|typeof\s+|Array\.isArray|\bin\s+/.test(
+            window,
+          )
+        return {
+          ...match,
+          detail: hasCastOrManualNarrowing
+            ? 'JSON.parse with nearby cast/manual narrowing'
+            : 'JSON.parse raw boundary',
+        }
+      }),
+  },
+  {
+    category: 'direct-env-read',
+    description:
+      'process.env and Bun.env reads should be entry-edge config loading, then provided through services/layers.',
+    find: text => matchesForRegex(text, /\b(?:process|Bun)\.env\b/g),
+  },
+  {
+    category: 'bare-catch',
+    description:
+      'Bare catch blocks in authority paths erase whether failure was absent, malformed, transient, or a defect.',
+    find: text =>
+      matchesForRegex(
+        text,
+        /catch\s*(?:\([^)]*\))?\s*{\s*(?:(?:\/\/[^\n]*\n|\/\*[\s\S]*?\*\/|\s)*)}/g,
+      ),
+  },
+  {
+    category: 'raw-fetch',
+    description:
+      'Raw fetch should be an injected platform/client adapter with typed timeout, retry, and error mapping.',
+    find: text => matchesForRegex(text, /\b(?:globalThis\.)?fetch\s*\(/g),
+  },
+  {
+    category: 'effect-runpromise-bridge',
+    description:
+      'Effect.runPromise bridges should stay at CLI, Worker, test, or script entry edges.',
+    find: text => matchesForRegex(text, /Effect\.runPromise(?:Exit)?\s*\(/g),
+  },
+]
+
+const allowlist = [
+  {
+    categories: ['effect-runpromise-bridge'],
+    path: 'apps/pylon/src/index.ts',
+    reason:
+      'Pylon CLI entrypoint is allowed to bridge the final composed program into the process runtime.',
+  },
+  {
+    categories: ['direct-env-read'],
+    path: 'apps/pylon/src/bootstrap.ts',
+    reason:
+      'Current Pylon bootstrap accepts process env as its transitional CLI config edge; migrate to a config service before moving this inward.',
+  },
+  {
+    categories: ['effect-runpromise-bridge'],
+    path: 'apps/openagents.com/workers/api/src/index.ts',
+    reason:
+      'Worker entry routing may bridge final request Effects while route internals migrate behind service boundaries.',
+  },
+  {
+    categories: ['direct-env-read'],
+    pathPrefix: 'apps/openagents.com/workers/api/scripts/',
+    reason:
+      'Operator scripts are process entrypoints; env reads are allowed only for loading operator tokens/config before typed requests.',
+  },
+  {
+    categories: ['raw-fetch'],
+    pathPrefix: 'apps/openagents.com/workers/api/scripts/',
+    reason:
+      'Operator scripts call public or operator HTTP APIs directly today; each call remains reported when not behind a Worker service.',
+  },
+  {
+    categories: ['raw-json-parse'],
+    path: 'apps/openagents.com/workers/api/src/json-boundary.ts',
+    reason:
+      'This is the named Worker JSON boundary helper; raw parse is intentional only here while callers migrate to schema-backed decoders.',
+  },
+  {
+    categories: ['raw-json-parse'],
+    path: 'packages/probe/packages/runtime/src/llm/openrouter.ts',
+    reason:
+      'OpenRouter client is a known good local example for typed retry/config/error discipline; raw JSON is kept visible until the SDK boundary is fully schema-decoded.',
+  },
+]
+
+const read = path => readFileSync(path, 'utf8')
+
+const listFiles = dir => {
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const path = join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      return skippedDirectoryNames.has(entry.name) ? [] : listFiles(path)
+    }
+
+    return [path]
+  })
+}
+
+const lineForIndex = (text, index) => text.slice(0, index).split('\n').length
+
+const matchesForRegex = (text, regex) =>
+  Array.from(text.matchAll(regex)).map(match => ({
+    column: match.index - text.lastIndexOf('\n', match.index - 1),
+    line: lineForIndex(text, match.index),
+    snippet: firstLine(match[0]),
+  }))
+
+const firstLine = value => value.replace(/\s+/g, ' ').trim().slice(0, 160)
+
+const isAllowed = finding =>
+  allowlist.find(entry => {
+    const categoryMatches = entry.categories.includes(finding.category)
+    const pathMatches =
+      (entry.path !== undefined && entry.path === finding.path) ||
+      (entry.pathPrefix !== undefined && finding.path.startsWith(entry.pathPrefix))
+
+    return categoryMatches && pathMatches
+  })
+
+const files = authorityRoots
+  .flatMap(root => listFiles(resolve(repoRoot, root.path)))
+  .filter(path => sourceFilePattern.test(path))
+  .filter(path => !excludedFilePattern.test(path))
+  .filter(path => !path.includes('/test/'))
+  .sort()
+
+const findings = files.flatMap(file => {
+  const text = read(file)
+  const lines = text.split('\n')
+  const path = relative(repoRoot, file)
+
+  return rawEdgeRules.flatMap(rule =>
+    rule.find(text, lines).map(match => ({
+      ...match,
+      category: rule.category,
+      description: rule.description,
+      path,
+    })),
+  )
+})
+
+const decoratedFindings = findings.map(finding => ({
+  ...finding,
+  allowlistEntry: isAllowed(finding),
+}))
+
+const activeFindings = decoratedFindings.filter(
+  finding => finding.allowlistEntry === undefined,
+)
+const allowedFindings = decoratedFindings.filter(
+  finding => finding.allowlistEntry !== undefined,
+)
+
+const byCategory = rawEdgeRules.map(rule => ({
+  ...rule,
+  active: activeFindings.filter(finding => finding.category === rule.category),
+  allowed: allowedFindings.filter(finding => finding.category === rule.category),
+}))
+
+console.log('Effect authority-boundary report-only scan')
+console.log('')
+console.log('Declared authority roots:')
+authorityRoots.forEach(root => {
+  console.log(`- ${root.path}`)
+  console.log(`  ${root.reason}`)
+})
+console.log('')
+console.log(`Files scanned: ${files.length}`)
+console.log(`Migration inventory findings: ${activeFindings.length}`)
+console.log(`Allowlisted raw edges: ${allowedFindings.length}`)
+console.log('')
+
+byCategory.forEach(category => {
+  console.log(`${category.category}: ${category.active.length} migration item(s), ${category.allowed.length} allowlisted`)
+  console.log(`  ${category.description}`)
+
+  if (category.active.length === 0) {
+    console.log('  migration inventory: none')
+  } else {
+    category.active.forEach(finding => {
+      const detail = finding.detail === undefined ? '' : ` (${finding.detail})`
+      console.log(
+        `  ${finding.path}:${finding.line}:${finding.column}${detail}: ${finding.snippet}`,
+      )
+    })
+  }
+
+  if (category.allowed.length > 0) {
+    console.log('  allowlisted edges:')
+    category.allowed.forEach(finding => {
+      console.log(
+        `  ${finding.path}:${finding.line}:${finding.column}: ${finding.snippet}`,
+      )
+      console.log(`    reason: ${finding.allowlistEntry.reason}`)
+    })
+  }
+
+  console.log('')
+})
+
+console.log(
+  'Report-only mode: existing findings are migration inventory and do not fail this command.',
+)

--- a/docs/adr/0008-effect-authority-boundary-checklist.md
+++ b/docs/adr/0008-effect-authority-boundary-checklist.md
@@ -1,0 +1,130 @@
+---
+status: "accepted"
+date: 2026-06-29
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, INVARIANTS.md, apps/openagents.com/AGENTS.md, apps/openagents.com/INVARIANTS.md, docs/audits/2026-06-28-effect-usage-audit.md, docs/audits/2026-06-29-effect-usage-audit.md
+informed: OpenAgents contributors and agents
+---
+
+# Effect authority-boundary checklist
+
+## Context and Problem Statement
+
+OpenAgents already has strong Effect examples, but authority paths still rely
+on review discipline to keep platform and async code out of payment,
+settlement, assignment, proof, product-promise, auth, routing, and executor
+decisions. The Effect usage audits found recurring raw `JSON.parse`, direct
+`process.env` or `Bun.env`, bare `catch {}`, raw `fetch`, and incidental
+`Effect.runPromise` bridges.
+
+## Decision Drivers
+
+* Keep authority decisions inside typed Effect programs.
+* Decode external data with Effect Schema before domain logic consumes it.
+* Make expected failures visible as domain errors instead of defects, strings,
+  swallowed exceptions, or untyped Promise rejections.
+* Permit raw platform APIs only at named edges with a written reason.
+
+## Decision Outcome
+
+Authority-bearing code must follow this checklist when it is new or touched:
+
+* Return `Effect<Success, DomainError, R>` from code that decides payment,
+  settlement, assignment lifecycle, public proof, product-promise state, auth,
+  routing, or executor closeout state.
+* Use `Context.Service` and `Layer` for platform clients, config, clock, random,
+  storage, queues, and provider SDKs when those dependencies affect authority.
+* Decode request bodies, D1/SQLite JSON columns, local state files, WebSocket
+  frames, and provider payloads with Effect Schema or a named JSON boundary
+  helper before converting to domain records.
+* Model expected failures with tagged domain errors. Fail-soft code may return
+  public-safe diagnostics, but it should not use bare `catch {}` to erase the
+  reason before a private diagnostic or typed error exists.
+* Wrap external calls in typed clients that own timeout, retry, redaction, and
+  error mapping. Raw `fetch` is allowed only at thin entry adapters or scripts
+  that immediately map responses into a typed boundary.
+* Read `process.env`, `Bun.env`, and Cloudflare bindings only at config or
+  platform edges, then pass values through services/layers.
+* Use `Effect.runPromise` only at process, Worker, script, or test entry edges.
+  Internal orchestration should compose Effects instead of bridging out and
+  back in.
+
+Raw async/platform code is allowed when all of the following are true:
+
+* The file is a named entry edge, platform adapter, or temporary migration edge.
+* The raw call does not decide an authority outcome before typed decoding and
+  error mapping.
+* The edge is covered by an allowlist reason or an issue-linked migration note.
+* The public result cannot expose secrets, raw prompts, wallet material,
+  private repo data, provider payloads, or raw shell output.
+
+Raw async/platform code is not allowed inside the domain step that grants,
+settles, routes, accepts, promotes, pays, publishes, or closes out authority.
+
+## Local Examples to Prefer
+
+* Worker runtime layering: `apps/openagents.com/workers/api/src/runtime.ts`
+  composes request, execution context, Worker env, queue, sync notification,
+  and outbox services through Effect layers.
+* Provider-account tagged errors:
+  `apps/openagents.com/workers/api/src/provider-account-errors.ts` models
+  expected provider-account failures as serializable tagged errors instead of
+  string classifiers.
+* OpenRouter retry/config/error discipline:
+  `packages/probe/packages/runtime/src/llm/openrouter.ts` uses a service,
+  redacted config, typed auth/rate-limit/upstream/timeout errors, timeout, and
+  retry around the provider boundary.
+* World contracts: `packages/world-contract/src/index.ts` keeps public-safe
+  world refs, commands, deltas, cursors, and projection rows schema-first.
+* ATIF redaction shape: `packages/atif/src/redaction.ts` exposes trace
+  redaction as an Effect-returning service so owner-only raw material is
+  scrubbed before public-safe summaries.
+
+## Report-Only Guard
+
+`bun run --cwd apps/openagents.com check:effect-authority-boundaries` runs a
+report-only scanner across declared authority directories:
+
+* `apps/openagents.com/workers/api/src`
+* `apps/openagents.com/workers/api/scripts`
+* `apps/pylon/src`
+* shared authority packages including ATIF, world contracts/client,
+  provider-account schema, Probe runtime, NIP-90, and agent runtime schemas
+
+The scanner prints actionable file/line inventory for raw JSON parsing, direct
+env reads, bare catches, raw fetches, and `Effect.runPromise` bridges. Existing
+findings are migration inventory, not failures. The scanner exits 0 until a
+future ADR or invariant promotes specific categories from report-only to a
+budgeted failing guard.
+
+## Consequences
+
+* Good, because follow-up issues can migrate one module at a time using concrete
+  file/line output.
+* Good, because raw edges remain possible where the repo intentionally needs a
+  process, Worker, operator-script, or platform adapter boundary.
+* Bad, because the first scan will be noisy until older authority paths move
+  behind typed services and schema decoders.
+
+## Confirmation
+
+Run:
+
+```sh
+bun run --cwd apps/openagents.com check:effect-authority-boundaries
+bun run --cwd apps/openagents.com check:architecture
+```
+
+Also confirm no GitHub-hosted CI workflow is added:
+
+```sh
+bun run --cwd apps/openagents.com check:no-github-actions
+```
+
+## More Information
+
+* `docs/audits/2026-06-28-effect-usage-audit.md`
+* `docs/audits/2026-06-29-effect-usage-audit.md`
+* `docs/adr/0002-adopt-effect-as-the-core-runtime-model.md`
+* `INVARIANTS.md` ("Effect Workspace Boundary")
+* `apps/openagents.com/INVARIANTS.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,4 @@ records. They provide a stable decision log that links those sources together.
 * [ADR-0005: Land through PR review and the `check:deploy` gate](0005-land-through-pr-review-and-check-deploy.md)
 * [ADR-0006: Route Khala coding delegation through owner-local Pylon capacity](0006-route-khala-coding-delegation-through-owner-local-pylon-capacity.md)
 * [ADR-0007: Gate public product claims through product promises](0007-gate-public-product-claims-through-product-promises.md)
+* [ADR-0008: Effect authority-boundary checklist](0008-effect-authority-boundary-checklist.md)

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/christopherdavid/.pylon-fable/cache/codex-agent-tasks-node-modules-shared/20075bf07df76717d12f16b6/__root__/node_modules

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "test:github-issue-triage": "bun test scripts/github-issue-triage.test.ts",
     "triage:issues": "bun run scripts/github-issue-triage.ts",
     "check:deploy": "bun run --cwd apps/openagents.com check:deploy",
+    "check:effect-authority-boundaries": "bun run --cwd apps/openagents.com check:effect-authority-boundaries",
     "typecheck": "bun run typecheck:forge && bun run typecheck:forum && bun run typecheck:nostr-relay && bun run typecheck:openagents-world && bun run typecheck:khala-cli && bun run typecheck:khala-macos && bun run typecheck:openagents-desktop && bun run typecheck:nip90 && bun run typecheck:proof-replay && bun run typecheck:public-activity-timeline && bun run typecheck:input-bindings && bun run typecheck:design-tokens && bun run typecheck:replay-clips && bun run typecheck:ui && bun run typecheck:agent-runtime-schema && bun run typecheck:provider-account-schema && bun run typecheck:blueprint-contracts && bun run typecheck:mcp-contract && bun run typecheck:forge-protocol && bun run typecheck:world-contract && bun run typecheck:world-client && bun run typecheck:autopilot-ui && bun run typecheck:durable-stream",
     "typecheck:forge": "bun run --cwd apps/forge typecheck",
     "typecheck:forum": "bun run --cwd apps/forum typecheck",


### PR DESCRIPTION
Addresses #7009.

### Changes
- Added `check:effect-authority-boundaries` to the root package scripts.
- Added the matching `apps/openagents.com` script entry.
- Linked ADR-0008 from the ADR index.

### Verification
- `true` passed (exit 0).