### PR TITLE
Add X-claim reward smoke harness

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -1095,6 +1095,7 @@ import {
   handleOperatorTreasuryRecipientReportApi,
   handleOperatorTreasuryStatusApi,
   handleOperatorTreasuryTransactionReconcileApi,
+  handleOperatorXClaimRewardSmokeRunApi,
   handlePublicTreasuryLaunchStatusApi,
   reconcilePendingTreasuryTransactions,
 } from './treasury-routes'
@@ -1109,8 +1110,11 @@ import {
 } from './voice-program-ingest-routes'
 import { makeWorkerRouteRequest } from './worker-routes'
 import {
+  makeD1XClaimRewardRecipientResolver,
   makeD1XClaimRewardTreasuryDispatchStore,
+  makeXClaimRewardTreasuryClient,
   readXClaimRewardTreasuryDispatchConfig,
+  runXClaimRewardTreasuryDispatch,
   runXClaimRewardTreasuryDispatchScheduled,
   xClaimRewardDispatchDayStartIso,
 } from './x-claim-reward-treasury-dispatcher'
@@ -11463,6 +11467,29 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         requireAdminApiToken: adminRequest =>
           requireAdminApiToken(adminRequest, env),
       }),
+  },
+  {
+    path: '/api/operator/treasury/x-claim-reward-smoke',
+    handler: (request, env) => {
+      const db = openAgentsDatabase(env)
+      const store = makeD1XClaimRewardTreasuryDispatchStore(db)
+
+      return handleOperatorXClaimRewardSmokeRunApi(request, {
+        readRewardByRef: rewardRef => store.readRewardByRef(rewardRef),
+        requireAdminApiToken: adminRequest =>
+          requireAdminApiToken(adminRequest, env),
+        runRewardDispatch: () => {
+          const nowIso = currentIsoTimestamp()
+
+          return runXClaimRewardTreasuryDispatch({
+            config: readXClaimRewardTreasuryDispatchConfig(env, nowIso),
+            resolveRecipient: makeD1XClaimRewardRecipientResolver(db),
+            store,
+            treasury: makeXClaimRewardTreasuryClient(fetchMdkTreasuryPath(env)),
+          })
+        },
+      })
+    },
   },
   {
     path: '/api/operator/treasury/funding-destination',

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1787,6 +1787,12 @@ const schemaComponents = (): JsonSchema => ({
   XClaimRewardEligibilityStatusResponse: objectSummary(
     'Public-safe single X-claim reward eligibility projection resolved by reward id or receipt ref, with the four-state lifecycle position, digest-only identity refs, generatedAt, and the declared staleness contract. Eligibility is not a spendable balance and grants no payout authority.',
   ),
+  XClaimRewardSmokeRunRequest: objectSummary(
+    'Operator-only X-claim reward smoke run request with rewardRef (reward id or receipt ref) naming the single approved reward row to audit after the armed dispatcher runs.',
+  ),
+  XClaimRewardSmokeRunResponse: objectSummary(
+    'Operator-only public-safe X-claim reward smoke run report: kind, redacted reward summary, completion gate result, blocking reason refs, dispatch outcome counters, and optional product-promise transitionRequest. It never returns treasury payment ids, recipient destinations, invoices, preimages, payment hashes, or BOLT12 offers.',
+  ),
   ProviderAccountPoolResponse: objectSummary(
     'Account-pool dashboard projection over the connected provider accounts owned by the signed-in user or the agent grant owner: provider-tagged per-account status/health, lease eligibility with typed reasons, active lease count vs lease limit, cooldown-until plus remaining seconds, low-credit flags, recent failure class, last-selected/sanity-check/probe/launch timestamps, and reconnect nudges for expired or reauth-required accounts; plus the active lease list, the next-selection explain row, summary counts, generatedAt, and the declared staleness contract (live_at_read, rebuilds on provider-account connect/disconnect/health/lease/failover transitions). Read-only projection: lease refs and typed state only. Provider tokens, secrets, grants, and raw provider payloads are never returned, and the projection grants no lease, spend, or provider-mutation authority.',
   ),
@@ -9733,6 +9739,26 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Updated public-safe reward projection.',
           '#/components/schemas/XClaimRewardEnvelope',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/operator/treasury/x-claim-reward-smoke': {
+    post: operation({
+      operationId: 'runXClaimRewardTreasurySmoke',
+      summary: 'Run X-claim reward treasury smoke',
+      description:
+        'Admin-token-gated live smoke harness for the promotional X-claim reward dispatcher. When the treasury dispatch flag is armed, it runs the bounded dispatcher, resolves the named reward by id or receipt ref, and returns the composite public-safe completion gate: dispatch outcome, settled receipt audit, and optional product-promise transition request. The response is redacted and carries no treasury payment ids, recipient destinations, invoices, preimages, payment hashes, raw BOLT12 offers, wallet material, or payout authority.',
+      tags: ['Treasury'],
+      security: adminSession,
+      requestBody: jsonContent(
+        '#/components/schemas/XClaimRewardSmokeRunRequest',
+      ),
+      responses: {
+        '200': okJson(
+          'Public-safe X-claim reward smoke completion report.',
+          '#/components/schemas/XClaimRewardSmokeRunResponse',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -1995,15 +1995,17 @@ export const publicProductPromisesDocument = () => {
         claim:
           'An owner who verifies agent ownership with an X verification tweet can become eligible for a promotional 1000-sat reward.',
         safeCopy:
-          'Verified X owner claims record a 1000-sat reward eligibility row in a bounded campaign ledger with anti-Sybil dedupe (one reward per X account and per challenge) and a campaign budget cap. Eligibility, operator-approved dispatch, treasury dispatch, and settlement are separate states. The Worker-side dispatcher is implemented behind TREASURY_DISPATCH_ENABLED=false by default with BOLT12-only recipient resolution, per-run and per-day caps, pending-payment polling, public-safe status stats, and smoke gates for candidate, preflight, dispatch outcome, settlement evidence, settled receipt audit, and transition-request assembly. No owner-armed reward has completed a live dispatch smoke to a real receive code yet.',
+          'Verified X owner claims record a 1000-sat reward eligibility row in a bounded campaign ledger with anti-Sybil dedupe (one reward per X account and per challenge) and a campaign budget cap. Eligibility, operator-approved dispatch, treasury dispatch, and settlement are separate states. The Worker-side dispatcher is implemented behind TREASURY_DISPATCH_ENABLED=false by default with BOLT12-only recipient resolution, per-run and per-day caps, pending-payment polling, public-safe status stats, and an admin-gated smoke-run endpoint that executes the armed dispatcher for one named reward and returns only the composite public-safe completion report. No owner-armed reward has completed a live dispatch smoke to a real receive code yet.',
         unsafeCopy:
           'Do not claim verified owners are instantly or automatically paid, do not present eligibility as spendable balance or settlement, and do not describe the promotional reward as Forum tip settlement or accepted-work payout.',
         evidenceRefs: [
           'route:/api/agents/claims/{claimId}/x/verify',
           'route:/api/agents/claims/rewards/{rewardId}/dispatch',
+          'route:/api/operator/treasury/x-claim-reward-smoke',
           'apps/openagents.com/workers/api/migrations/0149_x_claim_reward_ledger.sql',
           'apps/openagents.com/workers/api/migrations/0164_x_claim_reward_treasury_dispatch.sql',
           'apps/openagents.com/workers/api/src/agent-owner-claim-routes.test.ts',
+          'apps/openagents.com/workers/api/src/treasury-routes.test.ts',
           'apps/openagents.com/workers/api/src/x-claim-reward-smoke-candidate.test.ts',
           'apps/openagents.com/workers/api/src/x-claim-reward-smoke-dispatch-outcome.test.ts',
           'apps/openagents.com/workers/api/src/x-claim-reward-smoke-receipt-audit.test.ts',
@@ -2015,7 +2017,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.x_claim_reward_live_dispatch_smoke_missing',
         ],
         verification:
-          'Run the agent-owner-claim reward tests, X-claim treasury dispatcher tests, and X-claim smoke harness tests: verified X claims must create eligibility with dedupe and budget refusal, dispatch transitions must be admin-gated, the dispatcher must stay flag-off by default, resolve only registered BOLT12 recipient identity, enforce caps, poll pending payments without re-paying, redact payment material, reject unsafe settlement evidence before persistence, and emit a transition request only after both the dispatch outcome and settled receipt audits pass. Green requires one live operator-dispatched reward settled to a real owner receive code with public-safe receipt refs and owner sign-off.',
+          'Run the agent-owner-claim reward tests, X-claim treasury dispatcher tests, treasury route tests, and X-claim smoke harness tests: verified X claims must create eligibility with dedupe and budget refusal, dispatch transitions must be admin-gated, the dispatcher must stay flag-off by default, resolve only registered BOLT12 recipient identity, enforce caps, poll pending payments without re-paying, redact payment material, reject unsafe settlement evidence before persistence, and have the operator smoke-run endpoint emit a transition request only after both the dispatch outcome and settled receipt audits pass. Green requires one live operator-dispatched reward settled to a real owner receive code with public-safe receipt refs and owner sign-off.',
         authorityBoundary:
           'Reward eligibility is a promotional campaign state, not Forum tip settlement, accepted-work payout, Treasury authority, or spendable balance. Dispatch requires the operator admin gate.',
       },

--- a/apps/openagents.com/workers/api/src/treasury-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/treasury-routes.test.ts
@@ -1,6 +1,7 @@
 import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
+import type { XClaimRewardRecord } from './agent-owner-claim-routes'
 import type { ContainerPathFetch } from './http/container-fetch'
 import type {
   TreasuryTransactionRecord,
@@ -16,10 +17,12 @@ import {
   handleOperatorTreasuryRecipientReportApi,
   handleOperatorTreasuryStatusApi,
   handleOperatorTreasuryTransactionReconcileApi,
+  handleOperatorXClaimRewardSmokeRunApi,
   handlePublicTreasuryLaunchStatusApi,
   reconcilePendingTreasuryTransactions,
   treasuryPayoutPlan,
 } from './treasury-routes'
+import type { XClaimRewardTreasuryDispatchSummary } from './x-claim-reward-treasury-dispatcher'
 
 const run = <A>(effect: Effect.Effect<A>): Promise<A> =>
   Effect.runPromise(effect)
@@ -36,6 +39,50 @@ const healthzPayload = (configured: boolean) => ({
   ok: true,
   serviceTokenConfigured: configured,
   service: 'openagents-mdk-treasury',
+})
+
+const settledXClaimReward = (
+  overrides: Partial<XClaimRewardRecord> = {},
+): XClaimRewardRecord => ({
+  agentUserId: 'user_agent_1',
+  amountSats: 1000,
+  challengeId: 'x_challenge_1',
+  claimId: 'agent_claim_1',
+  createdAt: '2026-06-10T10:00:00.000Z',
+  evidenceRefs: [
+    'receipt.public.x_claim.1',
+    'settlement_evidence.public.mdk_treasury.x_claim_reward_1',
+  ],
+  id: 'x_claim_reward_1',
+  ownerUserId: 'user_owner_1',
+  receiptRef: 'x_claim_reward_receipt_x_claim_reward_1',
+  state: 'settled',
+  stateReasonRef: null,
+  treasuryPaymentId: 'payment_secret_1',
+  updatedAt: '2026-06-10T12:00:00.000Z',
+  xAccountRef: 'x_account.public.owner_1',
+  ...overrides,
+})
+
+const xClaimRewardSmokeSummary = (
+  overrides: Partial<XClaimRewardTreasuryDispatchSummary> = {},
+): XClaimRewardTreasuryDispatchSummary => ({
+  failed: 0,
+  pending: 0,
+  polled: 0,
+  requested: 1,
+  settled: 1,
+  skippedReasonRefs: [],
+  stats: {
+    dailySatsCap: 5000,
+    enabled: true,
+    liquidityBufferSats: 11,
+    pendingPaymentCount: 0,
+    perRunRewardCap: 1,
+    requestedDispatchCount: 0,
+    todayReservedSats: 1000,
+  },
+  ...overrides,
 })
 
 const makeMemoryTransactionStore = (
@@ -428,6 +475,137 @@ describe('operator treasury status', () => {
 
     expect(response.status).toBe(200)
     expect('rewardDispatchSmokePreflight' in body).toBe(false)
+  })
+})
+
+describe('operator X-claim reward smoke run', () => {
+  const smokeRequest = (body: unknown) =>
+    new Request(
+      'https://openagents.com/api/operator/treasury/x-claim-reward-smoke',
+      {
+        body: JSON.stringify(body),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      },
+    )
+
+  test('requires the admin api token', async () => {
+    const response = await run(
+      handleOperatorXClaimRewardSmokeRunApi(
+        smokeRequest({ rewardRef: 'x_claim_reward_1' }),
+        {
+          readRewardByRef: () => Promise.resolve(settledXClaimReward()),
+          requireAdminApiToken: () => Promise.resolve(false),
+          runRewardDispatch: () => Promise.resolve(xClaimRewardSmokeSummary()),
+        },
+      ),
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  test('requires a reward ref', async () => {
+    const response = await run(
+      handleOperatorXClaimRewardSmokeRunApi(smokeRequest({}), {
+        readRewardByRef: () => Promise.resolve(settledXClaimReward()),
+        requireAdminApiToken: () => Promise.resolve(true),
+        runRewardDispatch: () => Promise.resolve(xClaimRewardSmokeSummary()),
+      }),
+    )
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'reward_ref_required',
+    })
+    expect(response.status).toBe(400)
+  })
+
+  test('runs the dispatcher and emits a public-safe completion report', async () => {
+    let dispatchRan = false
+    const response = await run(
+      handleOperatorXClaimRewardSmokeRunApi(
+        smokeRequest({ rewardRef: 'x_claim_reward_receipt_x_claim_reward_1' }),
+        {
+          readRewardByRef: rewardRef =>
+            Promise.resolve(
+              rewardRef === 'x_claim_reward_receipt_x_claim_reward_1'
+                ? settledXClaimReward()
+                : undefined,
+            ),
+          requireAdminApiToken: () => Promise.resolve(true),
+          runRewardDispatch: () => {
+            dispatchRan = true
+
+            return Promise.resolve(xClaimRewardSmokeSummary())
+          },
+        },
+      ),
+    )
+    const body = (await response.json()) as {
+      completion: {
+        ready: boolean
+        transitionRequest: { evidenceRefs: ReadonlyArray<string> } | null
+      }
+      reward: {
+        amountSats: number
+        receiptRef: string
+        rewardId: string
+        state: string
+      }
+    }
+    const serialized = JSON.stringify(body)
+
+    expect(response.status).toBe(200)
+    expect(dispatchRan).toBe(true)
+    expect(body.reward).toEqual({
+      amountSats: 1000,
+      receiptRef: 'x_claim_reward_receipt_x_claim_reward_1',
+      rewardId: 'x_claim_reward_1',
+      state: 'settled',
+    })
+    expect(body.completion.ready).toBe(true)
+    expect(body.completion.transitionRequest?.evidenceRefs).toEqual([
+      'x_claim_reward_receipt_x_claim_reward_1',
+      'settlement_evidence.public.mdk_treasury.x_claim_reward_1',
+    ])
+    expect(serialized).not.toContain('payment_secret_1')
+    expect(serialized).not.toMatch(/lno1[a-z0-9]{20,}/i)
+    expect(serialized).not.toMatch(/\b[0-9a-f]{64}\b/i)
+  })
+
+  test('withholds transition request when the dispatch run is not clean', async () => {
+    const response = await run(
+      handleOperatorXClaimRewardSmokeRunApi(
+        smokeRequest({ rewardRef: 'x_claim_reward_1' }),
+        {
+          readRewardByRef: () => Promise.resolve(settledXClaimReward()),
+          requireAdminApiToken: () => Promise.resolve(true),
+          runRewardDispatch: () =>
+            Promise.resolve(
+              xClaimRewardSmokeSummary({
+                pending: 1,
+                stats: {
+                  ...xClaimRewardSmokeSummary().stats,
+                  pendingPaymentCount: 1,
+                },
+              }),
+            ),
+        },
+      ),
+    )
+    const body = (await response.json()) as {
+      completion: {
+        blockingReasonRefs: ReadonlyArray<string>
+        ready: boolean
+        transitionRequest: unknown
+      }
+    }
+
+    expect(response.status).toBe(200)
+    expect(body.completion.ready).toBe(false)
+    expect(body.completion.transitionRequest).toBeNull()
+    expect(body.completion.blockingReasonRefs).toContain(
+      'reason.public.x_claim_reward_smoke_dispatch_payment_still_pending',
+    )
   })
 })
 

--- a/apps/openagents.com/workers/api/src/treasury-routes.ts
+++ b/apps/openagents.com/workers/api/src/treasury-routes.ts
@@ -1,5 +1,6 @@
 import { Effect } from 'effect'
 
+import type { XClaimRewardRecord } from './agent-owner-claim-routes'
 import { sha256Hex } from './agent-registration'
 import type { ContainerPathFetch } from './http/container-fetch'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
@@ -11,7 +12,11 @@ import type {
   TreasuryTransactionStore,
 } from './treasury-page-routes'
 import {
+  assertXClaimRewardSmokeCompletion,
+} from './x-claim-reward-smoke-completion'
+import {
   evaluateXClaimRewardSmokePreflight,
+  type XClaimRewardTreasuryDispatchSummary,
   type XClaimRewardTreasuryDispatchStats,
 } from './x-claim-reward-treasury-dispatcher'
 
@@ -47,6 +52,14 @@ export type TreasuryRouteDependencies = Readonly<{
     address: string,
     amountSat: number,
   ) => Promise<{ ok: true; bolt11: string } | { ok: false; reason: string }>
+}>
+
+export type XClaimRewardSmokeRunDependencies = Readonly<{
+  readRewardByRef: (
+    rewardRef: string,
+  ) => Promise<XClaimRewardRecord | undefined>
+  requireAdminApiToken: (request: Request) => Promise<boolean>
+  runRewardDispatch: () => Promise<XClaimRewardTreasuryDispatchSummary>
 }>
 
 type TreasuryHealth = Readonly<{
@@ -535,6 +548,93 @@ export const handleOperatorTreasuryStatusApi = (
               state: treasuryState(health),
             })
           }),
+        ),
+      )
+    }),
+  )
+}
+
+export const handleOperatorXClaimRewardSmokeRunApi = (
+  request: Request,
+  dependencies: XClaimRewardSmokeRunDependencies,
+) => {
+  if (request.method !== 'POST') {
+    return Effect.succeed(methodNotAllowed(['POST']))
+  }
+
+  return Effect.tryPromise({
+    catch: () => false,
+    try: () => dependencies.requireAdminApiToken(request),
+  }).pipe(
+    Effect.catch(() => Effect.succeed(false)),
+    Effect.flatMap(authorized => {
+      if (!authorized) {
+        return Effect.succeed(
+          noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 }),
+        )
+      }
+
+      return Effect.tryPromise({
+        catch: error =>
+          error instanceof Error
+            ? error
+            : new Error('x_claim_reward_smoke_run_failed'),
+        try: async () => {
+          let body: { rewardRef?: unknown } = {}
+
+          try {
+            body = (await request.json()) as typeof body
+          } catch {
+            return noStoreJsonResponse(
+              { error: 'invalid_json_body' },
+              { status: 400 },
+            )
+          }
+
+          const rewardRef =
+            typeof body.rewardRef === 'string' ? body.rewardRef.trim() : ''
+
+          if (rewardRef === '') {
+            return noStoreJsonResponse(
+              { error: 'reward_ref_required' },
+              { status: 400 },
+            )
+          }
+
+          const summary = await dependencies.runRewardDispatch()
+          const reward = await dependencies.readRewardByRef(rewardRef)
+
+          if (reward === undefined) {
+            return noStoreJsonResponse(
+              { error: 'x_claim_reward_not_found' },
+              { status: 404 },
+            )
+          }
+
+          const completion = assertXClaimRewardSmokeCompletion({
+            reward,
+            summary,
+          })
+
+          return noStoreJsonResponse({
+            completion,
+            kind: 'x_claim_reward_dispatch_smoke_run',
+            reward: {
+              amountSats: reward.amountSats,
+              receiptRef: reward.receiptRef,
+              rewardId: reward.id,
+              state: reward.state,
+            },
+          })
+        },
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(
+            noStoreJsonResponse(
+              { error: 'x_claim_reward_smoke_run_failed' },
+              { status: 503 },
+            ),
+          ),
         ),
       )
     }),

