### PR TITLE
fix(khala-desktop): fail closed on malformed Apple FM readiness

### DIFF
--- a/clients/khala-desktop/src/shared/apple-fm-readiness.ts
+++ b/clients/khala-desktop/src/shared/apple-fm-readiness.ts
@@ -145,11 +145,19 @@ export function buildKhalaAppleFmReadiness(
   input: BuildKhalaAppleFmReadinessInput,
 ): KhalaAppleFmReadiness {
   const supported = appleFmSupportedOn(input.platform)
+  const pylonStatusIdentityOk =
+    input.pylonStatus !== null &&
+    input.pylonStatus !== undefined &&
+    optionalString(input.pylonStatus.backendKind) === APPLE_FM_BACKEND_KIND &&
+    optionalString(input.pylonStatus.profileId) === APPLE_FM_LOCAL_PROFILE_ID &&
+    optionalString(input.pylonStatus.model) === APPLE_FM_MODEL_ID &&
+    optionalString(input.pylonStatus.capability) === APPLE_FM_CAPABILITY
   const pylon =
     input.pylonStatus === null || input.pylonStatus === undefined
       ? null
       : sanitizePylonAppleFmStatus(input.pylonStatus)
   const pylonReady =
+    pylonStatusIdentityOk &&
     pylon !== null &&
     pylon.available &&
     pylon.status === "ready" &&
@@ -186,7 +194,9 @@ export function buildKhalaAppleFmReadiness(
   }
 
   if (supported && helperUsable && !pylonReady) {
-    if (input.pylonControlConfigured === true) {
+    if (input.pylonControlConfigured === true && pylon !== null && !pylonStatusIdentityOk) {
+      blockers.add("blocker.khala_desktop.apple_fm.pylon_status_malformed")
+    } else if (input.pylonControlConfigured === true) {
       blockers.add("blocker.khala_desktop.apple_fm.pylon_not_ready")
     } else {
       blockers.add("blocker.khala_desktop.apple_fm.pylon_control_unconfigured")

--- a/clients/khala-desktop/tests/apple-fm-readiness.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-readiness.test.ts
@@ -34,6 +34,10 @@ describe("khala desktop Apple FM readiness", () => {
       pylonStatus: {
         available: true,
         status: "ready",
+        backendKind: "apple_fm_bridge",
+        profileId: "apple-fm-local",
+        model: "apple-foundation-model",
+        capability: APPLE_FM_CAPABILITY,
         advertisedCapabilities: [APPLE_FM_CAPABILITY, "probe.blueprint.tool_menu"],
         blockerRefs: [],
       },
@@ -45,6 +49,29 @@ describe("khala desktop Apple FM readiness", () => {
     expect(readiness.provider).toBe("pylon-apple-fm-own-capacity")
     expect(readiness.demandSource).toBe("khala_apple_fm_delegation")
     expect(readiness.usageTruth).toBe("estimated")
+  })
+
+  test("fails closed when Pylon ready status is missing the Apple FM identity", () => {
+    const readiness = buildKhalaAppleFmReadiness({
+      platform: { platform: "darwin", arch: "arm64" },
+      helperFound: true,
+      helperExecutable: true,
+      helperLaunchState: "running",
+      pylonControlConfigured: true,
+      pylonStatus: {
+        available: true,
+        status: "ready",
+        advertisedCapabilities: [APPLE_FM_CAPABILITY],
+        blockerRefs: [],
+      },
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
+    expect(readiness.available).toBe(false)
+    expect(readiness.state).toBe("running")
+    expect(readiness.blockerRefs).toContain(
+      "blocker.khala_desktop.apple_fm.pylon_status_malformed",
+    )
   })
 
   test("keeps Pylon status public-safe and omits loopback paths and tokens", () => {

--- a/clients/khala-desktop/tests/apple-fm-sidecar.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-sidecar.test.ts
@@ -50,6 +50,10 @@ describe("Khala Desktop Apple FM sidecar host", () => {
           result: {
             available: true,
             status: "ready",
+            backendKind: "apple_fm_bridge",
+            profileId: "apple-fm-local",
+            model: "apple-foundation-model",
+            capability: APPLE_FM_CAPABILITY,
             advertisedCapabilities: [APPLE_FM_CAPABILITY],
             baseUrl: "http://127.0.0.1:11435",
             callbackUrl: "http://127.0.0.1/callback",


### PR DESCRIPTION
## Summary
- require Khala Desktop Apple FM readiness to see the expected Pylon backend/profile/model/capability identity before marking local Apple FM ready
- add an explicit malformed-status blocker when Pylon control returns an incomplete ready projection
- update Apple FM readiness and sidecar tests to cover the stricter identity contract

Closes #6978

## Verification
- bun test clients/khala-desktop/tests/apple-fm-readiness.test.ts clients/khala-desktop/tests/apple-fm-sidecar.test.ts clients/khala-desktop/tests/apple-fm-packaging.test.ts
- bun run --cwd clients/khala-desktop verify