### PR TITLE
[codex] Fix ops triage priority label queue

### DIFF
--- a/scripts/github-issue-triage.test.ts
+++ b/scripts/github-issue-triage.test.ts
@@ -121,9 +121,30 @@ describe("github issue triage output", () => {
     expect(issueHasAnyLabel(issue({ labels: [{ name: "standing-task" }] }))).toBe(true)
   })
 
-  test("builds the default candidate query from newly opened unlabeled issues", () => {
-    expect(buildCandidateIssueSearch(false)).toBe("is:issue is:open no:label sort:created-desc")
+  test("builds the default candidate query from issues missing priority labels", () => {
+    expect(buildCandidateIssueSearch(false)).toBe(
+      [
+        "is:issue is:open",
+        '-label:"prio:0-pr-burndown"',
+        '-label:"prio:1-continual-learning"',
+        '-label:"prio:2-issue-triage"',
+        '-label:"prio:3-product-promises"',
+        '-label:"prio:4-backstop-burn"',
+        "sort:created-desc",
+      ].join(" "),
+    )
     expect(buildCandidateIssueSearch(true)).toBe("is:issue is:open sort:created-desc")
+  })
+
+  test("keeps standing-task issues eligible until they have a priority label", () => {
+    expect(issueHasPriorityLabel(issue({ labels: [{ name: "standing-task" }] }))).toBe(false)
+    expect(
+      issueHasPriorityLabel(
+        issue({
+          labels: [{ name: "standing-task" }, { name: "prio:2-issue-triage" }],
+        }),
+      ),
+    ).toBe(true)
   })
 
   test("builds a scoped execution plan and rendered comment", () => {

--- a/scripts/github-issue-triage.ts
+++ b/scripts/github-issue-triage.ts
@@ -311,7 +311,9 @@ export const listRepositoryFiles = (cwd: string): ReadonlyArray<string> => {
 }
 
 export const buildCandidateIssueSearch = (includeLabeled: boolean): string =>
-  includeLabeled ? "is:issue is:open sort:created-desc" : "is:issue is:open no:label sort:created-desc"
+  includeLabeled
+    ? "is:issue is:open sort:created-desc"
+    : `is:issue is:open ${PRIORITY_LABELS.map(label => `-label:"${label}"`).join(" ")} sort:created-desc`
 
 const listCandidateIssues = (
   repo: string,
@@ -378,7 +380,7 @@ const main = () => {
   const options = parseArgs(Bun.argv.slice(2))
   const repositoryFiles = listRepositoryFiles(process.cwd())
   const candidates = listCandidateIssues(options.repo, options.limit, options.includeLabeled).filter(
-    issue => options.includeLabeled || !issueHasAnyLabel(issue),
+    issue => options.includeLabeled || !issueHasPriorityLabel(issue),
   )
   const openIssues = listOpenIssues(options.repo, Math.max(options.limit, 100))
   const decisions = candidates.map(issue =>


### PR DESCRIPTION
## Summary

- Change the default GitHub issue triage queue from fully unlabeled issues to open issues missing any `prio:*` label.
- Keep `standing-task` and other non-priority-labeled issues eligible for triage until a priority label is applied.
- Add regression coverage for the priority-label exclusion query and standing-task eligibility.

Closes #6708.

## Verification

- `bun run test:github-issue-triage` (11 pass, 0 fail)

Note: the requested opaque verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not resolvable to raw argv from this checkout; a bounded repo search found no matching ref text outside the task prompt. The concrete affected root verification above passed.