### PR TITLE
feat(operator): surface live Pylon runtime progress

### DIFF
--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -64,6 +64,22 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
     ]
   }
 
+  if (sql.includes('FROM pylon_api_events')) {
+    return [
+      {
+        assignment_ref: 'assignment.public.issue_6427',
+        created_at: '2026-06-27T18:40:30.000Z',
+        event_body_json: JSON.stringify({
+          elapsedMs: 630000,
+          lastProgressEvent: 'turn.completed',
+          message: 'Runtime phase: testing.',
+          phase: 'testing',
+          tokensSoFar: 4242,
+        }),
+      },
+    ]
+  }
+
   if (sql.includes('FROM provider_accounts')) {
     return [
       {
@@ -191,7 +207,7 @@ describe('operator fleet status route', () => {
     expect(first.headers.get('x-openagents-cache')).toBe('miss')
     expect(second.headers.get('x-openagents-cache')).toBe('hit')
     expect(log.length).toBeGreaterThan(0)
-    expect(log.length).toBe(9)
+    expect(log.length).toBe(10)
     expect(cachedBody).toEqual(body)
     expect(body).toMatchObject({
       authority: {
@@ -208,10 +224,12 @@ describe('operator fleet status route', () => {
         activeAssignments: [
           {
             assignmentRef: 'assignment.public.issue_6427',
-            elapsedMs: 660000,
-            lastProgressEvent: null,
-            phase: 'running',
-            tokensSoFar: null,
+            elapsedMs: 630000,
+            lastLog: 'Runtime phase: testing.',
+            lastProgressEvent: 'turn.completed',
+            phase: 'testing',
+            progressObservedAt: '2026-06-27T18:40:30.000Z',
+            tokensSoFar: 4242,
           },
         ],
         activeSlots: 3,
@@ -289,6 +307,7 @@ describe('operator fleet status route', () => {
     expect(body.fleet.sourceRefs).toContain('d1:pylon_api_registrations')
     expect(log.some(sql => sql.includes('owner_agent_user_id = ?'))).toBe(true)
     expect(log.some(sql => sql.includes('AND user_id = ?'))).toBe(true)
+    expect(log.some(sql => sql.includes('FROM pylon_api_events') && sql.includes('pylon_ref IN'))).toBe(true)
   })
 
   test('keeps the legacy fleet status path admin-token only', async () => {

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -1,7 +1,7 @@
 import { jsonResponse } from '@openagentsinc/sync-worker'
 
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
-import { parseJsonStringArray } from './json-boundary'
+import { parseJsonRecord, parseJsonStringArray } from './json-boundary'
 import { openAgentsDatabase } from './runtime'
 import { currentIsoTimestamp } from './runtime-primitives'
 
@@ -43,6 +43,12 @@ type AssignmentRow = Readonly<{
   created_at: string
   updated_at: string
   lease_expires_at: string
+}>
+
+type AssignmentProgressRow = Readonly<{
+  assignment_ref: string
+  created_at: string
+  event_body_json: string
 }>
 
 type AlertRow = Readonly<{
@@ -110,6 +116,16 @@ const millisBetween = (startIso: string, endIso: string): number => {
     : 0
 }
 
+const boundedString = (value: unknown, maxLength: number): string | null =>
+  typeof value === 'string' && value.length > 0
+    ? value.slice(0, maxLength)
+    : null
+
+const boundedInteger = (value: unknown): number | null => {
+  const numberValue = typeof value === 'number' ? value : Number.NaN
+  return Number.isFinite(numberValue) ? Math.max(0, Math.trunc(numberValue)) : null
+}
+
 const safeAll = async <T>(
   db: D1Database,
   sql: string,
@@ -162,6 +178,7 @@ const buildFleetStatusSnapshot = async (
   const [
     registrations,
     assignments,
+    assignmentProgressRows,
     providerAccounts,
     latestAlert,
     today,
@@ -192,6 +209,18 @@ const buildFleetStatusSnapshot = async (
           AND state IN ('offered','accepted','running','proof_submitted')
         ORDER BY updated_at DESC
         LIMIT 50`,
+      ...ownerBindings,
+    ),
+    safeAll<AssignmentProgressRow>(
+      db,
+      `SELECT assignment_ref, created_at, event_body_json
+         FROM pylon_api_events
+        WHERE archived_at IS NULL
+          AND event_kind = 'assignment_progress'
+          AND assignment_ref IS NOT NULL
+          ${assignmentOwnerClause}
+        ORDER BY created_at DESC
+        LIMIT 100`,
       ...ownerBindings,
     ),
     safeAll<ProviderAccountRow>(
@@ -284,6 +313,26 @@ const buildFleetStatusSnapshot = async (
   const activeAssignments = assignments.filter(row =>
     row.state === 'accepted' || row.state === 'running' || row.state === 'proof_submitted',
   )
+  const latestProgressByAssignment = new Map<string, {
+    createdAt: string
+    elapsedMs: number | null
+    lastLog: string | null
+    lastProgressEvent: string | null
+    phase: string | null
+    tokensSoFar: number | null
+  }>()
+  for (const row of assignmentProgressRows) {
+    if (latestProgressByAssignment.has(row.assignment_ref)) continue
+    const body = parseJsonRecord(row.event_body_json) ?? {}
+    latestProgressByAssignment.set(row.assignment_ref, {
+      createdAt: row.created_at,
+      elapsedMs: boundedInteger(body.elapsedMs),
+      lastLog: boundedString(body.message, 240),
+      lastProgressEvent: boundedString(body.lastProgressEvent, 120),
+      phase: boundedString(body.phase, 80),
+      tokensSoFar: boundedInteger(body.tokensSoFar),
+    })
+  }
   const accountLedger = providerAccounts.map(row => {
     const cooldownExpiresAt =
       row.cooldown_until !== null && row.cooldown_until > nowIso
@@ -369,24 +418,29 @@ const buildFleetStatusSnapshot = async (
       busySlots,
       queuedSlots,
       spread: fleetAccounts,
-      activeAssignments: assignments.map(row => ({
-        assignmentRef: row.assignment_ref,
-        pylonRef: row.pylon_ref,
-        jobKind: row.job_kind,
-        state: row.state,
-        elapsedMs: millisBetween(row.created_at, nowIso),
-        phase:
+      activeAssignments: assignments.map(row => {
+        const progress = latestProgressByAssignment.get(row.assignment_ref)
+        const fallbackPhase =
           row.state === 'proof_submitted'
             ? 'proof'
             : row.state === 'running' || row.state === 'accepted'
               ? 'running'
-              : 'queued',
-        tokensSoFar: null,
-        lastProgressEvent: null,
-        lastLog: null,
-        updatedAt: row.updated_at,
-        leaseExpiresAt: row.lease_expires_at,
-      })),
+              : 'queued'
+        return {
+          assignmentRef: row.assignment_ref,
+          pylonRef: row.pylon_ref,
+          jobKind: row.job_kind,
+          state: row.state,
+          elapsedMs: progress?.elapsedMs ?? millisBetween(row.created_at, nowIso),
+          phase: progress?.phase ?? fallbackPhase,
+          tokensSoFar: progress?.tokensSoFar ?? null,
+          lastProgressEvent: progress?.lastProgressEvent ?? null,
+          lastLog: progress?.lastLog ?? null,
+          progressObservedAt: progress?.createdAt ?? null,
+          updatedAt: row.updated_at,
+          leaseExpiresAt: row.lease_expires_at,
+        }
+      }),
       inFlightAssignments: assignments.map(row => ({
         assignmentRef: row.assignment_ref,
         pylonRef: row.pylon_ref,
@@ -397,7 +451,11 @@ const buildFleetStatusSnapshot = async (
         leaseExpiresAt: row.lease_expires_at,
       })),
       activeAssignmentCount: activeAssignments.length,
-      sourceRefs: ['d1:pylon_api_registrations', 'd1:pylon_api_assignments'],
+      sourceRefs: [
+        'd1:pylon_api_registrations',
+        'd1:pylon_api_assignments',
+        'd1:pylon_api_events.assignment_progress',
+      ],
     },
     accounts: {
       status: accountLedger,

--- a/apps/openagents.com/workers/api/src/pylon-api.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api.ts
@@ -30,6 +30,21 @@ const PylonRef = NonEmptyTrimmedString.check(
 )
 const PylonDisplayName = NonEmptyTrimmedString.check(S.isMaxLength(120))
 const PylonEventStatus = NonEmptyTrimmedString.check(S.isMaxLength(80))
+const PylonAssignmentRuntimePhase = S.Literals([
+  'diff',
+  'installing',
+  'materializing',
+  'proof',
+  'running',
+  'testing',
+])
+const PublicSafeProgressEvent = NonEmptyTrimmedString.check(
+  S.isMaxLength(120),
+  S.isPattern(/^[A-Za-z0-9][A-Za-z0-9_.:-]*$/),
+)
+const PublicSafeProgressMessage = NonEmptyTrimmedString.check(
+  S.isMaxLength(240),
+)
 const PylonClientVersion = NonEmptyTrimmedString.check(
   S.isMaxLength(80),
   S.isPattern(
@@ -506,9 +521,14 @@ export type PylonApiAssignmentAcceptanceRequest =
 export const PylonApiAssignmentProgressRequest = S.Struct({
   artifactRefs: PublicSafeRefs,
   blockerRefs: PublicSafeRefs,
+  elapsedMs: S.optionalKey(NonNegativeInteger),
+  lastProgressEvent: S.optionalKey(PublicSafeProgressEvent),
+  message: S.optionalKey(PublicSafeProgressMessage),
+  phase: S.optionalKey(PylonAssignmentRuntimePhase),
   progressPercent: S.optionalKey(S.Number),
   progressRefs: PublicSafeRefs,
   status: S.optionalKey(PylonEventStatus),
+  tokensSoFar: S.optionalKey(NonNegativeInteger),
 })
 export type PylonApiAssignmentProgressRequest =
   typeof PylonApiAssignmentProgressRequest.Type

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -128,6 +128,10 @@ export type AssignmentProgress = {
   artifactRefs: string[]
   proofRefs: string[]
   observedAt: string
+  elapsedMs?: number
+  phase?: "runtime_active" | CodexAgentRuntimePhase
+  tokensSoFar?: number
+  lastProgressEvent?: AssignmentRunLifecycleEvent["event"] | string
 }
 
 export type AssignmentCloseout = {
@@ -1816,16 +1820,36 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
           ...(options.codexAgentProbe === undefined ? {} : { codexAgentProbe: options.codexAgentProbe }),
           ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
           onCodexProgress: async (progress) => {
+            const elapsedMs = Math.max(0, Date.now() - runtimeStartedAtMs)
             await emitLifecycleEvent({
               event: "assignment_run.runtime_progress",
               assignmentRef: lease.assignmentRef,
               ...(agentAccount.accountRefHash === undefined ? {} : { accountRefHash: agentAccount.accountRefHash }),
               leaseRef: lease.leaseRef,
               phase: progress.phase,
-              elapsedMs: Math.max(0, Date.now() - runtimeStartedAtMs),
+              elapsedMs,
               ...(progress.tokensSoFar === undefined ? {} : { tokensSoFar: progress.tokensSoFar }),
               ...(progress.lastProgressEvent === undefined ? {} : { lastProgressEvent: progress.lastProgressEvent }),
             })
+            await submitAssignmentProgress(
+              summary,
+              {
+                schema: "openagents.pylon.assignment_progress.v0.3",
+                assignmentRef: lease.assignmentRef,
+                leaseRef: lease.leaseRef,
+                sequence: Math.max(1, Math.floor(elapsedMs / 1000)),
+                status: "running",
+                message: `Runtime phase: ${progress.phase}.`,
+                artifactRefs: [],
+                proofRefs: [],
+                observedAt: (options.now?.() ?? new Date()).toISOString(),
+                elapsedMs,
+                phase: progress.phase,
+                ...(progress.tokensSoFar === undefined ? {} : { tokensSoFar: progress.tokensSoFar }),
+                ...(progress.lastProgressEvent === undefined ? {} : { lastProgressEvent: progress.lastProgressEvent }),
+              },
+              options,
+            ).catch(() => {})
           },
         })) ??
         (await executeRuntimeGate(state, lease, observedAtDate)),

--- a/apps/pylon/tests/assignment.test.ts
+++ b/apps/pylon/tests/assignment.test.ts
@@ -594,6 +594,18 @@ describe("Pylon assignment lease flow", () => {
       })
       expect(typeof runtimeActiveProgress?.elapsedMs).toBe("number")
       expect(runtimeActiveProgress?.elapsedMs).toBeGreaterThanOrEqual(0)
+      const postedRuntimeProgress = fake.requests
+        .filter((request) => request.path.endsWith("/progress"))
+        .map((request) => request.body)
+        .find((body) => body.status === "running" && body.phase === "proof")
+      expect(postedRuntimeProgress).toMatchObject({
+        assignmentRef: codexLease.assignmentRef,
+        leaseRef: codexLease.leaseRef,
+        message: "Runtime phase: proof.",
+        phase: "proof",
+        status: "running",
+      })
+      expect(typeof postedRuntimeProgress.elapsedMs).toBe("number")
 
       const lifecycleJson = JSON.stringify(lifecycleEvents)
       expect(lifecycleJson).not.toContain(home)


### PR DESCRIPTION
Closes #6958.

## Summary
- Post Codex runtime progress snapshots from Pylon no-spend assignment runs through the existing assignment progress endpoint.
- Extend the Pylon assignment progress schema with bounded public-safe phase, elapsed, token, event, and message fields.
- Teach `/api/operator/fleet/state` to read the latest `pylon_api_events.assignment_progress` row per active assignment and return live `phase`, `elapsedMs`, `tokensSoFar`, `lastProgressEvent`, `lastLog`, and `progressObservedAt`.
- Keep owner-scoped state reads filtered by the token owner, including the progress-event query.

## Verification
- `bun test tests/assignment.test.ts` from `apps/pylon` passed: 28 tests.
- `bunx vitest run src/operator-fleet-status-routes.test.ts` from `apps/openagents.com/workers/api` passed: 5 tests.
- `bun run typecheck` from `apps/pylon` passed.
- `bun run typecheck` from `apps/openagents.com/workers/api` passed; it printed existing Effect advisory messages in unrelated files.
- `bun run --cwd apps/openagents.com check:deploy` passed.
- `bunx vitest run src/worker-exact-routes.test.ts src/openagents-openapi-routes.test.ts src/operator-fleet-status-routes.test.ts` from `apps/openagents.com/workers/api` passed: 11 tests.
