### PR TITLE
Guard world-first promise claims

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -440,8 +440,9 @@ describe('public product promises document', () => {
       /latest stays 0\.2\.5|only published, installable Pylon|release candidate, not stable 0\.3\.0|Pylon v1\.0 is present in the monorepo as a release candidate/i,
     )
     expect(currentCopy).toContain('Pylon v1.0 has a stable source cut')
-    expect(currentCopy).toContain('Registry 2026-06-29.2')
+    expect(currentCopy).toContain('Registry 2026-06-29.3')
     expect(currentCopy).toContain('flips NO promise state')
+    expect(currentCopy).toContain('implements #7027')
     expect(currentCopy).toContain('Khala Desktop now carries source-level')
     expect(currentCopy).toContain('maxStalenessSeconds:0')
     const codexSuccessorPromise = decoded.promises.find(
@@ -797,6 +798,7 @@ describe('public product promises document', () => {
           evidenceRefs: expect.arrayContaining([
             'docs/transcripts/238.md',
             'docs/launch/2026-06-18-world-firsts-verification.md',
+            'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md',
           ]),
         }),
         expect.objectContaining({
@@ -814,6 +816,7 @@ describe('public product promises document', () => {
             'promise:compute.tassadar_executor_poc.v1',
             'docs/launch/2026-06-20-llm-computer-training-run-definition.md',
             'docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md',
+            'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md',
             'apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts',
           ]),
         }),
@@ -936,12 +939,18 @@ describe('public product promises document', () => {
           blockerRefs: expect.arrayContaining([
             'blocker.product_promises.world_first_agentic_sales_force_not_achieved',
           ]),
+          evidenceRefs: expect.arrayContaining([
+            'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md',
+          ]),
         }),
         expect.objectContaining({
           promiseId: 'claims.pursued_world_first_largest_sales_force.v1',
           state: 'planned',
           blockerRefs: expect.arrayContaining([
             'blocker.product_promises.world_first_largest_sales_force_not_achieved',
+          ]),
+          evidenceRefs: expect.arrayContaining([
+            'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md',
           ]),
         }),
         expect.objectContaining({

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -261,6 +261,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-28.3 implements #6891 for models.tassadar_percepta_executor.v1 and flips NO promise state. Pylon v1.0 now has a deterministic bounded CPU computation-transform fixture in apps/pylon/src/tassadar-cpu-transform-training.ts that runs one CPU-only optimization step, self-verifies loss improvement, emits receipt.models.tassadar_percepta_executor.cpu_transform_training.cpu_transform_fixture_v1, and keeps realBitcoinMoved:false / settlementState:not_settled. GET /api/public/models/tassadar-percepta-executor/cpu-transform-training-receipts now projects that public-safe receipt alongside the architecture and Artanis distillation dataset inputs, so the old pylon_v03_cpu_transform_training_receipts_missing blocker is replaced by blocker.product_promises.tassadar_cpu_transform_real_settlement_missing and blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing. The promise STAYS planned: this is one fixture-scale receipt, not a trained model, not a paid earning path, not model promotion, and not a green transition; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.1 implements #6848 for payments.accepted_outcome_economics.v1 and flips NO promise state. The accepted-outcome economics spine now has a dereferenceable contributor accrual bundle at GET /api/public/payments/contributor-accrual-bundle?economicsId=... plus the settlement bundle at GET /api/public/accepted-outcome/settlement/{economicsId}; together they compose a gross-margin receipt, contributor accrual ledger entries, and an eight-state settlement machine from one stored accepted-outcome economics row. Tests prove the ledger and receipt share the same economicsId, reconcile gross margin exactly, reconcile pending_payout to the distributable ledger pool, keep public projections free of internal cents/raw payment material, and surface missing contributor provenance honestly. The old source-level blockers contributor_ledger_missing and gross_margin_receipts_missing are replaced by real_accepted_outcome_receipt_missing and owner_signed_green_transition_missing. The promise STAYS red because source/fixture receipt machinery is not a real accepted outcome carried through a money-moving settlement path, and any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.2 is a current-main refresh after #6997/#6999/#7001/#7002/#7006 and flips NO promise state. The terminal-agent current-state audit and Codex tool-layer study are now cited as evidence for the Codex/Probe/Pylon runtime direction: current production coding delegation is still Pylon plus external agent SDK lanes and OpenAgents-native terminal tools remain a consolidation task, not a new green claim. The codex-supervisor LOCKOUT replenishment helper can create or reuse three bounded standing issues so owner-capacity supervisors do not idle indefinitely, but it creates no paid labor, payout, settlement, or broad availability claim. The inference router now has GLM own-capacity failover alerting and public-safe fallback telemetry for repeated no-headroom saturation, but the paid gateway still stays red until a dereferenceable paid receipt exists. Khala Desktop now carries source-level Electrobun Apple FM sidecar packaging/readiness plus redaction tests, but Apple FM local mode remains yellow until a signed/notarized from-install smoke with helper supervision exists. The Khala model-mix promise remains live-at-read with maxStalenessSeconds:0; the stale 2-second cache wording is not applied.',
+        'Registry 2026-06-29.3 implements #7027 and flips NO promise state. The world-first / largest-force claims now cite docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md as the dated blocker/evidence audit. claims.world_first_ai_training_paid_bitcoin.v1 stays red pending a dedicated qualified evidence pack plus owner-signed transition receipt; claims.world_first_public_llm_computer_training_run.v1 stays red pending owner-signed transition despite its narrowed evidence pack; claims.pursued_world_first_largest_agentic_sales_force.v1 and claims.pursued_world_first_largest_sales_force.v1 stay planned aspirations until a real sized force, independent review, dereferenceable evidence pack, and owner-signed receipt-first upgrade exist. Public copy remains limited to exact qualified wording and must reject unqualified world-first or record-holder language.',
       ],
     },
     promises: [
@@ -697,6 +698,7 @@ export const publicProductPromisesDocument = () => {
           'docs/transcripts/238.md',
           'docs/launch/2026-06-18-pylon-v1-launch-readiness-audit.md',
           'docs/launch/2026-06-18-world-firsts-verification.md',
+          'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md',
           'promise:training.decentralized_training_launch.v1',
           'promise:promises.registry.v1',
           'promise:proof.claim_upgrade_receipts.v1',
@@ -706,7 +708,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md; prior art checked includes Spirit of Satoshi, Bittensor/Templar, Gensyn, Prime Intellect, Nous/Psyche, Salad, Percepta, Tracr) with a defensible narrowed wording. Green still requires (1) a dereferenceable evidence pack tying the qualified world-first to the live run receipts and (2) an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then this stays red and any public use must carry the full qualifiers.',
+          'As of the 2026-06-29 #7027 audit (docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md), this remains red: the prior-art review supports only narrow, fully qualified wording, the dedicated paid-Bitcoin evidence pack is still missing, and no owner-signed receipt-first transition exists. Public copy may mention the bounded paid training evidence only with the Bitcoin + replay-verified training compute + own consumer-device qualifiers together.',
         authorityBoundary:
           'A launch transcript does not establish a world-first. The bounded real settlements prove payment to two contributors, not a first-in-the-world claim, and grant no network-scale or comparison authority.',
       },
@@ -728,6 +730,7 @@ export const publicProductPromisesDocument = () => {
           'docs/launch/2026-06-18-world-firsts-verification.md',
           'docs/launch/2026-06-20-llm-computer-training-run-definition.md',
           'docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md',
+          'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md',
           'apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts',
           'promise:compute.tassadar_executor_poc.v1',
           'promise:models.tassadar_percepta_executor.v1',
@@ -738,7 +741,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md) with a defensible narrowed wording crediting Percepta as the paradigm originator. A precise definition of "LLM-computer training run" now exists (docs/launch/2026-06-20-llm-computer-training-run-definition.md): it pins the phrase to the executor-construction / exact-trace sense (sense B), distinguishes it from gradient-descent model training (sense A), credits Percepta, and enumerates the refuse-list so the phrase cannot overclaim against the no-gradient-descent executor PoC. A focused, dereferenceable evidence pack now exists (docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md): it ties the qualified Claim-2 world-first to the live-run receipts qualifier-by-qualifier (public/open-contributor paid loop -> run summary + two contributor settlement receipts; Percepta paradigm credit -> Percepta blog/transformer-vm + prior-art search; executor/exact-trace/replay-verified -> verified+rejected replay pairs and a Verified challenge), with a skeptic-runnable verification recipe and a refuse-list. A regression guard (apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts) now machine-enforces that the pack and definition stay dereferenceable: every repo-relative doc they cite resolves on disk, every promise: evidence ref resolves to a real registry promiseId, the cleared definition/evidence-pack blockers stay cleared without flipping state, and the refuse-list plus Percepta credit stay in the copy. Green still requires an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1, and the underlying public paid loop remains bounded (two contributors, not at scale).',
+          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md) with a defensible narrowed wording crediting Percepta as the paradigm originator. A precise definition of "LLM-computer training run" now exists (docs/launch/2026-06-20-llm-computer-training-run-definition.md): it pins the phrase to the executor-construction / exact-trace sense (sense B), distinguishes it from gradient-descent model training (sense A), credits Percepta, and enumerates the refuse-list so the phrase cannot overclaim against the no-gradient-descent executor PoC. A focused, dereferenceable evidence pack now exists (docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md): it ties the qualified Claim-2 world-first to the live-run receipts qualifier-by-qualifier (public/open-contributor paid loop -> run summary + two contributor settlement receipts; Percepta paradigm credit -> Percepta blog/transformer-vm + prior-art search; executor/exact-trace/replay-verified -> verified+rejected replay pairs and a Verified challenge), with a skeptic-runnable verification recipe and a refuse-list. The 2026-06-29 #7027 audit (docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md) keeps the claim red until an owner-signed transition receipt exists and repeats the public-copy qualifiers: public/open-contributor, Percepta credit, executor-construction / exact-trace sense only, not gradient-descent model training. A regression guard (apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts) now machine-enforces that the pack and definition stay dereferenceable: every repo-relative doc they cite resolves on disk, every promise: evidence ref resolves to a real registry promiseId, the cleared definition/evidence-pack blockers stay cleared without flipping state, and the refuse-list plus Percepta credit stay in the copy. Green still requires an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1, and the underlying public paid loop remains bounded (two contributors, not at scale).',
         authorityBoundary:
           'A bounded exact-trace executor proof of concept grants no general LLM-computer capability claim and no world-first claim. The Tassadar research publication gates stay closed for everything beyond the scoped compute.tassadar_executor_poc.v1 promise.',
       },
