### PR TITLE
[codex] Advance marketplace compose lifecycle scaffold

### DIFF
--- a/apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts
@@ -3,13 +3,19 @@ import { describe, expect, test } from 'vitest'
 import {
   MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
   MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+  MARKETPLACE_PRODUCT_LIFECYCLE_SCHEMA,
   type ComposedProductDefinition,
+  assembleComposedProductForListing,
   buildComposedProductDefinition,
   composedProductMonetizableLayers,
   composedProductPrimitives,
+  installComposedProduct,
+  makeInMemoryComposedProductLifecycleStore,
   listComposedProducts,
   makeInMemoryComposedProductListingStore,
+  recordComposedProductUse,
   readComposedProduct,
+  selfServeListComposedProduct,
 } from './marketplace-product-composition'
 
 const okDefinition = (
@@ -114,6 +120,125 @@ describe('compose-and-list product definition model (#5515)', () => {
       { layer: 'inference', capabilityRef: 'inference.gateway.v1' },
       { layer: 'sandbox', capabilityRef: 'cloud.sandbox.v1' },
     ])
+  })
+})
+
+describe('compose-and-list runtime core (#6882)', () => {
+  test('assembles a builder definition into an inert listed product with attribution', () => {
+    const assembled = assembleComposedProductForListing({
+      productId: 'prod_research_pack',
+      definitionVersion: 1,
+      builderRef: 'agent:raynor',
+      title: 'Research + sandbox pack',
+      summary: 'Inference and a sandbox composed into one product.',
+      components: [
+        {
+          primitive: 'inference',
+          capabilityRef: 'inference.gateway_credits_business.v1',
+        },
+        { primitive: 'sandbox', capabilityRef: 'cloud.sandbox_compute_service.v1' },
+      ],
+      createdAt: '2026-06-19T00:00:00.000Z',
+      assembledAt: '2026-06-20T00:00:00.000Z',
+    })
+    expect(assembled.ok).toBe(true)
+    if (!assembled.ok) {
+      throw new Error(assembled.error.reason)
+    }
+    expect(assembled.result.definition.listingState).toBe('listed')
+    expect(assembled.result.assemblyPlan).toMatchObject({
+      schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+      status: 'assembled',
+      inert: true,
+      attribution: {
+        builderRef: 'agent:raynor',
+        attributionRef: 'marketplace.builder:prod_research_pack:1:agent:raynor',
+      },
+    })
+  })
+
+  test('persists self-serve listing, install, and use lifecycle evidence', () => {
+    const store = makeInMemoryComposedProductLifecycleStore()
+    const listed = selfServeListComposedProduct(store, {
+      productId: 'prod_research_pack',
+      definitionVersion: 1,
+      builderRef: 'agent:raynor',
+      title: 'Research + sandbox pack',
+      summary: 'Inference and a sandbox composed into one product.',
+      components: [
+        {
+          primitive: 'inference',
+          capabilityRef: 'inference.gateway_credits_business.v1',
+        },
+      ],
+      createdAt: '2026-06-19T00:00:00.000Z',
+      assembledAt: '2026-06-20T00:00:00.000Z',
+    })
+    expect(listed.ok).toBe(true)
+    expect(listComposedProducts(store).products.map(product => product.productId)).toEqual([
+      'prod_research_pack',
+    ])
+
+    const installed = installComposedProduct(store, {
+      productId: 'prod_research_pack',
+      buyerRef: 'buyer:tychus',
+      installedAt: '2026-06-21T00:00:00.000Z',
+    })
+    expect(installed.ok).toBe(true)
+    if (!installed.ok) {
+      throw new Error(installed.error.reason)
+    }
+    expect(installed.row).toMatchObject({
+      schema: MARKETPLACE_PRODUCT_LIFECYCLE_SCHEMA,
+      evidenceKind: 'marketplace_composed_product_install',
+      status: 'installed',
+      inert: true,
+      buyerRef: 'buyer:tychus',
+      builderRef: 'agent:raynor',
+      attributionRef: 'marketplace.builder:prod_research_pack:1:agent:raynor',
+    })
+
+    const used = recordComposedProductUse(store, {
+      lifecycleRef: installed.row.lifecycleRef,
+      usedAt: '2026-06-22T00:00:00.000Z',
+    })
+    expect(used.ok).toBe(true)
+    if (!used.ok) {
+      throw new Error(used.error.reason)
+    }
+    expect(used.row).toMatchObject({
+      schema: MARKETPLACE_PRODUCT_LIFECYCLE_SCHEMA,
+      evidenceKind: 'marketplace_composed_product_usage',
+      status: 'used',
+      inert: true,
+      buyerRef: 'buyer:tychus',
+      builderRef: 'agent:raynor',
+      attributionRef: 'marketplace.builder:prod_research_pack:1:agent:raynor',
+    })
+    expect(store.listInstallEvidence()).toHaveLength(1)
+    expect(store.listUsageEvidence()).toHaveLength(1)
+  })
+
+  test('blocks install before listing and use before install', () => {
+    const store = makeInMemoryComposedProductLifecycleStore([
+      okDefinition({ productId: 'p_draft', listingState: 'draft' }),
+    ])
+    const install = installComposedProduct(store, {
+      productId: 'p_draft',
+      buyerRef: 'buyer:tychus',
+    })
+    expect(install.ok).toBe(false)
+    if (!install.ok) {
+      expect(install.error.reason).toContain('listed before install')
+    }
+
+    const use = recordComposedProductUse(store, {
+      lifecycleRef: 'marketplace.install:missing:buyer',
+    })
+    expect(use.ok).toBe(false)
+    if (!use.ok) {
+      expect(use.error.reason).toContain('install lifecycle')
+    }
   })
 })
 

