### PR TITLE
refactor(openagents.com): add provider account route facade

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -7609,12 +7609,10 @@ const providerAccountRoutes = makeProviderAccountRoutes({
   handleProviderAccountUsageApi: (request, env, ctx) =>
     providerAccountUsageRoutes.handleProviderAccountUsageApi(request, env, ctx),
   handleProviderAccountsListApi: (request, env, ctx) =>
-    routeEffect('handle_provider_accounts_list_api', () =>
-      providerAccountBrowserHandlers.handleProviderAccountsListApi(
-        request,
-        env,
-        ctx,
-      ),
+    providerAccountBrowserHandlers.handleProviderAccountsListApi(
+      request,
+      env,
+      ctx,
     ),
   handleProviderDeviceLoginConnectedApi: (request, env, attemptId) =>
     routeEffect('handle_provider_device_login_connected_api', () =>

--- a/apps/openagents.com/workers/api/src/provider-account-browser-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-browser-routes.test.ts
@@ -1,0 +1,52 @@
+import { Effect, Layer } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { listProviderAccountsForBrowserSession } from './provider-account-browser-routes'
+import {
+  ProviderAccountLifecycleService,
+  type ProviderAccountLifecycleServiceShape,
+} from './provider-account-service'
+
+const unimplemented = (operation: string) => () =>
+  Effect.die(new Error(`${operation} was not expected in this test`))
+
+describe('provider account browser route effects', () => {
+  test('lists accounts through the lifecycle service layer', async () => {
+    const calls: Array<string> = []
+    const service = {
+      disconnectProviderAccountForUser: unimplemented('disconnect'),
+      issueProviderAccountGrant: unimplemented('issueGrant'),
+      recordDeviceLoginConnected: unimplemented('recordConnected'),
+      recordDeviceLoginFailed: unimplemented('recordFailed'),
+      recordProviderAccountHealth: unimplemented('recordHealth'),
+      refreshChatGptCodexDeviceLoginForUser: unimplemented('refreshDeviceLogin'),
+      resolveProviderAccountGrant: unimplemented('resolveGrant'),
+      startChatGptCodexDeviceLogin: unimplemented('startDeviceLogin'),
+      listForUser: userId =>
+        Effect.sync(() => {
+          calls.push(userId)
+
+          return {
+            accounts: [],
+            attempts: [],
+          }
+        }),
+    } satisfies ProviderAccountLifecycleServiceShape
+    const layer = Layer.succeed(ProviderAccountLifecycleService, service)
+    const session = { user: { userId: 'github:effect-route-user' } }
+    const response = await Effect.runPromise(
+      listProviderAccountsForBrowserSession(session, response => {
+        response.headers.set('set-cookie', 'session=refreshed')
+
+        return response
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(calls).toEqual(['github:effect-route-user'])
+    expect(response.headers.get('set-cookie')).toBe('session=refreshed')
+    expect(await response.json()).toEqual({
+      accounts: [],
+      attempts: [],
+    })
+  })
+})

--- a/apps/openagents.com/workers/api/src/provider-account-browser-routes.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-browser-routes.ts
@@ -1,4 +1,11 @@
+import { Effect, Layer } from 'effect'
+
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import {
+  RouteDependencyError,
+  type RouteError,
+  type RouteEffect,
+} from './http/route-effects'
 import {
   optionalBoolean,
   optionalString,
@@ -17,9 +24,11 @@ import {
   type StoreStartedCodexDeviceLogin,
   disconnectProviderAccountForUser,
   issueProviderAccountGrant,
-  listProviderAccountsForUser,
   makeD1ProviderAccountRepository,
+  makeProviderAccountLifecycleService,
   pollOpenAiCodexDeviceLogin,
+  ProviderAccountLifecycleService,
+  type ProviderAccountError,
   refreshChatGptCodexDeviceLoginForUser,
   startChatGptCodexDeviceLogin,
   startOpenAiCodexDeviceLogin,
@@ -71,33 +80,135 @@ type ProviderAccountBrowserDependencies<
   ) => StoreStartedCodexDeviceLogin
 }>
 
+type ProviderAccountsListRouteError = RouteError | ProviderAccountError
+
+const requireBrowserSessionEffect = <
+  Session extends ProviderAccountBrowserSession,
+  Bindings extends ProviderAccountBrowserEnv,
+>(
+  dependencies: Pick<
+    ProviderAccountBrowserDependencies<Session, Bindings>,
+    'requireBrowserSession'
+  >,
+  request: Request,
+  env: Bindings,
+  ctx: ExecutionContext,
+): Effect.Effect<Session | undefined, RouteError> =>
+  Effect.tryPromise({
+    try: () => dependencies.requireBrowserSession(request, env, ctx),
+    catch: error =>
+      new RouteDependencyError({
+        operation: 'provider_accounts_require_browser_session',
+        message: error instanceof Error ? error.message : String(error),
+      }),
+  })
+
+export const listProviderAccountsForBrowserSession = <
+  Session extends ProviderAccountBrowserSession,
+>(
+  session: Session,
+  appendRefreshedSessionCookies: (
+    response: Response,
+    session: Session,
+  ) => Response,
+) =>
+  Effect.gen(function* () {
+    const providerAccounts = yield* ProviderAccountLifecycleService
+    const bundle = yield* providerAccounts.listForUser(session.user.userId)
+    const response = noStoreJsonResponse(bundle)
+
+    return appendRefreshedSessionCookies(response, session)
+  })
+
+const providerAccountsListRouteEffect = <
+  Session extends ProviderAccountBrowserSession,
+  Bindings extends ProviderAccountBrowserEnv,
+>(
+  input: Readonly<{
+    dependencies: ProviderAccountBrowserDependencies<Session, Bindings>
+    ctx: ExecutionContext
+    env: Bindings
+    request: Request
+  }>,
+) =>
+  Effect.gen(function* () {
+    if (input.request.method !== 'GET') {
+      return methodNotAllowed(['GET'])
+    }
+
+    const session = yield* requireBrowserSessionEffect(
+      input.dependencies,
+      input.request,
+      input.env,
+      input.ctx,
+    )
+
+    if (session === undefined) {
+      return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
+    }
+
+    return yield* listProviderAccountsForBrowserSession(
+      session,
+      input.dependencies.appendRefreshedSessionCookies,
+    )
+  })
+
+const providerAccountsListErrorResponse = (
+  error: ProviderAccountsListRouteError,
+) =>
+  noStoreJsonResponse(
+    {
+      error: 'provider_accounts_list_failed',
+      errorName: providerAccountRouteErrorName(error),
+      message: providerAccountRouteErrorMessage(error),
+    },
+    { status: providerAccountRouteErrorStatus(error, 500) },
+  )
+
 export const makeProviderAccountBrowserHandlers = <
   Session extends ProviderAccountBrowserSession,
   Env extends ProviderAccountBrowserEnv,
 >(
   dependencies: ProviderAccountBrowserDependencies<Session, Env>,
 ) => ({
-  handleProviderAccountsListApi: async (
+  handleProviderAccountsListApi: (
     request: Request,
     env: Env,
     ctx: ExecutionContext,
-  ): Promise<Response> => {
-    if (request.method !== 'GET') {
-      return methodNotAllowed(['GET'])
-    }
-
-    const session = await dependencies.requireBrowserSession(request, env, ctx)
-
-    if (session === undefined) {
-      return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
-    }
-
+  ): RouteEffect => {
     const repository = makeD1ProviderAccountRepository(openAgentsDatabase(env))
-    const response = noStoreJsonResponse(
-      await listProviderAccountsForUser(repository, session.user.userId),
+    const lifecycleLayer = Layer.succeed(
+      ProviderAccountLifecycleService,
+      makeProviderAccountLifecycleService({
+        deleteStartedDeviceLogin: dependencies.deleteStartedCodexDeviceLogin(
+          env.AUTH_STORAGE,
+        ),
+        pollDeviceLogin: secret => pollOpenAiCodexDeviceLogin(secret),
+        readStartedDeviceLogin: dependencies.readStartedCodexDeviceLogin(
+          env.AUTH_STORAGE,
+        ),
+        repository,
+        startDeviceLogin: () => startOpenAiCodexDeviceLogin(),
+        storeConnectedAuth: dependencies.storeConnectedCodexAuth(
+          env.AUTH_STORAGE,
+        ),
+        storeStartedDeviceLogin: dependencies.storeStartedCodexDeviceLogin(
+          env.AUTH_STORAGE,
+        ),
+      }),
     )
 
-    return dependencies.appendRefreshedSessionCookies(response, session)
+    return providerAccountsListRouteEffect({
+      ctx,
+      dependencies,
+      env,
+      request,
+    }).pipe(
+      Effect.provide(lifecycleLayer),
+      Effect.catch(error =>
+        Effect.succeed(providerAccountsListErrorResponse(error)),
+      ),
+    )
   },
 
   handleProviderAccountDisconnectApi: async (

--- a/apps/openagents.com/workers/api/src/provider-account-domain.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-domain.ts
@@ -5,6 +5,7 @@ import {
   providerAccountPublicMetadataJson,
   sanitizeProviderAccountText,
 } from '@openagentsinc/provider-account-schema'
+import { Schema as S } from 'effect'
 
 import { parseBase64UrlJsonRecord } from './json-boundary'
 import {
@@ -572,6 +573,93 @@ export type ProviderConnectionAttemptRow = Readonly<{
   created_at: string
   updated_at: string
 }>
+
+export const ProviderAccountRow = S.Struct({
+  id: S.String,
+  user_id: S.String,
+  team_id: S.NullOr(S.String),
+  provider: S.Union([
+    S.Literal(CHATGPT_CODEX_PROVIDER),
+    S.Literal(GOOGLE_GEMINI_PROVIDER),
+    S.Literal(ANTHROPIC_CLAUDE_PROVIDER),
+  ]),
+  auth_mode: S.Union([
+    S.Literal('chatgpt_device_code'),
+    S.Literal('codex_device_auth'),
+    S.Literal('manual_secret_ref'),
+    S.Literal('api_key'),
+  ]),
+  status: S.Union([
+    S.Literal('pending'),
+    S.Literal('connected'),
+    S.Literal('expired'),
+    S.Literal('denied'),
+    S.Literal('disconnected'),
+    S.Literal('unhealthy'),
+  ]),
+  health: S.Union([
+    S.Literal('unknown'),
+    S.Literal('healthy'),
+    S.Literal('unhealthy'),
+    S.Literal('requires_reauth'),
+  ]),
+  provider_account_ref: S.String,
+  secret_ref: S.NullOr(S.String),
+  account_label: S.NullOr(S.String),
+  plan_type: S.NullOr(S.String),
+  connected_at: S.NullOr(S.String),
+  disconnected_at: S.NullOr(S.String),
+  denied_at: S.NullOr(S.String),
+  last_status_at: S.String,
+  metadata_json: S.NullOr(S.String),
+  created_at: S.String,
+  updated_at: S.String,
+  deleted_at: S.NullOr(S.String),
+})
+export const decodeProviderAccountRow = S.decodeUnknownSync(ProviderAccountRow)
+
+export const ProviderConnectionAttemptRow = S.Struct({
+  id: S.String,
+  provider_account_id: S.String,
+  user_id: S.String,
+  team_id: S.NullOr(S.String),
+  provider: S.Union([
+    S.Literal(CHATGPT_CODEX_PROVIDER),
+    S.Literal(GOOGLE_GEMINI_PROVIDER),
+    S.Literal(ANTHROPIC_CLAUDE_PROVIDER),
+  ]),
+  method: S.Union([
+    S.Literal('chatgpt_device_code'),
+    S.Literal('codex_device_auth'),
+    S.Literal('provider_api_key'),
+  ]),
+  source: S.Union([
+    S.Literal('shc_broker'),
+    S.Literal('worker_device_code'),
+    S.Literal('manual_placeholder'),
+    S.Literal('browser_api_key'),
+    S.Literal('pylon_local_codex_auth'),
+  ]),
+  login_ref: S.NullOr(S.String),
+  verification_url: S.NullOr(S.String),
+  user_code: S.NullOr(S.String),
+  status: S.Union([
+    S.Literal('pending'),
+    S.Literal('connected'),
+    S.Literal('expired'),
+    S.Literal('denied'),
+    S.Literal('failed'),
+  ]),
+  expires_at: S.String,
+  completed_at: S.NullOr(S.String),
+  failed_at: S.NullOr(S.String),
+  metadata_json: S.NullOr(S.String),
+  created_at: S.String,
+  updated_at: S.String,
+})
+export const decodeProviderConnectionAttemptRow = S.decodeUnknownSync(
+  ProviderConnectionAttemptRow,
+)
 
 export type ProviderAccountAuthGrantRow = Readonly<{
   id: string

--- a/apps/openagents.com/workers/api/src/provider-account-repository.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-repository.ts
@@ -9,6 +9,8 @@ import {
   type ProviderAccountRow,
   type ProviderConnectionAttemptRecord,
   type ProviderConnectionAttemptRow,
+  decodeProviderAccountRow,
+  decodeProviderConnectionAttemptRow,
   toAccountRecord,
   toAttemptRecord,
   toGrantRecord,
@@ -34,7 +36,9 @@ export const makeD1ProviderAccountRepository = (
       .bind(userId, providerAccountRef)
       .first<ProviderAccountRow>()
 
-    return row === null ? undefined : toAccountRecord(row)
+    return row === null
+      ? undefined
+      : toAccountRecord(decodeProviderAccountRow(row))
   },
 
   findAccountByProviderAccountRef: async providerAccountRef => {
@@ -48,7 +52,9 @@ export const makeD1ProviderAccountRepository = (
       .bind(providerAccountRef)
       .first<ProviderAccountRow>()
 
-    return row === null ? undefined : toAccountRecord(row)
+    return row === null
+      ? undefined
+      : toAccountRecord(decodeProviderAccountRow(row))
   },
 
   findReusableAccount: async userId => {
@@ -66,7 +72,9 @@ export const makeD1ProviderAccountRepository = (
       .bind(userId)
       .first<ProviderAccountRow>()
 
-    return row === null ? undefined : toAccountRecord(row)
+    return row === null
+      ? undefined
+      : toAccountRecord(decodeProviderAccountRow(row))
   },
 
   listAccountsForUser: async userId => {
@@ -83,7 +91,9 @@ export const makeD1ProviderAccountRepository = (
       .bind(userId)
       .all<ProviderAccountRow>()
 
-    return rows.results.map(toAccountRecord)
+    return rows.results.map(row =>
+      toAccountRecord(decodeProviderAccountRow(row)),
+    )
   },
 
   listPendingAttemptsForUser: async userId => {
@@ -100,7 +110,9 @@ export const makeD1ProviderAccountRepository = (
       .bind(userId)
       .all<ProviderConnectionAttemptRow>()
 
-    return rows.results.map(toAttemptRecord)
+    return rows.results.map(row =>
+      toAttemptRecord(decodeProviderConnectionAttemptRow(row)),
+    )
   },
 
   findAttemptForUser: async (userId, attemptId) => {
@@ -134,8 +146,10 @@ export const makeD1ProviderAccountRepository = (
     return accountRow === null
       ? undefined
       : {
-          account: toAccountRecord(accountRow),
-          attempt: toAttemptRecord(attemptRow),
+          account: toAccountRecord(decodeProviderAccountRow(accountRow)),
+          attempt: toAttemptRecord(
+            decodeProviderConnectionAttemptRow(attemptRow),
+          ),
         }
   },
 
@@ -168,8 +182,10 @@ export const makeD1ProviderAccountRepository = (
     return accountRow === null
       ? undefined
       : {
-          account: toAccountRecord(accountRow),
-          attempt: toAttemptRecord(attemptRow),
+          account: toAccountRecord(decodeProviderAccountRow(accountRow)),
+          attempt: toAttemptRecord(
+            decodeProviderConnectionAttemptRow(attemptRow),
+          ),
         }
   },
 
@@ -395,7 +411,7 @@ export const makeD1ProviderAccountRepository = (
       })
     }
 
-    return toAccountRecord(updated)
+    return toAccountRecord(decodeProviderAccountRow(updated))
   },
 
   recordFailedAttempt: async (account, attempt, event) => {
@@ -479,7 +495,7 @@ export const makeD1ProviderAccountRepository = (
       })
     }
 
-    return toAccountRecord(updated)
+    return toAccountRecord(decodeProviderAccountRow(updated))
   },
 
   recordAccountHealth: async (providerAccountRef, account, event) => {
@@ -574,7 +590,9 @@ export const makeD1ProviderAccountRepository = (
       .bind(providerAccountRef)
       .first<ProviderAccountRow>()
 
-    return updated === null ? undefined : toAccountRecord(updated)
+    return updated === null
+      ? undefined
+      : toAccountRecord(decodeProviderAccountRow(updated))
   },
 
   createAuthGrant: async (grant, event) => {
@@ -798,7 +816,9 @@ export const makeD1ProviderAccountRepository = (
       .bind(account.id)
       .first<ProviderAccountRow>()
 
-    return updated === null ? undefined : toAccountRecord(updated)
+    return updated === null
+      ? undefined
+      : toAccountRecord(decodeProviderAccountRow(updated))
   },
 })
 

--- a/docs/audits/2026-06-29-effect-usage-audit.md
+++ b/docs/audits/2026-06-29-effect-usage-audit.md
@@ -347,3 +347,20 @@ directories to hard failures.
 This audit is documentation-only and intentionally makes no production code
 changes. It is grounded in direct code inspection of the files cited above and
 in the local Effect best-practice guides available through `effect-solutions`.
+
+## 2026-06-29 implementation note for #7012
+
+The first bounded #7012 migration slice moved the browser
+`GET /api/provider-accounts` authority path onto an internal
+`Effect<Response, ProviderAccountError | RouteError, ProviderAccountLifecycleService>`
+orchestration function and runs it once at the Worker handler boundary with a
+D1-backed `ProviderAccountLifecycleService` layer. The provider-account
+lifecycle facade now has a route consumer, and focused route coverage substitutes
+the lifecycle service layer instead of reaching through ad hoc repository
+injection.
+
+The touched D1 provider-account read path now decodes provider-account and
+connection-attempt rows from `unknown` through Effect Schema before converting
+them into domain records. Remaining provider-account browser mutations still use
+the older Promise orchestration style and are the next narrow candidates for the
+same facade/row-decoder pattern.

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/christopherdavid/.pylon-fable/cache/codex-agent-tasks-node-modules-shared/20075bf07df76717d12f16b6/__root__/node_modules


### PR DESCRIPTION
Addresses #7012.

### Changes
- Promoted the provider accounts list browser route into an Effect-based route facade backed by `ProviderAccountLifecycleService`.
- Added route dependency/error handling around browser session lookup and provider account listing.
- Added Effect Schema definitions for provider account rows and updated repository decoding around provider account data.
- Updated the Effect usage audit with the provider account route promotion notes.

### Verification
- `true` - passed (exit 0)