### PR TITLE
refactor(effect): report authority boundary inventory

### DIFF
--- a/docs/adr/0008-effect-authority-boundary-checklist.md
+++ b/docs/adr/0008-effect-authority-boundary-checklist.md
@@ -1,0 +1,75 @@
+# ADR-0008: Effect Authority Boundary Checklist
+
+Date: 2026-06-29
+
+Status: Accepted
+
+## Context
+
+The Effect usage audits from 2026-06-28 and 2026-06-29 found strong local
+examples, but authority paths still rely on review discipline to avoid fresh raw
+platform code. This checklist applies when code decides payment, settlement,
+assignment lifecycle, public proof, product-promise, auth, routing, or owner
+local executor state.
+
+## Decision
+
+Authority code should return `Effect<Success, DomainError, R>` once it is past a
+thin platform edge. Raw async/platform code is allowed only at entry adapters
+that immediately map untyped inputs into Effect services, Schema decoders, or
+tagged domain errors.
+
+Use this checklist for new or touched authority code:
+
+- Decode external JSON, D1 rows, WebSocket frames, CLI input, and local state
+  files from `unknown` with Effect Schema or a named boundary helper before
+  domain logic uses the value.
+- Read config and secrets through a config service or redacted `Config` layer.
+  Direct `process.env`, `Bun.env`, and Cloudflare `Env` reads belong at
+  bootstrap or Worker binding edges only.
+- Model expected failures with `Schema.TaggedErrorClass` or equivalent tagged
+  domain errors. A fail-soft projection can return a public-safe fallback, but
+  the swallowed cause must first become an observed private diagnostic.
+- Wrap external HTTP, provider SDKs, storage calls, subprocesses, and Durable
+  Object calls in service methods that return `Effect`, with timeout/retry where
+  the domain requires it.
+- Use `Effect.runPromise` only at CLI, Worker, test, or explicit adapter edges.
+  Do not bridge out in the middle of assignment, payment, proof, product-promise,
+  auth, or routing decisions.
+- Manage long-lived resources with `Scope`, `acquireRelease`, scoped fibers, or
+  explicit service lifetimes instead of open-ended Promises and manual cleanup.
+
+Promoted examples from the audits:
+
+- Worker runtime layering: `apps/openagents.com/workers/api/src/runtime.ts`
+  composes request, environment, execution context, queue, and notification
+  services through layers.
+- Provider-account tagged errors:
+  `apps/openagents.com/workers/api/src/provider-account-errors.ts` keeps
+  account failures in serializable typed variants.
+- OpenRouter retry/config/error discipline:
+  `packages/probe/packages/runtime/src/llm/openrouter.ts` keeps credentials
+  redacted, provider failures tagged, and network calls bounded by timeout and
+  retry.
+- World contract schemas: `packages/world-contract/src/index.ts` uses branded
+  refs and Schema classes for shared public world rows and commands.
+- ATIF redaction service shape: `packages/atif/src/redaction.ts` exposes
+  Effect-returning redaction methods behind a service contract.
+
+## Guardrail
+
+Run the report-only inventory with:
+
+```sh
+bun run check:effect-authority-boundaries
+```
+
+The scanner covers declared authority-bearing directories, including
+`apps/openagents.com/workers/api`, `apps/pylon/src`, and shared packages. It
+reports raw `JSON.parse`, direct `process.env` / `Bun.env`, bare `catch {}`,
+raw `fetch`, and suspicious `Effect.runPromise` bridges with file and line
+output. Existing findings are migration inventory, not deploy blockers.
+
+Intentional raw edges must be recorded in
+`scripts/effect-authority-boundary-allowlist.json` with a rationale explaining
+why the edge is raw and what typed Effect or Schema boundary contains it.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "test:github-issue-triage": "bun test scripts/github-issue-triage.test.ts",
     "triage:issues": "bun run scripts/github-issue-triage.ts",
     "check:deploy": "bun run --cwd apps/openagents.com check:deploy",
+    "check:effect-authority-boundaries": "bun scripts/check-effect-authority-boundaries.mjs",
     "typecheck": "bun run typecheck:forge && bun run typecheck:forum && bun run typecheck:nostr-relay && bun run typecheck:openagents-world && bun run typecheck:khala-cli && bun run typecheck:khala-macos && bun run typecheck:openagents-desktop && bun run typecheck:nip90 && bun run typecheck:proof-replay && bun run typecheck:public-activity-timeline && bun run typecheck:input-bindings && bun run typecheck:design-tokens && bun run typecheck:replay-clips && bun run typecheck:ui && bun run typecheck:agent-runtime-schema && bun run typecheck:provider-account-schema && bun run typecheck:blueprint-contracts && bun run typecheck:mcp-contract && bun run typecheck:forge-protocol && bun run typecheck:world-contract && bun run typecheck:world-client && bun run typecheck:autopilot-ui && bun run typecheck:durable-stream",
     "typecheck:forge": "bun run --cwd apps/forge typecheck",
     "typecheck:forum": "bun run --cwd apps/forum typecheck",