--- a/apps/openagents.com/workers/api/src/marketplace-product-composition.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-product-composition.ts
@@ -1,5 +1,6 @@
-// Compose-and-list marketplace MVP — typed product-composition model + a pure
-// listing surface (EPIC #5510, child #5515; promise
+// Compose-and-list marketplace MVP — typed product-composition model, bounded
+// composition runtime core, install/use lifecycle records, and a pure listing
+// surface (EPIC #5510, child #5515; promise
 // marketplace.compose_and_list_products.v1).
 //
 // Episode 239 ("Let's Make Money", docs/transcripts/239.md): agents and their
@@ -11,13 +12,12 @@
 // claim it is live. It is PURE:
 //   - it moves no money, runs no fulfillment, reads no wallet, writes no
 //     receipt, and provisions no primitive;
-//   - it only defines a typed, versioned product DEFINITION (a composition of
-//     primitive/market capability references) and a read-only listing
-//     projection over an injected store.
+//   - the composition runtime only assembles a typed definition into an inert
+//     listing row, then records public-safe install/use lifecycle evidence.
 // The promise marketplace.compose_and_list_products.v1 STAYS `planned`. Nothing
-// here flips it green: there is no composition runtime, no install/use
-// lifecycle, no billing, attribution, rev-share, or settlement. A green flip
-// stays receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.
+// here flips it green: this is source-level scaffold evidence only, with no
+// public write route, billing, rev-share, sale receipt, or settlement. A green
+// flip stays receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.
 
 import { Schema as S } from 'effect'
 
@@ -32,6 +32,9 @@ export const MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA =
 
 export const MARKETPLACE_COMPOSE_AND_LIST_PROMISE =
   'marketplace.compose_and_list_products.v1' as const
