### PR TITLE
promise: add clean-Mac proof contract for desktop gates

### DIFF
--- a/apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.test.ts
@@ -1,0 +1,179 @@
+import { Schema as S } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  AutopilotDesktopCleanMacProofInput,
+  AutopilotDesktopCleanMacProofProjection,
+  autopilotDesktopCleanMacProofHasPrivateMaterial,
+  planAutopilotDesktopCleanMacProof,
+} from './autopilot-desktop-clean-mac-proof'
+
+const ciInput = (
+  overrides: Partial<AutopilotDesktopCleanMacProofInput> = {},
+): AutopilotDesktopCleanMacProofInput =>
+  new AutopilotDesktopCleanMacProofInput({
+    desktopRuntimeWiringRefs: [],
+    installerSignatureRefs: [],
+    meteredComputeSessionRefs: [],
+    mode: 'ci_contract_only',
+    nowIso: '2026-06-29T12:00:00.000Z',
+    ownerSignoffRefs: [],
+    packagedComputeReadinessRefs: [],
+    productionPresenceRefs: [],
+    renderedWindowRefs: [],
+    settledBitcoinReceiptRefs: [],
+    ...overrides,
+  })
+
+const liveInput = (
+  overrides: Partial<AutopilotDesktopCleanMacProofInput> = {},
+): AutopilotDesktopCleanMacProofInput =>
+  new AutopilotDesktopCleanMacProofInput({
+    desktopRuntimeWiringRefs: [
+      'runtime.autopilot_desktop.pdf_preview_ingest_browser.live.ref',
+    ],
+    installerSignatureRefs: ['installer.autopilot_desktop.dmg.notarized.sha256.ref'],
+    meteredComputeSessionRefs: [
+      'metering.builtin_compute.from_install.token_usage_event.ref',
+    ],
+    mode: 'owner_clean_mac_from_dmg',
+    nowIso: '2026-06-29T12:00:00.000Z',
+    ownerSignoffRefs: ['promise_transition.owner_signed.autopilot_desktop.ref'],
+    packagedComputeReadinessRefs: [
+      'builtin_compute.packaged_entitlement.secret_ref_only.ready.ref',
+    ],
+    productionPresenceRefs: ['production.pylon_stats.clean_mac_presence.ref'],
+    renderedWindowRefs: ['screenshot.clean_mac.rendered_window.public.ref'],
+    settledBitcoinReceiptRefs: ['receipt.tassadar.settled_bitcoin.public.ref'],
+    ...overrides,
+  })
+
+describe('planAutopilotDesktopCleanMacProof — ci_contract_only', () => {
+  test('produces a schema-valid CI contract projection without live refs', () => {
+    const projection = planAutopilotDesktopCleanMacProof(ciInput())
+
+    expect(
+      S.decodeUnknownSync(AutopilotDesktopCleanMacProofProjection)(
+        projection,
+      ),
+    ).toEqual(projection)
+    expect(projection.status).toBe('ci_contract_ready')
+    expect(projection.cleanMacProofVerified).toBe(false)
+    expect(projection.blockerRefs).toHaveLength(0)
+    expect(projection.proofBundleRefs).toHaveLength(0)
+  })
+
+  test('keeps every step present and non-blocked in CI mode', () => {
+    const projection = planAutopilotDesktopCleanMacProof(ciInput())
+    expect(projection.steps.map(step => step.kind)).toEqual([
+      'installer_signed',
+      'rendered_window_captured',
+      'production_presence_observed',
+      'desktop_runtime_wiring_observed',
+      'packaged_compute_ready',
+      'metered_compute_session_recorded',
+      'settled_bitcoin_receipt_captured',
+      'owner_signoff_recorded',
+    ])
+    for (const step of projection.steps) {
+      expect(step.state).toBe('planned_no_live_sessions')
+    }
+  })
+})
+
+describe('planAutopilotDesktopCleanMacProof — owner_clean_mac_from_dmg', () => {
+  test('verifies the live clean-Mac proof when all public refs exist', () => {
+    const projection = planAutopilotDesktopCleanMacProof(liveInput())
+
+    expect(projection.status).toBe('clean_mac_proof_verified')
+    expect(projection.cleanMacProofVerified).toBe(true)
+    expect(projection.blockerRefs).toHaveLength(0)
+    for (const step of projection.steps) {
+      expect(step.state).toBe('passed')
+    }
+  })
+
+  test('keeps desktop GUI and packaged compute refs separated', () => {
+    const projection = planAutopilotDesktopCleanMacProof(liveInput())
+
+    expect(projection.desktopGuiProofRefs).toContain(
+      'screenshot.clean_mac.rendered_window.public.ref',
+    )
+    expect(projection.desktopGuiProofRefs).toContain(
+      'production.pylon_stats.clean_mac_presence.ref',
+    )
+    expect(projection.desktopGuiProofRefs).not.toContain(
+      'metering.builtin_compute.from_install.token_usage_event.ref',
+    )
+
+    expect(projection.packagedComputeProofRefs).toContain(
+      'builtin_compute.packaged_entitlement.secret_ref_only.ready.ref',
+    )
+    expect(projection.packagedComputeProofRefs).toContain(
+      'metering.builtin_compute.from_install.token_usage_event.ref',
+    )
+    expect(projection.packagedComputeProofRefs).not.toContain(
+      'screenshot.clean_mac.rendered_window.public.ref',
+    )
+  })
+
+  test('blocks when the clean-Mac rendered-window proof is missing', () => {
+    const projection = planAutopilotDesktopCleanMacProof(
+      liveInput({ renderedWindowRefs: [] }),
+    )
+
+    expect(projection.status).toBe('blocked')
+    expect(projection.blockerRefs).toContain(
+      'blocker.autopilot_desktop_clean_mac_proof.rendered_window_missing',
+    )
+    expect(
+      projection.steps.find(step => step.kind === 'rendered_window_captured')
+        ?.state,
+    ).toBe('blocked')
+  })
+
+  test('blocks when packaged compute readiness is missing', () => {
+    const projection = planAutopilotDesktopCleanMacProof(
+      liveInput({ packagedComputeReadinessRefs: [] }),
+    )
+
+    expect(projection.status).toBe('blocked')
+    expect(projection.blockerRefs).toContain(
+      'blocker.autopilot_desktop_clean_mac_proof.packaged_compute_missing',
+    )
+  })
+
+  test('blocks when owner signoff is missing', () => {
+    const projection = planAutopilotDesktopCleanMacProof(
+      liveInput({ ownerSignoffRefs: [] }),
+    )
+
+    expect(projection.status).toBe('blocked')
+    expect(projection.blockerRefs).toContain(
+      'blocker.autopilot_desktop_clean_mac_proof.owner_signoff_missing',
+    )
+  })
+})
+
+describe('autopilotDesktopCleanMacProofHasPrivateMaterial', () => {
+  test('allows public-safe refs', () => {
+    expect(
+      autopilotDesktopCleanMacProofHasPrivateMaterial({
+        ref: 'receipt.public.clean_mac.ref',
+      }),
+    ).toBe(false)
+  })
+
+  test('rejects raw local paths and bearer material', () => {
+    expect(
+      autopilotDesktopCleanMacProofHasPrivateMaterial({
+        log: '/Users/operator/Library/Application Support/OpenAgents/auth.json',
+      }),
+    ).toBe(true)
+    expect(
+      autopilotDesktopCleanMacProofHasPrivateMaterial({
+        authorization: 'Bearer eyJhbGciOiJIUzI1NiJ9',
+      }),
+    ).toBe(true)
+  })
+})

