### PR TITLE
docs(promises): audit desktop DMG compute gate

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -440,10 +440,39 @@ describe('public product promises document', () => {
       /latest stays 0\.2\.5|only published, installable Pylon|release candidate, not stable 0\.3\.0|Pylon v1\.0 is present in the monorepo as a release candidate/i,
     )
     expect(currentCopy).toContain('Pylon v1.0 has a stable source cut')
-    expect(currentCopy).toContain('Registry 2026-06-29.2')
+    expect(currentCopy).toContain('Registry 2026-06-29.3')
     expect(currentCopy).toContain('flips NO promise state')
+    expect(currentCopy).toContain('audits #7023')
     expect(currentCopy).toContain('Khala Desktop now carries source-level')
     expect(currentCopy).toContain('maxStalenessSeconds:0')
+    const desktopPromise = decoded.promises.find(
+      promise => promise.promiseId === 'autopilot.desktop_gui_client.v1',
+    )
+    expect(desktopPromise?.state).toBe('yellow')
+    expect(desktopPromise?.evidenceRefs).toContain(
+      'docs/promises/2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md',
+    )
+    expect(desktopPromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.autopilot_desktop_from_dmg_proof_owner_gated',
+        'blocker.product_promises.autopilot_desktop_live_runtimes_not_wired',
+        'blocker.product_promises.autopilot_desktop_pricing_distribution_undecided',
+      ]),
+    )
+    const builtinComputePromise = decoded.promises.find(
+      promise => promise.promiseId === 'autopilot.builtin_compute_agent.v1',
+    )
+    expect(builtinComputePromise?.state).toBe('yellow')
+    expect(builtinComputePromise?.evidenceRefs).toContain(
+      'docs/promises/2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md',
+    )
+    expect(builtinComputePromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.builtin_compute_agent_signed_recut_missing',
+        'blocker.product_promises.builtin_compute_agent_live_from_install_smoke_missing',
+        'blocker.product_promises.openagents_compute_metering_live_smoke_missing',
+      ]),
+    )
     const codexSuccessorPromise = decoded.promises.find(
       promise => promise.promiseId === 'autopilot.codex_probe_pylon_successor.v1',
     )

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -66,6 +66,7 @@ const sourceRefs = [
   'apps/openagents.com/workers/api/src/inference/model-router.ts',
   'apps/openagents.com/workers/api/src/inference/model-router.test.ts',
   'docs/apple-fm/2026-06-29-electrobun-apple-fm-swift-sidecar-plan.md',
+  'docs/promises/2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md',
   'clients/khala-desktop/src/bun/apple-fm-sidecar.ts',
   'clients/khala-desktop/src/shared/apple-fm-packaging.ts',
   'clients/khala-desktop/src/shared/apple-fm-readiness.ts',
@@ -261,6 +262,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-28.3 implements #6891 for models.tassadar_percepta_executor.v1 and flips NO promise state. Pylon v1.0 now has a deterministic bounded CPU computation-transform fixture in apps/pylon/src/tassadar-cpu-transform-training.ts that runs one CPU-only optimization step, self-verifies loss improvement, emits receipt.models.tassadar_percepta_executor.cpu_transform_training.cpu_transform_fixture_v1, and keeps realBitcoinMoved:false / settlementState:not_settled. GET /api/public/models/tassadar-percepta-executor/cpu-transform-training-receipts now projects that public-safe receipt alongside the architecture and Artanis distillation dataset inputs, so the old pylon_v03_cpu_transform_training_receipts_missing blocker is replaced by blocker.product_promises.tassadar_cpu_transform_real_settlement_missing and blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing. The promise STAYS planned: this is one fixture-scale receipt, not a trained model, not a paid earning path, not model promotion, and not a green transition; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.1 implements #6848 for payments.accepted_outcome_economics.v1 and flips NO promise state. The accepted-outcome economics spine now has a dereferenceable contributor accrual bundle at GET /api/public/payments/contributor-accrual-bundle?economicsId=... plus the settlement bundle at GET /api/public/accepted-outcome/settlement/{economicsId}; together they compose a gross-margin receipt, contributor accrual ledger entries, and an eight-state settlement machine from one stored accepted-outcome economics row. Tests prove the ledger and receipt share the same economicsId, reconcile gross margin exactly, reconcile pending_payout to the distributable ledger pool, keep public projections free of internal cents/raw payment material, and surface missing contributor provenance honestly. The old source-level blockers contributor_ledger_missing and gross_margin_receipts_missing are replaced by real_accepted_outcome_receipt_missing and owner_signed_green_transition_missing. The promise STAYS red because source/fixture receipt machinery is not a real accepted outcome carried through a money-moving settlement path, and any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.2 is a current-main refresh after #6997/#6999/#7001/#7002/#7006 and flips NO promise state. The terminal-agent current-state audit and Codex tool-layer study are now cited as evidence for the Codex/Probe/Pylon runtime direction: current production coding delegation is still Pylon plus external agent SDK lanes and OpenAgents-native terminal tools remain a consolidation task, not a new green claim. The codex-supervisor LOCKOUT replenishment helper can create or reuse three bounded standing issues so owner-capacity supervisors do not idle indefinitely, but it creates no paid labor, payout, settlement, or broad availability claim. The inference router now has GLM own-capacity failover alerting and public-safe fallback telemetry for repeated no-headroom saturation, but the paid gateway still stays red until a dereferenceable paid receipt exists. Khala Desktop now carries source-level Electrobun Apple FM sidecar packaging/readiness plus redaction tests, but Apple FM local mode remains yellow until a signed/notarized from-install smoke with helper supervision exists. The Khala model-mix promise remains live-at-read with maxStalenessSeconds:0; the stale 2-second cache wording is not applied.',
+        'Registry 2026-06-29.3 audits #7023 and flips NO promise state. autopilot.desktop_gui_client.v1 and autopilot.builtin_compute_agent.v1 stay yellow; the audit records the exact fresh signed/notarized DMG, clean external Mac render/presence/runtime, packaged compute entitlement, no-user-key Go online, bounded session, usage/quota, and owner-approval refs required before either promise can move green. No blocker is cleared: the from-DMG proof, live runtime wiring, signed recut, packaged compute smoke, metering evidence, pricing/distribution decision, and owner-signed transition remain required.',
       ],
     },
     promises: [
@@ -2836,6 +2838,7 @@ export const publicProductPromisesDocument = () => {
           'apps/autopilot-desktop/scripts/auto-onboarding-e2e-smoke.ts',
           'docs/launch/2026-06-18-autopilot-desktop-availability-audit.md',
           'docs/launch/2026-06-18-autopilot-desktop-ao6-from-dmg-runbook.md',
+          'docs/promises/2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md',
           'docs/autopilot-coder/2026-06-13-autopilot-desktop-app-audit.md',
           'docs/autopilot-coder/2026-06-13-autopilot-desktop-reality-vs-claim-status.md',
           'docs/autopilot-coder/2026-06-14-cloud-desktop-mobile-coding-sessions-full-flow-audit.md',
@@ -3236,6 +3239,7 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/builtin-compute-agent-metering-smoke.ts',
           'apps/openagents.com/workers/api/src/builtin-compute-agent-metering-smoke.test.ts',
           'docs/launch/2026-06-19-coding-agent-live-verification.md',
+          'docs/promises/2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md',
         ],
         blockerRefs: [
           'blocker.product_promises.builtin_compute_agent_signed_recut_missing',

--- a/docs/promises/2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md
+++ b/docs/promises/2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md
@@ -1,0 +1,105 @@
+# Autopilot Desktop From-DMG + Builtin Compute Gate Audit
+
+> Status: public-safe issue #7023 audit, 2026-06-29. This record flips no
+> product-promise state. It narrows the remaining closure gates for
+> `autopilot.desktop_gui_client.v1` and
+> `autopilot.builtin_compute_agent.v1` without claiming owner-gated installer
+> proof exists.
+
+## Scope
+
+Issue #7023 asks for the clean-Mac from-DMG proof needed before the desktop GUI
+and built-in compute promises can move past yellow. The source registry already
+keeps both promises yellow and names the relevant blockers:
+
+- `blocker.product_promises.autopilot_desktop_from_dmg_proof_owner_gated`
+- `blocker.product_promises.autopilot_desktop_live_runtimes_not_wired`
+- `blocker.product_promises.autopilot_desktop_remote_cloud_lane_not_wired`
+- `blocker.product_promises.autopilot_desktop_pricing_distribution_undecided`
+- `blocker.product_promises.builtin_compute_agent_signed_recut_missing`
+- `blocker.product_promises.builtin_compute_agent_live_from_install_smoke_missing`
+- `blocker.product_promises.openagents_compute_metering_live_smoke_missing`
+
+This audit keeps those blockers intact. It records the exact evidence bundle a
+future owner-run release proof must attach so the next pass can be mechanical
+rather than interpretive.
+
+## Current Evidence
+
+The desktop GUI has source and test evidence for the local shell, local Pylon
+loopback, first-run onboarding, AO-3 identity choice, AO-4 status projection,
+black-screen guard, and AO-6 headless smoke. The runtime cores for PDF,
+loopback Sites preview, asset ingestion, and browser automation are built behind
+test seams, but their live desktop runtime wiring is not yet proven from the
+installer.
+
+The built-in compute agent has source and test evidence for the first-screen
+Go online path, built-in-agent RPC, hosted-compute readiness checks, managed
+scratch workspace, local daily-start cap, bounded session start, and the
+metering smoke projection. The already-published installer is not evidence for
+that source because it predates the source change.
+
+## Required From-DMG Bundle
+
+A closure-quality proof for `autopilot.desktop_gui_client.v1` needs public-safe
+refs for all of the following:
+
+- Fresh signed and notarized DMG built from the target release commit.
+- Clean external Apple Silicon Mac install launched from Finder, not from a
+  source checkout or terminal.
+- Rendered Autopilot Desktop window screenshot or video proving no black-screen
+  regression.
+- Production `/api/public/pylon-stats` appearance for the freshly installed
+  local Pylon.
+- Local session list, decision cards, and event timeline populated from
+  public-safe projections.
+- Live runtime proof for PDF rendering, loopback Sites preview, asset ingestion,
+  and browser automation through the packaged desktop runtime.
+- Distribution and pricing decision refs, or an explicit registry narrowing
+  that removes those claims from the desktop promise.
+
+## Required Builtin Compute Bundle
+
+A closure-quality proof for `autopilot.builtin_compute_agent.v1` needs
+public-safe refs for all of the following:
+
+- Signed and notarized recut that includes the built-in-agent source.
+- Packaged OpenAgents compute entitlement or credential resolution, represented
+  only by public-safe refs.
+- From-install Go online session with no user-supplied provider key.
+- Bounded session closeout proving the daily session and token ceilings held.
+- Exact usage or quota ledger row refs for the metered compute path.
+- Public quota projection refs showing sessions remaining and reset timing.
+- Operator approval refs for any live hosted-compute spend or production
+  activation.
+
+The existing `builtin-compute-agent-metering-smoke` projection is the expected
+shape for the built-in compute bundle. CI-mode projection tests are not a
+substitute for live signed-install evidence.
+
+## Promise Decision
+
+No promise state changes in this audit:
+
+- `autopilot.desktop_gui_client.v1` stays yellow.
+- `autopilot.builtin_compute_agent.v1` stays yellow.
+
+No blocker is cleared. The audit moves #7023 forward by making the release proof
+checklist explicit and adding it as dereferenceable evidence on both promise
+records. A future green transition still requires the owner-run proof bundle,
+owner sign-off, and a receipt-first transition record via
+`POST /api/operator/product-promises/transitions`.
+
+## Focused Verification
+
+Run the product-promise registry test after updating the registry refs:
+
+```sh
+bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts
+```
+
+Run the built-in compute projection test when touching the smoke shape:
+
+```sh
+bun run --cwd apps/openagents.com/workers/api test -- src/builtin-compute-agent-metering-smoke.test.ts
+```

--- a/docs/promises/README.md
+++ b/docs/promises/README.md
@@ -95,6 +95,11 @@ Product Promises Forum.
   the gate review for `autopilot.repo_study_packets.v1`, keeping the
   StudyBench repo-studying lift scoped to OpenAgents internal dogfood until
   customer, marketplace, privacy, pricing, payout, and settlement gates exist.
+- [`2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md`](2026-06-29-autopilot-desktop-dmg-compute-gate-audit.md):
+  the #7023 audit for `autopilot.desktop_gui_client.v1` and
+  `autopilot.builtin_compute_agent.v1`, recording the fresh signed-DMG,
+  clean-Mac, packaged compute, and metered from-install proof bundle required
+  before those yellow promises can move green.
 - [`templates/promise-record.md`](templates/promise-record.md): a reusable
   promise record template.
 - [`templates/promise-report.md`](templates/promise-report.md): a reusable

--- a/docs/promises/registry.md
+++ b/docs/promises/registry.md
@@ -1,5 +1,12 @@
 # Promise Registry
 
+> Registry `2026-06-29.3` audits #7023 and flips NO promise state.
+> `autopilot.desktop_gui_client.v1` and
+> `autopilot.builtin_compute_agent.v1` stay yellow; the new audit records the
+> exact signed-DMG, clean external Mac, live runtime, packaged compute,
+> no-user-key Go online, bounded metering, quota, and owner-approval refs needed
+> before those records can move green. No blocker is cleared.
+>
 > Registry `2026-06-29.2` is a current-main refresh after #6997, #6999,
 > #7001, #7002, and #7006 and flips NO promise state. It records the
 > terminal-agent current-state audit and Codex tool-layer study as evidence for
@@ -66,9 +73,9 @@
 > Current machine-readable source of truth: `/api/public/product-promises` is
 > generated from
 > [`product-promises.ts`](../../apps/openagents.com/workers/api/src/product-promises.ts),
-> which currently advertises registry `2026-06-29.2` with
+> which currently advertises registry `2026-06-29.3` with
 > `lastUpdated: "2026-06-29"`. This narrative document records the same
-> top-line 2026-06-29.2 promise decisions above, plus historical reconciliation
+> top-line 2026-06-29.3 promise decisions above, plus historical reconciliation
 > context below; when in doubt, agents and reviewers should defer to the
 > machine-readable registry and include its version in mismatch reports.
 >
@@ -76,7 +83,7 @@
 > Tassadar CPU-transform, referral, small-model proxy, WASM plugin, Verse scene,
 > native email, marketplace, metrics, terminal-agent audit, supervisor
 > replenishment, GLM failover, Apple FM sidecar, and operator-safety merges were
-> checked against the current `2026-06-29.2` registry header. This pass records
+> checked against the current `2026-06-29.3` registry header. This pass records
 > no additional promise state flips and no new green claims beyond the already
 > source-recorded scoped transitions; red/planned/yellow records keep their
 > owner-signed, receipt-first green gates.


### PR DESCRIPTION
Summary: Add a public-safe issue #7023 audit receipt for the Autopilot Desktop from-DMG and builtin compute green gates. Bump the product-promise registry to 2026-06-29.3 with no state flips. Cite the audit from autopilot.desktop_gui_client.v1 and autopilot.builtin_compute_agent.v1 while tests assert they remain yellow with blockers. Closes #7023. Verification: bun install --frozen-lockfile; bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts; bun run --cwd apps/openagents.com/workers/api test -- src/builtin-compute-agent-metering-smoke.test.ts. Note: generated verification ref command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24 did not expose original argv in this checkout/Pylon metadata, and the Pylon CLI catalog has no direct command-ref runner.