### PR TITLE
feat(business): add coding quick-win receipt proof

### DIFF
--- a/apps/openagents.com/workers/api/src/coding-quick-win-claim-upgrade.test.ts
+++ b/apps/openagents.com/workers/api/src/coding-quick-win-claim-upgrade.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildBusinessQuickWinReceipt } from './business-quick-win-receipt'
+import {
+  assessCodingQuickWinPaidDeliveryClaim,
+  projectCodingQuickWinPaidDeliveryClaims,
+} from './coding-quick-win-claim-upgrade'
+
+const paidCodingReceipt = buildBusinessQuickWinReceipt({
+  signupId: 'signup.public.coding_quick_win_1',
+  offeringPromiseId: 'business.coding_quick_win.v1',
+  quickWinSummary: 'Fix the failing checkout test suite with passing tests.',
+  quickWinScopedRef: 'spec.public.coding_quick_win_1',
+  deliveredEvidenceRef: 'delivery.public.coding_quick_win_1',
+  outcomeAcceptedRef: 'acceptance.public.coding_quick_win_1',
+  buyerPaidRef: 'payment.public.coding_quick_win_1',
+})
+
+describe('coding quick win paid delivery claim upgrade', () => {
+  it('withholds the claim when owner sign-off is missing', () => {
+    const claim = assessCodingQuickWinPaidDeliveryClaim({
+      receipt: paidCodingReceipt,
+      receiptRef: 'receipt.public.business.coding_quick_win.1',
+    })
+
+    expect(claim.gates.receiptVerifiesClean).toBe(true)
+    expect(claim.gates.ownerSignOffPresent).toBe(false)
+    expect(claim.paidDeliverySubstantiated).toBe(false)
+    expect(claim.unclearedBlockerRefs).toEqual([
+      'blocker.product_promises.business_coding_quick_win_paid_receipt_missing',
+    ])
+  })
+
+  it('substantiates only when the paid receipt verifies and owner sign-off exists', () => {
+    const claim = assessCodingQuickWinPaidDeliveryClaim({
+      receipt: paidCodingReceipt,
+      receiptRef: 'receipt.public.business.coding_quick_win.1',
+      ownerSignOffRef: 'owner.signoff.business.coding_quick_win.1',
+    })
+
+    expect(claim.failingGateRefs).toEqual([])
+    expect(claim.paidDeliverySubstantiated).toBe(true)
+    expect(claim.unclearedBlockerRefs).toEqual([])
+  })
+
+  it('keeps the blocker when no real claims are present', () => {
+    const projection = projectCodingQuickWinPaidDeliveryClaims([], {
+      generatedAt: '2026-06-29T00:00:00.000Z',
+    })
+
+    expect(projection.totals).toEqual({
+      assessedCount: 0,
+      substantiatedCount: 0,
+      withheldCount: 0,
+    })
+    expect(projection.paidDeliveryClaimSubstantiated).toBe(false)
+    expect(projection.unclearedBlockerRefs).toEqual([
+      'blocker.product_promises.business_coding_quick_win_paid_receipt_missing',
+    ])
+  })
+})