+
+export const MARKETPLACE_PRODUCT_LIFECYCLE_SCHEMA =
+  'openagents.marketplace_product_lifecycle.v1' as const
 
 /**
  * The OpenAgents primitives + open-market capabilities a product can be
@@ -103,6 +106,18 @@ export class ComposedProductValidationError extends S.TaggedErrorClass<ComposedP
 ) {}
 
 const isNonEmpty = (value: string): boolean => value.trim().length > 0
+
+const publicSafeRefPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/@-]{0,260}$/
+const unsafeLifecycleRefPattern =
+  /(\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer\s+|cookie|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|payment[_-]?(hash|preimage|secret)|preimage|private[_-]?key|provider[_-]?(credential|grant|payload|secret|token)|seed[_-]?phrase|sk-[a-z0-9]|wallet[._-]?(key|material|mnemonic|preimage|secret|seed)|xprv)/i
+
+const isPublicSafeRef = (value: string): boolean =>
+  publicSafeRefPattern.test(value) && !unsafeLifecycleRefPattern.test(value)
+
+const composedProductBuilderAttributionRef = (
+  definition: ComposedProductDefinition,
+): string =>
+  `marketplace.builder:${definition.productId}:${definition.definitionVersion}:${definition.builderRef}`
 
 /**
  * Build a typed product definition from raw input. PURE and validating:
@@ -191,6 +206,94 @@ export const buildComposedProductDefinition = (input: {
   }
 }
 
+export type ComposedProductBuilderAttribution = Readonly<{
+  builderRef: string
+  attributionRef: string
+}>
+
+export type ComposedProductAssemblyPlan = Readonly<{
+  schema: typeof MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA
+  productId: string
+  definitionVersion: number
+  status: 'assembled'
+  promiseId: typeof MARKETPLACE_COMPOSE_AND_LIST_PROMISE
+  inert: true
+  componentRefs: ReadonlyArray<MarketplaceComponentRef>
+  attribution: ComposedProductBuilderAttribution
+  assembledAt: string
+}>
+
+export type ComposedProductAssemblyResult = Readonly<{
+  definition: ComposedProductDefinition
+  assemblyPlan: ComposedProductAssemblyPlan
+}>
+
+/**
+ * Source-level composition runtime core: validate a builder-supplied typed
+ * definition, pin it to `listed`, and emit the public-safe builder attribution
+ * row future billing/rev-share work can bind to. It does not provision, bill,
+ * fulfill, or expose a public write route.
+ */
+export const assembleComposedProductForListing = (input: {
+  productId: string
+  definitionVersion: number
+  builderRef: string
+  title: string
+  summary: string
+  components: ReadonlyArray<MarketplaceComponentRef>
+  createdAt?: string
+  assembledAt?: string
+}):
+  | { ok: true; result: ComposedProductAssemblyResult }
+  | { ok: false; error: ComposedProductValidationError } => {
+  const definitionResult = buildComposedProductDefinition({
+    ...input,
+    listingState: 'listed',
+  })
+  if (!definitionResult.ok) {
+    return definitionResult
+  }
+  if (!isPublicSafeRef(input.productId)) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'productId must be a public-safe product ref',
+      }),
+    }
+  }
+  if (!isPublicSafeRef(input.builderRef)) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'builderRef must be a public-safe attribution ref',
+      }),
+    }
+  }
+
+  const definition = definitionResult.definition
+  const attributionRef = composedProductBuilderAttributionRef(definition)
+  return {
+    ok: true,
+    result: {
+      definition,
+      assemblyPlan: {
+        schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+        productId: definition.productId,
+        definitionVersion: definition.definitionVersion,
+        status: 'assembled',
+        promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
+        inert: true,
+        componentRefs: definition.components,
+        attribution: {
+          builderRef: definition.builderRef,
+          attributionRef,
+        },
+        assembledAt: input.assembledAt ?? currentIsoTimestamp(),
+      },
+    },
+  }
+}
+
 /**
  * The set of distinct primitives a definition composes — useful for a listing
  * surface and for the monetize-any-layer seam (#5518).
@@ -243,6 +346,43 @@ export type ComposedProductListingStore = {
   list: () => ReadonlyArray<ComposedProductDefinition>
 }
 
+export type ComposedProductInstallEvidenceRow = Readonly<{
+  schema: typeof MARKETPLACE_PRODUCT_LIFECYCLE_SCHEMA
+  evidenceKind: 'marketplace_composed_product_install'
+  lifecycleRef: string
+  productId: string
+  definitionVersion: number
+  buyerRef: string
+  builderRef: string
+  attributionRef: string
+  status: 'installed'
+  inert: true
+  installedAt: string
+}>
+
+export type ComposedProductUsageEvidenceRow = Readonly<{
+  schema: typeof MARKETPLACE_PRODUCT_LIFECYCLE_SCHEMA
+  evidenceKind: 'marketplace_composed_product_usage'
+  usageRef: string
+  lifecycleRef: string
+  productId: string
+  buyerRef: string
+  builderRef: string
+  attributionRef: string
+  status: 'used'
+  inert: true
+  usedAt: string
+}>
+
+export type ComposedProductLifecycleStore = ComposedProductListingStore & {
+  upsertDefinition: (definition: ComposedProductDefinition) => void
+  readDefinition: (productId: string) => ComposedProductDefinition | undefined
+  writeInstallEvidence: (row: ComposedProductInstallEvidenceRow) => void
+  listInstallEvidence: () => ReadonlyArray<ComposedProductInstallEvidenceRow>
+  writeUsageEvidence: (row: ComposedProductUsageEvidenceRow) => void
+  listUsageEvidence: () => ReadonlyArray<ComposedProductUsageEvidenceRow>
+}
+
 export const emptyComposedProductListingStore: ComposedProductListingStore = {
   list: () => [],
 }
@@ -252,6 +392,128 @@ export const makeInMemoryComposedProductListingStore = (
 ): ComposedProductListingStore => ({
   list: () => definitions,
 })
+
+export const makeInMemoryComposedProductLifecycleStore = (
+  initialDefinitions: ReadonlyArray<ComposedProductDefinition> = [],
+): ComposedProductLifecycleStore => {
+  const definitions = new Map<string, ComposedProductDefinition>(
+    initialDefinitions.map(definition => [definition.productId, definition]),
+  )
+  const installRows: Array<ComposedProductInstallEvidenceRow> = []
+  const usageRows: Array<ComposedProductUsageEvidenceRow> = []
+  return {
+    list: () => [...definitions.values()],
+    upsertDefinition: definition => {
+      definitions.set(definition.productId, definition)
+    },
+    readDefinition: productId => definitions.get(productId),
+    writeInstallEvidence: row => {
+      installRows.push(row)
+    },
+    listInstallEvidence: () => [...installRows],
+    writeUsageEvidence: row => {
+      usageRows.push(row)
+    },
+    listUsageEvidence: () => [...usageRows],
+  }
+}
+
+export const selfServeListComposedProduct = (
+  store: ComposedProductLifecycleStore,
+  input: Parameters<typeof assembleComposedProductForListing>[0],
+):
+  | { ok: true; result: ComposedProductAssemblyResult }
+  | { ok: false; error: ComposedProductValidationError } => {
+  const assembled = assembleComposedProductForListing(input)
+  if (!assembled.ok) {
+    return assembled
+  }
+  store.upsertDefinition(assembled.result.definition)
+  return assembled
+}
+
+export const installComposedProduct = (
+  store: ComposedProductLifecycleStore,
+  input: {
+    productId: string
+    buyerRef: string
+    installedAt?: string
+  },
+):
+  | { ok: true; row: ComposedProductInstallEvidenceRow }
+  | { ok: false; error: ComposedProductValidationError } => {
+  if (!isPublicSafeRef(input.buyerRef)) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'buyerRef must be public-safe',
+      }),
+    }
+  }
+  const definition = readComposedProduct(store, input.productId)
+  if (definition === null) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'product must be listed before install',
+      }),
+    }
+  }
+  const lifecycleRef = `marketplace.install:${definition.productId}:${input.buyerRef}`
+  const row: ComposedProductInstallEvidenceRow = {
+    schema: MARKETPLACE_PRODUCT_LIFECYCLE_SCHEMA,
+    evidenceKind: 'marketplace_composed_product_install',
+    lifecycleRef,
+    productId: definition.productId,
+    definitionVersion: definition.definitionVersion,
+    buyerRef: input.buyerRef,
+    builderRef: definition.builderRef,
+    attributionRef: composedProductBuilderAttributionRef(definition),
+    status: 'installed',
+    inert: true,
+    installedAt: input.installedAt ?? currentIsoTimestamp(),
+  }
+  store.writeInstallEvidence(row)
+  return { ok: true, row }
+}
+
+export const recordComposedProductUse = (
+  store: ComposedProductLifecycleStore,
+  input: {
+    lifecycleRef: string
+    usedAt?: string
+  },
+):
+  | { ok: true; row: ComposedProductUsageEvidenceRow }
+  | { ok: false; error: ComposedProductValidationError } => {
+  const installRow = store
+    .listInstallEvidence()
+    .find(row => row.lifecycleRef === input.lifecycleRef)
+  if (installRow === undefined) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'install lifecycle must exist before use',
+      }),
+    }
+  }
+  const usageRef = `marketplace.use:${installRow.productId}:${installRow.buyerRef}:${store.listUsageEvidence().length + 1}`
+  const row: ComposedProductUsageEvidenceRow = {
+    schema: MARKETPLACE_PRODUCT_LIFECYCLE_SCHEMA,
+    evidenceKind: 'marketplace_composed_product_usage',
+    usageRef,
+    lifecycleRef: installRow.lifecycleRef,
+    productId: installRow.productId,
+    buyerRef: installRow.buyerRef,
+    builderRef: installRow.builderRef,
+    attributionRef: installRow.attributionRef,
+    status: 'used',
+    inert: true,
+    usedAt: input.usedAt ?? currentIsoTimestamp(),
+  }
+  store.writeUsageEvidence(row)
+  return { ok: true, row }
+}
 
 /**
  * Staleness contract for the listing projection. It is built fresh from the

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -396,10 +396,15 @@ describe('public product promises document', () => {
     expect(composeAndListPromise?.blockerRefs).not.toContain(
       'blocker.product_promises.marketplace_listing_lifecycle_unbuilt',
     )
+    expect(composeAndListPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.marketplace_composition_runtime_unbuilt',
+    )
+    expect(composeAndListPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+    )
     expect(composeAndListPromise?.blockerRefs).toEqual(
       expect.arrayContaining([
-        'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-        'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+        'blocker.product_promises.marketplace_public_self_serve_write_install_route_unlaunched',
         'blocker.product_promises.marketplace_billing_settlement_missing',
       ]),
     )
@@ -408,6 +413,9 @@ describe('public product promises document', () => {
     )
     expect(composeAndListPromise?.safeCopy).toContain(
       'public read-only listing/discovery projection',
+    )
+    expect(composeAndListPromise?.safeCopy).toContain(
+      'bounded source-level composition runtime core',
     )
     const agenticNpmPromise = decoded.promises.find(
       promise =>
@@ -915,8 +923,7 @@ describe('public product promises document', () => {
           promiseId: 'marketplace.compose_and_list_products.v1',
           state: 'planned',
           blockerRefs: expect.arrayContaining([
-            'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-            'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+            'blocker.product_promises.marketplace_public_self_serve_write_install_route_unlaunched',
             'blocker.product_promises.marketplace_billing_settlement_missing',
           ]),
           evidenceRefs: expect.arrayContaining([

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3795,7 +3795,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Agents and humans build their own products out of the OpenAgents Cloud primitives and open markets, then list those products for sale in the OpenAgents marketplace.',
         safeCopy:
-          'Compose-your-own-product-and-list-it-for-sale is the Episode 239 marketplace vision (docs/transcripts/239.md), and it is roadmap. A typed product-definition scaffold and public read-only listing/discovery projection exist at GET /api/public/marketplace/composed-products; the route is inert, planned-state, and empty by default unless injected/flag-armed. Adjacent planned lanes exist — the agentic-npm module registry (marketplace.agentic_npm_module_registry.v1) and WASM plugins (marketplace.wasm_plugins.v1) — but there is no live composition runtime that provisions primitives into a buyable product, no self-serve listing write/install/use lifecycle, no marketplace billing, attribution, rev-share, or settlement. Nobody has composed a product from the primitives and sold it through OpenAgents.',
+          'Compose-your-own-product-and-list-it-for-sale is the Episode 239 marketplace vision (docs/transcripts/239.md), and it is roadmap. A typed product-definition scaffold, bounded source-level composition runtime core, inert self-serve listing/install/use lifecycle evidence records, and public read-only listing/discovery projection exist at GET /api/public/marketplace/composed-products; the route is inert, planned-state, and empty by default unless injected/flag-armed. Builder attribution is recorded in the source-level lifecycle rows for future rev-share binding. Adjacent planned lanes exist — the agentic-npm module registry (marketplace.agentic_npm_module_registry.v1) and WASM plugins (marketplace.wasm_plugins.v1) — but there is no public self-serve write route, no live provisioning into a buyable product, no marketplace billing, rev-share, sale receipt, or settlement. Nobody has composed a product from the primitives and sold it through OpenAgents.',
         unsafeCopy:
           'Do not claim users or agents can build a live product from the primitives and list it for sale today, that an OpenAgents product marketplace is live, or that composed products are buyable, installable, fulfillable, billable, settled, or revenue-bearing. Do not present the inert read-only listing scaffold or planned module/plugin lanes as a live compose-and-sell marketplace.',
         evidenceRefs: [
@@ -3810,14 +3810,13 @@ export const publicProductPromisesDocument = () => {
           'route:/api/public/marketplace/composed-products',
         ],
         blockerRefs: [
-          'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-          'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+          'blocker.product_promises.marketplace_public_self_serve_write_install_route_unlaunched',
           'blocker.product_promises.marketplace_billing_settlement_missing',
         ],
         verification:
-          'Planned until a composed product can be assembled from primitives, self-serve listed, discovered, installed/used by a buyer, and produce a dereferenceable paid receipt with attribution and rev-share to the builder. The current route proves only the inert typed definition + read-only listing/discovery scaffold. Per proof.demand_provenance.v1, an internally-built or injected listing is plumbing proof, not market proof.',
+          'Planned until a composed product can be assembled from primitives through a public self-serve write route, discovered, installed/used by a buyer, and produce a dereferenceable paid receipt with attribution and rev-share to the builder. The current code proves a bounded inert composition runtime core, source-level listing/install/use lifecycle records, builder attribution, and the inert read-only listing/discovery route. Per proof.demand_provenance.v1, an internally-built or injected listing is plumbing proof, not market proof.',
         authorityBoundary:
-          'A compose-and-list vision and read-only listing scaffold grant no live composition runtime, self-serve listing write, install/use, fulfillment, billing, rev-share, payout, or public-marketplace-claim authority.',
+          'A compose-and-list vision, source-level runtime core, inert lifecycle rows, and read-only listing scaffold grant no public self-serve write route, live provisioning, fulfillment, billing, rev-share, payout, or public-marketplace-claim authority.',
       },
       {
         ...basePromiseFields,


### PR DESCRIPTION
## Summary

- Add a bounded source-level compose-and-list runtime core that assembles typed product definitions into inert listed rows with builder attribution.
- Add in-memory self-serve listing, buyer install, and buyer use lifecycle evidence helpers, all public-safe and inert.
- Update the marketplace promise copy/tests to remove stale "runtime unbuilt" blockers while keeping the promise planned on the missing public write route, billing, rev-share, sale receipt, and settlement.

Closes #6882.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/marketplace-product-composition.test.ts src/marketplace-composition-routes.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:deploy`

Note: I could not recover the argv behind `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` from repo or local workspace metadata. I ran the issue-specified full verifier (`check:deploy`) plus the focused marketplace tests above.