### PR TITLE
feat(artanis-web): link active task board proof refs

### DIFF
--- a/apps/openagents.com/apps/web/src/docs-blog-route.test.ts
+++ b/apps/openagents.com/apps/web/src/docs-blog-route.test.ts
@@ -394,8 +394,8 @@ describe('docs and blog routes', () => {
             tokensUsed: 1250,
             timeUsedSeconds: 60,
             remainingTokens: 8750,
-            createdAt: '2026-06-04T00:00:00.000Z',
-            updatedAt: '2026-06-04T00:05:00.000Z',
+            createdAt: '2026-06-29T08:00:00.000Z',
+            updatedAt: '2026-06-29T08:05:00.000Z',
             completedAt: null,
             publicUrl: 'https://openagents.com/api/public/goals/goal_public_1',
           },
@@ -412,7 +412,7 @@ describe('docs and blog routes', () => {
               artifactRefs: ['artifact_public-release-notes'],
               receiptRefs: ['sha256:1234567890abcdef'],
               commitRefs: ['ae7912549301df1a0df78353d47f64196ad6faf6'],
-              createdAt: '2026-06-04T00:01:00.000Z',
+              createdAt: '2026-06-29T08:01:00.000Z',
             },
           ],
         },
@@ -566,7 +566,7 @@ describe('docs and blog routes', () => {
       Scene.expect(
         Scene.text('Make Artanis progress visible safely.'),
       ).toExist(),
-      Scene.expect(Scene.text('Run accepted.')).toExist(),
+      Scene.expect(Scene.text('Run accepted.')).toBeAbsent(),
       // Live fleet-shipping feed replaces the stale status report + admin ticks.
       Scene.expect(Scene.text('Fleet shipping')).toExist(),
       Scene.expect(Scene.text('What the fleet is doing now')).toExist(),

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.story.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.story.test.ts
@@ -307,6 +307,9 @@ describe('public Artanis Pulse panel', () => {
     expect(markup).toContain('Claimed')
     expect(markup).toContain('Verifying')
     expect(markup).toContain('Issue 6656 fleet board work claimed.')
+    expect(markup).toContain(
+      'https://github.com/OpenAgentsInc/openagents/issues/6656',
+    )
     expect(markup).toContain('Issue 6656 public verification queued.')
     expect(markup).toContain('Only public activity rows are shown')
     expect(markup).toContain('artanis-virtual-merge-queue')

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/publicAgent.ts
@@ -7,6 +7,7 @@ import type { Html } from 'foldkit/html'
 import { html } from 'foldkit/html'
 
 import { userFacingCopy } from '../../../display-copy'
+import { publicActivityEventUrls } from '../../../scene/publicActivityTimelineElement'
 import { currentUnixMs, friendlyRelativeTime } from '../../../time-format'
 import * as Ui from '../../../ui'
 import type { Message } from '../message'
@@ -1761,6 +1762,7 @@ const activeTaskBoardEvents = (
 const taskBoardRow = (event: PublicActivityTimelineEvent): Html => {
   const h = html<Message>()
   const actor = event.actorRef ?? event.targetRef ?? event.runRef ?? 'public ref'
+  const proofUrl = publicActivityEventUrls(event)[0]
 
   return h.li(
     [
@@ -1781,9 +1783,25 @@ const taskBoardRow = (event: PublicActivityTimelineEvent): Html => {
         ],
         [
           h.span([Ui.className<Message>('truncate')], [actor]),
-          h.span([Ui.className<Message>('tabular-nums')], [
-            friendlyRelativeTime(event.ts),
-          ]),
+          h.span(
+            [Ui.className<Message>('flex shrink-0 items-center gap-2')],
+            [
+              proofUrl === undefined
+                ? null
+                : h.a(
+                    [
+                      h.Href(proofUrl.href),
+                      Ui.className<Message>(
+                        'text-white/55 underline underline-offset-4 hover:text-[#f1efe8]',
+                      ),
+                    ],
+                    ['Proof'],
+                  ),
+              h.span([Ui.className<Message>('tabular-nums')], [
+                friendlyRelativeTime(event.ts),
+              ]),
+            ],
+          ),
         ],
       ),
     ],

--- a/apps/openagents.com/apps/web/src/scene/publicActivityTimelineElement.ts
+++ b/apps/openagents.com/apps/web/src/scene/publicActivityTimelineElement.ts
@@ -696,6 +696,11 @@ const publicHrefForRef = (
     return safePublicPath(trimmed)
   }
 
+  const githubIssue = /^issue\.public\.github\.(\d+)$/i.exec(trimmed)
+  if (githubIssue !== null) {
+    return `https://github.com/OpenAgentsInc/openagents/issues/${githubIssue[1]}`
+  }
+
   if (/^receipt\.forum\./i.test(trimmed)) {
     return safePublicPath(`/api/forum/receipts/${encodeURIComponent(trimmed)}`)
   }


### PR DESCRIPTION
Closes #6656.

## Summary
- Keeps the rebuilt `/artanis` fleet map and active task board on the current public-agent surface.
- Adds public-safe Proof links to active task rows by reusing the live activity timeline URL resolver.
- Resolves `issue.public.github.N` activity refs to public GitHub issue URLs, so board rows can link directly to the public work item without exposing private payloads.
- Updates current-surface tests to assert stale per-goal activity stays absent and issue #6656 task rows remain inspectable.

## Verification
- `bun run --cwd apps/openagents.com/apps/web test -- src/page/loggedOut/page/publicAgent.story.test.ts src/docs-blog-route.test.ts src/scene/publicActivityTimelineElement.test.ts`
- `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`: `bun run --cwd apps/openagents.com check:deploy`
