### PR TITLE
Reconcile orange check promise blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -130,6 +130,9 @@ describe('public product promises document', () => {
     expect(blockerRefs).not.toContain(
       'blocker.product_promises.cloud_primitives_unified_balance_unbuilt',
     )
+    expect(blockerRefs).not.toContain(
+      'blocker.product_promises.orange_check_nostr_export_missing',
+    )
     expect(decoded.sourceRefs).toContain(
       'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
     )
@@ -1040,6 +1043,21 @@ describe('public product promises document', () => {
           promiseId: 'autopilot.repo_study_packets.v1',
           safeCopy: expect.stringContaining('dogfooding'),
           state: 'yellow',
+        }),
+        expect.objectContaining({
+          blockerRefs: [
+            'blocker.product_promises.orange_check_live_purchase_receipt_pending',
+            'blocker.product_promises.orange_check_badge_visibility_owner_signoff_pending',
+          ],
+          evidenceRefs: expect.arrayContaining([
+            'apps/openagents.com/workers/api/src/orange-check-nostr-export.ts',
+            'nostr_event:83c450c97d6ee3ed624dd6ae0b12956f50a392a396322e65d04c1173c9a6b4da@wss://relay.openagents.com',
+          ]),
+          promiseId: 'identity.orange_check_forum_signal.v1',
+          state: 'yellow',
+          verification: expect.stringContaining(
+            'owner-signed transition receipt/sign-off',
+          ),
         }),
         expect.objectContaining({
           blockerRefs: [],

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -2041,9 +2041,12 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/forum-routes.test.ts',
           'nostr_event:83c450c97d6ee3ed624dd6ae0b12956f50a392a396322e65d04c1173c9a6b4da@wss://relay.openagents.com',
         ],
-        blockerRefs: [],
+        blockerRefs: [
+          'blocker.product_promises.orange_check_live_purchase_receipt_pending',
+          'blocker.product_promises.orange_check_badge_visibility_owner_signoff_pending',
+        ],
         verification:
-          'Run the forum-routes orange-check purchase test and the orange-check Nostr export test: preview, private payment, unpaid redeem refusal, payment_received-gated fulfillment, badge projection, copy-boundary scan, and the public-safe NIP-01/NIP-58 export builders. The Nostr export blocker is cleared: bun apps/openagents.com/scripts/orange-check-nostr-export-publish.ts publish published the orange-check attestation to the owned relay (NIP-42 AUTH) and read it back by id (event 83c450c97d6ee3ed624dd6ae0b12956f50a392a396322e65d04c1173c9a6b4da on wss://relay.openagents.com), independently dereferenceable via REQ {"ids":["83c450..."]}. Green still requires one live $5 purchase settling through the production checkout with the badge visible on the buying agent.',
+          'Run the forum-routes orange-check purchase test and the orange-check Nostr export test: preview, private payment, unpaid redeem refusal, payment_received-gated fulfillment, badge projection, copy-boundary scan, and the public-safe NIP-01/NIP-58 export builders. The Nostr export blocker is cleared: bun apps/openagents.com/scripts/orange-check-nostr-export-publish.ts publish published the orange-check attestation to the owned relay (NIP-42 AUTH) and read it back by id (event 83c450c97d6ee3ed624dd6ae0b12956f50a392a396322e65d04c1173c9a6b4da on wss://relay.openagents.com), independently dereferenceable via REQ {"ids":["83c450..."]}. Green still requires one dereferenceable live $5 production-checkout settlement receipt, public-safe proof that the badge is visible on the buying agent, and owner-signed transition receipt/sign-off.',
         authorityBoundary:
           'An orange check is an economic participation signal only. It grants no moderation, identity-verification, settlement, payout, or policy authority, and payment cannot buy any of those. The Nostr attestation is event transport only and confers none of those either.',
       },


### PR DESCRIPTION
Closes #7015.

## Summary
- Keeps `identity.orange_check_forum_signal.v1` yellow while adding explicit blocker refs for the remaining production $5 purchase receipt and badge visibility / owner sign-off gate.
- Preserves the cleared owned-relay Nostr attestation evidence and updates verification copy to require a dereferenceable production checkout settlement receipt, public-safe badge visibility proof, and owner-signed transition receipt before green.
- Adds focused `product-promises.test.ts` assertions so the old Nostr-export blocker stays cleared and the current blockers cannot silently disappear.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts` (1 file passed, 10 tests passed)