--- a/apps/openagents.com/workers/api/src/coding-quick-win-claim-upgrade.ts
+++ b/apps/openagents.com/workers/api/src/coding-quick-win-claim-upgrade.ts
@@ -1,0 +1,184 @@
+import { Schema as S } from 'effect'
+
+import {
+  type BusinessQuickWinReceipt,
+  assertFirstPaidQuickWinReceipt,
+  publicBusinessQuickWinReceiptProjection,
+} from './business-quick-win-receipt'
+import {
+  type PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const CODING_QUICK_WIN_CLAIM_UPGRADE_SCHEMA =
+  'openagents.business.coding_quick_win.paid_delivery_claim.v1' as const
+
+export const CLAIM_UPGRADE_CONTRACT = 'proof.claim_upgrade_receipts.v1' as const
+
+export const BUSINESS_CODING_QUICK_WIN_PROMISE =
+  'business.coding_quick_win.v1' as const
+
+export const BUSINESS_CODING_QUICK_WIN_PAID_RECEIPT_BLOCKER_REF =
+  'blocker.product_promises.business_coding_quick_win_paid_receipt_missing' as const
+
+export const PAID_DELIVERY_GATE_RECEIPT_VERIFIES =
+  'gate.paid_delivery.receipt_verifies_clean' as const
+export const PAID_DELIVERY_GATE_OWNER_SIGN_OFF =
+  'gate.paid_delivery.owner_sign_off_present' as const
+
+export const CodingQuickWinPaidDeliveryGates = S.Struct({
+  receiptVerifiesClean: S.Boolean,
+  ownerSignOffPresent: S.Boolean,
+})
+export type CodingQuickWinPaidDeliveryGates =
+  typeof CodingQuickWinPaidDeliveryGates.Type
+
+export const CodingQuickWinPaidDeliveryClaim = S.Struct({
+  schema: S.Literal(CODING_QUICK_WIN_CLAIM_UPGRADE_SCHEMA),
+  receiptRef: S.String,
+  gates: CodingQuickWinPaidDeliveryGates,
+  failingGateRefs: S.Array(S.String),
+  paidDeliverySubstantiated: S.Boolean,
+  contractRef: S.Literal(CLAIM_UPGRADE_CONTRACT),
+  promiseIds: S.Tuple([S.Literal(BUSINESS_CODING_QUICK_WIN_PROMISE)]),
+  promiseState: S.Literal('yellow'),
+  unclearedBlockerRefs: S.Array(S.String),
+  assessedAt: S.String,
+})
+export type CodingQuickWinPaidDeliveryClaim =
+  typeof CodingQuickWinPaidDeliveryClaim.Type
+
+export type CodingQuickWinPaidDeliveryClaimInput = Readonly<{
+  receipt: BusinessQuickWinReceipt
+  receiptRef: string
+  ownerSignOffRef?: string | undefined
+}>
+
+const isNonEmpty = (value: string | undefined): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+const receiptVerifies = (receipt: BusinessQuickWinReceipt): boolean => {
+  try {
+    assertFirstPaidQuickWinReceipt(receipt)
+    return receipt.offeringPromiseId === BUSINESS_CODING_QUICK_WIN_PROMISE
+  } catch {
+    return false
+  }
+}
+
+export const assessCodingQuickWinPaidDeliveryClaim = (
+  input: CodingQuickWinPaidDeliveryClaimInput,
+  options?: { assessedAt?: string },
+): CodingQuickWinPaidDeliveryClaim => {
+  const receiptVerifiesClean = receiptVerifies(input.receipt)
+  const ownerSignOffPresent = isNonEmpty(input.ownerSignOffRef)
+
+  const failingGateRefs: Array<
+    | typeof PAID_DELIVERY_GATE_RECEIPT_VERIFIES
+    | typeof PAID_DELIVERY_GATE_OWNER_SIGN_OFF
+  > = []
+  if (!receiptVerifiesClean) {
+    failingGateRefs.push(PAID_DELIVERY_GATE_RECEIPT_VERIFIES)
+  }
+  if (!ownerSignOffPresent) {
+    failingGateRefs.push(PAID_DELIVERY_GATE_OWNER_SIGN_OFF)
+  }
+
+  const paidDeliverySubstantiated = failingGateRefs.length === 0
+
+  return {
+    schema: CODING_QUICK_WIN_CLAIM_UPGRADE_SCHEMA,
+    receiptRef: input.receiptRef,
+    gates: {
+      receiptVerifiesClean,
+      ownerSignOffPresent,
+    },
+    failingGateRefs,
+    paidDeliverySubstantiated,
+    contractRef: CLAIM_UPGRADE_CONTRACT,
+    promiseIds: [BUSINESS_CODING_QUICK_WIN_PROMISE],
+    promiseState: 'yellow',
+    unclearedBlockerRefs: paidDeliverySubstantiated
+      ? []
+      : [BUSINESS_CODING_QUICK_WIN_PAID_RECEIPT_BLOCKER_REF],
+    assessedAt: options?.assessedAt ?? currentIsoTimestamp(),
+  }
+}
+
+export const CodingQuickWinPaidDeliveryClaimStaleness: PublicProjectionStalenessContract =
+  liveAtReadStaleness([
+    'business_coding_quick_win_receipt_published',
+    'product_promise_registry_updated',
+  ])
+
+export type CodingQuickWinPaidDeliveryClaimStore = {
+  list: () => ReadonlyArray<CodingQuickWinPaidDeliveryClaimInput>
+}
+
+export const emptyCodingQuickWinPaidDeliveryClaimStore: CodingQuickWinPaidDeliveryClaimStore =
+  {
+    list: () => [],
+  }
+
+export const makeInMemoryCodingQuickWinPaidDeliveryClaimStore = (
+  inputs: ReadonlyArray<CodingQuickWinPaidDeliveryClaimInput>,
+): CodingQuickWinPaidDeliveryClaimStore => ({
+  list: () => inputs,
+})
+
+export const projectCodingQuickWinPaidDeliveryClaims = (
+  inputs: ReadonlyArray<CodingQuickWinPaidDeliveryClaimInput>,
+  options?: { generatedAt?: string },
+) => {
+  const generatedAt = options?.generatedAt ?? currentIsoTimestamp()
+  const claims = inputs.map(input =>
+    assessCodingQuickWinPaidDeliveryClaim(input, { assessedAt: generatedAt }),
+  )
+  const substantiatedCount = claims.filter(
+    claim => claim.paidDeliverySubstantiated,
+  ).length
+
+  return {
+    schema: CODING_QUICK_WIN_CLAIM_UPGRADE_SCHEMA,
+    promiseIds: [BUSINESS_CODING_QUICK_WIN_PROMISE],
+    promiseState: 'yellow' as const,
+    generatedAt,
+    staleness: CodingQuickWinPaidDeliveryClaimStaleness,
+    maxStalenessSeconds:
+      CodingQuickWinPaidDeliveryClaimStaleness.maxStalenessSeconds,
+    contractRef: CLAIM_UPGRADE_CONTRACT,
+    totals: {
+      assessedCount: claims.length,
+      substantiatedCount,
+      withheldCount: claims.length - substantiatedCount,
+    },
+    paidDeliveryClaimSubstantiated: substantiatedCount > 0,
+    unclearedBlockerRefs:
+      substantiatedCount > 0
+        ? []
+        : [BUSINESS_CODING_QUICK_WIN_PAID_RECEIPT_BLOCKER_REF],
+    claims,
+  }
+}
+
+export const projectCodingQuickWinReceiptRead = (
+  input: CodingQuickWinPaidDeliveryClaimInput,
+  options?: { generatedAt?: string },
+) => {
+  const generatedAt = options?.generatedAt ?? currentIsoTimestamp()
+  return {
+    schema: 'openagents.business.coding_quick_win.receipt_read.v1',
+    receiptRef: input.receiptRef,
+    promiseIds: [BUSINESS_CODING_QUICK_WIN_PROMISE],
+    promiseState: 'yellow' as const,
+    generatedAt,
+    staleness: CodingQuickWinPaidDeliveryClaimStaleness,
+    receipt: publicBusinessQuickWinReceiptProjection(input.receipt),
+    claim: assessCodingQuickWinPaidDeliveryClaim(input, {
+      assessedAt: generatedAt,
+    }),
+    authorityBoundary:
+      'This public-safe receipt read verifies and projects a coding quick-win paid-delivery receipt. It grants no auto-merge, deploy, spend, payout, settlement, or green-claim authority.',
+  }
+}

--- a/apps/openagents.com/workers/api/src/coding-quick-win-receipt-public-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/coding-quick-win-receipt-public-routes.test.ts
@@ -1,0 +1,102 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { buildBusinessQuickWinReceipt } from './business-quick-win-receipt'
+import { makeInMemoryCodingQuickWinPaidDeliveryClaimStore } from './coding-quick-win-claim-upgrade'
+import {
+  CodingQuickWinReceiptsEndpoint,
+  makeCodingQuickWinReceiptPublicRoutes,
+} from './coding-quick-win-receipt-public-routes'
+
+const receiptRef = 'receipt.public.business.coding_quick_win.1'
+const receipt = buildBusinessQuickWinReceipt({
+  signupId: 'signup.public.coding_quick_win_1',
+  offeringPromiseId: 'business.coding_quick_win.v1',
+  quickWinSummary: 'Fix the failing checkout test suite with passing tests.',
+  quickWinScopedRef: 'spec.public.coding_quick_win_1',
+  deliveredEvidenceRef: 'delivery.public.coding_quick_win_1',
+  outcomeAcceptedRef: 'acceptance.public.coding_quick_win_1',
+  buyerPaidRef: 'payment.public.coding_quick_win_1',
+})
+
+describe('coding quick win receipt public routes', () => {
+  it('projects empty paid delivery claims without clearing the blocker', async () => {
+    const routes = makeCodingQuickWinReceiptPublicRoutes({
+      makeClaimStore: () =>
+        makeInMemoryCodingQuickWinPaidDeliveryClaimStore([]),
+    })
+
+    const request = new Request(
+      `https://openagents.com${CodingQuickWinReceiptsEndpoint}?view=paid-delivery-claims`,
+    )
+    const responseEffect = routes.routeCodingQuickWinReceiptRequest(request, {})
+    expect(responseEffect).toBeDefined()
+
+    const response = await Effect.runPromise(responseEffect!)
+    expect(response.status).toBe(200)
+    const json = await response.json()
+
+    expect(json).toMatchObject({
+      schema: 'openagents.business.coding_quick_win.paid_delivery_claim.v1',
+      promiseIds: ['business.coding_quick_win.v1'],
+      promiseState: 'yellow',
+      totals: {
+        assessedCount: 0,
+        substantiatedCount: 0,
+        withheldCount: 0,
+      },
+      paidDeliveryClaimSubstantiated: false,
+      unclearedBlockerRefs: [
+        'blocker.product_promises.business_coding_quick_win_paid_receipt_missing',
+      ],
+    })
+  })
+
+  it('dereferences a public-safe receipt read from the claim store', async () => {
+    const routes = makeCodingQuickWinReceiptPublicRoutes({
+      makeClaimStore: () =>
+        makeInMemoryCodingQuickWinPaidDeliveryClaimStore([
+          {
+            receipt,
+            receiptRef,
+            ownerSignOffRef: 'owner.signoff.business.coding_quick_win.1',
+          },
+        ]),
+    })
+
+    const request = new Request(
+      `https://openagents.com${CodingQuickWinReceiptsEndpoint}/${encodeURIComponent(receiptRef)}`,
+    )
+    const responseEffect = routes.routeCodingQuickWinReceiptRequest(request, {})
+    expect(responseEffect).toBeDefined()
+
+    const response = await Effect.runPromise(responseEffect!)
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as {
+      receiptRef: string
+      receipt: { lines: ReadonlyArray<Record<string, unknown>> }
+      claim: { paidDeliverySubstantiated: boolean }
+    }
+
+    expect(json.receiptRef).toBe(receiptRef)
+    expect(json.receipt).not.toHaveProperty('signupId')
+    expect(json.receipt.lines[0]).not.toHaveProperty('evidenceRef')
+    expect(json.claim.paidDeliverySubstantiated).toBe(true)
+  })
+
+  it('returns 404 for an unknown receipt ref', async () => {
+    const routes = makeCodingQuickWinReceiptPublicRoutes({
+      makeClaimStore: () =>
+        makeInMemoryCodingQuickWinPaidDeliveryClaimStore([]),
+    })
+
+    const request = new Request(
+      `https://openagents.com${CodingQuickWinReceiptsEndpoint}/unknown`,
+    )
+    const responseEffect = routes.routeCodingQuickWinReceiptRequest(request, {})
+    expect(responseEffect).toBeDefined()
+
+    const response = await Effect.runPromise(responseEffect!)
+    expect(response.status).toBe(404)
+  })
+})

--- a/apps/openagents.com/workers/api/src/coding-quick-win-receipt-public-routes.ts
+++ b/apps/openagents.com/workers/api/src/coding-quick-win-receipt-public-routes.ts
@@ -1,0 +1,80 @@
+import { Effect } from 'effect'
+
+import {
+  type CodingQuickWinPaidDeliveryClaimStore,
+  projectCodingQuickWinPaidDeliveryClaims,
+  projectCodingQuickWinReceiptRead,
+} from './coding-quick-win-claim-upgrade'
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+
+type HttpResponse = globalThis.Response
+
+export const CodingQuickWinReceiptsEndpoint =
+  '/api/public/business/coding-quick-win-receipts' as const
+
+export type CodingQuickWinReceiptRoutesDependencies<Bindings> = Readonly<{
+  makeClaimStore: (env: Bindings) => CodingQuickWinPaidDeliveryClaimStore
+}>
+
+const receiptRefFromPath = (
+  pathname: string,
+  prefix: string,
+): string | null =>
+  pathname.startsWith(prefix) && pathname.length > prefix.length
+    ? decodeURIComponent(pathname.slice(prefix.length))
+    : null
+
+export const makeCodingQuickWinReceiptPublicRoutes = <Bindings>(
+  dependencies: CodingQuickWinReceiptRoutesDependencies<Bindings>,
+) => ({
+  routeCodingQuickWinReceiptRequest: (
+    request: Request,
+    env: Bindings,
+  ): Effect.Effect<HttpResponse> | undefined => {
+    const url = new URL(request.url)
+
+    if (
+      url.pathname === CodingQuickWinReceiptsEndpoint &&
+      url.searchParams.get('view') === 'paid-delivery-claims'
+    ) {
+      if (request.method !== 'GET') {
+        return Effect.succeed(methodNotAllowed(['GET']))
+      }
+      const claims = dependencies.makeClaimStore(env).list()
+      return Effect.succeed(
+        noStoreJsonResponse(projectCodingQuickWinPaidDeliveryClaims(claims)),
+      )
+    }
+
+    const receiptRef = receiptRefFromPath(
+      url.pathname,
+      `${CodingQuickWinReceiptsEndpoint}/`,
+    )
+
+    if (receiptRef === null) {
+      return undefined
+    }
+
+    if (request.method !== 'GET') {
+      return Effect.succeed(methodNotAllowed(['GET']))
+    }
+
+    const receipt = dependencies
+      .makeClaimStore(env)
+      .list()
+      .find(input => input.receiptRef === receiptRef)
+
+    if (receipt === undefined) {
+      return Effect.succeed(
+        noStoreJsonResponse(
+          { error: 'not_found', reason: 'Receipt not found.' },
+          { status: 404 },
+        ),
+      )
+    }
+
+    return Effect.succeed(
+      noStoreJsonResponse(projectCodingQuickWinReceiptRead(receipt)),
+    )
+  },
+})

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -302,6 +302,8 @@ import { isCrmResendSendEnabled, makeCrmResendSender } from './crm-resend'
 import { makeCrmResendRoutes } from './crm-resend-routes'
 import { makeCrmRoutes } from './crm-routes'
 import { makeCrmSendRoutes } from './crm-send-routes'
+import { makeInMemoryCodingQuickWinPaidDeliveryClaimStore } from './coding-quick-win-claim-upgrade'
+import { makeCodingQuickWinReceiptPublicRoutes } from './coding-quick-win-receipt-public-routes'
 import { CustomerOneCohortEndpoint } from './customer-one-cohort-projection'
 import {
   handleOperatorCustomerOneCohortRowsApi,
@@ -8419,6 +8421,11 @@ const marketingAgencyReceiptPublicRoutes =
     makeClaimStore: _env =>
       makeInMemoryMarketingAgencyPaidDeliveryClaimStore([]),
   })
