### PR TITLE
Implement batch inference result retrieval

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -26,8 +26,6 @@ import { Exit } from 'effect'
 import { WorkerEnvironment } from 'effect-cf'
 
 import { handleAcceptedOutcomesPerKwhApi } from './accepted-outcomes-per-kwh-routes'
-import { EnergyFlexibleLoadProofEndpoint } from './energy-flexible-load-proof'
-import { handleEnergyFlexibleLoadProofApi } from './energy-flexible-load-proof-routes'
 import { AdjutantEnrichmentQueueMessage } from './adjutant-enrichment-jobs'
 import type { AdjutantTaskPacketRefValidationInput } from './adjutant-task-packets'
 import { recordAdjutantUsageReceipt } from './adjutant-usage-receipts'
@@ -81,11 +79,11 @@ import {
   runArtanisAdminTickScheduled,
   runArtanisCloseoutVerifierScheduled,
 } from './artanis-administrator-tick'
-import { runArtanisFleetOverseerTickScheduled } from './artanis-fleet-overseer-tick'
 import {
   boundedDistillationDatasetLimit,
   readArtanisDistillationDatasetReceipt,
 } from './artanis-distillation-dataset-receipt'
+import { runArtanisFleetOverseerTickScheduled } from './artanis-fleet-overseer-tick'
 import { deliverArtanisForumPublicationIntent } from './artanis-forum-delivery'
 import { ArtanisForumPublicationIntentRecord } from './artanis-forum-publication'
 import { exampleArtanisForumPublicationQueue } from './artanis-forum-publication'
@@ -102,8 +100,8 @@ import {
 } from './artanis-labor-receipt-routes'
 import { makeD1ArtanisLaborUnattendedReceiptStore } from './artanis-labor-receipt-store'
 import { ArtanisMindSmokeSystem, artanisMindComplete } from './artanis-mind'
-import { makeOperatorArtanisChatRoutes } from './artanis-operator-chat-routes'
 import { loadArtanisNetworkStatsFromLedger } from './artanis-network-stats-d1'
