### PR TITLE
feat(khala): arm free-tier trace capture disclosure gates

### DIFF
--- a/apps/openagents.com/apps/web/public/AGENTS.md
+++ b/apps/openagents.com/apps/web/public/AGENTS.md
@@ -69,15 +69,17 @@ your key. Streaming via `"stream": true` (SSE). Over the free quota → `402`; a
 or wait for the UTC reset. Full quickstart (curl + Python + JS, limits, errors):
 `docs/faq/khala-inference-quickstart.md`.
 
-**Free-tier data sharing (read this).** When you use the free Khala API without
-paying for privacy, your traffic is **captured by default** as a **redacted,
-private-by-default (`owner_only`)** trace and **may be used to improve and train**
-OpenAgents models. **Pay for privacy** (or run confidential compute) to opt out of
-capture entirely. A captured trace is shared **publicly only if its owner opts it
-in**. Capture grants **no payout or settlement** (the data-market reward marker is
-inert and owner-gated). The full canonical terms are agent-readable at
+**Free-tier data sharing (read this).** When the owner-gated capture default is
+armed, free Khala API traffic from callers who have not paid for privacy is
+**captured by default** as a **redacted, private-by-default (`owner_only`)** trace
+and **may be used to improve and train** OpenAgents models. **Pay for privacy**
+(or run confidential compute) to opt out of capture entirely. A captured trace is
+shared **publicly only if its owner opts it in**. Capture grants **no payout or
+settlement** (the data-market reward marker is inert and owner-gated). The full
+canonical terms are agent-readable at
 `GET https://openagents.com/api/public/free-tier-data-sharing` (also embedded in
-the `POST /api/keys/free` mint response as `dataSharing`), and tracked as the
+the `POST /api/keys/free` mint response as `dataSharing`), expose
+`deployment.captureDefaultGate`, and are tracked as the
 `data.free_tier_capture_disclosure.v1` product promise.
 
 ## Your Job

