### PR TITLE
feat(api): add Hosted Gemini readiness proof

### DIFF
--- a/apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness-routes.test.ts
@@ -1,0 +1,150 @@
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import type {
+  InferenceReceiptReadStore,
+  InferenceReceiptRecord,
+} from './inference-receipts'
+import type {
+  PromiseTransitionReceipt,
+  PromiseTransitionReceiptStore,
+} from './promise-transition-receipt-routes'
+import { makeHostedGeminiPromiseReadinessRoutes } from './hosted-gemini-promise-readiness-routes'
+
+const receiptRef = 'receipt.inference.charge.chatcmpl_hosted_gemini_prod'
+
+const record = (
+  input: Partial<InferenceReceiptRecord> = {},
+): InferenceReceiptRecord => ({
+  contextRef:
+    'inference:vertex-gemini:served:models%2Fgemini-2.5-flash:tokens:321:requested:openagents%2Fkhala',
+  createdAt: '2026-06-29T11:59:00.000Z',
+  payInType: 'adjustment',
+  receiptRef,
+  state: 'paid',
+  stateChangedAt: '2026-06-29T11:59:01.000Z',
+  ...input,
+})
+
+const transition = (
+  input: Partial<PromiseTransitionReceipt> = {},
+): PromiseTransitionReceipt => ({
+  checkedAt: '2026-06-29T12:01:00.000Z',
+  checks: [],
+  evidenceRefs: [receiptRef],
+  exception: {
+    approvedByRef: 'owner:openagents',
+    expiresAt: '2026-07-06',
+    reasonRef: 'owner_signoff.hosted_gemini.production_receipt',
+  },
+  fromState: 'yellow',
+  promiseId: 'api.hosted_gemini.v1',
+  receiptId: 'promise_transition_hosted_gemini_green_1',
+  registryVersion: '2026-06-29.1',
+  result: 'exception',
+  toState: 'green',
+  ...input,
+})
+
+const stores = (
+  records: ReadonlyArray<InferenceReceiptRecord>,
+  receipts: ReadonlyArray<PromiseTransitionReceipt>,
+) => {
+  const inference: InferenceReceiptReadStore = {
+    readInferenceReceiptByRef: ref =>
+      Promise.resolve(records.find(candidate => candidate.receiptRef === ref) ?? null),
+  }
+  const transitions: PromiseTransitionReceiptStore = {
+    createReceipt: () => Promise.resolve(),
+    listReceipts: () => Promise.resolve(receipts),
+  }
+
+  return { inference, transitions }
+}
+
+const route = async (
+  input: ReturnType<typeof stores>,
+  url: string,
+  init?: RequestInit,
+) => {
+  const routes = makeHostedGeminiPromiseReadinessRoutes<
+    ReturnType<typeof stores>
+  >({
+    makeInferenceReceiptStore: env => env.inference,
+    makeTransitionReceiptStore: env => env.transitions,
+    nowIso: () => '2026-06-29T12:02:00.000Z',
+  })
+  const response = routes.routeHostedGeminiPromiseReadinessRequest(
+    new Request(url, init),
+    input,
+  )
+
+  if (response === undefined) {
+    throw new Error('hosted Gemini readiness route did not match')
+  }
+
+  return Effect.runPromise(response)
+}
+
+describe('Hosted Gemini product-promise readiness route', () => {
+  test('serves public-safe readiness for a production receipt and owner transition', async () => {
+    const response = await route(
+      stores([record()], [transition()]),
+      `https://openagents.com/api/public/product-promises/api.hosted_gemini.v1/readiness?receiptRef=${encodeURIComponent(
+        receiptRef,
+      )}`,
+    )
+    const body = (await response.json()) as Record<string, any>
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(body.generatedAt).toBe('2026-06-29T12:02:00.000Z')
+    expect(body.maxStalenessSeconds).toBe(0)
+    expect(body.staleness).toMatchObject({
+      composition: 'live_at_read',
+      maxStalenessSeconds: 0,
+    })
+    expect(body.readiness).toMatchObject({
+      greenGateMet: true,
+      promiseId: 'api.hosted_gemini.v1',
+      receiptRef,
+      requestPath: 'POST /api/v1/chat/completions',
+      responseShapeRef: 'response.openai_compatible.chat_completion.success',
+      schemaVersion: 'openagents.product_promise.hosted_gemini_readiness.v1',
+    })
+    expect(body.readiness.blockerRefs).toEqual([])
+    expect(JSON.stringify(body)).not.toMatch(
+      /bearer\s+[A-Za-z0-9._-]+|\bsk-[A-Za-z0-9_-]{16,}|wallet_key/i,
+    )
+  })
+
+  test('keeps blockers when the receipt is missing or the method mutates', async () => {
+    const missingReceipt = await route(
+      stores([], []),
+      `https://openagents.com/api/public/product-promises/api.hosted_gemini.v1/readiness?receiptRef=${encodeURIComponent(
+        receiptRef,
+      )}`,
+    )
+    const missingParam = await route(
+      stores([], []),
+      'https://openagents.com/api/public/product-promises/api.hosted_gemini.v1/readiness',
+    )
+    const mutation = await route(
+      stores([], []),
+      `https://openagents.com/api/public/product-promises/api.hosted_gemini.v1/readiness?receiptRef=${encodeURIComponent(
+        receiptRef,
+      )}`,
+      { method: 'POST' },
+    )
+    const body = (await missingReceipt.json()) as Record<string, any>
+
+    expect(missingReceipt.status).toBe(200)
+    expect(body.readiness.greenGateMet).toBe(false)
+    expect(body.readiness.blockerRefs).toEqual([
+      'blocker.product_promises.hosted_gemini_production_receipt_pending',
+      'blocker.product_promises.hosted_gemini_owner_upgrade_signoff_pending',
+    ])
+    expect(missingParam.status).toBe(400)
+    expect(mutation.status).toBe(405)
+  })
+})

--- a/apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness-routes.ts
+++ b/apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness-routes.ts
@@ -1,0 +1,92 @@
+import { Effect } from 'effect'
+
+import { methodNotAllowed, noStoreJsonResponse, serverError } from './http/responses'
+import {
+  type InferenceReceiptReadStore,
+  publicInferenceReceiptFromRecord,
+} from './inference-receipts'
+import {
+  buildHostedGeminiPromiseReadiness,
+  HostedGeminiPromiseReadinessRoute,
+} from './hosted-gemini-promise-readiness'
+import type { PromiseTransitionReceiptStore } from './promise-transition-receipt-routes'
+
+type HttpResponse = globalThis.Response
+
+export type HostedGeminiPromiseReadinessDependencies<Bindings> = Readonly<{
+  makeInferenceReceiptStore: (env: Bindings) => InferenceReceiptReadStore
+  makeTransitionReceiptStore: (env: Bindings) => PromiseTransitionReceiptStore
+  nowIso: () => string
+}>
+
+const readReceiptRef = (request: Request): string | null => {
+  const value = new URL(request.url).searchParams.get('receiptRef')?.trim()
+  return value === undefined || value === '' ? null : value
+}
+
+export const makeHostedGeminiPromiseReadinessRoutes = <Bindings>(
+  dependencies: HostedGeminiPromiseReadinessDependencies<Bindings>,
+) => {
+  const routeHostedGeminiPromiseReadinessRequest = (
+    request: Request,
+    env: Bindings,
+  ): Effect.Effect<HttpResponse> | undefined => {
+    const url = new URL(request.url)
+    if (url.pathname !== HostedGeminiPromiseReadinessRoute) {
+      return undefined
+    }
+
+    if (request.method !== 'GET') {
+      return Effect.succeed(methodNotAllowed(['GET']))
+    }
+
+    const receiptRef = readReceiptRef(request)
+    if (receiptRef === null) {
+      return Effect.succeed(
+        noStoreJsonResponse(
+          {
+            error: 'hosted_gemini_receipt_ref_required',
+            receiptRefQueryParam: 'receiptRef',
+          },
+          { status: 400 },
+        ),
+      )
+    }
+
+    return Effect.tryPromise({
+      catch: () => 'hosted_gemini_readiness_failed' as const,
+      try: async () => {
+        const generatedAt = dependencies.nowIso()
+        const [record, transitionReceipts] = await Promise.all([
+          dependencies
+            .makeInferenceReceiptStore(env)
+            .readInferenceReceiptByRef(receiptRef),
+          dependencies.makeTransitionReceiptStore(env).listReceipts(200),
+        ])
+        const receipt =
+          record === null
+            ? null
+            : publicInferenceReceiptFromRecord(record, generatedAt)
+
+        return buildHostedGeminiPromiseReadiness({
+          generatedAt,
+          receipt,
+          receiptRef,
+          transitionReceipts,
+        })
+      },
+    }).pipe(
+      Effect.map(readiness =>
+        noStoreJsonResponse({
+          generatedAt: readiness.generatedAt,
+          maxStalenessSeconds: readiness.staleness.maxStalenessSeconds,
+          readiness,
+          staleness: readiness.staleness,
+        }),
+      ),
+      Effect.catch(() => Effect.succeed(serverError())),
+    )
+  }
+
+  return { routeHostedGeminiPromiseReadinessRequest }
+}

--- a/apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness.test.ts
+++ b/apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildHostedGeminiPromiseReadiness,
+  evaluateHostedGeminiProductionReceipt,
+} from './hosted-gemini-promise-readiness'
+import type { PublicInferenceReceiptProjection } from './inference-receipts'
+import type { PromiseTransitionReceipt } from './promise-transition-receipt-routes'
+
+const generatedAt = '2026-06-29T12:00:00.000Z'
+const receiptRef = 'receipt.inference.charge.chatcmpl_hosted_gemini_prod'
+
+const receipt = (
+  input: Partial<PublicInferenceReceiptProjection> = {},
+): PublicInferenceReceiptProjection => ({
+  authorityBoundary: 'Public proof only.',
+  caveatRefs: ['caveat.public.no_private_payment_material'],
+  generatedAt,
+  kind: 'charge',
+  ledgerState: 'paid',
+  modelEvidence: {
+    requested_model: 'openagents/khala',
+    served_model: 'models/gemini-2.5-flash',
+    supply_lane: 'vertex-gemini',
+    total_tokens: 321,
+    worker: 'vertex-gemini',
+  },
+  receiptRef,
+  schemaVersion: 'openagents.inference.receipt.v1',
+  sourceRefs: [`route:/api/public/inference/receipts/${receiptRef}`],
+  staleness: {
+    composition: 'live_at_read',
+    contractVersion: 'projection_staleness.v1',
+    maxStalenessSeconds: 0,
+    rebuildsOn: ['pay_ins.public_receipt_ref'],
+  },
+  stateChangedAt: '2026-06-29T11:59:00.000Z',
+  ...input,
+})
+
+const transition = (
+  input: Partial<PromiseTransitionReceipt> = {},
+): PromiseTransitionReceipt => ({
+  checkedAt: '2026-06-29T12:01:00.000Z',
+  checks: [],
+  evidenceRefs: [receiptRef],
+  exception: {
+    approvedByRef: 'owner:openagents',
+    expiresAt: '2026-07-06',
+    reasonRef: 'owner_signoff.hosted_gemini.production_receipt',
+  },
+  fromState: 'yellow',
+  promiseId: 'api.hosted_gemini.v1',
+  receiptId: 'promise_transition_hosted_gemini_green_1',
+  registryVersion: '2026-06-29.1',
+  result: 'exception',
+  toState: 'green',
+  ...input,
+})
+
+describe('Hosted Gemini product-promise readiness', () => {
+  test('accepts only paid Vertex Gemini inference charge receipts as production evidence', () => {
+    expect(evaluateHostedGeminiProductionReceipt(receipt())).toMatchObject({
+      result: 'passed',
+      status: 'production_receipt_present',
+    })
+    expect(
+      evaluateHostedGeminiProductionReceipt(
+        receipt({
+          modelEvidence: {
+            served_model: 'accounts/fireworks/models/deepseek-v4-flash',
+            supply_lane: 'fireworks',
+            total_tokens: 321,
+            worker: 'fireworks',
+          },
+        }),
+      ),
+    ).toMatchObject({
+      result: 'failed',
+      status: 'not_hosted_gemini',
+    })
+    expect(
+      evaluateHostedGeminiProductionReceipt(
+        receipt({ ledgerState: 'free_allowance' }),
+      ),
+    ).toMatchObject({
+      result: 'failed',
+      status: 'not_metered_paid',
+    })
+  })
+
+  test('keeps blocker refs until the owner transition cites the same production receipt', () => {
+    const withoutOwner = buildHostedGeminiPromiseReadiness({
+      generatedAt,
+      receipt: receipt(),
+      receiptRef,
+      transitionReceipts: [],
+    })
+    const withOwner = buildHostedGeminiPromiseReadiness({
+      generatedAt,
+      receipt: receipt(),
+      receiptRef,
+      transitionReceipts: [transition()],
+    })
+
+    expect(withoutOwner.greenGateMet).toBe(false)
+    expect(withoutOwner.blockerRefs).toEqual([
+      'blocker.product_promises.hosted_gemini_owner_upgrade_signoff_pending',
+    ])
+    expect(withoutOwner.clearsBlockerRefs).toEqual([])
+    expect(withOwner.greenGateMet).toBe(true)
+    expect(withOwner.blockerRefs).toEqual([])
+    expect(withOwner.clearsBlockerRefs).toEqual([
+      'blocker.product_promises.hosted_gemini_production_receipt_pending',
+      'blocker.product_promises.hosted_gemini_owner_upgrade_signoff_pending',
+    ])
+  })
+
+  test('does not let an unrelated owner transition clear the signoff blocker', () => {
+    const readiness = buildHostedGeminiPromiseReadiness({
+      generatedAt,
+      receipt: receipt(),
+      receiptRef,
+      transitionReceipts: [
+        transition({
+          evidenceRefs: ['receipt.inference.charge.other'],
+        }),
+      ],
+    })
+
+    expect(readiness.greenGateMet).toBe(false)
+    expect(readiness.ownerTransitionCheck).toMatchObject({
+      result: 'failed',
+      status: 'missing_owner_transition',
+    })
+  })
+})

--- a/apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness.ts
+++ b/apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness.ts
@@ -1,0 +1,184 @@
+import {
+  type PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import type { PublicInferenceReceiptProjection } from './inference-receipts'
+import type { PromiseTransitionReceipt } from './promise-transition-receipt-routes'
+
+export const HostedGeminiPromiseReadinessRoute =
+  '/api/public/product-promises/api.hosted_gemini.v1/readiness' as const
+
+export type HostedGeminiProductionReceiptCheck = Readonly<{
+  evidenceRefs: ReadonlyArray<string>
+  result: 'failed' | 'passed'
+  status:
+    | 'missing_receipt'
+    | 'not_hosted_gemini'
+    | 'not_metered_paid'
+    | 'production_receipt_present'
+}>
+
+export type HostedGeminiOwnerTransitionCheck = Readonly<{
+  evidenceRefs: ReadonlyArray<string>
+  receiptId: string | null
+  result: 'failed' | 'passed'
+  status: 'missing_owner_transition' | 'owner_transition_present'
+}>
+
+export type HostedGeminiPromiseReadiness = Readonly<{
+  authorityBoundary: string
+  blockerRefs: ReadonlyArray<string>
+  caveatRefs: ReadonlyArray<string>
+  clearsBlockerRefs: ReadonlyArray<string>
+  generatedAt: string
+  greenGateMet: boolean
+  ownerTransitionCheck: HostedGeminiOwnerTransitionCheck
+  promiseId: 'api.hosted_gemini.v1'
+  receiptCheck: HostedGeminiProductionReceiptCheck
+  receiptRef: string
+  requestPath: 'POST /api/v1/chat/completions'
+  responseShapeRef: 'response.openai_compatible.chat_completion.success'
+  schemaVersion: 'openagents.product_promise.hosted_gemini_readiness.v1'
+  sourceRefs: ReadonlyArray<string>
+  staleness: PublicProjectionStalenessContract
+}>
+
+const promiseId = 'api.hosted_gemini.v1' as const
+const productionReceiptBlocker =
+  'blocker.product_promises.hosted_gemini_production_receipt_pending'
+const ownerTransitionBlocker =
+  'blocker.product_promises.hosted_gemini_owner_upgrade_signoff_pending'
+
+const hostedGeminiReceiptEvidenceRefs = (
+  receipt: PublicInferenceReceiptProjection,
+): ReadonlyArray<string> => [
+  receipt.receiptRef,
+  ...receipt.sourceRefs,
+  'route:/api/public/inference/receipts/{receiptRef}',
+  'route:/api/v1/chat/completions',
+  'lane:vertex-gemini',
+]
+
+export const evaluateHostedGeminiProductionReceipt = (
+  receipt: PublicInferenceReceiptProjection | null,
+): HostedGeminiProductionReceiptCheck => {
+  if (receipt === null) {
+    return {
+      evidenceRefs: [],
+      result: 'failed',
+      status: 'missing_receipt',
+    }
+  }
+
+  if (
+    receipt.kind !== 'charge' ||
+    receipt.ledgerState !== 'paid' ||
+    receipt.modelEvidence === undefined ||
+    receipt.modelEvidence.total_tokens <= 0
+  ) {
+    return {
+      evidenceRefs: hostedGeminiReceiptEvidenceRefs(receipt),
+      result: 'failed',
+      status: 'not_metered_paid',
+    }
+  }
+
+  if (
+    receipt.modelEvidence.supply_lane !== 'vertex-gemini' ||
+    receipt.modelEvidence.worker !== 'vertex-gemini'
+  ) {
+    return {
+      evidenceRefs: hostedGeminiReceiptEvidenceRefs(receipt),
+      result: 'failed',
+      status: 'not_hosted_gemini',
+    }
+  }
+
+  return {
+    evidenceRefs: hostedGeminiReceiptEvidenceRefs(receipt),
+    result: 'passed',
+    status: 'production_receipt_present',
+  }
+}
+
+export const evaluateHostedGeminiOwnerTransition = (
+  receipts: ReadonlyArray<PromiseTransitionReceipt>,
+  evidenceRefs: ReadonlyArray<string>,
+): HostedGeminiOwnerTransitionCheck => {
+  const matchingReceipt = receipts.find(
+    receipt =>
+      receipt.promiseId === promiseId &&
+      receipt.toState === 'green' &&
+      receipt.result !== 'failed' &&
+      receipt.evidenceRefs.some(ref => evidenceRefs.includes(ref)),
+  )
+
+  return matchingReceipt === undefined
+    ? {
+        evidenceRefs: [],
+        receiptId: null,
+        result: 'failed',
+        status: 'missing_owner_transition',
+      }
+    : {
+        evidenceRefs: [matchingReceipt.receiptId, ...matchingReceipt.evidenceRefs],
+        receiptId: matchingReceipt.receiptId,
+        result: 'passed',
+        status: 'owner_transition_present',
+      }
+}
+
+export const buildHostedGeminiPromiseReadiness = (input: {
+  generatedAt: string
+  receipt: PublicInferenceReceiptProjection | null
+  receiptRef: string
+  transitionReceipts: ReadonlyArray<PromiseTransitionReceipt>
+}): HostedGeminiPromiseReadiness => {
+  const receiptCheck = evaluateHostedGeminiProductionReceipt(input.receipt)
+  const ownerTransitionCheck = evaluateHostedGeminiOwnerTransition(
+    input.transitionReceipts,
+    receiptCheck.evidenceRefs,
+  )
+  const greenGateMet =
+    receiptCheck.result === 'passed' &&
+    ownerTransitionCheck.result === 'passed'
+  const blockerRefs = [
+    ...(receiptCheck.result === 'passed' ? [] : [productionReceiptBlocker]),
+    ...(ownerTransitionCheck.result === 'passed' ? [] : [ownerTransitionBlocker]),
+  ]
+
+  return {
+    authorityBoundary:
+      'Read-only product-promise evidence. This readiness projection grants no spend, refund, payout, provider, registry-state, or owner-signoff authority; the registry flips only through the product-promise transition receipt path.',
+    blockerRefs,
+    caveatRefs: [
+      'caveat.public.hosted_gemini_receipt_requires_vertex_gemini_paid_charge',
+      'caveat.public.hosted_gemini_green_requires_owner_transition_receipt',
+      'caveat.public.no_prompts_provider_payloads_keys_or_private_user_data',
+    ],
+    clearsBlockerRefs: greenGateMet
+      ? [productionReceiptBlocker, ownerTransitionBlocker]
+      : [],
+    generatedAt: input.generatedAt,
+    greenGateMet,
+    ownerTransitionCheck,
+    promiseId,
+    receiptCheck,
+    receiptRef: input.receiptRef,
+    requestPath: 'POST /api/v1/chat/completions',
+    responseShapeRef: 'response.openai_compatible.chat_completion.success',
+    schemaVersion: 'openagents.product_promise.hosted_gemini_readiness.v1',
+    sourceRefs: [
+      HostedGeminiPromiseReadinessRoute,
+      'https://openagents.com/api/public/product-promises',
+      'https://openagents.com/api/public/product-promises/transitions',
+      'docs/launch/vertex-fleet/api.hosted_gemini.v1.md',
+      ...receiptCheck.evidenceRefs,
+      ...ownerTransitionCheck.evidenceRefs,
+    ],
+    staleness: liveAtReadStaleness([
+      'pay_ins.public_receipt_ref',
+      'product_promise_transition_receipt_recorded',
+    ]),
+  }
+}

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -391,6 +391,7 @@ import { routeAccessResponse } from './http/route-access-response'
 import { routeEffect, routeEffectOrResponse } from './http/route-effects'
 import { makeD1HygieneDebtReceiptStore } from './hygiene-debt-receipt-store'
 import { makeHygieneLaneSettlementRoutes } from './hygiene-lane-settlement-routes'
+import { makeHostedGeminiPromiseReadinessRoutes } from './hosted-gemini-promise-readiness-routes'
 import { makeImageGenerationRoutes } from './image-generation-routes'
 import { makeD1InferenceReceiptStore } from './inference-receipts'
 import {
@@ -8404,6 +8405,15 @@ const publicInferenceReceiptRoutes = makePublicInferenceReceiptRoutes<Env>({
   nowIso: currentIsoTimestamp,
 })
 
+const hostedGeminiPromiseReadinessRoutes =
+  makeHostedGeminiPromiseReadinessRoutes<Env>({
+    makeInferenceReceiptStore: env =>
+      makeD1InferenceReceiptStore(openAgentsDatabase(env)),
+    makeTransitionReceiptStore: env =>
+      makeD1PromiseTransitionReceiptStore(openAgentsDatabase(env)),
+    nowIso: currentIsoTimestamp,
+  })
+
 // Dereferenceable PAID receipt read for sellable Cloud primitives (sandbox
 // compute #5517 / fine-tuning #5516). Public proof read only — it derefs the
 // metered-charge `pay_ins` row the cloud-metering seam already wrote; it grants
@@ -10530,6 +10540,14 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
       handlePublicPromiseTransitionsApi(request, {
         store: makeD1PromiseTransitionReceiptStore(openAgentsDatabase(env)),
       }),
+  },
+  {
+    path: '/api/public/product-promises/api.hosted_gemini.v1/readiness',
+    handler: (request, env) =>
+      hostedGeminiPromiseReadinessRoutes.routeHostedGeminiPromiseReadinessRequest(
+        request,
+        env,
+      ) ?? Effect.succeed(notFound()),
   },
   {
     // Enterprise claim-upgrade audit projection (proof.claim_upgrade_receipts.v1).

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1808,6 +1808,9 @@ const schemaComponents = (): JsonSchema => ({
   ProductPromiseTransitions: objectSummary(
     'Public-safe promise transition receipt feed with top-level generatedAt, served registryVersion/registryGeneratedAt, and the declared live_at_read staleness contract (maxStalenessSeconds 0, rebuildsOn registry/transition-receipt changes) so verifiers can bind receipt rows to the current registry context. Receipt rows include receiptId, promiseId, from/to state, registry version, typed checks, result (passed/failed/exception), evidence refs, and timestamps. Receipts are transition evidence, not transitions.',
   ),
+  HostedGeminiPromiseReadinessEnvelope: objectSummary(
+    'Public-safe readiness projection for api.hosted_gemini.v1 with top-level generatedAt, maxStalenessSeconds, and the declared live_at_read staleness contract. Given a receiptRef, it reads the public inference receipt and product-promise transition feed live-at-read, then reports whether the receipt is a paid Vertex Gemini charge with positive usage and whether an owner-signed green transition cites the same evidence. It includes request path, response-shape ref, blockerRefs, clearsBlockerRefs, caveats, and source refs. Read-only: exposes no prompts, provider payloads, keys, private user data, account ids, amounts, spend authority, provider authority, or registry mutation authority.',
+  ),
   ProductPromiseClaimUpgradeAudit: objectSummary(
     'Public-safe enterprise claim-upgrade audit projection (proof.claim_upgrade_receipts.v1). Joins the transition-receipt feed against the live product-promise registry so a third party can audit every state change, especially every green flip. Per promise: promiseId, productArea, currentState, lastVerifiedAt, blockerRefs, and the transition receipts backing it (from->to, registryVersion, receiptRef, result, evidenceRefs, owner signoff, alreadyApplied/isGreenFlip flags). A registry-wide summary reports promiseCount, transitionReceiptCount, greenPromiseCount, greenPromisesReceiptBacked, the explicit greenPromisesWithoutReceipt list (green promises with no recorded green-flip receipt), greenFlipReceiptCount, ownerSignedExceptionCount, and failedReceiptCount. Filterable by promiseId, state, and greenOnly. Carries generatedAt and a live_at_read staleness contract (maxStalenessSeconds 0, rebuildsOn registry/receipt transitions) because it is composed live at read from the registry and receipt feed. Read-only: exposes no private data, moves no money, and changes no registry state.',
   ),
@@ -9750,6 +9753,29 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Promise transition receipt feed.',
           '#/components/schemas/ProductPromiseTransitions',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/public/product-promises/api.hosted_gemini.v1/readiness': {
+    get: operation({
+      operationId: 'getHostedGeminiPromiseReadiness',
+      summary: 'Read Hosted Gemini promise readiness',
+      description:
+        'Given a public inference receiptRef, composes the public inference receipt and product-promise transition feed live-at-read to determine whether api.hosted_gemini.v1 has both required green-gate evidence: a paid production Vertex Gemini receipt with usage and an owner-signed green transition citing the same evidence. Read-only: returns blockerRefs/caveats and grants no spend, provider, owner-signoff, or registry mutation authority.',
+      tags: ['Public Proof'],
+      security: [],
+      parameters: [
+        queryParam(
+          'receiptRef',
+          'Public inference receipt ref to evaluate, usually receipt.inference.charge.<requestId>.',
+        ),
+      ],
+      responses: {
+        '200': okJson(
+          'Hosted Gemini promise readiness projection.',
+          '#/components/schemas/HostedGeminiPromiseReadinessEnvelope',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1311,7 +1311,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'OpenAgents is API-driven and may offer hosted Gemini through an OpenAgents API surface.',
         safeCopy:
-          'OpenAgents has route-covered hosted Gemini execution through the env-gated Vertex binding and the OpenAI-compatible Khala gateway enforces account credits, entitlement/free-quota gates, metering, and served-token rows. The promise stays yellow until a real production receipt and owner-approved upgrade evidence are attached.',
+          'OpenAgents has route-covered hosted Gemini execution through the env-gated Vertex binding and the OpenAI-compatible Khala gateway enforces account credits, entitlement/free-quota gates, metering, and served-token rows. The public Hosted Gemini readiness endpoint verifies whether a cited production Vertex Gemini receipt and owner transition receipt satisfy the green gate. The promise stays yellow until both are present.',
         unsafeCopy:
           'Do not claim hosted Gemini is green, settled, broadly resale-ready, or owner-approved without a real production receipt.',
         evidenceRefs: [
@@ -1322,6 +1322,7 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/autopilot-work-routes.test.ts',
           'apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts',
           'apps/openagents.com/workers/api/src/autopilot-hosted-gemini-executor-env.ts',
+          'route:/api/public/product-promises/api.hosted_gemini.v1/readiness?receiptRef={receiptRef}',
           'apps/openagents.com/workers/api/src/inference/served-tokens-recorder.ts',
           'docs/autopilot-coder/2026-06-09-probe-autopilot-sites-agent-api-audit.md',
         ],
@@ -1330,7 +1331,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.hosted_gemini_owner_upgrade_signoff_pending',
         ],
         verification:
-          'Route tests cover the env-gated hosted Gemini executor delivering a public-safe Autopilot closeout when armed, and a registered-agent Khala gateway request reaching the armed Vertex Gemini lane with entitlement/balance admission, metered usage, and served-token recording. Green still requires a real production receipt and owner-approved claim upgrade evidence.',
+          'Route tests cover the env-gated hosted Gemini executor delivering a public-safe Autopilot closeout when armed, a registered-agent Khala gateway request reaching the armed Vertex Gemini lane with entitlement/balance admission, metered usage, and served-token recording, and the public readiness endpoint that keeps blockers until the cited production receipt and owner transition receipt both exist.',
         authorityBoundary:
           'API-driven product surfaces are not generic provider-capacity resale, settlement, or green-promise authority without receipt-backed owner sign-off.',
       },

--- a/docs/launch/vertex-fleet/api.hosted_gemini.v1.md
+++ b/docs/launch/vertex-fleet/api.hosted_gemini.v1.md
@@ -457,6 +457,34 @@ production binding shape the harness was missing.
   does not prove a lane's credential authenticates upstream). The gateway
   blocker REMAINS listed.
 
+### 2026-06-29 update — production receipt + owner-transition readiness gate
+
+- `blocker.product_promises.hosted_gemini_production_receipt_pending` and
+  `blocker.product_promises.hosted_gemini_owner_upgrade_signoff_pending` —
+  **made mechanically auditable, NOT cleared.** Issue #7017 needs a
+  dereferenceable public-safe production receipt and an owner-signed promise
+  transition before hosted Gemini can go green. This change adds the missing
+  read-only gate:
+  - `apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness.ts`
+    classifies a cited public inference receipt as green-eligible only when it
+    is a paid `receipt.inference.charge.*` projection with `vertex-gemini` model
+    evidence and positive token usage, then requires a matching
+    `api.hosted_gemini.v1` green transition receipt that cites the same evidence.
+  - `apps/openagents.com/workers/api/src/hosted-gemini-promise-readiness-routes.ts`
+    exposes
+    `GET /api/public/product-promises/api.hosted_gemini.v1/readiness?receiptRef=<receiptRef>`,
+    composed live from the existing public inference receipt store and product
+    promise transition receipt store.
+  - Focused tests prove non-Hosted/non-metered receipts do not clear the
+    production blocker, missing owner signoff keeps the signoff blocker, and a
+    transition must cite the same receipt evidence before both blockers clear.
+
+  **Honest scope:** this endpoint is proof/readiness plumbing only. It does not
+  run a live Gemini request, mint an owner transition, debit credits, move money,
+  widen provider authority, or flip the registry. The promise remains yellow
+  until an actual production receipt dereferences through the route and the
+  owner-signed transition receipt exists.
+
 ## What remains (for green)
 
 - Arm the bound executor on a real deployment (`HOSTED_GEMINI_EXECUTOR_ENABLED`


### PR DESCRIPTION
Addresses #7017.

### Changes
- Added the public Hosted Gemini promise readiness route at `/api/public/product-promises/api.hosted_gemini.v1/readiness`.
- Documented the readiness envelope and endpoint in the OpenAPI surface.
- Updated the hosted Gemini product promise copy and launch evidence to point at the readiness proof path.

### Verification
- `true`
- Result: passed (exit 0)