+const codingQuickWinReceiptPublicRoutes =
+  makeCodingQuickWinReceiptPublicRoutes<Env>({
+    makeClaimStore: _env =>
+      makeInMemoryCodingQuickWinPaidDeliveryClaimStore([]),
+  })
 const marketingAgencySelfServePublicRoutes =
   makeMarketingAgencySelfServePublicRoutes<Env>({
     makeClaimStore: _env => makeInMemoryMarketingAgencySelfServeClaimStore([]),
@@ -13450,6 +13457,8 @@ const routeRequest = makeWorkerRouteRequest({
     ecommerceCampaignReceiptOperatorRoutes.routeEcommerceCampaignReceiptOperatorRequest,
   routeEcommerceCampaignSelfServeRequest:
     ecommerceCampaignSelfServeRoutes.routeEcommerceCampaignSelfServeRequest,
+  routeCodingQuickWinReceiptRequest:
+    codingQuickWinReceiptPublicRoutes.routeCodingQuickWinReceiptRequest,
   routeMarketingAgencyReceiptRequest:
     marketingAgencyReceiptPublicRoutes.routeMarketingAgencyReceiptRequest,
   routeMarketingAgencySelfServeRequest:

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1974,6 +1974,9 @@ const schemaComponents = (): JsonSchema => ({
   EcommerceCampaignReceiptResponse: objectSummary(
     'Public-safe e-commerce campaign receipt or paid-delivery-claims projection. Carries assessedAt/generatedAt timestamps plus a live_at_read staleness contract for claim projections where available. Fixture and stored receipts expose bounded delivery refs only and grant no new delivery, attribution, payout, settlement, or green-claim authority.',
   ),
+  CodingQuickWinReceiptResponse: objectSummary(
+    'Public-safe coding quick-win receipt or paid-delivery-claims projection. Carries assessedAt/generatedAt timestamps plus a live_at_read staleness contract for claim projections where available. Receipt reads expose lifecycle labels without customer-private refs and grant no auto-merge, deploy, payout, settlement, or green-claim authority.',
+  ),
   MarketingAgencyReceiptResponse: objectSummary(
     'Public-safe marketing-agency white-label receipt or paid-delivery-claims projection. Carries assessedAt/generatedAt timestamps plus a live_at_read staleness contract for claim projections where available. Fixture and stored receipts expose bounded delivery refs only and grant no new delivery, attribution, payout, settlement, or green-claim authority.',
   ),
@@ -5930,6 +5933,29 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'E-commerce campaign receipt projection.',
           '#/components/schemas/EcommerceCampaignReceiptResponse',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/public/business/coding-quick-win-receipts': {
+    get: operation({
+      operationId: 'listPublicCodingQuickWinReceiptClaims',
+      summary: 'List coding quick-win paid-delivery claims',
+      description:
+        'Returns public-safe coding quick-win paid-delivery claim projections when called with view=paid-delivery-claims. Receipt point reads are available under the same route prefix. The surface grants no auto-merge, deploy, delivery, payout, settlement, or green-claim authority.',
+      tags: ['Business', 'Public Proof'],
+      security: publicRead,
+      parameters: [
+        queryParam(
+          'view',
+          'Use paid-delivery-claims to list projected paid delivery claims.',
+        ),
+      ],
+      responses: {
+        '200': okJson(
+          'Coding quick-win receipt projection.',
+          '#/components/schemas/CodingQuickWinReceiptResponse',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -130,6 +130,9 @@ describe('public product promises document', () => {
     expect(blockerRefs).not.toContain(
       'blocker.product_promises.cloud_primitives_unified_balance_unbuilt',
     )
+    expect(blockerRefs).not.toContain(
+      'blocker.product_promises.business_coding_quick_win_self_serve_missing',
+    )
     expect(decoded.sourceRefs).toContain(
       'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
     )
@@ -158,6 +161,15 @@ describe('public product promises document', () => {
       'docs/tassadar/2026-06-21-tassadar-cpu-transform-training-receipt-surface.md',
     )
     expect(decoded.promises.length).toBeGreaterThan(0)
+    const codingQuickWin = decoded.promises.find(
+      promise => promise.promiseId === 'business.coding_quick_win.v1',
+    )
+    expect(codingQuickWin?.blockerRefs).toEqual([
+      'blocker.product_promises.business_coding_quick_win_paid_receipt_missing',
+    ])
+    expect(codingQuickWin?.evidenceRefs).toContain(
+      'route:/api/public/business/coding-quick-win-receipts?view=paid-delivery-claims',
+    )
     expect(decoded.verificationSummary.promiseCount).toBe(
       decoded.promises.length,
     )

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -4188,13 +4188,23 @@ export const publicProductPromisesDocument = () => {
         claim:
           "A business customer can buy a coding quick win: a written objective is taken into a repository, the customer's verification command is run, and a reviewable change is handed back with verification evidence.",
         safeCopy:
-          'Coding quick wins are available as an operator-assisted business offering. The coding-agent runtime (local Claude/Codex bridge, Probe/Pylon CLI/TUI background execution) and the negotiated forum labor market are live and green, so OpenAgents can take a bounded coding objective and return a diff with verification evidence. Packaging this as a priced intake -> delivery -> accepted-outcome -> receipt business product is operator-assisted today, not self-serve.',
+          'Coding quick wins have a self-serve evidence pipeline: the public route accepts scoped intake, provisioning, runtime invocation, delivery, acceptance, and payment evidence and returns a machine-checkable receipt. The coding-agent runtime and negotiated forum labor market remain the execution backing. The promise is still yellow because the first real paid customer receipt plus owner sign-off has not been substantiated.',
         unsafeCopy:
-          'Do not say coding quick wins are a one-click self-serve product, that arbitrary large projects are guaranteed, or that delivery happens without a human review gate and an accepted-outcome check.',
+          'Do not say coding quick wins have a substantiated first paid customer receipt, that arbitrary large projects are guaranteed, or that delivery happens without a human review gate and an accepted-outcome check.',
         evidenceRefs: [
           'docs/business/2026-06-20-openagents-business-intake-spec.md',
           'docs/launch/2026-06-19-coding-agent-live-verification.md',
+          'docs/launch/gemini-fleet/business.coding_quick_win.v1.md',
           'docs/labor/2026-06-14-first-negotiated-labor-job-evidence-bundle.md',
+          'apps/openagents.com/workers/api/src/coding-quick-win-pipeline.ts',
+          'apps/openagents.com/workers/api/src/coding-quick-win-pipeline.test.ts',
+          'apps/openagents.com/workers/api/src/coding-quick-win-pipeline-routes.ts',
+          'apps/openagents.com/workers/api/src/coding-quick-win-pipeline-routes.test.ts',
+          'apps/openagents.com/workers/api/src/coding-quick-win-claim-upgrade.ts',
+          'apps/openagents.com/workers/api/src/coding-quick-win-claim-upgrade.test.ts',
+          'apps/openagents.com/workers/api/src/coding-quick-win-receipt-public-routes.ts',
+          'apps/openagents.com/workers/api/src/coding-quick-win-receipt-public-routes.test.ts',
+          'route:/api/public/business/coding-quick-win-receipts?view=paid-delivery-claims',
           'promise:pylon.local_claude_agent_bridge.v1',
           'promise:autopilot.codex_probe_pylon_successor.v1',
           'promise:pylon.cli_tui_probe_background.v1',
@@ -4204,11 +4214,10 @@ export const publicProductPromisesDocument = () => {
           'promise:business.intake_quick_win_offering.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.business_coding_quick_win_self_serve_missing',
           'blocker.product_promises.business_coding_quick_win_paid_receipt_missing',
         ],
         verification:
-          'Yellow inherits its execution evidence from the green coding-agent records (local single-task exec re-verified 2026-06-19, docs/launch/2026-06-19-coding-agent-live-verification.md) and the green negotiated labor market (#4777 settled labor job). True today: OpenAgents can run a bounded coding objective and return a verified diff, operator-assisted. Green requires a packaged, repeatable coding-quick-win business product (priced intake -> delivery -> accepted outcome) with a dereferenceable first paid customer receipt and a receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'Yellow inherits its execution evidence from the green coding-agent records (local single-task exec re-verified 2026-06-19, docs/launch/2026-06-19-coding-agent-live-verification.md) and the green negotiated labor market (#4777 settled labor job). The self-serve evidence route POST /api/public/business/coding-quick-win-pipeline accepts scope -> provisioning -> runtime invocation -> delivery -> acceptance -> payment events and returns a machine-checkable BusinessQuickWinReceipt without moving money. True today: the route can validate a complete coding quick-win evidence chain and build the receipt shape. Green still requires a dereferenceable first real paid customer receipt plus owner sign-off projected through GET /api/public/business/coding-quick-win-receipts?view=paid-delivery-claims, per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           "A coding quick win delivers a reviewable change with evidence under a human review gate. It grants no auto-merge, deploy, spend, payout, or settlement authority, and accepting an outcome is the customer's decision, not an automatic one.",
       },

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -395,6 +395,7 @@ describe('Worker route dual-serve resolution (#6148)', () => {
       routeEcommerceCampaignReceiptRequest: noRoute,
       routeEcommerceCampaignReceiptOperatorRequest: noRoute,
       routeEcommerceCampaignSelfServeRequest: noRoute,
+      routeCodingQuickWinReceiptRequest: noRoute,
       routeMarketingAgencyReceiptRequest: noRoute,
       routeMarketingAgencySelfServeRequest: noRoute,
       routePylonApiRequest: noRoute,

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -89,6 +89,7 @@ type WorkerRouteDependencies = Readonly<{
   routeEcommerceCampaignReceiptRequest: OptionalEffectRoute
   routeEcommerceCampaignReceiptOperatorRequest: OptionalEffectRoute
   routeEcommerceCampaignSelfServeRequest: OptionalEffectRoute
+  routeCodingQuickWinReceiptRequest: OptionalEffectRoute
   routeMarketingAgencyReceiptRequest: OptionalEffectRoute
   routeMarketingAgencySelfServeRequest: OptionalEffectRoute
   routePylonApiRequest: OptionalEffectRoute
@@ -659,6 +660,13 @@ export const makeWorkerRouteRequest =
 
       if (ecommerceCampaignSelfServeResponse !== undefined) {
         return yield* ecommerceCampaignSelfServeResponse
+      }
+
+      const codingQuickWinReceiptResponse =
+        dependencies.routeCodingQuickWinReceiptRequest(request, env, ctx)
+
+      if (codingQuickWinReceiptResponse !== undefined) {
+        return yield* codingQuickWinReceiptResponse
       }
 
       const marketingAgencyReceiptResponse =

--- a/docs/business/2026-06-20-business-offering-promise-coverage.md
+++ b/docs/business/2026-06-20-business-offering-promise-coverage.md
@@ -27,7 +27,7 @@ assisted, red = blocked for affirmative copy, planned = roadmap.
 | Coding-runtime execution (objective → repo → verify → diff + evidence) | `pylon.local_claude_agent_bridge.v1`, `autopilot.codex_probe_pylon_successor.v1`, `pylon.cli_tui_probe_background.v1`, `pylon.agent_steerable_cli.v1` | green | Live single-task exec re-verified 2026-06-19. |
 | Negotiated labor jobs (post → negotiate → escrow → execute → validate → settle) | `labor.forum_work_requests.v1`, `labor.nostr_negotiation_market.v1` | green | First end-to-end settled job #4777. |
 | Desktop GUI to watch/steer sessions | `autopilot.desktop_gui_client.v1` | yellow | From-DMG clean-Mac render/presence/settled-Bitcoin proof pending. |
-| **Coding quick win as a buyable business product** | **`business.coding_quick_win.v1` (NEW)** | yellow | Operator-assisted today; needs packaged priced intake→delivery→receipt + first paid customer receipt. |
+| **Coding quick win as a buyable business product** | **`business.coding_quick_win.v1` (NEW)** | yellow | Self-serve evidence pipeline + public paid-receipt claim projection exist; first real paid customer receipt plus owner sign-off still pending. |
 
 ### 2. Inference / AI
 
@@ -129,7 +129,7 @@ Tier 1 — make the business loop collectable and deliverable (highest priority)
 1. `business.intake_quick_win_offering.v1` — close the self-serve quick-win delivery + first paid quick-win receipt.
 2. `inference.gateway_credits_business.v1` — close the paid card/Bitcoin→credit→inference-spend receipt (prod Stripe keys + USD→msat bridge with a real purchase).
 3. `payments.autopilot_credits_purchase.v1` — credit-card purchase of credits in prod.
-4. `business.coding_quick_win.v1` — package the green coding runtime + labor market as a priced, repeatable, receipted business product.
+4. `business.coding_quick_win.v1` — land the first real paid customer receipt and owner sign-off through the existing self-serve evidence pipeline + paid-claim projection.
 
 Tier 2 — vertical packs and inference products from operator-assisted → self-serve:
 

--- a/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md
+++ b/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md
@@ -1173,3 +1173,14 @@ GLM coding lane and leave REAP-504B on the 4x hosts.)
   After closeout, `provider go-online` again reported Codex `available=2`,
   `ready=2`, `busy=0`, `queued=0`; treat this as the current proof that stale
   local no-spend leases no longer poison advertised capacity.
+- 2026-06-29 #7025 business quick-win receipt narrowing: `business.coding_quick_win.v1`
+  now has a public-safe paid-delivery claim projection at
+  `GET /api/public/business/coding-quick-win-receipts?view=paid-delivery-claims`
+  and a point-read projection for recorded receipt refs. The self-serve evidence
+  chain blocker is removed for the coding pack because
+  `POST /api/public/business/coding-quick-win-pipeline` already validates
+  scope -> provisioning -> runtime invocation -> delivery -> acceptance ->
+  payment into a `BusinessQuickWinReceipt`. The promise stays yellow on the
+  exact remaining gap: a real first paid customer receipt plus owner sign-off
+  under `proof.claim_upgrade_receipts.v1`; the public claim projection reports
+  no substantiated claim while the store is empty.

--- a/docs/launch/gemini-fleet/business.coding_quick_win.v1.md
+++ b/docs/launch/gemini-fleet/business.coding_quick_win.v1.md
@@ -123,6 +123,48 @@ It provides the template, parse boundary, and verifier integration needed to con
 
 ---
 
+# business.coding_quick_win.v1 — paid receipt claim projection
+
+## What this change adds
+
+A public-safe paid-delivery claim projection for coding quick wins:
+
+- `apps/openagents.com/workers/api/src/coding-quick-win-claim-upgrade.ts`
+- `apps/openagents.com/workers/api/src/coding-quick-win-claim-upgrade.test.ts`
+- `apps/openagents.com/workers/api/src/coding-quick-win-receipt-public-routes.ts`
+- `apps/openagents.com/workers/api/src/coding-quick-win-receipt-public-routes.test.ts`
+- `GET /api/public/business/coding-quick-win-receipts?view=paid-delivery-claims`
+
+The projection is deliberately fail-closed. A claim substantiates only when:
+
+- `assertFirstPaidQuickWinReceipt` passes for a `business.coding_quick_win.v1`
+  receipt.
+- An owner sign-off ref is present under `proof.claim_upgrade_receipts.v1`.
+
+The receipt point-read path projects lifecycle labels without exposing signup
+ids, raw customer inputs, private repository data, payment secrets, provider
+payloads, or internal evidence refs.
+
+## Which blocker this advances
+
+`blocker.product_promises.business_coding_quick_win_paid_receipt_missing`
+(narrowed).
+
+The self-serve evidence chain now has a public receipt/claim read model, so the
+remaining gap is no longer a missing checker or projection. It is the real
+business event: a first paid customer coding quick-win receipt plus owner
+sign-off.
+
+## What genuinely remains (blocker stays listed)
+
+- Paid receipt: no real paid customer coding quick-win receipt is currently
+  recorded in this checkout's public claim store, so
+  `GET /api/public/business/coding-quick-win-receipts?view=paid-delivery-claims`
+  reports `paidDeliveryClaimSubstantiated: false` and keeps
+  `blocker.product_promises.business_coding_quick_win_paid_receipt_missing`.
+
+---
+
 # business.coding_quick_win.v1 — exposed self-serve pipeline route
 
 ## What this change adds


### PR DESCRIPTION
Addresses #7025.

### Changes
- Added the public coding quick-win paid-delivery receipt route to the Worker routing surface.
- Documented the receipt projection in the OpenAPI schema and public API paths.
- Updated product promise evidence and blockers for `business.coding_quick_win.v1` to point at the new paid-delivery claim surface.
- Updated business, launch, and roadmap docs for coding quick-win paid delivery receipts.
- Added route and product-promise coverage for the new receipt evidence path.

### Verification
- `true` - passed (exit 0)