--- a/scripts/check-effect-authority-boundaries.mjs
+++ b/scripts/check-effect-authority-boundaries.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env bun
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const root = process.cwd()
+const allowlistPath = join(root, 'scripts/effect-authority-boundary-allowlist.json')
+
+const scopes = [
+  'apps/openagents.com/workers/api/src',
+  'apps/pylon/src',
+  'packages/agent-runtime-schema/src',
+  'packages/atif/src',
+  'packages/blueprint-contracts/src',
+  'packages/durable-stream/src',
+  'packages/mcp-contract/src',
+  'packages/proof-replay/src',
+  'packages/provider-account-schema/src',
+  'packages/probe/packages/runtime/src',
+  'packages/world-client/src',
+  'packages/world-contract/src',
+]
+
+const ignoredPathFragments = [
+  '/__fixtures__/',
+  '/fixtures/',
+  '/test/',
+  '.generated.',
+  '.test-support.',
+  '.test.',
+  '.spec.',
+  '.d.ts',
+]
+
+const rules = [
+  {
+    id: 'raw-json-parse',
+    label: 'raw JSON.parse boundary',
+    test: (line, context) =>
+      line.includes('JSON.parse(') &&
+      /(\bas\b|typeof |Array\.isArray|Schema\.decode|Schema\.decodeUnknown|recordFromUnknown)/.test(
+        `${line}\n${context.nextOne}\n${context.nextTwo}`,
+      ),
+  },
+  {
+    id: 'direct-env-read',
+    label: 'direct process.env or Bun.env read',
+    test: line => /\b(?:process|Bun)\.env\b/.test(line),
+  },
+  {
+    id: 'bare-catch',
+    label: 'bare catch block',
+    test: line => /\bcatch\s*(?:\([^)]*\))?\s*\{\s*\}/.test(line),
+  },
+  {
+    id: 'raw-fetch',
+    label: 'raw fetch call',
+    test: line =>
+      /\b(?:await|return|=>|=|\?|:)\s*fetch\s*\(/.test(line) ||
+      /\bfetch\s*\([^)]*,/.test(line),
+  },
+  {
+    id: 'effect-run-promise-bridge',
+    label: 'Effect.runPromise bridge',
+    test: line => /\bEffect\.runPromise(?:Exit)?\s*\(/.test(line),
+  },
+]
+
+function listFiles(directory) {
+  if (!existsSync(directory)) return []
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return listFiles(path)
+    return [path]
+  })
+}
+
+function readAllowlist() {
+  if (!existsSync(allowlistPath)) return []
+  const parsed = JSON.parse(readFileSync(allowlistPath, 'utf8'))
+  if (!Array.isArray(parsed.entries)) {
+    throw new Error('effect authority boundary allowlist must contain an entries array')
+  }
+  return parsed.entries.map((entry, index) => {
+    for (const key of ['ruleId', 'path', 'reason']) {
+      if (typeof entry[key] !== 'string' || entry[key].trim() === '') {
+        throw new Error(`allowlist entry ${index} must include non-empty ${key}`)
+      }
+    }
+    return {
+      lineContains: typeof entry.lineContains === 'string' ? entry.lineContains : null,
+      path: entry.path,
+      reason: entry.reason,
+      ruleId: entry.ruleId,
+    }
+  })
+}
+
+function isAllowed(finding, allowlist) {
+  return allowlist.find(entry => {
+    if (entry.ruleId !== finding.ruleId || entry.path !== finding.path) return false
+    return entry.lineContains === null || finding.source.includes(entry.lineContains)
+  })
+}
+
+const files = scopes
+  .flatMap(scope => listFiles(join(root, scope)))
+  .filter(path => /\.tsx?$/.test(path))
+  .map(path => relative(root, path))
+  .filter(path => !ignoredPathFragments.some(fragment => path.includes(fragment)))
+  .sort()
+
+const allowlist = readAllowlist()
+const findings = []
+const allowed = []
+
+for (const path of files) {
+  const lines = readFileSync(join(root, path), 'utf8').split('\n')
+  lines.forEach((line, index) => {
+    const trimmed = line.trim()
+    if (
+      trimmed === '' ||
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('/*')
+    ) {
+      return
+    }
+    const context = {
+      nextOne: lines[index + 1] ?? '',
+      nextTwo: lines[index + 2] ?? '',
+    }
+    for (const rule of rules) {
+      if (!rule.test(line, context)) continue
+      const finding = {
+        label: rule.label,
+        line: index + 1,
+        path,
+        ruleId: rule.id,
+        source: line.trim(),
+      }
+      const allowance = isAllowed(finding, allowlist)
+      if (allowance) {
+        allowed.push({ ...finding, reason: allowance.reason })
+      } else {
+        findings.push(finding)
+      }
+    }
+  })
+}
+
+const byRule = new Map()
+for (const finding of findings) {
+  const bucket = byRule.get(finding.ruleId) ?? []
+  bucket.push(finding)
+  byRule.set(finding.ruleId, bucket)
+}
+
+if (process.argv.includes('--json')) {
+  console.log(
+    JSON.stringify(
+      {
+        allowedCount: allowed.length,
+        findingCount: findings.length,
+        findings,
+        scannedFiles: files.length,
+        scopes,
+      },
+      null,
+      2,
+    ),
+  )
+  process.exit(0)
+}
+
+console.log('Effect authority-boundary report (report-only)')
+console.log(`Scanned files: ${files.length}`)
+console.log(`Findings: ${findings.length}`)
+console.log(`Allowlisted intentional edges: ${allowed.length}`)
+console.log('')
+
+for (const rule of rules) {
+  const matches = byRule.get(rule.id) ?? []
+  console.log(`${rule.id} (${rule.label}): ${matches.length}`)
+  for (const finding of matches) {
+    console.log(`  ${finding.path}:${finding.line} ${finding.source}`)
+  }
+  console.log('')
+}
+
+if (allowed.length > 0) {
+  console.log('Allowlisted edges:')
+  for (const finding of allowed) {
+    console.log(`  ${finding.path}:${finding.line} ${finding.ruleId} - ${finding.reason}`)
+  }
+  console.log('')
+}
+
+console.log('Report-only: this command exits 0 so existing findings are migration inventory.')