@@ -3870,6 +3873,7 @@ export const publicProductPromisesDocument = () => {
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
+          'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md',
           'promise:referral.refer_once_earn_forever.v1',
           'promise:claims.world_first_ai_training_paid_bitcoin.v1',
         ],
@@ -3879,7 +3883,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'This record is intentionally never green from aspiration. Any future non-aspirational claim would require a real, sized, independently-countable agentic sales force, an independent prior-art / record review, a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then it stays a labeled pursuit.',
+          'This record is intentionally never green from aspiration. The 2026-06-29 #7027 audit (docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md) keeps it planned because no real, sized, independently-countable agentic sales force exists. Any future non-aspirational claim would require that force, an independent prior-art / record review, a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then it stays a labeled pursuit.',
         authorityBoundary:
           'A pursued world first grants no record-holder status, no marketing-claim authority, and no sales, payout, or settlement authority. Aspiration is not achievement.',
       },
@@ -3898,6 +3902,7 @@ export const publicProductPromisesDocument = () => {
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
+          'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md',
           'promise:claims.pursued_world_first_largest_agentic_sales_force.v1',
           'promise:claims.world_first_public_llm_computer_training_run.v1',
         ],
@@ -3907,7 +3912,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'This record is intentionally never green from aspiration. Any future non-aspirational claim would require independently verified counts crossing the stated bar, an independent prior-art / record review (with the comparison figure independently sourced, not ChatGPT-attributed), a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'This record is intentionally never green from aspiration. The 2026-06-29 #7027 audit (docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md) keeps it planned because the seven-million-agent bar is not met and the Avon comparison figure remains video-attributed, not independently sourced. Any future non-aspirational claim would require independently verified counts crossing the stated bar, an independent prior-art / record review (with the comparison figure independently sourced, not ChatGPT-attributed), a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'A pursued world first grants no record-holder status, no marketing-claim authority, and no sales, payout, or settlement authority. Aspiration is not achievement.',
       },

