### PR TITLE
docs(autopilot): align fanout marketplace claim text

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -2460,25 +2460,25 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     (`generatedAt`, `live_at_read` contract). The surface is flag-gated
     (`SELF_SERVE_FANOUT_ENABLED`, default off => empty store) and the payload
     always reports `inert: true` / `promiseState: 'yellow'` / `selfServe: true`
-    / `workClass: 'code_task'`, surfacing the cleared self-serve blocker and the
-    still-uncleared plugin-marketplace blocker. It models a customer-initiated
-    single-action fanout plan (the lane-C gate decision plus the linked market
-    work-request the fanout would list) over the existing server-side lane-C
-    gate. The dispatch seam (`dispatchSelfServeFanout`) is flag-gated INERT and
-    is unreachable from this read-only route; the surface lists nothing on the
-    market and moves no money.
+    plus a typed marketplace work class, surfacing the cleared self-serve and
+    plugin-marketplace-beyond-code_task blockers at the planner/catalog level.
+    It models a customer-initiated single-action fanout plan (the lane-C gate
+    decision plus the linked market work-request the fanout would list) over the
+    existing server-side lane-C gate. The dispatch seam
+    (`dispatchSelfServeFanout`) is flag-gated INERT and is unreachable from this
+    read-only route; the surface lists nothing on the market and moves no money.
   - `GET /api/public/autopilot/marketplace-work-classes` — live at read over the
     in-module marketplace work-class catalog (promise
     `autopilot.control_center_fanout_marketplace.v1`, yellow) — compliant
     (`generatedAt`, `live_at_read` contract). Read-only registry view: it lists