--- a/apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.test.ts
+++ b/apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.test.ts
@@ -168,6 +168,11 @@ class MemoryDispatchStore implements XClaimRewardTreasuryDispatchStore {
     todayReservedSats: await this.countTodayReservedSats(dayStartIso),
   })
 
+  readRewardByRef = async (rewardRef: string) =>
+    this.sortedRewards().find(
+      reward => reward.id === rewardRef || reward.receiptRef === rewardRef,
+    )
+
   settleReward = async (input: {
     evidenceRefs: ReadonlyArray<string>
     nowIso: string

--- a/apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.ts
+++ b/apps/openagents.com/workers/api/src/x-claim-reward-treasury-dispatcher.ts
@@ -114,6 +114,9 @@ export type XClaimRewardTreasuryDispatchStore = Readonly<{
     dayStartIso: string,
     config: XClaimRewardTreasuryDispatchConfig,
   ) => Promise<XClaimRewardTreasuryDispatchStats>
+  readRewardByRef: (
+    rewardRef: string,
+  ) => Promise<XClaimRewardRecord | undefined>
   settleReward: (input: {
     evidenceRefs: ReadonlyArray<string>
     nowIso: string
@@ -407,6 +410,20 @@ export const makeD1XClaimRewardTreasuryDispatchStore = (
           requested === null ? 0 : Number(requested.count),
         todayReservedSats,
       }
+    },
+    readRewardByRef: async rewardRef => {
+      const row = await db
+        .prepare(
+          `SELECT *
+             FROM x_claim_reward_ledger
+            WHERE id = ?
+               OR receipt_ref = ?
+            LIMIT 1`,
+        )
+        .bind(rewardRef, rewardRef)
+        .first<XClaimRewardRow>()
+
+      return row === null ? undefined : rowToReward(row)
     },
     settleReward: input =>
       updateReward({


### PR DESCRIPTION
Closes #6856.

## Summary
- Adds an admin-gated `POST /api/operator/treasury/x-claim-reward-smoke` harness that runs the armed X-claim treasury dispatcher for a named reward ref, then returns the composite public-safe completion report.
- Adds D1 reward lookup by reward id or receipt ref so the harness can audit the settled row without exposing treasury payment ids or recipient material.
- Updates OpenAPI and the `agents.x_claim_reward.v1` promise copy/evidence to document the smoke-run endpoint while keeping the promise yellow until a real owner-armed settled receipt exists.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/treasury-routes.test.ts src/x-claim-reward-treasury-dispatcher.test.ts src/x-claim-reward-smoke-completion.test.ts src/product-promises.test.ts` passed: 4 files, 87 tests.
- `bun run --cwd apps/openagents.com check:deploy` was run. It still fails at `check:architecture` on pre-existing unrelated dirty-worktree changes outside this PR: `workers/api/src/marketplace-composition-routes.ts` generic throws/raw JSON.parse and `apps/web/src/scene/tassadarCloudflareWorld.ts` raw time/id/random primitive. The X-claim smoke change's temporary Response-surface guard regression was removed; the guard now reports Worker Response return surfaces at budget `123/123`.