--- a/scripts/effect-authority-boundary-allowlist.json
+++ b/scripts/effect-authority-boundary-allowlist.json
@@ -1,0 +1,26 @@
+{
+  "schema": "openagents.effect_authority_boundary_allowlist.v1",
+  "description": "Report-only allowlist for intentional raw authority edges. Each entry must explain why the edge is raw and what Effect or Schema boundary contains it.",
+  "entries": [
+    {
+      "ruleId": "raw-json-parse",
+      "path": "apps/openagents.com/workers/api/src/json-boundary.ts",
+      "reason": "This is the Worker named JSON boundary. Raw parse is intentionally centralized here before callers decode or narrow unknown values."
+    },
+    {
+      "ruleId": "direct-env-read",
+      "path": "apps/pylon/src/bootstrap.ts",
+      "reason": "Bootstrap is a CLI edge adapter. It accepts process env as raw input and turns it into a bounded bootstrap summary for downstream code."
+    },
+    {
+      "ruleId": "effect-run-promise-bridge",
+      "path": "apps/pylon/src/index.ts",
+      "reason": "Pylon CLI/node startup is an entry edge where Effect programs are finally bridged into Bun process execution."
+    },
+    {
+      "ruleId": "raw-fetch",
+      "path": "packages/probe/packages/runtime/src/llm/openrouter.ts",
+      "reason": "OpenRouterClientLive is the provider HTTP adapter. It wraps fetch in Effect.tryPromise, tagged errors, timeout, retry, and redacted config."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #7009.

- Adds ADR-0008 with the Effect authority-boundary checklist for payment, settlement, assignment, proof, product-promise, auth, routing, and owner-local executor paths.
- Adds a report-only root scanner for raw JSON.parse/manual narrowing, direct process.env/Bun.env reads, bare catch blocks, raw fetch calls, and Effect.runPromise bridges across declared authority directories.
- Adds an allowlist file where intentional raw edges must carry a rationale.

## Verification

- `bun run check:effect-authority-boundaries` passed as report-only inventory: scanned 1,423 files, reported 493 findings, and recognized 9 allowlisted intentional edges. Rule counts: raw JSON.parse 82, direct env reads 317, bare catch 2, raw fetch 46, Effect.runPromise bridges 46.
- `bun run --cwd apps/openagents.com check:architecture` passed.
- Required command ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` resolved to `true` and passed.
- `git diff --check` passed.

No GitHub-hosted CI workflow added.