+import { makeOperatorArtanisChatRoutes } from './artanis-operator-chat-routes'
 import { makeOperatorArtanisConsoleRoutes } from './artanis-operator-console-routes'
 import { makeOperatorArtanisDashboardRoutes } from './artanis-operator-dashboard-routes'
 import {
@@ -112,25 +110,25 @@ import {
   readEffectiveArtanisPylonDispatchApprovalForOwner,
 } from './artanis-operator-dispatch-execution'
 import { makeArtanisForumUpdateWriter } from './artanis-operator-forum-update'
-import {
-  isOpenAgentsOwnerAgentOpenAuthUserId,
-  ownerAgentHasStandingApprovalForRiskyAction,
-} from './artanis-owner-authority'
+import { makeArtanisGlmFleetStatusLoader } from './artanis-operator-glm-fleet-status'
+import { makeArtanisKhalaFeedbackReader } from './artanis-operator-khala-feedback'
 import {
   makeArtanisPylonAssignmentsLister,
   makeArtanisPylonJobStatusReader,
 } from './artanis-operator-pylon-job-status'
-import { makeArtanisGlmFleetStatusLoader } from './artanis-operator-glm-fleet-status'
-import { makeArtanisKhalaFeedbackReader } from './artanis-operator-khala-feedback'
-import { makeArtanisTraceReviewLoader } from './artanis-operator-trace-review'
 import {
   makeArtanisGithubIssueOpener,
   makeArtanisOperatorTools,
 } from './artanis-operator-tools'
+import { makeArtanisTraceReviewLoader } from './artanis-operator-trace-review'
 import {
-  makeArtanisUnsupportedRequestsReader,
   makeArtanisUnsupportedRequestWriter,
+  makeArtanisUnsupportedRequestsReader,
 } from './artanis-operator-unsupported-requests'
+import {
+  isOpenAgentsOwnerAgentOpenAuthUserId,
+  ownerAgentHasStandingApprovalForRiskyAction,
+} from './artanis-owner-authority'
 import { saveArtanisForumPublicationIntent } from './artanis-persistence'
 import { handlePublicArtanisReportApi } from './artanis-public-report-routes'
 import { runArtanisComposerScheduled } from './artanis-reply-composer'
@@ -205,6 +203,10 @@ import {
   verifyAutopilotL402PaymentProofFromBuyerLedger,
 } from './autopilot-work-routes'
 import {
+  recordBackendIncidentEvent,
+  routePatternFromRequest,
+} from './backend-incident-events'
+import {
   type BillingSummary,
   markOutOfCreditsNotificationFailed,
   markOutOfCreditsNotificationSent,
@@ -216,10 +218,6 @@ import {
   withBillingCreditPackages,
 } from './billing'
 import { makeBillingApiHandlers } from './billing-routes'
-import {
-  recordBackendIncidentEvent,
-  routePatternFromRequest,
-} from './backend-incident-events'
 import { OpenAgentsDatabase, ThreadFileArtifacts } from './bindings'
 import { makeBlueprintProbeContributionRoutes } from './blueprint-probe-contribution-routes'
 import { makeBlueprintRoutes } from './blueprint-routes'
@@ -250,8 +248,8 @@ import { makeCheckoutPageRoutes } from './checkout-page-routes'
 // OA_CLOUD_CONTROL_URL/TOKEN are configured. The promise STAYS red until a real
 // desktop-originated GCE run produces artifact + receipt evidence.
 import {
-  isCloudGceProvisioningArmed,
   isCloudCodingSessionsEnabled,
+  isCloudGceProvisioningArmed,
   makeCloudControlCloudCodingAdapter,
   routeCloudCodingSessionRequest as routeCloudCodingSessionRequestImpl,
 } from './cloud/cloud-coding-session-routes'
@@ -335,8 +333,19 @@ import {
   isEmailSequenceSendEnabled,
   makeCloudflareEmailSequenceSender,
 } from './email-sequence-send-service'
+import { EnergyFlexibleLoadProofEndpoint } from './energy-flexible-load-proof'
+import { handleEnergyFlexibleLoadProofApi } from './energy-flexible-load-proof-routes'
 import { makeFirmupBitcoinSettlementRoutes } from './firmup-bitcoin-settlement-routes'
 import { readFirmupSettleableEscrow } from './firmup-settleable-escrow'
+import {
+  authorizeForgeControlPlaneBearer,
+  makeForgeControlPlaneRoutes,
+} from './forge-control-plane-routes'
+import { makeD1ForgeCoordinationStore } from './forge-coordination-store'
+import { makeD1ForgeGitCanonicalStore } from './forge-git-canonical-store'
+import { makeForgeGitIntakeRoutes } from './forge-git-intake-routes'
+import { makeD1R2ForgeGitPackfileArchiveStore } from './forge-git-packfile-archive-store'
+import { makeD1ForgeTenantGitAuthStore } from './forge-tenant-git-auth-store'
 import { makeForumRoutes } from './forum-routes'
 import { forumWorkRequestRelayPublisherForEnv } from './forum-work-request-live-publisher'
 import { archiveStaleDirectTipRecoveries } from './forum/paid-actions'
@@ -410,12 +419,19 @@ import {
   BatchJobQueueMessage,
   executeBatchJob,
 } from './inference/batch-job-consumer'
+import { makeR2BatchJobResultStore } from './inference/batch-job-results'
 import {
   handleBatchJobReceiptRead,
+  handleBatchJobResultsRead,
   handleBatchJobStatusRead,
   handleBatchJobsSubmit,
 } from './inference/batch-job-routes'
 import { makeD1BatchJobStore } from './inference/batch-job-store'
+import {
+  handleOperatorKhalaHeadToHeadApi,
+  handlePublicKhalaHeadToHeadApi,
+} from './inference/benchmark/head-to-head-routes'
+import { makeD1KhalaHeadToHeadStore } from './inference/benchmark/head-to-head-store'
 import { makeD1CardCreditSpendReceiptStore } from './inference/card-credit-spend-receipt-store'
 import {
   handleChatCompletions,
@@ -423,11 +439,11 @@ import {
   isInferenceGatewayEnabled,
   khalaRequestForAdapter,
 } from './inference/chat-completions-routes'
-import { handleDispatchFailureTelemetryReadout } from './inference/dispatch-failure-telemetry-routes'
 import {
   type DiscoverySurfacePath,
   renderDiscoverySurface,
 } from './inference/discovery-surfaces'
+import { handleDispatchFailureTelemetryReadout } from './inference/dispatch-failure-telemetry-routes'
 import { type DurableStreamNamespace } from './inference/durable-inference-do-transport'
 import {
   matchDurableReadRequest,
@@ -450,12 +466,6 @@ import {
 import { handleOperatorHarborFullTraceArchivesApi } from './inference/gym/harbor-full-trace-archive-routes'
 import { makeD1R2HarborFullTraceArchiveStore } from './inference/gym/harbor-full-trace-archive-store'
 import {
-  handleOperatorGymRunProgressApi,
-  handlePublicGymRunProgressApi,
-} from './inference/gym/run-progress-routes'
-import { makeD1GymRunProgressStore } from './inference/gym/run-progress-store'
-import { publishGymRunProgressSnapshot } from './inference/gym/run-progress-sync'
-import {
   handleOperatorGymLeaderboardApi,
   handlePublicGymLeaderboardApi,
 } from './inference/gym/ladder-routes'
@@ -467,10 +477,11 @@ import {
 } from './inference/gym/mirrorcode-routes'
 import { makeD1MirrorCodeRunStore } from './inference/gym/mirrorcode-store'
 import {
-  handleOperatorKhalaHeadToHeadApi,
-  handlePublicKhalaHeadToHeadApi,
-} from './inference/benchmark/head-to-head-routes'
-import { makeD1KhalaHeadToHeadStore } from './inference/benchmark/head-to-head-store'
+  handleOperatorGymRunProgressApi,
+  handlePublicGymRunProgressApi,
+} from './inference/gym/run-progress-routes'
+import { makeD1GymRunProgressStore } from './inference/gym/run-progress-store'
+import { publishGymRunProgressSnapshot } from './inference/gym/run-progress-sync'
 import {
   type HydraliskPoolRouteAdmissionSnapshot,
   makeHydraliskVllmAdapter,
@@ -513,6 +524,11 @@ import {
 import { withReferralAccrual } from './inference/inference-referral-accrual'
 import { makeInferenceReferralRoutes } from './inference/inference-referral-routes'
 import {
+  type InternalStressSchedulerNamespace,
+  makeInternalStressPreemptionCoordinatorDO,
+  makeInternalStressPreemptionRegistry,
+} from './inference/internal-stress-preemption'
+import {
   settleVerifiedAcceptedOutcome,
   summarizeAcceptedOutcomeSettlement,
 } from './inference/khala-accepted-outcome-settlement'
@@ -532,12 +548,6 @@ import {
   buildKhalaTokensServedDelta,
   publishKhalaTokensServedDelta,
 } from './inference/khala-tokens-served-sync'
-import {
-  type InternalStressSchedulerNamespace,
-  makeInternalStressPreemptionCoordinatorDO,
-  makeInternalStressPreemptionRegistry,
-} from './inference/internal-stress-preemption'
-export { GlmStressSchedulerDurableObject } from './inference/internal-stress-preemption-do'
 import { makeLedgerMeteringHook } from './inference/metering-hook'
 import {
   FIREWORKS_ADAPTER_ID,
@@ -635,15 +645,6 @@ import {
   safeJsonRecord,
   stringArrayFromUnknown,
 } from './json-boundary'
-import {
-  authorizeForgeControlPlaneBearer,
-  makeForgeControlPlaneRoutes,
-} from './forge-control-plane-routes'
-import { makeD1ForgeCoordinationStore } from './forge-coordination-store'
-import { makeD1ForgeGitCanonicalStore } from './forge-git-canonical-store'
-import { makeForgeGitIntakeRoutes } from './forge-git-intake-routes'
-import { makeD1R2ForgeGitPackfileArchiveStore } from './forge-git-packfile-archive-store'
-import { makeD1ForgeTenantGitAuthStore } from './forge-tenant-git-auth-store'
 import type { KhalaChatStreamClient } from './khala-chat-program'
 import {
   loadKhalaChatAccountPylonContext,
@@ -656,23 +657,19 @@ import {
   makeD1KhalaFeedbackStore,
 } from './khala-feedback-routes'
 import {
-  handleOperatorKhalaTraceReview,
-  makeD1KhalaTraceReviewStore,
-} from './khala-trace-review-routes'
-import {
-  handleOperatorRlmTraces,
-  makeD1OperatorRlmTraceStore,
-} from './rlm-operator-traces-routes'
-import {
-  handleOperatorKhalaUnsupportedRequests,
-  makeD1KhalaUnsupportedRequestStore,
-} from './khala-unsupported-request-routes'
-import {
   combineMcpCatalogs,
   khalaDurableRequestIsLinkedToPrincipal,
   khalaMcpAgentPrincipal,
   makeKhalaMcpCatalog,
 } from './khala-mcp'
+import {
+  handleOperatorKhalaTraceReview,
+  makeD1KhalaTraceReviewStore,
+} from './khala-trace-review-routes'
+import {
+  handleOperatorKhalaUnsupportedRequests,
+  makeD1KhalaUnsupportedRequestStore,
+} from './khala-unsupported-request-routes'
 import { makeOpenAgentsL402HmacSigningBoundary } from './l402-credential-service'
 import { handlePublicLaborEarningsApi } from './labor-earnings-routes'
 import { handleSelfServeLaborPayoutApi } from './labor-self-serve-earning-payout-routes'
@@ -689,10 +686,6 @@ import {
   MarketplaceWorkClassCatalogEndpoint,
   handleMarketplaceWorkClassCatalogApi,
 } from './marketplace-work-class-catalog-routes'
-import {
-  WasmPluginMarketplaceEndpoint,
-  handleWasmPluginMarketplaceApi,
-} from './wasm-plugin-marketplace-routes'
 import {
   mdkContainerEnvVars,
   optionalMdkContainerSecret,
@@ -812,11 +805,11 @@ import { handlePublicAdjutantActivityApi } from './public-adjutant-activity-rout
 import { makePublicCardCreditSpendReceiptRoutes } from './public-card-credit-spend-receipt-routes'
 import { handlePublicForumActivityApiForEnv } from './public-forum-activity-routes'
 import { makePublicInferenceReceiptRoutes } from './public-inference-receipt-routes'
+import { recordPublicKhalaChatServedTokens } from './public-khala-chat-served-tokens'
 import { handlePublicKhalaTokensServedDemandMixApi } from './public-khala-tokens-served-demand-mix-routes'
 import { handlePublicKhalaTokensServedHistoryApi } from './public-khala-tokens-served-history-routes'
 import { handlePublicKhalaTokensServedModelMixApi } from './public-khala-tokens-served-model-mix-routes'
 import { handlePublicKhalaTokensServedApi } from './public-khala-tokens-served-routes'
-import { recordPublicKhalaChatServedTokens } from './public-khala-chat-served-tokens'
 import { handlePublicLaunchDashboardApi } from './public-launch-dashboard-routes'
 import { makePublicNip90MarketReceiptRoutes } from './public-nip90-market-receipt-routes'
 import { handlePublicOtecProofApi } from './public-otec-proof-routes'
@@ -868,6 +861,10 @@ import {
 } from './relay-health'
 import { handlePublicRelayHealthApi } from './relay-health-routes'
 import { handleResendWebhook } from './resend-webhooks'
+import {
+  handleOperatorRlmTraces,
+  makeD1OperatorRlmTraceStore,
+} from './rlm-operator-traces-routes'
 import { makeExactRouteRegistry } from './routing/exact-routes'
 import {
   cleanProductRouteRedirectLocation,
@@ -1060,7 +1057,6 @@ import {
   TrainingPublicGradientWindowsEndpoint,
   handleTrainingPublicGradientWindowsApi,
 } from './training-public-gradient-windows-routes'
-import { handleVerifiedOutcomeReputationApi } from './verified-outcome-reputation-routes'
 import {
   buildTrainingWindowRecord,
   makeD1TrainingAuthorityStore,
@@ -1098,6 +1094,7 @@ import {
   handlePublicTreasuryLaunchStatusApi,
   reconcilePendingTreasuryTransactions,
 } from './treasury-routes'
+import { handleVerifiedOutcomeReputationApi } from './verified-outcome-reputation-routes'
 import {
   type ViralAgentFunnelEventKind,
   recordViralAgentFunnelEvent,
@@ -1107,6 +1104,10 @@ import {
   handleVoiceProgramIngestApi,
   isVoiceProgramIngestEnabled,
 } from './voice-program-ingest-routes'
+import {
+  WasmPluginMarketplaceEndpoint,
+  handleWasmPluginMarketplaceApi,
+} from './wasm-plugin-marketplace-routes'
 import { makeWorkerRouteRequest } from './worker-routes'
 import {
   makeD1XClaimRewardTreasuryDispatchStore,
@@ -1114,6 +1115,8 @@ import {
   runXClaimRewardTreasuryDispatchScheduled,
   xClaimRewardDispatchDayStartIso,
 } from './x-claim-reward-treasury-dispatcher'
+
+export { GlmStressSchedulerDurableObject } from './inference/internal-stress-preemption-do'
 
 export type Env = WorkerBindings & OpenAgentsWorkerConfigEnv
 
@@ -1358,8 +1361,7 @@ const fetchMdkTreasuryPath = (
   environment: Env,
 ): ContainerPathFetch | undefined => {
   const namespace = environment.MDK_TREASURY as
-    | DurableObjectNamespace<MdkTreasuryContainer>
-    | undefined
+    DurableObjectNamespace<MdkTreasuryContainer> | undefined
 
   if (namespace === undefined) {
     return undefined
@@ -6734,23 +6736,23 @@ export const handleProgrammaticAgentRegistration = async (
             'readiness.public.spark_primary.agent_balance',
           ]
         : lightningAddressPrimary
-        ? [
-            'readiness.public.spark_lightning_address.receive_ready',
-            'readiness.public.spark_primary.agent_balance',
-          ]
-        : [
-            'readiness.public.mdk_agent.daemon_running',
-            'readiness.public.mdk_agent.receive_ready',
-            'readiness.public.mdk_agent.setup_present',
-          ]
+          ? [
+              'readiness.public.spark_lightning_address.receive_ready',
+              'readiness.public.spark_primary.agent_balance',
+            ]
+          : [
+              'readiness.public.mdk_agent.daemon_running',
+              'readiness.public.mdk_agent.receive_ready',
+              'readiness.public.mdk_agent.setup_present',
+            ]
       const custodyPolicyRefs = sparkAddressPrimary
         ? [
             'policy.public.forum_tip_recipient.self_custody_mdk_agent_wallet',
             'policy.public.forum_tip_recipient.spark_self_custody',
           ]
         : lightningAddressPrimary
-        ? ['policy.public.forum_tip_recipient.spark_self_custody']
-        : ['policy.public.forum_tip_recipient.self_custody_mdk_agent_wallet']
+          ? ['policy.public.forum_tip_recipient.spark_self_custody']
+          : ['policy.public.forum_tip_recipient.self_custody_mdk_agent_wallet']
 
       await Effect.runPromise(
         upsertForumTipRecipientWallet(db, {
@@ -6828,9 +6830,7 @@ export const handleAdminReissueAgentToken = async (
 
       const session = await requireBrowserSession(authRequest, authEnv, authCtx)
 
-      return (
-        session !== undefined && isOpenAgentsAdminEmail(session.user.email)
-      )
+      return session !== undefined && isOpenAgentsAdminEmail(session.user.email)
     })
 
   if (!(await authorize(request, env, ctx))) {
@@ -6852,8 +6852,8 @@ export const handleAdminReissueAgentToken = async (
     parsed.slug !== undefined
       ? ({ slug: parsed.slug } as const)
       : parsed.externalId !== undefined
-      ? ({ externalId: parsed.externalId } as const)
-      : undefined
+        ? ({ externalId: parsed.externalId } as const)
+        : undefined
 
   if (selector === undefined) {
     return badRequest('slug or externalId is required')
@@ -7197,7 +7197,8 @@ const pylonCodexTurnIngestRoutes = makePylonCodexTurnIngestRoutes<Env>({
   agentStore: env => makeD1AgentRegistrationStore(openAgentsDatabase(env)),
   ledger: env => makeD1TokenUsageLedger(openAgentsDatabase(env)),
   pylonStore: env => makeD1PylonApiStore(openAgentsDatabase(env)),
-  proofStore: env => makeD1PylonCodexAssignmentProofStore(openAgentsDatabase(env)),
+  proofStore: env =>
+    makeD1PylonCodexAssignmentProofStore(openAgentsDatabase(env)),
   traceStatusStore: env =>
     makeD1PylonCodexAssignmentProofStore(openAgentsDatabase(env)),
   rawEventChunkStore: env =>
@@ -9698,9 +9699,9 @@ const fireworksStrongCodingAdapter: InferenceProviderAdapter = {
     ? {}
     : {
         streamSse: request =>
-          fireworksAdapter
-            .streamSse!(request)
-            .pipe(Effect.mapError(toRetryableStrongCodingError)),
+          fireworksAdapter.streamSse!(request).pipe(
+            Effect.mapError(toRetryableStrongCodingError),
+          ),
       }),
 }
 inferenceProviderRegistry.register(fireworksStrongCodingAdapter)
@@ -9858,8 +9859,7 @@ const registerHydraliskAdapter = (
 }
 
 let latestHydraliskGlm52RouteAdmission:
-  | HydraliskPoolRouteAdmissionSnapshot
-  | undefined
+  HydraliskPoolRouteAdmissionSnapshot | undefined
 
 const hydraliskGlm52RouteAdmissionForEnv = (
   env: HydraliskServeEnv,
@@ -9889,10 +9889,7 @@ const registerOpenRouterAdapter = (
   openRouterAdaptersRegistered.add(env)
   const apiKey = env.OPENROUTER_API_KEY?.trim()
   const baseUrl = env.OPENROUTER_BASE_URL?.trim() || OPENROUTER_DEFAULT_BASE_URL
-  if (
-    apiKey === undefined ||
-    apiKey === ''
-  ) {
+  if (apiKey === undefined || apiKey === '') {
     return
   }
   registry.register(
@@ -9982,7 +9979,8 @@ const setInferenceAdapterEnv = (env: OpenAgentsWorkerConfigEnv): void => {
 // passthrough/Vertex secrets) — rather than a raw Cloudflare `Env`, keeping the
 // worker off the raw-Env ratchet.
 type BatchJobConsumerEnv = OpenAgentsWorkerConfigEnv &
-  Pick<WorkerBindings, 'OPENAGENTS_DB'>
+  Pick<WorkerBindings, 'OPENAGENTS_DB'> &
+  Readonly<{ ARTIFACTS: R2Bucket }>
 const makeBatchJobConsumerDeps = (env: BatchJobConsumerEnv) => {
   registerPassthroughAdapters(inferenceProviderRegistry, env)
   registerHydraliskAdapter(inferenceProviderRegistry, env)
@@ -10000,6 +9998,7 @@ const makeBatchJobConsumerDeps = (env: BatchJobConsumerEnv) => {
     // END of the batch wait) with this clock so the closeout receipt can disclose
     // an honest `batchWaitMs`.
     nowIso: currentIsoTimestamp,
+    resultStore: makeR2BatchJobResultStore(env.ARTIFACTS),
     store: makeD1BatchJobStore(openAgentsDatabase(env), currentIsoTimestamp),
   }
 }
@@ -12234,6 +12233,29 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
       }),
   },
   {
+    path: '/v1/inference/batches/:jobId/results',
+    handler: (request, env) =>
+      handleBatchJobResultsRead(request, {
+        authenticate: async authRequest => {
+          const token = readBearerToken(authRequest)
+          if (token === undefined) {
+            return undefined
+          }
+          const session = await authenticateProgrammaticAgent(
+            makeD1AgentRegistrationStore(openAgentsDatabase(env)),
+            token,
+          )
+          return session === undefined
+            ? undefined
+            : { accountRef: `agent:${session.user.id}` }
+        },
+        db: openAgentsDatabase(env),
+        enabled: isInferenceGatewayEnabled(env.INFERENCE_GATEWAY_ENABLED),
+        nowIso: currentIsoTimestamp,
+        resultStore: makeR2BatchJobResultStore(env.ARTIFACTS),
+      }),
+  },
+  {
     // Inference gateway (EPIC #5474, #5476). INERT by default: gated behind
     // INFERENCE_GATEWAY_ENABLED (default off). Ships wired to the stub/echo
     // adapter + no-op metering stub; Phase-2 issues register real adapters
@@ -13230,7 +13252,9 @@ const routeRequest = makeWorkerRouteRequest({
           : { accountRef: `agent:${session.user.id}` }
       },
       adapter: makeD1SandboxRuntimeAdapter(openAgentsDatabase(env)),
-      enabled: isSandboxComputeServiceEnabled(env.CLOUD_SANDBOX_COMPUTE_ENABLED),
+      enabled: isSandboxComputeServiceEnabled(
+        env.CLOUD_SANDBOX_COMPUTE_ENABLED,
+      ),
     }),
   // OpenAI-compatible GET /v1/models/{model} retrieve. Gated by the SAME
   // INFERENCE_GATEWAY_ENABLED flag as the list and chat-completions routes, so

--- a/apps/openagents.com/workers/api/src/inference/batch-job-consumer.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-consumer.test.ts
@@ -8,6 +8,10 @@ import {
   executeBatchJob,
 } from './batch-job-consumer'
 import type {
+  BatchJobResultStore,
+  BatchJobResultsPayload,
+} from './batch-job-results'
+import type {
   BatchJobRecord,
   BatchJobStatus,
   BatchJobStore,
@@ -37,6 +41,7 @@ const makeFakeStore = (
     status: BatchJobStatus
     processedItems?: number
     failedItems?: number
+    resultsR2Key?: string | null
     startedAt?: string
   }>
 } => {
@@ -45,6 +50,7 @@ const makeFakeStore = (
     status: BatchJobStatus
     processedItems?: number
     failedItems?: number
+    resultsR2Key?: string | null
     startedAt?: string
   }> = []
   const store: BatchJobStore = {
@@ -159,6 +165,26 @@ const meteringRecorder = (): {
   }
 }
 
+const memoryResultStore = (): {
+  store: BatchJobResultStore
+  payloads: () => ReadonlyArray<BatchJobResultsPayload>
+} => {
+  const payloads: Array<BatchJobResultsPayload> = []
+  return {
+    payloads: () => payloads,
+    store: {
+      getResults: key =>
+        Effect.succeed(
+          payloads.find(payload => `memory://${payload.jobId}` === key) ?? null,
+        ),
+      putResults: payload => {
+        payloads.push(payload)
+        return Effect.succeed(`memory://${payload.jobId}`)
+      },
+    },
+  }
+}
+
 const dispatchDepsFor = (adapter: InferenceProviderAdapter) => {
   const registry = new InferenceProviderRegistry()
   registry.register(adapter)
@@ -179,12 +205,14 @@ describe('executeBatchJob', () => {
       usage: { completionTokens: 20, promptTokens: 10, totalTokens: 30 },
     })
     const metering = meteringRecorder()
+    const resultStore = memoryResultStore()
 
     const outcome = await run(
       executeBatchJob(
         {
           dispatch: dispatchDepsFor(gateway.adapter),
           meteringHook: metering.hook,
+          resultStore: resultStore.store,
           store: fake.store,
         },
         makeQueueMessage('batch_test', 2),
@@ -218,7 +246,43 @@ describe('executeBatchJob', () => {
     expect(terminal?.status).toBe('completed')
     expect(terminal?.processedItems).toBe(2)
     expect(terminal?.failedItems).toBe(0)
+    expect(terminal?.resultsR2Key).toBe('memory://batch_test')
     expect(fake.reads()?.status).toBe('completed')
+    expect(fake.reads()?.resultsR2Key).toBe('memory://batch_test')
+    expect(resultStore.payloads()).toEqual([
+      {
+        jobId: 'batch_test',
+        results: [
+          {
+            content: 'fake completion',
+            finishReason: 'stop',
+            index: 0,
+            model: 'gemini-3.5-flash',
+            servedModel: 'served/fireworks',
+            status: 'succeeded',
+            usage: {
+              completionTokens: 20,
+              promptTokens: 10,
+              totalTokens: 30,
+            },
+          },
+          {
+            content: 'fake completion',
+            finishReason: 'stop',
+            index: 1,
+            model: 'gemini-3.5-flash',
+            servedModel: 'served/fireworks',
+            status: 'succeeded',
+            usage: {
+              completionTokens: 20,
+              promptTokens: 10,
+              totalTokens: 30,
+            },
+          },
+        ],
+        schemaVersion: 'openagents.inference.batch_job.results.v1',
+      },
+    ])
   })
 
   it('stamps the consumer-start time (END of the batch wait) from the injected clock', async () => {

--- a/apps/openagents.com/workers/api/src/inference/batch-job-consumer.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-consumer.ts
@@ -25,22 +25,21 @@
 // module is pure orchestration over injected seams (store, registry, metering
 // hook, clock) so it is fully exercisable against a fake gateway + fake queue
 // message with no live run and no new infrastructure.
-
 import { Effect, Schema as S } from 'effect'
 
 import { workerLogEntry } from '../observability'
 import { currentIsoTimestamp } from '../runtime-primitives'
 import {
-  type DispatchDeps,
-  dispatchWithOverflow,
-} from './model-router'
+  type BatchJobResultItem,
+  type BatchJobResultStore,
+  failedBatchJobResultItem,
+  succeededBatchJobResultItem,
+} from './batch-job-results'
+import type { BatchJobStore } from './batch-job-store'
 import type { MeteringContext, MeteringHook } from './metering-hook'
 import { stubMeteringHook } from './metering-hook'
-import type {
-  InferenceRequest,
-  InferenceResult,
-} from './provider-adapter'
-import type { BatchJobStore } from './batch-job-store'
+import { type DispatchDeps, dispatchWithOverflow } from './model-router'
+import type { InferenceRequest, InferenceResult } from './provider-adapter'
 
 // One executable unit of a batch job. The submit route prices on token counts;
 // the consumer needs the actual prompt to RUN the item, so the queue message
@@ -121,6 +120,9 @@ export type BatchJobConsumerDeps = Readonly<{
   // `batchWaitMs` is exactly assertable. Injectable so the consumer stays a pure
   // function of its seams.
   nowIso?: (() => string) | undefined
+  // Stores the customer-visible result payload once item execution completes.
+  // Production uses the private ARTIFACTS R2 bucket; tests inject memory stores.
+  resultStore?: BatchJobResultStore | undefined
 }>
 
 const toInferenceRequest = (
@@ -193,6 +195,7 @@ export const executeBatchJob = (
 
     let processedItems = 0
     let failedItems = 0
+    const results: Array<BatchJobResultItem> = []
 
     for (let index = 0; index < message.items.length; index += 1) {
       const item = message.items[index]
@@ -223,6 +226,13 @@ export const executeBatchJob = (
 
       if (!dispatched.ok) {
         failedItems += 1
+        results.push(
+          failedBatchJobResultItem({
+            errorReason: dispatched.reason,
+            index,
+            model: item.model,
+          }),
+        )
         yield* Effect.logInfo(
           workerLogEntry('inference.batch_job.item.failed', {
             index,
@@ -232,6 +242,14 @@ export const executeBatchJob = (
         )
         continue
       }
+
+      results.push(
+        succeededBatchJobResultItem({
+          index,
+          model: item.model,
+          result: dispatched.served.value,
+        }),
+      )
 
       // Decrement credits through the EXISTING metering hook. The per-item
       // request id is `<jobId>:<index>` so the hook's idempotency key dedupes a
@@ -252,10 +270,19 @@ export const executeBatchJob = (
     const allFailed =
       message.items.length > 0 && failedItems === message.items.length
     const terminalStatus = allFailed ? 'failed' : 'completed'
+    const resultsR2Key =
+      deps.resultStore === undefined
+        ? null
+        : yield* deps.resultStore.putResults({
+            jobId: message.jobId,
+            results,
+            schemaVersion: 'openagents.inference.batch_job.results.v1',
+          })
 
     yield* deps.store.updateBatchJobStatus(message.jobId, terminalStatus, {
       failedItems,
       processedItems,
+      ...(resultsR2Key === null ? {} : { resultsR2Key }),
     })
 
     yield* Effect.logInfo(

--- a/apps/openagents.com/workers/api/src/inference/batch-job-flow.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-flow.test.ts
@@ -16,22 +16,27 @@ import { Effect, Schema as S } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import {
-  type BatchJobRoutesDeps,
-  handleBatchJobReceiptRead,
-  handleBatchJobsSubmit,
-} from './batch-job-routes'
-import {
   type BatchJobConsumerDeps,
   BatchJobQueueMessage,
   batchJobCloseoutReceiptRef,
   executeBatchJob,
 } from './batch-job-consumer'
+import type {
+  BatchJobResultStore,
+  BatchJobResultsPayload,
+} from './batch-job-results'
+import {
+  type BatchJobRoutesDeps,
+  handleBatchJobReceiptRead,
+  handleBatchJobResultsRead,
+  handleBatchJobsSubmit,
+} from './batch-job-routes'
 import { makeD1BatchJobStore } from './batch-job-store'
 import type { MeteringContext, MeteringOutcome } from './metering-hook'
 import {
   type InferenceProviderAdapter,
-  type InferenceResult,
   InferenceProviderRegistry,
+  type InferenceResult,
 } from './provider-adapter'
 
 const run = <A>(effect: Effect.Effect<A, never, never>): Promise<A> =>
@@ -68,7 +73,7 @@ const makeStatefulDb = (): D1Database => {
 
   const prepare = (sql: string) => {
     const make = (bindings: unknown[]) => ({
-      first: async <T,>(): Promise<T | null> => {
+      first: async <T>(): Promise<T | null> => {
         if (sql.includes('FROM inference_batch_jobs')) {
           const jobId = String(bindings[0])
           const row = rows.get(jobId)
@@ -219,6 +224,37 @@ const receiptDeps = (db: D1Database): BatchJobRoutesDeps => ({
   nowIso: () => '2026-06-22T00:05:00.000Z',
 })
 
+const resultsDeps = (
+  db: D1Database,
+  resultStore: BatchJobResultStore,
+): BatchJobRoutesDeps => ({
+  authenticate: async () => ({ accountRef: 'agent:flow' }),
+  db,
+  enabled: true,
+  nowIso: () => '2026-06-22T00:05:00.000Z',
+  resultStore,
+})
+
+const memoryResultStore = (): {
+  store: BatchJobResultStore
+  payloads: () => ReadonlyArray<BatchJobResultsPayload>
+} => {
+  const payloads: Array<BatchJobResultsPayload> = []
+  return {
+    payloads: () => payloads,
+    store: {
+      getResults: key =>
+        Effect.succeed(
+          payloads.find(payload => `memory://${payload.jobId}` === key) ?? null,
+        ),
+      putResults: payload => {
+        payloads.push(payload)
+        return Effect.succeed(`memory://${payload.jobId}`)
+      },
+    },
+  }
+}
+
 const submitRequest = (body: unknown): Request =>
   new Request('https://openagents.com/v1/inference/batches', {
     body: JSON.stringify(body),
@@ -230,6 +266,11 @@ const receiptRequest = (receiptRef: string): Request =>
     `https://openagents.com/api/public/inference/batch-job-receipts/${receiptRef}`,
     { method: 'GET' },
   )
+
+const resultsRequest = (jobId: string): Request =>
+  new Request(`https://openagents.com/v1/inference/batches/${jobId}/results`, {
+    method: 'GET',
+  })
 
 describe('async batch-job flow (submit -> queue -> consumer -> receipt)', () => {
   it('runs a detached khala job end-to-end and makes its receipt dereferenceable', async () => {
@@ -298,6 +339,7 @@ describe('async batch-job flow (submit -> queue -> consumer -> receipt)', () => 
       JSON.parse(JSON.stringify(captured[0])),
     )
     const metering = recordingMetering()
+    const resultStore = memoryResultStore()
     const outcome = await run(
       executeBatchJob(
         {
@@ -307,6 +349,7 @@ describe('async batch-job flow (submit -> queue -> consumer -> receipt)', () => 
           // the batch wait) with this clock; with the 00:00:00 enqueue the receipt
           // discloses a real batchWaitMs of 120000 (2 min in queue).
           nowIso: () => '2026-06-22T00:02:00.000Z',
+          resultStore: resultStore.store,
           store: makeD1BatchJobStore(db, () => '2026-06-22T00:02:00.000Z'),
         },
         message,
@@ -322,7 +365,26 @@ describe('async batch-job flow (submit -> queue -> consumer -> receipt)', () => 
     expect(metering.calls()[0]?.accountRef).toBe('agent:flow')
     expect(metering.calls()[0]?.requestId).toBe(`${jobId}:0`)
 
-    // 3) RECEIPT is now dereferenceable (status flipped to completed).
+    // 3) RESULT retrieval is now dereferenceable for the owning account.
+    const resultsResponse = await run(
+      handleBatchJobResultsRead(
+        resultsRequest(jobId),
+        resultsDeps(db, resultStore.store),
+      ),
+    )
+    expect(resultsResponse.status).toBe(200)
+    const resultsBody = (await resultsResponse.json()) as {
+      resultsR2Key: string
+      results: ReadonlyArray<{ content: string; status: string }>
+    }
+    expect(resultsBody.resultsR2Key).toBe(`memory://${jobId}`)
+    expect(resultsBody.results).toHaveLength(1)
+    expect(resultsBody.results[0]).toMatchObject({
+      content: 'fake completion',
+      status: 'succeeded',
+    })
+
+    // 4) RECEIPT is now dereferenceable (status flipped to completed).
     const finalReceipt = await run(
       handleBatchJobReceiptRead(
         receiptRequest(batchJobCloseoutReceiptRef(jobId)),

--- a/apps/openagents.com/workers/api/src/inference/batch-job-results.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-results.ts
@@ -1,0 +1,96 @@
+import { Effect, Schema as S } from 'effect'
+
+import { parseJsonUnknown } from '../json-boundary'
+import type { InferenceResult, InferenceUsage } from './provider-adapter'
+
+export const BatchJobResultItem = S.Struct({
+  index: S.Number,
+  model: S.String,
+  status: S.Literals(['succeeded', 'failed']),
+  content: S.optionalKey(S.String),
+  errorReason: S.optionalKey(S.String),
+  finishReason: S.optionalKey(S.String),
+  servedModel: S.optionalKey(S.String),
+  usage: S.optionalKey(
+    S.Struct({
+      completionTokens: S.Number,
+      promptTokens: S.Number,
+      totalTokens: S.Number,
+      cachedPromptTokens: S.optionalKey(S.Number),
+    }),
+  ),
+})
+export type BatchJobResultItem = S.Schema.Type<typeof BatchJobResultItem>
+
+export const BatchJobResultsPayload = S.Struct({
+  schemaVersion: S.Literal('openagents.inference.batch_job.results.v1'),
+  jobId: S.String,
+  results: S.Array(BatchJobResultItem),
+})
+export type BatchJobResultsPayload = S.Schema.Type<
+  typeof BatchJobResultsPayload
+>
+
+export type BatchJobResultStore = Readonly<{
+  putResults: (payload: BatchJobResultsPayload) => Effect.Effect<string>
+  getResults: (key: string) => Effect.Effect<BatchJobResultsPayload | null>
+}>
+
+export const batchJobResultsR2Key = (jobId: string): string =>
+  `inference/batch-jobs/${jobId}/results.json`
+
+export const succeededBatchJobResultItem = (input: {
+  index: number
+  model: string
+  result: InferenceResult
+}): BatchJobResultItem => ({
+  content: input.result.content,
+  finishReason: input.result.finishReason,
+  index: input.index,
+  model: input.model,
+  servedModel: input.result.servedModel,
+  status: 'succeeded',
+  usage: usageToResultUsage(input.result.usage),
+})
+
+export const failedBatchJobResultItem = (input: {
+  errorReason: string
+  index: number
+  model: string
+}): BatchJobResultItem => ({
+  errorReason: input.errorReason,
+  index: input.index,
+  model: input.model,
+  status: 'failed',
+})
+
+const usageToResultUsage = (usage: InferenceUsage) => ({
+  completionTokens: usage.completionTokens,
+  promptTokens: usage.promptTokens,
+  totalTokens: usage.totalTokens,
+  ...(usage.cachedPromptTokens === undefined
+    ? {}
+    : { cachedPromptTokens: usage.cachedPromptTokens }),
+})
+
+export const makeR2BatchJobResultStore = (
+  bucket: R2Bucket,
+): BatchJobResultStore => ({
+  putResults: payload =>
+    Effect.tryPromise(async () => {
+      const key = batchJobResultsR2Key(payload.jobId)
+      await bucket.put(key, JSON.stringify(payload), {
+        httpMetadata: { contentType: 'application/json' },
+      })
+      return key
+    }).pipe(Effect.orDie),
+  getResults: key =>
+    Effect.tryPromise(async () => {
+      const object = await bucket.get(key)
+      if (object === null) {
+        return null
+      }
+      const text = await object.text()
+      return S.decodeUnknownSync(BatchJobResultsPayload)(parseJsonUnknown(text))
+    }).pipe(Effect.orDie),
+})

--- a/apps/openagents.com/workers/api/src/inference/batch-job-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-routes.test.ts
@@ -1,13 +1,18 @@
 import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import { inferenceBatchJobChargeReceiptRef } from './batch-job-metering'
+import type {
+  BatchJobResultStore,
+  BatchJobResultsPayload,
+} from './batch-job-results'
 import {
   type BatchJobRoutesDeps,
   handleBatchJobReceiptRead,
-  handleBatchJobsSubmit,
+  handleBatchJobResultsRead,
   handleBatchJobStatusRead,
+  handleBatchJobsSubmit,
 } from './batch-job-routes'
-import { inferenceBatchJobChargeReceiptRef } from './batch-job-metering'
 
 const run = <A>(effect: Effect.Effect<A, never, never>): Promise<A> =>
   Effect.runPromise(effect)
@@ -38,6 +43,13 @@ const makeRequest = (body: unknown): Request =>
     body: JSON.stringify(body),
     method: 'POST',
   })
+
+const resultStoreFor = (
+  payloads: Readonly<Record<string, BatchJobResultsPayload>>,
+): BatchJobResultStore => ({
+  getResults: key => Effect.succeed(payloads[key] ?? null),
+  putResults: payload => Effect.succeed(`memory://${payload.jobId}`),
+})
 
 describe('handleBatchJobsSubmit', () => {
   it('returns 404 when disabled', async () => {
@@ -72,7 +84,10 @@ describe('handleBatchJobsSubmit', () => {
 
   it('returns 400 for invalid schema', async () => {
     const response = await run(
-      handleBatchJobsSubmit(makeRequest({ dataset: [{ foo: 'bar' }] }), baseDeps()),
+      handleBatchJobsSubmit(
+        makeRequest({ dataset: [{ foo: 'bar' }] }),
+        baseDeps(),
+      ),
     )
     expect(response.status).toBe(400)
   })
@@ -149,7 +164,8 @@ describe('handleBatchJobReceiptRead', () => {
                 job_id: 'batch_123',
                 account_ref: 'agent:123',
                 status: jobStatus,
-                charge_receipt_ref: 'receipt.inference.batch_job_charge.batch_123',
+                charge_receipt_ref:
+                  'receipt.inference.batch_job_charge.batch_123',
                 dataset_size: 100,
                 processed_items: 99,
                 failed_items: 1,
@@ -172,28 +188,40 @@ describe('handleBatchJobReceiptRead', () => {
   }
 
   const makeReadRequest = (receiptRef: string): Request =>
-    new Request(`https://openagents.com/api/public/inference/batch-job-receipts/${receiptRef}`, {
-      method: 'GET',
-    })
+    new Request(
+      `https://openagents.com/api/public/inference/batch-job-receipts/${receiptRef}`,
+      {
+        method: 'GET',
+      },
+    )
 
   it('returns 404 when disabled', async () => {
     const response = await run(
-      handleBatchJobReceiptRead(makeReadRequest('receipt.inference.batch_job.closeout.batch_123'), baseDeps({ enabled: false })),
+      handleBatchJobReceiptRead(
+        makeReadRequest('receipt.inference.batch_job.closeout.batch_123'),
+        baseDeps({ enabled: false }),
+      ),
     )
     expect(response.status).toBe(404)
   })
 
   it('returns 405 for non-GET requests', async () => {
-    const request = new Request('https://openagents.com/api/public/inference/batch-job-receipts/receipt.inference.batch_job.closeout.batch_123', {
-      method: 'POST',
-    })
+    const request = new Request(
+      'https://openagents.com/api/public/inference/batch-job-receipts/receipt.inference.batch_job.closeout.batch_123',
+      {
+        method: 'POST',
+      },
+    )
     const response = await run(handleBatchJobReceiptRead(request, baseDeps()))
     expect(response.status).toBe(405)
   })
 
   it('returns 404 for invalid prefix', async () => {
     const response = await run(
-      handleBatchJobReceiptRead(makeReadRequest('invalid-prefix.batch_123'), baseDeps()),
+      handleBatchJobReceiptRead(
+        makeReadRequest('invalid-prefix.batch_123'),
+        baseDeps(),
+      ),
     )
     expect(response.status).toBe(404)
   })
@@ -201,7 +229,10 @@ describe('handleBatchJobReceiptRead', () => {
   it('returns 404 if job not found', async () => {
     const deps = baseDeps({ db: makeReadDb(null) })
     const response = await run(
-      handleBatchJobReceiptRead(makeReadRequest('receipt.inference.batch_job.closeout.batch_123'), deps),
+      handleBatchJobReceiptRead(
+        makeReadRequest('receipt.inference.batch_job.closeout.batch_123'),
+        deps,
+      ),
     )
     expect(response.status).toBe(404)
   })
@@ -209,7 +240,10 @@ describe('handleBatchJobReceiptRead', () => {
   it('returns 404 if job is pending', async () => {
     const deps = baseDeps({ db: makeReadDb('pending') })
     const response = await run(
-      handleBatchJobReceiptRead(makeReadRequest('receipt.inference.batch_job.closeout.batch_123'), deps),
+      handleBatchJobReceiptRead(
+        makeReadRequest('receipt.inference.batch_job.closeout.batch_123'),
+        deps,
+      ),
     )
     expect(response.status).toBe(404)
   })
@@ -217,7 +251,10 @@ describe('handleBatchJobReceiptRead', () => {
   it('returns projected closeout receipt for completed job', async () => {
     const deps = baseDeps({ db: makeReadDb('completed') })
     const response = await run(
-      handleBatchJobReceiptRead(makeReadRequest('receipt.inference.batch_job.closeout.batch_123'), deps),
+      handleBatchJobReceiptRead(
+        makeReadRequest('receipt.inference.batch_job.closeout.batch_123'),
+        deps,
+      ),
     )
 
     expect(response.status).toBe(200)
@@ -288,7 +325,10 @@ describe('handleBatchJobReceiptRead', () => {
 })
 
 describe('handleBatchJobStatusRead', () => {
-  const makeReadDb = (jobStatus: string | null, accountRef = 'agent:123'): D1Database => {
+  const makeReadDb = (
+    jobStatus: string | null,
+    accountRef = 'agent:123',
+  ): D1Database => {
     return {
       prepare: (sql: string) => ({
         bind: () => ({
@@ -299,7 +339,8 @@ describe('handleBatchJobStatusRead', () => {
                 job_id: 'batch_123',
                 account_ref: accountRef,
                 status: jobStatus,
-                charge_receipt_ref: 'receipt.inference.batch_job_charge.batch_123',
+                charge_receipt_ref:
+                  'receipt.inference.batch_job_charge.batch_123',
                 dataset_size: 100,
                 processed_items: 99,
                 failed_items: 1,
@@ -324,22 +365,30 @@ describe('handleBatchJobStatusRead', () => {
 
   it('returns 404 when disabled', async () => {
     const response = await run(
-      handleBatchJobStatusRead(makeStatusRequest('batch_123'), baseDeps({ enabled: false })),
+      handleBatchJobStatusRead(
+        makeStatusRequest('batch_123'),
+        baseDeps({ enabled: false }),
+      ),
     )
     expect(response.status).toBe(404)
   })
 
   it('returns 405 for non-GET requests', async () => {
-    const request = new Request('https://openagents.com/v1/inference/batches/batch_123', {
-      method: 'POST',
-    })
+    const request = new Request(
+      'https://openagents.com/v1/inference/batches/batch_123',
+      {
+        method: 'POST',
+      },
+    )
     const response = await run(handleBatchJobStatusRead(request, baseDeps()))
     expect(response.status).toBe(405)
   })
 
   it('returns 401 when unauthenticated', async () => {
     const deps = baseDeps({ authenticate: async () => undefined })
-    const response = await run(handleBatchJobStatusRead(makeStatusRequest('batch_123'), deps))
+    const response = await run(
+      handleBatchJobStatusRead(makeStatusRequest('batch_123'), deps),
+    )
     expect(response.status).toBe(401)
   })
 
@@ -379,5 +428,126 @@ describe('handleBatchJobStatusRead', () => {
     expect(body.enqueuedAt).toBe('2026-06-20T12:00:00.000Z')
     expect(body.startedAt).toBe('2026-06-20T12:00:45.000Z')
     expect(body.batchWaitMs).toBe(45000)
+  })
+})
+
+describe('handleBatchJobResultsRead', () => {
+  const makeReadDb = (
+    jobStatus: string | null,
+    accountRef = 'agent:123',
+    resultsR2Key: string | null = 'batch_123/results.json',
+  ): D1Database => {
+    return {
+      prepare: (sql: string) => ({
+        bind: () => ({
+          first: async () => {
+            if (sql.includes('inference_batch_jobs')) {
+              if (jobStatus === null) return null
+              return {
+                account_ref: accountRef,
+                charge_receipt_ref:
+                  'receipt.inference.batch_job_charge.batch_123',
+                created_at: '2026-06-20T12:00:00.000Z',
+                dataset_size: 2,
+                enqueued_at: '2026-06-20T12:00:00.000Z',
+                failed_items: 0,
+                job_id: 'batch_123',
+                processed_items: 2,
+                results_r2_key: resultsR2Key,
+                started_at: '2026-06-20T12:00:45.000Z',
+                status: jobStatus,
+                updated_at: '2026-06-20T12:05:00.000Z',
+              }
+            }
+            return null
+          },
+        }),
+      }),
+    } as unknown as D1Database
+  }
+
+  const makeResultsRequest = (jobId: string): Request =>
+    new Request(
+      `https://openagents.com/v1/inference/batches/${jobId}/results`,
+      {
+        method: 'GET',
+      },
+    )
+
+  const payload: BatchJobResultsPayload = {
+    jobId: 'batch_123',
+    results: [
+      {
+        content: 'classified as urgent',
+        finishReason: 'stop',
+        index: 0,
+        model: 'gemini-3.5-flash',
+        servedModel: 'served/fireworks',
+        status: 'succeeded',
+        usage: {
+          completionTokens: 8,
+          promptTokens: 12,
+          totalTokens: 20,
+        },
+      },
+      {
+        content: 'summary text',
+        finishReason: 'stop',
+        index: 1,
+        model: 'gemini-3.5-flash',
+        servedModel: 'served/fireworks',
+        status: 'succeeded',
+        usage: {
+          completionTokens: 11,
+          promptTokens: 15,
+          totalTokens: 26,
+        },
+      },
+    ],
+    schemaVersion: 'openagents.inference.batch_job.results.v1',
+  }
+
+  it('returns authenticated batch results for the owning account', async () => {
+    const deps = baseDeps({
+      db: makeReadDb('completed'),
+      resultStore: resultStoreFor({ 'batch_123/results.json': payload }),
+    })
+    const response = await run(
+      handleBatchJobResultsRead(makeResultsRequest('batch_123'), deps),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as any
+    expect(body.jobId).toBe('batch_123')
+    expect(body.resultsR2Key).toBe('batch_123/results.json')
+    expect(body.results).toHaveLength(2)
+    expect(body.results[0].content).toBe('classified as urgent')
+  })
+
+  it('returns 409 before results are written', async () => {
+    const deps = baseDeps({
+      db: makeReadDb('processing', 'agent:123', null),
+      resultStore: resultStoreFor({}),
+    })
+    const response = await run(
+      handleBatchJobResultsRead(makeResultsRequest('batch_123'), deps),
+    )
+
+    expect(response.status).toBe(409)
+    const body = (await response.json()) as any
+    expect(body.error).toBe('batch_results_not_ready')
+    expect(body.status).toBe('processing')
+  })
+
+  it('returns 404 when the job belongs to another account', async () => {
+    const deps = baseDeps({
+      db: makeReadDb('completed', 'agent:other'),
+      resultStore: resultStoreFor({ 'batch_123/results.json': payload }),
+    })
+    const response = await run(
+      handleBatchJobResultsRead(makeResultsRequest('batch_123'), deps),
+    )
+
+    expect(response.status).toBe(404)
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/batch-job-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/batch-job-routes.ts
@@ -1,18 +1,20 @@
 import { Effect, Schema as S } from 'effect'
 
 import { noStoreJsonResponse } from '../http/responses'
+import { parseJsonUnknown } from '../json-boundary'
 import { compactRandomId } from '../runtime-primitives'
-import {
-  type BatchJobExecutableItem,
-  BatchJobQueueMessage,
-} from './batch-job-consumer'
-import { settleBatchJobCharge } from './batch-job-metering'
-import { makeD1BatchJobStore } from './batch-job-store'
 import {
   buildBatchJobTelemetryRecord,
   computeBatchWaitMs,
   projectBatchJobCloseoutReceipt,
 } from './batch-job-closeout-receipts'
+import {
+  type BatchJobExecutableItem,
+  BatchJobQueueMessage,
+} from './batch-job-consumer'
+import { settleBatchJobCharge } from './batch-job-metering'
+import type { BatchJobResultStore } from './batch-job-results'
+import { makeD1BatchJobStore } from './batch-job-store'
 // public-projection-staleness
 import { estimateRequestCost } from './cost-estimate'
 
@@ -43,6 +45,7 @@ export type BatchJobRoutesDeps = Readonly<{
   // accepted + persisted but never executed, preserving the pre-producer
   // behaviour for the flag-off path.
   enqueueBatchJob?: EnqueueBatchJob | undefined
+  resultStore?: BatchJobResultStore | undefined
 }>
 
 // One submitted dataset row. Carries BOTH the token counts the route prices the
@@ -83,8 +86,6 @@ const decodeBody = (value: unknown) => {
   }
 }
 
-import { parseJsonUnknown } from '../json-boundary'
-
 const safeJsonParse = (text: string): unknown => {
   try {
     return parseJsonUnknown(text)
@@ -113,7 +114,7 @@ export const handleBatchJobsSubmit = (
     }
 
     const session = yield* Effect.promise(() => deps.authenticate(request))
-    
+
     if (session === undefined) {
       const headers = new Headers({ 'www-authenticate': 'Bearer' })
       return noStoreJsonResponse(
@@ -122,8 +123,10 @@ export const handleBatchJobsSubmit = (
       )
     }
 
-    const textResult = yield* Effect.promise(() => request.text().catch(() => ''))
-    
+    const textResult = yield* Effect.promise(() =>
+      request.text().catch(() => ''),
+    )
+
     if (textResult === '') {
       return noStoreJsonResponse({ error: 'invalid_json' }, { status: 400 })
     }
@@ -254,11 +257,16 @@ export const handleBatchJobReceiptRead = (
     }
 
     if (request.method !== 'GET') {
-      return noStoreJsonResponse({ error: 'method_not_allowed' }, { status: 405 })
+      return noStoreJsonResponse(
+        { error: 'method_not_allowed' },
+        { status: 405 },
+      )
     }
 
     const url = new URL(request.url)
-    const match = url.pathname.match(/^\/api\/public\/inference\/batch-job-receipts\/(.+)$/)
+    const match = url.pathname.match(
+      /^\/api\/public\/inference\/batch-job-receipts\/(.+)$/,
+    )
     if (!match) {
       return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
     }
@@ -280,9 +288,11 @@ export const handleBatchJobReceiptRead = (
     // Cost MSat from ledger
     const costMsatRaw = yield* Effect.tryPromise(() =>
       deps.db
-        .prepare('SELECT cost_msat FROM pay_ins WHERE public_receipt_ref = ? LIMIT 1')
+        .prepare(
+          'SELECT cost_msat FROM pay_ins WHERE public_receipt_ref = ? LIMIT 1',
+        )
         .bind(job.chargeReceiptRef)
-        .first<{ cost_msat: number }>()
+        .first<{ cost_msat: number }>(),
     ).pipe(Effect.orDie)
 
     const costMsat = costMsatRaw ? costMsatRaw.cost_msat : 0
@@ -313,7 +323,7 @@ export const handleBatchJobReceiptRead = (
     }
 
     return noStoreJsonResponse(
-      projectBatchJobCloseoutReceipt(receipt, deps.nowIso())
+      projectBatchJobCloseoutReceipt(receipt, deps.nowIso()),
     )
   })
 
@@ -330,13 +340,19 @@ export const handleBatchJobStatusRead = (
     }
 
     if (request.method !== 'GET') {
-      return noStoreJsonResponse({ error: 'method_not_allowed' }, { status: 405 })
+      return noStoreJsonResponse(
+        { error: 'method_not_allowed' },
+        { status: 405 },
+      )
     }
 
     const session = yield* Effect.promise(() => deps.authenticate(request))
     if (session === undefined) {
       const headers = new Headers({ 'www-authenticate': 'Bearer' })
-      return noStoreJsonResponse({ error: 'unauthorized' }, { headers, status: 401 })
+      return noStoreJsonResponse(
+        { error: 'unauthorized' },
+        { headers, status: 401 },
+      )
     }
 
     const url = new URL(request.url)
@@ -369,5 +385,76 @@ export const handleBatchJobStatusRead = (
       enqueuedAt: job.enqueuedAt,
       startedAt: job.startedAt,
       batchWaitMs: batchWaitMs ?? null,
+    })
+  })
+
+export const handleBatchJobResultsRead = (
+  request: Request,
+  deps: BatchJobRoutesDeps,
+) =>
+  Effect.gen(function* () {
+    if (!deps.enabled) {
+      return noStoreJsonResponse(
+        { error: 'inference_batch_jobs_disabled' },
+        { status: 404 },
+      )
+    }
+
+    if (request.method !== 'GET') {
+      return noStoreJsonResponse(
+        { error: 'method_not_allowed' },
+        { status: 405 },
+      )
+    }
+
+    const session = yield* Effect.promise(() => deps.authenticate(request))
+    if (session === undefined) {
+      const headers = new Headers({ 'www-authenticate': 'Bearer' })
+      return noStoreJsonResponse(
+        { error: 'unauthorized' },
+        { headers, status: 401 },
+      )
+    }
+
+    const url = new URL(request.url)
+    const match = url.pathname.match(
+      /^\/v1\/inference\/batches\/(.+)\/results$/,
+    )
+    if (!match) {
+      return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
+    }
+
+    const jobId = match[1] ?? ''
+    const store = makeD1BatchJobStore(deps.db, deps.nowIso)
+    const job = yield* store.getBatchJob(jobId)
+
+    if (!job || job.accountRef !== session.accountRef) {
+      return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
+    }
+
+    if (job.resultsR2Key === null) {
+      return noStoreJsonResponse(
+        { error: 'batch_results_not_ready', status: job.status },
+        { status: 409 },
+      )
+    }
+
+    if (deps.resultStore === undefined) {
+      return noStoreJsonResponse(
+        { error: 'batch_results_store_unavailable' },
+        { status: 503 },
+      )
+    }
+
+    const results = yield* deps.resultStore.getResults(job.resultsR2Key)
+    if (results === null) {
+      return noStoreJsonResponse({ error: 'not_found' }, { status: 404 })
+    }
+
+    return noStoreJsonResponse({
+      jobId: job.jobId,
+      status: job.status,
+      resultsR2Key: job.resultsR2Key,
+      results: results.results,
     })
   })

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -4076,9 +4076,7 @@ export const publicProductPromisesDocument = () => {
           'promise:autopilot.agent_world_scene.v1',
           'promise:autopilot.bitcoin_payment_visualization.v1',
         ],
-        blockerRefs: [
-          'blocker.product_promises.pylon_growth_flag_default_off',
-        ],
+        blockerRefs: ['blocker.product_promises.pylon_growth_flag_default_off'],
         verification:
           'Yellow now covers the live scene wiring behind CHAT_WORLD_SCENE / CHAT_WORLD_PAYMENTS: PublicRecentPylon preserves public cumulativeSettledSats when present, projectChatWorldPylonScene computes each node growth descriptor from that value, liveChatWorldNetworkScene carries the descriptor into PylonNetworkNode, and pylonNetworkVisualizationOptions maps tiers onto the pinned three-effect renderer knobs (larger role geometry, brighter status, and facet/sats detail). Tier 0 remains the 0-sat still crystal. Green still requires an owner decision on default-on and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
@@ -4251,23 +4249,28 @@ export const publicProductPromisesDocument = () => {
         claim:
           'A business customer can hand OpenAgents a batch of items (summaries, classifications, extractions) and get the processed results back as a buyable, metered inference job.',
         safeCopy:
-          'Batch inference processing as a buyable business offering is planned roadmap scope. The underlying single-request gateway is live and free inference works, but there is no batch-job product surface (submit a dataset, meter it, return results with a receipt) and the paid credits loop it would bill against is not yet collectable.',
+          'Batch inference processing as a buyable business offering remains planned. The code-backed batch surface now accepts datasets, queues executable items through the existing inference gateway, meters each processed item, stores owner-scoped results, exposes status/result retrieval, and projects a closeout receipt for completed jobs. Keep public copy receipt-first: this is tested implementation evidence, not a green product claim, until a real paid batch job receipt and collectable paid-credits loop are owner-signed.',
         unsafeCopy:
-          'Do not say OpenAgents has a live batch-processing product, that customers can submit datasets for metered batch inference today, or that batch jobs return billed receipts.',
+          'Do not say OpenAgents has a broadly live batch-processing product, that customers can buy production batch jobs today, or that the promise is green before a real paid batch-job receipt and owner-signed transition exist.',
         evidenceRefs: [
           'docs/business/2026-06-20-openagents-business-intake-spec.md',
           'docs/inference/README.md',
           'docs/inference/2026-06-19-inference-gateway-business.md',
           'docs/launch/gemini-fleet/inference.batch_processing_jobs.v1.md',
+          'apps/openagents.com/workers/api/src/inference/batch-job-flow.test.ts',
+          'apps/openagents.com/workers/api/src/inference/batch-job-routes.test.ts',
+          'apps/openagents.com/workers/api/src/inference/batch-job-consumer.test.ts',
           'promise:inference.gateway_credits_business.v1',
           'promise:inference.free_tier_taste.v1',
           'promise:business.intake_quick_win_offering.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.inference_batch_job_surface_unbuilt',
+          'blocker.product_promises.inference_batch_job_first_real_paid_receipt_missing',
+          'blocker.product_promises.inference_paid_credits_collectable_loop_missing',
+          'blocker.product_promises.inference_batch_job_owner_signed_green_transition_missing',
         ],
         verification:
-          'Planned: the per-request gateway (POST /v1/chat/completions) and free taste are live, but no batch-job offering exists — there is no dataset-submission surface, no batch metering/result-return loop, and the paid credits path it would bill against is not collectable (see inference.gateway_credits_business.v1). Green requires a built, tested batch-processing product with a dereferenceable first paid batch-job receipt and a receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'Planned with tested implementation evidence: POST /v1/inference/batches accepts a fixture dataset, the async consumer executes items through the existing provider-adapter gateway, per-item metering hooks run with batch=true, GET /v1/inference/batches/{jobId} exposes owner-scoped status, GET /v1/inference/batches/{jobId}/results returns owner-scoped processed results, and GET /api/public/inference/batch-job-receipts/{receiptRef} dereferences completed closeout receipts. Route/consumer/flow tests cover submit -> process -> results -> receipt. The promise stays planned because green still requires a real paid batch-job receipt, collectable paid credits, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           "A batch inference job, when built, grants no spend authority beyond the customer's funded balance, no payout, and no settlement authority, and processing results never asserts an outcome the underlying model run did not produce.",
       },
@@ -4463,6 +4466,7 @@ export const publicProductPromisesDocument = () => {
       'Registry 2026-06-28.2 is a marketplace.agentic_npm_module_registry.v1 runtime-core pass and flips NO promise state. The source-level runtime now supports public-safe module publication into a registry store, discovery, deterministic dependency-closure resolution, verification-on-install, adapter-scoped invocation, and install/use evidence rows, with tests covering success and failed verification blocking. The live paid marketplace claim remains planned because authenticated self-serve publication, arbitrary package isolation policy, metering, billing, attribution, rev-share, abuse handling, sale receipts, and settlement are still not live.',
       'Registry 2026-06-28.3 is a training.ablation_system.v1 paid-dispatch receipt pass and flips NO promise state. GET /api/public/training/ablation-derisking-ledger now records one public-safe accepted paid ablation settlement receipt for assignment.public.training_ablation.wsd_schedule.one_delta_paid.v1, so paidAblationDispatchAvailable=true, paidAblationCount=1, and acceptedVerdictCount=1. This clears blocker.product_promises.paid_ablation_dispatch_missing, but the promise stays planned on seeded_ablation_replication_missing plus owner_signed_green_transition_missing. No model promotion, checkpoint mutation, broad ablation-system green claim, future spend authority, or public capability claim is created.',
       'Registry 2026-06-20.57 is an inference.batch_processing_jobs.v1 paid-receipt surface pass and flips NO promise state (stays planned, green count unchanged at 26). The POST /v1/inference/batches route now persists jobs to D1, and GET /api/public/inference/batch-job-receipts/{receiptRef} serves projected BatchJobCloseoutReceipts for completed jobs. This clears blocker.product_promises.inference_batch_job_paid_receipt_missing only. The promise remains planned on blocker.product_promises.inference_batch_job_surface_unbuilt: there is still no background job processing pipeline to execute workloads, store R2 results, and mark jobs completed. No batch processing workload, R2 execution payload, spend, real closeout, revenue claim, or green transition is created. Evidence: docs/launch/gemini-fleet/inference.batch_processing_jobs.v1.md.',
+      'Registry 2026-06-29.3 is an inference.batch_processing_jobs.v1 result-return and end-to-end flow pass and flips NO promise state. The batch lane now has code-backed submit -> queue -> consumer -> owner-scoped results -> closeout receipt coverage: executable dataset rows are enqueued, the consumer dispatches through the existing inference gateway, meters each successful item with batch=true, writes a private ARTIFACTS-backed results payload, stores the result key on the job row, GET /v1/inference/batches/{jobId}/results returns those results only to the owning agent token, and the public closeout receipt remains dereferenceable for completed jobs. This clears the stale unbuilt-surface wording, but the promise STAYS planned on first real paid batch-job receipt, collectable paid credits, and owner-signed green transition blockers. No live broad product claim, no green flip, no new spend authority, and no owner-signoff transition is created.',
       'Registry 2026-06-20.58 is a business.ecommerce_workspace_pack.v1 de-stale pass and flips NO promise state (stays yellow, green count unchanged at 26). The POST /api/public/ecommerce-campaign/workspaces route already exists, seeding workspaces using the forge.template.ecommerce.inventory_campaign.v1 template, so blocker.product_promises.ecommerce_pack_self_serve_missing is cleared. The promise remains yellow on blocker.product_promises.ecommerce_pack_first_paid_delivery_receipt_missing: no active operator route to record receipts exists, and no real paid delivery receipt, attribution, revenue claim, or green transition is created. Evidence: docs/launch/gemini-fleet/business.ecommerce_workspace_pack.v1.md.',
       'Registry 2026-06-21.1 is a DE-2 cloud primitive blocker de-stale pass and flips NO promise state (cloud.primitives_suite.v1 stays planned; cloud.fine_tuning_service.v1 and cloud.sandbox_compute_service.v1 stay red; green count unchanged). Fine-tuning and sandbox still are not live sellable services, but their route scaffolds are no longer accurately described as simply unbuilt: /v1/fine_tuning/jobs and /v1/sandboxes exist behind default-off flags, with typed request surfaces, lifecycle reads, cross-account isolation, TTL/isolation controls where applicable, and a tested receipt-first cloud-metering seam. Stale unbuilt blocker refs are replaced with narrower live-service blockers: live fine-tuning intake disabled, real fine-tuning runtime unwired, live sandbox rent surface disabled, sandbox live metering/billing unwired, and suite-level fine-tuning/sandbox live-sellable-service missing. No flags are armed, no runtime adapter is wired, no pricing is live, no credit debit or settlement occurs, and no paid receipt or green transition is created. Evidence: docs/inference/2026-06-19-cloud-primitives-fine-tuning-sandbox-scaffold-advance.md and apps/openagents.com/workers/api/src/cloud/*.',
       'Registry 2026-06-21.2 is a DE-2 cloud primitives unified-balance blocker de-stale pass and flips NO promise state (cloud.primitives_suite.v1 stays planned; green count unchanged). The composed-run source already models the one-shared-balance shape: buildComposedRunPlan carries a single ComposedRunBalance and receipt envelope, composeRunExecution folds component charge shapes into one composed spend, and the receipt gate checks one_shared_balance plus reconciliation. Therefore the stale blocker.product_promises.cloud_primitives_unified_balance_unbuilt is replaced with blocker.product_promises.cloud_primitives_live_unified_balance_debit_receipt_missing. The remaining gap is live multi-primitive execution debiting one real balance and producing a dereferenceable unified-balance receipt. No route is armed, no D1 balance is read/debited, no receipt row is written, no customer composed-run claim is created, and no green transition is created.',


### PR DESCRIPTION
## Summary
- Add an ARTIFACTS-backed batch job results payload/store and persist per-item success/failure results from the async batch consumer.
- Add authenticated `GET /v1/inference/batches/:jobId/results` retrieval with account isolation, plus route/consumer/end-to-end tests for submit -> process -> results -> receipt.
- Update `inference.batch_processing_jobs.v1` promise copy/verification to reflect the tested code-backed evidence while keeping the promise planned pending real paid receipt, collectable credits, and owner-signed green transition.

Closes #6835

## Verification
- `bun test workers/api/src/inference/batch-job-consumer.test.ts workers/api/src/inference/batch-job-routes.test.ts workers/api/src/inference/batch-job-flow.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:deploy`