-    every registered work class with its `status`, names the single live class
-    (`code_task`), and always reports `pluginMarketplaceBeyondCodeTaskLive: false`
-    with the still-uncleared plugin-marketplace-beyond-code_task blocker in
-    `unclearedBlockerRefs`. Optional `?workClass=` narrows to one class. No flag
-    and no store: `assertCatalogInvariants` (inside the projection) throws rather
-    than let any plugin class silently flip live, so the surface can never
-    over-claim a live plugin marketplace; it lists nothing executable and moves no
-    money.
+    every registered work class with its `status`, names the live classes
+    (`code_task` and `data_labeling`), and reports
+    `pluginMarketplaceBeyondCodeTaskLive: true` with no uncleared
+    plugin-marketplace-beyond-code_task blocker in `unclearedBlockerRefs`.
+    Optional `?workClass=` narrows to one class. No flag and no store:
+    `assertCatalogInvariants` (inside the projection) throws rather than let a
+    misedit silently over-claim support, so the surface can never overstate a
+    green marketplace; it lists no market job and moves no money.
   - `GET /api/public/markets/signature-monetization/metering` — live at read
     over the INERT signature usage-metering store (promise
     `marketplace.signature_monetization.v1`, red) — compliant (`generatedAt`,

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -323,11 +323,12 @@ const budgetChecks = [
     // +1 (93 -> 94) for the marketplace work-class catalog surface
     // (marketplace-work-class-catalog-routes.ts,
     // autopilot.control_center_fanout_marketplace.v1, yellow): a read-only
-    // registry projection of the listable marketplace work classes that always
-    // reports the still-uncleared plugin-marketplace-beyond-code_task blocker and
-    // clears nothing. It returns `Effect.Effect<Response>` like the sibling
-    // public read handlers. Ratchet back down when these public-projection
-    // handlers are extracted behind shared route mappers.
+    // registry projection of the listable marketplace work classes, including
+    // the live non-code `data_labeling` class that clears the
+    // plugin-marketplace-beyond-code_task blocker at the catalog/planner level
+    // while keeping the promise yellow. It returns `Effect.Effect<Response>` like
+    // the sibling public read handlers. Ratchet back down when these
+    // public-projection handlers are extracted behind shared route mappers.
     // +1 (94 -> 95) for the OpenAI-compatible single-model retrieve dispatcher
     // (inference/models-routes.ts, inference.gateway_credits_business.v1, red):
     // routeModelRetrieveRequest dispatches the path-param GET /v1/models/{model}

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -10887,12 +10887,13 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     // Self-serve control-center fanout scaffold (promise
     // autopilot.control_center_fanout_marketplace.v1, yellow). INERT: the store
     // is empty unless SELF_SERVE_FANOUT_ENABLED is armed, and the response
-    // always reports inert/yellow/selfServe with workClass code_task. It models
-    // a customer-initiated single-action fanout plan (gate decision + the linked
-    // market work-request the fanout would list) over the existing lane-C gate;
-    // the dispatch seam (dispatchSelfServeFanout) lists nothing. It clears only
-    // the self-serve blocker (the plugin-marketplace-beyond-code_task blocker
-    // stays uncleared) and makes no broad-live-marketplace claim. Read-only.
+    // always reports inert/yellow/selfServe with typed marketplace work classes.
+    // It models a customer-initiated single-action fanout plan (gate decision +
+    // the linked market work-request the fanout would list) over the existing
+    // lane-C gate; the dispatch seam (dispatchSelfServeFanout) lists nothing.
+    // It clears the self-serve and plugin-marketplace-beyond-code_task blockers
+    // at the planner/catalog level, but still makes no green broad-live-
+    // marketplace claim. Read-only.
     path: SelfServeFanoutEndpoint,
     handler: (request, env) =>
       handleSelfServeFanoutApi(request, {
@@ -10902,11 +10903,12 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
   {
     // Marketplace work-class catalog (promise
     // autopilot.control_center_fanout_marketplace.v1, yellow). Read-only registry
-    // view: it lists every registered work class with its status, names the single
-    // live class (code_task), and always reports the still-uncleared
-    // plugin-marketplace-beyond-code_task blocker. No flag, no store, nothing
-    // executable — the projection's assertCatalogInvariants throws rather than let
-    // any plugin class silently flip live. Makes no broad-live-marketplace claim.
+    // view: it lists every registered work class with its status, names the live
+    // classes (`code_task` and `data_labeling`), and reports no uncleared
+    // plugin-marketplace-beyond-code_task blocker. No flag, no store, and no
+    // dispatch side effect — the projection's assertCatalogInvariants throws
+    // rather than let a misedit silently over-claim support. Makes no green
+    // broad-live-marketplace claim.
     path: MarketplaceWorkClassCatalogEndpoint,
     handler: request => handleMarketplaceWorkClassCatalogApi(request),
   },

--- a/apps/openagents.com/workers/api/src/marketplace-work-class-catalog-routes.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-work-class-catalog-routes.ts
@@ -2,13 +2,14 @@
 // (promise autopilot.control_center_fanout_marketplace.v1, yellow).
 //
 // HONESTY / SCOPE: this route exposes the catalog projection unchanged. It is
-// ALWAYS honest: `inert: true`, `promiseState: 'yellow'`, the single live work
-// class (`code_task`), and the still-uncleared plugin-marketplace-beyond-code_task
-// blocker. There is NO flag and NO store to arm here because the catalog makes no
-// live claim of its own — `code_task` is the only live class and
+// ALWAYS honest: `inert: false`, `promiseState: 'yellow'`, the live work
+// classes (`code_task` and `data_labeling`), and no uncleared
+// plugin-marketplace-beyond-code_task blocker. There is NO flag and NO store to
+// arm here because the catalog itself only declares typed work-class contracts;
 // `assertCatalogInvariants` (called inside the projection) throws rather than let
-// any plugin class silently flip live. This route lists nothing executable; it is
-// purely a read-only registry view. Read-only (GET only).
+// a misedit silently over-claim live fanout support. This route lists no market
+// job, opens no escrow, and moves no money; it is purely a read-only registry
+// view. Read-only (GET only).
 
 import { Effect } from 'effect'
 


### PR DESCRIPTION
## Summary
- Align the self-serve fanout route comments, marketplace work-class catalog route comments, architecture allowance, and invariant ledger with the implemented #6893 state.
- Record that `data_labeling` is a live non-code work class at the planner/catalog level, with the plugin-marketplace-beyond-code-task blocker cleared while the promise remains yellow until receipt-first owner-signed settlement.

Closes #6893

## Verification
- `bun test apps/openagents.com/workers/api/src/marketplace-work-class-catalog.test.ts apps/openagents.com/workers/api/src/marketplace-work-class-catalog-routes.test.ts apps/openagents.com/workers/api/src/self-serve-fanout.test.ts apps/openagents.com/workers/api/src/autopilot-work-routes.test.ts`
- `bun run --cwd apps/openagents.com check:deploy`