--- a/apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts
+++ b/apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts
@@ -15,10 +15,18 @@ const readRepoFile = (relPath: string): string =>
   readFileSync(repoFile(relPath), 'utf8')
 
 const PROMISE_ID = 'claims.world_first_public_llm_computer_training_run.v1'
+const PAID_BITCOIN_PROMISE_ID =
+  'claims.world_first_ai_training_paid_bitcoin.v1'
+const AGENTIC_SALES_FORCE_PROMISE_ID =
+  'claims.pursued_world_first_largest_agentic_sales_force.v1'
+const SALES_FORCE_PROMISE_ID =
+  'claims.pursued_world_first_largest_sales_force.v1'
 const DEFINITION_DOC =
   'docs/launch/2026-06-20-llm-computer-training-run-definition.md'
 const EVIDENCE_PACK_DOC =
   'docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md'
+const WORLD_FIRST_AUDIT_DOC =
+  'docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md'
 
 const docRefs = (markdown: string): ReadonlyArray<string> => [
   ...new Set(markdown.match(/docs\/[A-Za-z0-9._/-]+\.md/g) ?? []),
@@ -33,6 +41,17 @@ const claim2Promise = () => {
     throw new Error(`promise ${PROMISE_ID} not found in registry`)
   }
   return { document, promise }
+}
+
+const getPromise = (promiseId: string) => {
+  const document = publicProductPromisesDocument()
+  const promise = document.promises.find(
+    candidate => candidate.promiseId === promiseId,
+  )
+  if (!promise) {
+    throw new Error(`promise ${promiseId} not found in registry`)
+  }
+  return promise
 }
 
 describe('world-first LLM-computer evidence pack dereferenceability', () => {
@@ -115,5 +134,71 @@ describe('world-first LLM-computer evidence pack dereferenceability', () => {
     // Public copy must never authorize a bare "world first" claim.
     expect(promise.unsafeCopy).toContain('world first')
     expect(promise.safeCopy).toContain('Percepta')
+  })
+
+  test('the #7027 world-first audit is wired into every gated world-first claim', () => {
+    expect(repoFileExists(WORLD_FIRST_AUDIT_DOC)).toBe(true)
+
+    const promises = [
+      getPromise(PAID_BITCOIN_PROMISE_ID),
+      getPromise(PROMISE_ID),
+      getPromise(AGENTIC_SALES_FORCE_PROMISE_ID),
+      getPromise(SALES_FORCE_PROMISE_ID),
+    ]
+
+    for (const promise of promises) {
+      expect(promise.evidenceRefs).toContain(WORLD_FIRST_AUDIT_DOC)
+      expect(promise.verification).toContain('2026-06-29 #7027 audit')
+    }
+  })
+
+  test('the #7027 audit keeps red/planned states and owner-signed blockers', () => {
+    expect(getPromise(PAID_BITCOIN_PROMISE_ID)).toEqual(
+      expect.objectContaining({
+        state: 'red',
+        blockerRefs: expect.arrayContaining([
+          'blocker.product_promises.world_first_evidence_pack_missing',
+          'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+        ]),
+      }),
+    )
+    expect(getPromise(PROMISE_ID)).toEqual(
+      expect.objectContaining({
+        state: 'red',
+        blockerRefs: expect.arrayContaining([
+          'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+        ]),
+      }),
+    )
+    expect(getPromise(AGENTIC_SALES_FORCE_PROMISE_ID)).toEqual(
+      expect.objectContaining({
+        state: 'planned',
+        blockerRefs: expect.arrayContaining([
+          'blocker.product_promises.world_first_agentic_sales_force_not_achieved',
+          'blocker.product_promises.world_first_agentic_sales_force_no_sized_verifiable_force',
+          'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+        ]),
+      }),
+    )
+    expect(getPromise(SALES_FORCE_PROMISE_ID)).toEqual(
+      expect.objectContaining({
+        state: 'planned',
+        blockerRefs: expect.arrayContaining([
+          'blocker.product_promises.world_first_largest_sales_force_not_achieved',
+          'blocker.product_promises.world_first_largest_sales_force_seven_million_bar_unmet',
+          'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+        ]),
+      }),
+    )
+  })
+
+  test('the #7027 audit carries a refuse-list for unqualified public copy', () => {
+    const audit = readRepoFile(WORLD_FIRST_AUDIT_DOC)
+
+    expect(audit).toContain('Refuse-List')
+    expect(audit).toContain('bare "world first" framing')
+    expect(audit).toContain('OpenAgents has the largest agentic sales force')
+    expect(audit).toContain('has met the seven-million-agent bar')
+    expect(audit).toContain('owner-signed transition receipt')
   })
 })

--- a/docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md
+++ b/docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md
@@ -1,0 +1,57 @@
+# World-First Claims Qualified Evidence Audit
+
+Issue: #7027
+Date: 2026-06-29
+
+This audit keeps the current world-first and largest-force promises honest. It
+does not promote any claim. The only claim with a focused evidence pack remains
+blocked on an owner-signed transition receipt, and the other claims stay red or
+planned until their missing evidence exists.
+
+## Claim Status
+
+| Promise | State | Decision |
+| --- | --- | --- |
+| `claims.world_first_ai_training_paid_bitcoin.v1` | `red` | Keep red. The prior-art review supports only narrow, fully qualified wording: Bitcoin plus replay-verified training compute plus own consumer devices together. A dereferenceable evidence pack and owner-signed upgrade are still missing. |
+| `claims.world_first_public_llm_computer_training_run.v1` | `red` | Keep red. The definition and focused evidence pack exist for the narrowed public/open-contributor LLM-computer training-run wording, with Percepta credit and executor-construction qualifiers. Green still requires an owner-signed transition receipt. |
+| `claims.pursued_world_first_largest_agentic_sales_force.v1` | `planned` | Keep planned. This is an aspiration from Episode 239, not an achieved record. A real, sized, independently countable agentic sales force does not exist yet. |
+| `claims.pursued_world_first_largest_sales_force.v1` | `planned` | Keep planned. The seven-million-agent bar is not met, and the Avon comparison cited in the video is not an OpenAgents-verified statistic. |
+
+## Allowed Wording
+
+- Paid-Bitcoin training claim: use only qualified wording that preserves all
+  three qualifiers together: Bitcoin, replay-verified training compute, and own
+  consumer devices. Do not use bare "world first" framing.
+- Public LLM-computer claim: use only the narrowed
+  "public/open-contributor LLM-computer training run" wording, credit Percepta,
+  and state that "training run" means executor construction / exact-trace work,
+  not gradient-descent model training.
+- Largest-force claims: describe only as a pursuit or aspiration until there is
+  a real, sized, independently countable force, independent prior-art / record
+  review, dereferenceable evidence pack, and owner-signed transition receipt.
+
+## Refuse-List
+
+Product and marketing copy must not say or imply:
+
+- OpenAgents has already achieved any unqualified "world first" claim.
+- OpenAgents ran the first AI training paid in Bitcoin without the full
+  Bitcoin plus replay-verified training compute plus own consumer-device
+  qualifiers.
+- OpenAgents invented the LLM-computer, owns a general LLM-computer capability,
+  or ran gradient-descent model training under the LLM-computer claim.
+- OpenAgents has the largest agentic sales force, holds the largest sales-force
+  record, has met the seven-million-agent bar, or has independently verified
+  the Avon comparison statistic.
+
+## Receipt Gates
+
+Future promotion of any non-aspirational world-first or largest-force claim
+requires all of the following:
+
+- Dereferenceable evidence pack tied to public receipts.
+- Independent prior-art or record review for the exact wording.
+- Exact qualifier language in the promise safe copy.
+- Owner-signed receipt-first transition under
+  `proof.claim_upgrade_receipts.v1`.
+

--- a/docs/promises/registry.md
+++ b/docs/promises/registry.md
@@ -1,5 +1,19 @@
 # Promise Registry
 
+> Registry `2026-06-29.3` implements #7027 and flips NO promise state. The
+> world-first / largest-force claims now cite
+> [`docs/promises/2026-06-29-world-first-claims-qualified-evidence-audit.md`](2026-06-29-world-first-claims-qualified-evidence-audit.md)
+> as the dated blocker/evidence audit. `claims.world_first_ai_training_paid_bitcoin.v1`
+> stays red pending a dedicated qualified evidence pack plus owner-signed
+> transition receipt; `claims.world_first_public_llm_computer_training_run.v1`
+> stays red pending owner-signed transition despite its narrowed evidence pack;
+> `claims.pursued_world_first_largest_agentic_sales_force.v1` and
+> `claims.pursued_world_first_largest_sales_force.v1` stay planned aspirations
+> until a real sized force, independent review, dereferenceable evidence pack,
+> and owner-signed receipt-first upgrade exist. Public copy remains limited to
+> exact qualified wording and must reject unqualified world-first or
+> record-holder language.
+>
 > Registry `2026-06-29.2` is a current-main refresh after #6997, #6999,
 > #7001, #7002, and #7006 and flips NO promise state. It records the
 > terminal-agent current-state audit and Codex tool-layer study as evidence for
@@ -66,9 +80,9 @@
 > Current machine-readable source of truth: `/api/public/product-promises` is
 > generated from
 > [`product-promises.ts`](../../apps/openagents.com/workers/api/src/product-promises.ts),
-> which currently advertises registry `2026-06-29.2` with
+> which currently advertises registry `2026-06-29.3` with
 > `lastUpdated: "2026-06-29"`. This narrative document records the same
-> top-line 2026-06-29.2 promise decisions above, plus historical reconciliation
+> top-line 2026-06-29.3 promise decisions above, plus historical reconciliation
 > context below; when in doubt, agents and reviewers should defer to the
 > machine-readable registry and include its version in mismatch reports.
 >
@@ -76,7 +90,7 @@
 > Tassadar CPU-transform, referral, small-model proxy, WASM plugin, Verse scene,
 > native email, marketplace, metrics, terminal-agent audit, supervisor
 > replenishment, GLM failover, Apple FM sidecar, and operator-safety merges were
-> checked against the current `2026-06-29.2` registry header. This pass records
+> checked against the current `2026-06-29.3` registry header. This pass records
 > no additional promise state flips and no new green claims beyond the already
 > source-recorded scoped transitions; red/planned/yellow records keep their
 > owner-signed, receipt-first green gates.


### PR DESCRIPTION
## Summary

- Adds a dated #7027 audit for world-first and largest-force promise wording, blockers, and refusal language.
- Bumps the product-promise registry to 2026-06-29.3 without state flips and wires the audit into the four gated claims.
- Extends promise tests so the audit remains dereferenceable and the claims stay red/planned behind owner-signed receipt gates.

## Verification

- `bun test apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts apps/openagents.com/workers/api/src/product-promises.test.ts`
- `bun test scripts/qa-pre-push-smoke.test.ts` (`command.public.pylon_khala.verify.6a93af317040c3caab50af69`)

Closes #7027
