### PR TITLE
fix(glm): admit internal stress to idle GLM capacity

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -2807,7 +2807,7 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
-  test('rejects internal_stress route admission when reserved external headroom is unavailable', async () => {
+  test('admits internal_stress route dispatch when only reserved external headroom is unavailable', async () => {
     let dispatched = false
     const registry = new InferenceProviderRegistry()
     registry.register({
@@ -2837,19 +2837,12 @@ describe('POST /v1/chat/completions', () => {
       ),
     )
 
-    expect(response.status).toBe(429)
-    expect(response.headers.get('retry-after')).toBe('1')
-    expect(dispatched).toBe(false)
+    expect(response.status).toBe(200)
+    expect(dispatched).toBe(true)
     const body = (await response.json()) as {
-      error?: { code?: string; message?: string; retryable?: boolean }
+      openagents?: { worker?: string }
     }
-    expect(body.error).toEqual({
-      code: 'route_admission_reserved_headroom_unavailable',
-      message:
-        'internal_stress rejected because reserved external headroom is unavailable: glm_aggregate_external_headroom_zero',
-      retryable: true,
-      type: 'route_admission_reserved_headroom_unavailable',
-    })
+    expect(body.openagents?.worker).toBe('primary')
   })
 
   test('keeps external route demand admitted when breached SLO shedding is external-labeled', async () => {
@@ -3253,7 +3246,7 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
-  test('global coordinator is not registered when route admission rejects internal_stress before dispatch', async () => {
+  test('global coordinator still registers internal_stress when reserved external headroom is unavailable', async () => {
     let registerCalls = 0
     const coordinator: InternalStressPreemptionCoordinator = {
       preempt: async () => undefined,
@@ -3292,13 +3285,9 @@ describe('POST /v1/chat/completions', () => {
       ),
     )
 
-    expect(stressResponse.status).toBe(429)
-    expect(await stressResponse.json()).toMatchObject({
-      error: {
-        code: 'route_admission_reserved_headroom_unavailable',
-      },
-    })
-    expect(registerCalls).toBe(0)
+    expect(stressResponse.status).toBe(200)
+    await stressResponse.text()
+    expect(registerCalls).toBe(1)
   })
 
   test('wired GLM saturation proof: internal_stress yields while external overflows and records exact served tokens', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -3119,13 +3119,8 @@ export const handleChatCompletions = (
     const traceEmitOptIn = resolveKhalaChatTraceOptIn({ rawBody, request })
 
     const routeDemandClass = routeDemandClassFromAttribution(requestAttribution)
-    const internalStressRouteAdmissionRejected =
-      routeDemandClass === 'internal_stress' &&
-      deps.routeAdmission !== undefined &&
-      deps.routeAdmission.reservedExternalHeadroomAvailable === false
     const preemptionAbortController =
       routeDemandClass === 'internal_stress' &&
-      !internalStressRouteAdmissionRejected &&
       (deps.internalStressPreemption !== undefined ||
         deps.internalStressCoordinator !== undefined)
         ? new AbortController()

--- a/apps/openagents.com/workers/api/src/inference/model-router.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.ts
@@ -735,9 +735,9 @@ export type DispatchDeps = Readonly<{
   // Optional SLO shedding. Only non-external demand can be shed; external demand
   // continues through normal dispatch even when the SLO snapshot is breached.
   shedding?: DispatchLoadSheddingPolicy | undefined
-  // Optional typed route admission guard. It only refuses internal_stress when
-  // the control-plane snapshot says reserved external headroom is unavailable;
-  // external demand still dispatches through the normal lane plan.
+  // Optional typed route admission snapshot. Internal stress is not hard-failed
+  // from this coarse snapshot; real GLM headroom is enforced by the adapter and
+  // external pressure is handled by SLO shedding / preemption.
   admission?: DispatchRouteAdmissionPolicy | undefined
   // Optional typed scheduler hook. It can preempt one in-flight internal_stress
   // request only when external demand arrives and reserved external headroom is
@@ -899,24 +899,6 @@ const shedError = (
       shedding.demandClass === 'internal_stress'
         ? `internal_stress yielded because external SLO is breached: ${shedding.slo.reason}`
         : `request shed because SLO is breached: ${shedding.slo.reason}`,
-    retryable: true,
-  })
-
-const shouldRejectAdmission = (
-  admission: DispatchRouteAdmissionPolicy | undefined,
-): boolean =>
-  admission !== undefined &&
-  admission.demandClass === 'internal_stress' &&
-  !admission.reservedExternalHeadroomAvailable
-
-const admissionError = (
-  admission: DispatchRouteAdmissionPolicy,
-): InferenceAdapterError =>
-  new InferenceAdapterError({
-    adapterId: 'router',
-    httpStatus: 429,
-    kind: 'route_admission_reserved_headroom_unavailable',
-    reason: `internal_stress rejected because reserved external headroom is unavailable: ${admission.reason}`,
     retryable: true,
   })
 
@@ -1193,16 +1175,6 @@ export const dispatchWithOverflowWithMetadata = <A>(
     const backoff = deps.backoff ?? DEFAULT_OVERFLOW_BACKOFF
     const sleep = deps.sleep ?? Effect.sleep
     const retryCount = normalizedRetryCount(deps.retry)
-
-    const admission = deps.admission
-    if (shouldRejectAdmission(admission) && admission !== undefined) {
-      const error = admissionError(admission)
-      recordFailureTelemetry(
-        deps.failureTelemetry,
-        telemetryForError(error, 'load_shed'),
-      )
-      return yield* Effect.fail(error)
-    }
 
     const shedding = deps.shedding
     if (shouldShedRequest(shedding) && shedding !== undefined) {


### PR DESCRIPTION
Closes #6963.

## Summary
- Stops treating the GLM reserved-external-headroom snapshot as a hard pre-dispatch rejection for `internal_stress` requests.
- Keeps external protection paths intact: SLO shedding still yields internal stress, external demand can still preempt active internal stress, and the Hydralisk GLM adapter still enforces real runtime headroom with retryable saturation/overflow metadata.
- Updates chat-completions coverage so `internal_stress` + `glm-saturation` dispatches when the only negative signal is reserved external headroom, and the global stress coordinator still registers the run for later external preemption.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/model-router.test.ts src/inference/chat-completions-routes.test.ts` (231 passed)
- `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` resolved to `true` and passed
- `bun run --cwd apps/openagents.com/workers/api typecheck` exited 0; it printed existing Effect diagnostics in unrelated files (`artanis-*`, `pylon-api-routes.ts`) but did not fail

## Infra note
This PR fixes the in-repo admission policy that blocked the request before GLM dispatch. If live probes still report no GLM usage after this lands, the remaining blocker is likely real GLM fleet capacity/replica health and should be handled as owner/cloud infrastructure work.