--- a/apps/openagents.com/workers/api/src/free-key-mint-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/free-key-mint-routes.test.ts
@@ -100,11 +100,13 @@ const makeEnv = (
   db: D1Database,
   flag: string | undefined,
   mintCap?: string | undefined,
+  captureDefault?: string | undefined,
 ): Env =>
   ({
     OPENAGENTS_DB: db,
     INFERENCE_FREE_TIER_ENABLED: flag,
     FREE_KEY_MAX_MINTS_PER_IP_PER_DAY: mintCap,
+    KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT: captureDefault,
   }) as unknown as Env
 
 const mintRequest = (
@@ -156,6 +158,10 @@ describe('POST /api/keys/free (issue #6228)', () => {
         promiseId: string
         terms: ReadonlyArray<string>
         policy: { capturedByDefault: boolean; paidPrivacyOptOut: boolean }
+        deployment: {
+          captureDefaultGate: string
+          blockerRef: string
+        }
       }
     }
     expect(body.tier).toBe('free')
@@ -170,6 +176,10 @@ describe('POST /api/keys/free (issue #6228)', () => {
     expect(body.dataSharing.terms.length).toBeGreaterThan(0)
     expect(body.dataSharing.policy.capturedByDefault).toBe(true)
     expect(body.dataSharing.policy.paidPrivacyOptOut).toBe(true)
+    expect(body.dataSharing.deployment.captureDefaultGate).toBe('owner_gated')
+    expect(body.dataSharing.deployment.blockerRef).toBe(
+      'blocker.product_promises.free_tier_capture_default_owner_gated',
+    )
     // The minted account is now marked free-tier in D1.
     const row = await db
       .prepare(
@@ -179,6 +189,19 @@ describe('POST /api/keys/free (issue #6228)', () => {
       .bind(`agent:${store.registrations[0]!.user.id}`)
       .first<{ account_ref: string }>()
     expect(row).not.toBeNull()
+  })
+
+  test('data-sharing disclosure reports armed capture gate when owner flag is on', async () => {
+    const response = await handleFreeKeyMint(
+      mintRequest(),
+      makeEnv(makeDb(), 'true', undefined, 'true'),
+      new MemoryAgentRegistrationStore(),
+    )
+    expect(response.status).toBe(201)
+    const body = (await response.json()) as {
+      dataSharing: { deployment: { captureDefaultGate: string } }
+    }
+    expect(body.dataSharing.deployment.captureDefaultGate).toBe('armed')
   })
 
   test('rejects non-POST with 405', async () => {

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -6983,7 +6983,11 @@ export const handleFreeKeyMint = async (
           // privacy (or use confidential compute) to opt out; public sharing is
           // opt-in only. The same canonical disclosure is served at
           // GET /api/public/free-tier-data-sharing for agents.
-          dataSharing: freeTierDataSharingDisclosure(),
+          dataSharing: freeTierDataSharingDisclosure({
+            captureDefaultArmed: isKhalaFreeTierTraceCaptureDefaultEnabled(
+              env.KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT,
+            ),
+          }),
         },
         { status: 201 },
       ),

--- a/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.test.ts
@@ -24,7 +24,20 @@ describe('free-tier data-sharing disclosure (#6296)', () => {
       publicSharingOptIn: true,
       rewardInert: true,
     })
+    expect(disclosure.deployment).toEqual({
+      captureDefaultGate: 'owner_gated',
+      captureDefaultEnv: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT',
+      blockerRef:
+        'blocker.product_promises.free_tier_capture_default_owner_gated',
+    })
     expect(disclosure.reportPath).toContain('forum/f/product-promises')
+  })
+
+  test('can project an env-aware armed capture gate for mint responses', () => {
+    expect(
+      freeTierDataSharingDisclosure({ captureDefaultArmed: true }).deployment
+        .captureDefaultGate,
+    ).toBe('armed')
   })
 
   test('terms cover the four honest clauses without overclaiming', () => {
@@ -53,8 +66,15 @@ describe('free-tier data-sharing disclosure (#6296)', () => {
       ),
     )
     expect(ok.status).toBe(200)
-    const body = (await ok.json()) as { promiseId: string }
+    const body = (await ok.json()) as {
+      promiseId: string
+      deployment: { captureDefaultGate: string; blockerRef: string }
+    }
     expect(body.promiseId).toBe(FREE_TIER_DATA_SHARING_PROMISE_ID)
+    expect(body.deployment.captureDefaultGate).toBe('owner_gated')
+    expect(body.deployment.blockerRef).toBe(
+      'blocker.product_promises.free_tier_capture_default_owner_gated',
+    )
 
     const denied = await Effect.runPromise(
       handleFreeTierDataSharingDisclosureApi(

--- a/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.ts
+++ b/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.ts
@@ -36,7 +36,7 @@ export const FREE_TIER_DATA_SHARING_PROMISE_ID =
 
 // Disclosure version. Bump when the TERMS text changes (not on unrelated copy
 // edits). Surfaces echo this so a caller/agent can pin which terms they saw.
-export const FREE_TIER_DATA_SHARING_DISCLOSURE_VERSION = '2026-06-25.1' as const
+export const FREE_TIER_DATA_SHARING_DISCLOSURE_VERSION = '2026-06-29.1' as const
 
 // Public, human-readable summary line. Intentionally short and quotable; the
 // full clause list carries the precise terms.
@@ -78,6 +78,16 @@ export type FreeTierDataSharingPolicy = Readonly<{
   rewardInert: true
 }>
 
+export type FreeTierDataSharingDeployment = Readonly<{
+  // The production flip that turns default-on free-tier capture from policy into
+  // live behavior. Public endpoint reads are env-free, so they intentionally
+  // report the conservative owner-gated state; env-aware mint responses pass the
+  // actual deployment value.
+  captureDefaultGate: 'armed' | 'owner_gated'
+  captureDefaultEnv: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT'
+  blockerRef: 'blocker.product_promises.free_tier_capture_default_owner_gated'
+}>
+
 export const FREE_TIER_DATA_SHARING_POLICY: FreeTierDataSharingPolicy = {
   capturedByDefault: true,
   redacted: true,
@@ -104,14 +114,23 @@ export type FreeTierDataSharingDisclosure = Readonly<{
   reportPath: string
   // Public references for the policy and its source.
   references: ReadonlyArray<string>
+  // Current deployment gate for default-on capture behavior.
+  deployment: FreeTierDataSharingDeployment
 }>
 
 export const FREE_TIER_DATA_SHARING_REPORT_PATH =
   'https://openagents.com/forum/f/product-promises' as const
 
-// Build the canonical disclosure object. Pure; no IO, no env, no clock.
-export const freeTierDataSharingDisclosure =
-  (): FreeTierDataSharingDisclosure => ({
+export type FreeTierDataSharingDisclosureOptions = Readonly<{
+  captureDefaultArmed?: boolean | undefined
+}>
+
+// Build the canonical disclosure object. Pure; no IO, no env, no clock. The
+// public endpoint leaves captureDefaultArmed unset so the owner-gated blocker
+// remains explicit; env-aware call sites can pass the actual deployment gate.
+export const freeTierDataSharingDisclosure = (
+  options: FreeTierDataSharingDisclosureOptions = {},
+): FreeTierDataSharingDisclosure => ({
     promiseId: FREE_TIER_DATA_SHARING_PROMISE_ID,
     version: FREE_TIER_DATA_SHARING_DISCLOSURE_VERSION,
     summary: FREE_TIER_DATA_SHARING_SUMMARY,
@@ -128,4 +147,11 @@ export const freeTierDataSharingDisclosure =
       'https://github.com/OpenAgentsInc/openagents/blob/main/docs/promises/2026-06-25-free-tier-data-sharing-disclosure.md',
       'https://github.com/OpenAgentsInc/openagents/blob/main/docs/traces/2026-06-25-default-on-trace-capture-audit.md',
     ],
+    deployment: {
+      captureDefaultGate:
+        options.captureDefaultArmed === true ? 'armed' : 'owner_gated',
+      captureDefaultEnv: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT',
+      blockerRef:
+        'blocker.product_promises.free_tier_capture_default_owner_gated',
+    },
   })

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -4099,9 +4099,10 @@ const requestSchemas = (): JsonSchema => ({
       'publicSharing',
       'reportPath',
       'references',
+      'deployment',
     ],
     description:
-      'Canonical, code-accurate data-sharing terms for the free Khala API (#6296). Public-safe: terms text + bounded policy facts only — no secrets, account, or payment material.',
+      'Canonical, code-accurate data-sharing terms for the free Khala API (#6296). Public-safe: terms text + bounded policy facts + capture gate state only — no secrets, account, or payment material.',
     properties: {
       promiseId: {
         type: 'string',
@@ -4146,6 +4147,29 @@ const requestSchemas = (): JsonSchema => ({
       publicSharing: { type: 'string' },
       reportPath: { type: 'string' },
       references: { type: 'array', items: { type: 'string' } },
+      deployment: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['captureDefaultGate', 'captureDefaultEnv', 'blockerRef'],
+        description:
+          'Current deployment gate for default-on capture behavior. The public disclosure endpoint is env-free and reports owner_gated; env-aware mint responses report armed only when KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT is armed.',
+        properties: {
+          captureDefaultGate: {
+            type: 'string',
+            enum: ['armed', 'owner_gated'],
+          },
+          captureDefaultEnv: {
+            type: 'string',
+            enum: ['KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT'],
+          },
+          blockerRef: {
+            type: 'string',
+            enum: [
+              'blocker.product_promises.free_tier_capture_default_owner_gated',
+            ],
+          },
+        },
+      },
     },
   },
   FreeApiKeyMintResponse: {
@@ -4153,7 +4177,7 @@ const requestSchemas = (): JsonSchema => ({
     additionalProperties: false,
     required: ['tier', 'model', 'credential', 'quota', 'usage', 'dataSharing'],
     description:
-      'Khala FREE API mode mint result. The raw bearer token is returned ONCE here and is not redisplayed. No wallet, payment, or owner-private material is included. The dataSharing field carries the honest free-tier data-sharing terms (#6296): free usage is captured by default as redacted, private traces that may improve/train models; pay for privacy to opt out; public sharing is opt-in only.',
+      'Khala FREE API mode mint result. The raw bearer token is returned ONCE here and is not redisplayed. No wallet, payment, or owner-private material is included. The dataSharing field carries the honest free-tier data-sharing terms (#6296): when the owner-gated capture default is armed, free usage is captured by default as redacted, private traces that may improve/train models; pay for privacy to opt out; public sharing is opt-in only; deployment.captureDefaultGate reports the actual mint-time gate.',
     properties: {
       tier: { type: 'string', enum: ['free'] },
       model: { type: 'string', enum: ['openagents/khala'] },

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1028,7 +1028,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Free Khala API usage is captured by default as redacted, private traces that may be used to improve and train models; pay for privacy to opt out; public sharing is opt-in only.',
         safeCopy:
-          'Free tier: when you use the free Khala API without paying for privacy, your traffic is captured by default as a redacted, private-by-default (owner_only) trace and may be used to improve and train OpenAgents models. Pay for privacy, or run confidential compute, to opt out of capture (fail-closed to not-captured). A captured trace is shared publicly only if its owner explicitly opts it into public visibility. Capture grants no payout or settlement — the data-market reward marker is inert and owner-gated. The canonical terms are served at GET /api/public/free-tier-data-sharing and embedded in the POST /api/keys/free mint response.',
+          'Free tier: when the owner-gated capture default is armed, free Khala API traffic from callers who have not paid for privacy is captured by default as a redacted, private-by-default (owner_only) trace and may be used to improve and train OpenAgents models. Pay for privacy, or run confidential compute, to opt out of capture (fail-closed to not-captured). A captured trace is shared publicly only if its owner explicitly opts it into public visibility. Capture grants no payout or settlement — the data-market reward marker is inert and owner-gated. The canonical terms are served at GET /api/public/free-tier-data-sharing and embedded in the POST /api/keys/free mint response; both expose deployment.captureDefaultGate so the owner-gated blocker remains visible until the production flip is armed.',
         unsafeCopy:
           'Do not claim free traffic is never captured, do not claim captured traces are public by default, do not claim paid-privacy callers are captured, and do not claim capture earns the user a payout, reward, or settlement.',
         evidenceRefs: [
@@ -1047,7 +1047,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.disclosure_copy_owner_signoff_pending',
         ],
         verification:
-          'GET /api/public/free-tier-data-sharing returns the canonical disclosure (version, summary, ordered terms, bounded policy facts) and the POST /api/keys/free mint response embeds the same dataSharing object. The terms must stay accurate to the capture seams: auto-capture is redacted and owner_only (khala-chat-trace-emitter.ts), paid-privacy is excluded fail-closed (inference-privacy-entitlement.ts), public is owner opt-in only, and the reward marker stays inert (#6221). Green requires the default-on capture flip armed in prod (KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT) and owner-approved public copy.',
+          'GET /api/public/free-tier-data-sharing returns the canonical disclosure (version, summary, ordered terms, bounded policy facts, and deployment.captureDefaultGate=owner_gated unless an env-aware caller reports the armed flag) and the POST /api/keys/free mint response embeds the same dataSharing object with the actual KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT gate. The terms must stay accurate to the capture seams: auto-capture is redacted and owner_only (khala-chat-trace-emitter.ts), paid-privacy is excluded fail-closed (inference-privacy-entitlement.ts), public is owner opt-in only, and the reward marker stays inert (#6221). Green requires the default-on capture flip armed in prod and owner-approved public copy.',
         authorityBoundary:
           'A disclosure grants no spend, payout, settlement, training-consent, or capture authority. It describes policy only; it does not change capture behavior or move money.',
       },
@@ -1060,7 +1060,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Free Khala API usage can be captured as redacted, private-by-default traces for model improvement.',
         safeCopy:
-          'The free-tier trace-capture seams exist and are intentionally private/redacted by default when armed: captured traces are owner_only unless the owner opts into public sharing, and trace capture does not create payout or settlement eligibility. This is yellow because the behavior is owner-gated by KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT and must remain aligned with the public disclosure and paid-privacy exclusion path.',
+          'The free-tier trace-capture seams exist and are intentionally private/redacted by default when armed: captured traces are owner_only unless the owner opts into public sharing, and trace capture does not create payout or settlement eligibility. This is yellow because the behavior is owner-gated by KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT; the disclosure endpoint and free-key mint response must expose that gate state and remain aligned with the paid-privacy exclusion path.',
         unsafeCopy:
           'Do not claim all free-tier traffic is currently captured unless the production gate is armed, do not claim captured traces are public by default, and do not claim capture pays users or contributors.',
         evidenceRefs: [

--- a/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md
+++ b/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md
@@ -1148,6 +1148,17 @@ GLM coding lane and leave REAP-504B on the 4x hosts.)
 - The owner-gated honesty bar still applies: any published benchmark number must come from
   the owner-armed real seam over realistic traffic (`decisionGrade:true`); internal
   dogfood/stress tokens stay segmented (#6298 demand tags) and out of external metrics.
+- 2026-06-29 #7019 local promise/data-privacy slice: the free-tier data-sharing
+  disclosure now exposes `deployment.captureDefaultGate` so
+  `GET /api/public/free-tier-data-sharing` remains blocker-explicit
+  (`owner_gated`) while the env-aware `POST /api/keys/free` mint response reports
+  `armed` only when `KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT` is actually armed.
+  Paid privacy / confidential compute remains the fail-closed non-capture path,
+  public sharing remains owner opt-in only, and trace reward/payout markers stay
+  inert. Keep `data.free_tier_capture_disclosure.v1`,
+  `data.khala_free_tier_trace_capture.v1`, and
+  `privacy.khala_paid_capture_optout.v1` yellow until owner sign-off, live gate
+  evidence, and the paid Khala business loop are green.
 - Khala -> Pylon -> Codex worker status at refresh: the latest supervised batch
   completed across `codex-2`, `codex-3`, and `codex-4`, with simultaneous runs
   on both `codex-2` and `codex-3` across the broader stress sequence. Accepted

--- a/docs/promises/2026-06-25-free-tier-data-sharing-disclosure.md
+++ b/docs/promises/2026-06-25-free-tier-data-sharing-disclosure.md
@@ -1,6 +1,6 @@
 # Free-API data-sharing terms / consent disclosure (promise record)
 
-> **Status: 2026-06-25.** Disclosure-only. This record documents the honest
+> **Status: 2026-06-29.** Disclosure-only. This record documents the honest
 > free-tier data-sharing terms that back default-on trace capture (#6293). It
 > ships NO capture behavior, NO authority, and moves NO money. It is the policy
 > half of capture going live; the storage/exclusion halves are #6293/#6294/#6295.
@@ -13,11 +13,11 @@
 ## Why
 
 Default-on capture (#6293) must be backed by an honest, discoverable disclosure.
-As of capture going live, free-tier `/api/v1/chat/completions` traffic is
-captured by default as **redacted, private (`owner_only`) ATIF traces** and **may
-be used to improve and train** OpenAgents models. Capturing free traffic for
-training without a clearly disclosed term is not acceptable. Users and agents
-must be told, in plain terms:
+When the owner-gated capture default is armed, free-tier
+`/api/v1/chat/completions` traffic is captured by default as **redacted, private
+(`owner_only`) ATIF traces** and **may be used to improve and train** OpenAgents
+models. Capturing free traffic for training without a clearly disclosed term is
+not acceptable. Users and agents must be told, in plain terms:
 
 > Use the free API and we capture your traffic (redacted, private by default) and
 > may use it to improve/train. Pay for privacy to opt out. Public sharing is
@@ -35,13 +35,15 @@ claim: >
   may be used to improve and train models; pay for privacy to opt out; public
   sharing is opt-in only.
 safeCopy: >
-  Free tier: when you use the free Khala API without paying for privacy, your
-  traffic is captured by default as a redacted, private-by-default (owner_only)
-  trace and may be used to improve and train OpenAgents models. Pay for privacy,
-  or run confidential compute, to opt out of capture (fail-closed to
-  not-captured). A captured trace is shared publicly only if its owner explicitly
-  opts it into public visibility. Capture grants no payout or settlement — the
-  data-market reward marker is inert and owner-gated.
+  Free tier: when the owner-gated capture default is armed, free Khala API
+  traffic from callers who have not paid for privacy is captured by default as a
+  redacted, private-by-default (owner_only) trace and may be used to improve and
+  train OpenAgents models. Pay for privacy, or run confidential compute, to opt
+  out of capture (fail-closed to not-captured). A captured trace is shared
+  publicly only if its owner explicitly opts it into public visibility. Capture
+  grants no payout or settlement — the data-market reward marker is inert and
+  owner-gated. The disclosure exposes deployment.captureDefaultGate so the
+  owner-gated blocker remains visible until the production flip is armed.
 unsafeCopy: >
   Do not claim free traffic is never captured, do not claim captured traces are
   public by default, do not claim paid-privacy callers are captured, and do not
@@ -60,8 +62,9 @@ blockerRefs:
   - blocker.product_promises.disclosure_copy_owner_signoff_pending
 verification: >
   GET /api/public/free-tier-data-sharing returns the canonical disclosure
-  (version, summary, ordered terms, bounded policy facts) and POST /api/keys/free
-  embeds the same dataSharing object. Terms stay accurate to the capture seams.
+  (version, summary, ordered terms, bounded policy facts, deployment gate) and
+  POST /api/keys/free embeds the same dataSharing object with the env-aware gate.
+  Terms stay accurate to the capture seams.
 reportPath: https://openagents.com/forum/f/product-promises
 authorityBoundary: >
   A disclosure grants no spend, payout, settlement, training-consent, or capture
@@ -88,10 +91,14 @@ Every clause maps to a real seam so the disclosure can never overclaim:
 
 1. **Free-key mint flow** — `POST /api/keys/free` returns a `dataSharing` object
    carrying the full terms, so the disclosure is delivered at the exact moment a
-   free key is created.
+   free key is created. This response is env-aware and reports
+   `deployment.captureDefaultGate: "armed"` only when
+   `KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT` is armed.
 2. **Agent-readable endpoint** — `GET /api/public/free-tier-data-sharing` serves
    the same canonical disclosure over the documented API surface (no auth), so
-   agents discover it without scraping human UI.
+   agents discover it without scraping human UI. Because this endpoint is
+   env-free and read-only, it keeps the conservative
+   `deployment.captureDefaultGate: "owner_gated"` blocker visible.
 3. **OpenAPI** — both surfaces are documented in the served OpenAPI contract
    (`FreeTierDataSharingDisclosure` schema; `getFreeTierDataSharingDisclosure`
    operation).
@@ -111,6 +118,7 @@ The disclosure text is implemented and discoverable, but two gates remain:
   gated per the audit (the keystone "drafts the terms for the owner to approve;
   the keystone does not ship copy").
 
-The terms are written to be true *whether or not* the flip is armed (they
-describe the policy that applies when it is), so they are safe to publish now and
-go green when the flip + owner sign-off land.
+The terms describe the policy that applies when the capture default is armed,
+while the `deployment.captureDefaultGate` field tells clients whether the current
+surface is still owner-gated. The promise goes green only when the flip and owner
+sign-off land.

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/christopherdavid/.pylon-fable/cache/codex-agent-tasks-node-modules-shared/20075bf07df76717d12f16b6/__root__/node_modules


### PR DESCRIPTION
Addresses #7019.

### Changes
- Added deployment gate metadata to the free-tier data-sharing disclosure, including the owner-gated default, env flag name, blocker ref, and armed state when `KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT` is enabled.
- Threaded the disclosure gate into `POST /api/keys/free` mint responses and updated the public disclosure API/OpenAPI surface.
- Updated product-promise and agent-facing docs to describe the owner-gated capture default and paid privacy opt-out path.
- Added tests for the default owner-gated disclosure and armed capture gate behavior.

### Verification
- `true` - passed (exit 0)