### PR TITLE
refactor(effect): standardize Pylon scoped resources

### DIFF
--- a/apps/pylon/src/effect-runtime-patterns.ts
+++ b/apps/pylon/src/effect-runtime-patterns.ts
@@ -1,0 +1,91 @@
+import { Context, Effect, Layer, Schedule } from "effect"
+
+export type PylonEffectRuntimePolicyShape = {
+  readonly gitOperationMaxRetries: number
+  readonly gitOperationBaseDelayMs: number
+  readonly gitOperationMaxDelayMs: number
+  readonly durableObjectMaxRetries: number
+  readonly externalHttpMaxRetries: number
+  readonly walletAdjacentMaxRetries: number
+  readonly publicProjectionMaxRetries: number
+}
+
+export const PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS: PylonEffectRuntimePolicyShape = {
+  durableObjectMaxRetries: 3,
+  externalHttpMaxRetries: 3,
+  gitOperationBaseDelayMs: 40,
+  gitOperationMaxDelayMs: 1_500,
+  gitOperationMaxRetries: 5,
+  publicProjectionMaxRetries: 3,
+  walletAdjacentMaxRetries: 2,
+}
+
+export class PylonEffectRuntimePolicy extends Context.Service<
+  PylonEffectRuntimePolicy,
+  PylonEffectRuntimePolicyShape
+>()("PylonEffectRuntimePolicy") {
+  static readonly Default = Layer.succeed(PylonEffectRuntimePolicy, PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS)
+}
+
+export function boundedExponentialSchedule(input: {
+  readonly baseDelayMs: number
+  readonly maxDelayMs?: number
+  readonly retries: number
+}) {
+  return Schedule.exponential(`${input.baseDelayMs} millis`).pipe(Schedule.both(Schedule.recurs(input.retries)))
+}
+
+export function gitOperationRetrySchedule(policy: PylonEffectRuntimePolicyShape = PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS) {
+  return boundedExponentialSchedule({
+    baseDelayMs: policy.gitOperationBaseDelayMs,
+    maxDelayMs: policy.gitOperationMaxDelayMs,
+    retries: policy.gitOperationMaxRetries,
+  })
+}
+
+export function externalHttpRetrySchedule(policy: PylonEffectRuntimePolicyShape = PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS) {
+  return boundedExponentialSchedule({
+    baseDelayMs: 250,
+    maxDelayMs: 5_000,
+    retries: policy.externalHttpMaxRetries,
+  })
+}
+
+export function durableObjectRetrySchedule(policy: PylonEffectRuntimePolicyShape = PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS) {
+  return boundedExponentialSchedule({
+    baseDelayMs: 25,
+    maxDelayMs: 1_000,
+    retries: policy.durableObjectMaxRetries,
+  })
+}
+
+export function walletAdjacentRetrySchedule(policy: PylonEffectRuntimePolicyShape = PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS) {
+  return boundedExponentialSchedule({
+    baseDelayMs: 500,
+    maxDelayMs: 10_000,
+    retries: policy.walletAdjacentMaxRetries,
+  })
+}
+
+export function publicProjectionRetrySchedule(policy: PylonEffectRuntimePolicyShape = PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS) {
+  return boundedExponentialSchedule({
+    baseDelayMs: 100,
+    maxDelayMs: 2_000,
+    retries: policy.publicProjectionMaxRetries,
+  })
+}
+
+export function scopedResource<A, E, R, R2>(
+  acquire: Effect.Effect<A, E, R>,
+  release: (resource: A) => Effect.Effect<unknown, never, R2>,
+) {
+  return Effect.acquireRelease(acquire, (resource) => release(resource))
+}
+
+export function withScopedResource<A, E, R, R2, B, E2, R3>(
+  acquire: Effect.Effect<A, E, R>,
+  release: (resource: A) => Effect.Effect<unknown, never, R2>,
+  use: (resource: A) => Effect.Effect<B, E2, R3>,
+) {
+  return scopedResource(acquire, release).pipe(Effect.flatMap(use), Effect.scoped)
+}

