### PR TITLE
Align partner payout public blocker refs

### DIFF
--- a/apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts
@@ -41,9 +41,13 @@ describe('aggregatePartnerPayoutPublicProjection', () => {
       )?.percentBps,
     ).toBe(PARTNER_PAYOUT_ROLE_POLICY.referral.percentBps)
     expect(projection.blockerRefs).toEqual([
-      'blocker.product_promises.partner_payout_settlement_not_wired',
       'blocker.product_promises.partner_first_real_payout_pending',
     ])
+    expect(
+      projection.blockerRefs.includes(
+        'blocker.product_promises.partner_payout_settlement_not_wired',
+      ),
+    ).toBe(false)
     expect(
       projection.blockerRefs.includes(
         'blocker.product_promises.partner_projection_api_missing',

--- a/apps/openagents.com/workers/api/src/partner-payout-public-projection.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-projection.ts
@@ -36,7 +36,6 @@ const PARTNER_PAYOUT_PUBLIC_CAVEAT_REFS = [
 ] as const
 
 const PARTNER_PAYOUT_PUBLIC_BLOCKER_REFS = [
-  'blocker.product_promises.partner_payout_settlement_not_wired',
   'blocker.product_promises.partner_first_real_payout_pending',
 ] as const
 


### PR DESCRIPTION
## Summary

- Remove the stale `partner_payout_settlement_not_wired` blocker from the public partner-payout aggregate projection.
- Keep `partner_first_real_payout_pending` as the only public blocker, matching the product-promise registry while preserving the red state until a real settled partner payout receipt exists.
- Update regression coverage so the public projection cannot reintroduce the stale settlement-wiring blocker.

Refs #7021.

## Verification

- `bun install --frozen-lockfile`
- `bun run --cwd apps/openagents.com/workers/api test -- src/partner-payout-public-projection.test.ts src/partner-payout-ledger-routes.test.ts src/public-partner-payout-receipt-routes.test.ts src/product-promises.test.ts`

## Caveat

This PR does not claim a real partner payout settled. The remaining `partner_first_real_payout_pending` blocker stays in place until owner-armed production payout evidence exists.
