### PR TITLE
docs(promises): narrow paid inference blocker

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -466,10 +466,31 @@ describe('public product promises document', () => {
     expect(inferenceGatewayPromise?.safeCopy).toContain(
       'GLM own-capacity failover alerting',
     )
+    expect(inferenceGatewayPromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.inference_paid_credits_card_to_credit_not_collectable',
+        'blocker.product_promises.inference_paid_receipt_not_yet_supplied',
+        'blocker.product_promises.inference_mpp_owner_activation_pending',
+      ]),
+    )
+    expect(inferenceGatewayPromise?.blockerRefs).not.toContain(
+      'public_paid_model_gateway_missing',
+    )
     expect(inferenceGatewayPromise?.evidenceRefs).toEqual(
       expect.arrayContaining([
         'apps/openagents.com/workers/api/src/inference/model-router.ts',
         'apps/openagents.com/workers/api/src/inference/model-router.test.ts',
+      ]),
+    )
+    const autopilotCreditsPurchasePromise = decoded.promises.find(
+      promise => promise.promiseId === 'payments.autopilot_credits_purchase.v1',
+    )
+    expect(autopilotCreditsPurchasePromise?.state).toBe('red')
+    expect(autopilotCreditsPurchasePromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.autopilot_credits_prod_stripe_secrets_missing',
+        'blocker.product_promises.autopilot_credits_no_real_card_purchase_receipt',
+        'blocker.product_promises.autopilot_credits_no_card_credit_spend_receipt',
       ]),
     )
     expect(decoded.promises).toEqual(

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3397,7 +3397,6 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.inference_paid_credits_card_to_credit_not_collectable',
           'blocker.product_promises.inference_paid_receipt_not_yet_supplied',
           'blocker.product_promises.inference_mpp_owner_activation_pending',
-          'public_paid_model_gateway_missing',
         ],
         verification:
           'The gateway request surface (live OpenAI-compatible /v1/chat/completions endpoint, key-auth, balance gate, cheapest-viable routing, receipt-first credit decrement from provider usage, Gemini 3.5 Flash served end-to-end) is satisfied and verified live. The code path for card-funded USD credit -> explicit USD->msat bridge -> metered inference receipt is implemented and has public receipt resolution. Focused model-router tests now cover GLM own-capacity failover activation after consecutive no-headroom saturation failures, automatic recovery clearing, and public-safe fallback telemetry. The remaining gate for GREEN as a credits business is receipt-first paid evidence: a real customer/agent or approved staging-to-prod path funds a balance with card/MPP, bridges USD credit into inference spend, and settles a metered inference request with a dereferenceable card->credit->inference-spend receipt. Stays red/non-green until that paid receipt exists; free inference being live does not green the credits business.',


### PR DESCRIPTION
## Summary

- Removes the stale broad `public_paid_model_gateway_missing` blocker from `inference.gateway_credits_business.v1` now that the registry already states the gateway surface is built and live.
- Adds focused product-promise coverage for #7018 showing both `inference.gateway_credits_business.v1` and `payments.autopilot_credits_purchase.v1` remain red on the precise paid receipt/payment blockers.

Closes #7018.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/billing-routes.test.ts src/public-stripe-checkout-receipt-routes.test.ts src/inference/card-credit-provenance.test.ts src/inference/card-credit-spend-receipt.test.ts src/inference/card-credit-spend-receipt-store.test.ts src/inference/card-credit-spend-receipt-resolver.test.ts src/public-card-credit-spend-receipt-routes.test.ts src/inference/usd-credit-bridge.test.ts src/product-promises.test.ts`

Note: I could not resolve `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` to argv from the local checkout metadata, so I ran the focused #7018 payment/credit/inference receipt and product-promise verification set directly.