--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -2,8 +2,14 @@ import { existsSync, realpathSync } from "node:fs"
 import { mkdir, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { createHash } from "node:crypto"
+import { Effect, Scope } from "effect"
 import { CLAUDE_AGENT_CAPABILITY_REF } from "./claude-agent.js"
 import { CODEX_AGENT_CAPABILITY_REF } from "./codex-agent.js"
+import {
+  PylonEffectRuntimePolicy,
+  gitOperationRetrySchedule,
+  scopedResource,
+} from "./effect-runtime-patterns.js"
 
 /**
  * The adapter-neutral git_checkout workspace materializer (issue #4798).
@@ -203,10 +209,6 @@ export function checkoutSourceRef(checkout: GitCheckoutWorkspace): string {
 // collide with a background `git gc --auto` that escaped the critical section.
 // These are recoverable: retry the same git command a bounded number of times
 // with exponential backoff instead of surfacing a hard checkout failure.
-const gitCommandMaxAttempts = 6
-const gitCommandRetryBaseMs = 40
-const gitCommandRetryMaxMs = 1_500
-
 const transientGitLockPattern =
   /(?:index|config|shallow|packed-refs|HEAD|ORIG_HEAD|FETCH_HEAD)\.lock|unable to create '[^']*\.lock'|cannot lock ref|unable to lock|could not lock|gc is already running|another git process seems to be running|Unable to create '[^']*': File exists|fatal: Unable to create/i
 
@@ -227,6 +229,55 @@ async function spawnGitCommand(
   return { exitCode, stdout, stderr }
 }
 
+class TransientGitLockFailure {
+  readonly _tag = "TransientGitLockFailure"
+
+  constructor(readonly result: { exitCode: number; stdout: string; stderr: string }) {}
+}
+
+function retryableGitCommandResult(result: {
+  exitCode: number
+  stdout: string
+  stderr: string
+}) {
+  return result.exitCode !== 0 && isTransientGitLockStderr(result.stderr)
+}
+
+function runGitCommandEffect(
+  args: string[],
+  cwd: string,
+): Effect.Effect<{ exitCode: number; stdout: string; stderr: string }, never, PylonEffectRuntimePolicy> {
+  return Effect.gen(function* () {
+    const policy = yield* PylonEffectRuntimePolicy
+    const attempt = Effect.tryPromise({
+      try: () => spawnGitCommand(args, cwd),
+      catch: (error) => error,
+    }).pipe(
+      Effect.flatMap((result) =>
+        retryableGitCommandResult(result)
+          ? Effect.fail(new TransientGitLockFailure(result))
+          : Effect.succeed(result),
+      ),
+    )
+    return yield* attempt.pipe(
+      Effect.retry({
+        schedule: gitOperationRetrySchedule(policy),
+        while: (error) => error instanceof TransientGitLockFailure,
+      }),
+      Effect.catchIf(
+        (error): error is TransientGitLockFailure => error instanceof TransientGitLockFailure,
+        (error) => Effect.succeed(error.result),
+        (error) =>
+          Effect.succeed({
+            exitCode: 1,
+            stdout: "",
+            stderr: error instanceof Error ? error.message : String(error),
+          }),
+      ),
+    )
+  })
+}
+
 /**
  * Runs a git command, retrying with bounded exponential backoff only when the
  * failure is a transient git lock collision. Non-lock failures (a missing
@@ -237,14 +288,7 @@ async function runGitCommand(
   args: string[],
   cwd: string,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  let result = await spawnGitCommand(args, cwd)
-  for (let attempt = 1; attempt < gitCommandMaxAttempts; attempt += 1) {
-    if (result.exitCode === 0 || !isTransientGitLockStderr(result.stderr)) return result
-    const backoff = Math.min(gitCommandRetryBaseMs * 2 ** (attempt - 1), gitCommandRetryMaxMs)
-    await sleep(backoff + Math.floor(Math.random() * gitCommandRetryBaseMs))
-    result = await spawnGitCommand(args, cwd)
-  }
-  return result
+  return Effect.runPromise(runGitCommandEffect(args, cwd).pipe(Effect.provide(PylonEffectRuntimePolicy.Default)))
 }
 
 async function runQuietCommand(args: string[], cwd: string): Promise<number> {
@@ -875,13 +919,38 @@ async function withRepositoryCacheProcessLock<T>(
   bareDirectory: string,
   work: () => Promise<T>,
 ): Promise<T> {
-  const lock = await acquireRepositoryCacheProcessLock(bareDirectory)
-  try {
-    return await work()
-  } finally {
-    clearInterval(lock.heartbeat)
-    await rm(lock.lockDirectory, { recursive: true, force: true })
-  }
+  return Effect.runPromise(
+    withRepositoryCacheProcessLockEffect(
+      bareDirectory,
+      Effect.tryPromise({
+        try: work,
+        catch: (error) => error,
+      }),
+    ).pipe(Effect.provide(PylonEffectRuntimePolicy.Default)),
+  )
+}
+
+export function repositoryCacheProcessLockResource(
+  bareDirectory: string,
+): Effect.Effect<RepositoryCacheProcessLock, unknown, PylonEffectRuntimePolicy | Scope.Scope> {
+  return scopedResource(
+    Effect.tryPromise({
+      try: () => acquireRepositoryCacheProcessLock(bareDirectory),
+      catch: (error) => error,
+    }),
+    (lock) =>
+      Effect.promise(async () => {
+        clearInterval(lock.heartbeat)
+        await rm(lock.lockDirectory, { recursive: true, force: true })
+      }),
+  )
+}
+
+export function withRepositoryCacheProcessLockEffect<A, E, R>(
+  bareDirectory: string,
+  work: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | unknown, R | PylonEffectRuntimePolicy> {
+  return repositoryCacheProcessLockResource(bareDirectory).pipe(Effect.flatMap(() => work), Effect.scoped)
 }
 
 async function withRepositoryCacheLock<T>(bareDirectory: string, work: () => Promise<T>): Promise<T> {

--- a/apps/pylon/tests/workspace-worktree.test.ts
+++ b/apps/pylon/tests/workspace-worktree.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs"
 import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { Deferred, Effect, Fiber, Layer } from "effect"
 import {
   captureWorkspaceChanges,
   cleanupExpiredWorkspaces,
@@ -14,6 +15,7 @@ import {
   pruneWorkspaceCacheDirectories,
   publicWorkspaceChangeCaptureProjection,
   publicWorkspaceLeaseProjection,
+  repositoryCacheProcessLockResource,
   releaseWorkspace,
   repositoryCacheProcessLockOwnerIsLive,
   repositoryCacheKeyFor,
@@ -29,6 +31,11 @@ import {
   type WorkspaceCheckoutRunner,
   type WorkspaceLeaseRecord,
 } from "../src/workspace-materializer"
+import {
+  PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS,
+  PylonEffectRuntimePolicy,
+  gitOperationRetrySchedule,
+} from "../src/effect-runtime-patterns"
 import { CLAUDE_AGENT_CAPABILITY_REF } from "../src/claude-agent"
 import { CODEX_AGENT_CAPABILITY_REF } from "../src/codex-agent"
 import { assertPublicProjectionSafe } from "../src/state"
@@ -497,6 +504,72 @@ describe("createGitWorktreeCheckoutRunner", () => {
     } finally {
       await rm(root, { recursive: true, force: true })
     }
+  })
+})
+
+class FixtureRetryError {
+  readonly _tag = "FixtureRetryError"
+}
+
+describe("Effect runtime resource patterns", () => {
+  test("scoped repository cache locks clean up when interrupted", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-worktree-scope-"))
+    try {
+      const bareDirectory = join(root, "git-cache", "fixture.git")
+      const lockDirectory = `${bareDirectory}.pylon-lock`
+      const exit = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          const acquired = yield* Deferred.make<boolean>()
+          const fiber = yield* Effect.gen(function* () {
+            yield* repositoryCacheProcessLockResource(bareDirectory)
+            yield* Deferred.succeed(acquired, existsSync(lockDirectory))
+            yield* Effect.never
+          }).pipe(
+            Effect.scoped,
+            Effect.provide(PylonEffectRuntimePolicy.Default),
+            Effect.forkChild,
+          )
+          const lockExistsWhileHeld = yield* Deferred.await(acquired)
+          yield* Fiber.interrupt(fiber)
+          return lockExistsWhileHeld
+        }),
+      )
+
+      expect(exit._tag).toBe("Success")
+      if (exit._tag === "Success") expect(exit.value).toBe(true)
+      expect(existsSync(lockDirectory)).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("per-test retry policy layers expose typed failures through runPromiseExit", async () => {
+    let attempts = 0
+    const layer = Layer.succeed(PylonEffectRuntimePolicy, {
+      ...PYLON_EFFECT_RUNTIME_POLICY_DEFAULTS,
+      gitOperationBaseDelayMs: 1,
+      gitOperationMaxDelayMs: 5,
+      gitOperationMaxRetries: 2,
+    })
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const policy = yield* PylonEffectRuntimePolicy
+        return yield* Effect.sync(() => {
+          attempts += 1
+          return attempts
+        }).pipe(
+          Effect.flatMap(() => Effect.fail(new FixtureRetryError())),
+          Effect.retry({
+            schedule: gitOperationRetrySchedule(policy),
+            while: (error) => error instanceof FixtureRetryError,
+          }),
+        )
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    expect(attempts).toBe(3)
   })
 })
 

--- a/docs/refactor/2026-06-29-effect-scoped-resource-patterns.md
+++ b/docs/refactor/2026-06-29-effect-scoped-resource-patterns.md
@@ -1,0 +1,32 @@
+# Effect scoped resource patterns
+
+Issue: #7013
+
+Use Effect `Scope` / `acquireRelease` for runtime resources whose cleanup must
+run on success, failure, or interruption. In this repo that includes:
+
+- subprocess runners and long-running assignment runners,
+- WebSocket clients and stream subscriptions,
+- local leases, process locks, and file locks,
+- temporary checkouts and worktrees.
+
+The Pylon reference helper is `apps/pylon/src/effect-runtime-patterns.ts`.
+Prefer `scopedResource(acquire, release)` when a lower-level API needs to
+return a resource effect, and `withScopedResource(acquire, release, use)` when a
+caller can keep the full use-site inside one scoped effect. Promise-facing
+entry points may bridge with `Effect.runPromise`, but the acquire/release pair
+should remain in Effect so interruption closes the scope.
+
+Retry and timeout policy should be named at the boundary instead of encoded as
+ad hoc loops. The same helper module names reusable schedules for:
+
+- Git and GitHub operations,
+- external HTTP/provider calls,
+- Durable Object calls,
+- wallet-adjacent calls,
+- public projection sync.
+
+Tests for new Effect services should use per-test layers for stateful
+dependencies and `Effect.runPromiseExit` for expected typed failures. Use
+`TestClock` or bounded injected schedules for time-sensitive behavior so tests
+do not depend on wall-clock sleeps.


### PR DESCRIPTION
Closes #7013

## Summary
- add a Pylon Effect runtime helper with scoped resource wrappers and named retry schedules for Git, HTTP/provider, Durable Object, wallet-adjacent, and projection calls
- migrate the Pylon workspace materializer Git retry path and repository cache process lock to the Effect schedule/scoped-resource pattern
- document the local scoped resource pattern and add Effect-native tests for interruption cleanup plus per-test policy layer typed failure assertions

## Verification
- `bun test apps/pylon/tests/workspace-worktree.test.ts`
- `bun run --cwd apps/pylon typecheck`