### PR TITLE
docs: reconcile orange-check promise blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -84,6 +84,29 @@ const ProductPromisesDocument = S.Struct({
 })
 
 describe('public product promises document', () => {
+  test('orange-check promise stays yellow with explicit remaining green blockers', () => {
+    const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
+      publicProductPromisesDocument(),
+    )
+    const orangeCheckPromise = decoded.promises.find(
+      promise => promise.promiseId === 'identity.orange_check_forum_signal.v1',
+    )
+
+    expect(orangeCheckPromise).toMatchObject({
+      state: 'yellow',
+      blockerRefs: [
+        'blocker.product_promises.orange_check_live_purchase_receipt_missing',
+        'blocker.product_promises.orange_check_owner_signed_green_transition_missing',
+      ],
+    })
+    expect(orangeCheckPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.orange_check_nostr_export_missing',
+    )
+    expect(orangeCheckPromise?.verification).toContain(
+      'owner-signed promise transition receipt',
+    )
+  })
+
   test('matches the browser-facing schema', () => {
     const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
       publicProductPromisesDocument(),

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -2041,9 +2041,12 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/forum-routes.test.ts',
           'nostr_event:83c450c97d6ee3ed624dd6ae0b12956f50a392a396322e65d04c1173c9a6b4da@wss://relay.openagents.com',
         ],
-        blockerRefs: [],
+        blockerRefs: [
+          'blocker.product_promises.orange_check_live_purchase_receipt_missing',
+          'blocker.product_promises.orange_check_owner_signed_green_transition_missing',
+        ],
         verification:
-          'Run the forum-routes orange-check purchase test and the orange-check Nostr export test: preview, private payment, unpaid redeem refusal, payment_received-gated fulfillment, badge projection, copy-boundary scan, and the public-safe NIP-01/NIP-58 export builders. The Nostr export blocker is cleared: bun apps/openagents.com/scripts/orange-check-nostr-export-publish.ts publish published the orange-check attestation to the owned relay (NIP-42 AUTH) and read it back by id (event 83c450c97d6ee3ed624dd6ae0b12956f50a392a396322e65d04c1173c9a6b4da on wss://relay.openagents.com), independently dereferenceable via REQ {"ids":["83c450..."]}. Green still requires one live $5 purchase settling through the production checkout with the badge visible on the buying agent.',
+          'Run the forum-routes orange-check purchase test and the orange-check Nostr export test: preview, private payment, unpaid redeem refusal, payment_received-gated fulfillment, badge projection, copy-boundary scan, and the public-safe NIP-01/NIP-58 export builders. The Nostr export blocker is cleared: bun apps/openagents.com/scripts/orange-check-nostr-export-publish.ts publish published the orange-check attestation to the owned relay (NIP-42 AUTH) and read it back by id (event 83c450c97d6ee3ed624dd6ae0b12956f50a392a396322e65d04c1173c9a6b4da on wss://relay.openagents.com), independently dereferenceable via REQ {"ids":["83c450..."]}. Green still requires one live $5 purchase settling through the production checkout with a public-safe receipt, the badge visible on the buying agent, and an owner-signed promise transition receipt.',
         authorityBoundary:
           'An orange check is an economic participation signal only. It grants no moderation, identity-verification, settlement, payout, or policy authority, and payment cannot buy any of those. The Nostr attestation is event transport only and confers none of those either.',
       },


### PR DESCRIPTION
Closes #7015.

## Summary
- keeps `identity.orange_check_forum_signal.v1` yellow because no live production purchase/signoff receipt is present in this checkout
- adds explicit blockers for the remaining live $5 purchase receipt and owner-signed green transition gates
- adds product-promises regression coverage so the orange-check promise cannot regress to yellow-without-blockers while the Nostr export blocker stays cleared

## Verification
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts`