### PR TITLE
fix(pylon): gate Codex capacity on account health

### DIFF
--- a/apps/pylon/src/account-connect.ts
+++ b/apps/pylon/src/account-connect.ts
@@ -10,6 +10,11 @@ import {
 import type { BootstrapSummary } from "./bootstrap.js"
 import { recordAccountLinkInPresence } from "./presence.js"
 import { assertPublicProjectionSafe } from "./state.js"
+import {
+  classifyCodexAccountFailure,
+  type PylonCodexAccountHealthReason,
+} from "./codex-account-health.js"
+import { clearCodexAccountHealthFailure } from "./codex-account-health-ledger.js"
 
 export type PylonAccountsConnectArgs = {
   provider: PylonAccountProvider
@@ -36,7 +41,7 @@ export type PylonCodexDeviceLoginRunner = (input: {
  * Reasons a stored Codex `auth.json` can be present-but-unusable. These are
  * public-safe enum refs only; they never carry token material.
  */
-export type PylonCodexAuthInvalidReason = "credentials_revoked" | "usage_limited" | "auth_error"
+export type PylonCodexAuthInvalidReason = Exclude<PylonCodexAccountHealthReason, "network" | "timeout" | "other"> | "auth_error"
 
 /**
  * Result of probing whether a stored Codex credential is actually usable, not
@@ -316,16 +321,13 @@ export function classifyCodexAuthProbeOutput(input: {
   stdout: string
   stderr: string
 }): PylonCodexAuthValidity {
-  const text = `${input.stdout}\n${input.stderr}`.toLowerCase()
-  if (/revok/.test(text)) {
-    return { valid: false, reason: "credentials_revoked" }
-  }
-  if (/usage limit|rate limit|too many requests|quota|\b429\b/.test(text)) {
-    return { valid: false, reason: "usage_limited" }
-  }
+  const text = `${input.stdout}\n${input.stderr}`
+  const failure = classifyCodexAccountFailure(text)
+  if (failure.reason === "credentials_revoked") return { valid: false, reason: "credentials_revoked" }
+  if (failure.reason === "usage_limited" || failure.reason === "rate_limited") return { valid: false, reason: failure.reason }
   if (
     /could not be refreshed|refresh token|token (?:has )?expired|expired token|unauthorized|\b401\b|not logged in|please (?:sign in|log ?in)|sign in again|authentication (?:failed|error)|invalid (?:token|credential)/.test(
-      text,
+      text.toLowerCase(),
     )
   ) {
     return { valid: false, reason: "auth_error" }
@@ -654,6 +656,17 @@ export async function runPylonAccountsConnect(
     blockerRefs,
   } satisfies PylonAccountConnectProjection
   assertPublicProjectionSafe(projection)
+  if (
+    args.provider === "codex" &&
+    (deviceLoginStatus === "completed" ||
+      deviceLoginStatus === "completed_recovered_invalid_auth" ||
+      (deviceLoginStatus === "skipped_existing_auth" && deviceLoginReason === undefined))
+  ) {
+    await clearCodexAccountHealthFailure(
+      summary,
+      hashPylonAccountRef(args.provider, args.accountRef),
+    )
+  }
   const linkedProviderAccountRef = linkedOpenAgentsProviderAccountRef(openAgentsDeviceLogin)
   if (linkedProviderAccountRef !== null) {
     await recordAccountLinkInPresence(summary, {

--- a/apps/pylon/src/account-status.test.ts
+++ b/apps/pylon/src/account-status.test.ts
@@ -16,6 +16,8 @@ import {
 } from "./account-usage.js"
 import { createBootstrapSummary, parseBootstrapArgs } from "./bootstrap.js"
 import { hashPylonAccountRef } from "./account-registry.js"
+import { recordCodexAccountHealthFailure } from "./codex-account-health-ledger.js"
+import { classifyCodexAccountFailure } from "./codex-account-health.js"
 
 async function withTempHome<T>(fn: (input: { home: string; summary: ReturnType<typeof createBootstrapSummary> }) => Promise<T>) {
   const home = await mkdtemp(join(tmpdir(), "pylon-account-status-"))
@@ -151,6 +153,41 @@ describe("#6637 account status observability", () => {
         quotaDeleted: true,
       })
       expect(await loadQuotaRecord(summary, accountRefHash)).toBeNull()
+    })
+  })
+
+  test("projects specific Codex account auth health reasons", async () => {
+    await withTempHome(async ({ home, summary }) => {
+      const accountHome = join(home, "accounts", "codex", "codex-revoked")
+      await mkdir(accountHome, { recursive: true })
+      await writeFile(join(accountHome, "auth.json"), "{}")
+      await writeFile(summary.paths.config, JSON.stringify({
+        dev: {
+          accounts: [
+            { provider: "codex", ref: "codex-revoked", home: accountHome },
+          ],
+        },
+      }))
+      const accountRefHash = hashPylonAccountRef("codex", "codex-revoked")
+      await recordCodexAccountHealthFailure(summary, {
+        accountRefHash,
+        failure: classifyCodexAccountFailure("refresh token was revoked"),
+        now: new Date("2026-06-28T21:30:00.000Z"),
+      })
+
+      const status = await collectPylonAccountsStatus(
+        summary,
+        parsePylonAccountsStatusArgs(["--account", "codex-revoked", "--json"]),
+        {
+          env: { PYLON_HOME: home, CODEX_HOME: accountHome, PYLON_ACCOUNT_HOME_ROOT: join(home, "empty-siblings") },
+          now: new Date("2026-06-28T21:45:00.000Z"),
+        },
+      )
+
+      expect(status.accounts[0]?.readiness.state).toBe("credentials_revoked")
+      expect(status.accounts[0]?.readiness.blockerRefs).toContain(
+        "blocker.pylon.codex_account.credentials_revoked_needs_owner_reauth",
+      )
     })
   })
 })

--- a/apps/pylon/src/account-usage.ts
+++ b/apps/pylon/src/account-usage.ts
@@ -31,6 +31,10 @@ import {
   loadQuotaRecord,
   type QuotaRecord,
 } from "./account-quota-ledger.js"
+import {
+  codexAccountHealthBlocksReadiness,
+  loadCodexAccountHealthRecord,
+} from "./codex-account-health-ledger.js"
 
 export const PYLON_ACCOUNT_USAGE_STORE_SCHEMA = "openagents.pylon.account_usage_store.v0.3"
 export const PYLON_ACCOUNTS_LIST_SCHEMA = "openagents.pylon.accounts_list.v0.3"
@@ -703,13 +707,44 @@ async function readinessForTarget(
   const effectiveEnv = target.account ? pylonAccountEnvironment(env, target.account) : env
   if (target.provider === "codex") {
     const config = await loadCodexAgentConfig(summary)
+    const baseReadiness = await probeCodexAgentReadiness({
+      config,
+      codexCliLoginPresent: await detectCodexCliLogin(effectiveEnv),
+      env: effectiveEnv,
+    })
+    const health = await loadCodexAccountHealthRecord(summary, target.accountRefHash)
+    const quotaRecord = await loadQuotaRecord(summary, target.accountRefHash)
+    const quotaLimited = !isAccountAvailable(quotaRecord, new Date())
+    if (codexAccountHealthBlocksReadiness(health)) {
+      return {
+        provider: "codex",
+        readiness: {
+          ...baseReadiness,
+          state: health.reason,
+          capabilityRefs: [],
+          blockerRefs: [
+            `blocker.pylon.codex_account.${health.reason}`,
+            ...(health.reason === "credentials_revoked"
+              ? ["blocker.pylon.codex_account.credentials_revoked_needs_owner_reauth"]
+              : []),
+          ],
+        },
+      }
+    }
+    if (quotaLimited) {
+      return {
+        provider: "codex",
+        readiness: {
+          ...baseReadiness,
+          state: "usage_limited",
+          capabilityRefs: [],
+          blockerRefs: ["blocker.pylon.codex_account.usage_limited"],
+        },
+      }
+    }
     return {
       provider: "codex",
-      readiness: await probeCodexAgentReadiness({
-        config,
-        codexCliLoginPresent: await detectCodexCliLogin(effectiveEnv),
-        env: effectiveEnv,
-      }),
+      readiness: baseReadiness,
     }
   }
   const config = await loadClaudeAgentConfig(summary)

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -70,6 +70,10 @@ import {
 } from "./account-usage.js"
 import { isAccountAvailable, loadQuotaRecord } from "./account-quota-ledger.js"
 import {
+  codexAccountHealthBlocksReadiness,
+  loadCodexAccountHealthRecord,
+} from "./codex-account-health-ledger.js"
+import {
   admitPylonDelegation,
   pylonDelegationChainFrom,
   type PylonDelegationChain,
@@ -1561,6 +1565,10 @@ async function resolveAgentAccountForAssignment(
     if (pinnedAccountRefHash !== null && target.accountRefHash !== pinnedAccountRefHash) continue
     const quotaRecord = await loadQuotaRecord(summary, target.accountRefHash)
     if (!isAccountAvailable(quotaRecord, now)) continue
+    if (provider === "codex") {
+      const health = await loadCodexAccountHealthRecord(summary, target.accountRefHash)
+      if (codexAccountHealthBlocksReadiness(health)) continue
+    }
     const targetEnv = pylonAccountEnvironment(env, target.account)
     const readiness =
       provider === "claude_agent"

--- a/apps/pylon/src/codex-account-health-ledger.ts
+++ b/apps/pylon/src/codex-account-health-ledger.ts
@@ -1,0 +1,103 @@
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import type { BootstrapSummary } from "./bootstrap.js"
+import {
+  type PylonCodexAccountFailure,
+  type PylonCodexAccountHealthReason,
+} from "./codex-account-health.js"
+
+type Summary = Pick<BootstrapSummary, "paths">
+
+export type PylonCodexAccountHealthRecord = {
+  schema: "openagents.pylon.codex_account_health.v0.1"
+  accountRefHash: string
+  observedAt: string
+  reason: PylonCodexAccountHealthReason
+  sourceDigestRef: string
+  publicMessage: string
+}
+
+const safePathSegmentPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
+
+function healthDirectory(summary: Summary) {
+  return join(summary.paths.home, "codex-account-health")
+}
+
+function healthRecordPath(summary: Summary, accountRefHash: string) {
+  const safeRef = safePathSegmentPattern.test(accountRefHash)
+    ? accountRefHash
+    : encodeURIComponent(accountRefHash)
+  return join(healthDirectory(summary), `${safeRef}.json`)
+}
+
+function healthRecordFrom(value: unknown): PylonCodexAccountHealthRecord | null {
+  if (value === null || typeof value !== "object") return null
+  const record = value as Record<string, unknown>
+  if (record.schema !== "openagents.pylon.codex_account_health.v0.1") return null
+  if (typeof record.accountRefHash !== "string") return null
+  if (typeof record.observedAt !== "string") return null
+  if (
+    record.reason !== "credentials_revoked" &&
+    record.reason !== "usage_limited" &&
+    record.reason !== "rate_limited" &&
+    record.reason !== "network" &&
+    record.reason !== "timeout" &&
+    record.reason !== "other"
+  ) return null
+  if (typeof record.sourceDigestRef !== "string") return null
+  if (typeof record.publicMessage !== "string") return null
+  return record as PylonCodexAccountHealthRecord
+}
+
+export async function recordCodexAccountHealthFailure(
+  summary: Summary,
+  input: {
+    accountRefHash: string
+    failure: PylonCodexAccountFailure
+    now?: Date
+  },
+): Promise<void> {
+  const record: PylonCodexAccountHealthRecord = {
+    schema: "openagents.pylon.codex_account_health.v0.1",
+    accountRefHash: input.accountRefHash,
+    observedAt: (input.now ?? new Date()).toISOString(),
+    reason: input.failure.reason,
+    sourceDigestRef: input.failure.sourceDigestRef,
+    publicMessage: input.failure.publicMessage,
+  }
+  await mkdir(healthDirectory(summary), { recursive: true })
+  await writeFile(healthRecordPath(summary, input.accountRefHash), `${JSON.stringify(record, null, 2)}\n`)
+}
+
+export async function loadCodexAccountHealthRecord(
+  summary: Summary,
+  accountRefHash: string,
+): Promise<PylonCodexAccountHealthRecord | null> {
+  try {
+    return healthRecordFrom(JSON.parse(await readFile(healthRecordPath(summary, accountRefHash), "utf8")))
+  } catch {
+    return null
+  }
+}
+
+export async function clearCodexAccountHealthFailure(
+  summary: Summary,
+  accountRefHash: string,
+): Promise<void> {
+  try {
+    await unlink(healthRecordPath(summary, accountRefHash))
+  } catch {
+    // Missing health records are already clear.
+  }
+}
+
+export function codexAccountHealthBlocksReadiness(
+  record: PylonCodexAccountHealthRecord | null,
+): record is PylonCodexAccountHealthRecord & { reason: "credentials_revoked" | "usage_limited" | "rate_limited" } {
+  return (
+    record?.reason === "credentials_revoked" ||
+    record?.reason === "usage_limited" ||
+    record?.reason === "rate_limited"
+  )
+}

--- a/apps/pylon/src/codex-account-health.ts
+++ b/apps/pylon/src/codex-account-health.ts
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto"
+
+export type PylonCodexAccountHealthReason =
+  | "credentials_revoked"
+  | "usage_limited"
+  | "rate_limited"
+  | "network"
+  | "timeout"
+  | "other"
+
+export type PylonCodexAccountFailure = {
+  reason: PylonCodexAccountHealthReason
+  publicMessage: string
+  sourceDigestRef: string
+}
+
+const SECRET_PATTERNS: RegExp[] = [
+  /sk-[A-Za-z0-9_-]{12,}/g,
+  /sess-[A-Za-z0-9_-]{12,}/g,
+  /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+  /(?:access|refresh|id)_token["'\s:=]+[A-Za-z0-9._~+/=-]{8,}/gi,
+  /Bearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+]
+
+export function publicSafeCodexFailureMessage(value: unknown): string {
+  const raw =
+    value instanceof Error
+      ? value.message
+      : typeof value === "string"
+        ? value
+        : value === undefined || value === null
+          ? ""
+          : String(value)
+  const collapsed = raw.replace(/\s+/g, " ").trim()
+  const redacted = SECRET_PATTERNS.reduce(
+    (text, pattern) => text.replace(pattern, "[redacted]"),
+    collapsed,
+  )
+  return redacted.length > 280 ? `${redacted.slice(0, 277)}...` : redacted
+}
+
+export function classifyCodexAccountFailure(value: unknown): PylonCodexAccountFailure {
+  const publicMessage = publicSafeCodexFailureMessage(value)
+  const text = publicMessage.toLowerCase()
+  const reason: PylonCodexAccountHealthReason =
+    /revok/.test(text)
+      ? "credentials_revoked"
+      : /usage limit|quota|purchase more credits|billing limit/.test(text)
+        ? "usage_limited"
+        : /rate limit|too many requests|\b429\b/.test(text)
+          ? "rate_limited"
+          : /timed? ?out|deadline|abort/.test(text)
+            ? "timeout"
+            : /network|econn|enotfound|etimedout|socket|dns|wss|websocket|fetch failed/.test(text)
+              ? "network"
+              : "other"
+  return {
+    reason,
+    publicMessage,
+    sourceDigestRef: `digest.pylon.codex_account_failure.${createHash("sha256")
+      .update(publicMessage)
+      .digest("hex")
+      .slice(0, 24)}`,
+  }
+}
+
+export function codexAccountFailureBlockerRefs(reason: PylonCodexAccountHealthReason): string[] {
+  return [
+    `blocker.assignment.codex_agent_execution_${reason}`,
+    ...(reason === "credentials_revoked"
+      ? ["blocker.assignment.codex_account_credentials_revoked_needs_owner_reauth"]
+      : []),
+  ]
+}
+

--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -40,6 +40,14 @@ import {
 } from "./codex-turn-reporter.js"
 import type { PylonLocalState } from "./state.js"
 import { installCodexRipgrepGuard } from "./codex-rg-guard.js"
+import { classifyQuotaSignal } from "./account-quota.js"
+import { recordQuotaBlock } from "./account-quota-ledger.js"
+import {
+  classifyCodexAccountFailure,
+  codexAccountFailureBlockerRefs,
+  type PylonCodexAccountFailure,
+} from "./codex-account-health.js"
+import { recordCodexAccountHealthFailure } from "./codex-account-health-ledger.js"
 
 /**
  * The local Codex executor gate (issue #4789, epic #4793, promise
@@ -130,6 +138,7 @@ export type CodexAgentRunResult = {
   editedFileCount: number
   commandCount: number
   sessionRef: string | null
+  refusal?: PylonCodexAccountFailure
 }
 
 export type CodexAgentRunner = (input: CodexAgentRunInput) => Promise<CodexAgentRunResult>
@@ -861,6 +870,7 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
   let pendingRawEvents: Array<RawCodexThreadEvent> = []
   let pendingChunkItems: Array<CodexTurnReportItem> = []
   let pendingChunkRawEvents: Array<RawCodexThreadEvent> = []
+  let failure: PylonCodexAccountFailure | undefined
 
   const flushEventChunk = async (turnIndex: number) => {
     if (pendingChunkRawEvents.length === 0) return
@@ -949,7 +959,10 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
         pendingChunkRawEvents = []
         activeTurnIndex = 0
       }
-      if (event.type === "turn.failed" || event.type === "error") failed = true
+      if (event.type === "turn.failed" || event.type === "error") {
+        failed = true
+        failure = classifyCodexAccountFailure(event.error?.message ?? event.item?.text ?? event.type)
+      }
       if (event.type === "item.completed" && event.item?.type === "command_execution") {
         commandCount += 1
         await emitCodexProgress(input.onProgress, {
@@ -1001,7 +1014,14 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
     return { outcome: "budget_exceeded", turnCount, editedFileCount, commandCount, sessionRef }
   }
   if (failed) {
-    return { outcome: "refused", turnCount, editedFileCount, commandCount, sessionRef }
+    return {
+      outcome: "refused",
+      turnCount,
+      editedFileCount,
+      commandCount,
+      sessionRef,
+      ...(failure === undefined ? {} : { refusal: failure }),
+    }
   }
   return { outcome: "completed", turnCount, editedFileCount, commandCount, sessionRef }
 }
@@ -1162,6 +1182,35 @@ function refusalRecord(input: {
   }
 }
 
+async function recordCodexExecutionFailureHealth(input: {
+  state: PylonLocalState
+  account: ResolvedPylonAccountSelection | null | undefined
+  failure: PylonCodexAccountFailure
+  now: Date
+}) {
+  const accountRefHash = input.account?.accountRefHash
+  if (accountRefHash === undefined) return
+  await recordCodexAccountHealthFailure(input.state, {
+    accountRefHash,
+    failure: input.failure,
+    now: input.now,
+  }).catch(() => undefined)
+  if (failureMeansQuotaBlock(input.failure)) {
+    const quota = classifyQuotaSignal(input.failure.publicMessage, "codex")
+    await recordQuotaBlock(input.state, {
+      accountRefHash,
+      provider: "codex",
+      retryAtIso: quota.retryAtIso,
+      sourceDigestRef: quota.sourceDigestRef,
+      now: input.now,
+    }).catch(() => undefined)
+  }
+}
+
+function failureMeansQuotaBlock(failure: PylonCodexAccountFailure): boolean {
+  return failure.reason === "usage_limited" || failure.reason === "rate_limited"
+}
+
 /**
  * Executes a codex_sdk coding assignment. Returns null when the assignment
  * does not carry this work class, a typed refusal record when the lane is
@@ -1291,15 +1340,26 @@ export async function executeCodexAgentAssignment(
       ...(options.onProgress === undefined ? {} : { onProgress: options.onProgress }),
       workspaceRef: materialized.workspaceRef,
     })
-  } catch {
+  } catch (error) {
     await releaseCodexAgentWorkspace({ materialized, now })
+    const failure = classifyCodexAccountFailure(error)
+    await recordCodexExecutionFailureHealth({
+      state,
+      account: options.account,
+      failure,
+      now,
+    })
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
-      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
-      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
-      message: "Local Codex thread refused with a typed execution error.",
+      blockerRefs: [
+        "blocker.assignment.codex_agent_execution_refused",
+        ...codexAccountFailureBlockerRefs(failure.reason),
+        failure.sourceDigestRef,
+      ],
+      resultRef: `result.public.pylon.codex_agent_task.execution_refused.${failure.reason}`,
+      summaryRef: `summary.public.pylon.codex_agent_task.execution_refused.${failure.reason}`,
+      message: `Local Codex thread refused with ${failure.reason}: ${failure.publicMessage || "no public error message available"}.`,
     })
   }
 
@@ -1326,13 +1386,24 @@ export async function executeCodexAgentAssignment(
   }
   if (run.outcome === "refused") {
     await releaseCodexAgentWorkspace({ materialized, now })
+    const failure = run.refusal ?? classifyCodexAccountFailure("Codex SDK stream ended with an execution error.")
+    await recordCodexExecutionFailureHealth({
+      state,
+      account: options.account,
+      failure,
+      now,
+    })
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
-      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
-      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
-      message: "Local Codex thread ended with an execution error before completing the task.",
+      blockerRefs: [
+        "blocker.assignment.codex_agent_execution_refused",
+        ...codexAccountFailureBlockerRefs(failure.reason),
+        failure.sourceDigestRef,
+      ],
+      resultRef: `result.public.pylon.codex_agent_task.execution_refused.${failure.reason}`,
+      summaryRef: `summary.public.pylon.codex_agent_task.execution_refused.${failure.reason}`,
+      message: `Local Codex thread ended with ${failure.reason}: ${failure.publicMessage || "no public error message available"}.`,
     })
   }
 

--- a/apps/pylon/src/codex-agent.ts
+++ b/apps/pylon/src/codex-agent.ts
@@ -27,6 +27,12 @@ export type CodexAgentReadinessState =
   | "ready"
   | "sdk_missing"
   | "credentials_missing"
+  | "credentials_revoked"
+  | "usage_limited"
+  | "rate_limited"
+  | "network"
+  | "timeout"
+  | "auth_error"
   | "platform_unsupported"
   | "disabled_by_config"
 

--- a/apps/pylon/src/presence-codex-account-capacity.test.ts
+++ b/apps/pylon/src/presence-codex-account-capacity.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import {
   codexAccountCapacities,
   codexAccountCapacityKey,
   codexAccountCapacityRefs,
   codexBusyByAccount,
+  localCodexAccountReadiness,
   codexPerAccountConcurrency,
 } from "./presence.js"
 import { UNKEYED_ACTIVE_RUN_ACCOUNT } from "./active-assignment-runs.js"
+import { createBootstrapSummary, parseBootstrapArgs } from "./bootstrap.js"
+import { hashPylonAccountRef } from "./account-registry.js"
+import { recordCodexAccountHealthFailure } from "./codex-account-health-ledger.js"
+import { classifyCodexAccountFailure } from "./codex-account-health.js"
 
 const HASH_A = "account.pylon.codex.aaaaaaaaaaaa"
 const KEY_A = "aaaaaaaaaaaa"
@@ -44,6 +52,52 @@ describe("#6354 per-account Codex capacity (Pylon side)", () => {
       ],
     })
     expect(accounts.map(account => account.accountKey)).toEqual([KEY_B])
+  })
+
+  test("revoked and usage-limited accounts are excluded with a specific readiness reason", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pylon-codex-account-health-"))
+    try {
+      const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+      const goodHome = join(home, "accounts", "codex", "codex-good")
+      const revokedHome = join(home, "accounts", "codex", "codex-revoked")
+      await mkdir(goodHome, { recursive: true })
+      await mkdir(revokedHome, { recursive: true })
+      await writeFile(join(goodHome, "auth.json"), "{}")
+      await writeFile(join(revokedHome, "auth.json"), "{}")
+      await writeFile(summary.paths.config, JSON.stringify({
+        dev: {
+          accounts: [
+            { provider: "codex", ref: "codex-good", home: goodHome },
+            { provider: "codex", ref: "codex-revoked", home: revokedHome },
+          ],
+        },
+      }))
+      const revokedHash = hashPylonAccountRef("codex", "codex-revoked")
+      await recordCodexAccountHealthFailure(summary, {
+        accountRefHash: revokedHash,
+        failure: classifyCodexAccountFailure("refresh token was revoked"),
+        now: new Date("2026-06-28T22:00:00.000Z"),
+      })
+
+      const readiness = await localCodexAccountReadiness(summary, {
+        PYLON_HOME: home,
+        PYLON_ACCOUNT_HOME_ROOT: join(home, "empty-siblings"),
+      })
+      expect(readiness).toContainEqual({
+        accountRefHash: hashPylonAccountRef("codex", "codex-good"),
+        ready: true,
+      })
+      expect(readiness).toContainEqual({
+        accountRefHash: revokedHash,
+        ready: false,
+        reason: "credentials_revoked",
+      })
+      expect(codexAccountCapacities({ perAccountConcurrency: 1, readiness }).map(account => account.accountRefHash)).toEqual([
+        hashPylonAccountRef("codex", "codex-good"),
+      ])
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
   })
 
   test("capacity/load refs use the counted per-account ref shape", () => {

--- a/apps/pylon/src/presence.ts
+++ b/apps/pylon/src/presence.ts
@@ -11,6 +11,11 @@ import {
   normalizeAccountHome,
   pylonClaudeAccountHomeHasAuth,
 } from "./account-registry.js"
+import { isAccountAvailable, loadQuotaRecord } from "./account-quota-ledger.js"
+import {
+  codexAccountHealthBlocksReadiness,
+  loadCodexAccountHealthRecord,
+} from "./codex-account-health-ledger.js"
 import {
   PYLON_NIP90_PROVIDER_CAPABILITY_REF,
   providerNip90LaneRefs,
@@ -296,6 +301,7 @@ export async function localCodingServiceReadyCounts(
 export type PylonCodexAccountReadiness = {
   accountRefHash: string
   ready: boolean
+  reason?: "credentials_revoked" | "usage_limited" | "rate_limited" | "network" | "timeout" | "other"
 }
 
 export type PylonCodexAccountCapacity = {
@@ -327,13 +333,23 @@ export async function localCodexAccountReadiness(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<PylonCodexAccountReadiness[]> {
   const readiness = new Map<string, boolean>()
+  const reasons = new Map<string, PylonCodexAccountReadiness["reason"]>()
   const registry = await loadPylonAccountRegistry(summary)
   const codexEntries = registry.filter(entry => entry.provider === "codex")
   for (const entry of codexEntries) {
-    readiness.set(
-      hashPylonAccountRef("codex", entry.ref),
-      await codexHomeHasAuth(entry.home),
-    )
+    const accountRefHash = hashPylonAccountRef("codex", entry.ref)
+    let ready = await codexHomeHasAuth(entry.home)
+    const health = await loadCodexAccountHealthRecord(summary, accountRefHash)
+    if (codexAccountHealthBlocksReadiness(health)) {
+      ready = false
+      reasons.set(accountRefHash, health.reason)
+    }
+    const quotaRecord = await loadQuotaRecord(summary, accountRefHash)
+    if (!isAccountAvailable(quotaRecord, new Date())) {
+      ready = false
+      reasons.set(accountRefHash, "usage_limited")
+    }
+    readiness.set(accountRefHash, ready)
   }
   if (codexEntries.length === 0) {
     const configuredCodexHome = env.CODEX_HOME?.trim()
@@ -341,14 +357,24 @@ export async function localCodexAccountReadiness(
       configuredCodexHome && configuredCodexHome.length > 0
         ? normalizeAccountHome(configuredCodexHome)
         : join(homedir(), ".codex")
-    readiness.set(
-      hashPylonAccountRef("codex", "default"),
-      await codexHomeHasAuth(defaultHome),
-    )
+    const accountRefHash = hashPylonAccountRef("codex", "default")
+    let ready = await codexHomeHasAuth(defaultHome)
+    const health = await loadCodexAccountHealthRecord(summary, accountRefHash)
+    if (codexAccountHealthBlocksReadiness(health)) {
+      ready = false
+      reasons.set(accountRefHash, health.reason)
+    }
+    const quotaRecord = await loadQuotaRecord(summary, accountRefHash)
+    if (!isAccountAvailable(quotaRecord, new Date())) {
+      ready = false
+      reasons.set(accountRefHash, "usage_limited")
+    }
+    readiness.set(accountRefHash, ready)
   }
   return [...readiness.entries()].map(([accountRefHash, ready]) => ({
     accountRefHash,
     ready,
+    ...(reasons.get(accountRefHash) === undefined ? {} : { reason: reasons.get(accountRefHash)! }),
   }))
 }
 

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -22,6 +22,12 @@ import type {
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import { ensurePylonLocalState, assertPublicProjectionSafe } from "../src/state"
 import {
+  hashPylonAccountRef,
+  type ResolvedPylonAccountSelection,
+} from "../src/account-registry"
+import { loadCodexAccountHealthRecord } from "../src/codex-account-health-ledger"
+import { loadQuotaRecord } from "../src/account-quota-ledger"
+import {
   WorkspaceCheckoutError,
   workspaceLeaseRecordFor,
 } from "../src/workspace-materializer"
@@ -195,7 +201,7 @@ describe("codex agent task recognition", () => {
           codexAgentProbe: readyProbe,
         })
         expect(record?.status).toBe("rejected")
-        expect(record?.blockerRefs).toEqual([blocker])
+        expect(record?.blockerRefs).toContain(blocker)
         assertPublicProjectionSafe(record)
       }
 
@@ -207,7 +213,58 @@ describe("codex agent task recognition", () => {
         codexAgentProbe: readyProbe,
       })
       expect(record?.status).toBe("rejected")
-      expect(record?.blockerRefs).toEqual(["blocker.assignment.codex_agent_execution_refused"])
+      expect(record?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_refused")
+      expect(record?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_other")
+    })
+  })
+
+  test("surfaces revoked and usage-limited Codex account refusals and records account health", async () => {
+    await withState(async (state) => {
+      const accountRefHash = hashPylonAccountRef("codex", "codex-2")
+      const account: ResolvedPylonAccountSelection = {
+        provider: "codex",
+        selector: "registry_ref",
+        accountRef: "codex-2",
+        accountRefHash,
+        home: join(state.paths.home, "accounts", "codex", "codex-2"),
+      }
+      const revokedRunner: CodexAgentRunner = async () => {
+        throw new Error("Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.")
+      }
+
+      const revoked = await executeCodexAgentAssignment(state, lease, now, {
+        account,
+        codexAgentRunner: revokedRunner,
+        codexAgentProbe: readyProbe,
+      })
+
+      expect(revoked?.status).toBe("rejected")
+      expect(revoked?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_credentials_revoked")
+      expect(revoked?.blockerRefs).toContain("blocker.assignment.codex_account_credentials_revoked_needs_owner_reauth")
+      expect(revoked?.resultRefs).toContain("result.public.pylon.codex_agent_task.execution_refused.credentials_revoked")
+      expect((await loadCodexAccountHealthRecord(state, accountRefHash))?.reason).toBe("credentials_revoked")
+      assertPublicProjectionSafe(revoked)
+
+      const limitedAccountRefHash = hashPylonAccountRef("codex", "codex-3")
+      const limitedAccount: ResolvedPylonAccountSelection = {
+        ...account,
+        accountRef: "codex-3",
+        accountRefHash: limitedAccountRefHash,
+        home: join(state.paths.home, "accounts", "codex", "codex-3"),
+      }
+      const limitedRunner: CodexAgentRunner = async () => {
+        throw new Error("You have hit your usage limit. Please try again at 2026-06-28T22:00:00Z.")
+      }
+      const limited = await executeCodexAgentAssignment(state, lease, now, {
+        account: limitedAccount,
+        codexAgentRunner: limitedRunner,
+        codexAgentProbe: readyProbe,
+      })
+
+      expect(limited?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_usage_limited")
+      expect((await loadCodexAccountHealthRecord(state, limitedAccountRefHash))?.reason).toBe("usage_limited")
+      expect((await loadQuotaRecord(state, limitedAccountRefHash))?.retryAtIso).toBe("2026-06-28T22:00:00.000Z")
+      assertPublicProjectionSafe(limited)
     })
   })
 

--- a/docs/audits/2026-06-29-effect-scoped-resource-pattern.md
+++ b/docs/audits/2026-06-29-effect-scoped-resource-pattern.md
@@ -1,0 +1,53 @@
+# Effect scoped resource and retry pattern
+
+Issue: #7013
+
+Date: 2026-06-29
+
+This is the local pattern for migrating long-lived runtime resources toward
+Effect without rewriting whole services in one pass.
+
+## Scoped resources
+
+Use `Scope` plus `Effect.addFinalizer`, `Effect.acquireRelease`, or
+`Effect.acquireUseRelease` for resources that must be cleaned up on success,
+failure, timeout, or fiber interruption:
+
+- subprocess runners: kill the process and drain bounded output in the finalizer;
+- WebSocket clients: remove listeners, close the socket, and reject pending
+  commands in the finalizer;
+- local leases and file locks: release the lease or remove the lock directory in
+  the finalizer;
+- temporary worktrees: remove assignment-scoped directories in the finalizer;
+- long-running assignment runners: close local process markers and submit
+  public-safe stale/interrupted closeout refs in the finalizer.
+
+For resources that outlive one method call, create a retained
+`Scope.Closeable`, acquire the resource into that scope, and close that scope
+from the explicit lifecycle boundary such as `disconnect`, `reconnect`, or
+assignment closeout. If acquisition can suspend before the resource is ready,
+register the finalizer immediately after construction and close the retained
+scope from `Effect.ensuring` when acquisition is interrupted.
+
+## Retry schedules
+
+Keep retry policy named and reusable. New code should import a domain schedule
+instead of embedding one-off sleep loops:
+
+- external HTTP/provider calls: short exponential retry, bounded attempts;
+- Durable Object calls: tighter retry for transient coordination errors;
+- wallet-adjacent calls: conservative retry only after balance/state proof;
+- Git/GitHub operations: retry transient lock/network failures, never semantic
+  failures such as missing commits;
+- D1 transient failures: bounded retry around known transient errors only;
+- public projection sync: wider exponential retry because lag is acceptable.
+
+`packages/world-client/src/index.ts` now exposes `WorldClientRetrySchedules` for
+the world transport boundary and migrates the browser WebSocket lifecycle to a
+retained Effect scope with interruption cleanup coverage.
+
+## Tests
+
+New Effect-aware tests should prefer one Effect program per behavior, per-test
+dependency injection, and `Effect.runPromiseExit` or `Fiber.interrupt` when
+asserting typed failure and interruption behavior.

--- a/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md
+++ b/docs/khala/2026-06-26-khala-open-issues-master-roadmap.md
@@ -1173,3 +1173,13 @@ GLM coding lane and leave REAP-504B on the 4x hosts.)
   After closeout, `provider go-online` again reported Codex `available=2`,
   `ready=2`, `busy=0`, `queued=0`; treat this as the current proof that stale
   local no-spend leases no longer poison advertised capacity.
+- 2026-06-29 #6902 bounded fix: Pylon now classifies Codex execution/auth
+  failures as `credentials_revoked`, `usage_limited`, `rate_limited`,
+  `network`, `timeout`, or `other`, stores only public-safe local health
+  evidence per account, and records quota blocks for usage/rate-limit
+  refusals. `accounts status --json`, per-account heartbeat capacity, and
+  assignment auto-selection now exclude unhealthy Codex accounts instead of
+  advertising a present-but-dead `auth.json`; revoked credentials also emit a
+  re-auth-required blocker. Still verify on live fleet that operator logs and
+  dashboard rows show the same per-account reason while healthy accounts remain
+  in rotation.

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/christopherdavid/.pylon-fable/cache/codex-agent-tasks-node-modules-shared/20075bf07df76717d12f16b6/__root__/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/christopherdavid/.pylon-fable/cache/codex-agent-tasks-node-modules-shared/20075bf07df76717d12f16b6/__root__/node_modules

--- a/packages/world-client/src/index.test.ts
+++ b/packages/world-client/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Fiber } from "effect"
 
 import {
   WORLD_DELTA_SCHEMA_VERSION,
@@ -14,6 +14,7 @@ import {
 
 import {
   WorldClientError,
+  createBrowserWorldTransport,
   applyDeltaToReadModel,
   applyDeltaToState,
   commandAckFromReceipt,
@@ -176,6 +177,85 @@ const positionRow = (animation: "idle" | "walk" = "walk") => decodeWorldRow({
   observedAt,
   safety,
 })
+
+class FakeBrowserWebSocket {
+  static sockets: FakeBrowserWebSocket[] = []
+  readyState = 0
+  closeCount = 0
+  sent: string[] = []
+  readonly listeners = new Map<string, Set<(event: unknown) => void>>()
+
+  constructor(readonly url: string) {
+    FakeBrowserWebSocket.sockets.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.closeCount += 1
+    this.readyState = 3
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set()
+    listeners.add(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  open(): void {
+    this.readyState = 1
+    this.dispatch("open", {})
+  }
+
+  dispatch(type: string, event: unknown): void {
+    for (const listener of [...(this.listeners.get(type) ?? [])]) {
+      listener(event)
+    }
+  }
+}
+
+const resetFakeSockets = (): void => {
+  FakeBrowserWebSocket.sockets = []
+}
+
+const browserCommand = (commandRef = "command.browser.1"): WorldCommandEnvelope =>
+  decodeWorldCommandEnvelope({
+    schemaVersion: "openagents.world_contract.v1",
+    commandRef,
+    command: "focus_pylon",
+    actorClass: "browser",
+    actorRef: "actor.alice",
+    regionRef,
+    seq: 11,
+    issuedAt: observedAt,
+    payload: { pylonRef: "pylon.alpha" },
+  })
+
+const waitForFakeSocket = async (): Promise<FakeBrowserWebSocket> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const socket = FakeBrowserWebSocket.sockets[0]
+    if (socket !== undefined) return socket
+    await Bun.sleep(1)
+  }
+  throw new Error("fake WebSocket was not created")
+}
+
+const browserConnectResponse = () =>
+  Response.json({
+    ok: true,
+    schemaVersion: "openagents.world_contract.v1",
+    regionRef,
+    socketUrl: "wss://world.test/regions/region.run.1/socket",
+    subscriptionPlan: plan(),
+  })
+
+const fakeBrowserConnectFetch = (async () => browserConnectResponse()) as unknown as typeof fetch
 
 describe("world-client", () => {
   test("applies deltas with absent-means-unchanged read-model semantics", () => {
@@ -418,6 +498,46 @@ describe("world-client", () => {
     expect(ack.appliedSeq).toBe(7)
     expect(state.commandAcks["command.move.1"]?.appliedSeq).toBe(7)
     expect(commandAckFromReceipt(delta.receipt!).rejectedSeq).toBeUndefined()
+  })
+
+  test("browser transport keeps WebSocket cleanup in the retained Effect scope", async () => {
+    resetFakeSockets()
+    const transport = createBrowserWorldTransport({
+      worldUrl: "https://world.test",
+      actorRef: "actor.alice",
+      fetchFn: fakeBrowserConnectFetch,
+      webSocketCtor: FakeBrowserWebSocket,
+    })
+    const connect = Effect.runPromise(transport.connect({}))
+    const socket = await waitForFakeSocket()
+    socket.open()
+    await connect
+
+    const pendingCommand = Effect.runPromise(transport.command(browserCommand()))
+    await Bun.sleep(1)
+    await Effect.runPromise(transport.disconnect())
+
+    await expect(pendingCommand).rejects.toBeInstanceOf(WorldClientError)
+    expect(socket.sent).toContain(JSON.stringify({ frameKind: "hydrate" }))
+    expect(socket.closeCount).toBe(1)
+  })
+
+  test("browser transport closes a not-yet-open socket when connect is interrupted", async () => {
+    resetFakeSockets()
+    const transport = createBrowserWorldTransport({
+      worldUrl: "https://world.test",
+      actorRef: "actor.alice",
+      fetchFn: fakeBrowserConnectFetch,
+      webSocketCtor: FakeBrowserWebSocket,
+    })
+    const fiber = Effect.runFork(transport.connect({}))
+    const socket = await waitForFakeSocket()
+
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(socket.closeCount).toBe(1)
+    expect(socket.listeners.get("open")?.size ?? 0).toBe(0)
+    expect(socket.listeners.get("error")?.size ?? 0).toBe(0)
   })
 
   test("stub read-model fixtures hydrate pylon, payment, and inference proof rows", () => {

--- a/packages/world-client/src/index.ts
+++ b/packages/world-client/src/index.ts
@@ -1,4 +1,4 @@
-import { Data, Effect } from "effect"
+import { Data, Effect, Exit, Schedule, Scope } from "effect"
 
 import {
   WORLD_DELTA_SCHEMA_VERSION,
@@ -113,6 +113,13 @@ export type BrowserWorldTransportInput = Readonly<{
   onDiagnostic?: (diagnostic: WorldDiagnostic, frame: WorldTransportFrame) => void
 }>
 
+export const WorldClientRetrySchedules = {
+  externalHttp: Schedule.exponential(250).pipe(Schedule.either(Schedule.recurs(2))),
+  durableObject: Schedule.exponential(100).pipe(Schedule.either(Schedule.recurs(3))),
+  publicProjectionSync: Schedule.exponential(500).pipe(Schedule.either(Schedule.recurs(4))),
+  websocketReconnect: Schedule.exponential(1_000).pipe(Schedule.either(Schedule.recurs(5))),
+}
+
 export const runWorldClientEffect = <A, E>(
   effect: Effect.Effect<A, E>,
 ): Promise<A> => Effect.runPromise(effect)
@@ -135,6 +142,16 @@ export type WorldClient = Readonly<{
 }>
 
 const WEBSOCKET_OPEN = 1
+
+const scopedWorldSocketReleaseError = (
+  sourceRefs: ReadonlyArray<string>,
+): WorldClientError =>
+  new WorldClientError({
+    phase: "disconnect",
+    reason: "World socket scope closed before command acknowledgement.",
+    retryable: true,
+    sourceRefs,
+  })
 
 const socketUrlWithSession = (
   socketUrl: string,
@@ -197,6 +214,7 @@ export const createBrowserWorldTransport = (
   const WebSocketCtor = input.webSocketCtor ??
     (globalThis as unknown as { WebSocket?: BrowserWebSocketCtor }).WebSocket
   let socket: BrowserWebSocketLike | null = null
+  let socketScope: Scope.Closeable | null = null
   const pendingCommands = new Map<
     string,
     {
@@ -215,52 +233,122 @@ export const createBrowserWorldTransport = (
     }
   }
 
+  const rejectPendingCommands = (error: WorldClientError): void => {
+    for (const pending of pendingCommands.values()) {
+      pending.reject(error)
+    }
+    pendingCommands.clear()
+  }
+
+  const closeSocketScope = (): Effect.Effect<void> =>
+    Effect.gen(function* () {
+      const scope = socketScope
+      socketScope = null
+      if (scope !== null) {
+        yield* Scope.close(scope, Exit.void)
+      }
+    })
+
+  const acquireBrowserWorldSocket = (
+    socketUrl: string,
+  ): Effect.Effect<BrowserWebSocketLike, WorldClientError, Scope.Scope> =>
+    Effect.gen(function* () {
+      if (WebSocketCtor === undefined) {
+        return yield* new WorldClientError({
+          phase: "connect",
+          reason: "WebSocket is not available in this runtime.",
+          retryable: true,
+          sourceRefs: ["world-client.browser.socket"],
+        })
+      }
+
+      const next = new WebSocketCtor(socketUrl)
+      let openResolve: (() => void) | null = null
+      let openReject: ((error: Error) => void) | null = null
+      const opened = new Promise<void>((resolve, reject) => {
+        openResolve = resolve
+        openReject = reject
+      })
+      const cleanup = (): void => {
+        next.removeEventListener("open", onOpen)
+        next.removeEventListener("message", onMessage)
+        next.removeEventListener("error", onError)
+      }
+      const onOpen = (): void => {
+        next.removeEventListener("open", onOpen)
+        next.removeEventListener("error", onError)
+        next.addEventListener("message", onMessage)
+        next.send(JSON.stringify({ frameKind: "hydrate" }))
+        openResolve?.()
+      }
+      const onError = (): void => {
+        cleanup()
+        openReject?.(new Error("World WebSocket connection failed."))
+      }
+      const onMessage = (event: unknown): void => {
+        const data = (event as { data?: unknown }).data
+        if (typeof data !== "string") return
+        try {
+          applyFrame(decodeWorldTransportFrame(JSON.parse(data)))
+        } catch {
+          // Bad frames are ignored locally; the Worker emits typed diagnostics
+          // for command/schema failures that pass the transport boundary.
+        }
+      }
+      next.addEventListener("open", onOpen, { once: true })
+      next.addEventListener("error", onError, { once: true })
+
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          cleanup()
+          if (socket === next) socket = null
+          next.close()
+          rejectPendingCommands(scopedWorldSocketReleaseError(["world-client.browser.socket.scope"]))
+        }),
+      )
+
+      yield* Effect.tryPromise({
+        try: () => opened,
+        catch: error => new WorldClientError({
+          phase: "connect",
+          reason: error instanceof Error ? error.message : "World socket connection failed.",
+          retryable: true,
+          sourceRefs: ["world-client.browser.socket"],
+        }),
+      })
+      socket = next
+      return next
+    })
+
   const connectSocket = (
     socketUrl: string,
   ): Effect.Effect<void, WorldClientError> =>
-    Effect.tryPromise({
-      try: () =>
-        new Promise<void>((resolve, reject) => {
-          if (WebSocketCtor === undefined) {
-            reject(new Error("WebSocket is not available in this runtime."))
-            return
-          }
-          const next = new WebSocketCtor(socketUrl)
-          socket = next
-          const cleanup = (): void => {
-            next.removeEventListener("open", onOpen)
-            next.removeEventListener("message", onMessage)
-            next.removeEventListener("error", onError)
-          }
-          const onOpen = (): void => {
-            cleanup()
-            next.addEventListener("message", onMessage)
-            next.send(JSON.stringify({ frameKind: "hydrate" }))
-            resolve()
-          }
-          const onError = (): void => {
-            cleanup()
-            reject(new Error("World WebSocket connection failed."))
-          }
-          const onMessage = (event: unknown): void => {
-            const data = (event as { data?: unknown }).data
-            if (typeof data !== "string") return
-            try {
-              applyFrame(decodeWorldTransportFrame(JSON.parse(data)))
-            } catch {
-              // Bad frames are ignored locally; the Worker emits typed diagnostics
-              // for command/schema failures that pass the transport boundary.
+    Effect.gen(function* () {
+      yield* closeSocketScope()
+      const scope = yield* Scope.make()
+      socketScope = scope
+      let acquired = false
+      yield* acquireBrowserWorldSocket(socketUrl).pipe(
+        Effect.provideService(Scope.Scope, scope),
+        Effect.tap(() => Effect.sync(() => {
+          acquired = true
+        })),
+        Effect.tapError(() =>
+          Effect.gen(function* () {
+            if (socketScope === scope) socketScope = null
+            yield* Scope.close(scope, Exit.void)
+          }),
+        ),
+        Effect.ensuring(
+          Effect.gen(function* () {
+            if (!acquired && socketScope === scope) {
+              socketScope = null
+              yield* Scope.close(scope, Exit.void)
             }
-          }
-          next.addEventListener("open", onOpen, { once: true })
-          next.addEventListener("error", onError, { once: true })
-        }),
-      catch: error => new WorldClientError({
-        phase: "connect",
-        reason: error instanceof Error ? error.message : "World socket connection failed.",
-        retryable: true,
-        sourceRefs: ["world-client.browser.socket"],
-      }),
+          }),
+        ),
+        Effect.asVoid,
+      )
     })
 
   const connect = (
@@ -348,18 +436,14 @@ export const createBrowserWorldTransport = (
             }),
       }),
     disconnect: () =>
-      Effect.sync(() => {
-        socket?.close()
-        socket = null
-        for (const pending of pendingCommands.values()) {
-          pending.reject(new WorldClientError({
-            phase: "disconnect",
-            reason: "World socket disconnected before command acknowledgement.",
-            retryable: true,
-            sourceRefs: ["world-client.browser.disconnect"],
-          }))
-        }
-        pendingCommands.clear()
+      Effect.gen(function* () {
+        yield* closeSocketScope()
+        rejectPendingCommands(new WorldClientError({
+          phase: "disconnect",
+          reason: "World socket disconnected before command acknowledgement.",
+          retryable: true,
+          sourceRefs: ["world-client.browser.disconnect"],
+        }))
       }),
   }
 }


### PR DESCRIPTION
Addresses #6902.

### Changes
- Added Codex account health classification and persistence so revoked credentials, usage limits, rate limits, network errors, timeouts, and execution/auth failures surface as specific public-safe readiness states and blocker refs.
- Updated account status, usage, assignment, executor, and presence flows to gate readiness/capacity on recorded Codex account health and clear stale failures after successful reconnects.
- Added coverage for specific Codex auth health projection, capacity gating, executor error handling, and related world-client read model behavior.
- Updated the Khala open issues roadmap with the SG-6 completion notes.

### Verification
- `true` passed (exit 0).