### PR TITLE
test(autopilot): cover pylon growth live scene

### DIFF
--- a/apps/autopilot-desktop/tests/chat-world-scene.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-scene.test.ts
@@ -18,7 +18,9 @@ import {
   type LiveRecentPylon,
   type PaymentParticle,
 } from "../src/shared/chat-world-scene"
+import { liveChatWorldNetworkScene } from "../src/shared/chat-world-visualization"
 import type { PylonStatsSnapshot } from "../src/shared/pylon-network-scene"
+import { pylonNetworkVisualizationOptions } from "../src/ui/pylon-network-visualization"
 
 // ── P1: pylon-stats → scene ──────────────────────────────────────────────────
 
@@ -184,6 +186,77 @@ describe("projectChatWorldPylonScene", () => {
     // 1.1M total → tier ≥ the 1M threshold
     expect(scene.growth.settledSats).toBe(1_100_000)
     expect(scene.growth.tier).toBeGreaterThanOrEqual(4)
+  })
+
+  test("live renderer adapter keeps zero-earning Pylons at the still tier-0 crystal", () => {
+    const scene = projectChatWorldPylonScene(
+      snapshot({
+        pylonsOnlineNow: 1,
+        recentPylons: [
+          {
+            nodeLabel: "zero",
+            nostrPubkeyShort: "pylon.zero",
+            onlineNow: true,
+            assignmentReadyNow: false,
+            walletReadyNow: false,
+            lastHeartbeatAgeSeconds: 8,
+            cumulativeSettledSats: 0,
+          } satisfies LiveRecentPylon,
+        ] as never,
+      }),
+    )
+
+    expect(scene.growth).toEqual(pylonGrowthTier(0))
+    expect(scene.nodes[0]?.growth).toEqual(pylonGrowthTier(0))
+    expect(scene.nodes[0]?.pulseSpeed).toBeGreaterThan(0)
+
+    const network = liveChatWorldNetworkScene(scene)
+    const options = pylonNetworkVisualizationOptions(network!)
+    const node = options.nodes?.find((item) => item.id === "pylon.zero")
+
+    expect(node).toMatchObject({
+      detail: "online - tier 0 - 0 sats",
+      role: "lifecycle",
+      status: "queued",
+    })
+  })
+
+  test("live renderer adapter maps cumulative settled sats into scale, brightness, and facet cues", () => {
+    const scene = projectChatWorldPylonScene(
+      snapshot({
+        pylonsOnlineNow: 1,
+        recentPylons: [
+          {
+            nodeLabel: "earned",
+            nostrPubkeyShort: "pylon.earned",
+            onlineNow: false,
+            assignmentReadyNow: false,
+            walletReadyNow: false,
+            cumulativeSettledSats: 100_000,
+          } satisfies LiveRecentPylon,
+        ] as never,
+      }),
+    )
+
+    expect(scene.nodes[0]?.growth).toEqual(pylonGrowthTier(100_000))
+
+    const network = liveChatWorldNetworkScene(scene)
+    expect(network?.nodes[0]?.growth).toEqual({
+      brightness: 0.6,
+      facets: 12,
+      scale: 1.54,
+      settledSats: 100_000,
+      tier: 3,
+    })
+
+    const options = pylonNetworkVisualizationOptions(network!)
+    const node = options.nodes?.find((item) => item.id === "pylon.earned")
+
+    expect(node).toMatchObject({
+      detail: "seen - tier 3 - 100000 sats - 12 facets",
+      role: "rung",
+      status: "sealed",
+    })
   })
 
   test("empty recentPylons with zero online → empty zero-state", () => {

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4071,7 +4071,8 @@ export const publicProductPromisesDocument = () => {
           'https://github.com/OpenAgentsInc/openagents/issues/5737',
           'https://github.com/OpenAgentsInc/openagents/issues/6868',
           'apps/autopilot-desktop/src/shared/chat-world-scene.ts',
-          'apps/autopilot-desktop/src/shared/chat-world-scene.test.ts',
+          'apps/autopilot-desktop/tests/chat-world-scene.test.ts',
+          'apps/autopilot-desktop/src/shared/chat-world-visualization.ts',
           'apps/autopilot-desktop/src/ui/pylon-network-visualization.ts',
           'promise:autopilot.agent_world_scene.v1',
           'promise:autopilot.bitcoin_payment_visualization.v1',
@@ -4080,7 +4081,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.pylon_growth_flag_default_off',
         ],
         verification:
-          'Yellow now covers the live scene wiring behind CHAT_WORLD_SCENE / CHAT_WORLD_PAYMENTS: PublicRecentPylon preserves public cumulativeSettledSats when present, projectChatWorldPylonScene computes each node growth descriptor from that value, liveChatWorldNetworkScene carries the descriptor into PylonNetworkNode, and pylonNetworkVisualizationOptions maps tiers onto the pinned three-effect renderer knobs (larger role geometry, brighter status, and facet/sats detail). Tier 0 remains the 0-sat still crystal. Green still requires an owner decision on default-on and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'Yellow now covers the live scene wiring behind CHAT_WORLD_SCENE / CHAT_WORLD_PAYMENTS: PublicRecentPylon preserves public cumulativeSettledSats when present, projectChatWorldPylonScene computes each node growth descriptor from that value, liveChatWorldNetworkScene carries the descriptor into PylonNetworkNode, and pylonNetworkVisualizationOptions maps tiers onto the pinned three-effect renderer knobs (larger role geometry, brighter status, and facet/sats detail). apps/autopilot-desktop/tests/chat-world-scene.test.ts covers both the 0-sat still crystal and the earned-tier renderer adapter path for #6868. Green still requires an owner decision on default-on and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'Pylon growth visualization is a presentational projection of already-public settled-sats data. It grants no earning, spend, payout, or settlement authority, and a crystal tier never asserts earnings the underlying settlement receipts do not.',
       },


### PR DESCRIPTION
Closes #6868.

## Summary
- Adds executable scene coverage for the live pylon growth path: pylon-stats snapshot -> ChatWorldPylonScene -> live network scene -> pylon network visualization options.
- Verifies tier 0 remains the honest 0-sat still crystal and earned cumulative settled sats survive into scale, brightness, and facet cues.
- Updates the product-promise evidence refs/verification copy to point at the executable scene test without changing the yellow/default-off owner-gated state.

## Verification
- `bun test tests/chat-world-scene.test.ts` from `apps/autopilot-desktop` (37 pass)
- `bun run --cwd workers/api test -- src/product-promises.test.ts` from `apps/openagents.com` (10 pass)
- `bun run --cwd apps/openagents.com check:deploy` (pass)
