### PR TITLE
feat(forge): add GitHub mirror receipts

### DIFF
--- a/apps/forge/src/index.test.ts
+++ b/apps/forge/src/index.test.ts
@@ -29,7 +29,7 @@ describe("Forge UI Worker", () => {
     expect(html).toContain("--forge-energy")
   })
 
-  it("defines shell routes for dogfood, work, changes, verification, queue, and refs", () => {
+  it("defines shell routes for dogfood, work, changes, verification, queue, refs, and mirror", () => {
     expect(forgeShellRoutes.map(route => route.path)).toEqual([
       "/",
       "/dogfood",
@@ -38,6 +38,7 @@ describe("Forge UI Worker", () => {
       "/verification",
       "/queue",
       "/refs",
+      "/mirror",
     ])
     expect(forgeShellRoutes.map(route => route.apiPath)).toEqual([
       "/api/forge/overview",
@@ -47,6 +48,7 @@ describe("Forge UI Worker", () => {
       "/api/forge/verification-receipts",
       "/api/forge/queue",
       "/api/forge/refs",
+      "/api/forge/github-mirror-runs",
     ])
     expect(resolveForgeShellRoute("/work/")?.id).toBe("work")
   })
@@ -84,6 +86,13 @@ describe("Forge UI Worker", () => {
     expect(body.preview.apiBasePath).toBe("/api/forge")
     expect(body.preview.dogfoodLanes).toHaveLength(1)
     expect(body.preview.dogfoodLanes[0]?.issueRef).toBe("#6797")
+    expect(body.routes).toContainEqual({
+      id: "mirror",
+      path: "/mirror",
+      label: "Mirror",
+      summary: "GitHub mirror receipts and attention state",
+      apiPath: "/api/forge/github-mirror-runs",
+    })
   })
 
   it("renders a direct route shell without the old logged-in Forge page", () => {

--- a/apps/forge/src/index.ts
+++ b/apps/forge/src/index.ts
@@ -42,6 +42,7 @@ export const ForgeShellRouteId = Schema.Literals([
   "verification",
   "queue",
   "refs",
+  "mirror",
 ])
 export type ForgeShellRouteId = typeof ForgeShellRouteId.Type
 
@@ -103,6 +104,13 @@ export const forgeShellRoutes: ReadonlyArray<ForgeShellRoute> = [
     label: "Git Refs",
     summary: "canonical ref namespaces and mirror state",
     apiPath: "/api/forge/refs",
+  },
+  {
+    id: "mirror",
+    path: "/mirror",
+    label: "Mirror",
+    summary: "GitHub mirror receipts and attention state",
+    apiPath: "/api/forge/github-mirror-runs",
   },
 ]
 
@@ -1233,6 +1241,24 @@ const renderRefs = (): string => `<section class="forge-panel" data-span="wide">
   </div>
 </section>`
 
+const renderMirror = (): string => `<section class="forge-panel" data-span="wide">
+  <div class="forge-panel-head">
+    <h3 class="forge-panel-title">GitHub Mirror</h3>
+    <span class="forge-table-caption">/api/forge/github-mirror-runs</span>
+  </div>
+  <div class="forge-list">
+    ${forgeShellPreviewState.dogfoodLanes
+      .map(
+        lane => `<div class="forge-list-item">
+          <span class="forge-list-kicker">${escapeHtml(lane.issueRef)}</span>
+          <span class="forge-list-title">${escapeHtml(lane.mirrorRef)}</span>
+          <span class="forge-list-body">Mirrors ${escapeHtml(lane.promotionRef)} to GitHub only after Forge accepts the promoted head.</span>
+        </div>`,
+      )
+      .join("\n")}
+  </div>
+</section>`
+
 const renderRouteContent = (routeId: ForgeShellRouteId): string => {
   switch (routeId) {
     case "dogfood":
@@ -1247,6 +1273,8 @@ const renderRouteContent = (routeId: ForgeShellRouteId): string => {
       return renderQueue()
     case "refs":
       return renderRefs()
+    case "mirror":
+      return renderMirror()
     case "overview":
       return renderOverview()
   }

--- a/apps/openagents.com/workers/api/migrations/0259_forge_github_mirror_receipts.sql
+++ b/apps/openagents.com/workers/api/migrations/0259_forge_github_mirror_receipts.sql
@@ -1,0 +1,34 @@
+-- FORGE SU-6 (#6796): GitHub mirror receipts for Forge-promoted commits.
+--
+-- GitHub is a downstream mirror only. These rows record attempts to mirror a
+-- Forge promotion receipt to the configured GitHub repository/branch, including
+-- refusals and failures. They never authorize promotion decisions and never
+-- store GitHub tokens, private repo contents, raw logs, prompts, local paths,
+-- provider payloads, wallet material, invoices, preimages, or bearer tokens.
+
+CREATE TABLE IF NOT EXISTS forge_github_mirror_receipts (
+  tenant_ref TEXT NOT NULL,
+  mirror_ref TEXT NOT NULL,
+  promotion_ref TEXT NOT NULL,
+  source_canonical_ref TEXT NOT NULL,
+  destination_github_ref TEXT NOT NULL,
+  destination_repository TEXT NOT NULL,
+  commit_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'mirrored', 'refused', 'failed')),
+  attempted_at TEXT NOT NULL,
+  mirrored_at TEXT,
+  refusal_reason TEXT,
+  error_reason TEXT,
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  attention_refs_json TEXT NOT NULL DEFAULT '[]',
+  redacted INTEGER NOT NULL DEFAULT 1 CHECK (redacted = 1),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (tenant_ref, mirror_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_promotion
+  ON forge_github_mirror_receipts (tenant_ref, promotion_ref, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_status
+  ON forge_github_mirror_receipts (tenant_ref, status, updated_at);

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -67,6 +67,10 @@ const canonicalGitMigration = readFileSync(
   new URL('../migrations/0255_forge_git_canonical_store.sql', import.meta.url),
   'utf8',
 )
+const githubMirrorMigration = readFileSync(
+  new URL('../migrations/0259_forge_github_mirror_receipts.sql', import.meta.url),
+  'utf8',
+)
 
 const makeStores = (): Readonly<{
   canonicalStore: ForgeGitCanonicalStore
@@ -77,6 +81,7 @@ const makeStores = (): Readonly<{
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
   db.exec(canonicalGitMigration)
+  db.exec(githubMirrorMigration)
   const d1 = new SqliteD1(db) as unknown as D1Database
   return {
     canonicalStore: makeD1ForgeGitCanonicalStore(d1),
@@ -106,6 +111,38 @@ const makeGitHubFetch = (sha: string = githubMainSha): typeof fetch =>
       },
     })) as typeof fetch
 
+const makeMirrorFetch = (
+  input: Readonly<{
+    currentSha?: string
+    updateStatus?: number
+    calls?: Array<Readonly<{ method: string; url: string; body: string | null }>>
+  }> = {},
+): typeof fetch =>
+  (async (request: RequestInfo | URL, init?: RequestInit) => {
+    const url = request instanceof Request ? request.url : String(request)
+    const method = init?.method ?? (request instanceof Request ? request.method : 'GET')
+    const body =
+      typeof init?.body === 'string'
+        ? init.body
+        : request instanceof Request
+          ? await request.clone().text()
+          : null
+    input.calls?.push({ body, method, url })
+    if (method === 'GET') {
+      return Response.json({
+        ref: 'refs/heads/main',
+        object: {
+          sha: input.currentSha ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          type: 'commit',
+        },
+      })
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'content-type': 'application/json' },
+      status: input.updateStatus ?? 200,
+    })
+  }) as typeof fetch
+
 type JsonRequestInit = Omit<RequestInit, 'body'> & Readonly<{ json?: unknown }>
 
 const requestJson = (
@@ -121,12 +158,18 @@ const requestJson = (
     },
   })
 
-const makeHarness = () => {
+const makeHarness = (
+  options: Readonly<{
+    fetch?: typeof fetch
+    githubMirrorToken?: string | undefined
+  }> = {},
+) => {
   const { canonicalStore, coordinationStore } = makeStores()
   const routes = makeForgeControlPlaneRoutes({
     authorizeControlPlaneBearer: (request, _env, scope) =>
       authorizeForgeControlPlaneBearer(request, controlPlaneToken, scope),
-    fetch: makeGitHubFetch(),
+    fetch: options.fetch ?? makeGitHubFetch(),
+    githubMirrorToken: () => options.githubMirrorToken,
     makeCanonicalStore: () => canonicalStore,
     makeStore: () => coordinationStore,
     nowIso: () => now,
@@ -389,6 +432,172 @@ describe('Forge control-plane routes', () => {
       promotionDecisions: ReadonlyArray<unknown>
     }
     expect(decisionsBody.promotionDecisions).toHaveLength(1)
+  })
+
+  test('mirrors approved Forge promotions and records idempotent receipts', async () => {
+    const calls: Array<Readonly<{ method: string; url: string; body: string | null }>> = []
+    const { run, store } = makeHarness({
+      fetch: makeMirrorFetch({ calls }),
+      githubMirrorToken: 'github-token',
+    })
+    const scopes = 'forge:promotion:decide forge:mirror:write forge:mirror:read'
+    const promotedHead = '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac'
+
+    await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: {
+          schema: 'openagents.forge.promotion.decision.v0.1',
+          tenant_ref: 'tenant.openagents',
+          promotion_ref: 'promotion.forge.6796',
+          queue_ref: 'queue.forge.main',
+          change_ref: 'change.forge.6796',
+          decision: 'approved',
+          base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
+          candidate_head: promotedHead,
+          promoted_head: promotedHead,
+          verification_ref: 'verification.forge.6796',
+          gate_refs: ['gate.forge.verification.passed'],
+          blocker_refs: [],
+          decided_by_ref: 'agent.public.forge',
+          decided_at: '2026-06-28T17:03:00.000Z',
+          source_refs: ['github:OpenAgentsInc/openagents#6796'],
+          redacted: true,
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+
+    const first = await run(
+      requestJson('/api/forge/github-mirror-runs', {
+        json: { promotionRef: 'promotion.forge.6796', tenantRef: 'tenant.openagents' },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const firstBody = (await first.json()) as {
+      githubMirrorReceipt: { commit_id: string; status: string; destination_github_ref: string }
+    }
+    expect(first.status).toBe(201)
+    expect(firstBody.githubMirrorReceipt).toMatchObject({
+      commit_id: promotedHead,
+      destination_github_ref: 'refs/heads/main',
+      status: 'mirrored',
+    })
+    expect(calls.filter(call => call.method === 'PATCH')).toHaveLength(1)
+    expect(calls.find(call => call.method === 'PATCH')?.body).toContain(
+      `"sha":"${promotedHead}"`,
+    )
+
+    const second = await run(
+      requestJson('/api/forge/github-mirror-runs', {
+        json: { promotionRef: 'promotion.forge.6796', tenantRef: 'tenant.openagents' },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const secondBody = (await second.json()) as { idempotent: boolean }
+    expect(second.status).toBe(200)
+    expect(secondBody.idempotent).toBe(true)
+    expect(calls.filter(call => call.method === 'PATCH')).toHaveLength(1)
+    await expect(
+      store.listGithubMirrorReceipts('tenant.openagents', 10, 'promotion.forge.6796'),
+    ).resolves.toHaveLength(1)
+
+    const listResponse = await run(
+      new Request(
+        'https://openagents.com/api/forge/github-mirror-runs?tenantRef=tenant.openagents&promotionRef=promotion.forge.6796',
+        { headers: authHeaders(scopes) },
+      ),
+    )
+    const listBody = (await listResponse.json()) as {
+      githubMirrorReceipts: ReadonlyArray<unknown>
+    }
+    expect(listResponse.status).toBe(200)
+    expect(listBody.githubMirrorReceipts).toHaveLength(1)
+  })
+
+  test('refuses non-promoted changes without calling GitHub', async () => {
+    const calls: Array<Readonly<{ method: string; url: string; body: string | null }>> = []
+    const { run } = makeHarness({
+      fetch: makeMirrorFetch({ calls }),
+      githubMirrorToken: 'github-token',
+    })
+
+    const response = await run(
+      requestJson('/api/forge/github-mirror-runs', {
+        json: {
+          promotionRef: 'promotion.forge.not-promoted',
+          tenantRef: 'tenant.openagents',
+        },
+        headers: authHeaders('forge:mirror:write'),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as {
+      githubMirrorReceipt: { refusal_reason: string | null; status: string }
+    }
+
+    expect(response.status).toBe(409)
+    expect(body.githubMirrorReceipt.status).toBe('refused')
+    expect(body.githubMirrorReceipt.refusal_reason).toContain('not approved')
+    expect(calls).toHaveLength(0)
+  })
+
+  test('records GitHub mirror failures as Forge attention state', async () => {
+    const { run } = makeHarness({
+      fetch: makeMirrorFetch({ updateStatus: 422 }),
+      githubMirrorToken: 'github-token',
+    })
+    const scopes = 'forge:promotion:decide forge:mirror:write'
+    const promotedHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab'
+
+    await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: {
+          schema: 'openagents.forge.promotion.decision.v0.1',
+          tenant_ref: 'tenant.openagents',
+          promotion_ref: 'promotion.forge.fail',
+          queue_ref: 'queue.forge.main',
+          change_ref: 'change.forge.fail',
+          decision: 'approved',
+          base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
+          candidate_head: promotedHead,
+          promoted_head: promotedHead,
+          verification_ref: 'verification.forge.fail',
+          gate_refs: ['gate.forge.verification.passed'],
+          blocker_refs: [],
+          decided_by_ref: 'agent.public.forge',
+          decided_at: '2026-06-28T17:03:00.000Z',
+          source_refs: ['github:OpenAgentsInc/openagents#6796'],
+          redacted: true,
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+
+    const response = await run(
+      requestJson('/api/forge/github-mirror-runs', {
+        json: { promotionRef: 'promotion.forge.fail', tenantRef: 'tenant.openagents' },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as {
+      githubMirrorReceipt: {
+        attention_refs: ReadonlyArray<string>
+        error_reason: string | null
+        status: string
+      }
+    }
+
+    expect(response.status).toBe(502)
+    expect(body.githubMirrorReceipt.status).toBe('failed')
+    expect(body.githubMirrorReceipt.error_reason).toContain('HTTP 422')
+    expect(body.githubMirrorReceipt.attention_refs).toContain(
+      'attention.forge.github_mirror.update_failed',
+    )
   })
 
   test('imports the public OpenAgents main ref into canonical refs idempotently', async () => {

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -2,9 +2,11 @@ import {
   ForgeCoordinationChangeState,
   ForgeCoordinationIssueState,
   ForgeCoordinationStatusState,
+  ForgeGithubMirrorReceipt,
   ForgeMergeQueueLedgerState,
   ForgePromotionDecisionReceipt,
   ForgeVerificationReceipt,
+  decodeForgeGithubMirrorReceipt,
   decodeForgeControlPlaneScope,
   type ForgeControlPlaneScope,
 } from '@openagentsinc/forge-protocol'
@@ -27,6 +29,9 @@ const OPENAGENTS_FORGE_REPOSITORY_REF = 'repo.openagents.openagents'
 const OPENAGENTS_GITHUB_OWNER = 'OpenAgentsInc'
 const OPENAGENTS_GITHUB_REPO = 'openagents'
 const OPENAGENTS_DEFAULT_BRANCH_REF = 'refs/heads/main'
+const OPENAGENTS_GITHUB_API_MAIN_REF = 'heads/main'
+const OPENAGENTS_GITHUB_MIRROR_REF = 'refs/heads/main'
+const OPENAGENTS_GITHUB_MIRROR_REPOSITORY = `${OPENAGENTS_GITHUB_OWNER}/${OPENAGENTS_GITHUB_REPO}`
 
 export type ForgeControlPlaneAuth = Readonly<{
   mode: 'admin' | 'control_plane'
@@ -44,6 +49,7 @@ export type ForgeControlPlaneAuthorize<Bindings> = (
 type ForgeControlPlaneRouteDependencies<Bindings> = Readonly<{
   authorizeControlPlaneBearer?: ForgeControlPlaneAuthorize<Bindings> | undefined
   fetch?: typeof fetch
+  githubMirrorToken?: (env: Bindings) => string | undefined
   makeCanonicalStore: (env: Bindings) => ForgeGitCanonicalStore
   makeStore: (env: Bindings) => ForgeCoordinationStore
   nowIso?: () => string
@@ -120,6 +126,14 @@ const ForgeMergeQueueSnapshotRequest = S.Struct({
 const ForgeOpenAgentsImportRequest = S.Struct({
   tenantRef: S.String,
   repositoryRef: S.String,
+})
+
+const ForgeGithubMirrorRunRequest = S.Struct({
+  tenantRef: S.String,
+  promotionRef: S.String,
+  repositoryRef: S.optionalKey(S.NullOr(S.String)),
+  destinationRepository: S.optionalKey(S.NullOr(S.String)),
+  destinationGithubRef: S.optionalKey(S.NullOr(S.String)),
 })
 
 const readBearerToken = (request: Request): string | undefined => {
@@ -700,6 +714,311 @@ const readGitHubMainTip = async <Bindings>(
   }
 }
 
+const maybeEnvString = <Bindings>(
+  env: Bindings,
+  name: string,
+): string | undefined => {
+  if (typeof env !== 'object' || env === null) {
+    return undefined
+  }
+  const value = (env as Record<string, unknown>)[name]
+  return typeof value === 'string' && value.trim() !== ''
+    ? value.trim()
+    : undefined
+}
+
+const githubMirrorToken = <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  env: Bindings,
+): string | undefined =>
+  dependencies.githubMirrorToken?.(env) ??
+  maybeEnvString(env, 'OPENAGENTS_FORGE_GITHUB_MIRROR_TOKEN') ??
+  maybeEnvString(env, 'FORGE_GITHUB_MIRROR_TOKEN')
+
+const assertSha1 = (value: string, label: string): string => {
+  const normalized = value.toLowerCase()
+  if (!/^[0-9a-f]{40}$/u.test(normalized)) {
+    throw new ForgeControlPlaneHttpError(
+      400,
+      'forge_github_mirror_invalid_commit',
+      `${label} must be a SHA-1 commit id.`,
+    )
+  }
+  return normalized
+}
+
+const safeMirrorSegment = (value: string): string =>
+  value.replace(/[^A-Za-z0-9_.-]+/g, '_').replace(/^_+|_+$/g, '').slice(0, 120) ||
+  'ref'
+
+const githubMirrorRef = (promotionRef: string, commitId: string): string =>
+  `mirror.github.openagents.main.${safeMirrorSegment(promotionRef)}.${commitId.slice(0, 12)}`
+
+const githubMirrorReceipt = (
+  input: Readonly<{
+    tenantRef: string
+    mirrorRef: string
+    promotionRef: string
+    sourceCanonicalRef: string
+    commitId: string
+    status: 'pending' | 'mirrored' | 'refused' | 'failed'
+    attemptedAt: string
+    mirroredAt: string | null
+    refusalReason: string | null
+    errorReason: string | null
+    sourceRefs: ReadonlyArray<string>
+    attentionRefs: ReadonlyArray<string>
+  }>,
+): ForgeGithubMirrorReceipt => decodeForgeGithubMirrorReceipt({
+  schema: 'openagents.forge.github_mirror.receipt.v0.1',
+  tenant_ref: input.tenantRef,
+  mirror_ref: input.mirrorRef,
+  promotion_ref: input.promotionRef,
+  source_canonical_ref: input.sourceCanonicalRef,
+  destination_github_ref: OPENAGENTS_GITHUB_MIRROR_REF,
+  destination_repository: OPENAGENTS_GITHUB_MIRROR_REPOSITORY,
+  commit_id: input.commitId,
+  status: input.status,
+  attempted_at: input.attemptedAt,
+  mirrored_at: input.mirroredAt,
+  refusal_reason: input.refusalReason,
+  error_reason: input.errorReason,
+  source_refs: [...input.sourceRefs],
+  attention_refs: [...input.attentionRefs],
+  redacted: true,
+})
+
+const readGitHubMirrorTip = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  token: string,
+): Promise<string | undefined> => {
+  const response = await (dependencies.fetch ?? fetch)(
+    `https://api.github.com/repos/${OPENAGENTS_GITHUB_MIRROR_REPOSITORY}/git/ref/${OPENAGENTS_GITHUB_API_MAIN_REF}`,
+    {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'user-agent': 'openagents-forge-github-mirror',
+      },
+    },
+  )
+
+  if (!response.ok) {
+    return undefined
+  }
+
+  const body = (await response.json()) as { object?: { sha?: unknown } }
+  return typeof body.object?.sha === 'string'
+    ? assertSha1(body.object.sha, 'GitHub mirror tip')
+    : undefined
+}
+
+const updateGitHubMirrorRef = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  token: string,
+  commitId: string,
+): Promise<Readonly<{ ok: true } | { ok: false; reason: string }>> => {
+  const response = await (dependencies.fetch ?? fetch)(
+    `https://api.github.com/repos/${OPENAGENTS_GITHUB_MIRROR_REPOSITORY}/git/refs/${OPENAGENTS_GITHUB_API_MAIN_REF}`,
+    {
+      body: JSON.stringify({ force: false, sha: commitId }),
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        'user-agent': 'openagents-forge-github-mirror',
+      },
+      method: 'PATCH',
+    },
+  )
+
+  return response.ok
+    ? { ok: true }
+    : { ok: false, reason: `GitHub ref update failed with HTTP ${response.status}.` }
+}
+
+const routeGithubMirrorRuns = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  url: URL,
+) => {
+  const store = dependencies.makeStore(env)
+
+  if (request.method === 'GET') {
+    const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:mirror:read', tenantRef)
+    const limit = limitFromQuery(url)
+    return noStoreJsonResponse({
+      githubMirrorReceipts: await store.listGithubMirrorReceipts(
+        tenantRef,
+        limit,
+        optionalQuery(url, 'promotionRef'),
+      ),
+      limit,
+      tenantRef,
+    })
+  }
+
+  if (request.method !== 'POST') {
+    return methodNotAllowed(['GET', 'POST'])
+  }
+
+  const body = await decodeBody(request, ForgeGithubMirrorRunRequest)
+  await requireScope(dependencies, request, env, 'forge:mirror:write', body.tenantRef)
+
+  if (
+    (body.repositoryRef ?? OPENAGENTS_FORGE_REPOSITORY_REF) !== OPENAGENTS_FORGE_REPOSITORY_REF ||
+    (body.destinationRepository ?? OPENAGENTS_GITHUB_MIRROR_REPOSITORY) !==
+      OPENAGENTS_GITHUB_MIRROR_REPOSITORY ||
+    (body.destinationGithubRef ?? OPENAGENTS_GITHUB_MIRROR_REF) !==
+      OPENAGENTS_GITHUB_MIRROR_REF
+  ) {
+    throw new ForgeControlPlaneHttpError(
+      403,
+      'forge_github_mirror_target_forbidden',
+      `Forge GitHub mirror is pinned to ${OPENAGENTS_GITHUB_MIRROR_REPOSITORY}:${OPENAGENTS_GITHUB_MIRROR_REF}.`,
+    )
+  }
+
+  const attemptedAt = routeNowIso(dependencies)
+  const sourceCanonicalRef = `${OPENAGENTS_FORGE_REPOSITORY_REF}:${OPENAGENTS_DEFAULT_BRANCH_REF}`
+  const promotion = await store.readPromotionDecisionReceipt(
+    body.tenantRef,
+    body.promotionRef,
+  )
+  const commitId = assertSha1(
+    promotion?.promoted_head ?? promotion?.candidate_head ?? '0'.repeat(40),
+    'Forge promoted head',
+  )
+  const mirrorRef = githubMirrorRef(body.promotionRef, commitId)
+  const sourceRefs = [
+    body.promotionRef,
+    sourceCanonicalRef,
+    'github:OpenAgentsInc/openagents#6796',
+    'docs/forge/2026-06-28-forge-standup-spec.md#su-6--github-mirror-worker-6796',
+  ]
+  const existing = await store.readGithubMirrorReceipt(body.tenantRef, mirrorRef)
+
+  if (existing?.status === 'mirrored') {
+    return noStoreJsonResponse(
+      { githubMirrorReceipt: existing, idempotent: true },
+      { status: 200 },
+    )
+  }
+
+  if (
+    promotion === undefined ||
+    promotion.decision !== 'approved' ||
+    promotion.promoted_head === null ||
+    promotion.blocker_refs.length > 0
+  ) {
+    const receipt = await store.recordGithubMirrorReceipt(
+      githubMirrorReceipt({
+        attentionRefs: ['attention.forge.github_mirror.promotion_not_approved'],
+        attemptedAt,
+        commitId,
+        errorReason: null,
+        mirroredAt: null,
+        mirrorRef,
+        promotionRef: body.promotionRef,
+        refusalReason:
+          'Forge promotion receipt is missing, blocked, or not approved.',
+        sourceCanonicalRef,
+        sourceRefs,
+        status: 'refused',
+        tenantRef: body.tenantRef,
+      }),
+      attemptedAt,
+    )
+    return noStoreJsonResponse({ githubMirrorReceipt: receipt }, { status: 409 })
+  }
+
+  const token = githubMirrorToken(dependencies, env)
+  if (token === undefined) {
+    const receipt = await store.recordGithubMirrorReceipt(
+      githubMirrorReceipt({
+        attentionRefs: ['attention.forge.github_mirror.token_missing'],
+        attemptedAt,
+        commitId,
+        errorReason: 'Forge GitHub mirror token is not configured.',
+        mirroredAt: null,
+        mirrorRef,
+        promotionRef: body.promotionRef,
+        refusalReason: null,
+        sourceCanonicalRef,
+        sourceRefs,
+        status: 'failed',
+        tenantRef: body.tenantRef,
+      }),
+      attemptedAt,
+    )
+    return noStoreJsonResponse({ githubMirrorReceipt: receipt }, { status: 503 })
+  }
+
+  if ((await readGitHubMirrorTip(dependencies, token)) === commitId) {
+    const receipt = await store.recordGithubMirrorReceipt(
+      githubMirrorReceipt({
+        attentionRefs: [],
+        attemptedAt,
+        commitId,
+        errorReason: null,
+        mirroredAt: attemptedAt,
+        mirrorRef,
+        promotionRef: body.promotionRef,
+        refusalReason: null,
+        sourceCanonicalRef,
+        sourceRefs,
+        status: 'mirrored',
+        tenantRef: body.tenantRef,
+      }),
+      attemptedAt,
+    )
+    return noStoreJsonResponse({ githubMirrorReceipt: receipt, idempotent: true })
+  }
+
+  const update = await updateGitHubMirrorRef(dependencies, token, commitId)
+  if (!update.ok) {
+    const receipt = await store.recordGithubMirrorReceipt(
+      githubMirrorReceipt({
+        attentionRefs: ['attention.forge.github_mirror.update_failed'],
+        attemptedAt,
+        commitId,
+        errorReason: update.reason,
+        mirroredAt: null,
+        mirrorRef,
+        promotionRef: body.promotionRef,
+        refusalReason: null,
+        sourceCanonicalRef,
+        sourceRefs,
+        status: 'failed',
+        tenantRef: body.tenantRef,
+      }),
+      attemptedAt,
+    )
+    return noStoreJsonResponse({ githubMirrorReceipt: receipt }, { status: 502 })
+  }
+
+  const receipt = await store.recordGithubMirrorReceipt(
+    githubMirrorReceipt({
+      attentionRefs: [],
+      attemptedAt,
+      commitId,
+      errorReason: null,
+      mirroredAt: attemptedAt,
+      mirrorRef,
+      promotionRef: body.promotionRef,
+      refusalReason: null,
+      sourceCanonicalRef,
+      sourceRefs,
+      status: 'mirrored',
+      tenantRef: body.tenantRef,
+    }),
+    attemptedAt,
+  )
+  return noStoreJsonResponse({ githubMirrorReceipt: receipt }, { status: 201 })
+}
+
 const routeRefs = async <Bindings>(
   dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
   request: Request,
@@ -873,6 +1192,12 @@ export const makeForgeControlPlaneRoutes = <Bindings>(
     if (route.length === 1 && route[0] === 'promotion-decisions') {
       return routeEffect(() =>
         routePromotionDecisions(dependencies, request, env, url),
+      )
+    }
+
+    if (route.length === 1 && route[0] === 'github-mirror-runs') {
+      return routeEffect(() =>
+        routeGithubMirrorRuns(dependencies, request, env, url),
       )
     }
 

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.ts
@@ -3,6 +3,7 @@ import {
   decodeForgeCoordinationPrRow,
   decodeForgeCoordinationStatusRow,
   decodeForgeDispatchLeaseRow,
+  decodeForgeGithubMirrorReceipt,
   decodeForgeMergeQueueLedgerRow,
   decodeForgePromotionDecisionReceipt,
   decodeForgeVerificationReceipt,
@@ -14,6 +15,7 @@ import {
   type ForgeCoordinationStatusRow,
   type ForgeCoordinationStatusState,
   type ForgeDispatchLeaseRow,
+  type ForgeGithubMirrorReceipt,
   type ForgeMergeQueueLedgerRow,
   type ForgeMergeQueueLedgerState,
   type ForgePromotionDecisionReceipt,
@@ -138,6 +140,23 @@ export type ForgeCoordinationStore = Readonly<{
     limit: number,
     changeRef?: string,
   ) => Promise<ReadonlyArray<ForgePromotionDecisionReceipt>>
+  readPromotionDecisionReceipt: (
+    tenantRef: string,
+    promotionRef: string,
+  ) => Promise<ForgePromotionDecisionReceipt | undefined>
+  recordGithubMirrorReceipt: (
+    receipt: ForgeGithubMirrorReceipt,
+    createdAt: string,
+  ) => Promise<ForgeGithubMirrorReceipt>
+  listGithubMirrorReceipts: (
+    tenantRef: string,
+    limit: number,
+    promotionRef?: string,
+  ) => Promise<ReadonlyArray<ForgeGithubMirrorReceipt>>
+  readGithubMirrorReceipt: (
+    tenantRef: string,
+    mirrorRef: string,
+  ) => Promise<ForgeGithubMirrorReceipt | undefined>
 }>
 
 const StringArray = S.Array(S.String)
@@ -187,6 +206,24 @@ type ForgePromotionDecisionReceiptRow = Readonly<{
   decided_by_ref: string
   decided_at: string
   source_refs_json: string
+  redacted: number | boolean
+}>
+
+type ForgeGithubMirrorReceiptRow = Readonly<{
+  tenant_ref: string
+  mirror_ref: string
+  promotion_ref: string
+  source_canonical_ref: string
+  destination_github_ref: string
+  destination_repository: string
+  commit_id: string
+  status: string
+  attempted_at: string
+  mirrored_at: string | null
+  refusal_reason: string | null
+  error_reason: string | null
+  source_refs_json: string
+  attention_refs_json: string
   redacted: number | boolean
 }>
 
@@ -240,6 +277,28 @@ const promotionDecisionReceiptFromRow = (
     decided_by_ref: row.decided_by_ref,
     decided_at: row.decided_at,
     source_refs: stringArrayFromJson(row.source_refs_json),
+    redacted: row.redacted === true || row.redacted === 1,
+  })
+
+const githubMirrorReceiptFromRow = (
+  row: ForgeGithubMirrorReceiptRow,
+): ForgeGithubMirrorReceipt =>
+  decodeForgeGithubMirrorReceipt({
+    schema: 'openagents.forge.github_mirror.receipt.v0.1',
+    tenant_ref: row.tenant_ref,
+    mirror_ref: row.mirror_ref,
+    promotion_ref: row.promotion_ref,
+    source_canonical_ref: row.source_canonical_ref,
+    destination_github_ref: row.destination_github_ref,
+    destination_repository: row.destination_repository,
+    commit_id: row.commit_id,
+    status: row.status,
+    attempted_at: row.attempted_at,
+    mirrored_at: row.mirrored_at,
+    refusal_reason: row.refusal_reason,
+    error_reason: row.error_reason,
+    source_refs: stringArrayFromJson(row.source_refs_json),
+    attention_refs: stringArrayFromJson(row.attention_refs_json),
     redacted: row.redacted === true || row.redacted === 1,
   })
 
@@ -958,5 +1017,142 @@ export const makeD1ForgeCoordinationStore = (
             .all<ForgePromotionDecisionReceiptRow>()
 
     return rows.results.map(promotionDecisionReceiptFromRow)
+  },
+
+  async readPromotionDecisionReceipt(tenantRef, promotionRef) {
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_promotion_decisions
+          WHERE tenant_ref = ? AND promotion_ref = ?
+        `,
+      )
+      .bind(tenantRef, promotionRef)
+      .first<ForgePromotionDecisionReceiptRow>()
+
+    return row === null ? undefined : promotionDecisionReceiptFromRow(row)
+  },
+
+  async recordGithubMirrorReceipt(receipt, createdAt) {
+    const decoded = decodeForgeGithubMirrorReceipt(receipt)
+    await db
+      .prepare(
+        `
+          INSERT INTO forge_github_mirror_receipts (
+            tenant_ref,
+            mirror_ref,
+            promotion_ref,
+            source_canonical_ref,
+            destination_github_ref,
+            destination_repository,
+            commit_id,
+            status,
+            attempted_at,
+            mirrored_at,
+            refusal_reason,
+            error_reason,
+            source_refs_json,
+            attention_refs_json,
+            redacted,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+          ON CONFLICT (tenant_ref, mirror_ref) DO UPDATE SET
+            promotion_ref = excluded.promotion_ref,
+            source_canonical_ref = excluded.source_canonical_ref,
+            destination_github_ref = excluded.destination_github_ref,
+            destination_repository = excluded.destination_repository,
+            commit_id = excluded.commit_id,
+            status = excluded.status,
+            attempted_at = excluded.attempted_at,
+            mirrored_at = excluded.mirrored_at,
+            refusal_reason = excluded.refusal_reason,
+            error_reason = excluded.error_reason,
+            source_refs_json = excluded.source_refs_json,
+            attention_refs_json = excluded.attention_refs_json,
+            updated_at = excluded.updated_at
+        `,
+      )
+      .bind(
+        decoded.tenant_ref,
+        decoded.mirror_ref,
+        decoded.promotion_ref,
+        decoded.source_canonical_ref,
+        decoded.destination_github_ref,
+        decoded.destination_repository,
+        decoded.commit_id,
+        decoded.status,
+        decoded.attempted_at,
+        decoded.mirrored_at,
+        decoded.refusal_reason,
+        decoded.error_reason,
+        jsonArray(decoded.source_refs),
+        jsonArray(decoded.attention_refs),
+        createdAt,
+        createdAt,
+      )
+      .run()
+
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_github_mirror_receipts
+          WHERE tenant_ref = ? AND mirror_ref = ?
+        `,
+      )
+      .bind(decoded.tenant_ref, decoded.mirror_ref)
+      .first<ForgeGithubMirrorReceiptRow>()
+
+    return githubMirrorReceiptFromRow(
+      rowOrFail(row, 'forge github mirror receipt'),
+    )
+  },
+
+  async listGithubMirrorReceipts(tenantRef, limit, promotionRef) {
+    const rows =
+      promotionRef === undefined
+        ? await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ?
+                ORDER BY updated_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, limitRows(limit))
+            .all<ForgeGithubMirrorReceiptRow>()
+        : await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ? AND promotion_ref = ?
+                ORDER BY updated_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, promotionRef, limitRows(limit))
+            .all<ForgeGithubMirrorReceiptRow>()
+
+    return rows.results.map(githubMirrorReceiptFromRow)
+  },
+
+  async readGithubMirrorReceipt(tenantRef, mirrorRef) {
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_github_mirror_receipts
+          WHERE tenant_ref = ? AND mirror_ref = ?
+        `,
+      )
+      .bind(tenantRef, mirrorRef)
+      .first<ForgeGithubMirrorReceiptRow>()
+
+    return row === null ? undefined : githubMirrorReceiptFromRow(row)
   },
 })

--- a/docs/forge/2026-06-28-forge-standup-spec.md
+++ b/docs/forge/2026-06-28-forge-standup-spec.md
@@ -179,10 +179,16 @@ move behind the same host or into its own Worker once the boundary is proven.
   (Docker-isolated `bun test`) and posts a receipt + verdict back to Forge
   before the change is promotable. Acceptance: a failing change cannot reach
   `nextActualPromotion`, and the D1 status is backed by a receipt artifact.
-- **SU-6 — GitHub mirror worker (#6796).** A one-way worker that pushes
-  promoted commits to GitHub as a read-only mirror (keeps external visibility;
-  removes GitHub from the critical path). Acceptance: a Forge-promoted commit
-  appears on GitHub `main` via the mirror, not via a PR.
+- **SU-6 — GitHub mirror worker (#6796).** The control-plane mirror entrypoint is
+  `POST /api/forge/github-mirror-runs`: it reads a Forge promotion decision
+  receipt, refuses anything missing/blocked/not approved, and pushes only the
+  promoted head to the configured downstream `OpenAgentsInc/openagents`
+  `refs/heads/main` GitHub mirror with `force:false`. `GET
+  /api/forge/github-mirror-runs` lists `ForgeGithubMirrorReceipt` rows so the
+  Forge API/shell can surface mirrored, refused, and failed attention state.
+  Re-running a mirrored promotion is idempotent and does not advance GitHub
+  again. Acceptance: a Forge-promoted commit appears on GitHub `main` via the
+  mirror, not via a PR.
 - **SU-7 — Dogfood one OpenAgents fleet lane (#6797).** Point ONE codex/Pylon
   lane at Forge (intake -> verify -> queue -> promote -> mirror) end-to-end;
   prove zero GitHub PR contention. Then widen the cutover lane-by-lane.

--- a/packages/forge-protocol/src/index.test.ts
+++ b/packages/forge-protocol/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   decodeForgeDispatchDecision,
   decodeForgeDispatchMessage,
   decodeForgeDispatchWorkItem,
+  decodeForgeGithubMirrorReceipt,
   decodeForgePromotionDecisionReceipt,
   decodeForgeTenantRow,
   decodeForgeVerificationReceipt,
@@ -42,6 +43,7 @@ describe("@openagentsinc/forge-protocol", () => {
 
   test("keeps control-plane scopes separate from smart Git token scopes", () => {
     expect(forgeControlPlaneScopes).toContain("forge:promotion:decide");
+    expect(forgeControlPlaneScopes).toContain("forge:mirror:write");
     expect(decodeForgeControlPlaneScope("forge:work:write")).toBe(
       "forge:work:write",
     );
@@ -332,5 +334,26 @@ describe("@openagentsinc/forge-protocol", () => {
     });
     expect(promotion.decision).toBe("approved");
     expect(promotion.promoted_head).toBe(verification.head_head);
+
+    const mirror = decodeForgeGithubMirrorReceipt({
+      schema: "openagents.forge.github_mirror.receipt.v0.1",
+      tenant_ref: "tenant.openagents",
+      mirror_ref: "mirror.github.openagents.main.6768",
+      promotion_ref: promotion.promotion_ref,
+      source_canonical_ref: "repo.openagents.openagents:refs/heads/main",
+      destination_github_ref: "refs/heads/main",
+      destination_repository: "OpenAgentsInc/openagents",
+      commit_id: verification.head_head,
+      status: "mirrored",
+      attempted_at: "2026-06-28T16:03:00.000Z",
+      mirrored_at: "2026-06-28T16:03:00.000Z",
+      refusal_reason: null,
+      error_reason: null,
+      source_refs: [promotion.promotion_ref],
+      attention_refs: [],
+      redacted: true,
+    });
+    expect(mirror.status).toBe("mirrored");
+    expect(mirror.commit_id).toBe(verification.head_head);
   });
 });

--- a/packages/forge-protocol/src/index.ts
+++ b/packages/forge-protocol/src/index.ts
@@ -100,6 +100,8 @@ export const ForgeControlPlaneScope = S.Literals([
   "forge:queue:write",
   "forge:receipt:write",
   "forge:promotion:decide",
+  "forge:mirror:read",
+  "forge:mirror:write",
   "forge:admin",
 ]);
 export type ForgeControlPlaneScope = typeof ForgeControlPlaneScope.Type;
@@ -115,6 +117,8 @@ export const forgeControlPlaneScopes: ReadonlyArray<ForgeControlPlaneScope> = [
   "forge:queue:write",
   "forge:receipt:write",
   "forge:promotion:decide",
+  "forge:mirror:read",
+  "forge:mirror:write",
   "forge:admin",
 ];
 
@@ -166,6 +170,14 @@ export const ForgePromotionDecisionState = S.Literals([
 ]);
 export type ForgePromotionDecisionState =
   typeof ForgePromotionDecisionState.Type;
+
+export const ForgeGithubMirrorStatus = S.Literals([
+  "pending",
+  "mirrored",
+  "refused",
+  "failed",
+]);
+export type ForgeGithubMirrorStatus = typeof ForgeGithubMirrorStatus.Type;
 
 export const ForgeDispatchGitAccessDelivery = S.Literals([
   "out_of_band",
@@ -464,6 +476,27 @@ export const ForgePromotionDecisionReceipt = S.Struct({
 export type ForgePromotionDecisionReceipt =
   typeof ForgePromotionDecisionReceipt.Type;
 
+export const ForgeGithubMirrorReceipt = S.Struct({
+  schema: S.Literal("openagents.forge.github_mirror.receipt.v0.1"),
+  tenant_ref: S.String,
+  mirror_ref: S.String,
+  promotion_ref: S.String,
+  source_canonical_ref: S.String,
+  destination_github_ref: S.String,
+  destination_repository: S.String,
+  commit_id: S.String,
+  status: ForgeGithubMirrorStatus,
+  attempted_at: S.String,
+  mirrored_at: S.NullOr(S.String),
+  refusal_reason: S.NullOr(S.String),
+  error_reason: S.NullOr(S.String),
+  source_refs: S.Array(S.String),
+  attention_refs: S.Array(S.String),
+  redacted: S.Literal(true),
+});
+export type ForgeGithubMirrorReceipt =
+  typeof ForgeGithubMirrorReceipt.Type;
+
 export const ForgeDispatchMessage = S.Union([
   ForgeDispatchWorkItem,
   ForgeDispatchDecision,
@@ -528,6 +561,9 @@ export const decodeForgeVerificationReceipt = S.decodeUnknownSync(
 );
 export const decodeForgePromotionDecisionReceipt = S.decodeUnknownSync(
   ForgePromotionDecisionReceipt,
+);
+export const decodeForgeGithubMirrorReceipt = S.decodeUnknownSync(
+  ForgeGithubMirrorReceipt,
 );
 
 export const forgeCoordinationStatusStateForNip34Kind = (


### PR DESCRIPTION
Addresses #6796.

### Changes
- Added Forge GitHub mirror run protocol schemas and tests.
- Added control-plane support for mirroring approved promoted heads to GitHub, including idempotent receipt storage and read APIs.
- Added the Forge `/mirror` shell route wired to `/api/forge/github-mirror-runs`.
- Added D1 migration support for Forge GitHub mirror receipts and updated the standup spec.

### Verification
- `true` passed (exit 0).