### PR TITLE
fix(codex-supervisor): recover stale claims and retry gate conflicts

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
@@ -122,7 +122,7 @@ sup_dispatch_failure_signature() {
     return 0
   fi
   if grep -qiE '409|dispatch gate refused|target_pylon_unavailable|duplicate_active_assignment' "$out" 2>/dev/null; then
-    printf 'refused'
+    printf 'dispatch_gate_conflict'
     return 0
   fi
   printf 'other'
@@ -143,6 +143,9 @@ sup_should_escalate_failure_backoff() {
   local sig="$1"
   local repeated="$2"
   if [ "$sig" = "codex_agent_execution_refused" ]; then
+    return 1
+  fi
+  if [ "$sig" = "dispatch_gate_conflict" ]; then
     return 1
   fi
   [ "$repeated" -ge "$SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD" ] 2>/dev/null

--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
@@ -52,8 +52,8 @@ else
   bad "executor refusal classification failed"
 fi
 
-if [ "$(sup_dispatch_failure_signature "$WORK/gate-refused.json")" = "refused" ]; then
-  ok "gate refusal remains generic refused"
+if [ "$(sup_dispatch_failure_signature "$WORK/gate-refused.json")" = "dispatch_gate_conflict" ]; then
+  ok "gate 409 refusal is classified as fast-retry dispatch conflict"
 else
   bad "gate refusal classification failed"
 fi
@@ -113,6 +113,12 @@ if sup_should_escalate_failure_backoff refused 2; then
   ok "repeated genuine refusal escalates backoff"
 else
   bad "repeated genuine refusal should escalate backoff"
+fi
+
+if sup_should_escalate_failure_backoff dispatch_gate_conflict 9; then
+  bad "dispatch gate conflicts should not escalate general backoff"
+else
+  ok "dispatch gate conflicts retry fast without escalating backoff"
 fi
 
 if sup_should_escalate_failure_backoff codex_agent_execution_refused 9; then

--- a/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
@@ -101,6 +101,14 @@ if sup_claim_is_active 701; then bad "stale #701 should be GC'd"; else ok "stale
 if sup_claim_is_active 702; then ok "fresh #702 survives GC"; else bad "fresh #702 should survive GC"; fi
 sup_release_claim 702
 
+# --- sup_gc_orphan_claims removes claims owned by dead supervisor pids -------
+sup_try_claim_issue 704 "$$" >/dev/null
+sup_try_claim_issue 705 99999999 >/dev/null
+sup_gc_orphan_claims
+if sup_claim_is_active 704; then ok "startup orphan GC preserves live-owner claim"; else bad "live-owner #704 should survive orphan GC"; fi
+if sup_claim_is_active 705; then bad "dead-owner #705 should be removed by orphan GC"; else ok "startup orphan GC removes dead-owner claim"; fi
+sup_release_claim 704
+
 # --- sup_refresh_claim renews TTL ------------------------------------------
 sup_try_claim_issue 703 >/dev/null
 touch -t 200001010000 "$(sup_claims_dir)/claim.703" 2>/dev/null || true
@@ -132,6 +140,30 @@ sup_release_claim 710; sup_release_claim 711; sup_release_claim 712
 picked=$(pick_and_claim_unlocked_issue 0 799 713)
 if [ "$picked" = "713" ]; then ok "pick_and_claim skips CLOSED #799 -> #713"; else bad "expected 713, got '$picked'"; fi
 sup_release_claim 713
+
+# --- pick_and_claim never claims epics / standing tasks ----------------------
+sup_labels_for_issue() {
+  case "$1" in
+    730) printf 'standing-task,prio:4-backstop-burn' ;;
+    731) printf 'epic,prio:1-continual-learning' ;;
+    *) printf '' ;;
+  esac
+}
+printf 'OPEN' > "$STUB_DIR/state.730"
+printf 'OPEN' > "$STUB_DIR/state.731"
+printf 'OPEN' > "$STUB_DIR/state.732"
+picked=$(pick_and_claim_unlocked_issue 0 730 731 732)
+if [ "$picked" = "732" ]; then ok "pick_and_claim skips standing-task/epic labels -> #732"; else bad "expected 732 after standing/epic exclusions, got '$picked'"; fi
+if sup_claim_is_active 730 || sup_claim_is_active 731; then
+  bad "standing-task/epic issues must not be claimed"
+else
+  ok "standing-task/epic issues have no claim directories"
+fi
+sup_release_claim 732
+
+picked=$(pick_and_claim_unlocked_issue 0 730 731)
+if [ "$picked" = "730" ]; then ok "standing-task can dispatch as fallback when no concrete issue remains"; else bad "expected fallback standing-task #730, got '$picked'"; fi
+if sup_claim_is_active 730; then bad "fallback standing-task dispatch must remain unclaimed"; else ok "fallback standing-task dispatch creates no claim"; fi
 
 # --- CONCURRENCY: N slots, same pool -> all DISTINCT, no duplicates ---------
 # This is the core regression assertion for the duplicate-dispatch bug.

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -494,11 +494,12 @@ worker_loop() {
       last_failure_sig="$sig"
       failure_repeat=1
     fi
-    if [ "$sig" = "refused" ]; then
-      # The gate already has an active assignment for this issue (it is busy
-      # elsewhere). PARK it for the full claim TTL so the fleet stops hammering
-      # the same stuck issue (#6661/#6662) and other slots spread to distinct
-      # work; the claim GCs once the TTL elapses for a later retry.
+    if [ "$sig" = "dispatch_gate_conflict" ]; then
+      # Gate 409s are often cross-driver contention, not proof this issue needs
+      # to be parked for a full claim TTL. Release and retry fast so the slot
+      # does not idle behind a stale local claim.
+      sup_release_claim "$issue"
+    elif [ "$sig" = "refused" ]; then
       sup_refresh_claim "$issue"
     else
       # Transient rate-limit/error on our side, not the issue's fault: release
@@ -511,6 +512,9 @@ worker_loop() {
     local failure_sleep="$backoff"
     local escalate_backoff=1
     if [ "$sig" = "codex_agent_execution_refused" ]; then
+      failure_sleep="$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
+      escalate_backoff=0
+    elif [ "$sig" = "dispatch_gate_conflict" ]; then
       failure_sleep="$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
       escalate_backoff=0
     elif ! sup_should_escalate_failure_backoff "$sig" "$failure_repeat"; then
@@ -543,6 +547,11 @@ echo $$ > "$SUP_STATE_DIR/supervisor.pid"
 # fresh process is not flagged wedged before its first dispatch (#6646).
 record_dispatch_attempt
 log "=== codex-supervisor START pid=$$ repo=$REPO_ROOT pylon=$SUP_PYLON_REF per_account=$SUP_PER_ACCOUNT max_slots=$SUP_MAX_SLOTS account_refs=${SUP_ACCOUNT_REFS:-all} ==="
+
+if [ "$SUP_CLAIM_STARTUP_GC_ORPHANS" = "1" ]; then
+  sup_gc_orphan_claims
+  log "startup claim GC complete (orphan claims removed)"
+fi
 
 sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" provider go-online >> "$SUP_LOG" 2>&1 || log "provider go-online nonzero (continuing)"
 

--- a/apps/pylon/scripts/codex-supervisor/lockout.sh
+++ b/apps/pylon/scripts/codex-supervisor/lockout.sh
@@ -273,6 +273,9 @@ pick_unlocked_issue() {
 # an issue another slot is actively working. Defaults to the dispatch timeout
 # when set, else 30m.
 : "${SUP_CLAIM_TTL_SECS:=${SUP_DISPATCH_TIMEOUT_SECS:-1800}}"
+# Claims from a previous supervisor process must not wedge a restarted fleet.
+# At startup we drop any claim whose recorded owner pid is not alive.
+: "${SUP_CLAIM_STARTUP_GC_ORPHANS:=1}"
 
 sup_claims_dir() {
   local d="${SUP_LOCKOUT_CACHE_DIR:-$SUP_STATE_DIR}/claims"
@@ -296,6 +299,73 @@ sup_gc_stale_claims() {
       rm -rf "$claim" 2>/dev/null || true
     fi
   done
+}
+
+sup_claim_owner_pid() {
+  local claim="$1"
+  [ -f "$claim/meta" ] || return 1
+  awk 'NR==1 {print $1; exit}' "$claim/meta" 2>/dev/null
+}
+
+sup_pid_is_alive() {
+  local pid="$1"
+  [ "$pid" -gt 0 ] 2>/dev/null || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+# sup_gc_orphan_claims
+#   Startup recovery for SIGKILL/restart: clear claims recorded by a supervisor
+#   pid that is no longer alive. TTL-only cleanup is too slow for a deep backlog;
+#   stale claim directories from the prior process can otherwise make every slot
+#   report LOCKOUT even though no assignment is actually running.
+sup_gc_orphan_claims() {
+  local dir; dir="$(sup_claims_dir)"
+  local claim owner
+  for claim in "$dir"/claim.*; do
+    [ -e "$claim" ] || continue
+    owner="$(sup_claim_owner_pid "$claim" || true)"
+    if [ -z "$owner" ] || ! sup_pid_is_alive "$owner"; then
+      rm -rf "$claim" 2>/dev/null || true
+    fi
+  done
+}
+
+# sup_labels_for_claim_guard <issue>
+#   Source-order tolerant label lookup. In the live supervisor, priority-
+#   dispatch.sh provides sup_labels_for_issue after this file is sourced. Tests
+#   may override that function. Standalone lockout tests fall back to gh.
+sup_labels_for_claim_guard() {
+  local issue="$1"
+  [ -n "$issue" ] || return 0
+  if command -v sup_labels_for_issue >/dev/null 2>&1; then
+    sup_labels_for_issue "$issue"
+    return 0
+  fi
+  command -v "$SUP_GH_BIN" >/dev/null 2>&1 || return 0
+  sup_run_timeout "$SUP_GH_TIMEOUT_SECS" "$SUP_GH_BIN" issue view "$issue" --repo "$SUP_REPO" \
+    --json labels 2>/dev/null | python3 -c "import sys,json
+try:
+    data=json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+labels=[(l.get('name') or '') for l in (data.get('labels') or []) if isinstance(l,dict)]
+print(','.join([x for x in labels if x]))" 2>/dev/null
+}
+
+# sup_issue_is_dispatch_claim_excluded <issue>
+#   Epics and standing tasks are coordination/source issues, not one-off
+#   dispatch units. Claiming them can reserve the whole queue floor and starve
+#   concrete backlog work, so the supervisor prefers concrete issues and never
+#   creates an in-flight claim for these labels.
+sup_issue_is_dispatch_claim_excluded() {
+  local issue="$1"
+  local labels=",${2:-$(sup_labels_for_claim_guard "$issue")},"
+  case "$labels" in
+    *",standing-task,"*|*",epic,"*|*",type:epic,"*|*",kind:epic,"*)
+      return 0
+      ;;
+  esac
+  return 1
 }
 
 # sup_claim_is_active <issue>
@@ -359,7 +429,8 @@ sup_release_claim() {
 #   ATOMICALLY claims the first remaining issue before returning it. Two slots
 #   racing the same ordered pool therefore resolve to DISTINCT issues. rc 0 with
 #   the claimed issue on stdout; rc 1 when no distinct unlocked+unclaimed issue
-#   is available.
+#   is available. Epic / standing-task issues are fallback-only and returned
+#   without a claim, so they cannot wedge a restarted supervisor.
 pick_and_claim_unlocked_issue() {
   local start="$1"; shift
   local arr=("$@")
@@ -370,6 +441,11 @@ pick_and_claim_unlocked_issue() {
   for (( k=0; k<n; k++ )); do
     i=$(( (start + k) % n ))
     issue="${arr[$i]}"
+    # First pass prefers concrete issues. Epics / standing tasks are fallback-
+    # only and are handled without claims below.
+    if sup_issue_is_dispatch_claim_excluded "$issue"; then
+      continue
+    fi
     # Already reserved by another slot this window -> spread to a distinct issue.
     if sup_claim_is_active "$issue"; then
       continue
@@ -388,6 +464,24 @@ pick_and_claim_unlocked_issue() {
       printf '%s' "$issue"
       return 0
     fi
+  done
+  # Fallback: if only epic / standing-task issues are dispatchable, allow one
+  # through WITHOUT creating a claim directory. This preserves the standing queue
+  # floor while preventing orphaned coordination claims from wedging restarts.
+  for (( k=0; k<n; k++ )); do
+    i=$(( (start + k) % n ))
+    issue="${arr[$i]}"
+    if ! sup_issue_is_dispatch_claim_excluded "$issue"; then
+      continue
+    fi
+    if ! issue_is_open "$issue"; then
+      continue
+    fi
+    if issue_has_open_pr "$issue"; then
+      continue
+    fi
+    printf '%s' "$issue"
+    return 0
   done
   return 1
 }


### PR DESCRIPTION
Closes #6987.

## Summary
- GC orphaned codex-supervisor issue claims on startup when the recorded owner pid is gone.
- Avoid persistent in-flight claim directories for epic / standing-task issues while preserving them as fallback dispatch work.
- Classify dispatch-gate 409 style refusals as fast-retry conflicts, release the local claim, and avoid exponential idle backoff.

## Verification
- `bash apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh`
- `bash apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh`
- `bash apps/pylon/scripts/codex-supervisor/lockout.test.sh`
- `bash -n apps/pylon/scripts/codex-supervisor/lockout.sh apps/pylon/scripts/codex-supervisor/backoff-policy.sh apps/pylon/scripts/codex-supervisor/codex-supervisor.sh apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
