### PR TITLE
task(ops): expose MirrorCode backstop burn projection

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -11000,6 +11000,18 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
       }),
   },
   {
+    // MirrorCode standing backstop burn (#6923). Public read-only live plan +
+    // ledger report over stored public-safe run rows. The surface never
+    // dispatches, spends, settles, or exposes task contents.
+    path: '/api/gym/mirrorcode/backstop-burn',
+    handler: (request, env) =>
+      handleMirrorCodeRunsApi(request, {
+        requireAdminApiToken: adminRequest =>
+          requireAdminApiToken(adminRequest, env),
+        store: makeD1MirrorCodeRunStore(openAgentsDatabase(env)),
+      }),
+  },
+  {
     // Operator-only Harbor full trace archive (#6253). Stores raw Harbor job
     // tarballs in private R2 with D1 metadata. Unlike `/api/traces`, this is
     // NOT a public-safe ATIF projection and never appears on public `/gym`.

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.test.ts
@@ -56,6 +56,20 @@ describe('MirrorCode standing backstop burn', () => {
     ])
   })
 
+  test('skips completed and active public task refs before filling the next batch', () => {
+    const plan = buildMirrorCodeBackstopBatchPlan({
+      maxTasks: 3,
+      completedTaskRefs: ['task.public.gym.mirrorcode.s.qsv-select.python'],
+      activeTaskRefs: ['task.public.gym.mirrorcode.s.jq-simple.python'],
+    })
+
+    expect(plan.tasks.map(task => task.taskId)).toEqual([
+      'gron',
+      'bitwise',
+      'hexyl',
+    ])
+  })
+
   test('builds a ledger-ready report with pass rate and exact token evidence separated', () => {
     const passed = buildMirrorCodeRun({
       runId: 'mc-backstop-s-cal-python-0001',

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.ts
@@ -102,13 +102,13 @@ const publicSegment = (value: string): string =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
 
-const taskKey = (
+export const mirrorCodeBackstopTaskKey = (
   bucket: MirrorCodeBucket,
   taskId: string,
   language: string,
 ): string => `${bucket}:${taskId}:${language}`
 
-const taskRefFor = (
+export const mirrorCodeBackstopTaskRefFor = (
   bucket: MirrorCodeBucket,
   taskId: string,
   language: string,
@@ -128,6 +128,15 @@ const runIdFor = (
     publicSegment(taskId),
     publicSegment(language),
   ].join('-')
+
+const skipRefsFor = (
+  bucket: MirrorCodeBucket,
+  taskId: string,
+  language: string,
+): ReadonlyArray<string> => [
+  mirrorCodeBackstopTaskKey(bucket, taskId, language),
+  mirrorCodeBackstopTaskRefFor(bucket, taskId, language),
+]
 
 const boundedBatchSize = (value: number | undefined): number => {
   if (value === undefined || !Number.isFinite(value)) {
@@ -164,13 +173,15 @@ export const buildMirrorCodeBackstopBatchPlan = (
   const tasks = candidates
     .filter(
       candidate =>
-        !skippedRefs.has(
-          taskKey(candidate.bucket, candidate.taskId, candidate.language),
-        ),
+        skipRefsFor(
+          candidate.bucket,
+          candidate.taskId,
+          candidate.language,
+        ).every(ref => !skippedRefs.has(ref)),
     )
     .slice(0, boundedBatchSize(input.maxTasks))
     .map(candidate => {
-      const taskRef = taskRefFor(
+      const taskRef = mirrorCodeBackstopTaskRefFor(
         candidate.bucket,
         candidate.taskId,
         candidate.language,
@@ -221,7 +232,11 @@ const ledgerTraceForRun = (
 ): MirrorCodeBackstopLedgerTrace => ({
   traceRef: `trace.public.gym.mirrorcode.backstop.${publicSegment(run.runId)}`,
   runId: run.runId,
-  taskRef: taskRefFor(run.bucket, run.taskId, run.language ?? DEFAULT_LANGUAGE),
+  taskRef: mirrorCodeBackstopTaskRefFor(
+    run.bucket,
+    run.taskId,
+    run.language ?? DEFAULT_LANGUAGE,
+  ),
   taskId: run.taskId,
   bucket: run.bucket,
   status: run.status,

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
@@ -294,6 +294,90 @@ describe('handleMirrorCodeTokenBurnReportApi', () => {
   })
 })
 
+describe('handleMirrorCodeBackstopBurnApi', () => {
+  test('public GET returns the next standing batch plan and ledger report', async () => {
+    const terminalRun = buildMirrorCodeRun({
+      ...validInput,
+      runId: 'mc-backstop-qsv-select-python-0001',
+      taskId: 'qsv_select',
+      status: 'failed',
+      passRate: 0.25,
+      tokens: { total: 1_000 },
+      exactTokenUsageEventRefs: [],
+    })
+    const activeRun = buildMirrorCodeRun({
+      ...validInput,
+      runId: 'mc-backstop-jq-simple-python-0001',
+      taskId: 'jq_simple',
+      status: 'running',
+      passRate: 0.8,
+      tokens: { total: 500 },
+      exactTokenUsageEventRefs: [
+        'token_usage_event.gym_mirrorcode.jq_simple.0001',
+      ],
+    })
+    const response = await run(
+      handleMirrorCodeRunsApi(
+        new Request(
+          'https://openagents.com/api/gym/mirrorcode/backstop-burn?maxTasks=3',
+        ),
+        {
+          requireAdminApiToken: async () => false,
+          listRuns: () => [terminalRun, activeRun],
+          nowIso: () => '2026-06-28T00:00:00.000Z',
+        },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      schemaVersion: string
+      issueNumber: number
+      plan: {
+        taskCount: number
+        tasks: ReadonlyArray<{ taskId: string }>
+      }
+      report: {
+        runCount: number
+        terminalRunCount: number
+        passRateBps: number | null
+        totalTokensBurned: number
+        exactTokenBackedTokens: number
+      }
+      staleness: { composition: string }
+    }
+    expect(body.schemaVersion).toBe(
+      'openagents.gym.mirrorcode_backstop_burn.v1',
+    )
+    expect(body.issueNumber).toBe(6923)
+    expect(body.staleness.composition).toBe('live_at_read')
+    expect(body.plan.taskCount).toBe(3)
+    expect(body.plan.tasks.map(task => task.taskId)).toEqual([
+      'gron',
+      'bitwise',
+      'hexyl',
+    ])
+    expect(body.report.runCount).toBe(2)
+    expect(body.report.terminalRunCount).toBe(1)
+    expect(body.report.passRateBps).toBe(0)
+    expect(body.report.totalTokensBurned).toBe(1_500)
+    expect(body.report.exactTokenBackedTokens).toBe(500)
+  })
+
+  test('non-GET is rejected', async () => {
+    const response = await run(
+      handleMirrorCodeRunsApi(
+        new Request('https://openagents.com/api/gym/mirrorcode/backstop-burn', {
+          method: 'POST',
+        }),
+        { requireAdminApiToken: async () => false, listRuns: () => [] },
+      ),
+    )
+
+    expect(response.status).toBe(405)
+  })
+})
+
 describe('handleMirrorCodeRunsApi POST', () => {
   const postRequest = (body: unknown) =>
     new Request('https://openagents.com/api/gym/mirrorcode/runs', {

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.ts
@@ -16,6 +16,9 @@
 //   - `GET /api/gym/mirrorcode/token-burn` (no auth): automated public-safe
 //     token-burn reporter over the stored run rows. It aggregates exact
 //     token-row refs where present and keeps unproven totals separate.
+//   - `GET /api/gym/mirrorcode/backstop-burn` (no auth): public-safe standing
+//     backstop plan + ledger report for issue #6923. It reads stored public run
+//     rows only and does not dispatch, spend, settle, or expose task contents.
 //
 // The public GET is composed live from D1 at read, so it declares a
 // `live_at_read` staleness contract (epic #4751). No dispatch, spend,
@@ -25,6 +28,15 @@ import { Effect } from 'effect'
 import { methodNotAllowed, noStoreJsonResponse } from '../../http/responses'
 import { currentIsoTimestamp } from '../../runtime-primitives'
 import { liveAtReadStaleness } from '../../public-projection-staleness'
+import {
+  buildMirrorCodeBackstopBatchPlan,
+  buildMirrorCodeBackstopBurnReport,
+  type BuildMirrorCodeBackstopBatchPlanInput,
+  mirrorCodeBackstopTaskKey,
+  mirrorCodeBackstopTaskRefFor,
+  MIRRORCODE_BACKSTOP_ISSUE_NUMBER,
+  MirrorCodeBackstopBurnSchemaVersion,
+} from './mirrorcode-backstop-burn'
 import {
   buildMirrorCodeLaunchRun,
   buildMirrorCodeRun,
@@ -169,6 +181,57 @@ const tokenBurnEnvelope = (
   report: buildMirrorCodeTokenBurnReport(runs),
 })
 
+const queryValues = (url: URL, name: string): ReadonlyArray<string> =>
+  url.searchParams
+    .getAll(name)
+    .flatMap(value => value.split(','))
+    .map(value => value.trim())
+    .filter(value => value.length > 0)
+
+const backstopRefsForRun = (run: MirrorCodeRun): ReadonlyArray<string> => {
+  const language = run.language ?? 'python'
+  return [
+    mirrorCodeBackstopTaskKey(run.bucket, run.taskId, language),
+    mirrorCodeBackstopTaskRefFor(run.bucket, run.taskId, language),
+  ]
+}
+
+const backstopBurnEnvelope = (
+  request: Request,
+  input: MirrorCodeRunsRouteInput,
+  runs: ReadonlyArray<MirrorCodeRun>,
+) => {
+  const url = new URL(request.url)
+  const batchRef = url.searchParams.get('batchRef')
+  const maxTasks = url.searchParams.get('maxTasks')
+  const planInput: BuildMirrorCodeBackstopBatchPlanInput = {
+    activeTaskRefs: [
+      ...queryValues(url, 'activeTaskRef'),
+      ...runs
+        .filter(run => ['queued', 'running'].includes(run.status))
+        .flatMap(backstopRefsForRun),
+    ],
+    completedTaskRefs: [
+      ...queryValues(url, 'completedTaskRef'),
+      ...runs
+        .filter(run => ['passed', 'failed', 'error'].includes(run.status))
+        .flatMap(backstopRefsForRun),
+    ],
+    languages: queryValues(url, 'language'),
+    ...(batchRef === null ? {} : { batchRef }),
+    ...(maxTasks === null ? {} : { maxTasks: Number(maxTasks) }),
+  }
+  return {
+    schemaVersion: MirrorCodeBackstopBurnSchemaVersion,
+    scope: 'public' as const,
+    generatedAt: (input.nowIso ?? currentIsoTimestamp)(),
+    staleness: mirrorCodeStaleness(),
+    issueNumber: MIRRORCODE_BACKSTOP_ISSUE_NUMBER,
+    plan: buildMirrorCodeBackstopBatchPlan(planInput),
+    report: buildMirrorCodeBackstopBurnReport(runs),
+  }
+}
+
 // Owner-gated launch / ingest: rebuilds + upserts a run. Admin-bearer gated.
 const handleOperatorIngestRun = (
   request: Request,
@@ -217,6 +280,16 @@ export const handleMirrorCodeRunsApi = (
     }
     return listRuns(input).pipe(
       Effect.map(runs => noStoreJsonResponse(tokenBurnEnvelope(input, runs))),
+    )
+  }
+  if (new URL(request.url).pathname === '/api/gym/mirrorcode/backstop-burn') {
+    if (request.method !== 'GET') {
+      return Effect.succeed(methodNotAllowed(['GET']))
+    }
+    return listRuns(input).pipe(
+      Effect.map(runs =>
+        noStoreJsonResponse(backstopBurnEnvelope(request, input, runs)),
+      ),
     )
   }
   if (request.method === 'POST') {

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -64,6 +64,7 @@ const approvedExactRoutePaths = [
   '/api/operator/khala/head-to-head',
   '/api/gym/mirrorcode/runs',
   '/api/gym/mirrorcode/token-burn',
+  '/api/gym/mirrorcode/backstop-burn',
   '/api/operator/gym/full-trace-archives',
   '/api/operator/customer-one-cohort/rows',
   '/api/operator/product-promises/transitions',


### PR DESCRIPTION
Closes #6923.

## Summary
- Exposes `GET /api/gym/mirrorcode/backstop-burn` as a public-safe live-at-read projection over stored MirrorCode run rows.
- Returns the next bounded standing backstop batch plan plus a ledger/token-burn report without dispatching, spending, settling, or exposing task contents.
- Lets the planner skip stored terminal and active runs by either task key or public task ref.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/mirrorcode-backstop-burn.test.ts src/inference/gym/mirrorcode-routes.test.ts src/worker-exact-routes.test.ts`
- `python3 apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exits 0; existing unrelated Effect language-service advisories remain in Artanis/Pylon files)