--- a/apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.ts
@@ -1,0 +1,344 @@
+// Autopilot Desktop clean-Mac proof fixture.
+//
+// Models the owner-run from-DMG proof needed before the desktop GUI and
+// built-in compute promises can move beyond yellow. CI validates the proof
+// contract only; live mode requires public-safe refs from a signed installer
+// run on a clean Mac.
+
+import { Schema as S } from 'effect'
+
+export const AUTOPILOT_DESKTOP_CLEAN_MAC_PROOF_SCHEMA_VERSION =
+  'openagents.autopilot_desktop_clean_mac_proof.v1' as const
+
+export const AutopilotDesktopCleanMacProofMode = S.Literals([
+  'ci_contract_only',
+  'owner_clean_mac_from_dmg',
+])
+export type AutopilotDesktopCleanMacProofMode =
+  typeof AutopilotDesktopCleanMacProofMode.Type
+
+export const AutopilotDesktopCleanMacProofStepKind = S.Literals([
+  'installer_signed',
+  'rendered_window_captured',
+  'production_presence_observed',
+  'desktop_runtime_wiring_observed',
+  'packaged_compute_ready',
+  'metered_compute_session_recorded',
+  'settled_bitcoin_receipt_captured',
+  'owner_signoff_recorded',
+])
+export type AutopilotDesktopCleanMacProofStepKind =
+  typeof AutopilotDesktopCleanMacProofStepKind.Type
+
+export const AutopilotDesktopCleanMacProofStepState = S.Literals([
+  'blocked',
+  'passed',
+  'planned_no_live_sessions',
+])
+export type AutopilotDesktopCleanMacProofStepState =
+  typeof AutopilotDesktopCleanMacProofStepState.Type
+
+export const AutopilotDesktopCleanMacProofStatus = S.Literals([
+  'blocked',
+  'ci_contract_ready',
+  'clean_mac_proof_verified',
+])
+export type AutopilotDesktopCleanMacProofStatus =
+  typeof AutopilotDesktopCleanMacProofStatus.Type
+
+export class AutopilotDesktopCleanMacProofInput extends S.Class<AutopilotDesktopCleanMacProofInput>(
+  'AutopilotDesktopCleanMacProofInput',
+)({
+  desktopRuntimeWiringRefs: S.Array(S.String),
+  installerSignatureRefs: S.Array(S.String),
+  meteredComputeSessionRefs: S.Array(S.String),
+  mode: AutopilotDesktopCleanMacProofMode,
+  nowIso: S.String,
+  ownerSignoffRefs: S.Array(S.String),
+  packagedComputeReadinessRefs: S.Array(S.String),
+  productionPresenceRefs: S.Array(S.String),
+  renderedWindowRefs: S.Array(S.String),
+  settledBitcoinReceiptRefs: S.Array(S.String),
+}) {}
+
+export class AutopilotDesktopCleanMacProofStep extends S.Class<AutopilotDesktopCleanMacProofStep>(
+  'AutopilotDesktopCleanMacProofStep',
+)({
+  blockerRefs: S.Array(S.String),
+  evidenceRefs: S.Array(S.String),
+  guardRefs: S.Array(S.String),
+  kind: AutopilotDesktopCleanMacProofStepKind,
+  state: AutopilotDesktopCleanMacProofStepState,
+}) {}
+
+export class AutopilotDesktopCleanMacProofProjection extends S.Class<AutopilotDesktopCleanMacProofProjection>(
+  'AutopilotDesktopCleanMacProofProjection',
+)({
+  blockerRefs: S.Array(S.String),
+  cleanMacProofVerified: S.Boolean,
+  desktopGuiProofRefs: S.Array(S.String),
+  desktopRuntimeWiringRefs: S.Array(S.String),
+  mode: AutopilotDesktopCleanMacProofMode,
+  packagedComputeProofRefs: S.Array(S.String),
+  proofBundleRefs: S.Array(S.String),
+  redactionScanPassed: S.Boolean,
+  schemaVersion: S.Literal(
+    AUTOPILOT_DESKTOP_CLEAN_MAC_PROOF_SCHEMA_VERSION,
+  ),
+  status: AutopilotDesktopCleanMacProofStatus,
+  steps: S.Array(AutopilotDesktopCleanMacProofStep),
+}) {}
+
+export class AutopilotDesktopCleanMacProofUnsafe extends S.TaggedErrorClass<AutopilotDesktopCleanMacProofUnsafe>()(
+  'AutopilotDesktopCleanMacProofUnsafe',
+  { reason: S.String },
+) {}
+
+const requiredStepKinds: ReadonlyArray<AutopilotDesktopCleanMacProofStepKind> =
+  [
+    'installer_signed',
+    'rendered_window_captured',
+    'production_presence_observed',
+    'desktop_runtime_wiring_observed',
+    'packaged_compute_ready',
+    'metered_compute_session_recorded',
+    'settled_bitcoin_receipt_captured',
+    'owner_signoff_recorded',
+  ]
+
+const unsafeMaterialPattern =
+  /(@|AIza[0-9A-Za-z_-]{10,}|api[_-]?key|bearer|raw[_-]?key|secret[^_-]|sk-[a-z0-9]|provider[_-]?(key|credential)|token[^_-]?(=|:)|\/Users\/|\/home\/)/i
+
+const hasRefs = (refs: ReadonlyArray<string>): boolean =>
+  refs.some(ref => ref.trim() !== '')
+
+const uniqueRefs = (refs: ReadonlyArray<string>): ReadonlyArray<string> =>
+  [...new Set(refs.map(ref => ref.trim()).filter(ref => ref !== ''))].sort()
+
+const blockerIfMissing = (
+  condition: boolean,
+  ref: string,
+): ReadonlyArray<string> => (condition ? [] : [ref])
+
+const stepState = (
+  mode: AutopilotDesktopCleanMacProofMode,
+  blockers: ReadonlyArray<string>,
+): AutopilotDesktopCleanMacProofStepState => {
+  if (blockers.length > 0) return 'blocked'
+  if (mode === 'ci_contract_only') return 'planned_no_live_sessions'
+  return 'passed'
+}
+
+const stepFor = (
+  kind: AutopilotDesktopCleanMacProofStepKind,
+  evidenceRefs: ReadonlyArray<string>,
+  guardRefs: ReadonlyArray<string>,
+  blockerRefs: ReadonlyArray<string>,
+  mode: AutopilotDesktopCleanMacProofMode,
+): AutopilotDesktopCleanMacProofStep =>
+  new AutopilotDesktopCleanMacProofStep({
+    blockerRefs: uniqueRefs(blockerRefs),
+    evidenceRefs: uniqueRefs(evidenceRefs),
+    guardRefs: uniqueRefs(guardRefs),
+    kind,
+    state: stepState(mode, blockerRefs),
+  })
+
+const commonBlockerRefs = (
+  input: AutopilotDesktopCleanMacProofInput,
+): ReadonlyArray<string> => {
+  if (input.mode === 'ci_contract_only') return []
+
+  return [
+    ...blockerIfMissing(
+      hasRefs(input.installerSignatureRefs),
+      'blocker.autopilot_desktop_clean_mac_proof.installer_signature_missing',
+    ),
+    ...blockerIfMissing(
+      hasRefs(input.renderedWindowRefs),
+      'blocker.autopilot_desktop_clean_mac_proof.rendered_window_missing',
+    ),
+    ...blockerIfMissing(
+      hasRefs(input.productionPresenceRefs),
+      'blocker.autopilot_desktop_clean_mac_proof.production_presence_missing',
+    ),
+    ...blockerIfMissing(
+      hasRefs(input.desktopRuntimeWiringRefs),
+      'blocker.autopilot_desktop_clean_mac_proof.runtime_wiring_missing',
+    ),
+    ...blockerIfMissing(
+      hasRefs(input.packagedComputeReadinessRefs),
+      'blocker.autopilot_desktop_clean_mac_proof.packaged_compute_missing',
+    ),
+    ...blockerIfMissing(
+      hasRefs(input.meteredComputeSessionRefs),
+      'blocker.autopilot_desktop_clean_mac_proof.metered_compute_session_missing',
+    ),
+    ...blockerIfMissing(
+      hasRefs(input.settledBitcoinReceiptRefs),
+      'blocker.autopilot_desktop_clean_mac_proof.settled_bitcoin_receipt_missing',
+    ),
+    ...blockerIfMissing(
+      hasRefs(input.ownerSignoffRefs),
+      'blocker.autopilot_desktop_clean_mac_proof.owner_signoff_missing',
+    ),
+  ]
+}
+
+const statusFor = (
+  input: AutopilotDesktopCleanMacProofInput,
+  blockers: ReadonlyArray<string>,
+): AutopilotDesktopCleanMacProofStatus => {
+  if (blockers.length > 0) return 'blocked'
+  if (input.mode === 'owner_clean_mac_from_dmg') {
+    return 'clean_mac_proof_verified'
+  }
+  return 'ci_contract_ready'
+}
+
+export const autopilotDesktopCleanMacProofHasPrivateMaterial = (
+  value: unknown,
+): boolean => unsafeMaterialPattern.test(JSON.stringify(value))
+
+export const planAutopilotDesktopCleanMacProof = (
+  input: AutopilotDesktopCleanMacProofInput,
+): AutopilotDesktopCleanMacProofProjection => {
+  const blockerRefs = uniqueRefs(commonBlockerRefs(input))
+  const isLive = input.mode === 'owner_clean_mac_from_dmg'
+
+  const steps = [
+    stepFor(
+      'installer_signed',
+      input.installerSignatureRefs,
+      ['guard.autopilot_desktop_clean_mac_proof.notarized_dmg_required'],
+      blockerIfMissing(
+        !isLive || hasRefs(input.installerSignatureRefs),
+        'blocker.autopilot_desktop_clean_mac_proof.installer_signature_missing',
+      ),
+      input.mode,
+    ),
+    stepFor(
+      'rendered_window_captured',
+      input.renderedWindowRefs,
+      ['guard.autopilot_desktop_clean_mac_proof.clean_mac_window_screenshot'],
+      blockerIfMissing(
+        !isLive || hasRefs(input.renderedWindowRefs),
+        'blocker.autopilot_desktop_clean_mac_proof.rendered_window_missing',
+      ),
+      input.mode,
+    ),
+    stepFor(
+      'production_presence_observed',
+      input.productionPresenceRefs,
+      ['guard.autopilot_desktop_clean_mac_proof.production_pylon_stats_ref'],
+      blockerIfMissing(
+        !isLive || hasRefs(input.productionPresenceRefs),
+        'blocker.autopilot_desktop_clean_mac_proof.production_presence_missing',
+      ),
+      input.mode,
+    ),
+    stepFor(
+      'desktop_runtime_wiring_observed',
+      input.desktopRuntimeWiringRefs,
+      ['guard.autopilot_desktop_clean_mac_proof.live_runtime_refs_required'],
+      blockerIfMissing(
+        !isLive || hasRefs(input.desktopRuntimeWiringRefs),
+        'blocker.autopilot_desktop_clean_mac_proof.runtime_wiring_missing',
+      ),
+      input.mode,
+    ),
+    stepFor(
+      'packaged_compute_ready',
+      input.packagedComputeReadinessRefs,
+      ['guard.autopilot_desktop_clean_mac_proof.packaged_compute_secret_ref_only'],
+      blockerIfMissing(
+        !isLive || hasRefs(input.packagedComputeReadinessRefs),
+        'blocker.autopilot_desktop_clean_mac_proof.packaged_compute_missing',
+      ),
+      input.mode,
+    ),
+    stepFor(
+      'metered_compute_session_recorded',
+      input.meteredComputeSessionRefs,
+      ['guard.autopilot_desktop_clean_mac_proof.metering_ledger_ref_required'],
+      blockerIfMissing(
+        !isLive || hasRefs(input.meteredComputeSessionRefs),
+        'blocker.autopilot_desktop_clean_mac_proof.metered_compute_session_missing',
+      ),
+      input.mode,
+    ),
+    stepFor(
+      'settled_bitcoin_receipt_captured',
+      input.settledBitcoinReceiptRefs,
+      ['guard.autopilot_desktop_clean_mac_proof.settled_receipt_required'],
+      blockerIfMissing(
+        !isLive || hasRefs(input.settledBitcoinReceiptRefs),
+        'blocker.autopilot_desktop_clean_mac_proof.settled_bitcoin_receipt_missing',
+      ),
+      input.mode,
+    ),
+    stepFor(
+      'owner_signoff_recorded',
+      input.ownerSignoffRefs,
+      ['guard.autopilot_desktop_clean_mac_proof.promise_transition_owner_signed'],
+      blockerIfMissing(
+        !isLive || hasRefs(input.ownerSignoffRefs),
+        'blocker.autopilot_desktop_clean_mac_proof.owner_signoff_missing',
+      ),
+      input.mode,
+    ),
+  ]
+
+  const desktopGuiProofRefs = uniqueRefs([
+    ...input.installerSignatureRefs,
+    ...input.renderedWindowRefs,
+    ...input.productionPresenceRefs,
+    ...input.desktopRuntimeWiringRefs,
+    ...input.settledBitcoinReceiptRefs,
+    ...input.ownerSignoffRefs,
+  ])
+
+  const packagedComputeProofRefs = uniqueRefs([
+    ...input.installerSignatureRefs,
+    ...input.packagedComputeReadinessRefs,
+    ...input.meteredComputeSessionRefs,
+    ...input.ownerSignoffRefs,
+  ])
+
+  const projection = new AutopilotDesktopCleanMacProofProjection({
+    blockerRefs,
+    cleanMacProofVerified: isLive && blockerRefs.length === 0,
+    desktopGuiProofRefs,
+    desktopRuntimeWiringRefs: uniqueRefs(input.desktopRuntimeWiringRefs),
+    mode: input.mode,
+    packagedComputeProofRefs,
+    proofBundleRefs: uniqueRefs([
+      ...desktopGuiProofRefs,
+      ...packagedComputeProofRefs,
+    ]),
+    redactionScanPassed: true,
+    schemaVersion: AUTOPILOT_DESKTOP_CLEAN_MAC_PROOF_SCHEMA_VERSION,
+    status: statusFor(input, blockerRefs),
+    steps,
+  })
+
+  if (
+    requiredStepKinds.some(
+      kind => !projection.steps.some(step => step.kind === kind),
+    )
+  ) {
+    throw new AutopilotDesktopCleanMacProofUnsafe({
+      reason:
+        'Autopilot Desktop clean-Mac proof projection is missing a required step.',
+    })
+  }
+
+  if (autopilotDesktopCleanMacProofHasPrivateMaterial(projection)) {
+    throw new AutopilotDesktopCleanMacProofUnsafe({
+      reason:
+        'Autopilot Desktop clean-Mac proof projection contains private material.',
+    })
+  }
+
+  return projection
+}

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -440,9 +440,9 @@ describe('public product promises document', () => {
       /latest stays 0\.2\.5|only published, installable Pylon|release candidate, not stable 0\.3\.0|Pylon v1\.0 is present in the monorepo as a release candidate/i,
     )
     expect(currentCopy).toContain('Pylon v1.0 has a stable source cut')
-    expect(currentCopy).toContain('Registry 2026-06-29.2')
+    expect(currentCopy).toContain('Registry 2026-06-29.3')
     expect(currentCopy).toContain('flips NO promise state')
-    expect(currentCopy).toContain('Khala Desktop now carries source-level')
+    expect(currentCopy).toContain('typed clean-Mac from-DMG proof contract')
     expect(currentCopy).toContain('maxStalenessSeconds:0')
     const codexSuccessorPromise = decoded.promises.find(
       promise => promise.promiseId === 'autopilot.codex_probe_pylon_successor.v1',

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -65,6 +65,8 @@ const sourceRefs = [
   'apps/pylon/scripts/codex-supervisor/replenishment.test.sh',
   'apps/openagents.com/workers/api/src/inference/model-router.ts',
   'apps/openagents.com/workers/api/src/inference/model-router.test.ts',
+  'apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.ts',
+  'apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.test.ts',
   'docs/apple-fm/2026-06-29-electrobun-apple-fm-swift-sidecar-plan.md',
   'clients/khala-desktop/src/bun/apple-fm-sidecar.ts',
   'clients/khala-desktop/src/shared/apple-fm-packaging.ts',
@@ -261,6 +263,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-28.3 implements #6891 for models.tassadar_percepta_executor.v1 and flips NO promise state. Pylon v1.0 now has a deterministic bounded CPU computation-transform fixture in apps/pylon/src/tassadar-cpu-transform-training.ts that runs one CPU-only optimization step, self-verifies loss improvement, emits receipt.models.tassadar_percepta_executor.cpu_transform_training.cpu_transform_fixture_v1, and keeps realBitcoinMoved:false / settlementState:not_settled. GET /api/public/models/tassadar-percepta-executor/cpu-transform-training-receipts now projects that public-safe receipt alongside the architecture and Artanis distillation dataset inputs, so the old pylon_v03_cpu_transform_training_receipts_missing blocker is replaced by blocker.product_promises.tassadar_cpu_transform_real_settlement_missing and blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing. The promise STAYS planned: this is one fixture-scale receipt, not a trained model, not a paid earning path, not model promotion, and not a green transition; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.1 implements #6848 for payments.accepted_outcome_economics.v1 and flips NO promise state. The accepted-outcome economics spine now has a dereferenceable contributor accrual bundle at GET /api/public/payments/contributor-accrual-bundle?economicsId=... plus the settlement bundle at GET /api/public/accepted-outcome/settlement/{economicsId}; together they compose a gross-margin receipt, contributor accrual ledger entries, and an eight-state settlement machine from one stored accepted-outcome economics row. Tests prove the ledger and receipt share the same economicsId, reconcile gross margin exactly, reconcile pending_payout to the distributable ledger pool, keep public projections free of internal cents/raw payment material, and surface missing contributor provenance honestly. The old source-level blockers contributor_ledger_missing and gross_margin_receipts_missing are replaced by real_accepted_outcome_receipt_missing and owner_signed_green_transition_missing. The promise STAYS red because source/fixture receipt machinery is not a real accepted outcome carried through a money-moving settlement path, and any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.2 is a current-main refresh after #6997/#6999/#7001/#7002/#7006 and flips NO promise state. The terminal-agent current-state audit and Codex tool-layer study are now cited as evidence for the Codex/Probe/Pylon runtime direction: current production coding delegation is still Pylon plus external agent SDK lanes and OpenAgents-native terminal tools remain a consolidation task, not a new green claim. The codex-supervisor LOCKOUT replenishment helper can create or reuse three bounded standing issues so owner-capacity supervisors do not idle indefinitely, but it creates no paid labor, payout, settlement, or broad availability claim. The inference router now has GLM own-capacity failover alerting and public-safe fallback telemetry for repeated no-headroom saturation, but the paid gateway still stays red until a dereferenceable paid receipt exists. Khala Desktop now carries source-level Electrobun Apple FM sidecar packaging/readiness plus redaction tests, but Apple FM local mode remains yellow until a signed/notarized from-install smoke with helper supervision exists. The Khala model-mix promise remains live-at-read with maxStalenessSeconds:0; the stale 2-second cache wording is not applied.',
+        'Registry 2026-06-29.3 implements #7023 as a typed clean-Mac from-DMG proof contract and flips NO promise state. apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.ts now projects the owner-run signed/notarized DMG gate into explicit public-safe steps: installer signature, rendered clean-Mac window, production pylon-stats presence, live desktop runtime wiring, packaged compute readiness, metered from-install compute session, settled Bitcoin receipt, and owner signoff. Tests prove CI contract mode needs no live refs, live mode blocks on missing evidence, desktop GUI refs stay separated from packaged-compute refs, and private paths/bearer material are rejected. The desktop GUI and built-in compute promises STAY yellow because the actual owner-run clean-Mac refs, live runtime observations, metered compute rows, settled receipt, and transition signoff are still not present.',
       ],
     },
     promises: [
@@ -2836,6 +2839,8 @@ export const publicProductPromisesDocument = () => {
           'apps/autopilot-desktop/scripts/auto-onboarding-e2e-smoke.ts',
           'docs/launch/2026-06-18-autopilot-desktop-availability-audit.md',
           'docs/launch/2026-06-18-autopilot-desktop-ao6-from-dmg-runbook.md',
+          'apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.ts',
+          'apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.test.ts',
           'docs/autopilot-coder/2026-06-13-autopilot-desktop-app-audit.md',
           'docs/autopilot-coder/2026-06-13-autopilot-desktop-reality-vs-claim-status.md',
           'docs/autopilot-coder/2026-06-14-cloud-desktop-mobile-coding-sessions-full-flow-audit.md',
@@ -3235,6 +3240,8 @@ export const publicProductPromisesDocument = () => {
           'apps/autopilot-desktop/tests/cl-53-foldkit.test.ts',
           'apps/openagents.com/workers/api/src/builtin-compute-agent-metering-smoke.ts',
           'apps/openagents.com/workers/api/src/builtin-compute-agent-metering-smoke.test.ts',
+          'apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.ts',
+          'apps/openagents.com/workers/api/src/autopilot-desktop-clean-mac-proof.test.ts',
           'docs/launch/2026-06-19-coding-agent-live-verification.md',
         ],
         blockerRefs: [

--- a/docs/promises/registry.md
+++ b/docs/promises/registry.md
@@ -1,5 +1,13 @@
 # Promise Registry
 
+> Registry `2026-06-29.3` implements #7023 as a typed clean-Mac from-DMG proof
+> contract and flips NO promise state. The new proof planner requires
+> public-safe refs for a signed/notarized DMG, rendered clean-Mac window,
+> production pylon-stats presence, live desktop runtime wiring, packaged
+> compute readiness, metered from-install compute, settled Bitcoin receipt, and
+> owner signoff before either the desktop GUI or built-in compute claims can
+> advance.
+>
 > Registry `2026-06-29.2` is a current-main refresh after #6997, #6999,
 > #7001, #7002, and #7006 and flips NO promise state. It records the
 > terminal-agent current-state audit and Codex tool-layer study as evidence for
@@ -66,9 +74,9 @@
 > Current machine-readable source of truth: `/api/public/product-promises` is
 > generated from
 > [`product-promises.ts`](../../apps/openagents.com/workers/api/src/product-promises.ts),
-> which currently advertises registry `2026-06-29.2` with
+> which currently advertises registry `2026-06-29.3` with
 > `lastUpdated: "2026-06-29"`. This narrative document records the same
-> top-line 2026-06-29.2 promise decisions above, plus historical reconciliation
+> top-line 2026-06-29.3 promise decisions above, plus historical reconciliation
 > context below; when in doubt, agents and reviewers should defer to the
 > machine-readable registry and include its version in mismatch reports.
 >
@@ -76,7 +84,7 @@
 > Tassadar CPU-transform, referral, small-model proxy, WASM plugin, Verse scene,
 > native email, marketplace, metrics, terminal-agent audit, supervisor
 > replenishment, GLM failover, Apple FM sidecar, and operator-safety merges were
-> checked against the current `2026-06-29.2` registry header. This pass records
+> checked against the current `2026-06-29.3` registry header. This pass records
 > no additional promise state flips and no new green claims beyond the already
 > source-recorded scoped transitions; red/planned/yellow records keep their
 > owner-signed, receipt-first green gates.


### PR DESCRIPTION
## Summary

- Add a typed Autopilot Desktop clean-Mac from-DMG proof planner for #7023.
- Keep desktop GUI and packaged built-in compute proof refs separated while requiring owner-run public-safe evidence before either promise can advance.
- Bump the product-promise registry to 2026-06-29.3 and cite the new proof contract without flipping promise state.

Closes #7023

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/autopilot-desktop-clean-mac-proof.test.ts src/builtin-compute-agent-metering-smoke.test.ts src/product-promises.test.ts` (38 pass)
- `bun run --cwd apps/openagents.com check:deploy` (pass)
